### PR TITLE
fix(tests): allow console.error in malformed JSON security tests

### DIFF
--- a/test/integration/server/api-edge-cases.test.ts
+++ b/test/integration/server/api-edge-cases.test.ts
@@ -144,6 +144,12 @@ describe('API Edge Cases - Security Testing', () => {
   // 1. MALFORMED JSON IN REQUEST BODY
   // =============================================================================
   describe('Malformed JSON Handling', () => {
+    beforeEach(() => {
+      // These tests intentionally send malformed JSON, which triggers
+      // console.error from Express's built-in JSON parser. That's expected.
+      ;(globalThis as any).__ALLOW_CONSOLE_ERROR__ = true
+    })
+
     it('rejects completely invalid JSON with 400', async () => {
       const res = await request(app)
         .patch('/api/settings')
@@ -310,6 +316,10 @@ describe('API Edge Cases - Security Testing', () => {
   // 3. EXTREMELY LARGE PAYLOADS
   // =============================================================================
   describe('Payload Size Limits', () => {
+    beforeEach(() => {
+      ;(globalThis as any).__ALLOW_CONSOLE_ERROR__ = true
+    })
+
     it('rejects payload larger than 1MB', async () => {
       const largeString = 'a'.repeat(1.5 * 1024 * 1024) // 1.5MB
       const res = await request(app)
@@ -1198,6 +1208,10 @@ describe('API Edge Cases - Security Testing', () => {
   // 12. CONTENT-TYPE EDGE CASES
   // =============================================================================
   describe('Content-Type Edge Cases', () => {
+    beforeEach(() => {
+      ;(globalThis as any).__ALLOW_CONSOLE_ERROR__ = true
+    })
+
     it('rejects non-JSON content type', async () => {
       const res = await request(app)
         .patch('/api/settings')


### PR DESCRIPTION
## Summary

- Fix 9 pre-existing test failures in `api-edge-cases.test.ts` on main
- Root cause: global `console.error` spy in `test/setup/dom.ts` throws on any unexpected error output, but Express's JSON parser legitimately logs parse errors to `console.error`
- Uses the existing `__ALLOW_CONSOLE_ERROR__` escape hatch in the 3 affected `describe` blocks (Malformed JSON, Payload Size, Content-Type Edge Cases)

Resolves [FRE-9](https://linear.app/intensitymagic/issue/FRE-9)

## Test plan

- [x] All 87 tests in `api-edge-cases.test.ts` pass (was 78/87)
- [x] Full suite: 2683 passed, 0 failed (was 2656 passed, 9 failed)
- [x] No other tests affected

Generated with [Claude Code](https://claude.com/claude-code)