### PR TITLE
feat: track OpenCode busy and finished activity

### DIFF
--- a/docs/plans/2026-04-05-opencode-busy-finished-status.md
+++ b/docs/plans/2026-04-05-opencode-busy-finished-status.md
@@ -1,0 +1,563 @@
+# OpenCode Busy/Finished Status Implementation Plan
+
+> **For Claude:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Freshell reflect OpenCode terminal busy vs finished state reliably by using OpenCode's own localhost status API from spawn time through websocket delivery to the UI.
+
+**Architecture:** Each OpenCode terminal must be launched with an explicit localhost control endpoint that is threaded through `providerSettings.opencodeServer`, not through a new positional `buildSpawnSpec()` parameter. `providerSettings` already flows from async callsites into `buildSpawnSpec()` and then `resolveCodingCliCommand()`, and `resolveCodingCliCommand()` is the only seam that feeds Unix, WSL, `cmd.exe`, and PowerShell launch paths. Server-side tracking should use OpenCode's documented `/global/health`, `/session/status`, and per-instance `/event` SSE stream as the authoritative busy source. Do not parse terminal output for busy or finished state, and do not add heuristic fallbacks.
+
+**Verified upstream contract:**
+- OpenCode CLI docs show `--hostname` and `--port` on the TUI entrypoint, which is what Freshell launches for `mode === 'opencode'`: <https://opencode.ai/docs/cli/>
+- OpenCode server docs show:
+  - `GET /global/health`
+  - `GET /session/status`
+  - `GET /event`
+  - `GET /doc` for the OpenAPI spec
+  - `GET /global/event` also exists, but it is the global wrapper stream and is not needed for one Freshell terminal talking to one OpenCode instance: <https://opencode.ai/docs/server/>
+- OpenCode's generated SDK types define:
+  - `SessionStatus = { type: "idle" } | { type: "retry", ... } | { type: "busy" }`
+  - `EventSessionStatus = { type: "session.status", properties: { sessionID, status } }`
+  - `EventSessionIdle = { type: "session.idle", properties: { sessionID } }`
+  - `EventServerConnected = { type: "server.connected", ... }`
+  Source: <https://raw.githubusercontent.com/anomalyco/opencode/refs/heads/dev/packages/sdk/js/src/gen/types.gen.ts>
+
+**Implementation note:** If the launched OpenCode instance's `/doc` output disagrees with the upstream docs above, stop and update this plan plus the contract tests before proceeding.
+
+**Tech Stack:** Node.js, Express, ws, Redux Toolkit, React 18, Vitest, Testing Library, supertest, OpenCode CLI local server endpoints.
+
+---
+
+## File Structure
+
+**Create**
+- `server/local-port.ts`
+  Async helper that allocates an ephemeral localhost port for OpenCode launch callsites.
+- `server/coding-cli/opencode-activity-tracker.ts`
+  Server-side monitor that waits for health, snapshots current busy state, consumes the OpenCode SSE event stream, and emits normalized `{ upsert, remove }` changes per terminal.
+- `server/coding-cli/opencode-activity-wiring.ts`
+  Lifecycle glue between `TerminalRegistry` events and `OpencodeActivityTracker`.
+- `src/store/opencodeActivitySlice.ts`
+  Redux slice mirroring the snapshot and mutation ordering protections already used by `codexActivity`.
+- `test/unit/server/coding-cli/opencode-activity-tracker.test.ts`
+  Unit coverage for health wait, snapshot bootstrap, idle removal, reconnect backoff, and terminal teardown.
+- `test/server/ws-opencode-activity.test.ts`
+  WebSocket protocol coverage for list and update messages.
+- `test/unit/client/store/opencodeActivitySlice.test.ts`
+  Reducer coverage for stale snapshot ordering, upsert/remove mutation ordering, and reset behavior.
+
+**Modify**
+- `server/terminal-registry.ts`
+  Extend `ProviderSettings` with `opencodeServer`, require it for OpenCode launches, inject `--hostname` and `--port` inside `resolveCodingCliCommand()`, and store the endpoint on terminal records.
+- `server/ws-handler.ts`
+  Allocate OpenCode control ports before `registry.create()`, merge them into `providerSettings`, serve `opencode.activity.list`, and broadcast `opencode.activity.updated`.
+- `server/agent-api/router.ts`
+  Allocate OpenCode control ports for `/tabs`, `/run`, split, and respawn routes before terminal creation and merge them into `providerSettings`.
+- `server/index.ts`
+  Construct the OpenCode tracker wiring, expose list snapshots to websocket clients, broadcast tracker mutations, and dispose the wiring on shutdown.
+- `shared/ws-protocol.ts`
+  Add `opencode.activity.list`, `opencode.activity.list.response`, and `opencode.activity.updated` schemas/types.
+- `src/store/store.ts`
+  Register the new `opencodeActivity` reducer.
+- `src/App.tsx`
+  Bootstrap the OpenCode activity snapshot, handle websocket deltas, and reset stale overlay state on reconnect/disconnect.
+- `src/lib/pane-activity.ts`
+  Treat exact-match OpenCode busy records as blue activity and include them in busy session-key collection.
+- `src/components/panes/PaneContainer.tsx`
+  Feed OpenCode activity into per-pane activity resolution.
+- `src/components/TabBar.tsx`
+  Feed OpenCode activity into busy-tab computation.
+- `src/components/TabSwitcher.tsx`
+  Feed OpenCode activity into mobile switcher busy badges.
+- `src/components/MobileTabStrip.tsx`
+  Feed OpenCode activity into the active-tab busy badge.
+- `src/components/Sidebar.tsx`
+  Feed OpenCode activity into busy session highlighting.
+- `test/unit/server/terminal-registry.test.ts`
+  Lock the OpenCode launch flags, provider-settings threading, and explicit-endpoint requirement.
+- `test/server/agent-tabs-write.test.ts`
+  Assert `/api/tabs` allocates and passes an OpenCode control endpoint.
+- `test/server/agent-run.test.ts`
+  Assert `/api/run` still works when the launched mode is `opencode`.
+- `test/unit/client/components/App.ws-bootstrap.test.tsx`
+  Cover OpenCode snapshot request, reset-on-ready, reset-on-disconnect, and stale snapshot ordering.
+- `test/unit/client/lib/pane-activity.test.ts`
+  Cover exact-match OpenCode busy semantics and busy session-key collection.
+- `test/unit/client/components/panes/PaneContainer.test.tsx`
+  Cover per-pane OpenCode busy resolution where pane runtime activity used to be the only source.
+- `test/unit/client/components/TabBar.test.tsx`
+  Cover OpenCode blue-tab behavior.
+- `test/unit/client/components/TabSwitcher.test.tsx`
+  Cover OpenCode busy badges in the switcher.
+- `test/unit/client/components/MobileTabStrip.test.tsx`
+  Cover OpenCode busy badge on the active mobile tab.
+- `test/unit/client/components/Sidebar.test.tsx`
+  Cover busy OpenCode session highlighting.
+- `test/e2e/pane-activity-indicator-flow.test.tsx`
+  Add an OpenCode pane/tab busy-indicator flow.
+- `test/e2e/opencode-startup-probes.test.tsx`
+  Guard against OpenCode startup regressions after adding control-port launch args.
+
+**Explicit non-goals**
+- No terminal-text parsing for busy/finished state.
+- No generic multi-provider activity refactor beyond small local helpers needed to avoid repetition.
+- No `docs/index.html` update unless the visible UX changes beyond the existing busy-indicator behavior.
+
+## Architectural Guardrails
+
+- OpenCode server state is authoritative. Use:
+  - `/global/health` to know when the embedded server is reachable.
+  - `/session/status` to seed the current busy snapshot.
+  - `/event` to receive live per-instance transitions. Ignore the initial `server.connected` event.
+- Do not use `/global/event` for this feature. It wraps events with `directory` and is unnecessary when a Freshell terminal owns exactly one OpenCode instance.
+- Normalize every non-idle OpenCode session status into a single UI-facing concept: `busy`.
+- Remove activity records when OpenCode reports idle, a resnapshot after reconnect no longer shows a busy session, or the terminal exits.
+- Require an explicit OpenCode control endpoint at spawn time. If it is missing, throw a clear error instead of silently falling back.
+- Preserve Codex behavior exactly. OpenCode is additive, not a rewrite of the Codex path.
+- Use concrete retry policy:
+  - health probe: poll every `200ms`, fail startup after `15_000ms`
+  - SSE reconnect: exponential backoff starting at `250ms`, doubling to a `5_000ms` cap, with small jitter
+  - stop retrying immediately once the terminal exits or the monitor is disposed
+
+## Chunk 1: Server Launch And Activity Authority
+
+### Task 1: Require And Pass An OpenCode Control Endpoint At Spawn Time
+
+**Files:**
+- Create: `server/local-port.ts`
+- Modify: `server/terminal-registry.ts`
+- Modify: `server/ws-handler.ts`
+- Modify: `server/agent-api/router.ts`
+- Test: `test/unit/server/terminal-registry.test.ts`
+- Test: `test/server/agent-tabs-write.test.ts`
+- Test: `test/server/agent-run.test.ts`
+
+- [ ] **Step 1: Write the failing launch-contract tests**
+
+```ts
+expect(buildSpawnSpec(
+  'opencode',
+  '/repo/app',
+  'system',
+  undefined,
+  {
+    opencodeServer: { hostname: '127.0.0.1', port: 43123 },
+  },
+  undefined,
+  'term-oc',
+).args).toEqual(expect.arrayContaining([
+  '--hostname', '127.0.0.1',
+  '--port', '43123',
+]))
+
+await request(app)
+  .post('/api/tabs')
+  .send({ mode: 'opencode', name: 'OpenCode' })
+
+expect(registry.create).toHaveBeenCalledWith(expect.objectContaining({
+  mode: 'opencode',
+  providerSettings: expect.objectContaining({
+    opencodeServer: {
+      hostname: '127.0.0.1',
+      port: expect.any(Number),
+    },
+  }),
+}))
+```
+
+- [ ] **Step 2: Run the focused server tests and verify they fail**
+
+Run: `npm run test:vitest -- test/unit/server/terminal-registry.test.ts test/server/agent-tabs-write.test.ts test/server/agent-run.test.ts`
+
+Expected: FAIL because OpenCode launch args do not include `--hostname`/`--port`, and OpenCode callsites do not pass `providerSettings.opencodeServer`.
+
+- [ ] **Step 3: Implement the minimal launch-path changes**
+
+```ts
+export type OpencodeServerEndpoint = {
+  hostname: '127.0.0.1'
+  port: number
+}
+
+type ProviderSettings = {
+  permissionMode?: string
+  model?: string
+  sandbox?: string
+  opencodeServer?: OpencodeServerEndpoint
+}
+
+if (mode === 'opencode') {
+  if (!providerSettings?.opencodeServer) {
+    throw new Error('OpenCode launch requires an allocated localhost control endpoint.')
+  }
+  settingsArgs.push(
+    '--hostname', providerSettings.opencodeServer.hostname,
+    '--port', String(providerSettings.opencodeServer.port),
+  )
+}
+```
+
+Implementation notes:
+- Keep `TerminalRegistry.create()` synchronous by allocating ports in async callsites before `registry.create(...)`.
+- Do not add a new positional parameter to `buildSpawnSpec()`.
+- Inject the OpenCode launch flags inside `resolveCodingCliCommand()`, because that command spec is what flows through Unix, WSL, `cmd.exe`, and PowerShell paths today.
+- Keep the hostname pinned to the IPv4 loopback literal `'127.0.0.1'` intentionally. Do not broaden this to `localhost` or `::1` without an explicit design change, because the goal here is a private, consistent, single-stack control endpoint across all shell launch paths.
+- Route callsites should merge the endpoint into existing provider settings, not replace them:
+
+```ts
+const providerSettings = await resolveProviderSettings(mode, configStore, overrides)
+const finalProviderSettings = mode === 'opencode'
+  ? { ...providerSettings, opencodeServer: await allocateLocalhostPort() }
+  : providerSettings
+```
+
+- Update direct OpenCode test fixtures that call `registry.create({ mode: 'opencode' })` or `buildSpawnSpec('opencode', ...)` to pass a stub endpoint under `providerSettings.opencodeServer`.
+
+- [ ] **Step 4: Run the focused server tests and verify they pass**
+
+Run: `npm run test:vitest -- test/unit/server/terminal-registry.test.ts test/server/agent-tabs-write.test.ts test/server/agent-run.test.ts`
+
+Expected: PASS with OpenCode routes explicitly allocating and forwarding a control endpoint through `providerSettings`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/local-port.ts server/terminal-registry.ts server/ws-handler.ts server/agent-api/router.ts test/unit/server/terminal-registry.test.ts test/server/agent-tabs-write.test.ts test/server/agent-run.test.ts
+git commit -m "feat: launch opencode with explicit control endpoint"
+```
+
+### Task 2: Track OpenCode Busy And Finished State From Its Own Server API
+
+**Files:**
+- Create: `server/coding-cli/opencode-activity-tracker.ts`
+- Create: `server/coding-cli/opencode-activity-wiring.ts`
+- Modify: `server/index.ts`
+- Modify: `shared/ws-protocol.ts`
+- Modify: `server/ws-handler.ts`
+- Test: `test/unit/server/coding-cli/opencode-activity-tracker.test.ts`
+- Test: `test/server/ws-opencode-activity.test.ts`
+
+- [ ] **Step 1: Write the failing tracker and websocket protocol tests**
+
+```ts
+expect(changes).toContainEqual({
+  upsert: [{
+    terminalId: 'term-oc',
+    sessionId: 'session-oc',
+    phase: 'busy',
+    updatedAt: expect.any(Number),
+  }],
+  remove: [],
+})
+
+ws.send(JSON.stringify({ type: 'opencode.activity.list', requestId: 'req-oc-1' }))
+const response = await waitForMessage(ws, (msg) => (
+  msg.type === 'opencode.activity.list.response' && msg.requestId === 'req-oc-1'
+))
+expect(response.terminals).toEqual(sampleActivity)
+```
+
+Add tracker cases for:
+- health endpoint not ready yet, then becoming healthy within `15_000ms`
+- startup timeout when `/global/health` never becomes healthy
+- initial `/session/status` showing one busy session
+- ignoring the initial `server.connected` SSE event
+- `session.status` with `busy` or `retry` upserting the record
+- `session.idle` or `session.status` with `idle` removing the record
+- `session.idle` for a different `sessionID` not clearing the currently tracked session
+- SSE disconnect followed by reconnect, backoff, resnapshot, and resubscribe
+- terminal exit removing monitor state and cancelling retry timers
+
+- [ ] **Step 2: Run the focused tracker tests and verify they fail**
+
+Run: `npm run test:vitest -- test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/server/ws-opencode-activity.test.ts`
+
+Expected: FAIL because no OpenCode tracker, websocket message types, or broadcasts exist.
+
+- [ ] **Step 3: Implement the tracker, wiring, and websocket contract**
+
+```ts
+type OpencodeActivityRecord = {
+  terminalId: string
+  sessionId?: string
+  phase: 'busy'
+  updatedAt: number
+}
+
+const HEALTH_POLL_MS = 200
+const HEALTH_TIMEOUT_MS = 15_000
+const RECONNECT_BASE_MS = 250
+const RECONNECT_MAX_MS = 5_000
+
+if (event.type === 'session.status' && event.properties.status.type !== 'idle') {
+  this.upsertBusy(terminalId, event.properties.sessionID, now())
+}
+
+if (event.type === 'session.idle' || (
+  event.type === 'session.status' && event.properties.status.type === 'idle'
+)) {
+  this.removeBusy(terminalId)
+}
+```
+
+Implementation notes:
+- Use one tracker monitor per OpenCode terminal record.
+- Start monitoring from `terminal.created` when `record.mode === 'opencode'` and `record.providerSettings?.opencodeServer` or equivalent stored endpoint data exists.
+- If current terminal records do not already retain provider settings, store only the endpoint data needed for runtime monitoring.
+- Validate the OpenCode SSE payload boundary with local Zod schemas before mutating tracker state. Unknown or malformed payloads should be logged and ignored, not trusted.
+- On reconnect, re-run `/session/status` before resubscribing to `/event`.
+- Back off reconnect attempts with capped exponential backoff plus jitter. Do not spin in a tight loop if OpenCode exits or crashes.
+- Only clear a busy record on idle if the event's `sessionID` matches the currently tracked session id, unless no session id is recorded yet.
+- Add websocket types:
+  - client: `opencode.activity.list`
+  - server: `opencode.activity.list.response`
+  - server: `opencode.activity.updated`
+- Mirror the existing Codex list/broadcast path instead of inventing a second transport pattern.
+- Log clear tracker failures with terminal id and endpoint, but do not invent a fallback busy detector.
+
+- [ ] **Step 4: Run the focused tracker tests and verify they pass**
+
+Run: `npm run test:vitest -- test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/server/ws-opencode-activity.test.ts`
+
+Expected: PASS with authenticated websocket updates, bounded reconnect behavior, and tracker removal on idle/exit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/coding-cli/opencode-activity-tracker.ts server/coding-cli/opencode-activity-wiring.ts server/index.ts shared/ws-protocol.ts server/ws-handler.ts test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/server/ws-opencode-activity.test.ts
+git commit -m "feat: track opencode activity from server events"
+```
+
+## Chunk 2: Client Activity Overlay And Busy Projection
+
+### Task 3: Add A Client-Side OpenCode Activity Overlay
+
+**Files:**
+- Create: `src/store/opencodeActivitySlice.ts`
+- Modify: `src/store/store.ts`
+- Modify: `src/App.tsx`
+- Test: `test/unit/client/store/opencodeActivitySlice.test.ts`
+- Test: `test/unit/client/components/App.ws-bootstrap.test.tsx`
+
+- [ ] **Step 1: Write the failing client-store and websocket-bootstrap tests**
+
+```ts
+store.dispatch(setOpencodeActivitySnapshot({
+  terminals: [{ terminalId: 'term-oc', sessionId: 'session-oc', phase: 'busy', updatedAt: 20 }],
+  requestSeq: 3,
+}))
+expect(store.getState().opencodeActivity.byTerminalId['term-oc']?.phase).toBe('busy')
+
+expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+  type: 'opencode.activity.list',
+}))
+```
+
+Add bootstrap cases for:
+- requesting `opencode.activity.list` after `ready`
+- clearing stale OpenCode activity when bootstrapping onto an already-ready socket
+- clearing OpenCode activity on disconnect
+- ignoring stale `opencode.activity.list.response` snapshots that arrive after newer mutations
+
+- [ ] **Step 2: Run the focused client bootstrap tests and verify they fail**
+
+Run: `npm run test:vitest -- test/unit/client/store/opencodeActivitySlice.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx`
+
+Expected: FAIL because the store has no `opencodeActivity` slice and `App.tsx` does not request or process OpenCode activity messages.
+
+- [ ] **Step 3: Implement the client overlay**
+
+```ts
+const opencodeActivitySlice = createSlice({
+  name: 'opencodeActivity',
+  initialState: createInitialState(),
+  reducers: {
+    setOpencodeActivitySnapshot,
+    upsertOpencodeActivity,
+    removeOpencodeActivity,
+    resetOpencodeActivity,
+  },
+})
+
+ws.send({ type: 'opencode.activity.list', requestId })
+
+if (msg.type === 'opencode.activity.updated') {
+  dispatch(upsertOpencodeActivity({ terminals: msg.upsert ?? [], mutationSeq }))
+  dispatch(removeOpencodeActivity({ terminalIds: msg.remove ?? [], mutationSeq }))
+}
+```
+
+Implementation notes:
+- Mirror the ordering protections from `codexActivitySlice.ts` instead of sharing provider state.
+- It is acceptable to extract a small local helper inside `src/App.tsx` to avoid copy-pasting the request/reset/snapshot bookkeeping for Codex and OpenCode.
+- Reset OpenCode overlay state in the same places Codex resets today: on `ready`, on explicit disconnect, and when bootstrapping onto a pre-ready socket.
+
+- [ ] **Step 4: Run the focused client bootstrap tests and verify they pass**
+
+Run: `npm run test:vitest -- test/unit/client/store/opencodeActivitySlice.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx`
+
+Expected: PASS with deterministic snapshot ordering and prompt reset behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/opencodeActivitySlice.ts src/store/store.ts src/App.tsx test/unit/client/store/opencodeActivitySlice.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx
+git commit -m "feat: add opencode activity client overlay"
+```
+
+### Task 4: Feed OpenCode Activity Into The Existing Busy Indicators
+
+**Files:**
+- Modify: `src/lib/pane-activity.ts`
+- Modify: `src/components/panes/PaneContainer.tsx`
+- Modify: `src/components/TabBar.tsx`
+- Modify: `src/components/TabSwitcher.tsx`
+- Modify: `src/components/MobileTabStrip.tsx`
+- Modify: `src/components/Sidebar.tsx`
+- Test: `test/unit/client/lib/pane-activity.test.ts`
+- Test: `test/unit/client/components/panes/PaneContainer.test.tsx`
+- Test: `test/unit/client/components/TabBar.test.tsx`
+- Test: `test/unit/client/components/TabSwitcher.test.tsx`
+- Test: `test/unit/client/components/MobileTabStrip.test.tsx`
+- Test: `test/unit/client/components/Sidebar.test.tsx`
+- Test: `test/e2e/pane-activity-indicator-flow.test.tsx`
+- Test: `test/e2e/opencode-startup-probes.test.tsx`
+
+- [ ] **Step 1: Write the failing busy-indicator tests**
+
+```ts
+expect(resolvePaneActivity({
+  paneId: 'pane-oc',
+  content: {
+    kind: 'terminal',
+    createRequestId: 'req-oc',
+    status: 'running',
+    mode: 'opencode',
+    shell: 'system',
+    terminalId: 'term-oc',
+    resumeSessionId: 'session-oc',
+  },
+  tabMode: 'opencode',
+  isOnlyPane: true,
+  codexActivityByTerminalId: {},
+  opencodeActivityByTerminalId: {
+    'term-oc': { terminalId: 'term-oc', sessionId: 'session-oc', phase: 'busy', updatedAt: 10 },
+  },
+  paneRuntimeActivityByPaneId: {},
+  agentChatSessions: {},
+})).toMatchObject({ isBusy: true, source: 'opencode' })
+```
+
+Add UI assertions for:
+- blue pane and tab icons for a busy OpenCode pane
+- busy badge in `PaneContainer`
+- busy badge in `TabSwitcher`
+- busy badge in `MobileTabStrip`
+- blue highlight for the matching OpenCode session in `Sidebar`
+- no false positives for shell or other providers
+- no selector-instability warnings when `opencodeActivity` state is absent
+
+- [ ] **Step 2: Run the focused UI tests and verify they fail**
+
+Run: `npm run test:vitest -- test/unit/client/lib/pane-activity.test.ts test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/TabBar.test.tsx test/unit/client/components/TabSwitcher.test.tsx test/unit/client/components/MobileTabStrip.test.tsx test/unit/client/components/Sidebar.test.tsx test/e2e/pane-activity-indicator-flow.test.tsx test/e2e/opencode-startup-probes.test.tsx`
+
+Expected: FAIL because the busy-indicator pipeline only reads Codex activity today.
+
+- [ ] **Step 3: Implement the busy-projection changes**
+
+```ts
+type PaneActivitySource =
+  | 'codex'
+  | 'opencode'
+  | 'claude-terminal'
+  | 'agent-chat'
+  | 'browser'
+
+if (effectiveMode === 'opencode') {
+  const record = input.content.terminalId
+    ? input.opencodeActivityByTerminalId[input.content.terminalId]
+    : undefined
+  return record?.phase === 'busy'
+    ? { isBusy: true, source: 'opencode' }
+    : IDLE_PANE_ACTIVITY
+}
+```
+
+Implementation notes:
+- Keep OpenCode semantics exact-match by `terminalId`, just like Codex.
+- Update all three pane-activity entry points, not just `resolvePaneActivity()`:
+  - `resolvePaneActivity()`
+  - `getBusyPaneIdsForTab()`
+  - `collectBusySessionKeys()`
+- Thread `opencodeActivityByTerminalId` into every component and selector path that already threads `codexActivityByTerminalId`.
+- Use the existing blue busy styles. This is a behavior fix, not a visual redesign.
+- `TerminalView.tsx` should remain unchanged unless a test proves a launch/startup regression caused by the new server flags.
+
+- [ ] **Step 4: Run the focused UI tests and verify they pass**
+
+Run: `npm run test:vitest -- test/unit/client/lib/pane-activity.test.ts test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/TabBar.test.tsx test/unit/client/components/TabSwitcher.test.tsx test/unit/client/components/MobileTabStrip.test.tsx test/unit/client/components/Sidebar.test.tsx test/e2e/pane-activity-indicator-flow.test.tsx test/e2e/opencode-startup-probes.test.tsx`
+
+Expected: PASS with OpenCode busy panes/tabs/sessions turning blue only while the server reports work in progress.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/pane-activity.ts src/components/panes/PaneContainer.tsx src/components/TabBar.tsx src/components/TabSwitcher.tsx src/components/MobileTabStrip.tsx src/components/Sidebar.tsx test/unit/client/lib/pane-activity.test.ts test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/TabBar.test.tsx test/unit/client/components/TabSwitcher.test.tsx test/unit/client/components/MobileTabStrip.test.tsx test/unit/client/components/Sidebar.test.tsx test/e2e/pane-activity-indicator-flow.test.tsx test/e2e/opencode-startup-probes.test.tsx
+git commit -m "feat: surface opencode busy state in ui"
+```
+
+## Chunk 3: Final Verification And Handoff
+
+### Task 5: Refactor, Verify Broadly, And Record Any Residual Risk
+
+**Files:**
+- Modify only if needed after refactor/test fallout.
+- Verify: `server/*`, `src/*`, `test/*`
+
+- [ ] **Step 1: Refactor any duplicated helper logic that the passing tests exposed**
+
+```ts
+function createActivityOverlayController(...) {
+  return {
+    requestList,
+    reset,
+    applySnapshot,
+    applyMutation,
+  }
+}
+```
+
+Refactor only if it clearly reduces duplication between Codex and OpenCode without changing behavior.
+
+- [ ] **Step 2: Run lint and all focused Vitest suites together**
+
+Run: `npm run lint`
+
+Run: `npm run test:vitest -- test/unit/server/terminal-registry.test.ts test/server/agent-tabs-write.test.ts test/server/agent-run.test.ts test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/server/ws-opencode-activity.test.ts test/unit/client/store/opencodeActivitySlice.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx test/unit/client/lib/pane-activity.test.ts test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/TabBar.test.tsx test/unit/client/components/TabSwitcher.test.tsx test/unit/client/components/MobileTabStrip.test.tsx test/unit/client/components/Sidebar.test.tsx test/e2e/pane-activity-indicator-flow.test.tsx test/e2e/opencode-startup-probes.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the coordinated full suite**
+
+Run: `npm run test:status`
+
+Run: `FRESHELL_TEST_SUMMARY="opencode busy/finished status" npm test`
+
+Expected: PASS across the repo-owned coordinated suite. If the coordinator is busy, wait instead of interrupting it.
+
+- [ ] **Step 4: Inspect for any residual risk and update the implementation notes if necessary**
+
+```md
+- Residual risk: the initial `15_000ms` health timeout may need tuning on very slow hosts.
+- Residual risk: if OpenCode changes its `/event` payload contract, the tracker should fail loudly in tests before it fails silently in production.
+- Residual risk: localhost port allocation still uses the normal bind-to-0 then close pattern, so there is a small TOCTOU race before OpenCode binds the chosen port.
+- No fallback path was added; failures should surface as clear launch or tracker errors.
+```
+
+If a real residual risk remains, document it in the final implementation summary and keep the error path explicit.
+
+- [ ] **Step 5: Commit the final verified state**
+
+```bash
+git add server/local-port.ts server/coding-cli/opencode-activity-tracker.ts server/coding-cli/opencode-activity-wiring.ts server/terminal-registry.ts server/ws-handler.ts server/agent-api/router.ts server/index.ts shared/ws-protocol.ts src/store/opencodeActivitySlice.ts src/store/store.ts src/App.tsx src/lib/pane-activity.ts src/components/panes/PaneContainer.tsx src/components/TabBar.tsx src/components/TabSwitcher.tsx src/components/MobileTabStrip.tsx src/components/Sidebar.tsx test/unit/server/terminal-registry.test.ts test/server/agent-tabs-write.test.ts test/server/agent-run.test.ts test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/server/ws-opencode-activity.test.ts test/unit/client/store/opencodeActivitySlice.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx test/unit/client/lib/pane-activity.test.ts test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/TabBar.test.tsx test/unit/client/components/TabSwitcher.test.tsx test/unit/client/components/MobileTabStrip.test.tsx test/unit/client/components/Sidebar.test.tsx test/e2e/pane-activity-indicator-flow.test.tsx test/e2e/opencode-startup-probes.test.tsx
+git commit -m "feat: wire opencode busy and finished status end to end"
+```

--- a/server/agent-api/router.ts
+++ b/server/agent-api/router.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import fs from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { nanoid } from 'nanoid'
+import { allocateLocalhostPort, type OpencodeServerEndpoint } from '../local-port.js'
 import { makeSessionKey } from '../coding-cli/types.js'
 import { MAX_TERMINAL_TITLE_OVERRIDE_LENGTH } from '../terminals-router.js'
 import { ok, approx, fail } from './response.js'
@@ -29,6 +30,24 @@ async function resolveProviderSettings(
     permissionMode: overrides.permissionMode ?? defaults.permissionMode,
     model: overrides.model ?? defaults.model,
     sandbox: overrides.sandbox ?? defaults.sandbox,
+  }
+}
+
+async function resolveSpawnProviderSettings(
+  mode: string,
+  configStore: any,
+  overrides: { permissionMode?: string; model?: string; sandbox?: string },
+): Promise<{
+  permissionMode?: string
+  model?: string
+  sandbox?: string
+  opencodeServer?: OpencodeServerEndpoint
+} | undefined> {
+  const providerSettings = await resolveProviderSettings(mode, configStore, overrides)
+  if (mode !== 'opencode') return providerSettings
+  return {
+    ...(providerSettings ?? {}),
+    opencodeServer: await allocateLocalhostPort(),
   }
 }
 
@@ -224,7 +243,7 @@ export function createAgentApiRouter({
         paneContent = { kind: 'editor', filePath: editor, language: null, readOnly: false, content: '', viewMode: 'source' }
       } else {
         const effectiveMode = mode || 'shell'
-        const providerSettings = await resolveProviderSettings(effectiveMode, configStore, { permissionMode, model, sandbox })
+        const providerSettings = await resolveSpawnProviderSettings(effectiveMode, configStore, { permissionMode, model, sandbox })
         const terminal = registry.create({
           mode: effectiveMode,
           shell,
@@ -551,7 +570,7 @@ export function createAgentApiRouter({
     const created = layoutStore.createTab?.({ title })
     const tabId = created?.tabId || nanoid()
     const paneId = created?.paneId || nanoid()
-    const providerSettings = await resolveProviderSettings(mode, configStore, {})
+    const providerSettings = await resolveSpawnProviderSettings(mode, configStore, {})
     const terminal = registry.create({ mode, shell, cwd, providerSettings, envContext: { tabId, paneId } })
     layoutStore.attachPaneContent?.(tabId, paneId, { kind: 'terminal', terminalId: terminal.terminalId })
     wsHandler?.broadcastUiCommand({
@@ -613,7 +632,7 @@ export function createAgentApiRouter({
       content = { kind: 'editor', filePath: req.body.editor, language: null, readOnly: false, content: '', viewMode: 'source' }
     } else {
       const splitMode = req.body?.mode || 'shell'
-      const splitProviderSettings = await resolveProviderSettings(splitMode, configStore, {})
+      const splitProviderSettings = await resolveSpawnProviderSettings(splitMode, configStore, {})
       const terminal = registry.create({
         mode: splitMode,
         shell: req.body?.shell,
@@ -800,7 +819,7 @@ export function createAgentApiRouter({
     const tabId = target?.tabId
     if (!tabId) return res.status(404).json(fail('pane not found'))
     const effectiveMode = req.body?.mode || 'shell'
-    const providerSettings = await resolveProviderSettings(effectiveMode, configStore, {})
+    const providerSettings = await resolveSpawnProviderSettings(effectiveMode, configStore, {})
     const terminal = registry.create({ mode: effectiveMode, shell: req.body?.shell, cwd: req.body?.cwd, providerSettings, envContext: { tabId, paneId } })
     const content = { kind: 'terminal', terminalId: terminal.terminalId, status: 'running', mode: req.body?.mode || 'shell', shell: req.body?.shell || 'system', createRequestId: nanoid() }
     layoutStore.attachPaneContent(tabId, paneId, content)

--- a/server/coding-cli/opencode-activity-tracker.ts
+++ b/server/coding-cli/opencode-activity-tracker.ts
@@ -1,0 +1,488 @@
+import { EventEmitter } from 'events'
+import { z } from 'zod'
+import type { OpencodeServerEndpoint } from '../local-port.js'
+import { logger } from '../logger.js'
+
+export const OPENCODE_HEALTH_POLL_MS = 200
+// Applies per health-wait cycle; connection failures restart the cycle after backoff.
+export const OPENCODE_HEALTH_TIMEOUT_MS = 15_000
+export const OPENCODE_RECONNECT_BASE_MS = 250
+export const OPENCODE_RECONNECT_MAX_MS = 5_000
+
+export type OpencodeActivityPhase = 'busy'
+
+export type OpencodeActivityRecord = {
+  terminalId: string
+  sessionId?: string
+  phase: OpencodeActivityPhase
+  updatedAt: number
+}
+
+export type OpencodeActivityChange = {
+  upsert: OpencodeActivityRecord[]
+  remove: string[]
+}
+
+const SessionIdleStatusSchema = z.object({
+  type: z.literal('idle'),
+}).passthrough()
+
+const SessionBusyStatusSchema = z.object({
+  type: z.literal('busy'),
+}).passthrough()
+
+const SessionRetryStatusSchema = z.object({
+  type: z.literal('retry'),
+}).passthrough()
+
+const SessionStatusSchema = z.discriminatedUnion('type', [
+  SessionIdleStatusSchema,
+  SessionBusyStatusSchema,
+  SessionRetryStatusSchema,
+])
+
+const SessionStatusMapSchema = z.record(z.string(), SessionStatusSchema)
+
+const ServerConnectedEventSchema = z.object({
+  type: z.literal('server.connected'),
+}).passthrough()
+
+const SessionStatusEventSchema = z.object({
+  type: z.literal('session.status'),
+  properties: z.object({
+    sessionID: z.string().min(1),
+    status: SessionStatusSchema,
+  }).passthrough(),
+}).passthrough()
+
+const SessionIdleEventSchema = z.object({
+  type: z.literal('session.idle'),
+  properties: z.object({
+    sessionID: z.string().min(1),
+  }).passthrough(),
+}).passthrough()
+
+const OpencodeEventSchema = z.discriminatedUnion('type', [
+  ServerConnectedEventSchema,
+  SessionStatusEventSchema,
+  SessionIdleEventSchema,
+])
+
+const OpencodeEventTypeSchema = z.object({
+  type: z.string().min(1),
+}).passthrough()
+
+const KNOWN_OPENCODE_EVENT_TYPES = new Set<z.infer<typeof OpencodeEventSchema>['type']>([
+  'server.connected',
+  'session.status',
+  'session.idle',
+])
+
+type FetchLike = typeof fetch
+
+type TrackerLogger = {
+  warn: (payload: object, message?: string) => void
+}
+
+type MonitorState = {
+  terminalId: string
+  endpoint: OpencodeServerEndpoint
+  disposed: boolean
+  controller?: AbortController
+  reconnectDelayMs: number
+  reconnectTimer?: ReturnType<typeof setTimeout>
+  reconnectResolve?: () => void
+}
+
+function createAbortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
+function createAbortPromise(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal.aborted) {
+      reject(createAbortError())
+      return
+    }
+    signal.addEventListener('abort', () => reject(createAbortError()), { once: true })
+  })
+}
+
+function parseSseData(block: string): string | undefined {
+  const dataLines: string[] = []
+  for (const line of block.split('\n')) {
+    if (!line || line.startsWith(':')) continue
+    if (!line.startsWith('data:')) continue
+    dataLines.push(line.slice(5).trimStart())
+  }
+  return dataLines.length > 0 ? dataLines.join('\n') : undefined
+}
+
+function parseOpencodeEvent(data: string): z.infer<typeof OpencodeEventSchema> | undefined {
+  let parsedJson: unknown
+  try {
+    parsedJson = JSON.parse(data)
+  } catch {
+    throw new Error('OpenCode event payload was not valid JSON.')
+  }
+
+  const parsedType = OpencodeEventTypeSchema.safeParse(parsedJson)
+  if (!parsedType.success) {
+    throw new Error('OpenCode event payload did not include a string type.')
+  }
+  if (!KNOWN_OPENCODE_EVENT_TYPES.has(parsedType.data.type as z.infer<typeof OpencodeEventSchema>['type'])) {
+    return undefined
+  }
+
+  const parsedEvent = OpencodeEventSchema.safeParse(parsedJson)
+  if (!parsedEvent.success) {
+    throw new Error('OpenCode event payload did not match the expected schema.')
+  }
+
+  return parsedEvent.data
+}
+
+function extractBusySessionId(
+  snapshot: Record<string, z.infer<typeof SessionStatusSchema>>,
+  currentSessionId?: string,
+): string | undefined {
+  const busySessionIds = Object.entries(snapshot)
+    .filter(([, status]) => status.type !== 'idle')
+    .map(([sessionId]) => sessionId)
+    .sort()
+  if (busySessionIds.length === 0) return undefined
+  if (currentSessionId && busySessionIds.includes(currentSessionId)) {
+    return currentSessionId
+  }
+  return busySessionIds[0]
+}
+
+export class OpencodeActivityTracker extends EventEmitter {
+  private readonly records = new Map<string, OpencodeActivityRecord>()
+  private readonly monitors = new Map<string, MonitorState>()
+  private readonly fetchImpl: FetchLike
+  private readonly log: TrackerLogger
+  private readonly now: () => number
+  private readonly setTimeoutFn: typeof setTimeout
+  private readonly clearTimeoutFn: typeof clearTimeout
+  private readonly random: () => number
+
+  constructor(input: {
+    fetchImpl?: FetchLike
+    log?: TrackerLogger
+    now?: () => number
+    setTimeoutFn?: typeof setTimeout
+    clearTimeoutFn?: typeof clearTimeout
+    random?: () => number
+  } = {}) {
+    super()
+    this.fetchImpl = input.fetchImpl ?? fetch
+    this.log = input.log ?? logger.child({ component: 'opencode-activity-tracker' })
+    this.now = input.now ?? (() => Date.now())
+    this.setTimeoutFn = input.setTimeoutFn ?? setTimeout
+    this.clearTimeoutFn = input.clearTimeoutFn ?? clearTimeout
+    this.random = input.random ?? Math.random
+  }
+
+  list(): OpencodeActivityRecord[] {
+    return Array.from(this.records.values())
+  }
+
+  getActivity(terminalId: string): OpencodeActivityRecord | undefined {
+    return this.records.get(terminalId)
+  }
+
+  trackTerminal(input: { terminalId: string; endpoint: OpencodeServerEndpoint }): void {
+    const existing = this.monitors.get(input.terminalId)
+    if (
+      existing
+      && existing.endpoint.hostname === input.endpoint.hostname
+      && existing.endpoint.port === input.endpoint.port
+      && !existing.disposed
+    ) {
+      return
+    }
+
+    this.untrackTerminal({ terminalId: input.terminalId })
+
+    const monitor: MonitorState = {
+      terminalId: input.terminalId,
+      endpoint: input.endpoint,
+      disposed: false,
+      reconnectDelayMs: OPENCODE_RECONNECT_BASE_MS,
+    }
+    this.monitors.set(input.terminalId, monitor)
+    void this.runMonitor(monitor)
+  }
+
+  untrackTerminal(input: { terminalId: string }): void {
+    const monitor = this.monitors.get(input.terminalId)
+    if (monitor) {
+      monitor.disposed = true
+      monitor.controller?.abort()
+      if (monitor.reconnectTimer) {
+        this.clearTimeoutFn(monitor.reconnectTimer)
+        monitor.reconnectTimer = undefined
+      }
+      monitor.reconnectResolve?.()
+      monitor.reconnectResolve = undefined
+      this.monitors.delete(input.terminalId)
+    }
+    this.removeRecord(input.terminalId)
+  }
+
+  dispose(): void {
+    for (const terminalId of Array.from(this.monitors.keys())) {
+      this.untrackTerminal({ terminalId })
+    }
+  }
+
+  private async runMonitor(monitor: MonitorState): Promise<void> {
+    while (!monitor.disposed) {
+      const controller = new AbortController()
+      monitor.controller = controller
+      try {
+        await this.waitForHealth(monitor, controller.signal)
+        await this.refreshSnapshot(monitor, controller.signal)
+        monitor.reconnectDelayMs = OPENCODE_RECONNECT_BASE_MS
+        await this.consumeEvents(monitor, controller.signal)
+      } catch (error) {
+        if (monitor.disposed || isAbortError(error)) {
+          return
+        }
+        this.log.warn({
+          terminalId: monitor.terminalId,
+          endpoint: monitor.endpoint,
+          err: error,
+        }, 'OpenCode activity tracker cycle failed; retrying.')
+      } finally {
+        if (monitor.controller === controller) {
+          monitor.controller = undefined
+        }
+      }
+
+      if (monitor.disposed) return
+      await this.sleepWithBackoff(monitor)
+    }
+  }
+
+  private async waitForHealth(monitor: MonitorState, signal: AbortSignal): Promise<void> {
+    const startedAt = this.now()
+    while (true) {
+      try {
+        const response = await this.fetchImpl(this.buildUrl(monitor.endpoint, '/global/health'), {
+          signal,
+        })
+        if (response.ok) {
+          return
+        }
+      } catch (error) {
+        if (isAbortError(error)) {
+          throw error
+        }
+      }
+      if (this.now() - startedAt >= OPENCODE_HEALTH_TIMEOUT_MS) {
+        throw new Error('Timed out waiting for OpenCode health endpoint.')
+      }
+      await this.sleep(signal, OPENCODE_HEALTH_POLL_MS)
+    }
+  }
+
+  private async refreshSnapshot(monitor: MonitorState, signal: AbortSignal): Promise<void> {
+    const response = await this.fetchImpl(this.buildUrl(monitor.endpoint, '/session/status'), {
+      signal,
+    })
+    if (!response.ok) {
+      throw new Error(`OpenCode session status request failed with ${response.status}.`)
+    }
+
+    const parsed = SessionStatusMapSchema.safeParse(await response.json())
+    if (!parsed.success) {
+      throw new Error('OpenCode session status response did not match the expected schema.')
+    }
+
+    const current = this.records.get(monitor.terminalId)
+    const busySessionId = extractBusySessionId(parsed.data, current?.sessionId)
+    if (!busySessionId) {
+      this.removeRecord(monitor.terminalId)
+      return
+    }
+
+    this.upsertRecord({
+      terminalId: monitor.terminalId,
+      sessionId: busySessionId,
+      phase: 'busy',
+      updatedAt: this.now(),
+    })
+  }
+
+  private async consumeEvents(monitor: MonitorState, signal: AbortSignal): Promise<void> {
+    const response = await this.fetchImpl(this.buildUrl(monitor.endpoint, '/event'), {
+      signal,
+      headers: { accept: 'text/event-stream' },
+    })
+    if (!response.ok || !response.body) {
+      throw new Error(`OpenCode event stream request failed with ${response.status}.`)
+    }
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    const abortPromise = createAbortPromise(signal)
+    let buffer = ''
+
+    try {
+      while (true) {
+        const result = await Promise.race([
+          reader.read(),
+          abortPromise,
+        ])
+
+        if (result.done) {
+          return
+        }
+
+        buffer += decoder.decode(result.value, { stream: true })
+          .replace(/\r\n/g, '\n')
+          .replace(/\r/g, '\n')
+
+        let separatorIndex = buffer.indexOf('\n\n')
+        while (separatorIndex >= 0) {
+          const block = buffer.slice(0, separatorIndex)
+          buffer = buffer.slice(separatorIndex + 2)
+          this.handleSseBlock(monitor.terminalId, block)
+          separatorIndex = buffer.indexOf('\n\n')
+        }
+      }
+    } finally {
+      try {
+        await reader.cancel()
+      } catch {
+        // ignore cancellation errors during teardown
+      }
+    }
+  }
+
+  private handleSseBlock(terminalId: string, block: string): void {
+    const data = parseSseData(block)
+    if (!data) return
+
+    let event: z.infer<typeof OpencodeEventSchema> | undefined
+    try {
+      event = parseOpencodeEvent(data)
+    } catch (error) {
+      const endpoint = this.monitors.get(terminalId)?.endpoint
+      this.log.warn({
+        terminalId,
+        endpoint,
+        err: error,
+      }, 'OpenCode event payload was invalid; skipping payload.')
+      return
+    }
+
+    if (!event) return
+    if (event.type === 'server.connected') return
+    if (event.type === 'session.idle') {
+      this.removeRecordForSession(terminalId, event.properties.sessionID)
+      return
+    }
+    if (event.properties.status.type === 'idle') {
+      this.removeRecordForSession(terminalId, event.properties.sessionID)
+      return
+    }
+
+    this.upsertRecord({
+      terminalId,
+      sessionId: event.properties.sessionID,
+      phase: 'busy',
+      updatedAt: this.now(),
+    })
+  }
+
+  private async sleepWithBackoff(monitor: MonitorState): Promise<void> {
+    const baseDelay = monitor.reconnectDelayMs
+    const jitter = Math.floor(baseDelay * 0.1 * this.random())
+    const delayMs = Math.min(OPENCODE_RECONNECT_MAX_MS, baseDelay + jitter)
+    monitor.reconnectDelayMs = Math.min(OPENCODE_RECONNECT_MAX_MS, baseDelay * 2)
+    await new Promise<void>((resolve) => {
+      monitor.reconnectResolve = resolve
+      monitor.reconnectTimer = this.setTimeoutFn(() => {
+        monitor.reconnectTimer = undefined
+        monitor.reconnectResolve = undefined
+        resolve()
+      }, delayMs)
+    })
+  }
+
+  private async sleep(signal: AbortSignal, delayMs: number): Promise<void> {
+    if (signal.aborted) {
+      throw createAbortError()
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const onAbort = () => {
+      if (timer) {
+        this.clearTimeoutFn(timer)
+      }
+    }
+
+    try {
+      await Promise.race([
+        new Promise<void>((resolve) => {
+          timer = this.setTimeoutFn(() => {
+            timer = undefined
+            resolve()
+          }, delayMs)
+          signal.addEventListener('abort', onAbort, { once: true })
+        }),
+        createAbortPromise(signal),
+      ])
+    } finally {
+      signal.removeEventListener('abort', onAbort)
+      if (timer) {
+        this.clearTimeoutFn(timer)
+      }
+    }
+  }
+
+  private buildUrl(endpoint: OpencodeServerEndpoint, pathname: string): string {
+    return `http://${endpoint.hostname}:${endpoint.port}${pathname}`
+  }
+
+  private removeRecordForSession(terminalId: string, sessionId: string): void {
+    const existing = this.records.get(terminalId)
+    if (!existing) return
+    if (existing.sessionId && existing.sessionId !== sessionId) return
+    this.removeRecord(terminalId)
+  }
+
+  private upsertRecord(record: OpencodeActivityRecord): void {
+    const previous = this.records.get(record.terminalId)
+    if (
+      previous
+      && previous.sessionId === record.sessionId
+      && previous.phase === record.phase
+      && previous.updatedAt === record.updatedAt
+    ) {
+      return
+    }
+    this.records.set(record.terminalId, record)
+    this.emit('changed', {
+      upsert: [record],
+      remove: [],
+    } satisfies OpencodeActivityChange)
+  }
+
+  private removeRecord(terminalId: string): void {
+    if (!this.records.delete(terminalId)) return
+    this.emit('changed', {
+      upsert: [],
+      remove: [terminalId],
+    } satisfies OpencodeActivityChange)
+  }
+}

--- a/server/coding-cli/opencode-activity-wiring.ts
+++ b/server/coding-cli/opencode-activity-wiring.ts
@@ -1,0 +1,67 @@
+import { OpencodeActivityTracker } from './opencode-activity-tracker.js'
+import type { OpencodeServerEndpoint } from '../local-port.js'
+import type { TerminalRecord } from '../terminal-registry.js'
+
+type OpencodeActivityRegistry = {
+  list: () => Array<{ terminalId: string }>
+  get: (terminalId: string) => TerminalRecord | undefined
+  on: (event: string, handler: (...args: any[]) => void) => void
+  off: (event: string, handler: (...args: any[]) => void) => void
+}
+
+function getEndpoint(record: TerminalRecord): OpencodeServerEndpoint | undefined {
+  return record.mode === 'opencode' ? record.opencodeServer : undefined
+}
+
+export function wireOpencodeActivityTracker(input: {
+  registry: OpencodeActivityRegistry
+  fetchImpl?: typeof fetch
+  now?: () => number
+  setTimeoutFn?: typeof setTimeout
+  clearTimeoutFn?: typeof clearTimeout
+  random?: () => number
+}) {
+  const tracker = new OpencodeActivityTracker({
+    fetchImpl: input.fetchImpl,
+    now: input.now,
+    setTimeoutFn: input.setTimeoutFn,
+    clearTimeoutFn: input.clearTimeoutFn,
+    random: input.random,
+  })
+
+  const startTracking = (record: TerminalRecord) => {
+    const endpoint = getEndpoint(record)
+    if (!endpoint || record.status !== 'running') return
+    tracker.trackTerminal({
+      terminalId: record.terminalId,
+      endpoint,
+    })
+  }
+
+  const onCreated = (record: TerminalRecord) => {
+    startTracking(record)
+  }
+
+  const onExit = (event: { terminalId?: string }) => {
+    if (!event.terminalId) return
+    tracker.untrackTerminal({ terminalId: event.terminalId })
+  }
+
+  input.registry.on('terminal.created', onCreated)
+  input.registry.on('terminal.exit', onExit)
+
+  for (const listed of input.registry.list()) {
+    const record = input.registry.get(listed.terminalId)
+    if (!record) continue
+    startTracking(record)
+  }
+
+  return {
+    tracker,
+    dispose(): void {
+      input.registry.off('terminal.created', onCreated)
+      input.registry.off('terminal.exit', onExit)
+      tracker.dispose()
+    },
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,6 +20,7 @@ import { SessionsSyncService } from './sessions-sync/service.js'
 import { CodingCliSessionIndexer } from './coding-cli/session-indexer.js'
 import { CodingCliSessionManager } from './coding-cli/session-manager.js'
 import { wireCodexActivityTracker } from './coding-cli/codex-activity-wiring.js'
+import { wireOpencodeActivityTracker } from './coding-cli/opencode-activity-wiring.js'
 import { claudeProvider } from './coding-cli/providers/claude.js'
 import { codexProvider } from './coding-cli/providers/codex.js'
 import { opencodeProvider } from './coding-cli/providers/opencode.js'
@@ -185,6 +186,7 @@ async function main() {
   const terminalMetadata = new TerminalMetadataService()
   const layoutStore = new LayoutStore()
   const codexActivity = wireCodexActivityTracker({ registry, codingCliIndexer })
+  const opencodeActivity = wireOpencodeActivityTracker({ registry })
 
   const sessionRepairService = getSessionRepairService({ skipDiscovery: true })
   const serverInstanceId = await loadOrCreateServerInstanceId()
@@ -287,29 +289,32 @@ async function main() {
   const wsHandler = new WsHandler(
     server,
     registry,
-    codingCliSessionManager,
-    sdkBridge,
-    sessionRepairService,
-    async () => {
-      const currentSettings = migrateSettingsSortMode(await configStore.getSettings())
-      const readError = configStore.getLastReadError()
-      const configFallback = readError
-        ? { reason: readError, backupExists: await configStore.backupExists() }
-        : undefined
-      return {
-        settings: currentSettings,
-        projects: codingCliIndexer.getProjects(),
-        perfLogging: perfConfig.enabled,
-        configFallback,
-      }
+    {
+      codingCliManager: codingCliSessionManager,
+      sdkBridge,
+      sessionRepairService,
+      handshakeSnapshotProvider: async () => {
+        const currentSettings = migrateSettingsSortMode(await configStore.getSettings())
+        const readError = configStore.getLastReadError()
+        const configFallback = readError
+          ? { reason: readError, backupExists: await configStore.backupExists() }
+          : undefined
+        return {
+          settings: currentSettings,
+          projects: codingCliIndexer.getProjects(),
+          perfLogging: perfConfig.enabled,
+          configFallback,
+        }
+      },
+      terminalMetaListProvider: () => terminalMetadata.list(),
+      tabsRegistryStore,
+      serverInstanceId,
+      layoutStore,
+      extensionManager,
+      codexActivityListProvider: () => codexActivity.tracker.list(),
+      agentHistorySource,
+      opencodeActivityListProvider: () => opencodeActivity.tracker.list(),
     },
-    () => terminalMetadata.list(),
-    tabsRegistryStore,
-    serverInstanceId,
-    layoutStore,
-    extensionManager,
-    () => codexActivity.tracker.list(),
-    agentHistorySource,
   )
   attachProxyUpgradeHandler(server)
   const port = Number(process.env.PORT || 3001)
@@ -347,6 +352,9 @@ async function main() {
 
   codexActivity.tracker.on('changed', (payload) => {
     wsHandler.broadcastCodexActivityUpdated(payload)
+  })
+  opencodeActivity.tracker.on('changed', (payload) => {
+    wsHandler.broadcastOpencodeActivityUpdated(payload)
   })
 
   const broadcastTerminalMetaUpserts = (upsert: ReturnType<TerminalMetadataService['list']>) => {
@@ -783,6 +791,7 @@ async function main() {
 
     // 8b. Stop Codex activity tracker listeners and sweep timer
     codexActivity.dispose()
+    opencodeActivity.dispose()
 
     // 9. Stop session repair service
     await sessionRepairService.stop()

--- a/server/local-port.ts
+++ b/server/local-port.ts
@@ -1,0 +1,39 @@
+import net from 'node:net'
+
+export type OpencodeServerEndpoint = {
+  hostname: '127.0.0.1'
+  port: number
+}
+
+// This is a best-effort ephemeral port reservation. There is an unavoidable race
+// between closing this probe socket and the child process binding the same port,
+// so callers must still be prepared to retry startup if OpenCode loses the bind.
+export async function allocateLocalhostPort(): Promise<OpencodeServerEndpoint> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+
+    const onError = (error: Error) => {
+      server.close(() => reject(error))
+    }
+
+    server.once('error', onError)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Failed to allocate a localhost control port for OpenCode.')))
+        return
+      }
+
+      server.close((closeError) => {
+        if (closeError) {
+          reject(closeError)
+          return
+        }
+        resolve({
+          hostname: '127.0.0.1',
+          port: address.port,
+        })
+      })
+    })
+  })
+}

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -11,6 +11,7 @@ import { getPerfConfig, logPerfEvent, shouldLog, startPerfTimer } from './perf-l
 import type { ServerSettings } from '../shared/settings.js'
 import { convertWindowsPathToWslPath, isReachableDirectorySync } from './path-utils.js'
 import { isValidClaudeSessionId } from './claude-session-id.js'
+import type { OpencodeServerEndpoint } from './local-port.js'
 import { makeSessionKey, parseSessionKey, type CodingCliProviderName } from './coding-cli/types.js'
 import { SessionBindingAuthority, type BindResult } from './session-binding-authority.js'
 import type {
@@ -165,10 +166,11 @@ function providerNotificationArgs(
   return { args: mcpInjection.args, env: mcpInjection.env }
 }
 
-type ProviderSettings = {
+export type ProviderSettings = {
   permissionMode?: string
   model?: string
   sandbox?: string
+  opencodeServer?: OpencodeServerEndpoint
 }
 
 function resolveCodingCliCommand(
@@ -199,6 +201,24 @@ function resolveCodingCliCommand(
     }
   }
   const settingsArgs: string[] = []
+  if (mode === 'opencode') {
+    const endpoint = providerSettings?.opencodeServer
+    if (
+      !endpoint
+      || endpoint.hostname !== '127.0.0.1'
+      || !Number.isInteger(endpoint.port)
+      || endpoint.port <= 0
+      || endpoint.port > 65535
+    ) {
+      throw new Error('OpenCode launch requires an allocated localhost control endpoint.')
+    }
+    settingsArgs.push(
+      '--hostname',
+      endpoint.hostname,
+      '--port',
+      String(endpoint.port),
+    )
+  }
   const effectiveModel = mode === 'opencode'
     ? resolveOpencodeLaunchModel(providerSettings?.model, { ...process.env, ...commandEnv })
     : providerSettings?.model
@@ -323,6 +343,7 @@ export type TerminalRecord = {
   title: string
   description?: string
   mode: TerminalMode
+  opencodeServer?: OpencodeServerEndpoint
   resumeSessionId?: string
   pendingResumeName?: string
   createdAt: number
@@ -1137,6 +1158,7 @@ export class TerminalRegistry extends EventEmitter {
       title,
       description: undefined,
       mode: opts.mode,
+      opencodeServer: opts.mode === 'opencode' ? opts.providerSettings?.opencodeServer : undefined,
       resumeSessionId: undefined,
       createdAt,
       lastActivityAt: createdAt,

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -16,8 +16,14 @@ import type { SessionScanResult, SessionRepairResult } from './session-scanner/t
 import { isValidClaudeSessionId } from './claude-session-id.js'
 import type { SdkBridge } from './sdk-bridge.js'
 import { createAgentHistorySource, type AgentHistorySource } from './agent-timeline/history-source.js'
-import type { CodexActivityRecord, SdkServerMessage, SdkSessionStatus } from '../shared/ws-protocol.js'
+import type {
+  CodexActivityRecord,
+  OpencodeActivityRecord,
+  SdkServerMessage,
+  SdkSessionStatus,
+} from '../shared/ws-protocol.js'
 import type { ExtensionManager } from './extension-manager.js'
+import { allocateLocalhostPort } from './local-port.js'
 import { TerminalStreamBroker } from './terminal-stream/broker.js'
 import { buildSidebarOpenSessionKeys, type SidebarSessionLocator } from './sidebar-session-selection.js'
 import { loadSessionHistory } from './session-history-loader.js'
@@ -34,6 +40,9 @@ import {
   CodexActivityListResponseSchema,
   CodexActivityListSchema,
   CodexActivityUpdatedSchema,
+  OpencodeActivityListResponseSchema,
+  OpencodeActivityListSchema,
+  OpencodeActivityUpdatedSchema,
   HelloSchema,
   PingSchema,
   TerminalAttachSchema,
@@ -71,6 +80,21 @@ type WsHandlerConfig = {
   drainTimeoutMs: number
   terminalCreateRateLimit: number
   terminalCreateRateWindowMs: number
+}
+
+export type WsHandlerOptions = {
+  codingCliManager?: CodingCliSessionManager
+  sdkBridge?: SdkBridge
+  sessionRepairService?: SessionRepairService
+  handshakeSnapshotProvider?: HandshakeSnapshotProvider
+  terminalMetaListProvider?: () => TerminalMeta[]
+  tabsRegistryStore?: TabsRegistryStore
+  serverInstanceId?: string
+  layoutStore?: LayoutStore
+  extensionManager?: ExtensionManager
+  codexActivityListProvider?: () => CodexActivityRecord[]
+  agentHistorySource?: AgentHistorySource
+  opencodeActivityListProvider?: () => OpencodeActivityRecord[]
 }
 
 function readWsHandlerConfig(): WsHandlerConfig {
@@ -321,6 +345,9 @@ function createScreenshotError(code: ScreenshotErrorCode, message: string): Erro
 export class WsHandler {
   private readonly config: WsHandlerConfig
   private readonly authToken: string
+  private readonly registry: TerminalRegistry
+  private readonly codingCliManager?: CodingCliSessionManager
+  private readonly sdkBridge?: SdkBridge
   private wss: WebSocketServer
   private connections = new Set<LiveWebSocket>()
   private clientStates = new Map<LiveWebSocket, ClientState>()
@@ -330,6 +357,7 @@ export class WsHandler {
   private handshakeSnapshotProvider?: HandshakeSnapshotProvider
   private terminalMetaListProvider?: () => TerminalMeta[]
   private codexActivityListProvider?: () => CodexActivityRecord[]
+  private opencodeActivityListProvider?: () => OpencodeActivityRecord[]
   private tabsRegistryStore?: TabsRegistryStore
   private layoutStore?: LayoutStore
   private extensionManager?: ExtensionManager
@@ -358,44 +386,39 @@ export class WsHandler {
 
   constructor(
     server: http.Server,
-    private registry: TerminalRegistry,
-    private codingCliManager?: CodingCliSessionManager,
-    private sdkBridge?: SdkBridge,
-    sessionRepairService?: SessionRepairService,
-    handshakeSnapshotProvider?: HandshakeSnapshotProvider,
-    terminalMetaListProvider?: () => TerminalMeta[],
-    tabsRegistryStore?: TabsRegistryStore,
-    serverInstanceId?: string,
-    layoutStore?: LayoutStore,
-    extensionManager?: ExtensionManager,
-    codexActivityListProvider?: () => CodexActivityRecord[],
-    agentHistorySource?: AgentHistorySource,
+    registry: TerminalRegistry,
+    options: WsHandlerOptions = {},
   ) {
     this.config = readWsHandlerConfig()
     this.authToken = getRequiredAuthToken()
-    this.sessionRepairService = sessionRepairService
-    this.handshakeSnapshotProvider = handshakeSnapshotProvider
-    this.terminalMetaListProvider = terminalMetaListProvider
-    this.codexActivityListProvider = codexActivityListProvider
-    this.tabsRegistryStore = tabsRegistryStore
-    this.layoutStore = layoutStore
-    this.extensionManager = extensionManager
-    this.agentHistorySource = agentHistorySource ?? (this.sdkBridge
+    this.registry = registry
+    this.codingCliManager = options.codingCliManager
+    this.sdkBridge = options.sdkBridge
+    this.sessionRepairService = options.sessionRepairService
+    this.handshakeSnapshotProvider = options.handshakeSnapshotProvider
+    this.terminalMetaListProvider = options.terminalMetaListProvider
+    this.codexActivityListProvider = options.codexActivityListProvider
+    this.opencodeActivityListProvider = options.opencodeActivityListProvider
+    this.tabsRegistryStore = options.tabsRegistryStore
+    this.layoutStore = options.layoutStore
+    this.extensionManager = options.extensionManager
+    this.agentHistorySource = options.agentHistorySource ?? (this.sdkBridge
       ? createAgentHistorySource({
         loadSessionHistory,
         getLiveSessionBySdkSessionId: (sdkSessionId) => this.sdkBridge?.getLiveSession(sdkSessionId),
         getLiveSessionByCliSessionId: (timelineSessionId) => this.sdkBridge?.findLiveSessionByCliSessionId(timelineSessionId),
       })
       : undefined)
-    this.serverInstanceId = serverInstanceId && serverInstanceId.trim().length > 0
-      ? serverInstanceId
+    this.serverInstanceId = options.serverInstanceId && options.serverInstanceId.trim().length > 0
+      ? options.serverInstanceId
       : `srv-${randomUUID()}`
     this.bootId = `boot-${randomUUID()}`
     this.terminalStreamBroker = new TerminalStreamBroker(this.registry)
 
     // Build the set of valid CLI provider/mode names from extensions
+    const extensionManager = this.extensionManager
     const canEnumerateCliExtensions = typeof extensionManager?.getAll === 'function'
-    const extensionModes = canEnumerateCliExtensions
+    const extensionModes = canEnumerateCliExtensions && extensionManager
       ? extensionManager.getAll()
           .filter(e => e.manifest.category === 'cli')
           .map(e => e.manifest.name)
@@ -454,6 +477,7 @@ export class WsHandler {
       TerminalResizeSchema,
       TerminalKillSchema,
       CodexActivityListSchema,
+      OpencodeActivityListSchema,
       TabsSyncPushSchema,
       TabsSyncQuerySchema,
       dynamicCodingCliCreateSchema,
@@ -1600,19 +1624,24 @@ export class WsHandler {
                 effectiveResumeSessionId,
               }, '[TRACE resumeSessionId] about to create terminal')
 
+              const spawnProviderSettings = providerSettings
+                ? {
+                    permissionMode: providerSettings.permissionMode,
+                    model: providerSettings.model,
+                    sandbox: providerSettings.sandbox,
+                    ...(m.mode === 'opencode'
+                      ? { opencodeServer: await allocateLocalhostPort() }
+                      : {}),
+                  }
+                : undefined
+
               const record = this.registry.create({
                 mode: m.mode as TerminalMode,
                 shell: m.shell as 'system' | 'cmd' | 'powershell' | 'wsl',
                 cwd: m.cwd,
                 resumeSessionId: effectiveResumeSessionId,
                 envContext: { tabId: m.tabId, paneId: m.paneId },
-                providerSettings: providerSettings
-                  ? {
-                      permissionMode: providerSettings.permissionMode,
-                      model: providerSettings.model,
-                      sandbox: providerSettings.sandbox,
-                    }
-                  : undefined,
+                providerSettings: spawnProviderSettings,
               })
 
               if (m.mode !== 'shell' && typeof m.cwd === 'string' && m.cwd.trim()) {
@@ -1754,6 +1783,26 @@ export class WsHandler {
           this.sendError(ws, {
             code: 'INTERNAL_ERROR',
             message: 'Codex activity unavailable',
+            requestId: m.requestId,
+          })
+          return
+        }
+        this.send(ws, response.data)
+        return
+      }
+
+      case 'opencode.activity.list': {
+        const terminals = this.opencodeActivityListProvider ? this.opencodeActivityListProvider() : []
+        const response = OpencodeActivityListResponseSchema.safeParse({
+          type: 'opencode.activity.list.response',
+          requestId: m.requestId,
+          terminals,
+        })
+        if (!response.success) {
+          log.warn({ issues: response.error.issues }, 'Invalid opencode.activity.list.response payload')
+          this.sendError(ws, {
+            code: 'INTERNAL_ERROR',
+            message: 'OpenCode activity unavailable',
             requestId: m.requestId,
           })
           return
@@ -2491,6 +2540,21 @@ export class WsHandler {
 
     if (!parsed.success) {
       log.warn({ issues: parsed.error.issues }, 'Invalid codex.activity.updated payload')
+      return
+    }
+
+    this.broadcastAuthenticated(parsed.data)
+  }
+
+  broadcastOpencodeActivityUpdated(msg: { upsert?: OpencodeActivityRecord[]; remove?: string[] }): void {
+    const parsed = OpencodeActivityUpdatedSchema.safeParse({
+      type: 'opencode.activity.updated',
+      upsert: msg.upsert || [],
+      remove: msg.remove || [],
+    })
+
+    if (!parsed.success) {
+      log.warn({ issues: parsed.error.issues }, 'Invalid opencode.activity.updated payload')
       return
     }
 

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -106,6 +106,27 @@ export const CodexActivityUpdatedSchema = z.object({
   remove: z.array(z.string().min(1)),
 })
 
+export const OpencodeActivityRecordSchema = z.object({
+  terminalId: z.string().min(1),
+  sessionId: z.string().optional(),
+  phase: z.literal('busy'),
+  updatedAt: z.number().int().nonnegative(),
+})
+
+export type OpencodeActivityRecord = z.infer<typeof OpencodeActivityRecordSchema>
+
+export const OpencodeActivityListResponseSchema = z.object({
+  type: z.literal('opencode.activity.list.response'),
+  requestId: z.string().min(1),
+  terminals: z.array(OpencodeActivityRecordSchema),
+})
+
+export const OpencodeActivityUpdatedSchema = z.object({
+  type: z.literal('opencode.activity.updated'),
+  upsert: z.array(OpencodeActivityRecordSchema),
+  remove: z.array(z.string().min(1)),
+})
+
 // ──────────────────────────────────────────────────────────────
 // SDK content block schemas (from Claude Code NDJSON)
 // ──────────────────────────────────────────────────────────────
@@ -227,6 +248,11 @@ export const TerminalKillSchema = z.object({
 
 export const CodexActivityListSchema = z.object({
   type: z.literal('codex.activity.list'),
+  requestId: z.string().min(1),
+})
+
+export const OpencodeActivityListSchema = z.object({
+  type: z.literal('opencode.activity.list'),
   requestId: z.string().min(1),
 })
 
@@ -376,6 +402,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   TerminalResizeSchema,
   TerminalKillSchema,
   CodexActivityListSchema,
+  OpencodeActivityListSchema,
   UiLayoutSyncSchema,
   UiScreenshotResultSchema,
   CodingCliCreateSchema,
@@ -491,6 +518,10 @@ export type TerminalMetaUpdatedMessage = z.infer<typeof TerminalMetaUpdatedSchem
 export type CodexActivityListResponseMessage = z.infer<typeof CodexActivityListResponseSchema>
 
 export type CodexActivityUpdatedMessage = z.infer<typeof CodexActivityUpdatedSchema>
+
+export type OpencodeActivityListResponseMessage = z.infer<typeof OpencodeActivityListResponseSchema>
+
+export type OpencodeActivityUpdatedMessage = z.infer<typeof OpencodeActivityUpdatedSchema>
 
 // -- Sessions --
 
@@ -717,6 +748,8 @@ export type ServerMessage =
   | TerminalInventoryMessage
   | CodexActivityListResponseMessage
   | CodexActivityUpdatedMessage
+  | OpencodeActivityListResponseMessage
+  | OpencodeActivityUpdatedMessage
   | SessionsChangedMessage
   | SettingsUpdatedMessage
   | UiCommandMessage

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import { setTerminalMetaSnapshot, upsertTerminalMeta, removeTerminalMeta } from 
 import { clearDeadTerminals } from '@/store/panesSlice'
 import { addTerminalRestoreRequestId } from '@/lib/terminal-restore'
 import { setCodexActivitySnapshot, upsertCodexActivity, removeCodexActivity, resetCodexActivity } from '@/store/codexActivitySlice'
+import { setOpencodeActivitySnapshot, upsertOpencodeActivity, removeOpencodeActivity, resetOpencodeActivity } from '@/store/opencodeActivitySlice'
 import { setRegistry, updateServerStatus } from '@/store/extensionsSlice'
 import { handleSdkMessage } from '@/lib/sdk-message-handler'
 import { createLogger } from '@/lib/client-logger'
@@ -220,7 +221,9 @@ export default function App() {
   const mainContentRef = useRef<HTMLDivElement>(null)
   const userOpenedSidebarOnMobileRef = useRef(false)
   const codexActivityListRequestSeqRef = useRef(new Map<string, number>())
+  const opencodeActivityListRequestSeqRef = useRef(new Map<string, number>())
   const codexActivityOrderRef = useRef(0)
+  const opencodeActivityOrderRef = useRef(0)
   const copiedResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const fullscreenTouchStartYRef = useRef<number | null>(null)
   const isLandscapeTerminalView = isMobile && isLandscape && view === 'terminal'
@@ -626,9 +629,24 @@ export default function App() {
         })
       }
 
+      const requestOpencodeActivityList = () => {
+        const requestId = `opencode-activity-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+        const requestSeq = ++opencodeActivityOrderRef.current
+        opencodeActivityListRequestSeqRef.current.set(requestId, requestSeq)
+        ws.send({
+          type: 'opencode.activity.list',
+          requestId,
+        })
+      }
+
       const resetCodexActivityOverlay = () => {
         codexActivityListRequestSeqRef.current.clear()
         dispatch(resetCodexActivity())
+      }
+
+      const resetOpencodeActivityOverlay = () => {
+        opencodeActivityListRequestSeqRef.current.clear()
+        dispatch(resetOpencodeActivity())
       }
 
       const wsWithOptionalDisconnect = ws as typeof ws & {
@@ -638,6 +656,7 @@ export default function App() {
       stopWsDisconnectSync = wsWithOptionalDisconnect.onDisconnect?.(() => {
         if (cancelled) return
         resetCodexActivityOverlay()
+        resetOpencodeActivityOverlay()
         dispatch(setStatus('disconnected'))
       }) ?? null
 
@@ -721,6 +740,7 @@ export default function App() {
           // If the initial connect attempt failed before ready, WsClient may still auto-reconnect.
           // Treat 'ready' as the source of truth for connection status.
           resetCodexActivityOverlay()
+          resetOpencodeActivityOverlay()
           dispatch(setError(undefined))
           dispatch(setStatus('ready'))
           dispatch(setServerInstanceId(ready.success ? ready.data.serverInstanceId : undefined))
@@ -737,6 +757,7 @@ export default function App() {
           // from this bootstrap cycle is still safe for enabling follow-up refreshes.
           promoteRecentHttpSessionsBaseline()
           requestCodexActivityList()
+          requestOpencodeActivityList()
           lastSessionsRevision = -1
           void recoverMissingStartupState()
         }
@@ -826,6 +847,35 @@ export default function App() {
             }))
           }
         }
+        if (msg.type === 'opencode.activity.list.response') {
+          const requestId = typeof msg.requestId === 'string' ? msg.requestId : ''
+          if (!requestId) return
+          const requestSeq = opencodeActivityListRequestSeqRef.current.get(requestId)
+          opencodeActivityListRequestSeqRef.current.delete(requestId)
+          if (requestSeq === undefined) return
+          dispatch(setOpencodeActivitySnapshot({
+            terminals: msg.terminals || [],
+            requestSeq,
+          }))
+        }
+        if (msg.type === 'opencode.activity.updated') {
+          const mutationSeq = ++opencodeActivityOrderRef.current
+          const upsert = Array.isArray(msg.upsert) ? msg.upsert : []
+          if (upsert.length > 0) {
+            dispatch(upsertOpencodeActivity({
+              terminals: upsert,
+              mutationSeq,
+            }))
+          }
+
+          const remove = Array.isArray(msg.remove) ? msg.remove : []
+          if (remove.length > 0) {
+            dispatch(removeOpencodeActivity({
+              terminalIds: remove,
+              mutationSeq,
+            }))
+          }
+        }
         if (msg.type === 'terminal.exit') {
           const terminalId = msg.terminalId
           const code = msg.exitCode
@@ -893,6 +943,7 @@ export default function App() {
         if (cancelled) return
         lastReadyServerInstanceId = ws.serverInstanceId
         resetCodexActivityOverlay()
+        resetOpencodeActivityOverlay()
         dispatch(setError(undefined))
         dispatch(setStatus('ready'))
         dispatch(setServerInstanceId(ws.serverInstanceId))
@@ -902,6 +953,7 @@ export default function App() {
 
         if (!cancelled) {
           requestCodexActivityList()
+          requestOpencodeActivityList()
         }
         void recoverMissingStartupState()
         return
@@ -915,6 +967,7 @@ export default function App() {
       } catch (err: any) {
         if (!cancelled) {
           resetCodexActivityOverlay()
+          resetOpencodeActivityOverlay()
           dispatch(setStatus('disconnected'))
           dispatch(setError(err?.message || 'WebSocket connection failed'))
           if (typeof err?.wsCloseCode === 'number') {

--- a/src/components/MobileTabStrip.tsx
+++ b/src/components/MobileTabStrip.tsx
@@ -8,6 +8,7 @@ import type { ChatSessionState } from '@/store/agentChatTypes'
 import type { PaneRuntimeActivityRecord } from '@/store/paneRuntimeActivitySlice'
 
 const EMPTY_CODEX_ACTIVITY_BY_ID = {}
+const EMPTY_OPENCODE_ACTIVITY_BY_ID = {}
 const EMPTY_AGENT_CHAT_SESSIONS: Record<string, ChatSessionState> = {}
 const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecord> = {}
 
@@ -24,6 +25,7 @@ export function MobileTabStrip({ onOpenSwitcher, sidebarCollapsed, onToggleSideb
   const paneLayouts = useAppSelector((s) => s.panes.layouts)
   const paneTitles = useAppSelector((s) => s.panes.paneTitles)
   const codexActivityByTerminalId = useAppSelector((s) => s.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID)
+  const opencodeActivityByTerminalId = useAppSelector((s) => s.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID)
   const agentChatSessions = useAppSelector((s) => s.agentChat?.sessions ?? EMPTY_AGENT_CHAT_SESSIONS)
   const paneRuntimeActivityByPaneId = useAppSelector(
     (s) => s.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID
@@ -41,6 +43,7 @@ export function MobileTabStrip({ onOpenSwitcher, sidebarCollapsed, onToggleSideb
       tab: activeTab,
       paneLayouts,
       codexActivityByTerminalId,
+      opencodeActivityByTerminalId,
       paneRuntimeActivityByPaneId,
       agentChatSessions,
     }).length > 0

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -26,6 +26,7 @@ import type { PaneRuntimeActivityRecord } from '@/store/paneRuntimeActivitySlice
 const EMPTY_TERMINALS: BackgroundTerminal[] = []
 const EMPTY_LAYOUTS: Record<string, never> = {}
 const EMPTY_CODEX_ACTIVITY_BY_ID = {}
+const EMPTY_OPENCODE_ACTIVITY_BY_ID = {}
 const EMPTY_AGENT_CHAT_SESSIONS: Record<string, ChatSessionState> = {}
 const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecord> = {}
 
@@ -308,6 +309,7 @@ export default function Sidebar({
     tabs: state.tabs.tabs,
     paneLayouts: state.panes?.layouts ?? EMPTY_LAYOUTS,
     codexActivityByTerminalId: state.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID,
+    opencodeActivityByTerminalId: state.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID,
     paneRuntimeActivityByPaneId: state.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID,
     agentChatSessions: state.agentChat?.sessions ?? EMPTY_AGENT_CHAT_SESSIONS,
   }), shallowEqual)

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -130,6 +130,7 @@ const EMPTY_LAYOUTS: Record<string, never> = {}
 const EMPTY_PANE_TITLES: Record<string, Record<string, string>> = {}
 const EMPTY_ATTENTION: Record<string, boolean> = {}
 const EMPTY_CODEX_ACTIVITY_BY_ID = {}
+const EMPTY_OPENCODE_ACTIVITY_BY_ID = {}
 const EMPTY_AGENT_CHAT_SESSIONS: Record<string, ChatSessionState> = {}
 const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecord> = {}
 
@@ -151,6 +152,7 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
   const attentionByTab = useAppSelector((s) => s.turnCompletion?.attentionByTab) ?? EMPTY_ATTENTION
   const attentionByPane = useAppSelector((s) => s.turnCompletion?.attentionByPane) ?? EMPTY_ATTENTION
   const codexActivityByTerminalId = useAppSelector((s) => s.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID)
+  const opencodeActivityByTerminalId = useAppSelector((s) => s.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID)
   const agentChatSessions = useAppSelector((s) => s.agentChat?.sessions ?? EMPTY_AGENT_CHAT_SESSIONS)
   const paneRuntimeActivityByPaneId = useAppSelector(
     (s) => s.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID
@@ -208,9 +210,10 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
     tab,
     paneLayouts: paneLayouts as Record<string, PaneNode | undefined>,
     codexActivityByTerminalId,
+    opencodeActivityByTerminalId,
     paneRuntimeActivityByPaneId,
     agentChatSessions,
-  }), [agentChatSessions, codexActivityByTerminalId, paneLayouts, paneRuntimeActivityByPaneId])
+  }), [agentChatSessions, codexActivityByTerminalId, opencodeActivityByTerminalId, paneLayouts, paneRuntimeActivityByPaneId])
 
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')

--- a/src/components/TabSwitcher.tsx
+++ b/src/components/TabSwitcher.tsx
@@ -10,6 +10,7 @@ import type { ChatSessionState } from '@/store/agentChatTypes'
 import type { PaneRuntimeActivityRecord } from '@/store/paneRuntimeActivitySlice'
 
 const EMPTY_CODEX_ACTIVITY_BY_ID = {}
+const EMPTY_OPENCODE_ACTIVITY_BY_ID = {}
 const EMPTY_AGENT_CHAT_SESSIONS: Record<string, ChatSessionState> = {}
 const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecord> = {}
 
@@ -39,6 +40,7 @@ export function TabSwitcher({ onClose }: TabSwitcherProps) {
   const paneLayouts = useAppSelector((s) => s.panes.layouts)
   const paneTitles = useAppSelector((s) => s.panes.paneTitles)
   const codexActivityByTerminalId = useAppSelector((s) => s.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID)
+  const opencodeActivityByTerminalId = useAppSelector((s) => s.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID)
   const agentChatSessions = useAppSelector((s) => s.agentChat?.sessions ?? EMPTY_AGENT_CHAT_SESSIONS)
   const paneRuntimeActivityByPaneId = useAppSelector(
     (s) => s.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID
@@ -95,6 +97,7 @@ export function TabSwitcher({ onClose }: TabSwitcherProps) {
               tab,
               paneLayouts,
               codexActivityByTerminalId,
+              opencodeActivityByTerminalId,
               paneRuntimeActivityByPaneId,
               agentChatSessions,
             }).length > 0

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -51,6 +51,7 @@ const EMPTY_TERMINAL_META_BY_ID: Record<string, TerminalMetaRecord> = {}
 const EMPTY_PROJECTS: ProjectGroup[] = []
 const EMPTY_AGENT_CHAT_SESSIONS: Record<string, ChatSessionState> = {}
 const EMPTY_CODEX_ACTIVITY_BY_ID = {}
+const EMPTY_OPENCODE_ACTIVITY_BY_ID = {}
 const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecord> = {}
 const EMPTY_ATTENTION_BY_PANE: Record<string, boolean> = {}
 const EMPTY_PENDING_CREATES: Record<string, PendingAgentCreate> = {}
@@ -164,6 +165,9 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
   const agentChatSessions = useAppSelector((s) => s.agentChat?.sessions ?? EMPTY_AGENT_CHAT_SESSIONS)
   const codexActivityByTerminalId = useAppSelector(
     (s) => s.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID
+  )
+  const opencodeActivityByTerminalId = useAppSelector(
+    (s) => s.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID
   )
   const paneRuntimeActivityByPaneId = useAppSelector(
     (s) => s.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID
@@ -420,6 +424,7 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
       tabMode: tab?.mode,
       isOnlyPane,
       codexActivityByTerminalId,
+      opencodeActivityByTerminalId,
       paneRuntimeActivityByPaneId,
       agentChatSessions,
     }).isBusy

--- a/src/lib/pane-activity.ts
+++ b/src/lib/pane-activity.ts
@@ -11,9 +11,9 @@ import type {
 import type { PaneRuntimeActivityRecord } from '@/store/paneRuntimeActivitySlice'
 import { getPreferredResumeSessionId } from '@/store/persistControl'
 import type { Tab } from '@/store/types'
-import type { CodexActivityRecord } from '@shared/ws-protocol'
+import type { CodexActivityRecord, OpencodeActivityRecord } from '@shared/ws-protocol'
 
-type PaneActivitySource = 'codex' | 'claude-terminal' | 'agent-chat' | 'browser'
+type PaneActivitySource = 'codex' | 'opencode' | 'claude-terminal' | 'agent-chat' | 'browser'
 
 export type PaneActivityProjection = {
   isBusy: boolean
@@ -106,6 +106,7 @@ export function resolvePaneActivity(input: {
   tabMode?: Tab['mode']
   isOnlyPane: boolean
   codexActivityByTerminalId: Record<string, CodexActivityRecord>
+  opencodeActivityByTerminalId: Record<string, OpencodeActivityRecord>
   paneRuntimeActivityByPaneId: Record<string, PaneRuntimeActivityRecord>
   agentChatSessions: Record<string, ChatSessionState>
 }): PaneActivityProjection {
@@ -125,6 +126,16 @@ export function resolvePaneActivity(input: {
       })
       return record?.phase === 'busy'
         ? { isBusy: true, source: 'codex' }
+        : IDLE_PANE_ACTIVITY
+    }
+
+    if (effectiveMode === 'opencode') {
+      const terminalId = input.content.terminalId
+      const record = terminalId
+        ? input.opencodeActivityByTerminalId[terminalId]
+        : undefined
+      return record?.phase === 'busy'
+        ? { isBusy: true, source: 'opencode' }
         : IDLE_PANE_ACTIVITY
     }
 
@@ -157,6 +168,7 @@ export function getBusyPaneIdsForTab(input: {
   tab: Tab
   paneLayouts: Record<string, PaneNode | undefined>
   codexActivityByTerminalId: Record<string, CodexActivityRecord>
+  opencodeActivityByTerminalId: Record<string, OpencodeActivityRecord>
   paneRuntimeActivityByPaneId: Record<string, PaneRuntimeActivityRecord>
   agentChatSessions: Record<string, ChatSessionState>
 }): string[] {
@@ -171,6 +183,7 @@ export function getBusyPaneIdsForTab(input: {
       tabMode: input.tab.mode,
       isOnlyPane: true,
       codexActivityByTerminalId: input.codexActivityByTerminalId,
+      opencodeActivityByTerminalId: input.opencodeActivityByTerminalId,
       paneRuntimeActivityByPaneId: input.paneRuntimeActivityByPaneId,
       agentChatSessions: input.agentChatSessions,
     }).isBusy
@@ -186,6 +199,7 @@ export function getBusyPaneIdsForTab(input: {
       tabMode: input.tab.mode,
       isOnlyPane,
       codexActivityByTerminalId: input.codexActivityByTerminalId,
+      opencodeActivityByTerminalId: input.opencodeActivityByTerminalId,
       paneRuntimeActivityByPaneId: input.paneRuntimeActivityByPaneId,
       agentChatSessions: input.agentChatSessions,
     }).isBusy)
@@ -196,6 +210,7 @@ export function collectBusySessionKeys(input: {
   tabs: Tab[]
   paneLayouts: Record<string, PaneNode | undefined>
   codexActivityByTerminalId: Record<string, CodexActivityRecord>
+  opencodeActivityByTerminalId: Record<string, OpencodeActivityRecord>
   paneRuntimeActivityByPaneId: Record<string, PaneRuntimeActivityRecord>
   agentChatSessions: Record<string, ChatSessionState>
 }): string[] {
@@ -213,6 +228,7 @@ export function collectBusySessionKeys(input: {
         tabMode: tab.mode,
         isOnlyPane: true,
         codexActivityByTerminalId: input.codexActivityByTerminalId,
+        opencodeActivityByTerminalId: input.opencodeActivityByTerminalId,
         paneRuntimeActivityByPaneId: input.paneRuntimeActivityByPaneId,
         agentChatSessions: input.agentChatSessions,
       }).isBusy
@@ -231,6 +247,7 @@ export function collectBusySessionKeys(input: {
         tabMode: tab.mode,
         isOnlyPane,
         codexActivityByTerminalId: input.codexActivityByTerminalId,
+        opencodeActivityByTerminalId: input.opencodeActivityByTerminalId,
         paneRuntimeActivityByPaneId: input.paneRuntimeActivityByPaneId,
         agentChatSessions: input.agentChatSessions,
       }).isBusy

--- a/src/store/opencodeActivitySlice.ts
+++ b/src/store/opencodeActivitySlice.ts
@@ -1,0 +1,126 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { OpencodeActivityRecord } from '@shared/ws-protocol'
+
+export type OpencodeActivityState = {
+  byTerminalId: Record<string, OpencodeActivityRecord>
+  lastSnapshotSeq: number
+  liveMutationSeqByTerminalId: Record<string, number>
+  removedMutationSeqByTerminalId: Record<string, number>
+}
+
+type OpencodeActivitySnapshotPayload = {
+  terminals: OpencodeActivityRecord[]
+  requestSeq?: number
+}
+
+type OpencodeActivityUpsertPayload = {
+  terminals: OpencodeActivityRecord[]
+  mutationSeq?: number
+}
+
+type OpencodeActivityRemovalPayload = {
+  terminalIds: string[]
+  mutationSeq?: number
+}
+
+function createInitialState(): OpencodeActivityState {
+  return {
+    byTerminalId: {},
+    lastSnapshotSeq: 0,
+    liveMutationSeqByTerminalId: {},
+    removedMutationSeqByTerminalId: {},
+  }
+}
+
+const initialState: OpencodeActivityState = createInitialState()
+
+const opencodeActivitySlice = createSlice({
+  name: 'opencodeActivity',
+  initialState,
+  reducers: {
+    setOpencodeActivitySnapshot(state, action: PayloadAction<OpencodeActivitySnapshotPayload>) {
+      const requestSeq = action.payload.requestSeq ?? 0
+      if (requestSeq < state.lastSnapshotSeq) {
+        return
+      }
+      const next: Record<string, OpencodeActivityRecord> = {}
+      const nextLiveMutationSeqByTerminalId: Record<string, number> = {}
+      const incomingIds = new Set<string>()
+
+      for (const record of action.payload.terminals) {
+        const removedMutationSeq = state.removedMutationSeqByTerminalId[record.terminalId] ?? 0
+        if (removedMutationSeq > requestSeq) continue
+        const liveMutationSeq = state.liveMutationSeqByTerminalId[record.terminalId] ?? 0
+        const existing = state.byTerminalId[record.terminalId]
+        if (liveMutationSeq > requestSeq && existing) {
+          next[record.terminalId] = existing
+          nextLiveMutationSeqByTerminalId[record.terminalId] = liveMutationSeq
+          incomingIds.add(record.terminalId)
+          continue
+        }
+        next[record.terminalId] = record
+        incomingIds.add(record.terminalId)
+      }
+
+      for (const [terminalId, existing] of Object.entries(state.byTerminalId)) {
+        if (incomingIds.has(terminalId)) continue
+        const liveMutationSeq = state.liveMutationSeqByTerminalId[terminalId] ?? 0
+        if (liveMutationSeq > requestSeq) {
+          next[terminalId] = existing
+          nextLiveMutationSeqByTerminalId[terminalId] = liveMutationSeq
+        }
+      }
+
+      const nextRemovedMutationSeqByTerminalId: Record<string, number> = {}
+      for (const [terminalId, removedMutationSeq] of Object.entries(state.removedMutationSeqByTerminalId)) {
+        if (removedMutationSeq > requestSeq && !next[terminalId]) {
+          nextRemovedMutationSeqByTerminalId[terminalId] = removedMutationSeq
+        }
+      }
+
+      state.byTerminalId = next
+      state.lastSnapshotSeq = requestSeq
+      state.liveMutationSeqByTerminalId = nextLiveMutationSeqByTerminalId
+      state.removedMutationSeqByTerminalId = nextRemovedMutationSeqByTerminalId
+    },
+
+    upsertOpencodeActivity(state, action: PayloadAction<OpencodeActivityUpsertPayload>) {
+      const mutationSeq = action.payload.mutationSeq ?? 0
+      for (const record of action.payload.terminals) {
+        const removedMutationSeq = state.removedMutationSeqByTerminalId[record.terminalId] ?? 0
+        if (removedMutationSeq > mutationSeq) continue
+
+        const existing = state.byTerminalId[record.terminalId]
+        if (!existing || record.updatedAt >= existing.updatedAt) {
+          state.byTerminalId[record.terminalId] = record
+          state.liveMutationSeqByTerminalId[record.terminalId] = mutationSeq
+          delete state.removedMutationSeqByTerminalId[record.terminalId]
+        }
+      }
+    },
+
+    removeOpencodeActivity(state, action: PayloadAction<OpencodeActivityRemovalPayload>) {
+      const mutationSeq = action.payload.mutationSeq ?? 0
+      for (const terminalId of action.payload.terminalIds) {
+        delete state.byTerminalId[terminalId]
+        delete state.liveMutationSeqByTerminalId[terminalId]
+        if ((state.removedMutationSeqByTerminalId[terminalId] ?? 0) < mutationSeq) {
+          state.removedMutationSeqByTerminalId[terminalId] = mutationSeq
+        }
+      }
+    },
+
+    resetOpencodeActivity() {
+      return createInitialState()
+    },
+  },
+})
+
+export const {
+  setOpencodeActivitySnapshot,
+  upsertOpencodeActivity,
+  removeOpencodeActivity,
+  resetOpencodeActivity,
+} = opencodeActivitySlice.actions
+
+export default opencodeActivitySlice.reducer

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -13,6 +13,7 @@ import terminalDirectoryReducer from './terminalDirectorySlice'
 import turnCompletionReducer from './turnCompletionSlice'
 import terminalMetaReducer from './terminalMetaSlice'
 import codexActivityReducer from './codexActivitySlice'
+import opencodeActivityReducer from './opencodeActivitySlice'
 import agentChatReducer from './agentChatSlice'
 import paneRuntimeActivityReducer from './paneRuntimeActivitySlice'
 import { networkReducer } from './networkSlice'
@@ -45,6 +46,7 @@ export const store = configureStore({
     turnCompletion: turnCompletionReducer,
     terminalMeta: terminalMetaReducer,
     codexActivity: codexActivityReducer,
+    opencodeActivity: opencodeActivityReducer,
     agentChat: agentChatReducer,
     paneRuntimeActivity: paneRuntimeActivityReducer,
     network: networkReducer,

--- a/test/e2e/pane-activity-indicator-flow.test.tsx
+++ b/test/e2e/pane-activity-indicator-flow.test.tsx
@@ -9,6 +9,10 @@ import panesReducer from '@/store/panesSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
 import codexActivityReducer from '@/store/codexActivitySlice'
+import opencodeActivityReducer, {
+  removeOpencodeActivity,
+  upsertOpencodeActivity,
+} from '@/store/opencodeActivitySlice'
 import agentChatReducer, { removePermission } from '@/store/agentChatSlice'
 import type { AgentChatState } from '@/store/agentChatTypes'
 import paneRuntimeActivityReducer, {
@@ -106,6 +110,7 @@ function renderHarness(options: RenderHarnessOptions) {
       settings: settingsReducer,
       turnCompletion: turnCompletionReducer,
       codexActivity: codexActivityReducer,
+      opencodeActivity: opencodeActivityReducer,
       agentChat: agentChatReducer,
       paneRuntimeActivity: paneRuntimeActivityReducer,
     },
@@ -138,6 +143,12 @@ function renderHarness(options: RenderHarnessOptions) {
         attentionByPane: {},
       },
       codexActivity: {
+        byTerminalId: {},
+        lastSnapshotSeq: 0,
+        liveMutationSeqByTerminalId: {},
+        removedMutationSeqByTerminalId: {},
+      },
+      opencodeActivity: {
         byTerminalId: {},
         lastSnapshotSeq: 0,
         liveMutationSeqByTerminalId: {},
@@ -305,6 +316,61 @@ describe('pane activity indicator flow (e2e)', () => {
 
     act(() => {
       store.dispatch(clearPaneRuntimeActivity({ paneId: 'pane-activity' }))
+    })
+
+    expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+    expect(within(getVisibleSinglePaneTab()).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+  })
+
+  it('shows OpenCode terminals blue only for exact terminal busy activity and clears on removal', () => {
+    const pane: TerminalPaneContent = {
+      kind: 'terminal',
+      createRequestId: 'req-opencode',
+      status: 'running',
+      mode: 'opencode',
+      shell: 'system',
+      terminalId: 'term-opencode',
+      resumeSessionId: 'session-opencode',
+    }
+
+    const { store } = renderHarness({
+      pane,
+      tab: {
+        mode: 'opencode',
+        terminalId: 'term-opencode',
+        resumeSessionId: 'session-opencode',
+      },
+    })
+
+    const paneHeader = screen.getByRole('banner', { name: 'Pane: Activity Pane' })
+    expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+    expect(within(getVisibleSinglePaneTab()).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+
+    act(() => {
+      store.dispatch(upsertOpencodeActivity({
+        terminals: [{ terminalId: 'term-foreign', phase: 'busy', updatedAt: 1 }],
+        mutationSeq: 1,
+      }))
+    })
+
+    expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+    expect(within(getVisibleSinglePaneTab()).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+
+    act(() => {
+      store.dispatch(upsertOpencodeActivity({
+        terminals: [{ terminalId: 'term-opencode', phase: 'busy', updatedAt: 2 }],
+        mutationSeq: 2,
+      }))
+    })
+
+    expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class')).toContain('text-blue-500')
+    expect(within(getVisibleSinglePaneTab()).getByTestId('pane-icon').getAttribute('class')).toContain('text-blue-500')
+
+    act(() => {
+      store.dispatch(removeOpencodeActivity({
+        terminalIds: ['term-opencode'],
+        mutationSeq: 3,
+      }))
     })
 
     expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')

--- a/test/helpers/visible-first/protocol-harness.ts
+++ b/test/helpers/visible-first/protocol-harness.ts
@@ -225,10 +225,9 @@ export async function createProtocolHarness(options: ProtocolHarnessOptions = {}
   const handler = new WsHandler(
     server,
     registry as any,
-    undefined,
-    undefined,
-    undefined,
-    handshakeSnapshotProvider,
+    {
+      handshakeSnapshotProvider,
+    },
   )
   const { port } = await listen(server)
   const openClients = new Set<WebSocket>()

--- a/test/integration/server/codex-session-flow.test.ts
+++ b/test/integration/server/codex-session-flow.test.ts
@@ -197,7 +197,7 @@ describe('Codex Session Flow Integration', () => {
     server = http.createServer(app)
     registry = new TerminalRegistry()
     cliManager = new CodingCliSessionManager([codexProvider])
-    wsHandler = new WsHandler(server, registry, cliManager)
+    wsHandler = new WsHandler(server, registry, { codingCliManager: cliManager })
 
     await new Promise<void>((resolve) => {
       server.listen(0, '127.0.0.1', () => {

--- a/test/server/agent-run.test.ts
+++ b/test/server/agent-run.test.ts
@@ -1,4 +1,4 @@
-import { it, expect } from 'vitest'
+import { it, expect, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
 import { createAgentApiRouter } from '../../server/agent-api/router'
@@ -25,4 +25,37 @@ it('runs a command and returns captured output', async () => {
   const res = await request(app).post('/api/run').send({ command: 'echo done', capture: true })
   expect(res.body.status).toBe('ok')
   expect(res.body.data.output).toContain('done')
+})
+
+it('allocates and passes an OpenCode control endpoint for /api/run in opencode mode', async () => {
+  let buffer = ''
+  const registry = {
+    create: vi.fn(() => ({ terminalId: 'term1' })),
+    input: (_terminalId: string, data: string) => {
+      const match = data.match(/__FRESHELL_DONE_[A-Za-z0-9_-]+__/)
+      if (match) buffer = `done\n${match[0]}\n`
+      return true
+    },
+    get: () => ({ buffer: { snapshot: () => buffer }, status: 'running' }),
+  }
+
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { createTab: () => ({ tabId: 't1', paneId: 'p1' }), attachPaneContent: () => {} },
+    registry,
+  }))
+
+  const res = await request(app).post('/api/run').send({ command: 'echo done', capture: true, mode: 'opencode' })
+
+  expect(res.body.status).toBe('ok')
+  expect(registry.create).toHaveBeenCalledWith(expect.objectContaining({
+    mode: 'opencode',
+    providerSettings: expect.objectContaining({
+      opencodeServer: {
+        hostname: '127.0.0.1',
+        port: expect.any(Number),
+      },
+    }),
+  }))
 })

--- a/test/server/agent-tabs-write.test.ts
+++ b/test/server/agent-tabs-write.test.ts
@@ -51,6 +51,36 @@ describe('tab endpoints', () => {
     expect(layoutStore.attachPaneContent).toHaveBeenCalled()
   })
 
+  it('allocates and passes an OpenCode control endpoint when creating an opencode tab', async () => {
+    const app = express()
+    app.use(express.json())
+    const registry = new FakeRegistry()
+    const layoutStore = {
+      createTab: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+      attachPaneContent: () => {},
+      selectTab: () => ({}),
+      renameTab: () => ({}),
+      closeTab: () => ({}),
+      hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }),
+      selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry, wsHandler: { broadcastUiCommand: () => {} } }))
+
+    const res = await request(app).post('/api/tabs').send({ mode: 'opencode', name: 'OpenCode' })
+
+    expect(res.body.status).toBe('ok')
+    expect(registry.create).toHaveBeenCalledWith(expect.objectContaining({
+      mode: 'opencode',
+      providerSettings: expect.objectContaining({
+        opencodeServer: {
+          hostname: '127.0.0.1',
+          port: expect.any(Number),
+        },
+      }),
+    }))
+  })
+
   it('rejects blank tab rename payloads', async () => {
     const app = express()
     app.use(express.json())

--- a/test/server/session-association.test.ts
+++ b/test/server/session-association.test.ts
@@ -30,6 +30,19 @@ const SESSION_ID_SIX = '4b1c3d2e-5f6a-7b8c-9d0e-1f2a3b4c5d6e'
 const SESSION_ID_SEVEN = '5c2d4e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f'
 const SESSION_ID_EIGHT = '6d3e5f7a-8b9c-0d1e-2f3a-4b5c6d7e8f90'
 
+function withOpencodeServer<T extends { providerSettings?: Record<string, unknown> }>(options: T): T {
+  return {
+    ...options,
+    providerSettings: {
+      ...(options.providerSettings ?? {}),
+      opencodeServer: {
+        hostname: '127.0.0.1',
+        port: 41001,
+      },
+    },
+  }
+}
+
 function createMetadataService() {
   let now = 1_000
   return new TerminalMetadataService({
@@ -851,7 +864,7 @@ describe('Codex Session-Terminal Association via onUpdate', () => {
     const registry = new TerminalRegistry()
     const broadcasts: any[] = []
 
-    const term = registry.create({ mode: 'opencode', cwd: '/home/user/project' })
+    const term = registry.create(withOpencodeServer({ mode: 'opencode', cwd: '/home/user/project' }))
 
     associateOnUpdate(registry, [{
       projectPath: '/home/user/project',

--- a/test/server/ws-coding-cli-events.test.ts
+++ b/test/server/ws-coding-cli-events.test.ts
@@ -64,7 +64,7 @@ describe('WebSocket Coding CLI Events', () => {
     server = http.createServer(app)
     registry = new TerminalRegistry()
     cliManager = new CodingCliSessionManager([claudeProvider])
-    wsHandler = new WsHandler(server, registry, cliManager)
+    wsHandler = new WsHandler(server, registry, { codingCliManager: cliManager })
 
     await new Promise<void>((resolve) => {
       server.listen(0, '127.0.0.1', () => {
@@ -251,7 +251,7 @@ describe('WebSocket Coding CLI Events', () => {
     } as unknown as CodingCliSessionManager
 
     wsHandler.close()
-    wsHandler = new WsHandler(server, registry, fakeManager)
+    wsHandler = new WsHandler(server, registry, { codingCliManager: fakeManager })
 
     vi.mocked(configStore.snapshot).mockResolvedValueOnce({
       settings: {

--- a/test/server/ws-extension-registry.test.ts
+++ b/test/server/ws-extension-registry.test.ts
@@ -98,6 +98,7 @@ function closeWebSocket(ws: WebSocket, timeoutMs = 500): Promise<void> {
 
 class FakeRegistry {
   detach() { return true }
+  list() { return [] }
 }
 
 const fakeExtensions = [
@@ -145,15 +146,9 @@ describe('ws extension registry', () => {
     new (WsHandler as any)(
       server,
       new FakeRegistry() as any,
-      undefined, // codingCliManager
-      undefined, // sdkBridge
-      undefined, // sessionRepairService
-      undefined, // handshakeSnapshotProvider
-      undefined, // terminalMetaListProvider
-      undefined, // tabsRegistryStore
-      undefined, // serverInstanceId
-      undefined, // layoutStore
-      new FakeExtensionManager() as any, // extensionManager
+      {
+        extensionManager: new FakeExtensionManager() as any,
+      },
     )
 
     const info = await listen(server)

--- a/test/server/ws-handshake-snapshot.test.ts
+++ b/test/server/ws-handshake-snapshot.test.ts
@@ -188,10 +188,9 @@ describe('ws handshake snapshot', () => {
     new (WsHandler as any)(
       server,
       new FakeRegistry() as any,
-      undefined,
-      undefined,
-      undefined,
-      async () => snapshot
+      {
+        handshakeSnapshotProvider: async () => snapshot,
+      },
     )
 
     const info = await listen(server)

--- a/test/server/ws-opencode-activity.test.ts
+++ b/test/server/ws-opencode-activity.test.ts
@@ -82,20 +82,20 @@ class FakeRegistry {
   findRunningClaudeTerminalBySession() { return undefined }
 }
 
-describe('ws codex activity protocol', () => {
+describe('ws opencode activity protocol', () => {
   let server: http.Server
   let port: number
   let wsHandler: any
   const sampleActivity = [{
-    terminalId: 'term-1',
-    sessionId: 'session-1',
+    terminalId: 'term-opencode-1',
+    sessionId: 'session-opencode-1',
     phase: 'busy',
     updatedAt: 1234,
   }]
 
   beforeAll(async () => {
     process.env.NODE_ENV = 'test'
-    process.env.AUTH_TOKEN = 'codex-activity-token'
+    process.env.AUTH_TOKEN = 'opencode-activity-token'
 
     const { WsHandler } = await import('../../server/ws-handler')
     server = http.createServer((_req, res) => {
@@ -106,7 +106,7 @@ describe('ws codex activity protocol', () => {
       server,
       new FakeRegistry() as any,
       {
-        codexActivityListProvider: () => sampleActivity as any,
+        opencodeActivityListProvider: () => sampleActivity as any,
       },
     )
     port = await listen(server)
@@ -117,43 +117,43 @@ describe('ws codex activity protocol', () => {
     await new Promise<void>((resolve) => server.close(() => resolve()))
   })
 
-  it('returns codex.activity.list.response for codex.activity.list requests', async () => {
+  it('returns opencode.activity.list.response for opencode.activity.list requests', async () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
     await new Promise<void>((resolve) => ws.on('open', () => resolve()))
-    ws.send(JSON.stringify({ type: 'hello', token: 'codex-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
+    ws.send(JSON.stringify({ type: 'hello', token: 'opencode-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
     await waitForMessage(ws, (msg) => msg.type === 'ready')
 
-    ws.send(JSON.stringify({ type: 'codex.activity.list', requestId: 'req-codex-1' }))
+    ws.send(JSON.stringify({ type: 'opencode.activity.list', requestId: 'req-opencode-1' }))
     const response = await waitForMessage(
       ws,
-      (msg) => msg.type === 'codex.activity.list.response' && msg.requestId === 'req-codex-1',
+      (msg) => msg.type === 'opencode.activity.list.response' && msg.requestId === 'req-opencode-1',
     )
 
     expect(response.terminals).toEqual(sampleActivity)
     ws.close()
   })
 
-  it('broadcasts codex.activity.updated payloads', async () => {
+  it('broadcasts opencode.activity.updated payloads', async () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
     await new Promise<void>((resolve) => ws.on('open', () => resolve()))
-    ws.send(JSON.stringify({ type: 'hello', token: 'codex-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
+    ws.send(JSON.stringify({ type: 'hello', token: 'opencode-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
     await waitForMessage(ws, (msg) => msg.type === 'ready')
 
-    wsHandler.broadcastCodexActivityUpdated({
+    wsHandler.broadcastOpencodeActivityUpdated({
       upsert: sampleActivity as any,
       remove: [],
     })
 
-    const updated = await waitForMessage(ws, (msg) => msg.type === 'codex.activity.updated')
+    const updated = await waitForMessage(ws, (msg) => msg.type === 'opencode.activity.updated')
     expect(updated).toEqual({
-      type: 'codex.activity.updated',
+      type: 'opencode.activity.updated',
       upsert: sampleActivity,
       remove: [],
     })
     ws.close()
   })
 
-  it('does not broadcast codex.activity.updated payloads to unauthenticated sockets', async () => {
+  it('does not broadcast opencode.activity.updated payloads to unauthenticated sockets', async () => {
     const authenticated = new WebSocket(`ws://127.0.0.1:${port}/ws`)
     const unauthenticated = new WebSocket(`ws://127.0.0.1:${port}/ws`)
 
@@ -162,22 +162,22 @@ describe('ws codex activity protocol', () => {
       new Promise<void>((resolve) => unauthenticated.on('open', () => resolve())),
     ])
 
-    authenticated.send(JSON.stringify({ type: 'hello', token: 'codex-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
+    authenticated.send(JSON.stringify({ type: 'hello', token: 'opencode-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
     await waitForMessage(authenticated, (msg) => msg.type === 'ready')
 
-    wsHandler.broadcastCodexActivityUpdated({
+    wsHandler.broadcastOpencodeActivityUpdated({
       upsert: sampleActivity as any,
       remove: [],
     })
 
-    const updated = await waitForMessage(authenticated, (msg) => msg.type === 'codex.activity.updated')
+    const updated = await waitForMessage(authenticated, (msg) => msg.type === 'opencode.activity.updated')
     expect(updated).toEqual({
-      type: 'codex.activity.updated',
+      type: 'opencode.activity.updated',
       upsert: sampleActivity,
       remove: [],
     })
 
-    await expect(expectNoMatchingMessage(unauthenticated, (msg) => msg.type === 'codex.activity.updated')).resolves.toBeUndefined()
+    await expect(expectNoMatchingMessage(unauthenticated, (msg) => msg.type === 'opencode.activity.updated')).resolves.toBeUndefined()
 
     authenticated.close()
     unauthenticated.close()

--- a/test/server/ws-session-repair-activity.test.ts
+++ b/test/server/ws-session-repair-activity.test.ts
@@ -62,7 +62,7 @@ describe('ws session repair activity', () => {
     sessionRepairService = new FakeSessionRepairService()
     const registry = new FakeRegistry()
 
-    new WsHandler(server, registry as any, undefined, undefined, sessionRepairService as any)
+    new WsHandler(server, registry as any, { sessionRepairService: sessionRepairService as any })
     const info = await listen(server)
     port = info.port
   }, HOOK_TIMEOUT_MS)

--- a/test/server/ws-sidebar-snapshot-refresh.test.ts
+++ b/test/server/ws-sidebar-snapshot-refresh.test.ts
@@ -12,6 +12,10 @@ class FakeRegistry {
   detach() {
     return true
   }
+
+  list() {
+    return []
+  }
 }
 
 function listen(server: http.Server, timeoutMs = HOOK_TIMEOUT_MS): Promise<{ port: number }> {
@@ -96,29 +100,26 @@ describe('ws sidebar snapshot refresh', () => {
     wsHandler = new (WsHandler as any)(
       server,
       new FakeRegistry() as any,
-      undefined,
-      undefined,
-      undefined,
-      async () => ({
-        settings: { theme: 'dark' },
-        projects: [
-          {
-            projectPath: '/demo',
-            sessions: [
-              {
-                provider: 'claude',
-                sessionId: 'older-open',
-                projectPath: '/demo',
-                lastActivityAt: 10,
-              },
-            ],
-          },
-        ],
-      }),
-      undefined,
-      undefined,
-      'srv-local',
-      new (LayoutStore as any)(),
+      {
+        handshakeSnapshotProvider: async () => ({
+          settings: { theme: 'dark' },
+          projects: [
+            {
+              projectPath: '/demo',
+              sessions: [
+                {
+                  provider: 'claude',
+                  sessionId: 'older-open',
+                  projectPath: '/demo',
+                  lastActivityAt: 10,
+                },
+              ],
+            },
+          ],
+        }),
+        serverInstanceId: 'srv-local',
+        layoutStore: new (LayoutStore as any)(),
+      },
     )
 
     const info = await listen(server)

--- a/test/server/ws-tabs-registry.test.ts
+++ b/test/server/ws-tabs-registry.test.ts
@@ -106,12 +106,9 @@ describe('ws tabs registry protocol', () => {
     wsHandler = new WsHandler(
       server,
       new FakeRegistry() as any,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      tabsStore,
+      {
+        tabsRegistryStore: tabsStore,
+      },
     )
     port = await listen(server)
   })

--- a/test/server/ws-terminal-create-session-repair.test.ts
+++ b/test/server/ws-terminal-create-session-repair.test.ts
@@ -293,7 +293,7 @@ describe('terminal.create session repair wait', () => {
 
     sessionRepairService = new FakeSessionRepairService()
     registry = new FakeRegistry()
-    new WsHandler(server, registry as any, undefined, undefined, sessionRepairService as any)
+    new WsHandler(server, registry as any, { sessionRepairService: sessionRepairService as any })
 
     const info = await listen(server)
     port = info.port

--- a/test/server/ws-terminal-meta.test.ts
+++ b/test/server/ws-terminal-meta.test.ts
@@ -101,11 +101,9 @@ describe('ws terminal metadata protocol', () => {
     wsHandler = new WsHandler(
       server,
       new FakeRegistry() as any,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      () => sampleMeta as any,
+      {
+        terminalMetaListProvider: () => sampleMeta as any,
+      },
     )
     port = await listen(server)
   })

--- a/test/unit/client/components/App.ws-bootstrap.test.tsx
+++ b/test/unit/client/components/App.ws-bootstrap.test.tsx
@@ -13,6 +13,7 @@ import terminalMetaReducer from '@/store/terminalMetaSlice'
 import extensionsReducer from '@/store/extensionsSlice'
 import { networkReducer } from '@/store/networkSlice'
 import codexActivityReducer, { type CodexActivityState } from '@/store/codexActivitySlice'
+import opencodeActivityReducer, { type OpencodeActivityState } from '@/store/opencodeActivitySlice'
 import { makeSelectSortedSessionItems } from '@/store/selectors/sidebarSelectors'
 import {
   composeResolvedSettings,
@@ -129,9 +130,16 @@ function createStore(options?: {
     zoomedPane?: Record<string, string>
   }
   codexActivity?: Partial<CodexActivityState>
+  opencodeActivity?: Partial<OpencodeActivityState>
   sessions?: Record<string, unknown>
 }) {
   const defaultCodexActivity: CodexActivityState = {
+    byTerminalId: {},
+    lastSnapshotSeq: 0,
+    liveMutationSeqByTerminalId: {},
+    removedMutationSeqByTerminalId: {},
+  }
+  const defaultOpencodeActivity: OpencodeActivityState = {
     byTerminalId: {},
     lastSnapshotSeq: 0,
     liveMutationSeqByTerminalId: {},
@@ -156,6 +164,7 @@ function createStore(options?: {
       panes: panesReducer,
       network: networkReducer,
       codexActivity: codexActivityReducer,
+      opencodeActivity: opencodeActivityReducer,
       tabRegistry: tabRegistryReducer,
       terminalMeta: terminalMetaReducer,
       extensions: extensionsReducer,
@@ -187,6 +196,10 @@ function createStore(options?: {
       codexActivity: {
         ...defaultCodexActivity,
         ...(options?.codexActivity ?? {}),
+      },
+      opencodeActivity: {
+        ...defaultOpencodeActivity,
+        ...(options?.opencodeActivity ?? {}),
       },
       tabRegistry: {
         deviceId: 'device-test',
@@ -535,6 +548,7 @@ describe('App WS bootstrap recovery', () => {
     expect(bootstrapCalls).toBe(2)
     expect(sidebarCalls).toBe(2)
     expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'codex.activity.list' }))
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'opencode.activity.list' }))
   })
 
   it('repairs missing bootstrap platform capabilities from /api/platform after websocket readiness', async () => {
@@ -752,6 +766,40 @@ describe('App WS bootstrap recovery', () => {
     })
 
     expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'codex.activity.list' }))
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'opencode.activity.list' }))
+  })
+
+  it('clears stale opencode activity immediately when bootstrap attaches to an already-ready socket', async () => {
+    const store = createStore({
+      opencodeActivity: {
+        byTerminalId: {
+          'term-stale': {
+            terminalId: 'term-stale',
+            sessionId: 'session-stale',
+            phase: 'busy',
+            updatedAt: 10,
+          },
+        },
+        lastSnapshotSeq: 4,
+        liveMutationSeqByTerminalId: { 'term-stale': 4 },
+      },
+    })
+    wsMocks.isReady = true
+    wsMocks.serverInstanceId = 'srv-preconnected-opencode-stale'
+
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(store.getState().connection.status).toBe('ready')
+      expect(store.getState().connection.serverInstanceId).toBe('srv-preconnected-opencode-stale')
+      expect(store.getState().opencodeActivity.byTerminalId).toEqual({})
+    })
+
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'opencode.activity.list' }))
   })
 
   it('mounts with legacy ws clients that do not implement onDisconnect', async () => {
@@ -819,6 +867,48 @@ describe('App WS bootstrap recovery', () => {
     })
   })
 
+  it('clears opencode activity promptly when the websocket disconnects after readiness', async () => {
+    const store = createStore()
+    wsMocks.isReady = true
+    wsMocks.serverInstanceId = 'srv-preconnected-opencode-disconnect'
+
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(store.getState().connection.status).toBe('ready')
+    })
+
+    act(() => {
+      messageHandler?.({
+        type: 'opencode.activity.updated',
+        upsert: [{
+          terminalId: 'term-live',
+          sessionId: 'session-live',
+          phase: 'busy',
+          updatedAt: 20,
+        }],
+        remove: [],
+      })
+    })
+
+    await waitFor(() => {
+      expect(store.getState().opencodeActivity.byTerminalId['term-live']?.phase).toBe('busy')
+    })
+
+    act(() => {
+      disconnectHandler?.()
+    })
+
+    await waitFor(() => {
+      expect(store.getState().connection.status).toBe('disconnected')
+      expect(store.getState().opencodeActivity.byTerminalId).toEqual({})
+    })
+  })
+
   it('keeps the WS message handler registered after an initial connect failure, so a later ready can recover state', async () => {
     const store = createStore()
 
@@ -853,6 +943,7 @@ describe('App WS bootstrap recovery', () => {
 
     expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'terminal.meta.list' }))
     expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'codex.activity.list' }))
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'opencode.activity.list' }))
   })
 
   it('dispatches wsCloseCode to lastErrorCode in Redux when connect rejects with close code', async () => {
@@ -1043,6 +1134,7 @@ describe('App WS bootstrap recovery', () => {
     expect(wsMocks.connect).not.toHaveBeenCalled()
     expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'terminal.meta.list' }))
     expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'codex.activity.list' }))
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'opencode.activity.list' }))
     expect(fetchSidebarSessionsSnapshot).not.toHaveBeenCalled()
     expect(store.getState().sessions.projects.map((p: any) => p.projectPath)).toEqual(['/p1'])
 
@@ -1130,6 +1222,7 @@ describe('App WS bootstrap recovery', () => {
     expect(wsMocks.connect).not.toHaveBeenCalled()
     expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'terminal.meta.list' }))
     expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'codex.activity.list' }))
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'opencode.activity.list' }))
   })
 
   it('keeps the active non-sidebar session surface during websocket recovery when the sidebar window is already loaded', async () => {
@@ -1243,5 +1336,61 @@ describe('App WS bootstrap recovery', () => {
     })
 
     expect(store.getState().codexActivity.byTerminalId['term-1']?.phase).toBe('idle')
+  })
+
+  it('ignores stale opencode activity list responses that arrive after a newer snapshot', async () => {
+    const store = createStore()
+    wsMocks.isReady = true
+    wsMocks.serverInstanceId = 'srv-preconnected-opencode-race'
+
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    )
+
+    expect(messageHandler).toBeTypeOf('function')
+    act(() => {
+      messageHandler?.({
+        type: 'ready',
+        timestamp: new Date().toISOString(),
+        serverInstanceId: 'srv-preconnected-opencode-race',
+      })
+    })
+
+    await waitFor(() => {
+      const requests = wsMocks.send.mock.calls
+        .map(([payload]) => payload)
+        .filter((payload) => payload?.type === 'opencode.activity.list')
+      expect(requests.length).toBeGreaterThanOrEqual(2)
+    })
+
+    const requests = wsMocks.send.mock.calls
+      .map(([payload]) => payload)
+      .filter((payload) => payload?.type === 'opencode.activity.list')
+    const olderRequestId = requests[0]?.requestId as string
+    const newerRequestId = requests.at(-1)?.requestId as string
+
+    act(() => {
+      messageHandler?.({
+        type: 'opencode.activity.list.response',
+        requestId: newerRequestId,
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 200,
+          },
+        ],
+      })
+      messageHandler?.({
+        type: 'opencode.activity.list.response',
+        requestId: olderRequestId,
+        terminals: [],
+      })
+    })
+
+    expect(store.getState().opencodeActivity.byTerminalId['term-1']?.phase).toBe('busy')
   })
 })

--- a/test/unit/client/components/MobileTabStrip.test.tsx
+++ b/test/unit/client/components/MobileTabStrip.test.tsx
@@ -7,6 +7,7 @@ import panesReducer from '@/store/panesSlice'
 import connectionReducer from '@/store/connectionSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import codexActivityReducer, { type CodexActivityState } from '@/store/codexActivitySlice'
+import opencodeActivityReducer, { type OpencodeActivityState } from '@/store/opencodeActivitySlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
 import type { Tab } from '@/store/types'
 import type { PaneNode } from '@/store/paneTypes'
@@ -56,7 +57,12 @@ function createLeafLayout(tab: Tab): PaneNode {
 function createStore(
   tabs: Tab[],
   activeTabId: string,
-  opts?: { codexActivity?: Partial<CodexActivityState>; includeCodexActivity?: boolean },
+  opts?: {
+    codexActivity?: Partial<CodexActivityState>
+    opencodeActivity?: Partial<OpencodeActivityState>
+    includeCodexActivity?: boolean
+    includeOpencodeActivity?: boolean
+  },
 ) {
   const layouts: Record<string, PaneNode> = {}
   const activePane: Record<string, string> = {}
@@ -72,6 +78,13 @@ function createStore(
     liveMutationSeqByTerminalId: {},
     removedMutationSeqByTerminalId: {},
   }
+  const includeOpencodeActivity = opts?.includeOpencodeActivity ?? true
+  const defaultOpencodeActivity: OpencodeActivityState = {
+    byTerminalId: {},
+    lastSnapshotSeq: 0,
+    liveMutationSeqByTerminalId: {},
+    removedMutationSeqByTerminalId: {},
+  }
 
   const reducer = {
     tabs: tabsReducer,
@@ -80,6 +93,7 @@ function createStore(
     settings: settingsReducer,
     turnCompletion: turnCompletionReducer,
     ...(includeCodexActivity ? { codexActivity: codexActivityReducer } : {}),
+    ...(includeOpencodeActivity ? { opencodeActivity: opencodeActivityReducer } : {}),
   }
   const preloadedState: Record<string, unknown> = {
     tabs: {
@@ -111,6 +125,12 @@ function createStore(
     preloadedState.codexActivity = {
       ...defaultCodexActivity,
       ...(opts?.codexActivity ?? {}),
+    }
+  }
+  if (includeOpencodeActivity) {
+    preloadedState.opencodeActivity = {
+      ...defaultOpencodeActivity,
+      ...(opts?.opencodeActivity ?? {}),
     }
   }
 
@@ -336,6 +356,37 @@ describe('MobileTabStrip', () => {
     expect(badge.className).toContain('bg-blue-500/15')
     expect(badge.className).toContain('text-blue-600')
     expect(badge.className).not.toContain('animate-pulse')
+  })
+
+  it('shows a busy badge when the active opencode tab has exact busy activity', async () => {
+    const { MobileTabStrip } = await import('@/components/MobileTabStrip')
+    const opencodeTab = createTab('tab-1', 'OpenCode', {
+      mode: 'opencode',
+      terminalId: 'term-opencode',
+    })
+    const store = createStore([opencodeTab], 'tab-1', {
+      opencodeActivity: {
+        byTerminalId: {
+          'term-opencode': {
+            terminalId: 'term-opencode',
+            sessionId: 'session-opencode',
+            phase: 'busy',
+            updatedAt: 10,
+          },
+        },
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <MobileTabStrip />
+      </Provider>
+    )
+
+    const badge = screen.getByTestId('mobile-tab-busy-badge')
+    expect(badge).toHaveTextContent('Busy')
+    expect(badge.className).toContain('bg-blue-500/15')
+    expect(badge.className).toContain('text-blue-600')
   })
 
   it('does not warn about selector instability when codex activity state is absent', async () => {

--- a/test/unit/client/components/Sidebar.test.tsx
+++ b/test/unit/client/components/Sidebar.test.tsx
@@ -15,6 +15,7 @@ import sessionsReducer, {
 import sessionActivityReducer from '@/store/sessionActivitySlice'
 import extensionsReducer from '@/store/extensionsSlice'
 import codexActivityReducer, { type CodexActivityState } from '@/store/codexActivitySlice'
+import opencodeActivityReducer, { type OpencodeActivityState } from '@/store/opencodeActivitySlice'
 import terminalDirectoryReducer, { setTerminalDirectoryWindowData } from '@/store/terminalDirectorySlice'
 import type { ProjectGroup, BackgroundTerminal, TabMode } from '@/store/types'
 import type { PaneNode } from '@/store/paneTypes'
@@ -101,6 +102,7 @@ function createTestStore(options?: {
   sessionOpenMode?: 'tab' | 'split'
   sessionActivity?: Record<string, number>
   codexActivity?: Partial<CodexActivityState>
+  opencodeActivity?: Partial<OpencodeActivityState>
 }) {
   const projects = (options?.projects ?? []).map((project) => ({
     ...project,
@@ -142,6 +144,7 @@ function createTestStore(options?: {
       sessionActivity: sessionActivityReducer,
       extensions: extensionsReducer,
       codexActivity: codexActivityReducer,
+      opencodeActivity: opencodeActivityReducer,
       terminalDirectory: terminalDirectoryReducer,
     },
     middleware: (getDefault) =>
@@ -202,6 +205,13 @@ function createTestStore(options?: {
         liveMutationSeqByTerminalId: {},
         removedMutationSeqByTerminalId: {},
         ...(options?.codexActivity ?? {}),
+      },
+      opencodeActivity: {
+        byTerminalId: {},
+        lastSnapshotSeq: 0,
+        liveMutationSeqByTerminalId: {},
+        removedMutationSeqByTerminalId: {},
+        ...(options?.opencodeActivity ?? {}),
       },
       terminalDirectory: {
         windows: {
@@ -1155,6 +1165,91 @@ describe('Sidebar Component - Session-Centric Display', () => {
       const button = screen.getByRole('button', { name: /Multi terminal/ })
       expect(button.querySelector('.text-blue-500')).toBeTruthy()
       expect(button.querySelector('.text-success')).toBeFalsy()
+    })
+
+    it('shows blue for a busy opencode session when the exact terminal is active', async () => {
+      const now = Date.now()
+      const terminalId = 'term-opencode'
+      const busySessionId = sessionId('busy-opencode')
+      const idleSessionId = sessionId('idle-opencode')
+      const projects: ProjectGroup[] = [
+        {
+          projectPath: '/home/user/project',
+          sessions: [
+            {
+              sessionId: busySessionId,
+              projectPath: '/home/user/project',
+              lastActivityAt: now,
+              title: 'Busy opencode session',
+              cwd: '/home/user/project',
+              provider: 'opencode',
+            },
+            {
+              sessionId: idleSessionId,
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 1000,
+              title: 'Idle opencode session',
+              cwd: '/home/user/project',
+              provider: 'opencode',
+            },
+          ],
+        },
+      ]
+
+      const tabs = [
+        {
+          id: 'tab-1',
+          terminalId,
+          resumeSessionId: busySessionId,
+          mode: 'opencode',
+        },
+        {
+          id: 'tab-2',
+          resumeSessionId: idleSessionId,
+          mode: 'opencode',
+        },
+      ]
+
+      const terminals: BackgroundTerminal[] = [
+        {
+          terminalId,
+          title: 'OpenCode',
+          createdAt: now,
+          status: 'running',
+          hasClients: true,
+          mode: 'opencode',
+          resumeSessionId: busySessionId,
+        },
+      ]
+
+      const store = createTestStore({
+        projects,
+        tabs,
+        sortMode: 'activity',
+        opencodeActivity: {
+          byTerminalId: {
+            [terminalId]: {
+              terminalId,
+              sessionId: busySessionId,
+              phase: 'busy',
+              updatedAt: 10,
+            },
+          },
+        },
+      })
+      renderSidebar(store, terminals)
+
+      await act(async () => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const busyButton = screen.getByRole('button', { name: /Busy opencode session/ })
+      expect(busyButton.querySelector('.text-blue-500')).toBeTruthy()
+      expect(busyButton.querySelector('.text-success')).toBeFalsy()
+
+      const idleButton = screen.getByRole('button', { name: /Idle opencode session/ })
+      expect(idleButton.querySelector('.text-success')).toBeTruthy()
+      expect(idleButton.querySelector('.text-blue-500')).toBeFalsy()
     })
   })
 

--- a/test/unit/client/components/TabBar.test.tsx
+++ b/test/unit/client/components/TabBar.test.tsx
@@ -6,6 +6,7 @@ import TabBar from '@/components/TabBar'
 import tabsReducer, { TabsState } from '@/store/tabsSlice'
 import codingCliReducer, { registerCodingCliRequest } from '@/store/codingCliSlice'
 import codexActivityReducer, { type CodexActivityState } from '@/store/codexActivitySlice'
+import opencodeActivityReducer, { type OpencodeActivityState } from '@/store/opencodeActivitySlice'
 import panesReducer from '@/store/panesSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
@@ -128,6 +129,12 @@ function createStore(
     liveMutationSeqByTerminalId: {},
     removedMutationSeqByTerminalId: {},
   },
+  opencodeActivityState: OpencodeActivityState = {
+    byTerminalId: {},
+    lastSnapshotSeq: 0,
+    liveMutationSeqByTerminalId: {},
+    removedMutationSeqByTerminalId: {},
+  },
 ) {
   const serverSettings = createDefaultServerSettings({
     loggingDebug: defaultSettings.logging.debug,
@@ -139,6 +146,7 @@ function createStore(
       tabs: tabsReducer,
       codingCli: codingCliReducer,
       codexActivity: codexActivityReducer,
+      opencodeActivity: opencodeActivityReducer,
       panes: panesReducer,
       settings: settingsReducer,
       turnCompletion: turnCompletionReducer,
@@ -155,6 +163,7 @@ function createStore(
         pendingRequests: {},
       },
       codexActivity: codexActivityState,
+      opencodeActivity: opencodeActivityState,
       panes: {
         layouts: {},
         activePane: {},
@@ -410,6 +419,39 @@ describe('TabBar', () => {
         .filter((icon) => icon.getAttribute('class')?.includes('text-blue-500'))
 
       expect(blueIcons).toHaveLength(0)
+    })
+
+    it('shows blue icon on the exact busy OpenCode terminal in a tab', () => {
+      const tab = createTab({
+        id: 'tab-opencode',
+        title: 'OpenCode Tab',
+        mode: 'opencode',
+        terminalId: 'term-opencode-1',
+      })
+      const store = createStore(
+        { tabs: [tab], activeTabId: 'tab-opencode' },
+        {},
+        { layouts: { 'tab-opencode': createTwoTerminalSplitLayout('term-opencode-1', 'term-opencode-2') } },
+        undefined,
+        {
+          byTerminalId: {
+            'term-opencode-1': { terminalId: 'term-opencode-1', phase: 'busy', updatedAt: 10 },
+          },
+          lastSnapshotSeq: 0,
+          liveMutationSeqByTerminalId: {},
+          removedMutationSeqByTerminalId: {},
+        },
+      )
+
+      renderWithStore(<TabBar />, store)
+
+      const tabElement = screen.getByLabelText('OpenCode Tab')
+      const icons = within(tabElement).getAllByTestId('pane-icon')
+      const busyIcon = icons.find((icon) => icon.getAttribute('data-terminal-id') === 'term-opencode-1')
+      const idleIcon = icons.find((icon) => icon.getAttribute('data-terminal-id') === 'term-opencode-2')
+
+      expect(busyIcon?.getAttribute('class')).toContain('text-blue-500')
+      expect(idleIcon?.getAttribute('class') ?? '').not.toContain('text-blue-500')
     })
   })
 

--- a/test/unit/client/components/TabSwitcher.test.tsx
+++ b/test/unit/client/components/TabSwitcher.test.tsx
@@ -7,6 +7,7 @@ import panesReducer from '@/store/panesSlice'
 import connectionReducer from '@/store/connectionSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import codexActivityReducer, { type CodexActivityState } from '@/store/codexActivitySlice'
+import opencodeActivityReducer, { type OpencodeActivityState } from '@/store/opencodeActivitySlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
 import type { Tab } from '@/store/types'
 import type { PaneNode } from '@/store/paneTypes'
@@ -56,7 +57,12 @@ function createLeafLayout(tab: Tab): PaneNode {
 function createStore(
   tabs: Tab[],
   activeTabId: string,
-  opts?: { codexActivity?: Partial<CodexActivityState>; includeCodexActivity?: boolean },
+  opts?: {
+    codexActivity?: Partial<CodexActivityState>
+    opencodeActivity?: Partial<OpencodeActivityState>
+    includeCodexActivity?: boolean
+    includeOpencodeActivity?: boolean
+  },
 ) {
   const layouts: Record<string, PaneNode> = {}
   const activePane: Record<string, string> = {}
@@ -72,6 +78,13 @@ function createStore(
     liveMutationSeqByTerminalId: {},
     removedMutationSeqByTerminalId: {},
   }
+  const includeOpencodeActivity = opts?.includeOpencodeActivity ?? true
+  const defaultOpencodeActivity: OpencodeActivityState = {
+    byTerminalId: {},
+    lastSnapshotSeq: 0,
+    liveMutationSeqByTerminalId: {},
+    removedMutationSeqByTerminalId: {},
+  }
 
   const reducer = {
     tabs: tabsReducer,
@@ -80,6 +93,7 @@ function createStore(
     settings: settingsReducer,
     turnCompletion: turnCompletionReducer,
     ...(includeCodexActivity ? { codexActivity: codexActivityReducer } : {}),
+    ...(includeOpencodeActivity ? { opencodeActivity: opencodeActivityReducer } : {}),
   }
   const preloadedState: Record<string, unknown> = {
     tabs: {
@@ -111,6 +125,12 @@ function createStore(
     preloadedState.codexActivity = {
       ...defaultCodexActivity,
       ...(opts?.codexActivity ?? {}),
+    }
+  }
+  if (includeOpencodeActivity) {
+    preloadedState.opencodeActivity = {
+      ...defaultOpencodeActivity,
+      ...(opts?.opencodeActivity ?? {}),
     }
   }
 
@@ -406,6 +426,42 @@ describe('TabSwitcher', () => {
     expect(badge.className).toContain('bg-blue-500/15')
     expect(badge.className).toContain('text-blue-600')
     expect(badge.className).not.toContain('animate-pulse')
+  })
+
+  it('shows a busy badge only on tabs with exact busy opencode activity', async () => {
+    const { TabSwitcher } = await import('@/components/TabSwitcher')
+    const shellTab = createTab('tab-1', 'Shell')
+    const opencodeTab = createTab('tab-2', 'OpenCode', {
+      mode: 'opencode',
+      terminalId: 'term-opencode',
+    })
+    const store = createStore([shellTab, opencodeTab], 'tab-1', {
+      opencodeActivity: {
+        byTerminalId: {
+          'term-opencode': {
+            terminalId: 'term-opencode',
+            sessionId: 'session-opencode',
+            phase: 'busy',
+            updatedAt: 10,
+          },
+        },
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <TabSwitcher onClose={() => {}} />
+      </Provider>
+    )
+
+    const shellCard = screen.getByRole('button', { name: /switch to shell/i })
+    const opencodeCard = screen.getByRole('button', { name: /switch to opencode/i })
+
+    expect(within(shellCard).queryByText('Busy')).not.toBeInTheDocument()
+    const badge = within(opencodeCard).getByTestId('tab-switcher-busy-badge-tab-2')
+    expect(badge).toHaveTextContent('Busy')
+    expect(badge.className).toContain('bg-blue-500/15')
+    expect(badge.className).toContain('text-blue-600')
   })
 
   it('does not warn about selector instability when codex activity state is absent', async () => {

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -11,6 +11,7 @@ import extensionsReducer from '@/store/extensionsSlice'
 import terminalMetaReducer from '@/store/terminalMetaSlice'
 import sessionsReducer, { applySessionsPatch, type SessionsState } from '@/store/sessionsSlice'
 import agentChatReducer, { turnResult } from '@/store/agentChatSlice'
+import opencodeActivityReducer, { upsertOpencodeActivity } from '@/store/opencodeActivitySlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
 import { markTabAttention, markPaneAttention } from '@/store/turnCompletionSlice'
 import type { PanesState } from '@/store/panesSlice'
@@ -223,6 +224,7 @@ function createStore(
       terminalMeta: terminalMetaReducer,
       sessions: sessionsReducer,
       agentChat: agentChatReducer,
+      opencodeActivity: opencodeActivityReducer,
       turnCompletion: turnCompletionReducer,
     },
     middleware: (getDefaultMiddleware) =>
@@ -269,6 +271,12 @@ function createStore(
         pendingCreates: {},
         availableModels: [],
         ...initialAgentChatState,
+      },
+      opencodeActivity: {
+        byTerminalId: {},
+        lastSnapshotSeq: 0,
+        liveMutationSeqByTerminalId: {},
+        removedMutationSeqByTerminalId: {},
       },
     },
   })
@@ -908,6 +916,41 @@ describe('PaneContainer', () => {
       )
 
       expect(screen.getByTestId(`terminal-${paneId}`)).toBeInTheDocument()
+    })
+
+    it('marks an opencode pane busy when the exact terminal has live activity', () => {
+      const paneId = 'pane-1'
+      const leafNode: PaneNode = {
+        type: 'leaf',
+        id: paneId,
+        content: createTerminalContent({
+          mode: 'opencode',
+          status: 'running',
+          createRequestId: 'req-pane-1',
+          terminalId: 'term-opencode',
+        }),
+      }
+
+      const store = createStore({
+        layouts: { 'tab-1': leafNode },
+        activePane: { 'tab-1': paneId },
+      })
+      store.dispatch(upsertOpencodeActivity({
+        terminals: [{
+          terminalId: 'term-opencode',
+          sessionId: 'session-opencode',
+          phase: 'busy',
+          updatedAt: 10,
+        }],
+      }))
+
+      renderWithStore(
+        <PaneContainer tabId="tab-1" node={leafNode} />,
+        store
+      )
+
+      const pane = screen.getByRole('group', { name: /pane: opencode/i })
+      expect(pane.querySelector('svg.text-blue-500')).toBeTruthy()
     })
 
     it('renders browser content for leaf node', () => {

--- a/test/unit/client/lib/pane-activity.test.ts
+++ b/test/unit/client/lib/pane-activity.test.ts
@@ -23,6 +23,7 @@ describe('pane activity', () => {
       codexActivityByTerminalId: {
         'term-live': { terminalId: 'term-live', phase: 'busy', updatedAt: 10 },
       },
+      opencodeActivityByTerminalId: {},
       paneRuntimeActivityByPaneId: {},
       agentChatSessions: {},
     })).toMatchObject({ isBusy: true, source: 'codex' })
@@ -35,6 +36,7 @@ describe('pane activity', () => {
       codexActivityByTerminalId: {
         'term-live': { terminalId: 'term-live', phase: 'pending', updatedAt: 10 },
       },
+      opencodeActivityByTerminalId: {},
       paneRuntimeActivityByPaneId: {},
       agentChatSessions: {},
     }).isBusy).toBe(false)
@@ -45,6 +47,43 @@ describe('pane activity', () => {
       tabTerminalId: undefined,
       isOnlyPane: false,
       codexActivityByTerminalId: {
+        'term-foreign': { terminalId: 'term-foreign', phase: 'busy', updatedAt: 10 },
+      },
+      opencodeActivityByTerminalId: {},
+      paneRuntimeActivityByPaneId: {},
+      agentChatSessions: {},
+    }).isBusy).toBe(false)
+  })
+
+  it('keeps OpenCode exact-match semantics and only treats live terminal matches as busy', () => {
+    const content: TerminalPaneContent = {
+      kind: 'terminal',
+      createRequestId: 'req-opencode',
+      status: 'running',
+      mode: 'opencode',
+      terminalId: 'term-live',
+      shell: 'system',
+      resumeSessionId: 'session-opencode',
+    }
+
+    expect(resolvePaneActivity({
+      paneId: 'pane-1',
+      content,
+      isOnlyPane: true,
+      codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {
+        'term-live': { terminalId: 'term-live', phase: 'busy', updatedAt: 10 },
+      },
+      paneRuntimeActivityByPaneId: {},
+      agentChatSessions: {},
+    })).toMatchObject({ isBusy: true, source: 'opencode' })
+
+    expect(resolvePaneActivity({
+      paneId: 'pane-1',
+      content: { ...content, terminalId: undefined },
+      isOnlyPane: true,
+      codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {
         'term-foreign': { terminalId: 'term-foreign', phase: 'busy', updatedAt: 10 },
       },
       paneRuntimeActivityByPaneId: {},
@@ -111,6 +150,7 @@ describe('pane activity', () => {
       tabs,
       paneLayouts,
       codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {},
       paneRuntimeActivityByPaneId: {
         'pane-claude': {
           source: 'terminal',
@@ -171,6 +211,7 @@ describe('pane activity', () => {
         },
       },
       codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {},
       paneRuntimeActivityByPaneId: {},
       agentChatSessions: {
         'sdk-restore-1': {
@@ -222,6 +263,7 @@ describe('pane activity', () => {
         },
       },
       codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {},
       paneRuntimeActivityByPaneId: {},
       agentChatSessions: {
         'sdk-restore-2': {
@@ -244,5 +286,52 @@ describe('pane activity', () => {
     })
 
     expect(busySessionKeys).toEqual(['claude:00000000-0000-4000-8000-000000000321'])
+  })
+
+  it('collects busy session keys from OpenCode terminals using exact terminal matches', () => {
+    const sessionId = '33333333-3333-4333-8333-333333333333'
+    const busySessionKeys = collectBusySessionKeys({
+      tabs: [
+        {
+          id: 'tab-opencode',
+          title: 'OpenCode',
+          createRequestId: 'req-opencode',
+          status: 'running',
+          mode: 'opencode',
+          shell: 'system',
+          createdAt: 1,
+          terminalId: 'term-live',
+          resumeSessionId: sessionId,
+        },
+      ],
+      paneLayouts: {
+        'tab-opencode': {
+          type: 'leaf',
+          id: 'pane-opencode',
+          content: {
+            kind: 'terminal',
+            createRequestId: 'req-opencode',
+            status: 'running',
+            mode: 'opencode',
+            shell: 'system',
+            terminalId: 'term-live',
+            resumeSessionId: sessionId,
+          },
+        },
+      },
+      codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {
+        'term-live': {
+          terminalId: 'term-live',
+          sessionId,
+          phase: 'busy',
+          updatedAt: 1,
+        },
+      },
+      paneRuntimeActivityByPaneId: {},
+      agentChatSessions: {},
+    })
+
+    expect(busySessionKeys).toEqual([`opencode:${sessionId}`])
   })
 })

--- a/test/unit/client/store/opencodeActivitySlice.test.ts
+++ b/test/unit/client/store/opencodeActivitySlice.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest'
+import opencodeActivityReducer, {
+  removeOpencodeActivity,
+  resetOpencodeActivity,
+  setOpencodeActivitySnapshot,
+  upsertOpencodeActivity,
+} from '@/store/opencodeActivitySlice'
+
+describe('opencodeActivitySlice', () => {
+  it('replaces state from opencode.activity.list.response snapshot payloads', () => {
+    const first = opencodeActivityReducer(
+      undefined,
+      setOpencodeActivitySnapshot({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 100,
+          },
+        ],
+      }),
+    )
+
+    const second = opencodeActivityReducer(
+      first,
+      setOpencodeActivitySnapshot({
+        terminals: [
+          {
+            terminalId: 'term-2',
+            sessionId: 'session-2',
+            phase: 'busy',
+            updatedAt: 200,
+          },
+        ],
+        requestSeq: 2,
+      }),
+    )
+
+    expect(Object.keys(second.byTerminalId)).toEqual(['term-2'])
+    expect(second.byTerminalId['term-2']?.phase).toBe('busy')
+  })
+
+  it('ignores older snapshots that arrive after a newer snapshot already applied', () => {
+    const newest = opencodeActivityReducer(
+      undefined,
+      setOpencodeActivitySnapshot({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 200,
+          },
+        ],
+        requestSeq: 2,
+      }),
+    )
+
+    const stale = opencodeActivityReducer(
+      newest,
+      setOpencodeActivitySnapshot({
+        terminals: [],
+        requestSeq: 1,
+      }),
+    )
+
+    expect(stale.byTerminalId['term-1']?.phase).toBe('busy')
+  })
+
+  it('preserves newer live upserts when an older snapshot arrives', () => {
+    const stateWithUpsert = opencodeActivityReducer(
+      undefined,
+      upsertOpencodeActivity({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 500,
+          },
+        ],
+        mutationSeq: 2,
+      }),
+    )
+
+    const next = opencodeActivityReducer(
+      stateWithUpsert,
+      setOpencodeActivitySnapshot({
+        terminals: [],
+        requestSeq: 1,
+      }),
+    )
+
+    expect(next.byTerminalId['term-1']?.phase).toBe('busy')
+  })
+
+  it('ratchets upserts by updatedAt', () => {
+    const initial = opencodeActivityReducer(
+      undefined,
+      upsertOpencodeActivity({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 500,
+          },
+        ],
+        mutationSeq: 1,
+      }),
+    )
+
+    const next = opencodeActivityReducer(
+      initial,
+      upsertOpencodeActivity({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 400,
+          },
+          {
+            terminalId: 'term-2',
+            sessionId: 'session-2',
+            phase: 'busy',
+            updatedAt: 600,
+          },
+        ],
+        mutationSeq: 2,
+      }),
+    )
+
+    expect(next.byTerminalId['term-1']?.updatedAt).toBe(500)
+    expect(next.byTerminalId['term-2']?.phase).toBe('busy')
+  })
+
+  it('keeps removals authoritative even when snapshot and record timestamps are older on the client clock', () => {
+    const initial = opencodeActivityReducer(
+      undefined,
+      upsertOpencodeActivity({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 1_000,
+          },
+        ],
+        mutationSeq: 10,
+      }),
+    )
+
+    const removed = opencodeActivityReducer(
+      initial,
+      removeOpencodeActivity({
+        terminalIds: ['term-1'],
+        mutationSeq: 11,
+      }),
+    )
+
+    const next = opencodeActivityReducer(
+      removed,
+      setOpencodeActivitySnapshot({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 900,
+          },
+        ],
+        requestSeq: 9,
+      }),
+    )
+
+    expect(next.byTerminalId['term-1']).toBeUndefined()
+  })
+
+  it('resets stale overlay records and sequencing state', () => {
+    const populated = opencodeActivityReducer(
+      undefined,
+      upsertOpencodeActivity({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 1_000,
+          },
+        ],
+        mutationSeq: 7,
+      }),
+    )
+
+    const removed = opencodeActivityReducer(
+      populated,
+      removeOpencodeActivity({
+        terminalIds: ['term-2'],
+        mutationSeq: 8,
+      }),
+    )
+
+    const reset = opencodeActivityReducer(removed, resetOpencodeActivity())
+
+    expect(reset).toEqual({
+      byTerminalId: {},
+      lastSnapshotSeq: 0,
+      liveMutationSeqByTerminalId: {},
+      removedMutationSeqByTerminalId: {},
+    })
+  })
+})

--- a/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
+++ b/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  OPENCODE_HEALTH_POLL_MS,
+  OPENCODE_RECONNECT_BASE_MS,
+  OpencodeActivityTracker,
+} from '../../../../server/coding-cli/opencode-activity-tracker'
+
+const TEST_ENDPOINT = { hostname: '127.0.0.1' as const, port: 43123 }
+
+function createJsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}
+
+function createSseResponse(events: unknown[]) {
+  const encoder = new TextEncoder()
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
+      }
+      controller.close()
+    },
+  }), {
+    headers: { 'content-type': 'text/event-stream' },
+  })
+}
+
+function createRawSseResponse(blocks: string[]) {
+  const encoder = new TextEncoder()
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const block of blocks) {
+        controller.enqueue(encoder.encode(block))
+      }
+      controller.close()
+    },
+  }), {
+    headers: { 'content-type': 'text/event-stream' },
+  })
+}
+
+describe('OpencodeActivityTracker', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('waits for health to become ready, snapshots busy state, and emits an upsert', async () => {
+    vi.useFakeTimers()
+    let healthCalls = 0
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        healthCalls += 1
+        return healthCalls === 1
+          ? new Response('not ready', { status: 503 })
+          : createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({
+          'session-oc': { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([{ type: 'server.connected', properties: {} }])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('changed', (payload) => changes.push(payload))
+
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(changes).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(OPENCODE_HEALTH_POLL_MS)
+
+    expect(changes).toContainEqual({
+      upsert: [{
+        terminalId: 'term-oc',
+        sessionId: 'session-oc',
+        phase: 'busy',
+        updatedAt: expect.any(Number),
+      }],
+      remove: [],
+    })
+
+    tracker.dispose()
+  })
+
+  it('keeps health polling on connection errors until the endpoint comes up', async () => {
+    vi.useFakeTimers()
+    let healthCalls = 0
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        healthCalls += 1
+        if (healthCalls === 1) {
+          throw new Error('connect ECONNREFUSED')
+        }
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({
+          'session-oc': { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([{ type: 'server.connected', properties: {} }])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(tracker.list()).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(OPENCODE_HEALTH_POLL_MS)
+    expect(healthCalls).toBe(2)
+    expect(tracker.list()).toEqual([expect.objectContaining({
+      terminalId: 'term-oc',
+      sessionId: 'session-oc',
+      phase: 'busy',
+    })])
+
+    tracker.dispose()
+  })
+
+  it('removes busy state when session.status reports idle for the tracked session', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({
+          'session-oc': { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([
+          { type: 'server.connected', properties: {} },
+          {
+            type: 'session.status',
+            properties: {
+              sessionID: 'session-oc',
+              status: { type: 'idle' },
+            },
+          },
+        ])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('changed', (payload) => changes.push(payload))
+
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(changes).toContainEqual({
+      upsert: [{
+        terminalId: 'term-oc',
+        sessionId: 'session-oc',
+        phase: 'busy',
+        updatedAt: expect.any(Number),
+      }],
+      remove: [],
+    })
+    expect(changes).toContainEqual({
+      upsert: [],
+      remove: ['term-oc'],
+    })
+    expect(tracker.list()).toEqual([])
+
+    tracker.dispose()
+  })
+
+  it('ignores session.idle for a different session than the tracked busy session', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({
+          'session-oc': { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([
+          { type: 'server.connected', properties: {} },
+          {
+            type: 'session.idle',
+            properties: {
+              sessionID: 'different-session',
+            },
+          },
+        ])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('changed', (payload) => changes.push(payload))
+
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(changes).toHaveLength(1)
+    expect(tracker.list()).toEqual([expect.objectContaining({
+      terminalId: 'term-oc',
+      sessionId: 'session-oc',
+      phase: 'busy',
+    })])
+
+    tracker.dispose()
+  })
+
+  it('reconnects after the SSE stream closes and resnapshots before removing stale busy state', async () => {
+    vi.useFakeTimers()
+    let snapshotCalls = 0
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        snapshotCalls += 1
+        return createJsonResponse(snapshotCalls === 1
+          ? { 'session-oc': { type: 'retry', attempt: 1 } }
+          : {})
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([{ type: 'server.connected', properties: {} }])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('changed', (payload) => changes.push(payload))
+
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(tracker.list()).toEqual([expect.objectContaining({
+      terminalId: 'term-oc',
+      sessionId: 'session-oc',
+      phase: 'busy',
+    })])
+
+    await vi.advanceTimersByTimeAsync(OPENCODE_RECONNECT_BASE_MS)
+
+    expect(changes).toContainEqual({
+      upsert: [],
+      remove: ['term-oc'],
+    })
+    expect(tracker.list()).toEqual([])
+
+    tracker.dispose()
+  })
+
+  it('ignores malformed SSE JSON and keeps processing subsequent events from the same stream', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({ 'session-oc': { type: 'busy' } })
+      }
+      if (url.endsWith('/event')) {
+        return createRawSseResponse([
+          'data: {not valid json}\n\n',
+          `data: ${JSON.stringify({ type: 'session.idle', properties: { sessionID: 'session-oc' } })}\n\n`,
+        ])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const log = { warn: vi.fn() }
+    const tracker = new OpencodeActivityTracker({
+      fetchImpl: fetchImpl as typeof fetch,
+      log,
+      random: () => 0,
+    })
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('changed', (payload) => changes.push(payload))
+
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(changes).toContainEqual({
+      upsert: [{
+        terminalId: 'term-oc',
+        sessionId: 'session-oc',
+        phase: 'busy',
+        updatedAt: expect.any(Number),
+      }],
+      remove: [],
+    })
+    expect(changes).toContainEqual({
+      upsert: [],
+      remove: ['term-oc'],
+    })
+    expect(log.warn).toHaveBeenCalledTimes(1)
+    expect(tracker.list()).toEqual([])
+
+    tracker.dispose()
+  })
+
+  it('ignores unknown SSE event types and keeps processing known events from the same stream', async () => {
+    vi.useFakeTimers()
+    let snapshotCalls = 0
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        snapshotCalls += 1
+        return createJsonResponse({
+          'session-oc': { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createRawSseResponse([
+          `data: ${JSON.stringify({ type: 'server.connected', properties: {} })}\n\n`,
+          `data: ${JSON.stringify({ type: 'session.progress', properties: { percent: 50 } })}\n\n`,
+          `data: ${JSON.stringify({ type: 'session.idle', properties: { sessionID: 'session-oc' } })}\n\n`,
+        ])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('changed', (payload) => changes.push(payload))
+
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(changes).toContainEqual({
+      upsert: [{
+        terminalId: 'term-oc',
+        sessionId: 'session-oc',
+        phase: 'busy',
+        updatedAt: expect.any(Number),
+      }],
+      remove: [],
+    })
+    expect(changes).toContainEqual({
+      upsert: [],
+      remove: ['term-oc'],
+    })
+    expect(snapshotCalls).toBe(1)
+    expect(tracker.list()).toEqual([])
+
+    tracker.dispose()
+  })
+
+  it('stops retrying and removes state when the terminal is untracked', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({
+          'session-oc': { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([{ type: 'server.connected', properties: {} }])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(tracker.list()).toEqual([expect.objectContaining({
+      terminalId: 'term-oc',
+      sessionId: 'session-oc',
+      phase: 'busy',
+    })])
+
+    const fetchCallsBeforeStop = fetchImpl.mock.calls.length
+    tracker.untrackTerminal({ terminalId: 'term-oc' })
+
+    expect(tracker.list()).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(OPENCODE_RECONNECT_BASE_MS * 4)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(fetchCallsBeforeStop)
+    tracker.dispose()
+  })
+})

--- a/test/unit/server/terminal-registry.test.ts
+++ b/test/unit/server/terminal-registry.test.ts
@@ -70,6 +70,16 @@ vi.mock('../../../server/mcp/config-writer.js', () => ({
 
 const VALID_CLAUDE_SESSION_ID = '550e8400-e29b-41d4-a716-446655440000'
 const OTHER_CLAUDE_SESSION_ID = '6f1c2b3a-4d5e-6f70-8a9b-0c1d2e3f4a5b'
+const TEST_OPENCODE_SERVER = { hostname: '127.0.0.1' as const, port: 43123 }
+
+function withOpencodeServer(
+  settings: { permissionMode?: string; model?: string; sandbox?: string } = {},
+) {
+  return {
+    ...settings,
+    opencodeServer: TEST_OPENCODE_SERVER,
+  }
+}
 
 function expectCodexMcpArgs(args: string[]) {
   // Bell notification still present
@@ -971,11 +981,29 @@ describe('buildSpawnSpec Unix paths', () => {
       delete process.env.OPENCODE_CMD
 
       const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, {
+        ...withOpencodeServer(),
         model: 'openai/gpt-5-mini',
       })
 
       expect(spec.args).toContain('--model')
       expect(spec.args).toContain('openai/gpt-5-mini')
+    })
+
+    it('requires an explicit localhost control endpoint for opencode and passes it as launch args', () => {
+      delete process.env.OPENCODE_CMD
+
+      expect(() => buildSpawnSpec('opencode', '/Users/john/project', 'system')).toThrow(
+        'OpenCode launch requires an allocated localhost control endpoint.',
+      )
+
+      const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, withOpencodeServer())
+
+      expect(spec.args).toEqual(expect.arrayContaining([
+        '--hostname',
+        '127.0.0.1',
+        '--port',
+        '43123',
+      ]))
     })
 
     it('defaults OpenCode to a usable Google model and alias env when only GEMINI_API_KEY is set', () => {
@@ -986,7 +1014,7 @@ describe('buildSpawnSpec Unix paths', () => {
       delete process.env.ANTHROPIC_API_KEY
       process.env.GEMINI_API_KEY = 'gemini-key'
 
-      const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system')
+      const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, withOpencodeServer())
 
       expect(spec.args).toContain('--model')
       expect(spec.args).toContain('google/gemini-3-pro-preview')
@@ -997,6 +1025,7 @@ describe('buildSpawnSpec Unix paths', () => {
       delete process.env.OPENCODE_CMD
 
       const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, {
+        ...withOpencodeServer(),
         permissionMode: 'plan',
       })
 
@@ -1007,6 +1036,7 @@ describe('buildSpawnSpec Unix paths', () => {
       delete process.env.OPENCODE_CMD
 
       const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, {
+        ...withOpencodeServer(),
         permissionMode: 'acceptEdits',
       })
 
@@ -2495,6 +2525,7 @@ describe('TerminalRegistry', () => {
           mode: 'opencode',
           cwd: '/home/user/project',
           resumeSessionId: 'session-opencode',
+          providerSettings: withOpencodeServer(),
         })
       } catch (err) {
         thrown = err
@@ -2517,7 +2548,11 @@ describe('TerminalRegistry', () => {
       const { cleanupMcpConfig } = await import('../../../server/mcp/config-writer.js')
       vi.mocked(cleanupMcpConfig).mockClear()
 
-      const record = registry.create({ mode: 'opencode', cwd: '/home/user/oc-project' })
+      const record = registry.create({
+        mode: 'opencode',
+        cwd: '/home/user/oc-project',
+        providerSettings: withOpencodeServer(),
+      })
       registry.kill(record.terminalId)
 
       // cleanup must use mcpCwd (the normalized cwd used during injection)
@@ -2528,7 +2563,11 @@ describe('TerminalRegistry', () => {
       const { cleanupMcpConfig } = await import('../../../server/mcp/config-writer.js')
       vi.mocked(cleanupMcpConfig).mockClear()
 
-      const record = registry.create({ mode: 'opencode', cwd: '/home/user/oc-exit' })
+      const record = registry.create({
+        mode: 'opencode',
+        cwd: '/home/user/oc-exit',
+        providerSettings: withOpencodeServer(),
+      })
       const pty = await import('node-pty')
       const mockPty = vi.mocked(pty.spawn).mock.results.at(-1)?.value
       const onExitCallback = mockPty.onExit.mock.calls[0][0]
@@ -3536,7 +3575,7 @@ describe('buildSpawnSpec Unix paths', () => {
 
     it('opencode mode passes cwd to generateMcpInjection', async () => {
       const { generateMcpInjection } = await import('../../../server/mcp/config-writer.js')
-      buildSpawnSpec('opencode', '/home/user/project', 'system', undefined, undefined, undefined, 'term-oc1')
+      buildSpawnSpec('opencode', '/home/user/project', 'system', undefined, withOpencodeServer(), undefined, 'term-oc1')
       expect(generateMcpInjection).toHaveBeenCalledWith('opencode', 'term-oc1', '/home/user/project', 'unix')
     })
 
@@ -3562,7 +3601,7 @@ describe('buildSpawnSpec Unix paths', () => {
       // On WSL, a Windows-style cwd (e.g. D:\project) should be converted to a Linux path
       // before being passed to generateMcpInjection. resolveUnixShellCwd handles this.
       // The raw Windows path would fail existsSync in config-writer on Linux.
-      buildSpawnSpec('opencode', 'D:\\project', 'system', undefined, undefined, undefined, 'term-wsl1')
+      buildSpawnSpec('opencode', 'D:\\project', 'system', undefined, withOpencodeServer(), undefined, 'term-wsl1')
       // The cwd passed to generateMcpInjection should be the resolved Unix path,
       // not the raw Windows path. On WSL, convertWindowsPathToWslPath converts
       // D:\project to /mnt/d/project.

--- a/test/unit/server/ws-handler-sdk.test.ts
+++ b/test/unit/server/ws-handler-sdk.test.ts
@@ -384,17 +384,10 @@ describe('WS Handler SDK Integration', () => {
       handler = new WsHandler(
         server,
         registry,
-        undefined, // codingCliManager
-        mockSdkBridge,
-        undefined, // sessionRepairService
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        mockHistorySource,
+        {
+          sdkBridge: mockSdkBridge,
+          agentHistorySource: mockHistorySource,
+        },
       )
     })
 

--- a/test/unit/server/ws-sdk-session-history-cache.test.ts
+++ b/test/unit/server/ws-sdk-session-history-cache.test.ts
@@ -227,17 +227,10 @@ describe('WsHandler agent history source DI', () => {
     handler = new WsHandler(
       server,
       registry,
-      undefined, // codingCliManager
-      mockSdkBridge as any,
-      undefined, // sessionRepairService
-      undefined, // handshakeSnapshotProvider
-      undefined, // terminalMetaListProvider
-      undefined, // tabsRegistryStore
-      undefined, // serverInstanceId
-      undefined, // layoutStore
-      undefined, // extensionManager
-      undefined, // codexActivityListProvider
-      injectedHistorySource,
+      {
+        sdkBridge: mockSdkBridge as any,
+        agentHistorySource: injectedHistorySource,
+      },
     )
 
     const ws = await connectAndAuth(server)
@@ -298,17 +291,10 @@ describe('WsHandler agent history source DI', () => {
     handler = new WsHandler(
       server,
       registry,
-      undefined,
-      mockSdkBridge as any,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      injectedHistorySource,
+      {
+        sdkBridge: mockSdkBridge as any,
+        agentHistorySource: injectedHistorySource,
+      },
     )
 
     const ws = await connectAndAuth(server)
@@ -364,17 +350,10 @@ describe('WsHandler agent history source DI', () => {
     handler = new WsHandler(
       server,
       registry,
-      undefined,
-      mockSdkBridge as any,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      injectedHistorySource,
+      {
+        sdkBridge: mockSdkBridge as any,
+        agentHistorySource: injectedHistorySource,
+      },
     )
 
     const ws = await connectAndAuth(server)
@@ -449,8 +428,9 @@ describe('WsHandler agent history source DI', () => {
     handler = new WsHandler(
       server,
       registry,
-      undefined,
-      mockSdkBridge as any,
+      {
+        sdkBridge: mockSdkBridge as any,
+      },
     )
 
     const ws = await connectAndAuth(server)


### PR DESCRIPTION
## Summary
- launch OpenCode terminals with an explicit localhost control endpoint and track activity server-side from the OpenCode health/status/event APIs
- expose OpenCode activity over the websocket protocol, store it in a dedicated client slice, and drive pane/tab/sidebar busy indicators from exact terminal matches
- add regression coverage across tracker, websocket, client bootstrap/store, UI surfaces, startup probes, and end-to-end pane activity flows

## Verification
- `npm run check`
- `fresheyes` independent review passed
