### PR TITLE
Port durable session restore identity

### DIFF
--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -43,6 +43,7 @@ import {
   ErrorCode,
   ShellSchema,
   CodingCliProviderSchema,
+  SessionLocatorSchema,
   TerminalMetaUpdatedSchema,
   CodexActivityListResponseSchema,
   CodexActivityListSchema,
@@ -74,6 +75,7 @@ import {
 } from '../shared/ws-protocol.js'
 import { UiLayoutSyncSchema } from './agent-api/layout-schema.js'
 import type { LayoutStore } from './agent-api/layout-store.js'
+import { LiveTerminalHandleSchema } from '../shared/session-contract.js'
 
 type WsHandlerConfig = {
   maxConnections: number
@@ -466,11 +468,12 @@ export class WsHandler {
       }),
       shell: ShellSchema.default('system'),
       cwd: z.string().optional(),
-      resumeSessionId: z.string().optional(),
+      sessionRef: SessionLocatorSchema.optional(),
+      liveTerminal: LiveTerminalHandleSchema.optional(),
       restore: z.boolean().optional(),
       tabId: z.string().min(1).optional(),
       paneId: z.string().min(1).optional(),
-    })
+    }).strict()
 
     const dynamicProviderSchema = CodingCliProviderSchema.superRefine((val, ctx) => {
       if (!canEnumerateCliExtensions || extensionModes.includes(val)) return
@@ -1627,7 +1630,20 @@ export class WsHandler {
       }
 
       // Send terminal inventory so the client knows what's alive
-      const terminals = this.registry.list()
+      const terminals = this.registry.list().map((terminal) => {
+        const { resumeSessionId, ...rest } = terminal
+        return {
+          ...rest,
+          ...(resumeSessionId
+            ? {
+                sessionRef: {
+                  provider: terminal.mode,
+                  sessionId: resumeSessionId,
+                },
+              }
+            : {}),
+        }
+      })
       const terminalMeta = this.terminalMetaListProvider?.() ?? []
       this.safeSend(ws, {
         type: 'terminal.inventory',
@@ -1806,12 +1822,23 @@ export class WsHandler {
         return
       }
       case 'terminal.create': {
+        const requestedSessionRef = m.sessionRef?.provider === m.mode
+          ? m.sessionRef
+          : undefined
+        const canonicalSessionId = requestedSessionRef?.sessionId
+        const restoreRequested = m.restore === true
+        const localLiveTerminalId = (
+          m.liveTerminal?.serverInstanceId === this.serverInstanceId
+          && typeof m.liveTerminal?.terminalId === 'string'
+        )
+          ? m.liveTerminal.terminalId
+          : undefined
         log.debug({
           requestId: m.requestId,
           connectionId: ws.connectionId,
           mode: m.mode,
-          resumeSessionId: m.resumeSessionId,
-        }, '[TRACE resumeSessionId] terminal.create received')
+          sessionRef: requestedSessionRef,
+        }, '[TRACE sessionRef] terminal.create received')
         recordSessionLifecycleEvent({
           kind: 'terminal_create_requested',
           requestId: m.requestId,
@@ -1820,9 +1847,9 @@ export class WsHandler {
           ...(m.paneId ? { paneId: m.paneId } : {}),
           ...(m.cwd ? { cwd: m.cwd } : {}),
           mode: m.mode as TerminalMode,
-          restoreRequested: m.restore === true,
-          hasRequestedSessionRef: false,
-          ...(m.resumeSessionId ? { requestedSessionId: m.resumeSessionId } : {}),
+          restoreRequested,
+          hasRequestedSessionRef: !!requestedSessionRef,
+          ...(canonicalSessionId ? { requestedSessionId: canonicalSessionId } : {}),
         })
         const endCreateTimer = startPerfTimer(
           'terminal_create',
@@ -1834,10 +1861,10 @@ export class WsHandler {
         let reused = false
         let error = false
         let rateLimited = false
-        let effectiveResumeSessionId = m.resumeSessionId
+        let effectiveResumeSessionId = canonicalSessionId
         try {
           await this.withTerminalCreateLock(
-            this.terminalCreateLockKey(m.mode as TerminalMode, m.requestId, effectiveResumeSessionId),
+            this.terminalCreateLockKey(m.mode as TerminalMode, m.requestId, canonicalSessionId),
             async () => {
               const resolveExistingRequestTerminalId = (requestId: string): string | undefined => {
                 const local = state.createdByRequestId.get(requestId)
@@ -1855,7 +1882,6 @@ export class WsHandler {
                 requestId: string
                 terminalId: string
                 createdAt: number
-                effectiveResumeSessionId?: string
               }): Promise<boolean> => {
                 if (opts.ws.readyState !== WebSocket.OPEN) {
                   return false
@@ -1866,7 +1892,6 @@ export class WsHandler {
                   requestId: opts.requestId,
                   terminalId: opts.terminalId,
                   createdAt: opts.createdAt,
-                  ...(opts.effectiveResumeSessionId ? { effectiveResumeSessionId: opts.effectiveResumeSessionId } : {}),
                 })
                 return true
               }
@@ -1881,7 +1906,6 @@ export class WsHandler {
                   requestId: m.requestId,
                   terminalId: reusedTerminalId,
                   createdAt,
-                  effectiveResumeSessionId: resumeSessionId,
                 })
                 if (!sent) {
                   return false
@@ -1923,19 +1947,27 @@ export class WsHandler {
                 this.forgetCreatedRequestId(m.requestId)
               }
 
-              if (modeSupportsResume(m.mode as TerminalMode) && effectiveResumeSessionId) {
+              if (localLiveTerminalId) {
+                const liveTerminal = this.registry.get(localLiveTerminalId)
+                if (liveTerminal?.status === 'running' && liveTerminal.mode === m.mode) {
+                  await attachReusedTerminal(liveTerminal.terminalId, liveTerminal.createdAt, liveTerminal.resumeSessionId)
+                  return
+                }
+              }
+
+              if (modeSupportsResume(m.mode as TerminalMode) && canonicalSessionId) {
                 let existing = this.registry.getCanonicalRunningTerminalBySession(
                   m.mode as TerminalMode,
-                  effectiveResumeSessionId,
+                  canonicalSessionId,
                 )
                 if (!existing) {
                   this.registry.repairLegacySessionOwners(
                     m.mode as TerminalMode,
-                    effectiveResumeSessionId,
+                    canonicalSessionId,
                   )
                   existing = this.registry.getCanonicalRunningTerminalBySession(
                     m.mode as TerminalMode,
-                    effectiveResumeSessionId,
+                    canonicalSessionId,
                   )
                 }
                 if (existing) {
@@ -1967,7 +1999,7 @@ export class WsHandler {
               }
 
               // Rate limit: prevent runaway terminal creation (e.g., infinite respawn loops)
-              if (!m.restore) {
+              if (!restoreRequested) {
                 const now = Date.now()
                 state.terminalCreateTimestamps = state.terminalCreateTimestamps.filter(
                   (t) => now - t < this.config.terminalCreateRateWindowMs
@@ -1983,19 +2015,27 @@ export class WsHandler {
 
               // Re-check session ownership after async config loading in case another request
               // created or repaired a matching running session while we were waiting.
-              if (modeSupportsResume(m.mode as TerminalMode) && effectiveResumeSessionId) {
+              if (localLiveTerminalId) {
+                const liveTerminal = this.registry.get(localLiveTerminalId)
+                if (liveTerminal?.status === 'running' && liveTerminal.mode === m.mode) {
+                  await attachReusedTerminal(liveTerminal.terminalId, liveTerminal.createdAt, liveTerminal.resumeSessionId)
+                  return
+                }
+              }
+
+              if (modeSupportsResume(m.mode as TerminalMode) && canonicalSessionId) {
                 let existing = this.registry.getCanonicalRunningTerminalBySession(
                   m.mode as TerminalMode,
-                  effectiveResumeSessionId,
+                  canonicalSessionId,
                 )
                 if (!existing) {
                   this.registry.repairLegacySessionOwners(
                     m.mode as TerminalMode,
-                    effectiveResumeSessionId,
+                    canonicalSessionId,
                   )
                   existing = this.registry.getCanonicalRunningTerminalBySession(
                     m.mode as TerminalMode,
-                    effectiveResumeSessionId,
+                    canonicalSessionId,
                   )
                 }
                 if (existing) {
@@ -2035,6 +2075,24 @@ export class WsHandler {
                 }
               }
 
+              if (m.mode === 'opencode' && restoreRequested && !canonicalSessionId) {
+                this.sendError(ws, {
+                  code: 'RESTORE_UNAVAILABLE',
+                  message: 'OpenCode restore requires a canonical durable session id',
+                  requestId: m.requestId,
+                })
+                return
+              }
+
+              if (m.mode === 'claude' && restoreRequested && !isValidClaudeSessionId(effectiveResumeSessionId)) {
+                this.sendError(ws, {
+                  code: 'RESTORE_UNAVAILABLE',
+                  message: 'Claude restore requires a canonical durable session id',
+                  requestId: m.requestId,
+                })
+                return
+              }
+
               // After async repair wait, check if the client disconnected
               if (ws.readyState !== WebSocket.OPEN) {
                 log.debug({ connectionId: ws.connectionId, requestId: m.requestId },
@@ -2048,9 +2106,9 @@ export class WsHandler {
               log.debug({
                 requestId: m.requestId,
                 connectionId: ws.connectionId,
-                originalResumeSessionId: m.resumeSessionId,
+                sessionRef: requestedSessionRef,
                 effectiveResumeSessionId,
-              }, '[TRACE resumeSessionId] about to create terminal')
+              }, '[TRACE sessionRef] about to create terminal')
 
               const requestedCodexResumeSessionId = m.mode === 'codex'
                 ? effectiveResumeSessionId
@@ -2162,7 +2220,6 @@ export class WsHandler {
                 requestId: m.requestId,
                 terminalId: record.terminalId,
                 createdAt: record.createdAt,
-                effectiveResumeSessionId,
               })
               if (!sent) {
                 // Terminal may still exist even if created delivery failed (for

--- a/src/components/agent-chat/AgentChatView.tsx
+++ b/src/components/agent-chat/AgentChatView.tsx
@@ -52,10 +52,10 @@ import {
   buildAgentChatPersistedIdentityUpdate,
   flushPersistedLayoutNow,
   getCanonicalDurableSessionId,
-  getPreferredResumeSessionId,
 } from '@/store/persistControl'
 import { useMobile } from '@/hooks/useMobile'
 import { useKeyboardInset } from '@/hooks/useKeyboardInset'
+import { buildRestoreError } from '@shared/session-contract'
 
 /** Early lifecycle states that should not be re-entered once the session has advanced. */
 const EARLY_STATES = new Set(['creating', 'starting'])
@@ -136,6 +136,7 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
   const currentTab = useAppSelector((s) => (
     (s as { tabs?: { tabs?: Tab[] } }).tabs?.tabs?.find((entry) => entry.id === tabId)
   ))
+  const tabHasSinglePane = useAppSelector((s) => s.panes.layouts[tabId]?.type === 'leaf')
   const tabTitleSetByUser = currentTab?.titleSetByUser ?? false
   const providerCapabilitiesState = useAppSelector(
     (s) => s.agentChat.capabilitiesByProvider?.[paneContent.provider],
@@ -177,18 +178,15 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
   const surfaceVisibleMarkedRef = useRef(false)
   const sessionRef = useRef(session)
   sessionRef.current = session
-  const persistedTimelineSessionId = isValidClaudeSessionId(paneContent.resumeSessionId)
-    ? paneContent.resumeSessionId
-    : undefined
+  const persistedTimelineSessionId = (
+    paneContent.sessionRef?.provider === 'claude'
+    && isValidClaudeSessionId(paneContent.sessionRef.sessionId)
+  )
+    ? paneContent.sessionRef.sessionId
+    : (isValidClaudeSessionId(paneContent.resumeSessionId) ? paneContent.resumeSessionId : undefined)
   const canonicalDurableSessionId = getCanonicalDurableSessionId(session) ?? persistedTimelineSessionId
-  const timelineSessionId = getPreferredResumeSessionId(session) ?? persistedTimelineSessionId
-  const restoreHistoryQueryId = timelineSessionId ?? paneContent.sessionId
-  const attachResumeSessionId = getPreferredResumeSessionId(session)
-    ?? (
-      typeof paneContent.resumeSessionId === 'string' && paneContent.resumeSessionId.trim().length > 0
-        ? paneContent.resumeSessionId
-        : undefined
-    )
+  const restoreHistoryQueryId = canonicalDurableSessionId ?? paneContent.sessionId
+  const attachResumeSessionId = canonicalDurableSessionId
   const attachPayload = useMemo(() => {
     if (!paneContent.sessionId) return null
     return {
@@ -236,21 +234,47 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
   )
   const isRestoring = !!paneContent.sessionId && !session?.historyLoaded && !hasRestoreFailure
 
-  // Shared recovery logic: clears stale sessionId and resets to 'creating' so a new
-  // SDK session is spawned. Preserves resumeSessionId for CLI session continuity.
+  // Shared recovery logic: clears stale SDK sessionId and recreates through the
+  // canonical durable identity when one is available.
   const triggerRecovery = useCallback(() => {
+    const durableResumeSessionId = getCanonicalDurableSessionId(sessionRef.current)
+      ?? (
+        paneContentRef.current.sessionRef?.provider === 'claude'
+        && isValidClaudeSessionId(paneContentRef.current.sessionRef.sessionId)
+          ? paneContentRef.current.sessionRef.sessionId
+          : (isValidClaudeSessionId(paneContentRef.current.resumeSessionId) ? paneContentRef.current.resumeSessionId : undefined)
+      )
+    if (!durableResumeSessionId) {
+      dispatch(updatePaneContent({
+        tabId,
+        paneId,
+        content: {
+          ...paneContentRef.current,
+          sessionId: undefined,
+          status: 'idle' as const,
+          restoreError: buildRestoreError('dead_live_handle'),
+        },
+      }))
+      createSentRef.current = false
+      attachSentRef.current = false
+      return
+    }
+
     const newRequestId = nanoid()
-    const resumeSessionId = getPreferredResumeSessionId(sessionRef.current)
-      ?? paneContentRef.current.resumeSessionId
     dispatch(updatePaneContent({
       tabId,
       paneId,
       content: {
         ...paneContentRef.current,
         sessionId: undefined,
-        resumeSessionId,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: durableResumeSessionId,
+        },
+        resumeSessionId: undefined,
         createRequestId: newRequestId,
         status: 'creating' as const,
+        restoreError: undefined,
       },
     }))
     createSentRef.current = false
@@ -410,7 +434,7 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
     const identityUpdate = buildAgentChatPersistedIdentityUpdate({
       session,
       paneContent: paneContentRef.current,
-      currentTab,
+      currentTab: tabHasSinglePane ? currentTab : undefined,
       metadataProvider,
     })
     if (!identityUpdate) return
@@ -433,7 +457,7 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
     if (identityUpdate.shouldFlush) {
       dispatch(flushPersistedLayoutNow())
     }
-  }, [currentTab, dispatch, paneId, providerConfig?.codingCliProvider, session, tabId])
+  }, [currentTab, dispatch, paneId, providerConfig?.codingCliProvider, session, tabHasSinglePane, tabId])
 
   // Tag this Claude Code session as belonging to this agent-chat provider.
   // Fires once when cliSessionId first becomes available (including resumes).
@@ -441,21 +465,20 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
   const taggedSessionRef = useRef<string | null>(null)
   useEffect(() => {
     if (suppressNetworkEffects) return
-    const preferredResumeSessionId = getPreferredResumeSessionId(session)
-    if (!preferredResumeSessionId) return
-    if (taggedSessionRef.current === preferredResumeSessionId) return
-    taggedSessionRef.current = preferredResumeSessionId
+    if (!canonicalDurableSessionId) return
+    if (taggedSessionRef.current === canonicalDurableSessionId) return
+    taggedSessionRef.current = canonicalDurableSessionId
 
     if (providerConfig?.codingCliProvider) {
       setSessionMetadata(
         providerConfig.codingCliProvider,
-        preferredResumeSessionId,
+        canonicalDurableSessionId,
         paneContent.provider,
       ).catch((err) => {
         console.warn('Failed to tag session metadata:', err)
       })
     }
-  }, [paneContent.provider, providerConfig?.codingCliProvider, session?.cliSessionId, session?.timelineSessionId, suppressNetworkEffects])
+  }, [canonicalDurableSessionId, paneContent.provider, providerConfig?.codingCliProvider, suppressNetworkEffects])
 
   // Reset createSentRef when createRequestId changes
   const prevCreateRequestIdRef = useRef(paneContent.createRequestId)
@@ -469,6 +492,7 @@ export default function AgentChatView({ tabId, paneId, paneContent, hidden }: Ag
     if (suppressNetworkEffects) return
     if (paneContent.sessionId || createSentRef.current) return
     if (paneContent.status !== 'creating') return
+    if (paneContent.restoreError) return
 
     const requestId = paneContent.createRequestId
     createSentRef.current = true

--- a/test/e2e/agent-chat-restore-flow.test.tsx
+++ b/test/e2e/agent-chat-restore-flow.test.tsx
@@ -136,6 +136,7 @@ describe('agent chat restore flow', () => {
   })
 
   it('restores a reloaded pane from sdk.session.snapshot, persists the durable id into pane and tab state, and shows partial output without a blank running gap', async () => {
+    const canonicalSessionId = '00000000-0000-4000-8000-000000000211'
     const store = makeStore({
       resumeSessionId: 'named-resume',
       sessionMetadataByKey: {
@@ -160,11 +161,11 @@ describe('agent chat restore flow', () => {
     }))
 
     getAgentTimelinePage.mockResolvedValue({
-      sessionId: 'cli-session-1',
+      sessionId: canonicalSessionId,
       items: [
         {
           turnId: 'turn-2',
-          sessionId: 'cli-session-1',
+          sessionId: canonicalSessionId,
           role: 'assistant',
           summary: 'Recent summary',
           timestamp: '2026-03-10T10:01:00.000Z',
@@ -174,7 +175,7 @@ describe('agent chat restore flow', () => {
       revision: 2,
       bodies: {
         'turn-2': {
-          sessionId: 'cli-session-1',
+          sessionId: canonicalSessionId,
           turnId: 'turn-2',
           message: {
             role: 'assistant',
@@ -197,7 +198,7 @@ describe('agent chat restore flow', () => {
         sessionId: 'sdk-sess-1',
         latestTurnId: 'turn-2',
         status: 'running',
-        timelineSessionId: 'cli-session-1',
+        timelineSessionId: canonicalSessionId,
         revision: 2,
         streamingActive: true,
         streamingText: 'partial reply',
@@ -209,7 +210,7 @@ describe('agent chat restore flow', () => {
 
     await waitFor(() => {
       expect(getAgentTimelinePage).toHaveBeenCalledWith(
-        'cli-session-1',
+        canonicalSessionId,
         expect.objectContaining({ priority: 'visible', includeBodies: true }),
         expect.anything(),
       )
@@ -222,11 +223,18 @@ describe('agent chat restore flow', () => {
     await waitFor(() => {
       const root = store.getState().panes.layouts.t1
       const leaf = root && findLeaf(root, 'p1')
-      expect(leaf?.content.kind === 'agent-chat' ? leaf.content.resumeSessionId : undefined).toBe('cli-session-1')
+      expect(leaf?.content.kind === 'agent-chat' ? leaf.content.sessionRef : undefined).toEqual({
+        provider: 'claude',
+        sessionId: canonicalSessionId,
+      })
 
       const tab = store.getState().tabs.tabs.find((entry) => entry.id === 't1')
-      expect(tab?.resumeSessionId).toBe('cli-session-1')
-      expect(tab?.sessionMetadataByKey?.['claude:cli-session-1']).toEqual(expect.objectContaining({
+      expect(tab?.resumeSessionId).toBeUndefined()
+      expect(tab?.sessionRef).toEqual({
+        provider: 'claude',
+        sessionId: canonicalSessionId,
+      })
+      expect(tab?.sessionMetadataByKey?.[`claude:${canonicalSessionId}`]).toEqual(expect.objectContaining({
         sessionType: 'freshclaude',
         firstUserMessage: 'Continue from the old tab',
       }))

--- a/test/integration/server/codex-session-flow.test.ts
+++ b/test/integration/server/codex-session-flow.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../../server/logger', () => {
     child: vi.fn(),
   }
   logger.child.mockReturnValue(logger)
-  return { logger }
+  return { logger, sessionLifecycleLogger: logger }
 })
 
 process.env.AUTH_TOKEN = 'test-token'
@@ -373,7 +373,7 @@ describe('Codex Session Flow Integration', () => {
         throw new Error(`terminal.create failed: ${created.message}`)
       }
 
-      expect(created.effectiveResumeSessionId).toBe('thread-new-1')
+      expect(created).not.toHaveProperty('effectiveResumeSessionId')
 
       const record = registry.get(created.terminalId)
       expect(record?.resumeSessionId).toBe('thread-new-1')
@@ -415,7 +415,10 @@ describe('Codex Session Flow Integration', () => {
         requestId: 'test-req-codex-restore',
         mode: 'codex',
         cwd: tempDir,
-        resumeSessionId: 'thread-existing-1',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: 'thread-existing-1',
+        },
       }))
 
       const created = await waitForMessage(
@@ -429,7 +432,7 @@ describe('Codex Session Flow Integration', () => {
         throw new Error(`terminal.create failed: ${created.message}`)
       }
 
-      expect(created.effectiveResumeSessionId).toBe('thread-existing-1')
+      expect(created).not.toHaveProperty('effectiveResumeSessionId')
 
       const record = registry.get(created.terminalId)
       expect(record?.resumeSessionId).toBe('thread-existing-1')

--- a/test/server/ws-protocol.test.ts
+++ b/test/server/ws-protocol.test.ts
@@ -819,7 +819,10 @@ describe('ws protocol', () => {
         type: 'terminal.create',
         requestId: 'shutdown-during-readiness',
         mode: 'codex',
-        resumeSessionId: 'thread-during-readiness',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: 'thread-during-readiness',
+        },
       })),
     )
     await vi.waitFor(() => expect(sidecar.waitForLoadedThreadCalls).toHaveLength(1))
@@ -848,7 +851,10 @@ describe('ws protocol', () => {
       type: 'terminal.create',
       requestId,
       mode: 'codex',
-      resumeSessionId: 'thread-resume-1',
+      sessionRef: {
+        provider: 'codex',
+        sessionId: 'thread-resume-1',
+      },
     }))
     const created = await waitForMessage(
       ws,
@@ -880,7 +886,10 @@ describe('ws protocol', () => {
       type: 'terminal.create',
       requestId,
       mode: 'codex',
-      resumeSessionId: 'thread-missing',
+      sessionRef: {
+        provider: 'codex',
+        sessionId: 'thread-missing',
+      },
     }))
     const error = await waitForMessage(
       ws,
@@ -916,7 +925,10 @@ describe('ws protocol', () => {
         type: 'terminal.create',
         requestId,
         mode: 'codex',
-        resumeSessionId: 'thread-resume-exits',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: 'thread-resume-exits',
+        },
       }))
       const error = await waitForMessage(
         ws,

--- a/test/unit/client/components/agent-chat/AgentChatView.reload.test.tsx
+++ b/test/unit/client/components/agent-chat/AgentChatView.reload.test.tsx
@@ -30,6 +30,10 @@ beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn()
 })
 
+const DURABLE_SESSION_ID = '00000000-0000-4000-8000-000000000201'
+const DURABLE_SESSION_ID_ALT = '00000000-0000-4000-8000-000000000202'
+const DURABLE_SHELL_SESSION_ID = '00000000-0000-4000-8000-000000000203'
+
 const wsSend = vi.fn()
 const getAgentTimelinePage = vi.fn()
 const getAgentTurnBody = vi.fn()
@@ -142,7 +146,10 @@ const RELOAD_PANE: AgentChatPaneContent = {
 
 const RELOAD_PANE_WITH_CANONICAL_RESUME: AgentChatPaneContent = {
   ...RELOAD_PANE,
-  resumeSessionId: '00000000-0000-4000-8000-000000000321',
+  sessionRef: {
+    provider: 'claude',
+    sessionId: '00000000-0000-4000-8000-000000000321',
+  },
 }
 
 const RELOAD_PANE_WITH_NAMED_RESUME: AgentChatPaneContent = {
@@ -201,7 +208,7 @@ describe('AgentChatView reload/restore behavior', () => {
     })
   })
 
-  it('includes the named resumeSessionId when attaching a persisted pane before the canonical durable id exists', () => {
+  it('does not attach through a named legacy resumeSessionId before the canonical durable id exists', () => {
     const store = makeStore()
     render(
       <Provider store={store}>
@@ -216,7 +223,6 @@ describe('AgentChatView reload/restore behavior', () => {
     expect(wsSend).toHaveBeenCalledWith({
       type: 'sdk.attach',
       sessionId: 'sess-reload-1',
-      resumeSessionId: 'named-resume-token',
     })
   })
 
@@ -840,7 +846,7 @@ describe('AgentChatView reload/restore behavior', () => {
       sessionId: 'sess-reload-1',
       latestTurnId: 'turn-2',
       status: 'idle',
-      timelineSessionId: 'cli-sess-1',
+      timelineSessionId: DURABLE_SESSION_ID,
       revision: 12,
     }))
 
@@ -856,7 +862,7 @@ describe('AgentChatView reload/restore behavior', () => {
       expect(attachCalls[1]?.[0]).toEqual({
         type: 'sdk.attach',
         sessionId: 'sess-reload-1',
-        resumeSessionId: 'cli-sess-1',
+        resumeSessionId: DURABLE_SESSION_ID,
       })
     })
   })
@@ -1076,15 +1082,15 @@ describe('AgentChatView reload/restore behavior', () => {
     })
   })
 
-  it('uses timelineSessionId from sdk.session.snapshot for visible restore hydration', async () => {
-    getAgentTimelinePage.mockResolvedValue({ sessionId: 'cli-sess-1', items: [], nextCursor: null, revision: 1 })
+  it('uses canonical timelineSessionId from sdk.session.snapshot for visible restore hydration', async () => {
+    getAgentTimelinePage.mockResolvedValue({ sessionId: DURABLE_SESSION_ID, items: [], nextCursor: null, revision: 1 })
 
     const store = makeStore()
     store.dispatch(sessionSnapshotReceived({
       sessionId: 'sess-reload-1',
       latestTurnId: 'turn-2',
       status: 'idle',
-      timelineSessionId: 'cli-sess-1',
+      timelineSessionId: DURABLE_SESSION_ID,
       revision: 2,
     }))
 
@@ -1096,7 +1102,7 @@ describe('AgentChatView reload/restore behavior', () => {
 
     await waitFor(() => {
       expect(getAgentTimelinePage).toHaveBeenCalledWith(
-        'cli-sess-1',
+        DURABLE_SESSION_ID,
         expect.objectContaining({ includeBodies: true, revision: 2 }),
         expect.anything(),
       )
@@ -1164,15 +1170,22 @@ describe('AgentChatView reload/restore behavior', () => {
         sessionId: 'sdk-sess-1',
         latestTurnId: 'turn-2',
         status: 'idle',
-        timelineSessionId: 'cli-session-abc-123',
+        timelineSessionId: DURABLE_SESSION_ID_ALT,
         revision: 2,
       }))
     })
 
-    expect(getPaneContent(store as unknown as ReturnType<typeof makeStore>, 't1', 'p1')?.resumeSessionId).toBe('cli-session-abc-123')
+    expect(getPaneContent(store as unknown as ReturnType<typeof makeStore>, 't1', 'p1')?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: DURABLE_SESSION_ID_ALT,
+    })
     const tab = store.getState().tabs.tabs.find((entry) => entry.id === 't1')
-    expect(tab?.resumeSessionId).toBe('cli-session-abc-123')
-    expect(tab?.sessionMetadataByKey?.['claude:cli-session-abc-123']).toEqual(expect.objectContaining({
+    expect(tab?.resumeSessionId).toBeUndefined()
+    expect(tab?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: DURABLE_SESSION_ID_ALT,
+    })
+    expect(tab?.sessionMetadataByKey?.[`claude:${DURABLE_SESSION_ID_ALT}`]).toEqual(expect.objectContaining({
       sessionType: 'freshclaude',
       firstUserMessage: 'Continue from the old tab',
     }))
@@ -1212,16 +1225,23 @@ describe('AgentChatView reload/restore behavior', () => {
         sessionId: 'sdk-shell-1',
         latestTurnId: 'turn-2',
         status: 'idle',
-        timelineSessionId: 'cli-shell-abc-123',
+        timelineSessionId: DURABLE_SHELL_SESSION_ID,
         revision: 2,
       }))
     })
 
-    expect(getPaneContent(store as unknown as ReturnType<typeof makeStore>, 't-shell', 'p1')?.resumeSessionId).toBe('cli-shell-abc-123')
+    expect(getPaneContent(store as unknown as ReturnType<typeof makeStore>, 't-shell', 'p1')?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: DURABLE_SHELL_SESSION_ID,
+    })
     const tab = store.getState().tabs.tabs.find((entry) => entry.id === 't-shell')
-    expect(tab?.resumeSessionId).toBe('cli-shell-abc-123')
+    expect(tab?.resumeSessionId).toBeUndefined()
+    expect(tab?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: DURABLE_SHELL_SESSION_ID,
+    })
     expect(tab?.codingCliProvider).toBe('claude')
-    expect(tab?.sessionMetadataByKey?.['claude:cli-shell-abc-123']).toEqual(expect.objectContaining({
+    expect(tab?.sessionMetadataByKey?.[`claude:${DURABLE_SHELL_SESSION_ID}`]).toEqual(expect.objectContaining({
       sessionType: 'freshclaude',
       firstUserMessage: 'Continue from shell fallback',
     }))
@@ -1362,14 +1382,13 @@ describe('AgentChatView reload/restore behavior', () => {
         sessionId: 'sdk-meta-upgrade-1',
         latestTurnId: 'turn-2',
         status: 'idle',
-        timelineSessionId: 'named-resume',
         revision: 1,
       }))
     })
 
     await waitFor(() => {
       expect(getAgentTimelinePage).toHaveBeenCalledWith(
-        'named-resume',
+        'sdk-meta-upgrade-1',
         expect.objectContaining({ includeBodies: true, revision: 1 }),
         expect.anything(),
       )
@@ -1440,9 +1459,16 @@ describe('AgentChatView reload/restore behavior', () => {
     expect(screen.queryByText('Live-only full body')).not.toBeInTheDocument()
     expect(screen.getAllByText('Post-watermark live delta')).toHaveLength(1)
 
-    expect(getPaneContent(store as unknown as ReturnType<typeof makeStore>, 't-meta', 'p1')?.resumeSessionId).toBe(canonicalSessionId)
+    expect(getPaneContent(store as unknown as ReturnType<typeof makeStore>, 't-meta', 'p1')?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: canonicalSessionId,
+    })
     const tab = store.getState().tabs.tabs.find((entry) => entry.id === 't-meta')
-    expect(tab?.resumeSessionId).toBe(canonicalSessionId)
+    expect(tab?.resumeSessionId).toBeUndefined()
+    expect(tab?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: canonicalSessionId,
+    })
     expect(tab?.sessionMetadataByKey?.['claude:00000000-0000-4000-8000-000000000321']).toEqual(expect.objectContaining({
       sessionType: 'freshclaude',
       firstUserMessage: 'Continue from metadata upgrade',
@@ -1893,14 +1919,17 @@ describe('AgentChatView server-restart recovery', () => {
       store.dispatch(sessionCreated({ requestId: 'req-1', sessionId: 'sdk-sess-1' }))
       store.dispatch(sessionInit({
         sessionId: 'sdk-sess-1',
-        cliSessionId: 'cli-session-abc-123',
+        cliSessionId: DURABLE_SESSION_ID_ALT,
         model: 'claude-opus-4-6',
       }))
     })
 
-    // Pane content should now have resumeSessionId persisted
+    // Pane content should now have canonical sessionRef persisted
     const content = getPaneContent(store, 't1', 'p1')
-    expect(content?.resumeSessionId).toBe('cli-session-abc-123')
+    expect(content?.sessionRef).toEqual({
+      provider: 'claude',
+      sessionId: DURABLE_SESSION_ID_ALT,
+    })
   })
 
   it('does not reset the pane or send sdk.create when restore remains pending past the legacy timeout window', () => {


### PR DESCRIPTION
## Summary
- make terminal.create restore through canonical sessionRef/liveTerminal instead of raw legacy resumeSessionId
- emit terminal inventory sessionRef values for durable terminal identity
- make AgentChat reload/recovery persist and use canonical durable Claude session identity

## Tests
- npm run typecheck
- npm run test:vitest -- test/unit/client/components/agent-chat/AgentChatView.reload.test.tsx test/e2e/agent-chat-restore-flow.test.tsx test/e2e/agent-chat-resume-history-flow.test.tsx --run
- npm run test:server -- --run test/integration/server/durable-session-contract.test.ts test/integration/server/opencode-session-flow.test.ts test/server/ws-handshake-snapshot.test.ts