### PR TITLE
server: use timing-safe comparison for auth token checks

### DIFF
--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -4,7 +4,7 @@ import WebSocket, { WebSocketServer } from 'ws'
 import { z } from 'zod'
 import { logger } from './logger.js'
 import { getPerfConfig, logPerfEvent, shouldLog, startPerfTimer } from './perf-logger.js'
-import { getRequiredAuthToken, isLoopbackAddress, isOriginAllowed } from './auth.js'
+import { getRequiredAuthToken, isLoopbackAddress, isOriginAllowed, timingSafeCompare } from './auth.js'
 import { modeSupportsResume } from './terminal-registry.js'
 import type { TerminalRegistry, TerminalMode } from './terminal-registry.js'
 import { configStore, type AppSettings } from './config-store.js'
@@ -1010,7 +1010,7 @@ export class WsHandler {
 
       if (m.type === 'hello') {
         const expected = getRequiredAuthToken()
-        if (!m.token || m.token !== expected) {
+        if (!m.token || !timingSafeCompare(m.token, expected)) {
           log.warn({ event: 'ws_auth_failed', connectionId: ws.connectionId }, 'WebSocket auth failed')
           this.sendError(ws, { code: 'NOT_AUTHENTICATED', message: 'Invalid token' })
           ws.close(CLOSE_CODES.NOT_AUTHENTICATED, 'Invalid token')

--- a/test/unit/server/auth.test.ts
+++ b/test/unit/server/auth.test.ts
@@ -6,6 +6,7 @@ import {
   parseAllowedOrigins,
   isOriginAllowed,
   isLoopbackAddress,
+  timingSafeCompare,
 } from '../../../server/auth'
 
 describe('auth module', () => {
@@ -157,6 +158,34 @@ describe('auth module', () => {
     it('returns false for disallowed origin', () => {
       delete process.env.ALLOWED_ORIGINS
       expect(isOriginAllowed('http://evil.com')).toBe(false)
+    })
+  })
+
+  describe('timingSafeCompare', () => {
+    it('returns true for identical tokens', () => {
+      expect(timingSafeCompare('my-secret-token', 'my-secret-token')).toBe(true)
+    })
+
+    it('returns false for different tokens of same length', () => {
+      expect(timingSafeCompare('my-secret-token', 'xx-secret-token')).toBe(false)
+    })
+
+    it('returns false for different length tokens', () => {
+      expect(timingSafeCompare('short', 'a-much-longer-token')).toBe(false)
+    })
+
+    it('returns true for two empty strings', () => {
+      expect(timingSafeCompare('', '')).toBe(true)
+    })
+
+    it('returns false when one is empty', () => {
+      expect(timingSafeCompare('', 'non-empty')).toBe(false)
+      expect(timingSafeCompare('non-empty', '')).toBe(false)
+    })
+
+    it('handles unicode/multibyte characters', () => {
+      expect(timingSafeCompare('tokën-with-ünïcödé', 'tokën-with-ünïcödé')).toBe(true)
+      expect(timingSafeCompare('tokën-with-ünïcödé', 'token-with-unicode')).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Summary

- Replace `!==` with `crypto.timingSafeEqual` via shared `timingSafeCompare()` helper to prevent timing attacks on LAN environments
- Add length pre-check to avoid `timingSafeEqual` throwing on mismatched buffer lengths
- Update both HTTP middleware (`auth.ts`) and WebSocket hello handler (`ws-handler.ts`)
- Add unit tests covering: identical tokens, different tokens, different lengths, empty strings, unicode

Refs FRE-21

Generated with [Claude Code](https://claude.com/claude-code)