### PR TITLE
terminal: add link warning + tab completion indicator settings

### DIFF
--- a/server/config-store.ts
+++ b/server/config-store.ts
@@ -54,6 +54,7 @@ export type AppSettings = {
   panes: {
     defaultNewPane: 'ask' | 'shell' | 'browser' | 'editor'
     snapThreshold: number // 0-8, % of container's smallest dimension; 0 = off
+    tabAttentionStyle: 'highlight' | 'pulse' | 'darken' | 'none'
   }
   sidebar: {
     sortMode: 'recency' | 'activity' | 'project'

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -609,6 +609,22 @@ export default function SettingsView() {
                 }}
               />
             </SettingsRow>
+
+            <SettingsRow label="Tab completion indicator">
+              <SegmentedControl
+                value={settings.panes?.tabAttentionStyle ?? 'highlight'}
+                options={[
+                  { value: 'highlight', label: 'Highlight' },
+                  { value: 'pulse', label: 'Pulse' },
+                  { value: 'darken', label: 'Darken' },
+                  { value: 'none', label: 'None' },
+                ]}
+                onChange={(v: string) => {
+                  dispatch(updateSettingsLocal({ panes: { tabAttentionStyle: v } } as any))
+                  scheduleSave({ panes: { tabAttentionStyle: v } })
+                }}
+              />
+            </SettingsRow>
           </SettingsSection>
 
           {/* Terminal */}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -40,6 +40,7 @@ interface SortableTabProps {
   renameValue: string
   paneContents?: PaneContent[]
   iconsOnTabs?: boolean
+  tabAttentionStyle?: string
   onRenameChange: (value: string) => void
   onRenameBlur: () => void
   onRenameKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void
@@ -58,6 +59,7 @@ function SortableTab({
   renameValue,
   paneContents,
   iconsOnTabs,
+  tabAttentionStyle,
   onRenameChange,
   onRenameBlur,
   onRenameKeyDown,
@@ -95,6 +97,7 @@ function SortableTab({
         renameValue={renameValue}
         paneContents={paneContents}
         iconsOnTabs={iconsOnTabs}
+        tabAttentionStyle={tabAttentionStyle}
         onRenameChange={onRenameChange}
         onRenameBlur={onRenameBlur}
         onRenameKeyDown={onRenameKeyDown}
@@ -121,6 +124,7 @@ export default function TabBar() {
   const paneLayouts = useAppSelector((s) => s.panes?.layouts) ?? EMPTY_LAYOUTS
   const attentionByTab = useAppSelector((s) => s.turnCompletion?.attentionByTab) ?? EMPTY_ATTENTION
   const iconsOnTabs = useAppSelector((s) => s.settings?.settings?.panes?.iconsOnTabs ?? true)
+  const tabAttentionStyle = useAppSelector((s) => s.settings?.settings?.panes?.tabAttentionStyle ?? 'highlight')
 
   const ws = useMemo(() => getWsClient(), [])
 
@@ -257,6 +261,7 @@ export default function TabBar() {
                 renameValue={renameValue}
                 paneContents={getPaneContents(tab)}
                 iconsOnTabs={iconsOnTabs}
+                tabAttentionStyle={tabAttentionStyle}
                 onRenameChange={setRenameValue}
                 onRenameBlur={() => {
                   dispatch(
@@ -333,6 +338,7 @@ export default function TabBar() {
                 renameValue=""
                 paneContents={getPaneContents(activeTab)}
                 iconsOnTabs={iconsOnTabs}
+                tabAttentionStyle={tabAttentionStyle}
                 onRenameChange={() => {}}
                 onRenameBlur={() => {}}
                 onRenameKeyDown={() => {}}

--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -42,6 +42,7 @@ export interface TabItemProps {
   renameValue: string
   paneContents?: PaneContent[]
   iconsOnTabs?: boolean
+  tabAttentionStyle?: string
   onRenameChange: (value: string) => void
   onRenameBlur: () => void
   onRenameKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void
@@ -59,6 +60,7 @@ export default function TabItem({
   renameValue,
   paneContents,
   iconsOnTabs = true,
+  tabAttentionStyle = 'highlight',
   onRenameChange,
   onRenameBlur,
   onRenameKeyDown,
@@ -106,12 +108,29 @@ export default function TabItem({
       className={cn(
         'group relative flex items-center gap-2 h-8 px-3 rounded-t-md border-x border-t border-muted-foreground/45 text-sm cursor-pointer transition-colors',
         isActive
-          ? "z-30 -mb-px border-b border-b-background bg-background text-foreground after:pointer-events-none after:absolute after:inset-x-0 after:-bottom-px after:h-[2px] after:bg-background after:content-['']"
-          : needsAttention
-            ? 'border-b border-muted-foreground/45 bg-emerald-100 text-emerald-900 hover:bg-emerald-200 mt-1 dark:bg-emerald-900/40 dark:text-emerald-100 dark:hover:bg-emerald-900/55'
+          ? cn(
+              "z-30 -mb-px border-b border-b-background bg-background text-foreground after:pointer-events-none after:absolute after:inset-x-0 after:-bottom-px after:h-[2px] after:bg-background after:content-['']",
+              needsAttention && tabAttentionStyle !== 'none' && tabAttentionStyle === 'pulse' && 'animate-pulse'
+            )
+          : needsAttention && tabAttentionStyle !== 'none'
+            ? tabAttentionStyle === 'darken'
+              ? 'border-b border-muted-foreground/45 bg-foreground/15 text-foreground hover:bg-foreground/20 mt-1 dark:bg-foreground/20 dark:text-foreground dark:hover:bg-foreground/25'
+              : cn(
+                  'border-b border-muted-foreground/45 bg-emerald-100 text-emerald-900 hover:bg-emerald-200 mt-1 dark:bg-emerald-900/40 dark:text-emerald-100 dark:hover:bg-emerald-900/55',
+                  tabAttentionStyle === 'pulse' && 'animate-pulse'
+                )
             : 'border-b border-muted-foreground/45 bg-muted text-muted-foreground hover:text-foreground hover:bg-muted/90 mt-1',
         isDragging && 'opacity-50'
       )}
+      style={isActive && needsAttention && tabAttentionStyle !== 'none' ? {
+        borderTopWidth: '3px',
+        borderTopStyle: 'solid',
+        borderTopColor: tabAttentionStyle === 'darken' ? '#666' : '#059669',
+        backgroundColor: tabAttentionStyle === 'darken' ? 'rgba(0,0,0,0.15)' : 'rgba(16,185,129,0.25)',
+        boxShadow: tabAttentionStyle === 'darken'
+          ? 'inset 0 4px 8px rgba(0,0,0,0.15)'
+          : 'inset 0 4px 8px rgba(16,185,129,0.3)',
+      } : undefined}
       role="button"
       tabIndex={0}
       aria-label={tab.title}

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -3,7 +3,7 @@ import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { updateTab, switchToNextTab, switchToPrevTab } from '@/store/tabsSlice'
 import { updatePaneContent, updatePaneTitle } from '@/store/panesSlice'
 import { updateSessionActivity } from '@/store/sessionActivitySlice'
-import { recordTurnComplete } from '@/store/turnCompletionSlice'
+import { recordTurnComplete, clearTabAttention } from '@/store/turnCompletionSlice'
 import { getWsClient } from '@/lib/ws-client'
 import { getTerminalTheme } from '@/lib/terminal-themes'
 import { getResumeSessionIdFromRef } from '@/components/terminal-view-utils'
@@ -152,8 +152,10 @@ export default function TerminalView({ tabId, paneId, paneContent, hidden }: Ter
   const sendInput = useCallback((data: string) => {
     const tid = terminalIdRef.current
     if (!tid) return
+    // Clear attention indicator when user starts typing
+    dispatch(clearTabAttention({ tabId }))
     ws.send({ type: 'terminal.input', terminalId: tid, data })
-  }, [ws])
+  }, [dispatch, tabId, ws])
 
   // Init xterm once
   useEffect(() => {

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -37,6 +37,7 @@ export const defaultSettings: AppSettings = {
     defaultNewPane: 'ask' as const,
     snapThreshold: 2,
     iconsOnTabs: true,
+    tabAttentionStyle: 'highlight' as const,
   },
   codingCli: {
     enabledProviders: ['claude', 'codex'],

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -88,6 +88,8 @@ export type SidebarSortMode = 'recency' | 'recency-pinned' | 'activity' | 'proje
 
 export type DefaultNewPane = 'ask' | 'shell' | 'browser' | 'editor'
 
+export type TabAttentionStyle = 'highlight' | 'pulse' | 'darken' | 'none'
+
 export type TerminalTheme =
   | 'auto'           // Follow app theme (dark/light)
   | 'dracula'
@@ -146,5 +148,6 @@ export interface AppSettings {
     defaultNewPane: DefaultNewPane
     snapThreshold: number // 0-8, % of container's smallest dimension; 0 = off
     iconsOnTabs: boolean
+    tabAttentionStyle: TabAttentionStyle
   }
 }


### PR DESCRIPTION
## Summary

Two new configurable terminal/tab settings:

### 1. Warn on external links (Settings > Terminal)
- When ON (default): xterm.js shows confirm dialog before opening links
- When OFF: links open directly in a new tab with no warning

### 2. Tab completion indicator (Settings > Panes)
- When a coding CLI (Claude/Codex) finishes a turn, the tab shows a visual indicator
- Indicator **persists until the user starts typing** in that tab (not a timer)
- Works on both active and background tabs
- Four styles: **Highlight** (emerald, default), **Pulse** (animated), **Darken** (dimmed), **None** (off)

## Key implementation details

- `markTabAttention` fires for ALL tabs including the active one
- Auto-clear timer removed; attention cleared via `clearTabAttention` in `sendInput`
- Active tab attention uses inline `style` prop (tailwind-merge drops conflicting border classes)
- Background tab attention uses class-based styling (no conflict)
- Server config-store: both settings added to type, defaults, and merge allowlist

## Files changed

| File | Change |
|------|--------|
| `server/config-store.ts` | Types, defaults, and merge allowlist for both settings |
| `src/store/types.ts` | `TabAttentionStyle` union type |
| `src/store/settingsSlice.ts` | Default values |
| `src/components/SettingsView.tsx` | UI controls for both settings |
| `src/components/TerminalView.tsx` | Link handler + clearTabAttention on input |
| `src/components/TabBar.tsx` | `tabAttentionStyle` selector and prop threading |
| `src/components/TabItem.tsx` | Visual indicator rendering (inline styles for active tab) |
| `src/hooks/useTurnCompletionNotifications.ts` | Simplified: removed auto-clear timer, marks all tabs |

## Test plan

**Link warning:**
- [ ] Settings > Terminal: toggle "Warn on external links" OFF
- [ ] Click a terminal link — opens directly, no confirm dialog
- [ ] Toggle ON — confirm dialog reappears
- [ ] Restart freshell — setting persists

**Tab completion indicator:**
- [ ] Start Claude in a tab, run a prompt, switch to another tab
- [ ] Background tab should show emerald highlight when turn completes
- [ ] Switch back — indicator clears when you type
- [ ] Active tab: stay on the tab, run a prompt — indicator appears on active tab too
- [ ] Settings > Panes: try Highlight, Pulse, Darken, None
- [ ] Restart freshell — setting persists

Generated with [Claude Code](https://claude.com/claude-code)