### PR TITLE
Fix code block copy button in agent-chat panes

### DIFF
--- a/src/components/markdown/MarkdownRenderer.tsx
+++ b/src/components/markdown/MarkdownRenderer.tsx
@@ -4,6 +4,7 @@ import remarkGfm from 'remark-gfm'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import { Copy, Check, ExternalLink } from 'lucide-react'
+import { copyText } from '@/lib/clipboard'
 
 type MarkdownRendererProps = {
   content: string
@@ -43,14 +44,11 @@ function CopyButton({ code }: { code: string }) {
   }, [])
 
   const handleCopy = useCallback(async () => {
-    if (!navigator.clipboard?.writeText) return
-    try {
-      await navigator.clipboard.writeText(code)
+    const ok = await copyText(code)
+    if (ok) {
       if (timerRef.current) clearTimeout(timerRef.current)
       setCopied(true)
       timerRef.current = setTimeout(() => setCopied(false), 2000)
-    } catch {
-      // Permission denied or other clipboard error
     }
   }, [code])
 


### PR DESCRIPTION
## Summary
- CopyButton used `navigator.clipboard.writeText()` directly, which silently fails in non-secure contexts (HTTP, remote LAN access)
- Replaced with shared `copyText()` utility from `src/lib/clipboard.ts` that falls back to `document.execCommand('copy')`
- Updated tests to mock the clipboard module and verify delegation

## Test plan
- [ ] Open a Freshclaude pane, send a message that produces a code block
- [ ] Click the "Copy" button on the code block header — should copy and show "Copied!" feedback
- [ ] Test over remote access (non-localhost HTTP) to confirm fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)