### PR TITLE
Fix Codex skill discovery cwd in Freshell panes

### DIFF
--- a/server/coding-cli/codex-app-server/launch-planner.ts
+++ b/server/coding-cli/codex-app-server/launch-planner.ts
@@ -74,7 +74,7 @@ export class CodexLaunchPlanner {
 
     try {
       if (input.resumeSessionId) {
-        const ready = await runtime.ensureReady()
+        const ready = await runtime.ensureReady(input.cwd)
         this.assertAcceptingPlans()
         return {
           sessionId: input.resumeSessionId,

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -65,6 +65,7 @@ type ChildProcessHandle = ReturnType<typeof spawn>
 type RuntimeOptions = {
   command?: string
   commandArgs?: string[]
+  cwd?: string
   env?: NodeJS.ProcessEnv
   requestTimeoutMs?: number
   startupAttemptLimit?: number
@@ -103,6 +104,11 @@ function sleep(ms: number): Promise<void> {
 function defaultMetadataDir(): string {
   return process.env.FRESHELL_CODEX_SIDECAR_DIR
     || path.join(os.homedir(), '.freshell', 'codex-sidecars')
+}
+
+function normalizeLaunchCwd(cwd: string | undefined): string | undefined {
+  const trimmed = cwd?.trim()
+  return trimmed ? trimmed : undefined
 }
 
 function assertUnixSidecarSupport(): void {
@@ -509,6 +515,7 @@ export class CodexAppServerRuntime {
 
   private readonly command: string
   private readonly commandArgs: string[]
+  private readonly defaultCwd?: string
   private readonly env?: NodeJS.ProcessEnv
   private readonly requestTimeoutMs?: number
   private readonly startupAttemptLimit: number
@@ -519,10 +526,13 @@ export class CodexAppServerRuntime {
   private readonly ownershipIdFactory: () => string
   private readonly metadataWriter: (filePath: string, metadata: CodexSidecarOwnershipMetadata) => Promise<void>
   private readonly processIdentityReader: (pid: number) => Promise<WrapperIdentity | null>
+  private readyCwd: string | undefined
+  private ensureReadyCwd: string | undefined
 
   constructor(options: RuntimeOptions = {}) {
     this.command = options.command ?? (process.env.CODEX_CMD || 'codex')
     this.commandArgs = options.commandArgs ?? []
+    this.defaultCwd = normalizeLaunchCwd(options.cwd)
     this.env = options.env
     this.requestTimeoutMs = options.requestTimeoutMs
     this.startupAttemptLimit = options.startupAttemptLimit ?? DEFAULT_STARTUP_ATTEMPT_LIMIT
@@ -539,19 +549,38 @@ export class CodexAppServerRuntime {
     return this.statusValue
   }
 
-  async ensureReady(): Promise<ReadyState> {
+  private assertCompatibleLaunchCwd(requestedCwd: string | undefined, activeCwd: string | undefined): void {
+    if (!requestedCwd || requestedCwd === activeCwd) return
+    throw new Error(
+      activeCwd
+        ? `Codex app-server sidecar is already starting or running in cwd ${activeCwd}; it cannot be reused for cwd ${requestedCwd}.`
+        : `Codex app-server sidecar is already starting or running without an explicit cwd; it cannot be reused for cwd ${requestedCwd}.`,
+    )
+  }
+
+  async ensureReady(cwd?: string): Promise<ReadyState> {
     if (this.shutdownRequested) {
       throw new Error('Codex app-server sidecar is shutting down.')
     }
     await this.assertNoBlockedOwnership('ensure Codex app-server sidecar readiness')
-    if (this.ready) return this.ready
-    if (this.ensureReadyPromise) return this.ensureReadyPromise
+    const launchCwd = normalizeLaunchCwd(cwd) ?? this.defaultCwd
+    if (this.ready) {
+      this.assertCompatibleLaunchCwd(launchCwd, this.readyCwd)
+      return this.ready
+    }
+    if (this.ensureReadyPromise) {
+      this.assertCompatibleLaunchCwd(launchCwd, this.ensureReadyCwd)
+      return this.ensureReadyPromise
+    }
 
-    this.ensureReadyPromise = this.startRuntime().finally(() => {
+    this.ensureReadyCwd = launchCwd
+    this.ensureReadyPromise = this.startRuntime(launchCwd).finally(() => {
       this.ensureReadyPromise = null
+      this.ensureReadyCwd = undefined
     })
 
     this.ready = await this.ensureReadyPromise
+    this.readyCwd = launchCwd
     this.statusValue = 'running'
     return this.ready
   }
@@ -559,7 +588,7 @@ export class CodexAppServerRuntime {
   async startThread(
     params: Omit<CodexThreadStartParams, 'experimentalRawEvents' | 'persistExtendedHistory'>,
   ): Promise<{ threadId: string; wsUrl: string }> {
-    const ready = await this.ensureReady()
+    const ready = await this.ensureReady(params.cwd)
     return {
       ...(await this.client!.startThread(params)),
       wsUrl: ready.wsUrl,
@@ -569,7 +598,7 @@ export class CodexAppServerRuntime {
   async resumeThread(
     params: Omit<CodexThreadResumeParams, 'persistExtendedHistory'>,
   ): Promise<{ threadId: string; wsUrl: string }> {
-    const ready = await this.ensureReady()
+    const ready = await this.ensureReady(params.cwd)
     return {
       ...(await this.client!.resumeThread(params)),
       wsUrl: ready.wsUrl,
@@ -651,6 +680,8 @@ export class CodexAppServerRuntime {
       const pendingReady = this.ensureReadyPromise
       this.ready = null
       this.ensureReadyPromise = null
+      this.readyCwd = undefined
+      this.ensureReadyCwd = undefined
       this.statusValue = 'stopped'
 
       const client = this.client
@@ -672,7 +703,7 @@ export class CodexAppServerRuntime {
     await this.stopActiveChild()
   }
 
-  private async startRuntime(): Promise<ReadyState> {
+  private async startRuntime(cwd?: string): Promise<ReadyState> {
     await assertProcOwnershipProofAvailable()
     await this.waitForOwnershipTeardown()
     await this.assertNoBlockedOwnership('start a new Codex app-server sidecar')
@@ -695,6 +726,7 @@ export class CodexAppServerRuntime {
         wsUrl,
       ], {
         detached: true,
+        ...(cwd ? { cwd } : {}),
         env: {
           ...process.env,
           ...this.env,
@@ -906,6 +938,8 @@ export class CodexAppServerRuntime {
           this.child = null
           this.ready = null
           this.ensureReadyPromise = null
+          this.readyCwd = undefined
+          this.ensureReadyCwd = undefined
           this.statusValue = 'stopped'
         }
         resolve(launchError)
@@ -923,6 +957,8 @@ export class CodexAppServerRuntime {
       this.child = null
       this.ready = null
       this.ensureReadyPromise = null
+      this.readyCwd = undefined
+      this.ensureReadyCwd = undefined
       this.statusValue = 'stopped'
 
       const client = this.client
@@ -961,6 +997,9 @@ export class CodexAppServerRuntime {
     const child = this.child
     this.child = null
     this.ready = null
+    this.ensureReadyPromise = null
+    this.readyCwd = undefined
+    this.ensureReadyCwd = undefined
     this.statusValue = 'stopped'
 
     if (!ownership) {

--- a/server/mcp/freshell-tool.ts
+++ b/server/mcp/freshell-tool.ts
@@ -70,7 +70,7 @@ FRESHELL_URL and FRESHELL_TOKEN are already set in your environment.
 ## Key gotchas
 
 - **Tab and pane IDs are ephemeral.** IDs from open-browser, new-tab, and split-pane are valid only within the current session. If the Freshell server restarts or the agent conversation resumes after a disconnect, previously returned IDs may no longer exist. Always call open-browser or list-tabs fresh rather than reusing stale IDs.
-- **Always screenshot with `screenshot({ scope: "tab", target: tabId })` after open-browser.** Network errors, CORS issues, or server problems can cause blank pages. open-browser returns a tabId — use it immediately to screenshot and confirm the page rendered before proceeding.
+- **Always screenshot with \`screenshot({ scope: "tab", target: tabId })\` after open-browser.** Network errors, CORS issues, or server problems can cause blank pages. open-browser returns a tabId — use it immediately to screenshot and confirm the page rendered before proceeding.
 - send-keys: use literal mode (literal: true + keys as a string) for natural-language prompts or multi-word text. Do NOT append "ENTER" as literal text -- send the command with literal:true, then send ["ENTER"] as a separate call in token mode.
 - wait-for with stable (seconds of no output) is more reliable than pattern matching across different CLI providers.
 - Editor panes show "Loading..." until the tab is visited in the browser. When screenshotting multiple tabs, visit each tab first (select-tab), then loop back for screenshots.
@@ -469,7 +469,7 @@ Meta:
 
 ## Screenshot guidance
 
-- **Always screenshot with `screenshot({ scope: "tab", target: tabId })` after open-browser.** Network errors, blank pages, and CORS failures are silent unless you look. open-browser returns a tabId — use it immediately to confirm the page rendered before acting on it.
+- **Always screenshot with \`screenshot({ scope: "tab", target: tabId })\` after open-browser.** Network errors, blank pages, and CORS failures are silent unless you look. open-browser returns a tabId — use it immediately to confirm the page rendered before acting on it.
 - Tab and pane IDs from earlier in a session may become stale after reconnections or server restarts. If screenshot fails to find a tab/pane, call list-tabs or list-panes to get fresh IDs rather than reusing old ones.
 - Use a dedicated canary tab when validating screenshot behavior so live project panes are not contaminated.
 - Close temporary tabs/panes after verification unless user asked to keep them open.

--- a/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
@@ -14,6 +14,8 @@ function deferred<T = void>() {
 class FakeRuntime {
   shutdownCalls = 0
   startThreadCalls = 0
+  ensureReadyCalls: Array<string | undefined> = []
+  startThreadParams: unknown[] = []
   adopted: Array<{ terminalId: string; generation: number }> = []
   loadedThreadListCalls = 0
   adoptError?: Error
@@ -28,7 +30,8 @@ class FakeRuntime {
     private readonly loadedThreadLists: string[][] = [],
   ) {}
 
-  async ensureReady() {
+  async ensureReady(cwd?: string) {
+    this.ensureReadyCalls.push(cwd)
     return {
       wsUrl: this.wsUrl,
       processPid: 100,
@@ -38,8 +41,9 @@ class FakeRuntime {
     }
   }
 
-  async startThread() {
+  async startThread(params?: unknown) {
     this.startThreadCalls += 1
+    this.startThreadParams.push(params)
     await this.startThreadBlocker
     if (this.startError) throw this.startError
     return {
@@ -84,6 +88,8 @@ describe('CodexLaunchPlanner', () => {
     expect(runtimes).toHaveLength(2)
     expect(first.remote.wsUrl).toBe('ws://127.0.0.1:43001')
     expect(second.remote.wsUrl).toBe('ws://127.0.0.1:43002')
+    expect(runtimes[0].startThreadParams[0]).toEqual(expect.objectContaining({ cwd: '/repo/one' }))
+    expect(runtimes[1].startThreadParams[0]).toEqual(expect.objectContaining({ cwd: '/repo/two' }))
 
     await first.sidecar.adopt({ terminalId: 'term-one', generation: 1 })
     await second.sidecar.shutdown()
@@ -313,6 +319,15 @@ describe('CodexLaunchPlanner', () => {
     await expect(plan.sidecar.waitForLoadedThread('thread-ready', { timeoutMs: 1_000, pollMs: 1 }))
       .resolves.toBeUndefined()
     expect(runtime.loadedThreadListCalls).toBe(3)
+  })
+
+  it('passes resume cwd to sidecar readiness', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43024', 'thread-ready', undefined, [['thread-ready']])
+    const planner = new CodexLaunchPlanner(() => runtime as any)
+
+    await planner.planCreate({ resumeSessionId: 'thread-ready', cwd: '/repo/resume' })
+
+    expect(runtime.ensureReadyCalls).toEqual(['/repo/resume'])
   })
 
   it('stops loaded-thread readiness polling after sidecar shutdown starts', async () => {

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -1196,23 +1196,50 @@ describe('CodexAppServerRuntime', () => {
 
   it('proxies thread/start through the sidecar client after boot', async () => {
     const runtime = createRuntime()
+    const launchCwd = await makeTempDir()
 
-    await expect(runtime.startThread({ cwd: '/repo/worktree' })).resolves.toEqual({
+    await expect(runtime.startThread({ cwd: launchCwd })).resolves.toEqual({
       threadId: 'thread-new-1',
       wsUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
     })
   })
 
+  it('starts the app-server wrapper in the requested thread cwd', async () => {
+    const metadataDir = await makeTempDir()
+    const launchCwd = await makeTempDir()
+    const runtime = createRuntime({ metadataDir })
+
+    await runtime.startThread({ cwd: launchCwd })
+
+    const record = await waitForMetadataRecord(metadataDir)
+    expect(record.wrapperIdentity.cwd).toBe(launchCwd)
+  })
+
   it('proxies thread/resume through the sidecar client after boot', async () => {
     const runtime = createRuntime()
+    const launchCwd = await makeTempDir()
 
     await expect(runtime.resumeThread({
       threadId: '019d9859-5670-72b1-851f-794ad7fef112',
-      cwd: '/repo/worktree',
+      cwd: launchCwd,
     })).resolves.toEqual({
       threadId: '019d9859-5670-72b1-851f-794ad7fef112',
       wsUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
     })
+  })
+
+  it('starts the app-server wrapper in the requested resume cwd', async () => {
+    const metadataDir = await makeTempDir()
+    const launchCwd = await makeTempDir()
+    const runtime = createRuntime({ metadataDir })
+
+    await runtime.resumeThread({
+      threadId: '019d9859-5670-72b1-851f-794ad7fef112',
+      cwd: launchCwd,
+    })
+
+    const record = await waitForMetadataRecord(metadataDir)
+    expect(record.wrapperIdentity.cwd).toBe(launchCwd)
   })
 
   it('drops cached state after an unexpected child exit and starts a fresh process on the next call', async () => {
@@ -1249,6 +1276,7 @@ describe('CodexAppServerRuntime', () => {
   })
 
   it('keeps child stdio drained so large app-server logs do not stall thread/start replies', async () => {
+    const launchCwd = await makeTempDir()
     const runtime = createRuntime({
       env: {
         FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
@@ -1260,13 +1288,14 @@ describe('CodexAppServerRuntime', () => {
       requestTimeoutMs: 1_500,
     })
 
-    await expect(runtime.startThread({ cwd: '/repo/worktree' })).resolves.toEqual({
+    await expect(runtime.startThread({ cwd: launchCwd })).resolves.toEqual({
       threadId: 'thread-new-1',
       wsUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
     })
   })
 
   it('keeps child stderr drained so large app-server error logs do not stall thread/resume replies', async () => {
+    const launchCwd = await makeTempDir()
     const runtime = createRuntime({
       env: {
         FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
@@ -1280,7 +1309,7 @@ describe('CodexAppServerRuntime', () => {
 
     await expect(runtime.resumeThread({
       threadId: '019d9859-5670-72b1-851f-794ad7fef112',
-      cwd: '/repo/worktree',
+      cwd: launchCwd,
     })).resolves.toEqual({
       threadId: '019d9859-5670-72b1-851f-794ad7fef112',
       wsUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),


### PR DESCRIPTION
## Summary
- Launch the Codex app-server sidecar in the requested pane cwd instead of inheriting the Freshell server cwd.
- Thread cwd through fresh and resumed Codex launch planning.
- Add focused coverage for runtime sidecar cwd and launch-planner readiness behavior.

## Verification
- npm run test:vitest -- test/unit/server/coding-cli/codex-app-server/runtime.test.ts test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts --run
- PORT=3356 npm run build
- Dev-proof temp server on PORT=3357 showed a /tmp Codex pane with both [Skill] entries and the GitHub [Plugin], and sidecar metadata reported wrapper cwd /tmp.