### PR TITLE
fix: set LANG and LC_ALL to ensure UTF-8 encoding in spawned terminals

### DIFF
--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -687,6 +687,8 @@ export function buildSpawnSpec(
     ...parentEnv,
     TERM: process.env.TERM || 'xterm-256color',
     COLORTERM: process.env.COLORTERM || 'truecolor',
+    LANG: 'en_US.UTF-8',
+    LC_ALL: 'en_US.UTF-8',
     ...envOverrides,
   }
 

--- a/test/unit/server/terminal-registry.test.ts
+++ b/test/unit/server/terminal-registry.test.ts
@@ -1067,6 +1067,18 @@ describe('buildSpawnSpec Unix paths', () => {
       expect(spec.env.COLORTERM).toBe('24bit')
     })
 
+    it('includes LANG environment variable for UTF-8 encoding', () => {
+      const spec = buildSpawnSpec('shell', '/Users/john', 'system')
+
+      expect(spec.env.LANG).toBe('en_US.UTF-8')
+    })
+
+    it('includes LC_ALL environment variable for UTF-8 encoding', () => {
+      const spec = buildSpawnSpec('shell', '/Users/john', 'system')
+
+      expect(spec.env.LC_ALL).toBe('en_US.UTF-8')
+    })
+
     it('passes through other environment variables', () => {
       process.env.MY_CUSTOM_VAR = 'test-value'
 
@@ -2718,6 +2730,18 @@ describe('buildSpawnSpec Unix paths', () => {
       const spec = buildSpawnSpec('shell', '/Users/john', 'system')
 
       expect(spec.env.COLORTERM).toBe('24bit')
+    })
+
+    it('includes LANG environment variable for UTF-8 encoding', () => {
+      const spec = buildSpawnSpec('shell', '/Users/john', 'system')
+
+      expect(spec.env.LANG).toBe('en_US.UTF-8')
+    })
+
+    it('includes LC_ALL environment variable for UTF-8 encoding', () => {
+      const spec = buildSpawnSpec('shell', '/Users/john', 'system')
+
+      expect(spec.env.LC_ALL).toBe('en_US.UTF-8')
     })
 
     it('passes through other environment variables', () => {


### PR DESCRIPTION
## Summary
- Adds `LANG=en_US.UTF-8` and `LC_ALL=en_US.UTF-8` to the environment of all spawned terminals
- Fixes xterm.js parsing errors (code 65533 / U+FFFD replacement character) caused by non-UTF-8 output from child processes

## Root Cause
The `buildSpawnSpec` function was setting `TERM` and `COLORTERM` but not locale environment variables. When the parent environment lacks UTF-8 locale settings, child terminals may use a different encoding. node-pty then decodes non-UTF-8 bytes as UTF-8, producing replacement characters that cause xterm.js parsing errors.