### PR TITLE
fix: harden production static client routing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -72,6 +72,7 @@ import { resolveStartupBanner } from './startup-banner.js'
 import { shouldPromoteSessionTitle } from './session-title-sync.js'
 import { CodexAppServerRuntime } from './coding-cli/codex-app-server/runtime.js'
 import { CodexLaunchPlanner } from './coding-cli/codex-app-server/launch-planner.js'
+import { registerStaticClientRoutes } from './static-client-routes.js'
 
 function compileArgTemplate(
   template: string[] | undefined,
@@ -518,11 +519,9 @@ async function main() {
   // --- Static client in production ---
   const distRoot = path.resolve(__dirname, '..')
   const clientDir = path.join(distRoot, 'client')
-  const indexHtml = path.join(clientDir, 'index.html')
 
   if (!isDev) {
-    app.use(express.static(clientDir, { index: false }))
-    app.get('*', (_req, res) => res.sendFile(indexHtml))
+    registerStaticClientRoutes(app, clientDir)
   }
 
   // Coding CLI watcher hooks

--- a/server/static-client-routes.ts
+++ b/server/static-client-routes.ts
@@ -1,0 +1,47 @@
+import express, { type Express, type Response } from 'express'
+import path from 'path'
+
+const HASHED_ASSET_RE = /[.-][A-Za-z0-9_-]{6,}\.(js|css|svg|png|jpg|jpeg|gif|woff2?)$/
+
+function setNoStoreHeaders(res: Response): void {
+  res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
+  res.setHeader('Pragma', 'no-cache')
+  res.setHeader('Expires', '0')
+}
+
+function applyStaticClientCacheHeaders(res: Response, filePath: string): void {
+  const normalizedPath = path.normalize(filePath)
+  const isIndexHtml = normalizedPath.endsWith(`${path.sep}index.html`)
+  const isHashedAsset = normalizedPath.includes(`${path.sep}assets${path.sep}`)
+    && HASHED_ASSET_RE.test(path.basename(normalizedPath))
+
+  if (isIndexHtml) {
+    setNoStoreHeaders(res)
+    return
+  }
+
+  if (isHashedAsset) {
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
+    return
+  }
+
+  res.setHeader('Cache-Control', 'no-cache')
+}
+
+export function registerStaticClientRoutes(app: Express, clientDir: string): void {
+  const indexHtml = path.join(clientDir, 'index.html')
+
+  app.use(express.static(clientDir, {
+    index: false,
+    setHeaders: (res, filePath) => applyStaticClientCacheHeaders(res, filePath),
+  }))
+
+  app.get('/assets/*', (_req, res) => {
+    res.status(404).send('Not found')
+  })
+
+  app.get('*', (_req, res) => {
+    setNoStoreHeaders(res)
+    res.sendFile(indexHtml)
+  })
+}

--- a/test/unit/server/production-build-integrity.test.ts
+++ b/test/unit/server/production-build-integrity.test.ts
@@ -1,0 +1,112 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import express from 'express'
+import fs from 'fs'
+import path from 'path'
+import request from 'supertest'
+import { registerStaticClientRoutes } from '../../../server/static-client-routes.js'
+
+const distClientDir = path.resolve(__dirname, '../../../dist/client')
+const hasBuild = fs.existsSync(path.join(distClientDir, 'index.html'))
+
+describe.skipIf(!hasBuild)('production build integrity', () => {
+  let indexHtml: string
+  let mainJsUrl: string | null = null
+  let mainJsContent = ''
+  let app: express.Express
+
+  beforeAll(() => {
+    indexHtml = fs.readFileSync(path.join(distClientDir, 'index.html'), 'utf8')
+    const scriptMatch = indexHtml.match(/src="(\/assets\/index-[A-Za-z0-9_-]+\.js)"/)
+    if (scriptMatch) mainJsUrl = scriptMatch[1]
+    if (mainJsUrl) {
+      const mainJsPath = path.join(distClientDir, ...mainJsUrl.split('/').filter(Boolean))
+      mainJsContent = fs.readFileSync(mainJsPath, 'utf8')
+    }
+
+    app = express()
+    registerStaticClientRoutes(app, distClientDir)
+  })
+
+  it('every <script src> asset in index.html exists on disk', () => {
+    const scripts = [...indexHtml.matchAll(/src="(\/assets\/[^"]+)"/g)].map((match) => match[1])
+    expect(scripts.length).toBeGreaterThanOrEqual(1)
+
+    for (const href of scripts) {
+      const filePath = path.join(distClientDir, ...href.split('/').filter(Boolean))
+      expect(fs.existsSync(filePath), `missing: ${href}`).toBe(true)
+    }
+  })
+
+  it('every <link href> asset in index.html exists on disk', () => {
+    const links = [...indexHtml.matchAll(/href="(\/assets\/[^"]+)"/g)].map((match) => match[1])
+
+    for (const href of links) {
+      const filePath = path.join(distClientDir, ...href.split('/').filter(Boolean))
+      expect(fs.existsSync(filePath), `missing: ${href}`).toBe(true)
+    }
+  })
+
+  it('every dynamic import in the main bundle exists on disk', () => {
+    expect(mainJsUrl).not.toBeNull()
+    const chunks = [...mainJsContent.matchAll(/import\(\s*"\.\/([^"]+)"/g)].map((match) => match[1])
+    expect(chunks.length).toBeGreaterThanOrEqual(1)
+
+    for (const chunk of chunks) {
+      const chunkPath = path.join(distClientDir, 'assets', chunk)
+      expect(fs.existsSync(chunkPath), `missing chunk: ${chunk}`).toBe(true)
+    }
+  })
+
+  it('serves index.html with no-cache headers', async () => {
+    const res = await request(app).get('/index.html')
+    expect(res.status).toBe(200)
+    expect(res.headers['cache-control']).toBe('no-cache, no-store, must-revalidate')
+  })
+
+  it('serves hashed emitted assets with immutable one-year cache', async () => {
+    const scripts = [...indexHtml.matchAll(/src="(\/assets\/[^"]+)"/g)].map((match) => match[1])
+    expect(scripts.length).toBeGreaterThanOrEqual(1)
+
+    for (const href of scripts) {
+      const res = await request(app).get(href)
+      expect(res.status, `failed to fetch ${href}`).toBe(200)
+      expect(res.headers['cache-control'], `${href} cache-control`).toBe('public, max-age=31536000, immutable')
+    }
+  })
+
+  it('serves dynamically imported chunks with immutable one-year cache', async () => {
+    expect(mainJsUrl).not.toBeNull()
+    const chunks = [...mainJsContent.matchAll(/import\(\s*"\.\/([^"]+)"/g)].map((match) => match[1])
+    expect(chunks.length).toBeGreaterThanOrEqual(1)
+
+    for (const chunk of chunks) {
+      const res = await request(app).get(`/assets/${chunk}`)
+      expect(res.status, `failed to fetch chunk ${chunk}`).toBe(200)
+      expect(res.headers['cache-control'], `chunk ${chunk} cache-control`).toBe('public, max-age=31536000, immutable')
+    }
+  })
+
+  it('returns 404 for missing /assets paths', async () => {
+    const res = await request(app).get('/assets/SettingsView-DOESNOTEXIST.js')
+    expect(res.status).toBe(404)
+  })
+
+  it('falls through to SPA HTML for missing non-asset paths', async () => {
+    const res = await request(app).get('/some/deep/spa/route')
+    expect(res.status).toBe(200)
+    expect(res.headers['cache-control']).toBe('no-cache, no-store, must-revalidate')
+    expect(res.text).toContain('<html')
+  })
+
+  it('serves unhashed root assets with no-cache', async () => {
+    const res = await request(app).get('/sw.js')
+    expect(res.status).toBe(200)
+    expect(res.headers['cache-control']).toBe('no-cache')
+  })
+
+  it('serves manifest.webmanifest with no-cache', async () => {
+    const res = await request(app).get('/manifest.webmanifest')
+    expect(res.status).toBe(200)
+    expect(res.headers['cache-control']).toBe('no-cache')
+  })
+})

--- a/test/unit/server/static-cache-headers.test.ts
+++ b/test/unit/server/static-cache-headers.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import express from 'express'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import request from 'supertest'
+import { registerStaticClientRoutes } from '../../../server/static-client-routes.js'
+
+describe('production static file cache headers', () => {
+  let app: express.Express
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'freshell-static-client-'))
+    const clientDir = path.join(tempDir, 'client')
+    fs.mkdirSync(path.join(clientDir, 'assets'), { recursive: true })
+    fs.writeFileSync(path.join(clientDir, 'index.html'), '<html>test</html>')
+    fs.writeFileSync(path.join(clientDir, 'sw.js'), 'self.addEventListener("fetch", () => {})')
+    fs.writeFileSync(path.join(clientDir, 'manifest.webmanifest'), '{}')
+    fs.writeFileSync(path.join(clientDir, 'favicon.ico'), '')
+    fs.writeFileSync(path.join(clientDir, 'assets', 'index-abc123.js'), 'console.log("hello")')
+    fs.writeFileSync(path.join(clientDir, 'assets', 'EditorPane-xyz789.js'), 'export {}')
+    fs.writeFileSync(path.join(clientDir, 'assets', 'styles-def456.css'), 'body{}')
+
+    app = express()
+    registerStaticClientRoutes(app, clientDir)
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('serves index.html directly with no-cache/no-store headers', async () => {
+    const res = await request(app).get('/index.html')
+    expect(res.status).toBe(200)
+    expect(res.headers['cache-control']).toBe('no-cache, no-store, must-revalidate')
+    expect(res.headers['pragma']).toBe('no-cache')
+    expect(res.headers['expires']).toBe('0')
+  })
+
+  it('serves SPA fallback routes with no-cache/no-store headers', async () => {
+    const res = await request(app).get('/some/deep/route')
+    expect(res.status).toBe(200)
+    expect(res.headers['cache-control']).toBe('no-cache, no-store, must-revalidate')
+    expect(res.headers['pragma']).toBe('no-cache')
+    expect(res.headers['expires']).toBe('0')
+  })
+
+  it('serves hashed assets with immutable one-year cache', async () => {
+    const res = await request(app).get('/assets/index-abc123.js')
+    expect(res.status).toBe(200)
+    expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable')
+  })
+
+  it('serves hashed editor chunks with immutable one-year cache', async () => {
+    const res = await request(app).get('/assets/EditorPane-xyz789.js')
+    expect(res.status).toBe(200)
+    expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable')
+  })
+
+  it('serves hashed CSS assets with immutable one-year cache', async () => {
+    const res = await request(app).get('/assets/styles-def456.css')
+    expect(res.status).toBe(200)
+    expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable')
+  })
+
+  it('serves unhashed root assets with no-cache', async () => {
+    const sw = await request(app).get('/sw.js')
+    expect(sw.status).toBe(200)
+    expect(sw.headers['cache-control']).toBe('no-cache')
+
+    const manifest = await request(app).get('/manifest.webmanifest')
+    expect(manifest.status).toBe(200)
+    expect(manifest.headers['cache-control']).toBe('no-cache')
+
+    const favicon = await request(app).get('/favicon.ico')
+    expect(favicon.status).toBe(200)
+    expect(favicon.headers['cache-control']).toBe('no-cache')
+  })
+
+  it('returns 404 for missing assets under /assets', async () => {
+    const res = await request(app).get('/assets/missing-abc123.js')
+    expect(res.status).toBe(404)
+  })
+
+  it('falls through to SPA HTML for missing non-asset routes', async () => {
+    const res = await request(app).get('/missing/non-asset/path')
+    expect(res.status).toBe(200)
+    expect(res.headers['cache-control']).toBe('no-cache, no-store, must-revalidate')
+    expect(res.text).toContain('<html')
+  })
+})


### PR DESCRIPTION
## Summary
- extract production static-client wiring into a dedicated helper with explicit cache rules
- mark unhashed shell responses as no-store and keep long-lived caching only for hashed build assets
- fail closed on missing `/assets/*` requests and cover the contract with server tests

## Testing
- npm run test:vitest -- --config vitest.server.config.ts test/unit/server/static-cache-headers.test.ts --run
- npm run build
- npm run test:vitest -- --config vitest.server.config.ts test/unit/server/static-cache-headers.test.ts test/unit/server/production-build-integrity.test.ts --run
- npm run check