### PR TITLE
release: v0.7.0 housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,24 @@
 
 ## Features
 
-- **Tabs and panes** — Organize projects with multiple coding agents, shells, browsers, editors, and more on a tab - and as many tabs as you want. 
+- **Tabs and panes** — Organize projects with multiple coding agents, shells, browsers, editors, and more on a tab - and as many tabs as you want.
 - **Desktop, laptop, phone** — Run on your main machine, then work on your project anywhere via VPN or Tailscale.
 - **Speak with the dead** — Resume any Claude, Codex, or OpenCode session from any device (even if you weren't using freshell to run it)
 - **Fancy tabs** — Auto-name from terminal content, drag-and-drop reorder, and per-pane type icons so you know what's in each tab
-- **Freshclaude** — An interactive alternative to Claude CLI that works with your Anthropic subscription.
+- **Freshclaude** — An interactive alternative to Claude CLI that works with your Anthropic subscription. Rich chat UI with collapsible tool strips, token budget display, and full session persistence.
+- **Extension system** — Add new pane types, CLI integrations, and server-side services via manifest-based extensions. Enable and disable from the Extensions management page.
 - **Self-configuring workspace** — Just ask Claude or Codex to open a browser in a pane, or create a tab with four subagents. Built-in tmux-like API and skill makes it simple.
 - **Live pane headers** — See your active directory, git branch, and context usage in every pane title bar, updating live as you work
 - **Activity notifications** — Configurable attention indicators (highlight, pulse, darken) on tabs and pane headers when a coding CLI finishes its turn, with click or type dismiss modes
+- **AI-powered session titles** — Right-click any session and generate a Gemini-powered title based on conversation content
+- **Progressive sidebar search** — Two-phase search with instant local results followed by deep server-side content search
 - **Mobile responsive** — Auto-collapsing sidebar and overlay navigation for phones and tablets
 
 ## Quick Start
 
 ```bash
 # Clone the repository at the latest stable release
-git clone --branch v0.6.0 https://github.com/danshapiro/freshell.git
+git clone --branch v0.7.0 https://github.com/danshapiro/freshell.git
 cd freshell
 
 # Install dependencies

--- a/docs/index.html
+++ b/docs/index.html
@@ -530,6 +530,11 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
                   <span class="picker-label">Shell</span>
                   <span class="picker-shortcut">S</span>
                 </button>
+                <button class="picker-option">
+                  <i data-lucide="message-circle" class="picker-lucide"></i>
+                  <span class="picker-label">Freshclaude</span>
+                  <span class="picker-shortcut">F</span>
+                </button>
               </div>
             </div>
           </div>
@@ -774,7 +779,7 @@ const content = {
   welcome: [
     { typed: true, prompt: P, command: 'freshell', delay: 700 },
     { html: '' },
-    { html: '  🐚🔥 <span class="t-bold">freshell</span> <span class="t-dim">v0.4.1</span>', delay: 60 },
+    { html: '  🐚🔥 <span class="t-bold">freshell</span> <span class="t-dim">v0.7.0</span>', delay: 60 },
     { html: '  <span class="t-dim">Self-hosted browser terminal multiplexer</span>', delay: 60 },
     { html: '', delay: 200 },
     { html: '  <span class="t-success">✓</span> Multi-tab terminal management', delay: 50 },
@@ -785,6 +790,12 @@ const content = {
     { html: '  <span class="t-success">✓</span> Session history &amp; AI summaries', delay: 50 },
     { html: '  <span class="t-success">✓</span> Remote tab copies keep layout and reconnect safely on this machine', delay: 50 },
     { html: '  <span class="t-success">✓</span> Remote access with setup wizard &amp; QR code', delay: 50 },
+    { html: '  <span class="t-success">✓</span> Extension system for custom pane types', delay: 50 },
+    { html: '  <span class="t-success">✓</span> AI-powered session titles', delay: 50 },
+    { html: '  <span class="t-success">✓</span> Progressive sidebar search', delay: 50 },
+    { html: '  <span class="t-success">✓</span> Keyboard shortcuts dialog (Alt+T, Alt+W)', delay: 50 },
+    { html: '  <span class="t-success">✓</span> Personalized sidebar per device', delay: 50 },
+    { html: '  <span class="t-success">✓</span> Freshclaude rich chat UI', delay: 50 },
     { html: '', delay: 300 },
     { html: '  <span class="t-dim">Your coding CLIs, organized in the browser.</span>', delay: 80 },
     { html: '  <span class="t-dim">GitHub:</span> <a href="https://github.com/danshapiro/freshell" target="_blank" class="t-blue">https://github.com/danshapiro/freshell</a>', delay: 80 },
@@ -876,7 +887,7 @@ const content = {
     { html: '<span class="t-dim"># Start the server</span>', delay: 100 },
     { typed: true, prompt: P, command: 'freshell --port 3000', delay: 600 },
     { html: '', delay: 400 },
-    { html: '🐚🔥 <span class="t-bold">freshell</span> <span class="t-dim">v0.4.1</span>', delay: 60 },
+    { html: '🐚🔥 <span class="t-bold">freshell</span> <span class="t-dim">v0.7.0</span>', delay: 60 },
     { html: '', delay: 200 },
     { html: '<span class="t-dim">Open your browser to connect.</span>', delay: 80 },
     { html: '<span class="t-dim">Run</span> <span class="t-cyan">freshell --help</span> <span class="t-dim">for more options.</span>', delay: 100 },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freshell",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "bin": {
     "freshell": "dist/server/cli/index.js"


### PR DESCRIPTION
## Summary

- Bump version to 0.7.0 in package.json
- Update README: clone tag v0.6.0 → v0.7.0, add Extension system, AI-powered session titles, and Progressive sidebar search to Features
- Update homepage (docs/index.html): v0.4.1 → v0.7.0, add 6 new features to startup checklist, add Freshclaude to pane picker

Cherry-picked from the v0.7.0 tag onto current main.

## Test plan

- [ ] Verify homepage renders correctly at freshell.net after merge
- [ ] Confirm `git clone --branch v0.7.0` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)