### PR TITLE
fix: use cross-platform font fallback for terminal

### DIFF
--- a/server/config-store.ts
+++ b/server/config-store.ts
@@ -64,7 +64,7 @@ export const defaultSettings: AppSettings = {
   theme: 'system',
   terminal: {
     fontSize: 12,
-    fontFamily: 'Consolas',
+    fontFamily: 'Menlo, Monaco, Consolas, monospace',
     lineHeight: 1,
     cursorBlink: true,
     scrollback: 5000,

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -8,14 +8,16 @@ import type { SidebarSortMode, TerminalTheme } from '@/store/types'
 
 /** Monospace fonts with good Unicode block element support for terminal use */
 const terminalFonts = [
+  { value: 'Menlo', label: 'Menlo' },
+  { value: 'Monaco', label: 'Monaco' },
+  { value: 'SF Mono', label: 'SF Mono' },
+  { value: 'Consolas', label: 'Consolas' },
   { value: 'JetBrains Mono', label: 'JetBrains Mono' },
   { value: 'Cascadia Code', label: 'Cascadia Code' },
   { value: 'Fira Code', label: 'Fira Code' },
   { value: 'Source Code Pro', label: 'Source Code Pro' },
   { value: 'IBM Plex Mono', label: 'IBM Plex Mono' },
-  { value: 'Consolas', label: 'Consolas' },
-  { value: 'Monaco', label: 'Monaco' },
-  { value: 'Menlo', label: 'Menlo' },
+  { value: 'Courier New', label: 'Courier New' },
   { value: 'monospace', label: 'System monospace' },
 ]
 

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -6,7 +6,7 @@ export const defaultSettings: AppSettings = {
   uiScale: 1.0, // 100% = UI text matches terminal font size
   terminal: {
     fontSize: 16,
-    fontFamily: 'Consolas',
+    fontFamily: 'Menlo, Monaco, Consolas, monospace',
     lineHeight: 1,
     cursorBlink: true,
     scrollback: 5000,


### PR DESCRIPTION
## Summary
- Default terminal font was `Consolas` (Windows-only), causing poor rendering on macOS/Linux
- Changed default to `Menlo, Monaco, Consolas, monospace` so each platform uses its native monospace font
- Reordered font picker to list platform-native fonts first (Menlo, Monaco, SF Mono)
- Added SF Mono and Courier New as selectable options

## Test plan
- [ ] On macOS: verify terminal renders with Menlo by default
- [ ] On Windows: verify terminal renders with Consolas by default
- [ ] On Linux: verify terminal falls back to system monospace
- [ ] Verify font picker dropdown shows all options and switching works

🤖 Generated with [Claude Code](https://claude.com/claude-code)