### PR TITLE
refactor: import CodingCliProviderName from shared instead of redefining

### DIFF
--- a/server/coding-cli/types.ts
+++ b/server/coding-cli/types.ts
@@ -1,4 +1,5 @@
-export type CodingCliProviderName = 'claude' | 'codex' | 'opencode' | 'gemini' | 'kimi'
+import type { CodingCliProviderName } from '../../shared/ws-protocol.js'
+export type { CodingCliProviderName }
 
 /**
  * Sessions are uniquely identified by provider + sessionId.

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,6 +1,7 @@
 export type TerminalStatus = 'creating' | 'running' | 'exited' | 'error'
 
-export type CodingCliProviderName = 'claude' | 'codex' | 'opencode' | 'gemini' | 'kimi'
+import type { CodingCliProviderName } from '@shared/ws-protocol'
+export type { CodingCliProviderName }
 
 // TabMode includes 'shell' for regular terminals, plus all coding CLI providers
 // This allows future providers (opencode, gemini, kimi) to work as tab modes


### PR DESCRIPTION
## Summary
- Replace local `CodingCliProviderName` type definition in `server/coding-cli/types.ts` with `import type` + `export type` re-export from `shared/ws-protocol.js`
- Replace local `CodingCliProviderName` type definition in `src/store/types.ts` with `import type` + `export type` re-export from `@shared/ws-protocol`
- Eliminates type duplication: one canonical source in `shared/ws-protocol.ts`, two re-export bridges, zero consumer changes

## Test plan
- [x] `npm run typecheck` passes (client + server)
- [x] `npm test` passes (3395 passed, 2 pre-existing WSL failures)
- [x] No consumer changes needed — both files continue to export `CodingCliProviderName`

Refs FRE-45

Generated with [Claude Code](https://claude.com/claude-code)