### PR TITLE
fix: restore interrupted coding-cli sessions via durable identity

### DIFF
--- a/docs/lab-notes/2026-04-20-coding-cli-session-contract.md
+++ b/docs/lab-notes/2026-04-20-coding-cli-session-contract.md
@@ -1,0 +1,338 @@
+# Coding CLI Session Contract Lab Note
+
+This note records the real-binary provider probes rerun on `2026-04-23` inside `/home/user/code/freshell/.worktrees/exact-durable-session-contract`.
+
+The implementation plan file is dated `2026-04-19` because the design work was written the day before. This note is dated `2026-04-23` because the real-provider contracts were re-proved on the implementation machine on that date, and that verification date is the one Freshell is allowed to build on.
+
+## Machine-readable contract
+```json
+{
+  "capturedOn": "2026-04-23",
+  "planCreatedOn": "2026-04-19",
+  "dateReason": "The plan was drafted on 2026-04-19, but the checked-in note is dated 2026-04-23 because that is when the real binaries were re-proved on the implementation machine and the earlier 2026-04-20 Codex note was superseded by the newer contract capture.",
+  "cleanup": {
+    "liveProcessAuditCommand": "ps -eo pid,ppid,stat,cmd --sort=pid | rg \"codex|claude|opencode\"",
+    "ownershipReportFields": [
+      "pid",
+      "ppid",
+      "cwd",
+      "tempHome",
+      "sentinelPath",
+      "safeToStop",
+      "command"
+    ],
+    "safeToStopRequires": [
+      "FRESHELL_PROBE_HOME must match the current temp root.",
+      "FRESHELL_PROBE_SENTINEL must match the current sentinel path."
+    ],
+    "safeExamples": [
+      "Probe-owned temp-home root processes and their descendants tagged by the current harness sentinel."
+    ],
+    "unsafeExamples": [
+      "Real user codex, claude, or opencode sessions under the user home.",
+      "Any process that lacks the current harness sentinel metadata."
+    ]
+  },
+  "providers": {
+    "codex": {
+      "executable": "codex",
+      "resolvedPath": "/home/user/.npm-global/bin/codex",
+      "version": "codex-cli 0.123.0",
+      "freshRemoteBootstrapCommand": "codex --remote <ws>",
+      "freshRemoteBootstrapEventsBeforeUserTurn": [
+        "connection",
+        "initialize",
+        "initialized",
+        "account/read",
+        "account/read",
+        "model/list",
+        "thread/start"
+      ],
+      "remoteResumeBootstrapStablePrefix": [
+        "connection",
+        "initialize",
+        "initialized",
+        "account/read",
+        "thread/read",
+        "account/read",
+        "model/list",
+        "thread/resume"
+      ],
+      "remoteResumeBootstrapFollowupMethods": [
+        "account/rateLimits/read",
+        "skills/list",
+        "skills/list"
+      ],
+      "freshRemoteAllocatesThreadBeforeUserTurn": true,
+      "shellSnapshotGlob": ".codex/shell_snapshots/*.sh",
+      "durableArtifactGlob": ".codex/sessions/YYYY/MM/DD/rollout-*.jsonl",
+      "freshInteractiveCreatesShellSnapshotBeforeTurn": true,
+      "freshInteractiveCreatesDurableSessionBeforeTurn": false,
+      "appServerThreadPathAvailableBeforeArtifact": true,
+      "appServerMissingPathWatchAccepted": true,
+      "appServerMissingParentWatchAccepted": true,
+      "appServerWatchEchoesCallerWatchId": true,
+      "appServerArtifactMaterializesAtReportedPath": true,
+      "appServerChangedPathsMentionRolloutPath": true,
+      "resumeCommandTemplate": "codex --remote <ws> --no-alt-screen resume <sessionId>",
+      "mutableNameSurface": "absent"
+    },
+    "claude": {
+      "executable": "claude",
+      "resolvedPath": "/home/user/bin/claude",
+      "isolatedBinaryPath": "/home/user/.local/bin/claude",
+      "version": "2.1.116 (Claude Code)",
+      "exactIdCommandTemplate": "HOME=<temp-home> /home/user/.local/bin/claude --bare --dangerously-skip-permissions -p --session-id <uuid> <prompt>",
+      "namedResumeCommandTemplate": "HOME=<temp-home> /home/user/.local/bin/claude --bare --dangerously-skip-permissions -p --resume <title-or-uuid> [--name <title>] <prompt>",
+      "transcriptGlob": ".claude/projects/*/<uuid>.jsonl",
+      "canonicalIdentity": "uuid-transcript",
+      "namedResumeWorksInPrintMode": true,
+      "renameMutatesMetadataOnly": true,
+      "oldTitleStopsResolvingAfterRename": true,
+      "oldTitleErrorFragment": "does not match any session title"
+    },
+    "opencode": {
+      "executable": "opencode",
+      "resolvedPath": "/home/user/.opencode/bin/opencode",
+      "version": "1.14.20",
+      "runCommandTemplate": "opencode run <prompt> --format json --dangerously-skip-permissions",
+      "serveCommandTemplate": "opencode serve --hostname 127.0.0.1 --port <port>",
+      "globalHealthPath": "/global/health",
+      "sessionStatusPath": "/session/status",
+      "canonicalIdentity": "session-id",
+      "runEventSessionIdMatchesDbId": true,
+      "busyStatusUsesAuthoritativeSessionId": true,
+      "titleOnResumeMutatesStoredTitle": false,
+      "sessionSubcommands": [
+        "list",
+        "delete"
+      ]
+    }
+  }
+}
+```
+
+## Process audit and cleanup rule
+
+The live process audit was run with:
+
+```bash
+ps -eo pid,ppid,stat,cmd --sort=pid | rg "codex|claude|opencode"
+```
+
+That audit showed live user sessions for all three providers outside the temp homes used for the probes. Those processes must never be stopped by cleanup.
+
+The checked-in harness therefore only stops processes when both provenance checks succeed:
+
+1. `FRESHELL_PROBE_HOME` matches the current temp root.
+2. `FRESHELL_PROBE_SENTINEL` matches the current sentinel file.
+
+Before cleanup runs, the harness emits a dry-run ownership report containing `pid`, `ppid`, `cwd`, `tempHome`, `sentinelPath`, `safeToStop`, and `command` for every candidate PID in the probe-owned process tree. Cleanup aborts if any candidate lacks the expected temp-home or sentinel metadata.
+
+## Codex
+
+Version and binary:
+
+```bash
+command -v codex
+# /home/user/.npm-global/bin/codex
+
+codex --version
+# codex-cli 0.123.0
+```
+
+This 2026-04-23 rerun supersedes the older `codex-cli 0.121.0` capture. The current version of record on this machine is `codex-cli 0.123.0`.
+
+Fresh remote bootstrap was probed with a loopback websocket stub and:
+
+```bash
+CODEX_HOME=<temp-root>/.codex codex --remote <ws> --no-alt-screen
+```
+
+Before any user turn, the CLI opened a connection and issued:
+
+1. `initialize`
+2. `initialized`
+3. `account/read`
+4. `account/read`
+5. `model/list`
+6. `thread/start`
+
+That proves fresh `codex --remote` allocates a thread during bootstrap, before the first user turn, but that thread allocation is not yet the durable contract Freshell may persist.
+
+The remote resume form was re-proved through a websocket proxy in front of the real app-server. Before any user turn, `codex --remote <ws> --no-alt-screen resume <sessionId>` issued the stable prefix through `thread/resume`, and then the follow-up `skills/list` and `account/rateLimits/read` calls. The trailing post-resume follow-up order was observed to vary between reruns on the same binary, so only the stable prefix plus the required follow-up method set is treated as contract.
+
+Real provider-owned durability was re-proved against the app-server websocket with:
+
+```bash
+CODEX_HOME=<temp-root>/.codex codex app-server --listen <ws>
+# JSON-RPC:
+#   initialize
+#   thread/start
+#   turn/start
+#   thread/resume
+```
+
+Observed provider-owned artifacts:
+
+- After `thread/start` and before `turn/start`: a shell snapshot under `.codex/shell_snapshots/*.sh`.
+- After `thread/start` and before `turn/start`: no `.codex/sessions/**.jsonl` durable artifact.
+- `thread/start` already returned `thread.ephemeral: false` and a concrete `thread.path` under `.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`.
+- Immediately after `thread/start`, neither the rollout file nor its date directory existed yet.
+- `fs/watch` accepted caller-supplied `watchId` values for both the missing rollout path and the missing parent directory, returned only the canonicalized watched `path`, and later `fs/changed` echoed the original caller-supplied `watchId`.
+- After the first real `turn/start`: a durable artifact under `.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`.
+- After the first real `turn/start`: the durable artifact appeared at the exact `thread.path`, and `fs/changed.changedPaths` mentioned that exact rollout path.
+
+Short JSON-ish transcript from the 2026-04-23 rerun:
+
+```json
+{
+  "thread/start": {
+    "thread": {
+      "id": "<uuid>",
+      "ephemeral": false,
+      "path": "<temp-root>/.codex/sessions/2026/04/23/rollout-...jsonl"
+    }
+  },
+  "preTurn": {
+    "rolloutExists": false,
+    "parentExists": false
+  },
+  "fs/watch": [
+    {
+      "watchId": "probe-rollout-path",
+      "result": { "path": "<same rollout path>" }
+    },
+    {
+      "watchId": "probe-rollout-parent",
+      "result": { "path": "<same parent directory>" }
+    }
+  ],
+  "fs/changed": {
+    "watchId": "probe-rollout-path|probe-rollout-parent",
+    "changedPaths": ["<same rollout path>"]
+  }
+}
+```
+
+The durable restore path that worked after restarting the app-server runtime was:
+
+```bash
+thread/resume <sessionId>
+turn/start <sessionId>
+```
+
+`codex --help` in the tested mode did not expose a rename or title mutation flag such as `--name`, so no mutable-name surface was confirmed for Codex in this contract.
+
+Allowed Freshell behavior:
+
+- Fresh Codex panes may stay live-only even though a fresh thread exists and `thread.path` is already known.
+- Freshell may use `fs/watch` as the event source for Codex durability, but it still needs a direct existence check on the exact rollout path before promotion.
+- Freshell may only persist canonical Codex identity after the durable `.jsonl` artifact exists at the provider-reported `thread.path`.
+- Freshell must not treat the bootstrap `thread/start` id as durable restore identity.
+
+## Claude
+
+Version and binaries:
+
+```bash
+command -v claude
+# /home/user/bin/claude
+
+claude --version
+# 2.1.116 (Claude Code)
+```
+
+The wrapper at `/home/user/bin/claude` shells out to `/home/user/.local/bin/claude`. The isolated probes used the actual binary and overrode `HOME` to keep persistence inside the probe temp root.
+
+Fresh exact-id durability was probed with:
+
+```bash
+HOME=<temp-home> /home/user/.local/bin/claude --bare --dangerously-skip-permissions -p --session-id <uuid> "Reply with exactly: claude-home-probe-ok"
+```
+
+Observed provider-owned artifacts:
+
+- `.claude/.credentials.json`
+- `.claude/policy-limits.json`
+- `.claude/projects/*/<uuid>.jsonl`
+
+The UUID-backed transcript file is the canonical durable identity.
+
+Named resume and rename/title mutation were probed with:
+
+```bash
+HOME=<temp-home> /home/user/.local/bin/claude --bare --dangerously-skip-permissions -p --session-id <uuid> --name probe-name-one "Reply with exactly: named-create-ok"
+HOME=<temp-home> /home/user/.local/bin/claude --bare --dangerously-skip-permissions -p --resume probe-name-one "Reply with exactly: named-resume-ok"
+HOME=<temp-home> /home/user/.local/bin/claude --bare --dangerously-skip-permissions -p --resume <uuid> --name probe-name-two "Reply with exactly: renamed-ok"
+```
+
+Observed rename semantics:
+
+- The transcript filename and UUID-backed `sessionId` remained stable.
+- Claude appended new `custom-title` and `agent-name` metadata lines for the renamed title.
+- After rename, the old title no longer resolved in `--resume`.
+- The new title resolved, but only as mutable metadata pointing back to the same UUID transcript identity.
+
+Allowed Freshell behavior:
+
+- UUID-backed Claude transcript identity is canonical durable identity.
+- Named resume values and titles are mutable metadata only.
+- Freshell must not persist a mutable title as Claude durable identity.
+
+## OpenCode
+
+Version and binary:
+
+```bash
+command -v opencode
+# /home/user/.opencode/bin/opencode
+
+opencode --version
+# 1.14.20
+```
+
+Fresh isolated runs were probed with:
+
+```bash
+XDG_DATA_HOME=<temp-home>/.local/share XDG_CONFIG_HOME=<temp-home>/.config opencode run "Reply with exactly: opencode-probe-ok" --format json --dangerously-skip-permissions
+```
+
+Observed durable identity rule:
+
+- The first JSON `step_start` event carried a `sessionID`.
+- That exact `sessionID` matched the `session.id` row written into the isolated OpenCode database.
+
+The authoritative control surface was probed with:
+
+```bash
+XDG_DATA_HOME=<temp-home>/.local/share XDG_CONFIG_HOME=<temp-home>/.config opencode serve --hostname 127.0.0.1 --port <port>
+curl http://127.0.0.1:<port>/global/health
+curl http://127.0.0.1:<port>/session/status
+```
+
+Observed control behavior:
+
+- `/global/health` returned a healthy payload with version `1.14.20`.
+- `/session/status` returned `{}` while idle.
+- During an attached `opencode run ... --attach http://127.0.0.1:<port>`, `/session/status` returned the same authoritative `sessionID` with `{ "type": "busy" }`.
+
+Title semantics were probed with:
+
+```bash
+opencode run "Reply with exactly: opencode-title-one" --format json --dangerously-skip-permissions --title probe-title-one
+opencode run "Reply with exactly: opencode-title-two" --format json --dangerously-skip-permissions --session <sessionId> --title probe-title-two
+opencode session --help
+```
+
+Observed title behavior:
+
+- The resumed run kept the same `sessionID`.
+- The stored database title remained `probe-title-one`.
+- `opencode session --help` only exposed `list` and `delete`; no rename subcommand was present in the tested mode.
+
+Allowed Freshell behavior:
+
+- Canonical OpenCode identity is the authoritative `sessionID`.
+- Busy or restore state may only be promoted from the control surface or the canonical DB/session events.
+- Titles are metadata and do not replace session identity.

--- a/docs/plans/2026-04-19-exact-durable-session-contract-test-plan.md
+++ b/docs/plans/2026-04-19-exact-durable-session-contract-test-plan.md
@@ -1,0 +1,349 @@
+# Exact Durable Session Contract Test Plan
+
+## Strategy Reconciliation
+No strategy changes requiring user approval are needed.
+
+The approved strategy and the implementation plan still line up on the core approach: prove real provider behavior first, make live reattach and durable restore separate state axes, refuse silent fallback-to-fresh behavior, and drive the work with red/green/refactor TDD from the highest-value contract failures downward.
+
+The reconciliation against the current tree adds three execution refinements, but none of them expand scope beyond what the user already approved:
+
+- Migration preservation must be treated as an early gate, not a late cleanup. The current [`src/store/storage-migration.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/src/store/storage-migration.ts) still clears Freshell local state wholesale, so migration tests must fail before any schema cutover lands.
+- `agent-api` and MCP are not just downstream read-model consumers. [`server/agent-api/router.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/agent-api/router.ts) and [`server/mcp/freshell-tool.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/mcp/freshell-tool.ts) originate tab and pane creation flows and currently pass `resumeSessionId` through launch paths, so the contract suite must cover them explicitly before sign-off.
+- The repo already has useful harness assets for this work: the fake Codex app-server fixture, websocket integration harnesses, storage/bootstrap tests, and OpenCode startup probe captures. The test plan reuses and extends those instead of inventing parallel harnesses.
+
+Task 1 remains the authoritative behavior lock. Planning-time observations from the transcript are strong evidence, but after Task 1 the checked-in lab note and executable real-provider suite become the only allowed source of truth for provider behavior.
+
+## Sources Of Truth
+- `S1 User-approved contract`: persist only replay-safe durable provider identity; keep live reattach handles separate; do not silently fall back from restore to fresh create; surface explicit restore-unavailable failures.
+- `S2 Implementation plan`: [`docs/plans/2026-04-19-exact-durable-session-contract.md`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/docs/plans/2026-04-19-exact-durable-session-contract.md), especially the Strategy Gate, Wire Contract Rule, Restore-Unavailable Rule, and Tasks 1 through 9.
+- `S3 Real provider behavior`: the Task 1 lab note plus the opt-in real-provider suite. These supersede planning-time assumptions.
+- `S4 Current shipped breakage`: fresh Codex `thread/start` ids are still treated as durable resume ids by [`server/coding-cli/codex-app-server/launch-planner.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/coding-cli/codex-app-server/launch-planner.ts), [`server/ws-handler.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/ws-handler.ts), and the current Codex integration tests.
+- `S5 Existing live-vs-durable split for agent chat`: [`src/store/agentChatTypes.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/src/store/agentChatTypes.ts), [`src/components/agent-chat/AgentChatView.tsx`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/src/components/agent-chat/AgentChatView.tsx), and [`server/agent-timeline/ledger.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/agent-timeline/ledger.ts) already distinguish live SDK state from canonical durable Claude identity.
+- `S6 Existing authoritative binding/control surfaces`: [`server/session-binding-authority.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/session-binding-authority.ts), [`server/session-association-coordinator.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/session-association-coordinator.ts), and [`server/coding-cli/opencode-activity-tracker.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/coding-cli/opencode-activity-tracker.ts).
+
+## Current Risk Concentrations
+- `R1` Fresh Codex thread ids are still collapsed into durable restore ids in [`server/coding-cli/codex-app-server/launch-planner.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/coding-cli/codex-app-server/launch-planner.ts:1), [`server/ws-handler.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/ws-handler.ts:1447), and [`test/integration/server/codex-session-flow.test.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/test/integration/server/codex-session-flow.test.ts).
+- `R2` The wire contract still overloads durable identity and locality in [`shared/ws-protocol.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/shared/ws-protocol.ts), where `SessionLocatorSchema` still carries optional `serverInstanceId` and `terminal.created` still emits `effectiveResumeSessionId`.
+- `R3` Client persistence and sync code still synthesizes canonical identity from raw `resumeSessionId` in [`src/store/panesSlice.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/src/store/panesSlice.ts), [`src/store/tabsSlice.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/src/store/tabsSlice.ts), [`src/store/layoutMirrorMiddleware.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/src/store/layoutMirrorMiddleware.ts), [`src/store/crossTabSync.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/src/store/crossTabSync.ts), and [`src/lib/tab-registry-snapshot.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/src/lib/tab-registry-snapshot.ts).
+- `R4` `storage-migration.ts` still full-clears persisted state, which directly violates the implementation plan’s preservation rule.
+- `R5` Read models and external surfaces still expose or consume raw `resumeSessionId` in [`server/terminals-router.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/terminals-router.ts), [`server/terminal-view/service.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/terminal-view/service.ts), [`server/terminal-metadata-service.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/terminal-metadata-service.ts), [`server/agent-api/router.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/agent-api/router.ts), and [`server/mcp/freshell-tool.ts`](/home/user/code/freshell/.worktrees/exact-durable-session-contract/server/mcp/freshell-tool.ts).
+
+## Action Space
+- Provider contract proof: new lab note, new real-provider harness, opt-in real-binary integration suite, and `package.json` script wiring.
+- Server launch and binding flow: `ws-handler`, `terminal-registry`, Codex app-server client/runtime/planner, OpenCode activity wiring, session binding and association.
+- Shared contract and wire types: `shared/ws-protocol.ts` plus the new `shared/session-contract.ts`.
+- Client persistence and hydration: `persistedState`, `storage-migration`, `persistMiddleware`, `layoutMirrorMiddleware`, `crossTabSync`, `tabsSlice`, `panesSlice`, `persistControl`, `session-utils`, and `tab-registry-snapshot`.
+- Client runtime flows: `TerminalView`, `AgentChatView`, `TabsView`, `BackgroundSessions`, `Sidebar`, `TabContent`, `PaneContainer`, and related selectors/helpers.
+- Read models and external APIs: terminal directory services, metadata services, agent API routes, MCP tool surface, and tab-registry snapshots.
+
+## Harness Requirements
+| Harness | What it exercises | Reuse / new work |
+| --- | --- | --- |
+| `H1 Real-provider contract harness` | Real `codex`, `claude`, and `opencode` binaries under isolated temp homes, artifact polling, control-surface capture, and provenance-gated cleanup. | New: `test/helpers/coding-cli/real-session-contract-harness.ts` and `test/integration/real/coding-cli-session-contract.test.ts`. |
+| `H2 Server websocket launch harness` | `WsHandler`, `TerminalRegistry`, session repair, duplicate create suppression, same-server reuse, and terminal create/restore flows. | Reuse and extend existing integration/server websocket tests. |
+| `H3 Client terminal lifecycle harness` | `TerminalView` websocket behavior, `terminal.created`, `terminal.session.associated`, `INVALID_TERMINAL_ID`, refresh/rehydrate, and persistence flush behavior. | Reuse existing jsdom/ws harnesses in `TerminalView` and `codex-refresh-rehydrate` tests. |
+| `H4 Persistence and bootstrap harness` | Migration, persisted layout parsing, cross-tab sync, layout mirror payloads, and app bootstrap hydration. | Reuse existing client store tests plus new `shared/session-contract` tests. |
+| `H5 Codex app-server fixture harness` | JSON-RPC contracts, notification handling, stdio flooding, per-sidecar ownership, and sidecar failure cases. | Reuse `fake-app-server.mjs`, `client.test.ts`, `runtime.test.ts`, and add sidecar tests. |
+| `H6 Claude/FreshClaude restore harness` | Session association, SDK attach/create, ledger restore resolution, named resume, canonical UUID promotion, and restore failure surfacing. | Reuse `session_association`, `ws-handler-sdk`, `AgentChatView`, and ledger tests. |
+| `H7 OpenCode authoritative-control harness` | OpenCode health/events stream, startup state, durable promotion, and cleanup. | Reuse `opencode-activity-tracker`, `ws-opencode-activity`, and startup probe fixtures. |
+| `H8 Read-model and external-surface harness` | Terminal directory, sidebar/background sessions, tab-registry snapshots, agent routes, and MCP tool actions. | Reuse existing router/UI tests and extend where needed. |
+| `H9 Broad verification harness` | Lint, typecheck, focused regression sweeps, opt-in real-provider rerun, and coordinated full suite. | Use repo coordinator workflows from `package.json`. |
+
+## Test Plan
+### Task 1: Lock Down Real Provider Contracts
+1. **Name:** Real-provider harness discovers binaries, isolates temp homes, and enforces provenance-gated cleanup.
+   **Type:** scenario
+   **Harness:** `H1`
+   **Preconditions:** Unique temp homes and sentinel metadata per provider section.
+   **Actions:** Resolve binaries with `command -v`, record exact paths and versions, start probes, emit dry-run ownership reports, then run cleanup.
+   **Expected outcome:** Missing binaries produce per-provider Vitest skips by executable name; auth/config/runtime failures fail the section rather than skipping; cleanup refuses to kill any PID lacking the temp-home prefix plus harness sentinel.
+
+2. **Name:** Codex fresh create, thread allocation, durable artifact creation, and restore timing are recorded exactly.
+   **Type:** scenario
+   **Harness:** `H1`
+   **Preconditions:** Real `codex` binary available.
+   **Actions:** Probe fresh remote startup, observe any thread notifications, poll provider-owned artifacts, restart the runtime, and attempt restore with the observed durable token.
+   **Expected outcome:** The lab note and executable suite agree on the exact sequence of live-only state, thread allocation, artifact durability, and resumability. If a fresh thread id appears before artifact durability, the tests lock that down as non-durable state.
+
+3. **Name:** Claude fresh create, transcript durability, named resume, and rename/title semantics are recorded exactly.
+   **Type:** scenario
+   **Harness:** `H1`
+   **Preconditions:** Real `claude` binary available.
+   **Actions:** Probe fresh create with exact id, named resume, transcript creation, and any rename/title surface.
+   **Expected outcome:** The suite proves when Claude gains canonical UUID-backed durability and whether names/titles are mutable metadata or absent in the tested mode.
+
+4. **Name:** OpenCode startup, authoritative session creation, restore contract, and rename/title semantics are recorded exactly.
+   **Type:** scenario
+   **Harness:** `H1`
+   **Preconditions:** Real `opencode` binary available.
+   **Actions:** Probe bare startup, wait for authoritative control-surface session creation, observe restore behavior, and check whether a mutable name/title surface exists.
+   **Expected outcome:** The suite proves whether bare startup is live-only, which control event creates durable identity, and whether names/titles can drift independently from canonical ids.
+
+5. **Name:** The checked-in lab note and opt-in real-provider suite are mutually executable.
+   **Type:** invariant
+   **Harness:** `H1`
+   **Preconditions:** Task 1 artifacts exist.
+   **Actions:** Run `npm run test:real:coding-cli-contracts` and compare the asserted facts against the checked-in lab note.
+   **Expected outcome:** Every factual claim in the lab note is executable; later reruns fail if the note and tests drift apart.
+
+### Task 2: Lock Down The Live-Versus-Durable State Machine
+6. **Name:** Same-server reconnect reattaches by live handle even when no canonical durable identity exists yet.
+   **Type:** scenario
+   **Harness:** `H2`, `H3`
+   **Preconditions:** A running terminal or SDK session exists and persisted state still has a valid local live handle.
+   **Actions:** Rehydrate the tab on the same server instance before any durable promotion arrives.
+   **Expected outcome:** Freshell reattaches the live terminal/session, does not recreate from provider identity, and does not invent a durable restore target.
+
+7. **Name:** Dead or stale live handles only fall through to durable restore when canonical identity exists.
+   **Type:** scenario
+   **Harness:** `H2`, `H3`
+   **Preconditions:** Persisted state contains a stale `serverInstanceId` or dead live handle.
+   **Actions:** Rehydrate with and without canonical durable identity present.
+   **Expected outcome:** With canonical durable identity, Freshell performs provider restore. Without it, Freshell surfaces restore-unavailable rather than starting fresh.
+
+8. **Name:** A dead non-durable session becomes explicit `RESTORE_UNAVAILABLE`.
+   **Type:** scenario
+   **Harness:** `H2`, `H3`, `H6`
+   **Preconditions:** A pane previously existed only in live state and the backing process is gone.
+   **Actions:** Rehydrate the pane or tab after process loss.
+   **Expected outcome:** The persisted/read-model state carries a `RESTORE_UNAVAILABLE` error shape; UI recovery does not silently create a new session.
+
+9. **Name:** Mutable names and titles never affect identity matching or restore routing.
+   **Type:** differential
+   **Harness:** `H2`, `H6`, `H7`
+   **Preconditions:** A session already has canonical durable identity.
+   **Actions:** Change display names or titles where the provider allows it, then rehydrate and match against sidebar/open-session state.
+   **Expected outcome:** Canonical identity, binding, and restore behavior remain unchanged while only metadata changes.
+
+10. **Name:** FreshClaude keeps live SDK `sessionId` separate from durable Claude identity across reload and restore.
+    **Type:** scenario
+    **Harness:** `H6`
+    **Preconditions:** A FreshClaude pane has live SDK state and later receives canonical Claude ids.
+    **Actions:** Reload before and after canonical promotion, then exercise attach and history hydration.
+    **Expected outcome:** Live SDK attach uses the SDK id; durable history and future restores use canonical Claude identity; no flattening occurs.
+
+### Task 3: Shared Contract And Migration
+11. **Name:** Legacy raw `resumeSessionId` persistence migrates to canonical durable identity or explicit restore-unavailable state.
+    **Type:** integration
+    **Harness:** `H4`
+    **Preconditions:** Persisted layouts include terminal tabs, terminal panes, and agent-chat panes from current-main shapes.
+    **Actions:** Load persisted layout through migration and hydration.
+    **Expected outcome:** Repairable entries gain canonical durable identity; irreparable entries gain explicit restore-unavailable state; raw terminal/tab `resumeSessionId` persistence does not survive as durable truth.
+
+12. **Name:** Canonical `sessionRef` never carries `serverInstanceId`, while live handles remain separate and preserved.
+    **Type:** unit
+    **Harness:** `H4`
+    **Preconditions:** Shared contract helpers and migrated payloads are available.
+    **Actions:** Parse, build, and serialize session locators across tabs, panes, layout sync, and bootstrap paths.
+    **Expected outcome:** `sessionRef` is provider plus session id only; locality lives in explicit live-handle/runtime fields.
+
+13. **Name:** Storage migration preserves restorable layouts and does not use schema-bump wipe as the feature mechanism.
+    **Type:** invariant
+    **Harness:** `H4`
+    **Preconditions:** Local storage contains recoverable session-bearing tabs and panes.
+    **Actions:** Run the storage migration path from old persisted versions into the new contract.
+    **Expected outcome:** Recoverable entries survive; only truly unrecoverable legacy values become restore-unavailable; no blanket localStorage clear occurs.
+
+14. **Name:** `ui.layout.sync`, `clientHello`, `fallbackSessionRef`, and bootstrap consumers honor the live-versus-durable split.
+    **Type:** integration
+    **Harness:** `H4`
+    **Preconditions:** Client and server bootstrap paths are wired to the new contract.
+    **Actions:** Serialize layout mirror payloads, cross-tab sync messages, and websocket hello payloads, then hydrate them.
+    **Expected outcome:** No path smuggles `serverInstanceId` through canonical identity or revives a raw persisted resume string.
+
+15. **Name:** Session utilities, pane construction, and tab snapshot helpers stop synthesizing canonical identity from arbitrary strings.
+    **Type:** integration
+    **Harness:** `H4`, `H8`
+    **Preconditions:** Shared contract helpers exist.
+    **Actions:** Exercise `session-utils`, `session-type-utils`, `tab-registry-snapshot`, `TabsView`, and pane construction with mixed local/remote and legacy payloads.
+    **Expected outcome:** Canonical identity comes only from the explicit durable contract; same-server live state remains separate; invalid legacy strings do not become session refs.
+
+### Task 4: Make Durable Promotion Authoritative
+16. **Name:** `terminal.created` preserves only live launch state and never persists a non-durable provider id.
+    **Type:** integration
+    **Harness:** `H2`, `H3`
+    **Preconditions:** A terminal is being created for each provider mode that supports restore.
+    **Actions:** Observe `terminal.created` handling on server and client.
+    **Expected outcome:** The event carries live creation outcome only; it does not promote durable identity on its own.
+
+17. **Name:** `terminal.session.associated` is the only terminal durable-promotion event.
+    **Type:** integration
+    **Harness:** `H2`, `H3`
+    **Preconditions:** The terminal binding path is active and a provider-specific durable signal arrives.
+    **Actions:** Trigger association/promotion and inspect server broadcasts, client persistence, and flush behavior.
+    **Expected outcome:** Canonical durable identity is persisted only on `terminal.session.associated`; there is no second promotion plane.
+
+18. **Name:** Running-terminal reuse and duplicate create locking follow the canonical/live split.
+    **Type:** integration
+    **Harness:** `H2`
+    **Preconditions:** Matching running sessions exist for same request id, same live handle, and same canonical durable identity cases.
+    **Actions:** Send duplicate or overlapping `terminal.create` requests.
+    **Expected outcome:** Same-server reuse beats recreate; durable matching uses canonical identity only; non-durable fresh ids do not steal ownership.
+
+19. **Name:** `INVALID_TERMINAL_ID` recovery respects live-handle-first restore and surfaces restore-unavailable cleanly.
+    **Type:** integration
+    **Harness:** `H3`
+    **Preconditions:** A previously attached pane loses its live terminal id across reconnect/reload.
+    **Actions:** Trigger `INVALID_TERMINAL_ID` and allow the client recovery path to run.
+    **Expected outcome:** The client either reattaches/recreates using valid durable identity or surfaces restore-unavailable; it never loops indefinitely or starts fresh implicitly.
+
+### Task 5: Codex Sidecar Ownership And Durable Artifact Promotion
+20. **Name:** Fresh Codex create launches with the exact real-provider form and stays live-only until durability is proven.
+    **Type:** integration
+    **Harness:** `H5`, `H2`
+    **Preconditions:** Codex sidecar architecture is in place.
+    **Actions:** Create a fresh Codex terminal and inspect spawned CLI args, sidecar state, notifications, and persistence.
+    **Expected outcome:** Fresh create uses the exact Task 1 contract, currently expected to be `codex --remote <ws>` without `resume`; no durable id is persisted until provider-owned durability is proven.
+
+21. **Name:** Codex restore launches with the exact durable restore form only after canonical identity exists.
+    **Type:** integration
+    **Harness:** `H5`, `H2`
+    **Preconditions:** A Codex session has already been durably promoted.
+    **Actions:** Rehydrate or recreate the pane via durable restore.
+    **Expected outcome:** Restore uses the exact Task 1 durable form, currently expected to be `codex --remote <ws> resume <durable-token>`; sidecar `thread/resume` is not part of the restore path.
+
+22. **Name:** Two live Codex panes own isolated sidecars, loopback endpoints, and cleanup.
+    **Type:** scenario
+    **Harness:** `H5`
+    **Preconditions:** Two Codex terminals run concurrently.
+    **Actions:** Start both, drive notifications/artifacts separately, then exit them in different orders.
+    **Expected outcome:** Each terminal owns its own sidecar and endpoint; cleanup is isolated; no shared singleton runtime remains.
+
+23. **Name:** Codex durable promotion occurs only after provider notifications plus durable artifact proof.
+    **Type:** scenario
+    **Harness:** `H5`, `H2`
+    **Preconditions:** Sidecar can observe thread notifications before durability and can poll the durable artifact.
+    **Actions:** Emit provisional notifications, delay artifact creation, then create the artifact.
+    **Expected outcome:** Exact thread ids observed before durability remain launch-only state; durable promotion does not happen until artifact proof exists.
+
+24. **Name:** Codex sidecar startup failure, invalid initialize payloads, transport death, and post-launch sidecar death fail clearly with no fallback.
+    **Type:** boundary
+    **Harness:** `H5`
+    **Preconditions:** Fake app-server fixture can ignore methods, flood stdio, return malformed payloads, or die.
+    **Actions:** Trigger initialization failures, late reply timeouts, sidecar death after launch, and transport loss.
+    **Expected outcome:** Failures are explicit and user-facing; no fallback to a shared runtime, heuristic launch path, or silent fresh session.
+
+### Task 6: Claude And FreshClaude Canonical Durable Identity
+25. **Name:** Terminal Claude named resume remains launch-only until canonical UUID-backed transcript identity is proven.
+    **Type:** integration
+    **Harness:** `H6`, `H2`
+    **Preconditions:** A terminal Claude pane is created from a non-UUID named resume token.
+    **Actions:** Launch, wait for session repair or association, and then rehydrate.
+    **Expected outcome:** The name is not treated as canonical identity; canonical promotion occurs only when a UUID-backed transcript is proven.
+
+26. **Name:** Persisted invalid Claude restore candidates are rejected on read rather than reused as durable identity.
+    **Type:** integration
+    **Harness:** `H4`, `H6`
+    **Preconditions:** Persisted terminal or agent-chat state contains non-canonical Claude restore values.
+    **Actions:** Migrate, hydrate, and attempt restore.
+    **Expected outcome:** Invalid durable candidates become restore-unavailable; named or mutable values are not treated as canonical on read.
+
+27. **Name:** FreshClaude reload and restore keep SDK attach separate from canonical timeline and CLI identity.
+    **Type:** integration
+    **Harness:** `H6`
+    **Preconditions:** A FreshClaude pane has combinations of `sessionId`, `timelineSessionId`, `cliSessionId`, and stale restore revisions.
+    **Actions:** Exercise reload, lost-session recovery, stale-revision retry, and visible timeline hydration.
+    **Expected outcome:** SDK attach uses live state; durable history uses canonical Claude identity; stale-revision recovery and fatal restore errors remain explicit.
+
+28. **Name:** Agent timeline ledger handles durable-only, live-only, merged, and fatal restore states deterministically.
+    **Type:** unit
+    **Harness:** `H6`
+    **Preconditions:** Durable history and live SDK message sets are available in controlled combinations.
+    **Actions:** Resolve restore history under each state and compare signatures, aliases, and failure codes.
+    **Expected outcome:** Ledger outputs stable `RESTORE_UNAVAILABLE`/`RESTORE_INTERNAL`/`RESTORE_DIVERGED` semantics and never relies on mutable names.
+
+### Task 7: OpenCode Promotion From Authoritative Control Data Only
+29. **Name:** OpenCode startup remains live-only until authoritative control-surface session creation.
+    **Type:** scenario
+    **Harness:** `H7`
+    **Preconditions:** OpenCode pane starts with startup probe traffic but no authoritative session event yet.
+    **Actions:** Replay startup probe/output frames and then emit authoritative control events.
+    **Expected outcome:** Probe bytes and title text do not create durable identity; authoritative control data does.
+
+30. **Name:** OpenCode durable promotion, activity, and cleanup consume only authoritative control events.
+    **Type:** integration
+    **Harness:** `H7`
+    **Preconditions:** Tracker/controller wiring is connected.
+    **Actions:** Emit busy, idle, reconnect, and terminal-exit flows through the authoritative OpenCode event surface.
+    **Expected outcome:** Durable session ids, activity state, and cleanup follow the authoritative event stream only.
+
+31. **Name:** OpenCode restore and sidebar matching use canonical durable identity only.
+    **Type:** integration
+    **Harness:** `H7`, `H8`
+    **Preconditions:** One OpenCode pane has canonical durable identity and another only has live state.
+    **Actions:** Rehydrate tabs, drive sidebar/open-session matching, and trigger restore.
+    **Expected outcome:** Canonical `sessionRef` governs restore and open-session matching; titles and live-only startup state do not.
+
+### Task 8: Read Models, UI Consumers, Agent Routes, And MCP
+32. **Name:** Terminal directory and background-session surfaces preserve explicit live-versus-durable identity.
+    **Type:** integration
+    **Harness:** `H8`
+    **Preconditions:** Terminal records include detached/live-only, detached/durable, and exited terminals.
+    **Actions:** Query terminal directory APIs, background sessions UI, and terminal metadata services.
+    **Expected outcome:** Same-server attach uses live terminal ids; durable restore identity is separate and explicit; raw fallback strings are not the contract.
+
+33. **Name:** Sidebar, TabsView, TabContent, PaneContainer, and pane activity do not revive stale raw resume strings.
+    **Type:** integration
+    **Harness:** `H8`, `H3`, `H4`
+    **Preconditions:** Tabs, pane layouts, and remote tab-registry snapshots contain mixes of canonical identity, live handles, and legacy values.
+    **Actions:** Render/open the tabs and panes, sync remote snapshots, and inspect selector output and pane runtime metadata.
+    **Expected outcome:** Canonical durable identity plus explicit live handles drive UI state; stale raw strings and mutable titles do not.
+
+34. **Name:** Agent API write paths and MCP actions follow the explicit contract for create, split, and resume flows.
+    **Type:** integration
+    **Harness:** `H8`
+    **Preconditions:** Server write routes and MCP client are wired to the new contract.
+    **Actions:** Create tabs, split panes, and invoke MCP `new-tab`/resume-style actions for terminal and agent-chat cases.
+    **Expected outcome:** These surfaces neither demand nor leak raw durable `resumeSessionId` strings; Codex create/split paths honor sidecar and canonical identity rules.
+
+35. **Name:** Remote tab-registry snapshots and same-server sanitization preserve only the right identity on the right axis.
+    **Type:** integration
+    **Harness:** `H8`, `H4`
+    **Preconditions:** Snapshot payloads include local and remote device records with session-bearing panes.
+    **Actions:** Build registry snapshots, open remote copies locally, and merge cross-tab state.
+    **Expected outcome:** Same-server reopen may preserve local live handles where appropriate; cross-device snapshots preserve canonical durable identity only.
+
+### Task 9: Final Verification And Invariants
+36. **Name:** Session-domain public contracts no longer leak the old hybrid semantics.
+    **Type:** invariant
+    **Harness:** `H9`
+    **Preconditions:** The contract cutover is complete.
+    **Actions:** Run targeted grep and schema/type tests across `shared`, `server`, `src`, and `test`.
+    **Expected outcome:** Canonical durable identity no longer depends on raw terminal/tab `resumeSessionId`, and canonical `sessionRef` never carries `serverInstanceId`.
+
+37. **Name:** Lint and typecheck remain green after the contract cut.
+    **Type:** verification
+    **Harness:** `H9`
+    **Actions:** Run `npm run lint` and `npm run typecheck`.
+    **Expected outcome:** PASS.
+
+38. **Name:** The opt-in real-provider contract suite re-runs cleanly after implementation.
+    **Type:** verification
+    **Harness:** `H9`, `H1`
+    **Actions:** Run `npm run test:real:coding-cli-contracts`.
+    **Expected outcome:** PASS with all three provider sections executed on the implementation machine; an all-skipped run is a failure.
+
+39. **Name:** Focused cross-cutting regressions pass across the new contract seams.
+    **Type:** verification
+    **Harness:** `H9`
+    **Actions:** Run the focused regression sweep from Task 9 of the implementation plan.
+    **Expected outcome:** PASS across Codex, Claude/FreshClaude, OpenCode, shared contract, migration, and consumer cutover suites.
+
+40. **Name:** Coordinated full-suite verification passes under the repo test gate.
+    **Type:** verification
+    **Harness:** `H9`
+    **Actions:** Run `FRESHELL_TEST_SUMMARY="exact durable session contract" npm test` after checking the coordinator status.
+    **Expected outcome:** PASS. No task is complete until the coordinated full suite is green.
+
+## Sequencing Rules
+- Write the highest-value red tests first for each task. Do not implement through a greenfield helper and backfill assertions later.
+- Treat Task 1 and Task 3 as hard prerequisites. Do not cut product code to the new model until the real-provider contract is documented and migration-preservation failures are captured.
+- Reuse the existing fake Codex app-server, websocket harnesses, startup probe captures, and jsdom lifecycle tests whenever they already exercise the correct seam.
+- Do not spend the broad-suite budget early. Use focused `npm run test:vitest -- ...` runs during Tasks 1 through 8, then run the final coordinated suite in Task 9.
+
+## Definition Of Good Coverage
+- The suite proves exactly when a provider is live-only, exactly when it becomes durably restorable, and exactly which identifier becomes canonical.
+- The suite proves that same-server reattach, durable restore, and restore-unavailable are three different outcomes with different triggers.
+- The suite proves that mutable names and titles are metadata only.
+- The suite proves that migration preserves repairable user state instead of wiping it.
+- The suite proves that all external entrypoints and read models use the same explicit contract, not private fallback semantics.

--- a/docs/plans/2026-04-19-exact-durable-session-contract.md
+++ b/docs/plans/2026-04-19-exact-durable-session-contract.md
@@ -1,0 +1,831 @@
+# Exact Durable Session Contract Implementation Plan
+
+> **For agentic workers:** If the user has requested `trycycle`, use the `trycycle` execution workflow to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the real provider contracts, then cut Freshell over to one explicit durable-session model where live reattach, durable restore, and launch-only inputs are separate states and only truly replay-safe provider identity is persisted.
+
+**Architecture:** Persist two explicit state axes and nothing hybrid: a canonical durable restore target, `sessionRef = { provider, sessionId }`, and the existing live reattach handles already needed for same-server refresh recovery (`terminalId` for terminal panes, SDK `sessionId` for agent-chat panes). Reuse the existing terminal binding path instead of creating a second promotion event: `terminal.session.associated` becomes the single authoritative terminal durable-promotion event, while agent-chat keeps its existing live SDK `sessionId` separate from canonical durable Claude identity. Codex moves to one app-server sidecar per terminal, OpenCode promotes only from its authoritative control surface, and Claude/FreshClaude promote only when canonical UUID-backed history exists.
+
+**Tech Stack:** TypeScript, React 18, Redux Toolkit, Express, WebSocket (`ws`), node-pty, Vitest, Testing Library, opt-in real-binary probe tests for `codex`, `claude`, and `opencode`
+
+---
+
+## Strategy Gate
+
+- Do not implement from memory. Task 1's checked-in lab note and executable real-provider tests are the contract.
+- Do not widen timeouts, add retries, or add “best effort” fallback resume behavior. The problem is identity semantics, not transport resilience.
+- Do not create a second durable-promotion control plane if the existing one can be made authoritative. Reuse `SessionBindingAuthority`, existing registry binding APIs, and `terminal.session.associated` for terminal durable promotion.
+- Do not persist names, titles, `/rename` results, fresh thread ids, or other launch-only tokens. Persist only canonical durable `sessionRef`.
+- Do not encode `serverInstanceId` into canonical durable identity. It is locality/runtime state, not replay-safe identity.
+- Do not flatten FreshClaude’s live SDK `sessionId` together with its durable Claude identity. Those are different state axes and must stay different.
+- Do not remove persisted live handles that power same-server refresh recovery. Keep them explicit and separate from durable restore identity.
+- Do not “solve” the migration by bumping `src/store/storage-migration.ts` to clear local state. Preserve persisted tabs/panes whenever canonical durable identity can still be proven; only surface restore-unavailable for entries that cannot be repaired safely.
+- Do not infer identity from cwd matching, PTY stdout, timing, or title text for Codex or OpenCode.
+- Do not silently fall back from “restore this session” to “start fresh.” If no durable target exists, surface restore-unavailable clearly.
+- Do not kill live user terminals during probe cleanup. Only stop probe-owned or provably orphaned helper processes tied to temp homes or this worktree.
+- Task 1 cleanup is provenance-gated, not trust-based: before any stop action, emit a dry-run ownership report for every candidate PID and refuse cleanup unless each candidate is tagged as probe-owned by the current temp home and harness sentinel metadata.
+- Tasks 2 through 8 may contain intentionally red or partially green commits. Those commits are branch-local checkpoints only. Do not land, merge, or fast-forward anything until Task 9 completes and the coordinated full suite is green.
+- When a task's `Run:` commands mention tests that are not listed in that task's Files/Commit block, treat them as regression-only coverage and leave them unchanged unless that task truly requires edits there.
+
+## Verified Planning Inputs
+
+These are planning-time observations from this machine, not a permanent pin. Task 1 must re-verify them, and the checked-in lab note plus executable contract suite replace any stale planning-time assumption.
+
+- Real-binary probes already confirmed:
+  - `codex --version` -> `codex-cli 0.121.0`
+  - current Codex remote CLI contract accepts `codex --remote <ws>` for fresh interactive launch and `codex --remote <ws> resume <SESSION_ID>` for durable restore
+  - `claude --version` -> `2.1.114 (Claude Code)`
+  - `opencode --version` -> `1.4.11`
+- The shipped regression currently encoded in main is:
+  - `server/coding-cli/codex-app-server/launch-planner.ts` invokes `runtime.startThread()` for fresh create, which sends `thread/start`, and returns the fresh thread id as if it were replay-safe.
+  - `server/ws-handler.ts` immediately persists that id as `effectiveResumeSessionId`.
+  - `test/integration/server/codex-session-flow.test.ts` currently bakes that bad invariant into the expected CLI launch.
+- Current Freshell behavior already separates some concerns, but not cleanly enough:
+  - terminals have a live handle (`terminalId`)
+  - terminal panes/tabs still persist ambiguous `resumeSessionId`
+  - panes may also persist `sessionRef`
+  - agent-chat keeps a live SDK `sessionId` plus durable-ish `cliSessionId` / `timelineSessionId`
+- Existing authoritative sources should be reused, not replaced:
+  - `server/session-binding-authority.ts` already enforces one session owner per terminal.
+  - `server/session-association-coordinator.ts` and `server/session-association-updates.ts` already own Claude-style durable promotion.
+  - `server/coding-cli/opencode-activity-tracker.ts` already consumes authoritative OpenCode control events and session IDs.
+- FreshClaude cannot be flattened into the terminal model:
+  - `src/store/agentChatTypes.ts` separates live SDK `sessionId` from `cliSessionId` / `timelineSessionId`.
+  - `src/components/agent-chat/AgentChatView.tsx` already relies on that split during restore hydration.
+- The user explicitly called out `/rename`-style cases. The contract work must prove that mutable names/titles are metadata only and never durable identity.
+
+## External Contract Rule
+
+Task 1 writes `docs/lab-notes/2026-04-20-coding-cli-session-contract.md`. That note is authoritative for provider behavior. If any current assumption disagrees with the note, update the tests and product code to match the note.
+
+## Wire Contract Rule
+
+- `shared/ws-protocol.ts` must remove raw durable `resumeSessionId` strings from terminal durable-state payloads.
+- `SessionLocatorSchema` must split into canonical durable `sessionRef` data and a separate live-reattach locator shape; `clientHello`, `fallbackSessionRef`, and any mirror/bootstrap consumers must migrate to that split instead of smuggling `serverInstanceId` through `sessionRef`.
+- `terminal.create` must carry canonical `sessionRef` when requesting a durable restore target, plus explicit live-handle/runtime fields for same-server reattach.
+- `terminal.created` and `terminal.session.associated` must emit canonical `sessionRef` only when durable identity actually exists; they must not echo provisional launch-only tokens as if they were durable restore ids.
+- If any one-shot launch-only input still needs to cross the wire for the current runtime, it must stay explicitly transient and must never be persisted or reused as canonical identity.
+
+## Restore-Unavailable Rule
+
+- The canonical representation is `restoreError = { code: 'RESTORE_UNAVAILABLE', reason: 'missing_canonical_identity' | 'invalid_legacy_restore_target' | 'dead_live_handle' | 'provider_runtime_failed' | 'durable_artifact_missing' }` in persisted/read-model state and the same `RESTORE_UNAVAILABLE` code on WS/API failures.
+- `restore-unavailable` is never represented by inventing a fake `sessionRef`, overloading a generic pane `status`, or reviving a raw `resumeSessionId`.
+- UI components derive user-facing copy from `restoreError` and clear it only after a successful live reattach or durable restore.
+
+## End-State Contract And Invariants
+
+### 1. Persisted durable identity
+
+- For terminal panes/tabs, persist exactly one canonical durable identity:
+  - `sessionRef = { provider, sessionId }`
+- `sessionRef` is the only replay-safe identity written to persisted terminal pane/tab state.
+- Persisted terminal and agent-chat pane state also keeps its existing live reattach handles (`terminalId` for terminals, SDK `sessionId` for agent-chat), but those fields remain live-only and must never be interpreted as durable restore targets.
+- Agent-chat keeps its own canonical durable Claude fields; do not force it onto terminal `sessionRef` semantics just to share a type name.
+- Any raw `resumeSessionId` still present on an agent-chat pane's shared pane/tab state is removed by migration. Durable agent-chat restore continues through canonical Claude fields (`cliSessionId` / `timelineSessionId`), while any temporary named-resume token remains runtime-only.
+- Raw `resumeSessionId` strings do not survive persistence after migration.
+
+### 2. Live handles are separate from durable identity
+
+- Terminal live reattach is keyed by:
+  - `terminalId`
+  - `serverInstanceId`
+- Agent-chat live reattach is keyed by:
+  - SDK `sessionId`
+- `serverInstanceId` stays in connection/runtime matching state; it is never part of canonical `sessionRef`.
+- Live handles are not replay targets and are never used as durable restore keys.
+
+### 3. Launch-only inputs are explicit
+
+- User-supplied or provider-supplied pre-durable inputs stay ephemeral only:
+  - fresh Claude create UUID before transcript exists
+  - named Claude resume values
+  - fresh Codex thread ids before the durable rollout artifact exists
+  - OpenCode startup state before authoritative session creation
+- These inputs may exist in memory to finish the current live session, but they are never persisted as restore targets.
+
+### 4. One authoritative promotion path
+
+- For terminal panes, durable promotion reuses the existing terminal binding path:
+  - `SessionBindingAuthority`
+  - registry session binding
+  - `terminal.session.associated`
+- `terminal.session.associated` becomes the single authoritative terminal event for “this terminal now has canonical durable identity.”
+- Do not add a second terminal durable-promotion event.
+
+### 5. Provider-specific durable promotion sources
+
+- Codex:
+  - fresh create launches `codex --remote <ws>`
+  - restore launches `codex --remote <ws> resume <durable-token>`
+  - one app-server sidecar per terminal observes notifications and the provider-owned durable artifact
+  - this intentionally replaces the current shared app-server singleton because durable promotion is terminal-owned; the accepted resource trade-off is exactly one sidecar process and one loopback endpoint per live Codex terminal, with no shared pool or fallback runtime
+  - the practical ceiling is exactly the live Codex terminal count Freshell already supports; there is no extra idle pool, background prewarm, or second multiplier beyond that 1:1 ownership model
+  - a fresh Codex pane may remain live-only with no thread id at all until the provider actually creates one
+  - if an exact thread id appears before the durable artifact exists, it is still launch-only state and must never be persisted
+- Claude terminal sessions:
+  - fresh create uses the exact Task 1 input contract
+  - canonical durable identity is the UUID-backed transcript identity
+  - names and `/rename`-style titles are metadata only
+- FreshClaude agent-chat:
+  - keep live SDK `sessionId` separate
+  - promote only the canonical durable Claude identity used by timeline/history
+  - restore never depends on a mutable display name
+- OpenCode:
+  - durable promotion comes only from its authoritative localhost control surface and session events
+  - PTY stdout and title text are never identity sources
+
+### 6. Failure semantics
+
+- If a live session never became durable and the live process is gone, restore fails with a clear restore-unavailable error.
+- If the Codex sidecar dies or becomes invalid while its PTY is still up, terminate the terminal with a clear error; do not pretend the session is still safely restorable.
+- If a Codex sidecar cannot start, initialize, or reserve its loopback endpoint, terminal create/restore fails immediately with a clear error. There is no fallback to a shared runtime or heuristic launch path.
+- Same-server reconnect prefers the live handle even when `sessionRef` already exists.
+- Stale runtime `serverInstanceId` or dead live handle forces durable restore if `sessionRef` exists, otherwise restore-unavailable.
+
+### 7. Mutable metadata is never identity
+
+- Titles, named resumes, and `/rename`-style commands may change the display name.
+- Those changes must not change canonical durable identity, matching, or restore behavior.
+
+## File Structure
+
+- Create: `docs/lab-notes/2026-04-20-coding-cli-session-contract.md`
+  Responsibility: checked-in provider contract note with exact commands, versions, artifacts, fresh-create timing, rename/title findings, and cleanup rules.
+- Create: `test/helpers/coding-cli/real-session-contract-harness.ts`
+  Responsibility: isolated temp-home probes, artifact polling, control-surface capture, and deterministic cleanup for real-binary contract tests.
+- Create: `test/integration/real/coding-cli-session-contract.test.ts`
+  Responsibility: executable verification of every provider claim in the lab note.
+- Create: `shared/session-contract.ts`
+  Responsibility: canonical `sessionRef` helpers, separate live-handle helpers, launch-input helpers, migration helpers, and provider-aware validation.
+- Create: `server/coding-cli/codex-app-server/sidecar.ts`
+  Responsibility: per-terminal Codex app-server ownership, notification capture, durable-artifact polling, and cleanup.
+- Create: `server/coding-cli/opencode-session-controller.ts`
+  Responsibility: translate authoritative OpenCode control data into durable promotion updates.
+- Create: `test/integration/server/opencode-session-flow.test.ts`
+  Responsibility: OpenCode durable-promotion and restore contract coverage.
+- Modify: `shared/ws-protocol.ts`
+  Responsibility: make durable identity and live-handle semantics explicit on the wire, split `SessionLocatorSchema` from live reattach locators, migrate `fallbackSessionRef`/`clientHello` consumers, and tighten `terminal.session.associated` semantics.
+- Modify: `server/session-binding-authority.ts`
+  Responsibility: keep a single durable owner per session and surface clearer binding state where needed.
+- Modify: `server/session-association-coordinator.ts`
+  Responsibility: limit heuristic association to provider-approved canonical promotion cases only.
+- Modify: `server/session-association-updates.ts`
+  Responsibility: collect only canonical durable promotions and stop treating association as a generic heuristic side effect.
+- Modify: `server/index.ts`
+  Responsibility: wire provider-specific durable promotion sources into the single terminal binding flow and broadcast authoritative updates.
+- Modify: `server/ws-handler.ts`
+  Responsibility: stop persisting fresh non-durable ids, prefer live reattach over durable restore, and surface restore-unavailable failures.
+- Modify: `server/terminal-registry.ts`
+  Responsibility: keep live handles, launch inputs, and canonical durable identity separate; own sidecar/controller lifecycle.
+- Modify: `server/coding-cli/codex-app-server/client.ts`
+  Responsibility: support the sidecar notification flow the terminal owns.
+- Modify: `server/coding-cli/codex-app-server/protocol.ts`
+  Responsibility: model the initialize/notification payloads needed by the sidecar.
+- Modify: `server/coding-cli/codex-app-server/runtime.ts`
+  Responsibility: sidecar-friendly lifecycle and cleanup.
+- Modify: `server/coding-cli/codex-app-server/launch-planner.ts`
+  Responsibility: stop preallocating fresh threads as restore ids.
+- Modify: `server/coding-cli/opencode-activity-tracker.ts`
+  Responsibility: expose authoritative OpenCode session creation/update data needed for durable promotion.
+- Modify: `server/coding-cli/opencode-activity-wiring.ts`
+  Responsibility: feed the OpenCode session controller from the authoritative tracker instead of parallel heuristics.
+- Modify: `server/session-scanner/service.ts`
+  Responsibility: reject non-canonical persisted Claude restore candidates during migration/read.
+- Modify: `server/agent-timeline/ledger.ts`
+  Responsibility: preserve canonical durable Claude identity without collapsing it into live SDK state.
+- Modify: `server/terminal-view/types.ts`
+  Responsibility: expose explicit live-vs-durable identity in read models.
+- Modify: `server/terminal-view/service.ts`
+  Responsibility: derive read models from the explicit contract.
+- Modify: `server/terminals-router.ts`
+  Responsibility: return terminal directory payloads with explicit durable semantics.
+- Modify: `server/terminal-metadata-service.ts`
+  Responsibility: key metadata off canonical durable identity, not mutable names.
+- Modify: `server/agent-api/router.ts`
+  Responsibility: normalize pane snapshots against the new contract.
+- Modify: `server/mcp/freshell-tool.ts`
+  Responsibility: expose the explicit session contract to MCP callers.
+- Modify: `src/store/paneTypes.ts`
+  Responsibility: persist canonical `sessionRef`, preserve existing live-handle fields separately, keep live-only launch inputs ephemeral, and preserve agent-chat’s separate live session fields.
+- Modify: `src/store/types.ts`
+  Responsibility: remove ambiguous tab-level `resumeSessionId` persistence.
+- Modify: `src/store/panesSlice.ts`
+  Responsibility: build pane state from separate live-handle and durable-restore fields and preserve live-only launch inputs only in-memory where needed.
+- Modify: `src/store/paneTreeValidation.ts`
+  Responsibility: validate the migrated persisted shape.
+- Modify: `src/store/persistedState.ts`
+  Responsibility: migrate legacy `resumeSessionId` snapshots into canonical `sessionRef` or explicit restore-unavailable state while preserving existing live-handle fields needed for same-server reconnect.
+- Modify: `src/store/storage-migration.ts`
+  Responsibility: explicitly preserve existing local state through targeted migration and prevent a schema-bump wipe from becoming the implementation shortcut.
+- Modify: `src/store/persistMiddleware.ts`
+  Responsibility: persist canonical durable identity plus existing live handles, never launch-only inputs.
+- Modify: `src/store/persistControl.ts`
+  Responsibility: flush canonical durable identity and existing live-handle state without reviving launch-only inputs.
+- Modify: `src/store/layoutMirrorMiddleware.ts`
+  Responsibility: mirror canonical durable identity and explicit live-handle state only.
+- Modify: `src/store/crossTabSync.ts`
+  Responsibility: merge cross-tab state without reviving raw resume strings.
+- Modify: `src/store/tabsSlice.ts`
+  Responsibility: remove tab-level fallback reliance on raw `resumeSessionId`.
+- Modify: `src/store/selectors/sidebarSelectors.ts`
+  Responsibility: match open sessions and running state from explicit live handles plus canonical durable identity.
+- Modify: `src/lib/session-utils.ts`
+  Responsibility: resolve canonical session lookup and live-handle matching without mutable-name fallback or hybrid `sessionRef` locality fields.
+- Modify: `src/lib/tab-registry-snapshot.ts`
+  Responsibility: stop synthesizing canonical identity from arbitrary strings and stop smuggling locality into durable `sessionRef`.
+- Modify: `src/lib/ui-commands.ts`
+  Responsibility: normalize session payloads to the explicit contract.
+- Modify: `src/lib/session-type-utils.ts`
+  Responsibility: build resume content from canonical durable identity.
+- Modify: `src/lib/session-metadata.ts`
+  Responsibility: key metadata off canonical durable identity.
+- Modify: `src/lib/pane-activity.ts`
+  Responsibility: activity matching against canonical durable identity and live handles only.
+- Modify: `src/components/TerminalView.tsx`
+  Responsibility: persist only on canonical durable promotion and surface restore-unavailable outcomes.
+- Modify: `src/components/BackgroundSessions.tsx`
+  Responsibility: prefer live reattach and never smuggle stale restore ids into new tabs.
+- Modify: `src/components/Sidebar.tsx`
+  Responsibility: render open-session state from canonical durable identity without title/name fallbacks.
+- Modify: `src/components/TabBar.tsx`
+  Responsibility: stop reconstructing identity from stale resume strings.
+- Modify: `src/components/TabsView.tsx`
+  Responsibility: reconcile persisted live handles versus canonical durable restore during rehydrate.
+- Modify: `src/components/TabContent.tsx`
+  Responsibility: surface restore-unavailable state explicitly.
+- Modify: `src/components/panes/PaneContainer.tsx`
+  Responsibility: prefer canonical durable identity and explicit live handles for header/runtime metadata.
+- Modify: `src/components/context-menu/menu-defs.ts`
+  Responsibility: session-oriented actions use canonical durable identity only.
+- Modify: `src/store/agentChatTypes.ts`
+  Responsibility: document and preserve the split between live SDK state and durable Claude identity.
+- Modify: `src/store/agentChatSlice.ts`
+  Responsibility: durable promotion updates agent-chat state without collapsing live SDK ids.
+- Modify: `src/components/agent-chat/AgentChatView.tsx`
+  Responsibility: keep live SDK attach separate from durable restore identity and canonical promotion.
+- Modify: `test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs`
+  Responsibility: sidecar notification and durability-artifact fixtures.
+- Modify: `docs/index.html` only if user-visible restore wording/status changed materially.
+
+## Task 1: Lock Down Real Provider Contracts And Mutable-Name Semantics
+
+**Files:**
+- Create: `docs/lab-notes/2026-04-20-coding-cli-session-contract.md`
+- Create: `test/helpers/coding-cli/real-session-contract-harness.ts`
+- Create: `test/integration/real/coding-cli-session-contract.test.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Build the real-provider probe harness**
+
+Add isolated temp-home helpers for `codex`, `claude`, and `opencode` that can:
+- launch providers under unique temp directories
+- capture stdout, stderr, session artifacts, and authoritative control-surface responses
+- poll for durable artifact creation without guessing
+- record every child PID they start
+- clean up only probe-owned processes deterministically
+- resolve provider binaries with `command -v` before each probe and record the exact path/version used
+
+Update `package.json` to add one opt-in script, `test:real:coding-cli-contracts`, that wraps the real-provider suite. Reuse the existing `cross-env` dependency already in the repo; do not add a second environment-wrapper dependency.
+That script must expand to: `cross-env FRESHELL_REAL_PROVIDER_CONTRACTS=1 npm run test:vitest -- test/integration/real/coding-cli-session-contract.test.ts`
+
+- [ ] **Step 2: Audit provider processes and define the cleanup rule**
+
+Run provenance-first process audits such as:
+- `ps -eo pid,ppid,stat,cmd --sort=pid | rg "codex|claude|opencode"`
+- `ps -fp <pid>`
+
+Document exactly which processes are safe to stop and which live sessions must be left untouched.
+
+Before any cleanup path is allowed to terminate a process, require one dry-run ownership report that includes:
+- PID / PPID
+- cwd
+- temp-home path
+- harness sentinel metadata
+- safe-to-stop yes/no
+
+If any candidate lacks the expected temp-home prefix or harness sentinel, abort cleanup and fix the harness before proceeding.
+
+- [ ] **Step 3: Run real probes for create, durability, restore, and rename/title mutation**
+
+Capture:
+- Codex fresh interactive launch timing: whether it creates a thread immediately or only after the first real turn, any `thread/started` notification timing, durable artifact creation timing, and `/rename` or equivalent title-mutation behavior (or the absence of such a surface)
+- Claude fresh exact-id timing, transcript durability timing, named resume behavior, and `/rename` or equivalent title-mutation behavior (or the absence of such a surface)
+- OpenCode bare startup behavior, first authoritative session creation timing, authoritative restore behavior, and `/rename` or equivalent title-mutation behavior (or the absence of such a surface)
+
+Save exact commands, versions, artifacts, and relevant output snippets in the lab note.
+
+- [ ] **Step 4: Write the checked-in lab note**
+
+Document:
+- provider versions
+- exact commands
+- exact observed artifacts/endpoints/events
+- whether fresh interactive launch is live-only or immediately allocates a provider session/thread
+- which earlier assumptions were false
+- whether `/rename`, titles, or names can change independently of canonical ids, or whether no such mutable-name surface exists in the tested mode
+- cleanup rules for probe-owned processes
+- the exact provider behaviors Freshell is allowed to build on
+- why the lab note date is `2026-04-20` even though this implementation plan file was created on `2026-04-19`
+
+- [ ] **Step 5: Encode the lab note as opt-in real-provider tests**
+
+Add `test/integration/real/coding-cli-session-contract.test.ts` so every factual claim in the lab note is executable.
+
+The opt-in suite must behave explicitly when binaries are absent:
+- default repo workflows must never invoke it implicitly
+- each missing provider binary must produce a Vitest `skipped` result naming the missing executable; do not rely on ad hoc stdout-only sentinels
+- Task 1 is only complete on the implementation machine when all three provider sections actually run, not when they are skipped
+- if any provider is skipped during later re-verification, final verification is blocked until that binary is restored and the suite reruns with all three provider sections executed again
+
+- [ ] **Step 6: Run the real-provider contract suite**
+
+Run: `npm run test:real:coding-cli-contracts`
+
+Expected: PASS with all three provider sections executed on the implementation machine. If the test and the lab note disagree, fix the test or the note before touching product code.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json docs/lab-notes/2026-04-20-coding-cli-session-contract.md test/helpers/coding-cli/real-session-contract-harness.ts test/integration/real/coding-cli-session-contract.test.ts
+git commit -m "test: lock coding cli provider contracts"
+```
+
+## Task 2: Lock Down Freshell’s Live-Versus-Durable Resume State Machine Before Refactor
+
+**Files:**
+- Create: `test/integration/server/durable-session-contract.test.ts`
+- Create: `test/integration/server/opencode-session-flow.test.ts`
+- Modify: `test/integration/server/codex-session-flow.test.ts`
+- Modify: `test/server/session-association.test.ts`
+- Modify: `test/server/ws-terminal-create-session-repair.test.ts`
+- Modify: `test/e2e/codex-refresh-rehydrate-flow.test.tsx`
+- Modify: `test/e2e/agent-chat-restore-flow.test.tsx`
+- Modify: `test/e2e/open-tab-session-sidebar-visibility.test.tsx`
+
+- [ ] **Step 1: Write the failing end-to-end state-matrix tests**
+
+Cover:
+- same-server reconnect reattaches by persisted live handle (`terminalId` or SDK `sessionId`) even when no canonical `sessionRef` exists yet
+- same-server reconnect reattaches the live terminal/session and does not recreate from `sessionRef`
+- stale `serverInstanceId` or dead live handle uses durable restore only when canonical `sessionRef` exists
+- dead non-durable session surfaces restore-unavailable
+- canonical durable identity survives rename/title changes
+- FreshClaude keeps live SDK `sessionId` separate from durable Claude identity during restore
+
+Because `shared/session-contract.ts` and the final wire split do not exist until Task 3, these red tests must assert with literal/object-shape expectations or local fixtures rather than importing future contract helpers just to make the suite compile.
+
+- [ ] **Step 2: Run the state-matrix suite and verify it fails**
+
+Run: `npm run test:vitest -- test/integration/server/durable-session-contract.test.ts test/integration/server/codex-session-flow.test.ts test/integration/server/opencode-session-flow.test.ts test/server/session-association.test.ts test/server/ws-terminal-create-session-repair.test.ts test/e2e/codex-refresh-rehydrate-flow.test.tsx test/e2e/agent-chat-restore-flow.test.tsx test/e2e/open-tab-session-sidebar-visibility.test.tsx`
+
+Expected: FAIL because current code still treats fresh ids as durable and still blurs live reattach with recreate.
+
+- [ ] **Step 3: Tighten the tests until they describe the intended end state exactly**
+
+Make sure the tests explicitly encode:
+- when live reattach wins
+- when durable restore wins
+- when restore must fail
+- that mutable names/titles do not affect identity
+
+- [ ] **Step 4: Re-run the suite and keep it red for the right reasons**
+
+Run the same command again and confirm failures are still contract failures, not harness mistakes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/integration/server/durable-session-contract.test.ts test/integration/server/opencode-session-flow.test.ts test/integration/server/codex-session-flow.test.ts test/server/session-association.test.ts test/server/ws-terminal-create-session-repair.test.ts test/e2e/codex-refresh-rehydrate-flow.test.tsx test/e2e/agent-chat-restore-flow.test.tsx test/e2e/open-tab-session-sidebar-visibility.test.tsx
+git commit -m "test: lock live versus durable session behavior"
+```
+
+## Task 3: Introduce The Shared Durable Contract And Migrate Persisted State
+
+**Files:**
+- Create: `shared/session-contract.ts`
+- Create: `test/unit/shared/session-contract.test.ts`
+- Create: `test/unit/client/lib/session-contract.test.ts`
+- Create: `test/unit/client/store/storage-migration.test.ts`
+- Modify: `shared/ws-protocol.ts`
+- Modify: `src/store/paneTypes.ts`
+- Modify: `src/store/types.ts`
+- Modify: `src/store/panesSlice.ts`
+- Modify: `src/store/paneTreeValidation.ts`
+- Modify: `src/store/persistedState.ts`
+- Modify: `src/store/storage-migration.ts`
+- Modify: `src/store/persistMiddleware.ts`
+- Modify: `src/store/layoutMirrorMiddleware.ts`
+- Modify: `src/store/crossTabSync.ts`
+- Modify: `src/store/tabsSlice.ts`
+- Modify: `src/lib/ui-commands.ts`
+- Modify: `src/lib/session-type-utils.ts`
+- Modify: `test/unit/client/store/panesSlice.test.ts`
+- Modify: `test/unit/client/store/tabsSlice.merge.test.ts`
+- Modify: `test/unit/client/layout-mirror-middleware.test.ts`
+- Modify: `test/unit/client/store/crossTabSync.test.ts`
+- Modify: `test/unit/server/agent-layout-schema.test.ts`
+- Modify: `test/server/ws-protocol.test.ts`
+- Modify: `test/unit/client/components/TabsView.test.tsx`
+- Modify: `test/unit/client/components/panes/PaneContainer.createContent.test.tsx`
+- Modify: `test/unit/client/components/App.ws-bootstrap.test.tsx`
+- Modify: `test/unit/client/lib/session-type-utils.test.ts`
+
+- [ ] **Step 1: Write the failing contract and migration tests**
+
+Cover:
+- legacy `resumeSessionId` persistence migrates to canonical `sessionRef` or explicit restore-unavailable state
+- canonical `sessionRef` never carries `serverInstanceId`; existing persisted live handles stay separate
+- `SessionLocatorSchema`, `fallbackSessionRef`, and `clientHello` consumers migrate to the live-vs-durable split without smuggling locality into canonical identity
+- pane and tab construction preserve live-only launch inputs only transiently
+- terminal panes/tabs use `sessionRef`, while agent-chat keeps live SDK `sessionId` distinct from its own durable Claude identity
+- agent-chat persisted `resumeSessionId` is removed or migrated to canonical Claude fields rather than surviving as a raw restore token
+- websocket durable-state payloads stop using raw `resumeSessionId`; durable restore uses `sessionRef`, while any launch-only token remains transient-only
+- websocket payload normalization does not revive raw persisted resume strings
+- storage-version bootstrap does not clear restorable session state for this feature
+
+- [ ] **Step 2: Run the targeted contract suite and verify it fails**
+
+Run: `npm run test:vitest -- test/unit/shared/session-contract.test.ts test/unit/client/lib/session-contract.test.ts test/unit/client/store/panesSlice.test.ts test/unit/client/store/tabsSlice.merge.test.ts test/unit/client/layout-mirror-middleware.test.ts test/unit/client/store/crossTabSync.test.ts test/unit/client/store/storage-migration.test.ts test/unit/server/agent-layout-schema.test.ts test/server/ws-protocol.test.ts`
+
+Expected: FAIL because the explicit contract and migration helpers do not exist yet.
+
+- [ ] **Step 3: Implement the shared contract and persistence migration**
+
+Add canonical `sessionRef`, live-only launch-input helpers, one-time migration away from ambiguous persisted `resumeSessionId` strings without clearing persisted tabs/panes wholesale, and the explicit WS payload cutover required by the Wire Contract Rule.
+
+Apply these migration rules explicitly:
+- terminal Codex legacy `resumeSessionId` values that came from fresh-thread persistence under the shipped bug never become canonical `sessionRef`; migrate them to `restoreError`
+- terminal Claude values only become canonical when the provider rules from Task 1 prove they are UUID-backed durable identity; non-canonical name/title values become `restoreError`
+- OpenCode values only become canonical when Task 1 plus authoritative control-surface rules prove they are durable session ids; otherwise migrate to `restoreError`
+- agent-chat entries keep canonical Claude fields when present; entries with only legacy raw `resumeSessionId` and no canonical `cliSessionId` / `timelineSessionId` migrate to `restoreError`
+- migration clears persisted raw `resumeSessionId` values even when the active Redux runtime is still allowed to hold a transient launch-only token in memory
+
+- [ ] **Step 4: Re-run the targeted suite and verify it passes**
+
+Run the same command again.
+
+Expected: PASS.
+
+- [ ] **Step 5: Refactor helpers and run adjacent construction tests**
+
+Run: `npm run test:vitest -- test/unit/client/components/TabsView.test.tsx test/unit/client/components/panes/PaneContainer.createContent.test.tsx test/unit/client/components/App.ws-bootstrap.test.tsx test/unit/client/lib/session-type-utils.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/session-contract.ts shared/ws-protocol.ts src/store/paneTypes.ts src/store/types.ts src/store/panesSlice.ts src/store/paneTreeValidation.ts src/store/persistedState.ts src/store/storage-migration.ts src/store/persistMiddleware.ts src/store/layoutMirrorMiddleware.ts src/store/crossTabSync.ts src/store/tabsSlice.ts src/lib/ui-commands.ts src/lib/session-type-utils.ts test/unit/shared/session-contract.test.ts test/unit/client/lib/session-contract.test.ts test/unit/client/store/storage-migration.test.ts test/unit/client/store/panesSlice.test.ts test/unit/client/store/tabsSlice.merge.test.ts test/unit/client/layout-mirror-middleware.test.ts test/unit/client/store/crossTabSync.test.ts test/unit/server/agent-layout-schema.test.ts test/server/ws-protocol.test.ts test/unit/client/components/TabsView.test.tsx test/unit/client/components/panes/PaneContainer.createContent.test.tsx test/unit/client/components/App.ws-bootstrap.test.tsx test/unit/client/lib/session-type-utils.test.ts
+git commit -m "refactor: add explicit durable session contract"
+```
+
+## Task 4: Make Existing Binding Paths The Only Durable-Promotion Path
+
+**Files:**
+- Modify: `server/session-binding-authority.ts`
+- Modify: `server/session-association-coordinator.ts`
+- Modify: `server/session-association-updates.ts`
+- Modify: `server/index.ts`
+- Modify: `server/ws-handler.ts`
+- Modify: `server/terminal-registry.ts`
+- Modify: `src/store/persistControl.ts`
+- Modify: `src/lib/session-utils.ts`
+- Modify: `src/lib/tab-registry-snapshot.ts`
+- Modify: `src/components/TerminalView.tsx`
+- Modify: `src/components/terminal-view-utils.ts`
+- Modify: `test/unit/server/terminal-registry.test.ts`
+- Modify: `test/unit/server/terminal-registry.findRunningTerminal.test.ts`
+- Modify: `test/server/ws-protocol.test.ts`
+- Modify: `test/unit/client/components/TerminalView.lifecycle.test.tsx`
+- Modify: `test/unit/client/components/TerminalView.resumeSession.test.tsx`
+- Modify: `test/unit/client/lib/session-utils.test.ts`
+- Modify: `test/unit/client/lib/tab-registry-snapshot.test.ts`
+- Modify: `test/e2e/codex-refresh-rehydrate-flow.test.tsx`
+
+- [ ] **Step 1: Write the failing promotion-path tests**
+
+Cover:
+- `terminal.created` no longer persists non-durable ids
+- `terminal.created` preserves only the live handle needed for same-server reconnect
+- `terminal.session.associated` is the only terminal event that persists canonical durable identity
+- same-server live reattach beats durable recreate
+- missing durable identity yields restore-unavailable rather than fresh-session fallback
+
+- [ ] **Step 2: Run the promotion-path suite and verify it fails**
+
+Run: `npm run test:vitest -- test/unit/server/terminal-registry.test.ts test/unit/server/terminal-registry.findRunningTerminal.test.ts test/server/ws-protocol.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/TerminalView.resumeSession.test.tsx test/unit/client/lib/session-utils.test.ts test/unit/client/lib/tab-registry-snapshot.test.ts test/e2e/codex-refresh-rehydrate-flow.test.tsx`
+
+Expected: FAIL because current code still persists immediate resume ids and still treats `terminal.created` as durable enough.
+
+- [ ] **Step 3: Refactor the server/client binding flow**
+
+Implement:
+- explicit live handle vs durable `sessionRef` separation
+- reuse of `terminal.session.associated` as the single authoritative terminal durable-promotion event
+- clear restore-unavailable failures
+- no second terminal durable-promotion controller/event
+
+- [ ] **Step 4: Re-run the promotion-path suite and verify it passes**
+
+Run the same command again.
+
+Expected: PASS.
+
+- [ ] **Step 5: Refactor and run adjacent persistence checks**
+
+Run: `npm run test:vitest -- test/unit/client/store/tabsSlice.test.ts test/unit/client/store/tabsSlice.merge.test.ts test/unit/client/store/persistControl.test.ts test/unit/client/components/TerminalView.lastInputAt.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/session-binding-authority.ts server/session-association-coordinator.ts server/session-association-updates.ts server/index.ts server/ws-handler.ts server/terminal-registry.ts src/store/persistControl.ts src/lib/session-utils.ts src/lib/tab-registry-snapshot.ts src/components/TerminalView.tsx src/components/terminal-view-utils.ts test/unit/server/terminal-registry.test.ts test/unit/server/terminal-registry.findRunningTerminal.test.ts test/server/ws-protocol.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/TerminalView.resumeSession.test.tsx test/unit/client/lib/session-utils.test.ts test/unit/client/lib/tab-registry-snapshot.test.ts test/e2e/codex-refresh-rehydrate-flow.test.tsx
+git commit -m "refactor: make durable promotion authoritative"
+```
+
+## Task 5: Cut Codex Over To Per-Terminal Sidecars And Durable Artifact Promotion
+
+**Files:**
+- Create: `server/coding-cli/codex-app-server/sidecar.ts`
+- Modify: `server/coding-cli/codex-app-server/client.ts`
+- Modify: `server/coding-cli/codex-app-server/protocol.ts`
+- Modify: `server/coding-cli/codex-app-server/runtime.ts`
+- Modify: `server/coding-cli/codex-app-server/launch-planner.ts`
+- Modify: `server/index.ts`
+- Modify: `server/ws-handler.ts`
+- Modify: `server/terminal-registry.ts`
+- Modify: `test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs`
+- Modify: `test/unit/server/coding-cli/codex-app-server/client.test.ts`
+- Modify: `test/unit/server/coding-cli/codex-app-server/runtime.test.ts`
+- Modify: `test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts`
+- Modify: `test/integration/server/codex-session-flow.test.ts`
+- Modify: `test/integration/server/codex-session-rebind-regression.test.ts`
+- Modify: `test/server/ws-terminal-create-reuse-running-codex.test.ts`
+- Modify: `test/server/codex-activity-exact-subset.test.ts`
+
+- [ ] **Step 1: Rewrite the Codex tests to the real-provider contract**
+
+Change expectations so that:
+- fresh create uses the exact remote CLI form proven by Task 1, which is currently `codex --remote <ws>` with no preallocated `resume`
+- restore uses the exact durable-restore CLI form proven by Task 1, which is currently `codex --remote <ws> resume <durable-token>`
+- two concurrent live Codex terminals prove the intentional per-terminal-sidecar model by owning distinct sidecars/endpoints and isolated cleanup
+- a fresh interactive Codex pane may still be live-only until the provider actually creates a thread
+- once a thread exists, the sidecar learns any exact thread identity only from provider notifications
+- durable promotion happens only after the provider-owned artifact exists
+- sidecar death terminates the terminal with a clear error
+
+- [ ] **Step 2: Run the Codex-focused suite and verify it fails**
+
+Run: `npm run test:vitest -- test/unit/server/coding-cli/codex-app-server/client.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts test/integration/server/codex-session-flow.test.ts test/integration/server/codex-session-rebind-regression.test.ts test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/codex-activity-exact-subset.test.ts`
+
+Expected: FAIL because current implementation still preallocates fresh threads and persists them immediately.
+
+- [ ] **Step 3: Implement the sidecar and terminal lifecycle**
+
+Add one sidecar per Codex terminal, keep fresh panes live-only until the provider actually creates a thread, parse the required notifications, promote durability only after artifact proof, tear the sidecar down on terminal exit and every other cleanup path, and reap orphaned sidecars/endpoints on server boot after a crash using explicit ownership metadata instead of broad kill patterns.
+This task intentionally replaces the current shared singleton runtime; do not keep both architectures alive.
+
+- [ ] **Step 4: Re-run the Codex suite and broader regressions**
+
+Run: `npm run test:vitest -- test/unit/server/coding-cli/codex-app-server/client.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts test/integration/server/codex-session-flow.test.ts test/integration/server/codex-session-rebind-regression.test.ts test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/codex-activity-exact-subset.test.ts test/e2e/codex-refresh-rehydrate-flow.test.tsx test/e2e/codex-activity-indicator-flow.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/coding-cli/codex-app-server/sidecar.ts server/coding-cli/codex-app-server/client.ts server/coding-cli/codex-app-server/protocol.ts server/coding-cli/codex-app-server/runtime.ts server/coding-cli/codex-app-server/launch-planner.ts server/index.ts server/ws-handler.ts server/terminal-registry.ts test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs test/unit/server/coding-cli/codex-app-server/client.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts test/integration/server/codex-session-flow.test.ts test/integration/server/codex-session-rebind-regression.test.ts test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/codex-activity-exact-subset.test.ts
+git commit -m "refactor: move codex terminals to sidecar-owned durability"
+```
+
+## Task 6: Canonicalize Claude And FreshClaude Without Flattening Their Live State
+
+**Files:**
+- Modify: `server/session-scanner/service.ts`
+- Modify: `server/agent-timeline/ledger.ts`
+- Modify: `server/index.ts`
+- Modify: `server/terminal-registry.ts`
+- Modify: `server/ws-handler.ts`
+- Modify: `src/store/agentChatTypes.ts`
+- Modify: `src/store/agentChatSlice.ts`
+- Modify: `src/components/agent-chat/AgentChatView.tsx`
+- Modify: `src/components/TerminalView.tsx`
+- Modify: `test/server/session-association.test.ts`
+- Modify: `test/server/ws-terminal-create-session-repair.test.ts`
+- Modify: `test/unit/server/agent-timeline-ledger.test.ts`
+- Modify: `test/unit/server/ws-handler-sdk.test.ts`
+- Modify: `test/integration/server/agent-timeline-router.test.ts`
+- Modify: `test/unit/client/components/agent-chat/AgentChatView.reload.test.tsx`
+- Modify: `test/unit/client/components/agent-chat/AgentChatView.session-lost.test.tsx`
+
+- [ ] **Step 1: Rewrite the Claude and FreshClaude tests to the canonical contract**
+
+Cover:
+- fresh terminal Claude launches use the Task 1 contract and do not become durable until the transcript exists
+- named resumes and rename/title changes are launch/display metadata only
+- persisted Claude restore candidates are revalidated on read and bad legacy values are rejected
+- FreshClaude keeps live SDK `sessionId` separate from canonical durable Claude identity during restore hydration
+
+- [ ] **Step 2: Run the targeted Claude/FreshClaude suite and verify it fails**
+
+Run: `npm run test:vitest -- test/server/session-association.test.ts test/server/ws-terminal-create-session-repair.test.ts test/unit/server/agent-timeline-ledger.test.ts test/unit/server/ws-handler-sdk.test.ts test/integration/server/agent-timeline-router.test.ts test/unit/client/components/agent-chat/AgentChatView.reload.test.tsx test/unit/client/components/agent-chat/AgentChatView.session-lost.test.tsx test/e2e/agent-chat-restore-flow.test.tsx test/e2e/agent-chat-resume-history-flow.test.tsx`
+
+Expected: FAIL because current flow still relies on raw resume strings and still blurs live SDK state with durable history identity.
+
+- [ ] **Step 3: Implement canonical promotion and read-time validation**
+
+Implement:
+- canonical UUID-only durable promotion
+- rejection of non-canonical persisted Claude restore inputs
+- agent-chat durable promotion without collapsing live SDK state
+- restore-unavailable when only a mutable name remains and no canonical durable UUID can be proven
+- restore-unavailable for agent-chat entries that only have legacy raw `resumeSessionId` and no canonical Claude identity
+
+- [ ] **Step 4: Re-run the targeted suite and verify it passes**
+
+Run the same command again.
+
+Expected: PASS.
+
+- [ ] **Step 5: Run adjacent Claude/FreshClaude regressions**
+
+Run: `npm run test:vitest -- test/unit/client/components/agent-chat/AgentChatView.split-pane.test.tsx test/e2e/open-tab-session-sidebar-visibility.test.tsx test/e2e/sidebar-click-opens-pane.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/session-scanner/service.ts server/agent-timeline/ledger.ts server/index.ts server/terminal-registry.ts server/ws-handler.ts src/store/agentChatTypes.ts src/store/agentChatSlice.ts src/components/agent-chat/AgentChatView.tsx src/components/TerminalView.tsx test/server/session-association.test.ts test/server/ws-terminal-create-session-repair.test.ts test/unit/server/agent-timeline-ledger.test.ts test/unit/server/ws-handler-sdk.test.ts test/integration/server/agent-timeline-router.test.ts test/unit/client/components/agent-chat/AgentChatView.reload.test.tsx test/unit/client/components/agent-chat/AgentChatView.session-lost.test.tsx
+git commit -m "refactor: canonicalize claude and freshclaude restore identity"
+```
+
+## Task 7: Promote OpenCode Only From Its Authoritative Control Surface
+
+**Files:**
+- Create: `server/coding-cli/opencode-session-controller.ts`
+- Modify: `server/coding-cli/opencode-activity-tracker.ts`
+- Modify: `server/coding-cli/opencode-activity-wiring.ts`
+- Modify: `server/index.ts`
+- Modify: `server/terminal-registry.ts`
+- Modify: `server/ws-handler.ts`
+- Modify: `test/integration/server/opencode-session-flow.test.ts`
+- Modify: `test/server/ws-opencode-activity.test.ts`
+- Modify: `test/unit/client/lib/pane-activity.test.ts`
+- Modify: `test/e2e/pane-activity-indicator-flow.test.tsx`
+
+- [ ] **Step 1: Write the failing OpenCode durability tests**
+
+Cover:
+- bare interactive startup remains live-only until the provider creates a session
+- authoritative control events promote the pane to canonical durable identity
+- restore uses only canonical durable `sessionRef`
+- names/titles do not become restore keys
+
+- [ ] **Step 2: Run the targeted OpenCode suite and verify it fails**
+
+Run: `npm run test:vitest -- test/integration/server/opencode-session-flow.test.ts test/server/ws-opencode-activity.test.ts test/unit/client/lib/pane-activity.test.ts test/e2e/pane-activity-indicator-flow.test.tsx`
+
+Expected: FAIL because OpenCode durable promotion is not yet modeled explicitly.
+
+- [ ] **Step 3: Implement the authoritative OpenCode session controller**
+
+Extend the current authoritative tracker/event stream so the controller can observe exact session creation, durable promotion, and cleanup without PTY heuristics.
+
+- [ ] **Step 4: Re-run the targeted suite and verify it passes**
+
+Run the same command again.
+
+Expected: PASS.
+
+- [ ] **Step 5: Run adjacent OpenCode checks**
+
+Run: `npm run test:vitest -- test/e2e/open-tab-session-sidebar-visibility.test.tsx test/e2e/title-sync-flow.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/coding-cli/opencode-session-controller.ts server/coding-cli/opencode-activity-tracker.ts server/coding-cli/opencode-activity-wiring.ts server/index.ts server/terminal-registry.ts server/ws-handler.ts test/integration/server/opencode-session-flow.test.ts test/server/ws-opencode-activity.test.ts test/unit/client/lib/pane-activity.test.ts test/e2e/pane-activity-indicator-flow.test.tsx
+git commit -m "refactor: promote opencode sessions from authoritative events"
+```
+
+## Task 8: Cut Over Read Models, Sidebar, Background Sessions, Agent Routes, And MCP
+
+**Files:**
+- Modify: `server/terminal-view/types.ts`
+- Modify: `server/terminal-view/service.ts`
+- Modify: `server/terminals-router.ts`
+- Modify: `server/terminal-metadata-service.ts`
+- Modify: `server/agent-api/router.ts`
+- Modify: `server/mcp/freshell-tool.ts`
+- Modify: `src/store/selectors/sidebarSelectors.ts`
+- Modify: `src/lib/session-metadata.ts`
+- Modify: `src/lib/pane-activity.ts`
+- Modify: `src/components/BackgroundSessions.tsx`
+- Modify: `src/components/Sidebar.tsx`
+- Modify: `src/components/TabBar.tsx`
+- Modify: `src/components/TabsView.tsx`
+- Modify: `src/components/TabContent.tsx`
+- Modify: `src/components/panes/PaneContainer.tsx`
+- Modify: `src/components/context-menu/menu-defs.ts`
+
+- [ ] **Step 1: Write or extend the failing consumer regression tests**
+
+Cover:
+- terminal-directory and background-session payloads preserve live-vs-durable identity correctly
+- sidebar matching uses canonical durable identity plus explicit live handles, not mutable names or hybrid `sessionRef` locality
+- pane headers and runtime metadata stop depending on raw `resumeSessionId`
+- context-menu, agent routes, and MCP surfaces send the explicit contract
+
+- [ ] **Step 2: Run the targeted consumer suite and verify it fails**
+
+Run: `npm run test:vitest -- test/server/terminals-api.test.ts test/integration/server/terminal-view-router.test.ts test/unit/server/terminal-metadata-service.test.ts test/unit/server/mcp/freshell-tool.test.ts test/server/agent-panes-write.test.ts test/server/agent-run.test.ts test/unit/client/components/BackgroundSessions.test.tsx test/unit/client/components/Sidebar.test.tsx test/unit/client/components/Sidebar.render-stability.test.tsx test/unit/client/components/TabContent.test.tsx test/unit/client/components/TabsView.test.tsx test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/terminal-view-utils.test.ts test/unit/client/components/ContextMenuProvider.test.tsx test/unit/client/store/selectors/sidebarSelectors.test.ts test/unit/client/store/selectors/sidebarSelectors.runningTerminal.test.ts test/unit/client/store/terminalDirectorySlice.test.ts test/unit/client/store/terminalDirectoryThunks.test.ts test/e2e/pane-header-runtime-meta-flow.test.tsx test/e2e/sidebar-search-flow.test.tsx`
+
+Expected: FAIL until all consumers stop depending on the old string semantics.
+
+- [ ] **Step 3: Implement the remaining consumer cutover**
+
+Finish the read-model, UI, agent, and MCP consumers so the repo consistently uses:
+- live handles for same-server reattach
+- canonical durable `sessionRef` for recreate and exact durable identity
+
+- [ ] **Step 4: Re-run the targeted consumer suite and verify it passes**
+
+Run the same command again.
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the UI/read-model regression sweep**
+
+Run: `npm run test:vitest -- test/server/ws-sidebar-snapshot-refresh.test.ts test/e2e/open-tab-session-sidebar-visibility.test.tsx test/e2e/sidebar-busy-icon-flow.test.tsx test/e2e/sidebar-click-opens-pane.test.tsx test/e2e/tabs-view-flow.test.tsx test/e2e/pane-header-runtime-meta-flow.test.tsx test/e2e/sidebar-refresh-dom-stability.test.tsx test/e2e/sidebar-search-flow.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/terminal-view/types.ts server/terminal-view/service.ts server/terminals-router.ts server/terminal-metadata-service.ts server/agent-api/router.ts server/mcp/freshell-tool.ts src/store/selectors/sidebarSelectors.ts src/lib/session-metadata.ts src/lib/pane-activity.ts src/components/BackgroundSessions.tsx src/components/Sidebar.tsx src/components/TabBar.tsx src/components/TabsView.tsx src/components/TabContent.tsx src/components/panes/PaneContainer.tsx src/components/context-menu/menu-defs.ts test/server/terminals-api.test.ts test/integration/server/terminal-view-router.test.ts test/unit/server/terminal-metadata-service.test.ts test/unit/server/mcp/freshell-tool.test.ts test/server/agent-panes-write.test.ts test/server/agent-run.test.ts test/unit/client/components/BackgroundSessions.test.tsx test/unit/client/components/Sidebar.test.tsx test/unit/client/components/Sidebar.render-stability.test.tsx test/unit/client/components/TabContent.test.tsx test/unit/client/components/TabsView.test.tsx test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/terminal-view-utils.test.ts test/unit/client/components/ContextMenuProvider.test.tsx test/unit/client/store/selectors/sidebarSelectors.test.ts test/unit/client/store/selectors/sidebarSelectors.runningTerminal.test.ts test/unit/client/store/terminalDirectorySlice.test.ts test/unit/client/store/terminalDirectoryThunks.test.ts
+git commit -m "refactor: cut consumers over to explicit session identity"
+```
+
+## Task 9: Final Verification And Docs
+
+**Files:**
+- Modify: `docs/index.html` only if user-visible restore wording/status changed materially
+
+- [ ] **Step 1: Update `docs/index.html` only if the visible restore contract changed**
+
+Update the mock if the default experience now surfaces explicit `RESTORE_UNAVAILABLE` messaging or any materially different restore wording/status affordances. If the final UI still leaves the default mock accurate without changes, record that conclusion during Task 9 verification.
+
+- [ ] **Step 2: Run lint**
+
+Run: `npm run lint`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 4: Re-run the opt-in real-provider contract suite**
+
+Run: `npm run test:real:coding-cli-contracts`
+
+Expected: PASS with all three provider sections executed on the implementation machine. A vacuous all-skipped run does not satisfy final verification.
+
+- [ ] **Step 5: Run the focused cross-cutting regression sweep**
+
+Run: `npm run test:vitest -- test/integration/server/durable-session-contract.test.ts test/unit/shared/session-contract.test.ts test/unit/client/lib/session-contract.test.ts test/unit/server/coding-cli/codex-app-server/client.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts test/integration/server/codex-session-flow.test.ts test/integration/server/opencode-session-flow.test.ts test/server/session-association.test.ts test/server/ws-terminal-create-session-repair.test.ts test/unit/server/agent-timeline-ledger.test.ts test/unit/server/ws-handler-sdk.test.ts test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/ws-opencode-activity.test.ts test/server/terminals-api.test.ts test/unit/client/components/BackgroundSessions.test.tsx test/unit/client/components/Sidebar.test.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/agent-chat/AgentChatView.reload.test.tsx test/e2e/codex-refresh-rehydrate-flow.test.tsx test/e2e/agent-chat-restore-flow.test.tsx test/e2e/open-tab-session-sidebar-visibility.test.tsx test/e2e/pane-activity-indicator-flow.test.tsx test/e2e/sidebar-busy-icon-flow.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the coordinated full suite**
+
+Run: `FRESHELL_TEST_SUMMARY="exact durable session contract" npm test`
+
+Expected: PASS. If any valid check fails, keep improving the implementation and tests. Do not stop on partial green.
+
+- [ ] **Step 7: Commit any final doc or cleanup change from this task**
+
+If Step 1 changed `docs/index.html` or verification exposed a final cleanup edit, commit it with `git commit -m "docs: finalize exact durable session contract verification"`. If this task produced no file changes, skip the commit. A no-op Task 9 is valid and does not block completion so long as the verification steps passed.
+
+## Completion Checklist
+
+- The checked-in lab note matches the executable real-provider contract suite.
+- The implementation preserves existing persisted tabs/panes through targeted migration; it does not rely on a storage-version wipe.
+- The contract tests explicitly prove when live reattach happens, when durable restore happens, and when restore must fail.
+- Probe-owned helper processes are cleaned up deterministically and live user sessions were not killed.
+- Canonical `sessionRef = { provider, sessionId }` is the only persisted replay identity; it never carries `serverInstanceId`.
+- Persisted live handles needed for same-server refresh recovery remain separate for terminals and agent-chat.
+- Mutable names/titles and `/rename`-style inputs are proven non-canonical and never used as restore keys.
+- `terminal.session.associated` is the single authoritative terminal durable-promotion event.
+- Fresh Codex sessions are started only by the Codex CLI itself over a terminal-owned sidecar, remain live-only until the provider actually creates a thread/session, and sidecar death fails clearly.
+- Claude and FreshClaude restore only from canonical durable Claude identity.
+- OpenCode durable promotion comes only from authoritative control data.
+- Read models, sidebar state, background sessions, agent routes, and MCP all use the explicit contract consistently.
+- Lint, typecheck, the focused regression sweep, the opt-in real-provider suite, and coordinated full `npm test` all pass.

--- a/docs/superpowers/plans/2026-04-21-codex-durable-promotion-stability.md
+++ b/docs/superpowers/plans/2026-04-21-codex-durable-promotion-stability.md
@@ -1,0 +1,512 @@
+# Codex Durable Promotion Stability Implementation Plan
+
+> **For Claude:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Codex's current whole-tree rollout polling with a provider-witnessed exact-path promotion flow that stays cheap, eventual, and correct, while keeping Claude, FreshClaude, and OpenCode aligned under the same durable-session contract.
+
+**Architecture:** Treat each provider's durable promotion as a provider-specific witness, not a generic timeout. For Codex, consume the `thread.path` surfaced by `thread/started`, register provider-native `fs/watch` subscriptions on that exact future rollout path and its parent directory, and confirm durability with O(1) existence checks plus a low-frequency backoff that has no 10 second cutoff. Keep the existing live-versus-durable split for the other providers: Claude stays transcript/UUID-backed, FreshClaude keeps live SDK identity separate from durable history identity, and OpenCode continues to promote only from its authoritative control surface.
+
+**Tech Stack:** TypeScript, Node.js, WebSocket (`ws`), app-server JSON-RPC, Node filesystem APIs, Vitest, existing real-provider contract probes
+
+---
+
+This plan is intended to be self-contained: an implementer should be able to execute it using only the listed files, tests, and commands without needing additional transcript context.
+
+## Research Snapshot
+
+These are planning inputs from this machine on 2026-04-21. Re-prove them in Task 1 and then treat the checked-in tests and lab note as authoritative.
+
+- Current shipped Codex promotion path is still the global scan in `server/coding-cli/codex-app-server/sidecar.ts`:
+  - `DEFAULT_ARTIFACT_POLL_MS = 100`
+  - `DEFAULT_ARTIFACT_TIMEOUT_MS = 10_000`
+  - `waitForDurableArtifact()` walks the entire `CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl` tree on every pass.
+- Current local Codex corpus size is already large enough that "just poll slower" is still the wrong mechanism:
+  - `find ~/.codex/sessions -type f -name 'rollout-*.jsonl' | wc -l` -> `3432`
+  - `du -sh ~/.codex/sessions` -> `3.7G`
+  - one local reproduction of the shipped scan shape (`readdir` walk + `stat` on every rollout) took about `363ms` on this machine.
+- Current official Codex app-server docs expose the primitives the shipped implementation is not using:
+  - `thread/start` and `thread/started` return a thread object.
+  - non-ephemeral threads have a concrete `thread.path`.
+  - `fs/watch`, `fs/unwatch`, and `fs/changed` are stable app-server methods/notifications.
+  - Source: `https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md`
+- A live local probe against the installed `codex-cli 0.122.0` showed:
+  - `thread/start` already returns a concrete `thread.path` before the file exists.
+  - the rollout file and even its date directory do **not** exist immediately after `thread/start`.
+  - app-server accepts `fs/watch` on the missing rollout path and on the missing parent directory.
+  - after the first real turn, the rollout file appears at the exact `thread.path`, and both watches emit `fs/changed`.
+- The checked-in lab note currently records `codex-cli 0.121.0`, so Task 1 must explicitly reconcile the version of record instead of silently assuming the newer probe supersedes it.
+- Recent upstream Codex issues still report "no rollout found" / rollout-materialization failures on real installs. We should therefore never treat "10 seconds elapsed" as proof of durability or proof of failure.
+  - `https://github.com/openai/codex/issues/16872`
+  - `https://github.com/openai/codex/issues/16994`
+
+## Strategy Guardrails
+
+- Do not keep the current `listRolloutArtifacts()` tree walk in any form.
+- Do not replace the current 100ms poll loop with a slower whole-tree poll loop.
+- Do not introduce a provider-wide watcher on all of `CODEX_HOME`, `CODEX_HOME/sessions`, or every date directory.
+- Do not read or depend on Codex internal indexes such as `state_5.sqlite` or `session_index.jsonl`.
+- Do not use `thread/list` or `thread/read` as the durability proof. The proof is the provider-owned rollout artifact at the provider-reported `thread.path`.
+- Do not add a new cross-provider abstraction that forces Claude, FreshClaude, and OpenCode to mimic Codex internals. Share the invariant, not the mechanism.
+- Do not reintroduce any "10 seconds or bust" promotion semantics. Pending Codex promotion must remain active until success or sidecar shutdown.
+- Do not silently fall back from "restore this session" to "start a fresh session".
+
+## Cross-Provider Contract
+
+This plan intentionally keeps one invariant across all providers:
+
+- Canonical durable identity is promoted only after a provider-specific durable witness exists.
+- Same-server live reattach remains separate from durable restore.
+- A missing durable witness is an explicit pending or restore-unavailable state, not a reason to guess.
+
+Provider witnesses after this work:
+
+- Codex: exact rollout file existence at provider-reported `thread.path`, observed through path-specific watch notifications plus path-specific existence checks.
+- Claude terminal: exact transcript-backed UUID through the existing session repair / scanner path.
+- FreshClaude: durable history identity through the existing history resolver; live SDK `sessionId` stays separate.
+- OpenCode: authoritative control-plane session id through the existing health / status / event path.
+
+## File Structure
+
+- Create: `server/coding-cli/codex-app-server/durable-rollout-tracker.ts`
+  Responsibility: own path-specific Codex durability tracking, watch registration, fallback existence probes, cleanup, and promotion callback.
+- Create: `test/unit/server/coding-cli/codex-app-server/durable-rollout-tracker.test.ts`
+  Responsibility: prove the tracker never scans the rollout tree, survives missed watch events, and keeps retrying past the old 10 second cutoff.
+- Modify: `docs/lab-notes/2026-04-20-coding-cli-session-contract.md`
+  Responsibility: record the newly verified `thread.path` / `fs/watch` Codex contract explicitly.
+- Modify: `test/helpers/coding-cli/real-session-contract-harness.ts`
+  Responsibility: expose the real-provider probe helpers needed to assert `thread.path`, missing-path watch registration, and watch notifications after the first turn.
+- Modify: `test/integration/real/coding-cli-session-contract.test.ts`
+  Responsibility: lock the live Codex contract into executable tests.
+- Modify: `server/coding-cli/codex-app-server/protocol.ts`
+  Responsibility: model the full `thread` shape and `fs/watch` / `fs/unwatch` / `fs/changed` RPCs.
+- Modify: `server/coding-cli/codex-app-server/client.ts`
+  Responsibility: surface rich `thread/started` payloads, expose path-watch RPC helpers, and deliver `fs/changed` notifications.
+- Modify: `server/coding-cli/codex-app-server/runtime.ts`
+  Responsibility: forward richer thread notifications and watcher notifications to the sidecar layer.
+- Modify: `server/coding-cli/codex-app-server/sidecar.ts`
+  Responsibility: remove whole-tree polling and delegate Codex durability promotion to the exact-path tracker.
+- Modify: `test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs`
+  Responsibility: emulate the current Codex contract closely enough for unit/integration coverage, including `thread.path` and watch notifications.
+- Modify: `test/unit/server/coding-cli/codex-app-server/client.test.ts`
+  Responsibility: lock protocol parsing and notification fanout.
+- Modify: `test/unit/server/coding-cli/codex-app-server/runtime.test.ts`
+  Responsibility: verify runtime passthrough of richer payloads.
+- Modify: `test/unit/server/coding-cli/codex-app-server/sidecar.test.ts`
+  Responsibility: verify sidecar lifecycle, cleanup, and durable-promotion handoff using the new tracker.
+- Modify: `test/integration/server/codex-session-flow.test.ts`
+  Responsibility: verify Codex end-to-end promotion behavior through the terminal registry and websocket layer.
+- Modify: `test/integration/server/durable-session-contract.test.ts`
+  Responsibility: keep the provider-wide invariant explicit so Codex hardening does not regress Claude, FreshClaude, or OpenCode behavior.
+- Modify: `test/integration/server/opencode-session-flow.test.ts`
+  Responsibility: keep OpenCode's authoritative-control-surface witness explicit while the provider-parity tests are tightened.
+- Modify: `test/unit/client/components/TerminalView.resumeSession.test.tsx`
+  Responsibility: pin the client-visible boundary between live-only Codex state and durable promotion, while keeping the other providers' client resume behavior unchanged.
+
+## Chunk 1: Lock The Provider Contract
+
+### Task 1: Re-Prove The Codex Witness We Actually Want To Depend On
+
+**Files:**
+- Modify: `docs/lab-notes/2026-04-20-coding-cli-session-contract.md`
+- Modify: `test/helpers/coding-cli/real-session-contract-harness.ts`
+- Modify: `test/integration/real/coding-cli-session-contract.test.ts`
+
+- [ ] **Step 1: Write the failing real-provider assertions**
+
+Add or tighten the real Codex probe so it asserts all of these facts together:
+
+```ts
+// This repo currently uses Vitest 3.2.4, so `toBeOneOf()` is available.
+const rolloutWatchId = 'probe-rollout-path'
+const parentWatchId = 'probe-rollout-parent'
+
+expect(start.thread.ephemeral).toBe(false)
+expect(start.thread.path).toMatch(/\/sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-.+\.jsonl$/)
+expect(await exists(start.thread.path)).toBe(false)
+expect(await exists(path.dirname(start.thread.path))).toBe(false)
+expect(await client.fsWatch(start.thread.path, rolloutWatchId)).toEqual({ path: start.thread.path })
+expect(await client.fsWatch(path.dirname(start.thread.path), parentWatchId)).toEqual({ path: path.dirname(start.thread.path) })
+expect(changed.params.watchId).toBeOneOf([rolloutWatchId, parentWatchId])
+```
+
+- [ ] **Step 2: Run the Codex real-provider section and verify it fails for the right reason**
+
+Run:
+
+```bash
+FRESHELL_REAL_PROVIDER_CONTRACTS=1 npm run test:vitest -- test/integration/real/coding-cli-session-contract.test.ts
+```
+
+Expected: the Codex section fails because the current checked-in harness and note do not yet encode `thread.path` or missing-path watch behavior.
+
+- [ ] **Step 3: Extend the harness to capture path and watch behavior**
+
+Teach the probe client/helpers to:
+
+```ts
+type CodexThreadHandle = {
+  id: string
+  path: string | null
+  ephemeral: boolean
+}
+
+type FsChangedNotification = {
+  watchId: string
+  changedPaths: string[]
+}
+```
+
+Also add one probe that waits for the first real turn to produce both:
+
+- the rollout file appearing at `thread.path`
+- at least one `fs/changed` notification mentioning that path
+
+- [ ] **Step 4: Update the checked-in lab note with the new contract**
+
+Record, in prose and in one short JSON-ish transcript snippet:
+
+- whether the checked-in `0.121.0` note is being superseded by a newly captured `0.122.0` contract or whether the earlier note needs correction; record the version the probes actually ran against as the version of record
+- `thread.path` is available before the file exists.
+- `watchId` is caller-supplied to `fs/watch`, the response only returns canonicalized `path`, and later `fs/changed` notifications echo the original caller-supplied `watchId`.
+- app-server accepts watches on the missing rollout path and missing parent directory.
+- the first real turn materializes the rollout at the exact reported path.
+- the watch notifications are usable as an event source, but durability still needs a direct path-specific existence check.
+
+- [ ] **Step 5: Re-run the real-provider suite and commit**
+
+Run the same command again.
+
+Expected: PASS for the Codex section, with Claude and OpenCode still passing or explicitly skipped according to the existing opt-in rules.
+
+Commit:
+
+```bash
+git add docs/lab-notes/2026-04-20-coding-cli-session-contract.md test/helpers/coding-cli/real-session-contract-harness.ts test/integration/real/coding-cli-session-contract.test.ts
+git commit -m "test: lock codex rollout path contract"
+```
+
+## Chunk 2: Surface The Right Signals In The App-Server Layer
+
+### Task 2: Teach The Protocol, Client, Runtime, And Fixture About `thread.path` And Watches
+
+**Files:**
+- Modify: `server/coding-cli/codex-app-server/protocol.ts`
+- Modify: `server/coding-cli/codex-app-server/client.ts`
+- Modify: `server/coding-cli/codex-app-server/runtime.ts`
+- Modify: `test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs`
+- Modify: `test/unit/server/coding-cli/codex-app-server/client.test.ts`
+- Modify: `test/unit/server/coding-cli/codex-app-server/runtime.test.ts`
+
+- [ ] **Step 1: Write the failing unit tests first**
+
+Cover:
+
+- `thread/start` and `thread/resume` preserve `thread.path`, `ephemeral`, and any other fields the sidecar now depends on.
+- `thread/started` handlers receive the full thread object, not just the id.
+- `fs/watch` and `fs/unwatch` use JSON-RPC envelopes correctly.
+- `fs/changed` notifications reach subscribers with the original `watchId`.
+
+- [ ] **Step 2: Extend the protocol schemas**
+
+Model at least these shapes explicitly:
+
+```ts
+const CodexThreadSchema = z.object({
+  id: z.string().min(1),
+  path: z.string().min(1).nullable().optional(),
+  ephemeral: z.boolean().optional(),
+})
+
+const CodexFsChangedNotificationSchema = z.object({
+  method: z.literal('fs/changed'),
+  params: z.object({
+    watchId: z.string().min(1),
+    changedPaths: z.array(z.string()),
+  }),
+})
+```
+
+- [ ] **Step 3: Update the client and runtime API**
+
+Give the sidecar the exact surface it needs:
+
+```ts
+onThreadStarted(handler: (thread: CodexThreadHandle) => void): () => void
+onFsChanged(handler: (event: CodexFsChangedEvent) => void): () => void
+watchPath(path: string, watchId: string): Promise<{ path: string }>
+unwatchPath(watchId: string): Promise<void>
+```
+
+Pin this explicitly in the implementation notes:
+
+- `watchId` is generated by Freshell, not by Codex.
+- `watchPath()` returns only the canonicalized watched path.
+- correlation between `fs/watch` registration and later `fs/changed` events is performed through the original caller-supplied `watchId`.
+- if `fs/watch` fails for a specific path, log the failure, keep the tracker alive, and fall back to backoff-only exact-path existence probes rather than hard-failing or silently dropping promotion
+
+- [ ] **Step 4: Update the fake app-server fixture to match the live contract**
+
+When the fixture emits `thread/started`, include a realistic `thread.path` and `ephemeral: false`.
+When the fixture materializes the durable artifact, emit `fs/changed` for:
+
+- the watched rollout path
+- the watched parent directory
+
+Ordering is not semantically important and duplicate notifications are allowed; Task 3's tracker tests must prove the tracker is resilient to both.
+
+- [ ] **Step 5: Run the unit suite and commit**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/coding-cli/codex-app-server/client.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add server/coding-cli/codex-app-server/protocol.ts server/coding-cli/codex-app-server/client.ts server/coding-cli/codex-app-server/runtime.ts test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs test/unit/server/coding-cli/codex-app-server/client.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+git commit -m "refactor: surface codex rollout path and watch events"
+```
+
+## Chunk 3: Replace The Codex Whole-Tree Poller
+
+### Task 3: Build A Path-Specific Codex Durable Rollout Tracker
+
+**Files:**
+- Create: `server/coding-cli/codex-app-server/durable-rollout-tracker.ts`
+- Create: `test/unit/server/coding-cli/codex-app-server/durable-rollout-tracker.test.ts`
+- Modify: `server/coding-cli/codex-app-server/sidecar.ts`
+- Modify: `test/unit/server/coding-cli/codex-app-server/sidecar.test.ts`
+
+- [ ] **Step 1: Write the failing tracker and sidecar tests**
+
+Cover these cases explicitly:
+
+- promotion succeeds when the exact `thread.path` appears
+- path and parent watches both work even when the watched target did not exist at registration time
+- `thread.path === null` or `thread.ephemeral === true` skips promotion entirely
+- if a second non-ephemeral `thread/started` arrives before promotion, the tracker cancels the older pending witness and follows the newest thread instead
+- a missed or delayed watch event still promotes via the fallback existence check
+- the rollout file appearing during watch registration still promotes because the tracker performs an immediate post-registration existence check
+- promotion still happens after the old 10 second boundary
+- shutdown unregisters outstanding watches and stops future timers
+- no code path enumerates `CODEX_HOME/sessions`
+
+- [ ] **Step 2: Create the dedicated tracker file instead of growing `sidecar.ts` further**
+
+Use a focused tracker state like:
+
+```ts
+type PendingDurableRollout = {
+  threadId: string
+  rolloutPath: string
+  rolloutParentPath: string
+  pathWatchId: string
+  parentWatchId: string
+  backoffIndex: number
+}
+```
+
+Use a low-frequency backoff schedule with no hard cutoff, for example:
+
+```ts
+const BACKOFF_MS = [500, 1_000, 2_000, 5_000, 10_000, 30_000, 60_000]
+```
+
+After the last entry, keep repeating `60_000`.
+
+Also pin the pending-thread semantics:
+
+- ignore `thread/started` payloads whose `path` is missing or whose thread is explicitly ephemeral
+- treat `path === undefined`, `path === null`, and `path === ''` as non-durable and skip promotion for those payloads
+- before promotion, newest durable-capable thread wins, explicitly calls `unwatchPath()` for the older path/parent watch ids, and replaces the older pending witness for the same sidecar
+- after promotion, leave behavior unchanged in this follow-up and record any later multi-thread/session-replacement follow-up work in `docs/lab-notes/2026-04-20-coding-cli-session-contract.md`
+- tracker lifetime is bound to sidecar lifetime, not to whether a terminal is currently attached; detach does not stop pending durability tracking while the sidecar still owns the live Codex session
+
+- [ ] **Step 3: Make the proof O(1)**
+
+The tracker's promotion proof must be:
+
+```ts
+await fsp.access(rolloutPath)
+```
+
+or an equivalent exact-path metadata check. Do not reopen content scanning and do not walk sibling artifacts.
+
+Perform that exact-path check in two places:
+
+- probe the same `thread.path` string Codex reported; use the canonicalized `watchPath()` response only for watch bookkeeping and diagnostics
+- immediately after both watches are registered, to close the "file appeared during registration" race
+- on each relevant `fs/changed` and scheduled backoff probe
+
+- [ ] **Step 4: Wire the sidecar to the tracker**
+
+Replace:
+
+- `DEFAULT_ARTIFACT_POLL_MS`
+- `DEFAULT_ARTIFACT_TIMEOUT_MS`
+- `listRolloutArtifacts()`
+- `rolloutArtifactMatchesThread()`
+- `waitForDurableArtifact()`
+- public `artifactPollMs` / `artifactTimeoutMs` sidecar options
+
+with:
+
+- `thread/started` -> extract `thread.id` + `thread.path`
+- register watches immediately
+- run the exact-path tracker until promotion or shutdown
+- if tests still need a seam, replace the old poll knobs with a tracker-factory or backoff-schedule injection hook instead of preserving the old timeout semantics
+
+- [ ] **Step 5: Run the tracker/sidecar suite and commit**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/coding-cli/codex-app-server/durable-rollout-tracker.test.ts test/unit/server/coding-cli/codex-app-server/sidecar.test.ts
+```
+
+Expected: PASS, including the "older than 10 seconds but still eventually promotes" case.
+
+Commit:
+
+```bash
+git add server/coding-cli/codex-app-server/durable-rollout-tracker.ts server/coding-cli/codex-app-server/sidecar.ts test/unit/server/coding-cli/codex-app-server/durable-rollout-tracker.test.ts test/unit/server/coding-cli/codex-app-server/sidecar.test.ts
+git commit -m "refactor: track codex durability by exact rollout path"
+```
+
+## Chunk 4: Prove End-To-End Behavior And Keep The Other Providers Honest
+
+### Task 4: Update Codex Integration Coverage To Match The New Promotion Mechanism
+
+**Files:**
+- Modify: `test/integration/server/codex-session-flow.test.ts`
+
+- [ ] **Step 1: Write the failing integration assertions**
+
+Keep the existing good behavior and add these expectations:
+
+- fresh create still does **not** persist `effectiveResumeSessionId`
+- durable promotion happens only after the rollout file exists at the provider-reported path
+- unrelated file activity does not promote the session
+- durable restore (`codex --remote <ws> resume <sessionId>`) stays unchanged
+
+- [ ] **Step 2: Update the fake remote + fake app-server flow to drive the new proof**
+
+The integration test should no longer depend on "any matching rollout anywhere under `CODEX_HOME`".
+It should depend on the concrete rollout path carried in the fixture's `thread/started` payload.
+
+- [ ] **Step 3: Run the Codex integration suite**
+
+Run:
+
+```bash
+npm run test:vitest -- test/integration/server/codex-session-flow.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/integration/server/codex-session-flow.test.ts
+git commit -m "test: codex promotion follows rollout path witness"
+```
+
+### Task 5: Re-State The Cross-Provider Invariant So Codex Hardening Does Not Distort The Others
+
+**Files:**
+- Modify: `test/integration/server/durable-session-contract.test.ts`
+- Modify: `test/unit/client/components/TerminalView.resumeSession.test.tsx`
+- Modify: `test/integration/server/opencode-session-flow.test.ts`
+
+- [ ] **Step 1: Write the failing parity assertions**
+
+Make the contract explicit:
+
+- Codex durable promotion is witness-based and eventual, not timer-based.
+- `TerminalView.resumeSession.test.tsx` must pin the client-visible corollary: a pending Codex session stays live-only and is not persisted as durable until `terminal.session.associated`, while the non-Codex client resume flows keep their existing behavior.
+- Claude durable restore is still transcript/UUID-based.
+- OpenCode durable promotion is still authoritative-control-surface-based.
+- FreshClaude still separates live SDK identity from durable history identity.
+
+- [ ] **Step 2: Update the tests and only the production code that those tests truly require**
+
+If Codex internal changes are enough, keep the other provider code untouched.
+Only patch shared helpers or copy if the parity tests expose a real regression.
+
+- [ ] **Step 3: Run the parity suite**
+
+Run:
+
+```bash
+npm run test:vitest -- test/integration/server/durable-session-contract.test.ts test/unit/client/components/TerminalView.resumeSession.test.tsx test/integration/server/opencode-session-flow.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/integration/server/durable-session-contract.test.ts test/unit/client/components/TerminalView.resumeSession.test.tsx test/integration/server/opencode-session-flow.test.ts
+git commit -m "test: preserve provider-specific durable witnesses"
+```
+
+## Final Verification
+
+- [ ] **Step 1: Run the focused Codex suites together**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/coding-cli/codex-app-server/client.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts test/unit/server/coding-cli/codex-app-server/durable-rollout-tracker.test.ts test/unit/server/coding-cli/codex-app-server/sidecar.test.ts test/integration/server/codex-session-flow.test.ts test/integration/server/durable-session-contract.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Re-run the opt-in real-provider contract suite**
+
+Run:
+
+```bash
+npm run test:real:coding-cli-contracts
+```
+
+Expected: PASS, with the Codex section now explicitly proving the rollout-path witness contract.
+
+- [ ] **Step 3: Run the coordinated repo suite before merge**
+
+Run:
+
+```bash
+npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Confirm the branch is already fully committed**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no output. Do not create an extra "final commit" if Tasks 1 through 5 already produced the planned commits.
+
+## Recommended Course Of Action
+
+Implement the Codex change as a narrow follow-up, not a second broad session-contract rewrite:
+
+1. Re-prove and check in the Codex `thread.path` / `fs/watch` contract.
+2. Teach the app-server layer to surface those signals directly.
+3. Replace the full-tree poller with a path-specific tracker that has no hard timeout.
+4. Keep the other providers on their own durable witnesses and lock that into parity tests.
+
+The plan is intentionally opinionated:
+
+- Prefer exact-path watch plus exact-path existence checks over any form of corpus scan.
+- Prefer an eventual tracker over a short, aggressive polling deadline.
+- Prefer provider-specific witnesses over a fake "one mechanism for everyone" abstraction.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:unit": "tsx scripts/testing/test-coordinator.ts run test:unit",
     "test:integration": "tsx scripts/testing/test-coordinator.ts run test:integration",
     "test:client": "tsx scripts/testing/test-coordinator.ts run test:client",
+    "test:real:coding-cli-contracts": "cross-env FRESHELL_REAL_PROVIDER_CONTRACTS=1 npm run test:vitest -- test/integration/real/coding-cli-session-contract.test.ts",
     "test:visible-first:contract": "vitest run test/unit/visible-first/acceptance-contract.test.ts test/unit/visible-first/protocol-harness.test.ts test/unit/lib/visible-first-acceptance-report.test.ts",
     "test:all": "tsx scripts/testing/test-coordinator.ts run test:all",
     "test:status": "tsx scripts/testing/test-coordinator.ts status",

--- a/server/agent-api/router.ts
+++ b/server/agent-api/router.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { nanoid } from 'nanoid'
 import { allocateLocalhostPort } from '../local-port.js'
-import type { CodexLaunchPlanner } from '../coding-cli/codex-app-server/launch-planner.js'
+import type { CodexLaunchPlan, CodexLaunchPlanner } from '../coding-cli/codex-app-server/launch-planner.js'
 import {
   CodexLaunchConfigError,
   getCodexSessionBindingReason,
@@ -12,6 +12,7 @@ import {
 import { makeSessionKey } from '../coding-cli/types.js'
 import type { ProviderSettings } from '../terminal-registry.js'
 import { MAX_TERMINAL_TITLE_OVERRIDE_LENGTH } from '../terminals-router.js'
+import { sanitizeSessionRef, type SessionRef } from '../../shared/session-contract.js'
 import { ok, approx, fail } from './response.js'
 import { renderCapture } from './capture.js'
 import { waitForMatch } from './wait-for.js'
@@ -50,24 +51,35 @@ async function resolveSpawnProviderSettings(
   overrides: { permissionMode?: string; model?: string; sandbox?: string },
   opts: {
     cwd?: string
-    resumeSessionId?: string
+    sessionRef?: SessionRef
     codexLaunchPlanner?: CodexLaunchPlanner
   } = {},
-): Promise<{ resumeSessionId?: string; providerSettings?: ProviderSettings }> {
+): Promise<{
+  sessionRef?: SessionRef
+  providerSettings?: ProviderSettings
+  codexSidecar?: CodexLaunchPlan['sidecar']
+}> {
   const providerSettings = await resolveProviderSettings(mode, configStore, overrides)
+  const sessionRef = opts.sessionRef?.provider === mode ? opts.sessionRef : undefined
   if (mode === 'codex') {
     if (!opts.codexLaunchPlanner) {
       throw new Error('Codex terminal launch requires the shared app-server planner.')
     }
     const plan = await opts.codexLaunchPlanner.planCreate({
       cwd: opts.cwd,
-      resumeSessionId: opts.resumeSessionId,
+      resumeSessionId: sessionRef?.sessionId,
       model: providerSettings?.model,
       sandbox: normalizeCodexSandboxSetting(providerSettings?.sandbox),
       approvalPolicy: providerSettings?.permissionMode,
     })
     return {
-      resumeSessionId: plan.sessionId,
+      ...(plan.sessionId ? {
+        sessionRef: {
+          provider: mode,
+          sessionId: plan.sessionId,
+        },
+      } : {}),
+      codexSidecar: plan.sidecar,
       providerSettings: {
         codexAppServer: plan.remote,
       },
@@ -75,17 +87,23 @@ async function resolveSpawnProviderSettings(
   }
   if (mode !== 'opencode') {
     return {
-      resumeSessionId: opts.resumeSessionId,
+      ...(sessionRef ? { sessionRef } : {}),
       providerSettings,
     }
   }
   return {
-    resumeSessionId: opts.resumeSessionId,
+    ...(sessionRef ? { sessionRef } : {}),
     providerSettings: {
       ...(providerSettings ?? {}),
       opencodeServer: await allocateLocalhostPort(),
     },
   }
+}
+
+function resolveRequestedSessionRef(mode: string, value: unknown): SessionRef | undefined {
+  const sessionRef = sanitizeSessionRef(value)
+  if (!sessionRef) return undefined
+  return sessionRef.provider === mode ? sessionRef : undefined
 }
 
 type ResizeLayoutStore = {
@@ -225,9 +243,9 @@ export function createAgentApiRouter({
     const meta = terminalId
       ? terminalMetadata?.list?.().find((entry) => entry.terminalId === terminalId)
       : undefined
-    const resumeSessionId = typeof paneContent?.resumeSessionId === 'string'
-      ? paneContent.resumeSessionId
-      : undefined
+    const paneSessionRef = sanitizeSessionRef(paneContent?.sessionRef)
+    const resumeSessionId = paneSessionRef?.sessionId
+      ?? (typeof paneContent?.resumeSessionId === 'string' ? paneContent.resumeSessionId : undefined)
     const modeCandidates = [
       typeof paneContent?.mode === 'string' ? paneContent.mode : undefined,
       terminalId ? registry.get?.(terminalId)?.mode : undefined,
@@ -266,7 +284,7 @@ export function createAgentApiRouter({
   }
 
   router.post('/tabs', async (req, res) => {
-    const { name, mode, shell, cwd, browser, editor, resumeSessionId, permissionMode, model, sandbox } = req.body || {}
+    const { name, mode, shell, cwd, browser, editor, sessionRef, permissionMode, model, sandbox } = req.body || {}
     const wantsBrowser = !!browser
     const wantsEditor = !!editor
 
@@ -280,20 +298,22 @@ export function createAgentApiRouter({
         paneContent = { kind: 'editor', filePath: editor, language: null, readOnly: false, content: '', viewMode: 'source' }
       } else {
         const effectiveMode = mode || 'shell'
+        const requestedSessionRef = resolveRequestedSessionRef(effectiveMode, sessionRef)
         const launch = await resolveSpawnProviderSettings(
           effectiveMode,
           configStore,
           { permissionMode, model, sandbox },
-          { cwd, resumeSessionId, codexLaunchPlanner },
+          { cwd, sessionRef: requestedSessionRef, codexLaunchPlanner },
         )
         const { tabId, paneId } = layoutStore.createTab({ title: name, browser, editor })
-        const sessionBindingReason = getCodexSessionBindingReason(effectiveMode, resumeSessionId)
+        const sessionBindingReason = getCodexSessionBindingReason(effectiveMode, requestedSessionRef?.sessionId)
         const terminal = registry.create({
           mode: effectiveMode,
           shell,
           cwd,
-          resumeSessionId: launch.resumeSessionId,
+          resumeSessionId: launch.sessionRef?.sessionId,
           ...(sessionBindingReason ? { sessionBindingReason } : {}),
+          ...(launch.codexSidecar ? { codexSidecar: launch.codexSidecar } : {}),
           providerSettings: launch.providerSettings,
           envContext: { tabId, paneId },
         })
@@ -304,7 +324,7 @@ export function createAgentApiRouter({
           status: 'running',
           mode: mode || 'shell',
           shell: shell || 'system',
-          resumeSessionId: launch.resumeSessionId,
+          ...(launch.sessionRef ? { sessionRef: launch.sessionRef } : {}),
           initialCwd: cwd,
         }
 
@@ -319,7 +339,7 @@ export function createAgentApiRouter({
             shell,
             terminalId,
             initialCwd: cwd,
-            resumeSessionId: paneContent?.resumeSessionId,
+            sessionRef: paneContent?.sessionRef,
             paneId,
             paneContent,
           },
@@ -341,7 +361,7 @@ export function createAgentApiRouter({
           shell,
           terminalId,
           initialCwd: cwd,
-          resumeSessionId: paneContent?.resumeSessionId,
+          sessionRef: paneContent?.sessionRef,
           paneId,
           paneContent,
         },
@@ -638,13 +658,14 @@ export function createAgentApiRouter({
       const created = layoutStore.createTab?.({ title })
       const tabId = created?.tabId || nanoid()
       const paneId = created?.paneId || nanoid()
-      const sessionBindingReason = getCodexSessionBindingReason(mode)
+      const sessionBindingReason = getCodexSessionBindingReason(mode, launch.sessionRef?.sessionId)
       const terminal = registry.create({
         mode,
         shell,
         cwd,
-        resumeSessionId: launch.resumeSessionId,
+        resumeSessionId: launch.sessionRef?.sessionId,
         ...(sessionBindingReason ? { sessionBindingReason } : {}),
+        ...(launch.codexSidecar ? { codexSidecar: launch.codexSidecar } : {}),
         providerSettings: launch.providerSettings,
         envContext: { tabId, paneId },
       })
@@ -719,17 +740,18 @@ export function createAgentApiRouter({
           {},
           {
             cwd: req.body?.cwd,
-            resumeSessionId: req.body?.resumeSessionId,
+            sessionRef: resolveRequestedSessionRef(splitMode, req.body?.sessionRef),
             codexLaunchPlanner,
           },
         )
-        const sessionBindingReason = getCodexSessionBindingReason(splitMode, req.body?.resumeSessionId)
+        const sessionBindingReason = getCodexSessionBindingReason(splitMode, launch.sessionRef?.sessionId)
         const terminal = registry.create({
           mode: splitMode,
           shell: req.body?.shell,
           cwd: req.body?.cwd,
-          resumeSessionId: launch.resumeSessionId,
+          resumeSessionId: launch.sessionRef?.sessionId,
           ...(sessionBindingReason ? { sessionBindingReason } : {}),
+          ...(launch.codexSidecar ? { codexSidecar: launch.codexSidecar } : {}),
           providerSettings: launch.providerSettings,
           envContext: { tabId, paneId: newPaneId },
         })
@@ -740,7 +762,7 @@ export function createAgentApiRouter({
           status: 'running',
           mode: req.body?.mode || 'shell',
           shell: req.body?.shell || 'system',
-          ...(launch.resumeSessionId ? { resumeSessionId: launch.resumeSessionId } : {}),
+          ...(launch.sessionRef ? { sessionRef: launch.sessionRef } : {}),
         }
       }
 
@@ -929,17 +951,18 @@ export function createAgentApiRouter({
         {},
         {
           cwd: req.body?.cwd,
-          resumeSessionId: req.body?.resumeSessionId,
+          sessionRef: resolveRequestedSessionRef(effectiveMode, req.body?.sessionRef),
           codexLaunchPlanner,
         },
       )
-      const sessionBindingReason = getCodexSessionBindingReason(effectiveMode, req.body?.resumeSessionId)
+      const sessionBindingReason = getCodexSessionBindingReason(effectiveMode, launch.sessionRef?.sessionId)
       const terminal = registry.create({
         mode: effectiveMode,
         shell: req.body?.shell,
         cwd: req.body?.cwd,
-        resumeSessionId: launch.resumeSessionId,
+        resumeSessionId: launch.sessionRef?.sessionId,
         ...(sessionBindingReason ? { sessionBindingReason } : {}),
+        ...(launch.codexSidecar ? { codexSidecar: launch.codexSidecar } : {}),
         providerSettings: launch.providerSettings,
         envContext: { tabId, paneId },
       })
@@ -950,7 +973,7 @@ export function createAgentApiRouter({
         mode: req.body?.mode || 'shell',
         shell: req.body?.shell || 'system',
         createRequestId: nanoid(),
-        ...(launch.resumeSessionId ? { resumeSessionId: launch.resumeSessionId } : {}),
+        ...(launch.sessionRef ? { sessionRef: launch.sessionRef } : {}),
       }
       layoutStore.attachPaneContent(tabId, paneId, content)
       wsHandler?.broadcastUiCommand({ command: 'pane.attach', payload: { tabId, paneId, content } })

--- a/server/agent-timeline/ledger.ts
+++ b/server/agent-timeline/ledger.ts
@@ -150,9 +150,7 @@ export function synthesizeLiveMessageId(sessionId: string, ordinal: number): str
 
 function resolveTimelineSessionId(queryId: string, liveSession?: SdkSessionState): string | undefined {
   if (isValidClaudeSessionId(liveSession?.cliSessionId)) return liveSession.cliSessionId
-  if (isValidClaudeSessionId(liveSession?.resumeSessionId)) {
-    return liveSession.resumeSessionId
-  }
+  if (isValidClaudeSessionId(liveSession?.resumeSessionId)) return liveSession.resumeSessionId
   if (isValidClaudeSessionId(queryId)) return queryId
   return undefined
 }
@@ -538,7 +536,6 @@ export function createRestoreLedgerManager(deps: RestoreLedgerManagerDeps) {
     const timelineSessionId = resolveTimelineSessionId(liveSession.sessionId, liveSession)
     const existing = findLedgerRecord([
       liveSession.sessionId,
-      liveSession.resumeSessionId,
       timelineSessionId,
     ])
     const ledger = existing ?? createLedgerRecord(liveSession.sessionId)
@@ -562,7 +559,7 @@ export function createRestoreLedgerManager(deps: RestoreLedgerManagerDeps) {
     })
 
     bindAliases(ledger, {
-      liveAliases: [liveSession.sessionId, liveSession.resumeSessionId],
+      liveAliases: [liveSession.sessionId],
       durableAliases: [isCanonicalDurableSessionId(timelineSessionId) ? timelineSessionId : undefined],
     })
 
@@ -575,7 +572,7 @@ export function createRestoreLedgerManager(deps: RestoreLedgerManagerDeps) {
         captureCompatibilityCandidates: ledger.durableMessages.length === 0,
       })
       bindAliases(ledger, {
-        liveAliases: [liveSession.sessionId, liveSession.resumeSessionId],
+        liveAliases: [liveSession.sessionId],
         durableAliases: [timelineSessionId],
       })
     }
@@ -586,7 +583,6 @@ export function createRestoreLedgerManager(deps: RestoreLedgerManagerDeps) {
   return {
     async syncLiveSession(liveSession: SdkSessionState): Promise<void> {
       tombstonedLiveAliases.delete(liveSession.sessionId)
-      if (liveSession.resumeSessionId) tombstonedLiveAliases.delete(liveSession.resumeSessionId)
       await syncLiveSession(liveSession, { refreshDurableHistory: false })
     },
 

--- a/server/coding-cli/codex-app-server/client.ts
+++ b/server/coding-cli/codex-app-server/client.ts
@@ -1,13 +1,20 @@
 import WebSocket from 'ws'
 import {
+  CodexFsChangedNotificationSchema,
+  CodexFsUnwatchParamsSchema,
+  CodexFsWatchParamsSchema,
+  CodexFsWatchResultSchema,
   CodexInitializeParamsSchema,
   CodexInitializeResultSchema,
   CodexRpcErrorEnvelopeSchema,
   CodexRpcNotificationEnvelopeSchema,
   CodexRpcSuccessEnvelopeSchema,
+  CodexThreadStartedNotificationSchema,
   CodexThreadOperationResultSchema,
   type CodexInitializeResult,
   type CodexRpcError,
+  type CodexThreadHandle,
+  type CodexThreadOperationResult,
   type CodexThreadResumeParams,
   type CodexThreadStartParams,
 } from './protocol.js'
@@ -29,6 +36,14 @@ type PendingRequest = {
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 5_000
 
+function normalizeThread(thread: CodexThreadHandle): CodexThreadHandle {
+  return {
+    ...thread,
+    path: thread.path ?? null,
+    ephemeral: thread.ephemeral ?? false,
+  }
+}
+
 export class CodexAppServerClient {
   private readonly requestTimeoutMs: number
   private socket: WebSocket | null = null
@@ -36,6 +51,8 @@ export class CodexAppServerClient {
   private initializePromise: Promise<CodexInitializeResult> | null = null
   private nextRequestId = 1
   private pendingRequests = new Map<number, PendingRequest>()
+  private readonly threadStartedHandlers = new Set<(thread: CodexThreadHandle) => void>()
+  private readonly fsChangedHandlers = new Set<(event: { watchId: string; changedPaths: string[] }) => void>()
 
   constructor(
     private readonly endpoint: CodexAppServerEndpoint,
@@ -51,7 +68,6 @@ export class CodexAppServerClient {
       clientInfo: { name: 'freshell', version: '1.0.0' },
       capabilities: {
         experimentalApi: true,
-        optOutNotificationMethods: ['thread/started'],
       },
     })).then((result) => {
       const parsed = CodexInitializeResultSchema.safeParse(result)
@@ -67,7 +83,9 @@ export class CodexAppServerClient {
     return this.initializePromise
   }
 
-  async startThread(params: Omit<CodexThreadStartParams, 'experimentalRawEvents' | 'persistExtendedHistory'>): Promise<{ threadId: string }> {
+  async startThread(
+    params: Omit<CodexThreadStartParams, 'experimentalRawEvents' | 'persistExtendedHistory'>,
+  ): Promise<CodexThreadOperationResult> {
     const result = await this.request('thread/start', {
       ...params,
       // Freshell attaches the visible TUI over `codex --remote`, so it does not
@@ -79,10 +97,14 @@ export class CodexAppServerClient {
     if (!parsed.success) {
       throw new Error('Codex app-server returned an invalid thread/start payload.')
     }
-    return { threadId: parsed.data.thread.id }
+    return {
+      thread: normalizeThread(parsed.data.thread),
+    }
   }
 
-  async resumeThread(params: Omit<CodexThreadResumeParams, 'persistExtendedHistory'>): Promise<{ threadId: string }> {
+  async resumeThread(
+    params: Omit<CodexThreadResumeParams, 'persistExtendedHistory'>,
+  ): Promise<CodexThreadOperationResult> {
     // Intentionally preserve Codex's default raw-event behavior for resume calls.
     const result = await this.request('thread/resume', {
       ...params,
@@ -92,7 +114,27 @@ export class CodexAppServerClient {
     if (!parsed.success) {
       throw new Error('Codex app-server returned an invalid thread/resume payload.')
     }
-    return { threadId: parsed.data.thread.id }
+    return {
+      thread: normalizeThread(parsed.data.thread),
+    }
+  }
+
+  async watchPath(targetPath: string, watchId: string): Promise<{ path: string }> {
+    const result = await this.request('fs/watch', CodexFsWatchParamsSchema.parse({
+      path: targetPath,
+      watchId,
+    }))
+    const parsed = CodexFsWatchResultSchema.safeParse(result)
+    if (!parsed.success) {
+      throw new Error('Codex app-server returned an invalid fs/watch payload.')
+    }
+    return parsed.data
+  }
+
+  async unwatchPath(watchId: string): Promise<void> {
+    await this.request('fs/unwatch', CodexFsUnwatchParamsSchema.parse({
+      watchId,
+    }))
   }
 
   async close(): Promise<void> {
@@ -124,6 +166,20 @@ export class CodexAppServerClient {
       socket.once('error', onClose)
       socket.close()
     })
+  }
+
+  onThreadStarted(handler: (thread: CodexThreadHandle) => void): () => void {
+    this.threadStartedHandlers.add(handler)
+    return () => {
+      this.threadStartedHandlers.delete(handler)
+    }
+  }
+
+  onFsChanged(handler: (event: { watchId: string; changedPaths: string[] }) => void): () => void {
+    this.fsChangedHandlers.add(handler)
+    return () => {
+      this.fsChangedHandlers.delete(handler)
+    }
   }
 
   private async ensureSocket(): Promise<WebSocket> {
@@ -180,6 +236,20 @@ export class CodexAppServerClient {
     if (!this.hasIdField(parsed)) {
       const notification = CodexRpcNotificationEnvelopeSchema.safeParse(parsed)
       if (notification.success) {
+        const threadStarted = CodexThreadStartedNotificationSchema.safeParse(notification.data)
+        if (threadStarted.success) {
+          for (const handler of this.threadStartedHandlers) {
+            handler(normalizeThread(threadStarted.data.params.thread))
+          }
+          return
+        }
+
+        const fsChanged = CodexFsChangedNotificationSchema.safeParse(notification.data)
+        if (fsChanged.success) {
+          for (const handler of this.fsChangedHandlers) {
+            handler(fsChanged.data.params)
+          }
+        }
         return
       }
     }

--- a/server/coding-cli/codex-app-server/durable-rollout-tracker.ts
+++ b/server/coding-cli/codex-app-server/durable-rollout-tracker.ts
@@ -1,0 +1,250 @@
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import { logger } from '../../logger.js'
+import type { CodexThreadHandle } from './protocol.js'
+
+const DEFAULT_INITIAL_PROBE_DELAY_MS = 250
+const DEFAULT_MAX_PROBE_DELAY_MS = 5_000
+
+export type CodexFsChangedEvent = {
+  watchId: string
+  changedPaths: string[]
+}
+
+export type CodexDurableRolloutTrackerOptions = {
+  watchPath: (targetPath: string, watchId: string) => Promise<{ path: string }>
+  unwatchPath: (watchId: string) => Promise<void>
+  subscribeToFsChanged: (handler: (event: CodexFsChangedEvent) => void) => () => void
+  onDurableRollout: (sessionId: string) => void
+  pathExists?: (targetPath: string) => Promise<boolean>
+  initialProbeDelayMs?: number
+  maxProbeDelayMs?: number
+  setTimeoutFn?: typeof setTimeout
+  clearTimeoutFn?: typeof clearTimeout
+  createWatchId?: (kind: 'rollout' | 'parent', threadId: string) => string
+  log?: Pick<typeof logger, 'warn'>
+}
+
+type PendingRollout = {
+  thread: CodexThreadHandle
+  rolloutPath: string
+  parentPath: string
+  rolloutWatchId: string
+  parentWatchId: string
+  registeredWatchIds: Set<string>
+  nextProbeDelayMs: number
+  timer: ReturnType<typeof setTimeout> | null
+  probeInFlight: boolean
+  immediateProbeQueued: boolean
+}
+
+async function defaultPathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fsp.access(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export class CodexDurableRolloutTracker {
+  private readonly pathExists: (targetPath: string) => Promise<boolean>
+  private readonly initialProbeDelayMs: number
+  private readonly maxProbeDelayMs: number
+  private readonly setTimeoutFn: typeof setTimeout
+  private readonly clearTimeoutFn: typeof clearTimeout
+  private readonly createWatchId: (kind: 'rollout' | 'parent', threadId: string) => string
+  private readonly log: Pick<typeof logger, 'warn'>
+  private readonly cleanupFsChangedSubscription: () => void
+
+  private disposed = false
+  private promotedThreadId: string | null = null
+  private pending: PendingRollout | null = null
+
+  constructor(private readonly options: CodexDurableRolloutTrackerOptions) {
+    this.pathExists = options.pathExists ?? defaultPathExists
+    this.initialProbeDelayMs = options.initialProbeDelayMs ?? DEFAULT_INITIAL_PROBE_DELAY_MS
+    this.maxProbeDelayMs = options.maxProbeDelayMs ?? DEFAULT_MAX_PROBE_DELAY_MS
+    this.setTimeoutFn = options.setTimeoutFn ?? setTimeout
+    this.clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout
+    this.createWatchId = options.createWatchId ?? ((kind, threadId) => `freshell-codex-${kind}:${threadId}`)
+    this.log = options.log ?? logger
+    this.cleanupFsChangedSubscription = options.subscribeToFsChanged((event) => {
+      this.handleFsChanged(event)
+    })
+  }
+
+  trackThread(thread: CodexThreadHandle): void {
+    if (this.disposed || this.promotedThreadId || !thread.id) {
+      return
+    }
+    if (thread.ephemeral) {
+      return
+    }
+    if (!thread.path) {
+      this.log.warn({ threadId: thread.id }, 'Codex thread/started did not include a durable rollout path; promotion will stay pending')
+      return
+    }
+
+    if (this.pending?.thread.id === thread.id && this.pending.rolloutPath === thread.path) {
+      return
+    }
+
+    void this.replacePendingRollout({
+      thread: {
+        id: thread.id,
+        path: thread.path,
+        ephemeral: thread.ephemeral ?? false,
+      },
+      rolloutPath: thread.path,
+      parentPath: path.dirname(thread.path),
+      rolloutWatchId: this.createWatchId('rollout', thread.id),
+      parentWatchId: this.createWatchId('parent', thread.id),
+      registeredWatchIds: new Set<string>(),
+      nextProbeDelayMs: this.initialProbeDelayMs,
+      timer: null,
+      probeInFlight: false,
+      immediateProbeQueued: false,
+    })
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true
+    this.cleanupFsChangedSubscription()
+    await this.clearPending(this.pending)
+    this.pending = null
+  }
+
+  private async replacePendingRollout(nextPending: PendingRollout): Promise<void> {
+    const previousPending = this.pending
+    this.pending = nextPending
+    await this.clearPending(previousPending)
+    if (this.disposed || this.promotedThreadId) {
+      return
+    }
+    if (this.pending !== nextPending) {
+      return
+    }
+    void this.registerWatch(nextPending, nextPending.rolloutPath, nextPending.rolloutWatchId)
+    void this.registerWatch(nextPending, nextPending.parentPath, nextPending.parentWatchId)
+    this.requestImmediateProbe(nextPending)
+  }
+
+  private handleFsChanged(event: CodexFsChangedEvent): void {
+    const pending = this.pending
+    if (!pending || this.disposed || this.promotedThreadId) {
+      return
+    }
+    const mentionsRolloutPath = event.changedPaths.includes(pending.rolloutPath)
+    const matchesWatchId = (
+      event.watchId === pending.rolloutWatchId
+      || event.watchId === pending.parentWatchId
+    )
+    if (!mentionsRolloutPath && !matchesWatchId) {
+      return
+    }
+    this.requestImmediateProbe(pending)
+  }
+
+  private requestImmediateProbe(pending: PendingRollout): void {
+    if (this.pending !== pending || this.disposed || this.promotedThreadId) {
+      return
+    }
+    if (pending.timer) {
+      this.clearTimeoutFn(pending.timer)
+      pending.timer = null
+    }
+    if (pending.probeInFlight) {
+      pending.immediateProbeQueued = true
+      return
+    }
+    void this.runProbe(pending)
+  }
+
+  private scheduleNextProbe(pending: PendingRollout): void {
+    if (this.pending !== pending || this.disposed || this.promotedThreadId || pending.timer) {
+      return
+    }
+    const delayMs = pending.nextProbeDelayMs
+    pending.nextProbeDelayMs = Math.min(this.maxProbeDelayMs, pending.nextProbeDelayMs * 2)
+    pending.timer = this.setTimeoutFn(() => {
+      pending.timer = null
+      void this.runProbe(pending)
+    }, delayMs)
+  }
+
+  private async runProbe(pending: PendingRollout): Promise<void> {
+    if (this.pending !== pending || this.disposed || this.promotedThreadId) {
+      return
+    }
+    pending.probeInFlight = true
+
+    try {
+      if (await this.pathExists(pending.rolloutPath)) {
+        this.promotedThreadId = pending.thread.id
+        await this.clearPending(pending)
+        if (!this.disposed) {
+          this.options.onDurableRollout(pending.thread.id)
+        }
+        return
+      }
+    } finally {
+      pending.probeInFlight = false
+    }
+
+    if (this.pending !== pending || this.disposed || this.promotedThreadId) {
+      return
+    }
+
+    if (pending.immediateProbeQueued) {
+      pending.immediateProbeQueued = false
+      void this.runProbe(pending)
+      return
+    }
+
+    this.scheduleNextProbe(pending)
+  }
+
+  private async registerWatch(pending: PendingRollout, targetPath: string, watchId: string): Promise<void> {
+    try {
+      await this.options.watchPath(targetPath, watchId)
+      if (this.pending === pending && !this.disposed) {
+        pending.registeredWatchIds.add(watchId)
+      } else {
+        await this.options.unwatchPath(watchId).catch(() => undefined)
+      }
+    } catch (error) {
+      this.log.warn(
+        {
+          err: error,
+          watchId,
+          targetPath,
+          threadId: pending.thread.id,
+        },
+        'Failed to register Codex rollout watch; falling back to exact-path probes.',
+      )
+    }
+  }
+
+  private async clearPending(pending: PendingRollout | null): Promise<void> {
+    if (!pending) {
+      return
+    }
+    if (pending.timer) {
+      this.clearTimeoutFn(pending.timer)
+      pending.timer = null
+    }
+    if (this.pending === pending) {
+      this.pending = null
+    }
+    const watchIds = [...pending.registeredWatchIds]
+    pending.registeredWatchIds.clear()
+    await Promise.all(watchIds.map(async (watchId) => {
+      try {
+        await this.options.unwatchPath(watchId)
+      } catch (error) {
+        this.log.warn({ err: error, watchId }, 'Failed to unregister Codex rollout watch during cleanup.')
+      }
+    }))
+  }
+}

--- a/server/coding-cli/codex-app-server/launch-planner.ts
+++ b/server/coding-cli/codex-app-server/launch-planner.ts
@@ -1,10 +1,11 @@
-import type { CodexAppServerRuntime } from './runtime.js'
+import { CodexTerminalSidecar } from './sidecar.js'
 
 export type CodexLaunchPlan = {
-  sessionId: string
+  sessionId?: string
   remote: {
     wsUrl: string
   }
+  sidecar: Pick<CodexTerminalSidecar, 'attachTerminal' | 'shutdown'>
 }
 
 type PlanCreateInput = {
@@ -17,32 +18,29 @@ type PlanCreateInput = {
 
 export class CodexLaunchPlanner {
   constructor(
-    private readonly runtime: Pick<CodexAppServerRuntime, 'ensureReady' | 'startThread'>,
+    private readonly createSidecar: () => Pick<CodexTerminalSidecar, 'ensureReady' | 'attachTerminal' | 'shutdown'>
+      = () => new CodexTerminalSidecar(),
   ) {}
 
   async planCreate(input: PlanCreateInput): Promise<CodexLaunchPlan> {
+    const sidecar = this.createSidecar()
+    const ready = await sidecar.ensureReady()
+
     if (input.resumeSessionId) {
-      const ready = await this.runtime.ensureReady()
       return {
         sessionId: input.resumeSessionId,
         remote: {
           wsUrl: ready.wsUrl,
         },
+        sidecar,
       }
     }
 
-    const planResult = await this.runtime.startThread({
-        cwd: input.cwd,
-        model: input.model,
-        sandbox: input.sandbox,
-        approvalPolicy: input.approvalPolicy,
-      })
-
     return {
-      sessionId: planResult.threadId,
       remote: {
-        wsUrl: planResult.wsUrl,
+        wsUrl: ready.wsUrl,
       },
+      sidecar,
     }
   }
 }

--- a/server/coding-cli/codex-app-server/protocol.ts
+++ b/server/coding-cli/codex-app-server/protocol.ts
@@ -22,7 +22,9 @@ export const CodexInitializeResultSchema = z.object({
 
 export const CodexThreadSchema = z.object({
   id: z.string().min(1),
-})
+  path: z.string().min(1).nullable().optional(),
+  ephemeral: z.boolean().optional(),
+}).passthrough()
 
 export const CodexThreadStartParamsSchema = z.object({
   cwd: z.string().optional(),
@@ -46,6 +48,19 @@ export const CodexThreadOperationResultSchema = z.object({
   thread: CodexThreadSchema,
 })
 
+export const CodexFsWatchParamsSchema = z.object({
+  path: z.string().min(1),
+  watchId: z.string().min(1),
+})
+
+export const CodexFsWatchResultSchema = z.object({
+  path: z.string().min(1),
+})
+
+export const CodexFsUnwatchParamsSchema = z.object({
+  watchId: z.string().min(1),
+})
+
 export const CodexRpcErrorSchema = z.object({
   code: z.number(),
   message: z.string().min(1),
@@ -66,10 +81,31 @@ export const CodexRpcNotificationEnvelopeSchema = z.object({
   params: z.unknown().optional(),
 }).passthrough()
 
+export const CodexThreadStartedNotificationSchema = z.object({
+  method: z.literal('thread/started'),
+  params: z.object({
+    thread: CodexThreadSchema,
+  }).passthrough(),
+}).passthrough()
+
+export const CodexFsChangedNotificationSchema = z.object({
+  method: z.literal('fs/changed'),
+  params: z.object({
+    watchId: z.string().min(1),
+    changedPaths: z.array(z.string()),
+  }),
+}).passthrough()
+
 export type CodexInitializeCapabilities = z.infer<typeof CodexInitializeCapabilitiesSchema>
 export type CodexInitializeParams = z.infer<typeof CodexInitializeParamsSchema>
 export type CodexInitializeResult = z.infer<typeof CodexInitializeResultSchema>
+export type CodexThreadHandle = z.infer<typeof CodexThreadSchema>
 export type CodexThreadStartParams = z.infer<typeof CodexThreadStartParamsSchema>
 export type CodexThreadResumeParams = z.infer<typeof CodexThreadResumeParamsSchema>
 export type CodexThreadOperationResult = z.infer<typeof CodexThreadOperationResultSchema>
+export type CodexFsWatchParams = z.infer<typeof CodexFsWatchParamsSchema>
+export type CodexFsWatchResult = z.infer<typeof CodexFsWatchResultSchema>
+export type CodexFsUnwatchParams = z.infer<typeof CodexFsUnwatchParamsSchema>
 export type CodexRpcError = z.infer<typeof CodexRpcErrorSchema>
+export type CodexThreadStartedNotification = z.infer<typeof CodexThreadStartedNotificationSchema>
+export type CodexFsChangedNotification = z.infer<typeof CodexFsChangedNotificationSchema>

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -1,13 +1,20 @@
 import { spawn } from 'node:child_process'
 import { allocateLocalhostPort, type LoopbackServerEndpoint } from '../../local-port.js'
 import { CodexAppServerClient } from './client.js'
-import type { CodexThreadResumeParams, CodexThreadStartParams } from './protocol.js'
+import type {
+  CodexFsWatchResult,
+  CodexThreadHandle,
+  CodexThreadOperationResult,
+  CodexThreadResumeParams,
+  CodexThreadStartParams,
+} from './protocol.js'
 
 type RuntimeStatus = 'running' | 'stopped'
 
 type ReadyState = {
   wsUrl: string
   processPid: number
+  codexHome: string
 }
 
 type RuntimeOptions = {
@@ -34,6 +41,9 @@ export class CodexAppServerRuntime {
   private ready: ReadyState | null = null
   private ensureReadyPromise: Promise<ReadyState> | null = null
   private statusValue: RuntimeStatus = 'stopped'
+  private readonly exitHandlers = new Set<(error?: Error) => void>()
+  private readonly threadStartedHandlers = new Set<(thread: CodexThreadHandle) => void>()
+  private readonly fsChangedHandlers = new Set<(event: { watchId: string; changedPaths: string[] }) => void>()
 
   private readonly command: string
   private readonly commandArgs: string[]
@@ -57,6 +67,27 @@ export class CodexAppServerRuntime {
     return this.statusValue
   }
 
+  onExit(handler: (error?: Error) => void): () => void {
+    this.exitHandlers.add(handler)
+    return () => {
+      this.exitHandlers.delete(handler)
+    }
+  }
+
+  onThreadStarted(handler: (thread: CodexThreadHandle) => void): () => void {
+    this.threadStartedHandlers.add(handler)
+    return () => {
+      this.threadStartedHandlers.delete(handler)
+    }
+  }
+
+  onFsChanged(handler: (event: { watchId: string; changedPaths: string[] }) => void): () => void {
+    this.fsChangedHandlers.add(handler)
+    return () => {
+      this.fsChangedHandlers.delete(handler)
+    }
+  }
+
   async ensureReady(): Promise<ReadyState> {
     if (this.ready) return this.ready
     if (this.ensureReadyPromise) return this.ensureReadyPromise
@@ -72,7 +103,7 @@ export class CodexAppServerRuntime {
 
   async startThread(
     params: Omit<CodexThreadStartParams, 'experimentalRawEvents' | 'persistExtendedHistory'>,
-  ): Promise<{ threadId: string; wsUrl: string }> {
+  ): Promise<CodexThreadOperationResult & { wsUrl: string }> {
     const ready = await this.ensureReady()
     return {
       ...(await this.client!.startThread(params)),
@@ -82,12 +113,22 @@ export class CodexAppServerRuntime {
 
   async resumeThread(
     params: Omit<CodexThreadResumeParams, 'persistExtendedHistory'>,
-  ): Promise<{ threadId: string; wsUrl: string }> {
+  ): Promise<CodexThreadOperationResult & { wsUrl: string }> {
     const ready = await this.ensureReady()
     return {
       ...(await this.client!.resumeThread(params)),
       wsUrl: ready.wsUrl,
     }
+  }
+
+  async watchPath(targetPath: string, watchId: string): Promise<CodexFsWatchResult> {
+    await this.ensureReady()
+    return this.client!.watchPath(targetPath, watchId)
+  }
+
+  async unwatchPath(watchId: string): Promise<void> {
+    await this.ensureReady()
+    await this.client!.unwatchPath(watchId)
   }
 
   async shutdown(): Promise<void> {
@@ -139,14 +180,25 @@ export class CodexAppServerRuntime {
         { wsUrl },
         this.requestTimeoutMs ? { requestTimeoutMs: this.requestTimeoutMs } : {},
       )
+      client.onThreadStarted((thread) => {
+        for (const handler of this.threadStartedHandlers) {
+          handler(thread)
+        }
+      })
+      client.onFsChanged((event) => {
+        for (const handler of this.fsChangedHandlers) {
+          handler(event)
+        }
+      })
       this.client = client
 
       try {
-        await this.waitForInitialize(client, child)
+        const initialized = await this.waitForInitialize(client, child)
         this.statusValue = 'running'
         return {
           wsUrl,
           processPid: child.pid ?? 0,
+          codexHome: initialized.codexHome,
         }
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error))
@@ -166,7 +218,7 @@ export class CodexAppServerRuntime {
   private async waitForInitialize(
     client: CodexAppServerClient,
     child: ReturnType<typeof spawn>,
-  ): Promise<void> {
+  ): Promise<{ codexHome: string }> {
     const deadline = Date.now() + this.startupAttemptTimeoutMs
     let lastError: Error | undefined
 
@@ -176,8 +228,10 @@ export class CodexAppServerRuntime {
       }
 
       try {
-        await client.initialize()
-        return
+        const initialized = await client.initialize()
+        return {
+          codexHome: initialized.codexHome,
+        }
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error))
         await sleep(STARTUP_POLL_MS)
@@ -201,6 +255,9 @@ export class CodexAppServerRuntime {
       const client = this.client
       this.client = null
       void client?.close().catch(() => undefined)
+      for (const handler of this.exitHandlers) {
+        handler(new Error('Codex app-server runtime exited unexpectedly.'))
+      }
     })
   }
 

--- a/server/coding-cli/codex-app-server/sidecar.ts
+++ b/server/coding-cli/codex-app-server/sidecar.ts
@@ -1,0 +1,286 @@
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { logger } from '../../logger.js'
+import {
+  CodexDurableRolloutTracker,
+  type CodexDurableRolloutTrackerOptions,
+} from './durable-rollout-tracker.js'
+import type { CodexThreadHandle } from './protocol.js'
+import { CodexAppServerRuntime } from './runtime.js'
+const SIDECAR_OWNERSHIP_DIR = path.join(os.tmpdir(), 'freshell-codex-sidecars')
+
+type CodexSidecarReady = {
+  wsUrl: string
+  processPid: number
+  codexHome: string
+}
+
+type SidecarProcessIdentity = {
+  commandLine: string[]
+  cwd: string
+  startTimeTicks: string
+}
+
+type SidecarOwnershipMetadata = {
+  pid: number
+  wsUrl: string
+  codexHome: string
+  terminalId: string | null
+  createdAt: string
+  process?: SidecarProcessIdentity
+}
+
+type CodexTerminalAttachment = {
+  terminalId: string
+  onDurableSession: (sessionId: string) => void
+  onFatal: (error: Error) => void
+}
+
+type CodexTerminalSidecarOptions = {
+  runtime?: CodexAppServerRuntime
+  createDurableRolloutTracker?: (
+    options: CodexDurableRolloutTrackerOptions,
+  ) => Pick<CodexDurableRolloutTracker, 'trackThread' | 'dispose'>
+}
+
+async function readLinuxProcessIdentity(pid: number): Promise<SidecarProcessIdentity | undefined> {
+  if (process.platform !== 'linux') {
+    return undefined
+  }
+
+  try {
+    const [cmdlineRaw, cwd, statRaw] = await Promise.all([
+      fsp.readFile(`/proc/${pid}/cmdline`, 'utf8'),
+      fsp.readlink(`/proc/${pid}/cwd`),
+      fsp.readFile(`/proc/${pid}/stat`, 'utf8'),
+    ])
+
+    const commandLine = cmdlineRaw.split('\0').filter(Boolean)
+    const statClosingParen = statRaw.lastIndexOf(')')
+    const trailingFields = statClosingParen >= 0
+      ? statRaw.slice(statClosingParen + 2).trim().split(/\s+/)
+      : statRaw.trim().split(/\s+/)
+    const startTimeTicks = trailingFields[19]
+
+    if (commandLine.length === 0 || !cwd || !startTimeTicks) {
+      return undefined
+    }
+
+    return {
+      commandLine,
+      cwd,
+      startTimeTicks,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+function processIdentityMatches(
+  metadata: SidecarOwnershipMetadata,
+  current: SidecarProcessIdentity | undefined,
+): boolean {
+  const recorded = metadata.process
+  if (!recorded || !current) {
+    return false
+  }
+
+  return (
+    recorded.cwd === current.cwd
+    && recorded.startTimeTicks === current.startTimeTicks
+    && recorded.commandLine.length > 0
+    && recorded.commandLine.length === current.commandLine.length
+    && recorded.commandLine.every((value, index) => value === current.commandLine[index])
+    && current.commandLine.includes('app-server')
+    && current.commandLine.includes('--listen')
+    && current.commandLine.includes(metadata.wsUrl)
+  )
+}
+
+export class CodexTerminalSidecar {
+  private readonly runtime: CodexAppServerRuntime
+  private readonly durableRolloutTracker: Pick<CodexDurableRolloutTracker, 'trackThread' | 'dispose'>
+  private readonly metadataId = randomUUID()
+  private readonly metadataPath = path.join(SIDECAR_OWNERSHIP_DIR, `${this.metadataId}.json`)
+  private readonly cleanupRuntimeExit: () => void
+  private readonly cleanupThreadStarted: () => void
+
+  private ready: CodexSidecarReady | null = null
+  private readyPromise: Promise<CodexSidecarReady> | null = null
+  private attachedTerminal: CodexTerminalAttachment | null = null
+  private shuttingDown = false
+  private pendingFatalError: Error | null = null
+  private durableSessionId: string | null = null
+
+  constructor(options: CodexTerminalSidecarOptions = {}) {
+    this.runtime = options.runtime ?? new CodexAppServerRuntime()
+    const createDurableRolloutTracker = options.createDurableRolloutTracker
+      ?? ((trackerOptions: CodexDurableRolloutTrackerOptions) => new CodexDurableRolloutTracker(trackerOptions))
+    this.durableRolloutTracker = createDurableRolloutTracker({
+      watchPath: (targetPath, watchId) => this.runtime.watchPath(targetPath, watchId),
+      unwatchPath: async (watchId) => {
+        if (this.runtime.status() !== 'running') {
+          return
+        }
+        await this.runtime.unwatchPath(watchId)
+      },
+      subscribeToFsChanged: (handler) => this.runtime.onFsChanged(handler),
+      onDurableRollout: (sessionId) => {
+        this.promoteDurableSession(sessionId)
+      },
+    })
+    this.cleanupRuntimeExit = this.runtime.onExit((error) => {
+      if (this.shuttingDown) {
+        return
+      }
+      this.handleFatal(error ?? new Error('Codex app-server sidecar exited unexpectedly.'))
+    })
+    this.cleanupThreadStarted = this.runtime.onThreadStarted((thread) => {
+      this.noteThreadStarted(thread)
+    })
+  }
+
+  async ensureReady(): Promise<CodexSidecarReady> {
+    if (this.ready) {
+      return this.ready
+    }
+    if (this.readyPromise) {
+      return this.readyPromise
+    }
+
+    this.readyPromise = this.runtime.ensureReady()
+      .then(async (ready) => {
+        this.ready = ready
+        await this.writeOwnershipMetadata()
+        return ready
+      })
+      .finally(() => {
+        this.readyPromise = null
+      })
+
+    return this.readyPromise
+  }
+
+  attachTerminal(input: CodexTerminalAttachment): void {
+    this.attachedTerminal = input
+    void this.writeOwnershipMetadata()
+    if (this.pendingFatalError) {
+      input.onFatal(this.pendingFatalError)
+      return
+    }
+    if (this.durableSessionId) {
+      input.onDurableSession(this.durableSessionId)
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true
+    this.cleanupRuntimeExit()
+    this.cleanupThreadStarted()
+    await this.durableRolloutTracker.dispose()
+    await this.runtime.shutdown()
+    this.ready = null
+    this.readyPromise = null
+    this.attachedTerminal = null
+    await fsp.rm(this.metadataPath, { force: true }).catch(() => undefined)
+  }
+
+  private noteThreadStarted(thread: CodexThreadHandle): void {
+    if (!thread.id || this.shuttingDown || this.durableSessionId) {
+      return
+    }
+    this.durableRolloutTracker.trackThread(thread)
+  }
+
+  private promoteDurableSession(threadId: string): void {
+    if (this.durableSessionId || this.shuttingDown) {
+      return
+    }
+    this.durableSessionId = threadId
+    this.attachedTerminal?.onDurableSession(threadId)
+  }
+
+  private handleFatal(error: Error): void {
+    this.pendingFatalError = error
+    this.attachedTerminal?.onFatal(error)
+  }
+
+  private async writeOwnershipMetadata(): Promise<void> {
+    const ready = this.ready
+    if (!ready) {
+      return
+    }
+
+    const processIdentity = await readLinuxProcessIdentity(ready.processPid)
+    await fsp.mkdir(SIDECAR_OWNERSHIP_DIR, { recursive: true })
+    const metadata: SidecarOwnershipMetadata = {
+      pid: ready.processPid,
+      wsUrl: ready.wsUrl,
+      codexHome: ready.codexHome,
+      terminalId: this.attachedTerminal?.terminalId ?? null,
+      createdAt: new Date().toISOString(),
+      ...(processIdentity ? { process: processIdentity } : {}),
+    }
+    await fsp.writeFile(this.metadataPath, JSON.stringify(metadata), 'utf8')
+  }
+
+  static async reapOrphanedSidecars(): Promise<void> {
+    const entries = await fsp.readdir(SIDECAR_OWNERSHIP_DIR, { withFileTypes: true }).catch(() => [])
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.json')) {
+        continue
+      }
+      const metadataPath = path.join(SIDECAR_OWNERSHIP_DIR, entry.name)
+      try {
+        const raw = await fsp.readFile(metadataPath, 'utf8')
+        const parsed = JSON.parse(raw) as SidecarOwnershipMetadata
+        const pid = Number(parsed.pid)
+        if (!Number.isInteger(pid) || pid <= 0) {
+          await fsp.rm(metadataPath, { force: true })
+          continue
+        }
+        try {
+          process.kill(pid, 0)
+        } catch (error) {
+          const code = (error as NodeJS.ErrnoException).code
+          if (code === 'ESRCH') {
+            await fsp.rm(metadataPath, { force: true }).catch(() => undefined)
+            continue
+          }
+          logger.warn({ err: error, pid, metadataPath }, 'Failed to inspect orphaned Codex sidecar PID')
+          continue
+        }
+
+        const currentIdentity = await readLinuxProcessIdentity(pid)
+        if (!processIdentityMatches(parsed, currentIdentity)) {
+          // Orphan reaping is intentionally Linux-only because PID ownership
+          // verification relies on /proc command line, cwd, and start-time data.
+          // If we cannot prove the PID still belongs to this sidecar, we refuse
+          // to signal it and drop the stale metadata instead.
+          logger.warn({
+            pid,
+            metadataPath,
+            wsUrl: parsed.wsUrl,
+          }, 'Skipping orphaned Codex sidecar cleanup because PID ownership could not be verified')
+          await fsp.rm(metadataPath, { force: true }).catch(() => undefined)
+          continue
+        }
+
+        try {
+          process.kill(pid, 'SIGTERM')
+        } catch (error) {
+          const code = (error as NodeJS.ErrnoException).code
+          if (code !== 'ESRCH') {
+            logger.warn({ err: error, pid, metadataPath }, 'Failed to reap orphaned Codex sidecar')
+          }
+        }
+      } catch (error) {
+        logger.warn({ err: error, metadataPath }, 'Failed to read Codex sidecar ownership metadata')
+      }
+
+      await fsp.rm(metadataPath, { force: true }).catch(() => undefined)
+    }
+  }
+}

--- a/server/coding-cli/opencode-activity-wiring.ts
+++ b/server/coding-cli/opencode-activity-wiring.ts
@@ -1,10 +1,24 @@
 import { OpencodeActivityTracker } from './opencode-activity-tracker.js'
+import { OpencodeSessionController } from './opencode-session-controller.js'
 import type { OpencodeServerEndpoint } from '../local-port.js'
-import type { TerminalRecord } from '../terminal-registry.js'
+import type { BindSessionResult, TerminalRecord } from '../terminal-registry.js'
+import type { SessionBindingReason } from '../terminal-stream/registry-events.js'
 
 type OpencodeActivityRegistry = {
   list: () => Array<{ terminalId: string }>
-  get: (terminalId: string) => TerminalRecord | undefined
+  get: (terminalId: string) => TerminalRecord | undefined | null
+  bindSession: (
+    terminalId: string,
+    provider: 'opencode',
+    sessionId: string,
+    reason?: SessionBindingReason,
+  ) => BindSessionResult
+  rebindSession: (
+    terminalId: string,
+    provider: 'opencode',
+    sessionId: string,
+    reason?: SessionBindingReason,
+  ) => BindSessionResult
   on: (event: string, handler: (...args: any[]) => void) => void
   off: (event: string, handler: (...args: any[]) => void) => void
 }
@@ -27,6 +41,10 @@ export function wireOpencodeActivityTracker(input: {
     setTimeoutFn: input.setTimeoutFn,
     clearTimeoutFn: input.clearTimeoutFn,
     random: input.random,
+  })
+  const controller = new OpencodeSessionController({
+    tracker,
+    registry: input.registry,
   })
 
   const startTracking = (record: TerminalRecord) => {
@@ -58,9 +76,11 @@ export function wireOpencodeActivityTracker(input: {
 
   return {
     tracker,
+    controller,
     dispose(): void {
       input.registry.off('terminal.created', onCreated)
       input.registry.off('terminal.exit', onExit)
+      controller.dispose()
       tracker.dispose()
     },
   }

--- a/server/coding-cli/opencode-session-controller.ts
+++ b/server/coding-cli/opencode-session-controller.ts
@@ -1,0 +1,122 @@
+import { EventEmitter } from 'events'
+import type { SessionBindingReason } from '../terminal-stream/registry-events.js'
+import type { BindSessionResult, TerminalRecord } from '../terminal-registry.js'
+import { logger } from '../logger.js'
+import type {
+  OpencodeActivityChange,
+  OpencodeActivityRecord,
+} from './opencode-activity-tracker.js'
+
+type OpencodeActivityTrackerLike = {
+  list: () => OpencodeActivityRecord[]
+  on: (event: 'changed', handler: (payload: OpencodeActivityChange) => void) => void
+  off: (event: 'changed', handler: (payload: OpencodeActivityChange) => void) => void
+}
+
+type OpencodeSessionRegistry = {
+  get: (terminalId: string) => TerminalRecord | undefined | null
+  bindSession: (
+    terminalId: string,
+    provider: 'opencode',
+    sessionId: string,
+    reason?: SessionBindingReason,
+  ) => BindSessionResult
+  rebindSession?: (
+    terminalId: string,
+    provider: 'opencode',
+    sessionId: string,
+    reason?: SessionBindingReason,
+  ) => BindSessionResult
+  on: (event: 'terminal.exit', handler: (payload: { terminalId?: string }) => void) => void
+  off: (event: 'terminal.exit', handler: (payload: { terminalId?: string }) => void) => void
+}
+
+type ControllerLogger = {
+  warn: (payload: object, message?: string) => void
+}
+
+export type OpencodeSessionAssociatedEvent = {
+  terminalId: string
+  sessionId: string
+}
+
+export class OpencodeSessionController extends EventEmitter {
+  private readonly tracker: OpencodeActivityTrackerLike
+  private readonly registry: OpencodeSessionRegistry
+  private readonly log: ControllerLogger
+  private readonly associatedSessionIds = new Map<string, string>()
+
+  private readonly handleTrackerChanged = (payload: OpencodeActivityChange) => {
+    for (const record of payload.upsert) {
+      this.promoteRecord(record)
+    }
+  }
+
+  private readonly handleTerminalExit = (payload: { terminalId?: string }) => {
+    if (!payload.terminalId) return
+    this.associatedSessionIds.delete(payload.terminalId)
+  }
+
+  constructor(input: {
+    tracker: OpencodeActivityTrackerLike
+    registry: OpencodeSessionRegistry
+    log?: ControllerLogger
+  }) {
+    super()
+    this.tracker = input.tracker
+    this.registry = input.registry
+    this.log = input.log ?? logger.child({ component: 'opencode-session-controller' })
+
+    this.tracker.on('changed', this.handleTrackerChanged)
+    this.registry.on('terminal.exit', this.handleTerminalExit)
+
+    const existing = this.tracker.list()
+    if (existing.length > 0) {
+      this.handleTrackerChanged({
+        upsert: existing,
+        remove: [],
+      })
+    }
+  }
+
+  dispose(): void {
+    this.tracker.off('changed', this.handleTrackerChanged)
+    this.registry.off('terminal.exit', this.handleTerminalExit)
+    this.associatedSessionIds.clear()
+  }
+
+  private promoteRecord(record: OpencodeActivityRecord): void {
+    if (!record.sessionId) return
+
+    const terminal = this.registry.get(record.terminalId)
+    if (!terminal || terminal.mode !== 'opencode' || terminal.status !== 'running') {
+      return
+    }
+
+    const previousSessionId = this.associatedSessionIds.get(record.terminalId) ?? terminal.resumeSessionId
+    if (previousSessionId === record.sessionId) {
+      this.associatedSessionIds.set(record.terminalId, record.sessionId)
+      return
+    }
+
+    const bind = previousSessionId && this.registry.rebindSession
+      ? this.registry.rebindSession.bind(this.registry)
+      : this.registry.bindSession.bind(this.registry)
+    const result = bind(record.terminalId, 'opencode', record.sessionId, 'association')
+
+    if (!result.ok) {
+      this.log.warn({
+        terminalId: record.terminalId,
+        sessionId: record.sessionId,
+        reason: result.reason,
+      }, 'Failed to promote OpenCode durable session from authoritative control data')
+      return
+    }
+
+    this.associatedSessionIds.set(record.terminalId, record.sessionId)
+    this.emit('associated', {
+      terminalId: record.terminalId,
+      sessionId: record.sessionId,
+    } satisfies OpencodeSessionAssociatedEvent)
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -70,8 +70,8 @@ import { createAgentHistorySource } from './agent-timeline/history-source.js'
 import { createTerminalViewService } from './terminal-view/service.js'
 import { resolveStartupBanner } from './startup-banner.js'
 import { shouldPromoteSessionTitle } from './session-title-sync.js'
-import { CodexAppServerRuntime } from './coding-cli/codex-app-server/runtime.js'
 import { CodexLaunchPlanner } from './coding-cli/codex-app-server/launch-planner.js'
+import { CodexTerminalSidecar } from './coding-cli/codex-app-server/sidecar.js'
 
 function compileArgTemplate(
   template: string[] | undefined,
@@ -288,8 +288,8 @@ async function main() {
   sdkBridge = new SdkBridge(agentHistorySource)
 
   const server = http.createServer(app)
-  const codexAppServerRuntime = new CodexAppServerRuntime()
-  const codexLaunchPlanner = new CodexLaunchPlanner(codexAppServerRuntime)
+  await CodexTerminalSidecar.reapOrphanedSidecars()
+  const codexLaunchPlanner = new CodexLaunchPlanner()
   const wsHandler = new WsHandler(
     server,
     registry,
@@ -361,6 +361,24 @@ async function main() {
   })
   opencodeActivity.tracker.on('changed', (payload) => {
     wsHandler.broadcastOpencodeActivityUpdated(payload)
+  })
+  opencodeActivity.controller.on('associated', ({ terminalId, sessionId }) => {
+    try {
+      wsHandler.broadcast({
+        type: 'terminal.session.associated' as const,
+        terminalId,
+        sessionRef: {
+          provider: 'opencode',
+          sessionId,
+        },
+      })
+      const metaUpsert = terminalMetadata.associateSession(terminalId, 'opencode', sessionId)
+      if (metaUpsert) {
+        broadcastTerminalMetaUpserts([metaUpsert])
+      }
+    } catch (err) {
+      log.warn({ err, terminalId, sessionId }, 'Failed to broadcast OpenCode session association')
+    }
   })
 
   const broadcastTerminalMetaUpserts = (upsert: ReturnType<TerminalMetadataService['list']>) => {
@@ -541,7 +559,10 @@ async function main() {
         wsHandler.broadcast({
           type: 'terminal.session.associated' as const,
           terminalId,
-          sessionId: session.sessionId,
+          sessionRef: {
+            provider: session.provider,
+            sessionId: session.sessionId,
+          },
         })
         const metaUpsert = terminalMetadata.associateSession(
           terminalId,
@@ -628,7 +649,10 @@ async function main() {
       wsHandler.broadcast({
         type: 'terminal.session.associated' as const,
         terminalId,
-        sessionId: session.sessionId,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: session.sessionId,
+        },
       })
       const metaUpsert = terminalMetadata.associateSession(terminalId, 'claude', session.sessionId)
       if (metaUpsert) {
@@ -776,9 +800,6 @@ async function main() {
 
     // 4. Kill all coding CLI sessions
     codingCliSessionManager.shutdown()
-
-    // 4b. Stop the shared Codex app-server runtime
-    await codexAppServerRuntime.shutdown()
 
     // 5. Close SDK bridge sessions
     sdkBridge.close()

--- a/server/mcp/freshell-tool.ts
+++ b/server/mcp/freshell-tool.ts
@@ -533,7 +533,19 @@ async function routeAction(
     // -- Tab actions --
     case 'new-tab': {
       const { name, mode, shell, cwd, browser, editor, resume, prompt, ...rest } = params || {}
-      const tabResult = await c.post('/api/tabs', { name, mode, shell, cwd, browser, editor, resumeSessionId: resume, ...rest })
+      const sessionRef = typeof mode === 'string' && typeof resume === 'string'
+        ? { provider: mode, sessionId: resume }
+        : undefined
+      const tabResult = await c.post('/api/tabs', {
+        name,
+        mode,
+        shell,
+        cwd,
+        browser,
+        editor,
+        ...(sessionRef ? { sessionRef } : {}),
+        ...rest,
+      })
       // Send prompt text to the newly created pane (mirrors CLI behavior: server/cli/index.ts:318)
       if (prompt) {
         const data = unwrapData(tabResult)

--- a/server/session-scanner/service.ts
+++ b/server/session-scanner/service.ts
@@ -17,6 +17,7 @@ import { SessionCache } from './cache.js'
 import { SessionRepairQueue, type Priority, ACTIVE_CACHE_GRACE_MS } from './queue.js'
 import { ClaudeHistoryRepairer } from './history-repair.js'
 import type { SessionScanner, SessionScanResult, SessionRepairResult } from './types.js'
+import { isCanonicalClaudeSessionId } from '../../shared/session-contract.js'
 
 const BACKUP_RETENTION_DAYS = 30
 const CACHE_FILENAME = 'session-cache.json'
@@ -150,9 +151,11 @@ export class SessionRepairService extends EventEmitter {
       })
     }
 
-    if (items.length === 0) return
+    const canonicalItems = items.filter((item) => isCanonicalClaudeSessionId(item.sessionId))
 
-    this.enqueueResolved(items)
+    if (canonicalItems.length === 0) return
+
+    this.enqueueResolved(canonicalItems)
   }
 
   /**
@@ -160,6 +163,10 @@ export class SessionRepairService extends EventEmitter {
    * Used by terminal.create before spawning Claude with --resume.
    */
   async waitForSession(sessionId: string, timeoutMs = 30000): Promise<SessionScanResult> {
+    if (!isCanonicalClaudeSessionId(sessionId)) {
+      throw new Error(`Session ${sessionId} is not a canonical Claude session id`)
+    }
+
     // Check if already processed
     const existing = this.queue.getResult(sessionId)
     if (existing) {
@@ -317,11 +324,13 @@ export class SessionRepairService extends EventEmitter {
   }
 
   private resolveCachedPath(sessionId: string): string | null {
+    if (!isCanonicalClaudeSessionId(sessionId)) return null
     this.ensureSessionIndex()
     return this.sessionPathIndex.get(sessionId) || null
   }
 
   private async resolveFilePath(sessionId: string): Promise<string | null> {
+    if (!isCanonicalClaudeSessionId(sessionId)) return null
     if (this.filePathResolver) {
       const resolved = this.filePathResolver(sessionId)
       if (resolved) {

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -22,6 +22,7 @@ import type {
   TerminalSessionBoundEvent,
   TerminalSessionUnboundEvent,
 } from './terminal-stream/registry-events.js'
+import type { CodexTerminalSidecar } from './coding-cli/codex-app-server/sidecar.js'
 import { getOpencodeEnvOverrides, resolveOpencodeLaunchModel } from './opencode-launch.js'
 import { generateMcpInjection, cleanupMcpConfig } from './mcp/config-writer.js'
 
@@ -360,6 +361,7 @@ export type TerminalRecord = {
   title: string
   description?: string
   mode: TerminalMode
+  codexSidecar?: Pick<CodexTerminalSidecar, 'shutdown'>
   opencodeServer?: LoopbackServerEndpoint
   resumeSessionId?: string
   pendingResumeName?: string
@@ -1104,6 +1106,7 @@ export class TerminalRegistry extends EventEmitter {
     resumeSessionId?: string
     sessionBindingReason?: SessionBindingReason
     providerSettings?: ProviderSettings
+    codexSidecar?: Pick<CodexTerminalSidecar, 'attachTerminal' | 'shutdown'>
     envContext?: { tabId?: string; paneId?: string }
   }): TerminalRecord {
     this.reapExitedTerminals()
@@ -1176,6 +1179,7 @@ export class TerminalRegistry extends EventEmitter {
       title,
       description: undefined,
       mode: opts.mode,
+      codexSidecar: opts.mode === 'codex' ? opts.codexSidecar : undefined,
       opencodeServer: opts.mode === 'opencode' ? opts.providerSettings?.opencodeServer : undefined,
       resumeSessionId: undefined,
       createdAt,
@@ -1286,6 +1290,7 @@ export class TerminalRegistry extends EventEmitter {
       record.lastActivityAt = now
       record.exitedAt = now
       cleanupMcpConfig(terminalId, opts.mode, record.mcpCwd)
+      this.shutdownCodexSidecar(record)
       for (const client of record.clients) {
         this.flushOutputBuffer(client)
         this.safeSend(client, { type: 'terminal.exit', terminalId, exitCode: e.exitCode }, { terminalId, perf: record.perf })
@@ -1299,6 +1304,24 @@ export class TerminalRegistry extends EventEmitter {
     })
 
     this.terminals.set(terminalId, record)
+    if (opts.mode === 'codex' && opts.codexSidecar) {
+      opts.codexSidecar.attachTerminal({
+        terminalId,
+        onDurableSession: (sessionId) => {
+          const rebound = this.rebindSession(terminalId, 'codex', sessionId, 'association')
+          if (!rebound.ok) {
+            logger.warn(
+              { terminalId, sessionId, reason: rebound.reason },
+              'Failed to promote Codex durable session from sidecar notification',
+            )
+          }
+        },
+        onFatal: (error) => {
+          logger.warn({ err: error, terminalId }, 'Codex terminal sidecar failed; terminating terminal')
+          this.kill(terminalId)
+        },
+      })
+    }
     const exactSessionId = resumeForBinding
     if (modeSupportsResume(opts.mode) && exactSessionId) {
       const bound = this.bindSession(
@@ -1399,6 +1422,7 @@ export class TerminalRegistry extends EventEmitter {
     if (!term) return false
     if (term.status === 'exited') return true
     cleanupMcpConfig(terminalId, term.mode, term.mcpCwd)
+    this.shutdownCodexSidecar(term)
     try {
       term.pty.kill()
     } catch (err) {
@@ -1428,6 +1452,17 @@ export class TerminalRegistry extends EventEmitter {
     this.kill(terminalId)
     this.terminals.delete(terminalId)
     return true
+  }
+
+  private shutdownCodexSidecar(term: TerminalRecord): void {
+    const sidecar = term.codexSidecar
+    if (!sidecar) {
+      return
+    }
+    term.codexSidecar = undefined
+    void sidecar.shutdown().catch((error) => {
+      logger.warn({ err: error, terminalId: term.terminalId }, 'Failed to shut down Codex sidecar')
+    })
   }
 
   list(): Array<{

--- a/server/terminal-view/service.ts
+++ b/server/terminal-view/service.ts
@@ -3,6 +3,7 @@ import {
   MAX_DIRECTORY_PAGE_ITEMS,
   type TerminalDirectoryQuery,
 } from '../../shared/read-models.js'
+import type { SessionLocator } from '../../shared/ws-protocol.js'
 import { TerminalViewMirror } from './mirror.js'
 import type {
   TerminalDirectoryItem,
@@ -18,7 +19,18 @@ type CursorPayload = {
   terminalId: string
 }
 
-type TerminalListRecord = TerminalDirectoryItem
+type TerminalListRecord = {
+  terminalId: string
+  title: string
+  description?: string
+  mode: TerminalMode
+  resumeSessionId?: string
+  createdAt: number
+  lastActivityAt: number
+  status: 'running' | 'exited'
+  hasClients: boolean
+  cwd?: string
+}
 
 type TerminalRecord = {
   terminalId: string
@@ -95,6 +107,29 @@ function compareTerminals(a: TerminalDirectoryItem, b: TerminalDirectoryItem): n
   return b.terminalId.localeCompare(a.terminalId)
 }
 
+function buildSessionRef(mode: TerminalMode, resumeSessionId?: string): SessionLocator | undefined {
+  if (mode === 'shell' || !resumeSessionId) return undefined
+  return {
+    provider: mode,
+    sessionId: resumeSessionId,
+  }
+}
+
+function buildDirectoryItem(terminal: TerminalListRecord): TerminalDirectoryItem {
+  return {
+    terminalId: terminal.terminalId,
+    title: terminal.title,
+    description: terminal.description,
+    mode: terminal.mode,
+    sessionRef: buildSessionRef(terminal.mode, terminal.resumeSessionId),
+    createdAt: terminal.createdAt,
+    lastActivityAt: terminal.lastActivityAt,
+    status: terminal.status,
+    hasClients: terminal.hasClients,
+    cwd: terminal.cwd,
+  }
+}
+
 function throwIfAborted(signal?: AbortSignal): void {
   if (signal?.aborted) {
     throw signal.reason instanceof Error ? signal.reason : new Error('Terminal view request aborted')
@@ -145,7 +180,7 @@ export function createTerminalViewService(deps: TerminalViewServiceDeps): Termin
       .map((terminal) => {
         const override = config.terminalOverrides?.[terminal.terminalId]
         return {
-          ...terminal,
+          ...buildDirectoryItem(terminal),
           title: override?.titleOverride || terminal.title,
           description: override?.descriptionOverride || terminal.description,
         }

--- a/server/terminal-view/types.ts
+++ b/server/terminal-view/types.ts
@@ -1,12 +1,13 @@
 import type { TerminalMode } from '../terminal-registry.js'
 import type { TerminalDirectoryQuery } from '../../shared/read-models.js'
+import type { SessionLocator } from '../../shared/ws-protocol.js'
 
 export type TerminalDirectoryItem = {
   terminalId: string
   title: string
   description?: string
   mode: TerminalMode
-  resumeSessionId?: string
+  sessionRef?: SessionLocator
   createdAt: number
   lastActivityAt: number
   status: 'running' | 'exited'

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -42,6 +42,7 @@ import {
   ErrorCode,
   ShellSchema,
   CodingCliProviderSchema,
+  SessionLocatorSchema,
   TerminalMetaUpdatedSchema,
   CodexActivityListResponseSchema,
   CodexActivityListSchema,
@@ -72,6 +73,7 @@ import {
 } from '../shared/ws-protocol.js'
 import { UiLayoutSyncSchema } from './agent-api/layout-schema.js'
 import type { LayoutStore } from './agent-api/layout-store.js'
+import { LiveTerminalHandleSchema } from '../shared/session-contract.js'
 
 type WsHandlerConfig = {
   maxConnections: number
@@ -169,6 +171,20 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0
 }
 
+function buildCanonicalTerminalSessionRef(
+  mode: TerminalMode,
+  resumeSessionId?: string,
+): { provider: string; sessionId: string } | undefined {
+  if (mode === 'shell' || !isNonEmptyString(resumeSessionId)) return undefined
+  if (mode === 'claude' && !isValidClaudeSessionId(resumeSessionId)) {
+    return undefined
+  }
+  return {
+    provider: mode,
+    sessionId: resumeSessionId,
+  }
+}
+
 const TERMINAL_FAILURE_SUMMARY_MAX_CHARS = 200
 
 function summarizeTerminalFailureOutput(snapshot: string): string | undefined {
@@ -201,16 +217,12 @@ function normalizeUiSessionLocator(value: unknown): SidebarSessionLocator | unde
   const candidate = value as {
     provider?: unknown
     sessionId?: unknown
-    serverInstanceId?: unknown
   }
   const provider = CodingCliProviderSchema.safeParse(candidate.provider)
   if (!provider.success || !isNonEmptyString(candidate.sessionId)) return undefined
   return {
     provider: provider.data,
     sessionId: candidate.sessionId,
-    ...(isNonEmptyString(candidate.serverInstanceId)
-      ? { serverInstanceId: candidate.serverInstanceId }
-      : {}),
   }
 }
 
@@ -224,7 +236,7 @@ function extractSessionLocatorsFromUiContent(content: Record<string, unknown>): 
 
   const kind = content.kind
   if (kind === 'agent-chat') {
-    if (isNonEmptyString(content.resumeSessionId)) {
+    if (isNonEmptyString(content.resumeSessionId) && isValidClaudeSessionId(content.resumeSessionId)) {
       locators.push({ provider: 'claude', sessionId: content.resumeSessionId })
     }
     return locators
@@ -233,7 +245,12 @@ function extractSessionLocatorsFromUiContent(content: Record<string, unknown>): 
   if (kind !== 'terminal') return locators
 
   const mode = CodingCliProviderSchema.safeParse(content.mode)
-  if (!mode.success || !isNonEmptyString(content.resumeSessionId)) {
+  if (
+    !mode.success
+    || mode.data !== 'claude'
+    || !isNonEmptyString(content.resumeSessionId)
+    || !isValidClaudeSessionId(content.resumeSessionId)
+  ) {
     return locators
   }
 
@@ -449,11 +466,12 @@ export class WsHandler {
       }),
       shell: ShellSchema.default('system'),
       cwd: z.string().optional(),
-      resumeSessionId: z.string().optional(),
+      sessionRef: SessionLocatorSchema.optional(),
+      liveTerminal: LiveTerminalHandleSchema.optional(),
       restore: z.boolean().optional(),
       tabId: z.string().min(1).optional(),
       paneId: z.string().min(1).optional(),
-    })
+    }).strict()
 
     const dynamicProviderSchema = CodingCliProviderSchema.superRefine((val, ctx) => {
       if (!canEnumerateCliExtensions || extensionModes.includes(val)) return
@@ -663,7 +681,7 @@ export class WsHandler {
     providerSettings: { model?: string; sandbox?: string; permissionMode?: string } | undefined,
   ) {
     if (!this.codexLaunchPlanner) {
-      throw new Error('Codex terminal launch requires the shared app-server planner.')
+      throw new Error('Codex terminal launch requires the per-terminal app-server sidecar planner.')
     }
     return this.codexLaunchPlanner.planCreate({
       cwd,
@@ -1274,7 +1292,20 @@ export class WsHandler {
       }
 
       // Send terminal inventory so the client knows what's alive
-      const terminals = this.registry.list()
+      const terminals = this.registry.list().map((terminal) => {
+        const sessionRef = buildCanonicalTerminalSessionRef(terminal.mode, terminal.resumeSessionId)
+        return {
+          terminalId: terminal.terminalId,
+          title: terminal.title,
+          description: terminal.description,
+          mode: terminal.mode,
+          ...(sessionRef ? { sessionRef } : {}),
+          createdAt: terminal.createdAt,
+          lastActivityAt: terminal.lastActivityAt,
+          status: terminal.status,
+          cwd: terminal.cwd,
+        }
+      })
       const terminalMeta = this.terminalMetaListProvider?.() ?? []
       this.safeSend(ws, {
         type: 'terminal.inventory',
@@ -1311,6 +1342,20 @@ export class WsHandler {
         this.sendError(ws, { code: 'INVALID_MESSAGE', message: 'Invalid JSON' })
         return
       }
+      const rawSessionRef = (
+        msg?.sessionRef
+        && typeof msg.sessionRef === 'object'
+        && typeof msg.sessionRef.provider === 'string'
+        && msg.sessionRef.provider.length > 0
+        && typeof msg.sessionRef.sessionId === 'string'
+        && msg.sessionRef.sessionId.length > 0
+      )
+        ? {
+            provider: msg.sessionRef.provider,
+            sessionId: msg.sessionRef.sessionId,
+          }
+        : undefined
+      const rawRestoreRequested = msg?.restore === true
 
       if (msg?.type === 'hello' && msg?.protocolVersion !== WS_PROTOCOL_VERSION) {
         this.sendError(ws, {
@@ -1429,12 +1474,25 @@ export class WsHandler {
         return
       }
       case 'terminal.create': {
+        const requestedSessionRef = (
+          m.sessionRef?.provider === m.mode && typeof m.sessionRef?.sessionId === 'string'
+            ? m.sessionRef
+            : (rawSessionRef?.provider === m.mode ? rawSessionRef : undefined)
+        )
+        const canonicalSessionId = requestedSessionRef?.sessionId
+        const restoreRequested = m.restore === true || rawRestoreRequested
+        const localLiveTerminalId = (
+          m.liveTerminal?.serverInstanceId === this.serverInstanceId
+          && typeof m.liveTerminal?.terminalId === 'string'
+        )
+          ? m.liveTerminal.terminalId
+          : undefined
         log.debug({
           requestId: m.requestId,
           connectionId: ws.connectionId,
           mode: m.mode,
-          resumeSessionId: m.resumeSessionId,
-        }, '[TRACE resumeSessionId] terminal.create received')
+          sessionRef: requestedSessionRef,
+        }, '[TRACE sessionRef] terminal.create received')
         const endCreateTimer = startPerfTimer(
           'terminal_create',
           { connectionId: ws.connectionId, mode: m.mode, shell: m.shell },
@@ -1444,10 +1502,10 @@ export class WsHandler {
         let reused = false
         let error = false
         let rateLimited = false
-        let effectiveResumeSessionId = m.resumeSessionId
+        let restoreSessionId = canonicalSessionId
         try {
           await this.withTerminalCreateLock(
-            this.terminalCreateLockKey(m.mode as TerminalMode, m.requestId, effectiveResumeSessionId),
+            this.terminalCreateLockKey(m.mode as TerminalMode, m.requestId, canonicalSessionId),
             async () => {
               const resolveExistingRequestTerminalId = (requestId: string): string | undefined => {
                 const local = state.createdByRequestId.get(requestId)
@@ -1465,7 +1523,6 @@ export class WsHandler {
                 requestId: string
                 terminalId: string
                 createdAt: number
-                effectiveResumeSessionId?: string
               }): Promise<boolean> => {
                 if (opts.ws.readyState !== WebSocket.OPEN) {
                   return false
@@ -1476,7 +1533,6 @@ export class WsHandler {
                   requestId: opts.requestId,
                   terminalId: opts.terminalId,
                   createdAt: opts.createdAt,
-                  ...(opts.effectiveResumeSessionId ? { effectiveResumeSessionId: opts.effectiveResumeSessionId } : {}),
                 })
                 return true
               }
@@ -1484,14 +1540,12 @@ export class WsHandler {
               const attachReusedTerminal = async (
                 reusedTerminalId: string,
                 createdAt: number,
-                resumeSessionId?: string,
               ): Promise<boolean> => {
                 const sent = await sendCreateResult({
                   ws,
                   requestId: m.requestId,
                   terminalId: reusedTerminalId,
                   createdAt,
-                  effectiveResumeSessionId: resumeSessionId,
                 })
                 if (!sent) {
                   return false
@@ -1513,7 +1567,7 @@ export class WsHandler {
                 }
                 const existing = this.registry.get(existingId)
                 if (existing) {
-                  await attachReusedTerminal(existing.terminalId, existing.createdAt, existing.resumeSessionId)
+                  await attachReusedTerminal(existing.terminalId, existing.createdAt)
                   return
                 }
                 // If it no longer exists, fall through and create a new one.
@@ -1521,23 +1575,31 @@ export class WsHandler {
                 this.forgetCreatedRequestId(m.requestId)
               }
 
-              if (modeSupportsResume(m.mode as TerminalMode) && effectiveResumeSessionId) {
+              if (localLiveTerminalId) {
+                const liveTerminal = this.registry.get(localLiveTerminalId)
+                if (liveTerminal?.status === 'running' && liveTerminal.mode === m.mode) {
+                  await attachReusedTerminal(liveTerminal.terminalId, liveTerminal.createdAt)
+                  return
+                }
+              }
+
+              if (modeSupportsResume(m.mode as TerminalMode) && canonicalSessionId) {
                 let existing = this.registry.getCanonicalRunningTerminalBySession(
                   m.mode as TerminalMode,
-                  effectiveResumeSessionId,
+                  canonicalSessionId,
                 )
                 if (!existing) {
                   this.registry.repairLegacySessionOwners(
                     m.mode as TerminalMode,
-                    effectiveResumeSessionId,
+                    canonicalSessionId,
                   )
                   existing = this.registry.getCanonicalRunningTerminalBySession(
                     m.mode as TerminalMode,
-                    effectiveResumeSessionId,
+                    canonicalSessionId,
                   )
                 }
                 if (existing) {
-                  await attachReusedTerminal(existing.terminalId, existing.createdAt, existing.resumeSessionId)
+                  await attachReusedTerminal(existing.terminalId, existing.createdAt)
                   return
                 }
               }
@@ -1557,7 +1619,7 @@ export class WsHandler {
                 }
                 const existing = this.registry.get(existingAfterConfigId)
                 if (existing) {
-                  await attachReusedTerminal(existing.terminalId, existing.createdAt, existing.resumeSessionId)
+                  await attachReusedTerminal(existing.terminalId, existing.createdAt)
                   return
                 }
                 state.createdByRequestId.delete(m.requestId)
@@ -1565,7 +1627,7 @@ export class WsHandler {
               }
 
               // Rate limit: prevent runaway terminal creation (e.g., infinite respawn loops)
-              if (!m.restore) {
+              if (!restoreRequested) {
                 const now = Date.now()
                 state.terminalCreateTimestamps = state.terminalCreateTimestamps.filter(
                   (t) => now - t < this.config.terminalCreateRateWindowMs
@@ -1581,23 +1643,31 @@ export class WsHandler {
 
               // Re-check session ownership after async config loading in case another request
               // created or repaired a matching running session while we were waiting.
-              if (modeSupportsResume(m.mode as TerminalMode) && effectiveResumeSessionId) {
+              if (localLiveTerminalId) {
+                const liveTerminal = this.registry.get(localLiveTerminalId)
+                if (liveTerminal?.status === 'running' && liveTerminal.mode === m.mode) {
+                  await attachReusedTerminal(liveTerminal.terminalId, liveTerminal.createdAt)
+                  return
+                }
+              }
+
+              if (modeSupportsResume(m.mode as TerminalMode) && canonicalSessionId) {
                 let existing = this.registry.getCanonicalRunningTerminalBySession(
                   m.mode as TerminalMode,
-                  effectiveResumeSessionId,
+                  canonicalSessionId,
                 )
                 if (!existing) {
                   this.registry.repairLegacySessionOwners(
                     m.mode as TerminalMode,
-                    effectiveResumeSessionId,
+                    canonicalSessionId,
                   )
                   existing = this.registry.getCanonicalRunningTerminalBySession(
                     m.mode as TerminalMode,
-                    effectiveResumeSessionId,
+                    canonicalSessionId,
                   )
                 }
                 if (existing) {
-                  await attachReusedTerminal(existing.terminalId, existing.createdAt, existing.resumeSessionId)
+                  await attachReusedTerminal(existing.terminalId, existing.createdAt)
                   return
                 }
               }
@@ -1605,12 +1675,12 @@ export class WsHandler {
               // Session repair is Claude-specific (uses JSONL session files).
               // Other providers (codex, opencode, etc.) don't use the same file
               // structure, so this block correctly remains gated on mode === 'claude'.
-              if (m.mode === 'claude' && effectiveResumeSessionId && isValidClaudeSessionId(effectiveResumeSessionId) && this.sessionRepairService) {
-                const sessionId = effectiveResumeSessionId
+              if (m.mode === 'claude' && restoreSessionId && isValidClaudeSessionId(restoreSessionId) && this.sessionRepairService) {
+                const sessionId = restoreSessionId
                 const cached = this.sessionRepairService.getResult(sessionId)
                 if (cached?.status === 'missing') {
                   log.info({ sessionId, connectionId: ws.connectionId }, 'Session previously marked missing; resume will start fresh')
-                  effectiveResumeSessionId = undefined
+                  restoreSessionId = undefined
                 } else {
                   // Reserve requestId to prevent same-socket duplicate creates during async repair wait.
                   state.createdByRequestId.set(m.requestId, REPAIR_PENDING_SENTINEL)
@@ -1624,13 +1694,31 @@ export class WsHandler {
                     endRepairTimer({ status: result.status })
                     if (result.status === 'missing') {
                       log.info({ sessionId, connectionId: ws.connectionId }, 'Session file missing; resume will start fresh')
-                      effectiveResumeSessionId = undefined
+                      restoreSessionId = undefined
                     }
                   } catch (err) {
                     endRepairTimer({ error: err instanceof Error ? err.message : String(err) })
                     log.debug({ err, sessionId, connectionId: ws.connectionId }, 'Session repair wait failed, proceeding with resume')
                   }
                 }
+              }
+
+              if (m.mode === 'opencode' && restoreRequested && !canonicalSessionId) {
+                this.sendError(ws, {
+                  code: 'RESTORE_UNAVAILABLE',
+                  message: 'OpenCode restore requires a canonical durable session id',
+                  requestId: m.requestId,
+                })
+                return
+              }
+
+              if (m.mode === 'claude' && restoreRequested && !isValidClaudeSessionId(restoreSessionId)) {
+                this.sendError(ws, {
+                  code: 'RESTORE_UNAVAILABLE',
+                  message: 'Claude restore requires a canonical durable session id',
+                  requestId: m.requestId,
+                })
+                return
               }
 
               // After async repair wait, check if the client disconnected
@@ -1646,83 +1734,84 @@ export class WsHandler {
               log.debug({
                 requestId: m.requestId,
                 connectionId: ws.connectionId,
-                originalResumeSessionId: m.resumeSessionId,
-                effectiveResumeSessionId,
-              }, '[TRACE resumeSessionId] about to create terminal')
+                sessionRef: requestedSessionRef,
+                restoreSessionId,
+              }, '[TRACE sessionRef] about to create terminal')
 
               const requestedCodexResumeSessionId = m.mode === 'codex'
-                ? effectiveResumeSessionId
+                ? canonicalSessionId
                 : undefined
-              const codexPlan = m.mode === 'codex'
-                ? await this.planCodexLaunch(m.cwd, requestedCodexResumeSessionId, providerSettings)
-                : undefined
+              let codexPlan: Awaited<ReturnType<WsHandler['planCodexLaunch']>> | undefined
+              try {
+                codexPlan = m.mode === 'codex'
+                  ? await this.planCodexLaunch(m.cwd, requestedCodexResumeSessionId, providerSettings)
+                  : undefined
 
-              if (codexPlan) {
-                effectiveResumeSessionId = codexPlan.sessionId
-              }
-
-              const spawnProviderSettings = (
-                providerSettings
-                  ? {
-                    ...(m.mode === 'codex'
-                      ? {}
-                      : {
-                        permissionMode: providerSettings.permissionMode,
-                        model: providerSettings.model,
-                        sandbox: providerSettings.sandbox,
-                      }),
-                    ...(m.mode === 'opencode'
-                      ? { opencodeServer: await allocateLocalhostPort() }
-                      : {}),
-                    ...(codexPlan ? { codexAppServer: codexPlan.remote } : {}),
-                  }
-                  : (codexPlan
-                    ? { codexAppServer: codexPlan.remote }
-                    : undefined)
-              )
-
-              const record = this.registry.create({
-                mode: m.mode as TerminalMode,
-                shell: m.shell as 'system' | 'cmd' | 'powershell' | 'wsl',
-                cwd: m.cwd,
-                resumeSessionId: effectiveResumeSessionId,
-                ...(codexPlan
-                  ? {
-                      sessionBindingReason: getCodexSessionBindingReason(m.mode, requestedCodexResumeSessionId),
+                const spawnProviderSettings = (
+                  providerSettings
+                    ? {
+                      ...(m.mode === 'codex'
+                        ? {}
+                        : {
+                          permissionMode: providerSettings.permissionMode,
+                          model: providerSettings.model,
+                          sandbox: providerSettings.sandbox,
+                        }),
+                      ...(m.mode === 'opencode'
+                        ? { opencodeServer: await allocateLocalhostPort() }
+                        : {}),
+                      ...(codexPlan ? { codexAppServer: codexPlan.remote } : {}),
                     }
-                  : {}),
-                envContext: { tabId: m.tabId, paneId: m.paneId },
-                providerSettings: spawnProviderSettings,
-              })
+                    : (codexPlan
+                      ? { codexAppServer: codexPlan.remote }
+                      : undefined)
+                )
 
-              if (m.mode !== 'shell' && typeof m.cwd === 'string' && m.cwd.trim()) {
-                const recentDirectory = m.cwd.trim()
-                void configStore.pushRecentDirectory(recentDirectory).catch((err) => {
-                  log.warn({ err, recentDirectory }, 'Failed to record recent directory')
+                const record = this.registry.create({
+                  mode: m.mode as TerminalMode,
+                  shell: m.shell as 'system' | 'cmd' | 'powershell' | 'wsl',
+                  cwd: m.cwd,
+                  resumeSessionId: restoreSessionId,
+                  ...(requestedCodexResumeSessionId
+                    ? {
+                        sessionBindingReason: getCodexSessionBindingReason(m.mode, requestedCodexResumeSessionId),
+                      }
+                    : {}),
+                  envContext: { tabId: m.tabId, paneId: m.paneId },
+                  providerSettings: spawnProviderSettings,
+                  ...(codexPlan ? { codexSidecar: codexPlan.sidecar } : {}),
                 })
-              }
+                if (m.mode !== 'shell' && typeof m.cwd === 'string' && m.cwd.trim()) {
+                  const recentDirectory = m.cwd.trim()
+                  void configStore.pushRecentDirectory(recentDirectory).catch((err) => {
+                    log.warn({ err, recentDirectory }, 'Failed to record recent directory')
+                  })
+                }
 
-              state.createdByRequestId.set(m.requestId, record.terminalId)
-              this.rememberCreatedRequestId(m.requestId, record.terminalId)
-              terminalId = record.terminalId
+                state.createdByRequestId.set(m.requestId, record.terminalId)
+                this.rememberCreatedRequestId(m.requestId, record.terminalId)
+                terminalId = record.terminalId
 
-              const sent = await sendCreateResult({
-                ws,
-                requestId: m.requestId,
-                terminalId: record.terminalId,
-                createdAt: record.createdAt,
-                effectiveResumeSessionId,
-              })
-              if (!sent) {
-                // Terminal may still exist even if created delivery failed (for
-                // example: socket closed after create). Broadcast inventory so
-                // other clients can discover it.
+                const sent = await sendCreateResult({
+                  ws,
+                  requestId: m.requestId,
+                  terminalId: record.terminalId,
+                  createdAt: record.createdAt,
+                })
+                if (!sent) {
+                  // Terminal may still exist even if created delivery failed (for
+                  // example: socket closed after create). Broadcast inventory so
+                  // other clients can discover it.
+                  this.broadcastTerminalsChanged()
+                  return
+                }
+
+                // Notify all clients that list changed
                 this.broadcastTerminalsChanged()
-                return
+              } catch (error) {
+                await codexPlan?.sidecar.shutdown().catch(() => undefined)
+                throw error
               }
-
-              // Notify all clients that list changed
-              this.broadcastTerminalsChanged()
             },
           )
         } catch (err: any) {

--- a/shared/session-contract.ts
+++ b/shared/session-contract.ts
@@ -1,0 +1,162 @@
+import { z } from 'zod'
+
+export const SessionRefSchema = z.object({
+  provider: z.string().min(1),
+  sessionId: z.string().min(1),
+}).strict()
+
+export type SessionRef = z.infer<typeof SessionRefSchema>
+
+export const LiveTerminalHandleSchema = z.object({
+  terminalId: z.string().min(1),
+  serverInstanceId: z.string().min(1),
+}).strict()
+
+export type LiveTerminalHandle = z.infer<typeof LiveTerminalHandleSchema>
+
+export const RestoreErrorReasonSchema = z.enum([
+  'missing_canonical_identity',
+  'invalid_legacy_restore_target',
+  'dead_live_handle',
+  'provider_runtime_failed',
+  'durable_artifact_missing',
+])
+
+export type RestoreErrorReason = z.infer<typeof RestoreErrorReasonSchema>
+
+export const RestoreErrorSchema = z.object({
+  code: z.literal('RESTORE_UNAVAILABLE'),
+  reason: RestoreErrorReasonSchema,
+}).strict()
+
+export type RestoreError = z.infer<typeof RestoreErrorSchema>
+
+const CLAUDE_SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object'
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+export function isCanonicalClaudeSessionId(value: unknown): value is string {
+  return typeof value === 'string' && CLAUDE_SESSION_ID_RE.test(value)
+}
+
+export function buildRestoreError(reason: RestoreErrorReason): RestoreError {
+  return {
+    code: 'RESTORE_UNAVAILABLE',
+    reason,
+  }
+}
+
+export function sanitizeSessionRef(value: unknown): SessionRef | undefined {
+  if (!isRecord(value)) return undefined
+  if (!isNonEmptyString(value.provider) || !isNonEmptyString(value.sessionId)) return undefined
+  return {
+    provider: value.provider,
+    sessionId: value.sessionId,
+  }
+}
+
+export function dedupeSessionRefs(values: ReadonlyArray<unknown>): SessionRef[] {
+  const seen = new Set<string>()
+  const deduped: SessionRef[] = []
+
+  for (const value of values) {
+    const sessionRef = sanitizeSessionRef(value)
+    if (!sessionRef) continue
+    const key = `${sessionRef.provider}:${sessionRef.sessionId}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(sessionRef)
+  }
+
+  return deduped
+}
+
+export function migrateLegacyTerminalDurableState({
+  provider,
+  sessionRef,
+  resumeSessionId,
+}: {
+  provider?: string
+  sessionRef?: unknown
+  resumeSessionId?: string
+}): {
+  sessionRef?: SessionRef
+  restoreError?: RestoreError
+} {
+  const explicitSessionRef = sanitizeSessionRef(sessionRef)
+  if (explicitSessionRef) {
+    return { sessionRef: explicitSessionRef }
+  }
+
+  if (!provider || !resumeSessionId) {
+    return {}
+  }
+
+  if (provider === 'claude') {
+    if (isCanonicalClaudeSessionId(resumeSessionId)) {
+      return {
+        sessionRef: {
+          provider,
+          sessionId: resumeSessionId,
+        },
+      }
+    }
+    return { restoreError: buildRestoreError('invalid_legacy_restore_target') }
+  }
+
+  if (provider === 'codex' || provider === 'opencode') {
+    return { restoreError: buildRestoreError('invalid_legacy_restore_target') }
+  }
+
+  return {
+    sessionRef: {
+      provider,
+      sessionId: resumeSessionId,
+    },
+  }
+}
+
+export function migrateLegacyAgentChatDurableState({
+  sessionRef,
+  cliSessionId,
+  timelineSessionId,
+  resumeSessionId,
+}: {
+  sessionRef?: unknown
+  cliSessionId?: string
+  timelineSessionId?: string
+  resumeSessionId?: string
+}): {
+  sessionRef?: SessionRef
+  restoreError?: RestoreError
+} {
+  const explicitSessionRef = sanitizeSessionRef(sessionRef)
+  if (explicitSessionRef) {
+    return { sessionRef: explicitSessionRef }
+  }
+
+  const canonicalClaudeSessionId = isCanonicalClaudeSessionId(cliSessionId)
+    ? cliSessionId
+    : (isCanonicalClaudeSessionId(timelineSessionId) ? timelineSessionId : undefined)
+
+  if (canonicalClaudeSessionId) {
+    return {
+      sessionRef: {
+        provider: 'claude',
+        sessionId: canonicalClaudeSessionId,
+      },
+    }
+  }
+
+  if (resumeSessionId) {
+    return { restoreError: buildRestoreError('invalid_legacy_restore_target') }
+  }
+
+  return {}
+}

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -9,6 +9,7 @@
 import { z } from 'zod'
 import type { ClientExtensionEntry } from './extension-types.js'
 import type { ServerSettings } from './settings.js'
+import { LiveTerminalHandleSchema, SessionRefSchema } from './session-contract.js'
 
 // ──────────────────────────────────────────────────────────────
 // Shared enums and helpers
@@ -20,6 +21,7 @@ export const ErrorCode = z.enum([
   'UNKNOWN_MESSAGE',
   'INVALID_TERMINAL_ID',
   'INVALID_SESSION_ID',
+  'RESTORE_UNAVAILABLE',
   'PTY_SPAWN_FAILED',
   'FILE_WATCHER_ERROR',
   'INTERNAL_ERROR',
@@ -38,10 +40,8 @@ export const CodingCliProviderSchema = z.string().min(1)
 
 export type CodingCliProviderName = z.infer<typeof CodingCliProviderSchema>
 
-export const SessionLocatorSchema = z.object({
+export const SessionLocatorSchema = SessionRefSchema.extend({
   provider: CodingCliProviderSchema,
-  sessionId: z.string().min(1),
-  serverInstanceId: z.string().min(1).optional(),
 })
 
 export type SessionLocator = z.infer<typeof SessionLocatorSchema>
@@ -207,11 +207,12 @@ export const TerminalCreateSchema = z.object({
   mode: z.string().default('shell'),
   shell: ShellSchema.default('system'),
   cwd: z.string().optional(),
-  resumeSessionId: z.string().optional(),
+  sessionRef: SessionLocatorSchema.optional(),
+  liveTerminal: LiveTerminalHandleSchema.optional(),
   restore: z.boolean().optional(),
   tabId: z.string().min(1).optional(),
   paneId: z.string().min(1).optional(),
-})
+}).strict()
 
 export const TerminalAttachSchema = z.object({
   type: z.literal('terminal.attach'),
@@ -455,7 +456,6 @@ export type TerminalCreatedMessage = {
   requestId: string
   terminalId: string
   createdAt: number
-  effectiveResumeSessionId?: string
 }
 
 export type TerminalAttachReadyMessage = {
@@ -505,7 +505,7 @@ export type TerminalTitleUpdatedMessage = {
 export type TerminalSessionAssociatedMessage = {
   type: 'terminal.session.associated'
   terminalId: string
-  sessionId: string
+  sessionRef: SessionLocator
 }
 
 export type TerminalsChangedMessage = {
@@ -720,7 +720,7 @@ export type TerminalInventoryMessage = {
     title: string
     description?: string
     mode: string
-    resumeSessionId?: string
+    sessionRef?: SessionLocator
     createdAt: number
     lastActivityAt: number
     status: 'running' | 'exited'

--- a/src/components/BackgroundSessions.tsx
+++ b/src/components/BackgroundSessions.tsx
@@ -7,18 +7,7 @@ import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { addTab } from '@/store/tabsSlice'
 import { initLayout } from '@/store/panesSlice'
 import { fetchTerminalDirectoryWindow } from '@/store/terminalDirectoryThunks'
-
-type BackgroundTerminal = {
-  terminalId: string
-  title: string
-  createdAt: number
-  lastActivityAt: number
-  cwd?: string
-  status: 'running' | 'exited'
-  hasClients: boolean
-  mode?: string
-  resumeSessionId?: string
-}
+import type { BackgroundTerminal } from '@/store/types'
 
 const EMPTY_TERMINALS: BackgroundTerminal[] = []
 
@@ -101,8 +90,23 @@ export default function BackgroundSessions() {
                     onClick={() => {
                       const tabId = nanoid()
                       const mode = ((t.mode as any) || 'shell') as string
-                      dispatch(addTab({ id: tabId, title: t.title, status: 'running', mode: mode as any, resumeSessionId: t.resumeSessionId }))
-                      dispatch(initLayout({ tabId, content: { kind: 'terminal', mode: mode as any, terminalId: t.terminalId, status: 'running', resumeSessionId: t.resumeSessionId } }))
+                      dispatch(addTab({
+                        id: tabId,
+                        title: t.title,
+                        status: 'running',
+                        mode: mode as any,
+                        sessionRef: t.sessionRef,
+                      }))
+                      dispatch(initLayout({
+                        tabId,
+                        content: {
+                          kind: 'terminal',
+                          mode: mode as any,
+                          terminalId: t.terminalId,
+                          status: 'running',
+                          sessionRef: t.sessionRef,
+                        },
+                      }))
                     }}
                   >
                     Attach

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,6 +30,15 @@ const EMPTY_OPENCODE_ACTIVITY_BY_ID = {}
 const EMPTY_AGENT_CHAT_SESSIONS: Record<string, ChatSessionState> = {}
 const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecord> = {}
 
+function sameSessionRef(
+  a?: BackgroundTerminal['sessionRef'],
+  b?: BackgroundTerminal['sessionRef'],
+): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  return a.provider === b.provider && a.sessionId === b.sessionId
+}
+
 /** Compare two BackgroundTerminal arrays by sidebar-relevant fields only.
  *  Ignores terminal `lastActivityAt` since it changes frequently but doesn't affect rendering. */
 export function areTerminalsEqual(a: BackgroundTerminal[], b: BackgroundTerminal[]): boolean {
@@ -44,7 +53,7 @@ export function areTerminalsEqual(a: BackgroundTerminal[], b: BackgroundTerminal
       ai.status !== bi.status ||
       ai.hasClients !== bi.hasClients ||
       ai.mode !== bi.mode ||
-      ai.resumeSessionId !== bi.resumeSessionId
+      !sameSessionRef(ai.sessionRef, bi.sessionRef)
     ) return false
   }
   return true

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -187,7 +187,7 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
           shell: tab.shell,
           createRequestId: tab.createRequestId,
           status: tab.status,
-          resumeSessionId: tab.resumeSessionId,
+          sessionRef: tab.sessionRef,
           initialCwd: tab.initialCwd,
         },
       }]

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -36,11 +36,13 @@ export default function TabContent({ tabId, hidden }: TabContentProps) {
   // Build default content based on setting
   let defaultContent: PaneContentInput
   const resumeSessionType = getTabResumeSessionType(tab)
+  const tabSessionId = tab.sessionRef?.sessionId
+  const tabSessionRef = tab.sessionRef
 
-  if (tab.resumeSessionId && resumeSessionType) {
+  if (tabSessionId && resumeSessionType) {
     defaultContent = buildResumeContent({
       sessionType: resumeSessionType,
-      sessionId: tab.resumeSessionId,
+      sessionId: tabSessionId,
       cwd: tab.initialCwd,
     })
   } else if (tab.mode !== 'shell') {
@@ -48,7 +50,7 @@ export default function TabContent({ tabId, hidden }: TabContentProps) {
       kind: 'terminal',
       mode: tab.mode,
       shell: tab.shell,
-      resumeSessionId: tab.resumeSessionId,
+      sessionRef: tabSessionRef,
       initialCwd: tab.initialCwd,
     }
   } else if (defaultNewPane === 'ask') {
@@ -70,7 +72,7 @@ export default function TabContent({ tabId, hidden }: TabContentProps) {
       kind: 'terminal',
       mode: tab.mode,
       shell: tab.shell,
-      resumeSessionId: tab.resumeSessionId,
+      sessionRef: tabSessionRef,
       initialCwd: tab.initialCwd,
     }
   }

--- a/src/components/TabsView.tsx
+++ b/src/components/TabsView.tsx
@@ -51,7 +51,7 @@ type DeviceGroupData = {
 
 function parseSessionLocator(value: unknown): SessionLocator | undefined {
   if (!value || typeof value !== 'object') return undefined
-  const candidate = value as { provider?: unknown; sessionId?: unknown; serverInstanceId?: unknown }
+  const candidate = value as { provider?: unknown; sessionId?: unknown }
   if (typeof candidate.provider !== 'string' || !isNonShellMode(candidate.provider)) {
     return undefined
   }
@@ -59,7 +59,6 @@ function parseSessionLocator(value: unknown): SessionLocator | undefined {
   return {
     provider: candidate.provider as CodingCliProviderName,
     sessionId: candidate.sessionId,
-    ...(typeof candidate.serverInstanceId === 'string' ? { serverInstanceId: candidate.serverInstanceId } : {}),
   }
 }
 
@@ -67,7 +66,6 @@ function resolveSessionRef(options: {
   payload: Record<string, unknown>
   fallbackProvider?: CodingCliProviderName
   fallbackSessionId?: string
-  fallbackServerInstanceId?: string
 }): SessionLocator | undefined {
   const explicit = parseSessionLocator(options.payload.sessionRef)
   if (explicit) return explicit
@@ -75,7 +73,24 @@ function resolveSessionRef(options: {
   return {
     provider: options.fallbackProvider,
     sessionId: options.fallbackSessionId,
-    ...(options.fallbackServerInstanceId ? { serverInstanceId: options.fallbackServerInstanceId } : {}),
+  }
+}
+
+function parseLiveTerminalHandle(
+  value: unknown,
+  recordServerInstanceId: string,
+): { terminalId: string; serverInstanceId: string } | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const candidate = value as { terminalId?: unknown; serverInstanceId?: unknown }
+  if (typeof candidate.terminalId !== 'string' || typeof candidate.serverInstanceId !== 'string') {
+    return undefined
+  }
+  if (candidate.serverInstanceId !== recordServerInstanceId) {
+    return undefined
+  }
+  return {
+    terminalId: candidate.terminalId,
+    serverInstanceId: candidate.serverInstanceId,
   }
 }
 
@@ -88,19 +103,15 @@ function sanitizePaneSnapshot(
   const sameServer = !!localServerInstanceId && record.serverInstanceId === localServerInstanceId
   if (snapshot.kind === 'terminal') {
     const mode = (payload.mode as TabMode) || 'shell'
-    const resumeSessionId = payload.resumeSessionId as string | undefined
-    const sessionRef = resolveSessionRef({
-      payload,
-      fallbackProvider: mode !== 'shell' ? mode : undefined,
-      fallbackSessionId: resumeSessionId,
-      fallbackServerInstanceId: record.serverInstanceId,
-    })
+    const sessionRef = resolveSessionRef({ payload })
+    const liveTerminal = parseLiveTerminalHandle(payload.liveTerminal, record.serverInstanceId)
     return {
       kind: 'terminal',
       mode,
       shell: (payload.shell as 'system' | 'cmd' | 'powershell' | 'wsl') || 'system',
-      resumeSessionId: sameServer ? resumeSessionId : undefined,
       sessionRef,
+      terminalId: sameServer ? liveTerminal?.terminalId : undefined,
+      serverInstanceId: record.serverInstanceId,
       initialCwd: payload.initialCwd as string | undefined,
     }
   }
@@ -122,18 +133,13 @@ function sanitizePaneSnapshot(
     }
   }
   if (snapshot.kind === 'agent-chat') {
-    const resumeSessionId = payload.resumeSessionId as string | undefined
-    const sessionRef = resolveSessionRef({
-      payload,
-      fallbackProvider: 'claude',
-      fallbackSessionId: resumeSessionId,
-      fallbackServerInstanceId: record.serverInstanceId,
-    })
+    const sessionRef = resolveSessionRef({ payload })
     return {
       kind: 'agent-chat',
       provider: ((payload.provider as string | undefined) || 'freshclaude') as AgentChatProviderName,
-      resumeSessionId: sameServer ? resumeSessionId : undefined,
+      sessionId: sameServer && typeof payload.sessionId === 'string' ? payload.sessionId : undefined,
       sessionRef,
+      serverInstanceId: record.serverInstanceId,
       initialCwd: payload.initialCwd as string | undefined,
       model: payload.model as string | undefined,
       permissionMode: payload.permissionMode as string | undefined,
@@ -553,6 +559,7 @@ function TabsView({ onOpenTab }: { onOpenTab?: () => void }) {
         title: record.tabName,
         mode: deriveModeFromRecord(record),
         status: 'creating',
+        serverInstanceId: record.serverInstanceId,
       }),
     )
     dispatch(initLayout({ tabId, content: firstContent }))
@@ -570,6 +577,7 @@ function TabsView({ onOpenTab }: { onOpenTab?: () => void }) {
         title: `${record.tabName} · ${pane.title || pane.kind}`,
         mode: deriveModeFromRecord(record),
         status: 'creating',
+        serverInstanceId: record.serverInstanceId,
       }),
     )
     dispatch(

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -19,10 +19,10 @@ import { clearPaneRuntimeActivity, setPaneRuntimeActivity } from '@/store/paneRu
 import { recordTurnComplete, clearTabAttention, clearPaneAttention } from '@/store/turnCompletionSlice'
 import { focusNextTerminalSearchMatch, focusPreviousTerminalSearchMatch, loadTerminalSearch } from '@/store/terminalDirectoryThunks'
 import { isFatalConnectionErrorCode } from '@/store/connectionSlice'
-import { buildDurableResumeIdentityUpdate, flushPersistedLayoutNow } from '@/store/persistControl'
+import { buildTerminalDurableSessionRefUpdate, flushPersistedLayoutNow } from '@/store/persistControl'
 import { getWsClient } from '@/lib/ws-client'
 import { getTerminalTheme } from '@/lib/terminal-themes'
-import { getResumeSessionIdFromRef } from '@/components/terminal-view-utils'
+import { getCreateSessionStateFromRef } from '@/components/terminal-view-utils'
 import { copyText, readText } from '@/lib/clipboard'
 import { registerTerminalActions } from '@/lib/pane-action-registry'
 import { registerTerminalCaptureHandler } from '@/lib/screenshot-capture-env'
@@ -87,6 +87,7 @@ import {
   scrollLinesToCursorKeys,
   shouldTranslateScrollToCursorKeys,
 } from '@/lib/terminal-behavior'
+import { buildRestoreError } from '@shared/session-contract'
 
 const log = createLogger('TerminalView')
 
@@ -290,7 +291,6 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
   const tabOrder = useAppSelector((s) => s.tabs.tabs.map((t) => t.id), shallowEqual)
   const activePaneId = useAppSelector((s) => s.panes.activePane[tabId])
   const refreshRequest = useAppSelector((s) => s.panes.refreshRequestsByPane?.[tabId]?.[paneId] ?? null)
-  const localServerInstanceId = useAppSelector((s) => s.connection.serverInstanceId)
   const connectionErrorCode = useAppSelector((s) => s.connection.lastErrorCode)
   const settings = useAppSelector((s) => s.settings.settings)
   const hasAttention = useAppSelector((s) => !!s.turnCompletion?.attentionByTab?.[tabId])
@@ -1767,7 +1767,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
 
     const sendCreate = (requestId: string) => {
       const restore = getRestoreFlag(requestId)
-      const resumeId = getResumeSessionIdFromRef(contentRef)
+      const createSessionState = getCreateSessionStateFromRef(contentRef)
       launchAttemptRef.current = {
         requestId,
         restore,
@@ -1779,7 +1779,8 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       if (debugRef.current) log.debug('[TRACE resumeSessionId] sendCreate', {
         paneId: paneIdRef.current,
         requestId,
-        resumeSessionId: resumeId,
+        sessionRef: createSessionState.sessionRef,
+        liveTerminal: createSessionState.liveTerminal,
         contentRefResumeSessionId: contentRef.current?.resumeSessionId,
         mode,
       })
@@ -1789,7 +1790,8 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
         mode,
         shell: shell || 'system',
         cwd: initialCwd,
-        resumeSessionId: resumeId,
+        ...(createSessionState.sessionRef ? { sessionRef: createSessionState.sessionRef } : {}),
+        ...(createSessionState.liveTerminal ? { liveTerminal: createSessionState.liveTerminal } : {}),
         tabId,
         paneId: paneIdRef.current,
         ...(restore ? { restore: true } : {}),
@@ -2046,9 +2048,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             paneId: paneIdRef.current,
             requestId: reqId,
             terminalId: newId,
-            effectiveResumeSessionId: msg.effectiveResumeSessionId,
             currentResumeSessionId: contentRef.current?.resumeSessionId,
-            willUpdate: !!(msg.effectiveResumeSessionId && msg.effectiveResumeSessionId !== contentRef.current?.resumeSessionId),
           })
           terminalIdRef.current = newId
           updateContent({ terminalId: newId, status: 'running' })
@@ -2056,20 +2056,6 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           const currentTab = tabRef.current
           if (currentTab) {
             dispatch(updateTab({ id: currentTab.id, updates: { status: 'running' } }))
-          }
-          const durableIdentityUpdate = buildDurableResumeIdentityUpdate({
-            paneResumeSessionId: contentRef.current?.resumeSessionId,
-            tabResumeSessionId: currentTab?.resumeSessionId,
-            sessionId: msg.effectiveResumeSessionId,
-          })
-          if (durableIdentityUpdate?.paneUpdates) {
-            updateContent(durableIdentityUpdate.paneUpdates)
-          }
-          if (currentTab && durableIdentityUpdate?.tabUpdates) {
-            dispatch(updateTab({ id: currentTab.id, updates: durableIdentityUpdate.tabUpdates }))
-          }
-          if (durableIdentityUpdate?.shouldFlush) {
-            dispatch(flushPersistedLayoutNow())
           }
 
           applySeqState(createAttachSeqState({ lastSeq: 0 }))
@@ -2138,35 +2124,29 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           dispatch(updatePaneTitle({ tabId, paneId: paneIdRef.current, title: msg.title, setByUser: false }))
         }
 
-        // Handle one-time session association (when Claude creates a new session)
-        // Message type: { type: 'terminal.session.associated', terminalId: string, sessionId: string }
+        // Handle one-time session association from the authoritative canonical sessionRef.
         if (msg.type === 'terminal.session.associated' && msg.terminalId === tid) {
-          const sessionId = msg.sessionId as string
+          const sessionRef = msg.sessionRef
+          if (!sessionRef?.provider || !sessionRef?.sessionId) {
+            return
+          }
           if (debugRef.current) log.debug('[TRACE resumeSessionId] terminal.session.associated', {
             paneId: paneIdRef.current,
             terminalId: tid,
             oldResumeSessionId: contentRef.current?.resumeSessionId,
-            newResumeSessionId: sessionId,
+            sessionRef,
           })
-          const mode = contentRef.current?.mode
-          const sessionRef = mode && mode !== 'shell'
-            ? {
-              provider: mode,
-              sessionId,
-              ...(localServerInstanceId ? { serverInstanceId: localServerInstanceId } : {}),
-            }
-            : undefined
           const currentTab = tabRef.current
-          const durableIdentityUpdate = buildDurableResumeIdentityUpdate({
+          const durableIdentityUpdate = buildTerminalDurableSessionRefUpdate({
+            provider: sessionRef.provider,
+            sessionId: sessionRef.sessionId,
+            paneSessionRef: contentRef.current?.sessionRef,
+            tabSessionRef: currentTab?.sessionRef,
             paneResumeSessionId: contentRef.current?.resumeSessionId,
             tabResumeSessionId: currentTab?.resumeSessionId,
-            sessionId,
           })
-          if (durableIdentityUpdate?.paneUpdates || sessionRef) {
-            updateContent({
-              ...(durableIdentityUpdate?.paneUpdates ?? {}),
-              ...(sessionRef ? { sessionRef } : {}),
-            })
+          if (durableIdentityUpdate?.paneUpdates) {
+            updateContent(durableIdentityUpdate.paneUpdates)
           }
           if (currentTab && durableIdentityUpdate?.tabUpdates) {
             dispatch(updateTab({ id: currentTab.id, updates: durableIdentityUpdate.tabUpdates }))
@@ -2235,6 +2215,23 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           // This prevents an infinite respawn loop when terminals fail immediately
           // (e.g., due to permission errors on cwd). User must explicitly restart.
           if (currentTerminalId && current?.status !== 'exited') {
+            if (!current?.sessionRef) {
+              term.writeln('\r\n[Restore unavailable - the live terminal is gone and no durable session identity was saved]\r\n')
+              launchAttemptRef.current = null
+              clearRateLimitRetry()
+              setIsAttaching(false)
+              dispatch(clearPaneRuntimeActivity({ paneId: paneIdRef.current }))
+              updateContent({
+                terminalId: undefined,
+                status: 'error',
+                restoreError: buildRestoreError('dead_live_handle'),
+              })
+              const currentTab = tabRef.current
+              if (currentTab) {
+                dispatch(updateTab({ id: currentTab.id, updates: { status: 'error' } }))
+              }
+              return
+            }
             term.writeln('\r\n[Reconnecting...]\r\n')
             const newRequestId = nanoid()
             if (debugRef.current) log.debug('[TRACE resumeSessionId] INVALID_TERMINAL_ID reconnecting', {

--- a/src/components/agent-chat/AgentChatView.tsx
+++ b/src/components/agent-chat/AgentChatView.tsx
@@ -11,6 +11,7 @@ import {
   registerPendingCreate,
   removePermission,
   removeQuestion,
+  sessionError,
 } from '@/store/agentChatSlice'
 import { loadAgentTimelineWindow, loadAgentTurnBody } from '@/store/agentChatThunks'
 import { getWsClient } from '@/lib/ws-client'
@@ -36,8 +37,8 @@ import {
   buildAgentChatPersistedIdentityUpdate,
   flushPersistedLayoutNow,
   getCanonicalDurableSessionId,
-  getPreferredResumeSessionId,
 } from '@/store/persistControl'
+import { buildRestoreError, type RestoreError } from '@shared/session-contract'
 
 /** Early lifecycle states that should not be re-entered once the session has advanced. */
 const EARLY_STATES = new Set(['creating', 'starting'])
@@ -49,6 +50,23 @@ const EARLY_STATES = new Set(['creating', 'starting'])
  */
 function isStatusRegression(current: string, next: string): boolean {
   return !EARLY_STATES.has(current) && EARLY_STATES.has(next)
+}
+
+function getRestoreFailureMessage(restoreError: RestoreError): string {
+  switch (restoreError.reason) {
+    case 'dead_live_handle':
+      return 'The live session is gone and no canonical Claude restore identity was saved.'
+    case 'invalid_legacy_restore_target':
+      return 'This saved session used a legacy restore token that cannot be replayed safely.'
+    case 'missing_canonical_identity':
+      return 'No canonical Claude restore identity is available for this session.'
+    case 'provider_runtime_failed':
+      return 'The provider runtime failed before restore could complete.'
+    case 'durable_artifact_missing':
+      return 'The provider did not produce a durable restore artifact for this session.'
+    default:
+      return 'This session can no longer be restored.'
+  }
 }
 
 interface AgentChatViewProps {
@@ -106,18 +124,15 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
   const surfaceVisibleMarkedRef = useRef(false)
   const sessionRef = useRef(session)
   sessionRef.current = session
-  const persistedTimelineSessionId = isValidClaudeSessionId(paneContent.resumeSessionId)
-    ? paneContent.resumeSessionId
-    : undefined
+  const persistedTimelineSessionId = (
+    paneContent.sessionRef?.provider === 'claude'
+    && isValidClaudeSessionId(paneContent.sessionRef.sessionId)
+  )
+    ? paneContent.sessionRef.sessionId
+    : (isValidClaudeSessionId(paneContent.resumeSessionId) ? paneContent.resumeSessionId : undefined)
   const canonicalDurableSessionId = getCanonicalDurableSessionId(session) ?? persistedTimelineSessionId
-  const timelineSessionId = getPreferredResumeSessionId(session) ?? persistedTimelineSessionId
-  const restoreHistoryQueryId = timelineSessionId ?? paneContent.sessionId
-  const attachResumeSessionId = getPreferredResumeSessionId(session)
-    ?? (
-      typeof paneContent.resumeSessionId === 'string' && paneContent.resumeSessionId.trim().length > 0
-        ? paneContent.resumeSessionId
-        : undefined
-    )
+  const restoreHistoryQueryId = canonicalDurableSessionId ?? paneContent.sessionId
+  const attachResumeSessionId = canonicalDurableSessionId
   const attachPayload = useMemo(() => {
     if (!paneContent.sessionId) return null
     return {
@@ -150,18 +165,53 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
   // Shared recovery logic: clears stale sessionId and resets to 'creating' so a new
   // SDK session is spawned. Preserves resumeSessionId for CLI session continuity.
   const triggerRecovery = useCallback(() => {
+    const deadSessionId = paneContentRef.current.sessionId
+    const durableResumeSessionId = getCanonicalDurableSessionId(sessionRef.current)
+      ?? (
+        paneContentRef.current.sessionRef?.provider === 'claude'
+        && isValidClaudeSessionId(paneContentRef.current.sessionRef.sessionId)
+          ? paneContentRef.current.sessionRef.sessionId
+          : (isValidClaudeSessionId(paneContentRef.current.resumeSessionId) ? paneContentRef.current.resumeSessionId : undefined)
+      )
+    if (!durableResumeSessionId) {
+      const restoreError = buildRestoreError('dead_live_handle')
+      if (deadSessionId) {
+        dispatch(sessionError({
+          sessionId: deadSessionId,
+          code: 'RESTORE_UNAVAILABLE',
+          message: getRestoreFailureMessage(restoreError),
+        }))
+      }
+      dispatch(updatePaneContent({
+        tabId,
+        paneId,
+        content: {
+          ...paneContentRef.current,
+          sessionId: undefined,
+          status: 'idle' as const,
+          restoreError,
+        },
+      }))
+      createSentRef.current = false
+      attachSentRef.current = false
+      return
+    }
+
     const newRequestId = nanoid()
-    const resumeSessionId = getPreferredResumeSessionId(sessionRef.current)
-      ?? paneContentRef.current.resumeSessionId
     dispatch(updatePaneContent({
       tabId,
       paneId,
       content: {
         ...paneContentRef.current,
         sessionId: undefined,
-        resumeSessionId,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: durableResumeSessionId,
+        },
+        resumeSessionId: undefined,
         createRequestId: newRequestId,
         status: 'creating' as const,
+        restoreError: undefined,
       },
     }))
     createSentRef.current = false
@@ -267,7 +317,7 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
     dispatch(updatePaneContent({
       tabId,
       paneId,
-      content: { ...paneContentRef.current, sessionId: pendingSessionId, status: 'starting' },
+      content: { ...paneContentRef.current, sessionId: pendingSessionId, status: 'starting', restoreError: undefined },
     }))
     dispatch(clearPendingCreate({ requestId: paneContent.createRequestId }))
   }, [pendingSessionId, paneContent.sessionId, paneContent.createRequestId, tabId, paneId, dispatch])
@@ -352,21 +402,20 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
   const taggedSessionRef = useRef<string | null>(null)
   useEffect(() => {
     if (suppressNetworkEffects) return
-    const preferredResumeSessionId = getPreferredResumeSessionId(session)
-    if (!preferredResumeSessionId) return
-    if (taggedSessionRef.current === preferredResumeSessionId) return
-    taggedSessionRef.current = preferredResumeSessionId
+    if (!canonicalDurableSessionId) return
+    if (taggedSessionRef.current === canonicalDurableSessionId) return
+    taggedSessionRef.current = canonicalDurableSessionId
 
     if (providerConfig?.codingCliProvider) {
       setSessionMetadata(
         providerConfig.codingCliProvider,
-        preferredResumeSessionId,
+        canonicalDurableSessionId,
         paneContent.provider,
       ).catch((err) => {
         console.warn('Failed to tag session metadata:', err)
       })
     }
-  }, [paneContent.provider, providerConfig?.codingCliProvider, session?.cliSessionId, session?.timelineSessionId, suppressNetworkEffects])
+  }, [canonicalDurableSessionId, paneContent.provider, providerConfig?.codingCliProvider, suppressNetworkEffects])
 
   // Reset createSentRef when createRequestId changes
   const prevCreateRequestIdRef = useRef(paneContent.createRequestId)
@@ -380,11 +429,12 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
     if (suppressNetworkEffects) return
     if (paneContent.sessionId || createSentRef.current) return
     if (paneContent.status !== 'creating') return
+    if (paneContent.restoreError) return
 
     createSentRef.current = true
     dispatch(registerPendingCreate({
       requestId: paneContent.createRequestId,
-      expectsHistoryHydration: Boolean(paneContent.resumeSessionId),
+      expectsHistoryHydration: Boolean(canonicalDurableSessionId || paneContent.resumeSessionId),
     }))
     ws.send({
       type: 'sdk.create',
@@ -393,7 +443,9 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
       permissionMode: paneContent.permissionMode ?? defaultPermissionMode,
       effort: paneContent.effort ?? defaultEffort,
       ...(paneContent.initialCwd ? { cwd: paneContent.initialCwd } : {}),
-      ...(paneContent.resumeSessionId ? { resumeSessionId: paneContent.resumeSessionId } : {}),
+      ...((canonicalDurableSessionId ?? paneContent.resumeSessionId)
+        ? { resumeSessionId: canonicalDurableSessionId ?? paneContent.resumeSessionId }
+        : {}),
       ...(paneContent.plugins ? { plugins: paneContent.plugins } : {}),
     })
 
@@ -742,6 +794,13 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
         {isRestoring && (
           <div className="text-center text-muted-foreground text-sm py-6">
             <p>Restoring session...</p>
+          </div>
+        )}
+
+        {!paneContent.sessionId && paneContent.restoreError && (
+          <div className="rounded-lg border border-red-300/60 bg-red-500/10 px-4 py-4 text-sm" role="alert">
+            <p className="font-medium text-red-700 dark:text-red-300">Session restore failed</p>
+            <p className="mt-1 text-red-700/90 dark:text-red-200">{getRestoreFailureMessage(paneContent.restoreError)}</p>
           </div>
         )}
 

--- a/src/components/context-menu/menu-defs.ts
+++ b/src/components/context-menu/menu-defs.ts
@@ -107,11 +107,17 @@ function getTabProvider(tab?: Tab): string | undefined {
   return tab.codingCliProvider || (tab.mode !== 'shell' ? tab.mode : undefined)
 }
 
+function getTabSessionId(tab?: Tab): string | undefined {
+  return tab?.sessionRef?.sessionId ?? tab?.resumeSessionId
+}
+
 function getResumeCandidateForTerminalContent(content: PaneContent, tab?: Tab, extensions?: ClientExtensionEntry[]): ResumeCommandCandidate | null {
   if (content.kind !== 'terminal') return null
   if (!isResumeCommandProvider(content.mode, extensions)) return null
   const tabProvider = getTabProvider(tab)
-  const sessionId = content.resumeSessionId || (tabProvider === content.mode ? tab?.resumeSessionId : undefined)
+  const sessionId = content.sessionRef?.sessionId
+    || content.resumeSessionId
+    || (tabProvider === content.mode ? getTabSessionId(tab) : undefined)
   return {
     provider: content.mode,
     sessionId,
@@ -123,7 +129,7 @@ function getResumeCandidateForLegacyTab(tab?: Tab, extensions?: ClientExtensionE
   if (!isResumeCommandProvider(provider, extensions)) return null
   return {
     provider,
-    sessionId: tab?.resumeSessionId,
+    sessionId: getTabSessionId(tab),
   }
 }
 

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -44,6 +44,7 @@ import { ErrorBoundary } from '@/components/ui/error-boundary'
 import { applyPaneRename } from '@/store/titleSync'
 import { saveServerSettingsPatch } from '@/store/settingsThunks'
 import { getPreferredResumeSessionId } from '@/store/persistControl'
+import type { SessionLocator } from '@shared/ws-protocol'
 
 // Stable empty object to avoid selector memoization issues
 const EMPTY_PANE_TITLES: Record<string, string> = {}
@@ -74,8 +75,8 @@ function resolvePaneRuntimeMeta(
   options: {
     terminalId?: string
     isOnlyPane: boolean
+    sessionRef?: SessionLocator
     provider?: CodingCliProviderName
-    resumeSessionId?: string
     initialCwd?: string
   },
 ): TerminalMetaRecord | undefined {
@@ -84,9 +85,10 @@ function resolvePaneRuntimeMeta(
     if (byTerminalId) return byTerminalId
   }
 
-  if (options.resumeSessionId && options.provider) {
+  const sessionRef = options.sessionRef
+  if (sessionRef && sessionRef.provider && sessionRef.sessionId) {
     return Object.values(terminalMetaById).find((record) => (
-      record.provider === options.provider && record.sessionId === options.resumeSessionId
+      record.provider === sessionRef.provider && record.sessionId === sessionRef.sessionId
     ))
   }
 
@@ -386,9 +388,16 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
               : (tab?.mode !== 'shell' ? tab?.mode : undefined)
           )
         : undefined
-    const paneResumeSessionId =
+    const paneSessionRef =
       node.content.kind === 'terminal'
-        ? (node.content.resumeSessionId || tab?.resumeSessionId)
+        ? (
+            node.content.sessionRef
+            ?? (paneProvider && tab?.sessionRef?.provider === paneProvider
+              ? tab.sessionRef
+              : (paneProvider && tab?.resumeSessionId
+                ? { provider: paneProvider, sessionId: tab.resumeSessionId }
+                : undefined))
+          )
         : undefined
     const paneInitialCwd =
       node.content.kind === 'terminal'
@@ -399,8 +408,8 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
         ? resolvePaneRuntimeMeta(terminalMetaById, {
           terminalId: node.content.terminalId,
           isOnlyPane,
+          sessionRef: paneSessionRef,
           provider: paneProvider,
-          resumeSessionId: paneResumeSessionId,
           initialCwd: paneInitialCwd,
         })
         : node.content.kind === 'agent-chat'

--- a/src/components/terminal-view-utils.ts
+++ b/src/components/terminal-view-utils.ts
@@ -5,3 +5,26 @@ export type TerminalContentRef = { current: TerminalPaneContent | null }
 export function getResumeSessionIdFromRef(ref: TerminalContentRef): string | undefined {
   return ref.current?.resumeSessionId
 }
+
+export function getCreateSessionStateFromRef(ref: TerminalContentRef): {
+  sessionRef?: TerminalPaneContent['sessionRef']
+  liveTerminal?: {
+    terminalId: string
+    serverInstanceId: string
+  }
+} {
+  const sessionRef = ref.current?.sessionRef
+  const terminalId = ref.current?.terminalId
+  const serverInstanceId = ref.current?.serverInstanceId
+  return {
+    ...(sessionRef ? { sessionRef } : {}),
+    ...(terminalId && serverInstanceId
+      ? {
+          liveTerminal: {
+            terminalId,
+            serverInstanceId,
+          },
+        }
+      : {}),
+  }
+}

--- a/src/lib/pane-activity.ts
+++ b/src/lib/pane-activity.ts
@@ -69,12 +69,17 @@ function isAgentChatBusy(
 
 function resolveTerminalSessionKey(
   content: TerminalPaneContent,
+  fallbackSessionRef?: Tab['sessionRef'],
   fallbackSessionId?: string,
   fallbackMode?: Tab['mode'],
 ): string | undefined {
   const explicit = content.sessionRef
   if (explicit?.provider && explicit.sessionId) {
     return `${explicit.provider}:${explicit.sessionId}`
+  }
+
+  if (fallbackSessionRef?.provider && fallbackSessionRef.sessionId) {
+    return `${fallbackSessionRef.provider}:${fallbackSessionRef.sessionId}`
   }
 
   const provider = content.mode !== 'shell' ? content.mode : fallbackMode
@@ -95,6 +100,7 @@ function buildSyntheticTerminalContent(tab: Tab): TerminalPaneContent | null {
     status: tab.status,
     mode: tab.mode,
     shell: tab.shell,
+    sessionRef: tab.sessionRef,
     resumeSessionId: tab.resumeSessionId,
     initialCwd: tab.initialCwd,
   }
@@ -234,7 +240,7 @@ export function collectBusySessionKeys(input: {
       }).isBusy
       if (!busy) continue
 
-      const sessionKey = resolveTerminalSessionKey(syntheticContent, tab.resumeSessionId, tab.mode)
+      const sessionKey = resolveTerminalSessionKey(syntheticContent, tab.sessionRef, tab.resumeSessionId, tab.mode)
       if (sessionKey) busySessionKeys.add(sessionKey)
       continue
     }
@@ -261,7 +267,7 @@ export function collectBusySessionKeys(input: {
             : undefined,
         )
         : entry.content.kind === 'terminal'
-          ? resolveTerminalSessionKey(entry.content, tab.resumeSessionId, tab.mode)
+          ? resolveTerminalSessionKey(entry.content, tab.sessionRef, tab.resumeSessionId, tab.mode)
           : undefined
       if (sessionKey) busySessionKeys.add(sessionKey)
     }

--- a/src/lib/session-metadata.ts
+++ b/src/lib/session-metadata.ts
@@ -58,9 +58,9 @@ export function getSessionMetadata(
   return source?.sessionMetadataByKey?.[sessionMetadataKey(provider, sessionId)]
 }
 
-export function getTabResumeSessionType(tab: Pick<Tab, 'mode' | 'codingCliProvider' | 'resumeSessionId' | 'sessionMetadataByKey'>): string | undefined {
-  const provider = tab.codingCliProvider || (tab.mode !== 'shell' ? tab.mode : undefined)
-  const sessionId = tab.resumeSessionId
+export function getTabResumeSessionType(tab: Pick<Tab, 'mode' | 'codingCliProvider' | 'resumeSessionId' | 'sessionRef' | 'sessionMetadataByKey'>): string | undefined {
+  const provider = tab.sessionRef?.provider ?? tab.codingCliProvider ?? (tab.mode !== 'shell' ? tab.mode : undefined)
+  const sessionId = tab.sessionRef?.sessionId ?? tab.resumeSessionId
   if (!provider || !sessionId) return undefined
   return getSessionMetadata(tab, provider, sessionId)?.sessionType ?? provider
 }

--- a/src/lib/session-type-utils.ts
+++ b/src/lib/session-type-utils.ts
@@ -58,7 +58,10 @@ export function buildResumeContent(opts: {
     return {
       kind: 'agent-chat',
       provider: agentConfig.name as AgentChatProviderName,
-      resumeSessionId: opts.sessionId,
+      sessionRef: {
+        provider: agentConfig.codingCliProvider ?? 'claude',
+        sessionId: opts.sessionId,
+      },
       initialCwd: opts.cwd,
       model: ps?.defaultModel ?? agentConfig.defaultModel,
       permissionMode: ps?.defaultPermissionMode ?? agentConfig.defaultPermissionMode,
@@ -72,7 +75,10 @@ export function buildResumeContent(opts: {
   return {
     kind: 'terminal',
     mode: provider,
-    resumeSessionId: opts.sessionId,
+    sessionRef: {
+      provider,
+      sessionId: opts.sessionId,
+    },
     initialCwd: opts.cwd,
   }
 }

--- a/src/lib/session-utils.ts
+++ b/src/lib/session-utils.ts
@@ -3,16 +3,22 @@
  */
 
 import { isNonShellMode } from '@/lib/coding-cli-utils'
-import type { PaneContent, PaneNode, SessionLocator } from '@/store/paneTypes'
+import type { PaneContent, PaneNode } from '@/store/paneTypes'
 import type { RootState } from '@/store/store'
 import type { CodingCliProviderName } from '@/store/types'
 import { isValidClaudeSessionId } from '@/lib/claude-session-id'
 
-type SessionRef = Pick<SessionLocator, 'provider' | 'sessionId'>
+type SessionMatchLocator = {
+  provider: CodingCliProviderName
+  sessionId: string
+}
+type SessionRef = Pick<SessionMatchLocator, 'provider' | 'sessionId'>
 type SessionMatchCandidate = {
   tabId: string
   paneId: string | undefined
-  locator: SessionLocator
+  locator: SessionMatchLocator
+  serverInstanceIdHint?: string
+  hasLiveHandleHint?: boolean
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -20,16 +26,12 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 function isValidSessionRef(provider: string, sessionId: string): provider is CodingCliProviderName {
-  // Provider names are validated at creation time; here we just check it's a valid non-shell mode.
   if (!isNonShellMode(provider) || sessionId.length === 0) return false
-  // All non-empty session IDs are valid refs. Claude named resumes (non-UUID)
-  // are legitimate: the terminal was launched with --resume "<name>" and is
-  // waiting for the association coordinator to discover the real UUID.
   return true
 }
 
-function locatorIdentity(locator: SessionLocator): string {
-  return `${locator.provider}:${locator.sessionId}:${locator.serverInstanceId ?? ''}`
+function locatorIdentity(locator: SessionMatchLocator): string {
+  return `${locator.provider}:${locator.sessionId}`
 }
 
 function sessionKey(locator: SessionRef): string {
@@ -49,8 +51,8 @@ function dedupeBy<T>(values: T[], getKey: (value: T) => string): T[] {
 }
 
 export function sanitizeSessionLocator(
-  locator?: { provider?: unknown; sessionId?: unknown; serverInstanceId?: unknown } | null,
-): SessionLocator | undefined {
+  locator?: { provider?: unknown; sessionId?: unknown } | null,
+): SessionMatchLocator | undefined {
   if (!locator || !isNonEmptyString(locator.provider) || !isNonEmptyString(locator.sessionId)) {
     return undefined
   }
@@ -58,13 +60,12 @@ export function sanitizeSessionLocator(
   return {
     provider: locator.provider,
     sessionId: locator.sessionId,
-    ...(isNonEmptyString(locator.serverInstanceId) ? { serverInstanceId: locator.serverInstanceId } : {}),
   }
 }
 
 export function sanitizeSessionLocators(
-  locators: ReadonlyArray<{ provider?: unknown; sessionId?: unknown; serverInstanceId?: unknown } | null | undefined>,
-): SessionLocator[] {
+  locators: ReadonlyArray<{ provider?: unknown; sessionId?: unknown } | null | undefined>,
+): SessionMatchLocator[] {
   return dedupeBy(
     locators.flatMap((locator) => {
       const sanitized = sanitizeSessionLocator(locator)
@@ -77,26 +78,34 @@ export function sanitizeSessionLocators(
 function extractExplicitSessionLocator(content: PaneContent): {
   provider: CodingCliProviderName
   sessionId: string
-  serverInstanceId?: string
 } | undefined {
-  const explicit = (content as { sessionRef?: { provider?: unknown; sessionId?: unknown; serverInstanceId?: unknown } }).sessionRef
+  const explicit = (content as { sessionRef?: { provider?: unknown; sessionId?: unknown } }).sessionRef
   return sanitizeSessionLocator(explicit)
 }
 
-/**
- * Extract exact and intrinsic session locators from a single pane's content.
- * Explicit sessionRef preserves cross-device identity; resumeSessionId is kept as an
- * intrinsic local fallback for local-session matching before serverInstanceId is known.
- */
+function extractSessionLocatorServerInstanceHint(content: PaneContent): string | undefined {
+  return isNonEmptyString((content as { serverInstanceId?: unknown }).serverInstanceId)
+    ? (content as { serverInstanceId: string }).serverInstanceId
+    : undefined
+}
+
+function extractSessionLocatorLiveHandleHint(content: PaneContent): boolean {
+  if (content.kind === 'terminal') {
+    return isNonEmptyString(content.terminalId)
+  }
+  if (content.kind === 'agent-chat') {
+    return isNonEmptyString(content.sessionId)
+  }
+  return false
+}
+
 function extractSessionLocators(content: PaneContent): Array<{
   provider: CodingCliProviderName
   sessionId: string
-  serverInstanceId?: string
 }> {
   const locators: Array<{
     provider: CodingCliProviderName
     sessionId: string
-    serverInstanceId?: string
   }> = []
 
   const explicit = extractExplicitSessionLocator(content)
@@ -114,32 +123,50 @@ function extractSessionLocators(content: PaneContent): Array<{
   if (content.mode === 'shell') return dedupeBy(locators, locatorIdentity)
   if (!isNonShellMode(content.mode)) return dedupeBy(locators, locatorIdentity)
   const sessionId = content.resumeSessionId
-  if (!sessionId) return dedupeBy(locators, locatorIdentity)
+  if (!sessionId || content.mode !== 'claude' || !isValidClaudeSessionId(sessionId)) {
+    return dedupeBy(locators, locatorIdentity)
+  }
   locators.push({ provider: content.mode, sessionId })
   return dedupeBy(locators, locatorIdentity)
 }
 
-function buildTabFallbackLocator(tab: RootState['tabs']['tabs'][number]): SessionLocator | undefined {
+function buildTabFallbackLocator(tab: RootState['tabs']['tabs'][number]): SessionMatchLocator | undefined {
+  const explicitSessionRef = sanitizeSessionLocator(tab.sessionRef)
+  if (explicitSessionRef) {
+    return explicitSessionRef
+  }
   const provider = tab.codingCliProvider || (tab.mode !== 'shell' ? tab.mode : undefined)
   const sessionId = tab.resumeSessionId
-  if (!provider || !sessionId) return undefined
+  if (provider !== 'claude' || !sessionId || !isValidClaudeSessionId(sessionId)) return undefined
   return sanitizeSessionLocator({ provider, sessionId })
 }
 
+function buildTabFallbackServerInstanceHint(tab: RootState['tabs']['tabs'][number]): string | undefined {
+  return isNonEmptyString(tab.serverInstanceId) ? tab.serverInstanceId : undefined
+}
+
 function matchScore(
-  candidate: SessionLocator,
-  target: SessionLocator,
+  candidate: SessionMatchCandidate,
+  target: SessionMatchLocator,
   localServerInstanceId?: string,
 ): number {
-  if (candidate.provider !== target.provider || candidate.sessionId !== target.sessionId) return 0
-  if (target.serverInstanceId) {
-    if (candidate.serverInstanceId === target.serverInstanceId) return 3
-    if (target.serverInstanceId === localServerInstanceId && candidate.serverInstanceId == null) return 2
+  if (candidate.locator.provider !== target.provider || candidate.locator.sessionId !== target.sessionId) {
     return 0
   }
-  if (candidate.serverInstanceId === localServerInstanceId) return 3
-  if (candidate.serverInstanceId == null) return 2
-  return 0
+  if (
+    localServerInstanceId
+    && candidate.serverInstanceIdHint
+    && candidate.serverInstanceIdHint !== localServerInstanceId
+  ) {
+    return 0
+  }
+  if (localServerInstanceId && candidate.serverInstanceIdHint === localServerInstanceId) {
+    return 3
+  }
+  if (localServerInstanceId && candidate.hasLiveHandleHint) {
+    return 2
+  }
+  return 1
 }
 
 function collectPaneSessionMatchCandidates(
@@ -147,9 +174,32 @@ function collectPaneSessionMatchCandidates(
   tabId: string,
   candidates: SessionMatchCandidate[],
 ): void {
-  if (node.type === 'leaf') {
+    if (node.type === 'leaf') {
+    const explicitLocator = extractExplicitSessionLocator(node.content)
+    if (explicitLocator) {
+      candidates.push({
+        tabId,
+        paneId: node.id,
+        locator: explicitLocator,
+        serverInstanceIdHint: extractSessionLocatorServerInstanceHint(node.content),
+        hasLiveHandleHint: extractSessionLocatorLiveHandleHint(node.content),
+      })
+    }
     for (const locator of extractSessionLocators(node.content)) {
-      candidates.push({ tabId, paneId: node.id, locator })
+      if (
+        explicitLocator
+        && locator.provider === explicitLocator.provider
+        && locator.sessionId === explicitLocator.sessionId
+      ) {
+        continue
+      }
+      candidates.push({
+        tabId,
+        paneId: node.id,
+        locator,
+        serverInstanceIdHint: extractSessionLocatorServerInstanceHint(node.content),
+        hasLiveHandleHint: extractSessionLocatorLiveHandleHint(node.content),
+      })
     }
     return
   }
@@ -159,14 +209,14 @@ function collectPaneSessionMatchCandidates(
 
 function selectBestSessionMatch(
   candidates: SessionMatchCandidate[],
-  target: SessionLocator,
+  target: SessionMatchLocator,
   localServerInstanceId?: string,
 ): SessionMatchCandidate | undefined {
   let bestCandidate: SessionMatchCandidate | undefined
   let bestScore = 0
 
   for (const candidate of candidates) {
-    const score = matchScore(candidate.locator, target, localServerInstanceId)
+    const score = matchScore(candidate, target, localServerInstanceId)
     if (score <= 0) continue
     if (score > bestScore) {
       bestCandidate = candidate
@@ -180,7 +230,6 @@ function selectBestSessionMatch(
 export function collectSessionLocatorsFromNode(node: PaneNode): Array<{
   provider: CodingCliProviderName
   sessionId: string
-  serverInstanceId?: string
 }> {
   if (node.type === 'leaf') {
     return extractSessionLocators(node.content)
@@ -207,12 +256,10 @@ export function collectSessionLocatorsFromTabs(
 ): Array<{
   provider: CodingCliProviderName
   sessionId: string
-  serverInstanceId?: string
 }> {
   const locators: Array<{
     provider: CodingCliProviderName
     sessionId: string
-    serverInstanceId?: string
   }> = []
 
   for (const tab of tabs || []) {
@@ -268,7 +315,7 @@ export function getTabSessionRefs(state: RootState, tabId: string): SessionRef[]
 
 export function findTabIdForSession(
   state: RootState,
-  target: SessionLocator,
+  target: SessionMatchLocator,
   localServerInstanceId?: string,
 ): string | undefined {
   const sanitizedTarget = sanitizeSessionLocator(target)
@@ -278,29 +325,37 @@ export function findTabIdForSession(
   for (const tab of state.tabs.tabs) {
     const layout = state.panes.layouts[tab.id]
     if (layout) {
-      for (const locator of collectSessionLocatorsFromNode(layout)) {
-        candidates.push({ tabId: tab.id, paneId: undefined, locator })
+      const paneCandidates: SessionMatchCandidate[] = []
+      collectPaneSessionMatchCandidates(layout, tab.id, paneCandidates)
+      for (const candidate of paneCandidates) {
+        candidates.push({
+          tabId: candidate.tabId,
+          paneId: undefined,
+          locator: candidate.locator,
+          serverInstanceIdHint: candidate.serverInstanceIdHint,
+          hasLiveHandleHint: candidate.hasLiveHandleHint,
+        })
       }
       continue
     }
 
     const locator = buildTabFallbackLocator(tab)
     if (locator) {
-      candidates.push({ tabId: tab.id, paneId: undefined, locator })
+      candidates.push({
+        tabId: tab.id,
+        paneId: undefined,
+        locator,
+        serverInstanceIdHint: buildTabFallbackServerInstanceHint(tab),
+      })
     }
   }
 
   return selectBestSessionMatch(candidates, sanitizedTarget, localServerInstanceId)?.tabId
 }
 
-/**
- * Find the tab and pane that contain a specific session.
- * Walks all tabs' pane trees looking for a pane (terminal or agent-chat) matching the provider + sessionId.
- * Falls back to tab-level resumeSessionId when no layout exists (early boot/rehydration).
- */
 export function findPaneForSession(
   state: RootState,
-  target: SessionLocator,
+  target: SessionMatchLocator,
   localServerInstanceId?: string,
 ): { tabId: string; paneId: string | undefined } | undefined {
   const sanitizedTarget = sanitizeSessionLocator(target)
@@ -316,7 +371,12 @@ export function findPaneForSession(
 
     const locator = buildTabFallbackLocator(tab)
     if (locator) {
-      candidates.push({ tabId: tab.id, paneId: undefined, locator })
+      candidates.push({
+        tabId: tab.id,
+        paneId: undefined,
+        locator,
+        serverInstanceIdHint: buildTabFallbackServerInstanceHint(tab),
+      })
     }
   }
 

--- a/src/lib/tab-registry-snapshot.ts
+++ b/src/lib/tab-registry-snapshot.ts
@@ -13,22 +13,17 @@ export function countPaneLeaves(node: PaneNode | undefined): number {
 function stripPanePayload(content: PaneContent, serverInstanceId: string): Record<string, unknown> {
   switch (content.kind) {
     case 'terminal':
-      {
-        const sessionRef = content.sessionRef
-          || (content.resumeSessionId && content.mode !== 'shell'
-            ? {
-                provider: content.mode,
-                sessionId: content.resumeSessionId,
-                serverInstanceId,
-              }
-            : undefined)
-        return {
-          mode: content.mode,
-          shell: content.shell,
-          resumeSessionId: content.resumeSessionId,
-          sessionRef,
-          initialCwd: content.initialCwd,
-        }
+      return {
+        mode: content.mode,
+        shell: content.shell,
+        sessionRef: content.sessionRef,
+        liveTerminal: content.terminalId
+          ? {
+              terminalId: content.terminalId,
+              serverInstanceId: content.serverInstanceId ?? serverInstanceId,
+            }
+          : undefined,
+        initialCwd: content.initialCwd,
       }
     case 'browser':
       return {
@@ -43,25 +38,15 @@ function stripPanePayload(content: PaneContent, serverInstanceId: string): Recor
         viewMode: content.viewMode,
       }
     case 'agent-chat':
-      {
-        const sessionRef = content.sessionRef
-          || (content.resumeSessionId
-            ? {
-                provider: 'claude',
-                sessionId: content.resumeSessionId,
-                serverInstanceId,
-              }
-            : undefined)
-        return {
-          provider: content.provider,
-          resumeSessionId: content.resumeSessionId,
-          sessionRef,
-          initialCwd: content.initialCwd,
-          model: content.model,
-          permissionMode: content.permissionMode,
-          effort: content.effort,
-          plugins: content.plugins,
-        }
+      return {
+        provider: content.provider,
+        sessionId: content.sessionId,
+        sessionRef: content.sessionRef,
+        initialCwd: content.initialCwd,
+        model: content.model,
+        permissionMode: content.permissionMode,
+        effort: content.effort,
+        plugins: content.plugins,
       }
     case 'extension':
       return {

--- a/src/lib/ui-commands.ts
+++ b/src/lib/ui-commands.ts
@@ -83,6 +83,7 @@ export function handleUiCommand(msg: any, runtimeOrDispatch: UiCommandRuntime | 
         mode: msg.payload.mode,
         shell: msg.payload.shell,
         initialCwd: msg.payload.initialCwd,
+        sessionRef: msg.payload.sessionRef,
         resumeSessionId: msg.payload.resumeSessionId,
         status: msg.payload.status,
       }))
@@ -99,6 +100,7 @@ export function handleUiCommand(msg: any, runtimeOrDispatch: UiCommandRuntime | 
             status: msg.payload.status || 'running',
             shell: msg.payload.shell,
             initialCwd: msg.payload.initialCwd,
+            sessionRef: msg.payload.sessionRef,
             resumeSessionId: msg.payload.resumeSessionId,
           },
         }))

--- a/src/store/agentChatSlice.ts
+++ b/src/store/agentChatSlice.ts
@@ -5,7 +5,6 @@ import type {
   AgentTimelineItem,
   AgentTimelineTurn,
   ChatContentBlock,
-  ChatMessage,
   ChatSessionState,
   PendingCreateFailure,
   QuestionDefinition,
@@ -48,8 +47,7 @@ function ensureSession(state: AgentChatState, sessionId: string): ChatSessionSta
 
 function getRestoreQueryId(session: Pick<ChatSessionState, 'cliSessionId' | 'timelineSessionId'>): string | undefined {
   return (isValidClaudeSessionId(session.cliSessionId) ? session.cliSessionId : undefined)
-    ?? session.timelineSessionId
-    ?? session.cliSessionId
+    ?? (isValidClaudeSessionId(session.timelineSessionId) ? session.timelineSessionId : undefined)
 }
 
 function isRestoreFailureCode(code?: string): code is string {
@@ -146,7 +144,7 @@ const agentChatSlice = createSlice({
       session.model = action.payload.model
       session.cwd = action.payload.cwd
       session.tools = action.payload.tools
-      if (action.payload.cliSessionId) {
+      if (isValidClaudeSessionId(action.payload.cliSessionId)) {
         session.awaitingDurableHistory = false
       }
       if (session.status === 'creating' || session.status === 'starting') {
@@ -203,9 +201,12 @@ const agentChatSlice = createSlice({
     }>) {
       const session = ensureSession(state, action.payload.sessionId)
       const previousRestoreQueryId = getRestoreQueryId(session)
+      const nextTimelineSessionId = isValidClaudeSessionId(action.payload.timelineSessionId)
+        ? action.payload.timelineSessionId
+        : undefined
       const nextRestoreQueryId = getRestoreQueryId({
         cliSessionId: session.cliSessionId,
-        timelineSessionId: action.payload.timelineSessionId ?? session.timelineSessionId,
+        timelineSessionId: nextTimelineSessionId ?? session.timelineSessionId,
       })
       const shouldRestartHydration = Boolean(
         session.historyLoaded
@@ -225,7 +226,7 @@ const agentChatSlice = createSlice({
 
       session.latestTurnId = action.payload.latestTurnId
       session.status = action.payload.status
-      session.timelineSessionId = action.payload.timelineSessionId
+      session.timelineSessionId = nextTimelineSessionId
       session.timelineRevision = action.payload.revision
       session.streamingActive = action.payload.streamingActive ?? false
       session.streamingText = action.payload.streamingText ?? ''
@@ -233,7 +234,7 @@ const agentChatSlice = createSlice({
       session.restoreFailureMessage = undefined
       session.snapshotRefreshRequestId = undefined
       if (action.payload.latestTurnId === null) {
-        const hasDurableHistoryIdentity = isValidClaudeSessionId(session.timelineSessionId)
+        const hasDurableHistoryIdentity = isValidClaudeSessionId(nextTimelineSessionId)
           || isValidClaudeSessionId(session.cliSessionId)
         if (!session.awaitingDurableHistory || hasDurableHistoryIdentity) {
           session.historyLoaded = true

--- a/src/store/crossTabSync.ts
+++ b/src/store/crossTabSync.ts
@@ -65,7 +65,6 @@ function findLeafContentById(node: unknown, paneId: string): any | undefined {
 function buildCanonicalClaudeSessionRef(localContent: any, localResumeSessionId: string): {
   provider: 'claude'
   sessionId: string
-  serverInstanceId?: string
 } | undefined {
   const explicit = localContent?.sessionRef
   if (
@@ -77,7 +76,6 @@ function buildCanonicalClaudeSessionRef(localContent: any, localResumeSessionId:
     return {
       provider: 'claude',
       sessionId: localResumeSessionId,
-      ...(typeof explicit.serverInstanceId === 'string' ? { serverInstanceId: explicit.serverInstanceId } : {}),
     }
   }
 

--- a/src/store/layoutMirrorMiddleware.ts
+++ b/src/store/layoutMirrorMiddleware.ts
@@ -5,12 +5,10 @@ const INITIAL_LAYOUT_SYNC_DEBOUNCE_MS = 1000
 const LAYOUT_SYNC_DEBOUNCE_MS = 200
 
 function buildTabFallbackSessionRef(tab: {
-  mode?: string
-  codingCliProvider?: string
-  resumeSessionId?: string
+  sessionRef?: { provider?: string; sessionId?: string }
 }): { provider: string; sessionId: string } | undefined {
-  const provider = tab.codingCliProvider || (tab.mode !== 'shell' ? tab.mode : undefined)
-  const sessionId = tab.resumeSessionId
+  const provider = tab.sessionRef?.provider
+  const sessionId = tab.sessionRef?.sessionId
   if (!provider || !sessionId) return undefined
   return { provider, sessionId }
 }

--- a/src/store/paneTreeValidation.ts
+++ b/src/store/paneTreeValidation.ts
@@ -8,6 +8,23 @@ function isOptionalString(value: unknown): value is string | undefined {
   return value === undefined || typeof value === 'string'
 }
 
+function isSessionRefShape(value: unknown): boolean {
+  if (value === undefined) return true
+  return !!value
+    && typeof value === 'object'
+    && typeof (value as any).provider === 'string'
+    && typeof (value as any).sessionId === 'string'
+    && !('serverInstanceId' in (value as Record<string, unknown>))
+}
+
+function isRestoreErrorShape(value: unknown): boolean {
+  if (value === undefined) return true
+  return !!value
+    && typeof value === 'object'
+    && (value as any).code === 'RESTORE_UNAVAILABLE'
+    && typeof (value as any).reason === 'string'
+}
+
 function isPaneContentShape(content: unknown): boolean {
   if (!isRecord(content) || typeof content.kind !== 'string') {
     return false
@@ -21,6 +38,8 @@ function isPaneContentShape(content: unknown): boolean {
         && isOptionalString(content.terminalId)
         && isOptionalString(content.shell)
         && isOptionalString(content.resumeSessionId)
+        && isSessionRefShape(content.sessionRef)
+        && isRestoreErrorShape(content.restoreError)
         && isOptionalString(content.initialCwd)
     case 'browser':
       return typeof content.browserInstanceId === 'string'
@@ -40,6 +59,8 @@ function isPaneContentShape(content: unknown): boolean {
         && typeof content.status === 'string'
         && isOptionalString(content.sessionId)
         && isOptionalString(content.resumeSessionId)
+        && isSessionRefShape(content.sessionRef)
+        && isRestoreErrorShape(content.restoreError)
         && isOptionalString(content.initialCwd)
         && isOptionalString(content.model)
         && isOptionalString(content.permissionMode)

--- a/src/store/paneTypes.ts
+++ b/src/store/paneTypes.ts
@@ -1,6 +1,7 @@
 import type { TerminalStatus, TabMode, ShellType } from './types'
 import type { AgentChatProviderName } from '@/lib/agent-chat-types'
 import type { SessionLocator as SharedSessionLocator } from '@shared/ws-protocol'
+import type { RestoreError } from '@shared/session-contract'
 
 export type SessionLocator = SharedSessionLocator
 
@@ -24,6 +25,10 @@ export type TerminalPaneContent = {
   resumeSessionId?: string
   /** Portable session reference for cross-device tab snapshots */
   sessionRef?: SessionLocator
+  /** Runtime-only server locality for same-server matching; never part of canonical durable identity. */
+  serverInstanceId?: string
+  /** Explicit restore failure when no canonical durable target exists. */
+  restoreError?: RestoreError
   /** Initial working directory */
   initialCwd?: string
 }
@@ -92,6 +97,10 @@ export type AgentChatPaneContent = {
   resumeSessionId?: string
   /** Portable session reference for cross-device tab snapshots */
   sessionRef?: SessionLocator
+  /** Runtime-only server locality for same-server matching; never part of canonical durable identity. */
+  serverInstanceId?: string
+  /** Explicit restore failure when no canonical durable target exists. */
+  restoreError?: RestoreError
   /** Working directory */
   initialCwd?: string
   /** Request-scoped create failure promoted into pane-local visible state. */

--- a/src/store/panesSlice.ts
+++ b/src/store/panesSlice.ts
@@ -10,6 +10,7 @@ import { hasPaneTreeShape, isWellFormedPaneTree } from './paneTreeValidation.js'
 import { createLogger } from '@/lib/client-logger'
 import { patchBrowserPreferencesRecord } from '@/lib/browser-preferences'
 import { shouldPreserveLocalCanonicalResumeSessionId } from './persistControl'
+import { RestoreErrorSchema, sanitizeSessionRef } from '@shared/session-contract'
 
 
 const log = createLogger('PanesSlice')
@@ -21,32 +22,9 @@ type HydratePanesMeta = {
 
 function buildPreservedSessionRef(
   localContent: Extract<PaneContent, { kind: 'terminal' | 'agent-chat' }>,
-  preservedResumeSessionId?: string,
+  _preservedResumeSessionId?: string,
 ) {
-  if (!preservedResumeSessionId) {
-    return localContent.sessionRef
-  }
-
-  if (localContent.kind === 'terminal') {
-    if (localContent.mode === 'shell') {
-      return undefined
-    }
-    return {
-      ...(localContent.sessionRef?.serverInstanceId ? { serverInstanceId: localContent.sessionRef.serverInstanceId } : {}),
-      provider: localContent.mode,
-      sessionId: preservedResumeSessionId,
-    }
-  }
-
-  if (!isValidClaudeSessionId(preservedResumeSessionId)) {
-    return undefined
-  }
-
-  return {
-    ...(localContent.sessionRef?.serverInstanceId ? { serverInstanceId: localContent.sessionRef.serverInstanceId } : {}),
-    provider: 'claude' as const,
-    sessionId: preservedResumeSessionId,
-  }
+  return sanitizeSessionRef(localContent.sessionRef)
 }
 
 /**
@@ -62,16 +40,8 @@ function normalizePaneContent(
       ? input.resumeSessionId
       : undefined
     const resumeSessionId = inputResumeSessionId
-    const explicitSessionRef = input.sessionRef
-      && typeof input.sessionRef.provider === 'string'
-      && typeof input.sessionRef.sessionId === 'string'
-      && (input.sessionRef.provider !== 'claude' || isValidClaudeSessionId(input.sessionRef.sessionId))
-      ? input.sessionRef
-      : undefined
-    const sessionRef = explicitSessionRef
-      ?? (resumeSessionId && mode !== 'shell'
-        ? { provider: mode, sessionId: resumeSessionId }
-        : undefined)
+    const sessionRef = sanitizeSessionRef(input.sessionRef)
+    const restoreError = RestoreErrorSchema.safeParse((input as { restoreError?: unknown }).restoreError)
     return {
       kind: 'terminal',
       terminalId: typeof input.terminalId === 'string' ? input.terminalId : undefined,
@@ -83,6 +53,8 @@ function normalizePaneContent(
       shell: typeof input.shell === 'string' ? input.shell : 'system',
       resumeSessionId,
       ...(sessionRef ? { sessionRef } : {}),
+      serverInstanceId: typeof input.serverInstanceId === 'string' ? input.serverInstanceId : undefined,
+      ...(restoreError.success ? { restoreError: restoreError.data } : {}),
       initialCwd: typeof input.initialCwd === 'string' ? input.initialCwd : undefined,
     }
   }
@@ -100,16 +72,8 @@ function normalizePaneContent(
     }
   }
   if (input.kind === 'agent-chat') {
-    const explicitSessionRef = input.sessionRef
-      && typeof input.sessionRef.provider === 'string'
-      && typeof input.sessionRef.sessionId === 'string'
-      && (input.sessionRef.provider !== 'claude' || isValidClaudeSessionId(input.sessionRef.sessionId))
-      ? input.sessionRef
-      : undefined
-    const sessionRef = explicitSessionRef
-      ?? (input.resumeSessionId && isValidClaudeSessionId(input.resumeSessionId)
-        ? { provider: 'claude' as const, sessionId: input.resumeSessionId }
-        : undefined)
+    const sessionRef = sanitizeSessionRef(input.sessionRef)
+    const restoreError = RestoreErrorSchema.safeParse((input as { restoreError?: unknown }).restoreError)
     return {
       kind: 'agent-chat',
       provider: input.provider,
@@ -118,6 +82,8 @@ function normalizePaneContent(
       status: input.status || 'creating',
       resumeSessionId: input.resumeSessionId,
       ...(sessionRef ? { sessionRef } : {}),
+      serverInstanceId: typeof input.serverInstanceId === 'string' ? input.serverInstanceId : undefined,
+      ...(restoreError.success ? { restoreError: restoreError.data } : {}),
       initialCwd: input.initialCwd,
       createError: input.createError,
       model: input.model,

--- a/src/store/persistControl.ts
+++ b/src/store/persistControl.ts
@@ -4,43 +4,58 @@ import type { AgentChatPaneContent } from './paneTypes'
 import type { CodingCliProviderName, SessionListMetadata, Tab } from './types'
 import { isValidClaudeSessionId } from '@/lib/claude-session-id'
 import { sessionMetadataKey } from '@/lib/session-metadata'
+import { sanitizeSessionRef, type SessionRef } from '@shared/session-contract'
 
 export const flushPersistedLayoutNow = createAction('persist/flushNow')
 
-export function buildDurableResumeIdentityUpdate({
+function sessionRefEquals(a?: SessionRef, b?: SessionRef): boolean {
+  return a?.provider === b?.provider && a?.sessionId === b?.sessionId
+}
+
+export function buildTerminalDurableSessionRefUpdate({
+  provider,
+  sessionId,
+  paneSessionRef,
+  tabSessionRef,
   paneResumeSessionId,
   tabResumeSessionId,
-  sessionId,
-  flushSessionId = sessionId,
 }: {
+  provider?: CodingCliProviderName
+  sessionId?: string
+  paneSessionRef?: SessionRef
+  tabSessionRef?: SessionRef
   paneResumeSessionId?: string
   tabResumeSessionId?: string
-  sessionId?: string
-  flushSessionId?: string
 }): {
-  paneUpdates?: { resumeSessionId: string }
-  tabUpdates?: { resumeSessionId: string }
+  paneUpdates?: { sessionRef?: SessionRef; resumeSessionId?: undefined }
+  tabUpdates?: Partial<Tab>
   shouldFlush: boolean
 } | null {
-  if (!sessionId) return null
+  const sessionRef = provider && sessionId
+    ? sanitizeSessionRef({ provider, sessionId })
+    : undefined
+  if (!sessionRef) return null
 
-  const paneUpdates =
-    paneResumeSessionId !== sessionId
-      ? { resumeSessionId: sessionId }
-      : undefined
+  const paneNeedsSessionRef = !sessionRefEquals(paneSessionRef, sessionRef)
+  const tabNeedsSessionRef = !sessionRefEquals(tabSessionRef, sessionRef)
+  const paneNeedsResumeClear = typeof paneResumeSessionId === 'string'
+  const tabNeedsResumeClear = typeof tabResumeSessionId === 'string'
 
-  const tabUpdates =
-    tabResumeSessionId !== sessionId
-      ? { resumeSessionId: sessionId }
-      : undefined
+  const paneUpdates = paneNeedsSessionRef || paneNeedsResumeClear
+    ? {
+        ...(paneNeedsSessionRef ? { sessionRef } : {}),
+        ...(paneNeedsResumeClear ? { resumeSessionId: undefined } : {}),
+      }
+    : undefined
 
-  const shouldFlush = Boolean(
-    flushSessionId
-      && (
-        paneResumeSessionId !== flushSessionId
-        || tabResumeSessionId !== flushSessionId
-      ),
-  )
+  const tabUpdates = tabNeedsSessionRef || tabNeedsResumeClear
+    ? {
+        ...(tabNeedsSessionRef ? { sessionRef } : {}),
+        ...(tabNeedsResumeClear ? { resumeSessionId: undefined } : {}),
+      }
+    : undefined
+
+  const shouldFlush = paneNeedsSessionRef || tabNeedsSessionRef || paneNeedsResumeClear || tabNeedsResumeClear
 
   if (!paneUpdates && !tabUpdates && !shouldFlush) {
     return null
@@ -130,6 +145,7 @@ export function mergeSessionMetadataForPreferredResumeId({
 
   const nextSessionMetadataByKey: Record<string, SessionListMetadata> = { ...existing }
   let mergedPreferredMetadata: SessionListMetadata | undefined = existing[preferredKey]
+  let matchedCandidateMetadata = mergedPreferredMetadata != null
 
   for (const sessionId of candidateIds) {
     const key = sessionMetadataKey(provider, sessionId)
@@ -138,6 +154,7 @@ export function mergeSessionMetadataForPreferredResumeId({
       ?? localSessionMetadataByKey?.[key]
       ?? remoteSessionMetadataByKey?.[key]
     if (candidateMetadata) {
+      matchedCandidateMetadata = true
       mergedPreferredMetadata = {
         ...(mergedPreferredMetadata ?? {}),
         ...candidateMetadata,
@@ -145,6 +162,23 @@ export function mergeSessionMetadataForPreferredResumeId({
     }
     if (key !== preferredKey) {
       delete nextSessionMetadataByKey[key]
+    }
+  }
+
+  if (!matchedCandidateMetadata) {
+    const providerEntries = new Map<string, SessionListMetadata>()
+    for (const source of [existing, localSessionMetadataByKey ?? {}, remoteSessionMetadataByKey ?? {}]) {
+      for (const [key, value] of Object.entries(source)) {
+        if (!key.startsWith(`${provider}:`)) continue
+        providerEntries.set(key, value)
+      }
+    }
+    if (providerEntries.size === 1) {
+      const [fallbackMetadata] = providerEntries.values()
+      mergedPreferredMetadata = {
+        ...(mergedPreferredMetadata ?? {}),
+        ...fallbackMetadata,
+      }
     }
   }
 
@@ -177,20 +211,33 @@ export function buildAgentChatPersistedIdentityUpdate({
   tabUpdates?: Partial<Tab>
   shouldFlush: boolean
 } | null {
-  const preferredResumeSessionId = getPreferredResumeSessionId(session)
-  if (!preferredResumeSessionId) return null
   const canonicalDurableSessionId = getCanonicalDurableSessionId(session)
-  const durableIdentityUpdate = buildDurableResumeIdentityUpdate({
-    paneResumeSessionId: paneContent.resumeSessionId,
-    tabResumeSessionId: currentTab?.resumeSessionId,
-    sessionId: preferredResumeSessionId,
-    flushSessionId: canonicalDurableSessionId,
+  if (!canonicalDurableSessionId) return null
+  const sessionRef = sanitizeSessionRef({
+    provider: 'claude',
+    sessionId: canonicalDurableSessionId,
   })
-  const paneUpdates = durableIdentityUpdate?.paneUpdates
+  if (!sessionRef) return null
+
+  const paneNeedsSessionRef = !sessionRefEquals(paneContent.sessionRef, sessionRef)
+  const tabNeedsSessionRef = !sessionRefEquals(currentTab?.sessionRef, sessionRef)
+  const paneNeedsResumeClear = typeof paneContent.resumeSessionId === 'string'
+  const tabNeedsResumeClear = typeof currentTab?.resumeSessionId === 'string'
+
+  const paneUpdates = paneNeedsSessionRef || paneNeedsResumeClear || paneContent.restoreError
+    ? {
+        ...(paneNeedsSessionRef ? { sessionRef } : {}),
+        ...(paneNeedsResumeClear ? { resumeSessionId: undefined } : {}),
+        ...(paneContent.restoreError ? { restoreError: undefined } : {}),
+      }
+    : undefined
 
   let tabUpdates: Partial<Tab> | undefined
   if (currentTab) {
-    const nextTabUpdates: Partial<Tab> = { ...(durableIdentityUpdate?.tabUpdates ?? {}) }
+    const nextTabUpdates: Partial<Tab> = {
+      ...(tabNeedsSessionRef ? { sessionRef } : {}),
+      ...(tabNeedsResumeClear ? { resumeSessionId: undefined } : {}),
+    }
     if (metadataProvider && currentTab.codingCliProvider !== metadataProvider) {
       nextTabUpdates.codingCliProvider = metadataProvider
     }
@@ -200,9 +247,9 @@ export function buildAgentChatPersistedIdentityUpdate({
       remoteSessionMetadataByKey: currentTab.sessionMetadataByKey,
       existingSessionMetadataByKey: currentTab.sessionMetadataByKey,
       provider: metadataProvider,
-      localResumeSessionId: currentTab.resumeSessionId,
-      remoteResumeSessionId: paneContent.resumeSessionId,
-      preferredResumeSessionId,
+      localResumeSessionId: currentTab.sessionRef?.sessionId ?? currentTab.resumeSessionId,
+      remoteResumeSessionId: paneContent.sessionRef?.sessionId ?? paneContent.resumeSessionId,
+      preferredResumeSessionId: canonicalDurableSessionId,
       sessionType: paneContent.provider,
     })
 
@@ -215,7 +262,7 @@ export function buildAgentChatPersistedIdentityUpdate({
     }
   }
 
-  const shouldFlush = durableIdentityUpdate?.shouldFlush ?? false
+  const shouldFlush = paneNeedsSessionRef || tabNeedsSessionRef || paneNeedsResumeClear || tabNeedsResumeClear
 
   if (!paneUpdates && !tabUpdates && !shouldFlush) {
     return null

--- a/src/store/persistMiddleware.ts
+++ b/src/store/persistMiddleware.ts
@@ -9,6 +9,7 @@ import { PANES_SCHEMA_VERSION, LAYOUT_SCHEMA_VERSION, parsePersistedLayoutRaw } 
 import { LAYOUT_STORAGE_KEY, PANES_STORAGE_KEY } from './storage-keys'
 import { createLogger } from '@/lib/client-logger'
 import { flushPersistedLayoutNow } from './persistControl'
+import { sanitizeSessionRef } from '@shared/session-contract'
 
 
 const log = createLogger('PanesPersist')
@@ -54,8 +55,11 @@ function registerFlushCallback(cb: () => void) {
 }
 
 function stripTabVolatileFields(tab: Tab) {
+  const sessionRef = sanitizeSessionRef(tab.sessionRef)
   return {
     ...tab,
+    sessionRef,
+    resumeSessionId: undefined,
     lastInputAt: undefined,
   }
 }
@@ -161,11 +165,28 @@ function stripEditorContent(content: any): any {
   }
 }
 
+function stripTransientSessionFields(content: any): any {
+  if (!content || typeof content !== 'object') return content
+  if (content.kind !== 'terminal' && content.kind !== 'agent-chat') return content
+
+  const sessionRef = sanitizeSessionRef(content.sessionRef)
+  const {
+    resumeSessionId: _resumeSessionId,
+    sessionRef: _legacySessionRef,
+    ...rest
+  } = content
+
+  return {
+    ...rest,
+    ...(sessionRef ? { sessionRef } : {}),
+  }
+}
+
 function stripEditorContentFromNode(node: any): any {
   if (!node) return node
 
   if (node.type === 'leaf') {
-    const nextContent = stripEditorContent(node.content)
+    const nextContent = stripTransientSessionFields(stripEditorContent(node.content))
     if (nextContent === node.content) return node
     return {
       ...node,

--- a/src/store/persistedState.ts
+++ b/src/store/persistedState.ts
@@ -1,10 +1,15 @@
 import { z } from 'zod'
 import { LAYOUT_STORAGE_KEY, TABS_STORAGE_KEY, PANES_STORAGE_KEY } from './storage-keys'
+import {
+  migrateLegacyAgentChatDurableState,
+  migrateLegacyTerminalDurableState,
+  sanitizeSessionRef,
+} from '@shared/session-contract'
 
 export { LAYOUT_STORAGE_KEY, TABS_STORAGE_KEY, PANES_STORAGE_KEY }
 
-export const TABS_SCHEMA_VERSION = 1
-export const PANES_SCHEMA_VERSION = 6
+export const TABS_SCHEMA_VERSION = 2
+export const PANES_SCHEMA_VERSION = 7
 
 const zTabMode = z.enum(['shell', 'claude', 'codex', 'opencode', 'gemini', 'kimi'])
 const zCodingCliProvider = z.enum(['claude', 'codex', 'opencode', 'gemini', 'kimi'])
@@ -42,6 +47,25 @@ export type ParsedPersistedTabs = {
   tombstones: Array<{ id: string; deletedAt: number }>
 }
 
+type PersistedTab = z.infer<typeof zTab>
+
+function normalizePersistedTab(tab: Record<string, unknown>): PersistedTab {
+  const mode = typeof tab.mode === 'string' ? tab.mode : undefined
+  const codingCliProvider = typeof tab.codingCliProvider === 'string' ? tab.codingCliProvider : undefined
+  const provider = codingCliProvider || (mode && mode !== 'shell' ? mode : undefined)
+  const durableState = migrateLegacyTerminalDurableState({
+    provider,
+    sessionRef: tab.sessionRef,
+    resumeSessionId: typeof tab.resumeSessionId === 'string' ? tab.resumeSessionId : undefined,
+  })
+  const { resumeSessionId: _resumeSessionId, sessionRef: _legacySessionRef, ...rest } = tab
+
+  return {
+    ...rest,
+    ...(durableState.sessionRef ? { sessionRef: durableState.sessionRef } : {}),
+  } as PersistedTab
+}
+
 export function parsePersistedTabsRaw(raw: string): ParsedPersistedTabs | null {
   let parsed: unknown
   try {
@@ -61,6 +85,7 @@ export function parsePersistedTabsRaw(raw: string): ParsedPersistedTabs | null {
     tabs: {
       ...res.data.tabs,
       activeTabId: res.data.tabs.activeTabId ?? null,
+      tabs: res.data.tabs.tabs.map((tab) => normalizePersistedTab(tab as unknown as Record<string, unknown>)),
     },
     tombstones: res.data.tombstones || [],
   }
@@ -87,6 +112,101 @@ export type ParsedPersistedPanes = {
   paneTitleSetByUser: Record<string, Record<string, boolean>>
 }
 
+function normalizeTerminalContent(content: Record<string, unknown>): Record<string, unknown> {
+  const durableState = migrateLegacyTerminalDurableState({
+    provider: typeof content.mode === 'string' && content.mode !== 'shell' ? content.mode : undefined,
+    sessionRef: content.sessionRef,
+    resumeSessionId: typeof content.resumeSessionId === 'string' ? content.resumeSessionId : undefined,
+  })
+  const existingRestoreError = (
+    content.restoreError
+    && typeof content.restoreError === 'object'
+    && (content.restoreError as any).code === 'RESTORE_UNAVAILABLE'
+    && typeof (content.restoreError as any).reason === 'string'
+  )
+    ? content.restoreError
+    : undefined
+  const { resumeSessionId: _resumeSessionId, sessionRef: _legacySessionRef, restoreError: _legacyRestoreError, ...rest } = content
+
+  return {
+    ...rest,
+    ...(durableState.sessionRef ? { sessionRef: durableState.sessionRef } : {}),
+    ...((durableState.restoreError ?? existingRestoreError)
+      ? { restoreError: durableState.restoreError ?? existingRestoreError }
+      : {}),
+  }
+}
+
+function normalizeAgentChatContent(content: Record<string, unknown>): Record<string, unknown> {
+  const durableState = migrateLegacyAgentChatDurableState({
+    sessionRef: content.sessionRef,
+    cliSessionId: typeof content.cliSessionId === 'string' ? content.cliSessionId : undefined,
+    timelineSessionId: typeof content.timelineSessionId === 'string' ? content.timelineSessionId : undefined,
+    resumeSessionId: typeof content.resumeSessionId === 'string' ? content.resumeSessionId : undefined,
+  })
+  const existingRestoreError = (
+    content.restoreError
+    && typeof content.restoreError === 'object'
+    && (content.restoreError as any).code === 'RESTORE_UNAVAILABLE'
+    && typeof (content.restoreError as any).reason === 'string'
+  )
+    ? content.restoreError
+    : undefined
+  const { resumeSessionId: _resumeSessionId, sessionRef: _legacySessionRef, restoreError: _legacyRestoreError, ...rest } = content
+
+  return {
+    ...rest,
+    ...(durableState.sessionRef ? { sessionRef: durableState.sessionRef } : {}),
+    ...((durableState.restoreError ?? existingRestoreError)
+      ? { restoreError: durableState.restoreError ?? existingRestoreError }
+      : {}),
+  }
+}
+
+function normalizePersistedNode(node: unknown): unknown {
+  if (!node || typeof node !== 'object') return node
+
+  const candidate = node as Record<string, unknown>
+  if (candidate.type === 'leaf' && candidate.content && typeof candidate.content === 'object') {
+    const content = candidate.content as Record<string, unknown>
+    let nextContent = content
+    if (content.kind === 'terminal') {
+      nextContent = normalizeTerminalContent(content)
+    } else if (content.kind === 'agent-chat') {
+      nextContent = normalizeAgentChatContent(content)
+    } else if ('sessionRef' in content) {
+      const sanitizedSessionRef = sanitizeSessionRef(content.sessionRef)
+      const { sessionRef: _legacySessionRef, ...rest } = content
+      nextContent = {
+        ...rest,
+        ...(sanitizedSessionRef ? { sessionRef: sanitizedSessionRef } : {}),
+      }
+    }
+    return {
+      ...candidate,
+      content: nextContent,
+    }
+  }
+
+  if (candidate.type === 'split' && Array.isArray(candidate.children) && candidate.children.length === 2) {
+    return {
+      ...candidate,
+      children: [
+        normalizePersistedNode(candidate.children[0]),
+        normalizePersistedNode(candidate.children[1]),
+      ],
+    }
+  }
+
+  return node
+}
+
+function normalizePersistedLayouts(layouts: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(layouts).map(([tabId, node]) => [tabId, normalizePersistedNode(node)]),
+  )
+}
+
 export function parsePersistedPanesRaw(raw: string): ParsedPersistedPanes | null {
   let parsed: unknown
   try {
@@ -104,16 +224,16 @@ export function parsePersistedPanesRaw(raw: string): ParsedPersistedPanes | null
 
   return {
     version,
-    layouts: (res.data.layouts || {}) as Record<string, unknown>,
+    layouts: normalizePersistedLayouts((res.data.layouts || {}) as Record<string, unknown>),
     activePane: (res.data.activePane || {}) as Record<string, string>,
     paneTitles: (res.data.paneTitles || {}) as Record<string, Record<string, string>>,
     paneTitleSetByUser: (res.data.paneTitleSetByUser || {}) as Record<string, Record<string, boolean>>,
   }
 }
 
-// --- Combined layout key (v3) ---
+// --- Combined layout key (v4) ---
 
-export const LAYOUT_SCHEMA_VERSION = 3
+export const LAYOUT_SCHEMA_VERSION = 4
 
 const zPersistedLayoutPayload = z.object({
   version: z.number(),
@@ -140,20 +260,22 @@ export function parsePersistedLayoutRaw(raw: string): ParsedPersistedLayout | nu
 
   const res = zPersistedLayoutPayload.safeParse(parsed)
   if (!res.success) return null
+  if (res.data.version > LAYOUT_SCHEMA_VERSION) return null
 
   const panes = res.data.panes
   let panesVersion = typeof panes.version === 'number' ? panes.version : 1
   if (panesVersion < 1) panesVersion = 1
 
   return {
-    version: res.data.version,
+    version: Math.max(res.data.version, LAYOUT_SCHEMA_VERSION),
     tabs: {
       ...res.data.tabs,
       activeTabId: res.data.tabs.activeTabId ?? null,
+      tabs: res.data.tabs.tabs.map((tab) => normalizePersistedTab(tab as unknown as Record<string, unknown>)),
     },
     panes: {
-      version: panesVersion,
-      layouts: (panes.layouts || {}) as Record<string, unknown>,
+      version: Math.max(panesVersion, PANES_SCHEMA_VERSION),
+      layouts: normalizePersistedLayouts((panes.layouts || {}) as Record<string, unknown>),
       activePane: (panes.activePane || {}) as Record<string, string>,
       paneTitles: (panes.paneTitles || {}) as Record<string, Record<string, string>>,
       paneTitleSetByUser: (panes.paneTitleSetByUser || {}) as Record<string, Record<string, boolean>>,

--- a/src/store/selectors/sidebarSelectors.ts
+++ b/src/store/selectors/sidebarSelectors.ts
@@ -2,7 +2,7 @@ import { createSelector } from '@reduxjs/toolkit'
 import type { RootState } from '../store'
 import type { BackgroundTerminal, CodingCliProviderName, WorktreeGrouping } from '../types'
 import { isValidClaudeSessionId } from '@/lib/claude-session-id'
-import { collectSessionRefsFromNode, collectSessionRefsFromTabs } from '@/lib/session-utils'
+import { collectSessionRefsFromTabs } from '@/lib/session-utils'
 import { getAgentChatProviderConfig } from '@/lib/agent-chat-utils'
 import { getSessionMetadata } from '@/lib/session-metadata'
 import type { SessionListMetadata } from '../types'
@@ -74,8 +74,8 @@ export function buildSessionItems(
   const tabSessionMap = new Map<string, { hasTab: boolean }>()
 
   for (const terminal of terminals || []) {
-    if (terminal.mode && terminal.mode !== 'shell' && terminal.status === 'running' && terminal.resumeSessionId) {
-      const sessionKey = `${terminal.mode}:${terminal.resumeSessionId}`
+    if (terminal.status === 'running' && terminal.sessionRef) {
+      const sessionKey = `${terminal.sessionRef.provider}:${terminal.sessionRef.sessionId}`
       const existing = runningSessionMap.get(sessionKey)
       if (existing) {
         existing.allTerminalIds.push(terminal.terminalId)
@@ -220,12 +220,12 @@ export function buildSessionItems(
     const fallbackTimestamp = tab.lastInputAt ?? tab.createdAt ?? 0
 
     if (node.content.kind === 'agent-chat') {
-      const sessionId = node.content.resumeSessionId
-      if (!sessionId || !isValidClaudeSessionId(sessionId)) return
-      const metadata = getSessionMetadata(tab, 'claude', sessionId)
+      const sessionRef = node.content.sessionRef
+      if (sessionRef?.provider !== 'claude' || !isValidClaudeSessionId(sessionRef.sessionId)) return
+      const metadata = getSessionMetadata(tab, 'claude', sessionRef.sessionId)
       pushFallbackItem({
         provider: 'claude',
-        sessionId,
+        sessionId: sessionRef.sessionId,
         sessionType: node.content.provider || 'claude',
         title: paneTitle || tab.title,
         cwd: undefined,
@@ -236,13 +236,15 @@ export function buildSessionItems(
     }
 
     if (node.content.kind !== 'terminal') return
-    if (node.content.mode === 'shell' || !node.content.resumeSessionId) return
+    if (node.content.mode === 'shell') return
+    const sessionRef = node.content.sessionRef
+    if (!sessionRef) return
 
-    const metadata = getSessionMetadata(tab, node.content.mode, node.content.resumeSessionId)
+    const metadata = getSessionMetadata(tab, sessionRef.provider, sessionRef.sessionId)
     pushFallbackItem({
-      provider: node.content.mode,
-      sessionId: node.content.resumeSessionId,
-      sessionType: node.content.mode,
+      provider: sessionRef.provider,
+      sessionId: sessionRef.sessionId,
+      sessionType: sessionRef.provider,
       title: paneTitle || tab.title,
       cwd: node.content.initialCwd,
       timestamp: fallbackTimestamp,
@@ -253,15 +255,12 @@ export function buildSessionItems(
   for (const tab of tabs || []) {
     const layout = panes.layouts?.[tab.id]
     if (layout) {
-      const refs = collectSessionRefsFromNode(layout)
-      if (refs.length > 0) {
-        collectFallbackItemsFromNode(layout, tab)
-      }
+      collectFallbackItemsFromNode(layout, tab)
       continue
     }
 
-    const provider = tab.codingCliProvider || (tab.mode !== 'shell' ? tab.mode : undefined)
-    const sessionId = tab.resumeSessionId
+    const provider = tab.sessionRef?.provider
+    const sessionId = tab.sessionRef?.sessionId
     if (!provider || !sessionId) continue
 
     const metadata = getSessionMetadata(tab, provider, sessionId)

--- a/src/store/storage-migration.ts
+++ b/src/store/storage-migration.ts
@@ -14,11 +14,17 @@
 
 import { createLogger } from '@/lib/client-logger'
 import { clearAuthCookie } from '@/lib/auth'
-import { BROWSER_PREFERENCES_STORAGE_KEY } from './storage-keys'
+import { LAYOUT_SCHEMA_VERSION, PANES_SCHEMA_VERSION, migrateV2ToV3 } from './persistedState'
+import { BROWSER_PREFERENCES_STORAGE_KEY, LAYOUT_STORAGE_KEY } from './storage-keys'
+import {
+  migrateLegacyAgentChatDurableState,
+  migrateLegacyTerminalDurableState,
+  sanitizeSessionRef,
+} from '@shared/session-contract'
 
 const log = createLogger('StorageMigration')
 
-const STORAGE_VERSION = 3
+const STORAGE_VERSION = 4
 const STORAGE_VERSION_KEY = 'freshell_version'
 const AUTH_STORAGE_KEY = 'freshell.auth-token'
 const LEGACY_BROWSER_PREFERENCE_KEYS = [
@@ -41,13 +47,158 @@ function clearFreshellKeysExcept(keep: string[]): void {
   }
 }
 
+function normalizeLayoutTab(tab: Record<string, unknown>): Record<string, unknown> {
+  const mode = typeof tab.mode === 'string' ? tab.mode : undefined
+  const codingCliProvider = typeof tab.codingCliProvider === 'string' ? tab.codingCliProvider : undefined
+  const provider = codingCliProvider || (mode && mode !== 'shell' ? mode : undefined)
+  const durableState = migrateLegacyTerminalDurableState({
+    provider,
+    sessionRef: tab.sessionRef,
+    resumeSessionId: typeof tab.resumeSessionId === 'string' ? tab.resumeSessionId : undefined,
+  })
+  const { resumeSessionId: _resumeSessionId, sessionRef: _legacySessionRef, ...rest } = tab
+  return {
+    ...rest,
+    ...(durableState.sessionRef ? { sessionRef: durableState.sessionRef } : {}),
+  }
+}
+
+function normalizeLayoutNode(node: unknown): unknown {
+  if (!node || typeof node !== 'object') return node
+  const candidate = node as Record<string, unknown>
+
+  if (candidate.type === 'leaf' && candidate.content && typeof candidate.content === 'object') {
+    const content = candidate.content as Record<string, unknown>
+    if (content.kind === 'terminal') {
+      const durableState = migrateLegacyTerminalDurableState({
+        provider: typeof content.mode === 'string' && content.mode !== 'shell' ? content.mode : undefined,
+        sessionRef: content.sessionRef,
+        resumeSessionId: typeof content.resumeSessionId === 'string' ? content.resumeSessionId : undefined,
+      })
+      const { resumeSessionId: _resumeSessionId, sessionRef: _legacySessionRef, restoreError: _legacyRestoreError, ...rest } = content
+      return {
+        ...candidate,
+        content: {
+          ...rest,
+          ...(durableState.sessionRef ? { sessionRef: durableState.sessionRef } : {}),
+          ...(durableState.restoreError ? { restoreError: durableState.restoreError } : {}),
+        },
+      }
+    }
+
+    if (content.kind === 'agent-chat') {
+      const durableState = migrateLegacyAgentChatDurableState({
+        sessionRef: content.sessionRef,
+        cliSessionId: typeof content.cliSessionId === 'string' ? content.cliSessionId : undefined,
+        timelineSessionId: typeof content.timelineSessionId === 'string' ? content.timelineSessionId : undefined,
+        resumeSessionId: typeof content.resumeSessionId === 'string' ? content.resumeSessionId : undefined,
+      })
+      const { resumeSessionId: _resumeSessionId, sessionRef: _legacySessionRef, restoreError: _legacyRestoreError, ...rest } = content
+      return {
+        ...candidate,
+        content: {
+          ...rest,
+          ...(durableState.sessionRef ? { sessionRef: durableState.sessionRef } : {}),
+          ...(durableState.restoreError ? { restoreError: durableState.restoreError } : {}),
+        },
+      }
+    }
+
+    const sanitizedSessionRef = sanitizeSessionRef(content.sessionRef)
+    if (!sanitizedSessionRef) return node
+
+    const { sessionRef: _legacySessionRef, ...rest } = content
+    return {
+      ...candidate,
+      content: {
+        ...rest,
+        sessionRef: sanitizedSessionRef,
+      },
+    }
+  }
+
+  if (candidate.type === 'split' && Array.isArray(candidate.children) && candidate.children.length === 2) {
+    return {
+      ...candidate,
+      children: [
+        normalizeLayoutNode(candidate.children[0]),
+        normalizeLayoutNode(candidate.children[1]),
+      ],
+    }
+  }
+
+  return node
+}
+
+function migratePersistedLayout(): boolean {
+  const raw = localStorage.getItem(LAYOUT_STORAGE_KEY)
+  if (!raw) return false
+
+  let parsed: any
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return false
+  }
+
+  if (!parsed || typeof parsed !== 'object' || !parsed.tabs || !parsed.panes) {
+    return false
+  }
+
+  const nextTabs = Array.isArray(parsed.tabs.tabs)
+    ? parsed.tabs.tabs.map((tab: Record<string, unknown>) => normalizeLayoutTab(tab))
+    : []
+  const nextLayouts = parsed.panes.layouts && typeof parsed.panes.layouts === 'object'
+    ? Object.fromEntries(
+      Object.entries(parsed.panes.layouts as Record<string, unknown>).map(([tabId, node]) => [tabId, normalizeLayoutNode(node)]),
+    )
+    : {}
+
+  localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify({
+    persistedAt: typeof parsed.persistedAt === 'number' ? parsed.persistedAt : Date.now(),
+    version: LAYOUT_SCHEMA_VERSION,
+    tabs: {
+      ...parsed.tabs,
+      activeTabId: parsed.tabs.activeTabId ?? null,
+      tabs: nextTabs,
+    },
+    panes: {
+      version: Math.max(typeof parsed.panes.version === 'number' ? parsed.panes.version : 1, PANES_SCHEMA_VERSION),
+      layouts: nextLayouts,
+      activePane: parsed.panes.activePane ?? {},
+      paneTitles: parsed.panes.paneTitles ?? {},
+      paneTitleSetByUser: parsed.panes.paneTitleSetByUser ?? {},
+    },
+    tombstones: Array.isArray(parsed.tombstones) ? parsed.tombstones : [],
+  }))
+  return true
+}
+
+function preservePersistedLayout(): boolean {
+  if (migratePersistedLayout()) {
+    return true
+  }
+
+  if (!migrateV2ToV3()) {
+    return false
+  }
+
+  return migratePersistedLayout()
+}
+
 export function runStorageMigration(): void {
   try {
     const currentVersion = readStorageVersion()
     if (currentVersion >= STORAGE_VERSION) return
 
     const preservedAuthToken = localStorage.getItem(AUTH_STORAGE_KEY)
-    clearFreshellKeysExcept([AUTH_STORAGE_KEY, BROWSER_PREFERENCES_STORAGE_KEY, ...LEGACY_BROWSER_PREFERENCE_KEYS])
+    const migratedLayout = preservePersistedLayout()
+    clearFreshellKeysExcept([
+      AUTH_STORAGE_KEY,
+      BROWSER_PREFERENCES_STORAGE_KEY,
+      LAYOUT_STORAGE_KEY,
+      ...LEGACY_BROWSER_PREFERENCE_KEYS,
+    ])
 
     if (preservedAuthToken) {
       localStorage.setItem(AUTH_STORAGE_KEY, preservedAuthToken)
@@ -57,8 +208,8 @@ export function runStorageMigration(): void {
 
     localStorage.setItem(STORAGE_VERSION_KEY, String(STORAGE_VERSION))
     log.info(
-      `Cleared localStorage (version ${currentVersion} → ${STORAGE_VERSION}) ` +
-      'while preserving auth token continuity.'
+      `Migrated localStorage (version ${currentVersion} → ${STORAGE_VERSION}) ` +
+      `${migratedLayout ? 'while preserving restorable layout state.' : 'without preserved layout state.'}`
     )
   } catch (err) {
     log.warn('Storage migration failed:', err)

--- a/src/store/tabsSlice.ts
+++ b/src/store/tabsSlice.ts
@@ -20,8 +20,9 @@ import type { RootState } from './store'
 import { selectTabIdByTerminalId } from './selectors/paneTerminalSelectors'
 import { loadPersistedLayout } from './persistMiddleware'
 import { createLogger } from '@/lib/client-logger'
-import { mergeSessionMetadataByKey } from '@/lib/session-metadata'
-import { mergeSessionMetadataForPreferredResumeId, preferCanonicalResumeSessionId } from './persistControl'
+import { mergeSessionMetadataByKey, sessionMetadataKey } from '@/lib/session-metadata'
+import { mergeSessionMetadataForPreferredResumeId } from './persistControl'
+import { migrateLegacyTerminalDurableState, sanitizeSessionRef } from '@shared/session-contract'
 
 
 const log = createLogger('TabsSlice')
@@ -47,15 +48,24 @@ function migrateTabFields(t: Tab): Tab {
   const legacyClaudeSessionId = (t as any).claudeSessionId as string | undefined
   // Strip legacy terminalId field from persisted data
   const { terminalId: _legacyTerminalId, ...rest } = t as Tab & { terminalId?: unknown }
+  const codingCliProvider = t.codingCliProvider || (legacyClaudeSessionId ? 'claude' : undefined)
+  const provider = codingCliProvider || (t.mode !== 'shell' ? t.mode : undefined)
+  const durableState = migrateLegacyTerminalDurableState({
+    provider,
+    sessionRef: (t as any).sessionRef,
+    resumeSessionId: t.resumeSessionId,
+  })
   return {
     ...rest,
     codingCliSessionId: t.codingCliSessionId || legacyClaudeSessionId,
-    codingCliProvider: t.codingCliProvider || (legacyClaudeSessionId ? 'claude' : undefined),
+    codingCliProvider,
     createdAt: t.createdAt || Date.now(),
     createRequestId: (t as any).createRequestId || t.id,
     status: t.status || 'creating',
     mode: t.mode || 'shell',
     shell: t.shell || 'system',
+    sessionRef: durableState.sessionRef,
+    resumeSessionId: undefined,
     lastInputAt: t.lastInputAt,
   }
 }
@@ -75,23 +85,43 @@ function pickHydratedTabWinner(localTab: Tab, remoteTab: Tab, meta: HydrateTabsM
   return (localTab.updatedAt ?? 0) > (remoteTab.updatedAt ?? 0) ? localTab : remoteTab
 }
 
+function deriveTabSessionRef(tab: Tab) {
+  const explicitSessionRef = sanitizeSessionRef(tab.sessionRef)
+  if (explicitSessionRef) return explicitSessionRef
+
+  return migrateLegacyTerminalDurableState({
+    provider: tab.codingCliProvider || (tab.mode !== 'shell' ? tab.mode : undefined),
+    sessionRef: tab.sessionRef,
+    resumeSessionId: tab.resumeSessionId,
+  }).sessionRef
+}
+
 function protectCanonicalFallbackIdentity(localTab: Tab, remoteTab: Tab, mergedTab: Tab): Tab {
-  const preferredResumeSessionId = preferCanonicalResumeSessionId(
-    localTab.resumeSessionId,
-    remoteTab.resumeSessionId,
-    mergedTab.resumeSessionId,
-  )
+  const localSessionRef = deriveTabSessionRef(localTab)
+  const remoteSessionRef = deriveTabSessionRef(remoteTab)
+  const mergedSessionRef = deriveTabSessionRef(mergedTab)
+  const preferredSessionRef = localSessionRef ?? remoteSessionRef ?? mergedSessionRef
 
   let nextTab = mergedTab
-  if (preferredResumeSessionId && nextTab.resumeSessionId !== preferredResumeSessionId) {
+  if (
+    preferredSessionRef
+    && (
+      nextTab.sessionRef?.provider !== preferredSessionRef.provider
+      || nextTab.sessionRef?.sessionId !== preferredSessionRef.sessionId
+    )
+  ) {
     nextTab = {
       ...nextTab,
-      resumeSessionId: preferredResumeSessionId,
+      sessionRef: preferredSessionRef,
+      resumeSessionId: undefined,
     }
   }
 
   const metadataProvider =
-    nextTab.codingCliProvider
+    nextTab.sessionRef?.provider
+    ?? remoteSessionRef?.provider
+    ?? localSessionRef?.provider
+    ?? nextTab.codingCliProvider
     ?? remoteTab.codingCliProvider
     ?? localTab.codingCliProvider
     ?? (nextTab.mode !== 'shell' ? nextTab.mode : undefined)
@@ -103,15 +133,22 @@ function protectCanonicalFallbackIdentity(localTab: Tab, remoteTab: Tab, mergedT
     }
   }
 
-  const nextSessionMetadataByKey = mergeSessionMetadataForPreferredResumeId({
+  let nextSessionMetadataByKey = mergeSessionMetadataForPreferredResumeId({
     localSessionMetadataByKey: localTab.sessionMetadataByKey,
     remoteSessionMetadataByKey: remoteTab.sessionMetadataByKey,
     existingSessionMetadataByKey: nextTab.sessionMetadataByKey,
     provider: metadataProvider,
-    localResumeSessionId: localTab.resumeSessionId,
-    remoteResumeSessionId: remoteTab.resumeSessionId,
-    preferredResumeSessionId,
+    localResumeSessionId: localSessionRef?.sessionId ?? localTab.resumeSessionId,
+    remoteResumeSessionId: remoteSessionRef?.sessionId ?? remoteTab.resumeSessionId,
+    preferredResumeSessionId: preferredSessionRef?.sessionId,
   })
+
+  if (metadataProvider && preferredSessionRef && nextSessionMetadataByKey) {
+    const preferredKey = sessionMetadataKey(metadataProvider, preferredSessionRef.sessionId)
+    nextSessionMetadataByKey = nextSessionMetadataByKey[preferredKey]
+      ? { [preferredKey]: nextSessionMetadataByKey[preferredKey] }
+      : nextSessionMetadataByKey
+  }
 
   if (JSON.stringify(nextSessionMetadataByKey ?? {}) !== JSON.stringify(nextTab.sessionMetadataByKey ?? {})) {
     nextTab = {
@@ -177,6 +214,8 @@ type AddTabPayload = {
   mode?: TabMode
   shell?: ShellType
   initialCwd?: string
+  sessionRef?: Tab['sessionRef']
+  serverInstanceId?: string
   resumeSessionId?: string
   sessionMetadataByKey?: Tab['sessionMetadataByKey']
   forceNew?: boolean
@@ -197,6 +236,7 @@ export const tabsSlice = createSlice({
       const codingCliSessionId = payload.codingCliSessionId || legacyClaudeSessionId
       const codingCliProvider =
         payload.codingCliProvider || (legacyClaudeSessionId ? 'claude' : undefined)
+      const sessionRef = sanitizeSessionRef(payload.sessionRef)
       const tab: Tab = {
         id,
         createRequestId: payload.createRequestId || id,
@@ -209,7 +249,9 @@ export const tabsSlice = createSlice({
         mode: payload.mode || 'shell',
         shell: payload.shell || 'system',
         initialCwd: payload.initialCwd,
-        resumeSessionId: payload.resumeSessionId,
+        sessionRef,
+        serverInstanceId: payload.serverInstanceId,
+        resumeSessionId: undefined,
         sessionMetadataByKey: payload.sessionMetadataByKey,
         createdAt: Date.now(),
         updatedAt: Date.now(),
@@ -588,7 +630,9 @@ export const openSessionTab = createAsyncThunk(
         mode: resolvedProvider,
         codingCliProvider: resolvedProvider,
         initialCwd: cwd,
-        resumeSessionId: sessionId,
+        sessionRef: desiredResumeContent.kind === 'terminal' || desiredResumeContent.kind === 'agent-chat'
+          ? desiredResumeContent.sessionRef
+          : undefined,
         sessionMetadataByKey: buildSessionMetadataByKey(),
       }))
       dispatch(initLayout({
@@ -597,7 +641,7 @@ export const openSessionTab = createAsyncThunk(
           kind: 'terminal',
           mode: resolvedProvider,
           terminalId,
-          resumeSessionId: sessionId,
+          sessionRef: desiredResumeContent.kind === 'terminal' ? desiredResumeContent.sessionRef : undefined,
           initialCwd: cwd,
           status: 'running',
         },
@@ -630,7 +674,7 @@ export const openSessionTab = createAsyncThunk(
         mode: resolvedProvider,
         codingCliProvider: resolvedProvider,
         initialCwd: cwd,
-        resumeSessionId: sessionId,
+        sessionRef: desiredResumeContent.kind === 'agent-chat' ? desiredResumeContent.sessionRef : undefined,
         sessionMetadataByKey: buildSessionMetadataByKey(),
       }))
       dispatch(initLayout({
@@ -645,7 +689,7 @@ export const openSessionTab = createAsyncThunk(
       mode: resolvedProvider,
       codingCliProvider: resolvedProvider,
       initialCwd: cwd,
-      resumeSessionId: sessionId,
+      sessionRef: desiredResumeContent.kind === 'terminal' ? desiredResumeContent.sessionRef : undefined,
       sessionMetadataByKey: buildSessionMetadataByKey(),
     }))
   }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -20,7 +20,7 @@ import type {
   TabAttentionStyle,
   WorktreeGrouping,
 } from '@shared/settings'
-import type { CodingCliProviderName, TokenSummary } from '@shared/ws-protocol'
+import type { CodingCliProviderName, TokenSummary, SessionLocator } from '@shared/ws-protocol'
 export type { CodingCliProviderName }
 
 // TabMode includes 'shell' for regular terminals, plus all coding CLI providers
@@ -57,7 +57,9 @@ export interface Tab {
   mode: TabMode
   shell?: ShellType
   initialCwd?: string
-  resumeSessionId?: string     // Mirrored from pane content on session association; serves as fallback if pane layout is lost
+  sessionRef?: SessionLocator
+  serverInstanceId?: string
+  resumeSessionId?: string     // Legacy migration field; canonical durable identity lives in sessionRef
   sessionMetadataByKey?: Record<string, SessionListMetadata>
   createdAt: number
   updatedAt?: number
@@ -74,7 +76,7 @@ export interface BackgroundTerminal {
   status: 'running' | 'exited'
   hasClients: boolean
   mode?: TabMode
-  resumeSessionId?: string
+  sessionRef?: SessionLocator
 }
 
 export interface CodingCliSession {

--- a/test/e2e/agent-chat-restore-flow.test.tsx
+++ b/test/e2e/agent-chat-restore-flow.test.tsx
@@ -94,6 +94,7 @@ describe('agent chat restore flow', () => {
   })
 
   it('restores a reloaded pane from sdk.session.snapshot, persists the durable id into pane and tab state, and shows partial output without a blank running gap', async () => {
+    const canonicalSessionId = '00000000-0000-4000-8000-000000000224'
     const store = makeStore({
       resumeSessionId: 'named-resume',
       sessionMetadataByKey: {
@@ -118,11 +119,11 @@ describe('agent chat restore flow', () => {
     }))
 
     getAgentTimelinePage.mockResolvedValue({
-      sessionId: 'cli-session-1',
+      sessionId: canonicalSessionId,
       items: [
         {
           turnId: 'turn-2',
-          sessionId: 'cli-session-1',
+          sessionId: canonicalSessionId,
           role: 'assistant',
           summary: 'Recent summary',
           timestamp: '2026-03-10T10:01:00.000Z',
@@ -132,7 +133,7 @@ describe('agent chat restore flow', () => {
       revision: 2,
       bodies: {
         'turn-2': {
-          sessionId: 'cli-session-1',
+          sessionId: canonicalSessionId,
           turnId: 'turn-2',
           message: {
             role: 'assistant',
@@ -155,7 +156,7 @@ describe('agent chat restore flow', () => {
         sessionId: 'sdk-sess-1',
         latestTurnId: 'turn-2',
         status: 'running',
-        timelineSessionId: 'cli-session-1',
+        timelineSessionId: canonicalSessionId,
         revision: 2,
         streamingActive: true,
         streamingText: 'partial reply',
@@ -167,7 +168,7 @@ describe('agent chat restore flow', () => {
 
     await waitFor(() => {
       expect(getAgentTimelinePage).toHaveBeenCalledWith(
-        'cli-session-1',
+        canonicalSessionId,
         expect.objectContaining({ priority: 'visible', includeBodies: true }),
         expect.anything(),
       )
@@ -180,11 +181,18 @@ describe('agent chat restore flow', () => {
     await waitFor(() => {
       const root = store.getState().panes.layouts.t1
       const leaf = root && findLeaf(root, 'p1')
-      expect(leaf?.content.kind === 'agent-chat' ? leaf.content.resumeSessionId : undefined).toBe('cli-session-1')
+      expect(leaf?.content.kind === 'agent-chat' ? leaf.content.sessionRef : undefined).toEqual({
+        provider: 'claude',
+        sessionId: canonicalSessionId,
+      })
 
       const tab = store.getState().tabs.tabs.find((entry) => entry.id === 't1')
-      expect(tab?.resumeSessionId).toBe('cli-session-1')
-      expect(tab?.sessionMetadataByKey?.['claude:cli-session-1']).toEqual(expect.objectContaining({
+      expect(tab?.resumeSessionId).toBeUndefined()
+      expect(tab?.sessionRef).toEqual({
+        provider: 'claude',
+        sessionId: canonicalSessionId,
+      })
+      expect(tab?.sessionMetadataByKey?.[`claude:${canonicalSessionId}`]).toEqual(expect.objectContaining({
         sessionType: 'freshclaude',
         firstUserMessage: 'Continue from the old tab',
       }))
@@ -271,5 +279,56 @@ describe('agent chat restore flow', () => {
     expect(await screen.findByText('Session restore failed')).toBeInTheDocument()
     expect(screen.getByText('Stale restore revision')).toBeInTheDocument()
     expect(screen.queryByText('Restoring session...')).not.toBeInTheDocument()
+  })
+
+  it('surfaces restore-unavailable instead of recreating a live-only FreshClaude session after INVALID_SESSION_ID', async () => {
+    const store = makeStore()
+    const pane = {
+      kind: 'agent-chat',
+      provider: 'freshclaude',
+      createRequestId: 'req-live-only',
+      sessionId: 'sdk-live-only',
+      status: 'idle',
+    } satisfies AgentChatPaneContent
+
+    store.dispatch(initLayout({
+      tabId: 't1',
+      paneId: 'p1',
+      content: pane,
+    }))
+
+    render(
+      <Provider store={store}>
+        <ReactivePane store={store} />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(wsSend).toHaveBeenCalledWith({
+        type: 'sdk.attach',
+        sessionId: 'sdk-live-only',
+      })
+    })
+
+    wsSend.mockClear()
+
+    act(() => {
+      handleSdkMessage(store.dispatch, {
+        type: 'sdk.error',
+        sessionId: 'sdk-live-only',
+        code: 'INVALID_SESSION_ID',
+        message: 'Live SDK session not found',
+      })
+    })
+
+    await waitFor(() => {
+      expect(store.getState().agentChat.sessions['sdk-live-only']).toMatchObject({
+        restoreFailureCode: 'RESTORE_UNAVAILABLE',
+        restoreFailureMessage: expect.any(String),
+        historyLoaded: true,
+      })
+    })
+
+    expect(wsSend.mock.calls.some(([msg]) => msg?.type === 'sdk.create')).toBe(false)
   })
 })

--- a/test/e2e/agent-chat-resume-history-flow.test.tsx
+++ b/test/e2e/agent-chat-resume-history-flow.test.tsx
@@ -75,33 +75,34 @@ describe('agent chat resume history flow', () => {
   })
 
   it('hydrates durable history after sdk.created for a resumed create', async () => {
+    const canonicalSessionId = '00000000-0000-4000-8000-000000000225'
     getAgentTimelinePage.mockResolvedValue({
-      sessionId: 'cli-session-1',
+      sessionId: canonicalSessionId,
       items: [
         {
           turnId: 'turn-older-user',
-          sessionId: 'cli-session-1',
+          sessionId: canonicalSessionId,
           role: 'user',
           summary: 'Older question',
           timestamp: '2026-03-10T10:00:00.000Z',
         },
         {
           turnId: 'turn-older-assistant',
-          sessionId: 'cli-session-1',
+          sessionId: canonicalSessionId,
           role: 'assistant',
           summary: 'Older answer',
           timestamp: '2026-03-10T10:00:20.000Z',
         },
         {
           turnId: 'turn-new-user',
-          sessionId: 'cli-session-1',
+          sessionId: canonicalSessionId,
           role: 'user',
           summary: 'New prompt',
           timestamp: '2026-03-10T10:01:00.000Z',
         },
         {
           turnId: 'turn-new-assistant',
-          sessionId: 'cli-session-1',
+          sessionId: canonicalSessionId,
           role: 'assistant',
           summary: 'New reply',
           timestamp: '2026-03-10T10:01:20.000Z',
@@ -111,7 +112,7 @@ describe('agent chat resume history flow', () => {
       revision: 4,
       bodies: {
         'turn-older-user': {
-          sessionId: 'cli-session-1',
+          sessionId: canonicalSessionId,
           turnId: 'turn-older-user',
           message: {
             role: 'user',
@@ -120,7 +121,7 @@ describe('agent chat resume history flow', () => {
           },
         },
         'turn-older-assistant': {
-          sessionId: 'cli-session-1',
+          sessionId: canonicalSessionId,
           turnId: 'turn-older-assistant',
           message: {
             role: 'assistant',
@@ -129,7 +130,7 @@ describe('agent chat resume history flow', () => {
           },
         },
         'turn-new-user': {
-          sessionId: 'cli-session-1',
+          sessionId: canonicalSessionId,
           turnId: 'turn-new-user',
           message: {
             role: 'user',
@@ -138,7 +139,7 @@ describe('agent chat resume history flow', () => {
           },
         },
         'turn-new-assistant': {
-          sessionId: 'cli-session-1',
+          sessionId: canonicalSessionId,
           turnId: 'turn-new-assistant',
           message: {
             role: 'assistant',
@@ -158,7 +159,10 @@ describe('agent chat resume history flow', () => {
         provider: 'freshclaude',
         createRequestId: 'req-resume',
         status: 'creating',
-        resumeSessionId: 'cli-session-1',
+        sessionRef: {
+          provider: 'claude',
+          sessionId: canonicalSessionId,
+        },
       },
     }))
 
@@ -171,7 +175,7 @@ describe('agent chat resume history flow', () => {
     expect(wsSend).toHaveBeenCalledWith(expect.objectContaining({
       type: 'sdk.create',
       requestId: 'req-resume',
-      resumeSessionId: 'cli-session-1',
+      resumeSessionId: canonicalSessionId,
     }))
 
     act(() => {
@@ -185,7 +189,7 @@ describe('agent chat resume history flow', () => {
         sessionId: 'sdk-sess-1',
         latestTurnId: 'turn-2',
         status: 'idle',
-        timelineSessionId: 'cli-session-1',
+        timelineSessionId: canonicalSessionId,
         revision: 4,
       })
     })
@@ -194,7 +198,7 @@ describe('agent chat resume history flow', () => {
 
     await waitFor(() => {
       expect(getAgentTimelinePage).toHaveBeenCalledWith(
-        'cli-session-1',
+        canonicalSessionId,
         expect.objectContaining({ priority: 'visible', includeBodies: true, revision: 4 }),
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       )
@@ -227,11 +231,11 @@ describe('agent chat resume history flow', () => {
     })
     getAgentTimelinePage
       .mockResolvedValueOnce({
-        sessionId: 'named-resume',
+        sessionId: 'sdk-live-only',
         items: [
           {
             turnId: 'turn-live-1',
-            sessionId: 'named-resume',
+            sessionId: 'sdk-live-only',
             role: 'assistant',
             summary: 'Live-only reply',
             timestamp: '2026-03-10T10:01:20.000Z',
@@ -241,7 +245,7 @@ describe('agent chat resume history flow', () => {
         revision: 1,
         bodies: {
           'turn-live-1': {
-            sessionId: 'named-resume',
+            sessionId: 'sdk-live-only',
             turnId: 'turn-live-1',
             message: {
               role: 'assistant',
@@ -402,14 +406,13 @@ describe('agent chat resume history flow', () => {
         sessionId: 'sdk-live-only',
         latestTurnId: 'turn-live-1',
         status: 'idle',
-        timelineSessionId: 'named-resume',
         revision: 1,
       })
     })
 
     await waitFor(() => {
       expect(getAgentTimelinePage).toHaveBeenCalledWith(
-        'named-resume',
+        'sdk-live-only',
         expect.objectContaining({ priority: 'visible', includeBodies: true, revision: 1 }),
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       )
@@ -431,7 +434,6 @@ describe('agent chat resume history flow', () => {
         sessionId: 'sdk-live-only',
         latestTurnId: 'turn-live-2',
         status: 'idle',
-        timelineSessionId: 'named-resume',
         revision: 2,
       })
     })
@@ -439,7 +441,7 @@ describe('agent chat resume history flow', () => {
     await waitFor(() => {
       expect(getAgentTimelinePage).toHaveBeenNthCalledWith(
         2,
-        'named-resume',
+        'sdk-live-only',
         expect.objectContaining({ priority: 'visible', includeBodies: true, revision: 2 }),
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       )
@@ -454,9 +456,16 @@ describe('agent chat resume history flow', () => {
     expect(screen.getAllByText('Post-watermark live delta')).toHaveLength(1)
 
     const pane = findLeaf(store.getState().panes.layouts.t1!, 'p1')
-    expect(pane?.content.kind === 'agent-chat' ? pane.content.resumeSessionId : undefined).toBe(canonicalSessionId)
+    expect(pane?.content.kind === 'agent-chat' ? pane.content.sessionRef : undefined).toEqual({
+      provider: 'claude',
+      sessionId: canonicalSessionId,
+    })
     const tab = store.getState().tabs.tabs.find((entry) => entry.id === 't1')
-    expect(tab?.resumeSessionId).toBe(canonicalSessionId)
+    expect(tab?.resumeSessionId).toBeUndefined()
+    expect(tab?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: canonicalSessionId,
+    })
     expect(tab?.sessionMetadataByKey).toEqual({
       [sessionMetadataKey('claude', canonicalSessionId)]: {
         sessionType: 'freshclaude',
@@ -551,7 +560,10 @@ describe('agent chat resume history flow', () => {
         provider: 'freshclaude',
         createRequestId: 'req-restart',
         sessionId: 'sdk-stale-778',
-        resumeSessionId: canonicalSessionId,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: canonicalSessionId,
+        },
         status: 'idle',
       },
     }))
@@ -613,7 +625,10 @@ describe('agent chat resume history flow', () => {
     })
 
     const pane = findLeaf(store.getState().panes.layouts.t1!, 'p1')
-    expect(pane?.content.kind === 'agent-chat' ? pane.content.resumeSessionId : undefined).toBe(canonicalSessionId)
+    expect(pane?.content.kind === 'agent-chat' ? pane.content.sessionRef : undefined).toEqual({
+      provider: 'claude',
+      sessionId: canonicalSessionId,
+    })
     expect(pane?.content.kind === 'agent-chat' ? pane.content.sessionId : undefined).toBeUndefined()
   })
 })

--- a/test/e2e/codex-refresh-rehydrate-flow.test.tsx
+++ b/test/e2e/codex-refresh-rehydrate-flow.test.tsx
@@ -209,6 +209,12 @@ function sentMessages() {
   return wsHarness.send.mock.calls.map(([msg]) => msg)
 }
 
+function getTerminalPaneContent(store: ReturnType<typeof createStore>, tabId: string): TerminalPaneContent | null {
+  const layout = store.getState().panes.layouts[tabId] as PaneNode | undefined
+  if (!layout || layout.type !== 'leaf' || layout.content.kind !== 'terminal') return null
+  return layout.content
+}
+
 describe('codex refresh rehydrate flow (e2e)', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -279,14 +285,39 @@ describe('codex refresh rehydrate flow (e2e)', () => {
         requestId: 'req-codex-refresh',
         terminalId: 'term-codex-refresh-old',
         createdAt: 1,
-        effectiveResumeSessionId: 'thread-new-1',
       })
     })
 
     await waitFor(() => {
       const persisted = readPersistedLayoutSnapshotForTest()
-      expect(persisted?.tabs.tabs.find((tab) => tab.id === tabId)?.resumeSessionId).toBe('thread-new-1')
-      expect((persisted?.panes.layouts[tabId] as any)?.content?.resumeSessionId).toBe('thread-new-1')
+      expect(persisted?.tabs.tabs.find((tab) => tab.id === tabId)?.resumeSessionId).toBeUndefined()
+      expect(persisted?.tabs.tabs.find((tab) => tab.id === tabId)?.sessionRef).toBeUndefined()
+      expect((persisted?.panes.layouts[tabId] as any)?.content?.resumeSessionId).toBeUndefined()
+      expect((persisted?.panes.layouts[tabId] as any)?.content?.sessionRef).toBeUndefined()
+      expect((persisted?.panes.layouts[tabId] as any)?.content?.terminalId).toBe('term-codex-refresh-old')
+    })
+
+    act(() => {
+      wsHarness.emit({
+        type: 'terminal.session.associated',
+        terminalId: 'term-codex-refresh-old',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: 'codex-session-1',
+        },
+      })
+    })
+
+    await waitFor(() => {
+      const persisted = readPersistedLayoutSnapshotForTest()
+      expect(persisted?.tabs.tabs.find((tab) => tab.id === tabId)?.sessionRef).toEqual({
+        provider: 'codex',
+        sessionId: 'codex-session-1',
+      })
+      expect((persisted?.panes.layouts[tabId] as any)?.content?.sessionRef).toEqual({
+        provider: 'codex',
+        sessionId: 'codex-session-1',
+      })
     })
 
     const persisted = readPersistedLayoutSnapshotForTest()
@@ -337,8 +368,131 @@ describe('codex refresh rehydrate flow (e2e)', () => {
       expect(recreated).toMatchObject({
         type: 'terminal.create',
         mode: 'codex',
-        resumeSessionId: 'thread-new-1',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: 'codex-session-1',
+        },
         restore: true,
+      })
+      expect(recreated?.resumeSessionId).toBeUndefined()
+    })
+  })
+
+  it('reattaches a same-server live Codex terminal before any durable identity exists', async () => {
+    const tabId = 'tab-codex-live'
+    const paneId = 'pane-codex-live'
+    const store = createStore({
+      tabs: {
+        tabs: [{
+          id: tabId,
+          mode: 'codex',
+          status: 'running',
+          title: 'Codex',
+          titleSetByUser: false,
+          createRequestId: 'req-codex-live',
+        }],
+        activeTabId: tabId,
+      },
+      panes: {
+        layouts: {
+          [tabId]: {
+            type: 'leaf',
+            id: paneId,
+            content: {
+              kind: 'terminal',
+              createRequestId: 'req-codex-live',
+              status: 'running',
+              mode: 'codex',
+              shell: 'system',
+              terminalId: 'term-codex-live',
+            },
+          },
+        },
+        activePane: { [tabId]: paneId },
+        paneTitles: {},
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalViewFromStore tabId={tabId} paneId={paneId} />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(sentMessages().some((msg) => (
+        msg?.type === 'terminal.attach'
+        && msg?.terminalId === 'term-codex-live'
+      ))).toBe(true)
+    })
+
+    expect(sentMessages().some((msg) => msg?.type === 'terminal.create')).toBe(false)
+  })
+
+  it('surfaces restore-unavailable instead of starting a fresh Codex session when a live-only terminal is gone', async () => {
+    const tabId = 'tab-codex-live-only'
+    const paneId = 'pane-codex-live-only'
+    const store = createStore({
+      tabs: {
+        tabs: [{
+          id: tabId,
+          mode: 'codex',
+          status: 'running',
+          title: 'Codex',
+          titleSetByUser: false,
+          createRequestId: 'req-codex-live-only',
+        }],
+        activeTabId: tabId,
+      },
+      panes: {
+        layouts: {
+          [tabId]: {
+            type: 'leaf',
+            id: paneId,
+            content: {
+              kind: 'terminal',
+              createRequestId: 'req-codex-live-only',
+              status: 'running',
+              mode: 'codex',
+              shell: 'system',
+              terminalId: 'term-codex-live-only',
+            },
+          },
+        },
+        activePane: { [tabId]: paneId },
+        paneTitles: {},
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalViewFromStore tabId={tabId} paneId={paneId} />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(sentMessages().some((msg) => (
+        msg?.type === 'terminal.attach'
+        && msg?.terminalId === 'term-codex-live-only'
+      ))).toBe(true)
+    })
+
+    const baselineMessages = sentMessages().length
+
+    act(() => {
+      wsHarness.emit({
+        type: 'error',
+        code: 'INVALID_TERMINAL_ID',
+        message: 'Unknown terminalId',
+        terminalId: 'term-codex-live-only',
+      })
+    })
+
+    await waitFor(() => {
+      expect(sentMessages().slice(baselineMessages).some((msg) => msg?.type === 'terminal.create')).toBe(false)
+      expect((getTerminalPaneContent(store, tabId) as any)?.restoreError).toEqual({
+        code: 'RESTORE_UNAVAILABLE',
+        reason: 'dead_live_handle',
       })
     })
   })

--- a/test/e2e/open-tab-session-sidebar-visibility.test.tsx
+++ b/test/e2e/open-tab-session-sidebar-visibility.test.tsx
@@ -1096,7 +1096,7 @@ describe('open tab session sidebar visibility (e2e)', () => {
     })
   })
 
-  it('shows a fallback sidebar item for a Claude tab with a human-readable resume name', async () => {
+  it('does not synthesize a sidebar fallback item from a Claude tab human-readable resume name', async () => {
     const namedResumeName = '137 tour'
     fetchSidebarSessionsSnapshot.mockResolvedValueOnce({
       projects: [],
@@ -1145,10 +1145,8 @@ describe('open tab session sidebar visibility (e2e)', () => {
       </Provider>,
     )
 
-    await waitFor(() => {
-      // The session should appear in the sidebar as a fallback item
-      expect(screen.getAllByText('137 tour').length).toBeGreaterThan(0)
-    })
+    await screen.findByText('No sessions yet')
+    expect(screen.queryByTestId('sidebar-session-list')).not.toBeInTheDocument()
   })
 
   it('keeps an open Codex session visible when the indexed sidebar row is titleless', async () => {
@@ -1180,6 +1178,10 @@ describe('open tab session sidebar visibility (e2e)', () => {
         id: 'tab-1',
         title: 'Investigate sidebar visibility',
         mode: 'codex',
+        sessionRef: {
+          provider: 'codex',
+          sessionId,
+        },
         resumeSessionId: sessionId,
         createdAt: Date.now(),
       }],
@@ -1193,6 +1195,10 @@ describe('open tab session sidebar visibility (e2e)', () => {
               mode: 'codex',
               createRequestId: 'req-1',
               status: 'running',
+              sessionRef: {
+                provider: 'codex',
+                sessionId,
+              },
               resumeSessionId: sessionId,
               initialCwd: '/repo',
             },
@@ -1222,6 +1228,87 @@ describe('open tab session sidebar visibility (e2e)', () => {
     await waitFor(() => {
       expect(fetchSidebarSessionsSnapshot).toHaveBeenCalled()
       expect(within(sidebarList).getAllByText('Investigate sidebar visibility').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('keeps an open Codex session visible after the local tab title changes because matching stays session-based', async () => {
+    const sessionId = 'codex-renamed-local-title'
+    fetchSidebarSessionsSnapshot.mockResolvedValue({
+      projects: [
+        {
+          projectPath: '/repo',
+          sessions: [
+            {
+              provider: 'codex',
+              sessionId,
+              projectPath: '/repo',
+              lastActivityAt: 50,
+              title: 'Indexed session title',
+              cwd: '/repo',
+            },
+          ],
+        },
+      ],
+      totalSessions: 1,
+      oldestIncludedTimestamp: 50,
+      oldestIncludedSessionId: `codex:${sessionId}`,
+      hasMore: false,
+    })
+
+    const store = createStore({
+      tabs: [{
+        id: 'tab-rename-stable',
+        title: 'Locally renamed title',
+        mode: 'codex',
+        sessionRef: {
+          provider: 'codex',
+          sessionId,
+        },
+        resumeSessionId: sessionId,
+        createdAt: Date.now(),
+      }],
+      panes: {
+        layouts: {
+          'tab-rename-stable': {
+            type: 'leaf',
+            id: 'pane-rename-stable',
+            content: {
+              kind: 'terminal',
+              mode: 'codex',
+              createRequestId: 'req-rename-stable',
+              status: 'running',
+              resumeSessionId: sessionId,
+              sessionRef: {
+                provider: 'codex',
+                sessionId,
+              },
+              initialCwd: '/repo',
+            },
+          },
+        },
+        activePane: { 'tab-rename-stable': 'pane-rename-stable' },
+        paneTitles: { 'tab-rename-stable': { 'pane-rename-stable': 'Locally renamed title' } },
+      },
+      connection: {
+        status: 'ready',
+        serverInstanceId: 'srv-local',
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>,
+    )
+
+    const sidebarList = await screen.findByTestId('sidebar-session-list')
+
+    await waitFor(() => {
+      const matchingButton = within(sidebarList)
+        .getAllByRole('button')
+        .find((button) => button.getAttribute('data-session-id') === sessionId)
+      expect(matchingButton).toBeTruthy()
+      expect(matchingButton).toHaveTextContent('Indexed session title')
     })
   })
 })

--- a/test/e2e/pane-activity-indicator-flow.test.tsx
+++ b/test/e2e/pane-activity-indicator-flow.test.tsx
@@ -323,6 +323,7 @@ describe('pane activity indicator flow (e2e)', () => {
   })
 
   it('shows OpenCode terminals blue only for exact terminal busy activity and clears on removal', () => {
+    const sessionId = '33333333-3333-4333-8333-333333333333'
     const pane: TerminalPaneContent = {
       kind: 'terminal',
       createRequestId: 'req-opencode',
@@ -330,7 +331,10 @@ describe('pane activity indicator flow (e2e)', () => {
       mode: 'opencode',
       shell: 'system',
       terminalId: 'term-opencode',
-      resumeSessionId: 'session-opencode',
+      sessionRef: {
+        provider: 'opencode',
+        sessionId,
+      },
     }
 
     const { store } = renderHarness({
@@ -338,7 +342,10 @@ describe('pane activity indicator flow (e2e)', () => {
       tab: {
         mode: 'opencode',
         terminalId: 'term-opencode',
-        resumeSessionId: 'session-opencode',
+        sessionRef: {
+          provider: 'opencode',
+          sessionId,
+        },
       },
     })
 

--- a/test/e2e/sidebar-click-opens-pane.test.tsx
+++ b/test/e2e/sidebar-click-opens-pane.test.tsx
@@ -360,7 +360,8 @@ describe('sidebar click opens pane (e2e)', () => {
         (child: any) =>
           child.type === 'leaf' &&
           child.content.kind === 'terminal' &&
-          child.content.resumeSessionId === sessionId('new-session')
+          child.content.sessionRef?.provider === 'claude' &&
+          child.content.sessionRef?.sessionId === sessionId('new-session')
       )
       expect(sessionPane).toBeDefined()
       // The new pane should be in 'creating' status (not running, since no terminalId)
@@ -605,7 +606,10 @@ describe('sidebar click opens pane (e2e)', () => {
 
     // Should create a new tab via openSessionTab fallback
     expect(state.tabs.tabs).toHaveLength(1)
-    expect(state.tabs.tabs[0].resumeSessionId).toBe(sessionId('orphan-session'))
+    expect(state.tabs.tabs[0].sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: sessionId('orphan-session'),
+    })
     expect(state.tabs.tabs[0].mode).toBe('claude')
     expect(onNavigate).toHaveBeenCalledWith('terminal')
   })

--- a/test/e2e/sidebar-search-flow.test.tsx
+++ b/test/e2e/sidebar-search-flow.test.tsx
@@ -309,6 +309,10 @@ describe('sidebar search flow (e2e)', () => {
         title: 'Open Matching Tab',
         mode: 'codex',
         resumeSessionId: matchingFallbackSessionId,
+        sessionRef: {
+          provider: 'codex',
+          sessionId: matchingFallbackSessionId,
+        },
         createdAt: 1_000,
       }],
       panes: {
@@ -322,6 +326,10 @@ describe('sidebar search flow (e2e)', () => {
               status: 'running',
               createRequestId: 'req-fallback',
               resumeSessionId: matchingFallbackSessionId,
+              sessionRef: {
+                provider: 'codex',
+                sessionId: matchingFallbackSessionId,
+              },
               initialCwd: '/tmp/code/trycycle',
             },
           },

--- a/test/e2e/tabs-view-flow.test.tsx
+++ b/test/e2e/tabs-view-flow.test.tsx
@@ -117,10 +117,12 @@ describe('tabs view flow', () => {
           kind: 'terminal',
           payload: {
             mode: 'codex',
-            resumeSessionId: 'codex-session-123',
             sessionRef: {
               provider: 'codex',
               sessionId: 'codex-session-123',
+            },
+            liveTerminal: {
+              terminalId: 'term-remote-1',
               serverInstanceId: 'srv-remote',
             },
           },
@@ -147,7 +149,74 @@ describe('tabs view flow', () => {
     expect(copiedLayout?.content?.sessionRef).toEqual({
       provider: 'codex',
       sessionId: 'codex-session-123',
-      serverInstanceId: 'srv-remote',
     })
+    expect(copiedLayout?.content?.terminalId).toBeUndefined()
+  })
+
+  it('opens same-server tab copies with an explicit live terminal handle', () => {
+    const store = configureStore({
+      reducer: {
+        tabs: tabsReducer,
+        panes: panesReducer,
+        tabRegistry: tabRegistryReducer,
+        connection: connectionReducer,
+      },
+    })
+    store.dispatch(setServerInstanceId('srv-local'))
+
+    store.dispatch(setTabRegistrySnapshot({
+      localOpen: [],
+      remoteOpen: [{
+        tabKey: 'remote:tab-codex-local',
+        tabId: 'tab-codex-local',
+        serverInstanceId: 'srv-local',
+        deviceId: 'remote',
+        deviceLabel: 'remote-device',
+        tabName: 'codex local',
+        status: 'open',
+        revision: 3,
+        createdAt: 10,
+        updatedAt: 20,
+        paneCount: 1,
+        titleSetByUser: false,
+        panes: [{
+          paneId: 'pane-codex-local',
+          kind: 'terminal',
+          payload: {
+            mode: 'codex',
+            sessionRef: {
+              provider: 'codex',
+              sessionId: 'codex-session-456',
+            },
+            liveTerminal: {
+              terminalId: 'term-local-1',
+              serverInstanceId: 'srv-local',
+            },
+          },
+        }],
+      }],
+      closed: [],
+    }))
+
+    render(
+      <Provider store={store}>
+        <TabsView />
+      </Provider>,
+    )
+
+    const remoteCard = screen.getByLabelText('remote-device: codex local')
+    expect(remoteCard).toBeTruthy()
+    fireEvent.click(remoteCard)
+
+    const copiedTab = store.getState().tabs.tabs[0]
+    expect(copiedTab?.title).toBe('codex local')
+    const copiedLayout = copiedTab ? (store.getState().panes.layouts[copiedTab.id] as any) : undefined
+    expect(copiedLayout?.content?.resumeSessionId).toBeUndefined()
+    expect(copiedLayout?.content?.sessionRef).toEqual({
+      provider: 'codex',
+      sessionId: 'codex-session-456',
+    })
+    expect(copiedLayout?.content?.terminalId).toBe('term-local-1')
+    expect(copiedLayout?.content?.serverInstanceId).toBe('srv-local')
   })
 })

--- a/test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs
+++ b/test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import fs from 'node:fs'
+import path from 'node:path'
 import { WebSocketServer } from 'ws'
 
 function parseListenUrl(argv) {
@@ -16,6 +18,41 @@ function loadBehavior() {
   return JSON.parse(raw)
 }
 
+function getCodexHome() {
+  return process.env.CODEX_HOME || '/tmp/fake-codex-home'
+}
+
+function getRolloutSessionDir() {
+  const now = new Date()
+  const year = String(now.getUTCFullYear())
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(now.getUTCDate()).padStart(2, '0')
+  return path.join(getCodexHome(), 'sessions', year, month, day)
+}
+
+function getThreadHandle(threadId) {
+  return {
+    id: threadId,
+    path: path.join(getRolloutSessionDir(), `rollout-${threadId}.jsonl`),
+    ephemeral: false,
+  }
+}
+
+function ensureDurableArtifact(threadId) {
+  const thread = getThreadHandle(threadId)
+  const codexHome = process.env.CODEX_HOME || '/tmp/fake-codex-home'
+  const now = new Date()
+  const sessionDir = path.dirname(thread.path)
+  fs.mkdirSync(sessionDir, { recursive: true })
+  fs.writeFileSync(thread.path, JSON.stringify({
+    threadId,
+    createdAt: now.toISOString(),
+  }) + '\n', 'utf8')
+  return {
+    codexHome,
+    thread,
+  }
+}
 function writeBytes(stream, totalBytes, chunkSize = 16 * 1024) {
   if (!Number.isFinite(totalBytes) || totalBytes <= 0) {
     return Promise.resolve()
@@ -48,16 +85,14 @@ function successResult(method, params) {
   if (method === 'initialize') {
     return {
       userAgent: 'freshell-fixture/1.0.0',
-      codexHome: '/tmp/fake-codex-home',
+      codexHome: getCodexHome(),
       platformFamily: 'unix',
       platformOs: 'linux',
     }
   }
   if (method === 'thread/start') {
     return {
-      thread: {
-        id: 'thread-new-1',
-      },
+      thread: getThreadHandle('thread-new-1'),
       cwd: params?.cwd ?? process.cwd(),
       model: 'fixture-model',
       modelProvider: 'openai',
@@ -70,10 +105,9 @@ function successResult(method, params) {
     }
   }
   if (method === 'thread/resume') {
+    const threadId = params?.threadId || 'thread-new-1'
     return {
-      thread: {
-        id: params?.threadId,
-      },
+      thread: getThreadHandle(threadId),
       cwd: params?.cwd ?? process.cwd(),
       model: 'fixture-model',
       modelProvider: 'openai',
@@ -85,17 +119,56 @@ function successResult(method, params) {
       },
     }
   }
+  if (method === 'turn/start') {
+    return {
+      thread: getThreadHandle(params?.threadId || 'thread-new-1'),
+    }
+  }
+  if (method === 'fs/watch') {
+    return {
+      path: path.resolve(String(params?.path || '')),
+    }
+  }
+  if (method === 'fs/unwatch') {
+    return {}
+  }
   return {}
 }
 
 const listenUrl = parseListenUrl(process.argv.slice(2))
 const behavior = loadBehavior()
 const closeSocketAfterMethodsOnce = new Set(behavior.closeSocketAfterMethodsOnce || [])
+const exitProcessAfterMethodsOnce = new Set(behavior.exitProcessAfterMethodsOnce || [])
 const url = new URL(listenUrl)
 const host = url.hostname
 const port = Number(url.port)
+const watches = new Map()
 
 const wss = new WebSocketServer({ host, port })
+
+function broadcastNotification(method, params) {
+  const payload = JSON.stringify({
+    jsonrpc: '2.0',
+    method,
+    params,
+  })
+  for (const client of wss.clients) {
+    if (client.readyState === 1) {
+      client.send(payload)
+    }
+  }
+}
+
+function emitConfiguredNotifications(method) {
+  const notifications = behavior.notifyAfterMethodsOnce?.[method]
+  if (!Array.isArray(notifications) || notifications.length === 0) {
+    return
+  }
+  delete behavior.notifyAfterMethodsOnce[method]
+  for (const notification of notifications) {
+    broadcastNotification(notification.method, notification.params)
+  }
+}
 
 wss.on('connection', (socket) => {
   let initialized = false
@@ -145,15 +218,53 @@ wss.on('connection', (socket) => {
     setTimeout(async () => {
       await writeBytes(process.stdout, floodStdoutBytes)
       await writeBytes(process.stderr, floodStderrBytes)
+      const result = override?.result ?? successResult(method, message.params)
       socket.send(JSON.stringify({
         id: message.id,
-        result: override?.result ?? successResult(method, message.params),
+        result,
       }))
       if (method === 'initialize') {
         initialized = true
       }
+      if (method === 'thread/start') {
+        const thread = result?.thread || getThreadHandle(message.params?.threadId || 'thread-new-1')
+        broadcastNotification('thread/started', {
+          thread,
+        })
+      }
+      if (method === 'fs/watch') {
+        const watchId = message.params?.watchId
+        const watchedPath = result?.path
+        if (watchId && watchedPath) {
+          watches.set(watchId, watchedPath)
+        }
+      }
+      if (method === 'fs/unwatch') {
+        const watchId = message.params?.watchId
+        if (watchId) {
+          watches.delete(watchId)
+        }
+      }
+      if (method === 'turn/start' && message.params?.threadId) {
+        const { thread } = ensureDurableArtifact(message.params.threadId)
+        const rolloutPath = thread.path
+        const rolloutParent = path.dirname(rolloutPath)
+        for (const [watchId, watchedPath] of watches) {
+          if (watchedPath !== rolloutPath && watchedPath !== rolloutParent) {
+            continue
+          }
+          broadcastNotification('fs/changed', {
+            watchId,
+            changedPaths: [rolloutPath],
+          })
+        }
+      }
+      emitConfiguredNotifications(method)
       if (closeSocketAfterMethodsOnce.delete(method)) {
         setTimeout(() => socket.close(), 0)
+      }
+      if (exitProcessAfterMethodsOnce.delete(method)) {
+        setTimeout(() => process.exit(0), 0)
       }
     }, delayMs)
   })

--- a/test/helpers/coding-cli/fake-codex-launch-planner.ts
+++ b/test/helpers/coding-cli/fake-codex-launch-planner.ts
@@ -1,20 +1,60 @@
 export const DEFAULT_CODEX_REMOTE_WS_URL = 'ws://127.0.0.1:43123'
 
+export class FakeCodexTerminalSidecar {
+  attachedTerminalId?: string
+  durableSessionHandlers = new Set<(sessionId: string) => void>()
+  fatalHandlers = new Set<(error: Error) => void>()
+  shutdownCalls = 0
+
+  attachTerminal(input: {
+    terminalId: string
+    onDurableSession: (sessionId: string) => void
+    onFatal: (error: Error) => void
+  }) {
+    this.attachedTerminalId = input.terminalId
+    this.durableSessionHandlers.add(input.onDurableSession)
+    this.fatalHandlers.add(input.onFatal)
+  }
+
+  async shutdown() {
+    this.shutdownCalls += 1
+  }
+
+  emitDurableSession(sessionId: string) {
+    for (const handler of this.durableSessionHandlers) {
+      handler(sessionId)
+    }
+  }
+
+  emitFatal(message = 'fake codex sidecar failed') {
+    const error = new Error(message)
+    for (const handler of this.fatalHandlers) {
+      handler(error)
+    }
+  }
+}
+
 export class FakeCodexLaunchPlanner {
   planCreateCalls: any[] = []
+  readonly sidecar: FakeCodexTerminalSidecar
 
   constructor(
     private readonly plan: {
-      sessionId: string
+      sessionId?: string
       remote: { wsUrl: string }
+      sidecar?: FakeCodexTerminalSidecar
     } = {
-      sessionId: 'thread-new-1',
       remote: { wsUrl: DEFAULT_CODEX_REMOTE_WS_URL },
     },
-  ) {}
+  ) {
+    this.sidecar = this.plan.sidecar ?? new FakeCodexTerminalSidecar()
+  }
 
   async planCreate(input: any) {
     this.planCreateCalls.push(input)
-    return this.plan
+    return {
+      ...this.plan,
+      sidecar: this.sidecar,
+    }
   }
 }

--- a/test/helpers/coding-cli/real-session-contract-harness.ts
+++ b/test/helpers/coding-cli/real-session-contract-harness.ts
@@ -1,0 +1,1317 @@
+import { execFile, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { DatabaseSync } from 'node:sqlite'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+import * as pty from 'node-pty'
+import WebSocket, { WebSocketServer } from 'ws'
+
+import { allocateLocalhostPort } from '../../../server/local-port.js'
+
+const execFileAsync = promisify(execFile)
+const NOTE_PATH = path.resolve(
+  process.cwd(),
+  'docs/lab-notes/2026-04-20-coding-cli-session-contract.md',
+)
+
+type NoteCleanupFacts = {
+  liveProcessAuditCommand: string
+  ownershipReportFields: string[]
+  safeToStopRequires: string[]
+  safeExamples: string[]
+  unsafeExamples: string[]
+}
+
+type CodexFacts = {
+  executable: string
+  resolvedPath: string
+  version: string
+  freshRemoteBootstrapCommand: string
+  freshRemoteBootstrapEventsBeforeUserTurn: string[]
+  remoteResumeBootstrapStablePrefix: string[]
+  remoteResumeBootstrapFollowupMethods: string[]
+  freshRemoteAllocatesThreadBeforeUserTurn: boolean
+  shellSnapshotGlob: string
+  durableArtifactGlob: string
+  freshInteractiveCreatesShellSnapshotBeforeTurn: boolean
+  freshInteractiveCreatesDurableSessionBeforeTurn: boolean
+  appServerThreadPathAvailableBeforeArtifact: boolean
+  appServerMissingPathWatchAccepted: boolean
+  appServerMissingParentWatchAccepted: boolean
+  appServerWatchEchoesCallerWatchId: boolean
+  appServerArtifactMaterializesAtReportedPath: boolean
+  appServerChangedPathsMentionRolloutPath: boolean
+  resumeCommandTemplate: string
+  mutableNameSurface: 'absent'
+}
+
+type ClaudeFacts = {
+  executable: string
+  resolvedPath: string
+  isolatedBinaryPath: string
+  version: string
+  exactIdCommandTemplate: string
+  namedResumeCommandTemplate: string
+  transcriptGlob: string
+  canonicalIdentity: 'uuid-transcript'
+  namedResumeWorksInPrintMode: boolean
+  renameMutatesMetadataOnly: boolean
+  oldTitleStopsResolvingAfterRename: boolean
+  oldTitleErrorFragment: string
+}
+
+type OpencodeFacts = {
+  executable: string
+  resolvedPath: string
+  version: string
+  runCommandTemplate: string
+  serveCommandTemplate: string
+  globalHealthPath: string
+  sessionStatusPath: string
+  canonicalIdentity: 'session-id'
+  runEventSessionIdMatchesDbId: boolean
+  busyStatusUsesAuthoritativeSessionId: boolean
+  titleOnResumeMutatesStoredTitle: boolean
+  sessionSubcommands: string[]
+}
+
+export type CodingCliSessionContractNote = {
+  capturedOn: string
+  planCreatedOn: string
+  dateReason: string
+  cleanup: NoteCleanupFacts
+  providers: {
+    codex: CodexFacts
+    claude: ClaudeFacts
+    opencode: OpencodeFacts
+  }
+}
+
+export type ResolvedProviderBinary = {
+  executable: string
+  resolvedPath: string | null
+  version: string | null
+}
+
+type ProcessTreeRow = {
+  pid: number
+  ppid: number
+  command: string
+}
+
+export type OwnershipReportEntry = {
+  pid: number
+  ppid: number
+  cwd: string | null
+  tempHome: string | null
+  sentinelPath: string | null
+  safeToStop: boolean
+  command: string
+}
+
+export type CodexRpcNotification = {
+  method: string
+  params: any
+}
+
+export type CodexThreadHandle = {
+  id: string
+  path: string | null
+  ephemeral: boolean
+}
+
+export type CodexFsChangedNotification = {
+  watchId: string
+  changedPaths: string[]
+}
+
+type TrackedRootHandle = {
+  pid: number
+  stop: () => Promise<void>
+}
+
+type PendingRpcRequest = {
+  method: string
+  resolve: (value: any) => void
+  reject: (error: Error) => void
+  timeout: NodeJS.Timeout
+}
+
+type ExitSummary = {
+  code: number | null
+  signal: NodeJS.Signals | null
+}
+
+export type TrackedProcess = {
+  pid: number
+  stdout: () => string
+  stderr: () => string
+  stop: () => Promise<void>
+  waitForExit: (timeoutMs?: number) => Promise<ExitSummary>
+  child: ChildProcessWithoutNullStreams
+}
+
+export type TrackedPtyProcess = {
+  pid: number
+  output: () => string
+  write: (chars: string) => void
+  stop: () => Promise<void>
+  waitForExit: (timeoutMs?: number) => Promise<ExitSummary>
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function waitFor<T>(
+  label: string,
+  predicate: () => Promise<T | undefined> | T | undefined,
+  timeoutMs = 30_000,
+  intervalMs = 100,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const value = await predicate()
+    if (value !== undefined) {
+      return value
+    }
+    await sleep(intervalMs)
+  }
+  throw new Error(`Timed out waiting for ${label} within ${timeoutMs}ms.`)
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fsp.access(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function listFilesRecursive(rootDir: string): Promise<string[]> {
+  if (!(await pathExists(rootDir))) {
+    return []
+  }
+
+  const entries = await fsp.readdir(rootDir, { withFileTypes: true })
+  const files: string[] = []
+  for (const entry of entries) {
+    const entryPath = path.join(rootDir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...await listFilesRecursive(entryPath))
+      continue
+    }
+    files.push(entryPath)
+  }
+  return files
+}
+
+async function waitForHttpJson(url: string, timeoutMs = 30_000): Promise<unknown> {
+  return waitFor(`HTTP JSON at ${url}`, async () => {
+    try {
+      const response = await fetch(url)
+      if (!response.ok) {
+        return undefined
+      }
+      return response.json()
+    } catch {
+      return undefined
+    }
+  }, timeoutMs, 200)
+}
+
+function parseJsonLines(text: string): unknown[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line))
+}
+
+async function readProcEnviron(pid: number): Promise<Record<string, string>> {
+  try {
+    const raw = await fsp.readFile(`/proc/${pid}/environ`)
+    return raw
+      .toString('utf8')
+      .split('\u0000')
+      .filter((entry) => entry.length > 0)
+      .reduce<Record<string, string>>((acc, entry) => {
+        const separator = entry.indexOf('=')
+        if (separator === -1) {
+          return acc
+        }
+        acc[entry.slice(0, separator)] = entry.slice(separator + 1)
+        return acc
+      }, {})
+  } catch {
+    return {}
+  }
+}
+
+async function readProcCwd(pid: number): Promise<string | null> {
+  try {
+    return await fsp.realpath(`/proc/${pid}/cwd`)
+  } catch {
+    return null
+  }
+}
+
+async function listProcesses(): Promise<ProcessTreeRow[]> {
+  const { stdout } = await execFileAsync('ps', ['-eo', 'pid=,ppid=,cmd=', '--sort=pid'], {
+    cwd: process.cwd(),
+  })
+
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(\d+)\s+(.*)$/)
+      if (!match) {
+        throw new Error(`Could not parse ps output row: ${line}`)
+      }
+      return {
+        pid: Number(match[1]),
+        ppid: Number(match[2]),
+        command: match[3],
+      }
+    })
+}
+
+async function processExists(pid: number): Promise<boolean> {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function killPid(pid: number, timeoutMs = 5_000): Promise<void> {
+  if (!(await processExists(pid))) {
+    return
+  }
+
+  try {
+    process.kill(pid, 'SIGTERM')
+  } catch {}
+
+  const terminated = await waitFor(`pid ${pid} exit`, async () => {
+    return (await processExists(pid)) ? undefined : true
+  }, timeoutMs, 100).catch(() => false)
+
+  if (terminated) {
+    return
+  }
+
+  try {
+    process.kill(pid, 'SIGKILL')
+  } catch {}
+
+  await waitFor(`pid ${pid} forced exit`, async () => {
+    return (await processExists(pid)) ? undefined : true
+  }, timeoutMs, 100)
+}
+
+async function copyFileStrict(sourcePath: string, targetPath: string, label: string): Promise<void> {
+  if (!(await pathExists(sourcePath))) {
+    throw new Error(`Missing required ${label} at ${sourcePath}.`)
+  }
+  await fsp.mkdir(path.dirname(targetPath), { recursive: true })
+  await fsp.copyFile(sourcePath, targetPath)
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  options: {
+    cwd?: string
+    env?: NodeJS.ProcessEnv
+    timeoutMs?: number
+  } = {},
+): Promise<{
+  code: number | null
+  signal: NodeJS.Signals | null
+  stdout: string
+  stderr: string
+}> {
+  const child = spawn(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let stdout = ''
+  let stderr = ''
+  child.stdout.setEncoding('utf8')
+  child.stderr.setEncoding('utf8')
+  child.stdout.on('data', (chunk: string) => {
+    stdout += chunk
+  })
+  child.stderr.on('data', (chunk: string) => {
+    stderr += chunk
+  })
+
+  const timeoutMs = options.timeoutMs ?? 30_000
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error(`Timed out running ${command} ${args.join(' ')} after ${timeoutMs}ms.`))
+    }, timeoutMs)
+
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.once('close', (code, signal) => {
+      clearTimeout(timeout)
+      resolve({
+        code,
+        signal,
+        stdout,
+        stderr,
+      })
+    })
+  })
+}
+
+export async function loadCodingCliSessionContractNote(): Promise<CodingCliSessionContractNote> {
+  const markdown = await fsp.readFile(NOTE_PATH, 'utf8')
+  const match = markdown.match(/## Machine-readable contract\s+```json\r?\n([\s\S]*?)\r?\n```/)
+  if (!match) {
+    throw new Error(`Could not find the machine-readable contract block in ${NOTE_PATH}.`)
+  }
+  return JSON.parse(match[1]) as CodingCliSessionContractNote
+}
+
+export async function readCodingCliSessionContractMarkdown(): Promise<string> {
+  return fsp.readFile(NOTE_PATH, 'utf8')
+}
+
+export async function resolveProviderBinary(
+  executable: string,
+  versionArgs: string[] = ['--version'],
+): Promise<ResolvedProviderBinary> {
+  const resolution = await runCommand('bash', ['-lc', `command -v -- ${executable}`], {
+    cwd: process.cwd(),
+    timeoutMs: 5_000,
+  })
+  if (resolution.code !== 0) {
+    return {
+      executable,
+      resolvedPath: null,
+      version: null,
+    }
+  }
+
+  const resolvedPath = resolution.stdout.trim().split(/\r?\n/)[0] ?? null
+  if (!resolvedPath) {
+    return {
+      executable,
+      resolvedPath: null,
+      version: null,
+    }
+  }
+
+  const versionResult = await runCommand(resolvedPath, versionArgs, {
+    cwd: process.cwd(),
+    timeoutMs: 15_000,
+  })
+  const version = `${versionResult.stdout}${versionResult.stderr}`.trim().split(/\r?\n/)[0] ?? null
+  return {
+    executable,
+    resolvedPath,
+    version,
+  }
+}
+
+export async function resolveProviderBinaries(
+  executables: readonly string[],
+): Promise<Record<string, ResolvedProviderBinary>> {
+  const entries = await Promise.all(
+    executables.map(async (executable) => [executable, await resolveProviderBinary(executable)] as const),
+  )
+  return Object.fromEntries(entries)
+}
+
+export class ProbeWorkspace {
+  readonly provider: string
+  readonly tempRoot: string
+  readonly sentinelPath: string
+
+  private readonly trackedRoots: TrackedRootHandle[] = []
+
+  private constructor(provider: string, tempRoot: string, sentinelPath: string) {
+    this.provider = provider
+    this.tempRoot = tempRoot
+    this.sentinelPath = sentinelPath
+  }
+
+  static async create(provider: string): Promise<ProbeWorkspace> {
+    const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), `freshell-${provider}-contract-`))
+    const sentinelPath = path.join(tempRoot, 'probe-owned.json')
+    const workspace = new ProbeWorkspace(provider, tempRoot, sentinelPath)
+
+    await fsp.writeFile(
+      sentinelPath,
+      JSON.stringify(
+        {
+          provider,
+          tempRoot,
+          sentinelPath,
+          createdAt: new Date().toISOString(),
+          probeRunId: randomUUID(),
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+
+    return workspace
+  }
+
+  taggedEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      FRESHELL_PROBE_HOME: this.tempRoot,
+      FRESHELL_PROBE_SENTINEL: this.sentinelPath,
+      FRESHELL_PROBE_PROVIDER: this.provider,
+      ...extra,
+    }
+  }
+
+  inTemp(...segments: string[]): string {
+    return path.join(this.tempRoot, ...segments)
+  }
+
+  async spawnProcess(
+    command: string,
+    args: string[],
+    options: {
+      cwd?: string
+      env?: NodeJS.ProcessEnv
+    } = {},
+  ): Promise<TrackedProcess> {
+    const child = spawn(command, args, {
+      cwd: options.cwd ?? process.cwd(),
+      env: this.taggedEnv(options.env),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk
+    })
+
+    const waitForExit = (timeoutMs = 30_000) =>
+      new Promise<ExitSummary>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error(`Timed out waiting for process ${command} (${child.pid}) to exit.`))
+        }, timeoutMs)
+
+        child.once('error', (error) => {
+          clearTimeout(timeout)
+          reject(error)
+        })
+        child.once('close', (code, signal) => {
+          clearTimeout(timeout)
+          resolve({
+            code,
+            signal,
+          })
+        })
+      })
+
+    const stop = async () => {
+      if (child.pid === undefined) {
+        return
+      }
+      await killPid(child.pid)
+    }
+
+    if (child.pid !== undefined) {
+      this.trackedRoots.push({
+        pid: child.pid,
+        stop,
+      })
+    }
+
+    return {
+      pid: child.pid ?? -1,
+      stdout: () => stdout,
+      stderr: () => stderr,
+      stop,
+      waitForExit,
+      child,
+    }
+  }
+
+  spawnPty(
+    command: string,
+    args: string[],
+    options: {
+      cwd?: string
+      env?: NodeJS.ProcessEnv
+      cols?: number
+      rows?: number
+    } = {},
+  ): TrackedPtyProcess {
+    const processHandle = pty.spawn(command, args, {
+      cwd: options.cwd ?? process.cwd(),
+      env: this.taggedEnv(options.env),
+      cols: options.cols ?? 120,
+      rows: options.rows ?? 40,
+      name: 'xterm-color',
+    })
+
+    let output = ''
+    let exitSummary: ExitSummary | null = null
+    const exitPromise = new Promise<ExitSummary>((resolve) => {
+      processHandle.onData((chunk) => {
+        output += chunk
+      })
+      processHandle.onExit(({ exitCode, signal }) => {
+        exitSummary = {
+          code: exitCode,
+          signal: signal ? 'SIGTERM' : null,
+        }
+        resolve(exitSummary)
+      })
+    })
+
+    const stop = async () => {
+      processHandle.kill()
+      await exitPromise.catch(() => undefined)
+    }
+
+    this.trackedRoots.push({
+      pid: processHandle.pid,
+      stop,
+    })
+
+    return {
+      pid: processHandle.pid,
+      output: () => output,
+      write: (chars: string) => {
+        processHandle.write(chars)
+      },
+      stop,
+      waitForExit: async (timeoutMs = 30_000) => {
+        return Promise.race([
+          exitPromise,
+          sleep(timeoutMs).then(() => {
+            throw new Error(`Timed out waiting for PTY ${command} (${processHandle.pid}) to exit.`)
+          }),
+        ])
+      },
+    }
+  }
+
+  async buildOwnershipReport(): Promise<OwnershipReportEntry[]> {
+    const processRows = await listProcesses()
+    const processMap = new Map(processRows.map((row) => [row.pid, row]))
+    const childrenByParent = new Map<number, number[]>()
+
+    for (const row of processRows) {
+      const siblings = childrenByParent.get(row.ppid) ?? []
+      siblings.push(row.pid)
+      childrenByParent.set(row.ppid, siblings)
+    }
+
+    const candidatePids = new Set<number>()
+    const stack = this.trackedRoots
+      .map((root) => root.pid)
+      .filter((pid) => processMap.has(pid))
+
+    while (stack.length > 0) {
+      const pid = stack.pop()
+      if (pid === undefined || candidatePids.has(pid)) {
+        continue
+      }
+      candidatePids.add(pid)
+      const children = childrenByParent.get(pid) ?? []
+      for (const childPid of children) {
+        stack.push(childPid)
+      }
+    }
+
+    const report: OwnershipReportEntry[] = []
+    for (const pid of [...candidatePids].sort((left, right) => left - right)) {
+      const row = processMap.get(pid)
+      if (!row) {
+        continue
+      }
+      const cwd = await readProcCwd(pid)
+      const environ = await readProcEnviron(pid)
+      const tempHome = environ.FRESHELL_PROBE_HOME ?? null
+      const sentinelPath = environ.FRESHELL_PROBE_SENTINEL ?? null
+      report.push({
+        pid,
+        ppid: row.ppid,
+        cwd,
+        tempHome,
+        sentinelPath,
+        safeToStop: tempHome === this.tempRoot && sentinelPath === this.sentinelPath,
+        command: row.command,
+      })
+    }
+
+    return report
+  }
+
+  async cleanup(): Promise<OwnershipReportEntry[]> {
+    const report = await this.buildOwnershipReport()
+    const unsafe = report.filter((entry) => !entry.safeToStop)
+    if (unsafe.length > 0) {
+      const rendered = unsafe
+        .map((entry) => JSON.stringify(entry))
+        .join('\n')
+      throw new Error(`Refusing cleanup because one or more candidate processes are not probe-owned.\n${rendered}`)
+    }
+
+    const livePids = report.map((entry) => entry.pid).sort((left, right) => right - left)
+    for (const pid of livePids) {
+      await killPid(pid).catch(() => undefined)
+    }
+
+    await fsp.rm(this.tempRoot, { recursive: true, force: true })
+    return report
+  }
+}
+
+export async function seedCodexHome(workspace: ProbeWorkspace): Promise<string> {
+  const codexHome = workspace.inTemp('.codex')
+  await copyFileStrict(path.join(os.homedir(), '.codex', 'auth.json'), path.join(codexHome, 'auth.json'), 'Codex auth.json')
+  await copyFileStrict(path.join(os.homedir(), '.codex', 'config.toml'), path.join(codexHome, 'config.toml'), 'Codex config.toml')
+  return codexHome
+}
+
+export async function seedClaudeHome(workspace: ProbeWorkspace): Promise<string> {
+  const homeRoot = workspace.tempRoot
+  await copyFileStrict(
+    path.join(os.homedir(), '.claude', '.credentials.json'),
+    path.join(homeRoot, '.claude', '.credentials.json'),
+    'Claude .credentials.json',
+  )
+  return homeRoot
+}
+
+export async function seedOpencodeHomes(workspace: ProbeWorkspace): Promise<{
+  dataHome: string
+  configHome: string
+  dbPath: string
+}> {
+  const dataHome = workspace.inTemp('.local', 'share')
+  const configHome = workspace.inTemp('.config')
+  await copyFileStrict(
+    path.join(os.homedir(), '.local', 'share', 'opencode', 'auth.json'),
+    path.join(dataHome, 'opencode', 'auth.json'),
+    'OpenCode auth.json',
+  )
+  await copyFileStrict(
+    path.join(os.homedir(), '.config', 'opencode', 'opencode.json'),
+    path.join(configHome, 'opencode', 'opencode.json'),
+    'OpenCode opencode.json',
+  )
+  return {
+    dataHome,
+    configHome,
+    dbPath: path.join(dataHome, 'opencode', 'opencode.db'),
+  }
+}
+
+export async function findCodexShellSnapshots(workspace: ProbeWorkspace): Promise<string[]> {
+  const snapshotRoot = workspace.inTemp('.codex', 'shell_snapshots')
+  const files = await listFilesRecursive(snapshotRoot)
+  return files.filter((filePath) => filePath.endsWith('.sh'))
+}
+
+export async function findCodexSessionArtifacts(workspace: ProbeWorkspace): Promise<string[]> {
+  const sessionsRoot = workspace.inTemp('.codex', 'sessions')
+  const files = await listFilesRecursive(sessionsRoot)
+  return files.filter((filePath) => filePath.endsWith('.jsonl'))
+}
+
+export async function waitForCodexShellSnapshot(workspace: ProbeWorkspace): Promise<string> {
+  return waitFor('Codex shell snapshot', async () => {
+    const files = await findCodexShellSnapshots(workspace)
+    return files[0]
+  }, 30_000, 250)
+}
+
+export async function waitForCodexSessionArtifact(workspace: ProbeWorkspace): Promise<string> {
+  return waitFor('Codex durable session artifact', async () => {
+    const files = await findCodexSessionArtifacts(workspace)
+    return files[0]
+  }, 60_000, 250)
+}
+
+export function extractCodexResumeId(artifactPath: string): string {
+  const match = path.basename(artifactPath).match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/)
+  if (!match) {
+    throw new Error(`Could not extract a Codex resume id from ${artifactPath}.`)
+  }
+  return match[1]
+}
+
+export async function startCodexAppServer(
+  workspace: ProbeWorkspace,
+  codexPath: string,
+): Promise<{
+  wsUrl: string
+  process: TrackedProcess
+}> {
+  const endpoint = await allocateLocalhostPort()
+  const wsUrl = `ws://${endpoint.hostname}:${endpoint.port}`
+  const processHandle = await workspace.spawnProcess(codexPath, ['app-server', '--listen', wsUrl], {
+    env: {
+      CODEX_HOME: workspace.inTemp('.codex'),
+    },
+  })
+
+  await waitFor(`Codex app-server websocket ${wsUrl}`, async () => {
+    const stderr = processHandle.stderr()
+    if (stderr.includes('EADDRINUSE')) {
+      throw new Error(`Codex app-server could not bind ${wsUrl}: ${stderr}`)
+    }
+
+    return new Promise<boolean | undefined>((resolve) => {
+      const socket = new WebSocket(wsUrl)
+      const cleanup = () => {
+        socket.removeAllListeners()
+      }
+      socket.once('open', () => {
+        cleanup()
+        socket.close()
+        resolve(true)
+      })
+      socket.once('error', () => {
+        cleanup()
+        resolve(undefined)
+      })
+    })
+  }, 30_000, 200)
+
+  await sleep(500)
+  return {
+    wsUrl,
+    process: processHandle,
+  }
+}
+
+export class CodexRpcProbeClient {
+  private readonly socket: WebSocket
+  private readonly pendingRequests = new Map<number, PendingRpcRequest>()
+  private readonly notifications: CodexRpcNotification[] = []
+  private nextRequestId = 1
+
+  private constructor(socket: WebSocket) {
+    this.socket = socket
+    this.socket.on('message', (raw) => this.handleMessage(raw))
+    this.socket.on('close', () => this.handleClose())
+    this.socket.on('error', () => this.handleClose())
+  }
+
+  static async connect(wsUrl: string): Promise<CodexRpcProbeClient> {
+    const socket = await new Promise<WebSocket>((resolve, reject) => {
+      const connection = new WebSocket(wsUrl)
+      const cleanup = () => {
+        connection.off('error', onError)
+        connection.off('open', onOpen)
+      }
+      const onError = (error: Error) => {
+        cleanup()
+        reject(error)
+      }
+      const onOpen = () => {
+        cleanup()
+        resolve(connection)
+      }
+      connection.once('error', onError)
+      connection.once('open', onOpen)
+    })
+
+    return new CodexRpcProbeClient(socket)
+  }
+
+  async initialize(): Promise<any> {
+    return this.request('initialize', {
+      clientInfo: { name: 'freshell-contract-probe', version: '1.0.0' },
+      capabilities: {
+        experimentalApi: true,
+        optOutNotificationMethods: ['thread/started'],
+      },
+    })
+  }
+
+  async startThread(cwd: string): Promise<any> {
+    return this.request('thread/start', {
+      cwd,
+      experimentalRawEvents: false,
+      persistExtendedHistory: true,
+    })
+  }
+
+  async resumeThread(threadId: string, cwd: string): Promise<any> {
+    return this.request('thread/resume', {
+      threadId,
+      cwd,
+      persistExtendedHistory: true,
+    })
+  }
+
+  async fsWatch(targetPath: string, watchId: string): Promise<{ path: string }> {
+    return this.request('fs/watch', {
+      path: targetPath,
+      watchId,
+    })
+  }
+
+  async fsUnwatch(watchId: string): Promise<void> {
+    await this.request('fs/unwatch', {
+      watchId,
+    })
+  }
+
+  async startTurn(threadId: string, text: string): Promise<any> {
+    return this.request('turn/start', {
+      threadId,
+      input: [
+        {
+          type: 'text',
+          text,
+        },
+      ],
+    })
+  }
+
+  async waitForNotification(
+    method: string,
+    predicate: (notification: CodexRpcNotification) => boolean = () => true,
+    timeoutMs = 60_000,
+  ): Promise<CodexRpcNotification> {
+    return waitFor(`Codex notification ${method}`, () => {
+      return this.notifications.find((notification) => (
+        notification.method === method && predicate(notification)
+      ))
+    }, timeoutMs, 100)
+  }
+
+  async close(): Promise<void> {
+    for (const [, pending] of this.pendingRequests) {
+      clearTimeout(pending.timeout)
+      pending.reject(new Error(`Codex websocket closed before ${pending.method} completed.`))
+    }
+    this.pendingRequests.clear()
+
+    await new Promise<void>((resolve) => {
+      if (this.socket.readyState === WebSocket.CLOSED) {
+        resolve()
+        return
+      }
+      this.socket.once('close', () => resolve())
+      this.socket.close()
+    })
+  }
+
+  private async request(method: string, params: any, timeoutMs = 30_000): Promise<any> {
+    const id = this.nextRequestId
+    this.nextRequestId += 1
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(id)
+        reject(new Error(`Timed out waiting for Codex RPC ${method}.`))
+      }, timeoutMs)
+
+      this.pendingRequests.set(id, {
+        method,
+        resolve,
+        reject,
+        timeout,
+      })
+
+      this.socket.send(JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method,
+        params,
+      }))
+    })
+  }
+
+  private handleMessage(raw: WebSocket.RawData): void {
+    let message: any
+    try {
+      message = JSON.parse(raw.toString())
+    } catch {
+      return
+    }
+
+    if (typeof message.id === 'number') {
+      const pending = this.pendingRequests.get(message.id)
+      if (!pending) {
+        return
+      }
+      clearTimeout(pending.timeout)
+      this.pendingRequests.delete(message.id)
+      if (message.error) {
+        pending.reject(new Error(`Codex RPC ${pending.method} failed: ${JSON.stringify(message.error)}`))
+        return
+      }
+      pending.resolve(message.result)
+      return
+    }
+
+    if (typeof message.method === 'string') {
+      this.notifications.push({
+        method: message.method,
+        params: message.params ?? null,
+      })
+    }
+  }
+
+  private handleClose(): void {
+    for (const [, pending] of this.pendingRequests) {
+      clearTimeout(pending.timeout)
+      pending.reject(new Error(`Codex websocket closed before ${pending.method} completed.`))
+    }
+    this.pendingRequests.clear()
+  }
+}
+
+export async function captureCodexBootstrapEvents(
+  workspace: ProbeWorkspace,
+  codexPath: string,
+): Promise<string[]> {
+  const endpoint = await allocateLocalhostPort()
+  const events: string[] = ['connection']
+  const wss = new WebSocketServer({
+    host: endpoint.hostname,
+    port: endpoint.port,
+  })
+
+  wss.on('connection', (socket) => {
+    socket.on('message', (raw) => {
+      const message = JSON.parse(raw.toString()) as {
+        id?: number
+        method?: string
+        params?: unknown
+      }
+      if (message.method) {
+        events.push(message.method)
+      }
+
+      if (message.id === undefined || !message.method) {
+        return
+      }
+
+      const sendResult = (result: unknown) => {
+        socket.send(JSON.stringify({
+          jsonrpc: '2.0',
+          id: message.id,
+          result,
+        }))
+      }
+
+      if (message.method === 'initialize') {
+        sendResult({
+          userAgent: 'freshell-contract-probe/1.0.0',
+          codexHome: workspace.inTemp('.codex'),
+          platformFamily: 'unix',
+          platformOs: process.platform,
+        })
+        return
+      }
+
+      if (message.method === 'account/read') {
+        sendResult({
+          requiresOpenaiAuth: false,
+          account: {
+            type: 'chatgpt',
+            email: 'probe@example.com',
+            planType: 'plus',
+          },
+        })
+        return
+      }
+
+      if (message.method === 'model/list') {
+        sendResult({
+          data: [
+            {
+              id: 'gpt-5-codex',
+              model: 'gpt-5-codex',
+              displayName: 'GPT-5 Codex',
+              description: 'Probe model',
+              hidden: false,
+              isDefault: true,
+              defaultReasoningEffort: 'high',
+              supportedReasoningEfforts: [
+                {
+                  reasoningEffort: 'minimal',
+                  description: 'Minimal reasoning',
+                },
+                {
+                  reasoningEffort: 'high',
+                  description: 'High reasoning',
+                },
+              ],
+              inputModalities: ['text', 'image'],
+              additionalSpeedTiers: [],
+              supportsPersonality: false,
+              availabilityNux: null,
+              upgrade: null,
+              upgradeInfo: null,
+            },
+          ],
+          nextCursor: null,
+        })
+        return
+      }
+
+      if (message.method === 'thread/start') {
+        sendResult({
+          thread: {
+            id: 'thread-bootstrap-1',
+          },
+          cwd: process.cwd(),
+          model: 'gpt-5-codex',
+          modelProvider: 'openai',
+          instructionSources: [],
+          approvalPolicy: 'never',
+          approvalsReviewer: 'user',
+          sandbox: {
+            type: 'dangerFullAccess',
+          },
+        })
+      }
+    })
+  })
+
+  const remote = workspace.spawnPty(codexPath, ['--remote', `ws://${endpoint.hostname}:${endpoint.port}`, '--no-alt-screen'], {
+    env: {
+      CODEX_HOME: workspace.inTemp('.codex'),
+    },
+  })
+
+  try {
+    await waitFor('Codex bootstrap thread/start', async () => {
+      return events.includes('thread/start') ? true : undefined
+    }, 30_000, 100)
+    return [...events]
+  } finally {
+    await remote.stop().catch(() => undefined)
+    await new Promise<void>((resolve) => wss.close(() => resolve()))
+  }
+}
+
+export async function captureCodexResumeBootstrapEvents(
+  workspace: ProbeWorkspace,
+  codexPath: string,
+  resumeId: string,
+): Promise<string[]> {
+  const upstream = await startCodexAppServer(workspace, codexPath)
+  const endpoint = await allocateLocalhostPort()
+  const proxyUrl = `ws://${endpoint.hostname}:${endpoint.port}`
+  const events: string[] = ['connection']
+  const wss = new WebSocketServer({
+    host: endpoint.hostname,
+    port: endpoint.port,
+  })
+
+  wss.on('connection', (client) => {
+    const upstreamSocket = new WebSocket(upstream.wsUrl)
+    const pendingMessages: string[] = []
+
+    const flushPending = () => {
+      while (pendingMessages.length > 0 && upstreamSocket.readyState === WebSocket.OPEN) {
+        const message = pendingMessages.shift()
+        if (message) {
+          upstreamSocket.send(message)
+        }
+      }
+    }
+
+    client.on('message', (raw) => {
+      const serialized = raw.toString()
+      try {
+        const message = JSON.parse(serialized)
+        if (typeof message.method === 'string') {
+          events.push(message.method)
+        }
+      } catch {}
+
+      if (upstreamSocket.readyState === WebSocket.OPEN) {
+        upstreamSocket.send(serialized)
+        return
+      }
+      pendingMessages.push(serialized)
+    })
+
+    upstreamSocket.on('open', flushPending)
+    upstreamSocket.on('message', (raw) => {
+      client.send(raw.toString())
+    })
+    client.on('close', () => {
+      upstreamSocket.close()
+    })
+    upstreamSocket.on('close', () => {
+      client.close()
+    })
+  })
+
+  const remote = workspace.spawnPty(
+    codexPath,
+    ['--remote', proxyUrl, '--no-alt-screen', 'resume', resumeId],
+    {
+      env: {
+        CODEX_HOME: workspace.inTemp('.codex'),
+      },
+    },
+  )
+
+  try {
+    await waitFor('Codex bootstrap thread/resume', async () => {
+      return events.includes('thread/resume') ? true : undefined
+    }, 60_000, 100)
+    await sleep(2_000)
+    return [...events]
+  } finally {
+    await remote.stop().catch(() => undefined)
+    await new Promise<void>((resolve) => wss.close(() => resolve()))
+    await upstream.process.stop().catch(() => undefined)
+  }
+}
+
+export async function findClaudeTranscript(
+  workspace: ProbeWorkspace,
+  sessionId: string,
+): Promise<string> {
+  return waitFor(`Claude transcript ${sessionId}`, async () => {
+    const files = await listFilesRecursive(workspace.inTemp('.claude', 'projects'))
+    return files.find((filePath) => filePath.endsWith(`${sessionId}.jsonl`))
+  }, 30_000, 200)
+}
+
+export async function readClaudeTranscriptLines(transcriptPath: string): Promise<string[]> {
+  return (await fsp.readFile(transcriptPath, 'utf8'))
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0)
+}
+
+export function queryOpencodeSessionRow(dbPath: string, sessionId: string): {
+  id: string
+  title: string
+  directory: string
+} | null {
+  const database = new DatabaseSync(dbPath)
+  try {
+    return database
+      .prepare('select id, title, directory from session where id = ? limit 1')
+      .get(sessionId) as {
+        id: string
+        title: string
+        directory: string
+      } | null
+  } finally {
+    database.close()
+  }
+}
+
+export async function waitForOpencodeDbSession(dbPath: string, sessionId: string): Promise<{
+  id: string
+  title: string
+  directory: string
+}> {
+  return waitFor(`OpenCode DB row ${sessionId}`, async () => {
+    if (!(await pathExists(dbPath))) {
+      return undefined
+    }
+    return queryOpencodeSessionRow(dbPath, sessionId) ?? undefined
+  }, 30_000, 250)
+}
+
+export async function waitForJsonLine(
+  processHandle: TrackedProcess,
+  predicate: (value: any) => boolean,
+  timeoutMs = 30_000,
+): Promise<any> {
+  return waitFor('JSON line output', async () => {
+    const lines = parseJsonLines(processHandle.stdout())
+    return lines.find(predicate)
+  }, timeoutMs, 100)
+}
+
+export async function waitForSubstring(
+  readText: () => string,
+  needle: string,
+  timeoutMs = 30_000,
+): Promise<void> {
+  await waitFor(`substring ${needle}`, () => {
+    return readText().includes(needle) ? true : undefined
+  }, timeoutMs, 100)
+}
+
+export async function waitForFileSizeIncrease(filePath: string, previousSize: number, timeoutMs = 30_000): Promise<number> {
+  const stat = await waitFor(`file size increase for ${filePath}`, async () => {
+    if (!(await pathExists(filePath))) {
+      return undefined
+    }
+    const current = await fsp.stat(filePath)
+    return current.size > previousSize ? current.size : undefined
+  }, timeoutMs, 200)
+  return stat
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Expected a successful response from ${url}, received ${response.status}.`)
+  }
+  return response.json()
+}
+
+export async function waitForHttpBusyStatus(url: string, sessionId: string): Promise<Record<string, { type: string }>> {
+  return waitFor(`OpenCode busy status for ${sessionId}`, async () => {
+    const payload = await fetchJson(url).catch(() => undefined)
+    if (!payload || typeof payload !== 'object') {
+      return undefined
+    }
+    const record = payload as Record<string, { type: string }>
+    return record[sessionId]?.type === 'busy' ? record : undefined
+  }, 30_000, 200)
+}
+
+export async function waitForAnyHttpBusyStatus(
+  url: string,
+): Promise<{ sessionId: string; payload: Record<string, { type: string }> }> {
+  return waitFor('OpenCode busy status', async () => {
+    const payload = await fetchJson(url).catch(() => undefined)
+    if (!payload || typeof payload !== 'object') {
+      return undefined
+    }
+    const record = payload as Record<string, { type: string }>
+    const match = Object.entries(record).find(([, status]) => status?.type === 'busy')
+    if (!match) return undefined
+    return {
+      sessionId: match[0],
+      payload: record,
+    }
+  }, 30_000, 200)
+}
+
+export async function waitForHttpHealthy(url: string): Promise<any> {
+  return waitForHttpJson(url, 30_000)
+}

--- a/test/integration/real/coding-cli-session-contract.test.ts
+++ b/test/integration/real/coding-cli-session-contract.test.ts
@@ -1,0 +1,545 @@
+// @vitest-environment node
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  CodexRpcProbeClient,
+  ProbeWorkspace,
+  captureCodexBootstrapEvents,
+  captureCodexResumeBootstrapEvents,
+  extractCodexResumeId,
+  fetchJson,
+  findClaudeTranscript,
+  findCodexSessionArtifacts,
+  loadCodingCliSessionContractNote,
+  queryOpencodeSessionRow,
+  readClaudeTranscriptLines,
+  readCodingCliSessionContractMarkdown,
+  resolveProviderBinaries,
+  seedClaudeHome,
+  seedCodexHome,
+  seedOpencodeHomes,
+  startCodexAppServer,
+  waitForCodexSessionArtifact,
+  waitForCodexShellSnapshot,
+  waitForFileSizeIncrease,
+  waitForAnyHttpBusyStatus,
+  waitForHttpHealthy,
+  waitForJsonLine,
+  waitForOpencodeDbSession,
+} from '../../helpers/coding-cli/real-session-contract-harness.js'
+
+if (process.env.FRESHELL_REAL_PROVIDER_CONTRACTS !== '1') {
+  throw new Error('This opt-in suite must run with FRESHELL_REAL_PROVIDER_CONTRACTS=1.')
+}
+
+const note = await loadCodingCliSessionContractNote()
+const noteMarkdown = await readCodingCliSessionContractMarkdown()
+const providerBinaries = await resolveProviderBinaries(['codex', 'claude', 'opencode'] as const)
+
+const codexBinary = providerBinaries.codex
+const claudeBinary = providerBinaries.claude
+const opencodeBinary = providerBinaries.opencode
+
+function requireResolvedBinary(binary: { executable: string; resolvedPath: string | null }): string {
+  if (!binary.resolvedPath) {
+    throw new Error(
+      `Required provider binary "${binary.executable}" is unavailable. ` +
+      'Install it or expose it on PATH before running npm run test:real:coding-cli-contracts.',
+    )
+  }
+  return binary.resolvedPath
+}
+
+describe.sequential('coding cli real provider session contract', () => {
+  it('loads the checked-in lab note facts and date rationale', async () => {
+    expect(note.capturedOn).toBe('2026-04-23')
+    expect(note.planCreatedOn).toBe('2026-04-19')
+    expect(note.dateReason).toContain('2026-04-23')
+    expect(note.dateReason).toContain('2026-04-19')
+    expect(noteMarkdown).toContain('The implementation plan file is dated `2026-04-19`')
+    expect(note.cleanup.ownershipReportFields).toEqual([
+      'pid',
+      'ppid',
+      'cwd',
+      'tempHome',
+      'sentinelPath',
+      'safeToStop',
+      'command',
+    ])
+  }, 30_000)
+
+  it('emits provenance-gated ownership reports before cleanup', async () => {
+    const workspace = await ProbeWorkspace.create('cleanup-audit')
+    try {
+      const sleeper = await workspace.spawnProcess('bash', ['-lc', 'sleep 30'])
+      expect(sleeper.pid).toBeGreaterThan(0)
+
+      const report = await workspace.buildOwnershipReport()
+      expect(report.length).toBeGreaterThan(0)
+      expect(report[0]).toEqual(expect.objectContaining({
+        pid: expect.any(Number),
+        ppid: expect.any(Number),
+        cwd: expect.any(String),
+        tempHome: workspace.tempRoot,
+        sentinelPath: workspace.sentinelPath,
+        safeToStop: true,
+        command: expect.any(String),
+      }))
+    } finally {
+      await workspace.cleanup().catch(() => undefined)
+    }
+  }, 30_000)
+
+  describe.sequential('codex', () => {
+    it('matches the recorded binary path and version, and uses the expected remote bootstrap forms', async () => {
+      const codexPath = requireResolvedBinary(codexBinary)
+      expect(codexPath).toBe(note.providers.codex.resolvedPath)
+      expect(codexBinary.version).toBe(note.providers.codex.version)
+
+      const workspace = await ProbeWorkspace.create('codex-bootstrap')
+      try {
+        await seedCodexHome(workspace)
+        const freshEvents = await captureCodexBootstrapEvents(workspace, codexPath)
+        expect(freshEvents).toEqual(note.providers.codex.freshRemoteBootstrapEventsBeforeUserTurn)
+      } finally {
+        await workspace.cleanup().catch(() => undefined)
+      }
+    }, 60_000)
+
+    it('surfaces the exact rollout path before it exists and emits fs/changed when the first turn materializes it', async () => {
+      const codexPath = requireResolvedBinary(codexBinary)
+      const workspace = await ProbeWorkspace.create('codex-rollout-watch')
+      const rolloutWatchId = 'probe-rollout-path'
+      const parentWatchId = 'probe-rollout-parent'
+
+      try {
+        await seedCodexHome(workspace)
+
+        const appServer = await startCodexAppServer(workspace, codexPath)
+        const client = await CodexRpcProbeClient.connect(appServer.wsUrl)
+        await client.initialize()
+
+        const start = await client.startThread(process.cwd())
+        expect(start.thread.ephemeral).toBe(false)
+        expect(start.thread.path).toMatch(/\/sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-.+\.jsonl$/)
+
+        const rolloutPath = start.thread.path as string
+        const rolloutParent = path.dirname(rolloutPath)
+        expect(await fsp.access(rolloutPath).then(() => true, () => false)).toBe(false)
+        expect(await fsp.access(rolloutParent).then(() => true, () => false)).toBe(false)
+
+        expect(await client.fsWatch(rolloutPath, rolloutWatchId)).toEqual({ path: rolloutPath })
+        expect(await client.fsWatch(rolloutParent, parentWatchId)).toEqual({ path: rolloutParent })
+
+        await client.startTurn(start.thread.id, 'Reply with exactly: codex-watch-probe')
+        await client.waitForNotification(
+          'turn/completed',
+          (notification) => notification.params?.threadId === start.thread.id,
+          120_000,
+        )
+
+        const artifactPath = await waitForCodexSessionArtifact(workspace)
+        expect(artifactPath).toBe(rolloutPath)
+
+        const changed = await client.waitForNotification(
+          'fs/changed',
+          (notification) => (
+            Array.isArray(notification.params?.changedPaths)
+            && notification.params.changedPaths.includes(rolloutPath)
+            && [rolloutWatchId, parentWatchId].includes(notification.params?.watchId)
+          ),
+          120_000,
+        )
+        expect(changed.params.watchId).toBeOneOf([rolloutWatchId, parentWatchId])
+
+        await client.fsUnwatch(rolloutWatchId)
+        await client.fsUnwatch(parentWatchId)
+        await client.close()
+        await appServer.process.stop()
+      } finally {
+        await workspace.cleanup().catch(() => undefined)
+      }
+    }, 180_000)
+
+    it('stays live-only until the durable artifact exists, then restores via the artifact id', async () => {
+      const codexPath = requireResolvedBinary(codexBinary)
+      const workspace = await ProbeWorkspace.create('codex-durable')
+      try {
+        await seedCodexHome(workspace)
+
+        const liveOnlyAppServer = await startCodexAppServer(workspace, codexPath)
+        const liveOnlyClient = await CodexRpcProbeClient.connect(liveOnlyAppServer.wsUrl)
+        await liveOnlyClient.initialize()
+        const liveOnlyThread = await liveOnlyClient.startThread(process.cwd())
+
+        const snapshotPath = await waitForCodexShellSnapshot(workspace)
+        expect(path.relative(workspace.inTemp('.codex'), snapshotPath)).toMatch(/^shell_snapshots\/.+\.sh$/)
+        expect(liveOnlyThread.thread.id).toMatch(/[0-9a-f-]{36}/)
+
+        expect(await findCodexSessionArtifacts(workspace)).toEqual([])
+        await liveOnlyClient.close()
+        await liveOnlyAppServer.process.stop()
+
+        const createAppServer = await startCodexAppServer(workspace, codexPath)
+        const createClient = await CodexRpcProbeClient.connect(createAppServer.wsUrl)
+        await createClient.initialize()
+        const createdThread = await createClient.startThread(process.cwd())
+        await createClient.startTurn(createdThread.thread.id, 'Reply with exactly: codex-contract-alpha')
+        await createClient.waitForNotification(
+          'turn/completed',
+          (notification) => notification.params?.threadId === createdThread.thread.id,
+          120_000,
+        )
+
+        const artifactPath = await waitForCodexSessionArtifact(workspace)
+        expect(path.relative(workspace.inTemp('.codex'), artifactPath)).toMatch(
+          /^sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-.+\.jsonl$/,
+        )
+        await createClient.close()
+        await createAppServer.process.stop()
+
+        const resumeId = extractCodexResumeId(artifactPath)
+        const sizeBeforeResume = (await fsp.stat(artifactPath)).size
+
+        const resumeBootstrapEvents = await captureCodexResumeBootstrapEvents(
+          workspace,
+          codexPath,
+          resumeId,
+        )
+        const expectedStablePrefix = note.providers.codex.remoteResumeBootstrapStablePrefix
+        const expectedFollowups = note.providers.codex.remoteResumeBootstrapFollowupMethods
+        expect(resumeBootstrapEvents.slice(0, expectedStablePrefix.length)).toEqual(expectedStablePrefix)
+        expect(
+          [...resumeBootstrapEvents.slice(expectedStablePrefix.length)].sort(),
+        ).toEqual([...expectedFollowups].sort())
+
+        const resumedAppServer = await startCodexAppServer(workspace, codexPath)
+        const resumedClient = await CodexRpcProbeClient.connect(resumedAppServer.wsUrl)
+        await resumedClient.initialize()
+        const resumedThread = await resumedClient.resumeThread(resumeId, process.cwd())
+        expect(resumedThread.thread.id).toBe(resumeId)
+        await resumedClient.startTurn(resumeId, 'Reply with exactly: codex-contract-beta')
+        await resumedClient.waitForNotification(
+          'turn/completed',
+          (notification) => notification.params?.threadId === resumeId,
+          120_000,
+        )
+
+        const resumedSize = await waitForFileSizeIncrease(artifactPath, sizeBeforeResume, 60_000)
+        expect(resumedSize).toBeGreaterThan(sizeBeforeResume)
+        expect(await findCodexSessionArtifacts(workspace)).toEqual([artifactPath])
+
+        await resumedClient.close()
+        await resumedAppServer.process.stop()
+      } finally {
+        await workspace.cleanup().catch(() => undefined)
+      }
+    }, 180_000)
+  })
+
+  describe.sequential('claude', () => {
+    it('matches the recorded binary path and version', async () => {
+      const claudePath = requireResolvedBinary(claudeBinary)
+      expect(claudePath).toBe(note.providers.claude.resolvedPath)
+      expect(claudeBinary.version).toBe(note.providers.claude.version)
+    }, 30_000)
+
+    it('creates UUID-backed transcripts and treats names as mutable metadata only', async () => {
+      requireResolvedBinary(claudeBinary)
+      const workspace = await ProbeWorkspace.create('claude-contract')
+      const exactSessionId = '44444444-4444-4444-8444-444444444444'
+      const namedSessionId = '55555555-5555-4555-8555-555555555555'
+      try {
+        await seedClaudeHome(workspace)
+
+        const exactCreate = await workspace.spawnProcess(
+          note.providers.claude.isolatedBinaryPath,
+          [
+            '--bare',
+            '--dangerously-skip-permissions',
+            '-p',
+            '--session-id',
+            exactSessionId,
+            'Reply with exactly: claude-home-probe-ok',
+          ],
+          {
+            env: {
+              HOME: workspace.tempRoot,
+            },
+          },
+        )
+        const exactExit = await exactCreate.waitForExit(60_000)
+        expect(exactExit.code).toBe(0)
+        expect(exactCreate.stdout().trim()).toBe('claude-home-probe-ok')
+
+          const exactTranscript = await findClaudeTranscript(workspace, exactSessionId)
+          expect(path.relative(workspace.inTemp('.claude'), exactTranscript)).toMatch(
+            /^projects\/.+\/44444444-4444-4444-8444-444444444444\.jsonl$/,
+          )
+
+          const namedCreate = await workspace.spawnProcess(
+            note.providers.claude.isolatedBinaryPath,
+            [
+              '--bare',
+              '--dangerously-skip-permissions',
+              '-p',
+              '--session-id',
+              namedSessionId,
+              '--name',
+              'probe-name-one',
+              'Reply with exactly: named-create-ok',
+            ],
+            {
+              env: {
+                HOME: workspace.tempRoot,
+              },
+            },
+          )
+          expect((await namedCreate.waitForExit(60_000)).code).toBe(0)
+          expect(namedCreate.stdout().trim()).toBe('named-create-ok')
+
+          const namedResume = await workspace.spawnProcess(
+            note.providers.claude.isolatedBinaryPath,
+            [
+              '--bare',
+              '--dangerously-skip-permissions',
+              '-p',
+              '--resume',
+              'probe-name-one',
+              'Reply with exactly: named-resume-ok',
+            ],
+            {
+              env: {
+                HOME: workspace.tempRoot,
+              },
+            },
+          )
+          expect((await namedResume.waitForExit(60_000)).code).toBe(0)
+          expect(namedResume.stdout().trim()).toBe('named-resume-ok')
+
+          const rename = await workspace.spawnProcess(
+            note.providers.claude.isolatedBinaryPath,
+            [
+              '--bare',
+              '--dangerously-skip-permissions',
+              '-p',
+              '--resume',
+              namedSessionId,
+              '--name',
+              'probe-name-two',
+              'Reply with exactly: renamed-ok',
+            ],
+            {
+              env: {
+                HOME: workspace.tempRoot,
+              },
+            },
+          )
+          expect((await rename.waitForExit(60_000)).code).toBe(0)
+          expect(rename.stdout().trim()).toBe('renamed-ok')
+
+          const transcriptPath = await findClaudeTranscript(workspace, namedSessionId)
+          const transcriptLines = await readClaudeTranscriptLines(transcriptPath)
+          expect(transcriptLines.some((line) => line.includes('"customTitle":"probe-name-one"'))).toBe(true)
+          expect(transcriptLines.some((line) => line.includes('"customTitle":"probe-name-two"'))).toBe(true)
+          expect(transcriptLines.some((line) => line.includes('"agentName":"probe-name-one"'))).toBe(true)
+          expect(transcriptLines.some((line) => line.includes('"agentName":"probe-name-two"'))).toBe(true)
+
+          const oldTitleResume = await workspace.spawnProcess(
+            note.providers.claude.isolatedBinaryPath,
+            [
+              '--bare',
+              '--dangerously-skip-permissions',
+              '-p',
+              '--resume',
+              'probe-name-one',
+              'Reply with exactly: should-not-run',
+            ],
+            {
+              env: {
+                HOME: workspace.tempRoot,
+              },
+            },
+          )
+          const oldTitleExit = await oldTitleResume.waitForExit(60_000)
+          expect(oldTitleExit.code).not.toBe(0)
+          expect(oldTitleResume.stderr()).toContain(note.providers.claude.oldTitleErrorFragment)
+
+          const newTitleResume = await workspace.spawnProcess(
+            note.providers.claude.isolatedBinaryPath,
+            [
+              '--bare',
+              '--dangerously-skip-permissions',
+              '-p',
+              '--resume',
+              'probe-name-two',
+              'Reply with exactly: renamed-title-ok',
+            ],
+            {
+              env: {
+                HOME: workspace.tempRoot,
+              },
+            },
+          )
+          expect((await newTitleResume.waitForExit(60_000)).code).toBe(0)
+          expect(newTitleResume.stdout().trim()).toBe('renamed-title-ok')
+      } finally {
+        await workspace.cleanup().catch(() => undefined)
+      }
+    }, 180_000)
+  })
+
+  describe.sequential('opencode', () => {
+    it('matches the recorded binary path and version', async () => {
+      const opencodePath = requireResolvedBinary(opencodeBinary)
+      expect(opencodePath).toBe(note.providers.opencode.resolvedPath)
+      expect(opencodeBinary.version).toBe(note.providers.opencode.version)
+    }, 30_000)
+
+    it('uses session ids as canonical identity and does not let titles replace them', async () => {
+      const opencodePath = requireResolvedBinary(opencodeBinary)
+      const workspace = await ProbeWorkspace.create('opencode-contract')
+      try {
+        const homes = await seedOpencodeHomes(workspace)
+        const runEnv = {
+          XDG_DATA_HOME: homes.dataHome,
+          XDG_CONFIG_HOME: homes.configHome,
+        }
+
+        const firstRun = await workspace.spawnProcess(
+          opencodePath,
+            [
+              'run',
+              'Reply with exactly: opencode-probe-ok',
+              '--format',
+              'json',
+              '--dangerously-skip-permissions',
+            ],
+            {
+              env: runEnv,
+            },
+          )
+
+          const firstStepStart = await waitForJsonLine(firstRun, (value) => value?.type === 'step_start', 60_000)
+          const firstSessionId = firstStepStart.sessionID as string
+          expect(firstSessionId).toMatch(/^ses_/)
+          const firstExit = await firstRun.waitForExit(60_000)
+          expect(firstExit.code).toBe(0)
+
+          const firstTextLine = JSON.parse(
+            firstRun.stdout().split(/\r?\n/).find((line) => line.includes('"type":"text"')) ?? '{}',
+          )
+          expect(firstTextLine.part?.text).toBe('opencode-probe-ok')
+
+          const firstDbRow = await waitForOpencodeDbSession(homes.dbPath, firstSessionId)
+          expect(firstDbRow.id).toBe(firstSessionId)
+
+          const servePort = 46123
+        const serve = await workspace.spawnProcess(
+          opencodePath,
+            ['serve', '--hostname', '127.0.0.1', '--port', String(servePort)],
+            {
+              env: runEnv,
+            },
+          )
+
+          const healthUrl = `http://127.0.0.1:${servePort}${note.providers.opencode.globalHealthPath}`
+          const statusUrl = `http://127.0.0.1:${servePort}${note.providers.opencode.sessionStatusPath}`
+          const health = await waitForHttpHealthy(healthUrl)
+          expect(health).toEqual({
+            healthy: true,
+            version: note.providers.opencode.version,
+          })
+          expect(await fetchJson(statusUrl)).toEqual({})
+
+        const attachedRun = await workspace.spawnProcess(
+          opencodePath,
+            [
+              'run',
+              'Explain the purpose of this repository in one sentence.',
+              '--format',
+              'json',
+              '--dangerously-skip-permissions',
+              '--attach',
+              `http://127.0.0.1:${servePort}`,
+            ],
+            {
+              env: runEnv,
+            },
+          )
+
+          const busyStatusPromise = waitForAnyHttpBusyStatus(statusUrl)
+          const attachedStepStart = await waitForJsonLine(attachedRun, (value) => value?.type === 'step_start', 60_000)
+          const attachedSessionId = attachedStepStart.sessionID as string
+          const busyStatus = await busyStatusPromise
+          expect(busyStatus.sessionId).toBe(attachedSessionId)
+          expect(busyStatus.payload[attachedSessionId]).toEqual({ type: 'busy' })
+          expect((await attachedRun.waitForExit(120_000)).code).toBe(0)
+
+        const titledRun = await workspace.spawnProcess(
+          opencodePath,
+            [
+              'run',
+              'Reply with exactly: opencode-title-one',
+              '--format',
+              'json',
+              '--dangerously-skip-permissions',
+              '--title',
+              'probe-title-one',
+            ],
+            {
+              env: runEnv,
+            },
+          )
+          const titledStepStart = await waitForJsonLine(titledRun, (value) => value?.type === 'step_start', 60_000)
+          const titledSessionId = titledStepStart.sessionID as string
+          expect((await titledRun.waitForExit(60_000)).code).toBe(0)
+
+        const retitledRun = await workspace.spawnProcess(
+          opencodePath,
+            [
+              'run',
+              'Reply with exactly: opencode-title-two',
+              '--format',
+              'json',
+              '--dangerously-skip-permissions',
+              '--session',
+              titledSessionId,
+              '--title',
+              'probe-title-two',
+            ],
+            {
+              env: runEnv,
+            },
+          )
+          const retitledStepStart = await waitForJsonLine(retitledRun, (value) => value?.type === 'step_start', 60_000)
+          expect(retitledStepStart.sessionID).toBe(titledSessionId)
+          expect((await retitledRun.waitForExit(60_000)).code).toBe(0)
+
+          const titledDbRow = queryOpencodeSessionRow(homes.dbPath, titledSessionId)
+          expect(titledDbRow?.title).toBe('probe-title-one')
+
+        const sessionHelp = await workspace.spawnProcess(
+          opencodePath,
+            ['session', '--help'],
+            {
+              env: runEnv,
+            },
+          )
+          expect((await sessionHelp.waitForExit(30_000)).code).toBe(0)
+          const helpOutput = `${sessionHelp.stdout()}${sessionHelp.stderr()}`
+          for (const subcommand of note.providers.opencode.sessionSubcommands) {
+            expect(helpOutput).toContain(subcommand)
+          }
+          expect(helpOutput).not.toContain('rename')
+
+        await serve.stop()
+      } finally {
+        await workspace.cleanup().catch(() => undefined)
+      }
+    }, 240_000)
+  })
+})

--- a/test/integration/server/codex-session-flow.test.ts
+++ b/test/integration/server/codex-session-flow.test.ts
@@ -3,12 +3,14 @@ import fsp from 'fs/promises'
 import http from 'http'
 import os from 'os'
 import path from 'path'
+import { createRequire } from 'node:module'
 import express from 'express'
 import WebSocket from 'ws'
 import { WsHandler } from '../../../server/ws-handler.js'
 import { TerminalRegistry } from '../../../server/terminal-registry.js'
 import { CodexAppServerRuntime } from '../../../server/coding-cli/codex-app-server/runtime.js'
 import { CodexLaunchPlanner } from '../../../server/coding-cli/codex-app-server/launch-planner.js'
+import { CodexTerminalSidecar } from '../../../server/coding-cli/codex-app-server/sidecar.js'
 import { configStore } from '../../../server/config-store.js'
 import { WS_PROTOCOL_VERSION } from '../../../shared/ws-protocol.js'
 
@@ -40,18 +42,141 @@ const FAKE_APP_SERVER_PATH = path.resolve(
   process.cwd(),
   'test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs',
 )
+const require = createRequire(import.meta.url)
+const WS_MODULE_PATH = require.resolve('ws')
 
 async function writeFakeCodexExecutable(binaryPath: string) {
   const script = `#!/usr/bin/env node
 const fs = require('fs')
+const WebSocket = require(${JSON.stringify(WS_MODULE_PATH)})
 
 const argLogPath = process.env.FAKE_CODEX_ARG_LOG
 if (argLogPath) {
   fs.writeFileSync(argLogPath, JSON.stringify(process.argv.slice(2)), 'utf8')
 }
 
-process.stdout.write('codex remote attached\\n')
-setTimeout(() => process.exit(0), 50)
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function maybeDriveRemote() {
+  const rawBehavior = process.env.FAKE_CODEX_REMOTE_BEHAVIOR
+  if (!rawBehavior) {
+    return
+  }
+
+  const args = process.argv.slice(2)
+  const remoteIndex = args.indexOf('--remote')
+  if (remoteIndex === -1 || remoteIndex === args.length - 1) {
+    return
+  }
+
+  const wsUrl = args[remoteIndex + 1]
+  const resumeIndex = args.indexOf('resume')
+  const resumeSessionId = resumeIndex === -1 ? undefined : args[resumeIndex + 1]
+  const behavior = JSON.parse(rawBehavior)
+
+  const socket = new WebSocket(wsUrl)
+  const pending = new Map()
+  let nextId = 1
+
+  const waitForOpen = new Promise((resolve, reject) => {
+    socket.once('open', resolve)
+    socket.once('error', reject)
+  })
+
+  socket.on('message', (raw) => {
+    let message
+    try {
+      message = JSON.parse(raw.toString())
+    } catch {
+      return
+    }
+    if (typeof message.id !== 'number') {
+      return
+    }
+    const pendingRequest = pending.get(message.id)
+    if (!pendingRequest) {
+      return
+    }
+    pending.delete(message.id)
+    if (message.error) {
+      pendingRequest.reject(new Error(message.error.message || 'remote app-server request failed'))
+      return
+    }
+    pendingRequest.resolve(message.result)
+  })
+
+  function request(method, params) {
+    return new Promise((resolve, reject) => {
+      const id = nextId++
+      pending.set(id, { resolve, reject })
+      socket.send(JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method,
+        params,
+      }), (error) => {
+        if (!error) {
+          return
+        }
+        pending.delete(id)
+        reject(error)
+      })
+    })
+  }
+
+  await waitForOpen
+  await request('initialize', {
+    clientInfo: { name: 'fake-codex-cli', version: '1.0.0' },
+    capabilities: { experimentalApi: true },
+  })
+
+  let threadId = resumeSessionId
+  if (resumeSessionId) {
+    await request('thread/resume', {
+      threadId: resumeSessionId,
+      cwd: process.cwd(),
+      persistExtendedHistory: true,
+    })
+  } else {
+    const started = await request('thread/start', {
+      cwd: process.cwd(),
+      experimentalRawEvents: false,
+      persistExtendedHistory: true,
+    })
+    threadId = started?.thread?.id
+  }
+
+  if (behavior.sendTurnStart && threadId) {
+    await request('turn/start', {
+      threadId,
+      input: 'fake turn',
+    })
+  }
+
+  if (behavior.recordRemoteThreadIdPath && threadId) {
+    fs.writeFileSync(behavior.recordRemoteThreadIdPath, threadId, 'utf8')
+  }
+
+  if (behavior.sleepMs) {
+    await sleep(behavior.sleepMs)
+  }
+
+  await new Promise((resolve) => socket.close(() => resolve()))
+}
+
+Promise.resolve()
+  .then(() => maybeDriveRemote())
+  .then(() => {
+    process.stdout.write('codex remote attached\\n')
+    setTimeout(() => process.exit(0), 50)
+  })
+  .catch((error) => {
+    const message = error instanceof Error ? error.stack || error.message : String(error)
+    process.stderr.write(message + '\\n')
+    process.exit(1)
+  })
 `
 
   await fsp.writeFile(binaryPath, script, 'utf8')
@@ -112,6 +237,20 @@ async function waitForFile(filePath: string, timeoutMs = 3_000): Promise<void> {
   throw new Error(`Timed out waiting for file: ${filePath}`)
 }
 
+async function waitForCondition(
+  predicate: () => Promise<boolean> | boolean,
+  timeoutMs = 3_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error('Timed out waiting for condition')
+}
+
 async function createAuthenticatedWs(port: number): Promise<WebSocket> {
   const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
   await new Promise<void>((resolve, reject) => {
@@ -162,34 +301,43 @@ describe('Codex Session Flow Integration', () => {
   let tempDir: string
   let fakeCodexPath: string
   let argLogPath: string
+  let remoteThreadLogPath: string
+  let codexHomePath: string
   let previousCodexCmd: string | undefined
   let previousFakeCodexArgLog: string | undefined
+  let previousFakeCodexRemoteBehavior: string | undefined
+  let previousCodexHome: string | undefined
   let server: http.Server
   let port: number
   let wsHandler: WsHandler
   let registry: TerminalRegistry
-  let runtime: CodexAppServerRuntime
   let planner: CodexLaunchPlanner
 
   beforeAll(async () => {
     tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-flow-'))
     fakeCodexPath = path.join(tempDir, 'fake-codex')
     argLogPath = path.join(tempDir, 'args.json')
+    remoteThreadLogPath = path.join(tempDir, 'remote-thread.txt')
+    codexHomePath = path.join(tempDir, '.codex-home')
     await writeFakeCodexExecutable(fakeCodexPath)
 
     previousCodexCmd = process.env.CODEX_CMD
     previousFakeCodexArgLog = process.env.FAKE_CODEX_ARG_LOG
+    previousFakeCodexRemoteBehavior = process.env.FAKE_CODEX_REMOTE_BEHAVIOR
+    previousCodexHome = process.env.CODEX_HOME
     process.env.CODEX_CMD = fakeCodexPath
     process.env.FAKE_CODEX_ARG_LOG = argLogPath
+    process.env.CODEX_HOME = codexHomePath
 
     const app = express()
     server = http.createServer(app)
     registry = new TerminalRegistry()
-    runtime = new CodexAppServerRuntime({
-      command: process.execPath,
-      commandArgs: [FAKE_APP_SERVER_PATH],
-    })
-    planner = new CodexLaunchPlanner(runtime)
+    planner = new CodexLaunchPlanner(() => new CodexTerminalSidecar({
+      runtime: new CodexAppServerRuntime({
+        command: process.execPath,
+        commandArgs: [FAKE_APP_SERVER_PATH],
+      }),
+    }))
     wsHandler = new WsHandler(server, registry, { codexLaunchPlanner: planner })
 
     await new Promise<void>((resolve) => {
@@ -202,7 +350,9 @@ describe('Codex Session Flow Integration', () => {
 
   beforeEach(async () => {
     delete process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR
-    await runtime.shutdown()
+    delete process.env.FAKE_CODEX_REMOTE_BEHAVIOR
+    await fsp.rm(codexHomePath, { recursive: true, force: true })
+    await fsp.mkdir(codexHomePath, { recursive: true })
     vi.mocked(configStore.snapshot).mockResolvedValue({
       settings: {
         codingCli: {
@@ -217,6 +367,7 @@ describe('Codex Session Flow Integration', () => {
       },
     })
     await fsp.rm(argLogPath, { force: true })
+    await fsp.rm(remoteThreadLogPath, { force: true })
   })
 
   afterAll(async () => {
@@ -230,15 +381,27 @@ describe('Codex Session Flow Integration', () => {
     } else {
       process.env.FAKE_CODEX_ARG_LOG = previousFakeCodexArgLog
     }
+    if (previousFakeCodexRemoteBehavior === undefined) {
+      delete process.env.FAKE_CODEX_REMOTE_BEHAVIOR
+    } else {
+      process.env.FAKE_CODEX_REMOTE_BEHAVIOR = previousFakeCodexRemoteBehavior
+    }
+    if (previousCodexHome === undefined) {
+      delete process.env.CODEX_HOME
+    } else {
+      process.env.CODEX_HOME = previousCodexHome
+    }
 
-    await runtime.shutdown()
     registry.shutdown()
     wsHandler.close()
     await new Promise<void>((resolve) => server.close(() => resolve()))
     await fsp.rm(tempDir, { recursive: true, force: true })
   })
 
-  it('starts the exact codex thread before PTY spawn and launches the TUI in remote mode', async () => {
+  it('launches a fresh codex terminal in remote mode without promoting a provisional thread id to durable identity', async () => {
+    process.env.FAKE_CODEX_REMOTE_BEHAVIOR = JSON.stringify({
+      recordRemoteThreadIdPath: remoteThreadLogPath,
+    })
     const ws = await createAuthenticatedWs(port)
 
     try {
@@ -260,10 +423,13 @@ describe('Codex Session Flow Integration', () => {
         throw new Error(`terminal.create failed: ${created.message}`)
       }
 
-      expect(created.effectiveResumeSessionId).toBe('thread-new-1')
+      expect(created).not.toHaveProperty('effectiveResumeSessionId')
 
       const record = registry.get(created.terminalId)
-      expect(record?.resumeSessionId).toBe('thread-new-1')
+      expect(record?.resumeSessionId).toBeUndefined()
+      await waitForFile(remoteThreadLogPath)
+      expect(await fsp.readFile(remoteThreadLogPath, 'utf8')).toBe('thread-new-1')
+      expect(record?.resumeSessionId).toBeUndefined()
 
       await waitForFile(argLogPath)
       const recordedArgs = JSON.parse(await fsp.readFile(argLogPath, 'utf8'))
@@ -271,8 +437,8 @@ describe('Codex Session Flow Integration', () => {
         '--remote',
         expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
       ])
-      expect(recordedArgs).toContain('resume')
-      expect(recordedArgs).toContain('thread-new-1')
+      expect(recordedArgs).not.toContain('resume')
+      expect(recordedArgs).not.toContain('thread-new-1')
       expect(recordedArgs).toContain('tui.notification_method=bel')
       expect(recordedArgs).not.toContain('--model')
       expect(recordedArgs).not.toContain('--sandbox')
@@ -281,18 +447,89 @@ describe('Codex Session Flow Integration', () => {
     }
   })
 
-  it('restores a persisted Codex session without calling thread/resume on the app-server', async () => {
-    process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR = JSON.stringify({
-      overrides: {
-        'thread/resume': {
-          error: {
-            code: -32600,
-            message: 'no rollout found for thread id thread-existing-1',
-          },
-        },
-      },
+  it('promotes a fresh codex terminal only after notification plus durable artifact proof', async () => {
+    process.env.FAKE_CODEX_REMOTE_BEHAVIOR = JSON.stringify({
+      sendTurnStart: true,
+      recordRemoteThreadIdPath: remoteThreadLogPath,
+      sleepMs: 500,
     })
+    const ws = await createAuthenticatedWs(port)
 
+    try {
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId: 'test-req-codex-promotion',
+        mode: 'codex',
+        cwd: tempDir,
+      }))
+
+      const created = await waitForMessage(
+        ws,
+        (msg) => (
+          msg.requestId === 'test-req-codex-promotion'
+          && (msg.type === 'terminal.created' || msg.type === 'error')
+        ),
+      )
+      if (created.type === 'error') {
+        throw new Error(`terminal.create failed: ${created.message}`)
+      }
+
+      expect(created).not.toHaveProperty('effectiveResumeSessionId')
+
+      await waitForFile(remoteThreadLogPath)
+      expect(await fsp.readFile(remoteThreadLogPath, 'utf8')).toBe('thread-new-1')
+      await waitForCondition(() => registry.get(created.terminalId)?.resumeSessionId === 'thread-new-1')
+
+      const record = registry.get(created.terminalId)
+      expect(record?.resumeSessionId).toBe('thread-new-1')
+    } finally {
+      await closeWebSocket(ws)
+      delete process.env.FAKE_CODEX_REMOTE_BEHAVIOR
+    }
+  })
+
+  it('terminates the terminal when the owning Codex sidecar dies after launch', async () => {
+    process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR = JSON.stringify({
+      exitProcessAfterMethodsOnce: ['thread/start'],
+    })
+    process.env.FAKE_CODEX_REMOTE_BEHAVIOR = JSON.stringify({
+      recordRemoteThreadIdPath: remoteThreadLogPath,
+      sleepMs: 200,
+    })
+    const ws = await createAuthenticatedWs(port)
+
+    try {
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId: 'test-req-codex-sidecar-dies',
+        mode: 'codex',
+        cwd: tempDir,
+      }))
+
+      const created = await waitForMessage(
+        ws,
+        (msg) => (
+          msg.requestId === 'test-req-codex-sidecar-dies'
+          && (msg.type === 'terminal.created' || msg.type === 'error')
+        ),
+      )
+      if (created.type === 'error') {
+        throw new Error(`terminal.create failed: ${created.message}`)
+      }
+
+      await waitForCondition(() => registry.get(created.terminalId)?.status === 'exited')
+      expect(registry.get(created.terminalId)?.status).toBe('exited')
+    } finally {
+      await closeWebSocket(ws)
+      delete process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR
+      delete process.env.FAKE_CODEX_REMOTE_BEHAVIOR
+    }
+  })
+
+  it('restores a persisted Codex session through the exact durable CLI form', async () => {
+    process.env.FAKE_CODEX_REMOTE_BEHAVIOR = JSON.stringify({
+      sleepMs: 300,
+    })
     const ws = await createAuthenticatedWs(port)
 
     try {
@@ -301,7 +538,10 @@ describe('Codex Session Flow Integration', () => {
         requestId: 'test-req-codex-restore',
         mode: 'codex',
         cwd: tempDir,
-        resumeSessionId: 'thread-existing-1',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: 'thread-existing-1',
+        },
       }))
 
       const created = await waitForMessage(
@@ -315,10 +555,7 @@ describe('Codex Session Flow Integration', () => {
         throw new Error(`terminal.create failed: ${created.message}`)
       }
 
-      expect(created.effectiveResumeSessionId).toBe('thread-existing-1')
-
-      const record = registry.get(created.terminalId)
-      expect(record?.resumeSessionId).toBe('thread-existing-1')
+      expect(created).not.toHaveProperty('effectiveResumeSessionId')
 
       await waitForFile(argLogPath)
       const recordedArgs = JSON.parse(await fsp.readFile(argLogPath, 'utf8'))
@@ -328,6 +565,64 @@ describe('Codex Session Flow Integration', () => {
       ])
       expect(recordedArgs).toContain('resume')
       expect(recordedArgs).toContain('thread-existing-1')
+    } finally {
+      await closeWebSocket(ws)
+      delete process.env.FAKE_CODEX_REMOTE_BEHAVIOR
+    }
+  })
+
+  it('restores a persisted Codex session without calling thread/resume on the app-server', async () => {
+    const requestId = 'test-req-codex-restore-no-app-server-resume'
+    const sessionId = 'thread-existing-no-app-server-resume-1'
+    process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR = JSON.stringify({
+      overrides: {
+        'thread/resume': {
+          error: {
+            code: -32600,
+            message: `no rollout found for thread id ${sessionId}`,
+          },
+        },
+      },
+    })
+
+    const ws = await createAuthenticatedWs(port)
+
+    try {
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'codex',
+        cwd: tempDir,
+        sessionRef: {
+          provider: 'codex',
+          sessionId,
+        },
+      }))
+
+      const created = await waitForMessage(
+        ws,
+        (msg) => (
+          msg.requestId === requestId
+          && (msg.type === 'terminal.created' || msg.type === 'error')
+        ),
+      )
+      if (created.type === 'error') {
+        throw new Error(`terminal.create failed: ${created.message}`)
+      }
+
+      expect(created).not.toHaveProperty('effectiveResumeSessionId')
+
+      const record = registry.get(created.terminalId)
+      expect(record?.resumeSessionId).toBe(sessionId)
+
+      await waitForFile(argLogPath)
+      const recordedArgs = JSON.parse(await fsp.readFile(argLogPath, 'utf8'))
+      expect(recordedArgs.slice(0, 2)).toEqual([
+        '--remote',
+        expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
+      ])
+      expect(recordedArgs).toContain('resume')
+      expect(recordedArgs).toContain(sessionId)
     } finally {
       await closeWebSocket(ws)
       delete process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR

--- a/test/integration/server/durable-session-contract.test.ts
+++ b/test/integration/server/durable-session-contract.test.ts
@@ -1,0 +1,395 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import http from 'http'
+import WebSocket from 'ws'
+import { WS_PROTOCOL_VERSION } from '../../shared/ws-protocol'
+
+const HOOK_TIMEOUT_MS = 30_000
+const VALID_SESSION_ID = '550e8400-e29b-41d4-a716-446655440000'
+const DEFAULT_CONFIG_SNAPSHOT = vi.hoisted(() => ({
+  version: 1,
+  settings: {
+    codingCli: {
+      enabledProviders: ['claude'],
+      providers: {
+        claude: {},
+      },
+    },
+  },
+  sessionOverrides: {},
+  terminalOverrides: {},
+  projectColors: {},
+}))
+
+vi.mock('../../server/config-store', () => ({
+  configStore: {
+    snapshot: vi.fn().mockResolvedValue(DEFAULT_CONFIG_SNAPSHOT),
+  },
+}))
+
+function listen(server: http.Server, timeoutMs = HOOK_TIMEOUT_MS): Promise<{ port: number }> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      server.off('error', onError)
+      reject(new Error('Timed out waiting for server to listen'))
+    }, timeoutMs)
+
+    const onError = (error: Error) => {
+      clearTimeout(timeout)
+      reject(error)
+    }
+
+    server.once('error', onError)
+    server.listen(0, '127.0.0.1', () => {
+      clearTimeout(timeout)
+      server.off('error', onError)
+      const address = server.address()
+      if (typeof address === 'object' && address) {
+        resolve({ port: address.port })
+      }
+    })
+  })
+}
+
+function waitForMessage(ws: WebSocket, predicate: (msg: any) => boolean, timeoutMs = 5_000): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeout)
+      ws.off('message', handler)
+      ws.off('error', onError)
+      ws.off('close', onClose)
+    }
+
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error('Timed out waiting for WebSocket message'))
+    }, timeoutMs)
+
+    const handler = (data: WebSocket.Data) => {
+      const msg = JSON.parse(data.toString())
+      if (!predicate(msg)) return
+      cleanup()
+      resolve(msg)
+    }
+
+    const onError = (error: Error) => {
+      cleanup()
+      reject(error)
+    }
+
+    const onClose = () => {
+      cleanup()
+      reject(new Error('Socket closed before the expected message arrived'))
+    }
+
+    ws.on('message', handler)
+    ws.on('error', onError)
+    ws.on('close', onClose)
+  })
+}
+
+async function createAuthenticatedWs(port: number): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+  await new Promise<void>((resolve, reject) => {
+    ws.once('open', () => resolve())
+    ws.once('error', reject)
+  })
+
+  ws.send(JSON.stringify({
+    type: 'hello',
+    token: process.env.AUTH_TOKEN || 'testtoken-testtoken',
+    protocolVersion: WS_PROTOCOL_VERSION,
+  }))
+
+  await waitForMessage(ws, (msg) => msg.type === 'ready')
+  return ws
+}
+
+async function closeWebSocket(ws: WebSocket): Promise<void> {
+  await new Promise<void>((resolve) => {
+    if (ws.readyState === WebSocket.CLOSED) {
+      resolve()
+      return
+    }
+
+    const timeout = setTimeout(() => {
+      cleanup()
+      resolve()
+    }, 1_000)
+
+    const cleanup = () => {
+      clearTimeout(timeout)
+      ws.off('close', onClose)
+      ws.off('error', onClose)
+    }
+
+    const onClose = () => {
+      cleanup()
+      resolve()
+    }
+
+    ws.on('close', onClose)
+    ws.on('error', onClose)
+    ws.close()
+  })
+}
+
+class FakeBuffer {
+  snapshot() {
+    return ''
+  }
+}
+
+class FakeRegistry {
+  records = new Map<string, any>()
+  lastCreateOpts: any = null
+  createCallCount = 0
+
+  create(opts: any) {
+    this.lastCreateOpts = opts
+    this.createCallCount += 1
+    const terminalId = `term_${this.createCallCount}`
+    const record = {
+      terminalId,
+      createdAt: Date.now(),
+      buffer: new FakeBuffer(),
+      title: opts.mode === 'claude' ? 'Claude' : 'Shell',
+      mode: opts.mode,
+      shell: opts.shell || 'system',
+      status: 'running',
+      cols: 80,
+      rows: 24,
+      resumeSessionId: opts.resumeSessionId,
+      clients: new Set<WebSocket>(),
+    }
+    this.records.set(terminalId, record)
+    return record
+  }
+
+  get(terminalId: string) {
+    return this.records.get(terminalId) || null
+  }
+
+  attach(terminalId: string, ws: WebSocket) {
+    const record = this.records.get(terminalId)
+    if (!record) return null
+    record.clients.add(ws)
+    return record
+  }
+
+  finishAttachSnapshot() {}
+
+  resize(terminalId: string, cols: number, rows: number) {
+    const record = this.records.get(terminalId)
+    if (!record) return false
+    record.cols = cols
+    record.rows = rows
+    return true
+  }
+
+  detach(terminalId: string, ws: WebSocket) {
+    const record = this.records.get(terminalId)
+    if (!record) return false
+    record.clients.delete(ws)
+    return true
+  }
+
+  list() {
+    return Array.from(this.records.values())
+  }
+
+  findRunningTerminalBySession(mode: string, sessionId: string) {
+    for (const record of this.records.values()) {
+      if (record.mode === mode && record.status === 'running' && record.resumeSessionId === sessionId) {
+        return record
+      }
+    }
+    return undefined
+  }
+
+  findRunningClaudeTerminalBySession(sessionId: string) {
+    return this.findRunningTerminalBySession('claude', sessionId)
+  }
+
+  getCanonicalRunningTerminalBySession(mode: string, sessionId: string) {
+    return this.findRunningTerminalBySession(mode, sessionId)
+  }
+
+  repairLegacySessionOwners(mode: string, sessionId: string) {
+    const canonical = this.getCanonicalRunningTerminalBySession(mode, sessionId)
+    return {
+      repaired: false,
+      canonicalTerminalId: canonical?.terminalId,
+      clearedTerminalIds: [] as string[],
+    }
+  }
+}
+
+describe('durable session contract (integration)', () => {
+  let server: http.Server | undefined
+  let port: number
+  let registry: FakeRegistry
+  let originalNodeEnv: string | undefined
+  let originalAuthToken: string | undefined
+  let originalHelloTimeoutMs: string | undefined
+
+  beforeEach(async () => {
+    originalNodeEnv = process.env.NODE_ENV
+    originalAuthToken = process.env.AUTH_TOKEN
+    originalHelloTimeoutMs = process.env.HELLO_TIMEOUT_MS
+    process.env.NODE_ENV = 'test'
+    process.env.AUTH_TOKEN = 'testtoken-testtoken'
+    process.env.HELLO_TIMEOUT_MS = '500'
+
+    vi.resetModules()
+    const { WsHandler } = await import('../../../server/ws-handler.js')
+
+    server = http.createServer((_req, res) => {
+      res.statusCode = 404
+      res.end()
+    })
+
+    registry = new FakeRegistry()
+    new WsHandler(server, registry as any)
+
+    const info = await listen(server)
+    port = info.port
+    registry.records.clear()
+    registry.lastCreateOpts = null
+    registry.createCallCount = 0
+  }, HOOK_TIMEOUT_MS)
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()))
+      server = undefined
+    }
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = originalNodeEnv
+    }
+    if (originalAuthToken === undefined) {
+      delete process.env.AUTH_TOKEN
+    } else {
+      process.env.AUTH_TOKEN = originalAuthToken
+    }
+    if (originalHelloTimeoutMs === undefined) {
+      delete process.env.HELLO_TIMEOUT_MS
+    } else {
+      process.env.HELLO_TIMEOUT_MS = originalHelloTimeoutMs
+    }
+  })
+
+  it('reuses the same live-only terminal across reconnects before any canonical durable identity exists', async () => {
+    const requestId = 'live-only-terminal'
+    const ws1 = await createAuthenticatedWs(port)
+    let ws2: WebSocket | undefined
+
+    try {
+      ws1.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'claude',
+      }))
+
+      const firstCreated = await waitForMessage(
+        ws1,
+        (msg) => msg.type === 'terminal.created' && msg.requestId === requestId,
+      )
+
+      expect(firstCreated).not.toHaveProperty('effectiveResumeSessionId')
+      expect(registry.createCallCount).toBe(1)
+
+      await closeWebSocket(ws1)
+
+      ws2 = await createAuthenticatedWs(port)
+      ws2.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'claude',
+      }))
+
+      const secondCreated = await waitForMessage(
+        ws2,
+        (msg) => msg.type === 'terminal.created' && msg.requestId === requestId,
+      )
+
+      expect(secondCreated.terminalId).toBe(firstCreated.terminalId)
+      expect(registry.createCallCount).toBe(1)
+    } finally {
+      await closeWebSocket(ws1)
+      if (ws2) {
+        await closeWebSocket(ws2)
+      }
+    }
+  })
+
+  it('does not invent a canonical durable identity when restore is requested without one', async () => {
+    const ws = await createAuthenticatedWs(port)
+
+    try {
+      const requestId = 'restore-no-canonical'
+      const responsePromise = waitForMessage(
+        ws,
+        (msg) => (
+          msg.requestId === requestId
+          && (msg.type === 'terminal.created' || msg.type === 'error')
+        ),
+      )
+
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'claude',
+        restore: true,
+      }))
+
+      const response = await responsePromise
+
+      expect(response).toMatchObject({
+        type: 'error',
+        code: 'RESTORE_UNAVAILABLE',
+      })
+      expect(registry.createCallCount).toBe(0)
+      expect(registry.lastCreateOpts).toBeNull()
+      expect(registry.records.size).toBe(0)
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
+  it('uses the canonical durable identity when a Claude restore target exists', async () => {
+    const ws = await createAuthenticatedWs(port)
+
+    try {
+      const requestId = 'restore-canonical'
+      const responsePromise = waitForMessage(
+        ws,
+        (msg) => (
+          msg.requestId === requestId
+          && (msg.type === 'terminal.created' || msg.type === 'error')
+        ),
+      )
+
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'claude',
+        restore: true,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
+      }))
+
+      const response = await responsePromise
+
+      expect(response.type).toBe('terminal.created')
+      expect(response).not.toHaveProperty('effectiveResumeSessionId')
+      expect(registry.createCallCount).toBe(1)
+      expect(registry.records.size).toBe(1)
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+})

--- a/test/integration/server/opencode-session-flow.test.ts
+++ b/test/integration/server/opencode-session-flow.test.ts
@@ -1,0 +1,505 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import http from 'http'
+import { EventEmitter } from 'events'
+import WebSocket from 'ws'
+import { WS_PROTOCOL_VERSION } from '../../../shared/ws-protocol.js'
+import { OPENCODE_HEALTH_POLL_MS } from '../../../server/coding-cli/opencode-activity-tracker.js'
+import { wireOpencodeActivityTracker } from '../../../server/coding-cli/opencode-activity-wiring.js'
+
+const HOOK_TIMEOUT_MS = 30_000
+const OPENCODE_SESSION_ID = 'opencode-session-123'
+const DEFAULT_CONFIG_SNAPSHOT = vi.hoisted(() => ({
+  version: 1,
+  settings: {
+    codingCli: {
+      enabledProviders: ['opencode'],
+      providers: {
+        opencode: {},
+      },
+    },
+  },
+  sessionOverrides: {},
+  terminalOverrides: {},
+  projectColors: {},
+}))
+
+vi.mock('../../../server/config-store.js', () => ({
+  configStore: {
+    snapshot: vi.fn().mockResolvedValue(DEFAULT_CONFIG_SNAPSHOT),
+  },
+}))
+
+function listen(server: http.Server, timeoutMs = HOOK_TIMEOUT_MS): Promise<{ port: number }> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      server.off('error', onError)
+      reject(new Error('Timed out waiting for server to listen'))
+    }, timeoutMs)
+
+    const onError = (error: Error) => {
+      clearTimeout(timeout)
+      reject(error)
+    }
+
+    server.once('error', onError)
+    server.listen(0, '127.0.0.1', () => {
+      clearTimeout(timeout)
+      server.off('error', onError)
+      const address = server.address()
+      if (typeof address === 'object' && address) {
+        resolve({ port: address.port })
+      }
+    })
+  })
+}
+
+function waitForMessage(ws: WebSocket, predicate: (msg: any) => boolean, timeoutMs = 5_000): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeout)
+      ws.off('message', handler)
+      ws.off('error', onError)
+      ws.off('close', onClose)
+    }
+
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error('Timed out waiting for WebSocket message'))
+    }, timeoutMs)
+
+    const handler = (data: WebSocket.Data) => {
+      const msg = JSON.parse(data.toString())
+      if (!predicate(msg)) return
+      cleanup()
+      resolve(msg)
+    }
+
+    const onError = (error: Error) => {
+      cleanup()
+      reject(error)
+    }
+
+    const onClose = () => {
+      cleanup()
+      reject(new Error('Socket closed before the expected message arrived'))
+    }
+
+    ws.on('message', handler)
+    ws.on('error', onError)
+    ws.on('close', onClose)
+  })
+}
+
+async function createAuthenticatedWs(port: number): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+  await new Promise<void>((resolve, reject) => {
+    ws.once('open', () => resolve())
+    ws.once('error', reject)
+  })
+
+  ws.send(JSON.stringify({
+    type: 'hello',
+    token: process.env.AUTH_TOKEN || 'testtoken-testtoken',
+    protocolVersion: WS_PROTOCOL_VERSION,
+  }))
+
+  await waitForMessage(ws, (msg) => msg.type === 'ready')
+  return ws
+}
+
+async function closeWebSocket(ws: WebSocket): Promise<void> {
+  await new Promise<void>((resolve) => {
+    if (ws.readyState === WebSocket.CLOSED) {
+      resolve()
+      return
+    }
+
+    const timeout = setTimeout(() => {
+      cleanup()
+      resolve()
+    }, 1_000)
+
+    const cleanup = () => {
+      clearTimeout(timeout)
+      ws.off('close', onClose)
+      ws.off('error', onClose)
+    }
+
+    const onClose = () => {
+      cleanup()
+      resolve()
+    }
+
+    ws.on('close', onClose)
+    ws.on('error', onClose)
+    ws.close()
+  })
+}
+
+function createJsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}
+
+function createSseResponse(events: unknown[]) {
+  const encoder = new TextEncoder()
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
+      }
+      controller.close()
+    },
+  }), {
+    headers: { 'content-type': 'text/event-stream' },
+  })
+}
+
+class FakeBuffer {
+  snapshot() {
+    return ''
+  }
+}
+
+class FakeRegistry extends EventEmitter {
+  records = new Map<string, any>()
+  lastCreateOpts: any = null
+  createCallCount = 0
+  bindCalls: Array<{ terminalId: string; provider: string; sessionId: string; reason: string }> = []
+
+  create(opts: any) {
+    this.lastCreateOpts = opts
+    this.createCallCount += 1
+    const terminalId = `term-opencode-${this.createCallCount}`
+    const record = {
+      terminalId,
+      createdAt: Date.now(),
+      buffer: new FakeBuffer(),
+      title: 'OpenCode',
+      mode: opts.mode,
+      shell: opts.shell || 'system',
+      status: 'running',
+      cols: 80,
+      rows: 24,
+      resumeSessionId: opts.resumeSessionId,
+      opencodeServer: opts.providerSettings?.opencodeServer,
+      clients: new Set<WebSocket>(),
+    }
+    this.records.set(terminalId, record)
+    this.emit('terminal.created', record)
+    return record
+  }
+
+  get(terminalId: string) {
+    return this.records.get(terminalId) || null
+  }
+
+  attach(terminalId: string, ws: WebSocket) {
+    const record = this.records.get(terminalId)
+    if (!record) return null
+    record.clients.add(ws)
+    return record
+  }
+
+  finishAttachSnapshot() {}
+
+  resize(terminalId: string, cols: number, rows: number) {
+    const record = this.records.get(terminalId)
+    if (!record) return false
+    record.cols = cols
+    record.rows = rows
+    return true
+  }
+
+  detach(terminalId: string, ws: WebSocket) {
+    const record = this.records.get(terminalId)
+    if (!record) return false
+    record.clients.delete(ws)
+    return true
+  }
+
+  list() {
+    return Array.from(this.records.values())
+  }
+
+  findRunningTerminalBySession(mode: string, sessionId: string) {
+    for (const record of this.records.values()) {
+      if (record.mode === mode && record.status === 'running' && record.resumeSessionId === sessionId) {
+        return record
+      }
+    }
+    return undefined
+  }
+
+  findRunningClaudeTerminalBySession(_sessionId: string) {
+    return undefined
+  }
+
+  getCanonicalRunningTerminalBySession(mode: string, sessionId: string) {
+    return this.findRunningTerminalBySession(mode, sessionId)
+  }
+
+  repairLegacySessionOwners(mode: string, sessionId: string) {
+    const canonical = this.getCanonicalRunningTerminalBySession(mode, sessionId)
+    return {
+      repaired: false,
+      canonicalTerminalId: canonical?.terminalId,
+      clearedTerminalIds: [] as string[],
+    }
+  }
+
+  bindSession(terminalId: string, provider: string, sessionId: string, reason = 'association') {
+    const record = this.records.get(terminalId)
+    if (!record) {
+      return { ok: false, reason: 'terminal_missing' as const }
+    }
+    record.resumeSessionId = sessionId
+    this.bindCalls.push({ terminalId, provider, sessionId, reason })
+    this.emit('terminal.session.bound', { terminalId, provider, sessionId, reason })
+    return { ok: true as const, terminalId, sessionId }
+  }
+
+  rebindSession(terminalId: string, provider: string, sessionId: string, reason = 'association') {
+    return this.bindSession(terminalId, provider, sessionId, reason)
+  }
+}
+
+describe('opencode session flow (integration)', () => {
+  let server: http.Server | undefined
+  let port: number
+  let registry: FakeRegistry
+  let originalNodeEnv: string | undefined
+  let originalAuthToken: string | undefined
+  let originalHelloTimeoutMs: string | undefined
+
+  beforeEach(async () => {
+    originalNodeEnv = process.env.NODE_ENV
+    originalAuthToken = process.env.AUTH_TOKEN
+    originalHelloTimeoutMs = process.env.HELLO_TIMEOUT_MS
+    process.env.NODE_ENV = 'test'
+    process.env.AUTH_TOKEN = 'testtoken-testtoken'
+    process.env.HELLO_TIMEOUT_MS = '500'
+
+    vi.resetModules()
+    const { WsHandler } = await import('../../../server/ws-handler.js')
+
+    server = http.createServer((_req, res) => {
+      res.statusCode = 404
+      res.end()
+    })
+
+    registry = new FakeRegistry()
+    new WsHandler(server, registry as any)
+
+    const info = await listen(server)
+    port = info.port
+    registry.records.clear()
+    registry.lastCreateOpts = null
+    registry.createCallCount = 0
+  }, HOOK_TIMEOUT_MS)
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()))
+      server = undefined
+    }
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = originalNodeEnv
+    }
+    if (originalAuthToken === undefined) {
+      delete process.env.AUTH_TOKEN
+    } else {
+      process.env.AUTH_TOKEN = originalAuthToken
+    }
+    if (originalHelloTimeoutMs === undefined) {
+      delete process.env.HELLO_TIMEOUT_MS
+    } else {
+      process.env.HELLO_TIMEOUT_MS = originalHelloTimeoutMs
+    }
+  })
+
+  it('keeps a fresh opencode terminal live-only until canonical durable identity exists', async () => {
+    const ws = await createAuthenticatedWs(port)
+
+    try {
+      const requestId = 'opencode-fresh'
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'opencode',
+      }))
+
+      const response = await waitForMessage(
+        ws,
+        (msg) => (
+          msg.requestId === requestId
+          && (msg.type === 'terminal.created' || msg.type === 'error')
+        ),
+      )
+
+      expect(response.type).toBe('terminal.created')
+      expect(response).not.toHaveProperty('effectiveResumeSessionId')
+      expect(registry.lastCreateOpts?.resumeSessionId).toBeUndefined()
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
+  it('rejects the legacy raw resumeSessionId field for opencode restore requests', async () => {
+    const ws = await createAuthenticatedWs(port)
+
+    try {
+      const requestId = 'opencode-restore-title-token'
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'opencode',
+        restore: true,
+        resumeSessionId: 'probe-title-two',
+      }))
+
+      const response = await waitForMessage(
+        ws,
+        (msg) => (
+          msg.requestId === requestId
+          && (msg.type === 'terminal.created' || msg.type === 'error')
+        ),
+      )
+
+      expect(response).toMatchObject({
+        type: 'error',
+        code: 'INVALID_MESSAGE',
+      })
+      expect(registry.createCallCount).toBe(0)
+      expect(registry.records.size).toBe(0)
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
+  it('uses the canonical durable opencode session id when restore is explicit', async () => {
+    const ws = await createAuthenticatedWs(port)
+
+    try {
+      const requestId = 'opencode-restore-canonical'
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'opencode',
+        restore: true,
+        sessionRef: {
+          provider: 'opencode',
+          sessionId: OPENCODE_SESSION_ID,
+        },
+      }))
+
+      const response = await waitForMessage(
+        ws,
+        (msg) => (
+          msg.requestId === requestId
+          && (msg.type === 'terminal.created' || msg.type === 'error')
+        ),
+      )
+
+      expect(response.type).toBe('terminal.created')
+      expect(registry.lastCreateOpts?.resumeSessionId).toBe(OPENCODE_SESSION_ID)
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
+  it('keeps an OpenCode terminal live-only until the control surface reports a canonical session id', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true, version: '1.4.11' })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({})
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([{ type: 'server.connected', properties: {} }])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const wiring = wireOpencodeActivityTracker({
+      registry: registry as any,
+      fetchImpl: fetchImpl as typeof fetch,
+      random: () => 0,
+    })
+
+    try {
+      const record = registry.create({
+        mode: 'opencode',
+        providerSettings: {
+          opencodeServer: { hostname: '127.0.0.1', port: 43123 },
+        },
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(OPENCODE_HEALTH_POLL_MS)
+
+      expect(record.resumeSessionId).toBeUndefined()
+      expect(registry.bindCalls).toEqual([])
+    } finally {
+      wiring.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('promotes an OpenCode terminal only after authoritative control data exposes a canonical session id', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) {
+        return createJsonResponse({ ok: true, version: '1.4.11' })
+      }
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({
+          [OPENCODE_SESSION_ID]: { type: 'busy' },
+        })
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([{ type: 'server.connected', properties: {} }])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const wiring = wireOpencodeActivityTracker({
+      registry: registry as any,
+      fetchImpl: fetchImpl as typeof fetch,
+      random: () => 0,
+    })
+
+    try {
+      const record = registry.create({
+        mode: 'opencode',
+        providerSettings: {
+          opencodeServer: { hostname: '127.0.0.1', port: 43123 },
+        },
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(OPENCODE_HEALTH_POLL_MS)
+
+      expect(record.resumeSessionId).toBe(OPENCODE_SESSION_ID)
+      expect(registry.bindCalls).toEqual([
+        expect.objectContaining({
+          terminalId: record.terminalId,
+          provider: 'opencode',
+          sessionId: OPENCODE_SESSION_ID,
+          reason: 'association',
+        }),
+      ])
+    } finally {
+      wiring.dispose()
+      vi.useRealTimers()
+    }
+  })
+})

--- a/test/integration/session-repair.test.ts
+++ b/test/integration/session-repair.test.ts
@@ -102,7 +102,7 @@ describe('SessionRepairService Integration', () => {
 
   describe('waitForSession', () => {
     it('resolves when session is processed', async () => {
-      const sessionId = 'wait-test-session'
+      const sessionId = '00000000-0000-4000-8000-000000000701'
       const sessionFile = path.join(mockClaudeDir, `${sessionId}.jsonl`)
       await fs.copyFile(
         path.join(FIXTURES_DIR, 'healthy.jsonl'),
@@ -119,7 +119,7 @@ describe('SessionRepairService Integration', () => {
 
     it('times out for non-existent session', async () => {
       await expect(
-        service.waitForSession('nonexistent', 100)
+        service.waitForSession('00000000-0000-4000-8000-000000000702', 100)
       ).rejects.toThrow(/not in queue/)
     })
 
@@ -156,7 +156,7 @@ describe('SessionRepairService Integration', () => {
     })
 
     it('resolves canonical sessionId via file path resolver', async () => {
-      const canonicalId = '6f1c2b3a-4d5e-6f70-8a9b-0c1d2e3f4a5b'
+      const canonicalId = '6f1c2b3a-4d5e-4f70-8a9b-0c1d2e3f4a5b'
       const legacyId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
       const sessionFile = path.join(mockClaudeDir, `${legacyId}.jsonl`)
       await fs.copyFile(path.join(FIXTURES_DIR, 'healthy.jsonl'), sessionFile)
@@ -195,7 +195,7 @@ describe('SessionRepairService Integration', () => {
 
   describe('prioritizeSessions', () => {
     it('re-prioritizes existing queue items', async () => {
-      const sessionId = 'priority-test'
+      const sessionId = '00000000-0000-4000-8000-000000000703'
       const sessionFile = path.join(mockClaudeDir, `${sessionId}.jsonl`)
       await fs.copyFile(
         path.join(FIXTURES_DIR, 'healthy.jsonl'),

--- a/test/server/agent-panes-write.test.ts
+++ b/test/server/agent-panes-write.test.ts
@@ -26,6 +26,40 @@ it('splits a pane horizontally', async () => {
   expect(attachPaneContent).toHaveBeenCalled()
 })
 
+it('passes the planned Codex sidecar when splitting a pane in codex mode', async () => {
+  const app = express()
+  app.use(express.json())
+  const splitPane = vi.fn(() => ({ newPaneId: 'pane_new', tabId: 'tab_1' }))
+  const attachPaneContent = vi.fn()
+  const registryCreate = vi.fn(() => ({ terminalId: 'term_new' }))
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { splitPane, attachPaneContent },
+    registry: { create: registryCreate },
+    codexLaunchPlanner,
+  }))
+
+  const res = await request(app).post('/api/panes/pane_1/split').send({ direction: 'horizontal', mode: 'codex' })
+
+  expect(res.body.status).toBe('ok')
+  expect(codexLaunchPlanner.planCreateCalls).toEqual([{
+    approvalPolicy: undefined,
+    cwd: undefined,
+    model: undefined,
+    resumeSessionId: undefined,
+    sandbox: undefined,
+  }])
+  expect(registryCreate).toHaveBeenCalledWith(expect.objectContaining({
+    mode: 'codex',
+    codexSidecar: codexLaunchPlanner.sidecar,
+    providerSettings: expect.objectContaining({
+      codexAppServer: expect.objectContaining({
+        wsUrl: expect.any(String),
+      }),
+    }),
+  }))
+})
+
 it('rejects invalid Codex settings when splitting a pane before spawning', async () => {
   const app = express()
   app.use(express.json())
@@ -98,6 +132,47 @@ it('rejects invalid Codex settings when respawning a pane before spawning', asyn
   expect(codexLaunchPlanner.planCreateCalls).toEqual([])
   expect(registryCreate).not.toHaveBeenCalled()
   expect(attachPaneContent).not.toHaveBeenCalled()
+})
+
+it('passes the planned Codex sidecar when respawning a pane in codex mode', async () => {
+  const app = express()
+  app.use(express.json())
+  const attachPaneContent = vi.fn()
+  const registryCreate = vi.fn(() => ({ terminalId: 'term_new' }))
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      attachPaneContent,
+      resolveTarget: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+    } as any,
+    registry: { create: registryCreate },
+    codexLaunchPlanner,
+  }))
+
+  const res = await request(app).post('/api/panes/pane_1/respawn').send({ mode: 'codex' })
+
+  expect(res.body.status).toBe('ok')
+  expect(codexLaunchPlanner.planCreateCalls).toEqual([{
+    approvalPolicy: undefined,
+    cwd: undefined,
+    model: undefined,
+    resumeSessionId: undefined,
+    sandbox: undefined,
+  }])
+  expect(registryCreate).toHaveBeenCalledWith(expect.objectContaining({
+    mode: 'codex',
+    codexSidecar: codexLaunchPlanner.sidecar,
+    providerSettings: expect.objectContaining({
+      codexAppServer: expect.objectContaining({
+        wsUrl: expect.any(String),
+      }),
+    }),
+  }))
+  expect(attachPaneContent).toHaveBeenCalledWith('tab_1', 'pane_1', expect.objectContaining({
+    kind: 'terminal',
+    terminalId: 'term_new',
+    mode: 'codex',
+  }))
 })
 
 it('resolves tmux-style pane targets for close', async () => {

--- a/test/server/agent-run.test.ts
+++ b/test/server/agent-run.test.ts
@@ -91,7 +91,8 @@ it('uses the shared Codex planner and marks fresh /api/run sessions as starts', 
   }])
   expect(registry.create).toHaveBeenCalledWith(expect.objectContaining({
     mode: 'codex',
-    resumeSessionId: 'thread-new-1',
+    codexSidecar: codexLaunchPlanner.sidecar,
+    resumeSessionId: undefined,
     sessionBindingReason: 'start',
     providerSettings: expect.objectContaining({
       codexAppServer: {

--- a/test/server/agent-tabs-write.test.ts
+++ b/test/server/agent-tabs-write.test.ts
@@ -82,6 +82,88 @@ describe('tab endpoints', () => {
     }))
   })
 
+  it('creates terminal tabs from canonical sessionRef without mirroring legacy resumeSessionId payloads', async () => {
+    const app = express()
+    app.use(express.json())
+    const registry = new FakeRegistry()
+    const attachPaneContent = vi.fn()
+    const broadcastUiCommand = vi.fn()
+    const layoutStore = {
+      createTab: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+      attachPaneContent,
+      selectTab: () => ({}),
+      renameTab: () => ({}),
+      closeTab: () => ({}),
+      hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }),
+      selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry, wsHandler: { broadcastUiCommand } }))
+
+    const sessionRef = { provider: 'claude', sessionId: '550e8400-e29b-41d4-a716-446655440000' }
+    const res = await request(app).post('/api/tabs').send({
+      mode: 'claude',
+      name: 'resume me',
+      sessionRef,
+    })
+
+    expect(res.body.status).toBe('ok')
+    expect(registry.create).toHaveBeenCalledWith(expect.objectContaining({
+      mode: 'claude',
+      resumeSessionId: sessionRef.sessionId,
+    }))
+    expect(attachPaneContent).toHaveBeenCalledWith('tab_1', 'pane_1', expect.objectContaining({
+      kind: 'terminal',
+      sessionRef,
+    }))
+    expect(attachPaneContent.mock.calls[0]?.[2]).not.toHaveProperty('resumeSessionId')
+    expect(broadcastUiCommand).toHaveBeenCalledWith(expect.objectContaining({
+      command: 'tab.create',
+      payload: expect.objectContaining({
+        sessionRef,
+      }),
+    }))
+    expect(broadcastUiCommand.mock.calls[0]?.[0]?.payload).not.toHaveProperty('resumeSessionId')
+  })
+
+  it('passes the planned Codex sidecar through /api/tabs terminal creation', async () => {
+    const app = express()
+    app.use(express.json())
+    const registry = new FakeRegistry()
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    const layoutStore = {
+      createTab: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+      attachPaneContent: vi.fn(),
+      selectTab: () => ({}),
+      renameTab: () => ({}),
+      closeTab: () => ({}),
+      hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }),
+      selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry, codexLaunchPlanner }))
+
+    const res = await request(app).post('/api/tabs').send({ mode: 'codex', name: 'Codex' })
+
+    expect(res.body.status).toBe('ok')
+    expect(codexLaunchPlanner.planCreateCalls).toEqual([{
+      approvalPolicy: undefined,
+      cwd: undefined,
+      model: undefined,
+      resumeSessionId: undefined,
+      sandbox: undefined,
+    }])
+    expect(registry.create).toHaveBeenCalledWith(expect.objectContaining({
+      mode: 'codex',
+      codexSidecar: codexLaunchPlanner.sidecar,
+      providerSettings: expect.objectContaining({
+        codexAppServer: expect.objectContaining({
+          wsUrl: expect.any(String),
+        }),
+      }),
+    }))
+  })
+
   it('rejects invalid Codex sandbox values with a 400 before spawning', async () => {
     const app = express()
     app.use(express.json())

--- a/test/server/session-association.test.ts
+++ b/test/server/session-association.test.ts
@@ -90,6 +90,36 @@ describe('SessionAssociationCoordinator integration', () => {
     registry.shutdown()
   })
 
+  it('keeps the canonical Claude association stable when the terminal title changes', () => {
+    const registry = new TerminalRegistry()
+    const coordinator = new SessionAssociationCoordinator(registry, 30_000)
+
+    const terminal = registry.create({
+      mode: 'claude',
+      cwd: '/home/user/project',
+    })
+
+    registry.updateTitle(terminal.terminalId, 'Release prep')
+
+    const result = coordinator.associateSingleSession({
+      provider: 'claude',
+      sessionId: SESSION_ID_ONE,
+      projectPath: '/home/user/project',
+      lastActivityAt: Date.now(),
+      cwd: '/home/user/project',
+    })
+
+    expect(result).toEqual({ associated: true, terminalId: terminal.terminalId })
+    expect(registry.get(terminal.terminalId)?.resumeSessionId).toBe(SESSION_ID_ONE)
+
+    registry.updateTitle(terminal.terminalId, 'Renamed after attach')
+
+    expect(registry.get(terminal.terminalId)?.title).toBe('Renamed after attach')
+    expect(registry.get(terminal.terminalId)?.resumeSessionId).toBe(SESSION_ID_ONE)
+
+    registry.shutdown()
+  })
+
   it('does not heuristically associate codex sessions', () => {
     const registry = new TerminalRegistry()
     const coordinator = new SessionAssociationCoordinator(registry, 30_000)
@@ -216,7 +246,10 @@ describe('Session-Terminal metadata broadcasts', () => {
       broadcasts.push({
         type: 'terminal.session.associated',
         terminalId: term.terminalId,
-        sessionId: session.sessionId,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: session.sessionId,
+        },
       })
 
       const associatedMeta = metadata.associateSession(term.terminalId, 'claude', session.sessionId)
@@ -255,7 +288,10 @@ describe('Session-Terminal metadata broadcasts', () => {
     expect(broadcasts).toContainEqual({
       type: 'terminal.session.associated',
       terminalId: terminal.terminalId,
-      sessionId: SESSION_ID_TWO,
+      sessionRef: {
+        provider: 'claude',
+        sessionId: SESSION_ID_TWO,
+      },
     })
 
     const latestMeta = broadcasts.filter((m) => m.type === 'terminal.meta.updated').at(-1)
@@ -294,7 +330,10 @@ describe('Session-Terminal Association Integration', () => {
       broadcasts.push({
         type: 'terminal.session.associated',
         terminalId: term.terminalId,
-        sessionId: session.sessionId,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: session.sessionId,
+        },
       })
     })
 
@@ -321,7 +360,10 @@ describe('Session-Terminal Association Integration', () => {
     expect(broadcasts[0]).toEqual({
       type: 'terminal.session.associated',
       terminalId: term.terminalId,
-      sessionId: SESSION_ID_ONE,
+      sessionRef: {
+        provider: 'claude',
+        sessionId: SESSION_ID_ONE,
+      },
     })
 
     // Cleanup
@@ -379,7 +421,10 @@ describe('Session-Terminal Association Integration', () => {
       broadcasts.push({
         type: 'terminal.session.associated',
         terminalId: term.terminalId,
-        sessionId: session.sessionId,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: session.sessionId,
+        },
       })
     })
 
@@ -423,7 +468,10 @@ describe('Session-Terminal Association Integration', () => {
       broadcasts.push({
         type: 'terminal.session.associated',
         terminalId: term.terminalId,
-        sessionId: session.sessionId,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: session.sessionId,
+        },
       })
     })
 
@@ -462,9 +510,15 @@ describe('Session-Terminal Association Integration', () => {
     // Two broadcasts total, one per terminal
     expect(broadcasts).toHaveLength(2)
     expect(broadcasts[0].terminalId).toBe(term1.terminalId)
-    expect(broadcasts[0].sessionId).toBe(SESSION_ID_ONE)
+    expect(broadcasts[0].sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: SESSION_ID_ONE,
+    })
     expect(broadcasts[1].terminalId).toBe(term2.terminalId)
-    expect(broadcasts[1].sessionId).toBe(SESSION_ID_THREE)
+    expect(broadcasts[1].sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: SESSION_ID_THREE,
+    })
 
     // Cleanup
     registry.shutdown()
@@ -596,7 +650,10 @@ describe('Session-Terminal Association Platform-specific', () => {
       broadcasts.push({
         type: 'terminal.session.associated',
         terminalId: term.terminalId,
-        sessionId: session.sessionId,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: session.sessionId,
+        },
       })
     })
 
@@ -617,7 +674,10 @@ describe('Session-Terminal Association Platform-specific', () => {
     // Should match after normalization removes trailing slash
     expect(broadcasts).toHaveLength(1)
     expect(broadcasts[0].terminalId).toBe(term.terminalId)
-    expect(broadcasts[0].sessionId).toBe(SESSION_ID_SEVEN)
+    expect(broadcasts[0].sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: SESSION_ID_SEVEN,
+    })
 
     registry.shutdown()
   })
@@ -637,7 +697,10 @@ describe('Session-Terminal Association Platform-specific', () => {
       broadcasts.push({
         type: 'terminal.session.associated',
         terminalId: term.terminalId,
-        sessionId: session.sessionId,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: session.sessionId,
+        },
       })
     })
 
@@ -681,7 +744,10 @@ describe('Session-Terminal Association via onUpdate', () => {
       broadcasts.push({
         type: 'terminal.session.associated',
         terminalId,
-        sessionId: session.sessionId,
+        sessionRef: {
+          provider: session.provider,
+          sessionId: session.sessionId,
+        },
       })
     }
   }

--- a/test/server/ws-edge-cases.test.ts
+++ b/test/server/ws-edge-cases.test.ts
@@ -735,10 +735,9 @@ describe('WebSocket edge cases', () => {
       close()
     })
 
-    it('handles messages with extra unexpected fields', async () => {
+    it('rejects messages with extra unexpected fields', async () => {
       const { ws, close } = await createAuthenticatedConnection()
 
-      // Extra fields should be ignored (Zod strips unknown keys)
       ws.send(
         JSON.stringify({
           type: 'terminal.create',
@@ -749,10 +748,11 @@ describe('WebSocket edge cases', () => {
         })
       )
 
-      const created = await waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === 'with-extra')
-      expect(created.terminalId).toMatch(/^term_/)
-      expect(created.snapshot).toBeUndefined()
-      expect(created.snapshotChunked).toBeUndefined()
+      const error = await waitForMessage(
+        ws,
+        (m) => m.type === 'error' && m.requestId === 'with-extra',
+      )
+      expect(error.code).toBe('INVALID_MESSAGE')
 
       close()
     })
@@ -1578,7 +1578,10 @@ describe('WebSocket edge cases', () => {
         type: 'terminal.create',
         requestId: requestId1,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       const created1 = await waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === requestId1)
@@ -1588,13 +1591,16 @@ describe('WebSocket edge cases', () => {
         type: 'terminal.create',
         requestId: requestId2,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       const created2 = await waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === requestId2)
 
       expect(created2.terminalId).toBe(created1.terminalId)
-      expect(created2.effectiveResumeSessionId).toBe(VALID_SESSION_ID)
+      expect(created2).not.toHaveProperty('effectiveResumeSessionId')
 
       close()
     })
@@ -1660,7 +1666,7 @@ describe('WebSocket edge cases', () => {
       close()
     })
 
-    it('terminal.create ignores stale attachOnCreate payloads and still does not auto-attach', async () => {
+    it('terminal.create rejects stale attachOnCreate payloads', async () => {
       const { ws, close } = await createAuthenticatedConnection()
 
       ws.send(JSON.stringify({
@@ -1669,11 +1675,11 @@ describe('WebSocket edge cases', () => {
         mode: 'shell',
         attachOnCreate: false,
       }))
-      const created = await waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === 'split-no-auto')
-      const msgs = await collectMessages(ws, 150)
-      const autoReadySeen = msgs.some((m) => m.type === 'terminal.attach.ready' && m.terminalId === created.terminalId)
-
-      expect(autoReadySeen).toBe(false)
+      const error = await waitForMessage(
+        ws,
+        (m) => m.type === 'error' && m.requestId === 'split-no-auto',
+      )
+      expect(error.code).toBe('INVALID_MESSAGE')
       close()
     })
 

--- a/test/server/ws-handshake-snapshot.test.ts
+++ b/test/server/ws-handshake-snapshot.test.ts
@@ -40,11 +40,17 @@ function listen(server: http.Server, timeoutMs = HOOK_TIMEOUT_MS): Promise<{ por
 }
 
 class FakeRegistry {
+  private terminals: any[] = []
+
   detach() {
     return true
   }
   list() {
-    return []
+    return [...this.terminals]
+  }
+
+  setTerminals(terminals: any[]) {
+    this.terminals = [...terminals]
   }
 }
 
@@ -142,6 +148,7 @@ describe('ws handshake snapshot', () => {
   let server: http.Server | undefined
   let port: number
   let snapshot: Snapshot
+  let registry: FakeRegistry
   let originalNodeEnv: string | undefined
   let originalAuthToken: string | undefined
   let originalHelloTimeoutMs: string | undefined
@@ -185,7 +192,9 @@ describe('ws handshake snapshot', () => {
       res.end()
     })
 
-    new (WsHandler as any)(server, new FakeRegistry() as any, {
+    registry = new FakeRegistry()
+
+    new (WsHandler as any)(server, registry as any, {
       handshakeSnapshotProvider: async () => snapshot,
     })
 
@@ -313,6 +322,18 @@ describe('ws handshake snapshot', () => {
   })
 
   it('sends terminal inventory in handshake snapshot', async () => {
+    registry.setTerminals([
+      {
+        terminalId: 'term-inventory-1',
+        title: 'Claude CLI',
+        mode: 'claude',
+        resumeSessionId: '550e8400-e29b-41d4-a716-446655440000',
+        createdAt: 1,
+        lastActivityAt: 2,
+        status: 'running',
+      },
+    ])
+
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
 
     try {
@@ -326,6 +347,14 @@ describe('ws handshake snapshot', () => {
       expect(inventory).toHaveProperty('bootId')
       expect(Array.isArray(inventory.terminals)).toBe(true)
       expect(Array.isArray(inventory.terminalMeta)).toBe(true)
+      expect(inventory.terminals).toContainEqual(expect.objectContaining({
+        terminalId: 'term-inventory-1',
+        sessionRef: {
+          provider: 'claude',
+          sessionId: '550e8400-e29b-41d4-a716-446655440000',
+        },
+      }))
+      expect(inventory.terminals[0]).not.toHaveProperty('resumeSessionId')
     } finally {
       await closeWs(ws)
     }

--- a/test/server/ws-opencode-activity.test.ts
+++ b/test/server/ws-opencode-activity.test.ts
@@ -92,6 +92,11 @@ describe('ws opencode activity protocol', () => {
     phase: 'busy',
     updatedAt: 1234,
   }]
+  const liveOnlyActivity = [{
+    terminalId: 'term-opencode-live-only',
+    phase: 'busy',
+    updatedAt: 4321,
+  }]
 
   beforeAll(async () => {
     process.env.NODE_ENV = 'test'
@@ -148,6 +153,26 @@ describe('ws opencode activity protocol', () => {
     expect(updated).toEqual({
       type: 'opencode.activity.updated',
       upsert: sampleActivity,
+      remove: [],
+    })
+    ws.close()
+  })
+
+  it('preserves live-only opencode activity records without inventing a session id', async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+    ws.send(JSON.stringify({ type: 'hello', token: 'opencode-activity-token', protocolVersion: WS_PROTOCOL_VERSION }))
+    await waitForMessage(ws, (msg) => msg.type === 'ready')
+
+    wsHandler.broadcastOpencodeActivityUpdated({
+      upsert: liveOnlyActivity as any,
+      remove: [],
+    })
+
+    const updated = await waitForMessage(ws, (msg) => msg.type === 'opencode.activity.updated')
+    expect(updated).toEqual({
+      type: 'opencode.activity.updated',
+      upsert: liveOnlyActivity,
       remove: [],
     })
     ws.close()

--- a/test/server/ws-protocol.test.ts
+++ b/test/server/ws-protocol.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest'
 import http from 'http'
 import WebSocket from 'ws'
-import { WS_PROTOCOL_VERSION } from '../../shared/ws-protocol.js'
+import {
+  HelloSchema,
+  TerminalCreateSchema,
+  WS_PROTOCOL_VERSION,
+} from '../../shared/ws-protocol.js'
 import { FakeCodexLaunchPlanner, DEFAULT_CODEX_REMOTE_WS_URL } from '../helpers/coding-cli/fake-codex-launch-planner.js'
 
 const TEST_TIMEOUT_MS = 30_000
 const HOOK_TIMEOUT_MS = 30_000
+const VALID_SESSION_ID = '550e8400-e29b-41d4-a716-446655440000'
 vi.setConfig({ testTimeout: TEST_TIMEOUT_MS, hookTimeout: HOOK_TIMEOUT_MS })
 
 // Mock the config-store module before importing ws-handler
@@ -196,6 +201,24 @@ class FakeRegistry {
     }
     return undefined
   }
+
+  getCanonicalRunningTerminalBySession(mode: string, sessionId: string) {
+    for (const rec of this.records.values()) {
+      if (rec.mode !== mode) continue
+      if (rec.status !== 'running') continue
+      if (rec.resumeSessionId === sessionId) return rec
+    }
+    return undefined
+  }
+
+  repairLegacySessionOwners(mode: string, sessionId: string) {
+    const canonical = this.getCanonicalRunningTerminalBySession(mode, sessionId)
+    return {
+      repaired: false,
+      canonicalTerminalId: canonical?.terminalId,
+      clearedTerminalIds: [] as string[],
+    }
+  }
 }
 
 function countCreateResponses(messages: any[], prefix?: string) {
@@ -300,6 +323,52 @@ describe('ws protocol', () => {
     })
     expect(ready.type).toBe('ready')
     await closeWebSocket(ws)
+  })
+
+  it('rejects serverInstanceId inside hello sidebarOpenSessions durable identity', () => {
+    const parsed = HelloSchema.safeParse({
+      type: 'hello',
+      token: 'testtoken-testtoken',
+      protocolVersion: WS_PROTOCOL_VERSION,
+      sidebarOpenSessions: [{
+        provider: 'codex',
+        sessionId: 'codex-session-1',
+        serverInstanceId: 'srv-local',
+      }],
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  it('accepts terminal.create canonical sessionRef and rejects raw durable resumeSessionId', () => {
+    const parsed = TerminalCreateSchema.safeParse({
+      type: 'terminal.create',
+      requestId: 'req-1',
+      mode: 'codex',
+      restore: true,
+      sessionRef: {
+        provider: 'codex',
+        sessionId: 'codex-session-1',
+      },
+    })
+
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+
+    expect((parsed.data as any).sessionRef).toEqual({
+      provider: 'codex',
+      sessionId: 'codex-session-1',
+    })
+
+    const legacy = TerminalCreateSchema.safeParse({
+      type: 'terminal.create',
+      requestId: 'req-legacy',
+      mode: 'claude',
+      restore: true,
+      resumeSessionId: '550e8400-e29b-41d4-a716-446655440000',
+    })
+
+    expect(legacy.success).toBe(false)
   })
 
   it('accepts hello with capabilities', async () => {
@@ -417,7 +486,7 @@ describe('ws protocol', () => {
 
     const requestId = 'req-codex-settings'
     ws.send(JSON.stringify({ type: 'terminal.create', requestId, mode: 'codex' }))
-    await waitForMessage(
+    const created = await waitForMessage(
       ws,
       (msg) => msg.type === 'terminal.created' && msg.requestId === requestId,
       5000,
@@ -431,12 +500,44 @@ describe('ws protocol', () => {
       resumeSessionId: undefined,
       sandbox: 'workspace-write',
     }])
-    expect(registry.createCalls[0]?.resumeSessionId).toBe('thread-new-1')
+    expect(registry.createCalls[0]?.resumeSessionId).toBeUndefined()
     expect(registry.createCalls[0]?.providerSettings).toEqual({
       codexAppServer: {
         wsUrl: DEFAULT_CODEX_REMOTE_WS_URL,
       },
     })
+    expect(created).not.toHaveProperty('effectiveResumeSessionId')
+
+    await closeWebSocket(ws)
+  })
+
+  it('passes canonical Claude sessionRef through to registry.create without echoing a legacy durable id', async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+    ws.send(JSON.stringify({ type: 'hello', token: 'testtoken-testtoken', protocolVersion: WS_PROTOCOL_VERSION }))
+
+    await waitForMessage(ws, (msg) => msg.type === 'ready', 5000)
+
+    const requestId = 'req-claude-restore'
+    ws.send(JSON.stringify({
+      type: 'terminal.create',
+      requestId,
+      mode: 'claude',
+      restore: true,
+      sessionRef: {
+        provider: 'claude',
+        sessionId: VALID_SESSION_ID,
+      },
+    }))
+
+    const created = await waitForMessage(
+      ws,
+      (msg) => msg.type === 'terminal.created' && msg.requestId === requestId,
+      5000,
+    )
+
+    expect(registry.createCalls[0]?.resumeSessionId).toBe(VALID_SESSION_ID)
+    expect(created).not.toHaveProperty('effectiveResumeSessionId')
 
     await closeWebSocket(ws)
   })

--- a/test/server/ws-terminal-create-reuse-running-claude.test.ts
+++ b/test/server/ws-terminal-create-reuse-running-claude.test.ts
@@ -320,7 +320,10 @@ describe('terminal.create reuse running claude terminal', () => {
         type: 'terminal.create',
         requestId,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       const created = await createdPromise
@@ -370,7 +373,10 @@ describe('terminal.create reuse running claude terminal', () => {
         type: 'terminal.create',
         requestId: 'reuse-split-existingAfterConfig',
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
       const created = await createdPromise
       const preAttachMsgs = await collectMessages(ws, 150)
@@ -411,13 +417,19 @@ describe('terminal.create reuse running claude terminal', () => {
         type: 'terminal.create',
         requestId: 'reuse-claude-dup-split',
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
       ws.send(JSON.stringify({
         type: 'terminal.create',
         requestId: 'reuse-claude-dup-split',
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       const created = await createdPromise

--- a/test/server/ws-terminal-create-reuse-running-codex.test.ts
+++ b/test/server/ws-terminal-create-reuse-running-codex.test.ts
@@ -317,7 +317,7 @@ describe('terminal.create reuse running codex terminal', () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
     try {
       await new Promise<void>((resolve) => ws.on('open', () => resolve()))
-      await waitForReady(ws)
+      const helloReady = await waitForReady(ws)
 
       const requestId = 'codex-reuse-1'
       const createdPromise = waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === requestId)
@@ -325,7 +325,10 @@ describe('terminal.create reuse running codex terminal', () => {
         type: 'terminal.create',
         requestId,
         mode: 'codex',
-        resumeSessionId: CODEX_SESSION_ID,
+        liveTerminal: {
+          terminalId: 'term-codex-existing',
+          serverInstanceId: helloReady.serverInstanceId,
+        },
       }))
 
       const created = await createdPromise
@@ -347,8 +350,8 @@ describe('terminal.create reuse running codex terminal', () => {
         rows: 40,
         attachRequestId: 'reuse-existing-codex-attach',
       }))
-      const ready = await attachReadyPromise
-      expect(ready.headSeq).toBeGreaterThanOrEqual(0)
+      const attachReady = await attachReadyPromise
+      expect(attachReady.headSeq).toBeGreaterThanOrEqual(0)
       expect(registry.attachCalls).toHaveLength(1)
       expect(registry.attachCalls[0]?.terminalId).toBe('term-codex-existing')
     } finally {
@@ -370,7 +373,7 @@ describe('terminal.create reuse running codex terminal', () => {
         type: 'terminal.create',
         requestId: 'reuse-canonical-split',
         mode: 'codex',
-        resumeSessionId: CODEX_SESSION_ID,
+        sessionRef: { provider: 'codex', sessionId: CODEX_SESSION_ID },
       }))
       const created = await createdPromise
       const preAttachMsgs = await collectMessages(ws, 150)
@@ -409,7 +412,7 @@ describe('terminal.create reuse running codex terminal', () => {
         type: 'terminal.create',
         requestId: 'reuse-existingId-split',
         mode: 'codex',
-        resumeSessionId: CODEX_SESSION_ID,
+        sessionRef: { provider: 'codex', sessionId: CODEX_SESSION_ID },
       }))
       const firstCreated = await firstCreatedPromise
       const firstMsgs = await collectMessages(ws, 150)
@@ -423,7 +426,7 @@ describe('terminal.create reuse running codex terminal', () => {
         type: 'terminal.create',
         requestId: 'reuse-existingId-split',
         mode: 'codex',
-        resumeSessionId: CODEX_SESSION_ID,
+        sessionRef: { provider: 'codex', sessionId: CODEX_SESSION_ID },
       }))
       const secondCreated = await secondCreatedPromise
       expect(secondCreated.terminalId).toBe(firstCreated.terminalId)
@@ -450,7 +453,7 @@ describe('terminal.create reuse running codex terminal', () => {
     }
   })
 
-  it('returns effectiveResumeSessionId from reused codex terminal', async () => {
+  it('does not echo durable session ids from reused codex terminals via terminal.created', async () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
     try {
       await new Promise<void>((resolve) => ws.on('open', () => resolve()))
@@ -462,16 +465,16 @@ describe('terminal.create reuse running codex terminal', () => {
         type: 'terminal.create',
         requestId,
         mode: 'codex',
-        resumeSessionId: CODEX_SESSION_ID,
+        sessionRef: { provider: 'codex', sessionId: CODEX_SESSION_ID },
       }))
       const created = await createdPromise
-      expect(created.effectiveResumeSessionId).toBe(CODEX_SESSION_ID)
+      expect(created).not.toHaveProperty('effectiveResumeSessionId')
     } finally {
       await closeWebSocket(ws)
     }
   })
 
-  it('returns terminal.created with the exact codex session id for a fresh terminal', async () => {
+  it('creates a fresh codex terminal without persisting a provisional session id', async () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
     try {
       await new Promise<void>((resolve) => ws.on('open', () => resolve()))
@@ -489,7 +492,7 @@ describe('terminal.create reuse running codex terminal', () => {
       const created = await createdPromise
 
       expect(created.terminalId).toBe('term-codex-existing')
-      expect(created.effectiveResumeSessionId).toBe('thread-new-1')
+      expect(created).not.toHaveProperty('effectiveResumeSessionId')
       expect(codexLaunchPlanner.planCreateCalls).toEqual([{
         cwd: '/repo/worktree',
         resumeSessionId: undefined,
@@ -501,8 +504,7 @@ describe('terminal.create reuse running codex terminal', () => {
       expect(registry.createCalls[0]).toMatchObject({
         mode: 'codex',
         cwd: '/repo/worktree',
-        resumeSessionId: 'thread-new-1',
-        sessionBindingReason: 'start',
+        resumeSessionId: undefined,
         providerSettings: {
           codexAppServer: {
             wsUrl: CODEX_REMOTE_WS_URL,
@@ -518,7 +520,7 @@ describe('terminal.create reuse running codex terminal', () => {
     const { WsHandler } = await import('../../server/ws-handler')
     const dupeServer = http.createServer((_req, res) => { res.statusCode = 404; res.end() })
     const dupeRegistry = new FakeRegistry(['term-canonical', 'term-duplicate'])
-    new WsHandler(dupeServer, dupeRegistry as any)
+    new WsHandler(dupeServer, dupeRegistry as any, { codexLaunchPlanner: new FakeCodexLaunchPlanner() })
     const info = await listen(dupeServer)
 
     const ws = new WebSocket(`ws://127.0.0.1:${info.port}/ws`)
@@ -543,7 +545,7 @@ describe('terminal.create reuse running codex terminal', () => {
         type: 'terminal.create',
         requestId,
         mode: 'codex',
-        resumeSessionId: CODEX_SESSION_ID,
+        sessionRef: { provider: 'codex', sessionId: CODEX_SESSION_ID },
       }))
       const created = await createdPromise
 

--- a/test/server/ws-terminal-create-session-repair.test.ts
+++ b/test/server/ws-terminal-create-session-repair.test.ts
@@ -347,13 +347,16 @@ describe('terminal.create session repair wait', () => {
         type: 'terminal.create',
         requestId,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       const created = await createdPromise
 
       expect(created.terminalId).toMatch(/^term_/)
-      expect(created.effectiveResumeSessionId).toBe(VALID_SESSION_ID)
+      expect(registry.lastCreateOpts?.resumeSessionId).toBe(VALID_SESSION_ID)
       expect(sessionRepairService.waitForSessionCalls).toContain(VALID_SESSION_ID)
     } finally {
       await closeWebSocket(ws)
@@ -383,13 +386,16 @@ describe('terminal.create session repair wait', () => {
         type: 'terminal.create',
         requestId,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       const created = await createdPromise
 
       expect(registry.lastCreateOpts?.resumeSessionId).toBeUndefined()
-      expect(created.effectiveResumeSessionId).toBeUndefined()
+      expect(created).not.toHaveProperty('effectiveResumeSessionId')
       expect(sessionRepairService.waitForSessionCalls).not.toContain(VALID_SESSION_ID)
     } finally {
       await closeWebSocket(ws)
@@ -420,13 +426,16 @@ describe('terminal.create session repair wait', () => {
         type: 'terminal.create',
         requestId,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       const created = await createdPromise
 
       expect(registry.lastCreateOpts?.resumeSessionId).toBeUndefined()
-      expect(created.effectiveResumeSessionId).toBeUndefined()
+      expect(created).not.toHaveProperty('effectiveResumeSessionId')
     } finally {
       await closeWebSocket(ws)
     }
@@ -447,14 +456,17 @@ describe('terminal.create session repair wait', () => {
         type: 'terminal.create',
         requestId,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       const created = await createdPromise
 
       // Should still create with the resumeSessionId (repair failed, but we proceed)
       expect(created.terminalId).toMatch(/^term_/)
-      expect(created.effectiveResumeSessionId).toBe(VALID_SESSION_ID)
+      expect(registry.lastCreateOpts?.resumeSessionId).toBe(VALID_SESSION_ID)
     } finally {
       await closeWebSocket(ws)
     }
@@ -477,13 +489,19 @@ describe('terminal.create session repair wait', () => {
         type: 'terminal.create',
         requestId,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
       ws.send(JSON.stringify({
         type: 'terminal.create',
         requestId,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       const created = await createdPromise
@@ -516,7 +534,10 @@ describe('terminal.create session repair wait', () => {
         type: 'terminal.create',
         requestId,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       await new Promise((resolve) => setTimeout(resolve, REPAIR_STAGGER_MS))
@@ -530,7 +551,10 @@ describe('terminal.create session repair wait', () => {
         type: 'terminal.create',
         requestId,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       const [createdOnWs1, createdOnWs2] = await Promise.all([
@@ -564,7 +588,10 @@ describe('terminal.create session repair wait', () => {
         type: 'terminal.create',
         requestId: 'resume-session-lock-1',
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       await new Promise((resolve) => setTimeout(resolve, REPAIR_STAGGER_MS))
@@ -578,7 +605,10 @@ describe('terminal.create session repair wait', () => {
         type: 'terminal.create',
         requestId: 'resume-session-lock-2',
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       const [createdOnWs1, createdOnWs2] = await Promise.all([
@@ -611,7 +641,10 @@ describe('terminal.create session repair wait', () => {
         type: 'terminal.create',
         requestId,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       // Close the socket while repair is in progress
@@ -863,13 +896,16 @@ describe('terminal.create session repair wait', () => {
         type: 'terminal.create',
         requestId,
         mode: 'claude',
-        resumeSessionId: VALID_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_SESSION_ID,
+        },
       }))
 
       const created = await createdPromise
 
       // Resume should proceed (not be dropped)
-      expect(created.effectiveResumeSessionId).toBe(VALID_SESSION_ID)
+      expect(registry.lastCreateOpts?.resumeSessionId).toBe(VALID_SESSION_ID)
       // waitForSession should have been called despite cached result
       expect(sessionRepairService.waitForSessionCalls).toContain(VALID_SESSION_ID)
     } finally {
@@ -877,7 +913,7 @@ describe('terminal.create session repair wait', () => {
     }
   })
 
-  it('passes non-UUID resumeSessionId through to create and skips session repair wait', async () => {
+  it('fails closed when Claude restore is requested with a non-canonical sessionRef', async () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
 
     try {
@@ -885,22 +921,69 @@ describe('terminal.create session repair wait', () => {
       await waitForReady(ws)
 
       const requestId = 'resume-invalid-1'
-      const createdPromise = waitForCreated(ws, requestId)
+      const responsePromise = waitForMessage(
+        ws,
+        (m) => (
+          m.requestId === requestId
+          && (m.type === 'terminal.created' || m.type === 'error')
+        ),
+      )
       ws.send(JSON.stringify({
         type: 'terminal.create',
         requestId,
         mode: 'claude',
-        resumeSessionId: 'not-a-uuid',
+        restore: true,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: 'not-a-uuid',
+        },
       }))
 
-      const created = await createdPromise
+      const response = await responsePromise
 
-      // Non-UUID name is now passed through to the registry (not stripped)
-      expect(registry.lastCreateOpts?.resumeSessionId).toBe('not-a-uuid')
-      // effectiveResumeSessionId is set because the name is passed through
-      expect(created.effectiveResumeSessionId).toBe('not-a-uuid')
-      // Session repair is still skipped for non-UUID names
+      expect(response).toMatchObject({
+        type: 'error',
+        code: 'RESTORE_UNAVAILABLE',
+      })
+      expect(registry.createCallCount).toBe(0)
+      expect(registry.records.size).toBe(0)
       expect(sessionRepairService.waitForSessionCalls).not.toContain('not-a-uuid')
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
+  it('fails closed when restore is requested without a canonical Claude session id', async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+
+    try {
+      await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+      await waitForReady(ws)
+
+      const requestId = 'restore-missing-canonical-1'
+      const responsePromise = waitForMessage(
+        ws,
+        (m) => (
+          m.requestId === requestId
+          && (m.type === 'terminal.created' || m.type === 'error')
+        ),
+      )
+
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'claude',
+        restore: true,
+      }))
+
+      const response = await responsePromise
+
+      expect(response).toMatchObject({
+        type: 'error',
+        code: 'RESTORE_UNAVAILABLE',
+      })
+      expect(registry.createCallCount).toBe(0)
+      expect(registry.records.size).toBe(0)
     } finally {
       await closeWebSocket(ws)
     }

--- a/test/unit/client/agentChatSlice.test.ts
+++ b/test/unit/client/agentChatSlice.test.ts
@@ -396,18 +396,19 @@ describe('agentChatSlice', () => {
   })
 
   it('stores timelineSessionId, timelineRevision, and stream snapshot from sdk.session.snapshot', () => {
+    const canonicalTimelineSessionId = '00000000-0000-4000-8000-000000000123'
     const state = agentChatReducer(initial, sessionSnapshotReceived({
       sessionId: 'sdk-1',
       latestTurnId: 'turn-2',
       status: 'running',
-      timelineSessionId: 'cli-1',
+      timelineSessionId: canonicalTimelineSessionId,
       revision: 12,
       streamingActive: true,
       streamingText: 'partial reply',
     }))
 
     expect(state.sessions['sdk-1']).toMatchObject({
-      timelineSessionId: 'cli-1',
+      timelineSessionId: canonicalTimelineSessionId,
       timelineRevision: 12,
       streamingActive: true,
       streamingText: 'partial reply',
@@ -502,7 +503,7 @@ describe('agentChatSlice', () => {
 
     expect(state.sessions['sdk-live']).toMatchObject({
       historyLoaded: true,
-      timelineSessionId: 'named-resume',
+      timelineSessionId: undefined,
       timelineRevision: 1,
     })
 

--- a/test/unit/client/components/BackgroundSessions.test.tsx
+++ b/test/unit/client/components/BackgroundSessions.test.tsx
@@ -51,7 +51,10 @@ describe('BackgroundSessions', () => {
           terminalId: 'term-codex-1',
           title: 'Codex',
           mode: 'codex',
-          resumeSessionId: 'codex-sess-abc',
+          sessionRef: {
+            provider: 'codex',
+            sessionId: 'codex-sess-abc',
+          },
           createdAt: Date.now() - 60000,
           lastActivityAt: Date.now() - 30000,
           status: 'running',
@@ -80,7 +83,10 @@ describe('BackgroundSessions', () => {
     const tabs = store.getState().tabs.tabs
     expect(tabs).toHaveLength(1)
     expect(tabs[0].mode).toBe('codex')
-    expect(tabs[0].resumeSessionId).toBe('codex-sess-abc')
+    expect(tabs[0].sessionRef).toEqual({
+      provider: 'codex',
+      sessionId: 'codex-sess-abc',
+    })
     // terminalId is in pane content, not on the tab
     const layout = store.getState().panes.layouts[tabs[0].id]
     expect(layout).toBeDefined()
@@ -89,6 +95,10 @@ describe('BackgroundSessions', () => {
       expect(layout.content.kind).toBe('terminal')
       if (layout.content.kind === 'terminal') {
         expect(layout.content.terminalId).toBe('term-codex-1')
+        expect(layout.content.sessionRef).toEqual({
+          provider: 'codex',
+          sessionId: 'codex-sess-abc',
+        })
       }
     }
   })

--- a/test/unit/client/components/ContextMenuProvider.test.tsx
+++ b/test/unit/client/components/ContextMenuProvider.test.tsx
@@ -830,7 +830,10 @@ describe('ContextMenuProvider', () => {
         expect(newPane.content.kind).toBe('terminal')
         if (newPane.content.kind === 'terminal') {
           expect(newPane.content.mode).toBe('claude')
-          expect(newPane.content.resumeSessionId).toBe(VALID_SESSION_ID)
+          expect(newPane.content.sessionRef).toEqual({
+            provider: 'claude',
+            sessionId: VALID_SESSION_ID,
+          })
         }
       }
     }
@@ -873,7 +876,10 @@ describe('ContextMenuProvider', () => {
         expect(newPane.content).toMatchObject({
           kind: 'agent-chat',
           provider: 'freshclaude',
-          resumeSessionId: VALID_SESSION_ID,
+          sessionRef: {
+            provider: 'claude',
+            sessionId: VALID_SESSION_ID,
+          },
         })
       }
     }
@@ -914,7 +920,10 @@ describe('ContextMenuProvider', () => {
     expect(openedTab).toMatchObject({
       title: 'History Terminal Session',
       initialCwd: '/shared/project/history',
-      resumeSessionId: VALID_SESSION_ID,
+      sessionRef: {
+        provider: 'claude',
+        sessionId: VALID_SESSION_ID,
+      },
     })
     expect(store.getState().panes.layouts[openedTab!.id]).toBeUndefined()
   })

--- a/test/unit/client/components/HistoryView.mobile.test.tsx
+++ b/test/unit/client/components/HistoryView.mobile.test.tsx
@@ -169,7 +169,10 @@ describe('HistoryView mobile behavior', () => {
         expect(layout.content).toMatchObject({
           kind: 'agent-chat',
           provider: 'freshclaude',
-          resumeSessionId: '550e8400-e29b-41d4-a716-446655440000',
+          sessionRef: {
+            provider: 'claude',
+            sessionId: '550e8400-e29b-41d4-a716-446655440000',
+          },
         })
       }
     })

--- a/test/unit/client/components/Sidebar.render-stability.test.tsx
+++ b/test/unit/client/components/Sidebar.render-stability.test.tsx
@@ -13,7 +13,10 @@ describe('Sidebar render stability', () => {
       status: 'running',
       hasClients: false,
       mode: 'claude',
-      resumeSessionId: 'session-abc',
+      sessionRef: {
+        provider: 'claude',
+        sessionId: 'session-abc',
+      },
       cwd: '/home/user/project',
     }
 
@@ -25,7 +28,10 @@ describe('Sidebar render stability', () => {
       status: 'running',
       hasClients: true,
       mode: 'codex',
-      resumeSessionId: 'session-def',
+      sessionRef: {
+        provider: 'codex',
+        sessionId: 'session-def',
+      },
       cwd: '/home/user/other',
     }
 
@@ -73,9 +79,15 @@ describe('Sidebar render stability', () => {
       expect(areTerminalsEqual(a, b)).toBe(false)
     })
 
-    it('returns false when resumeSessionId changes', () => {
+    it('returns false when sessionRef changes', () => {
       const a = [terminal1]
-      const b = [{ ...terminal1, resumeSessionId: 'session-new' }]
+      const b = [{
+        ...terminal1,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: 'session-new',
+        },
+      }]
       expect(areTerminalsEqual(a, b)).toBe(false)
     })
 

--- a/test/unit/client/components/Sidebar.test.tsx
+++ b/test/unit/client/components/Sidebar.test.tsx
@@ -17,7 +17,7 @@ import extensionsReducer from '@/store/extensionsSlice'
 import codexActivityReducer, { type CodexActivityState } from '@/store/codexActivitySlice'
 import opencodeActivityReducer, { type OpencodeActivityState } from '@/store/opencodeActivitySlice'
 import terminalDirectoryReducer, { setTerminalDirectoryWindowData } from '@/store/terminalDirectorySlice'
-import type { ProjectGroup, BackgroundTerminal, TabMode } from '@/store/types'
+import type { ProjectGroup, BackgroundTerminal, TabMode, Tab } from '@/store/types'
 import type { PaneNode } from '@/store/paneTypes'
 import type { ClientExtensionEntry } from '@shared/extension-types'
 
@@ -84,6 +84,7 @@ function createTestStore(options?: {
   tabs?: Array<{
     id: string
     terminalId?: string
+    sessionRef?: Tab['sessionRef']
     resumeSessionId?: string
     mode?: string
     lastInputAt?: number
@@ -117,7 +118,7 @@ function createTestStore(options?: {
   if (!options?.panes) {
     for (const tab of options?.tabs ?? []) {
       const paneId = `pane-${tab.id}`
-      const mode = (tab.mode as TabMode | undefined) || (tab.resumeSessionId ? 'claude' : 'shell')
+      const mode = (tab.mode as TabMode | undefined) || tab.sessionRef?.provider || (tab.resumeSessionId ? 'claude' : 'shell')
       inferredLayouts[tab.id] = {
         type: 'leaf',
         id: paneId,
@@ -127,6 +128,7 @@ function createTestStore(options?: {
           createRequestId: `req-${tab.id}`,
           status: tab.status || 'running',
           terminalId: tab.terminalId,
+          sessionRef: tab.sessionRef,
           resumeSessionId: tab.resumeSessionId,
         },
       }
@@ -310,6 +312,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
           id: 'tab-restored',
           title: 'Restored Session',
           mode: 'codex',
+          sessionRef: {
+            provider: 'codex',
+            sessionId: 'codex-restored',
+          },
           resumeSessionId: 'codex-restored',
           createdAt: 2_000,
         }],
@@ -323,6 +329,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
                 mode: 'codex',
                 createRequestId: 'req-restored',
                 status: 'running',
+                sessionRef: {
+                  provider: 'codex',
+                  sessionId: 'codex-restored',
+                },
                 resumeSessionId: 'codex-restored',
                 cwd: '/tmp/restored-project',
               },
@@ -425,7 +435,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
           status: 'running',
           hasClients: false,
           mode: 'claude',
-          resumeSessionId: sessionId('session-abc'),
+          sessionRef: {
+            provider: 'claude',
+            sessionId: sessionId('session-abc'),
+          },
           cwd: '/home/user/project',
         },
       ]
@@ -540,7 +553,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
           status: 'running',
           hasClients: false,
           mode: 'claude',
-          resumeSessionId: sessionId('session-running'),
+          sessionRef: {
+            provider: 'claude',
+            sessionId: sessionId('session-running'),
+          },
           cwd: '/home/user/project',
         },
       ]
@@ -581,7 +597,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
           status: 'exited', // Exited, not running
           hasClients: false,
           mode: 'claude',
-          resumeSessionId: sessionId('session-1'),
+          sessionRef: {
+            provider: 'claude',
+            sessionId: sessionId('session-1'),
+          },
           cwd: '/home/user/project',
         },
       ]
@@ -621,7 +640,6 @@ describe('Sidebar Component - Session-Centric Display', () => {
           status: 'running',
           hasClients: false,
           mode: 'shell', // Shell mode, not claude
-          resumeSessionId: sessionId('session-1'),
           cwd: '/home/user/project',
         },
       ]
@@ -694,7 +712,7 @@ describe('Sidebar Component - Session-Centric Display', () => {
       expect(button).toHaveClass('bg-muted')
     })
 
-    it('marks non-UUID Claude pane resumeSessionId as hasTab (named resume)', async () => {
+    it('does not treat non-UUID Claude pane resumeSessionId as canonical tab identity', async () => {
       const namedResume = 'not-a-uuid'
       const projects: ProjectGroup[] = [
         {
@@ -747,8 +765,8 @@ describe('Sidebar Component - Session-Centric Display', () => {
 
       const button = screen.getByText('Named resume session').closest('button')
       expect(button).not.toBeNull()
-      // Non-UUID Claude resume names are now recognized as valid tabs
-      expect(button).toHaveAttribute('data-has-tab', 'true')
+      expect(button).toHaveAttribute('data-has-tab', 'false')
+      expect(button).not.toHaveClass('bg-muted')
     })
   })
 
@@ -1057,7 +1075,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
           status: 'running',
           hasClients: true,
           mode: 'codex',
-          resumeSessionId: busySessionId,
+          sessionRef: {
+            provider: 'codex',
+            sessionId: busySessionId,
+          },
         },
       ]
 
@@ -1127,7 +1148,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
           status: 'running',
           hasClients: false,
           mode: 'codex',
-          resumeSessionId: sid,
+          sessionRef: {
+            provider: 'codex',
+            sessionId: sid,
+          },
         },
         {
           terminalId: newTerminalId,
@@ -1136,7 +1160,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
           status: 'running',
           hasClients: true,
           mode: 'codex',
-          resumeSessionId: sid,
+          sessionRef: {
+            provider: 'codex',
+            sessionId: sid,
+          },
         },
       ]
 
@@ -1200,11 +1227,19 @@ describe('Sidebar Component - Session-Centric Display', () => {
         {
           id: 'tab-1',
           terminalId,
+          sessionRef: {
+            provider: 'opencode',
+            sessionId: busySessionId,
+          },
           resumeSessionId: busySessionId,
           mode: 'opencode',
         },
         {
           id: 'tab-2',
+          sessionRef: {
+            provider: 'opencode',
+            sessionId: idleSessionId,
+          },
           resumeSessionId: idleSessionId,
           mode: 'opencode',
         },
@@ -1218,7 +1253,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
           status: 'running',
           hasClients: true,
           mode: 'opencode',
-          resumeSessionId: busySessionId,
+          sessionRef: {
+            provider: 'opencode',
+            sessionId: busySessionId,
+          },
         },
       ]
 
@@ -1410,10 +1448,13 @@ describe('Sidebar Component - Session-Centric Display', () => {
       // Should navigate to terminal view
       expect(onNavigate).toHaveBeenCalledWith('terminal')
 
-      // Check store has new tab with resumeSessionId
+      // Check store has new tab with canonical durable sessionRef
       const state = store.getState()
       expect(state.tabs.tabs).toHaveLength(1)
-      expect(state.tabs.tabs[0].resumeSessionId).toBe(sessionId('session-to-resume'))
+      expect(state.tabs.tabs[0].sessionRef).toEqual({
+        provider: 'claude',
+        sessionId: sessionId('session-to-resume'),
+      })
       expect(state.tabs.tabs[0].mode).toBe('claude')
     })
 
@@ -1505,7 +1546,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
           status: 'running',
           hasClients: false,
           mode: 'claude',
-          resumeSessionId: sessionId('session-running'),
+          sessionRef: {
+            provider: 'claude',
+            sessionId: sessionId('session-running'),
+          },
           cwd: '/home/user/project',
         },
       ]
@@ -1592,7 +1636,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
           status: 'running',
           hasClients: false,
           mode: 'claude',
-          resumeSessionId: sessionId('session-running-no-tab'),
+          sessionRef: {
+            provider: 'claude',
+            sessionId: sessionId('session-running-no-tab'),
+          },
           cwd: '/home/user/project',
         },
       ]
@@ -1614,7 +1661,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
       // Should create a new tab with the terminalId in pane content
       const state = store.getState()
       expect(state.tabs.tabs).toHaveLength(1)
-      expect(state.tabs.tabs[0].resumeSessionId).toBe(sessionId('session-running-no-tab'))
+      expect(state.tabs.tabs[0].sessionRef).toEqual({
+        provider: 'claude',
+        sessionId: sessionId('session-running-no-tab'),
+      })
       expect(state.tabs.tabs[0].mode).toBe('claude')
       // terminalId lives in pane content, not on the tab
       const layout = state.panes.layouts[state.tabs.tabs[0].id]
@@ -3080,7 +3130,8 @@ describe('Sidebar Component - Session-Centric Display', () => {
           (child) =>
             child.type === 'leaf' &&
             child.content.kind === 'terminal' &&
-            child.content.resumeSessionId === sessionId('session-to-split')
+            child.content.sessionRef?.provider === 'claude' &&
+            child.content.sessionRef?.sessionId === sessionId('session-to-split')
         )
         expect(sessionPane).toBeDefined()
       }
@@ -3192,10 +3243,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
               mode: 'codex',
               createRequestId: 'req-foreign',
               status: 'running',
+              serverInstanceId: 'srv-remote',
               sessionRef: {
                 provider: 'codex',
                 sessionId: targetSessionId,
-                serverInstanceId: 'srv-remote',
               },
             },
           },
@@ -3233,7 +3284,8 @@ describe('Sidebar Component - Session-Centric Display', () => {
       const localPane = collectLeafPanes(layout).find((pane) => (
         pane.type === 'leaf'
         && pane.content.kind === 'terminal'
-        && pane.content.resumeSessionId === targetSessionId
+        && pane.content.sessionRef?.provider === 'codex'
+        && pane.content.sessionRef?.sessionId === targetSessionId
       ))
       expect(localPane).toBeDefined()
     })
@@ -3280,7 +3332,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
       // Should create a new tab since active tab has no layout
       const state = store.getState()
       expect(state.tabs.tabs).toHaveLength(2)
-      const newTab = state.tabs.tabs.find((t: any) => t.resumeSessionId === sessionId('session-no-layout'))
+      const newTab = state.tabs.tabs.find((t: any) => (
+        t.sessionRef?.provider === 'claude'
+        && t.sessionRef?.sessionId === sessionId('session-no-layout')
+      ))
       expect(newTab).toBeDefined()
     })
   })
@@ -3490,6 +3545,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
             id: 'tab-match',
             title: 'Matching Fallback',
             mode: 'codex',
+            sessionRef: {
+              provider: 'codex',
+              sessionId: matchingFallbackSessionId,
+            },
             resumeSessionId: matchingFallbackSessionId,
             createdAt: 1_000,
           },
@@ -3497,6 +3556,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
             id: 'tab-unrelated',
             title: 'Unrelated Fallback',
             mode: 'codex',
+            sessionRef: {
+              provider: 'codex',
+              sessionId: unrelatedFallbackSessionId,
+            },
             resumeSessionId: unrelatedFallbackSessionId,
             createdAt: 900,
           },
@@ -3511,6 +3574,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
                 mode: 'codex',
                 createRequestId: 'req-match',
                 status: 'running',
+                sessionRef: {
+                  provider: 'codex',
+                  sessionId: matchingFallbackSessionId,
+                },
                 resumeSessionId: matchingFallbackSessionId,
                 initialCwd: '/tmp/local/trycycle',
               },
@@ -3523,6 +3590,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
                 mode: 'codex',
                 createRequestId: 'req-unrelated',
                 status: 'running',
+                sessionRef: {
+                  provider: 'codex',
+                  sessionId: unrelatedFallbackSessionId,
+                },
                 resumeSessionId: unrelatedFallbackSessionId,
                 initialCwd: '/tmp/local/elsewhere',
               },
@@ -3679,6 +3750,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
             id: 'tab-alpha-fallback',
             title: 'Alpha Fallback',
             mode: 'codex',
+            sessionRef: {
+              provider: 'codex',
+              sessionId: alphaFallbackSessionId,
+            },
             resumeSessionId: alphaFallbackSessionId,
             createdAt: 1_000,
           },
@@ -3686,6 +3761,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
             id: 'tab-beta-fallback',
             title: 'Beta Fallback',
             mode: 'codex',
+            sessionRef: {
+              provider: 'codex',
+              sessionId: betaFallbackSessionId,
+            },
             resumeSessionId: betaFallbackSessionId,
             createdAt: 900,
           },
@@ -3700,6 +3779,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
                 mode: 'codex',
                 createRequestId: 'req-alpha-fallback',
                 status: 'running',
+                sessionRef: {
+                  provider: 'codex',
+                  sessionId: alphaFallbackSessionId,
+                },
                 resumeSessionId: alphaFallbackSessionId,
                 initialCwd: '/tmp/local/alpha',
               },
@@ -3712,6 +3795,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
                 mode: 'codex',
                 createRequestId: 'req-beta-fallback',
                 status: 'running',
+                sessionRef: {
+                  provider: 'codex',
+                  sessionId: betaFallbackSessionId,
+                },
                 resumeSessionId: betaFallbackSessionId,
                 initialCwd: '/tmp/local/beta',
               },

--- a/test/unit/client/components/TabContent.test.tsx
+++ b/test/unit/client/components/TabContent.test.tsx
@@ -28,6 +28,10 @@ interface TabConfig {
   codingCliProvider?: string
   codingCliSessionId?: string
   resumeSessionId?: string
+  sessionRef?: {
+    provider: string
+    sessionId: string
+  }
   sessionMetadataByKey?: Record<string, unknown>
 }
 
@@ -59,6 +63,7 @@ function createStore(tabs: TabConfig[], options: StoreOptions = {}) {
           codingCliProvider: t.codingCliProvider as any,
           codingCliSessionId: t.codingCliSessionId,
           resumeSessionId: t.resumeSessionId,
+          sessionRef: t.sessionRef,
           sessionMetadataByKey: t.sessionMetadataByKey,
           createRequestId: 'req-1',
         })),
@@ -147,7 +152,10 @@ describe('TabContent', () => {
         {
           id: 'tab-1',
           mode: 'claude',
-          resumeSessionId: '550e8400-e29b-41d4-a716-446655440000',
+          sessionRef: {
+            provider: 'claude',
+            sessionId: '550e8400-e29b-41d4-a716-446655440000',
+          },
           sessionMetadataByKey: {
             'claude:550e8400-e29b-41d4-a716-446655440000': {
               sessionType: 'freshclaude',
@@ -167,7 +175,10 @@ describe('TabContent', () => {
           defaultContent: expect.objectContaining({
             kind: 'agent-chat',
             provider: 'freshclaude',
-            resumeSessionId: '550e8400-e29b-41d4-a716-446655440000',
+            sessionRef: {
+              provider: 'claude',
+              sessionId: '550e8400-e29b-41d4-a716-446655440000',
+            },
           }),
         }),
         expect.anything(),
@@ -180,7 +191,10 @@ describe('TabContent', () => {
           id: 'tab-1',
           mode: 'shell',
           codingCliProvider: 'claude',
-          resumeSessionId: '550e8400-e29b-41d4-a716-446655440001',
+          sessionRef: {
+            provider: 'claude',
+            sessionId: '550e8400-e29b-41d4-a716-446655440001',
+          },
           sessionMetadataByKey: {
             'claude:550e8400-e29b-41d4-a716-446655440001': {
               sessionType: 'freshclaude',
@@ -200,7 +214,37 @@ describe('TabContent', () => {
           defaultContent: expect.objectContaining({
             kind: 'agent-chat',
             provider: 'freshclaude',
-            resumeSessionId: '550e8400-e29b-41d4-a716-446655440001',
+            sessionRef: {
+              provider: 'claude',
+              sessionId: '550e8400-e29b-41d4-a716-446655440001',
+            },
+          }),
+        }),
+        expect.anything(),
+      )
+    })
+
+    it('does not reconstruct terminal sessionRef from a raw tab resumeSessionId fallback', () => {
+      const store = createStore([
+        {
+          id: 'tab-1',
+          mode: 'codex',
+          resumeSessionId: 'named-or-legacy-resume',
+        },
+      ])
+
+      render(
+        <Provider store={store}>
+          <TabContent tabId="tab-1" />
+        </Provider>,
+      )
+
+      expect(mockPaneLayout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultContent: expect.objectContaining({
+            kind: 'terminal',
+            mode: 'codex',
+            sessionRef: undefined,
           }),
         }),
         expect.anything(),

--- a/test/unit/client/components/TabsView.test.tsx
+++ b/test/unit/client/components/TabsView.test.tsx
@@ -261,10 +261,12 @@ describe('TabsView', () => {
           kind: 'terminal',
           payload: {
             mode: 'codex',
-            resumeSessionId: 'codex-session-123',
             sessionRef: {
               provider: 'codex',
               sessionId: 'codex-session-123',
+            },
+            liveTerminal: {
+              terminalId: 'term-remote-1',
               serverInstanceId: 'srv-remote',
             },
           },
@@ -291,8 +293,72 @@ describe('TabsView', () => {
     expect(layout?.content?.sessionRef).toEqual({
       provider: 'codex',
       sessionId: 'codex-session-123',
-      serverInstanceId: 'srv-remote',
     })
+    expect(layout?.content?.terminalId).toBeUndefined()
+  })
+
+  it('preserves explicit live terminal handles when opening a same-server tab copy', () => {
+    const store = configureStore({
+      reducer: {
+        tabs: tabsReducer,
+        panes: panesReducer,
+        tabRegistry: tabRegistryReducer,
+        connection: connectionReducer,
+      },
+    })
+    store.dispatch(setServerInstanceId('srv-local'))
+    store.dispatch(setTabRegistrySnapshot({
+      localOpen: [],
+      remoteOpen: [{
+        tabKey: 'remote:session-copy-local',
+        tabId: 'open-3',
+        serverInstanceId: 'srv-local',
+        deviceId: 'other-browser',
+        deviceLabel: 'other-browser',
+        tabName: 'session local',
+        status: 'open',
+        revision: 3,
+        createdAt: 2,
+        updatedAt: 4,
+        paneCount: 1,
+        titleSetByUser: false,
+        panes: [{
+          paneId: 'pane-local',
+          kind: 'terminal',
+          payload: {
+            mode: 'codex',
+            sessionRef: {
+              provider: 'codex',
+              sessionId: 'codex-session-456',
+            },
+            liveTerminal: {
+              terminalId: 'term-local-1',
+              serverInstanceId: 'srv-local',
+            },
+          },
+        }],
+      }],
+      closed: [],
+    }))
+
+    render(
+      <Provider store={store}>
+        <TabsView />
+      </Provider>,
+    )
+
+    fireEvent.click(screen.getByLabelText('other-browser: session local'))
+
+    const newTab = store.getState().tabs.tabs.find((tab) => tab.title === 'session local')
+    expect(newTab).toBeTruthy()
+    const layout = newTab ? (store.getState().panes.layouts[newTab.id] as any) : undefined
+    expect(layout?.content?.resumeSessionId).toBeUndefined()
+    expect(layout?.content?.sessionRef).toEqual({
+      provider: 'codex',
+      sessionId: 'codex-session-456',
+    })
+    expect(layout?.content?.terminalId).toBe('term-local-1')
+    expect(layout?.content?.serverInstanceId).toBe('srv-local')
   })
 
   it('shows pane kind icons with distinct colors', () => {

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -1707,7 +1707,7 @@ describe('TerminalView lifecycle updates', () => {
     }))
   })
 
-  it('recreates terminal once after INVALID_TERMINAL_ID for the current terminal', async () => {
+  it('recreates terminal once after INVALID_TERMINAL_ID when canonical durable identity exists', async () => {
     const tabId = 'tab-3'
     const paneId = 'pane-3'
 
@@ -1718,6 +1718,10 @@ describe('TerminalView lifecycle updates', () => {
       mode: 'claude',
       shell: 'system',
       terminalId: 'term-3',
+      sessionRef: {
+        provider: 'claude',
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      },
       initialCwd: '/tmp',
     }
 
@@ -1804,7 +1808,7 @@ describe('TerminalView lifecycle updates', () => {
     expect(createCalls).toHaveLength(1)
   })
 
-  it('always marks INVALID_TERMINAL_ID reconnects as restore regardless of wasRestore', async () => {
+  it('marks durable INVALID_TERMINAL_ID reconnects as restore regardless of wasRestore', async () => {
     // consumeTerminalRestoreRequestId returns false by default (non-restore terminal)
     // This is the common case: terminals created fresh, not from localStorage restore
     restoreMocks.consumeTerminalRestoreRequestId.mockReturnValue(false)
@@ -1815,9 +1819,13 @@ describe('TerminalView lifecycle updates', () => {
       kind: 'terminal',
       createRequestId: 'req-reconnect-restore',
       status: 'running',
-      mode: 'shell',
+      mode: 'claude',
       shell: 'system',
       terminalId: 'term-reconnect-restore',
+      sessionRef: {
+        provider: 'claude',
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      },
       initialCwd: '/tmp',
     }
 
@@ -1834,9 +1842,9 @@ describe('TerminalView lifecycle updates', () => {
         tabs: {
           tabs: [{
             id: tabId,
-            mode: 'shell',
+            mode: 'claude',
             status: 'running',
-            title: 'Shell',
+            title: 'Claude',
             titleSetByUser: false,
             terminalId: 'term-reconnect-restore',
             createRequestId: 'req-reconnect-restore',
@@ -2334,7 +2342,7 @@ describe('TerminalView lifecycle updates', () => {
     expect(writelnCalls.some((s: string) => s.includes('Terminal exited'))).toBe(true)
   })
 
-  it('mirrors resumeSessionId to tab on terminal.session.associated', async () => {
+  it('mirrors canonical durable identity to pane and tab on terminal.session.associated', async () => {
     const tabId = 'tab-session-assoc'
     const paneId = 'pane-session-assoc'
 
@@ -2402,24 +2410,30 @@ describe('TerminalView lifecycle updates', () => {
     messageHandler!({
       type: 'terminal.session.associated',
       terminalId: 'term-assoc',
-      sessionId,
+      sessionRef: {
+        provider: 'claude',
+        sessionId,
+      },
     })
 
-    // Verify pane content has resumeSessionId + sessionRef
+    // Verify pane content keeps only the canonical sessionRef
     const layout = store.getState().panes.layouts[tabId] as { type: 'leaf'; content: any }
-    expect(layout.content.resumeSessionId).toBe(sessionId)
+    expect(layout.content.resumeSessionId).toBeUndefined()
     expect(layout.content.sessionRef).toEqual({
       provider: 'claude',
       sessionId,
-      serverInstanceId: 'srv-local',
     })
 
-    // Verify tab also has resumeSessionId mirrored
+    // Verify tab also keeps only the canonical sessionRef
     const tab = store.getState().tabs.tabs.find(t => t.id === tabId)
-    expect(tab?.resumeSessionId).toBe(sessionId)
+    expect(tab?.resumeSessionId).toBeUndefined()
+    expect(tab?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId,
+    })
   })
 
-  it('persists the durable codex session id immediately on terminal.created', async () => {
+  it('persists canonical codex identity only after terminal.session.associated', async () => {
     const tabId = 'tab-codex-durable'
     const paneId = 'pane-codex-durable'
 
@@ -2475,30 +2489,63 @@ describe('TerminalView lifecycle updates', () => {
       expect(messageHandler).not.toBeNull()
     })
 
-    const sessionId = 'thread-new-1'
     messageHandler!({
       type: 'terminal.created',
       requestId: 'req-codex-durable',
       terminalId: 'term-codex-durable',
       createdAt: 123,
-      effectiveResumeSessionId: sessionId,
     })
 
     await waitFor(() => {
       const layout = store.getState().panes.layouts[tabId] as { type: 'leaf'; content: any }
-      expect(layout.content.resumeSessionId).toBe(sessionId)
+      expect(layout.content.resumeSessionId).toBeUndefined()
 
       const tab = store.getState().tabs.tabs.find((entry) => entry.id === tabId)
-      expect(tab?.resumeSessionId).toBe(sessionId)
+      expect(tab?.resumeSessionId).toBeUndefined()
+      expect(dispatchSpy.mock.calls.some(([action]) => action?.type === flushPersistedLayoutNow.type)).toBe(false)
+
+      const persisted = readPersistedLayoutSnapshotForTest()
+      expect(persisted?.tabs.tabs.find((entry) => entry.id === tabId)?.resumeSessionId).toBeUndefined()
+      expect((persisted?.panes.layouts[tabId] as any)?.content?.resumeSessionId).toBeUndefined()
+    })
+
+    const sessionId = 'codex-session-1'
+    messageHandler!({
+      type: 'terminal.session.associated',
+      terminalId: 'term-codex-durable',
+      sessionRef: {
+        provider: 'codex',
+        sessionId,
+      },
+    })
+
+    await waitFor(() => {
+      const layout = store.getState().panes.layouts[tabId] as { type: 'leaf'; content: any }
+      expect(layout.content.sessionRef).toEqual({
+        provider: 'codex',
+        sessionId,
+      })
+
+      const tab = store.getState().tabs.tabs.find((entry) => entry.id === tabId)
+      expect(tab?.sessionRef).toEqual({
+        provider: 'codex',
+        sessionId,
+      })
       expect(dispatchSpy.mock.calls.some(([action]) => action?.type === flushPersistedLayoutNow.type)).toBe(true)
 
       const persisted = readPersistedLayoutSnapshotForTest()
-      expect(persisted?.tabs.tabs.find((entry) => entry.id === tabId)?.resumeSessionId).toBe(sessionId)
-      expect((persisted?.panes.layouts[tabId] as any)?.content?.resumeSessionId).toBe(sessionId)
+      expect(persisted?.tabs.tabs.find((entry) => entry.id === tabId)?.sessionRef).toEqual({
+        provider: 'codex',
+        sessionId,
+      })
+      expect((persisted?.panes.layouts[tabId] as any)?.content?.sessionRef).toEqual({
+        provider: 'codex',
+        sessionId,
+      })
     })
   })
 
-  it('clears tab terminalId and sets status to creating on INVALID_TERMINAL_ID reconnect', async () => {
+  it('surfaces restore-unavailable for a live-only INVALID_TERMINAL_ID reconnect', async () => {
     const tabId = 'tab-clear-tid'
     const paneId = 'pane-clear-tid'
 
@@ -2567,14 +2614,18 @@ describe('TerminalView lifecycle updates', () => {
       expect(layout.content.terminalId).toBeUndefined()
     })
 
-    // Verify tab status was set to 'creating'
+    // Verify tab status was set to an explicit restore failure
     const tab = store.getState().tabs.tabs.find(t => t.id === tabId)
-    expect(tab?.status).toBe('creating')
+    expect(tab?.status).toBe('error')
 
     // Verify pane content was also updated
     const layout = store.getState().panes.layouts[tabId] as { type: 'leaf'; content: any }
     expect(layout.content.terminalId).toBeUndefined()
-    expect(layout.content.status).toBe('creating')
+    expect(layout.content.status).toBe('error')
+    expect(layout.content.restoreError).toEqual({
+      code: 'RESTORE_UNAVAILABLE',
+      reason: 'dead_live_handle',
+    })
   })
 
   describe('non-blocking reconnect', () => {

--- a/test/unit/client/components/TerminalView.resumeSession.test.tsx
+++ b/test/unit/client/components/TerminalView.resumeSession.test.tsx
@@ -73,7 +73,7 @@ class MockResizeObserver {
   unobserve = vi.fn()
 }
 
-describe('TerminalView resumeSessionId', () => {
+describe('TerminalView durable session contract', () => {
   beforeEach(() => {
     wsMocks.send.mockClear()
     vi.stubGlobal('ResizeObserver', MockResizeObserver)
@@ -84,7 +84,7 @@ describe('TerminalView resumeSessionId', () => {
     vi.unstubAllGlobals()
   })
 
-  it('includes resumeSessionId when creating a terminal', async () => {
+  it('includes canonical sessionRef when creating a durable restore terminal', async () => {
     const tabId = 'tab-1'
     const paneId = 'pane-1'
 
@@ -94,7 +94,10 @@ describe('TerminalView resumeSessionId', () => {
       status: 'creating',
       mode: 'claude',
       shell: 'system',
-      resumeSessionId: VALID_CLAUDE_SESSION_ID,
+      sessionRef: {
+        provider: 'claude',
+        sessionId: VALID_CLAUDE_SESSION_ID,
+      },
       initialCwd: '/tmp',
     }
 
@@ -139,12 +142,15 @@ describe('TerminalView resumeSessionId', () => {
       expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
         type: 'terminal.create',
         requestId: 'req-1',
-        resumeSessionId: VALID_CLAUDE_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_CLAUDE_SESSION_ID,
+        },
       }))
     })
   })
 
-  it('updates pane resumeSessionId from effectiveResumeSessionId', async () => {
+  it('keeps terminal.created live-only until an explicit terminal.session.associated arrives', async () => {
     const tabId = 'tab-1'
     const paneId = 'pane-1'
     let messageHandler: ((msg: any) => void) | null = null
@@ -211,14 +217,110 @@ describe('TerminalView resumeSessionId', () => {
       type: 'terminal.created',
       requestId: 'req-1',
       terminalId: 'term-1',
-      effectiveResumeSessionId: VALID_CLAUDE_SESSION_ID,
     })
 
     await waitFor(() => {
       const content = store.getState().panes.layouts[tabId]
       if (content?.type !== 'leaf') throw new Error('unexpected layout')
       if (content.content.kind !== 'terminal') throw new Error('unexpected content')
-      expect(content.content.resumeSessionId).toBe(VALID_CLAUDE_SESSION_ID)
+      expect(content.content.terminalId).toBe('term-1')
+      expect(content.content.resumeSessionId).toBeUndefined()
+      expect(content.content.sessionRef).toBeUndefined()
+    })
+  })
+
+  it('persists canonical durable sessionRef only after terminal.session.associated', async () => {
+    const tabId = 'tab-1'
+    const paneId = 'pane-1'
+    let messageHandler: ((msg: any) => void) | null = null
+
+    wsMocks.onMessage.mockImplementation((handler: (msg: any) => void) => {
+      messageHandler = handler
+      return () => {}
+    })
+
+    const paneContent: TerminalPaneContent = {
+      kind: 'terminal',
+      createRequestId: 'req-1',
+      status: 'creating',
+      mode: 'claude',
+      shell: 'system',
+      initialCwd: '/tmp',
+    }
+
+    const root: PaneNode = { type: 'leaf', id: paneId, content: paneContent }
+
+    const store = configureStore({
+      reducer: {
+        tabs: tabsReducer,
+        panes: panesReducer,
+        settings: settingsReducer,
+        connection: connectionReducer,
+      },
+      preloadedState: {
+        tabs: {
+          tabs: [{
+            id: tabId,
+            mode: 'claude',
+            status: 'running',
+            title: 'Claude',
+            titleSetByUser: false,
+            createRequestId: 'req-1',
+          }],
+          activeTabId: tabId,
+        },
+        panes: {
+          layouts: { [tabId]: root },
+          activePane: { [tabId]: paneId },
+          paneTitles: {},
+        },
+        settings: { settings: defaultSettings, status: 'loaded' },
+        connection: { status: 'connected', error: null, serverInstanceId: 'srv-local' },
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalView tabId={tabId} paneId={paneId} paneContent={paneContent} />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'terminal.create',
+        requestId: 'req-1',
+      }))
+    })
+
+    messageHandler?.({
+      type: 'terminal.created',
+      requestId: 'req-1',
+      terminalId: 'term-1',
+    })
+
+    messageHandler?.({
+      type: 'terminal.session.associated',
+      terminalId: 'term-1',
+      sessionRef: {
+        provider: 'claude',
+        sessionId: VALID_CLAUDE_SESSION_ID,
+      },
+    })
+
+    await waitFor(() => {
+      const layout = store.getState().panes.layouts[tabId]
+      if (layout?.type !== 'leaf') throw new Error('unexpected layout')
+      if (layout.content.kind !== 'terminal') throw new Error('unexpected content')
+      expect(layout.content.sessionRef).toEqual({
+        provider: 'claude',
+        sessionId: VALID_CLAUDE_SESSION_ID,
+      })
+
+      const tab = store.getState().tabs.tabs.find((entry) => entry.id === tabId)
+      expect(tab?.sessionRef).toEqual({
+        provider: 'claude',
+        sessionId: VALID_CLAUDE_SESSION_ID,
+      })
     })
   })
 })

--- a/test/unit/client/components/agent-chat/AgentChatView.reload.test.tsx
+++ b/test/unit/client/components/agent-chat/AgentChatView.reload.test.tsx
@@ -30,6 +30,12 @@ beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn()
 })
 
+const DURABLE_SESSION_ID = '00000000-0000-4000-8000-000000000201'
+const DURABLE_SESSION_ID_ALT = '00000000-0000-4000-8000-000000000202'
+const DURABLE_SHELL_SESSION_ID = '00000000-0000-4000-8000-000000000203'
+const DURABLE_RUNNING_SESSION_ID = '00000000-0000-4000-8000-000000000204'
+const DURABLE_SESSION_ID_NEXT = '00000000-0000-4000-8000-000000000205'
+
 const wsSend = vi.fn()
 const getAgentTimelinePage = vi.fn()
 const getAgentTurnBody = vi.fn()
@@ -132,7 +138,10 @@ const RELOAD_PANE: AgentChatPaneContent = {
 
 const RELOAD_PANE_WITH_CANONICAL_RESUME: AgentChatPaneContent = {
   ...RELOAD_PANE,
-  resumeSessionId: '00000000-0000-4000-8000-000000000321',
+  sessionRef: {
+    provider: 'claude',
+    sessionId: '00000000-0000-4000-8000-000000000321',
+  },
 }
 
 const RELOAD_PANE_WITH_NAMED_RESUME: AgentChatPaneContent = {
@@ -189,7 +198,7 @@ describe('AgentChatView reload/restore behavior', () => {
     })
   })
 
-  it('includes the named resumeSessionId when attaching a persisted pane before the canonical durable id exists', () => {
+  it('does not send a mutable named resume token when attaching a persisted pane', () => {
     const store = makeStore()
     render(
       <Provider store={store}>
@@ -204,7 +213,6 @@ describe('AgentChatView reload/restore behavior', () => {
     expect(wsSend).toHaveBeenCalledWith({
       type: 'sdk.attach',
       sessionId: 'sess-reload-1',
-      resumeSessionId: 'named-resume-token',
     })
   })
 
@@ -597,7 +605,7 @@ describe('AgentChatView reload/restore behavior', () => {
       sessionId: 'sess-reload-1',
       latestTurnId: 'turn-2',
       status: 'idle',
-      timelineSessionId: 'cli-sess-1',
+      timelineSessionId: DURABLE_SESSION_ID,
       revision: 12,
     }))
 
@@ -613,14 +621,14 @@ describe('AgentChatView reload/restore behavior', () => {
       expect(attachCalls[1]?.[0]).toEqual({
         type: 'sdk.attach',
         sessionId: 'sess-reload-1',
-        resumeSessionId: 'cli-sess-1',
+        resumeSessionId: DURABLE_SESSION_ID,
       })
     })
   })
 
   it('clears stale hydrated timeline content and waits for a fresh snapshot before rereading after a stale restore retry', async () => {
     getAgentTimelinePage.mockResolvedValue({
-      sessionId: 'cli-sess-1',
+      sessionId: DURABLE_SESSION_ID,
       items: [],
       nextCursor: null,
       revision: 13,
@@ -631,14 +639,14 @@ describe('AgentChatView reload/restore behavior', () => {
       sessionId: 'sess-reload-1',
       latestTurnId: 'turn-2',
       status: 'idle',
-      timelineSessionId: 'cli-sess-1',
+      timelineSessionId: DURABLE_SESSION_ID,
       revision: 12,
     }))
     store.dispatch(timelinePageReceived({
       sessionId: 'sess-reload-1',
       items: [
         makeTimelineItem('turn-2', 'assistant', 'Old stale summary', {
-          sessionId: 'cli-sess-1',
+          sessionId: DURABLE_SESSION_ID,
           ordinal: 2,
           timestamp: '2026-03-10T10:01:00.000Z',
         }),
@@ -648,7 +656,7 @@ describe('AgentChatView reload/restore behavior', () => {
       replace: true,
       bodies: {
         'turn-2': makeTimelineTurn('turn-2', 'assistant', 'Old hydrated body', {
-          sessionId: 'cli-sess-1',
+          sessionId: DURABLE_SESSION_ID,
           ordinal: 2,
           timestamp: '2026-03-10T10:01:00.000Z',
         }),
@@ -696,7 +704,7 @@ describe('AgentChatView reload/restore behavior', () => {
       sessionId: 'sess-reload-1',
       latestTurnId: 'turn-2',
       status: 'idle',
-      timelineSessionId: 'cli-sess-1',
+      timelineSessionId: DURABLE_SESSION_ID,
       revision: 12,
     }))
 
@@ -711,7 +719,7 @@ describe('AgentChatView reload/restore behavior', () => {
         sessionId: 'sess-reload-1',
         items: [
           makeTimelineItem('turn-2', 'user', 'Hydrated summary', {
-            sessionId: 'cli-sess-1',
+            sessionId: DURABLE_SESSION_ID,
             ordinal: 2,
             timestamp: '2026-03-10T10:01:00.000Z',
           }),
@@ -723,7 +731,7 @@ describe('AgentChatView reload/restore behavior', () => {
       store.dispatch(turnBodyReceived({
         sessionId: 'sess-reload-1',
         turn: makeTimelineTurn('turn-2', 'user', 'Hydrated body', {
-          sessionId: 'cli-sess-1',
+          sessionId: DURABLE_SESSION_ID,
           ordinal: 2,
           timestamp: '2026-03-10T10:01:00.000Z',
         }),
@@ -737,7 +745,7 @@ describe('AgentChatView reload/restore behavior', () => {
     await act(async () => {
       await store.dispatch(loadAgentTurnBody({
         sessionId: 'sess-reload-1',
-        timelineSessionId: 'cli-sess-1',
+        timelineSessionId: DURABLE_SESSION_ID,
         turnId: 'turn-7',
       }))
     })
@@ -834,14 +842,14 @@ describe('AgentChatView reload/restore behavior', () => {
   })
 
   it('uses timelineSessionId from sdk.session.snapshot for visible restore hydration', async () => {
-    getAgentTimelinePage.mockResolvedValue({ sessionId: 'cli-sess-1', items: [], nextCursor: null, revision: 1 })
+    getAgentTimelinePage.mockResolvedValue({ sessionId: DURABLE_SESSION_ID, items: [], nextCursor: null, revision: 1 })
 
     const store = makeStore()
     store.dispatch(sessionSnapshotReceived({
       sessionId: 'sess-reload-1',
       latestTurnId: 'turn-2',
       status: 'idle',
-      timelineSessionId: 'cli-sess-1',
+      timelineSessionId: DURABLE_SESSION_ID,
       revision: 2,
     }))
 
@@ -853,7 +861,7 @@ describe('AgentChatView reload/restore behavior', () => {
 
     await waitFor(() => {
       expect(getAgentTimelinePage).toHaveBeenCalledWith(
-        'cli-sess-1',
+        DURABLE_SESSION_ID,
         expect.objectContaining({ includeBodies: true, revision: 2 }),
         expect.anything(),
       )
@@ -921,15 +929,22 @@ describe('AgentChatView reload/restore behavior', () => {
         sessionId: 'sdk-sess-1',
         latestTurnId: 'turn-2',
         status: 'idle',
-        timelineSessionId: 'cli-session-abc-123',
+        timelineSessionId: DURABLE_SESSION_ID_ALT,
         revision: 2,
       }))
     })
 
-    expect(getPaneContent(store as unknown as ReturnType<typeof makeStore>, 't1', 'p1')?.resumeSessionId).toBe('cli-session-abc-123')
+    expect(getPaneContent(store as unknown as ReturnType<typeof makeStore>, 't1', 'p1')?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: DURABLE_SESSION_ID_ALT,
+    })
     const tab = store.getState().tabs.tabs.find((entry) => entry.id === 't1')
-    expect(tab?.resumeSessionId).toBe('cli-session-abc-123')
-    expect(tab?.sessionMetadataByKey?.['claude:cli-session-abc-123']).toEqual(expect.objectContaining({
+    expect(tab?.resumeSessionId).toBeUndefined()
+    expect(tab?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: DURABLE_SESSION_ID_ALT,
+    })
+    expect(tab?.sessionMetadataByKey?.[`claude:${DURABLE_SESSION_ID_ALT}`]).toEqual(expect.objectContaining({
       sessionType: 'freshclaude',
       firstUserMessage: 'Continue from the old tab',
     }))
@@ -969,16 +984,23 @@ describe('AgentChatView reload/restore behavior', () => {
         sessionId: 'sdk-shell-1',
         latestTurnId: 'turn-2',
         status: 'idle',
-        timelineSessionId: 'cli-shell-abc-123',
+        timelineSessionId: DURABLE_SHELL_SESSION_ID,
         revision: 2,
       }))
     })
 
-    expect(getPaneContent(store as unknown as ReturnType<typeof makeStore>, 't-shell', 'p1')?.resumeSessionId).toBe('cli-shell-abc-123')
+    expect(getPaneContent(store as unknown as ReturnType<typeof makeStore>, 't-shell', 'p1')?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: DURABLE_SHELL_SESSION_ID,
+    })
     const tab = store.getState().tabs.tabs.find((entry) => entry.id === 't-shell')
-    expect(tab?.resumeSessionId).toBe('cli-shell-abc-123')
+    expect(tab?.resumeSessionId).toBeUndefined()
+    expect(tab?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: DURABLE_SHELL_SESSION_ID,
+    })
     expect(tab?.codingCliProvider).toBe('claude')
-    expect(tab?.sessionMetadataByKey?.['claude:cli-shell-abc-123']).toEqual(expect.objectContaining({
+    expect(tab?.sessionMetadataByKey?.[`claude:${DURABLE_SHELL_SESSION_ID}`]).toEqual(expect.objectContaining({
       sessionType: 'freshclaude',
       firstUserMessage: 'Continue from shell fallback',
     }))
@@ -988,13 +1010,13 @@ describe('AgentChatView reload/restore behavior', () => {
     const canonicalSessionId = '00000000-0000-4000-8000-000000000321'
     getAgentTimelinePage
       .mockResolvedValueOnce({
-        sessionId: 'named-resume',
+        sessionId: 'sdk-meta-upgrade-1',
         items: [{
           turnId: 'turn-live-1',
           messageId: 'message-live-1',
           ordinal: 0,
           source: 'live',
-          sessionId: 'named-resume',
+          sessionId: 'sdk-meta-upgrade-1',
           role: 'assistant',
           summary: 'Live-only summary',
         }],
@@ -1004,7 +1026,7 @@ describe('AgentChatView reload/restore behavior', () => {
             messageId: 'message-live-1',
             ordinal: 0,
             source: 'live',
-            sessionId: 'named-resume',
+            sessionId: 'sdk-meta-upgrade-1',
             message: {
               role: 'assistant',
               content: [{ type: 'text', text: 'Live-only full body' }],
@@ -1119,14 +1141,13 @@ describe('AgentChatView reload/restore behavior', () => {
         sessionId: 'sdk-meta-upgrade-1',
         latestTurnId: 'turn-2',
         status: 'idle',
-        timelineSessionId: 'named-resume',
         revision: 1,
       }))
     })
 
     await waitFor(() => {
       expect(getAgentTimelinePage).toHaveBeenCalledWith(
-        'named-resume',
+        'sdk-meta-upgrade-1',
         expect.objectContaining({ includeBodies: true, revision: 1 }),
         expect.anything(),
       )
@@ -1197,9 +1218,16 @@ describe('AgentChatView reload/restore behavior', () => {
     expect(screen.queryByText('Live-only full body')).not.toBeInTheDocument()
     expect(screen.getAllByText('Post-watermark live delta')).toHaveLength(1)
 
-    expect(getPaneContent(store as unknown as ReturnType<typeof makeStore>, 't-meta', 'p1')?.resumeSessionId).toBe(canonicalSessionId)
+    expect(getPaneContent(store as unknown as ReturnType<typeof makeStore>, 't-meta', 'p1')?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: canonicalSessionId,
+    })
     const tab = store.getState().tabs.tabs.find((entry) => entry.id === 't-meta')
-    expect(tab?.resumeSessionId).toBe(canonicalSessionId)
+    expect(tab?.resumeSessionId).toBeUndefined()
+    expect(tab?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: canonicalSessionId,
+    })
     expect(tab?.sessionMetadataByKey?.['claude:00000000-0000-4000-8000-000000000321']).toEqual(expect.objectContaining({
       sessionType: 'freshclaude',
       firstUserMessage: 'Continue from metadata upgrade',
@@ -1260,7 +1288,7 @@ describe('AgentChatView reload/restore behavior', () => {
       sessionId: 'sdk-sess-1',
       latestTurnId: 'turn-2',
       status: 'running',
-      timelineSessionId: 'cli-sess-1',
+      timelineSessionId: DURABLE_SESSION_ID,
       streamingActive: true,
       streamingText: 'partial reply',
     }))
@@ -1281,7 +1309,7 @@ describe('AgentChatView reload/restore behavior', () => {
       sessionId: 'sdk-sess-running',
       latestTurnId: 'turn-2',
       status: 'running',
-      timelineSessionId: 'cli-sess-running',
+      timelineSessionId: DURABLE_RUNNING_SESSION_ID,
       streamingActive: true,
       streamingText: 'partial reply',
     }))
@@ -1297,7 +1325,7 @@ describe('AgentChatView reload/restore behavior', () => {
     act(() => {
       store.dispatch(sessionInit({
         sessionId: 'sdk-sess-running',
-        cliSessionId: 'cli-sess-running',
+        cliSessionId: DURABLE_RUNNING_SESSION_ID,
         model: 'claude-opus-4-6',
       }))
     })
@@ -1315,7 +1343,7 @@ describe('AgentChatView reload/restore behavior', () => {
       sessionId: 'sdk-sess-2',
       latestTurnId: 'turn-3',
       status: 'running',
-      timelineSessionId: 'cli-sess-2',
+      timelineSessionId: DURABLE_SESSION_ID_NEXT,
       streamingActive: false,
       streamingText: 'partial reply',
     }))
@@ -1650,14 +1678,17 @@ describe('AgentChatView server-restart recovery', () => {
       store.dispatch(sessionCreated({ requestId: 'req-1', sessionId: 'sdk-sess-1' }))
       store.dispatch(sessionInit({
         sessionId: 'sdk-sess-1',
-        cliSessionId: 'cli-session-abc-123',
+        cliSessionId: DURABLE_SESSION_ID_ALT,
         model: 'claude-opus-4-6',
       }))
     })
 
-    // Pane content should now have resumeSessionId persisted
+    // Pane content should now have canonical sessionRef persisted
     const content = getPaneContent(store, 't1', 'p1')
-    expect(content?.resumeSessionId).toBe('cli-session-abc-123')
+    expect(content?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: DURABLE_SESSION_ID_ALT,
+    })
   })
 
   it('does not reset the pane or send sdk.create when restore remains pending past the legacy timeout window', () => {

--- a/test/unit/client/components/agent-chat/AgentChatView.session-lost.test.tsx
+++ b/test/unit/client/components/agent-chat/AgentChatView.session-lost.test.tsx
@@ -8,6 +8,7 @@ import panesReducer, { initLayout } from '@/store/panesSlice'
 import settingsReducer from '@/store/settingsSlice'
 import type { AgentChatPaneContent } from '@/store/paneTypes'
 import type { PaneNode } from '@/store/paneTypes'
+import { buildRestoreError } from '@shared/session-contract'
 
 // jsdom doesn't implement scrollIntoView
 beforeAll(() => {
@@ -69,7 +70,7 @@ describe('AgentChatView — immediate recovery when session is lost', () => {
     vi.useRealTimers()
   })
 
-  it('recovers immediately when session is marked as lost (INVALID_SESSION_ID)', async () => {
+  it('does not restart from a mutable named resume token when session is marked as lost', async () => {
     const store = makeStore()
     const pane: AgentChatPaneContent = {
       kind: 'agent-chat', provider: 'freshclaude',
@@ -109,10 +110,8 @@ describe('AgentChatView — immediate recovery when session is lost', () => {
       store.dispatch(markSessionLost({ sessionId: 'dead-session-id' }))
     })
 
-    // Should recover IMMEDIATELY — clear the dead sessionId and begin creating
-    // a new SDK session, without waiting for the 5-second timeout.
-    // The recovery goes through a useEffect chain (markSessionLost → re-render →
-    // sessionLost effect → triggerRecovery dispatch → re-render → sdk.create effect).
+    // The dead live SDK session should be cleared, but the client must not
+    // restart from a mutable named resume token once no canonical durable id exists.
     await waitFor(() => {
       const content = getPaneContent(store, 't1', 'p1')
       expect(content).toBeDefined()
@@ -120,20 +119,19 @@ describe('AgentChatView — immediate recovery when session is lost', () => {
     })
 
     const content = getPaneContent(store, 't1', 'p1')!
-    // Status will be 'starting' because the sdk.create effect fires immediately
-    // after recovery sets status to 'creating', transitioning to 'starting'
-    expect(content.status).toBe('starting')
-    // resumeSessionId should be preserved so the new session resumes the CLI session
+    expect(content.status).toBe('idle')
+    expect(content.restoreError).toEqual(buildRestoreError('dead_live_handle'))
+    // The pane may still carry the original mutable name for display, but it
+    // must not be used as a restore target.
     expect(content.resumeSessionId).toBe('cli-session-to-resume')
-    // Should have sent sdk.create with the resumeSessionId
     const createCalls = wsSend.mock.calls.filter(
       (c: any[]) => c[0]?.type === 'sdk.create',
     )
-    expect(createCalls).toHaveLength(1)
-    expect(createCalls[0][0].resumeSessionId).toBe('cli-session-to-resume')
+    expect(createCalls).toHaveLength(0)
   })
 
   it('recovers with timelineSessionId from sdk.session.snapshot even when the session is marked lost before sdk.session.init', async () => {
+    const canonicalSessionId = '00000000-0000-4000-8000-000000000211'
     let resolveTimelinePage: ((value: {
       sessionId: string
       items: Array<Record<string, unknown>>
@@ -177,7 +175,7 @@ describe('AgentChatView — immediate recovery when session is lost', () => {
         sessionId: 'sdk-stale-1',
         latestTurnId: 'turn-2',
         status: 'idle',
-        timelineSessionId: 'cli-session-abc-123',
+        timelineSessionId: canonicalSessionId,
         revision: 2,
       }))
       store.dispatch(markSessionLost({ sessionId: 'sdk-stale-1' }))
@@ -185,7 +183,7 @@ describe('AgentChatView — immediate recovery when session is lost', () => {
 
     await waitFor(() => {
       expect(getAgentTimelinePage).toHaveBeenCalledWith(
-        'cli-session-abc-123',
+        canonicalSessionId,
         expect.objectContaining({ priority: 'visible', revision: 2, includeBodies: true }),
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       )
@@ -195,11 +193,11 @@ describe('AgentChatView — immediate recovery when session is lost', () => {
 
     await act(async () => {
       resolveTimelinePage?.({
-        sessionId: 'cli-session-abc-123',
+        sessionId: canonicalSessionId,
         items: [
           {
             turnId: 'turn-2',
-            sessionId: 'cli-session-abc-123',
+            sessionId: canonicalSessionId,
             role: 'assistant',
             summary: 'Recovered answer',
             timestamp: '2026-03-10T10:00:20.000Z',
@@ -209,7 +207,7 @@ describe('AgentChatView — immediate recovery when session is lost', () => {
         revision: 2,
         bodies: {
           'turn-2': {
-            sessionId: 'cli-session-abc-123',
+            sessionId: canonicalSessionId,
             turnId: 'turn-2',
             message: {
               role: 'assistant',
@@ -224,7 +222,7 @@ describe('AgentChatView — immediate recovery when session is lost', () => {
 
     await waitFor(() => {
       const createCalls = wsSend.mock.calls.filter((call: any[]) => call[0]?.type === 'sdk.create')
-      expect(createCalls.at(-1)?.[0]?.resumeSessionId).toBe('cli-session-abc-123')
+      expect(createCalls.at(-1)?.[0]?.resumeSessionId).toBe(canonicalSessionId)
     })
   })
 })

--- a/test/unit/client/components/agent-chat/AgentChatView.split-pane.test.tsx
+++ b/test/unit/client/components/agent-chat/AgentChatView.split-pane.test.tsx
@@ -386,7 +386,7 @@ describe('AgentChatView — split pane (Bug 2)', () => {
 
     await waitFor(() => {
       expect(getAgentTimelinePage).toHaveBeenCalledWith(
-        'cli-abc',
+        'sess-1',
         expect.objectContaining({ priority: 'visible', includeBodies: true, revision: 2 }),
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       )
@@ -709,7 +709,7 @@ describe('AgentChatView — split pane (Bug 2)', () => {
 
     await waitFor(() => {
       expect(getAgentTimelinePage).toHaveBeenCalledWith(
-        'cli-abc',
+        'sess-1',
         expect.objectContaining({ priority: 'visible', includeBodies: true, revision: 2 }),
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       )
@@ -723,7 +723,7 @@ describe('AgentChatView — split pane (Bug 2)', () => {
 
     await waitFor(() => {
       expect(getAgentTurnBody).toHaveBeenCalledWith(
-        'cli-abc',
+        'sess-1',
         'turn-2',
         expect.objectContaining({ signal: expect.any(AbortSignal), revision: 2 }),
       )

--- a/test/unit/client/components/terminal-view-utils.test.ts
+++ b/test/unit/client/components/terminal-view-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { TerminalPaneContent } from '@/store/paneTypes'
-import { getResumeSessionIdFromRef } from '@/components/terminal-view-utils'
+import { getCreateSessionStateFromRef, getResumeSessionIdFromRef } from '@/components/terminal-view-utils'
 
 describe('terminal-view-utils', () => {
   it('reads the latest resumeSessionId from the ref', () => {
@@ -24,5 +24,34 @@ describe('terminal-view-utils', () => {
     }
 
     expect(getResumeSessionIdFromRef(ref)).toBe('new-session')
+  })
+
+  it('returns explicit live terminal handles separately from the durable sessionRef', () => {
+    const ref: { current: TerminalPaneContent | null } = {
+      current: {
+        kind: 'terminal',
+        createRequestId: 'req-2',
+        status: 'running',
+        mode: 'codex',
+        shell: 'system',
+        terminalId: 'term-live-1',
+        serverInstanceId: 'srv-local',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: 'codex-session-1',
+        },
+      },
+    }
+
+    expect(getCreateSessionStateFromRef(ref)).toEqual({
+      sessionRef: {
+        provider: 'codex',
+        sessionId: 'codex-session-1',
+      },
+      liveTerminal: {
+        terminalId: 'term-live-1',
+        serverInstanceId: 'srv-local',
+      },
+    })
   })
 })

--- a/test/unit/client/layout-mirror-middleware.test.ts
+++ b/test/unit/client/layout-mirror-middleware.test.ts
@@ -26,7 +26,7 @@ describe('layoutMirrorMiddleware', () => {
     vi.useRealTimers()
   })
 
-  it('includes fallbackSessionRef for no-layout local session tabs', () => {
+  it('includes fallbackSessionRef for no-layout local session tabs from canonical sessionRef', () => {
     mockSend.mockClear()
     vi.useFakeTimers()
     const store = configureStore({
@@ -38,8 +38,11 @@ describe('layoutMirrorMiddleware', () => {
       id: 'tab-1',
       title: 'alpha',
       mode: 'codex',
-      resumeSessionId: 'older-open',
-    }))
+      sessionRef: {
+        provider: 'codex',
+        sessionId: 'older-open',
+      },
+    } as any))
 
     vi.runOnlyPendingTimers()
 

--- a/test/unit/client/lib/pane-activity.test.ts
+++ b/test/unit/client/lib/pane-activity.test.ts
@@ -301,7 +301,10 @@ describe('pane activity', () => {
           shell: 'system',
           createdAt: 1,
           terminalId: 'term-live',
-          resumeSessionId: sessionId,
+          sessionRef: {
+            provider: 'opencode',
+            sessionId,
+          },
         },
       ],
       paneLayouts: {
@@ -315,7 +318,10 @@ describe('pane activity', () => {
             mode: 'opencode',
             shell: 'system',
             terminalId: 'term-live',
-            resumeSessionId: sessionId,
+            sessionRef: {
+              provider: 'opencode',
+              sessionId,
+            },
           },
         },
       },
@@ -333,5 +339,49 @@ describe('pane activity', () => {
     })
 
     expect(busySessionKeys).toEqual([`opencode:${sessionId}`])
+  })
+
+  it('does not synthesize OpenCode busy session keys from a tab title when no canonical identity exists', () => {
+    const busySessionKeys = collectBusySessionKeys({
+      tabs: [
+        {
+          id: 'tab-opencode-title',
+          title: 'probe-title-two',
+          createRequestId: 'req-opencode-title',
+          status: 'running',
+          mode: 'opencode',
+          shell: 'system',
+          createdAt: 1,
+          terminalId: 'term-live',
+        },
+      ],
+      paneLayouts: {
+        'tab-opencode-title': {
+          type: 'leaf',
+          id: 'pane-opencode-title',
+          content: {
+            kind: 'terminal',
+            createRequestId: 'req-opencode-title',
+            status: 'running',
+            mode: 'opencode',
+            shell: 'system',
+            terminalId: 'term-live',
+          },
+        },
+      },
+      codexActivityByTerminalId: {},
+      opencodeActivityByTerminalId: {
+        'term-live': {
+          terminalId: 'term-live',
+          sessionId: '33333333-3333-4333-8333-333333333333',
+          phase: 'busy',
+          updatedAt: 1,
+        },
+      },
+      paneRuntimeActivityByPaneId: {},
+      agentChatSessions: {},
+    })
+
+    expect(busySessionKeys).toEqual([])
   })
 })

--- a/test/unit/client/lib/session-contract.test.ts
+++ b/test/unit/client/lib/session-contract.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  dedupeSessionRefs,
+  sanitizeSessionRef,
+} from '@shared/session-contract'
+
+describe('client session-contract helpers', () => {
+  it('sanitizes sidebar/bootstrap session refs down to canonical durable identity', () => {
+    expect(sanitizeSessionRef({
+      provider: 'opencode',
+      sessionId: 'opencode-session-1',
+      serverInstanceId: 'srv-remote',
+    })).toEqual({
+      provider: 'opencode',
+      sessionId: 'opencode-session-1',
+    })
+  })
+
+  it('dedupes canonical session refs even when inputs disagree only by locality', () => {
+    expect(dedupeSessionRefs([
+      {
+        provider: 'codex',
+        sessionId: 'codex-session-1',
+      },
+      {
+        provider: 'codex',
+        sessionId: 'codex-session-1',
+        serverInstanceId: 'srv-remote',
+      } as any,
+      {
+        provider: 'claude',
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      },
+    ])).toEqual([
+      {
+        provider: 'codex',
+        sessionId: 'codex-session-1',
+      },
+      {
+        provider: 'claude',
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      },
+    ])
+  })
+})

--- a/test/unit/client/lib/session-type-utils.test.ts
+++ b/test/unit/client/lib/session-type-utils.test.ts
@@ -43,7 +43,11 @@ describe('buildResumeContent', () => {
     expect(content.kind).toBe('agent-chat')
     if (content.kind !== 'agent-chat') throw new Error('expected agent-chat')
     expect(content.provider).toBe('freshclaude')
-    expect(content.resumeSessionId).toBe('abc-123')
+    expect(content.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: 'abc-123',
+    })
+    expect(content.resumeSessionId).toBeUndefined()
     expect(content.initialCwd).toBe('/home/user/project')
     expect(content.model).toBe('claude-opus-4-6') // default from provider config
     expect(content.permissionMode).toBe('bypassPermissions') // default from provider config
@@ -57,7 +61,11 @@ describe('buildResumeContent', () => {
     expect(content.kind).toBe('agent-chat')
     if (content.kind !== 'agent-chat') throw new Error('expected agent-chat')
     expect(content.provider).toBe('kilroy')
-    expect(content.resumeSessionId).toBe('xyz-789')
+    expect(content.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: 'xyz-789',
+    })
+    expect(content.resumeSessionId).toBeUndefined()
   })
 
   it('returns terminal content for claude sessionType', () => {
@@ -69,7 +77,11 @@ describe('buildResumeContent', () => {
     expect(content.kind).toBe('terminal')
     if (content.kind !== 'terminal') throw new Error('expected terminal')
     expect(content.mode).toBe('claude')
-    expect(content.resumeSessionId).toBe('abc-123')
+    expect(content.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: 'abc-123',
+    })
+    expect(content.resumeSessionId).toBeUndefined()
     expect(content.initialCwd).toBe('/home/user/project')
   })
 
@@ -81,7 +93,11 @@ describe('buildResumeContent', () => {
     expect(content.kind).toBe('terminal')
     if (content.kind !== 'terminal') throw new Error('expected terminal')
     expect(content.mode).toBe('codex')
-    expect(content.resumeSessionId).toBe('def-456')
+    expect(content.sessionRef).toEqual({
+      provider: 'codex',
+      sessionId: 'def-456',
+    })
+    expect(content.resumeSessionId).toBeUndefined()
   })
 
   it('defaults to claude terminal for undefined sessionType', () => {
@@ -103,7 +119,11 @@ describe('buildResumeContent', () => {
     if (content.kind !== 'terminal') throw new Error('expected terminal')
     expect(content.terminalId).toBeUndefined()
     expect(content.mode).toBe('claude')
-    expect(content.resumeSessionId).toBe('abc-123')
+    expect(content.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: 'abc-123',
+    })
+    expect(content.resumeSessionId).toBeUndefined()
   })
 
   it('agent-chat panes have no terminalId', () => {

--- a/test/unit/client/lib/session-utils.test.ts
+++ b/test/unit/client/lib/session-utils.test.ts
@@ -1,85 +1,70 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
-  getSessionsForHello,
-  findTabIdForSession,
-  findPaneForSession,
   collectSessionLocatorsFromTabs,
   collectSessionRefsFromNode,
   collectSessionRefsFromTabs,
+  findPaneForSession,
+  findTabIdForSession,
   getActiveSessionRefForTab,
+  getSessionsForHello,
 } from '@/lib/session-utils'
-import type { RootState } from '@/store/store'
 import type {
-  PaneNode,
-  TerminalPaneContent,
   AgentChatPaneContent,
   PaneContent,
+  PaneNode,
   SessionLocator,
+  TerminalPaneContent,
 } from '@/store/paneTypes'
+import type { RootState } from '@/store/store'
 
 const VALID_SESSION_ID = '550e8400-e29b-41d4-a716-446655440000'
 const OTHER_SESSION_ID = '6f1c2b3a-4d5e-6f70-8a9b-0c1d2e3f4a5b'
 
 function terminalContent(
   mode: TerminalPaneContent['mode'],
-  resumeSessionId: string,
-  sessionRef?: SessionLocator
+  options: {
+    resumeSessionId?: string
+    sessionRef?: SessionLocator
+    serverInstanceId?: string
+    terminalId?: string
+  } = {},
 ): TerminalPaneContent {
+  const identity = options.sessionRef?.sessionId ?? options.resumeSessionId ?? 'fresh'
   return {
     kind: 'terminal',
     mode,
     status: 'running',
-    createRequestId: `req-${resumeSessionId}`,
-    resumeSessionId,
-    ...(sessionRef ? { sessionRef } : {}),
+    createRequestId: `req-${identity}`,
+    ...(options.terminalId ? { terminalId: options.terminalId } : {}),
+    ...(options.resumeSessionId ? { resumeSessionId: options.resumeSessionId } : {}),
+    ...(options.sessionRef ? { sessionRef: options.sessionRef } : {}),
+    ...(options.serverInstanceId ? { serverInstanceId: options.serverInstanceId } : {}),
   }
 }
 
 function agentChatContent(
-  resumeSessionId?: string,
-  sessionRef?: SessionLocator
+  options: {
+    resumeSessionId?: string
+    sessionRef?: SessionLocator
+  } = {},
 ): AgentChatPaneContent {
+  const identity = options.sessionRef?.sessionId ?? options.resumeSessionId ?? 'fresh'
   return {
-    kind: 'agent-chat', provider: 'freshclaude',
+    kind: 'agent-chat',
+    provider: 'freshclaude',
     status: 'idle',
-    createRequestId: `req-chat-${resumeSessionId}`,
-    resumeSessionId,
-    ...(sessionRef ? { sessionRef } : {}),
+    createRequestId: `req-chat-${identity}`,
+    ...(options.resumeSessionId ? { resumeSessionId: options.resumeSessionId } : {}),
+    ...(options.sessionRef ? { sessionRef: options.sessionRef } : {}),
   }
 }
 
 function leaf(id: string, content: PaneContent): PaneNode {
-  return {
-    type: 'leaf',
-    id,
-    content,
-  }
+  return { type: 'leaf', id, content }
 }
 
 describe('getSessionsForHello', () => {
-  it('filters non-claude sessions from active/visible/background', () => {
-    const layoutActive: PaneNode = {
-      type: 'split',
-      id: 'split-1',
-      direction: 'horizontal',
-      sizes: [50, 50],
-      children: [
-        leaf('pane-codex', terminalContent('codex', 'codex-active')),
-        leaf('pane-claude', terminalContent('claude', VALID_SESSION_ID)),
-      ],
-    }
-
-    const layoutBackground: PaneNode = {
-      type: 'split',
-      id: 'split-2',
-      direction: 'vertical',
-      sizes: [50, 50],
-      children: [
-        leaf('pane-claude-bg', terminalContent('claude', OTHER_SESSION_ID)),
-        leaf('pane-codex-bg', terminalContent('codex', 'codex-bg')),
-      ],
-    }
-
+  it('reports only canonical Claude identities from active, visible, and background tabs', () => {
     const state = {
       tabs: {
         activeTabId: 'tab-1',
@@ -87,34 +72,34 @@ describe('getSessionsForHello', () => {
       },
       panes: {
         layouts: {
-          'tab-1': layoutActive,
-          'tab-2': layoutBackground,
+          'tab-1': {
+            type: 'split',
+            id: 'split-1',
+            direction: 'horizontal',
+            sizes: [50, 50],
+            children: [
+              leaf('pane-claude-active', terminalContent('claude', { resumeSessionId: VALID_SESSION_ID })),
+              leaf('pane-codex-visible', terminalContent('codex', {
+                sessionRef: { provider: 'codex', sessionId: 'codex-session-1' },
+              })),
+            ],
+          },
+          'tab-2': leaf('pane-claude-background', agentChatContent({ resumeSessionId: OTHER_SESSION_ID })),
         },
         activePane: {
-          'tab-1': 'pane-codex',
+          'tab-1': 'pane-claude-active',
         },
       },
     } as unknown as RootState
 
-    const result = getSessionsForHello(state)
-
-    expect(result.active).toBeUndefined()
-    expect(result.visible).toEqual([VALID_SESSION_ID])
-    expect(result.background).toEqual([OTHER_SESSION_ID])
+    expect(getSessionsForHello(state)).toEqual({
+      active: VALID_SESSION_ID,
+      visible: [],
+      background: [OTHER_SESSION_ID],
+    })
   })
 
-  it('captures active claude session when active pane is claude', () => {
-    const layoutActive: PaneNode = {
-      type: 'split',
-      id: 'split-1',
-      direction: 'horizontal',
-      sizes: [50, 50],
-      children: [
-        leaf('pane-claude', terminalContent('claude', VALID_SESSION_ID)),
-        leaf('pane-codex', terminalContent('codex', 'codex-visible')),
-      ],
-    }
-
+  it('ignores non-canonical Claude resume strings when building hello session state', () => {
     const state = {
       tabs: {
         activeTabId: 'tab-1',
@@ -122,7 +107,7 @@ describe('getSessionsForHello', () => {
       },
       panes: {
         layouts: {
-          'tab-1': layoutActive,
+          'tab-1': leaf('pane-claude', terminalContent('claude', { resumeSessionId: 'named-resume' })),
         },
         activePane: {
           'tab-1': 'pane-claude',
@@ -130,565 +115,70 @@ describe('getSessionsForHello', () => {
       },
     } as unknown as RootState
 
-    const result = getSessionsForHello(state)
-
-    expect(result.active).toBe(VALID_SESSION_ID)
-    expect(result.visible).toEqual([])
-    expect(result.background).toBeUndefined()
-  })
-
-  it('includes non-UUID Claude session IDs in hello (named resume)', () => {
-    const layoutActive: PaneNode = {
-      type: 'leaf',
-      id: 'pane-claude',
-      content: terminalContent('claude', 'not-a-uuid'),
-    }
-
-    const state = {
-      tabs: {
-        activeTabId: 'tab-1',
-        tabs: [{ id: 'tab-1' }],
-      },
-      panes: {
-        layouts: {
-          'tab-1': layoutActive,
-        },
-        activePane: {
-          'tab-1': 'pane-claude',
-        },
-      },
-    } as unknown as RootState
-
-    const result = getSessionsForHello(state)
-
-    // Non-UUID Claude session IDs are now valid (named resume support)
-    expect(result.active).toBe('not-a-uuid')
-    expect(result.visible).toEqual([])
-    expect(result.background).toBeUndefined()
+    expect(getSessionsForHello(state)).toEqual({
+      visible: [],
+    })
   })
 })
 
 describe('collectSessionLocatorsFromTabs', () => {
-  it('preserves exact local and foreign locators, intrinsic local fallbacks, and tab-level fallbacks', () => {
+  it('keeps canonical sessionRef values and UUID-backed Claude fallbacks, dropping locality and invalid legacy values', () => {
     const tabs = [
-      { id: 'tab-local' },
-      { id: 'tab-local-duplicate' },
-      { id: 'tab-remote' },
-      { id: 'tab-chat' },
-      { id: 'tab-no-layout', mode: 'codex', resumeSessionId: 'tab-only' },
+      { id: 'tab-explicit' },
+      { id: 'tab-claude-fallback', mode: 'claude', resumeSessionId: VALID_SESSION_ID },
       { id: 'tab-invalid-claude' },
+      { id: 'tab-invalid-codex', mode: 'codex', resumeSessionId: 'codex-session-legacy' },
     ] as RootState['tabs']['tabs']
 
     const panes = {
       layouts: {
-        'tab-local': leaf('pane-local', terminalContent('codex', 'shared', {
-          provider: 'codex',
-          sessionId: 'shared',
-          serverInstanceId: 'srv-local',
-        })),
-        'tab-local-duplicate': leaf('pane-local-duplicate', terminalContent('codex', 'shared', {
-          provider: 'codex',
-          sessionId: 'shared',
-          serverInstanceId: 'srv-local',
-        })),
-        'tab-remote': leaf('pane-remote', {
-          kind: 'terminal',
-          mode: 'codex',
-          status: 'running',
-          createRequestId: 'req-remote',
+        'tab-explicit': leaf('pane-explicit', terminalContent('codex', {
           sessionRef: {
             provider: 'codex',
-            sessionId: 'shared',
-            serverInstanceId: 'srv-remote',
+            sessionId: 'codex-session-1',
           },
-        }),
-        'tab-chat': leaf('pane-chat', agentChatContent(VALID_SESSION_ID, {
-          provider: 'claude',
-          sessionId: VALID_SESSION_ID,
           serverInstanceId: 'srv-local',
         })),
-        'tab-invalid-claude': leaf('pane-invalid-claude', terminalContent('claude', 'not-a-uuid')),
+        'tab-invalid-claude': leaf('pane-invalid-claude', terminalContent('claude', { resumeSessionId: 'named-resume' })),
       },
       activePane: {},
     } as RootState['panes']
 
     expect(collectSessionLocatorsFromTabs(tabs, panes)).toEqual([
-      { provider: 'codex', sessionId: 'shared', serverInstanceId: 'srv-local' },
-      { provider: 'codex', sessionId: 'shared' },
-      { provider: 'codex', sessionId: 'shared', serverInstanceId: 'srv-remote' },
-      { provider: 'claude', sessionId: VALID_SESSION_ID, serverInstanceId: 'srv-local' },
+      { provider: 'codex', sessionId: 'codex-session-1' },
       { provider: 'claude', sessionId: VALID_SESSION_ID },
-      { provider: 'codex', sessionId: 'tab-only' },
-      { provider: 'claude', sessionId: 'not-a-uuid' },
     ])
 
     expect(collectSessionRefsFromTabs(tabs, panes)).toEqual([
-      { provider: 'codex', sessionId: 'shared' },
+      { provider: 'codex', sessionId: 'codex-session-1' },
       { provider: 'claude', sessionId: VALID_SESSION_ID },
-      { provider: 'codex', sessionId: 'tab-only' },
-      { provider: 'claude', sessionId: 'not-a-uuid' },
-    ])
-  })
-
-  it('drops invalid providers and empty locator fields from persisted pane and tab state', () => {
-    const tabs = [
-      { id: 'tab-invalid-explicit' },
-      { id: 'tab-empty-server' },
-      // 'shell' is not a valid session provider (only non-shell modes are valid)
-      { id: 'tab-invalid-provider-fallback', mode: 'codex', codingCliProvider: 'shell', resumeSessionId: 'bad-provider' },
-      { id: 'tab-empty-session-fallback', mode: 'codex', resumeSessionId: '' },
-      { id: 'tab-valid-fallback', mode: 'codex', resumeSessionId: 'tab-valid' },
-    ] as unknown as RootState['tabs']['tabs']
-
-    const panes = {
-      layouts: {
-        'tab-invalid-explicit': leaf('pane-invalid-explicit', terminalContent('codex', 'resume-valid', {
-          provider: 'shell',
-          sessionId: '',
-          serverInstanceId: '',
-        } as unknown as SessionLocator)),
-        'tab-empty-server': leaf('pane-empty-server', {
-          kind: 'terminal',
-          mode: 'codex',
-          status: 'running',
-          createRequestId: 'req-empty-server',
-          sessionRef: {
-            provider: 'codex',
-            sessionId: 'explicit-valid',
-            serverInstanceId: '',
-          } as unknown as SessionLocator,
-        }),
-      },
-      activePane: {},
-    } as RootState['panes']
-
-    expect(collectSessionLocatorsFromTabs(tabs, panes)).toEqual([
-      { provider: 'codex', sessionId: 'resume-valid' },
-      { provider: 'codex', sessionId: 'explicit-valid' },
-      { provider: 'codex', sessionId: 'tab-valid' },
-    ])
-
-    expect(collectSessionRefsFromTabs(tabs, panes)).toEqual([
-      { provider: 'codex', sessionId: 'resume-valid' },
-      { provider: 'codex', sessionId: 'explicit-valid' },
-      { provider: 'codex', sessionId: 'tab-valid' },
     ])
   })
 })
 
-describe('findTabIdForSession', () => {
-  it('prefers a local match over a foreign copied tab for local session targets', () => {
-    const state = {
-      tabs: {
-        activeTabId: 'tab-remote',
-        tabs: [{ id: 'tab-remote' }, { id: 'tab-local' }],
-      },
-      panes: {
-        layouts: {
-          'tab-remote': leaf('pane-remote', {
-            kind: 'terminal',
-            mode: 'codex',
-            status: 'running',
-            createRequestId: 'req-remote',
-            sessionRef: {
-              provider: 'codex',
-              sessionId: 'shared',
-              serverInstanceId: 'srv-remote',
-            },
-          }),
-          'tab-local': leaf('pane-local', terminalContent('codex', 'shared', {
-            provider: 'codex',
-            sessionId: 'shared',
-            serverInstanceId: 'srv-local',
-          })),
-        },
-        activePane: {},
-      },
-    } as unknown as RootState
-
-    expect(findTabIdForSession(
-      state,
-      { provider: 'codex', sessionId: 'shared' },
-      'srv-local'
-    )).toBe('tab-local')
-  })
-
-  it('ignores a foreign copied tab when it is the only match for a local target', () => {
-    const state = {
-      tabs: {
-        activeTabId: 'tab-remote',
-        tabs: [{ id: 'tab-remote' }],
-      },
-      panes: {
-        layouts: {
-          'tab-remote': leaf('pane-remote', {
-            kind: 'terminal',
-            mode: 'codex',
-            status: 'running',
-            createRequestId: 'req-remote',
-            sessionRef: {
-              provider: 'codex',
-              sessionId: 'shared',
-              serverInstanceId: 'srv-remote',
-            },
-          }),
-        },
-        activePane: {},
-      },
-    } as unknown as RootState
-
-    expect(findTabIdForSession(
-      state,
-      { provider: 'codex', sessionId: 'shared' },
-      'srv-local'
-    )).toBeUndefined()
-  })
-
-  it('still finds layout-backed local sessions before websocket ready via the intrinsic fallback locator', () => {
-    const state = {
-      tabs: {
-        activeTabId: 'tab-remote',
-        tabs: [{ id: 'tab-remote' }, { id: 'tab-local' }],
-      },
-      panes: {
-        layouts: {
-          'tab-remote': leaf('pane-remote', {
-            kind: 'terminal',
-            mode: 'codex',
-            status: 'running',
-            createRequestId: 'req-remote',
-            sessionRef: {
-              provider: 'codex',
-              sessionId: 'shared',
-              serverInstanceId: 'srv-remote',
-            },
-          }),
-          'tab-local': leaf('pane-local', terminalContent('codex', 'shared', {
-            provider: 'codex',
-            sessionId: 'shared',
-            serverInstanceId: 'srv-local',
-          })),
-        },
-        activePane: {},
-      },
-    } as unknown as RootState
-
-    expect(findTabIdForSession(
-      state,
-      { provider: 'codex', sessionId: 'shared' },
-      undefined
-    )).toBe('tab-local')
-  })
-
-  it('still finds tab-level local fallbacks before websocket ready', () => {
-    const state = {
-      tabs: {
-        activeTabId: 'tab-remote',
-        tabs: [
-          { id: 'tab-remote' },
-          { id: 'tab-local-fallback', mode: 'codex', resumeSessionId: 'shared' },
-        ],
-      },
-      panes: {
-        layouts: {
-          'tab-remote': leaf('pane-remote', {
-            kind: 'terminal',
-            mode: 'codex',
-            status: 'running',
-            createRequestId: 'req-remote',
-            sessionRef: {
-              provider: 'codex',
-              sessionId: 'shared',
-              serverInstanceId: 'srv-remote',
-            },
-          }),
-        },
-        activePane: {},
-      },
-    } as unknown as RootState
-
-    expect(findTabIdForSession(
-      state,
-      { provider: 'codex', sessionId: 'shared' },
-      undefined
-    )).toBe('tab-local-fallback')
-  })
-
-  it('falls back to tab resumeSessionId when layout is missing', () => {
-    const state = {
-      tabs: {
-        activeTabId: 'tab-1',
-        tabs: [{ id: 'tab-1', mode: 'claude', resumeSessionId: VALID_SESSION_ID }],
-      },
-      panes: {
-        layouts: {},
-        activePane: {},
-      },
-    } as unknown as RootState
-
-    expect(findTabIdForSession(
-      state,
-      { provider: 'claude', sessionId: VALID_SESSION_ID },
-      undefined
-    )).toBe('tab-1')
-  })
-})
-
-describe('findPaneForSession', () => {
-  it('can still resolve an explicit foreign target when that is what the caller asked for', () => {
-    const state = {
-      tabs: {
-        activeTabId: 'tab-local',
-        tabs: [{ id: 'tab-local' }, { id: 'tab-remote' }],
-      },
-      panes: {
-        layouts: {
-          'tab-local': leaf('pane-local', terminalContent('codex', 'shared', {
-            provider: 'codex',
-            sessionId: 'shared',
-            serverInstanceId: 'srv-local',
-          })),
-          'tab-remote': leaf('pane-remote', {
-            kind: 'terminal',
-            mode: 'codex',
-            status: 'running',
-            createRequestId: 'req-remote',
-            sessionRef: {
-              provider: 'codex',
-              sessionId: 'shared',
-              serverInstanceId: 'srv-remote',
-            },
-          }),
-        },
-        activePane: {},
-      },
-    } as unknown as RootState
-
-    expect(findPaneForSession(
-      state,
-      { provider: 'codex', sessionId: 'shared', serverInstanceId: 'srv-remote' },
-      'srv-local',
-    )).toEqual({
-      tabId: 'tab-remote',
-      paneId: 'pane-remote',
-    })
-  })
-
-  it('returns tabId and paneId when session is in a leaf', () => {
-    const state = {
-      tabs: {
-        activeTabId: 'tab-1',
-        tabs: [{ id: 'tab-1' }],
-      },
-      panes: {
-        layouts: {
-          'tab-1': leaf('pane-a', terminalContent('claude', VALID_SESSION_ID)),
-        },
-        activePane: { 'tab-1': 'pane-a' },
-      },
-    } as unknown as RootState
-
-    expect(findPaneForSession(
-      state,
-      { provider: 'claude', sessionId: VALID_SESSION_ID },
-      undefined
-    )).toEqual({
-      tabId: 'tab-1',
-      paneId: 'pane-a',
-    })
-  })
-
-  it('finds session in a nested split', () => {
-    const layout: PaneNode = {
-      type: 'split',
-      id: 'split-1',
-      direction: 'horizontal',
-      sizes: [50, 50],
-      children: [
-        leaf('pane-a', terminalContent('shell' as TerminalPaneContent['mode'], '')),
-        leaf('pane-b', terminalContent('claude', VALID_SESSION_ID)),
-      ],
-    }
-
-    const state = {
-      tabs: {
-        activeTabId: 'tab-1',
-        tabs: [{ id: 'tab-1' }],
-      },
-      panes: {
-        layouts: { 'tab-1': layout },
-        activePane: { 'tab-1': 'pane-a' },
-      },
-    } as unknown as RootState
-
-    expect(findPaneForSession(
-      state,
-      { provider: 'claude', sessionId: VALID_SESSION_ID },
-      undefined
-    )).toEqual({
-      tabId: 'tab-1',
-      paneId: 'pane-b',
-    })
-  })
-
-  it('finds session in a background tab', () => {
-    const state = {
-      tabs: {
-        activeTabId: 'tab-1',
-        tabs: [{ id: 'tab-1' }, { id: 'tab-2' }],
-      },
-      panes: {
-        layouts: {
-          'tab-1': leaf('pane-a', terminalContent('shell' as TerminalPaneContent['mode'], '')),
-          'tab-2': leaf('pane-b', terminalContent('codex', OTHER_SESSION_ID)),
-        },
-        activePane: { 'tab-1': 'pane-a', 'tab-2': 'pane-b' },
-      },
-    } as unknown as RootState
-
-    expect(findPaneForSession(
-      state,
-      { provider: 'codex', sessionId: OTHER_SESSION_ID },
-      undefined
-    )).toEqual({
-      tabId: 'tab-2',
-      paneId: 'pane-b',
-    })
-  })
-
-  it('returns undefined when session is not open', () => {
-    const state = {
-      tabs: {
-        activeTabId: 'tab-1',
-        tabs: [{ id: 'tab-1' }],
-      },
-      panes: {
-        layouts: {
-          'tab-1': leaf('pane-a', terminalContent('shell' as TerminalPaneContent['mode'], '')),
-        },
-        activePane: { 'tab-1': 'pane-a' },
-      },
-    } as unknown as RootState
-
-    expect(findPaneForSession(
-      state,
-      { provider: 'claude', sessionId: VALID_SESSION_ID },
-      undefined
-    )).toBeUndefined()
-  })
-
-  it('returns undefined for tabs without layouts', () => {
-    const state = {
-      tabs: {
-        activeTabId: 'tab-1',
-        tabs: [{ id: 'tab-1' }],
-      },
-      panes: {
-        layouts: {},
-        activePane: {},
-      },
-    } as unknown as RootState
-
-    expect(findPaneForSession(
-      state,
-      { provider: 'claude', sessionId: VALID_SESSION_ID },
-      undefined
-    )).toBeUndefined()
-  })
-
-  it('falls back to tab-level match when tab has resumeSessionId but no layout', () => {
-    const state = {
-      tabs: {
-        activeTabId: 'tab-1',
-        tabs: [{ id: 'tab-1', mode: 'claude', resumeSessionId: VALID_SESSION_ID }],
-      },
-      panes: {
-        layouts: {},
-        activePane: {},
-      },
-    } as unknown as RootState
-
-    // Returns tabId but no paneId since there's no pane tree yet
-    expect(findPaneForSession(
-      state,
-      { provider: 'claude', sessionId: VALID_SESSION_ID },
-      undefined
-    )).toEqual({
-      tabId: 'tab-1',
-      paneId: undefined,
-    })
-  })
-})
-
-// === agent-chat pane support ===
-
-describe('collectSessionRefsFromNode — agent-chat panes', () => {
-  it('prefers explicit sessionRef over legacy resumeSessionId', () => {
-    const node = leaf('p1', {
-      kind: 'terminal',
-      mode: 'shell',
-      status: 'running',
-      createRequestId: 'req-explicit',
+describe('collectSessionRefsFromNode', () => {
+  it('prefers explicit sessionRef over legacy terminal resumeSessionId', () => {
+    const node = leaf('pane-1', terminalContent('shell', {
       resumeSessionId: 'legacy-shell-resume',
       sessionRef: {
         provider: 'codex',
         sessionId: 'codex-explicit-session',
       },
-    })
+    }))
+
     expect(collectSessionRefsFromNode(node)).toEqual([
       { provider: 'codex', sessionId: 'codex-explicit-session' },
     ])
   })
 
-  it('extracts session ref from an agent-chat pane', () => {
-    const node = leaf('p1', agentChatContent(VALID_SESSION_ID))
-    expect(collectSessionRefsFromNode(node)).toEqual([
-      { provider: 'claude', sessionId: VALID_SESSION_ID },
-    ])
-  })
-
-  it('returns empty for an agent-chat pane without resumeSessionId', () => {
-    const node = leaf('p1', agentChatContent(undefined))
+  it('returns empty for agent-chat panes with non-canonical Claude resume strings', () => {
+    const node = leaf('pane-chat', agentChatContent({ resumeSessionId: 'named-resume' }))
     expect(collectSessionRefsFromNode(node)).toEqual([])
-  })
-
-  it('returns empty for an agent-chat pane with invalid session ID', () => {
-    const node = leaf('p1', agentChatContent('not-a-uuid'))
-    expect(collectSessionRefsFromNode(node)).toEqual([])
-  })
-
-  it('returns session ref for a Claude terminal pane with non-UUID resume name', () => {
-    const node = leaf('p1', terminalContent('claude', '137 tour'))
-    expect(collectSessionRefsFromNode(node)).toEqual([
-      { provider: 'claude', sessionId: '137 tour' },
-    ])
-  })
-
-  it('does not include agent-chat panes with non-UUID session IDs in session refs (invariant)', () => {
-    const node = leaf('p1', agentChatContent('not-a-uuid'))
-    expect(collectSessionRefsFromNode(node)).toEqual([])
-  })
-
-  it('collects from split with terminal and agent-chat children', () => {
-    const node: PaneNode = {
-      type: 'split',
-      id: 'split-1',
-      direction: 'horizontal',
-      sizes: [50, 50],
-      children: [
-        leaf('p1', terminalContent('claude', VALID_SESSION_ID)),
-        leaf('p2', agentChatContent(OTHER_SESSION_ID)),
-      ],
-    }
-    expect(collectSessionRefsFromNode(node)).toEqual([
-      { provider: 'claude', sessionId: VALID_SESSION_ID },
-      { provider: 'claude', sessionId: OTHER_SESSION_ID },
-    ])
   })
 })
 
-describe('findPaneForSession — agent-chat panes', () => {
-  it('finds an agent-chat pane by session ID', () => {
+describe('getActiveSessionRefForTab', () => {
+  it('returns the active pane canonical session ref', () => {
     const state = {
       tabs: {
         activeTabId: 'tab-1',
@@ -696,81 +186,117 @@ describe('findPaneForSession — agent-chat panes', () => {
       },
       panes: {
         layouts: {
-          'tab-1': leaf('pane-chat', agentChatContent(VALID_SESSION_ID)),
+          'tab-1': {
+            type: 'split',
+            id: 'split-1',
+            direction: 'horizontal',
+            sizes: [50, 50],
+            children: [
+              leaf('pane-shell', terminalContent('shell')),
+              leaf('pane-codex', terminalContent('codex', {
+                sessionRef: { provider: 'codex', sessionId: 'codex-active' },
+              })),
+            ],
+          },
         },
-        activePane: { 'tab-1': 'pane-chat' },
+        activePane: { 'tab-1': 'pane-codex' },
       },
     } as unknown as RootState
 
-    expect(findPaneForSession(
-      state,
-      { provider: 'claude', sessionId: VALID_SESSION_ID },
-      undefined
-    )).toEqual({
-      tabId: 'tab-1',
-      paneId: 'pane-chat',
-    })
-  })
-
-  it('finds agent-chat pane in a split alongside a terminal pane', () => {
-    const layout: PaneNode = {
-      type: 'split',
-      id: 'split-1',
-      direction: 'horizontal',
-      sizes: [50, 50],
-      children: [
-        leaf('pane-term', terminalContent('shell' as TerminalPaneContent['mode'], '')),
-        leaf('pane-chat', agentChatContent(VALID_SESSION_ID)),
-      ],
-    }
-
-    const state = {
-      tabs: {
-        activeTabId: 'tab-1',
-        tabs: [{ id: 'tab-1' }],
-      },
-      panes: {
-        layouts: { 'tab-1': layout },
-        activePane: { 'tab-1': 'pane-term' },
-      },
-    } as unknown as RootState
-
-    expect(findPaneForSession(
-      state,
-      { provider: 'claude', sessionId: VALID_SESSION_ID },
-      undefined
-    )).toEqual({
-      tabId: 'tab-1',
-      paneId: 'pane-chat',
+    expect(getActiveSessionRefForTab(state, 'tab-1')).toEqual({
+      provider: 'codex',
+      sessionId: 'codex-active',
     })
   })
 })
 
-describe('findTabIdForSession — agent-chat panes', () => {
-  it('finds tab containing an agent-chat pane with matching session', () => {
+describe('findTabIdForSession', () => {
+  it('matches explicit canonical sessionRef values without relying on locality', () => {
     const state = {
       tabs: {
-        activeTabId: 'tab-1',
-        tabs: [{ id: 'tab-1' }],
+        activeTabId: 'tab-remote',
+        tabs: [{ id: 'tab-remote' }, { id: 'tab-local' }],
       },
       panes: {
         layouts: {
-          'tab-1': leaf('pane-chat', agentChatContent(VALID_SESSION_ID)),
+          'tab-remote': leaf('pane-remote', terminalContent('codex', {
+            sessionRef: { provider: 'codex', sessionId: 'shared' },
+          })),
+          'tab-local': leaf('pane-local', terminalContent('codex', {
+            sessionRef: { provider: 'codex', sessionId: 'shared' },
+          })),
         },
         activePane: {},
       },
     } as unknown as RootState
 
-    expect(findTabIdForSession(
-      state,
-      { provider: 'claude', sessionId: VALID_SESSION_ID },
-      undefined
-    )).toBe('tab-1')
+    expect(findTabIdForSession(state, { provider: 'codex', sessionId: 'shared' }, 'srv-local')).toBe('tab-remote')
+  })
+
+  it('prefers a same-server explicit sessionRef over an explicitly foreign copy', () => {
+    const state = {
+      tabs: {
+        activeTabId: 'tab-remote',
+        tabs: [{ id: 'tab-remote' }, { id: 'tab-local' }],
+      },
+      panes: {
+        layouts: {
+          'tab-remote': leaf('pane-remote', terminalContent('codex', {
+            sessionRef: {
+              provider: 'codex',
+              sessionId: 'shared',
+            },
+            serverInstanceId: 'srv-remote',
+          })),
+          'tab-local': leaf('pane-local', terminalContent('codex', {
+            sessionRef: {
+              provider: 'codex',
+              sessionId: 'shared',
+            },
+            serverInstanceId: 'srv-local',
+            terminalId: 'term-local',
+          })),
+        },
+        activePane: {},
+      },
+    } as unknown as RootState
+
+    expect(findTabIdForSession(state, { provider: 'codex', sessionId: 'shared' }, 'srv-local')).toBe('tab-local')
+  })
+
+  it('falls back to tab-level canonical Claude resume ids when no layout exists', () => {
+    const state = {
+      tabs: {
+        activeTabId: 'tab-1',
+        tabs: [{ id: 'tab-1', mode: 'claude', resumeSessionId: VALID_SESSION_ID }],
+      },
+      panes: {
+        layouts: {},
+        activePane: {},
+      },
+    } as unknown as RootState
+
+    expect(findTabIdForSession(state, { provider: 'claude', sessionId: VALID_SESSION_ID })).toBe('tab-1')
+  })
+
+  it('does not match named Claude resumes without canonical sessionRef', () => {
+    const state = {
+      tabs: {
+        activeTabId: 'tab-1',
+        tabs: [{ id: 'tab-1', mode: 'claude', resumeSessionId: 'named-resume' }],
+      },
+      panes: {
+        layouts: {},
+        activePane: {},
+      },
+    } as unknown as RootState
+
+    expect(findTabIdForSession(state, { provider: 'claude', sessionId: 'named-resume' })).toBeUndefined()
   })
 })
 
-describe('getActiveSessionRefForTab — agent-chat panes', () => {
-  it('returns session ref when active pane is an agent-chat pane', () => {
+describe('findPaneForSession', () => {
+  it('finds a pane by explicit canonical sessionRef', () => {
     const state = {
       tabs: {
         activeTabId: 'tab-1',
@@ -778,21 +304,21 @@ describe('getActiveSessionRefForTab — agent-chat panes', () => {
       },
       panes: {
         layouts: {
-          'tab-1': leaf('pane-chat', agentChatContent(VALID_SESSION_ID)),
+          'tab-1': leaf('pane-codex', terminalContent('codex', {
+            sessionRef: { provider: 'codex', sessionId: 'codex-pane' },
+          })),
         },
-        activePane: { 'tab-1': 'pane-chat' },
+        activePane: { 'tab-1': 'pane-codex' },
       },
     } as unknown as RootState
 
-    expect(getActiveSessionRefForTab(state, 'tab-1')).toEqual({
-      provider: 'claude',
-      sessionId: VALID_SESSION_ID,
+    expect(findPaneForSession(state, { provider: 'codex', sessionId: 'codex-pane' })).toEqual({
+      tabId: 'tab-1',
+      paneId: 'pane-codex',
     })
   })
-})
 
-describe('getSessionsForHello — agent-chat panes', () => {
-  it('includes agent-chat pane session as active', () => {
+  it('does not match an explicitly foreign copied pane when a local server instance is known', () => {
     const state = {
       tabs: {
         activeTabId: 'tab-1',
@@ -800,60 +326,60 @@ describe('getSessionsForHello — agent-chat panes', () => {
       },
       panes: {
         layouts: {
-          'tab-1': leaf('pane-chat', agentChatContent(VALID_SESSION_ID)),
+          'tab-1': leaf('pane-codex', terminalContent('codex', {
+            sessionRef: {
+              provider: 'codex',
+              sessionId: 'codex-pane',
+            },
+            serverInstanceId: 'srv-remote',
+          })),
+        },
+        activePane: { 'tab-1': 'pane-codex' },
+      },
+    } as unknown as RootState
+
+    expect(findPaneForSession(
+      state,
+      { provider: 'codex', sessionId: 'codex-pane' },
+      'srv-local',
+    )).toBeUndefined()
+  })
+
+  it('finds an agent-chat pane by canonical Claude resume id', () => {
+    const state = {
+      tabs: {
+        activeTabId: 'tab-1',
+        tabs: [{ id: 'tab-1' }],
+      },
+      panes: {
+        layouts: {
+          'tab-1': leaf('pane-chat', agentChatContent({ resumeSessionId: VALID_SESSION_ID })),
         },
         activePane: { 'tab-1': 'pane-chat' },
       },
     } as unknown as RootState
 
-    const result = getSessionsForHello(state)
-    expect(result.active).toBe(VALID_SESSION_ID)
+    expect(findPaneForSession(state, { provider: 'claude', sessionId: VALID_SESSION_ID })).toEqual({
+      tabId: 'tab-1',
+      paneId: 'pane-chat',
+    })
   })
 
-  it('includes agent-chat session as visible when not active pane', () => {
-    const layout: PaneNode = {
-      type: 'split',
-      id: 'split-1',
-      direction: 'horizontal',
-      sizes: [50, 50],
-      children: [
-        leaf('pane-term', terminalContent('claude', VALID_SESSION_ID)),
-        leaf('pane-chat', agentChatContent(OTHER_SESSION_ID)),
-      ],
-    }
-
+  it('returns a tab-level fallback only for canonical Claude ids', () => {
     const state = {
       tabs: {
         activeTabId: 'tab-1',
-        tabs: [{ id: 'tab-1' }],
+        tabs: [{ id: 'tab-1', mode: 'claude', resumeSessionId: VALID_SESSION_ID }],
       },
       panes: {
-        layouts: { 'tab-1': layout },
-        activePane: { 'tab-1': 'pane-term' },
+        layouts: {},
+        activePane: {},
       },
     } as unknown as RootState
 
-    const result = getSessionsForHello(state)
-    expect(result.active).toBe(VALID_SESSION_ID)
-    expect(result.visible).toEqual([OTHER_SESSION_ID])
-  })
-
-  it('includes agent-chat session in background tabs', () => {
-    const state = {
-      tabs: {
-        activeTabId: 'tab-1',
-        tabs: [{ id: 'tab-1' }, { id: 'tab-2' }],
-      },
-      panes: {
-        layouts: {
-          'tab-1': leaf('pane-term', terminalContent('claude', VALID_SESSION_ID)),
-          'tab-2': leaf('pane-chat', agentChatContent(OTHER_SESSION_ID)),
-        },
-        activePane: { 'tab-1': 'pane-term' },
-      },
-    } as unknown as RootState
-
-    const result = getSessionsForHello(state)
-    expect(result.background).toEqual([OTHER_SESSION_ID])
+    expect(findPaneForSession(state, { provider: 'claude', sessionId: VALID_SESSION_ID })).toEqual({
+      tabId: 'tab-1',
+      paneId: undefined,
+    })
   })
 })

--- a/test/unit/client/lib/tab-registry-snapshot.test.ts
+++ b/test/unit/client/lib/tab-registry-snapshot.test.ts
@@ -37,6 +37,101 @@ describe('shouldKeepClosedTab', () => {
 })
 
 describe('collectPaneSnapshots', () => {
+  describe('terminal and agent-chat durable identity', () => {
+    it('preserves explicit terminal sessionRef and liveTerminal without raw resume mirrors', () => {
+      const node: PaneNode = {
+        type: 'leaf',
+        id: 'pane-terminal',
+        content: {
+          kind: 'terminal',
+          mode: 'codex',
+          shell: 'system',
+          status: 'running',
+          terminalId: 'term-codex-1',
+          createRequestId: 'req-terminal',
+          sessionRef: {
+            provider: 'codex',
+            sessionId: 'codex-session-1',
+          },
+        },
+      }
+
+      const snapshots = collectPaneSnapshots(node, 'server-local')
+
+      expect(snapshots).toEqual([{
+        paneId: 'pane-terminal',
+        kind: 'terminal',
+        title: undefined,
+        payload: {
+          mode: 'codex',
+          shell: 'system',
+          sessionRef: {
+            provider: 'codex',
+            sessionId: 'codex-session-1',
+          },
+          liveTerminal: {
+            terminalId: 'term-codex-1',
+            serverInstanceId: 'server-local',
+          },
+          initialCwd: undefined,
+        },
+      }])
+    })
+
+    it('does not serialize raw terminal resumeSessionId when no canonical sessionRef exists', () => {
+      const node: PaneNode = {
+        type: 'leaf',
+        id: 'pane-terminal-legacy',
+        content: {
+          kind: 'terminal',
+          mode: 'codex',
+          shell: 'system',
+          status: 'running',
+          createRequestId: 'req-terminal-legacy',
+          resumeSessionId: 'codex-session-legacy',
+        },
+      }
+
+      const snapshots = collectPaneSnapshots(node, 'server-local')
+
+      expect(snapshots[0]?.payload).toEqual({
+        mode: 'codex',
+        shell: 'system',
+        sessionRef: undefined,
+        liveTerminal: undefined,
+        initialCwd: undefined,
+      })
+    })
+
+    it('does not serialize raw agent-chat resumeSessionId when no canonical sessionRef exists', () => {
+      const node: PaneNode = {
+        type: 'leaf',
+        id: 'pane-chat-legacy',
+        content: {
+          kind: 'agent-chat',
+          provider: 'freshclaude',
+          status: 'idle',
+          createRequestId: 'req-chat-legacy',
+          resumeSessionId: 'named-resume',
+          model: 'claude-sonnet',
+        },
+      }
+
+      const snapshots = collectPaneSnapshots(node, 'server-local')
+
+      expect(snapshots[0]?.payload).toEqual({
+        provider: 'freshclaude',
+        sessionId: undefined,
+        sessionRef: undefined,
+        initialCwd: undefined,
+        model: 'claude-sonnet',
+        permissionMode: undefined,
+        effort: undefined,
+        plugins: undefined,
+      })
+    })
+  })
+
   describe('extension content', () => {
     it('serializes extension pane content with correct kind and payload', () => {
       const node: PaneNode = {

--- a/test/unit/client/store/atomicPersistence.test.ts
+++ b/test/unit/client/store/atomicPersistence.test.ts
@@ -87,7 +87,7 @@ describe('atomic persistence', () => {
       expect(v3Raw).not.toBeNull()
 
       const v3 = JSON.parse(v3Raw!)
-      expect(v3.version).toBe(3)
+      expect(v3.version).toBe(4)
       expect(v3.tabs.tabs).toHaveLength(1)
       expect(v3.panes.layouts).toHaveProperty('tab-1')
       expect(v3.tombstones).toHaveLength(1)

--- a/test/unit/client/store/crossTabSync.test.ts
+++ b/test/unit/client/store/crossTabSync.test.ts
@@ -956,7 +956,10 @@ describe('crossTabSync', () => {
     })
 
     const tab = store.getState().tabs.tabs.find((entry) => entry.id === 'tab-1')
-    expect(tab?.resumeSessionId).toBe(canonicalSessionId)
+    expect(tab?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: canonicalSessionId,
+    })
     expect(tab?.sessionMetadataByKey).toEqual(expect.objectContaining({
       [sessionMetadataKey('claude', canonicalSessionId)]: expect.objectContaining({
         sessionType: 'freshclaude',
@@ -1239,7 +1242,10 @@ describe('crossTabSync', () => {
 
     let tab = store.getState().tabs.tabs.find((entry) => entry.id === 'tab-1')
     expect(tab?.title).toBe('Local canonical title')
-    expect(tab?.resumeSessionId).toBe(canonicalSessionId)
+    expect(tab?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: canonicalSessionId,
+    })
 
     window.dispatchEvent(new StorageEvent('storage', {
       key: LAYOUT_STORAGE_KEY,
@@ -1284,7 +1290,10 @@ describe('crossTabSync', () => {
 
     tab = store.getState().tabs.tabs.find((entry) => entry.id === 'tab-1')
     expect(tab?.title).toBe('Local canonical title')
-    expect(tab?.resumeSessionId).toBe(canonicalSessionId)
+    expect(tab?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: canonicalSessionId,
+    })
 
     const paneContent = (store.getState().panes.layouts['tab-1'] as any).content
     expect(paneContent.resumeSessionId).toBe(canonicalSessionId)

--- a/test/unit/client/store/panesSlice.test.ts
+++ b/test/unit/client/store/panesSlice.test.ts
@@ -312,6 +312,22 @@ describe('panesSlice', () => {
       }
     })
 
+    it('does not synthesize canonical sessionRef from raw terminal resumeSessionId', () => {
+      const state = panesReducer(
+        initialState,
+        initLayout({
+          tabId: 'tab-1',
+          content: { kind: 'terminal', mode: 'claude', resumeSessionId: VALID_CLAUDE_SESSION_ID },
+        }),
+      )
+
+      const leaf = state.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>
+      if (leaf.content.kind !== 'terminal') throw new Error('expected terminal')
+
+      expect(leaf.content.resumeSessionId).toBe(VALID_CLAUDE_SESSION_ID)
+      expect(leaf.content.sessionRef).toBeUndefined()
+    })
+
     it('does not assign resumeSessionId for shell panes', () => {
       const state = panesReducer(
         initialState,
@@ -338,6 +354,26 @@ describe('panesSlice', () => {
         // Non-UUID resume names are valid for Claude (named resume support)
         expect(leaf.content.resumeSessionId).toBe('not-a-uuid')
       }
+    })
+
+    it('does not synthesize canonical sessionRef from raw agent-chat resumeSessionId', () => {
+      const state = panesReducer(
+        initialState,
+        initLayout({
+          tabId: 'tab-1',
+          content: {
+            kind: 'agent-chat',
+            provider: 'freshclaude',
+            resumeSessionId: VALID_CLAUDE_SESSION_ID,
+          },
+        }),
+      )
+
+      const leaf = state.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>
+      if (leaf.content.kind !== 'agent-chat') throw new Error('expected agent-chat')
+
+      expect(leaf.content.resumeSessionId).toBe(VALID_CLAUDE_SESSION_ID)
+      expect(leaf.content.sessionRef).toBeUndefined()
     })
   })
 

--- a/test/unit/client/store/selectors/sidebarSelectors.runningTerminal.test.ts
+++ b/test/unit/client/store/selectors/sidebarSelectors.runningTerminal.test.ts
@@ -82,7 +82,10 @@ describe('sidebarSelectors running session mapping', () => {
         status: 'running',
         hasClients: true,
         mode: 'codex',
-        resumeSessionId: 'session-1',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: 'session-1',
+        },
       },
       {
         terminalId: 'older-terminal',
@@ -92,7 +95,10 @@ describe('sidebarSelectors running session mapping', () => {
         status: 'running',
         hasClients: true,
         mode: 'codex',
-        resumeSessionId: 'session-1',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: 'session-1',
+        },
       },
     ]
 

--- a/test/unit/client/store/selectors/sidebarSelectors.test.ts
+++ b/test/unit/client/store/selectors/sidebarSelectors.test.ts
@@ -25,10 +25,20 @@ function createSessionItem(overrides: Partial<SidebarSessionItem>): SidebarSessi
   }
 }
 
-function createFallbackTab(tabId: string, sessionId: string, title: string, cwd: string, mode: 'claude' | 'codex' = 'codex') {
+function createFallbackTab(
+  tabId: string,
+  sessionId: string,
+  title: string,
+  cwd: string,
+  mode: 'claude' | 'codex' = 'codex',
+) {
   const paneId = `pane-${tabId}`
+  const sessionRef = {
+    provider: mode,
+    sessionId,
+  }
   return {
-    tab: { id: tabId, title, mode, resumeSessionId: sessionId, createdAt: 1_000 },
+    tab: { id: tabId, title, mode, resumeSessionId: sessionId, sessionRef, createdAt: 1_000 },
     paneId,
     layout: {
       type: 'leaf',
@@ -39,6 +49,7 @@ function createFallbackTab(tabId: string, sessionId: string, title: string, cwd:
         status: 'running',
         createRequestId: `req-${tabId}`,
         resumeSessionId: sessionId,
+        sessionRef,
         initialCwd: cwd,
       },
     },
@@ -180,7 +191,15 @@ describe('sidebarSelectors', () => {
 
       const tabs = [
         { id: 'tab-layout' },
-        { id: 'tab-no-layout', mode: 'codex', resumeSessionId: 'codex-no-layout' },
+        {
+          id: 'tab-no-layout',
+          mode: 'codex',
+          resumeSessionId: 'codex-no-layout',
+          sessionRef: {
+            provider: 'codex',
+            sessionId: 'codex-no-layout',
+          },
+        },
         { id: 'tab-invalid', mode: 'claude', resumeSessionId: invalidClaudeSessionId },
       ] as any
 
@@ -204,7 +223,6 @@ describe('sidebarSelectors', () => {
                   sessionRef: {
                     provider: 'codex',
                     sessionId: 'codex-layout',
-                    serverInstanceId: 'srv-local',
                   },
                 },
               },
@@ -220,7 +238,6 @@ describe('sidebarSelectors', () => {
                   sessionRef: {
                     provider: 'claude',
                     sessionId: validClaudeSessionId,
-                    serverInstanceId: 'srv-local',
                   },
                 },
               },
@@ -247,10 +264,10 @@ describe('sidebarSelectors', () => {
       expect(hasTabBySessionId.get('codex-layout')).toBe(true)
       expect(hasTabBySessionId.get('codex-no-layout')).toBe(true)
       expect(hasTabBySessionId.get(validClaudeSessionId)).toBe(true)
-      expect(hasTabBySessionId.get(invalidClaudeSessionId)).toBe(true)
+      expect(hasTabBySessionId.get(invalidClaudeSessionId)).toBe(false)
     })
 
-    it('creates a fallback sidebar item for a Claude pane with a human-readable resume name', () => {
+    it('does not create a fallback sidebar item for a Claude pane with a human-readable resume name', () => {
       const tabs = [
         { id: 'tab-named', title: 'Named Resume Session', mode: 'claude', createdAt: 3_000 },
       ] as any
@@ -281,16 +298,10 @@ describe('sidebarSelectors', () => {
 
       const items = buildSessionItems([], tabs, panes, emptyTerminals, emptyActivity)
 
-      expect(items).toHaveLength(1)
-      expect(items[0]).toMatchObject({
-        sessionId: '137 tour',
-        provider: 'claude',
-        title: 'Named Resume Session',
-        hasTab: true,
-      })
+      expect(items).toEqual([])
     })
 
-    it('creates fallback item for Claude session with special character resume name', () => {
+    it('does not create fallback item for Claude session with special character resume name', () => {
       const tabs = [
         { id: 'tab-special', title: 'Special Name Session', mode: 'claude', createdAt: 3_000 },
       ] as any
@@ -315,15 +326,23 @@ describe('sidebarSelectors', () => {
 
       const items = buildSessionItems([], tabs, panes, emptyTerminals, emptyActivity)
 
-      expect(items).toHaveLength(1)
-      expect(items[0].sessionId).toBe("fix: can't parse (issue #42)")
-      expect(items[0].hasTab).toBe(true)
+      expect(items).toEqual([])
     })
 
     it('synthesizes a local fallback row for restored open sessions that are not in the current server window', () => {
       const fallbackSessionId = 'codex-restored'
       const tabs = [
-        { id: 'tab-restored', title: 'Restored Session', mode: 'codex', resumeSessionId: fallbackSessionId, createdAt: 2_000 },
+        {
+          id: 'tab-restored',
+          title: 'Restored Session',
+          mode: 'codex',
+          resumeSessionId: fallbackSessionId,
+          sessionRef: {
+            provider: 'codex',
+            sessionId: fallbackSessionId,
+          },
+          createdAt: 2_000,
+        },
       ] as any
 
       const panes = {
@@ -337,6 +356,10 @@ describe('sidebarSelectors', () => {
               status: 'running',
               createRequestId: 'req-restored',
               resumeSessionId: fallbackSessionId,
+              sessionRef: {
+                provider: 'codex',
+                sessionId: fallbackSessionId,
+              },
               initialCwd: '/tmp/restored-project',
             },
           },
@@ -405,6 +428,10 @@ describe('sidebarSelectors', () => {
           title: 'Hidden Session',
           mode: 'codex',
           resumeSessionId: hiddenSessionId,
+          sessionRef: {
+            provider: 'codex',
+            sessionId: hiddenSessionId,
+          },
           createdAt: 2_000,
           sessionMetadataByKey: {
             'codex:codex-hidden': {
@@ -428,6 +455,10 @@ describe('sidebarSelectors', () => {
               status: 'running',
               createRequestId: 'req-hidden',
               resumeSessionId: hiddenSessionId,
+              sessionRef: {
+                provider: 'codex',
+                sessionId: hiddenSessionId,
+              },
               initialCwd: '/tmp/hidden-project',
             },
           },
@@ -473,6 +504,10 @@ describe('sidebarSelectors', () => {
           title: 'Current Session',
           mode: 'claude',
           resumeSessionId: sessionId,
+          sessionRef: {
+            provider: 'claude',
+            sessionId,
+          },
           createdAt: 20_000,
           sessionMetadataByKey: {
             'claude:claude-current': {
@@ -494,6 +529,10 @@ describe('sidebarSelectors', () => {
                 status: 'running',
                 createRequestId: 'req-1',
                 resumeSessionId: sessionId,
+                sessionRef: {
+                  provider: 'claude',
+                  sessionId,
+                },
                 initialCwd: '/repo',
               },
             },

--- a/test/unit/client/store/storage-migration.test.ts
+++ b/test/unit/client/store/storage-migration.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { BROWSER_PREFERENCES_STORAGE_KEY } from '@/store/storage-keys'
+import { parsePersistedLayoutRaw } from '@/store/persistedState'
+import { BROWSER_PREFERENCES_STORAGE_KEY, PANES_STORAGE_KEY, TABS_STORAGE_KEY } from '@/store/storage-keys'
 
 const AUTH_STORAGE_KEY = 'freshell.auth-token'
+const LAYOUT_STORAGE_KEY = 'freshell.layout.v3'
+const VALID_CLAUDE_SESSION_ID = '550e8400-e29b-41d4-a716-446655440000'
 
 async function importFreshStorageMigration(): Promise<Record<string, unknown>> {
   vi.resetModules()
@@ -50,7 +53,7 @@ describe('storage-migration', () => {
     }))
     expect(localStorage.getItem('freshell.tabs.v1')).toBeNull()
     expect(localStorage.getItem('freshell.panes.v1')).toBeNull()
-    expect(localStorage.getItem('freshell_version')).toBe('3')
+    expect(localStorage.getItem('freshell_version')).toBe('4')
   })
 
   it('clears stale freshell-auth cookie when no auth token remains', async () => {
@@ -89,7 +92,156 @@ describe('storage-migration', () => {
     }))
     expect(localStorage.getItem('freshell.terminal.fontFamily.v1')).toBeNull()
     expect(localStorage.getItem('freshell.tabs.v1')).toBeNull()
-    expect(localStorage.getItem('freshell_version')).toBe('3')
+    expect(localStorage.getItem('freshell_version')).toBe('4')
+  })
+
+  it('preserves restorable layouts and migrates ambiguous resume ids instead of clearing state', async () => {
+    localStorage.setItem('freshell_version', '3')
+    localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify({
+      version: 3,
+      tabs: {
+        activeTabId: 'tab-claude',
+        tabs: [
+          {
+            id: 'tab-claude',
+            title: 'Claude terminal',
+            createdAt: 1,
+            mode: 'claude',
+            resumeSessionId: VALID_CLAUDE_SESSION_ID,
+          },
+          {
+            id: 'tab-codex',
+            title: 'Codex terminal',
+            createdAt: 2,
+            mode: 'codex',
+            resumeSessionId: 'thread-new-1',
+          },
+        ],
+      },
+      panes: {
+        version: 6,
+        layouts: {
+          'tab-claude': {
+            type: 'leaf',
+            id: 'pane-claude',
+            content: {
+              kind: 'terminal',
+              mode: 'claude',
+              createRequestId: 'req-claude',
+              status: 'running',
+              resumeSessionId: VALID_CLAUDE_SESSION_ID,
+            },
+          },
+          'tab-codex': {
+            type: 'leaf',
+            id: 'pane-codex',
+            content: {
+              kind: 'terminal',
+              mode: 'codex',
+              createRequestId: 'req-codex',
+              status: 'running',
+              resumeSessionId: 'thread-new-1',
+            },
+          },
+        },
+        activePane: {
+          'tab-claude': 'pane-claude',
+          'tab-codex': 'pane-codex',
+        },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+      },
+      tombstones: [],
+    }))
+
+    await importFreshStorageMigration()
+
+    const migratedRaw = localStorage.getItem(LAYOUT_STORAGE_KEY)
+    expect(migratedRaw).not.toBeNull()
+    expect(localStorage.getItem('freshell_version')).toBe('4')
+
+    const parsed = parsePersistedLayoutRaw(migratedRaw!)
+    expect(parsed).not.toBeNull()
+    expect((parsed!.tabs.tabs[0] as any).resumeSessionId).toBeUndefined()
+    expect((parsed!.tabs.tabs[0] as any).sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: VALID_CLAUDE_SESSION_ID,
+    })
+
+    const codexPane = (((parsed!.panes.layouts['tab-codex'] as any)?.content) ?? {}) as Record<string, unknown>
+    expect(codexPane.resumeSessionId).toBeUndefined()
+    expect(codexPane.sessionRef).toBeUndefined()
+    expect(codexPane.restoreError).toEqual({
+      code: 'RESTORE_UNAVAILABLE',
+      reason: 'invalid_legacy_restore_target',
+    })
+  })
+
+  it('migrates recoverable v2 tabs and panes into the v3 layout key before clearing legacy storage', async () => {
+    localStorage.setItem('freshell_version', '3')
+    localStorage.setItem(TABS_STORAGE_KEY, JSON.stringify({
+      version: 2,
+      tabs: {
+        activeTabId: 'tab-v2',
+        tabs: [
+          {
+            id: 'tab-v2',
+            title: 'Recovered Claude',
+            createdAt: 1,
+            mode: 'claude',
+            resumeSessionId: VALID_CLAUDE_SESSION_ID,
+          },
+        ],
+      },
+      tombstones: [],
+    }))
+    localStorage.setItem(PANES_STORAGE_KEY, JSON.stringify({
+      version: 6,
+      layouts: {
+        'tab-v2': {
+          type: 'leaf',
+          id: 'pane-v2',
+          content: {
+            kind: 'terminal',
+            mode: 'claude',
+            createRequestId: 'req-v2',
+            status: 'running',
+            resumeSessionId: VALID_CLAUDE_SESSION_ID,
+          },
+        },
+      },
+      activePane: {
+        'tab-v2': 'pane-v2',
+      },
+      paneTitles: {},
+      paneTitleSetByUser: {},
+    }))
+
+    await importFreshStorageMigration()
+
+    expect(localStorage.getItem(TABS_STORAGE_KEY)).toBeNull()
+    expect(localStorage.getItem(PANES_STORAGE_KEY)).toBeNull()
+
+    const migratedRaw = localStorage.getItem(LAYOUT_STORAGE_KEY)
+    expect(migratedRaw).not.toBeNull()
+
+    const parsed = parsePersistedLayoutRaw(migratedRaw!)
+    expect(parsed).not.toBeNull()
+    expect(parsed?.tabs.activeTabId).toBe('tab-v2')
+    expect(parsed?.tabs.tabs[0]).toEqual(expect.objectContaining({
+      id: 'tab-v2',
+      sessionRef: {
+        provider: 'claude',
+        sessionId: VALID_CLAUDE_SESSION_ID,
+      },
+    }))
+    expect(((parsed?.panes.layouts['tab-v2'] as any)?.content) ?? {}).toEqual(expect.objectContaining({
+      kind: 'terminal',
+      sessionRef: {
+        provider: 'claude',
+        sessionId: VALID_CLAUDE_SESSION_ID,
+      },
+    }))
   })
 
   it('keeps migration bootstrap order deterministic in static imports', async () => {

--- a/test/unit/client/store/tabsSlice.merge.test.ts
+++ b/test/unit/client/store/tabsSlice.merge.test.ts
@@ -277,14 +277,65 @@ describe('hydrateTabs merge', () => {
 
     expect(result.tabs[0]).toEqual(expect.objectContaining({
       title: 'Renamed elsewhere',
-      resumeSessionId: canonicalSessionId,
+      sessionRef: {
+        provider: 'claude',
+        sessionId: canonicalSessionId,
+      },
     }))
     expect(result.tabs[0].sessionMetadataByKey).toEqual(expect.objectContaining({
       [sessionMetadataKey('claude', canonicalSessionId)]: expect.objectContaining({
         sessionType: 'freshclaude',
       }),
     }))
+    expect((result.tabs[0] as any).resumeSessionId).toBeUndefined()
     expect(result.tabs[0].sessionMetadataByKey).not.toHaveProperty(sessionMetadataKey('claude', 'named-resume'))
+  })
+
+  it('preserves canonical tab sessionRef when newer remote state only carries a raw legacy resume string', () => {
+    const canonicalSessionId = '00000000-0000-4000-8000-000000000654'
+    const localTab = makeTab({
+      id: 'tab-1',
+      title: 'Local durable tab',
+      mode: 'shell',
+      codingCliProvider: 'claude',
+      updatedAt: 100,
+      sessionRef: {
+        provider: 'claude',
+        sessionId: canonicalSessionId,
+      },
+    } as any)
+    const remoteTab = makeTab({
+      id: 'tab-1',
+      title: 'Remote renamed tab',
+      mode: 'shell',
+      updatedAt: 200,
+      resumeSessionId: 'named-resume',
+    })
+
+    const result = tabsReducer(
+      makeState([localTab], 'tab-1'),
+      {
+        ...hydrateTabs({
+          tabs: [remoteTab],
+          activeTabId: 'tab-1',
+          renameRequestTabId: null,
+          tombstones: [],
+        }),
+        meta: {
+          localLayoutPersistedAt: 200,
+          remoteLayoutPersistedAt: 250,
+        },
+      } as any,
+    )
+
+    expect(result.tabs[0]).toEqual(expect.objectContaining({
+      title: 'Remote renamed tab',
+      sessionRef: {
+        provider: 'claude',
+        sessionId: canonicalSessionId,
+      },
+    }))
+    expect((result.tabs[0] as any).resumeSessionId).toBeUndefined()
   })
 })
 

--- a/test/unit/client/store/tabsSlice.test.ts
+++ b/test/unit/client/store/tabsSlice.test.ts
@@ -113,7 +113,10 @@ describe('tabsSlice', () => {
           shell: 'wsl',
           status: 'running',
           initialCwd: '/home/user',
-          resumeSessionId: 'session-123',
+          sessionRef: {
+            provider: 'codex',
+            sessionId: 'session-123',
+          },
         })
       )
 
@@ -124,7 +127,10 @@ describe('tabsSlice', () => {
       expect(tab.shell).toBe('wsl')
       expect(tab.status).toBe('running')
       expect(tab.initialCwd).toBe('/home/user')
-      expect(tab.resumeSessionId).toBe('session-123')
+      expect(tab.sessionRef).toEqual({
+        provider: 'codex',
+        sessionId: 'session-123',
+      })
     })
 
     it('increments tab number in default title', () => {
@@ -440,7 +446,10 @@ describe('tabsSlice', () => {
         mode: 'codex',
         shell: 'wsl',
         initialCwd: '/custom/path',
-        resumeSessionId: 'session-abc',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: 'session-abc',
+        },
         createdAt: 5000000,
       }
 
@@ -460,7 +469,10 @@ describe('tabsSlice', () => {
       expect(tab.mode).toBe('codex')
       expect(tab.shell).toBe('wsl')
       expect(tab.initialCwd).toBe('/custom/path')
-      expect(tab.resumeSessionId).toBe('session-abc')
+      expect(tab.sessionRef).toEqual({
+        provider: 'codex',
+        sessionId: 'session-abc',
+      })
       expect(tab.createdAt).toBe(5000000)
     })
   })
@@ -558,7 +570,7 @@ describe('tabsSlice', () => {
   })
 
   describe('openSessionTab', () => {
-    it('creates a new local tab instead of activating a foreign copied tab', async () => {
+    it('activates an existing canonical tab when a copied snapshot already has the durable session identity', async () => {
       const store = createOpenSessionStore('srv-local')
 
       store.dispatch(addTab({ id: 'foreign-tab', mode: 'codex' }))
@@ -578,13 +590,11 @@ describe('tabsSlice', () => {
       await store.dispatch(openSessionTab({ sessionId: 'shared', provider: 'codex' }))
 
       const state = store.getState()
-      expect(state.tabs.tabs).toHaveLength(2)
-      const localTab = state.tabs.tabs.find((tab) => tab.id !== 'foreign-tab')
-      expect(localTab?.resumeSessionId).toBe('shared')
-      expect(state.tabs.activeTabId).toBe(localTab?.id)
+      expect(state.tabs.tabs).toHaveLength(1)
+      expect(state.tabs.activeTabId).toBe('foreign-tab')
     })
 
-    it('activates an id-less local fallback before websocket ready instead of a foreign copied tab', async () => {
+    it('activates the first canonical match before websocket ready when multiple tabs share the durable session identity', async () => {
       const store = createOpenSessionStore()
 
       store.dispatch(addTab({ id: 'foreign-tab', mode: 'codex' }))
@@ -600,14 +610,21 @@ describe('tabsSlice', () => {
           },
         },
       }))
-      store.dispatch(addTab({ id: 'local-fallback', mode: 'codex', resumeSessionId: 'shared' }))
+      store.dispatch(addTab({
+        id: 'local-fallback',
+        mode: 'codex',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: 'shared',
+        },
+      }))
       store.dispatch(setActiveTab('foreign-tab'))
 
       await store.dispatch(openSessionTab({ sessionId: 'shared', provider: 'codex' }))
 
       const state = store.getState()
       expect(state.tabs.tabs).toHaveLength(2)
-      expect(state.tabs.activeTabId).toBe('local-fallback')
+      expect(state.tabs.activeTabId).toBe('foreign-tab')
     })
 
     it('activates existing tab when a pane already owns the session', async () => {
@@ -644,7 +661,10 @@ describe('tabsSlice', () => {
 
       const tabs = store.getState().tabs.tabs
       expect(tabs).toHaveLength(1)
-      expect(tabs[0].resumeSessionId).toBe(VALID_CLAUDE_SESSION_ID)
+      expect(tabs[0].sessionRef).toEqual({
+        provider: 'claude',
+        sessionId: VALID_CLAUDE_SESSION_ID,
+      })
       expect(tabs[0].mode).toBe('claude')
     })
 
@@ -682,7 +702,10 @@ describe('tabsSlice', () => {
       store.dispatch(addTab({
         id: 'local-fallback',
         mode: 'claude',
-        resumeSessionId: VALID_CLAUDE_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_CLAUDE_SESSION_ID,
+        },
       }))
 
       await store.dispatch(openSessionTab({
@@ -743,7 +766,10 @@ describe('tabsSlice', () => {
         content: {
           kind: 'agent-chat',
           provider: 'freshclaude',
-          resumeSessionId: VALID_CLAUDE_SESSION_ID,
+          sessionRef: {
+            provider: 'claude',
+            sessionId: VALID_CLAUDE_SESSION_ID,
+          },
         },
       })
     })
@@ -787,7 +813,10 @@ describe('tabsSlice', () => {
       const tabs = store.getState().tabs.tabs
       expect(tabs).toHaveLength(1)
       expect(tabs[0].status).toBe('running')
-      expect(tabs[0].resumeSessionId).toBe(VALID_CLAUDE_SESSION_ID)
+      expect(tabs[0].sessionRef).toEqual({
+        provider: 'claude',
+        sessionId: VALID_CLAUDE_SESSION_ID,
+      })
       // terminalId lives in pane content, not on the tab
       const layout = store.getState().panes.layouts[tabs[0].id]
       expect(layout).toBeDefined()

--- a/test/unit/server/agent-layout-schema.test.ts
+++ b/test/unit/server/agent-layout-schema.test.ts
@@ -27,4 +27,27 @@ describe('UiLayoutSyncSchema', () => {
       sessionId: 'older-open',
     })
   })
+
+  it('rejects fallbackSessionRef values that smuggle server locality into canonical identity', () => {
+    const parsed = UiLayoutSyncSchema.safeParse({
+      type: 'ui.layout.sync',
+      tabs: [{
+        id: 'tab_a',
+        title: 'alpha',
+        fallbackSessionRef: {
+          provider: 'codex',
+          sessionId: 'older-open',
+          serverInstanceId: 'srv-local',
+        },
+      }],
+      activeTabId: 'tab_a',
+      layouts: {},
+      activePane: {},
+      paneTitles: {},
+      paneTitleSetByUser: {},
+      timestamp: Date.now(),
+    })
+
+    expect(parsed.success).toBe(false)
+  })
 })

--- a/test/unit/server/agent-timeline-history-source.test.ts
+++ b/test/unit/server/agent-timeline-history-source.test.ts
@@ -109,9 +109,9 @@ describe('agent timeline history source', () => {
       timelineSessionId: undefined,
     })
 
-    await expect(source.resolve('named-only')).resolves.toMatchObject({
-      kind: 'resolved',
-      readiness: 'live_only',
+    await expect(source.resolve('named-only')).resolves.toEqual({
+      kind: 'missing',
+      code: 'RESTORE_NOT_FOUND',
     })
 
     source.teardownLiveSession('sdk-gone', { recoverable: false })

--- a/test/unit/server/agent-timeline-ledger.test.ts
+++ b/test/unit/server/agent-timeline-ledger.test.ts
@@ -53,7 +53,7 @@ describe('restore ledger manager', () => {
     })
   })
 
-  it('returns typed live-only, merged, and durable-only restore outcomes while upgrading aliases in place', async () => {
+  it('keeps mutable named aliases out of restore resolution while canonical ids upgrade in place', async () => {
     const liveSession = makeSession({
       sessionId: 'sdk-live',
       resumeSessionId: 'named-resume-token',
@@ -91,20 +91,15 @@ describe('restore ledger manager', () => {
     if (liveOnly.kind !== 'resolved') throw new Error('expected resolved')
     const initialRevision = liveOnly.revision
 
-    const namedAliasLiveOnly = await manager.resolve('named-resume-token')
-    expect(namedAliasLiveOnly).toMatchObject({
-      kind: 'resolved',
-      readiness: 'live_only',
-      liveSessionId: 'sdk-live',
-      timelineSessionId: undefined,
+    await expect(manager.resolve('named-resume-token')).resolves.toEqual({
+      kind: 'missing',
+      code: 'RESTORE_NOT_FOUND',
     })
-    if (namedAliasLiveOnly.kind !== 'resolved') throw new Error('expected resolved')
-    expect(namedAliasLiveOnly.revision).toBe(initialRevision)
 
     liveSession.cliSessionId = '00000000-0000-4000-8000-000000000123'
     liveSession.messages.push(makeMessage('assistant', 'new live reply', { messageId: 'live-assistant-2' }))
 
-    const merged = await manager.resolve('named-resume-token')
+    const merged = await manager.resolve('sdk-live')
     expect(merged).toMatchObject({
       kind: 'resolved',
       readiness: 'merged',
@@ -120,21 +115,10 @@ describe('restore ledger manager', () => {
       'live-assistant-2',
     ])
 
-    const namedAliasMerged = await manager.resolve('named-resume-token')
-    expect(namedAliasMerged).toMatchObject({
-      kind: 'resolved',
-      readiness: 'merged',
-      liveSessionId: 'sdk-live',
-      timelineSessionId: '00000000-0000-4000-8000-000000000123',
+    await expect(manager.resolve('named-resume-token')).resolves.toEqual({
+      kind: 'missing',
+      code: 'RESTORE_NOT_FOUND',
     })
-    if (namedAliasMerged.kind !== 'resolved') throw new Error('expected resolved')
-    expect(namedAliasMerged.revision).toBe(merged.revision)
-    expect(namedAliasMerged.turns.map((turn) => turn.messageId)).toEqual([
-      'durable-user-1',
-      'durable-assistant-1',
-      'live-user-1',
-      'live-assistant-2',
-    ])
 
     manager.teardownLiveSession('sdk-live', { recoverable: true })
 
@@ -223,6 +207,41 @@ describe('restore ledger manager', () => {
       'live-user-1',
       'live-assistant-2',
     ])
+  })
+
+  it('hydrates durable history from a canonical resumeSessionId before cliSessionId is known', async () => {
+    const canonicalSessionId = '00000000-0000-4000-8000-000000000321'
+    const liveSession = makeSession({
+      sessionId: 'sdk-create',
+      resumeSessionId: canonicalSessionId,
+      messages: [],
+    })
+    const durableMessages = [
+      makeMessage('user', 'restored prompt', { messageId: 'durable-restore-1' }),
+    ]
+    const loadSessionHistory = vi.fn(async (sessionId: string) => (
+      sessionId === canonicalSessionId ? durableMessages : null
+    ))
+
+    const manager = createRestoreLedgerManager({
+      loadSessionHistory,
+      getLiveSessionBySdkSessionId: () => undefined,
+      getLiveSessionByCliSessionId: () => undefined,
+    })
+
+    const resolved = await manager.resolve(liveSession.sessionId, {
+      liveSessionOverride: liveSession,
+    })
+
+    expect(loadSessionHistory).toHaveBeenCalledWith(canonicalSessionId)
+    expect(resolved).toMatchObject({
+      kind: 'resolved',
+      queryId: 'sdk-create',
+      timelineSessionId: canonicalSessionId,
+      readiness: 'durable_only',
+    })
+    if (resolved.kind !== 'resolved') throw new Error('expected resolved')
+    expect(resolved.turns.map((turn) => turn.messageId)).toEqual(['durable-restore-1'])
   })
 
   it('refreshes a non-empty durable backlog while the live ledger remains authoritative', async () => {
@@ -381,10 +400,17 @@ describe('restore ledger manager', () => {
       timelineSessionId: undefined,
     })
 
-    const beforeTeardown = await manager.resolve('named-only')
-    expect(beforeTeardown).toMatchObject({ kind: 'resolved', readiness: 'live_only' })
+    await expect(manager.resolve('named-only')).resolves.toEqual({
+      kind: 'missing',
+      code: 'RESTORE_NOT_FOUND',
+    })
 
     manager.teardownLiveSession('sdk-gone', { recoverable: false })
+
+    await expect(manager.resolve('sdk-gone')).resolves.toEqual({
+      kind: 'missing',
+      code: 'RESTORE_NOT_FOUND',
+    })
 
     const afterTeardown = await manager.resolve('named-only')
     expect(afterTeardown).toEqual({ kind: 'missing', code: 'RESTORE_NOT_FOUND' })
@@ -774,7 +800,7 @@ describe('restore ledger manager', () => {
 
     liveSession.cliSessionId = canonicalSessionId
 
-    const upgraded = await manager.resolve('named-repeat-upgrade')
+    const upgraded = await manager.resolve('sdk-repeat-upgrade')
 
     expect(upgraded).toMatchObject({
       kind: 'resolved',

--- a/test/unit/server/coding-cli/codex-app-server/client.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/client.test.ts
@@ -14,6 +14,7 @@ type FakeServerBehavior = {
   closeSocketAfterMethodsOnce?: string[]
   delayMethodsMs?: Record<string, number>
   ignoreMethods?: string[]
+  notifyAfterMethodsOnce?: Record<string, Array<{ method: string; params?: unknown }>>
   requireJsonRpc?: boolean
   requireInitializeBeforeOtherMethods?: boolean
   overrides?: Record<string, { result?: unknown; error?: { code: number; message: string } }>
@@ -118,7 +119,29 @@ describe('CodexAppServerClient', () => {
 
     await client.initialize()
     await expect(client.startThread({ cwd: '/repo/worktree' })).resolves.toEqual({
-      threadId: 'thread-new-1',
+      thread: {
+        id: 'thread-new-1',
+        path: expect.stringMatching(/\/sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-thread-new-1\.jsonl$/),
+        ephemeral: false,
+      },
+    })
+  })
+
+  it('surfaces thread/started notifications to sidecar consumers', async () => {
+    const server = await startFakeCodexAppServer()
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    const startedThread = new Promise<{ id: string; path: string | null; ephemeral: boolean }>((resolve) => {
+      client.onThreadStarted((thread) => resolve(thread))
+    })
+
+    await client.initialize()
+    await client.startThread({ cwd: '/repo/worktree' })
+
+    await expect(startedThread).resolves.toEqual({
+      id: 'thread-new-1',
+      path: expect.stringMatching(/\/sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-thread-new-1\.jsonl$/),
+      ephemeral: false,
     })
   })
 
@@ -128,7 +151,11 @@ describe('CodexAppServerClient', () => {
 
     await client.initialize()
     await expect(client.startThread({ cwd: '/repo/worktree' })).resolves.toEqual({
-      threadId: 'thread-new-1',
+      thread: {
+        id: 'thread-new-1',
+        path: expect.stringMatching(/\/sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-thread-new-1\.jsonl$/),
+        ephemeral: false,
+      },
     })
   })
 
@@ -141,7 +168,11 @@ describe('CodexAppServerClient', () => {
       threadId: '019d9859-5670-72b1-851f-794ad7fef112',
       cwd: '/repo/worktree',
     })).resolves.toEqual({
-      threadId: '019d9859-5670-72b1-851f-794ad7fef112',
+      thread: {
+        id: '019d9859-5670-72b1-851f-794ad7fef112',
+        path: expect.stringMatching(/rollout-019d9859-5670-72b1-851f-794ad7fef112\.jsonl$/),
+        ephemeral: false,
+      },
     })
   })
 
@@ -153,7 +184,11 @@ describe('CodexAppServerClient', () => {
     await new Promise((resolve) => setTimeout(resolve, 25))
 
     await expect(client.startThread({ cwd: '/repo/worktree' })).resolves.toEqual({
-      threadId: 'thread-new-1',
+      thread: {
+        id: 'thread-new-1',
+        path: expect.stringMatching(/\/sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-thread-new-1\.jsonl$/),
+        ephemeral: false,
+      },
     })
   })
 
@@ -174,8 +209,44 @@ describe('CodexAppServerClient', () => {
       platformOs: expect.any(String),
     })
     await expect(startThreadPromise).resolves.toEqual({
-      threadId: 'thread-new-1',
+      thread: {
+        id: 'thread-new-1',
+        path: expect.stringMatching(/\/sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-thread-new-1\.jsonl$/),
+        ephemeral: false,
+      },
     })
+  })
+
+  it('sends fs/watch and fs/unwatch envelopes and surfaces fs/changed notifications with the original watchId', async () => {
+    const rolloutPath = '/repo/worktree/.codex/sessions/2026/04/23/rollout-thread-new-1.jsonl'
+    const server = await startFakeCodexAppServer({
+      notifyAfterMethodsOnce: {
+        'fs/watch': [
+          {
+            method: 'fs/changed',
+            params: {
+              watchId: 'watch-rollout',
+              changedPaths: [rolloutPath],
+            },
+          },
+        ],
+      },
+    })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    const changedEvent = new Promise<{ watchId: string; changedPaths: string[] }>((resolve) => {
+      client.onFsChanged((event) => resolve(event))
+    })
+
+    await client.initialize()
+    await expect(client.watchPath(rolloutPath, 'watch-rollout')).resolves.toEqual({
+      path: rolloutPath,
+    })
+    await expect(changedEvent).resolves.toEqual({
+      watchId: 'watch-rollout',
+      changedPaths: [rolloutPath],
+    })
+    await expect(client.unwatchPath('watch-rollout')).resolves.toBeUndefined()
   })
 
   it('fails clearly when the app-server never answers a request', async () => {

--- a/test/unit/server/coding-cli/codex-app-server/durable-rollout-tracker.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/durable-rollout-tracker.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CodexDurableRolloutTracker } from '../../../../../server/coding-cli/codex-app-server/durable-rollout-tracker.js'
+
+describe('CodexDurableRolloutTracker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('checks only the exact rollout path when a matching fs/changed event arrives', async () => {
+    const rolloutPath = '/tmp/codex/sessions/2026/04/23/rollout-thread-new-1.jsonl'
+    const existsCalls: string[] = []
+    let rolloutExists = false
+    let fsChangedHandler: ((event: { watchId: string; changedPaths: string[] }) => void) | null = null
+    const onDurableRollout = vi.fn()
+
+    const tracker = new CodexDurableRolloutTracker({
+      watchPath: vi.fn(async (targetPath) => ({ path: targetPath })),
+      unwatchPath: vi.fn(async () => undefined),
+      subscribeToFsChanged: (handler) => {
+        fsChangedHandler = handler
+        return () => {
+          fsChangedHandler = null
+        }
+      },
+      pathExists: vi.fn(async (targetPath) => {
+        existsCalls.push(targetPath)
+        return rolloutExists
+      }),
+      onDurableRollout,
+    })
+
+    tracker.trackThread({
+      id: 'thread-new-1',
+      path: rolloutPath,
+      ephemeral: false,
+    })
+    await Promise.resolve()
+
+    rolloutExists = true
+    fsChangedHandler?.({
+      watchId: 'freshell-codex-rollout:thread-new-1',
+      changedPaths: [rolloutPath],
+    })
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(onDurableRollout).toHaveBeenCalledWith('thread-new-1')
+    expect(new Set(existsCalls)).toEqual(new Set([rolloutPath]))
+
+    await tracker.dispose()
+  })
+
+  it('keeps retrying exact-path probes after the old 10 second cutoff until the rollout exists', async () => {
+    const rolloutPath = '/tmp/codex/sessions/2026/04/23/rollout-thread-late.jsonl'
+    const onDurableRollout = vi.fn()
+
+    const tracker = new CodexDurableRolloutTracker({
+      watchPath: vi.fn(async (targetPath) => ({ path: targetPath })),
+      unwatchPath: vi.fn(async () => undefined),
+      subscribeToFsChanged: () => () => undefined,
+      pathExists: vi.fn(async () => Date.now() >= 11_000),
+      onDurableRollout,
+      initialProbeDelayMs: 1_000,
+      maxProbeDelayMs: 5_000,
+    })
+
+    tracker.trackThread({
+      id: 'thread-late',
+      path: rolloutPath,
+      ephemeral: false,
+    })
+    await Promise.resolve()
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(onDurableRollout).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(onDurableRollout).toHaveBeenCalledWith('thread-late')
+
+    await tracker.dispose()
+  })
+
+  it('falls back to exact-path probes when fs/watch registration fails', async () => {
+    const rolloutPath = '/tmp/codex/sessions/2026/04/23/rollout-thread-fallback.jsonl'
+    const log = { warn: vi.fn() }
+    const onDurableRollout = vi.fn()
+    const unwatchPath = vi.fn(async () => undefined)
+
+    const tracker = new CodexDurableRolloutTracker({
+      watchPath: vi.fn(async () => {
+        throw new Error('watch registration failed')
+      }),
+      unwatchPath,
+      subscribeToFsChanged: () => () => undefined,
+      pathExists: vi.fn(async () => Date.now() >= 6_000),
+      onDurableRollout,
+      initialProbeDelayMs: 1_000,
+      maxProbeDelayMs: 5_000,
+      log,
+    })
+
+    tracker.trackThread({
+      id: 'thread-fallback',
+      path: rolloutPath,
+      ephemeral: false,
+    })
+    await Promise.resolve()
+
+    await vi.advanceTimersByTimeAsync(7_000)
+    expect(onDurableRollout).toHaveBeenCalledWith('thread-fallback')
+    expect(log.warn).toHaveBeenCalled()
+    expect(unwatchPath).not.toHaveBeenCalled()
+
+    await tracker.dispose()
+  })
+
+  it('lets a later trackThread replace an earlier pending rollout without overlapping state', async () => {
+    const firstPath = '/tmp/codex/sessions/2026/04/23/rollout-thread-first.jsonl'
+    const secondPath = '/tmp/codex/sessions/2026/04/23/rollout-thread-second.jsonl'
+    const onDurableRollout = vi.fn()
+
+    const tracker = new CodexDurableRolloutTracker({
+      watchPath: vi.fn(async (targetPath) => ({ path: targetPath })),
+      unwatchPath: vi.fn(async () => undefined),
+      subscribeToFsChanged: () => () => undefined,
+      pathExists: vi.fn(async (targetPath) => targetPath === secondPath && Date.now() >= 1_000),
+      onDurableRollout,
+      initialProbeDelayMs: 500,
+      maxProbeDelayMs: 500,
+    })
+
+    tracker.trackThread({
+      id: 'thread-first',
+      path: firstPath,
+      ephemeral: false,
+    })
+    tracker.trackThread({
+      id: 'thread-second',
+      path: secondPath,
+      ephemeral: false,
+    })
+    await Promise.resolve()
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(onDurableRollout).toHaveBeenCalledTimes(1)
+    expect(onDurableRollout).toHaveBeenCalledWith('thread-second')
+
+    await tracker.dispose()
+  })
+})

--- a/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
@@ -2,15 +2,19 @@ import { describe, expect, it, vi } from 'vitest'
 import { CodexLaunchPlanner } from '../../../../../server/coding-cli/codex-app-server/launch-planner.js'
 
 describe('CodexLaunchPlanner', () => {
-  it('starts a fresh Codex thread and returns an exact remote endpoint handoff', async () => {
-    const runtime = {
-      ensureReady: vi.fn(),
-      startThread: vi.fn().mockResolvedValue({
-        threadId: 'thread-new-1',
+  function createSidecar() {
+    return {
+      ensureReady: vi.fn().mockResolvedValue({
         wsUrl: 'ws://127.0.0.1:43123',
       }),
+      attachTerminal: vi.fn(),
+      shutdown: vi.fn(),
     }
-    const planner = new CodexLaunchPlanner(runtime as any)
+  }
+
+  it('starts a fresh Codex terminal without preallocating a thread id', async () => {
+    const sidecar = createSidecar()
+    const planner = new CodexLaunchPlanner(() => sidecar as any)
 
     const plan = await planner.planCreate({
       cwd: '/repo/worktree',
@@ -18,53 +22,44 @@ describe('CodexLaunchPlanner', () => {
       sandbox: 'workspace-write',
     })
 
-    expect(runtime.startThread).toHaveBeenCalledWith({
-      cwd: '/repo/worktree',
-      model: 'codex-default',
-      sandbox: 'workspace-write',
-      approvalPolicy: undefined,
-    })
-    expect(plan.sessionId).toBe('thread-new-1')
+    expect(sidecar.ensureReady).toHaveBeenCalledTimes(1)
+    expect(plan.sessionId).toBeUndefined()
     expect(plan.remote.wsUrl).toBe('ws://127.0.0.1:43123')
+    expect(plan.sidecar).toBe(sidecar)
   })
 
   it('reuses an existing Codex session id and only ensures the remote runtime is ready', async () => {
-    const runtime = {
-      ensureReady: vi.fn().mockResolvedValue({
-        wsUrl: 'ws://127.0.0.1:43123',
-      }),
-      startThread: vi.fn(),
-    }
-    const planner = new CodexLaunchPlanner(runtime as any)
+    const sidecar = createSidecar()
+    const planner = new CodexLaunchPlanner(() => sidecar as any)
 
     const plan = await planner.planCreate({
       cwd: '/repo/worktree',
       resumeSessionId: '019d9859-5670-72b1-851f-794ad7fef112',
     })
 
-    expect(runtime.ensureReady).toHaveBeenCalledTimes(1)
-    expect(runtime.startThread).not.toHaveBeenCalled()
+    expect(sidecar.ensureReady).toHaveBeenCalledTimes(1)
     expect(plan.sessionId).toBe('019d9859-5670-72b1-851f-794ad7fef112')
     expect(plan.remote.wsUrl).toBe('ws://127.0.0.1:43123')
+    expect(plan.sidecar).toBe(sidecar)
   })
 
-  it('uses the runtime-reported wsUrl from the same thread create call', async () => {
-    const runtime = {
-      ensureReady: vi.fn(),
-      startThread: vi.fn().mockResolvedValue({
-        threadId: 'thread-new-2',
+  it('uses the ready runtime wsUrl for fresh launch handoff', async () => {
+    const sidecar = {
+      ensureReady: vi.fn().mockResolvedValue({
         wsUrl: 'ws://127.0.0.1:43199',
       }),
+      attachTerminal: vi.fn(),
+      shutdown: vi.fn(),
     }
-    const planner = new CodexLaunchPlanner(runtime as any)
+    const planner = new CodexLaunchPlanner(() => sidecar as any)
 
     const plan = await planner.planCreate({ cwd: '/repo/worktree' })
 
     expect(plan).toEqual({
-      sessionId: 'thread-new-2',
       remote: {
         wsUrl: 'ws://127.0.0.1:43199',
       },
+      sidecar,
     })
   })
 })

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -81,7 +81,7 @@ function createRuntime(options: ConstructorParameters<typeof CodexAppServerRunti
 }
 
 describe('CodexAppServerRuntime', () => {
-  it('starts one shared loopback app-server runtime on first use', async () => {
+  it('starts one loopback app-server runtime on first use', async () => {
     const runtime = createRuntime()
 
     const ready = await runtime.ensureReady()
@@ -89,6 +89,19 @@ describe('CodexAppServerRuntime', () => {
     expect(ready.wsUrl).toMatch(/^ws:\/\/127\.0\.0\.1:\d+$/)
     expect(ready.processPid).toBeGreaterThan(0)
     expect(runtime.status()).toBe('running')
+  })
+
+  it('keeps separate runtime instances isolated for concurrent codex terminals', async () => {
+    const firstRuntime = createRuntime()
+    const secondRuntime = createRuntime()
+
+    const [first, second] = await Promise.all([
+      firstRuntime.ensureReady(),
+      secondRuntime.ensureReady(),
+    ])
+
+    expect(first.processPid).not.toBe(second.processPid)
+    expect(first.wsUrl).not.toBe(second.wsUrl)
   })
 
   it('reuses the same process for repeated ensureReady calls', async () => {
@@ -124,23 +137,31 @@ describe('CodexAppServerRuntime', () => {
     expect(runtime.status()).toBe('stopped')
   })
 
-  it('proxies thread/start through the shared client after boot', async () => {
+  it('proxies thread/start through the runtime client after boot', async () => {
     const runtime = createRuntime()
 
     await expect(runtime.startThread({ cwd: '/repo/worktree' })).resolves.toEqual({
-      threadId: 'thread-new-1',
+      thread: {
+        id: 'thread-new-1',
+        path: expect.stringMatching(/\/sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-thread-new-1\.jsonl$/),
+        ephemeral: false,
+      },
       wsUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
     })
   })
 
-  it('proxies thread/resume through the shared client after boot', async () => {
+  it('proxies thread/resume through the runtime client after boot', async () => {
     const runtime = createRuntime()
 
     await expect(runtime.resumeThread({
       threadId: '019d9859-5670-72b1-851f-794ad7fef112',
       cwd: '/repo/worktree',
     })).resolves.toEqual({
-      threadId: '019d9859-5670-72b1-851f-794ad7fef112',
+      thread: {
+        id: '019d9859-5670-72b1-851f-794ad7fef112',
+        path: expect.stringMatching(/rollout-019d9859-5670-72b1-851f-794ad7fef112\.jsonl$/),
+        ephemeral: false,
+      },
       wsUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
     })
   })
@@ -191,7 +212,11 @@ describe('CodexAppServerRuntime', () => {
     })
 
     await expect(runtime.startThread({ cwd: '/repo/worktree' })).resolves.toEqual({
-      threadId: 'thread-new-1',
+      thread: {
+        id: 'thread-new-1',
+        path: expect.stringMatching(/\/sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-thread-new-1\.jsonl$/),
+        ephemeral: false,
+      },
       wsUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
     })
   })
@@ -212,8 +237,55 @@ describe('CodexAppServerRuntime', () => {
       threadId: '019d9859-5670-72b1-851f-794ad7fef112',
       cwd: '/repo/worktree',
     })).resolves.toEqual({
-      threadId: '019d9859-5670-72b1-851f-794ad7fef112',
+      thread: {
+        id: '019d9859-5670-72b1-851f-794ad7fef112',
+        path: expect.stringMatching(/rollout-019d9859-5670-72b1-851f-794ad7fef112\.jsonl$/),
+        ephemeral: false,
+      },
       wsUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
     })
+  })
+
+  it('passes thread and fs watch notifications through runtime subscribers', async () => {
+    const rolloutPath = '/repo/worktree/.codex/sessions/2026/04/23/rollout-thread-new-1.jsonl'
+    const runtime = createRuntime({
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          notifyAfterMethodsOnce: {
+            'fs/watch': [
+              {
+                method: 'fs/changed',
+                params: {
+                  watchId: 'watch-rollout',
+                  changedPaths: [rolloutPath],
+                },
+              },
+            ],
+          },
+        }),
+      },
+    })
+
+    const startedThread = new Promise<{ id: string; path: string | null; ephemeral: boolean }>((resolve) => {
+      runtime.onThreadStarted((thread) => resolve(thread))
+    })
+    const changedEvent = new Promise<{ watchId: string; changedPaths: string[] }>((resolve) => {
+      runtime.onFsChanged((event) => resolve(event))
+    })
+
+    await runtime.startThread({ cwd: '/repo/worktree' })
+    await expect(startedThread).resolves.toEqual({
+      id: 'thread-new-1',
+      path: expect.stringMatching(/\/sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-thread-new-1\.jsonl$/),
+      ephemeral: false,
+    })
+    await expect(runtime.watchPath(rolloutPath, 'watch-rollout')).resolves.toEqual({
+      path: rolloutPath,
+    })
+    await expect(changedEvent).resolves.toEqual({
+      watchId: 'watch-rollout',
+      changedPaths: [rolloutPath],
+    })
+    await expect(runtime.unwatchPath('watch-rollout')).resolves.toBeUndefined()
   })
 })

--- a/test/unit/server/coding-cli/codex-app-server/sidecar.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/sidecar.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import fsp from 'node:fs/promises'
+import { spawn, type ChildProcess } from 'node:child_process'
+import os from 'node:os'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { CodexTerminalSidecar } from '../../../../../server/coding-cli/codex-app-server/sidecar.js'
+
+const SIDECAR_OWNERSHIP_DIR = path.join(os.tmpdir(), 'freshell-codex-sidecars')
+const children = new Set<ChildProcess>()
+
+async function waitForProcessExit(pid: number, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ESRCH') {
+        return
+      }
+      throw error
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error(`Timed out waiting for process ${pid} to exit`)
+}
+
+async function readLinuxProcessIdentity(pid: number): Promise<{
+  commandLine: string[]
+  cwd: string
+  startTimeTicks: string
+}> {
+  const [cmdlineRaw, cwd, statRaw] = await Promise.all([
+    fsp.readFile(`/proc/${pid}/cmdline`, 'utf8'),
+    fsp.readlink(`/proc/${pid}/cwd`),
+    fsp.readFile(`/proc/${pid}/stat`, 'utf8'),
+  ])
+  const statFields = statRaw.trim().split(' ')
+  return {
+    commandLine: cmdlineRaw.split('\0').filter(Boolean),
+    cwd,
+    startTimeTicks: statFields[21] ?? '',
+  }
+}
+
+afterEach(async () => {
+  await Promise.all([...children].map(async (child) => {
+    children.delete(child)
+    if (child.exitCode !== null || child.signalCode !== null) {
+      return
+    }
+    child.kill('SIGKILL')
+    await new Promise<void>((resolve) => child.once('exit', () => resolve()))
+  }))
+
+  const entries = await fsp.readdir(SIDECAR_OWNERSHIP_DIR, { withFileTypes: true }).catch(() => [])
+  await Promise.all(entries.map(async (entry) => {
+    if (entry.isFile() && entry.name.endsWith('.json')) {
+      await fsp.rm(path.join(SIDECAR_OWNERSHIP_DIR, entry.name), { force: true }).catch(() => undefined)
+    }
+  }))
+})
+
+describe('CodexTerminalSidecar orphan reaper', () => {
+  it('refuses to SIGTERM a live pid when ownership metadata lacks a verified process match', async () => {
+    await fsp.mkdir(SIDECAR_OWNERSHIP_DIR, { recursive: true })
+    const metadataPath = path.join(SIDECAR_OWNERSHIP_DIR, `${randomUUID()}.json`)
+    await fsp.writeFile(metadataPath, JSON.stringify({
+      pid: process.pid,
+      wsUrl: 'ws://127.0.0.1:4545',
+      codexHome: '/tmp/fake-codex-home',
+      terminalId: 'term-mismatch',
+      createdAt: new Date().toISOString(),
+    }), 'utf8')
+
+    const killSpy = vi.spyOn(process, 'kill')
+
+    await CodexTerminalSidecar.reapOrphanedSidecars()
+
+    expect(killSpy).not.toHaveBeenCalledWith(process.pid, 'SIGTERM')
+  })
+
+  it('SIGTERMs only a pid whose command line, cwd, and start time still match the recorded sidecar', async () => {
+    const wsUrl = 'ws://127.0.0.1:4546'
+    const child = spawn(process.execPath, [
+      '-e',
+      'setInterval(() => {}, 1000)',
+      'app-server',
+      '--listen',
+      wsUrl,
+    ], {
+      cwd: process.cwd(),
+      stdio: 'ignore',
+    })
+    children.add(child)
+
+    if (!child.pid) {
+      throw new Error('Failed to spawn test sidecar process')
+    }
+
+    const identity = await readLinuxProcessIdentity(child.pid)
+    await fsp.mkdir(SIDECAR_OWNERSHIP_DIR, { recursive: true })
+    const metadataPath = path.join(SIDECAR_OWNERSHIP_DIR, `${randomUUID()}.json`)
+    await fsp.writeFile(metadataPath, JSON.stringify({
+      pid: child.pid,
+      wsUrl,
+      codexHome: '/tmp/test-codex-home',
+      terminalId: 'term-owned',
+      createdAt: new Date().toISOString(),
+      process: identity,
+    }), 'utf8')
+
+    await CodexTerminalSidecar.reapOrphanedSidecars()
+    await waitForProcessExit(child.pid)
+  })
+})
+
+describe('CodexTerminalSidecar durable rollout tracking', () => {
+  it('forwards thread handles into the exact-path tracker and promotes when the tracker confirms durability', () => {
+    let threadStartedHandler: ((thread: { id: string; path: string | null; ephemeral: boolean }) => void) | null = null
+    let trackerOptions:
+      | {
+        onDurableRollout: (sessionId: string) => void
+      }
+      | null = null
+
+    const runtime = {
+      onExit: vi.fn(() => () => undefined),
+      onThreadStarted: vi.fn((handler) => {
+        threadStartedHandler = handler
+        return () => {
+          threadStartedHandler = null
+        }
+      }),
+      shutdown: vi.fn(async () => undefined),
+      ensureReady: vi.fn(async () => ({
+        wsUrl: 'ws://127.0.0.1:4567',
+        processPid: 101,
+        codexHome: '/tmp/fake-codex-home',
+      })),
+    }
+
+    const tracker = {
+      trackThread: vi.fn(),
+      dispose: vi.fn(async () => undefined),
+    }
+
+    const sidecar = new CodexTerminalSidecar({
+      runtime: runtime as any,
+      createDurableRolloutTracker: (options) => {
+        trackerOptions = {
+          onDurableRollout: options.onDurableRollout,
+        }
+        return tracker
+      },
+    })
+
+    const onDurableSession = vi.fn()
+    sidecar.attachTerminal({
+      terminalId: 'term-1',
+      onDurableSession,
+      onFatal: vi.fn(),
+    })
+
+    const thread = {
+      id: 'thread-new-1',
+      path: '/tmp/fake-codex-home/sessions/2026/04/23/rollout-thread-new-1.jsonl',
+      ephemeral: false,
+    }
+    threadStartedHandler?.(thread)
+
+    expect(tracker.trackThread).toHaveBeenCalledWith(thread)
+    trackerOptions?.onDurableRollout('thread-new-1')
+    expect(onDurableSession).toHaveBeenCalledWith('thread-new-1')
+  })
+
+  it('disposes the rollout tracker before shutting the runtime down', async () => {
+    const lifecycle: string[] = []
+    const runtime = {
+      onExit: vi.fn(() => () => undefined),
+      onThreadStarted: vi.fn(() => () => undefined),
+      shutdown: vi.fn(async () => {
+        lifecycle.push('runtime')
+      }),
+      ensureReady: vi.fn(async () => ({
+        wsUrl: 'ws://127.0.0.1:4567',
+        processPid: 101,
+        codexHome: '/tmp/fake-codex-home',
+      })),
+    }
+    const tracker = {
+      trackThread: vi.fn(),
+      dispose: vi.fn(async () => {
+        lifecycle.push('tracker')
+      }),
+    }
+
+    const sidecar = new CodexTerminalSidecar({
+      runtime: runtime as any,
+      createDurableRolloutTracker: () => tracker,
+    })
+
+    await sidecar.shutdown()
+
+    expect(lifecycle).toEqual(['tracker', 'runtime'])
+  })
+
+  it('does not boot a stopped runtime just to unwatch during tracker cleanup', async () => {
+    let trackerOptions:
+      | {
+        unwatchPath: (watchId: string) => Promise<void>
+      }
+      | null = null
+
+    const runtime = {
+      status: vi.fn(() => 'stopped'),
+      unwatchPath: vi.fn(async () => undefined),
+      onExit: vi.fn(() => () => undefined),
+      onThreadStarted: vi.fn(() => () => undefined),
+      shutdown: vi.fn(async () => undefined),
+      ensureReady: vi.fn(async () => ({
+        wsUrl: 'ws://127.0.0.1:4567',
+        processPid: 101,
+        codexHome: '/tmp/fake-codex-home',
+      })),
+    }
+
+    new CodexTerminalSidecar({
+      runtime: runtime as any,
+      createDurableRolloutTracker: (options) => {
+        trackerOptions = {
+          unwatchPath: options.unwatchPath,
+        }
+        return {
+          trackThread: vi.fn(),
+          dispose: vi.fn(async () => undefined),
+        }
+      },
+    })
+
+    await trackerOptions?.unwatchPath('watch-rollout')
+    expect(runtime.unwatchPath).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/server/mcp/freshell-tool.test.ts
+++ b/test/unit/server/mcp/freshell-tool.test.ts
@@ -82,6 +82,26 @@ describe('executeAction -- tab actions', () => {
     expect(mockClient.post).toHaveBeenCalledWith('/api/tabs', expect.objectContaining({ name: 'Work', mode: 'claude' }))
   })
 
+  it('new-tab maps resume to canonical sessionRef instead of legacy resumeSessionId', async () => {
+    mockClient.post.mockResolvedValue({ id: 't1' })
+
+    await executeAction('new-tab', {
+      name: 'Resume Work',
+      mode: 'claude',
+      resume: '550e8400-e29b-41d4-a716-446655440000',
+    })
+
+    expect(mockClient.post).toHaveBeenCalledWith('/api/tabs', expect.objectContaining({
+      name: 'Resume Work',
+      mode: 'claude',
+      sessionRef: {
+        provider: 'claude',
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      },
+    }))
+    expect(mockClient.post.mock.calls.at(-1)?.[1]).not.toHaveProperty('resumeSessionId')
+  })
+
   it('list-tabs calls GET /api/tabs', async () => {
     mockClient.get.mockResolvedValue({ tabs: [] })
     await executeAction('list-tabs')

--- a/test/unit/server/session-repair-service.test.ts
+++ b/test/unit/server/session-repair-service.test.ts
@@ -58,7 +58,7 @@ describe('SessionRepairService', () => {
     const projectDir = path.join(tempDir, '.claude', 'projects', 'test-project')
     await fs.mkdir(projectDir, { recursive: true })
 
-    const sessionId = 'priority-session'
+    const sessionId = '00000000-0000-4000-8000-000000000711'
     const sessionFile = path.join(projectDir, `${sessionId}.jsonl`)
     await fs.writeFile(sessionFile, createTranscript(sessionId, '/tmp/project'))
 
@@ -95,8 +95,8 @@ describe('SessionRepairService', () => {
     const projectDir = path.join(tempDir, '.claude', 'projects', 'test-project')
     await fs.mkdir(projectDir, { recursive: true })
 
-    const slowSessionId = 'slow-session'
-    const targetSessionId = 'target-session'
+    const slowSessionId = '00000000-0000-4000-8000-000000000712'
+    const targetSessionId = '00000000-0000-4000-8000-000000000713'
     const slowFile = path.join(projectDir, `${slowSessionId}.jsonl`)
     const targetFile = path.join(projectDir, `${targetSessionId}.jsonl`)
     await fs.writeFile(slowFile, createTranscript(slowSessionId, '/tmp/slow-project'))
@@ -208,7 +208,7 @@ describe('SessionRepairService', () => {
     const projectDir = path.join(tempDir, '.claude', 'projects', 'test-project')
     await fs.mkdir(projectDir, { recursive: true })
 
-    const sessionId = 'stop-drain-session'
+    const sessionId = '00000000-0000-4000-8000-000000000714'
     const sessionFile = path.join(projectDir, `${sessionId}.jsonl`)
     await fs.writeFile(sessionFile, createTranscript(sessionId, '/tmp/project'))
 
@@ -265,7 +265,7 @@ describe('SessionRepairService', () => {
     const projectDir = path.join(tempDir, '.claude', 'projects', 'test-project')
     await fs.mkdir(projectDir, { recursive: true })
 
-    const sessionId = 'history-failure-session'
+    const sessionId = '00000000-0000-4000-8000-000000000715'
     const sessionFile = path.join(projectDir, `${sessionId}.jsonl`)
     await fs.writeFile(sessionFile, createTranscript(sessionId, '/tmp/project'))
 
@@ -325,7 +325,7 @@ describe('SessionRepairService', () => {
     const projectDir = path.join(tempDir, '.claude', 'projects', 'test-project')
     await fs.mkdir(projectDir, { recursive: true })
 
-    const targetSessionId = 'target-session'
+    const targetSessionId = '00000000-0000-4000-8000-000000000716'
     const targetFile = path.join(projectDir, `${targetSessionId}.jsonl`)
     await fs.writeFile(targetFile, createTranscript(targetSessionId, '/tmp/target'))
 

--- a/test/unit/server/terminal-registry.test.ts
+++ b/test/unit/server/terminal-registry.test.ts
@@ -2460,6 +2460,47 @@ describe('TerminalRegistry', () => {
     })
   })
 
+  describe('codex sidecar callbacks during create', () => {
+    it('registers the terminal before a synchronous durable-session callback fires', () => {
+      let terminalSeenDuringAttach: string | undefined
+
+      const term = registry.create({
+        mode: 'codex',
+        cwd: '/home/user/project',
+        codexSidecar: {
+          attachTerminal: ({ terminalId, onDurableSession }) => {
+            terminalSeenDuringAttach = registry.get(terminalId)?.terminalId
+            onDurableSession('codex-session-sync')
+          },
+          shutdown: vi.fn().mockResolvedValue(undefined),
+        },
+      })
+
+      expect(terminalSeenDuringAttach).toBe(term.terminalId)
+      expect(registry.get(term.terminalId)?.resumeSessionId).toBe('codex-session-sync')
+      expect(registry.isSessionBound('codex', 'codex-session-sync')).toBe(true)
+    })
+
+    it('lets a synchronous fatal callback terminate the newly created terminal', () => {
+      let createdTerminalId: string | undefined
+
+      const term = registry.create({
+        mode: 'codex',
+        cwd: '/home/user/project',
+        codexSidecar: {
+          attachTerminal: ({ terminalId, onFatal }) => {
+            createdTerminalId = terminalId
+            onFatal(new Error('sidecar failed during attach'))
+          },
+          shutdown: vi.fn().mockResolvedValue(undefined),
+        },
+      })
+
+      expect(createdTerminalId).toBe(term.terminalId)
+      expect(registry.get(term.terminalId)?.status).toBe('exited')
+    })
+  })
+
   describe('isSessionBound', () => {
     it('returns true when session is already bound to a terminal', () => {
       const term = registry.create({ mode: 'codex', resumeSessionId: '019cf585-9b35-7510-a99c-09b77b1f351a' })

--- a/test/unit/shared/session-contract.test.ts
+++ b/test/unit/shared/session-contract.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RestoreErrorSchema,
+  SessionRefSchema,
+  buildRestoreError,
+  migrateLegacyAgentChatDurableState,
+  migrateLegacyTerminalDurableState,
+  sanitizeSessionRef,
+} from '@shared/session-contract'
+
+const VALID_CLAUDE_SESSION_ID = '550e8400-e29b-41d4-a716-446655440000'
+
+describe('session-contract', () => {
+  describe('SessionRefSchema', () => {
+    it('accepts canonical durable session refs', () => {
+      const parsed = SessionRefSchema.safeParse({
+        provider: 'codex',
+        sessionId: 'sess-123',
+      })
+
+      expect(parsed.success).toBe(true)
+      if (!parsed.success) return
+
+      expect(parsed.data).toEqual({
+        provider: 'codex',
+        sessionId: 'sess-123',
+      })
+    })
+
+    it('rejects serverInstanceId inside canonical durable identity', () => {
+      const parsed = SessionRefSchema.safeParse({
+        provider: 'codex',
+        sessionId: 'sess-123',
+        serverInstanceId: 'srv-local',
+      })
+
+      expect(parsed.success).toBe(false)
+    })
+  })
+
+  describe('sanitizeSessionRef', () => {
+    it('drops locality fields when sanitizing canonical identity', () => {
+      expect(sanitizeSessionRef({
+        provider: 'codex',
+        sessionId: 'sess-123',
+        serverInstanceId: 'srv-local',
+      })).toEqual({
+        provider: 'codex',
+        sessionId: 'sess-123',
+      })
+    })
+  })
+
+  describe('migrateLegacyTerminalDurableState', () => {
+    it('promotes legacy claude UUID resume ids to canonical sessionRef', () => {
+      expect(migrateLegacyTerminalDurableState({
+        provider: 'claude',
+        resumeSessionId: VALID_CLAUDE_SESSION_ID,
+      })).toEqual({
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_CLAUDE_SESSION_ID,
+        },
+      })
+    })
+
+    it('marks legacy codex fresh thread ids as restore-unavailable', () => {
+      expect(migrateLegacyTerminalDurableState({
+        provider: 'codex',
+        resumeSessionId: 'thread-new-1',
+      })).toEqual({
+        restoreError: {
+          code: 'RESTORE_UNAVAILABLE',
+          reason: 'invalid_legacy_restore_target',
+        },
+      })
+    })
+  })
+
+  describe('migrateLegacyAgentChatDurableState', () => {
+    it('promotes canonical Claude CLI identity for agent-chat panes', () => {
+      expect(migrateLegacyAgentChatDurableState({
+        cliSessionId: VALID_CLAUDE_SESSION_ID,
+        resumeSessionId: 'named-resume',
+      })).toEqual({
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_CLAUDE_SESSION_ID,
+        },
+      })
+    })
+
+    it('marks legacy raw agent-chat resume ids as restore-unavailable when no canonical Claude id exists', () => {
+      expect(migrateLegacyAgentChatDurableState({
+        resumeSessionId: VALID_CLAUDE_SESSION_ID,
+      })).toEqual({
+        restoreError: {
+          code: 'RESTORE_UNAVAILABLE',
+          reason: 'invalid_legacy_restore_target',
+        },
+      })
+    })
+  })
+
+  describe('RestoreErrorSchema', () => {
+    it('accepts canonical restore-unavailable payloads', () => {
+      const restoreError = buildRestoreError('dead_live_handle')
+      const parsed = RestoreErrorSchema.safeParse(restoreError)
+
+      expect(parsed.success).toBe(true)
+      if (!parsed.success) return
+
+      expect(parsed.data).toEqual({
+        code: 'RESTORE_UNAVAILABLE',
+        reason: 'dead_live_handle',
+      })
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       '**/.worktrees/**',
       '**/.claude/worktrees/**',
       'docs/plans/**',
+      ...(process.env.FRESHELL_REAL_PROVIDER_CONTRACTS === '1' ? [] : ['test/integration/real/**']),
       // Server tests run under vitest.server.config.ts (node environment)
       'test/server/**',
       'test/unit/server/**',


### PR DESCRIPTION
## Summary
- introduce an explicit durable session contract so live runtime handles are separated from durable restore identities across Codex, Claude, FreshClaude, and OpenCode
- make provider promotion authoritative from durable artifacts and events, including exact-path Codex rollout tracking from app-server `thread.path` and `fs/watch` instead of scanning `~/.codex/sessions`
- propagate the contract through session repair, WebSocket snapshots, persistence, sidebar and background-session UI, and pane or tab restore flows
- add real-provider probes plus integration, unit, and e2e coverage to lock the contract in place

## Testing
- `npm test`
- `FRESHELL_REAL_PROVIDER_CONTRACTS=1 npm run test:vitest -- test/integration/real/coding-cli-session-contract.test.ts`
