### PR TITLE
fix(mcp): validate params and reject unknown parameters with helpful hints

### DIFF
--- a/server/mcp/freshell-tool.ts
+++ b/server/mcp/freshell-tool.ts
@@ -750,8 +750,13 @@ async function routeAction(
         // For screenshot aliases, inject scope from the alias name
         if (action.startsWith('screenshot-')) {
           const scope = action.replace('screenshot-', '')
-          return routeAction(resolved, { ...params, scope })
+          const mergedParams = { ...params, scope }
+          const aliasParamError = validateParams(resolved, mergedParams)
+          if (aliasParamError) return aliasParamError
+          return routeAction(resolved, mergedParams)
         }
+        const aliasParamError = validateParams(resolved, params)
+        if (aliasParamError) return aliasParamError
         return routeAction(resolved, params)
       }
       return {

--- a/test/unit/server/mcp/freshell-tool.test.ts
+++ b/test/unit/server/mcp/freshell-tool.test.ts
@@ -1177,11 +1177,23 @@ describe('executeAction -- parameter validation', () => {
     expect(mockClient.post).toHaveBeenCalledWith('/api/tabs', expect.objectContaining({ name: 'Work', mode: 'claude' }))
   })
 
-  it('action without params schema (tmux alias) skips validation', async () => {
-    mockClient.post.mockResolvedValue({ id: 't1' })
+  it('tmux alias validates params against the resolved action', async () => {
     const result = await executeAction('new-window', { unknownParam: 'value' })
-    // new-window is a tmux alias, not in ACTION_PARAMS directly, so no validation
+    expect(result).toHaveProperty('error')
+    expect(result.error).toContain('unknownParam')
+  })
+
+  it('tmux alias with valid params routes through', async () => {
+    mockClient.post.mockResolvedValue({ id: 't1' })
+    const result = await executeAction('new-window', { name: 'Work', mode: 'claude' })
     expect(result).not.toHaveProperty('error')
+    expect(mockClient.post).toHaveBeenCalledWith('/api/tabs', expect.objectContaining({ name: 'Work', mode: 'claude' }))
+  })
+
+  it('tmux alias surfaces common confusion hints', async () => {
+    const result = await executeAction('new-window', { url: 'https://example.com' })
+    expect(result).toHaveProperty('error')
+    expect(result.error).toContain('open-browser')
   })
 
   it('empty params on paramless action succeeds', async () => {


### PR DESCRIPTION
## Summary
- MCP tool now validates parameters against a known-schema per action and returns errors with valid-param hints when unknown params are passed
- Specific cross-action confusion detection (e.g. `url` on `new-tab` suggests `open-browser`)
- Help text updated to clarify `new-tab` vs `open-browser` distinction, with a new "Open a URL" playbook

## Test plan
- 8 new unit tests covering: unknown param rejection, specific confusion hints, multiple unknown params, valid param passthrough, tmux alias bypass, and help text content
- Full suite passes (2888+ tests)