### PR TITLE
Hide Kilroy pane option by default

### DIFF
--- a/server/platform-router.ts
+++ b/server/platform-router.ts
@@ -11,6 +11,17 @@ export interface PlatformRouterDeps {
   appVersion: string
 }
 
+function isTruthy(value: string | undefined): boolean {
+  if (!value) return false
+  return value === '1' || value.toLowerCase() === 'true'
+}
+
+function detectFeatureFlags(): Record<string, boolean> {
+  return {
+    kilroy: isTruthy(process.env.KILROY_ENABLED),
+  }
+}
+
 export function createPlatformRouter(deps: PlatformRouterDeps): Router {
   const { detectPlatform, detectAvailableClis, detectHostName, checkForUpdate, appVersion } = deps
   const router = Router()
@@ -21,7 +32,8 @@ export function createPlatformRouter(deps: PlatformRouterDeps): Router {
       detectAvailableClis(),
       detectHostName(),
     ])
-    res.json({ platform, availableClis, hostName })
+    const featureFlags = detectFeatureFlags()
+    res.json({ platform, availableClis, hostName, featureFlags })
   })
 
   router.get('/version', async (_req, res) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState, type TouchEvent as ReactTouchEvent } from 'react'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
-import { setStatus, setError, setErrorCode, setServerInstanceId, setPlatform, setAvailableClis } from '@/store/connectionSlice'
+import { setStatus, setError, setErrorCode, setServerInstanceId, setPlatform, setAvailableClis, setFeatureFlags } from '@/store/connectionSlice'
 import { setSettings } from '@/store/settingsSlice'
 import {
   setProjects,
@@ -560,11 +560,15 @@ export default function App() {
           platform: string
           availableClis?: Record<string, boolean>
           hostName?: string
+          featureFlags?: Record<string, boolean>
         }>('/api/platform')
         if (!cancelled) {
           dispatch(setPlatform(platformInfo.platform))
           if (platformInfo.availableClis) {
             dispatch(setAvailableClis(platformInfo.availableClis))
+          }
+          if (platformInfo.featureFlags) {
+            dispatch(setFeatureFlags(platformInfo.featureFlags))
           }
           dispatch(setTabRegistryDeviceMeta(resolveAndPersistDeviceMeta({
             platform: platformInfo.platform,

--- a/src/lib/agent-chat-types.ts
+++ b/src/lib/agent-chat-types.ts
@@ -34,4 +34,8 @@ export interface AgentChatProviderConfig {
   pickerShortcut: string
   /** If true, show after CLI options in the picker instead of before */
   pickerAfterCli?: boolean
+  /** If true, hide from pane picker unless corresponding feature flag is enabled */
+  hidden?: boolean
+  /** Feature flag name that unhides this provider (defaults to provider name) */
+  featureFlag?: string
 }

--- a/src/lib/agent-chat-utils.ts
+++ b/src/lib/agent-chat-utils.ts
@@ -51,6 +51,8 @@ export const AGENT_CHAT_PROVIDER_CONFIGS: AgentChatProviderConfig[] = [
     },
     pickerShortcut: 'K',
     pickerAfterCli: true,
+    hidden: true,
+    featureFlag: 'kilroy',
   },
 ]
 
@@ -67,4 +69,13 @@ export function getAgentChatProviderConfig(name?: string): AgentChatProviderConf
 export function getAgentChatProviderLabel(name?: string): string {
   const config = getAgentChatProviderConfig(name)
   return config?.label ?? 'Agent Chat'
+}
+
+/** Returns provider configs visible in the pane picker, filtering out hidden providers unless their feature flag is enabled. */
+export function getVisibleAgentChatConfigs(featureFlags: Record<string, boolean>): AgentChatProviderConfig[] {
+  return AGENT_CHAT_PROVIDER_CONFIGS.filter((config) => {
+    if (!config.hidden) return true
+    const flag = config.featureFlag ?? config.name
+    return featureFlags[flag] === true
+  })
 }

--- a/src/store/connectionSlice.ts
+++ b/src/store/connectionSlice.ts
@@ -10,6 +10,7 @@ export interface ConnectionState {
   serverInstanceId?: string
   platform: string | null
   availableClis: Record<string, boolean>
+  featureFlags: Record<string, boolean>
 }
 
 const FATAL_CONNECTION_ERROR_CODES = new Set([4001, 4003, 4010])
@@ -22,6 +23,7 @@ const initialState: ConnectionState = {
   status: 'disconnected',
   platform: null,
   availableClis: {},
+  featureFlags: {},
 }
 
 export const connectionSlice = createSlice({
@@ -51,8 +53,11 @@ export const connectionSlice = createSlice({
     setAvailableClis: (state, action: PayloadAction<Record<string, boolean>>) => {
       state.availableClis = action.payload
     },
+    setFeatureFlags: (state, action: PayloadAction<Record<string, boolean>>) => {
+      state.featureFlags = action.payload
+    },
   },
 })
 
-export const { setStatus, setError, setErrorCode, setServerInstanceId, setPlatform, setAvailableClis } = connectionSlice.actions
+export const { setStatus, setError, setErrorCode, setServerInstanceId, setPlatform, setAvailableClis, setFeatureFlags } = connectionSlice.actions
 export default connectionSlice.reducer

--- a/test/unit/client/lib/agent-chat-utils.test.ts
+++ b/test/unit/client/lib/agent-chat-utils.test.ts
@@ -5,6 +5,7 @@ import {
   isAgentChatProviderName,
   getAgentChatProviderConfig,
   getAgentChatProviderLabel,
+  getVisibleAgentChatConfigs,
 } from '@/lib/agent-chat-utils'
 
 describe('agent-chat-utils', () => {
@@ -66,5 +67,38 @@ describe('agent-chat-utils', () => {
   it('all providers have unique picker shortcuts', () => {
     const shortcuts = AGENT_CHAT_PROVIDER_CONFIGS.map((c) => c.pickerShortcut)
     expect(new Set(shortcuts).size).toBe(shortcuts.length)
+  })
+
+  it('kilroy config has hidden flag set to true', () => {
+    const config = getAgentChatProviderConfig('kilroy')
+    expect(config!.hidden).toBe(true)
+  })
+
+  it('freshclaude config does not have hidden flag', () => {
+    const config = getAgentChatProviderConfig('freshclaude')
+    expect(config!.hidden).toBeUndefined()
+  })
+
+  describe('getVisibleAgentChatConfigs', () => {
+    it('excludes hidden providers when no feature flags are set', () => {
+      const visible = getVisibleAgentChatConfigs({})
+      const names = visible.map((c) => c.name)
+      expect(names).toContain('freshclaude')
+      expect(names).not.toContain('kilroy')
+    })
+
+    it('includes hidden providers when their feature flag is true', () => {
+      const visible = getVisibleAgentChatConfigs({ kilroy: true })
+      const names = visible.map((c) => c.name)
+      expect(names).toContain('freshclaude')
+      expect(names).toContain('kilroy')
+    })
+
+    it('still excludes hidden providers when their feature flag is false', () => {
+      const visible = getVisibleAgentChatConfigs({ kilroy: false })
+      const names = visible.map((c) => c.name)
+      expect(names).toContain('freshclaude')
+      expect(names).not.toContain('kilroy')
+    })
   })
 })

--- a/test/unit/client/store/connectionSlice.test.ts
+++ b/test/unit/client/store/connectionSlice.test.ts
@@ -5,6 +5,7 @@ import connectionReducer, {
   setErrorCode,
   setPlatform,
   setAvailableClis,
+  setFeatureFlags,
   ConnectionState,
   ConnectionStatus,
 } from '../../../../src/store/connectionSlice'
@@ -334,6 +335,31 @@ describe('connectionSlice', () => {
 
       expect(state.lastError).toBe('Too many connections')
       expect(state.lastErrorCode).toBe(4003)
+    })
+  })
+
+  describe('featureFlags state', () => {
+    it('has empty featureFlags in initial state', () => {
+      const state = connectionReducer(undefined, { type: 'unknown' })
+      expect(state.featureFlags).toEqual({})
+    })
+
+    it('stores featureFlags via setFeatureFlags', () => {
+      const state = connectionReducer(undefined, setFeatureFlags({ kilroy: true }))
+      expect(state.featureFlags).toEqual({ kilroy: true })
+    })
+
+    it('replaces featureFlags entirely on update', () => {
+      let state = connectionReducer(undefined, setFeatureFlags({ kilroy: true }))
+      state = connectionReducer(state, setFeatureFlags({ kilroy: false }))
+      expect(state.featureFlags).toEqual({ kilroy: false })
+    })
+
+    it('does not interfere with other state', () => {
+      let state = connectionReducer(undefined, setFeatureFlags({ kilroy: true }))
+      state = connectionReducer(state, setPlatform('linux'))
+      expect(state.platform).toBe('linux')
+      expect(state.featureFlags).toEqual({ kilroy: true })
     })
   })
 


### PR DESCRIPTION
## Summary
- Adds `KILROY_ENABLED` env var support — server includes `featureFlags.kilroy` in `/api/platform` response
- Client stores feature flags in Redux, PanePicker filters hidden agent-chat providers
- Kilroy config marked `hidden: true` with `featureFlag: 'kilroy'` — won't appear in picker unless env var is set

## Test plan
- [x] Verify Kilroy does not appear in pane picker by default
- [x] Set `KILROY_ENABLED=1`, restart server, verify Kilroy appears in picker
- [ ] Verify existing Kilroy sessions still render correctly (icon, label)
- [x] Verify Freshclaude still appears normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)