### PR TITLE
Fix Freshcodex runtime lifecycle

### DIFF
--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -46,6 +46,7 @@ export type CodexSidecarOwnershipMetadata = {
   ownershipId: string
   serverInstanceId: string
   ownerServerPid: number
+  ownerServerIdentity?: WrapperIdentity
   terminalId: string | null
   generation: number | null
   wsUrl: string
@@ -199,14 +200,18 @@ function isCompleteWrapperIdentity(identity: WrapperIdentity | null): identity i
     && Number.isFinite(identity.startTimeTicks)
 }
 
-function wrapperIdentityMatches(record: CodexSidecarOwnershipMetadata, current: WrapperIdentity | null): boolean {
+function processIdentityMatches(expected: WrapperIdentity | undefined, current: WrapperIdentity | null): boolean {
   if (!current) return false
-  const expected = record.wrapperIdentity
+  if (!expected) return false
   if (expected.startTimeTicks === null || current.startTimeTicks === null) return false
   if (expected.startTimeTicks !== current.startTimeTicks) return false
   if (expected.cwd === null || current.cwd === null || expected.cwd !== current.cwd) return false
   if (expected.commandLine.length === 0 || expected.commandLine.length !== current.commandLine.length) return false
   return expected.commandLine.every((arg, index) => arg === current.commandLine[index])
+}
+
+function wrapperIdentityMatches(record: CodexSidecarOwnershipMetadata, current: WrapperIdentity | null): boolean {
+  return processIdentityMatches(record.wrapperIdentity, current)
 }
 
 function emptyWrapperIdentity(): WrapperIdentity {
@@ -225,6 +230,12 @@ async function isPidAlive(pid: number): Promise<boolean> {
   } catch (error) {
     return (error as NodeJS.ErrnoException).code !== 'ESRCH'
   }
+}
+
+async function isOwnerServerProcess(metadata: CodexSidecarOwnershipMetadata): Promise<boolean> {
+  if (!metadata.ownerServerIdentity) return false
+  const currentIdentity = await readProcessIdentity(metadata.ownerServerPid)
+  return processIdentityMatches(metadata.ownerServerIdentity, currentIdentity)
 }
 
 async function processHasOwnershipEnv(pid: number, ownershipId: string): Promise<boolean> {
@@ -464,7 +475,11 @@ export async function reapOrphanedCodexAppServerSidecars(
     const metadata = parsed.metadata
 
     if (await isPidAlive(metadata.ownerServerPid)) {
-      result.skippedActiveOwnershipIds.push(metadata.ownershipId)
+      if (await isOwnerServerProcess(metadata)) {
+        result.skippedActiveOwnershipIds.push(metadata.ownershipId)
+      } else {
+        result.failedOwnershipIds.push(metadata.ownershipId)
+      }
       continue
     }
 
@@ -822,11 +837,17 @@ export class CodexAppServerRuntime {
           throw new Error('Codex app-server sidecar spawn did not expose a wrapper PID.')
         }
 
+        const ownerServerIdentity = await this.processIdentityReader(process.pid)
+        if (!isCompleteWrapperIdentity(ownerServerIdentity)) {
+          throw new Error(`Codex app-server owner identity could not be completely read for PID ${process.pid}.`)
+        }
+
         const ownership = this.createOwnershipRecord({
           ownershipId,
           wsUrl,
           wrapperPid: child.pid,
           processGroupId: child.pid,
+          ownerServerIdentity,
         })
         this.ownership = ownership
         attemptOwnership = ownership
@@ -927,6 +948,7 @@ export class CodexAppServerRuntime {
     wsUrl: string
     wrapperPid: number
     processGroupId: number
+    ownerServerIdentity: WrapperIdentity
   }): ActiveOwnership {
     const now = new Date().toISOString()
     const metadata: CodexSidecarOwnershipMetadata = {
@@ -934,6 +956,7 @@ export class CodexAppServerRuntime {
       ownershipId: input.ownershipId,
       serverInstanceId: this.serverInstanceId,
       ownerServerPid: process.pid,
+      ownerServerIdentity: input.ownerServerIdentity,
       terminalId: null,
       generation: null,
       wsUrl: input.wsUrl,

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -498,8 +498,8 @@ export const reapOrphanedCodexAppServerSidecarsOnStartup = runCodexStartupReaper
 
 export function assertCodexStartupReaperSucceeded(result: ReapOrphanedSidecarsResult): void {
   const failedOwnershipIds = [...new Set(result.failedOwnershipIds)]
-  const activeOwnershipIds = [...new Set(result.skippedActiveOwnershipIds)]
-  if (failedOwnershipIds.length === 0 && activeOwnershipIds.length === 0) return
+  const skippedActiveOwnershipIds = [...new Set(result.skippedActiveOwnershipIds)]
+  if (failedOwnershipIds.length === 0 && skippedActiveOwnershipIds.length === 0) return
 
   const reasons: string[] = []
   if (failedOwnershipIds.length > 0) {
@@ -507,15 +507,15 @@ export function assertCodexStartupReaperSucceeded(result: ReapOrphanedSidecarsRe
       `failed to reap ${failedOwnershipIds.length} ownership record(s): ${failedOwnershipIds.join(', ')}`,
     )
   }
-  if (activeOwnershipIds.length > 0) {
+  if (skippedActiveOwnershipIds.length > 0) {
     reasons.push(
-      `${activeOwnershipIds.length} ownership record(s) still owned by a live Freshell server/process: ${activeOwnershipIds.join(', ')}`,
+      `found ${skippedActiveOwnershipIds.length} active ownership record(s) requiring manual resolution: ${skippedActiveOwnershipIds.join(', ')}`,
     )
   }
 
   throw new Error(
     `Codex app-server startup reaper blocked startup: ${reasons.join('; ')}. `
-    + 'Refusing to continue until failed ownership records are handled and active owners have shut down or been verified gone.',
+    + 'Refusing to continue until failed ownership records are handled or verified gone.',
   )
 }
 

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -498,20 +498,12 @@ export const reapOrphanedCodexAppServerSidecarsOnStartup = runCodexStartupReaper
 
 export function assertCodexStartupReaperSucceeded(result: ReapOrphanedSidecarsResult): void {
   const failedOwnershipIds = [...new Set(result.failedOwnershipIds)]
-  const skippedActiveOwnershipIds = [...new Set(result.skippedActiveOwnershipIds)]
-  if (failedOwnershipIds.length === 0 && skippedActiveOwnershipIds.length === 0) return
+  if (failedOwnershipIds.length === 0) return
 
   const reasons: string[] = []
-  if (failedOwnershipIds.length > 0) {
-    reasons.push(
-      `failed to reap ${failedOwnershipIds.length} ownership record(s): ${failedOwnershipIds.join(', ')}`,
-    )
-  }
-  if (skippedActiveOwnershipIds.length > 0) {
-    reasons.push(
-      `found ${skippedActiveOwnershipIds.length} active ownership record(s) requiring manual resolution: ${skippedActiveOwnershipIds.join(', ')}`,
-    )
-  }
+  reasons.push(
+    `failed to reap ${failedOwnershipIds.length} ownership record(s): ${failedOwnershipIds.join(', ')}`,
+  )
 
   throw new Error(
     `Codex app-server startup reaper blocked startup: ${reasons.join('; ')}. `

--- a/server/fresh-agent/adapters/claude/adapter.ts
+++ b/server/fresh-agent/adapters/claude/adapter.ts
@@ -14,6 +14,7 @@ import {
   normalizeClaudeTurnBody,
   normalizeClaudeTurnPage,
 } from './normalize.js'
+import { normalizeFreshAgentEffort, normalizeFreshAgentModel } from '../../../../shared/fresh-agent-models.js'
 
 type ClaudeBridgePort = Pick<
   SdkBridge,
@@ -48,6 +49,15 @@ function toClaudeEffort(value: FreshAgentCreateRequest['effort']) {
   throw new Error(`Freshclaude does not support reasoning effort "${value}".`)
 }
 
+function normalizeClaudeInput(input: FreshAgentCreateRequest): FreshAgentCreateRequest {
+  const model = normalizeFreshAgentModel(input.sessionType, 'claude', input.model)
+  return {
+    ...input,
+    model,
+    effort: normalizeFreshAgentEffort(input.sessionType, 'claude', model, input.effort),
+  }
+}
+
 function mapMissingResult(ok: boolean, message: string): void {
   if (!ok) {
     throw new Error(message)
@@ -80,25 +90,27 @@ export function createClaudeFreshAgentAdapter(deps: ClaudeFreshAgentAdapterDeps)
     runtimeProvider: 'claude',
 
     async create(input: FreshAgentCreateRequest) {
+      const normalizedInput = normalizeClaudeInput(input)
       const session = await deps.sdkBridge.createSession({
-        cwd: input.cwd,
-        resumeSessionId: input.resumeSessionId,
-        model: input.model,
-        permissionMode: input.permissionMode,
-        effort: toClaudeEffort(input.effort),
-        plugins: input.plugins,
+        cwd: normalizedInput.cwd,
+        resumeSessionId: normalizedInput.resumeSessionId,
+        model: normalizedInput.model,
+        permissionMode: normalizedInput.permissionMode,
+        effort: toClaudeEffort(normalizedInput.effort),
+        plugins: normalizedInput.plugins,
       })
       return { sessionId: session.sessionId }
     },
 
     async resume(input: FreshAgentCreateRequest) {
+      const normalizedInput = normalizeClaudeInput(input)
       const session = await deps.sdkBridge.createSession({
-        cwd: input.cwd,
-        resumeSessionId: input.resumeSessionId,
-        model: input.model,
-        permissionMode: input.permissionMode,
-        effort: toClaudeEffort(input.effort),
-        plugins: input.plugins,
+        cwd: normalizedInput.cwd,
+        resumeSessionId: normalizedInput.resumeSessionId,
+        model: normalizedInput.model,
+        permissionMode: normalizedInput.permissionMode,
+        effort: toClaudeEffort(normalizedInput.effort),
+        plugins: normalizedInput.plugins,
       })
       return { sessionId: session.sessionId }
     },

--- a/server/fresh-agent/adapters/codex/adapter.ts
+++ b/server/fresh-agent/adapters/codex/adapter.ts
@@ -10,6 +10,7 @@ import {
   normalizeCodexTurnBody,
   normalizeCodexTurnPage,
 } from './normalize.js'
+import { normalizeFreshAgentEffort, normalizeFreshAgentModel } from '../../../../shared/fresh-agent-models.js'
 
 type CodexThreadLifecycleEvent =
   | {
@@ -118,6 +119,15 @@ function toCodexUserInput(text: string, images: FreshAgentInputImage[] | undefin
     }
   }
   return input
+}
+
+function normalizeCodexInput(input: FreshAgentCreateRequest): FreshAgentCreateRequest {
+  const model = normalizeFreshAgentModel(input.sessionType, 'codex', input.model)
+  return {
+    ...input,
+    model,
+    effort: normalizeFreshAgentEffort(input.sessionType, 'codex', model, input.effort),
+  }
 }
 
 function normalizeCodexThreadStatus(status: unknown): string {
@@ -270,15 +280,16 @@ export function createCodexFreshAgentAdapter(deps: {
     runtimeProvider: 'codex',
 
     async create(input: FreshAgentCreateRequest) {
-      toCodexReasoningEffort(input.effort)
+      const normalizedInput = normalizeCodexInput(input)
+      toCodexReasoningEffort(normalizedInput.effort)
       const { runtime, owned } = allocateRuntime()
       let started: { threadId: string; wsUrl: string }
       try {
         started = await runtime.startThread({
-          cwd: input.cwd,
-          model: input.model,
-          sandbox: input.sandbox,
-          approvalPolicy: toCodexApprovalPolicy(input.permissionMode),
+          cwd: normalizedInput.cwd,
+          model: normalizedInput.model,
+          sandbox: normalizedInput.sandbox,
+          approvalPolicy: toCodexApprovalPolicy(normalizedInput.permissionMode),
         })
       } catch (error) {
         if (owned) {
@@ -288,7 +299,7 @@ export function createCodexFreshAgentAdapter(deps: {
         throw error
       }
       rememberRuntimeThread(started.threadId, runtime)
-      settingsByThread.set(started.threadId, input)
+      settingsByThread.set(started.threadId, normalizedInput)
       return { sessionId: started.threadId, sessionRef: { provider: 'codex', sessionId: started.threadId } }
     },
 
@@ -296,16 +307,17 @@ export function createCodexFreshAgentAdapter(deps: {
       if (!input.resumeSessionId) {
         throw new Error('Codex rich resume requires resumeSessionId')
       }
-      toCodexReasoningEffort(input.effort)
+      const normalizedInput = normalizeCodexInput(input)
+      toCodexReasoningEffort(normalizedInput.effort)
       const { runtime, owned } = allocateRuntime()
       let resumed: { threadId: string; wsUrl: string }
       try {
         resumed = await runtime.resumeThread({
           threadId: input.resumeSessionId,
-          cwd: input.cwd,
-          model: input.model,
-          sandbox: input.sandbox,
-          approvalPolicy: toCodexApprovalPolicy(input.permissionMode),
+          cwd: normalizedInput.cwd,
+          model: normalizedInput.model,
+          sandbox: normalizedInput.sandbox,
+          approvalPolicy: toCodexApprovalPolicy(normalizedInput.permissionMode),
         })
       } catch (error) {
         if (owned) {
@@ -315,7 +327,7 @@ export function createCodexFreshAgentAdapter(deps: {
         throw error
       }
       rememberRuntimeThread(resumed.threadId, runtime)
-      settingsByThread.set(resumed.threadId, input)
+      settingsByThread.set(resumed.threadId, normalizedInput)
       return { sessionId: resumed.threadId, sessionRef: { provider: 'codex', sessionId: resumed.threadId } }
     },
 
@@ -355,6 +367,9 @@ export function createCodexFreshAgentAdapter(deps: {
         ...settingsByThread.get(sessionId),
         ...input.settings,
       }
+      const model = normalizeFreshAgentModel(settings.sessionType ?? 'freshcodex', 'codex', settings.model)
+      settings.model = model
+      settings.effort = normalizeFreshAgentEffort(settings.sessionType ?? 'freshcodex', 'codex', model, settings.effort)
       const runtime = await ensureRuntime(sessionId, Object.keys(settings).length > 0 ? settings : undefined)
       if (Object.keys(settings).length > 0) {
         settingsByThread.set(sessionId, settings)

--- a/server/fresh-agent/adapters/codex/adapter.ts
+++ b/server/fresh-agent/adapters/codex/adapter.ts
@@ -36,7 +36,6 @@ type CodexRuntimePort = {
     model?: string
     sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access'
     approvalPolicy?: 'untrusted' | 'on-failure' | 'on-request' | 'never'
-    excludeTurns?: boolean
   }) => Promise<{ threadId: string; wsUrl: string }>
   resumeThread: (input: {
     threadId: string
@@ -48,6 +47,7 @@ type CodexRuntimePort = {
   forkThread?: (input: CodexThreadForkParams) => Promise<{ threadId: string; wsUrl: string }>
   startTurn?: (input: CodexTurnStartParams) => Promise<{ turnId: string }>
   interruptTurn?: (input: CodexTurnInterruptParams) => Promise<void>
+  shutdown?: () => Promise<void>
   onThreadLifecycle?: (handler: (event: CodexThreadLifecycleEvent) => void) => () => void
   readThread: (input: { threadId: string; includeTurns?: boolean }) => Promise<Record<string, any>>
   listThreadTurns: (input: {
@@ -86,6 +86,19 @@ function toCodexSandboxPolicy(value: FreshAgentCreateRequest['sandbox'] | undefi
       return { type: 'workspaceWrite' }
     default:
       throw new Error(`Freshcodex does not support sandbox "${String(value)}".`)
+  }
+}
+
+function toCodexResumeInput(
+  threadId: string,
+  settings?: Partial<FreshAgentCreateRequest>,
+): Parameters<CodexRuntimePort['resumeThread']>[0] {
+  return {
+    threadId,
+    ...(settings?.cwd !== undefined ? { cwd: settings.cwd } : {}),
+    ...(settings?.model !== undefined ? { model: settings.model } : {}),
+    ...(settings?.sandbox !== undefined ? { sandbox: settings.sandbox } : {}),
+    ...(settings?.permissionMode !== undefined ? { approvalPolicy: toCodexApprovalPolicy(settings.permissionMode) } : {}),
   }
 }
 
@@ -128,24 +141,153 @@ function makeCodexStatusEvent(sessionId: string, status: unknown, revision?: num
   }
 }
 
+function isCodexIncludeTurnsUnavailable(error: unknown): boolean {
+  return error instanceof Error
+    && error.message.includes('includeTurns is unavailable before first user message')
+}
+
+function findActiveTurnId(rawSnapshot: Record<string, any>): string | undefined {
+  const turns = Array.isArray(rawSnapshot.thread?.turns) ? rawSnapshot.thread.turns : []
+  for (let index = turns.length - 1; index >= 0; index -= 1) {
+    const turn = turns[index]
+    if (!turn || typeof turn !== 'object' || Array.isArray(turn)) continue
+    const record = turn as Record<string, unknown>
+    if (record.status === 'inProgress' && typeof record.id === 'string' && record.id.length > 0) {
+      return record.id
+    }
+  }
+  return undefined
+}
+
 export function createCodexFreshAgentAdapter(deps: {
-  runtime: CodexRuntimePort
+  runtime?: CodexRuntimePort
+  runtimeFactory?: () => CodexRuntimePort
 }): FreshAgentRuntimeAdapter {
   const activeTurnByThread = new Map<string, string>()
-  const settingsByThread = new Map<string, FreshAgentCreateRequest>()
+  const settingsByThread = new Map<string, Partial<FreshAgentCreateRequest>>()
+  const runtimeByThread = new Map<string, CodexRuntimePort>()
+  const threadIdsByRuntime = new Map<CodexRuntimePort, Set<string>>()
+  const ownedRuntimes = new Set<CodexRuntimePort>()
+  const runtimeResumeByThread = new Map<string, Promise<CodexRuntimePort>>()
+  const runtimeResumeGenerationByThread = new Map<string, number>()
+  const modelByTurnByThread = new Map<string, Map<string, string>>()
+
+  const rememberRuntimeThread = (threadId: string, runtime: CodexRuntimePort) => {
+    runtimeByThread.set(threadId, runtime)
+    const threadIds = threadIdsByRuntime.get(runtime) ?? new Set<string>()
+    threadIds.add(threadId)
+    threadIdsByRuntime.set(runtime, threadIds)
+  }
+
+  const forgetRuntimeThread = (threadId: string): CodexRuntimePort | undefined => {
+    const runtime = runtimeByThread.get(threadId)
+    runtimeByThread.delete(threadId)
+    if (!runtime) return undefined
+    const threadIds = threadIdsByRuntime.get(runtime)
+    threadIds?.delete(threadId)
+    if (threadIds && threadIds.size === 0) {
+      threadIdsByRuntime.delete(runtime)
+    }
+    return runtime
+  }
+
+  const allocateRuntime = () => {
+    if (deps.runtimeFactory) {
+      const runtime = deps.runtimeFactory()
+      ownedRuntimes.add(runtime)
+      return { runtime, owned: true }
+    }
+    if (deps.runtime) return { runtime: deps.runtime, owned: false }
+    throw new Error('Codex fresh-agent adapter requires a runtime or runtimeFactory.')
+  }
+
+  const getExistingRuntime = (sessionId: string): CodexRuntimePort | undefined => {
+    return runtimeByThread.get(sessionId) ?? deps.runtime
+  }
+
+  const requireRuntime = (sessionId: string): CodexRuntimePort => {
+    const runtime = runtimeByThread.get(sessionId) ?? deps.runtime
+    if (!runtime) {
+      throw new Error(`Codex app-server runtime is not available for freshcodex session ${sessionId}.`)
+    }
+    return runtime
+  }
+
+  const ensureRuntime = async (sessionId: string, settings?: Partial<FreshAgentCreateRequest>): Promise<CodexRuntimePort> => {
+    const existing = getExistingRuntime(sessionId)
+    if (existing) return existing
+    const inflight = runtimeResumeByThread.get(sessionId)
+    if (inflight) return inflight
+
+    const { runtime, owned } = allocateRuntime()
+    const resumeGeneration = runtimeResumeGenerationByThread.get(sessionId) ?? 0
+    let resumePromise: Promise<CodexRuntimePort> | undefined
+    let runtimeDiscarded = false
+    const discardOwnedRuntime = async () => {
+      if (!owned || runtimeDiscarded) return
+      runtimeDiscarded = true
+      ownedRuntimes.delete(runtime)
+      await runtime.shutdown?.().catch(() => undefined)
+    }
+    resumePromise = (async () => {
+      try {
+        const resumed = await runtime.resumeThread(toCodexResumeInput(sessionId, settings))
+        if ((runtimeResumeGenerationByThread.get(sessionId) ?? 0) !== resumeGeneration) {
+          await discardOwnedRuntime()
+          throw new Error(`Codex app-server runtime resume was cancelled for freshcodex session ${sessionId}.`)
+        }
+        rememberRuntimeThread(resumed.threadId, runtime)
+        if (settings) {
+          settingsByThread.set(resumed.threadId, settings)
+        }
+        return runtime
+      } catch (error) {
+        await discardOwnedRuntime()
+        throw error
+      } finally {
+        if (resumePromise && runtimeResumeByThread.get(sessionId) === resumePromise) {
+          runtimeResumeByThread.delete(sessionId)
+        }
+      }
+    })()
+    runtimeResumeByThread.set(sessionId, resumePromise)
+    return resumePromise
+  }
+
+  const releaseRuntime = async (sessionId: string) => {
+    const runtime = runtimeByThread.get(sessionId)
+    runtimeByThread.delete(sessionId)
+    const threadIds = runtime ? threadIdsByRuntime.get(runtime) : undefined
+    threadIds?.delete(sessionId)
+    if (!runtime || !ownedRuntimes.has(runtime)) return
+    if ((threadIds?.size ?? 0) > 0) return
+    await runtime.shutdown?.()
+    ownedRuntimes.delete(runtime)
+    threadIdsByRuntime.delete(runtime)
+  }
 
   return {
     runtimeProvider: 'codex',
 
     async create(input: FreshAgentCreateRequest) {
       toCodexReasoningEffort(input.effort)
-      const started = await deps.runtime.startThread({
-        cwd: input.cwd,
-        model: input.model,
-        sandbox: input.sandbox,
-        approvalPolicy: toCodexApprovalPolicy(input.permissionMode),
-        excludeTurns: true,
-      })
+      const { runtime, owned } = allocateRuntime()
+      let started: { threadId: string; wsUrl: string }
+      try {
+        started = await runtime.startThread({
+          cwd: input.cwd,
+          model: input.model,
+          sandbox: input.sandbox,
+          approvalPolicy: toCodexApprovalPolicy(input.permissionMode),
+        })
+      } catch (error) {
+        if (owned) {
+          ownedRuntimes.delete(runtime)
+          await runtime.shutdown?.().catch(() => undefined)
+        }
+        throw error
+      }
+      rememberRuntimeThread(started.threadId, runtime)
       settingsByThread.set(started.threadId, input)
       return { sessionId: started.threadId, sessionRef: { provider: 'codex', sessionId: started.threadId } }
     },
@@ -155,22 +297,34 @@ export function createCodexFreshAgentAdapter(deps: {
         throw new Error('Codex rich resume requires resumeSessionId')
       }
       toCodexReasoningEffort(input.effort)
-      const resumed = await deps.runtime.resumeThread({
-        threadId: input.resumeSessionId,
-        cwd: input.cwd,
-        model: input.model,
-        sandbox: input.sandbox,
-        approvalPolicy: toCodexApprovalPolicy(input.permissionMode),
-      })
+      const { runtime, owned } = allocateRuntime()
+      let resumed: { threadId: string; wsUrl: string }
+      try {
+        resumed = await runtime.resumeThread({
+          threadId: input.resumeSessionId,
+          cwd: input.cwd,
+          model: input.model,
+          sandbox: input.sandbox,
+          approvalPolicy: toCodexApprovalPolicy(input.permissionMode),
+        })
+      } catch (error) {
+        if (owned) {
+          ownedRuntimes.delete(runtime)
+          await runtime.shutdown?.().catch(() => undefined)
+        }
+        throw error
+      }
+      rememberRuntimeThread(resumed.threadId, runtime)
       settingsByThread.set(resumed.threadId, input)
       return { sessionId: resumed.threadId, sessionRef: { provider: 'codex', sessionId: resumed.threadId } }
     },
 
-    subscribe(sessionId, listener) {
-      if (!deps.runtime.onThreadLifecycle) {
+    async subscribe(sessionId, listener) {
+      const runtime = await ensureRuntime(sessionId)
+      if (!runtime.onThreadLifecycle) {
         throw new Error('Codex app-server runtime does not support thread lifecycle subscriptions.')
       }
-      return deps.runtime.onThreadLifecycle((event) => {
+      return runtime.onThreadLifecycle((event) => {
         if (event.kind === 'thread_started') {
           if (event.thread.id !== sessionId) return
           listener(makeCodexStatusEvent(sessionId, event.thread.status, event.thread.updatedAt))
@@ -179,6 +333,7 @@ export function createCodexFreshAgentAdapter(deps: {
         if (event.kind === 'thread_closed') {
           if (event.threadId !== sessionId) return
           activeTurnByThread.delete(sessionId)
+          void releaseRuntime(sessionId).catch(() => undefined)
           listener({
             type: 'sdk.status',
             sessionId,
@@ -196,14 +351,18 @@ export function createCodexFreshAgentAdapter(deps: {
     },
 
     async send(sessionId, input) {
-      if (!deps.runtime.startTurn) {
-        throw new Error('Codex app-server runtime does not support turn/start.')
-      }
-      const settings = {
+      const settings: Partial<FreshAgentCreateRequest> = {
         ...settingsByThread.get(sessionId),
         ...input.settings,
       }
-      const turn = await deps.runtime.startTurn({
+      const runtime = await ensureRuntime(sessionId, Object.keys(settings).length > 0 ? settings : undefined)
+      if (Object.keys(settings).length > 0) {
+        settingsByThread.set(sessionId, settings)
+      }
+      if (!runtime.startTurn) {
+        throw new Error('Codex app-server runtime does not support turn/start.')
+      }
+      const turn = await runtime.startTurn({
         threadId: sessionId,
         input: toCodexUserInput(input.text, input.images),
         cwd: settings.cwd,
@@ -213,26 +372,46 @@ export function createCodexFreshAgentAdapter(deps: {
         effort: toCodexReasoningEffort(settings.effort),
       })
       activeTurnByThread.set(sessionId, turn.turnId)
+      if (settings.model) {
+        const modelByTurn = modelByTurnByThread.get(sessionId) ?? new Map<string, string>()
+        modelByTurn.set(turn.turnId, settings.model)
+        modelByTurnByThread.set(sessionId, modelByTurn)
+      }
     },
 
     async interrupt(sessionId) {
-      if (!deps.runtime.interruptTurn) {
+      const runtime = await ensureRuntime(sessionId, settingsByThread.get(sessionId))
+      if (!runtime.interruptTurn) {
         throw new Error('Codex app-server runtime does not support turn/interrupt.')
       }
-      const turnId = activeTurnByThread.get(sessionId)
+      let turnId = activeTurnByThread.get(sessionId)
+      if (!turnId) {
+        try {
+          const rawSnapshot = await runtime.readThread({ threadId: sessionId, includeTurns: true })
+          turnId = findActiveTurnId(rawSnapshot)
+          if (turnId) {
+            activeTurnByThread.set(sessionId, turnId)
+          }
+        } catch (error) {
+          if (!isCodexIncludeTurnsUnavailable(error)) {
+            throw error
+          }
+        }
+      }
       if (!turnId) {
         throw new Error(`No active Codex turn is tracked for ${sessionId}.`)
       }
-      await deps.runtime.interruptTurn({ threadId: sessionId, turnId })
+      await runtime.interruptTurn({ threadId: sessionId, turnId })
       activeTurnByThread.delete(sessionId)
     },
 
     async fork(sessionId, input) {
-      if (!deps.runtime.forkThread) {
+      const settings = settingsByThread.get(sessionId)
+      const runtime = await ensureRuntime(sessionId, settings)
+      if (!runtime.forkThread) {
         throw new Error('Codex app-server runtime does not support thread/fork.')
       }
-      const settings = settingsByThread.get(sessionId)
-      return await deps.runtime.forkThread({
+      const forked = await runtime.forkThread({
         threadId: sessionId,
         cwd: typeof input?.cwd === 'string' ? input.cwd : settings?.cwd,
         model: typeof input?.model === 'string' ? input.model : settings?.model,
@@ -242,16 +421,46 @@ export function createCodexFreshAgentAdapter(deps: {
         ),
         excludeTurns: true,
       })
+      if (forked && typeof forked.threadId === 'string') {
+        rememberRuntimeThread(forked.threadId, runtime)
+        settingsByThread.set(forked.threadId, {
+          ...(settings ?? { requestId: '', sessionType: 'freshcodex' }),
+          ...(typeof input?.cwd === 'string' ? { cwd: input.cwd } : {}),
+          ...(typeof input?.model === 'string' ? { model: input.model } : {}),
+          ...(typeof input?.sandbox === 'string' ? { sandbox: input.sandbox as FreshAgentCreateRequest['sandbox'] } : {}),
+          ...(typeof input?.permissionMode === 'string' ? { permissionMode: input.permissionMode } : {}),
+        })
+      }
+      return forked
     },
 
     async getSnapshot(thread, revision) {
-      const rawSnapshot = await deps.runtime.readThread({ threadId: thread.threadId, includeTurns: true })
+      const runtime = await ensureRuntime(thread.threadId)
+      let rawSnapshot: Record<string, any>
+      try {
+        rawSnapshot = await runtime.readThread({ threadId: thread.threadId, includeTurns: true })
+      } catch (error) {
+        if (!isCodexIncludeTurnsUnavailable(error)) {
+          throw error
+        }
+        rawSnapshot = await runtime.readThread({ threadId: thread.threadId, includeTurns: false })
+      }
       const rawThreadTurns: unknown[] = Array.isArray(rawSnapshot.thread?.turns)
         ? rawSnapshot.thread.turns
         : []
+      const activeTurnId = findActiveTurnId(rawSnapshot)
+      if (activeTurnId) {
+        activeTurnByThread.set(thread.threadId, activeTurnId)
+      } else if (normalizeCodexThreadStatus(rawSnapshot.thread?.status) !== 'running') {
+        activeTurnByThread.delete(thread.threadId)
+      }
       const rawTurns = rawThreadTurns
         .filter((turn): turn is Record<string, unknown> => !!turn && typeof turn === 'object' && !Array.isArray(turn))
-        .map((turn, index) => normalizeCodexTurn(turn, index))
+        .map((turn, index) => normalizeCodexTurn(turn, index, {
+          model: typeof turn.id === 'string'
+            ? modelByTurnByThread.get(thread.threadId)?.get(turn.id)
+            : undefined,
+        }))
       return normalizeCodexThreadSnapshot({
         threadId: thread.threadId,
         revision: Number(rawSnapshot.thread?.updatedAt ?? revision ?? 0),
@@ -264,7 +473,8 @@ export function createCodexFreshAgentAdapter(deps: {
     },
 
     async getTurnPage(thread, query) {
-      const rawPage = await deps.runtime.listThreadTurns({
+      const runtime = await ensureRuntime(thread.threadId)
+      const rawPage = await runtime.listThreadTurns({
         threadId: thread.threadId,
         cursor: typeof query.cursor === 'string' ? query.cursor : undefined,
         limit: typeof query.limit === 'number' ? query.limit : undefined,
@@ -273,11 +483,13 @@ export function createCodexFreshAgentAdapter(deps: {
         threadId: thread.threadId,
         revision: Number(rawPage.revision ?? query.revision ?? 0),
         rawPage,
+        modelByTurn: modelByTurnByThread.get(thread.threadId),
       })
     },
 
     async getTurnBody(thread, revision) {
-      const rawTurn = await deps.runtime.readThreadTurn({
+      const runtime = await ensureRuntime(thread.threadId)
+      const rawTurn = await runtime.readThreadTurn({
         threadId: thread.threadId,
         turnId: thread.turnId,
         revision,
@@ -286,7 +498,33 @@ export function createCodexFreshAgentAdapter(deps: {
         threadId: thread.threadId,
         revision,
         rawTurn,
+        model: typeof rawTurn.id === 'string'
+          ? modelByTurnByThread.get(thread.threadId)?.get(rawTurn.id)
+          : undefined,
       })
+    },
+
+    async kill(sessionId) {
+      activeTurnByThread.delete(sessionId)
+      settingsByThread.delete(sessionId)
+      runtimeResumeGenerationByThread.set(sessionId, (runtimeResumeGenerationByThread.get(sessionId) ?? 0) + 1)
+      runtimeResumeByThread.delete(sessionId)
+      modelByTurnByThread.delete(sessionId)
+      await releaseRuntime(sessionId)
+      return true
+    },
+
+    async shutdown() {
+      const runtimes = [...ownedRuntimes]
+      ownedRuntimes.clear()
+      runtimeByThread.clear()
+      threadIdsByRuntime.clear()
+      runtimeResumeByThread.clear()
+      runtimeResumeGenerationByThread.clear()
+      activeTurnByThread.clear()
+      settingsByThread.clear()
+      modelByTurnByThread.clear()
+      await Promise.all(runtimes.map((runtime) => runtime.shutdown?.()))
     },
   }
 }

--- a/server/fresh-agent/adapters/codex/normalize.ts
+++ b/server/fresh-agent/adapters/codex/normalize.ts
@@ -156,18 +156,81 @@ function normalizeCodexItem(turnId: string, item: Record<string, unknown>, index
   }
 }
 
-export function normalizeCodexTurn(rawTurn: Record<string, unknown>, ordinal = 0): FreshAgentTurn {
+function inferCodexTurnRole(rawItems: Record<string, unknown>[]): FreshAgentTurn['role'] {
+  if (rawItems.some((item) => item.type === 'agentMessage' || item.type === 'reasoning' || item.type === 'plan')) {
+    return 'assistant'
+  }
+  if (rawItems.some((item) => item.type === 'userMessage')) {
+    return 'user'
+  }
+  if (rawItems.some((item) => (
+    item.type === 'commandExecution'
+    || item.type === 'fileChange'
+    || item.type === 'mcpToolCall'
+    || item.type === 'dynamicToolCall'
+    || item.type === 'collabAgentToolCall'
+    || item.type === 'webSearch'
+    || item.type === 'imageView'
+    || item.type === 'imageGeneration'
+  ))) {
+    return 'tool'
+  }
+  return undefined
+}
+
+function readCodexTurnError(rawTurn: Record<string, unknown>): string | undefined {
+  const error = rawTurn.error
+  if (!error) return undefined
+  if (typeof error === 'string') return error
+  if (typeof error === 'object' && !Array.isArray(error)) {
+    const record = error as Record<string, unknown>
+    if (typeof record.message === 'string') return record.message
+    if (typeof record.error === 'string') return record.error
+  }
+  return String(error)
+}
+
+export function normalizeCodexTurn(
+  rawTurn: Record<string, unknown>,
+  ordinal = 0,
+  options: { model?: string } = {},
+): FreshAgentTurn {
   const turnId = String(rawTurn.id ?? `turn:${ordinal}`)
+  const model = typeof rawTurn.model === 'string' && rawTurn.model.length > 0
+    ? rawTurn.model
+    : options.model
   const rawItems = Array.isArray(rawTurn.items)
     ? rawTurn.items.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item))
     : []
   const items = rawItems.flatMap((item, index) => normalizeCodexItem(turnId, item, index))
+  const hasAssistantOutput = rawItems.some((item) => item.type === 'agentMessage' || item.type === 'reasoning' || item.type === 'plan')
+  const turnError = readCodexTurnError(rawTurn)
+  if (turnError) {
+    items.push({
+      id: `${turnId}:error`,
+      kind: 'text',
+      text: `Codex turn failed: ${turnError}`,
+    })
+  } else if (
+    rawTurn.status === 'completed'
+    && rawItems.some((item) => item.type === 'userMessage')
+    && rawItems.every((item) => item.type === 'userMessage')
+    && !hasAssistantOutput
+  ) {
+    items.push({
+      id: `${turnId}:empty-response`,
+      kind: 'text',
+      text: 'Codex completed this turn without recording an assistant response.',
+    })
+  }
   const firstText = items.find((item): item is Extract<FreshAgentTranscriptItem, { kind: 'text' }> => item.kind === 'text')
   return {
     id: turnId,
     turnId,
     ordinal,
     source: 'durable',
+    role: inferCodexTurnRole(rawItems),
+    ...(model ? { model } : {}),
     summary: firstText?.text.slice(0, 140) ?? '',
     items,
   }
@@ -177,10 +240,14 @@ export function normalizeCodexTurnPage(input: {
   threadId: string
   revision: number
   rawPage: { turns?: unknown[]; nextCursor?: string | null; backwardsCursor?: string | null }
+  model?: string
+  modelByTurn?: Map<string, string>
 }) {
   const turns = (Array.isArray(input.rawPage.turns) ? input.rawPage.turns : [])
     .filter((turn): turn is Record<string, unknown> => !!turn && typeof turn === 'object' && !Array.isArray(turn))
-    .map((turn, index) => normalizeCodexTurn(turn, index))
+    .map((turn, index) => normalizeCodexTurn(turn, index, {
+      model: (typeof turn.id === 'string' ? input.modelByTurn?.get(turn.id) : undefined) ?? input.model,
+    }))
 
   return FreshAgentTurnPageSchema.parse({
     sessionType: 'freshcodex',
@@ -198,9 +265,10 @@ export function normalizeCodexTurnBody(input: {
   threadId: string
   revision: number
   rawTurn: Record<string, unknown>
+  model?: string
 }) {
   return FreshAgentTurnBodySchema.parse({
-    ...normalizeCodexTurn(input.rawTurn),
+    ...normalizeCodexTurn(input.rawTurn, 0, { model: input.model }),
     sessionType: 'freshcodex',
     provider: 'codex',
     threadId: input.threadId,

--- a/server/fresh-agent/runtime-adapter.ts
+++ b/server/fresh-agent/runtime-adapter.ts
@@ -54,4 +54,5 @@ export interface FreshAgentRuntimeAdapter {
   getSnapshot?(thread: FreshAgentThreadLocator, revision?: number): Promise<unknown>
   getTurnPage?(thread: FreshAgentThreadLocator, query: Record<string, unknown>): Promise<unknown>
   getTurnBody?(thread: FreshAgentThreadLocator & { turnId: string }, revision: number): Promise<unknown>
+  shutdown?(): Promise<void> | void
 }

--- a/server/fresh-agent/runtime-manager.ts
+++ b/server/fresh-agent/runtime-manager.ts
@@ -67,10 +67,13 @@ export class FreshAgentRuntimeManager {
 
   async create(input: FreshAgentCreateRequest): Promise<FreshAgentCreateResult> {
     const registration = this.requireRegistration(input.sessionType, input.provider)
+    const resumeSessionId = input.resumeSessionId
+      ?? (input.sessionRef?.provider === registration.runtimeProvider ? input.sessionRef.sessionId : undefined)
+    const createInput = resumeSessionId ? { ...input, resumeSessionId } : input
 
-    const created = input.resumeSessionId && registration.adapter.resume
-      ? await registration.adapter.resume(input)
-      : await registration.adapter.create(input)
+    const created = resumeSessionId && registration.adapter.resume
+      ? await registration.adapter.resume(createInput)
+      : await registration.adapter.create(createInput)
     this.sessions.set(this.key({
       sessionType: input.sessionType,
       provider: registration.runtimeProvider,
@@ -168,7 +171,19 @@ export class FreshAgentRuntimeManager {
     if (!record.adapter.fork) {
       throw new FreshAgentUnsupportedCapabilityError(`Fork is not supported for ${record.sessionType}`)
     }
-    return await record.adapter.fork(locator.sessionId, input)
+    const forked = await record.adapter.fork(locator.sessionId, input)
+    const forkedRecord = forked && typeof forked === 'object' ? forked as Record<string, unknown> : {}
+    const forkedSessionId = typeof forkedRecord.threadId === 'string'
+      ? forkedRecord.threadId
+      : (typeof forkedRecord.sessionId === 'string' ? forkedRecord.sessionId : undefined)
+    if (forkedSessionId) {
+      this.sessions.set(this.key({
+        sessionType: locator.sessionType,
+        provider: locator.provider,
+        sessionId: forkedSessionId,
+      }), record)
+    }
+    return forked
   }
 
   async answerQuestion(locator: FreshAgentSessionLocator, requestId: FreshAgentRequestId, answers: Record<string, string>) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -305,14 +305,18 @@ async function main() {
   sdkBridge = new SdkBridge(agentHistorySource)
 
   const server = http.createServer(app)
-  const codexFreshAgentRuntime = new CodexAppServerRuntime({ serverInstanceId })
   const claudeFreshAgentAdapter = createClaudeFreshAgentAdapter({
     sdkBridge,
     agentHistorySource,
   })
   const codexFreshAgentAdapter = createCodexFreshAgentAdapter({
-    runtime: codexFreshAgentRuntime,
+    runtimeFactory: () => new CodexAppServerRuntime({ serverInstanceId }),
   })
+  const codexFreshAgentRuntime = {
+    shutdown: async () => {
+      await codexFreshAgentAdapter.shutdown?.()
+    },
+  }
   const freshAgentRuntimeManager = new FreshAgentRuntimeManager({
     registry: createFreshAgentProviderRegistry([
       {

--- a/server/tabs-registry/store.ts
+++ b/server/tabs-registry/store.ts
@@ -4,6 +4,7 @@ import fsp from 'fs/promises'
 import path from 'path'
 import { z } from 'zod'
 import { getFreshellConfigDir } from '../freshell-home.js'
+import { logger } from '../logger.js'
 import { TabRegistryRecordSchema, type RegistryTabRecord } from './types.js'
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -11,6 +12,37 @@ const MINUTE_MS = 60 * 1000
 const DEFAULT_CLOSED_RETENTION_DAYS = 30
 const DEFAULT_OPEN_SNAPSHOT_TTL_MINUTES = 30
 const DEFAULT_DEVICE_DISPLAY_TTL_DAYS = 7
+const log = logger.child({ component: 'tabs-registry-store' })
+
+class InvalidCompactTabsRegistryStateError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message)
+    this.name = 'InvalidCompactTabsRegistryStateError'
+    this.cause = options?.cause
+  }
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  return error && typeof error === 'object' && 'code' in error && typeof (error as { code?: unknown }).code === 'string'
+    ? (error as { code: string }).code
+    : undefined
+}
+
+function isOperationalFsError(error: unknown): boolean {
+  const code = getErrorCode(error)
+  return code === 'EACCES'
+    || code === 'EPERM'
+    || code === 'EIO'
+    || code === 'EMFILE'
+    || code === 'ENFILE'
+    || code === 'ENOMEM'
+    || code === 'ETIMEDOUT'
+    || code === 'EBUSY'
+}
+
+function invalidCompactState(message: string, cause?: unknown): InvalidCompactTabsRegistryStateError {
+  return new InvalidCompactTabsRegistryStateError(message, { cause })
+}
 
 type ObjectRef = {
   path: string
@@ -622,8 +654,25 @@ export class TabsRegistryStore {
 
     const compactManifestPath = path.join(resolvedRoot, 'v1', 'manifest.json')
     if (fs.existsSync(compactManifestPath)) {
-      const { state, manifestRevision, manifestObjectRefs } = await TabsRegistryStore.loadCompactState(resolvedRoot, caps)
-      return new TabsRegistryStore(resolvedRoot, state, manifestRevision, options, manifestObjectRefs)
+      try {
+        const { state, manifestRevision, manifestObjectRefs } = await TabsRegistryStore.loadCompactState(resolvedRoot, caps)
+        return new TabsRegistryStore(resolvedRoot, state, manifestRevision, options, manifestObjectRefs)
+      } catch (error) {
+        if (!(error instanceof InvalidCompactTabsRegistryStateError)) {
+          throw error
+        }
+        const archivedManifestPath = await TabsRegistryStore.archiveInvalidCompactManifest(compactManifestPath)
+        log.warn({
+          err: error,
+          manifestPath: compactManifestPath,
+          archivedManifestPath,
+          event: 'tabs_registry_compact_state_recovered',
+        }, 'Tabs registry compact state was invalid; archived manifest and started with an empty registry')
+        const state = emptyState(now(), options.defaultClosedRetentionDays ?? DEFAULT_CLOSED_RETENTION_DAYS)
+        const store = new TabsRegistryStore(resolvedRoot, state, 0, options)
+        await store.commitState(state)
+        return store
+      }
     }
 
     const legacyPath = path.join(resolvedRoot, 'tabs-registry.jsonl')
@@ -664,35 +713,58 @@ export class TabsRegistryStore {
       }
       manifest = ManifestSchema.parse(JSON.parse(rawManifest))
     } catch (error) {
-      throw new Error(`Tabs registry compact state manifest is invalid: ${error instanceof Error ? error.message : String(error)}`)
+      if (getErrorCode(error) === 'ENOENT' || isOperationalFsError(error)) {
+        throw error
+      }
+      throw invalidCompactState(`Tabs registry compact state manifest is invalid: ${error instanceof Error ? error.message : String(error)}`, error)
     }
 
     const readObject = async <T>(ref: ObjectRef, schema: z.ZodType<T>, maxBytes: number): Promise<T> => {
       if (ref.bytes > maxBytes) {
-        throw new Error(`Tabs registry compact state object ${ref.path} exceeds ${formatBytes(maxBytes)}`)
+        throw invalidCompactState(`Tabs registry compact state object ${ref.path} exceeds ${formatBytes(maxBytes)}`)
       }
       const absolute = path.join(rootDir, 'v1', ref.path)
-      const stat = await fsp.stat(absolute)
-      if (stat.size !== ref.bytes) {
-        throw new Error(`Tabs registry compact state object size mismatch: ${ref.path}`)
+      let stat: fs.Stats
+      try {
+        stat = await fsp.stat(absolute)
+      } catch (error) {
+        if (isOperationalFsError(error)) {
+          throw error
+        }
+        throw invalidCompactState(`Tabs registry compact state object ${ref.path} is unavailable: ${error instanceof Error ? error.message : String(error)}`, error)
       }
-      const raw = await fsp.readFile(absolute, 'utf-8')
+      if (stat.size !== ref.bytes) {
+        throw invalidCompactState(`Tabs registry compact state object size mismatch: ${ref.path}`)
+      }
+      let raw: string
+      try {
+        raw = await fsp.readFile(absolute, 'utf-8')
+      } catch (error) {
+        if (isOperationalFsError(error)) {
+          throw error
+        }
+        throw invalidCompactState(`Tabs registry compact state object ${ref.path} could not be read: ${error instanceof Error ? error.message : String(error)}`, error)
+      }
       const bytes = Buffer.byteLength(raw, 'utf-8')
       const digest = sha256(raw)
       if (bytes !== ref.bytes || digest !== ref.sha256) {
-        throw new Error(`Tabs registry compact state object failed hash validation: ${ref.path}`)
+        throw invalidCompactState(`Tabs registry compact state object failed hash validation: ${ref.path}`)
       }
-      return schema.parse(JSON.parse(raw))
+      try {
+        return schema.parse(JSON.parse(raw))
+      } catch (error) {
+        throw invalidCompactState(`Tabs registry compact state object ${ref.path} is invalid: ${error instanceof Error ? error.message : String(error)}`, error)
+      }
     }
 
     const validateManifestRefsBeforeRead = (manifest: TabsRegistryManifestV1): void => {
       const openRefs = Object.values(manifest.openSnapshots)
       if (openRefs.length > caps.maxClientSnapshotRefs) {
-        throw new Error(`Tabs registry can retain at most ${caps.maxClientSnapshotRefs} client snapshots`)
+        throw invalidCompactState(`Tabs registry can retain at most ${caps.maxClientSnapshotRefs} client snapshots`)
       }
       for (const ref of openRefs) {
         if (ref.bytes > caps.maxSerializedClientSnapshotObjectBytes) {
-          throw new Error(`Tabs registry compact state object ${ref.path} exceeds ${formatBytes(caps.maxSerializedClientSnapshotObjectBytes)}`)
+          throw invalidCompactState(`Tabs registry compact state object ${ref.path} exceeds ${formatBytes(caps.maxSerializedClientSnapshotObjectBytes)}`)
         }
       }
       const fixedRefs: Array<[ObjectRef, number]> = [
@@ -702,13 +774,13 @@ export class TabsRegistryStore {
       ]
       for (const [ref, maxBytes] of fixedRefs) {
         if (ref.bytes > maxBytes) {
-          throw new Error(`Tabs registry compact state object ${ref.path} exceeds ${formatBytes(maxBytes)}`)
+          throw invalidCompactState(`Tabs registry compact state object ${ref.path} exceeds ${formatBytes(maxBytes)}`)
         }
       }
       const referencedBytes = [...openRefs, manifest.clientRevisions, manifest.closedTombstones, manifest.devices]
         .reduce((sum, ref) => sum + ref.bytes, 0)
       if (referencedBytes > caps.maxCompactStateBytes) {
-        throw new Error(`Tabs registry compact state exceeds ${formatBytes(caps.maxCompactStateBytes)}`)
+        throw invalidCompactState(`Tabs registry compact state exceeds ${formatBytes(caps.maxCompactStateBytes)}`)
       }
     }
 
@@ -745,8 +817,17 @@ export class TabsRegistryStore {
         },
       }
     } catch (error) {
-      throw new Error(`Tabs registry compact state is invalid: ${error instanceof Error ? error.message : String(error)}`)
+      if (!(error instanceof InvalidCompactTabsRegistryStateError) && isOperationalFsError(error)) {
+        throw error
+      }
+      throw invalidCompactState(`Tabs registry compact state is invalid: ${error instanceof Error ? error.message : String(error)}`, error)
     }
+  }
+
+  private static async archiveInvalidCompactManifest(manifestPath: string): Promise<string> {
+    const archivedManifestPath = `${manifestPath}.invalid-${archiveTimestamp(new Date())}`
+    await fsp.rename(manifestPath, archivedManifestPath)
+    return archivedManifestPath
   }
 
   private static async migrateLegacyJsonl(

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -3587,7 +3587,7 @@ export class WsHandler {
         }
         const locator = { sessionId: m.sessionId, sessionType: m.sessionType, provider: m.provider }
         try {
-          await manager.send(locator, { text: m.text, images: m.images })
+          await manager.send(locator, { text: m.text, images: m.images, settings: m.settings })
         } catch (error) {
           this.sendError(ws, { code: 'INTERNAL_ERROR', message: errorMessage(error) })
         }
@@ -3647,7 +3647,28 @@ export class WsHandler {
         }
         const locator = { sessionId: m.sessionId, sessionType: m.sessionType, provider: m.provider }
         try {
-          await manager.fork(locator, m.input)
+          const forked = await manager.fork(locator, m.input)
+          const forkedRecord = forked && typeof forked === 'object' ? forked as Record<string, unknown> : {}
+          const forkedSessionId = typeof forkedRecord.threadId === 'string'
+            ? forkedRecord.threadId
+            : (typeof forkedRecord.sessionId === 'string' ? forkedRecord.sessionId : undefined)
+          if (forkedSessionId) {
+            this.send(ws, {
+              type: 'freshAgent.forked',
+              requestId: m.requestId,
+              parentSessionId: m.sessionId,
+              sessionId: forkedSessionId,
+              sessionType: m.sessionType,
+              provider: m.provider,
+              runtimeProvider: m.provider,
+              sessionRef: { provider: m.provider, sessionId: forkedSessionId },
+            })
+            this.ensureFreshAgentSubscription(ws, state, {
+              sessionId: forkedSessionId,
+              sessionType: m.sessionType,
+              provider: m.provider,
+            })
+          }
         } catch (error) {
           this.sendError(ws, { code: 'INTERNAL_ERROR', message: errorMessage(error) })
         }

--- a/shared/fresh-agent-models.ts
+++ b/shared/fresh-agent-models.ts
@@ -119,4 +119,3 @@ export function normalizeFreshAgentEffort(
   }
   return options[options.length - 1]?.value
 }
-

--- a/shared/fresh-agent-models.ts
+++ b/shared/fresh-agent-models.ts
@@ -1,0 +1,122 @@
+import type { FreshAgentRuntimeProvider, FreshAgentSessionType } from './fresh-agent.js'
+
+export type FreshAgentThinkingOption = {
+  value: string
+  label: string
+}
+
+export type FreshAgentModelOption = {
+  value: string
+  label: string
+  thinkingEfforts?: readonly string[]
+  defaultEffort?: string
+}
+
+export const FRESHCODEX_DEFAULT_MODEL = 'gpt-5.5'
+export const FRESHCODEX_DEFAULT_EFFORT = 'xhigh'
+
+export const FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE = {
+  freshclaude: [
+    {
+      value: 'claude-opus-4-6',
+      label: 'Claude Opus 4.6',
+      thinkingEfforts: ['low', 'medium', 'high', 'max'],
+      defaultEffort: 'max',
+    },
+  ],
+  freshcodex: [
+    {
+      value: FRESHCODEX_DEFAULT_MODEL,
+      label: 'GPT-5.5',
+      thinkingEfforts: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'],
+      defaultEffort: FRESHCODEX_DEFAULT_EFFORT,
+    },
+    {
+      value: 'gpt-5.4-flash',
+      label: 'GPT-5.4 Flash',
+      thinkingEfforts: ['none', 'minimal', 'low', 'medium', 'high'],
+      defaultEffort: 'high',
+    },
+    {
+      value: 'gpt-5.3-codex-spark',
+      label: 'GPT-5.3 Codex Spark',
+      thinkingEfforts: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'],
+      defaultEffort: FRESHCODEX_DEFAULT_EFFORT,
+    },
+  ],
+  kilroy: [
+    {
+      value: 'claude-opus-4-6',
+      label: 'Claude Opus 4.6',
+      thinkingEfforts: ['low', 'medium', 'high', 'max'],
+      defaultEffort: 'max',
+    },
+  ],
+  freshopencode: [
+    {
+      value: 'opencode',
+      label: 'Opencode',
+      thinkingEfforts: ['low', 'medium', 'high', 'max'],
+      defaultEffort: 'max',
+    },
+  ],
+} as const satisfies Record<FreshAgentSessionType, readonly FreshAgentModelOption[]>
+
+export const FRESHCODEX_MODEL_OPTIONS = FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE.freshcodex
+
+function defaultModelForSession(sessionType: FreshAgentSessionType): FreshAgentModelOption | undefined {
+  return FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE[sessionType]?.[0]
+}
+
+export function resolveFreshAgentModelOption(
+  sessionType: FreshAgentSessionType,
+  model: string | undefined,
+): FreshAgentModelOption | undefined {
+  const options = FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE[sessionType] ?? []
+  return options.find((option) => option.value === model) ?? defaultModelForSession(sessionType)
+}
+
+export function normalizeFreshcodexModel(model: string | undefined): string {
+  const option = FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE.freshcodex.find((candidate) => candidate.value === model)
+  return option?.value ?? FRESHCODEX_DEFAULT_MODEL
+}
+
+export function normalizeFreshAgentModel(
+  sessionType: FreshAgentSessionType,
+  provider: FreshAgentRuntimeProvider,
+  model: string | undefined,
+): string | undefined {
+  if (provider === 'codex') {
+    return normalizeFreshcodexModel(model)
+  }
+  return model ?? defaultModelForSession(sessionType)?.value
+}
+
+export function getFreshAgentThinkingOptions(
+  sessionType: FreshAgentSessionType,
+  provider: FreshAgentRuntimeProvider,
+  model: string | undefined,
+): readonly FreshAgentThinkingOption[] {
+  const normalizedModel = normalizeFreshAgentModel(sessionType, provider, model)
+  const modelOption = resolveFreshAgentModelOption(sessionType, normalizedModel)
+  return (modelOption?.thinkingEfforts ?? []).map((value) => ({ value, label: value }))
+}
+
+export function normalizeFreshAgentEffort(
+  sessionType: FreshAgentSessionType,
+  provider: FreshAgentRuntimeProvider,
+  model: string | undefined,
+  effort: string | undefined,
+): string | undefined {
+  const options = getFreshAgentThinkingOptions(sessionType, provider, model)
+  if (effort && options.some((option) => option.value === effort)) {
+    return effort
+  }
+  const normalizedModel = normalizeFreshAgentModel(sessionType, provider, model)
+  const modelOption = resolveFreshAgentModelOption(sessionType, normalizedModel)
+  if (modelOption?.defaultEffort && options.some((option) => option.value === modelOption.defaultEffort)) {
+    return modelOption.defaultEffort
+  }
+  return options[options.length - 1]?.value
+}
+

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -445,6 +445,13 @@ export const FreshAgentSendSchema = z.object({
   sessionType: z.enum(['freshclaude', 'freshcodex', 'kilroy', 'freshopencode']),
   provider: z.enum(['claude', 'codex', 'opencode']),
   text: z.string().min(1),
+  settings: z.object({
+    cwd: z.string().min(1).optional(),
+    model: z.string().min(1).optional(),
+    permissionMode: z.string().min(1).optional(),
+    sandbox: z.enum(['read-only', 'workspace-write', 'danger-full-access']).optional(),
+    effort: z.string().trim().min(1).optional(),
+  }).optional(),
   images: z.array(z.object({
     mediaType: z.string(),
     data: z.string(),
@@ -485,6 +492,7 @@ export const FreshAgentKillSchema = z.object({
 
 export const FreshAgentForkSchema = z.object({
   type: z.literal('freshAgent.fork'),
+  requestId: z.string().min(1).optional(),
   sessionId: z.string().min(1),
   sessionType: z.enum(['freshclaude', 'freshcodex', 'kilroy', 'freshopencode']),
   provider: z.enum(['claude', 'codex', 'opencode']),
@@ -825,6 +833,7 @@ export type FreshAgentServerMessage =
   | { type: 'freshAgent.created'; requestId: string; sessionId: string; sessionType: string; provider: string; runtimeProvider: string; sessionRef?: { provider: string; sessionId: string } }
   | { type: 'freshAgent.create.failed'; requestId: string; code: string; message: string; retryable?: boolean }
   | { type: 'freshAgent.event'; sessionId: string; sessionType: string; provider: string; event: unknown }
+  | { type: 'freshAgent.forked'; requestId?: string; parentSessionId: string; sessionId: string; sessionType: string; provider: string; runtimeProvider: string; sessionRef?: { provider: string; sessionId: string } }
   | { type: 'freshAgent.killed'; sessionId: string; sessionType: string; provider: string; success: boolean }
 
 export type SdkServerMessage =

--- a/src/components/ExtensionsView.tsx
+++ b/src/components/ExtensionsView.tsx
@@ -135,7 +135,7 @@ function ConfigField({ item, field, onConfigChange, cwdDrafts, cwdErrors }: Conf
         id={fieldId}
         type="text"
         value={field.value as string}
-        placeholder={field.key === 'model' ? (item.id === 'codex' ? 'e.g. gpt-5-codex' : 'e.g. claude-3-5-sonnet') : undefined}
+        placeholder={field.key === 'model' ? (item.id === 'codex' ? 'e.g. gpt-5.5' : 'e.g. claude-3-5-sonnet') : undefined}
         aria-label={field.label}
         onChange={(e) => onConfigChange(item, field.key, e.target.value)}
         className="h-8 w-full px-2 text-xs bg-muted border-0 rounded-md placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-border sm:max-w-[14rem]"

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -19,11 +19,7 @@ function getTurnLabel(turn: FreshAgentTurn): string {
 export function FreshAgentTranscript({ turns }: { turns: FreshAgentTurn[] }) {
   return (
     <div className="flex flex-1 flex-col gap-3 overflow-y-auto px-3 py-3" data-context="fresh-agent-transcript">
-      {turns.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-border/60 px-4 py-6 text-sm text-muted-foreground">
-          No transcript available yet.
-        </div>
-      ) : turns.map((turn) => {
+      {turns.map((turn) => {
         const isUser = turn.role === 'user'
         return (
           <article

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -8,7 +8,12 @@ import { getFreshAgentThreadSnapshot } from '@/lib/api'
 import { mergePaneContent, updatePaneContent } from '@/store/panesSlice'
 import { clearPendingCreateFailure } from '@/store/freshAgentSlice'
 import { handleFreshAgentTransportEvent, registerFreshAgentCreate } from '@/lib/fresh-agent-ws'
-import { resolveFreshAgentType } from '@/lib/fresh-agent-registry'
+import {
+  FRESHCODEX_DEFAULT_EFFORT,
+  FRESHCODEX_MODEL_OPTIONS,
+  normalizeFreshcodexModel,
+  resolveFreshAgentType,
+} from '@/lib/fresh-agent-registry'
 import { getCanonicalDurableSessionId, getPreferredResumeSessionId } from '@/store/persistControl'
 import { isValidClaudeSessionId } from '@/lib/claude-session-id'
 import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
@@ -22,10 +27,43 @@ import { FreshAgentDiffPanel } from './FreshAgentDiffPanel'
 import { FreshAgentSidebar } from './FreshAgentSidebar'
 
 const EARLY_STATES = new Set(['creating', 'starting'])
-const CODEX_MODEL_OPTIONS = [
-  { value: 'gpt-5-codex', label: 'GPT-5 Codex' },
-  { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
-] as const
+const FRESH_AGENT_THINKING_OPTIONS_BY_PROVIDER = {
+  claude: [
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High' },
+    { value: 'max', label: 'Maximum' },
+  ],
+  codex: [
+    { value: 'none', label: 'None' },
+    { value: 'minimal', label: 'Minimal' },
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High' },
+    { value: 'xhigh', label: 'Maximum' },
+  ],
+  opencode: [
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High' },
+    { value: 'max', label: 'Maximum' },
+  ],
+} as const
+
+function getEffectiveFreshAgentModel(content: FreshAgentPaneContent): string | undefined {
+  if (content.provider === 'codex') {
+    return normalizeFreshcodexModel(content.model)
+  }
+  return content.model
+}
+
+function getEffectiveFreshAgentEffort(content: FreshAgentPaneContent): string | undefined {
+  if (content.effort) return content.effort
+  if (content.provider === 'codex') return FRESHCODEX_DEFAULT_EFFORT
+  if (content.provider === 'claude') return 'max'
+  if (content.provider === 'opencode') return 'max'
+  return undefined
+}
 
 function isStatusRegression(current: string, next: string): boolean {
   return !EARLY_STATES.has(current) && EARLY_STATES.has(next)
@@ -199,10 +237,10 @@ export function FreshAgentView({
       ?? (content.sessionRef?.provider === content.provider ? content.sessionRef.sessionId : undefined),
     sessionRef: content.sessionRef,
     modelSelection: content.modelSelection,
-    model: content.model,
+    model: getEffectiveFreshAgentModel(content),
     permissionMode: content.permissionMode,
     sandbox: content.sandbox,
-    effort: content.effort,
+    effort: getEffectiveFreshAgentEffort(content),
     plugins: content.plugins,
   } as const), [])
 
@@ -581,10 +619,9 @@ export function FreshAgentView({
       ? null
       : (paneContent.restoreError ? getRestoreErrorMessage(paneContent.restoreError.reason) : null)
     const visibleLoadError = visibleRestoreFailure || visiblePaneRestoreFailure || isRestoring ? null : loadError
-    const codexModelValue = paneContent.model ?? 'gpt-5-codex'
-    const codexModelOptions = CODEX_MODEL_OPTIONS.some((option) => option.value === codexModelValue)
-      ? CODEX_MODEL_OPTIONS
-      : [{ value: codexModelValue, label: codexModelValue }, ...CODEX_MODEL_OPTIONS]
+    const codexModelValue = normalizeFreshcodexModel(paneContent.model)
+    const thinkingOptions = FRESH_AGENT_THINKING_OPTIONS_BY_PROVIDER[paneContent.provider] ?? []
+    const thinkingValue = getEffectiveFreshAgentEffort(paneContent) ?? ''
 
     return (
       <div className="flex h-full min-h-0 flex-col" data-context="fresh-agent" data-session-id={paneContent.sessionId}>
@@ -598,23 +635,49 @@ export function FreshAgentView({
               <span>{statusLabel}</span>
               {typeof totalTokens === 'number' ? <span>{totalTokens} tokens</span> : null}
               {paneContent.provider === 'codex' ? (
+                <fieldset
+                  className="flex items-center gap-2"
+                  disabled={effectiveStatus === 'running' || effectiveStatus === 'compacting'}
+                >
+                  <legend className="sr-only">Model</legend>
+                  {FRESHCODEX_MODEL_OPTIONS.map((option) => (
+                    <label key={option.value} className="flex items-center gap-1">
+                      <input
+                        type="radio"
+                        name={`${paneId}-freshcodex-model`}
+                        value={option.value}
+                        checked={codexModelValue === option.value}
+                        onChange={() => {
+                          dispatch(mergePaneContent({
+                            tabId,
+                            paneId,
+                            updates: { model: option.value },
+                          }))
+                        }}
+                      />
+                      <span>{option.label}</span>
+                    </label>
+                  ))}
+                </fieldset>
+              ) : null}
+              {thinkingOptions.length > 0 ? (
                 <label className="flex items-center gap-1">
-                  <span className="sr-only">Model</span>
+                  <span>Thinking</span>
                   <select
-                    aria-label="Model"
+                    aria-label="Thinking level"
                     className="rounded border border-border/70 bg-background px-2 py-1 text-xs"
-                    value={codexModelValue}
+                    value={thinkingValue}
                     disabled={effectiveStatus === 'running' || effectiveStatus === 'compacting'}
                     onChange={(event) => {
-                      const nextModel = event.target.value
+                      const nextEffort = event.target.value
                       dispatch(mergePaneContent({
                         tabId,
                         paneId,
-                        updates: { model: nextModel },
+                        updates: { effort: nextEffort },
                       }))
                     }}
                   >
-                    {codexModelOptions.map((option) => (
+                    {thinkingOptions.map((option) => (
                       <option key={option.value} value={option.value}>{option.label}</option>
                     ))}
                   </select>
@@ -766,10 +829,10 @@ export function FreshAgentView({
                   text,
                   settings: {
                     ...(paneContent.initialCwd ? { cwd: paneContent.initialCwd } : {}),
-                    ...(paneContent.model ? { model: paneContent.model } : {}),
+                    ...(getEffectiveFreshAgentModel(paneContent) ? { model: getEffectiveFreshAgentModel(paneContent) } : {}),
                     ...(paneContent.permissionMode ? { permissionMode: paneContent.permissionMode } : {}),
                     ...(paneContent.sandbox ? { sandbox: paneContent.sandbox } : {}),
-                    ...(paneContent.effort ? { effort: paneContent.effort } : {}),
+                    ...(getEffectiveFreshAgentEffort(paneContent) ? { effort: getEffectiveFreshAgentEffort(paneContent) } : {}),
                   },
                 })
               }}

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -9,10 +9,10 @@ import { mergePaneContent, updatePaneContent } from '@/store/panesSlice'
 import { clearPendingCreateFailure } from '@/store/freshAgentSlice'
 import { handleFreshAgentTransportEvent, registerFreshAgentCreate } from '@/lib/fresh-agent-ws'
 import {
-  FRESH_AGENT_THINKING_OPTIONS_BY_PROVIDER,
   FRESHCODEX_MODEL_OPTIONS,
+  getFreshAgentThinkingOptions,
   normalizeFreshAgentEffort,
-  normalizeFreshcodexModel,
+  normalizeFreshAgentModel,
   resolveFreshAgentType,
 } from '@/lib/fresh-agent-registry'
 import { getCanonicalDurableSessionId, getPreferredResumeSessionId } from '@/store/persistControl'
@@ -30,14 +30,11 @@ import { FreshAgentSidebar } from './FreshAgentSidebar'
 const EARLY_STATES = new Set(['creating', 'starting'])
 
 function getEffectiveFreshAgentModel(content: FreshAgentPaneContent): string | undefined {
-  if (content.provider === 'codex') {
-    return normalizeFreshcodexModel(content.model)
-  }
-  return content.model
+  return normalizeFreshAgentModel(content.sessionType, content.provider, content.model)
 }
 
 function getEffectiveFreshAgentEffort(content: FreshAgentPaneContent): string | undefined {
-  return normalizeFreshAgentEffort(content.provider, content.effort)
+  return normalizeFreshAgentEffort(content.sessionType, content.provider, getEffectiveFreshAgentModel(content), content.effort)
 }
 
 function isStatusRegression(current: string, next: string): boolean {
@@ -594,8 +591,9 @@ export function FreshAgentView({
       ? null
       : (paneContent.restoreError ? getRestoreErrorMessage(paneContent.restoreError.reason) : null)
     const visibleLoadError = visibleRestoreFailure || visiblePaneRestoreFailure || isRestoring ? null : loadError
-    const codexModelValue = normalizeFreshcodexModel(paneContent.model)
-    const thinkingOptions = FRESH_AGENT_THINKING_OPTIONS_BY_PROVIDER[paneContent.provider] ?? []
+    const activeModel = getEffectiveFreshAgentModel(paneContent)
+    const codexModelValue = activeModel ?? ''
+    const thinkingOptions = getFreshAgentThinkingOptions(paneContent.sessionType, paneContent.provider, activeModel)
     const thinkingValue = getEffectiveFreshAgentEffort(paneContent) ?? ''
 
     return (
@@ -623,10 +621,16 @@ export function FreshAgentView({
                         value={option.value}
                         checked={codexModelValue === option.value}
                         onChange={() => {
+                          const nextEffort = normalizeFreshAgentEffort(
+                            paneContent.sessionType,
+                            paneContent.provider,
+                            option.value,
+                            paneContent.effort,
+                          )
                           dispatch(mergePaneContent({
                             tabId,
                             paneId,
-                            updates: { model: option.value },
+                            updates: { model: option.value, effort: nextEffort },
                           }))
                         }}
                       />

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -9,8 +9,9 @@ import { mergePaneContent, updatePaneContent } from '@/store/panesSlice'
 import { clearPendingCreateFailure } from '@/store/freshAgentSlice'
 import { handleFreshAgentTransportEvent, registerFreshAgentCreate } from '@/lib/fresh-agent-ws'
 import {
-  FRESHCODEX_DEFAULT_EFFORT,
+  FRESH_AGENT_THINKING_OPTIONS_BY_PROVIDER,
   FRESHCODEX_MODEL_OPTIONS,
+  normalizeFreshAgentEffort,
   normalizeFreshcodexModel,
   resolveFreshAgentType,
 } from '@/lib/fresh-agent-registry'
@@ -27,28 +28,6 @@ import { FreshAgentDiffPanel } from './FreshAgentDiffPanel'
 import { FreshAgentSidebar } from './FreshAgentSidebar'
 
 const EARLY_STATES = new Set(['creating', 'starting'])
-const FRESH_AGENT_THINKING_OPTIONS_BY_PROVIDER = {
-  claude: [
-    { value: 'low', label: 'Low' },
-    { value: 'medium', label: 'Medium' },
-    { value: 'high', label: 'High' },
-    { value: 'max', label: 'Maximum' },
-  ],
-  codex: [
-    { value: 'none', label: 'None' },
-    { value: 'minimal', label: 'Minimal' },
-    { value: 'low', label: 'Low' },
-    { value: 'medium', label: 'Medium' },
-    { value: 'high', label: 'High' },
-    { value: 'xhigh', label: 'Maximum' },
-  ],
-  opencode: [
-    { value: 'low', label: 'Low' },
-    { value: 'medium', label: 'Medium' },
-    { value: 'high', label: 'High' },
-    { value: 'max', label: 'Maximum' },
-  ],
-} as const
 
 function getEffectiveFreshAgentModel(content: FreshAgentPaneContent): string | undefined {
   if (content.provider === 'codex') {
@@ -58,11 +37,7 @@ function getEffectiveFreshAgentModel(content: FreshAgentPaneContent): string | u
 }
 
 function getEffectiveFreshAgentEffort(content: FreshAgentPaneContent): string | undefined {
-  if (content.effort) return content.effort
-  if (content.provider === 'codex') return FRESHCODEX_DEFAULT_EFFORT
-  if (content.provider === 'claude') return 'max'
-  if (content.provider === 'opencode') return 'max'
-  return undefined
+  return normalizeFreshAgentEffort(content.provider, content.effort)
 }
 
 function isStatusRegression(current: string, next: string): boolean {

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -22,6 +22,10 @@ import { FreshAgentDiffPanel } from './FreshAgentDiffPanel'
 import { FreshAgentSidebar } from './FreshAgentSidebar'
 
 const EARLY_STATES = new Set(['creating', 'starting'])
+const CODEX_MODEL_OPTIONS = [
+  { value: 'gpt-5-codex', label: 'GPT-5 Codex' },
+  { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+] as const
 
 function isStatusRegression(current: string, next: string): boolean {
   return !EARLY_STATES.has(current) && EARLY_STATES.has(next)
@@ -72,6 +76,14 @@ function getQuestionAgentLabel(paneContent: FreshAgentPaneContent, descriptorLab
     default:
       return descriptorLabel ?? 'Fresh Agent'
   }
+}
+
+function isUnmaterializedCodexThreadError(error: unknown): boolean {
+  return !!error
+    && typeof error === 'object'
+    && 'message' in error
+    && typeof (error as { message?: unknown }).message === 'string'
+    && (error as { message: string }).message.includes('no rollout found for thread id')
 }
 
 function getRestoreErrorMessage(reason: RestoreErrorReason): string {
@@ -142,7 +154,6 @@ export function FreshAgentView({
   const paneContentRef = useRef(paneContent)
   paneContentRef.current = paneContent
   const snapshotSessionId = paneContent.sessionId
-    ?? (paneContent.sessionRef?.provider === paneContent.provider ? paneContent.sessionRef.sessionId : undefined)
   const restoreTimeoutRef = useRef<number | null>(null)
   const createSentRef = useRef(false)
   const preferredResumeSessionId = getPreferredResumeSessionId(claudeSession) ?? paneContent.resumeSessionId
@@ -184,7 +195,8 @@ export function FreshAgentView({
     sessionType: content.sessionType,
     provider: content.provider,
     cwd: content.initialCwd,
-    resumeSessionId: content.resumeSessionId,
+    resumeSessionId: content.resumeSessionId
+      ?? (content.sessionRef?.provider === content.provider ? content.sessionRef.sessionId : undefined),
     sessionRef: content.sessionRef,
     modelSelection: content.modelSelection,
     model: content.model,
@@ -344,9 +356,44 @@ export function FreshAgentView({
         })
         setSnapshotRefreshNonce((value) => value + 1)
       }
+      if (
+        message.type === 'freshAgent.forked'
+        && message.requestId === paneContent.createRequestId
+        && message.parentSessionId === paneContent.sessionId
+        && message.sessionType === paneContent.sessionType
+        && message.provider === paneContent.provider
+        && typeof message.sessionId === 'string'
+      ) {
+        if (message.sessionId !== paneContent.sessionId) {
+          sendFreshAgentMessage({
+            type: 'freshAgent.kill',
+            sessionId: paneContent.sessionId,
+            sessionType: paneContent.sessionType,
+            provider: paneContent.provider,
+          })
+        }
+        setSnapshot(null)
+        dispatch(updatePaneContent({
+          tabId,
+          paneId,
+          content: {
+            ...paneContentRef.current,
+            createRequestId: nanoid(),
+            sessionId: message.sessionId,
+            sessionRef: {
+              provider: paneContent.provider,
+              sessionId: message.sessionId,
+            },
+            resumeSessionId: message.sessionId,
+            status: 'connected',
+            createError: undefined,
+            restoreError: undefined,
+          },
+        }))
+      }
     })
     return unsubscribe
-  }, [dispatch, paneContent, paneContent.createRequestId, paneId, tabId, ws])
+  }, [dispatch, paneContent, paneContent.createRequestId, paneId, sendFreshAgentMessage, tabId, ws])
 
   useEffect(() => {
     if (!snapshotSessionId) return
@@ -379,6 +426,25 @@ export function FreshAgentView({
         if (error instanceof Error && error.name === 'AbortError') return
         if (paneContent.provider === 'claude' && claudeSession) {
           setLoadError(null)
+          return
+        }
+        if (paneContent.provider === 'codex' && isUnmaterializedCodexThreadError(error)) {
+          const fresh = paneContentRef.current
+          setLoadError(null)
+          setSnapshot(null)
+          dispatch(updatePaneContent({
+            tabId,
+            paneId,
+            content: {
+              ...fresh,
+              sessionId: undefined,
+              sessionRef: undefined,
+              createRequestId: nanoid(),
+              status: 'idle',
+              createError: undefined,
+              restoreError: buildRestoreError('durable_artifact_missing'),
+            },
+          }))
           return
         }
         setLoadError(error instanceof Error ? error.message : 'Failed to load session')
@@ -515,6 +581,10 @@ export function FreshAgentView({
       ? null
       : (paneContent.restoreError ? getRestoreErrorMessage(paneContent.restoreError.reason) : null)
     const visibleLoadError = visibleRestoreFailure || visiblePaneRestoreFailure || isRestoring ? null : loadError
+    const codexModelValue = paneContent.model ?? 'gpt-5-codex'
+    const codexModelOptions = CODEX_MODEL_OPTIONS.some((option) => option.value === codexModelValue)
+      ? CODEX_MODEL_OPTIONS
+      : [{ value: codexModelValue, label: codexModelValue }, ...CODEX_MODEL_OPTIONS]
 
     return (
       <div className="flex h-full min-h-0 flex-col" data-context="fresh-agent" data-session-id={paneContent.sessionId}>
@@ -527,6 +597,29 @@ export function FreshAgentView({
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <span>{statusLabel}</span>
               {typeof totalTokens === 'number' ? <span>{totalTokens} tokens</span> : null}
+              {paneContent.provider === 'codex' ? (
+                <label className="flex items-center gap-1">
+                  <span className="sr-only">Model</span>
+                  <select
+                    aria-label="Model"
+                    className="rounded border border-border/70 bg-background px-2 py-1 text-xs"
+                    value={codexModelValue}
+                    disabled={effectiveStatus === 'running' || effectiveStatus === 'compacting'}
+                    onChange={(event) => {
+                      const nextModel = event.target.value
+                      dispatch(mergePaneContent({
+                        tabId,
+                        paneId,
+                        updates: { model: nextModel },
+                      }))
+                    }}
+                  >
+                    {codexModelOptions.map((option) => (
+                      <option key={option.value} value={option.value}>{option.label}</option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
               <button
                 type="button"
                 className="rounded border border-border/70 px-2 py-1 disabled:opacity-50"
@@ -551,6 +644,7 @@ export function FreshAgentView({
                   if (!paneContent.sessionId || !canFork) return
                   sendFreshAgentMessage({
                     type: 'freshAgent.fork',
+                    requestId: paneContent.createRequestId,
                     sessionId: paneContent.sessionId,
                     sessionType: paneContent.sessionType,
                     provider: paneContent.provider,
@@ -670,6 +764,13 @@ export function FreshAgentView({
                   sessionType: paneContent.sessionType,
                   provider: paneContent.provider,
                   text,
+                  settings: {
+                    ...(paneContent.initialCwd ? { cwd: paneContent.initialCwd } : {}),
+                    ...(paneContent.model ? { model: paneContent.model } : {}),
+                    ...(paneContent.permissionMode ? { permissionMode: paneContent.permissionMode } : {}),
+                    ...(paneContent.sandbox ? { sandbox: paneContent.sandbox } : {}),
+                    ...(paneContent.effort ? { effort: paneContent.effort } : {}),
+                  },
                 })
               }}
             />

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -14,7 +14,7 @@ import PanePicker, { type PanePickerType } from './PanePicker'
 import DirectoryPicker from './DirectoryPicker'
 import { getProviderLabel, isCodingCliProviderName } from '@/lib/coding-cli-utils'
 import { isAgentChatProviderName, getAgentChatProviderConfig } from '@/lib/agent-chat-utils'
-import { normalizeFreshAgentEffort, normalizeFreshcodexModel, resolveFreshAgentType } from '@/lib/fresh-agent-registry'
+import { normalizeFreshAgentEffort, normalizeFreshAgentModel, resolveFreshAgentType } from '@/lib/fresh-agent-registry'
 import { clearDraft } from '@/lib/draft-store'
 import { getTerminalActions } from '@/lib/pane-action-registry'
 import { buildPaneRefreshTarget } from '@/lib/pane-utils'
@@ -463,11 +463,12 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
                     ...node.content,
                     kind: 'agent-chat',
                     provider: 'freshclaude',
-                    effort: (
-                      node.content.effort === 'none'
-                      || node.content.effort === 'minimal'
-                      || node.content.effort === 'xhigh'
-                    ) ? undefined : node.content.effort,
+                    effort: normalizeFreshAgentEffort(
+                      node.content.sessionType,
+                      node.content.provider,
+                      node.content.model,
+                      node.content.effort,
+                    ),
                   }
                 : node.content,
               node.content.sessionId ? agentChatSessions[node.content.sessionId] : undefined,
@@ -609,6 +610,13 @@ function PickerWrapper({
         ? getAgentChatProviderConfig(type)
         : undefined
       const providerSettings = agentChatSettings?.providers?.[type]
+      const model = normalizeFreshAgentModel(
+        freshAgentType.sessionType,
+        freshAgentType.runtimeProvider,
+        freshAgentType.runtimeProvider === 'codex'
+          ? settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.model
+          : freshAgentType.defaultModel,
+      )
       return {
         kind: 'fresh-agent',
         sessionType: freshAgentType.sessionType,
@@ -616,9 +624,7 @@ function PickerWrapper({
         createRequestId: nanoid(),
         status: 'creating',
         modelSelection: normalizeAgentChatModelSelection(providerSettings?.modelSelection),
-        model: freshAgentType.runtimeProvider === 'codex'
-          ? normalizeFreshcodexModel(settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.model)
-          : freshAgentType.defaultModel,
+        model,
         permissionMode: providerSettings?.defaultPermissionMode
           ?? (freshAgentType.runtimeProvider === 'codex'
             ? settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.permissionMode
@@ -629,7 +635,9 @@ function PickerWrapper({
           ? settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.sandbox
           : undefined,
         effort: normalizeFreshAgentEffort(
+          freshAgentType.sessionType,
           freshAgentType.runtimeProvider,
+          model,
           normalizeAgentChatEffortOverride(providerSettings?.effort),
         ) ?? freshAgentType.defaultEffort,
         plugins: freshAgentType.runtimeProvider === 'claude' ? agentChatSettings?.defaultPlugins : undefined,

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -14,7 +14,7 @@ import PanePicker, { type PanePickerType } from './PanePicker'
 import DirectoryPicker from './DirectoryPicker'
 import { getProviderLabel, isCodingCliProviderName } from '@/lib/coding-cli-utils'
 import { isAgentChatProviderName, getAgentChatProviderConfig } from '@/lib/agent-chat-utils'
-import { resolveFreshAgentType } from '@/lib/fresh-agent-registry'
+import { normalizeFreshcodexModel, resolveFreshAgentType } from '@/lib/fresh-agent-registry'
 import { clearDraft } from '@/lib/draft-store'
 import { getTerminalActions } from '@/lib/pane-action-registry'
 import { buildPaneRefreshTarget } from '@/lib/pane-utils'
@@ -617,7 +617,7 @@ function PickerWrapper({
         status: 'creating',
         modelSelection: normalizeAgentChatModelSelection(providerSettings?.modelSelection),
         model: freshAgentType.runtimeProvider === 'codex'
-          ? settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.model ?? freshAgentType.defaultModel
+          ? normalizeFreshcodexModel(settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.model)
           : freshAgentType.defaultModel,
         permissionMode: providerSettings?.defaultPermissionMode
           ?? (freshAgentType.runtimeProvider === 'codex'

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -14,7 +14,7 @@ import PanePicker, { type PanePickerType } from './PanePicker'
 import DirectoryPicker from './DirectoryPicker'
 import { getProviderLabel, isCodingCliProviderName } from '@/lib/coding-cli-utils'
 import { isAgentChatProviderName, getAgentChatProviderConfig } from '@/lib/agent-chat-utils'
-import { normalizeFreshcodexModel, resolveFreshAgentType } from '@/lib/fresh-agent-registry'
+import { normalizeFreshAgentEffort, normalizeFreshcodexModel, resolveFreshAgentType } from '@/lib/fresh-agent-registry'
 import { clearDraft } from '@/lib/draft-store'
 import { getTerminalActions } from '@/lib/pane-action-registry'
 import { buildPaneRefreshTarget } from '@/lib/pane-utils'
@@ -628,7 +628,10 @@ function PickerWrapper({
         sandbox: freshAgentType.runtimeProvider === 'codex'
           ? settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.sandbox
           : undefined,
-        effort: normalizeAgentChatEffortOverride(providerSettings?.effort) ?? freshAgentType.defaultEffort,
+        effort: normalizeFreshAgentEffort(
+          freshAgentType.runtimeProvider,
+          normalizeAgentChatEffortOverride(providerSettings?.effort),
+        ) ?? freshAgentType.defaultEffort,
         plugins: freshAgentType.runtimeProvider === 'claude' ? agentChatSettings?.defaultPlugins : undefined,
         ...(cwd ? { initialCwd: cwd } : {}),
       }

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -724,7 +724,8 @@ function PickerWrapper({
 
     // Save the selected directory for the provider
     const agentConfig = getAgentChatProviderConfig(providerType)
-    const settingsKey = (agentConfig ? agentConfig.codingCliProvider : providerType) as CodingCliProviderName
+    const freshAgentConfig = resolveFreshAgentType(providerType)
+    const settingsKey = (agentConfig?.codingCliProvider ?? freshAgentConfig?.runtimeProvider ?? providerType) as CodingCliProviderName
     const existingProviderSettings = settings?.codingCli?.providers?.[settingsKey] || {}
     const patch = {
       codingCli: { providers: { [settingsKey]: { ...existingProviderSettings, cwd } } },
@@ -739,8 +740,9 @@ function PickerWrapper({
   if (step.step === 'directory') {
     const providerType = step.providerType
     const agentConfig = getAgentChatProviderConfig(providerType)
-    const providerLabel = agentConfig ? agentConfig.label : getProviderLabel(providerType, extensionEntries)
-    const settingsKey = (agentConfig ? agentConfig.codingCliProvider : providerType) as CodingCliProviderName
+    const freshAgentConfig = resolveFreshAgentType(providerType)
+    const providerLabel = agentConfig ? agentConfig.label : (freshAgentConfig?.label ?? getProviderLabel(providerType, extensionEntries))
+    const settingsKey = (agentConfig?.codingCliProvider ?? freshAgentConfig?.runtimeProvider ?? providerType) as CodingCliProviderName
     const globalDefault = settings?.codingCli?.providers?.[settingsKey]?.cwd
     const defaultCwd = tabPref.defaultCwd ?? globalDefault
     return (

--- a/src/lib/fresh-agent-models.ts
+++ b/src/lib/fresh-agent-models.ts
@@ -11,4 +11,3 @@ export {
   type FreshAgentModelOption,
   type FreshAgentThinkingOption,
 } from '@shared/fresh-agent-models'
-

--- a/src/lib/fresh-agent-models.ts
+++ b/src/lib/fresh-agent-models.ts
@@ -1,0 +1,14 @@
+export {
+  FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE,
+  FRESHCODEX_DEFAULT_EFFORT,
+  FRESHCODEX_DEFAULT_MODEL,
+  FRESHCODEX_MODEL_OPTIONS,
+  getFreshAgentThinkingOptions,
+  normalizeFreshAgentEffort,
+  normalizeFreshAgentModel,
+  normalizeFreshcodexModel,
+  resolveFreshAgentModelOption,
+  type FreshAgentModelOption,
+  type FreshAgentThinkingOption,
+} from '@shared/fresh-agent-models'
+

--- a/src/lib/fresh-agent-registry.ts
+++ b/src/lib/fresh-agent-registry.ts
@@ -9,6 +9,20 @@ import {
   KilroyIcon,
   OpencodeIcon,
 } from '@/components/icons/provider-icons'
+import {
+  FRESHCODEX_DEFAULT_EFFORT,
+  FRESHCODEX_DEFAULT_MODEL,
+} from '@/lib/fresh-agent-models'
+export {
+  FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE,
+  FRESHCODEX_DEFAULT_EFFORT,
+  FRESHCODEX_DEFAULT_MODEL,
+  FRESHCODEX_MODEL_OPTIONS,
+  getFreshAgentThinkingOptions,
+  normalizeFreshAgentEffort,
+  normalizeFreshAgentModel,
+  normalizeFreshcodexModel,
+} from '@/lib/fresh-agent-models'
 
 export type FreshAgentRegistryEntry = {
   sessionType: FreshAgentSessionType
@@ -31,54 +45,6 @@ export type FreshAgentRegistryEntry = {
   hidden?: boolean
   disabled?: boolean
   featureFlag?: string
-}
-
-export const FRESHCODEX_DEFAULT_MODEL = 'gpt-5.5'
-export const FRESHCODEX_DEFAULT_EFFORT = 'xhigh'
-export const FRESHCODEX_MODEL_OPTIONS = [
-  { value: 'gpt-5.5', label: 'GPT-5.5' },
-  { value: 'gpt-5.4-flash', label: 'GPT-5.4 Flash' },
-  { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
-] as const
-export const FRESH_AGENT_THINKING_OPTIONS_BY_PROVIDER = {
-  claude: [
-    { value: 'low', label: 'Low' },
-    { value: 'medium', label: 'Medium' },
-    { value: 'high', label: 'High' },
-    { value: 'max', label: 'Maximum' },
-  ],
-  codex: [
-    { value: 'none', label: 'None' },
-    { value: 'minimal', label: 'Minimal' },
-    { value: 'low', label: 'Low' },
-    { value: 'medium', label: 'Medium' },
-    { value: 'high', label: 'High' },
-    { value: 'xhigh', label: 'Maximum' },
-  ],
-  opencode: [
-    { value: 'low', label: 'Low' },
-    { value: 'medium', label: 'Medium' },
-    { value: 'high', label: 'High' },
-    { value: 'max', label: 'Maximum' },
-  ],
-} as const
-
-export function normalizeFreshcodexModel(model: string | undefined): string {
-  if (model && FRESHCODEX_MODEL_OPTIONS.some((option) => option.value === model)) {
-    return model
-  }
-  return FRESHCODEX_DEFAULT_MODEL
-}
-
-export function normalizeFreshAgentEffort(provider: FreshAgentRuntimeProvider, effort: string | undefined): string | undefined {
-  const options = FRESH_AGENT_THINKING_OPTIONS_BY_PROVIDER[provider] ?? []
-  if (effort && options.some((option) => option.value === effort)) {
-    return effort
-  }
-  if (provider === 'codex') return FRESHCODEX_DEFAULT_EFFORT
-  if (provider === 'claude') return 'max'
-  if (provider === 'opencode') return 'max'
-  return undefined
 }
 
 export const FRESH_AGENT_REGISTRY: readonly FreshAgentRegistryEntry[] = [

--- a/src/lib/fresh-agent-registry.ts
+++ b/src/lib/fresh-agent-registry.ts
@@ -33,6 +33,20 @@ export type FreshAgentRegistryEntry = {
   featureFlag?: string
 }
 
+export const FRESHCODEX_DEFAULT_MODEL = 'gpt-5.5'
+export const FRESHCODEX_DEFAULT_EFFORT = 'xhigh'
+export const FRESHCODEX_MODEL_OPTIONS = [
+  { value: 'gpt-5.5', label: 'GPT-5.5' },
+  { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
+] as const
+
+export function normalizeFreshcodexModel(model: string | undefined): string {
+  if (model && FRESHCODEX_MODEL_OPTIONS.some((option) => option.value === model)) {
+    return model
+  }
+  return FRESHCODEX_DEFAULT_MODEL
+}
+
 export const FRESH_AGENT_REGISTRY: readonly FreshAgentRegistryEntry[] = [
   {
     sessionType: 'freshclaude',
@@ -41,7 +55,7 @@ export const FRESH_AGENT_REGISTRY: readonly FreshAgentRegistryEntry[] = [
     icon: FreshclaudeIcon,
     defaultModel: 'claude-opus-4-6',
     defaultPermissionMode: 'bypassPermissions',
-    defaultEffort: 'high',
+    defaultEffort: 'max',
     settingsVisibility: {
       model: true,
       permissionMode: true,
@@ -57,14 +71,14 @@ export const FRESH_AGENT_REGISTRY: readonly FreshAgentRegistryEntry[] = [
     runtimeProvider: 'codex',
     label: 'Freshcodex',
     icon: CodexIcon,
-    defaultModel: 'gpt-5-codex',
+    defaultModel: FRESHCODEX_DEFAULT_MODEL,
     defaultPermissionMode: 'on-request',
-    defaultEffort: 'high',
+    defaultEffort: FRESHCODEX_DEFAULT_EFFORT,
     settingsVisibility: {
       model: true,
       permissionMode: true,
       effort: true,
-      thinking: false,
+      thinking: true,
       tools: true,
       timecodes: true,
     },
@@ -78,7 +92,7 @@ export const FRESH_AGENT_REGISTRY: readonly FreshAgentRegistryEntry[] = [
     icon: KilroyIcon,
     defaultModel: 'claude-opus-4-6',
     defaultPermissionMode: 'bypassPermissions',
-    defaultEffort: 'high',
+    defaultEffort: 'max',
     settingsVisibility: {
       model: true,
       permissionMode: true,
@@ -99,12 +113,12 @@ export const FRESH_AGENT_REGISTRY: readonly FreshAgentRegistryEntry[] = [
     icon: OpencodeIcon,
     defaultModel: 'opencode',
     defaultPermissionMode: 'bypassPermissions',
-    defaultEffort: 'high',
+    defaultEffort: 'max',
     settingsVisibility: {
       model: true,
       permissionMode: true,
       effort: true,
-      thinking: false,
+      thinking: true,
       tools: true,
       timecodes: true,
     },

--- a/src/lib/fresh-agent-registry.ts
+++ b/src/lib/fresh-agent-registry.ts
@@ -37,6 +37,7 @@ export const FRESHCODEX_DEFAULT_MODEL = 'gpt-5.5'
 export const FRESHCODEX_DEFAULT_EFFORT = 'xhigh'
 export const FRESHCODEX_MODEL_OPTIONS = [
   { value: 'gpt-5.5', label: 'GPT-5.5' },
+  { value: 'gpt-5.4-flash', label: 'GPT-5.4 Flash' },
   { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
 ] as const
 

--- a/src/lib/fresh-agent-registry.ts
+++ b/src/lib/fresh-agent-registry.ts
@@ -40,12 +40,45 @@ export const FRESHCODEX_MODEL_OPTIONS = [
   { value: 'gpt-5.4-flash', label: 'GPT-5.4 Flash' },
   { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
 ] as const
+export const FRESH_AGENT_THINKING_OPTIONS_BY_PROVIDER = {
+  claude: [
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High' },
+    { value: 'max', label: 'Maximum' },
+  ],
+  codex: [
+    { value: 'none', label: 'None' },
+    { value: 'minimal', label: 'Minimal' },
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High' },
+    { value: 'xhigh', label: 'Maximum' },
+  ],
+  opencode: [
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High' },
+    { value: 'max', label: 'Maximum' },
+  ],
+} as const
 
 export function normalizeFreshcodexModel(model: string | undefined): string {
   if (model && FRESHCODEX_MODEL_OPTIONS.some((option) => option.value === model)) {
     return model
   }
   return FRESHCODEX_DEFAULT_MODEL
+}
+
+export function normalizeFreshAgentEffort(provider: FreshAgentRuntimeProvider, effort: string | undefined): string | undefined {
+  const options = FRESH_AGENT_THINKING_OPTIONS_BY_PROVIDER[provider] ?? []
+  if (effort && options.some((option) => option.value === effort)) {
+    return effort
+  }
+  if (provider === 'codex') return FRESHCODEX_DEFAULT_EFFORT
+  if (provider === 'claude') return 'max'
+  if (provider === 'opencode') return 'max'
+  return undefined
 }
 
 export const FRESH_AGENT_REGISTRY: readonly FreshAgentRegistryEntry[] = [

--- a/src/store/paneTreeValidation.ts
+++ b/src/store/paneTreeValidation.ts
@@ -1,5 +1,7 @@
 import { isAgentChatModelSelection, normalizeAgentChatEffortOverride, type PaneNode } from './paneTypes'
 import { CodexDurabilityRefSchema } from '@shared/codex-durability'
+import { getFreshAgentThinkingOptions, normalizeFreshAgentModel } from '@/lib/fresh-agent-models'
+import { isFreshAgentSessionType, resolveFreshAgentRuntimeProvider } from '@shared/fresh-agent'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object'
@@ -60,18 +62,26 @@ function isPaneContentShape(content: unknown): boolean {
     case 'picker':
       return true
     case 'fresh-agent': {
-      const isFreshAgentEffortValid = content.effort === undefined
-        || (
-          content.provider === 'codex'
-            ? (content.effort === 'none' || content.effort === 'minimal' || content.effort === 'low'
-              || content.effort === 'medium' || content.effort === 'high' || content.effort === 'xhigh')
-            : (content.effort === 'low' || content.effort === 'medium' || content.effort === 'high' || content.effort === 'max')
+      const sessionType = isFreshAgentSessionType(content.sessionType) ? content.sessionType : undefined
+      const runtimeProvider = sessionType ? resolveFreshAgentRuntimeProvider(sessionType) : undefined
+      const providerValid = typeof content.provider === 'string' && runtimeProvider === content.provider
+      const model = sessionType && runtimeProvider && providerValid
+        ? normalizeFreshAgentModel(
+          sessionType,
+          runtimeProvider,
+          typeof content.model === 'string' ? content.model : undefined,
         )
+        : undefined
+      const thinkingOptions = sessionType && runtimeProvider && providerValid
+        ? getFreshAgentThinkingOptions(sessionType, runtimeProvider, model)
+        : []
+      const isFreshAgentEffortValid = content.effort === undefined
+        || thinkingOptions.some((option) => option.value === content.effort)
       const hasSessionRef = content.sessionRef !== undefined
         && (typeof content.sessionRef === 'object' || !!(content.sessionRef as object))
       const hasRestoreError = content.restoreError !== undefined
-      return typeof content.sessionType === 'string'
-        && typeof content.provider === 'string'
+      return !!sessionType
+        && providerValid
         && typeof content.createRequestId === 'string'
         && typeof content.status === 'string'
         && isOptionalString(content.sessionId)

--- a/src/store/paneTreeValidation.ts
+++ b/src/store/paneTreeValidation.ts
@@ -60,12 +60,13 @@ function isPaneContentShape(content: unknown): boolean {
     case 'picker':
       return true
     case 'fresh-agent': {
-      const isFreshAgentEffortValid = content.provider === 'claude'
-        ? (content.effort === undefined || (typeof content.effort === 'string' && content.effort.length > 0))
-        : (content.effort === undefined
-          || content.effort === 'none' || content.effort === 'minimal' || content.effort === 'low'
-          || content.effort === 'medium' || content.effort === 'high' || content.effort === 'xhigh'
-          || content.effort === 'max')
+      const isFreshAgentEffortValid = content.effort === undefined
+        || (
+          content.provider === 'codex'
+            ? (content.effort === 'none' || content.effort === 'minimal' || content.effort === 'low'
+              || content.effort === 'medium' || content.effort === 'high' || content.effort === 'xhigh')
+            : (content.effort === 'low' || content.effort === 'medium' || content.effort === 'high' || content.effort === 'max')
+        )
       const hasSessionRef = content.sessionRef !== undefined
         && (typeof content.sessionRef === 'object' || !!(content.sessionRef as object))
       const hasRestoreError = content.restoreError !== undefined

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -3,6 +3,13 @@ import { render, screen } from '@testing-library/react'
 import { FreshAgentTranscript } from '@/components/fresh-agent/FreshAgentTranscript'
 
 describe('FreshAgentTranscript', () => {
+  it('renders a blank transcript when there are no turns', () => {
+    const { container } = render(<FreshAgentTranscript turns={[]} />)
+
+    expect(screen.queryByText('No transcript available yet.')).not.toBeInTheDocument()
+    expect(container.querySelector('[data-context="fresh-agent-transcript"]')).toBeEmptyDOMElement()
+  })
+
   it('renders normalized text turns', () => {
     render(
       <FreshAgentTranscript

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -306,6 +306,7 @@ describe('FreshAgentView', () => {
     wsMock.send.mockClear()
 
     expect(screen.getByRole('radio', { name: 'GPT-5.5' })).toBeChecked()
+    expect(screen.getByRole('radio', { name: 'GPT-5.4 Flash' })).not.toBeChecked()
     expect(screen.getByRole('combobox', { name: 'Thinking level' })).toHaveValue('xhigh')
     fireEvent.click(screen.getByRole('radio', { name: 'GPT-5.3 Codex Spark' }))
     await waitFor(() => {

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -256,6 +256,8 @@ describe('FreshAgentView', () => {
       requestId: 'req-create',
       sessionType: 'freshcodex',
       provider: 'codex',
+      model: 'gpt-5.5',
+      effort: 'xhigh',
     }))
 
     const onMessage = wsMock.onMessage.mock.calls[0]?.[0]
@@ -303,11 +305,11 @@ describe('FreshAgentView', () => {
 
     wsMock.send.mockClear()
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Model' }), {
-      target: { value: 'gpt-5.4-mini' },
-    })
+    expect(screen.getByRole('radio', { name: 'GPT-5.5' })).toBeChecked()
+    expect(screen.getByRole('combobox', { name: 'Thinking level' })).toHaveValue('xhigh')
+    fireEvent.click(screen.getByRole('radio', { name: 'GPT-5.3 Codex Spark' }))
     await waitFor(() => {
-      expect(screen.getByRole('combobox', { name: 'Model' })).toHaveValue('gpt-5.4-mini')
+      expect(screen.getByRole('radio', { name: 'GPT-5.3 Codex Spark' })).toBeChecked()
     })
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
@@ -323,7 +325,8 @@ describe('FreshAgentView', () => {
       text: 'Ship it',
       settings: {
         cwd: '/repo',
-        model: 'gpt-5.4-mini',
+        model: 'gpt-5.3-codex-spark',
+        effort: 'xhigh',
       },
     })
 
@@ -345,7 +348,7 @@ describe('FreshAgentView', () => {
     })
   })
 
-  it('keeps a configured custom Freshcodex model selectable', async () => {
+  it('normalizes obsolete Freshcodex models to the default radio option', async () => {
     const store = createStore()
     render(
       <Provider store={store}>
@@ -369,8 +372,8 @@ describe('FreshAgentView', () => {
       expect(screen.getByText('Codex summary')).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('combobox', { name: 'Model' })).toHaveValue('custom-codex-model')
-    expect(screen.getByRole('option', { name: 'custom-codex-model' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'GPT-5.5' })).toBeChecked()
+    expect(screen.queryByRole('radio', { name: 'custom-codex-model' })).not.toBeInTheDocument()
   })
 
   it('switches the pane to the forked Freshcodex thread when the server reports fork success', async () => {
@@ -608,6 +611,7 @@ describe('FreshAgentView', () => {
         sessionType: 'freshclaude',
         provider: 'claude',
         resumeSessionId: durableSessionId,
+        effort: 'max',
       }))
     })
   })

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -308,6 +308,7 @@ describe('FreshAgentView', () => {
     expect(screen.getByRole('radio', { name: 'GPT-5.5' })).toBeChecked()
     expect(screen.getByRole('radio', { name: 'GPT-5.4 Flash' })).not.toBeChecked()
     expect(screen.getByRole('combobox', { name: 'Thinking level' })).toHaveValue('xhigh')
+    expect(screen.getByRole('option', { name: 'xhigh' })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('radio', { name: 'GPT-5.3 Codex Spark' }))
     await waitFor(() => {
       expect(screen.getByRole('radio', { name: 'GPT-5.3 Codex Spark' })).toBeChecked()
@@ -347,6 +348,58 @@ describe('FreshAgentView', () => {
       sessionType: 'freshcodex',
       provider: 'codex',
     })
+  })
+
+  it('uses the selected Freshcodex model thinking substrings verbatim', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-flash',
+        sessionId: 'thread-flash',
+        status: 'idle',
+        model: 'gpt-5.5',
+        effort: 'xhigh',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex summary')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('radio', { name: 'GPT-5.4 Flash' }))
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: 'GPT-5.4 Flash' })).toBeChecked()
+    })
+
+    const thinking = screen.getByRole('combobox', { name: 'Thinking level' })
+    expect(thinking).toHaveValue('high')
+    expect(screen.queryByRole('option', { name: 'xhigh' })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'high' })).toBeInTheDocument()
+
+    wsMock.send.mockClear()
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'reply ok' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.send',
+      settings: expect.objectContaining({
+        model: 'gpt-5.4-flash',
+        effort: 'high',
+      }),
+    }))
   })
 
   it('normalizes obsolete Freshcodex models to the default radio option', async () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -10,6 +10,7 @@ import { FreshAgentView } from '@/components/fresh-agent/FreshAgentView'
 import { initLayout } from '@/store/panesSlice'
 import { useAppSelector } from '@/store/hooks'
 import { sessionInit, setSessionStatus } from '@/store/agentChatSlice'
+import type { PaneNode } from '@/store/paneTypes'
 
 const wsMock = vi.hoisted(() => ({
   send: vi.fn(),
@@ -275,20 +276,24 @@ describe('FreshAgentView', () => {
 
   it('sends, interrupts, and forks through fresh-agent WS actions when the capability is available', async () => {
     const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-2',
+        sessionId: 'thread-1',
+        status: 'idle',
+        initialCwd: '/repo',
+        model: 'gpt-5-codex',
+      },
+    }))
+
     render(
       <Provider store={store}>
-        <FreshAgentView
-          tabId="tab-1"
-          paneId="pane-1"
-          paneContent={{
-            kind: 'fresh-agent',
-            sessionType: 'freshcodex',
-            provider: 'codex',
-            createRequestId: 'req-2',
-            sessionId: 'thread-1',
-            status: 'running',
-          }}
-        />
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
       </Provider>,
     )
 
@@ -297,6 +302,13 @@ describe('FreshAgentView', () => {
     })
 
     wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Model' }), {
+      target: { value: 'gpt-5.4-mini' },
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: 'Model' })).toHaveValue('gpt-5.4-mini')
+    })
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
       target: { value: 'Ship it' },
@@ -309,6 +321,10 @@ describe('FreshAgentView', () => {
       sessionType: 'freshcodex',
       provider: 'codex',
       text: 'Ship it',
+      settings: {
+        cwd: '/repo',
+        model: 'gpt-5.4-mini',
+      },
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'Interrupt' }))
@@ -322,10 +338,155 @@ describe('FreshAgentView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Fork' }))
     expect(wsMock.send).toHaveBeenCalledWith({
       type: 'freshAgent.fork',
+      requestId: 'req-2',
       sessionId: 'thread-1',
       sessionType: 'freshcodex',
       provider: 'codex',
     })
+  })
+
+  it('keeps a configured custom Freshcodex model selectable', async () => {
+    const store = createStore()
+    render(
+      <Provider store={store}>
+        <FreshAgentView
+          tabId="tab-1"
+          paneId="pane-1"
+          paneContent={{
+            kind: 'fresh-agent',
+            sessionType: 'freshcodex',
+            provider: 'codex',
+            createRequestId: 'req-custom-model',
+            sessionId: 'thread-1',
+            status: 'idle',
+            model: 'custom-codex-model',
+          }}
+        />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex summary')).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('combobox', { name: 'Model' })).toHaveValue('custom-codex-model')
+    expect(screen.getByRole('option', { name: 'custom-codex-model' })).toBeInTheDocument()
+  })
+
+  it('switches the pane to the forked Freshcodex thread when the server reports fork success', async () => {
+    const store = createStore()
+    let onMessage: ((message: Record<string, unknown>) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler) => {
+      onMessage = handler
+      return () => {}
+    })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-2',
+        sessionId: 'thread-1',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(onMessage).toBeTypeOf('function')
+    })
+
+    act(() => {
+      onMessage?.({
+        type: 'freshAgent.forked',
+        requestId: 'req-2',
+        parentSessionId: 'thread-1',
+        sessionId: 'thread-forked',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        runtimeProvider: 'codex',
+      })
+    })
+
+    await waitFor(() => {
+      expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledWith('freshcodex', 'codex', 'thread-forked', expect.any(Object))
+    })
+    const layout = store.getState().panes.layouts['tab-1']
+    expect(layout?.type).toBe('leaf')
+    if (layout?.type !== 'leaf' || layout.content.kind !== 'fresh-agent') {
+      throw new Error('Expected fresh-agent leaf')
+    }
+    expect(layout.content.sessionId).toBe('thread-forked')
+    expect(layout.content.sessionRef).toEqual({ provider: 'codex', sessionId: 'thread-forked' })
+    expect(layout.content.createRequestId).not.toBe('req-2')
+    expect(wsMock.send).toHaveBeenCalledWith({
+      type: 'freshAgent.kill',
+      sessionId: 'thread-1',
+      sessionType: 'freshcodex',
+      provider: 'codex',
+    })
+  })
+
+  it('ignores Freshcodex fork responses for a different pane request', async () => {
+    const store = createStore()
+    let onMessage: ((message: Record<string, unknown>) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler) => {
+      onMessage = handler
+      return () => {}
+    })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-this-pane',
+        sessionId: 'thread-1',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(onMessage).toBeTypeOf('function')
+    })
+    wsMock.send.mockClear()
+
+    act(() => {
+      onMessage?.({
+        type: 'freshAgent.forked',
+        requestId: 'req-other-pane',
+        parentSessionId: 'thread-1',
+        sessionId: 'thread-forked',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        runtimeProvider: 'codex',
+      })
+    })
+
+    const layout = store.getState().panes.layouts['tab-1']
+    expect(layout?.type).toBe('leaf')
+    if (layout?.type !== 'leaf' || layout.content.kind !== 'fresh-agent') {
+      throw new Error('Expected fresh-agent leaf')
+    }
+    expect(layout.content.sessionId).toBe('thread-1')
+    expect(wsMock.send).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.kill',
+      sessionId: 'thread-1',
+    }))
   })
 
   it('keeps an established freshclaude pane interactive after remount when snapshot loading is unavailable', async () => {
@@ -524,8 +685,10 @@ describe('FreshAgentView', () => {
     expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
       type: 'freshAgent.create',
       requestId: 'req-sessionref-only',
+      resumeSessionId: 'codex-thread-recover',
       sessionRef: { provider: 'codex', sessionId: 'codex-thread-recover' },
     }))
+    expect(apiMock.getFreshAgentThreadSnapshot).not.toHaveBeenCalled()
 
     const onMessage = wsMock.onMessage.mock.calls[0]?.[0]
     onMessage({
@@ -546,6 +709,46 @@ describe('FreshAgentView', () => {
       expect(leaf.content.status).toBe('connected')
     })
     unmount()
+  })
+
+  it('surfaces a missing Freshcodex rollout as a restore error instead of replacing the thread', async () => {
+    const store = createStore()
+    apiMock.getFreshAgentThreadSnapshot.mockRejectedValueOnce(new Error('no rollout found for thread id codex-thread-missing'))
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-missing-rollout',
+        status: 'idle',
+        sessionId: 'codex-thread-missing',
+        resumeSessionId: 'codex-thread-missing',
+        sessionRef: { provider: 'codex', sessionId: 'codex-thread-missing' },
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      const leaf = store.getState().panes.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>
+      expect(leaf.content.kind).toBe('fresh-agent')
+      if (leaf.content.kind === 'fresh-agent') {
+        expect(leaf.content.restoreError).toEqual({ code: 'RESTORE_UNAVAILABLE', reason: 'durable_artifact_missing' })
+        expect(leaf.content.resumeSessionId).toBe('codex-thread-missing')
+        expect(leaf.content.sessionRef).toBeUndefined()
+        expect(leaf.content.status).toBe('idle')
+      }
+    })
+    expect(wsMock.send).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.create',
+      requestId: expect.not.stringMatching(/^req-missing-rollout$/),
+    }))
   })
 
   it('clears stale restoreError when a valid sessionRef appears', async () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -377,6 +377,62 @@ describe('FreshAgentView', () => {
     expect(screen.queryByRole('radio', { name: 'custom-codex-model' })).not.toBeInTheDocument()
   })
 
+  it('normalizes stale Freshcodex thinking effort before create and send', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-stale-effort',
+        status: 'creating',
+        effort: 'max',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.create',
+      requestId: 'req-stale-effort',
+      effort: 'xhigh',
+    }))
+
+    const onMessage = wsMock.onMessage.mock.calls[0]?.[0]
+    expect(onMessage).toBeTypeOf('function')
+    act(() => {
+      onMessage({
+        type: 'freshAgent.created',
+        requestId: 'req-stale-effort',
+        sessionId: 'thread-stale-effort',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        runtimeProvider: 'codex',
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: 'Thinking level' })).toHaveValue('xhigh')
+    })
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'reply ok' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.send',
+      settings: expect.objectContaining({ effort: 'xhigh' }),
+    }))
+  })
+
   it('switches the pane to the forked Freshcodex thread when the server reports fork success', async () => {
     const store = createStore()
     let onMessage: ((message: Record<string, unknown>) => void) | undefined

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -1751,15 +1751,15 @@ describe('PaneContainer', () => {
       }))
     })
 
-    it('normalizes stale Freshcodex effort from provider settings when creating a pane', async () => {
+    it('normalizes stale Freshcodex effort from provider settings against the active model', async () => {
       const node = createPickerNode('pane-1')
       const store = createStoreWithClaude(
         node,
         undefined,
-        undefined,
+        { codex: { model: 'gpt-5.4-flash' } },
         ['claude', 'codex'],
         { claude: true, codex: true },
-        { freshcodex: { effort: 'max' } },
+        { freshcodex: { effort: 'xhigh' } },
       )
       mockApiPost.mockResolvedValueOnce({ valid: true, resolvedPath: '/home/user/freshcodex-project' })
 
@@ -1780,7 +1780,8 @@ describe('PaneContainer', () => {
         const paneContent = (state.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>).content
         expect(paneContent.kind).toBe('fresh-agent')
         if (paneContent.kind === 'fresh-agent') {
-          expect(paneContent.effort).toBe('xhigh')
+          expect(paneContent.model).toBe('gpt-5.4-flash')
+          expect(paneContent.effort).toBe('high')
         }
       })
     })

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -1734,6 +1734,8 @@ describe('PaneContainer', () => {
           expect(paneContent.sessionType).toBe('freshcodex')
           expect(paneContent.provider).toBe('codex')
           expect(paneContent.initialCwd).toBe('/home/user/freshcodex-project')
+          expect(paneContent.model).toBe('gpt-5.5')
+          expect(paneContent.effort).toBe('xhigh')
         }
       })
 

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -1585,7 +1585,10 @@ describe('PaneContainer', () => {
 
     function createStoreWithClaude(
       node: PaneNode,
-      providerSettings?: { cwd?: string; permissionMode?: 'default' | 'plan' | 'acceptEdits' | 'bypassPermissions' }
+      providerSettings?: { cwd?: string; permissionMode?: 'default' | 'plan' | 'acceptEdits' | 'bypassPermissions' },
+      providerSettingsByName?: Record<string, { cwd?: string; permissionMode?: string; model?: string }>,
+      enabledProviders: string[] = ['claude'],
+      availableClis: Record<string, boolean> = { claude: true },
     ) {
       return configureStore({
         reducer: {
@@ -1617,7 +1620,7 @@ describe('PaneContainer', () => {
           connection: {
             status: 'ready' as const,
             platform: 'linux',
-            availableClis: { claude: true },
+            availableClis,
           },
           settings: {
             settings: {
@@ -1635,8 +1638,8 @@ describe('PaneContainer', () => {
               sidebar: { sortMode: 'activity' as const, showProjectBadges: true, width: 288, collapsed: false },
               panes: { defaultNewPane: 'ask' as const },
               codingCli: {
-                enabledProviders: ['claude'] as any[],
-                providers: providerSettings ? { claude: providerSettings } : {},
+                enabledProviders: enabledProviders as any[],
+                providers: providerSettingsByName ?? (providerSettings ? { claude: providerSettings } : {}),
               },
               logging: { debug: false },
             },
@@ -1704,6 +1707,60 @@ describe('PaneContainer', () => {
         codingCli: { providers: { claude: { permissionMode: 'plan', cwd: '/home/user/new-project' } } },
       })
       expect(mockApiPatch).not.toHaveBeenCalledWith('/api/settings', expect.anything())
+    })
+
+    it('persists Freshcodex directory under the Codex runtime provider key', async () => {
+      const node = createPickerNode('pane-1')
+      const store = createStoreWithClaude(node, undefined, undefined, ['claude', 'codex'], { claude: true, codex: true })
+      mockApiPost.mockResolvedValueOnce({ valid: true, resolvedPath: '/home/user/freshcodex-project' })
+
+      renderWithStore(
+        <PaneContainer tabId="tab-1" node={node} />,
+        store
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Freshcodex' }))
+      fireEvent.transitionEnd(getPickerContainer())
+
+      const input = screen.getByLabelText('Starting directory for Freshcodex')
+      fireEvent.change(input, { target: { value: '/home/user/freshcodex-project' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => {
+        const state = store.getState().panes
+        const paneContent = (state.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>).content
+        expect(paneContent.kind).toBe('fresh-agent')
+        if (paneContent.kind === 'fresh-agent') {
+          expect(paneContent.sessionType).toBe('freshcodex')
+          expect(paneContent.provider).toBe('codex')
+          expect(paneContent.initialCwd).toBe('/home/user/freshcodex-project')
+        }
+      })
+
+      expect(saveServerSettingsPatchSpy).toHaveBeenCalledWith({
+        codingCli: { providers: { codex: { cwd: '/home/user/freshcodex-project' } } },
+      })
+      expect(saveServerSettingsPatchSpy).not.toHaveBeenCalledWith(expect.objectContaining({
+        codingCli: { providers: expect.objectContaining({ freshcodex: expect.anything() }) },
+      }))
+    })
+
+    it('preloads Freshcodex directory from the Codex runtime provider key', () => {
+      const node = createPickerNode('pane-1')
+      const store = createStoreWithClaude(node, undefined, {
+        codex: { cwd: '/home/user/saved-codex-cwd' },
+        freshcodex: { cwd: '/home/user/wrong-freshcodex-cwd' },
+      }, ['claude', 'codex'], { claude: true, codex: true })
+
+      renderWithStore(
+        <PaneContainer tabId="tab-1" node={node} />,
+        store
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Freshcodex' }))
+      fireEvent.transitionEnd(getPickerContainer())
+
+      expect(screen.getByLabelText('Starting directory for Freshcodex')).toHaveValue('/home/user/saved-codex-cwd')
     })
 
     it('returns to pane type picker when back is clicked in directory picker', () => {

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -1586,9 +1586,10 @@ describe('PaneContainer', () => {
     function createStoreWithClaude(
       node: PaneNode,
       providerSettings?: { cwd?: string; permissionMode?: 'default' | 'plan' | 'acceptEdits' | 'bypassPermissions' },
-      providerSettingsByName?: Record<string, { cwd?: string; permissionMode?: string; model?: string }>,
+      providerSettingsByName?: Record<string, { cwd?: string; permissionMode?: string; model?: string; effort?: string }>,
       enabledProviders: string[] = ['claude'],
       availableClis: Record<string, boolean> = { claude: true },
+      freshAgentProviderSettingsByName?: Record<string, { effort?: string }>,
     ) {
       return configureStore({
         reducer: {
@@ -1640,6 +1641,9 @@ describe('PaneContainer', () => {
               codingCli: {
                 enabledProviders: enabledProviders as any[],
                 providers: providerSettingsByName ?? (providerSettings ? { claude: providerSettings } : {}),
+              },
+              freshAgent: {
+                providers: freshAgentProviderSettingsByName ?? {},
               },
               logging: { debug: false },
             },
@@ -1745,6 +1749,40 @@ describe('PaneContainer', () => {
       expect(saveServerSettingsPatchSpy).not.toHaveBeenCalledWith(expect.objectContaining({
         codingCli: { providers: expect.objectContaining({ freshcodex: expect.anything() }) },
       }))
+    })
+
+    it('normalizes stale Freshcodex effort from provider settings when creating a pane', async () => {
+      const node = createPickerNode('pane-1')
+      const store = createStoreWithClaude(
+        node,
+        undefined,
+        undefined,
+        ['claude', 'codex'],
+        { claude: true, codex: true },
+        { freshcodex: { effort: 'max' } },
+      )
+      mockApiPost.mockResolvedValueOnce({ valid: true, resolvedPath: '/home/user/freshcodex-project' })
+
+      renderWithStore(
+        <PaneContainer tabId="tab-1" node={node} />,
+        store
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Freshcodex' }))
+      fireEvent.transitionEnd(getPickerContainer())
+
+      const input = screen.getByLabelText('Starting directory for Freshcodex')
+      fireEvent.change(input, { target: { value: '/home/user/freshcodex-project' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => {
+        const state = store.getState().panes
+        const paneContent = (state.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>).content
+        expect(paneContent.kind).toBe('fresh-agent')
+        if (paneContent.kind === 'fresh-agent') {
+          expect(paneContent.effort).toBe('xhigh')
+        }
+      })
     })
 
     it('preloads Freshcodex directory from the Codex runtime provider key', () => {

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -984,16 +984,16 @@ describe('CodexAppServerRuntime', () => {
     })).toThrow(/startup reaper blocked startup.*failed to reap 2 ownership record.*ownership-alpha.*ownership-beta/i)
   })
 
-  it('blocks startup when ownership records still belong to live sidecar owners', () => {
+  it('allows startup when ownership records still belong to live sidecar owners', () => {
     expect(() => assertCodexStartupReaperSucceeded({
       reapedOwnershipIds: [],
       ignoredLegacyRecords: [],
       skippedActiveOwnershipIds: ['active-owner'],
       failedOwnershipIds: [],
-    })).toThrow(/startup reaper blocked startup.*active ownership record.*active-owner/i)
+    })).not.toThrow()
   })
 
-  it('reports failed reaps without conflating live active owners', () => {
+  it('reports failed reaps without treating live active owners as fatal', () => {
     let thrown: Error | undefined
 
     try {
@@ -1009,7 +1009,7 @@ describe('CodexAppServerRuntime', () => {
 
     expect(thrown).toBeDefined()
     expect(thrown?.message).toContain('failed to reap 1 ownership record(s): failed-owner')
-    expect(thrown?.message).toContain('active-owner')
+    expect(thrown?.message).not.toContain('active-owner')
   })
 
   it('reports a skipped new-schema ownership record when the owner pid is live', async () => {
@@ -1030,7 +1030,7 @@ describe('CodexAppServerRuntime', () => {
     })
 
     expect(result.skippedActiveOwnershipIds).toContain(ready.ownershipId)
-    expect(() => assertCodexStartupReaperSucceeded(result)).toThrow(new RegExp(ready.ownershipId))
+    expect(() => assertCodexStartupReaperSucceeded(result)).not.toThrow()
     await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
     expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
   })

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -984,27 +984,16 @@ describe('CodexAppServerRuntime', () => {
     })).toThrow(/startup reaper blocked startup.*failed to reap 2 ownership record.*ownership-alpha.*ownership-beta/i)
   })
 
-  it('reports active live sidecar owners separately from failed cleanup', () => {
-    let thrown: Error | undefined
-
-    try {
-      assertCodexStartupReaperSucceeded({
-        reapedOwnershipIds: [],
-        ignoredLegacyRecords: [],
-        skippedActiveOwnershipIds: ['active-owner'],
-        failedOwnershipIds: [],
-      })
-    } catch (error) {
-      thrown = error as Error
-    }
-
-    expect(thrown).toBeDefined()
-    expect(thrown?.message).toContain('still owned by a live Freshell server/process')
-    expect(thrown?.message).toContain('active-owner')
-    expect(thrown?.message).not.toContain('failed to reap 1 ownership record(s): active-owner')
+  it('blocks startup when ownership records still belong to live sidecar owners', () => {
+    expect(() => assertCodexStartupReaperSucceeded({
+      reapedOwnershipIds: [],
+      ignoredLegacyRecords: [],
+      skippedActiveOwnershipIds: ['active-owner'],
+      failedOwnershipIds: [],
+    })).toThrow(/startup reaper blocked startup.*active ownership record.*active-owner/i)
   })
 
-  it('reports mixed active owners and failed reaps without conflating them', () => {
+  it('reports failed reaps without conflating live active owners', () => {
     let thrown: Error | undefined
 
     try {
@@ -1020,10 +1009,10 @@ describe('CodexAppServerRuntime', () => {
 
     expect(thrown).toBeDefined()
     expect(thrown?.message).toContain('failed to reap 1 ownership record(s): failed-owner')
-    expect(thrown?.message).toContain('still owned by a live Freshell server/process: active-owner')
+    expect(thrown?.message).toContain('active-owner')
   })
 
-  it('blocks startup when a new-schema ownership record is skipped because the owner pid is live', async () => {
+  it('reports a skipped new-schema ownership record when the owner pid is live', async () => {
     const metadataDir = await makeTempDir()
     const runtime = createRuntime({
       metadataDir,
@@ -1034,11 +1023,14 @@ describe('CodexAppServerRuntime', () => {
       ownerServerPid: process.pid,
     })
 
-    await expect(runCodexStartupReaper({
+    const result = await reapOrphanedCodexAppServerSidecars({
       metadataDir,
       serverInstanceId: 'srv-current',
       terminateGraceMs: 1,
-    })).rejects.toThrow(new RegExp(ready.ownershipId))
+    })
+
+    expect(result.skippedActiveOwnershipIds).toContain(ready.ownershipId)
+    expect(() => assertCodexStartupReaperSucceeded(result)).toThrow(new RegExp(ready.ownershipId))
     await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
     expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
   })

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -361,7 +361,8 @@ describe('CodexAppServerRuntime', () => {
     const runtime = createRuntime({
       metadataDir,
       serverInstanceId: 'srv-runtime-test',
-      processIdentityReader: async () => {
+      processIdentityReader: async (pid) => {
+        if (pid === process.pid) return readWrapperIdentityForTest(pid)
         identityLookupStarted()
         return identityReleased
       },
@@ -397,6 +398,7 @@ describe('CodexAppServerRuntime', () => {
       startupAttemptLimit: 1,
       startupAttemptTimeoutMs: 500,
       processIdentityReader: async (pid) => {
+        if (pid === process.pid) return readWrapperIdentityForTest(pid)
         identityReadAttempts += 1
         if (identityReadAttempts === 1) {
           return { commandLine: [], cwd: null, startTimeTicks: null }
@@ -1021,6 +1023,7 @@ describe('CodexAppServerRuntime', () => {
     const ready = await runtime.ensureReady()
     await markOwnershipRecordStale(ready.metadataPath, {
       ownerServerPid: process.pid,
+      ownerServerIdentity: await readWrapperIdentityForTest(process.pid),
     })
 
     const result = await reapOrphanedCodexAppServerSidecars({
@@ -1031,6 +1034,35 @@ describe('CodexAppServerRuntime', () => {
 
     expect(result.skippedActiveOwnershipIds).toContain(ready.ownershipId)
     expect(() => assertCodexStartupReaperSucceeded(result)).not.toThrow()
+    await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
+    expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+  })
+
+  it('does not treat a live reused owner pid as active without matching owner identity', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-previous',
+    })
+    const ready = await runtime.ensureReady()
+    await markOwnershipRecordStale(ready.metadataPath, {
+      ownerServerPid: process.pid,
+      ownerServerIdentity: {
+        commandLine: ['different-process'],
+        cwd: '/tmp/different-process',
+        startTimeTicks: 1,
+      },
+    })
+
+    const result = await reapOrphanedCodexAppServerSidecars({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+      terminateGraceMs: 1,
+    })
+
+    expect(result.skippedActiveOwnershipIds).not.toContain(ready.ownershipId)
+    expect(result.failedOwnershipIds).toContain(ready.ownershipId)
+    expect(() => assertCodexStartupReaperSucceeded(result)).toThrow(new RegExp(ready.ownershipId))
     await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
     expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
   })

--- a/test/unit/server/fresh-agent/claude-adapter.test.ts
+++ b/test/unit/server/fresh-agent/claude-adapter.test.ts
@@ -60,4 +60,31 @@ describe('Claude fresh-agent adapter', () => {
     expect(sdkBridge.respondQuestion).toHaveBeenCalledWith('sdk-claude-1', 'question-1', { Proceed: 'Yes' })
     expect(sdkBridge.respondPermission).toHaveBeenCalledWith('sdk-claude-1', 'approval-1', { behavior: 'allow' })
   })
+
+  it('normalizes Freshclaude effort values against the active model', async () => {
+    const sdkBridge = {
+      createSession: vi.fn().mockResolvedValue({ sessionId: 'sdk-claude-1' }),
+    }
+
+    const adapter = createClaudeFreshAgentAdapter({
+      sdkBridge: sdkBridge as any,
+      timelineService: {
+        getSnapshot: vi.fn(),
+        getTimelinePage: vi.fn(),
+        getTurnBody: vi.fn(),
+      } as any,
+    })
+
+    await expect(adapter.create({
+      requestId: 'req-1',
+      sessionType: 'freshclaude',
+      model: 'claude-opus-4-6',
+      effort: 'xhigh',
+    })).resolves.toEqual({ sessionId: 'sdk-claude-1' })
+
+    expect(sdkBridge.createSession).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'claude-opus-4-6',
+      effort: 'max',
+    }))
+  })
 })

--- a/test/unit/server/fresh-agent/codex-adapter.test.ts
+++ b/test/unit/server/fresh-agent/codex-adapter.test.ts
@@ -101,7 +101,7 @@ describe('Codex fresh-agent adapter', () => {
       sessionType: 'freshcodex',
       cwd: '/repo',
       permissionMode: 'on-request',
-      model: 'codex-fixture',
+      model: 'gpt-5.3-codex-spark',
     })).resolves.toEqual({ sessionId: 'thread-new-1', sessionRef: { provider: 'codex', sessionId: 'thread-new-1' } })
 
     await expect(adapter.resume?.({
@@ -110,12 +110,12 @@ describe('Codex fresh-agent adapter', () => {
       resumeSessionId: 'thread-resume-1',
       cwd: '/repo',
       permissionMode: 'never',
-      model: 'codex-fixture',
+      model: 'gpt-5.3-codex-spark',
     })).resolves.toEqual({ sessionId: 'thread-resume-1', sessionRef: { provider: 'codex', sessionId: 'thread-resume-1' } })
 
     expect(runtime.startThread).toHaveBeenCalledWith(expect.objectContaining({
       cwd: '/repo',
-      model: 'codex-fixture',
+      model: 'gpt-5.3-codex-spark',
       approvalPolicy: 'on-request',
     }))
     expect(runtime.startThread).toHaveBeenCalledWith(expect.not.objectContaining({
@@ -124,7 +124,7 @@ describe('Codex fresh-agent adapter', () => {
     expect(runtime.resumeThread).toHaveBeenCalledWith(expect.objectContaining({
       threadId: 'thread-resume-1',
       cwd: '/repo',
-      model: 'codex-fixture',
+      model: 'gpt-5.3-codex-spark',
       approvalPolicy: 'never',
     }))
   })
@@ -342,7 +342,7 @@ describe('Codex fresh-agent adapter', () => {
         requestId: 'req-1',
         sessionType: 'freshcodex',
         cwd: '/repo',
-        model: 'codex-fixture',
+        model: 'gpt-5.3-codex-spark',
         permissionMode: 'never',
         sandbox: 'workspace-write',
       },
@@ -351,14 +351,14 @@ describe('Codex fresh-agent adapter', () => {
     expect(runtime.resumeThread).toHaveBeenCalledWith({
       threadId: 'thread-existing-1',
       cwd: '/repo',
-      model: 'codex-fixture',
+      model: 'gpt-5.3-codex-spark',
       sandbox: 'workspace-write',
       approvalPolicy: 'never',
     })
     expect(runtime.startTurn).toHaveBeenCalledWith(expect.objectContaining({
       threadId: 'thread-existing-1',
       cwd: '/repo',
-      model: 'codex-fixture',
+      model: 'gpt-5.3-codex-spark',
       approvalPolicy: 'never',
       sandboxPolicy: { type: 'workspaceWrite' },
     }))
@@ -391,7 +391,7 @@ describe('Codex fresh-agent adapter', () => {
     })
     await adapter.send?.('thread-new-1', {
       text: 'Use the small model',
-      settings: { model: 'gpt-5.4-mini' },
+      settings: { model: 'gpt-5.4-flash' },
     })
 
     await expect(adapter.getSnapshot?.({
@@ -401,7 +401,7 @@ describe('Codex fresh-agent adapter', () => {
     }, 7)).resolves.toMatchObject({
       turns: [
         { id: 'turn-1' },
-        { id: 'turn-2', model: 'gpt-5.4-mini' },
+        { id: 'turn-2', model: 'gpt-5.4-flash' },
       ],
     })
     const snapshot = await adapter.getSnapshot?.({
@@ -545,7 +545,7 @@ describe('Codex fresh-agent adapter', () => {
       permissionMode: 'on-request',
       sandbox: 'workspace-write',
       effort: 'xhigh',
-      model: 'codex-fixture',
+      model: 'gpt-5.5',
     })
 
     await adapter.send?.('thread-new-1', {
@@ -563,7 +563,7 @@ describe('Codex fresh-agent adapter', () => {
       cwd: '/repo',
       approvalPolicy: 'on-request',
       sandboxPolicy: { type: 'workspaceWrite' },
-      model: 'codex-fixture',
+      model: 'gpt-5.5',
       effort: 'xhigh',
     })
     expect(runtime.interruptTurn).toHaveBeenCalledWith({
@@ -603,7 +603,7 @@ describe('Codex fresh-agent adapter', () => {
     expect(runtime.interruptTurn).toHaveBeenCalledWith({ threadId: 'thread-existing-1', turnId: 'turn-active-1' })
   })
 
-  it('rejects Claude-only Freshcodex effort values before app-server calls', async () => {
+  it('normalizes Freshcodex effort values against the requested model before app-server calls', async () => {
     const runtime = {
       startThread: vi.fn().mockResolvedValue({
         threadId: 'thread-new-1',
@@ -611,7 +611,7 @@ describe('Codex fresh-agent adapter', () => {
       }),
       resumeThread: vi.fn(),
       forkThread: vi.fn(),
-      startTurn: vi.fn(),
+      startTurn: vi.fn().mockResolvedValue({ turnId: 'turn-1' }),
       interruptTurn: vi.fn(),
       readThread: vi.fn(),
       listThreadTurns: vi.fn(),
@@ -622,10 +622,19 @@ describe('Codex fresh-agent adapter', () => {
     await expect(adapter.create({
       requestId: 'req-1',
       sessionType: 'freshcodex',
-      effort: 'max',
-    })).rejects.toThrow('Freshcodex does not support reasoning effort "max"')
-    expect(runtime.startThread).not.toHaveBeenCalled()
-    expect(runtime.startTurn).not.toHaveBeenCalled()
+      model: 'gpt-5.4-flash',
+      effort: 'xhigh',
+    })).resolves.toEqual({ sessionId: 'thread-new-1', sessionRef: { provider: 'codex', sessionId: 'thread-new-1' } })
+
+    await adapter.send?.('thread-new-1', { text: 'reply ok' })
+
+    expect(runtime.startThread).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'gpt-5.4-flash',
+    }))
+    expect(runtime.startTurn).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'gpt-5.4-flash',
+      effort: 'high',
+    }))
   })
 
   it('forks Codex threads with stored runtime settings and excludeTurns', async () => {
@@ -651,7 +660,7 @@ describe('Codex fresh-agent adapter', () => {
       requestId: 'req-1',
       sessionType: 'freshcodex',
       cwd: '/repo',
-      model: 'codex-fixture',
+      model: 'gpt-5.3-codex-spark',
       permissionMode: 'never',
       sandbox: 'read-only',
     })
@@ -663,7 +672,7 @@ describe('Codex fresh-agent adapter', () => {
     expect(runtime.forkThread).toHaveBeenCalledWith({
       threadId: 'thread-new-1',
       cwd: '/repo',
-      model: 'codex-fixture',
+      model: 'gpt-5.3-codex-spark',
       sandbox: 'read-only',
       approvalPolicy: 'never',
       excludeTurns: true,

--- a/test/unit/server/fresh-agent/codex-adapter.test.ts
+++ b/test/unit/server/fresh-agent/codex-adapter.test.ts
@@ -34,6 +34,48 @@ function makeCodexTurn(id: string) {
 }
 
 describe('Codex fresh-agent adapter', () => {
+  it('allocates separate runtimes for fresh Codex threads in different cwd values', async () => {
+    const runtimes = ['/repo/one', '/repo/two'].map((cwd, index) => ({
+      startThread: vi.fn().mockImplementation(async (input) => {
+        if (input.cwd !== cwd) {
+          throw new Error(`runtime ${index + 1} received unexpected cwd ${input.cwd}`)
+        }
+        return {
+          threadId: `thread-${index + 1}`,
+          wsUrl: `ws://127.0.0.1:${43000 + index}`,
+        }
+      }),
+      resumeThread: vi.fn(),
+      readThread: vi.fn(),
+      listThreadTurns: vi.fn(),
+      readThreadTurn: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    }))
+    const runtimeFactory = vi.fn()
+      .mockReturnValueOnce(runtimes[0])
+      .mockReturnValueOnce(runtimes[1])
+    const adapter = createCodexFreshAgentAdapter({ runtimeFactory: runtimeFactory as any })
+
+    await expect(adapter.create({
+      requestId: 'req-1',
+      sessionType: 'freshcodex',
+      cwd: '/repo/one',
+    })).resolves.toMatchObject({ sessionId: 'thread-1' })
+    await expect(adapter.create({
+      requestId: 'req-2',
+      sessionType: 'freshcodex',
+      cwd: '/repo/two',
+    })).resolves.toMatchObject({ sessionId: 'thread-2' })
+
+    expect(runtimeFactory).toHaveBeenCalledTimes(2)
+    expect(runtimes[0].startThread).toHaveBeenCalledWith(expect.objectContaining({ cwd: '/repo/one' }))
+    expect(runtimes[1].startThread).toHaveBeenCalledWith(expect.objectContaining({ cwd: '/repo/two' }))
+
+    await adapter.shutdown?.()
+    expect(runtimes[0].shutdown).toHaveBeenCalledTimes(1)
+    expect(runtimes[1].shutdown).toHaveBeenCalledTimes(1)
+  })
+
   it('starts fresh Codex threads with generated app-server params', async () => {
     const runtime = {
       startThread: vi.fn().mockResolvedValue({
@@ -75,6 +117,9 @@ describe('Codex fresh-agent adapter', () => {
       cwd: '/repo',
       model: 'codex-fixture',
       approvalPolicy: 'on-request',
+    }))
+    expect(runtime.startThread).toHaveBeenCalledWith(expect.not.objectContaining({
+      excludeTurns: expect.anything(),
     }))
     expect(runtime.resumeThread).toHaveBeenCalledWith(expect.objectContaining({
       threadId: 'thread-resume-1',
@@ -137,6 +182,234 @@ describe('Codex fresh-agent adapter', () => {
       turnId: 'turn-1',
       revision: 7,
     })
+  })
+
+  it('reads a just-created Codex thread without turns when includeTurns is not materialized yet', async () => {
+    const runtime = {
+      startThread: vi.fn().mockResolvedValue({
+        threadId: 'thread-empty-1',
+        wsUrl: 'ws://127.0.0.1:43123',
+      }),
+      resumeThread: vi.fn(),
+      readThread: vi.fn()
+        .mockRejectedValueOnce(new Error('Codex app-server thread/read failed: thread thread-empty-1 is not materialized yet; includeTurns is unavailable before first user message'))
+        .mockResolvedValueOnce({
+          thread: makeCodexThread('thread-empty-1'),
+        }),
+      listThreadTurns: vi.fn(),
+      readThreadTurn: vi.fn(),
+    }
+    const adapter = createCodexFreshAgentAdapter({ runtime: runtime as any })
+
+    await adapter.create({
+      requestId: 'req-empty',
+      sessionType: 'freshcodex',
+      cwd: '/repo',
+    })
+
+    await expect(adapter.getSnapshot?.({
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      threadId: 'thread-empty-1',
+    }, 0)).resolves.toMatchObject({
+      threadId: 'thread-empty-1',
+      status: 'idle',
+      turns: [],
+    })
+
+    expect(runtime.readThread).toHaveBeenNthCalledWith(1, { threadId: 'thread-empty-1', includeTurns: true })
+    expect(runtime.readThread).toHaveBeenNthCalledWith(2, { threadId: 'thread-empty-1', includeTurns: false })
+  })
+
+  it('lazily resumes a Codex runtime before reading a persisted thread after server reload', async () => {
+    const runtime = {
+      startThread: vi.fn(),
+      resumeThread: vi.fn().mockResolvedValue({
+        threadId: 'thread-existing-1',
+        wsUrl: 'ws://127.0.0.1:43123',
+      }),
+      readThread: vi.fn().mockResolvedValue({
+        thread: makeCodexThread('thread-existing-1'),
+      }),
+      listThreadTurns: vi.fn().mockResolvedValue({ turns: [], nextCursor: null, revision: 7 }),
+      readThreadTurn: vi.fn().mockResolvedValue(makeCodexTurn('turn-1')),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    }
+    const adapter = createCodexFreshAgentAdapter({ runtimeFactory: vi.fn(() => runtime) as any })
+
+    await expect(adapter.getSnapshot?.({
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      threadId: 'thread-existing-1',
+    }, 7)).resolves.toMatchObject({
+      provider: 'codex',
+      threadId: 'thread-existing-1',
+      revision: 7,
+    })
+
+    expect(runtime.resumeThread).toHaveBeenCalledWith({ threadId: 'thread-existing-1' })
+    expect(runtime.readThread).toHaveBeenCalledWith({ threadId: 'thread-existing-1', includeTurns: true })
+
+    await adapter.shutdown?.()
+    expect(runtime.shutdown).toHaveBeenCalledTimes(1)
+  })
+
+  it('dedupes concurrent lazy runtime resumes for the same persisted thread', async () => {
+    let resolveResume: ((value: { threadId: string; wsUrl: string }) => void) | undefined
+    const resumePromise = new Promise<{ threadId: string; wsUrl: string }>((resolve) => {
+      resolveResume = resolve
+    })
+    const off = vi.fn()
+    const runtime = {
+      startThread: vi.fn(),
+      resumeThread: vi.fn().mockReturnValue(resumePromise),
+      onThreadLifecycle: vi.fn(() => off),
+      readThread: vi.fn().mockResolvedValue({
+        thread: makeCodexThread('thread-existing-1'),
+      }),
+      listThreadTurns: vi.fn(),
+      readThreadTurn: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    }
+    const runtimeFactory = vi.fn(() => runtime)
+    const adapter = createCodexFreshAgentAdapter({ runtimeFactory: runtimeFactory as any })
+
+    const snapshotPromise = adapter.getSnapshot?.({
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      threadId: 'thread-existing-1',
+    }, 7)
+    const subscribePromise = adapter.subscribe?.('thread-existing-1', vi.fn())
+
+    resolveResume?.({ threadId: 'thread-existing-1', wsUrl: 'ws://127.0.0.1:43123' })
+    await Promise.all([snapshotPromise, subscribePromise])
+
+    expect(runtimeFactory).toHaveBeenCalledTimes(1)
+    expect(runtime.resumeThread).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not attach a lazy runtime resume that completes after the thread is killed', async () => {
+    let resolveResume: ((value: { threadId: string; wsUrl: string }) => void) | undefined
+    const resumePromise = new Promise<{ threadId: string; wsUrl: string }>((resolve) => {
+      resolveResume = resolve
+    })
+    const runtime = {
+      startThread: vi.fn(),
+      resumeThread: vi.fn().mockReturnValue(resumePromise),
+      readThread: vi.fn().mockResolvedValue({
+        thread: makeCodexThread('thread-existing-1'),
+      }),
+      listThreadTurns: vi.fn(),
+      readThreadTurn: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    }
+    const adapter = createCodexFreshAgentAdapter({ runtimeFactory: vi.fn(() => runtime) as any })
+
+    const snapshotPromise = adapter.getSnapshot?.({
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      threadId: 'thread-existing-1',
+    }, 7)
+    await Promise.resolve()
+    await adapter.kill?.('thread-existing-1')
+    resolveResume?.({ threadId: 'thread-existing-1', wsUrl: 'ws://127.0.0.1:43123' })
+
+    await expect(snapshotPromise).rejects.toThrow(/resume was cancelled/)
+    expect(runtime.shutdown).toHaveBeenCalledTimes(1)
+    expect(runtime.readThread).not.toHaveBeenCalled()
+  })
+
+  it('lazily resumes a Codex runtime with send settings before starting a turn after server reload', async () => {
+    const runtime = {
+      startThread: vi.fn(),
+      resumeThread: vi.fn().mockResolvedValue({
+        threadId: 'thread-existing-1',
+        wsUrl: 'ws://127.0.0.1:43123',
+      }),
+      forkThread: vi.fn(),
+      startTurn: vi.fn().mockResolvedValue({ turnId: 'turn-active-1' }),
+      interruptTurn: vi.fn(),
+      readThread: vi.fn(),
+      listThreadTurns: vi.fn(),
+      readThreadTurn: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    }
+    const adapter = createCodexFreshAgentAdapter({ runtimeFactory: vi.fn(() => runtime) as any })
+
+    await adapter.send?.('thread-existing-1', {
+      text: 'Continue',
+      settings: {
+        requestId: 'req-1',
+        sessionType: 'freshcodex',
+        cwd: '/repo',
+        model: 'codex-fixture',
+        permissionMode: 'never',
+        sandbox: 'workspace-write',
+      },
+    })
+
+    expect(runtime.resumeThread).toHaveBeenCalledWith({
+      threadId: 'thread-existing-1',
+      cwd: '/repo',
+      model: 'codex-fixture',
+      sandbox: 'workspace-write',
+      approvalPolicy: 'never',
+    })
+    expect(runtime.startTurn).toHaveBeenCalledWith(expect.objectContaining({
+      threadId: 'thread-existing-1',
+      cwd: '/repo',
+      model: 'codex-fixture',
+      approvalPolicy: 'never',
+      sandboxPolicy: { type: 'workspaceWrite' },
+    }))
+  })
+
+  it('uses per-turn send models without relabeling earlier turns', async () => {
+    const runtime = {
+      startThread: vi.fn().mockResolvedValue({
+        threadId: 'thread-new-1',
+        wsUrl: 'ws://127.0.0.1:43123',
+      }),
+      resumeThread: vi.fn(),
+      startTurn: vi.fn().mockResolvedValue({ turnId: 'turn-2' }),
+      readThread: vi.fn().mockResolvedValue({
+        thread: {
+          ...makeCodexThread('thread-new-1'),
+          turns: [makeCodexTurn('turn-1'), makeCodexTurn('turn-2')],
+        },
+      }),
+      listThreadTurns: vi.fn(),
+      readThreadTurn: vi.fn(),
+    }
+    const adapter = createCodexFreshAgentAdapter({ runtime: runtime as any })
+
+    await adapter.create({
+      requestId: 'req-1',
+      sessionType: 'freshcodex',
+      cwd: '/repo',
+      model: 'gpt-5-codex',
+    })
+    await adapter.send?.('thread-new-1', {
+      text: 'Use the small model',
+      settings: { model: 'gpt-5.4-mini' },
+    })
+
+    await expect(adapter.getSnapshot?.({
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      threadId: 'thread-new-1',
+    }, 7)).resolves.toMatchObject({
+      turns: [
+        { id: 'turn-1' },
+        { id: 'turn-2', model: 'gpt-5.4-mini' },
+      ],
+    })
+    const snapshot = await adapter.getSnapshot?.({
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      threadId: 'thread-new-1',
+    }, 7) as any
+    expect(snapshot.turns[0]).not.toHaveProperty('model')
   })
 
   it('subscribes to Codex lifecycle notifications and projects matching thread updates', async () => {
@@ -202,6 +475,53 @@ describe('Codex fresh-agent adapter', () => {
     expect(off).toHaveBeenCalledTimes(1)
   })
 
+  it('lazily resumes a Codex runtime before subscribing to a persisted thread after server reload', async () => {
+    let lifecycleHandler: ((event: any) => void) | undefined
+    const off = vi.fn()
+    const runtime = {
+      startThread: vi.fn(),
+      resumeThread: vi.fn().mockResolvedValue({
+        threadId: 'thread-existing-1',
+        wsUrl: 'ws://127.0.0.1:43123',
+      }),
+      onThreadLifecycle: vi.fn((handler) => {
+        lifecycleHandler = handler
+        return off
+      }),
+      readThread: vi.fn(),
+      listThreadTurns: vi.fn(),
+      readThreadTurn: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    }
+    const adapter = createCodexFreshAgentAdapter({ runtimeFactory: vi.fn(() => runtime) as any })
+    const listener = vi.fn()
+
+    const unsubscribe = await adapter.subscribe?.('thread-existing-1', listener)
+
+    expect(runtime.resumeThread).toHaveBeenCalledWith({ threadId: 'thread-existing-1' })
+    expect(runtime.onThreadLifecycle).toHaveBeenCalledWith(expect.any(Function))
+
+    lifecycleHandler?.({
+      kind: 'thread_status_changed',
+      threadId: 'thread-existing-1',
+      status: { type: 'active', activeFlags: [] },
+    })
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'thread-existing-1',
+      status: 'running',
+    }))
+    lifecycleHandler?.({
+      kind: 'thread_closed',
+      threadId: 'thread-existing-1',
+    })
+    await vi.waitFor(() => {
+      expect(runtime.shutdown).toHaveBeenCalledTimes(1)
+    })
+
+    unsubscribe?.()
+    expect(off).toHaveBeenCalledTimes(1)
+  })
+
   it('starts turns with Codex-shaped input/settings and interrupts the active turn', async () => {
     const runtime = {
       startThread: vi.fn().mockResolvedValue({
@@ -250,6 +570,37 @@ describe('Codex fresh-agent adapter', () => {
       threadId: 'thread-new-1',
       turnId: 'turn-active-1',
     })
+  })
+
+  it('recovers an in-progress turn id before interrupting a restored running thread', async () => {
+    const runtime = {
+      startThread: vi.fn(),
+      resumeThread: vi.fn().mockResolvedValue({
+        threadId: 'thread-existing-1',
+        wsUrl: 'ws://127.0.0.1:43123',
+      }),
+      readThread: vi.fn().mockResolvedValue({
+        thread: {
+          ...makeCodexThread('thread-existing-1'),
+          status: { type: 'active', activeFlags: [] },
+          turns: [
+            makeCodexTurn('turn-done-1'),
+            { ...makeCodexTurn('turn-active-1'), status: 'inProgress' },
+          ],
+        },
+      }),
+      listThreadTurns: vi.fn(),
+      readThreadTurn: vi.fn(),
+      interruptTurn: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    }
+    const adapter = createCodexFreshAgentAdapter({ runtimeFactory: vi.fn(() => runtime) as any })
+
+    await adapter.interrupt?.('thread-existing-1')
+
+    expect(runtime.resumeThread).toHaveBeenCalledWith({ threadId: 'thread-existing-1' })
+    expect(runtime.readThread).toHaveBeenCalledWith({ threadId: 'thread-existing-1', includeTurns: true })
+    expect(runtime.interruptTurn).toHaveBeenCalledWith({ threadId: 'thread-existing-1', turnId: 'turn-active-1' })
   })
 
   it('rejects Claude-only Freshcodex effort values before app-server calls', async () => {
@@ -315,6 +666,115 @@ describe('Codex fresh-agent adapter', () => {
       model: 'codex-fixture',
       sandbox: 'read-only',
       approvalPolicy: 'never',
+      excludeTurns: true,
+    })
+  })
+
+  it('keeps a shared fork runtime alive until all sibling threads are released', async () => {
+    const runtime = {
+      startThread: vi.fn().mockResolvedValue({
+        threadId: 'thread-new-1',
+        wsUrl: 'ws://127.0.0.1:43123',
+      }),
+      resumeThread: vi.fn(),
+      forkThread: vi.fn().mockResolvedValue({
+        threadId: 'thread-fork-1',
+        wsUrl: 'ws://127.0.0.1:43123',
+      }),
+      startTurn: vi.fn(),
+      interruptTurn: vi.fn(),
+      readThread: vi.fn().mockResolvedValue({
+        thread: makeCodexThread('thread-fork-1'),
+      }),
+      listThreadTurns: vi.fn(),
+      readThreadTurn: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    }
+    const adapter = createCodexFreshAgentAdapter({ runtimeFactory: vi.fn(() => runtime) as any })
+
+    await adapter.create({
+      requestId: 'req-1',
+      sessionType: 'freshcodex',
+      cwd: '/repo',
+    })
+    await adapter.fork?.('thread-new-1')
+
+    await adapter.kill?.('thread-new-1')
+    expect(runtime.shutdown).not.toHaveBeenCalled()
+    await expect(adapter.getSnapshot?.({
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      threadId: 'thread-fork-1',
+    }, 7)).resolves.toMatchObject({
+      threadId: 'thread-fork-1',
+    })
+
+    await adapter.kill?.('thread-fork-1')
+    expect(runtime.shutdown).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps an owned runtime retryable when final release shutdown fails', async () => {
+    const runtime = {
+      startThread: vi.fn().mockResolvedValue({
+        threadId: 'thread-new-1',
+        wsUrl: 'ws://127.0.0.1:43123',
+      }),
+      resumeThread: vi.fn(),
+      forkThread: vi.fn(),
+      startTurn: vi.fn(),
+      interruptTurn: vi.fn(),
+      readThread: vi.fn(),
+      listThreadTurns: vi.fn(),
+      readThreadTurn: vi.fn(),
+      shutdown: vi.fn()
+        .mockRejectedValueOnce(new Error('teardown failed'))
+        .mockResolvedValueOnce(undefined),
+    }
+    const adapter = createCodexFreshAgentAdapter({ runtimeFactory: vi.fn(() => runtime) as any })
+
+    await adapter.create({
+      requestId: 'req-1',
+      sessionType: 'freshcodex',
+      cwd: '/repo',
+    })
+    await expect(adapter.kill?.('thread-new-1')).rejects.toThrow(/teardown failed/)
+    await adapter.shutdown?.()
+
+    expect(runtime.shutdown).toHaveBeenCalledTimes(2)
+  })
+
+  it('lazily resumes a Codex runtime before forking a persisted thread after server reload', async () => {
+    const runtime = {
+      startThread: vi.fn(),
+      resumeThread: vi.fn().mockResolvedValue({
+        threadId: 'thread-existing-1',
+        wsUrl: 'ws://127.0.0.1:43123',
+      }),
+      forkThread: vi.fn().mockResolvedValue({
+        threadId: 'thread-fork-1',
+        wsUrl: 'ws://127.0.0.1:43123',
+      }),
+      startTurn: vi.fn(),
+      interruptTurn: vi.fn(),
+      readThread: vi.fn(),
+      listThreadTurns: vi.fn(),
+      readThreadTurn: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    }
+    const adapter = createCodexFreshAgentAdapter({ runtimeFactory: vi.fn(() => runtime) as any })
+
+    await expect(adapter.fork?.('thread-existing-1')).resolves.toEqual({
+      threadId: 'thread-fork-1',
+      wsUrl: 'ws://127.0.0.1:43123',
+    })
+
+    expect(runtime.resumeThread).toHaveBeenCalledWith({ threadId: 'thread-existing-1' })
+    expect(runtime.forkThread).toHaveBeenCalledWith({
+      threadId: 'thread-existing-1',
+      cwd: undefined,
+      model: undefined,
+      sandbox: undefined,
+      approvalPolicy: undefined,
       excludeTurns: true,
     })
   })

--- a/test/unit/server/fresh-agent/codex-normalize.test.ts
+++ b/test/unit/server/fresh-agent/codex-normalize.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizeCodexThreadSnapshot } from '../../../../server/fresh-agent/adapters/codex/normalize.js'
+import {
+  normalizeCodexThreadSnapshot,
+  normalizeCodexTurn,
+} from '../../../../server/fresh-agent/adapters/codex/normalize.js'
 
 describe('Codex fresh-agent normalization', () => {
   it('normalizes codex fork, review, worktree, and child-thread metadata into the shared snapshot', () => {
@@ -54,5 +57,107 @@ describe('Codex fresh-agent normalization', () => {
       fork: { parentThreadId: 'thread-parent-1' },
     })
     expect(snapshot.diffs[0]).toMatchObject({ path: 'src/app.ts' })
+  })
+
+  it('surfaces the Codex turn model in the shared turn state', () => {
+    const turn = normalizeCodexTurn({
+      id: 'turn-1',
+      model: 'gpt-5.4-mini',
+      items: [
+        {
+          id: 'item-1',
+          type: 'agentMessage',
+          text: 'Done',
+        },
+      ],
+    })
+
+    expect(turn).toMatchObject({
+      id: 'turn-1',
+      turnId: 'turn-1',
+      model: 'gpt-5.4-mini',
+      role: 'assistant',
+      summary: 'Done',
+    })
+  })
+
+  it('uses the active runtime model as a fallback when Codex omits per-turn model metadata', () => {
+    const turn = normalizeCodexTurn({
+      id: 'turn-1',
+      items: [
+        {
+          id: 'item-1',
+          type: 'agentMessage',
+          text: 'Done',
+        },
+      ],
+    }, 0, { model: 'gpt-5.4-mini' })
+
+    expect(turn.model).toBe('gpt-5.4-mini')
+  })
+
+  it('marks user-only Codex turns and explains an empty assistant response', () => {
+    const turn = normalizeCodexTurn({
+      id: 'turn-empty',
+      status: 'completed',
+      items: [{
+        id: 'item-1',
+        type: 'userMessage',
+        content: [{ type: 'text', text: 'Write a temp file.' }],
+      }],
+    })
+
+    expect(turn.role).toBe('user')
+    expect(turn.items).toEqual([
+      { id: 'item-1:part:0', kind: 'text', text: 'Write a temp file.' },
+      {
+        id: 'turn-empty:empty-response',
+        kind: 'text',
+        text: 'Codex completed this turn without recording an assistant response.',
+      },
+    ])
+  })
+
+  it('does not add an empty response sentinel to user turns with tool output', () => {
+    const turn = normalizeCodexTurn({
+      id: 'turn-tool-only',
+      status: 'completed',
+      items: [
+        {
+          id: 'item-1',
+          type: 'userMessage',
+          content: [{ type: 'text', text: 'Write a temp file.' }],
+        },
+        {
+          id: 'item-2',
+          type: 'commandExecution',
+          command: 'cat temp.txt',
+          status: 'completed',
+          aggregatedOutput: 'ok',
+          exitCode: 0,
+        },
+      ],
+    })
+
+    expect(turn.items.map((item) => item.id)).not.toContain('turn-tool-only:empty-response')
+  })
+
+  it('surfaces Codex turn errors in transcript text', () => {
+    const turn = normalizeCodexTurn({
+      id: 'turn-error',
+      status: 'failed',
+      error: { message: 'model rejected the request' },
+      items: [{
+        id: 'item-1',
+        type: 'userMessage',
+        content: [{ type: 'text', text: 'Do the thing.' }],
+      }],
+    })
+
+    expect(turn.items.at(-1)).toEqual({
+      id: 'turn-error:error',
+      kind: 'text',
+      text: 'Codex turn failed: model rejected the request',
+    })
   })
 })

--- a/test/unit/server/fresh-agent/runtime-manager.test.ts
+++ b/test/unit/server/fresh-agent/runtime-manager.test.ts
@@ -95,6 +95,69 @@ describe('FreshAgentRuntimeManager', () => {
     })
   })
 
+  it('routes creates with matching sessionRef through adapter.resume', async () => {
+    const codexAdapter = {
+      create: vi.fn().mockResolvedValue({ sessionId: 'codex-session-created' }),
+      resume: vi.fn().mockResolvedValue({ sessionId: 'thread-existing-1' }),
+    }
+    const registry = createFreshAgentProviderRegistry([
+      {
+        sessionType: 'freshcodex',
+        runtimeProvider: 'codex',
+        adapter: codexAdapter as any,
+      },
+    ])
+    const manager = new FreshAgentRuntimeManager({ registry })
+
+    const resumed = await manager.create({
+      requestId: 'req-session-ref',
+      sessionType: 'freshcodex',
+      sessionRef: { provider: 'codex', sessionId: 'thread-existing-1' },
+    })
+
+    expect(codexAdapter.resume).toHaveBeenCalledWith(expect.objectContaining({
+      sessionType: 'freshcodex',
+      resumeSessionId: 'thread-existing-1',
+      sessionRef: { provider: 'codex', sessionId: 'thread-existing-1' },
+    }))
+    expect(codexAdapter.create).not.toHaveBeenCalled()
+    expect(resumed).toEqual({
+      sessionId: 'thread-existing-1',
+      sessionType: 'freshcodex',
+      runtimeProvider: 'codex',
+    })
+  })
+
+  it('tracks forked child sessions immediately', async () => {
+    const codexAdapter = {
+      create: vi.fn().mockResolvedValue({ sessionId: 'thread-parent-1' }),
+      fork: vi.fn().mockResolvedValue({ threadId: 'thread-child-1' }),
+      send: vi.fn().mockResolvedValue(undefined),
+    }
+    const registry = createFreshAgentProviderRegistry([
+      {
+        sessionType: 'freshcodex',
+        runtimeProvider: 'codex',
+        adapter: codexAdapter as any,
+      },
+    ])
+    const manager = new FreshAgentRuntimeManager({ registry })
+    await manager.create({ requestId: 'req-parent', sessionType: 'freshcodex' })
+
+    await expect(manager.fork({
+      sessionId: 'thread-parent-1',
+      sessionType: 'freshcodex',
+      provider: 'codex',
+    })).resolves.toEqual({ threadId: 'thread-child-1' })
+    await manager.send({
+      sessionId: 'thread-child-1',
+      sessionType: 'freshcodex',
+      provider: 'codex',
+    }, { text: 'hello' })
+
+    expect(codexAdapter.send).toHaveBeenCalledWith('thread-child-1', { text: 'hello' })
+  })
+
   it('routes freshAgent.kill through the tracked adapter and removes the session', async () => {
     const claudeAdapter = {
       create: vi.fn().mockResolvedValue({ sessionId: 'claude-session-1' }),

--- a/test/unit/server/tabs-registry/store.test.ts
+++ b/test/unit/server/tabs-registry/store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { promises as fs } from 'fs'
 import os from 'os'
 import path from 'path'
@@ -146,6 +146,69 @@ describe('TabsRegistryStore compact state', () => {
       snapshotRevision: 2,
       records: [{ ...record, tabName: 'different' }],
     })).rejects.toThrow(/duplicate snapshot revision/i)
+  })
+
+  it('archives an invalid compact manifest and starts with an empty recoverable registry', async () => {
+    await replace(store, {
+      deviceId: 'local-device',
+      deviceLabel: 'local',
+      clientInstanceId: 'window-a',
+      snapshotRevision: 1,
+      records: [
+        makeRecord({ tabKey: 'local:a', tabId: 'a', deviceId: 'local-device', deviceLabel: 'local', tabName: 'A' }),
+      ],
+    })
+    const manifestPath = path.join(tempDir, 'v1', 'manifest.json')
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8')) as {
+      openSnapshots: Record<string, { path: string }>
+    }
+    const missingRef = Object.values(manifest.openSnapshots)[0]
+    expect(missingRef).toBeDefined()
+    await fs.rm(path.join(tempDir, 'v1', missingRef!.path))
+
+    store = await createTabsRegistryStore(tempDir, { now: () => now })
+
+    const result = await store.query({
+      deviceId: 'local-device',
+      clientInstanceId: 'window-a',
+      closedTabRetentionDays: 30,
+    })
+    expect(result.localOpen).toEqual([])
+    const entries = await fs.readdir(path.join(tempDir, 'v1'))
+    expect(entries.some((entry) => entry.startsWith('manifest.json.invalid-'))).toBe(true)
+    await expect(fs.stat(manifestPath)).resolves.toBeDefined()
+  })
+
+  it('does not archive compact state for operational object read failures', async () => {
+    await replace(store, {
+      deviceId: 'local-device',
+      deviceLabel: 'local',
+      clientInstanceId: 'window-a',
+      snapshotRevision: 1,
+      records: [
+        makeRecord({ tabKey: 'local:a', tabId: 'a', deviceId: 'local-device', deviceLabel: 'local', tabName: 'A' }),
+      ],
+    })
+    const manifestPath = path.join(tempDir, 'v1', 'manifest.json')
+    const originalReadFile = fs.readFile.bind(fs)
+    const readFileSpy = vi.spyOn(fs, 'readFile').mockImplementation(async (file, ...args) => {
+      if (String(file).includes(`${path.sep}v1${path.sep}objects${path.sep}`)) {
+        const error = new Error('temporary permission failure') as NodeJS.ErrnoException
+        error.code = 'EACCES'
+        throw error
+      }
+      return await originalReadFile(file, ...args)
+    })
+
+    try {
+      await expect(createTabsRegistryStore(tempDir, { now: () => now })).rejects.toThrow(/temporary permission failure/)
+    } finally {
+      readFileSpy.mockRestore()
+    }
+
+    const entries = await fs.readdir(path.join(tempDir, 'v1'))
+    expect(entries.some((entry) => entry.startsWith('manifest.json.invalid-'))).toBe(false)
+    await expect(fs.stat(manifestPath)).resolves.toBeDefined()
   })
 
   it('rejects same-revision retries whose closed tombstones differ from the committed push', async () => {

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -248,6 +248,10 @@ describe('WsHandler fresh-agent routing', () => {
 
     try {
       const ws = await connectAndAuth(server)
+      const seenMessages: any[] = []
+      ws.on('message', (data) => {
+        seenMessages.push(JSON.parse(data.toString()))
+      })
 
       ws.send(JSON.stringify({
         type: 'freshAgent.create',
@@ -266,6 +270,7 @@ describe('WsHandler fresh-agent routing', () => {
         sessionType: 'freshcodex',
         provider: 'codex',
         text: 'Ship it',
+        settings: { cwd: '/repo', model: 'gpt-5.4-mini', effort: 'low' },
       }))
       ws.send(JSON.stringify({
         type: 'freshAgent.interrupt',
@@ -291,6 +296,7 @@ describe('WsHandler fresh-agent routing', () => {
       }))
       ws.send(JSON.stringify({
         type: 'freshAgent.fork',
+        requestId: 'fork-req-1',
         sessionId: 'codex-session-2',
         sessionType: 'freshcodex',
         provider: 'codex',
@@ -304,12 +310,28 @@ describe('WsHandler fresh-agent routing', () => {
 
       await vi.waitFor(() => {
         const locator = { sessionId: 'codex-session-2', sessionType: 'freshcodex', provider: 'codex' }
-        expect(runtimeManager.send).toHaveBeenCalledWith(locator, { text: 'Ship it', images: undefined })
+        expect(runtimeManager.send).toHaveBeenCalledWith(locator, {
+          text: 'Ship it',
+          images: undefined,
+          settings: { cwd: '/repo', model: 'gpt-5.4-mini', effort: 'low' },
+        })
         expect(runtimeManager.interrupt).toHaveBeenCalledWith(locator)
         expect(runtimeManager.resolveApproval).toHaveBeenCalledWith(locator, 'approval-1', { behavior: 'allow', updatedInput: {} })
         expect(runtimeManager.answerQuestion).toHaveBeenCalledWith(locator, 'question-1', { proceed: 'yes' })
         expect(runtimeManager.fork).toHaveBeenCalledWith(locator, undefined)
+        expect(runtimeManager.subscribe).toHaveBeenCalledWith(
+          { sessionId: 'forked-session', sessionType: 'freshcodex', provider: 'codex' },
+          expect.any(Function),
+        )
         expect(runtimeManager.kill).toHaveBeenCalledWith(locator)
+        expect(seenMessages).toContainEqual(expect.objectContaining({
+          type: 'freshAgent.forked',
+          requestId: 'fork-req-1',
+          parentSessionId: 'codex-session-2',
+          sessionId: 'forked-session',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+        }))
       })
     } finally {
       handler.close()

--- a/test/unit/shared/settings.test.ts
+++ b/test/unit/shared/settings.test.ts
@@ -75,6 +75,25 @@ describe('shared settings contract', () => {
     }).success).toBe(true)
   })
 
+  it('accepts Freshcodex directory persistence when keyed by the Codex runtime provider', () => {
+    const schema = buildServerSettingsPatchSchema(['claude', 'codex', 'opencode'])
+
+    expect(schema.safeParse({
+      codingCli: {
+        providers: {
+          codex: { cwd: '/workspace/freshcodex' },
+        },
+      },
+    }).success).toBe(true)
+    expect(schema.safeParse({
+      codingCli: {
+        providers: {
+          freshcodex: { cwd: '/workspace/freshcodex' },
+        },
+      },
+    }).success).toBe(false)
+  })
+
   it('rejects representative local-only fields in the server patch schema', () => {
     const schema = buildServerSettingsPatchSchema()
 


### PR DESCRIPTION
## Summary
- isolate Freshcodex Codex app-server runtimes per thread/runtime and make lazy resume concurrency-safe
- fix fork/session restore handling so child sessions are registered, subscribed, and correlated by request id
- preserve cwd/model settings, avoid stale transcript backfills, and harden invalid compact tab state recovery

## Verification
- npm run typecheck:server && npm run typecheck:client
- npm run test:vitest -- test/unit/client/components/fresh-agent/FreshAgentView.test.tsx test/unit/client/components/panes/PaneContainer.test.tsx --run
- npm run test:vitest -- --config vitest.server.config.ts test/unit/server/fresh-agent/runtime-manager.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts test/unit/server/tabs-registry/store.test.ts test/unit/server/fresh-agent/codex-adapter.test.ts test/unit/server/fresh-agent/codex-normalize.test.ts test/unit/server/ws-handler-fresh-agent.test.ts --run
- npm run test:vitest -- test/unit/shared/settings.test.ts --run
- npm run build

Also reran the focused typecheck/client/server/shared verification after merging into local dev.