### PR TITLE
Fix Codex sidecar lifecycle recovery

### DIFF
--- a/docs/debug-codex-app-server-leak.md
+++ b/docs/debug-codex-app-server-leak.md
@@ -1,0 +1,353 @@
+# Codex Sidecar Lifecycle Architecture Brief
+
+Worktree: `.worktrees/debug-codex-app-server-leak` (branch `debug/codex-app-server-leak`).
+
+## Goal
+
+Freshell always clears dead Codex sidecar sessions at the correct lifecycle boundary, without operator cleanup and without risking live panes.
+
+This is a go-forward lifecycle fix. Historical orphans from the pre-ownership implementation are out of scope for runtime automation and should be handled only by a separately approved one-time cleanup with an exact process list.
+
+## Recommendation
+
+Keep per-terminal Codex sidecars and add real ownership for the whole wrapper/native app-server bundle.
+
+The smallest solid fix is not a global process reconciler and not a rollback to PR298-era shared app-server runtime. It is an atomic change across six already-coupled boundaries:
+
+1. `CodexAppServerRuntime` owns one sidecar process group from spawn through verified teardown.
+2. Ownership metadata exists immediately after spawn, before app-server `initialize`.
+3. Durable recovery readiness uses candidate-local app-server state, not observer notifications that are not guaranteed for `thread/resume`.
+4. Verified teardown failure becomes sticky blocking state for the owner that observed it; later startup, recovery, create, publish, and retry paths must not progress past that ownership until it is verified gone or the server is exiting.
+5. Registry retries, recovery publication, final close, and shutdown await sidecar teardown before moving to the next lifecycle state.
+6. Server shutdown creates an admission barrier before joining registry and planner shutdown work, so existing WebSocket clients cannot create new Codex sidecars during shutdown.
+
+These pieces must ship together. Process ownership without readiness still leaves users in false recovery loops. Readiness without process ownership still leaks on future startup and candidate failures. Retry changes without initial-create and shutdown coverage leave non-recovery leaks behind. Verified teardown without sticky blocking state only moves the leak to the next lifecycle entry point.
+
+## Current Architecture
+
+Each Codex pane is a bundle:
+
+- a visible worker PTY running `codex --remote <wsUrl> ...`
+- an invisible app-server sidecar running `codex app-server --listen <wsUrl>`
+- optional MCP temp state
+- current generation and durable session identity tracked by `TerminalRegistry`
+
+The sidecar process launched by Freshell is not the long-lived native process. On this installation the command shape is:
+
+```text
+node <npm-prefix>/bin/codex ... app-server --listen ws://127.0.0.1:NNNNN
+  +-- <npm-prefix>/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex/codex \
+       ... app-server --listen ws://127.0.0.1:NNNNN
+```
+
+Current code records and signals the wrapper PID returned by `spawn()`. The native child can survive if the wrapper exits hard or is killed while the child keeps running. On the observed machine, orphaned native children reparented to the WSL `/init` shim with a non-1 parent PID from Freshell's point of view, so cleanup or diagnostics must not rely on `PPID == 1`.
+
+## Root Cause
+
+Freshell models the app-server sidecar as a child process, but operationally it is a wrapper/native process group.
+
+Five whys:
+
+1. Why did dead app-server sessions remain? Because `runtime.stopActiveChild()` signals only the spawned wrapper PID and does not prove the native app-server child is gone.
+2. Why was Freshell blind after the wrapper exited? Because ownership metadata records the wrapper PID and the reaper removes metadata when that PID no longer exists.
+3. Why can a sidecar exist without an ownership record? Because metadata is written only after `ensureReady()` receives app-server readiness; startup, initialize, create, or recovery failures can happen before then.
+4. Why did failures multiply? Because per-terminal sidecars plus durable recovery candidates made the latent wrapper/native bug happen once per pane or retry, and the retry loop is intentionally unbounded.
+5. Why did killing by process name hurt live panes? Because live and dead app-servers have the same native command shape; deadness was inferred from process name instead of Freshell ownership state.
+
+The second active failure is independent but coupled: durable recovery waits for observer-side `thread/started` or idle `thread/status/changed` evidence after spawning `codex --remote <wsUrl> resume <sessionId>`. The remote TUI owns the `thread/resume` response, and the app-server protocol does not guarantee a `thread/started` notification for resume. The official Codex app-server README documents `thread/loaded/list` for loaded in-memory thread ids and says clients should send `initialized` after `initialize`: <https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md>.
+
+## Why Not Revert PR298-Era Architecture
+
+The PR298-era shared app-server runtime would lower process count, but it reopens larger ownership problems:
+
+- A single shared app-server changes the failure domain. One pane's failed recovery candidate cannot be torn down independently without affecting unrelated panes.
+- The earlier planner pre-created or resumed Codex sessions before PTY adoption. If terminal creation failed after planning, durable sessions could be orphaned.
+- Current recovery logic treats a generation bundle as sidecar plus remote TUI PTY plus MCP state. Shared runtime does not match that boundary.
+- Current per-sidecar runtime has fixes worth preserving: cwd/environment scoping, stdio draining, startup retry behavior, and disconnect fatal handling.
+
+The regression after PR298 was not "per-terminal sidecars are wrong." It was "per-terminal sidecars inherited wrapper-only ownership and readiness assumptions that were acceptable only while the blast radius was small."
+
+## Alternatives Considered
+
+### A. Per-terminal sidecars with real bundle ownership
+
+Recommended.
+
+This keeps the current isolation and recovery model while fixing the real resource boundary. Each sidecar gets its own process group, an ownership id, early metadata, and verified teardown. Registry state remains responsible for current/candidate generation decisions.
+
+### B. Roll back toward a shared app-server runtime
+
+Rejected.
+
+This is a larger architectural move than the bug requires. It changes pane isolation, candidate teardown, MCP state coupling, and durable session adoption semantics. It also risks reintroducing pre-created-session ownership bugs from the PR298 era.
+
+### C. Minimal PID-only patch over current classes
+
+Rejected.
+
+Killing and recording only the wrapper PID cannot prove the native child is gone. Adding more retries, warning logs, or runbook cleanup would hide the symptom and leave the failure mode intact.
+
+### D. Global process-name reconciler
+
+Rejected.
+
+Historical sidecars were not launched in their own process groups; a prior snapshot showed leaked native processes in the same process group as the running Freshell server. Runtime cleanup must not scan by command name or assume `/init` parentage means dead.
+
+## Proposed Atomic Design
+
+### 1. Sidecar process ownership
+
+Create a small ownership layer in `CodexAppServerRuntime`. The runtime owns the ownership id, process group, metadata file, and teardown proof because it is the only class that controls spawn and shutdown. `CodexTerminalSidecar` should only enrich the runtime-owned record with terminal/generation/codexHome details and delegate shutdown to the runtime.
+
+The runtime creates an `ownershipId` before spawn and launches the sidecar wrapper with:
+
+- a Unix process group owned by the runtime (`detached: true` on Unix)
+- inherited `FRESHELL_CODEX_SIDECAR_ID=<ownershipId>`
+- a new-schema metadata file written immediately after successful spawn and before any app-server `initialize` attempt
+
+Minimum metadata fields:
+
+- `schemaVersion`
+- `ownershipId`
+- `serverInstanceId`
+- `ownerServerPid`
+- `terminalId` or `null`
+- `generation` or `null`
+- `wsUrl`
+- `wrapperPid`
+- `processGroupId`
+- wrapper process identity using the existing Linux identity shape: command line, cwd, and start-time ticks
+- `createdAt`
+- `updatedAt`
+- optional `codexHome`
+
+Do not put registry-only state such as `role`, `candidate`, `retiring`, or durable readiness into the process metadata unless implementation proves it is necessary. The registry already owns generation state.
+
+If the metadata write fails after spawn, startup fails and the runtime tears the process group down before retrying. Freshell must not continue with an unowned sidecar. If wrapper identity cannot be read after spawn, that missing identity is itself a startup failure. The runtime still owns the newly created process group by `ownershipId` and `processGroupId`, must not continue to app-server initialize or ready publication with empty wrapper identity metadata, and must attempt verified teardown before any retry.
+
+### 2. Verified process-group teardown
+
+`CodexAppServerRuntime.shutdown()` tears down the process group, not just `child.pid`.
+
+Teardown sequence:
+
+1. Close the app-server client best-effort.
+2. Verify the process group still belongs to the ownership record using process group id plus wrapper identity or inherited ownership id on a group member. Wrapper identity proof is valid only when the recorded wrapper PID is currently a member of the recorded `processGroupId`, and the current wrapper identity matches the stored command line, cwd, and start-time ticks. A matching wrapper PID/start time must not authorize signals to a different process group. Ownership-id proof is valid only when the matching process is a member of the recorded `processGroupId`.
+3. Send `SIGTERM` to the process group with the Unix group-signal form, `process.kill(-processGroupId, 'SIGTERM')`.
+4. Wait until the owned group is gone. On Linux this can be checked with `process.kill(-processGroupId, 0)` returning `ESRCH`, backed by `/proc` group-member scanning when diagnostics need exact remaining PIDs. If `/proc` cannot be read, ownership proof is unavailable; an empty or failed scan must not be treated as evidence that a live process group is gone.
+5. If still alive after the grace period, reverify ownership and send `SIGKILL` with `process.kill(-processGroupId, 'SIGKILL')`.
+6. Wait until the owned group is gone.
+7. Remove metadata only after verified teardown.
+
+If verification cannot prove ownership, throw a structured teardown error and leave metadata in place for diagnosis. The owner enters a blocking teardown-failed state for that ownership. The runtime must preserve the failed ownership record and refuse future `ensureReady()`, `listLoadedThreads()`, `adopt()`, or startup work on that runtime until the ownership is verified gone or the server process exits. Registry and planner callers must treat that error as a failed lifecycle boundary, not as best-effort cleanup.
+
+The teardown-failed state is sticky across asynchronous stimuli. A later wrapper exit, lifecycle-loss notification, retry timer, create request, or shutdown callback must join or report the same failed ownership instead of starting a sibling sidecar that overwrites it.
+
+Sticky teardown failure also means the owner retains a joinable handle. Do not reduce a failed sidecar teardown to only a stored error, log line, or cleared local variable. Runtime ownership, planner-owned sidecars, registry current sidecars, recovery candidates, retiring sidecars, natural PTY-exit shutdowns, and close/shutdown join sets may remove their sidecar handle or shutdown promise only after verified teardown succeeds, ownership transfers to another explicit owner, or the server process exits.
+
+On unsupported platforms, fail clearly before spawning. The Unix implementation may rely on process groups plus Linux `/proc` ownership proof; if the platform cannot provide the proof this design requires, Codex sidecar mode should reject startup before it creates an app-server process. If Windows behavior must be supported in the same PR, stop and design a platform-appropriate owner such as a job object.
+
+### 3. Startup cleanup for new-schema records only
+
+Replace the existing PID-only `reapOrphanedSidecars()` behavior with a new-schema reaper. Startup cleanup should read ownership records written by this fixed implementation. It may reap only sidecars that it can prove are stale and owned:
+
+- the record is new schema
+- the owning server process recorded in metadata is gone
+- the process group is not Freshell's current process group
+- the process group ownership proof still matches the record
+
+Startup reaper failure is a startup blocker, not a warning fallback. If the new-schema reaper throws while reading, verifying, signaling, waiting for teardown, or removing verified-dead metadata, Freshell must fail startup before accepting Codex creates. The same rule applies when the reaper returns unreaped new-schema ownership records.
+
+Unreaped new-schema records are not successful cleanup merely because the recorded `ownerServerPid` is currently live or because the recorded process group matches Freshell's current process group. PID liveness alone does not prove that the original owning server still owns the sidecar; it may be PID reuse or unrelated process state. Current-process-group matches must not be signaled, but unless the reaper has explicitly verified the record is handled by the current server, they are still unreaped new-schema ownership evidence and must block startup.
+
+Legacy metadata should not be used for automatic native cleanup. Old records can be removed if they contain no actionable new-schema ownership, but they must not trigger process-name scans or run through the old wrapper-PID signaling path in parallel with the new reaper. The parser must distinguish records that are not new-schema from malformed new-schema records. If a JSON record declares `schemaVersion: 1` but is missing required fields or has invalid field types, the reaper must leave the file for diagnosis and report it as failed ownership evidence so startup blocks instead of deleting the only durable ownership clue.
+
+### 4. Candidate-local durable readiness
+
+Add app-server protocol support for:
+
+- `initialized` notification after successful `initialize`
+- `thread/loaded/list` returning loaded thread ids
+
+After spawning a durable recovery candidate's remote TUI, poll the candidate sidecar's app-server with `thread/loaded/list` until either:
+
+- it contains the expected durable session id and the candidate PTY is still alive, in which case the candidate is ready
+- the existing readiness timeout expires, in which case the candidate fails
+
+Keep lifecycle notifications for loss detection:
+
+- `thread/closed`
+- documented `thread/status/changed` payloads whose status object has type `notLoaded`
+- documented `thread/status/changed` payloads whose status object has type `systemError`
+
+Do not use spawn success, first PTY output, elapsed time, or fake `thread/started` broadcasts as readiness proof.
+
+### 5. Retry and recovery transaction boundaries
+
+Keep recovery retries unbounded. A durable pane should not become permanently dead because an arbitrary attempt budget expired.
+
+Change the transaction boundary:
+
+- at most one active replacement attempt per terminal
+- failed candidate PTY is killed
+- failed candidate sidecar shutdown is awaited through verified process-group teardown
+- failed candidate sidecar teardown failure keeps the unpublished candidate ownership attached to the terminal or registry join set
+- retry delay starts only after teardown completes successfully
+- failed teardown marks the recovery transaction blocked and prevents later lifecycle-loss notifications from spawning another candidate for the same terminal
+- final close clears timers and prevents future recovery starts
+
+The invariant is that repeated failed readiness attempts do not increase the live sidecar process count.
+
+Recovery publication has its own transaction boundary:
+
+1. build an unpublished candidate sidecar and candidate PTY
+2. prove candidate readiness with loaded-thread evidence and live candidate PTY state
+3. mark the old PTY/sidecar as retiring so its natural exit cannot mark the terminal finally closed
+4. retire the old sidecar through verified teardown
+5. publish the candidate as current only after the old sidecar teardown succeeds and the candidate PTY is still alive
+
+If old-sidecar teardown fails, the terminal remains in a blocked recovery state with the failed retiring ownership still joinable. The registry must not publish the candidate, forget the failed old ownership, or treat the failure as a retryable candidate failure.
+
+If unpublished candidate teardown fails, the terminal also remains in a blocked recovery state with the failed candidate ownership still joinable. Final close, `terminal.kill`, and graceful shutdown must be able to join or report that same failed candidate ownership instead of depending on a local recovery-attempt variable that can be swallowed or cleared.
+
+The same blocked-recovery rule applies when recovery candidate planning fails before a `CodexLaunchPlan` is returned. If `recovery.planCreate()` or the planner/runtime cleanup it performs fails because sidecar teardown could not be verified, the registry must treat that failure as a recovery teardown boundary, keep the failed planner-owned ownership joinable through the planner/runtime owner, and prevent later retry timers or lifecycle-loss notifications from creating another sibling candidate for that terminal.
+
+### 6. Initial create and unowned-plan cleanup
+
+Apply the same ownership guarantees to non-recovery paths:
+
+- `CodexLaunchPlanner.planCreate()` startup failure
+- `runCodexLaunchWithRetry()` launch retry
+- WebSocket `terminal.create` failure after planning but before registry adoption
+- agent API create/run/split/respawn failure after planning but before registry adoption
+
+These paths may still use existing local ownership transfer variables. The important rule is that a sidecar has exactly one owner at a time: unowned launch plan, initial-create publication candidate, registry current sidecar, or active replacement candidate.
+
+Initial resume-create paths have the same publication proof requirement as recovery candidates. WebSocket `terminal.create` and agent API create/run/split/respawn calls that resume an existing Codex session must publish success only after both candidate-local loaded-list readiness proves the expected session is loaded and the created PTY is still alive immediately before publication. If the remote TUI exits before publication, the create path fails and cleanup covers both the created PTY and the sidecar.
+
+Initial create publication is the boundary where a sidecar may become registry-current and durable-recovery eligible. Before adoption succeeds and, for resume creates, loaded-list readiness plus live-PTY proof succeeds, lifecycle-loss notifications from that sidecar must not start durable recovery for the not-yet-published terminal. A lifecycle-loss event before publication is a create failure and should drive create cleanup, not recovery.
+
+Ownership transfer must be explicit and checked. `CodexLaunchPlanner.adopt()` should fail clearly if the runtime no longer has an active ownership record to enrich, and planner shutdown should only stop sidecars still owned by the planner. Adoption is allowed only while the planner still accepts ownership transfer for that sidecar. If planner shutdown has begun, or if shutdown for that sidecar is already in progress, `adopt()` must reject clearly, leave ownership with the planner, and allow the in-progress teardown to finish. Planner-owned sidecars remain planner-owned after a failed shutdown attempt and are removed from the planner's active set only after verified teardown succeeds or ownership is explicitly transferred by adoption. Once a sidecar is adopted by the registry, planner shutdown must not stop it as if it were still in planning.
+
+Create-failure cleanup is part of the lifecycle boundary. If WebSocket or agent API create/run/split/respawn fails after planning or registry creation, cleanup must cover both the sidecar and any created PTY. If verified cleanup fails, the caller should surface the cleanup failure as the blocking lifecycle error instead of hiding it behind the original create/adopt error.
+
+### 7. Final close and server shutdown
+
+Final close is terminal:
+
+- no new recovery attempt starts
+- current timers are cleared
+- current sidecar shutdown is awaited
+- unpublished candidate sidecar shutdown is awaited
+- published candidate sidecar shutdown is awaited
+- registry graceful shutdown waits for Codex sidecar teardown before server process exit
+
+It is acceptable for event handlers to schedule async failure handling, but close/shutdown paths must be able to join the pending teardown work. `terminal.kill` is a final-close request: it must await Codex teardown and send a clear protocol error if verified teardown fails instead of allowing the WebSocket message handler to reject without a response.
+
+Final-close and shutdown joins must be all-work joins, not first-error short-circuits. If a recovery attempt, current sidecar shutdown, unpublished candidate shutdown, published candidate shutdown, or tracked shutdown entry rejects, the close/shutdown path still waits for the other pending Codex teardown work before reporting the relevant lifecycle error.
+
+Server shutdown must establish an admission barrier before waiting for Codex teardown. Existing WebSocket clients should be closed or made to reject `terminal.create` before `registry.shutdownGracefully()` and `CodexLaunchPlanner.shutdown()` join existing sidecar work. HTTP agent API routes that can create or respawn Codex terminals (`/tabs`, `/run`, split/respawn flows, and equivalent future create paths) are part of the same barrier and must not publish a new Codex PTY/sidecar after shutdown has started. The barrier applies to in-flight creates as well as new requests: after shutdown begins, WebSocket and HTTP create paths must re-check admission before planning, before registry creation, before adoption, before readiness waits, and before publishing a created terminal. `CodexLaunchPlanner.planCreate()` should reject after planner shutdown begins. Registry shutdown must join Codex recovery attempts and sidecar shutdowns for all terminal records, including records already marked exited, not only records that are running in the first shutdown snapshot.
+
+## Restart Conditions
+
+Stop implementation and redesign if any of these prove true:
+
+- the installed Codex provider lacks `thread/loaded/list` or its response does not reliably show a remotely resumed thread
+- the npm shim/native child does not stay in the spawned process group or does not inherit `FRESHELL_CODEX_SIDECAR_ID`
+- `initialized` changes provider behavior enough to require compatibility work
+- current/candidate/retiring generation state cannot be kept local to the registry without putting registry semantics into process metadata
+- Windows sidecar cleanup must be fixed in the same atomic PR and Unix process groups are insufficient
+
+## Test Plan
+
+Use red-green-refactor. Add process-level tests where process behavior is the requirement; keep registry tests mocked where only state ordering matters.
+
+### Runtime and ownership tests
+
+- fake wrapper spawns a fake native child; `runtime.shutdown()` removes both
+- fake native child ignores `SIGTERM`; runtime escalates to `SIGKILL` and keeps metadata until the group is gone
+- metadata is written immediately after spawn, before app-server initialize
+- app-server initialize timeout tears down the failed attempt before startup retry
+- metadata write failure after spawn tears down the process group and fails startup
+- wrapper identity read failure after spawn is the direct startup failure: force identity lookup to return null without also forcing initialize failure, then assert the owned process group is torn down before retry and startup does not proceed with empty wrapper identity metadata
+- inherited ownership id is visible on the fake native child
+- startup reaper ignores legacy records, does not signal current-process-group records, and blocks startup for any unreaped new-schema record that is not explicitly verified as handled
+- startup reaper removes only verified stale new-schema groups
+- startup fails when the new-schema reaper returns unreaped active/skipped ownership records, including live `ownerServerPid` and current-process-group cases
+- startup fails when the new-schema reaper throws from ownership verification, process-group signaling, waiting, or metadata removal
+- malformed `schemaVersion: 1` ownership records are retained and reported as startup-blocking failures, not deleted as legacy records
+- direct-child sidecars still work
+- corrupted or mismatched ownership metadata cannot authorize teardown of another live process group: wrapper identity must match command line, cwd, start-time ticks, and current membership in the recorded `processGroupId`; ownership-id proof must come from a member of that same group
+- failed process-group teardown leaves runtime ownership in sticky failed state and a later `ensureReady()` does not spawn a new sidecar
+- thrown teardown errors, such as signal or metadata-removal failures, also set runtime sticky failed state before propagating
+- missing command or child-process `error` rejects startup with a clear launch error and does not crash the server process
+- unsupported platforms or missing `/proc` ownership proof reject before spawning a sidecar process
+- teardown does not treat a live process group as gone when `/proc` member scanning fails or returns no readable members
+
+### Protocol and readiness tests
+
+- client sends `initialized` after successful `initialize`
+- client exposes `thread/loaded/list`
+- fake app-server is configured to omit `thread/started` on `thread/resume`
+- durable recovery succeeds when `thread/loaded/list` contains the expected session without a resume `thread/started` broadcast
+- durable recovery fails when the loaded list never contains the expected session
+- durable recovery does not publish a candidate when loaded-list readiness succeeds after the candidate PTY has exited
+- initial WebSocket and agent API resume-create paths do not publish or return success when loaded-list readiness succeeds after the created PTY has exited
+- initial WebSocket and agent API resume-create paths treat sidecar lifecycle-loss before adoption/readiness publication as create failure cleanup, not durable recovery
+- lifecycle-loss detection still reacts to `thread/closed` and documented status-object `notLoaded` and `systemError` payloads
+
+### Registry lifecycle tests
+
+- candidate readiness timeout awaits sidecar teardown before scheduling the next retry
+- repeated readiness failures do not increase active fake sidecar count
+- recovery `planCreate()` failure caused by failed planner/runtime sidecar teardown blocks that terminal's recovery transaction and does not schedule another candidate over the failed ownership
+- teardown failure during recovery records a blocked terminal/recovery state and repeated lifecycle-loss notifications do not spawn another candidate
+- unpublished candidate teardown failure remains joinable by final close, `terminal.kill`, and graceful shutdown
+- retiring old-sidecar teardown failure is treated as a blocked recovery boundary, not as a retryable candidate failure
+- recovery publication proves the candidate PTY is alive immediately before publication
+- old PTY exit during retiring does not mark the terminal finally closed or tear down the ready replacement
+- final close during pending launch does not start recovery later
+- final close with unpublished candidate awaits candidate shutdown
+- final close with published candidate awaits candidate shutdown
+- final close with a rejecting recovery attempt still joins current sidecar shutdown and tracked candidate/sidecar shutdown entries before reporting the teardown error
+- natural PTY exit observes sidecar shutdown failures and keeps them joinable for shutdown
+- `terminal.kill` returns a clear protocol error when Codex verified teardown fails
+- graceful server shutdown waits for Codex recovery attempts and sidecar shutdown promises for running and already-exited records
+- shutdown closes or rejects existing and in-flight WebSocket `terminal.create` before joining registry and planner teardown work
+- shutdown rejects or blocks existing and in-flight HTTP agent API Codex create/run/split/respawn work before joining registry and planner teardown work
+- HTTP agent API shutdown-admission tests close admission while async provider settings are resolving and assert no `CodexLaunchPlanner.planCreate()` call occurs before rejection for the shared create/run/split/respawn helper paths
+- WebSocket create failure after planning awaits sidecar and created-PTY cleanup and surfaces cleanup failure
+- agent API create/run/split/respawn failure after planning awaits sidecar and created-PTY cleanup and surfaces cleanup failure
+- planner `planCreate()` rejects after shutdown begins
+- planner shutdown only stops unadopted sidecars, failed unadopted teardown remains planner-owned and joinable, adoption fails clearly when the runtime has no active ownership to transfer, and a sidecar cannot be adopted after planner shutdown or that sidecar's shutdown has begun
+
+### Integration and provider smoke tests
+
+- fake wrapper/native integration proves retiring app-server process exits and later input uses only the replacement
+- default automated test suites contain no `.skip`, `.skipIf`, or early-pass environment gates for required coverage
+- real-provider smoke is an explicit opt-in command outside the default suite unless the provider prerequisites are guaranteed in CI; when invoked without prerequisites it fails with a clear prerequisite error instead of passing as skipped
+- real-provider smoke starts a real Codex app-server, resumes through the actual `codex --remote <wsUrl> resume <sessionId>` path, observes readiness through loaded-list, shuts down, and asserts no process with the test ownership id remains
+
+Baseline focused checks already run during investigation, before architecture implementation:
+
+```bash
+npm run test:vitest -- test/unit/server/terminal-registry.codex-recovery.test.ts test/unit/server/coding-cli/codex-app-server/recovery-policy.test.ts
+```
+
+Result: 37 tests passed across 2 files.
+
+## Acceptance Criteria
+
+- A live Codex pane is never reaped because of process name alone.
+- Creating a Codex pane either succeeds or leaves no owned wrapper/native app-server process behind.
+- Closing a Codex pane removes its owned wrapper/native app-server processes before close is considered complete.
+- Failed verified teardown leaves a sticky blocking state and a retained joinable ownership handle; later lifecycle events cannot spawn or publish another sidecar over the failed ownership.
+- Server shutdown rejects or closes new and in-flight terminal creation before joining Codex sidecar teardown.
+- Restarting Freshell removes only verified stale new-schema sidecars from prior server instances.
+- Historical legacy sidecars are not automatically process-killed by runtime cleanup.
+- Recovery replacement retires the old generation without touching unrelated panes, and publication only occurs while the candidate PTY is alive.
+- A candidate that fails readiness is fully torn down before the next retry starts.
+- Retry remains unbounded while the pane exists, but failed attempts are serialized behind teardown.
+- Many consecutive recovery failures do not grow wrapper/native process count.
+- Durable recovery can become ready from candidate-local loaded-thread proof without a `thread/started` resume broadcast.
+- Logs identify `ownershipId`, `terminalId`, `generation`, `wsUrl`, `wrapperPid`, `processGroupId`, and `serverInstanceId` for recovery and teardown events.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:all": "tsx scripts/testing/test-coordinator.ts run test:all",
     "test:status": "tsx scripts/testing/test-coordinator.ts status",
     "test:vitest": "tsx scripts/testing/test-coordinator.ts run test:vitest",
+    "test:codex-real-provider-smoke": "vitest run --config vitest.codex-real-provider-smoke.config.ts",
     "smoke:browser-use": "python3 test/browser_use/smoke_freshell.py",
     "prepare:icons": "node assets/icons/prepare-icons.mjs",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",

--- a/server/agent-api/router.ts
+++ b/server/agent-api/router.ts
@@ -3,14 +3,14 @@ import fs from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { nanoid } from 'nanoid'
 import { allocateLocalhostPort } from '../local-port.js'
-import type { CodexLaunchPlanner } from '../coding-cli/codex-app-server/launch-planner.js'
+import type { CodexLaunchPlan, CodexLaunchPlanner } from '../coding-cli/codex-app-server/launch-planner.js'
 import {
   CodexLaunchConfigError,
   getCodexSessionBindingReason,
   normalizeCodexSandboxSetting,
 } from '../coding-cli/codex-launch-config.js'
 import { makeSessionKey } from '../coding-cli/types.js'
-import type { ProviderSettings } from '../terminal-registry.js'
+import { terminalIdFromCreateError, type ProviderSettings } from '../terminal-registry.js'
 import { MAX_TERMINAL_TITLE_OVERRIDE_LENGTH } from '../terminals-router.js'
 import { ok, approx, fail } from './response.js'
 import { renderCapture } from './capture.js'
@@ -22,6 +22,16 @@ const SYNCABLE_TERMINAL_MODES = new Set(['claude', 'codex', 'opencode', 'gemini'
 
 function agentRouteErrorStatus(error: unknown): number {
   return error instanceof CodexLaunchConfigError ? 400 : 500
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function combineWithCleanupError(primary: unknown, cleanupError: unknown): Error {
+  const primaryMessage = errorMessage(primary)
+  const cleanupMessage = errorMessage(cleanupError)
+  return new Error(`${primaryMessage}; cleanup failed: ${cleanupMessage}`)
 }
 
 /**
@@ -52,13 +62,15 @@ async function resolveSpawnProviderSettings(
     cwd?: string
     resumeSessionId?: string
     codexLaunchPlanner?: CodexLaunchPlanner
+    assertTerminalCreateAccepted?: () => void
   } = {},
-): Promise<{ resumeSessionId?: string; providerSettings?: ProviderSettings }> {
+): Promise<{ resumeSessionId?: string; providerSettings?: ProviderSettings; codexPlan?: CodexLaunchPlan }> {
   const providerSettings = await resolveProviderSettings(mode, configStore, overrides)
   if (mode === 'codex') {
     if (!opts.codexLaunchPlanner) {
-      throw new Error('Codex terminal launch requires the shared app-server planner.')
+      throw new Error('Codex terminal launch requires the app-server launch planner.')
     }
+    opts.assertTerminalCreateAccepted?.()
     const plan = await opts.codexLaunchPlanner.planCreate({
       cwd: opts.cwd,
       resumeSessionId: opts.resumeSessionId,
@@ -69,8 +81,22 @@ async function resolveSpawnProviderSettings(
     return {
       resumeSessionId: plan.sessionId,
       providerSettings: {
-        codexAppServer: plan.remote,
+        codexAppServer: {
+          ...plan.remote,
+          sidecar: plan.sidecar,
+          deferLifecycleUntilPublished: true,
+          recovery: {
+            planCreate: (input) => opts.codexLaunchPlanner!.planCreate({
+              cwd: input.cwd ?? opts.cwd,
+              resumeSessionId: input.resumeSessionId,
+              model: providerSettings?.model,
+              sandbox: normalizeCodexSandboxSetting(providerSettings?.sandbox),
+              approvalPolicy: providerSettings?.permissionMode,
+            }),
+          },
+        },
       },
+      codexPlan: plan,
     }
   }
   if (mode !== 'opencode') {
@@ -85,6 +111,66 @@ async function resolveSpawnProviderSettings(
       ...(providerSettings ?? {}),
       opencodeServer: await allocateLocalhostPort(),
     },
+  }
+}
+
+type ResolvedSpawnProviderSettings = Awaited<ReturnType<typeof resolveSpawnProviderSettings>>
+
+async function adoptCodexLaunch(
+  launch: ResolvedSpawnProviderSettings | undefined,
+  terminalId: string,
+): Promise<void> {
+  await launch?.codexPlan?.sidecar.adopt({ terminalId, generation: 0 })
+}
+
+async function cleanupUnadoptedCodexLaunch(launch: ResolvedSpawnProviderSettings | undefined): Promise<void> {
+  await launch?.codexPlan?.sidecar.shutdown()
+}
+
+async function waitForCodexResumeReadiness(
+  launch: ResolvedSpawnProviderSettings | undefined,
+  requestedResumeSessionId: string | undefined,
+): Promise<void> {
+  if (!launch?.codexPlan || !requestedResumeSessionId) return
+  await launch.codexPlan.sidecar.waitForLoadedThread(requestedResumeSessionId)
+}
+
+function publishCodexLaunch(registry: any, launch: ResolvedSpawnProviderSettings | undefined, terminalId: string): void {
+  if (!launch?.codexPlan) return
+  registry.publishCodexSidecar?.(terminalId)
+}
+
+function assertCodexCreateTerminalRunning(terminal: { status?: unknown }): void {
+  if (terminal.status === 'exited') {
+    throw new Error('Codex terminal PTY exited before create completed.')
+  }
+}
+
+async function cleanupCreatedTerminal(registry: any, terminalId: string | undefined): Promise<void> {
+  if (!terminalId) return
+  if (typeof registry?.killAndWait === 'function') {
+    await registry.killAndWait(terminalId)
+    return
+  }
+  if (typeof registry?.kill === 'function') {
+    registry.kill(terminalId)
+  }
+}
+
+async function cleanupFailedCodexCreate(
+  registry: any,
+  terminalId: string | undefined,
+  launch: ResolvedSpawnProviderSettings | undefined,
+): Promise<void> {
+  const cleanupErrors: string[] = []
+  await cleanupCreatedTerminal(registry, terminalId).catch((error) => {
+    cleanupErrors.push(`created terminal cleanup failed: ${errorMessage(error)}`)
+  })
+  await cleanupUnadoptedCodexLaunch(launch).catch((error) => {
+    cleanupErrors.push(`Codex sidecar cleanup failed: ${errorMessage(error)}`)
+  })
+  if (cleanupErrors.length > 0) {
+    throw new Error(cleanupErrors.join('; '))
   }
 }
 
@@ -139,6 +225,7 @@ export function createAgentApiRouter({
   codingCliIndexer,
   codexActivityTracker,
   codexLaunchPlanner,
+  assertTerminalCreateAccepted,
 }: {
   layoutStore: any
   registry: any
@@ -148,8 +235,12 @@ export function createAgentApiRouter({
   codingCliIndexer?: { refresh: () => Promise<void> }
   codexActivityTracker?: CodexPromptBlocker
   codexLaunchPlanner?: CodexLaunchPlanner
+  assertTerminalCreateAccepted?: () => void
 }) {
   const router = Router()
+  const assertTerminalAdmission = () => {
+    assertTerminalCreateAccepted?.()
+  }
 
   const resolvePaneTarget = (raw: string) => {
     if (layoutStore.resolveTarget) {
@@ -269,6 +360,8 @@ export function createAgentApiRouter({
     const { name, mode, shell, cwd, browser, editor, resumeSessionId, permissionMode, model, sandbox } = req.body || {}
     const wantsBrowser = !!browser
     const wantsEditor = !!editor
+    let launch: ResolvedSpawnProviderSettings | undefined
+    let createdTerminalId: string | undefined
 
     try {
       let paneContent: any
@@ -280,14 +373,17 @@ export function createAgentApiRouter({
         paneContent = { kind: 'editor', filePath: editor, language: null, readOnly: false, content: '', viewMode: 'source' }
       } else {
         const effectiveMode = mode || 'shell'
-        const launch = await resolveSpawnProviderSettings(
+        assertTerminalAdmission()
+        launch = await resolveSpawnProviderSettings(
           effectiveMode,
           configStore,
           { permissionMode, model, sandbox },
-          { cwd, resumeSessionId, codexLaunchPlanner },
+          { cwd, resumeSessionId, codexLaunchPlanner, assertTerminalCreateAccepted: assertTerminalAdmission },
         )
+        assertTerminalAdmission()
         const { tabId, paneId } = layoutStore.createTab({ title: name, browser, editor })
         const sessionBindingReason = getCodexSessionBindingReason(effectiveMode, resumeSessionId)
+        assertTerminalAdmission()
         const terminal = registry.create({
           mode: effectiveMode,
           shell,
@@ -297,6 +393,16 @@ export function createAgentApiRouter({
           providerSettings: launch.providerSettings,
           envContext: { tabId, paneId },
         })
+        createdTerminalId = terminal.terminalId
+        const launchResumeSessionId = launch.resumeSessionId
+        assertTerminalAdmission()
+        await adoptCodexLaunch(launch, terminal.terminalId)
+        assertTerminalAdmission()
+        await waitForCodexResumeReadiness(launch, resumeSessionId)
+        assertCodexCreateTerminalRunning(terminal)
+        assertTerminalAdmission()
+        publishCodexLaunch(registry, launch, terminal.terminalId)
+        launch = undefined
         terminalId = terminal.terminalId
         paneContent = {
           kind: 'terminal',
@@ -304,7 +410,7 @@ export function createAgentApiRouter({
           status: 'running',
           mode: mode || 'shell',
           shell: shell || 'system',
-          resumeSessionId: launch.resumeSessionId,
+          resumeSessionId: launchResumeSessionId,
           initialCwd: cwd,
         }
 
@@ -326,6 +432,7 @@ export function createAgentApiRouter({
         })
 
         res.json(ok({ tabId, paneId, terminalId }, 'tab created'))
+        createdTerminalId = undefined
         return
       }
 
@@ -349,8 +456,12 @@ export function createAgentApiRouter({
 
       res.json(ok({ tabId, paneId, terminalId }, 'tab created'))
     } catch (err: any) {
-      const status = agentRouteErrorStatus(err)
-      res.status(status).json(fail(err?.message || 'Failed to create tab'))
+      let responseError = err
+      await cleanupFailedCodexCreate(registry, createdTerminalId ?? terminalIdFromCreateError(err), launch).catch((cleanupError) => {
+        responseError = combineWithCleanupError(err, cleanupError)
+      })
+      const status = agentRouteErrorStatus(responseError)
+      res.status(status).json(fail(responseError?.message || 'Failed to create tab'))
     }
   })
 
@@ -633,12 +744,21 @@ export function createAgentApiRouter({
     const rawTimeout = payload.timeout || payload.T
     const timeoutSeconds = typeof rawTimeout === 'number' ? rawTimeout : Number(rawTimeout)
     const timeoutMs = Number.isFinite(timeoutSeconds) ? timeoutSeconds * 1000 : 30000
+    let launch: ResolvedSpawnProviderSettings | undefined
+    let createdTerminalId: string | undefined
     try {
-      const launch = await resolveSpawnProviderSettings(mode, configStore, {}, { cwd, codexLaunchPlanner })
+      assertTerminalAdmission()
+      launch = await resolveSpawnProviderSettings(mode, configStore, {}, {
+        cwd,
+        codexLaunchPlanner,
+        assertTerminalCreateAccepted: assertTerminalAdmission,
+      })
+      assertTerminalAdmission()
       const created = layoutStore.createTab?.({ title })
       const tabId = created?.tabId || nanoid()
       const paneId = created?.paneId || nanoid()
       const sessionBindingReason = getCodexSessionBindingReason(mode)
+      assertTerminalAdmission()
       const terminal = registry.create({
         mode,
         shell,
@@ -648,6 +768,12 @@ export function createAgentApiRouter({
         providerSettings: launch.providerSettings,
         envContext: { tabId, paneId },
       })
+      createdTerminalId = terminal.terminalId
+      assertTerminalAdmission()
+      await adoptCodexLaunch(launch, terminal.terminalId)
+      assertTerminalAdmission()
+      publishCodexLaunch(registry, launch, terminal.terminalId)
+      launch = undefined
       layoutStore.attachPaneContent?.(tabId, paneId, { kind: 'terminal', terminalId: terminal.terminalId })
       wsHandler?.broadcastUiCommand({
         command: 'tab.create',
@@ -660,6 +786,7 @@ export function createAgentApiRouter({
 
       if (!capture || detached) {
         const message = detached ? 'command started (detached)' : 'command sent'
+        createdTerminalId = undefined
         return res.json(ok({ terminalId: terminal.terminalId, tabId, paneId }, message))
       }
 
@@ -673,14 +800,21 @@ export function createAgentApiRouter({
       const output = rawOutput.split(sentinel).join('').trim()
       const responder = result.matched ? ok : approx
       const message = result.matched ? 'run complete' : 'timeout waiting for command'
+      createdTerminalId = undefined
       return res.json(responder({ terminalId: terminal.terminalId, tabId, paneId, output }, message))
     } catch (err: any) {
-      const status = agentRouteErrorStatus(err)
-      return res.status(status).json(fail(err?.message || 'Failed to run command'))
+      let responseError = err
+      await cleanupFailedCodexCreate(registry, createdTerminalId ?? terminalIdFromCreateError(err), launch).catch((cleanupError) => {
+        responseError = combineWithCleanupError(err, cleanupError)
+      })
+      const status = agentRouteErrorStatus(responseError)
+      return res.status(status).json(fail(responseError?.message || 'Failed to run command'))
     }
   })
 
   router.post('/panes/:id/split', async (req, res) => {
+    let launch: ResolvedSpawnProviderSettings | undefined
+    let createdTerminalId: string | undefined
     try {
       const rawPaneId = req.params.id
       const resolved = resolvePaneTarget(rawPaneId)
@@ -689,6 +823,9 @@ export function createAgentApiRouter({
       const direction = req.body?.direction || 'vertical'
       const wantsBrowser = !!req.body?.browser
       const wantsEditor = !!req.body?.editor
+      if (!wantsBrowser && !wantsEditor) {
+        assertTerminalAdmission()
+      }
 
       const result = layoutStore.splitPane({
         paneId,
@@ -713,7 +850,7 @@ export function createAgentApiRouter({
         content = { kind: 'editor', filePath: req.body.editor, language: null, readOnly: false, content: '', viewMode: 'source' }
       } else {
         const splitMode = req.body?.mode || 'shell'
-        const launch = await resolveSpawnProviderSettings(
+        launch = await resolveSpawnProviderSettings(
           splitMode,
           configStore,
           {},
@@ -721,9 +858,12 @@ export function createAgentApiRouter({
             cwd: req.body?.cwd,
             resumeSessionId: req.body?.resumeSessionId,
             codexLaunchPlanner,
+            assertTerminalCreateAccepted: assertTerminalAdmission,
           },
         )
+        assertTerminalAdmission()
         const sessionBindingReason = getCodexSessionBindingReason(splitMode, req.body?.resumeSessionId)
+        assertTerminalAdmission()
         const terminal = registry.create({
           mode: splitMode,
           shell: req.body?.shell,
@@ -733,6 +873,16 @@ export function createAgentApiRouter({
           providerSettings: launch.providerSettings,
           envContext: { tabId, paneId: newPaneId },
         })
+        createdTerminalId = terminal.terminalId
+        const launchResumeSessionId = launch.resumeSessionId
+        assertTerminalAdmission()
+        await adoptCodexLaunch(launch, terminal.terminalId)
+        assertTerminalAdmission()
+        await waitForCodexResumeReadiness(launch, req.body?.resumeSessionId)
+        assertCodexCreateTerminalRunning(terminal)
+        assertTerminalAdmission()
+        publishCodexLaunch(registry, launch, terminal.terminalId)
+        launch = undefined
         terminalId = terminal.terminalId
         content = {
           kind: 'terminal',
@@ -740,7 +890,7 @@ export function createAgentApiRouter({
           status: 'running',
           mode: req.body?.mode || 'shell',
           shell: req.body?.shell || 'system',
-          ...(launch.resumeSessionId ? { resumeSessionId: launch.resumeSessionId } : {}),
+          ...(launchResumeSessionId ? { resumeSessionId: launchResumeSessionId } : {}),
         }
       }
 
@@ -758,9 +908,14 @@ export function createAgentApiRouter({
       })
 
       const message = wantsBrowser || wantsEditor ? 'pane split (non-terminal)' : 'pane split'
+      createdTerminalId = undefined
       res.json(ok({ paneId: newPaneId, terminalId }, message))
     } catch (err: any) {
-      res.status(agentRouteErrorStatus(err)).json(fail(err?.message || 'Failed to split pane'))
+      let responseError = err
+      await cleanupFailedCodexCreate(registry, createdTerminalId ?? terminalIdFromCreateError(err), launch).catch((cleanupError) => {
+        responseError = combineWithCleanupError(err, cleanupError)
+      })
+      res.status(agentRouteErrorStatus(responseError)).json(fail(responseError?.message || 'Failed to split pane'))
     }
   })
 
@@ -915,6 +1070,8 @@ export function createAgentApiRouter({
   })
 
   router.post('/panes/:id/respawn', async (req, res) => {
+    let launch: ResolvedSpawnProviderSettings | undefined
+    let createdTerminalId: string | undefined
     try {
       const resolved = resolvePaneTarget(req.params.id)
       if (rejectPaneTargetError(res, resolved)) return
@@ -923,7 +1080,8 @@ export function createAgentApiRouter({
       const tabId = target?.tabId
       if (!tabId) return res.status(404).json(fail('pane not found'))
       const effectiveMode = req.body?.mode || 'shell'
-      const launch = await resolveSpawnProviderSettings(
+      assertTerminalAdmission()
+      launch = await resolveSpawnProviderSettings(
         effectiveMode,
         configStore,
         {},
@@ -931,9 +1089,12 @@ export function createAgentApiRouter({
           cwd: req.body?.cwd,
           resumeSessionId: req.body?.resumeSessionId,
           codexLaunchPlanner,
+          assertTerminalCreateAccepted: assertTerminalAdmission,
         },
       )
+      assertTerminalAdmission()
       const sessionBindingReason = getCodexSessionBindingReason(effectiveMode, req.body?.resumeSessionId)
+      assertTerminalAdmission()
       const terminal = registry.create({
         mode: effectiveMode,
         shell: req.body?.shell,
@@ -943,6 +1104,16 @@ export function createAgentApiRouter({
         providerSettings: launch.providerSettings,
         envContext: { tabId, paneId },
       })
+      createdTerminalId = terminal.terminalId
+      const launchResumeSessionId = launch.resumeSessionId
+      assertTerminalAdmission()
+      await adoptCodexLaunch(launch, terminal.terminalId)
+      assertTerminalAdmission()
+      await waitForCodexResumeReadiness(launch, req.body?.resumeSessionId)
+      assertCodexCreateTerminalRunning(terminal)
+      assertTerminalAdmission()
+      publishCodexLaunch(registry, launch, terminal.terminalId)
+      launch = undefined
       const content = {
         kind: 'terminal',
         terminalId: terminal.terminalId,
@@ -950,13 +1121,18 @@ export function createAgentApiRouter({
         mode: req.body?.mode || 'shell',
         shell: req.body?.shell || 'system',
         createRequestId: nanoid(),
-        ...(launch.resumeSessionId ? { resumeSessionId: launch.resumeSessionId } : {}),
+        ...(launchResumeSessionId ? { resumeSessionId: launchResumeSessionId } : {}),
       }
       layoutStore.attachPaneContent(tabId, paneId, content)
       wsHandler?.broadcastUiCommand({ command: 'pane.attach', payload: { tabId, paneId, content } })
+      createdTerminalId = undefined
       res.json(ok({ terminalId: terminal.terminalId }, 'pane respawned'))
     } catch (err: any) {
-      res.status(agentRouteErrorStatus(err)).json(fail(err?.message || 'Failed to respawn pane'))
+      let responseError = err
+      await cleanupFailedCodexCreate(registry, createdTerminalId ?? terminalIdFromCreateError(err), launch).catch((cleanupError) => {
+        responseError = combineWithCleanupError(err, cleanupError)
+      })
+      res.status(agentRouteErrorStatus(responseError)).json(fail(responseError?.message || 'Failed to respawn pane'))
     }
   })
 

--- a/server/coding-cli/codex-app-server/client.ts
+++ b/server/coding-cli/codex-app-server/client.ts
@@ -2,6 +2,7 @@ import WebSocket from 'ws'
 import {
   CodexInitializeParamsSchema,
   CodexInitializeResultSchema,
+  CodexLoadedThreadListResultSchema,
   CodexRpcErrorEnvelopeSchema,
   CodexRpcNotificationEnvelopeSchema,
   CodexRpcSuccessEnvelopeSchema,
@@ -27,7 +28,12 @@ type PendingRequest = {
   timeout: NodeJS.Timeout
 }
 
+export type CodexThreadLifecycleLossEvent =
+  | { method: 'thread/closed'; threadId?: string }
+  | { method: 'thread/status/changed'; threadId?: string; status: 'notLoaded' | 'systemError' }
+
 const DEFAULT_REQUEST_TIMEOUT_MS = 5_000
+const LOSS_STATUSES = new Set(['notLoaded', 'systemError'])
 
 export class CodexAppServerClient {
   private readonly requestTimeoutMs: number
@@ -36,6 +42,7 @@ export class CodexAppServerClient {
   private initializePromise: Promise<CodexInitializeResult> | null = null
   private nextRequestId = 1
   private pendingRequests = new Map<number, PendingRequest>()
+  private lifecycleLossHandlers = new Set<(event: CodexThreadLifecycleLossEvent) => void>()
 
   constructor(
     private readonly endpoint: CodexAppServerEndpoint,
@@ -53,11 +60,12 @@ export class CodexAppServerClient {
         experimentalApi: true,
         optOutNotificationMethods: ['thread/started'],
       },
-    })).then((result) => {
+    })).then(async (result) => {
       const parsed = CodexInitializeResultSchema.safeParse(result)
       if (!parsed.success) {
         throw new Error('Codex app-server returned an invalid initialize payload.')
       }
+      await this.notify('initialized')
       return parsed.data
     }).catch((error) => {
       this.initializePromise = null
@@ -95,6 +103,15 @@ export class CodexAppServerClient {
     return { threadId: parsed.data.thread.id }
   }
 
+  async listLoadedThreads(): Promise<string[]> {
+    const result = await this.request('thread/loaded/list', {})
+    const parsed = CodexLoadedThreadListResultSchema.safeParse(result)
+    if (!parsed.success) {
+      throw new Error('Codex app-server returned an invalid thread/loaded/list payload.')
+    }
+    return parsed.data.data
+  }
+
   async close(): Promise<void> {
     const socket = this.socket
     this.socket = null
@@ -124,6 +141,13 @@ export class CodexAppServerClient {
       socket.once('error', onClose)
       socket.close()
     })
+  }
+
+  onThreadLifecycleLoss(handler: (event: CodexThreadLifecycleLossEvent) => void): () => void {
+    this.lifecycleLossHandlers.add(handler)
+    return () => {
+      this.lifecycleLossHandlers.delete(handler)
+    }
   }
 
   private async ensureSocket(): Promise<WebSocket> {
@@ -180,6 +204,7 @@ export class CodexAppServerClient {
     if (!this.hasIdField(parsed)) {
       const notification = CodexRpcNotificationEnvelopeSchema.safeParse(parsed)
       if (notification.success) {
+        this.handleNotification(notification.data)
         return
       }
     }
@@ -207,6 +232,68 @@ export class CodexAppServerClient {
     clearTimeout(pending.timeout)
     this.pendingRequests.delete(failure.data.id)
     pending.reject(new Error(this.formatRpcError(pending.method, failure.data.error)))
+  }
+
+  private handleNotification(notification: { method: string; params?: unknown }): void {
+    if (notification.method === 'thread/closed') {
+      this.emitLifecycleLoss({
+        method: 'thread/closed',
+        threadId: this.extractThreadId(notification.params),
+      })
+      return
+    }
+
+    if (notification.method !== 'thread/status/changed') return
+    const status = this.extractThreadStatus(notification.params)
+    if (status !== 'notLoaded' && status !== 'systemError') return
+
+    this.emitLifecycleLoss({
+      method: 'thread/status/changed',
+      threadId: this.extractThreadId(notification.params),
+      status,
+    })
+  }
+
+  private emitLifecycleLoss(event: CodexThreadLifecycleLossEvent): void {
+    for (const handler of this.lifecycleLossHandlers) {
+      handler(event)
+    }
+  }
+
+  private extractThreadId(params: unknown): string | undefined {
+    if (!params || typeof params !== 'object') return undefined
+    const object = params as Record<string, unknown>
+    if (typeof object.threadId === 'string') return object.threadId
+    const thread = object.thread
+    if (thread && typeof thread === 'object' && typeof (thread as Record<string, unknown>).id === 'string') {
+      return (thread as Record<string, string>).id
+    }
+    return undefined
+  }
+
+  private extractThreadStatus(params: unknown): 'notLoaded' | 'systemError' | undefined {
+    if (!params || typeof params !== 'object') return undefined
+    const object = params as Record<string, unknown>
+    const status = this.extractLossStatus(object.status)
+    if (status) return status
+    const thread = object.thread
+    if (thread && typeof thread === 'object') {
+      return this.extractLossStatus((thread as Record<string, unknown>).status)
+    }
+    return undefined
+  }
+
+  private extractLossStatus(status: unknown): 'notLoaded' | 'systemError' | undefined {
+    if (typeof status === 'string' && LOSS_STATUSES.has(status)) {
+      return status as 'notLoaded' | 'systemError'
+    }
+    if (status && typeof status === 'object') {
+      const statusType = (status as Record<string, unknown>).type
+      if (typeof statusType === 'string' && LOSS_STATUSES.has(statusType)) {
+        return statusType as 'notLoaded' | 'systemError'
+      }
+    }
+    return undefined
   }
 
   private handleSocketClose(): void {
@@ -246,6 +333,23 @@ export class CodexAppServerClient {
         clearTimeout(timeout)
         this.pendingRequests.delete(id)
         reject(error)
+      })
+    })
+  }
+
+  private async notify<TParams extends object>(method: string, params?: TParams): Promise<void> {
+    const socket = await this.ensureSocket()
+    await new Promise<void>((resolve, reject) => {
+      socket.send(JSON.stringify({
+        jsonrpc: '2.0',
+        method,
+        ...(params ? { params } : {}),
+      }), (error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolve()
       })
     })
   }

--- a/server/coding-cli/codex-app-server/launch-planner.ts
+++ b/server/coding-cli/codex-app-server/launch-planner.ts
@@ -1,10 +1,30 @@
 import type { CodexAppServerRuntime } from './runtime.js'
+import type { CodexThreadLifecycleLossEvent } from './client.js'
+import { waitForAllSettledOrThrow } from '../../shutdown-join.js'
+
+type CodexRuntimeLike = Pick<
+  CodexAppServerRuntime,
+  'ensureReady' | 'startThread' | 'listLoadedThreads' | 'shutdown' | 'updateOwnershipMetadata' | 'onThreadLifecycleLoss'
+>
+
+export type CodexLaunchSidecar = {
+  adopt(input: { terminalId: string; generation: number }): Promise<void>
+  listLoadedThreads(): Promise<string[]>
+  onLifecycleLoss?(handler: (event: CodexThreadLifecycleLossEvent) => void): () => void
+  shutdown(): Promise<void>
+  waitForLoadedThread(threadId: string, options?: { timeoutMs?: number; pollMs?: number }): Promise<void>
+}
 
 export type CodexLaunchPlan = {
   sessionId: string
   remote: {
     wsUrl: string
   }
+  sidecar: CodexLaunchSidecar
+}
+
+export type CodexSidecarTeardownError = Error & {
+  codexSidecarTeardownFailed: true
 }
 
 type PlanCreateInput = {
@@ -15,34 +35,212 @@ type PlanCreateInput = {
   approvalPolicy?: string
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function codexSidecarTeardownError(message: string, cause: unknown): CodexSidecarTeardownError {
+  const error = new Error(message) as CodexSidecarTeardownError
+  error.codexSidecarTeardownFailed = true
+  error.cause = cause
+  return error
+}
+
+export function isCodexSidecarTeardownError(error: unknown): error is CodexSidecarTeardownError {
+  return (error as { codexSidecarTeardownFailed?: boolean } | null | undefined)?.codexSidecarTeardownFailed === true
+}
+
 export class CodexLaunchPlanner {
-  constructor(
-    private readonly runtime: Pick<CodexAppServerRuntime, 'ensureReady' | 'startThread'>,
-  ) {}
+  private readonly activeSidecars = new Set<CodexLaunchSidecar>()
+  private readonly failedSidecarShutdowns = new Set<CodexLaunchSidecar>()
+  private readonly runtimeFactory: () => CodexRuntimeLike
+  private shutdownStarted = false
+  private shutdownPromise: Promise<void> | null = null
+
+  constructor(runtimeOrFactory: CodexRuntimeLike | (() => CodexRuntimeLike)) {
+    this.runtimeFactory = typeof runtimeOrFactory === 'function'
+      ? runtimeOrFactory
+      : () => runtimeOrFactory
+  }
 
   async planCreate(input: PlanCreateInput): Promise<CodexLaunchPlan> {
-    if (input.resumeSessionId) {
-      const ready = await this.runtime.ensureReady()
-      return {
-        sessionId: input.resumeSessionId,
-        remote: {
-          wsUrl: ready.wsUrl,
-        },
-      }
-    }
+    this.assertAcceptingPlans()
+    await this.retryFailedSidecarShutdownsBeforePlan()
+    this.assertAcceptingPlans()
 
-    const planResult = await this.runtime.startThread({
+    const runtime = this.runtimeFactory()
+    const sidecar = this.createSidecar(runtime)
+    this.activeSidecars.add(sidecar)
+
+    try {
+      if (input.resumeSessionId) {
+        const ready = await runtime.ensureReady()
+        this.assertAcceptingPlans()
+        return {
+          sessionId: input.resumeSessionId,
+          remote: {
+            wsUrl: ready.wsUrl,
+          },
+          sidecar,
+        }
+      }
+
+      const planResult = await runtime.startThread({
         cwd: input.cwd,
         model: input.model,
         sandbox: input.sandbox,
         approvalPolicy: input.approvalPolicy,
       })
+      this.assertAcceptingPlans()
 
-    return {
-      sessionId: planResult.threadId,
-      remote: {
-        wsUrl: planResult.wsUrl,
+      return {
+        sessionId: planResult.threadId,
+        remote: {
+          wsUrl: planResult.wsUrl,
+        },
+        sidecar,
+      }
+    } catch (error) {
+      try {
+        await sidecar.shutdown()
+      } catch (shutdownError) {
+        throw codexSidecarTeardownError(
+          `Codex launch sidecar teardown failed after planning error: ${errorMessage(shutdownError)}`,
+          shutdownError,
+        )
+      }
+      throw error
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this.shutdownStarted = true
+    if (this.shutdownPromise) {
+      await this.shutdownPromise
+      return
+    }
+    const attempt = waitForAllSettledOrThrow(
+      [...this.activeSidecars].map((sidecar) => Promise.resolve().then(() => sidecar.shutdown())),
+      'Codex launch planner shutdown failed.',
+    )
+    this.shutdownPromise = attempt
+    try {
+      await attempt
+    } finally {
+      if (this.shutdownPromise === attempt) {
+        this.shutdownPromise = null
+      }
+    }
+  }
+
+  private assertAcceptingPlans(): void {
+    if (this.shutdownStarted) {
+      throw new Error('Codex launch planner is shutting down; new Codex launch plans are not accepted.')
+    }
+  }
+
+  private async retryFailedSidecarShutdownsBeforePlan(): Promise<void> {
+    const failedSidecars = [...this.failedSidecarShutdowns]
+      .filter((sidecar) => this.activeSidecars.has(sidecar))
+    if (failedSidecars.length === 0) return
+
+    try {
+      await waitForAllSettledOrThrow(
+        failedSidecars.map((sidecar) => sidecar.shutdown()),
+        'Codex launch planner failed to clear blocked sidecar shutdowns.',
+      )
+    } catch (error) {
+      throw codexSidecarTeardownError(
+        `Codex launch planner cannot create a new plan while sidecar teardown is blocked: ${errorMessage(error)}`,
+        error,
+      )
+    }
+  }
+
+  private createSidecar(runtime: CodexRuntimeLike): CodexLaunchSidecar {
+    let shutdownPromise: Promise<void> | null = null
+    let shutdownAttemptStarted = false
+    let shutdownSucceeded = false
+    let notifyShutdownStarted!: () => void
+    const shutdownStarted = new Promise<void>((resolve) => {
+      notifyShutdownStarted = resolve
+    })
+    const assertAdoptable = () => {
+      if (this.shutdownStarted || shutdownAttemptStarted) {
+        throw new Error('Codex launch sidecar is shutting down; it cannot be adopted.')
+      }
+    }
+    const assertReadable = () => {
+      if (this.shutdownStarted || shutdownAttemptStarted) {
+        throw new Error('Codex launch sidecar is shutting down; loaded-thread readiness polling stopped.')
+      }
+    }
+    const waitForNextPoll = async (pollMs: number) => {
+      await Promise.race([
+        new Promise((resolve) => setTimeout(resolve, pollMs)),
+        shutdownStarted,
+      ])
+      assertReadable()
+    }
+    const sidecar: CodexLaunchSidecar = {
+      adopt: async ({ terminalId, generation }) => {
+        assertAdoptable()
+        await runtime.updateOwnershipMetadata({ terminalId, generation })
+        assertAdoptable()
+        this.activeSidecars.delete(sidecar)
+        this.failedSidecarShutdowns.delete(sidecar)
+      },
+      listLoadedThreads: async () => {
+        assertReadable()
+        const loaded = await runtime.listLoadedThreads()
+        assertReadable()
+        return loaded
+      },
+      onLifecycleLoss: (handler) => runtime.onThreadLifecycleLoss(handler),
+      shutdown: async () => {
+        if (shutdownSucceeded) return
+        if (shutdownPromise) {
+          await shutdownPromise
+          return
+        }
+        if (!shutdownAttemptStarted) {
+          shutdownAttemptStarted = true
+          notifyShutdownStarted()
+        }
+        const attempt = Promise.resolve()
+          .then(() => runtime.shutdown())
+          .then(() => {
+            shutdownSucceeded = true
+            this.activeSidecars.delete(sidecar)
+            this.failedSidecarShutdowns.delete(sidecar)
+          })
+          .catch((error) => {
+            this.failedSidecarShutdowns.add(sidecar)
+            throw error
+          })
+        shutdownPromise = attempt
+        try {
+          await attempt
+        } finally {
+          if (shutdownPromise === attempt) {
+            shutdownPromise = null
+          }
+        }
+      },
+      waitForLoadedThread: async (threadId, options = {}) => {
+        const timeoutMs = options.timeoutMs ?? 10_000
+        const pollMs = options.pollMs ?? 100
+        const deadline = Date.now() + timeoutMs
+
+        while (Date.now() < deadline) {
+          const loaded = await sidecar.listLoadedThreads()
+          if (loaded.includes(threadId)) return
+          await waitForNextPoll(pollMs)
+        }
+
+        throw new Error(`Codex app-server did not load thread ${threadId} within ${timeoutMs}ms.`)
       },
     }
+    return sidecar
   }
 }

--- a/server/coding-cli/codex-app-server/protocol.ts
+++ b/server/coding-cli/codex-app-server/protocol.ts
@@ -46,6 +46,10 @@ export const CodexThreadOperationResultSchema = z.object({
   thread: CodexThreadSchema,
 })
 
+export const CodexLoadedThreadListResultSchema = z.object({
+  data: z.array(z.string().min(1)),
+})
+
 export const CodexRpcErrorSchema = z.object({
   code: z.number(),
   message: z.string().min(1),
@@ -72,4 +76,5 @@ export type CodexInitializeResult = z.infer<typeof CodexInitializeResultSchema>
 export type CodexThreadStartParams = z.infer<typeof CodexThreadStartParamsSchema>
 export type CodexThreadResumeParams = z.infer<typeof CodexThreadResumeParamsSchema>
 export type CodexThreadOperationResult = z.infer<typeof CodexThreadOperationResultSchema>
+export type CodexLoadedThreadListResult = z.infer<typeof CodexLoadedThreadListResultSchema>
 export type CodexRpcError = z.infer<typeof CodexRpcErrorSchema>

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -1,14 +1,55 @@
+import { randomUUID } from 'node:crypto'
 import { spawn } from 'node:child_process'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 import { allocateLocalhostPort, type LoopbackServerEndpoint } from '../../local-port.js'
-import { CodexAppServerClient } from './client.js'
-import type { CodexThreadResumeParams, CodexThreadStartParams } from './protocol.js'
+import { logger } from '../../logger.js'
+import {
+  CodexAppServerClient,
+  type CodexThreadLifecycleLossEvent,
+} from './client.js'
+import type { CodexInitializeResult, CodexThreadResumeParams, CodexThreadStartParams } from './protocol.js'
 
 type RuntimeStatus = 'running' | 'stopped'
 
-type ReadyState = {
+type WrapperIdentity = {
+  commandLine: string[]
+  cwd: string | null
+  startTimeTicks: number | null
+}
+
+export type CodexSidecarOwnershipMetadata = {
+  schemaVersion: 1
+  ownershipId: string
+  serverInstanceId: string
+  ownerServerPid: number
+  terminalId: string | null
+  generation: number | null
+  wsUrl: string
+  wrapperPid: number
+  processGroupId: number
+  wrapperIdentity: WrapperIdentity
+  createdAt: string
+  updatedAt: string
+  codexHome?: string
+}
+
+export type ReadyState = {
   wsUrl: string
   processPid: number
+  ownershipId: string
+  processGroupId: number
+  metadataPath: string
 }
+
+type ActiveOwnership = {
+  metadataDir: string
+  metadataPath: string
+  metadata: CodexSidecarOwnershipMetadata
+}
+
+type ChildProcessHandle = ReturnType<typeof spawn>
 
 type RuntimeOptions = {
   command?: string
@@ -18,22 +59,436 @@ type RuntimeOptions = {
   startupAttemptLimit?: number
   startupAttemptTimeoutMs?: number
   portAllocator?: () => Promise<LoopbackServerEndpoint>
+  metadataDir?: string
+  serverInstanceId?: string
+  ownershipIdFactory?: () => string
+  metadataWriter?: (filePath: string, metadata: CodexSidecarOwnershipMetadata) => Promise<void>
+  processIdentityReader?: (pid: number) => Promise<WrapperIdentity | null>
+}
+
+export type ReapOrphanedSidecarsOptions = {
+  metadataDir?: string
+  serverInstanceId: string
+  terminateGraceMs?: number
+}
+
+export type ReapOrphanedSidecarsResult = {
+  reapedOwnershipIds: string[]
+  ignoredLegacyRecords: string[]
+  skippedActiveOwnershipIds: string[]
+  failedOwnershipIds: string[]
 }
 
 const DEFAULT_STARTUP_ATTEMPT_LIMIT = 2
 const DEFAULT_STARTUP_ATTEMPT_TIMEOUT_MS = 3_000
 const STARTUP_POLL_MS = 50
+const DEFAULT_TERMINATE_GRACE_MS = 1_000
+const OWNERSHIP_SCHEMA_VERSION = 1
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function defaultMetadataDir(): string {
+  return process.env.FRESHELL_CODEX_SIDECAR_DIR
+    || path.join(os.homedir(), '.freshell', 'codex-sidecars')
+}
+
+function assertUnixSidecarSupport(): void {
+  if (process.platform !== 'linux') {
+    throw new Error('Codex app-server sidecar process-group ownership requires Linux /proc support.')
+  }
+}
+
+async function assertProcOwnershipProofAvailable(): Promise<void> {
+  assertUnixSidecarSupport()
+  let entries: string[]
+  try {
+    entries = await fsp.readdir('/proc')
+  } catch (error) {
+    throw new Error(
+      `Codex app-server sidecar requires readable Linux /proc ownership proof; failed to read /proc: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+  if (!entries.some((entry) => /^\d+$/.test(entry))) {
+    throw new Error('Codex app-server sidecar requires readable Linux /proc ownership proof with process entries.')
+  }
+}
+
+async function atomicWriteJson(filePath: string, value: unknown): Promise<void> {
+  await fsp.mkdir(path.dirname(filePath), { recursive: true })
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`
+  await fsp.writeFile(tmpPath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
+  await fsp.rename(tmpPath, filePath)
+}
+
+function parseProcStat(stat: string): { pgrp: number; startTimeTicks: number } | null {
+  const closeParen = stat.lastIndexOf(')')
+  if (closeParen === -1) return null
+  const fields = stat.slice(closeParen + 2).trim().split(/\s+/)
+  const pgrp = Number(fields[2])
+  const startTimeTicks = Number(fields[19])
+  if (!Number.isInteger(pgrp) || !Number.isFinite(startTimeTicks)) return null
+  return { pgrp, startTimeTicks }
+}
+
+async function getProcessGroupId(pid: number | 'self'): Promise<number | null> {
+  try {
+    const stat = await fsp.readFile(`/proc/${pid}/stat`, 'utf8')
+    return parseProcStat(stat)?.pgrp ?? null
+  } catch {
+    return null
+  }
+}
+
+async function readProcessIdentity(pid: number): Promise<WrapperIdentity | null> {
+  try {
+    const [cmdline, cwd, stat] = await Promise.all([
+      fsp.readFile(`/proc/${pid}/cmdline`).catch(() => Buffer.from('')),
+      fsp.readlink(`/proc/${pid}/cwd`).catch(() => null),
+      fsp.readFile(`/proc/${pid}/stat`, 'utf8'),
+    ])
+    const parsed = parseProcStat(stat)
+    const identity = {
+      commandLine: cmdline.toString('utf8').split('\0').filter(Boolean),
+      cwd,
+      startTimeTicks: parsed?.startTimeTicks ?? null,
+    }
+    return isCompleteWrapperIdentity(identity) ? identity : null
+  } catch {
+    return null
+  }
+}
+
+function isCompleteWrapperIdentity(identity: WrapperIdentity | null): identity is WrapperIdentity {
+  return !!identity
+    && identity.commandLine.length > 0
+    && typeof identity.cwd === 'string'
+    && identity.cwd.length > 0
+    && typeof identity.startTimeTicks === 'number'
+    && Number.isFinite(identity.startTimeTicks)
+}
+
+function wrapperIdentityMatches(record: CodexSidecarOwnershipMetadata, current: WrapperIdentity | null): boolean {
+  if (!current) return false
+  const expected = record.wrapperIdentity
+  if (expected.startTimeTicks === null || current.startTimeTicks === null) return false
+  if (expected.startTimeTicks !== current.startTimeTicks) return false
+  if (expected.cwd === null || current.cwd === null || expected.cwd !== current.cwd) return false
+  if (expected.commandLine.length === 0 || expected.commandLine.length !== current.commandLine.length) return false
+  return expected.commandLine.every((arg, index) => arg === current.commandLine[index])
+}
+
+function emptyWrapperIdentity(): WrapperIdentity {
+  return {
+    commandLine: [],
+    cwd: null,
+    startTimeTicks: null,
+  }
+}
+
+async function isPidAlive(pid: number): Promise<boolean> {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+async function processHasOwnershipEnv(pid: number, ownershipId: string): Promise<boolean> {
+  try {
+    const raw = await fsp.readFile(`/proc/${pid}/environ`)
+    return raw.toString('utf8').split('\0').includes(`FRESHELL_CODEX_SIDECAR_ID=${ownershipId}`)
+  } catch {
+    return false
+  }
+}
+
+async function processGroupMembers(processGroupId: number): Promise<number[]> {
+  const entries = await fsp.readdir('/proc')
+  const members: number[] = []
+
+  await Promise.all(entries.map(async (entry) => {
+    if (!/^\d+$/.test(entry)) return
+    const pid = Number(entry)
+    const pgrp = await getProcessGroupId(pid)
+    if (pgrp === processGroupId) members.push(pid)
+  }))
+
+  return members.sort((a, b) => a - b)
+}
+
+async function isProcessGroupGone(processGroupId: number): Promise<boolean> {
+  if (!Number.isInteger(processGroupId) || processGroupId <= 0) return true
+  try {
+    process.kill(-processGroupId, 0)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return true
+  }
+  return false
+}
+
+async function verifyOwnedProcessGroup(metadata: CodexSidecarOwnershipMetadata): Promise<boolean> {
+  if (await isProcessGroupGone(metadata.processGroupId)) return true
+
+  const currentProcessGroupId = await getProcessGroupId('self')
+  if (currentProcessGroupId !== null && metadata.processGroupId === currentProcessGroupId) {
+    return false
+  }
+
+  const wrapperProcessGroupId = await getProcessGroupId(metadata.wrapperPid)
+  if (wrapperProcessGroupId === metadata.processGroupId) {
+    const currentWrapperIdentity = await readProcessIdentity(metadata.wrapperPid)
+    if (wrapperIdentityMatches(metadata, currentWrapperIdentity)) {
+      return true
+    }
+  }
+
+  const members = await processGroupMembers(metadata.processGroupId)
+  for (const pid of members) {
+    if (await processHasOwnershipEnv(pid, metadata.ownershipId)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function signalProcessGroup(processGroupId: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(-processGroupId, signal)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+      throw error
+    }
+  }
+}
+
+async function waitForProcessGroupGone(processGroupId: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await isProcessGroupGone(processGroupId)) return true
+    await sleep(25)
+  }
+  return isProcessGroupGone(processGroupId)
+}
+
+async function teardownOwnedProcessGroup(
+  ownership: ActiveOwnership,
+  terminateGraceMs: number,
+): Promise<boolean> {
+  const { metadata } = ownership
+  if (!(await verifyOwnedProcessGroup(metadata))) {
+    logger.error(
+      {
+        ownershipId: metadata.ownershipId,
+        terminalId: metadata.terminalId,
+        generation: metadata.generation,
+        wsUrl: metadata.wsUrl,
+        wrapperPid: metadata.wrapperPid,
+        processGroupId: metadata.processGroupId,
+        serverInstanceId: metadata.serverInstanceId,
+      },
+      'Refusing to tear down Codex app-server sidecar because ownership could not be verified',
+    )
+    return false
+  }
+
+  if (!(await isProcessGroupGone(metadata.processGroupId))) {
+    signalProcessGroup(metadata.processGroupId, 'SIGTERM')
+  }
+  if (!(await waitForProcessGroupGone(metadata.processGroupId, terminateGraceMs))) {
+    if (!(await verifyOwnedProcessGroup(metadata))) {
+      logger.error(
+        {
+          ownershipId: metadata.ownershipId,
+          terminalId: metadata.terminalId,
+          generation: metadata.generation,
+          wsUrl: metadata.wsUrl,
+          wrapperPid: metadata.wrapperPid,
+          processGroupId: metadata.processGroupId,
+          serverInstanceId: metadata.serverInstanceId,
+        },
+        'Refusing SIGKILL for Codex app-server sidecar because ownership changed during shutdown',
+      )
+      return false
+    }
+    signalProcessGroup(metadata.processGroupId, 'SIGKILL')
+  }
+
+  const gone = await waitForProcessGroupGone(metadata.processGroupId, terminateGraceMs)
+  if (!gone) {
+    logger.error(
+      {
+        ownershipId: metadata.ownershipId,
+        terminalId: metadata.terminalId,
+        generation: metadata.generation,
+        wsUrl: metadata.wsUrl,
+        wrapperPid: metadata.wrapperPid,
+        processGroupId: metadata.processGroupId,
+        serverInstanceId: metadata.serverInstanceId,
+        remainingPids: await processGroupMembers(metadata.processGroupId),
+      },
+      'Codex app-server sidecar process group remained alive after shutdown',
+    )
+    return false
+  }
+
+  await fsp.unlink(ownership.metadataPath).catch((error) => {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code !== 'ENOENT' && code !== 'ENOTDIR') throw error
+  })
+  return true
+}
+
+type ParsedMetadataRecord =
+  | { kind: 'valid'; metadata: CodexSidecarOwnershipMetadata }
+  | { kind: 'legacy' }
+  | { kind: 'malformedNewSchema'; ownershipId: string }
+
+function isWrapperIdentity(value: unknown): value is WrapperIdentity {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<WrapperIdentity>
+  return Array.isArray(candidate.commandLine)
+    && candidate.commandLine.every((arg) => typeof arg === 'string')
+    && (candidate.cwd === null || typeof candidate.cwd === 'string')
+    && (candidate.startTimeTicks === null || typeof candidate.startTimeTicks === 'number')
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function parseMetadataRecord(raw: string, metadataPath: string): ParsedMetadataRecord {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return { kind: 'legacy' }
+  }
+  if (!parsed || typeof parsed !== 'object') return { kind: 'legacy' }
+  const candidate = parsed as Partial<CodexSidecarOwnershipMetadata>
+  if (candidate.schemaVersion !== OWNERSHIP_SCHEMA_VERSION) return { kind: 'legacy' }
+  const ownershipId = typeof candidate.ownershipId === 'string' ? candidate.ownershipId : metadataPath
+  if (
+    typeof candidate.ownershipId !== 'string'
+    || typeof candidate.serverInstanceId !== 'string'
+    || !isPositiveInteger(candidate.ownerServerPid)
+    || (candidate.terminalId !== null && typeof candidate.terminalId !== 'string')
+    || (candidate.generation !== null && !isNonNegativeInteger(candidate.generation))
+    || typeof candidate.wsUrl !== 'string'
+    || !isPositiveInteger(candidate.wrapperPid)
+    || !isPositiveInteger(candidate.processGroupId)
+    || !isWrapperIdentity(candidate.wrapperIdentity)
+    || typeof candidate.createdAt !== 'string'
+    || typeof candidate.updatedAt !== 'string'
+  ) {
+    return { kind: 'malformedNewSchema', ownershipId }
+  }
+  return { kind: 'valid', metadata: candidate as CodexSidecarOwnershipMetadata }
+}
+
+export async function reapOrphanedCodexAppServerSidecars(
+  options: ReapOrphanedSidecarsOptions,
+): Promise<ReapOrphanedSidecarsResult> {
+  const metadataDir = options.metadataDir ?? defaultMetadataDir()
+  const result: ReapOrphanedSidecarsResult = {
+    reapedOwnershipIds: [],
+    ignoredLegacyRecords: [],
+    skippedActiveOwnershipIds: [],
+    failedOwnershipIds: [],
+  }
+  let procOwnershipProofChecked = false
+  const ensureProcOwnershipProof = async () => {
+    if (procOwnershipProofChecked) return
+    await assertProcOwnershipProofAvailable()
+    procOwnershipProofChecked = true
+  }
+  const entries = await fsp.readdir(metadataDir).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  })
+
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) continue
+    const metadataPath = path.join(metadataDir, entry)
+    const raw = await fsp.readFile(metadataPath, 'utf8')
+    const parsed = parseMetadataRecord(raw, metadataPath)
+    if (parsed.kind === 'legacy') {
+      result.ignoredLegacyRecords.push(metadataPath)
+      await fsp.unlink(metadataPath).catch(() => undefined)
+      continue
+    }
+    if (parsed.kind === 'malformedNewSchema') {
+      result.failedOwnershipIds.push(parsed.ownershipId)
+      continue
+    }
+
+    await ensureProcOwnershipProof()
+    const metadata = parsed.metadata
+
+    if (await isPidAlive(metadata.ownerServerPid)) {
+      result.skippedActiveOwnershipIds.push(metadata.ownershipId)
+      continue
+    }
+
+    const currentProcessGroupId = await getProcessGroupId('self')
+    if (currentProcessGroupId !== null && metadata.processGroupId === currentProcessGroupId) {
+      result.skippedActiveOwnershipIds.push(metadata.ownershipId)
+      continue
+    }
+
+    const ownership: ActiveOwnership = { metadataDir, metadataPath, metadata }
+    const reaped = await teardownOwnedProcessGroup(ownership, options.terminateGraceMs ?? DEFAULT_TERMINATE_GRACE_MS)
+    if (reaped) {
+      result.reapedOwnershipIds.push(metadata.ownershipId)
+    } else {
+      result.failedOwnershipIds.push(metadata.ownershipId)
+    }
+  }
+
+  return result
+}
+
+export async function runCodexStartupReaper(
+  options: ReapOrphanedSidecarsOptions,
+): Promise<ReapOrphanedSidecarsResult> {
+  const result = await reapOrphanedCodexAppServerSidecars(options)
+  assertCodexStartupReaperSucceeded(result)
+  return result
+}
+
+export function assertCodexStartupReaperSucceeded(result: ReapOrphanedSidecarsResult): void {
+  const unreapedOwnershipIds = [
+    ...result.failedOwnershipIds,
+    ...result.skippedActiveOwnershipIds,
+  ]
+  if (unreapedOwnershipIds.length === 0) return
+
+  const blockedOwnershipIds = [...new Set(unreapedOwnershipIds)]
+  throw new Error(
+    `Codex app-server startup reaper failed to reap ${blockedOwnershipIds.length} ownership record(s): ${blockedOwnershipIds.join(', ')}. `
+    + 'Refusing to continue until the unreaped Codex sidecar ownership is verified gone or handled explicitly.',
+  )
+}
+
 export class CodexAppServerRuntime {
-  private child: ReturnType<typeof spawn> | null = null
+  private child: ChildProcessHandle | null = null
   private client: CodexAppServerClient | null = null
   private ready: ReadyState | null = null
   private ensureReadyPromise: Promise<ReadyState> | null = null
   private statusValue: RuntimeStatus = 'stopped'
+  private ownership: ActiveOwnership | null = null
+  private ownershipTeardownPromise: Promise<void> | null = null
+  private ownershipTeardownFailure: Error | null = null
+  private shutdownRequested = false
+  private lifecycleLossHandlers = new Set<(event: CodexThreadLifecycleLossEvent) => void>()
 
   private readonly command: string
   private readonly commandArgs: string[]
@@ -42,6 +497,11 @@ export class CodexAppServerRuntime {
   private readonly startupAttemptLimit: number
   private readonly startupAttemptTimeoutMs: number
   private readonly portAllocator: () => Promise<LoopbackServerEndpoint>
+  private readonly metadataDir: string
+  private readonly serverInstanceId: string
+  private readonly ownershipIdFactory: () => string
+  private readonly metadataWriter: (filePath: string, metadata: CodexSidecarOwnershipMetadata) => Promise<void>
+  private readonly processIdentityReader: (pid: number) => Promise<WrapperIdentity | null>
 
   constructor(options: RuntimeOptions = {}) {
     this.command = options.command ?? (process.env.CODEX_CMD || 'codex')
@@ -51,6 +511,11 @@ export class CodexAppServerRuntime {
     this.startupAttemptLimit = options.startupAttemptLimit ?? DEFAULT_STARTUP_ATTEMPT_LIMIT
     this.startupAttemptTimeoutMs = options.startupAttemptTimeoutMs ?? DEFAULT_STARTUP_ATTEMPT_TIMEOUT_MS
     this.portAllocator = options.portAllocator ?? allocateLocalhostPort
+    this.metadataDir = options.metadataDir ?? defaultMetadataDir()
+    this.serverInstanceId = options.serverInstanceId ?? process.env.FRESHELL_SERVER_INSTANCE_ID ?? `srv-${process.pid}`
+    this.ownershipIdFactory = options.ownershipIdFactory ?? (() => `codex-sidecar-${randomUUID()}`)
+    this.metadataWriter = options.metadataWriter ?? atomicWriteJson
+    this.processIdentityReader = options.processIdentityReader ?? readProcessIdentity
   }
 
   status(): RuntimeStatus {
@@ -58,6 +523,10 @@ export class CodexAppServerRuntime {
   }
 
   async ensureReady(): Promise<ReadyState> {
+    if (this.shutdownRequested) {
+      throw new Error('Codex app-server sidecar is shutting down.')
+    }
+    await this.assertNoBlockedOwnership('ensure Codex app-server sidecar readiness')
     if (this.ready) return this.ready
     if (this.ensureReadyPromise) return this.ensureReadyPromise
 
@@ -90,18 +559,58 @@ export class CodexAppServerRuntime {
     }
   }
 
-  async shutdown(): Promise<void> {
-    this.ready = null
-    this.ensureReadyPromise = null
-    this.statusValue = 'stopped'
+  async listLoadedThreads(): Promise<string[]> {
+    await this.ensureReady()
+    return this.client!.listLoadedThreads()
+  }
 
-    const client = this.client
-    this.client = null
-    if (client) {
-      await client.close().catch(() => undefined)
+  async updateOwnershipMetadata(input: {
+    terminalId?: string | null
+    generation?: number | null
+    codexHome?: string
+  }): Promise<void> {
+    await this.assertNoBlockedOwnership('update Codex app-server ownership metadata')
+    if (!this.ownership) {
+      throw new Error('Cannot update Codex app-server ownership metadata because no active owned Codex app-server sidecar exists.')
     }
+    this.ownership.metadata = {
+      ...this.ownership.metadata,
+      ...(input.terminalId !== undefined ? { terminalId: input.terminalId } : {}),
+      ...(input.generation !== undefined ? { generation: input.generation } : {}),
+      ...(input.codexHome !== undefined ? { codexHome: input.codexHome } : {}),
+      updatedAt: new Date().toISOString(),
+    }
+    await atomicWriteJson(this.ownership.metadataPath, this.ownership.metadata)
+  }
 
-    await this.stopActiveChild()
+  onThreadLifecycleLoss(handler: (event: CodexThreadLifecycleLossEvent) => void): () => void {
+    this.lifecycleLossHandlers.add(handler)
+    return () => {
+      this.lifecycleLossHandlers.delete(handler)
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this.shutdownRequested = true
+    try {
+      const pendingReady = this.ensureReadyPromise
+      this.ready = null
+      this.ensureReadyPromise = null
+      this.statusValue = 'stopped'
+
+      const client = this.client
+      this.client = null
+      if (client) {
+        await client.close().catch(() => undefined)
+      }
+
+      await this.stopActiveChild()
+      await pendingReady?.catch(() => undefined)
+      await this.stopActiveChild()
+      await this.assertNoBlockedOwnership('shut down Codex app-server sidecar')
+    } finally {
+      this.shutdownRequested = false
+    }
   }
 
   async simulateChildExitForTest(): Promise<void> {
@@ -109,23 +618,36 @@ export class CodexAppServerRuntime {
   }
 
   private async startRuntime(): Promise<ReadyState> {
+    await assertProcOwnershipProofAvailable()
+    await this.waitForOwnershipTeardown()
+    await this.assertNoBlockedOwnership('start a new Codex app-server sidecar')
     let lastError: Error | undefined
 
     for (let attempt = 1; attempt <= this.startupAttemptLimit; attempt += 1) {
+      if (this.shutdownRequested) {
+        throw new Error('Codex app-server startup was cancelled because the sidecar is shutting down.')
+      }
       const endpoint = await this.portAllocator()
+      if (this.shutdownRequested) {
+        throw new Error('Codex app-server startup was cancelled because the sidecar is shutting down.')
+      }
       const wsUrl = `ws://${endpoint.hostname}:${endpoint.port}`
+      const ownershipId = this.ownershipIdFactory()
       const child = spawn(this.command, [
         ...this.commandArgs,
         'app-server',
         '--listen',
         wsUrl,
       ], {
+        detached: true,
         env: {
           ...process.env,
           ...this.env,
+          FRESHELL_CODEX_SIDECAR_ID: ownershipId,
         },
         stdio: ['ignore', 'pipe', 'pipe'],
       })
+      const childErrorPromise = this.watchChildError(child)
 
       // Drain child stdio continuously so verbose app-server or MCP startup logs
       // cannot fill the pipe buffer and stall JSON-RPC request handling.
@@ -134,28 +656,79 @@ export class CodexAppServerRuntime {
 
       this.child = child
       this.attachChildExitHandler(child)
-
-      const client = new CodexAppServerClient(
-        { wsUrl },
-        this.requestTimeoutMs ? { requestTimeoutMs: this.requestTimeoutMs } : {},
-      )
-      this.client = client
+      let attemptOwnership: ActiveOwnership | null = null
 
       try {
-        await this.waitForInitialize(client, child)
+        if (!child.pid) {
+          const launchError = await Promise.race([
+            childErrorPromise,
+            sleep(25).then(() => null),
+          ])
+          if (launchError) throw launchError
+          throw new Error('Codex app-server sidecar spawn did not expose a wrapper PID.')
+        }
+
+        const ownership = this.createOwnershipRecord({
+          ownershipId,
+          wsUrl,
+          wrapperPid: child.pid,
+          processGroupId: child.pid,
+        })
+        this.ownership = ownership
+        attemptOwnership = ownership
+        await this.writeOwnershipRecord(ownership)
+        await this.readWrapperIdentityInto(ownership)
+        this.ownership = ownership
+        await this.writeOwnershipRecord(ownership)
+
+        const client = new CodexAppServerClient(
+          { wsUrl },
+          this.requestTimeoutMs ? { requestTimeoutMs: this.requestTimeoutMs } : {},
+        )
+        client.onThreadLifecycleLoss((event) => {
+          for (const handler of this.lifecycleLossHandlers) {
+            handler(event)
+          }
+        })
+        this.client = client
+
+        const initialized = await this.waitForInitialize(client, child, childErrorPromise)
+        await this.updateOwnershipMetadata({ codexHome: initialized.codexHome })
         this.statusValue = 'running'
         return {
           wsUrl,
-          processPid: child.pid ?? 0,
+          processPid: child.pid,
+          ownershipId,
+          processGroupId: child.pid,
+          metadataPath: ownership.metadataPath,
         }
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error))
-        await client.close().catch(() => undefined)
+        const client = this.client
+        if (client) {
+          await client.close().catch(() => undefined)
+        }
         if (this.client === client) {
           this.client = null
         }
-        await this.stopActiveChild()
+        if (attemptOwnership) {
+          await this.beginOwnershipTeardown(attemptOwnership).catch((teardownError) => {
+            if (lastError) {
+              lastError = new Error(`${lastError.message}; teardown failed: ${teardownError instanceof Error ? teardownError.message : String(teardownError)}`)
+            } else {
+              lastError = teardownError instanceof Error ? teardownError : new Error(String(teardownError))
+            }
+            throw lastError
+          })
+        } else {
+          await this.stopActiveChild()
+        }
+        if (this.shutdownRequested) break
       }
+    }
+
+    if (this.shutdownRequested) {
+      throw lastError ?? new Error('Codex app-server startup was cancelled because the sidecar is shutting down.')
     }
 
     throw new Error(
@@ -163,10 +736,60 @@ export class CodexAppServerRuntime {
     )
   }
 
+  private createOwnershipRecord(input: {
+    ownershipId: string
+    wsUrl: string
+    wrapperPid: number
+    processGroupId: number
+  }): ActiveOwnership {
+    const now = new Date().toISOString()
+    const metadata: CodexSidecarOwnershipMetadata = {
+      schemaVersion: OWNERSHIP_SCHEMA_VERSION,
+      ownershipId: input.ownershipId,
+      serverInstanceId: this.serverInstanceId,
+      ownerServerPid: process.pid,
+      terminalId: null,
+      generation: null,
+      wsUrl: input.wsUrl,
+      wrapperPid: input.wrapperPid,
+      processGroupId: input.processGroupId,
+      wrapperIdentity: emptyWrapperIdentity(),
+      createdAt: now,
+      updatedAt: now,
+    }
+    const metadataPath = path.join(this.metadataDir, `${input.ownershipId}.json`)
+    return {
+      metadataDir: this.metadataDir,
+      metadataPath,
+      metadata,
+    }
+  }
+
+  private async readWrapperIdentityInto(ownership: ActiveOwnership): Promise<void> {
+    const wrapperIdentity = await this.processIdentityReader(ownership.metadata.wrapperPid)
+    if (!isCompleteWrapperIdentity(wrapperIdentity)) {
+      throw new Error(
+        `Codex app-server wrapper identity could not be completely read for PID ${ownership.metadata.wrapperPid}.`,
+      )
+    }
+    ownership.metadata = {
+      ...ownership.metadata,
+      wrapperIdentity,
+      updatedAt: new Date().toISOString(),
+    }
+  }
+
+  private async writeOwnershipRecord(ownership: ActiveOwnership): Promise<void> {
+    await this.metadataWriter(ownership.metadataPath, ownership.metadata).catch((error) => {
+      throw new Error(`Codex app-server ownership metadata write failed: ${error instanceof Error ? error.message : String(error)}`)
+    })
+  }
+
   private async waitForInitialize(
     client: CodexAppServerClient,
-    child: ReturnType<typeof spawn>,
-  ): Promise<void> {
+    child: ChildProcessHandle,
+    childErrorPromise: Promise<Error>,
+  ): Promise<CodexInitializeResult> {
     const deadline = Date.now() + this.startupAttemptTimeoutMs
     let lastError: Error | undefined
 
@@ -174,10 +797,18 @@ export class CodexAppServerRuntime {
       if (child.exitCode !== null || child.signalCode !== null) {
         break
       }
+      const remainingMs = Math.max(0, deadline - Date.now())
 
       try {
-        await client.initialize()
-        return
+        return await Promise.race([
+          client.initialize(),
+          childErrorPromise.then((error) => {
+            throw error
+          }),
+          sleep(remainingMs).then(() => {
+            throw new Error(`Codex app-server did not finish initialize within ${this.startupAttemptTimeoutMs}ms.`)
+          }),
+        ])
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error))
         await sleep(STARTUP_POLL_MS)
@@ -187,12 +818,32 @@ export class CodexAppServerRuntime {
     throw lastError ?? new Error('Codex app-server exited before it finished initializing.')
   }
 
-  private attachChildExitHandler(child: ReturnType<typeof spawn>): void {
+  private watchChildError(child: ChildProcessHandle): Promise<Error> {
+    return new Promise((resolve) => {
+      child.once('error', (error) => {
+        const base = error instanceof Error ? error : new Error(String(error))
+        const launchError = new Error(`Failed to launch Codex app-server sidecar: ${base.message}`)
+        ;(launchError as Error & { code?: string; cause?: unknown }).code =
+          (base as NodeJS.ErrnoException).code
+        ;(launchError as Error & { code?: string; cause?: unknown }).cause = base
+        if (this.child === child) {
+          this.child = null
+          this.ready = null
+          this.ensureReadyPromise = null
+          this.statusValue = 'stopped'
+        }
+        resolve(launchError)
+      })
+    })
+  }
+
+  private attachChildExitHandler(child: ChildProcessHandle): void {
     child.once('exit', () => {
       if (this.child !== child) {
         return
       }
 
+      const ownership = this.ownership
       this.child = null
       this.ready = null
       this.ensureReadyPromise = null
@@ -200,32 +851,110 @@ export class CodexAppServerRuntime {
 
       const client = this.client
       this.client = null
-      void client?.close().catch(() => undefined)
+      const closeClient = client?.close().catch(() => undefined)
+      if (ownership) {
+        void this.beginOwnershipTeardown(ownership, closeClient).catch((error) => {
+          logger.error(
+            {
+              err: error,
+              ownershipId: ownership.metadata.ownershipId,
+              terminalId: ownership.metadata.terminalId,
+              generation: ownership.metadata.generation,
+              wsUrl: ownership.metadata.wsUrl,
+              wrapperPid: ownership.metadata.wrapperPid,
+              processGroupId: ownership.metadata.processGroupId,
+              serverInstanceId: ownership.metadata.serverInstanceId,
+            },
+            'Codex app-server sidecar teardown after wrapper exit failed',
+          )
+        })
+      } else {
+        void closeClient
+      }
     })
   }
 
   private async stopActiveChild(): Promise<void> {
+    const ownership = this.ownership
     const child = this.child
     this.child = null
     this.ready = null
     this.statusValue = 'stopped'
 
-    if (!child || child.exitCode !== null || child.signalCode !== null) {
+    if (!ownership) {
+      if (child && child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGTERM')
+      }
       return
     }
 
-    child.kill('SIGTERM')
-    await new Promise<void>((resolve) => {
-      const timeout = setTimeout(() => {
-        if (child.exitCode === null && child.signalCode === null) {
-          child.kill('SIGKILL')
-        }
-        resolve()
-      }, 1_000)
-      child.once('exit', () => {
-        clearTimeout(timeout)
-        resolve()
+    await this.beginOwnershipTeardown(ownership)
+  }
+
+  private async waitForOwnershipTeardown(): Promise<void> {
+    const pending = this.ownershipTeardownPromise
+    if (pending) await pending
+    await this.assertNoBlockedOwnership('continue Codex app-server ownership lifecycle')
+  }
+
+  private async assertNoBlockedOwnership(operation: string): Promise<void> {
+    const failure = this.ownershipTeardownFailure
+    if (!failure) return
+
+    const ownership = this.ownership
+    if (!ownership) {
+      this.ownershipTeardownFailure = null
+      return
+    }
+
+    if (await isProcessGroupGone(ownership.metadata.processGroupId)) {
+      await fsp.unlink(ownership.metadataPath).catch((error) => {
+        const code = (error as NodeJS.ErrnoException).code
+        if (code !== 'ENOENT' && code !== 'ENOTDIR') throw error
       })
+      if (this.ownership === ownership) {
+        this.ownership = null
+      }
+      this.ownershipTeardownFailure = null
+      return
+    }
+
+    throw new Error(
+      `Cannot ${operation} because Codex app-server ownership ${ownership.metadata.ownershipId} is blocked after teardown failed: ${failure.message}`,
+    )
+  }
+
+  private beginOwnershipTeardown(
+    ownership: ActiveOwnership,
+    beforeTeardown?: Promise<unknown>,
+  ): Promise<void> {
+    if (this.ownershipTeardownPromise) return this.ownershipTeardownPromise
+
+    const teardown = (async () => {
+      await beforeTeardown?.catch(() => undefined)
+      try {
+        const stopped = await teardownOwnedProcessGroup(ownership, DEFAULT_TERMINATE_GRACE_MS)
+        if (!stopped) {
+          throw new Error(
+            `Codex app-server sidecar process-group teardown failed for ownership ${ownership.metadata.ownershipId}.`,
+          )
+        }
+        if (stopped && this.ownership === ownership) {
+          this.ownership = null
+        }
+        this.ownershipTeardownFailure = null
+      } catch (error) {
+        const failure = error instanceof Error ? error : new Error(String(error))
+        this.ownershipTeardownFailure = failure
+        throw failure
+      }
+    })()
+    const tracked = teardown.finally(() => {
+      if (this.ownershipTeardownPromise === tracked) {
+        this.ownershipTeardownPromise = null
+      }
     })
+    this.ownershipTeardownPromise = tracked
+    return tracked
   }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -70,9 +70,13 @@ import { createAgentHistorySource } from './agent-timeline/history-source.js'
 import { createTerminalViewService } from './terminal-view/service.js'
 import { resolveStartupBanner } from './startup-banner.js'
 import { shouldPromoteSessionTitle } from './session-title-sync.js'
-import { CodexAppServerRuntime } from './coding-cli/codex-app-server/runtime.js'
+import {
+  CodexAppServerRuntime,
+  runCodexStartupReaper,
+} from './coding-cli/codex-app-server/runtime.js'
 import { CodexLaunchPlanner } from './coding-cli/codex-app-server/launch-planner.js'
 import { registerStaticClientRoutes } from './static-client-routes.js'
+import { joinCodexShutdownOwners } from './shutdown-join.js'
 
 function compileArgTemplate(
   template: string[] | undefined,
@@ -193,6 +197,7 @@ async function main() {
 
   const sessionRepairService = getSessionRepairService({ skipDiscovery: true })
   const serverInstanceId = await loadOrCreateServerInstanceId()
+  await runCodexStartupReaper({ serverInstanceId })
 
   let sdkBridge: SdkBridge
 
@@ -289,8 +294,7 @@ async function main() {
   sdkBridge = new SdkBridge(agentHistorySource)
 
   const server = http.createServer(app)
-  const codexAppServerRuntime = new CodexAppServerRuntime()
-  const codexLaunchPlanner = new CodexLaunchPlanner(codexAppServerRuntime)
+  const codexLaunchPlanner = new CodexLaunchPlanner(() => new CodexAppServerRuntime({ serverInstanceId }))
   const wsHandler = new WsHandler(
     server,
     registry,
@@ -329,6 +333,12 @@ async function main() {
   const vitePort = isDev ? Number(process.env.VITE_PORT || 5173) : undefined
   const networkManager = new NetworkManager(server, configStore, port, isDev, vitePort)
   networkManager.setWsHandler(wsHandler)
+  let terminalCreateAdmissionOpen = true
+  const assertTerminalCreateAccepted = () => {
+    if (!terminalCreateAdmissionOpen) {
+      throw new Error('Server is shutting down; terminal creation is not accepted.')
+    }
+  }
   app.use('/api', createAgentApiRouter({
     layoutStore,
     registry,
@@ -338,6 +348,7 @@ async function main() {
     codingCliIndexer,
     codexActivityTracker: codexActivity.tracker,
     codexLaunchPlanner,
+    assertTerminalCreateAccepted,
   }))
 
   // --- Extension lifecycle broadcasts ---
@@ -760,51 +771,59 @@ async function main() {
 
     log.info({ signal }, 'Shutting down...')
 
-    // 1. Stop accepting new connections by closing the HTTP server
-    server.close((err) => {
-      if (err) {
-        log.warn({ err }, 'Error closing HTTP server')
-      }
-    })
-
-    // 2. Stop any coalesced sessions publish timers
-    sessionsSync.shutdown()
-
-    // 3. Gracefully shut down terminals (gives Claude time to flush JSONL writes)
-    await registry.shutdownGracefully(5000)
-
-    // 4. Kill all coding CLI sessions
-    codingCliSessionManager.shutdown()
-
-    // 4b. Stop the shared Codex app-server runtime
-    await codexAppServerRuntime.shutdown()
-
-    // 5. Close SDK bridge sessions
-    sdkBridge.close()
-
-    // 5b. Stop extension servers
-    await extensionManager.stopAll()
-
-    // 6. Stop NetworkManager
-    await networkManager.stop()
-
-    // 7. Close WebSocket connections gracefully
+    // 1. Establish terminal creation admission barriers before waiting on terminal teardown.
+    terminalCreateAdmissionOpen = false
     wsHandler.close()
 
-    // 7. Close port forwards
+    // 2. Stop accepting new connections by closing the HTTP server
+    const httpServerClosed = new Promise<void>((resolve) => {
+      server.close((err) => {
+        if (err) {
+          log.warn({ err }, 'Error closing HTTP server')
+        }
+        resolve()
+      })
+    })
+
+    // 3. Stop any coalesced sessions publish timers
+    sessionsSync.shutdown()
+
+    // 4. Gracefully shut down terminals and planner-owned Codex app-server sidecars.
+    try {
+      await httpServerClosed
+      await joinCodexShutdownOwners({
+        registry,
+        codexLaunchPlanner,
+        terminalShutdownTimeoutMs: 5000,
+      })
+    } finally {
+      // 5. Kill all coding CLI sessions
+      codingCliSessionManager.shutdown()
+    }
+
+    // 6. Close SDK bridge sessions
+    sdkBridge.close()
+
+    // 6b. Stop extension servers
+    await extensionManager.stopAll()
+
+    // 7. Stop NetworkManager
+    await networkManager.stop()
+
+    // 8. Close port forwards
     await portForwardManager.closeAll()
 
-    // 8. Stop session indexer
+    // 9. Stop session indexer
     await codingCliIndexer.stop()
 
-    // 8b. Stop Codex activity tracker listeners and sweep timer
+    // 9b. Stop Codex activity tracker listeners and sweep timer
     codexActivity.dispose()
     opencodeActivity.dispose()
 
-    // 9. Stop session repair service
+    // 10. Stop session repair service
     await sessionRepairService.stop()
 
-    // 10. Exit cleanly
+    // 11. Exit cleanly
     log.info('Shutdown complete')
     process.exit(0)
   }

--- a/server/shutdown-join.ts
+++ b/server/shutdown-join.ts
@@ -1,0 +1,50 @@
+export async function collectShutdownFailures(tasks: Iterable<PromiseLike<unknown>>): Promise<unknown[]> {
+  const results = await Promise.allSettled([...tasks])
+  return results
+    .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+    .map((result) => result.reason)
+}
+
+export function throwShutdownFailures(failures: unknown[], message: string): void {
+  if (failures.length === 0) return
+  if (failures.length === 1) {
+    throw failures[0]
+  }
+  throw new AggregateError(failures, message)
+}
+
+export async function waitForAllSettledOrThrow(
+  tasks: Iterable<PromiseLike<unknown>>,
+  message: string,
+): Promise<void> {
+  throwShutdownFailures(await collectShutdownFailures(tasks), message)
+}
+
+function invokeShutdownTask(task: () => PromiseLike<unknown>): Promise<unknown> {
+  try {
+    return Promise.resolve(task())
+  } catch (error) {
+    return Promise.reject(error)
+  }
+}
+
+type CodexShutdownOwners = {
+  registry: {
+    shutdownGracefully(timeoutMs?: number): Promise<void>
+  }
+  codexLaunchPlanner: {
+    shutdown(): Promise<void>
+  }
+  terminalShutdownTimeoutMs: number
+}
+
+export async function joinCodexShutdownOwners({
+  registry,
+  codexLaunchPlanner,
+  terminalShutdownTimeoutMs,
+}: CodexShutdownOwners): Promise<void> {
+  await waitForAllSettledOrThrow([
+    invokeShutdownTask(() => registry.shutdownGracefully(terminalShutdownTimeoutMs)),
+    invokeShutdownTask(() => codexLaunchPlanner.shutdown()),
+  ], 'Codex shutdown owners failed.')
+}

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -24,6 +24,9 @@ import type {
 } from './terminal-stream/registry-events.js'
 import { getOpencodeEnvOverrides, resolveOpencodeLaunchModel } from './opencode-launch.js'
 import { generateMcpInjection, cleanupMcpConfig } from './mcp/config-writer.js'
+import type { CodexLaunchPlan, CodexLaunchSidecar } from './coding-cli/codex-app-server/launch-planner.js'
+import { isCodexSidecarTeardownError } from './coding-cli/codex-app-server/launch-planner.js'
+import { collectShutdownFailures, throwShutdownFailures } from './shutdown-join.js'
 
 const MAX_WS_BUFFERED_AMOUNT = Number(process.env.MAX_WS_BUFFERED_AMOUNT || 2 * 1024 * 1024)
 const DEFAULT_MAX_SCROLLBACK_CHARS = Number(process.env.MAX_SCROLLBACK_CHARS || 512 * 1024)
@@ -172,8 +175,25 @@ export type ProviderSettings = {
   sandbox?: string
   codexAppServer?: {
     wsUrl: string
+    sidecar?: CodexLaunchSidecar
+    recovery?: CodexRecoveryOptions
+    deferLifecycleUntilPublished?: boolean
   }
   opencodeServer?: LoopbackServerEndpoint
+}
+
+export type CodexRecoveryLaunchInput = {
+  terminalId: string
+  generation: number
+  cwd?: string
+  resumeSessionId: string
+}
+
+export type CodexRecoveryOptions = {
+  planCreate(input: CodexRecoveryLaunchInput): Promise<CodexLaunchPlan>
+  retryDelayMs?: number
+  readinessTimeoutMs?: number
+  readinessPollMs?: number
 }
 
 function resolveCodingCliCommand(
@@ -343,6 +363,34 @@ function wrapTerminalSpawnError(
   return wrapped
 }
 
+type CodexRecoveryTeardownError = Error & {
+  codexRecoveryTeardownFailed?: boolean
+}
+
+function codexRecoveryTeardownError(message: string): CodexRecoveryTeardownError {
+  const error = new Error(message) as CodexRecoveryTeardownError
+  error.codexRecoveryTeardownFailed = true
+  return error
+}
+
+export function terminalIdFromCreateError(error: unknown): string | undefined {
+  if (!error || (typeof error !== 'object' && typeof error !== 'function')) return undefined
+  const terminalId = (error as { terminalId?: unknown }).terminalId
+  return typeof terminalId === 'string' ? terminalId : undefined
+}
+
+function attachTerminalIdToCreateError(error: unknown, terminalId: string): unknown {
+  const target: { terminalId?: string } = error && (typeof error === 'object' || typeof error === 'function')
+    ? error as { terminalId?: string }
+    : new Error(String(error)) as Error & { terminalId?: string }
+  try {
+    target.terminalId ??= terminalId
+  } catch {
+    // Preserve the original failure even if the thrown value rejects mutation.
+  }
+  return target
+}
+
 type PendingSnapshotQueue = {
   chunks: string[]
   queuedChars: number
@@ -353,6 +401,14 @@ type PendingOutput = {
   chunksByTerminal: Map<string, string[]>
   perfByTerminal: Map<string, TerminalRecord['perf'] | undefined>
   queuedChars: number
+}
+
+type SidecarShutdownEntry = {
+  promise: Promise<void>
+  status: 'pending' | 'failed'
+  terminalId: string
+  shutdownSidecar: () => Promise<void>
+  failureMessage: string
 }
 
 export type TerminalRecord = {
@@ -369,6 +425,8 @@ export type TerminalRecord = {
   status: 'running' | 'exited'
   exitCode?: number
   cwd?: string
+  shell: ShellType
+  envContext?: { tabId?: string; paneId?: string }
   /** Normalized cwd used for MCP config injection (may differ from raw cwd on WSL). */
   mcpCwd?: string
   cols: number
@@ -392,6 +450,17 @@ export type TerminalRecord = {
     lastInputToOutputMs?: number
     maxInputToOutputMs: number
   }
+  codexSidecar?: Pick<CodexLaunchSidecar, 'shutdown' | 'onLifecycleLoss'>
+  codexSidecarLifecycleUnsubscribe?: () => void
+  codexSidecarLifecyclePublished?: boolean
+  codexSidecarPrePublicationLoss?: unknown
+  codexSidecarGeneration?: number
+  codexRecovery?: CodexRecoveryOptions
+  codexRecoveryAttempt?: Promise<void>
+  codexRecoveryRetry?: { timer: NodeJS.Timeout; resolve: () => void }
+  codexRecoveryBlockedError?: Error
+  codexRecoveryFinalClose?: boolean
+  codexRecoveryRetiringPty?: pty.IPty
 }
 
 export type BindSessionResult =
@@ -935,6 +1004,7 @@ export class TerminalRegistry extends EventEmitter {
   private maxExitedTerminals: number
   private scrollbackMaxChars: number
   private maxPendingSnapshotChars: number
+  private sidecarShutdowns = new Map<string, SidecarShutdownEntry>()
   // Legacy transport batching path. Broker cutover destination:
   // - outputBuffers/flush timers/mobile batching -> broker client-output queue.
   private outputBuffers = new Map<WebSocket, PendingOutput>()
@@ -1085,13 +1155,28 @@ export class TerminalRegistry extends EventEmitter {
     if (!max || max <= 0) return
 
     const exited = Array.from(this.terminals.values())
-      .filter((t) => t.status === 'exited')
+      .filter((t) => t.status === 'exited' && !t.codexSidecar && this.sidecarShutdownPromisesForTerminal(t.terminalId).length === 0)
       .sort((a, b) => (a.exitedAt ?? a.lastActivityAt) - (b.exitedAt ?? b.lastActivityAt))
 
     const excess = exited.length - max
     if (excess <= 0) return
     for (let i = 0; i < excess; i += 1) {
       this.terminals.delete(exited[i].terminalId)
+    }
+  }
+
+  private buildTerminalBaseEnv(
+    terminalId: string,
+    envContext?: { tabId?: string; paneId?: string },
+  ): Record<string, string> {
+    const port = Number(process.env.PORT || 3001)
+    return {
+      FRESHELL: '1',
+      FRESHELL_URL: process.env.FRESHELL_URL || `http://localhost:${port}`,
+      FRESHELL_TOKEN: process.env.AUTH_TOKEN || '',
+      FRESHELL_TERMINAL_ID: terminalId,
+      ...(envContext?.tabId ? { FRESHELL_TAB_ID: envContext.tabId } : {}),
+      ...(envContext?.paneId ? { FRESHELL_PANE_ID: envContext.paneId } : {}),
     }
   }
 
@@ -1119,20 +1204,13 @@ export class TerminalRegistry extends EventEmitter {
     const cwd = opts.cwd || getDefaultCwd(this.settings) || (isWindows() ? undefined : os.homedir())
     const resumeForSpawn = normalizeResumeForSpawn(opts.mode, opts.resumeSessionId)
     const resumeForBinding = normalizeResumeForBinding(opts.mode, opts.resumeSessionId)
-    const port = Number(process.env.PORT || 3001)
-    const baseEnv = {
-      FRESHELL: '1',
-      FRESHELL_URL: process.env.FRESHELL_URL || `http://localhost:${port}`,
-      FRESHELL_TOKEN: process.env.AUTH_TOKEN || '',
-      FRESHELL_TERMINAL_ID: terminalId,
-      ...(opts.envContext?.tabId ? { FRESHELL_TAB_ID: opts.envContext.tabId } : {}),
-      ...(opts.envContext?.paneId ? { FRESHELL_PANE_ID: opts.envContext.paneId } : {}),
-    }
+    const shell = opts.shell || 'system'
+    const baseEnv = this.buildTerminalBaseEnv(terminalId, opts.envContext)
 
     const { file, args, env, cwd: procCwd, mcpCwd } = buildSpawnSpec(
       opts.mode,
       cwd,
-      opts.shell || 'system',
+      shell,
       resumeForSpawn,
       opts.providerSettings,
       baseEnv,
@@ -1141,11 +1219,11 @@ export class TerminalRegistry extends EventEmitter {
 
     const endSpawnTimer = startPerfTimer(
       'terminal_spawn',
-      { terminalId, mode: opts.mode, shell: opts.shell || 'system' },
+      { terminalId, mode: opts.mode, shell },
       { minDurationMs: perfConfig.slowTerminalCreateMs, level: 'warn' },
     )
 
-    logger.info({ terminalId, file, args, cwd: procCwd, mode: opts.mode, shell: opts.shell || 'system' }, 'Spawning terminal')
+    logger.info({ terminalId, file, args, cwd: procCwd, mode: opts.mode, shell }, 'Spawning terminal')
 
     let ptyProc: ReturnType<typeof pty.spawn>
     try {
@@ -1182,6 +1260,8 @@ export class TerminalRegistry extends EventEmitter {
       lastActivityAt: createdAt,
       status: 'running',
       cwd,
+      shell,
+      envContext: opts.envContext,
       mcpCwd,
       cols,
       rows,
@@ -1191,6 +1271,12 @@ export class TerminalRegistry extends EventEmitter {
 
       buffer: new ChunkRingBuffer(this.scrollbackMaxChars),
       pty: ptyProc,
+      codexSidecar: opts.mode === 'codex' ? opts.providerSettings?.codexAppServer?.sidecar : undefined,
+      codexSidecarLifecyclePublished: opts.mode === 'codex'
+        ? !opts.providerSettings?.codexAppServer?.deferLifecycleUntilPublished
+        : undefined,
+      codexSidecarGeneration: opts.mode === 'codex' ? 0 : undefined,
+      codexRecovery: opts.mode === 'codex' ? opts.providerSettings?.codexAppServer?.recovery : undefined,
       perf: perfConfig.enabled
         ? {
             outBytes: 0,
@@ -1204,11 +1290,14 @@ export class TerminalRegistry extends EventEmitter {
             lastInputBytes: undefined,
             lastInputToOutputMs: undefined,
             maxInputToOutputMs: 0,
-          }
-        : undefined,
+	          }
+	        : undefined,
     }
 
+    this.registerCodexSidecarLifecycle(record)
+
     ptyProc.onData((data) => {
+      if (record.pty !== ptyProc) return
       const now = Date.now()
       record.lastActivityAt = now
       record.buffer.append(data)
@@ -1277,9 +1366,16 @@ export class TerminalRegistry extends EventEmitter {
     })
 
     ptyProc.onExit((e) => {
+      if (record.codexRecoveryRetiringPty === ptyProc) {
+        return
+      }
+      if (record.pty !== ptyProc) {
+        return
+      }
       if (record.status === 'exited') {
         return
       }
+      this.markCodexRecoveryFinalClose(record)
       record.status = 'exited'
       record.exitCode = e.exitCode
       const now = Date.now()
@@ -1295,6 +1391,7 @@ export class TerminalRegistry extends EventEmitter {
       record.pendingSnapshotClients.clear()
       this.releaseBinding(terminalId, 'exit')
       this.emit('terminal.exit', { terminalId, exitCode: e.exitCode })
+      void this.releaseCodexSidecar(record).catch(() => undefined)
       this.reapExitedTerminals()
     })
 
@@ -1321,8 +1418,394 @@ export class TerminalRegistry extends EventEmitter {
         'Terminal created with named resume; awaiting session association',
       )
     }
-    this.emit('terminal.created', record)
+    try {
+      this.emit('terminal.created', record)
+    } catch (err) {
+      throw attachTerminalIdToCreateError(err, terminalId)
+    }
     return record
+  }
+
+  private registerCodexSidecarLifecycle(record: TerminalRecord): void {
+    record.codexSidecarLifecycleUnsubscribe?.()
+    record.codexSidecarLifecycleUnsubscribe = record.codexSidecar?.onLifecycleLoss?.((event) => {
+      this.handleCodexLifecycleLoss(record.terminalId, event)
+    })
+  }
+
+  publishCodexSidecar(terminalId: string): void {
+    const record = this.terminals.get(terminalId)
+    if (!record) {
+      throw new Error(`Cannot publish Codex sidecar for missing terminal ${terminalId}.`)
+    }
+    if (!record.codexSidecar) return
+    if (record.codexSidecarPrePublicationLoss !== undefined) {
+      throw new Error('Codex app-server reported lifecycle loss before terminal create completed.')
+    }
+    if (record.status !== 'running') {
+      throw new Error('Codex terminal PTY exited before create completed.')
+    }
+    record.codexSidecarLifecyclePublished = true
+  }
+
+  private handleCodexLifecycleLoss(terminalId: string, event: unknown): void {
+    const record = this.terminals.get(terminalId)
+    if (!record || record.status !== 'running' || record.codexRecoveryFinalClose) return
+
+    if (!record.codexSidecarLifecyclePublished) {
+      record.codexSidecarPrePublicationLoss = event
+      logger.warn(
+        { terminalId, event },
+        'Codex app-server reported lifecycle loss before terminal create completed',
+      )
+      return
+    }
+
+    const eventThreadId = typeof event === 'object' && event !== null && 'threadId' in event
+      ? (event as { threadId?: unknown }).threadId
+      : undefined
+    if (
+      typeof eventThreadId === 'string'
+      && record.resumeSessionId
+      && eventThreadId !== record.resumeSessionId
+    ) {
+      return
+    }
+
+    if (!record.resumeSessionId || !record.codexRecovery) {
+      logger.warn(
+        { terminalId, event },
+        'Codex app-server reported terminal lifecycle loss without durable recovery; closing terminal',
+      )
+      void this.killAndWait(terminalId).catch((err) => {
+        logger.error({ err, terminalId }, 'Failed to close terminal after Codex app-server lifecycle loss')
+      })
+      return
+    }
+
+    if (record.codexRecoveryBlockedError) {
+      logger.error(
+        { err: record.codexRecoveryBlockedError, terminalId, event },
+        'Codex durable recovery is blocked by a previous sidecar teardown failure',
+      )
+      return
+    }
+
+    if (record.codexRecoveryAttempt) return
+
+    logger.warn(
+      { terminalId, event, resumeSessionId: record.resumeSessionId },
+      'Codex app-server reported terminal lifecycle loss; starting durable recovery',
+    )
+    const attempt = this.runCodexRecoveryLoop(terminalId)
+      .catch((err) => {
+        logger.error({ err, terminalId }, 'Codex durable recovery loop failed')
+      })
+      .finally(() => {
+        const latest = this.terminals.get(terminalId)
+        if (latest?.codexRecoveryAttempt === attempt) {
+          latest.codexRecoveryAttempt = undefined
+        }
+      })
+    record.codexRecoveryAttempt = attempt
+  }
+
+  private canContinueCodexRecovery(record: TerminalRecord | undefined, resumeSessionId?: string): record is TerminalRecord {
+    return !!record
+      && record.status === 'running'
+      && !record.codexRecoveryFinalClose
+      && !record.codexRecoveryBlockedError
+      && !!record.codexRecovery
+      && !!record.resumeSessionId
+      && (!resumeSessionId || record.resumeSessionId === resumeSessionId)
+  }
+
+  private async runCodexRecoveryLoop(terminalId: string): Promise<void> {
+    while (true) {
+      const record = this.terminals.get(terminalId)
+      if (!this.canContinueCodexRecovery(record)) return
+      const resumeSessionId = record.resumeSessionId!
+
+      try {
+        await this.runCodexRecoveryAttempt(record, resumeSessionId)
+        return
+      } catch (err) {
+        if (
+          (err as { codexRecoveryTeardownFailed?: boolean })?.codexRecoveryTeardownFailed
+          || isCodexSidecarTeardownError(err)
+        ) {
+          this.blockCodexRecovery(record, err)
+          throw err
+        }
+        logger.warn(
+          { err, terminalId, resumeSessionId: record.resumeSessionId },
+          'Codex durable recovery candidate failed; retrying after teardown',
+        )
+      }
+
+      const latest = this.terminals.get(terminalId)
+      if (!this.canContinueCodexRecovery(latest, resumeSessionId)) return
+      await this.waitForCodexRecoveryRetry(latest, latest.codexRecovery?.retryDelayMs ?? 1_000)
+    }
+  }
+
+  private waitForCodexRecoveryRetry(record: TerminalRecord, delayMs: number): Promise<void> {
+    if (record.codexRecoveryFinalClose) return Promise.resolve()
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        if (record.codexRecoveryRetry?.timer === timer) {
+          record.codexRecoveryRetry = undefined
+        }
+        resolve()
+      }, Math.max(0, delayMs))
+      timer.unref?.()
+      record.codexRecoveryRetry = {
+        timer,
+        resolve: () => {
+          clearTimeout(timer)
+          if (record.codexRecoveryRetry?.timer === timer) {
+            record.codexRecoveryRetry = undefined
+          }
+          resolve()
+        },
+      }
+    })
+  }
+
+  private blockCodexRecovery(record: TerminalRecord, err: unknown): void {
+    record.codexRecoveryBlockedError = err instanceof Error ? err : new Error(String(err))
+    const retry = record.codexRecoveryRetry
+    if (retry) {
+      retry.resolve()
+    }
+  }
+
+  private markCodexRecoveryFinalClose(record: TerminalRecord): void {
+    record.codexRecoveryFinalClose = true
+    const retry = record.codexRecoveryRetry
+    if (retry) {
+      retry.resolve()
+    }
+  }
+
+  private async runCodexRecoveryAttempt(
+    record: TerminalRecord,
+    resumeSessionId: string,
+  ): Promise<void> {
+    const recovery = record.codexRecovery
+    if (!recovery) return
+    const generation = (record.codexSidecarGeneration ?? 0) + 1
+    let plan: CodexLaunchPlan | undefined
+    let candidate: { pty: ReturnType<typeof pty.spawn>; mcpCwd?: string; exited: boolean; exitCode?: number } | undefined
+    let published = false
+
+    const cleanupCandidate = async () => {
+      if (candidate && !published) {
+        try {
+          candidate.pty.kill()
+        } catch (err) {
+          logger.warn({ err, terminalId: record.terminalId }, 'Failed to kill unpublished Codex recovery PTY')
+        }
+      }
+      if (plan) {
+        try {
+          await this.trackSidecarShutdown(
+            record.terminalId,
+            `recovery-candidate:${generation}`,
+            () => plan!.sidecar.shutdown(),
+            'Codex recovery candidate sidecar shutdown failed',
+          )
+        } catch (err) {
+          throw codexRecoveryTeardownError(
+            `Codex recovery candidate teardown failed: ${err instanceof Error ? err.message : String(err)}`,
+          )
+        }
+      }
+    }
+
+    try {
+      plan = await recovery.planCreate({
+        terminalId: record.terminalId,
+        generation,
+        cwd: record.cwd,
+        resumeSessionId,
+      })
+      if (!this.canContinueCodexRecovery(this.terminals.get(record.terminalId), resumeSessionId)) {
+        await cleanupCandidate()
+        return
+      }
+
+      candidate = this.spawnCodexRecoveryPty(record, plan, resumeSessionId)
+      await plan.sidecar.adopt({ terminalId: record.terminalId, generation })
+      await plan.sidecar.waitForLoadedThread(resumeSessionId, {
+        ...(recovery.readinessTimeoutMs !== undefined ? { timeoutMs: recovery.readinessTimeoutMs } : {}),
+        ...(recovery.readinessPollMs !== undefined ? { pollMs: recovery.readinessPollMs } : {}),
+      })
+      if (candidate.exited) {
+        throw new Error(`Codex recovery candidate PTY exited before publication with code ${candidate.exitCode ?? 'unknown'}.`)
+      }
+
+      const latest = this.terminals.get(record.terminalId)
+      if (!this.canContinueCodexRecovery(latest, resumeSessionId) || latest !== record) {
+        await cleanupCandidate()
+        return
+      }
+
+      const oldPty = record.pty
+      const oldSidecar = record.codexSidecar
+      record.codexRecoveryRetiringPty = oldPty
+      if (oldSidecar) {
+        try {
+          await this.trackSidecarShutdown(
+            record.terminalId,
+            `recovery-retiring:${record.codexSidecarGeneration ?? 0}`,
+            () => oldSidecar.shutdown(),
+            'Codex retiring sidecar shutdown failed',
+          )
+        } catch (err) {
+          record.codexRecoveryRetiringPty = undefined
+          throw codexRecoveryTeardownError(
+            `Codex retiring sidecar teardown failed: ${err instanceof Error ? err.message : String(err)}`,
+          )
+        }
+      }
+
+      if (candidate.exited) {
+        throw new Error(`Codex recovery candidate PTY exited before publication with code ${candidate.exitCode ?? 'unknown'}.`)
+      }
+
+      const latestAfterRetire = this.terminals.get(record.terminalId)
+      if (!this.canContinueCodexRecovery(latestAfterRetire, resumeSessionId) || latestAfterRetire !== record) {
+        record.codexRecoveryRetiringPty = undefined
+        await cleanupCandidate()
+        return
+      }
+
+      record.codexSidecarLifecycleUnsubscribe?.()
+      record.codexSidecarLifecycleUnsubscribe = undefined
+      record.pty = candidate.pty
+      record.mcpCwd = candidate.mcpCwd
+      record.codexSidecar = plan.sidecar
+      record.codexSidecarLifecyclePublished = true
+      record.codexSidecarPrePublicationLoss = undefined
+      record.codexSidecarGeneration = generation
+      this.registerCodexSidecarLifecycle(record)
+      record.codexRecoveryRetiringPty = undefined
+      published = true
+
+      try {
+        oldPty.kill('SIGTERM')
+      } catch (err) {
+        logger.warn({ err, terminalId: record.terminalId }, 'Failed to retire previous Codex recovery PTY')
+      }
+    } catch (err) {
+      if (!published) {
+        record.codexRecoveryRetiringPty = undefined
+        await cleanupCandidate()
+      }
+      throw err
+    }
+  }
+
+  private spawnCodexRecoveryPty(
+    record: TerminalRecord,
+    plan: CodexLaunchPlan,
+    resumeSessionId: string,
+  ): { pty: ReturnType<typeof pty.spawn>; mcpCwd?: string; exited: boolean; exitCode?: number } {
+    const providerSettings: ProviderSettings = {
+      codexAppServer: {
+        ...plan.remote,
+        sidecar: plan.sidecar,
+      },
+    }
+    const { file, args, env, cwd: procCwd, mcpCwd } = buildSpawnSpec(
+      record.mode,
+      record.cwd,
+      record.shell,
+      resumeSessionId,
+      providerSettings,
+      this.buildTerminalBaseEnv(record.terminalId, record.envContext),
+      record.terminalId,
+    )
+
+    const ptyProc = pty.spawn(file, args, {
+      name: 'xterm-256color',
+      cols: record.cols,
+      rows: record.rows,
+      cwd: procCwd,
+      env: env as any,
+    })
+    const candidate = { pty: ptyProc, mcpCwd, exited: false, exitCode: undefined as number | undefined }
+    this.attachCodexRecoveryPtyHandlers(record, ptyProc, candidate)
+    return candidate
+  }
+
+  private attachCodexRecoveryPtyHandlers(
+    record: TerminalRecord,
+    ptyProc: ReturnType<typeof pty.spawn>,
+    candidate?: { exited: boolean; exitCode?: number },
+  ): void {
+    ptyProc.onData((data) => {
+      if (record.pty !== ptyProc || record.status !== 'running') return
+      const now = Date.now()
+      record.lastActivityAt = now
+      record.buffer.append(data)
+      this.emit('terminal.output.raw', {
+        terminalId: record.terminalId,
+        data,
+        at: now,
+      } satisfies TerminalOutputRawEvent)
+      for (const client of record.clients) {
+        if (record.suppressedOutputClients.has(client)) continue
+        const pending = record.pendingSnapshotClients.get(client)
+        if (pending) {
+          const nextChars = pending.queuedChars + data.length
+          if (data.length > this.maxPendingSnapshotChars || nextChars > this.maxPendingSnapshotChars) {
+            try {
+              client.close(4008, 'Attach snapshot queue overflow')
+            } catch {
+              // ignore
+            }
+            record.pendingSnapshotClients.delete(client)
+            record.clients.delete(client)
+            continue
+          }
+          pending.chunks.push(data)
+          pending.queuedChars = nextChars
+          continue
+        }
+        this.sendTerminalOutput(client, record.terminalId, data, record.perf)
+      }
+    })
+
+    ptyProc.onExit((event) => {
+      if (candidate) {
+        candidate.exited = true
+        candidate.exitCode = event.exitCode
+      }
+      if (record.codexRecoveryRetiringPty === ptyProc) {
+        return
+      }
+      if (record.pty !== ptyProc || record.status === 'exited') return
+      this.markCodexRecoveryFinalClose(record)
+      record.status = 'exited'
+      record.exitCode = event.exitCode
+      const now = Date.now()
+      record.lastActivityAt = now
+      record.exitedAt = now
+      cleanupMcpConfig(record.terminalId, record.mode, record.mcpCwd)
+      for (const client of record.clients) {
+        this.flushOutputBuffer(client)
+        this.safeSend(client, { type: 'terminal.exit', terminalId: record.terminalId, exitCode: event.exitCode }, { terminalId: record.terminalId, perf: record.perf })
+      }
+      record.clients.clear()
+      record.suppressedOutputClients.clear()
+      record.pendingSnapshotClients.clear()
+      this.releaseBinding(record.terminalId, 'exit')
+      this.emit('terminal.exit', { terminalId: record.terminalId, exitCode: event.exitCode })
+      void this.releaseCodexSidecar(record).catch(() => undefined)
+      this.reapExitedTerminals()
+    })
   }
 
   attach(terminalId: string, client: WebSocket, opts?: { pendingSnapshot?: boolean; suppressOutput?: boolean }): TerminalRecord | null {
@@ -1397,7 +1880,11 @@ export class TerminalRegistry extends EventEmitter {
   kill(terminalId: string): boolean {
     const term = this.terminals.get(terminalId)
     if (!term) return false
-    if (term.status === 'exited') return true
+    if (term.status === 'exited') {
+      void this.releaseCodexSidecar(term).catch(() => undefined)
+      return true
+    }
+    this.markCodexRecoveryFinalClose(term)
     cleanupMcpConfig(terminalId, term.mode, term.mcpCwd)
     try {
       term.pty.kill()
@@ -1418,7 +1905,25 @@ export class TerminalRegistry extends EventEmitter {
     term.pendingSnapshotClients.clear()
     this.releaseBinding(terminalId, 'exit')
     this.emit('terminal.exit', { terminalId, exitCode: term.exitCode })
+    void this.releaseCodexSidecar(term).catch(() => undefined)
     this.reapExitedTerminals()
+    return true
+  }
+
+  async killAndWait(terminalId: string): Promise<boolean> {
+    const term = this.terminals.get(terminalId)
+    const ok = this.kill(terminalId)
+    if (!ok) return false
+    const recoveryAttempt = term?.codexRecoveryAttempt
+      ? term.codexRecoveryAttempt.catch((err) => {
+          logger.error({ err, terminalId }, 'Codex recovery did not finish cleanly during terminal close')
+          throw err
+        })
+      : undefined
+    const joins = [this.waitForSidecarShutdown(terminalId)]
+    if (recoveryAttempt) joins.push(recoveryAttempt)
+    const failures = await collectShutdownFailures(joins)
+    throwShutdownFailures(failures, 'Codex terminal final close failed.')
     return true
   }
 
@@ -1428,6 +1933,116 @@ export class TerminalRegistry extends EventEmitter {
     this.kill(terminalId)
     this.terminals.delete(terminalId)
     return true
+  }
+
+  private releaseCodexSidecar(term: TerminalRecord): Promise<void> {
+    const existing = this.sidecarShutdowns.get(this.sidecarShutdownKey(term.terminalId))
+    if (existing?.status === 'pending') return existing.promise
+
+    term.codexSidecarLifecycleUnsubscribe?.()
+    term.codexSidecarLifecycleUnsubscribe = undefined
+    const sidecar = term.codexSidecar
+    if (!sidecar) return existing?.promise ?? Promise.resolve()
+
+    return this.trackSidecarShutdown(
+      term.terminalId,
+      'current',
+      async () => {
+        await sidecar.shutdown()
+        if (term.codexSidecar === sidecar) {
+          term.codexSidecar = undefined
+          term.codexSidecarLifecyclePublished = undefined
+          term.codexSidecarPrePublicationLoss = undefined
+        }
+      },
+      'Codex sidecar shutdown failed',
+    )
+  }
+
+  private sidecarShutdownKey(terminalId: string, scope = 'current'): string {
+    return scope === 'current' ? terminalId : `${terminalId}:${scope}`
+  }
+
+  private sidecarShutdownPromisesForTerminal(terminalId: string): Promise<void>[] {
+    const prefix = `${terminalId}:`
+    return [...this.sidecarShutdowns.entries()]
+      .filter(([key]) => key === terminalId || key.startsWith(prefix))
+      .map(([key, entry]) => this.runSidecarShutdownEntry(key, entry))
+  }
+
+  private trackSidecarShutdown(
+    terminalId: string,
+    scope: string,
+    shutdownSidecar: () => Promise<void>,
+    failureMessage: string,
+  ): Promise<void> {
+    const key = this.sidecarShutdownKey(terminalId, scope)
+    const existing = this.sidecarShutdowns.get(key)
+    if (existing?.status === 'pending') return existing.promise
+
+    const entry: SidecarShutdownEntry = existing ?? {
+      promise: Promise.resolve(),
+      status: 'failed',
+      terminalId,
+      shutdownSidecar,
+      failureMessage,
+    }
+    entry.terminalId = terminalId
+    entry.shutdownSidecar = shutdownSidecar
+    entry.failureMessage = failureMessage
+    this.sidecarShutdowns.set(key, entry)
+    return this.runSidecarShutdownEntry(key, entry)
+  }
+
+  private runSidecarShutdownEntry(key: string, entry: SidecarShutdownEntry): Promise<void> {
+    if (entry.status === 'pending') return entry.promise
+    entry.status = 'pending'
+    const shutdown = Promise.resolve()
+      .then(() => entry.shutdownSidecar())
+      .then(() => {
+        if (this.sidecarShutdowns.get(key) === entry) {
+          this.sidecarShutdowns.delete(key)
+        }
+      })
+      .catch((err) => {
+        if (this.sidecarShutdowns.get(key) === entry) {
+          entry.status = 'failed'
+        }
+        logger.error({ err, terminalId: entry.terminalId }, entry.failureMessage)
+        throw err
+      })
+    entry.promise = shutdown
+    return shutdown
+  }
+
+  private async waitForSidecarShutdown(terminalId: string): Promise<void> {
+    const term = this.terminals.get(terminalId)
+    const promises = new Set<Promise<void>>()
+    if (term) promises.add(this.releaseCodexSidecar(term))
+    for (const promise of this.sidecarShutdownPromisesForTerminal(terminalId)) {
+      promises.add(promise)
+    }
+    const failures = await collectShutdownFailures([...promises])
+    throwShutdownFailures(failures, 'Codex terminal sidecar shutdown failed.')
+  }
+
+  private async waitForCodexShutdownWork(records: Iterable<TerminalRecord>): Promise<void> {
+    const recordList = Array.from(records)
+    const recoveryAttempts = recordList
+      .map((term) => term.codexRecoveryAttempt)
+      .filter((promise): promise is Promise<void> => !!promise)
+    const sidecarShutdowns = new Set<Promise<void>>()
+    for (const term of recordList) {
+      sidecarShutdowns.add(this.releaseCodexSidecar(term))
+    }
+    for (const [key, entry] of [...this.sidecarShutdowns.entries()]) {
+      sidecarShutdowns.add(this.runSidecarShutdownEntry(key, entry))
+    }
+    const failures = [
+      ...await collectShutdownFailures(recoveryAttempts),
+      ...await collectShutdownFailures([...sidecarShutdowns]),
+    ]
+    throwShutdownFailures(failures, 'Codex registry shutdown work failed.')
   }
 
   list(): Array<{
@@ -2013,6 +2628,7 @@ export class TerminalRegistry extends EventEmitter {
     }
 
     if (running.length === 0) {
+      await this.waitForCodexShutdownWork(this.terminals.values())
       logger.info('No running terminals to shut down')
       return
     }
@@ -2044,6 +2660,7 @@ export class TerminalRegistry extends EventEmitter {
     // Send SIGTERM (or plain kill on Windows where signal args are unsupported)
     const isWindows = process.platform === 'win32'
     for (const term of running) {
+      this.markCodexRecoveryFinalClose(term)
       try {
         if (isWindows) {
           term.pty.kill()
@@ -2079,6 +2696,8 @@ export class TerminalRegistry extends EventEmitter {
     if (forceKilled > 0) {
       logger.warn({ forceKilled }, 'Force-killed terminals after graceful timeout')
     }
+
+    await this.waitForCodexShutdownWork(this.terminals.values())
 
     logger.info({ count: running.length, forceKilled }, 'All terminals shut down')
   }

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { logger } from './logger.js'
 import { getPerfConfig, logPerfEvent, shouldLog, startPerfTimer } from './perf-logger.js'
 import { getRequiredAuthToken, isLoopbackAddress, isOriginAllowed, timingSafeCompare } from './auth.js'
-import { modeSupportsResume } from './terminal-registry.js'
+import { modeSupportsResume, terminalIdFromCreateError } from './terminal-registry.js'
 import type { TerminalRecord, TerminalRegistry, TerminalMode } from './terminal-registry.js'
 import { configStore, type ConfigReadError } from './config-store.js'
 import type { CodingCliSessionManager } from './coding-cli/session-manager.js'
@@ -32,7 +32,7 @@ import { TabRegistryRecordBaseSchema, TabRegistryRecordSchema } from './tabs-reg
 import type { TabsRegistryStore } from './tabs-registry/store.js'
 import type { ServerSettings } from '../shared/settings.js'
 import { stripAnsi } from './ai-prompts.js'
-import type { CodexLaunchPlanner } from './coding-cli/codex-app-server/launch-planner.js'
+import type { CodexLaunchPlan, CodexLaunchPlanner } from './coding-cli/codex-app-server/launch-planner.js'
 import {
   CodexLaunchConfigError,
   getCodexSessionBindingReason,
@@ -196,6 +196,12 @@ function formatExitedTerminalAttachMessage(record: Pick<TerminalRecord, 'title' 
   return `${label} is no longer running${exitSuffix}.`
 }
 
+function assertCodexCreateTerminalRunning(record: Pick<TerminalRecord, 'status'>): void {
+  if (record.status !== 'running') {
+    throw new Error('Codex terminal PTY exited before create completed.')
+  }
+}
+
 function normalizeUiSessionLocator(value: unknown): SidebarSessionLocator | undefined {
   if (!value || typeof value !== 'object') return undefined
   const candidate = value as {
@@ -348,6 +354,12 @@ function createScreenshotError(code: ScreenshotErrorCode, message: string): Erro
   err.code = code
   return err
 }
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+class TerminalCreateAdmissionError extends Error {}
 
 export class WsHandler {
   private readonly config: WsHandlerConfig
@@ -666,7 +678,7 @@ export class WsHandler {
     providerSettings: { model?: string; sandbox?: string; permissionMode?: string } | undefined,
   ) {
     if (!this.codexLaunchPlanner) {
-      throw new Error('Codex terminal launch requires the shared app-server planner.')
+      throw new Error('Codex terminal launch requires the app-server launch planner.')
     }
     return this.codexLaunchPlanner.planCreate({
       cwd,
@@ -675,6 +687,12 @@ export class WsHandler {
       sandbox: normalizeCodexSandboxSetting(providerSettings?.sandbox),
       approvalPolicy: providerSettings?.permissionMode,
     })
+  }
+
+  private assertTerminalCreateAccepted(): void {
+    if (this.closed) {
+      throw new TerminalCreateAdmissionError('Server is shutting down; terminal.create is no longer accepted.')
+    }
   }
 
   private terminalCreateLockKey(
@@ -979,6 +997,11 @@ export class WsHandler {
   }
 
   private onConnection(ws: LiveWebSocket, req: http.IncomingMessage) {
+    if (this.closed) {
+      ws.close(CLOSE_CODES.SERVER_SHUTDOWN, 'Server shutting down')
+      return
+    }
+
     if (this.connections.size >= this.config.maxConnections) {
       ws.close(CLOSE_CODES.MAX_CONNECTIONS, 'Too many connections')
       return
@@ -1714,6 +1737,15 @@ export class WsHandler {
         return
       }
 
+      if (this.closed && m.type === 'terminal.create') {
+        this.sendError(ws, {
+          code: 'INTERNAL_ERROR',
+          message: 'Server is shutting down; terminal.create is no longer accepted.',
+          requestId: m.requestId,
+        })
+        return
+      }
+
       switch (m.type) {
       case 'ui.screenshot.result': {
         const pending = this.screenshotRequests.get(m.requestId)
@@ -1761,6 +1793,7 @@ export class WsHandler {
           { minDurationMs: perfConfig.slowTerminalCreateMs, level: 'warn' },
         )
         let terminalId: string | undefined
+        let pendingCodexPlan: CodexLaunchPlan | undefined
         let reused = false
         let error = false
         let rateLimited = false
@@ -1973,13 +2006,23 @@ export class WsHandler {
               const requestedCodexResumeSessionId = m.mode === 'codex'
                 ? effectiveResumeSessionId
                 : undefined
+              this.assertTerminalCreateAccepted()
               const codexPlan = m.mode === 'codex'
                 ? await this.planCodexLaunch(m.cwd, requestedCodexResumeSessionId, providerSettings)
                 : undefined
+              pendingCodexPlan = codexPlan
 
               if (codexPlan) {
                 effectiveResumeSessionId = codexPlan.sessionId
               }
+              this.assertTerminalCreateAccepted()
+
+              const codexRecovery = codexPlan
+                ? {
+                    planCreate: (input: { cwd?: string; resumeSessionId: string }) =>
+                      this.planCodexLaunch(input.cwd ?? m.cwd, input.resumeSessionId, providerSettings),
+                  }
+                : undefined
 
               const spawnProviderSettings = (
                 providerSettings
@@ -1994,13 +2037,28 @@ export class WsHandler {
                     ...(m.mode === 'opencode'
                       ? { opencodeServer: await allocateLocalhostPort() }
                       : {}),
-                    ...(codexPlan ? { codexAppServer: codexPlan.remote } : {}),
+                    ...(codexPlan ? {
+                      codexAppServer: {
+                        ...codexPlan.remote,
+                        sidecar: codexPlan.sidecar,
+                        recovery: codexRecovery,
+                        deferLifecycleUntilPublished: true,
+                      },
+                    } : {}),
                   }
                   : (codexPlan
-                    ? { codexAppServer: codexPlan.remote }
+                    ? {
+                      codexAppServer: {
+                        ...codexPlan.remote,
+                        sidecar: codexPlan.sidecar,
+                        recovery: codexRecovery,
+                        deferLifecycleUntilPublished: true,
+                      },
+                    }
                     : undefined)
               )
 
+              this.assertTerminalCreateAccepted()
               const record = this.registry.create({
                 mode: m.mode as TerminalMode,
                 shell: m.shell as 'system' | 'cmd' | 'powershell' | 'wsl',
@@ -2014,6 +2072,21 @@ export class WsHandler {
                 envContext: { tabId: m.tabId, paneId: m.paneId },
                 providerSettings: spawnProviderSettings,
               })
+              terminalId = record.terminalId
+              this.assertTerminalCreateAccepted()
+              if (codexPlan) {
+                await codexPlan.sidecar.adopt({ terminalId: record.terminalId, generation: 0 })
+                this.assertTerminalCreateAccepted()
+                if (requestedCodexResumeSessionId) {
+                  await codexPlan.sidecar.waitForLoadedThread(requestedCodexResumeSessionId)
+                  this.assertTerminalCreateAccepted()
+                }
+                assertCodexCreateTerminalRunning(record)
+                this.assertTerminalCreateAccepted()
+                this.registry.publishCodexSidecar?.(record.terminalId)
+                pendingCodexPlan = undefined
+              }
+              this.assertTerminalCreateAccepted()
 
               if (m.mode !== 'shell' && typeof m.cwd === 'string' && m.cwd.trim()) {
                 const recentDirectory = m.cwd.trim()
@@ -2024,7 +2097,6 @@ export class WsHandler {
 
               state.createdByRequestId.set(m.requestId, record.terminalId)
               this.rememberCreatedRequestId(m.requestId, record.terminalId)
-              terminalId = record.terminalId
 
               const sent = await sendCreateResult({
                 ws,
@@ -2047,14 +2119,35 @@ export class WsHandler {
           )
         } catch (err: any) {
           error = true
+          const cleanupErrors: string[] = []
+          const cleanupTerminalId = terminalId ?? terminalIdFromCreateError(err)
+          if (typeof cleanupTerminalId === 'string') {
+            await this.registry.killAndWait(cleanupTerminalId).catch((killErr) => {
+              cleanupErrors.push(`created terminal cleanup failed: ${errorMessage(killErr)}`)
+              log.warn({ err: killErr, terminalId: cleanupTerminalId }, 'terminal.create cleanup failed')
+            })
+          }
+          if (pendingCodexPlan) {
+            await pendingCodexPlan.sidecar.shutdown().catch((shutdownErr) => {
+              cleanupErrors.push(`Codex sidecar cleanup failed: ${errorMessage(shutdownErr)}`)
+              log.warn({ err: shutdownErr }, 'terminal.create pending Codex sidecar cleanup failed')
+            })
+          }
+          const errorMessageText = cleanupErrors.length > 0
+            ? `${err?.message || 'Failed to spawn PTY'}; cleanup failed: ${cleanupErrors.join('; ')}`
+            : err?.message || 'Failed to spawn PTY'
           // Clean up repair sentinel if terminal creation failed
           if (state.createdByRequestId.get(m.requestId) === REPAIR_PENDING_SENTINEL) {
             state.createdByRequestId.delete(m.requestId)
           }
           log.warn({ err, connectionId: ws.connectionId }, 'terminal.create failed')
           this.sendError(ws, {
-            code: err instanceof CodexLaunchConfigError ? 'INVALID_MESSAGE' : 'PTY_SPAWN_FAILED',
-            message: err?.message || 'Failed to spawn PTY',
+            code: err instanceof CodexLaunchConfigError
+              ? 'INVALID_MESSAGE'
+              : err instanceof TerminalCreateAdmissionError
+                ? 'INTERNAL_ERROR'
+                : 'PTY_SPAWN_FAILED',
+            message: errorMessageText,
             requestId: m.requestId,
           })
         } finally {
@@ -2134,7 +2227,18 @@ export class WsHandler {
       }
 
       case 'terminal.kill': {
-        const ok = this.registry.kill(m.terminalId)
+        let ok: boolean
+        try {
+          ok = await this.registry.killAndWait(m.terminalId)
+        } catch (err) {
+          log.warn({ err, terminalId: m.terminalId, connectionId: ws.connectionId }, 'terminal.kill failed')
+          this.sendError(ws, {
+            code: 'INTERNAL_ERROR',
+            message: `Failed to kill terminal: ${errorMessage(err)}`,
+            terminalId: m.terminalId,
+          })
+          return
+        }
         if (!ok) {
           this.sendError(ws, { code: 'INVALID_TERMINAL_ID', message: 'Unknown terminalId', terminalId: m.terminalId })
           return

--- a/test/e2e-browser/global-setup.ts
+++ b/test/e2e-browser/global-setup.ts
@@ -15,21 +15,30 @@ function findProjectRoot(): string {
   throw new Error('Could not find project root')
 }
 
+interface EnsureFreshE2eBuildDeps {
+  execSync: typeof execSync
+  env: NodeJS.ProcessEnv
+  log: Pick<Console, 'log'>
+}
+
+export function ensureFreshE2eBuild(
+  root: string,
+  deps: EnsureFreshE2eBuildDeps = {
+    execSync,
+    env: process.env,
+    log: console,
+  },
+): void {
+  deps.log.log('[e2e-setup] Building client and server...')
+  deps.execSync('npm run build:client && npm run build:server', {
+    cwd: root,
+    stdio: 'inherit',
+    env: { ...deps.env, NODE_ENV: 'production' },
+  })
+  deps.log.log('[e2e-setup] Build complete.')
+}
+
 export default async function globalSetup() {
   const root = findProjectRoot()
-  const clientDir = path.join(root, 'dist', 'client')
-  const serverEntry = path.join(root, 'dist', 'server', 'index.js')
-
-  // Build if dist doesn't exist
-  if (!fs.existsSync(clientDir) || !fs.existsSync(serverEntry)) {
-    console.log('[e2e-setup] Building client and server...')
-    execSync('npm run build:client && npm run build:server', {
-      cwd: root,
-      stdio: 'inherit',
-      env: { ...process.env, NODE_ENV: 'production' },
-    })
-    console.log('[e2e-setup] Build complete.')
-  } else {
-    console.log('[e2e-setup] Using existing build in dist/')
-  }
+  ensureFreshE2eBuild(root)
 }

--- a/test/e2e-browser/helpers/test-harness.ts
+++ b/test/e2e-browser/helpers/test-harness.ts
@@ -21,7 +21,8 @@ export class TestHarness {
       () => {
         const harness = window.__FRESHELL_TEST_HARNESS__
         if (!harness) return false
-        return harness.getWsReadyState() === 'ready'
+        const reduxStatus = harness.getState()?.connection?.status
+        return harness.getWsReadyState() === 'ready' && reduxStatus === 'ready'
       },
       { timeout: timeoutMs + 1000 },
     )
@@ -33,9 +34,24 @@ export class TestHarness {
    * so the client will attempt to reconnect automatically.
    */
   async forceDisconnect(): Promise<void> {
+    const previousLastReadyAt = await this.page.evaluate(() => {
+      const state = window.__FRESHELL_TEST_HARNESS__?.getState()
+      return state?.connection?.lastReadyAt ?? null
+    })
     await this.page.evaluate(() => {
       window.__FRESHELL_TEST_HARNESS__?.forceDisconnect()
     })
+    await this.page.waitForFunction(
+      (lastReadyAt) => {
+        const harness = window.__FRESHELL_TEST_HARNESS__
+        if (!harness) return false
+        const state = harness.getState()
+        return harness.getWsReadyState() !== 'ready'
+          || (state?.connection?.lastReadyAt ?? null) !== lastReadyAt
+      },
+      previousLastReadyAt,
+      { timeout: 5_000 },
+    )
   }
 
   /** Get the current Redux state */

--- a/test/e2e-browser/helpers/test-server.test.ts
+++ b/test/e2e-browser/helpers/test-server.test.ts
@@ -327,6 +327,37 @@ describe('TestServer', () => {
     expect(info.configDir).not.toContain('.freshell')
   })
 
+  it('preserves config values written by setupHome while adding the setup-wizard bypass', async () => {
+    server = new TestServer({
+      preserveHomeOnStop: true,
+      setupHome: async (homeDir) => {
+        const freshellDir = path.join(homeDir, '.freshell')
+        await fs.mkdir(freshellDir, { recursive: true })
+        await fs.writeFile(path.join(freshellDir, 'config.json'), JSON.stringify({
+          version: 1,
+          settings: {
+            defaultCwd: '/repo',
+          },
+          legacyLocalSettingsSeed: {
+            theme: 'light',
+          },
+        }, null, 2))
+      },
+    })
+
+    const info = await server.start()
+    const config = JSON.parse(await fs.readFile(path.join(info.homeDir, '.freshell', 'config.json'), 'utf8'))
+
+    expect(config.settings.defaultCwd).toBe('/repo')
+    expect(config.settings.network).toMatchObject({
+      configured: true,
+      host: '127.0.0.1',
+    })
+    expect(config.legacyLocalSettingsSeed).toEqual({
+      theme: 'light',
+    })
+  })
+
   it('exposes HOME, logs, and debug-log paths and can preserve them for audit collection', async () => {
     server = new TestServer({
       preserveHomeOnStop: true,

--- a/test/e2e-browser/helpers/test-server.ts
+++ b/test/e2e-browser/helpers/test-server.ts
@@ -47,6 +47,10 @@ function isWindowsStylePath(filePath: string): boolean {
   return /^[A-Za-z]:\\/.test(filePath.replace(/\//g, '\\'))
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
 function applyAppDataIsolation(
   env: Record<string, string>,
   homeDir: string,
@@ -179,6 +183,35 @@ async function createIsolatedRuntimeRoot(projectRoot: string): Promise<string> {
   }
 }
 
+async function readJsonFileIfPresent(filePath: string): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed = JSON.parse(await fsp.readFile(filePath, 'utf8'))
+    return isRecord(parsed) ? parsed : null
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+}
+
+async function ensureSetupWizardBypassConfig(configPath: string): Promise<void> {
+  const existing = await readJsonFileIfPresent(configPath)
+  const existingSettings = isRecord(existing?.settings) ? existing.settings : {}
+  const existingNetwork = isRecord(existingSettings.network) ? existingSettings.network : {}
+
+  await fsp.writeFile(configPath, JSON.stringify({
+    ...(existing ?? {}),
+    version: 1,
+    settings: {
+      ...existingSettings,
+      network: {
+        configured: true,
+        host: '127.0.0.1',
+        ...existingNetwork,
+      },
+    },
+  }, null, 2))
+}
+
 function readAuthTokenFromEnvFile(envText: string): string {
   const match = envText.match(/^AUTH_TOKEN=(.+)$/m)
   if (!match) {
@@ -277,15 +310,7 @@ export class TestServer {
       // when config.json is missing, blocking all interaction. This minimal config
       // marks the network as already configured, bypassing the wizard.
       const configPath = path.join(freshellDir, 'config.json')
-      await fsp.writeFile(configPath, JSON.stringify({
-        version: 1,
-        settings: {
-          network: {
-            configured: true,
-            host: '127.0.0.1',
-          },
-        },
-      }, null, 2))
+      await ensureSetupWizardBypassConfig(configPath)
 
       // Create a logs dir
       const logsDir = path.join(homeDir, '.freshell', 'logs')

--- a/test/e2e-browser/specs/reconnection.spec.ts
+++ b/test/e2e-browser/specs/reconnection.spec.ts
@@ -14,9 +14,7 @@ test.describe('WebSocket Reconnection', () => {
     // Force-close the underlying WebSocket via the test harness.
     // This calls ws.close() on the raw WebSocket without setting intentionalClose,
     // so the WsClient will auto-reconnect.
-    await page.evaluate(() => {
-      window.__FRESHELL_TEST_HARNESS__?.forceDisconnect()
-    })
+    await harness.forceDisconnect()
 
     // The WS state should briefly leave 'ready'
     // Wait for it to reconnect
@@ -27,7 +25,7 @@ test.describe('WebSocket Reconnection', () => {
     expect(status).toBe('ready')
   })
 
-  test('terminal output resumes after reconnect', async ({ freshellPage, page, harness, terminal }) => {
+  test('terminal output resumes after reconnect', async ({ freshellPage, harness, terminal }) => {
     await terminal.waitForTerminal()
     await terminal.waitForPrompt()
 
@@ -36,9 +34,7 @@ test.describe('WebSocket Reconnection', () => {
     await terminal.waitForOutput('before-reconnect')
 
     // Force disconnect the WebSocket (triggers auto-reconnect)
-    await page.evaluate(() => {
-      window.__FRESHELL_TEST_HARNESS__?.forceDisconnect()
-    })
+    await harness.forceDisconnect()
 
     // Wait for reconnection
     await harness.waitForConnection()
@@ -67,9 +63,7 @@ test.describe('WebSocket Reconnection', () => {
 
     // Simulate flaky network with multiple rapid disconnects
     for (let i = 0; i < 3; i++) {
-      await page.evaluate(() => {
-        window.__FRESHELL_TEST_HARNESS__?.forceDisconnect()
-      })
+      await harness.forceDisconnect()
       // Brief pause between disconnects to let reconnect attempt start
       await page.waitForTimeout(500)
     }
@@ -93,9 +87,7 @@ test.describe('WebSocket Reconnection', () => {
     await harness.waitForTabCount(2)
 
     // Force disconnect
-    await page.evaluate(() => {
-      window.__FRESHELL_TEST_HARNESS__?.forceDisconnect()
-    })
+    await harness.forceDisconnect()
 
     // Wait for reconnection
     await harness.waitForConnection()
@@ -112,15 +104,13 @@ test.describe('WebSocket Reconnection', () => {
     }
   })
 
-  test('pending terminal creates retry after reconnect', async ({ freshellPage, page, harness, terminal }) => {
+  test('pending terminal creates retry after reconnect', async ({ freshellPage, harness, terminal }) => {
     await terminal.waitForTerminal()
     await terminal.waitForPrompt()
     await harness.waitForConnection()
 
     // Force disconnect
-    await page.evaluate(() => {
-      window.__FRESHELL_TEST_HARNESS__?.forceDisconnect()
-    })
+    await harness.forceDisconnect()
 
     // Wait for reconnection
     await harness.waitForConnection()

--- a/test/e2e-browser/specs/settings.spec.ts
+++ b/test/e2e-browser/specs/settings.spec.ts
@@ -11,14 +11,20 @@ test.describe('Settings', () => {
     await expect(page.getByText('Terminal').first()).toBeVisible({ timeout: 5_000 })
   }
 
+  async function openSettingsSection(page: any, section: string) {
+    await openSettings(page)
+    await page.getByRole('tab', { name: section }).click()
+    await expect(page.getByRole('tabpanel', { name: new RegExp(`${section} settings`, 'i') })).toBeVisible()
+  }
+
   test('settings view is accessible from sidebar', async ({ freshellPage, page }) => {
     await openSettings(page)
 
-    // Verify multiple settings sections are visible
-    // SettingsSection titles: "Appearance", "Terminal", "Debugging" (from SettingsView.tsx)
-    await expect(page.getByText('Appearance').first()).toBeVisible()
-    await expect(page.getByText('Terminal').first()).toBeVisible()
-    await expect(page.getByText('Debugging').first()).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Appearance' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Workspace' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'AI' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Safety' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Advanced' })).toBeVisible()
   })
 
   test('terminal font size slider changes setting', async ({ freshellPage, page, harness }) => {
@@ -120,7 +126,7 @@ test.describe('Settings', () => {
   })
 
   test('scrollback lines slider changes setting', async ({ freshellPage, page, harness }) => {
-    await openSettings(page)
+    await openSettingsSection(page, 'Advanced')
 
     // "Scrollback lines" row with RangeSlider
     const scrollbackRow = page.getByText('Scrollback lines')
@@ -138,9 +144,9 @@ test.describe('Settings', () => {
   })
 
   test('debug logging toggle', async ({ freshellPage, page, harness }) => {
-    await openSettings(page)
+    await openSettingsSection(page, 'Advanced')
 
-    // Scroll down to "Debugging" section, find "Debug logging" row
+    // Advanced section contains the debug logging row.
     const debugLoggingRow = page.getByText('Debug logging')
     await expect(debugLoggingRow).toBeVisible()
 

--- a/test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs
+++ b/test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs
@@ -1,6 +1,21 @@
 #!/usr/bin/env node
 
 import { WebSocketServer } from 'ws'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+
+if (process.argv[2] === 'fake-native-child') {
+  process.on('SIGTERM', () => {
+    if (process.env.FAKE_CODEX_NATIVE_CHILD_IGNORE_SIGTERM === '1') {
+      return
+    }
+    process.exit(0)
+  })
+
+  setInterval(() => undefined, 1_000)
+  process.stdin.resume()
+  await new Promise(() => undefined)
+}
 
 function parseListenUrl(argv) {
   const listenIndex = argv.indexOf('--listen')
@@ -85,6 +100,11 @@ function successResult(method, params) {
       },
     }
   }
+  if (method === 'thread/loaded/list') {
+    return {
+      data: behavior.loadedThreadIds || [],
+    }
+  }
   return {}
 }
 
@@ -95,12 +115,35 @@ const url = new URL(listenUrl)
 const host = url.hostname
 const port = Number(url.port)
 
+let nativeChild
+if (behavior.spawnNativeChild) {
+  nativeChild = spawn(process.execPath, [new URL(import.meta.url).pathname, 'fake-native-child'], {
+    env: {
+      ...process.env,
+      FAKE_CODEX_NATIVE_CHILD_IGNORE_SIGTERM: behavior.nativeChildIgnoresSigterm ? '1' : '',
+    },
+    stdio: 'ignore',
+  })
+  nativeChild.unref()
+  if (behavior.nativePidFile) {
+    fs.writeFileSync(behavior.nativePidFile, `${nativeChild.pid}\n`, 'utf8')
+  }
+  if (behavior.exitAfterSpawningNative) {
+    process.exit(Number(behavior.exitAfterSpawningNativeCode ?? 42))
+  }
+}
+
 const wss = new WebSocketServer({ host, port })
 
 wss.on('connection', (socket) => {
   let initialized = false
+  let initializedNotification = false
   socket.on('message', (raw) => {
     const message = JSON.parse(raw.toString())
+    if (message.method === 'initialized') {
+      initializedNotification = true
+      return
+    }
     if (behavior.requireJsonRpc && message.jsonrpc !== '2.0') {
       socket.send(JSON.stringify({
         id: message.id,
@@ -113,7 +156,11 @@ wss.on('connection', (socket) => {
     }
     const method = message.method
 
-    if (behavior.requireInitializeBeforeOtherMethods && method !== 'initialize' && !initialized) {
+    if (
+      behavior.requireInitializeBeforeOtherMethods
+      && method !== 'initialize'
+      && (!initialized || (behavior.requireInitializedNotification && !initializedNotification))
+    ) {
       socket.send(JSON.stringify({
         id: message.id,
         error: {
@@ -149,6 +196,9 @@ wss.on('connection', (socket) => {
         id: message.id,
         result: override?.result ?? successResult(method, message.params),
       }))
+      for (const notification of behavior.notificationsAfterMethods?.[method] || []) {
+        socket.send(JSON.stringify(notification))
+      }
       if (method === 'initialize') {
         initialized = true
       }
@@ -163,5 +213,17 @@ process.on('SIGTERM', () => {
   if (process.env.FAKE_CODEX_APP_SERVER_IGNORE_SIGTERM === '1') {
     return
   }
-  wss.close(() => process.exit(0))
+  if (behavior.signalFileOnSigterm) {
+    fs.writeFileSync(behavior.signalFileOnSigterm, `${process.pid}\n`, 'utf8')
+  }
+  if (!behavior.wrapperLeavesNativeOnSigterm) {
+    nativeChild?.kill('SIGTERM')
+  }
+  const exit = () => wss.close(() => process.exit(0))
+  const delayExitMs = Number(behavior.delayExitOnSigtermMs || 0)
+  if (delayExitMs > 0) {
+    setTimeout(exit, delayExitMs)
+    return
+  }
+  exit()
 })

--- a/test/helpers/coding-cli/fake-codex-launch-planner.ts
+++ b/test/helpers/coding-cli/fake-codex-launch-planner.ts
@@ -1,12 +1,55 @@
 export const DEFAULT_CODEX_REMOTE_WS_URL = 'ws://127.0.0.1:43123'
 
+export class FakeCodexLaunchSidecar {
+  adoptCalls: Array<{ terminalId: string; generation: number }> = []
+  shutdownCalls = 0
+  waitForLoadedThreadCalls: Array<{ threadId: string; options?: { timeoutMs?: number; pollMs?: number } }> = []
+  waitForLoadedThreadError: Error | null = null
+  shutdownError: Error | null = null
+  shutdownStarted = false
+  private lifecycleLossHandlers = new Set<(event: unknown) => void>()
+
+  async adopt(input: { terminalId: string; generation: number }) {
+    this.adoptCalls.push(input)
+  }
+
+  async listLoadedThreads() {
+    return ['thread-new-1']
+  }
+
+  async shutdown() {
+    if (this.shutdownStarted) return
+    this.shutdownStarted = true
+    this.shutdownCalls += 1
+    if (this.shutdownError) throw this.shutdownError
+  }
+
+  async waitForLoadedThread(threadId: string, options?: { timeoutMs?: number; pollMs?: number }) {
+    this.waitForLoadedThreadCalls.push({ threadId, options })
+    if (this.waitForLoadedThreadError) throw this.waitForLoadedThreadError
+  }
+
+  onLifecycleLoss(handler: (event: unknown) => void) {
+    this.lifecycleLossHandlers.add(handler)
+    return () => this.lifecycleLossHandlers.delete(handler)
+  }
+
+  emitLifecycleLoss(event: unknown) {
+    for (const handler of this.lifecycleLossHandlers) {
+      handler(event)
+    }
+  }
+}
+
 export class FakeCodexLaunchPlanner {
   planCreateCalls: any[] = []
+  sidecar = new FakeCodexLaunchSidecar()
 
   constructor(
     private readonly plan: {
       sessionId: string
       remote: { wsUrl: string }
+      sidecar?: FakeCodexLaunchSidecar
     } = {
       sessionId: 'thread-new-1',
       remote: { wsUrl: DEFAULT_CODEX_REMOTE_WS_URL },
@@ -15,6 +58,9 @@ export class FakeCodexLaunchPlanner {
 
   async planCreate(input: any) {
     this.planCreateCalls.push(input)
-    return this.plan
+    return {
+      ...this.plan,
+      sidecar: this.plan.sidecar ?? this.sidecar,
+    }
   }
 }

--- a/test/integration/server/codex-real-provider-smoke.test.ts
+++ b/test/integration/server/codex-real-provider-smoke.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { CodexLaunchPlanner } from '../../../server/coding-cli/codex-app-server/launch-planner.js'
+import { CodexAppServerRuntime } from '../../../server/coding-cli/codex-app-server/runtime.js'
+import { TerminalRegistry } from '../../../server/terminal-registry.js'
+
+const tempDirs = new Set<string>()
+const registries = new Set<TerminalRegistry>()
+const planners = new Set<CodexLaunchPlanner>()
+
+type SessionIndexEntry = {
+  id?: unknown
+}
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-real-provider-'))
+  tempDirs.add(dir)
+  return dir
+}
+
+async function processHasOwnershipEnv(pid: number, ownershipId: string): Promise<boolean> {
+  try {
+    const raw = await fsp.readFile(`/proc/${pid}/environ`)
+    return raw.toString('utf8').split('\0').includes(`FRESHELL_CODEX_SIDECAR_ID=${ownershipId}`)
+  } catch {
+    return false
+  }
+}
+
+async function pidsWithOwnershipId(ownershipId: string): Promise<number[]> {
+  const entries = await fsp.readdir('/proc').catch(() => [])
+  const matches: number[] = []
+  await Promise.all(entries.map(async (entry) => {
+    if (!/^\d+$/.test(entry)) return
+    const pid = Number(entry)
+    if (await processHasOwnershipEnv(pid, ownershipId)) {
+      matches.push(pid)
+    }
+  }))
+  return matches.sort((a, b) => a - b)
+}
+
+async function readOwnershipId(metadataDir: string): Promise<string> {
+  const entries = await fsp.readdir(metadataDir)
+  const metadataFile = entries.find((entry) => entry.endsWith('.json'))
+  if (!metadataFile) throw new Error(`No Codex ownership metadata found in ${metadataDir}`)
+  const raw = await fsp.readFile(path.join(metadataDir, metadataFile), 'utf8')
+  const parsed = JSON.parse(raw) as { ownershipId?: unknown }
+  if (typeof parsed.ownershipId !== 'string') {
+    throw new Error('Codex ownership metadata did not include an ownership id.')
+  }
+  return parsed.ownershipId
+}
+
+async function copyIfExists(source: string, target: string): Promise<boolean> {
+  try {
+    await fsp.copyFile(source, target)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT' || code === 'ENOTDIR') return false
+    throw error
+  }
+}
+
+async function collectRolloutFiles(root: string): Promise<Map<string, string[]>> {
+  const result = new Map<string, string[]>()
+  const visit = async (dir: string): Promise<void> => {
+    const entries = await fsp.readdir(dir, { withFileTypes: true }).catch((error) => {
+      const code = (error as NodeJS.ErrnoException).code
+      if (code === 'ENOENT' || code === 'ENOTDIR') return []
+      throw error
+    })
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        await visit(fullPath)
+        continue
+      }
+      const match = entry.name.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/)
+      if (!match) continue
+      const files = result.get(match[1]) ?? []
+      files.push(fullPath)
+      result.set(match[1], files)
+    }
+  }
+  await visit(root)
+  return result
+}
+
+async function prepareRealProviderCodexHome(targetCodexHome: string): Promise<{ sessionId: string }> {
+  const sourceCodexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex')
+  const authCopied = await copyIfExists(
+    path.join(sourceCodexHome, 'auth.json'),
+    path.join(targetCodexHome, 'auth.json'),
+  )
+  if (!authCopied) {
+    throw new Error(
+      `Codex real-provider smoke requires an authenticated Codex home at ${sourceCodexHome}. Run codex login before running the integration suite.`,
+    )
+  }
+  await copyIfExists(
+    path.join(sourceCodexHome, 'config.toml'),
+    path.join(targetCodexHome, 'config.toml'),
+  )
+  await fsp.writeFile(
+    path.join(targetCodexHome, 'version.json'),
+    `${JSON.stringify({
+      latest_version: '999.0.0',
+      last_checked_at: new Date().toISOString(),
+      dismissed_version: '999.0.0',
+    })}\n`,
+    { mode: 0o600 },
+  )
+
+  const indexPath = path.join(sourceCodexHome, 'session_index.jsonl')
+  const indexRaw = await fsp.readFile(indexPath, 'utf8').catch((error) => {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      throw new Error(
+        `Codex real-provider smoke requires at least one saved Codex session in ${sourceCodexHome}. Run Codex once before running the integration suite.`,
+      )
+    }
+    throw error
+  })
+  const sessionRollouts = await collectRolloutFiles(path.join(sourceCodexHome, 'sessions'))
+  const indexLines = indexRaw.split('\n').filter((line) => line.trim().length > 0)
+  const parsedIndexLines: Array<{ id: string; line: string }> = []
+  for (const line of indexLines) {
+    try {
+      const parsed = JSON.parse(line) as SessionIndexEntry
+      if (typeof parsed.id === 'string') {
+        parsedIndexLines.push({ id: parsed.id, line })
+      }
+    } catch {
+      // Ignore malformed historical index entries; the smoke only needs one
+      // current, resumable session.
+    }
+  }
+  const candidates: Array<{ id: string; lines: string[] }> = []
+  const seen = new Set<string>()
+  for (const parsed of [...parsedIndexLines].reverse()) {
+    if (seen.has(parsed.id)) continue
+    seen.add(parsed.id)
+    const lines = parsedIndexLines
+      .filter((candidateLine) => candidateLine.id === parsed.id)
+      .map((candidateLine) => candidateLine.line)
+    candidates.push({ id: parsed.id, lines })
+  }
+
+  const selected = candidates.find((candidate) => (sessionRollouts.get(candidate.id)?.length ?? 0) > 0)
+  if (!selected) {
+    throw new Error(
+      `Codex real-provider smoke requires at least one saved Codex rollout file under ${path.join(sourceCodexHome, 'sessions')}.`,
+    )
+  }
+
+  await fsp.writeFile(
+    path.join(targetCodexHome, 'session_index.jsonl'),
+    `${selected.lines.join('\n')}\n`,
+    { mode: 0o600 },
+  )
+  for (const rollout of sessionRollouts.get(selected.id) ?? []) {
+    const relativePath = path.relative(sourceCodexHome, rollout)
+    const target = path.join(targetCodexHome, relativePath)
+    await fsp.mkdir(path.dirname(target), { recursive: true })
+    await fsp.copyFile(rollout, target)
+  }
+  return { sessionId: selected.id }
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '')
+}
+
+afterEach(async () => {
+  await Promise.all([...registries].map(async (registry) => {
+    registries.delete(registry)
+    await registry.shutdownGracefully(100)
+  }))
+  await Promise.all([...planners].map(async (planner) => {
+    planners.delete(planner)
+    await planner.shutdown()
+  }))
+  await Promise.all([...tempDirs].map(async (dir) => {
+    tempDirs.delete(dir)
+    await fsp.rm(dir, { recursive: true, force: true })
+  }))
+})
+
+describe('Codex real-provider smoke', () => {
+  it('covers the actual codex remote resume path and owned process cleanup', async () => {
+    const metadataDir = await makeTempDir()
+    const codexHome = await makeTempDir()
+    const { sessionId } = await prepareRealProviderCodexHome(codexHome)
+    const registry = new TerminalRegistry()
+    registries.add(registry)
+    const outputChunks: string[] = []
+    const outputHandler = (event: { data?: unknown }) => {
+      if (typeof event.data === 'string') {
+        outputChunks.push(stripAnsi(event.data))
+      }
+    }
+    registry.on('terminal.output.raw', outputHandler)
+    const previousCodexHome = process.env.CODEX_HOME
+    process.env.CODEX_HOME = codexHome
+    const planner = new CodexLaunchPlanner(() => new CodexAppServerRuntime({
+      metadataDir,
+      env: {
+        CODEX_HOME: codexHome,
+      },
+      requestTimeoutMs: 5_000,
+      startupAttemptTimeoutMs: 10_000,
+    }))
+    planners.add(planner)
+
+    try {
+      const resumePlan = await planner.planCreate({
+        cwd: process.cwd(),
+        resumeSessionId: sessionId,
+        sandbox: 'danger-full-access',
+        approvalPolicy: 'never',
+      })
+      const term = registry.create({
+        mode: 'codex',
+        cwd: process.cwd(),
+        resumeSessionId: resumePlan.sessionId,
+        providerSettings: {
+          codexAppServer: {
+            ...resumePlan.remote,
+            sidecar: resumePlan.sidecar,
+          },
+        },
+      })
+      await resumePlan.sidecar.adopt({ terminalId: term.terminalId, generation: 0 })
+      try {
+        await resumePlan.sidecar.waitForLoadedThread(sessionId, { timeoutMs: 20_000, pollMs: 250 })
+      } catch (error) {
+        const outputTail = outputChunks.join('').slice(-1_000)
+        throw new Error(
+          `${error instanceof Error ? error.message : String(error)}\nCodex TUI output before failure:\n${outputTail}`,
+        )
+      }
+      const ownershipId = await readOwnershipId(metadataDir)
+
+      await registry.killAndWait(term.terminalId)
+      await planner.shutdown()
+
+      await expect(pidsWithOwnershipId(ownershipId)).resolves.toEqual([])
+    } finally {
+      if (previousCodexHome === undefined) {
+        delete process.env.CODEX_HOME
+      } else {
+        process.env.CODEX_HOME = previousCodexHome
+      }
+      registry.off('terminal.output.raw', outputHandler)
+    }
+  }, 60_000)
+})

--- a/test/integration/server/codex-session-flow.test.ts
+++ b/test/integration/server/codex-session-flow.test.ts
@@ -45,13 +45,56 @@ async function writeFakeCodexExecutable(binaryPath: string) {
   const script = `#!/usr/bin/env node
 const fs = require('fs')
 
+function appendJsonLine(filePath, value) {
+  if (!filePath) return
+  fs.appendFileSync(filePath, JSON.stringify(value) + '\\n', 'utf8')
+}
+
 const argLogPath = process.env.FAKE_CODEX_ARG_LOG
 if (argLogPath) {
   fs.writeFileSync(argLogPath, JSON.stringify(process.argv.slice(2)), 'utf8')
 }
 
+appendJsonLine(process.env.FAKE_CODEX_LAUNCH_LOG, {
+  pid: process.pid,
+  args: process.argv.slice(2),
+})
+
+let isFirstLaunch = false
+if (process.env.FAKE_CODEX_FIRST_LAUNCH_CLAIM_PATH) {
+  try {
+    fs.writeFileSync(process.env.FAKE_CODEX_FIRST_LAUNCH_CLAIM_PATH, String(process.pid), { flag: 'wx' })
+    isFirstLaunch = true
+  } catch {
+    isFirstLaunch = false
+  }
+}
+
+process.stdin.on('data', (chunk) => {
+  appendJsonLine(process.env.FAKE_CODEX_INPUT_LOG, {
+    pid: process.pid,
+    data: chunk.toString('utf8'),
+  })
+})
+
+process.on('SIGTERM', () => process.exit(0))
 process.stdout.write('codex remote attached\\n')
-setTimeout(() => process.exit(0), 50)
+if (process.env.FAKE_CODEX_STAY_ALIVE === '1') {
+  if (
+    process.env.FAKE_CODEX_EXIT_WHEN_FILE_EXISTS
+    && (process.env.FAKE_CODEX_EXIT_WATCH_FIRST_LAUNCH_ONLY !== '1' || isFirstLaunch)
+  ) {
+    setInterval(() => {
+      if (fs.existsSync(process.env.FAKE_CODEX_EXIT_WHEN_FILE_EXISTS)) {
+        process.exit(0)
+      }
+    }, 10)
+  }
+  process.stdin.resume()
+  setInterval(() => undefined, 1000)
+} else {
+  setTimeout(() => process.exit(0), 50)
+}
 `
 
   await fsp.writeFile(binaryPath, script, 'utf8')
@@ -112,6 +155,59 @@ async function waitForFile(filePath: string, timeoutMs = 3_000): Promise<void> {
   throw new Error(`Timed out waiting for file: ${filePath}`)
 }
 
+async function waitForPidFile(filePath: string, timeoutMs = 5_000): Promise<number> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const raw = await fsp.readFile(filePath, 'utf8').catch(() => '')
+    const pid = Number(raw.trim())
+    if (Number.isInteger(pid) && pid > 0) return pid
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error(`Timed out waiting for pid file: ${filePath}`)
+}
+
+async function isProcessAlive(pid: number): Promise<boolean> {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return false
+    throw error
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (!(await isProcessAlive(pid))) return
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error(`Timed out waiting for process ${pid} to exit`)
+}
+
+async function readJsonLines(filePath: string): Promise<any[]> {
+  const raw = await fsp.readFile(filePath, 'utf8').catch(() => '')
+  return raw
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+}
+
+async function waitForJsonLine(
+  filePath: string,
+  predicate: (line: any) => boolean,
+  timeoutMs = 3_000,
+): Promise<any> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const lines = await readJsonLines(filePath)
+    const match = lines.find(predicate)
+    if (match) return match
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error(`Timed out waiting for matching JSON line in ${filePath}`)
+}
+
 async function createAuthenticatedWs(port: number): Promise<WebSocket> {
   const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
   await new Promise<void>((resolve, reject) => {
@@ -168,8 +264,17 @@ describe('Codex Session Flow Integration', () => {
   let port: number
   let wsHandler: WsHandler
   let registry: TerminalRegistry
-  let runtime: CodexAppServerRuntime
-  let planner: CodexLaunchPlanner
+  let runtimes: Set<CodexAppServerRuntime>
+  let planner: CodexLaunchPlanner | null
+
+  const createPlanner = () => new CodexLaunchPlanner(() => {
+    const runtime = new CodexAppServerRuntime({
+      command: process.execPath,
+      commandArgs: [FAKE_APP_SERVER_PATH],
+    })
+    runtimes.add(runtime)
+    return runtime
+  })
 
   beforeAll(async () => {
     tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-flow-'))
@@ -185,12 +290,15 @@ describe('Codex Session Flow Integration', () => {
     const app = express()
     server = http.createServer(app)
     registry = new TerminalRegistry()
-    runtime = new CodexAppServerRuntime({
-      command: process.execPath,
-      commandArgs: [FAKE_APP_SERVER_PATH],
-    })
-    planner = new CodexLaunchPlanner(runtime)
-    wsHandler = new WsHandler(server, registry, { codexLaunchPlanner: planner })
+    runtimes = new Set()
+    planner = createPlanner()
+    const plannerDelegate = {
+      planCreate: (input: Parameters<CodexLaunchPlanner['planCreate']>[0]) => {
+        if (!planner) throw new Error('Codex launch planner is not initialized')
+        return planner.planCreate(input)
+      },
+    } as CodexLaunchPlanner
+    wsHandler = new WsHandler(server, registry, { codexLaunchPlanner: plannerDelegate })
 
     await new Promise<void>((resolve) => {
       server.listen(0, '127.0.0.1', () => {
@@ -202,7 +310,10 @@ describe('Codex Session Flow Integration', () => {
 
   beforeEach(async () => {
     delete process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR
-    await runtime.shutdown()
+    await planner?.shutdown()
+    await Promise.all([...runtimes].map((runtime) => runtime.shutdown()))
+    runtimes.clear()
+    planner = createPlanner()
     vi.mocked(configStore.snapshot).mockResolvedValue({
       settings: {
         codingCli: {
@@ -231,7 +342,9 @@ describe('Codex Session Flow Integration', () => {
       process.env.FAKE_CODEX_ARG_LOG = previousFakeCodexArgLog
     }
 
-    await runtime.shutdown()
+    await planner?.shutdown()
+    await Promise.all([...runtimes].map((runtime) => runtime.shutdown()))
+    runtimes.clear()
     registry.shutdown()
     wsHandler.close()
     await new Promise<void>((resolve) => server.close(() => resolve()))
@@ -283,6 +396,7 @@ describe('Codex Session Flow Integration', () => {
 
   it('restores a persisted Codex session without calling thread/resume on the app-server', async () => {
     process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR = JSON.stringify({
+      loadedThreadIds: ['thread-existing-1'],
       overrides: {
         'thread/resume': {
           error: {
@@ -331,6 +445,139 @@ describe('Codex Session Flow Integration', () => {
     } finally {
       await closeWebSocket(ws)
       delete process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR
+    }
+  })
+
+  it('retires the previous wrapper/native app-server during recovery replacement and routes later input only to the replacement', async () => {
+    const testDir = await fsp.mkdtemp(path.join(tempDir, 'recovery-retire-'))
+    const metadataDir = path.join(testDir, 'metadata')
+    const oldNativePidFile = path.join(testDir, 'old-native.pid')
+    const replacementNativePidFile = path.join(testDir, 'replacement-native.pid')
+    const launchLogPath = path.join(testDir, 'codex-launches.jsonl')
+    const inputLogPath = path.join(testDir, 'codex-input.jsonl')
+    const oldSidecarShutdownSignalPath = path.join(testDir, 'old-sidecar-shutdown.signal')
+    const firstLaunchClaimPath = path.join(testDir, 'first-tui.claim')
+    await fsp.mkdir(metadataDir, { recursive: true })
+
+    const previousStayAlive = process.env.FAKE_CODEX_STAY_ALIVE
+    const previousLaunchLog = process.env.FAKE_CODEX_LAUNCH_LOG
+    const previousInputLog = process.env.FAKE_CODEX_INPUT_LOG
+    const previousExitWhenFileExists = process.env.FAKE_CODEX_EXIT_WHEN_FILE_EXISTS
+    const previousFirstLaunchOnly = process.env.FAKE_CODEX_EXIT_WATCH_FIRST_LAUNCH_ONLY
+    const previousFirstLaunchClaim = process.env.FAKE_CODEX_FIRST_LAUNCH_CLAIM_PATH
+    process.env.FAKE_CODEX_STAY_ALIVE = '1'
+    process.env.FAKE_CODEX_LAUNCH_LOG = launchLogPath
+    process.env.FAKE_CODEX_INPUT_LOG = inputLogPath
+    process.env.FAKE_CODEX_EXIT_WHEN_FILE_EXISTS = oldSidecarShutdownSignalPath
+    process.env.FAKE_CODEX_EXIT_WATCH_FIRST_LAUNCH_ONLY = '1'
+    process.env.FAKE_CODEX_FIRST_LAUNCH_CLAIM_PATH = firstLaunchClaimPath
+
+    const oldRuntime = new CodexAppServerRuntime({
+      command: process.execPath,
+      commandArgs: [FAKE_APP_SERVER_PATH],
+      metadataDir,
+      serverInstanceId: 'srv-codex-recovery-old',
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          spawnNativeChild: true,
+          nativePidFile: oldNativePidFile,
+          wrapperLeavesNativeOnSigterm: true,
+          signalFileOnSigterm: oldSidecarShutdownSignalPath,
+          delayExitOnSigtermMs: 200,
+          loadedThreadIds: ['thread-existing-1'],
+        }),
+      },
+    })
+    const replacementRuntime = new CodexAppServerRuntime({
+      command: process.execPath,
+      commandArgs: [FAKE_APP_SERVER_PATH],
+      metadataDir,
+      serverInstanceId: 'srv-codex-recovery-replacement',
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          spawnNativeChild: true,
+          nativePidFile: replacementNativePidFile,
+          wrapperLeavesNativeOnSigterm: true,
+          loadedThreadIds: ['thread-existing-1'],
+        }),
+      },
+    })
+    runtimes.add(oldRuntime)
+    runtimes.add(replacementRuntime)
+    const oldPlanner = new CodexLaunchPlanner(oldRuntime)
+    const replacementPlanner = new CodexLaunchPlanner(replacementRuntime)
+    let terminalId: string | undefined
+
+    try {
+      const oldPlan = await oldPlanner.planCreate({ resumeSessionId: 'thread-existing-1' })
+      const oldNativePid = await waitForPidFile(oldNativePidFile)
+      const recovery = {
+        planCreate: vi.fn(() => replacementPlanner.planCreate({ resumeSessionId: 'thread-existing-1' })),
+        retryDelayMs: 0,
+        readinessTimeoutMs: 1_000,
+        readinessPollMs: 25,
+      }
+      const term = registry.create({
+        mode: 'codex',
+        resumeSessionId: 'thread-existing-1',
+        cwd: tempDir,
+        providerSettings: {
+          codexAppServer: {
+            wsUrl: oldPlan.remote.wsUrl,
+            sidecar: oldPlan.sidecar,
+            recovery,
+          },
+        } as any,
+      })
+      terminalId = term.terminalId
+      const oldPtyPid = term.pty.pid
+      await waitForJsonLine(launchLogPath, (line) => line.pid === oldPtyPid)
+
+      await (registry as any).runCodexRecoveryAttempt(
+        registry.get(term.terminalId),
+        'thread-existing-1',
+      )
+
+      const replacementNativePid = await waitForPidFile(replacementNativePidFile)
+      await waitForProcessExit(oldNativePid)
+      await waitForProcessExit(oldPtyPid)
+      expect(await isProcessAlive(replacementNativePid)).toBe(true)
+
+      const latest = registry.get(term.terminalId)
+      const replacementPtyPid = latest?.pty.pid
+      expect(replacementPtyPid).toEqual(expect.any(Number))
+      expect(replacementPtyPid).not.toBe(oldPtyPid)
+
+      expect(registry.input(term.terminalId, 'after recovery replacement\n')).toBe(true)
+      await waitForJsonLine(
+        inputLogPath,
+        (line) => line.pid === replacementPtyPid && line.data.includes('after recovery replacement'),
+      )
+      const inputLines = await readJsonLines(inputLogPath)
+      expect(inputLines.some((line) => line.pid === oldPtyPid && line.data.includes('after recovery replacement'))).toBe(false)
+    } finally {
+      if (terminalId) {
+        await registry.killAndWait(terminalId).catch(() => undefined)
+      }
+      await replacementPlanner.shutdown().catch(() => undefined)
+      await oldPlanner.shutdown().catch(() => undefined)
+      await replacementRuntime.shutdown().catch(() => undefined)
+      await oldRuntime.shutdown().catch(() => undefined)
+      runtimes.delete(oldRuntime)
+      runtimes.delete(replacementRuntime)
+      if (previousStayAlive === undefined) delete process.env.FAKE_CODEX_STAY_ALIVE
+      else process.env.FAKE_CODEX_STAY_ALIVE = previousStayAlive
+      if (previousLaunchLog === undefined) delete process.env.FAKE_CODEX_LAUNCH_LOG
+      else process.env.FAKE_CODEX_LAUNCH_LOG = previousLaunchLog
+      if (previousInputLog === undefined) delete process.env.FAKE_CODEX_INPUT_LOG
+      else process.env.FAKE_CODEX_INPUT_LOG = previousInputLog
+      if (previousExitWhenFileExists === undefined) delete process.env.FAKE_CODEX_EXIT_WHEN_FILE_EXISTS
+      else process.env.FAKE_CODEX_EXIT_WHEN_FILE_EXISTS = previousExitWhenFileExists
+      if (previousFirstLaunchOnly === undefined) delete process.env.FAKE_CODEX_EXIT_WATCH_FIRST_LAUNCH_ONLY
+      else process.env.FAKE_CODEX_EXIT_WATCH_FIRST_LAUNCH_ONLY = previousFirstLaunchOnly
+      if (previousFirstLaunchClaim === undefined) delete process.env.FAKE_CODEX_FIRST_LAUNCH_CLAIM_PATH
+      else process.env.FAKE_CODEX_FIRST_LAUNCH_CLAIM_PATH = previousFirstLaunchClaim
+      await fsp.rm(testDir, { recursive: true, force: true })
     }
   })
 })

--- a/test/integration/server/test-coordinator.test.ts
+++ b/test/integration/server/test-coordinator.test.ts
@@ -522,7 +522,9 @@ describe('test coordinator CLI', () => {
           FRESHELL_TEST_COORDINATOR_CAPTURE_FILE: captureFile,
           FRESHELL_TEST_COORDINATOR_POLL_MS: '50',
           FRESHELL_TEST_COORDINATOR_FAKE_BEHAVIOR: JSON.stringify({
-            'npm:test:balanced': { holdMs: 1_000 },
+            'npm:typecheck': { holdMs: 1_000 },
+            'npm:build': { holdMs: 1_000 },
+            'npm:test:balanced': { holdMs: 2_000 },
           }),
         },
       )
@@ -557,7 +559,7 @@ describe('test coordinator CLI', () => {
           isDirty: true,
         },
       })
-      expect(latest.durationMs).toBeLessThan(2_000)
+      expect(latest.durationMs).toBeLessThan(5_000)
     },
   )
 

--- a/test/server/agent-panes-write.test.ts
+++ b/test/server/agent-panes-write.test.ts
@@ -62,6 +62,115 @@ it('rejects invalid Codex settings when splitting a pane before spawning', async
   expect(attachPaneContent).not.toHaveBeenCalled()
 })
 
+it('rejects Codex split without planning when shutdown admission closes while reading settings', async () => {
+  const app = express()
+  app.use(express.json())
+  let acceptingCreates = true
+  const splitPane = vi.fn(() => ({ newPaneId: 'pane_new', tabId: 'tab_1' }))
+  const attachPaneContent = vi.fn()
+  const registry = {
+    create: vi.fn(() => ({ terminalId: 'term_new' })),
+    killAndWait: vi.fn(async () => true),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { splitPane, attachPaneContent },
+    registry,
+    codexLaunchPlanner,
+    configStore: {
+      getSettings: vi.fn(async () => {
+        acceptingCreates = false
+        return { codingCli: { providers: { codex: {} } } }
+      }),
+    },
+    assertTerminalCreateAccepted: () => {
+      if (!acceptingCreates) {
+        throw new Error('Server is shutting down; terminal creation is not accepted.')
+      }
+    },
+  }))
+
+  const res = await request(app).post('/api/panes/pane_1/split').send({ direction: 'horizontal', mode: 'codex' })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toContain('Server is shutting down')
+  expect(codexLaunchPlanner.planCreateCalls).toEqual([])
+  expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(0)
+  expect(registry.create).not.toHaveBeenCalled()
+  expect(registry.killAndWait).not.toHaveBeenCalled()
+  expect(attachPaneContent).not.toHaveBeenCalled()
+})
+
+it('kills the created Codex terminal when split adoption fails after registry.create', async () => {
+  const app = express()
+  app.use(express.json())
+  const splitPane = vi.fn(() => ({ newPaneId: 'pane_new', tabId: 'tab_1' }))
+  const attachPaneContent = vi.fn()
+  const registry = {
+    create: vi.fn(() => ({ terminalId: 'term_new' })),
+    killAndWait: vi.fn(async () => true),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+  vi.spyOn(codexLaunchPlanner.sidecar, 'adopt').mockRejectedValue(new Error('adopt failed after split create'))
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { splitPane, attachPaneContent },
+    registry,
+    codexLaunchPlanner,
+  }))
+
+  const res = await request(app).post('/api/panes/pane_1/split').send({ direction: 'horizontal', mode: 'codex' })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toBe('adopt failed after split create')
+  expect(registry.killAndWait).toHaveBeenCalledWith('term_new')
+  expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+  expect(attachPaneContent).not.toHaveBeenCalled()
+})
+
+it('kills the created Codex split terminal without waiting for readiness when shutdown admission closes after adoption', async () => {
+  const app = express()
+  app.use(express.json())
+  let acceptingCreates = true
+  const splitPane = vi.fn(() => ({ newPaneId: 'pane_new', tabId: 'tab_1' }))
+  const attachPaneContent = vi.fn()
+  const registry = {
+    create: vi.fn(() => ({ terminalId: 'term_split_shutdown', status: 'running' })),
+    killAndWait: vi.fn(async () => true),
+    publishCodexSidecar: vi.fn(),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+  const originalAdopt = codexLaunchPlanner.sidecar.adopt.bind(codexLaunchPlanner.sidecar)
+  vi.spyOn(codexLaunchPlanner.sidecar, 'adopt').mockImplementation(async (input) => {
+    await originalAdopt(input)
+    acceptingCreates = false
+  })
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { splitPane, attachPaneContent },
+    registry,
+    codexLaunchPlanner,
+    assertTerminalCreateAccepted: () => {
+      if (!acceptingCreates) {
+        throw new Error('Server is shutting down; terminal creation is not accepted.')
+      }
+    },
+  }))
+
+  const res = await request(app).post('/api/panes/pane_1/split').send({
+    direction: 'horizontal',
+    mode: 'codex',
+    resumeSessionId: 'thread-split-shutdown',
+  })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toContain('Server is shutting down')
+  expect(codexLaunchPlanner.sidecar.adoptCalls).toEqual([{ terminalId: 'term_split_shutdown', generation: 0 }])
+  expect(codexLaunchPlanner.sidecar.waitForLoadedThreadCalls).toEqual([])
+  expect(registry.publishCodexSidecar).not.toHaveBeenCalled()
+  expect(registry.killAndWait).toHaveBeenCalledWith('term_split_shutdown')
+  expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+  expect(attachPaneContent).not.toHaveBeenCalled()
+})
+
 it('rejects invalid Codex settings when respawning a pane before spawning', async () => {
   const app = express()
   app.use(express.json())
@@ -97,6 +206,120 @@ it('rejects invalid Codex settings when respawning a pane before spawning', asyn
   })
   expect(codexLaunchPlanner.planCreateCalls).toEqual([])
   expect(registryCreate).not.toHaveBeenCalled()
+  expect(attachPaneContent).not.toHaveBeenCalled()
+})
+
+it('rejects Codex respawn without planning when shutdown admission closes while reading settings', async () => {
+  const app = express()
+  app.use(express.json())
+  let acceptingCreates = true
+  const attachPaneContent = vi.fn()
+  const registry = {
+    create: vi.fn(() => ({ terminalId: 'term_new' })),
+    killAndWait: vi.fn(async () => true),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      attachPaneContent,
+      resolveTarget: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+    } as any,
+    registry,
+    codexLaunchPlanner,
+    configStore: {
+      getSettings: vi.fn(async () => {
+        acceptingCreates = false
+        return { codingCli: { providers: { codex: {} } } }
+      }),
+    },
+    assertTerminalCreateAccepted: () => {
+      if (!acceptingCreates) {
+        throw new Error('Server is shutting down; terminal creation is not accepted.')
+      }
+    },
+  }))
+
+  const res = await request(app).post('/api/panes/pane_1/respawn').send({ mode: 'codex' })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toContain('Server is shutting down')
+  expect(codexLaunchPlanner.planCreateCalls).toEqual([])
+  expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(0)
+  expect(registry.create).not.toHaveBeenCalled()
+  expect(registry.killAndWait).not.toHaveBeenCalled()
+  expect(attachPaneContent).not.toHaveBeenCalled()
+})
+
+it('kills the created Codex terminal when respawn adoption fails after registry.create', async () => {
+  const app = express()
+  app.use(express.json())
+  const attachPaneContent = vi.fn()
+  const registry = {
+    create: vi.fn(() => ({ terminalId: 'term_new' })),
+    killAndWait: vi.fn(async () => true),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+  vi.spyOn(codexLaunchPlanner.sidecar, 'adopt').mockRejectedValue(new Error('adopt failed after respawn create'))
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      attachPaneContent,
+      resolveTarget: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+    } as any,
+    registry,
+    codexLaunchPlanner,
+  }))
+
+  const res = await request(app).post('/api/panes/pane_1/respawn').send({ mode: 'codex' })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toBe('adopt failed after respawn create')
+  expect(registry.killAndWait).toHaveBeenCalledWith('term_new')
+  expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+  expect(attachPaneContent).not.toHaveBeenCalled()
+})
+
+it('kills the created Codex respawn terminal without waiting for readiness when shutdown admission closes after adoption', async () => {
+  const app = express()
+  app.use(express.json())
+  let acceptingCreates = true
+  const attachPaneContent = vi.fn()
+  const registry = {
+    create: vi.fn(() => ({ terminalId: 'term_respawn_shutdown', status: 'running' })),
+    killAndWait: vi.fn(async () => true),
+    publishCodexSidecar: vi.fn(),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+  const originalAdopt = codexLaunchPlanner.sidecar.adopt.bind(codexLaunchPlanner.sidecar)
+  vi.spyOn(codexLaunchPlanner.sidecar, 'adopt').mockImplementation(async (input) => {
+    await originalAdopt(input)
+    acceptingCreates = false
+  })
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      attachPaneContent,
+      resolveTarget: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+    } as any,
+    registry,
+    codexLaunchPlanner,
+    assertTerminalCreateAccepted: () => {
+      if (!acceptingCreates) {
+        throw new Error('Server is shutting down; terminal creation is not accepted.')
+      }
+    },
+  }))
+
+  const res = await request(app).post('/api/panes/pane_1/respawn').send({
+    mode: 'codex',
+    resumeSessionId: 'thread-respawn-shutdown',
+  })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toContain('Server is shutting down')
+  expect(codexLaunchPlanner.sidecar.adoptCalls).toEqual([{ terminalId: 'term_respawn_shutdown', generation: 0 }])
+  expect(codexLaunchPlanner.sidecar.waitForLoadedThreadCalls).toEqual([])
+  expect(registry.publishCodexSidecar).not.toHaveBeenCalled()
+  expect(registry.killAndWait).toHaveBeenCalledWith('term_respawn_shutdown')
+  expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
   expect(attachPaneContent).not.toHaveBeenCalled()
 })
 

--- a/test/server/agent-run.test.ts
+++ b/test/server/agent-run.test.ts
@@ -61,7 +61,7 @@ it('allocates and passes an OpenCode control endpoint for /api/run in opencode m
   }))
 })
 
-it('uses the shared Codex planner and marks fresh /api/run sessions as starts', async () => {
+it('uses the Codex planner and marks fresh /api/run sessions as starts', async () => {
   const registry = {
     create: vi.fn(() => ({ terminalId: 'term1' })),
     input: vi.fn(() => true),
@@ -94,11 +94,129 @@ it('uses the shared Codex planner and marks fresh /api/run sessions as starts', 
     resumeSessionId: 'thread-new-1',
     sessionBindingReason: 'start',
     providerSettings: expect.objectContaining({
-      codexAppServer: {
+      codexAppServer: expect.objectContaining({
         wsUrl: DEFAULT_CODEX_REMOTE_WS_URL,
-      },
+      }),
     }),
   }))
+  expect(codexLaunchPlanner.sidecar.adoptCalls).toEqual([{ terminalId: 'term1', generation: 0 }])
+})
+
+it('shuts down the pending Codex sidecar when /api/run fails after planning', async () => {
+  const registry = {
+    create: vi.fn(() => {
+      throw new Error('spawn failed after planning')
+    }),
+    input: vi.fn(() => true),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      createTab: () => ({ tabId: 't1', paneId: 'p1' }),
+      attachPaneContent: () => {},
+    },
+    registry,
+    codexLaunchPlanner,
+  }))
+
+  const res = await request(app).post('/api/run').send({ command: 'echo done', mode: 'codex' })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toBe('spawn failed after planning')
+  expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+  expect(codexLaunchPlanner.sidecar.adoptCalls).toEqual([])
+})
+
+it('reports pending Codex sidecar shutdown failure when /api/run fails after planning', async () => {
+  const registry = {
+    create: vi.fn(() => {
+      throw new Error('spawn failed after planning')
+    }),
+    input: vi.fn(() => true),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+  codexLaunchPlanner.sidecar.shutdownError = new Error('verified sidecar teardown failed')
+
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      createTab: () => ({ tabId: 't1', paneId: 'p1' }),
+      attachPaneContent: () => {},
+    },
+    registry,
+    codexLaunchPlanner,
+  }))
+
+  const res = await request(app).post('/api/run').send({ command: 'echo done', mode: 'codex' })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toContain('spawn failed after planning')
+  expect(res.body.message).toContain('verified sidecar teardown failed')
+  expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+  expect(codexLaunchPlanner.sidecar.adoptCalls).toEqual([])
+})
+
+it('kills the created terminal and sidecar when /api/run fails after registry.create', async () => {
+  const registry = {
+    create: vi.fn(() => ({ terminalId: 'term1' })),
+    input: vi.fn(() => true),
+    killAndWait: vi.fn(async () => true),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+  vi.spyOn(codexLaunchPlanner.sidecar, 'adopt').mockRejectedValue(new Error('adopt failed after create'))
+
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      createTab: () => ({ tabId: 't1', paneId: 'p1' }),
+      attachPaneContent: () => {},
+    },
+    registry,
+    codexLaunchPlanner,
+  }))
+
+  const res = await request(app).post('/api/run').send({ command: 'echo done', mode: 'codex' })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toBe('adopt failed after create')
+  expect(registry.killAndWait).toHaveBeenCalledWith('term1')
+  expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+})
+
+it('reports created-terminal cleanup failure when /api/run fails after registry.create', async () => {
+  const registry = {
+    create: vi.fn(() => ({ terminalId: 'term1' })),
+    input: vi.fn(() => true),
+    killAndWait: vi.fn(async () => {
+      throw new Error('terminal cleanup failed')
+    }),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+  vi.spyOn(codexLaunchPlanner.sidecar, 'adopt').mockRejectedValue(new Error('adopt failed after create'))
+
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      createTab: () => ({ tabId: 't1', paneId: 'p1' }),
+      attachPaneContent: () => {},
+    },
+    registry,
+    codexLaunchPlanner,
+  }))
+
+  const res = await request(app).post('/api/run').send({ command: 'echo done', mode: 'codex' })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toContain('adopt failed after create')
+  expect(res.body.message).toContain('terminal cleanup failed')
+  expect(registry.killAndWait).toHaveBeenCalledWith('term1')
+  expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
 })
 
 it('rejects invalid Codex settings for /api/run before creating a tab', async () => {
@@ -141,4 +259,48 @@ it('rejects invalid Codex settings for /api/run before creating a tab', async ()
   expect(codexLaunchPlanner.planCreateCalls).toEqual([])
   expect(createTab).not.toHaveBeenCalled()
   expect(registry.create).not.toHaveBeenCalled()
+})
+
+it('rejects Codex /api/run without planning when shutdown admission closes while reading settings', async () => {
+  let acceptingCreates = true
+  const createTab = vi.fn(() => ({ tabId: 't1', paneId: 'p1' }))
+  const registry = {
+    create: vi.fn(() => ({ terminalId: 'term1' })),
+    input: vi.fn(() => true),
+    killAndWait: vi.fn(async () => true),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      createTab,
+      attachPaneContent: vi.fn(),
+    },
+    registry,
+    codexLaunchPlanner,
+    configStore: {
+      getSettings: vi.fn(async () => {
+        acceptingCreates = false
+        return { codingCli: { providers: { codex: {} } } }
+      }),
+    },
+    assertTerminalCreateAccepted: () => {
+      if (!acceptingCreates) {
+        throw new Error('Server is shutting down; terminal creation is not accepted.')
+      }
+    },
+  }))
+
+  const res = await request(app).post('/api/run').send({ command: 'echo done', mode: 'codex' })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toContain('Server is shutting down')
+  expect(codexLaunchPlanner.planCreateCalls).toEqual([])
+  expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(0)
+  expect(createTab).not.toHaveBeenCalled()
+  expect(registry.create).not.toHaveBeenCalled()
+  expect(registry.input).not.toHaveBeenCalled()
+  expect(registry.killAndWait).not.toHaveBeenCalled()
 })

--- a/test/server/agent-tabs-write.test.ts
+++ b/test/server/agent-tabs-write.test.ts
@@ -116,6 +116,298 @@ describe('tab endpoints', () => {
     expect(registry.create).not.toHaveBeenCalled()
   })
 
+  it('rejects Codex tab creation without planning when shutdown admission closes while reading settings', async () => {
+    const app = express()
+    app.use(express.json())
+    let acceptingCreates = true
+    const registry = {
+      create: vi.fn(() => {
+        throw new Error('registry.create should not run')
+      }),
+      killAndWait: vi.fn(async () => true),
+    }
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    const layoutStore = {
+      createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })),
+      attachPaneContent: vi.fn(),
+      selectTab: () => ({}),
+      renameTab: () => ({}),
+      closeTab: () => ({}),
+      hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }),
+      selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    const configStore = {
+      getSettings: vi.fn(async () => {
+        acceptingCreates = false
+        return { codingCli: { providers: { codex: {} } } }
+      }),
+    }
+    app.use('/api', createAgentApiRouter({
+      layoutStore,
+      registry,
+      configStore,
+      codexLaunchPlanner,
+      assertTerminalCreateAccepted: () => {
+        if (!acceptingCreates) {
+          throw new Error('Server is shutting down; terminal creation is not accepted.')
+        }
+      },
+    }))
+
+    const res = await request(app).post('/api/tabs').send({ mode: 'codex', name: 'shutdown before planning' })
+
+    expect(res.status).toBe(500)
+    expect(res.body.message).toContain('Server is shutting down')
+    expect(configStore.getSettings).toHaveBeenCalledTimes(1)
+    expect(codexLaunchPlanner.planCreateCalls).toEqual([])
+    expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(0)
+    expect(registry.create).not.toHaveBeenCalled()
+    expect(registry.killAndWait).not.toHaveBeenCalled()
+    expect(layoutStore.createTab).not.toHaveBeenCalled()
+    expect(layoutStore.attachPaneContent).not.toHaveBeenCalled()
+  })
+
+  it('kills the created Codex terminal when tab creation fails after registry.create', async () => {
+    const app = express()
+    app.use(express.json())
+    const registry = {
+      create: vi.fn(() => ({ terminalId: 'term_1' })),
+      killAndWait: vi.fn(async () => true),
+    }
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    vi.spyOn(codexLaunchPlanner.sidecar, 'adopt').mockRejectedValue(new Error('adopt failed after tab create'))
+    const layoutStore = {
+      createTab: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+      attachPaneContent: vi.fn(),
+      selectTab: () => ({}),
+      renameTab: () => ({}),
+      closeTab: () => ({}),
+      hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }),
+      selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry, codexLaunchPlanner }))
+
+    const res = await request(app).post('/api/tabs').send({ mode: 'codex', name: 'resume tab' })
+
+    expect(res.status).toBe(500)
+    expect(res.body.message).toBe('adopt failed after tab create')
+    expect(registry.killAndWait).toHaveBeenCalledWith('term_1')
+    expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+    expect(layoutStore.attachPaneContent).not.toHaveBeenCalled()
+  })
+
+  it('kills the inserted Codex terminal when registry.create fails after insertion', async () => {
+    const app = express()
+    app.use(express.json())
+    const createError = new Error('terminal.created listener failed') as Error & { terminalId?: string }
+    createError.terminalId = 'term_inserted'
+    const registry = {
+      create: vi.fn(() => {
+        throw createError
+      }),
+      killAndWait: vi.fn(async () => true),
+    }
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    const layoutStore = {
+      createTab: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+      attachPaneContent: vi.fn(),
+      selectTab: () => ({}),
+      renameTab: () => ({}),
+      closeTab: () => ({}),
+      hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }),
+      selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry, codexLaunchPlanner }))
+
+    const res = await request(app).post('/api/tabs').send({ mode: 'codex', name: 'emit failure tab' })
+
+    expect(res.status).toBe(500)
+    expect(res.body.message).toBe('terminal.created listener failed')
+    expect(registry.killAndWait).toHaveBeenCalledWith('term_inserted')
+    expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+    expect(layoutStore.attachPaneContent).not.toHaveBeenCalled()
+  })
+
+  it('kills the created Codex terminal when resume readiness returns after the PTY exited', async () => {
+    const app = express()
+    app.use(express.json())
+    const terminal = { terminalId: 'term_exited_before_publish', status: 'running' }
+    const registry = {
+      create: vi.fn(() => terminal),
+      killAndWait: vi.fn(async () => true),
+    }
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    vi.spyOn(codexLaunchPlanner.sidecar, 'waitForLoadedThread').mockImplementation(async (threadId, options) => {
+      codexLaunchPlanner.sidecar.waitForLoadedThreadCalls.push({ threadId, options })
+      terminal.status = 'exited'
+    })
+    const layoutStore = {
+      createTab: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+      attachPaneContent: vi.fn(),
+      selectTab: () => ({}),
+      renameTab: () => ({}),
+      closeTab: () => ({}),
+      hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }),
+      selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry, codexLaunchPlanner }))
+
+    const res = await request(app).post('/api/tabs').send({
+      mode: 'codex',
+      name: 'resume tab',
+      resumeSessionId: 'thread-resume-exits',
+    })
+
+    expect(res.status).toBe(500)
+    expect(res.body.message).toContain('Codex terminal PTY exited before create completed')
+    expect(registry.killAndWait).toHaveBeenCalledWith('term_exited_before_publish')
+    expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+    expect(layoutStore.attachPaneContent).not.toHaveBeenCalled()
+  })
+
+  it('kills the created Codex terminal without waiting for readiness when shutdown admission closes after adoption', async () => {
+    const app = express()
+    app.use(express.json())
+    let acceptingCreates = true
+    const terminal = { terminalId: 'term_shutdown_after_adopt', status: 'running' }
+    const registry = {
+      create: vi.fn(() => terminal),
+      killAndWait: vi.fn(async () => true),
+      publishCodexSidecar: vi.fn(),
+    }
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    const originalAdopt = codexLaunchPlanner.sidecar.adopt.bind(codexLaunchPlanner.sidecar)
+    vi.spyOn(codexLaunchPlanner.sidecar, 'adopt').mockImplementation(async (input) => {
+      await originalAdopt(input)
+      acceptingCreates = false
+    })
+    const layoutStore = {
+      createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })),
+      attachPaneContent: vi.fn(),
+      selectTab: () => ({}),
+      renameTab: () => ({}),
+      closeTab: () => ({}),
+      hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }),
+      selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({
+      layoutStore,
+      registry,
+      codexLaunchPlanner,
+      assertTerminalCreateAccepted: () => {
+        if (!acceptingCreates) {
+          throw new Error('Server is shutting down; terminal creation is not accepted.')
+        }
+      },
+    }))
+
+    const res = await request(app).post('/api/tabs').send({
+      mode: 'codex',
+      name: 'resume tab',
+      resumeSessionId: 'thread-resume-shutdown',
+    })
+
+    expect(res.status).toBe(500)
+    expect(res.body.message).toContain('Server is shutting down')
+    expect(codexLaunchPlanner.sidecar.adoptCalls).toEqual([{ terminalId: 'term_shutdown_after_adopt', generation: 0 }])
+    expect(codexLaunchPlanner.sidecar.waitForLoadedThreadCalls).toEqual([])
+    expect(registry.publishCodexSidecar).not.toHaveBeenCalled()
+    expect(registry.killAndWait).toHaveBeenCalledWith('term_shutdown_after_adopt')
+    expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+    expect(layoutStore.attachPaneContent).not.toHaveBeenCalled()
+  })
+
+  it('rejects Codex tab creation when shutdown admission closes after planning', async () => {
+    const app = express()
+    app.use(express.json())
+    let acceptingCreates = true
+    const registry = {
+      create: vi.fn(() => ({ terminalId: 'term_1', status: 'running' })),
+      killAndWait: vi.fn(async () => true),
+    }
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    const originalPlanCreate = codexLaunchPlanner.planCreate.bind(codexLaunchPlanner)
+    vi.spyOn(codexLaunchPlanner, 'planCreate').mockImplementation(async (input) => {
+      const plan = await originalPlanCreate(input)
+      acceptingCreates = false
+      return plan
+    })
+    const layoutStore = {
+      createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })),
+      attachPaneContent: vi.fn(),
+      selectTab: () => ({}),
+      renameTab: () => ({}),
+      closeTab: () => ({}),
+      hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }),
+      selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({
+      layoutStore,
+      registry,
+      codexLaunchPlanner,
+      assertTerminalCreateAccepted: () => {
+        if (!acceptingCreates) {
+          throw new Error('Server is shutting down; terminal creation is not accepted.')
+        }
+      },
+    }))
+
+    const res = await request(app).post('/api/tabs').send({ mode: 'codex', name: 'shutdown after plan' })
+
+    expect(res.status).toBe(500)
+    expect(res.body.message).toContain('Server is shutting down')
+    expect(registry.create).not.toHaveBeenCalled()
+    expect(registry.killAndWait).not.toHaveBeenCalled()
+    expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+    expect(layoutStore.attachPaneContent).not.toHaveBeenCalled()
+  })
+
+  it('kills the created Codex terminal when shutdown admission closes before adoption', async () => {
+    const app = express()
+    app.use(express.json())
+    const registry = {
+      create: vi.fn(() => ({ terminalId: 'term_1', status: 'running' })),
+      killAndWait: vi.fn(async () => true),
+    }
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    const layoutStore = {
+      createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })),
+      attachPaneContent: vi.fn(),
+      selectTab: () => ({}),
+      renameTab: () => ({}),
+      closeTab: () => ({}),
+      hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }),
+      selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({
+      layoutStore,
+      registry,
+      codexLaunchPlanner,
+      assertTerminalCreateAccepted: () => {
+        if (registry.create.mock.calls.length > 0) {
+          throw new Error('Server is shutting down; terminal creation is not accepted.')
+        }
+      },
+    }))
+
+    const res = await request(app).post('/api/tabs').send({ mode: 'codex', name: 'shutdown before adopt' })
+
+    expect(res.status).toBe(500)
+    expect(res.body.message).toContain('Server is shutting down')
+    expect(registry.create).toHaveBeenCalledTimes(1)
+    expect(codexLaunchPlanner.sidecar.adoptCalls).toEqual([])
+    expect(registry.killAndWait).toHaveBeenCalledWith('term_1')
+    expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+    expect(layoutStore.attachPaneContent).not.toHaveBeenCalled()
+  })
+
   it('rejects blank tab rename payloads', async () => {
     const app = express()
     app.use(express.json())

--- a/test/server/ws-edge-cases.test.ts
+++ b/test/server/ws-edge-cases.test.ts
@@ -167,6 +167,10 @@ class FakeRegistry extends EventEmitter {
     return true
   }
 
+  async killAndWait(terminalId: string) {
+    return this.kill(terminalId)
+  }
+
   list() {
     return Array.from(this.records.values()).map((r) => ({
       terminalId: r.terminalId,

--- a/test/server/ws-protocol.test.ts
+++ b/test/server/ws-protocol.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vites
 import http from 'http'
 import WebSocket from 'ws'
 import { WS_PROTOCOL_VERSION } from '../../shared/ws-protocol.js'
-import { FakeCodexLaunchPlanner, DEFAULT_CODEX_REMOTE_WS_URL } from '../helpers/coding-cli/fake-codex-launch-planner.js'
+import {
+  FakeCodexLaunchPlanner,
+  FakeCodexLaunchSidecar,
+  DEFAULT_CODEX_REMOTE_WS_URL,
+} from '../helpers/coding-cli/fake-codex-launch-planner.js'
 
 const TEST_TIMEOUT_MS = 30_000
 const HOOK_TIMEOUT_MS = 30_000
@@ -25,6 +29,16 @@ function defaultConfigSnapshot() {
     terminalOverrides: {},
     projectColors: {},
   }
+}
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
 }
 
 function listen(server: http.Server, timeoutMs = HOOK_TIMEOUT_MS): Promise<{ port: number }> {
@@ -115,6 +129,7 @@ class FakeRegistry {
   inputCalls: { terminalId: string; data: string }[] = []
   resizeCalls: { terminalId: string; cols: number; rows: number }[] = []
   killCalls: string[] = []
+  publishCalls: string[] = []
 
   create(opts: any) {
     this.createCalls.push(opts)
@@ -176,6 +191,14 @@ class FakeRegistry {
     return true
   }
 
+  async killAndWait(terminalId: string) {
+    return this.kill(terminalId)
+  }
+
+  publishCodexSidecar(terminalId: string) {
+    this.publishCalls.push(terminalId)
+  }
+
   list() {
     return Array.from(this.records.values()).map((r) => ({
       terminalId: r.terminalId,
@@ -195,6 +218,49 @@ class FakeRegistry {
       if (rec.resumeSessionId === sessionId) return rec
     }
     return undefined
+  }
+
+  getCanonicalRunningTerminalBySession(mode: string, sessionId: string) {
+    for (const rec of this.records.values()) {
+      if (rec.mode !== mode) continue
+      if (rec.status !== 'running') continue
+      if (rec.resumeSessionId === sessionId) return rec
+    }
+    return undefined
+  }
+
+  repairLegacySessionOwners() {
+    return { repaired: false, clearedTerminalIds: [] }
+  }
+}
+
+function createAuthenticatedState() {
+  return {
+    authenticated: true,
+    supportsUiScreenshotV1: false,
+    attachedTerminalIds: new Set(),
+    createdByRequestId: new Map(),
+    terminalCreateTimestamps: [],
+    codingCliSessions: new Set(),
+    codingCliSubscriptions: new Map(),
+    sdkSessions: new Set(),
+    sdkSubscriptions: new Map(),
+    sdkSessionTargets: new Map(),
+    interestedSessions: new Set(),
+    sidebarOpenSessionKeys: new Set(),
+  }
+}
+
+function createOpenFakeWs(connectionId: string, sent: any[]) {
+  return {
+    readyState: WebSocket.OPEN,
+    bufferedAmount: 0,
+    connectionId,
+    send: vi.fn((payload: string, cb?: (err?: Error) => void) => {
+      sent.push(JSON.parse(payload))
+      cb?.()
+    }),
+    close: vi.fn(),
   }
 }
 
@@ -268,7 +334,14 @@ describe('ws protocol', () => {
     registry.inputCalls = []
     registry.resizeCalls = []
     registry.killCalls = []
+    registry.publishCalls = []
     codexLaunchPlanner.planCreateCalls = []
+    codexLaunchPlanner.sidecar.adoptCalls = []
+    codexLaunchPlanner.sidecar.shutdownCalls = 0
+    codexLaunchPlanner.sidecar.shutdownStarted = false
+    codexLaunchPlanner.sidecar.shutdownError = null
+    codexLaunchPlanner.sidecar.waitForLoadedThreadCalls = []
+    codexLaunchPlanner.sidecar.waitForLoadedThreadError = null
   })
 
   afterAll(async () => {
@@ -434,12 +507,432 @@ describe('ws protocol', () => {
     }])
     expect(registry.createCalls[0]?.resumeSessionId).toBe('thread-new-1')
     expect(registry.createCalls[0]?.providerSettings).toEqual({
-      codexAppServer: {
+      codexAppServer: expect.objectContaining({
         wsUrl: DEFAULT_CODEX_REMOTE_WS_URL,
-      },
+      }),
     })
 
     await closeWebSocket(ws)
+  })
+
+  it('shuts down a pending Codex sidecar when terminal.create fails after planning', async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+    ws.send(JSON.stringify({ type: 'hello', token: 'testtoken-testtoken', protocolVersion: WS_PROTOCOL_VERSION }))
+    await waitForMessage(ws, (msg) => msg.type === 'ready', 5000)
+
+    const originalCreate = registry.create.bind(registry)
+    registry.create = vi.fn((opts: any) => {
+      registry.createCalls.push(opts)
+      throw new Error('spawn failed after planning')
+    }) as any
+
+    try {
+      ws.send(JSON.stringify({ type: 'terminal.create', requestId: 'codex-create-fails', mode: 'codex' }))
+      const error = await waitForMessage(
+        ws,
+        (msg) => msg.type === 'error' && msg.requestId === 'codex-create-fails',
+        5000,
+      )
+
+      expect(error.message).toContain('spawn failed after planning')
+      expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+      expect(codexLaunchPlanner.sidecar.adoptCalls).toEqual([])
+    } finally {
+      registry.create = originalCreate as any
+      await closeWebSocket(ws)
+    }
+  })
+
+  it('reports terminal.create cleanup failure when pending Codex sidecar shutdown fails', async () => {
+    codexLaunchPlanner.sidecar.shutdownError = new Error('verified sidecar teardown failed')
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+    ws.send(JSON.stringify({ type: 'hello', token: 'testtoken-testtoken', protocolVersion: WS_PROTOCOL_VERSION }))
+    await waitForMessage(ws, (msg) => msg.type === 'ready', 5000)
+
+    const originalCreate = registry.create.bind(registry)
+    registry.create = vi.fn((opts: any) => {
+      registry.createCalls.push(opts)
+      throw new Error('spawn failed after planning')
+    }) as any
+
+    try {
+      ws.send(JSON.stringify({ type: 'terminal.create', requestId: 'codex-cleanup-fails', mode: 'codex' }))
+      const error = await waitForMessage(
+        ws,
+        (msg) => msg.type === 'error' && msg.requestId === 'codex-cleanup-fails',
+        5000,
+      )
+
+      expect(error.message).toContain('spawn failed after planning')
+      expect(error.message).toContain('verified sidecar teardown failed')
+      expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+      expect(codexLaunchPlanner.sidecar.adoptCalls).toEqual([])
+    } finally {
+      registry.create = originalCreate as any
+      await closeWebSocket(ws)
+    }
+  })
+
+  it('kills the inserted terminal when terminal.create fails before registry.create returns', async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+    ws.send(JSON.stringify({ type: 'hello', token: 'testtoken-testtoken', protocolVersion: WS_PROTOCOL_VERSION }))
+    await waitForMessage(ws, (msg) => msg.type === 'ready', 5000)
+
+    const originalCreate = registry.create.bind(registry)
+    registry.create = vi.fn((opts: any) => {
+      registry.createCalls.push(opts)
+      const terminalId = 'term_inserted_before_emit_failure'
+      registry.records.set(terminalId, {
+        terminalId,
+        createdAt: Date.now(),
+        buffer: new FakeBuffer(),
+        title: 'Codex',
+        mode: opts.mode || 'codex',
+        shell: opts.shell || 'system',
+        status: 'running',
+        resumeSessionId: opts.resumeSessionId,
+        clients: new Set(),
+      })
+      const error = new Error('terminal.created listener failed') as Error & { terminalId?: string }
+      error.terminalId = terminalId
+      throw error
+    }) as any
+
+    try {
+      ws.send(JSON.stringify({ type: 'terminal.create', requestId: 'codex-create-emit-fails', mode: 'codex' }))
+      const error = await waitForMessage(
+        ws,
+        (msg) => msg.type === 'error' && msg.requestId === 'codex-create-emit-fails',
+        5000,
+      )
+
+      expect(error.message).toContain('terminal.created listener failed')
+      expect(registry.killCalls).toContain('term_inserted_before_emit_failure')
+      expect(registry.records.has('term_inserted_before_emit_failure')).toBe(false)
+      expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+    } finally {
+      registry.create = originalCreate as any
+      await closeWebSocket(ws)
+    }
+  })
+
+  it('rejects late terminal.create after the WebSocket handler starts closing', async () => {
+    const localServer = http.createServer((_req, res) => {
+      res.statusCode = 404
+      res.end()
+    })
+    const localRegistry = new FakeRegistry()
+    const localPlanner = new FakeCodexLaunchPlanner()
+    const localHandler = new WsHandler(localServer, localRegistry as any, { codexLaunchPlanner: localPlanner })
+    const sent: any[] = []
+    const ws = {
+      readyState: WebSocket.OPEN,
+      bufferedAmount: 0,
+      connectionId: 'late-create-after-close',
+      send: vi.fn((payload: string, cb?: (err?: Error) => void) => {
+        sent.push(JSON.parse(payload))
+        cb?.()
+      }),
+      close: vi.fn(),
+    }
+    const state = {
+      authenticated: true,
+      supportsUiScreenshotV1: false,
+      attachedTerminalIds: new Set(),
+      createdByRequestId: new Map(),
+      terminalCreateTimestamps: [],
+      codingCliSessions: new Set(),
+      codingCliSubscriptions: new Map(),
+      sdkSessions: new Set(),
+      sdkSubscriptions: new Map(),
+      sdkSessionTargets: new Map(),
+      interestedSessions: new Set(),
+      sidebarOpenSessionKeys: new Set(),
+    }
+
+    localHandler.close()
+    await (localHandler as any).onMessage(
+      ws,
+      state,
+      Buffer.from(JSON.stringify({ type: 'terminal.create', requestId: 'after-close', mode: 'codex' })),
+    )
+
+    expect(sent).toContainEqual(expect.objectContaining({
+      type: 'error',
+      requestId: 'after-close',
+    }))
+    expect(localRegistry.createCalls).toEqual([])
+    expect(localPlanner.planCreateCalls).toEqual([])
+  })
+
+  it('aborts in-flight Codex terminal.create when shutdown starts after planning before registry create', async () => {
+    const localServer = http.createServer((_req, res) => {
+      res.statusCode = 404
+      res.end()
+    })
+    const localRegistry = new FakeRegistry()
+    const sidecar = new FakeCodexLaunchSidecar()
+    const plan = deferred<any>()
+    const localPlanner = {
+      planCreateCalls: [] as any[],
+      planCreate: vi.fn((input: any) => {
+        localPlanner.planCreateCalls.push(input)
+        return plan.promise
+      }),
+    }
+    const localHandler = new WsHandler(localServer, localRegistry as any, { codexLaunchPlanner: localPlanner as any })
+    const sent: any[] = []
+    const ws = createOpenFakeWs('shutdown-after-plan', sent)
+    const state = createAuthenticatedState()
+
+    const message = (localHandler as any).onMessage(
+      ws,
+      state,
+      Buffer.from(JSON.stringify({ type: 'terminal.create', requestId: 'shutdown-after-plan', mode: 'codex' })),
+    )
+    await vi.waitFor(() => expect(localPlanner.planCreate).toHaveBeenCalledTimes(1))
+    localHandler.close()
+    plan.resolve({
+      sessionId: 'thread-after-plan',
+      remote: { wsUrl: DEFAULT_CODEX_REMOTE_WS_URL },
+      sidecar,
+    })
+    await message
+
+    expect(sent).toContainEqual(expect.objectContaining({
+      type: 'error',
+      requestId: 'shutdown-after-plan',
+    }))
+    expect(localRegistry.createCalls).toEqual([])
+    expect(sidecar.shutdownCalls).toBe(1)
+  })
+
+  it('aborts in-flight Codex terminal.create when shutdown starts after registry create before adoption', async () => {
+    const localServer = http.createServer((_req, res) => {
+      res.statusCode = 404
+      res.end()
+    })
+    const localRegistry = new FakeRegistry()
+    const sidecar = new FakeCodexLaunchSidecar()
+    const localPlanner = new FakeCodexLaunchPlanner({
+      sessionId: 'thread-after-registry-create',
+      remote: { wsUrl: DEFAULT_CODEX_REMOTE_WS_URL },
+      sidecar,
+    })
+    const localHandler = new WsHandler(localServer, localRegistry as any, { codexLaunchPlanner: localPlanner })
+    const originalCreate = localRegistry.create.bind(localRegistry)
+    localRegistry.create = vi.fn((opts: any) => {
+      const record = originalCreate(opts)
+      localHandler.close()
+      return record
+    }) as any
+    const sent: any[] = []
+    const ws = createOpenFakeWs('shutdown-after-registry-create', sent)
+    const state = createAuthenticatedState()
+
+    await (localHandler as any).onMessage(
+      ws,
+      state,
+      Buffer.from(JSON.stringify({ type: 'terminal.create', requestId: 'shutdown-after-registry-create', mode: 'codex' })),
+    )
+
+    expect(sent).toContainEqual(expect.objectContaining({
+      type: 'error',
+      requestId: 'shutdown-after-registry-create',
+    }))
+    expect(sidecar.adoptCalls).toEqual([])
+    expect(sidecar.shutdownCalls).toBe(1)
+    expect(localRegistry.killCalls).toHaveLength(1)
+    expect(localRegistry.records.size).toBe(0)
+  })
+
+  it('aborts in-flight Codex terminal.create when shutdown starts after adoption before publication', async () => {
+    const localServer = http.createServer((_req, res) => {
+      res.statusCode = 404
+      res.end()
+    })
+    const localRegistry = new FakeRegistry()
+    const sidecar = new FakeCodexLaunchSidecar()
+    const originalAdopt = sidecar.adopt.bind(sidecar)
+    const localPlanner = new FakeCodexLaunchPlanner({
+      sessionId: 'thread-after-adoption',
+      remote: { wsUrl: DEFAULT_CODEX_REMOTE_WS_URL },
+      sidecar,
+    })
+    const localHandler = new WsHandler(localServer, localRegistry as any, { codexLaunchPlanner: localPlanner })
+    vi.spyOn(sidecar, 'adopt').mockImplementation(async (input) => {
+      await originalAdopt(input)
+      localHandler.close()
+    })
+    const sent: any[] = []
+    const ws = createOpenFakeWs('shutdown-after-adoption', sent)
+    const state = createAuthenticatedState()
+
+    await (localHandler as any).onMessage(
+      ws,
+      state,
+      Buffer.from(JSON.stringify({ type: 'terminal.create', requestId: 'shutdown-after-adoption', mode: 'codex' })),
+    )
+
+    expect(sent).toContainEqual(expect.objectContaining({
+      type: 'error',
+      requestId: 'shutdown-after-adoption',
+    }))
+    expect(sidecar.adoptCalls).toHaveLength(1)
+    expect(localRegistry.publishCalls).toEqual([])
+    expect(localRegistry.killCalls).toHaveLength(1)
+    expect(sidecar.shutdownCalls).toBe(1)
+    expect(localRegistry.records.size).toBe(0)
+  })
+
+  it('aborts in-flight Codex resume terminal.create when shutdown starts during loaded-list readiness', async () => {
+    const localServer = http.createServer((_req, res) => {
+      res.statusCode = 404
+      res.end()
+    })
+    const localRegistry = new FakeRegistry()
+    const sidecar = new FakeCodexLaunchSidecar()
+    const readiness = deferred()
+    const originalWaitForLoadedThread = sidecar.waitForLoadedThread.bind(sidecar)
+    const localPlanner = new FakeCodexLaunchPlanner({
+      sessionId: 'thread-during-readiness',
+      remote: { wsUrl: DEFAULT_CODEX_REMOTE_WS_URL },
+      sidecar,
+    })
+    const localHandler = new WsHandler(localServer, localRegistry as any, { codexLaunchPlanner: localPlanner })
+    vi.spyOn(sidecar, 'waitForLoadedThread').mockImplementation(async (threadId, options) => {
+      await originalWaitForLoadedThread(threadId, options)
+      localHandler.close()
+      await readiness.promise
+    })
+    const sent: any[] = []
+    const ws = createOpenFakeWs('shutdown-during-readiness', sent)
+    const state = createAuthenticatedState()
+
+    const message = (localHandler as any).onMessage(
+      ws,
+      state,
+      Buffer.from(JSON.stringify({
+        type: 'terminal.create',
+        requestId: 'shutdown-during-readiness',
+        mode: 'codex',
+        resumeSessionId: 'thread-during-readiness',
+      })),
+    )
+    await vi.waitFor(() => expect(sidecar.waitForLoadedThreadCalls).toHaveLength(1))
+    readiness.resolve()
+    await message
+
+    expect(sent).toContainEqual(expect.objectContaining({
+      type: 'error',
+      requestId: 'shutdown-during-readiness',
+    }))
+    expect(sidecar.adoptCalls).toHaveLength(1)
+    expect(localRegistry.publishCalls).toEqual([])
+    expect(localRegistry.killCalls).toHaveLength(1)
+    expect(sidecar.shutdownCalls).toBe(1)
+    expect(localRegistry.records.size).toBe(0)
+  })
+
+  it('waits for candidate-local loaded-thread readiness before reporting Codex resume create success', async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+    ws.send(JSON.stringify({ type: 'hello', token: 'testtoken-testtoken', protocolVersion: WS_PROTOCOL_VERSION }))
+    await waitForMessage(ws, (msg) => msg.type === 'ready', 5000)
+
+    const requestId = 'codex-resume-loaded-list'
+    ws.send(JSON.stringify({
+      type: 'terminal.create',
+      requestId,
+      mode: 'codex',
+      resumeSessionId: 'thread-resume-1',
+    }))
+    const created = await waitForMessage(
+      ws,
+      (msg) => msg.type === 'terminal.created' && msg.requestId === requestId,
+      5000,
+    )
+
+    expect(codexLaunchPlanner.planCreateCalls[0]).toEqual(expect.objectContaining({
+      resumeSessionId: 'thread-resume-1',
+    }))
+    expect(codexLaunchPlanner.sidecar.waitForLoadedThreadCalls).toEqual([{
+      threadId: 'thread-resume-1',
+      options: undefined,
+    }])
+    expect(registry.publishCalls).toEqual([created.terminalId])
+
+    await closeWebSocket(ws)
+  })
+
+  it('kills the created terminal and sidecar when Codex resume loaded-list readiness fails', async () => {
+    codexLaunchPlanner.sidecar.waitForLoadedThreadError = new Error('resume thread never loaded')
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+    ws.send(JSON.stringify({ type: 'hello', token: 'testtoken-testtoken', protocolVersion: WS_PROTOCOL_VERSION }))
+    await waitForMessage(ws, (msg) => msg.type === 'ready', 5000)
+
+    const requestId = 'codex-resume-loaded-list-fails'
+    ws.send(JSON.stringify({
+      type: 'terminal.create',
+      requestId,
+      mode: 'codex',
+      resumeSessionId: 'thread-missing',
+    }))
+    const error = await waitForMessage(
+      ws,
+      (msg) => msg.type === 'error' && msg.requestId === requestId,
+      5000,
+    )
+
+    expect(error.message).toContain('resume thread never loaded')
+    expect(codexLaunchPlanner.sidecar.waitForLoadedThreadCalls).toHaveLength(1)
+    expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+    expect(registry.killCalls).toHaveLength(1)
+    expect(registry.records.size).toBe(0)
+
+    await closeWebSocket(ws)
+  })
+
+  it('kills the created terminal and sidecar when the Codex resume PTY exits before publication', async () => {
+    const originalWaitForLoadedThread = codexLaunchPlanner.sidecar.waitForLoadedThread.bind(codexLaunchPlanner.sidecar)
+    const waitSpy = vi.spyOn(codexLaunchPlanner.sidecar, 'waitForLoadedThread').mockImplementation(async (threadId, options) => {
+      await originalWaitForLoadedThread(threadId, options)
+      const terminalId = codexLaunchPlanner.sidecar.adoptCalls[0]?.terminalId
+      const record = terminalId ? registry.get(terminalId) : null
+      if (record) record.status = 'exited'
+    })
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+    ws.send(JSON.stringify({ type: 'hello', token: 'testtoken-testtoken', protocolVersion: WS_PROTOCOL_VERSION }))
+    await waitForMessage(ws, (msg) => msg.type === 'ready', 5000)
+
+    const requestId = 'codex-resume-pty-exits-before-publication'
+    try {
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'codex',
+        resumeSessionId: 'thread-resume-exits',
+      }))
+      const error = await waitForMessage(
+        ws,
+        (msg) => msg.type === 'error' && msg.requestId === requestId,
+        5000,
+      )
+
+      expect(error.message).toContain('Codex terminal PTY exited before create completed')
+      expect(codexLaunchPlanner.sidecar.waitForLoadedThreadCalls).toHaveLength(1)
+      expect(codexLaunchPlanner.sidecar.shutdownCalls).toBe(1)
+      expect(registry.killCalls).toHaveLength(1)
+      expect(registry.records.size).toBe(0)
+    } finally {
+      waitSpy.mockRestore()
+      await closeWebSocket(ws)
+    }
   })
 
   it('returns INVALID_MESSAGE when persisted Codex settings are invalid', async () => {
@@ -810,6 +1303,30 @@ describe('ws protocol', () => {
     expect(error.terminalId).toBe('nonexistent_terminal')
 
     await close()
+  })
+
+  it('terminal.kill returns a protocol error when verified Codex teardown fails', async () => {
+    const { ws, close } = await createAuthenticatedConnection()
+    const originalKillAndWait = registry.killAndWait.bind(registry)
+    registry.killAndWait = vi.fn(async () => {
+      throw new Error('verified Codex teardown failed')
+    }) as any
+
+    try {
+      ws.send(JSON.stringify({ type: 'terminal.kill', terminalId: 'codex-terminal-with-failed-teardown' }))
+
+      const error = await waitForMessage(
+        ws,
+        (msg) => msg.type === 'error' && msg.terminalId === 'codex-terminal-with-failed-teardown',
+        5000,
+      )
+
+      expect(error.code).toBe('INTERNAL_ERROR')
+      expect(error.message).toContain('verified Codex teardown failed')
+    } finally {
+      registry.killAndWait = originalKillAndWait as any
+      await close()
+    }
   })
 
   it('rejects legacy terminal.list commands', async () => {

--- a/test/unit/server/codex-real-provider-smoke-config.test.ts
+++ b/test/unit/server/codex-real-provider-smoke-config.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+
+describe('Codex real-provider smoke suite configuration', () => {
+  it('keeps the real-provider smoke out of the default server suite and exposes an opt-in command', async () => {
+    const root = process.cwd()
+    const serverConfig = await fsp.readFile(path.join(root, 'vitest.server.config.ts'), 'utf8')
+    expect(serverConfig).toContain("'test/integration/server/codex-real-provider-smoke.test.ts'")
+
+    const packageJson = JSON.parse(await fsp.readFile(path.join(root, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>
+    }
+    expect(packageJson.scripts?.['test:codex-real-provider-smoke'])
+      .toContain('vitest.codex-real-provider-smoke.config.ts')
+
+    const optInConfig = await fsp.readFile(path.join(root, 'vitest.codex-real-provider-smoke.config.ts'), 'utf8')
+    expect(optInConfig).toContain("'test/integration/server/codex-real-provider-smoke.test.ts'")
+  })
+})

--- a/test/unit/server/coding-cli/codex-app-server/client.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/client.test.ts
@@ -14,8 +14,11 @@ type FakeServerBehavior = {
   closeSocketAfterMethodsOnce?: string[]
   delayMethodsMs?: Record<string, number>
   ignoreMethods?: string[]
+  loadedThreadIds?: string[]
+  notificationsAfterMethods?: Record<string, unknown[]>
   requireJsonRpc?: boolean
   requireInitializeBeforeOtherMethods?: boolean
+  requireInitializedNotification?: boolean
   overrides?: Record<string, { result?: unknown; error?: { code: number; message: string } }>
 }
 
@@ -176,6 +179,73 @@ describe('CodexAppServerClient', () => {
     await expect(startThreadPromise).resolves.toEqual({
       threadId: 'thread-new-1',
     })
+  })
+
+  it('sends initialized after initialize before later requests', async () => {
+    const server = await startFakeCodexAppServer({
+      requireInitializeBeforeOtherMethods: true,
+      requireInitializedNotification: true,
+    })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    await client.initialize()
+
+    await expect(client.startThread({ cwd: '/repo/worktree' })).resolves.toEqual({
+      threadId: 'thread-new-1',
+    })
+  })
+
+  it('lists loaded in-memory thread ids', async () => {
+    const server = await startFakeCodexAppServer({
+      loadedThreadIds: ['019d9859-5670-72b1-851f-794ad7fef112', 'thread-new-1'],
+    })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    await client.initialize()
+
+    await expect(client.listLoadedThreads()).resolves.toEqual([
+      '019d9859-5670-72b1-851f-794ad7fef112',
+      'thread-new-1',
+    ])
+  })
+
+  it('emits lifecycle-loss events for closed, notLoaded, and systemError notifications', async () => {
+    const server = await startFakeCodexAppServer({
+      notificationsAfterMethods: {
+        'thread/loaded/list': [
+          {
+            method: 'thread/closed',
+            params: { threadId: 'thread-closed' },
+          },
+          {
+            method: 'thread/status/changed',
+            params: { threadId: 'thread-not-loaded', status: { type: 'notLoaded' } },
+          },
+          {
+            method: 'thread/status/changed',
+            params: { thread: { id: 'thread-system-error', status: { type: 'systemError' } } },
+          },
+          {
+            method: 'thread/status/changed',
+            params: { threadId: 'thread-running', status: { type: 'running' } },
+          },
+        ],
+      },
+    })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+    const events: unknown[] = []
+    const unsubscribe = client.onThreadLifecycleLoss((event) => events.push(event))
+
+    await client.initialize()
+    await client.listLoadedThreads()
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    unsubscribe()
+
+    expect(events).toEqual([
+      { method: 'thread/closed', threadId: 'thread-closed' },
+      { method: 'thread/status/changed', threadId: 'thread-not-loaded', status: 'notLoaded' },
+      { method: 'thread/status/changed', threadId: 'thread-system-error', status: 'systemError' },
+    ])
   })
 
   it('fails clearly when the app-server never answers a request', async () => {

--- a/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
@@ -1,70 +1,333 @@
 import { describe, expect, it, vi } from 'vitest'
 import { CodexLaunchPlanner } from '../../../../../server/coding-cli/codex-app-server/launch-planner.js'
 
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+class FakeRuntime {
+  shutdownCalls = 0
+  startThreadCalls = 0
+  adopted: Array<{ terminalId: string; generation: number }> = []
+  loadedThreadListCalls = 0
+  adoptError?: Error
+  startThreadBlocker?: Promise<void>
+  shutdownBlocker?: Promise<void>
+  shutdownError?: Error
+
+  constructor(
+    readonly wsUrl: string,
+    private readonly threadId: string,
+    private readonly startError?: Error,
+    private readonly loadedThreadLists: string[][] = [],
+  ) {}
+
+  async ensureReady() {
+    return {
+      wsUrl: this.wsUrl,
+      processPid: 100,
+      ownershipId: `ownership-${this.threadId}`,
+      processGroupId: 100,
+      metadataPath: `/tmp/${this.threadId}.json`,
+    }
+  }
+
+  async startThread() {
+    this.startThreadCalls += 1
+    await this.startThreadBlocker
+    if (this.startError) throw this.startError
+    return {
+      threadId: this.threadId,
+      wsUrl: this.wsUrl,
+    }
+  }
+
+  async updateOwnershipMetadata(input: { terminalId?: string | null; generation?: number | null }) {
+    if (this.adoptError) throw this.adoptError
+    if (input.terminalId && typeof input.generation === 'number') {
+      this.adopted.push({ terminalId: input.terminalId, generation: input.generation })
+    }
+  }
+
+  async listLoadedThreads() {
+    const index = Math.min(this.loadedThreadListCalls, Math.max(0, this.loadedThreadLists.length - 1))
+    this.loadedThreadListCalls += 1
+    return this.loadedThreadLists[index] ?? []
+  }
+
+  async shutdown() {
+    this.shutdownCalls += 1
+    await this.shutdownBlocker
+    if (this.shutdownError) throw this.shutdownError
+  }
+}
+
 describe('CodexLaunchPlanner', () => {
-  it('starts a fresh Codex thread and returns an exact remote endpoint handoff', async () => {
-    const runtime = {
-      ensureReady: vi.fn(),
-      startThread: vi.fn().mockResolvedValue({
-        threadId: 'thread-new-1',
-        wsUrl: 'ws://127.0.0.1:43123',
-      }),
-    }
-    const planner = new CodexLaunchPlanner(runtime as any)
-
-    const plan = await planner.planCreate({
-      cwd: '/repo/worktree',
-      model: 'codex-default',
-      sandbox: 'workspace-write',
+  it('creates a distinct owned sidecar for each launch plan', async () => {
+    const runtimes: FakeRuntime[] = []
+    const planner = new CodexLaunchPlanner(() => {
+      const index = runtimes.length + 1
+      const runtime = new FakeRuntime(`ws://127.0.0.1:${43000 + index}`, `thread-${index}`)
+      runtimes.push(runtime)
+      return runtime as any
     })
 
-    expect(runtime.startThread).toHaveBeenCalledWith({
-      cwd: '/repo/worktree',
-      model: 'codex-default',
-      sandbox: 'workspace-write',
-      approvalPolicy: undefined,
-    })
-    expect(plan.sessionId).toBe('thread-new-1')
-    expect(plan.remote.wsUrl).toBe('ws://127.0.0.1:43123')
+    const first = await planner.planCreate({ cwd: '/repo/one' })
+    const second = await planner.planCreate({ cwd: '/repo/two' })
+
+    expect(runtimes).toHaveLength(2)
+    expect(first.remote.wsUrl).toBe('ws://127.0.0.1:43001')
+    expect(second.remote.wsUrl).toBe('ws://127.0.0.1:43002')
+
+    await first.sidecar.adopt({ terminalId: 'term-one', generation: 1 })
+    await second.sidecar.shutdown()
+
+    expect(runtimes[0].adopted).toEqual([{ terminalId: 'term-one', generation: 1 }])
+    expect(runtimes[0].shutdownCalls).toBe(0)
+    expect(runtimes[1].shutdownCalls).toBe(1)
   })
 
-  it('reuses an existing Codex session id and only ensures the remote runtime is ready', async () => {
-    const runtime = {
-      ensureReady: vi.fn().mockResolvedValue({
-        wsUrl: 'ws://127.0.0.1:43123',
-      }),
-      startThread: vi.fn(),
-    }
-    const planner = new CodexLaunchPlanner(runtime as any)
+  it('shuts down the owned sidecar when planning fails before adoption', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43010', 'thread-fail', new Error('start failed'))
+    const planner = new CodexLaunchPlanner(() => runtime as any)
 
-    const plan = await planner.planCreate({
-      cwd: '/repo/worktree',
-      resumeSessionId: '019d9859-5670-72b1-851f-794ad7fef112',
-    })
+    await expect(planner.planCreate({ cwd: '/repo/fail' })).rejects.toThrow('start failed')
 
-    expect(runtime.ensureReady).toHaveBeenCalledTimes(1)
-    expect(runtime.startThread).not.toHaveBeenCalled()
-    expect(plan.sessionId).toBe('019d9859-5670-72b1-851f-794ad7fef112')
-    expect(plan.remote.wsUrl).toBe('ws://127.0.0.1:43123')
+    expect(runtime.shutdownCalls).toBe(1)
   })
 
-  it('uses the runtime-reported wsUrl from the same thread create call', async () => {
-    const runtime = {
-      ensureReady: vi.fn(),
-      startThread: vi.fn().mockResolvedValue({
-        threadId: 'thread-new-2',
-        wsUrl: 'ws://127.0.0.1:43199',
-      }),
+  it('marks planning cleanup teardown failures as sidecar teardown failures', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43022', 'thread-fail', new Error('start failed'))
+    runtime.shutdownError = new Error('verified runtime teardown failed')
+    const planner = new CodexLaunchPlanner(() => runtime as any)
+
+    let rejection: unknown
+    try {
+      await planner.planCreate({ cwd: '/repo/fail-teardown' })
+    } catch (err) {
+      rejection = err
     }
-    const planner = new CodexLaunchPlanner(runtime as any)
 
-    const plan = await planner.planCreate({ cwd: '/repo/worktree' })
+    expect(rejection).toBeInstanceOf(Error)
+    expect((rejection as Error).message).toContain('verified runtime teardown failed')
+    expect(rejection).toMatchObject({ codexSidecarTeardownFailed: true })
+    expect(runtime.shutdownCalls).toBe(1)
+  })
 
-    expect(plan).toEqual({
-      sessionId: 'thread-new-2',
-      remote: {
-        wsUrl: 'ws://127.0.0.1:43199',
-      },
+  it('transfers sidecar ownership to the registry on adoption so planner shutdown only cleans unadopted plans', async () => {
+    const adoptedRuntime = new FakeRuntime('ws://127.0.0.1:43011', 'thread-adopted')
+    const pendingRuntime = new FakeRuntime('ws://127.0.0.1:43012', 'thread-pending')
+    const runtimes = [adoptedRuntime, pendingRuntime]
+    const planner = new CodexLaunchPlanner(() => runtimes.shift()! as any)
+
+    const adopted = await planner.planCreate({ cwd: '/repo/adopted' })
+    const pending = await planner.planCreate({ cwd: '/repo/pending' })
+    await adopted.sidecar.adopt({ terminalId: 'term-adopted', generation: 1 })
+
+    await planner.shutdown()
+
+    expect(adoptedRuntime.adopted).toEqual([{ terminalId: 'term-adopted', generation: 1 }])
+    expect(adoptedRuntime.shutdownCalls).toBe(0)
+    expect(pendingRuntime.shutdownCalls).toBe(1)
+
+    await pending.sidecar.shutdown()
+    expect(pendingRuntime.shutdownCalls).toBe(1)
+  })
+
+  it('keeps a failed-adoption sidecar planner-owned so shutdown can clean it up', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43013', 'thread-adopt-fails')
+    runtime.adoptError = new Error('no active owned Codex app-server sidecar')
+    const planner = new CodexLaunchPlanner(() => runtime as any)
+
+    const plan = await planner.planCreate({ cwd: '/repo/adopt-fails' })
+    await expect(plan.sidecar.adopt({ terminalId: 'term-adopt-fails', generation: 1 }))
+      .rejects.toThrow('no active owned Codex app-server sidecar')
+
+    await planner.shutdown()
+
+    expect(runtime.adopted).toEqual([])
+    expect(runtime.shutdownCalls).toBe(1)
+  })
+
+  it('rejects new plans after shutdown begins without creating another sidecar', async () => {
+    const shutdownGate = deferred()
+    const firstRuntime = new FakeRuntime('ws://127.0.0.1:43014', 'thread-before-shutdown')
+    firstRuntime.shutdownBlocker = shutdownGate.promise
+    const runtimes = [firstRuntime]
+    const planner = new CodexLaunchPlanner(() => {
+      const runtime = runtimes.shift()
+      if (!runtime) throw new Error('unexpected runtime allocation')
+      return runtime as any
     })
+
+    await planner.planCreate({ cwd: '/repo/before-shutdown' })
+    const shutdown = planner.shutdown()
+    await new Promise((resolve) => setImmediate(resolve))
+
+    await expect(planner.planCreate({ cwd: '/repo/after-shutdown' })).rejects.toThrow(/shutting down/i)
+    expect(runtimes).toHaveLength(0)
+
+    shutdownGate.resolve()
+    await shutdown
+    await expect(planner.planCreate({ cwd: '/repo/after-shutdown-complete' })).rejects.toThrow(/shutting down/i)
+  })
+
+  it('rejects and cleans up an in-flight launch plan when shutdown starts before thread creation returns', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43018', 'thread-after-shutdown')
+    const startThreadGate = deferred()
+    runtime.startThreadBlocker = startThreadGate.promise
+    const planner = new CodexLaunchPlanner(() => runtime as any)
+
+    const plan = planner.planCreate({ cwd: '/repo/in-flight' })
+    await vi.waitFor(() => expect(runtime.startThreadCalls).toBe(1))
+
+    const shutdown = planner.shutdown()
+    await vi.waitFor(() => expect(runtime.shutdownCalls).toBe(1))
+
+    startThreadGate.resolve()
+
+    await expect(plan).rejects.toThrow(/shutting down/i)
+    await expect(shutdown).resolves.toBeUndefined()
+    expect(runtime.shutdownCalls).toBe(1)
+  })
+
+  it('rejects adoption after planner shutdown has started sidecar teardown', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43019', 'thread-adopt-after-shutdown')
+    const shutdownGate = deferred()
+    runtime.shutdownBlocker = shutdownGate.promise
+    const planner = new CodexLaunchPlanner(() => runtime as any)
+
+    const plan = await planner.planCreate({ cwd: '/repo/adopt-after-shutdown' })
+    const shutdown = planner.shutdown()
+    await vi.waitFor(() => expect(runtime.shutdownCalls).toBe(1))
+
+    await expect(plan.sidecar.adopt({ terminalId: 'term-after-shutdown', generation: 1 }))
+      .rejects.toThrow(/shutting down/i)
+    expect(runtime.adopted).toEqual([])
+
+    shutdownGate.resolve()
+    await shutdown
+  })
+
+  it('keeps failed unadopted sidecar teardown planner-owned and joinable by planner shutdown', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43015', 'thread-teardown-fails')
+    runtime.shutdownError = new Error('verified runtime teardown failed')
+    const planner = new CodexLaunchPlanner(() => runtime as any)
+
+    const plan = await planner.planCreate({ cwd: '/repo/unadopted' })
+
+    await expect(plan.sidecar.shutdown()).rejects.toThrow('verified runtime teardown failed')
+    await expect(planner.shutdown()).rejects.toThrow('verified runtime teardown failed')
+    expect(runtime.shutdownCalls).toBe(2)
+  })
+
+  it('retries a failed planner-owned sidecar teardown on a later shutdown join', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43023', 'thread-teardown-retry')
+    runtime.shutdownError = new Error('transient metadata cleanup failure')
+    const planner = new CodexLaunchPlanner(() => runtime as any)
+
+    const plan = await planner.planCreate({ cwd: '/repo/unadopted-retry' })
+
+    await expect(plan.sidecar.shutdown()).rejects.toThrow('transient metadata cleanup failure')
+    expect(runtime.shutdownCalls).toBe(1)
+
+    runtime.shutdownError = undefined
+
+    await expect(planner.shutdown()).resolves.toBeUndefined()
+    expect(runtime.shutdownCalls).toBe(2)
+  })
+
+  it('blocks new plans behind a failed planner-owned sidecar teardown until retry succeeds', async () => {
+    const runtimes: FakeRuntime[] = []
+    const planner = new CodexLaunchPlanner(() => {
+      const index = runtimes.length + 1
+      const runtime = new FakeRuntime(`ws://127.0.0.1:${43030 + index}`, `thread-${index}`)
+      runtimes.push(runtime)
+      return runtime as any
+    })
+
+    const first = await planner.planCreate({ cwd: '/repo/one' })
+    runtimes[0].shutdownError = new Error('transient teardown failure')
+
+    await expect(first.sidecar.shutdown()).rejects.toThrow('transient teardown failure')
+    expect(runtimes[0].shutdownCalls).toBe(1)
+
+    await expect(planner.planCreate({ cwd: '/repo/two' })).rejects.toThrow('transient teardown failure')
+    expect(runtimes).toHaveLength(1)
+    expect(runtimes[0].shutdownCalls).toBe(2)
+
+    runtimes[0].shutdownError = undefined
+
+    const second = await planner.planCreate({ cwd: '/repo/two' })
+
+    expect(second.sessionId).toBe('thread-2')
+    expect(runtimes).toHaveLength(2)
+    expect(runtimes[0].shutdownCalls).toBe(3)
+  })
+
+  it('waits for every planner-owned sidecar shutdown before reporting a teardown failure', async () => {
+    const firstRuntime = new FakeRuntime('ws://127.0.0.1:43016', 'thread-fast-fails')
+    firstRuntime.shutdownError = new Error('fast verified runtime teardown failed')
+    const secondRuntime = new FakeRuntime('ws://127.0.0.1:43017', 'thread-slow-shutdown')
+    const slowShutdown = deferred()
+    secondRuntime.shutdownBlocker = slowShutdown.promise
+    const runtimes = [firstRuntime, secondRuntime]
+    const planner = new CodexLaunchPlanner(() => runtimes.shift()! as any)
+
+    await planner.planCreate({ cwd: '/repo/fast-fails' })
+    await planner.planCreate({ cwd: '/repo/slow-shutdown' })
+
+    const shutdown = planner.shutdown()
+    let settled = false
+    void shutdown.then(
+      () => { settled = true },
+      () => { settled = true },
+    )
+
+    await vi.waitFor(() => expect(firstRuntime.shutdownCalls).toBe(1))
+    await vi.waitFor(() => expect(secondRuntime.shutdownCalls).toBe(1))
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(settled).toBe(false)
+
+    slowShutdown.resolve()
+    await expect(shutdown).rejects.toThrow('fast verified runtime teardown failed')
+  })
+
+  it('waits for candidate-local loaded-thread readiness', async () => {
+    const runtime = new FakeRuntime(
+      'ws://127.0.0.1:43020',
+      'thread-ready',
+      undefined,
+      [[], ['other-thread'], ['thread-ready']],
+    )
+    const planner = new CodexLaunchPlanner(() => runtime as any)
+
+    const plan = await planner.planCreate({ resumeSessionId: 'thread-ready' })
+
+    await expect(plan.sidecar.waitForLoadedThread('thread-ready', { timeoutMs: 1_000, pollMs: 1 }))
+      .resolves.toBeUndefined()
+    expect(runtime.loadedThreadListCalls).toBe(3)
+  })
+
+  it('stops loaded-thread readiness polling after sidecar shutdown starts', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43021', 'thread-never-loads')
+    const planner = new CodexLaunchPlanner(() => runtime as any)
+
+    const plan = await planner.planCreate({ resumeSessionId: 'thread-never-loads' })
+    const readiness = plan.sidecar.waitForLoadedThread('thread-never-loads', { timeoutMs: 250, pollMs: 20 })
+    await vi.waitFor(() => expect(runtime.loadedThreadListCalls).toBeGreaterThan(0))
+
+    await plan.sidecar.shutdown()
+    await expect(readiness).rejects.toThrow(/shutting down/i)
+
+    const callsAfterShutdown = runtime.loadedThreadListCalls
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(runtime.loadedThreadListCalls).toBe(callsAfterShutdown)
   })
 })

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -1,8 +1,15 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import http from 'node:http'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { CodexAppServerRuntime } from '../../../../../server/coding-cli/codex-app-server/runtime.js'
+import {
+  assertCodexStartupReaperSucceeded,
+  CodexAppServerRuntime,
+  reapOrphanedCodexAppServerSidecars,
+  runCodexStartupReaper,
+} from '../../../../../server/coding-cli/codex-app-server/runtime.js'
 import { allocateLocalhostPort, type LoopbackServerEndpoint } from '../../../../../server/local-port.js'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -11,6 +18,7 @@ const FAKE_SERVER_PATH = path.resolve(__dirname, '../../../../fixtures/coding-cl
 
 const runtimes = new Set<CodexAppServerRuntime>()
 const blockers = new Set<http.Server>()
+const tempDirs = new Set<string>()
 
 async function closeBlocker(server: http.Server): Promise<void> {
   blockers.delete(server)
@@ -23,7 +31,17 @@ afterEach(async () => {
     await runtime.shutdown()
   }))
   await Promise.all([...blockers].map((blocker) => closeBlocker(blocker)))
+  await Promise.all([...tempDirs].map(async (dir) => {
+    tempDirs.delete(dir)
+    await fsp.rm(dir, { recursive: true, force: true })
+  }))
 })
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-runtime-'))
+  tempDirs.add(dir)
+  return dir
+}
 
 async function occupyLoopbackPort(): Promise<{ blocker: http.Server; endpoint: LoopbackServerEndpoint }> {
   const blocker = http.createServer((_req, res) => {
@@ -70,6 +88,101 @@ async function waitForProcessExit(pid: number, timeoutMs = 5_000): Promise<void>
   throw new Error(`Timed out waiting for process ${pid} to exit`)
 }
 
+async function killProcessGroupForTest(processGroupId: number): Promise<void> {
+  try {
+    process.kill(-processGroupId, 'SIGKILL')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error
+  }
+  await waitForProcessExit(processGroupId).catch(() => undefined)
+}
+
+async function waitForMetadataRecord(metadataDir: string, timeoutMs = 5_000): Promise<any> {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    const entries = await fsp.readdir(metadataDir).catch(() => [])
+    for (const entry of entries) {
+      if (!entry.endsWith('.json')) continue
+      const raw = await fsp.readFile(path.join(metadataDir, entry), 'utf8')
+      return JSON.parse(raw)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+
+  throw new Error(`Timed out waiting for metadata record in ${metadataDir}`)
+}
+
+async function waitForPidFile(pidFile: string, timeoutMs = 5_000): Promise<number> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const raw = await fsp.readFile(pidFile, 'utf8').catch(() => '')
+    const pid = Number(raw.trim())
+    if (Number.isInteger(pid) && pid > 0) return pid
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error(`Timed out waiting for pid file ${pidFile}`)
+}
+
+async function readProcessEnvironment(pid: number): Promise<Record<string, string>> {
+  const raw = await fsp.readFile(`/proc/${pid}/environ`)
+  const pairs = raw.toString('utf8').split('\0').filter(Boolean)
+  return Object.fromEntries(pairs.map((pair) => {
+    const index = pair.indexOf('=')
+    return index === -1 ? [pair, ''] : [pair.slice(0, index), pair.slice(index + 1)]
+  }))
+}
+
+async function readCurrentProcessGroupId(): Promise<number> {
+  const stat = await fsp.readFile('/proc/self/stat', 'utf8')
+  const closeParen = stat.lastIndexOf(')')
+  const fields = stat.slice(closeParen + 2).trim().split(/\s+/)
+  return Number(fields[2])
+}
+
+async function markOwnershipRecordStale(
+  metadataPath: string,
+  overrides: Record<string, unknown> = {},
+): Promise<any> {
+  const raw = await fsp.readFile(metadataPath, 'utf8')
+  const metadata = JSON.parse(raw)
+  const stale = {
+    ...metadata,
+    ownerServerPid: 999_999_999,
+    serverInstanceId: 'srv-previous',
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+  await fsp.writeFile(metadataPath, JSON.stringify(stale, null, 2), 'utf8')
+  return stale
+}
+
+async function isProcessGroupAlive(processGroupId: number): Promise<boolean> {
+  try {
+    process.kill(-processGroupId, 0)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return false
+    throw error
+  }
+}
+
+async function readWrapperIdentityForTest(pid: number) {
+  const [cmdline, cwd, stat] = await Promise.all([
+    fsp.readFile(`/proc/${pid}/cmdline`).catch(() => Buffer.from('')),
+    fsp.readlink(`/proc/${pid}/cwd`).catch(() => null),
+    fsp.readFile(`/proc/${pid}/stat`, 'utf8'),
+  ])
+  const closeParen = stat.lastIndexOf(')')
+  const fields = stat.slice(closeParen + 2).trim().split(/\s+/)
+  const startTimeTicks = Number(fields[19])
+  return {
+    commandLine: cmdline.toString('utf8').split('\0').filter(Boolean),
+    cwd,
+    startTimeTicks: Number.isFinite(startTimeTicks) ? startTimeTicks : null,
+  }
+}
+
 function createRuntime(options: ConstructorParameters<typeof CodexAppServerRuntime>[0] = {}): CodexAppServerRuntime {
   const runtime = new CodexAppServerRuntime({
     command: process.execPath,
@@ -81,7 +194,7 @@ function createRuntime(options: ConstructorParameters<typeof CodexAppServerRunti
 }
 
 describe('CodexAppServerRuntime', () => {
-  it('starts one shared loopback app-server runtime on first use', async () => {
+  it('starts one owned loopback app-server sidecar on first use', async () => {
     const runtime = createRuntime()
 
     const ready = await runtime.ensureReady()
@@ -91,7 +204,66 @@ describe('CodexAppServerRuntime', () => {
     expect(runtime.status()).toBe('running')
   })
 
-  it('reuses the same process for repeated ensureReady calls', async () => {
+  it('rejects before spawning on platforms without Linux /proc ownership support', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    if (!originalPlatform?.configurable) {
+      throw new Error('process.platform descriptor is not configurable in this test environment')
+    }
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      startupAttemptLimit: 1,
+    })
+
+    try {
+      Object.defineProperty(process, 'platform', { value: 'darwin' })
+
+      await expect(runtime.ensureReady()).rejects.toThrow(/linux.*\/proc/i)
+      const entries = await fsp.readdir(metadataDir).catch((error) => {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+        throw error
+      })
+      expect(entries).toEqual([])
+    } finally {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  })
+
+  it('rejects before spawning when Linux /proc ownership proof is unavailable', async () => {
+    const metadataDir = await makeTempDir()
+    let ownershipIdCalls = 0
+    const originalReaddir = fsp.readdir.bind(fsp)
+    const readdirSpy = vi.spyOn(fsp, 'readdir').mockImplementation(((target: any, options?: any) => {
+      if (String(target) === '/proc') {
+        const error = new Error('simulated /proc read failure') as NodeJS.ErrnoException
+        error.code = 'EACCES'
+        return Promise.reject(error)
+      }
+      return originalReaddir(target, options as any) as any
+    }) as typeof fsp.readdir)
+    const runtime = createRuntime({
+      metadataDir,
+      startupAttemptLimit: 1,
+      ownershipIdFactory: () => {
+        ownershipIdCalls += 1
+        return `ownership-${ownershipIdCalls}`
+      },
+    })
+
+    try {
+      await expect(runtime.ensureReady()).rejects.toThrow(/\/proc.*ownership proof/i)
+      expect(ownershipIdCalls).toBe(0)
+      const entries = await originalReaddir(metadataDir).catch((error) => {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+        throw error
+      })
+      expect(entries).toEqual([])
+    } finally {
+      readdirSpy.mockRestore()
+    }
+  })
+
+  it('reuses the same process for repeated ensureReady calls on one runtime', async () => {
     const runtime = createRuntime()
 
     const first = await runtime.ensureReady()
@@ -124,7 +296,905 @@ describe('CodexAppServerRuntime', () => {
     expect(runtime.status()).toBe('stopped')
   })
 
-  it('proxies thread/start through the shared client after boot', async () => {
+  it('writes ownership metadata immediately after spawn before initialize completes', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          delayMethodsMs: {
+            initialize: 250,
+          },
+        }),
+      },
+    })
+
+    const readyPromise = runtime.ensureReady()
+    const metadata = await waitForMetadataRecord(metadataDir)
+    const ready = await readyPromise
+
+    expect(metadata.schemaVersion).toBe(1)
+    expect(metadata.ownershipId).toBe(ready.ownershipId)
+    expect(metadata.serverInstanceId).toBe('srv-runtime-test')
+    expect(metadata.ownerServerPid).toBe(process.pid)
+    expect(metadata.terminalId).toBeNull()
+    expect(metadata.generation).toBeNull()
+    expect(metadata.wsUrl).toBe(ready.wsUrl)
+    expect(metadata.wrapperPid).toBe(ready.processPid)
+    expect(metadata.processGroupId).toBe(ready.processGroupId)
+    expect(metadata.wrapperIdentity.startTimeTicks).toEqual(expect.any(Number))
+  })
+
+  it('writes durable ownership metadata before wrapper identity lookup resolves', async () => {
+    const metadataDir = await makeTempDir()
+    let identityLookupStarted!: () => void
+    let releaseIdentityLookup!: (identity: null) => void
+    const identityStarted = new Promise<void>((resolve) => {
+      identityLookupStarted = resolve
+    })
+    const identityReleased = new Promise<null>((resolve) => {
+      releaseIdentityLookup = resolve
+    })
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      processIdentityReader: async () => {
+        identityLookupStarted()
+        return identityReleased
+      },
+    })
+
+    const readyPromise = runtime.ensureReady()
+    try {
+      await identityStarted
+      const metadata = await waitForMetadataRecord(metadataDir, 500)
+
+      expect(metadata.schemaVersion).toBe(1)
+      expect(metadata.serverInstanceId).toBe('srv-runtime-test')
+      expect(metadata.wrapperIdentity).toEqual({
+        commandLine: [],
+        cwd: null,
+        startTimeTicks: null,
+      })
+    } finally {
+      releaseIdentityLookup(null)
+      await readyPromise.catch(() => undefined)
+    }
+  })
+
+  it('tears down both the wrapper and native child in its process group', async () => {
+    const metadataDir = await makeTempDir()
+    const nativePidFile = path.join(metadataDir, 'native.pid')
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          spawnNativeChild: true,
+          nativePidFile,
+          wrapperLeavesNativeOnSigterm: true,
+        }),
+      },
+    })
+
+    const ready = await runtime.ensureReady()
+    const nativePid = await waitForPidFile(nativePidFile)
+
+    expect(nativePid).not.toBe(ready.processPid)
+
+    await runtime.shutdown()
+
+    await waitForProcessExit(ready.processPid)
+    await waitForProcessExit(nativePid)
+    await expect(fsp.readdir(metadataDir)).resolves.not.toContain(path.basename(ready.metadataPath))
+  })
+
+  it('tears down an owned native child after the wrapper exits hard before restarting', async () => {
+    const metadataDir = await makeTempDir()
+    const nativePidFile = path.join(metadataDir, 'native.pid')
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          spawnNativeChild: true,
+          nativePidFile,
+          wrapperLeavesNativeOnSigterm: true,
+        }),
+      },
+    })
+
+    const first = await runtime.ensureReady()
+    const oldNativePid = await waitForPidFile(nativePidFile)
+
+    process.kill(first.processPid, 'SIGKILL')
+    await waitForProcessExit(first.processPid)
+
+    const second = await runtime.ensureReady()
+
+    expect(second.processPid).not.toBe(first.processPid)
+    await waitForProcessExit(oldNativePid)
+  })
+
+  it('tears down a native child when the wrapper exits before initialize', async () => {
+    const metadataDir = await makeTempDir()
+    const nativePidFile = path.join(metadataDir, 'native.pid')
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      startupAttemptLimit: 1,
+      startupAttemptTimeoutMs: 100,
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          spawnNativeChild: true,
+          nativePidFile,
+          wrapperLeavesNativeOnSigterm: true,
+          exitAfterSpawningNative: true,
+        }),
+      },
+    })
+
+    await expect(runtime.ensureReady()).rejects.toThrow(/failed to start codex app-server/i)
+
+    const nativePid = await waitForPidFile(nativePidFile)
+    await waitForProcessExit(nativePid)
+  })
+
+  it('uses the startup attempt timeout to tear down an initialize hang before retrying', async () => {
+    const tempDir = await makeTempDir()
+    const metadataDir = path.join(tempDir, 'metadata')
+    const processGroups: number[] = []
+    const seenProcessGroups = new Set<number>()
+    let previousAttemptGoneBeforeRetry = false
+    const start = Date.now()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      startupAttemptLimit: 2,
+      startupAttemptTimeoutMs: 120,
+      requestTimeoutMs: 1_000,
+      metadataWriter: async (filePath, metadata) => {
+        if (!seenProcessGroups.has(metadata.processGroupId)) {
+          if (processGroups.length > 0) {
+            previousAttemptGoneBeforeRetry = !(await isProcessGroupAlive(processGroups[0]))
+          }
+          seenProcessGroups.add(metadata.processGroupId)
+          processGroups.push(metadata.processGroupId)
+        }
+        await fsp.mkdir(path.dirname(filePath), { recursive: true })
+        await fsp.writeFile(filePath, JSON.stringify(metadata), 'utf8')
+      },
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          ignoreMethods: ['initialize'],
+        }),
+      },
+    })
+
+    await expect(runtime.ensureReady()).rejects.toThrow(/initialize|failed to start codex app-server/i)
+
+    expect(processGroups).toHaveLength(2)
+    expect(previousAttemptGoneBeforeRetry).toBe(true)
+    expect(Date.now() - start).toBeLessThan(1_500)
+  }, 3_000)
+
+  it('tears down the owned process group before retry when wrapper identity cannot be read', async () => {
+    const tempDir = await makeTempDir()
+    const metadataDir = path.join(tempDir, 'metadata')
+    const processGroups: number[] = []
+    const seenProcessGroups = new Set<number>()
+    let previousAttemptGoneBeforeRetry = false
+    let identityReadAttempts = 0
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      startupAttemptLimit: 2,
+      startupAttemptTimeoutMs: 120,
+      requestTimeoutMs: 1_000,
+      processIdentityReader: async (pid) => {
+        identityReadAttempts += 1
+        if (identityReadAttempts === 1) return null
+        return readWrapperIdentityForTest(pid)
+      },
+      metadataWriter: async (filePath, metadata) => {
+        if (!seenProcessGroups.has(metadata.processGroupId)) {
+          if (processGroups.length > 0) {
+            previousAttemptGoneBeforeRetry = !(await isProcessGroupAlive(processGroups[0]))
+          }
+          seenProcessGroups.add(metadata.processGroupId)
+          processGroups.push(metadata.processGroupId)
+        }
+        await fsp.mkdir(path.dirname(filePath), { recursive: true })
+        await fsp.writeFile(filePath, JSON.stringify(metadata), 'utf8')
+      },
+    })
+
+    const ready = await runtime.ensureReady()
+    const record = JSON.parse(await fsp.readFile(ready.metadataPath, 'utf8'))
+
+    expect(processGroups).toHaveLength(2)
+    expect(identityReadAttempts).toBe(2)
+    expect(previousAttemptGoneBeforeRetry).toBe(true)
+    expect(record.processGroupId).toBe(processGroups[1])
+    expect(record.wrapperIdentity.startTimeTicks).toEqual(expect.any(Number))
+  }, 3_000)
+
+  it('tears down the owned process group before retry when wrapper identity is incomplete', async () => {
+    const tempDir = await makeTempDir()
+    const metadataDir = path.join(tempDir, 'metadata')
+    const processGroups: number[] = []
+    const seenProcessGroups = new Set<number>()
+    let previousAttemptGoneBeforeRetry = false
+    let identityReadAttempts = 0
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      startupAttemptLimit: 2,
+      startupAttemptTimeoutMs: 120,
+      requestTimeoutMs: 1_000,
+      processIdentityReader: async (pid) => {
+        identityReadAttempts += 1
+        if (identityReadAttempts === 1) {
+          return { commandLine: [], cwd: null, startTimeTicks: null }
+        }
+        return readWrapperIdentityForTest(pid)
+      },
+      metadataWriter: async (filePath, metadata) => {
+        if (!seenProcessGroups.has(metadata.processGroupId)) {
+          if (processGroups.length > 0) {
+            previousAttemptGoneBeforeRetry = !(await isProcessGroupAlive(processGroups[0]))
+          }
+          seenProcessGroups.add(metadata.processGroupId)
+          processGroups.push(metadata.processGroupId)
+        }
+        await fsp.mkdir(path.dirname(filePath), { recursive: true })
+        await fsp.writeFile(filePath, JSON.stringify(metadata), 'utf8')
+      },
+    })
+
+    const ready = await runtime.ensureReady()
+    const record = JSON.parse(await fsp.readFile(ready.metadataPath, 'utf8'))
+
+    expect(processGroups).toHaveLength(2)
+    expect(identityReadAttempts).toBe(2)
+    expect(previousAttemptGoneBeforeRetry).toBe(true)
+    expect(record.processGroupId).toBe(processGroups[1])
+    expect(record.wrapperIdentity.commandLine.length).toBeGreaterThan(0)
+    expect(record.wrapperIdentity.cwd).toEqual(expect.any(String))
+    expect(record.wrapperIdentity.startTimeTicks).toEqual(expect.any(Number))
+  }, 3_000)
+
+  it('escalates to SIGKILL when the native child ignores SIGTERM', async () => {
+    const metadataDir = await makeTempDir()
+    const nativePidFile = path.join(metadataDir, 'native.pid')
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          spawnNativeChild: true,
+          nativePidFile,
+          nativeChildIgnoresSigterm: true,
+          wrapperLeavesNativeOnSigterm: true,
+        }),
+      },
+    })
+
+    const ready = await runtime.ensureReady()
+    const nativePid = await waitForPidFile(nativePidFile)
+
+    await runtime.shutdown()
+
+    await waitForProcessExit(ready.processPid)
+    await waitForProcessExit(nativePid)
+    await expect(fsp.stat(ready.metadataPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('sets the ownership id in the fake native child environment', async () => {
+    const metadataDir = await makeTempDir()
+    const nativePidFile = path.join(metadataDir, 'native.pid')
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          spawnNativeChild: true,
+          nativePidFile,
+        }),
+      },
+    })
+
+    const ready = await runtime.ensureReady()
+    const nativePid = await waitForPidFile(nativePidFile)
+    const nativeEnv = await readProcessEnvironment(nativePid)
+
+    expect(ready.ownershipId).toEqual(expect.any(String))
+    expect(nativeEnv.FRESHELL_CODEX_SIDECAR_ID).toBe(ready.ownershipId)
+  })
+
+  it('rejects adoption metadata updates when no active owned sidecar exists', async () => {
+    const runtime = createRuntime()
+
+    await expect(runtime.updateOwnershipMetadata({
+      terminalId: 'term-missing',
+      generation: 1,
+    })).rejects.toThrow(/no active owned codex app-server sidecar/i)
+  })
+
+  it('tears down the process group and fails startup when ownership metadata cannot be written', async () => {
+    const tempDir = await makeTempDir()
+    const metadataDir = path.join(tempDir, 'metadata')
+    const nativePidFile = path.join(tempDir, 'native.pid')
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      startupAttemptLimit: 1,
+      metadataWriter: async () => {
+        await waitForPidFile(nativePidFile)
+        throw new Error('simulated metadata write failure')
+      },
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          spawnNativeChild: true,
+          nativePidFile,
+          wrapperLeavesNativeOnSigterm: true,
+        }),
+      },
+    })
+
+    await expect(runtime.ensureReady()).rejects.toThrow(/ownership metadata/i)
+
+    const nativePid = await waitForPidFile(nativePidFile)
+    await waitForProcessExit(nativePid)
+  })
+
+  it('does not retry startup when failed-attempt teardown cannot be verified', async () => {
+    const tempDir = await makeTempDir()
+    const metadataDir = path.join(tempDir, 'metadata')
+    const spawnedProcessGroups: number[] = []
+    let metadataWriteAttempts = 0
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      startupAttemptLimit: 3,
+      metadataWriter: async (_filePath, metadata) => {
+        metadataWriteAttempts += 1
+        spawnedProcessGroups.push(metadata.processGroupId)
+        metadata.processGroupId = await readCurrentProcessGroupId()
+        throw new Error('simulated metadata write failure')
+      },
+    })
+
+    try {
+      await expect(runtime.ensureReady()).rejects.toThrow(/teardown failed|process-group teardown failed/i)
+      expect(metadataWriteAttempts).toBe(1)
+    } finally {
+      runtimes.delete(runtime)
+      for (const processGroupId of spawnedProcessGroups) {
+        await killProcessGroupForTest(processGroupId)
+      }
+    }
+  })
+
+  it('rejects shutdown when owned process-group teardown cannot be verified', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+    })
+
+    const ready = await runtime.ensureReady()
+    const ownership = (runtime as any).ownership
+    ownership.metadata.processGroupId = await readCurrentProcessGroupId()
+
+    await expect(runtime.shutdown()).rejects.toThrow(/could not be verified|failed/i)
+
+    runtimes.delete(runtime)
+    await killProcessGroupForTest(ready.processGroupId)
+  })
+
+  it('does not use matching wrapper identity to authorize teardown of a different process group', async () => {
+    const firstRuntime = createRuntime({
+      metadataDir: await makeTempDir(),
+      serverInstanceId: 'srv-runtime-test',
+    })
+    const secondRuntime = createRuntime({
+      metadataDir: await makeTempDir(),
+      serverInstanceId: 'srv-runtime-test',
+    })
+    let firstReady: Awaited<ReturnType<CodexAppServerRuntime['ensureReady']>> | undefined
+    let secondReady: Awaited<ReturnType<CodexAppServerRuntime['ensureReady']>> | undefined
+
+    try {
+      firstReady = await firstRuntime.ensureReady()
+      secondReady = await secondRuntime.ensureReady()
+      const ownership = (firstRuntime as any).ownership
+      ownership.metadata.processGroupId = secondReady.processGroupId
+
+      await expect(firstRuntime.shutdown()).rejects.toThrow(/could not be verified|failed|ownership/i)
+      expect(await isProcessGroupAlive(secondReady.processGroupId)).toBe(true)
+      expect(await isProcessGroupAlive(firstReady.processGroupId)).toBe(true)
+    } finally {
+      runtimes.delete(firstRuntime)
+      runtimes.delete(secondRuntime)
+      if (firstReady) await killProcessGroupForTest(firstReady.processGroupId)
+      if (secondReady) await killProcessGroupForTest(secondReady.processGroupId)
+    }
+  })
+
+  it('does not use wrapper start ticks alone when command line and cwd no longer match', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+    })
+    const ready = await runtime.ensureReady()
+    const ownership = (runtime as any).ownership
+    ownership.metadata.wrapperIdentity = {
+      commandLine: ['not-the-recorded-wrapper-command'],
+      cwd: '/not/the/recorded/cwd',
+      startTimeTicks: ownership.metadata.wrapperIdentity.startTimeTicks,
+    }
+    const originalReadFile = fsp.readFile.bind(fsp)
+    const readFileSpy = vi.spyOn(fsp, 'readFile').mockImplementation(((target: any, options?: any) => {
+      if (String(target) === `/proc/${ready.processPid}/environ`) {
+        return Promise.resolve(Buffer.from('')) as any
+      }
+      return originalReadFile(target, options as any) as any
+    }) as typeof fsp.readFile)
+
+    try {
+      await expect(runtime.shutdown()).rejects.toThrow(/could not be verified|failed|ownership/i)
+      expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+    } finally {
+      readFileSpy.mockRestore()
+      runtimes.delete(runtime)
+      await killProcessGroupForTest(ready.processGroupId)
+    }
+  })
+
+  it('keeps failed teardown ownership sticky and refuses a later startup', async () => {
+    const metadataDir = await makeTempDir()
+    let metadataWriteAttempts = 0
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      metadataWriter: async (filePath, metadata) => {
+        metadataWriteAttempts += 1
+        await fsp.mkdir(path.dirname(filePath), { recursive: true })
+        await fsp.writeFile(filePath, JSON.stringify(metadata), 'utf8')
+      },
+    })
+
+    const ready = await runtime.ensureReady()
+    const metadataWriteAttemptsAfterReady = metadataWriteAttempts
+    const ownership = (runtime as any).ownership
+    ownership.metadata.processGroupId = await readCurrentProcessGroupId()
+
+    await expect(runtime.shutdown()).rejects.toThrow(/could not be verified|failed/i)
+    await expect(runtime.ensureReady()).rejects.toThrow(/teardown failed|blocked/i)
+    expect(metadataWriteAttempts).toBe(metadataWriteAttemptsAfterReady)
+
+    runtimes.delete(runtime)
+    await killProcessGroupForTest(ready.processGroupId)
+  })
+
+  it('does not treat a live process group as gone when /proc member scanning returns no members', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+    })
+    const ready = await runtime.ensureReady()
+    const ownership = (runtime as any).ownership
+    ownership.metadata.wrapperIdentity = {
+      ...ownership.metadata.wrapperIdentity,
+      startTimeTicks: -1,
+    }
+    const originalReaddir = fsp.readdir.bind(fsp)
+    const readdirSpy = vi.spyOn(fsp, 'readdir').mockImplementation(((target: any, options?: any) => {
+      if (String(target) === '/proc') {
+        return Promise.resolve([]) as any
+      }
+      return originalReaddir(target, options as any) as any
+    }) as typeof fsp.readdir)
+
+    try {
+      await expect(runtime.shutdown()).rejects.toThrow(/could not be verified|failed|ownership/i)
+      expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+    } finally {
+      readdirSpy.mockRestore()
+      runtimes.delete(runtime)
+      await killProcessGroupForTest(ready.processGroupId)
+    }
+  })
+
+  it('sets sticky failed ownership when process-group teardown throws', async () => {
+    const metadataDir = await makeTempDir()
+    let ownershipIdCalls = 0
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      ownershipIdFactory: () => {
+        ownershipIdCalls += 1
+        return `ownership-throws-${ownershipIdCalls}`
+      },
+    })
+    const ready = await runtime.ensureReady()
+    const originalUnlink = fsp.unlink.bind(fsp)
+    const unlinkSpy = vi.spyOn(fsp, 'unlink').mockImplementation(((target: any) => {
+      if (String(target) === ready.metadataPath) {
+        return Promise.reject(new Error('simulated metadata unlink failure'))
+      }
+      return originalUnlink(target) as any
+    }) as typeof fsp.unlink)
+
+    try {
+      await expect(runtime.shutdown()).rejects.toThrow('simulated metadata unlink failure')
+      await expect(runtime.ensureReady()).rejects.toThrow(/simulated metadata unlink failure|blocked/i)
+      expect(ownershipIdCalls).toBe(1)
+    } finally {
+      unlinkSpy.mockRestore()
+      await runtime.shutdown().catch(() => undefined)
+      runtimes.delete(runtime)
+      await killProcessGroupForTest(ready.processGroupId)
+    }
+  })
+
+  it('retries a failed live process-group teardown on a later shutdown join', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+    })
+    const ready = await runtime.ensureReady()
+    const originalKill = process.kill
+    let injected = false
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (!injected && pid === -ready.processGroupId && signal === 'SIGTERM') {
+        injected = true
+        const error = new Error('simulated transient SIGTERM failure') as NodeJS.ErrnoException
+        error.code = 'EPERM'
+        throw error
+      }
+      return originalKill(pid, signal as any)
+    }) as typeof process.kill)
+
+    try {
+      await expect(runtime.shutdown()).rejects.toThrow('simulated transient SIGTERM failure')
+      expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+
+      killSpy.mockRestore()
+
+      await expect(runtime.shutdown()).resolves.toBeUndefined()
+      await waitForProcessExit(ready.processPid)
+      expect(await isProcessGroupAlive(ready.processGroupId)).toBe(false)
+      await expect(fsp.stat(ready.metadataPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      killSpy.mockRestore()
+      runtimes.delete(runtime)
+      await killProcessGroupForTest(ready.processGroupId)
+    }
+  })
+
+  it('rejects with a launch error instead of crashing when the command is missing', async () => {
+    const runtime = new CodexAppServerRuntime({
+      command: '/tmp/definitely-missing-freshell-codex-binary',
+      startupAttemptLimit: 1,
+      startupAttemptTimeoutMs: 100,
+    })
+    runtimes.add(runtime)
+
+    await expect(runtime.ensureReady()).rejects.toThrow(/failed to launch codex app-server sidecar|enoent/i)
+  })
+
+  it('reaps only verified stale new-schema sidecar groups on startup', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-previous',
+    })
+    const ready = await runtime.ensureReady()
+    const raw = await fsp.readFile(ready.metadataPath, 'utf8')
+    const metadata = JSON.parse(raw)
+    await fsp.writeFile(ready.metadataPath, JSON.stringify({
+      ...metadata,
+      ownerServerPid: 999_999_999,
+      serverInstanceId: 'srv-previous',
+      updatedAt: new Date().toISOString(),
+    }, null, 2), 'utf8')
+
+    const result = await reapOrphanedCodexAppServerSidecars({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+    })
+
+    expect(result.reapedOwnershipIds).toContain(ready.ownershipId)
+    await waitForProcessExit(ready.processPid)
+    await expect(fsp.stat(ready.metadataPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('treats unreaped new-schema ownership records as a startup-blocking reaper failure', () => {
+    expect(() => assertCodexStartupReaperSucceeded({
+      reapedOwnershipIds: [],
+      ignoredLegacyRecords: [],
+      skippedActiveOwnershipIds: [],
+      failedOwnershipIds: ['ownership-alpha', 'ownership-beta'],
+    })).toThrow(/startup reaper failed.*ownership-alpha.*ownership-beta/i)
+  })
+
+  it('blocks startup when a new-schema ownership record is skipped because the owner pid is live', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-previous',
+    })
+    const ready = await runtime.ensureReady()
+    await markOwnershipRecordStale(ready.metadataPath, {
+      ownerServerPid: process.pid,
+    })
+
+    await expect(runCodexStartupReaper({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+      terminateGraceMs: 1,
+    })).rejects.toThrow(new RegExp(ready.ownershipId))
+    await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
+    expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+  })
+
+  it('propagates thrown startup reaper failures instead of treating them as warning fallbacks', async () => {
+    const metadataDir = await makeTempDir()
+    const originalReaddir = fsp.readdir.bind(fsp)
+    const readdirSpy = vi.spyOn(fsp, 'readdir').mockImplementation(((target: any, options?: any) => {
+      if (String(target) === metadataDir) {
+        return Promise.reject(new Error('simulated startup reaper metadata scan failure'))
+      }
+      return originalReaddir(target, options as any) as any
+    }) as typeof fsp.readdir)
+
+    try {
+      await expect(runCodexStartupReaper({
+        metadataDir,
+        serverInstanceId: 'srv-current',
+      })).rejects.toThrow('simulated startup reaper metadata scan failure')
+    } finally {
+      readdirSpy.mockRestore()
+    }
+  })
+
+  it('propagates startup reaper ownership verification failures', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-previous',
+    })
+    const ready = await runtime.ensureReady()
+    const raw = await fsp.readFile(ready.metadataPath, 'utf8')
+    const metadata = JSON.parse(raw)
+    await markOwnershipRecordStale(ready.metadataPath, {
+      wrapperIdentity: {
+        ...metadata.wrapperIdentity,
+        startTimeTicks: -1,
+      },
+    })
+    const originalReaddir = fsp.readdir.bind(fsp)
+    let procReaddirCalls = 0
+    const readdirSpy = vi.spyOn(fsp, 'readdir').mockImplementation(((target: any, options?: any) => {
+      if (String(target) === '/proc') {
+        procReaddirCalls += 1
+        if (procReaddirCalls > 1) {
+          return Promise.reject(new Error('simulated ownership verification proc failure'))
+        }
+      }
+      return originalReaddir(target, options as any) as any
+    }) as typeof fsp.readdir)
+
+    try {
+      await expect(runCodexStartupReaper({
+        metadataDir,
+        serverInstanceId: 'srv-current',
+        terminateGraceMs: 1,
+      })).rejects.toThrow('simulated ownership verification proc failure')
+    } finally {
+      readdirSpy.mockRestore()
+    }
+  })
+
+  it('propagates startup reaper process-group signaling failures', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-previous',
+    })
+    const ready = await runtime.ensureReady()
+    await markOwnershipRecordStale(ready.metadataPath)
+    const originalKill = process.kill
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === -ready.processGroupId && signal === 'SIGTERM') {
+        const error = new Error('simulated SIGTERM failure') as NodeJS.ErrnoException
+        error.code = 'EPERM'
+        throw error
+      }
+      return originalKill(pid, signal as any)
+    }) as typeof process.kill)
+
+    try {
+      await expect(runCodexStartupReaper({
+        metadataDir,
+        serverInstanceId: 'srv-current',
+        terminateGraceMs: 1,
+      })).rejects.toThrow('simulated SIGTERM failure')
+      expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+    } finally {
+      killSpy.mockRestore()
+    }
+  })
+
+  it('propagates startup reaper wait-for-gone diagnostic failures', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-previous',
+    })
+    const ready = await runtime.ensureReady()
+    await markOwnershipRecordStale(ready.metadataPath)
+    const originalKill = process.kill
+    let throwRemainingScan = false
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === -ready.processGroupId && (signal === 'SIGTERM' || signal === 'SIGKILL')) {
+        if (signal === 'SIGKILL') throwRemainingScan = true
+        return true
+      }
+      return originalKill(pid, signal as any)
+    }) as typeof process.kill)
+    const originalReaddir = fsp.readdir.bind(fsp)
+    const readdirSpy = vi.spyOn(fsp, 'readdir').mockImplementation(((target: any, options?: any) => {
+      if (String(target) === '/proc' && throwRemainingScan) {
+        return Promise.reject(new Error('simulated wait-for-gone process scan failure'))
+      }
+      return originalReaddir(target, options as any) as any
+    }) as typeof fsp.readdir)
+
+    try {
+      await expect(runCodexStartupReaper({
+        metadataDir,
+        serverInstanceId: 'srv-current',
+        terminateGraceMs: 1,
+      })).rejects.toThrow('simulated wait-for-gone process scan failure')
+      expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+    } finally {
+      readdirSpy.mockRestore()
+      killSpy.mockRestore()
+    }
+  })
+
+  it('propagates startup reaper metadata removal failures', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-previous',
+    })
+    const ready = await runtime.ensureReady()
+    await markOwnershipRecordStale(ready.metadataPath)
+    const originalKill = process.kill
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === -ready.processGroupId && signal === 0) {
+        const error = new Error('simulated process group gone') as NodeJS.ErrnoException
+        error.code = 'ESRCH'
+        throw error
+      }
+      return originalKill(pid, signal as any)
+    }) as typeof process.kill)
+    const originalUnlink = fsp.unlink.bind(fsp)
+    const unlinkSpy = vi.spyOn(fsp, 'unlink').mockImplementation(((target: any) => {
+      if (String(target) === ready.metadataPath) {
+        return Promise.reject(new Error('simulated metadata removal failure'))
+      }
+      return originalUnlink(target) as any
+    }) as typeof fsp.unlink)
+
+    try {
+      await expect(runCodexStartupReaper({
+        metadataDir,
+        serverInstanceId: 'srv-current',
+        terminateGraceMs: 1,
+      })).rejects.toThrow('simulated metadata removal failure')
+      await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
+    } finally {
+      unlinkSpy.mockRestore()
+      killSpy.mockRestore()
+    }
+  })
+
+  it('removes legacy sidecar records without process-name cleanup', async () => {
+    const metadataDir = await makeTempDir()
+    const legacyPath = path.join(metadataDir, 'legacy.json')
+    await fsp.writeFile(legacyPath, JSON.stringify({
+      pid: 12345,
+      wsUrl: 'ws://127.0.0.1:55555',
+    }), 'utf8')
+
+    const result = await reapOrphanedCodexAppServerSidecars({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+    })
+
+    expect(result.ignoredLegacyRecords).toContain(legacyPath)
+    await expect(fsp.stat(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('retains malformed new-schema ownership records and reports them as startup-blocking failures', async () => {
+    const metadataDir = await makeTempDir()
+    const malformedPath = path.join(metadataDir, 'damaged-new-schema.json')
+    await fsp.writeFile(malformedPath, JSON.stringify({
+      schemaVersion: 1,
+      ownershipId: 'damaged-ownership',
+      serverInstanceId: 'srv-previous',
+      ownerServerPid: 999_999_999,
+    }), 'utf8')
+
+    const result = await reapOrphanedCodexAppServerSidecars({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+    })
+
+    expect(result.ignoredLegacyRecords).not.toContain(malformedPath)
+    expect(result.failedOwnershipIds).toContain('damaged-ownership')
+    await expect(fsp.stat(malformedPath)).resolves.toBeDefined()
+    expect(() => assertCodexStartupReaperSucceeded(result)).toThrow(/damaged-ownership/)
+  })
+
+  it('retains schema-v1 ownership records with invalid numeric ownership fields', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-previous',
+    })
+    const ready = await runtime.ensureReady()
+    await markOwnershipRecordStale(ready.metadataPath, {
+      processGroupId: 0,
+    })
+
+    const result = await reapOrphanedCodexAppServerSidecars({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+    })
+
+    expect(result.reapedOwnershipIds).not.toContain(ready.ownershipId)
+    expect(result.failedOwnershipIds).toContain(ready.ownershipId)
+    await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
+    expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+    expect(() => assertCodexStartupReaperSucceeded(result)).toThrow(new RegExp(ready.ownershipId))
+  })
+
+  it('does not reap new-schema records for the current process group', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-previous',
+    })
+    const ready = await runtime.ensureReady()
+    const raw = await fsp.readFile(ready.metadataPath, 'utf8')
+    const metadata = JSON.parse(raw)
+    await fsp.writeFile(ready.metadataPath, JSON.stringify({
+      ...metadata,
+      ownerServerPid: 999_999_999,
+      processGroupId: await readCurrentProcessGroupId(),
+      updatedAt: new Date().toISOString(),
+    }, null, 2), 'utf8')
+
+    const result = await reapOrphanedCodexAppServerSidecars({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+    })
+
+    expect(result.skippedActiveOwnershipIds).toContain(ready.ownershipId)
+    await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
+  })
+
+  it('proxies thread/start through the sidecar client after boot', async () => {
     const runtime = createRuntime()
 
     await expect(runtime.startThread({ cwd: '/repo/worktree' })).resolves.toEqual({
@@ -133,7 +1203,7 @@ describe('CodexAppServerRuntime', () => {
     })
   })
 
-  it('proxies thread/resume through the shared client after boot', async () => {
+  it('proxies thread/resume through the sidecar client after boot', async () => {
     const runtime = createRuntime()
 
     await expect(runtime.resumeThread({

--- a/test/unit/server/shutdown-join.test.ts
+++ b/test/unit/server/shutdown-join.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+import { joinCodexShutdownOwners } from '../../../server/shutdown-join.js'
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('Codex shutdown owner joining', () => {
+  it('waits for planner shutdown before reporting a registry shutdown failure', async () => {
+    const registryShutdown = deferred()
+    const plannerShutdown = deferred()
+    const registryError = new Error('registry verified teardown failed')
+    const registry = {
+      shutdownGracefully: vi.fn(() => registryShutdown.promise),
+    }
+    const codexLaunchPlanner = {
+      shutdown: vi.fn(() => plannerShutdown.promise),
+    }
+
+    const joined = joinCodexShutdownOwners({
+      registry,
+      codexLaunchPlanner,
+      terminalShutdownTimeoutMs: 5_000,
+    })
+    let settled = false
+    void joined.then(
+      () => { settled = true },
+      () => { settled = true },
+    )
+
+    await vi.waitFor(() => expect(registry.shutdownGracefully).toHaveBeenCalledWith(5_000))
+    await vi.waitFor(() => expect(codexLaunchPlanner.shutdown).toHaveBeenCalledTimes(1))
+    registryShutdown.reject(registryError)
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(settled).toBe(false)
+
+    plannerShutdown.resolve()
+    await expect(joined).rejects.toThrow('registry verified teardown failed')
+  })
+})

--- a/test/unit/server/terminal-registry.codex-sidecar.test.ts
+++ b/test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -1,0 +1,1065 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+
+const mockPtyProcess = vi.hoisted(() => {
+  const createMockPty = () => {
+    const emitter = new EventEmitter()
+    const pty = {
+      pid: Math.floor(Math.random() * 100000) + 1000,
+      cols: 120,
+      rows: 30,
+      process: 'mock-shell',
+      handleFlowControl: false,
+      autoExitOnKill: true,
+      onData: vi.fn((handler: (data: string) => void) => {
+        emitter.on('data', handler)
+        return { dispose: () => emitter.off('data', handler) }
+      }),
+      onExit: vi.fn((handler: (e: { exitCode: number; signal?: number }) => void) => {
+        emitter.on('exit', handler)
+        return { dispose: () => emitter.off('exit', handler) }
+      }),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(() => {
+        if (pty.autoExitOnKill) {
+          emitter.emit('exit', { exitCode: 0 })
+        }
+      }),
+      _emitExit: (exitCode: number, signal?: number) => emitter.emit('exit', { exitCode, signal }),
+    }
+    return pty
+  }
+  return { createMockPty, instances: [] as ReturnType<typeof createMockPty>[] }
+})
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(() => {
+    const pty = mockPtyProcess.createMockPty()
+    mockPtyProcess.instances.push(pty)
+    return pty
+  }),
+}))
+
+vi.mock('../../../server/logger', () => {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(),
+  }
+  logger.child.mockReturnValue(logger)
+  return { logger }
+})
+
+import { TerminalRegistry } from '../../../server/terminal-registry.js'
+import { logger } from '../../../server/logger.js'
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function createFakeSidecar(options: {
+  waitForLoadedThread?: () => Promise<void>
+  shutdown?: () => Promise<void>
+} = {}) {
+  const lifecycleLossHandlers = new Set<(event: unknown) => void>()
+  return {
+    adopt: vi.fn(async () => undefined),
+    listLoadedThreads: vi.fn(async () => ['thread-1']),
+    waitForLoadedThread: vi.fn(options.waitForLoadedThread ?? (async () => undefined)),
+    shutdown: vi.fn(options.shutdown ?? (async () => undefined)),
+    onLifecycleLoss: vi.fn((handler: (event: unknown) => void) => {
+      lifecycleLossHandlers.add(handler)
+      return () => lifecycleLossHandlers.delete(handler)
+    }),
+    emitLifecycleLoss(event: unknown) {
+      for (const handler of lifecycleLossHandlers) {
+        handler(event)
+      }
+    },
+  }
+}
+
+describe('TerminalRegistry Codex sidecar ownership', () => {
+  beforeEach(() => {
+    mockPtyProcess.instances = []
+    vi.clearAllMocks()
+  })
+
+  it('awaits Codex sidecar teardown when killing a terminal', async () => {
+    const registry = new TerminalRegistry()
+    const shutdown = vi.fn(async () => undefined)
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: { shutdown },
+        },
+      },
+    })
+
+    await expect(registry.killAndWait(term.terminalId)).resolves.toBe(true)
+
+    expect(shutdown).toHaveBeenCalledTimes(1)
+  })
+
+  it('joins current sidecar shutdown before reporting a recovery-attempt failure on final close', async () => {
+    const registry = new TerminalRegistry()
+    const recoveryAttempt = deferred()
+    const currentShutdown = deferred()
+    const currentSidecar = createFakeSidecar({
+      shutdown: () => currentShutdown.promise,
+    })
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+        },
+      } as any,
+    })
+    term.codexRecoveryAttempt = recoveryAttempt.promise
+
+    const close = registry.killAndWait(term.terminalId)
+    let closeSettled = false
+    void close.then(
+      () => { closeSettled = true },
+      () => { closeSettled = true },
+    )
+    await vi.waitFor(() => expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1))
+
+    recoveryAttempt.reject(new Error('durable recovery failed during close'))
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(closeSettled).toBe(false)
+
+    currentShutdown.resolve()
+    await expect(close).rejects.toThrow('durable recovery failed during close')
+  })
+
+  it('recovers a durable Codex terminal when its sidecar reports lifecycle loss', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    expect(currentSidecar.onLifecycleLoss).toHaveBeenCalledTimes(1)
+    currentSidecar.emitLifecycleLoss({ method: 'thread/status/changed', threadId: 'thread-1', status: 'notLoaded' })
+    await vi.waitFor(() => expect(replacementSidecar.waitForLoadedThread).toHaveBeenCalledWith('thread-1', expect.any(Object)))
+
+    expect(registry.get(term.terminalId)?.status).toBe('running')
+    expect(planCreate).toHaveBeenCalledWith(expect.objectContaining({
+      terminalId: term.terminalId,
+      resumeSessionId: 'thread-1',
+    }))
+    expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: term.terminalId, generation: 1 })
+    expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1)
+    expect(mockPtyProcess.instances[0].kill).toHaveBeenCalled()
+    expect(mockPtyProcess.instances[1].write).toBeDefined()
+
+    expect(registry.input(term.terminalId, 'after recovery')).toBe(true)
+    expect(mockPtyProcess.instances[0].write).not.toHaveBeenCalled()
+    expect(mockPtyProcess.instances[1].write).toHaveBeenCalledWith('after recovery')
+  })
+
+  it('treats lifecycle loss before initial Codex publication as a create failure instead of recovery', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: createFakeSidecar(),
+    }))
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+          deferLifecycleUntilPublished: true,
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await new Promise((resolve) => setTimeout(resolve, 25))
+
+    expect(planCreate).not.toHaveBeenCalled()
+    expect(() => registry.publishCodexSidecar(term.terminalId)).toThrow(
+      'Codex app-server reported lifecycle loss before terminal create completed.',
+    )
+    await expect(registry.killAndWait(term.terminalId)).resolves.toBe(true)
+    expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1)
+  })
+
+  it('starts durable recovery only after deferred initial Codex publication succeeds', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+          deferLifecycleUntilPublished: true,
+        },
+      } as any,
+    })
+
+    registry.publishCodexSidecar(term.terminalId)
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(replacementSidecar.waitForLoadedThread).toHaveBeenCalledWith('thread-1', expect.any(Object)))
+
+    expect(planCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the old Codex generation current when retiring sidecar teardown fails', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar({
+      shutdown: async () => {
+        throw new Error('retiring sidecar teardown failed')
+      },
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(1))
+
+    expect(planCreate).toHaveBeenCalledTimes(1)
+    expect(registry.input(term.terminalId, 'still old generation')).toBe(true)
+    expect(mockPtyProcess.instances[0].write).toHaveBeenCalledWith('still old generation')
+    expect(mockPtyProcess.instances[1].write).not.toHaveBeenCalled()
+  })
+
+  it('blocks repeated lifecycle-loss recovery after retiring sidecar teardown fails', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar({
+      shutdown: async () => {
+        throw new Error('retiring sidecar teardown failed')
+      },
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(1))
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await new Promise((resolve) => setTimeout(resolve, 25))
+
+    expect(planCreate).toHaveBeenCalledTimes(1)
+    expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks repeated lifecycle-loss recovery after candidate sidecar teardown fails', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar({
+      waitForLoadedThread: async () => {
+        throw new Error('candidate never became ready')
+      },
+      shutdown: async () => {
+        throw new Error('candidate sidecar teardown failed')
+      },
+    })
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(1))
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await new Promise((resolve) => setTimeout(resolve, 25))
+
+    expect(planCreate).toHaveBeenCalledTimes(1)
+    expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks durable recovery when candidate planning fails from sidecar teardown', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const teardownError = new Error('planner-owned sidecar teardown failed') as Error & {
+      codexSidecarTeardownFailed?: boolean
+    }
+    teardownError.codexSidecarTeardownFailed = true
+    const planCreate = vi.fn(async () => {
+      throw teardownError
+    })
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    try {
+      currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+      await vi.waitFor(() => expect(planCreate).toHaveBeenCalledTimes(1))
+      await vi.waitFor(() => expect(registry.get(term.terminalId)?.codexRecoveryBlockedError).toBe(teardownError))
+
+      currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+      await new Promise((resolve) => setTimeout(resolve, 25))
+
+      expect(planCreate).toHaveBeenCalledTimes(1)
+    } finally {
+      await registry.killAndWait(term.terminalId).catch(() => undefined)
+    }
+  })
+
+  it('keeps unpublished candidate teardown failure retryable for final close', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const candidateShutdown = vi.fn()
+      .mockRejectedValueOnce(new Error('candidate verified teardown failed'))
+      .mockResolvedValueOnce(undefined)
+    const replacementSidecar = createFakeSidecar({
+      waitForLoadedThread: async () => {
+        throw new Error('candidate never became ready')
+      },
+      shutdown: candidateShutdown,
+    })
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect((registry.get(term.terminalId) as any)?.codexRecoveryAttempt).toBeUndefined())
+
+    await expect(registry.killAndWait(term.terminalId)).resolves.toBe(true)
+    await expect(registry.shutdownGracefully(1_000)).resolves.toBeUndefined()
+    expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps unpublished candidate teardown failure retryable for graceful shutdown', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const candidateShutdown = vi.fn()
+      .mockRejectedValueOnce(new Error('candidate verified teardown failed'))
+      .mockResolvedValueOnce(undefined)
+    const replacementSidecar = createFakeSidecar({
+      waitForLoadedThread: async () => {
+        throw new Error('candidate never became ready')
+      },
+      shutdown: candidateShutdown,
+    })
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(1))
+
+    await expect(registry.shutdownGracefully(1_000)).resolves.toBeUndefined()
+    expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not publish a recovery candidate whose PTY exited before readiness completed', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const readiness = deferred()
+    const firstCandidate = createFakeSidecar({
+      waitForLoadedThread: () => readiness.promise,
+    })
+    const secondCandidate = createFakeSidecar()
+    const planCreate = vi.fn()
+      .mockResolvedValueOnce({
+        sessionId: 'thread-1',
+        remote: { wsUrl: 'ws://127.0.0.1:43124' },
+        sidecar: firstCandidate,
+      })
+      .mockResolvedValueOnce({
+        sessionId: 'thread-1',
+        remote: { wsUrl: 'ws://127.0.0.1:43125' },
+        sidecar: secondCandidate,
+      })
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(firstCandidate.waitForLoadedThread).toHaveBeenCalledTimes(1))
+    mockPtyProcess.instances[1]._emitExit(42)
+    readiness.resolve()
+
+    await vi.waitFor(() => expect(firstCandidate.shutdown).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(secondCandidate.adopt).toHaveBeenCalledTimes(1))
+
+    expect(registry.get(term.terminalId)?.status).toBe('running')
+    expect(planCreate).toHaveBeenCalledTimes(2)
+    expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1)
+    expect(firstCandidate.shutdown).toHaveBeenCalledTimes(1)
+    expect(registry.input(term.terminalId, 'after retry')).toBe(true)
+    expect(mockPtyProcess.instances[1].write).not.toHaveBeenCalled()
+    expect(mockPtyProcess.instances[2].write).toHaveBeenCalledWith('after retry')
+  })
+
+  it('publishes a ready recovery candidate even if the old PTY exits during retiring sidecar teardown', async () => {
+    const registry = new TerminalRegistry()
+    let oldPtyExitedDuringShutdown = false
+    const currentSidecar = createFakeSidecar({
+      shutdown: async () => {
+        mockPtyProcess.instances[0]._emitExit(0)
+        oldPtyExitedDuringShutdown = true
+      },
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledTimes(1))
+    expect(oldPtyExitedDuringShutdown).toBe(true)
+    expect(registry.get(term.terminalId)?.status).toBe('running')
+    expect(replacementSidecar.shutdown).not.toHaveBeenCalled()
+    expect(registry.input(term.terminalId, 'after atomic handoff')).toBe(true)
+    expect(mockPtyProcess.instances[0].write).not.toHaveBeenCalled()
+    expect(mockPtyProcess.instances[1].write).toHaveBeenCalledWith('after atomic handoff')
+  })
+
+  it('waits for a failed recovery candidate to shut down before retrying', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const firstShutdown = deferred()
+    const firstCandidate = createFakeSidecar({
+      waitForLoadedThread: async () => {
+        throw new Error('candidate not ready')
+      },
+      shutdown: () => firstShutdown.promise,
+    })
+    const secondCandidate = createFakeSidecar()
+    const planCreate = vi.fn()
+      .mockResolvedValueOnce({
+        sessionId: 'thread-1',
+        remote: { wsUrl: 'ws://127.0.0.1:43124' },
+        sidecar: firstCandidate,
+      })
+      .mockResolvedValueOnce({
+        sessionId: 'thread-1',
+        remote: { wsUrl: 'ws://127.0.0.1:43125' },
+        sidecar: secondCandidate,
+      })
+    registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(firstCandidate.shutdown).toHaveBeenCalledTimes(1))
+    await Promise.resolve()
+
+    expect(planCreate).toHaveBeenCalledTimes(1)
+    firstShutdown.resolve()
+    await vi.waitFor(() => expect(planCreate).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(secondCandidate.adopt).toHaveBeenCalled())
+  })
+
+  it('does not grow active recovery candidates across repeated readiness failures', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    let activeCandidates = 0
+    let maxActiveCandidates = 0
+    const planCreate = vi.fn(async () => {
+      const attempt = planCreate.mock.calls.length
+      activeCandidates += 1
+      maxActiveCandidates = Math.max(maxActiveCandidates, activeCandidates)
+      return {
+        sessionId: 'thread-1',
+        remote: { wsUrl: `ws://127.0.0.1:${43124 + attempt}` },
+        sidecar: createFakeSidecar({
+          waitForLoadedThread: async () => {
+            if (attempt >= 3) return
+            throw new Error('candidate not ready')
+          },
+          shutdown: async () => {
+            activeCandidates -= 1
+          },
+        }),
+      }
+    })
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 1 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(planCreate.mock.calls.length).toBeGreaterThanOrEqual(3))
+
+    expect(maxActiveCandidates).toBe(1)
+    await registry.killAndWait(term.terminalId)
+  })
+
+  it('final close during a pending recovery launch prevents later recovery', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const launch = deferred<any>()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(() => launch.promise)
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(planCreate).toHaveBeenCalledTimes(1))
+    const close = registry.killAndWait(term.terminalId)
+    launch.resolve({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    })
+    await close
+
+    expect(registry.get(term.terminalId)?.status).toBe('exited')
+    expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(1)
+    expect(replacementSidecar.adopt).not.toHaveBeenCalled()
+  })
+
+  it('final close with an unpublished recovery candidate awaits candidate shutdown', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const readiness = deferred()
+    const shutdown = deferred()
+    const replacementSidecar = createFakeSidecar({
+      waitForLoadedThread: () => readiness.promise,
+      shutdown: () => shutdown.promise,
+    })
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(replacementSidecar.waitForLoadedThread).toHaveBeenCalledTimes(1))
+    const close = registry.killAndWait(term.terminalId)
+    readiness.resolve()
+    await vi.waitFor(() => expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(1))
+
+    let closed = false
+    void close.then(() => { closed = true })
+    await Promise.resolve()
+    expect(closed).toBe(false)
+    shutdown.resolve()
+    await close
+    expect(closed).toBe(true)
+  })
+
+  it('final close with a published recovery candidate awaits replacement shutdown', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const replacementShutdown = deferred()
+    const replacementSidecar = createFakeSidecar({
+      shutdown: () => replacementShutdown.promise,
+    })
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledTimes(1))
+    const close = registry.killAndWait(term.terminalId)
+    await vi.waitFor(() => expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(1))
+
+    let closed = false
+    void close.then(() => { closed = true })
+    await Promise.resolve()
+    expect(closed).toBe(false)
+    replacementShutdown.resolve()
+    await close
+    expect(closed).toBe(true)
+  })
+
+  it('awaits Codex sidecar teardown after natural PTY exit during graceful shutdown', async () => {
+    const registry = new TerminalRegistry()
+    let releaseShutdown: (() => void) | undefined
+    const shutdownStarted = vi.fn()
+    const shutdown = vi.fn(async () => {
+      shutdownStarted()
+      await new Promise<void>((resolve) => {
+        releaseShutdown = resolve
+      })
+    })
+    registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: { shutdown },
+        },
+      },
+    })
+
+    const graceful = registry.shutdownGracefully(1_000)
+    mockPtyProcess.instances[0]._emitExit(0)
+    await vi.waitFor(() => expect(shutdownStarted).toHaveBeenCalledTimes(1))
+
+    let finished = false
+    void graceful.then(() => {
+      finished = true
+    })
+    await Promise.resolve()
+    expect(finished).toBe(false)
+
+    releaseShutdown?.()
+    await graceful
+    expect(finished).toBe(true)
+  })
+
+  it('prevents Codex lifecycle-loss recovery from starting during graceful shutdown', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    mockPtyProcess.instances[0].autoExitOnKill = false
+
+    const graceful = registry.shutdownGracefully(1_000)
+    await vi.waitFor(() => expect(mockPtyProcess.instances[0].kill).toHaveBeenCalledTimes(1))
+    currentSidecar.emitLifecycleLoss({ method: 'thread/status/changed', threadId: 'thread-1', status: 'notLoaded' })
+    await Promise.resolve()
+
+    expect(planCreate).not.toHaveBeenCalled()
+    mockPtyProcess.instances[0]._emitExit(0)
+    await graceful
+    expect(registry.get(term.terminalId)?.status).toBe('exited')
+  })
+
+  it('awaits in-flight Codex sidecar teardown when no terminals are still running', async () => {
+    const registry = new TerminalRegistry()
+    let releaseShutdown: (() => void) | undefined
+    const shutdownStarted = vi.fn()
+    const shutdown = vi.fn(async () => {
+      shutdownStarted()
+      await new Promise<void>((resolve) => {
+        releaseShutdown = resolve
+      })
+    })
+    registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: { shutdown },
+        },
+      },
+    })
+    mockPtyProcess.instances[0]._emitExit(0)
+    await vi.waitFor(() => expect(shutdownStarted).toHaveBeenCalledTimes(1))
+
+    const graceful = registry.shutdownGracefully(1_000)
+    let finished = false
+    void graceful.then(() => {
+      finished = true
+    })
+    await Promise.resolve()
+
+    expect(finished).toBe(false)
+    releaseShutdown?.()
+    await graceful
+    expect(finished).toBe(true)
+  })
+
+  it('awaits recovery candidate teardown for exited Codex terminals while shutting down other running terminals', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const readiness = deferred()
+    const candidateShutdown = deferred()
+    const replacementSidecar = createFakeSidecar({
+      waitForLoadedThread: () => readiness.promise,
+      shutdown: () => candidateShutdown.promise,
+    })
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    const codexTerm = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+    await vi.waitFor(() => expect(replacementSidecar.waitForLoadedThread).toHaveBeenCalledTimes(1))
+    registry.kill(codexTerm.terminalId)
+    readiness.resolve()
+    await vi.waitFor(() => expect(replacementSidecar.shutdown).toHaveBeenCalledTimes(1))
+
+    registry.create({ mode: 'shell' })
+    const runningPty = mockPtyProcess.instances[2]
+    runningPty.autoExitOnKill = false
+
+    const graceful = registry.shutdownGracefully(1_000)
+    let finished = false
+    void graceful.then(() => {
+      finished = true
+    })
+    await vi.waitFor(() => expect(runningPty.kill).toHaveBeenCalledTimes(1))
+    runningPty._emitExit(0)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(finished).toBe(false)
+    candidateShutdown.resolve()
+    await graceful
+    expect(finished).toBe(true)
+  })
+
+  it('observes Codex sidecar shutdown rejection after natural PTY exit and keeps it joinable for shutdown', async () => {
+    const registry = new TerminalRegistry()
+    const shutdownError = new Error('verified sidecar teardown failed')
+    const unhandledRejection = vi.fn()
+    process.once('unhandledRejection', unhandledRejection)
+
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: {
+            shutdown: vi.fn(async () => {
+              throw shutdownError
+            }),
+          },
+        },
+      },
+    })
+
+    try {
+      mockPtyProcess.instances[0]._emitExit(0)
+      await vi.waitFor(() => expect(logger.error).toHaveBeenCalledWith(
+        { err: shutdownError, terminalId: term.terminalId },
+        'Codex sidecar shutdown failed',
+      ))
+      await new Promise((resolve) => setImmediate(resolve))
+      expect(unhandledRejection).not.toHaveBeenCalled()
+      await expect(registry.shutdownGracefully(1_000)).rejects.toThrow('verified sidecar teardown failed')
+    } finally {
+      process.off('unhandledRejection', unhandledRejection)
+    }
+  })
+
+  it('retries a failed current sidecar shutdown on later terminal close joins', async () => {
+    const registry = new TerminalRegistry()
+    const shutdown = vi.fn()
+      .mockRejectedValueOnce(new Error('verified sidecar teardown failed'))
+      .mockResolvedValueOnce(undefined)
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: { shutdown },
+        },
+      },
+    })
+
+    await expect(registry.killAndWait(term.terminalId)).rejects.toThrow('verified sidecar teardown failed')
+    await expect(registry.killAndWait(term.terminalId)).resolves.toBe(true)
+
+    expect(shutdown).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a failed natural-exit sidecar shutdown during graceful shutdown', async () => {
+    const registry = new TerminalRegistry()
+    const shutdown = vi.fn()
+      .mockRejectedValueOnce(new Error('verified sidecar teardown failed'))
+      .mockResolvedValueOnce(undefined)
+    registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: { shutdown },
+        },
+      },
+    })
+
+    mockPtyProcess.instances[0]._emitExit(0)
+    await vi.waitFor(() => expect(shutdown).toHaveBeenCalledTimes(1))
+
+    await expect(registry.shutdownGracefully(1_000)).resolves.toBeUndefined()
+    expect(shutdown).toHaveBeenCalledTimes(2)
+  })
+
+  it('exposes the inserted terminal id when terminal.created listeners throw', async () => {
+    const registry = new TerminalRegistry()
+    const sidecar = createFakeSidecar()
+    registry.on('terminal.created', () => {
+      throw new Error('terminal.created listener failed')
+    })
+
+    let createdTerminalId: string | undefined
+    try {
+      registry.create({
+        mode: 'codex',
+        providerSettings: {
+          codexAppServer: {
+            wsUrl: 'ws://127.0.0.1:43123',
+            sidecar,
+          },
+        } as any,
+      })
+    } catch (err) {
+      createdTerminalId = (err as { terminalId?: string }).terminalId
+      expect(err).toBeInstanceOf(Error)
+      expect((err as Error).message).toBe('terminal.created listener failed')
+    }
+
+    expect(createdTerminalId).toEqual(expect.any(String))
+    expect(registry.get(createdTerminalId!)).not.toBeNull()
+    await expect(registry.killAndWait(createdTerminalId!)).resolves.toBe(true)
+    expect(sidecar.shutdown).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for every tracked Codex sidecar shutdown before reporting a graceful-shutdown failure', async () => {
+    const registry = new TerminalRegistry()
+    const fastFailure = new Error('fast verified sidecar teardown failed')
+    const slowShutdown = deferred()
+    const fastSidecar = createFakeSidecar({
+      shutdown: async () => {
+        throw fastFailure
+      },
+    })
+    const slowSidecar = createFakeSidecar({
+      shutdown: () => slowShutdown.promise,
+    })
+
+    registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: fastSidecar,
+        },
+      } as any,
+    })
+    registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43124',
+          sidecar: slowSidecar,
+        },
+      } as any,
+    })
+    mockPtyProcess.instances[0]._emitExit(0)
+    mockPtyProcess.instances[1]._emitExit(0)
+    await vi.waitFor(() => expect(fastSidecar.shutdown).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(slowSidecar.shutdown).toHaveBeenCalledTimes(1))
+
+    const graceful = registry.shutdownGracefully(1_000)
+    let settled = false
+    void graceful.then(
+      () => { settled = true },
+      () => { settled = true },
+    )
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(settled).toBe(false)
+
+    slowShutdown.resolve()
+    await expect(graceful).rejects.toThrow('fast verified sidecar teardown failed')
+  })
+})

--- a/test/unit/server/testing/playwright-e2e-global-setup.test.ts
+++ b/test/unit/server/testing/playwright-e2e-global-setup.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ensureFreshE2eBuild } from '../../../e2e-browser/global-setup.js'
+
+describe('Playwright e2e global setup', () => {
+  it('rebuilds current client and server assets instead of accepting an existing dist build', () => {
+    const execSync = vi.fn()
+    const log = vi.fn()
+
+    ensureFreshE2eBuild('/repo', {
+      execSync,
+      env: { PATH: '/bin' },
+      log: { log },
+    })
+
+    expect(execSync).toHaveBeenCalledWith('npm run build:client && npm run build:server', {
+      cwd: '/repo',
+      env: {
+        PATH: '/bin',
+        NODE_ENV: 'production',
+      },
+      stdio: 'inherit',
+    })
+    expect(log).toHaveBeenNthCalledWith(1, '[e2e-setup] Building client and server...')
+    expect(log).toHaveBeenNthCalledWith(2, '[e2e-setup] Build complete.')
+  })
+})

--- a/vitest.codex-real-provider-smoke.config.ts
+++ b/vitest.codex-real-provider-smoke.config.ts
@@ -23,33 +23,16 @@ export default defineConfig({
     environment: 'node',
     globalSetup: ['./test/setup/server-global-setup.ts'],
     include: [
-      'test/server/**/*.test.ts',
-      'test/unit/server/**/*.test.ts',
-      'test/unit/visible-first/**/*.test.ts',
-      'test/integration/server/**/*.test.ts',
-      'test/integration/session-repair.test.ts',
-      'test/integration/session-search-e2e.test.ts',
-      'test/integration/extension-system.test.ts',
-    ],
-    exclude: [
-      'docs/plans/**',
       'test/integration/server/codex-real-provider-smoke.test.ts',
-      'test/unit/visible-first/slow-network-controller.test.ts',
     ],
-    testTimeout: 30000,
+    testTimeout: 60000,
     hookTimeout: 30000,
-    // Maximum parallelization settings
     pool: 'threads',
     poolOptions: {
       threads: {
         singleThread: false,
         isolate: true,
       },
-    },
-    fileParallelism: true,
-    maxConcurrency: 10,
-    sequence: {
-      shuffle: true, // Detect order-dependent tests
     },
   },
 })


### PR DESCRIPTION
## Summary
- Add explicit Codex app-server ownership and shutdown joining so recovery replaces only owned sidecars and waits for cleanup evidence.
- Harden durable-session recovery planning, readiness checks, retry behavior, and WebSocket/agent-pane cleanup paths.
- Add focused unit, integration, real-provider smoke, and browser e2e coverage for sidecar lifecycle and reconnect behavior.

## Validation already run on the same resulting tree before the mistaken merge
- `npm run typecheck`
- focused server/unit suite
- `npm run build`
- full coordinated `npm test`
- `npm run test:codex-real-provider-smoke`
- `npm run test:e2e` — 112 passed
- `git diff --check`

This PR is intentionally left open for review.