### PR TITLE
fix(editor): follow app theme in Monaco editor panes

### DIFF
--- a/src/components/panes/EditorPane.tsx
+++ b/src/components/panes/EditorPane.tsx
@@ -2,6 +2,17 @@ import { useRef, useState, useCallback, useEffect, useMemo, type ChangeEvent } f
 import { Editor } from '@monaco-editor/react'
 import type * as Monaco from 'monaco-editor'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
+
+function getSystemPrefersDark(): boolean {
+  return window.matchMedia?.('(prefers-color-scheme: dark)')?.matches ?? false
+}
+
+function useMonacoTheme(): 'vs-dark' | 'vs' {
+  const theme = useAppSelector((s) => s.settings.settings.theme)
+  const isDark =
+    theme === 'dark' ? true : theme === 'light' ? false : getSystemPrefersDark()
+  return isDark ? 'vs-dark' : 'vs'
+}
 import { updatePaneContent } from '@/store/panesSlice'
 import type { EditorPaneContent } from '@/store/paneTypes'
 import EditorToolbar from './EditorToolbar'
@@ -138,6 +149,7 @@ export default function EditorPane({
   viewMode = 'source',
 }: EditorPaneProps) {
   const dispatch = useAppDispatch()
+  const monacoTheme = useMonacoTheme()
   const layout = useAppSelector((s) => s.panes.layouts[tabId])
   const defaultCwd = useAppSelector((s) => s.settings.settings.defaultCwd)
   const mountedRef = useRef(true)
@@ -745,7 +757,7 @@ export default function EditorPane({
             height="100%"
             language={editorLanguage}
             value={editorValue}
-            theme="vs-dark"
+            theme={monacoTheme}
             onMount={handleEditorMount}
             onChange={handleEditorChange}
             options={{

--- a/test/unit/client/components/panes/EditorPane.test.tsx
+++ b/test/unit/client/components/panes/EditorPane.test.tsx
@@ -20,9 +20,10 @@ vi.mock('@/components/markdown/LazyMarkdown', async () => {
 
 // Mock Monaco to avoid loading issues in tests
 vi.mock('@monaco-editor/react', () => {
-  const MonacoMock = ({ value, onChange }: any) => (
+  const MonacoMock = ({ value, onChange, theme }: any) => (
     <textarea
       data-testid="monaco-mock"
+      data-theme={theme}
       value={value}
       onChange={(e: any) => onChange?.(e.target.value)}
     />
@@ -77,12 +78,29 @@ function createRoutedFetch(opts?: {
   }
 }
 
-const createMockStore = () =>
+const createMockStore = (overrides?: { theme?: string }) =>
   configureStore({
     reducer: {
       panes: panesReducer,
       settings: settingsReducer,
     },
+    preloadedState: overrides
+      ? {
+          settings: {
+            settings: {
+              theme: overrides.theme ?? 'system',
+              defaultCwd: '',
+              uiScale: 1.0,
+              terminal: { fontSize: 16 },
+              sidebar: { canarySubstrings: [] },
+              codingCli: { theme: 'auto' },
+              tabs: {},
+              logging: {},
+              agentChat: { providers: {} },
+            },
+          },
+        }
+      : undefined,
   })
 
 describe('EditorPane', () => {
@@ -574,6 +592,46 @@ describe('EditorPane', () => {
         expect.stringContaining('/api/files/read'),
         expect.any(Object)
       )
+    })
+  })
+
+  describe('theme', () => {
+    it('uses vs-dark theme when settings theme is dark', () => {
+      const darkStore = createMockStore({ theme: 'dark' })
+      render(
+        <Provider store={darkStore}>
+          <EditorPane
+            paneId="pane-1"
+            tabId="tab-1"
+            filePath="/test.ts"
+            language="typescript"
+            readOnly={false}
+            content="const x = 1"
+            viewMode="source"
+          />
+        </Provider>
+      )
+
+      expect(screen.getByTestId('monaco-mock').getAttribute('data-theme')).toBe('vs-dark')
+    })
+
+    it('uses vs (light) theme when settings theme is light', () => {
+      const lightStore = createMockStore({ theme: 'light' })
+      render(
+        <Provider store={lightStore}>
+          <EditorPane
+            paneId="pane-1"
+            tabId="tab-1"
+            filePath="/test.ts"
+            language="typescript"
+            readOnly={false}
+            content="const x = 1"
+            viewMode="source"
+          />
+        </Provider>
+      )
+
+      expect(screen.getByTestId('monaco-mock').getAttribute('data-theme')).toBe('vs')
     })
   })
 })


### PR DESCRIPTION
## Summary

- Monaco editor panes were hardcoded to `vs-dark` theme regardless of the app's light/dark mode setting
- Now reads the theme from Redux settings store and resolves to `vs-dark` or `vs` (light) accordingly
- Uses the same theme resolution logic as `useThemeEffect` (respects dark/light/system settings)

Fixes #144

## Changes

- `src/components/panes/EditorPane.tsx`: Added `useMonacoTheme()` hook that reads the settings theme and returns the correct Monaco theme string
- `test/unit/client/components/panes/EditorPane.test.tsx`: Added tests verifying dark and light theme rendering, updated Monaco mock to capture theme prop

## Test plan

- [x] `npm run typecheck` passes
- [x] All 20 EditorPane tests pass (including 2 new theme tests)
- [ ] Manual: Toggle app between light and dark mode, verify editor pane follows

This contribution was developed with AI assistance (Claude Code).