### PR TITLE
refactor: remove vestigial @ts-ignore for ws.bufferedAmount

### DIFF
--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -1221,7 +1221,6 @@ export class TerminalRegistry extends EventEmitter {
 
   safeSend(client: WebSocket, msg: unknown, context?: { terminalId?: string; perf?: TerminalRecord['perf'] }) {
     // Backpressure guard.
-    // @ts-ignore
     const buffered = client.bufferedAmount as number | undefined
     if (typeof buffered === 'number' && buffered > MAX_WS_BUFFERED_AMOUNT) {
       if (context?.perf) context.perf.droppedMessages += 1

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -575,7 +575,6 @@ export class WsHandler {
     let messageType: string | undefined
     try {
       // Backpressure guard.
-      // @ts-ignore
       const buffered = ws.bufferedAmount as number | undefined
       if (this.closeForBackpressureIfNeeded(ws, buffered)) return
       let serialized = ''
@@ -660,7 +659,6 @@ export class WsHandler {
   private queueAttachFrame(ws: LiveWebSocket, msg: unknown): Promise<boolean> {
     if (ws.readyState !== WebSocket.OPEN) return Promise.resolve(false)
 
-    // @ts-ignore
     const buffered = ws.bufferedAmount as number | undefined
     if (this.closeForBackpressureIfNeeded(ws, buffered)) return Promise.resolve(false)
 

--- a/test/server/ws-edge-cases.test.ts
+++ b/test/server/ws-edge-cases.test.ts
@@ -238,7 +238,6 @@ class FakeRegistry {
 
   // Simulate backpressure by checking buffered amount
   safeSend(client: WebSocket, msg: unknown) {
-    // @ts-ignore - bufferedAmount may not be typed
     const buffered = client.bufferedAmount as number | undefined
     if (typeof buffered === 'number' && buffered > 2 * 1024 * 1024) {
       return // Drop message under backpressure


### PR DESCRIPTION
## Summary
- `@types/ws@8.18.1` already declares `readonly bufferedAmount: number` on the WebSocket class
- Removed 4 dead `@ts-ignore` comments that were suppressing non-existent TypeScript errors
- Kept the defensive `as number | undefined` casts (zero behavior change)
- Files: `ws-handler.ts` (2), `terminal-registry.ts` (1), `ws-edge-cases.test.ts` (1)

## Test plan
- [x] `npx tsc --project tsconfig.server.json --noEmit` passes (confirms types exist without @ts-ignore)
- [x] `npm test` passes (3395 passed, 2 pre-existing WSL failures)
- [x] Verified zero remaining `@ts-ignore` in server/ and test/

Generated with [Claude Code](https://claude.com/claude-code)