### PR TITLE
fix(security): bind to localhost by default

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -590,18 +590,27 @@ async function main() {
   }
 
   const port = Number(process.env.PORT || 3001)
-  server.listen(port, '0.0.0.0', () => {
-    log.info({ port, appVersion: APP_VERSION }, 'Server listening')
+  const host = process.env.HOST || '127.0.0.1'  // Default to localhost for safety
+  server.listen(port, host, () => {
+    log.info({ port, host, appVersion: APP_VERSION }, 'Server listening')
 
     // Print friendly startup message
     const token = process.env.AUTH_TOKEN
     const lanIps = detectLanIps()
     const lanIp = lanIps[0] || 'localhost'
-    const url = `http://${lanIp}:${port}/?token=${token}`
+    const isDev = process.env.NODE_ENV !== 'production'
+    const frontendPort = isDev ? (process.env.VITE_PORT || '5173') : port
+    const networkUrl = `http://${lanIp}:${frontendPort}/?token=${token}`
+    const localUrl = `http://localhost:${frontendPort}/?token=${token}`
 
     console.log('')
     console.log(`\x1b[32m\u{1F41A}\u{1F525} freshell is ready!\x1b[0m`)
-    console.log(`   Visit from anywhere on your network: \x1b[36m${url}\x1b[0m`)
+    if (host === '127.0.0.1' || host === 'localhost') {
+      console.log(`   Local only: \x1b[36m${localUrl}\x1b[0m`)
+      console.log(`   \x1b[33m(Set HOST=0.0.0.0 to expose to network)\x1b[0m`)
+    } else {
+      console.log(`   Visit from anywhere on your network: \x1b[36m${networkUrl}\x1b[0m`)
+    }
     console.log('')
 
     startBackgroundTasks()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig(({ mode }) => {
       sourcemap: mode === 'development',
     },
     server: {
-      host: true,
+      host: env.VITE_HOST || '127.0.0.1',  // Default to localhost for safety
       port: vitePort,
       watch: {
         ignored: ['**/.worktrees/**', '**/demo-projects/**'],


### PR DESCRIPTION
## Summary

Changes the default bind address from `0.0.0.0` to `127.0.0.1` for both the Express server and Vite dev server, mitigating the unauthenticated `/local-file` endpoint vulnerability on untrusted networks.

## Problem

The `/local-file` endpoint serves arbitrary files without authentication. When the server binds to `0.0.0.0`, anyone on the same network can read any file:

```bash
curl "http://<server-ip>:3001/local-file?path=/etc/passwd"
```

## Solution

- Default to `127.0.0.1` (localhost only)
- Add `HOST` env var to opt-in to network exposure
- Add `VITE_HOST` env var for the Vite dev server
- Update startup message to show correct URL and hint

## Usage

```bash
# Safe default (localhost only)
npm run dev

# Explicit network exposure (trusted networks)
HOST=0.0.0.0 npm run dev
```

## Files Changed

- `server/index.ts` - Server bind address + startup message
- `vite.config.ts` - Vite dev server bind address