### PR TITLE
server: move /local-file endpoint behind auth middleware

### DIFF
--- a/src/components/panes/BrowserPane.tsx
+++ b/src/components/panes/BrowserPane.tsx
@@ -18,11 +18,11 @@ interface BrowserPaneProps {
 
 const MAX_HISTORY_SIZE = 50
 
-// Convert file:// URLs to the /local-file API endpoint for iframe loading
+// Convert file:// URLs to the /api/local-file endpoint for iframe loading
 function toIframeSrc(url: string): string {
   if (url.startsWith('file://')) {
     const filePath = url.replace(/^file:\/\/\/?/, '')
-    return `/local-file?path=${encodeURIComponent(filePath)}`
+    return `/api/local-file?path=${encodeURIComponent(filePath)}`
   }
   return url
 }

--- a/test/unit/client/components/panes/BrowserPane.test.tsx
+++ b/test/unit/client/components/panes/BrowserPane.test.tsx
@@ -145,14 +145,14 @@ describe('BrowserPane', () => {
   })
 
   describe('file:// URL handling', () => {
-    it('converts file:// URLs to /local-file API endpoint', () => {
+    it('converts file:// URLs to /api/local-file endpoint', () => {
       renderBrowserPane({ url: 'file:///home/user/index.html' })
 
       const iframe = document.querySelector('iframe')
       expect(iframe).toBeTruthy()
       // The existing regex strips the leading slash after file:///
       expect(iframe!.getAttribute('src')).toBe(
-        '/local-file?path=' + encodeURIComponent('home/user/index.html'),
+        '/api/local-file?path=' + encodeURIComponent('home/user/index.html'),
       )
     })
   })
@@ -257,9 +257,9 @@ describe('BrowserPane', () => {
 
       const iframe = document.querySelector('iframe')
       expect(iframe).toBeTruthy()
-      // file:// should still go through /local-file endpoint (existing regex strips leading /)
+      // file:// should still go through /api/local-file endpoint (existing regex strips leading /)
       expect(iframe!.getAttribute('src')).toBe(
-        '/local-file?path=' + encodeURIComponent('home/user/index.html'),
+        '/api/local-file?path=' + encodeURIComponent('home/user/index.html'),
       )
     })
 

--- a/test/unit/server/auth.test.ts
+++ b/test/unit/server/auth.test.ts
@@ -110,6 +110,18 @@ describe('auth module', () => {
       expect(next).toHaveBeenCalled()
     })
 
+    it('requires auth for /api/local-file', () => {
+      process.env.AUTH_TOKEN = 'valid-token-16chars'
+      const req = { path: '/api/local-file', headers: {} } as any
+      const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any
+      const next = vi.fn()
+
+      httpAuthMiddleware(req, res, next)
+
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(next).not.toHaveBeenCalled()
+    })
+
     it('returns 500 when AUTH_TOKEN is not configured', () => {
       delete process.env.AUTH_TOKEN
       const req = { path: '/api/settings', headers: {} } as any


### PR DESCRIPTION
## Summary

- Move `/local-file` route from before `httpAuthMiddleware` to after it under `/api` prefix
- The route was registered outside the `/api` prefix, so auth middleware never applied — anyone on the network could read any file on the host without a token
- Update client `BrowserPane.tsx` to use `/api/local-file` path
- Add auth test verifying `/api/local-file` returns 401 without token
- Fix inconsistent tab indentation in route handler

Refs FRE-20

Generated with [Claude Code](https://claude.com/claude-code)