### PR TITLE
[codex] add required client typecheck workflow

### DIFF
--- a/.github/workflows/typecheck-client.yml
+++ b/.github/workflows/typecheck-client.yml
@@ -1,0 +1,32 @@
+name: Typecheck Client
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: typecheck-client-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck-client:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run client typecheck
+        run: npm run typecheck:client

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -6,6 +6,7 @@
 
 | Command | Purpose |
 |---------|---------|
+| `npm run typecheck:client` | Cheap client-only compile gate; safe while prod is live |
 | `npm test` | Coordinated full suite (`vitest run` plus `vitest run --config vitest.server.config.ts`) |
 | `npm run test:all` | Alias for the same coordinated full suite |
 | `npm run check` | Run `typecheck`, then the coordinated full suite |
@@ -31,12 +32,14 @@
 
 1. Run `npm run test:status` if you need to know whether another agent is already holding the coordinated gate.
 2. Set `FRESHELL_TEST_SUMMARY="why this run matters"` before broad runs so holder/status output is readable.
-3. Use the narrowest truthful public command you can.
-4. If another holder is active, wait rather than killing a foreign process.
+3. Use `npm run typecheck:client` when you only need the cheap frontend compile gate.
+4. Use the narrowest truthful public command you can.
+5. If another holder is active, wait rather than killing a foreign process.
 
 ## Focused Examples
 
 ```bash
+npm run typecheck:client
 FRESHELL_TEST_SUMMARY="Verify coordinated full suite" npm test
 npm run test:server -- --help
 npm run test:server -- --run


### PR DESCRIPTION
## Summary

- add a dedicated GitHub Actions workflow that runs `npm run typecheck:client` on every pull request and pushes to `main`
- document `npm run typecheck:client` as the cheap client-side compile gate in the testing skill docs
- keep the new gate separate from the full coordinated suite so it can be marked required without forcing the expensive path

## Why

A recent regression made it through `npm test` because the behavior tests were green while TypeScript still rejected the code. The missing safety net was the cheap client-only compile gate: `npm run typecheck:client` catches those issues in about eight seconds, versus roughly ninety-five seconds for `npm run check`.

## Impact

- pull requests get a fast frontend compile signal early
- branch protection can require a cheap, low-friction gate instead of the full suite
- the existing `npm test` and `npm run check` workflows remain available for broader verification

## Validation

- parsed `.github/workflows/typecheck-client.yml` with PyYAML
- `git diff --check`
