### PR TITLE
fix: align Codex app-server initialize contract

### DIFF
--- a/server/coding-cli/codex-app-server/protocol.ts
+++ b/server/coding-cli/codex-app-server/protocol.ts
@@ -14,7 +14,10 @@ export const CodexInitializeParamsSchema = z.object({
 })
 
 export const CodexInitializeResultSchema = z.object({
-  protocolVersion: z.string().min(1),
+  userAgent: z.string().min(1),
+  codexHome: z.string().min(1),
+  platformFamily: z.string().min(1),
+  platformOs: z.string().min(1),
 })
 
 export const CodexThreadSchema = z.object({

--- a/test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs
+++ b/test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs
@@ -18,7 +18,12 @@ function loadBehavior() {
 
 function successResult(method, params) {
   if (method === 'initialize') {
-    return { protocolVersion: 'fixture-v1' }
+    return {
+      userAgent: 'freshell-fixture/1.0.0',
+      codexHome: '/tmp/fake-codex-home',
+      platformFamily: 'unix',
+      platformOs: 'linux',
+    }
   }
   if (method === 'thread/start') {
     return {
@@ -26,6 +31,14 @@ function successResult(method, params) {
         id: 'thread-new-1',
       },
       cwd: params?.cwd ?? process.cwd(),
+      model: 'fixture-model',
+      modelProvider: 'openai',
+      instructionSources: [],
+      approvalPolicy: 'never',
+      approvalsReviewer: 'user',
+      sandbox: {
+        type: 'dangerFullAccess',
+      },
     }
   }
   if (method === 'thread/resume') {
@@ -34,6 +47,14 @@ function successResult(method, params) {
         id: params?.threadId,
       },
       cwd: params?.cwd ?? process.cwd(),
+      model: 'fixture-model',
+      modelProvider: 'openai',
+      instructionSources: [],
+      approvalPolicy: 'never',
+      approvalsReviewer: 'user',
+      sandbox: {
+        type: 'dangerFullAccess',
+      },
     }
   }
   return {}

--- a/test/unit/server/coding-cli/codex-app-server/client.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/client.test.ts
@@ -100,12 +100,15 @@ afterEach(async () => {
 })
 
 describe('CodexAppServerClient', () => {
-  it('initializes the app-server and returns the reported protocol version', async () => {
+  it('initializes the app-server and returns the negotiated server metadata', async () => {
     const server = await startFakeCodexAppServer()
     const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
 
     await expect(client.initialize()).resolves.toMatchObject({
-      protocolVersion: expect.any(String),
+      userAgent: expect.any(String),
+      codexHome: expect.any(String),
+      platformFamily: expect.any(String),
+      platformOs: expect.any(String),
     })
   })
 
@@ -165,7 +168,10 @@ describe('CodexAppServerClient', () => {
     const startThreadPromise = client.startThread({ cwd: '/repo/worktree' })
 
     await expect(initializePromise).resolves.toMatchObject({
-      protocolVersion: expect.any(String),
+      userAgent: expect.any(String),
+      codexHome: expect.any(String),
+      platformFamily: expect.any(String),
+      platformOs: expect.any(String),
     })
     await expect(startThreadPromise).resolves.toEqual({
       threadId: 'thread-new-1',


### PR DESCRIPTION
## Summary
- update Freshell's Codex app-server initialize schema to match the current app-server response shape
- refresh the fake app-server fixture and client test expectations so protocol drift fails in tests instead of production
- cover the regression against the real installed `codex app-server` runtime path before publishing

## Root Cause
PR #298 introduced the shared Codex app-server runtime in commit `996f48b9`, but it validated `initialize` as `{ protocolVersion }`. Current Codex app-server builds return server metadata (`userAgent`, `codexHome`, `platformFamily`, `platformOs`) instead, so Freshell rejected startup before any thread launch.

## Verification
- `npm run test:vitest -- --config vitest.server.config.ts test/unit/server/coding-cli/codex-app-server/client.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts test/integration/server/codex-session-flow.test.ts`
- `npx tsx --eval "import { CodexAppServerRuntime } from './server/coding-cli/codex-app-server/runtime.ts'; void (async () => { const runtime = new CodexAppServerRuntime({ startupAttemptTimeoutMs: 5000, requestTimeoutMs: 5000 }); try { const ready = await runtime.ensureReady(); console.log(JSON.stringify(ready)); } finally { await runtime.shutdown(); } })();"`

## Notes
- PR #298 is already merged, so this lands as a follow-up fix rather than an amendment to the closed PR.