### PR TITLE
fix: prevent infinite terminal respawn loop on immediate exit

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -344,7 +344,11 @@ export default function TerminalView({ tabId, paneId, paneContent, hidden }: Ter
         }
 
         if (msg.type === 'error' && msg.code === 'INVALID_TERMINAL_ID' && !msg.requestId) {
-          if (terminalIdRef.current) {
+          // Only auto-reconnect if terminal hasn't already exited.
+          // This prevents an infinite respawn loop when terminals fail immediately
+          // (e.g., due to permission errors on cwd). User must explicitly restart.
+          const current = contentRef.current
+          if (terminalIdRef.current && current?.status !== 'exited') {
             term.writeln('\r\n[Reconnecting...]\r\n')
             const newRequestId = nanoid()
             requestIdRef.current = newRequestId

--- a/test/unit/client/components/TerminalView.test.tsx
+++ b/test/unit/client/components/TerminalView.test.tsx
@@ -185,6 +185,96 @@ describe('TerminalView xterm title change behavior', () => {
   })
 })
 
+describe('TerminalView INVALID_TERMINAL_ID respawn behavior', () => {
+  // This tests the fix for infinite respawn loop when terminal exits immediately
+  // (e.g., due to permission denied on cwd).
+  // The INVALID_TERMINAL_ID handler should NOT respawn if status is already 'exited'.
+
+  it('should not respawn when terminal status is exited', () => {
+    // Simulate the state that would exist after terminal.exit
+    const contentRef = {
+      current: {
+        kind: 'terminal' as const,
+        terminalId: 'term-123',
+        createRequestId: 'req-1',
+        status: 'exited' as const,
+        mode: 'shell' as const,
+        shell: 'system' as const,
+      }
+    }
+    const terminalIdRef = { current: 'term-123' }
+
+    // Simulate receiving INVALID_TERMINAL_ID error
+    const msg = { type: 'error', code: 'INVALID_TERMINAL_ID' }
+
+    // This is the logic from TerminalView - should NOT trigger respawn
+    let respawnTriggered = false
+    if (msg.type === 'error' && msg.code === 'INVALID_TERMINAL_ID') {
+      const current = contentRef.current
+      if (terminalIdRef.current && current?.status !== 'exited') {
+        respawnTriggered = true
+      }
+    }
+
+    expect(respawnTriggered).toBe(false)
+  })
+
+  it('should respawn when terminal status is running (normal reconnect)', () => {
+    // Simulate a running terminal that gets disconnected
+    const contentRef = {
+      current: {
+        kind: 'terminal' as const,
+        terminalId: 'term-123',
+        createRequestId: 'req-1',
+        status: 'running' as const,
+        mode: 'shell' as const,
+        shell: 'system' as const,
+      }
+    }
+    const terminalIdRef = { current: 'term-123' }
+
+    // Simulate receiving INVALID_TERMINAL_ID error (e.g., server restarted)
+    const msg = { type: 'error', code: 'INVALID_TERMINAL_ID' }
+
+    // This should trigger respawn - terminal was running, not exited
+    let respawnTriggered = false
+    if (msg.type === 'error' && msg.code === 'INVALID_TERMINAL_ID') {
+      const current = contentRef.current
+      if (terminalIdRef.current && current?.status !== 'exited') {
+        respawnTriggered = true
+      }
+    }
+
+    expect(respawnTriggered).toBe(true)
+  })
+
+  it('should not respawn when terminalId is not set', () => {
+    const contentRef = {
+      current: {
+        kind: 'terminal' as const,
+        terminalId: undefined,
+        createRequestId: 'req-1',
+        status: 'creating' as const,
+        mode: 'shell' as const,
+        shell: 'system' as const,
+      }
+    }
+    const terminalIdRef = { current: undefined as string | undefined }
+
+    const msg = { type: 'error', code: 'INVALID_TERMINAL_ID' }
+
+    let respawnTriggered = false
+    if (msg.type === 'error' && msg.code === 'INVALID_TERMINAL_ID') {
+      const current = contentRef.current
+      if (terminalIdRef.current && current?.status !== 'exited') {
+        respawnTriggered = true
+      }
+    }
+
+    expect(respawnTriggered).toBe(false)
+  })
+})
+
 describe('TerminalView title normalization', () => {
   // Helper that mirrors the normalization logic in TerminalView
   function normalizeTitle(rawTitle: string): string | null {


### PR DESCRIPTION
When a terminal exits immediately (e.g., due to permission denied on cwd), the INVALID_TERMINAL_ID handler would create a new terminal with the same bad configuration, causing an infinite loop until hitting the 50 terminal limit.

Now checks if terminal status is 'exited' before auto-reconnecting. Terminals that have already exited require explicit user restart.