### PR TITLE
fix: restore native scroll behavior for OpenCode CLI

### DIFF
--- a/docs/lab-notes/2026-04-20-coding-cli-session-contract.md
+++ b/docs/lab-notes/2026-04-20-coding-cli-session-contract.md
@@ -94,7 +94,7 @@ The implementation plan file is dated `2026-04-19` because the design work was w
     "opencode": {
       "executable": "opencode",
       "resolvedPath": "/home/user/.opencode/bin/opencode",
-      "version": "1.14.33",
+      "version": "1.14.39",
       "runCommandTemplate": "opencode run <prompt> --format json --dangerously-skip-permissions",
       "serveCommandTemplate": "opencode serve --hostname 127.0.0.1 --port <port>",
       "globalHealthPath": "/global/health",
@@ -287,7 +287,7 @@ command -v opencode
 # /home/user/.opencode/bin/opencode
 
 opencode --version
-# 1.14.33
+# 1.14.39
 ```
 
 Fresh isolated runs were probed with:
@@ -312,7 +312,7 @@ curl http://127.0.0.1:<port>/session/status
 
 Observed control behavior:
 
-- `/global/health` returned a healthy payload with version `1.14.33`.
+- `/global/health` returned a healthy payload with version `1.14.39`.
 - `/session/status` returned `{}` while idle.
 - During an attached `opencode run ... --attach http://127.0.0.1:<port>`, `/session/status` returned the same authoritative `sessionID` with `{ "type": "busy" }`.
 

--- a/extensions/opencode/freshell.json
+++ b/extensions/opencode/freshell.json
@@ -19,7 +19,7 @@
     "supportsModel": true,
     "terminalBehavior": {
       "preferredRenderer": "canvas",
-      "scrollInputPolicy": "fallbackToCursorKeysWhenAltScreenMouseCapture"
+      "scrollInputPolicy": "native"
     }
   },
   "picker": {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -706,7 +706,9 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     const lines = rawLines > 0 ? Math.floor(rawLines) : Math.ceil(rawLines)
     if (lines !== 0) {
       if (!translateScrollLinesToInput(term, lines)) {
-        term.scrollLines(lines)
+        if (term.buffer.active.type !== 'alternate') {
+          term.scrollLines(lines)
+        }
       }
 
       touchScrollAccumulatorRef.current -= lines * TOUCH_SCROLL_PIXELS_PER_LINE

--- a/test/e2e/opencode-scroll-input-policy.test.tsx
+++ b/test/e2e/opencode-scroll-input-policy.test.tsx
@@ -103,7 +103,7 @@ const opencodeExtensionWithBehaviorHint: ClientExtensionEntry = {
   cli: {
     terminalBehavior: {
       preferredRenderer: 'canvas',
-      scrollInputPolicy: 'fallbackToCursorKeysWhenAltScreenMouseCapture',
+      scrollInputPolicy: 'native',
     },
   },
 }
@@ -178,7 +178,7 @@ describe('opencode scroll input policy (e2e)', () => {
     vi.unstubAllGlobals()
   })
 
-  it('sends cursor-key input when an OpenCode pane receives wheel input in alt screen mouse mode', async () => {
+  it('does not translate wheel input for opencode providers when policy is native', async () => {
     const { store, tabId, paneId, paneContent } = createStore('opencode', [opencodeExtensionWithBehaviorHint])
 
     const { getByTestId } = render(
@@ -195,10 +195,8 @@ describe('opencode scroll input policy (e2e)', () => {
 
     fireEvent.wheel(getByTestId('terminal-xterm-container'), { deltaY: 24 })
 
-    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+    expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({
       type: 'terminal.input',
-      terminalId: 'term-opencode',
-      data: '\u001b[B',
     }))
   })
 

--- a/test/e2e/opencode-touch-scroll-input-policy.test.tsx
+++ b/test/e2e/opencode-touch-scroll-input-policy.test.tsx
@@ -101,7 +101,7 @@ const opencodeExtensionWithBehaviorHint: ClientExtensionEntry = {
   cli: {
     terminalBehavior: {
       preferredRenderer: 'canvas',
-      scrollInputPolicy: 'fallbackToCursorKeysWhenAltScreenMouseCapture',
+      scrollInputPolicy: 'native',
     },
   },
 }
@@ -177,7 +177,7 @@ describe('opencode touch scroll input policy (e2e)', () => {
     ;(globalThis as any).setMobileForTest(false)
   })
 
-  it('sends translated cursor-key input instead of local scrollback for OpenCode touch scrolling', async () => {
+  it('does not translate touch scroll for opencode providers when policy is native', async () => {
     const { store, tabId, paneId, paneContent } = createStore('opencode', [opencodeExtensionWithBehaviorHint])
 
     const { getByTestId } = render(
@@ -202,14 +202,12 @@ describe('opencode touch scroll input policy (e2e)', () => {
     })
 
     expect(latestTerminal?.scrollLines).not.toHaveBeenCalled()
-    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+    expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({
       type: 'terminal.input',
-      terminalId: 'term-opencode',
-      data: '\u001b[B',
     }))
   })
 
-  it('keeps native touch scrolling for non-opted-in providers', async () => {
+  it('skips scrollLines in alt screen for non-opted-in providers', async () => {
     const { store, tabId, paneId, paneContent } = createStore('shell')
 
     const { getByTestId } = render(
@@ -233,7 +231,7 @@ describe('opencode touch scroll input policy (e2e)', () => {
       touches: [{ clientX: 20, clientY: 100 }],
     })
 
-    expect(latestTerminal?.scrollLines).toHaveBeenCalledWith(1)
+    expect(latestTerminal?.scrollLines).not.toHaveBeenCalled()
     expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({
       type: 'terminal.input',
     }))

--- a/test/unit/client/components/TerminalView.scroll-input-policy.test.tsx
+++ b/test/unit/client/components/TerminalView.scroll-input-policy.test.tsx
@@ -111,7 +111,7 @@ const opencodeExtensionWithBehaviorHint: ClientExtensionEntry = {
   cli: {
     terminalBehavior: {
       preferredRenderer: 'canvas',
-      scrollInputPolicy: 'fallbackToCursorKeysWhenAltScreenMouseCapture',
+      scrollInputPolicy: 'native',
     },
   },
 }
@@ -193,7 +193,7 @@ describe('TerminalView wheel scroll input policy', () => {
     vi.unstubAllGlobals()
   })
 
-  it('loads the extension registry for coding-cli panes before applying wheel translation', async () => {
+  it('loads the extension registry for coding-cli panes and does not translate when policy is native', async () => {
     authMocks.getAuthToken.mockReturnValue('token-test')
     apiMocks.get.mockResolvedValue([opencodeExtensionWithBehaviorHint])
     const { store, tabId, paneId, paneContent } = createStore('opencode', [], 'term-opencode')
@@ -212,15 +212,11 @@ describe('TerminalView wheel scroll input policy', () => {
     wsMocks.send.mockClear()
 
     const event = new WheelEvent('wheel', { deltaY: 24, cancelable: true })
-    expect(wheelHandler?.(event)).toBe(false)
-    expect(wsMocks.send).toHaveBeenCalledWith({
-      type: 'terminal.input',
-      terminalId: 'term-opencode',
-      data: '\u001b[B',
-    })
+    expect(wheelHandler?.(event)).toBe(true)
+    expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'terminal.input' }))
   })
 
-  it('translates wheel scrolling into cursor-key input for opted-in providers', async () => {
+  it('does not translate wheel scrolling for opencode providers when policy is native', async () => {
     const { store, tabId, paneId, paneContent } = createStore('opencode', [opencodeExtensionWithBehaviorHint], 'term-opencode')
 
     render(
@@ -242,14 +238,10 @@ describe('TerminalView wheel scroll input policy', () => {
       preventDefault,
       stopPropagation,
     } as unknown as WheelEvent
-    expect(wheelHandler?.(event)).toBe(false)
-    expect(preventDefault).toHaveBeenCalledOnce()
-    expect(stopPropagation).toHaveBeenCalledOnce()
-    expect(wsMocks.send).toHaveBeenCalledWith({
-      type: 'terminal.input',
-      terminalId: 'term-opencode',
-      data: '\u001b[B',
-    })
+    expect(wheelHandler?.(event)).toBe(true)
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(stopPropagation).not.toHaveBeenCalled()
+    expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'terminal.input' }))
   })
 
   it('keeps non-opted-in providers on native wheel behavior', async () => {
@@ -307,11 +299,9 @@ describe('TerminalView wheel scroll input policy', () => {
     })
 
     wsMocks.send.mockClear()
-    expect(wheelHandler?.(event)).toBe(false)
-    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+    expect(wheelHandler?.(event)).toBe(true)
+    expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({
       type: 'terminal.input',
-      terminalId: 'term-opencode',
-      data: '\u001b[B',
     }))
   })
 })

--- a/test/unit/client/components/TerminalView.touch-scroll-input-policy.test.tsx
+++ b/test/unit/client/components/TerminalView.touch-scroll-input-policy.test.tsx
@@ -101,7 +101,7 @@ const opencodeExtensionWithBehaviorHint: ClientExtensionEntry = {
   cli: {
     terminalBehavior: {
       preferredRenderer: 'canvas',
-      scrollInputPolicy: 'fallbackToCursorKeysWhenAltScreenMouseCapture',
+      scrollInputPolicy: 'native',
     },
   },
 }
@@ -177,7 +177,7 @@ describe('TerminalView touch scroll input policy', () => {
     ;(globalThis as any).setMobileForTest(false)
   })
 
-  it('translates touch scrolling into cursor-key input for opted-in providers', async () => {
+  it('does not translate touch scrolling for opencode providers when policy is native', async () => {
     const { store, tabId, paneId, paneContent } = createStore('opencode', [opencodeExtensionWithBehaviorHint])
 
     const { getByTestId } = render(
@@ -203,10 +203,8 @@ describe('TerminalView touch scroll input policy', () => {
     })
 
     expect(latestTerminal?.scrollLines).not.toHaveBeenCalled()
-    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+    expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({
       type: 'terminal.input',
-      terminalId: 'term-opencode',
-      data: '\u001b[B',
     }))
   })
 })

--- a/test/unit/client/lib/terminal-behavior.test.ts
+++ b/test/unit/client/lib/terminal-behavior.test.ts
@@ -17,7 +17,7 @@ const extensions: ClientExtensionEntry[] = [{
   cli: {
     terminalBehavior: {
       preferredRenderer: 'canvas',
-      scrollInputPolicy: 'fallbackToCursorKeysWhenAltScreenMouseCapture',
+      scrollInputPolicy: 'native',
     },
   },
 }]
@@ -26,7 +26,7 @@ describe('terminal behavior', () => {
   it('returns provider terminal behavior from the extension registry', () => {
     expect(getProviderTerminalBehavior('opencode', extensions)).toEqual({
       preferredRenderer: 'canvas',
-      scrollInputPolicy: 'fallbackToCursorKeysWhenAltScreenMouseCapture',
+      scrollInputPolicy: 'native',
     })
   })
 


### PR DESCRIPTION
Rebuilt on current origin/main.

Notes:
- Resolved the lab-note conflict by keeping current origin/main context and layering only the current OpenCode/Claude version facts from this PR.
- Did not restore OpenCode turn-complete notification args; that implementation was intentionally removed because it was broken.

Verification:
- npm run test:vitest -- test/unit/client/components/TerminalView.scroll-input-policy.test.tsx test/unit/client/components/TerminalView.touch-scroll-input-policy.test.tsx test/unit/client/lib/terminal-behavior.test.ts test/e2e/opencode-scroll-input-policy.test.tsx test/e2e/opencode-touch-scroll-input-policy.test.tsx --run