### PR TITLE
Keep sidebar reopen control reachable after collapse

### DIFF
--- a/docs/lab-notes/2026-04-20-coding-cli-session-contract.md
+++ b/docs/lab-notes/2026-04-20-coding-cli-session-contract.md
@@ -81,7 +81,7 @@ The implementation plan file is dated `2026-04-19` because the design work was w
       "executable": "claude",
       "resolvedPath": "/home/user/bin/claude",
       "isolatedBinaryPath": "/home/user/.local/bin/claude",
-      "version": "2.1.126 (Claude Code)",
+      "version": "2.1.129 (Claude Code)",
       "exactIdCommandTemplate": "HOME=<temp-home> /home/user/.local/bin/claude --bare --dangerously-skip-permissions -p --session-id <uuid> <prompt>",
       "namedResumeCommandTemplate": "HOME=<temp-home> /home/user/.local/bin/claude --bare --dangerously-skip-permissions -p --resume <title-or-uuid> [--name <title>] <prompt>",
       "transcriptGlob": ".claude/projects/*/<uuid>.jsonl",
@@ -238,7 +238,7 @@ command -v claude
 # /home/user/bin/claude
 
 claude --version
-# 2.1.126 (Claude Code)
+# 2.1.129 (Claude Code)
 ```
 
 The wrapper at `/home/user/bin/claude` shells out to `/home/user/.local/bin/claude`. The isolated probes used the actual binary and overrode `HOME` to keep persistence inside the probe temp root.

--- a/docs/lab-notes/2026-04-20-coding-cli-session-contract.md
+++ b/docs/lab-notes/2026-04-20-coding-cli-session-contract.md
@@ -1,6 +1,6 @@
 # Coding CLI Session Contract Lab Note
 
-This note records the real-binary provider probes rerun on `2026-04-26` inside `/home/user/code/freshell/.worktrees/trycycle-codex-session-resilience`. Binary version facts were refreshed on `2026-05-03` inside `/home/user/code/freshell/.worktrees/land-local-main-codex-sidecar-lifecycle`; the Claude Code binary version fact was refreshed again on `2026-05-05` inside `/home/user/code/freshell/.worktrees/codex-sidebar-reopen-corner-20260505` after the installed binary changed. The later version-only refreshes did not re-prove the behavior contract, so `capturedOn` remains `2026-04-26`.
+This note records the real-binary provider probes rerun on `2026-04-26` inside `/home/user/code/freshell/.worktrees/trycycle-codex-session-resilience`. Binary version facts were refreshed on `2026-05-03` inside `/home/user/code/freshell/.worktrees/land-local-main-codex-sidecar-lifecycle`; the Claude Code binary version fact was refreshed again on `2026-05-06` inside `/home/user/code/freshell/.worktrees/codex-sidebar-reopen-corner-origin-pr-20260505` after the installed binary changed. The later version-only refreshes did not re-prove the behavior contract, so `capturedOn` remains `2026-04-26`.
 
 The implementation plan file is dated `2026-04-19` because the design work was written the day before. This note is dated `2026-04-26` because the real-provider contracts were re-proved on the implementation machine on that date, and that verification date is the one Freshell is allowed to build on.
 
@@ -9,8 +9,8 @@ The implementation plan file is dated `2026-04-19` because the design work was w
 {
   "capturedOn": "2026-04-26",
   "planCreatedOn": "2026-04-19",
-  "binaryVersionFactsRefreshedOn": "2026-05-05",
-  "dateReason": "The plan was drafted on 2026-04-19, but the checked-in note is dated 2026-04-26 because that is when the durable behavior contract was re-proved on the implementation machine and the earlier 2026-04-23 contract capture was superseded by the newer provider behavior. Binary version facts were refreshed on 2026-05-03 after installed provider versions changed, and the Claude Code binary version fact was refreshed on 2026-05-05 after the local installed binary changed to 2.1.129. These later version-only refreshes did not re-prove the behavior contract.",
+  "binaryVersionFactsRefreshedOn": "2026-05-06",
+  "dateReason": "The plan was drafted on 2026-04-19, but the checked-in note is dated 2026-04-26 because that is when the durable behavior contract was re-proved on the implementation machine and the earlier 2026-04-23 contract capture was superseded by the newer provider behavior. Binary version facts were refreshed on 2026-05-03 after installed provider versions changed, and the Claude Code binary version fact was refreshed on 2026-05-06 after the local installed binary changed to 2.1.132. These later version-only refreshes did not re-prove the behavior contract.",
   "cleanup": {
     "liveProcessAuditCommand": "ps -eo pid,ppid,stat,cmd --sort=pid | rg \"codex|claude|opencode\"",
     "ownershipReportFields": [
@@ -82,7 +82,7 @@ The implementation plan file is dated `2026-04-19` because the design work was w
       "executable": "claude",
       "resolvedPath": "/home/user/bin/claude",
       "isolatedBinaryPath": "/home/user/.local/bin/claude",
-      "version": "2.1.129 (Claude Code)",
+      "version": "2.1.132 (Claude Code)",
       "exactIdCommandTemplate": "HOME=<temp-home> /home/user/.local/bin/claude --bare --dangerously-skip-permissions -p --session-id <uuid> <prompt>",
       "namedResumeCommandTemplate": "HOME=<temp-home> /home/user/.local/bin/claude --bare --dangerously-skip-permissions -p --resume <title-or-uuid> [--name <title>] <prompt>",
       "transcriptGlob": ".claude/projects/*/<uuid>.jsonl",
@@ -239,10 +239,10 @@ command -v claude
 # /home/user/bin/claude
 
 claude --version
-# 2.1.129 (Claude Code)
+# 2.1.132 (Claude Code)
 ```
 
-This Claude Code version line was refreshed on `2026-05-05`; the behavior observations below remain from the `2026-04-26` real-provider proof.
+This Claude Code version line was refreshed on `2026-05-06`; the behavior observations below remain from the `2026-04-26` real-provider proof.
 
 The wrapper at `/home/user/bin/claude` shells out to `/home/user/.local/bin/claude`. The isolated probes used the actual binary and overrode `HOME` to keep persistence inside the probe temp root.
 

--- a/docs/lab-notes/2026-04-20-coding-cli-session-contract.md
+++ b/docs/lab-notes/2026-04-20-coding-cli-session-contract.md
@@ -1,6 +1,6 @@
 # Coding CLI Session Contract Lab Note
 
-This note records the real-binary provider probes rerun on `2026-04-26` inside `/home/user/code/freshell/.worktrees/trycycle-codex-session-resilience`. Binary version facts were refreshed on `2026-05-03` inside `/home/user/code/freshell/.worktrees/land-local-main-codex-sidecar-lifecycle`.
+This note records the real-binary provider probes rerun on `2026-04-26` inside `/home/user/code/freshell/.worktrees/trycycle-codex-session-resilience`. Binary version facts were refreshed on `2026-05-03` inside `/home/user/code/freshell/.worktrees/land-local-main-codex-sidecar-lifecycle`; the Claude Code binary version fact was refreshed again on `2026-05-05` inside `/home/user/code/freshell/.worktrees/codex-sidebar-reopen-corner-20260505` after the installed binary changed. The later version-only refreshes did not re-prove the behavior contract, so `capturedOn` remains `2026-04-26`.
 
 The implementation plan file is dated `2026-04-19` because the design work was written the day before. This note is dated `2026-04-26` because the real-provider contracts were re-proved on the implementation machine on that date, and that verification date is the one Freshell is allowed to build on.
 
@@ -9,7 +9,8 @@ The implementation plan file is dated `2026-04-19` because the design work was w
 {
   "capturedOn": "2026-04-26",
   "planCreatedOn": "2026-04-19",
-  "dateReason": "The plan was drafted on 2026-04-19, but the checked-in note is dated 2026-04-26 because that is when the durable behavior contract was re-proved on the implementation machine and the earlier 2026-04-23 contract capture was superseded by the newer provider behavior. Binary version facts were refreshed on 2026-05-03 after the installed provider versions changed.",
+  "binaryVersionFactsRefreshedOn": "2026-05-05",
+  "dateReason": "The plan was drafted on 2026-04-19, but the checked-in note is dated 2026-04-26 because that is when the durable behavior contract was re-proved on the implementation machine and the earlier 2026-04-23 contract capture was superseded by the newer provider behavior. Binary version facts were refreshed on 2026-05-03 after installed provider versions changed, and the Claude Code binary version fact was refreshed on 2026-05-05 after the local installed binary changed to 2.1.129. These later version-only refreshes did not re-prove the behavior contract.",
   "cleanup": {
     "liveProcessAuditCommand": "ps -eo pid,ppid,stat,cmd --sort=pid | rg \"codex|claude|opencode\"",
     "ownershipReportFields": [
@@ -240,6 +241,8 @@ command -v claude
 claude --version
 # 2.1.129 (Claude Code)
 ```
+
+This Claude Code version line was refreshed on `2026-05-05`; the behavior observations below remain from the `2026-04-26` real-provider proof.
 
 The wrapper at `/home/user/bin/claude` shells out to `/home/user/.local/bin/claude`. The isolated probes used the actual binary and overrode `HOME` to keep persistence inside the probe temp root.
 

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -7,6 +7,7 @@ import { allocateLocalhostPort, type LoopbackServerEndpoint } from '../../local-
 import { logger } from '../../logger.js'
 import {
   CodexAppServerClient,
+  type CodexAppServerDisconnectEvent,
   type CodexThreadLifecycleEvent,
   type CodexThreadLifecycleLossEvent,
 } from './client.js'
@@ -500,6 +501,7 @@ export class CodexAppServerRuntime {
   private ownership: ActiveOwnership | null = null
   private ownershipTeardownPromise: Promise<void> | null = null
   private ownershipTeardownFailure: Error | null = null
+  private startupAbortError: Error | null = null
   private shutdownRequested = false
   private lifecycleLossHandlers = new Set<(event: CodexThreadLifecycleLossEvent) => void>()
   private readonly exitHandlers = new Set<(error?: Error, source?: CodexAppServerRuntimeFailureSource) => void>()
@@ -551,9 +553,17 @@ export class CodexAppServerRuntime {
       this.ensureReadyPromise = null
     })
 
-    this.ready = await this.ensureReadyPromise
+    return this.publishReady(await this.ensureReadyPromise)
+  }
+
+  private publishReady(ready: ReadyState): ReadyState {
+    if (this.startupAbortError) {
+      throw this.startupAbortError
+    }
+    this.startupAbortError = null
+    this.ready = ready
     this.statusValue = 'running'
-    return this.ready
+    return ready
   }
 
   async startThread(
@@ -597,7 +607,7 @@ export class CodexAppServerRuntime {
       ...(input.codexHome !== undefined ? { codexHome: input.codexHome } : {}),
       updatedAt: new Date().toISOString(),
     }
-    await atomicWriteJson(this.ownership.metadataPath, this.ownership.metadata)
+    await this.writeOwnershipRecord(this.ownership)
   }
 
   onThreadLifecycleLoss(handler: (event: CodexThreadLifecycleLossEvent) => void): () => void {
@@ -682,6 +692,7 @@ export class CodexAppServerRuntime {
       if (this.shutdownRequested) {
         throw new Error('Codex app-server startup was cancelled because the sidecar is shutting down.')
       }
+      this.startupAbortError = null
       const endpoint = await this.portAllocator()
       if (this.shutdownRequested) {
         throw new Error('Codex app-server startup was cancelled because the sidecar is shutting down.')
@@ -732,7 +743,7 @@ export class CodexAppServerRuntime {
         this.ownership = ownership
         attemptOwnership = ownership
         await this.writeOwnershipRecord(ownership)
-        await this.readWrapperIdentityInto(ownership)
+        await this.readWrapperIdentityInto(ownership, child, childErrorPromise)
         this.ownership = ownership
         await this.writeOwnershipRecord(ownership)
 
@@ -761,16 +772,14 @@ export class CodexAppServerRuntime {
           }
         })
         client.onDisconnect((event) => {
-          if (this.shutdownRequested) return
-          for (const handler of this.exitHandlers) {
-            handler(event.error, 'app_server_client_disconnect')
-          }
+          this.handleClientDisconnect(client, event)
         })
         this.client = client
 
         const initialized = await this.waitForInitialize(client, child, childErrorPromise)
+        this.assertStartupRuntimeStillActive(client, child)
         await this.updateOwnershipMetadata({ codexHome: initialized.codexHome })
-        this.statusValue = 'running'
+        this.assertStartupRuntimeStillActive(client, child)
         return {
           wsUrl,
           processPid: child.pid,
@@ -841,18 +850,41 @@ export class CodexAppServerRuntime {
     }
   }
 
-  private async readWrapperIdentityInto(ownership: ActiveOwnership): Promise<void> {
-    const wrapperIdentity = await this.processIdentityReader(ownership.metadata.wrapperPid)
-    if (!isCompleteWrapperIdentity(wrapperIdentity)) {
-      throw new Error(
-        `Codex app-server wrapper identity could not be completely read for PID ${ownership.metadata.wrapperPid}.`,
-      )
+  private async readWrapperIdentityInto(
+    ownership: ActiveOwnership,
+    child: ChildProcessHandle,
+    childErrorPromise: Promise<Error>,
+  ): Promise<void> {
+    const deadline = Date.now() + this.startupAttemptTimeoutMs
+
+    while (true) {
+      const [wrapperIdentity, hasOwnershipEnv] = await Promise.race([
+        Promise.all([
+          this.processIdentityReader(ownership.metadata.wrapperPid),
+          processHasOwnershipEnv(ownership.metadata.wrapperPid, ownership.metadata.ownershipId),
+        ]),
+        childErrorPromise.then((error) => {
+          throw error
+        }),
+      ])
+      if (hasOwnershipEnv && isCompleteWrapperIdentity(wrapperIdentity)) {
+        ownership.metadata = {
+          ...ownership.metadata,
+          wrapperIdentity,
+          updatedAt: new Date().toISOString(),
+        }
+        return
+      }
+
+      if (child.exitCode !== null || child.signalCode !== null || Date.now() >= deadline) {
+        break
+      }
+      await sleep(STARTUP_POLL_MS)
     }
-    ownership.metadata = {
-      ...ownership.metadata,
-      wrapperIdentity,
-      updatedAt: new Date().toISOString(),
-    }
+
+    throw new Error(
+      `Codex app-server wrapper identity could not be completely read for PID ${ownership.metadata.wrapperPid}.`,
+    )
   }
 
   private async writeOwnershipRecord(ownership: ActiveOwnership): Promise<void> {
@@ -894,6 +926,18 @@ export class CodexAppServerRuntime {
     throw lastError ?? new Error('Codex app-server exited before it finished initializing.')
   }
 
+  private assertStartupRuntimeStillActive(client: CodexAppServerClient, child: ChildProcessHandle): void {
+    if (this.startupAbortError) {
+      throw this.startupAbortError
+    }
+    if (this.child !== child) {
+      throw new Error('Codex app-server child exited before startup completed.')
+    }
+    if (this.client !== client) {
+      throw new Error('Codex app-server client disconnected before startup completed.')
+    }
+  }
+
   private watchChildError(child: ChildProcessHandle): Promise<Error> {
     return new Promise((resolve) => {
       child.once('error', (error) => {
@@ -919,6 +963,7 @@ export class CodexAppServerRuntime {
         return
       }
 
+      const wasReady = this.ready !== null
       const ownership = this.ownership
       this.child = null
       this.ready = null
@@ -948,12 +993,41 @@ export class CodexAppServerRuntime {
         void closeClient
       }
 
-      if (!this.shutdownRequested) {
+      if (wasReady && !this.shutdownRequested) {
         for (const handler of this.exitHandlers) {
           handler(undefined, 'app_server_exit')
         }
       }
     })
+  }
+
+  private handleClientDisconnect(client: CodexAppServerClient, event: CodexAppServerDisconnectEvent): void {
+    if (this.client !== client) {
+      return
+    }
+
+    const wasReady = this.ready !== null
+    this.client = null
+    this.ready = null
+    this.statusValue = 'stopped'
+
+    if (!wasReady || this.shutdownRequested) {
+      if (!this.shutdownRequested) {
+        this.startupAbortError = new Error(event.reason === 'error'
+          ? `Codex app-server client socket errored before startup completed: ${event.error?.message ?? 'unknown error'}`
+          : 'Codex app-server client disconnected before startup completed.')
+      }
+      void this.stopActiveChild().catch(() => undefined)
+      return
+    }
+
+    const error = event.reason === 'error'
+      ? new Error(`Codex app-server client socket errored: ${event.error?.message ?? 'unknown error'}`)
+      : new Error('Codex app-server client socket closed unexpectedly.')
+    for (const handler of this.exitHandlers) {
+      handler(error, 'app_server_client_disconnect')
+    }
+    void this.stopActiveChild().catch(() => undefined)
   }
 
   private async stopActiveChild(): Promise<void> {

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -400,6 +400,21 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
         className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-muted-foreground/45"
         aria-hidden="true"
       />
+      {sidebarCollapsed && onToggleSidebar && (
+        <div
+          className="flex-shrink-0 w-10 h-full flex items-end justify-center pb-1"
+          data-testid="desktop-sidebar-reopen-slot"
+        >
+          <button
+            className="p-1 min-h-11 min-w-11 md:h-8 md:w-8 md:min-h-0 md:min-w-0 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-colors"
+            title="Show sidebar"
+            aria-label="Show sidebar"
+            onClick={onToggleSidebar}
+          >
+            <PanelLeft className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
@@ -433,16 +448,6 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
             ref={callbackRef}
             className="flex items-end gap-0.5 overflow-x-auto overflow-y-hidden scrollbar-none pt-px flex-1 min-w-0"
           >
-            {sidebarCollapsed && onToggleSidebar && (
-              <button
-                className="flex-shrink-0 mb-1 p-1 min-h-11 min-w-11 md:min-h-0 md:min-w-0 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-colors"
-                title="Show sidebar"
-                aria-label="Show sidebar"
-                onClick={onToggleSidebar}
-              >
-                <PanelLeft className="h-3.5 w-3.5" />
-              </button>
-            )}
             {tabs.map(renderSortableTab)}
           </div>
 

--- a/test/e2e-browser/specs/sidebar.spec.ts
+++ b/test/e2e-browser/specs/sidebar.spec.ts
@@ -26,6 +26,61 @@ test.describe('Sidebar', () => {
     await expect(page.getByRole('button', { name: /hide sidebar/i })).toBeVisible()
   })
 
+  test('sidebar reopen button stays fixed when overflowing tabs are scrolled', async ({ freshellPage, page }) => {
+    await page.setViewportSize({ width: 900, height: 700 })
+    await page.evaluate(() => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      if (!harness) throw new Error('Freshell test harness is not installed')
+      for (let i = 0; i < 18; i += 1) {
+        harness.dispatch({
+          type: 'tabs/addTab',
+          payload: {
+            id: `overflow-tab-${i}`,
+            createRequestId: `overflow-tab-${i}`,
+            title: `Overflow tab ${i}`,
+            mode: 'shell',
+            shell: 'system',
+            status: 'running',
+          },
+        })
+      }
+    })
+    await page.waitForFunction(() => (
+      window.__FRESHELL_TEST_HARNESS__?.getState()?.tabs?.tabs?.length ?? 0
+    ) >= 18)
+
+    const collapseButton = page.getByRole('button', { name: /hide sidebar/i })
+    await collapseButton.click()
+
+    const showButton = page.getByRole('button', { name: /show sidebar/i })
+    await expect(showButton).toBeVisible({ timeout: 3_000 })
+
+    const tabBar = page.locator('[data-context="global"]').filter({
+      has: page.getByRole('button', { name: /new shell tab/i }),
+    }).first()
+    const tabScroller = tabBar.locator('.overflow-x-auto').first()
+    await expect(tabScroller).toBeVisible()
+    await expect.poll(async () => tabScroller.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(true)
+
+    const before = await showButton.boundingBox()
+    expect(before).not.toBeNull()
+
+    const scrollLeft = await tabScroller.evaluate((element) => {
+      element.scrollLeft = element.scrollWidth
+      element.dispatchEvent(new Event('scroll', { bubbles: true }))
+      return element.scrollLeft
+    })
+    expect(scrollLeft).toBeGreaterThan(0)
+
+    const after = await showButton.boundingBox()
+    const scrollerBox = await tabScroller.boundingBox()
+    expect(after).not.toBeNull()
+    expect(scrollerBox).not.toBeNull()
+    expect(after!.x).toBeCloseTo(before!.x, 0)
+    expect(after!.x).toBeGreaterThanOrEqual(0)
+    expect(after!.x + after!.width).toBeLessThanOrEqual(scrollerBox!.x)
+  })
+
   test('sidebar shows navigation buttons', async ({ freshellPage, page }) => {
     // Nav buttons have title attributes like "Settings (Ctrl+B ,)", "Tabs (Ctrl+B A)", etc.
     // Playwright matches title as accessible name for buttons with no text/aria-label.

--- a/test/unit/client/components/TabBar.mobile.test.tsx
+++ b/test/unit/client/components/TabBar.mobile.test.tsx
@@ -137,7 +137,7 @@ describe('TabBar sidebar toggle integration', () => {
     ;(globalThis as any).setMobileForTest?.(false)
   })
 
-  it('renders show-sidebar button before tabs on desktop when sidebar is collapsed', () => {
+  it('renders show-sidebar button in a fixed desktop slot when sidebar is collapsed', () => {
     const onToggleSidebar = vi.fn()
     const store = createStore(defaultTabsState, defaultPanesState)
     render(
@@ -147,7 +147,10 @@ describe('TabBar sidebar toggle integration', () => {
     )
 
     const showButton = screen.getByTitle('Show sidebar')
+    const fixedSlot = screen.getByTestId('desktop-sidebar-reopen-slot')
     expect(showButton).toBeInTheDocument()
+    expect(fixedSlot).toContainElement(showButton)
+    expect(showButton.closest('.overflow-x-auto')).toBeNull()
     fireEvent.click(showButton)
     expect(onToggleSidebar).toHaveBeenCalled()
   })

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -204,6 +204,24 @@ describe('CodexAppServerRuntime', () => {
     expect(runtime.status()).toBe('running')
   })
 
+  it('waits for a complete wrapper identity proof during startup', async () => {
+    let identityReads = 0
+    const runtime = createRuntime({
+      startupAttemptLimit: 1,
+      startupAttemptTimeoutMs: 1_000,
+      processIdentityReader: async (pid) => {
+        identityReads += 1
+        if (identityReads === 1) return null
+        return readWrapperIdentityForTest(pid)
+      },
+    })
+
+    await expect(runtime.ensureReady()).resolves.toEqual(expect.objectContaining({
+      wsUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
+    }))
+    expect(identityReads).toBeGreaterThan(1)
+  })
+
   it('rejects before spawning on platforms without Linux /proc ownership support', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     if (!originalPlatform?.configurable) {
@@ -479,12 +497,11 @@ describe('CodexAppServerRuntime', () => {
     expect(Date.now() - start).toBeLessThan(1_500)
   }, 3_000)
 
-  it('tears down the owned process group before retry when wrapper identity cannot be read', async () => {
+  it('waits for a transiently unreadable wrapper identity without retrying startup', async () => {
     const tempDir = await makeTempDir()
     const metadataDir = path.join(tempDir, 'metadata')
     const processGroups: number[] = []
     const seenProcessGroups = new Set<number>()
-    let previousAttemptGoneBeforeRetry = false
     let identityReadAttempts = 0
     const runtime = createRuntime({
       metadataDir,
@@ -499,9 +516,6 @@ describe('CodexAppServerRuntime', () => {
       },
       metadataWriter: async (filePath, metadata) => {
         if (!seenProcessGroups.has(metadata.processGroupId)) {
-          if (processGroups.length > 0) {
-            previousAttemptGoneBeforeRetry = !(await isProcessGroupAlive(processGroups[0]))
-          }
           seenProcessGroups.add(metadata.processGroupId)
           processGroups.push(metadata.processGroupId)
         }
@@ -513,19 +527,17 @@ describe('CodexAppServerRuntime', () => {
     const ready = await runtime.ensureReady()
     const record = JSON.parse(await fsp.readFile(ready.metadataPath, 'utf8'))
 
-    expect(processGroups).toHaveLength(2)
+    expect(processGroups).toHaveLength(1)
     expect(identityReadAttempts).toBe(2)
-    expect(previousAttemptGoneBeforeRetry).toBe(true)
-    expect(record.processGroupId).toBe(processGroups[1])
+    expect(record.processGroupId).toBe(processGroups[0])
     expect(record.wrapperIdentity.startTimeTicks).toEqual(expect.any(Number))
   }, 3_000)
 
-  it('tears down the owned process group before retry when wrapper identity is incomplete', async () => {
+  it('waits for a transiently incomplete wrapper identity without retrying startup', async () => {
     const tempDir = await makeTempDir()
     const metadataDir = path.join(tempDir, 'metadata')
     const processGroups: number[] = []
     const seenProcessGroups = new Set<number>()
-    let previousAttemptGoneBeforeRetry = false
     let identityReadAttempts = 0
     const runtime = createRuntime({
       metadataDir,
@@ -542,9 +554,6 @@ describe('CodexAppServerRuntime', () => {
       },
       metadataWriter: async (filePath, metadata) => {
         if (!seenProcessGroups.has(metadata.processGroupId)) {
-          if (processGroups.length > 0) {
-            previousAttemptGoneBeforeRetry = !(await isProcessGroupAlive(processGroups[0]))
-          }
           seenProcessGroups.add(metadata.processGroupId)
           processGroups.push(metadata.processGroupId)
         }
@@ -556,10 +565,9 @@ describe('CodexAppServerRuntime', () => {
     const ready = await runtime.ensureReady()
     const record = JSON.parse(await fsp.readFile(ready.metadataPath, 'utf8'))
 
-    expect(processGroups).toHaveLength(2)
+    expect(processGroups).toHaveLength(1)
     expect(identityReadAttempts).toBe(2)
-    expect(previousAttemptGoneBeforeRetry).toBe(true)
-    expect(record.processGroupId).toBe(processGroups[1])
+    expect(record.processGroupId).toBe(processGroups[0])
     expect(record.wrapperIdentity.commandLine.length).toBeGreaterThan(0)
     expect(record.wrapperIdentity.cwd).toEqual(expect.any(String))
     expect(record.wrapperIdentity.startTimeTicks).toEqual(expect.any(Number))
@@ -909,6 +917,7 @@ describe('CodexAppServerRuntime', () => {
       metadataDir,
       serverInstanceId: 'srv-current',
     })
+    runtimes.delete(runtime)
 
     expect(result.reapedOwnershipIds).toContain(ready.ownershipId)
     await waitForProcessExit(ready.processPid)
@@ -1246,6 +1255,32 @@ describe('CodexAppServerRuntime', () => {
     expect(ready.wsUrl).toMatch(/^ws:\/\/127\.0\.0\.1:\d+$/)
     expect(ready.wsUrl).not.toBe(`ws://${endpoint.hostname}:${endpoint.port}`)
     await closeBlocker(blocker)
+  })
+
+  it('does not publish ready when the app-server client socket disconnects before startup completes', async () => {
+    const runtime = createRuntime({
+      startupAttemptLimit: 1,
+      metadataWriter: async (filePath, metadata) => {
+        if (metadata.codexHome) {
+          await new Promise((resolve) => setTimeout(resolve, 500))
+        }
+        await fsp.mkdir(path.dirname(filePath), { recursive: true })
+        await fsp.writeFile(filePath, `${JSON.stringify(metadata, null, 2)}\n`, { mode: 0o600 })
+      },
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          closeSocketAfterMethodsOnce: ['initialize'],
+        }),
+      },
+    })
+    const onExit = vi.fn()
+    runtime.onExit(onExit)
+
+    await expect(runtime.ensureReady()).rejects.toThrow(
+      /Codex app-server client disconnected before startup completed/,
+    )
+    expect(runtime.status()).toBe('stopped')
+    expect(onExit).not.toHaveBeenCalled()
   })
 
   it('keeps child stdio drained so large app-server logs do not stall thread/start replies', async () => {


### PR DESCRIPTION
## Summary
- Reserve a compact top-left area outside the tab scroller for the collapsed-sidebar reopen button.
- Add a browser regression proving the reopen button remains visible/fixed when overflowing tabs are scrolled.
- Adapt the Codex app-server startup hardening for current `origin/main`: pre-ready socket disconnects no longer publish ready, and transient wrapper identity reads are retried with ownership-env proof.
- Clarify the Claude Code lab-note version refresh provenance without re-dating the behavior proof.

## Verification
- PASS: `npm run test:vitest -- --config vitest.server.config.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts --run`
- PASS: `npm run test:vitest -- test/unit/client/components/TabBar.mobile.test.tsx --run`
- PASS: `npm run test:e2e:chromium -- test/e2e-browser/specs/sidebar.spec.ts`
- PASS: `npm run lint` (0 errors; existing warnings remain)
- FAIL, baseline on `origin/main`: `FRESHELL_TEST_SUMMARY="sidebar reopen corner origin-main PR full check" npm run check`

The full check failure is not from this PR's touched files. A clean detached `origin/main` worktree at `63944cfd` fails the focused baseline test `npm run test:vitest -- --config vitest.server.config.ts test/unit/server/terminal-registry.codex-recovery.test.ts --run` with the same 30/31 failures. The failure shape is a test/implementation mismatch: those tests expect `record.codex` recovery state, while `origin/main`'s `TerminalRegistry.create()` currently builds `codexSidecar`/`codexRecovery` fields without populating `record.codex`.