### PR TITLE
feat(agent-chat): move Show settings to per-machine browser state

### DIFF
--- a/shared/settings.ts
+++ b/shared/settings.ts
@@ -60,6 +60,11 @@ const SIDEBAR_LOCAL_KEYS = [
   'width',
   'collapsed',
 ] as const
+const AGENT_CHAT_LOCAL_KEYS = [
+  'showThinking',
+  'showTools',
+  'showTimecodes',
+] as const
 
 export type ThemeMode = (typeof THEME_VALUES)[number]
 export type TerminalTheme = (typeof TERMINAL_THEME_VALUES)[number]
@@ -180,6 +185,11 @@ export type LocalSettings = {
     width: number
     collapsed: boolean
   }
+  agentChat: {
+    showThinking: boolean
+    showTools: boolean
+    showTimecodes: boolean
+  }
   notifications: {
     soundEnabled: boolean
   }
@@ -201,7 +211,7 @@ export type ResolvedSettings = {
   codingCli: ServerSettings['codingCli']
   panes: ServerSettings['panes'] & LocalSettings['panes']
   editor: ServerSettings['editor']
-  agentChat: ServerSettings['agentChat']
+  agentChat: ServerSettings['agentChat'] & LocalSettings['agentChat']
   extensions: ServerSettings['extensions']
   network: ServerSettings['network']
 }
@@ -465,6 +475,22 @@ function normalizeExtractedLocalSeed(patch: Record<string, unknown>): LocalSetti
     }
   }
 
+  if (isRecord(patch.agentChat)) {
+    const agentChat: LocalSettingsPatch['agentChat'] = {}
+    if (typeof patch.agentChat.showThinking === 'boolean') {
+      agentChat.showThinking = patch.agentChat.showThinking as boolean
+    }
+    if (typeof patch.agentChat.showTools === 'boolean') {
+      agentChat.showTools = patch.agentChat.showTools as boolean
+    }
+    if (typeof patch.agentChat.showTimecodes === 'boolean') {
+      agentChat.showTimecodes = patch.agentChat.showTimecodes as boolean
+    }
+    if (Object.keys(agentChat).length > 0) {
+      normalized.agentChat = agentChat
+    }
+  }
+
   if (isRecord(patch.notifications)) {
     const notifications: LocalSettingsPatch['notifications'] = {}
     if (typeof patch.notifications.soundEnabled === 'boolean') {
@@ -694,6 +720,11 @@ export const defaultLocalSettings: LocalSettings = {
     hideEmptySessions: true,
     width: 288,
     collapsed: false,
+  },
+  agentChat: {
+    showThinking: false,
+    showTools: false,
+    showTimecodes: false,
   },
   notifications: {
     soundEnabled: true,
@@ -978,6 +1009,7 @@ export function resolveLocalSettings(patch?: LocalSettingsPatch): LocalSettings 
       sortMode: normalizeLocalSortMode(patch?.sidebar?.sortMode),
       worktreeGrouping: normalizeWorktreeGrouping(patch?.sidebar?.worktreeGrouping),
     },
+    agentChat: mergeDefined(defaultLocalSettings.agentChat, patch?.agentChat),
     notifications: mergeDefined(defaultLocalSettings.notifications, patch?.notifications),
   }
 }
@@ -1016,6 +1048,14 @@ export function mergeLocalSettings(base: LocalSettingsPatch | undefined, patch: 
   }
   if (Object.keys(sidebar).length > 0) {
     next.sidebar = sidebar as LocalSettingsPatch['sidebar']
+  }
+
+  const agentChat = mergeDefined(
+    (base?.agentChat || {}) as Record<string, unknown>,
+    patch.agentChat as Record<string, unknown> | undefined,
+  )
+  if (Object.keys(agentChat).length > 0) {
+    next.agentChat = agentChat as LocalSettingsPatch['agentChat']
   }
 
   const notifications = mergeDefined(
@@ -1062,6 +1102,7 @@ export function composeResolvedSettings(server: ServerSettings, local: LocalSett
       ...server.agentChat,
       defaultPlugins: [...server.agentChat.defaultPlugins],
       providers: mergeRecordOfObjects(server.agentChat.providers),
+      ...local.agentChat,
     },
     extensions: {
       disabled: [...server.extensions.disabled],
@@ -1096,6 +1137,9 @@ export function extractLegacyLocalSettingsSeed(
       sidebarPatch.ignoreCodexSubagents = raw.sidebar.ignoreCodexSubagentSessions
     }
     maybeAssignNested(patch, 'sidebar', sidebarPatch)
+  }
+  if (isRecord(raw.agentChat)) {
+    maybeAssignNested(patch, 'agentChat', pickKeys(raw.agentChat, AGENT_CHAT_LOCAL_KEYS))
   }
   if (isRecord(raw.notifications)) {
     maybeAssignNested(patch, 'notifications', pickKeys(raw.notifications, ['soundEnabled']))
@@ -1137,6 +1181,15 @@ export function stripLocalSettings(
       next.sidebar = strippedSidebar
     } else {
       delete next.sidebar
+    }
+  }
+
+  if (isRecord(raw.agentChat)) {
+    const strippedAgentChat = omitKeys(raw.agentChat, AGENT_CHAT_LOCAL_KEYS)
+    if (Object.keys(strippedAgentChat).length > 0) {
+      next.agentChat = strippedAgentChat
+    } else {
+      delete next.agentChat
     }
   }
 

--- a/src/components/agent-chat/AgentChatSettings.tsx
+++ b/src/components/agent-chat/AgentChatSettings.tsx
@@ -7,7 +7,11 @@ import type { AgentChatPaneContent } from '@/store/paneTypes'
 import type { AgentChatProviderConfig } from '@/lib/agent-chat-types'
 import { formatModelDisplayName } from '../../../shared/format-model-name'
 
-type SettingsFields = Pick<AgentChatPaneContent, 'model' | 'permissionMode' | 'effort' | 'showThinking' | 'showTools' | 'showTimecodes'>
+type SettingsFields = Pick<AgentChatPaneContent, 'model' | 'permissionMode' | 'effort'> & {
+  showThinking?: boolean
+  showTools?: boolean
+  showTimecodes?: boolean
+}
 
 interface AgentChatSettingsProps {
   model: string

--- a/src/components/agent-chat/AgentChatView.tsx
+++ b/src/components/agent-chat/AgentChatView.tsx
@@ -30,6 +30,7 @@ import { getAgentChatProviderConfig } from '@/lib/agent-chat-utils'
 import { isValidClaudeSessionId } from '@/lib/claude-session-id'
 import { getInstalledPerfAuditBridge } from '@/lib/perf-audit-bridge'
 import { saveServerSettingsPatch } from '@/store/settingsThunks'
+import { updateSettingsLocal } from '@/store/settingsSlice'
 import type { Tab } from '@/store/types'
 import {
   buildAgentChatPersistedIdentityUpdate,
@@ -64,9 +65,10 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
   const defaultModel = providerConfig?.defaultModel ?? 'claude-opus-4-6'
   const defaultPermissionMode = providerConfig?.defaultPermissionMode ?? 'bypassPermissions'
   const defaultEffort = providerConfig?.defaultEffort ?? 'high'
-  const defaultShowThinking = providerConfig?.defaultShowThinking ?? true
-  const defaultShowTools = providerConfig?.defaultShowTools ?? true
-  const defaultShowTimecodes = providerConfig?.defaultShowTimecodes ?? false
+  const localSettings = useAppSelector((state) => state.settings.settings)
+  const defaultShowThinking = localSettings.agentChat.showThinking
+  const defaultShowTools = localSettings.agentChat.showTools
+  const defaultShowTimecodes = localSettings.agentChat.showTimecodes
   const providerLabel = providerConfig?.label ?? 'Agent Chat'
   const createSentRef = useRef(false)
   const attachSentRef = useRef(false)
@@ -543,11 +545,28 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
   }, [])
 
   const handleSettingsChange = useCallback((changes: Record<string, unknown>) => {
-    dispatch(updatePaneContent({
-      tabId,
-      paneId,
-      content: { ...paneContentRef.current, ...changes },
-    }))
+    const paneChanges: Partial<AgentChatPaneContent> = {}
+    const localChanges: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(changes)) {
+      if (key === 'showThinking' || key === 'showTools' || key === 'showTimecodes') {
+        localChanges[key] = value
+      } else {
+        (paneChanges as Record<string, unknown>)[key] = value
+      }
+    }
+
+    if (Object.keys(paneChanges).length > 0) {
+      dispatch(updatePaneContent({
+        tabId,
+        paneId,
+        content: { ...paneContentRef.current, ...paneChanges },
+      }))
+    }
+
+    if (Object.keys(localChanges).length > 0) {
+      dispatch(updateSettingsLocal({ agentChat: localChanges }))
+    }
 
     const pc = paneContentRef.current
 
@@ -703,9 +722,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
             model={paneContent.model ?? defaultModel}
             permissionMode={paneContent.permissionMode ?? defaultPermissionMode}
             effort={paneContent.effort ?? defaultEffort}
-            showThinking={paneContent.showThinking ?? defaultShowThinking}
-            showTools={paneContent.showTools ?? defaultShowTools}
-            showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+            showThinking={defaultShowThinking}
+            showTools={defaultShowTools}
+            showTimecodes={defaultShowTimecodes}
             sessionStarted={sessionStarted}
             defaultOpen={shouldShowSettings}
             modelOptions={availableModels.length > 0 ? availableModels : undefined}
@@ -765,9 +784,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
                 content={turn.message.content}
                 timestamp={turn.message.timestamp}
                 model={turn.message.model}
-                showThinking={paneContent.showThinking ?? defaultShowThinking}
-                showTools={paneContent.showTools ?? defaultShowTools}
-                showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+                showThinking={defaultShowThinking}
+                showTools={defaultShowTools}
+                showTimecodes={defaultShowTimecodes}
               />
             )
           }
@@ -785,9 +804,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
                   turnId: item.turnId,
                 }))
               }}
-              showThinking={paneContent.showThinking ?? defaultShowThinking}
-              showTools={paneContent.showTools ?? defaultShowTools}
-              showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+              showThinking={defaultShowThinking}
+              showTools={defaultShowTools}
+              showTimecodes={defaultShowTimecodes}
             />
           )
         })}
@@ -805,9 +824,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
                     key={`turn-${i}`}
                     userMessage={item.user}
                     assistantMessage={item.assistant}
-                    showThinking={paneContent.showThinking ?? defaultShowThinking}
-                    showTools={paneContent.showTools ?? defaultShowTools}
-                    showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+                    showThinking={defaultShowThinking}
+                    showTools={defaultShowTools}
+                    showTimecodes={defaultShowTimecodes}
                   />
                 )
               }
@@ -817,9 +836,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
                     speaker={item.user.role}
                     content={item.user.content}
                     timestamp={item.user.timestamp}
-                    showThinking={paneContent.showThinking ?? defaultShowThinking}
-                    showTools={paneContent.showTools ?? defaultShowTools}
-                    showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+                    showThinking={defaultShowThinking}
+                    showTools={defaultShowTools}
+                    showTimecodes={defaultShowTimecodes}
                   />
                   <MessageBubble
                     speaker={item.assistant.role}
@@ -827,9 +846,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
                     timestamp={item.assistant.timestamp}
                     model={item.assistant.model}
                     isLastMessage={isLast}
-                    showThinking={paneContent.showThinking ?? defaultShowThinking}
-                    showTools={paneContent.showTools ?? defaultShowTools}
-                    showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+                    showThinking={defaultShowThinking}
+                    showTools={defaultShowTools}
+                    showTimecodes={defaultShowTimecodes}
                   />
                 </React.Fragment>
               )
@@ -843,9 +862,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
                 timestamp={item.message.timestamp}
                 model={item.message.model}
                 isLastMessage={isLast}
-                showThinking={paneContent.showThinking ?? defaultShowThinking}
-                showTools={paneContent.showTools ?? defaultShowTools}
-                showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+                showThinking={defaultShowThinking}
+                showTools={defaultShowTools}
+                showTimecodes={defaultShowTimecodes}
               />
             )
           })
@@ -855,9 +874,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
           <MessageBubble
             speaker="assistant"
             content={streamingContent}
-            showThinking={paneContent.showThinking ?? defaultShowThinking}
-            showTools={paneContent.showTools ?? defaultShowTools}
-            showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+            showThinking={defaultShowThinking}
+            showTools={defaultShowTools}
+            showTimecodes={defaultShowTimecodes}
           />
         )}
 

--- a/src/components/agent-chat/CollapsedTurn.tsx
+++ b/src/components/agent-chat/CollapsedTurn.tsx
@@ -42,8 +42,8 @@ function CollapsedTurn({
   message,
   loading = false,
   onExpand,
-  showThinking = true,
-  showTools = true,
+  showThinking = false,
+  showTools = false,
   showTimecodes = false,
 }: CollapsedTurnProps) {
   const [expanded, setExpanded] = useState(false)

--- a/src/components/agent-chat/MessageBubble.tsx
+++ b/src/components/agent-chat/MessageBubble.tsx
@@ -31,8 +31,8 @@ function MessageBubble({
   content,
   timestamp,
   model,
-  showThinking = true,
-  showTools = true,
+  showThinking = false,
+  showTools = false,
   showTimecodes = false,
   isLastMessage = false,
 }: MessageBubbleProps) {

--- a/src/components/agent-chat/ToolStrip.tsx
+++ b/src/components/agent-chat/ToolStrip.tsx
@@ -17,7 +17,7 @@ export interface ToolPair {
 interface ToolStripProps {
   pairs: ToolPair[]
   isStreaming: boolean
-  /** When false, strip is locked to collapsed view (no expand chevron). Default false. */
+  /** When true, strip starts expanded. Default false. */
   showTools?: boolean
 }
 

--- a/src/components/agent-chat/ToolStrip.tsx
+++ b/src/components/agent-chat/ToolStrip.tsx
@@ -17,11 +17,11 @@ export interface ToolPair {
 interface ToolStripProps {
   pairs: ToolPair[]
   isStreaming: boolean
-  /** When false, strip is locked to collapsed view (no expand chevron). Default true. */
+  /** When false, strip is locked to collapsed view (no expand chevron). Default false. */
   showTools?: boolean
 }
 
-function ToolStrip({ pairs, isStreaming, showTools = true }: ToolStripProps) {
+function ToolStrip({ pairs, isStreaming, showTools = false }: ToolStripProps) {
   const [stripExpanded, setStripExpanded] = useState(showTools)
   useEffect(() => { setStripExpanded(showTools) }, [showTools])
 

--- a/src/components/settings/WorkspaceSettings.tsx
+++ b/src/components/settings/WorkspaceSettings.tsx
@@ -253,6 +253,33 @@ export default function WorkspaceSettings({
         </SettingsRow>
       </SettingsSection>
 
+      <SettingsSection title="Agent chat" description="Display settings for agent chat panes">
+        <SettingsRow label="Show thinking">
+          <Toggle
+            checked={settings.agentChat?.showThinking ?? false}
+            onChange={(checked) => {
+              applyLocalSetting({ agentChat: { showThinking: checked } })
+            }}
+          />
+        </SettingsRow>
+        <SettingsRow label="Show tools">
+          <Toggle
+            checked={settings.agentChat?.showTools ?? false}
+            onChange={(checked) => {
+              applyLocalSetting({ agentChat: { showTools: checked } })
+            }}
+          />
+        </SettingsRow>
+        <SettingsRow label="Show timecodes &amp; model">
+          <Toggle
+            checked={settings.agentChat?.showTimecodes ?? false}
+            onChange={(checked) => {
+              applyLocalSetting({ agentChat: { showTimecodes: checked } })
+            }}
+          />
+        </SettingsRow>
+      </SettingsSection>
+
       <SettingsSection title="Editor" description="External editor for file opening">
         <SettingsRow label="External editor" description="Which editor to use when opening files from the editor pane">
           <select

--- a/src/lib/agent-chat-types.ts
+++ b/src/lib/agent-chat-types.ts
@@ -17,10 +17,6 @@ export interface AgentChatProviderConfig {
   defaultPermissionMode: string
   /** Default effort level */
   defaultEffort: 'low' | 'medium' | 'high' | 'max'
-  /** Default display settings */
-  defaultShowThinking: boolean
-  defaultShowTools: boolean
-  defaultShowTimecodes: boolean
   /** Which settings are visible in the settings popover */
   settingsVisibility: {
     model: boolean

--- a/src/lib/agent-chat-utils.ts
+++ b/src/lib/agent-chat-utils.ts
@@ -17,9 +17,6 @@ export const AGENT_CHAT_PROVIDER_CONFIGS: AgentChatProviderConfig[] = [
     defaultModel: 'claude-opus-4-6',
     defaultPermissionMode: 'bypassPermissions',
     defaultEffort: 'high',
-    defaultShowThinking: true,
-    defaultShowTools: true,
-    defaultShowTimecodes: false,
     settingsVisibility: {
       model: true,
       permissionMode: true,
@@ -38,9 +35,6 @@ export const AGENT_CHAT_PROVIDER_CONFIGS: AgentChatProviderConfig[] = [
     defaultModel: 'claude-opus-4-6',
     defaultPermissionMode: 'bypassPermissions',
     defaultEffort: 'high',
-    defaultShowThinking: true,
-    defaultShowTools: true,
-    defaultShowTimecodes: false,
     settingsVisibility: {
       model: true,
       permissionMode: true,

--- a/src/store/browserPreferencesPersistence.ts
+++ b/src/store/browserPreferencesPersistence.ts
@@ -126,6 +126,14 @@ export function buildLocalSettingsPatch(localSettings: LocalSettings): LocalSett
     patch.sidebar = sidebar
   }
 
+  const agentChat: LocalSettingsPatch['agentChat'] = {}
+  assignChangedScalar(agentChat, localSettings.agentChat, defaultLocalSettings.agentChat, 'showThinking')
+  assignChangedScalar(agentChat, localSettings.agentChat, defaultLocalSettings.agentChat, 'showTools')
+  assignChangedScalar(agentChat, localSettings.agentChat, defaultLocalSettings.agentChat, 'showTimecodes')
+  if (Object.keys(agentChat).length > 0) {
+    patch.agentChat = agentChat
+  }
+
   const notifications: LocalSettingsPatch['notifications'] = {}
   assignChangedScalar(notifications, localSettings.notifications, defaultLocalSettings.notifications, 'soundEnabled')
   if (Object.keys(notifications).length > 0) {

--- a/src/store/paneTreeValidation.ts
+++ b/src/store/paneTreeValidation.ts
@@ -50,9 +50,6 @@ function isPaneContentShape(content: unknown): boolean {
           || content.effort === 'max')
         && (content.plugins === undefined
           || (Array.isArray(content.plugins) && content.plugins.every((plugin) => typeof plugin === 'string')))
-        && (content.showThinking === undefined || typeof content.showThinking === 'boolean')
-        && (content.showTools === undefined || typeof content.showTools === 'boolean')
-        && (content.showTimecodes === undefined || typeof content.showTimecodes === 'boolean')
         && (content.settingsDismissed === undefined || typeof content.settingsDismissed === 'boolean')
     case 'extension':
       return typeof content.extensionName === 'string'

--- a/src/store/paneTypes.ts
+++ b/src/store/paneTypes.ts
@@ -104,12 +104,6 @@ export type AgentChatPaneContent = {
   effort?: 'low' | 'medium' | 'high' | 'max'
   /** Plugin paths to load into this session (absolute paths to plugin directories) */
   plugins?: string[]
-  /** Show thinking blocks in message feed */
-  showThinking?: boolean
-  /** Show tool-use blocks in message feed */
-  showTools?: boolean
-  /** Show timestamps on messages */
-  showTimecodes?: boolean
   /** Whether the user has dismissed the first-launch settings popover */
   settingsDismissed?: boolean
 }

--- a/src/store/panesSlice.ts
+++ b/src/store/panesSlice.ts
@@ -123,9 +123,6 @@ function normalizePaneContent(
       permissionMode: input.permissionMode,
       effort: input.effort,
       plugins: input.plugins,
-      showThinking: input.showThinking,
-      showTools: input.showTools,
-      showTimecodes: input.showTimecodes,
       settingsDismissed: input.settingsDismissed,
     }
   }

--- a/src/store/panesSlice.ts
+++ b/src/store/panesSlice.ts
@@ -8,6 +8,7 @@ import { buildPaneRefreshTarget, paneRefreshTargetMatchesContent } from '@/lib/p
 import { loadPersistedPanes, loadPersistedTabs } from './persistMiddleware.js'
 import { hasPaneTreeShape, isWellFormedPaneTree } from './paneTreeValidation.js'
 import { createLogger } from '@/lib/client-logger'
+import { patchBrowserPreferencesRecord } from '@/lib/browser-preferences'
 import { shouldPreserveLocalCanonicalResumeSessionId } from './persistControl'
 
 
@@ -201,6 +202,85 @@ function cleanOrphanedLayouts(state: PanesState): PanesState {
   }
 }
 
+type LegacyDisplayFields = {
+  showThinking?: boolean
+  showTools?: boolean
+  showTimecodes?: boolean
+}
+
+function collectLegacyDisplayFields(node: unknown): LegacyDisplayFields {
+  if (!node || typeof node !== 'object') return {}
+  const n = node as { type?: string; content?: Record<string, unknown>; children?: unknown[] }
+
+  if (n.type === 'leaf' && n.content && n.content.kind === 'agent-chat') {
+    const c = n.content as Record<string, unknown>
+    return {
+      ...(typeof c.showThinking === 'boolean' && c.showThinking ? { showThinking: true } : {}),
+      ...(typeof c.showTools === 'boolean' && c.showTools ? { showTools: true } : {}),
+      ...(typeof c.showTimecodes === 'boolean' && c.showTimecodes ? { showTimecodes: true } : {}),
+    }
+  }
+
+  if (n.type === 'split' && Array.isArray(n.children)) {
+    let merged: LegacyDisplayFields = {}
+    for (const child of n.children) {
+      const childFields = collectLegacyDisplayFields(child)
+      if (childFields.showThinking) merged.showThinking = true
+      if (childFields.showTools) merged.showTools = true
+      if (childFields.showTimecodes) merged.showTimecodes = true
+    }
+    return merged
+  }
+
+  return {}
+}
+
+function stripLegacyDisplayFields(node: any): any {
+  if (!node) return node
+  if (node.type === 'leaf' && node.content?.kind === 'agent-chat') {
+    const { showThinking: _st, showTools: _stl, showTimecodes: _stc, ...rest } = node.content
+    if (_st === undefined && _stl === undefined && _stc === undefined) return node
+    return { ...node, content: rest }
+  }
+  if (node.type === 'split' && Array.isArray(node.children)) {
+    const nextChildren = node.children.map(stripLegacyDisplayFields)
+    if (nextChildren.every((c: any, i: number) => c === node.children[i])) return node
+    return { ...node, children: nextChildren }
+  }
+  return node
+}
+
+function migrateLegacyAgentChatDisplaySettings(state: PanesState): PanesState {
+  let legacy: LegacyDisplayFields = {}
+  let hasLegacy = false
+  const nextLayouts: Record<string, any> = {}
+
+  for (const [tabId, node] of Object.entries(state.layouts)) {
+    const fields = collectLegacyDisplayFields(node)
+    if (fields.showThinking || fields.showTools || fields.showTimecodes) {
+      legacy.showThinking = legacy.showThinking || fields.showThinking
+      legacy.showTools = legacy.showTools || fields.showTools
+      legacy.showTimecodes = legacy.showTimecodes || fields.showTimecodes
+      hasLegacy = true
+    }
+    nextLayouts[tabId] = hasLegacy ? stripLegacyDisplayFields(node) : node
+  }
+
+  if (!hasLegacy) return state
+
+  patchBrowserPreferencesRecord({
+    settings: {
+      agentChat: {
+        ...(legacy.showThinking ? { showThinking: true } : {}),
+        ...(legacy.showTools ? { showTools: true } : {}),
+        ...(legacy.showTimecodes ? { showTimecodes: true } : {}),
+      },
+    },
+  })
+
+  return { ...state, layouts: nextLayouts as Record<string, PaneNode> }
+}
+
 // Load persisted panes state directly at module initialization time
 // This ensures the initial state includes persisted data BEFORE the store is created.
 // Delegates to loadPersistedPanes() so that both Redux initial state and
@@ -233,6 +313,7 @@ function loadInitialPanesState(): PanesState {
       refreshRequestsByPane: {},
     }
     state = cleanOrphanedLayouts(state)
+    state = migrateLegacyAgentChatDisplaySettings(state)
     return state
   } catch (err) {
     log.error('Failed to load from localStorage:', err)

--- a/test/e2e/agent-chat-context-menu-flow.test.tsx
+++ b/test/e2e/agent-chat-context-menu-flow.test.tsx
@@ -18,7 +18,8 @@ import agentChatReducer, {
   setSessionStatus,
 } from '@/store/agentChatSlice'
 import panesReducer from '@/store/panesSlice'
-import settingsReducer from '@/store/settingsSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
+import { defaultLocalSettings } from '@shared/settings'
 import type { AgentChatPaneContent } from '@/store/paneTypes'
 import { buildMenuItems, type MenuActions, type MenuBuildContext } from '@/components/context-menu/menu-defs'
 import type { ContextTarget } from '@/components/context-menu/context-menu-types'
@@ -41,6 +42,14 @@ function makeStore() {
       agentChat: agentChatReducer,
       panes: panesReducer,
       settings: settingsReducer,
+    },
+    preloadedState: {
+      settings: {
+        serverSettings: defaultSettings,
+        localSettings: { ...defaultLocalSettings, agentChat: { showThinking: false, showTools: true, showTimecodes: false } },
+        settings: { ...defaultSettings, agentChat: { ...defaultSettings.agentChat, showTools: true } },
+        loaded: false,
+      },
     },
   })
 }
@@ -147,7 +156,7 @@ describe('freshclaude context menu integration', () => {
       </Provider>,
     )
 
-    // Tool strips start expanded when showTools=true (default), so ToolBlock data attributes are in the DOM
+    // showTools=true via preloadedState, so ToolBlock data attributes are in the DOM
     const toolInputEl = container.querySelector('[data-tool-input]')
     expect(toolInputEl).not.toBeNull()
     expect(toolInputEl?.getAttribute('data-tool-name')).toBe('Bash')
@@ -198,7 +207,7 @@ describe('freshclaude context menu integration', () => {
       </Provider>,
     )
 
-    // Tool strips start expanded when showTools=true (default)
+    // showTools=true via preloadedState
     const diffEl = container.querySelector('[data-diff]')
     expect(diffEl).not.toBeNull()
     expect(diffEl?.getAttribute('data-file-path')).toBe('/tmp/test.ts')
@@ -241,7 +250,7 @@ describe('freshclaude context menu integration', () => {
       </Provider>,
     )
 
-    // Tool strips start expanded when showTools=true (default)
+    // showTools=true via preloadedState
     const toolOutputEl = container.querySelector('[data-tool-output]')
     expect(toolOutputEl).not.toBeNull()
 

--- a/test/e2e/agent-chat-polish-flow.test.tsx
+++ b/test/e2e/agent-chat-polish-flow.test.tsx
@@ -18,7 +18,8 @@ import agentChatReducer, {
   setSessionStatus,
 } from '@/store/agentChatSlice'
 import panesReducer from '@/store/panesSlice'
-import settingsReducer from '@/store/settingsSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
+import { defaultLocalSettings } from '@shared/settings'
 import type { AgentChatPaneContent } from '@/store/paneTypes'
 import type { ChatContentBlock } from '@/store/agentChatTypes'
 import { BROWSER_PREFERENCES_STORAGE_KEY } from '@/store/storage-keys'
@@ -49,6 +50,14 @@ function makeStore() {
       agentChat: agentChatReducer,
       panes: panesReducer,
       settings: settingsReducer,
+    },
+    preloadedState: {
+      settings: {
+        serverSettings: defaultSettings,
+        localSettings: { ...defaultLocalSettings, agentChat: { showThinking: false, showTools: true, showTimecodes: false } },
+        settings: { ...defaultSettings, agentChat: { ...defaultSettings.agentChat, showTools: true } },
+        loaded: false,
+      },
     },
   })
 }
@@ -174,7 +183,7 @@ describe('freshclaude polish e2e: tool block expand/collapse', () => {
     const toolButton = screen.getByRole('button', { name: /tool call/i })
     expect(toolButton).toBeInTheDocument()
 
-    // With showTools=true (default), ToolBlocks start expanded
+    // With showTools=true via preloadedState, ToolBlocks start expanded
     expect(toolButton).toHaveAttribute('aria-expanded', 'true')
 
     // Click to collapse
@@ -217,7 +226,7 @@ describe('freshclaude polish e2e: all tools expanded when showTools=true', () =>
     const toolButtons = screen.getAllByRole('button', { name: /tool call/i })
     expect(toolButtons).toHaveLength(5)
 
-    // All tools should start expanded when showTools=true (default)
+    // All tools should start expanded when showTools=true via preloadedState
     expect(toolButtons[0]).toHaveAttribute('aria-expanded', 'true')
     expect(toolButtons[1]).toHaveAttribute('aria-expanded', 'true')
     expect(toolButtons[2]).toHaveAttribute('aria-expanded', 'true')
@@ -354,7 +363,7 @@ describe('freshclaude polish e2e: diff view for Edit tool', () => {
       </Provider>,
     )
 
-    // Tool block should be present; with showTools=true (default), it starts expanded
+    // Tool block should be present; with showTools=true via preloadedState, it starts expanded
     const toolButton = screen.getByRole('button', { name: /tool call/i })
     expect(toolButton).toHaveAttribute('aria-expanded', 'true')
 
@@ -397,7 +406,7 @@ describe('freshclaude polish e2e: system-reminder stripping', () => {
       </Provider>,
     )
 
-    // ToolBlock should be expanded (showTools=true default)
+    // ToolBlock should be expanded (showTools=true via preloadedState)
     const toolButton = screen.getByRole('button', { name: /tool call/i })
     expect(toolButton).toHaveAttribute('aria-expanded', 'true')
 

--- a/test/unit/client/components/SettingsView.agent-chat.test.tsx
+++ b/test/unit/client/components/SettingsView.agent-chat.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen, fireEvent, act } from '@testing-library/react'
+import {
+  createSettingsViewStore,
+  installSettingsViewHooks,
+  renderSettingsView,
+  switchSettingsTab,
+} from './settings-view-test-utils'
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    patch: vi.fn().mockResolvedValue({}),
+    get: vi.fn().mockResolvedValue({}),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+  },
+}))
+
+installSettingsViewHooks({ fakeTimers: true, mockFonts: true })
+
+function getToggle(labelText: string) {
+  const label = screen.getByText(labelText)
+  const row = label.closest('div[class*="flex"]')
+  if (!row) throw new Error(`Row with label "${labelText}" not found`)
+  return row.querySelector('[role="switch"]') as HTMLElement
+}
+
+describe('SettingsView agent chat settings', () => {
+  it('renders the Agent chat section on the Workspace tab', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    expect(screen.getByRole('heading', { name: 'Agent chat' })).toBeInTheDocument()
+    expect(screen.getByText('Display settings for agent chat panes')).toBeInTheDocument()
+  })
+
+  it('renders Show thinking, Show tools, and Show timecodes toggles', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    expect(getToggle('Show thinking')).toBeInTheDocument()
+    expect(getToggle('Show tools')).toBeInTheDocument()
+    expect(getToggle('Show timecodes & model')).toBeInTheDocument()
+  })
+
+  it('all agent chat toggles default to unchecked (off)', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    expect(getToggle('Show thinking')).toHaveAttribute('aria-checked', 'false')
+    expect(getToggle('Show tools')).toHaveAttribute('aria-checked', 'false')
+    expect(getToggle('Show timecodes & model')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('reflects current agentChat settings when preloaded', () => {
+    const store = createSettingsViewStore({
+      settings: { agentChat: { showThinking: true, showTools: true, showTimecodes: true } },
+    })
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    expect(getToggle('Show thinking')).toHaveAttribute('aria-checked', 'true')
+    expect(getToggle('Show tools')).toHaveAttribute('aria-checked', 'true')
+    expect(getToggle('Show timecodes & model')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('toggling Show thinking updates the store to true', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    fireEvent.click(getToggle('Show thinking'))
+
+    expect(store.getState().settings.settings.agentChat.showThinking).toBe(true)
+  })
+
+  it('toggling Show tools updates the store to true', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    fireEvent.click(getToggle('Show tools'))
+
+    expect(store.getState().settings.settings.agentChat.showTools).toBe(true)
+  })
+
+  it('toggling Show timecodes updates the store to true', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    fireEvent.click(getToggle('Show timecodes & model'))
+
+    expect(store.getState().settings.settings.agentChat.showTimecodes).toBe(true)
+  })
+
+  it('toggling off a previously-on setting sets it to false', () => {
+    const store = createSettingsViewStore({
+      settings: { agentChat: { showThinking: true } },
+    })
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    fireEvent.click(getToggle('Show thinking'))
+
+    expect(store.getState().settings.settings.agentChat.showThinking).toBe(false)
+  })
+
+  it('agent chat setting changes are local-only (no api.patch call)', async () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    fireEvent.click(getToggle('Show thinking'))
+    fireEvent.click(getToggle('Show tools'))
+    fireEvent.click(getToggle('Show timecodes & model'))
+
+    await act(async () => {
+      vi.advanceTimersByTime(600)
+    })
+
+    const { api } = await import('@/lib/api')
+    expect(api.patch).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/client/components/agent-chat/AgentChatView.behavior.test.tsx
+++ b/test/unit/client/components/agent-chat/AgentChatView.behavior.test.tsx
@@ -12,7 +12,7 @@ import agentChatReducer, {
   setSessionStatus,
 } from '@/store/agentChatSlice'
 import panesReducer from '@/store/panesSlice'
-import settingsReducer from '@/store/settingsSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import type { AgentChatPaneContent } from '@/store/paneTypes'
 import type { ChatContentBlock } from '@/store/agentChatTypes'
 
@@ -47,6 +47,7 @@ function makeStore(settingsOverrides?: Record<string, unknown>) {
     preloadedState: {
       settings: {
         settings: {
+          ...defaultSettings,
           ...(settingsOverrides || {}),
         } as any,
         loaded: true,
@@ -329,7 +330,7 @@ describe('AgentChatView tool blocks expanded by default', () => {
   })
 
   it('all tool blocks start expanded when showTools is true', () => {
-    const store = makeStore()
+    const store = makeStore({ agentChat: { ...defaultSettings.agentChat, showTools: true } })
     store.dispatch(sessionCreated({ requestId: 'req-1', sessionId: 'sess-1' }))
     // Create a turn with 5 completed tools
     addTurns(store, 1, 5)
@@ -406,7 +407,7 @@ describe('AgentChatView settings auto-open (#110)', () => {
   })
 
   it('does not open settings on new pane when global initialSetupDone is true', () => {
-    const store = makeStore({ agentChat: { initialSetupDone: true, providers: {} } })
+    const store = makeStore({ agentChat: { ...defaultSettings.agentChat, initialSetupDone: true, providers: {} } })
     store.dispatch(sessionCreated({ requestId: 'req-1', sessionId: 'sess-1' }))
 
     // Fresh pane (no settingsDismissed), but global flag is set
@@ -420,8 +421,6 @@ describe('AgentChatView settings auto-open (#110)', () => {
   })
 
   it('does not open settings while global settings are still loading', () => {
-    // Simulates a returning user: settings haven't loaded from server yet,
-    // so initialSetupDone is still false. We should NOT flash the settings panel.
     const store = configureStore({
       reducer: {
         agentChat: agentChatReducer,
@@ -430,7 +429,7 @@ describe('AgentChatView settings auto-open (#110)', () => {
       },
       preloadedState: {
         settings: {
-          settings: {} as any,
+          settings: { ...defaultSettings } as any,
           loaded: false,
           lastSavedAt: 0,
         },
@@ -449,7 +448,7 @@ describe('AgentChatView settings auto-open (#110)', () => {
 
   it('auto-focuses composer when global initialSetupDone skips settings', () => {
     vi.useFakeTimers()
-    const store = makeStore({ agentChat: { initialSetupDone: true, providers: {} } })
+    const store = makeStore({ agentChat: { ...defaultSettings.agentChat, initialSetupDone: true, providers: {} } })
     store.dispatch(sessionCreated({ requestId: 'req-1', sessionId: 'sess-1' }))
 
     render(

--- a/test/unit/client/components/agent-chat/AgentChatView.perf-audit.test.tsx
+++ b/test/unit/client/components/agent-chat/AgentChatView.perf-audit.test.tsx
@@ -10,7 +10,7 @@ import agentChatReducer, {
   setSessionStatus,
 } from '@/store/agentChatSlice'
 import panesReducer from '@/store/panesSlice'
-import settingsReducer from '@/store/settingsSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import { createPerfAuditBridge, installPerfAuditBridge } from '@/lib/perf-audit-bridge'
 
 beforeAll(() => {
@@ -47,7 +47,7 @@ describe('AgentChatView perf audit milestone', () => {
           paneTitles: {},
         },
         settings: {
-          settings: {},
+          settings: { ...defaultSettings } as any,
           loaded: true,
           lastSavedAt: 0,
         },

--- a/test/unit/client/components/agent-chat/MessageBubble.test.tsx
+++ b/test/unit/client/components/agent-chat/MessageBubble.test.tsx
@@ -63,6 +63,7 @@ describe('MessageBubble', () => {
       <MessageBubble
         role="assistant"
         content={[{ type: 'thinking', thinking: 'Let me think...' }]}
+        showThinking={true}
       />
     )
     expect(screen.getByText(/Thinking/)).toBeInTheDocument()
@@ -235,7 +236,7 @@ describe('MessageBubble display toggles', () => {
     expect(screen.getByRole('article').querySelector('time')).not.toBeInTheDocument()
   })
 
-  it('defaults to showing thinking and tools, hiding timecodes', () => {
+  it('defaults to hiding thinking, tools, and timecodes', () => {
     render(
       <MessageBubble
         role="assistant"
@@ -243,7 +244,7 @@ describe('MessageBubble display toggles', () => {
         timestamp="2026-02-13T10:00:00Z"
       />
     )
-    expect(screen.getByText(/Let me think/)).toBeInTheDocument()
+    expect(screen.queryByText(/Let me think/)).not.toBeInTheDocument()
     expect(screen.getByRole('region', { name: /tool strip/i })).toBeInTheDocument()
     expect(screen.getByRole('article').querySelector('time')).not.toBeInTheDocument()
   })
@@ -476,6 +477,7 @@ describe('MessageBubble tool strip grouping', () => {
           { type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } },
           { type: 'tool_result', tool_use_id: 't1', content: 'output' },
         ]}
+        showThinking={true}
         showTools={true}
       />
     )

--- a/test/unit/client/components/agent-chat/ToolStrip.test.tsx
+++ b/test/unit/client/components/agent-chat/ToolStrip.test.tsx
@@ -208,9 +208,10 @@ describe('ToolStrip', () => {
     expect(screen.getByRole('button', { name: /Bash tool call/i })).toBeInTheDocument()
   })
 
-  it('defaults to showTools=true when not specified', () => {
+  it('defaults to showTools=false when not specified', () => {
     const pairs = [makePair('Bash', { command: 'ls' }, 'output')]
     render(<ToolStrip pairs={pairs} isStreaming={false} />)
-    expect(screen.getByRole('button', { name: /Bash tool call/i })).toBeInTheDocument()
+    expect(screen.getByText('1 tool used')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Bash tool call/i })).not.toBeInTheDocument()
   })
 })

--- a/test/unit/client/store/browserPreferencesPersistence.test.ts
+++ b/test/unit/client/store/browserPreferencesPersistence.test.ts
@@ -157,4 +157,67 @@ describe('browserPreferencesPersistence', () => {
 
     setItemSpy.mockRestore()
   })
+
+  it('persists agentChat.showThinking/showTools/showTimecodes to browser preferences', () => {
+    const store = createStore()
+
+    store.dispatch(updateSettingsLocal({
+      agentChat: { showThinking: true },
+    }))
+
+    vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings.agentChat).toEqual({ showThinking: true })
+    expect(bp.settings.agentChat.showTools).toBeUndefined()
+    expect(bp.settings.agentChat.showTimecodes).toBeUndefined()
+  })
+
+  it('persists all three agentChat toggles when all are enabled', () => {
+    const store = createStore()
+
+    store.dispatch(updateSettingsLocal({
+      agentChat: { showThinking: true, showTools: true, showTimecodes: true },
+    }))
+
+    vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings.agentChat).toEqual({
+      showThinking: true,
+      showTools: true,
+      showTimecodes: true,
+    })
+  })
+
+  it('round-trips agentChat settings through localStorage', () => {
+    const store = createStore()
+
+    store.dispatch(updateSettingsLocal({
+      agentChat: { showThinking: true, showTools: true },
+    }))
+
+    vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
+
+    const saved = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(saved.settings.agentChat).toEqual({ showThinking: true, showTools: true })
+
+    const rehydrated = resolveLocalSettings(saved.settings)
+    expect(rehydrated.agentChat.showThinking).toBe(true)
+    expect(rehydrated.agentChat.showTools).toBe(true)
+    expect(rehydrated.agentChat.showTimecodes).toBe(false)
+  })
+
+  it('does not persist agentChat when set to defaults', () => {
+    const store = createStore()
+
+    store.dispatch(updateSettingsLocal({
+      agentChat: { showThinking: false, showTools: false, showTimecodes: false },
+    }))
+
+    vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings?.agentChat).toBeUndefined()
+  })
 })

--- a/test/unit/client/store/panesPersistence.test.ts
+++ b/test/unit/client/store/panesPersistence.test.ts
@@ -744,6 +744,182 @@ describe('version 5 migration (drop claude-chat panes)', () => {
   })
 })
 
+import { BROWSER_PREFERENCES_STORAGE_KEY } from '../../../../src/store/storage-keys'
+
+describe('legacy agent-chat display settings migration', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    resetPersistedPanesCacheForTests()
+    resetPersistedLayoutCacheForTests()
+  })
+
+  it('migrates showThinking/showTools/showTimecodes from agent-chat panes to browser preferences', async () => {
+    localStorageMock.clear()
+    localStorage.setItem('freshell.layout.v3', JSON.stringify({
+      version: 3,
+      tabs: { tabs: [{ id: 'tab1', title: 'Tab 1' }], activeTabId: 'tab1' },
+      panes: {
+        version: PANES_SCHEMA_VERSION,
+        layouts: {
+          tab1: {
+            type: 'leaf',
+            id: 'pane1',
+            content: {
+              kind: 'agent-chat',
+              provider: 'claude',
+              createRequestId: 'req1',
+              status: 'idle',
+              showThinking: true,
+              showTools: true,
+              showTimecodes: true,
+            },
+          },
+        },
+        activePane: { tab1: 'pane1' },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+      },
+      tombstones: [],
+    }))
+
+    vi.resetModules()
+    const { default: freshPanesReducer } = await import('../../../../src/store/panesSlice')
+    const store = configureStore({ reducer: { panes: freshPanesReducer } })
+    const content = (store.getState().panes.layouts['tab1'] as any).content
+
+    expect(content.showThinking).toBeUndefined()
+    expect(content.showTools).toBeUndefined()
+    expect(content.showTimecodes).toBeUndefined()
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings.agentChat).toEqual({
+      showThinking: true,
+      showTools: true,
+      showTimecodes: true,
+    })
+  })
+
+  it('migrates legacy display settings from panes inside splits', async () => {
+    localStorageMock.clear()
+    localStorage.setItem('freshell.layout.v3', JSON.stringify({
+      version: 3,
+      tabs: { tabs: [{ id: 'tab1', title: 'Tab 1' }], activeTabId: 'tab1' },
+      panes: {
+        version: PANES_SCHEMA_VERSION,
+        layouts: {
+          tab1: {
+            type: 'split',
+            id: 'split1',
+            direction: 'horizontal',
+            sizes: [50, 50],
+            children: [
+              {
+                type: 'leaf',
+                id: 'pane1',
+                content: { kind: 'terminal', createRequestId: 'req1', status: 'running', mode: 'shell' },
+              },
+              {
+                type: 'leaf',
+                id: 'pane2',
+                content: {
+                  kind: 'agent-chat',
+                  provider: 'claude',
+                  createRequestId: 'req2',
+                  status: 'idle',
+                  showTools: true,
+                },
+              },
+            ],
+          },
+        },
+        activePane: { tab1: 'pane1' },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+      },
+      tombstones: [],
+    }))
+
+    vi.resetModules()
+    const { default: freshPanesReducer } = await import('../../../../src/store/panesSlice')
+    const store = configureStore({ reducer: { panes: freshPanesReducer } })
+    const split = store.getState().panes.layouts['tab1'] as any
+
+    expect(split.children[1].content.showTools).toBeUndefined()
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings.agentChat.showTools).toBe(true)
+  })
+
+  it('does not touch panes that have no legacy fields', async () => {
+    localStorageMock.clear()
+    localStorage.setItem('freshell.layout.v3', JSON.stringify({
+      version: 3,
+      tabs: { tabs: [{ id: 'tab1', title: 'Tab 1' }], activeTabId: 'tab1' },
+      panes: {
+        version: PANES_SCHEMA_VERSION,
+        layouts: {
+          tab1: {
+            type: 'leaf',
+            id: 'pane1',
+            content: { kind: 'terminal', createRequestId: 'req1', status: 'running', mode: 'shell' },
+          },
+        },
+        activePane: { tab1: 'pane1' },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+      },
+      tombstones: [],
+    }))
+
+    vi.resetModules()
+    const { default: freshPanesReducer } = await import('../../../../src/store/panesSlice')
+    configureStore({ reducer: { panes: freshPanesReducer } })
+
+    expect(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY)).toBeNull()
+  })
+
+  it('merges with existing browser preferences without clobbering', async () => {
+    localStorageMock.clear()
+    localStorage.setItem(BROWSER_PREFERENCES_STORAGE_KEY, JSON.stringify({
+      settings: { theme: 'dark' },
+      tabs: { searchRangeDays: 60 },
+    }))
+    localStorage.setItem('freshell.layout.v3', JSON.stringify({
+      version: 3,
+      tabs: { tabs: [{ id: 'tab1', title: 'Tab 1' }], activeTabId: 'tab1' },
+      panes: {
+        version: PANES_SCHEMA_VERSION,
+        layouts: {
+          tab1: {
+            type: 'leaf',
+            id: 'pane1',
+            content: {
+              kind: 'agent-chat',
+              provider: 'claude',
+              createRequestId: 'req1',
+              status: 'idle',
+              showThinking: true,
+            },
+          },
+        },
+        activePane: { tab1: 'pane1' },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+      },
+      tombstones: [],
+    }))
+
+    vi.resetModules()
+    const { default: freshPanesReducer } = await import('../../../../src/store/panesSlice')
+    configureStore({ reducer: { panes: freshPanesReducer } })
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings.theme).toBe('dark')
+    expect(bp.tabs.searchRangeDays).toBe(60)
+    expect(bp.settings.agentChat.showThinking).toBe(true)
+  })
+})
+
 describe('schema version consistency', () => {
   beforeEach(() => {
     localStorageMock.clear()

--- a/test/unit/client/store/state-edge-cases.test.ts
+++ b/test/unit/client/store/state-edge-cases.test.ts
@@ -787,6 +787,7 @@ describe('State Edge Cases', () => {
           sidebar: {
             excludeFirstChatSubstrings: [],
             excludeFirstChatMustStart: false,
+            autoGenerateTitles: true,
           },
           panes: {
             defaultNewPane: 'shell',
@@ -797,6 +798,7 @@ describe('State Edge Cases', () => {
               claude: { permissionMode: 'default' },
               codex: { model: 'gpt-5-codex' },
             },
+            mcpServer: true,
           },
           editor: {
             externalEditor: 'auto',
@@ -804,6 +806,9 @@ describe('State Edge Cases', () => {
           agentChat: {
             defaultPlugins: ['fs'],
             providers: {},
+          },
+          extensions: {
+            disabled: [],
           },
           network: {
             host: '127.0.0.1',
@@ -841,6 +846,7 @@ describe('State Edge Cases', () => {
               claude: { permissionMode: 'default' },
               codex: { model: 'gpt-5-codex' },
             },
+            mcpServer: true,
           },
           editor: {
             ...defaultSettings.editor,
@@ -850,6 +856,9 @@ describe('State Edge Cases', () => {
             ...defaultSettings.agentChat,
             defaultPlugins: ['fs'],
             providers: {},
+          },
+          extensions: {
+            ...defaultSettings.extensions,
           },
           network: {
             ...defaultSettings.network,

--- a/test/unit/shared/settings.test.ts
+++ b/test/unit/shared/settings.test.ts
@@ -34,6 +34,9 @@ describe('shared settings contract', () => {
     expect(schema.safeParse({ sidebar: { sortMode: 'activity' } }).success).toBe(false)
     expect(schema.safeParse({ sidebar: { showSubagents: true } }).success).toBe(false)
     expect(schema.safeParse({ sidebar: { ignoreCodexSubagents: true } }).success).toBe(false)
+    expect(schema.safeParse({ agentChat: { showThinking: true } }).success).toBe(false)
+    expect(schema.safeParse({ agentChat: { showTools: true } }).success).toBe(false)
+    expect(schema.safeParse({ agentChat: { showTimecodes: true } }).success).toBe(false)
   })
 
   it('defaults local sort mode to activity', () => {
@@ -107,6 +110,8 @@ describe('shared settings contract', () => {
       },
       agentChat: {
         defaultPlugins: ['fs'],
+        showThinking: true,
+        showTools: true,
       },
     }
 
@@ -125,6 +130,10 @@ describe('shared settings contract', () => {
         sortMode: 'project',
         showSubagents: true,
         ignoreCodexSubagents: false,
+      },
+      agentChat: {
+        showThinking: true,
+        showTools: true,
       },
       notifications: {
         soundEnabled: false,
@@ -199,6 +208,7 @@ describe('shared settings contract', () => {
       },
       agentChat: {
         defaultPlugins: ['fs'],
+        showThinking: true,
       },
     }
 


### PR DESCRIPTION
## Summary
- move agent-chat Show toggles from pane-scoped state into persisted per-machine browser preferences
- migrate legacy pane-stored display settings and update defaults/e2e flows for the new storage model
- add regression coverage for settings, persistence, migration, and agent-chat display behavior

## Context
- extracts the local-only `main` drift into a dedicated PR branch

## Testing
- `npm run test:vitest -- test/unit/shared/settings.test.ts test/unit/client/store/state-edge-cases.test.ts test/unit/client/store/panesPersistence.test.ts test/unit/client/store/browserPreferencesPersistence.test.ts test/unit/client/components/SettingsView.agent-chat.test.tsx`
- `npm run test:vitest -- test/unit/client/components/agent-chat/AgentChatView.behavior.test.tsx test/unit/client/components/agent-chat/AgentChatView.perf-audit.test.tsx test/unit/client/components/agent-chat/MessageBubble.test.tsx test/unit/client/components/agent-chat/ToolStrip.test.tsx test/e2e/agent-chat-context-menu-flow.test.tsx test/e2e/agent-chat-polish-flow.test.tsx`