### PR TITLE
feat(terminal): add Shift+Enter as newline shortcut

### DIFF
--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -935,10 +935,12 @@ export default function SettingsView() {
           </SettingsSection>
 
           {/* Keyboard shortcuts */}
-          <SettingsSection title="Keyboard shortcuts" description="Tab navigation">
+          <SettingsSection title="Keyboard shortcuts" description="Navigation and terminal">
             <div className="space-y-2 text-sm">
               <ShortcutRow keys={['Ctrl', 'Shift', '[']} description="Previous tab" />
               <ShortcutRow keys={['Ctrl', 'Shift', ']']} description="Next tab" />
+              <ShortcutRow keys={['Shift', 'Enter']} description="Newline (same as Ctrl+J)" />
+              <ShortcutRow keys={['Ctrl', 'J']} description="Newline" />
             </div>
           </SettingsSection>
 

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -315,6 +315,16 @@ export default function TerminalView({ tabId, paneId, paneContent, hidden }: Ter
         }
       }
 
+      // Shift+Enter → send newline (same as Ctrl+J)
+      if (event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey
+          && event.key === 'Enter' && event.type === 'keydown' && !event.repeat) {
+        const tid = terminalIdRef.current
+        if (tid) {
+          ws.send({ type: 'terminal.input', terminalId: tid, data: '\n' })
+        }
+        return false
+      }
+
       return true
     })
 

--- a/test/unit/client/components/SettingsView.test.tsx
+++ b/test/unit/client/components/SettingsView.test.tsx
@@ -125,7 +125,7 @@ describe('SettingsView Component', () => {
       expect(screen.getByText('Providers and defaults for coding sessions')).toBeInTheDocument()
 
       expect(screen.getByText('Keyboard shortcuts')).toBeInTheDocument()
-      expect(screen.getByText('Tab navigation')).toBeInTheDocument()
+      expect(screen.getByText('Navigation and terminal')).toBeInTheDocument()
     })
 
     it('renders a terminal preview above Appearance', () => {


### PR DESCRIPTION
## Summary

- Adds Shift+Enter as an alternative way to insert a newline in the terminal (sends same `\n` as Ctrl+J)
- Documents both Shift+Enter and Ctrl+J shortcuts in the Settings keyboard shortcuts section
- Updates section description from "Tab navigation" to "Navigation and terminal"

## Design decisions

- **Intercept at xterm addon level**: The shortcut is handled in the `attachCustomKeyEventHandler` callback, which runs before xterm processes the key. This ensures Shift+Enter doesn't trigger the default Enter behavior (command submission) before we can convert it to a newline.
- **Same mechanism as Ctrl+J**: Rather than introducing a new input path, Shift+Enter sends the exact same `\n` byte via `terminal.input` WebSocket message. This keeps behavior consistent and predictable.
- **Guard conditions**: The handler checks `!event.repeat` and `event.type === 'keydown'` to avoid duplicate sends on key repeat or processing both keydown+keyup.

## Test plan

- [x] Updated SettingsView test to match new section description
- [ ] Manual: Shift+Enter inserts newline in terminal
- [ ] Manual: Regular Enter still submits commands normally
- [ ] Manual: Ctrl+J still works as before

Refs FRE-4

Generated with [Claude Code](https://claude.com/claude-code)