### PR TITLE
feat(agent-chat): use full pane width instead of constrained prose width

### DIFF
--- a/src/components/agent-chat/AgentChatView.tsx
+++ b/src/components/agent-chat/AgentChatView.tsx
@@ -569,7 +569,7 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
 
       {/* Message area wrapper (relative for scroll-to-bottom button positioning) */}
       <div className="relative flex-1 min-h-0">
-      <div ref={scrollContainerRef} onScroll={handleScroll} className="h-full overflow-y-auto px-3 py-3 space-y-2" data-context="agent-chat" data-session-id={paneContent.sessionId}>
+      <div ref={scrollContainerRef} onScroll={handleScroll} className="h-full overflow-y-auto overflow-x-auto px-3 py-3 space-y-2" data-context="agent-chat" data-session-id={paneContent.sessionId}>
         {/* Restoring: persisted sessionId but history not yet loaded (reload/back-nav).
              Falls back to welcome screen after timeout (e.g. server restarted, session lost). */}
         {isRestoring && !restoreTimedOut && (

--- a/src/components/agent-chat/MessageBubble.tsx
+++ b/src/components/agent-chat/MessageBubble.tsx
@@ -174,7 +174,7 @@ function MessageBubble({
   return (
     <div
       className={cn(
-        'max-w-prose pl-2.5 py-0.5 text-sm',
+        'w-full pl-2.5 py-0.5 text-sm',
         resolvedSpeaker === 'user'
           ? 'border-l-[3px] border-l-[hsl(var(--claude-user))]'
           : 'border-l-2 border-l-[hsl(var(--claude-assistant))]'

--- a/src/components/agent-chat/ThinkingIndicator.tsx
+++ b/src/components/agent-chat/ThinkingIndicator.tsx
@@ -15,7 +15,7 @@ function ThinkingIndicator() {
 
   return (
     <div
-      className="max-w-prose border-l-2 border-l-[hsl(var(--claude-assistant))] pl-2.5 py-0.5"
+      className="w-full border-l-2 border-l-[hsl(var(--claude-assistant))] pl-2.5 py-0.5"
       role="status"
       aria-label="Claude is thinking"
     >

--- a/test/unit/client/components/agent-chat/MessageBubble.test.tsx
+++ b/test/unit/client/components/agent-chat/MessageBubble.test.tsx
@@ -50,12 +50,12 @@ describe('MessageBubble', () => {
     expect(article.className).toContain('border-l-2')
   })
 
-  it('constrains content width with max-w-prose', () => {
+  it('fills available width with w-full (matches CLI behavior)', () => {
     const { container } = render(
       <MessageBubble role="assistant" content={[{ type: 'text', text: 'Hello' }]} />
     )
     const article = container.querySelector('[role="article"]')!
-    expect(article.className).toContain('max-w-prose')
+    expect(article.className).toContain('w-full')
   })
 
   it('uses compact vertical padding for denser FreshClaude messages', () => {


### PR DESCRIPTION
## Summary
- Freshclaude content now fills the available pane width, matching Claude Code CLI behavior
- Previously content was constrained to ~65 characters via `max-w-prose` regardless of actual pane/window width
- Added `overflow-x-auto` to scroll container for wide content (tables, long lines)

## Changes
- `MessageBubble.tsx`: `max-w-prose` → `w-full`
- `ThinkingIndicator.tsx`: `max-w-prose` → `w-full`  
- `AgentChatView.tsx`: added `overflow-x-auto` to scroll container
- Updated test to verify full-width behavior

## Testing
- All 229 tests pass (213 unit + 16 e2e)
- Typecheck and lint clean