### PR TITLE
Document green-base gate before creating worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Freshell is a self-hosted, browser-accessible terminal multiplexer and session o
 
 ## Repo Rules
 - Always work in a worktree (in \.worktrees\)
+- Before creating a new worktree, ensure the repo-supported test suite is green on the intended base. If the suite is not green, pause before creating the worktree and notify the user with the failing command and failure summary.
 - New behavior changes start on a worktree branch from `origin/main` and are submitted as PRs to `origin/main`; local `dev` only consumes PR heads.
 - Many agents may be working in the worktree at the same time. If you see activity from other agents (for example test runs or file changes), respect it.
 - Specific user instructions override ALL other instructions, including the above, and including superpowers or skills


### PR DESCRIPTION
## Summary
- Add an AGENTS.md repo rule requiring agents to verify the repo-supported suite is green on the intended base before creating a new worktree.
- Require agents to pause and report the failing command and failure summary when the base is not green.

## Verification
- Documentation-only change; no code tests run.
- `npm run test:status` currently reports the latest coordinated full/check/unit/client/server-related runs as failing, so this was landed under explicit user instruction despite the new rule’s pause condition.