### PR TITLE
fix: preserve newer pane layouts during stale hydration

### DIFF
--- a/src/store/panesSlice.ts
+++ b/src/store/panesSlice.ts
@@ -460,16 +460,17 @@ function mergeHydratedPaneMetadata(
   for (const [tabId, layout] of Object.entries(layouts)) {
     const paneIds = collectLeafPaneIds(layout)
     const paneIdSet = new Set(paneIds)
-    const preferredTitleSource = incomingLayoutTabIds.has(tabId)
-      ? incoming.paneTitles
-      : state.paneTitles
-    const preferredTitleSetByUserSource = incomingLayoutTabIds.has(tabId)
-      ? incoming.paneTitleSetByUser
-      : state.paneTitleSetByUser
+    const localLayoutPreserved = !incomingLayoutTabIds.has(tabId)
+    const preferredTitleSource = localLayoutPreserved
+      ? state.paneTitles
+      : incoming.paneTitles
+    const preferredTitleSetByUserSource = localLayoutPreserved
+      ? state.paneTitleSetByUser
+      : incoming.paneTitleSetByUser
 
     const nextActivePane = pickHydratedActivePane(
       paneIds,
-      incoming.activePane?.[tabId],
+      localLayoutPreserved ? undefined : incoming.activePane?.[tabId],
       state.activePane?.[tabId],
     )
     if (nextActivePane) {
@@ -477,8 +478,26 @@ function mergeHydratedPaneMetadata(
     }
 
     const nextPaneTitles = filterPaneMetadataByLayout(preferredTitleSource, tabId, paneIdSet)
+    const fallbackTitles = !localLayoutPreserved
+      ? filterPaneMetadataByLayout(state.paneTitles, tabId, paneIdSet)
+      : undefined
+    const localUserSetTitleFlags = !localLayoutPreserved
+      ? filterPaneMetadataByLayout(state.paneTitleSetByUser, tabId, paneIdSet)
+      : undefined
     if (nextPaneTitles) {
-      paneTitles[tabId] = nextPaneTitles
+      if (fallbackTitles && localUserSetTitleFlags) {
+        const merged = { ...nextPaneTitles }
+        for (const [paneId, title] of Object.entries(fallbackTitles)) {
+          if (localUserSetTitleFlags[paneId]) {
+            merged[paneId] = title
+          }
+        }
+        paneTitles[tabId] = merged
+      } else {
+        paneTitles[tabId] = nextPaneTitles
+      }
+    } else if (fallbackTitles) {
+      paneTitles[tabId] = fallbackTitles
     }
 
     const nextPaneTitleSetByUser = filterPaneMetadataByLayout(
@@ -486,8 +505,14 @@ function mergeHydratedPaneMetadata(
       tabId,
       paneIdSet,
     )
-    if (nextPaneTitleSetByUser) {
-      paneTitleSetByUser[tabId] = nextPaneTitleSetByUser
+    const fallbackTitleSetByUser = !localLayoutPreserved
+      ? filterPaneMetadataByLayout(state.paneTitleSetByUser, tabId, paneIdSet)
+      : undefined
+    if (nextPaneTitleSetByUser || fallbackTitleSetByUser) {
+      paneTitleSetByUser[tabId] = {
+        ...(nextPaneTitleSetByUser || {}),
+        ...(fallbackTitleSetByUser || {}),
+      }
     }
   }
 
@@ -648,6 +673,24 @@ function mergeTerminalState(
     return {
       ...incoming,
       children: [mergedLeft, mergedRight],
+    }
+  }
+
+  if (local.type !== incoming.type) {
+    const localAt = meta?.localLayoutPersistedAt
+    const remoteAt = meta?.remoteLayoutPersistedAt
+    const timestampsAvailable = typeof localAt === 'number' && typeof remoteAt === 'number'
+    const localIsNewer = timestampsAvailable && remoteAt < localAt
+    const remoteIsNewer = timestampsAvailable && remoteAt >= localAt
+
+    if (local.type === 'split' && incoming.type === 'leaf') {
+      if (localIsNewer) return local
+      if (remoteIsNewer) return incoming
+    }
+
+    if (local.type === 'leaf' && incoming.type === 'split') {
+      if (localIsNewer) return local
+      if (remoteIsNewer) return incoming
     }
   }
 

--- a/test/unit/client/store/panesSlice.test.ts
+++ b/test/unit/client/store/panesSlice.test.ts
@@ -2297,6 +2297,323 @@ describe('panesSlice', () => {
       expect(next.paneTitles['tab-1']).toEqual({ 'pane-1': 'Local title' })
       expect(next.paneTitleSetByUser['tab-1']).toEqual({ 'pane-1': true })
     })
+
+    const terminalLeaf = (id: string, terminalId: string): PaneNode => ({
+      type: 'leaf',
+      id,
+      content: {
+        kind: 'terminal',
+        mode: 'shell',
+        createRequestId: `req-${id}`,
+        status: 'running',
+        terminalId,
+      } as TerminalPaneContent,
+    })
+
+    const editorLeaf = (id: string, filePath: string): PaneNode => ({
+      type: 'leaf',
+      id,
+      content: {
+        kind: 'editor',
+        filePath,
+        language: null,
+        readOnly: false,
+        content: '',
+        viewMode: 'source',
+      } as EditorPaneContent,
+    })
+
+    const crossTabMeta = (localLayoutPersistedAt: number, remoteLayoutPersistedAt: number) => ({
+      localLayoutPersistedAt,
+      remoteLayoutPersistedAt,
+    })
+
+    it('preserves local split when incoming is a stale leaf', () => {
+      const now = 1_000_000
+      const localState: PanesState = {
+        layouts: {
+          'tab-1': {
+            type: 'split',
+            id: 'split-1',
+            direction: 'horizontal',
+            sizes: [50, 50],
+            children: [
+              terminalLeaf('pane-1', 't1'),
+              editorLeaf('pane-2', '/path/to/file.ts'),
+            ],
+          },
+        },
+        activePane: { 'tab-1': 'pane-2' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Shell', 'pane-2': 'file.ts' } },
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const incoming: PanesState = {
+        layouts: { 'tab-1': terminalLeaf('pane-1', 't1') },
+        activePane: { 'tab-1': 'pane-1' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Shell' } },
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const action = {
+        ...hydratePanes(incoming),
+        meta: crossTabMeta(now, now - 60_000),
+      }
+
+      const state = panesReducer(localState, action)
+      expect(state.layouts['tab-1']?.type).toBe('split')
+      expect(state.activePane['tab-1']).toBe('pane-2')
+    })
+
+    it('accepts incoming leaf over local split when incoming is newer', () => {
+      const now = 1_000_000
+      const localState: PanesState = {
+        layouts: {
+          'tab-1': {
+            type: 'split',
+            id: 'split-1',
+            direction: 'horizontal',
+            sizes: [50, 50],
+            children: [
+              terminalLeaf('pane-1', 't1'),
+              editorLeaf('pane-2', '/path/to/file.ts'),
+            ],
+          },
+        },
+        activePane: { 'tab-1': 'pane-2' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Shell', 'pane-2': 'file.ts' } },
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const incoming: PanesState = {
+        layouts: { 'tab-1': terminalLeaf('pane-1', 't1') },
+        activePane: { 'tab-1': 'pane-1' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Shell' } },
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const action = {
+        ...hydratePanes(incoming),
+        meta: crossTabMeta(now - 60_000, now),
+      }
+
+      const state = panesReducer(localState, action)
+      expect(state.layouts['tab-1']?.type).toBe('leaf')
+      expect(state.activePane['tab-1']).toBe('pane-1')
+    })
+
+    it('accepts incoming leaf over local split when timestamps are absent', () => {
+      const localState: PanesState = {
+        layouts: {
+          'tab-1': {
+            type: 'split',
+            id: 'split-1',
+            direction: 'horizontal',
+            sizes: [50, 50],
+            children: [
+              terminalLeaf('pane-1', 't1'),
+              editorLeaf('pane-2', '/path/to/file.ts'),
+            ],
+          },
+        },
+        activePane: { 'tab-1': 'pane-2' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Shell', 'pane-2': 'file.ts' } },
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const incoming: PanesState = {
+        layouts: { 'tab-1': terminalLeaf('pane-1', 't1') },
+        activePane: { 'tab-1': 'pane-1' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Shell' } },
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const state = panesReducer(localState, hydratePanes(incoming))
+      expect(state.layouts['tab-1']?.type).toBe('leaf')
+      expect(state.activePane['tab-1']).toBe('pane-1')
+    })
+
+    it('preserves local leaf when incoming is a stale split', () => {
+      const now = 1_000_000
+      const localState: PanesState = {
+        layouts: { 'tab-1': terminalLeaf('pane-1', 't1') },
+        activePane: { 'tab-1': 'pane-1' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Shell' } },
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const incoming: PanesState = {
+        layouts: {
+          'tab-1': {
+            type: 'split',
+            id: 'split-1',
+            direction: 'horizontal',
+            sizes: [50, 50],
+            children: [
+              terminalLeaf('pane-1', 't1'),
+              editorLeaf('pane-2', '/path/to/file.ts'),
+            ],
+          },
+        },
+        activePane: { 'tab-1': 'pane-2' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Shell', 'pane-2': 'file.ts' } },
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const action = {
+        ...hydratePanes(incoming),
+        meta: crossTabMeta(now, now - 60_000),
+      }
+
+      const state = panesReducer(localState, action)
+      expect(state.layouts['tab-1']?.type).toBe('leaf')
+      expect(state.activePane['tab-1']).toBe('pane-1')
+    })
+
+    it('keeps incoming metadata as the base but reapplies local user titles for surviving panes', () => {
+      const now = 1_000_000
+      const localState: PanesState = {
+        layouts: {
+          'tab-1': {
+            type: 'split',
+            id: 'split-1',
+            direction: 'horizontal',
+            sizes: [50, 50],
+            children: [
+              terminalLeaf('pane-1', 't1'),
+              editorLeaf('pane-2', '/path/to/local-file.ts'),
+            ],
+          },
+        },
+        activePane: { 'tab-1': 'pane-2' },
+        paneTitles: { 'tab-1': { 'pane-1': 'My shell', 'pane-2': 'My file alias' } },
+        paneTitleSetByUser: { 'tab-1': { 'pane-1': true, 'pane-2': true } },
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const incoming: PanesState = {
+        layouts: {
+          'tab-1': {
+            type: 'split',
+            id: 'split-1',
+            direction: 'horizontal',
+            sizes: [50, 50],
+            children: [
+              terminalLeaf('pane-1', 't1'),
+              editorLeaf('pane-2', '/path/to/remote-file.ts'),
+            ],
+          },
+        },
+        activePane: { 'tab-1': 'pane-1' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Remote shell', 'pane-2': 'remote-file.ts' } },
+        paneTitleSetByUser: { 'tab-1': { 'pane-2': false } },
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const action = {
+        ...hydratePanes(incoming),
+        meta: crossTabMeta(now - 60_000, now),
+      }
+
+      const state = panesReducer(localState, action)
+      expect(state.activePane['tab-1']).toBe('pane-1')
+      expect(state.paneTitles['tab-1']).toEqual({
+        'pane-1': 'My shell',
+        'pane-2': 'My file alias',
+      })
+      expect(state.paneTitleSetByUser['tab-1']).toEqual({
+        'pane-1': true,
+        'pane-2': true,
+      })
+    })
+
+    it('preserves local user-set pane titles for surviving panes when local layout wins', () => {
+      const now = 1_000_000
+      const localState: PanesState = {
+        layouts: {
+          'tab-1': {
+            type: 'split',
+            id: 'split-1',
+            direction: 'horizontal',
+            sizes: [50, 50],
+            children: [
+              terminalLeaf('pane-1', 't1'),
+              editorLeaf('pane-2', '/path/to/local-file.ts'),
+            ],
+          },
+        },
+        activePane: { 'tab-1': 'pane-2' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Shell', 'pane-2': 'My file alias' } },
+        paneTitleSetByUser: { 'tab-1': { 'pane-2': true } },
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const incoming: PanesState = {
+        layouts: { 'tab-1': terminalLeaf('pane-1', 't1') },
+        activePane: { 'tab-1': 'pane-1' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Shell' } },
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const action = {
+        ...hydratePanes(incoming),
+        meta: crossTabMeta(now, now - 60_000),
+      }
+
+      const state = panesReducer(localState, action)
+      expect(state.paneTitles['tab-1']).toEqual({
+        'pane-1': 'Shell',
+        'pane-2': 'My file alias',
+      })
+      expect(state.paneTitleSetByUser['tab-1']).toEqual({
+        'pane-2': true,
+      })
+    })
   })
 
   describe('clearDeadTerminals', () => {


### PR DESCRIPTION
## Summary
- preserve newer local split/leaf structure during stale cross-tab `hydratePanes` merges
- keep incoming structure when timestamps prove it is newer, and keep existing behavior when timestamps are absent
- preserve local user-owned pane titles and title flags across surviving panes during hydrate metadata merges

## Testing
- npm run test:vitest -- test/unit/client/store/panesSlice.test.ts --run
- npm run check