### PR TITLE
fix(settings): allow partial provider patches in SettingsPatchSchema

### DIFF
--- a/server/settings-router.ts
+++ b/server/settings-router.ts
@@ -5,6 +5,8 @@ import { withPerfSpan } from './perf-logger.js'
 
 // --- SettingsPatchSchema (moved from settings-schema.ts) ---
 
+const CODING_CLI_PROVIDER_NAMES = ['claude', 'codex', 'opencode', 'gemini', 'kimi'] as const
+
 const CodingCliProviderConfigSchema = z
   .object({
     model: z.string().optional(),
@@ -92,9 +94,10 @@ export const SettingsPatchSchema = z
           .array(z.enum(['claude', 'codex', 'opencode', 'gemini', 'kimi']))
           .optional(),
         providers: z
-          .record(
-            z.enum(['claude', 'codex', 'opencode', 'gemini', 'kimi']),
-            CodingCliProviderConfigSchema,
+          .record(z.string(), CodingCliProviderConfigSchema)
+          .refine(
+            (obj) => Object.keys(obj).every((k) => (CODING_CLI_PROVIDER_NAMES as readonly string[]).includes(k)),
+            { message: 'Unknown provider name' },
           )
           .optional(),
       })


### PR DESCRIPTION
## Summary

- **Fixes** #91 — Settings PATCH fails with 400 when changing Claude permission mode
- `z.record(z.enum([...]), valueSchema)` requires ALL enum keys to have valid values. PATCHing a single provider (e.g. just `claude`) failed because the other provider keys were `undefined`
- Switched to `z.record(z.string(), schema)` with a `.refine()` for key validation — accepts partial patches without materializing missing keys or risking data loss from spread-based merging

## Test plan

- [x] 3 new integration tests: single provider permissionMode, single provider model (verifies other providers preserved), multiple providers in one patch
- [x] Full server test suite passes (113/113, pre-existing Windows path test excluded)
- [x] Manually verified in the UI — permission mode dropdown saves successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)