### PR TITLE
Deduplicate WSL detection into canonical platform helpers

### DIFF
--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -13,23 +13,12 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { isWSL } from './platform.js'
 
 export type BootstrapResult = {
   action: 'created' | 'patched' | 'skipped' | 'error'
   token?: string
   error?: string
-}
-
-/**
- * Check if running inside WSL2.
- */
-function isWSL2(): boolean {
-  try {
-    const version = fs.readFileSync('/proc/version', 'utf-8')
-    return version.toLowerCase().includes('microsoft')
-  } catch {
-    return false
-  }
 }
 
 /**
@@ -132,7 +121,7 @@ export function readConfigHost(): '127.0.0.1' | '0.0.0.0' {
  */
 export function detectLanIps(): string[] {
   // In WSL2, get Windows host's physical LAN IPs instead of WSL's virtual IPs
-  if (isWSL2()) {
+  if (isWSL()) {
     const windowsIps = getWindowsHostIps()
     if (windowsIps.length > 0) {
       // Score and sort Windows IPs (using /24 as assumed netmask)

--- a/server/firewall.ts
+++ b/server/firewall.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process'
-import { readFileSync } from 'node:fs'
 import { promisify } from 'node:util'
+import { isWSL2 } from './platform.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -21,21 +21,6 @@ export interface FirewallInfo {
 export interface FirewallDeps {
   isWSL2: () => boolean
   tryExec: (cmd: string, args: string[]) => Promise<string | null>
-}
-
-function isWSL2(): boolean {
-  // readFileSync is acceptable here — /proc/version is a virtual filesystem
-  // that returns instantly (no disk I/O). This runs once and the result is
-  // cached by NetworkManager.
-  try {
-    const version = readFileSync('/proc/version', 'utf-8').toLowerCase()
-    // WSL2 has "microsoft-standard" or "wsl2" in the version string.
-    // WSL1 has "Microsoft" but not these patterns.
-    // This matches the detection logic in server/wsl-port-forward.ts:179-184.
-    return version.includes('wsl2') || version.includes('microsoft-standard')
-  } catch {
-    return false
-  }
 }
 
 /** Run a command asynchronously and return stdout, or null on failure. */

--- a/server/get-network-host.ts
+++ b/server/get-network-host.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import dotenv from 'dotenv'
+import { isWSL } from './platform.js'
 
 /**
  * Read the effective network bind host from ~/.freshell/config.json.
@@ -31,7 +32,7 @@ export function getNetworkHost(): string {
 
   // On WSL2, binding to 127.0.0.1 makes the server unreachable from the
   // Windows host browser. Always bind to 0.0.0.0 so Windows can connect.
-  if (isWSL2()) return '0.0.0.0'
+  if (isWSL()) return '0.0.0.0'
 
   try {
     const configPath = join(homedir(), '.freshell', 'config.json')
@@ -55,11 +56,3 @@ export function getNetworkHost(): string {
   }
 }
 
-function isWSL2(): boolean {
-  try {
-    const version = readFileSync('/proc/version', 'utf-8')
-    return version.toLowerCase().includes('microsoft')
-  } catch {
-    return false
-  }
-}

--- a/server/platform.ts
+++ b/server/platform.ts
@@ -1,6 +1,35 @@
 import cp from 'child_process'
+import { readFileSync } from 'fs'
 import fsPromises from 'fs/promises'
 import os from 'os'
+
+/**
+ * Check if running inside WSL2 (Windows Subsystem for Linux 2).
+ * Uses synchronous /proc/version check for WSL2-specific markers.
+ * WSL2 has "microsoft-standard" or "wsl2" in the version string.
+ * WSL1 has "Microsoft" but not these patterns.
+ */
+export function isWSL2(): boolean {
+  try {
+    const version = readFileSync('/proc/version', 'utf-8').toLowerCase()
+    return version.includes('wsl2') || version.includes('microsoft-standard')
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Check if running inside any version of WSL (WSL1 or WSL2).
+ * Uses synchronous /proc/version check for broad "microsoft" marker.
+ */
+export function isWSL(): boolean {
+  try {
+    const version = readFileSync('/proc/version', 'utf-8').toLowerCase()
+    return version.includes('microsoft')
+  } catch {
+    return false
+  }
+}
 
 /**
  * Detect the platform, including WSL detection.

--- a/server/wsl-port-forward.ts
+++ b/server/wsl-port-forward.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process'
-import fs from 'fs'
+import { isWSL2 } from './platform.js'
 
 const IPV4_REGEX = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
 const NETSH_PATH = '/mnt/c/Windows/System32/netsh.exe'
@@ -173,20 +173,6 @@ export function buildPortForwardingScript(wslIp: string, ports: number[]): strin
   )
 
   return commands.join('; ')
-}
-
-/**
- * Check if running inside WSL2.
- */
-function isWSL2(): boolean {
-  try {
-    const version = fs.readFileSync('/proc/version', 'utf-8').toLowerCase()
-    // WSL2 has "microsoft-standard" or "wsl2" in version string
-    // WSL1 has "Microsoft" but not these patterns
-    return version.includes('wsl2') || version.includes('microsoft-standard')
-  } catch {
-    return false
-  }
 }
 
 export type SetupResult = 'success' | 'skipped' | 'failed' | 'not-wsl2'

--- a/test/unit/server/bootstrap.test.ts
+++ b/test/unit/server/bootstrap.test.ts
@@ -6,6 +6,10 @@ import path from 'path'
 // Mock fs and os modules before importing the module under test
 vi.mock('fs')
 vi.mock('os')
+// Mock platform module — WSL detection is now centralized in platform.ts
+vi.mock('../../../server/platform.js', () => ({
+  isWSL: vi.fn(() => false),
+}))
 
 // Import the module under test after mocking
 import {

--- a/test/unit/vite-config.test.ts
+++ b/test/unit/vite-config.test.ts
@@ -11,6 +11,12 @@ vi.mock('dotenv', () => ({
   default: { config: vi.fn() },
   config: vi.fn(),
 }))
+// Mock platform module — WSL detection is now centralized in platform.ts
+vi.mock('../../server/platform.js', () => ({
+  isWSL: vi.fn(() => false),
+}))
+
+import { isWSL } from '../../server/platform.js'
 
 const TEST_TIMEOUT_MS = 20_000
 
@@ -73,13 +79,8 @@ describe('getNetworkHost', () => {
     expect(getNetworkHost()).toBe('0.0.0.0')
   })
 
-  it('always returns 0.0.0.0 on WSL2 regardless of config', async () => {
-    vi.mocked(readFileSync).mockImplementation((path: any) => {
-      if (String(path) === '/proc/version') return 'Linux version 5.15.167.4-microsoft-standard-WSL2'
-      return JSON.stringify({
-        settings: { network: { host: '127.0.0.1', configured: true } },
-      })
-    })
+  it('always returns 0.0.0.0 on WSL regardless of config', async () => {
+    vi.mocked(isWSL).mockReturnValue(true)
     const { getNetworkHost } = await import('../../server/get-network-host.js')
     expect(getNetworkHost()).toBe('0.0.0.0')
   })


### PR DESCRIPTION
## Summary
- Add `isWSL2()` (WSL2-specific) and `isWSL()` (broad WSL) as canonical helpers in `server/platform.ts`
- Remove 4 local duplicates from `firewall.ts`, `wsl-port-forward.ts`, `bootstrap.ts`, `get-network-host.ts`
- Fix naming bug: `bootstrap.ts` and `get-network-host.ts` had functions named `isWSL2()` that actually performed broad WSL detection (matching WSL1 too) — now correctly named `isWSL()`
- Update 4 test files to mock platform module exports instead of `fs.readFileSync`
- Add 9 new tests for canonical functions in `platform.test.ts`

## Test plan
- [x] `npm test` passes (3404 passed, 2 pre-existing WSL path failures, 12 skipped)
- [x] No new test failures introduced
- [x] All modified tests use platform module mocking

Refs FRE-46

Generated with [Claude Code](https://claude.com/claude-code)