### PR TITLE
Fix Codex session history replay stability

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -1348,21 +1348,13 @@ export default function TerminalView({ tabId, paneId, paneContent, hidden }: Ter
             return
           }
 
-          const currentAttach = currentAttachRef.current
-          const suppressReplayWindowBanner =
-            msg.reason === 'replay_window_exceeded'
-            && currentAttach?.terminalId === msg.terminalId
-            && (currentAttach.intent === 'viewport_hydrate' || currentAttach.sinceSeq === 0)
-
-          if (!suppressReplayWindowBanner) {
-            const reason = msg.reason === 'replay_window_exceeded'
-              ? 'reconnect window exceeded'
-              : 'slow link backlog'
-            try {
-              term.writeln(`\r\n[Output gap ${msg.fromSeq}-${msg.toSeq}: ${reason}]\r\n`)
-            } catch {
-              // disposed
-            }
+          const reason = msg.reason === 'replay_window_exceeded'
+            ? 'reconnect window exceeded'
+            : 'slow link backlog'
+          try {
+            term.writeln(`\r\n[Output gap ${msg.fromSeq}-${msg.toSeq}: ${reason}]\r\n`)
+          } catch {
+            // disposed
           }
           const previousSeqState = seqStateRef.current
           const nextSeqState = onOutputGap(previousSeqState, { fromSeq: msg.fromSeq, toSeq: msg.toSeq })

--- a/src/store/selectors/sidebarSelectors.ts
+++ b/src/store/selectors/sidebarSelectors.ts
@@ -59,12 +59,16 @@ function buildSessionItems(
   sessionActivity: Record<string, number>
 ): SidebarSessionItem[] {
   const items: SidebarSessionItem[] = []
-  const runningSessionMap = new Map<string, string>()
+  const runningSessionMap = new Map<string, { terminalId: string; createdAt: number }>()
   const tabSessionMap = new Map<string, { hasTab: boolean }>()
 
   for (const terminal of terminals || []) {
     if (terminal.mode && terminal.mode !== 'shell' && terminal.status === 'running' && terminal.resumeSessionId) {
-      runningSessionMap.set(`${terminal.mode}:${terminal.resumeSessionId}`, terminal.terminalId)
+      const sessionKey = `${terminal.mode}:${terminal.resumeSessionId}`
+      const existing = runningSessionMap.get(sessionKey)
+      if (!existing || terminal.createdAt < existing.createdAt) {
+        runningSessionMap.set(sessionKey, { terminalId: terminal.terminalId, createdAt: terminal.createdAt })
+      }
     }
   }
 
@@ -97,7 +101,8 @@ function buildSessionItems(
     for (const session of project.sessions || []) {
       const provider = session.provider || 'claude'
       const key = `${provider}:${session.sessionId}`
-      const runningTerminalId = runningSessionMap.get(key)
+      const runningTerminal = runningSessionMap.get(key)
+      const runningTerminalId = runningTerminal?.terminalId
       const tabInfo = tabSessionMap.get(key)
       const ratchetedActivity = sessionActivity[key]
       const hasTitle = !!session.title

--- a/test/unit/client/store/selectors/sidebarSelectors.runningTerminal.test.ts
+++ b/test/unit/client/store/selectors/sidebarSelectors.runningTerminal.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { makeSelectSortedSessionItems } from '@/store/selectors/sidebarSelectors'
+import type { BackgroundTerminal } from '@/store/types'
+import type { RootState } from '@/store/store'
+
+function createState(): RootState {
+  return {
+    sessions: {
+      projects: [
+        {
+          projectPath: '/repo',
+          sessions: [
+            {
+              provider: 'codex',
+              sessionId: 'session-1',
+              projectPath: '/repo',
+              updatedAt: 1,
+              title: 'Session One',
+              cwd: '/repo',
+            },
+          ],
+        },
+      ],
+      loading: false,
+      error: null,
+      expandedProjects: new Set<string>(),
+      projectColors: {},
+      sessionColorOverrides: {},
+      source: 'runtime',
+    },
+    tabs: {
+      tabs: [],
+      activeTabId: null,
+      renameRequestTabId: null,
+    },
+    panes: {
+      layouts: {},
+      activePaneByTabId: {},
+      paneTitles: {},
+      paneTitleSetByUser: {},
+      tabTitleTemplates: {},
+      tabTitleTemplateSetByUser: {},
+      tabTitleEphemeralSuppressed: {},
+      tabTitleTemplateLastAppliedAt: {},
+      mode: 'single',
+      splitOrientation: 'vertical',
+      defaultSplitDirection: 'right',
+    },
+    settings: {
+      settings: {
+        sidebar: {
+          sortMode: 'recency-pinned',
+          showSubagents: false,
+          ignoreCodexSubagentSessions: true,
+          showNoninteractiveSessions: false,
+          hideEmptySessions: true,
+          excludeFirstChatSubstrings: [],
+          excludeFirstChatMustStart: false,
+          showProjectBadges: true,
+        },
+      },
+      loading: false,
+      saving: false,
+      error: null,
+    },
+    sessionActivity: {
+      sessions: {},
+    },
+  } as unknown as RootState
+}
+
+describe('sidebarSelectors running session mapping', () => {
+  it('pins session runningTerminalId to the oldest running terminal when duplicate mappings exist', () => {
+    const selector = makeSelectSortedSessionItems()
+    const state = createState()
+    const terminals: BackgroundTerminal[] = [
+      {
+        terminalId: 'newer-terminal',
+        title: 'Codex',
+        createdAt: 200,
+        lastActivityAt: 500,
+        status: 'running',
+        hasClients: true,
+        mode: 'codex',
+        resumeSessionId: 'session-1',
+      },
+      {
+        terminalId: 'older-terminal',
+        title: 'Codex',
+        createdAt: 100,
+        lastActivityAt: 600,
+        status: 'running',
+        hasClients: true,
+        mode: 'codex',
+        resumeSessionId: 'session-1',
+      },
+    ]
+
+    const items = selector(state, terminals, '')
+
+    expect(items).toHaveLength(1)
+    expect(items[0].runningTerminalId).toBe('older-terminal')
+  })
+})


### PR DESCRIPTION
## Summary
- make sidebar session-to-running-terminal mapping deterministic by selecting the oldest running terminal on duplicate provider/session mappings
- increase replay retention floor for coding CLI terminals (default 8MB via `CODING_CLI_MIN_REPLAY_RING_MAX_BYTES`) to reduce replay window loss on attach
- always render replay gap markers in `TerminalView` so truncation is visible instead of silently suppressed
- add/update tests for selector behavior, broker replay floor behavior, and lifecycle gap banner expectations

## Validation
- `NODE_ENV=test npx vitest run --config vitest.config.ts test/unit/client/components/TerminalView.lifecycle.test.tsx`
- `NODE_ENV=test npx vitest run --config vitest.config.ts test/unit/client/store/selectors/sidebarSelectors.runningTerminal.test.ts`
- `NODE_ENV=test npx vitest run --config vitest.server.config.ts test/unit/server/ws-handler-backpressure.test.ts -t "coding-cli terminals"`

## Notes
- orchestration-only validation cannot fully exercise Codex TUI replay because Codex expects terminal-emulator cursor responses; CLI-only panes exit quickly without that emulator loop
