### PR TITLE
server: add structured error logging to WebSocket send catch blocks

### DIFF
--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -1059,10 +1059,22 @@ export class TerminalRegistry extends EventEmitter {
       }
       return
     }
+    let messageType: string | undefined
+    if (msg && typeof msg === 'object' && 'type' in msg) {
+      const typeValue = (msg as { type?: unknown }).type
+      if (typeof typeValue === 'string') messageType = typeValue
+    }
     try {
       client.send(JSON.stringify(msg))
-    } catch {
-      // ignore
+    } catch (err) {
+      logger.warn(
+        {
+          err: err instanceof Error ? err : new Error(String(err)),
+          terminalId: context?.terminalId || 'unknown',
+          messageType: messageType || 'unknown',
+        },
+        'Terminal output send failed',
+      )
     }
   }
 

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -675,8 +675,15 @@ export class WsHandler {
           'warn',
         )
       })
-    } catch {
-      // ignore
+    } catch (err) {
+      log.warn(
+        {
+          err: err instanceof Error ? err : new Error(String(err)),
+          connectionId: ws.connectionId || 'unknown',
+          messageType: messageType || 'unknown',
+        },
+        'WebSocket send failed',
+      )
     }
   }
 


### PR DESCRIPTION
## Summary

- Replace bare `catch { // ignore }` blocks in `ws-handler.ts:send()` and `terminal-registry.ts:safeSend()` with structured `logger.warn()` calls
- Logs include connectionId/terminalId, messageType, and error details for diagnosing frozen terminals
- Follows existing codebase patterns for error logging (same as `claude-indexer.ts`, `terminal-registry.ts` elsewhere)

Refs FRE-24

Generated with [Claude Code](https://claude.com/claude-code)