### PR TITLE
fix: recover from stale Vite chunk load failures

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ import { handleSdkMessage } from '@/lib/sdk-message-handler'
 import { createLogger } from '@/lib/client-logger'
 import type { LocalSettingsPatch, ServerSettings } from '@shared/settings'
 import { z } from 'zod'
+import { withChunkErrorRecovery } from '@/lib/import-retry'
 
 const log = createLogger('App')
 
@@ -89,9 +90,9 @@ function ShareQrCode({ url }: { url: string }) {
   return <img src={svgUrl} alt="QR code for access URL" className="w-48 h-48" />
 }
 
-const HistoryView = lazy(() => import('@/components/HistoryView'))
-const SettingsView = lazy(() => import('@/components/SettingsView'))
-const ExtensionsView = lazy(() => import('@/components/ExtensionsView'))
+const HistoryView = lazy(() => withChunkErrorRecovery(import('@/components/HistoryView')))
+const SettingsView = lazy(() => withChunkErrorRecovery(import('@/components/SettingsView')))
+const ExtensionsView = lazy(() => withChunkErrorRecovery(import('@/components/ExtensionsView')))
 
 const SIDEBAR_MIN_WIDTH = 200
 const SIDEBAR_MAX_WIDTH = 500

--- a/src/components/markdown/LazyMarkdown.tsx
+++ b/src/components/markdown/LazyMarkdown.tsx
@@ -1,7 +1,8 @@
 import { lazy, Suspense, type ReactNode } from 'react'
+import { withChunkErrorRecovery } from '@/lib/import-retry'
 
 const MarkdownRenderer = lazy(() =>
-  import('./MarkdownRenderer').then((module) => ({ default: module.MarkdownRenderer }))
+  withChunkErrorRecovery(import('./MarkdownRenderer')).then((module) => ({ default: module.MarkdownRenderer }))
 )
 
 type LazyMarkdownProps = {

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -17,6 +17,7 @@ import { clearDraft } from '@/lib/draft-store'
 import { getTerminalActions } from '@/lib/pane-action-registry'
 import { buildPaneRefreshTarget } from '@/lib/pane-utils'
 import { cn } from '@/lib/utils'
+import { withChunkErrorRecovery } from '@/lib/import-retry'
 import { getWsClient } from '@/lib/ws-client'
 import { api } from '@/lib/api'
 import { resolvePaneActivity } from '@/lib/pane-activity'
@@ -58,7 +59,7 @@ const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecor
 const EMPTY_ATTENTION_BY_PANE: Record<string, boolean> = {}
 const EMPTY_PENDING_CREATES: Record<string, PendingAgentCreate> = {}
 const EMPTY_EXTENSION_ENTRIES: ClientExtensionEntry[] = []
-const EditorPane = lazy(() => import('./EditorPane'))
+const EditorPane = lazy(() => withChunkErrorRecovery(import('./EditorPane')))
 
 interface PaneContainerProps {
   tabId: string

--- a/src/components/ui/error-boundary.tsx
+++ b/src/components/ui/error-boundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { isChunkLoadError } from '@/lib/import-retry'
 
 type ErrorBoundaryProps = {
   children: ReactNode
@@ -30,6 +31,16 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   private handleReset = () => {
+    const err = this.state.error
+    if (err != null && isChunkLoadError(err)) {
+      const key = 'freshell.chunk-reload'
+      const last = sessionStorage.getItem(key)
+      if (!last || Date.now() - parseInt(last, 10) >= 10_000) {
+        sessionStorage.setItem(key, String(Date.now()))
+        window.location.reload()
+        return
+      }
+    }
     this.setState({ hasError: false, error: null })
   }
 

--- a/src/components/ui/error-boundary.tsx
+++ b/src/components/ui/error-boundary.tsx
@@ -1,5 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
-import { isChunkLoadError } from '@/lib/import-retry'
+import { isChunkLoadError, shouldReload } from '@/lib/import-retry'
 
 type ErrorBoundaryProps = {
   children: ReactNode
@@ -33,10 +33,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   private handleReset = () => {
     const err = this.state.error
     if (err != null && isChunkLoadError(err)) {
-      const key = 'freshell.chunk-reload'
-      const last = sessionStorage.getItem(key)
-      if (!last || Date.now() - parseInt(last, 10) >= 10_000) {
-        sessionStorage.setItem(key, String(Date.now()))
+      if (shouldReload()) {
         window.location.reload()
         return
       }

--- a/src/lib/import-retry.ts
+++ b/src/lib/import-retry.ts
@@ -1,0 +1,47 @@
+const CHUNK_ERROR_RE =
+  /(?:failed to fetch|error loading).*dynamically imported module|importing a module script|loading chunk \d+ failed/i
+
+const RELOAD_KEY = 'freshell.chunk-reload'
+const RELOAD_COOLDOWN_MS = 10_000
+
+export function isChunkLoadError(err: unknown): boolean {
+  return err instanceof TypeError && CHUNK_ERROR_RE.test(err.message)
+}
+
+function shouldReload(): boolean {
+  const last = sessionStorage.getItem(RELOAD_KEY)
+  if (last && Date.now() - parseInt(last, 10) < RELOAD_COOLDOWN_MS) {
+    return false
+  }
+  sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
+  return true
+}
+
+export function withChunkErrorRecovery<T>(importPromise: Promise<T>): Promise<T> {
+  return importPromise.catch((err: unknown) => {
+    if (isChunkLoadError(err)) {
+      if (shouldReload()) {
+        window.location.reload()
+        return new Promise<never>(() => {})
+      }
+      throw err
+    }
+    throw err
+  })
+}
+
+export function initChunkErrorRecovery(): void {
+  window.addEventListener('vite:preloadError', (event) => {
+    if (shouldReload()) {
+      event.preventDefault()
+      window.location.reload()
+    }
+  })
+
+  window.addEventListener('unhandledrejection', (event) => {
+    if (isChunkLoadError(event.reason) && shouldReload()) {
+      event.preventDefault()
+      window.location.reload()
+    }
+  })
+}

--- a/src/lib/import-retry.ts
+++ b/src/lib/import-retry.ts
@@ -1,20 +1,24 @@
 const CHUNK_ERROR_RE =
   /(?:failed to fetch|error loading).*dynamically imported module|importing a module script|loading chunk \d+ failed/i
 
-const RELOAD_KEY = 'freshell.chunk-reload'
+export const RELOAD_KEY = 'freshell.chunk-reload'
 const RELOAD_COOLDOWN_MS = 10_000
 
 export function isChunkLoadError(err: unknown): boolean {
   return err instanceof TypeError && CHUNK_ERROR_RE.test(err.message)
 }
 
-function shouldReload(): boolean {
-  const last = sessionStorage.getItem(RELOAD_KEY)
-  if (last && Date.now() - parseInt(last, 10) < RELOAD_COOLDOWN_MS) {
-    return false
+export function shouldReload(): boolean {
+  try {
+    const last = sessionStorage.getItem(RELOAD_KEY)
+    if (last && Date.now() - parseInt(last, 10) < RELOAD_COOLDOWN_MS) {
+      return false
+    }
+    sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
+    return true
+  } catch {
+    return true
   }
-  sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
-  return true
 }
 
 export function withChunkErrorRecovery<T>(importPromise: Promise<T>): Promise<T> {
@@ -30,7 +34,12 @@ export function withChunkErrorRecovery<T>(importPromise: Promise<T>): Promise<T>
   })
 }
 
+let recoveryInitialized = false
+
 export function initChunkErrorRecovery(): void {
+  if (recoveryInitialized) return
+  recoveryInitialized = true
+
   window.addEventListener('vite:preloadError', (event) => {
     if (shouldReload()) {
       event.preventDefault()

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,11 +9,13 @@ import { initializeAuthToken } from '@/lib/auth'
 import { createClientLogger } from '@/lib/client-logger'
 import { initClientPerfLogging } from '@/lib/perf-logger'
 import { registerServiceWorker } from '@/lib/pwa'
+import { initChunkErrorRecovery } from '@/lib/import-retry'
 
 initializeAuthToken()
 createClientLogger().installConsoleCapture()
 initClientPerfLogging()
 registerServiceWorker()
+initChunkErrorRecovery()
 
 if (import.meta.env.DEV) {
   document.title = 'freshell:dev'

--- a/test/unit/client/components/ui/error-boundary.test.tsx
+++ b/test/unit/client/components/ui/error-boundary.test.tsx
@@ -125,4 +125,101 @@ describe('ErrorBoundary', () => {
     await user.click(screen.getByRole('button', { name: 'Go to Overview' }))
     expect(onNavigate).toHaveBeenCalledTimes(1)
   })
+
+  describe('chunk-load error recovery', () => {
+    const originalReload = window.location.reload
+
+    beforeEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: { ...window.location, reload: vi.fn() },
+        writable: true,
+        configurable: true,
+      })
+      sessionStorage.clear()
+    })
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: { ...window.location, reload: originalReload },
+        writable: true,
+        configurable: true,
+      })
+    })
+
+    it('reloads the page when Try Again is clicked on a Chrome chunk-load error', async () => {
+      const user = userEvent.setup()
+      const chunkError = new TypeError(
+        'Failed to fetch dynamically imported module: http://192.168.3.50:3001/assets/EditorPane-DAYbRo9B.js'
+      )
+      function BadImport() {
+        throw chunkError
+      }
+      render(
+        <ErrorBoundary label="Editor">
+          <BadImport />
+        </ErrorBoundary>
+      )
+      await user.click(screen.getByRole('button', { name: 'Try Again' }))
+      expect(window.location.reload).toHaveBeenCalled()
+    })
+
+    it('reloads on Firefox-style chunk error', async () => {
+      const user = userEvent.setup()
+      const err = new TypeError(
+        'error loading dynamically imported module: http://localhost/assets/chunk.js'
+      )
+      function BadImport() {
+        throw err
+      }
+      render(
+        <ErrorBoundary>
+          <BadImport />
+        </ErrorBoundary>
+      )
+      await user.click(screen.getByRole('button', { name: 'Try Again' }))
+      expect(window.location.reload).toHaveBeenCalled()
+    })
+
+    it('still resets state for non-chunk errors (no reload)', async () => {
+      const user = userEvent.setup()
+      let shouldThrow = true
+      function ToggleChild() {
+        if (shouldThrow) throw new Error('Regular error')
+        return <div>Recovered</div>
+      }
+      const { container, rerender } = render(
+        <ErrorBoundary>
+          <ToggleChild />
+        </ErrorBoundary>
+      )
+      expect(within(container).getByRole('alert')).toBeInTheDocument()
+      shouldThrow = false
+      await user.click(within(container).getByRole('button', { name: 'Try Again' }))
+      rerender(
+        <ErrorBoundary>
+          <ToggleChild />
+        </ErrorBoundary>
+      )
+      expect(within(container).getByText('Recovered')).toBeInTheDocument()
+      expect(window.location.reload).not.toHaveBeenCalled()
+    })
+
+    it('does not reload if circuit breaker is tripped', async () => {
+      sessionStorage.setItem('freshell.chunk-reload', String(Date.now()))
+      const user = userEvent.setup()
+      const err = new TypeError(
+        'Failed to fetch dynamically imported module: http://localhost/assets/chunk.js'
+      )
+      function BadImport() {
+        throw err
+      }
+      render(
+        <ErrorBoundary>
+          <BadImport />
+        </ErrorBoundary>
+      )
+      await user.click(screen.getByRole('button', { name: 'Try Again' }))
+      expect(window.location.reload).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/test/unit/client/lib/chunk-error-recovery.test.ts
+++ b/test/unit/client/lib/chunk-error-recovery.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { initChunkErrorRecovery } from '@/lib/import-retry'
+
+function createRejectionEvent(reason: unknown): Event {
+  const event = new Event('unhandledrejection', { cancelable: true })
+  Object.defineProperty(event, 'reason', { value: reason, writable: false })
+  return event
+}
+
+describe('initChunkErrorRecovery', () => {
+  const originalReload = window.location.reload
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: vi.fn() },
+      writable: true,
+      configurable: true,
+    })
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: originalReload },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it('reloads on vite:preloadError event', () => {
+    initChunkErrorRecovery()
+    const event = new Event('vite:preloadError', { cancelable: true })
+    window.dispatchEvent(event)
+    expect(window.location.reload).toHaveBeenCalled()
+  })
+
+  it('reloads on unhandledrejection with chunk-load error', () => {
+    initChunkErrorRecovery()
+    const err = new TypeError(
+      'Failed to fetch dynamically imported module: http://localhost/assets/chunk-abc123.js'
+    )
+    window.dispatchEvent(createRejectionEvent(err))
+    expect(window.location.reload).toHaveBeenCalled()
+  })
+
+  it('does not reload on unhandledrejection with non-chunk error', () => {
+    initChunkErrorRecovery()
+    const err = new Error('Something else')
+    window.dispatchEvent(createRejectionEvent(err))
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+
+  it('respects circuit breaker on vite:preloadError', () => {
+    sessionStorage.setItem('freshell.chunk-reload', String(Date.now()))
+    initChunkErrorRecovery()
+    const event = new Event('vite:preloadError', { cancelable: true })
+    window.dispatchEvent(event)
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/client/lib/chunk-error-recovery.test.ts
+++ b/test/unit/client/lib/chunk-error-recovery.test.ts
@@ -57,4 +57,12 @@ describe('initChunkErrorRecovery', () => {
     window.dispatchEvent(event)
     expect(window.location.reload).not.toHaveBeenCalled()
   })
+
+  it('is idempotent — calling initChunkErrorRecovery multiple times does not double-fire', () => {
+    initChunkErrorRecovery()
+    initChunkErrorRecovery()
+    const event = new Event('vite:preloadError', { cancelable: true })
+    window.dispatchEvent(event)
+    expect(window.location.reload).toHaveBeenCalledTimes(1)
+  })
 })

--- a/test/unit/client/lib/import-retry.test.ts
+++ b/test/unit/client/lib/import-retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { withChunkErrorRecovery } from '@/lib/import-retry'
+import { withChunkErrorRecovery, shouldReload, isChunkLoadError } from '@/lib/import-retry'
 
 describe('withChunkErrorRecovery', () => {
   const originalReload = window.location.reload
@@ -99,5 +99,46 @@ describe('withChunkErrorRecovery', () => {
       'string failure'
     )
     expect(window.location.reload).not.toHaveBeenCalled()
+  })
+})
+
+describe('shouldReload', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('returns true on first call', () => {
+    expect(shouldReload()).toBe(true)
+  })
+
+  it('returns false if called within cooldown window', () => {
+    sessionStorage.setItem('freshell.chunk-reload', String(Date.now()))
+    expect(shouldReload()).toBe(false)
+  })
+
+  it('returns true after cooldown expires', () => {
+    sessionStorage.setItem('freshell.chunk-reload', String(Date.now() - 20_000))
+    expect(shouldReload()).toBe(true)
+  })
+
+  it('returns true when sessionStorage is unavailable', () => {
+    const originalGetItem = sessionStorage.getItem
+    sessionStorage.getItem = () => { throw new DOMException('SecurityError') }
+    expect(shouldReload()).toBe(true)
+    sessionStorage.getItem = originalGetItem
+  })
+})
+
+describe('isChunkLoadError', () => {
+  it('returns false for non-TypeError errors', () => {
+    const err = new RangeError(
+      'Failed to fetch dynamically imported module: http://localhost/assets/chunk.js'
+    )
+    expect(isChunkLoadError(err)).toBe(false)
+  })
+
+  it('returns false for matching message in regular Error', () => {
+    const err = new Error('importing a module script')
+    expect(isChunkLoadError(err)).toBe(false)
   })
 })

--- a/test/unit/client/lib/import-retry.test.ts
+++ b/test/unit/client/lib/import-retry.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { withChunkErrorRecovery } from '@/lib/import-retry'
+
+describe('withChunkErrorRecovery', () => {
+  const originalReload = window.location.reload
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: vi.fn() },
+      writable: true,
+      configurable: true,
+    })
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: originalReload },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it('resolves with the module when import succeeds', async () => {
+    const mod = { foo: 'bar' }
+    const result = await withChunkErrorRecovery(Promise.resolve(mod))
+    expect(result).toBe(mod)
+  })
+
+  describe('chunk-load error detection', () => {
+    it('reloads on Chrome-style chunk error', async () => {
+      const err = new TypeError(
+        'Failed to fetch dynamically imported module: http://localhost/assets/chunk-abc123.js'
+      )
+      const p = withChunkErrorRecovery(Promise.reject(err))
+      await new Promise((r) => setTimeout(r, 0))
+      expect(window.location.reload).toHaveBeenCalled()
+    })
+
+    it('reloads on Firefox-style chunk error', async () => {
+      const err = new TypeError(
+        'error loading dynamically imported module: http://localhost/assets/chunk-abc123.js'
+      )
+      const p = withChunkErrorRecovery(Promise.reject(err))
+      await new Promise((r) => setTimeout(r, 0))
+      expect(window.location.reload).toHaveBeenCalled()
+    })
+
+    it('reloads on Safari-style chunk error', async () => {
+      const err = new TypeError('Importing a module script failed.')
+      const p = withChunkErrorRecovery(Promise.reject(err))
+      await new Promise((r) => setTimeout(r, 0))
+      expect(window.location.reload).toHaveBeenCalled()
+    })
+
+    it('reloads on Vite-style chunk failure', async () => {
+      const err = new TypeError('loading chunk 42 failed')
+      const p = withChunkErrorRecovery(Promise.reject(err))
+      await new Promise((r) => setTimeout(r, 0))
+      expect(window.location.reload).toHaveBeenCalled()
+    })
+
+    it('does not reload on unrelated TypeError', async () => {
+      const err = new TypeError('NetworkError when attempting to fetch resource.')
+      await expect(withChunkErrorRecovery(Promise.reject(err))).rejects.toBe(err)
+      expect(window.location.reload).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('circuit breaker', () => {
+    it('does not reload if a reload happened within cooldown window', async () => {
+      sessionStorage.setItem('freshell.chunk-reload', String(Date.now()))
+      const err = new TypeError(
+        'Failed to fetch dynamically imported module: http://localhost/assets/chunk-abc123.js'
+      )
+      await expect(withChunkErrorRecovery(Promise.reject(err))).rejects.toBe(err)
+      expect(window.location.reload).not.toHaveBeenCalled()
+    })
+
+    it('reloads if the previous reload was outside cooldown window', async () => {
+      sessionStorage.setItem('freshell.chunk-reload', String(Date.now() - 20_000))
+      const err = new TypeError(
+        'Failed to fetch dynamically imported module: http://localhost/assets/chunk-abc123.js'
+      )
+      const p = withChunkErrorRecovery(Promise.reject(err))
+      await new Promise((r) => setTimeout(r, 0))
+      expect(window.location.reload).toHaveBeenCalled()
+    })
+  })
+
+  it('re-throws regular Error unchanged', async () => {
+    const err = new Error('Something else broke')
+    await expect(withChunkErrorRecovery(Promise.reject(err))).rejects.toBe(err)
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+
+  it('re-throws non-Error rejections unchanged', async () => {
+    await expect(withChunkErrorRecovery(Promise.reject('string failure'))).rejects.toBe(
+      'string failure'
+    )
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Supersedes #337. PR #337 is stale/dev-based and carries unrelated old dev/fresh-agent history; this replacement branch is rebuilt from current origin/main and only ports the focused chunk-recovery work.

Ported commits/content:
- 4ae106c0 feat: add withChunkErrorRecovery utility with broad chunk-error detection and circuit breaker
- aa6e1f0d feat: add global vite:preloadError and unhandledrejection listener for chunk-error recovery
- 890dcfb6 fix: wrap all 5 lazy imports with chunk-error recovery
- 55c9db5d fix: reload page on chunk-load errors in ErrorBoundary Try Again with circuit breaker
- fdbefe52 refactor: export shouldReload, add try/catch on sessionStorage, make initChunkErrorRecovery idempotent, add unit test coverage

Scope:
- Detect stale Vite chunk-load failures across lazy imports, preload errors, and unhandled promise rejections.
- Reload once through a sessionStorage circuit breaker instead of repeatedly reloading.
- Add focused client unit coverage for the recovery utility, global recovery setup, and ErrorBoundary Try Again behavior.

Verification:
- PASS: `FRESHELL_TEST_SUMMARY="chunk recovery focused tests" npm run test:vitest -- --run test/unit/client/lib/import-retry.test.ts test/unit/client/lib/chunk-error-recovery.test.ts test/unit/client/components/ui/error-boundary.test.tsx` (32 tests).
- PARTIAL: `PORT=3345 npm run build` passed client typecheck and Vite client build, then failed server compilation in unchanged `/home/user/code/freshell/.worktrees/chunk-error-recovery-main-20260518/server/mcp/freshell-tool.ts` at lines 73 and 472. The same syntax exists on current `origin/main`; this branch does not touch that file.