### PR TITLE
fix: log config corruption and notify clients instead of silent fallback

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -168,10 +168,15 @@ async function main() {
     sessionRepairService,
     async () => {
       const currentSettings = migrateSettingsSortMode(await configStore.getSettings())
+      const lastError = configStore.getLastReadError()
+      const configFallback = lastError
+        ? { reason: lastError, backupExists: await configStore.backupExists() }
+        : undefined
       return {
         settings: currentSettings,
         projects: codingCliIndexer.getProjects(),
         perfLogging: perfConfig.enabled,
+        configFallback,
       }
     },
     () => terminalMetadata.list(),

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -356,6 +356,7 @@ type HandshakeSnapshot = {
   settings?: AppSettings
   projects?: ProjectGroup[]
   perfLogging?: boolean
+  configFallback?: { reason: string; backupExists: boolean }
 }
 
 type HandshakeSnapshotProvider = () => Promise<HandshakeSnapshot>
@@ -955,6 +956,9 @@ export class WsHandler {
       }
       if (typeof snapshot.perfLogging === 'boolean') {
         this.safeSend(ws, { type: 'perf.logging', enabled: snapshot.perfLogging })
+      }
+      if (snapshot.configFallback) {
+        this.safeSend(ws, { type: 'config.fallback', ...snapshot.configFallback })
       }
     } catch (err) {
       logger.warn({ err }, 'Failed to send handshake snapshot')


### PR DESCRIPTION
## Summary

- **Structured error logging**: `readConfigFile()` now distinguishes ENOENT (normal first-run) from corruption (parse errors, version mismatches) and logs with pino structured events
- **Automatic config backup**: After every successful save, a backup copy is created at `~/.freshell/config.backup.json` so users can recover from corruption
- **WebSocket notification**: Sends `config.fallback` message via handshake snapshot so all connected clients learn about corruption — not just those connected at startup
- **Client-side warning banner**: Dismissible red banner in the UI warns users when config was corrupted and defaults are in use, with note about backup availability

## Test plan

- [x] 8 new unit tests (52/52 total passing)
  - Backup creation after save
  - Backup failure doesn't block saves
  - `backupExists()` true/false cases
  - Error tracking for ENOENT (silent), PARSE_ERROR, VERSION_MISMATCH, valid config
- [x] Full test suite: 186/190 files pass (pre-existing ws-handler-sdk failures unrelated)

Refs FRE-30

Generated with [Claude Code](https://claude.com/claude-code)