### PR TITLE
fix: image paste support for Codex CLI terminal panes

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -1207,6 +1207,22 @@ export default function TerminalView({ tabId, paneId, paneContent, hidden }: Ter
       }
     })
 
+    // When the clipboard contains an image but no text, the browser paste event
+    // fires but xterm has nothing to write. CLI tools like Codex listen for the
+    // raw Ctrl+V byte (\x16) to trigger a native clipboard read. Send it so
+    // image paste works for CLIs running inside the terminal.
+    const xtermTextarea = term.textarea
+    const handleImagePaste = (e: ClipboardEvent) => {
+      const hasText = e.clipboardData?.types.includes('text/plain')
+      const hasImage = Array.from(e.clipboardData?.items ?? []).some(
+        (item) => item.kind === 'file' && item.type.startsWith('image/'),
+      )
+      if (hasImage && !hasText) {
+        sendInput('\x16')
+      }
+    }
+    xtermTextarea?.addEventListener('paste', handleImagePaste)
+
     term.attachCustomKeyEventHandler((event) => {
       if (
         event.ctrlKey &&
@@ -1290,6 +1306,7 @@ export default function TerminalView({ tabId, paneId, paneContent, hidden }: Ter
         delete wrapperEl.dataset.hoveredUrl
       }
       ro.disconnect()
+      xtermTextarea?.removeEventListener('paste', handleImagePaste)
       unregisterActions()
       unregisterCaptureHandler()
       if (writeQueueRef.current === writeQueue) {


### PR DESCRIPTION
## Summary
- When pasting an image (no text on clipboard), sends the raw `\x16` byte to the PTY so CLI tools that use it as their clipboard-read trigger can detect the paste
- Fixes image paste for Codex CLI and any other CLI that relies on the Ctrl+V byte rather than clipboard polling
- No change in behavior for text paste or CLIs that already work (Claude, OpenCode)

Fixes #262

## Test plan
- [ ] Copy an image to clipboard, Cmd+V in Codex CLI pane → should show `[Image #1]`
- [ ] Copy an image to clipboard, Cmd+V in Claude CLI pane → should still work as before
- [ ] Copy text to clipboard, Cmd+V in any terminal pane → should paste text normally (no `\x16` sent)
- [ ] Verify no regression with Ctrl+V text paste in shell pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)