### PR TITLE
server: add path sandboxing to file API endpoints

### DIFF
--- a/server/config-store.ts
+++ b/server/config-store.ts
@@ -43,6 +43,7 @@ export type AppSettings = {
       | 'github-light'
   }
   defaultCwd?: string
+  allowedFilePaths?: string[]
   logging: {
     debug: boolean
   }
@@ -112,6 +113,7 @@ export const defaultSettings: AppSettings = {
     theme: 'auto',
   },
   defaultCwd: undefined,
+  allowedFilePaths: undefined,
   logging: {
     debug: resolveDefaultLoggingDebug(),
   },

--- a/server/files-router.ts
+++ b/server/files-router.ts
@@ -1,12 +1,34 @@
-import express from 'express'
+import express, { type Request, type Response, type NextFunction } from 'express'
 import fsp from 'fs/promises'
 import path from 'path'
 import { spawn } from 'child_process'
-import { isReachableDirectory, resolveUserPath } from './path-utils.js'
+import { isPathAllowed, isReachableDirectory, resolveUserPath } from './path-utils.js'
+import { configStore } from './config-store.js'
 
 export const filesRouter = express.Router()
 
-filesRouter.get('/read', async (req, res) => {
+/**
+ * Middleware that validates file paths against the configured allowedFilePaths sandbox.
+ * Returns 403 if the path is outside all allowed roots.
+ * When allowedFilePaths is empty/undefined, all paths are allowed (backward compatible).
+ */
+async function validatePath(req: Request, res: Response, next: NextFunction) {
+  const filePath = (req.query.path as string) || (req.query.prefix as string) || req.body?.path
+  if (!filePath) {
+    return next()
+  }
+
+  const resolved = path.resolve(resolveUserPath(filePath))
+  const settings = await configStore.getSettings()
+
+  if (!isPathAllowed(resolved, settings.allowedFilePaths)) {
+    return res.status(403).json({ error: 'Path not allowed' })
+  }
+
+  next()
+}
+
+filesRouter.get('/read', validatePath, async (req, res) => {
   const filePath = req.query.path as string
   if (!filePath) {
     return res.status(400).json({ error: 'path query parameter required' })
@@ -34,7 +56,7 @@ filesRouter.get('/read', async (req, res) => {
   }
 })
 
-filesRouter.post('/write', async (req, res) => {
+filesRouter.post('/write', validatePath, async (req, res) => {
   const { path: filePath, content } = req.body
 
   if (!filePath) {
@@ -62,7 +84,7 @@ filesRouter.post('/write', async (req, res) => {
   }
 })
 
-filesRouter.get('/complete', async (req, res) => {
+filesRouter.get('/complete', validatePath, async (req, res) => {
   const prefix = req.query.prefix as string
   const dirsOnly = req.query.dirs === 'true' || req.query.dirs === '1'
   if (!prefix) {
@@ -118,7 +140,7 @@ filesRouter.get('/complete', async (req, res) => {
   }
 })
 
-filesRouter.post('/validate-dir', async (req, res) => {
+filesRouter.post('/validate-dir', validatePath, async (req, res) => {
   const pathInput = req.body?.path
   if (!pathInput || typeof pathInput !== 'string') {
     return res.status(400).json({ error: 'path is required' })
@@ -133,7 +155,7 @@ filesRouter.post('/validate-dir', async (req, res) => {
   return res.json({ valid: ok, resolvedPath })
 })
 
-filesRouter.post('/open', async (req, res) => {
+filesRouter.post('/open', validatePath, async (req, res) => {
   const { path: filePath, reveal } = req.body || {}
   if (!filePath) {
     return res.status(400).json({ error: 'path is required' })

--- a/server/path-utils.ts
+++ b/server/path-utils.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import fsp from 'fs/promises'
 import os from 'os'
 import path from 'path'
+import { logger } from './logger.js'
 
 export function resolveUserPath(input: string): string {
   const trimmed = input.trim()
@@ -33,4 +34,53 @@ export async function isReachableDirectory(input: string): Promise<{ ok: boolean
   } catch {
     return { ok: false, resolvedPath }
   }
+}
+
+/**
+ * Normalize a path by resolving it to an absolute path and removing trailing slashes.
+ * Handles `~` expansion via resolveUserPath.
+ */
+export function normalizePath(input: string): string {
+  const resolved = resolveUserPath(input)
+  return path.normalize(resolved)
+}
+
+/**
+ * Check whether a target path falls within one of the allowed root directories.
+ * Returns true if sandboxing is disabled (allowedRoots is undefined or empty).
+ * When enabled, resolves symlinks via fs.realpathSync to prevent symlink escapes.
+ */
+export function isPathAllowed(targetPath: string, allowedRoots: string[] | undefined): boolean {
+  if (!allowedRoots || allowedRoots.length === 0) {
+    return true
+  }
+
+  const resolved = path.resolve(targetPath)
+
+  // Try to resolve symlinks; fall back to resolved path if file doesn't exist yet
+  let realTarget: string
+  try {
+    realTarget = fs.realpathSync(resolved)
+  } catch {
+    realTarget = resolved
+  }
+
+  const normalizedTarget = path.normalize(realTarget)
+
+  for (const root of allowedRoots) {
+    const normalizedRoot = path.normalize(path.resolve(root))
+    // Ensure prefix match is at a directory boundary
+    if (
+      normalizedTarget === normalizedRoot ||
+      normalizedTarget.startsWith(normalizedRoot + path.sep)
+    ) {
+      return true
+    }
+  }
+
+  logger.warn(
+    { targetPath: normalizedTarget, allowedRoots },
+    'Path access denied by sandbox policy',
+  )
+  return false
 }

--- a/test/unit/server/files-router.test.ts
+++ b/test/unit/server/files-router.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import path from 'path'
+
+// Mock logger before importing files-router
+vi.mock('../../../server/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock configStore
+const mockGetSettings = vi.fn()
+vi.mock('../../../server/config-store', () => ({
+  configStore: {
+    getSettings: () => mockGetSettings(),
+    load: vi.fn().mockResolvedValue({ settings: {} }),
+  },
+  defaultSettings: {},
+}))
+
+// Mock fs/promises
+const mockStat = vi.fn()
+const mockReadFile = vi.fn()
+const mockWriteFile = vi.fn()
+const mockMkdir = vi.fn()
+const mockReaddir = vi.fn()
+vi.mock('fs/promises', () => ({
+  default: {
+    stat: (...args: unknown[]) => mockStat(...args),
+    readFile: (...args: unknown[]) => mockReadFile(...args),
+    writeFile: (...args: unknown[]) => mockWriteFile(...args),
+    mkdir: (...args: unknown[]) => mockMkdir(...args),
+    readdir: (...args: unknown[]) => mockReaddir(...args),
+  },
+}))
+
+// Mock child_process.spawn
+const mockSpawn = vi.fn()
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>()
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => mockSpawn(...args),
+  }
+})
+
+// Import after mocks are set up
+const { filesRouter } = await import('../../../server/files-router')
+
+function createApp() {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/files', filesRouter)
+  return app
+}
+
+describe('files-router path validation', () => {
+  let app: express.Express
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    // Default: no sandboxing (backward compatible)
+    mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+  })
+
+  describe('GET /api/files/read', () => {
+    it('allows reading when allowedFilePaths is undefined', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockStat.mockResolvedValue({ isDirectory: () => false, size: 42, mtime: new Date() })
+      mockReadFile.mockResolvedValue('file content')
+
+      const res = await request(app)
+        .get('/api/files/read')
+        .query({ path: '/home/user/file.txt' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.content).toBe('file content')
+    })
+
+    it('allows reading file inside allowed directory', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+      mockStat.mockResolvedValue({ isDirectory: () => false, size: 42, mtime: new Date() })
+      mockReadFile.mockResolvedValue('file content')
+
+      const res = await request(app)
+        .get('/api/files/read')
+        .query({ path: '/home/user/projects/src/index.ts' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.content).toBe('file content')
+    })
+
+    it('blocks reading file outside allowed directory with 403', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+
+      const res = await request(app)
+        .get('/api/files/read')
+        .query({ path: '/etc/passwd' })
+
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('Path not allowed')
+    })
+
+    it('blocks path traversal attack', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+
+      const res = await request(app)
+        .get('/api/files/read')
+        .query({ path: '/home/user/projects/../../etc/passwd' })
+
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('Path not allowed')
+    })
+  })
+
+  describe('POST /api/files/write', () => {
+    it('allows writing when allowedFilePaths is undefined', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockMkdir.mockResolvedValue(undefined)
+      mockWriteFile.mockResolvedValue(undefined)
+      mockStat.mockResolvedValue({ mtime: new Date() })
+
+      const res = await request(app)
+        .post('/api/files/write')
+        .send({ path: '/home/user/file.txt', content: 'hello' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.success).toBe(true)
+    })
+
+    it('allows writing file inside allowed directory', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+      mockMkdir.mockResolvedValue(undefined)
+      mockWriteFile.mockResolvedValue(undefined)
+      mockStat.mockResolvedValue({ mtime: new Date() })
+
+      const res = await request(app)
+        .post('/api/files/write')
+        .send({ path: '/home/user/projects/new-file.txt', content: 'hello' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.success).toBe(true)
+    })
+
+    it('blocks writing file outside allowed directory with 403', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+
+      const res = await request(app)
+        .post('/api/files/write')
+        .send({ path: '/etc/evil-file', content: 'malicious' })
+
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('Path not allowed')
+    })
+
+    it('blocks path traversal in write path', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+
+      const res = await request(app)
+        .post('/api/files/write')
+        .send({ path: '/home/user/projects/../../../tmp/evil', content: 'malicious' })
+
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('Path not allowed')
+    })
+  })
+
+  describe('POST /api/files/open', () => {
+    it('allows opening when allowedFilePaths is undefined', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockStat.mockResolvedValue({ isFile: () => true })
+      mockSpawn.mockReturnValue({ unref: vi.fn() })
+
+      const res = await request(app)
+        .post('/api/files/open')
+        .send({ path: '/home/user/file.txt' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.ok).toBe(true)
+    })
+
+    it('allows opening file inside allowed directory', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+      mockStat.mockResolvedValue({ isFile: () => true })
+      mockSpawn.mockReturnValue({ unref: vi.fn() })
+
+      const res = await request(app)
+        .post('/api/files/open')
+        .send({ path: '/home/user/projects/file.txt' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.ok).toBe(true)
+    })
+
+    it('blocks opening file outside allowed directory with 403', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+
+      const res = await request(app)
+        .post('/api/files/open')
+        .send({ path: '/usr/bin/dangerous' })
+
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('Path not allowed')
+    })
+
+    it('blocks path traversal in open endpoint', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+
+      const res = await request(app)
+        .post('/api/files/open')
+        .send({ path: '/home/user/projects/../../etc/passwd' })
+
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('Path not allowed')
+    })
+  })
+
+  describe('GET /api/files/complete', () => {
+    it('allows completion when allowedFilePaths is undefined', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockStat.mockRejectedValue({ code: 'ENOENT' })
+      mockReaddir.mockResolvedValue([])
+
+      const res = await request(app)
+        .get('/api/files/complete')
+        .query({ prefix: '/home/user/pro' })
+
+      expect(res.status).toBe(200)
+    })
+
+    it('allows completion inside allowed directory', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+      mockStat.mockRejectedValue({ code: 'ENOENT' })
+      mockReaddir.mockResolvedValue([])
+
+      const res = await request(app)
+        .get('/api/files/complete')
+        .query({ prefix: '/home/user/projects/src' })
+
+      expect(res.status).toBe(200)
+    })
+
+    it('blocks completion outside allowed directory', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+
+      const res = await request(app)
+        .get('/api/files/complete')
+        .query({ prefix: '/etc/pass' })
+
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('Path not allowed')
+    })
+  })
+
+  describe('POST /api/files/validate-dir', () => {
+    it('allows validation when allowedFilePaths is undefined', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockStat.mockResolvedValue({ isDirectory: () => true })
+
+      const res = await request(app)
+        .post('/api/files/validate-dir')
+        .send({ path: '/home/user/projects' })
+
+      expect(res.status).toBe(200)
+    })
+
+    it('allows validation inside allowed directory', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+      mockStat.mockResolvedValue({ isDirectory: () => true })
+
+      const res = await request(app)
+        .post('/api/files/validate-dir')
+        .send({ path: '/home/user/projects/subdir' })
+
+      expect(res.status).toBe(200)
+    })
+
+    it('blocks validation outside allowed directory', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+
+      const res = await request(app)
+        .post('/api/files/validate-dir')
+        .send({ path: '/var/log' })
+
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('Path not allowed')
+    })
+  })
+})

--- a/test/unit/server/path-utils.test.ts
+++ b/test/unit/server/path-utils.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import path from 'path'
+import { isPathAllowed, normalizePath, resolveUserPath } from '../../../server/path-utils'
+
+// Mock logger to prevent console output in tests
+vi.mock('../../../server/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+describe('path-utils', () => {
+  describe('normalizePath', () => {
+    it('resolves relative paths to absolute', () => {
+      const result = normalizePath('foo/bar')
+      expect(path.isAbsolute(result)).toBe(true)
+    })
+
+    it('resolves .. sequences', () => {
+      const result = normalizePath('/home/user/projects/../other')
+      expect(result).toBe(path.normalize('/home/user/other'))
+    })
+
+    it('handles trailing slashes', () => {
+      const result = normalizePath('/home/user/')
+      expect(result).toBe(path.normalize('/home/user'))
+    })
+
+    it('handles tilde expansion', () => {
+      const result = normalizePath('~/projects')
+      expect(path.isAbsolute(result)).toBe(true)
+      expect(result).not.toContain('~')
+    })
+  })
+
+  describe('isPathAllowed', () => {
+    describe('when allowedRoots is undefined or empty', () => {
+      it('allows any path when allowedRoots is undefined', () => {
+        expect(isPathAllowed('/etc/passwd', undefined)).toBe(true)
+      })
+
+      it('allows any path when allowedRoots is empty array', () => {
+        expect(isPathAllowed('/etc/passwd', [])).toBe(true)
+      })
+    })
+
+    describe('when allowedRoots is configured', () => {
+      const allowedRoots = ['/home/user/projects', '/tmp/workspace']
+
+      it('allows path inside an allowed directory', () => {
+        expect(isPathAllowed('/home/user/projects/myapp/src/index.ts', allowedRoots)).toBe(true)
+      })
+
+      it('allows path that is exactly an allowed root', () => {
+        expect(isPathAllowed('/home/user/projects', allowedRoots)).toBe(true)
+      })
+
+      it('allows path inside second allowed root', () => {
+        expect(isPathAllowed('/tmp/workspace/file.txt', allowedRoots)).toBe(true)
+      })
+
+      it('blocks path outside all allowed directories', () => {
+        expect(isPathAllowed('/etc/passwd', allowedRoots)).toBe(false)
+      })
+
+      it('blocks path traversal attack', () => {
+        expect(isPathAllowed('/home/user/projects/../../etc/passwd', allowedRoots)).toBe(false)
+      })
+
+      it('blocks path that is a prefix but not a directory boundary', () => {
+        // /home/user/projects-evil should NOT match /home/user/projects
+        expect(isPathAllowed('/home/user/projects-evil/file.txt', allowedRoots)).toBe(false)
+      })
+
+      it('blocks parent of allowed directory', () => {
+        expect(isPathAllowed('/home/user', allowedRoots)).toBe(false)
+      })
+
+      it('blocks root path', () => {
+        expect(isPathAllowed('/', allowedRoots)).toBe(false)
+      })
+    })
+
+    describe('path traversal edge cases', () => {
+      const allowedRoots = ['/home/user/projects']
+
+      it('blocks double-dot traversal escaping the sandbox', () => {
+        expect(isPathAllowed('/home/user/projects/../../../etc/shadow', allowedRoots)).toBe(false)
+      })
+
+      it('blocks traversal with redundant slashes', () => {
+        expect(isPathAllowed('/home/user/projects//../../../etc/passwd', allowedRoots)).toBe(false)
+      })
+
+      it('allows traversal that stays within the sandbox', () => {
+        // /home/user/projects/a/../b resolves to /home/user/projects/b
+        expect(isPathAllowed('/home/user/projects/a/../b/file.txt', allowedRoots)).toBe(true)
+      })
+    })
+  })
+
+  describe('resolveUserPath', () => {
+    it('handles empty input', () => {
+      expect(resolveUserPath('')).toBe('')
+      expect(resolveUserPath('  ')).toBe('')
+    })
+
+    it('resolves absolute paths', () => {
+      expect(resolveUserPath('/usr/local/bin')).toBe('/usr/local/bin')
+    })
+
+    it('expands tilde to home directory', () => {
+      const result = resolveUserPath('~/Documents')
+      expect(path.isAbsolute(result)).toBe(true)
+      expect(result).toContain('Documents')
+      expect(result).not.toContain('~')
+    })
+
+    it('expands bare tilde to home directory', () => {
+      const result = resolveUserPath('~')
+      expect(path.isAbsolute(result)).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add configurable `allowedFilePaths` to AppSettings for sandbox boundaries
- Add `isPathAllowed()` validation with `path.resolve()` + directory boundary prefix check
- Add `validatePath` middleware to all 5 file endpoints (`/read`, `/write`, `/complete`, `/validate-dir`, `/open`)
- Handle symlink resolution via `fs.realpathSync` with fallback for new files
- Default: empty/undefined config allows all paths (backward compatible, non-breaking)
- Add 39 tests covering path traversal, directory boundaries, and all endpoints

## Design decisions

- **`path.resolve()` + prefix check over regex**: Regex can't safely resolve `..` sequences. `path.resolve()` canonicalizes the path first, neutralizing traversal attempts like `../../etc/passwd` before the boundary check runs. This is the industry-standard approach for path sandboxing.

- **Directory boundary matching (`root + path.sep`)**: A naive `startsWith(root)` has a subtle bug — `/home/user/projects-evil/file.txt` would pass a check against `/home/user/projects` because the string prefix matches. Appending `path.sep` before comparison ensures the match is at a real directory boundary, so only true subdirectories are allowed.

- **Symlink resolution with fallback**: `fs.realpathSync()` resolves symlinks before validation, preventing symlink-escape attacks. But it throws for files that don't exist yet (e.g., writing a new file). The `try/catch` fallback to the resolved path is intentional — for new files, we validate the resolved path since symlinks can't exist for non-existent targets.

- **Backward compatible defaults**: Empty/undefined `allowedFilePaths` allows all paths. Existing users aren't broken by the change. Sandboxing is opt-in via the settings API.

## Edge cases

- Path traversal with `..` sequences (resolved before boundary check)
- Prefix collision: `/projects-evil` vs `/projects` (directory boundary check prevents false match)
- Symlinks pointing outside sandbox (resolved via `realpathSync`)
- New file creation inside sandbox (fallback when `realpathSync` throws ENOENT)
- Multiple allowed roots (any match permits access)

Refs FRE-25

Generated with [Claude Code](https://claude.com/claude-code)