### PR TITLE
fix(codex): start sidecars in requested cwd

### DIFF
--- a/server/coding-cli/codex-app-server/launch-planner.ts
+++ b/server/coding-cli/codex-app-server/launch-planner.ts
@@ -35,6 +35,10 @@ type PlanCreateInput = {
   approvalPolicy?: string
 }
 
+type RuntimeCreateInput = {
+  cwd?: string
+}
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
@@ -53,11 +57,11 @@ export function isCodexSidecarTeardownError(error: unknown): error is CodexSidec
 export class CodexLaunchPlanner {
   private readonly activeSidecars = new Set<CodexLaunchSidecar>()
   private readonly failedSidecarShutdowns = new Set<CodexLaunchSidecar>()
-  private readonly runtimeFactory: () => CodexRuntimeLike
+  private readonly runtimeFactory: (input: RuntimeCreateInput) => CodexRuntimeLike
   private shutdownStarted = false
   private shutdownPromise: Promise<void> | null = null
 
-  constructor(runtimeOrFactory: CodexRuntimeLike | (() => CodexRuntimeLike)) {
+  constructor(runtimeOrFactory: CodexRuntimeLike | ((input: RuntimeCreateInput) => CodexRuntimeLike)) {
     this.runtimeFactory = typeof runtimeOrFactory === 'function'
       ? runtimeOrFactory
       : () => runtimeOrFactory
@@ -68,7 +72,7 @@ export class CodexLaunchPlanner {
     await this.retryFailedSidecarShutdownsBeforePlan()
     this.assertAcceptingPlans()
 
-    const runtime = this.runtimeFactory()
+    const runtime = this.runtimeFactory({ cwd: input.cwd })
     const sidecar = this.createSidecar(runtime)
     this.activeSidecars.add(sidecar)
 

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -5,6 +5,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { allocateLocalhostPort, type LoopbackServerEndpoint } from '../../local-port.js'
 import { logger } from '../../logger.js'
+import { convertWindowsPathToWslPath, isWslEnvironment, sanitizeUserPathInput } from '../../path-utils.js'
 import {
   CodexAppServerClient,
   type CodexThreadLifecycleEvent,
@@ -65,6 +66,7 @@ type ChildProcessHandle = ReturnType<typeof spawn>
 type RuntimeOptions = {
   command?: string
   commandArgs?: string[]
+  cwd?: string
   env?: NodeJS.ProcessEnv
   requestTimeoutMs?: number
   startupAttemptLimit?: number
@@ -98,6 +100,16 @@ const OWNERSHIP_SCHEMA_VERSION = 1
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function resolveAppServerCwd(cwd: string | undefined): string | undefined {
+  if (typeof cwd !== 'string') return undefined
+  const candidate = sanitizeUserPathInput(cwd)
+  if (!candidate) return undefined
+  if (isWslEnvironment()) {
+    return convertWindowsPathToWslPath(candidate) ?? candidate
+  }
+  return candidate
 }
 
 function defaultMetadataDir(): string {
@@ -509,6 +521,7 @@ export class CodexAppServerRuntime {
 
   private readonly command: string
   private readonly commandArgs: string[]
+  private readonly cwd?: string
   private readonly env?: NodeJS.ProcessEnv
   private readonly requestTimeoutMs?: number
   private readonly startupAttemptLimit: number
@@ -523,6 +536,7 @@ export class CodexAppServerRuntime {
   constructor(options: RuntimeOptions = {}) {
     this.command = options.command ?? (process.env.CODEX_CMD || 'codex')
     this.commandArgs = options.commandArgs ?? []
+    this.cwd = resolveAppServerCwd(options.cwd)
     this.env = options.env
     this.requestTimeoutMs = options.requestTimeoutMs
     this.startupAttemptLimit = options.startupAttemptLimit ?? DEFAULT_STARTUP_ATTEMPT_LIMIT
@@ -695,6 +709,7 @@ export class CodexAppServerRuntime {
         wsUrl,
       ], {
         detached: true,
+        ...(this.cwd ? { cwd: this.cwd } : {}),
         env: {
           ...process.env,
           ...this.env,

--- a/server/index.ts
+++ b/server/index.ts
@@ -298,7 +298,10 @@ async function main() {
   sdkBridge = new SdkBridge(agentHistorySource)
 
   const server = http.createServer(app)
-  const codexLaunchPlanner = new CodexLaunchPlanner(() => new CodexAppServerRuntime({ serverInstanceId }))
+  const codexLaunchPlanner = new CodexLaunchPlanner((input) => new CodexAppServerRuntime({
+    serverInstanceId,
+    cwd: input.cwd,
+  }))
   const wsHandler = new WsHandler(
     server,
     registry,

--- a/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
@@ -71,7 +71,9 @@ class FakeRuntime {
 describe('CodexLaunchPlanner', () => {
   it('creates a distinct owned sidecar for each launch plan', async () => {
     const runtimes: FakeRuntime[] = []
-    const planner = new CodexLaunchPlanner(() => {
+    const runtimeInputs: Array<{ cwd?: string }> = []
+    const planner = new CodexLaunchPlanner((input) => {
+      runtimeInputs.push(input)
       const index = runtimes.length + 1
       const runtime = new FakeRuntime(`ws://127.0.0.1:${43000 + index}`, `thread-${index}`)
       runtimes.push(runtime)
@@ -82,6 +84,7 @@ describe('CodexLaunchPlanner', () => {
     const second = await planner.planCreate({ cwd: '/repo/two' })
 
     expect(runtimes).toHaveLength(2)
+    expect(runtimeInputs).toEqual([{ cwd: '/repo/one' }, { cwd: '/repo/two' }])
     expect(first.remote.wsUrl).toBe('ws://127.0.0.1:43001')
     expect(second.remote.wsUrl).toBe('ws://127.0.0.1:43002')
 

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -263,6 +263,16 @@ describe('CodexAppServerRuntime', () => {
     }
   })
 
+  it('starts the app-server process in the requested cwd', async () => {
+    if (process.platform !== 'linux') return
+    const runtimeCwd = await makeTempDir()
+    const runtime = createRuntime({ cwd: runtimeCwd })
+
+    const ready = await runtime.ensureReady()
+
+    await expect(fsp.readlink(`/proc/${ready.processPid}/cwd`)).resolves.toBe(runtimeCwd)
+  })
+
   it('reuses the same process for repeated ensureReady calls on one runtime', async () => {
     const runtime = createRuntime()
 


### PR DESCRIPTION
Updated to resolve the pairwise dev-queue conflict with PR #321.

Notes:
- Kept #309's root-cause startup behavior focused for independent review.
- Moved the new cwd runtime test away from #321's runtime startup test insertion so both PRs compose cleanly.
- Verified #309 now composes with #321 when both are applied to origin/main.

Verification:
- npm run test:server -- --run test/unit/server/coding-cli/codex-app-server/runtime.test.ts