### PR TITLE
Promote copied agent-chat durable session refs

### DIFF
--- a/shared/session-contract.ts
+++ b/shared/session-contract.ts
@@ -143,7 +143,9 @@ export function migrateLegacyAgentChatDurableState({
 
   const canonicalClaudeSessionId = isCanonicalClaudeSessionId(cliSessionId)
     ? cliSessionId
-    : (isCanonicalClaudeSessionId(timelineSessionId) ? timelineSessionId : undefined)
+    : (isCanonicalClaudeSessionId(timelineSessionId)
+        ? timelineSessionId
+        : (isCanonicalClaudeSessionId(resumeSessionId) ? resumeSessionId : undefined))
 
   if (canonicalClaudeSessionId) {
     return {

--- a/test/unit/client/components/TabsView.test.tsx
+++ b/test/unit/client/components/TabsView.test.tsx
@@ -199,8 +199,8 @@ describe('TabsView', () => {
       sessionRef: {
         provider: 'claude',
         sessionId: '00000000-0000-4000-8000-000000000444',
-        serverInstanceId: 'srv-remote',
       },
+      serverInstanceId: 'srv-remote',
       modelSelection: { kind: 'tracked', modelId: 'opus[1m]' },
       permissionMode: 'plan',
       effort: 'turbo',
@@ -366,8 +366,8 @@ describe('TabsView', () => {
     expect(layout?.content?.sessionRef).toEqual({
       provider: 'codex',
       sessionId: 'codex-session-123',
-      serverInstanceId: 'srv-remote',
     })
+    expect(layout?.content?.serverInstanceId).toBe('srv-remote')
   })
 
   it('shows pane kind icons with distinct colors', () => {

--- a/test/unit/client/lib/session-contract.test.ts
+++ b/test/unit/client/lib/session-contract.test.ts
@@ -21,6 +21,7 @@ describe('client session-contract helpers', () => {
       {
         provider: 'codex',
         sessionId: 'codex-session-1',
+        serverInstanceId: 'srv-local',
       },
       {
         provider: 'codex',

--- a/test/unit/shared/session-contract.test.ts
+++ b/test/unit/shared/session-contract.test.ts
@@ -90,9 +90,20 @@ describe('session-contract', () => {
       })
     })
 
-    it('marks legacy raw agent-chat resume ids as restore-unavailable when no canonical Claude id exists', () => {
+    it('promotes canonical Claude legacy resume ids for agent-chat panes', () => {
       expect(migrateLegacyAgentChatDurableState({
         resumeSessionId: VALID_CLAUDE_SESSION_ID,
+      })).toEqual({
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_CLAUDE_SESSION_ID,
+        },
+      })
+    })
+
+    it('marks legacy raw agent-chat resume ids as restore-unavailable when no canonical Claude id exists', () => {
+      expect(migrateLegacyAgentChatDurableState({
+        resumeSessionId: 'named-resume',
       })).toEqual({
         restoreError: {
           code: 'RESTORE_UNAVAILABLE',


### PR DESCRIPTION
## Summary
- promote canonical legacy Claude agent-chat resume IDs into sessionRef when copying registry tabs
- keep sessionRef canonical and keep server provenance on pane-level serverInstanceId
- update TabsView/session-contract tests to reflect the canonical identity boundary

## Tests
- npm run typecheck
- npm run test:vitest -- test/e2e/tabs-view-flow.test.tsx test/unit/client/components/TabsView.test.tsx test/unit/shared/session-contract.test.ts test/unit/client/lib/session-contract.test.ts
- npm run test:server -- --run test/server/ws-protocol.test.ts test/unit/server/agent-layout-schema.test.ts