### PR TITLE
fix: correct false non-interactive classification for large sessions

### DIFF
--- a/server/coding-cli/session-indexer.ts
+++ b/server/coding-cli/session-indexer.ts
@@ -66,7 +66,9 @@ export async function scanFileForUserTextMessages(filePath: string): Promise<boo
       while (position < stat.size) {
         const readSize = Math.min(chunkSize + USER_TEXT_PATTERN.length, stat.size - position)
         const { bytesRead } = await fd.read(buf, 0, readSize, position)
-        let offset = 0
+        // Skip byte 0 on non-first chunks — it was already the last scannable
+        // position in the previous chunk's overlap region.
+        let offset = position > 0 ? 1 : 0
         while (offset < bytesRead) {
           const idx = buf.indexOf(USER_TEXT_PATTERN, offset)
           if (idx === -1 || idx >= bytesRead) break

--- a/test/unit/server/coding-cli/scan-user-text-messages.test.ts
+++ b/test/unit/server/coding-cli/scan-user-text-messages.test.ts
@@ -110,6 +110,26 @@ describe('scanFileForUserTextMessages', () => {
     expect(await scanFileForUserTextMessages(filePath)).toBe(true)
   })
 
+  it('does not double-count a pattern at an exact chunk boundary', async () => {
+    // Place a single user text message so the target byte pattern starts at
+    // exactly byte 64KB — the overlap position scanned by both adjacent chunks.
+    const chunkSize = 64 * 1024
+    const filePath = path.join(tempDir, 'boundary.jsonl')
+    const pattern = '"role":"user","content":"'
+    // Build a user message line, then figure out where the pattern sits inside it
+    const userLine = userTextMessage('Only message')
+    const patternOffsetInLine = userLine.indexOf(pattern)
+    // Pad so that (padding + \n + patternOffsetInLine) = chunkSize
+    const prefixLength = chunkSize - 1 - patternOffsetInLine // -1 for \n separator
+    const padding = 'x'.repeat(prefixLength)
+    const content = padding + '\n' + userLine
+    // Sanity-check alignment
+    expect(content.indexOf(pattern)).toBe(chunkSize)
+    await fsp.writeFile(filePath, content)
+    // Only one text user message — must return false, not double-count
+    expect(await scanFileForUserTextMessages(filePath)).toBe(false)
+  })
+
   it('returns false for nonexistent file', async () => {
     const filePath = path.join(tempDir, 'nonexistent.jsonl')
     expect(await scanFileForUserTextMessages(filePath)).toBe(false)


### PR DESCRIPTION
## Summary

- Large Claude sessions (>256KB) could be incorrectly classified as non-interactive when all text user messages fall outside the head+tail snippet window
- Adds a fast byte-level scan fallback: when snippet-based enrichment marks a truncated session as non-interactive, scans the full file for `"role":"user","content":"` patterns
- If >1 text user message is found, overrides the non-interactive classification so the session appears in the default sidebar

## Root cause

Session enrichment reads a 256KB snippet (128KB head + 128KB tail) for performance. The Claude provider counts user messages with text content (not tool_result arrays) and classifies sessions with ≤1 text user message as non-interactive. In sessions with heavy tool use, all text user messages can fall in the middle of the file outside the snippet window, causing false classification.

## Test plan

- [x] Unit tests for `scanFileForUserTextMessages` covering:
  - Empty files, single message, multiple messages
  - Tool result messages not counted
  - Pattern spanning chunk boundaries (>64KB)
  - Nonexistent file graceful handling
- [x] Full test suite passes (2 pre-existing WSL-only failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)