### PR TITLE
Add port forwarding for remote browser pane access

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,7 @@ import { createClientLogsRouter } from './client-logs.js'
 import { createStartupState } from './startup-state.js'
 import { getPerfConfig, initPerfLogging, setPerfLoggingEnabled, startPerfTimer, withPerfSpan } from './perf-logger.js'
 import { detectPlatform } from './platform.js'
+import { PortForwardManager } from './port-forward.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -473,6 +474,35 @@ async function main() {
   // --- API: files (for editor pane) ---
   app.use('/api/files', filesRouter)
 
+  // --- API: port forwarding (for browser pane remote access) ---
+  const portForwardManager = new PortForwardManager()
+
+  app.post('/api/proxy/forward', async (req, res) => {
+    const { port: targetPort } = req.body || {}
+
+    if (!Number.isInteger(targetPort) || targetPort < 1 || targetPort > 65535) {
+      return res.status(400).json({ error: 'Invalid port number' })
+    }
+
+    try {
+      const result = await portForwardManager.forward(targetPort)
+      res.json({ forwardedPort: result.port })
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err)
+      log.error({ err, targetPort }, 'Port forward failed')
+      res.status(500).json({ error: `Failed to create port forward: ${msg}` })
+    }
+  })
+
+  app.delete('/api/proxy/forward/:port', (req, res) => {
+    const targetPort = parseInt(req.params.port, 10)
+    if (!Number.isInteger(targetPort) || targetPort < 1 || targetPort > 65535) {
+      return res.status(400).json({ error: 'Invalid port number' })
+    }
+    portForwardManager.close(targetPort)
+    res.json({ ok: true })
+  })
+
   // --- Static client in production ---
   const distRoot = path.resolve(__dirname, '..')
   const clientDir = path.join(distRoot, 'client')
@@ -631,14 +661,17 @@ async function main() {
     // 4. Close WebSocket connections gracefully
     wsHandler.close()
 
-    // 5. Stop session indexers
+    // 5. Close port forwards
+    portForwardManager.closeAll()
+
+    // 6. Stop session indexers
     codingCliIndexer.stop()
     claudeIndexer.stop()
 
-    // 6. Stop session repair service
+    // 7. Stop session repair service
     await sessionRepairService.stop()
 
-    // 7. Exit cleanly
+    // 8. Exit cleanly
     log.info('Shutdown complete')
     process.exit(0)
   }

--- a/server/port-forward.ts
+++ b/server/port-forward.ts
@@ -1,0 +1,161 @@
+import * as net from 'net'
+import { logger } from './logger.js'
+
+const log = logger.child({ component: 'port-forward' })
+
+interface ForwardEntry {
+  /** Port the proxy listens on (assigned by OS) */
+  localPort: number
+  /** The localhost port being forwarded to */
+  targetPort: number
+  /** The TCP server accepting connections */
+  server: net.Server
+  /** Active client connections (for cleanup) */
+  connections: Set<net.Socket>
+  /** Timestamp of last connection activity */
+  lastActivity: number
+}
+
+export interface PortForwardOptions {
+  /** How long (ms) a forward can be idle before auto-cleanup. Default: 5 minutes. */
+  idleTimeoutMs?: number
+}
+
+export class PortForwardManager {
+  private forwards = new Map<number, ForwardEntry>()
+  private idleTimeoutMs: number
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null
+
+  constructor(opts: PortForwardOptions = {}) {
+    this.idleTimeoutMs = opts.idleTimeoutMs ?? 5 * 60 * 1000
+    this.startIdleCleanup()
+  }
+
+  /**
+   * Create (or reuse) a TCP forward from a random OS-assigned port to
+   * 127.0.0.1:<targetPort>. Returns the local port the proxy listens on.
+   */
+  async forward(targetPort: number): Promise<{ port: number }> {
+    if (!Number.isInteger(targetPort) || targetPort < 1 || targetPort > 65535) {
+      throw new Error(`Invalid target port: ${targetPort}`)
+    }
+
+    // Reuse existing forward
+    const existing = this.forwards.get(targetPort)
+    if (existing) {
+      existing.lastActivity = Date.now()
+      return { port: existing.localPort }
+    }
+
+    return new Promise<{ port: number }>((resolve, reject) => {
+      const server = net.createServer((clientSocket) => {
+        const entry = this.forwards.get(targetPort)
+        if (entry) {
+          entry.lastActivity = Date.now()
+          entry.connections.add(clientSocket)
+        }
+
+        const targetSocket = net.createConnection(
+          { host: '127.0.0.1', port: targetPort },
+          () => {
+            clientSocket.pipe(targetSocket)
+            targetSocket.pipe(clientSocket)
+          },
+        )
+
+        const cleanup = () => {
+          clientSocket.destroy()
+          targetSocket.destroy()
+          if (entry) entry.connections.delete(clientSocket)
+        }
+
+        clientSocket.on('error', cleanup)
+        targetSocket.on('error', (err) => {
+          // Propagate target errors to the client so it sees the failure
+          clientSocket.destroy(err)
+          targetSocket.destroy()
+          if (entry) entry.connections.delete(clientSocket)
+        })
+        clientSocket.on('close', cleanup)
+        targetSocket.on('close', cleanup)
+      })
+
+      server.on('error', (err) => {
+        reject(err)
+      })
+
+      // Listen on port 0 → OS assigns an available port.
+      // Bind to 0.0.0.0 so remote clients can reach it.
+      server.listen(0, '0.0.0.0', () => {
+        const addr = server.address() as net.AddressInfo
+        const entry: ForwardEntry = {
+          localPort: addr.port,
+          targetPort,
+          server,
+          connections: new Set(),
+          lastActivity: Date.now(),
+        }
+        this.forwards.set(targetPort, entry)
+        log.info(
+          { targetPort, localPort: addr.port },
+          'Port forward created',
+        )
+        resolve({ port: addr.port })
+      })
+    })
+  }
+
+  /** Return the forwarded local port for a given target port, or undefined. */
+  getForwardedPort(targetPort: number): number | undefined {
+    return this.forwards.get(targetPort)?.localPort
+  }
+
+  /** Close a single forward by target port. */
+  close(targetPort: number): void {
+    const entry = this.forwards.get(targetPort)
+    if (!entry) return
+
+    for (const conn of entry.connections) {
+      conn.destroy()
+    }
+    entry.server.close()
+    this.forwards.delete(targetPort)
+    log.info(
+      { targetPort, localPort: entry.localPort },
+      'Port forward closed',
+    )
+  }
+
+  /** Close all active forwards and stop the idle-cleanup timer. */
+  closeAll(): void {
+    for (const targetPort of [...this.forwards.keys()]) {
+      this.close(targetPort)
+    }
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer)
+      this.cleanupTimer = null
+    }
+  }
+
+  private startIdleCleanup(): void {
+    this.cleanupTimer = setInterval(() => {
+      const now = Date.now()
+      for (const [targetPort, entry] of this.forwards) {
+        const idle = now - entry.lastActivity > this.idleTimeoutMs
+        const noConnections = entry.connections.size === 0
+        if (idle && noConnections) {
+          log.info(
+            { targetPort, localPort: entry.localPort },
+            'Port forward idle-closed',
+          )
+          this.close(targetPort)
+        }
+      }
+    }, 60_000)
+
+    // Don't let the timer keep the process alive
+    if (this.cleanupTimer.unref) {
+      this.cleanupTimer.unref()
+    }
+  }
+}

--- a/src/lib/url-rewrite.ts
+++ b/src/lib/url-rewrite.ts
@@ -7,35 +7,3 @@ const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
 export function isLoopbackHostname(hostname: string): boolean {
   return LOOPBACK_HOSTNAMES.has(hostname)
 }
-
-/**
- * When accessing Freshell remotely, rewrite localhost/127.0.0.1/[::1] URLs
- * so the browser resolves them to the host machine instead of the remote
- * client's own machine.
- *
- * If the user is already accessing from localhost, URLs are returned unchanged.
- *
- * @param url - The URL entered by the user (e.g. "http://localhost:3000")
- * @param currentHostname - The hostname the user is accessing Freshell from
- *                          (i.e. window.location.hostname)
- */
-export function rewriteLocalhostUrl(url: string, currentHostname: string): string {
-  if (isLoopbackHostname(currentHostname)) return url
-
-  try {
-    const parsed = new URL(url)
-
-    // Only rewrite http/https URLs pointing at loopback
-    if (
-      (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
-      isLoopbackHostname(parsed.hostname)
-    ) {
-      parsed.hostname = currentHostname
-      return parsed.toString()
-    }
-  } catch {
-    // Not a valid URL, return as-is
-  }
-
-  return url
-}

--- a/test/integration/server/port-forward-api.test.ts
+++ b/test/integration/server/port-forward-api.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import express, { type Express } from 'express'
+import request from 'supertest'
+import * as net from 'net'
+import { PortForwardManager } from '../../../server/port-forward.js'
+
+const TEST_AUTH_TOKEN = 'test-auth-token-12345678'
+
+// Helper: create a TCP server on localhost that echoes data back
+function createEchoServer(): Promise<{ server: net.Server; port: number }> {
+  return new Promise((resolve) => {
+    const server = net.createServer((socket) => {
+      socket.pipe(socket)
+    })
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as net.AddressInfo
+      resolve({ server, port: addr.port })
+    })
+  })
+}
+
+describe('Port Forward API Integration', () => {
+  let app: Express
+  let manager: PortForwardManager
+  let echoServer: { server: net.Server; port: number } | null = null
+
+  beforeAll(() => {
+    process.env.AUTH_TOKEN = TEST_AUTH_TOKEN
+    manager = new PortForwardManager({ idleTimeoutMs: 60_000 })
+
+    app = express()
+    app.use(express.json({ limit: '1mb' }))
+
+    // Auth middleware (matches server/auth.ts)
+    app.use('/api', (req, res, next) => {
+      const token = process.env.AUTH_TOKEN
+      const provided = req.headers['x-auth-token'] as string | undefined
+      if (!provided || provided !== token) {
+        return res.status(401).json({ error: 'Unauthorized' })
+      }
+      next()
+    })
+
+    // Register the endpoint under test
+    app.post('/api/proxy/forward', async (req, res) => {
+      const { port } = req.body || {}
+
+      if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        return res.status(400).json({ error: 'Invalid port number' })
+      }
+
+      try {
+        const result = await manager.forward(port)
+        res.json({ forwardedPort: result.port })
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err)
+        res.status(500).json({ error: `Failed to create port forward: ${msg}` })
+      }
+    })
+
+    app.delete('/api/proxy/forward/:port', (req, res) => {
+      const port = parseInt(req.params.port, 10)
+      if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        return res.status(400).json({ error: 'Invalid port number' })
+      }
+      manager.close(port)
+      res.json({ ok: true })
+    })
+  })
+
+  afterEach(() => {
+    if (echoServer) {
+      echoServer.server.close()
+      echoServer = null
+    }
+  })
+
+  afterAll(() => {
+    manager.closeAll()
+  })
+
+  describe('POST /api/proxy/forward', () => {
+    it('requires authentication', async () => {
+      await request(app)
+        .post('/api/proxy/forward')
+        .send({ port: 3000 })
+        .expect(401)
+    })
+
+    it('rejects missing port', async () => {
+      await request(app)
+        .post('/api/proxy/forward')
+        .set('x-auth-token', TEST_AUTH_TOKEN)
+        .send({})
+        .expect(400)
+    })
+
+    it('rejects invalid port numbers', async () => {
+      await request(app)
+        .post('/api/proxy/forward')
+        .set('x-auth-token', TEST_AUTH_TOKEN)
+        .send({ port: 0 })
+        .expect(400)
+
+      await request(app)
+        .post('/api/proxy/forward')
+        .set('x-auth-token', TEST_AUTH_TOKEN)
+        .send({ port: 70000 })
+        .expect(400)
+
+      await request(app)
+        .post('/api/proxy/forward')
+        .set('x-auth-token', TEST_AUTH_TOKEN)
+        .send({ port: 'abc' })
+        .expect(400)
+    })
+
+    it('creates a port forward and returns the forwarded port', async () => {
+      echoServer = await createEchoServer()
+
+      const res = await request(app)
+        .post('/api/proxy/forward')
+        .set('x-auth-token', TEST_AUTH_TOKEN)
+        .send({ port: echoServer.port })
+        .expect(200)
+
+      expect(res.body.forwardedPort).toBeGreaterThan(0)
+      expect(res.body.forwardedPort).not.toBe(echoServer.port)
+    })
+
+    it('returns the same forwarded port for repeated requests', async () => {
+      echoServer = await createEchoServer()
+
+      const res1 = await request(app)
+        .post('/api/proxy/forward')
+        .set('x-auth-token', TEST_AUTH_TOKEN)
+        .send({ port: echoServer.port })
+        .expect(200)
+
+      const res2 = await request(app)
+        .post('/api/proxy/forward')
+        .set('x-auth-token', TEST_AUTH_TOKEN)
+        .send({ port: echoServer.port })
+        .expect(200)
+
+      expect(res1.body.forwardedPort).toBe(res2.body.forwardedPort)
+    })
+  })
+
+  describe('DELETE /api/proxy/forward/:port', () => {
+    it('requires authentication', async () => {
+      await request(app)
+        .delete('/api/proxy/forward/3000')
+        .expect(401)
+    })
+
+    it('closes an existing forward', async () => {
+      echoServer = await createEchoServer()
+
+      // Create the forward
+      const res = await request(app)
+        .post('/api/proxy/forward')
+        .set('x-auth-token', TEST_AUTH_TOKEN)
+        .send({ port: echoServer.port })
+        .expect(200)
+
+      const forwardedPort = res.body.forwardedPort
+
+      // Delete it
+      await request(app)
+        .delete(`/api/proxy/forward/${echoServer.port}`)
+        .set('x-auth-token', TEST_AUTH_TOKEN)
+        .expect(200)
+
+      // Verify the forwarded port is no longer listening
+      await expect(
+        new Promise((resolve, reject) => {
+          const socket = net.createConnection(
+            { host: '127.0.0.1', port: forwardedPort },
+            () => {
+              socket.destroy()
+              resolve('connected')
+            },
+          )
+          socket.on('error', reject)
+          socket.setTimeout(2000, () => {
+            socket.destroy(new Error('timeout'))
+          })
+        }),
+      ).rejects.toThrow()
+    })
+
+    it('is a no-op for non-existent forwards', async () => {
+      await request(app)
+        .delete('/api/proxy/forward/12345')
+        .set('x-auth-token', TEST_AUTH_TOKEN)
+        .expect(200)
+    })
+  })
+})

--- a/test/unit/client/lib/url-rewrite.test.ts
+++ b/test/unit/client/lib/url-rewrite.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { rewriteLocalhostUrl, isLoopbackHostname } from '@/lib/url-rewrite'
+import { isLoopbackHostname } from '@/lib/url-rewrite'
 
 describe('isLoopbackHostname', () => {
   it('returns true for localhost', () => {
@@ -14,6 +14,10 @@ describe('isLoopbackHostname', () => {
     expect(isLoopbackHostname('::1')).toBe(true)
   })
 
+  it('returns true for [::1] (bracketed IPv6)', () => {
+    expect(isLoopbackHostname('[::1]')).toBe(true)
+  })
+
   it('returns false for a LAN IP', () => {
     expect(isLoopbackHostname('192.168.1.100')).toBe(false)
   })
@@ -24,91 +28,5 @@ describe('isLoopbackHostname', () => {
 
   it('returns false for empty string', () => {
     expect(isLoopbackHostname('')).toBe(false)
-  })
-})
-
-describe('rewriteLocalhostUrl', () => {
-  describe('when accessing from localhost (no rewrite needed)', () => {
-    it('returns localhost URLs unchanged', () => {
-      expect(rewriteLocalhostUrl('http://localhost:3000', 'localhost'))
-        .toBe('http://localhost:3000')
-    })
-
-    it('returns 127.0.0.1 URLs unchanged', () => {
-      expect(rewriteLocalhostUrl('http://127.0.0.1:3000', '127.0.0.1'))
-        .toBe('http://127.0.0.1:3000')
-    })
-
-    it('returns ::1 URLs unchanged when accessing from ::1', () => {
-      expect(rewriteLocalhostUrl('http://[::1]:3000', '::1'))
-        .toBe('http://[::1]:3000')
-    })
-  })
-
-  describe('when accessing remotely', () => {
-    const remoteHost = '192.168.1.100'
-
-    it('rewrites http://localhost:port to use the remote host', () => {
-      expect(rewriteLocalhostUrl('http://localhost:3000', remoteHost))
-        .toBe('http://192.168.1.100:3000/')
-    })
-
-    it('rewrites http://127.0.0.1:port to use the remote host', () => {
-      expect(rewriteLocalhostUrl('http://127.0.0.1:3000', remoteHost))
-        .toBe('http://192.168.1.100:3000/')
-    })
-
-    it('rewrites https://localhost:port to use the remote host', () => {
-      expect(rewriteLocalhostUrl('https://localhost:3000', remoteHost))
-        .toBe('https://192.168.1.100:3000/')
-    })
-
-    it('rewrites http://[::1]:port to use the remote host', () => {
-      expect(rewriteLocalhostUrl('http://[::1]:3000', remoteHost))
-        .toBe('http://192.168.1.100:3000/')
-    })
-
-    it('preserves path and query string', () => {
-      expect(rewriteLocalhostUrl('http://localhost:3000/api/data?q=test&page=1', remoteHost))
-        .toBe('http://192.168.1.100:3000/api/data?q=test&page=1')
-    })
-
-    it('preserves hash fragment', () => {
-      expect(rewriteLocalhostUrl('http://localhost:3000/page#section', remoteHost))
-        .toBe('http://192.168.1.100:3000/page#section')
-    })
-
-    it('handles localhost without explicit port', () => {
-      expect(rewriteLocalhostUrl('http://localhost', remoteHost))
-        .toBe('http://192.168.1.100/')
-    })
-
-    it('handles localhost with trailing path', () => {
-      expect(rewriteLocalhostUrl('http://localhost:8080/index.html', remoteHost))
-        .toBe('http://192.168.1.100:8080/index.html')
-    })
-
-    it('does not rewrite non-localhost URLs', () => {
-      expect(rewriteLocalhostUrl('https://example.com/page', remoteHost))
-        .toBe('https://example.com/page')
-    })
-
-    it('does not rewrite URLs with other hostnames', () => {
-      expect(rewriteLocalhostUrl('http://10.0.0.5:3000', remoteHost))
-        .toBe('http://10.0.0.5:3000')
-    })
-
-    it('returns invalid URLs unchanged', () => {
-      expect(rewriteLocalhostUrl('not-a-url', remoteHost)).toBe('not-a-url')
-    })
-
-    it('returns empty string unchanged', () => {
-      expect(rewriteLocalhostUrl('', remoteHost)).toBe('')
-    })
-
-    it('does not rewrite file:// URLs', () => {
-      expect(rewriteLocalhostUrl('file:///home/user/index.html', remoteHost))
-        .toBe('file:///home/user/index.html')
-    })
   })
 })

--- a/test/unit/server/port-forward.test.ts
+++ b/test/unit/server/port-forward.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
+import * as net from 'net'
+import { PortForwardManager } from '../../../server/port-forward.js'
+
+// Helper: create a TCP server on localhost that echoes data back
+function createEchoServer(): Promise<{ server: net.Server; port: number }> {
+  return new Promise((resolve) => {
+    const server = net.createServer((socket) => {
+      socket.pipe(socket)
+    })
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as net.AddressInfo
+      resolve({ server, port: addr.port })
+    })
+  })
+}
+
+// Helper: connect to a TCP port and send/receive data
+function tcpExchange(
+  host: string,
+  port: number,
+  data: string,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const settle = (fn: () => void) => {
+      if (!settled) {
+        settled = true
+        fn()
+      }
+    }
+
+    const socket = net.createConnection({ host, port }, () => {
+      socket.write(data)
+    })
+    const chunks: Buffer[] = []
+    socket.on('data', (chunk) => {
+      chunks.push(chunk)
+      const received = Buffer.concat(chunks).toString()
+      if (received.length >= data.length) {
+        socket.end()
+        settle(() => resolve(received))
+      }
+    })
+    socket.on('error', (err) => settle(() => reject(err)))
+    socket.on('close', () => {
+      settle(() => {
+        const received = Buffer.concat(chunks).toString()
+        if (received.length > 0) resolve(received)
+        else reject(new Error('Connection closed without data'))
+      })
+    })
+    socket.setTimeout(5000, () => {
+      socket.destroy(new Error('TCP exchange timeout'))
+    })
+  })
+}
+
+// Helper: find a port that nothing is listening on
+async function findUnusedPort(): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = net.createServer()
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as net.AddressInfo).port
+      srv.close(() => resolve(port))
+    })
+  })
+}
+
+describe('PortForwardManager', () => {
+  let manager: PortForwardManager
+  let echoServer: net.Server | null = null
+
+  beforeEach(() => {
+    manager = new PortForwardManager({ idleTimeoutMs: 60_000 })
+  })
+
+  afterEach(async () => {
+    manager.closeAll()
+    if (echoServer) {
+      echoServer.close()
+      echoServer = null
+    }
+  })
+
+  describe('forward()', () => {
+    it('creates a TCP forwarding proxy to the target port', async () => {
+      const echo = await createEchoServer()
+      echoServer = echo.server
+
+      const result = await manager.forward(echo.port)
+      expect(result.port).toBeGreaterThan(0)
+      expect(result.port).not.toBe(echo.port)
+
+      // Connect through the forward and verify data is piped
+      const response = await tcpExchange('127.0.0.1', result.port, 'hello')
+      expect(response).toBe('hello')
+    })
+
+    it('reuses an existing forward for the same target port', async () => {
+      const echo = await createEchoServer()
+      echoServer = echo.server
+
+      const first = await manager.forward(echo.port)
+      const second = await manager.forward(echo.port)
+
+      expect(first.port).toBe(second.port)
+    })
+
+    it('creates separate forwards for different target ports', async () => {
+      const echo1 = await createEchoServer()
+      const echo2 = await createEchoServer()
+
+      const forward1 = await manager.forward(echo1.port)
+      const forward2 = await manager.forward(echo2.port)
+
+      expect(forward1.port).not.toBe(forward2.port)
+
+      echo1.server.close()
+      echo2.server.close()
+    })
+
+    it('rejects invalid port numbers', async () => {
+      await expect(manager.forward(0)).rejects.toThrow()
+      await expect(manager.forward(70000)).rejects.toThrow()
+      await expect(manager.forward(-1)).rejects.toThrow()
+    })
+
+    it('handles connection errors when target is not listening', async () => {
+      // Forward to a port nothing is listening on
+      const unusedPort = await findUnusedPort()
+      const result = await manager.forward(unusedPort)
+
+      // The forward itself succeeds (TCP server starts)
+      expect(result.port).toBeGreaterThan(0)
+
+      // But connecting through it should fail (ECONNREFUSED from target)
+      await expect(
+        tcpExchange('127.0.0.1', result.port, 'hello'),
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('close()', () => {
+    it('closes the forward and frees the port', async () => {
+      const echo = await createEchoServer()
+      echoServer = echo.server
+
+      const result = await manager.forward(echo.port)
+
+      // Verify forward works
+      const response = await tcpExchange('127.0.0.1', result.port, 'test')
+      expect(response).toBe('test')
+
+      // Close the forward
+      manager.close(echo.port)
+
+      // Verify forward is gone (connection should fail)
+      await expect(
+        tcpExchange('127.0.0.1', result.port, 'test'),
+      ).rejects.toThrow()
+    })
+
+    it('is a no-op for non-existent forwards', () => {
+      // Should not throw
+      manager.close(99999)
+    })
+
+    it('allows re-creating a forward after closing', async () => {
+      const echo = await createEchoServer()
+      echoServer = echo.server
+
+      const first = await manager.forward(echo.port)
+      manager.close(echo.port)
+
+      const second = await manager.forward(echo.port)
+      // May or may not get the same port, but it should work
+      const response = await tcpExchange('127.0.0.1', second.port, 'again')
+      expect(response).toBe('again')
+    })
+  })
+
+  describe('closeAll()', () => {
+    it('closes all active forwards', async () => {
+      const echo1 = await createEchoServer()
+      const echo2 = await createEchoServer()
+
+      const f1 = await manager.forward(echo1.port)
+      const f2 = await manager.forward(echo2.port)
+
+      manager.closeAll()
+
+      await expect(
+        tcpExchange('127.0.0.1', f1.port, 'test'),
+      ).rejects.toThrow()
+      await expect(
+        tcpExchange('127.0.0.1', f2.port, 'test'),
+      ).rejects.toThrow()
+
+      echo1.server.close()
+      echo2.server.close()
+    })
+  })
+
+  describe('getForwardedPort()', () => {
+    it('returns the forwarded port for an active forward', async () => {
+      const echo = await createEchoServer()
+      echoServer = echo.server
+
+      const result = await manager.forward(echo.port)
+      expect(manager.getForwardedPort(echo.port)).toBe(result.port)
+    })
+
+    it('returns undefined for non-existent forwards', () => {
+      expect(manager.getForwardedPort(12345)).toBeUndefined()
+    })
+  })
+
+  describe('idle timeout', () => {
+    it('cleans up forwards after idle timeout with no active connections', async () => {
+      vi.useFakeTimers()
+
+      const shortManager = new PortForwardManager({ idleTimeoutMs: 1000 })
+      const echo = await createEchoServer()
+      echoServer = echo.server
+
+      await shortManager.forward(echo.port)
+      expect(shortManager.getForwardedPort(echo.port)).toBeDefined()
+
+      // Advance past idle timeout + cleanup interval
+      vi.advanceTimersByTime(70_000)
+
+      expect(shortManager.getForwardedPort(echo.port)).toBeUndefined()
+
+      shortManager.closeAll()
+      vi.useRealTimers()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Adds TCP port forwarding functionality to enable remote users to access localhost services through the browser pane. When a user accesses the application from a remote host and navigates to a localhost URL (e.g., `http://localhost:3000`), the system automatically creates a port forward and rewrites the URL to use the host's IP address with the forwarded port.

## Key Changes

### Server-side
- **New `PortForwardManager` class** (`server/port-forward.ts`): Manages TCP port forwarding with the following features:
  - Creates bidirectional TCP proxies from OS-assigned ports to target localhost ports
  - Reuses existing forwards for the same target port
  - Automatic idle timeout cleanup (default 5 minutes) for unused forwards
  - Graceful connection handling and error propagation
  
- **New API endpoints** (`server/index.ts`):
  - `POST /api/proxy/forward`: Creates or reuses a port forward, returns the forwarded port
  - `DELETE /api/proxy/forward/:port`: Closes a specific port forward
  - Proper validation of port numbers (1-65535)
  - Error handling with descriptive messages

- **Shutdown integration**: Port forwards are properly closed during server shutdown

### Client-side
- **Port forwarding detection** (`src/lib/url-rewrite.ts`): New utility to identify loopback hostnames (localhost, 127.0.0.1, ::1, [::1])

- **Enhanced BrowserPane** (`src/components/panes/BrowserPane.tsx`):
  - Detects when a localhost URL is being accessed from a remote host
  - Automatically requests port forwarding from the server
  - Rewrites URLs to use the host's IP and forwarded port while preserving path/query/hash
  - Shows loading state while port forward is being established
  - Displays user-friendly error messages if forwarding fails
  - Preserves existing file:// URL handling and direct access for local users

## Implementation Details

- **Smart URL rewriting**: Only activates when accessing from a remote host (detected via `window.location.hostname`). Local access bypasses forwarding entirely.
- **Connection lifecycle**: Forwards are tracked with last-activity timestamps and automatically cleaned up after idle timeout with no active connections.
- **Error handling**: Connection errors to the target port are properly propagated to the client, and the UI provides a "Try Again" button for recovery.
- **Comprehensive testing**: Includes unit tests for the PortForwardManager, integration tests for the API endpoints, and component tests for the BrowserPane UI behavior.

https://claude.ai/code/session_01GbHxn8smqBGvDdKRT7BRbj