### PR TITLE
Fix Codex clean exits and turn paging

### DIFF
--- a/docs/superpowers/plans/2026-05-21-codex-clean-exit-recovery.md
+++ b/docs/superpowers/plans/2026-05-21-codex-clean-exit-recovery.md
@@ -1,0 +1,333 @@
+# Codex Clean Exit Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop Freshell from auto-recovering durable Codex terminals when the visible Codex PTY exits cleanly with code 0.
+
+**Architecture:** Keep durable recovery for unexpected Codex worker loss, nonzero PTY exits, signals, and app-server lifecycle loss. Treat a clean Codex PTY exit as final only after confirming it is not associated with an active, unconfirmed, restored, or recently observed in-progress turn. Use the Codex app-server's paged `thread/turns/list` contract for lightweight recent-turn inspection, request full item detail only for Freshcodex page/body hydration, and fall back to `thread/read` synthesis when the experimental paged method is unavailable. Coalesce clean PTY exits into existing lifecycle-loss recovery when recovery or pre-durable lifecycle-loss proof is already pending. Cover the behavior with TerminalRegistry recovery tests, app-server client contract tests, and the public API/WS/UI blocked-input surfaces.
+
+**Tech Stack:** TypeScript, Node.js, node-pty, Vitest, Freshell TerminalRegistry.
+
+---
+
+## File Structure
+
+- Modify `server/terminal-registry.ts`: change both durable Codex PTY-exit recovery decision points so a clean idle exit finishes the terminal, while clean exits with active/unconfirmed/restored in-progress turn evidence still recover.
+- Modify `server/coding-cli/codex-app-server/client.ts` and `protocol.ts`: add paged `thread/turns/list` support, pass `itemsView` per call, hydrate individual turns by following cursors, and fall back to `thread/read` when paged listing is unavailable.
+- Modify `test/unit/server/terminal-registry.codex-recovery.test.ts`: add focused regression tests for initial clean durable Codex PTY exit, recovered clean durable Codex PTY exit, signal exits, active/in-progress turn exits, clean PTY exit during lifecycle-loss recovery, and clean PTY exit during pre-durable lifecycle-loss proof.
+- Modify app-server fake, client, schema traceability, and real readiness-contract tests so paged turn listing and cursor progression are covered.
+- Modify terminal input blocked plumbing to distinguish lifecycle-loss proof, durable recovery, and clean-exit decision pending states when reporting blocked input to clients.
+- Extend WS, `/api/run`, `/api/panes/:id/send-keys`, TerminalView, and browser-level resilience coverage so the new blocked-input reason and clean-exit final UX are pinned at their public surfaces.
+- Coalesce duplicate pre-durable lifecycle-loss proof notifications while proof is already pending, and cover the `/api/panes/:id/send-keys` blocked-input surface.
+- No README or `docs/index.html` update is needed because this is a bug fix to terminal lifecycle behavior, not an end-user feature or major UI change.
+
+## Scope
+
+This plan only changes terminal lifecycle handling for Codex PTY exits. It does not change Codex app-server launch arguments, plugin/MCP configuration, or session history rendering.
+
+### Task 1: Add Regression Coverage For Clean Durable Codex Exit
+
+**Files:**
+- Test: `test/unit/server/terminal-registry.codex-recovery.test.ts`
+
+- [ ] **Step 1: Write the failing clean-exit test**
+
+Insert this test after `it('recovers a durable Codex terminal when the visible PTY exits unexpectedly', ...)`:
+
+```ts
+  it('keeps a durable Codex PTY exit final when the visible process exits cleanly', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    expect(planCreate).not.toHaveBeenCalled()
+    expect(replacementSidecar.adopt).not.toHaveBeenCalled()
+    expect(registry.get(record.terminalId)?.status).toBe('exited')
+    expect(registry.get(record.terminalId)?.exitCode).toBe(0)
+    expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 0 })
+  })
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/terminal-registry.codex-recovery.test.ts -t "keeps a durable Codex PTY exit final when the visible process exits cleanly" --run
+```
+
+Expected: FAIL because `planCreate` is called and the terminal remains in durable recovery instead of exiting.
+
+- [ ] **Step 3: Add recovered clean-exit coverage before implementation**
+
+Insert this test after the clean-exit test to cover the recovery-created PTY handler:
+
+```ts
+  it('keeps a recovered durable Codex PTY exit final when the replacement process exits cleanly', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [oldPty] = await spawnedPtys()
+
+    oldPty.onExit.mock.calls[0][0]({ exitCode: 1, signal: 0 })
+
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    const [, replacementPty] = await spawnedPtys()
+
+    replacementPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    expect(planCreate).toHaveBeenCalledTimes(1)
+    expect(registry.get(record.terminalId)?.status).toBe('exited')
+    expect(registry.get(record.terminalId)?.exitCode).toBe(0)
+    expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 0 })
+  })
+```
+
+- [ ] **Step 4: Add lifecycle-loss coalescing coverage before implementation**
+
+Add a fake sidecar lifecycle-loss emitter and regression tests proving that if app-server lifecycle loss already started recovery, or started final pre-durable rollout proof, a later clean PTY exit does not finalize the terminal or unblock input before the replacement PTY is adopted.
+
+Add a regression test proving that a replacement PTY clean exit is still final if it happens after the replacement is published as the current PTY but before recovery bookkeeping has fully settled.
+
+- [ ] **Step 5: Add signal-exit coverage before implementation**
+
+Insert this test after the clean-exit test:
+
+```ts
+  it('recovers a durable Codex terminal when the visible PTY exits from a signal', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [oldPty] = await spawnedPtys()
+
+    oldPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 15 })
+
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(planCreate).toHaveBeenCalledWith(expect.objectContaining({
+      terminalId: record.terminalId,
+      resumeSessionId: 'thread-durable-1',
+      generation: 1,
+    }))
+    expect(registry.get(record.terminalId)?.status).toBe('running')
+    expect(exited).not.toHaveBeenCalled()
+  })
+```
+
+- [ ] **Step 6: Run all new tests and verify current behavior**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/terminal-registry.codex-recovery.test.ts -t "visible PTY exits" --run
+```
+
+Expected: the initial clean-exit and recovered clean-exit tests fail before implementation; the signal-exit test passes or remains skipped by the name filter depending on Vitest matching. If the name filter does not select all tests, run the full file command after implementation.
+
+### Task 2: Implement Clean-Exit Guard
+
+**Files:**
+- Modify: `server/terminal-registry.ts`
+- Test: `test/unit/server/terminal-registry.codex-recovery.test.ts`
+
+- [ ] **Step 1: Add a helper for clean PTY exits**
+
+In `server/terminal-registry.ts`, near the existing private helper methods, add:
+
+```ts
+  private isCleanPtyExit(event: { exitCode: number; signal?: number }): boolean {
+    return event.exitCode === 0 && (!event.signal || event.signal === 0)
+  }
+
+  private shouldRecoverCodexPtyExit(record: TerminalRecord, event: { exitCode: number; signal?: number }): boolean {
+    return Boolean(record.codexRecoveryAttempt || record.codexLifecycleLossProofPending) || !this.isCleanPtyExit(event)
+  }
+```
+
+- [ ] **Step 2: Use the helper before starting durable recovery for initial PTY exits**
+
+In the `ptyProc.onExit((e) => { ... })` block, replace the current `finishExit` function with:
+
+```ts
+      const finishExit = () => {
+        if (
+          this.shouldRecoverCodexPtyExit(record, e)
+          && this.startCodexDurableRecovery(record, {
+            source: 'pty_exit',
+            exitCode: e.exitCode,
+            signal: e.signal,
+          })
+        ) {
+          return
+        }
+        this.finishTerminalPtyExit(record, e)
+      }
+```
+
+- [ ] **Step 3: Use the helper before starting durable recovery for recovered PTY exits**
+
+In `attachCodexRecoveryPtyHandlers(...)`, replace the current `finishExit` function with:
+
+```ts
+      const finishExit = () => {
+        if (
+          this.shouldRecoverCodexPtyExit(record, event)
+          && this.startCodexDurableRecovery(record, {
+            source: 'pty_exit',
+            exitCode: event.exitCode,
+            signal: event.signal,
+          })
+        ) {
+          return
+        }
+        this.finishTerminalPtyExit(record, event)
+      }
+```
+
+- [ ] **Step 4: Run focused recovery tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/terminal-registry.codex-recovery.test.ts --run
+```
+
+Expected: PASS. The clean-exit test should now finalize the terminal, and the existing nonzero-exit recovery test should still recover.
+
+- [ ] **Step 5: Run nearby TerminalRegistry tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/terminal-registry.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts test/unit/server/terminal-registry.codex-recovery.test.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the implementation**
+
+Run:
+
+```bash
+git add server/terminal-registry.ts test/unit/server/terminal-registry.codex-recovery.test.ts docs/superpowers/plans/2026-05-21-codex-clean-exit-recovery.md
+git commit -m "fix: stop recovering clean Codex exits"
+```
+
+Expected: commit succeeds with the plan, test, and implementation.
+
+### Task 3: Verify And Review
+
+**Files:**
+- Verify: `server/terminal-registry.ts`
+- Verify: `test/unit/server/terminal-registry.codex-recovery.test.ts`
+
+- [ ] **Step 1: Run coordinated status before broad verification**
+
+Run:
+
+```bash
+npm run test:status
+```
+
+Expected: either `state: idle` or a clear holder status. If another agent holds the gate, wait rather than killing it.
+
+- [ ] **Step 2: Run the repo check**
+
+Run:
+
+```bash
+FRESHELL_TEST_SUMMARY="verify Codex clean exit recovery fix" npm run check
+```
+
+Expected: typecheck and coordinated test suite pass.
+
+- [ ] **Step 3: Run fresh-eyes review**
+
+Run:
+
+```bash
+bash "/home/dan/.codex/skills/fresheyes/fresheyes.sh" --claude "Review the changes between origin/main and this branch using git diff origin/main...HEAD."
+```
+
+Expected: independent review returns either no findings or actionable issues.
+
+- [ ] **Step 4: Fix actionable review findings**
+
+For each valid issue, update the smallest relevant files. If the issue concerns clean-exit classification, prefer changing `isCleanPtyExit(...)` and adding or adjusting a unit test in `test/unit/server/terminal-registry.codex-recovery.test.ts`.
+
+- [ ] **Step 5: Repeat review loop up to three total times**
+
+After each fix, run:
+
+```bash
+npm run test:vitest -- test/unit/server/terminal-registry.codex-recovery.test.ts --run
+git add server/terminal-registry.ts test/unit/server/terminal-registry.codex-recovery.test.ts
+git commit -m "fix: address Codex clean exit review"
+bash "/home/dan/.codex/skills/fresheyes/fresheyes.sh" --claude "Review the changes between origin/main and this branch using git diff origin/main...HEAD."
+```
+
+Expected: stop after a review with no findings or after three review attempts.
+
+## Self-Review
+
+Spec coverage: The plan covers the user-facing rule that `exitCode: 0` should complete the terminal instead of recovering for both initial and recovered Codex PTYs. It preserves recovery for nonzero exits, signal exits, app-server lifecycle loss, duplicate PTY exits while lifecycle-loss recovery is already pending, and clean PTY exits that race with pre-durable lifecycle-loss proof.
+
+Placeholder scan: No `TBD`, `TODO`, or open-ended test instructions remain. The only flexible step is the review-fix loop, which depends on actual independent findings.
+
+Type consistency: The helpers use the same event shape already passed to `startCodexDurableRecovery` for PTY exits: `{ exitCode: number; signal?: number }`. Test names and expected registry behavior match existing `TerminalRegistry` test helpers.

--- a/server/agent-api/router.ts
+++ b/server/agent-api/router.ts
@@ -198,6 +198,12 @@ function terminalInputFailureMessage(result: Exclude<TerminalInputResult, { stat
   if (result.status === 'blocked_codex_recovery_pending') {
     return 'Codex durable recovery is still in progress.'
   }
+  if (result.status === 'blocked_codex_clean_exit_decision_pending') {
+    return 'Codex clean exit state is still being resolved.'
+  }
+  if (result.status === 'blocked_codex_lifecycle_loss_pending') {
+    return 'Codex worker lifecycle loss is still being resolved.'
+  }
   return 'Terminal is not running.'
 }
 

--- a/server/coding-cli/codex-app-server/client.ts
+++ b/server/coding-cli/codex-app-server/client.ts
@@ -281,7 +281,7 @@ export class CodexAppServerClient {
         } else if (page.revision !== undefined && page.revision !== observedListRevision) {
           throw new Error('Codex app-server thread turn list revision changed while paging thread turns.')
         }
-        if (params.revision !== undefined && page.revision !== params.revision) {
+        if (params.revision !== undefined && page.revision !== undefined && page.revision !== params.revision) {
           throw new Error('Codex app-server thread turn list revision does not match requested revision.')
         }
         const turn = page.turns.find((candidate) => candidate.id === params.turnId)

--- a/server/coding-cli/codex-app-server/client.ts
+++ b/server/coding-cli/codex-app-server/client.ts
@@ -33,6 +33,7 @@ import {
   type CodexRpcError,
   type CodexThreadHandle,
   type CodexThreadOperationResult,
+  type CodexThreadPageParams,
   type CodexThreadReadParams,
   type CodexThreadReadResult,
   type CodexThreadForkParams,
@@ -63,6 +64,18 @@ type PendingRequest = {
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 5_000
 const LOSS_STATUSES = new Set(['notLoaded', 'systemError'])
+
+class CodexAppServerRpcError extends Error {
+  constructor(
+    readonly method: string,
+    readonly code: number,
+    message: string,
+    readonly data?: unknown,
+  ) {
+    super(`Codex app-server ${method} failed: ${message}`)
+    this.name = 'CodexAppServerRpcError'
+  }
+}
 
 type CodexThreadStartInput =
   Omit<CodexThreadStartParams, 'experimentalRawEvents' | 'persistExtendedHistory'> & {
@@ -238,45 +251,174 @@ export class CodexAppServerClient {
 
   async listThreadTurns(params: CodexThreadTurnsListParams): Promise<CodexThreadTurnsListResult> {
     const parsedParams = CodexThreadPageParamsSchema.parse(params)
-    const result = await this.request('thread/read', {
-      threadId: parsedParams.threadId,
-      includeTurns: true,
-    })
-    const parsedThread = CodexThreadReadResultSchema.safeParse(result)
-    if (!parsedThread.success) {
-      throw new Error('Codex app-server returned an invalid thread/read payload.')
+    if (this.isThreadReadFallbackCursor(parsedParams.cursor)) {
+      return await this.listThreadTurnsViaThreadRead(parsedParams, new Error('thread/read fallback cursor'))
     }
-    const turns = parsedThread.data.thread.turns.slice(0, parsedParams.limit)
-    const parsed = CodexThreadTurnsListResultSchema.safeParse({
-      revision: Math.max(0, Math.trunc(parsedThread.data.thread.updatedAt)),
-      nextCursor: null,
-      backwardsCursor: null,
-      turns,
-      bodies: Object.fromEntries(turns.map((turn) => [turn.id, turn])),
-    })
+    try {
+      return await this.requestThreadTurnsList(parsedParams)
+    } catch (error) {
+      if (!this.canFallbackToThreadRead(parsedParams, error)) {
+        throw error
+      }
+      return await this.listThreadTurnsViaThreadRead(parsedParams, error)
+    }
+  }
+
+  async readThreadTurn(params: CodexThreadTurnReadParams): Promise<CodexThreadTurnReadResult> {
+    let cursor: string | undefined
+    let observedListRevision: number | undefined
+    try {
+      for (;;) {
+        const page = await this.requestThreadTurnsList({
+          threadId: params.threadId,
+          limit: 50,
+          sortDirection: 'desc',
+          itemsView: 'full',
+          ...(cursor ? { cursor } : {}),
+        })
+        if (page.revision !== undefined && observedListRevision === undefined) {
+          observedListRevision = page.revision
+        } else if (page.revision !== undefined && page.revision !== observedListRevision) {
+          throw new Error('Codex app-server thread turn list revision changed while paging thread turns.')
+        }
+        if (params.revision !== undefined && page.revision !== params.revision) {
+          throw new Error('Codex app-server thread turn list revision does not match requested revision.')
+        }
+        const turn = page.turns.find((candidate) => candidate.id === params.turnId)
+        if (turn) {
+          const revision = params.revision ?? observedListRevision
+          const parsedTurn = CodexThreadTurnReadResultSchema.safeParse({
+            ...turn,
+            turnId: turn.id,
+            revision,
+          })
+          if (!parsedTurn.success) {
+            throw new Error('Codex app-server returned an invalid synthesized thread turn body.')
+          }
+          return parsedTurn.data
+        }
+        if (!page.nextCursor) break
+        cursor = page.nextCursor
+      }
+    } catch (error) {
+      if (!this.isThreadTurnsListUnavailableError(error)) throw error
+      return await this.readThreadTurnViaThreadRead(params)
+    }
+    throw new Error(`Codex app-server thread ${params.threadId} does not contain turn ${params.turnId}.`)
+  }
+
+  private async requestThreadTurnsList(params: CodexThreadPageParams): Promise<CodexThreadTurnsListResult> {
+    const result = await this.request('thread/turns/list', params)
+    const parsed = CodexThreadTurnsListResultSchema.safeParse(result)
     if (!parsed.success) {
-      throw new Error('Codex app-server returned an invalid synthesized thread turn page.')
+      throw new Error('Codex app-server returned an invalid thread/turns/list payload.')
     }
     return parsed.data
   }
 
-  async readThreadTurn(params: CodexThreadTurnReadParams): Promise<CodexThreadTurnReadResult> {
-    const page = await this.listThreadTurns({
-      threadId: params.threadId,
-    })
-    const turn = page.turns.find((candidate) => candidate.id === params.turnId)
+  private async readThreadTurnViaThreadRead(params: CodexThreadTurnReadParams): Promise<CodexThreadTurnReadResult> {
+    const snapshot = await this.readThread({ threadId: params.threadId, includeTurns: true })
+    const snapshotRevision = Number.isFinite(snapshot.thread.updatedAt)
+      ? Math.max(0, Math.trunc(snapshot.thread.updatedAt))
+      : undefined
+    if (params.revision !== undefined && snapshotRevision !== params.revision) {
+      throw new Error('Codex app-server thread/read revision does not match requested revision.')
+    }
+    const revision = params.revision ?? snapshotRevision
+    const turn = (snapshot.thread.turns ?? []).find((candidate) => candidate.id === params.turnId)
     if (!turn) {
       throw new Error(`Codex app-server thread ${params.threadId} does not contain turn ${params.turnId}.`)
     }
     const parsedTurn = CodexThreadTurnReadResultSchema.safeParse({
       ...turn,
       turnId: turn.id,
-      revision: params.revision ?? page.revision,
+      revision,
     })
     if (!parsedTurn.success) {
-      throw new Error('Codex app-server returned an invalid synthesized thread turn body.')
+      throw new Error('Codex app-server returned an invalid synthesized thread turn body from thread/read fallback.')
     }
     return parsedTurn.data
+  }
+
+  private async listThreadTurnsViaThreadRead(
+    params: CodexThreadPageParams,
+    cause: unknown,
+  ): Promise<CodexThreadTurnsListResult> {
+    const fallbackCursor = this.parseThreadReadFallbackCursor(params.cursor)
+    const snapshot = await this.readThread({ threadId: params.threadId, includeTurns: true })
+    const rawTurns = snapshot.thread.turns ?? []
+    const orderedTurns = params.sortDirection === 'asc'
+      ? rawTurns.slice()
+      : rawTurns.slice().reverse()
+    const revision = Number.isFinite(snapshot.thread.updatedAt)
+      ? Math.max(0, Math.trunc(snapshot.thread.updatedAt))
+      : 0
+    if (fallbackCursor.revision !== undefined && fallbackCursor.revision !== revision) {
+      throw new Error('Codex app-server thread/read fallback snapshot changed while paging thread turns.')
+    }
+    const offset = fallbackCursor.offset
+    const limit = params.limit ?? orderedTurns.length
+    const turns = orderedTurns.slice(offset, offset + limit).map((turn) => {
+      if (params.itemsView === 'notLoaded') {
+        return { ...turn, itemsView: 'notLoaded' as const, items: [] }
+      }
+      if (params.itemsView === 'summary') {
+        return {
+          ...turn,
+          itemsView: 'summary' as const,
+          items: turn.items.map((item) => ({
+            type: item.type,
+            id: item.id,
+            summary: this.summarizeThreadItem(item),
+          })),
+        }
+      }
+      return { ...turn, itemsView: 'full' as const }
+    })
+    const nextOffset = offset + turns.length
+    const parsed = CodexThreadTurnsListResultSchema.safeParse({
+      revision,
+      nextCursor: nextOffset < orderedTurns.length ? this.formatThreadReadFallbackCursor(revision, nextOffset) : null,
+      backwardsCursor: null,
+      turns,
+      bodies: Object.fromEntries(turns.map((turn) => [turn.id, turn])),
+    })
+    if (!parsed.success) {
+      throw new Error(`Codex app-server thread/turns/list fallback returned an invalid payload after paging failed: ${cause instanceof Error ? cause.message : String(cause)}`)
+    }
+    return parsed.data
+  }
+
+  private parseThreadReadFallbackCursor(cursor: string | undefined): { offset: number; revision?: number } {
+    if (!cursor) return { offset: 0 }
+    const match = cursor.match(/^thread-read:(\d+):(\d+)$/)
+    if (!match) {
+      throw new Error(`Codex app-server thread/turns/list is unavailable and thread/read fallback cannot honor opaque cursor "${cursor}".`)
+    }
+    return { revision: Number(match[1]), offset: Number(match[2]) }
+  }
+
+  private formatThreadReadFallbackCursor(revision: number, offset: number): string {
+    return `thread-read:${revision}:${offset}`
+  }
+
+  private summarizeThreadItem(item: { type: string; summary?: unknown; text?: unknown; command?: unknown }): string {
+    if (typeof item.summary === 'string') return item.summary
+    if (typeof item.text === 'string') return item.text
+    if (typeof item.command === 'string') return item.command
+    return item.type
+  }
+
+  private canFallbackToThreadRead(params: CodexThreadPageParams, error: unknown): boolean {
+    if (!this.isThreadTurnsListUnavailableError(error)) return false
+    if (params.cursor && !this.isThreadReadFallbackCursor(params.cursor)) {
+      throw new Error(`Codex app-server thread/turns/list is unavailable and thread/read fallback cannot honor opaque cursor "${params.cursor}".`)
+    }
+    return true
+  }
+
+  private isThreadReadFallbackCursor(cursor: string | undefined): boolean {
+    return typeof cursor === 'string' && /^thread-read:\d+:\d+$/.test(cursor)
   }
 
   async startTurn(params: CodexTurnStartParams): Promise<{ turnId: string }> {
@@ -495,7 +637,7 @@ export class CodexAppServerClient {
     if (!pending) return
     clearTimeout(pending.timeout)
     this.pendingRequests.delete(failure.data.id)
-    pending.reject(new Error(this.formatRpcError(pending.method, failure.data.error)))
+    pending.reject(this.formatRpcError(pending.method, failure.data.error))
   }
 
   private handleNotification(notification: { method: string; params?: unknown }): void {
@@ -666,8 +808,16 @@ export class CodexAppServerClient {
     socket.send(JSON.stringify(payload))
   }
 
-  private formatRpcError(method: string, error: CodexRpcError): string {
-    return `Codex app-server ${method} failed: ${error.message}`
+  private isThreadTurnsListUnavailableError(error: unknown): boolean {
+    if (error instanceof CodexAppServerRpcError) {
+      return error.method === 'thread/turns/list' && error.code === -32601
+    }
+    const message = error instanceof Error ? error.message : String(error)
+    return /\b(method not found|unknown method|not implemented|unsupported method)\b/i.test(message)
+  }
+
+  private formatRpcError(method: string, error: CodexRpcError): Error {
+    return new CodexAppServerRpcError(method, error.code, error.message, error.data)
   }
 
   private hasIdField(value: unknown): boolean {

--- a/server/coding-cli/codex-app-server/launch-planner.ts
+++ b/server/coding-cli/codex-app-server/launch-planner.ts
@@ -1,5 +1,11 @@
 import type { CodexAppServerRuntime } from './runtime.js'
 import type { CodexThreadLifecycleEvent, CodexThreadLifecycleLossEvent, CodexTurnEvent } from './client.js'
+import type {
+  CodexThreadTurnReadParams,
+  CodexThreadTurnReadResult,
+  CodexThreadTurnsListParams,
+  CodexThreadTurnsListResult,
+} from './protocol.js'
 import { waitForAllSettledOrThrow } from '../../shutdown-join.js'
 import {
   CodexRemoteProxy,
@@ -16,6 +22,8 @@ type CodexRuntimeLike = Pick<
   | 'onFsChanged'
   | 'watchPath'
   | 'unwatchPath'
+  | 'readThreadTurn'
+  | 'listThreadTurns'
 >
 
 export type CodexLaunchSidecar = {
@@ -28,6 +36,8 @@ export type CodexLaunchSidecar = {
   onFsChanged?(handler: (event: { watchId: string; changedPaths: string[] }) => void): () => void
   onThreadLifecycle?(handler: (event: CodexThreadLifecycleEvent) => void): () => void
   onLifecycleLoss?(handler: (event: CodexThreadLifecycleLossEvent) => void): () => void
+  listThreadTurns?(params: CodexThreadTurnsListParams): Promise<CodexThreadTurnsListResult>
+  readThreadTurn?(params: CodexThreadTurnReadParams): Promise<CodexThreadTurnReadResult>
   watchPath?(targetPath: string, watchId: string): Promise<{ path: string }>
   unwatchPath?(watchId: string): Promise<void>
   shutdown(): Promise<void>
@@ -217,6 +227,14 @@ export class CodexLaunchPlanner {
           unsubRuntime()
           unsubProxy?.()
         }
+      },
+      readThreadTurn: (params) => {
+        assertActive()
+        return runtime.readThreadTurn(params)
+      },
+      listThreadTurns: (params) => {
+        assertActive()
+        return runtime.listThreadTurns(params)
       },
       watchPath: async (targetPath, watchId) => {
         assertActive()

--- a/server/coding-cli/codex-app-server/protocol.ts
+++ b/server/coding-cli/codex-app-server/protocol.ts
@@ -102,6 +102,7 @@ export const CodexThreadStatusSchema = z.discriminatedUnion('type', [
 ])
 
 export const CodexTurnStatusSchema = z.enum(['completed', 'interrupted', 'failed', 'inProgress'])
+export const CodexThreadItemsViewSchema = z.enum(['notLoaded', 'summary', 'full'])
 
 export const CodexSessionSourceSchema = z.union([
   z.enum(['cli', 'vscode', 'exec', 'appServer', 'unknown']),
@@ -136,6 +137,7 @@ export const CodexThreadItemSchema = z.object({
 export const CodexTurnSchema = z.object({
   id: z.string().min(1),
   items: z.array(CodexThreadItemSchema),
+  itemsView: CodexThreadItemsViewSchema.optional(),
   status: CodexTurnStatusSchema,
   error: z.unknown().nullable().optional().default(null),
   startedAt: z.number().nullable().optional().default(null),
@@ -262,15 +264,30 @@ export const CodexThreadPageParamsSchema = z.object({
   cursor: z.string().min(1).optional(),
   limit: z.number().int().positive().optional(),
   sortDirection: z.enum(['asc', 'desc']).optional(),
+  itemsView: CodexThreadItemsViewSchema.optional(),
 }).strict()
 
-export const CodexThreadTurnsListResultSchema = z.object({
+export const CodexThreadTurnsListResultSchema = z.preprocess((value) => {
+  if (
+    value
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && 'data' in value
+    && !('turns' in value)
+  ) {
+    return {
+      ...value,
+      turns: (value as { data: unknown }).data,
+    }
+  }
+  return value
+}, z.object({
   revision: z.number().int().nonnegative().optional(),
   nextCursor: z.string().nullable().optional().default(null),
   backwardsCursor: z.string().nullable().optional().default(null),
   turns: z.array(CodexTurnSchema),
   bodies: z.record(z.string(), CodexTurnSchema).optional(),
-}).passthrough()
+}).passthrough())
 
 export const CodexThreadTurnReadParamsSchema = z.object({
   threadId: z.string().min(1),

--- a/server/fresh-agent/adapters/codex/adapter.ts
+++ b/server/fresh-agent/adapters/codex/adapter.ts
@@ -54,6 +54,7 @@ type CodexRuntimePort = {
     threadId: string
     cursor?: string
     limit?: number
+    itemsView?: 'notLoaded' | 'summary' | 'full'
   }) => Promise<Record<string, any>>
   readThreadTurn: (input: { threadId: string; turnId: string; revision?: number }) => Promise<Record<string, any>>
 }
@@ -268,6 +269,7 @@ export function createCodexFreshAgentAdapter(deps: {
         threadId: thread.threadId,
         cursor: typeof query.cursor === 'string' ? query.cursor : undefined,
         limit: typeof query.limit === 'number' ? query.limit : undefined,
+        itemsView: 'full',
       })
       return normalizeCodexTurnPage({
         threadId: thread.threadId,

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -2401,6 +2401,7 @@ export class TerminalRegistry extends EventEmitter {
         const latest = this.terminals.get(record.terminalId)
         if (latest?.codexRecoveryAttempt === attempt) {
           latest.codexRecoveryAttempt = undefined
+          latest.codexRecoveryRetiringPty = undefined
         }
       })
     record.codexRecoveryAttempt = attempt

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -53,6 +53,8 @@ const DEFAULT_MAX_PENDING_SNAPSHOT_CHARS = 512 * 1024
 const OUTPUT_FLUSH_MS = Number(process.env.OUTPUT_FLUSH_MS || process.env.MOBILE_OUTPUT_FLUSH_MS || 40)
 const MAX_OUTPUT_BUFFER_CHARS = Number(process.env.MAX_OUTPUT_BUFFER_CHARS || process.env.MAX_MOBILE_OUTPUT_BUFFER_CHARS || 256 * 1024)
 const MAX_OUTPUT_FRAME_CHARS = Math.max(1, Number(process.env.MAX_OUTPUT_FRAME_CHARS || 8192))
+const CODEX_CLEAN_EXIT_RECENT_INPUT_GRACE_MS = Math.max(0, Number(process.env.CODEX_CLEAN_EXIT_RECENT_INPUT_GRACE_MS || 750))
+const CODEX_CLEAN_EXIT_LIFECYCLE_LOSS_GRACE_MS = Math.max(0, Number(process.env.CODEX_CLEAN_EXIT_LIFECYCLE_LOSS_GRACE_MS || 2000))
 const perfConfig = getPerfConfig()
 
 // TerminalMode is now a wider type -- any string is valid as a mode name.
@@ -478,6 +480,8 @@ export type TerminalRecord = {
     | 'watchPath'
     | 'unwatchPath'
     | 'markCandidatePersisted'
+    | 'readThreadTurn'
+    | 'listThreadTurns'
   >
   codexSidecarLifecycleUnsubscribe?: () => void
   codexSidecarLifecyclePublished?: boolean
@@ -489,13 +493,23 @@ export type TerminalRecord = {
     inFlight?: Promise<void>
     rerunRequested?: boolean
   }
+  codexActiveTurn?: CodexTurnEvent
+  codexUnconfirmedInputAt?: number
+  codexUnconfirmedInputSource?: 'resume' | 'input'
   codexInputGate?: { state: 'identity_pending' }
   codexRecovery?: CodexRecoveryOptions
   codexRecoveryAttempt?: Promise<void>
+  codexRecoveryAttemptSerial?: number
+  codexLifecycleLossProofPending?: boolean
+  codexCleanExitDecisionPending?: boolean
   codexRecoveryRetry?: { timer: NodeJS.Timeout; resolve: () => void }
   codexRecoveryBlockedError?: Error
   codexRecoveryFinalClose?: boolean
   codexRecoveryRetiringPty?: pty.IPty
+  codexHandledPtyExits?: WeakSet<pty.IPty>
+  codexPendingCleanExitFinalizer?: {
+    timer: NodeJS.Timeout
+  }
 }
 
 export type TerminalInputResult =
@@ -504,6 +518,8 @@ export type TerminalInputResult =
   | { status: 'blocked_codex_identity_capture_timeout'; terminalId: string }
   | { status: 'blocked_codex_identity_unavailable'; terminalId: string; reason?: string }
   | { status: 'blocked_codex_recovery_pending'; terminalId: string }
+  | { status: 'blocked_codex_clean_exit_decision_pending'; terminalId: string }
+  | { status: 'blocked_codex_lifecycle_loss_pending'; terminalId: string }
   | { status: 'no_terminal' }
   | { status: 'not_running' }
 
@@ -1261,6 +1277,7 @@ export class TerminalRegistry extends EventEmitter {
     record: TerminalRecord,
     event: { exitCode: number; signal?: number },
   ): void {
+    this.clearCodexPendingCleanExitFinalizer(record)
     this.markCodexRecoveryFinalClose(record)
     record.status = 'exited'
     record.exitCode = event.exitCode
@@ -1420,6 +1437,12 @@ export class TerminalRegistry extends EventEmitter {
         : undefined,
       codexSidecarGeneration: opts.mode === 'codex' ? 0 : undefined,
       codexDurability: initialCodexDurability,
+      codexUnconfirmedInputAt: opts.mode === 'codex' && resumeForBinding && (opts.sessionBindingReason ?? 'resume') === 'resume'
+        ? createdAt
+        : undefined,
+      codexUnconfirmedInputSource: opts.mode === 'codex' && resumeForBinding && (opts.sessionBindingReason ?? 'resume') === 'resume'
+        ? 'resume'
+        : undefined,
       codexInputGate: opts.mode === 'codex' && !resumeForBinding
         ? { state: 'identity_pending' }
         : undefined,
@@ -1437,8 +1460,8 @@ export class TerminalRegistry extends EventEmitter {
             lastInputBytes: undefined,
             lastInputToOutputMs: undefined,
             maxInputToOutputMs: 0,
-	          }
-	        : undefined,
+          }
+        : undefined,
     }
 
     this.registerCodexSidecarLifecycle(record)
@@ -1513,7 +1536,9 @@ export class TerminalRegistry extends EventEmitter {
     })
 
     ptyProc.onExit((e) => {
-      if (record.codexRecoveryRetiringPty === ptyProc) {
+      if (this.hasHandledPtyExit(record, ptyProc)) return
+      this.markHandledPtyExit(record, ptyProc)
+      if (!record.codexRecoveryFinalClose && record.codexRecoveryRetiringPty === ptyProc) {
         return
       }
       if (record.pty !== ptyProc) {
@@ -1523,24 +1548,63 @@ export class TerminalRegistry extends EventEmitter {
         return
       }
       const finishExit = () => {
-        if (this.startCodexDurableRecovery(record, {
-          source: 'pty_exit',
-          exitCode: e.exitCode,
-          signal: e.signal,
-        })) {
+        if (
+          this.shouldRecoverCodexPtyExit(record, e)
+          && this.startCodexDurableRecovery(record, {
+            source: 'pty_exit',
+            exitCode: e.exitCode,
+            signal: e.signal,
+          })
+        ) {
           return
         }
-        this.finishTerminalPtyExit(record, e)
+        if (!this.scheduleCodexCleanExitFinalizer(record, ptyProc, e)) {
+          this.finishTerminalPtyExit(record, e)
+        }
+      }
+      const finishExitAfterActiveTurnCheck = () => {
+        if (!this.shouldCheckCodexActiveTurnBeforeCleanExit(record, e)) {
+          finishExit()
+          return
+        }
+        record.codexCleanExitDecisionPending = true
+        const recoverySerial = record.codexRecoveryAttemptSerial ?? 0
+        void (async () => {
+          try {
+            const shouldRecover = await this.shouldRecoverCleanCodexExitForActiveTurn(record)
+            if ((record.codexRecoveryAttemptSerial ?? 0) !== recoverySerial) return
+            if (record.pty !== ptyProc || record.status === 'exited') return
+            if (record.codexRecoveryAttempt || record.codexLifecycleLossProofPending) return
+            if (
+              shouldRecover
+              && this.startCodexDurableRecovery(record, {
+                source: 'pty_exit',
+                exitCode: e.exitCode,
+                signal: e.signal,
+              })
+            ) {
+              return
+            }
+            if (!this.scheduleCodexCleanExitFinalizer(record, ptyProc, e)) {
+              this.finishTerminalPtyExit(record, e)
+            }
+          } finally {
+            if (this.terminals.get(record.terminalId) === record && !record.codexPendingCleanExitFinalizer) {
+              record.codexCleanExitDecisionPending = undefined
+            }
+          }
+        })()
       }
       if (this.needsCodexFinalDurabilityProof(record)) {
+        if (record.codexLifecycleLossProofPending) return
         void (async () => {
           await this.proveCodexBeforeFinalLoss(record, 'pty_exit')
           if (record.pty !== ptyProc || record.status === 'exited') return
-          finishExit()
+          finishExitAfterActiveTurnCheck()
         })()
         return
       }
-      finishExit()
+      finishExitAfterActiveTurnCheck()
     })
 
     this.terminals.set(terminalId, record)
@@ -1592,14 +1656,17 @@ export class TerminalRegistry extends EventEmitter {
       record.codexSidecarLifecycleUnsubscribe = undefined
       return
     }
+    const isCurrentSidecar = () => this.terminals.get(record.terminalId)?.codexSidecar === sidecar
 
     const unsubscribers: Array<() => void> = []
     const lifecycleUnsubscribe = sidecar.onLifecycleLoss?.((event) => {
+      if (!isCurrentSidecar()) return
       this.handleCodexLifecycleLoss(record.terminalId, event)
     })
     if (lifecycleUnsubscribe) unsubscribers.push(lifecycleUnsubscribe)
 
     const candidateUnsubscribe = sidecar.onCandidate?.((candidate) => {
+      if (!isCurrentSidecar()) return
       void this.persistCodexCandidate(record.terminalId, candidate).catch((err) => {
         logger.error({ err, terminalId: record.terminalId }, 'Failed to persist Codex restore identity')
         void this.failCodexFreshIdentity(record.terminalId, 'candidate_persist_failed').catch((failErr) => {
@@ -1610,6 +1677,7 @@ export class TerminalRegistry extends EventEmitter {
     if (candidateUnsubscribe) unsubscribers.push(candidateUnsubscribe)
 
     const turnStartedUnsubscribe = sidecar.onTurnStarted?.((event) => {
+      if (!isCurrentSidecar()) return
       void this.handleCodexTurnStarted(record.terminalId, event).catch((err) => {
         logger.error({ err, terminalId: record.terminalId }, 'Failed to update Codex turn-start durability state')
       })
@@ -1617,6 +1685,7 @@ export class TerminalRegistry extends EventEmitter {
     if (turnStartedUnsubscribe) unsubscribers.push(turnStartedUnsubscribe)
 
     const turnCompletedUnsubscribe = sidecar.onTurnCompleted?.((event) => {
+      if (!isCurrentSidecar()) return
       void this.handleCodexTurnCompleted(record.terminalId, event).catch((err) => {
         logger.error({ err, terminalId: record.terminalId }, 'Failed to proof Codex rollout after turn completion')
       })
@@ -1624,10 +1693,15 @@ export class TerminalRegistry extends EventEmitter {
     if (turnCompletedUnsubscribe) unsubscribers.push(turnCompletedUnsubscribe)
 
     const repairUnsubscribe = sidecar.onRepairTrigger?.((event) => {
+      if (!isCurrentSidecar()) return
       if (event.kind === 'candidate_capture_timeout') {
         void this.failCodexFreshIdentity(record.terminalId, 'candidate_capture_timeout').catch((err) => {
           logger.error({ err, terminalId: record.terminalId }, 'Failed to mark Codex terminal non-restorable after candidate capture timeout')
         })
+        return
+      }
+      if (event.kind === 'proxy_close' || event.kind === 'proxy_error') {
+        this.handleCodexLifecycleLoss(record.terminalId, event)
         return
       }
       this.requestCodexDurabilityProof(record.terminalId, `repair:${event.kind}`)
@@ -1635,6 +1709,7 @@ export class TerminalRegistry extends EventEmitter {
     if (repairUnsubscribe) unsubscribers.push(repairUnsubscribe)
 
     const fsChangedUnsubscribe = sidecar.onFsChanged?.((event) => {
+      if (!isCurrentSidecar()) return
       this.handleCodexRolloutFsChanged(record.terminalId, event)
     })
     if (fsChangedUnsubscribe) unsubscribers.push(fsChangedUnsubscribe)
@@ -1704,8 +1779,16 @@ export class TerminalRegistry extends EventEmitter {
   }
 
   private codexCandidateMatches(record: TerminalRecord, threadId: string | undefined): boolean {
+    if (!threadId) return false
     const candidateThreadId = record.codexDurability?.candidate?.candidateThreadId
-    return !!candidateThreadId && candidateThreadId === threadId
+    return record.resumeSessionId === threadId || candidateThreadId === threadId
+  }
+
+  private getCodexRecoveryThreadId(record: TerminalRecord): string | undefined {
+    const durableThreadId = record.codexDurability?.state === 'durable'
+      ? record.codexDurability.durableThreadId
+      : undefined
+    return durableThreadId ?? record.resumeSessionId ?? record.codexDurability?.candidate?.candidateThreadId
   }
 
   private buildCodexDurabilityRef(candidate: CodexRemoteProxyCandidate, capturedAt: number): CodexDurabilityRef | undefined {
@@ -1916,6 +1999,9 @@ export class TerminalRegistry extends EventEmitter {
     const record = this.terminals.get(terminalId)
     if (!record || record.status !== 'running') return
     if (!this.codexCandidateMatches(record, event.threadId)) return
+    record.codexActiveTurn = event
+    record.codexUnconfirmedInputAt = undefined
+    record.codexUnconfirmedInputSource = undefined
     if (!record.codexDurability?.candidate || record.codexDurability.state === 'durable') return
 
     const durability: CodexDurabilityRef = {
@@ -1935,6 +2021,17 @@ export class TerminalRegistry extends EventEmitter {
     const record = this.terminals.get(terminalId)
     if (!record || record.status !== 'running') return
     if (!this.codexCandidateMatches(record, event.threadId)) return
+    const completedActiveTurn = (
+      record.codexActiveTurn?.threadId === event.threadId
+      && !!record.codexActiveTurn.turnId
+      && !!event.turnId
+      && record.codexActiveTurn.turnId === event.turnId
+    )
+    if (completedActiveTurn) {
+      record.codexActiveTurn = undefined
+      record.codexUnconfirmedInputAt = undefined
+      record.codexUnconfirmedInputSource = undefined
+    }
     if (!record.codexDurability?.candidate || record.codexDurability.state === 'durable') return
 
     const completedAt = Date.now()
@@ -2186,13 +2283,13 @@ export class TerminalRegistry extends EventEmitter {
     if (!record) {
       throw new Error(`Cannot publish Codex sidecar for missing terminal ${terminalId}.`)
     }
-    if (!record.codexSidecar) return
     if (record.codexSidecarPrePublicationLoss !== undefined) {
       throw new Error('Codex app-server reported lifecycle loss before terminal create completed.')
     }
     if (record.status !== 'running') {
       throw new Error('Codex terminal PTY exited before create completed.')
     }
+    if (!record.codexSidecar) return
     record.codexSidecarLifecyclePublished = true
   }
 
@@ -2214,29 +2311,37 @@ export class TerminalRegistry extends EventEmitter {
       : undefined
     if (
       typeof eventThreadId === 'string'
-      && record.resumeSessionId
-      && eventThreadId !== record.resumeSessionId
+      && (record.resumeSessionId || record.codexDurability?.candidate?.candidateThreadId)
+      && !this.codexCandidateMatches(record, eventThreadId)
     ) {
       return
     }
 
+    this.clearCodexPendingCleanExitFinalizer(record)
+
     if (!record.resumeSessionId || !record.codexRecovery) {
+      if (record.codexLifecycleLossProofPending) return
       void (async () => {
-        await this.proveCodexBeforeFinalLoss(record, 'lifecycle_loss')
-        if (record.status !== 'running') return
-        if (record.resumeSessionId && record.codexRecovery) {
-          if (!this.startCodexDurableRecovery(record, { source: 'lifecycle_loss', event })) {
-            this.closeCodexTerminalAfterBlockedLifecycleLoss(record, event)
+        record.codexLifecycleLossProofPending = true
+        try {
+          await this.proveCodexBeforeFinalLoss(record, 'lifecycle_loss')
+          if (record.status !== 'running') return
+          if (record.resumeSessionId && record.codexRecovery) {
+            if (!this.startCodexDurableRecovery(record, { source: 'lifecycle_loss', event })) {
+              this.closeCodexTerminalAfterBlockedLifecycleLoss(record, event)
+            }
+            return
           }
-          return
+          logger.warn(
+            { terminalId, event },
+            'Codex app-server reported terminal lifecycle loss without durable recovery; closing terminal',
+          )
+          await this.killAndWait(terminalId).catch((err) => {
+            logger.error({ err, terminalId }, 'Failed to close terminal after Codex app-server lifecycle loss')
+          })
+        } finally {
+          record.codexLifecycleLossProofPending = false
         }
-        logger.warn(
-          { terminalId, event },
-          'Codex app-server reported terminal lifecycle loss without durable recovery; closing terminal',
-        )
-        await this.killAndWait(terminalId).catch((err) => {
-          logger.error({ err, terminalId }, 'Failed to close terminal after Codex app-server lifecycle loss')
-        })
       })()
       return
     }
@@ -2274,7 +2379,11 @@ export class TerminalRegistry extends EventEmitter {
       { terminalId: record.terminalId, trigger, resumeSessionId: record.resumeSessionId },
       'Codex durable terminal lost its live worker; starting durable recovery',
     )
-    const attempt = this.runCodexRecoveryLoop(record.terminalId)
+    record.codexRecoveryAttemptSerial = (record.codexRecoveryAttemptSerial ?? 0) + 1
+    record.codexRecoveryRetiringPty = record.pty
+    let attempt!: Promise<void>
+    attempt = Promise.resolve()
+      .then(() => this.runCodexRecoveryLoop(record.terminalId))
       .catch((err) => {
         logger.error({ err, terminalId: record.terminalId }, 'Codex durable recovery loop failed')
         if (record.codexRecoveryBlockedError && this.terminals.get(record.terminalId) === record && record.status === 'running') {
@@ -2296,6 +2405,189 @@ export class TerminalRegistry extends EventEmitter {
       })
     record.codexRecoveryAttempt = attempt
     return true
+  }
+
+  private isCleanPtyExit(event: { exitCode: number; signal?: number }): boolean {
+    return event.exitCode === 0 && (!event.signal || event.signal === 0)
+  }
+
+  private clearCodexPendingCleanExitFinalizer(record: TerminalRecord): void {
+    const pending = record.codexPendingCleanExitFinalizer
+    if (!pending) return
+    clearTimeout(pending.timer)
+    record.codexPendingCleanExitFinalizer = undefined
+    record.codexCleanExitDecisionPending = undefined
+  }
+
+  private shouldDelayCodexCleanExitForLifecycleLoss(record: TerminalRecord, event: { exitCode: number; signal?: number }): boolean {
+    return record.mode === 'codex'
+      && this.isCleanPtyExit(event)
+      && !!record.resumeSessionId
+      && !!record.codexRecovery
+      && record.codexSidecarLifecyclePublished === true
+      && !record.codexRecoveryAttempt
+      && !record.codexLifecycleLossProofPending
+      && !record.codexRecoveryFinalClose
+  }
+
+  private scheduleCodexCleanExitFinalizer(
+    record: TerminalRecord,
+    ptyProc: pty.IPty,
+    event: { exitCode: number; signal?: number },
+  ): boolean {
+    if (!this.shouldDelayCodexCleanExitForLifecycleLoss(record, event)) return false
+    this.clearCodexPendingCleanExitFinalizer(record)
+    record.codexCleanExitDecisionPending = true
+    const timer = setTimeout(() => {
+      if (record.codexPendingCleanExitFinalizer?.timer !== timer) return
+      record.codexPendingCleanExitFinalizer = undefined
+      record.codexCleanExitDecisionPending = undefined
+      if (this.terminals.get(record.terminalId) !== record) return
+      if (record.pty !== ptyProc || record.status === 'exited') return
+      if (record.codexRecoveryAttempt || record.codexLifecycleLossProofPending) return
+      this.finishTerminalPtyExit(record, event)
+    }, CODEX_CLEAN_EXIT_LIFECYCLE_LOSS_GRACE_MS)
+    timer.unref?.()
+    record.codexPendingCleanExitFinalizer = { timer }
+    return true
+  }
+
+  private hasHandledPtyExit(record: TerminalRecord, ptyProc: pty.IPty): boolean {
+    return record.codexHandledPtyExits?.has(ptyProc) ?? false
+  }
+
+  private markHandledPtyExit(record: TerminalRecord, ptyProc: pty.IPty): void {
+    record.codexHandledPtyExits ??= new WeakSet()
+    record.codexHandledPtyExits.add(ptyProc)
+  }
+
+  private shouldCheckCodexActiveTurnBeforeCleanExit(record: TerminalRecord, event: { exitCode: number; signal?: number }): boolean {
+    return this.isCleanPtyExit(event)
+      && !record.codexRecoveryAttempt
+      && !record.codexLifecycleLossProofPending
+      && !!this.getCodexRecoveryThreadId(record)
+      && (
+        !!record.codexActiveTurn
+        || record.codexUnconfirmedInputAt !== undefined
+      )
+  }
+
+  private async shouldRecoverCleanCodexExitForActiveTurn(record: TerminalRecord): Promise<boolean> {
+    const initialSnapshot = record.codexActiveTurn
+      ? { turn: record.codexActiveTurn, reliable: true }
+      : await this.findCurrentCodexActiveTurn(record)
+    let turn = initialSnapshot.turn
+    if (!turn) {
+      if (!initialSnapshot.reliable) return true
+      const delayedSnapshot = await this.waitForRecentCodexInputVisibility(record)
+      turn = delayedSnapshot.turn
+      if (!turn) return !delayedSnapshot.reliable
+    }
+
+    if (!turn.turnId) {
+      const currentSnapshot = await this.findCurrentCodexActiveTurn(record)
+      turn = currentSnapshot.turn
+      if (!turn) return !currentSnapshot.reliable
+    }
+
+    if (!turn.turnId || (!record.codexSidecar?.listThreadTurns && !record.codexSidecar?.readThreadTurn)) {
+      return true
+    }
+
+    try {
+      const latestTurnStatus = await this.readCodexTurnStatusForCleanExit(record, turn.threadId, turn.turnId)
+      if (latestTurnStatus === 'inProgress') return true
+      record.codexActiveTurn = undefined
+      record.codexUnconfirmedInputAt = undefined
+      const currentSnapshot = await this.findCurrentCodexActiveTurn(record)
+      if (currentSnapshot.turn) return true
+      return !currentSnapshot.reliable
+    } catch (err) {
+      logger.warn({
+        err,
+        terminalId: record.terminalId,
+        threadId: turn.threadId,
+        turnId: turn.turnId,
+      }, 'Failed to read Codex active turn before clean PTY exit recovery decision')
+      return true
+    }
+  }
+
+  private async readCodexTurnStatusForCleanExit(
+    record: TerminalRecord,
+    threadId: string,
+    turnId: string,
+  ): Promise<string | undefined> {
+    if (record.codexSidecar?.listThreadTurns) {
+      let cursor: string | undefined
+      for (;;) {
+        const page = await record.codexSidecar.listThreadTurns({
+          threadId,
+          limit: 50,
+          sortDirection: 'desc',
+          itemsView: 'notLoaded',
+          ...(cursor ? { cursor } : {}),
+        })
+        const turn = page.turns.find((candidate) => candidate.id === turnId)
+        if (turn) return turn.status
+        if (!page.nextCursor) return undefined
+        cursor = page.nextCursor
+      }
+    }
+
+    const turn = await record.codexSidecar!.readThreadTurn!({ threadId, turnId })
+    return turn.status
+  }
+
+  private async waitForRecentCodexInputVisibility(record: TerminalRecord): Promise<{ turn?: CodexTurnEvent; reliable: boolean }> {
+    if (record.codexUnconfirmedInputAt === undefined) return { reliable: true }
+    if (!record.codexSidecar?.listThreadTurns) return { reliable: true }
+    const elapsedMs = Date.now() - record.codexUnconfirmedInputAt
+    const remainingMs = CODEX_CLEAN_EXIT_RECENT_INPUT_GRACE_MS - elapsedMs
+    if (remainingMs <= 0) return { reliable: record.codexUnconfirmedInputSource !== 'input' }
+
+    logger.debug({
+      terminalId: record.terminalId,
+      elapsedMs,
+      graceMs: CODEX_CLEAN_EXIT_RECENT_INPUT_GRACE_MS,
+    }, 'Waiting briefly for recent Codex input to appear in turn listing before clean PTY exit decision')
+    await new Promise<void>((resolve) => setTimeout(resolve, remainingMs))
+    const snapshot = await this.findCurrentCodexActiveTurn(record)
+    return snapshot
+  }
+
+  private async findCurrentCodexActiveTurn(record: TerminalRecord): Promise<{ turn?: CodexTurnEvent; reliable: boolean }> {
+    const threadId = this.getCodexRecoveryThreadId(record)
+    if (!threadId || !record.codexSidecar?.listThreadTurns) return { reliable: true }
+
+    try {
+      const page = await record.codexSidecar.listThreadTurns({
+        threadId,
+        limit: 50,
+        sortDirection: 'desc',
+        itemsView: 'notLoaded',
+      })
+      const inProgress = page.turns.find((turn) => turn.status === 'inProgress')
+      if (!inProgress) return { reliable: true }
+      const event: CodexTurnEvent = {
+        threadId,
+        turnId: inProgress.id,
+        params: {},
+      }
+      record.codexActiveTurn = event
+      return { turn: event, reliable: true }
+    } catch (err) {
+      logger.warn({
+        err,
+        terminalId: record.terminalId,
+        threadId,
+      }, 'Failed to list Codex turns before clean PTY exit recovery decision')
+      return { reliable: false }
+    }
+  }
+
+  private shouldRecoverCodexPtyExit(record: TerminalRecord, event: { exitCode: number; signal?: number }): boolean {
+    return Boolean(record.codexRecoveryAttempt || record.codexLifecycleLossProofPending) || !this.isCleanPtyExit(event)
   }
 
   private canContinueCodexRecovery(record: TerminalRecord | undefined, resumeSessionId?: string): record is TerminalRecord {
@@ -2403,6 +2695,7 @@ export class TerminalRegistry extends EventEmitter {
 
   private markCodexRecoveryFinalClose(record: TerminalRecord): void {
     record.codexRecoveryFinalClose = true
+    this.clearCodexPendingCleanExitFinalizer(record)
     const retry = record.codexRecoveryRetry
     if (retry) {
       retry.resolve()
@@ -2508,6 +2801,7 @@ export class TerminalRegistry extends EventEmitter {
       record.codexSidecarGeneration = generation
       this.registerCodexSidecarLifecycle(record)
       record.codexRecoveryRetiringPty = undefined
+      record.codexRecoveryAttempt = undefined
       published = true
 
       try {
@@ -2614,33 +2908,74 @@ export class TerminalRegistry extends EventEmitter {
     })
 
     ptyProc.onExit((event) => {
+      if (this.hasHandledPtyExit(record, ptyProc)) return
+      this.markHandledPtyExit(record, ptyProc)
       if (candidate) {
         candidate.exited = true
         candidate.exitCode = event.exitCode
       }
-      if (record.codexRecoveryRetiringPty === ptyProc) {
+      if (!record.codexRecoveryFinalClose && record.codexRecoveryRetiringPty === ptyProc) {
         return
       }
       if (record.pty !== ptyProc || record.status === 'exited') return
       const finishExit = () => {
-        if (this.startCodexDurableRecovery(record, {
-          source: 'pty_exit',
-          exitCode: event.exitCode,
-          signal: event.signal,
-        })) {
+        if (
+          this.shouldRecoverCodexPtyExit(record, event)
+          && this.startCodexDurableRecovery(record, {
+            source: 'pty_exit',
+            exitCode: event.exitCode,
+            signal: event.signal,
+          })
+        ) {
           return
         }
-        this.finishTerminalPtyExit(record, event)
+        if (!this.scheduleCodexCleanExitFinalizer(record, ptyProc, event)) {
+          this.finishTerminalPtyExit(record, event)
+        }
+      }
+      const finishExitAfterActiveTurnCheck = () => {
+        if (!this.shouldCheckCodexActiveTurnBeforeCleanExit(record, event)) {
+          finishExit()
+          return
+        }
+        record.codexCleanExitDecisionPending = true
+        const recoverySerial = record.codexRecoveryAttemptSerial ?? 0
+        void (async () => {
+          try {
+            const shouldRecover = await this.shouldRecoverCleanCodexExitForActiveTurn(record)
+            if ((record.codexRecoveryAttemptSerial ?? 0) !== recoverySerial) return
+            if (record.pty !== ptyProc || record.status === 'exited') return
+            if (record.codexRecoveryAttempt || record.codexLifecycleLossProofPending) return
+            if (
+              shouldRecover
+              && this.startCodexDurableRecovery(record, {
+                source: 'pty_exit',
+                exitCode: event.exitCode,
+                signal: event.signal,
+              })
+            ) {
+              return
+            }
+            if (!this.scheduleCodexCleanExitFinalizer(record, ptyProc, event)) {
+              this.finishTerminalPtyExit(record, event)
+            }
+          } finally {
+            if (this.terminals.get(record.terminalId) === record && !record.codexPendingCleanExitFinalizer) {
+              record.codexCleanExitDecisionPending = undefined
+            }
+          }
+        })()
       }
       if (this.needsCodexFinalDurabilityProof(record)) {
+        if (record.codexLifecycleLossProofPending) return
         void (async () => {
           await this.proveCodexBeforeFinalLoss(record, 'pty_exit')
           if (record.pty !== ptyProc || record.status === 'exited') return
-          finishExit()
+          finishExitAfterActiveTurnCheck()
         })()
         return
       }
-      finishExit()
+      finishExitAfterActiveTurnCheck()
     })
   }
 
@@ -2692,15 +3027,21 @@ export class TerminalRegistry extends EventEmitter {
       }
     }
     if (term.status !== 'running') return { status: 'not_running' }
+    if (term.codexRecoveryAttempt) {
+      return { status: 'blocked_codex_recovery_pending', terminalId }
+    }
+    if (term.codexCleanExitDecisionPending) {
+      return { status: 'blocked_codex_clean_exit_decision_pending', terminalId }
+    }
+    if (term.codexLifecycleLossProofPending) {
+      return { status: 'blocked_codex_lifecycle_loss_pending', terminalId }
+    }
     if (term.codexInputGate?.state === 'identity_pending') {
       if (isCodexStartupTerminalControlInput(data)) {
         term.pty.write(data)
         return { status: 'written' }
       }
       return { status: 'blocked_codex_identity_pending', terminalId }
-    }
-    if (term.codexRecoveryAttempt) {
-      return { status: 'blocked_codex_recovery_pending', terminalId }
     }
     const now = Date.now()
     term.lastActivityAt = now
@@ -2713,6 +3054,10 @@ export class TerminalRegistry extends EventEmitter {
       if (term.perf.pendingInputAt === undefined) {
         term.perf.pendingInputAt = now
       }
+    }
+    if (term.mode === 'codex') {
+      term.codexUnconfirmedInputAt = now
+      term.codexUnconfirmedInputSource = 'input'
     }
     term.pty.write(data)
     this.emit('terminal.input.raw', {

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -3124,6 +3124,32 @@ export class WsHandler {
           })
           return
         }
+        if (result.status === 'blocked_codex_clean_exit_decision_pending') {
+          log.debug({
+            terminalId: m.terminalId,
+            connectionId: ws.connectionId,
+            attemptedInputBytes: Buffer.byteLength(m.data, 'utf8'),
+          }, 'Codex terminal input blocked while clean exit state is being resolved')
+          this.send(ws, {
+            type: 'terminal.input.blocked',
+            terminalId: m.terminalId,
+            reason: 'codex_clean_exit_decision_pending',
+          })
+          return
+        }
+        if (result.status === 'blocked_codex_lifecycle_loss_pending') {
+          log.debug({
+            terminalId: m.terminalId,
+            connectionId: ws.connectionId,
+            attemptedInputBytes: Buffer.byteLength(m.data, 'utf8'),
+          }, 'Codex terminal input blocked while lifecycle loss is being resolved')
+          this.send(ws, {
+            type: 'terminal.input.blocked',
+            terminalId: m.terminalId,
+            reason: 'codex_lifecycle_loss_pending',
+          })
+          return
+        }
         if (result.status !== 'written') {
           if (result.status === 'no_terminal') {
             recordSessionLifecycleEvent({

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -659,7 +659,7 @@ export type TerminalCodexDurabilityUpdatedMessage = {
 export type TerminalInputBlockedMessage = {
   type: 'terminal.input.blocked'
   terminalId: string
-  reason: 'codex_identity_pending' | 'codex_identity_capture_timeout' | 'codex_identity_unavailable' | 'codex_recovery_pending'
+  reason: 'codex_identity_pending' | 'codex_identity_capture_timeout' | 'codex_identity_unavailable' | 'codex_recovery_pending' | 'codex_clean_exit_decision_pending' | 'codex_lifecycle_loss_pending'
 }
 
 export type TerminalsChangedMessage = {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -132,6 +132,8 @@ type TerminalInputBlockedReason =
   | 'codex_identity_capture_timeout'
   | 'codex_identity_unavailable'
   | 'codex_recovery_pending'
+  | 'codex_clean_exit_decision_pending'
+  | 'codex_lifecycle_loss_pending'
 
 function shouldSuppressNativeTouchScroll(term: Terminal): boolean {
   return term.buffer.active.type === 'alternate' && term.modes.mouseTrackingMode !== 'none'
@@ -143,6 +145,10 @@ function terminalInputBlockedNotice(reason: TerminalInputBlockedReason): string 
       return 'Input not sent: Codex is still saving restore state. Try again in a moment.'
     case 'codex_recovery_pending':
       return 'Input not sent: Codex is still reconnecting. Try again in a moment.'
+    case 'codex_clean_exit_decision_pending':
+      return 'Input not sent: Codex is checking whether the session is still active. Try again in a moment.'
+    case 'codex_lifecycle_loss_pending':
+      return 'Input not sent: Codex is resolving a worker disconnect. Try again in a moment.'
     case 'codex_identity_capture_timeout':
       return 'Input not sent: Codex did not provide restore state before startup timed out. Start a new Codex pane or resume inside Codex.'
     case 'codex_identity_unavailable':

--- a/test/e2e/codex-session-resilience-flow.test.tsx
+++ b/test/e2e/codex-session-resilience-flow.test.tsx
@@ -266,6 +266,58 @@ describe('Codex session resilience flow', () => {
     expect(contentFor(store, tabId).status).toBe('exited')
   })
 
+  it('keeps a clean Codex exit final across reconnect instead of requesting recovery', async () => {
+    const { store, tabId, paneId, paneContent } = createStore()
+
+    render(
+      <Provider store={store}>
+        <TerminalView tabId={tabId} paneId={paneId} paneContent={paneContent} />
+      </Provider>,
+    )
+
+    await waitFor(() => expect(messageHandler).not.toBeNull())
+    await waitFor(() => expect(reconnectHandler).not.toBeNull())
+
+    act(() => {
+      messageHandler!({
+        type: 'terminal.created',
+        requestId: 'req-codex-resilience',
+        terminalId: 'term-codex-clean-exit',
+        createdAt: Date.now(),
+      })
+      messageHandler!({
+        type: 'terminal.attach.ready',
+        terminalId: 'term-codex-clean-exit',
+        attachRequestId: latestAttachRequestId('term-codex-clean-exit'),
+        headSeq: 0,
+        replayFromSeq: 0,
+        replayToSeq: 0,
+      })
+      messageHandler!({
+        type: 'terminal.exit',
+        terminalId: 'term-codex-clean-exit',
+        exitCode: 0,
+      })
+    })
+
+    expect(contentFor(store, tabId).terminalId).toBeUndefined()
+    expect(contentFor(store, tabId).status).toBe('exited')
+    wsMocks.send.mockClear()
+
+    act(() => {
+      reconnectHandler!()
+    })
+
+    expect(contentFor(store, tabId).status).toBe('exited')
+    expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: 'terminal.create',
+    }))
+    expect(wsMocks.send).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: 'terminal.attach',
+      terminalId: 'term-codex-clean-exit',
+    }))
+  })
+
   it('keeps recovering status through reattach until the server reports running', async () => {
     const { store, tabId, paneId, paneContent } = createStore()
 

--- a/test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs
+++ b/test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs
@@ -100,6 +100,7 @@ function makeTurn(id = 'turn-1') {
   return {
     id,
     status: 'completed',
+    itemsView: 'full',
     items: [{
       type: 'agentMessage',
       id: `${id}:item-0`,
@@ -111,6 +112,24 @@ function makeTurn(id = 'turn-1') {
     startedAt: 1770000001,
     completedAt: 1770000002,
     durationMs: 1000,
+  }
+}
+
+function projectTurnItemsView(turn, itemsView = 'summary') {
+  if (itemsView === 'full') {
+    return { ...turn, itemsView: 'full' }
+  }
+  if (itemsView === 'notLoaded') {
+    return { ...turn, itemsView: 'notLoaded', items: [] }
+  }
+  return {
+    ...turn,
+    itemsView: 'summary',
+    items: turn.items.map((item) => ({
+      type: item.type,
+      id: item.id,
+      summary: item.summary ?? item.text ?? item.command ?? item.type,
+    })),
   }
 }
 
@@ -130,6 +149,32 @@ function makeThread(id, params = {}) {
     source: 'appServer',
     turns: params.includeTurns ? [makeTurn()] : [],
     path: handle.path,
+  }
+}
+
+function makeThreadTurnsPage(params = {}) {
+  const configuredTurns = Array.isArray(behavior.threadTurns)
+    ? behavior.threadTurns
+    : [makeTurn()]
+  const orderedTurns = params.sortDirection === 'asc'
+    ? configuredTurns.slice()
+    : configuredTurns.slice().reverse()
+  const offset = typeof params.cursor === 'string' && /^\d+$/.test(params.cursor)
+    ? Number(params.cursor)
+    : 0
+  const limit = Number.isInteger(params.limit) && params.limit > 0
+    ? params.limit
+    : orderedTurns.length
+  const turns = orderedTurns
+    .slice(offset, offset + limit)
+    .map((turn) => projectTurnItemsView(turn, params.itemsView))
+  const nextOffset = offset + turns.length
+  return {
+    revision: 1770000007,
+    data: turns,
+    nextCursor: nextOffset < orderedTurns.length ? String(nextOffset) : null,
+    backwardsCursor: null,
+    bodies: Object.fromEntries(turns.map((turn) => [turn.id, turn])),
   }
 }
 
@@ -200,6 +245,9 @@ function successResult(method, params) {
         includeTurns: params?.includeTurns === true,
       }),
     }
+  }
+  if (method === 'thread/turns/list') {
+    return makeThreadTurnsPage(params)
   }
   if (method === 'thread/loaded/list') {
     return {

--- a/test/fixtures/coding-cli/codex-app-server/schema-traceability.ts
+++ b/test/fixtures/coding-cli/codex-app-server/schema-traceability.ts
@@ -93,7 +93,7 @@ export const CODEX_CLIENT_REQUEST_TRACEABILITY: readonly CodexTraceEntry<CodexCl
       ? 'test/unit/server/coding-cli/codex-app-server/client.test.ts'
       : 'test/unit/server/coding-cli/codex-app-server/schema-traceability.test.ts',
     notes: name === 'thread/read'
-      ? 'codex-cli 0.129.0 does not expose thread/turns/list; page work must be built from generated methods or a later schema.'
+      ? 'codex-cli 0.129.0 stable schema does not expose experimental thread/turns/list; Freshell opts into the experimental runtime method, falls back to thread/read when it is unavailable, and covers both paths with tests.'
       : undefined,
   }))
 

--- a/test/integration/real/codex-app-server-readiness-contract.test.ts
+++ b/test/integration/real/codex-app-server-readiness-contract.test.ts
@@ -213,7 +213,15 @@ describe('real Codex app-server durable readiness contract', () => {
       })
       await creationClient.waitForNotification(
         (notification) => notification.method === 'turn/completed'
-          && notification.params?.threadId === durableThreadId,
+        && notification.params?.threadId === durableThreadId,
+      )
+      await creationClient.request('turn/start', {
+        threadId: durableThreadId,
+        input: [{ type: 'text', text: 'Reply with exactly: freshell-readiness-contract-page-two' }],
+      })
+      await creationClient.waitForNotification(
+        (notification) => notification.method === 'turn/completed'
+        && notification.params?.threadId === durableThreadId,
       )
       await waitForSessionArtifact(codexHome, durableThreadId)
     } finally {
@@ -243,6 +251,47 @@ describe('real Codex app-server durable readiness contract', () => {
 
       const resumed = await actor.resumeThread({ threadId: durableThreadId, cwd: process.cwd() })
       expect(resumed.threadId).toBe(durableThreadId)
+      const newestTurnPage = await actor.listThreadTurns({
+        threadId: durableThreadId,
+        limit: 1,
+        sortDirection: 'desc',
+        itemsView: 'full',
+      })
+      expect(newestTurnPage.turns).toEqual([expect.objectContaining({
+        id: expect.any(String),
+        itemsView: 'full',
+      })])
+      expect(newestTurnPage.nextCursor).toEqual(expect.any(String))
+      const newestMetadataPage = await actor.listThreadTurns({
+        threadId: durableThreadId,
+        limit: 1,
+        sortDirection: 'desc',
+        itemsView: 'notLoaded',
+      })
+      expect(newestMetadataPage.turns).toEqual([expect.objectContaining({
+        id: newestTurnPage.turns[0]!.id,
+        itemsView: 'notLoaded',
+        items: [],
+      })])
+      const olderTurnPage = await actor.listThreadTurns({
+        threadId: durableThreadId,
+        limit: 1,
+        sortDirection: 'desc',
+        cursor: newestTurnPage.nextCursor ?? undefined,
+        itemsView: 'full',
+      })
+      expect(olderTurnPage.turns).toEqual([expect.objectContaining({
+        id: expect.any(String),
+        itemsView: 'full',
+      })])
+      expect(olderTurnPage.turns[0]!.id).not.toBe(newestTurnPage.turns[0]!.id)
+      await expect(actor.readThreadTurn({
+        threadId: durableThreadId,
+        turnId: olderTurnPage.turns[0]!.id,
+      })).resolves.toMatchObject({
+        id: olderTurnPage.turns[0]!.id,
+        itemsView: 'full',
+      })
 
       const readiness = await waitForLifecycle(
         lifecycle,

--- a/test/integration/server/codex-session-flow.test.ts
+++ b/test/integration/server/codex-session-flow.test.ts
@@ -636,6 +636,243 @@ describe('Codex Session Flow Integration', () => {
     }
   })
 
+  it('keeps a real durable Codex PTY clean exit final without recovery replacement', async () => {
+    const testDir = await fsp.mkdtemp(path.join(tempDir, 'clean-exit-final-'))
+    const metadataDir = path.join(testDir, 'metadata')
+    const launchLogPath = path.join(testDir, 'codex-launches.jsonl')
+    await fsp.mkdir(metadataDir, { recursive: true })
+
+    const previousLaunchLog = process.env.FAKE_CODEX_LAUNCH_LOG
+    process.env.FAKE_CODEX_LAUNCH_LOG = launchLogPath
+
+    const oldRuntime = new CodexAppServerRuntime({
+      command: process.execPath,
+      commandArgs: [FAKE_APP_SERVER_PATH],
+      metadataDir,
+      serverInstanceId: 'srv-codex-clean-exit-old',
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          loadedThreadIds: ['thread-existing-1'],
+        }),
+      },
+    })
+    const replacementRuntime = new CodexAppServerRuntime({
+      command: process.execPath,
+      commandArgs: [FAKE_APP_SERVER_PATH],
+      metadataDir,
+      serverInstanceId: 'srv-codex-clean-exit-replacement',
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          loadedThreadIds: ['thread-existing-1'],
+        }),
+      },
+    })
+    runtimes.add(oldRuntime)
+    runtimes.add(replacementRuntime)
+    const oldPlanner = new CodexLaunchPlanner(oldRuntime)
+    const replacementPlanner = new CodexLaunchPlanner(replacementRuntime)
+    let terminalId: string | undefined
+
+    try {
+      const oldPlan = await oldPlanner.planCreate({ resumeSessionId: 'thread-existing-1' })
+      const recovery = {
+        planCreate: vi.fn(() => replacementPlanner.planCreate({ resumeSessionId: 'thread-existing-1' })),
+        retryDelayMs: 0,
+      }
+      const term = registry.create({
+        mode: 'codex',
+        resumeSessionId: 'thread-existing-1',
+        cwd: tempDir,
+        providerSettings: {
+          codexAppServer: {
+            wsUrl: oldPlan.remote.wsUrl,
+            sidecar: oldPlan.sidecar,
+            recovery,
+          },
+        } as any,
+      })
+      terminalId = term.terminalId
+      const exited = new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          cleanup()
+          reject(new Error('Timed out waiting for clean Codex PTY exit'))
+        }, MESSAGE_TIMEOUT_MS)
+        const cleanup = () => {
+          clearTimeout(timeout)
+          registry.off('terminal.exit', onExit)
+        }
+        const onExit = (event: { terminalId: string; exitCode?: number }) => {
+          if (event.terminalId !== term.terminalId) return
+          try {
+            expect(event.exitCode).toBe(0)
+            cleanup()
+            resolve()
+          } catch (err) {
+            cleanup()
+            reject(err)
+          }
+        }
+        registry.on('terminal.exit', onExit)
+      })
+      await oldPlan.sidecar.adopt({ terminalId: term.terminalId, generation: 0 })
+      await waitForJsonLine(launchLogPath, (line) => line.pid === term.pty.pid)
+      await exited
+
+      expect(recovery.planCreate).not.toHaveBeenCalled()
+      expect(registry.get(term.terminalId)?.status).toBe('exited')
+      expect(registry.get(term.terminalId)?.exitCode).toBe(0)
+    } finally {
+      if (terminalId) {
+        await registry.killAndWait(terminalId).catch(() => undefined)
+      }
+      await replacementPlanner.shutdown().catch(() => undefined)
+      await oldPlanner.shutdown().catch(() => undefined)
+      await replacementRuntime.shutdown().catch(() => undefined)
+      await oldRuntime.shutdown().catch(() => undefined)
+      runtimes.delete(oldRuntime)
+      runtimes.delete(replacementRuntime)
+      if (previousLaunchLog === undefined) delete process.env.FAKE_CODEX_LAUNCH_LOG
+      else process.env.FAKE_CODEX_LAUNCH_LOG = previousLaunchLog
+      await fsp.rm(testDir, { recursive: true, force: true })
+    }
+  })
+
+  it('recovers a real durable Codex PTY that exits 0 after SIGTERM during an active turn', async () => {
+    const testDir = await fsp.mkdtemp(path.join(tempDir, 'sigterm-active-turn-'))
+    const metadataDir = path.join(testDir, 'metadata')
+    const launchLogPath = path.join(testDir, 'codex-launches.jsonl')
+    const remoteLogPath = path.join(testDir, 'codex-remote.jsonl')
+    await fsp.mkdir(metadataDir, { recursive: true })
+
+    const previousConnectRemote = process.env.FAKE_CODEX_CONNECT_REMOTE
+    const previousRemoteLog = process.env.FAKE_CODEX_REMOTE_LOG
+    const previousStayAlive = process.env.FAKE_CODEX_STAY_ALIVE
+    const previousLaunchLog = process.env.FAKE_CODEX_LAUNCH_LOG
+    const previousBehavior = process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR
+    process.env.FAKE_CODEX_CONNECT_REMOTE = '1'
+    process.env.FAKE_CODEX_REMOTE_LOG = remoteLogPath
+    process.env.FAKE_CODEX_STAY_ALIVE = '1'
+    process.env.FAKE_CODEX_LAUNCH_LOG = launchLogPath
+    process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR = JSON.stringify({
+      threadStartThreadId: 'thread-existing-1',
+      loadedThreadIds: ['thread-existing-1'],
+      threadTurns: [{
+        id: 'turn-1',
+        status: 'inProgress',
+        items: [],
+        error: null,
+        startedAt: 1770000001,
+        completedAt: null,
+        durationMs: null,
+      }],
+      notificationsAfterMethods: {
+        'turn/start': [{
+          method: 'turn/started',
+          params: {
+            threadId: 'thread-existing-1',
+            turnId: 'turn-1',
+          },
+        }],
+      },
+    })
+
+    const oldRuntime = new CodexAppServerRuntime({
+      command: process.execPath,
+      commandArgs: [FAKE_APP_SERVER_PATH],
+      metadataDir,
+      serverInstanceId: 'srv-codex-sigterm-active-old',
+    })
+    const replacementRuntime = new CodexAppServerRuntime({
+      command: process.execPath,
+      commandArgs: [FAKE_APP_SERVER_PATH],
+      metadataDir,
+      serverInstanceId: 'srv-codex-sigterm-active-replacement',
+    })
+    runtimes.add(oldRuntime)
+    runtimes.add(replacementRuntime)
+    const oldPlanner = new CodexLaunchPlanner(oldRuntime)
+    const replacementPlanner = new CodexLaunchPlanner(replacementRuntime)
+    let terminalId: string | undefined
+    let oldPtyPid: number | undefined
+
+    try {
+      const oldPlan = await oldPlanner.planCreate({ resumeSessionId: 'thread-existing-1' })
+      const recovery = {
+        planCreate: vi.fn(() => replacementPlanner.planCreate({ resumeSessionId: 'thread-existing-1' })),
+        retryDelayMs: 0,
+      }
+      const term = registry.create({
+        mode: 'codex',
+        resumeSessionId: 'thread-existing-1',
+        cwd: tempDir,
+        providerSettings: {
+          codexAppServer: {
+            wsUrl: oldPlan.remote.wsUrl,
+            sidecar: oldPlan.sidecar,
+            recovery,
+          },
+        } as any,
+      })
+      terminalId = term.terminalId
+      oldPtyPid = term.pty.pid
+      await oldPlan.sidecar.adopt({ terminalId: term.terminalId, generation: 0 })
+      await waitForJsonLine(remoteLogPath, (line) => (
+        line.pid === oldPtyPid
+        && line.message?.result?.thread?.id === 'thread-existing-1'
+      ))
+
+      expect(registry.input(term.terminalId, 'start active turn\n')).toEqual({ status: 'written' })
+      await vi.waitFor(() => {
+        expect((registry.get(term.terminalId) as any)?.codexActiveTurn).toMatchObject({
+          threadId: 'thread-existing-1',
+          turnId: 'turn-1',
+        })
+      })
+
+      process.kill(oldPtyPid, 'SIGTERM')
+
+      await vi.waitFor(() => expect(recovery.planCreate).toHaveBeenCalledTimes(1))
+      const replacementLaunch = await waitForJsonLine(
+        launchLogPath,
+        (line) => line.pid !== oldPtyPid && Array.isArray(line.args) && line.args.includes('thread-existing-1'),
+      )
+      await vi.waitFor(() => {
+        const latest = registry.get(term.terminalId)
+        expect(latest?.status).toBe('running')
+        expect(latest?.pty.pid).toBe(replacementLaunch.pid)
+        expect(latest?.exitCode).toBeUndefined()
+      })
+    } finally {
+      if (oldPtyPid && await isProcessAlive(oldPtyPid)) {
+        try {
+          process.kill(oldPtyPid, 'SIGKILL')
+        } catch {
+          // Best-effort cleanup for a fake PTY process that can outlive the assertion window under parallel load.
+        }
+      }
+      if (terminalId) {
+        await registry.killAndWait(terminalId).catch(() => undefined)
+      }
+      await replacementPlanner.shutdown().catch(() => undefined)
+      await oldPlanner.shutdown().catch(() => undefined)
+      await replacementRuntime.shutdown().catch(() => undefined)
+      await oldRuntime.shutdown().catch(() => undefined)
+      runtimes.delete(oldRuntime)
+      runtimes.delete(replacementRuntime)
+      if (previousConnectRemote === undefined) delete process.env.FAKE_CODEX_CONNECT_REMOTE
+      else process.env.FAKE_CODEX_CONNECT_REMOTE = previousConnectRemote
+      if (previousRemoteLog === undefined) delete process.env.FAKE_CODEX_REMOTE_LOG
+      else process.env.FAKE_CODEX_REMOTE_LOG = previousRemoteLog
+      if (previousStayAlive === undefined) delete process.env.FAKE_CODEX_STAY_ALIVE
+      else process.env.FAKE_CODEX_STAY_ALIVE = previousStayAlive
+      if (previousLaunchLog === undefined) delete process.env.FAKE_CODEX_LAUNCH_LOG
+      else process.env.FAKE_CODEX_LAUNCH_LOG = previousLaunchLog
+      if (previousBehavior === undefined) delete process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR
+      else process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR = previousBehavior
+      await fsp.rm(testDir, { recursive: true, force: true })
+    }
+  })
+
   it('retires the previous wrapper/native app-server during recovery replacement and routes later input only to the replacement', async () => {
     const testDir = await fsp.mkdtemp(path.join(tempDir, 'recovery-retire-'))
     const metadataDir = path.join(testDir, 'metadata')

--- a/test/server/agent-run.test.ts
+++ b/test/server/agent-run.test.ts
@@ -246,6 +246,62 @@ it('reports Codex recovery-pending input rejection for /api/run', async () => {
   expect(registry.killAndWait).toHaveBeenCalledWith('term1')
 })
 
+it('reports Codex lifecycle-loss-pending input rejection for /api/run', async () => {
+  const registry = {
+    create: vi.fn((opts?: { terminalId?: string }) => ({ terminalId: opts?.terminalId ?? 'term1' })),
+    input: vi.fn(() => ({ status: 'blocked_codex_lifecycle_loss_pending', terminalId: 'term1' })),
+    killAndWait: vi.fn(async () => true),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      createTab: () => ({ tabId: 't1', paneId: 'p1' }),
+      closeTab: vi.fn(),
+      attachPaneContent: () => {},
+    },
+    registry,
+    codexLaunchPlanner,
+  }))
+
+  const res = await request(app).post('/api/run').send({ command: 'echo done', mode: 'codex' })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toBe('Codex worker lifecycle loss is still being resolved.')
+  expect(registry.input).toHaveBeenCalledTimes(1)
+  expect(registry.killAndWait).toHaveBeenCalledWith('term1')
+})
+
+it('reports Codex clean-exit-decision-pending input rejection for /api/run', async () => {
+  const registry = {
+    create: vi.fn((opts?: { terminalId?: string }) => ({ terminalId: opts?.terminalId ?? 'term1' })),
+    input: vi.fn(() => ({ status: 'blocked_codex_clean_exit_decision_pending', terminalId: 'term1' })),
+    killAndWait: vi.fn(async () => true),
+  }
+  const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      createTab: () => ({ tabId: 't1', paneId: 'p1' }),
+      closeTab: vi.fn(),
+      attachPaneContent: () => {},
+    },
+    registry,
+    codexLaunchPlanner,
+  }))
+
+  const res = await request(app).post('/api/run').send({ command: 'echo done', mode: 'codex' })
+
+  expect(res.status).toBe(500)
+  expect(res.body.message).toBe('Codex clean exit state is still being resolved.')
+  expect(registry.input).toHaveBeenCalledTimes(1)
+  expect(registry.killAndWait).toHaveBeenCalledWith('term1')
+})
+
 it('shuts down the pending Codex sidecar when /api/run fails after planning', async () => {
   const registry = {
     create: vi.fn(() => {

--- a/test/server/agent-send-keys.test.ts
+++ b/test/server/agent-send-keys.test.ts
@@ -54,6 +54,46 @@ it('rejects blocked Codex input instead of reporting success', async () => {
   expect(res.body.message).toBe('Codex restore identity could not be captured before input could be accepted.')
 })
 
+it('rejects lifecycle-loss-pending Codex input instead of reporting success', async () => {
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { resolvePaneToTerminal: () => 'term_1' },
+    registry: {
+      input: () => ({
+        status: 'blocked_codex_lifecycle_loss_pending',
+        terminalId: 'term_1',
+      }),
+    },
+  }))
+
+  const res = await request(app).post('/api/panes/p1/send-keys').send({ data: 'ls\r' })
+
+  expect(res.status).toBe(409)
+  expect(res.body.status).toBe('error')
+  expect(res.body.message).toBe('Codex worker lifecycle loss is still being resolved.')
+})
+
+it('rejects clean-exit-decision-pending Codex input instead of reporting success', async () => {
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { resolvePaneToTerminal: () => 'term_1' },
+    registry: {
+      input: () => ({
+        status: 'blocked_codex_clean_exit_decision_pending',
+        terminalId: 'term_1',
+      }),
+    },
+  }))
+
+  const res = await request(app).post('/api/panes/p1/send-keys').send({ data: 'ls\r' })
+
+  expect(res.status).toBe(409)
+  expect(res.body.status).toBe('error')
+  expect(res.body.message).toBe('Codex clean exit state is still being resolved.')
+})
+
 it('waits for Codex identity capture before sending a seeded prompt when requested', async () => {
   const events = new EventEmitter()
   let identityReady = false

--- a/test/server/ws-protocol.test.ts
+++ b/test/server/ws-protocol.test.ts
@@ -1175,6 +1175,56 @@ describe('ws protocol', () => {
     }
   })
 
+  it('terminal.input reports Codex lifecycle-loss proof as blocked input', async () => {
+    const { ws, close } = await createAuthenticatedConnection()
+
+    const terminalId = await createTerminal(ws, 'create-for-codex-lifecycle-loss-input')
+    const originalInput = registry.input.bind(registry)
+    registry.input = vi.fn(() => ({
+      status: 'blocked_codex_lifecycle_loss_pending',
+      terminalId,
+    })) as any
+
+    try {
+      ws.send(JSON.stringify({ type: 'terminal.input', terminalId, data: 'test' }))
+
+      const blocked = await waitForMessage(ws, (msg) => msg.type === 'terminal.input.blocked')
+      expect(blocked).toEqual({
+        type: 'terminal.input.blocked',
+        terminalId,
+        reason: 'codex_lifecycle_loss_pending',
+      })
+    } finally {
+      registry.input = originalInput as any
+      await close()
+    }
+  })
+
+  it('terminal.input reports Codex clean-exit decision as blocked input', async () => {
+    const { ws, close } = await createAuthenticatedConnection()
+
+    const terminalId = await createTerminal(ws, 'create-for-codex-clean-exit-decision-input')
+    const originalInput = registry.input.bind(registry)
+    registry.input = vi.fn(() => ({
+      status: 'blocked_codex_clean_exit_decision_pending',
+      terminalId,
+    })) as any
+
+    try {
+      ws.send(JSON.stringify({ type: 'terminal.input', terminalId, data: 'test' }))
+
+      const blocked = await waitForMessage(ws, (msg) => msg.type === 'terminal.input.blocked')
+      expect(blocked).toEqual({
+        type: 'terminal.input.blocked',
+        terminalId,
+        reason: 'codex_clean_exit_decision_pending',
+      })
+    } finally {
+      registry.input = originalInput as any
+      await close()
+    }
+  })
+
   it('terminal.resize changes terminal dimensions', async () => {
     const { ws, close } = await createAuthenticatedConnection()
 

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -2522,6 +2522,70 @@ describe('TerminalView lifecycle updates', () => {
     )
   })
 
+  it('shows feedback when Codex input is blocked by lifecycle-loss proof', async () => {
+    const { store, tabId, paneId, paneContent } = setupThemeTerminal({
+      terminalId: 'term-codex',
+      status: 'running',
+      mode: 'codex',
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalView tabId={tabId} paneId={paneId} paneContent={paneContent} />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(messageHandler).not.toBeNull()
+      expect(terminalInstances.length).toBeGreaterThan(0)
+    })
+
+    act(() => {
+      messageHandler!({
+        type: 'terminal.input.blocked',
+        terminalId: 'term-codex',
+        reason: 'codex_lifecycle_loss_pending',
+      })
+    })
+
+    const term = terminalInstances[0]
+    expect(term.writeln).toHaveBeenCalledWith(
+      expect.stringContaining('Input not sent: Codex is resolving a worker disconnect. Try again in a moment.'),
+    )
+  })
+
+  it('shows feedback when Codex input is blocked by clean-exit state resolution', async () => {
+    const { store, tabId, paneId, paneContent } = setupThemeTerminal({
+      terminalId: 'term-codex',
+      status: 'running',
+      mode: 'codex',
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalView tabId={tabId} paneId={paneId} paneContent={paneContent} />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(messageHandler).not.toBeNull()
+      expect(terminalInstances.length).toBeGreaterThan(0)
+    })
+
+    act(() => {
+      messageHandler!({
+        type: 'terminal.input.blocked',
+        terminalId: 'term-codex',
+        reason: 'codex_clean_exit_decision_pending',
+      })
+    })
+
+    const term = terminalInstances[0]
+    expect(term.writeln).toHaveBeenCalledWith(
+      expect.stringContaining('Input not sent: Codex is checking whether the session is still active. Try again in a moment.'),
+    )
+  })
+
   it('mirrors canonical durable identity to pane and tab on terminal.session.associated', async () => {
     const tabId = 'tab-session-assoc'
     const paneId = 'pane-session-assoc'

--- a/test/unit/server/coding-cli/codex-app-server/client.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/client.test.ts
@@ -598,6 +598,36 @@ describe('CodexAppServerClient', () => {
     })
   })
 
+  it('accepts a pinned individual thread turn read when a list page omits its revision', async () => {
+    const client = new CodexAppServerClient({ wsUrl: 'ws://127.0.0.1:1' })
+    vi.spyOn(client as any, 'request').mockImplementation(async (method: string) => {
+      if (method !== 'thread/turns/list') throw new Error(`unexpected method ${method}`)
+      return {
+        nextCursor: null,
+        turns: [{
+          id: 'turn-target',
+          status: 'completed',
+          itemsView: 'full',
+          items: [],
+          error: null,
+          startedAt: 1770000001,
+          completedAt: 1770000002,
+          durationMs: 1000,
+        }],
+      }
+    })
+
+    await expect(client.readThreadTurn({
+      threadId: 'thread-new-1',
+      turnId: 'turn-target',
+      revision: 7,
+    })).resolves.toMatchObject({
+      turnId: 'turn-target',
+      revision: 7,
+      status: 'completed',
+    })
+  })
+
   it('rejects an individual thread turn when the list revision no longer matches the requested revision', async () => {
     const client = new CodexAppServerClient({ wsUrl: 'ws://127.0.0.1:1' })
     vi.spyOn(client as any, 'request').mockImplementation(async (method: string) => {

--- a/test/unit/server/coding-cli/codex-app-server/client.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/client.test.ts
@@ -19,6 +19,16 @@ type FakeServerBehavior = {
   rejectJsonRpc?: boolean
   requireInitializeBeforeOtherMethods?: boolean
   overrides?: Record<string, { result?: unknown; error?: { code: number; message: string } }>
+  threadTurns?: Array<{
+    id: string
+    status: string
+    itemsView?: string
+    items: unknown[]
+    error: unknown
+    startedAt: number
+    completedAt: number | null
+    durationMs: number | null
+  }>
 }
 
 type FakeServerHandle = {
@@ -503,11 +513,71 @@ describe('CodexAppServerClient', () => {
     await client.initialize()
     await expect(client.listThreadTurns({
       threadId: 'thread-new-1',
+      itemsView: 'full',
     })).resolves.toMatchObject({
       revision: 1770000007,
       nextCursor: null,
+      turns: [expect.objectContaining({
+        id: 'turn-1',
+        itemsView: 'full',
+        items: [expect.objectContaining({ type: 'agentMessage', text: 'Fixture turn' })],
+      })],
+      bodies: {
+        'turn-1': expect.objectContaining({
+          id: 'turn-1',
+          itemsView: 'full',
+          items: [expect.objectContaining({ type: 'agentMessage', text: 'Fixture turn' })],
+        }),
+      },
+    })
+  })
+
+  it('lists newest thread turns first when descending sort is requested', async () => {
+    const turns = Array.from({ length: 75 }, (_, index) => ({
+      id: `turn-${index + 1}`,
+      status: index === 74 ? 'inProgress' : 'completed',
+      items: [],
+      error: null,
+      startedAt: 1770000001 + index,
+      completedAt: index === 74 ? null : 1770000002 + index,
+      durationMs: index === 74 ? null : 1000,
+    }))
+    const server = await startFakeCodexAppServer({ threadTurns: turns })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    await client.initialize()
+    const page = await client.listThreadTurns({
+      threadId: 'thread-long-1',
+      limit: 50,
+      sortDirection: 'desc',
+      itemsView: 'summary',
+    })
+    expect(page.turns).toHaveLength(50)
+    expect(page.turns[0]).toMatchObject({ id: 'turn-75', status: 'inProgress' })
+    expect(page.turns[1]).toMatchObject({ id: 'turn-74' })
+    expect(page.bodies).toMatchObject({
+      'turn-75': expect.objectContaining({ status: 'inProgress' }),
+    })
+  })
+
+  it('does not use full thread reads when listing thread turns', async () => {
+    const server = await startFakeCodexAppServer({
+      overrides: {
+        'thread/read': {
+          error: { code: -32000, message: 'thread/read should not be used for turn paging' },
+        },
+      },
+    })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    await client.initialize()
+    await expect(client.listThreadTurns({
+      threadId: 'thread-new-1',
+      limit: 1,
+      sortDirection: 'desc',
+      itemsView: 'full',
+    })).resolves.toMatchObject({
       turns: [expect.objectContaining({ id: 'turn-1' })],
-      bodies: { 'turn-1': expect.objectContaining({ id: 'turn-1' }) },
     })
   })
 
@@ -519,10 +589,547 @@ describe('CodexAppServerClient', () => {
     await expect(client.readThreadTurn({
       threadId: 'thread-new-1',
       turnId: 'turn-1',
-      revision: 7,
+      revision: 1770000007,
     })).resolves.toMatchObject({
       turnId: 'turn-1',
-      revision: 7,
+      revision: 1770000007,
+      itemsView: 'full',
+      items: [expect.objectContaining({ type: 'agentMessage', text: 'Fixture turn' })],
     })
+  })
+
+  it('rejects an individual thread turn when the list revision no longer matches the requested revision', async () => {
+    const client = new CodexAppServerClient({ wsUrl: 'ws://127.0.0.1:1' })
+    vi.spyOn(client as any, 'request').mockImplementation(async (method: string) => {
+      if (method !== 'thread/turns/list') throw new Error(`unexpected method ${method}`)
+      return {
+        revision: 8,
+        nextCursor: null,
+        turns: [{
+          id: 'turn-target',
+          status: 'completed',
+          itemsView: 'full',
+          items: [],
+          error: null,
+          startedAt: 1770000001,
+          completedAt: 1770000002,
+          durationMs: 1000,
+        }],
+      }
+    })
+
+    await expect(client.readThreadTurn({
+      threadId: 'thread-new-1',
+      turnId: 'turn-target',
+      revision: 7,
+    })).rejects.toThrow('list revision does not match requested revision')
+  })
+
+  it('falls back to thread/read when thread turn listing is unavailable', async () => {
+    const server = await startFakeCodexAppServer({
+      overrides: {
+        'thread/turns/list': {
+          error: { code: -32601, message: 'method not found' },
+        },
+      },
+    })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    await client.initialize()
+    await expect(client.listThreadTurns({
+      threadId: 'thread-new-1',
+      itemsView: 'full',
+    })).resolves.toMatchObject({
+      revision: 1770000007,
+      turns: [expect.objectContaining({
+        id: 'turn-1',
+        itemsView: 'full',
+        items: [expect.objectContaining({ type: 'agentMessage', text: 'Fixture turn' })],
+      })],
+    })
+  })
+
+  it('falls back to thread/read for thread turn listing when JSON-RPC code reports an unknown method', async () => {
+    const server = await startFakeCodexAppServer({
+      overrides: {
+        'thread/turns/list': {
+          error: { code: -32601, message: 'No such procedure' },
+        },
+      },
+    })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    await client.initialize()
+    await expect(client.listThreadTurns({
+      threadId: 'thread-new-1',
+      itemsView: 'full',
+    })).resolves.toMatchObject({
+      turns: [expect.objectContaining({ id: 'turn-1' })],
+    })
+  })
+
+  it('uses one thread/read snapshot for individual thread-turn fallback when listing is unavailable', async () => {
+    const client = new CodexAppServerClient({ wsUrl: 'ws://127.0.0.1:1' })
+    const turns = Array.from({ length: 75 }, (_, index) => ({
+      id: `turn-${index + 1}`,
+      status: 'completed',
+      itemsView: 'full',
+      items: [],
+      error: null,
+      startedAt: 1770000001 + index,
+      completedAt: 1770000002 + index,
+      durationMs: 1000,
+    }))
+    const request = vi.spyOn(client as any, 'request').mockImplementation(async (method: string) => {
+      if (method === 'thread/turns/list') throw new Error('method not found')
+      if (method === 'thread/read') {
+        return {
+          thread: {
+            id: 'thread-new-1',
+            sessionId: 'thread-new-1',
+            updatedAt: 1770000007,
+            turns,
+          },
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    await expect(client.readThreadTurn({
+      threadId: 'thread-new-1',
+      turnId: 'turn-10',
+    })).resolves.toMatchObject({
+      id: 'turn-10',
+      turnId: 'turn-10',
+      revision: 1770000007,
+    })
+    expect(request.mock.calls.filter(([method]) => method === 'thread/read')).toHaveLength(1)
+  })
+
+  it('rejects individual thread-turn fallback when thread/read revision no longer matches the requested revision', async () => {
+    const client = new CodexAppServerClient({ wsUrl: 'ws://127.0.0.1:1' })
+    vi.spyOn(client as any, 'request').mockImplementation(async (method: string) => {
+      if (method === 'thread/turns/list') throw new Error('method not found')
+      if (method === 'thread/read') {
+        return {
+          thread: {
+            id: 'thread-new-1',
+            sessionId: 'thread-new-1',
+            updatedAt: 8,
+            turns: [{
+              id: 'turn-target',
+              status: 'completed',
+              itemsView: 'full',
+              items: [],
+              error: null,
+              startedAt: 1770000001,
+              completedAt: 1770000002,
+              durationMs: 1000,
+            }],
+          },
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    await expect(client.readThreadTurn({
+      threadId: 'thread-new-1',
+      turnId: 'turn-target',
+      revision: 7,
+    })).rejects.toThrow('thread/read revision does not match requested revision')
+  })
+
+  it('normalizes fractional thread/read updatedAt revisions in the thread-turn listing fallback', async () => {
+    const server = await startFakeCodexAppServer({
+      overrides: {
+        'thread/turns/list': {
+          error: { code: -32601, message: 'method not found' },
+        },
+        'thread/read': {
+          result: {
+            thread: {
+              id: 'thread-new-1',
+              sessionId: 'thread-new-1',
+              updatedAt: 1770000007.25,
+              turns: [{
+                id: 'turn-1',
+                status: 'completed',
+                itemsView: 'full',
+                items: [{
+                  type: 'agentMessage',
+                  id: 'turn-1:item-0',
+                  text: 'Fixture turn',
+                  phase: null,
+                  memoryCitation: null,
+                }],
+                error: null,
+                startedAt: 1770000001,
+                completedAt: 1770000002,
+                durationMs: 1000,
+              }],
+            },
+          },
+        },
+      },
+    })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    await client.initialize()
+    await expect(client.listThreadTurns({
+      threadId: 'thread-new-1',
+      itemsView: 'full',
+    })).resolves.toMatchObject({
+      revision: 1770000007,
+      turns: [expect.objectContaining({ id: 'turn-1' })],
+    })
+  })
+
+  it('does not fall back to thread/read for non-compatibility paging failures', async () => {
+    const server = await startFakeCodexAppServer({
+      overrides: {
+        'thread/turns/list': {
+          error: { code: -32000, message: 'temporary paging failure' },
+        },
+      },
+    })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    await client.initialize()
+    await expect(client.listThreadTurns({
+      threadId: 'thread-new-1',
+      itemsView: 'full',
+    })).rejects.toThrow('temporary paging failure')
+  })
+
+  it('does not reinterpret opaque app-server cursors through the thread/read fallback', async () => {
+    const server = await startFakeCodexAppServer({
+      overrides: {
+        'thread/turns/list': {
+          error: { code: -32601, message: 'method not found' },
+        },
+      },
+    })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    await client.initialize()
+    await expect(client.listThreadTurns({
+      threadId: 'thread-new-1',
+      cursor: 'opaque-cursor',
+      itemsView: 'full',
+    })).rejects.toThrow('cannot honor opaque cursor')
+  })
+
+  it('does not reinterpret numeric app-server cursors through the thread/read fallback', async () => {
+    const server = await startFakeCodexAppServer({
+      overrides: {
+        'thread/turns/list': {
+          error: { code: -32601, message: 'method not found' },
+        },
+      },
+    })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    await client.initialize()
+    await expect(client.listThreadTurns({
+      threadId: 'thread-new-1',
+      cursor: '1',
+      itemsView: 'full',
+    })).rejects.toThrow('cannot honor opaque cursor')
+  })
+
+  it('uses revision-bound cursors when paging through the thread/read fallback', async () => {
+    const client = new CodexAppServerClient({ wsUrl: 'ws://127.0.0.1:1' })
+    const turns = Array.from({ length: 3 }, (_, index) => ({
+      id: `turn-${index + 1}`,
+      status: 'completed',
+      itemsView: 'full',
+      items: [],
+      error: null,
+      startedAt: 1770000001 + index,
+      completedAt: 1770000002 + index,
+      durationMs: 1000,
+    }))
+    vi.spyOn(client as any, 'request').mockImplementation(async (method: string) => {
+      if (method === 'thread/turns/list') throw new Error('method not found')
+      if (method === 'thread/read') {
+        return {
+          thread: {
+            id: 'thread-new-1',
+            sessionId: 'thread-new-1',
+            updatedAt: 1770000007,
+            turns,
+          },
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    const firstPage = await client.listThreadTurns({
+      threadId: 'thread-new-1',
+      limit: 1,
+      sortDirection: 'desc',
+      itemsView: 'full',
+    })
+    expect(firstPage.turns.map((turn) => turn.id)).toEqual(['turn-3'])
+    expect(firstPage.nextCursor).toBe('thread-read:1770000007:1')
+
+    const secondPage = await client.listThreadTurns({
+      threadId: 'thread-new-1',
+      limit: 1,
+      sortDirection: 'desc',
+      cursor: firstPage.nextCursor ?? undefined,
+      itemsView: 'full',
+    })
+    expect(secondPage.turns.map((turn) => turn.id)).toEqual(['turn-2'])
+  })
+
+  it('summarizes thread/read fallback items like thread/turns/list summary pages', async () => {
+    const client = new CodexAppServerClient({ wsUrl: 'ws://127.0.0.1:1' })
+    vi.spyOn(client as any, 'request').mockImplementation(async (method: string) => {
+      if (method === 'thread/turns/list') throw new Error('method not found')
+      if (method === 'thread/read') {
+        return {
+          thread: {
+            id: 'thread-new-1',
+            sessionId: 'thread-new-1',
+            updatedAt: 1770000007,
+            turns: [{
+              id: 'turn-1',
+              status: 'completed',
+              itemsView: 'full',
+              items: [
+                { id: 'item-summary', type: 'agentMessage', summary: 'existing summary', text: 'ignored text' },
+                { id: 'item-text', type: 'userMessage', text: 'typed prompt' },
+                { id: 'item-command', type: 'commandExecution', command: 'npm test' },
+                { id: 'item-type', type: 'plan' },
+              ],
+              error: null,
+              startedAt: 1770000001,
+              completedAt: 1770000002,
+              durationMs: 1000,
+            }],
+          },
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    const page = await client.listThreadTurns({
+      threadId: 'thread-new-1',
+      limit: 1,
+      sortDirection: 'desc',
+      itemsView: 'summary',
+    })
+
+    expect(page.turns[0].items).toEqual([
+      { id: 'item-summary', type: 'agentMessage', summary: 'existing summary' },
+      { id: 'item-text', type: 'userMessage', summary: 'typed prompt' },
+      { id: 'item-command', type: 'commandExecution', summary: 'npm test' },
+      { id: 'item-type', type: 'plan', summary: 'plan' },
+    ])
+  })
+
+  it('keeps thread/read fallback cursors on the fallback path when thread/turns/list becomes available', async () => {
+    const client = new CodexAppServerClient({ wsUrl: 'ws://127.0.0.1:1' })
+    const turns = Array.from({ length: 3 }, (_, index) => ({
+      id: `turn-${index + 1}`,
+      status: 'completed',
+      itemsView: 'full',
+      items: [],
+      error: null,
+      startedAt: 1770000001 + index,
+      completedAt: 1770000002 + index,
+      durationMs: 1000,
+    }))
+    let turnsListCalls = 0
+    vi.spyOn(client as any, 'request').mockImplementation(async (method: string) => {
+      if (method === 'thread/turns/list') {
+        turnsListCalls += 1
+        if (turnsListCalls === 1) throw new Error('method not found')
+        throw new Error('thread/read fallback cursor was sent to thread/turns/list')
+      }
+      if (method === 'thread/read') {
+        return {
+          thread: {
+            id: 'thread-new-1',
+            sessionId: 'thread-new-1',
+            updatedAt: 1770000007,
+            turns,
+          },
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    const firstPage = await client.listThreadTurns({
+      threadId: 'thread-new-1',
+      limit: 1,
+      sortDirection: 'desc',
+      itemsView: 'full',
+    })
+    expect(firstPage.nextCursor).toBe('thread-read:1770000007:1')
+
+    const secondPage = await client.listThreadTurns({
+      threadId: 'thread-new-1',
+      limit: 1,
+      sortDirection: 'desc',
+      cursor: firstPage.nextCursor ?? undefined,
+      itemsView: 'full',
+    })
+
+    expect(secondPage.turns.map((turn) => turn.id)).toEqual(['turn-2'])
+    expect(turnsListCalls).toBe(1)
+  })
+
+  it('defaults thread/read fallback turn pages to newest first', async () => {
+    const client = new CodexAppServerClient({ wsUrl: 'ws://127.0.0.1:1' })
+    const turns = Array.from({ length: 3 }, (_, index) => ({
+      id: `turn-${index + 1}`,
+      status: 'completed',
+      itemsView: 'full',
+      items: [],
+      error: null,
+      startedAt: 1770000001 + index,
+      completedAt: 1770000002 + index,
+      durationMs: 1000,
+    }))
+    vi.spyOn(client as any, 'request').mockImplementation(async (method: string) => {
+      if (method === 'thread/turns/list') throw new Error('method not found')
+      if (method === 'thread/read') {
+        return {
+          thread: {
+            id: 'thread-new-1',
+            sessionId: 'thread-new-1',
+            updatedAt: 1770000007,
+            turns,
+          },
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    await expect(client.listThreadTurns({
+      threadId: 'thread-new-1',
+      limit: 2,
+      itemsView: 'full',
+    })).resolves.toMatchObject({
+      turns: [
+        expect.objectContaining({ id: 'turn-3' }),
+        expect.objectContaining({ id: 'turn-2' }),
+      ],
+    })
+  })
+
+  it('rejects thread/read fallback paging when the snapshot revision changes', async () => {
+    const client = new CodexAppServerClient({ wsUrl: 'ws://127.0.0.1:1' })
+    const turns = Array.from({ length: 3 }, (_, index) => ({
+      id: `turn-${index + 1}`,
+      status: 'completed',
+      itemsView: 'full',
+      items: [],
+      error: null,
+      startedAt: 1770000001 + index,
+      completedAt: 1770000002 + index,
+      durationMs: 1000,
+    }))
+    let readCount = 0
+    vi.spyOn(client as any, 'request').mockImplementation(async (method: string) => {
+      if (method === 'thread/turns/list') throw new Error('method not found')
+      if (method === 'thread/read') {
+        readCount += 1
+        return {
+          thread: {
+            id: 'thread-new-1',
+            sessionId: 'thread-new-1',
+            updatedAt: readCount === 1 ? 1770000007 : 1770000008,
+            turns,
+          },
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    const firstPage = await client.listThreadTurns({
+      threadId: 'thread-new-1',
+      limit: 1,
+      sortDirection: 'desc',
+      itemsView: 'full',
+    })
+
+    await expect(client.listThreadTurns({
+      threadId: 'thread-new-1',
+      limit: 1,
+      sortDirection: 'desc',
+      cursor: firstPage.nextCursor ?? undefined,
+      itemsView: 'full',
+    })).rejects.toThrow('snapshot changed while paging')
+  })
+
+  it('pages until it finds an older individual thread turn', async () => {
+    const turns = Array.from({ length: 75 }, (_, index) => ({
+      id: `turn-${index + 1}`,
+      status: 'completed',
+      items: [],
+      error: null,
+      startedAt: 1770000001 + index,
+      completedAt: 1770000002 + index,
+      durationMs: 1000,
+    }))
+    const server = await startFakeCodexAppServer({ threadTurns: turns })
+    const client = new CodexAppServerClient({ wsUrl: server.wsUrl })
+
+    await client.initialize()
+    await expect(client.readThreadTurn({
+      threadId: 'thread-long-1',
+      turnId: 'turn-10',
+      revision: 1770000007,
+    })).resolves.toMatchObject({
+      id: 'turn-10',
+      turnId: 'turn-10',
+      revision: 1770000007,
+    })
+  })
+
+  it('rejects individual thread-turn paging when list revisions change', async () => {
+    const client = new CodexAppServerClient({ wsUrl: 'ws://127.0.0.1:1' })
+    let pageCount = 0
+    vi.spyOn(client as any, 'request').mockImplementation(async (method: string) => {
+      if (method !== 'thread/turns/list') throw new Error(`unexpected method ${method}`)
+      pageCount += 1
+      return pageCount === 1
+        ? {
+            revision: 7,
+            nextCursor: 'cursor-2',
+            turns: [{
+              id: 'turn-newer',
+              status: 'completed',
+              itemsView: 'full',
+              items: [],
+              error: null,
+              startedAt: 1770000001,
+              completedAt: 1770000002,
+              durationMs: 1000,
+            }],
+          }
+        : {
+            revision: 8,
+            nextCursor: null,
+            turns: [{
+              id: 'turn-target',
+              status: 'completed',
+              itemsView: 'full',
+              items: [],
+              error: null,
+              startedAt: 1770000003,
+              completedAt: 1770000004,
+              durationMs: 1000,
+            }],
+          }
+    })
+
+    await expect(client.readThreadTurn({
+      threadId: 'thread-new-1',
+      turnId: 'turn-target',
+    })).rejects.toThrow('revision changed while paging')
   })
 })

--- a/test/unit/server/coding-cli/codex-app-server/schema-traceability.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/schema-traceability.test.ts
@@ -61,7 +61,7 @@ describe('Codex generated schema traceability', () => {
     expect(CODEX_RUNTIME_LEAF_VALUES.askForApproval).not.toContain('bypassPermissions')
   })
 
-  it('records that codex-cli 0.129.0 has no generated thread/turns/list method', () => {
+  it('records that codex-cli 0.129.0 stable schema has no generated thread/turns/list method', () => {
     expect(CODEX_CLIENT_REQUEST_METHODS).not.toContain('thread/turns/list')
   })
 })

--- a/test/unit/server/fresh-agent/codex-adapter.test.ts
+++ b/test/unit/server/fresh-agent/codex-adapter.test.ts
@@ -104,6 +104,7 @@ describe('Codex fresh-agent adapter', () => {
 
   it('reads snapshots and turns from the official Codex thread APIs', async () => {
     const durableTurn = makeCodexTurn('turn-1')
+    const expectedFullItem = expect.objectContaining({ kind: 'text', text: 'Codex summary' })
     const runtime = {
       startThread: vi.fn(),
       resumeThread: vi.fn(),
@@ -131,11 +132,13 @@ describe('Codex fresh-agent adapter', () => {
     expect(runtime.readThread).toHaveBeenCalledWith({ threadId: 'thread-new-1', includeTurns: true })
     await expect(adapter.getTurnPage?.({ sessionType: 'freshcodex', provider: 'codex', threadId: 'thread-new-1' }, { revision: 7 })).resolves.toMatchObject({
       revision: 7,
-      turns: [{ id: 'turn-1', turnId: 'turn-1' }],
+      turns: [{ id: 'turn-1', turnId: 'turn-1', items: [expectedFullItem] }],
+      bodies: { 'turn-1': expect.objectContaining({ items: [expectedFullItem] }) },
     })
     await expect(adapter.getTurnBody?.({ sessionType: 'freshcodex', provider: 'codex', threadId: 'thread-new-1', turnId: 'turn-1' }, 7)).resolves.toMatchObject({
       turnId: 'turn-1',
       revision: 7,
+      items: [expectedFullItem],
     })
   })
 

--- a/test/unit/server/terminal-registry.codex-recovery.test.ts
+++ b/test/unit/server/terminal-registry.codex-recovery.test.ts
@@ -170,6 +170,42 @@ describe.sequential('TerminalRegistry Codex durable recovery', () => {
     expect(exited).not.toHaveBeenCalled()
   })
 
+  it('clears the retiring PTY marker when recovery aborts before planning', async () => {
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [oldPty] = await spawnedPtys()
+
+    currentSidecar.emitLifecycleLoss({
+      method: 'thread/status/changed',
+      threadId: 'thread-durable-1',
+      status: 'notLoaded',
+    })
+    expect(record.codexRecoveryRetiringPty).toBe(oldPty)
+
+    ;(record as any).status = 'exited'
+
+    await vi.waitFor(() => expect(record.codexRecoveryAttempt).toBeUndefined())
+    expect(record.codexRecoveryRetiringPty).toBeUndefined()
+    expect(planCreate).not.toHaveBeenCalled()
+  })
+
   it('keeps a durable Codex PTY exit final when the visible process exits cleanly', async () => {
     const exited = vi.fn()
     registry.on('terminal.exit', exited)

--- a/test/unit/server/terminal-registry.codex-recovery.test.ts
+++ b/test/unit/server/terminal-registry.codex-recovery.test.ts
@@ -72,27 +72,58 @@ function deferred<T = void>() {
 
 function createFakeSidecar(options: {
   shutdown?: CodexLaunchSidecar['shutdown']
-} = {}): CodexLaunchSidecar {
+  readThreadTurn?: CodexLaunchSidecar['readThreadTurn']
+  listThreadTurns?: CodexLaunchSidecar['listThreadTurns']
+} = {}): CodexLaunchSidecar & { emitLifecycleLoss(event: unknown): void; emitRepairTrigger(event: { kind: string; error?: Error }): void } {
+  const lifecycleLossHandlers = new Set<(event: unknown) => void>()
+  const repairHandlers = new Set<(event: { kind: string; error?: Error }) => void>()
   return {
     adopt: vi.fn().mockResolvedValue(undefined),
     shutdown: vi.fn(options.shutdown ?? (async () => undefined)),
-    onLifecycleLoss: vi.fn(() => vi.fn()),
+    onLifecycleLoss: vi.fn((handler: (event: unknown) => void) => {
+      lifecycleLossHandlers.add(handler)
+      return () => lifecycleLossHandlers.delete(handler)
+    }),
+    onRepairTrigger: vi.fn((handler: (event: { kind: string; error?: Error }) => void) => {
+      repairHandlers.add(handler)
+      return () => repairHandlers.delete(handler)
+    }),
+    readThreadTurn: options.readThreadTurn ? vi.fn(options.readThreadTurn) : undefined,
+    listThreadTurns: options.listThreadTurns ? vi.fn(options.listThreadTurns) : undefined,
+    emitLifecycleLoss(event: unknown) {
+      for (const handler of lifecycleLossHandlers) handler(event)
+    },
+    emitRepairTrigger(event: { kind: string; error?: Error }) {
+      for (const handler of repairHandlers) handler(event)
+    },
   }
 }
 
-describe('TerminalRegistry Codex durable recovery', () => {
+describe.sequential('TerminalRegistry Codex durable recovery', () => {
   let registry: TerminalRegistry
 
   beforeEach(async () => {
     vi.clearAllMocks()
     const pty = await import('node-pty')
     vi.mocked(pty.spawn).mockImplementation(() => createMockPty() as any)
-    registry = new TerminalRegistry(undefined, 10)
+    registry = new TerminalRegistry()
   })
 
-  afterEach(() => {
-    registry.shutdown()
-    vi.useRealTimers()
+  afterEach(async () => {
+    try {
+      await vi.waitFor(() => {
+        for (const terminal of registry.list()) {
+          const record = registry.get(terminal.terminalId)
+          expect(record?.codexRecoveryAttempt).toBeUndefined()
+          expect(record?.codexCleanExitDecisionPending).toBeUndefined()
+          expect(record?.codexPendingCleanExitFinalizer).toBeUndefined()
+          expect(record?.codexLifecycleLossProofPending).not.toBe(true)
+        }
+      })
+    } finally {
+      registry.shutdown()
+      vi.useRealTimers()
+    }
   })
 
   it('recovers a durable Codex terminal when the visible PTY exits unexpectedly', async () => {
@@ -125,8 +156,10 @@ describe('TerminalRegistry Codex durable recovery', () => {
     await vi.waitFor(() => expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1))
     const [, replacementPty] = await spawnedPtys()
 
-    expect(registry.get(record.terminalId)?.status).toBe('running')
-    expect(registry.get(record.terminalId)?.pty).toBe(replacementPty)
+    await vi.waitFor(() => {
+      expect(record.status).toBe('running')
+      expect(registry.get(record.terminalId)?.pty).toBe(replacementPty)
+    })
     expect(planCreate).toHaveBeenCalledWith(expect.objectContaining({
       terminalId: record.terminalId,
       resumeSessionId: 'thread-durable-1',
@@ -134,6 +167,1636 @@ describe('TerminalRegistry Codex durable recovery', () => {
     }))
     expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 })
     expect(oldPty.kill).toHaveBeenCalledTimes(1)
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('keeps a durable Codex PTY exit final when the visible process exits cleanly', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    expect(planCreate).not.toHaveBeenCalled()
+    expect(replacementSidecar.adopt).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(record.status).toBe('exited'), { timeout: 3000 })
+    expect(registry.get(record.terminalId)?.exitCode).toBe(0)
+    expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 0 })
+  })
+
+  it('recovers a durable Codex terminal when the visible PTY exits cleanly during an active turn', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      readThreadTurn: vi.fn(async () => ({
+        id: 'turn-1',
+        turnId: 'turn-1',
+        revision: 1,
+        status: 'inProgress',
+        items: [],
+        error: null,
+        startedAt: Date.now(),
+        completedAt: null,
+        durationMs: null,
+      })),
+    })
+    const replacementSidecar = createFakeSidecar({
+      readThreadTurn: vi.fn(async () => ({
+        id: 'turn-1',
+        turnId: 'turn-1',
+        revision: 1,
+        status: 'completed',
+        items: [],
+        error: null,
+        startedAt: null,
+        completedAt: Date.now(),
+        durationMs: 1000,
+      })),
+    })
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [oldPty] = await spawnedPtys()
+
+    await (registry as any).handleCodexTurnStarted(record.terminalId, {
+      threadId: 'thread-durable-1',
+      turnId: 'turn-1',
+      params: {},
+    })
+    oldPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(currentSidecar.readThreadTurn).toHaveBeenCalledWith({
+      threadId: 'thread-durable-1',
+      turnId: 'turn-1',
+    }))
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(planCreate).toHaveBeenCalledWith(expect.objectContaining({
+      terminalId: record.terminalId,
+      resumeSessionId: 'thread-durable-1',
+      generation: 1,
+    }))
+    const [, replacementPty] = await spawnedPtys()
+    expect(registry.get(record.terminalId)?.pty).toBe(replacementPty)
+    expect(exited).not.toHaveBeenCalled()
+    replacementPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(replacementSidecar.readThreadTurn).toHaveBeenCalledWith({
+      threadId: 'thread-durable-1',
+      turnId: 'turn-1',
+    }))
+    expect(planCreate).toHaveBeenCalled()
+    await vi.waitFor(() => expect(record.status).toBe('exited'), { timeout: 3000 })
+    expect(registry.get(record.terminalId)?.exitCode).toBe(0)
+    expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 0 })
+  })
+
+  it('keeps recovering clean PTY exits after handoff while the active turn remains in progress', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar({
+      readThreadTurn: vi.fn(async () => ({
+        id: 'turn-1',
+        turnId: 'turn-1',
+        revision: 1,
+        status: 'inProgress',
+        items: [],
+        error: null,
+        startedAt: Date.now(),
+        completedAt: null,
+        durationMs: null,
+      })),
+    })
+    const secondReplacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn()
+      .mockResolvedValueOnce({
+        sessionId: 'thread-durable-1',
+        remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+        sidecar: replacementSidecar,
+      })
+      .mockResolvedValueOnce({
+        sessionId: 'thread-durable-1',
+        remote: { wsUrl: 'ws://127.0.0.1:46003/' },
+        sidecar: secondReplacementSidecar,
+      })
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [oldPty] = await spawnedPtys()
+
+    await (registry as any).handleCodexTurnStarted(record.terminalId, {
+      threadId: 'thread-durable-1',
+      turnId: 'turn-1',
+      params: {},
+    })
+    oldPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+
+    const [, replacementPty] = await spawnedPtys()
+    replacementPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(replacementSidecar.readThreadTurn).toHaveBeenCalledWith({
+      threadId: 'thread-durable-1',
+      turnId: 'turn-1',
+    }))
+    await vi.waitFor(() => expect(secondReplacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 2 }))
+    expect(planCreate).toHaveBeenCalledTimes(2)
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('keeps a durable Codex clean exit final when a lost turn-completed notification has a completed turn state', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      readThreadTurn: vi.fn(async () => ({
+        id: 'turn-1',
+        turnId: 'turn-1',
+        revision: 1,
+        status: 'completed',
+        items: [],
+        error: null,
+        startedAt: null,
+        completedAt: Date.now(),
+        durationMs: 1000,
+      })),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    await (registry as any).handleCodexTurnStarted(record.terminalId, {
+      threadId: 'thread-durable-1',
+      turnId: 'turn-1',
+    })
+
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(currentSidecar.readThreadTurn).toHaveBeenCalledWith({
+      threadId: 'thread-durable-1',
+      turnId: 'turn-1',
+    }))
+    expect(planCreate).not.toHaveBeenCalled()
+    expect(replacementSidecar.adopt).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(record.status).toBe('exited'), { timeout: 3000 })
+    expect(registry.get(record.terminalId)?.exitCode).toBe(0)
+    expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 0 })
+  })
+
+  it('does not let an unidentified turn-completed event clear a different active turn before clean exit', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      readThreadTurn: vi.fn(async () => ({
+        id: 'turn-1',
+        turnId: 'turn-1',
+        revision: 1,
+        status: 'inProgress',
+        items: [],
+        error: null,
+        startedAt: Date.now(),
+        completedAt: null,
+        durationMs: null,
+      })),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    await (registry as any).handleCodexTurnStarted(record.terminalId, {
+      threadId: 'thread-durable-1',
+      turnId: 'turn-1',
+      params: {},
+    })
+    await (registry as any).handleCodexTurnCompleted(record.terminalId, {
+      threadId: 'thread-durable-1',
+      params: {},
+    })
+
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(currentSidecar.readThreadTurn).toHaveBeenCalledWith({
+      threadId: 'thread-durable-1',
+      turnId: 'turn-1',
+    }))
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(planCreate).toHaveBeenCalled()
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('keeps a fresh clean PTY exit final without polling turns when no activity was observed', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      listThreadTurns: vi.fn(async () => ({
+        revision: 1,
+        nextCursor: null,
+        backwardsCursor: null,
+        turns: [{
+          id: 'turn-1',
+          status: 'inProgress',
+          items: [],
+          error: null,
+          startedAt: Date.now(),
+          completedAt: null,
+          durationMs: null,
+        }],
+        bodies: {},
+      })),
+      readThreadTurn: vi.fn(async () => ({
+        id: 'turn-1',
+        turnId: 'turn-1',
+        revision: 1,
+        status: 'inProgress',
+        items: [],
+        error: null,
+        startedAt: Date.now(),
+        completedAt: null,
+        durationMs: null,
+      })),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      sessionBindingReason: 'start',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(record.status).toBe('exited'), { timeout: 3000 })
+    expect(currentSidecar.listThreadTurns).not.toHaveBeenCalled()
+    expect(currentSidecar.readThreadTurn).not.toHaveBeenCalled()
+    expect(planCreate).not.toHaveBeenCalled()
+    expect(replacementSidecar.adopt).not.toHaveBeenCalled()
+    expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 0 })
+  })
+
+  it('recovers a clean PTY exit when a restored thread has an in-progress turn snapshot', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      listThreadTurns: vi.fn(async () => ({
+        revision: 1,
+        nextCursor: null,
+        backwardsCursor: null,
+        turns: [{
+          id: 'turn-1',
+          status: 'inProgress',
+          items: [],
+          error: null,
+          startedAt: Date.now(),
+          completedAt: null,
+          durationMs: null,
+        }],
+        bodies: {},
+      })),
+      readThreadTurn: vi.fn(async () => ({
+        id: 'turn-1',
+        turnId: 'turn-1',
+        revision: 1,
+        status: 'inProgress',
+        items: [],
+        error: null,
+        startedAt: Date.now(),
+        completedAt: null,
+        durationMs: null,
+      })),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      sessionBindingReason: 'resume',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(currentSidecar.listThreadTurns).toHaveBeenCalledWith({
+      threadId: 'thread-durable-1',
+      limit: 50,
+      sortDirection: 'desc',
+      itemsView: 'notLoaded',
+    }))
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(currentSidecar.readThreadTurn).not.toHaveBeenCalled()
+    expect(planCreate).toHaveBeenCalled()
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('recovers a clean PTY exit when recent input has an in-progress turn snapshot despite a missed turn-start event', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      listThreadTurns: vi.fn(async () => ({
+        revision: 1,
+        nextCursor: null,
+        backwardsCursor: null,
+        turns: [{
+          id: 'turn-1',
+          status: 'inProgress',
+          items: [],
+          error: null,
+          startedAt: Date.now(),
+          completedAt: null,
+          durationMs: null,
+        }],
+        bodies: {},
+      })),
+      readThreadTurn: vi.fn(async () => ({
+        id: 'turn-1',
+        turnId: 'turn-1',
+        revision: 1,
+        status: 'inProgress',
+        items: [],
+        error: null,
+        startedAt: Date.now(),
+        completedAt: null,
+        durationMs: null,
+      })),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    await (registry as any).handleCodexTurnStarted(record.terminalId, {
+      threadId: 'thread-durable-1',
+      params: {},
+    })
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(currentSidecar.listThreadTurns).toHaveBeenCalledWith({
+      threadId: 'thread-durable-1',
+      limit: 50,
+      sortDirection: 'desc',
+      itemsView: 'notLoaded',
+    }))
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(currentSidecar.readThreadTurn).not.toHaveBeenCalled()
+    expect(planCreate).toHaveBeenCalled()
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('keeps ordinary clean exits final when user input never becomes turn evidence', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      listThreadTurns: vi.fn(async () => ({
+        revision: 1,
+        nextCursor: null,
+        backwardsCursor: null,
+        turns: [],
+        bodies: {},
+      })),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    expect(registry.input(record.terminalId, 'exit\n')).toEqual({ status: 'written' })
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+    expect(planCreate).not.toHaveBeenCalled()
+    expect(exited).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(3000)
+
+    await vi.waitFor(() => expect(record.status).toBe('exited'))
+    expect(currentSidecar.listThreadTurns).toHaveBeenCalledWith({
+      threadId: 'thread-durable-1',
+      limit: 50,
+      sortDirection: 'desc',
+      itemsView: 'notLoaded',
+    })
+    expect(replacementSidecar.adopt).not.toHaveBeenCalled()
+    expect(planCreate).not.toHaveBeenCalled()
+    expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 0 })
+  })
+
+  it('recovers when a resumed clean exit sees a turn appear after recent user input', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      listThreadTurns: vi.fn()
+        .mockResolvedValueOnce({
+          revision: 1,
+          nextCursor: null,
+          backwardsCursor: null,
+          turns: [],
+          bodies: {},
+        })
+        .mockResolvedValueOnce({
+          revision: 2,
+          nextCursor: null,
+          backwardsCursor: null,
+          turns: [{
+            id: 'turn-1',
+            status: 'inProgress',
+            items: [],
+            error: null,
+            startedAt: Date.now(),
+            completedAt: null,
+            durationMs: null,
+          }],
+          bodies: {},
+        })
+        .mockResolvedValueOnce({
+          revision: 3,
+          nextCursor: null,
+          backwardsCursor: null,
+          turns: [{
+            id: 'turn-1',
+            status: 'inProgress',
+            items: [],
+            error: null,
+            startedAt: Date.now(),
+            completedAt: null,
+            durationMs: null,
+          }],
+          bodies: {},
+        }),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(registry.input(record.terminalId, 'start active turn\n')).toEqual({ status: 'written' })
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+    await vi.waitFor(() => expect(currentSidecar.listThreadTurns).toHaveBeenCalledTimes(1))
+    expect(planCreate).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(800)
+
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('recovers when a freshly-promoted durable clean exit sees a turn appear after recent user input', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      listThreadTurns: vi.fn()
+        .mockResolvedValueOnce({
+          revision: 1,
+          nextCursor: null,
+          backwardsCursor: null,
+          turns: [],
+          bodies: {},
+        })
+        .mockResolvedValueOnce({
+          revision: 2,
+          nextCursor: null,
+          backwardsCursor: null,
+          turns: [{
+            id: 'turn-1',
+            status: 'inProgress',
+            items: [],
+            error: null,
+            startedAt: Date.now(),
+            completedAt: null,
+            durationMs: null,
+          }],
+          bodies: {},
+        })
+        .mockResolvedValueOnce({
+          revision: 3,
+          nextCursor: null,
+          backwardsCursor: null,
+          turns: [{
+            id: 'turn-1',
+            status: 'inProgress',
+            items: [],
+            error: null,
+            startedAt: Date.now(),
+            completedAt: null,
+            durationMs: null,
+          }],
+          bodies: {},
+        }),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const latest = registry.get(record.terminalId)!
+    latest.resumeSessionId = 'thread-durable-1'
+    latest.codexDurability = {
+      state: 'durable',
+      durableThreadId: 'thread-durable-1',
+    } as any
+    registry.releaseCodexInputGateForTest(record.terminalId)
+    const [pty] = await spawnedPtys()
+
+    expect(registry.input(record.terminalId, 'start active turn\n')).toEqual({ status: 'written' })
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+    await vi.waitFor(() => expect(currentSidecar.listThreadTurns).toHaveBeenCalledTimes(1))
+    expect(planCreate).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(800)
+
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('keeps a clean PTY exit final when recent user input is still not visible after the grace window', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      listThreadTurns: vi.fn(async () => ({
+        revision: 1,
+        nextCursor: null,
+        backwardsCursor: null,
+        turns: [],
+        bodies: {},
+      })),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    expect(registry.input(record.terminalId, 'start slow turn\n')).toEqual({ status: 'written' })
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.advanceTimersByTimeAsync(3000)
+
+    await vi.waitFor(() => expect(record.status).toBe('exited'))
+    expect(currentSidecar.listThreadTurns).toHaveBeenCalledWith({
+      threadId: 'thread-durable-1',
+      limit: 50,
+      sortDirection: 'desc',
+      itemsView: 'notLoaded',
+    })
+    expect(replacementSidecar.adopt).not.toHaveBeenCalled()
+    expect(planCreate).not.toHaveBeenCalled()
+    expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 0 })
+  })
+
+  it('blocks input while a clean-exit active-turn decision is in flight', async () => {
+    const turnRead = deferred<Awaited<ReturnType<NonNullable<CodexLaunchSidecar['readThreadTurn']>>>>()
+    const currentSidecar = createFakeSidecar({
+      readThreadTurn: vi.fn(() => turnRead.promise),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    await (registry as any).handleCodexTurnStarted(record.terminalId, {
+      threadId: 'thread-durable-1',
+      turnId: 'turn-1',
+      params: {},
+    })
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+    await vi.waitFor(() => expect(currentSidecar.readThreadTurn).toHaveBeenCalled())
+
+    expect(registry.input(record.terminalId, 'during decision')).toEqual({
+      status: 'blocked_codex_clean_exit_decision_pending',
+      terminalId: record.terminalId,
+    })
+    expect(pty.write).not.toHaveBeenCalledWith('during decision')
+
+    turnRead.resolve({
+      id: 'turn-1',
+      turnId: 'turn-1',
+      revision: 1,
+      status: 'inProgress',
+      items: [],
+      error: null,
+      startedAt: Date.now(),
+      completedAt: null,
+      durationMs: null,
+    })
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+  })
+
+  it('keeps a clean exit final when an active-turn event omitted turnId and the snapshot is idle', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      listThreadTurns: vi.fn(async () => ({
+        revision: 1,
+        nextCursor: null,
+        backwardsCursor: null,
+        turns: [{
+          id: 'turn-1',
+          status: 'completed',
+          items: [],
+          error: null,
+          startedAt: Date.now() - 1000,
+          completedAt: Date.now(),
+          durationMs: 1000,
+        }],
+        bodies: {},
+      })),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    await (registry as any).handleCodexTurnStarted(record.terminalId, {
+      threadId: 'thread-durable-1',
+      params: {},
+    })
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(currentSidecar.listThreadTurns).toHaveBeenCalledWith({
+      threadId: 'thread-durable-1',
+      limit: 50,
+      sortDirection: 'desc',
+      itemsView: 'notLoaded',
+    }))
+    expect(planCreate).not.toHaveBeenCalled()
+    expect(replacementSidecar.adopt).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(record.status).toBe('exited'), { timeout: 3000 })
+    expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 0 })
+  })
+
+  it('matches active turns by the promoted durable thread when a stale candidate remains', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      readThreadTurn: vi.fn(async () => ({
+        id: 'turn-1',
+        turnId: 'turn-1',
+        revision: 1,
+        status: 'inProgress',
+        items: [],
+        error: null,
+        startedAt: Date.now(),
+        completedAt: null,
+        durationMs: null,
+      })),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-create-durable',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-create-durable',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const latest = registry.get(record.terminalId)!
+    latest.codexDurability = {
+      state: 'durable',
+      durableThreadId: 'thread-create-durable',
+      candidate: {
+        candidateThreadId: 'thread-create-candidate',
+        rolloutPath: '/repo/.codex/sessions/rollout.jsonl',
+      },
+    } as any
+    const [pty] = await spawnedPtys()
+
+    await (registry as any).handleCodexTurnStarted(record.terminalId, {
+      threadId: 'thread-create-candidate',
+      turnId: 'turn-1',
+      params: {},
+    })
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(currentSidecar.readThreadTurn).toHaveBeenCalledWith({
+      threadId: 'thread-create-candidate',
+      turnId: 'turn-1',
+    }))
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('polls the promoted durable thread instead of a stale candidate when clean exit has no active-turn event', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      listThreadTurns: vi.fn(async (params) => ({
+        revision: 1,
+        nextCursor: null,
+        backwardsCursor: null,
+        turns: params.threadId === 'thread-create-durable'
+          ? [{
+            id: 'turn-1',
+            status: 'inProgress',
+            items: [],
+            error: null,
+            startedAt: Date.now(),
+            completedAt: null,
+            durationMs: null,
+          }]
+          : [],
+        bodies: {},
+      })),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-create-durable',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-create-durable',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const latest = registry.get(record.terminalId)!
+    latest.codexDurability = {
+      state: 'durable',
+      durableThreadId: 'thread-create-durable',
+      candidate: {
+        candidateThreadId: 'thread-create-candidate',
+        rolloutPath: '/repo/.codex/sessions/rollout.jsonl',
+      },
+    } as any
+    ;(latest as any).codexUnconfirmedInputAt = Date.now() - 1000
+    const [pty] = await spawnedPtys()
+
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(currentSidecar.listThreadTurns).toHaveBeenCalledWith({
+      threadId: 'thread-create-durable',
+      limit: 50,
+      sortDirection: 'desc',
+      itemsView: 'notLoaded',
+    }))
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(currentSidecar.listThreadTurns).not.toHaveBeenCalledWith(expect.objectContaining({
+      threadId: 'thread-create-candidate',
+    }))
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('recovers a clean PTY exit when a completed cached turn is followed by a newer in-progress turn', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      readThreadTurn: vi.fn(async () => ({
+        id: 'turn-1',
+        turnId: 'turn-1',
+        revision: 1,
+        status: 'completed',
+        items: [],
+        error: null,
+        startedAt: null,
+        completedAt: Date.now(),
+        durationMs: 1000,
+      })),
+      listThreadTurns: vi.fn(async () => ({
+        revision: 2,
+        nextCursor: null,
+        backwardsCursor: null,
+        turns: [{
+          id: 'turn-2',
+          status: 'inProgress',
+          items: [],
+          error: null,
+          startedAt: Date.now(),
+          completedAt: null,
+          durationMs: null,
+        }],
+        bodies: {},
+      })),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    await (registry as any).handleCodexTurnStarted(record.terminalId, {
+      threadId: 'thread-durable-1',
+      turnId: 'turn-1',
+      params: {},
+    })
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(currentSidecar.listThreadTurns).toHaveBeenCalledWith({
+      threadId: 'thread-durable-1',
+      limit: 50,
+      sortDirection: 'desc',
+      itemsView: 'notLoaded',
+    }))
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(currentSidecar.readThreadTurn).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('recovers a clean PTY exit when an observed active-turn snapshot cannot be read', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar({
+      listThreadTurns: vi.fn(async () => {
+        throw new Error('thread read failed')
+      }),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    await (registry as any).handleCodexTurnStarted(record.terminalId, {
+      threadId: 'thread-durable-1',
+      params: {},
+    })
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(currentSidecar.listThreadTurns).toHaveBeenCalled())
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('does not finalize a clean PTY exit when lifecycle-loss recovery starts during the active-turn read', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const turnRead = deferred<Awaited<ReturnType<NonNullable<CodexLaunchSidecar['readThreadTurn']>>>>()
+    const currentSidecar = createFakeSidecar({
+      readThreadTurn: vi.fn(() => turnRead.promise),
+    })
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [pty] = await spawnedPtys()
+
+    await (registry as any).handleCodexTurnStarted(record.terminalId, {
+      threadId: 'thread-durable-1',
+      turnId: 'turn-1',
+      params: {},
+    })
+    pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+    await vi.waitFor(() => expect(currentSidecar.readThreadTurn).toHaveBeenCalled())
+
+    currentSidecar.emitLifecycleLoss({
+      method: 'thread/status/changed',
+      threadId: 'thread-durable-1',
+      status: 'notLoaded',
+    })
+    await vi.waitFor(() => expect(planCreate).toHaveBeenCalled())
+    turnRead.resolve({
+      id: 'turn-1',
+      turnId: 'turn-1',
+      revision: 1,
+      status: 'completed',
+      items: [],
+      error: null,
+      startedAt: Date.now() - 1000,
+      completedAt: Date.now(),
+      durationMs: 1000,
+    })
+
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('recovers lifecycle loss reported for a promoted live candidate thread id', async () => {
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-create-durable',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-create-durable',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const latest = registry.get(record.terminalId)!
+    latest.codexDurability = {
+      state: 'durable',
+      durableThreadId: 'thread-create-durable',
+      candidate: {
+        candidateThreadId: 'thread-create-candidate',
+        rolloutPath: '/repo/.codex/sessions/rollout.jsonl',
+      },
+    } as any
+
+    currentSidecar.emitLifecycleLoss({
+      method: 'thread/status/changed',
+      threadId: 'thread-create-candidate',
+      status: 'notLoaded',
+    })
+
+    await vi.waitFor(() => expect(planCreate).toHaveBeenCalled())
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+  })
+
+  it('keeps a recovered durable Codex PTY exit final when the replacement process exits cleanly', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [oldPty] = await spawnedPtys()
+
+    oldPty.onExit.mock.calls[0][0]({ exitCode: 1, signal: 0 })
+
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    const [, replacementPty] = await spawnedPtys()
+
+    replacementPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    expect(planCreate).toHaveBeenCalled()
+    await vi.waitFor(() => expect(record.status).toBe('exited'), { timeout: 3000 })
+    expect(registry.get(record.terminalId)?.exitCode).toBe(0)
+    expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 0 })
+  })
+
+  it('keeps a recovered Codex clean exit final when it happens before recovery bookkeeping settles', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const ptyModule = await import('node-pty')
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [oldPty] = await spawnedPtys()
+    oldPty.kill.mockImplementation(() => {
+      const replacementPty = vi.mocked(ptyModule.spawn).mock.results[1]?.value as MockPty | undefined
+      replacementPty?.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+    })
+
+    oldPty.onExit.mock.calls[0][0]({ exitCode: 1, signal: 0 })
+
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(planCreate).toHaveBeenCalled()
+    await vi.waitFor(() => expect(record.status).toBe('exited'), { timeout: 3000 })
+    expect(registry.get(record.terminalId)?.exitCode).toBe(0)
+    expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 0 })
+  })
+
+  it('keeps lifecycle-loss recovery running when the current PTY exits cleanly', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const planReady = deferred()
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => {
+      await planReady.promise
+      return {
+        sessionId: 'thread-durable-1',
+        remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+        sidecar: replacementSidecar,
+      }
+    })
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [oldPty] = await spawnedPtys()
+
+    currentSidecar.emitLifecycleLoss({
+      method: 'thread/status/changed',
+      threadId: 'thread-durable-1',
+      status: 'notLoaded',
+    })
+    await vi.waitFor(() => expect(planCreate).toHaveBeenCalled())
+
+    oldPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(registry.input(record.terminalId, 'during recovery')).toEqual({
+      status: 'blocked_codex_recovery_pending',
+      terminalId: record.terminalId,
+    })
+    expect(exited).not.toHaveBeenCalled()
+
+    planReady.resolve()
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('recovers lifecycle loss that arrives immediately after a durable clean PTY exit', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const planReady = deferred()
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => {
+      await planReady.promise
+      return {
+        sessionId: 'thread-durable-1',
+        remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+        sidecar: replacementSidecar,
+      }
+    })
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      sessionBindingReason: 'association',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [oldPty] = await spawnedPtys()
+
+    oldPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+    expect(registry.input(record.terminalId, 'during clean exit grace')).toEqual({
+      status: 'blocked_codex_clean_exit_decision_pending',
+      terminalId: record.terminalId,
+    })
+
+    currentSidecar.emitLifecycleLoss({
+      method: 'thread/status/changed',
+      threadId: 'thread-durable-1',
+      status: 'notLoaded',
+    })
+
+    await vi.waitFor(() => expect(planCreate).toHaveBeenCalled())
+    expect(registry.input(record.terminalId, 'during recovery')).toEqual({
+      status: 'blocked_codex_recovery_pending',
+      terminalId: record.terminalId,
+    })
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    expect(record.status).toBe('running')
+    expect(exited).not.toHaveBeenCalled()
+
+    planReady.resolve()
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('keeps the clean-exit finalizer when an unrelated lifecycle-loss event arrives during the grace window', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      sessionBindingReason: 'association',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [oldPty] = await spawnedPtys()
+
+    oldPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+    currentSidecar.emitLifecycleLoss({
+      method: 'thread/status/changed',
+      threadId: 'unrelated-thread',
+      status: 'notLoaded',
+    })
+
+    expect(registry.input(record.terminalId, 'during clean exit grace')).toEqual({
+      status: 'blocked_codex_clean_exit_decision_pending',
+      terminalId: record.terminalId,
+    })
+    expect(planCreate).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(record.status).toBe('exited'), { timeout: 3000 })
+    expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 0 })
+    expect(planCreate).not.toHaveBeenCalled()
+  })
+
+  it('recovers proxy repair triggers that arrive during a durable clean PTY exit grace window', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const planReady = deferred()
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => {
+      await planReady.promise
+      return {
+        sessionId: 'thread-durable-1',
+        remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+        sidecar: replacementSidecar,
+      }
+    })
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      sessionBindingReason: 'association',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [oldPty] = await spawnedPtys()
+
+    oldPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+    currentSidecar.emitRepairTrigger({ kind: 'proxy_close' })
+
+    await vi.waitFor(() => expect(planCreate).toHaveBeenCalled())
+    expect(registry.input(record.terminalId, 'during recovery')).toEqual({
+      status: 'blocked_codex_recovery_pending',
+      terminalId: record.terminalId,
+    })
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    expect(record.status).toBe('running')
+    expect(exited).not.toHaveBeenCalled()
+
+    planReady.resolve()
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('keeps pre-durable lifecycle-loss proof running when the current PTY exits cleanly', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const proofReady = deferred()
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const latest = registry.get(record.terminalId)!
+    latest.codexDurability = {
+      state: 'captured_pre_turn',
+      candidate: {
+        candidateThreadId: 'thread-durable-1',
+        rolloutPath: '/repo/.codex/sessions/rollout.jsonl',
+      },
+    } as any
+    const proof = vi.spyOn(registry as any, 'runCodexDurabilityProof')
+      .mockImplementation(async () => {
+        await proofReady.promise
+        const proved = registry.get(record.terminalId)
+        if (!proved || proved.status !== 'running') return
+        proved.resumeSessionId = 'thread-durable-1'
+        proved.codexDurability = {
+          ...proved.codexDurability,
+          state: 'durable',
+        } as any
+      })
+    const [oldPty] = await spawnedPtys()
+
+    currentSidecar.emitLifecycleLoss({
+      method: 'thread/status/changed',
+      threadId: 'thread-durable-1',
+      status: 'notLoaded',
+    })
+    await vi.waitFor(() => expect(proof).toHaveBeenCalledWith(record.terminalId, 'lifecycle_loss'))
+
+    oldPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 })
+    expect(proof).not.toHaveBeenCalledWith(record.terminalId, 'pty_exit')
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(registry.input(record.terminalId, 'during proof')).toEqual({
+      status: 'blocked_codex_lifecycle_loss_pending',
+      terminalId: record.terminalId,
+    })
+    expect(oldPty.write).not.toHaveBeenCalledWith('during proof')
+    expect(exited).not.toHaveBeenCalled()
+
+    proofReady.resolve()
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(planCreate).toHaveBeenCalled()
+    await vi.waitFor(() => expect(record.status).toBe('running'))
+    expect(exited).not.toHaveBeenCalled()
+  })
+
+  it('coalesces duplicate pre-durable lifecycle-loss events while proof is pending', async () => {
+    const proofReady = deferred()
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const latest = registry.get(record.terminalId)!
+    latest.codexDurability = {
+      state: 'captured_pre_turn',
+      candidate: {
+        candidateThreadId: 'thread-durable-1',
+        rolloutPath: '/repo/.codex/sessions/rollout.jsonl',
+      },
+    } as any
+    const proof = vi.spyOn(registry as any, 'runCodexDurabilityProof')
+      .mockImplementation(async () => {
+        await proofReady.promise
+        const proved = registry.get(record.terminalId)
+        if (!proved || proved.status !== 'running') return
+        proved.resumeSessionId = 'thread-durable-1'
+        proved.codexDurability = {
+          ...proved.codexDurability,
+          state: 'durable',
+        } as any
+      })
+
+    currentSidecar.emitLifecycleLoss({
+      method: 'thread/status/changed',
+      threadId: 'thread-durable-1',
+      status: 'notLoaded',
+    })
+    currentSidecar.emitLifecycleLoss({
+      method: 'thread/status/changed',
+      threadId: 'thread-durable-1',
+      status: 'notLoaded',
+    })
+
+    await vi.waitFor(() => expect(proof).toHaveBeenCalledTimes(1))
+    expect(registry.input(record.terminalId, 'during duplicate proof')).toEqual({
+      status: 'blocked_codex_lifecycle_loss_pending',
+      terminalId: record.terminalId,
+    })
+
+    proofReady.resolve()
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(planCreate).toHaveBeenCalled()
+  })
+
+  it('recovers a durable Codex terminal when the visible PTY exits from a signal', async () => {
+    const exited = vi.fn()
+    registry.on('terminal.exit', exited)
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-durable-1',
+      remote: { wsUrl: 'ws://127.0.0.1:46002/' },
+      sidecar: replacementSidecar,
+    }))
+    const record = registry.create({
+      mode: 'codex',
+      cwd: '/repo',
+      resumeSessionId: 'thread-durable-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:46001/',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const [oldPty] = await spawnedPtys()
+
+    oldPty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 15 })
+
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
+    expect(planCreate).toHaveBeenCalledWith(expect.objectContaining({
+      terminalId: record.terminalId,
+      resumeSessionId: 'thread-durable-1',
+      generation: 1,
+    }))
+    await vi.waitFor(() => expect(record.status).toBe('running'))
     expect(exited).not.toHaveBeenCalled()
   })
 
@@ -164,7 +1827,7 @@ describe('TerminalRegistry Codex durable recovery', () => {
     const [oldPty] = await spawnedPtys()
 
     oldPty.onExit.mock.calls[0][0]({ exitCode: 1, signal: 0 })
-    await vi.waitFor(() => expect(planCreate).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(planCreate).toHaveBeenCalled())
 
     expect(registry.input(record.terminalId, 'during recovery')).toEqual({
       status: 'blocked_codex_recovery_pending',
@@ -173,8 +1836,9 @@ describe('TerminalRegistry Codex durable recovery', () => {
     expect(oldPty.write).not.toHaveBeenCalledWith('during recovery')
 
     planReady.resolve()
-    await vi.waitFor(() => expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: record.terminalId, generation: 1 }))
     const [, replacementPty] = await spawnedPtys()
+    await vi.waitFor(() => expect(record.status).toBe('running'))
 
     expect(registry.input(record.terminalId, 'after recovery')).toEqual({ status: 'written' })
     expect(oldPty.write).not.toHaveBeenCalledWith('after recovery')
@@ -189,7 +1853,7 @@ describe('TerminalRegistry Codex durable recovery', () => {
 
     pty.onExit.mock.calls[0][0]({ exitCode: 2, signal: 0 })
 
-    expect(registry.get(record.terminalId)?.status).toBe('exited')
+    expect(record.status).toBe('exited')
     expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 2 })
   })
 
@@ -212,7 +1876,7 @@ describe('TerminalRegistry Codex durable recovery', () => {
     registry.kill(record.terminalId)
 
     expect(planCreate).not.toHaveBeenCalled()
-    expect(registry.get(record.terminalId)?.status).toBe('exited')
+    expect(record.status).toBe('exited')
     await vi.waitFor(() => expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1))
   })
 
@@ -239,7 +1903,7 @@ describe('TerminalRegistry Codex durable recovery', () => {
     pty.onExit.mock.calls[0][0]({ exitCode: 9, signal: 0 })
 
     expect(planCreate).not.toHaveBeenCalled()
-    expect(registry.get(record.terminalId)?.status).toBe('exited')
+    expect(record.status).toBe('exited')
     expect(exited).toHaveBeenCalledWith({ terminalId: record.terminalId, exitCode: 9 })
   })
 })

--- a/test/unit/server/terminal-registry.codex-sidecar.test.ts
+++ b/test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -1272,6 +1272,69 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
     expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1)
   })
 
+  it('treats proxy repair triggers before initial Codex publication as a create failure instead of recovery', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: createFakeSidecar(),
+    }))
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+          deferLifecycleUntilPublished: true,
+        },
+      } as any,
+    })
+
+    currentSidecar.emitRepairTrigger({ kind: 'proxy_close' })
+    await new Promise((resolve) => setTimeout(resolve, 25))
+
+    expect(planCreate).not.toHaveBeenCalled()
+    expect(() => registry.publishCodexSidecar(term.terminalId)).toThrow(
+      'Codex app-server reported lifecycle loss before terminal create completed.',
+    )
+    await expect(registry.killAndWait(term.terminalId)).resolves.toBe(true)
+    expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a clean PTY exit before initial Codex publication as a create failure instead of recovery', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: createFakeSidecar(),
+    }))
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+          deferLifecycleUntilPublished: true,
+        },
+      } as any,
+    })
+
+    mockPtyProcess.instances[0]._emitExit(0)
+    await vi.waitFor(() => expect(registry.get(term.terminalId)?.status).toBe('exited'))
+
+    expect(planCreate).not.toHaveBeenCalled()
+    expect(() => registry.publishCodexSidecar(term.terminalId)).toThrow(
+      'Codex terminal PTY exited before create completed.',
+    )
+    expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1)
+  })
+
   it('starts durable recovery only after deferred initial Codex publication succeeds', async () => {
     const registry = new TerminalRegistry()
     const currentSidecar = createFakeSidecar()


### PR DESCRIPTION
## Summary
- handle Codex clean PTY exits with durable recovery only when lifecycle or active-turn evidence requires it
- harden app-server turn paging, fallback cursors, and revision checks
- add regression coverage for clean-exit recovery, proxy repair triggers, and thread/read fallback behavior

## Verification
- npm run test:vitest -- --config vitest.server.config.ts test/unit/server/coding-cli/codex-app-server/client.test.ts test/unit/server/terminal-registry.codex-recovery.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts --run
- npm run check