### PR TITLE
Move agent chat Show settings from per-pane to per-machine

### DIFF
--- a/docs/plans/2026-03-31-tool-coalesce-test-plan.md
+++ b/docs/plans/2026-03-31-tool-coalesce-test-plan.md
@@ -1,0 +1,375 @@
+# Test Plan: Tool Coalescing
+
+appendum
+> **Feature:** Coalesce consecutive tool-only assistant messages into a single message so that multiple tool uses appear in ONE ToolStrip showing "N tools used" instead of multiple separate "1 tool used" strips.
+> **Implementation Plan:** `docs/plans/2026-03-31-tool-coalesce.md`
+> 
+> ---
+> 
+> ## Strategy Reconciliation
+> 
+> The testing strategy from the conversation aligns with the implementation plan:
+> 
+> | Strategy Element | Implementation Plan Coverage | Status |
+> |-----------------|------------------------------|--------|
+> | Unit tests for Redux coalescing | Task 1: 5 tests in `agentChatSlice.test.ts` | Aligned |
+> | Unit tests for JSONL loader coalescing | Task 2: 4 tests in `session-history-loader.test.ts` | Aligned |
+> | Browser-use test with LLM judge | Task 4: `tool_coalesce.py` + `tool_coalesce_test.py` | Aligned |
+> 
+> **No strategy changes requiring user approval.** The implementation plan already includes the browser-use tests with LLM as judge that the user explicitly requested.
+> 
+> ---
+> 
+> ## Action Space
+> 
+> ### User-Visible Actions Affected
+> 
+> 1. **Freshclaude session viewing** - When a user opens a Freshclaude session in the sidebar, the assistant messages should show coalesced tool strips
+> 2. **Session history loading** - When resuming a session, JSONL history should show coalesced tool strips
+> 3. **Live message streaming** - When an assistant uses multiple tools in sequence during a live session, they should coalesce into one strip
+> 
+> ### Internal Actions
+> 
+> 1. `addAssistantMessage` Redux action - Coalesces when previous message is tool-only assistant
+> 2. `extractChatMessagesFromJsonl` function - Coalesces when parsing JSONL history
+> 
+> ---
+> 
+> ## Test Plan
+> 
+> ### Priority 1: Problem-Statement Red Checks (Acceptance Gates)
+> 
+> These tests directly address the reported bug: seeing "1 tool used" twice instead of "2 tools used".
+> 
+> #### Test 1.1: Coalesces consecutive tool-only assistant messages
+> - **Name:** Coalesces consecutive tool-only assistant messages
+> - **Type:** regression
+> - **Disposition:** new
+> - **Harness:** Redux slice unit test (direct reducer calls)
+> - **Source of Truth:** User's reported bug - seeing "1 tool used" twice instead of "2 tools used"
+> - **Preconditions:** Session 's1' exists with no messages
+> - **Actions:**
+>   1. Dispatch `addAssistantMessage({ sessionId: 's1', content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }] })`
+>   2. Dispatch `addAssistantMessage({ sessionId: 's1', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'output' }, { type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } }] })`
+> - **Expected outcome:** Session has exactly 1 message with exactly 3 content blocks (tool_use, tool_result, tool_use)
+> - **Interactions:** None
+> 
+> #### Test 1.2: Does not coalesce when previous message has text content
+> - **Name:** Does not coalesce when previous message has text content
+> - **Type:** boundary
+> - **Disposition:** new
+> - **Harness:** Redux slice unit test
+> - **Source of Truth:** Implementation plan - text content breaks coalescing
+> - **Preconditions:** Session 's1' exists with no messages
+> - **Actions:**
+>   1. Dispatch `addAssistantMessage({ sessionId: 's1', content: [{ type: 'text', text: 'Hello' }] })`
+>   2. Dispatch `addAssistantMessage({ sessionId: 's1', content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }] })`
+> - **Expected outcome:** Session has exactly 2 messages
+> - **Interactions:** None
+> 
+> #### Test 1.3: Does not coalesce when new message has text content
+> - **Name:** Does not coalesce when new message has text content
+> - **Type:** boundary
+> - **Disposition:** new
+> - **Harness:** Redux slice unit test
+> - **Source of Truth:** Implementation plan - text content breaks coalescing
+> - **Preconditions:** Session 's1' exists with no messages
+> - **Actions:**
+>   1. Dispatch `addAssistantMessage({ sessionId: 's1', content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }] })`
+>   2. Dispatch `addAssistantMessage({ sessionId: 's1', content: [{ type: 'text', text: 'Done' }] })`
+> - **Expected outcome:** Session has exactly 2 messages
+> - **Interactions:** None
+> 
+> #### Test 1.4: Coalesces multiple consecutive tool-only messages
+> - **Name:** Coalesces multiple consecutive tool-only messages
+> - **Type:** regression
+> - **Disposition:** new
+> - **Harness:** Redux slice unit test
+> - **Source of Truth:** User's reported bug - multiple tools should all coalesce
+> - **Preconditions:** Session 's1' exists with no messages
+> - **Actions:**
+>   1. Dispatch `addAssistantMessage` with tool_use t1
+>   2. Dispatch `addAssistantMessage` with tool_result for t1
+>   3. Dispatch `addAssistantMessage` with tool_use t2
+>   4. Dispatch `addAssistantMessage` with tool_result for t2
+> - **Expected outcome:** Session has exactly 1 message with exactly 4 content blocks
+> - **Interactions:** None
+> 
+> #### Test 1.5: Does not coalesce across user messages
+> - **Name:** Does not coalesce across user messages
+> - **Type:** boundary
+> - **Disposition:** new
+> - **Harness:** Redux slice unit test
+> - **Source of Truth:** Implementation plan - user messages break coalescing
+> - **Preconditions:** Session 's1' exists with no messages
+> - **Actions:**
+>   1. Dispatch `addAssistantMessage` with tool_use t1
+>   2. Dispatch `addUserMessage` with text
+>   3. Dispatch `addAssistantMessage` with tool_use t2
+> - **Expected outcome:** Session has exactly 3 messages (assistant, user, assistant)
+> - **Interactions:** None
+> 
+> #### Test 1.6: JSONL loader coalesces consecutive tool-only assistant messages
+> - **Name:** JSONL loader coalesces consecutive tool-only assistant messages
+> - **Type:** regression
+> - **Disposition:** new
+> - **Harness:** JSONL parser unit test (direct function calls)
+> - **Source of Truth:** User's reported bug - restored sessions also show separate "1 tool used"
+> - **Preconditions:** None
+> - **Actions:**
+>   1. Call `extractChatMessagesFromJsonl` with JSONL containing 3 consecutive tool-only assistant messages
+> - **Expected outcome:** Returns 1 message with 3 content blocks
+> - **Interactions:** None
+> 
+> #### Test 1.7: JSONL loader does not coalesce when assistant message has text content
+> - **Name:** JSONL loader does not coalesce when assistant message has text content
+> - **Type:** boundary
+> - **Disposition:** new
+> - **Harness:** JSONL parser unit test
+> - **Source of Truth:** Implementation plan - text content breaks coalescing
+> - **Preconditions:** None
+> - **Actions:**
+>   1. Call `extractChatMessagesFromJsonl` with JSONL containing text message followed by tool_use message
+> - **Expected outcome:** Returns 2 messages
+> - **Interactions:** None
+> 
+> #### Test 1.8: JSONL loader does not coalesce across user messages
+> - **Name:** JSONL loader does not coalesce across user messages
+> - **Type:** boundary
+> - **Disposition:** new
+> - **Harness:** JSONL parser unit test
+> - **Source of Truth:** Implementation plan - user messages break coalescing
+> - **Preconditions:** None
+> - **Actions:**
+>   1. Call `extractChatMessagesFromJsonl` with JSONL containing tool_use, user, tool_use
+> - **Expected outcome:** Returns 3 messages
+> - **Interactions:** None
+> 
+> #### Test 1.9: JSONL loader preserves timestamp from first message in coalesced group
+> - **Name:** JSONL loader preserves timestamp from first message in coalesced group
+> - **Type:** invariant
+> - **Disposition:** new
+> - **Harness:** JSONL parser unit test
+> - **Source of Truth:** Implementation plan - timestamp from first message preserved
+> - **Preconditions:** None
+> - **Actions:**
+>   1. Call `extractChatMessagesFromJsonl` with JSONL containing 2 tool-only messages with different timestamps
+> - **Expected outcome:** Coalesced message has timestamp of first message
+> - **Interactions:** None
+> 
+> ---
+> 
+> ### Priority 2: High-Value Existing Integration Tests
+> 
+> The existing `MessageBubble.test.tsx` already verifies tool grouping within a single message. These tests remain unchanged and provide confidence that the rendering layer still works correctly after the Redux/JSONL changes.
+> 
+> **Existing tests to keep passing (no modifications needed):**
+> - `groups contiguous tool blocks into a single ToolStrip` - verifies rendering of coalesced content
+> - `creates separate strips for non-contiguous tool groups` - verifies text breaks tool groups
+> - `renders collapsed strip with summary text when showTools is false` - verifies "N tools used" display
+> 
+> ---
+> 
+> ### Priority 3: New Integration Tests
+> 
+> #### Test 3.1: End-to-end tool strip rendering with coalesced messages
+> - **Name:** End-to-end tool strip rendering with coalesced messages
+> - **Type:** integration
+> - **Disposition:** new
+> - **Harness:** React Testing Library with Redux store
+> - **Source of Truth:** User-visible behavior - one strip showing "N tools used"
+> - **Preconditions:** Redux store with session 's1'
+> - **Actions:**
+>   1. Dispatch `sessionCreated` for 's1'
+>   2. Dispatch `addAssistantMessage` with tool_use t1
+>   3. Dispatch `addAssistantMessage` with tool_result t1 + tool_use t2
+>   4. Render `MessageBubble` with the resulting message content
+> - **Expected outcome:** One ToolStrip showing "2 tools used" (collapsed) or 2 tool blocks (expanded)
+> - **Interactions:** Redux store -> MessageBubble component
+> 
+> #### Test 3.2: Session history loading produces coalesced messages
+> - **Name:** Session history loading produces coalesced messages
+> - **Type:** integration
+> - **Disposition:** new
+> - **Harness:** JSONL file I/O + Redux store
+> - **Source of Truth:** User-visible behavior - restored sessions show coalesced tools
+> - **Preconditions:** Temporary JSONL file with 3 tool-only assistant messages
+> - **Actions:**
+>   1. Call `loadSessionHistory` with the temp file
+>   2. Dispatch messages to Redux store
+>   3. Render `MessageBubble` with the resulting messages
+> - **Expected outcome:** One ToolStrip showing "3 tools used"
+> - **Interactions:** File system -> JSONL loader -> Redux store -> MessageBubble
+> 
+> ---
+> 
+> ### Priority 4: Boundary and Edge Cases
+> 
+> #### Test 4.1: Empty content array does not trigger coalescing
+> - **Name:** Empty content array does not trigger coalescing
+> - **Type:** boundary
+> - **Disposition:** new
+> - **Harness:** Redux slice unit test
+> - **Source of Truth:** Implementation plan - `isToolOnlyContent([])` returns false
+> - **Preconditions:** Session 's1' exists with one tool-only message
+> - **Actions:**
+>   1. Dispatch `addAssistantMessage` with empty content array
+> - **Expected outcome:** Empty message is added (not coalesced) - 2 messages total
+> - **Interactions:** None
+> 
+> #### Test 4.2: Thinking block breaks coalescing
+> - **Name:** Thinking block breaks coalescing
+> - **Type:** boundary
+> - **Disposition:** new
+> - **Harness:** Redux slice unit test
+> - **Source of Truth:** Implementation plan - only tool_use/tool_result are tool-only
+> - **Preconditions:** Session 's1' exists with one tool-only message
+> - **Actions:**
+>   1. Dispatch `addAssistantMessage` with thinking block
+> - **Expected outcome:** New message is added (not coalesced) - 2 messages total
+> - **Interactions:** None
+> 
+> #### Test 4.3: Session not found returns early without modification
+> - **Name:** Session not found returns early without modification
+> - **Type:** boundary
+> - **Disposition:** new
+> - **Harness:** Redux slice unit test
+> - **Source of Truth:** Existing reducer behavior - early return for unknown session
+> - **Preconditions:** No session 'nonexistent'
+> - **Actions:**
+>   1. Dispatch `addAssistantMessage` with sessionId 'nonexistent'
+> - **Expected outcome:** State unchanged
+> - **Interactions:** None
+> 
+> #### Test 4.4: Malformed JSONL skips bad lines gracefully
+> - **Name:** Malformed JSONL skips bad lines gracefully
+> - **Type:** boundary
+> - **Disposition:** extend
+> - **Harness:** JSONL parser unit test
+> - **Source of Truth:** Existing behavior - malformed JSON skipped
+> - **Preconditions:** None
+> - **Actions:**
+>   1. Call `extractChatMessagesFromJsonl` with JSONL containing malformed JSON between valid messages
+> - **Expected outcome:** Valid messages parsed, malformed lines skipped, coalescing works on valid messages
+> - **Interactions:** None
+> 
+> ---
+> 
+> ### Priority 5: Invariant Tests
+> 
+> #### Test 5.1: Message order preserved after coalescing
+> - **Name:** Message order preserved after coalescing
+> - **Type:** invariant
+> - **Disposition:** new
+> - **Harness:** Redux slice unit test
+> - **Source of Truth:** Implementation plan - coalescing appends content, never reorders
+> - **Preconditions:** Session exists with tool-only message
+> - **Actions:**
+>   1. Add tool_use t1
+>   2. Add tool_result t1
+>   3. Add tool_use t2
+> - **Expected outcome:** Content blocks in order: t1 tool_use, t1 tool_result, t2 tool_use
+> - **Interactions:** None
+> 
+> #### Test 5.2: Model preserved from first message in coalesced group
+> - **Name:** Model preserved from first message in coalesced group
+> - **Type:** invariant
+> - **Disposition:** new
+> - **Harness:** Redux slice unit test
+> - **Source of Truth:** Implementation plan - first message's metadata preserved
+> - **Preconditions:** Session exists
+> - **Actions:**
+>   1. Add tool_use with model 'claude-opus'
+>   2. Add tool_result (no model specified)
+> - **Expected outcome:** Coalesced message has model 'claude-opus'
+> - **Interactions:** None
+> 
+> #### Test 5.3: Status updated to 'running' after coalescing
+> - **Name:** Status updated to 'running' after coalescing
+> - **Type:** invariant
+> - **Disposition:** new
+> - **Harness:** Redux slice unit test
+> - **Source of Truth:** Existing reducer behavior - status set to 'running' on addAssistantMessage
+> - **Preconditions:** Session with status 'idle'
+> - **Actions:**
+>   1. Add tool_use message
+>   2. Add tool_result message
+> - **Expected outcome:** Session status is 'running'
+> - **Interactions:** None
+> 
+> ---
+> 
+> ### Priority 6: Browser-Use Scenario Test (LLM Judge)
+> 
+> #### Test 6.1: Browser-use verifies tool strip coalescing in live UI
+> - **Name:** Browser-use verifies tool strip coalescing in live UI
+> - **Type:** scenario
+> - **Disposition:** new
+> - **Harness:** Browser-use with ChatBrowserUse LLM
+> - **Source of Truth:** User's explicit request for browser-use tests with LLM as judge
+> - **Preconditions:** Freshell server running, Freshclaude session exists with multiple tool uses
+> - **Actions:**
+>   1. Open Freshell in browser
+>   2. Navigate to Freshclaude session with tool uses
+>   3. Examine tool strip display for assistant messages
+>   4. Judge whether strips are coalesced
+> - **Expected outcome:** Output line `TOOL_COALESCE_RESULT: PASS` if one strip per turn, `TOOL_COALESCE_RESULT: FAIL - <reason>` otherwise
+> - **Interactions:** Browser automation, LLM judgment,> 
+> #### Test 6.2: Browser-use parsing utilities unit tests
+> - **Name:** Browser-use parsing utilities unit tests
+> - **Type:** unit
+> - **Disposition:** new
+> - **Harness:** Python pytest
+> - **Source of Truth:** Browser-use test contract enforcement
+> - **Preconditions:** None
+> - **Actions:**
+>   1. Test `_parse_result("TOOL_COALESCE_RESULT: PASS")` returns (True, None)
+>   2. Test `_parse_result("TOOL_COALESCE_RESULT: FAIL - reason")` returns (False, None)
+>   3. Test `_parse_result("")` returns (False, "missing_final_result")
+>   4. Test `_parse_result("PASS\nextra")` returns (False, "final_result_not_single_line")
+> - **Expected outcome:** All parsing tests pass
+> - **Interactions:** None
+> 
+> ---
+> 
+> ## Coverage Summary
+> 
+> | Area | Coverage | Priority |
+> |------|---------|----------|
+> | Redux coalescing logic | Tests 1.1-1.5, 4.1-4.3, 5.1-5.3 | 1, 4, 5 |
+> | JSONL loader coalescing | Tests 1.6-1.9, 4.4 | 1, 4 |
+> | Component rendering with coalesced data | Tests 3.1-3.2 | 3 |
+> | End-to-end browser verification | Tests 6.1-6.2 | 6 |
+> | Existing MessageBubble tests | Unchanged | 2 |
+> 
+> ### Explicitly Excluded
+> 
+> | Area | Reason | Risk |
+> |------|--------|------|
+> | Server-side WebSocket message handling | Not in scope - fix is client-side Redux | Low - WebSocket sends individual messages, coalescing happens after |
+> | `sdk-bridge.ts` changes | Not modified - coalescing happens at Redux layer | None |
+> | `turnBodyReceived` timeline hydration | Uses separate `timelineBodies` storage, not live messages | Low - timeline is read-only view |
+> | Performance testing | Low risk - coalescing is O(1) per message, no loops | None |
+> 
+> ### Test Count by Type
+> 
+> | Type | Count |
+> |------|-------|
+> | regression | 3 |
+> | boundary | 7 |
+> | invariant | 3 |
+> | integration | 2 |
+> | scenario | 1 |
+> | unit | 1 |
+> | **Total** | **17** |
+> 
+> ---
+> 
+> ## Execution Order
+> 
+> 1. **Phase 1: Red checks** (Tests 1.1-1.9) - Verify the fix works for the reported bug
+> 2. **Phase 2: Run existing tests** - Verify no regressions in MessageBubble rendering
+> 3. **Phase 3: Integration tests** (Tests 3.1-3.2) - Verify end-to-end flow
+> 4. **Phase 4: Boundary cases** (Tests 4.1-4.4) - Verify edge cases
+> 5. **Phase 5: Invariant tests** (Tests 5.1-5.3) - Verify properties preserved
+> 6. **Phase 6: Browser-use** (Tests 6.1-6.2) - Verify in real UI with LLM judge

--- a/docs/plans/2026-03-31-tool-coalesce.md
+++ b/docs/plans/2026-03-31-tool-coalesce.md
@@ -6,15 +6,15 @@
 
 **Architecture:** The SDK sends separate `assistant` messages (one per tool_use block). The fix intercepts at two points: (1) the Redux `addAssistantMessage` reducer for live messages, and (2) the `extractChatMessagesFromJsonl` function for restored sessions. Both locations check if the previous message is also a tool-only assistant message, and if so, append content blocks instead of creating a new message.
 
-**Tech Stack:** Redux Toolkit, TypeScript, Vitest, Testing Library, browser-use CLI
+**Tech Stack:** Redux Toolkit, TypeScript, Vitest, Testing Library, browser-use (Python)
 
 ---
 
 ## Root Cause Analysis
 
-The Claude SDK sends multiple `assistant` messages (one per `tool_use` block). The server's `sdk-bridge.ts` (lines 273-296) creates a **new Redux message** for each SDK message via `state.messages.push(...)`. Each message becomes a separate `MessageBubble`, each with its own `ToolStrip` showing "1 tool used".
+The Claude SDK sends multiple `assistant` messages (one per `tool_use` block). The server's `sdk-bridge.ts` creates a **new Redux message** for each SDK message. Each message becomes a separate `MessageBubble`, each with its own `ToolStrip` showing "1 tool used".
 
-The `MessageBubble` grouping logic (lines 50-126) correctly groups consecutive `tool_use` blocks **within a single message's content array**, but cannot merge across separate messages.
+The `MessageBubble` grouping logic correctly groups consecutive `tool_use` blocks **within a single message's content array**, but cannot merge across separate messages.
 
 ## Strategy
 
@@ -33,82 +33,15 @@ Fix at the message creation boundary, not the rendering boundary. This is cleane
 | `server/session-history-loader.ts` | Modify | Add coalescing logic to `extractChatMessagesFromJsonl` |
 | `test/unit/client/agentChatSlice.test.ts` | Modify | Add tests for coalescing |
 | `test/unit/server/session-history-loader.test.ts` | Modify | Add tests for coalescing |
-| `test/browser-use/tool-coalesce.md` | Create | Browser-use test procedure documentation |
+| `test/browser_use/tool_coalesce.py` | Create | Automated browser-use test with LLM judge |
+| `test/browser_use/tool_coalesce_test.py` | Create | Unit tests for parsing logic |
 
 ---
 
-## Task 1: Add Helper Function to Identify Tool-Only Content
+## Task 1: Implement Coalescing in addAssistantMessage Reducer
 
 **Files:**
-- Modify: `src/store/agentChatSlice.ts:1-10`
-
-- [ ] **Step 1: Identify or write the failing test**
-
-First, verify the existing tests pass (no existing check for coalescing - this is the gap):
-
-```bash
-npm run test:vitest -- test/unit/client/agentChatSlice.test.ts --run
-```
-
-Expected: All tests pass
-
-- [ ] **Step 2: Run test to verify it fails**
-
-No failing test yet - we're adding new functionality. Proceed to implementation.
-
-- [ ] **Step 3: Write minimal implementation**
-
-Add a helper function at the top of `agentChatSlice.ts` to identify if content blocks are tool-only:
-
-```typescript
-import type {
-  AgentChatState,
-  AgentTimelineItem,
-  ChatContentBlock,
-  ChatMessage,
-  ChatSessionState,
-  QuestionDefinition,
-} from './agentChatTypes'
-
-/** Check if content blocks contain only tool_use and tool_result blocks (no text or thinking). */
-function isToolOnlyContent(blocks: ChatContentBlock[]): boolean {
-  return blocks.length > 0 && blocks.every(
-    (b) => b.type === 'tool_use' || b.type === 'tool_result'
-  )
-}
-```
-
-- [ ] **Step 4: Run test to verify it passes**
-
-```bash
-npm run test:vitest -- test/unit/client/agentChatSlice.test.ts --run
-```
-
-Expected: All tests pass
-
-- [ ] **Step 5: Refactor and verify**
-
-The helper is minimal. Run typecheck:
-
-```bash
-npx tsc --noEmit -p src/tsconfig.json
-```
-
-Expected: No errors
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add src/store/agentChatSlice.ts
-git commit -m "feat(agent-chat): add isToolOnlyContent helper for message coalescing"
-```
-
----
-
-## Task 2: Implement Coalescing in addAssistantMessage Reducer
-
-**Files:**
-- Modify: `src/store/agentChatSlice.ts:109-123`
+- Modify: `src/store/agentChatSlice.ts` (add helper after imports, modify reducer)
 
 - [ ] **Step 1: Write the failing test**
 
@@ -233,7 +166,18 @@ Expected: FAIL - "expected 1 to equal 2" (messages not coalescing)
 
 - [ ] **Step 3: Write minimal implementation**
 
-Modify `addAssistantMessage` reducer in `src/store/agentChatSlice.ts`:
+First, add helper function after the imports in `src/store/agentChatSlice.ts` (after line 9, before `initialState`):
+
+```typescript
+/** Check if content blocks contain only tool_use and tool_result blocks (no text or thinking). */
+function isToolOnlyContent(blocks: ChatContentBlock[]): boolean {
+  return blocks.length > 0 && blocks.every(
+    (b) => b.type === 'tool_use' || b.type === 'tool_result'
+  )
+}
+```
+
+Then modify the `addAssistantMessage` reducer:
 
 ```typescript
 addAssistantMessage(state, action: PayloadAction<{
@@ -295,10 +239,10 @@ git commit -m "feat(agent-chat): coalesce consecutive tool-only assistant messag
 
 ---
 
-## Task 3: Implement Coalescing in Session History Loader
+## Task 2: Implement Coalescing in Session History Loader
 
 **Files:**
-- Modify: `server/session-history-loader.ts:30-68`
+- Modify: `server/session-history-loader.ts`
 - Modify: `test/unit/server/session-history-loader.test.ts`
 
 - [ ] **Step 1: Write the failing test**
@@ -470,7 +414,7 @@ git commit -m "feat(server): coalesce consecutive tool-only assistant messages i
 
 ---
 
-## Task 4: Run Full Test Suite
+## Task 3: Run Full Test Suite
 
 **Files:**
 - None (verification only)
@@ -510,150 +454,330 @@ git commit -m "fix: address test/typecheck/lint issues from tool coalescing"
 
 ---
 
-## Task 5: Browser-Use Visual Verification
+## Task 4: Create Automated Browser-Use Test
 
 **Files:**
-- Create: `test/browser_use/tool-coalesce.md` (test instructions, not code)
+- Create: `test/browser_use/tool_coalesce.py`
+- Create: `test/browser_use/tool_coalesce_test.py`
 
-**Prerequisites:**
-- `browser-use` CLI installed: `uvx "browser-use[cli]" --help` (or `pip install "browser-use[cli]"`)
-- Chromium installed: `browser-use install`
-- API key: `BROWSER_USE_API_KEY` environment variable (for Browser Use's hosted LLM gateway)
+This task creates an **automated** browser-use test following the repo's established pattern (`smoke_freshell.py`). The test uses an LLM as judge to verify tool strip coalescing.
 
-- [ ] **Step 1: Ensure browser-use is available**
+- [ ] **Step 1: Create the test parsing utilities**
 
-```bash
-# Check if browser-use is installed
-browser-use --version || uvx "browser-use[cli]" --help
+Create `test/browser_use/tool_coalesce_test.py` with unit tests for result parsing:
 
-# Install Chromium if needed
-browser-use install
+```python
+import unittest
+from tool_coalesce import _parse_result
+
+
+class ToolCoalesceParseTest(unittest.TestCase):
+  def test_pass_requires_exact_single_line(self) -> None:
+    ok, err = _parse_result("TOOL_COALESCE_RESULT: PASS")
+    self.assertTrue(ok)
+    self.assertIsNone(err)
+
+  def test_pass_with_extra_text_is_invalid(self) -> None:
+    ok, err = _parse_result("TOOL_COALESCE_RESULT: PASS. extra")
+    self.assertFalse(ok)
+    self.assertEqual(err, "final_result_invalid_format")
+
+  def test_fail_requires_reason(self) -> None:
+    ok, err = _parse_result("TOOL_COALESCE_RESULT: FAIL - multiple strips found")
+    self.assertFalse(ok)
+    self.assertIsNone(err)
+
+  def test_empty_is_invalid(self) -> None:
+    ok, err = _parse_result("")
+    self.assertFalse(ok)
+    self.assertEqual(err, "missing_final_result")
+
+  def test_multiple_lines_is_invalid(self) -> None:
+    ok, err = _parse_result("TOOL_COALESCE_RESULT: PASS\nmore")
+    self.assertFalse(ok)
+    self.assertEqual(err, "final_result_not_single_line")
+
+
+if __name__ == "__main__":
+  raise SystemExit(unittest.main())
 ```
 
-Expected: browser-use CLI available, Chromium installed
-
-- [ ] **Step 2: Start Freshell server on test port**
+- [ ] **Step 2: Run parsing tests to verify they fail (module not created yet)**
 
 ```bash
-cd /home/user/code/freshell/.worktrees/tool-coalesce
-PORT=3355 npm run dev:server > /tmp/freshell-3355.log 2>&1 & echo $! > /tmp/freshell-3355.pid
-sleep 5
-curl -s http://localhost:3355/api/health > /dev/null && echo "Server ready"
+cd /home/user/code/freshell/.worktrees/tool-coalesce/test/browser_use
+python -m pytest tool_coalesce_test.py -v 2>&1 || echo "Expected to fail - module not created"
 ```
 
-Expected: "Server ready"
+Expected: Import error (module not created yet)
 
-- [ ] **Step 3: Navigate to Freshell and find a session with tools**
+- [ ] **Step 3: Create the main browser-use test script**
+
+Create `test/browser_use/tool_coalesce.py`:
+
+```python
+#!/usr/bin/env python3
+"""
+Browser-use test for tool strip coalescing in Freshclaude.
+
+Verifies that consecutive tool uses in an assistant turn appear as ONE
+strip showing "N tools used" instead of multiple separate "1 tool used" strips.
+Uses an LLM as judge to evaluate the visual result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import logging
+import urllib.request
+from pathlib import Path
+
+# Add parent directory for shared utilities
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from smoke_utils import (
+  JsonLogger,
+  build_target_url,
+  default_base_url,
+  env_or,
+  find_upwards,
+  load_dotenv,
+  monotonic_timer,
+  redact_url,
+  redact_text,
+  require,
+  token_fingerprint,
+)
+
+
+def _parse_result(final_text: str) -> tuple[bool, str | None]:
+  """
+  Enforce strict output contract:
+  - Exactly one line
+  - Exactly "TOOL_COALESCE_RESULT: PASS"
+    or "TOOL_COALESCE_RESULT: FAIL - <short reason>"
+  """
+  text = (final_text or "").strip()
+  if not text:
+    return False, "missing_final_result"
+
+  lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+  if len(lines) != 1:
+    return False, "final_result_not_single_line"
+
+  line = lines[0]
+  if line == "TOOL_COALESCE_RESULT: PASS":
+    return True, None
+  if line.startswith("TOOL_COALESCE_RESULT: FAIL - ") and len(line) > len("TOOL_COALESCE_RESULT: FAIL - "):
+    return False, None
+  return False, "final_result_invalid_format"
+
+
+def _build_task(*, base_url: str) -> str:
+  return f"""
+You are testing the tool strip coalescing feature in a Freshell Freshclaude session.
+
+The app is already opened and authenticated at {base_url}.
+
+Your goal: Verify that when an assistant turn uses multiple tools, they appear grouped in ONE tool strip showing "N tools used" instead of multiple separate "1 tool used" strips.
+
+Steps:
+
+1. Open the sidebar if it's collapsed. Look for Freshclaude sessions (they have a different icon than shell tabs).
+
+2. Find and click on a Freshclaude session that has assistant messages with tool uses. Look for sessions that show tool indicators or message counts.
+
+3. If no session with multiple tool uses exists, skip to step 7 and report what you found.
+
+4. Once in a session, look at the assistant messages that contain tool uses. Find a message where the assistant used 2 or more tools in a single turn.
+
+5. Examine the tool strip display for that message:
+   - A tool strip should be visible showing either "N tools used" (collapsed) or individual tool blocks (expanded)
+   - Count how many separate tool-related text lines are visible (e.g., "1 tool used", "2 tools used", etc.)
+
+6. Judge the result:
+   - PASS: You see ONE tool strip per assistant turn, showing the combined count (e.g., "2 tools used" or "3 tools used")
+   - FAIL: You see MULTIPLE separate lines each showing "1 tool used" for tools that should be grouped
+
+7. Report your findings as exactly one line:
+   - If tool strips are correctly coalesced: TOOL_COALESCE_RESULT: PASS
+   - If you see multiple separate "1 tool used" strips: TOOL_COALESCE_RESULT: FAIL - multiple strips found
+   - If no suitable session found: TOOL_COALESCE_RESULT: FAIL - no session with tools
+
+Non-negotiable constraints:
+- Do not create or write any files
+- Stay in ONE browser tab
+- Output exactly one result line at the end
+"""
+
+
+async def _run(args: argparse.Namespace) -> int:
+  repo_root = Path(__file__).resolve().parents[2]
+  dotenv_path = find_upwards(repo_root, ".env")
+  dotenv = load_dotenv(dotenv_path) if dotenv_path else {}
+
+  log = JsonLogger(min_level=("debug" if args.debug else "info"))
+
+  if args.require_api_key and not os.environ.get("BROWSER_USE_API_KEY"):
+    log.error("Missing BROWSER_USE_API_KEY", event="missing_browser_use_api_key")
+    return 2
+
+  base_url = args.base_url or default_base_url(dotenv)
+  token = env_or(args.token, "AUTH_TOKEN") or dotenv.get("AUTH_TOKEN")
+  try:
+    token = require("AUTH_TOKEN", token)
+  except ValueError as e:
+    log.error(str(e), event="missing_auth_token")
+    return 2
+
+  model = env_or(args.model, "BROWSER_USE_MODEL") or "bu-latest"
+  target_url = build_target_url(base_url, token)
+  redacted_target_url = redact_url(target_url)
+
+  log.info(
+    "Tool coalesce test start",
+    event="test_start",
+    baseUrl=base_url,
+    tokenFp=token_fingerprint(token),
+    model=model,
+    headless=args.headless,
+  )
+
+  if args.preflight:
+    health_url = f"{base_url.rstrip('/')}/api/health"
+    try:
+      with urllib.request.urlopen(health_url, timeout=3) as resp:
+        log.info("Preflight ok", event="preflight_ok", url=health_url)
+    except Exception as e:
+      log.error("Preflight failed", event="preflight_failed", url=health_url, error=str(e))
+      return 1
+
+  from browser_use import Agent, Browser, ChatBrowserUse  # type: ignore
+
+  llm = ChatBrowserUse(model=model)
+  browser = Browser(
+    headless=args.headless,
+    window_size={"width": args.width, "height": args.height},
+    viewport={"width": args.width, "height": args.height},
+    no_viewport=False,
+  )
+  browser_started = False
+
+  try:
+    log.info("Pre-opening target URL", event="preopen_target", targetUrl=redacted_target_url)
+    await browser.start()
+    browser_started = True
+
+    # Navigate to authenticated URL
+    page = await browser.new_page(target_url)
+
+    log.info("Target URL opened", event="preopen_target_ok")
+  except Exception as e:
+    log.error("Failed to pre-open target URL", event="preopen_target_failed", error=str(e))
+    if browser_started:
+      try:
+        await browser.stop()
+      except Exception:
+        pass
+    return 1
+
+  task = _build_task(base_url=base_url)
+
+  agent = Agent(
+    task=task.strip(),
+    llm=llm,
+    browser=browser,
+    use_vision=True,
+    max_actions_per_step=2,
+    directly_open_url=False,
+  )
+
+  _start, elapsed_s = monotonic_timer()
+  try:
+    log.info("Agent run start", event="agent_run_start", maxSteps=args.max_steps)
+    history = await agent.run(max_steps=args.max_steps)
+  finally:
+    if browser_started:
+      try:
+        await browser.stop()
+      except Exception:
+        pass
+
+  log.info("Agent finished", event="agent_finished", elapsedS=round(elapsed_s(), 2))
+
+  final_result_fn = getattr(history, "final_result", None)
+  final = final_result_fn() if callable(final_result_fn) else None
+  final_text = str(final or "").strip()
+
+  ok, parse_err = _parse_result(final_text)
+  if parse_err:
+    log.error("Invalid final_result format", event="invalid_final_result", error=parse_err, text=final_text[:500])
+    return 1
+  if ok:
+    log.info("TOOL_COALESCE_RESULT: PASS", event="test_pass")
+    return 0
+  log.error("TOOL_COALESCE_RESULT: FAIL", event="test_fail", reason=final_text[:500])
+  return 1
+
+
+def main(argv: list[str]) -> int:
+  p = argparse.ArgumentParser(description="Browser-use test for tool strip coalescing.")
+  p.add_argument("--base-url", default=None, help="Base URL")
+  p.add_argument("--token", default=None, help="Auth token")
+  p.add_argument("--model", default=None, help="Browser Use model")
+  p.add_argument("--headless", action="store_true", help="Run headless")
+  p.add_argument("--width", type=int, default=1024)
+  p.add_argument("--height", type=int, default=768)
+  p.add_argument("--max-steps", type=int, default=30)
+  p.add_argument("--preflight", action="store_true", help="Check /api/health first")
+  p.add_argument("--debug", action="store_true")
+  p.add_argument("--no-require-api-key", dest="require_api_key", action="store_false")
+  p.set_defaults(require_api_key=True)
+  args = p.parse_args(argv)
+  try:
+    return asyncio.run(_run(args))
+  except KeyboardInterrupt:
+    return 130
+  except Exception:
+    sys.stderr.write(__import__("traceback").format_exc())
+    return 1
+
+
+if __name__ == "__main__":
+  raise SystemExit(main(sys.argv[1:]))
+```
+
+- [ ] **Step 4: Run parsing tests to verify they pass**
 
 ```bash
-browser-use open http://localhost:3355
-browser-use state
+cd /home/user/code/freshell/.worktrees/tool-coalesce/test/browser_use
+python -m pytest tool_coalesce_test.py -v
 ```
 
-Expected: Page loads, shows Freshell UI
+Expected: All parsing tests pass
 
-- [ ] **Step 4: Navigate to Freshclaude session**
-
-Using browser-use, find and click on a Freshclaude session in the sidebar that has tool uses. If no session exists with multiple tools, create a test scenario by sending a message that triggers multiple tool calls.
+- [ ] **Step 5: Make the test script executable and verify syntax**
 
 ```bash
-# Get page state to find Freshclaude sessions
-browser-use state
-
-# Click on a session that shows tool indicators (look for "tools" or tool count)
-# Example: browser-use click 3  # where 3 is the index of a Freshclaude session
+chmod +x /home/user/code/freshell/.worktrees/tool-coalesce/test/browser_use/tool_coalesce.py
+python -m py_compile /home/user/code/freshell/.worktrees/tool-coalesce/test/browser_use/tool_coalesce.py
 ```
 
-- [ ] **Step 5: Verify tool strip coalescing with LLM as judge**
+Expected: No syntax errors
 
-Use browser-use's `extract` command with LLM to verify the tool strip behavior:
+- [ ] **Step 6: Commit**
 
 ```bash
-# Extract tool strip information using LLM
-browser-use extract "Find all tool strip regions on this page. For each strip, report: 1) The text shown (e.g., '2 tools used' or individual tool names), 2) Whether it's collapsed or expanded. Return as a JSON array."
-```
-
-Expected output: Single tool strip showing combined count like "2 tools used" or "3 tools used" - NOT multiple strips each showing "1 tool used"
-
-- [ ] **Step 6: Take screenshot for evidence**
-
-```bash
-browser-use screenshot /tmp/tool-coalesce-verify.png
-```
-
-- [ ] **Step 7: Verify collapsed state shows single summary**
-
-When the tool strip is collapsed, verify it shows one summary line:
-
-```bash
-browser-use extract "Count how many separate lines contain the text 'tool' or 'tools used'. Return only the number."
-```
-
-Expected: 1 (single summary line, not multiple "1 tool used" lines)
-
-- [ ] **Step 8: Verify expand/collapse toggle works**
-
-```bash
-# Find and click the chevron to expand
-browser-use state
-# Look for chevron/expand button in the state output
-# browser-use click <index>  # click the chevron
-
-# Verify tools are now visible individually
-browser-use extract "List all tool names visible on the page. Return as a comma-separated list."
-```
-
-Expected: Individual tool names visible after expansion
-
-- [ ] **Step 9: Cleanup**
-
-```bash
-browser-use close
-kill "$(cat /tmp/freshell-3355.pid)" && rm -f /tmp/freshell-3355.pid
-```
-
-- [ ] **Step 10: Create test documentation file**
-
-Create `test/browser_use/tool-coalesce.md` documenting the test procedure:
-
-```markdown
-# Tool Coalescing Browser-Use Test
-
-## Purpose
-Verify that consecutive tool uses in an assistant turn are grouped into a single ToolStrip showing "N tools used" instead of multiple separate "1 tool used" strips.
-
-## Prerequisites
-- browser-use CLI installed
-- Chromium installed (`browser-use install`)
-- API key: `BROWSER_USE_API_KEY` environment variable
-
-## Test Steps
-
-1. Start Freshell server: `PORT=3355 npm run dev:server`
-2. Navigate to Freshell: `browser-use open http://localhost:3355`
-3. Open a Freshclaude session with multiple tool uses
-4. Verify single tool strip with combined count using: `browser-use extract "Find all tool strip regions..."`
-5. Verify collapsed state shows one summary line, not multiple
-6. Verify expand/collapse chevron works
-
-## Expected Results
-- Single tool strip per assistant turn showing "N tools used"
-- Chevron toggles strip visibility
-- No multiple "1 tool used" strips for consecutive tools in same turn
-
-## LLM Judge Criteria
-Pass if LLM extraction returns single strip with combined count.
-Fail if multiple strips each showing "1 tool used" for tools in same turn.
-```
-
-```bash
-git add test/browser_use/tool-coalesce.md
-git commit -m "test(browser-use): add tool coalescing visual verification procedure"
+git add test/browser_use/tool_coalesce.py test/browser_use/tool_coalesce_test.py
+git commit -m "test(browser-use): add automated tool coalescing verification with LLM judge"
 ```
 
 ---
 
-## Task 6: Final Verification and Integration
+## Task 5: Final Verification and Integration
 
 **Files:**
 - None (verification only)
@@ -678,11 +802,12 @@ Expected: Clean working tree, all commits present
 - [ ] **Step 3: Summary of changes**
 
 Files changed:
-- `src/store/agentChatSlice.ts` - Coalescing in `addAssistantMessage`
+- `src/store/agentChatSlice.ts` - Coalescing in `addAssistantMessage` + helper function
 - `server/session-history-loader.ts` - Coalescing in `extractChatMessagesFromJsonl`
 - `test/unit/client/agentChatSlice.test.ts` - Unit tests for Redux coalescing
 - `test/unit/server/session-history-loader.test.ts` - Unit tests for loader coalescing
-- `test/browser_use/tool-coalesce.md` - Browser-use test procedure
+- `test/browser_use/tool_coalesce.py` - Automated browser-use test with LLM judge
+- `test/browser_use/tool_coalesce_test.py` - Unit tests for parsing logic
 
 ---
 
@@ -714,7 +839,7 @@ Files changed:
 
 If issues arise after merge:
 
-1. Revert the two implementation commits
+1. Revert the implementation commits
 2. The coalescing logic is isolated to two functions - easy to disable by removing the `if` check
 3. No database migrations or schema changes involved
 
@@ -722,7 +847,8 @@ If issues arise after merge:
 
 ## References
 
-- `server/sdk-bridge.ts:273-296` - Where SDK assistant messages are created
-- `src/lib/sdk-message-handler.ts:82-88` - Where `sdk.assistant` dispatches `addAssistantMessage`
-- `src/components/agent-chat/MessageBubble.tsx:50-126` - Tool grouping logic within single message
+- `server/sdk-bridge.ts` - Where SDK assistant messages are created
+- `src/lib/sdk-message-handler.ts` - Where `sdk.assistant` dispatches `addAssistantMessage`
+- `src/components/agent-chat/MessageBubble.tsx` - Tool grouping logic within single message
 - `test/unit/client/components/agent-chat/MessageBubble.test.tsx` - Existing grouping tests
+- `test/browser_use/smoke_freshell.py` - Pattern for browser-use tests in this repo

--- a/docs/plans/2026-03-31-tool-coalesce.md
+++ b/docs/plans/2026-03-31-tool-coalesce.md
@@ -33,7 +33,7 @@ Fix at the message creation boundary, not the rendering boundary. This is cleane
 | `server/session-history-loader.ts` | Modify | Add coalescing logic to `extractChatMessagesFromJsonl` |
 | `test/unit/client/agentChatSlice.test.ts` | Modify | Add tests for coalescing |
 | `test/unit/server/session-history-loader.test.ts` | Modify | Add tests for coalescing |
-| `test/browser-use/tool-coalesce.test.ts` | Create | Visual verification with LLM as judge |
+| `test/browser-use/tool-coalesce.md` | Create | Browser-use test procedure documentation |
 
 ---
 
@@ -513,115 +513,143 @@ git commit -m "fix: address test/typecheck/lint issues from tool coalescing"
 ## Task 5: Browser-Use Visual Verification
 
 **Files:**
-- Create: `test/browser-use/tool-coalesce.spec.ts`
+- Create: `test/browser-use/tool-coalesce.md` (test instructions, not code)
 
-- [ ] **Step 1: Create browser-use test file**
+**Prerequisites:**
+- `browser-use` CLI installed: `uvx "browser-use[cli]" --help` (or `pip install "browser-use[cli]"`)
+- Chromium installed: `browser-use install`
+- API key for LLM extraction: `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` environment variable
 
-Create `test/browser-use/tool-coalesce.spec.ts`:
-
-```typescript
-/**
- * @browser-use
- * 
- * Test: Tool Coalescing Visual Verification
- * 
- * Intent: Verify that consecutive tool uses in an assistant turn
- * are grouped into a single ToolStrip showing "N tools used"
- * instead of multiple separate "1 tool used" strips.
- * 
- * Setup:
- * 1. Start a Freshell server on a unique port (e.g., 3355)
- * 2. Open Freshell in browser
- * 3. Navigate to a Freshclaude session with multiple tool uses
- * 
- * Verification (LLM as judge):
- * 1. Look for tool strip regions in the DOM
- * 2. Verify there is exactly ONE tool strip containing all tools
- * 3. Verify the collapsed summary shows "N tools used" (not multiple "1 tool used")
- * 4. Expand the strip and verify all individual tools are present
- * 
- * Expected behavior:
- * - When showTools=false: Collapsed strip shows "N tools used" with chevron
- * - When showTools=true: Expanded strip shows all individual tools
- * - Chevron toggles strip visibility
- * - Individual tool toggles work independently
- */
-
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-
-describe('Tool Coalescing Visual Verification', () => {
-  const TEST_PORT = 3355
-  let serverPid: string | null = null
-
-  beforeAll(async () => {
-    // Start server if needed - actual implementation would use browser-use
-  })
-
-  afterAll(async () => {
-    // Stop server if started
-    if (serverPid) {
-      // Cleanup
-    }
-  })
-
-  it('shows single tool strip for multiple consecutive tools', async () => {
-    // This test is executed via browser-use CLI
-    // The implementation agent will:
-    // 1. Open browser to Freshell
-    // 2. Navigate to a Freshclaude session
-    // 3. Use LLM to verify tool strip grouping
-    // 
-    // Intent-based verification:
-    // - "Find all tool strip regions on the page"
-    // - "Count how many show 'N tools used' text"
-    // - "Verify exactly ONE strip exists with combined count"
-    expect(true).toBe(true) // Placeholder - actual browser-use execution
-  })
-
-  it('collapses multiple tools to single summary line', async () => {
-    // Intent: When multiple tools are in a turn, the collapsed view
-    // shows one summary line with total count, not multiple lines
-    expect(true).toBe(true) // Placeholder
-  })
-})
-```
-
-- [ ] **Step 2: Run browser-use verification**
-
-The executing agent will run browser-use commands:
+- [ ] **Step 1: Ensure browser-use is available**
 
 ```bash
-# Start Freshell server on test port
+# Check if browser-use is installed
+browser-use --version || uvx "browser-use[cli]" --help
+
+# Install Chromium if needed
+browser-use install
+```
+
+Expected: browser-use CLI available, Chromium installed
+
+- [ ] **Step 2: Start Freshell server on test port**
+
+```bash
 cd /home/user/code/freshell/.worktrees/tool-coalesce
 PORT=3355 npm run dev:server > /tmp/freshell-3355.log 2>&1 & echo $! > /tmp/freshell-3355.pid
-
-# Wait for server to start
 sleep 5
+curl -s http://localhost:3355/api/health > /dev/null && echo "Server ready"
+```
 
-# Open browser and navigate to Freshell
+Expected: "Server ready"
+
+- [ ] **Step 3: Navigate to Freshell and find a session with tools**
+
+```bash
 browser-use open http://localhost:3355
+browser-use state
+```
 
-# Wait for page load
-browser-use wait selector "[aria-label='Tool strip']" --timeout 10000
+Expected: Page loads, shows Freshell UI
 
-# Take screenshot for verification
+- [ ] **Step 4: Navigate to Freshclaude session**
+
+Using browser-use, find and click on a Freshclaude session in the sidebar that has tool uses. If no session exists with multiple tools, create a test scenario by sending a message that triggers multiple tool calls.
+
+```bash
+# Get page state to find Freshclaude sessions
+browser-use state
+
+# Click on a session that shows tool indicators (look for "tools" or tool count)
+# Example: browser-use click 3  # where 3 is the index of a Freshclaude session
+```
+
+- [ ] **Step 5: Verify tool strip coalescing with LLM as judge**
+
+Use browser-use's `extract` command with LLM to verify the tool strip behavior:
+
+```bash
+# Extract tool strip information using LLM
+browser-use extract "Find all tool strip regions on this page. For each strip, report: 1) The text shown (e.g., '2 tools used' or individual tool names), 2) Whether it's collapsed or expanded. Return as a JSON array."
+```
+
+Expected output: Single tool strip showing combined count like "2 tools used" or "3 tools used" - NOT multiple strips each showing "1 tool used"
+
+- [ ] **Step 6: Take screenshot for evidence**
+
+```bash
 browser-use screenshot /tmp/tool-coalesce-verify.png
+```
 
-# Verify tool strip count using LLM extraction
-browser-use extract "Count how many tool strip regions exist on this page. Each tool strip shows either 'N tools used' or individual tool names. Return only the count as a number."
+- [ ] **Step 7: Verify collapsed state shows single summary**
 
-# Expected: 1 (single strip with all tools)
+When the tool strip is collapsed, verify it shows one summary line:
 
-# Cleanup
+```bash
+browser-use extract "Count how many separate lines contain the text 'tool' or 'tools used'. Return only the number."
+```
+
+Expected: 1 (single summary line, not multiple "1 tool used" lines)
+
+- [ ] **Step 8: Verify expand/collapse toggle works**
+
+```bash
+# Find and click the chevron to expand
+browser-use state
+# Look for chevron/expand button in the state output
+# browser-use click <index>  # click the chevron
+
+# Verify tools are now visible individually
+browser-use extract "List all tool names visible on the page. Return as a comma-separated list."
+```
+
+Expected: Individual tool names visible after expansion
+
+- [ ] **Step 9: Cleanup**
+
+```bash
 browser-use close
 kill "$(cat /tmp/freshell-3355.pid)" && rm -f /tmp/freshell-3355.pid
 ```
 
-- [ ] **Step 3: Commit browser-use test**
+- [ ] **Step 10: Create test documentation file**
+
+Create `test/browser-use/tool-coalesce.md` documenting the test procedure:
+
+```markdown
+# Tool Coalescing Browser-Use Test
+
+## Purpose
+Verify that consecutive tool uses in an assistant turn are grouped into a single ToolStrip showing "N tools used" instead of multiple separate "1 tool used" strips.
+
+## Prerequisites
+- browser-use CLI installed
+- Chromium installed (`browser-use install`)
+- API key for LLM extraction (OPENAI_API_KEY or ANTHROPIC_API_KEY)
+
+## Test Steps
+
+1. Start Freshell server: `PORT=3355 npm run dev:server`
+2. Navigate to Freshell: `browser-use open http://localhost:3355`
+3. Open a Freshclaude session with multiple tool uses
+4. Verify single tool strip with combined count using: `browser-use extract "Find all tool strip regions..."`
+5. Verify collapsed state shows one summary line, not multiple
+6. Verify expand/collapse chevron works
+
+## Expected Results
+- Single tool strip per assistant turn showing "N tools used"
+- Chevron toggles strip visibility
+- No multiple "1 tool used" strips for consecutive tools in same turn
+
+## LLM Judge Criteria
+Pass if LLM extraction returns single strip with combined count.
+Fail if multiple strips each showing "1 tool used" for tools in same turn.
+```
 
 ```bash
-git add test/browser-use/tool-coalesce.spec.ts
-git commit -m "test(browser-use): add visual verification for tool coalescing"
+mkdir -p test/browser-use
+git add test/browser-use/tool-coalesce.md
+git commit -m "test(browser-use): add tool coalescing visual verification procedure"
 ```
 
 ---
@@ -655,7 +683,7 @@ Files changed:
 - `server/session-history-loader.ts` - Coalescing in `extractChatMessagesFromJsonl`
 - `test/unit/client/agentChatSlice.test.ts` - Unit tests for Redux coalescing
 - `test/unit/server/session-history-loader.test.ts` - Unit tests for loader coalescing
-- `test/browser-use/tool-coalesce.spec.ts` - Visual verification (optional)
+- `test/browser-use/tool-coalesce.md` - Browser-use test procedure
 
 ---
 

--- a/docs/plans/2026-03-31-tool-coalesce.md
+++ b/docs/plans/2026-03-31-tool-coalesce.md
@@ -513,12 +513,12 @@ git commit -m "fix: address test/typecheck/lint issues from tool coalescing"
 ## Task 5: Browser-Use Visual Verification
 
 **Files:**
-- Create: `test/browser-use/tool-coalesce.md` (test instructions, not code)
+- Create: `test/browser_use/tool-coalesce.md` (test instructions, not code)
 
 **Prerequisites:**
 - `browser-use` CLI installed: `uvx "browser-use[cli]" --help` (or `pip install "browser-use[cli]"`)
 - Chromium installed: `browser-use install`
-- API key for LLM extraction: `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` environment variable
+- API key: `BROWSER_USE_API_KEY` environment variable (for Browser Use's hosted LLM gateway)
 
 - [ ] **Step 1: Ensure browser-use is available**
 
@@ -614,7 +614,7 @@ kill "$(cat /tmp/freshell-3355.pid)" && rm -f /tmp/freshell-3355.pid
 
 - [ ] **Step 10: Create test documentation file**
 
-Create `test/browser-use/tool-coalesce.md` documenting the test procedure:
+Create `test/browser_use/tool-coalesce.md` documenting the test procedure:
 
 ```markdown
 # Tool Coalescing Browser-Use Test
@@ -625,7 +625,7 @@ Verify that consecutive tool uses in an assistant turn are grouped into a single
 ## Prerequisites
 - browser-use CLI installed
 - Chromium installed (`browser-use install`)
-- API key for LLM extraction (OPENAI_API_KEY or ANTHROPIC_API_KEY)
+- API key: `BROWSER_USE_API_KEY` environment variable
 
 ## Test Steps
 
@@ -647,8 +647,7 @@ Fail if multiple strips each showing "1 tool used" for tools in same turn.
 ```
 
 ```bash
-mkdir -p test/browser-use
-git add test/browser-use/tool-coalesce.md
+git add test/browser_use/tool-coalesce.md
 git commit -m "test(browser-use): add tool coalescing visual verification procedure"
 ```
 
@@ -683,7 +682,7 @@ Files changed:
 - `server/session-history-loader.ts` - Coalescing in `extractChatMessagesFromJsonl`
 - `test/unit/client/agentChatSlice.test.ts` - Unit tests for Redux coalescing
 - `test/unit/server/session-history-loader.test.ts` - Unit tests for loader coalescing
-- `test/browser-use/tool-coalesce.md` - Browser-use test procedure
+- `test/browser_use/tool-coalesce.md` - Browser-use test procedure
 
 ---
 

--- a/docs/plans/2026-03-31-tool-coalesce.md
+++ b/docs/plans/2026-03-31-tool-coalesce.md
@@ -1,0 +1,701 @@
+# Tool Coalescing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use trycycle-executing to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Coalesce consecutive tool-only assistant messages into a single message so that multiple tool uses appear in ONE ToolStrip showing "N tools used" instead of multiple separate "1 tool used" strips.
+
+**Architecture:** The SDK sends separate `assistant` messages (one per tool_use block). The fix intercepts at two points: (1) the Redux `addAssistantMessage` reducer for live messages, and (2) the `extractChatMessagesFromJsonl` function for restored sessions. Both locations check if the previous message is also a tool-only assistant message, and if so, append content blocks instead of creating a new message.
+
+**Tech Stack:** Redux Toolkit, TypeScript, Vitest, Testing Library, browser-use CLI
+
+---
+
+## Root Cause Analysis
+
+The Claude SDK sends multiple `assistant` messages (one per `tool_use` block). The server's `sdk-bridge.ts` (lines 273-296) creates a **new Redux message** for each SDK message via `state.messages.push(...)`. Each message becomes a separate `MessageBubble`, each with its own `ToolStrip` showing "1 tool used".
+
+The `MessageBubble` grouping logic (lines 50-126) correctly groups consecutive `tool_use` blocks **within a single message's content array**, but cannot merge across separate messages.
+
+## Strategy
+
+Fix at the message creation boundary, not the rendering boundary. This is cleaner because:
+1. **Single source of truth**: Messages in Redux state are already coalesced
+2. **Consistent behavior**: Both live sessions and restored sessions behave identically
+3. **Simpler testing**: Unit tests verify the Redux slice and loader, not UI rendering
+
+---
+
+## Files to Modify/Create
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/store/agentChatSlice.ts` | Modify | Add coalescing logic to `addAssistantMessage` |
+| `server/session-history-loader.ts` | Modify | Add coalescing logic to `extractChatMessagesFromJsonl` |
+| `test/unit/client/agentChatSlice.test.ts` | Modify | Add tests for coalescing |
+| `test/unit/server/session-history-loader.test.ts` | Modify | Add tests for coalescing |
+| `test/browser-use/tool-coalesce.test.ts` | Create | Visual verification with LLM as judge |
+
+---
+
+## Task 1: Add Helper Function to Identify Tool-Only Content
+
+**Files:**
+- Modify: `src/store/agentChatSlice.ts:1-10`
+
+- [ ] **Step 1: Identify or write the failing test**
+
+First, verify the existing tests pass (no existing check for coalescing - this is the gap):
+
+```bash
+npm run test:vitest -- test/unit/client/agentChatSlice.test.ts --run
+```
+
+Expected: All tests pass
+
+- [ ] **Step 2: Run test to verify it fails**
+
+No failing test yet - we're adding new functionality. Proceed to implementation.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add a helper function at the top of `agentChatSlice.ts` to identify if content blocks are tool-only:
+
+```typescript
+import type {
+  AgentChatState,
+  AgentTimelineItem,
+  ChatContentBlock,
+  ChatMessage,
+  ChatSessionState,
+  QuestionDefinition,
+} from './agentChatTypes'
+
+/** Check if content blocks contain only tool_use and tool_result blocks (no text or thinking). */
+function isToolOnlyContent(blocks: ChatContentBlock[]): boolean {
+  return blocks.length > 0 && blocks.every(
+    (b) => b.type === 'tool_use' || b.type === 'tool_result'
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm run test:vitest -- test/unit/client/agentChatSlice.test.ts --run
+```
+
+Expected: All tests pass
+
+- [ ] **Step 5: Refactor and verify**
+
+The helper is minimal. Run typecheck:
+
+```bash
+npx tsc --noEmit -p src/tsconfig.json
+```
+
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/store/agentChatSlice.ts
+git commit -m "feat(agent-chat): add isToolOnlyContent helper for message coalescing"
+```
+
+---
+
+## Task 2: Implement Coalescing in addAssistantMessage Reducer
+
+**Files:**
+- Modify: `src/store/agentChatSlice.ts:109-123`
+
+- [ ] **Step 1: Write the failing test**
+
+Add test to `test/unit/client/agentChatSlice.test.ts`:
+
+```typescript
+describe('tool message coalescing', () => {
+  it('coalesces consecutive tool-only assistant messages', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+    
+    // First tool-only message
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+    
+    // Second tool-only message - should coalesce
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [
+        { type: 'tool_result', tool_use_id: 't1', content: 'output' },
+        { type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } },
+      ],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+    expect(state.sessions['s1'].messages[0].content).toHaveLength(3)
+    expect(state.sessions['s1'].messages[0].content[0]).toEqual({ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } })
+    expect(state.sessions['s1'].messages[0].content[1]).toEqual({ type: 'tool_result', tool_use_id: 't1', content: 'output' })
+    expect(state.sessions['s1'].messages[0].content[2]).toEqual({ type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } })
+  })
+
+  it('does not coalesce when previous message has text content', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+    
+    // Message with text
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'text', text: 'Hello' }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+    
+    // Tool-only message - should NOT coalesce (previous has text)
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(2)
+  })
+
+  it('does not coalesce when new message has text content', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+    
+    // Tool-only message
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+    
+    // Message with text - should NOT coalesce (new has text)
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'text', text: 'Done' }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(2)
+  })
+
+  it('coalesces multiple consecutive tool-only messages', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+    
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_result', tool_use_id: 't1', content: 'file1' }],
+    }))
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } }],
+    }))
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_result', tool_use_id: 't2', content: 'content' }],
+    }))
+    
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+    expect(state.sessions['s1'].messages[0].content).toHaveLength(4)
+  })
+
+  it('does not coalesce across user messages', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+    
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    state = agentChatReducer(state, addUserMessage({ sessionId: 's1', text: 'Thanks' }))
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } }],
+    }))
+    
+    expect(state.sessions['s1'].messages).toHaveLength(3) // assistant, user, assistant
+  })
+})
+```
+
+Run to verify it fails:
+
+```bash
+npm run test:vitest -- test/unit/client/agentChatSlice.test.ts --run -t "tool message coalescing"
+```
+
+Expected: FAIL - "expected 1 to equal 2" (messages not coalescing)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+(Already confirmed above)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `addAssistantMessage` reducer in `src/store/agentChatSlice.ts`:
+
+```typescript
+addAssistantMessage(state, action: PayloadAction<{
+  sessionId: string
+  content: ChatContentBlock[]
+  model?: string
+}>) {
+  const session = state.sessions[action.payload.sessionId]
+  if (!session) return
+  
+  const newContent = action.payload.content
+  const prevMessage = session.messages[session.messages.length - 1]
+  
+  // Coalesce consecutive tool-only assistant messages
+  if (
+    prevMessage?.role === 'assistant' &&
+    isToolOnlyContent(prevMessage.content) &&
+    isToolOnlyContent(newContent)
+  ) {
+    // Append content blocks to previous message instead of creating new one
+    prevMessage.content = [...prevMessage.content, ...newContent]
+  } else {
+    session.messages.push({
+      role: 'assistant',
+      content: newContent,
+      timestamp: new Date().toISOString(),
+      model: action.payload.model,
+    })
+  }
+  session.status = 'running'
+},
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm run test:vitest -- test/unit/client/agentChatSlice.test.ts --run -t "tool message coalescing"
+```
+
+Expected: All 5 coalescing tests pass
+
+- [ ] **Step 5: Refactor and verify**
+
+Run full agentChatSlice test suite and typecheck:
+
+```bash
+npm run test:vitest -- test/unit/client/agentChatSlice.test.ts --run
+npx tsc --noEmit -p src/tsconfig.json
+```
+
+Expected: All tests pass, no type errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/store/agentChatSlice.ts test/unit/client/agentChatSlice.test.ts
+git commit -m "feat(agent-chat): coalesce consecutive tool-only assistant messages"
+```
+
+---
+
+## Task 3: Implement Coalescing in Session History Loader
+
+**Files:**
+- Modify: `server/session-history-loader.ts:30-68`
+- Modify: `test/unit/server/session-history-loader.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add test to `test/unit/server/session-history-loader.test.ts`:
+
+```typescript
+describe('tool message coalescing', () => {
+  it('coalesces consecutive tool-only assistant messages from JSONL', () => {
+    const content = [
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]},"timestamp":"2026-01-01T00:00:01Z"}',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_result","tool_use_id":"t1","content":"file1\\nfile2"}]},"timestamp":"2026-01-01T00:00:02Z"}',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"f.ts"}}]},"timestamp":"2026-01-01T00:00:03Z"}',
+    ].join('\n')
+
+    const messages = extractChatMessagesFromJsonl(content)
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].content).toHaveLength(3)
+    expect(messages[0].content[0]).toEqual({ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } })
+    expect(messages[0].content[1]).toEqual({ type: 'tool_result', tool_use_id: 't1', content: 'file1\nfile2' })
+    expect(messages[0].content[2]).toEqual({ type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } })
+  })
+
+  it('does not coalesce when assistant message has text content', () => {
+    const content = [
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello"}]},"timestamp":"2026-01-01T00:00:01Z"}',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]},"timestamp":"2026-01-01T00:00:02Z"}',
+    ].join('\n')
+
+    const messages = extractChatMessagesFromJsonl(content)
+
+    expect(messages).toHaveLength(2)
+  })
+
+  it('does not coalesce across user messages', () => {
+    const content = [
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]},"timestamp":"2026-01-01T00:00:01Z"}',
+      '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Thanks"}]},"timestamp":"2026-01-01T00:00:02Z"}',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"f.ts"}}]},"timestamp":"2026-01-01T00:00:03Z"}',
+    ].join('\n')
+
+    const messages = extractChatMessagesFromJsonl(content)
+
+    expect(messages).toHaveLength(3)
+  })
+
+  it('preserves timestamp from first message in coalesced group', () => {
+    const content = [
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]},"timestamp":"2026-01-01T00:00:01Z"}',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_result","tool_use_id":"t1","content":"output"}]},"timestamp":"2026-01-01T00:00:02Z"}',
+    ].join('\n')
+
+    const messages = extractChatMessagesFromJsonl(content)
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].timestamp).toBe('2026-01-01T00:00:01Z')
+  })
+})
+```
+
+Run to verify it fails:
+
+```bash
+npm run test:vitest -- test/unit/server/session-history-loader.test.ts --run -t "tool message coalescing"
+```
+
+Expected: FAIL - messages not coalescing
+
+- [ ] **Step 2: Run test to verify it fails**
+
+(Already confirmed above)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `extractChatMessagesFromJsonl` in `server/session-history-loader.ts`:
+
+```typescript
+export function extractChatMessagesFromJsonl(content: string): ChatMessage[] {
+  const lines = content.split(/\r?\n/).filter(Boolean)
+  const messages: ChatMessage[] = []
+
+  /** Check if content blocks contain only tool_use and tool_result blocks. */
+  const isToolOnly = (blocks: ContentBlock[]): boolean =>
+    blocks.length > 0 && blocks.every(
+      (b) => b.type === 'tool_use' || b.type === 'tool_result'
+    )
+
+  for (const line of lines) {
+    let obj: any
+    try {
+      obj = JSON.parse(line)
+    } catch {
+      continue
+    }
+
+    if (obj.type !== 'user' && obj.type !== 'assistant') continue
+
+    const role = obj.type as 'user' | 'assistant'
+    const timestamp = obj.timestamp as string | undefined
+    const msg = obj.message
+
+    let newContent: ContentBlock[]
+    let newMessage: ChatMessage
+
+    if (typeof msg === 'string') {
+      newContent = [{ type: 'text', text: msg }]
+      newMessage = {
+        role,
+        content: newContent,
+        ...(timestamp ? { timestamp } : {}),
+      }
+    } else if (msg && typeof msg === 'object' && Array.isArray(msg.content)) {
+      newContent = msg.content as ContentBlock[]
+      newMessage = {
+        role: msg.role || role,
+        content: newContent,
+        ...(timestamp ? { timestamp } : {}),
+        ...(msg.model ? { model: msg.model } : {}),
+      }
+    } else {
+      continue
+    }
+
+    // Coalesce consecutive tool-only assistant messages
+    const prevMessage = messages[messages.length - 1]
+    if (
+      prevMessage?.role === 'assistant' &&
+      newMessage.role === 'assistant' &&
+      isToolOnly(prevMessage.content) &&
+      isToolOnly(newMessage.content)
+    ) {
+      // Append content blocks to previous message
+      prevMessage.content = [...prevMessage.content, ...newMessage.content]
+    } else {
+      messages.push(newMessage)
+    }
+  }
+
+  return messages
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm run test:vitest -- test/unit/server/session-history-loader.test.ts --run -t "tool message coalescing"
+```
+
+Expected: All 4 coalescing tests pass
+
+- [ ] **Step 5: Refactor and verify**
+
+Run full test suite and typecheck:
+
+```bash
+npm run test:vitest -- test/unit/server/session-history-loader.test.ts --run
+npx tsc --noEmit -p server/tsconfig.json
+```
+
+Expected: All tests pass, no type errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/session-history-loader.ts test/unit/server/session-history-loader.test.ts
+git commit -m "feat(server): coalesce consecutive tool-only assistant messages in JSONL loader"
+```
+
+---
+
+## Task 4: Run Full Test Suite
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run full unit test suite**
+
+```bash
+npm run test:vitest -- test/unit --run
+```
+
+Expected: All tests pass
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+npm run check
+```
+
+Expected: All checks pass
+
+- [ ] **Step 3: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: No errors
+
+- [ ] **Step 4: Commit if any fixes were needed**
+
+(Only if fixes were made)
+
+```bash
+git add -A
+git commit -m "fix: address test/typecheck/lint issues from tool coalescing"
+```
+
+---
+
+## Task 5: Browser-Use Visual Verification
+
+**Files:**
+- Create: `test/browser-use/tool-coalesce.spec.ts`
+
+- [ ] **Step 1: Create browser-use test file**
+
+Create `test/browser-use/tool-coalesce.spec.ts`:
+
+```typescript
+/**
+ * @browser-use
+ * 
+ * Test: Tool Coalescing Visual Verification
+ * 
+ * Intent: Verify that consecutive tool uses in an assistant turn
+ * are grouped into a single ToolStrip showing "N tools used"
+ * instead of multiple separate "1 tool used" strips.
+ * 
+ * Setup:
+ * 1. Start a Freshell server on a unique port (e.g., 3355)
+ * 2. Open Freshell in browser
+ * 3. Navigate to a Freshclaude session with multiple tool uses
+ * 
+ * Verification (LLM as judge):
+ * 1. Look for tool strip regions in the DOM
+ * 2. Verify there is exactly ONE tool strip containing all tools
+ * 3. Verify the collapsed summary shows "N tools used" (not multiple "1 tool used")
+ * 4. Expand the strip and verify all individual tools are present
+ * 
+ * Expected behavior:
+ * - When showTools=false: Collapsed strip shows "N tools used" with chevron
+ * - When showTools=true: Expanded strip shows all individual tools
+ * - Chevron toggles strip visibility
+ * - Individual tool toggles work independently
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+
+describe('Tool Coalescing Visual Verification', () => {
+  const TEST_PORT = 3355
+  let serverPid: string | null = null
+
+  beforeAll(async () => {
+    // Start server if needed - actual implementation would use browser-use
+  })
+
+  afterAll(async () => {
+    // Stop server if started
+    if (serverPid) {
+      // Cleanup
+    }
+  })
+
+  it('shows single tool strip for multiple consecutive tools', async () => {
+    // This test is executed via browser-use CLI
+    // The implementation agent will:
+    // 1. Open browser to Freshell
+    // 2. Navigate to a Freshclaude session
+    // 3. Use LLM to verify tool strip grouping
+    // 
+    // Intent-based verification:
+    // - "Find all tool strip regions on the page"
+    // - "Count how many show 'N tools used' text"
+    // - "Verify exactly ONE strip exists with combined count"
+    expect(true).toBe(true) // Placeholder - actual browser-use execution
+  })
+
+  it('collapses multiple tools to single summary line', async () => {
+    // Intent: When multiple tools are in a turn, the collapsed view
+    // shows one summary line with total count, not multiple lines
+    expect(true).toBe(true) // Placeholder
+  })
+})
+```
+
+- [ ] **Step 2: Run browser-use verification**
+
+The executing agent will run browser-use commands:
+
+```bash
+# Start Freshell server on test port
+cd /home/user/code/freshell/.worktrees/tool-coalesce
+PORT=3355 npm run dev:server > /tmp/freshell-3355.log 2>&1 & echo $! > /tmp/freshell-3355.pid
+
+# Wait for server to start
+sleep 5
+
+# Open browser and navigate to Freshell
+browser-use open http://localhost:3355
+
+# Wait for page load
+browser-use wait selector "[aria-label='Tool strip']" --timeout 10000
+
+# Take screenshot for verification
+browser-use screenshot /tmp/tool-coalesce-verify.png
+
+# Verify tool strip count using LLM extraction
+browser-use extract "Count how many tool strip regions exist on this page. Each tool strip shows either 'N tools used' or individual tool names. Return only the count as a number."
+
+# Expected: 1 (single strip with all tools)
+
+# Cleanup
+browser-use close
+kill "$(cat /tmp/freshell-3355.pid)" && rm -f /tmp/freshell-3355.pid
+```
+
+- [ ] **Step 3: Commit browser-use test**
+
+```bash
+git add test/browser-use/tool-coalesce.spec.ts
+git commit -m "test(browser-use): add visual verification for tool coalescing"
+```
+
+---
+
+## Task 6: Final Verification and Integration
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run coordinated full test suite**
+
+```bash
+FRESHELL_TEST_SUMMARY="tool-coalesce final verification" npm test
+```
+
+Expected: All tests pass
+
+- [ ] **Step 2: Verify git status**
+
+```bash
+git status
+git log --oneline -5
+```
+
+Expected: Clean working tree, all commits present
+
+- [ ] **Step 3: Summary of changes**
+
+Files changed:
+- `src/store/agentChatSlice.ts` - Coalescing in `addAssistantMessage`
+- `server/session-history-loader.ts` - Coalescing in `extractChatMessagesFromJsonl`
+- `test/unit/client/agentChatSlice.test.ts` - Unit tests for Redux coalescing
+- `test/unit/server/session-history-loader.test.ts` - Unit tests for loader coalescing
+- `test/browser-use/tool-coalesce.spec.ts` - Visual verification (optional)
+
+---
+
+## Edge Cases and Invariants
+
+### Invariants Preserved
+
+1. **Message order is preserved** - Coalescing only appends content, never reorders
+2. **User messages break coalescing** - Tool-only assistant messages on opposite sides of a user message stay separate
+3. **Text content breaks coalescing** - Any text or thinking block prevents coalescing
+4. **Timestamp from first message** - Coalesced message keeps timestamp of first message in group
+
+### Edge Cases Handled
+
+1. **Empty content array** - `isToolOnlyContent` returns false for empty arrays (no coalescing)
+2. **Mixed content** - Text + tool_use in same message prevents coalescing with next
+3. **Session not found** - Reducer returns early without modification
+4. **Malformed JSONL** - Parser skips bad lines (existing behavior preserved)
+
+### Regression Risks
+
+1. **Timeline body hydration** - Uses same `ChatMessage` type, but `turnBodyReceived` stores separately (not affected)
+2. **Message count in UI** - Count may decrease due to coalescing (expected behavior)
+3. **Timestamp display** - First timestamp preserved (may differ from last tool's timestamp)
+
+---
+
+## Rollback Plan
+
+If issues arise after merge:
+
+1. Revert the two implementation commits
+2. The coalescing logic is isolated to two functions - easy to disable by removing the `if` check
+3. No database migrations or schema changes involved
+
+---
+
+## References
+
+- `server/sdk-bridge.ts:273-296` - Where SDK assistant messages are created
+- `src/lib/sdk-message-handler.ts:82-88` - Where `sdk.assistant` dispatches `addAssistantMessage`
+- `src/components/agent-chat/MessageBubble.tsx:50-126` - Tool grouping logic within single message
+- `test/unit/client/components/agent-chat/MessageBubble.test.tsx` - Existing grouping tests

--- a/docs/plans/2026-04-05-opencode-busy-finished-status.md
+++ b/docs/plans/2026-04-05-opencode-busy-finished-status.md
@@ -1,0 +1,563 @@
+# OpenCode Busy/Finished Status Implementation Plan
+
+> **For Claude:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Freshell reflect OpenCode terminal busy vs finished state reliably by using OpenCode's own localhost status API from spawn time through websocket delivery to the UI.
+
+**Architecture:** Each OpenCode terminal must be launched with an explicit localhost control endpoint that is threaded through `providerSettings.opencodeServer`, not through a new positional `buildSpawnSpec()` parameter. `providerSettings` already flows from async callsites into `buildSpawnSpec()` and then `resolveCodingCliCommand()`, and `resolveCodingCliCommand()` is the only seam that feeds Unix, WSL, `cmd.exe`, and PowerShell launch paths. Server-side tracking should use OpenCode's documented `/global/health`, `/session/status`, and per-instance `/event` SSE stream as the authoritative busy source. Do not parse terminal output for busy or finished state, and do not add heuristic fallbacks.
+
+**Verified upstream contract:**
+- OpenCode CLI docs show `--hostname` and `--port` on the TUI entrypoint, which is what Freshell launches for `mode === 'opencode'`: <https://opencode.ai/docs/cli/>
+- OpenCode server docs show:
+  - `GET /global/health`
+  - `GET /session/status`
+  - `GET /event`
+  - `GET /doc` for the OpenAPI spec
+  - `GET /global/event` also exists, but it is the global wrapper stream and is not needed for one Freshell terminal talking to one OpenCode instance: <https://opencode.ai/docs/server/>
+- OpenCode's generated SDK types define:
+  - `SessionStatus = { type: "idle" } | { type: "retry", ... } | { type: "busy" }`
+  - `EventSessionStatus = { type: "session.status", properties: { sessionID, status } }`
+  - `EventSessionIdle = { type: "session.idle", properties: { sessionID } }`
+  - `EventServerConnected = { type: "server.connected", ... }`
+  Source: <https://raw.githubusercontent.com/anomalyco/opencode/refs/heads/dev/packages/sdk/js/src/gen/types.gen.ts>
+
+**Implementation note:** If the launched OpenCode instance's `/doc` output disagrees with the upstream docs above, stop and update this plan plus the contract tests before proceeding.
+
+**Tech Stack:** Node.js, Express, ws, Redux Toolkit, React 18, Vitest, Testing Library, supertest, OpenCode CLI local server endpoints.
+
+---
+
+## File Structure
+
+**Create**
+- `server/local-port.ts`
+  Async helper that allocates an ephemeral localhost port for OpenCode launch callsites.
+- `server/coding-cli/opencode-activity-tracker.ts`
+  Server-side monitor that waits for health, snapshots current busy state, consumes the OpenCode SSE event stream, and emits normalized `{ upsert, remove }` changes per terminal.
+- `server/coding-cli/opencode-activity-wiring.ts`
+  Lifecycle glue between `TerminalRegistry` events and `OpencodeActivityTracker`.
+- `src/store/opencodeActivitySlice.ts`
+  Redux slice mirroring the snapshot and mutation ordering protections already used by `codexActivity`.
+- `test/unit/server/coding-cli/opencode-activity-tracker.test.ts`
+  Unit coverage for health wait, snapshot bootstrap, idle removal, reconnect backoff, and terminal teardown.
+- `test/server/ws-opencode-activity.test.ts`
+  WebSocket protocol coverage for list and update messages.
+- `test/unit/client/store/opencodeActivitySlice.test.ts`
+  Reducer coverage for stale snapshot ordering, upsert/remove mutation ordering, and reset behavior.
+
+**Modify**
+- `server/terminal-registry.ts`
+  Extend `ProviderSettings` with `opencodeServer`, require it for OpenCode launches, inject `--hostname` and `--port` inside `resolveCodingCliCommand()`, and store the endpoint on terminal records.
+- `server/ws-handler.ts`
+  Allocate OpenCode control ports before `registry.create()`, merge them into `providerSettings`, serve `opencode.activity.list`, and broadcast `opencode.activity.updated`.
+- `server/agent-api/router.ts`
+  Allocate OpenCode control ports for `/tabs`, `/run`, split, and respawn routes before terminal creation and merge them into `providerSettings`.
+- `server/index.ts`
+  Construct the OpenCode tracker wiring, expose list snapshots to websocket clients, broadcast tracker mutations, and dispose the wiring on shutdown.
+- `shared/ws-protocol.ts`
+  Add `opencode.activity.list`, `opencode.activity.list.response`, and `opencode.activity.updated` schemas/types.
+- `src/store/store.ts`
+  Register the new `opencodeActivity` reducer.
+- `src/App.tsx`
+  Bootstrap the OpenCode activity snapshot, handle websocket deltas, and reset stale overlay state on reconnect/disconnect.
+- `src/lib/pane-activity.ts`
+  Treat exact-match OpenCode busy records as blue activity and include them in busy session-key collection.
+- `src/components/panes/PaneContainer.tsx`
+  Feed OpenCode activity into per-pane activity resolution.
+- `src/components/TabBar.tsx`
+  Feed OpenCode activity into busy-tab computation.
+- `src/components/TabSwitcher.tsx`
+  Feed OpenCode activity into mobile switcher busy badges.
+- `src/components/MobileTabStrip.tsx`
+  Feed OpenCode activity into the active-tab busy badge.
+- `src/components/Sidebar.tsx`
+  Feed OpenCode activity into busy session highlighting.
+- `test/unit/server/terminal-registry.test.ts`
+  Lock the OpenCode launch flags, provider-settings threading, and explicit-endpoint requirement.
+- `test/server/agent-tabs-write.test.ts`
+  Assert `/api/tabs` allocates and passes an OpenCode control endpoint.
+- `test/server/agent-run.test.ts`
+  Assert `/api/run` still works when the launched mode is `opencode`.
+- `test/unit/client/components/App.ws-bootstrap.test.tsx`
+  Cover OpenCode snapshot request, reset-on-ready, reset-on-disconnect, and stale snapshot ordering.
+- `test/unit/client/lib/pane-activity.test.ts`
+  Cover exact-match OpenCode busy semantics and busy session-key collection.
+- `test/unit/client/components/panes/PaneContainer.test.tsx`
+  Cover per-pane OpenCode busy resolution where pane runtime activity used to be the only source.
+- `test/unit/client/components/TabBar.test.tsx`
+  Cover OpenCode blue-tab behavior.
+- `test/unit/client/components/TabSwitcher.test.tsx`
+  Cover OpenCode busy badges in the switcher.
+- `test/unit/client/components/MobileTabStrip.test.tsx`
+  Cover OpenCode busy badge on the active mobile tab.
+- `test/unit/client/components/Sidebar.test.tsx`
+  Cover busy OpenCode session highlighting.
+- `test/e2e/pane-activity-indicator-flow.test.tsx`
+  Add an OpenCode pane/tab busy-indicator flow.
+- `test/e2e/opencode-startup-probes.test.tsx`
+  Guard against OpenCode startup regressions after adding control-port launch args.
+
+**Explicit non-goals**
+- No terminal-text parsing for busy/finished state.
+- No generic multi-provider activity refactor beyond small local helpers needed to avoid repetition.
+- No `docs/index.html` update unless the visible UX changes beyond the existing busy-indicator behavior.
+
+## Architectural Guardrails
+
+- OpenCode server state is authoritative. Use:
+  - `/global/health` to know when the embedded server is reachable.
+  - `/session/status` to seed the current busy snapshot.
+  - `/event` to receive live per-instance transitions. Ignore the initial `server.connected` event.
+- Do not use `/global/event` for this feature. It wraps events with `directory` and is unnecessary when a Freshell terminal owns exactly one OpenCode instance.
+- Normalize every non-idle OpenCode session status into a single UI-facing concept: `busy`.
+- Remove activity records when OpenCode reports idle, a resnapshot after reconnect no longer shows a busy session, or the terminal exits.
+- Require an explicit OpenCode control endpoint at spawn time. If it is missing, throw a clear error instead of silently falling back.
+- Preserve Codex behavior exactly. OpenCode is additive, not a rewrite of the Codex path.
+- Use concrete retry policy:
+  - health probe: poll every `200ms`, fail startup after `15_000ms`
+  - SSE reconnect: exponential backoff starting at `250ms`, doubling to a `5_000ms` cap, with small jitter
+  - stop retrying immediately once the terminal exits or the monitor is disposed
+
+## Chunk 1: Server Launch And Activity Authority
+
+### Task 1: Require And Pass An OpenCode Control Endpoint At Spawn Time
+
+**Files:**
+- Create: `server/local-port.ts`
+- Modify: `server/terminal-registry.ts`
+- Modify: `server/ws-handler.ts`
+- Modify: `server/agent-api/router.ts`
+- Test: `test/unit/server/terminal-registry.test.ts`
+- Test: `test/server/agent-tabs-write.test.ts`
+- Test: `test/server/agent-run.test.ts`
+
+- [ ] **Step 1: Write the failing launch-contract tests**
+
+```ts
+expect(buildSpawnSpec(
+  'opencode',
+  '/repo/app',
+  'system',
+  undefined,
+  {
+    opencodeServer: { hostname: '127.0.0.1', port: 43123 },
+  },
+  undefined,
+  'term-oc',
+).args).toEqual(expect.arrayContaining([
+  '--hostname', '127.0.0.1',
+  '--port', '43123',
+]))
+
+await request(app)
+  .post('/api/tabs')
+  .send({ mode: 'opencode', name: 'OpenCode' })
+
+expect(registry.create).toHaveBeenCalledWith(expect.objectContaining({
+  mode: 'opencode',
+  providerSettings: expect.objectContaining({
+    opencodeServer: {
+      hostname: '127.0.0.1',
+      port: expect.any(Number),
+    },
+  }),
+}))
+```
+
+- [ ] **Step 2: Run the focused server tests and verify they fail**
+
+Run: `npm run test:vitest -- test/unit/server/terminal-registry.test.ts test/server/agent-tabs-write.test.ts test/server/agent-run.test.ts`
+
+Expected: FAIL because OpenCode launch args do not include `--hostname`/`--port`, and OpenCode callsites do not pass `providerSettings.opencodeServer`.
+
+- [ ] **Step 3: Implement the minimal launch-path changes**
+
+```ts
+export type OpencodeServerEndpoint = {
+  hostname: '127.0.0.1'
+  port: number
+}
+
+type ProviderSettings = {
+  permissionMode?: string
+  model?: string
+  sandbox?: string
+  opencodeServer?: OpencodeServerEndpoint
+}
+
+if (mode === 'opencode') {
+  if (!providerSettings?.opencodeServer) {
+    throw new Error('OpenCode launch requires an allocated localhost control endpoint.')
+  }
+  settingsArgs.push(
+    '--hostname', providerSettings.opencodeServer.hostname,
+    '--port', String(providerSettings.opencodeServer.port),
+  )
+}
+```
+
+Implementation notes:
+- Keep `TerminalRegistry.create()` synchronous by allocating ports in async callsites before `registry.create(...)`.
+- Do not add a new positional parameter to `buildSpawnSpec()`.
+- Inject the OpenCode launch flags inside `resolveCodingCliCommand()`, because that command spec is what flows through Unix, WSL, `cmd.exe`, and PowerShell paths today.
+- Keep the hostname pinned to the IPv4 loopback literal `'127.0.0.1'` intentionally. Do not broaden this to `localhost` or `::1` without an explicit design change, because the goal here is a private, consistent, single-stack control endpoint across all shell launch paths.
+- Route callsites should merge the endpoint into existing provider settings, not replace them:
+
+```ts
+const providerSettings = await resolveProviderSettings(mode, configStore, overrides)
+const finalProviderSettings = mode === 'opencode'
+  ? { ...providerSettings, opencodeServer: await allocateLocalhostPort() }
+  : providerSettings
+```
+
+- Update direct OpenCode test fixtures that call `registry.create({ mode: 'opencode' })` or `buildSpawnSpec('opencode', ...)` to pass a stub endpoint under `providerSettings.opencodeServer`.
+
+- [ ] **Step 4: Run the focused server tests and verify they pass**
+
+Run: `npm run test:vitest -- test/unit/server/terminal-registry.test.ts test/server/agent-tabs-write.test.ts test/server/agent-run.test.ts`
+
+Expected: PASS with OpenCode routes explicitly allocating and forwarding a control endpoint through `providerSettings`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/local-port.ts server/terminal-registry.ts server/ws-handler.ts server/agent-api/router.ts test/unit/server/terminal-registry.test.ts test/server/agent-tabs-write.test.ts test/server/agent-run.test.ts
+git commit -m "feat: launch opencode with explicit control endpoint"
+```
+
+### Task 2: Track OpenCode Busy And Finished State From Its Own Server API
+
+**Files:**
+- Create: `server/coding-cli/opencode-activity-tracker.ts`
+- Create: `server/coding-cli/opencode-activity-wiring.ts`
+- Modify: `server/index.ts`
+- Modify: `shared/ws-protocol.ts`
+- Modify: `server/ws-handler.ts`
+- Test: `test/unit/server/coding-cli/opencode-activity-tracker.test.ts`
+- Test: `test/server/ws-opencode-activity.test.ts`
+
+- [ ] **Step 1: Write the failing tracker and websocket protocol tests**
+
+```ts
+expect(changes).toContainEqual({
+  upsert: [{
+    terminalId: 'term-oc',
+    sessionId: 'session-oc',
+    phase: 'busy',
+    updatedAt: expect.any(Number),
+  }],
+  remove: [],
+})
+
+ws.send(JSON.stringify({ type: 'opencode.activity.list', requestId: 'req-oc-1' }))
+const response = await waitForMessage(ws, (msg) => (
+  msg.type === 'opencode.activity.list.response' && msg.requestId === 'req-oc-1'
+))
+expect(response.terminals).toEqual(sampleActivity)
+```
+
+Add tracker cases for:
+- health endpoint not ready yet, then becoming healthy within `15_000ms`
+- startup timeout when `/global/health` never becomes healthy
+- initial `/session/status` showing one busy session
+- ignoring the initial `server.connected` SSE event
+- `session.status` with `busy` or `retry` upserting the record
+- `session.idle` or `session.status` with `idle` removing the record
+- `session.idle` for a different `sessionID` not clearing the currently tracked session
+- SSE disconnect followed by reconnect, backoff, resnapshot, and resubscribe
+- terminal exit removing monitor state and cancelling retry timers
+
+- [ ] **Step 2: Run the focused tracker tests and verify they fail**
+
+Run: `npm run test:vitest -- test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/server/ws-opencode-activity.test.ts`
+
+Expected: FAIL because no OpenCode tracker, websocket message types, or broadcasts exist.
+
+- [ ] **Step 3: Implement the tracker, wiring, and websocket contract**
+
+```ts
+type OpencodeActivityRecord = {
+  terminalId: string
+  sessionId?: string
+  phase: 'busy'
+  updatedAt: number
+}
+
+const HEALTH_POLL_MS = 200
+const HEALTH_TIMEOUT_MS = 15_000
+const RECONNECT_BASE_MS = 250
+const RECONNECT_MAX_MS = 5_000
+
+if (event.type === 'session.status' && event.properties.status.type !== 'idle') {
+  this.upsertBusy(terminalId, event.properties.sessionID, now())
+}
+
+if (event.type === 'session.idle' || (
+  event.type === 'session.status' && event.properties.status.type === 'idle'
+)) {
+  this.removeBusy(terminalId)
+}
+```
+
+Implementation notes:
+- Use one tracker monitor per OpenCode terminal record.
+- Start monitoring from `terminal.created` when `record.mode === 'opencode'` and `record.providerSettings?.opencodeServer` or equivalent stored endpoint data exists.
+- If current terminal records do not already retain provider settings, store only the endpoint data needed for runtime monitoring.
+- Validate the OpenCode SSE payload boundary with local Zod schemas before mutating tracker state. Unknown or malformed payloads should be logged and ignored, not trusted.
+- On reconnect, re-run `/session/status` before resubscribing to `/event`.
+- Back off reconnect attempts with capped exponential backoff plus jitter. Do not spin in a tight loop if OpenCode exits or crashes.
+- Only clear a busy record on idle if the event's `sessionID` matches the currently tracked session id, unless no session id is recorded yet.
+- Add websocket types:
+  - client: `opencode.activity.list`
+  - server: `opencode.activity.list.response`
+  - server: `opencode.activity.updated`
+- Mirror the existing Codex list/broadcast path instead of inventing a second transport pattern.
+- Log clear tracker failures with terminal id and endpoint, but do not invent a fallback busy detector.
+
+- [ ] **Step 4: Run the focused tracker tests and verify they pass**
+
+Run: `npm run test:vitest -- test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/server/ws-opencode-activity.test.ts`
+
+Expected: PASS with authenticated websocket updates, bounded reconnect behavior, and tracker removal on idle/exit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/coding-cli/opencode-activity-tracker.ts server/coding-cli/opencode-activity-wiring.ts server/index.ts shared/ws-protocol.ts server/ws-handler.ts test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/server/ws-opencode-activity.test.ts
+git commit -m "feat: track opencode activity from server events"
+```
+
+## Chunk 2: Client Activity Overlay And Busy Projection
+
+### Task 3: Add A Client-Side OpenCode Activity Overlay
+
+**Files:**
+- Create: `src/store/opencodeActivitySlice.ts`
+- Modify: `src/store/store.ts`
+- Modify: `src/App.tsx`
+- Test: `test/unit/client/store/opencodeActivitySlice.test.ts`
+- Test: `test/unit/client/components/App.ws-bootstrap.test.tsx`
+
+- [ ] **Step 1: Write the failing client-store and websocket-bootstrap tests**
+
+```ts
+store.dispatch(setOpencodeActivitySnapshot({
+  terminals: [{ terminalId: 'term-oc', sessionId: 'session-oc', phase: 'busy', updatedAt: 20 }],
+  requestSeq: 3,
+}))
+expect(store.getState().opencodeActivity.byTerminalId['term-oc']?.phase).toBe('busy')
+
+expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+  type: 'opencode.activity.list',
+}))
+```
+
+Add bootstrap cases for:
+- requesting `opencode.activity.list` after `ready`
+- clearing stale OpenCode activity when bootstrapping onto an already-ready socket
+- clearing OpenCode activity on disconnect
+- ignoring stale `opencode.activity.list.response` snapshots that arrive after newer mutations
+
+- [ ] **Step 2: Run the focused client bootstrap tests and verify they fail**
+
+Run: `npm run test:vitest -- test/unit/client/store/opencodeActivitySlice.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx`
+
+Expected: FAIL because the store has no `opencodeActivity` slice and `App.tsx` does not request or process OpenCode activity messages.
+
+- [ ] **Step 3: Implement the client overlay**
+
+```ts
+const opencodeActivitySlice = createSlice({
+  name: 'opencodeActivity',
+  initialState: createInitialState(),
+  reducers: {
+    setOpencodeActivitySnapshot,
+    upsertOpencodeActivity,
+    removeOpencodeActivity,
+    resetOpencodeActivity,
+  },
+})
+
+ws.send({ type: 'opencode.activity.list', requestId })
+
+if (msg.type === 'opencode.activity.updated') {
+  dispatch(upsertOpencodeActivity({ terminals: msg.upsert ?? [], mutationSeq }))
+  dispatch(removeOpencodeActivity({ terminalIds: msg.remove ?? [], mutationSeq }))
+}
+```
+
+Implementation notes:
+- Mirror the ordering protections from `codexActivitySlice.ts` instead of sharing provider state.
+- It is acceptable to extract a small local helper inside `src/App.tsx` to avoid copy-pasting the request/reset/snapshot bookkeeping for Codex and OpenCode.
+- Reset OpenCode overlay state in the same places Codex resets today: on `ready`, on explicit disconnect, and when bootstrapping onto a pre-ready socket.
+
+- [ ] **Step 4: Run the focused client bootstrap tests and verify they pass**
+
+Run: `npm run test:vitest -- test/unit/client/store/opencodeActivitySlice.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx`
+
+Expected: PASS with deterministic snapshot ordering and prompt reset behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/opencodeActivitySlice.ts src/store/store.ts src/App.tsx test/unit/client/store/opencodeActivitySlice.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx
+git commit -m "feat: add opencode activity client overlay"
+```
+
+### Task 4: Feed OpenCode Activity Into The Existing Busy Indicators
+
+**Files:**
+- Modify: `src/lib/pane-activity.ts`
+- Modify: `src/components/panes/PaneContainer.tsx`
+- Modify: `src/components/TabBar.tsx`
+- Modify: `src/components/TabSwitcher.tsx`
+- Modify: `src/components/MobileTabStrip.tsx`
+- Modify: `src/components/Sidebar.tsx`
+- Test: `test/unit/client/lib/pane-activity.test.ts`
+- Test: `test/unit/client/components/panes/PaneContainer.test.tsx`
+- Test: `test/unit/client/components/TabBar.test.tsx`
+- Test: `test/unit/client/components/TabSwitcher.test.tsx`
+- Test: `test/unit/client/components/MobileTabStrip.test.tsx`
+- Test: `test/unit/client/components/Sidebar.test.tsx`
+- Test: `test/e2e/pane-activity-indicator-flow.test.tsx`
+- Test: `test/e2e/opencode-startup-probes.test.tsx`
+
+- [ ] **Step 1: Write the failing busy-indicator tests**
+
+```ts
+expect(resolvePaneActivity({
+  paneId: 'pane-oc',
+  content: {
+    kind: 'terminal',
+    createRequestId: 'req-oc',
+    status: 'running',
+    mode: 'opencode',
+    shell: 'system',
+    terminalId: 'term-oc',
+    resumeSessionId: 'session-oc',
+  },
+  tabMode: 'opencode',
+  isOnlyPane: true,
+  codexActivityByTerminalId: {},
+  opencodeActivityByTerminalId: {
+    'term-oc': { terminalId: 'term-oc', sessionId: 'session-oc', phase: 'busy', updatedAt: 10 },
+  },
+  paneRuntimeActivityByPaneId: {},
+  agentChatSessions: {},
+})).toMatchObject({ isBusy: true, source: 'opencode' })
+```
+
+Add UI assertions for:
+- blue pane and tab icons for a busy OpenCode pane
+- busy badge in `PaneContainer`
+- busy badge in `TabSwitcher`
+- busy badge in `MobileTabStrip`
+- blue highlight for the matching OpenCode session in `Sidebar`
+- no false positives for shell or other providers
+- no selector-instability warnings when `opencodeActivity` state is absent
+
+- [ ] **Step 2: Run the focused UI tests and verify they fail**
+
+Run: `npm run test:vitest -- test/unit/client/lib/pane-activity.test.ts test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/TabBar.test.tsx test/unit/client/components/TabSwitcher.test.tsx test/unit/client/components/MobileTabStrip.test.tsx test/unit/client/components/Sidebar.test.tsx test/e2e/pane-activity-indicator-flow.test.tsx test/e2e/opencode-startup-probes.test.tsx`
+
+Expected: FAIL because the busy-indicator pipeline only reads Codex activity today.
+
+- [ ] **Step 3: Implement the busy-projection changes**
+
+```ts
+type PaneActivitySource =
+  | 'codex'
+  | 'opencode'
+  | 'claude-terminal'
+  | 'agent-chat'
+  | 'browser'
+
+if (effectiveMode === 'opencode') {
+  const record = input.content.terminalId
+    ? input.opencodeActivityByTerminalId[input.content.terminalId]
+    : undefined
+  return record?.phase === 'busy'
+    ? { isBusy: true, source: 'opencode' }
+    : IDLE_PANE_ACTIVITY
+}
+```
+
+Implementation notes:
+- Keep OpenCode semantics exact-match by `terminalId`, just like Codex.
+- Update all three pane-activity entry points, not just `resolvePaneActivity()`:
+  - `resolvePaneActivity()`
+  - `getBusyPaneIdsForTab()`
+  - `collectBusySessionKeys()`
+- Thread `opencodeActivityByTerminalId` into every component and selector path that already threads `codexActivityByTerminalId`.
+- Use the existing blue busy styles. This is a behavior fix, not a visual redesign.
+- `TerminalView.tsx` should remain unchanged unless a test proves a launch/startup regression caused by the new server flags.
+
+- [ ] **Step 4: Run the focused UI tests and verify they pass**
+
+Run: `npm run test:vitest -- test/unit/client/lib/pane-activity.test.ts test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/TabBar.test.tsx test/unit/client/components/TabSwitcher.test.tsx test/unit/client/components/MobileTabStrip.test.tsx test/unit/client/components/Sidebar.test.tsx test/e2e/pane-activity-indicator-flow.test.tsx test/e2e/opencode-startup-probes.test.tsx`
+
+Expected: PASS with OpenCode busy panes/tabs/sessions turning blue only while the server reports work in progress.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/pane-activity.ts src/components/panes/PaneContainer.tsx src/components/TabBar.tsx src/components/TabSwitcher.tsx src/components/MobileTabStrip.tsx src/components/Sidebar.tsx test/unit/client/lib/pane-activity.test.ts test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/TabBar.test.tsx test/unit/client/components/TabSwitcher.test.tsx test/unit/client/components/MobileTabStrip.test.tsx test/unit/client/components/Sidebar.test.tsx test/e2e/pane-activity-indicator-flow.test.tsx test/e2e/opencode-startup-probes.test.tsx
+git commit -m "feat: surface opencode busy state in ui"
+```
+
+## Chunk 3: Final Verification And Handoff
+
+### Task 5: Refactor, Verify Broadly, And Record Any Residual Risk
+
+**Files:**
+- Modify only if needed after refactor/test fallout.
+- Verify: `server/*`, `src/*`, `test/*`
+
+- [ ] **Step 1: Refactor any duplicated helper logic that the passing tests exposed**
+
+```ts
+function createActivityOverlayController(...) {
+  return {
+    requestList,
+    reset,
+    applySnapshot,
+    applyMutation,
+  }
+}
+```
+
+Refactor only if it clearly reduces duplication between Codex and OpenCode without changing behavior.
+
+- [ ] **Step 2: Run lint and all focused Vitest suites together**
+
+Run: `npm run lint`
+
+Run: `npm run test:vitest -- test/unit/server/terminal-registry.test.ts test/server/agent-tabs-write.test.ts test/server/agent-run.test.ts test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/server/ws-opencode-activity.test.ts test/unit/client/store/opencodeActivitySlice.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx test/unit/client/lib/pane-activity.test.ts test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/TabBar.test.tsx test/unit/client/components/TabSwitcher.test.tsx test/unit/client/components/MobileTabStrip.test.tsx test/unit/client/components/Sidebar.test.tsx test/e2e/pane-activity-indicator-flow.test.tsx test/e2e/opencode-startup-probes.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the coordinated full suite**
+
+Run: `npm run test:status`
+
+Run: `FRESHELL_TEST_SUMMARY="opencode busy/finished status" npm test`
+
+Expected: PASS across the repo-owned coordinated suite. If the coordinator is busy, wait instead of interrupting it.
+
+- [ ] **Step 4: Inspect for any residual risk and update the implementation notes if necessary**
+
+```md
+- Residual risk: the initial `15_000ms` health timeout may need tuning on very slow hosts.
+- Residual risk: if OpenCode changes its `/event` payload contract, the tracker should fail loudly in tests before it fails silently in production.
+- Residual risk: localhost port allocation still uses the normal bind-to-0 then close pattern, so there is a small TOCTOU race before OpenCode binds the chosen port.
+- No fallback path was added; failures should surface as clear launch or tracker errors.
+```
+
+If a real residual risk remains, document it in the final implementation summary and keep the error path explicit.
+
+- [ ] **Step 5: Commit the final verified state**
+
+```bash
+git add server/local-port.ts server/coding-cli/opencode-activity-tracker.ts server/coding-cli/opencode-activity-wiring.ts server/terminal-registry.ts server/ws-handler.ts server/agent-api/router.ts server/index.ts shared/ws-protocol.ts src/store/opencodeActivitySlice.ts src/store/store.ts src/App.tsx src/lib/pane-activity.ts src/components/panes/PaneContainer.tsx src/components/TabBar.tsx src/components/TabSwitcher.tsx src/components/MobileTabStrip.tsx src/components/Sidebar.tsx test/unit/server/terminal-registry.test.ts test/server/agent-tabs-write.test.ts test/server/agent-run.test.ts test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/server/ws-opencode-activity.test.ts test/unit/client/store/opencodeActivitySlice.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx test/unit/client/lib/pane-activity.test.ts test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/TabBar.test.tsx test/unit/client/components/TabSwitcher.test.tsx test/unit/client/components/MobileTabStrip.test.tsx test/unit/client/components/Sidebar.test.tsx test/e2e/pane-activity-indicator-flow.test.tsx test/e2e/opencode-startup-probes.test.tsx
+git commit -m "feat: wire opencode busy and finished status end to end"
+```

--- a/docs/superpowers/plans/2026-04-05-session-sidebar-title-hardening.md
+++ b/docs/superpowers/plans/2026-04-05-session-sidebar-title-hardening.md
@@ -1,0 +1,855 @@
+# Session Sidebar Title Hardening Implementation Plan
+
+> **For Claude:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make inferred session titles durable, keep active or running sessions visible in the sidebar, and improve lightweight Codex title recovery so long-lived sessions do not disappear from the left pane.
+
+**Architecture:** Treat this as one indexing contract fix spanning server and client. The server becomes the durable source of inferred titles via a sticky metadata field plus monotonic index merges, the client selector merges live tab state into server rows instead of suppressing it, and the lightweight scan learns enough of the Codex JSONL shape to recover titles during cold start without waiting for full enrichment. Keep user session overrides authoritative and preserve the existing `hideEmptySessions` behavior for inactive, truly titleless sessions.
+
+**Tech Stack:** TypeScript, Node.js, Express, React 18, Redux Toolkit, Vitest, Testing Library, Supertest.
+
+---
+
+## Scope Check
+
+These three fixes are tightly coupled parts of the same failure mode:
+
+1. server-side sticky derived titles
+2. client-side sidebar visibility invariants
+3. lightweight Codex title recovery
+
+Keep them in one plan so the same regression harnesses prove the full user-visible behavior.
+
+Spec source: the current Freshell session thread about sticky derived titles, sidebar visibility for active sessions, and lightweight Codex title recovery. There is no separate spec document.
+
+## Guardrails
+
+- Execute only from a dedicated git worktree under `.worktrees/`. Do not edit `main` directly.
+- Follow Red-Green-Refactor for every code change in this plan.
+- Preserve precedence: user rename override > freshly parsed title > previous cached title > persisted derived title.
+- Do not let session metadata writes become unbounded. Only persist `derivedTitle` when the non-empty value changes.
+- `hideEmptySessions` may still hide inactive, truly empty sessions. It must not hide sessions that are open in a tab or actively running.
+- Keep `readLightweightMeta()` bounded to head/tail reads. Do not turn cold start back into a full-file parse.
+- Keep `POST /api/session-metadata` backward compatible. Updating `sessionType` must not clear stored `derivedTitle`.
+- Scope this change to file-backed providers (`claude`, `codex`, and other JSONL-backed providers). Do not widen the direct-listing provider contract in this pass.
+
+## File Structure Map
+
+- Modify: `server/session-metadata-store.ts`
+  - Purpose: persist a sticky `derivedTitle` field and merge metadata patches instead of overwriting sibling fields.
+- Modify: `test/unit/server/session-metadata-store.test.ts`
+  - Purpose: lock in merged metadata semantics and defensive-copy behavior for `derivedTitle`.
+- Modify: `test/integration/server/session-metadata-api.test.ts`
+  - Purpose: prove the existing session metadata API still updates `sessionType` without clearing stored sticky titles.
+- Modify: `server/coding-cli/session-indexer.ts`
+  - Purpose: preserve non-empty titles across reparses, hydrate lightweight rows from persisted metadata, persist newly discovered titles, and improve lightweight Codex title extraction.
+- Modify: `test/unit/server/coding-cli/session-indexer.test.ts`
+  - Purpose: capture title-preservation regressions, cold-start metadata hydration, metadata persistence, and lightweight Codex title recovery.
+- Modify: `src/store/selectors/sidebarSelectors.ts`
+  - Purpose: merge fallback live-tab data into matching server-backed rows and guarantee active/running sessions are not hidden by `hideEmptySessions`.
+- Modify: `test/unit/client/store/selectors/sidebarSelectors.test.ts`
+  - Purpose: prove a titleless indexed row is upgraded by matching tab state instead of shadowing the fallback row.
+- Modify: `test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts`
+  - Purpose: prove empty-session filtering still hides inactive empty rows but keeps open/running ones visible.
+- Modify: `test/e2e/open-tab-session-sidebar-visibility.test.tsx`
+  - Purpose: reproduce the user-visible regression through `App`, including HTTP-owned sidebar refresh and an open Codex tab whose indexed row is titleless.
+
+## Chunk 1: Persist And Preserve Derived Titles
+
+### Task 1: Extend session metadata storage for sticky inferred titles
+
+**Files:**
+- Modify: `server/session-metadata-store.ts`
+- Test: `test/unit/server/session-metadata-store.test.ts`
+- Test: `test/integration/server/session-metadata-api.test.ts`
+
+- [ ] **Step 1: Write the failing metadata-store unit tests**
+
+```ts
+it('merges derivedTitle into an existing metadata record', async () => {
+  await store.set('codex', 'sess-1', { sessionType: 'codex' })
+  await store.set('codex', 'sess-1', { derivedTitle: 'Investigate sidebar visibility' })
+
+  expect(await store.get('codex', 'sess-1')).toEqual({
+    sessionType: 'codex',
+    derivedTitle: 'Investigate sidebar visibility',
+  })
+})
+
+it('returns defensive copies that include derivedTitle', async () => {
+  await store.set('codex', 'sess-2', { derivedTitle: 'Sticky title' })
+
+  const entry = await store.get('codex', 'sess-2')
+  entry!.derivedTitle = 'mutated'
+
+  expect((await store.get('codex', 'sess-2'))?.derivedTitle).toBe('Sticky title')
+})
+```
+
+- [ ] **Step 2: Write the failing integration test for the existing metadata API**
+
+```ts
+it('preserves derivedTitle when the session metadata API updates sessionType', async () => {
+  await sessionMetadataStore.set('claude', 'sess-123', { derivedTitle: 'Sticky title' })
+
+  const res = await request(app)
+    .post('/api/session-metadata')
+    .set('x-auth-token', TEST_AUTH_TOKEN)
+    .send({ provider: 'claude', sessionId: 'sess-123', sessionType: 'agent' })
+
+  expect(res.status).toBe(200)
+  expect(await sessionMetadataStore.get('claude', 'sess-123')).toEqual({
+    sessionType: 'agent',
+    derivedTitle: 'Sticky title',
+  })
+})
+```
+
+- [ ] **Step 3: Run the new red tests**
+
+Run: `npm run test:vitest -- test/unit/server/session-metadata-store.test.ts test/integration/server/session-metadata-api.test.ts`
+
+Expected: FAIL because `SessionMetadataEntry` does not include `derivedTitle`, and `set()` currently overwrites the whole record instead of merging.
+
+- [ ] **Step 4: Implement sticky-title metadata support**
+
+```ts
+export interface SessionMetadataEntry {
+  sessionType?: string
+  derivedTitle?: string
+}
+
+sessions[provider][sessionId] = {
+  ...(sessions[provider][sessionId] ?? {}),
+  ...entry,
+}
+```
+
+Implementation notes:
+- Keep `set()` copy-safe by cloning the merged object before saving.
+- Do not special-case the API route; the store merge semantics should make it safe automatically.
+
+- [ ] **Step 5: Run the server metadata tests to verify green**
+
+Run: `npm run test:vitest -- test/unit/server/session-metadata-store.test.ts test/integration/server/session-metadata-api.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the metadata-store change**
+
+```bash
+git add server/session-metadata-store.ts test/unit/server/session-metadata-store.test.ts test/integration/server/session-metadata-api.test.ts
+git commit -m "feat: persist sticky derived session titles"
+```
+
+### Task 2: Lock in monotonic title resolution inside the session indexer
+
+**Files:**
+- Modify: `server/coding-cli/session-indexer.ts`
+- Test: `test/unit/server/coding-cli/session-indexer.test.ts`
+
+- [ ] **Step 1: Write the failing indexer regression tests**
+
+```ts
+it('keeps an existing non-empty title when the same session reparses without one', async () => {
+  const fileA = path.join(tempDir, 'session-a.jsonl')
+  await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a', title: 'Original title' }) + '\n')
+
+  const provider = makeProvider([fileA])
+  const indexer = new CodingCliSessionIndexer([provider])
+  await indexer.refresh()
+
+  await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a' }) + '\n')
+  ;(indexer as any).markDirty(fileA)
+  await indexer.refresh()
+
+  expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('Original title')
+})
+
+it('hydrates a cold-start lightweight row from metadata-store derivedTitle when parsing finds no title', async () => {
+  const files: string[] = []
+  const sessionId = 'older-codex-session'
+  const fileA = path.join(tempDir, `${sessionId}.jsonl`)
+  await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a' }) + '\n')
+  await fsp.utimes(fileA, new Date(2026, 0, 1), new Date(2026, 0, 1))
+  files.push(fileA)
+
+  for (let i = 0; i < 151; i += 1) {
+    const file = path.join(tempDir, `recent-${i}.jsonl`)
+    await fsp.writeFile(file, JSON.stringify({ cwd: `/project/${i}`, title: `Recent ${i}` }) + '\n')
+    files.push(file)
+  }
+
+  const provider = makeProvider(files, { name: 'codex' })
+  const metadataStore = mockMetadataStore({
+    [makeSessionKey('codex', sessionId)]: { derivedTitle: 'Sticky old title' },
+  })
+
+  vi.mocked(configStore.snapshot).mockResolvedValue({
+    sessionOverrides: {},
+    settings: { codingCli: { enabledProviders: ['codex'], providers: {} } },
+  })
+
+  const indexer = new CodingCliSessionIndexer([provider], {}, metadataStore)
+  await indexer.refresh()
+
+  const olderSession = indexer.getProjects()
+    .flatMap((group) => group.sessions)
+    .find((session) => session.sessionId === sessionId)
+
+  expect(olderSession?.title).toBe('Sticky old title')
+})
+
+it('persists a newly parsed non-empty title to the metadata store', async () => {
+  const fileA = path.join(tempDir, 'session-b.jsonl')
+  await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a', title: 'Fresh title' }) + '\n')
+
+  const metadataStore = mockMetadataStore({})
+  metadataStore.set = vi.fn().mockResolvedValue(undefined)
+
+  const indexer = new CodingCliSessionIndexer([makeProvider([fileA])], {}, metadataStore)
+  await indexer.refresh()
+
+  expect(metadataStore.set).toHaveBeenCalledWith('claude', 'session-b', {
+    derivedTitle: 'Fresh title',
+  })
+})
+
+it('does not rewrite derivedTitle when the parsed title matches the stored title', async () => {
+  const fileA = path.join(tempDir, 'session-c.jsonl')
+  await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a', title: 'Stable title' }) + '\n')
+
+  const metadataStore = mockMetadataStore({
+    [makeSessionKey('claude', 'session-c')]: { derivedTitle: 'Stable title' },
+  })
+  metadataStore.set = vi.fn().mockResolvedValue(undefined)
+
+  const indexer = new CodingCliSessionIndexer([makeProvider([fileA])], {}, metadataStore)
+  await indexer.refresh()
+
+  expect(metadataStore.set).not.toHaveBeenCalled()
+})
+
+it('resolves title precedence as parsed title, then previous cached title, then stored derivedTitle', async () => {
+  const fileA = path.join(tempDir, 'session-d.jsonl')
+  await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a', title: 'Parsed title' }) + '\n')
+
+  const metadataStore = mockMetadataStore({
+    [makeSessionKey('claude', 'session-d')]: { derivedTitle: 'Stored title' },
+  })
+
+  const indexer = new CodingCliSessionIndexer([makeProvider([fileA])], {}, metadataStore)
+  await indexer.refresh()
+  expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('Parsed title')
+
+  await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a' }) + '\n')
+  ;(indexer as any).markDirty(fileA)
+  await indexer.refresh()
+
+  expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('Parsed title')
+})
+```
+
+- [ ] **Step 2: Run the new red tests**
+
+Run: `npm run test:vitest -- test/unit/server/coding-cli/session-indexer.test.ts`
+
+Expected: FAIL because the indexer demotes `title` to `undefined`, does not read `derivedTitle` from metadata, and never persists parsed titles back to the metadata store.
+
+- [ ] **Step 3: Implement monotonic title resolution in the indexer**
+
+```ts
+const metaKey = makeSessionKey(provider.name, sessionId)
+const storedTitle = sessionMetadata[metaKey]?.derivedTitle?.trim()
+const parsedTitle = meta.title?.trim()
+const resolvedTitle = parsedTitle || previous?.title || storedTitle
+
+const baseSession: CodingCliSession = {
+  ...,
+  title: resolvedTitle,
+}
+
+if (this.sessionMetadataStore && parsedTitle && parsedTitle !== storedTitle) {
+  await this.sessionMetadataStore.set(provider.name, sessionId, { derivedTitle: parsedTitle })
+}
+```
+
+Implementation notes:
+- Use the same resolution order for both lightweight cache entries and full cache entries.
+- Update the local `mockMetadataStore()` helper in `test/unit/server/coding-cli/session-indexer.test.ts` so its entry shape accepts `derivedTitle` alongside `sessionType`.
+- Persist only the freshly parsed non-empty title, not the fallback title from user overrides.
+- Leave direct-listing providers alone in this change. They do not go through `readLightweightMeta()` and are not part of the regression being fixed.
+- Keep `sessionType` merge behavior unchanged.
+
+- [ ] **Step 4: Run the full indexer unit suite to verify green**
+
+Run: `npm run test:vitest -- test/unit/server/coding-cli/session-indexer.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit the indexer durability change**
+
+```bash
+git add server/coding-cli/session-indexer.ts test/unit/server/coding-cli/session-indexer.test.ts
+git commit -m "fix: preserve inferred session titles across refreshes"
+```
+
+## Chunk 2: Keep Active Sessions Visible In The Sidebar
+
+### Task 3: Add selector-level regressions for fallback merge and visibility invariants
+
+**Files:**
+- Modify: `src/store/selectors/sidebarSelectors.ts`
+- Test: `test/unit/client/store/selectors/sidebarSelectors.test.ts`
+- Test: `test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts`
+
+- [ ] **Step 1: Write the failing selector merge test**
+
+```ts
+it('merges open-tab fallback data into a matching server-backed titleless session', () => {
+  const sessionId = 'claude-current'
+  const items = buildSessionItems(
+    [makeProject([{ provider: 'claude', sessionId, title: undefined, lastActivityAt: 10 }])],
+    [{
+      id: 'tab-1',
+      title: 'Current Session',
+      mode: 'claude',
+      resumeSessionId: sessionId,
+      createdAt: 20_000,
+      sessionMetadataByKey: {
+        'claude:claude-current': {
+          sessionType: 'freshclaude',
+          firstUserMessage: 'IMPORTANT: internal trycycle task',
+          isSubagent: true,
+          isNonInteractive: true,
+        },
+      },
+    }] as any,
+    {
+      layouts: {
+        'tab-1': {
+          type: 'leaf',
+          id: 'pane-1',
+          content: {
+            kind: 'terminal',
+            mode: 'claude',
+            status: 'running',
+            createRequestId: 'req-1',
+            resumeSessionId: sessionId,
+            initialCwd: '/repo',
+          },
+        },
+      },
+      activePane: { 'tab-1': 'pane-1' },
+      paneTitles: { 'tab-1': { 'pane-1': 'Current Session' } },
+    } as any,
+    emptyTerminals,
+    emptyActivity,
+  )
+
+  expect(items).toEqual([
+    expect.objectContaining({
+      sessionId,
+      provider: 'claude',
+      title: 'Current Session',
+      hasTitle: true,
+      hasTab: true,
+      sessionType: 'freshclaude',
+      firstUserMessage: 'IMPORTANT: internal trycycle task',
+      isSubagent: true,
+      isNonInteractive: true,
+      isFallback: undefined,
+    }),
+  ])
+})
+```
+
+- [ ] **Step 2: Write the failing visibility tests**
+
+```ts
+it('keeps titleless sessions visible when they have an open tab', () => {
+  const result = filterSessionItemsByVisibility([
+    createSessionItem({ id: '1', title: 'deadbeef', hasTitle: false, hasTab: true }),
+  ], {
+    ...baseSettings,
+    showSubagents: true,
+    showNoninteractiveSessions: true,
+    hideEmptySessions: true,
+  })
+
+  expect(result.map((item) => item.id)).toEqual(['1'])
+})
+
+it('keeps titleless sessions visible when they are running', () => {
+  const result = filterSessionItemsByVisibility([
+    createSessionItem({ id: '1', title: 'deadbeef', hasTitle: false, isRunning: true }),
+  ], {
+    ...baseSettings,
+    showSubagents: true,
+    showNoninteractiveSessions: true,
+    hideEmptySessions: true,
+  })
+
+  expect(result.map((item) => item.id)).toEqual(['1'])
+})
+```
+
+- [ ] **Step 3: Run the selector tests to verify red**
+
+Run: `npm run test:vitest -- test/unit/client/store/selectors/sidebarSelectors.test.ts test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts`
+
+Expected: FAIL because `knownKeys` suppresses the fallback row entirely and `hideEmptySessions` still drops the indexed row.
+
+### Task 4: Add an App-level regression for an open Codex session with a titleless indexed row
+
+**Files:**
+- Modify: `test/e2e/open-tab-session-sidebar-visibility.test.tsx`
+
+- [ ] **Step 1: Write the failing App regression**
+
+```tsx
+it('keeps an open Codex session visible when the indexed sidebar row is titleless', async () => {
+  const sessionId = 'codex-current'
+  fetchSidebarSessionsSnapshot.mockResolvedValue({
+    projects: [
+      {
+        projectPath: '/repo',
+        sessions: [
+          {
+            provider: 'codex',
+            sessionId,
+            projectPath: '/repo',
+            lastActivityAt: 40,
+            title: undefined,
+            cwd: '/repo',
+          },
+        ],
+      },
+    ],
+    totalSessions: 1,
+    oldestIncludedTimestamp: 40,
+    oldestIncludedSessionId: `codex:${sessionId}`,
+    hasMore: false,
+  })
+
+  const store = createStore({
+    tabs: [{
+      id: 'tab-1',
+      title: 'Investigate sidebar visibility',
+      mode: 'codex',
+      resumeSessionId: sessionId,
+      createdAt: Date.now(),
+    }],
+    panes: {
+      layouts: {
+        'tab-1': {
+          type: 'leaf',
+          id: 'pane-1',
+          content: {
+            kind: 'terminal',
+            mode: 'codex',
+            createRequestId: 'req-1',
+            status: 'running',
+            resumeSessionId: sessionId,
+            initialCwd: '/repo',
+          },
+        },
+      },
+      activePane: { 'tab-1': 'pane-1' },
+      paneTitles: { 'tab-1': { 'pane-1': 'Investigate sidebar visibility' } },
+    },
+  })
+
+  render(<Provider store={store}><App /></Provider>)
+
+  await waitFor(() => {
+    expect(screen.getAllByText('Investigate sidebar visibility').length).toBeGreaterThan(0)
+  })
+
+  act(() => {
+    broadcastWs({ type: 'sessions.changed', revision: 1 })
+  })
+
+  await waitFor(() => {
+    expect(fetchSidebarSessionsSnapshot).toHaveBeenCalled()
+    expect(screen.getAllByText('Investigate sidebar visibility').length).toBeGreaterThan(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run the new e2e regression to verify red**
+
+Run: `npm run test:vitest -- test/e2e/open-tab-session-sidebar-visibility.test.tsx`
+
+Expected: FAIL because the server-backed row shadows the fallback row and the empty-session filter hides it.
+
+### Task 5: Implement sidebar row merging and the active-session visibility invariant
+
+**Files:**
+- Modify: `src/store/selectors/sidebarSelectors.ts`
+- Test: `test/unit/client/store/selectors/sidebarSelectors.test.ts`
+- Test: `test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts`
+- Test: `test/e2e/open-tab-session-sidebar-visibility.test.tsx`
+
+- [ ] **Step 1: Merge fallback row data into an existing item instead of discarding it**
+
+```ts
+const existing = itemsByKey.get(key)
+if (existing) {
+  existing.hasTab = true
+  existing.timestamp = Math.max(existing.timestamp, input.timestamp ?? 0)
+  if (!existing.hasTitle && input.title?.trim()) {
+    existing.title = input.title.trim()
+    existing.hasTitle = true
+  }
+  const fallbackSessionType = input.metadata?.sessionType || input.sessionType
+  if (fallbackSessionType && (!existing.sessionType || existing.sessionType === existing.provider)) {
+    existing.sessionType = fallbackSessionType
+  }
+  if (!existing.cwd && input.cwd) existing.cwd = input.cwd
+  if (!existing.firstUserMessage && input.metadata?.firstUserMessage) {
+    existing.firstUserMessage = input.metadata.firstUserMessage
+  }
+  if (existing.isSubagent === undefined && input.metadata?.isSubagent !== undefined) {
+    existing.isSubagent = input.metadata.isSubagent
+  }
+  if (existing.isNonInteractive === undefined && input.metadata?.isNonInteractive !== undefined) {
+    existing.isNonInteractive = input.metadata.isNonInteractive
+  }
+  return
+}
+```
+
+Implementation notes:
+- Keep one row per `provider:sessionId`.
+- Server-backed rows should remain server-backed; do not flip them to `isFallback`.
+- Prefer the existing non-empty server title if one already exists.
+- Preserve fallback metadata that affects filtering and labeling: `sessionType`, `firstUserMessage`, `isSubagent`, and `isNonInteractive`.
+
+- [ ] **Step 2: Update empty-session filtering so open/running rows survive**
+
+```ts
+if (settings.hideEmptySessions && !item.hasTitle && !item.hasTab && !item.isRunning) {
+  return false
+}
+```
+
+- [ ] **Step 3: Run the selector and e2e tests to verify green**
+
+Run: `npm run test:vitest -- test/unit/client/store/selectors/sidebarSelectors.test.ts test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts test/e2e/open-tab-session-sidebar-visibility.test.tsx`
+
+Expected: PASS
+
+- [ ] **Step 4: Commit the sidebar selector hardening**
+
+```bash
+git add src/store/selectors/sidebarSelectors.ts test/unit/client/store/selectors/sidebarSelectors.test.ts test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts test/e2e/open-tab-session-sidebar-visibility.test.tsx
+git commit -m "fix: keep active sessions visible in the sidebar"
+```
+
+## Chunk 3: Improve Lightweight Codex Title Recovery
+
+### Task 6: Add a cold-start regression for older Codex sessions outside the enrichment batch
+
+**Files:**
+- Modify: `server/coding-cli/session-indexer.ts`
+- Test: `test/unit/server/coding-cli/session-indexer.test.ts`
+
+- [ ] **Step 1: Write the failing lightweight Codex title test**
+
+```ts
+it('extracts a lightweight title from a Codex response_item user message on cold start', async () => {
+  const files: string[] = []
+  for (let i = 0; i < 151; i += 1) {
+    const file = path.join(tempDir, `recent-${i}.jsonl`)
+    await fsp.writeFile(file, [
+      JSON.stringify({ type: 'session_meta', payload: { id: `recent-${i}`, cwd: `/project/${i}` } }),
+      JSON.stringify({
+        timestamp: new Date(2026, 3, 5, 12, i).toISOString(),
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: `Recent task ${i}` }],
+        },
+      }),
+    ].join('\n'))
+    files.push(file)
+  }
+
+  const olderSessionId = 'older-codex-session'
+  const olderFile = path.join(tempDir, `${olderSessionId}.jsonl`)
+  await fsp.writeFile(olderFile, [
+    JSON.stringify({ type: 'session_meta', payload: { id: olderSessionId, cwd: '/project/older' } }),
+    JSON.stringify({
+      timestamp: new Date(2026, 0, 1).toISOString(),
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Investigate sidebar visibility' }],
+      },
+    }),
+  ].join('\n'))
+  files.push(olderFile)
+
+  vi.mocked(configStore.snapshot).mockResolvedValue({
+    sessionOverrides: {},
+    settings: { codingCli: { enabledProviders: ['codex'], providers: {} } },
+  })
+
+  const provider = makeProvider(files, {
+    name: 'codex',
+    parseSessionFile: codexProvider.parseSessionFile,
+  })
+
+  const indexer = new CodingCliSessionIndexer([provider], { fullScanIntervalMs: 0 })
+  await indexer.refresh()
+
+  const olderSession = indexer.getProjects()
+    .flatMap((group) => group.sessions)
+    .find((session) => session.sessionId === olderSessionId)
+
+  expect(olderSession?.title).toBe('Investigate sidebar visibility')
+})
+```
+
+- [ ] **Step 2: Add the failing lightweight system-context guard test**
+
+```ts
+it('does not synthesize a lightweight title from older system-context user records', async () => {
+  const files: string[] = []
+  const systemOnlyId = 'system-only'
+  const fileA = path.join(tempDir, `${systemOnlyId}.jsonl`)
+  await fsp.writeFile(fileA, JSON.stringify({
+    sessionId: systemOnlyId,
+    cwd: '/project/a',
+    role: 'user',
+    content: '<environment_context>\n  <cwd>/project/a</cwd>\n</environment_context>',
+    timestamp: new Date(2026, 0, 1).toISOString(),
+  }) + '\n')
+  await fsp.utimes(fileA, new Date(2026, 0, 1), new Date(2026, 0, 1))
+  files.push(fileA)
+
+  for (let i = 0; i < 151; i += 1) {
+    const file = path.join(tempDir, `recent-system-${i}.jsonl`)
+    await fsp.writeFile(file, [
+      JSON.stringify({ type: 'session_meta', payload: { id: `recent-system-${i}`, cwd: `/project/${i}` } }),
+      JSON.stringify({
+        timestamp: new Date(2026, 3, 5, 12, i).toISOString(),
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: `Recent task ${i}` }],
+        },
+      }),
+    ].join('\n'))
+    files.push(file)
+  }
+
+  vi.mocked(configStore.snapshot).mockResolvedValue({
+    sessionOverrides: {},
+    settings: { codingCli: { enabledProviders: ['codex'], providers: {} } },
+  })
+
+  const provider = makeProvider(files, {
+    name: 'codex',
+    parseSessionFile: codexProvider.parseSessionFile,
+  })
+
+  const indexer = new CodingCliSessionIndexer([provider], { fullScanIntervalMs: 0 })
+  await indexer.refresh()
+
+  const systemOnlySession = indexer.getProjects()
+    .flatMap((group) => group.sessions)
+    .find((session) => session.sessionId === systemOnlyId)
+
+  expect(systemOnlySession?.title).toBeUndefined()
+})
+```
+
+- [ ] **Step 3: Add the failing IDE-context lightweight title test**
+
+```ts
+it('extracts lightweight Codex titles from IDE-context messages', async () => {
+  const ideSessionId = 'ide-context-session'
+  const ideFile = path.join(tempDir, `${ideSessionId}.jsonl`)
+  await fsp.writeFile(ideFile, [
+    JSON.stringify({ type: 'session_meta', payload: { id: ideSessionId, cwd: '/project/ide' } }),
+    JSON.stringify({
+      timestamp: new Date(2026, 0, 1).toISOString(),
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{
+          type: 'input_text',
+          text: '# Context from my IDE setup:\n\n## My request for Codex:\nFix the authentication bug in the login form',
+        }],
+      },
+    }),
+  ].join('\n'))
+  await fsp.utimes(ideFile, new Date(2026, 0, 1), new Date(2026, 0, 1))
+
+  const files = [ideFile]
+  for (let i = 0; i < 151; i += 1) {
+    const file = path.join(tempDir, `recent-ide-${i}.jsonl`)
+    await fsp.writeFile(file, [
+      JSON.stringify({ type: 'session_meta', payload: { id: `recent-ide-${i}`, cwd: `/project/${i}` } }),
+      JSON.stringify({
+        timestamp: new Date(2026, 3, 5, 12, i).toISOString(),
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: `Recent task ${i}` }],
+        },
+      }),
+    ].join('\n'))
+    files.push(file)
+  }
+
+  vi.mocked(configStore.snapshot).mockResolvedValue({
+    sessionOverrides: {},
+    settings: { codingCli: { enabledProviders: ['codex'], providers: {} } },
+  })
+
+  const provider = makeProvider(files, {
+    name: 'codex',
+    parseSessionFile: codexProvider.parseSessionFile,
+  })
+
+  const indexer = new CodingCliSessionIndexer([provider], { fullScanIntervalMs: 0 })
+  await indexer.refresh()
+
+  const ideSession = indexer.getProjects()
+    .flatMap((group) => group.sessions)
+    .find((session) => session.sessionId === ideSessionId)
+
+  expect(ideSession?.title).toBe('Fix the authentication bug in the login form')
+})
+```
+
+- [ ] **Step 4: Run the targeted red tests**
+
+Run: `npm run test:vitest -- test/unit/server/coding-cli/session-indexer.test.ts`
+
+Expected: FAIL because `readLightweightMeta()` only recognizes flat `role/content` records and does not apply the same IDE-context or system-context handling as the full Codex parser.
+
+### Task 7: Teach the lightweight scan enough of the Codex message shape to recover titles safely
+
+**Files:**
+- Modify: `server/coding-cli/session-indexer.ts`
+- Test: `test/unit/server/coding-cli/session-indexer.test.ts`
+
+- [ ] **Step 1: Implement bounded lightweight title extraction for nested message payloads**
+
+```ts
+const nestedMessagePayload =
+  obj?.type === 'response_item' && obj?.payload?.type === 'message'
+    ? obj.payload
+    : undefined
+
+const rawContent =
+  nestedMessagePayload?.content ??
+  obj?.message?.content ??
+  obj?.content
+
+const isUser =
+  nestedMessagePayload?.role === 'user' ||
+  obj?.role === 'user' ||
+  obj?.type === 'user' ||
+  obj?.message?.role === 'user'
+
+const rawText = typeof rawContent === 'string'
+  ? rawContent
+  : Array.isArray(rawContent)
+    ? rawContent
+        .filter((part: any) => typeof part?.text === 'string')
+        .map((part: any) => part.text)
+        .join('\n')
+    : undefined
+
+if (isUser) {
+  const ideRequest = rawText ? extractFromIdeContext(rawText) : undefined
+  const candidate = ideRequest || (!isSystemContext(rawText ?? '') ? rawText?.replace(/<\/?image[^>]*>/g, '').trim() : '')
+  if (!title && candidate) {
+    title = extractTitleFromMessage(candidate, 200)
+  }
+}
+```
+
+Implementation notes:
+- Import the same helpers the full Codex parser uses: `extractTitleFromMessage`, `extractFromIdeContext`, and `isSystemContext`.
+- Preserve the current flat-record behavior (`obj.content`, `obj.message?.content`, `obj.role === 'user'`) while adding nested `response_item.payload` support.
+- Keep the logic inside the existing head-only scan. Do not call the full provider parser from the lightweight path.
+
+- [ ] **Step 2: Run the indexer unit suite to verify green**
+
+Run: `npm run test:vitest -- test/unit/server/coding-cli/session-indexer.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 3: Commit the lightweight Codex parsing improvement**
+
+```bash
+git add server/coding-cli/session-indexer.ts test/unit/server/coding-cli/session-indexer.test.ts
+git commit -m "fix: improve lightweight codex session titles"
+```
+
+## Chunk 4: Final Verification And Merge Readiness
+
+### Task 8: Run the focused pack, then the coordinated full suite
+
+**Files:**
+- Verify only:
+  - `server/session-metadata-store.ts`
+  - `test/unit/server/session-metadata-store.test.ts`
+  - `test/integration/server/session-metadata-api.test.ts`
+  - `server/coding-cli/session-indexer.ts`
+  - `test/unit/server/coding-cli/session-indexer.test.ts`
+  - `src/store/selectors/sidebarSelectors.ts`
+  - `test/unit/client/store/selectors/sidebarSelectors.test.ts`
+  - `test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts`
+  - `test/e2e/open-tab-session-sidebar-visibility.test.tsx`
+
+- [ ] **Step 1: Run the focused client/e2e regression pack**
+
+Run: `npm run test:vitest -- test/unit/client/store/selectors/sidebarSelectors.test.ts test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts test/e2e/open-tab-session-sidebar-visibility.test.tsx`
+
+Expected: PASS under the default JSDOM/client Vitest config.
+
+- [ ] **Step 2: Run the focused server/integration regression pack**
+
+Run: `npm run test:vitest -- --config vitest.server.config.ts test/unit/server/session-metadata-store.test.ts test/unit/server/coding-cli/session-indexer.test.ts test/integration/server/session-metadata-api.test.ts`
+
+Expected: PASS under the server/node Vitest config.
+
+- [ ] **Step 3: Check the coordinated test gate before the broad run**
+
+Run: `npm run test:status`
+
+Expected: no conflicting holder, or a clear signal to wait for the shared coordinator before starting `npm test`.
+
+- [ ] **Step 4: Run the full coordinated suite**
+
+Run: `FRESHELL_TEST_SUMMARY="session sidebar title hardening" npm test`
+
+Expected: PASS across the coordinated default and server configs.
+
+- [ ] **Step 5: Review the final diff for scope**
+
+Run: `git diff --stat "$(git merge-base main HEAD)"..HEAD`
+
+Expected: the diff covers the full branch and only includes the planned server, selector, and regression-test files. If anything extra appears, inspect it before continuing.
+
+- [ ] **Step 6: If the full suite forced any cleanup, make the minimal fix, rerun the focused packs and the coordinated suite, then create a final commit**
+
+```bash
+npm run test:vitest -- test/unit/client/store/selectors/sidebarSelectors.test.ts test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts test/e2e/open-tab-session-sidebar-visibility.test.tsx
+npm run test:vitest -- --config vitest.server.config.ts test/unit/server/session-metadata-store.test.ts test/unit/server/coding-cli/session-indexer.test.ts test/integration/server/session-metadata-api.test.ts
+FRESHELL_TEST_SUMMARY="session sidebar title hardening" npm test
+git add server/session-metadata-store.ts server/coding-cli/session-indexer.ts src/store/selectors/sidebarSelectors.ts test/unit/server/session-metadata-store.test.ts test/integration/server/session-metadata-api.test.ts test/unit/server/coding-cli/session-indexer.test.ts test/unit/client/store/selectors/sidebarSelectors.test.ts test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts test/e2e/open-tab-session-sidebar-visibility.test.tsx
+git commit -m "fix: harden session sidebar title recovery"
+```

--- a/server/agent-api/router.ts
+++ b/server/agent-api/router.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import fs from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { nanoid } from 'nanoid'
+import { allocateLocalhostPort, type OpencodeServerEndpoint } from '../local-port.js'
 import { makeSessionKey } from '../coding-cli/types.js'
 import { MAX_TERMINAL_TITLE_OVERRIDE_LENGTH } from '../terminals-router.js'
 import { ok, approx, fail } from './response.js'
@@ -29,6 +30,24 @@ async function resolveProviderSettings(
     permissionMode: overrides.permissionMode ?? defaults.permissionMode,
     model: overrides.model ?? defaults.model,
     sandbox: overrides.sandbox ?? defaults.sandbox,
+  }
+}
+
+async function resolveSpawnProviderSettings(
+  mode: string,
+  configStore: any,
+  overrides: { permissionMode?: string; model?: string; sandbox?: string },
+): Promise<{
+  permissionMode?: string
+  model?: string
+  sandbox?: string
+  opencodeServer?: OpencodeServerEndpoint
+} | undefined> {
+  const providerSettings = await resolveProviderSettings(mode, configStore, overrides)
+  if (mode !== 'opencode') return providerSettings
+  return {
+    ...(providerSettings ?? {}),
+    opencodeServer: await allocateLocalhostPort(),
   }
 }
 
@@ -224,7 +243,7 @@ export function createAgentApiRouter({
         paneContent = { kind: 'editor', filePath: editor, language: null, readOnly: false, content: '', viewMode: 'source' }
       } else {
         const effectiveMode = mode || 'shell'
-        const providerSettings = await resolveProviderSettings(effectiveMode, configStore, { permissionMode, model, sandbox })
+        const providerSettings = await resolveSpawnProviderSettings(effectiveMode, configStore, { permissionMode, model, sandbox })
         const terminal = registry.create({
           mode: effectiveMode,
           shell,
@@ -551,7 +570,7 @@ export function createAgentApiRouter({
     const created = layoutStore.createTab?.({ title })
     const tabId = created?.tabId || nanoid()
     const paneId = created?.paneId || nanoid()
-    const providerSettings = await resolveProviderSettings(mode, configStore, {})
+    const providerSettings = await resolveSpawnProviderSettings(mode, configStore, {})
     const terminal = registry.create({ mode, shell, cwd, providerSettings, envContext: { tabId, paneId } })
     layoutStore.attachPaneContent?.(tabId, paneId, { kind: 'terminal', terminalId: terminal.terminalId })
     wsHandler?.broadcastUiCommand({
@@ -613,7 +632,7 @@ export function createAgentApiRouter({
       content = { kind: 'editor', filePath: req.body.editor, language: null, readOnly: false, content: '', viewMode: 'source' }
     } else {
       const splitMode = req.body?.mode || 'shell'
-      const splitProviderSettings = await resolveProviderSettings(splitMode, configStore, {})
+      const splitProviderSettings = await resolveSpawnProviderSettings(splitMode, configStore, {})
       const terminal = registry.create({
         mode: splitMode,
         shell: req.body?.shell,
@@ -800,7 +819,7 @@ export function createAgentApiRouter({
     const tabId = target?.tabId
     if (!tabId) return res.status(404).json(fail('pane not found'))
     const effectiveMode = req.body?.mode || 'shell'
-    const providerSettings = await resolveProviderSettings(effectiveMode, configStore, {})
+    const providerSettings = await resolveSpawnProviderSettings(effectiveMode, configStore, {})
     const terminal = registry.create({ mode: effectiveMode, shell: req.body?.shell, cwd: req.body?.cwd, providerSettings, envContext: { tabId, paneId } })
     const content = { kind: 'terminal', terminalId: terminal.terminalId, status: 'running', mode: req.body?.mode || 'shell', shell: req.body?.shell || 'system', createRequestId: nanoid() }
     layoutStore.attachPaneContent(tabId, paneId, content)

--- a/server/coding-cli/opencode-activity-tracker.ts
+++ b/server/coding-cli/opencode-activity-tracker.ts
@@ -1,0 +1,488 @@
+import { EventEmitter } from 'events'
+import { z } from 'zod'
+import type { OpencodeServerEndpoint } from '../local-port.js'
+import { logger } from '../logger.js'
+
+export const OPENCODE_HEALTH_POLL_MS = 200
+// Applies per health-wait cycle; connection failures restart the cycle after backoff.
+export const OPENCODE_HEALTH_TIMEOUT_MS = 15_000
+export const OPENCODE_RECONNECT_BASE_MS = 250
+export const OPENCODE_RECONNECT_MAX_MS = 5_000
+
+export type OpencodeActivityPhase = 'busy'
+
+export type OpencodeActivityRecord = {
+  terminalId: string
+  sessionId?: string
+  phase: OpencodeActivityPhase
+  updatedAt: number
+}
+
+export type OpencodeActivityChange = {
+  upsert: OpencodeActivityRecord[]
+  remove: string[]
+}
+
+const SessionIdleStatusSchema = z.object({
+  type: z.literal('idle'),
+}).passthrough()
+
+const SessionBusyStatusSchema = z.object({
+  type: z.literal('busy'),
+}).passthrough()
+
+const SessionRetryStatusSchema = z.object({
+  type: z.literal('retry'),
+}).passthrough()
+
+const SessionStatusSchema = z.discriminatedUnion('type', [
+  SessionIdleStatusSchema,
+  SessionBusyStatusSchema,
+  SessionRetryStatusSchema,
+])
+
+const SessionStatusMapSchema = z.record(z.string(), SessionStatusSchema)
+
+const ServerConnectedEventSchema = z.object({
+  type: z.literal('server.connected'),
+}).passthrough()
+
+const SessionStatusEventSchema = z.object({
+  type: z.literal('session.status'),
+  properties: z.object({
+    sessionID: z.string().min(1),
+    status: SessionStatusSchema,
+  }).passthrough(),
+}).passthrough()
+
+const SessionIdleEventSchema = z.object({
+  type: z.literal('session.idle'),
+  properties: z.object({
+    sessionID: z.string().min(1),
+  }).passthrough(),
+}).passthrough()
+
+const OpencodeEventSchema = z.discriminatedUnion('type', [
+  ServerConnectedEventSchema,
+  SessionStatusEventSchema,
+  SessionIdleEventSchema,
+])
+
+const OpencodeEventTypeSchema = z.object({
+  type: z.string().min(1),
+}).passthrough()
+
+const KNOWN_OPENCODE_EVENT_TYPES = new Set<z.infer<typeof OpencodeEventSchema>['type']>([
+  'server.connected',
+  'session.status',
+  'session.idle',
+])
+
+type FetchLike = typeof fetch
+
+type TrackerLogger = {
+  warn: (payload: object, message?: string) => void
+}
+
+type MonitorState = {
+  terminalId: string
+  endpoint: OpencodeServerEndpoint
+  disposed: boolean
+  controller?: AbortController
+  reconnectDelayMs: number
+  reconnectTimer?: ReturnType<typeof setTimeout>
+  reconnectResolve?: () => void
+}
+
+function createAbortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
+function createAbortPromise(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal.aborted) {
+      reject(createAbortError())
+      return
+    }
+    signal.addEventListener('abort', () => reject(createAbortError()), { once: true })
+  })
+}
+
+function parseSseData(block: string): string | undefined {
+  const dataLines: string[] = []
+  for (const line of block.split('\n')) {
+    if (!line || line.startsWith(':')) continue
+    if (!line.startsWith('data:')) continue
+    dataLines.push(line.slice(5).trimStart())
+  }
+  return dataLines.length > 0 ? dataLines.join('\n') : undefined
+}
+
+function parseOpencodeEvent(data: string): z.infer<typeof OpencodeEventSchema> | undefined {
+  let parsedJson: unknown
+  try {
+    parsedJson = JSON.parse(data)
+  } catch {
+    throw new Error('OpenCode event payload was not valid JSON.')
+  }
+
+  const parsedType = OpencodeEventTypeSchema.safeParse(parsedJson)
+  if (!parsedType.success) {
+    throw new Error('OpenCode event payload did not include a string type.')
+  }
+  if (!KNOWN_OPENCODE_EVENT_TYPES.has(parsedType.data.type as z.infer<typeof OpencodeEventSchema>['type'])) {
+    return undefined
+  }
+
+  const parsedEvent = OpencodeEventSchema.safeParse(parsedJson)
+  if (!parsedEvent.success) {
+    throw new Error('OpenCode event payload did not match the expected schema.')
+  }
+
+  return parsedEvent.data
+}
+
+function extractBusySessionId(
+  snapshot: Record<string, z.infer<typeof SessionStatusSchema>>,
+  currentSessionId?: string,
+): string | undefined {
+  const busySessionIds = Object.entries(snapshot)
+    .filter(([, status]) => status.type !== 'idle')
+    .map(([sessionId]) => sessionId)
+    .sort()
+  if (busySessionIds.length === 0) return undefined
+  if (currentSessionId && busySessionIds.includes(currentSessionId)) {
+    return currentSessionId
+  }
+  return busySessionIds[0]
+}
+
+export class OpencodeActivityTracker extends EventEmitter {
+  private readonly records = new Map<string, OpencodeActivityRecord>()
+  private readonly monitors = new Map<string, MonitorState>()
+  private readonly fetchImpl: FetchLike
+  private readonly log: TrackerLogger
+  private readonly now: () => number
+  private readonly setTimeoutFn: typeof setTimeout
+  private readonly clearTimeoutFn: typeof clearTimeout
+  private readonly random: () => number
+
+  constructor(input: {
+    fetchImpl?: FetchLike
+    log?: TrackerLogger
+    now?: () => number
+    setTimeoutFn?: typeof setTimeout
+    clearTimeoutFn?: typeof clearTimeout
+    random?: () => number
+  } = {}) {
+    super()
+    this.fetchImpl = input.fetchImpl ?? fetch
+    this.log = input.log ?? logger.child({ component: 'opencode-activity-tracker' })
+    this.now = input.now ?? (() => Date.now())
+    this.setTimeoutFn = input.setTimeoutFn ?? setTimeout
+    this.clearTimeoutFn = input.clearTimeoutFn ?? clearTimeout
+    this.random = input.random ?? Math.random
+  }
+
+  list(): OpencodeActivityRecord[] {
+    return Array.from(this.records.values())
+  }
+
+  getActivity(terminalId: string): OpencodeActivityRecord | undefined {
+    return this.records.get(terminalId)
+  }
+
+  trackTerminal(input: { terminalId: string; endpoint: OpencodeServerEndpoint }): void {
+    const existing = this.monitors.get(input.terminalId)
+    if (
+      existing
+      && existing.endpoint.hostname === input.endpoint.hostname
+      && existing.endpoint.port === input.endpoint.port
+      && !existing.disposed
+    ) {
+      return
+    }
+
+    this.untrackTerminal({ terminalId: input.terminalId })
+
+    const monitor: MonitorState = {
+      terminalId: input.terminalId,
+      endpoint: input.endpoint,
+      disposed: false,
+      reconnectDelayMs: OPENCODE_RECONNECT_BASE_MS,
+    }
+    this.monitors.set(input.terminalId, monitor)
+    void this.runMonitor(monitor)
+  }
+
+  untrackTerminal(input: { terminalId: string }): void {
+    const monitor = this.monitors.get(input.terminalId)
+    if (monitor) {
+      monitor.disposed = true
+      monitor.controller?.abort()
+      if (monitor.reconnectTimer) {
+        this.clearTimeoutFn(monitor.reconnectTimer)
+        monitor.reconnectTimer = undefined
+      }
+      monitor.reconnectResolve?.()
+      monitor.reconnectResolve = undefined
+      this.monitors.delete(input.terminalId)
+    }
+    this.removeRecord(input.terminalId)
+  }
+
+  dispose(): void {
+    for (const terminalId of Array.from(this.monitors.keys())) {
+      this.untrackTerminal({ terminalId })
+    }
+  }
+
+  private async runMonitor(monitor: MonitorState): Promise<void> {
+    while (!monitor.disposed) {
+      const controller = new AbortController()
+      monitor.controller = controller
+      try {
+        await this.waitForHealth(monitor, controller.signal)
+        await this.refreshSnapshot(monitor, controller.signal)
+        monitor.reconnectDelayMs = OPENCODE_RECONNECT_BASE_MS
+        await this.consumeEvents(monitor, controller.signal)
+      } catch (error) {
+        if (monitor.disposed || isAbortError(error)) {
+          return
+        }
+        this.log.warn({
+          terminalId: monitor.terminalId,
+          endpoint: monitor.endpoint,
+          err: error,
+        }, 'OpenCode activity tracker cycle failed; retrying.')
+      } finally {
+        if (monitor.controller === controller) {
+          monitor.controller = undefined
+        }
+      }
+
+      if (monitor.disposed) return
+      await this.sleepWithBackoff(monitor)
+    }
+  }
+
+  private async waitForHealth(monitor: MonitorState, signal: AbortSignal): Promise<void> {
+    const startedAt = this.now()
+    while (true) {
+      try {
+        const response = await this.fetchImpl(this.buildUrl(monitor.endpoint, '/global/health'), {
+          signal,
+        })
+        if (response.ok) {
+          return
+        }
+      } catch (error) {
+        if (isAbortError(error)) {
+          throw error
+        }
+      }
+      if (this.now() - startedAt >= OPENCODE_HEALTH_TIMEOUT_MS) {
+        throw new Error('Timed out waiting for OpenCode health endpoint.')
+      }
+      await this.sleep(signal, OPENCODE_HEALTH_POLL_MS)
+    }
+  }
+
+  private async refreshSnapshot(monitor: MonitorState, signal: AbortSignal): Promise<void> {
+    const response = await this.fetchImpl(this.buildUrl(monitor.endpoint, '/session/status'), {
+      signal,
+    })
+    if (!response.ok) {
+      throw new Error(`OpenCode session status request failed with ${response.status}.`)
+    }
+
+    const parsed = SessionStatusMapSchema.safeParse(await response.json())
+    if (!parsed.success) {
+      throw new Error('OpenCode session status response did not match the expected schema.')
+    }
+
+    const current = this.records.get(monitor.terminalId)
+    const busySessionId = extractBusySessionId(parsed.data, current?.sessionId)
+    if (!busySessionId) {
+      this.removeRecord(monitor.terminalId)
+      return
+    }
+
+    this.upsertRecord({
+      terminalId: monitor.terminalId,
+      sessionId: busySessionId,
+      phase: 'busy',
+      updatedAt: this.now(),
+    })
+  }
+
+  private async consumeEvents(monitor: MonitorState, signal: AbortSignal): Promise<void> {
+    const response = await this.fetchImpl(this.buildUrl(monitor.endpoint, '/event'), {
+      signal,
+      headers: { accept: 'text/event-stream' },
+    })
+    if (!response.ok || !response.body) {
+      throw new Error(`OpenCode event stream request failed with ${response.status}.`)
+    }
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    const abortPromise = createAbortPromise(signal)
+    let buffer = ''
+
+    try {
+      while (true) {
+        const result = await Promise.race([
+          reader.read(),
+          abortPromise,
+        ])
+
+        if (result.done) {
+          return
+        }
+
+        buffer += decoder.decode(result.value, { stream: true })
+          .replace(/\r\n/g, '\n')
+          .replace(/\r/g, '\n')
+
+        let separatorIndex = buffer.indexOf('\n\n')
+        while (separatorIndex >= 0) {
+          const block = buffer.slice(0, separatorIndex)
+          buffer = buffer.slice(separatorIndex + 2)
+          this.handleSseBlock(monitor.terminalId, block)
+          separatorIndex = buffer.indexOf('\n\n')
+        }
+      }
+    } finally {
+      try {
+        await reader.cancel()
+      } catch {
+        // ignore cancellation errors during teardown
+      }
+    }
+  }
+
+  private handleSseBlock(terminalId: string, block: string): void {
+    const data = parseSseData(block)
+    if (!data) return
+
+    let event: z.infer<typeof OpencodeEventSchema> | undefined
+    try {
+      event = parseOpencodeEvent(data)
+    } catch (error) {
+      const endpoint = this.monitors.get(terminalId)?.endpoint
+      this.log.warn({
+        terminalId,
+        endpoint,
+        err: error,
+      }, 'OpenCode event payload was invalid; skipping payload.')
+      return
+    }
+
+    if (!event) return
+    if (event.type === 'server.connected') return
+    if (event.type === 'session.idle') {
+      this.removeRecordForSession(terminalId, event.properties.sessionID)
+      return
+    }
+    if (event.properties.status.type === 'idle') {
+      this.removeRecordForSession(terminalId, event.properties.sessionID)
+      return
+    }
+
+    this.upsertRecord({
+      terminalId,
+      sessionId: event.properties.sessionID,
+      phase: 'busy',
+      updatedAt: this.now(),
+    })
+  }
+
+  private async sleepWithBackoff(monitor: MonitorState): Promise<void> {
+    const baseDelay = monitor.reconnectDelayMs
+    const jitter = Math.floor(baseDelay * 0.1 * this.random())
+    const delayMs = Math.min(OPENCODE_RECONNECT_MAX_MS, baseDelay + jitter)
+    monitor.reconnectDelayMs = Math.min(OPENCODE_RECONNECT_MAX_MS, baseDelay * 2)
+    await new Promise<void>((resolve) => {
+      monitor.reconnectResolve = resolve
+      monitor.reconnectTimer = this.setTimeoutFn(() => {
+        monitor.reconnectTimer = undefined
+        monitor.reconnectResolve = undefined
+        resolve()
+      }, delayMs)
+    })
+  }
+
+  private async sleep(signal: AbortSignal, delayMs: number): Promise<void> {
+    if (signal.aborted) {
+      throw createAbortError()
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const onAbort = () => {
+      if (timer) {
+        this.clearTimeoutFn(timer)
+      }
+    }
+
+    try {
+      await Promise.race([
+        new Promise<void>((resolve) => {
+          timer = this.setTimeoutFn(() => {
+            timer = undefined
+            resolve()
+          }, delayMs)
+          signal.addEventListener('abort', onAbort, { once: true })
+        }),
+        createAbortPromise(signal),
+      ])
+    } finally {
+      signal.removeEventListener('abort', onAbort)
+      if (timer) {
+        this.clearTimeoutFn(timer)
+      }
+    }
+  }
+
+  private buildUrl(endpoint: OpencodeServerEndpoint, pathname: string): string {
+    return `http://${endpoint.hostname}:${endpoint.port}${pathname}`
+  }
+
+  private removeRecordForSession(terminalId: string, sessionId: string): void {
+    const existing = this.records.get(terminalId)
+    if (!existing) return
+    if (existing.sessionId && existing.sessionId !== sessionId) return
+    this.removeRecord(terminalId)
+  }
+
+  private upsertRecord(record: OpencodeActivityRecord): void {
+    const previous = this.records.get(record.terminalId)
+    if (
+      previous
+      && previous.sessionId === record.sessionId
+      && previous.phase === record.phase
+      && previous.updatedAt === record.updatedAt
+    ) {
+      return
+    }
+    this.records.set(record.terminalId, record)
+    this.emit('changed', {
+      upsert: [record],
+      remove: [],
+    } satisfies OpencodeActivityChange)
+  }
+
+  private removeRecord(terminalId: string): void {
+    if (!this.records.delete(terminalId)) return
+    this.emit('changed', {
+      upsert: [],
+      remove: [terminalId],
+    } satisfies OpencodeActivityChange)
+  }
+}

--- a/server/coding-cli/opencode-activity-wiring.ts
+++ b/server/coding-cli/opencode-activity-wiring.ts
@@ -1,0 +1,67 @@
+import { OpencodeActivityTracker } from './opencode-activity-tracker.js'
+import type { OpencodeServerEndpoint } from '../local-port.js'
+import type { TerminalRecord } from '../terminal-registry.js'
+
+type OpencodeActivityRegistry = {
+  list: () => Array<{ terminalId: string }>
+  get: (terminalId: string) => TerminalRecord | undefined
+  on: (event: string, handler: (...args: any[]) => void) => void
+  off: (event: string, handler: (...args: any[]) => void) => void
+}
+
+function getEndpoint(record: TerminalRecord): OpencodeServerEndpoint | undefined {
+  return record.mode === 'opencode' ? record.opencodeServer : undefined
+}
+
+export function wireOpencodeActivityTracker(input: {
+  registry: OpencodeActivityRegistry
+  fetchImpl?: typeof fetch
+  now?: () => number
+  setTimeoutFn?: typeof setTimeout
+  clearTimeoutFn?: typeof clearTimeout
+  random?: () => number
+}) {
+  const tracker = new OpencodeActivityTracker({
+    fetchImpl: input.fetchImpl,
+    now: input.now,
+    setTimeoutFn: input.setTimeoutFn,
+    clearTimeoutFn: input.clearTimeoutFn,
+    random: input.random,
+  })
+
+  const startTracking = (record: TerminalRecord) => {
+    const endpoint = getEndpoint(record)
+    if (!endpoint || record.status !== 'running') return
+    tracker.trackTerminal({
+      terminalId: record.terminalId,
+      endpoint,
+    })
+  }
+
+  const onCreated = (record: TerminalRecord) => {
+    startTracking(record)
+  }
+
+  const onExit = (event: { terminalId?: string }) => {
+    if (!event.terminalId) return
+    tracker.untrackTerminal({ terminalId: event.terminalId })
+  }
+
+  input.registry.on('terminal.created', onCreated)
+  input.registry.on('terminal.exit', onExit)
+
+  for (const listed of input.registry.list()) {
+    const record = input.registry.get(listed.terminalId)
+    if (!record) continue
+    startTracking(record)
+  }
+
+  return {
+    tracker,
+    dispose(): void {
+      input.registry.off('terminal.created', onCreated)
+      input.registry.off('terminal.exit', onExit)
+      tracker.dispose()
+    },
+  }
+}

--- a/server/coding-cli/session-indexer.ts
+++ b/server/coding-cli/session-indexer.ts
@@ -47,6 +47,19 @@ function maxDefined(a: number | undefined, b: number | undefined): number | unde
   return Math.max(a, b)
 }
 
+function normalizeTitle(title: string | undefined): string | undefined {
+  const trimmed = title?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function resolveSessionTitle(
+  parsedTitle: string | undefined,
+  previousTitle: string | undefined,
+  storedTitle: string | undefined,
+): string | undefined {
+  return normalizeTitle(parsedTitle) || normalizeTitle(previousTitle) || normalizeTitle(storedTitle)
+}
+
 // Byte pattern for a text user message (content is a string, not a tool_result array).
 const USER_TEXT_PATTERN = Buffer.from('"role":"user","content":"')
 
@@ -718,7 +731,12 @@ export class CodingCliSessionIndexer {
     }
   }
 
-  private async updateCacheEntry(provider: CodingCliProvider, filePath: string, cacheKey: string) {
+  private async updateCacheEntry(
+    provider: CodingCliProvider,
+    filePath: string,
+    cacheKey: string,
+    sessionMetadata: Record<string, SessionMetadataEntry>,
+  ) {
     let stat: Stats
     try {
       stat = await fsp.stat(filePath)
@@ -772,6 +790,10 @@ export class CodingCliSessionIndexer {
     const sessionId = meta.sessionId || provider.extractSessionId(filePath, meta)
     const previous = cached?.lightweight ? undefined : cached?.baseSession
     const sameSession = previous?.provider === provider.name && previous?.sessionId === sessionId
+    const metaKey = makeSessionKey(provider.name, sessionId)
+    const storedTitle = normalizeTitle(sessionMetadata[metaKey]?.derivedTitle)
+    const parsedTitle = normalizeTitle(meta.title)
+    const resolvedTitle = resolveSessionTitle(parsedTitle, sameSession ? previous?.title : undefined, storedTitle)
     const appendOnlyReparse = sameSession && size >= (cached?.size ?? 0)
     const createdAt = appendOnlyReparse
       ? minDefined(previous?.createdAt, meta.createdAt)
@@ -793,7 +815,7 @@ export class CodingCliSessionIndexer {
       lastActivityAt,
       createdAt,
       messageCount: meta.messageCount,
-      title: meta.title,
+      title: resolvedTitle,
       summary: meta.summary,
       ...(meta.firstUserMessage ? { firstUserMessage: meta.firstUserMessage } : {}),
       cwd: meta.cwd,
@@ -804,6 +826,10 @@ export class CodingCliSessionIndexer {
       isSubagent: meta.isSubagent || isSubagentSession(filePath) || undefined,
       isNonInteractive: meta.isNonInteractive || undefined,
       codexTaskEvents: meta.codexTaskEvents,
+    }
+
+    if (this.sessionMetadataStore && parsedTitle && parsedTitle !== storedTitle) {
+      await this.sessionMetadataStore.set(provider.name, sessionId, { derivedTitle: parsedTitle })
     }
 
     this.fileCache.set(cacheKey, {
@@ -1035,6 +1061,9 @@ export class CodingCliSessionIndexer {
       if (existing && existing.baseSession) continue
 
       const sessionId = meta.sessionId || provider.extractSessionId(meta.filePath)
+      const metaKey = makeSessionKey(provider.name, sessionId)
+      const storedTitle = normalizeTitle(sessionMetadata[metaKey]?.derivedTitle)
+      const resolvedTitle = resolveSessionTitle(meta.title, existing?.baseSession?.title, storedTitle)
       const projectPath = meta.cwd ? await resolveGitRepoRoot(meta.cwd) : meta.cwd
       const baseSession: CodingCliSession = {
         provider: provider.name,
@@ -1042,7 +1071,7 @@ export class CodingCliSessionIndexer {
         projectPath,
         lastActivityAt: meta.lastActivityAt || meta.mtimeMs,
         createdAt: meta.createdAt,
-        title: meta.title,
+        title: resolvedTitle,
         cwd: meta.cwd,
         sourceFile: meta.filePath,
         isSubagent: isSubagentSession(meta.filePath) || undefined,
@@ -1081,6 +1110,7 @@ export class CodingCliSessionIndexer {
     filesByProvider: Map<CodingCliProvider, string[]>,
     enabledSet: Set<string>,
     seenCacheKeys: Set<string>,
+    sessionMetadata: Record<string, SessionMetadataEntry>,
   ): Promise<void> {
     // Collect all file-based entries for enrichment. Files the lightweight scan couldn't
     // parse (e.g. Codex with 14KB first lines) use file mtime as the recency estimate.
@@ -1128,7 +1158,7 @@ export class CodingCliSessionIndexer {
       if (INDEXER_DELAY_MS > 0) {
         await new Promise((r) => setTimeout(r, INDEXER_DELAY_MS))
       }
-      await this.updateCacheEntry(provider, filePath, cacheKey)
+      await this.updateCacheEntry(provider, filePath, cacheKey, sessionMetadata)
       enriched += 1
       if (enriched % REFRESH_YIELD_EVERY === 0) {
         await yieldToEventLoop()
@@ -1202,13 +1232,13 @@ export class CodingCliSessionIndexer {
         })
         fileCount += files.length
 
-        if (isColdStart) {
-          // Selective enrichment: only the most recent non-subagent sessions.
-          await this.enrichRecentSessions(
-            new Map([[provider, files]]), enabledSet, seenCacheKeys,
-          )
-          for (const f of files) seenCacheKeys.add(normalizeFilePath(f))
-        } else {
+      if (isColdStart) {
+        // Selective enrichment: only the most recent non-subagent sessions.
+        await this.enrichRecentSessions(
+          new Map([[provider, files]]), enabledSet, seenCacheKeys, sessionMetadata,
+        )
+        for (const f of files) seenCacheKeys.add(normalizeFilePath(f))
+      } else {
           // Warm rescan: process all files (cache hits skip unchanged files).
           for (const file of files) {
             processedEntries += 1
@@ -1217,7 +1247,7 @@ export class CodingCliSessionIndexer {
             }
             const cacheKey = normalizeFilePath(file)
             seenCacheKeys.add(cacheKey)
-            await this.updateCacheEntry(provider, file, cacheKey)
+            await this.updateCacheEntry(provider, file, cacheKey, sessionMetadata)
           }
         }
       }
@@ -1274,7 +1304,7 @@ export class CodingCliSessionIndexer {
           this.deleteCacheEntry(file)
           continue
         }
-        await this.updateCacheEntry(provider, file, file)
+        await this.updateCacheEntry(provider, file, file, sessionMetadata)
       }
     }
 

--- a/server/coding-cli/session-indexer.ts
+++ b/server/coding-cli/session-indexer.ts
@@ -6,10 +6,11 @@ import chokidar from 'chokidar'
 import { logger } from '../logger.js'
 import { getPerfConfig, startPerfTimer } from '../perf-logger.js'
 import { configStore, SessionOverride } from '../config-store.js'
+import { extractTitleFromMessage } from '../title-utils.js'
 import type { CodingCliProvider } from './provider.js'
 import { makeSessionKey, type CodingCliSession, type CodingCliProviderName, type ProjectGroup } from './types.js'
 import { sanitizeCodexTaskEventsForTruncatedSnippet } from './providers/codex.js'
-import { resolveGitCheckoutRoot, resolveGitRepoRoot } from './utils.js'
+import { extractFromIdeContext, isSystemContext, resolveGitCheckoutRoot, resolveGitRepoRoot } from './utils.js'
 import { diffProjects } from '../sessions-sync/diff.js'
 import type { SessionMetadataStore, SessionMetadataEntry } from '../session-metadata-store.js'
 
@@ -260,15 +261,35 @@ async function readLightweightMeta(filePath: string): Promise<LightweightFileMet
           if (Number.isFinite(parsed)) createdAt = parsed
         }
         if (!title) {
-          const isUser = obj?.role === 'user' || obj?.type === 'user' || obj?.message?.role === 'user'
+          const nestedMessagePayload =
+            obj?.type === 'response_item' && obj?.payload?.type === 'message'
+              ? obj.payload
+              : undefined
+          const rawContent =
+            nestedMessagePayload?.content ??
+            obj?.message?.content ??
+            obj?.content
+          const isUser =
+            nestedMessagePayload?.role === 'user' ||
+            obj?.role === 'user' ||
+            obj?.type === 'user' ||
+            obj?.message?.role === 'user'
           if (isUser) {
-            const content = obj?.message?.content || obj?.content
-            const text = typeof content === 'string'
-              ? content
-              : Array.isArray(content)
-                ? content.filter((b: any) => typeof b?.text === 'string').map((b: any) => b.text).join(' ')
+            const rawText = typeof rawContent === 'string'
+              ? rawContent
+              : Array.isArray(rawContent)
+                ? rawContent
+                    .filter((part: any) => typeof part?.text === 'string')
+                    .map((part: any) => part.text)
+                    .join('\n')
                 : undefined
-            if (typeof text === 'string' && text.trim()) title = text.trim().slice(0, 200)
+
+            const ideRequest = rawText ? extractFromIdeContext(rawText) : undefined
+            const candidate = ideRequest
+              || (!isSystemContext(rawText ?? '') ? rawText?.replace(/<\/?image[^>]*>/g, '').trim() : '')
+            if (candidate) {
+              title = extractTitleFromMessage(candidate, 200)
+            }
           }
         }
         if (sessionId && cwd && title && createdAt) break

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,6 +20,7 @@ import { SessionsSyncService } from './sessions-sync/service.js'
 import { CodingCliSessionIndexer } from './coding-cli/session-indexer.js'
 import { CodingCliSessionManager } from './coding-cli/session-manager.js'
 import { wireCodexActivityTracker } from './coding-cli/codex-activity-wiring.js'
+import { wireOpencodeActivityTracker } from './coding-cli/opencode-activity-wiring.js'
 import { claudeProvider } from './coding-cli/providers/claude.js'
 import { codexProvider } from './coding-cli/providers/codex.js'
 import { opencodeProvider } from './coding-cli/providers/opencode.js'
@@ -185,6 +186,7 @@ async function main() {
   const terminalMetadata = new TerminalMetadataService()
   const layoutStore = new LayoutStore()
   const codexActivity = wireCodexActivityTracker({ registry, codingCliIndexer })
+  const opencodeActivity = wireOpencodeActivityTracker({ registry })
 
   const sessionRepairService = getSessionRepairService({ skipDiscovery: true })
   const serverInstanceId = await loadOrCreateServerInstanceId()
@@ -287,29 +289,32 @@ async function main() {
   const wsHandler = new WsHandler(
     server,
     registry,
-    codingCliSessionManager,
-    sdkBridge,
-    sessionRepairService,
-    async () => {
-      const currentSettings = migrateSettingsSortMode(await configStore.getSettings())
-      const readError = configStore.getLastReadError()
-      const configFallback = readError
-        ? { reason: readError, backupExists: await configStore.backupExists() }
-        : undefined
-      return {
-        settings: currentSettings,
-        projects: codingCliIndexer.getProjects(),
-        perfLogging: perfConfig.enabled,
-        configFallback,
-      }
+    {
+      codingCliManager: codingCliSessionManager,
+      sdkBridge,
+      sessionRepairService,
+      handshakeSnapshotProvider: async () => {
+        const currentSettings = migrateSettingsSortMode(await configStore.getSettings())
+        const readError = configStore.getLastReadError()
+        const configFallback = readError
+          ? { reason: readError, backupExists: await configStore.backupExists() }
+          : undefined
+        return {
+          settings: currentSettings,
+          projects: codingCliIndexer.getProjects(),
+          perfLogging: perfConfig.enabled,
+          configFallback,
+        }
+      },
+      terminalMetaListProvider: () => terminalMetadata.list(),
+      tabsRegistryStore,
+      serverInstanceId,
+      layoutStore,
+      extensionManager,
+      codexActivityListProvider: () => codexActivity.tracker.list(),
+      agentHistorySource,
+      opencodeActivityListProvider: () => opencodeActivity.tracker.list(),
     },
-    () => terminalMetadata.list(),
-    tabsRegistryStore,
-    serverInstanceId,
-    layoutStore,
-    extensionManager,
-    () => codexActivity.tracker.list(),
-    agentHistorySource,
   )
   attachProxyUpgradeHandler(server)
   const port = Number(process.env.PORT || 3001)
@@ -347,6 +352,9 @@ async function main() {
 
   codexActivity.tracker.on('changed', (payload) => {
     wsHandler.broadcastCodexActivityUpdated(payload)
+  })
+  opencodeActivity.tracker.on('changed', (payload) => {
+    wsHandler.broadcastOpencodeActivityUpdated(payload)
   })
 
   const broadcastTerminalMetaUpserts = (upsert: ReturnType<TerminalMetadataService['list']>) => {
@@ -783,6 +791,7 @@ async function main() {
 
     // 8b. Stop Codex activity tracker listeners and sweep timer
     codexActivity.dispose()
+    opencodeActivity.dispose()
 
     // 9. Stop session repair service
     await sessionRepairService.stop()

--- a/server/local-port.ts
+++ b/server/local-port.ts
@@ -1,0 +1,39 @@
+import net from 'node:net'
+
+export type OpencodeServerEndpoint = {
+  hostname: '127.0.0.1'
+  port: number
+}
+
+// This is a best-effort ephemeral port reservation. There is an unavoidable race
+// between closing this probe socket and the child process binding the same port,
+// so callers must still be prepared to retry startup if OpenCode loses the bind.
+export async function allocateLocalhostPort(): Promise<OpencodeServerEndpoint> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+
+    const onError = (error: Error) => {
+      server.close(() => reject(error))
+    }
+
+    server.once('error', onError)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Failed to allocate a localhost control port for OpenCode.')))
+        return
+      }
+
+      server.close((closeError) => {
+        if (closeError) {
+          reject(closeError)
+          return
+        }
+        resolve({
+          hostname: '127.0.0.1',
+          port: address.port,
+        })
+      })
+    })
+  })
+}

--- a/server/session-history-loader.ts
+++ b/server/session-history-loader.ts
@@ -31,6 +31,12 @@ export function extractChatMessagesFromJsonl(content: string): ChatMessage[] {
   const lines = content.split(/\r?\n/).filter(Boolean)
   const messages: ChatMessage[] = []
 
+  /** Check if content blocks contain only tool_use and tool_result blocks. */
+  const isToolOnly = (blocks: ContentBlock[]): boolean =>
+    blocks.length > 0 && blocks.every(
+      (b) => b.type === 'tool_use' || b.type === 'tool_result'
+    )
+
   for (const line of lines) {
     let obj: any
     try {
@@ -46,21 +52,42 @@ export function extractChatMessagesFromJsonl(content: string): ChatMessage[] {
     const timestamp = obj.timestamp as string | undefined
     const msg = obj.message
 
+    let newContent: ContentBlock[]
+    let newMessage: ChatMessage
+
     if (typeof msg === 'string') {
       // Simple/legacy format: message is a plain string
-      messages.push({
+      newContent = [{ type: 'text', text: msg }]
+      newMessage = {
         role,
-        content: [{ type: 'text', text: msg }],
+        content: newContent,
         ...(timestamp ? { timestamp } : {}),
-      })
+      }
     } else if (msg && typeof msg === 'object' && Array.isArray(msg.content)) {
       // Structured format: message is a ClaudeMessage object
-      messages.push({
+      newContent = msg.content as ContentBlock[]
+      newMessage = {
         role: msg.role || role,
-        content: msg.content as ContentBlock[],
+        content: newContent,
         ...(timestamp ? { timestamp } : {}),
         ...(msg.model ? { model: msg.model } : {}),
-      })
+      }
+    } else {
+      continue
+    }
+
+    // Coalesce consecutive tool-only assistant messages
+    const prevMessage = messages[messages.length - 1]
+    if (
+      prevMessage?.role === 'assistant' &&
+      newMessage.role === 'assistant' &&
+      isToolOnly(prevMessage.content) &&
+      isToolOnly(newMessage.content)
+    ) {
+      // Append content blocks to previous message
+      prevMessage.content = [...prevMessage.content, ...newMessage.content]
+    } else {
+      messages.push(newMessage)
     }
   }
 

--- a/server/session-metadata-store.ts
+++ b/server/session-metadata-store.ts
@@ -4,6 +4,7 @@ import { logger } from './logger.js'
 
 export interface SessionMetadataEntry {
   sessionType?: string
+  derivedTitle?: string
 }
 
 interface MetadataFile {
@@ -126,7 +127,10 @@ export class SessionMetadataStore {
       if (!sessions[provider]) {
         sessions[provider] = safeRecord()
       }
-      sessions[provider][sessionId] = { ...entry }
+      sessions[provider][sessionId] = {
+        ...(sessions[provider][sessionId] ?? {}),
+        ...entry,
+      }
       await this.save({ version: 1, sessions })
     })
   }

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -11,6 +11,7 @@ import { getPerfConfig, logPerfEvent, shouldLog, startPerfTimer } from './perf-l
 import type { ServerSettings } from '../shared/settings.js'
 import { convertWindowsPathToWslPath, isReachableDirectorySync } from './path-utils.js'
 import { isValidClaudeSessionId } from './claude-session-id.js'
+import type { OpencodeServerEndpoint } from './local-port.js'
 import { makeSessionKey, parseSessionKey, type CodingCliProviderName } from './coding-cli/types.js'
 import { SessionBindingAuthority, type BindResult } from './session-binding-authority.js'
 import type {
@@ -165,10 +166,11 @@ function providerNotificationArgs(
   return { args: mcpInjection.args, env: mcpInjection.env }
 }
 
-type ProviderSettings = {
+export type ProviderSettings = {
   permissionMode?: string
   model?: string
   sandbox?: string
+  opencodeServer?: OpencodeServerEndpoint
 }
 
 function resolveCodingCliCommand(
@@ -199,6 +201,24 @@ function resolveCodingCliCommand(
     }
   }
   const settingsArgs: string[] = []
+  if (mode === 'opencode') {
+    const endpoint = providerSettings?.opencodeServer
+    if (
+      !endpoint
+      || endpoint.hostname !== '127.0.0.1'
+      || !Number.isInteger(endpoint.port)
+      || endpoint.port <= 0
+      || endpoint.port > 65535
+    ) {
+      throw new Error('OpenCode launch requires an allocated localhost control endpoint.')
+    }
+    settingsArgs.push(
+      '--hostname',
+      endpoint.hostname,
+      '--port',
+      String(endpoint.port),
+    )
+  }
   const effectiveModel = mode === 'opencode'
     ? resolveOpencodeLaunchModel(providerSettings?.model, { ...process.env, ...commandEnv })
     : providerSettings?.model
@@ -323,6 +343,7 @@ export type TerminalRecord = {
   title: string
   description?: string
   mode: TerminalMode
+  opencodeServer?: OpencodeServerEndpoint
   resumeSessionId?: string
   pendingResumeName?: string
   createdAt: number
@@ -1137,6 +1158,7 @@ export class TerminalRegistry extends EventEmitter {
       title,
       description: undefined,
       mode: opts.mode,
+      opencodeServer: opts.mode === 'opencode' ? opts.providerSettings?.opencodeServer : undefined,
       resumeSessionId: undefined,
       createdAt,
       lastActivityAt: createdAt,

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -16,8 +16,14 @@ import type { SessionScanResult, SessionRepairResult } from './session-scanner/t
 import { isValidClaudeSessionId } from './claude-session-id.js'
 import type { SdkBridge } from './sdk-bridge.js'
 import { createAgentHistorySource, type AgentHistorySource } from './agent-timeline/history-source.js'
-import type { CodexActivityRecord, SdkServerMessage, SdkSessionStatus } from '../shared/ws-protocol.js'
+import type {
+  CodexActivityRecord,
+  OpencodeActivityRecord,
+  SdkServerMessage,
+  SdkSessionStatus,
+} from '../shared/ws-protocol.js'
 import type { ExtensionManager } from './extension-manager.js'
+import { allocateLocalhostPort } from './local-port.js'
 import { TerminalStreamBroker } from './terminal-stream/broker.js'
 import { buildSidebarOpenSessionKeys, type SidebarSessionLocator } from './sidebar-session-selection.js'
 import { loadSessionHistory } from './session-history-loader.js'
@@ -34,6 +40,9 @@ import {
   CodexActivityListResponseSchema,
   CodexActivityListSchema,
   CodexActivityUpdatedSchema,
+  OpencodeActivityListResponseSchema,
+  OpencodeActivityListSchema,
+  OpencodeActivityUpdatedSchema,
   HelloSchema,
   PingSchema,
   TerminalAttachSchema,
@@ -71,6 +80,21 @@ type WsHandlerConfig = {
   drainTimeoutMs: number
   terminalCreateRateLimit: number
   terminalCreateRateWindowMs: number
+}
+
+export type WsHandlerOptions = {
+  codingCliManager?: CodingCliSessionManager
+  sdkBridge?: SdkBridge
+  sessionRepairService?: SessionRepairService
+  handshakeSnapshotProvider?: HandshakeSnapshotProvider
+  terminalMetaListProvider?: () => TerminalMeta[]
+  tabsRegistryStore?: TabsRegistryStore
+  serverInstanceId?: string
+  layoutStore?: LayoutStore
+  extensionManager?: ExtensionManager
+  codexActivityListProvider?: () => CodexActivityRecord[]
+  agentHistorySource?: AgentHistorySource
+  opencodeActivityListProvider?: () => OpencodeActivityRecord[]
 }
 
 function readWsHandlerConfig(): WsHandlerConfig {
@@ -321,6 +345,9 @@ function createScreenshotError(code: ScreenshotErrorCode, message: string): Erro
 export class WsHandler {
   private readonly config: WsHandlerConfig
   private readonly authToken: string
+  private readonly registry: TerminalRegistry
+  private readonly codingCliManager?: CodingCliSessionManager
+  private readonly sdkBridge?: SdkBridge
   private wss: WebSocketServer
   private connections = new Set<LiveWebSocket>()
   private clientStates = new Map<LiveWebSocket, ClientState>()
@@ -330,6 +357,7 @@ export class WsHandler {
   private handshakeSnapshotProvider?: HandshakeSnapshotProvider
   private terminalMetaListProvider?: () => TerminalMeta[]
   private codexActivityListProvider?: () => CodexActivityRecord[]
+  private opencodeActivityListProvider?: () => OpencodeActivityRecord[]
   private tabsRegistryStore?: TabsRegistryStore
   private layoutStore?: LayoutStore
   private extensionManager?: ExtensionManager
@@ -358,44 +386,39 @@ export class WsHandler {
 
   constructor(
     server: http.Server,
-    private registry: TerminalRegistry,
-    private codingCliManager?: CodingCliSessionManager,
-    private sdkBridge?: SdkBridge,
-    sessionRepairService?: SessionRepairService,
-    handshakeSnapshotProvider?: HandshakeSnapshotProvider,
-    terminalMetaListProvider?: () => TerminalMeta[],
-    tabsRegistryStore?: TabsRegistryStore,
-    serverInstanceId?: string,
-    layoutStore?: LayoutStore,
-    extensionManager?: ExtensionManager,
-    codexActivityListProvider?: () => CodexActivityRecord[],
-    agentHistorySource?: AgentHistorySource,
+    registry: TerminalRegistry,
+    options: WsHandlerOptions = {},
   ) {
     this.config = readWsHandlerConfig()
     this.authToken = getRequiredAuthToken()
-    this.sessionRepairService = sessionRepairService
-    this.handshakeSnapshotProvider = handshakeSnapshotProvider
-    this.terminalMetaListProvider = terminalMetaListProvider
-    this.codexActivityListProvider = codexActivityListProvider
-    this.tabsRegistryStore = tabsRegistryStore
-    this.layoutStore = layoutStore
-    this.extensionManager = extensionManager
-    this.agentHistorySource = agentHistorySource ?? (this.sdkBridge
+    this.registry = registry
+    this.codingCliManager = options.codingCliManager
+    this.sdkBridge = options.sdkBridge
+    this.sessionRepairService = options.sessionRepairService
+    this.handshakeSnapshotProvider = options.handshakeSnapshotProvider
+    this.terminalMetaListProvider = options.terminalMetaListProvider
+    this.codexActivityListProvider = options.codexActivityListProvider
+    this.opencodeActivityListProvider = options.opencodeActivityListProvider
+    this.tabsRegistryStore = options.tabsRegistryStore
+    this.layoutStore = options.layoutStore
+    this.extensionManager = options.extensionManager
+    this.agentHistorySource = options.agentHistorySource ?? (this.sdkBridge
       ? createAgentHistorySource({
         loadSessionHistory,
         getLiveSessionBySdkSessionId: (sdkSessionId) => this.sdkBridge?.getLiveSession(sdkSessionId),
         getLiveSessionByCliSessionId: (timelineSessionId) => this.sdkBridge?.findLiveSessionByCliSessionId(timelineSessionId),
       })
       : undefined)
-    this.serverInstanceId = serverInstanceId && serverInstanceId.trim().length > 0
-      ? serverInstanceId
+    this.serverInstanceId = options.serverInstanceId && options.serverInstanceId.trim().length > 0
+      ? options.serverInstanceId
       : `srv-${randomUUID()}`
     this.bootId = `boot-${randomUUID()}`
     this.terminalStreamBroker = new TerminalStreamBroker(this.registry)
 
     // Build the set of valid CLI provider/mode names from extensions
+    const extensionManager = this.extensionManager
     const canEnumerateCliExtensions = typeof extensionManager?.getAll === 'function'
-    const extensionModes = canEnumerateCliExtensions
+    const extensionModes = canEnumerateCliExtensions && extensionManager
       ? extensionManager.getAll()
           .filter(e => e.manifest.category === 'cli')
           .map(e => e.manifest.name)
@@ -454,6 +477,7 @@ export class WsHandler {
       TerminalResizeSchema,
       TerminalKillSchema,
       CodexActivityListSchema,
+      OpencodeActivityListSchema,
       TabsSyncPushSchema,
       TabsSyncQuerySchema,
       dynamicCodingCliCreateSchema,
@@ -1600,19 +1624,24 @@ export class WsHandler {
                 effectiveResumeSessionId,
               }, '[TRACE resumeSessionId] about to create terminal')
 
+              const spawnProviderSettings = providerSettings
+                ? {
+                    permissionMode: providerSettings.permissionMode,
+                    model: providerSettings.model,
+                    sandbox: providerSettings.sandbox,
+                    ...(m.mode === 'opencode'
+                      ? { opencodeServer: await allocateLocalhostPort() }
+                      : {}),
+                  }
+                : undefined
+
               const record = this.registry.create({
                 mode: m.mode as TerminalMode,
                 shell: m.shell as 'system' | 'cmd' | 'powershell' | 'wsl',
                 cwd: m.cwd,
                 resumeSessionId: effectiveResumeSessionId,
                 envContext: { tabId: m.tabId, paneId: m.paneId },
-                providerSettings: providerSettings
-                  ? {
-                      permissionMode: providerSettings.permissionMode,
-                      model: providerSettings.model,
-                      sandbox: providerSettings.sandbox,
-                    }
-                  : undefined,
+                providerSettings: spawnProviderSettings,
               })
 
               if (m.mode !== 'shell' && typeof m.cwd === 'string' && m.cwd.trim()) {
@@ -1754,6 +1783,26 @@ export class WsHandler {
           this.sendError(ws, {
             code: 'INTERNAL_ERROR',
             message: 'Codex activity unavailable',
+            requestId: m.requestId,
+          })
+          return
+        }
+        this.send(ws, response.data)
+        return
+      }
+
+      case 'opencode.activity.list': {
+        const terminals = this.opencodeActivityListProvider ? this.opencodeActivityListProvider() : []
+        const response = OpencodeActivityListResponseSchema.safeParse({
+          type: 'opencode.activity.list.response',
+          requestId: m.requestId,
+          terminals,
+        })
+        if (!response.success) {
+          log.warn({ issues: response.error.issues }, 'Invalid opencode.activity.list.response payload')
+          this.sendError(ws, {
+            code: 'INTERNAL_ERROR',
+            message: 'OpenCode activity unavailable',
             requestId: m.requestId,
           })
           return
@@ -2491,6 +2540,21 @@ export class WsHandler {
 
     if (!parsed.success) {
       log.warn({ issues: parsed.error.issues }, 'Invalid codex.activity.updated payload')
+      return
+    }
+
+    this.broadcastAuthenticated(parsed.data)
+  }
+
+  broadcastOpencodeActivityUpdated(msg: { upsert?: OpencodeActivityRecord[]; remove?: string[] }): void {
+    const parsed = OpencodeActivityUpdatedSchema.safeParse({
+      type: 'opencode.activity.updated',
+      upsert: msg.upsert || [],
+      remove: msg.remove || [],
+    })
+
+    if (!parsed.success) {
+      log.warn({ issues: parsed.error.issues }, 'Invalid opencode.activity.updated payload')
       return
     }
 

--- a/shared/settings.ts
+++ b/shared/settings.ts
@@ -60,6 +60,11 @@ const SIDEBAR_LOCAL_KEYS = [
   'width',
   'collapsed',
 ] as const
+const AGENT_CHAT_LOCAL_KEYS = [
+  'showThinking',
+  'showTools',
+  'showTimecodes',
+] as const
 
 export type ThemeMode = (typeof THEME_VALUES)[number]
 export type TerminalTheme = (typeof TERMINAL_THEME_VALUES)[number]
@@ -180,6 +185,11 @@ export type LocalSettings = {
     width: number
     collapsed: boolean
   }
+  agentChat: {
+    showThinking: boolean
+    showTools: boolean
+    showTimecodes: boolean
+  }
   notifications: {
     soundEnabled: boolean
   }
@@ -201,7 +211,7 @@ export type ResolvedSettings = {
   codingCli: ServerSettings['codingCli']
   panes: ServerSettings['panes'] & LocalSettings['panes']
   editor: ServerSettings['editor']
-  agentChat: ServerSettings['agentChat']
+  agentChat: ServerSettings['agentChat'] & LocalSettings['agentChat']
   extensions: ServerSettings['extensions']
   network: ServerSettings['network']
 }
@@ -465,6 +475,22 @@ function normalizeExtractedLocalSeed(patch: Record<string, unknown>): LocalSetti
     }
   }
 
+  if (isRecord(patch.agentChat)) {
+    const agentChat: LocalSettingsPatch['agentChat'] = {}
+    if (typeof patch.agentChat.showThinking === 'boolean') {
+      agentChat.showThinking = patch.agentChat.showThinking as boolean
+    }
+    if (typeof patch.agentChat.showTools === 'boolean') {
+      agentChat.showTools = patch.agentChat.showTools as boolean
+    }
+    if (typeof patch.agentChat.showTimecodes === 'boolean') {
+      agentChat.showTimecodes = patch.agentChat.showTimecodes as boolean
+    }
+    if (Object.keys(agentChat).length > 0) {
+      normalized.agentChat = agentChat
+    }
+  }
+
   if (isRecord(patch.notifications)) {
     const notifications: LocalSettingsPatch['notifications'] = {}
     if (typeof patch.notifications.soundEnabled === 'boolean') {
@@ -694,6 +720,11 @@ export const defaultLocalSettings: LocalSettings = {
     hideEmptySessions: true,
     width: 288,
     collapsed: false,
+  },
+  agentChat: {
+    showThinking: false,
+    showTools: false,
+    showTimecodes: false,
   },
   notifications: {
     soundEnabled: true,
@@ -978,6 +1009,7 @@ export function resolveLocalSettings(patch?: LocalSettingsPatch): LocalSettings 
       sortMode: normalizeLocalSortMode(patch?.sidebar?.sortMode),
       worktreeGrouping: normalizeWorktreeGrouping(patch?.sidebar?.worktreeGrouping),
     },
+    agentChat: mergeDefined(defaultLocalSettings.agentChat, patch?.agentChat),
     notifications: mergeDefined(defaultLocalSettings.notifications, patch?.notifications),
   }
 }
@@ -1016,6 +1048,14 @@ export function mergeLocalSettings(base: LocalSettingsPatch | undefined, patch: 
   }
   if (Object.keys(sidebar).length > 0) {
     next.sidebar = sidebar as LocalSettingsPatch['sidebar']
+  }
+
+  const agentChat = mergeDefined(
+    (base?.agentChat || {}) as Record<string, unknown>,
+    patch.agentChat as Record<string, unknown> | undefined,
+  )
+  if (Object.keys(agentChat).length > 0) {
+    next.agentChat = agentChat as LocalSettingsPatch['agentChat']
   }
 
   const notifications = mergeDefined(
@@ -1062,6 +1102,7 @@ export function composeResolvedSettings(server: ServerSettings, local: LocalSett
       ...server.agentChat,
       defaultPlugins: [...server.agentChat.defaultPlugins],
       providers: mergeRecordOfObjects(server.agentChat.providers),
+      ...local.agentChat,
     },
     extensions: {
       disabled: [...server.extensions.disabled],
@@ -1096,6 +1137,9 @@ export function extractLegacyLocalSettingsSeed(
       sidebarPatch.ignoreCodexSubagents = raw.sidebar.ignoreCodexSubagentSessions
     }
     maybeAssignNested(patch, 'sidebar', sidebarPatch)
+  }
+  if (isRecord(raw.agentChat)) {
+    maybeAssignNested(patch, 'agentChat', pickKeys(raw.agentChat, AGENT_CHAT_LOCAL_KEYS))
   }
   if (isRecord(raw.notifications)) {
     maybeAssignNested(patch, 'notifications', pickKeys(raw.notifications, ['soundEnabled']))
@@ -1137,6 +1181,15 @@ export function stripLocalSettings(
       next.sidebar = strippedSidebar
     } else {
       delete next.sidebar
+    }
+  }
+
+  if (isRecord(raw.agentChat)) {
+    const strippedAgentChat = omitKeys(raw.agentChat, AGENT_CHAT_LOCAL_KEYS)
+    if (Object.keys(strippedAgentChat).length > 0) {
+      next.agentChat = strippedAgentChat
+    } else {
+      delete next.agentChat
     }
   }
 

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -106,6 +106,27 @@ export const CodexActivityUpdatedSchema = z.object({
   remove: z.array(z.string().min(1)),
 })
 
+export const OpencodeActivityRecordSchema = z.object({
+  terminalId: z.string().min(1),
+  sessionId: z.string().optional(),
+  phase: z.literal('busy'),
+  updatedAt: z.number().int().nonnegative(),
+})
+
+export type OpencodeActivityRecord = z.infer<typeof OpencodeActivityRecordSchema>
+
+export const OpencodeActivityListResponseSchema = z.object({
+  type: z.literal('opencode.activity.list.response'),
+  requestId: z.string().min(1),
+  terminals: z.array(OpencodeActivityRecordSchema),
+})
+
+export const OpencodeActivityUpdatedSchema = z.object({
+  type: z.literal('opencode.activity.updated'),
+  upsert: z.array(OpencodeActivityRecordSchema),
+  remove: z.array(z.string().min(1)),
+})
+
 // ──────────────────────────────────────────────────────────────
 // SDK content block schemas (from Claude Code NDJSON)
 // ──────────────────────────────────────────────────────────────
@@ -227,6 +248,11 @@ export const TerminalKillSchema = z.object({
 
 export const CodexActivityListSchema = z.object({
   type: z.literal('codex.activity.list'),
+  requestId: z.string().min(1),
+})
+
+export const OpencodeActivityListSchema = z.object({
+  type: z.literal('opencode.activity.list'),
   requestId: z.string().min(1),
 })
 
@@ -376,6 +402,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   TerminalResizeSchema,
   TerminalKillSchema,
   CodexActivityListSchema,
+  OpencodeActivityListSchema,
   UiLayoutSyncSchema,
   UiScreenshotResultSchema,
   CodingCliCreateSchema,
@@ -491,6 +518,10 @@ export type TerminalMetaUpdatedMessage = z.infer<typeof TerminalMetaUpdatedSchem
 export type CodexActivityListResponseMessage = z.infer<typeof CodexActivityListResponseSchema>
 
 export type CodexActivityUpdatedMessage = z.infer<typeof CodexActivityUpdatedSchema>
+
+export type OpencodeActivityListResponseMessage = z.infer<typeof OpencodeActivityListResponseSchema>
+
+export type OpencodeActivityUpdatedMessage = z.infer<typeof OpencodeActivityUpdatedSchema>
 
 // -- Sessions --
 
@@ -717,6 +748,8 @@ export type ServerMessage =
   | TerminalInventoryMessage
   | CodexActivityListResponseMessage
   | CodexActivityUpdatedMessage
+  | OpencodeActivityListResponseMessage
+  | OpencodeActivityUpdatedMessage
   | SessionsChangedMessage
   | SettingsUpdatedMessage
   | UiCommandMessage

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import { setTerminalMetaSnapshot, upsertTerminalMeta, removeTerminalMeta } from 
 import { clearDeadTerminals } from '@/store/panesSlice'
 import { addTerminalRestoreRequestId } from '@/lib/terminal-restore'
 import { setCodexActivitySnapshot, upsertCodexActivity, removeCodexActivity, resetCodexActivity } from '@/store/codexActivitySlice'
+import { setOpencodeActivitySnapshot, upsertOpencodeActivity, removeOpencodeActivity, resetOpencodeActivity } from '@/store/opencodeActivitySlice'
 import { setRegistry, updateServerStatus } from '@/store/extensionsSlice'
 import { handleSdkMessage } from '@/lib/sdk-message-handler'
 import { createLogger } from '@/lib/client-logger'
@@ -220,7 +221,9 @@ export default function App() {
   const mainContentRef = useRef<HTMLDivElement>(null)
   const userOpenedSidebarOnMobileRef = useRef(false)
   const codexActivityListRequestSeqRef = useRef(new Map<string, number>())
+  const opencodeActivityListRequestSeqRef = useRef(new Map<string, number>())
   const codexActivityOrderRef = useRef(0)
+  const opencodeActivityOrderRef = useRef(0)
   const copiedResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const fullscreenTouchStartYRef = useRef<number | null>(null)
   const isLandscapeTerminalView = isMobile && isLandscape && view === 'terminal'
@@ -626,9 +629,24 @@ export default function App() {
         })
       }
 
+      const requestOpencodeActivityList = () => {
+        const requestId = `opencode-activity-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+        const requestSeq = ++opencodeActivityOrderRef.current
+        opencodeActivityListRequestSeqRef.current.set(requestId, requestSeq)
+        ws.send({
+          type: 'opencode.activity.list',
+          requestId,
+        })
+      }
+
       const resetCodexActivityOverlay = () => {
         codexActivityListRequestSeqRef.current.clear()
         dispatch(resetCodexActivity())
+      }
+
+      const resetOpencodeActivityOverlay = () => {
+        opencodeActivityListRequestSeqRef.current.clear()
+        dispatch(resetOpencodeActivity())
       }
 
       const wsWithOptionalDisconnect = ws as typeof ws & {
@@ -638,6 +656,7 @@ export default function App() {
       stopWsDisconnectSync = wsWithOptionalDisconnect.onDisconnect?.(() => {
         if (cancelled) return
         resetCodexActivityOverlay()
+        resetOpencodeActivityOverlay()
         dispatch(setStatus('disconnected'))
       }) ?? null
 
@@ -721,6 +740,7 @@ export default function App() {
           // If the initial connect attempt failed before ready, WsClient may still auto-reconnect.
           // Treat 'ready' as the source of truth for connection status.
           resetCodexActivityOverlay()
+          resetOpencodeActivityOverlay()
           dispatch(setError(undefined))
           dispatch(setStatus('ready'))
           dispatch(setServerInstanceId(ready.success ? ready.data.serverInstanceId : undefined))
@@ -737,6 +757,7 @@ export default function App() {
           // from this bootstrap cycle is still safe for enabling follow-up refreshes.
           promoteRecentHttpSessionsBaseline()
           requestCodexActivityList()
+          requestOpencodeActivityList()
           lastSessionsRevision = -1
           void recoverMissingStartupState()
         }
@@ -826,6 +847,35 @@ export default function App() {
             }))
           }
         }
+        if (msg.type === 'opencode.activity.list.response') {
+          const requestId = typeof msg.requestId === 'string' ? msg.requestId : ''
+          if (!requestId) return
+          const requestSeq = opencodeActivityListRequestSeqRef.current.get(requestId)
+          opencodeActivityListRequestSeqRef.current.delete(requestId)
+          if (requestSeq === undefined) return
+          dispatch(setOpencodeActivitySnapshot({
+            terminals: msg.terminals || [],
+            requestSeq,
+          }))
+        }
+        if (msg.type === 'opencode.activity.updated') {
+          const mutationSeq = ++opencodeActivityOrderRef.current
+          const upsert = Array.isArray(msg.upsert) ? msg.upsert : []
+          if (upsert.length > 0) {
+            dispatch(upsertOpencodeActivity({
+              terminals: upsert,
+              mutationSeq,
+            }))
+          }
+
+          const remove = Array.isArray(msg.remove) ? msg.remove : []
+          if (remove.length > 0) {
+            dispatch(removeOpencodeActivity({
+              terminalIds: remove,
+              mutationSeq,
+            }))
+          }
+        }
         if (msg.type === 'terminal.exit') {
           const terminalId = msg.terminalId
           const code = msg.exitCode
@@ -893,6 +943,7 @@ export default function App() {
         if (cancelled) return
         lastReadyServerInstanceId = ws.serverInstanceId
         resetCodexActivityOverlay()
+        resetOpencodeActivityOverlay()
         dispatch(setError(undefined))
         dispatch(setStatus('ready'))
         dispatch(setServerInstanceId(ws.serverInstanceId))
@@ -902,6 +953,7 @@ export default function App() {
 
         if (!cancelled) {
           requestCodexActivityList()
+          requestOpencodeActivityList()
         }
         void recoverMissingStartupState()
         return
@@ -915,6 +967,7 @@ export default function App() {
       } catch (err: any) {
         if (!cancelled) {
           resetCodexActivityOverlay()
+          resetOpencodeActivityOverlay()
           dispatch(setStatus('disconnected'))
           dispatch(setError(err?.message || 'WebSocket connection failed'))
           if (typeof err?.wsCloseCode === 'number') {

--- a/src/components/MobileTabStrip.tsx
+++ b/src/components/MobileTabStrip.tsx
@@ -8,6 +8,7 @@ import type { ChatSessionState } from '@/store/agentChatTypes'
 import type { PaneRuntimeActivityRecord } from '@/store/paneRuntimeActivitySlice'
 
 const EMPTY_CODEX_ACTIVITY_BY_ID = {}
+const EMPTY_OPENCODE_ACTIVITY_BY_ID = {}
 const EMPTY_AGENT_CHAT_SESSIONS: Record<string, ChatSessionState> = {}
 const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecord> = {}
 
@@ -24,6 +25,7 @@ export function MobileTabStrip({ onOpenSwitcher, sidebarCollapsed, onToggleSideb
   const paneLayouts = useAppSelector((s) => s.panes.layouts)
   const paneTitles = useAppSelector((s) => s.panes.paneTitles)
   const codexActivityByTerminalId = useAppSelector((s) => s.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID)
+  const opencodeActivityByTerminalId = useAppSelector((s) => s.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID)
   const agentChatSessions = useAppSelector((s) => s.agentChat?.sessions ?? EMPTY_AGENT_CHAT_SESSIONS)
   const paneRuntimeActivityByPaneId = useAppSelector(
     (s) => s.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID
@@ -41,6 +43,7 @@ export function MobileTabStrip({ onOpenSwitcher, sidebarCollapsed, onToggleSideb
       tab: activeTab,
       paneLayouts,
       codexActivityByTerminalId,
+      opencodeActivityByTerminalId,
       paneRuntimeActivityByPaneId,
       agentChatSessions,
     }).length > 0

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -26,6 +26,7 @@ import type { PaneRuntimeActivityRecord } from '@/store/paneRuntimeActivitySlice
 const EMPTY_TERMINALS: BackgroundTerminal[] = []
 const EMPTY_LAYOUTS: Record<string, never> = {}
 const EMPTY_CODEX_ACTIVITY_BY_ID = {}
+const EMPTY_OPENCODE_ACTIVITY_BY_ID = {}
 const EMPTY_AGENT_CHAT_SESSIONS: Record<string, ChatSessionState> = {}
 const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecord> = {}
 
@@ -308,6 +309,7 @@ export default function Sidebar({
     tabs: state.tabs.tabs,
     paneLayouts: state.panes?.layouts ?? EMPTY_LAYOUTS,
     codexActivityByTerminalId: state.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID,
+    opencodeActivityByTerminalId: state.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID,
     paneRuntimeActivityByPaneId: state.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID,
     agentChatSessions: state.agentChat?.sessions ?? EMPTY_AGENT_CHAT_SESSIONS,
   }), shallowEqual)

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -130,6 +130,7 @@ const EMPTY_LAYOUTS: Record<string, never> = {}
 const EMPTY_PANE_TITLES: Record<string, Record<string, string>> = {}
 const EMPTY_ATTENTION: Record<string, boolean> = {}
 const EMPTY_CODEX_ACTIVITY_BY_ID = {}
+const EMPTY_OPENCODE_ACTIVITY_BY_ID = {}
 const EMPTY_AGENT_CHAT_SESSIONS: Record<string, ChatSessionState> = {}
 const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecord> = {}
 
@@ -151,6 +152,7 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
   const attentionByTab = useAppSelector((s) => s.turnCompletion?.attentionByTab) ?? EMPTY_ATTENTION
   const attentionByPane = useAppSelector((s) => s.turnCompletion?.attentionByPane) ?? EMPTY_ATTENTION
   const codexActivityByTerminalId = useAppSelector((s) => s.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID)
+  const opencodeActivityByTerminalId = useAppSelector((s) => s.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID)
   const agentChatSessions = useAppSelector((s) => s.agentChat?.sessions ?? EMPTY_AGENT_CHAT_SESSIONS)
   const paneRuntimeActivityByPaneId = useAppSelector(
     (s) => s.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID
@@ -208,9 +210,10 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
     tab,
     paneLayouts: paneLayouts as Record<string, PaneNode | undefined>,
     codexActivityByTerminalId,
+    opencodeActivityByTerminalId,
     paneRuntimeActivityByPaneId,
     agentChatSessions,
-  }), [agentChatSessions, codexActivityByTerminalId, paneLayouts, paneRuntimeActivityByPaneId])
+  }), [agentChatSessions, codexActivityByTerminalId, opencodeActivityByTerminalId, paneLayouts, paneRuntimeActivityByPaneId])
 
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')

--- a/src/components/TabSwitcher.tsx
+++ b/src/components/TabSwitcher.tsx
@@ -10,6 +10,7 @@ import type { ChatSessionState } from '@/store/agentChatTypes'
 import type { PaneRuntimeActivityRecord } from '@/store/paneRuntimeActivitySlice'
 
 const EMPTY_CODEX_ACTIVITY_BY_ID = {}
+const EMPTY_OPENCODE_ACTIVITY_BY_ID = {}
 const EMPTY_AGENT_CHAT_SESSIONS: Record<string, ChatSessionState> = {}
 const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecord> = {}
 
@@ -39,6 +40,7 @@ export function TabSwitcher({ onClose }: TabSwitcherProps) {
   const paneLayouts = useAppSelector((s) => s.panes.layouts)
   const paneTitles = useAppSelector((s) => s.panes.paneTitles)
   const codexActivityByTerminalId = useAppSelector((s) => s.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID)
+  const opencodeActivityByTerminalId = useAppSelector((s) => s.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID)
   const agentChatSessions = useAppSelector((s) => s.agentChat?.sessions ?? EMPTY_AGENT_CHAT_SESSIONS)
   const paneRuntimeActivityByPaneId = useAppSelector(
     (s) => s.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID
@@ -95,6 +97,7 @@ export function TabSwitcher({ onClose }: TabSwitcherProps) {
               tab,
               paneLayouts,
               codexActivityByTerminalId,
+              opencodeActivityByTerminalId,
               paneRuntimeActivityByPaneId,
               agentChatSessions,
             }).length > 0

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -1207,22 +1207,6 @@ export default function TerminalView({ tabId, paneId, paneContent, hidden }: Ter
       }
     })
 
-    // When the clipboard contains an image but no text, the browser paste event
-    // fires but xterm has nothing to write. CLI tools like Codex listen for the
-    // raw Ctrl+V byte (\x16) to trigger a native clipboard read. Send it so
-    // image paste works for CLIs running inside the terminal.
-    const xtermTextarea = term.textarea
-    const handleImagePaste = (e: ClipboardEvent) => {
-      const hasText = e.clipboardData?.types.includes('text/plain')
-      const hasImage = Array.from(e.clipboardData?.items ?? []).some(
-        (item) => item.kind === 'file' && item.type.startsWith('image/'),
-      )
-      if (hasImage && !hasText) {
-        sendInput('\x16')
-      }
-    }
-    xtermTextarea?.addEventListener('paste', handleImagePaste)
-
     term.attachCustomKeyEventHandler((event) => {
       if (
         event.ctrlKey &&
@@ -1306,7 +1290,6 @@ export default function TerminalView({ tabId, paneId, paneContent, hidden }: Ter
         delete wrapperEl.dataset.hoveredUrl
       }
       ro.disconnect()
-      xtermTextarea?.removeEventListener('paste', handleImagePaste)
       unregisterActions()
       unregisterCaptureHandler()
       if (writeQueueRef.current === writeQueue) {

--- a/src/components/agent-chat/AgentChatSettings.tsx
+++ b/src/components/agent-chat/AgentChatSettings.tsx
@@ -7,7 +7,11 @@ import type { AgentChatPaneContent } from '@/store/paneTypes'
 import type { AgentChatProviderConfig } from '@/lib/agent-chat-types'
 import { formatModelDisplayName } from '../../../shared/format-model-name'
 
-type SettingsFields = Pick<AgentChatPaneContent, 'model' | 'permissionMode' | 'effort' | 'showThinking' | 'showTools' | 'showTimecodes'>
+type SettingsFields = Pick<AgentChatPaneContent, 'model' | 'permissionMode' | 'effort'> & {
+  showThinking?: boolean
+  showTools?: boolean
+  showTimecodes?: boolean
+}
 
 interface AgentChatSettingsProps {
   model: string

--- a/src/components/agent-chat/AgentChatView.tsx
+++ b/src/components/agent-chat/AgentChatView.tsx
@@ -30,6 +30,7 @@ import { getAgentChatProviderConfig } from '@/lib/agent-chat-utils'
 import { isValidClaudeSessionId } from '@/lib/claude-session-id'
 import { getInstalledPerfAuditBridge } from '@/lib/perf-audit-bridge'
 import { saveServerSettingsPatch } from '@/store/settingsThunks'
+import { updateSettingsLocal } from '@/store/settingsSlice'
 import type { Tab } from '@/store/types'
 import {
   buildAgentChatPersistedIdentityUpdate,
@@ -64,9 +65,10 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
   const defaultModel = providerConfig?.defaultModel ?? 'claude-opus-4-6'
   const defaultPermissionMode = providerConfig?.defaultPermissionMode ?? 'bypassPermissions'
   const defaultEffort = providerConfig?.defaultEffort ?? 'high'
-  const defaultShowThinking = providerConfig?.defaultShowThinking ?? true
-  const defaultShowTools = providerConfig?.defaultShowTools ?? true
-  const defaultShowTimecodes = providerConfig?.defaultShowTimecodes ?? false
+  const localSettings = useAppSelector((state) => state.settings.settings)
+  const defaultShowThinking = localSettings.agentChat.showThinking
+  const defaultShowTools = localSettings.agentChat.showTools
+  const defaultShowTimecodes = localSettings.agentChat.showTimecodes
   const providerLabel = providerConfig?.label ?? 'Agent Chat'
   const createSentRef = useRef(false)
   const attachSentRef = useRef(false)
@@ -543,11 +545,28 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
   }, [])
 
   const handleSettingsChange = useCallback((changes: Record<string, unknown>) => {
-    dispatch(updatePaneContent({
-      tabId,
-      paneId,
-      content: { ...paneContentRef.current, ...changes },
-    }))
+    const paneChanges: Partial<AgentChatPaneContent> = {}
+    const localChanges: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(changes)) {
+      if (key === 'showThinking' || key === 'showTools' || key === 'showTimecodes') {
+        localChanges[key] = value
+      } else {
+        (paneChanges as Record<string, unknown>)[key] = value
+      }
+    }
+
+    if (Object.keys(paneChanges).length > 0) {
+      dispatch(updatePaneContent({
+        tabId,
+        paneId,
+        content: { ...paneContentRef.current, ...paneChanges },
+      }))
+    }
+
+    if (Object.keys(localChanges).length > 0) {
+      dispatch(updateSettingsLocal({ agentChat: localChanges }))
+    }
 
     const pc = paneContentRef.current
 
@@ -703,9 +722,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
             model={paneContent.model ?? defaultModel}
             permissionMode={paneContent.permissionMode ?? defaultPermissionMode}
             effort={paneContent.effort ?? defaultEffort}
-            showThinking={paneContent.showThinking ?? defaultShowThinking}
-            showTools={paneContent.showTools ?? defaultShowTools}
-            showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+            showThinking={defaultShowThinking}
+            showTools={defaultShowTools}
+            showTimecodes={defaultShowTimecodes}
             sessionStarted={sessionStarted}
             defaultOpen={shouldShowSettings}
             modelOptions={availableModels.length > 0 ? availableModels : undefined}
@@ -765,9 +784,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
                 content={turn.message.content}
                 timestamp={turn.message.timestamp}
                 model={turn.message.model}
-                showThinking={paneContent.showThinking ?? defaultShowThinking}
-                showTools={paneContent.showTools ?? defaultShowTools}
-                showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+                showThinking={defaultShowThinking}
+                showTools={defaultShowTools}
+                showTimecodes={defaultShowTimecodes}
               />
             )
           }
@@ -785,9 +804,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
                   turnId: item.turnId,
                 }))
               }}
-              showThinking={paneContent.showThinking ?? defaultShowThinking}
-              showTools={paneContent.showTools ?? defaultShowTools}
-              showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+              showThinking={defaultShowThinking}
+              showTools={defaultShowTools}
+              showTimecodes={defaultShowTimecodes}
             />
           )
         })}
@@ -805,9 +824,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
                     key={`turn-${i}`}
                     userMessage={item.user}
                     assistantMessage={item.assistant}
-                    showThinking={paneContent.showThinking ?? defaultShowThinking}
-                    showTools={paneContent.showTools ?? defaultShowTools}
-                    showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+                    showThinking={defaultShowThinking}
+                    showTools={defaultShowTools}
+                    showTimecodes={defaultShowTimecodes}
                   />
                 )
               }
@@ -817,9 +836,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
                     speaker={item.user.role}
                     content={item.user.content}
                     timestamp={item.user.timestamp}
-                    showThinking={paneContent.showThinking ?? defaultShowThinking}
-                    showTools={paneContent.showTools ?? defaultShowTools}
-                    showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+                    showThinking={defaultShowThinking}
+                    showTools={defaultShowTools}
+                    showTimecodes={defaultShowTimecodes}
                   />
                   <MessageBubble
                     speaker={item.assistant.role}
@@ -827,9 +846,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
                     timestamp={item.assistant.timestamp}
                     model={item.assistant.model}
                     isLastMessage={isLast}
-                    showThinking={paneContent.showThinking ?? defaultShowThinking}
-                    showTools={paneContent.showTools ?? defaultShowTools}
-                    showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+                    showThinking={defaultShowThinking}
+                    showTools={defaultShowTools}
+                    showTimecodes={defaultShowTimecodes}
                   />
                 </React.Fragment>
               )
@@ -843,9 +862,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
                 timestamp={item.message.timestamp}
                 model={item.message.model}
                 isLastMessage={isLast}
-                showThinking={paneContent.showThinking ?? defaultShowThinking}
-                showTools={paneContent.showTools ?? defaultShowTools}
-                showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+                showThinking={defaultShowThinking}
+                showTools={defaultShowTools}
+                showTimecodes={defaultShowTimecodes}
               />
             )
           })
@@ -855,9 +874,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
           <MessageBubble
             speaker="assistant"
             content={streamingContent}
-            showThinking={paneContent.showThinking ?? defaultShowThinking}
-            showTools={paneContent.showTools ?? defaultShowTools}
-            showTimecodes={paneContent.showTimecodes ?? defaultShowTimecodes}
+            showThinking={defaultShowThinking}
+            showTools={defaultShowTools}
+            showTimecodes={defaultShowTimecodes}
           />
         )}
 

--- a/src/components/agent-chat/CollapsedTurn.tsx
+++ b/src/components/agent-chat/CollapsedTurn.tsx
@@ -42,8 +42,8 @@ function CollapsedTurn({
   message,
   loading = false,
   onExpand,
-  showThinking = true,
-  showTools = true,
+  showThinking = false,
+  showTools = false,
   showTimecodes = false,
 }: CollapsedTurnProps) {
   const [expanded, setExpanded] = useState(false)

--- a/src/components/agent-chat/MessageBubble.tsx
+++ b/src/components/agent-chat/MessageBubble.tsx
@@ -31,8 +31,8 @@ function MessageBubble({
   content,
   timestamp,
   model,
-  showThinking = true,
-  showTools = true,
+  showThinking = false,
+  showTools = false,
   showTimecodes = false,
   isLastMessage = false,
 }: MessageBubbleProps) {

--- a/src/components/agent-chat/ToolStrip.tsx
+++ b/src/components/agent-chat/ToolStrip.tsx
@@ -17,7 +17,7 @@ export interface ToolPair {
 interface ToolStripProps {
   pairs: ToolPair[]
   isStreaming: boolean
-  /** When false, strip is locked to collapsed view (no expand chevron). Default false. */
+  /** When true, strip starts expanded. Default false. */
   showTools?: boolean
 }
 

--- a/src/components/agent-chat/ToolStrip.tsx
+++ b/src/components/agent-chat/ToolStrip.tsx
@@ -17,11 +17,11 @@ export interface ToolPair {
 interface ToolStripProps {
   pairs: ToolPair[]
   isStreaming: boolean
-  /** When false, strip is locked to collapsed view (no expand chevron). Default true. */
+  /** When false, strip is locked to collapsed view (no expand chevron). Default false. */
   showTools?: boolean
 }
 
-function ToolStrip({ pairs, isStreaming, showTools = true }: ToolStripProps) {
+function ToolStrip({ pairs, isStreaming, showTools = false }: ToolStripProps) {
   const [stripExpanded, setStripExpanded] = useState(showTools)
   useEffect(() => { setStripExpanded(showTools) }, [showTools])
 

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -51,6 +51,7 @@ const EMPTY_TERMINAL_META_BY_ID: Record<string, TerminalMetaRecord> = {}
 const EMPTY_PROJECTS: ProjectGroup[] = []
 const EMPTY_AGENT_CHAT_SESSIONS: Record<string, ChatSessionState> = {}
 const EMPTY_CODEX_ACTIVITY_BY_ID = {}
+const EMPTY_OPENCODE_ACTIVITY_BY_ID = {}
 const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecord> = {}
 const EMPTY_ATTENTION_BY_PANE: Record<string, boolean> = {}
 const EMPTY_PENDING_CREATES: Record<string, PendingAgentCreate> = {}
@@ -164,6 +165,9 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
   const agentChatSessions = useAppSelector((s) => s.agentChat?.sessions ?? EMPTY_AGENT_CHAT_SESSIONS)
   const codexActivityByTerminalId = useAppSelector(
     (s) => s.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID
+  )
+  const opencodeActivityByTerminalId = useAppSelector(
+    (s) => s.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID
   )
   const paneRuntimeActivityByPaneId = useAppSelector(
     (s) => s.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID
@@ -420,6 +424,7 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
       tabMode: tab?.mode,
       isOnlyPane,
       codexActivityByTerminalId,
+      opencodeActivityByTerminalId,
       paneRuntimeActivityByPaneId,
       agentChatSessions,
     }).isBusy

--- a/src/components/settings/WorkspaceSettings.tsx
+++ b/src/components/settings/WorkspaceSettings.tsx
@@ -253,6 +253,33 @@ export default function WorkspaceSettings({
         </SettingsRow>
       </SettingsSection>
 
+      <SettingsSection title="Agent chat" description="Display settings for agent chat panes">
+        <SettingsRow label="Show thinking">
+          <Toggle
+            checked={settings.agentChat?.showThinking ?? false}
+            onChange={(checked) => {
+              applyLocalSetting({ agentChat: { showThinking: checked } })
+            }}
+          />
+        </SettingsRow>
+        <SettingsRow label="Show tools">
+          <Toggle
+            checked={settings.agentChat?.showTools ?? false}
+            onChange={(checked) => {
+              applyLocalSetting({ agentChat: { showTools: checked } })
+            }}
+          />
+        </SettingsRow>
+        <SettingsRow label="Show timecodes &amp; model">
+          <Toggle
+            checked={settings.agentChat?.showTimecodes ?? false}
+            onChange={(checked) => {
+              applyLocalSetting({ agentChat: { showTimecodes: checked } })
+            }}
+          />
+        </SettingsRow>
+      </SettingsSection>
+
       <SettingsSection title="Editor" description="External editor for file opening">
         <SettingsRow label="External editor" description="Which editor to use when opening files from the editor pane">
           <select

--- a/src/lib/agent-chat-types.ts
+++ b/src/lib/agent-chat-types.ts
@@ -17,10 +17,6 @@ export interface AgentChatProviderConfig {
   defaultPermissionMode: string
   /** Default effort level */
   defaultEffort: 'low' | 'medium' | 'high' | 'max'
-  /** Default display settings */
-  defaultShowThinking: boolean
-  defaultShowTools: boolean
-  defaultShowTimecodes: boolean
   /** Which settings are visible in the settings popover */
   settingsVisibility: {
     model: boolean

--- a/src/lib/agent-chat-utils.ts
+++ b/src/lib/agent-chat-utils.ts
@@ -17,9 +17,6 @@ export const AGENT_CHAT_PROVIDER_CONFIGS: AgentChatProviderConfig[] = [
     defaultModel: 'claude-opus-4-6',
     defaultPermissionMode: 'bypassPermissions',
     defaultEffort: 'high',
-    defaultShowThinking: true,
-    defaultShowTools: true,
-    defaultShowTimecodes: false,
     settingsVisibility: {
       model: true,
       permissionMode: true,
@@ -38,9 +35,6 @@ export const AGENT_CHAT_PROVIDER_CONFIGS: AgentChatProviderConfig[] = [
     defaultModel: 'claude-opus-4-6',
     defaultPermissionMode: 'bypassPermissions',
     defaultEffort: 'high',
-    defaultShowThinking: true,
-    defaultShowTools: true,
-    defaultShowTimecodes: false,
     settingsVisibility: {
       model: true,
       permissionMode: true,

--- a/src/lib/pane-activity.ts
+++ b/src/lib/pane-activity.ts
@@ -11,9 +11,9 @@ import type {
 import type { PaneRuntimeActivityRecord } from '@/store/paneRuntimeActivitySlice'
 import { getPreferredResumeSessionId } from '@/store/persistControl'
 import type { Tab } from '@/store/types'
-import type { CodexActivityRecord } from '@shared/ws-protocol'
+import type { CodexActivityRecord, OpencodeActivityRecord } from '@shared/ws-protocol'
 
-type PaneActivitySource = 'codex' | 'claude-terminal' | 'agent-chat' | 'browser'
+type PaneActivitySource = 'codex' | 'opencode' | 'claude-terminal' | 'agent-chat' | 'browser'
 
 export type PaneActivityProjection = {
   isBusy: boolean
@@ -106,6 +106,7 @@ export function resolvePaneActivity(input: {
   tabMode?: Tab['mode']
   isOnlyPane: boolean
   codexActivityByTerminalId: Record<string, CodexActivityRecord>
+  opencodeActivityByTerminalId: Record<string, OpencodeActivityRecord>
   paneRuntimeActivityByPaneId: Record<string, PaneRuntimeActivityRecord>
   agentChatSessions: Record<string, ChatSessionState>
 }): PaneActivityProjection {
@@ -125,6 +126,16 @@ export function resolvePaneActivity(input: {
       })
       return record?.phase === 'busy'
         ? { isBusy: true, source: 'codex' }
+        : IDLE_PANE_ACTIVITY
+    }
+
+    if (effectiveMode === 'opencode') {
+      const terminalId = input.content.terminalId
+      const record = terminalId
+        ? input.opencodeActivityByTerminalId[terminalId]
+        : undefined
+      return record?.phase === 'busy'
+        ? { isBusy: true, source: 'opencode' }
         : IDLE_PANE_ACTIVITY
     }
 
@@ -157,6 +168,7 @@ export function getBusyPaneIdsForTab(input: {
   tab: Tab
   paneLayouts: Record<string, PaneNode | undefined>
   codexActivityByTerminalId: Record<string, CodexActivityRecord>
+  opencodeActivityByTerminalId: Record<string, OpencodeActivityRecord>
   paneRuntimeActivityByPaneId: Record<string, PaneRuntimeActivityRecord>
   agentChatSessions: Record<string, ChatSessionState>
 }): string[] {
@@ -171,6 +183,7 @@ export function getBusyPaneIdsForTab(input: {
       tabMode: input.tab.mode,
       isOnlyPane: true,
       codexActivityByTerminalId: input.codexActivityByTerminalId,
+      opencodeActivityByTerminalId: input.opencodeActivityByTerminalId,
       paneRuntimeActivityByPaneId: input.paneRuntimeActivityByPaneId,
       agentChatSessions: input.agentChatSessions,
     }).isBusy
@@ -186,6 +199,7 @@ export function getBusyPaneIdsForTab(input: {
       tabMode: input.tab.mode,
       isOnlyPane,
       codexActivityByTerminalId: input.codexActivityByTerminalId,
+      opencodeActivityByTerminalId: input.opencodeActivityByTerminalId,
       paneRuntimeActivityByPaneId: input.paneRuntimeActivityByPaneId,
       agentChatSessions: input.agentChatSessions,
     }).isBusy)
@@ -196,6 +210,7 @@ export function collectBusySessionKeys(input: {
   tabs: Tab[]
   paneLayouts: Record<string, PaneNode | undefined>
   codexActivityByTerminalId: Record<string, CodexActivityRecord>
+  opencodeActivityByTerminalId: Record<string, OpencodeActivityRecord>
   paneRuntimeActivityByPaneId: Record<string, PaneRuntimeActivityRecord>
   agentChatSessions: Record<string, ChatSessionState>
 }): string[] {
@@ -213,6 +228,7 @@ export function collectBusySessionKeys(input: {
         tabMode: tab.mode,
         isOnlyPane: true,
         codexActivityByTerminalId: input.codexActivityByTerminalId,
+        opencodeActivityByTerminalId: input.opencodeActivityByTerminalId,
         paneRuntimeActivityByPaneId: input.paneRuntimeActivityByPaneId,
         agentChatSessions: input.agentChatSessions,
       }).isBusy
@@ -231,6 +247,7 @@ export function collectBusySessionKeys(input: {
         tabMode: tab.mode,
         isOnlyPane,
         codexActivityByTerminalId: input.codexActivityByTerminalId,
+        opencodeActivityByTerminalId: input.opencodeActivityByTerminalId,
         paneRuntimeActivityByPaneId: input.paneRuntimeActivityByPaneId,
         agentChatSessions: input.agentChatSessions,
       }).isBusy

--- a/src/store/agentChatSlice.ts
+++ b/src/store/agentChatSlice.ts
@@ -8,6 +8,13 @@ import type {
   QuestionDefinition,
 } from './agentChatTypes'
 
+/** Check if content blocks contain only tool_use and tool_result blocks (no text or thinking). */
+function isToolOnlyContent(blocks: ChatContentBlock[]): boolean {
+  return blocks.length > 0 && blocks.every(
+    (b) => b.type === 'tool_use' || b.type === 'tool_result'
+  )
+}
+
 const initialState: AgentChatState = {
   sessions: {},
   pendingCreates: {},
@@ -113,12 +120,26 @@ const agentChatSlice = createSlice({
     }>) {
       const session = state.sessions[action.payload.sessionId]
       if (!session) return
-      session.messages.push({
-        role: 'assistant',
-        content: action.payload.content,
-        timestamp: new Date().toISOString(),
-        model: action.payload.model,
-      })
+
+      const newContent = action.payload.content
+      const prevMessage = session.messages[session.messages.length - 1]
+
+      // Coalesce consecutive tool-only assistant messages
+      if (
+        prevMessage?.role === 'assistant' &&
+        isToolOnlyContent(prevMessage.content) &&
+        isToolOnlyContent(newContent)
+      ) {
+        // Append content blocks to previous message instead of creating new one
+        prevMessage.content = [...prevMessage.content, ...newContent]
+      } else {
+        session.messages.push({
+          role: 'assistant',
+          content: newContent,
+          timestamp: new Date().toISOString(),
+          model: action.payload.model,
+        })
+      }
       session.status = 'running'
     },
 

--- a/src/store/browserPreferencesPersistence.ts
+++ b/src/store/browserPreferencesPersistence.ts
@@ -126,6 +126,14 @@ export function buildLocalSettingsPatch(localSettings: LocalSettings): LocalSett
     patch.sidebar = sidebar
   }
 
+  const agentChat: LocalSettingsPatch['agentChat'] = {}
+  assignChangedScalar(agentChat, localSettings.agentChat, defaultLocalSettings.agentChat, 'showThinking')
+  assignChangedScalar(agentChat, localSettings.agentChat, defaultLocalSettings.agentChat, 'showTools')
+  assignChangedScalar(agentChat, localSettings.agentChat, defaultLocalSettings.agentChat, 'showTimecodes')
+  if (Object.keys(agentChat).length > 0) {
+    patch.agentChat = agentChat
+  }
+
   const notifications: LocalSettingsPatch['notifications'] = {}
   assignChangedScalar(notifications, localSettings.notifications, defaultLocalSettings.notifications, 'soundEnabled')
   if (Object.keys(notifications).length > 0) {

--- a/src/store/opencodeActivitySlice.ts
+++ b/src/store/opencodeActivitySlice.ts
@@ -1,0 +1,126 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { OpencodeActivityRecord } from '@shared/ws-protocol'
+
+export type OpencodeActivityState = {
+  byTerminalId: Record<string, OpencodeActivityRecord>
+  lastSnapshotSeq: number
+  liveMutationSeqByTerminalId: Record<string, number>
+  removedMutationSeqByTerminalId: Record<string, number>
+}
+
+type OpencodeActivitySnapshotPayload = {
+  terminals: OpencodeActivityRecord[]
+  requestSeq?: number
+}
+
+type OpencodeActivityUpsertPayload = {
+  terminals: OpencodeActivityRecord[]
+  mutationSeq?: number
+}
+
+type OpencodeActivityRemovalPayload = {
+  terminalIds: string[]
+  mutationSeq?: number
+}
+
+function createInitialState(): OpencodeActivityState {
+  return {
+    byTerminalId: {},
+    lastSnapshotSeq: 0,
+    liveMutationSeqByTerminalId: {},
+    removedMutationSeqByTerminalId: {},
+  }
+}
+
+const initialState: OpencodeActivityState = createInitialState()
+
+const opencodeActivitySlice = createSlice({
+  name: 'opencodeActivity',
+  initialState,
+  reducers: {
+    setOpencodeActivitySnapshot(state, action: PayloadAction<OpencodeActivitySnapshotPayload>) {
+      const requestSeq = action.payload.requestSeq ?? 0
+      if (requestSeq < state.lastSnapshotSeq) {
+        return
+      }
+      const next: Record<string, OpencodeActivityRecord> = {}
+      const nextLiveMutationSeqByTerminalId: Record<string, number> = {}
+      const incomingIds = new Set<string>()
+
+      for (const record of action.payload.terminals) {
+        const removedMutationSeq = state.removedMutationSeqByTerminalId[record.terminalId] ?? 0
+        if (removedMutationSeq > requestSeq) continue
+        const liveMutationSeq = state.liveMutationSeqByTerminalId[record.terminalId] ?? 0
+        const existing = state.byTerminalId[record.terminalId]
+        if (liveMutationSeq > requestSeq && existing) {
+          next[record.terminalId] = existing
+          nextLiveMutationSeqByTerminalId[record.terminalId] = liveMutationSeq
+          incomingIds.add(record.terminalId)
+          continue
+        }
+        next[record.terminalId] = record
+        incomingIds.add(record.terminalId)
+      }
+
+      for (const [terminalId, existing] of Object.entries(state.byTerminalId)) {
+        if (incomingIds.has(terminalId)) continue
+        const liveMutationSeq = state.liveMutationSeqByTerminalId[terminalId] ?? 0
+        if (liveMutationSeq > requestSeq) {
+          next[terminalId] = existing
+          nextLiveMutationSeqByTerminalId[terminalId] = liveMutationSeq
+        }
+      }
+
+      const nextRemovedMutationSeqByTerminalId: Record<string, number> = {}
+      for (const [terminalId, removedMutationSeq] of Object.entries(state.removedMutationSeqByTerminalId)) {
+        if (removedMutationSeq > requestSeq && !next[terminalId]) {
+          nextRemovedMutationSeqByTerminalId[terminalId] = removedMutationSeq
+        }
+      }
+
+      state.byTerminalId = next
+      state.lastSnapshotSeq = requestSeq
+      state.liveMutationSeqByTerminalId = nextLiveMutationSeqByTerminalId
+      state.removedMutationSeqByTerminalId = nextRemovedMutationSeqByTerminalId
+    },
+
+    upsertOpencodeActivity(state, action: PayloadAction<OpencodeActivityUpsertPayload>) {
+      const mutationSeq = action.payload.mutationSeq ?? 0
+      for (const record of action.payload.terminals) {
+        const removedMutationSeq = state.removedMutationSeqByTerminalId[record.terminalId] ?? 0
+        if (removedMutationSeq > mutationSeq) continue
+
+        const existing = state.byTerminalId[record.terminalId]
+        if (!existing || record.updatedAt >= existing.updatedAt) {
+          state.byTerminalId[record.terminalId] = record
+          state.liveMutationSeqByTerminalId[record.terminalId] = mutationSeq
+          delete state.removedMutationSeqByTerminalId[record.terminalId]
+        }
+      }
+    },
+
+    removeOpencodeActivity(state, action: PayloadAction<OpencodeActivityRemovalPayload>) {
+      const mutationSeq = action.payload.mutationSeq ?? 0
+      for (const terminalId of action.payload.terminalIds) {
+        delete state.byTerminalId[terminalId]
+        delete state.liveMutationSeqByTerminalId[terminalId]
+        if ((state.removedMutationSeqByTerminalId[terminalId] ?? 0) < mutationSeq) {
+          state.removedMutationSeqByTerminalId[terminalId] = mutationSeq
+        }
+      }
+    },
+
+    resetOpencodeActivity() {
+      return createInitialState()
+    },
+  },
+})
+
+export const {
+  setOpencodeActivitySnapshot,
+  upsertOpencodeActivity,
+  removeOpencodeActivity,
+  resetOpencodeActivity,
+} = opencodeActivitySlice.actions
+
+export default opencodeActivitySlice.reducer

--- a/src/store/paneTreeValidation.ts
+++ b/src/store/paneTreeValidation.ts
@@ -50,9 +50,6 @@ function isPaneContentShape(content: unknown): boolean {
           || content.effort === 'max')
         && (content.plugins === undefined
           || (Array.isArray(content.plugins) && content.plugins.every((plugin) => typeof plugin === 'string')))
-        && (content.showThinking === undefined || typeof content.showThinking === 'boolean')
-        && (content.showTools === undefined || typeof content.showTools === 'boolean')
-        && (content.showTimecodes === undefined || typeof content.showTimecodes === 'boolean')
         && (content.settingsDismissed === undefined || typeof content.settingsDismissed === 'boolean')
     case 'extension':
       return typeof content.extensionName === 'string'

--- a/src/store/paneTypes.ts
+++ b/src/store/paneTypes.ts
@@ -104,12 +104,6 @@ export type AgentChatPaneContent = {
   effort?: 'low' | 'medium' | 'high' | 'max'
   /** Plugin paths to load into this session (absolute paths to plugin directories) */
   plugins?: string[]
-  /** Show thinking blocks in message feed */
-  showThinking?: boolean
-  /** Show tool-use blocks in message feed */
-  showTools?: boolean
-  /** Show timestamps on messages */
-  showTimecodes?: boolean
   /** Whether the user has dismissed the first-launch settings popover */
   settingsDismissed?: boolean
 }

--- a/src/store/panesSlice.ts
+++ b/src/store/panesSlice.ts
@@ -123,9 +123,6 @@ function normalizePaneContent(
       permissionMode: input.permissionMode,
       effort: input.effort,
       plugins: input.plugins,
-      showThinking: input.showThinking,
-      showTools: input.showTools,
-      showTimecodes: input.showTimecodes,
       settingsDismissed: input.settingsDismissed,
     }
   }

--- a/src/store/panesSlice.ts
+++ b/src/store/panesSlice.ts
@@ -8,6 +8,7 @@ import { buildPaneRefreshTarget, paneRefreshTargetMatchesContent } from '@/lib/p
 import { loadPersistedPanes, loadPersistedTabs } from './persistMiddleware.js'
 import { hasPaneTreeShape, isWellFormedPaneTree } from './paneTreeValidation.js'
 import { createLogger } from '@/lib/client-logger'
+import { patchBrowserPreferencesRecord } from '@/lib/browser-preferences'
 import { shouldPreserveLocalCanonicalResumeSessionId } from './persistControl'
 
 
@@ -201,6 +202,85 @@ function cleanOrphanedLayouts(state: PanesState): PanesState {
   }
 }
 
+type LegacyDisplayFields = {
+  showThinking?: boolean
+  showTools?: boolean
+  showTimecodes?: boolean
+}
+
+function collectLegacyDisplayFields(node: unknown): LegacyDisplayFields {
+  if (!node || typeof node !== 'object') return {}
+  const n = node as { type?: string; content?: Record<string, unknown>; children?: unknown[] }
+
+  if (n.type === 'leaf' && n.content && n.content.kind === 'agent-chat') {
+    const c = n.content as Record<string, unknown>
+    return {
+      ...(typeof c.showThinking === 'boolean' && c.showThinking ? { showThinking: true } : {}),
+      ...(typeof c.showTools === 'boolean' && c.showTools ? { showTools: true } : {}),
+      ...(typeof c.showTimecodes === 'boolean' && c.showTimecodes ? { showTimecodes: true } : {}),
+    }
+  }
+
+  if (n.type === 'split' && Array.isArray(n.children)) {
+    let merged: LegacyDisplayFields = {}
+    for (const child of n.children) {
+      const childFields = collectLegacyDisplayFields(child)
+      if (childFields.showThinking) merged.showThinking = true
+      if (childFields.showTools) merged.showTools = true
+      if (childFields.showTimecodes) merged.showTimecodes = true
+    }
+    return merged
+  }
+
+  return {}
+}
+
+function stripLegacyDisplayFields(node: any): any {
+  if (!node) return node
+  if (node.type === 'leaf' && node.content?.kind === 'agent-chat') {
+    const { showThinking: _st, showTools: _stl, showTimecodes: _stc, ...rest } = node.content
+    if (_st === undefined && _stl === undefined && _stc === undefined) return node
+    return { ...node, content: rest }
+  }
+  if (node.type === 'split' && Array.isArray(node.children)) {
+    const nextChildren = node.children.map(stripLegacyDisplayFields)
+    if (nextChildren.every((c: any, i: number) => c === node.children[i])) return node
+    return { ...node, children: nextChildren }
+  }
+  return node
+}
+
+function migrateLegacyAgentChatDisplaySettings(state: PanesState): PanesState {
+  let legacy: LegacyDisplayFields = {}
+  let hasLegacy = false
+  const nextLayouts: Record<string, any> = {}
+
+  for (const [tabId, node] of Object.entries(state.layouts)) {
+    const fields = collectLegacyDisplayFields(node)
+    if (fields.showThinking || fields.showTools || fields.showTimecodes) {
+      legacy.showThinking = legacy.showThinking || fields.showThinking
+      legacy.showTools = legacy.showTools || fields.showTools
+      legacy.showTimecodes = legacy.showTimecodes || fields.showTimecodes
+      hasLegacy = true
+    }
+    nextLayouts[tabId] = hasLegacy ? stripLegacyDisplayFields(node) : node
+  }
+
+  if (!hasLegacy) return state
+
+  patchBrowserPreferencesRecord({
+    settings: {
+      agentChat: {
+        ...(legacy.showThinking ? { showThinking: true } : {}),
+        ...(legacy.showTools ? { showTools: true } : {}),
+        ...(legacy.showTimecodes ? { showTimecodes: true } : {}),
+      },
+    },
+  })
+
+  return { ...state, layouts: nextLayouts as Record<string, PaneNode> }
+}
+
 // Load persisted panes state directly at module initialization time
 // This ensures the initial state includes persisted data BEFORE the store is created.
 // Delegates to loadPersistedPanes() so that both Redux initial state and
@@ -233,6 +313,7 @@ function loadInitialPanesState(): PanesState {
       refreshRequestsByPane: {},
     }
     state = cleanOrphanedLayouts(state)
+    state = migrateLegacyAgentChatDisplaySettings(state)
     return state
   } catch (err) {
     log.error('Failed to load from localStorage:', err)

--- a/src/store/selectors/sidebarSelectors.ts
+++ b/src/store/selectors/sidebarSelectors.ts
@@ -69,6 +69,7 @@ export function buildSessionItems(
   worktreeGrouping: WorktreeGrouping = 'repo',
 ): SidebarSessionItem[] {
   const items: SidebarSessionItem[] = []
+  const itemsByKey = new Map<string, SidebarSessionItem>()
   const runningSessionMap = new Map<string, { terminalId: string; createdAt: number; allTerminalIds: string[] }>()
   const tabSessionMap = new Map<string, { hasTab: boolean }>()
 
@@ -108,7 +109,7 @@ export function buildSessionItems(
       const effectivePath = worktreeGrouping === 'worktree'
         ? (session.checkoutPath || project.projectPath)
         : project.projectPath
-      items.push({
+      const item: SidebarSessionItem = {
         id: `session-${provider}-${session.sessionId}`,
         sessionId: session.sessionId,
         provider,
@@ -129,11 +130,13 @@ export function buildSessionItems(
         isSubagent: session.isSubagent,
         isNonInteractive: session.isNonInteractive,
         firstUserMessage: session.firstUserMessage,
-      })
+        isFallback: undefined,
+      }
+      items.push(item)
+      itemsByKey.set(key, item)
     }
   }
 
-  const knownKeys = new Set(items.map((item) => `${item.provider}:${item.sessionId}`))
   const paneTitles = panes?.paneTitles ?? {}
 
   const pushFallbackItem = (input: {
@@ -146,14 +149,39 @@ export function buildSessionItems(
     metadata?: SessionListMetadata
   }) => {
     const key = `${input.provider}:${input.sessionId}`
-    if (knownKeys.has(key)) return
-    knownKeys.add(key)
+    const existing = itemsByKey.get(key)
+    if (existing) {
+      existing.hasTab = true
+      existing.timestamp = Math.max(existing.timestamp, input.timestamp ?? 0)
+      const fallbackTitle = input.title?.trim()
+      if (!existing.hasTitle && fallbackTitle) {
+        existing.title = fallbackTitle
+        existing.hasTitle = true
+      }
+      const fallbackSessionType = input.metadata?.sessionType || input.sessionType
+      if (fallbackSessionType && (!existing.sessionType || existing.sessionType === existing.provider)) {
+        existing.sessionType = fallbackSessionType
+      }
+      if (!existing.cwd && input.cwd) {
+        existing.cwd = input.cwd
+      }
+      if (!existing.firstUserMessage && input.metadata?.firstUserMessage) {
+        existing.firstUserMessage = input.metadata.firstUserMessage
+      }
+      if (existing.isSubagent === undefined && input.metadata?.isSubagent !== undefined) {
+        existing.isSubagent = input.metadata.isSubagent
+      }
+      if (existing.isNonInteractive === undefined && input.metadata?.isNonInteractive !== undefined) {
+        existing.isNonInteractive = input.metadata.isNonInteractive
+      }
+      return
+    }
 
     const fallbackTitle = input.title?.trim() || input.sessionId.slice(0, 8)
     const runningTerminal = runningSessionMap.get(key)
     const runningTerminalId = runningTerminal?.terminalId
     const runningTerminalIds = runningTerminal?.allTerminalIds
-    items.push({
+    const item: SidebarSessionItem = {
       id: `session-${input.provider}-${input.sessionId}`,
       sessionId: input.sessionId,
       provider: input.provider,
@@ -173,7 +201,9 @@ export function buildSessionItems(
       isNonInteractive: input.metadata?.isNonInteractive,
       firstUserMessage: input.metadata?.firstUserMessage,
       isFallback: true,
-    })
+    }
+    items.push(item)
+    itemsByKey.set(key, item)
   }
 
   const collectFallbackItemsFromNode = (
@@ -323,7 +353,7 @@ export function filterSessionItemsByVisibility(
     if (!settings.showSubagents && item.isSubagent) return false
     if (settings.ignoreCodexSubagents && item.isSubagent && item.provider === 'codex') return false
     if (shouldHideAsNonInteractive(item, settings.showNoninteractiveSessions)) return false
-    if (settings.hideEmptySessions && !item.hasTitle) return false
+    if (settings.hideEmptySessions && !item.hasTitle && !item.hasTab && !item.isRunning) return false
     if (isExcludedByFirstUserMessage(item.firstUserMessage, exclusions, settings.excludeFirstChatMustStart)) return false
     return true
   })

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -13,6 +13,7 @@ import terminalDirectoryReducer from './terminalDirectorySlice'
 import turnCompletionReducer from './turnCompletionSlice'
 import terminalMetaReducer from './terminalMetaSlice'
 import codexActivityReducer from './codexActivitySlice'
+import opencodeActivityReducer from './opencodeActivitySlice'
 import agentChatReducer from './agentChatSlice'
 import paneRuntimeActivityReducer from './paneRuntimeActivitySlice'
 import { networkReducer } from './networkSlice'
@@ -45,6 +46,7 @@ export const store = configureStore({
     turnCompletion: turnCompletionReducer,
     terminalMeta: terminalMetaReducer,
     codexActivity: codexActivityReducer,
+    opencodeActivity: opencodeActivityReducer,
     agentChat: agentChatReducer,
     paneRuntimeActivity: paneRuntimeActivityReducer,
     network: networkReducer,

--- a/test/browser_use/tool_coalesce.py
+++ b/test/browser_use/tool_coalesce.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Browser-use test for tool strip coalescing in Freshclaude.
+
+Verifies that consecutive tool uses in an assistant turn appear as ONE
+strip showing "N tools used" instead of multiple separate "1 tool used" strips.
+Uses an LLM as judge to evaluate the visual result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import logging
+import urllib.request
+from pathlib import Path
+
+# Add parent directory for shared utilities
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from smoke_utils import (
+  JsonLogger,
+  build_target_url,
+  default_base_url,
+  env_or,
+  find_upwards,
+  load_dotenv,
+  monotonic_timer,
+  redact_url,
+  redact_text,
+  require,
+  token_fingerprint,
+)
+
+
+def _parse_result(final_text: str) -> tuple[bool, str | None]:
+  """
+  Enforce strict output contract:
+  - Exactly one line
+  - Exactly "TOOL_COALESCE_RESULT: PASS"
+    or "TOOL_COALESCE_RESULT: FAIL - <short reason>"
+  """
+  text = (final_text or "").strip()
+  if not text:
+    return False, "missing_final_result"
+
+  lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+  if len(lines) != 1:
+    return False, "final_result_not_single_line"
+
+  line = lines[0]
+  if line == "TOOL_COALESCE_RESULT: PASS":
+    return True, None
+  if line.startswith("TOOL_COALESCE_RESULT: FAIL - ") and len(line) > len("TOOL_COALESCE_RESULT: FAIL - "):
+    return False, None
+  return False, "final_result_invalid_format"
+
+
+def _build_task(*, base_url: str) -> str:
+  return f"""
+You are testing the tool strip coalescing feature in a Freshell Freshclaude session.
+
+The app is already opened and authenticated at {base_url}.
+
+Your goal: Verify that when an assistant turn uses multiple tools, they appear grouped in ONE tool strip showing "N tools used" instead of multiple separate "1 tool used" strips.
+
+Steps:
+
+1. Open the sidebar if it's collapsed. Look for Freshclaude sessions (they have a different icon than shell tabs).
+
+2. Find and click on a Freshclaude session that has assistant messages with tool uses. Look for sessions that show tool indicators or message counts.
+
+3. If no session with multiple tool uses exists, skip to step 7 and report what you found.
+
+4. Once in a session, look at the assistant messages that contain tool uses. Find a message where the assistant used 2 or more tools in a single turn.
+
+5. Examine the tool strip display for that message:
+   - A tool strip should be visible showing either "N tools used" (collapsed) or individual tool blocks (expanded)
+   - Count how many separate tool-related text lines are visible (e.g., "1 tool used", "2 tools used", etc.)
+
+6. Judge the result:
+   - PASS: You see ONE tool strip per assistant turn, showing the combined count (e.g., "2 tools used" or "3 tools used")
+   - FAIL: You see MULTIPLE separate lines each showing "1 tool used" for tools that should be grouped
+
+7. Report your findings as exactly one line:
+   - If tool strips are correctly coalesced: TOOL_COALESCE_RESULT: PASS
+   - If you see multiple separate "1 tool used" strips: TOOL_COALESCE_RESULT: FAIL - multiple strips found
+   - If no suitable session found: TOOL_COALESCE_RESULT: FAIL - no session with tools
+
+Non-negotiable constraints:
+- Do not create or write any files
+- Stay in ONE browser tab
+- Output exactly one result line at the end
+"""
+
+
+async def _run(args: argparse.Namespace) -> int:
+  repo_root = Path(__file__).resolve().parents[2]
+  dotenv_path = find_upwards(repo_root, ".env")
+  dotenv = load_dotenv(dotenv_path) if dotenv_path else {}
+
+  log = JsonLogger(min_level=("debug" if args.debug else "info"))
+
+  if args.require_api_key and not os.environ.get("BROWSER_USE_API_KEY"):
+    log.error("Missing BROWSER_USE_API_KEY", event="missing_browser_use_api_key")
+    return 2
+
+  base_url = args.base_url or default_base_url(dotenv)
+  token = env_or(args.token, "AUTH_TOKEN") or dotenv.get("AUTH_TOKEN")
+  try:
+    token = require("AUTH_TOKEN", token)
+  except ValueError as e:
+    log.error(str(e), event="missing_auth_token")
+    return 2
+
+  model = env_or(args.model, "BROWSER_USE_MODEL") or "bu-latest"
+  target_url = build_target_url(base_url, token)
+  redacted_target_url = redact_url(target_url)
+
+  log.info(
+    "Tool coalesce test start",
+    event="test_start",
+    baseUrl=base_url,
+    tokenFp=token_fingerprint(token),
+    model=model,
+    headless=args.headless,
+  )
+
+  if args.preflight:
+    health_url = f"{base_url.rstrip('/')}/api/health"
+    try:
+      with urllib.request.urlopen(health_url, timeout=3) as resp:
+        log.info("Preflight ok", event="preflight_ok", url=health_url)
+    except Exception as e:
+      log.error("Preflight failed", event="preflight_failed", url=health_url, error=str(e))
+      return 1
+
+  from browser_use import Agent, Browser, ChatBrowserUse  # type: ignore
+
+  llm = ChatBrowserUse(model=model)
+  browser = Browser(
+    headless=args.headless,
+    window_size={"width": args.width, "height": args.height},
+    viewport={"width": args.width, "height": args.height},
+    no_viewport=False,
+  )
+  browser_started = False
+
+  try:
+    log.info("Pre-opening target URL", event="preopen_target", targetUrl=redacted_target_url)
+    await browser.start()
+    browser_started = True
+
+    # Navigate to authenticated URL
+    page = await browser.new_page(target_url)
+
+    log.info("Target URL opened", event="preopen_target_ok")
+  except Exception as e:
+    log.error("Failed to pre-open target URL", event="preopen_target_failed", error=str(e))
+    if browser_started:
+      try:
+        await browser.stop()
+      except Exception:
+        pass
+    return 1
+
+  task = _build_task(base_url=base_url)
+
+  agent = Agent(
+    task=task.strip(),
+    llm=llm,
+    browser=browser,
+    use_vision=True,
+    max_actions_per_step=2,
+    directly_open_url=False,
+  )
+
+  _start, elapsed_s = monotonic_timer()
+  try:
+    log.info("Agent run start", event="agent_run_start", maxSteps=args.max_steps)
+    history = await agent.run(max_steps=args.max_steps)
+  finally:
+    if browser_started:
+      try:
+        await browser.stop()
+      except Exception:
+        pass
+
+  log.info("Agent finished", event="agent_finished", elapsedS=round(elapsed_s(), 2))
+
+  final_result_fn = getattr(history, "final_result", None)
+  final = final_result_fn() if callable(final_result_fn) else None
+  final_text = str(final or "").strip()
+
+  ok, parse_err = _parse_result(final_text)
+  if parse_err:
+    log.error("Invalid final_result format", event="invalid_final_result", error=parse_err, text=final_text[:500])
+    return 1
+  if ok:
+    log.info("TOOL_COALESCE_RESULT: PASS", event="test_pass")
+    return 0
+  log.error("TOOL_COALESCE_RESULT: FAIL", event="test_fail", reason=final_text[:500])
+  return 1
+
+

--- a/test/browser_use/tool_coalesce.py
+++ b/test/browser_use/tool_coalesce.py
@@ -205,3 +205,37 @@ async def _run(args: argparse.Namespace) -> int:
   return 1
 
 
+def main(argv: list[str]) -> int:
+  p = argparse.ArgumentParser(description="browser_use test for tool strip coalescing in Freshell.")
+  p.add_argument("--base-url", default=None, help="Base URL (default: http://localhost:$VITE_PORT)")
+  p.add_argument("--token", default=None, help="Auth token (default: AUTH_TOKEN env or .env)")
+  p.add_argument("--model", default=None, help="Browser Use model (default: $BROWSER_USE_MODEL or bu-latest)")
+  p.add_argument("--headless", action="store_true", help="Run browser headless (default: headful)")
+  p.add_argument("--width", type=int, default=1024, help="Browser viewport width")
+  p.add_argument("--height", type=int, default=768, help="Browser viewport height")
+  p.add_argument("--max-steps", type=int, default=60, help="Max agent steps")
+  p.add_argument("--preflight", action="store_true", help="Fail fast if /api/health is unreachable")
+  p.add_argument("--debug", action="store_true", help="Enable debug logging")
+  p.add_argument(
+    "--no-require-api-key",
+    dest="require_api_key",
+    action="store_false",
+    help="Do not fail fast if BROWSER_USE_API_KEY is missing (may still fail later).",
+  )
+  p.set_defaults(require_api_key=True)
+  args = p.parse_args(argv)
+  try:
+    return asyncio.run(_run(args))
+  except KeyboardInterrupt:
+    return 130
+  except Exception:
+    import traceback
+    sys.stderr.write(traceback.format_exc())
+    sys.stderr.flush()
+    return 1
+
+
+if __name__ == "__main__":
+  raise SystemExit(main(sys.argv[1:]))
+
+

--- a/test/browser_use/tool_coalesce_test.py
+++ b/test/browser_use/tool_coalesce_test.py
@@ -1,0 +1,33 @@
+import unittest
+from tool_coalesce import _parse_result
+
+
+class ToolCoalesceParseTest(unittest.TestCase):
+  def test_pass_requires_exact_single_line(self) -> None:
+    ok, err = _parse_result("TOOL_COALESCE_RESULT: PASS")
+    self.assertTrue(ok)
+    self.assertIsNone(err)
+
+  def test_pass_with_extra_text_is_invalid(self) -> None:
+    ok, err = _parse_result("TOOL_COALESCE_RESULT: PASS. extra")
+    self.assertFalse(ok)
+    self.assertEqual(err, "final_result_invalid_format")
+
+  def test_fail_requires_reason(self) -> None:
+    ok, err = _parse_result("TOOL_COALESCE_RESULT: FAIL - multiple strips found")
+    self.assertFalse(ok)
+    self.assertIsNone(err)
+
+  def test_empty_is_invalid(self) -> None:
+    ok, err = _parse_result("")
+    self.assertFalse(ok)
+    self.assertEqual(err, "missing_final_result")
+
+  def test_multiple_lines_is_invalid(self) -> None:
+    ok, err = _parse_result("TOOL_COALESCE_RESULT: PASS\nmore")
+    self.assertFalse(ok)
+    self.assertEqual(err, "final_result_not_single_line")
+
+
+if __name__ == "__main__":
+  raise SystemExit(unittest.main())

--- a/test/e2e/agent-chat-context-menu-flow.test.tsx
+++ b/test/e2e/agent-chat-context-menu-flow.test.tsx
@@ -18,7 +18,8 @@ import agentChatReducer, {
   setSessionStatus,
 } from '@/store/agentChatSlice'
 import panesReducer from '@/store/panesSlice'
-import settingsReducer from '@/store/settingsSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
+import { defaultLocalSettings } from '@shared/settings'
 import type { AgentChatPaneContent } from '@/store/paneTypes'
 import { buildMenuItems, type MenuActions, type MenuBuildContext } from '@/components/context-menu/menu-defs'
 import type { ContextTarget } from '@/components/context-menu/context-menu-types'
@@ -41,6 +42,14 @@ function makeStore() {
       agentChat: agentChatReducer,
       panes: panesReducer,
       settings: settingsReducer,
+    },
+    preloadedState: {
+      settings: {
+        serverSettings: defaultSettings,
+        localSettings: { ...defaultLocalSettings, agentChat: { showThinking: false, showTools: true, showTimecodes: false } },
+        settings: { ...defaultSettings, agentChat: { ...defaultSettings.agentChat, showTools: true } },
+        loaded: false,
+      },
     },
   })
 }
@@ -147,7 +156,7 @@ describe('freshclaude context menu integration', () => {
       </Provider>,
     )
 
-    // Tool strips start expanded when showTools=true (default), so ToolBlock data attributes are in the DOM
+    // showTools=true via preloadedState, so ToolBlock data attributes are in the DOM
     const toolInputEl = container.querySelector('[data-tool-input]')
     expect(toolInputEl).not.toBeNull()
     expect(toolInputEl?.getAttribute('data-tool-name')).toBe('Bash')
@@ -198,7 +207,7 @@ describe('freshclaude context menu integration', () => {
       </Provider>,
     )
 
-    // Tool strips start expanded when showTools=true (default)
+    // showTools=true via preloadedState
     const diffEl = container.querySelector('[data-diff]')
     expect(diffEl).not.toBeNull()
     expect(diffEl?.getAttribute('data-file-path')).toBe('/tmp/test.ts')
@@ -241,7 +250,7 @@ describe('freshclaude context menu integration', () => {
       </Provider>,
     )
 
-    // Tool strips start expanded when showTools=true (default)
+    // showTools=true via preloadedState
     const toolOutputEl = container.querySelector('[data-tool-output]')
     expect(toolOutputEl).not.toBeNull()
 

--- a/test/e2e/agent-chat-polish-flow.test.tsx
+++ b/test/e2e/agent-chat-polish-flow.test.tsx
@@ -18,7 +18,8 @@ import agentChatReducer, {
   setSessionStatus,
 } from '@/store/agentChatSlice'
 import panesReducer from '@/store/panesSlice'
-import settingsReducer from '@/store/settingsSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
+import { defaultLocalSettings } from '@shared/settings'
 import type { AgentChatPaneContent } from '@/store/paneTypes'
 import type { ChatContentBlock } from '@/store/agentChatTypes'
 import { BROWSER_PREFERENCES_STORAGE_KEY } from '@/store/storage-keys'
@@ -49,6 +50,14 @@ function makeStore() {
       agentChat: agentChatReducer,
       panes: panesReducer,
       settings: settingsReducer,
+    },
+    preloadedState: {
+      settings: {
+        serverSettings: defaultSettings,
+        localSettings: { ...defaultLocalSettings, agentChat: { showThinking: false, showTools: true, showTimecodes: false } },
+        settings: { ...defaultSettings, agentChat: { ...defaultSettings.agentChat, showTools: true } },
+        loaded: false,
+      },
     },
   })
 }
@@ -174,7 +183,7 @@ describe('freshclaude polish e2e: tool block expand/collapse', () => {
     const toolButton = screen.getByRole('button', { name: /tool call/i })
     expect(toolButton).toBeInTheDocument()
 
-    // With showTools=true (default), ToolBlocks start expanded
+    // With showTools=true via preloadedState, ToolBlocks start expanded
     expect(toolButton).toHaveAttribute('aria-expanded', 'true')
 
     // Click to collapse
@@ -217,7 +226,7 @@ describe('freshclaude polish e2e: all tools expanded when showTools=true', () =>
     const toolButtons = screen.getAllByRole('button', { name: /tool call/i })
     expect(toolButtons).toHaveLength(5)
 
-    // All tools should start expanded when showTools=true (default)
+    // All tools should start expanded when showTools=true via preloadedState
     expect(toolButtons[0]).toHaveAttribute('aria-expanded', 'true')
     expect(toolButtons[1]).toHaveAttribute('aria-expanded', 'true')
     expect(toolButtons[2]).toHaveAttribute('aria-expanded', 'true')
@@ -354,7 +363,7 @@ describe('freshclaude polish e2e: diff view for Edit tool', () => {
       </Provider>,
     )
 
-    // Tool block should be present; with showTools=true (default), it starts expanded
+    // Tool block should be present; with showTools=true via preloadedState, it starts expanded
     const toolButton = screen.getByRole('button', { name: /tool call/i })
     expect(toolButton).toHaveAttribute('aria-expanded', 'true')
 
@@ -397,7 +406,7 @@ describe('freshclaude polish e2e: system-reminder stripping', () => {
       </Provider>,
     )
 
-    // ToolBlock should be expanded (showTools=true default)
+    // ToolBlock should be expanded (showTools=true via preloadedState)
     const toolButton = screen.getByRole('button', { name: /tool call/i })
     expect(toolButton).toHaveAttribute('aria-expanded', 'true')
 

--- a/test/e2e/open-tab-session-sidebar-visibility.test.tsx
+++ b/test/e2e/open-tab-session-sidebar-visibility.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import App from '@/App'
@@ -1148,6 +1148,80 @@ describe('open tab session sidebar visibility (e2e)', () => {
     await waitFor(() => {
       // The session should appear in the sidebar as a fallback item
       expect(screen.getAllByText('137 tour').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('keeps an open Codex session visible when the indexed sidebar row is titleless', async () => {
+    const sessionId = 'codex-current'
+    fetchSidebarSessionsSnapshot.mockResolvedValue({
+      projects: [
+        {
+          projectPath: '/repo',
+          sessions: [
+            {
+              provider: 'codex',
+              sessionId,
+              projectPath: '/repo',
+              lastActivityAt: 40,
+              title: undefined,
+              cwd: '/repo',
+            },
+          ],
+        },
+      ],
+      totalSessions: 1,
+      oldestIncludedTimestamp: 40,
+      oldestIncludedSessionId: `codex:${sessionId}`,
+      hasMore: false,
+    })
+
+    const store = createStore({
+      tabs: [{
+        id: 'tab-1',
+        title: 'Investigate sidebar visibility',
+        mode: 'codex',
+        resumeSessionId: sessionId,
+        createdAt: Date.now(),
+      }],
+      panes: {
+        layouts: {
+          'tab-1': {
+            type: 'leaf',
+            id: 'pane-1',
+            content: {
+              kind: 'terminal',
+              mode: 'codex',
+              createRequestId: 'req-1',
+              status: 'running',
+              resumeSessionId: sessionId,
+              initialCwd: '/repo',
+            },
+          },
+        },
+        activePane: { 'tab-1': 'pane-1' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Investigate sidebar visibility' } },
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>,
+    )
+
+    const sidebarList = await screen.findByTestId('sidebar-session-list')
+
+    await waitFor(() => {
+      expect(within(sidebarList).getAllByText('Investigate sidebar visibility').length).toBeGreaterThan(0)
+    })
+
+    act(() => {
+      broadcastWs({ type: 'sessions.changed', revision: 1 })
+    })
+
+    await waitFor(() => {
+      expect(fetchSidebarSessionsSnapshot).toHaveBeenCalled()
+      expect(within(sidebarList).getAllByText('Investigate sidebar visibility').length).toBeGreaterThan(0)
     })
   })
 })

--- a/test/e2e/pane-activity-indicator-flow.test.tsx
+++ b/test/e2e/pane-activity-indicator-flow.test.tsx
@@ -9,6 +9,10 @@ import panesReducer from '@/store/panesSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
 import codexActivityReducer from '@/store/codexActivitySlice'
+import opencodeActivityReducer, {
+  removeOpencodeActivity,
+  upsertOpencodeActivity,
+} from '@/store/opencodeActivitySlice'
 import agentChatReducer, { removePermission } from '@/store/agentChatSlice'
 import type { AgentChatState } from '@/store/agentChatTypes'
 import paneRuntimeActivityReducer, {
@@ -106,6 +110,7 @@ function renderHarness(options: RenderHarnessOptions) {
       settings: settingsReducer,
       turnCompletion: turnCompletionReducer,
       codexActivity: codexActivityReducer,
+      opencodeActivity: opencodeActivityReducer,
       agentChat: agentChatReducer,
       paneRuntimeActivity: paneRuntimeActivityReducer,
     },
@@ -138,6 +143,12 @@ function renderHarness(options: RenderHarnessOptions) {
         attentionByPane: {},
       },
       codexActivity: {
+        byTerminalId: {},
+        lastSnapshotSeq: 0,
+        liveMutationSeqByTerminalId: {},
+        removedMutationSeqByTerminalId: {},
+      },
+      opencodeActivity: {
         byTerminalId: {},
         lastSnapshotSeq: 0,
         liveMutationSeqByTerminalId: {},
@@ -305,6 +316,61 @@ describe('pane activity indicator flow (e2e)', () => {
 
     act(() => {
       store.dispatch(clearPaneRuntimeActivity({ paneId: 'pane-activity' }))
+    })
+
+    expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+    expect(within(getVisibleSinglePaneTab()).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+  })
+
+  it('shows OpenCode terminals blue only for exact terminal busy activity and clears on removal', () => {
+    const pane: TerminalPaneContent = {
+      kind: 'terminal',
+      createRequestId: 'req-opencode',
+      status: 'running',
+      mode: 'opencode',
+      shell: 'system',
+      terminalId: 'term-opencode',
+      resumeSessionId: 'session-opencode',
+    }
+
+    const { store } = renderHarness({
+      pane,
+      tab: {
+        mode: 'opencode',
+        terminalId: 'term-opencode',
+        resumeSessionId: 'session-opencode',
+      },
+    })
+
+    const paneHeader = screen.getByRole('banner', { name: 'Pane: Activity Pane' })
+    expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+    expect(within(getVisibleSinglePaneTab()).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+
+    act(() => {
+      store.dispatch(upsertOpencodeActivity({
+        terminals: [{ terminalId: 'term-foreign', phase: 'busy', updatedAt: 1 }],
+        mutationSeq: 1,
+      }))
+    })
+
+    expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+    expect(within(getVisibleSinglePaneTab()).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+
+    act(() => {
+      store.dispatch(upsertOpencodeActivity({
+        terminals: [{ terminalId: 'term-opencode', phase: 'busy', updatedAt: 2 }],
+        mutationSeq: 2,
+      }))
+    })
+
+    expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class')).toContain('text-blue-500')
+    expect(within(getVisibleSinglePaneTab()).getByTestId('pane-icon').getAttribute('class')).toContain('text-blue-500')
+
+    act(() => {
+      store.dispatch(removeOpencodeActivity({
+        terminalIds: ['term-opencode'],
+        mutationSeq: 3,
+      }))
     })
 
     expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')

--- a/test/e2e/tool-coalesce.test.tsx
+++ b/test/e2e/tool-coalesce.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import MessageBubble from '@/components/agent-chat/MessageBubble'
+import agentChatReducer, {
+  sessionCreated,
+  addAssistantMessage
+} from '@/store/agentChatSlice'
+import { BROWSER_PREFERENCES_STORAGE_KEY } from '@/store/storage-keys'
+
+vi.mock('@/components/markdown/LazyMarkdown', async () => {
+  const { MarkdownRenderer } = await import('@/components/markdown/MarkdownRenderer')
+  return {
+    LazyMarkdown: ({ content }: { content: string }) => (
+      <MarkdownRenderer content={content} />
+    ),
+  }
+})
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({
+    send: vi.fn(),
+    onReconnect: vi.fn(() => vi.fn()),
+  }),
+}))
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      agentChat: agentChatReducer,
+    },
+  })
+}
+
+describe('tool coalescing integration tests', () => {
+  afterEach(cleanup)
+  beforeEach(() => {
+    localStorage.removeItem(BROWSER_PREFERENCES_STORAGE_KEY)
+  })
+
+  describe('Priority 3.1: End-to-end tool strip rendering with coalesced messages', () => {
+    it('renders one tool strip showing "2 tools used" after coalescing', () => {
+      const store = makeStore()
+      store.dispatch(sessionCreated({ requestId: 'req-1', sessionId: 's1' }))
+      store.dispatch(addAssistantMessage({
+        sessionId: 's1',
+        content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+      }))
+      store.dispatch(addAssistantMessage({
+        sessionId: 's1',
+        content: [
+          { type: 'tool_result', tool_use_id: 't1', content: 'output' },
+          { type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } },
+        ],
+      }))
+      const session = store.getState().agentChat.sessions['s1']
+      expect(session.messages).toHaveLength(1)
+      expect(session.messages[0].content).toHaveLength(3)
+      render(
+        <Provider store={store}>
+          <MessageBubble
+            role="assistant"
+            content={session.messages[0].content}
+            showTools={false}
+          />
+        </Provider>,
+      )
+      expect(screen.getByText('2 tools used')).toBeInTheDocument()
+    })
+  })
+})

--- a/test/helpers/visible-first/protocol-harness.ts
+++ b/test/helpers/visible-first/protocol-harness.ts
@@ -225,10 +225,9 @@ export async function createProtocolHarness(options: ProtocolHarnessOptions = {}
   const handler = new WsHandler(
     server,
     registry as any,
-    undefined,
-    undefined,
-    undefined,
-    handshakeSnapshotProvider,
+    {
+      handshakeSnapshotProvider,
+    },
   )
   const { port } = await listen(server)
   const openClients = new Set<WebSocket>()

--- a/test/integration/server/codex-session-flow.test.ts
+++ b/test/integration/server/codex-session-flow.test.ts
@@ -197,7 +197,7 @@ describe('Codex Session Flow Integration', () => {
     server = http.createServer(app)
     registry = new TerminalRegistry()
     cliManager = new CodingCliSessionManager([codexProvider])
-    wsHandler = new WsHandler(server, registry, cliManager)
+    wsHandler = new WsHandler(server, registry, { codingCliManager: cliManager })
 
     await new Promise<void>((resolve) => {
       server.listen(0, '127.0.0.1', () => {

--- a/test/integration/server/session-metadata-api.test.ts
+++ b/test/integration/server/session-metadata-api.test.ts
@@ -68,6 +68,21 @@ describe('POST /api/session-metadata', () => {
     expect(mockRefresh).toHaveBeenCalled()
   })
 
+  it('preserves derivedTitle when the session metadata API updates sessionType', async () => {
+    await sessionMetadataStore.set('claude', 'sess-123', { derivedTitle: 'Sticky title' })
+
+    const res = await request(app)
+      .post('/api/session-metadata')
+      .set('x-auth-token', TEST_AUTH_TOKEN)
+      .send({ provider: 'claude', sessionId: 'sess-123', sessionType: 'agent' })
+
+    expect(res.status).toBe(200)
+    expect(await sessionMetadataStore.get('claude', 'sess-123')).toEqual({
+      sessionType: 'agent',
+      derivedTitle: 'Sticky title',
+    })
+  })
+
   it('returns 400 when provider is missing', async () => {
     const res = await request(app)
       .post('/api/session-metadata')

--- a/test/server/agent-run.test.ts
+++ b/test/server/agent-run.test.ts
@@ -1,4 +1,4 @@
-import { it, expect } from 'vitest'
+import { it, expect, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
 import { createAgentApiRouter } from '../../server/agent-api/router'
@@ -25,4 +25,37 @@ it('runs a command and returns captured output', async () => {
   const res = await request(app).post('/api/run').send({ command: 'echo done', capture: true })
   expect(res.body.status).toBe('ok')
   expect(res.body.data.output).toContain('done')
+})
+
+it('allocates and passes an OpenCode control endpoint for /api/run in opencode mode', async () => {
+  let buffer = ''
+  const registry = {
+    create: vi.fn(() => ({ terminalId: 'term1' })),
+    input: (_terminalId: string, data: string) => {
+      const match = data.match(/__FRESHELL_DONE_[A-Za-z0-9_-]+__/)
+      if (match) buffer = `done\n${match[0]}\n`
+      return true
+    },
+    get: () => ({ buffer: { snapshot: () => buffer }, status: 'running' }),
+  }
+
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { createTab: () => ({ tabId: 't1', paneId: 'p1' }), attachPaneContent: () => {} },
+    registry,
+  }))
+
+  const res = await request(app).post('/api/run').send({ command: 'echo done', capture: true, mode: 'opencode' })
+
+  expect(res.body.status).toBe('ok')
+  expect(registry.create).toHaveBeenCalledWith(expect.objectContaining({
+    mode: 'opencode',
+    providerSettings: expect.objectContaining({
+      opencodeServer: {
+        hostname: '127.0.0.1',
+        port: expect.any(Number),
+      },
+    }),
+  }))
 })

--- a/test/server/agent-tabs-write.test.ts
+++ b/test/server/agent-tabs-write.test.ts
@@ -51,6 +51,36 @@ describe('tab endpoints', () => {
     expect(layoutStore.attachPaneContent).toHaveBeenCalled()
   })
 
+  it('allocates and passes an OpenCode control endpoint when creating an opencode tab', async () => {
+    const app = express()
+    app.use(express.json())
+    const registry = new FakeRegistry()
+    const layoutStore = {
+      createTab: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+      attachPaneContent: () => {},
+      selectTab: () => ({}),
+      renameTab: () => ({}),
+      closeTab: () => ({}),
+      hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }),
+      selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry, wsHandler: { broadcastUiCommand: () => {} } }))
+
+    const res = await request(app).post('/api/tabs').send({ mode: 'opencode', name: 'OpenCode' })
+
+    expect(res.body.status).toBe('ok')
+    expect(registry.create).toHaveBeenCalledWith(expect.objectContaining({
+      mode: 'opencode',
+      providerSettings: expect.objectContaining({
+        opencodeServer: {
+          hostname: '127.0.0.1',
+          port: expect.any(Number),
+        },
+      }),
+    }))
+  })
+
   it('rejects blank tab rename payloads', async () => {
     const app = express()
     app.use(express.json())

--- a/test/server/session-association.test.ts
+++ b/test/server/session-association.test.ts
@@ -30,6 +30,19 @@ const SESSION_ID_SIX = '4b1c3d2e-5f6a-7b8c-9d0e-1f2a3b4c5d6e'
 const SESSION_ID_SEVEN = '5c2d4e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f'
 const SESSION_ID_EIGHT = '6d3e5f7a-8b9c-0d1e-2f3a-4b5c6d7e8f90'
 
+function withOpencodeServer<T extends { providerSettings?: Record<string, unknown> }>(options: T): T {
+  return {
+    ...options,
+    providerSettings: {
+      ...(options.providerSettings ?? {}),
+      opencodeServer: {
+        hostname: '127.0.0.1',
+        port: 41001,
+      },
+    },
+  }
+}
+
 function createMetadataService() {
   let now = 1_000
   return new TerminalMetadataService({
@@ -851,7 +864,7 @@ describe('Codex Session-Terminal Association via onUpdate', () => {
     const registry = new TerminalRegistry()
     const broadcasts: any[] = []
 
-    const term = registry.create({ mode: 'opencode', cwd: '/home/user/project' })
+    const term = registry.create(withOpencodeServer({ mode: 'opencode', cwd: '/home/user/project' }))
 
     associateOnUpdate(registry, [{
       projectPath: '/home/user/project',

--- a/test/server/ws-coding-cli-events.test.ts
+++ b/test/server/ws-coding-cli-events.test.ts
@@ -64,7 +64,7 @@ describe('WebSocket Coding CLI Events', () => {
     server = http.createServer(app)
     registry = new TerminalRegistry()
     cliManager = new CodingCliSessionManager([claudeProvider])
-    wsHandler = new WsHandler(server, registry, cliManager)
+    wsHandler = new WsHandler(server, registry, { codingCliManager: cliManager })
 
     await new Promise<void>((resolve) => {
       server.listen(0, '127.0.0.1', () => {
@@ -251,7 +251,7 @@ describe('WebSocket Coding CLI Events', () => {
     } as unknown as CodingCliSessionManager
 
     wsHandler.close()
-    wsHandler = new WsHandler(server, registry, fakeManager)
+    wsHandler = new WsHandler(server, registry, { codingCliManager: fakeManager })
 
     vi.mocked(configStore.snapshot).mockResolvedValueOnce({
       settings: {

--- a/test/server/ws-extension-registry.test.ts
+++ b/test/server/ws-extension-registry.test.ts
@@ -98,6 +98,7 @@ function closeWebSocket(ws: WebSocket, timeoutMs = 500): Promise<void> {
 
 class FakeRegistry {
   detach() { return true }
+  list() { return [] }
 }
 
 const fakeExtensions = [
@@ -145,15 +146,9 @@ describe('ws extension registry', () => {
     new (WsHandler as any)(
       server,
       new FakeRegistry() as any,
-      undefined, // codingCliManager
-      undefined, // sdkBridge
-      undefined, // sessionRepairService
-      undefined, // handshakeSnapshotProvider
-      undefined, // terminalMetaListProvider
-      undefined, // tabsRegistryStore
-      undefined, // serverInstanceId
-      undefined, // layoutStore
-      new FakeExtensionManager() as any, // extensionManager
+      {
+        extensionManager: new FakeExtensionManager() as any,
+      },
     )
 
     const info = await listen(server)

--- a/test/server/ws-handshake-snapshot.test.ts
+++ b/test/server/ws-handshake-snapshot.test.ts
@@ -188,10 +188,9 @@ describe('ws handshake snapshot', () => {
     new (WsHandler as any)(
       server,
       new FakeRegistry() as any,
-      undefined,
-      undefined,
-      undefined,
-      async () => snapshot
+      {
+        handshakeSnapshotProvider: async () => snapshot,
+      },
     )
 
     const info = await listen(server)

--- a/test/server/ws-opencode-activity.test.ts
+++ b/test/server/ws-opencode-activity.test.ts
@@ -82,20 +82,20 @@ class FakeRegistry {
   findRunningClaudeTerminalBySession() { return undefined }
 }
 
-describe('ws codex activity protocol', () => {
+describe('ws opencode activity protocol', () => {
   let server: http.Server
   let port: number
   let wsHandler: any
   const sampleActivity = [{
-    terminalId: 'term-1',
-    sessionId: 'session-1',
+    terminalId: 'term-opencode-1',
+    sessionId: 'session-opencode-1',
     phase: 'busy',
     updatedAt: 1234,
   }]
 
   beforeAll(async () => {
     process.env.NODE_ENV = 'test'
-    process.env.AUTH_TOKEN = 'codex-activity-token'
+    process.env.AUTH_TOKEN = 'opencode-activity-token'
 
     const { WsHandler } = await import('../../server/ws-handler')
     server = http.createServer((_req, res) => {
@@ -106,7 +106,7 @@ describe('ws codex activity protocol', () => {
       server,
       new FakeRegistry() as any,
       {
-        codexActivityListProvider: () => sampleActivity as any,
+        opencodeActivityListProvider: () => sampleActivity as any,
       },
     )
     port = await listen(server)
@@ -117,43 +117,43 @@ describe('ws codex activity protocol', () => {
     await new Promise<void>((resolve) => server.close(() => resolve()))
   })
 
-  it('returns codex.activity.list.response for codex.activity.list requests', async () => {
+  it('returns opencode.activity.list.response for opencode.activity.list requests', async () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
     await new Promise<void>((resolve) => ws.on('open', () => resolve()))
-    ws.send(JSON.stringify({ type: 'hello', token: 'codex-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
+    ws.send(JSON.stringify({ type: 'hello', token: 'opencode-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
     await waitForMessage(ws, (msg) => msg.type === 'ready')
 
-    ws.send(JSON.stringify({ type: 'codex.activity.list', requestId: 'req-codex-1' }))
+    ws.send(JSON.stringify({ type: 'opencode.activity.list', requestId: 'req-opencode-1' }))
     const response = await waitForMessage(
       ws,
-      (msg) => msg.type === 'codex.activity.list.response' && msg.requestId === 'req-codex-1',
+      (msg) => msg.type === 'opencode.activity.list.response' && msg.requestId === 'req-opencode-1',
     )
 
     expect(response.terminals).toEqual(sampleActivity)
     ws.close()
   })
 
-  it('broadcasts codex.activity.updated payloads', async () => {
+  it('broadcasts opencode.activity.updated payloads', async () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
     await new Promise<void>((resolve) => ws.on('open', () => resolve()))
-    ws.send(JSON.stringify({ type: 'hello', token: 'codex-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
+    ws.send(JSON.stringify({ type: 'hello', token: 'opencode-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
     await waitForMessage(ws, (msg) => msg.type === 'ready')
 
-    wsHandler.broadcastCodexActivityUpdated({
+    wsHandler.broadcastOpencodeActivityUpdated({
       upsert: sampleActivity as any,
       remove: [],
     })
 
-    const updated = await waitForMessage(ws, (msg) => msg.type === 'codex.activity.updated')
+    const updated = await waitForMessage(ws, (msg) => msg.type === 'opencode.activity.updated')
     expect(updated).toEqual({
-      type: 'codex.activity.updated',
+      type: 'opencode.activity.updated',
       upsert: sampleActivity,
       remove: [],
     })
     ws.close()
   })
 
-  it('does not broadcast codex.activity.updated payloads to unauthenticated sockets', async () => {
+  it('does not broadcast opencode.activity.updated payloads to unauthenticated sockets', async () => {
     const authenticated = new WebSocket(`ws://127.0.0.1:${port}/ws`)
     const unauthenticated = new WebSocket(`ws://127.0.0.1:${port}/ws`)
 
@@ -162,22 +162,22 @@ describe('ws codex activity protocol', () => {
       new Promise<void>((resolve) => unauthenticated.on('open', () => resolve())),
     ])
 
-    authenticated.send(JSON.stringify({ type: 'hello', token: 'codex-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
+    authenticated.send(JSON.stringify({ type: 'hello', token: 'opencode-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
     await waitForMessage(authenticated, (msg) => msg.type === 'ready')
 
-    wsHandler.broadcastCodexActivityUpdated({
+    wsHandler.broadcastOpencodeActivityUpdated({
       upsert: sampleActivity as any,
       remove: [],
     })
 
-    const updated = await waitForMessage(authenticated, (msg) => msg.type === 'codex.activity.updated')
+    const updated = await waitForMessage(authenticated, (msg) => msg.type === 'opencode.activity.updated')
     expect(updated).toEqual({
-      type: 'codex.activity.updated',
+      type: 'opencode.activity.updated',
       upsert: sampleActivity,
       remove: [],
     })
 
-    await expect(expectNoMatchingMessage(unauthenticated, (msg) => msg.type === 'codex.activity.updated')).resolves.toBeUndefined()
+    await expect(expectNoMatchingMessage(unauthenticated, (msg) => msg.type === 'opencode.activity.updated')).resolves.toBeUndefined()
 
     authenticated.close()
     unauthenticated.close()

--- a/test/server/ws-session-repair-activity.test.ts
+++ b/test/server/ws-session-repair-activity.test.ts
@@ -62,7 +62,7 @@ describe('ws session repair activity', () => {
     sessionRepairService = new FakeSessionRepairService()
     const registry = new FakeRegistry()
 
-    new WsHandler(server, registry as any, undefined, undefined, sessionRepairService as any)
+    new WsHandler(server, registry as any, { sessionRepairService: sessionRepairService as any })
     const info = await listen(server)
     port = info.port
   }, HOOK_TIMEOUT_MS)

--- a/test/server/ws-sidebar-snapshot-refresh.test.ts
+++ b/test/server/ws-sidebar-snapshot-refresh.test.ts
@@ -12,6 +12,10 @@ class FakeRegistry {
   detach() {
     return true
   }
+
+  list() {
+    return []
+  }
 }
 
 function listen(server: http.Server, timeoutMs = HOOK_TIMEOUT_MS): Promise<{ port: number }> {
@@ -96,29 +100,26 @@ describe('ws sidebar snapshot refresh', () => {
     wsHandler = new (WsHandler as any)(
       server,
       new FakeRegistry() as any,
-      undefined,
-      undefined,
-      undefined,
-      async () => ({
-        settings: { theme: 'dark' },
-        projects: [
-          {
-            projectPath: '/demo',
-            sessions: [
-              {
-                provider: 'claude',
-                sessionId: 'older-open',
-                projectPath: '/demo',
-                lastActivityAt: 10,
-              },
-            ],
-          },
-        ],
-      }),
-      undefined,
-      undefined,
-      'srv-local',
-      new (LayoutStore as any)(),
+      {
+        handshakeSnapshotProvider: async () => ({
+          settings: { theme: 'dark' },
+          projects: [
+            {
+              projectPath: '/demo',
+              sessions: [
+                {
+                  provider: 'claude',
+                  sessionId: 'older-open',
+                  projectPath: '/demo',
+                  lastActivityAt: 10,
+                },
+              ],
+            },
+          ],
+        }),
+        serverInstanceId: 'srv-local',
+        layoutStore: new (LayoutStore as any)(),
+      },
     )
 
     const info = await listen(server)

--- a/test/server/ws-tabs-registry.test.ts
+++ b/test/server/ws-tabs-registry.test.ts
@@ -106,12 +106,9 @@ describe('ws tabs registry protocol', () => {
     wsHandler = new WsHandler(
       server,
       new FakeRegistry() as any,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      tabsStore,
+      {
+        tabsRegistryStore: tabsStore,
+      },
     )
     port = await listen(server)
   })

--- a/test/server/ws-terminal-create-session-repair.test.ts
+++ b/test/server/ws-terminal-create-session-repair.test.ts
@@ -293,7 +293,7 @@ describe('terminal.create session repair wait', () => {
 
     sessionRepairService = new FakeSessionRepairService()
     registry = new FakeRegistry()
-    new WsHandler(server, registry as any, undefined, undefined, sessionRepairService as any)
+    new WsHandler(server, registry as any, { sessionRepairService: sessionRepairService as any })
 
     const info = await listen(server)
     port = info.port

--- a/test/server/ws-terminal-meta.test.ts
+++ b/test/server/ws-terminal-meta.test.ts
@@ -101,11 +101,9 @@ describe('ws terminal metadata protocol', () => {
     wsHandler = new WsHandler(
       server,
       new FakeRegistry() as any,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      () => sampleMeta as any,
+      {
+        terminalMetaListProvider: () => sampleMeta as any,
+      },
     )
     port = await listen(server)
   })

--- a/test/unit/client/agentChatSlice.test.ts
+++ b/test/unit/client/agentChatSlice.test.ts
@@ -466,3 +466,106 @@ describe('tool message coalescing', () => {
     expect(state.sessions['s1'].messages).toHaveLength(3) // assistant, user, assistant
   })
 })
+
+describe('tool coalescing edge cases', () => {
+  const initial = agentChatReducer(undefined, { type: 'init' })
+
+  it('empty content array does not trigger coalescing', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(2)
+  })
+
+  it('thinking block breaks coalescing', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'thinking', thinking: 'Let me think...' }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(2)
+  })
+
+  it('session not found returns early without modification', () => {
+    const state = agentChatReducer(initial, addAssistantMessage({
+      sessionId: 'nonexistent',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    expect(state).toEqual(initial)
+  })
+})
+
+describe('tool coalescing invariants', () => {
+  const initial = agentChatReducer(undefined, { type: 'init' })
+
+  it('message order preserved after coalescing', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_result', tool_use_id: 't1', content: 'output' }],
+    }))
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } }],
+    }))
+
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+    expect(state.sessions['s1'].messages[0].content[0]).toEqual({ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } })
+    expect(state.sessions['s1'].messages[0].content[1]).toEqual({ type: 'tool_result', tool_use_id: 't1', content: 'output' })
+    expect(state.sessions['s1'].messages[0].content[2]).toEqual({ type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } })
+  })
+
+  it('model preserved from first message in coalesced group', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+      model: 'claude-opus-4-6',
+    }))
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_result', tool_use_id: 't1', content: 'output' }],
+    }))
+
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+    expect(state.sessions['s1'].messages[0].model).toBe('claude-opus-4-6')
+  })
+
+  it('status updated to running after coalescing', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+    state = agentChatReducer(state, setSessionStatus({ sessionId: 's1', status: 'idle' }))
+
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_result', tool_use_id: 't1', content: 'output' }],
+    }))
+
+    expect(state.sessions['s1'].status).toBe('running')
+  })
+})

--- a/test/unit/client/agentChatSlice.test.ts
+++ b/test/unit/client/agentChatSlice.test.ts
@@ -361,3 +361,108 @@ describe('agentChatSlice', () => {
     expect(state.sessions['s1'].totalInputTokens).toBe(100)
   })
 })
+
+describe('tool message coalescing', () => {
+  const initial = agentChatReducer(undefined, { type: 'init' })
+
+  it('coalesces consecutive tool-only assistant messages', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+
+    // First tool-only message
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+
+    // Second tool-only message - should coalesce
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [
+        { type: 'tool_result', tool_use_id: 't1', content: 'output' },
+        { type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } },
+      ],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+    expect(state.sessions['s1'].messages[0].content).toHaveLength(3)
+    expect(state.sessions['s1'].messages[0].content[0]).toEqual({ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } })
+    expect(state.sessions['s1'].messages[0].content[1]).toEqual({ type: 'tool_result', tool_use_id: 't1', content: 'output' })
+    expect(state.sessions['s1'].messages[0].content[2]).toEqual({ type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } })
+  })
+
+  it('does not coalesce when previous message has text content', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+
+    // Message with text
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'text', text: 'Hello' }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+
+    // Tool-only message - should NOT coalesce (previous has text)
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(2)
+  })
+
+  it('does not coalesce when new message has text content', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+
+    // Tool-only message
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+
+    // Message with text - should NOT coalesce (new has text)
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'text', text: 'Done' }],
+    }))
+    expect(state.sessions['s1'].messages).toHaveLength(2)
+  })
+
+  it('coalesces multiple consecutive tool-only messages', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_result', tool_use_id: 't1', content: 'file1' }],
+    }))
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } }],
+    }))
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_result', tool_use_id: 't2', content: 'content' }],
+    }))
+
+    expect(state.sessions['s1'].messages).toHaveLength(1)
+    expect(state.sessions['s1'].messages[0].content).toHaveLength(4)
+  })
+
+  it('does not coalesce across user messages', () => {
+    let state = agentChatReducer(initial, sessionCreated({ requestId: 'r', sessionId: 's1' }))
+
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+    }))
+    state = agentChatReducer(state, addUserMessage({ sessionId: 's1', text: 'Thanks' }))
+    state = agentChatReducer(state, addAssistantMessage({
+      sessionId: 's1',
+      content: [{ type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } }],
+    }))
+
+    expect(state.sessions['s1'].messages).toHaveLength(3) // assistant, user, assistant
+  })
+})

--- a/test/unit/client/components/App.ws-bootstrap.test.tsx
+++ b/test/unit/client/components/App.ws-bootstrap.test.tsx
@@ -13,6 +13,7 @@ import terminalMetaReducer from '@/store/terminalMetaSlice'
 import extensionsReducer from '@/store/extensionsSlice'
 import { networkReducer } from '@/store/networkSlice'
 import codexActivityReducer, { type CodexActivityState } from '@/store/codexActivitySlice'
+import opencodeActivityReducer, { type OpencodeActivityState } from '@/store/opencodeActivitySlice'
 import { makeSelectSortedSessionItems } from '@/store/selectors/sidebarSelectors'
 import {
   composeResolvedSettings,
@@ -129,9 +130,16 @@ function createStore(options?: {
     zoomedPane?: Record<string, string>
   }
   codexActivity?: Partial<CodexActivityState>
+  opencodeActivity?: Partial<OpencodeActivityState>
   sessions?: Record<string, unknown>
 }) {
   const defaultCodexActivity: CodexActivityState = {
+    byTerminalId: {},
+    lastSnapshotSeq: 0,
+    liveMutationSeqByTerminalId: {},
+    removedMutationSeqByTerminalId: {},
+  }
+  const defaultOpencodeActivity: OpencodeActivityState = {
     byTerminalId: {},
     lastSnapshotSeq: 0,
     liveMutationSeqByTerminalId: {},
@@ -156,6 +164,7 @@ function createStore(options?: {
       panes: panesReducer,
       network: networkReducer,
       codexActivity: codexActivityReducer,
+      opencodeActivity: opencodeActivityReducer,
       tabRegistry: tabRegistryReducer,
       terminalMeta: terminalMetaReducer,
       extensions: extensionsReducer,
@@ -187,6 +196,10 @@ function createStore(options?: {
       codexActivity: {
         ...defaultCodexActivity,
         ...(options?.codexActivity ?? {}),
+      },
+      opencodeActivity: {
+        ...defaultOpencodeActivity,
+        ...(options?.opencodeActivity ?? {}),
       },
       tabRegistry: {
         deviceId: 'device-test',
@@ -535,6 +548,7 @@ describe('App WS bootstrap recovery', () => {
     expect(bootstrapCalls).toBe(2)
     expect(sidebarCalls).toBe(2)
     expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'codex.activity.list' }))
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'opencode.activity.list' }))
   })
 
   it('repairs missing bootstrap platform capabilities from /api/platform after websocket readiness', async () => {
@@ -752,6 +766,40 @@ describe('App WS bootstrap recovery', () => {
     })
 
     expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'codex.activity.list' }))
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'opencode.activity.list' }))
+  })
+
+  it('clears stale opencode activity immediately when bootstrap attaches to an already-ready socket', async () => {
+    const store = createStore({
+      opencodeActivity: {
+        byTerminalId: {
+          'term-stale': {
+            terminalId: 'term-stale',
+            sessionId: 'session-stale',
+            phase: 'busy',
+            updatedAt: 10,
+          },
+        },
+        lastSnapshotSeq: 4,
+        liveMutationSeqByTerminalId: { 'term-stale': 4 },
+      },
+    })
+    wsMocks.isReady = true
+    wsMocks.serverInstanceId = 'srv-preconnected-opencode-stale'
+
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(store.getState().connection.status).toBe('ready')
+      expect(store.getState().connection.serverInstanceId).toBe('srv-preconnected-opencode-stale')
+      expect(store.getState().opencodeActivity.byTerminalId).toEqual({})
+    })
+
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'opencode.activity.list' }))
   })
 
   it('mounts with legacy ws clients that do not implement onDisconnect', async () => {
@@ -819,6 +867,48 @@ describe('App WS bootstrap recovery', () => {
     })
   })
 
+  it('clears opencode activity promptly when the websocket disconnects after readiness', async () => {
+    const store = createStore()
+    wsMocks.isReady = true
+    wsMocks.serverInstanceId = 'srv-preconnected-opencode-disconnect'
+
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(store.getState().connection.status).toBe('ready')
+    })
+
+    act(() => {
+      messageHandler?.({
+        type: 'opencode.activity.updated',
+        upsert: [{
+          terminalId: 'term-live',
+          sessionId: 'session-live',
+          phase: 'busy',
+          updatedAt: 20,
+        }],
+        remove: [],
+      })
+    })
+
+    await waitFor(() => {
+      expect(store.getState().opencodeActivity.byTerminalId['term-live']?.phase).toBe('busy')
+    })
+
+    act(() => {
+      disconnectHandler?.()
+    })
+
+    await waitFor(() => {
+      expect(store.getState().connection.status).toBe('disconnected')
+      expect(store.getState().opencodeActivity.byTerminalId).toEqual({})
+    })
+  })
+
   it('keeps the WS message handler registered after an initial connect failure, so a later ready can recover state', async () => {
     const store = createStore()
 
@@ -853,6 +943,7 @@ describe('App WS bootstrap recovery', () => {
 
     expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'terminal.meta.list' }))
     expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'codex.activity.list' }))
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'opencode.activity.list' }))
   })
 
   it('dispatches wsCloseCode to lastErrorCode in Redux when connect rejects with close code', async () => {
@@ -1043,6 +1134,7 @@ describe('App WS bootstrap recovery', () => {
     expect(wsMocks.connect).not.toHaveBeenCalled()
     expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'terminal.meta.list' }))
     expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'codex.activity.list' }))
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'opencode.activity.list' }))
     expect(fetchSidebarSessionsSnapshot).not.toHaveBeenCalled()
     expect(store.getState().sessions.projects.map((p: any) => p.projectPath)).toEqual(['/p1'])
 
@@ -1130,6 +1222,7 @@ describe('App WS bootstrap recovery', () => {
     expect(wsMocks.connect).not.toHaveBeenCalled()
     expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'terminal.meta.list' }))
     expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'codex.activity.list' }))
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'opencode.activity.list' }))
   })
 
   it('keeps the active non-sidebar session surface during websocket recovery when the sidebar window is already loaded', async () => {
@@ -1243,5 +1336,61 @@ describe('App WS bootstrap recovery', () => {
     })
 
     expect(store.getState().codexActivity.byTerminalId['term-1']?.phase).toBe('idle')
+  })
+
+  it('ignores stale opencode activity list responses that arrive after a newer snapshot', async () => {
+    const store = createStore()
+    wsMocks.isReady = true
+    wsMocks.serverInstanceId = 'srv-preconnected-opencode-race'
+
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    )
+
+    expect(messageHandler).toBeTypeOf('function')
+    act(() => {
+      messageHandler?.({
+        type: 'ready',
+        timestamp: new Date().toISOString(),
+        serverInstanceId: 'srv-preconnected-opencode-race',
+      })
+    })
+
+    await waitFor(() => {
+      const requests = wsMocks.send.mock.calls
+        .map(([payload]) => payload)
+        .filter((payload) => payload?.type === 'opencode.activity.list')
+      expect(requests.length).toBeGreaterThanOrEqual(2)
+    })
+
+    const requests = wsMocks.send.mock.calls
+      .map(([payload]) => payload)
+      .filter((payload) => payload?.type === 'opencode.activity.list')
+    const olderRequestId = requests[0]?.requestId as string
+    const newerRequestId = requests.at(-1)?.requestId as string
+
+    act(() => {
+      messageHandler?.({
+        type: 'opencode.activity.list.response',
+        requestId: newerRequestId,
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 200,
+          },
+        ],
+      })
+      messageHandler?.({
+        type: 'opencode.activity.list.response',
+        requestId: olderRequestId,
+        terminals: [],
+      })
+    })
+
+    expect(store.getState().opencodeActivity.byTerminalId['term-1']?.phase).toBe('busy')
   })
 })

--- a/test/unit/client/components/MobileTabStrip.test.tsx
+++ b/test/unit/client/components/MobileTabStrip.test.tsx
@@ -7,6 +7,7 @@ import panesReducer from '@/store/panesSlice'
 import connectionReducer from '@/store/connectionSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import codexActivityReducer, { type CodexActivityState } from '@/store/codexActivitySlice'
+import opencodeActivityReducer, { type OpencodeActivityState } from '@/store/opencodeActivitySlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
 import type { Tab } from '@/store/types'
 import type { PaneNode } from '@/store/paneTypes'
@@ -56,7 +57,12 @@ function createLeafLayout(tab: Tab): PaneNode {
 function createStore(
   tabs: Tab[],
   activeTabId: string,
-  opts?: { codexActivity?: Partial<CodexActivityState>; includeCodexActivity?: boolean },
+  opts?: {
+    codexActivity?: Partial<CodexActivityState>
+    opencodeActivity?: Partial<OpencodeActivityState>
+    includeCodexActivity?: boolean
+    includeOpencodeActivity?: boolean
+  },
 ) {
   const layouts: Record<string, PaneNode> = {}
   const activePane: Record<string, string> = {}
@@ -72,6 +78,13 @@ function createStore(
     liveMutationSeqByTerminalId: {},
     removedMutationSeqByTerminalId: {},
   }
+  const includeOpencodeActivity = opts?.includeOpencodeActivity ?? true
+  const defaultOpencodeActivity: OpencodeActivityState = {
+    byTerminalId: {},
+    lastSnapshotSeq: 0,
+    liveMutationSeqByTerminalId: {},
+    removedMutationSeqByTerminalId: {},
+  }
 
   const reducer = {
     tabs: tabsReducer,
@@ -80,6 +93,7 @@ function createStore(
     settings: settingsReducer,
     turnCompletion: turnCompletionReducer,
     ...(includeCodexActivity ? { codexActivity: codexActivityReducer } : {}),
+    ...(includeOpencodeActivity ? { opencodeActivity: opencodeActivityReducer } : {}),
   }
   const preloadedState: Record<string, unknown> = {
     tabs: {
@@ -111,6 +125,12 @@ function createStore(
     preloadedState.codexActivity = {
       ...defaultCodexActivity,
       ...(opts?.codexActivity ?? {}),
+    }
+  }
+  if (includeOpencodeActivity) {
+    preloadedState.opencodeActivity = {
+      ...defaultOpencodeActivity,
+      ...(opts?.opencodeActivity ?? {}),
     }
   }
 
@@ -336,6 +356,37 @@ describe('MobileTabStrip', () => {
     expect(badge.className).toContain('bg-blue-500/15')
     expect(badge.className).toContain('text-blue-600')
     expect(badge.className).not.toContain('animate-pulse')
+  })
+
+  it('shows a busy badge when the active opencode tab has exact busy activity', async () => {
+    const { MobileTabStrip } = await import('@/components/MobileTabStrip')
+    const opencodeTab = createTab('tab-1', 'OpenCode', {
+      mode: 'opencode',
+      terminalId: 'term-opencode',
+    })
+    const store = createStore([opencodeTab], 'tab-1', {
+      opencodeActivity: {
+        byTerminalId: {
+          'term-opencode': {
+            terminalId: 'term-opencode',
+            sessionId: 'session-opencode',
+            phase: 'busy',
+            updatedAt: 10,
+          },
+        },
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <MobileTabStrip />
+      </Provider>
+    )
+
+    const badge = screen.getByTestId('mobile-tab-busy-badge')
+    expect(badge).toHaveTextContent('Busy')
+    expect(badge.className).toContain('bg-blue-500/15')
+    expect(badge.className).toContain('text-blue-600')
   })
 
   it('does not warn about selector instability when codex activity state is absent', async () => {

--- a/test/unit/client/components/SettingsView.agent-chat.test.tsx
+++ b/test/unit/client/components/SettingsView.agent-chat.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen, fireEvent, act } from '@testing-library/react'
+import {
+  createSettingsViewStore,
+  installSettingsViewHooks,
+  renderSettingsView,
+  switchSettingsTab,
+} from './settings-view-test-utils'
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    patch: vi.fn().mockResolvedValue({}),
+    get: vi.fn().mockResolvedValue({}),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+  },
+}))
+
+installSettingsViewHooks({ fakeTimers: true, mockFonts: true })
+
+function getToggle(labelText: string) {
+  const label = screen.getByText(labelText)
+  const row = label.closest('div[class*="flex"]')
+  if (!row) throw new Error(`Row with label "${labelText}" not found`)
+  return row.querySelector('[role="switch"]') as HTMLElement
+}
+
+describe('SettingsView agent chat settings', () => {
+  it('renders the Agent chat section on the Workspace tab', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    expect(screen.getByRole('heading', { name: 'Agent chat' })).toBeInTheDocument()
+    expect(screen.getByText('Display settings for agent chat panes')).toBeInTheDocument()
+  })
+
+  it('renders Show thinking, Show tools, and Show timecodes toggles', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    expect(getToggle('Show thinking')).toBeInTheDocument()
+    expect(getToggle('Show tools')).toBeInTheDocument()
+    expect(getToggle('Show timecodes & model')).toBeInTheDocument()
+  })
+
+  it('all agent chat toggles default to unchecked (off)', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    expect(getToggle('Show thinking')).toHaveAttribute('aria-checked', 'false')
+    expect(getToggle('Show tools')).toHaveAttribute('aria-checked', 'false')
+    expect(getToggle('Show timecodes & model')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('reflects current agentChat settings when preloaded', () => {
+    const store = createSettingsViewStore({
+      settings: { agentChat: { showThinking: true, showTools: true, showTimecodes: true } },
+    })
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    expect(getToggle('Show thinking')).toHaveAttribute('aria-checked', 'true')
+    expect(getToggle('Show tools')).toHaveAttribute('aria-checked', 'true')
+    expect(getToggle('Show timecodes & model')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('toggling Show thinking updates the store to true', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    fireEvent.click(getToggle('Show thinking'))
+
+    expect(store.getState().settings.settings.agentChat.showThinking).toBe(true)
+  })
+
+  it('toggling Show tools updates the store to true', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    fireEvent.click(getToggle('Show tools'))
+
+    expect(store.getState().settings.settings.agentChat.showTools).toBe(true)
+  })
+
+  it('toggling Show timecodes updates the store to true', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    fireEvent.click(getToggle('Show timecodes & model'))
+
+    expect(store.getState().settings.settings.agentChat.showTimecodes).toBe(true)
+  })
+
+  it('toggling off a previously-on setting sets it to false', () => {
+    const store = createSettingsViewStore({
+      settings: { agentChat: { showThinking: true } },
+    })
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    fireEvent.click(getToggle('Show thinking'))
+
+    expect(store.getState().settings.settings.agentChat.showThinking).toBe(false)
+  })
+
+  it('agent chat setting changes are local-only (no api.patch call)', async () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    fireEvent.click(getToggle('Show thinking'))
+    fireEvent.click(getToggle('Show tools'))
+    fireEvent.click(getToggle('Show timecodes & model'))
+
+    await act(async () => {
+      vi.advanceTimersByTime(600)
+    })
+
+    const { api } = await import('@/lib/api')
+    expect(api.patch).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/client/components/Sidebar.test.tsx
+++ b/test/unit/client/components/Sidebar.test.tsx
@@ -15,6 +15,7 @@ import sessionsReducer, {
 import sessionActivityReducer from '@/store/sessionActivitySlice'
 import extensionsReducer from '@/store/extensionsSlice'
 import codexActivityReducer, { type CodexActivityState } from '@/store/codexActivitySlice'
+import opencodeActivityReducer, { type OpencodeActivityState } from '@/store/opencodeActivitySlice'
 import terminalDirectoryReducer, { setTerminalDirectoryWindowData } from '@/store/terminalDirectorySlice'
 import type { ProjectGroup, BackgroundTerminal, TabMode } from '@/store/types'
 import type { PaneNode } from '@/store/paneTypes'
@@ -101,6 +102,7 @@ function createTestStore(options?: {
   sessionOpenMode?: 'tab' | 'split'
   sessionActivity?: Record<string, number>
   codexActivity?: Partial<CodexActivityState>
+  opencodeActivity?: Partial<OpencodeActivityState>
 }) {
   const projects = (options?.projects ?? []).map((project) => ({
     ...project,
@@ -142,6 +144,7 @@ function createTestStore(options?: {
       sessionActivity: sessionActivityReducer,
       extensions: extensionsReducer,
       codexActivity: codexActivityReducer,
+      opencodeActivity: opencodeActivityReducer,
       terminalDirectory: terminalDirectoryReducer,
     },
     middleware: (getDefault) =>
@@ -202,6 +205,13 @@ function createTestStore(options?: {
         liveMutationSeqByTerminalId: {},
         removedMutationSeqByTerminalId: {},
         ...(options?.codexActivity ?? {}),
+      },
+      opencodeActivity: {
+        byTerminalId: {},
+        lastSnapshotSeq: 0,
+        liveMutationSeqByTerminalId: {},
+        removedMutationSeqByTerminalId: {},
+        ...(options?.opencodeActivity ?? {}),
       },
       terminalDirectory: {
         windows: {
@@ -1155,6 +1165,91 @@ describe('Sidebar Component - Session-Centric Display', () => {
       const button = screen.getByRole('button', { name: /Multi terminal/ })
       expect(button.querySelector('.text-blue-500')).toBeTruthy()
       expect(button.querySelector('.text-success')).toBeFalsy()
+    })
+
+    it('shows blue for a busy opencode session when the exact terminal is active', async () => {
+      const now = Date.now()
+      const terminalId = 'term-opencode'
+      const busySessionId = sessionId('busy-opencode')
+      const idleSessionId = sessionId('idle-opencode')
+      const projects: ProjectGroup[] = [
+        {
+          projectPath: '/home/user/project',
+          sessions: [
+            {
+              sessionId: busySessionId,
+              projectPath: '/home/user/project',
+              lastActivityAt: now,
+              title: 'Busy opencode session',
+              cwd: '/home/user/project',
+              provider: 'opencode',
+            },
+            {
+              sessionId: idleSessionId,
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 1000,
+              title: 'Idle opencode session',
+              cwd: '/home/user/project',
+              provider: 'opencode',
+            },
+          ],
+        },
+      ]
+
+      const tabs = [
+        {
+          id: 'tab-1',
+          terminalId,
+          resumeSessionId: busySessionId,
+          mode: 'opencode',
+        },
+        {
+          id: 'tab-2',
+          resumeSessionId: idleSessionId,
+          mode: 'opencode',
+        },
+      ]
+
+      const terminals: BackgroundTerminal[] = [
+        {
+          terminalId,
+          title: 'OpenCode',
+          createdAt: now,
+          status: 'running',
+          hasClients: true,
+          mode: 'opencode',
+          resumeSessionId: busySessionId,
+        },
+      ]
+
+      const store = createTestStore({
+        projects,
+        tabs,
+        sortMode: 'activity',
+        opencodeActivity: {
+          byTerminalId: {
+            [terminalId]: {
+              terminalId,
+              sessionId: busySessionId,
+              phase: 'busy',
+              updatedAt: 10,
+            },
+          },
+        },
+      })
+      renderSidebar(store, terminals)
+
+      await act(async () => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const busyButton = screen.getByRole('button', { name: /Busy opencode session/ })
+      expect(busyButton.querySelector('.text-blue-500')).toBeTruthy()
+      expect(busyButton.querySelector('.text-success')).toBeFalsy()
+
+      const idleButton = screen.getByRole('button', { name: /Idle opencode session/ })
+      expect(idleButton.querySelector('.text-success')).toBeTruthy()
+      expect(idleButton.querySelector('.text-blue-500')).toBeFalsy()
     })
   })
 

--- a/test/unit/client/components/TabBar.test.tsx
+++ b/test/unit/client/components/TabBar.test.tsx
@@ -6,6 +6,7 @@ import TabBar from '@/components/TabBar'
 import tabsReducer, { TabsState } from '@/store/tabsSlice'
 import codingCliReducer, { registerCodingCliRequest } from '@/store/codingCliSlice'
 import codexActivityReducer, { type CodexActivityState } from '@/store/codexActivitySlice'
+import opencodeActivityReducer, { type OpencodeActivityState } from '@/store/opencodeActivitySlice'
 import panesReducer from '@/store/panesSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
@@ -128,6 +129,12 @@ function createStore(
     liveMutationSeqByTerminalId: {},
     removedMutationSeqByTerminalId: {},
   },
+  opencodeActivityState: OpencodeActivityState = {
+    byTerminalId: {},
+    lastSnapshotSeq: 0,
+    liveMutationSeqByTerminalId: {},
+    removedMutationSeqByTerminalId: {},
+  },
 ) {
   const serverSettings = createDefaultServerSettings({
     loggingDebug: defaultSettings.logging.debug,
@@ -139,6 +146,7 @@ function createStore(
       tabs: tabsReducer,
       codingCli: codingCliReducer,
       codexActivity: codexActivityReducer,
+      opencodeActivity: opencodeActivityReducer,
       panes: panesReducer,
       settings: settingsReducer,
       turnCompletion: turnCompletionReducer,
@@ -155,6 +163,7 @@ function createStore(
         pendingRequests: {},
       },
       codexActivity: codexActivityState,
+      opencodeActivity: opencodeActivityState,
       panes: {
         layouts: {},
         activePane: {},
@@ -410,6 +419,39 @@ describe('TabBar', () => {
         .filter((icon) => icon.getAttribute('class')?.includes('text-blue-500'))
 
       expect(blueIcons).toHaveLength(0)
+    })
+
+    it('shows blue icon on the exact busy OpenCode terminal in a tab', () => {
+      const tab = createTab({
+        id: 'tab-opencode',
+        title: 'OpenCode Tab',
+        mode: 'opencode',
+        terminalId: 'term-opencode-1',
+      })
+      const store = createStore(
+        { tabs: [tab], activeTabId: 'tab-opencode' },
+        {},
+        { layouts: { 'tab-opencode': createTwoTerminalSplitLayout('term-opencode-1', 'term-opencode-2') } },
+        undefined,
+        {
+          byTerminalId: {
+            'term-opencode-1': { terminalId: 'term-opencode-1', phase: 'busy', updatedAt: 10 },
+          },
+          lastSnapshotSeq: 0,
+          liveMutationSeqByTerminalId: {},
+          removedMutationSeqByTerminalId: {},
+        },
+      )
+
+      renderWithStore(<TabBar />, store)
+
+      const tabElement = screen.getByLabelText('OpenCode Tab')
+      const icons = within(tabElement).getAllByTestId('pane-icon')
+      const busyIcon = icons.find((icon) => icon.getAttribute('data-terminal-id') === 'term-opencode-1')
+      const idleIcon = icons.find((icon) => icon.getAttribute('data-terminal-id') === 'term-opencode-2')
+
+      expect(busyIcon?.getAttribute('class')).toContain('text-blue-500')
+      expect(idleIcon?.getAttribute('class') ?? '').not.toContain('text-blue-500')
     })
   })
 

--- a/test/unit/client/components/TabSwitcher.test.tsx
+++ b/test/unit/client/components/TabSwitcher.test.tsx
@@ -7,6 +7,7 @@ import panesReducer from '@/store/panesSlice'
 import connectionReducer from '@/store/connectionSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import codexActivityReducer, { type CodexActivityState } from '@/store/codexActivitySlice'
+import opencodeActivityReducer, { type OpencodeActivityState } from '@/store/opencodeActivitySlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
 import type { Tab } from '@/store/types'
 import type { PaneNode } from '@/store/paneTypes'
@@ -56,7 +57,12 @@ function createLeafLayout(tab: Tab): PaneNode {
 function createStore(
   tabs: Tab[],
   activeTabId: string,
-  opts?: { codexActivity?: Partial<CodexActivityState>; includeCodexActivity?: boolean },
+  opts?: {
+    codexActivity?: Partial<CodexActivityState>
+    opencodeActivity?: Partial<OpencodeActivityState>
+    includeCodexActivity?: boolean
+    includeOpencodeActivity?: boolean
+  },
 ) {
   const layouts: Record<string, PaneNode> = {}
   const activePane: Record<string, string> = {}
@@ -72,6 +78,13 @@ function createStore(
     liveMutationSeqByTerminalId: {},
     removedMutationSeqByTerminalId: {},
   }
+  const includeOpencodeActivity = opts?.includeOpencodeActivity ?? true
+  const defaultOpencodeActivity: OpencodeActivityState = {
+    byTerminalId: {},
+    lastSnapshotSeq: 0,
+    liveMutationSeqByTerminalId: {},
+    removedMutationSeqByTerminalId: {},
+  }
 
   const reducer = {
     tabs: tabsReducer,
@@ -80,6 +93,7 @@ function createStore(
     settings: settingsReducer,
     turnCompletion: turnCompletionReducer,
     ...(includeCodexActivity ? { codexActivity: codexActivityReducer } : {}),
+    ...(includeOpencodeActivity ? { opencodeActivity: opencodeActivityReducer } : {}),
   }
   const preloadedState: Record<string, unknown> = {
     tabs: {
@@ -111,6 +125,12 @@ function createStore(
     preloadedState.codexActivity = {
       ...defaultCodexActivity,
       ...(opts?.codexActivity ?? {}),
+    }
+  }
+  if (includeOpencodeActivity) {
+    preloadedState.opencodeActivity = {
+      ...defaultOpencodeActivity,
+      ...(opts?.opencodeActivity ?? {}),
     }
   }
 
@@ -406,6 +426,42 @@ describe('TabSwitcher', () => {
     expect(badge.className).toContain('bg-blue-500/15')
     expect(badge.className).toContain('text-blue-600')
     expect(badge.className).not.toContain('animate-pulse')
+  })
+
+  it('shows a busy badge only on tabs with exact busy opencode activity', async () => {
+    const { TabSwitcher } = await import('@/components/TabSwitcher')
+    const shellTab = createTab('tab-1', 'Shell')
+    const opencodeTab = createTab('tab-2', 'OpenCode', {
+      mode: 'opencode',
+      terminalId: 'term-opencode',
+    })
+    const store = createStore([shellTab, opencodeTab], 'tab-1', {
+      opencodeActivity: {
+        byTerminalId: {
+          'term-opencode': {
+            terminalId: 'term-opencode',
+            sessionId: 'session-opencode',
+            phase: 'busy',
+            updatedAt: 10,
+          },
+        },
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <TabSwitcher onClose={() => {}} />
+      </Provider>
+    )
+
+    const shellCard = screen.getByRole('button', { name: /switch to shell/i })
+    const opencodeCard = screen.getByRole('button', { name: /switch to opencode/i })
+
+    expect(within(shellCard).queryByText('Busy')).not.toBeInTheDocument()
+    const badge = within(opencodeCard).getByTestId('tab-switcher-busy-badge-tab-2')
+    expect(badge).toHaveTextContent('Busy')
+    expect(badge.className).toContain('bg-blue-500/15')
+    expect(badge.className).toContain('text-blue-600')
   })
 
   it('does not warn about selector instability when codex activity state is absent', async () => {

--- a/test/unit/client/components/agent-chat/AgentChatView.behavior.test.tsx
+++ b/test/unit/client/components/agent-chat/AgentChatView.behavior.test.tsx
@@ -12,7 +12,7 @@ import agentChatReducer, {
   setSessionStatus,
 } from '@/store/agentChatSlice'
 import panesReducer from '@/store/panesSlice'
-import settingsReducer from '@/store/settingsSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import type { AgentChatPaneContent } from '@/store/paneTypes'
 import type { ChatContentBlock } from '@/store/agentChatTypes'
 
@@ -47,6 +47,7 @@ function makeStore(settingsOverrides?: Record<string, unknown>) {
     preloadedState: {
       settings: {
         settings: {
+          ...defaultSettings,
           ...(settingsOverrides || {}),
         } as any,
         loaded: true,
@@ -329,7 +330,7 @@ describe('AgentChatView tool blocks expanded by default', () => {
   })
 
   it('all tool blocks start expanded when showTools is true', () => {
-    const store = makeStore()
+    const store = makeStore({ agentChat: { ...defaultSettings.agentChat, showTools: true } })
     store.dispatch(sessionCreated({ requestId: 'req-1', sessionId: 'sess-1' }))
     // Create a turn with 5 completed tools
     addTurns(store, 1, 5)
@@ -406,7 +407,7 @@ describe('AgentChatView settings auto-open (#110)', () => {
   })
 
   it('does not open settings on new pane when global initialSetupDone is true', () => {
-    const store = makeStore({ agentChat: { initialSetupDone: true, providers: {} } })
+    const store = makeStore({ agentChat: { ...defaultSettings.agentChat, initialSetupDone: true, providers: {} } })
     store.dispatch(sessionCreated({ requestId: 'req-1', sessionId: 'sess-1' }))
 
     // Fresh pane (no settingsDismissed), but global flag is set
@@ -420,8 +421,6 @@ describe('AgentChatView settings auto-open (#110)', () => {
   })
 
   it('does not open settings while global settings are still loading', () => {
-    // Simulates a returning user: settings haven't loaded from server yet,
-    // so initialSetupDone is still false. We should NOT flash the settings panel.
     const store = configureStore({
       reducer: {
         agentChat: agentChatReducer,
@@ -430,7 +429,7 @@ describe('AgentChatView settings auto-open (#110)', () => {
       },
       preloadedState: {
         settings: {
-          settings: {} as any,
+          settings: { ...defaultSettings } as any,
           loaded: false,
           lastSavedAt: 0,
         },
@@ -449,7 +448,7 @@ describe('AgentChatView settings auto-open (#110)', () => {
 
   it('auto-focuses composer when global initialSetupDone skips settings', () => {
     vi.useFakeTimers()
-    const store = makeStore({ agentChat: { initialSetupDone: true, providers: {} } })
+    const store = makeStore({ agentChat: { ...defaultSettings.agentChat, initialSetupDone: true, providers: {} } })
     store.dispatch(sessionCreated({ requestId: 'req-1', sessionId: 'sess-1' }))
 
     render(

--- a/test/unit/client/components/agent-chat/AgentChatView.perf-audit.test.tsx
+++ b/test/unit/client/components/agent-chat/AgentChatView.perf-audit.test.tsx
@@ -10,7 +10,7 @@ import agentChatReducer, {
   setSessionStatus,
 } from '@/store/agentChatSlice'
 import panesReducer from '@/store/panesSlice'
-import settingsReducer from '@/store/settingsSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import { createPerfAuditBridge, installPerfAuditBridge } from '@/lib/perf-audit-bridge'
 
 beforeAll(() => {
@@ -47,7 +47,7 @@ describe('AgentChatView perf audit milestone', () => {
           paneTitles: {},
         },
         settings: {
-          settings: {},
+          settings: { ...defaultSettings } as any,
           loaded: true,
           lastSavedAt: 0,
         },

--- a/test/unit/client/components/agent-chat/MessageBubble.test.tsx
+++ b/test/unit/client/components/agent-chat/MessageBubble.test.tsx
@@ -63,6 +63,7 @@ describe('MessageBubble', () => {
       <MessageBubble
         role="assistant"
         content={[{ type: 'thinking', thinking: 'Let me think...' }]}
+        showThinking={true}
       />
     )
     expect(screen.getByText(/Thinking/)).toBeInTheDocument()
@@ -235,7 +236,7 @@ describe('MessageBubble display toggles', () => {
     expect(screen.getByRole('article').querySelector('time')).not.toBeInTheDocument()
   })
 
-  it('defaults to showing thinking and tools, hiding timecodes', () => {
+  it('defaults to hiding thinking, tools, and timecodes', () => {
     render(
       <MessageBubble
         role="assistant"
@@ -243,7 +244,7 @@ describe('MessageBubble display toggles', () => {
         timestamp="2026-02-13T10:00:00Z"
       />
     )
-    expect(screen.getByText(/Let me think/)).toBeInTheDocument()
+    expect(screen.queryByText(/Let me think/)).not.toBeInTheDocument()
     expect(screen.getByRole('region', { name: /tool strip/i })).toBeInTheDocument()
     expect(screen.getByRole('article').querySelector('time')).not.toBeInTheDocument()
   })
@@ -476,6 +477,7 @@ describe('MessageBubble tool strip grouping', () => {
           { type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } },
           { type: 'tool_result', tool_use_id: 't1', content: 'output' },
         ]}
+        showThinking={true}
         showTools={true}
       />
     )

--- a/test/unit/client/components/agent-chat/ToolStrip.test.tsx
+++ b/test/unit/client/components/agent-chat/ToolStrip.test.tsx
@@ -208,9 +208,10 @@ describe('ToolStrip', () => {
     expect(screen.getByRole('button', { name: /Bash tool call/i })).toBeInTheDocument()
   })
 
-  it('defaults to showTools=true when not specified', () => {
+  it('defaults to showTools=false when not specified', () => {
     const pairs = [makePair('Bash', { command: 'ls' }, 'output')]
     render(<ToolStrip pairs={pairs} isStreaming={false} />)
-    expect(screen.getByRole('button', { name: /Bash tool call/i })).toBeInTheDocument()
+    expect(screen.getByText('1 tool used')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Bash tool call/i })).not.toBeInTheDocument()
   })
 })

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -11,6 +11,7 @@ import extensionsReducer from '@/store/extensionsSlice'
 import terminalMetaReducer from '@/store/terminalMetaSlice'
 import sessionsReducer, { applySessionsPatch, type SessionsState } from '@/store/sessionsSlice'
 import agentChatReducer, { turnResult } from '@/store/agentChatSlice'
+import opencodeActivityReducer, { upsertOpencodeActivity } from '@/store/opencodeActivitySlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
 import { markTabAttention, markPaneAttention } from '@/store/turnCompletionSlice'
 import type { PanesState } from '@/store/panesSlice'
@@ -223,6 +224,7 @@ function createStore(
       terminalMeta: terminalMetaReducer,
       sessions: sessionsReducer,
       agentChat: agentChatReducer,
+      opencodeActivity: opencodeActivityReducer,
       turnCompletion: turnCompletionReducer,
     },
     middleware: (getDefaultMiddleware) =>
@@ -269,6 +271,12 @@ function createStore(
         pendingCreates: {},
         availableModels: [],
         ...initialAgentChatState,
+      },
+      opencodeActivity: {
+        byTerminalId: {},
+        lastSnapshotSeq: 0,
+        liveMutationSeqByTerminalId: {},
+        removedMutationSeqByTerminalId: {},
       },
     },
   })
@@ -908,6 +916,41 @@ describe('PaneContainer', () => {
       )
 
       expect(screen.getByTestId(`terminal-${paneId}`)).toBeInTheDocument()
+    })
+
+    it('marks an opencode pane busy when the exact terminal has live activity', () => {
+      const paneId = 'pane-1'
+      const leafNode: PaneNode = {
+        type: 'leaf',
+        id: paneId,
+        content: createTerminalContent({
+          mode: 'opencode',
+          status: 'running',
+          createRequestId: 'req-pane-1',
+          terminalId: 'term-opencode',
+        }),
+      }
+
+      const store = createStore({
+        layouts: { 'tab-1': leafNode },
+        activePane: { 'tab-1': paneId },
+      })
+      store.dispatch(upsertOpencodeActivity({
+        terminals: [{
+          terminalId: 'term-opencode',
+          sessionId: 'session-opencode',
+          phase: 'busy',
+          updatedAt: 10,
+        }],
+      }))
+
+      renderWithStore(
+        <PaneContainer tabId="tab-1" node={leafNode} />,
+        store
+      )
+
+      const pane = screen.getByRole('group', { name: /pane: opencode/i })
+      expect(pane.querySelector('svg.text-blue-500')).toBeTruthy()
     })
 
     it('renders browser content for leaf node', () => {

--- a/test/unit/client/lib/pane-activity.test.ts
+++ b/test/unit/client/lib/pane-activity.test.ts
@@ -23,6 +23,7 @@ describe('pane activity', () => {
       codexActivityByTerminalId: {
         'term-live': { terminalId: 'term-live', phase: 'busy', updatedAt: 10 },
       },
+      opencodeActivityByTerminalId: {},
       paneRuntimeActivityByPaneId: {},
       agentChatSessions: {},
     })).toMatchObject({ isBusy: true, source: 'codex' })
@@ -35,6 +36,7 @@ describe('pane activity', () => {
       codexActivityByTerminalId: {
         'term-live': { terminalId: 'term-live', phase: 'pending', updatedAt: 10 },
       },
+      opencodeActivityByTerminalId: {},
       paneRuntimeActivityByPaneId: {},
       agentChatSessions: {},
     }).isBusy).toBe(false)
@@ -45,6 +47,43 @@ describe('pane activity', () => {
       tabTerminalId: undefined,
       isOnlyPane: false,
       codexActivityByTerminalId: {
+        'term-foreign': { terminalId: 'term-foreign', phase: 'busy', updatedAt: 10 },
+      },
+      opencodeActivityByTerminalId: {},
+      paneRuntimeActivityByPaneId: {},
+      agentChatSessions: {},
+    }).isBusy).toBe(false)
+  })
+
+  it('keeps OpenCode exact-match semantics and only treats live terminal matches as busy', () => {
+    const content: TerminalPaneContent = {
+      kind: 'terminal',
+      createRequestId: 'req-opencode',
+      status: 'running',
+      mode: 'opencode',
+      terminalId: 'term-live',
+      shell: 'system',
+      resumeSessionId: 'session-opencode',
+    }
+
+    expect(resolvePaneActivity({
+      paneId: 'pane-1',
+      content,
+      isOnlyPane: true,
+      codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {
+        'term-live': { terminalId: 'term-live', phase: 'busy', updatedAt: 10 },
+      },
+      paneRuntimeActivityByPaneId: {},
+      agentChatSessions: {},
+    })).toMatchObject({ isBusy: true, source: 'opencode' })
+
+    expect(resolvePaneActivity({
+      paneId: 'pane-1',
+      content: { ...content, terminalId: undefined },
+      isOnlyPane: true,
+      codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {
         'term-foreign': { terminalId: 'term-foreign', phase: 'busy', updatedAt: 10 },
       },
       paneRuntimeActivityByPaneId: {},
@@ -111,6 +150,7 @@ describe('pane activity', () => {
       tabs,
       paneLayouts,
       codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {},
       paneRuntimeActivityByPaneId: {
         'pane-claude': {
           source: 'terminal',
@@ -171,6 +211,7 @@ describe('pane activity', () => {
         },
       },
       codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {},
       paneRuntimeActivityByPaneId: {},
       agentChatSessions: {
         'sdk-restore-1': {
@@ -222,6 +263,7 @@ describe('pane activity', () => {
         },
       },
       codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {},
       paneRuntimeActivityByPaneId: {},
       agentChatSessions: {
         'sdk-restore-2': {
@@ -244,5 +286,52 @@ describe('pane activity', () => {
     })
 
     expect(busySessionKeys).toEqual(['claude:00000000-0000-4000-8000-000000000321'])
+  })
+
+  it('collects busy session keys from OpenCode terminals using exact terminal matches', () => {
+    const sessionId = '33333333-3333-4333-8333-333333333333'
+    const busySessionKeys = collectBusySessionKeys({
+      tabs: [
+        {
+          id: 'tab-opencode',
+          title: 'OpenCode',
+          createRequestId: 'req-opencode',
+          status: 'running',
+          mode: 'opencode',
+          shell: 'system',
+          createdAt: 1,
+          terminalId: 'term-live',
+          resumeSessionId: sessionId,
+        },
+      ],
+      paneLayouts: {
+        'tab-opencode': {
+          type: 'leaf',
+          id: 'pane-opencode',
+          content: {
+            kind: 'terminal',
+            createRequestId: 'req-opencode',
+            status: 'running',
+            mode: 'opencode',
+            shell: 'system',
+            terminalId: 'term-live',
+            resumeSessionId: sessionId,
+          },
+        },
+      },
+      codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {
+        'term-live': {
+          terminalId: 'term-live',
+          sessionId,
+          phase: 'busy',
+          updatedAt: 1,
+        },
+      },
+      paneRuntimeActivityByPaneId: {},
+      agentChatSessions: {},
+    })
+
+    expect(busySessionKeys).toEqual([`opencode:${sessionId}`])
   })
 })

--- a/test/unit/client/store/browserPreferencesPersistence.test.ts
+++ b/test/unit/client/store/browserPreferencesPersistence.test.ts
@@ -157,4 +157,67 @@ describe('browserPreferencesPersistence', () => {
 
     setItemSpy.mockRestore()
   })
+
+  it('persists agentChat.showThinking/showTools/showTimecodes to browser preferences', () => {
+    const store = createStore()
+
+    store.dispatch(updateSettingsLocal({
+      agentChat: { showThinking: true },
+    }))
+
+    vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings.agentChat).toEqual({ showThinking: true })
+    expect(bp.settings.agentChat.showTools).toBeUndefined()
+    expect(bp.settings.agentChat.showTimecodes).toBeUndefined()
+  })
+
+  it('persists all three agentChat toggles when all are enabled', () => {
+    const store = createStore()
+
+    store.dispatch(updateSettingsLocal({
+      agentChat: { showThinking: true, showTools: true, showTimecodes: true },
+    }))
+
+    vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings.agentChat).toEqual({
+      showThinking: true,
+      showTools: true,
+      showTimecodes: true,
+    })
+  })
+
+  it('round-trips agentChat settings through localStorage', () => {
+    const store = createStore()
+
+    store.dispatch(updateSettingsLocal({
+      agentChat: { showThinking: true, showTools: true },
+    }))
+
+    vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
+
+    const saved = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(saved.settings.agentChat).toEqual({ showThinking: true, showTools: true })
+
+    const rehydrated = resolveLocalSettings(saved.settings)
+    expect(rehydrated.agentChat.showThinking).toBe(true)
+    expect(rehydrated.agentChat.showTools).toBe(true)
+    expect(rehydrated.agentChat.showTimecodes).toBe(false)
+  })
+
+  it('does not persist agentChat when set to defaults', () => {
+    const store = createStore()
+
+    store.dispatch(updateSettingsLocal({
+      agentChat: { showThinking: false, showTools: false, showTimecodes: false },
+    }))
+
+    vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings?.agentChat).toBeUndefined()
+  })
 })

--- a/test/unit/client/store/opencodeActivitySlice.test.ts
+++ b/test/unit/client/store/opencodeActivitySlice.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest'
+import opencodeActivityReducer, {
+  removeOpencodeActivity,
+  resetOpencodeActivity,
+  setOpencodeActivitySnapshot,
+  upsertOpencodeActivity,
+} from '@/store/opencodeActivitySlice'
+
+describe('opencodeActivitySlice', () => {
+  it('replaces state from opencode.activity.list.response snapshot payloads', () => {
+    const first = opencodeActivityReducer(
+      undefined,
+      setOpencodeActivitySnapshot({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 100,
+          },
+        ],
+      }),
+    )
+
+    const second = opencodeActivityReducer(
+      first,
+      setOpencodeActivitySnapshot({
+        terminals: [
+          {
+            terminalId: 'term-2',
+            sessionId: 'session-2',
+            phase: 'busy',
+            updatedAt: 200,
+          },
+        ],
+        requestSeq: 2,
+      }),
+    )
+
+    expect(Object.keys(second.byTerminalId)).toEqual(['term-2'])
+    expect(second.byTerminalId['term-2']?.phase).toBe('busy')
+  })
+
+  it('ignores older snapshots that arrive after a newer snapshot already applied', () => {
+    const newest = opencodeActivityReducer(
+      undefined,
+      setOpencodeActivitySnapshot({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 200,
+          },
+        ],
+        requestSeq: 2,
+      }),
+    )
+
+    const stale = opencodeActivityReducer(
+      newest,
+      setOpencodeActivitySnapshot({
+        terminals: [],
+        requestSeq: 1,
+      }),
+    )
+
+    expect(stale.byTerminalId['term-1']?.phase).toBe('busy')
+  })
+
+  it('preserves newer live upserts when an older snapshot arrives', () => {
+    const stateWithUpsert = opencodeActivityReducer(
+      undefined,
+      upsertOpencodeActivity({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 500,
+          },
+        ],
+        mutationSeq: 2,
+      }),
+    )
+
+    const next = opencodeActivityReducer(
+      stateWithUpsert,
+      setOpencodeActivitySnapshot({
+        terminals: [],
+        requestSeq: 1,
+      }),
+    )
+
+    expect(next.byTerminalId['term-1']?.phase).toBe('busy')
+  })
+
+  it('ratchets upserts by updatedAt', () => {
+    const initial = opencodeActivityReducer(
+      undefined,
+      upsertOpencodeActivity({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 500,
+          },
+        ],
+        mutationSeq: 1,
+      }),
+    )
+
+    const next = opencodeActivityReducer(
+      initial,
+      upsertOpencodeActivity({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 400,
+          },
+          {
+            terminalId: 'term-2',
+            sessionId: 'session-2',
+            phase: 'busy',
+            updatedAt: 600,
+          },
+        ],
+        mutationSeq: 2,
+      }),
+    )
+
+    expect(next.byTerminalId['term-1']?.updatedAt).toBe(500)
+    expect(next.byTerminalId['term-2']?.phase).toBe('busy')
+  })
+
+  it('keeps removals authoritative even when snapshot and record timestamps are older on the client clock', () => {
+    const initial = opencodeActivityReducer(
+      undefined,
+      upsertOpencodeActivity({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 1_000,
+          },
+        ],
+        mutationSeq: 10,
+      }),
+    )
+
+    const removed = opencodeActivityReducer(
+      initial,
+      removeOpencodeActivity({
+        terminalIds: ['term-1'],
+        mutationSeq: 11,
+      }),
+    )
+
+    const next = opencodeActivityReducer(
+      removed,
+      setOpencodeActivitySnapshot({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 900,
+          },
+        ],
+        requestSeq: 9,
+      }),
+    )
+
+    expect(next.byTerminalId['term-1']).toBeUndefined()
+  })
+
+  it('resets stale overlay records and sequencing state', () => {
+    const populated = opencodeActivityReducer(
+      undefined,
+      upsertOpencodeActivity({
+        terminals: [
+          {
+            terminalId: 'term-1',
+            sessionId: 'session-1',
+            phase: 'busy',
+            updatedAt: 1_000,
+          },
+        ],
+        mutationSeq: 7,
+      }),
+    )
+
+    const removed = opencodeActivityReducer(
+      populated,
+      removeOpencodeActivity({
+        terminalIds: ['term-2'],
+        mutationSeq: 8,
+      }),
+    )
+
+    const reset = opencodeActivityReducer(removed, resetOpencodeActivity())
+
+    expect(reset).toEqual({
+      byTerminalId: {},
+      lastSnapshotSeq: 0,
+      liveMutationSeqByTerminalId: {},
+      removedMutationSeqByTerminalId: {},
+    })
+  })
+})

--- a/test/unit/client/store/panesPersistence.test.ts
+++ b/test/unit/client/store/panesPersistence.test.ts
@@ -744,6 +744,182 @@ describe('version 5 migration (drop claude-chat panes)', () => {
   })
 })
 
+import { BROWSER_PREFERENCES_STORAGE_KEY } from '../../../../src/store/storage-keys'
+
+describe('legacy agent-chat display settings migration', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    resetPersistedPanesCacheForTests()
+    resetPersistedLayoutCacheForTests()
+  })
+
+  it('migrates showThinking/showTools/showTimecodes from agent-chat panes to browser preferences', async () => {
+    localStorageMock.clear()
+    localStorage.setItem('freshell.layout.v3', JSON.stringify({
+      version: 3,
+      tabs: { tabs: [{ id: 'tab1', title: 'Tab 1' }], activeTabId: 'tab1' },
+      panes: {
+        version: PANES_SCHEMA_VERSION,
+        layouts: {
+          tab1: {
+            type: 'leaf',
+            id: 'pane1',
+            content: {
+              kind: 'agent-chat',
+              provider: 'claude',
+              createRequestId: 'req1',
+              status: 'idle',
+              showThinking: true,
+              showTools: true,
+              showTimecodes: true,
+            },
+          },
+        },
+        activePane: { tab1: 'pane1' },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+      },
+      tombstones: [],
+    }))
+
+    vi.resetModules()
+    const { default: freshPanesReducer } = await import('../../../../src/store/panesSlice')
+    const store = configureStore({ reducer: { panes: freshPanesReducer } })
+    const content = (store.getState().panes.layouts['tab1'] as any).content
+
+    expect(content.showThinking).toBeUndefined()
+    expect(content.showTools).toBeUndefined()
+    expect(content.showTimecodes).toBeUndefined()
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings.agentChat).toEqual({
+      showThinking: true,
+      showTools: true,
+      showTimecodes: true,
+    })
+  })
+
+  it('migrates legacy display settings from panes inside splits', async () => {
+    localStorageMock.clear()
+    localStorage.setItem('freshell.layout.v3', JSON.stringify({
+      version: 3,
+      tabs: { tabs: [{ id: 'tab1', title: 'Tab 1' }], activeTabId: 'tab1' },
+      panes: {
+        version: PANES_SCHEMA_VERSION,
+        layouts: {
+          tab1: {
+            type: 'split',
+            id: 'split1',
+            direction: 'horizontal',
+            sizes: [50, 50],
+            children: [
+              {
+                type: 'leaf',
+                id: 'pane1',
+                content: { kind: 'terminal', createRequestId: 'req1', status: 'running', mode: 'shell' },
+              },
+              {
+                type: 'leaf',
+                id: 'pane2',
+                content: {
+                  kind: 'agent-chat',
+                  provider: 'claude',
+                  createRequestId: 'req2',
+                  status: 'idle',
+                  showTools: true,
+                },
+              },
+            ],
+          },
+        },
+        activePane: { tab1: 'pane1' },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+      },
+      tombstones: [],
+    }))
+
+    vi.resetModules()
+    const { default: freshPanesReducer } = await import('../../../../src/store/panesSlice')
+    const store = configureStore({ reducer: { panes: freshPanesReducer } })
+    const split = store.getState().panes.layouts['tab1'] as any
+
+    expect(split.children[1].content.showTools).toBeUndefined()
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings.agentChat.showTools).toBe(true)
+  })
+
+  it('does not touch panes that have no legacy fields', async () => {
+    localStorageMock.clear()
+    localStorage.setItem('freshell.layout.v3', JSON.stringify({
+      version: 3,
+      tabs: { tabs: [{ id: 'tab1', title: 'Tab 1' }], activeTabId: 'tab1' },
+      panes: {
+        version: PANES_SCHEMA_VERSION,
+        layouts: {
+          tab1: {
+            type: 'leaf',
+            id: 'pane1',
+            content: { kind: 'terminal', createRequestId: 'req1', status: 'running', mode: 'shell' },
+          },
+        },
+        activePane: { tab1: 'pane1' },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+      },
+      tombstones: [],
+    }))
+
+    vi.resetModules()
+    const { default: freshPanesReducer } = await import('../../../../src/store/panesSlice')
+    configureStore({ reducer: { panes: freshPanesReducer } })
+
+    expect(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY)).toBeNull()
+  })
+
+  it('merges with existing browser preferences without clobbering', async () => {
+    localStorageMock.clear()
+    localStorage.setItem(BROWSER_PREFERENCES_STORAGE_KEY, JSON.stringify({
+      settings: { theme: 'dark' },
+      tabs: { searchRangeDays: 60 },
+    }))
+    localStorage.setItem('freshell.layout.v3', JSON.stringify({
+      version: 3,
+      tabs: { tabs: [{ id: 'tab1', title: 'Tab 1' }], activeTabId: 'tab1' },
+      panes: {
+        version: PANES_SCHEMA_VERSION,
+        layouts: {
+          tab1: {
+            type: 'leaf',
+            id: 'pane1',
+            content: {
+              kind: 'agent-chat',
+              provider: 'claude',
+              createRequestId: 'req1',
+              status: 'idle',
+              showThinking: true,
+            },
+          },
+        },
+        activePane: { tab1: 'pane1' },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+      },
+      tombstones: [],
+    }))
+
+    vi.resetModules()
+    const { default: freshPanesReducer } = await import('../../../../src/store/panesSlice')
+    configureStore({ reducer: { panes: freshPanesReducer } })
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings.theme).toBe('dark')
+    expect(bp.tabs.searchRangeDays).toBe(60)
+    expect(bp.settings.agentChat.showThinking).toBe(true)
+  })
+})
+
 describe('schema version consistency', () => {
   beforeEach(() => {
     localStorageMock.clear()

--- a/test/unit/client/store/selectors/sidebarSelectors.test.ts
+++ b/test/unit/client/store/selectors/sidebarSelectors.test.ts
@@ -463,6 +463,63 @@ describe('sidebarSelectors', () => {
         excludeFirstChatMustStart: true,
       })).toEqual([])
     })
+
+    it('merges open-tab fallback data into a matching server-backed titleless session', () => {
+      const sessionId = 'claude-current'
+      const items = buildSessionItems(
+        [makeProject([{ provider: 'claude', sessionId, title: undefined, lastActivityAt: 10 }])],
+        [{
+          id: 'tab-1',
+          title: 'Current Session',
+          mode: 'claude',
+          resumeSessionId: sessionId,
+          createdAt: 20_000,
+          sessionMetadataByKey: {
+            'claude:claude-current': {
+              sessionType: 'freshclaude',
+              firstUserMessage: 'IMPORTANT: internal trycycle task',
+              isSubagent: true,
+              isNonInteractive: true,
+            },
+          },
+        }] as any,
+        {
+          layouts: {
+            'tab-1': {
+              type: 'leaf',
+              id: 'pane-1',
+              content: {
+                kind: 'terminal',
+                mode: 'claude',
+                status: 'running',
+                createRequestId: 'req-1',
+                resumeSessionId: sessionId,
+                initialCwd: '/repo',
+              },
+            },
+          },
+          activePane: { 'tab-1': 'pane-1' },
+          paneTitles: { 'tab-1': { 'pane-1': 'Current Session' } },
+        } as any,
+        emptyTerminals,
+        emptyActivity,
+      )
+
+      expect(items).toEqual([
+        expect.objectContaining({
+          sessionId,
+          provider: 'claude',
+          title: 'Current Session',
+          hasTitle: true,
+          hasTab: true,
+          sessionType: 'freshclaude',
+          firstUserMessage: 'IMPORTANT: internal trycycle task',
+          isSubagent: true,
+          isNonInteractive: true,
+          isFallback: undefined,
+        }),
+      ])
+    })
   })
 
   describe('worktree grouping', () => {

--- a/test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts
+++ b/test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts
@@ -324,6 +324,32 @@ describe('filterSessionItemsByVisibility', () => {
 
       expect(result.map((i) => i.id)).toEqual(['1'])
     })
+
+    it('keeps titleless sessions visible when they have an open tab', () => {
+      const result = filterSessionItemsByVisibility([
+        createSessionItem({ id: '1', title: 'deadbeef', hasTitle: false, hasTab: true }),
+      ], {
+        ...baseSettings,
+        showSubagents: true,
+        showNoninteractiveSessions: true,
+        hideEmptySessions: true,
+      })
+
+      expect(result.map((item) => item.id)).toEqual(['1'])
+    })
+
+    it('keeps titleless sessions visible when they are running', () => {
+      const result = filterSessionItemsByVisibility([
+        createSessionItem({ id: '1', title: 'deadbeef', hasTitle: false, isRunning: true }),
+      ], {
+        ...baseSettings,
+        showSubagents: true,
+        showNoninteractiveSessions: true,
+        hideEmptySessions: true,
+      })
+
+      expect(result.map((item) => item.id)).toEqual(['1'])
+    })
   })
 })
 

--- a/test/unit/client/store/state-edge-cases.test.ts
+++ b/test/unit/client/store/state-edge-cases.test.ts
@@ -787,6 +787,7 @@ describe('State Edge Cases', () => {
           sidebar: {
             excludeFirstChatSubstrings: [],
             excludeFirstChatMustStart: false,
+            autoGenerateTitles: true,
           },
           panes: {
             defaultNewPane: 'shell',
@@ -797,6 +798,7 @@ describe('State Edge Cases', () => {
               claude: { permissionMode: 'default' },
               codex: { model: 'gpt-5-codex' },
             },
+            mcpServer: true,
           },
           editor: {
             externalEditor: 'auto',
@@ -804,6 +806,9 @@ describe('State Edge Cases', () => {
           agentChat: {
             defaultPlugins: ['fs'],
             providers: {},
+          },
+          extensions: {
+            disabled: [],
           },
           network: {
             host: '127.0.0.1',
@@ -841,6 +846,7 @@ describe('State Edge Cases', () => {
               claude: { permissionMode: 'default' },
               codex: { model: 'gpt-5-codex' },
             },
+            mcpServer: true,
           },
           editor: {
             ...defaultSettings.editor,
@@ -850,6 +856,9 @@ describe('State Edge Cases', () => {
             ...defaultSettings.agentChat,
             defaultPlugins: ['fs'],
             providers: {},
+          },
+          extensions: {
+            ...defaultSettings.extensions,
           },
           network: {
             ...defaultSettings.network,

--- a/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
+++ b/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  OPENCODE_HEALTH_POLL_MS,
+  OPENCODE_RECONNECT_BASE_MS,
+  OpencodeActivityTracker,
+} from '../../../../server/coding-cli/opencode-activity-tracker'
+
+const TEST_ENDPOINT = { hostname: '127.0.0.1' as const, port: 43123 }
+
+function createJsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}
+
+function createSseResponse(events: unknown[]) {
+  const encoder = new TextEncoder()
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
+      }
+      controller.close()
+    },
+  }), {
+    headers: { 'content-type': 'text/event-stream' },
+  })
+}
+
+function createRawSseResponse(blocks: string[]) {
+  const encoder = new TextEncoder()
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const block of blocks) {
+        controller.enqueue(encoder.encode(block))
+      }
+      controller.close()
+    },
+  }), {
+    headers: { 'content-type': 'text/event-stream' },
+  })
+}
+
+describe('OpencodeActivityTracker', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('waits for health to become ready, snapshots busy state, and emits an upsert', async () => {
+    vi.useFakeTimers()
+    let healthCalls = 0
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        healthCalls += 1
+        return healthCalls === 1
+          ? new Response('not ready', { status: 503 })
+          : createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({
+          'session-oc': { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([{ type: 'server.connected', properties: {} }])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('changed', (payload) => changes.push(payload))
+
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(changes).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(OPENCODE_HEALTH_POLL_MS)
+
+    expect(changes).toContainEqual({
+      upsert: [{
+        terminalId: 'term-oc',
+        sessionId: 'session-oc',
+        phase: 'busy',
+        updatedAt: expect.any(Number),
+      }],
+      remove: [],
+    })
+
+    tracker.dispose()
+  })
+
+  it('keeps health polling on connection errors until the endpoint comes up', async () => {
+    vi.useFakeTimers()
+    let healthCalls = 0
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        healthCalls += 1
+        if (healthCalls === 1) {
+          throw new Error('connect ECONNREFUSED')
+        }
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({
+          'session-oc': { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([{ type: 'server.connected', properties: {} }])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(tracker.list()).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(OPENCODE_HEALTH_POLL_MS)
+    expect(healthCalls).toBe(2)
+    expect(tracker.list()).toEqual([expect.objectContaining({
+      terminalId: 'term-oc',
+      sessionId: 'session-oc',
+      phase: 'busy',
+    })])
+
+    tracker.dispose()
+  })
+
+  it('removes busy state when session.status reports idle for the tracked session', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({
+          'session-oc': { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([
+          { type: 'server.connected', properties: {} },
+          {
+            type: 'session.status',
+            properties: {
+              sessionID: 'session-oc',
+              status: { type: 'idle' },
+            },
+          },
+        ])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('changed', (payload) => changes.push(payload))
+
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(changes).toContainEqual({
+      upsert: [{
+        terminalId: 'term-oc',
+        sessionId: 'session-oc',
+        phase: 'busy',
+        updatedAt: expect.any(Number),
+      }],
+      remove: [],
+    })
+    expect(changes).toContainEqual({
+      upsert: [],
+      remove: ['term-oc'],
+    })
+    expect(tracker.list()).toEqual([])
+
+    tracker.dispose()
+  })
+
+  it('ignores session.idle for a different session than the tracked busy session', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({
+          'session-oc': { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([
+          { type: 'server.connected', properties: {} },
+          {
+            type: 'session.idle',
+            properties: {
+              sessionID: 'different-session',
+            },
+          },
+        ])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('changed', (payload) => changes.push(payload))
+
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(changes).toHaveLength(1)
+    expect(tracker.list()).toEqual([expect.objectContaining({
+      terminalId: 'term-oc',
+      sessionId: 'session-oc',
+      phase: 'busy',
+    })])
+
+    tracker.dispose()
+  })
+
+  it('reconnects after the SSE stream closes and resnapshots before removing stale busy state', async () => {
+    vi.useFakeTimers()
+    let snapshotCalls = 0
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        snapshotCalls += 1
+        return createJsonResponse(snapshotCalls === 1
+          ? { 'session-oc': { type: 'retry', attempt: 1 } }
+          : {})
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([{ type: 'server.connected', properties: {} }])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('changed', (payload) => changes.push(payload))
+
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(tracker.list()).toEqual([expect.objectContaining({
+      terminalId: 'term-oc',
+      sessionId: 'session-oc',
+      phase: 'busy',
+    })])
+
+    await vi.advanceTimersByTimeAsync(OPENCODE_RECONNECT_BASE_MS)
+
+    expect(changes).toContainEqual({
+      upsert: [],
+      remove: ['term-oc'],
+    })
+    expect(tracker.list()).toEqual([])
+
+    tracker.dispose()
+  })
+
+  it('ignores malformed SSE JSON and keeps processing subsequent events from the same stream', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({ 'session-oc': { type: 'busy' } })
+      }
+      if (url.endsWith('/event')) {
+        return createRawSseResponse([
+          'data: {not valid json}\n\n',
+          `data: ${JSON.stringify({ type: 'session.idle', properties: { sessionID: 'session-oc' } })}\n\n`,
+        ])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const log = { warn: vi.fn() }
+    const tracker = new OpencodeActivityTracker({
+      fetchImpl: fetchImpl as typeof fetch,
+      log,
+      random: () => 0,
+    })
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('changed', (payload) => changes.push(payload))
+
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(changes).toContainEqual({
+      upsert: [{
+        terminalId: 'term-oc',
+        sessionId: 'session-oc',
+        phase: 'busy',
+        updatedAt: expect.any(Number),
+      }],
+      remove: [],
+    })
+    expect(changes).toContainEqual({
+      upsert: [],
+      remove: ['term-oc'],
+    })
+    expect(log.warn).toHaveBeenCalledTimes(1)
+    expect(tracker.list()).toEqual([])
+
+    tracker.dispose()
+  })
+
+  it('ignores unknown SSE event types and keeps processing known events from the same stream', async () => {
+    vi.useFakeTimers()
+    let snapshotCalls = 0
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        snapshotCalls += 1
+        return createJsonResponse({
+          'session-oc': { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createRawSseResponse([
+          `data: ${JSON.stringify({ type: 'server.connected', properties: {} })}\n\n`,
+          `data: ${JSON.stringify({ type: 'session.progress', properties: { percent: 50 } })}\n\n`,
+          `data: ${JSON.stringify({ type: 'session.idle', properties: { sessionID: 'session-oc' } })}\n\n`,
+        ])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('changed', (payload) => changes.push(payload))
+
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(changes).toContainEqual({
+      upsert: [{
+        terminalId: 'term-oc',
+        sessionId: 'session-oc',
+        phase: 'busy',
+        updatedAt: expect.any(Number),
+      }],
+      remove: [],
+    })
+    expect(changes).toContainEqual({
+      upsert: [],
+      remove: ['term-oc'],
+    })
+    expect(snapshotCalls).toBe(1)
+    expect(tracker.list()).toEqual([])
+
+    tracker.dispose()
+  })
+
+  it('stops retrying and removes state when the terminal is untracked', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({
+          'session-oc': { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([{ type: 'server.connected', properties: {} }])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    tracker.trackTerminal({ terminalId: 'term-oc', endpoint: TEST_ENDPOINT })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(tracker.list()).toEqual([expect.objectContaining({
+      terminalId: 'term-oc',
+      sessionId: 'session-oc',
+      phase: 'busy',
+    })])
+
+    const fetchCallsBeforeStop = fetchImpl.mock.calls.length
+    tracker.untrackTerminal({ terminalId: 'term-oc' })
+
+    expect(tracker.list()).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(OPENCODE_RECONNECT_BASE_MS * 4)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(fetchCallsBeforeStop)
+    tracker.dispose()
+  })
+})

--- a/test/unit/server/coding-cli/session-indexer.test.ts
+++ b/test/unit/server/coding-cli/session-indexer.test.ts
@@ -1939,6 +1939,170 @@ describe('CodingCliSessionIndexer', () => {
     })
   })
 
+  it('extracts a lightweight title from a Codex response_item user message on cold start', async () => {
+    const files: string[] = []
+    for (let i = 0; i < 151; i += 1) {
+      const file = path.join(tempDir, `recent-${i}.jsonl`)
+      await fsp.writeFile(file, [
+        JSON.stringify({ type: 'session_meta', payload: { id: `recent-${i}`, cwd: `/project/${i}` } }),
+        JSON.stringify({
+          timestamp: new Date(2026, 3, 5, 12, i).toISOString(),
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: `Recent task ${i}` }],
+          },
+        }),
+      ].join('\n'))
+      files.push(file)
+    }
+
+    const olderSessionId = 'older-codex-session'
+    const olderFile = path.join(tempDir, `${olderSessionId}.jsonl`)
+    await fsp.writeFile(olderFile, [
+      JSON.stringify({ type: 'session_meta', payload: { id: olderSessionId, cwd: '/project/older' } }),
+      JSON.stringify({
+        timestamp: new Date(2026, 0, 1).toISOString(),
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Investigate sidebar visibility' }],
+        },
+      }),
+    ].join('\n'))
+    files.push(olderFile)
+
+    vi.mocked(configStore.snapshot).mockResolvedValue({
+      sessionOverrides: {},
+      settings: { codingCli: { enabledProviders: ['codex'], providers: {} } },
+    })
+
+    const provider = makeProvider(files, {
+      name: 'codex',
+      parseSessionFile: codexProvider.parseSessionFile,
+    })
+
+    const indexer = new CodingCliSessionIndexer([provider], { fullScanIntervalMs: 0 })
+    await indexer.refresh()
+
+    const olderSession = indexer.getProjects()
+      .flatMap((group) => group.sessions)
+      .find((session) => session.sessionId === olderSessionId)
+
+    expect(olderSession?.title).toBe('Investigate sidebar visibility')
+  })
+
+  it('does not synthesize a lightweight title from older system-context user records', async () => {
+    const files: string[] = []
+    const systemOnlyId = 'system-only'
+    const fileA = path.join(tempDir, `${systemOnlyId}.jsonl`)
+    await fsp.writeFile(fileA, JSON.stringify({
+      sessionId: systemOnlyId,
+      cwd: '/project/a',
+      role: 'user',
+      content: '<environment_context>\n  <cwd>/project/a</cwd>\n</environment_context>',
+      timestamp: new Date(2026, 0, 1).toISOString(),
+    }) + '\n')
+    await fsp.utimes(fileA, new Date(2026, 0, 1), new Date(2026, 0, 1))
+    files.push(fileA)
+
+    for (let i = 0; i < 151; i += 1) {
+      const file = path.join(tempDir, `recent-system-${i}.jsonl`)
+      await fsp.writeFile(file, [
+        JSON.stringify({ type: 'session_meta', payload: { id: `recent-system-${i}`, cwd: `/project/${i}` } }),
+        JSON.stringify({
+          timestamp: new Date(2026, 3, 5, 12, i).toISOString(),
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: `Recent task ${i}` }],
+          },
+        }),
+      ].join('\n'))
+      files.push(file)
+    }
+
+    vi.mocked(configStore.snapshot).mockResolvedValue({
+      sessionOverrides: {},
+      settings: { codingCli: { enabledProviders: ['codex'], providers: {} } },
+    })
+
+    const provider = makeProvider(files, {
+      name: 'codex',
+      parseSessionFile: codexProvider.parseSessionFile,
+    })
+
+    const indexer = new CodingCliSessionIndexer([provider], { fullScanIntervalMs: 0 })
+    await indexer.refresh()
+
+    const systemOnlySession = indexer.getProjects()
+      .flatMap((group) => group.sessions)
+      .find((session) => session.sessionId === systemOnlyId)
+
+    expect(systemOnlySession?.title).toBeUndefined()
+  })
+
+  it('extracts lightweight Codex titles from IDE-context messages', async () => {
+    const ideSessionId = 'ide-context-session'
+    const ideFile = path.join(tempDir, `${ideSessionId}.jsonl`)
+    await fsp.writeFile(ideFile, [
+      JSON.stringify({ type: 'session_meta', payload: { id: ideSessionId, cwd: '/project/ide' } }),
+      JSON.stringify({
+        timestamp: new Date(2026, 0, 1).toISOString(),
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{
+            type: 'input_text',
+            text: '# Context from my IDE setup:\n\n## My request for Codex:\nFix the authentication bug in the login form',
+          }],
+        },
+      }),
+    ].join('\n'))
+    await fsp.utimes(ideFile, new Date(2026, 0, 1), new Date(2026, 0, 1))
+
+    const files = [ideFile]
+    for (let i = 0; i < 151; i += 1) {
+      const file = path.join(tempDir, `recent-ide-${i}.jsonl`)
+      await fsp.writeFile(file, [
+        JSON.stringify({ type: 'session_meta', payload: { id: `recent-ide-${i}`, cwd: `/project/${i}` } }),
+        JSON.stringify({
+          timestamp: new Date(2026, 3, 5, 12, i).toISOString(),
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: `Recent task ${i}` }],
+          },
+        }),
+      ].join('\n'))
+      files.push(file)
+    }
+
+    vi.mocked(configStore.snapshot).mockResolvedValue({
+      sessionOverrides: {},
+      settings: { codingCli: { enabledProviders: ['codex'], providers: {} } },
+    })
+
+    const provider = makeProvider(files, {
+      name: 'codex',
+      parseSessionFile: codexProvider.parseSessionFile,
+    })
+
+    const indexer = new CodingCliSessionIndexer([provider], { fullScanIntervalMs: 0 })
+    await indexer.refresh()
+
+    const ideSession = indexer.getProjects()
+      .flatMap((group) => group.sessions)
+      .find((session) => session.sessionId === ideSessionId)
+
+    expect(ideSession?.title).toBe('Fix the authentication bug in the login form')
+  })
+
   it('groups worktree sessions under the parent repo', async () => {
     // Set up a real git repo structure in tempDir
     const repoDir = path.join(tempDir, 'repo')

--- a/test/unit/server/coding-cli/session-indexer.test.ts
+++ b/test/unit/server/coding-cli/session-indexer.test.ts
@@ -1786,7 +1786,9 @@ describe('CodingCliSessionIndexer', () => {
   })
 
   describe('sessionType merge from metadata store', () => {
-    function mockMetadataStore(entries: Record<string, { sessionType?: string }>): SessionMetadataStore {
+    function mockMetadataStore(
+      entries: Record<string, { sessionType?: string; derivedTitle?: string }>,
+    ): SessionMetadataStore {
       return {
         getAll: vi.fn().mockResolvedValue(entries),
         get: vi.fn(),
@@ -1836,6 +1838,104 @@ describe('CodingCliSessionIndexer', () => {
 
       const session = indexer.getProjects()[0]?.sessions[0]
       expect(session?.sessionType).toBeUndefined()
+    })
+
+    it('keeps an existing non-empty title when the same session reparses without one', async () => {
+      const fileA = path.join(tempDir, 'session-a.jsonl')
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a', title: 'Original title' }) + '\n')
+
+      const provider = makeProvider([fileA])
+      const indexer = new CodingCliSessionIndexer([provider])
+      await indexer.refresh()
+
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a' }) + '\n')
+      ;(indexer as any).markDirty(fileA)
+      await indexer.refresh()
+
+      expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('Original title')
+    })
+
+    it('hydrates a cold-start lightweight row from metadata-store derivedTitle when parsing finds no title', async () => {
+      const files: string[] = []
+      const sessionId = 'older-codex-session'
+      const fileA = path.join(tempDir, `${sessionId}.jsonl`)
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a' }) + '\n')
+      await fsp.utimes(fileA, new Date(2026, 0, 1), new Date(2026, 0, 1))
+      files.push(fileA)
+
+      for (let i = 0; i < 151; i += 1) {
+        const file = path.join(tempDir, `recent-${i}.jsonl`)
+        await fsp.writeFile(file, JSON.stringify({ cwd: `/project/${i}`, title: `Recent ${i}` }) + '\n')
+        files.push(file)
+      }
+
+      const provider = makeProvider(files, { name: 'codex' })
+      const metadataStore = mockMetadataStore({
+        [makeSessionKey('codex', sessionId)]: { derivedTitle: 'Sticky old title' },
+      })
+
+      vi.mocked(configStore.snapshot).mockResolvedValue({
+        sessionOverrides: {},
+        settings: { codingCli: { enabledProviders: ['codex'], providers: {} } },
+      })
+
+      const indexer = new CodingCliSessionIndexer([provider], {}, metadataStore)
+      await indexer.refresh()
+
+      const olderSession = indexer.getProjects()
+        .flatMap((group) => group.sessions)
+        .find((session) => session.sessionId === sessionId)
+
+      expect(olderSession?.title).toBe('Sticky old title')
+    })
+
+    it('persists a newly parsed non-empty title to the metadata store', async () => {
+      const fileA = path.join(tempDir, 'session-b.jsonl')
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a', title: 'Fresh title' }) + '\n')
+
+      const metadataStore = mockMetadataStore({})
+      metadataStore.set = vi.fn().mockResolvedValue(undefined)
+
+      const indexer = new CodingCliSessionIndexer([makeProvider([fileA])], {}, metadataStore)
+      await indexer.refresh()
+
+      expect(metadataStore.set).toHaveBeenCalledWith('claude', 'session-b', {
+        derivedTitle: 'Fresh title',
+      })
+    })
+
+    it('does not rewrite derivedTitle when the parsed title matches the stored title', async () => {
+      const fileA = path.join(tempDir, 'session-c.jsonl')
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a', title: 'Stable title' }) + '\n')
+
+      const metadataStore = mockMetadataStore({
+        [makeSessionKey('claude', 'session-c')]: { derivedTitle: 'Stable title' },
+      })
+      metadataStore.set = vi.fn().mockResolvedValue(undefined)
+
+      const indexer = new CodingCliSessionIndexer([makeProvider([fileA])], {}, metadataStore)
+      await indexer.refresh()
+
+      expect(metadataStore.set).not.toHaveBeenCalled()
+    })
+
+    it('resolves title precedence as parsed title, then previous cached title, then stored derivedTitle', async () => {
+      const fileA = path.join(tempDir, 'session-d.jsonl')
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a', title: 'Parsed title' }) + '\n')
+
+      const metadataStore = mockMetadataStore({
+        [makeSessionKey('claude', 'session-d')]: { derivedTitle: 'Stored title' },
+      })
+
+      const indexer = new CodingCliSessionIndexer([makeProvider([fileA])], {}, metadataStore)
+      await indexer.refresh()
+      expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('Parsed title')
+
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a' }) + '\n')
+      ;(indexer as any).markDirty(fileA)
+      await indexer.refresh()
+
+      expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('Parsed title')
     })
   })
 

--- a/test/unit/server/session-history-loader.test.ts
+++ b/test/unit/server/session-history-loader.test.ts
@@ -208,3 +208,56 @@ describe('loadSessionHistory', () => {
     expect(messages![0].content[0].text).toBe('Found me')
   })
 })
+
+describe('tool message coalescing', () => {
+  it('coalesces consecutive tool-only assistant messages from JSONL', () => {
+    const content = [
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]},"timestamp":"2026-01-01T00:00:01Z"}',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_result","tool_use_id":"t1","content":"file1\\nfile2"}]},"timestamp":"2026-01-01T00:00:02Z"}',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"f.ts"}}]},"timestamp":"2026-01-01T00:00:03Z"}',
+    ].join('\n')
+
+    const messages = extractChatMessagesFromJsonl(content)
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].content).toHaveLength(3)
+    expect(messages[0].content[0]).toEqual({ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } })
+    expect(messages[0].content[1]).toEqual({ type: 'tool_result', tool_use_id: 't1', content: 'file1\nfile2' })
+    expect(messages[0].content[2]).toEqual({ type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } })
+  })
+
+  it('does not coalesce when assistant message has text content', () => {
+    const content = [
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello"}]},"timestamp":"2026-01-01T00:00:01Z"}',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]},"timestamp":"2026-01-01T00:00:02Z"}',
+    ].join('\n')
+
+    const messages = extractChatMessagesFromJsonl(content)
+
+    expect(messages).toHaveLength(2)
+  })
+
+  it('does not coalesce across user messages', () => {
+    const content = [
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]},"timestamp":"2026-01-01T00:00:01Z"}',
+      '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Thanks"}]},"timestamp":"2026-01-01T00:00:02Z"}',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"f.ts"}}]},"timestamp":"2026-01-01T00:00:03Z"}',
+    ].join('\n')
+
+    const messages = extractChatMessagesFromJsonl(content)
+
+    expect(messages).toHaveLength(3)
+  })
+
+  it('preserves timestamp from first message in coalesced group', () => {
+    const content = [
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]},"timestamp":"2026-01-01T00:00:01Z"}',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_result","tool_use_id":"t1","content":"output"}]},"timestamp":"2026-01-01T00:00:02Z"}',
+    ].join('\n')
+
+    const messages = extractChatMessagesFromJsonl(content)
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].timestamp).toBe('2026-01-01T00:00:01Z')
+  })
+})

--- a/test/unit/server/session-history-loader.test.ts
+++ b/test/unit/server/session-history-loader.test.ts
@@ -92,6 +92,24 @@ describe('extractChatMessagesFromJsonl', () => {
     expect(messages).toHaveLength(2)
   })
 
+  it('coalesces tool messages even when malformed lines are interspersed', () => {
+    const content = [
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]},"timestamp":"2026-01-01T00:00:01Z"}',
+      'not valid json',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_result","tool_use_id":"t1","content":"output"}]},"timestamp":"2026-01-01T00:00:02Z"}',
+      'also malformed',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"f.ts"}}]},"timestamp":"2026-01-01T00:00:03Z"}',
+    ].join('\n')
+
+    const messages = extractChatMessagesFromJsonl(content)
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].content).toHaveLength(3)
+    expect(messages[0].content[0]).toEqual({ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } })
+    expect(messages[0].content[1]).toEqual({ type: 'tool_result', tool_use_id: 't1', content: 'output' })
+    expect(messages[0].content[2]).toEqual({ type: 'tool_use', id: 't2', name: 'Read', input: { file_path: 'f.ts' } })
+  })
+
   it('returns empty array for empty content', () => {
     expect(extractChatMessagesFromJsonl('')).toEqual([])
     expect(extractChatMessagesFromJsonl('\n\n')).toEqual([])

--- a/test/unit/server/session-metadata-store.test.ts
+++ b/test/unit/server/session-metadata-store.test.ts
@@ -72,6 +72,25 @@ describe('SessionMetadataStore', () => {
     expect(allAgain['claude:x']?.sessionType).toBe('freshclaude')
   })
 
+  it('merges derivedTitle into an existing metadata record', async () => {
+    await store.set('codex', 'sess-1', { sessionType: 'codex' })
+    await store.set('codex', 'sess-1', { derivedTitle: 'Investigate sidebar visibility' })
+
+    expect(await store.get('codex', 'sess-1')).toEqual({
+      sessionType: 'codex',
+      derivedTitle: 'Investigate sidebar visibility',
+    })
+  })
+
+  it('returns defensive copies that include derivedTitle', async () => {
+    await store.set('codex', 'sess-2', { derivedTitle: 'Sticky title' })
+
+    const entry = await store.get('codex', 'sess-2')
+    entry!.derivedTitle = 'mutated'
+
+    expect((await store.get('codex', 'sess-2'))?.derivedTitle).toBe('Sticky title')
+  })
+
   it('does not allow caller to mutate cache via set input', async () => {
     const input = { sessionType: 'freshclaude' }
     await store.set('claude', 'y', input)

--- a/test/unit/server/terminal-registry.test.ts
+++ b/test/unit/server/terminal-registry.test.ts
@@ -70,6 +70,16 @@ vi.mock('../../../server/mcp/config-writer.js', () => ({
 
 const VALID_CLAUDE_SESSION_ID = '550e8400-e29b-41d4-a716-446655440000'
 const OTHER_CLAUDE_SESSION_ID = '6f1c2b3a-4d5e-6f70-8a9b-0c1d2e3f4a5b'
+const TEST_OPENCODE_SERVER = { hostname: '127.0.0.1' as const, port: 43123 }
+
+function withOpencodeServer(
+  settings: { permissionMode?: string; model?: string; sandbox?: string } = {},
+) {
+  return {
+    ...settings,
+    opencodeServer: TEST_OPENCODE_SERVER,
+  }
+}
 
 function expectCodexMcpArgs(args: string[]) {
   // Bell notification still present
@@ -971,11 +981,29 @@ describe('buildSpawnSpec Unix paths', () => {
       delete process.env.OPENCODE_CMD
 
       const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, {
+        ...withOpencodeServer(),
         model: 'openai/gpt-5-mini',
       })
 
       expect(spec.args).toContain('--model')
       expect(spec.args).toContain('openai/gpt-5-mini')
+    })
+
+    it('requires an explicit localhost control endpoint for opencode and passes it as launch args', () => {
+      delete process.env.OPENCODE_CMD
+
+      expect(() => buildSpawnSpec('opencode', '/Users/john/project', 'system')).toThrow(
+        'OpenCode launch requires an allocated localhost control endpoint.',
+      )
+
+      const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, withOpencodeServer())
+
+      expect(spec.args).toEqual(expect.arrayContaining([
+        '--hostname',
+        '127.0.0.1',
+        '--port',
+        '43123',
+      ]))
     })
 
     it('defaults OpenCode to a usable Google model and alias env when only GEMINI_API_KEY is set', () => {
@@ -986,7 +1014,7 @@ describe('buildSpawnSpec Unix paths', () => {
       delete process.env.ANTHROPIC_API_KEY
       process.env.GEMINI_API_KEY = 'gemini-key'
 
-      const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system')
+      const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, withOpencodeServer())
 
       expect(spec.args).toContain('--model')
       expect(spec.args).toContain('google/gemini-3-pro-preview')
@@ -997,6 +1025,7 @@ describe('buildSpawnSpec Unix paths', () => {
       delete process.env.OPENCODE_CMD
 
       const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, {
+        ...withOpencodeServer(),
         permissionMode: 'plan',
       })
 
@@ -1007,6 +1036,7 @@ describe('buildSpawnSpec Unix paths', () => {
       delete process.env.OPENCODE_CMD
 
       const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, {
+        ...withOpencodeServer(),
         permissionMode: 'acceptEdits',
       })
 
@@ -2495,6 +2525,7 @@ describe('TerminalRegistry', () => {
           mode: 'opencode',
           cwd: '/home/user/project',
           resumeSessionId: 'session-opencode',
+          providerSettings: withOpencodeServer(),
         })
       } catch (err) {
         thrown = err
@@ -2517,7 +2548,11 @@ describe('TerminalRegistry', () => {
       const { cleanupMcpConfig } = await import('../../../server/mcp/config-writer.js')
       vi.mocked(cleanupMcpConfig).mockClear()
 
-      const record = registry.create({ mode: 'opencode', cwd: '/home/user/oc-project' })
+      const record = registry.create({
+        mode: 'opencode',
+        cwd: '/home/user/oc-project',
+        providerSettings: withOpencodeServer(),
+      })
       registry.kill(record.terminalId)
 
       // cleanup must use mcpCwd (the normalized cwd used during injection)
@@ -2528,7 +2563,11 @@ describe('TerminalRegistry', () => {
       const { cleanupMcpConfig } = await import('../../../server/mcp/config-writer.js')
       vi.mocked(cleanupMcpConfig).mockClear()
 
-      const record = registry.create({ mode: 'opencode', cwd: '/home/user/oc-exit' })
+      const record = registry.create({
+        mode: 'opencode',
+        cwd: '/home/user/oc-exit',
+        providerSettings: withOpencodeServer(),
+      })
       const pty = await import('node-pty')
       const mockPty = vi.mocked(pty.spawn).mock.results.at(-1)?.value
       const onExitCallback = mockPty.onExit.mock.calls[0][0]
@@ -3536,7 +3575,7 @@ describe('buildSpawnSpec Unix paths', () => {
 
     it('opencode mode passes cwd to generateMcpInjection', async () => {
       const { generateMcpInjection } = await import('../../../server/mcp/config-writer.js')
-      buildSpawnSpec('opencode', '/home/user/project', 'system', undefined, undefined, undefined, 'term-oc1')
+      buildSpawnSpec('opencode', '/home/user/project', 'system', undefined, withOpencodeServer(), undefined, 'term-oc1')
       expect(generateMcpInjection).toHaveBeenCalledWith('opencode', 'term-oc1', '/home/user/project', 'unix')
     })
 
@@ -3562,7 +3601,7 @@ describe('buildSpawnSpec Unix paths', () => {
       // On WSL, a Windows-style cwd (e.g. D:\project) should be converted to a Linux path
       // before being passed to generateMcpInjection. resolveUnixShellCwd handles this.
       // The raw Windows path would fail existsSync in config-writer on Linux.
-      buildSpawnSpec('opencode', 'D:\\project', 'system', undefined, undefined, undefined, 'term-wsl1')
+      buildSpawnSpec('opencode', 'D:\\project', 'system', undefined, withOpencodeServer(), undefined, 'term-wsl1')
       // The cwd passed to generateMcpInjection should be the resolved Unix path,
       // not the raw Windows path. On WSL, convertWindowsPathToWslPath converts
       // D:\project to /mnt/d/project.

--- a/test/unit/server/ws-handler-sdk.test.ts
+++ b/test/unit/server/ws-handler-sdk.test.ts
@@ -384,17 +384,10 @@ describe('WS Handler SDK Integration', () => {
       handler = new WsHandler(
         server,
         registry,
-        undefined, // codingCliManager
-        mockSdkBridge,
-        undefined, // sessionRepairService
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        mockHistorySource,
+        {
+          sdkBridge: mockSdkBridge,
+          agentHistorySource: mockHistorySource,
+        },
       )
     })
 

--- a/test/unit/server/ws-sdk-session-history-cache.test.ts
+++ b/test/unit/server/ws-sdk-session-history-cache.test.ts
@@ -227,17 +227,10 @@ describe('WsHandler agent history source DI', () => {
     handler = new WsHandler(
       server,
       registry,
-      undefined, // codingCliManager
-      mockSdkBridge as any,
-      undefined, // sessionRepairService
-      undefined, // handshakeSnapshotProvider
-      undefined, // terminalMetaListProvider
-      undefined, // tabsRegistryStore
-      undefined, // serverInstanceId
-      undefined, // layoutStore
-      undefined, // extensionManager
-      undefined, // codexActivityListProvider
-      injectedHistorySource,
+      {
+        sdkBridge: mockSdkBridge as any,
+        agentHistorySource: injectedHistorySource,
+      },
     )
 
     const ws = await connectAndAuth(server)
@@ -298,17 +291,10 @@ describe('WsHandler agent history source DI', () => {
     handler = new WsHandler(
       server,
       registry,
-      undefined,
-      mockSdkBridge as any,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      injectedHistorySource,
+      {
+        sdkBridge: mockSdkBridge as any,
+        agentHistorySource: injectedHistorySource,
+      },
     )
 
     const ws = await connectAndAuth(server)
@@ -364,17 +350,10 @@ describe('WsHandler agent history source DI', () => {
     handler = new WsHandler(
       server,
       registry,
-      undefined,
-      mockSdkBridge as any,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      injectedHistorySource,
+      {
+        sdkBridge: mockSdkBridge as any,
+        agentHistorySource: injectedHistorySource,
+      },
     )
 
     const ws = await connectAndAuth(server)
@@ -449,8 +428,9 @@ describe('WsHandler agent history source DI', () => {
     handler = new WsHandler(
       server,
       registry,
-      undefined,
-      mockSdkBridge as any,
+      {
+        sdkBridge: mockSdkBridge as any,
+      },
     )
 
     const ws = await connectAndAuth(server)

--- a/test/unit/shared/settings.test.ts
+++ b/test/unit/shared/settings.test.ts
@@ -34,6 +34,9 @@ describe('shared settings contract', () => {
     expect(schema.safeParse({ sidebar: { sortMode: 'activity' } }).success).toBe(false)
     expect(schema.safeParse({ sidebar: { showSubagents: true } }).success).toBe(false)
     expect(schema.safeParse({ sidebar: { ignoreCodexSubagents: true } }).success).toBe(false)
+    expect(schema.safeParse({ agentChat: { showThinking: true } }).success).toBe(false)
+    expect(schema.safeParse({ agentChat: { showTools: true } }).success).toBe(false)
+    expect(schema.safeParse({ agentChat: { showTimecodes: true } }).success).toBe(false)
   })
 
   it('defaults local sort mode to activity', () => {
@@ -107,6 +110,8 @@ describe('shared settings contract', () => {
       },
       agentChat: {
         defaultPlugins: ['fs'],
+        showThinking: true,
+        showTools: true,
       },
     }
 
@@ -125,6 +130,10 @@ describe('shared settings contract', () => {
         sortMode: 'project',
         showSubagents: true,
         ignoreCodexSubagents: false,
+      },
+      agentChat: {
+        showThinking: true,
+        showTools: true,
       },
       notifications: {
         soundEnabled: false,
@@ -199,6 +208,7 @@ describe('shared settings contract', () => {
       },
       agentChat: {
         defaultPlugins: ['fs'],
+        showThinking: true,
       },
     }
 


### PR DESCRIPTION
## Summary

- Move `showThinking`, `showTools`, and `showTimecodes` settings from per-pane storage (`AgentChatPaneContent`) to per-machine browser-local storage (`LocalSettings.agentChat`), with all three defaulting to **off** (`false`)
- Add migration path for existing users: legacy per-pane values are detected and written to browser preferences on load
- Add Workspace Settings UI toggles in a new "Agent chat" section

## Commits

1. `feat: move agent chat Show settings from per-pane to per-machine browser state` — Core migration: types, persistence, UI, component defaults, unit tests
2. `fix: update e2e tests and CollapsedTurn defaults for per-machine show settings` — First fresheyes review fixes
3. `fix: add legacy display settings migration and fix ToolStrip JSDoc` — Second fresheyes review: legacy migration, stale comment fix
4. `test: add agent-chat display settings coverage` — 9 SettingsView tests + 4 browser-preferences round-trip tests

## Test plan

- 3234 tests pass across 314 files (full suite green)
- TypeScript typecheck clean
- New coverage: `SettingsView.agent-chat.test.tsx` (9 tests), `browserPreferencesPersistence.test.ts` (+4 tests), `panesPersistence.test.ts` (+4 migration tests)