### PR TITLE
Fix Codex restore planning and app-server stalls

### DIFF
--- a/server/coding-cli/codex-app-server/launch-planner.ts
+++ b/server/coding-cli/codex-app-server/launch-planner.ts
@@ -17,19 +17,21 @@ type PlanCreateInput = {
 
 export class CodexLaunchPlanner {
   constructor(
-    private readonly runtime: Pick<CodexAppServerRuntime, 'startThread' | 'resumeThread'>,
+    private readonly runtime: Pick<CodexAppServerRuntime, 'ensureReady' | 'startThread'>,
   ) {}
 
   async planCreate(input: PlanCreateInput): Promise<CodexLaunchPlan> {
-    const planResult = input.resumeSessionId
-      ? await this.runtime.resumeThread({
-        threadId: input.resumeSessionId,
-        cwd: input.cwd,
-        model: input.model,
-        sandbox: input.sandbox,
-        approvalPolicy: input.approvalPolicy,
-      })
-      : await this.runtime.startThread({
+    if (input.resumeSessionId) {
+      const ready = await this.runtime.ensureReady()
+      return {
+        sessionId: input.resumeSessionId,
+        remote: {
+          wsUrl: ready.wsUrl,
+        },
+      }
+    }
+
+    const planResult = await this.runtime.startThread({
         cwd: input.cwd,
         model: input.model,
         sandbox: input.sandbox,

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -127,6 +127,11 @@ export class CodexAppServerRuntime {
         stdio: ['ignore', 'pipe', 'pipe'],
       })
 
+      // Drain child stdio continuously so verbose app-server or MCP startup logs
+      // cannot fill the pipe buffer and stall JSON-RPC request handling.
+      child.stdout?.resume()
+      child.stderr?.resume()
+
       this.child = child
       this.attachChildExitHandler(child)
 

--- a/test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs
+++ b/test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs
@@ -16,6 +16,34 @@ function loadBehavior() {
   return JSON.parse(raw)
 }
 
+function writeBytes(stream, totalBytes, chunkSize = 16 * 1024) {
+  if (!Number.isFinite(totalBytes) || totalBytes <= 0) {
+    return Promise.resolve()
+  }
+
+  const chunk = Buffer.alloc(Math.max(1, Math.min(chunkSize, totalBytes)), 'x')
+  let remaining = totalBytes
+
+  return new Promise((resolve, reject) => {
+    const writeNext = () => {
+      while (remaining > 0) {
+        const size = Math.min(chunk.length, remaining)
+        const payload = size === chunk.length ? chunk : chunk.subarray(0, size)
+        remaining -= size
+        const canContinue = stream.write(payload)
+        if (!canContinue) {
+          stream.once('drain', writeNext)
+          return
+        }
+      }
+      resolve()
+    }
+
+    stream.once('error', reject)
+    writeNext()
+  })
+}
+
 function successResult(method, params) {
   if (method === 'initialize') {
     return {
@@ -102,6 +130,8 @@ wss.on('connection', (socket) => {
 
     const override = behavior.overrides?.[method]
     const delayMs = Number(behavior.delayMethodsMs?.[method] || 0)
+    const floodStdoutBytes = Number(behavior.floodStdoutBeforeMethodsBytes?.[method] || 0)
+    const floodStderrBytes = Number(behavior.floodStderrBeforeMethodsBytes?.[method] || 0)
     if (override?.error) {
       setTimeout(() => {
         socket.send(JSON.stringify({
@@ -112,7 +142,9 @@ wss.on('connection', (socket) => {
       return
     }
 
-    setTimeout(() => {
+    setTimeout(async () => {
+      await writeBytes(process.stdout, floodStdoutBytes)
+      await writeBytes(process.stderr, floodStderrBytes)
       socket.send(JSON.stringify({
         id: message.id,
         result: override?.result ?? successResult(method, message.params),

--- a/test/integration/server/codex-session-flow.test.ts
+++ b/test/integration/server/codex-session-flow.test.ts
@@ -201,6 +201,8 @@ describe('Codex Session Flow Integration', () => {
   })
 
   beforeEach(async () => {
+    delete process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR
+    await runtime.shutdown()
     vi.mocked(configStore.snapshot).mockResolvedValue({
       settings: {
         codingCli: {
@@ -276,6 +278,59 @@ describe('Codex Session Flow Integration', () => {
       expect(recordedArgs).not.toContain('--sandbox')
     } finally {
       await closeWebSocket(ws)
+    }
+  })
+
+  it('restores a persisted Codex session without calling thread/resume on the app-server', async () => {
+    process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR = JSON.stringify({
+      overrides: {
+        'thread/resume': {
+          error: {
+            code: -32600,
+            message: 'no rollout found for thread id thread-existing-1',
+          },
+        },
+      },
+    })
+
+    const ws = await createAuthenticatedWs(port)
+
+    try {
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId: 'test-req-codex-restore',
+        mode: 'codex',
+        cwd: tempDir,
+        resumeSessionId: 'thread-existing-1',
+      }))
+
+      const created = await waitForMessage(
+        ws,
+        (msg) => (
+          msg.requestId === 'test-req-codex-restore'
+          && (msg.type === 'terminal.created' || msg.type === 'error')
+        ),
+      )
+      if (created.type === 'error') {
+        throw new Error(`terminal.create failed: ${created.message}`)
+      }
+
+      expect(created.effectiveResumeSessionId).toBe('thread-existing-1')
+
+      const record = registry.get(created.terminalId)
+      expect(record?.resumeSessionId).toBe('thread-existing-1')
+
+      await waitForFile(argLogPath)
+      const recordedArgs = JSON.parse(await fsp.readFile(argLogPath, 'utf8'))
+      expect(recordedArgs.slice(0, 2)).toEqual([
+        '--remote',
+        expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
+      ])
+      expect(recordedArgs).toContain('resume')
+      expect(recordedArgs).toContain('thread-existing-1')
+    } finally {
+      await closeWebSocket(ws)
+      delete process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR
     }
   })
 })

--- a/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
@@ -4,11 +4,11 @@ import { CodexLaunchPlanner } from '../../../../../server/coding-cli/codex-app-s
 describe('CodexLaunchPlanner', () => {
   it('starts a fresh Codex thread and returns an exact remote endpoint handoff', async () => {
     const runtime = {
+      ensureReady: vi.fn(),
       startThread: vi.fn().mockResolvedValue({
         threadId: 'thread-new-1',
         wsUrl: 'ws://127.0.0.1:43123',
       }),
-      resumeThread: vi.fn(),
     }
     const planner = new CodexLaunchPlanner(runtime as any)
 
@@ -28,13 +28,12 @@ describe('CodexLaunchPlanner', () => {
     expect(plan.remote.wsUrl).toBe('ws://127.0.0.1:43123')
   })
 
-  it('resumes an existing Codex thread before spawn', async () => {
+  it('reuses an existing Codex session id and only ensures the remote runtime is ready', async () => {
     const runtime = {
-      startThread: vi.fn(),
-      resumeThread: vi.fn().mockResolvedValue({
-        threadId: '019d9859-5670-72b1-851f-794ad7fef112',
+      ensureReady: vi.fn().mockResolvedValue({
         wsUrl: 'ws://127.0.0.1:43123',
       }),
+      startThread: vi.fn(),
     }
     const planner = new CodexLaunchPlanner(runtime as any)
 
@@ -43,24 +42,19 @@ describe('CodexLaunchPlanner', () => {
       resumeSessionId: '019d9859-5670-72b1-851f-794ad7fef112',
     })
 
-    expect(runtime.resumeThread).toHaveBeenCalledWith({
-      threadId: '019d9859-5670-72b1-851f-794ad7fef112',
-      cwd: '/repo/worktree',
-      model: undefined,
-      sandbox: undefined,
-      approvalPolicy: undefined,
-    })
+    expect(runtime.ensureReady).toHaveBeenCalledTimes(1)
+    expect(runtime.startThread).not.toHaveBeenCalled()
     expect(plan.sessionId).toBe('019d9859-5670-72b1-851f-794ad7fef112')
     expect(plan.remote.wsUrl).toBe('ws://127.0.0.1:43123')
   })
 
   it('uses the runtime-reported wsUrl from the same thread create call', async () => {
     const runtime = {
+      ensureReady: vi.fn(),
       startThread: vi.fn().mockResolvedValue({
         threadId: 'thread-new-2',
         wsUrl: 'ws://127.0.0.1:43199',
       }),
-      resumeThread: vi.fn(),
     }
     const planner = new CodexLaunchPlanner(runtime as any)
 

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -177,4 +177,43 @@ describe('CodexAppServerRuntime', () => {
     expect(ready.wsUrl).not.toBe(`ws://${endpoint.hostname}:${endpoint.port}`)
     await closeBlocker(blocker)
   })
+
+  it('keeps child stdio drained so large app-server logs do not stall thread/start replies', async () => {
+    const runtime = createRuntime({
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          floodStdoutBeforeMethodsBytes: {
+            'thread/start': 512 * 1024,
+          },
+        }),
+      },
+      requestTimeoutMs: 1_500,
+    })
+
+    await expect(runtime.startThread({ cwd: '/repo/worktree' })).resolves.toEqual({
+      threadId: 'thread-new-1',
+      wsUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
+    })
+  })
+
+  it('keeps child stderr drained so large app-server error logs do not stall thread/resume replies', async () => {
+    const runtime = createRuntime({
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          floodStderrBeforeMethodsBytes: {
+            'thread/resume': 512 * 1024,
+          },
+        }),
+      },
+      requestTimeoutMs: 1_500,
+    })
+
+    await expect(runtime.resumeThread({
+      threadId: '019d9859-5670-72b1-851f-794ad7fef112',
+      cwd: '/repo/worktree',
+    })).resolves.toEqual({
+      threadId: '019d9859-5670-72b1-851f-794ad7fef112',
+      wsUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- stop calling `thread/resume` when restoring a persisted Codex session and instead reuse the stored session id with a ready remote app-server endpoint
- keep the shared Codex app-server child stdio drained so large startup/log output cannot stall `thread/start` or `thread/resume` responses
- add unit, integration, and fixture coverage for the restore path and the stdio backpressure case

## Validation
- `npm run test:vitest -- --config vitest.server.config.ts test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts test/integration/server/codex-session-flow.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts`
- `npm run test:vitest -- --config vitest.server.config.ts test/server/ws-terminal-create-reuse-running-codex.test.ts`
- `npm run test:vitest -- test/e2e/codex-refresh-rehydrate-flow.test.tsx`
- `npm run build:server`
- `npm test`
- real-binary probe against installed `codex-cli 0.121.0`: fresh `planCreate()` followed by restore `planCreate({ resumeSessionId })` succeeded with the same session id and remote ws URL, while direct app-server `thread/resume` on that id failed with `no rollout found for thread id ...`
