### PR TITLE
Remove dead PUT /api/settings handler

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -504,27 +504,6 @@ async function main() {
     res.json(migrated)
   })
 
-  // Alias (matches implementation plan)
-  app.put('/api/settings', async (req, res) => {
-    const parsed = SettingsPatchSchema.safeParse(req.body || {})
-    if (!parsed.success) {
-      return res.status(400).json({ error: 'Invalid request', details: parsed.error.issues })
-    }
-    const patch = normalizeSettingsPatch(migrateSettingsSortMode(parsed.data) as any)
-    const updated = await configStore.patchSettings(patch)
-    const migrated = migrateSettingsSortMode(updated)
-    registry.setSettings(migrated)
-    applyDebugLogging(!!migrated.logging?.debug, 'settings')
-    wsHandler.broadcast({ type: 'settings.updated', settings: migrated })
-	    await withPerfSpan(
-	      'coding_cli_refresh',
-	      () => codingCliIndexer.refresh(),
-	      {},
-	      { minDurationMs: perfConfig.slowSessionRefreshMs, level: 'warn' },
-	    )
-    res.json(migrated)
-  })
-
   // --- API: sessions ---
   // Search endpoint must come BEFORE the generic /api/sessions route
   app.get('/api/sessions/search', async (req, res) => {


### PR DESCRIPTION
## Summary
- Removed the PUT `/api/settings` handler from `server/index.ts` (21 lines)
- The PUT handler was a line-for-line copy of the PATCH handler with zero client consumers
- All settings mutations use `api.patch()` — the PUT endpoint was never called

## Test plan
- [x] `npm test` passes (3394 tests pass, 2 pre-existing WSL path failures unrelated)
- [x] Verified no client code references PUT `/api/settings`

Refs FRE-43

Generated with [Claude Code](https://claude.com/claude-code)