### PR TITLE
fix(agent-chat): preserve draft text when pane splits

### DIFF
--- a/src/components/agent-chat/AgentChatView.tsx
+++ b/src/components/agent-chat/AgentChatView.tsx
@@ -614,6 +614,7 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
       {/* Composer */}
       <ChatComposer
         ref={composerRef}
+        paneId={paneId}
         onSend={handleSend}
         onInterrupt={handleInterrupt}
         disabled={!isInteractive && !isRunning}

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -14,6 +14,7 @@ import PanePicker, { type PanePickerType } from './PanePicker'
 import DirectoryPicker from './DirectoryPicker'
 import { getProviderLabel, isCodingCliProviderName } from '@/lib/coding-cli-utils'
 import { isAgentChatProviderName, getAgentChatProviderConfig } from '@/lib/agent-chat-utils'
+import { clearDraft } from '@/lib/draft-store'
 import { getTerminalActions } from '@/lib/pane-action-registry'
 import { cn } from '@/lib/utils'
 import { getWsClient } from '@/lib/ws-client'
@@ -209,8 +210,9 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
         dispatch(updateTab({ id: tabId, updates: { terminalId: undefined } }))
       }
     }
-    // Clean up SDK session if this pane has one
+    // Clean up agent-chat resources
     if (content.kind === 'agent-chat') {
+      clearDraft(paneId)
       const sessionId = content.sessionId || sdkPendingCreates[content.createRequestId]
       if (sessionId) {
         ws.send({ type: 'sdk.kill', sessionId })

--- a/src/lib/draft-store.ts
+++ b/src/lib/draft-store.ts
@@ -1,0 +1,25 @@
+/**
+ * Module-level store for chat composer draft text.
+ *
+ * Survives React component unmount/remount (e.g. pane splits) without
+ * involving Redux or localStorage.  Keyed by paneId so each pane keeps
+ * its own independent draft.
+ */
+
+const drafts = new Map<string, string>()
+
+export function getDraft(paneId: string): string {
+  return drafts.get(paneId) ?? ''
+}
+
+export function setDraft(paneId: string, text: string): void {
+  if (text) {
+    drafts.set(paneId, text)
+  } else {
+    drafts.delete(paneId)
+  }
+}
+
+export function clearDraft(paneId: string): void {
+  drafts.delete(paneId)
+}

--- a/src/store/tabsSlice.ts
+++ b/src/store/tabsSlice.ts
@@ -9,6 +9,7 @@ import { getProviderLabel } from '@/lib/coding-cli-utils'
 import { buildResumeContent } from '@/lib/session-type-utils'
 import { isAgentChatProviderName, getAgentChatProviderConfig, getAgentChatProviderLabel } from '@/lib/agent-chat-utils'
 import { recordClosedTabSnapshot } from './tabRegistrySlice'
+import { clearDraft } from '@/lib/draft-store'
 import {
   buildClosedTabRegistryRecord,
   countPaneLeaves,
@@ -282,10 +283,11 @@ export const closeTab = createAsyncThunk(
     dispatch(removeTab(tabId))
     dispatch(removeLayout({ tabId }))
 
-    // Clean up attention for the tab and all its panes
+    // Clean up attention and drafts for the tab and all its panes
     dispatch(clearTabAttention({ tabId }))
     for (const paneId of paneIds) {
       dispatch(clearPaneAttention({ paneId }))
+      clearDraft(paneId)
     }
   }
 )

--- a/test/unit/client/lib/draft-store.test.ts
+++ b/test/unit/client/lib/draft-store.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getDraft, setDraft, clearDraft } from '@/lib/draft-store'
+
+describe('draft-store', () => {
+  beforeEach(() => {
+    // Clean slate — clear any drafts from previous tests
+    clearDraft('pane-a')
+    clearDraft('pane-b')
+  })
+
+  it('returns empty string when no draft exists', () => {
+    expect(getDraft('nonexistent')).toBe('')
+  })
+
+  it('stores and retrieves a draft', () => {
+    setDraft('pane-a', 'hello world')
+    expect(getDraft('pane-a')).toBe('hello world')
+  })
+
+  it('keeps independent drafts per paneId', () => {
+    setDraft('pane-a', 'draft A')
+    setDraft('pane-b', 'draft B')
+    expect(getDraft('pane-a')).toBe('draft A')
+    expect(getDraft('pane-b')).toBe('draft B')
+  })
+
+  it('clears a specific draft', () => {
+    setDraft('pane-a', 'some text')
+    clearDraft('pane-a')
+    expect(getDraft('pane-a')).toBe('')
+  })
+
+  it('removes draft when set to empty string', () => {
+    setDraft('pane-a', 'some text')
+    setDraft('pane-a', '')
+    expect(getDraft('pane-a')).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- Pane splits restructure the React component tree, causing `ChatComposer` to unmount/remount and lose typed text from `useState`
- Add a module-level `Map<paneId, string>` draft store (`src/lib/draft-store.ts`) that survives React lifecycle — ChatComposer reads from the store on mount and syncs on every keystroke
- Drafts are cleaned up on pane close (`PaneContainer`) and tab close (`tabsSlice`)
- Handles edge case where `paneId` prop changes in-place (resyncs text + textarea height)

## Test plan
- [x] Unit tests for `draft-store` (get/set/clear, independent per paneId, empty string cleanup)
- [x] Unit tests for `ChatComposer` draft preservation (restore after remount, clear on send, independent per paneId, no-paneId fallback)
- [ ] Manual: type text in a Freshclaude pane → split the pane → verify text is preserved
- [ ] Manual: type text → send message → verify draft is cleared
- [ ] Manual: close a pane with draft text → reopen → verify draft is not leaked

🤖 Generated with [Claude Code](https://claude.com/claude-code)