### PR TITLE
fix: sidebar highlight for running sessions in multi-pane tabs

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -99,37 +99,43 @@ interface SidebarRowProps {
   timestampTick: number
 }
 
+/**
+ * Determine whether a sidebar session item should be highlighted as active.
+ * Prefers activeSessionKey (derived from the active pane's content) when
+ * available. Falls back to activeTerminalId only when no session key exists
+ * (e.g. a fresh terminal not yet associated with a session).
+ * This prevents double-highlighting when activeTerminalId is stale.
+ */
+export function computeIsActive(params: {
+  isRunning: boolean
+  runningTerminalId: string | undefined
+  sessionKey: string
+  activeSessionKey: string | null
+  activeTerminalId: string | undefined
+}): boolean {
+  // When we have a session key from the active pane, use it for all items
+  if (params.activeSessionKey != null) {
+    return params.sessionKey === params.activeSessionKey
+  }
+  // No session key available — fall back to terminal ID matching for running sessions
+  if (params.isRunning) {
+    return params.runningTerminalId === params.activeTerminalId
+  }
+  return false
+}
+
 /** Row component defined at module scope for stable identity — prevents react-window
  *  from unmounting/remounting all visible rows on every parent re-render. */
 export const SidebarRow = ({ index, style, ariaAttributes, ...data }: RowComponentProps<SidebarRowProps>) => {
   const item = data.items[index]
   const sessionKey = `${item.provider}:${item.sessionId}`
-  const matchesByTerminalId = item.isRunning && item.runningTerminalId === data.activeTerminalId
-  const matchesBySessionKey = sessionKey === data.activeSessionKey
-  const isActive = item.isRunning
-    ? matchesByTerminalId
-    : matchesBySessionKey
-
-  // Debug: log when there's a mismatch between the two highlighting paths
-  if (item.isRunning && matchesBySessionKey !== matchesByTerminalId) {
-    log.debug(
-      `[SidebarHighlight] MISMATCH for "${item.title}" (${sessionKey}):`,
-      `isRunning=${item.isRunning}`,
-      `matchesByTerminalId=${matchesByTerminalId} (runningTerminalId=${item.runningTerminalId}, activeTerminalId=${data.activeTerminalId})`,
-      `matchesBySessionKey=${matchesBySessionKey} (activeSessionKey=${data.activeSessionKey})`,
-      `→ isActive=${isActive} (used terminalId path because isRunning=true)`
-    )
-  }
-
-  // Debug: log when any item is highlighted or when activeSessionKey matches but isn't used
-  if (isActive || (matchesBySessionKey && !isActive)) {
-    log.debug(
-      `[SidebarHighlight] "${item.title}" (${sessionKey}):`,
-      `isActive=${isActive}`,
-      `isRunning=${item.isRunning}`,
-      `path=${item.isRunning ? 'terminalId' : 'sessionKey'}`
-    )
-  }
+  const isActive = computeIsActive({
+    isRunning: item.isRunning,
+    runningTerminalId: item.runningTerminalId,
+    sessionKey,
+    activeSessionKey: data.activeSessionKey,
+    activeTerminalId: data.activeTerminalId,
+  })
 
   // Stable click handler: store latest callback + item in a ref so the
   // onClick function identity never changes, but always invokes current data.
@@ -191,16 +197,6 @@ export default function Sidebar({
     if (!ref) return null
     return `${ref.provider}:${ref.sessionId}`
   })
-  const activePaneIdForDebug = useAppSelector((s) => {
-    const tabId = s.tabs.activeTabId
-    return tabId ? s.panes.activePane[tabId] : null
-  })
-  useEffect(() => {
-    log.debug('[SidebarHighlight] activeSessionKeyFromPanes:',
-      activeSessionKeyFromPanes,
-      `activeTabId=${activeTabId}`,
-      `activePaneId=${activePaneIdForDebug}`)
-  }, [activeSessionKeyFromPanes, activeTabId, activePaneIdForDebug])
   const selectSortedItems = useMemo(() => makeSelectSortedSessionItems(), [])
   // Separate selector instance for allItems: createSelector caches only one
   // result, so calling the same instance with different filter args would thrash
@@ -401,18 +397,10 @@ export default function Sidebar({
     const state = store.getState()
     const currentActiveTabId = state.tabs.activeTabId
     const runningTerminalId = item.isRunning ? item.runningTerminalId : undefined
-    const sessionKey = `${provider}:${item.sessionId}`
-
-    log.info(`[SidebarClick] Clicked "${item.title}" (${sessionKey})`,
-      `isRunning=${item.isRunning}`,
-      `runningTerminalId=${runningTerminalId}`,
-      `currentActiveTabId=${currentActiveTabId}`)
 
     // 1. Dedup: if session is already open in a pane, focus it
     const existing = findPaneForSession(state, provider, item.sessionId)
     if (existing) {
-      log.info(`[SidebarClick] → Dedup: focusing existing pane`,
-        `tabId=${existing.tabId}`, `paneId=${existing.paneId}`)
       dispatch(setActiveTab(existing.tabId))
       if (existing.paneId) {
         dispatch(setActivePane({ tabId: existing.tabId, paneId: existing.paneId }))
@@ -424,7 +412,6 @@ export default function Sidebar({
     // 2. Fallback: no active tab or active tab has no layout → create new tab
     const activeLayout = currentActiveTabId ? state.panes.layouts[currentActiveTabId] : undefined
     if (!currentActiveTabId || !activeLayout) {
-      log.info(`[SidebarClick] → Creating new tab for session`)
       dispatch(openSessionTab({
         sessionId: item.sessionId,
         title: item.title,
@@ -437,9 +424,6 @@ export default function Sidebar({
     }
 
     // 3. Normal: split a new pane in the current tab
-    log.info(`[SidebarClick] → Adding pane to tab ${currentActiveTabId}`,
-      `activePaneBefore=${state.panes.activePane[currentActiveTabId]}`,
-      `tabTerminalId=${state.tabs.tabs.find(t => t.id === currentActiveTabId)?.terminalId}`)
     dispatch(addPane({
       tabId: currentActiveTabId,
       newContent: {
@@ -465,14 +449,6 @@ export default function Sidebar({
   const activeTab = tabs.find((t) => t.id === activeTabId)
   const activeSessionKey = activeSessionKeyFromPanes
   const activeTerminalId = activeTab?.terminalId
-
-  // Debug: log the key highlight inputs on every render
-  useEffect(() => {
-    log.debug('[SidebarHighlight] Render inputs:',
-      `activeTabId=${activeTabId}`,
-      `activeSessionKey=${activeSessionKey}`,
-      `activeTerminalId(tab-level)=${activeTerminalId}`)
-  }, [activeTabId, activeSessionKey, activeTerminalId])
   const effectiveListHeight = listHeight > 0
     ? listHeight
     : Math.min(sortedItems.length * SESSION_ITEM_HEIGHT, SESSION_LIST_MAX_HEIGHT)

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -1,5 +1,4 @@
 import { useRef, useCallback, useMemo, useState, useEffect } from 'react'
-import { createLogger } from '@/lib/client-logger'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { setActivePane, resizePanes, updatePaneContent, updatePaneTitle, clearPaneRenameRequest, toggleZoom } from '@/store/panesSlice'
 import { updateTab, closePaneWithCleanup } from '@/store/tabsSlice'
@@ -32,8 +31,6 @@ import { clearPendingCreate, removeSession } from '@/store/agentChatSlice'
 import { cancelCreate } from '@/lib/sdk-message-handler'
 import type { TerminalMetaRecord } from '@/store/terminalMetaSlice'
 import { ErrorBoundary } from '@/components/ui/error-boundary'
-
-const log = createLogger('PaneContainer')
 
 // Stable empty object to avoid selector memoization issues
 const EMPTY_PANE_TITLES: Record<string, string> = {}
@@ -231,22 +228,12 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
   }, [dispatch, tabId, tabTerminalId, ws, sdkPendingCreates])
 
   const handleFocus = useCallback((paneId: string) => {
-    // Debug: log pane focus with content info for sidebar highlight investigation
-    if (node.type === 'leaf' && node.id === paneId) {
-      const c = node.content
-      const sessionInfo = c.kind === 'terminal'
-        ? `mode=${c.mode} resumeSessionId=${c.resumeSessionId} terminalId=${c.terminalId}`
-        : c.kind === 'agent-chat'
-          ? `provider=${c.provider} resumeSessionId=${c.resumeSessionId}`
-          : `kind=${c.kind}`
-      log.info(`[PaneFocus] paneId=${paneId} tabId=${tabId} ${sessionInfo} tabTerminalId=${tabTerminalId}`)
-    }
     if (attentionDismiss === 'click' && attentionByPane[paneId]) {
       dispatch(clearPaneAttention({ paneId }))
       dispatch(clearTabAttention({ tabId }))
     }
     dispatch(setActivePane({ tabId, paneId }))
-  }, [dispatch, tabId, attentionDismiss, attentionByPane, node, tabTerminalId])
+  }, [dispatch, tabId, attentionDismiss, attentionByPane])
 
   const handleToggleZoom = useCallback((paneId: string) => {
     dispatch(toggleZoom({ tabId, paneId }))

--- a/test/unit/client/components/Sidebar.highlight.test.ts
+++ b/test/unit/client/components/Sidebar.highlight.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { computeIsActive } from '@/components/Sidebar'
+
+describe('Sidebar highlight logic (computeIsActive)', () => {
+  describe('when activeSessionKey is available (primary path)', () => {
+    it('highlights when sessionKey matches activeSessionKey', () => {
+      expect(computeIsActive({
+        isRunning: false,
+        runningTerminalId: undefined,
+        sessionKey: 'claude:session-abc',
+        activeSessionKey: 'claude:session-abc',
+        activeTerminalId: undefined,
+      })).toBe(true)
+    })
+
+    it('does not highlight when sessionKey differs from activeSessionKey', () => {
+      expect(computeIsActive({
+        isRunning: false,
+        runningTerminalId: undefined,
+        sessionKey: 'claude:session-abc',
+        activeSessionKey: 'claude:session-xyz',
+        activeTerminalId: undefined,
+      })).toBe(false)
+    })
+
+    // THE BUG: running session should highlight via sessionKey when
+    // activeTerminalId is undefined (multi-pane tab where tab-level
+    // terminalId was never set)
+    it('highlights a running session via sessionKey when activeTerminalId is undefined', () => {
+      expect(computeIsActive({
+        isRunning: true,
+        runningTerminalId: 'term-1',
+        sessionKey: 'codex:session-def',
+        activeSessionKey: 'codex:session-def',
+        activeTerminalId: undefined,
+      })).toBe(true)
+    })
+
+    // Running session should highlight via sessionKey even when
+    // activeTerminalId points to a different terminal
+    it('highlights a running session via sessionKey when activeTerminalId is a different terminal', () => {
+      expect(computeIsActive({
+        isRunning: true,
+        runningTerminalId: 'term-2',
+        sessionKey: 'claude:session-abc',
+        activeSessionKey: 'claude:session-abc',
+        activeTerminalId: 'term-1',
+      })).toBe(true)
+    })
+
+    // Prevents double-highlight: when activeSessionKey points to session A,
+    // a different running session whose terminalId matches activeTerminalId
+    // should NOT highlight
+    it('does not highlight a running session via stale terminalId when activeSessionKey points elsewhere', () => {
+      expect(computeIsActive({
+        isRunning: true,
+        runningTerminalId: 'term-1',
+        sessionKey: 'claude:session-other',
+        activeSessionKey: 'claude:session-abc',
+        activeTerminalId: 'term-1',
+      })).toBe(false)
+    })
+  })
+
+  describe('when activeSessionKey is null (fallback to terminalId)', () => {
+    it('highlights a running session when activeTerminalId matches', () => {
+      expect(computeIsActive({
+        isRunning: true,
+        runningTerminalId: 'term-1',
+        sessionKey: 'claude:session-abc',
+        activeSessionKey: null,
+        activeTerminalId: 'term-1',
+      })).toBe(true)
+    })
+
+    it('does not highlight a running session when activeTerminalId differs', () => {
+      expect(computeIsActive({
+        isRunning: true,
+        runningTerminalId: 'term-2',
+        sessionKey: 'claude:session-abc',
+        activeSessionKey: null,
+        activeTerminalId: 'term-1',
+      })).toBe(false)
+    })
+
+    it('does not highlight a non-running session when activeSessionKey is null', () => {
+      expect(computeIsActive({
+        isRunning: false,
+        runningTerminalId: undefined,
+        sessionKey: 'claude:session-abc',
+        activeSessionKey: null,
+        activeTerminalId: undefined,
+      })).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes sidebar session highlighting breaking when multiple panes are open in a tab
- Root cause: running sessions used tab-level `terminalId` for highlight matching, which was often `undefined` or stale in multi-pane tabs
- Fix: precedence-based logic — prefer `activeSessionKey` (derived from active pane) when available, fall back to `activeTerminalId` only when no session key exists
- Extracts `computeIsActive()` as a pure, testable function with 8 unit tests covering all highlight scenarios

## Test plan

- [x] Unit tests for `computeIsActive()` covering: session key match, terminal ID match, multi-pane bug cases, double-highlight prevention
- [x] Existing sidebar render-stability tests pass (47 total)
- [x] Manual: open a tab, select a session from sidebar → highlights correctly
- [x] Manual: open a second session from sidebar (splits pane) → new session highlights
- [x] Manual: click back on first pane → first session highlights in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)