### PR TITLE
fix: show correct worktree name in sidebar instead of shared repo root

### DIFF
--- a/server/coding-cli/providers/claude.ts
+++ b/server/coding-cli/providers/claude.ts
@@ -8,7 +8,7 @@ import { getClaudeHome } from '../../claude-home.js'
 import type { CodingCliProvider } from '../provider.js'
 import type { NormalizedEvent, ParsedSessionMeta, TokenSummary } from '../types.js'
 import { parseClaudeEvent, isMessageEvent, isResultEvent, isToolResultContent, isToolUseContent, isTextContent } from '../../claude-stream-types.js'
-import { looksLikePath, isSystemContext, extractFromIdeContext, resolveGitRepoRoot } from '../utils.js'
+import { looksLikePath, isSystemContext, extractFromIdeContext, resolveGitCheckoutRoot } from '../utils.js'
 
 export type JsonlMeta = {
   sessionId?: string
@@ -381,7 +381,7 @@ export const claudeProvider: CodingCliProvider = {
 
   async resolveProjectPath(_filePath: string, meta: ParsedSessionMeta): Promise<string> {
     if (!meta.cwd) return 'unknown'
-    return resolveGitRepoRoot(meta.cwd)
+    return resolveGitCheckoutRoot(meta.cwd)
   },
 
   extractSessionId(filePath: string): string {


### PR DESCRIPTION
## Summary

- Git worktrees that share a repository (e.g. `magic0` through `magic7`) all displayed as "magic0" in the sidebar because `resolveProjectPath` resolved to the shared git repo root
- Switch from `resolveGitRepoRoot` to `resolveGitCheckoutRoot` so each worktree gets its own project group and correct label

## Root cause

`resolveGitRepoRoot` reads the `.git` file in a worktree, follows the `gitdir` → `commondir` chain, and returns the parent repo root. For worktrees this collapses all checkout directories to a single path. `resolveGitCheckoutRoot` (already existing in `utils.ts`) returns the directory containing the `.git` file instead — the actual worktree directory.

## Test plan

- [x] Verified sessions from different worktrees now show distinct labels (magic0, magic5, etc.)
- [x] Server typecheck passes clean
- [x] Non-worktree repos unaffected (regular `.git` directories still resolve correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)