### PR TITLE
feat: add React error boundaries for crash recovery

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import TabContent from '@/components/TabContent'
 import HistoryView from '@/components/HistoryView'
 import SettingsView from '@/components/SettingsView'
 import OverviewView from '@/components/OverviewView'
+import { ErrorBoundary } from '@/components/ui/error-boundary'
 import PaneDivider from '@/components/panes/PaneDivider'
 import { AuthRequiredModal } from '@/components/AuthRequiredModal'
 import { ContextMenuProvider } from '@/components/context-menu/ContextMenuProvider'
@@ -405,9 +406,21 @@ export default function App() {
   }, [tabs.length, dispatch])
 
   const content = (() => {
-    if (view === 'sessions') return <HistoryView onOpenSession={() => setView('terminal')} />
-    if (view === 'settings') return <SettingsView />
-    if (view === 'overview') return <OverviewView onOpenTab={() => setView('terminal')} />
+    if (view === 'sessions') return (
+      <ErrorBoundary label="Sessions" onNavigate={() => setView('overview')}>
+        <HistoryView onOpenSession={() => setView('terminal')} />
+      </ErrorBoundary>
+    )
+    if (view === 'settings') return (
+      <ErrorBoundary label="Settings" onNavigate={() => setView('overview')}>
+        <SettingsView />
+      </ErrorBoundary>
+    )
+    if (view === 'overview') return (
+      <ErrorBoundary label="Overview">
+        <OverviewView onOpenTab={() => setView('terminal')} />
+      </ErrorBoundary>
+    )
     return (
       <div className="flex flex-col h-full">
         <TabBar />

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -2,6 +2,7 @@ import { PaneLayout } from './panes'
 import SessionView from './SessionView'
 import { useAppSelector } from '@/store/hooks'
 import type { PaneContentInput } from '@/store/paneTypes'
+import { ErrorBoundary } from '@/components/ui/error-boundary'
 
 interface TabContentProps {
   tabId: string
@@ -63,7 +64,9 @@ export default function TabContent({ tabId, hidden }: TabContentProps) {
   // Use PaneLayout for all terminal-based tabs
   return (
     <div className={hidden ? 'tab-hidden' : 'tab-visible h-full w-full'}>
-      <PaneLayout tabId={tabId} defaultContent={defaultContent} hidden={hidden} />
+      <ErrorBoundary key={tabId} label="Tab">
+        <PaneLayout tabId={tabId} defaultContent={defaultContent} hidden={hidden} />
+      </ErrorBoundary>
     </div>
   )
 }

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -26,6 +26,7 @@ import { clearPaneAttention, clearTabAttention } from '@/store/turnCompletionSli
 import { clearPendingCreate, removeSession } from '@/store/claudeChatSlice'
 import { cancelCreate } from '@/lib/sdk-message-handler'
 import type { TerminalMetaRecord } from '@/store/terminalMetaSlice'
+import { ErrorBoundary } from '@/components/ui/error-boundary'
 
 // Stable empty object to avoid selector memoization issues
 const EMPTY_PANE_TITLES: Record<string, string> = {}
@@ -542,31 +543,43 @@ function PickerWrapper({
 
 function renderContent(tabId: string, paneId: string, content: PaneContent, isOnlyPane: boolean, hidden?: boolean) {
   if (content.kind === 'terminal') {
-    // Terminal panes need a unique key based on paneId for proper lifecycle
-    // Pass paneContent directly to avoid redundant tree traversal in TerminalView
-    return <TerminalView key={paneId} tabId={tabId} paneId={paneId} paneContent={content} hidden={hidden} />
+    return (
+      <ErrorBoundary key={paneId} label="Terminal">
+        <TerminalView tabId={tabId} paneId={paneId} paneContent={content} hidden={hidden} />
+      </ErrorBoundary>
+    )
   }
 
   if (content.kind === 'browser') {
-    return <BrowserPane paneId={paneId} tabId={tabId} url={content.url} devToolsOpen={content.devToolsOpen} />
+    return (
+      <ErrorBoundary key={paneId} label="Browser">
+        <BrowserPane paneId={paneId} tabId={tabId} url={content.url} devToolsOpen={content.devToolsOpen} />
+      </ErrorBoundary>
+    )
   }
 
   if (content.kind === 'editor') {
     return (
-      <EditorPane
-        paneId={paneId}
-        tabId={tabId}
-        filePath={content.filePath}
-        language={content.language}
-        readOnly={content.readOnly}
-        content={content.content}
-        viewMode={content.viewMode}
-      />
+      <ErrorBoundary key={paneId} label="Editor">
+        <EditorPane
+          paneId={paneId}
+          tabId={tabId}
+          filePath={content.filePath}
+          language={content.language}
+          readOnly={content.readOnly}
+          content={content.content}
+          viewMode={content.viewMode}
+        />
+      </ErrorBoundary>
     )
   }
 
   if (content.kind === 'claude-chat') {
-    return <ClaudeChatView key={paneId} tabId={tabId} paneId={paneId} paneContent={content} hidden={hidden} />
+    return (
+      <ErrorBoundary key={paneId} label="Chat">
+        <ClaudeChatView tabId={tabId} paneId={paneId} paneContent={content} hidden={hidden} />
+      </ErrorBoundary>
+    )
   }
 
   if (content.kind === 'picker') {

--- a/src/components/ui/error-boundary.tsx
+++ b/src/components/ui/error-boundary.tsx
@@ -1,0 +1,79 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  /** Label shown in fallback UI, e.g. "Terminal", "Settings" */
+  label?: string
+  /** Called when user clicks "Go to Overview" in fallback */
+  onNavigate?: () => void
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error(
+      `[ErrorBoundary${this.props.label ? `: ${this.props.label}` : ''}] Caught error:`,
+      error,
+      errorInfo.componentStack,
+    )
+  }
+
+  private handleReset = () => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      const label = this.props.label ?? 'This section'
+      return (
+        <div
+          className="flex items-center justify-center h-full w-full p-4"
+          role="alert"
+        >
+          <div className="rounded-lg border border-border bg-card text-card-foreground shadow-sm max-w-md w-full p-6 text-center">
+            <h3 className="text-base font-semibold mb-2">Something went wrong</h3>
+            <p className="text-sm text-muted-foreground mb-4">
+              {label} encountered an error and couldn&apos;t render.
+            </p>
+            {import.meta.env.DEV && this.state.error && (
+              <pre className="text-xs text-left bg-muted rounded p-2 mb-4 overflow-auto max-h-32">
+                {this.state.error.message}
+              </pre>
+            )}
+            <div className="flex gap-2 justify-center">
+              <button
+                onClick={this.handleReset}
+                className="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                Try Again
+              </button>
+              {this.props.onNavigate && (
+                <button
+                  onClick={this.props.onNavigate}
+                  className="px-4 py-2 text-sm rounded-md border border-border hover:bg-muted transition-colors"
+                >
+                  Go to Overview
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/test/unit/client/components/ui/error-boundary.test.tsx
+++ b/test/unit/client/components/ui/error-boundary.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ErrorBoundary } from '@/components/ui/error-boundary'
+
+// React logs errors to console.error when boundaries catch.
+// The test setup throws on unexpected console.error — allow it here.
+beforeEach(() => {
+  ;(globalThis as any).__ALLOW_CONSOLE_ERROR__ = true
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+function ProblemChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('Test explosion')
+  return <div>Happy child</div>
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children when no error occurs', () => {
+    const { container } = render(
+      <ErrorBoundary>
+        <div>All good</div>
+      </ErrorBoundary>,
+    )
+
+    expect(within(container).getByText('All good')).toBeInTheDocument()
+    expect(within(container).queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('shows fallback UI when a child throws', () => {
+    const { container } = render(
+      <ErrorBoundary label="Terminal">
+        <ProblemChild shouldThrow />
+      </ErrorBoundary>,
+    )
+
+    expect(within(container).getByRole('alert')).toBeInTheDocument()
+    expect(within(container).getByText('Something went wrong')).toBeInTheDocument()
+    expect(within(container).getByText(/Terminal encountered an error/)).toBeInTheDocument()
+    expect(within(container).getByText('Try Again')).toBeInTheDocument()
+  })
+
+  it('uses default label when none provided', () => {
+    const { container } = render(
+      <ErrorBoundary>
+        <ProblemChild shouldThrow />
+      </ErrorBoundary>,
+    )
+
+    expect(within(container).getByText(/This section encountered an error/)).toBeInTheDocument()
+  })
+
+  it('resets error state when "Try Again" is clicked', async () => {
+    const user = userEvent.setup()
+
+    // Use a ref-like variable to control throw behavior
+    let shouldThrow = true
+    function ToggleChild() {
+      if (shouldThrow) throw new Error('Boom')
+      return <div>Recovered</div>
+    }
+
+    const { container, rerender } = render(
+      <ErrorBoundary key="test">
+        <ToggleChild />
+      </ErrorBoundary>,
+    )
+
+    expect(within(container).getByRole('alert')).toBeInTheDocument()
+
+    // Stop throwing before clicking reset
+    shouldThrow = false
+    await user.click(within(container).getByText('Try Again'))
+
+    // Force re-render after state reset
+    rerender(
+      <ErrorBoundary key="test">
+        <ToggleChild />
+      </ErrorBoundary>,
+    )
+
+    expect(within(container).getByText('Recovered')).toBeInTheDocument()
+    expect(within(container).queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('logs error with componentDidCatch', () => {
+    const errorSpy = vi.spyOn(console, 'error')
+
+    render(
+      <ErrorBoundary label="Settings">
+        <ProblemChild shouldThrow />
+      </ErrorBoundary>,
+    )
+
+    // React 18 calls console.error for caught errors, plus our componentDidCatch log
+    const ourLog = errorSpy.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes('[ErrorBoundary: Settings]'),
+    )
+    expect(ourLog).toBeDefined()
+    expect(ourLog![1]).toBeInstanceOf(Error)
+    expect((ourLog![1] as Error).message).toBe('Test explosion')
+  })
+
+  it('shows "Go to Overview" button when onNavigate is provided', () => {
+    const { container } = render(
+      <ErrorBoundary onNavigate={() => {}}>
+        <ProblemChild shouldThrow />
+      </ErrorBoundary>,
+    )
+
+    expect(within(container).getByText('Go to Overview')).toBeInTheDocument()
+  })
+
+  it('hides "Go to Overview" button when onNavigate is not provided', () => {
+    const { container } = render(
+      <ErrorBoundary>
+        <ProblemChild shouldThrow />
+      </ErrorBoundary>,
+    )
+
+    expect(within(container).queryByText('Go to Overview')).not.toBeInTheDocument()
+  })
+
+  it('calls onNavigate when "Go to Overview" is clicked', async () => {
+    const user = userEvent.setup()
+    const onNavigate = vi.fn()
+
+    const { container } = render(
+      <ErrorBoundary onNavigate={onNavigate}>
+        <ProblemChild shouldThrow />
+      </ErrorBoundary>,
+    )
+
+    await user.click(within(container).getByText('Go to Overview'))
+    expect(onNavigate).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- **ErrorBoundary component** (`src/components/ui/error-boundary.tsx`): Reusable React class component that catches render errors and displays fallback UI with "Try Again" reset and optional "Go to Overview" navigation
- **Three-tier boundary strategy**: View-level (App.tsx), tab-level (TabContent.tsx), and pane-level (PaneContainer.tsx) boundaries isolate crashes to the smallest possible UI section
- **Comprehensive tests**: 8 unit tests covering normal rendering, fallback display, error reset, componentDidCatch logging, and navigation callbacks

## Motivation

An unhandled error in any React component crashes the entire UI to a white screen with no recovery path. This adds error boundaries around major UI sections so a crash in one terminal/browser/editor pane doesn't take down the whole app.

## Test plan

- [x] All 8 ErrorBoundary unit tests pass (including with `sequence.shuffle: true`)
- [x] Full test suite passes (2858/2858, 14 pre-existing SDK timeout failures unrelated)
- [x] Type-check passes

Generated with [Claude Code](https://claude.com/claude-code)