### PR TITLE
chore: add superpowers plugin as project dependency

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "superpowers@superpowers-marketplace": true
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Freshell is a self-hosted, browser-accessible terminal multiplexer and session o
 - We fix the system over the symptom.
 
 ## Repo Rules
-- Always check for an use applicable skills
+- Always check for and use applicable skills
+- This project uses the [superpowers](https://github.com/obra/superpowers) plugin (configured in `.claude/settings.json`). Skills like `superpowers:executing-plans` are referenced throughout plan docs in `docs/plans/`.
 - Always work in a worktree (in \.worktrees\)
 - Specific user instructions override ALL other instructions, including the above, and including superpowers or skills
 - Server uses NodeNext/ESM; relative imports must include `.js` extensions


### PR DESCRIPTION
## Summary

- Configures the [superpowers](https://github.com/obra/superpowers) skills framework as a Claude Code project-scoped plugin via `.claude/settings.json`
- Documents superpowers as a project dependency in AGENTS.md Repo Rules
- Fixes typo in AGENTS.md ("an use" → "and use")

## Context

The plan docs in `docs/plans/` already reference `superpowers:executing-plans` as a required sub-skill, but the plugin was never declared in the repo. Any contributor opening a Claude Code session without superpowers pre-installed would have those skill references fail silently. This makes the dependency explicit — Claude Code auto-activates the plugin on session start.

## Test plan

- [x] Verified `.claude/settings.json` contains correct `enabledPlugins` entry
- [x] Verified AGENTS.md diff is clean (superpowers reference + typo fix only)
- [x] Ran `npm test` — 174/178 files pass; 10 failures in `api-edge-cases.test.ts` are pre-existing (temp file race condition, unrelated to this change)

Generated with [Claude Code](https://claude.com/claude-code)