### PR TITLE
fix(startup): show correct Vite client URL in dev mode

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -526,6 +526,9 @@ async function main() {
         console.log('   Auth token is configured in .env (not printed to logs).')
       }
     }
+    if (isDev) {
+      console.log(`   \x1b[33m(dev mode: Vite client on port ${visitPort}, Express server on port ${port})\x1b[0m`)
+    }
     console.log('')
 
     startBackgroundTasks()

--- a/server/startup-url.ts
+++ b/server/startup-url.ts
@@ -4,6 +4,6 @@
  * In production, the Express server serves everything on the server port.
  */
 export function resolveVisitPort(serverPort: number, env: NodeJS.ProcessEnv): number {
-  const isDev = env.NODE_ENV === 'development'
-  return isDev ? Number(env.VITE_PORT || 5173) : serverPort
+  const isProduction = env.NODE_ENV === 'production'
+  return isProduction ? serverPort : Number(env.VITE_PORT || 5173)
 }

--- a/test/unit/server/startup-url.test.ts
+++ b/test/unit/server/startup-url.test.ts
@@ -7,7 +7,7 @@ describe('resolveVisitPort', () => {
     expect(resolveVisitPort(3001, env)).toBe(3001)
   })
 
-  it('returns default Vite port (5173) in development', () => {
+  it('returns default Vite port (5173) when NODE_ENV is "development"', () => {
     const env = { NODE_ENV: 'development' } as NodeJS.ProcessEnv
     expect(resolveVisitPort(3001, env)).toBe(5173)
   })
@@ -17,13 +17,18 @@ describe('resolveVisitPort', () => {
     expect(resolveVisitPort(3001, env)).toBe(8080)
   })
 
-  it('returns server port when NODE_ENV is unset', () => {
+  it('returns Vite port when NODE_ENV is unset (dev default)', () => {
     const env = {} as NodeJS.ProcessEnv
-    expect(resolveVisitPort(3001, env)).toBe(3001)
+    expect(resolveVisitPort(3001, env)).toBe(5173)
   })
 
-  it('returns server port in test mode', () => {
+  it('returns Vite port in test mode', () => {
     const env = { NODE_ENV: 'test' } as NodeJS.ProcessEnv
-    expect(resolveVisitPort(4000, env)).toBe(4000)
+    expect(resolveVisitPort(4000, env)).toBe(5173)
+  })
+
+  it('respects VITE_PORT when NODE_ENV is unset', () => {
+    const env = { VITE_PORT: '9000' } as NodeJS.ProcessEnv
+    expect(resolveVisitPort(3001, env)).toBe(9000)
   })
 })


### PR DESCRIPTION
## Summary
- `resolveVisitPort` checked `NODE_ENV === 'development'` but dev scripts never set `NODE_ENV`, so the startup URL always pointed to the Express port (3001) instead of the Vite client port (5173)
- Aligned with the rest of the codebase by checking `!== 'production'`
- Added a dev mode hint line clarifying which port is the Vite client vs the Express server

## Test plan
- [x] Updated `startup-url.test.ts` with corrected expectations for unset/test NODE_ENV
- [x] Added test for VITE_PORT respect when NODE_ENV is unset
- [x] Server test suite passes (113/113, 2 pre-existing failures in unrelated Windows path tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)