### PR TITLE
Port multi-row tabs setting to main

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -97,6 +97,9 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
   background: hsl(var(--background)); flex-shrink: 0; position: relative; z-index: 20;
   transition: background-color .2s; gap: 2px;
 }
+.tabbar.multirow {
+  height: auto; max-height: 128px; flex-wrap: wrap; overflow-y: auto;
+}
 .tabbar::after {
   content: ''; position: absolute; inset: auto 0 0 0; height: 1px;
   background: hsl(var(--muted-foreground) / .45); z-index: 0;

--- a/shared/settings.ts
+++ b/shared/settings.ts
@@ -53,7 +53,7 @@ const TERMINAL_LOCAL_KEYS = [
   'osc52Clipboard',
   'renderer',
 ] as const
-const PANES_LOCAL_KEYS = ['snapThreshold', 'iconsOnTabs', 'tabAttentionStyle', 'attentionDismiss', 'sessionOpenMode'] as const
+const PANES_LOCAL_KEYS = ['snapThreshold', 'iconsOnTabs', 'tabAttentionStyle', 'attentionDismiss', 'sessionOpenMode', 'multirowTabs'] as const
 const SIDEBAR_LOCAL_KEYS = [
   'sortMode',
   'worktreeGrouping',
@@ -178,6 +178,7 @@ export type LocalSettings = {
     tabAttentionStyle: TabAttentionStyle
     attentionDismiss: AttentionDismiss
     sessionOpenMode: SessionOpenMode
+    multirowTabs: boolean
   }
   sidebar: {
     sortMode: SidebarSortMode
@@ -434,6 +435,9 @@ function normalizeExtractedLocalSeed(patch: Record<string, unknown>): LocalSetti
     }
     if (SessionOpenModeSchema.safeParse(patch.panes.sessionOpenMode).success) {
       panes.sessionOpenMode = patch.panes.sessionOpenMode as SessionOpenMode
+    }
+    if (typeof patch.panes.multirowTabs === 'boolean') {
+      panes.multirowTabs = patch.panes.multirowTabs as boolean
     }
     if (Object.keys(panes).length > 0) {
       normalized.panes = panes
@@ -723,6 +727,7 @@ export const defaultLocalSettings: LocalSettings = {
     tabAttentionStyle: 'highlight',
     attentionDismiss: 'click',
     sessionOpenMode: 'tab',
+    multirowTabs: false,
   },
   sidebar: {
     sortMode: 'activity',

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -449,6 +449,24 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
         className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-muted-foreground/45"
         aria-hidden="true"
       />
+      {sidebarCollapsed && onToggleSidebar && (
+        <div
+          className={cn(
+            "flex-shrink-0 w-10 flex items-end justify-center pb-1",
+            !multirowTabs && "h-full"
+          )}
+          data-testid="desktop-sidebar-reopen-slot"
+        >
+          <button
+            className="p-1 min-h-11 min-w-11 md:h-8 md:w-8 md:min-h-0 md:min-w-0 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-colors"
+            title="Show sidebar"
+            aria-label="Show sidebar"
+            onClick={onToggleSidebar}
+          >
+            <PanelLeft className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
       <DndContext
         sensors={sensors}
         collisionDetection={multirowTabs ? rectIntersection : closestCenter}
@@ -490,16 +508,6 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
                 : "overflow-x-auto overflow-y-hidden scrollbar-none"
             )}
           >
-            {sidebarCollapsed && onToggleSidebar && (
-              <button
-                className="flex-shrink-0 mb-1 p-1 min-h-11 min-w-11 md:min-h-0 md:min-w-0 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-colors"
-                title="Show sidebar"
-                aria-label="Show sidebar"
-                onClick={onToggleSidebar}
-              >
-                <PanelLeft className="h-3.5 w-3.5" />
-              </button>
-            )}
             {tabs.map(renderSortableTab)}
           </div>
 

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -7,7 +7,7 @@ import { getWsClient } from '@/lib/ws-client'
 import { getTabDisplayTitle } from '@/lib/tab-title'
 import { collectPaneEntries, collectTerminalIds } from '@/lib/pane-utils'
 import { getBusyPaneIdsForTab } from '@/lib/pane-activity'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTabBarScroll } from '@/hooks/useTabBarScroll'
 import TabItem from './TabItem'
 import { cancelCodingCliRequest } from '@/store/codingCliSlice'
@@ -17,6 +17,7 @@ import { TabSwitcher } from './TabSwitcher'
 import {
   DndContext,
   closestCenter,
+  rectIntersection,
   KeyboardSensor,
   PointerSensor,
   TouchSensor,
@@ -30,15 +31,23 @@ import {
   SortableContext,
   sortableKeyboardCoordinates,
   horizontalListSortingStrategy,
+  rectSortingStrategy,
   useSortable,
 } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
+import { CSS as DndCSS } from '@dnd-kit/utilities'
 import type { Tab, TabAttentionStyle } from '@/store/types'
 import type { PaneContent, PaneNode } from '@/store/paneTypes'
 import type { ChatSessionState } from '@/store/agentChatTypes'
 import type { PaneRuntimeActivityRecord } from '@/store/paneRuntimeActivitySlice'
 import { ContextIds } from '@/components/context-menu/context-menu-constants'
 import { applyTabRename } from '@/store/titleSync'
+
+function escapeSelector(id: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(id)
+  }
+  return id.replace(/(["\\])/g, '\\$1')
+}
 
 interface SortableTabProps {
   tab: Tab
@@ -90,7 +99,7 @@ function SortableTab({
   } = useSortable({ id: tab.id })
 
   const style = {
-    transform: CSS.Transform.toString(transform),
+    transform: DndCSS.Transform.toString(transform),
     transition: transition || 'transform 150ms ease',
   }
 
@@ -161,6 +170,7 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
   const attentionDismiss = useAppSelector((s) => s.settings?.settings?.panes?.attentionDismiss ?? 'click')
   const iconsOnTabs = useAppSelector((s) => s.settings?.settings?.panes?.iconsOnTabs ?? true)
   const tabAttentionStyle = useAppSelector((s) => s.settings?.settings?.panes?.tabAttentionStyle ?? 'highlight')
+  const multirowTabs = useAppSelector((s) => s.settings?.settings?.panes?.multirowTabs ?? false)
   const extensions = useAppSelector((s) => s.extensions?.entries)
 
   const ws = useMemo(() => getWsClient(), [])
@@ -369,11 +379,47 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
     callbackRef,
     canScrollLeft,
     canScrollRight,
+    scrollToTab,
     handleArrowClick,
     startHoldScroll,
     stopHoldScroll,
     cancelHoldScroll,
-  } = useTabBarScroll(activeTabId, tabs.length)
+  } = useTabBarScroll(activeTabId, tabs.length, multirowTabs)
+
+  // Container ref for multirow auto-scroll (scoped, not global DOM query)
+  const multirowContainerRef = useRef<HTMLDivElement | null>(null)
+  const combinedRef = useCallback((node: HTMLDivElement | null) => {
+    callbackRef(node)
+    multirowContainerRef.current = node
+  }, [callbackRef])
+
+  // Container-scoped scroll for active tab in multirow mode (vertical)
+  useEffect(() => {
+    if (!multirowTabs || !activeTabId) return
+    const container = multirowContainerRef.current
+    if (!container) return
+    const tabEl = container.querySelector(`[data-tab-id="${escapeSelector(activeTabId)}"]`) as HTMLElement | null
+    if (!tabEl) return
+    const containerRect = container.getBoundingClientRect()
+    const tabRect = tabEl.getBoundingClientRect()
+    // Only scroll if tab is outside the visible area
+    if (tabRect.top < containerRect.top || tabRect.bottom > containerRect.bottom) {
+      const offset = tabRect.top - containerRect.top - (containerRect.height / 2) + (tabRect.height / 2)
+      container.scrollBy({ top: offset, behavior: 'smooth' })
+    }
+  }, [activeTabId, multirowTabs])
+
+  // Re-fire horizontal scroll when transitioning from multirow to single-row
+  const prevMultirowRef = useRef(multirowTabs)
+  useEffect(() => {
+    let raf: number | null = null
+    if (prevMultirowRef.current && !multirowTabs && activeTabId) {
+      // Defer to next frame so the DOM has re-rendered with single-row layout
+      raf = requestAnimationFrame(() => scrollToTab(activeTabId))
+    }
+    prevMultirowRef.current = multirowTabs
+    return () => { if (raf !== null) cancelAnimationFrame(raf) }
+  }, [multirowTabs, activeTabId, scrollToTab])
 
   const activeTab = activeId ? tabs.find((t: Tab) => t.id === activeId) : null
 
@@ -395,43 +441,54 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
   }
 
   return (
-    <div className="relative z-20 h-12 md:h-10 shrink-0 flex items-end px-2 bg-background" data-context={ContextIds.Global}>
+    <div className={cn(
+      "relative z-20 shrink-0 flex items-end px-2 bg-background",
+      multirowTabs ? "h-auto" : "h-12 md:h-10"
+    )} data-context={ContextIds.Global}>
       <div
         className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-muted-foreground/45"
         aria-hidden="true"
       />
       <DndContext
         sensors={sensors}
-        collisionDetection={closestCenter}
+        collisionDetection={multirowTabs ? rectIntersection : closestCenter}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
       >
         <SortableContext
           items={tabs.map((t: Tab) => t.id)}
-          strategy={horizontalListSortingStrategy}
+          strategy={multirowTabs ? rectSortingStrategy : horizontalListSortingStrategy}
         >
           {/* Left scroll arrow -- flex sibling alongside the scroll container */}
-          <button
-            className={cn(
-              'flex-shrink-0 w-7 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-all duration-150',
-              canScrollLeft ? 'opacity-100' : 'opacity-0 pointer-events-none',
-            )}
-            aria-label="Scroll tabs left"
-            aria-hidden={canScrollLeft ? undefined : true}
-            tabIndex={canScrollLeft ? 0 : -1}
-            onClick={() => handleArrowClick('left')}
-            onPointerDown={() => startHoldScroll('left')}
-            onPointerUp={stopHoldScroll}
-            onPointerLeave={cancelHoldScroll}
-            onPointerCancel={cancelHoldScroll}
-          >
-            <ChevronLeft className="h-4 w-4" />
-          </button>
+          {!multirowTabs && (
+            <button
+              className={cn(
+                'flex-shrink-0 w-7 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-all duration-150',
+                canScrollLeft ? 'opacity-100' : 'opacity-0 pointer-events-none',
+              )}
+              aria-label="Scroll tabs left"
+              aria-hidden={canScrollLeft ? undefined : true}
+              tabIndex={canScrollLeft ? 0 : -1}
+              onClick={() => handleArrowClick('left')}
+              onPointerDown={() => startHoldScroll('left')}
+              onPointerUp={stopHoldScroll}
+              onPointerLeave={cancelHoldScroll}
+              onPointerCancel={cancelHoldScroll}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+          )}
 
           {/* Scrollable tab strip */}
           <div
-            ref={callbackRef}
-            className="flex items-end gap-0.5 overflow-x-auto overflow-y-hidden scrollbar-none pt-px flex-1 min-w-0"
+            ref={combinedRef}
+            data-testid="tab-strip"
+            className={cn(
+              "flex items-end gap-0.5 pt-px flex-1 min-w-0",
+              multirowTabs
+                ? "flex-wrap max-h-32 overflow-y-auto"
+                : "overflow-x-auto overflow-y-hidden scrollbar-none"
+            )}
           >
             {sidebarCollapsed && onToggleSidebar && (
               <button
@@ -447,22 +504,24 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
           </div>
 
           {/* Right scroll arrow -- flex sibling alongside the scroll container */}
-          <button
-            className={cn(
-              'flex-shrink-0 w-7 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-all duration-150',
-              canScrollRight ? 'opacity-100' : 'opacity-0 pointer-events-none',
-            )}
-            aria-label="Scroll tabs right"
-            aria-hidden={canScrollRight ? undefined : true}
-            tabIndex={canScrollRight ? 0 : -1}
-            onClick={() => handleArrowClick('right')}
-            onPointerDown={() => startHoldScroll('right')}
-            onPointerUp={stopHoldScroll}
-            onPointerLeave={cancelHoldScroll}
-            onPointerCancel={cancelHoldScroll}
-          >
-            <ChevronRight className="h-4 w-4" />
-          </button>
+          {!multirowTabs && (
+            <button
+              className={cn(
+                'flex-shrink-0 w-7 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-all duration-150',
+                canScrollRight ? 'opacity-100' : 'opacity-0 pointer-events-none',
+              )}
+              aria-label="Scroll tabs right"
+              aria-hidden={canScrollRight ? undefined : true}
+              tabIndex={canScrollRight ? 0 : -1}
+              onClick={() => handleArrowClick('right')}
+              onPointerDown={() => startHoldScroll('right')}
+              onPointerUp={stopHoldScroll}
+              onPointerLeave={cancelHoldScroll}
+              onPointerCancel={cancelHoldScroll}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          )}
         </SortableContext>
 
         {/* Pinned + button -- outside the scrollable area */}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -461,22 +461,22 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
         >
           {/* Left scroll arrow -- flex sibling alongside the scroll container */}
           {!multirowTabs && (
-            <button
-              className={cn(
-                'flex-shrink-0 w-7 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-all duration-150',
-                canScrollLeft ? 'opacity-100' : 'opacity-0 pointer-events-none',
-              )}
-              aria-label="Scroll tabs left"
-              aria-hidden={canScrollLeft ? undefined : true}
-              tabIndex={canScrollLeft ? 0 : -1}
-              onClick={() => handleArrowClick('left')}
-              onPointerDown={() => startHoldScroll('left')}
-              onPointerUp={stopHoldScroll}
-              onPointerLeave={cancelHoldScroll}
-              onPointerCancel={cancelHoldScroll}
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </button>
+          <button
+            className={cn(
+              'flex-shrink-0 w-7 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-all duration-150',
+              canScrollLeft ? 'opacity-100' : 'opacity-0 pointer-events-none',
+            )}
+            aria-label="Scroll tabs left"
+            aria-hidden={canScrollLeft ? undefined : true}
+            tabIndex={canScrollLeft ? 0 : -1}
+            onClick={() => handleArrowClick('left')}
+            onPointerDown={() => startHoldScroll('left')}
+            onPointerUp={stopHoldScroll}
+            onPointerLeave={cancelHoldScroll}
+            onPointerCancel={cancelHoldScroll}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
           )}
 
           {/* Scrollable tab strip */}
@@ -505,22 +505,22 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
 
           {/* Right scroll arrow -- flex sibling alongside the scroll container */}
           {!multirowTabs && (
-            <button
-              className={cn(
-                'flex-shrink-0 w-7 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-all duration-150',
-                canScrollRight ? 'opacity-100' : 'opacity-0 pointer-events-none',
-              )}
-              aria-label="Scroll tabs right"
-              aria-hidden={canScrollRight ? undefined : true}
-              tabIndex={canScrollRight ? 0 : -1}
-              onClick={() => handleArrowClick('right')}
-              onPointerDown={() => startHoldScroll('right')}
-              onPointerUp={stopHoldScroll}
-              onPointerLeave={cancelHoldScroll}
-              onPointerCancel={cancelHoldScroll}
-            >
-              <ChevronRight className="h-4 w-4" />
-            </button>
+          <button
+            className={cn(
+              'flex-shrink-0 w-7 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-all duration-150',
+              canScrollRight ? 'opacity-100' : 'opacity-0 pointer-events-none',
+            )}
+            aria-label="Scroll tabs right"
+            aria-hidden={canScrollRight ? undefined : true}
+            tabIndex={canScrollRight ? 0 : -1}
+            onClick={() => handleArrowClick('right')}
+            onPointerDown={() => startHoldScroll('right')}
+            onPointerUp={stopHoldScroll}
+            onPointerLeave={cancelHoldScroll}
+            onPointerCancel={cancelHoldScroll}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
           )}
         </SortableContext>
 

--- a/src/components/settings/WorkspaceSettings.tsx
+++ b/src/components/settings/WorkspaceSettings.tsx
@@ -211,6 +211,15 @@ export default function WorkspaceSettings({
           />
         </SettingsRow>
 
+        <SettingsRow label="Multi-row tabs" description="Show tabs in multiple rows instead of a single scrollable row.">
+          <Toggle
+            checked={settings.panes?.multirowTabs ?? false}
+            onChange={(checked) => {
+              applyLocalSetting({ panes: { multirowTabs: checked } })
+            }}
+          />
+        </SettingsRow>
+
         <SettingsRow label="Tab completion indicator">
           <SegmentedControl
             value={settings.panes?.tabAttentionStyle ?? 'highlight'}

--- a/src/hooks/useTabBarScroll.ts
+++ b/src/hooks/useTabBarScroll.ts
@@ -22,7 +22,7 @@ interface TabBarScrollResult extends TabBarScrollState {
 const SCROLL_THRESHOLD = 2 // px tolerance for scroll boundary detection
 const HOLD_SCROLL_SPEED = 4 // px per frame (~240px/s at 60fps)
 
-export function useTabBarScroll(activeTabId: string | null, tabCount: number): TabBarScrollResult {
+export function useTabBarScroll(activeTabId: string | null, tabCount: number, disabled = false): TabBarScrollResult {
   const nodeRef = useRef<HTMLDivElement | null>(null)
   const cleanupRef = useRef<(() => void) | null>(null)
   const holdRafRef = useRef<number | null>(null)
@@ -34,15 +34,20 @@ export function useTabBarScroll(activeTabId: string | null, tabCount: number): T
 
   const updateOverflow = useCallback((el: HTMLDivElement | null) => {
     if (!el) {
-      setOverflow({ canScrollLeft: false, canScrollRight: false })
+      setOverflow(prev =>
+        (prev.canScrollLeft === false && prev.canScrollRight === false) ? prev : { canScrollLeft: false, canScrollRight: false }
+      )
       return
     }
 
     const { scrollLeft, scrollWidth, clientWidth } = el
-    setOverflow({
-      canScrollLeft: scrollLeft > SCROLL_THRESHOLD,
-      canScrollRight: scrollLeft + clientWidth < scrollWidth - SCROLL_THRESHOLD,
-    })
+    const canScrollLeft = scrollLeft > SCROLL_THRESHOLD
+    const canScrollRight = scrollLeft + clientWidth < scrollWidth - SCROLL_THRESHOLD
+    setOverflow(prev =>
+      (prev.canScrollLeft === canScrollLeft && prev.canScrollRight === canScrollRight)
+        ? prev
+        : { canScrollLeft, canScrollRight }
+    )
   }, [])
 
   const callbackRef = useCallback((node: HTMLDivElement | null) => {
@@ -54,7 +59,7 @@ export function useTabBarScroll(activeTabId: string | null, tabCount: number): T
 
     nodeRef.current = node
 
-    if (!node) {
+    if (!node || disabled) {
       updateOverflow(null)
       return
     }
@@ -83,7 +88,7 @@ export function useTabBarScroll(activeTabId: string | null, tabCount: number): T
 
     // Initial overflow check
     updateOverflow(node)
-  }, [updateOverflow])
+  }, [updateOverflow, disabled])
 
   // Clean up on unmount
   useEffect(() => {

--- a/src/store/browserPreferencesPersistence.ts
+++ b/src/store/browserPreferencesPersistence.ts
@@ -109,6 +109,7 @@ export function buildLocalSettingsPatch(localSettings: LocalSettings): LocalSett
   assignChangedScalar(panes, localSettings.panes, defaultLocalSettings.panes, 'tabAttentionStyle')
   assignChangedScalar(panes, localSettings.panes, defaultLocalSettings.panes, 'attentionDismiss')
   assignChangedScalar(panes, localSettings.panes, defaultLocalSettings.panes, 'sessionOpenMode')
+  assignChangedScalar(panes, localSettings.panes, defaultLocalSettings.panes, 'multirowTabs')
   if (Object.keys(panes).length > 0) {
     patch.panes = panes
   }

--- a/test/e2e-browser/specs/multirow-tabs.spec.ts
+++ b/test/e2e-browser/specs/multirow-tabs.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '../helpers/fixtures.js'
+
+test.describe('Multi-row tabs', () => {
+  async function openSettings(page: any) {
+    await page.getByRole('button', { name: /settings/i }).click()
+    await expect(page.getByRole('tab', { name: /^Appearance$/i })).toBeVisible({ timeout: 10_000 })
+  }
+
+  test('enables multi-row tabs via settings toggle', async ({ freshellPage: page }) => {
+    await openSettings(page)
+
+    const toggle = page.getByRole('switch', { name: /multi-row tabs/i })
+    await expect(toggle).toBeVisible({ timeout: 5_000 })
+    await expect(toggle).not.toBeChecked()
+    await toggle.click()
+    await expect(toggle).toBeChecked()
+  })
+
+  test('multi-row mode applies flex-wrap to tab strip', async ({ freshellPage: page }) => {
+    await page.evaluate(() => {
+      window.__FRESHELL_TEST_HARNESS__?.dispatch({
+        type: 'settings/updateSettingsLocal',
+        payload: { panes: { multirowTabs: true } },
+      })
+    })
+
+    const tabStrip = page.getByTestId('tab-strip')
+    await expect(tabStrip).toBeVisible({ timeout: 5_000 })
+    await expect(tabStrip).toHaveClass(/flex-wrap/)
+    await expect(tabStrip).toHaveClass(/max-h-32/)
+  })
+
+  test('single-row mode uses overflow-x-auto', async ({ freshellPage: page }) => {
+    const tabStrip = page.getByTestId('tab-strip')
+    await expect(tabStrip).toBeVisible({ timeout: 5_000 })
+    await expect(tabStrip).toHaveClass(/overflow-x-auto/)
+    await expect(tabStrip).not.toHaveClass(/flex-wrap/)
+  })
+})

--- a/test/unit/client/components/TabBar.multirow.test.tsx
+++ b/test/unit/client/components/TabBar.multirow.test.tsx
@@ -224,7 +224,7 @@ describe('TabBar multirow tabs', () => {
     expect(flexWrap!.className).not.toContain('overflow-x-hidden')
   })
 
-  it('keeps the sidebar reopen control inside the wrapped tab strip in multirow mode', () => {
+  it('does not apply h-full to sidebar reopen slot in multirow mode', () => {
     const tab = createTab({ id: 'tab-1' })
     const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: true })
     const { container } = renderWithStore(
@@ -232,9 +232,8 @@ describe('TabBar multirow tabs', () => {
       store,
     )
 
-    const tabStrip = container.querySelector('[data-testid="tab-strip"]')
-    const button = screen.getByRole('button', { name: 'Show sidebar' })
-    expect(tabStrip).not.toBeNull()
-    expect(tabStrip).toContainElement(button)
+    const slot = container.querySelector('[data-testid="desktop-sidebar-reopen-slot"]')
+    expect(slot).not.toBeNull()
+    expect(slot!.className).not.toContain('h-full')
   })
 })

--- a/test/unit/client/components/TabBar.multirow.test.tsx
+++ b/test/unit/client/components/TabBar.multirow.test.tsx
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import TabBar from '@/components/TabBar'
+import tabsReducer from '@/store/tabsSlice'
+import codingCliReducer from '@/store/codingCliSlice'
+import codexActivityReducer from '@/store/codexActivitySlice'
+import opencodeActivityReducer from '@/store/opencodeActivitySlice'
+import panesReducer from '@/store/panesSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
+import turnCompletionReducer from '@/store/turnCompletionSlice'
+import type { Tab } from '@/store/types'
+import {
+  composeResolvedSettings,
+  createDefaultServerSettings,
+  resolveLocalSettings,
+} from '@shared/settings'
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({ send: vi.fn() }),
+}))
+
+vi.mock('lucide-react', () => ({
+  X: ({ className }: { className?: string }) => <svg data-testid="x-icon" className={className} />,
+  Plus: ({ className }: { className?: string }) => <svg data-testid="plus-icon" className={className} />,
+  Circle: ({ className }: { className?: string }) => <svg data-testid="circle-icon" className={className} />,
+  ChevronDown: ({ className }: { className?: string }) => <svg data-testid="chevron-down-icon" className={className} />,
+  ChevronLeft: ({ className }: { className?: string }) => <svg data-testid="chevron-left-icon" className={className} />,
+  ChevronRight: ({ className }: { className?: string }) => <svg data-testid="chevron-right-icon" className={className} />,
+  Terminal: ({ className }: { className?: string }) => <svg data-testid="terminal-icon" className={className} />,
+  MessageSquare: ({ className }: { className?: string }) => <svg data-testid="message-square-icon" className={className} />,
+  PanelLeft: ({ className }: { className?: string }) => <svg data-testid="panel-left-icon" className={className} />,
+}))
+
+vi.mock('@/components/icons/PaneIcon', () => ({
+  default: ({ content, className }: any) => (
+    <svg data-testid="pane-icon" data-content-kind={content?.kind} data-content-mode={content?.mode} className={className} />
+  ),
+}))
+
+function createTab(overrides: Partial<Tab> = {}): Tab {
+  return {
+    id: `tab-${Math.random().toString(36).slice(2)}`,
+    createRequestId: 'req-1',
+    title: 'Terminal 1',
+    status: 'running',
+    mode: 'shell',
+    shell: 'system',
+    createdAt: Date.now(),
+    ...overrides,
+  }
+}
+
+function createStore(options: { tabs: Tab[]; activeTabId: string | null; multirowTabs?: boolean }) {
+  const localSettings = resolveLocalSettings(
+    options.multirowTabs ? { panes: { multirowTabs: true } } : undefined,
+  )
+  const serverSettings = createDefaultServerSettings({
+    loggingDebug: defaultSettings.logging.debug,
+  })
+
+  return configureStore({
+    reducer: {
+      tabs: tabsReducer,
+      codingCli: codingCliReducer,
+      codexActivity: codexActivityReducer,
+      opencodeActivity: opencodeActivityReducer,
+      panes: panesReducer,
+      settings: settingsReducer,
+      turnCompletion: turnCompletionReducer,
+    },
+    preloadedState: {
+      tabs: { tabs: options.tabs, activeTabId: options.activeTabId, renameRequestTabId: null },
+      codingCli: { sessions: {}, pendingRequests: {} },
+      codexActivity: { byTerminalId: {}, lastSnapshotSeq: 0, liveMutationSeqByTerminalId: {}, removedMutationSeqByTerminalId: {} },
+      opencodeActivity: { byTerminalId: {}, lastSnapshotSeq: 0, liveMutationSeqByTerminalId: {}, removedMutationSeqByTerminalId: {} },
+      panes: { layouts: {}, activePane: {}, paneTitles: {} },
+      settings: {
+        serverSettings,
+        localSettings,
+        settings: composeResolvedSettings(serverSettings, localSettings),
+        loaded: true,
+      },
+      turnCompletion: { seq: 0, lastEvent: null, pendingEvents: [], attentionByTab: {} },
+    },
+  })
+}
+
+function renderWithStore(ui: React.ReactElement, store: ReturnType<typeof createStore>) {
+  return render(<Provider store={store}>{ui}</Provider>)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => cleanup())
+
+describe('TabBar multirow tabs', () => {
+  it('uses flex-wrap on the tab strip container when multirowTabs is enabled', () => {
+    const tab = createTab({ id: 'tab-1' })
+    const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: true })
+    const { container } = renderWithStore(<TabBar />, store)
+
+    const flexWrap = container.querySelector('.flex-wrap')
+    expect(flexWrap).not.toBeNull()
+  })
+
+  it('does not use flex-wrap when multirowTabs is disabled (default)', () => {
+    const tab = createTab({ id: 'tab-1' })
+    const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: false })
+    const { container } = renderWithStore(<TabBar />, store)
+
+    const flexWrap = container.querySelector('.flex-wrap')
+    expect(flexWrap).toBeNull()
+  })
+
+  it('uses overflow-x-auto when multirowTabs is disabled (default)', () => {
+    const tab = createTab({ id: 'tab-1' })
+    const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: false })
+    const { container } = renderWithStore(<TabBar />, store)
+
+    const scrollContainer = container.querySelector('.overflow-x-auto')
+    expect(scrollContainer).not.toBeNull()
+  })
+
+  it('does not render scroll arrow buttons when multirowTabs is enabled', () => {
+    const tab = createTab({ id: 'tab-1' })
+    const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: true })
+    renderWithStore(<TabBar />, store)
+
+    const leftBtn = screen.queryByLabelText('Scroll tabs left')
+    const rightBtn = screen.queryByLabelText('Scroll tabs right')
+    expect(leftBtn).toBeNull()
+    expect(rightBtn).toBeNull()
+  })
+
+  it('renders scroll arrow buttons when multirowTabs is disabled', () => {
+    const tab = createTab({ id: 'tab-1' })
+    const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: false })
+    renderWithStore(<TabBar />, store)
+
+    const leftBtn = screen.getByLabelText('Scroll tabs left')
+    const rightBtn = screen.getByLabelText('Scroll tabs right')
+    expect(leftBtn).toBeInTheDocument()
+    expect(rightBtn).toBeInTheDocument()
+  })
+
+  it('applies h-auto to the outer wrapper and max-h-32 to the tab strip when multirowTabs is enabled', () => {
+    const tab = createTab({ id: 'tab-1' })
+    const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: true })
+    const { container } = renderWithStore(<TabBar />, store)
+
+    const wrapper = container.firstElementChild as HTMLElement
+    expect(wrapper.className).toContain('h-auto')
+    expect(wrapper.className).not.toContain('h-12')
+
+    const tabStrip = container.querySelector('.flex-wrap')
+    expect(tabStrip).not.toBeNull()
+    expect(tabStrip!.className).toContain('max-h-32')
+  })
+
+  it('applies fixed height to the outer wrapper when multirowTabs is disabled', () => {
+    const tab = createTab({ id: 'tab-1' })
+    const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: false })
+    const { container } = renderWithStore(<TabBar />, store)
+
+    const wrapper = container.firstElementChild as HTMLElement
+    expect(wrapper.className).toContain('h-12')
+    expect(wrapper.className).not.toContain('h-auto')
+  })
+
+  it('still renders all tabs when multirowTabs is enabled', () => {
+    const tabs = [
+      createTab({ id: 'tab-1', title: 'Tab 1' }),
+      createTab({ id: 'tab-2', title: 'Tab 2' }),
+      createTab({ id: 'tab-3', title: 'Tab 3' }),
+    ]
+    const store = createStore({ tabs, activeTabId: 'tab-1', multirowTabs: true })
+    renderWithStore(<TabBar />, store)
+
+    expect(screen.getByText('Tab 1')).toBeInTheDocument()
+    expect(screen.getByText('Tab 2')).toBeInTheDocument()
+    expect(screen.getByText('Tab 3')).toBeInTheDocument()
+  })
+
+  it('still renders the + new tab button when multirowTabs is enabled', () => {
+    const tab = createTab({ id: 'tab-1' })
+    const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: true })
+    renderWithStore(<TabBar />, store)
+
+    const addButton = screen.getByRole('button', { name: 'New shell tab' })
+    expect(addButton).toBeInTheDocument()
+  })
+
+  it('does not use overflow-y-auto on the tab strip when multirowTabs is disabled', () => {
+    const tab = createTab({ id: 'tab-1' })
+    const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: false })
+    const { container } = renderWithStore(<TabBar />, store)
+
+    const scrollContainer = container.querySelector('.overflow-x-auto')
+    expect(scrollContainer).not.toBeNull()
+    expect(scrollContainer!.className).not.toContain('overflow-y-auto')
+  })
+
+  it('uses overflow-y-auto on the tab strip when multirowTabs is enabled', () => {
+    const tab = createTab({ id: 'tab-1' })
+    const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: true })
+    const { container } = renderWithStore(<TabBar />, store)
+
+    const flexWrap = container.querySelector('.flex-wrap')
+    expect(flexWrap).not.toBeNull()
+    expect(flexWrap!.className).toContain('overflow-y-auto')
+  })
+
+  it('does not apply overflow-x-hidden to the tab strip when multirowTabs is enabled', () => {
+    const tab = createTab({ id: 'tab-1' })
+    const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: true })
+    const { container } = renderWithStore(<TabBar />, store)
+
+    const flexWrap = container.querySelector('.flex-wrap')
+    expect(flexWrap).not.toBeNull()
+    expect(flexWrap!.className).not.toContain('overflow-x-hidden')
+  })
+
+  it('keeps the sidebar reopen control inside the wrapped tab strip in multirow mode', () => {
+    const tab = createTab({ id: 'tab-1' })
+    const store = createStore({ tabs: [tab], activeTabId: 'tab-1', multirowTabs: true })
+    const { container } = renderWithStore(
+      <TabBar sidebarCollapsed={true} onToggleSidebar={() => {}} />,
+      store,
+    )
+
+    const tabStrip = container.querySelector('[data-testid="tab-strip"]')
+    const button = screen.getByRole('button', { name: 'Show sidebar' })
+    expect(tabStrip).not.toBeNull()
+    expect(tabStrip).toContainElement(button)
+  })
+})

--- a/test/unit/client/store/browserPreferencesPersistence.test.ts
+++ b/test/unit/client/store/browserPreferencesPersistence.test.ts
@@ -64,6 +64,26 @@ describe('browserPreferencesPersistence', () => {
     })
   })
 
+  it('persists multirowTabs when enabled locally', () => {
+    const store = createStore()
+
+    store.dispatch(updateSettingsLocal({
+      panes: {
+        multirowTabs: true,
+      },
+    }))
+
+    vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
+
+    expect(JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')).toEqual({
+      settings: {
+        panes: {
+          multirowTabs: true,
+        },
+      },
+    })
+  })
+
   it('debounces updateSettingsLocal writes and flushes them on pagehide', () => {
     const store = createStore()
 

--- a/test/unit/client/store/browserPreferencesPersistence.test.ts
+++ b/test/unit/client/store/browserPreferencesPersistence.test.ts
@@ -64,26 +64,6 @@ describe('browserPreferencesPersistence', () => {
     })
   })
 
-  it('persists multirowTabs when enabled locally', () => {
-    const store = createStore()
-
-    store.dispatch(updateSettingsLocal({
-      panes: {
-        multirowTabs: true,
-      },
-    }))
-
-    vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
-
-    expect(JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')).toEqual({
-      settings: {
-        panes: {
-          multirowTabs: true,
-        },
-      },
-    })
-  })
-
   it('debounces updateSettingsLocal writes and flushes them on pagehide', () => {
     const store = createStore()
 

--- a/test/unit/shared/settings.test.ts
+++ b/test/unit/shared/settings.test.ts
@@ -310,4 +310,46 @@ describe('shared settings contract', () => {
       },
     })
   })
+
+  it('defaults multirowTabs to false in resolved local settings', () => {
+    expect(resolveLocalSettings(undefined).panes.multirowTabs).toBe(false)
+  })
+
+  it('accepts multirowTabs boolean in local settings patch', () => {
+    const resolved = resolveLocalSettings({ panes: { multirowTabs: true } })
+    expect(resolved.panes.multirowTabs).toBe(true)
+  })
+
+  it('preserves multirowTabs when extracting legacy local settings seed', () => {
+    expect(extractLegacyLocalSettingsSeed({
+      panes: {
+        multirowTabs: true,
+      },
+    } as Record<string, unknown>)).toEqual({
+      panes: {
+        multirowTabs: true,
+      },
+    })
+  })
+
+  it('rejects non-boolean multirowTabs in legacy seed extraction', () => {
+    expect(extractLegacyLocalSettingsSeed({
+      panes: {
+        multirowTabs: 'yes',
+      },
+    } as Record<string, unknown>)).toEqual(undefined)
+  })
+
+  it('includes multirowTabs in composed resolved settings', () => {
+    const resolved = composeResolvedSettings(
+      createDefaultServerSettings({ loggingDebug: false }),
+      resolveLocalSettings({ panes: { multirowTabs: true } }),
+    )
+    expect(resolved.panes.multirowTabs).toBe(true)
+  })
+
+  it('rejects multirowTabs in server patch schema', () => {
+    const schema = buildServerSettingsPatchSchema()
+    expect(schema.safeParse({ panes: { multirowTabs: true } }).success).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary
- Port the #335 multi-row tabs setting from the stale dev-stack PR #342 onto current `origin/main`.
- Add the per-client `multirowTabs` local pane setting, Settings > Panes toggle, local browser-preferences persistence, wrapped TabBar layout, and docs mock CSS.
- Carry focused unit and e2e test coverage for the setting and layout behavior.

## Source and scope
- Source payload: #335 commit `00a54902bb88c25c04dc7e49e2200188377e9f31` (`feat: add multi-row tabs setting (per-client, off by default)`).
- This branch intentionally does not port #331 compact tabs-registry content; #355 covers that separately.
- While resolving the `TabBar.tsx` conflict, this port preserved current `main` sidebar reopen placement instead of pulling in the unrelated `dev` parent change that had moved it outside the tab scroller.
- Added one main-scoped browser-preferences persistence assertion for `multirowTabs`.

## Verification
- `npm run test:vitest -- test/unit/shared/settings.test.ts test/unit/client/store/browserPreferencesPersistence.test.ts test/unit/client/components/TabBar.multirow.test.tsx --run` passed: 3 files, 43 tests.
- `npm run typecheck:client` passed.
- `npm run build:client` passed, with existing Vite dynamic-import and chunk-size warnings.
- `npm run lint` passed with 14 existing warnings and 0 errors.
- `npm run typecheck:server` failed before this branch's touched code due to existing `origin/main` parse errors in `server/mcp/freshell-tool.ts` lines 73 and 472.
- `npm run build:server` failed on the same existing parse errors.
- `npm run test:e2e:chromium -- test/e2e-browser/specs/multirow-tabs.spec.ts` was blocked in global setup because it runs `npm run build:client && npm run build:server`, and `build:server` fails on the same existing parse errors.

## Supersedes
This PR supersedes the #335 multi-row tabs setting payload currently embedded in stale #342.
