### PR TITLE
fix: replace 8 unnecessary as-any casts with proper types

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -12,7 +12,7 @@ import { logger, setLogLevel } from './logger.js'
 import { requestLogger } from './request-logger.js'
 import { validateStartupSecurity, httpAuthMiddleware, timingSafeCompare } from './auth.js'
 import { configStore } from './config-store.js'
-import { TerminalRegistry } from './terminal-registry.js'
+import { TerminalRegistry, type TerminalRecord } from './terminal-registry.js'
 import { WsHandler } from './ws-handler.js'
 import { SessionsSyncService } from './sessions-sync/service.js'
 import { CodingCliSessionIndexer } from './coding-cli/session-indexer.js'
@@ -41,7 +41,7 @@ import { createTabsRegistryStore } from './tabs-registry/store.js'
 import { checkForUpdate } from './updater/version-checker.js'
 import { SessionAssociationCoordinator } from './session-association-coordinator.js'
 import { loadOrCreateServerInstanceId } from './instance-id.js'
-import { SettingsPatchSchema } from './settings-schema.js'
+import { SettingsPatchSchema, type SettingsPatch } from './settings-schema.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -233,21 +233,21 @@ async function main() {
 
   await Promise.all(
     registry.list().map(async (terminal) => {
-      await terminalMetadata.seedFromTerminal(terminal as any)
+      await terminalMetadata.seedFromTerminal(terminal)
     }),
   )
 
-  registry.on('terminal.idle.warning', (payload) => {
-    wsHandler.broadcast({ type: 'terminal.idle.warning', ...(payload as any) })
+  registry.on('terminal.idle.warning', (payload: { terminalId: string; killMinutes: number; warnMinutes: number; lastActivityAt: number }) => {
+    wsHandler.broadcast({ type: 'terminal.idle.warning', ...payload })
   })
 
-  registry.on('terminal.created', (record) => {
-    void terminalMetadata.seedFromTerminal(record as any)
+  registry.on('terminal.created', (record: TerminalRecord) => {
+    void terminalMetadata.seedFromTerminal(record)
       .then((upsert) => {
         if (upsert) broadcastTerminalMetaUpserts([upsert])
       })
       .catch((err) => {
-        log.warn({ err, terminalId: (record as any)?.terminalId }, 'Failed to seed terminal metadata')
+        log.warn({ err, terminalId: record?.terminalId }, 'Failed to seed terminal metadata')
       })
   })
 
@@ -472,7 +472,7 @@ async function main() {
     res.json({ directories })
   })
 
-  const normalizeSettingsPatch = (patch: Record<string, any>) => {
+  const normalizeSettingsPatch = (patch: SettingsPatch) => {
     if (Object.prototype.hasOwnProperty.call(patch, 'defaultCwd')) {
       const raw = patch.defaultCwd
       if (raw === null) {
@@ -489,7 +489,7 @@ async function main() {
     if (!parsed.success) {
       return res.status(400).json({ error: 'Invalid request', details: parsed.error.issues })
     }
-    const patch = normalizeSettingsPatch(migrateSettingsSortMode(parsed.data) as any)
+    const patch = normalizeSettingsPatch(migrateSettingsSortMode(parsed.data))
     const updated = await configStore.patchSettings(patch)
     const migrated = migrateSettingsSortMode(updated)
     registry.setSettings(migrated)
@@ -510,7 +510,7 @@ async function main() {
     if (!parsed.success) {
       return res.status(400).json({ error: 'Invalid request', details: parsed.error.issues })
     }
-    const patch = normalizeSettingsPatch(migrateSettingsSortMode(parsed.data) as any)
+    const patch = normalizeSettingsPatch(migrateSettingsSortMode(parsed.data))
     const updated = await configStore.patchSettings(patch)
     const migrated = migrateSettingsSortMode(updated)
     registry.setSettings(migrated)

--- a/server/settings-schema.ts
+++ b/server/settings-schema.ts
@@ -111,3 +111,5 @@ export const SettingsPatchSchema = z
       .optional(),
   })
   .strict()
+
+export type SettingsPatch = z.infer<typeof SettingsPatchSchema>

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid'
 import type WebSocket from 'ws'
+import type { LiveWebSocket } from './ws-handler.js'
 import * as pty from 'node-pty'
 import os from 'os'
 import path from 'path'
@@ -962,7 +963,7 @@ export class TerminalRegistry extends EventEmitter {
             // If a terminal spews output while we're sending a snapshot, queueing unboundedly can OOM the server.
             // Prefer explicit resync: drop the client and let it reconnect/reattach for a fresh snapshot.
             try {
-              ;(client as any).close?.(4008, 'Attach snapshot queue overflow')
+              client.close(4008, 'Attach snapshot queue overflow')
             } catch {
               // ignore
             }
@@ -1146,7 +1147,7 @@ export class TerminalRegistry extends EventEmitter {
   }
 
   private isMobileClient(client: WebSocket): boolean {
-    return (client as any).isMobileClient === true
+    return (client as LiveWebSocket).isMobileClient === true
   }
 
   private clearMobileOutput(client: WebSocket): void {
@@ -1241,7 +1242,7 @@ export class TerminalRegistry extends EventEmitter {
       }
       // Prefer explicit resync over silent corruption.
       try {
-        ;(client as any).close?.(4008, 'Backpressure')
+        client.close(4008, 'Backpressure')
       } catch {
         // ignore
       }

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -68,7 +68,7 @@ const log = logger.child({ component: 'ws' })
 const perfConfig = getPerfConfig()
 
 // Extended WebSocket with liveness tracking for keepalive
-interface LiveWebSocket extends WebSocket {
+export interface LiveWebSocket extends WebSocket {
   isAlive?: boolean
   connectionId?: string
   connectedAt?: number


### PR DESCRIPTION
## Summary
- Export `LiveWebSocket` interface from `ws-handler.ts` for cross-module type use
- Remove unnecessary `(client as any).close()` casts — `close()` is already on the WebSocket type
- Type `isMobileClient` access via imported `LiveWebSocket` instead of `as any`
- Export `SettingsPatch` type (Zod-inferred) from `settings-schema.ts`
- Type `normalizeSettingsPatch` parameter as `SettingsPatch`, removing 2 `as any` casts
- Type terminal event payloads (`terminal.created` with `TerminalRecord`, `terminal.idle.warning` with inline shape)

Reduces server `as any` count from 18 to 10. Remaining 10 are justified (SDK boundaries, env types, monkey-patching, generic comparison).

## Test plan
- [x] `npm test` passes (3395 passed, 2 pre-existing WSL failures, 12 skipped)
- [x] All changes are type-only — zero runtime behavior change

Generated with [Claude Code](https://claude.com/claude-code)