### PR TITLE
fix: add session ownership checks to codingcli.input/kill and sdk.attach

### DIFF
--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -1460,6 +1460,11 @@ export class WsHandler {
           return
         }
 
+        if (!state.codingCliSessions.has(m.sessionId)) {
+          this.sendError(ws, { code: 'UNAUTHORIZED', message: 'Not owner of this coding CLI session' })
+          return
+        }
+
         const session = this.codingCliManager.get(m.sessionId)
         if (!session) {
           this.sendError(ws, { code: 'INVALID_SESSION_ID', message: 'Session not found' })
@@ -1473,6 +1478,11 @@ export class WsHandler {
       case 'codingcli.kill': {
         if (!this.codingCliManager) {
           this.sendError(ws, { code: 'INTERNAL_ERROR', message: 'Coding CLI sessions not enabled' })
+          return
+        }
+
+        if (!state.codingCliSessions.has(m.sessionId)) {
+          this.sendError(ws, { code: 'UNAUTHORIZED', message: 'Not owner of this coding CLI session' })
           return
         }
 
@@ -1640,6 +1650,11 @@ export class WsHandler {
           this.sendError(ws, { code: 'INTERNAL_ERROR', message: 'SDK bridge not enabled' })
           return
         }
+        if (!state.sdkSessions.has(m.sessionId) && !state.sdkSubscriptions.has(m.sessionId)) {
+          this.sendError(ws, { code: 'UNAUTHORIZED', message: 'Not subscribed to this SDK session' })
+          return
+        }
+
         const session = this.sdkBridge.getSession(m.sessionId)
         if (!session) {
           this.sendError(ws, { code: 'INVALID_SESSION_ID', message: 'SDK session not found' })


### PR DESCRIPTION
## Summary
- Add ownership guards to `codingcli.input`, `codingcli.kill`, and `sdk.attach` WebSocket handlers
- Previously any authenticated client could interact with sessions they didn't create — now returns `UNAUTHORIZED`
- Reorder `sdk.attach` to check ownership before session existence to prevent session ID enumeration
- Matches the existing pattern used by `sdk.send`, `sdk.kill`, and other SDK handlers

## Test plan
- [x] `npm test` passes (3398/3400, 2 pre-existing WSL failures)
- [x] 3 new ownership rejection tests added
- [x] 2 existing tests updated for new guard behavior
- [x] Code review addressed guard ordering (info disclosure) and test naming

Generated with [Claude Code](https://claude.com/claude-code)