### PR TITLE
feat(updater): add GPG signature verification and rollback on failure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,15 @@ PORT=3001
 # Useful when logs are aggregated or terminals are shared/recorded.
 # HIDE_STARTUP_TOKEN=true
 
+# -----------------------------------------------------------------------------
+# Auto-Update
+# -----------------------------------------------------------------------------
+
+# Set to true to require GPG signature verification on release tags before
+# applying updates. When enabled, unsigned or unverifiable tags will abort
+# the update. Requires the upstream signing key in your GPG keyring.
+# REQUIRE_GPG_VERIFICATION=false
+
 # Log level: fatal, error, warn, info, debug, trace
 # LOG_LEVEL=debug
 

--- a/server/updater/types.ts
+++ b/server/updater/types.ts
@@ -11,7 +11,7 @@ export interface UpdateCheckResult {
 }
 
 // Executor types
-export type UpdateStep = 'git-pull' | 'npm-install' | 'build'
+export type UpdateStep = 'verify-tag' | 'git-pull' | 'npm-install' | 'build' | 'rollback'
 export type UpdateStatus = 'running' | 'complete' | 'error'
 
 export interface UpdateProgress {
@@ -23,4 +23,6 @@ export interface UpdateProgress {
 export interface UpdateResult {
   success: boolean
   error?: string
+  snapshotSha?: string
+  rolledBack?: boolean
 }

--- a/test/unit/server/updater/executor.test.ts
+++ b/test/unit/server/updater/executor.test.ts
@@ -2,6 +2,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { executeUpdate, type UpdateProgress, type ExecAsyncFn } from '../../../../server/updater/executor.js'
 
+/**
+ * Helper: creates a mock exec that resolves for all commands by default,
+ * with optional per-command overrides via a map of command substring → behavior.
+ */
+function createMockExec(overrides: Record<string, 'reject' | Error | string> = {}): ExecAsyncFn {
+  return vi.fn().mockImplementation((cmd: string) => {
+    for (const [substr, behavior] of Object.entries(overrides)) {
+      if (cmd.includes(substr)) {
+        if (behavior === 'reject') {
+          return Promise.reject(new Error(`${substr} failed`))
+        }
+        if (behavior instanceof Error) {
+          return Promise.reject(behavior)
+        }
+        if (typeof behavior === 'string') {
+          return Promise.reject(new Error(behavior))
+        }
+      }
+    }
+    // Default: resolve with mock SHA for rev-parse, empty for others
+    if (cmd.includes('rev-parse')) {
+      return Promise.resolve({ stdout: 'abc1234snapshot\n', stderr: '' })
+    }
+    return Promise.resolve({ stdout: '', stderr: '' })
+  })
+}
+
 describe('executor', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -9,8 +36,7 @@ describe('executor', () => {
 
   describe('executeUpdate', () => {
     it('runs git pull, npm install, and npm run build in sequence', async () => {
-      const mockExec: ExecAsyncFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
-
+      const mockExec = createMockExec()
       const progress: UpdateProgress[] = []
       await executeUpdate((p) => progress.push(p), mockExec)
 
@@ -23,72 +49,53 @@ describe('executor', () => {
     })
 
     it('executes commands with correct project root cwd', async () => {
-      const mockExec: ExecAsyncFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+      const mockExec = createMockExec()
       const testProjectRoot = '/test/project/root'
 
       await executeUpdate(() => {}, mockExec, { projectRoot: testProjectRoot })
 
-      expect(mockExec).toHaveBeenCalledTimes(3)
-      expect(mockExec).toHaveBeenNthCalledWith(1, 'git pull', { cwd: testProjectRoot })
-      expect(mockExec).toHaveBeenNthCalledWith(2, 'npm ci', { cwd: testProjectRoot })
-      expect(mockExec).toHaveBeenNthCalledWith(3, 'npm run build', { cwd: testProjectRoot })
+      // rev-parse + 3 update steps = 4 calls
+      expect(mockExec).toHaveBeenCalledTimes(4)
+      expect(mockExec).toHaveBeenCalledWith('git rev-parse HEAD', { cwd: testProjectRoot })
+      expect(mockExec).toHaveBeenCalledWith('git pull', { cwd: testProjectRoot })
+      expect(mockExec).toHaveBeenCalledWith('npm ci', { cwd: testProjectRoot })
+      expect(mockExec).toHaveBeenCalledWith('npm run build', { cwd: testProjectRoot })
     })
 
     it('reports error and stops if git pull fails', async () => {
-      const mockExec: ExecAsyncFn = vi.fn().mockImplementation((cmd) => {
-        if (cmd.includes('git pull')) {
-          return Promise.reject(new Error('Git pull failed'))
-        }
-        return Promise.resolve({ stdout: '', stderr: '' })
-      })
-
+      const mockExec = createMockExec({ 'git pull': 'reject' })
       const progress: UpdateProgress[] = []
       const result = await executeUpdate((p) => progress.push(p), mockExec)
 
       expect(result.success).toBe(false)
-      expect(result.error).toContain('Git pull failed')
+      expect(result.error).toContain('git pull failed')
       expect(progress).toContainEqual({ step: 'git-pull', status: 'error', error: expect.any(String) })
-      // Should not continue to npm install
-      expect(mockExec).toHaveBeenCalledTimes(1)
+      // rev-parse + git pull = 2 calls (no npm install or build)
+      expect(mockExec).toHaveBeenCalledTimes(2)
     })
 
     it('reports error and stops if npm ci fails', async () => {
-      const mockExec: ExecAsyncFn = vi.fn().mockImplementation((cmd) => {
-        if (cmd.includes('npm ci')) {
-          return Promise.reject(new Error('npm ci failed'))
-        }
-        return Promise.resolve({ stdout: '', stderr: '' })
-      })
-
+      const mockExec = createMockExec({ 'npm ci': 'reject' })
       const progress: UpdateProgress[] = []
       const result = await executeUpdate((p) => progress.push(p), mockExec)
 
       expect(result.success).toBe(false)
       expect(result.error).toContain('npm ci failed')
       expect(progress).toContainEqual({ step: 'npm-install', status: 'error', error: expect.any(String) })
-      // Should have run git pull but not build
-      expect(mockExec).toHaveBeenCalledTimes(2)
     })
 
     it('reports error and stops if build fails', async () => {
-      const mockExec: ExecAsyncFn = vi.fn().mockImplementation((cmd) => {
-        if (cmd.includes('npm run build')) {
-          return Promise.reject(new Error('Build failed'))
-        }
-        return Promise.resolve({ stdout: '', stderr: '' })
-      })
-
+      const mockExec = createMockExec({ 'npm run build': 'reject' })
       const progress: UpdateProgress[] = []
       const result = await executeUpdate((p) => progress.push(p), mockExec)
 
       expect(result.success).toBe(false)
-      expect(result.error).toContain('Build failed')
+      expect(result.error).toContain('npm run build failed')
       expect(progress).toContainEqual({ step: 'build', status: 'error', error: expect.any(String) })
     })
 
     it('returns success: true when all commands succeed', async () => {
-      const mockExec: ExecAsyncFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
-
+      const mockExec = createMockExec()
       const result = await executeUpdate(() => {}, mockExec)
 
       expect(result.success).toBe(true)
@@ -96,7 +103,10 @@ describe('executor', () => {
     })
 
     it('handles non-Error thrown values', async () => {
-      const mockExec: ExecAsyncFn = vi.fn().mockRejectedValue('string error')
+      const mockExec: ExecAsyncFn = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd.includes('rev-parse')) return Promise.resolve({ stdout: 'abc123\n', stderr: '' })
+        return Promise.reject('string error')
+      })
 
       const progress: UpdateProgress[] = []
       const result = await executeUpdate((p) => progress.push(p), mockExec)
@@ -108,7 +118,10 @@ describe('executor', () => {
     it('includes stderr in error message when available', async () => {
       const errorWithStderr = new Error('Command failed') as Error & { stderr?: string }
       errorWithStderr.stderr = 'ENOENT: npm not found'
-      const mockExec: ExecAsyncFn = vi.fn().mockRejectedValue(errorWithStderr)
+      const mockExec: ExecAsyncFn = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd.includes('rev-parse')) return Promise.resolve({ stdout: 'abc123\n', stderr: '' })
+        return Promise.reject(errorWithStderr)
+      })
 
       const progress: UpdateProgress[] = []
       const result = await executeUpdate((p) => progress.push(p), mockExec)
@@ -116,6 +129,197 @@ describe('executor', () => {
       expect(result.success).toBe(false)
       expect(result.error).toContain('Command failed')
       expect(result.error).toContain('ENOENT: npm not found')
+    })
+  })
+
+  describe('snapshot', () => {
+    it('captures HEAD SHA via git rev-parse before update steps', async () => {
+      const mockExec = createMockExec()
+      await executeUpdate(() => {}, mockExec, { projectRoot: '/test' })
+
+      // First call should be rev-parse
+      expect(mockExec).toHaveBeenNthCalledWith(1, 'git rev-parse HEAD', { cwd: '/test' })
+    })
+
+    it('includes snapshotSha in successful result', async () => {
+      const mockExec = createMockExec()
+      const result = await executeUpdate(() => {}, mockExec)
+
+      expect(result.snapshotSha).toBe('abc1234snapshot')
+    })
+
+    it('continues without snapshot if rev-parse fails', async () => {
+      const mockExec = createMockExec({ 'rev-parse': 'reject' })
+      const result = await executeUpdate(() => {}, mockExec)
+
+      // Should still succeed — snapshot failure is non-fatal
+      expect(result.success).toBe(true)
+      expect(result.snapshotSha).toBeUndefined()
+    })
+  })
+
+  describe('GPG tag verification', () => {
+    it('runs verify-tag when targetTag is provided and verification succeeds', async () => {
+      const mockExec = createMockExec()
+      const progress: UpdateProgress[] = []
+
+      await executeUpdate((p) => progress.push(p), mockExec, {
+        targetTag: 'v0.5.0',
+        projectRoot: '/test'
+      })
+
+      expect(mockExec).toHaveBeenCalledWith('git fetch origin tag v0.5.0', { cwd: '/test' })
+      expect(mockExec).toHaveBeenCalledWith('git verify-tag v0.5.0', { cwd: '/test' })
+      expect(progress).toContainEqual({ step: 'verify-tag', status: 'running' })
+      expect(progress).toContainEqual({ step: 'verify-tag', status: 'complete' })
+    })
+
+    it('skips verification when no targetTag provided', async () => {
+      const mockExec = createMockExec()
+      const progress: UpdateProgress[] = []
+
+      await executeUpdate((p) => progress.push(p), mockExec)
+
+      expect(progress).not.toContainEqual(expect.objectContaining({ step: 'verify-tag' }))
+    })
+
+    it('aborts update when verification fails in strict mode', async () => {
+      const mockExec = createMockExec({ 'verify-tag': 'reject' })
+      const progress: UpdateProgress[] = []
+
+      const result = await executeUpdate((p) => progress.push(p), mockExec, {
+        targetTag: 'v0.5.0',
+        requireGpgVerification: true
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('verify-tag failed')
+      expect(progress).toContainEqual({ step: 'verify-tag', status: 'error', error: expect.any(String) })
+      // Should not have called git pull
+      const calls = (mockExec as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[0])
+      expect(calls).not.toContain('git pull')
+    })
+
+    it('continues with warning when verification fails in permissive mode', async () => {
+      const mockExec = createMockExec({ 'verify-tag': 'reject' })
+      const progress: UpdateProgress[] = []
+
+      const result = await executeUpdate((p) => progress.push(p), mockExec, {
+        targetTag: 'v0.5.0',
+        requireGpgVerification: false
+      })
+
+      expect(result.success).toBe(true)
+      // verify-tag should show error (warning)
+      expect(progress).toContainEqual({ step: 'verify-tag', status: 'error', error: expect.any(String) })
+      // But git-pull should still have run
+      expect(progress).toContainEqual({ step: 'git-pull', status: 'complete' })
+    })
+
+    it('continues when verification fails with no requireGpgVerification set', async () => {
+      const mockExec = createMockExec({ 'verify-tag': 'reject' })
+      const progress: UpdateProgress[] = []
+
+      const result = await executeUpdate((p) => progress.push(p), mockExec, {
+        targetTag: 'v0.5.0'
+      })
+
+      // Default is permissive — should continue
+      expect(result.success).toBe(true)
+      expect(progress).toContainEqual({ step: 'git-pull', status: 'complete' })
+    })
+  })
+
+  describe('rollback', () => {
+    it('rolls back on build failure with git reset and npm ci', async () => {
+      const calls: string[] = []
+      const mockExec: ExecAsyncFn = vi.fn().mockImplementation((cmd: string) => {
+        calls.push(cmd)
+        if (cmd.includes('rev-parse')) return Promise.resolve({ stdout: 'snap123\n', stderr: '' })
+        if (cmd === 'npm run build') return Promise.reject(new Error('Build failed'))
+        return Promise.resolve({ stdout: '', stderr: '' })
+      })
+
+      const progress: UpdateProgress[] = []
+      const result = await executeUpdate((p) => progress.push(p), mockExec)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Build failed')
+      expect(result.rolledBack).toBe(true)
+      expect(result.snapshotSha).toBe('snap123')
+
+      // Verify rollback commands were executed in order
+      expect(calls).toContain('git reset --hard snap123')
+      const resetIdx = calls.indexOf('git reset --hard snap123')
+      // The npm ci AFTER reset is the rollback restore
+      const rollbackNpmCiIdx = calls.indexOf('npm ci', resetIdx)
+      expect(rollbackNpmCiIdx).toBeGreaterThan(resetIdx)
+
+      // Verify rollback progress events
+      expect(progress).toContainEqual({ step: 'rollback', status: 'running' })
+      expect(progress).toContainEqual({ step: 'rollback', status: 'complete' })
+    })
+
+    it('rolls back on npm-install failure', async () => {
+      const mockExec: ExecAsyncFn = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd.includes('rev-parse')) return Promise.resolve({ stdout: 'snap456\n', stderr: '' })
+        if (cmd === 'npm ci' && (vi.mocked(mockExec).mock.calls.filter((c: unknown[]) => c[0] === 'npm ci').length === 1)) {
+          // First npm ci (update step) fails, second (rollback) succeeds
+          return Promise.reject(new Error('npm ci failed'))
+        }
+        return Promise.resolve({ stdout: '', stderr: '' })
+      })
+
+      const result = await executeUpdate(() => {}, mockExec)
+
+      expect(result.success).toBe(false)
+      expect(result.rolledBack).toBe(true)
+    })
+
+    it('does not roll back on git-pull failure', async () => {
+      const mockExec = createMockExec({ 'git pull': 'reject' })
+      const progress: UpdateProgress[] = []
+
+      const result = await executeUpdate((p) => progress.push(p), mockExec)
+
+      expect(result.success).toBe(false)
+      // No rollback events — code hasn't changed yet
+      expect(progress).not.toContainEqual(expect.objectContaining({ step: 'rollback' }))
+      expect(result.rolledBack).toBeUndefined()
+    })
+
+    it('reports rolledBack: false when rollback itself fails', async () => {
+      const mockExec: ExecAsyncFn = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd.includes('rev-parse')) return Promise.resolve({ stdout: 'snap789\n', stderr: '' })
+        if (cmd === 'npm run build') return Promise.reject(new Error('Build failed'))
+        if (cmd.includes('git reset')) return Promise.reject(new Error('Reset failed'))
+        return Promise.resolve({ stdout: '', stderr: '' })
+      })
+
+      const progress: UpdateProgress[] = []
+      const result = await executeUpdate((p) => progress.push(p), mockExec)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Build failed')
+      expect(result.rolledBack).toBe(false)
+      expect(progress).toContainEqual({ step: 'rollback', status: 'error', error: expect.any(String) })
+    })
+
+    it('skips rollback when snapshot SHA is unavailable', async () => {
+      const mockExec: ExecAsyncFn = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd.includes('rev-parse')) return Promise.reject(new Error('not a git repo'))
+        if (cmd === 'npm run build') return Promise.reject(new Error('Build failed'))
+        return Promise.resolve({ stdout: '', stderr: '' })
+      })
+
+      const progress: UpdateProgress[] = []
+      const result = await executeUpdate((p) => progress.push(p), mockExec)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Build failed')
+      // No rollback possible without snapshot
+      expect(progress).not.toContainEqual(expect.objectContaining({ step: 'rollback' }))
+      expect(result.rolledBack).toBeUndefined()
     })
   })
 })

--- a/test/unit/server/updater/index.test.ts
+++ b/test/unit/server/updater/index.test.ts
@@ -124,7 +124,14 @@ describe('update orchestrator', () => {
           await runUpdateCheck('0.1.0')
 
           expect(executeUpdate).toHaveBeenCalledTimes(1)
-          expect(executeUpdate).toHaveBeenCalledWith(expect.any(Function))
+          expect(executeUpdate).toHaveBeenCalledWith(
+            expect.any(Function),
+            undefined,
+            expect.objectContaining({
+              targetTag: expect.any(String),
+              requireGpgVerification: expect.any(Boolean)
+            })
+          )
         })
 
         it('returns action: updated with newVersion on success', async () => {


### PR DESCRIPTION
## Summary

- Add GPG tag signature verification before pulling updates (`git verify-tag`)
- Implement pre-update snapshot mechanism (`git rev-parse HEAD`)
- Add automatic rollback on build/install failure (`git reset --hard` + `npm ci`)
- Support strict mode (`REQUIRE_GPG_VERIFICATION=true`) that aborts on verification failure
- Default permissive mode warns but continues when verification fails

## Changes

### New Capabilities
- **GPG Verification**: Fetches and verifies release tags before pulling (`verify-tag` step)
- **Snapshot**: Captures current HEAD SHA before any update operations
- **Rollback**: On `npm ci` or `build` failure, restores previous commit and re-installs dependencies
- No rollback on `git pull` failure (code hasn't changed yet)

### Files Modified
- `server/updater/types.ts` — Extended `UpdateStep` union, added `snapshotSha`/`rolledBack` to `UpdateResult`
- `server/updater/executor.ts` — Snapshot, GPG verification, rollback logic
- `server/updater/index.ts` — Wire new options, progress labels, rollback status in failure message
- `.env.example` — Document `REQUIRE_GPG_VERIFICATION` env var
- `test/unit/server/updater/executor.test.ts` — 21 tests (snapshot, GPG, rollback)
- `test/unit/server/updater/index.test.ts` — Updated for new `executeUpdate` signature

## Test plan

- [x] All 96 updater tests pass (4 files)
- [x] Full suite: 186 passed, 3 skipped, 1 pre-existing failure (unrelated AUTH_TOKEN issue)
- [x] GPG verification: strict mode aborts, permissive mode continues
- [x] Rollback: triggers on build/npm failure, skips on git-pull failure
- [x] Snapshot: captures SHA, continues gracefully if rev-parse fails

Refs FRE-27

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>