### PR TITLE
docs(mcp): document ephemeral tab IDs and screenshot-after-open-browser

### DIFF
--- a/server/mcp/freshell-tool.ts
+++ b/server/mcp/freshell-tool.ts
@@ -69,6 +69,8 @@ FRESHELL_URL and FRESHELL_TOKEN are already set in your environment.
 
 ## Key gotchas
 
+- **Tab and pane IDs are ephemeral.** IDs from open-browser, new-tab, and split-pane are valid only within the current session. If the Freshell server restarts or the agent conversation resumes after a disconnect, previously returned IDs may no longer exist. Always call open-browser or list-tabs fresh rather than reusing stale IDs.
+- **Always screenshot with `screenshot({ scope: "tab", target: tabId })` after open-browser.** Network errors, CORS issues, or server problems can cause blank pages. open-browser returns a tabId — use it immediately to screenshot and confirm the page rendered before proceeding.
 - send-keys: use literal mode (literal: true + keys as a string) for natural-language prompts or multi-word text. Do NOT append "ENTER" as literal text -- send the command with literal:true, then send ["ENTER"] as a separate call in token mode.
 - wait-for with stable (seconds of no output) is more reliable than pattern matching across different CLI providers.
 - Editor panes show "Loading..." until the tab is visited in the browser. When screenshotting multiple tabs, visit each tab first (select-tab), then loop back for screenshots.
@@ -455,7 +457,11 @@ Meta:
   freshell({ action: "split-pane", params: { browser: "https://example.com" } })
 
   // Or open a URL in a new browser tab
-  freshell({ action: "open-browser", params: { url: "https://example.com", name: "My Page" } })
+  result = freshell({ action: "open-browser", params: { url: "https://example.com", name: "My Page" } })
+
+  // IMPORTANT: Always screenshot after open-browser to confirm the page loaded.
+  // Blank pages, network errors, and CORS issues are invisible without a screenshot.
+  freshell({ action: "screenshot", params: { scope: "tab", target: result.data.tabId } })
 
   // Navigate an existing browser pane to a different URL
   freshell({ action: "navigate", params: { target: paneId, url: "https://other.com" } })
@@ -463,6 +469,8 @@ Meta:
 
 ## Screenshot guidance
 
+- **Always screenshot with `screenshot({ scope: "tab", target: tabId })` after open-browser.** Network errors, blank pages, and CORS failures are silent unless you look. open-browser returns a tabId — use it immediately to confirm the page rendered before acting on it.
+- Tab and pane IDs from earlier in a session may become stale after reconnections or server restarts. If screenshot fails to find a tab/pane, call list-tabs or list-panes to get fresh IDs rather than reusing old ones.
 - Use a dedicated canary tab when validating screenshot behavior so live project panes are not contaminated.
 - Close temporary tabs/panes after verification unless user asked to keep them open.
 - Browser panes: proxied localhost URLs render actual content in the iframe screenshot. Truly cross-origin URLs (e.g. https://example.com) render a placeholder message with the source URL instead of a blank region.


### PR DESCRIPTION
## Summary

Agents using the Freshell MCP tool were hitting two avoidable pitfalls:

1. **Stale tab/pane IDs** — IDs from `open-browser`, `new-tab`, and `split-pane` become invalid after server restarts or session reconnects. Agents were reusing old IDs, causing "tab not found" errors.

2. **Silent browser failures** — After `open-browser`, agents assumed the page loaded successfully. Network errors, CORS issues, and blank pages went undetected because no screenshot was taken to confirm.

## Changes

Three places in `server/mcp/freshell-tool.ts` (all documentation/template strings, no code logic):

- **Key gotchas**: added two new bullets — tab IDs are ephemeral, always screenshot after open-browser
- **open-browser playbook**: added a `screenshot` call after `open-browser` showing the exact command
- **Screenshot guidance**: added confirmation-first guidance and stale-ID recovery note

## Test plan

- [x] String-only change; no logic affected
- [x] Lint passes (pre-existing zod locale warnings unrelated)