### PR TITLE
feat: add horizontal and vertical split directions to FAB

### DIFF
--- a/src/components/panes/FloatingActionButton.tsx
+++ b/src/components/panes/FloatingActionButton.tsx
@@ -1,33 +1,35 @@
-import { Plus } from 'lucide-react'
+import { Columns2, Rows2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 interface FloatingActionButtonProps {
-  onAdd: () => void
+  onAdd: (direction: 'horizontal' | 'vertical') => void
 }
 
-export default function FloatingActionButton({ onAdd }: FloatingActionButtonProps) {
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      onAdd()
-    }
-  }
+const buttonStyles = cn(
+  'h-10 w-10 rounded-full bg-foreground text-background',
+  'flex items-center justify-center',
+  'shadow-lg hover:shadow-xl transition-all',
+  'hover:scale-105 active:scale-95'
+)
 
+export default function FloatingActionButton({ onAdd }: FloatingActionButtonProps) {
   return (
-    <div className="absolute bottom-12 right-4 z-50">
+    <div className="absolute bottom-12 right-4 z-50 flex flex-col gap-2">
       <button
-        onClick={onAdd}
-        onKeyDown={handleKeyDown}
-        aria-label="Add pane"
-        className={cn(
-          'h-12 w-12 rounded-full bg-foreground text-background',
-          'flex items-center justify-center',
-          'shadow-lg hover:shadow-xl transition-all',
-          'hover:scale-105 active:scale-95'
-        )}
-        title="Add pane"
+        onClick={() => onAdd('vertical')}
+        aria-label="Split down"
+        className={buttonStyles}
+        title="Split down"
       >
-        <Plus className="h-5 w-5" />
+        <Rows2 className="h-4 w-4" />
+      </button>
+      <button
+        onClick={() => onAdd('horizontal')}
+        aria-label="Split right"
+        className={buttonStyles}
+        title="Split right"
+      >
+        <Columns2 className="h-4 w-4" />
       </button>
     </div>
   )

--- a/src/components/panes/PaneLayout.tsx
+++ b/src/components/panes/PaneLayout.tsx
@@ -32,10 +32,11 @@ export default function PaneLayout({ tabId, defaultContent, hidden }: PaneLayout
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, tabId, layout])
 
-  const handleAddPane = useCallback(() => {
+  const handleAddPane = useCallback((direction: 'horizontal' | 'vertical') => {
     dispatch(addPane({
       tabId,
       newContent: { kind: 'picker' },
+      direction,
     }))
   }, [dispatch, tabId])
 

--- a/src/store/panesSlice.ts
+++ b/src/store/panesSlice.ts
@@ -428,15 +428,17 @@ export const panesSlice = createSlice({
     },
 
     /**
-     * Add a pane by splitting the active pane horizontally (to the right).
+     * Add a pane by splitting the active pane in the given direction.
+     * Defaults to horizontal (to the right) if no direction is specified.
      * Preserves the existing layout structure instead of rebuilding a grid.
-     * The new pane is placed to the right of the active pane and becomes active.
+     * The new pane becomes active.
      */
     addPane: (
       state,
       action: PayloadAction<{
         tabId: string
         newContent: PaneContentInput
+        direction?: 'horizontal' | 'vertical'
       }>
     ) => {
       const { tabId, newContent } = action.payload
@@ -459,11 +461,11 @@ export const panesSlice = createSlice({
         content: normalizedContent,
       }
 
-      // Replace the active pane with a horizontal split: [activePane, newPane]
+      // Replace the active pane with a split: [activePane, newPane]
       const replacement: PaneNode = {
         type: 'split',
         id: nanoid(),
-        direction: 'horizontal',
+        direction: action.payload.direction || 'horizontal',
         sizes: [50, 50],
         children: [{ ...activeLeaf }, newLeaf],
       }

--- a/test/browser_use/demo_synth.py
+++ b/test/browser_use/demo_synth.py
@@ -219,7 +219,7 @@ async def setup_browser(args, log, token, base_url):
                 "() => !new URLSearchParams(window.location.search).has('token')"
             )
             has_add_pane = await page.evaluate(
-                '() => !!document.querySelector(\'button[aria-label="Add pane"]\')'
+                '() => !!document.querySelector(\'button[aria-label="Split right"]\')'
             )
             has_connected = await page.evaluate(
                 "() => !!document.querySelector('[title=\"Connected\"]')"

--- a/test/browser_use/smoke_freshell.py
+++ b/test/browser_use/smoke_freshell.py
@@ -412,7 +412,7 @@ async def _run(args: argparse.Namespace) -> int:
         # These checks intentionally avoid reading the token value to keep it out of any debug logs.
         auth_present = await page.evaluate("() => !!localStorage.getItem('freshell.auth-token')")
         token_removed = await page.evaluate("() => !new URLSearchParams(window.location.search).has('token')")
-        has_add_pane = await page.evaluate("() => !!document.querySelector('button[aria-label=\"Add pane\"]')")
+        has_add_pane = await page.evaluate("() => !!document.querySelector('button[aria-label=\"Split right\"]')")
         has_connected = await page.evaluate("() => !!document.querySelector('[title=\"Connected\"]')")
         if auth_present and token_removed and has_add_pane and has_connected:
           ready = True

--- a/test/integration/client/editor-pane.test.tsx
+++ b/test/integration/client/editor-pane.test.tsx
@@ -94,6 +94,12 @@ vi.mock('lucide-react', () => ({
   Search: ({ className }: { className?: string }) => (
     <svg data-testid="search-icon" className={className} />
   ),
+  Columns2: ({ className }: { className?: string }) => (
+    <svg data-testid="columns2-icon" className={className} />
+  ),
+  Rows2: ({ className }: { className?: string }) => (
+    <svg data-testid="rows2-icon" className={className} />
+  ),
 }))
 
 // Mock TerminalView component to avoid xterm.js dependencies
@@ -219,7 +225,7 @@ describe('Editor Pane Integration', () => {
     )
 
     // Click FAB to add picker pane
-    await user.click(screen.getByRole('button', { name: /add pane/i }))
+    await user.click(screen.getByRole('button', { name: /split right/i }))
 
     // Select Editor from picker (using keyboard shortcut for reliability)
     await user.keyboard('e')
@@ -255,7 +261,7 @@ describe('Editor Pane Integration', () => {
     )
 
     // Add editor pane via picker
-    await user.click(screen.getByRole('button', { name: /add pane/i }))
+    await user.click(screen.getByRole('button', { name: /split right/i }))
     await user.keyboard('e')
 
     // Should see the path input
@@ -517,7 +523,7 @@ describe('Editor Pane Integration', () => {
     })
 
     // Add another pane via FAB picker
-    await user.click(screen.getByRole('button', { name: /add pane/i }))
+    await user.click(screen.getByRole('button', { name: /split right/i }))
     await user.keyboard('s') // Select shell
 
     // Original editor content should still be present
@@ -613,7 +619,7 @@ describe('Editor Pane Integration', () => {
     })
 
     // Add an editor pane
-    await user.click(screen.getByRole('button', { name: /add pane/i }))
+    await user.click(screen.getByRole('button', { name: /split right/i }))
     // Click the Editor option directly (keyboard shortcuts require transition animation)
     await user.click(screen.getByText('Editor'))
 

--- a/test/unit/client/components/panes/FloatingActionButton.test.tsx
+++ b/test/unit/client/components/panes/FloatingActionButton.test.tsx
@@ -4,8 +4,11 @@ import FloatingActionButton from '@/components/panes/FloatingActionButton'
 
 // Mock lucide-react icons
 vi.mock('lucide-react', () => ({
-  Plus: ({ className }: { className?: string }) => (
-    <svg data-testid="plus-icon" className={className} />
+  Columns2: ({ className }: { className?: string }) => (
+    <svg data-testid="columns2-icon" className={className} />
+  ),
+  Rows2: ({ className }: { className?: string }) => (
+    <svg data-testid="rows2-icon" className={className} />
   ),
 }))
 
@@ -20,33 +23,35 @@ describe('FloatingActionButton', () => {
     cleanup()
   })
 
-  it('renders the FAB button', () => {
+  it('renders both split-right and split-down buttons', () => {
     render(<FloatingActionButton onAdd={onAdd} />)
-    expect(screen.getByTitle('Add pane')).toBeInTheDocument()
+    expect(screen.getByTitle('Split right')).toBeInTheDocument()
+    expect(screen.getByTitle('Split down')).toBeInTheDocument()
   })
 
-  it('calls onAdd when clicked', () => {
+  it('calls onAdd with horizontal when split-right is clicked', () => {
     render(<FloatingActionButton onAdd={onAdd} />)
-    fireEvent.click(screen.getByTitle('Add pane'))
+    fireEvent.click(screen.getByTitle('Split right'))
     expect(onAdd).toHaveBeenCalledTimes(1)
+    expect(onAdd).toHaveBeenCalledWith('horizontal')
   })
 
-  it('has aria-label for accessibility', () => {
+  it('calls onAdd with vertical when split-down is clicked', () => {
     render(<FloatingActionButton onAdd={onAdd} />)
-    expect(screen.getByTitle('Add pane')).toHaveAttribute('aria-label', 'Add pane')
-  })
-
-  it('calls onAdd on Enter key', () => {
-    render(<FloatingActionButton onAdd={onAdd} />)
-    const button = screen.getByTitle('Add pane')
-    fireEvent.keyDown(button, { key: 'Enter' })
+    fireEvent.click(screen.getByTitle('Split down'))
     expect(onAdd).toHaveBeenCalledTimes(1)
+    expect(onAdd).toHaveBeenCalledWith('vertical')
   })
 
-  it('calls onAdd on Space key', () => {
+  it('has aria-labels for accessibility', () => {
     render(<FloatingActionButton onAdd={onAdd} />)
-    const button = screen.getByTitle('Add pane')
-    fireEvent.keyDown(button, { key: ' ' })
-    expect(onAdd).toHaveBeenCalledTimes(1)
+    expect(screen.getByTitle('Split right')).toHaveAttribute('aria-label', 'Split right')
+    expect(screen.getByTitle('Split down')).toHaveAttribute('aria-label', 'Split down')
+  })
+
+  it('renders correct icons for each direction', () => {
+    render(<FloatingActionButton onAdd={onAdd} />)
+    expect(screen.getByTestId('columns2-icon')).toBeInTheDocument()
+    expect(screen.getByTestId('rows2-icon')).toBeInTheDocument()
   })
 })

--- a/test/unit/client/components/panes/PaneLayout.test.tsx
+++ b/test/unit/client/components/panes/PaneLayout.test.tsx
@@ -80,6 +80,12 @@ vi.mock('lucide-react', () => ({
   Search: ({ className }: { className?: string }) => (
     <svg data-testid="search-icon" className={className} />
   ),
+  Columns2: ({ className }: { className?: string }) => (
+    <svg data-testid="columns2-icon" className={className} />
+  ),
+  Rows2: ({ className }: { className?: string }) => (
+    <svg data-testid="rows2-icon" className={className} />
+  ),
 }))
 
 // Mock PaneIcon to avoid transitive dependency issues
@@ -296,8 +302,9 @@ describe('PaneLayout', () => {
         store
       )
 
-      // FAB should be present
-      expect(screen.getByTitle('Add pane')).toBeInTheDocument()
+      // FAB should have both split buttons
+      expect(screen.getByTitle('Split right')).toBeInTheDocument()
+      expect(screen.getByTitle('Split down')).toBeInTheDocument()
     })
   })
 
@@ -321,7 +328,7 @@ describe('PaneLayout', () => {
       )
 
       // Click FAB to add picker pane
-      const fabButton = screen.getByTitle('Add pane')
+      const fabButton = screen.getByTitle('Split right')
       fireEvent.click(fabButton)
 
       // Layout should now be a split
@@ -366,7 +373,7 @@ describe('PaneLayout', () => {
       )
 
       // Click FAB to add picker pane
-      fireEvent.click(screen.getByTitle('Add pane'))
+      fireEvent.click(screen.getByTitle('Split right'))
 
       const state = store.getState().panes
       const splitNode = state.layouts['tab-1'] as Extract<PaneNode, { type: 'split' }>
@@ -405,12 +412,39 @@ describe('PaneLayout', () => {
       )
 
       // Click FAB to add picker pane
-      fireEvent.click(screen.getByTitle('Add pane'))
+      fireEvent.click(screen.getByTitle('Split right'))
 
       // With grid layout, 2 panes are always horizontal (side by side)
       const state = store.getState().panes
       const splitNode = state.layouts['tab-1'] as Extract<PaneNode, { type: 'split' }>
       expect(splitNode.direction).toBe('horizontal')
+    })
+
+    it('creates vertical split when split-down button is clicked', async () => {
+      const paneId = 'pane-1'
+      const store = createStore({
+        layouts: {
+          'tab-1': {
+            type: 'leaf',
+            id: paneId,
+            content: createTerminalContent(),
+          },
+        },
+        activePane: { 'tab-1': paneId },
+      })
+
+      renderWithStore(
+        <PaneLayout tabId="tab-1" defaultContent={createTerminalContent()} />,
+        store
+      )
+
+      // Click split-down button
+      fireEvent.click(screen.getByTitle('Split down'))
+
+      const state = store.getState().panes
+      const splitNode = state.layouts['tab-1'] as Extract<PaneNode, { type: 'split' }>
+      expect(splitNode.direction).toBe('vertical')
+      expect(splitNode.children).toHaveLength(2)
     })
 
     it('sets new pane as active after adding', async () => {
@@ -432,7 +466,7 @@ describe('PaneLayout', () => {
       )
 
       // Click FAB to add picker pane
-      fireEvent.click(screen.getByTitle('Add pane'))
+      fireEvent.click(screen.getByTitle('Split right'))
 
       const state = store.getState().panes
       const splitNode = state.layouts['tab-1'] as Extract<PaneNode, { type: 'split' }>
@@ -462,7 +496,7 @@ describe('PaneLayout', () => {
       )
 
       // Click FAB to add picker pane
-      fireEvent.click(screen.getByTitle('Add pane'))
+      fireEvent.click(screen.getByTitle('Split right'))
 
       // Layout should now be a split with picker content
       const state = store.getState().panes
@@ -492,7 +526,7 @@ describe('PaneLayout', () => {
       )
 
       // Click FAB to add picker pane
-      fireEvent.click(screen.getByTitle('Add pane'))
+      fireEvent.click(screen.getByTitle('Split right'))
 
       const state = store.getState().panes
       const splitNode = state.layouts['tab-1'] as Extract<PaneNode, { type: 'split' }>
@@ -522,7 +556,7 @@ describe('PaneLayout', () => {
       )
 
       // Click FAB to add picker pane - falls back to first leaf when no active pane is set
-      fireEvent.click(screen.getByTitle('Add pane'))
+      fireEvent.click(screen.getByTitle('Split right'))
 
       // Layout should now be a split with 2 panes
       const state = store.getState().panes
@@ -548,14 +582,14 @@ describe('PaneLayout', () => {
       )
 
       // Add first picker pane
-      fireEvent.click(screen.getByTitle('Add pane'))
+      fireEvent.click(screen.getByTitle('Split right'))
 
       // Get the new active pane (which should be the newly added one)
       let state = store.getState().panes
       const firstNewPaneId = state.activePane['tab-1']
 
       // Add second picker pane
-      fireEvent.click(screen.getByTitle('Add pane'))
+      fireEvent.click(screen.getByTitle('Split right'))
 
       state = store.getState().panes
       // Should have 3 panes now in a nested structure

--- a/test/unit/client/store/panesSlice.test.ts
+++ b/test/unit/client/store/panesSlice.test.ts
@@ -2038,6 +2038,38 @@ describe('panesSlice', () => {
 
       expect(countLeaves(root)).toBe(3)
     })
+
+    it('splits the active pane downward when direction is vertical', () => {
+      const tabId = 'tab1'
+      const leaf: PaneNode = { type: 'leaf', id: 'active', content: terminalContent('active-req') }
+      const state = makeState({ [tabId]: leaf }, { [tabId]: 'active' })
+      const result = panesReducer(state, addPane({
+        tabId,
+        newContent: { kind: 'picker' },
+        direction: 'vertical',
+      }))
+      const root = result.layouts[tabId]
+      expect(root.type).toBe('split')
+      if (root.type !== 'split') return
+      expect(root.direction).toBe('vertical')
+      expect(root.sizes).toEqual([50, 50])
+      expect(root.children[0]).toEqual(leaf)
+      expect(root.children[1].type).toBe('leaf')
+    })
+
+    it('defaults to horizontal split when no direction specified', () => {
+      const tabId = 'tab1'
+      const leaf: PaneNode = { type: 'leaf', id: 'active', content: terminalContent('active-req') }
+      const state = makeState({ [tabId]: leaf }, { [tabId]: 'active' })
+      const result = panesReducer(state, addPane({
+        tabId,
+        newContent: { kind: 'picker' },
+      }))
+      const root = result.layouts[tabId]
+      expect(root.type).toBe('split')
+      if (root.type !== 'split') return
+      expect(root.direction).toBe('horizontal')
+    })
   })
 
   describe('updatePaneTitle', () => {


### PR DESCRIPTION
## Summary
- Replace single "+" FAB with two-button stack: "Split right" (horizontal) and "Split down" (vertical)
- Add optional `direction` parameter to `addPane` Redux reducer, defaulting to `'horizontal'` for backward compatibility
- Update all test selectors and browser automation queries for new button labels

## Test plan
- [x] `npm test` passes (253 files, 3398 tests — 2 pre-existing WSL failures only)
- [x] Type-check clean
- [x] Build succeeds
- [ ] Manual verification: both split directions work from FAB buttons

Refs FRE-13

🤖 Generated with [Claude Code](https://claude.com/claude-code)