### PR TITLE
server: add .catch() to fire-and-forget async IIFE in session repair

### DIFF
--- a/server/session-scanner/service.ts
+++ b/server/session-scanner/service.ts
@@ -332,7 +332,9 @@ export class SessionRepairService extends EventEmitter {
         if (resolved.length > 0) {
           this.queue.enqueue(resolved)
         }
-      })()
+      })().catch((err) => {
+        logger.warn({ err, sessionIds: pending.map((i) => i.sessionId) }, 'Failed to resolve pending session file paths')
+      })
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `.catch()` handler to the fire-and-forget async IIFE in `enqueueResolved()` to prevent unhandled rejections from crashing the Node process
- Logs with `logger.warn` and includes affected session IDs for debugging
- Matches existing error handling patterns in `claude-indexer.ts` and `terminal-registry.ts`

Refs FRE-23

Generated with [Claude Code](https://claude.com/claude-code)