### PR TITLE
Fix fresh agent settings and restart recovery

### DIFF
--- a/server/read-models/request-abort.ts
+++ b/server/read-models/request-abort.ts
@@ -12,14 +12,10 @@ export function createRequestAbortSignal(req: Request, res: Response): AbortSign
 
   const cleanup = () => {
     req.off('aborted', abort)
-    req.off('close', abort)
-    res.off('close', abort)
     res.off('finish', cleanup)
   }
 
   req.once('aborted', abort)
-  req.once('close', abort)
-  res.once('close', abort)
   res.once('finish', cleanup)
 
   return controller.signal

--- a/server/shell-bootstrap-router.ts
+++ b/server/shell-bootstrap-router.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express'
 import { MAX_BOOTSTRAP_PAYLOAD_BYTES, type BootstrapPayload } from '../shared/read-models.js'
 import { setResponsePerfContext } from './request-logger.js'
-import { createRequestAbortSignal } from './read-models/request-abort.js'
 import {
   defaultReadModelScheduler,
   isReadModelAbortError,
@@ -26,12 +25,10 @@ export function createShellBootstrapRouter(deps: ShellBootstrapRouterDeps): Rout
   const router = Router()
   const readModelScheduler = deps.readModelScheduler ?? defaultReadModelScheduler
 
-  router.get('/bootstrap', async (req, res) => {
-    const signal = createRequestAbortSignal(req, res)
+  router.get('/bootstrap', async (_req, res) => {
     try {
       const payload = await readModelScheduler.schedule({
         lane: 'critical',
-        signal,
         run: async (scheduledSignal) => {
           const settings = await deps.getSettings()
           const legacyLocalSettingsSeed = deps.getLegacyLocalSettingsSeed
@@ -96,7 +93,7 @@ export function createShellBootstrapRouter(deps: ShellBootstrapRouterDeps): Rout
       })
       res.json(payload)
     } catch (error) {
-      if (signal.aborted || isReadModelAbortError(error)) {
+      if (isReadModelAbortError(error)) {
         return
       }
       res.status(500).json({ error: 'Bootstrap failed' })

--- a/server/tabs-registry/store.ts
+++ b/server/tabs-registry/store.ts
@@ -26,6 +26,15 @@ function getErrorCode(error: unknown): string | undefined {
     : undefined
 }
 
+function hasErrorCode(error: unknown, code: string): boolean {
+  let current: unknown = error
+  while (current && typeof current === 'object') {
+    if (getErrorCode(current) === code) return true
+    current = 'cause' in current ? (current as { cause?: unknown }).cause : undefined
+  }
+  return false
+}
+
 function isOperationalFsError(error: unknown): boolean {
   const code = getErrorCode(error)
   return code === 'EACCES'
@@ -40,6 +49,15 @@ function isOperationalFsError(error: unknown): boolean {
 
 function invalidCompactState(message: string, cause?: unknown): InvalidCompactTabsRegistryStateError {
   return new InvalidCompactTabsRegistryStateError(message, { cause })
+}
+
+function writeStructuredWarning(event: string, details: Record<string, unknown>): void {
+  console.warn(JSON.stringify({
+    severity: 'warn',
+    component: 'tabs-registry-store',
+    event,
+    ...details,
+  }))
 }
 
 type ObjectRef = {
@@ -652,8 +670,19 @@ export class TabsRegistryStore {
 
     const compactManifestPath = path.join(resolvedRoot, 'v1', 'manifest.json')
     if (fs.existsSync(compactManifestPath)) {
-      const { state, manifestRevision, manifestObjectRefs } = await TabsRegistryStore.loadCompactState(resolvedRoot, caps)
-      return new TabsRegistryStore(resolvedRoot, state, manifestRevision, options, manifestObjectRefs)
+      try {
+        const { state, manifestRevision, manifestObjectRefs } = await TabsRegistryStore.loadCompactState(resolvedRoot, caps)
+        return new TabsRegistryStore(resolvedRoot, state, manifestRevision, options, manifestObjectRefs)
+      } catch (error) {
+        if (!(error instanceof InvalidCompactTabsRegistryStateError) || !hasErrorCode(error, 'ENOENT')) {
+          throw error
+        }
+        await TabsRegistryStore.archiveCompactManifest(resolvedRoot, now())
+        writeStructuredWarning('compact_manifest_archived_missing_object', {
+          manifestPath: compactManifestPath,
+          reason: error.message,
+        })
+      }
     }
 
     const legacyPath = path.join(resolvedRoot, 'tabs-registry.jsonl')
@@ -674,6 +703,18 @@ export class TabsRegistryStore {
       0,
       options,
     )
+  }
+
+  private static async archiveCompactManifest(rootDir: string, timestampMs: number): Promise<void> {
+    const manifestPath = path.join(rootDir, 'v1', 'manifest.json')
+    const archivePath = path.join(rootDir, 'v1', `manifest.json.invalid-${archiveTimestamp(new Date(timestampMs))}`)
+    try {
+      await fsp.rename(manifestPath, archivePath)
+      await bestEffortFsyncDir(path.dirname(manifestPath))
+    } catch (error) {
+      if (getErrorCode(error) === 'ENOENT') return
+      throw error
+    }
   }
 
   private static async loadCompactState(rootDir: string, caps: TabsRegistryCaps): Promise<{
@@ -1007,22 +1048,8 @@ export class TabsRegistryStore {
   }
 
   private async garbageCollectObjects(manifest: TabsRegistryManifestV1): Promise<void> {
-    const referenced = new Set<string>([
-      manifest.closedTombstones.path,
-      manifest.devices.path,
-      manifest.clientRevisions.path,
-      ...Object.values(manifest.openSnapshots).map((ref) => ref.path),
-    ])
-    const objectsDir = path.join(this.rootDir, 'v1', 'objects')
     const tmpDir = path.join(this.rootDir, 'v1', 'tmp')
-    await fsp.mkdir(objectsDir, { recursive: true })
     await fsp.mkdir(tmpDir, { recursive: true })
-    for (const file of await fsp.readdir(objectsDir)) {
-      const relative = `objects/${file}`
-      if (!referenced.has(relative)) {
-        await fsp.rm(path.join(objectsDir, file), { force: true })
-      }
-    }
     for (const file of await fsp.readdir(tmpDir)) {
       await fsp.rm(path.join(tmpDir, file), { force: true, recursive: true })
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,7 @@ import { setRegistry, updateServerStatus } from '@/store/extensionsSlice'
 import { handleSdkMessage } from '@/lib/sdk-message-handler'
 import { handleFreshAgentMessage } from '@/lib/fresh-agent-ws'
 import { createLogger } from '@/lib/client-logger'
+import { hasDismissedAutoSetupWizard, markAutoSetupWizardDismissed } from '@/lib/setup-wizard-dismissal'
 import type { LocalSettingsPatch, ServerSettings } from '@shared/settings'
 import { z } from 'zod'
 import { withChunkErrorRecovery } from '@/lib/import-retry'
@@ -217,6 +218,8 @@ export default function App() {
   const [showSetupWizard, setShowSetupWizard] = useState(false)
   const [configFallback, setConfigFallback] = useState<ConfigFallbackInfo | null>(null)
   const [wizardInitialStep, setWizardInitialStep] = useState<1 | 2>(1)
+  const setupWizardAutoShownRef = useRef(false)
+  const setupWizardUserInteractedRef = useRef(false)
   const [copied, setCopied] = useState(false)
   const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null)
   const [pendingFirewallCommand, setPendingFirewallCommand] = useState<{ tabId: string; command: string } | null>(null)
@@ -291,6 +294,18 @@ export default function App() {
   useEffect(() => {
     isMobileRef.current = isMobile
   }, [isMobile])
+
+  useEffect(() => {
+    const markUserInteracted = () => {
+      setupWizardUserInteractedRef.current = true
+    }
+    window.addEventListener('pointerdown', markUserInteracted, { capture: true })
+    window.addEventListener('keydown', markUserInteracted, { capture: true })
+    return () => {
+      window.removeEventListener('pointerdown', markUserInteracted, { capture: true })
+      window.removeEventListener('keydown', markUserInteracted, { capture: true })
+    }
+  }, [])
 
   // Sidebar width from settings (or local state during drag)
   const sidebarWidth = settings.sidebar?.width ?? 288
@@ -485,7 +500,7 @@ export default function App() {
         if (bootstrapDataLoading) return true
         bootstrapDataLoading = true
         try {
-          const bootstrapData = await api.get<{
+          type BootstrapData = {
             settings?: ServerSettings
             legacyLocalSettingsSeed?: LocalSettingsPatch
             platform?: BootstrapPlatformInfo
@@ -493,7 +508,26 @@ export default function App() {
               reason?: unknown
               backupExists?: unknown
             }
-          }>('/api/bootstrap')
+          }
+          let bootstrapData: BootstrapData | undefined
+          let lastBootstrapError: unknown
+          for (let attempt = 0; attempt < 2; attempt += 1) {
+            try {
+              bootstrapData = await api.get<BootstrapData>('/api/bootstrap')
+              break
+            } catch (err) {
+              lastBootstrapError = err
+              const isTransientFetchFailure = err instanceof TypeError && /failed to fetch/i.test(err.message)
+              if (attempt === 0 && isTransientFetchFailure && !cancelled) {
+                await new Promise((resolve) => setTimeout(resolve, 150))
+                continue
+              }
+              throw err
+            }
+          }
+          if (!bootstrapData) {
+            throw lastBootstrapError ?? new Error('Bootstrap data unavailable')
+          }
           if (!cancelled) {
             if (bootstrapData.legacyLocalSettingsSeed) {
               const currentPreferences = loadBrowserPreferencesRecord()
@@ -1059,7 +1093,15 @@ export default function App() {
 
   // Auto-show setup wizard on first run (unconfigured + localhost)
   useEffect(() => {
-    if (networkStatus && !networkStatus.configured && !isRemoteAccessEnabledStatus(networkStatus)) {
+    if (
+      networkStatus
+      && !setupWizardAutoShownRef.current
+      && !setupWizardUserInteractedRef.current
+      && !hasDismissedAutoSetupWizard()
+      && !networkStatus.configured
+      && !isRemoteAccessEnabledStatus(networkStatus)
+    ) {
+      setupWizardAutoShownRef.current = true
       setWizardInitialStep(1)
       setShowSetupWizard(true)
     }
@@ -1466,6 +1508,8 @@ npm run serve`}</pre>
           onNavigate={setView}
           onFirewallTerminal={setPendingFirewallCommand}
           onComplete={() => {
+            markAutoSetupWizardDismissed()
+            setupWizardAutoShownRef.current = true
             setShowSetupWizard(false)
             dispatch(fetchNetworkStatus())
           }}

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/lib/firewall-configure'
 import { ensureShareUrlToken, isRemoteAccessEnabledStatus } from '@/lib/share-utils'
 import { getAuthToken } from '@/lib/auth'
+import { markAutoSetupWizardDismissed } from '@/lib/setup-wizard-dismissal'
 import {
   SETUP_WIZARD_AUTO_ADVANCE_DELAY_MS,
   SETUP_WIZARD_COPY_RESET_DELAY_MS,
@@ -216,12 +217,13 @@ export function SetupWizard({ onComplete, initialStep = 1, onNavigate, onFirewal
 
   const handleNo = useCallback(async () => {
     setError(null)
+    markAutoSetupWizardDismissed()
+    onComplete()
     try {
       await dispatch(configureNetwork({
         host: '127.0.0.1',
         configured: true,
       })).unwrap()
-      onComplete()
     } catch (err: any) {
       setError(err?.message || 'Failed to save preference')
     }

--- a/src/components/fresh-agent/FreshAgentSettingsButton.tsx
+++ b/src/components/fresh-agent/FreshAgentSettingsButton.tsx
@@ -94,33 +94,45 @@ export function FreshAgentSettingsButton({
         >
           <div className="space-y-3">
             {modelOptions.length > 0 ? (
-              <label className="block space-y-1">
-                <span className="font-medium">Model</span>
-                <select
-                  aria-label="Model"
-                  className="w-full rounded border border-border/70 bg-background px-2 py-1 text-xs"
-                  value={modelValue}
-                  disabled={settingsDisabled}
-                  onChange={(event) => {
-                    const nextModel = event.target.value
-                    const nextEffort = normalizeFreshAgentEffort(
-                      paneContent.sessionType,
-                      paneContent.provider,
-                      nextModel,
-                      paneContent.effort,
-                    )
-                    dispatch(mergePaneContent({
-                      tabId,
-                      paneId,
-                      updates: { model: nextModel, effort: nextEffort },
-                    }))
-                  }}
-                >
+              <fieldset className="space-y-1">
+                <legend className="font-medium">Model</legend>
+                <div className="space-y-1" role="radiogroup" aria-label="Model">
                   {modelOptions.map((option) => (
-                    <option key={option.value} value={option.value}>{option.label}</option>
+                    <label
+                      key={option.value}
+                      className={cn(
+                        'flex cursor-pointer items-center gap-2 rounded border border-border/60 px-2 py-1 transition-colors',
+                        modelValue === option.value ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50',
+                        settingsDisabled && 'cursor-not-allowed opacity-60 hover:bg-transparent',
+                      )}
+                    >
+                      <input
+                        type="radio"
+                        className="h-3 w-3"
+                        name={`fresh-agent-model-${tabId}-${paneId}`}
+                        value={option.value}
+                        checked={modelValue === option.value}
+                        disabled={settingsDisabled}
+                        onChange={() => {
+                          const nextModel = option.value
+                          const nextEffort = normalizeFreshAgentEffort(
+                            paneContent.sessionType,
+                            paneContent.provider,
+                            nextModel,
+                            paneContent.effort,
+                          )
+                          dispatch(mergePaneContent({
+                            tabId,
+                            paneId,
+                            updates: { model: nextModel, effort: nextEffort },
+                          }))
+                        }}
+                      />
+                      <span>{option.label}</span>
+                    </label>
                   ))}
-                </select>
-              </label>
+                </div>
+              </fieldset>
             ) : null}
 
             {thinkingOptions.length > 0 ? (

--- a/src/lib/setup-wizard-dismissal.ts
+++ b/src/lib/setup-wizard-dismissal.ts
@@ -1,0 +1,17 @@
+const SETUP_WIZARD_AUTO_DISMISSED_KEY = 'freshell.setupWizardAutoDismissed'
+
+export function hasDismissedAutoSetupWizard(): boolean {
+  try {
+    return sessionStorage.getItem(SETUP_WIZARD_AUTO_DISMISSED_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export function markAutoSetupWizardDismissed(): void {
+  try {
+    sessionStorage.setItem(SETUP_WIZARD_AUTO_DISMISSED_KEY, 'true')
+  } catch {
+    // Session storage can be unavailable in hardened browser contexts.
+  }
+}

--- a/test/integration/server/bootstrap-router.test.ts
+++ b/test/integration/server/bootstrap-router.test.ts
@@ -83,11 +83,11 @@ describe('GET /api/bootstrap', () => {
     expect(res.body.configFallback).toEqual({ reason: 'read_error', backupExists: true })
   })
 
-  it('routes bootstrap through the critical read-model lane', async () => {
-    const schedule = vi.fn(async ({ lane, signal, run }: { lane: string; signal: AbortSignal; run: (signal: AbortSignal) => Promise<unknown> }) => {
+  it('routes bootstrap through the critical read-model lane without binding first paint to request aborts', async () => {
+    const schedule = vi.fn(async ({ lane, signal, run }: { lane: string; signal?: AbortSignal; run: (signal: AbortSignal) => Promise<unknown> }) => {
       expect(lane).toBe('critical')
-      expect(signal).toBeInstanceOf(AbortSignal)
-      return run(signal)
+      expect(signal).toBeUndefined()
+      return run(new AbortController().signal)
     })
     const appWithScheduler = createTestApp({
       readModelScheduler: { schedule },

--- a/test/integration/server/tabs-registry-store.persistence.test.ts
+++ b/test/integration/server/tabs-registry-store.persistence.test.ts
@@ -173,7 +173,7 @@ describe('tabs registry compact persistence', () => {
     expect(result.devices.map((device) => device.deviceId)).toContain('local-device')
   })
 
-  it('ignores orphaned object and temp files on startup and garbage-collects them after commit', async () => {
+  it('ignores orphaned object files on startup and cleans temp files after commit', async () => {
     const writer = await createTabsRegistryStore(tempDir, { now: () => now })
     await writer.replaceClientSnapshot({
       deviceId: 'local-device',
@@ -208,7 +208,7 @@ describe('tabs registry compact persistence', () => {
         makeRecord({ tabKey: 'local:open-2', tabId: 'open-2', deviceId: 'local-device', deviceLabel: 'local' }),
       ],
     })
-    await expect(fs.stat(orphanPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fs.stat(orphanPath)).resolves.toBeDefined()
     await expect(fs.stat(tmpPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 

--- a/test/unit/client/SetupWizard.test.tsx
+++ b/test/unit/client/SetupWizard.test.tsx
@@ -166,6 +166,21 @@ describe('SetupWizard', () => {
     await waitFor(() => expect(onComplete).toHaveBeenCalled())
   })
 
+  it('dismisses immediately when "No" is clicked, even while saving the preference', () => {
+    mockPost.mockReturnValue(new Promise(() => {}))
+    const onComplete = vi.fn()
+    const store = createTestStore()
+    render(
+      <Provider store={store}>
+        <SetupWizard onComplete={onComplete} />
+      </Provider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /no/i }))
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
   it('has dialog role with aria-modal', () => {
     const store = createTestStore()
     render(

--- a/test/unit/client/components/App.test.tsx
+++ b/test/unit/client/components/App.test.tsx
@@ -29,6 +29,7 @@ import {
 // Ensure DOM is clean even if another test file forgot cleanup.
 beforeEach(() => {
   cleanup()
+  sessionStorage.clear()
 })
 
 afterEach(() => {
@@ -154,8 +155,11 @@ vi.mock('@/components/OverviewView', () => ({
 }))
 
 vi.mock('@/components/SetupWizard', () => ({
-  SetupWizard: ({ initialStep }: { initialStep?: number }) => (
-    <div data-testid="mock-setup-wizard" data-initial-step={initialStep}>Setup Wizard (step {initialStep ?? 1})</div>
+  SetupWizard: ({ initialStep, onComplete }: { initialStep?: number; onComplete?: () => void }) => (
+    <div data-testid="mock-setup-wizard" data-initial-step={initialStep}>
+      Setup Wizard (step {initialStep ?? 1})
+      <button type="button" onClick={() => onComplete?.()}>Close setup wizard</button>
+    </div>
   ),
 }))
 
@@ -398,6 +402,67 @@ describe('App Component - Share Button', () => {
 
     expect(await screen.findByTestId('mock-setup-wizard')).toBeInTheDocument()
     expect(screen.getByTestId('mock-setup-wizard').dataset.initialStep).toBe('1')
+  })
+
+  it('does not auto-reopen setup wizard after the first-run wizard is dismissed', async () => {
+    const store = createTestStore()
+    const unconfiguredStatus = makeNetworkStatus({
+      configured: false,
+      host: '0.0.0.0',
+      remoteAccessEnabled: false,
+    })
+    mockApiGet.mockImplementation((url: string) => {
+      if (url === '/api/settings') return Promise.resolve(defaultSettings)
+      if (url === '/api/platform') return Promise.resolve({ platform: 'linux' })
+      if (url === '/api/version') return Promise.resolve(makeVersionInfo())
+      if (typeof url === 'string' && url.startsWith('/api/sessions')) return Promise.resolve([])
+      if (url === '/api/network/status') return Promise.resolve(unconfiguredStatus)
+      return Promise.resolve({})
+    })
+
+    act(() => {
+      store.dispatch(setNetworkStatus(unconfiguredStatus))
+    })
+
+    renderApp(store)
+
+    expect(await screen.findByTestId('mock-setup-wizard')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Close setup wizard' }))
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-setup-wizard')).not.toBeInTheDocument()
+    })
+
+    act(() => {
+      store.dispatch(setNetworkStatus({ ...unconfiguredStatus }))
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-setup-wizard')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not late-open setup wizard after the user starts interacting before status resolves', async () => {
+    const store = createTestStore({
+      status: makeNetworkStatus({
+        configured: true,
+        host: '127.0.0.1',
+      }),
+    })
+    renderApp(store)
+
+    fireEvent.pointerDown(screen.getByTitle('Go settings'))
+
+    act(() => {
+      store.dispatch(setNetworkStatus(makeNetworkStatus({
+        configured: false,
+        host: '0.0.0.0',
+        remoteAccessEnabled: false,
+      })))
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-setup-wizard')).not.toBeInTheDocument()
+    })
   })
 
   it('opens setup wizard at step 2 when configured but localhost-only', async () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -501,11 +501,11 @@ describe('FreshAgentView', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Agent settings' }))
-    fireEvent.change(screen.getByRole('combobox', { name: 'Model' }), {
-      target: { value: 'gpt-5.4-flash' },
-    })
+    expect(screen.queryByRole('combobox', { name: 'Model' })).not.toBeInTheDocument()
+    expect(screen.getByRole('radiogroup', { name: 'Model' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('radio', { name: 'GPT-5.4 Flash' }))
     await waitFor(() => {
-      expect(screen.getByRole('combobox', { name: 'Model' })).toHaveValue('gpt-5.4-flash')
+      expect(screen.getByRole('radio', { name: 'GPT-5.4 Flash' })).toBeChecked()
     })
 
     const thinking = screen.getByRole('combobox', { name: 'Thinking level' })
@@ -550,14 +550,13 @@ describe('FreshAgentView', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Agent settings' }))
-    expect(screen.getByRole('combobox', { name: 'Model' })).toHaveValue('opencode-go/deepseek-v4-flash')
+    expect(screen.queryByRole('combobox', { name: 'Model' })).not.toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'DeepSeek V4 Flash' })).toBeChecked()
     expect(screen.getByRole('combobox', { name: 'Thinking level' })).toHaveValue('max')
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Model' }), {
-      target: { value: 'opencode-go/glm-5.1' },
-    })
+    fireEvent.click(screen.getByRole('radio', { name: 'GLM 5.1' }))
     await waitFor(() => {
-      expect(screen.getByRole('combobox', { name: 'Model' })).toHaveValue('opencode-go/glm-5.1')
+      expect(screen.getByRole('radio', { name: 'GLM 5.1' })).toBeChecked()
     })
     fireEvent.change(screen.getByRole('combobox', { name: 'Thinking level' }), {
       target: { value: 'high' },

--- a/test/unit/server/read-models/request-abort.test.ts
+++ b/test/unit/server/read-models/request-abort.test.ts
@@ -1,0 +1,48 @@
+import { EventEmitter } from 'events'
+import { describe, expect, it } from 'vitest'
+import { createRequestAbortSignal } from '../../../../server/read-models/request-abort.js'
+
+function createMockRequestResponse() {
+  const req = new EventEmitter()
+  const res = new EventEmitter()
+  return { req, res }
+}
+
+describe('createRequestAbortSignal', () => {
+  it('does not abort on the request close event emitted during normal request completion', () => {
+    const { req, res } = createMockRequestResponse()
+    const signal = createRequestAbortSignal(req as any, res as any)
+
+    req.emit('close')
+
+    expect(signal.aborted).toBe(false)
+  })
+
+  it('aborts when the client aborts the request before response finish', () => {
+    const { req, res } = createMockRequestResponse()
+    const signal = createRequestAbortSignal(req as any, res as any)
+
+    req.emit('aborted')
+
+    expect(signal.aborted).toBe(true)
+  })
+
+  it('does not abort on response close because finite read-model routes can see it before finish', () => {
+    const { req, res } = createMockRequestResponse()
+    const signal = createRequestAbortSignal(req as any, res as any)
+
+    res.emit('close')
+
+    expect(signal.aborted).toBe(false)
+  })
+
+  it('keeps ignoring response close after the response finishes', () => {
+    const { req, res } = createMockRequestResponse()
+    const signal = createRequestAbortSignal(req as any, res as any)
+
+    res.emit('finish')
+    res.emit('close')
+
+    expect(signal.aborted).toBe(false)
+  })
+})

--- a/test/unit/server/tabs-registry/store.test.ts
+++ b/test/unit/server/tabs-registry/store.test.ts
@@ -148,7 +148,7 @@ describe('TabsRegistryStore compact state', () => {
     })).rejects.toThrow(/duplicate snapshot revision/i)
   })
 
-  it('rejects an invalid compact manifest without serving an empty registry', async () => {
+  it('archives a compact manifest that references a missing object and starts empty', async () => {
     await replace(store, {
       deviceId: 'local-device',
       deviceLabel: 'local',
@@ -166,11 +166,62 @@ describe('TabsRegistryStore compact state', () => {
     expect(missingRef).toBeDefined()
     await fs.rm(path.join(tempDir, 'v1', missingRef!.path))
 
-    await expect(createTabsRegistryStore(tempDir, { now: () => now })).rejects.toThrow(/compact state.*invalid|unavailable/i)
+    const restarted = await createTabsRegistryStore(tempDir, { now: () => now })
+    expect(restarted.count()).toBe(0)
 
     const entries = await fs.readdir(path.join(tempDir, 'v1'))
-    expect(entries.some((entry) => entry.startsWith('manifest.json.invalid-'))).toBe(false)
-    await expect(fs.stat(manifestPath)).resolves.toBeDefined()
+    expect(entries.some((entry) => entry.startsWith('manifest.json.invalid-'))).toBe(true)
+    await expect(fs.stat(manifestPath)).rejects.toThrow(/ENOENT/)
+  })
+
+  it('keeps superseded compact objects so overlapping restart processes cannot publish missing refs', async () => {
+    const recordA = makeRecord({ tabKey: 'local:a', tabId: 'a', deviceId: 'local-device', deviceLabel: 'local', tabName: 'A' })
+    await replace(store, {
+      deviceId: 'local-device',
+      deviceLabel: 'local',
+      clientInstanceId: 'window-a',
+      snapshotRevision: 1,
+      records: [recordA],
+    })
+    const firstManifest = JSON.parse(await fs.readFile(path.join(tempDir, 'v1', 'manifest.json'), 'utf8')) as {
+      openSnapshots: Record<string, { path: string }>
+    }
+    const originalSnapshotRef = Object.values(firstManifest.openSnapshots)[0]
+    expect(originalSnapshotRef).toBeDefined()
+
+    const overlappingRestart = await createTabsRegistryStore(tempDir, { now: () => now })
+    await replace(store, {
+      deviceId: 'local-device',
+      deviceLabel: 'local',
+      clientInstanceId: 'window-a',
+      snapshotRevision: 2,
+      records: [makeRecord({
+        tabKey: 'local:b',
+        tabId: 'b',
+        deviceId: 'local-device',
+        deviceLabel: 'local',
+        tabName: 'B',
+        revision: 2,
+        updatedAt: NOW,
+      })],
+    })
+
+    await expect(fs.stat(path.join(tempDir, 'v1', originalSnapshotRef!.path))).resolves.toBeDefined()
+    await replace(overlappingRestart, {
+      deviceId: 'other-device',
+      deviceLabel: 'other',
+      clientInstanceId: 'window-b',
+      snapshotRevision: 1,
+      records: [makeRecord({
+        tabKey: 'other:c',
+        tabId: 'c',
+        deviceId: 'other-device',
+        deviceLabel: 'other',
+        tabName: 'C',
+      })],
+    })
+
+    await expect(createTabsRegistryStore(tempDir, { now: () => now })).resolves.toBeDefined()
   })
 
   it('does not archive compact state for operational object read failures', async () => {


### PR DESCRIPTION
## Summary
- switch FreshAgent model selection to radio buttons while keeping thinking level as a per-model dropdown
- prevent first-run setup wizard dismissal/late-open races
- make tabs registry restart-safe by retaining content-addressed objects and recovering missing-object compact manifests
- avoid noisy first-paint bootstrap abort failures with critical bootstrap retry/route behavior

## Verification
- npm test
- Playwright production smoke: create FreshOpenCode via pane picker, submit `reply exactly ok`, SIGINT server, restart, verify FreshOpenCode restores without placeholder/failure states and without bootstrap abort warnings