### PR TITLE
feat: add notification sound toggle setting

### DIFF
--- a/server/config-store.ts
+++ b/server/config-store.ts
@@ -64,6 +64,9 @@ export type AppSettings = {
     width: number
     collapsed: boolean
   }
+  notifications: {
+    soundEnabled: boolean
+  }
   codingCli: {
     enabledProviders: CodingCliProviderName[]
     providers: Partial<Record<CodingCliProviderName, {
@@ -121,6 +124,9 @@ export const defaultSettings: AppSettings = {
   safety: {
     autoKillIdleMinutes: 180,
     warnBeforeKillMinutes: 5,
+  },
+  notifications: {
+    soundEnabled: true,
   },
   panes: {
     defaultNewPane: 'ask',
@@ -306,6 +312,7 @@ function mergeSettings(base: AppSettings, patch: Partial<AppSettings>): AppSetti
     },
     logging: { ...baseLogging, ...(patch.logging || {}) },
     safety: { ...base.safety, ...(patch.safety || {}) },
+    notifications: { ...base.notifications, ...(patch.notifications || {}) },
     panes: { ...base.panes, ...(patch.panes || {}) },
     sidebar: { ...base.sidebar, ...(patch.sidebar || {}) },
     codingCli: {

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -627,6 +627,19 @@ export default function SettingsView() {
             </SettingsRow>
           </SettingsSection>
 
+          {/* Notifications */}
+          <SettingsSection title="Notifications" description="Sound and alert preferences">
+            <SettingsRow label="Sound on completion">
+              <Toggle
+                checked={settings.notifications?.soundEnabled ?? true}
+                onChange={(checked) => {
+                  dispatch(updateSettingsLocal({ notifications: { soundEnabled: checked } } as any))
+                  scheduleSave({ notifications: { soundEnabled: checked } })
+                }}
+              />
+            </SettingsRow>
+          </SettingsSection>
+
           {/* Terminal */}
           <SettingsSection title="Terminal" description="Font and rendering options">
             <SettingsRow label="Color scheme">

--- a/src/hooks/useNotificationSound.ts
+++ b/src/hooks/useNotificationSound.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react'
 import type { MutableRefObject } from 'react'
+import { useAppSelector } from '@/store/hooks'
 
 const NOTIFICATION_SOUND_SRC = '/your-code-is-ready.mp3'
 
@@ -31,6 +32,7 @@ function createFallbackTone(ctxRef: MutableRefObject<AudioContext | null>) {
 }
 
 export function useNotificationSound() {
+  const soundEnabled = useAppSelector((s) => s.settings.settings.notifications?.soundEnabled ?? true)
   const audioRef = useRef<HTMLAudioElement | null>(null)
   const audioContextRef = useRef<AudioContext | null>(null)
 
@@ -53,6 +55,7 @@ export function useNotificationSound() {
 
   const play = useCallback(() => {
     if (typeof window === 'undefined') return
+    if (!soundEnabled) return
 
     try {
       if (!audioRef.current) {
@@ -71,7 +74,7 @@ export function useNotificationSound() {
     } catch {
       createFallbackTone(audioContextRef)
     }
-  }, [])
+  }, [soundEnabled])
 
   return { play }
 }

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -33,6 +33,9 @@ export const defaultSettings: AppSettings = {
     width: 288,
     collapsed: false,
   },
+  notifications: {
+    soundEnabled: true,
+  },
   panes: {
     defaultNewPane: 'ask' as const,
     snapThreshold: 2,
@@ -82,6 +85,7 @@ export function mergeSettings(base: AppSettings, patch: Partial<AppSettings>): A
     logging: { ...baseLogging, ...(patch.logging || {}) },
     safety: { ...base.safety, ...(patch.safety || {}) },
     sidebar: { ...base.sidebar, ...(patch.sidebar || {}) },
+    notifications: { ...base.notifications, ...(patch.notifications || {}) },
     panes: { ...base.panes, ...(patch.panes || {}) },
     codingCli: {
       ...baseCodingCli,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -143,6 +143,9 @@ export interface AppSettings {
     width: number // pixels, default 288 (equivalent to w-72)
     collapsed: boolean // for mobile/responsive use
   }
+  notifications: {
+    soundEnabled: boolean
+  }
   codingCli: CodingCliSettings
   panes: {
     defaultNewPane: DefaultNewPane

--- a/test/unit/client/store/settingsSlice.test.ts
+++ b/test/unit/client/store/settingsSlice.test.ts
@@ -110,6 +110,9 @@ describe('settingsSlice', () => {
           width: 320,
           collapsed: false,
         },
+        notifications: {
+          soundEnabled: false,
+        },
         codingCli: {
           enabledProviders: ['codex'],
           providers: {

--- a/test/unit/client/store/state-edge-cases.test.ts
+++ b/test/unit/client/store/state-edge-cases.test.ts
@@ -820,6 +820,9 @@ describe('State Edge Cases', () => {
             width: 400,
             collapsed: true,
           },
+          notifications: {
+            soundEnabled: false,
+          },
           panes: {
             defaultNewPane: 'shell',
             snapThreshold: 3,


### PR DESCRIPTION
## Summary

- Add `notifications.soundEnabled` boolean to AppSettings (client + server)
- Gate all notification sounds in one place: `useNotificationSound.play()` early-returns when disabled
- Add "Notifications" section to Settings UI with "Sound on completion" toggle
- Default `true` for backward compatibility — existing configs keep sound enabled

Resolves [FRE-6](https://linear.app/intensitymagic/issue/FRE-6)

## Test plan

- [x] Build passes (`npm run build`)
- [x] Existing settings tests updated and passing
- [x] Toggle should appear in Settings between Panes and Terminal sections
- [ ] Verify toggling off suppresses turn-completion and terminal-exit sounds
- [ ] Verify setting persists in `~/.freshell/config.json` across restarts

Generated with [Claude Code](https://claude.com/claude-code)