### PR TITLE
fix(sidebar): prevent scrollbar blink and enable real-time timestamps

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { setStatus, setError, setErrorCode, setServerInstanceId, setPlatform, se
 import { setSettings } from '@/store/settingsSlice'
 import {
   setProjects,
-  clearProjects,
   mergeProjects,
   applySessionsPatch,
   markWsSnapshotReceived,
@@ -330,6 +329,39 @@ export default function App() {
     let cleanedUp = false
     let cleanup: (() => void) | null = null
     let stopTabRegistrySync: (() => void) | null = null
+
+    // Buffer for chunked sessions.updated messages — we accumulate all chunks
+    // and apply them atomically to avoid the sidebar collapsing and rebuilding
+    // (scrollbar "blink") during incremental chunked delivery.
+    //
+    // The debounce timer fires 300ms after the LAST chunk.  Server inter-chunk
+    // delays are normally sub-millisecond (setImmediate yield); the only source
+    // of longer gaps is WebSocket drain backpressure.  300ms is generous enough
+    // for all practical scenarios.  If the timer fires with a partial buffer
+    // (extreme backpressure), setProjects replaces the sidebar briefly; any
+    // late-arriving append chunks merge gracefully via the fallback path.
+    let chunkedBuffer: ProjectGroup[] | null = null
+    let chunkedFlushTimer: ReturnType<typeof setTimeout> | null = null
+    const CHUNK_FLUSH_DELAY_MS = 300
+
+    function clearChunkedState() {
+      if (chunkedFlushTimer) { clearTimeout(chunkedFlushTimer); chunkedFlushTimer = null }
+      chunkedBuffer = null
+    }
+
+    function flushChunkedBuffer() {
+      if (chunkedFlushTimer) { clearTimeout(chunkedFlushTimer); chunkedFlushTimer = null }
+      if (chunkedBuffer) {
+        dispatch(setProjects(chunkedBuffer))
+        dispatch(markWsSnapshotReceived())
+        chunkedBuffer = null
+      }
+    }
+
+    function scheduleChunkedFlush() {
+      if (chunkedFlushTimer) clearTimeout(chunkedFlushTimer)
+      chunkedFlushTimer = setTimeout(flushChunkedBuffer, CHUNK_FLUSH_DELAY_MS)
+    }
     async function bootstrap() {
       const handleBootstrapAuthFailure = (err: unknown): boolean => {
         if (!isApiUnauthorizedError(err)) return false
@@ -388,33 +420,43 @@ export default function App() {
           dispatch(setStatus('ready'))
           dispatch(setServerInstanceId(ready.success ? ready.data.serverInstanceId : undefined))
           dispatch(resetWsSnapshotReceived())
+          // Discard any in-flight chunked buffer from a previous connection
+          // to prevent stale data from overwriting the new session snapshot.
+          clearChunkedState()
           // If App registered late and missed a prior snapshot, a fresh HTTP baseline
           // from this bootstrap cycle is still safe for enabling patch application.
           promoteRecentHttpSessionsBaseline()
           requestTerminalMetaList()
         }
         if (msg.type === 'sessions.updated') {
-          // Support chunked sessions for mobile browsers with limited WebSocket buffers
           const projects = (msg.projects || []) as ProjectGroup[]
-          const totalSessions = projects.reduce((n, p) => n + (p.sessions?.length || 0), 0)
-          log.debug('[DIAG] sessions.updated', { clear: !!msg.clear, append: !!msg.append, projects: projects.length, sessions: totalSessions })
           if (msg.clear) {
-            // First chunk: clear existing, then merge
-            dispatch(clearProjects())
-            dispatch(mergeProjects(projects))
+            // First chunk of a multi-chunk update: start buffering instead of
+            // clearing Redux state (which causes the sidebar to collapse).
+            chunkedBuffer = [...projects]
+            scheduleChunkedFlush()
           } else if (msg.append) {
-            // Subsequent chunks: merge with existing
-            dispatch(mergeProjects(projects))
+            if (chunkedBuffer) {
+              // Subsequent chunk while buffering: accumulate
+              chunkedBuffer.push(...projects)
+              scheduleChunkedFlush()
+            } else {
+              // Append without a prior clear (shouldn't happen, but handle gracefully)
+              dispatch(mergeProjects(projects))
+              dispatch(markWsSnapshotReceived())
+            }
           } else {
-            // Full update (broadcasts, legacy): replace all
+            // Single-chunk update (no clear/append flags): apply immediately
+            if (chunkedBuffer) flushChunkedBuffer()
             dispatch(setProjects(projects))
+            dispatch(markWsSnapshotReceived())
           }
-          dispatch(markWsSnapshotReceived())
         }
         if (msg.type === 'sessions.patch') {
+          // If a patch arrives while we're buffering a chunked update, flush
+          // the buffer first so the patch applies against a complete baseline.
+          if (chunkedBuffer) flushChunkedBuffer()
           const upsertProjects = (msg.upsertProjects || []) as ProjectGroup[]
-          const totalSessions = upsertProjects.reduce((n, p) => n + (p.sessions?.length || 0), 0)
-          log.debug('[DIAG] sessions.patch', { upsertProjects: upsertProjects.length, sessions: totalSessions, removeProjectPaths: (msg.removeProjectPaths || []).length })
           dispatch(applySessionsPatch({
             upsertProjects,
             removeProjectPaths: msg.removeProjectPaths || [],
@@ -488,6 +530,7 @@ export default function App() {
 
       cleanup = () => {
         unsubscribe()
+        clearChunkedState()
       }
       if (cleanedUp) cleanup()
 

--- a/test/unit/client/components/Sidebar.render-stability.test.tsx
+++ b/test/unit/client/components/Sidebar.render-stability.test.tsx
@@ -258,10 +258,10 @@ describe('Sidebar render stability', () => {
       expect(areSessionItemsEqual([item1], [item1, item2])).toBe(false)
     })
 
-    it('ignores timestamp changes (handled by timestampTick)', () => {
+    it('detects timestamp changes (session activity updates)', () => {
       const a = [item1]
       const b = [{ ...item1, timestamp: 9999 }]
-      expect(areSessionItemsEqual(a, b)).toBe(true)
+      expect(areSessionItemsEqual(a, b)).toBe(false)
     })
 
     it('returns false when sessionId changes', () => {


### PR DESCRIPTION
## Summary
- **Fixes scrollbar blink**: Buffers chunked `sessions.updated` WebSocket messages locally before flushing atomically to Redux, preventing the sidebar from collapsing and re-expanding during full session reloads
- **Enables real-time timestamps**: Removed `stableItemsRef` that was blocking timestamp updates from reaching sidebar items; React.memo comparator on `SidebarItem` already provides per-row render protection
- **Reconnect safety**: Clears in-flight chunked buffer on WebSocket reconnect (`ready` message) to prevent stale data from a previous connection

Closes #111

## Test plan
- [x] 3 new tests for chunked buffer behavior (atomic flush, patch-during-chunking, late-arriving chunks)
- [x] Updated render stability test to verify timestamps are now detected as changes
- [x] Manual verification: sidebar no longer blinks during session updates, timestamps update in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)