### PR TITLE
feat: show running version and update status next to logo

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -35,6 +35,7 @@ import { resolveVisitPort } from './startup-url.js'
 import { PortForwardManager } from './port-forward.js'
 import { getRequesterIdentity, parseTrustProxyEnv } from './request-ip.js'
 import { collectCandidateDirectories } from './candidate-dirs.js'
+import { checkForUpdate } from './updater/version-checker.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -277,6 +278,16 @@ async function main() {
       detectAvailableClis(),
     ])
     res.json({ platform, availableClis })
+  })
+
+  app.get('/api/version', async (_req, res) => {
+    try {
+      const updateCheck = await checkForUpdate(APP_VERSION)
+      res.json({ currentVersion: APP_VERSION, updateCheck })
+    } catch (err) {
+      console.warn('[version] checkForUpdate failed:', err instanceof Error ? err.message : String(err))
+      res.json({ currentVersion: APP_VERSION, updateCheck: null })
+    }
   })
 
   app.get('/api/files/candidate-dirs', async (_req, res) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -114,6 +114,17 @@ export const api = {
   },
 }
 
+export type VersionInfo = {
+  currentVersion: string
+  updateCheck: {
+    updateAvailable: boolean
+    currentVersion: string
+    latestVersion: string | null
+    releaseUrl: string | null
+    error: string | null
+  } | null
+}
+
 export type SearchResult = {
   sessionId: string
   provider: CodingCliProviderName

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -15,6 +15,7 @@ import idleWarningsReducer from './idleWarningsSlice'
 import turnCompletionReducer from './turnCompletionSlice'
 import terminalMetaReducer from './terminalMetaSlice'
 import claudeChatReducer from './claudeChatSlice'
+import versionReducer from './versionSlice'
 import { perfMiddleware } from './perfMiddleware'
 import { persistMiddleware } from './persistMiddleware'
 import { sessionActivityPersistMiddleware } from './sessionActivityPersistence'
@@ -35,6 +36,7 @@ export const store = configureStore({
     turnCompletion: turnCompletionReducer,
     terminalMeta: terminalMetaReducer,
     claudeChat: claudeChatReducer,
+    version: versionReducer,
   },
   middleware: (getDefault) =>
     getDefault({

--- a/src/store/versionSlice.ts
+++ b/src/store/versionSlice.ts
@@ -1,0 +1,44 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+export interface VersionState {
+  currentVersion: string | null
+  latestVersion: string | null
+  updateAvailable: boolean
+  releaseUrl: string | null
+  error: string | null
+}
+
+const initialState: VersionState = {
+  currentVersion: null,
+  latestVersion: null,
+  updateAvailable: false,
+  releaseUrl: null,
+  error: null,
+}
+
+export const versionSlice = createSlice({
+  name: 'version',
+  initialState,
+  reducers: {
+    setVersionInfo: (state, action: PayloadAction<{
+      currentVersion: string
+      updateCheck: {
+        updateAvailable: boolean
+        latestVersion: string | null
+        releaseUrl: string | null
+        error: string | null
+      } | null
+    }>) => {
+      state.currentVersion = action.payload.currentVersion
+      if (action.payload.updateCheck) {
+        state.updateAvailable = action.payload.updateCheck.updateAvailable
+        state.latestVersion = action.payload.updateCheck.latestVersion
+        state.releaseUrl = action.payload.updateCheck.releaseUrl
+        state.error = action.payload.updateCheck.error
+      }
+    },
+  },
+})
+
+export const { setVersionInfo } = versionSlice.actions
+export default versionSlice.reducer

--- a/test/unit/client/components/App.sidebar-resize.test.tsx
+++ b/test/unit/client/components/App.sidebar-resize.test.tsx
@@ -9,6 +9,7 @@ import connectionReducer from '@/store/connectionSlice'
 import sessionsReducer from '@/store/sessionsSlice'
 import panesReducer from '@/store/panesSlice'
 import idleWarningsReducer from '@/store/idleWarningsSlice'
+import versionReducer from '@/store/versionSlice'
 
 // Mock the WebSocket client
 const mockSend = vi.fn()
@@ -80,6 +81,7 @@ function createTestStore(options?: {
       sessions: sessionsReducer,
       panes: panesReducer,
       idleWarnings: idleWarningsReducer,
+      version: versionReducer,
     },
     middleware: (getDefault) =>
       getDefault({

--- a/test/unit/client/components/App.test.tsx
+++ b/test/unit/client/components/App.test.tsx
@@ -9,6 +9,7 @@ import connectionReducer from '@/store/connectionSlice'
 import sessionsReducer from '@/store/sessionsSlice'
 import panesReducer from '@/store/panesSlice'
 import idleWarningsReducer from '@/store/idleWarningsSlice'
+import versionReducer from '@/store/versionSlice'
 
 // Ensure DOM is clean even if another test file forgot cleanup.
 beforeEach(() => {
@@ -81,6 +82,7 @@ function createTestStore() {
       sessions: sessionsReducer,
       panes: panesReducer,
       idleWarnings: idleWarningsReducer,
+      version: versionReducer,
     },
     middleware: (getDefault) =>
       getDefault({
@@ -850,6 +852,7 @@ describe('Tab Switching Keyboard Shortcuts', () => {
         connection: connectionReducer,
         sessions: sessionsReducer,
         panes: panesReducer,
+        version: versionReducer,
       },
       middleware: (getDefault) =>
         getDefault({


### PR DESCRIPTION
## Summary

- Add `/api/version` endpoint that leverages existing `checkForUpdate()` from `version-checker.ts`
- Create Redux `versionSlice` to store version state on the client
- Display version badge (e.g., `v0.4.1`) next to the Freshell logo in the header
- Badge shows muted text when up-to-date, amber with alert icon when an update is available
- Version is fetched once on bootstrap (no polling)

## Files Changed

| File | Change |
|------|--------|
| `server/index.ts` | New `/api/version` endpoint |
| `src/store/versionSlice.ts` | New Redux slice for version state |
| `src/store/store.ts` | Register version reducer |
| `src/lib/api.ts` | Add `VersionInfo` type |
| `src/App.tsx` | Bootstrap fetch + badge UI next to logo |
| `test/unit/client/components/App.test.tsx` | Add version reducer to test store |
| `test/unit/client/components/App.sidebar-resize.test.tsx` | Add version reducer to test store |

## Test plan

- [x] Version badge renders next to logo showing current version
- [x] Amber indicator + AlertCircle icon appears when update is available
- [x] Tooltip shows "Up to date" or "Update available: vX.Y.Z"
- [x] Graceful degradation: badge hidden if `/api/version` fails
- [x] Existing App tests pass (33/33) with version reducer added to test stores

Generated with [Claude Code](https://claude.com/claude-code)