### PR TITLE
Define dev branch self-hosting workflow

### DIFF
--- a/.claude/skills/release-freshell/SKILL.md
+++ b/.claude/skills/release-freshell/SKILL.md
@@ -94,13 +94,14 @@ Present the proposed README changes to the user for approval before proceeding t
 
 ## Release Steps
 
-All work happens on a release branch in a worktree — main is untouched until the final atomic fast-forward. This protects the running Freshell instance.
+All release preparation happens on a release branch in a worktree from `origin/main`. Local `main` is a mirror of `origin/main`; do not commit to it, fast-forward it, or push it directly.
 
 ### 1. Create the release branch
 
 ```bash
-# From the main repo
-git worktree add .worktrees/release-vX.Y.Z -b release/vX.Y.Z main
+# From the repo root
+git fetch origin
+git worktree add .worktrees/release-vX.Y.Z -b release/vX.Y.Z origin/main
 cd .worktrees/release-vX.Y.Z
 npm install
 ```
@@ -129,19 +130,14 @@ All of these are committed to the release branch:
 2. **Update README:** Change `--branch vOLD` to `--branch vNEW` in the clone command, and apply the approved Features changes
 3. **Commit** with message like `release: vX.Y.Z`
 
-### 4. Fast-forward main
+### 4. Open and merge a release PR
 
-```bash
-# Back in the main repo working directory
-git merge --ff-only release/vX.Y.Z
-```
-
-If `--ff-only` fails, go back to the worktree and rebase onto main until it can fast-forward.
+Push the release branch and open a PR against `main`. After user approval and required checks, merge it through GitHub. If conflicts appear, rebase the release branch onto `origin/main`, resolve in the worktree, retest, and force-push with `--force-with-lease`.
 
 ### 5. Tag and publish
 
 ```bash
-git push origin main
+git fetch origin
 git tag -a vX.Y.Z -m "vX.Y.Z"
 git push --tags
 gh release create vX.Y.Z --title "vX.Y.Z" --notes "..."  # with the release notes
@@ -156,8 +152,8 @@ git branch -d release/vX.Y.Z
 
 ## Safety
 
-- Main can contain work-in-progress; users clone a specific release tag
-- You are running inside Freshell — if you break main mid-release, you kill yourself
-- All release prep happens on a branch in a worktree, so main is never modified until the atomic fast-forward
+- Local `main` mirrors `origin/main`; release work happens on a PR branch.
+- Users clone a specific release tag.
+- The self-hosted integration branch is `dev`, not local `main`.
 - Commit the version bump before tagging so the tag points to the right commit
 - If any step fails, stop and assess, then make recommendations to the user, rather than pushing forward

--- a/.claude/skills/reviewing-prs/SKILL.md
+++ b/.claude/skills/reviewing-prs/SKILL.md
@@ -17,7 +17,7 @@ We never push work back onto contributors. Our goal is to harvest **good ideas f
 
 1. Create a detached worktree for all PR work:
    ```bash
-   git worktree add .worktrees/pr-review --detach HEAD
+   git worktree add .worktrees/pr-review --detach origin/main
    ```
 2. List open PRs with `gh pr list`
 3. Process oldest-to-newest (reduces cascading merge conflicts)
@@ -28,11 +28,11 @@ We never push work back onto contributors. Our goal is to harvest **good ideas f
 
 ```bash
 cd .worktrees/pr-review
-git fetch origin && git checkout --detach origin/main
+git fetch origin && git switch --detach origin/main
 gh pr checkout <N>
 ```
 
-Always reset the worktree to latest main before each PR.
+Always reset the worktree to latest `origin/main` before each PR.
 
 ### 2. Review the Diff
 
@@ -85,7 +85,7 @@ Present build, test, and fresheyes results to the user. Include:
 
 Address all fresheyes findings and test failures before merging:
 - Commit fixes on the PR branch with detailed messages
-- **Show the diff and get approval before pushing** to the PR branch or main
+- **Show the diff and get approval before pushing** to the PR branch
 - Re-build and re-test after fixes
 
 ### 7. Merge (only after user approves)
@@ -96,14 +96,9 @@ gh pr merge <N> --merge
 ```
 
 **If GitHub's merge state is stale** (common after rebase/force-push):
-```bash
-# In the main repo (not the worktree)
-git fetch origin && git merge --ff-only origin/main
-git merge --no-ff <branch> -m "Merge pull request #N from ..."
-git push origin main
-```
+refresh the PR branch on `origin/main`, force-push it with `--force-with-lease`, and use GitHub merge after the merge state updates. Do not merge locally into `main` or push `main` directly.
 
-**If conflicts exist:** rebase the PR branch on main, resolve, rebuild, retest, force-push, then merge.
+**If conflicts exist:** rebase the PR branch on `origin/main`, resolve, rebuild, retest, force-push with `--force-with-lease`, then merge through GitHub.
 
 ### 8. Comment and Close
 
@@ -116,7 +111,7 @@ Leave an effusive comment summarizing:
 gh pr comment <N> --body "..."
 ```
 
-Then ensure the PR is closed. Local merges (the fallback path) don't trigger GitHub's auto-close:
+Then ensure the PR is closed:
 
 ```bash
 # Check if still open; close if needed
@@ -128,10 +123,6 @@ gh pr view <N> --json state -q '.state' | grep -q OPEN && gh pr close <N>
 Once all PRs are landed and there is no unfinished work, clean up:
 
 ```bash
-# Switch back to main in the primary repo
-cd <primary-repo>
-git checkout main && git pull --ff-only origin main
-
 # Remove the pr-review worktree
 git worktree remove .worktrees/pr-review
 ```
@@ -192,7 +183,7 @@ The user may respond with:
 
 ##### c. Fix (if approved)
 
-- Create a branch: `git checkout -b fix/issue-<N> origin/main`
+- Create a branch in a worktree from `origin/main`.
 - Implement the fix in the worktree
 - Build and run targeted tests
 - **Show the diff and get approval before pushing**
@@ -219,7 +210,7 @@ Always sign the comment `— Codex CLI`.
 | Tests | `go test ./...` (targeted) | — |
 | Present results | Build/test/fresheyes summary | **User approval (Gate 2)** |
 | Fix | Commit + show diff + get approval before push | Build + tests green |
-| Merge | `gh pr merge` or local merge | All fixes landed + user says merge |
+| Merge | `gh pr merge` | All fixes landed + user says merge |
 | Comment + Close | `gh pr comment` + `gh pr close` if still open | Merge complete |
 | Reset | `git checkout --detach origin/main` | Before next PR |
 | Teardown | `git worktree remove .worktrees/pr-review` | Queue empty, all landed |
@@ -248,10 +239,10 @@ If you catch yourself thinking any of these, you are about to violate a gate:
 | Proceeding without user approval | There are TWO hard gates. Always wait at both. |
 | Treating ambiguous signals as approval | Only explicit approval words count. When in doubt, ask. |
 | Merging after build+fresheyes without asking | Gate 2 requires presenting results and waiting for go/no-go. |
-| Pushing fixes to main without showing diff | Show the diff first. Get approval before any push. |
+| Pushing fixes without showing diff | Show the diff first. Get approval before any push to the PR branch. |
 | Merging with fresheyes FAILED | Fix all findings first. Never merge a failed review. |
 | Forgetting to update worktree between PRs | Stale base causes unnecessary conflicts. Always reset to origin/main. |
-| Forgetting to close after local merge | Local merges don't trigger GitHub auto-close. Always check and `gh pr close` if still open. |
+| Pushing directly to `main` | `main` mirrors `origin/main`. Use PR branches and GitHub merge. |
 | Signing comment as "Codex" or "Claude" | Always sign as `— Codex CLI`. |
 | Processing PRs newest-first | Oldest-first minimizes cascading conflicts since earlier PRs often touch files later ones depend on. |
 | Processing issues oldest-first | Issue triage is newest-first so the most recent reports and follow-ups are evaluated first. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Freshell is a self-hosted, browser-accessible terminal multiplexer and session o
 
 ## Repo Rules
 - Always work in a worktree (in \.worktrees\)
+- New behavior changes start on a worktree branch from `origin/main` and are submitted as PRs to `origin/main`; local `dev` only consumes PR heads.
 - Many agents may be working in the worktree at the same time. If you see activity from other agents (for example test runs or file changes), respect it.
 - Specific user instructions override ALL other instructions, including the above, and including superpowers or skills
 - Server uses NodeNext/ESM; relative imports must include `.js` extensions
@@ -26,16 +27,18 @@ Freshell is a self-hosted, browser-accessible terminal multiplexer and session o
 - Use `npm run test:vitest -- ...` for a repo-owned direct Vitest path. Raw `npx vitest` is not a coordinated workflow.
 - `test:unit` is the exact default-config `test/unit` workload, `test:integration` is the exact server-config `test/server` workload, and `test:server` stays watch-capable unless you pass an explicit broad `--run`.
 
-## Merging to Main (CRITICAL - Read This)
+## Branch Model And Self-Hosting (CRITICAL - Read This)
 
-**You are running inside Freshell right now. This session, the terminal the user is typing in, is served by the main branch. If you break main, you kill yourself mid-operation and the user has to clean up your mess with a separate agent.**
+**This checkout is self-hosted from local `dev`, not local `main`.**
 
-- Never run `git merge` directly on main - merge conflicts write `<<<<<<< HEAD` markers into source files, which crashes the server instantly
-- Always merge main INTO the feature branch in the worktree first, resolve any conflicts there
-- Before fast-forwarding main, run `npm test` and confirm all tests pass (not just related tests)
-- If you find failing tests, you must stop everything to understand them and make improvements, even if you do not think you were responsible for them.
-- Then fast-forward main: `git merge --ff-only feature/branch` - this is atomic (pointer move, no intermediate states)
-- If `--ff-only` fails, go back to the worktree and rebase/merge until it can fast-forward
+- Local `main` is a mirror of `origin/main`; do not commit to it, merge into it, or self-host from it.
+- Local `dev` is the self-hosted integration branch. It is rebuilt from `origin/main` plus pending PR heads.
+- Do not edit production behavior directly on `dev`.
+- If a change is needed on `dev`, create or update a PR against `origin/main`, then apply that PR head to `dev`.
+- If applying a PR to `dev` needs semantic conflict resolution, stop and fix the PR branch or create a replacement PR. Do not hide behavior changes in a local-only `dev` merge commit.
+- Never run `git merge` directly on `main`.
+- Never reset, force-push, or fast-forward local `main` unless the user explicitly asks to realign it to `origin/main`, the running server is no longer using `main`, and the intentional OpenCode notification-argument removal has been preserved in a PR that is included in `dev`.
+- We cannot approve our own PRs. `dev` may contain unapproved pending work, but `origin/main` changes still require independent review.
 
 ## Process Safety (CRITICAL)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Freshell is a self-hosted, browser-accessible terminal multiplexer and session o
 - If a change is needed on `dev`, create or update a PR against `origin/main`, then apply that PR head to `dev`.
 - If applying a PR to `dev` needs semantic conflict resolution, stop and fix the PR branch or create a replacement PR. Do not hide behavior changes in a local-only `dev` merge commit.
 - Never run `git merge` directly on `main`.
-- Never reset, force-push, or fast-forward local `main` unless the user explicitly asks to realign it to `origin/main`, the running server is no longer using `main`, and the intentional OpenCode notification-argument removal has been preserved in a PR that is included in `dev`.
+- Never reset, force-push, or fast-forward local `main` during ordinary work. If the user explicitly asks to refresh the mirror, first verify Freshell is self-hosting from `dev` and local `main` has no work to preserve.
 - We cannot approve our own PRs. `dev` may contain unapproved pending work, but `origin/main` changes still require independent review.
 
 ## Process Safety (CRITICAL)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Freshell is a self-hosted, browser-accessible terminal multiplexer and session o
 
 - Local `main` is a mirror of `origin/main`; do not commit to it, merge into it, or self-host from it.
 - Local `dev` is the self-hosted integration branch. It is rebuilt from `origin/main` plus pending PR heads.
+- The repo root normally remains on local `main`; use `.worktrees/dev` as the self-hosted integration checkout and create separate worktrees for authored changes.
 - Do not edit production behavior directly on `dev`.
 - If a change is needed on `dev`, create or update a PR against `origin/main`, then apply that PR head to `dev`.
 - If applying a PR to `dev` needs semantic conflict resolution, stop and fix the PR branch or create a replacement PR. Do not hide behavior changes in a local-only `dev` merge commit.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Drop a directory with a `freshell.json` manifest into `~/.freshell/extensions/` 
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome. Start from `origin/main`, submit a Pull Request against `main`, and keep behavior changes on PR branches. Local development self-hosting uses the `dev` integration branch described in [docs/development/branch-model.md](docs/development/branch-model.md).
 
 ## Community Projects
 

--- a/docs/development/branch-model.md
+++ b/docs/development/branch-model.md
@@ -67,7 +67,9 @@ npm run dev:queue -- assemble --prs 323,321,309,319,324,326,325,322
 
 Use replacement PR numbers instead of external or superseded PRs. If the script stops on a conflict, do not resolve the conflict on `dev`. Abort the merge, fix the PR branch, and rerun the queue.
 
-Initial migration queue:
+Current `dev` queue snapshot:
+
+Refresh this list before rebuilding `dev`; PR heads may move as branches are amended.
 
 | PR | Head SHA | Purpose |
 | --- | --- | --- |
@@ -80,18 +82,18 @@ Initial migration queue:
 | #325 | Current PR head | Intentional removal of broken Codex notification launch args |
 | #322 | Current PR head | Replacement for externally-owned factory terminal orchestration PR |
 
-Initial migration exclusions:
+Current queue exclusions:
 
 | PR | Head SHA | Reason |
 | --- | --- | --- |
 | #297 | `8cad328c158a6b33d9779ce1748bfe725ecd0d1c` | Externally-owned and superseded by #322 |
 | #289 | `4e4782699adadc3e006b96143f6ead6bda8b136d` | Draft approval artifact |
 
-## Local Main Realignment
+## Local Main Mirror
 
-Only realign local `main` after Freshell is self-hosting from `dev`, the user has explicitly approved the reset, and the intentional OpenCode notification-argument removal has been preserved in an open PR that is included in `dev` or confirmed already present in a selected pending PR.
+Local `main` is a read-only mirror of `origin/main`. It should contain no local-only work and should not host the running Freshell server.
 
-The intended final state is:
+Do not commit to, merge into, or fast-forward local `main` during ordinary development. If the user explicitly asks to refresh the mirror, first verify Freshell is self-hosting from local `dev`, then use:
 
 ```bash
 git switch main
@@ -99,4 +101,4 @@ git fetch origin
 git reset --hard origin/main
 ```
 
-Do not run that command during ordinary development. It belongs only to the migration task that realigns local `main` after self-hosting has moved to `dev`.
+Only run this when preserving local `main` history is not required.

--- a/docs/development/branch-model.md
+++ b/docs/development/branch-model.md
@@ -53,7 +53,7 @@ Use an explicit queue. Do not blindly apply every open PR.
 Example:
 
 ```bash
-npm run dev:queue -- plan --prs 321,309,319
+npm run dev:queue -- plan --prs 323,321,309,319,322
 ```
 
 The queue script must fail if a PR is draft, closed, not targeting `main`, or cannot be applied cleanly. Fix PR branches before rebuilding `dev`.
@@ -62,10 +62,27 @@ To rebuild local `dev`:
 
 ```bash
 git switch dev
-npm run dev:queue -- assemble --prs 321,309,319
+npm run dev:queue -- assemble --prs 323,321,309,319,322
 ```
 
 Use replacement PR numbers instead of external or superseded PRs. If the script stops on a conflict, do not resolve the conflict on `dev`. Abort the merge, fix the PR branch, and rerun the queue.
+
+Initial migration queue:
+
+| PR | Head SHA | Purpose |
+| --- | --- | --- |
+| #323 | Current PR head | `dev` branch workflow, launch guardrails, and queue tooling |
+| #321 | `7eae9acf13d2ecf36de6ecade8354cb22b944f7b` | Sidebar reopen corner behavior |
+| #309 | `93c0e15f8b3e04d7e1bbd8ab312619ae28cfefa2` | Codex startup cwd fix |
+| #319 | `a66568daf0dfd0dd447cc217d6f4c39d1cf22398` | OpenCode native scroll behavior |
+| #322 | `0a334be42553929aed033c3aa3920d0bf58a2a65` | Replacement for externally-owned factory terminal orchestration PR |
+
+Initial migration exclusions:
+
+| PR | Head SHA | Reason |
+| --- | --- | --- |
+| #297 | `8cad328c158a6b33d9779ce1748bfe725ecd0d1c` | Externally-owned and superseded by #322 |
+| #289 | `4e4782699adadc3e006b96143f6ead6bda8b136d` | Draft approval artifact |
 
 ## Local Main Realignment
 

--- a/docs/development/branch-model.md
+++ b/docs/development/branch-model.md
@@ -58,6 +58,15 @@ npm run dev:queue -- plan --prs 321,309,319
 
 The queue script must fail if a PR is draft, closed, not targeting `main`, or cannot be applied cleanly. Fix PR branches before rebuilding `dev`.
 
+To rebuild local `dev`:
+
+```bash
+git switch dev
+npm run dev:queue -- assemble --prs 321,309,319
+```
+
+Use replacement PR numbers instead of external or superseded PRs. If the script stops on a conflict, do not resolve the conflict on `dev`. Abort the merge, fix the PR branch, and rerun the queue.
+
 ## Local Main Realignment
 
 Only realign local `main` after Freshell is self-hosting from `dev`, the user has explicitly approved the reset, and the intentional OpenCode notification-argument removal has been preserved in an open PR that is included in `dev` or confirmed already present in a selected pending PR.

--- a/docs/development/branch-model.md
+++ b/docs/development/branch-model.md
@@ -78,7 +78,7 @@ Initial migration queue:
 | #324 | `fc8a953565c8c4e416fc7bc0e951b0888c8ed421` | Durable session restore identity parity |
 | #326 | Current PR head | Codex sidecar resilience parity |
 | #325 | Current PR head | Intentional removal of broken Codex notification launch args |
-| #322 | `26601cec20434790936af3a3f9cc823c8c19f984` | Replacement for externally-owned factory terminal orchestration PR |
+| #322 | Current PR head | Replacement for externally-owned factory terminal orchestration PR |
 
 Initial migration exclusions:
 

--- a/docs/development/branch-model.md
+++ b/docs/development/branch-model.md
@@ -74,7 +74,7 @@ Initial migration queue:
 | #323 | Current PR head | `dev` branch workflow, launch guardrails, and queue tooling |
 | #321 | `7eae9acf13d2ecf36de6ecade8354cb22b944f7b` | Sidebar reopen corner behavior |
 | #309 | `93c0e15f8b3e04d7e1bbd8ab312619ae28cfefa2` | Codex startup cwd fix |
-| #319 | `a66568daf0dfd0dd447cc217d6f4c39d1cf22398` | OpenCode native scroll behavior |
+| #319 | `48927eef6b46a2232ebe31d1e1dea38d2203eb72` | OpenCode native scroll behavior |
 | #322 | `0a334be42553929aed033c3aa3920d0bf58a2a65` | Replacement for externally-owned factory terminal orchestration PR |
 
 Initial migration exclusions:

--- a/docs/development/branch-model.md
+++ b/docs/development/branch-model.md
@@ -53,7 +53,7 @@ Use an explicit queue. Do not blindly apply every open PR.
 Example:
 
 ```bash
-npm run dev:queue -- plan --prs 323,321,309,319,322
+npm run dev:queue -- plan --prs 323,321,309,319,324,326,325,322
 ```
 
 The queue script must fail if a PR is draft, closed, not targeting `main`, or cannot be applied cleanly. Fix PR branches before rebuilding `dev`.
@@ -62,7 +62,7 @@ To rebuild local `dev`:
 
 ```bash
 git switch dev
-npm run dev:queue -- assemble --prs 323,321,309,319,322
+npm run dev:queue -- assemble --prs 323,321,309,319,324,326,325,322
 ```
 
 Use replacement PR numbers instead of external or superseded PRs. If the script stops on a conflict, do not resolve the conflict on `dev`. Abort the merge, fix the PR branch, and rerun the queue.
@@ -75,7 +75,10 @@ Initial migration queue:
 | #321 | `7eae9acf13d2ecf36de6ecade8354cb22b944f7b` | Sidebar reopen corner behavior |
 | #309 | `93c0e15f8b3e04d7e1bbd8ab312619ae28cfefa2` | Codex startup cwd fix |
 | #319 | `48927eef6b46a2232ebe31d1e1dea38d2203eb72` | OpenCode native scroll behavior |
-| #322 | `0a334be42553929aed033c3aa3920d0bf58a2a65` | Replacement for externally-owned factory terminal orchestration PR |
+| #324 | `fc8a953565c8c4e416fc7bc0e951b0888c8ed421` | Durable session restore identity parity |
+| #326 | Current PR head | Codex sidecar resilience parity |
+| #325 | Current PR head | Intentional removal of broken Codex notification launch args |
+| #322 | `26601cec20434790936af3a3f9cc823c8c19f984` | Replacement for externally-owned factory terminal orchestration PR |
 
 Initial migration exclusions:
 

--- a/docs/development/branch-model.md
+++ b/docs/development/branch-model.md
@@ -46,6 +46,18 @@ Do not resolve semantic conflicts only on `dev`. `dev` must remain reproducible 
 
 Draft PRs, do-not-merge PRs, closed PRs, superseded PRs, and approval artifacts are excluded from `dev` unless the user explicitly says otherwise.
 
+## Building `dev`
+
+Use an explicit queue. Do not blindly apply every open PR.
+
+Example:
+
+```bash
+npm run dev:queue -- plan --prs 321,309,319
+```
+
+The queue script must fail if a PR is draft, closed, not targeting `main`, or cannot be applied cleanly. Fix PR branches before rebuilding `dev`.
+
 ## Local Main Realignment
 
 Only realign local `main` after Freshell is self-hosting from `dev`, the user has explicitly approved the reset, and the intentional OpenCode notification-argument removal has been preserved in an open PR that is included in `dev` or confirmed already present in a selected pending PR.

--- a/docs/development/branch-model.md
+++ b/docs/development/branch-model.md
@@ -1,0 +1,61 @@
+# Branch Model
+
+Freshell development uses two local integration concepts:
+
+- `main`: exact mirror of `origin/main`
+- `dev`: self-hosted local integration branch
+
+## Branch Responsibilities
+
+`main` is disposable. It should always be resettable to `origin/main` with no local work lost.
+
+`dev` is where the local Freshell instance runs. It is assembled from `origin/main` plus pending PR heads. It is not where new behavior is authored.
+
+## Pending PR Definition
+
+A PR is pending for `dev` only when all of these are true:
+
+- It is open.
+- It targets `main`.
+- It is not draft.
+- It is not marked do-not-merge, superseded, or approval-artifact-only.
+- The user wants it in the self-hosted integration queue.
+- Its branch applies cleanly to `origin/main`, or its branch has been updated so it does.
+
+If a PR cannot be amended because it comes from an external fork, create a replacement PR before adding that behavior to `dev`.
+
+## Change Flow
+
+1. Start work from `origin/main` in a worktree.
+2. Implement the change.
+3. Push a PR against `origin/main`.
+4. Add that PR head to local `dev`.
+5. Wait for independent review before merging the PR to `origin/main`.
+
+Never put behavior changes only on `dev`.
+
+## Conflict Policy
+
+If a PR conflicts with `origin/main`, fix the PR branch.
+
+If two pending PRs conflict with each other, fix one or both PR branches.
+
+Do not resolve semantic conflicts only on `dev`. `dev` must remain reproducible from `origin/main` plus PR heads.
+
+## Excluded PRs
+
+Draft PRs, do-not-merge PRs, closed PRs, superseded PRs, and approval artifacts are excluded from `dev` unless the user explicitly says otherwise.
+
+## Local Main Realignment
+
+Only realign local `main` after Freshell is self-hosting from `dev`, the user has explicitly approved the reset, and the intentional OpenCode notification-argument removal has been preserved in an open PR that is included in `dev` or confirmed already present in a selected pending PR.
+
+The intended final state is:
+
+```bash
+git switch main
+git fetch origin
+git reset --hard origin/main
+```
+
+Do not run that command during ordinary development. It belongs only to the migration task that realigns local `main` after self-hosting has moved to `dev`.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "dev": "cross-env PORT=3002 concurrently -n client,server -c blue,green \"vite\" \"tsx watch server/index.ts\"",
     "dev:client": "vite",
     "dev:server": "cross-env PORT=3002 tsx watch server/index.ts",
+    "dev:queue": "tsx scripts/dev-pr-queue.ts",
+    "selfhost:check-branch": "tsx scripts/selfhost-branch.ts validate-launch",
     "typecheck": "npm run typecheck:client && npm run typecheck:server",
     "typecheck:client": "tsc -p tsconfig.json --noEmit",
     "typecheck:server": "tsc -p tsconfig.server.json --noEmit",

--- a/scripts/dev-pr-queue.ts
+++ b/scripts/dev-pr-queue.ts
@@ -1,0 +1,283 @@
+#!/usr/bin/env tsx
+
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+const REPO = 'danshapiro/freshell'
+const PR_JSON_FIELDS = 'number,state,isDraft,baseRefName,headRefOid,mergeStateStatus,title,labels'
+const EXCLUDED_LABELS = new Set([
+  'do-not-merge',
+  'superseded',
+  'approval-artifact',
+  'approval-artifact-only',
+])
+
+export type DevQueuePr = {
+  number: number
+  state: 'OPEN' | 'CLOSED' | string
+  isDraft: boolean
+  baseRefName: string
+  headRefOid: string
+  mergeStateStatus: string
+  title: string
+  labels: Array<{ name: string }>
+}
+
+export type DevQueuePlanStep = {
+  label: string
+  command: string[]
+}
+
+export type DevQueuePlan = {
+  originMain: string
+  steps: DevQueuePlanStep[]
+}
+
+export type DevQueueCommandRunner = (command: string, args: string[]) => Promise<string>
+
+export function parsePrList(input: string): number[] {
+  const prs = input
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => Number(part))
+
+  if (prs.length === 0 || prs.some((number) => !Number.isInteger(number) || number <= 0)) {
+    throw new Error('At least one PR number is required, formatted like 321,309,319.')
+  }
+
+  return prs
+}
+
+export function buildPrMetadataCommand(number: number): [string, string[]] {
+  return [
+    'gh',
+    [
+      'pr',
+      'view',
+      String(number),
+      '--repo',
+      REPO,
+      '--json',
+      PR_JSON_FIELDS,
+    ],
+  ]
+}
+
+export async function loadPrMetadata(
+  numbers: number[],
+  run: DevQueueCommandRunner,
+): Promise<DevQueuePr[]> {
+  const prs: DevQueuePr[] = []
+  for (const number of numbers) {
+    const [command, args] = buildPrMetadataCommand(number)
+    const stdout = await run(command, args)
+    try {
+      prs.push(JSON.parse(stdout) as DevQueuePr)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`Failed to parse gh metadata for PR #${number}: ${message}`)
+    }
+  }
+  return prs
+}
+
+function validatePrForDev(pr: DevQueuePr): void {
+  if (pr.state !== 'OPEN') {
+    throw new Error(`PR #${pr.number} is ${pr.state}, expected OPEN.`)
+  }
+  if (pr.isDraft) {
+    throw new Error(`PR #${pr.number} is draft and is not pending for dev.`)
+  }
+  if (pr.baseRefName !== 'main') {
+    throw new Error(`PR #${pr.number} targets ${pr.baseRefName}, expected main.`)
+  }
+
+  const excludedLabel = pr.labels.find((label) => EXCLUDED_LABELS.has(label.name.toLowerCase()))
+  if (excludedLabel) {
+    throw new Error(`PR #${pr.number} is labeled ${excludedLabel.name} and is not pending for dev.`)
+  }
+}
+
+export function buildDevQueuePlan(input: {
+  originMain: string
+  requestedPrs: number[]
+  prs: DevQueuePr[]
+}): DevQueuePlan {
+  const byNumber = new Map(input.prs.map((pr) => [pr.number, pr]))
+
+  for (const number of input.requestedPrs) {
+    const pr = byNumber.get(number)
+    if (!pr) {
+      throw new Error(`PR #${number} was not found.`)
+    }
+    validatePrForDev(pr)
+  }
+
+  const steps: DevQueuePlanStep[] = [
+    { label: 'fetch-origin-main', command: ['git', 'fetch', 'origin', 'main'] },
+    { label: 'reset-dev-to-origin-main', command: ['git', 'reset', '--hard', input.originMain] },
+  ]
+
+  for (const number of input.requestedPrs) {
+    steps.push({
+      label: `fetch-pr-${number}`,
+      command: ['git', 'fetch', 'origin', `+refs/pull/${number}/head:refs/remotes/pr/${number}`],
+    })
+    steps.push({
+      label: `merge-pr-${number}`,
+      command: ['git', 'merge', '--no-ff', '--no-edit', `refs/remotes/pr/${number}`],
+    })
+  }
+
+  return { originMain: input.originMain, steps }
+}
+
+export async function assertAssemblePreconditions(input: {
+  getBranch: () => Promise<string | undefined>
+  getStatus: () => Promise<string>
+}): Promise<void> {
+  const branch = await input.getBranch()
+  if (branch !== 'dev') {
+    throw new Error(`Refusing to assemble dev from ${branch ?? 'an unknown branch'}. Switch to dev first.`)
+  }
+
+  const status = await input.getStatus()
+  if (status.trim()) {
+    throw new Error('Refusing to reset dev with a dirty worktree. Commit, stash, or discard local changes first.')
+  }
+}
+
+export async function executeDevQueuePlan(
+  plan: DevQueuePlan,
+  run: DevQueueCommandRunner,
+): Promise<void> {
+  for (const step of plan.steps) {
+    try {
+      await run(step.command[0], step.command.slice(1))
+    } catch (error) {
+      const mergePrMatch = step.label.match(/^merge-pr-(\d+)$/)
+      if (mergePrMatch) {
+        throw new Error(`PR #${mergePrMatch[1]} did not merge cleanly. Fix the PR branch, abort the merge, and rerun the dev queue.`)
+      }
+
+      const cherryPickPrMatch = step.label.match(/^cherry-pick-pr-(\d+)$/)
+      if (cherryPickPrMatch) {
+        throw new Error(`PR #${cherryPickPrMatch[1]} did not cherry-pick cleanly. Fix the PR branch, abort the cherry-pick, and rerun the dev queue.`)
+      }
+
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`Step ${step.label} failed: ${message}`)
+    }
+  }
+}
+
+export async function assembleDevQueue(input: {
+  requestedPrs: number[]
+  run: DevQueueCommandRunner
+  getBranch: () => Promise<string | undefined>
+  getStatus: () => Promise<string>
+}): Promise<void> {
+  await assertAssemblePreconditions(input)
+  await input.run('git', ['fetch', 'origin', 'main'])
+  const originMain = await input.run('git', ['rev-parse', 'origin/main'])
+  const prs = await loadPrMetadata(input.requestedPrs, input.run)
+  const plan = buildDevQueuePlan({ originMain, requestedPrs: input.requestedPrs, prs })
+  await executeDevQueuePlan(plan, input.run)
+}
+
+const runCommand: DevQueueCommandRunner = async (command, args) => {
+  try {
+    const { stdout } = await execFileAsync(command, args, { encoding: 'utf8' })
+    return stdout.trim()
+  } catch (error) {
+    if (error instanceof Error) {
+      const details = error as Error & { stderr?: string; stdout?: string }
+      const output = [details.stderr, details.stdout]
+        .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+        .map((value) => value.trim())
+        .join('\n')
+      if (output) {
+        throw new Error(output)
+      }
+      throw error
+    }
+    throw new Error(String(error))
+  }
+}
+
+function printUsage(): void {
+  console.log('Usage: tsx scripts/dev-pr-queue.ts plan --prs 321,309,319')
+  console.log('       tsx scripts/dev-pr-queue.ts assemble --prs 321,309,319')
+}
+
+function parseCliPrList(argv: string[]): number[] {
+  const prsFlagIndex = argv.indexOf('--prs')
+  const prsValue = prsFlagIndex >= 0 ? argv[prsFlagIndex + 1] : ''
+  return parsePrList(prsValue)
+}
+
+async function buildPlanForCli(requestedPrs: number[]): Promise<{
+  plan: DevQueuePlan
+  prs: DevQueuePr[]
+}> {
+  await runCommand('git', ['fetch', 'origin', 'main'])
+  const originMain = await runCommand('git', ['rev-parse', 'origin/main'])
+  const prs = await loadPrMetadata(requestedPrs, runCommand)
+  const plan = buildDevQueuePlan({ originMain, requestedPrs, prs })
+  return { plan, prs }
+}
+
+export async function main(argv: string[]): Promise<number> {
+  const command = argv[0]
+  if (!command || command === '--help' || command === '-h') {
+    printUsage()
+    return command ? 0 : 2
+  }
+
+  try {
+    const requestedPrs = parseCliPrList(argv)
+
+    if (command === 'plan') {
+      const { plan, prs } = await buildPlanForCli(requestedPrs)
+      for (const step of plan.steps) {
+        console.log(`${step.label}: ${step.command.join(' ')}`)
+      }
+      console.log(`origin/main: ${plan.originMain}`)
+      for (const pr of prs) {
+        console.log(`PR #${pr.number}: ${pr.headRefOid}`)
+      }
+      return 0
+    }
+
+    if (command === 'assemble') {
+      console.log('This will reset local dev to origin/main before applying PRs.')
+      console.log('Refusing to continue unless current branch is dev and worktree is clean.')
+      await assembleDevQueue({
+        requestedPrs,
+        run: runCommand,
+        getBranch: async () => {
+          const branch = await runCommand('git', ['branch', '--show-current'])
+          return branch || undefined
+        },
+        getStatus: async () => runCommand('git', ['status', '--porcelain']),
+      })
+      console.log('Local dev has been reset to origin/main and updated with the requested PR heads.')
+      return 0
+    }
+
+    console.error(`Unsupported command: ${command}`)
+    printUsage()
+    return 2
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(message)
+    return 1
+  }
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'))) {
+  main(process.argv.slice(2)).then((code) => process.exit(code))
+}

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,20 +1,29 @@
 #!/usr/bin/env bash
-# Launch Freshell: pull upstream, build, start server in background.
+# Launch Freshell: build, start server in background.
 
 set -euo pipefail
 
 FRESHELL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-FRESHELL_HOME="$HOME/.freshell"
+FRESHELL_HOME="${FRESHELL_HOME:-$HOME/.freshell}"
 LOG_FILE="$FRESHELL_HOME/logs/server.log"
 URL_FILE="$FRESHELL_HOME/url"
 PID_FILE="$FRESHELL_HOME/server.pid"
 
 cd "$FRESHELL_DIR"
 
-# Check for already-running server (verify PID is actually a node process from this project)
+is_freshell_pid() {
+  local pid="$1"
+  local cwd=""
+  local args=""
+  cwd="$(readlink "/proc/$pid/cwd" 2>/dev/null || true)"
+  args="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+  [[ "$cwd" == "$FRESHELL_DIR" && ( "$args" == *"dist/server/index.js"* || "$args" == *"npm start"* ) ]]
+}
+
+# Check for already-running server (verify PID belongs to this project)
 if [[ -f "$PID_FILE" ]]; then
   saved_pid="$(cat "$PID_FILE")"
-  if kill -0 "$saved_pid" 2>/dev/null && ps -p "$saved_pid" -o args= 2>/dev/null | grep -q "dist/server/index.js"; then
+  if kill -0 "$saved_pid" 2>/dev/null && is_freshell_pid "$saved_pid"; then
     echo "freshell is already running (pid $saved_pid)"
     if [[ -f "$URL_FILE" ]]; then
       echo "  $(cat "$URL_FILE")"
@@ -25,30 +34,8 @@ if [[ -f "$PID_FILE" ]]; then
   fi
 fi
 
-# Pull latest from upstream (only on main)
-current_branch="$(git branch --show-current)"
-if [[ "$current_branch" == "main" ]]; then
-  echo "Pulling latest from upstream..."
-  if git remote get-url upstream >/dev/null 2>&1; then
-    git fetch upstream
-    if git merge-base --is-ancestor upstream/main HEAD 2>/dev/null; then
-      echo "  Already up to date."
-    elif git merge --ff-only upstream/main 2>/dev/null; then
-      echo "  Merged upstream changes."
-    else
-      echo "  Local main has diverged from upstream. Resetting to upstream/main..."
-      git reset --hard upstream/main
-      echo "  Done."
-    fi
-  else
-    echo "  No upstream remote, skipping pull."
-  fi
-
-  echo "Pushing to origin..."
-  git push origin main 2>/dev/null && echo "  Done." || echo "  Push failed (non-fatal)."
-else
-  echo "Warning: on branch '$current_branch', skipping upstream pull. Switch to main for auto-update."
-fi
+echo "Checking self-host branch..."
+npx tsx scripts/selfhost-branch.ts validate-launch
 
 # Build
 echo "Building..."
@@ -59,7 +46,7 @@ echo "Starting server..."
 mkdir -p "$(dirname "$LOG_FILE")"
 rm -f "$URL_FILE"
 
-NODE_ENV=production node dist/server/index.js > "$LOG_FILE" 2>&1 &
+npm start > "$LOG_FILE" 2>&1 &
 SERVER_PID=$!
 echo "$SERVER_PID" > "$PID_FILE"
 

--- a/scripts/precheck.ts
+++ b/scripts/precheck.ts
@@ -10,6 +10,7 @@
  */
 
 import { readFileSync } from 'fs'
+import { execFileSync } from 'child_process'
 import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { createRequire } from 'module'
@@ -27,6 +28,18 @@ function getPackageVersion(): string {
     return pkg.version || '0.0.0'
   } catch {
     return '0.0.0'
+  }
+}
+
+function getCurrentBranch(): string | undefined {
+  try {
+    return execFileSync('git', ['branch', '--show-current'], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim() || undefined
+  } catch {
+    return undefined
   }
 }
 
@@ -182,7 +195,7 @@ async function checkVitePort(): Promise<PortCheckResult> {
 
 async function main(): Promise<void> {
   // 1. Check for updates first (before anything else can fail)
-  if (!shouldSkipUpdateCheck()) {
+  if (!shouldSkipUpdateCheck({ branch: getCurrentBranch() })) {
     const currentVersion = getPackageVersion()
     const updateResult = await runUpdateCheck(currentVersion)
 

--- a/scripts/selfhost-branch.ts
+++ b/scripts/selfhost-branch.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env tsx
+
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { pathToFileURL } from 'url'
+import { classifySelfHostBranch, type SelfHostPolicyEnv } from '../shared/selfhost-branch-policy.js'
+
+const execFileAsync = promisify(execFile)
+
+export type LaunchBranchValidation =
+  | { ok: true; branch: string }
+  | { ok: false; message: string }
+
+export async function getCurrentGitBranch(cwd: string = process.cwd()): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync('git', ['branch', '--show-current'], { cwd })
+    return stdout.trim() || undefined
+  } catch {
+    return undefined
+  }
+}
+
+export async function validateLaunchBranch(input: {
+  env: SelfHostPolicyEnv
+  getBranch?: () => Promise<string | undefined>
+}): Promise<LaunchBranchValidation> {
+  const branch = await (input.getBranch ?? (() => getCurrentGitBranch()))()
+  const result = classifySelfHostBranch({ branch, env: input.env })
+  if (result.ok === true) return { ok: true, branch: branch ?? result.expectedBranch }
+  return { ok: false, message: result.message }
+}
+
+async function main(argv: string[]): Promise<number> {
+  const command = argv[0]
+  if (command !== 'validate-launch') {
+    console.error('Usage: tsx scripts/selfhost-branch.ts validate-launch')
+    return 2
+  }
+
+  const result = await validateLaunchBranch({ env: process.env })
+  if (result.ok === false) {
+    console.error(result.message)
+    return 1
+  }
+
+  return 0
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).then((code) => process.exit(code))
+}

--- a/server/updater/index.ts
+++ b/server/updater/index.ts
@@ -2,6 +2,7 @@
 import { checkForUpdate } from './version-checker.js'
 import { promptForUpdate } from './prompt.js'
 import { executeUpdate, type UpdateProgress } from './executor.js'
+import { shouldSkipSourceUpdateForBranch } from '../../shared/selfhost-branch-policy.js'
 
 export type UpdateAction = 'none' | 'updated' | 'skipped' | 'error' | 'check-failed'
 
@@ -67,6 +68,7 @@ export async function runUpdateCheck(currentVersion: string): Promise<UpdateChec
  * - --skip-update-check CLI flag is present
  * - SKIP_UPDATE_CHECK env var is 'true'
  * - Running via 'npm run dev' (predev lifecycle event)
+ * - Current branch is not main or cannot be determined
  *
  * Does NOT skip based on NODE_ENV because that may be set persistently
  * in dev environments even when running 'npm run serve'.
@@ -74,6 +76,7 @@ export async function runUpdateCheck(currentVersion: string): Promise<UpdateChec
 export interface SkipCheckOptions {
   argv?: string[]
   env?: NodeJS.ProcessEnv
+  branch?: string
 }
 
 export function shouldSkipUpdateCheck(options: SkipCheckOptions = {}): boolean {
@@ -83,6 +86,7 @@ export function shouldSkipUpdateCheck(options: SkipCheckOptions = {}): boolean {
   if (argv.includes('--skip-update-check')) return true
   if (env.SKIP_UPDATE_CHECK === 'true') return true
   if (env.npm_lifecycle_event === 'predev') return true
+  if (shouldSkipSourceUpdateForBranch({ branch: options.branch, env })) return true
 
   return false
 }

--- a/shared/selfhost-branch-policy.ts
+++ b/shared/selfhost-branch-policy.ts
@@ -1,0 +1,58 @@
+export type SelfHostPolicyEnv = {
+  FRESHELL_SELFHOST_BRANCH?: string
+  SKIP_UPDATE_CHECK?: string
+}
+
+export type SelfHostBranchResult =
+  | { ok: true; expectedBranch: string }
+  | { ok: false; code: 'mirror-branch' | 'unexpected-branch' | 'unknown-branch'; message: string }
+
+export function getExpectedSelfHostBranch(env: SelfHostPolicyEnv): string {
+  const configured = env.FRESHELL_SELFHOST_BRANCH?.trim()
+  if (!configured || configured === 'main') return 'dev'
+  return configured
+}
+
+export function classifySelfHostBranch(input: {
+  branch: string | undefined
+  env: SelfHostPolicyEnv
+}): SelfHostBranchResult {
+  const expectedBranch = getExpectedSelfHostBranch(input.env)
+  const branch = input.branch?.trim()
+
+  if (!branch) {
+    return {
+      ok: false,
+      code: 'unknown-branch',
+      message: `Could not determine the current Git branch. Switch to '${expectedBranch}' before self-hosting.`,
+    }
+  }
+
+  if (branch === 'main') {
+    return {
+      ok: false,
+      code: 'mirror-branch',
+      message: `Refusing to self-host from local 'main'. Local 'main' must mirror 'origin/main'. Switch to '${expectedBranch}' or set FRESHELL_SELFHOST_BRANCH.`,
+    }
+  }
+
+  if (branch === expectedBranch) {
+    return { ok: true, expectedBranch }
+  }
+
+  return {
+    ok: false,
+    code: 'unexpected-branch',
+    message: `Refusing to self-host from '${branch}'. Expected '${expectedBranch}'. Set FRESHELL_SELFHOST_BRANCH only if the user explicitly chose another integration branch.`,
+  }
+}
+
+export function shouldSkipSourceUpdateForBranch(input: {
+  branch: string | undefined
+  env: SelfHostPolicyEnv
+}): boolean {
+  if (input.env.SKIP_UPDATE_CHECK === 'true') return true
+  const branch = input.branch?.trim()
+  if (!branch) return true
+  return branch !== 'main'
+}

--- a/test/unit/scripts/dev-pr-queue.test.ts
+++ b/test/unit/scripts/dev-pr-queue.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assembleDevQueue,
+  assertAssemblePreconditions,
+  buildDevQueuePlan,
+  buildPrMetadataCommand,
+  executeDevQueuePlan,
+  loadPrMetadata,
+  parsePrList,
+  type DevQueuePr,
+} from '../../../scripts/dev-pr-queue.js'
+
+const pr = (input: Partial<DevQueuePr> & Pick<DevQueuePr, 'number'>): DevQueuePr => ({
+  number: input.number,
+  state: input.state ?? 'OPEN',
+  isDraft: input.isDraft ?? false,
+  baseRefName: input.baseRefName ?? 'main',
+  headRefOid: input.headRefOid ?? `sha-${input.number}`,
+  mergeStateStatus: input.mergeStateStatus ?? 'CLEAN',
+  title: input.title ?? `PR ${input.number}`,
+  labels: input.labels ?? [],
+})
+
+describe('dev PR queue planner', () => {
+  it('parses explicit PR numbers', () => {
+    expect(parsePrList('321,309,319')).toEqual([321, 309, 319])
+  })
+
+  it('rejects empty PR lists', () => {
+    expect(() => parsePrList('')).toThrow('At least one PR number is required')
+  })
+
+  it('rejects malformed PR lists', () => {
+    expect(() => parsePrList('321,nope')).toThrow('At least one PR number is required')
+    expect(() => parsePrList('0')).toThrow('At least one PR number is required')
+  })
+
+  it('plans origin/main plus PR heads in the requested order', () => {
+    const plan = buildDevQueuePlan({
+      originMain: 'origin-sha',
+      requestedPrs: [321, 309],
+      prs: [pr({ number: 321 }), pr({ number: 309 })],
+    })
+
+    expect(plan.steps.map((step) => step.label)).toEqual([
+      'fetch-origin-main',
+      'reset-dev-to-origin-main',
+      'fetch-pr-321',
+      'merge-pr-321',
+      'fetch-pr-309',
+      'merge-pr-309',
+    ])
+  })
+
+  it('uses no-ff merges so PR boundaries remain visible on dev', () => {
+    const plan = buildDevQueuePlan({
+      originMain: 'origin-sha',
+      requestedPrs: [321],
+      prs: [pr({ number: 321 })],
+    })
+
+    expect(plan.steps.find((step) => step.label === 'merge-pr-321')?.command).toEqual([
+      'git',
+      'merge',
+      '--no-ff',
+      '--no-edit',
+      'refs/remotes/pr/321',
+    ])
+  })
+
+  it('rejects missing metadata for requested PRs', () => {
+    expect(() => buildDevQueuePlan({
+      originMain: 'origin-sha',
+      requestedPrs: [321],
+      prs: [],
+    })).toThrow('PR #321 was not found')
+  })
+
+  it('rejects draft PRs', () => {
+    expect(() => buildDevQueuePlan({
+      originMain: 'origin-sha',
+      requestedPrs: [289],
+      prs: [pr({ number: 289, isDraft: true })],
+    })).toThrow('PR #289 is draft')
+  })
+
+  it('rejects closed PRs', () => {
+    expect(() => buildDevQueuePlan({
+      originMain: 'origin-sha',
+      requestedPrs: [310],
+      prs: [pr({ number: 310, state: 'CLOSED' })],
+    })).toThrow('PR #310 is CLOSED, expected OPEN')
+  })
+
+  it('rejects PRs that do not target main', () => {
+    expect(() => buildDevQueuePlan({
+      originMain: 'origin-sha',
+      requestedPrs: [310],
+      prs: [pr({ number: 310, baseRefName: 'other' })],
+    })).toThrow('PR #310 targets other, expected main')
+  })
+
+  it('rejects do-not-merge labels', () => {
+    expect(() => buildDevQueuePlan({
+      originMain: 'origin-sha',
+      requestedPrs: [289],
+      prs: [pr({ number: 289, labels: [{ name: 'do-not-merge' }] })],
+    })).toThrow('PR #289 is labeled do-not-merge')
+  })
+
+  it('rejects superseded and approval-artifact labels', () => {
+    expect(() => buildDevQueuePlan({
+      originMain: 'origin-sha',
+      requestedPrs: [310],
+      prs: [pr({ number: 310, labels: [{ name: 'superseded' }] })],
+    })).toThrow('PR #310 is labeled superseded')
+
+    expect(() => buildDevQueuePlan({
+      originMain: 'origin-sha',
+      requestedPrs: [311],
+      prs: [pr({ number: 311, labels: [{ name: 'approval-artifact-only' }] })],
+    })).toThrow('PR #311 is labeled approval-artifact-only')
+
+    expect(() => buildDevQueuePlan({
+      originMain: 'origin-sha',
+      requestedPrs: [312],
+      prs: [pr({ number: 312, labels: [{ name: 'approval-artifact' }] })],
+    })).toThrow('PR #312 is labeled approval-artifact')
+  })
+
+  it('builds gh commands for exact PR metadata', () => {
+    expect(buildPrMetadataCommand(321)).toEqual([
+      'gh',
+      [
+        'pr',
+        'view',
+        '321',
+        '--repo',
+        'danshapiro/freshell',
+        '--json',
+        'number,state,isDraft,baseRefName,headRefOid,mergeStateStatus,title,labels',
+      ],
+    ])
+  })
+
+  it('loads explicit PR metadata through the injected runner', async () => {
+    const calls: string[] = []
+    const prs = await loadPrMetadata([321, 309], async (command, args) => {
+      calls.push([command, ...args].join(' '))
+      const number = Number(args[2])
+      return JSON.stringify(pr({ number }))
+    })
+
+    expect(prs.map((item) => item.number)).toEqual([321, 309])
+    expect(calls).toEqual([
+      'gh pr view 321 --repo danshapiro/freshell --json number,state,isDraft,baseRefName,headRefOid,mergeStateStatus,title,labels',
+      'gh pr view 309 --repo danshapiro/freshell --json number,state,isDraft,baseRefName,headRefOid,mergeStateStatus,title,labels',
+    ])
+  })
+
+  it('reports invalid gh metadata clearly', async () => {
+    await expect(loadPrMetadata([321], async () => 'not json')).rejects.toThrow(
+      'Failed to parse gh metadata for PR #321',
+    )
+  })
+
+  it('refuses assemble outside dev', async () => {
+    await expect(assertAssemblePreconditions({
+      getBranch: async () => 'feature/x',
+      getStatus: async () => '',
+    })).rejects.toThrow('Refusing to assemble dev from feature/x')
+  })
+
+  it('refuses assemble on an unknown branch', async () => {
+    await expect(assertAssemblePreconditions({
+      getBranch: async () => undefined,
+      getStatus: async () => '',
+    })).rejects.toThrow('Refusing to assemble dev from an unknown branch')
+  })
+
+  it('refuses assemble with a dirty worktree', async () => {
+    await expect(assertAssemblePreconditions({
+      getBranch: async () => 'dev',
+      getStatus: async () => ' M package.json',
+    })).rejects.toThrow('Refusing to reset dev with a dirty worktree')
+  })
+
+  it('stops on the first failed merge and reports the PR', async () => {
+    const executed: string[] = []
+    await expect(executeDevQueuePlan({
+      originMain: 'origin-sha',
+      steps: [
+        { label: 'reset-dev-to-origin-main', command: ['git', 'reset', '--hard', 'origin-sha'] },
+        { label: 'merge-pr-321', command: ['git', 'merge', '--no-ff', '--no-edit', 'refs/remotes/pr/321'] },
+        { label: 'merge-pr-309', command: ['git', 'merge', '--no-ff', '--no-edit', 'refs/remotes/pr/309'] },
+      ],
+    }, async (_command, args) => {
+      executed.push(args.join(' '))
+      if (args.includes('refs/remotes/pr/321')) throw new Error('merge failed')
+      return ''
+    })).rejects.toThrow('PR #321 did not merge cleanly')
+
+    expect(executed).toHaveLength(2)
+  })
+
+  it('stops on the first failed cherry-pick and reports the PR', async () => {
+    await expect(executeDevQueuePlan({
+      originMain: 'origin-sha',
+      steps: [
+        { label: 'cherry-pick-pr-321', command: ['git', 'cherry-pick', 'sha-321'] },
+      ],
+    }, async () => {
+      throw new Error('conflict')
+    })).rejects.toThrow('PR #321 did not cherry-pick cleanly')
+  })
+
+  it('reports non-merge command failures clearly', async () => {
+    await expect(executeDevQueuePlan({
+      originMain: 'origin-sha',
+      steps: [
+        { label: 'fetch-origin-main', command: ['git', 'fetch', 'origin', 'main'] },
+      ],
+    }, async () => {
+      throw new Error('network unavailable')
+    })).rejects.toThrow('Step fetch-origin-main failed: network unavailable')
+  })
+
+  it('validates metadata before resetting dev', async () => {
+    const events: string[] = []
+    await expect(assembleDevQueue({
+      requestedPrs: [289],
+      run: async (command, args) => {
+        events.push([command, ...args].join(' '))
+        if (args.join(' ') === 'rev-parse origin/main') return 'origin-sha'
+        if (args.includes('view')) {
+          return JSON.stringify(pr({ number: 289, labels: [{ name: 'do-not-merge' }] }))
+        }
+        return ''
+      },
+      getBranch: async () => 'dev',
+      getStatus: async () => '',
+    })).rejects.toThrow('PR #289 is labeled do-not-merge')
+
+    expect(events.some((event) => event.includes('reset --hard'))).toBe(false)
+  })
+
+  it('assembles dev after preconditions and metadata validation', async () => {
+    const events: string[] = []
+    await assembleDevQueue({
+      requestedPrs: [321],
+      run: async (command, args) => {
+        events.push([command, ...args].join(' '))
+        if (args.join(' ') === 'rev-parse origin/main') return 'origin-sha'
+        if (args.includes('view')) return JSON.stringify(pr({ number: 321 }))
+        return ''
+      },
+      getBranch: async () => 'dev',
+      getStatus: async () => '',
+    })
+
+    expect(events).toEqual([
+      'git fetch origin main',
+      'git rev-parse origin/main',
+      'gh pr view 321 --repo danshapiro/freshell --json number,state,isDraft,baseRefName,headRefOid,mergeStateStatus,title,labels',
+      'git fetch origin main',
+      'git reset --hard origin-sha',
+      'git fetch origin +refs/pull/321/head:refs/remotes/pr/321',
+      'git merge --no-ff --no-edit refs/remotes/pr/321',
+    ])
+  })
+})

--- a/test/unit/scripts/selfhost-branch.test.ts
+++ b/test/unit/scripts/selfhost-branch.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+import { validateLaunchBranch } from '../../../scripts/selfhost-branch.js'
+
+describe('selfhost branch CLI helper', () => {
+  it('returns success on dev', async () => {
+    const result = await validateLaunchBranch({
+      env: {},
+      getBranch: async () => 'dev',
+    })
+
+    expect(result).toEqual({ ok: true, branch: 'dev' })
+  })
+
+  it('returns a clear error on main', async () => {
+    const result = await validateLaunchBranch({
+      env: {},
+      getBranch: async () => 'main',
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toContain("Refusing to self-host from local 'main'")
+    }
+  })
+
+  it('rejects main even when FRESHELL_SELFHOST_BRANCH is main', async () => {
+    const result = await validateLaunchBranch({
+      env: { FRESHELL_SELFHOST_BRANCH: 'main' },
+      getBranch: async () => 'main',
+    })
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('surfaces git branch lookup failures', async () => {
+    const result = await validateLaunchBranch({
+      env: {},
+      getBranch: vi.fn(async () => undefined),
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toContain('Could not determine the current Git branch')
+    }
+  })
+})

--- a/test/unit/server/updater/index.test.ts
+++ b/test/unit/server/updater/index.test.ts
@@ -343,7 +343,8 @@ describe('update orchestrator', () => {
     it('returns false by default when no skip conditions are met', () => {
       const result = shouldSkipUpdateCheck({
         argv: ['node', 'script.js'],
-        env: { npm_lifecycle_event: 'preserve' }
+        env: { npm_lifecycle_event: 'preserve' },
+        branch: 'main',
       })
       expect(result).toBe(false)
     })
@@ -367,7 +368,8 @@ describe('update orchestrator', () => {
     it('returns false when SKIP_UPDATE_CHECK env var is other value', () => {
       const result = shouldSkipUpdateCheck({
         argv: ['node', 'script.js'],
-        env: { SKIP_UPDATE_CHECK: 'false' }
+        env: { SKIP_UPDATE_CHECK: 'false' },
+        branch: 'main',
       })
       expect(result).toBe(false)
     })
@@ -383,7 +385,8 @@ describe('update orchestrator', () => {
     it('returns false when npm_lifecycle_event is "preserve"', () => {
       const result = shouldSkipUpdateCheck({
         argv: ['node', 'script.js'],
-        env: { npm_lifecycle_event: 'preserve' }
+        env: { npm_lifecycle_event: 'preserve' },
+        branch: 'main',
       })
       expect(result).toBe(false)
     })
@@ -392,9 +395,50 @@ describe('update orchestrator', () => {
       // This is the key behavior change - NODE_ENV should not affect the check
       const result = shouldSkipUpdateCheck({
         argv: ['node', 'script.js'],
-        env: { NODE_ENV: 'development', npm_lifecycle_event: 'preserve' }
+        env: { NODE_ENV: 'development', npm_lifecycle_event: 'preserve' },
+        branch: 'main',
       })
       expect(result).toBe(false)
+    })
+
+    it('skips update checks on dev branch', () => {
+      const result = shouldSkipUpdateCheck({
+        argv: ['node', 'script.js'],
+        env: {},
+        branch: 'dev',
+      })
+
+      expect(result).toBe(true)
+    })
+
+    it('skips update checks on feature branches', () => {
+      const result = shouldSkipUpdateCheck({
+        argv: ['node', 'script.js'],
+        env: {},
+        branch: 'feature/x',
+      })
+
+      expect(result).toBe(true)
+    })
+
+    it('does not skip update checks on main branch by branch policy alone', () => {
+      const result = shouldSkipUpdateCheck({
+        argv: ['node', 'script.js'],
+        env: {},
+        branch: 'main',
+      })
+
+      expect(result).toBe(false)
+    })
+
+    it('skips update checks when branch detection fails', () => {
+      const result = shouldSkipUpdateCheck({
+        argv: ['node', 'script.js'],
+        env: {},
+        branch: undefined,
+      })
+
+      expect(result).toBe(true)
     })
 
     it('uses process.argv and process.env by default', () => {

--- a/test/unit/shared/selfhost-branch-policy.test.ts
+++ b/test/unit/shared/selfhost-branch-policy.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifySelfHostBranch,
+  getExpectedSelfHostBranch,
+  shouldSkipSourceUpdateForBranch,
+} from '../../../shared/selfhost-branch-policy.js'
+
+describe('selfhost branch policy', () => {
+  it('defaults the expected self-host branch to dev', () => {
+    expect(getExpectedSelfHostBranch({})).toBe('dev')
+  })
+
+  it('allows overriding the expected self-host branch', () => {
+    expect(getExpectedSelfHostBranch({ FRESHELL_SELFHOST_BRANCH: 'dev/pr-queue' })).toBe('dev/pr-queue')
+  })
+
+  it('rejects self-host launch from main', () => {
+    expect(classifySelfHostBranch({ branch: 'main', env: {} })).toEqual({
+      ok: false,
+      code: 'mirror-branch',
+      message: "Refusing to self-host from local 'main'. Local 'main' must mirror 'origin/main'. Switch to 'dev' or set FRESHELL_SELFHOST_BRANCH.",
+    })
+  })
+
+  it('rejects self-host launch from main even if configured by env', () => {
+    expect(classifySelfHostBranch({
+      branch: 'main',
+      env: { FRESHELL_SELFHOST_BRANCH: 'main' },
+    })).toMatchObject({
+      ok: false,
+      code: 'mirror-branch',
+    })
+  })
+
+  it('accepts self-host launch from dev by default', () => {
+    expect(classifySelfHostBranch({ branch: 'dev', env: {} })).toEqual({ ok: true, expectedBranch: 'dev' })
+  })
+
+  it('rejects unexpected non-main branches unless they are configured', () => {
+    expect(classifySelfHostBranch({ branch: 'feature/x', env: {} })).toMatchObject({
+      ok: false,
+      code: 'unexpected-branch',
+    })
+  })
+
+  it('accepts a configured non-main self-host branch', () => {
+    expect(classifySelfHostBranch({
+      branch: 'dev/pr-queue',
+      env: { FRESHELL_SELFHOST_BRANCH: 'dev/pr-queue' },
+    })).toEqual({ ok: true, expectedBranch: 'dev/pr-queue' })
+  })
+
+  it('skips source updates on dev and feature branches', () => {
+    expect(shouldSkipSourceUpdateForBranch({ branch: 'dev', env: {} })).toBe(true)
+    expect(shouldSkipSourceUpdateForBranch({ branch: 'feature/x', env: {} })).toBe(true)
+  })
+
+  it('does not skip source updates on main unless another skip condition applies', () => {
+    expect(shouldSkipSourceUpdateForBranch({ branch: 'main', env: {} })).toBe(false)
+  })
+
+  it('skips source updates when the explicit skip env var is set', () => {
+    expect(shouldSkipSourceUpdateForBranch({
+      branch: 'main',
+      env: { SKIP_UPDATE_CHECK: 'true' },
+    })).toBe(true)
+  })
+
+  it('skips source updates when branch detection fails', () => {
+    expect(shouldSkipSourceUpdateForBranch({ branch: undefined, env: {} })).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- documents the `main` mirror + local `dev` integration branch model
- adds branch policy checks that prevent self-hosting from local `main` and skip source updates from non-`main` branches
- updates launch/source-update behavior so self-hosting is explicit and local-branch safe
- adds `npm run dev:queue` tooling to plan and assemble local `dev` from `origin/main` plus explicit PR heads
- updates release/review/contributing docs to avoid direct local `main` merges and direct `main` pushes

## PR queue context

This PR is intended to be the first item in the local `dev` assembly queue, because it provides the `dev:queue` script used to reproduce `dev` from `origin/main` + pending PRs.

## Tests

- `npm run test:vitest -- test/unit/shared/selfhost-branch-policy.test.ts test/unit/scripts/selfhost-branch.test.ts --run`
- `npm run test:vitest -- --config vitest.server.config.ts test/unit/server/updater/index.test.ts --run`
- `npm run test:vitest -- test/e2e/update-flow.test.ts --run`
- `bash -n scripts/launch.sh`
- `npx tsc --noEmit --allowImportingTsExtensions --module NodeNext --moduleResolution NodeNext --target ES2022 --types node scripts/selfhost-branch.ts shared/selfhost-branch-policy.ts`
- `npm run typecheck:server`
- `npm run test:vitest -- test/unit/scripts/dev-pr-queue.test.ts --run`
- `npx tsc --noEmit --allowImportingTsExtensions --module NodeNext --moduleResolution NodeNext --target ES2022 --types node scripts/dev-pr-queue.ts test/unit/scripts/dev-pr-queue.test.ts`
- `npm run test:vitest -- test/unit/shared/selfhost-branch-policy.test.ts test/unit/scripts/selfhost-branch.test.ts test/unit/scripts/dev-pr-queue.test.ts --run`
- `npm run typecheck`