### PR TITLE
feat: make local file paths clickable to open in Editor tab

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
-import { updateTab, switchToNextTab, switchToPrevTab } from '@/store/tabsSlice'
-import { updatePaneContent, updatePaneTitle } from '@/store/panesSlice'
+import { addTab, updateTab, switchToNextTab, switchToPrevTab } from '@/store/tabsSlice'
+import { initLayout, updatePaneContent, updatePaneTitle } from '@/store/panesSlice'
 import { updateSessionActivity } from '@/store/sessionActivitySlice'
 import { recordTurnComplete, clearTabAttention, clearPaneAttention } from '@/store/turnCompletionSlice'
 import { getWsClient } from '@/lib/ws-client'
@@ -11,6 +11,7 @@ import { copyText, readText } from '@/lib/clipboard'
 import { registerTerminalActions } from '@/lib/pane-action-registry'
 import { consumeTerminalRestoreRequestId, addTerminalRestoreRequestId } from '@/lib/terminal-restore'
 import { isTerminalPasteShortcut } from '@/lib/terminal-input-policy'
+import { findLocalFilePaths } from '@/lib/path-utils'
 import {
   createTurnCompleteSignalParserState,
   extractTurnCompleteSignals,
@@ -242,6 +243,39 @@ export default function TerminalView({ tabId, paneId, paneContent, hidden }: Ter
 
     term.open(containerRef.current)
 
+    // Register custom link provider for clickable local file paths
+    const filePathLinkDisposable = term.registerLinkProvider({
+      provideLinks(bufferLineNumber: number, callback: (links: import('xterm').ILink[] | undefined) => void) {
+        const bufferLine = term.buffer.active.getLine(bufferLineNumber - 1)
+        if (!bufferLine) { callback(undefined); return }
+        const text = bufferLine.translateToString()
+        const matches = findLocalFilePaths(text)
+        if (matches.length === 0) { callback(undefined); return }
+        callback(matches.map((m) => ({
+          range: {
+            start: { x: m.startIndex + 1, y: bufferLineNumber },
+            end: { x: m.endIndex, y: bufferLineNumber },
+          },
+          text: m.path,
+          activate: () => {
+            const id = nanoid()
+            dispatch(addTab({ id, mode: 'shell' }))
+            dispatch(initLayout({
+              tabId: id,
+              content: {
+                kind: 'editor',
+                filePath: m.path,
+                language: null,
+                readOnly: false,
+                content: '',
+                viewMode: 'source',
+              },
+            }))
+          },
+        })))
+      },
+    })
+
     const unregisterActions = registerTerminalActions(paneId, {
       copySelection: async () => {
         const selection = term.getSelection()
@@ -331,6 +365,7 @@ export default function TerminalView({ tabId, paneId, paneContent, hidden }: Ter
     ro.observe(containerRef.current)
 
     return () => {
+      filePathLinkDisposable.dispose()
       ro.disconnect()
       unregisterActions()
       if (termRef.current === term) {

--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -6,6 +6,61 @@ export function isAbsolutePath(value: string): boolean {
   return false
 }
 
+export interface FilePathMatch {
+  path: string
+  startIndex: number
+  endIndex: number
+}
+
+/**
+ * Find local file paths in a line of terminal output.
+ * Detects paths starting with ~/ (tilde) or / (absolute).
+ * Excludes URLs and requires paths to have meaningful content.
+ */
+export function findLocalFilePaths(line: string): FilePathMatch[] {
+  const results: FilePathMatch[] = []
+
+  // Pattern 1: Tilde paths (~/...)
+  // Low false-positive risk — tilde prefix is unambiguous
+  const tildeRegex = /~\/[^\s"')\]>,;`]+/g
+  let match
+  while ((match = tildeRegex.exec(line)) !== null) {
+    const path = stripTrailingPunctuation(match[0])
+    if (path.length >= 3) {
+      results.push({ path, startIndex: match.index, endIndex: match.index + path.length })
+    }
+  }
+
+  // Pattern 2: Absolute paths (/...)
+  // Must be preceded by start-of-line, whitespace, or opening delimiter
+  // to avoid matching mid-URL paths like http://example.com/path
+  const absRegex = /(^|[\s(["'`])(\/(?:[\w._~-]+\/)*[\w._~-]+(?:\.[\w]+)?)/gm
+  while ((match = absRegex.exec(line)) !== null) {
+    const prefix = match[1]
+    const raw = match[2]
+    const pathStart = match.index + prefix.length
+
+    // Skip if preceded by a URL scheme (e.g., "http:", "https:", "file:")
+    if (pathStart > 0) {
+      const before = line.substring(Math.max(0, pathStart - 10), pathStart)
+      if (/[a-zA-Z]+:$/.test(before)) continue
+    }
+
+    const path = stripTrailingPunctuation(raw)
+    if (path === '/') continue
+    // Require either multiple segments or a file extension for single-segment paths
+    if (!path.includes('/', 1) && !/\.[\w]+$/.test(path)) continue
+
+    results.push({ path, startIndex: pathStart, endIndex: pathStart + path.length })
+  }
+
+  return results
+}
+
+function stripTrailingPunctuation(path: string): string {
+  return path.replace(/[.,;:!?]+$/, '')
+}
+
 export function joinPath(root: string, relativePath: string): string {
   const separator = root.includes('\\') ? '\\' : '/'
   const trimmedRoot = root.endsWith('/') || root.endsWith('\\') ? root.slice(0, -1) : root

--- a/test/e2e/tab-focus-behavior.test.tsx
+++ b/test/e2e/tab-focus-behavior.test.tsx
@@ -41,6 +41,7 @@ vi.mock('xterm', () => {
     rows = 24
     open = vi.fn()
     loadAddon = vi.fn()
+    registerLinkProvider = vi.fn(() => ({ dispose: vi.fn() }))
     write = vi.fn()
     writeln = vi.fn()
     clear = vi.fn()

--- a/test/e2e/terminal-paste-single-ingress.test.tsx
+++ b/test/e2e/terminal-paste-single-ingress.test.tsx
@@ -39,6 +39,7 @@ vi.mock('xterm', () => {
       element.addEventListener('paste', this.pasteListener)
     })
     loadAddon = vi.fn()
+    registerLinkProvider = vi.fn(() => ({ dispose: vi.fn() }))
     write = vi.fn()
     writeln = vi.fn()
     clear = vi.fn()

--- a/test/e2e/turn-complete-notification-flow.test.tsx
+++ b/test/e2e/turn-complete-notification-flow.test.tsx
@@ -60,6 +60,7 @@ vi.mock('xterm', () => {
     rows = 24
     open = vi.fn()
     loadAddon = vi.fn()
+    registerLinkProvider = vi.fn(() => ({ dispose: vi.fn() }))
     write = vi.fn()
     writeln = vi.fn()
     clear = vi.fn()

--- a/test/unit/client/components/TerminalView.keyboard.test.tsx
+++ b/test/unit/client/components/TerminalView.keyboard.test.tsx
@@ -45,6 +45,7 @@ vi.mock('xterm', () => {
     rows = 24
     open = vi.fn()
     loadAddon = vi.fn()
+    registerLinkProvider = vi.fn(() => ({ dispose: vi.fn() }))
     write = vi.fn()
     writeln = vi.fn()
     clear = vi.fn()

--- a/test/unit/client/components/TerminalView.lastInputAt.test.tsx
+++ b/test/unit/client/components/TerminalView.lastInputAt.test.tsx
@@ -16,6 +16,7 @@ vi.mock('xterm', () => ({
   Terminal: vi.fn().mockImplementation(() => ({
     loadAddon: vi.fn(),
     open: vi.fn(),
+    registerLinkProvider: vi.fn(() => ({ dispose: vi.fn() })),
     onData: vi.fn((cb: (data: string) => void) => {
       onDataCallback = cb
       return { dispose: vi.fn() }

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -53,6 +53,7 @@ vi.mock('xterm', () => {
     rows = 24
     open = vi.fn()
     loadAddon = vi.fn()
+    registerLinkProvider = vi.fn(() => ({ dispose: vi.fn() }))
     write = vi.fn()
     writeln = vi.fn()
     clear = vi.fn()

--- a/test/unit/client/components/TerminalView.linkWarning.test.tsx
+++ b/test/unit/client/components/TerminalView.linkWarning.test.tsx
@@ -39,6 +39,7 @@ vi.mock('xterm', () => {
     rows = 24
     open = vi.fn()
     loadAddon = vi.fn()
+    registerLinkProvider = vi.fn(() => ({ dispose: vi.fn() }))
     write = vi.fn()
     writeln = vi.fn()
     clear = vi.fn()

--- a/test/unit/client/components/TerminalView.resumeSession.test.tsx
+++ b/test/unit/client/components/TerminalView.resumeSession.test.tsx
@@ -41,6 +41,7 @@ vi.mock('xterm', () => {
     rows = 24
     open = vi.fn()
     loadAddon = vi.fn()
+    registerLinkProvider = vi.fn(() => ({ dispose: vi.fn() }))
     write = vi.fn()
     writeln = vi.fn()
     clear = vi.fn()

--- a/test/unit/client/components/TerminalView.visibility.test.tsx
+++ b/test/unit/client/components/TerminalView.visibility.test.tsx
@@ -21,6 +21,7 @@ vi.mock('xterm', () => ({
   Terminal: vi.fn().mockImplementation(() => ({
     loadAddon: vi.fn(),
     open: vi.fn(),
+    registerLinkProvider: vi.fn(() => ({ dispose: vi.fn() })),
     onData: vi.fn(() => ({ dispose: vi.fn() })),
     onTitleChange: vi.fn(() => ({ dispose: vi.fn() })),
     attachCustomKeyEventHandler: vi.fn(),


### PR DESCRIPTION
## Summary
- Register a custom xterm.js `ILinkProvider` that detects local file paths (`~/...` and `/...`) in terminal output
- Clicking a detected path opens a new Editor tab with that file
- Path detection uses two regex patterns: generous matching for tilde paths, boundary-aware matching for absolute paths with URL exclusion
- Added `findLocalFilePaths()` utility in `path-utils.ts`
- Updated all 9 test MockTerminal definitions with `registerLinkProvider` mock

## Test plan
- [x] `npm test` passes (186/187 files — 1 pre-existing SDK failure unrelated)
- [ ] Manual: run a command that outputs file paths, verify they appear as clickable links
- [ ] Manual: click a file path link, verify Editor tab opens with correct file

Refs FRE-39

🤖 Generated with [Claude Code](https://claude.com/claude-code)