### PR TITLE
fix: default server bind to 127.0.0.1 for security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ AUTH_TOKEN=replace-with-a-long-random-token
 # Port for the Express server (backend API + production static files)
 PORT=3001
 
+# Bind address for the server (default: 127.0.0.1, localhost only).
+# Set to 0.0.0.0 to allow LAN access (or use --lan flag instead).
+# WARNING: Combined with HTTP (no TLS), binding to 0.0.0.0 exposes
+# AUTH_TOKEN in cleartext on your local network.
+# HOST=127.0.0.1
+
 # Set to true to hide AUTH_TOKEN from the startup URL printed to the console.
 # Useful when logs are aggregated or terminals are shared/recorded.
 # HIDE_STARTUP_TOKEN=true

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ npm run serve
 
 On first run, freshell auto-generates a `.env` file with a secure random `AUTH_TOKEN`. The token is printed to the console at startup — open the URL shown to connect.
 
+By default, freshell binds to `127.0.0.1` (localhost only). To access from other devices on your network:
+
+```bash
+npm run serve -- --lan
+```
+
+Or use `--host <address>` to bind to a specific interface. You can also set `HOST=0.0.0.0` in your `.env` file.
+
 ## Prerequisites
 
 Node.js 18+ (20+ recommended) and platform build tools for native modules (`windows-build-tools` on Windows, Xcode CLI Tools on macOS, `build-essential python3` on Linux).
@@ -88,6 +96,7 @@ Freshell checks for new GitHub releases before starting. Accept the prompt to au
 |----------|----------|-------------|
 | `AUTH_TOKEN` | Auto | Authentication token (auto-generated on first run, min 16 chars) |
 | `PORT` | No | Server port (default: 3001) |
+| `HOST` | No | Bind address (default: `127.0.0.1`). Set to `0.0.0.0` for LAN access |
 | `ALLOWED_ORIGINS` | No | Comma-separated allowed CORS origins (auto-detected from LAN) |
 | `CLAUDE_HOME` | No | Path to Claude config directory (default: `~/.claude`) |
 | `CODEX_HOME` | No | Path to Codex config directory (default: `~/.codex`) |

--- a/server/startup-url.ts
+++ b/server/startup-url.ts
@@ -7,3 +7,31 @@ export function resolveVisitPort(serverPort: number, env: NodeJS.ProcessEnv): nu
   const isDev = env.NODE_ENV === 'development'
   return isDev ? Number(env.VITE_PORT || 5173) : serverPort
 }
+
+/**
+ * Resolve the bind host address from CLI flags and environment.
+ * Priority: --lan flag > --host flag > HOST env var > default (127.0.0.1).
+ *
+ * Defaults to 127.0.0.1 (localhost only) to prevent AUTH_TOKEN from
+ * being exposed in cleartext on the LAN (no TLS).
+ */
+export function resolveBindHost(argv: string[] = process.argv, env: NodeJS.ProcessEnv = process.env): string {
+  // Check for --lan flag (shorthand for --host 0.0.0.0)
+  if (argv.includes('--lan')) {
+    return '0.0.0.0'
+  }
+
+  // Check for --host <value> flag
+  const hostIndex = argv.indexOf('--host')
+  if (hostIndex !== -1 && hostIndex + 1 < argv.length) {
+    return argv[hostIndex + 1]
+  }
+
+  // Fall back to HOST env var
+  if (env.HOST) {
+    return env.HOST
+  }
+
+  // Default: localhost only (secure by default)
+  return '127.0.0.1'
+}

--- a/test/unit/server/bind-host.test.ts
+++ b/test/unit/server/bind-host.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { resolveBindHost } from '../../../server/startup-url'
+
+describe('resolveBindHost', () => {
+  it('defaults to 127.0.0.1 with no args or env', () => {
+    expect(resolveBindHost([], {})).toBe('127.0.0.1')
+  })
+
+  it('reads HOST env var', () => {
+    expect(resolveBindHost([], { HOST: '0.0.0.0' })).toBe('0.0.0.0')
+  })
+
+  it('reads custom HOST env var', () => {
+    expect(resolveBindHost([], { HOST: '192.168.1.10' })).toBe('192.168.1.10')
+  })
+
+  it('--host flag overrides env var', () => {
+    expect(resolveBindHost(['node', 'index.js', '--host', '10.0.0.1'], { HOST: '192.168.1.10' })).toBe('10.0.0.1')
+  })
+
+  it('--lan maps to 0.0.0.0', () => {
+    expect(resolveBindHost(['node', 'index.js', '--lan'], {})).toBe('0.0.0.0')
+  })
+
+  it('--lan overrides HOST env var', () => {
+    expect(resolveBindHost(['node', 'index.js', '--lan'], { HOST: '192.168.1.10' })).toBe('0.0.0.0')
+  })
+
+  it('--host without value falls back to env', () => {
+    // --host is the last arg with no value after it
+    expect(resolveBindHost(['node', 'index.js', '--host'], { HOST: '10.0.0.5' })).toBe('10.0.0.5')
+  })
+
+  it('--host without value or env falls back to default', () => {
+    expect(resolveBindHost(['node', 'index.js', '--host'], {})).toBe('127.0.0.1')
+  })
+})


### PR DESCRIPTION
## Summary

- Default server bind address changed from `0.0.0.0` to `127.0.0.1` (localhost only)
- Added `--host <address>` CLI flag and `--lan` shorthand for explicit LAN access
- Added `HOST` env var support with CLI flag taking precedence
- Updated startup message to show bind scope with `--lan` hint when localhost-only
- Port forwarding unchanged (still binds to `0.0.0.0` by design)

## Design decisions

- **Secure by default**: Binding to `0.0.0.0` with HTTP (no TLS) exposes the AUTH_TOKEN in cleartext on the LAN. Defaulting to `127.0.0.1` prevents passive token sniffing without requiring users to understand the risk.
- **`--host` + `--lan` flags**: `--host` follows the Vite/Express convention for specifying bind address. `--lan` is a user-friendly alias for `--host 0.0.0.0` that communicates intent ("I want LAN access") rather than implementation ("bind to all interfaces").
- **Function in `startup-url.ts`**: Placed alongside `resolveVisitPort()` rather than `index.ts` to avoid side-effect imports in unit tests (importing `index.ts` boots the server).
- **Port forwards left on `0.0.0.0`**: Port forwarding proxies external requests to localhost services — binding to `127.0.0.1` would defeat its purpose.

## Edge cases

- `--lan` takes precedence over `--host` (checked first in argv)
- `--host` without a value after it gracefully falls back to env/default
- CLI flags override `HOST` env var (standard override pattern)

Refs FRE-26

Generated with [Claude Code](https://claude.com/claude-code)