### PR TITLE
Restore FreshAgent UX polish

### DIFF
--- a/docs/superpowers/plans/2026-05-24-fresh-agent-tab-naming.md
+++ b/docs/superpowers/plans/2026-05-24-fresh-agent-tab-naming.md
@@ -1,0 +1,645 @@
+# Fresh Agent Tab Naming Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make new FreshAgent tabs auto-name like terminal-backed CLI tabs: prefer the active working directory immediately, fall back to the FreshAgent label, then allow first-message auto-title without overriding user-renamed tabs.
+
+**Architecture:** Extend the shared tab-title derivation path instead of adding component-specific tab display logic. FreshAgent pane content already carries `initialCwd`, so `deriveTabName()` should treat it as a first-class title source, and `FreshAgentView` should reuse the existing shared `extractTitleFromMessage()` helper for first-message auto-title.
+
+**Tech Stack:** React 18, Redux Toolkit, Vitest, Testing Library, TypeScript/NodeNext.
+
+---
+
+## File Structure
+
+- Modify `src/lib/deriveTabName.ts`
+  - Add FreshAgent pane recognition.
+  - Reuse the existing last-directory-segment behavior for `initialCwd`.
+  - Prefer `initialCwd` for FreshAgent tabs; fall back to `getFreshAgentLabel(sessionType)`.
+- Modify `test/unit/client/lib/deriveTabName.test.ts`
+  - Add direct unit coverage for FreshAgent cwd naming and label fallback.
+- Modify `test/unit/client/components/TabBar.deriveTitle.test.tsx`
+  - Add integration-ish component coverage proving the visible tab label is the FreshAgent working directory, not `Tab`.
+- Modify `src/components/fresh-agent/FreshAgentView.tsx`
+  - Import `updatePaneTitle`, `updateTab`, and `extractTitleFromMessage`.
+  - Add first-message auto-title before `freshAgent.send`.
+  - Do not override user-set tab titles.
+- Modify `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
+  - Add a store with `tabs` reducer for title assertions.
+  - Add tests for first-message title updates and user-title preservation.
+- No README or `docs/index.html` update is needed; this is restoring expected chrome behavior, not adding an end-user-facing feature surface.
+
+## Design Notes
+
+- "As soon as it is active" means the tab display should derive from pane content synchronously as soon as the pane layout exists, the same way shell panes derive from `initialCwd`.
+- FreshAgent is not terminal-backed, so it will not receive PTY title/cwd metadata. Its existing `initialCwd` field is the canonical local source.
+- Title priority for a single FreshAgent pane:
+  1. User-set tab title.
+  2. User-set pane title override.
+  3. FreshAgent `initialCwd` last path segment.
+  4. FreshAgent label such as `Freshcodex`, `Freshopencode`, or `Freshclaude`.
+  5. Existing fallback `Tab`.
+- First-message auto-title should mirror legacy `AgentChatView`: set the pane title with `setByUser: false`, and update the tab title only if `tab.titleSetByUser` is false.
+
+---
+
+### Task 1: Unit-Test FreshAgent Tab Name Derivation
+
+**Files:**
+- Modify: `test/unit/client/lib/deriveTabName.test.ts`
+- Test: `test/unit/client/lib/deriveTabName.test.ts`
+
+- [ ] **Step 1: Write failing FreshAgent deriveTabName tests**
+
+Append these tests inside the existing `describe('deriveTabName', () => { ... })` block:
+
+```ts
+  it('returns the last working-directory segment for a fresh-agent pane', () => {
+    const layout: PaneNode = {
+      type: 'leaf',
+      id: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        status: 'idle',
+        createRequestId: 'req-1',
+        initialCwd: '/home/dan/code/freshell',
+      },
+    }
+
+    expect(deriveTabName(layout, mockExtensions)).toBe('freshell')
+  })
+
+  it('falls back to the fresh-agent label when there is no working directory', () => {
+    const layout: PaneNode = {
+      type: 'leaf',
+      id: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        status: 'idle',
+        createRequestId: 'req-1',
+      },
+    }
+
+    expect(deriveTabName(layout, mockExtensions)).toBe('Freshopencode')
+  })
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+npm run test:vitest -- --run test/unit/client/lib/deriveTabName.test.ts
+```
+
+Expected: FAIL. The new tests should currently return `Tab` because `src/lib/deriveTabName.ts` has no `fresh-agent` case.
+
+- [ ] **Step 3: Implement FreshAgent derivation in `deriveTabName`**
+
+Change the imports in `src/lib/deriveTabName.ts` from:
+
+```ts
+import type { PaneNode, PaneContent, TerminalPaneContent, BrowserPaneContent } from '../store/paneTypes'
+import type { ClientExtensionEntry } from '@shared/extension-types'
+import { getProviderLabel, isNonShellMode } from './coding-cli-utils'
+```
+
+to:
+
+```ts
+import type { PaneNode, PaneContent, TerminalPaneContent, BrowserPaneContent, FreshAgentPaneContent } from '../store/paneTypes'
+import type { ClientExtensionEntry } from '@shared/extension-types'
+import { getProviderLabel, isNonShellMode } from './coding-cli-utils'
+import { getFreshAgentLabel } from './fresh-agent-registry'
+```
+
+Add this type guard after `isCli()`:
+
+```ts
+/**
+ * Check if content is a FreshAgent pane.
+ */
+function isFreshAgent(content: PaneContent): content is FreshAgentPaneContent {
+  return content.kind === 'fresh-agent'
+}
+```
+
+Update the priority comment above `deriveTabName()` to:
+
+```ts
+/**
+ * Derives a tab name from pane layout content using priority order:
+ * 1. First CLI instance (claude or codex mode terminal)
+ * 2. First FreshAgent pane (last directory segment of initialCwd, then agent label)
+ * 3. First browser
+ * 4. First shell terminal (using last directory segment of initialCwd)
+ */
+```
+
+Insert this block immediately after the CLI block and before the browser block:
+
+```ts
+  // Priority 2: First FreshAgent pane
+  const freshAgent = contents.find(isFreshAgent)
+  if (freshAgent) {
+    if (freshAgent.initialCwd) {
+      const segment = extractLastDirSegment(freshAgent.initialCwd)
+      if (segment) return segment
+    }
+    return getFreshAgentLabel(freshAgent.sessionType)
+  }
+```
+
+Renumber the existing browser, shell, and picker comments so they remain accurate.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+npm run test:vitest -- --run test/unit/client/lib/deriveTabName.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add src/lib/deriveTabName.ts test/unit/client/lib/deriveTabName.test.ts
+git commit -m "fix: derive fresh-agent tab names from cwd"
+```
+
+---
+
+### Task 2: Prove the Visible TabBar Uses FreshAgent Directory Names
+
+**Files:**
+- Modify: `test/unit/client/components/TabBar.deriveTitle.test.tsx`
+- Test: `test/unit/client/components/TabBar.deriveTitle.test.tsx`
+
+- [ ] **Step 1: Write a failing visible-tab test**
+
+Append this test near the existing shell-directory derivation test in `test/unit/client/components/TabBar.deriveTitle.test.tsx`:
+
+```tsx
+  it('derives the visible tab title from a fresh-agent working directory', () => {
+    const store = createStore(
+      {
+        tabs: [
+          {
+            id: 'tab-1',
+            createRequestId: 'tab-1',
+            title: 'Tab 1',
+            titleSetByUser: false,
+            status: 'running',
+            mode: 'shell',
+            shell: 'system',
+            createdAt: Date.now(),
+          },
+        ],
+        activeTabId: 'tab-1',
+      },
+      {
+        layouts: {
+          'tab-1': {
+            type: 'leaf',
+            id: 'pane-1',
+            content: {
+              kind: 'fresh-agent',
+              sessionType: 'freshcodex',
+              provider: 'codex',
+              createRequestId: 'req-1',
+              status: 'idle',
+              initialCwd: '/home/dan/code/freshell',
+            },
+          },
+        },
+        activePane: { 'tab-1': 'pane-1' },
+      },
+    )
+
+    render(
+      <Provider store={store}>
+        <TabBar />
+      </Provider>,
+    )
+
+    expect(screen.getByText('freshell')).toBeInTheDocument()
+    expect(screen.queryByText('Tab 1')).not.toBeInTheDocument()
+    expect(screen.queryByText('Freshcodex')).not.toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 2: Run the focused TabBar test**
+
+Run:
+
+```bash
+npm run test:vitest -- --run test/unit/client/components/TabBar.deriveTitle.test.tsx
+```
+
+Expected after Task 1: PASS. If it fails because `deriveTabName()` did not apply through `getTabDisplayTitle()`, fix the derivation path rather than adding special logic to `TabBar`.
+
+- [ ] **Step 3: Commit Task 2**
+
+Run:
+
+```bash
+git add test/unit/client/components/TabBar.deriveTitle.test.tsx
+git commit -m "test: cover visible fresh-agent tab naming"
+```
+
+---
+
+### Task 3: First-Message Auto-Title for FreshAgent
+
+**Files:**
+- Modify: `src/components/fresh-agent/FreshAgentView.tsx`
+- Modify: `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
+- Test: `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
+
+- [ ] **Step 1: Extend the FreshAgentView test store with tabs state**
+
+In `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`, add this import near the existing reducer imports:
+
+```ts
+import tabsReducer from '@/store/tabsSlice'
+```
+
+Change `createStore()` from:
+
+```ts
+function createStore() {
+  return configureStore({
+    reducer: {
+      panes: panesReducer,
+      settings: settingsReducer,
+      freshAgent: freshAgentReducer,
+      agentChat: agentChatReducer,
+    },
+    preloadedState: {
+      panes: {
+        layouts: {},
+        activePane: {},
+        paneTitles: {},
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      },
+    },
+  })
+}
+```
+
+to:
+
+```ts
+function createStore(tabTitleSetByUser = false) {
+  return configureStore({
+    reducer: {
+      panes: panesReducer,
+      tabs: tabsReducer,
+      settings: settingsReducer,
+      freshAgent: freshAgentReducer,
+      agentChat: agentChatReducer,
+    },
+    preloadedState: {
+      tabs: {
+        tabs: [{
+          id: 'tab-1',
+          createRequestId: 'tab-1',
+          title: tabTitleSetByUser ? 'Pinned title' : 'Tab 1',
+          titleSetByUser: tabTitleSetByUser,
+          status: 'running',
+          mode: 'shell',
+          shell: 'system',
+          createdAt: Date.now(),
+        }],
+        activeTabId: 'tab-1',
+      },
+      panes: {
+        layouts: {},
+        activePane: {},
+        paneTitles: {},
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      },
+    },
+  })
+}
+```
+
+- [ ] **Step 2: Write failing first-message auto-title tests**
+
+Add these tests inside `describe('FreshAgentView', () => { ... })`:
+
+```tsx
+  it('auto-titles the fresh-agent pane and tab from the first user message', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-auto-title',
+        sessionId: 'thread-auto-title',
+        status: 'idle',
+        initialCwd: '/home/dan/code/freshell',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex turn')).toBeInTheDocument()
+    })
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Research tab naming behavior\nUse existing code paths.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(store.getState().panes.paneTitles['tab-1']?.['pane-1']).toBe('Research tab naming behavior')
+    })
+    expect(store.getState().panes.paneTitleSetByUser['tab-1']?.['pane-1']).toBe(false)
+    expect(store.getState().tabs.tabs[0].title).toBe('Research tab naming behavior')
+    expect(store.getState().tabs.tabs[0].titleSetByUser).toBe(false)
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.send',
+      text: 'Research tab naming behavior\nUse existing code paths.',
+    }))
+  })
+
+  it('does not replace a user-set tab title when auto-titling the first fresh-agent message', async () => {
+    const store = createStore(true)
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-auto-title-user-tab',
+        sessionId: 'thread-auto-title-user-tab',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex turn')).toBeInTheDocument()
+    })
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Do not override my tab title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(store.getState().panes.paneTitles['tab-1']?.['pane-1']).toBe('Do not override my tab title')
+    })
+    expect(store.getState().tabs.tabs[0].title).toBe('Pinned title')
+    expect(store.getState().tabs.tabs[0].titleSetByUser).toBe(true)
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.send',
+      text: 'Do not override my tab title',
+    }))
+  })
+```
+
+- [ ] **Step 3: Run the focused FreshAgentView test and verify it fails**
+
+Run:
+
+```bash
+npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+```
+
+Expected: FAIL. The pane and tab titles should not update yet because `FreshAgentView` does not currently auto-title before `freshAgent.send`.
+
+- [ ] **Step 4: Import title actions and helper in FreshAgentView**
+
+In `src/components/fresh-agent/FreshAgentView.tsx`, change:
+
+```ts
+import { consumePaneRefreshRequest, mergePaneContent, updatePaneContent } from '@/store/panesSlice'
+```
+
+to:
+
+```ts
+import { consumePaneRefreshRequest, mergePaneContent, updatePaneContent, updatePaneTitle } from '@/store/panesSlice'
+```
+
+Add these imports near the other store/shared imports:
+
+```ts
+import { updateTab } from '@/store/tabsSlice'
+import { extractTitleFromMessage } from '@shared/title-utils'
+```
+
+- [ ] **Step 5: Read current tab title state in FreshAgentView**
+
+Inside `FreshAgentView`, near the existing selectors, add:
+
+```ts
+  const currentTab = useAppSelector((state) => state.tabs.tabs.find((tab) => tab.id === tabId))
+  const tabTitleSetByUser = currentTab?.titleSetByUser ?? false
+```
+
+If this component already has a nearby `currentTab` selector by the time this plan is executed, reuse it instead of duplicating it.
+
+- [ ] **Step 6: Add the auto-title block before sending**
+
+Replace the existing inline `onSend` body:
+
+```tsx
+              onSend={(text) => {
+                if (!paneContent.sessionId || !canSend) return
+                sendFreshAgentMessage({
+                  type: 'freshAgent.send',
+                  sessionId: paneContent.sessionId,
+                  sessionType: paneContent.sessionType,
+                  provider: paneContent.provider,
+                  text,
+                  settings: {
+                    ...(paneContent.initialCwd ? { cwd: paneContent.initialCwd } : {}),
+                    ...(getEffectiveFreshAgentModel(paneContent) ? { model: getEffectiveFreshAgentModel(paneContent) } : {}),
+                    ...(paneContent.permissionMode ? { permissionMode: paneContent.permissionMode } : {}),
+                    ...(paneContent.sandbox ? { sandbox: paneContent.sandbox } : {}),
+                    ...(getEffectiveFreshAgentEffort(paneContent) ? { effort: getEffectiveFreshAgentEffort(paneContent) } : {}),
+                  },
+                })
+              }}
+```
+
+with:
+
+```tsx
+              onSend={(text) => {
+                if (!paneContent.sessionId || !canSend) return
+                const isFirstMessage = turns.length === 0
+                if (isFirstMessage) {
+                  const title = extractTitleFromMessage(text)
+                  if (title) {
+                    dispatch(updatePaneTitle({ tabId, paneId, title, setByUser: false }))
+                    if (!tabTitleSetByUser) {
+                      dispatch(updateTab({ id: tabId, updates: { title } }))
+                    }
+                  }
+                }
+                sendFreshAgentMessage({
+                  type: 'freshAgent.send',
+                  sessionId: paneContent.sessionId,
+                  sessionType: paneContent.sessionType,
+                  provider: paneContent.provider,
+                  text,
+                  settings: {
+                    ...(paneContent.initialCwd ? { cwd: paneContent.initialCwd } : {}),
+                    ...(getEffectiveFreshAgentModel(paneContent) ? { model: getEffectiveFreshAgentModel(paneContent) } : {}),
+                    ...(paneContent.permissionMode ? { permissionMode: paneContent.permissionMode } : {}),
+                    ...(paneContent.sandbox ? { sandbox: paneContent.sandbox } : {}),
+                    ...(getEffectiveFreshAgentEffort(paneContent) ? { effort: getEffectiveFreshAgentEffort(paneContent) } : {}),
+                  },
+                })
+              }}
+```
+
+Then add `tabTitleSetByUser` to the dependency array for the surrounding `useMemo`/callback if TypeScript or lint flags it. Do not add `currentTab` as a dependency if only `tabTitleSetByUser` is used.
+
+- [ ] **Step 7: Run the focused FreshAgentView test and verify it passes**
+
+Run:
+
+```bash
+npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 3**
+
+Run:
+
+```bash
+git add src/components/fresh-agent/FreshAgentView.tsx test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+git commit -m "fix: auto-title fresh-agent conversations"
+```
+
+---
+
+### Task 4: Regression Sweep and PR Update
+
+**Files:**
+- Verify: `src/lib/deriveTabName.ts`
+- Verify: `src/components/fresh-agent/FreshAgentView.tsx`
+- Verify: `test/unit/client/lib/deriveTabName.test.ts`
+- Verify: `test/unit/client/components/TabBar.deriveTitle.test.tsx`
+- Verify: `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
+
+- [ ] **Step 1: Run the narrow regression suite**
+
+Run:
+
+```bash
+npm run test:vitest -- --run \
+  test/unit/client/lib/deriveTabName.test.ts \
+  test/unit/client/components/TabBar.deriveTitle.test.tsx \
+  test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the existing FreshAgent focused suite**
+
+Run:
+
+```bash
+npm run test:vitest -- --run \
+  test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx \
+  test/unit/client/components/fresh-agent/FreshAgentView.test.tsx \
+  test/unit/client/components/panes/PaneContainer.test.tsx \
+  test/unit/client/components/panes/PaneContainer.createContent.test.tsx \
+  test/unit/server/fresh-agent/codex-adapter.test.ts \
+  test/unit/server/fresh-agent/runtime-manager.test.ts \
+  test/unit/server/ws-handler-fresh-agent.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run typecheck and coordinated tests**
+
+Run:
+
+```bash
+FRESHELL_TEST_SUMMARY="fresh-agent tab naming" npm run check
+```
+
+Expected: PASS. If another agent owns the broad test gate, wait for the coordinator instead of killing anything.
+
+- [ ] **Step 4: Push the PR branch**
+
+Run:
+
+```bash
+git push
+```
+
+Expected: branch `freshagent-ux-restoration` updates PR #366.
+
+- [ ] **Step 5: Update local integration branches only if requested**
+
+Do not restart the self-hosted `dev` server. If the user asks to land the updated PR head locally again, fast-forward `.worktrees/dev` to the branch head and leave local `main` alone unless they explicitly ask for a mirror refresh.
+
+Expected commands if explicitly requested:
+
+```bash
+git -C /home/dan/code/freshell/.worktrees/dev fetch origin
+git -C /home/dan/code/freshell/.worktrees/dev merge --ff-only freshagent-ux-restoration
+```
+
+---
+
+## Self-Review
+
+1. Spec coverage:
+   - Directory-first FreshAgent tab naming is covered by Tasks 1 and 2.
+   - Label fallback is covered by Task 1.
+   - First-message auto-title parity with legacy `AgentChatView` is covered by Task 3.
+   - User-set tab-title preservation is covered by Task 3.
+   - PR update and non-interference with self-hosted dev are covered by Task 4.
+
+2. Placeholder scan:
+   - No `TBD`, `TODO`, "similar to", or unspecified test instructions remain.
+   - Every code-changing step includes exact code or exact replacement guidance.
+
+3. Type consistency:
+   - `FreshAgentPaneContent` is imported from `src/store/paneTypes.ts`, where it is already defined.
+   - `getFreshAgentLabel()` is imported from `src/lib/fresh-agent-registry.ts`, matching existing `derivePaneTitle.ts` usage.
+   - `extractTitleFromMessage()` is imported from `@shared/title-utils`, matching `AgentChatView`.
+   - `updatePaneTitle()` and `updateTab()` match existing `AgentChatView` usage.

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "node": ">=22.5.0"
   },
   "scripts": {
-    "predev": "cross-env PORT=3002 tsx scripts/precheck.ts",
+    "predev": "tsx scripts/run-with-default-port.ts tsx scripts/precheck.ts",
     "preserve": "tsx scripts/precheck.ts",
-    "dev": "cross-env PORT=3002 concurrently -n client,server -c blue,green \"vite\" \"tsx watch server/index.ts\"",
+    "dev": "tsx scripts/run-with-default-port.ts concurrently -n client,server -c blue,green \"vite\" \"tsx watch server/index.ts\"",
     "dev:client": "vite",
-    "dev:server": "cross-env PORT=3002 tsx watch server/index.ts",
+    "dev:server": "tsx scripts/run-with-default-port.ts tsx watch server/index.ts",
     "dev:queue": "tsx scripts/dev-pr-queue.ts",
     "selfhost:check-branch": "tsx scripts/selfhost-branch.ts validate-launch",
     "typecheck": "npm run typecheck:client && npm run typecheck:server",

--- a/scripts/run-with-default-port.ts
+++ b/scripts/run-with-default-port.ts
@@ -1,0 +1,32 @@
+import { spawn } from 'node:child_process'
+
+const args = process.argv.slice(2)
+
+if (args.length === 0) {
+  console.error('run-with-default-port requires a command')
+  process.exit(1)
+}
+
+const env = {
+  ...process.env,
+  PORT: process.env.PORT || '3002',
+}
+
+const child = spawn(args[0], args.slice(1), {
+  env,
+  shell: process.platform === 'win32',
+  stdio: 'inherit',
+})
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+  process.exit(code ?? 0)
+})
+
+child.on('error', (error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/server/fresh-agent/adapters/codex/adapter.ts
+++ b/server/fresh-agent/adapters/codex/adapter.ts
@@ -154,8 +154,9 @@ function makeCodexStatusEvent(sessionId: string, status: unknown, revision?: num
 }
 
 function isCodexIncludeTurnsUnavailable(error: unknown): boolean {
-  return error instanceof Error
-    && error.message.includes('includeTurns is unavailable before first user message')
+  if (!(error instanceof Error)) return false
+  return error.message.includes('includeTurns is unavailable before first user message')
+    || error.message.includes('not materialized yet')
 }
 
 function findActiveTurnId(rawSnapshot: Record<string, any>): string | undefined {

--- a/server/fresh-agent/runtime-manager.ts
+++ b/server/fresh-agent/runtime-manager.ts
@@ -185,15 +185,19 @@ export class FreshAgentRuntimeManager {
       throw new FreshAgentUnsupportedCapabilityError(`Fork is not supported for ${record.sessionType}`)
     }
     const forked = await record.adapter.fork(locator.sessionId, input)
-    const forkedRecord = forked && typeof forked === 'object' ? forked as Record<string, unknown> : {}
-    const forkedSessionId = typeof forkedRecord.threadId === 'string'
-      ? forkedRecord.threadId
-      : (typeof forkedRecord.sessionId === 'string' ? forkedRecord.sessionId : undefined)
-    if (forkedSessionId) {
+    const forkedRecord = forked && typeof forked === 'object' && !Array.isArray(forked)
+      ? forked as { sessionId?: unknown; threadId?: unknown }
+      : undefined
+    const childSessionId = typeof forkedRecord?.sessionId === 'string'
+      ? forkedRecord.sessionId
+      : typeof forkedRecord?.threadId === 'string'
+        ? forkedRecord.threadId
+        : undefined
+    if (childSessionId) {
       this.sessions.set(this.key({
         sessionType: locator.sessionType,
-        provider: locator.provider,
-        sessionId: forkedSessionId,
+        provider: record.runtimeProvider,
+        sessionId: childSessionId,
       }), record)
     }
     return forked

--- a/src/components/fresh-agent/FreshAgentComposer.tsx
+++ b/src/components/fresh-agent/FreshAgentComposer.tsx
@@ -1,12 +1,28 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
-import { Command } from 'lucide-react'
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react'
+import { Command, Send, Square } from 'lucide-react'
 import type { FreshAgentSlashCommand } from '@shared/fresh-agent-slash-commands'
 
 type FreshAgentComposerProps = {
   disabled?: boolean
+  storageKey?: string
   onSend?: (value: string) => void
+  onInterrupt?: () => void
+  canInterrupt?: boolean
   commands?: readonly FreshAgentSlashCommand[]
   onCommand?: (command: FreshAgentSlashCommand, args: string) => void
+}
+
+export type FreshAgentComposerHandle = {
+  focus: () => void
 }
 
 type MenuMode = 'chat' | 'browse'
@@ -25,18 +41,28 @@ function parseSlashCommand(value: string): { name: string; args: string } | null
   return { name: match[1].toLowerCase(), args: match[2]?.trim() ?? '' }
 }
 
-export function FreshAgentComposer({
+export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgentComposerProps>(function FreshAgentComposer({
   disabled = false,
+  storageKey,
   onSend,
+  onInterrupt,
+  canInterrupt = false,
   commands = [],
   onCommand,
-}: FreshAgentComposerProps) {
-  const [text, setText] = useState('')
+}, ref) {
+  const [text, setText] = useState(() => {
+    if (!storageKey || typeof window === 'undefined') return ''
+    return window.sessionStorage.getItem(storageKey) ?? ''
+  })
   const [menuMode, setMenuMode] = useState<MenuMode | null>(null)
   const [filter, setFilter] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(0)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const filterRef = useRef<HTMLInputElement | null>(null)
+
+  useImperativeHandle(ref, () => ({
+    focus: () => textareaRef.current?.focus(),
+  }), [])
 
   const chatPrefix = getCommandPrefix(text)
   const activeFilter = menuMode === 'chat' ? (chatPrefix ?? '') : filter.toLowerCase()
@@ -44,6 +70,22 @@ export function FreshAgentComposer({
     const normalizedFilter = activeFilter.replace(/^\//, '')
     return commands.filter((command) => command.name.includes(normalizedFilter))
   }, [activeFilter, commands])
+
+  useEffect(() => {
+    if (!storageKey || typeof window === 'undefined') return
+    if (text) {
+      window.sessionStorage.setItem(storageKey, text)
+    } else {
+      window.sessionStorage.removeItem(storageKey)
+    }
+  }, [storageKey, text])
+
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+    textarea.style.height = 'auto'
+    textarea.style.height = `${Math.min(180, Math.max(40, textarea.scrollHeight))}px`
+  }, [text])
 
   useEffect(() => {
     setHighlightedIndex(0)
@@ -208,8 +250,10 @@ export function FreshAgentComposer({
           name="message"
           aria-label="Chat message input"
           disabled={disabled}
-          rows={2}
+          rows={1}
           value={text}
+          placeholder={disabled ? 'Read-only session' : 'Send a message'}
+          className="max-h-44 min-h-[40px] flex-1 resize-none rounded-md border border-border/70 bg-background px-3 py-2 text-sm outline-none"
           onChange={(event) => setText(event.target.value)}
           onKeyDown={(event) => {
             if (handleMenuKeyDown(event)) return
@@ -217,10 +261,22 @@ export function FreshAgentComposer({
               event.preventDefault()
               sendText()
             }
+            if (event.key === 'Escape' && canInterrupt) {
+              event.preventDefault()
+              onInterrupt?.()
+            }
           }}
-          placeholder={disabled ? 'Read-only session' : 'Send a message'}
-          className="min-h-[52px] flex-1 resize-none rounded-md border border-border/70 bg-background px-3 py-2 text-sm outline-none"
         />
+        {canInterrupt ? (
+          <button
+            type="button"
+            onClick={onInterrupt}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-border bg-background text-sm transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Stop"
+          >
+            <Square className="h-4 w-4" />
+          </button>
+        ) : null}
         <button
           type="button"
           disabled={disabled || commands.length === 0}
@@ -237,11 +293,12 @@ export function FreshAgentComposer({
         <button
           type="submit"
           disabled={disabled}
-          className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Send"
         >
-          Send
+          <Send className="h-4 w-4" />
         </button>
       </div>
     </form>
   )
-}
+})

--- a/src/components/fresh-agent/FreshAgentItemCard.tsx
+++ b/src/components/fresh-agent/FreshAgentItemCard.tsx
@@ -1,4 +1,9 @@
+import { memo, useMemo, useState } from 'react'
+import { Check, ChevronRight, Loader2, X } from 'lucide-react'
+import DiffView from '@/components/agent-chat/DiffView'
+import { getToolPreview } from '@/components/agent-chat/tool-preview'
 import type { FreshAgentTranscriptItem } from '@shared/fresh-agent-contract'
+import { cn } from '@/lib/utils'
 
 function formatJson(value: unknown): string {
   if (typeof value === 'string') return value
@@ -7,6 +12,30 @@ function formatJson(value: unknown): string {
   } catch {
     return String(value)
   }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+}
+
+function summarizeResult(name: string, output?: string, isError?: boolean): string | null {
+  if (isError) return 'error'
+  if (!output) return null
+  if (name === 'Read' || name === 'Result') {
+    const lineCount = output.split('\n').length
+    return `${lineCount} line${lineCount === 1 ? '' : 's'}`
+  }
+  if (name === 'Grep' || name === 'Glob') {
+    const matchCount = output.trim().split('\n').filter(Boolean).length
+    return `${matchCount} match${matchCount === 1 ? '' : 'es'}`
+  }
+  if (name === 'Bash' || name === 'Command') {
+    const lineCount = output.split('\n').filter(Boolean).length
+    return lineCount > 3 ? `${lineCount} lines` : 'done'
+  }
+  return 'done'
 }
 
 function StatusBadge({ value }: { value?: string }) {
@@ -18,13 +47,195 @@ function StatusBadge({ value }: { value?: string }) {
   )
 }
 
+export interface FreshAgentToolDisplay {
+  id: string
+  name: string
+  input?: Record<string, unknown>
+  output?: string
+  isError?: boolean
+  status: 'running' | 'complete'
+}
+
+export function stripSystemReminders(text: string): string {
+  return text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '').trim()
+}
+
+export function FreshAgentToolBlock({
+  tool,
+  initialExpanded = false,
+}: {
+  tool: FreshAgentToolDisplay
+  initialExpanded?: boolean
+}) {
+  const [expanded, setExpanded] = useState(initialExpanded)
+  const preview = useMemo(() => getToolPreview(tool.name, tool.input), [tool.input, tool.name])
+  const resultSummary = summarizeResult(tool.name, tool.output, tool.isError)
+  const hasEditDiff = tool.name === 'Edit'
+    && typeof tool.input?.old_string === 'string'
+    && typeof tool.input?.new_string === 'string'
+
+  return (
+    <div
+      className={cn(
+        'my-0.5 border-l-2 text-xs',
+        tool.isError ? 'border-l-[hsl(var(--destructive))]' : 'border-l-[hsl(var(--primary))]',
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-center gap-2 rounded-r px-2 py-0.5 text-left transition-colors hover:bg-accent/50"
+        aria-expanded={expanded}
+        aria-label={`${tool.name} tool call`}
+      >
+        <ChevronRight className={cn('h-3 w-3 shrink-0 transition-transform', expanded && 'rotate-90')} />
+        <span className="font-medium">{tool.name}:</span>
+        {preview ? <span className="truncate font-mono text-muted-foreground">{preview}</span> : null}
+        {resultSummary ? (
+          <span className={cn('shrink-0 text-muted-foreground', tool.isError && 'text-destructive')}>
+            ({resultSummary})
+          </span>
+        ) : null}
+        <span className="ml-auto shrink-0">
+          {tool.status === 'running' ? <Loader2 className="h-3 w-3 animate-spin" aria-label="running" /> : null}
+          {tool.status === 'complete' && !tool.isError ? <Check className="h-3 w-3 text-green-500" aria-label="complete" /> : null}
+          {tool.status === 'complete' && tool.isError ? <X className="h-3 w-3 text-destructive" aria-label="error" /> : null}
+        </span>
+      </button>
+      {expanded ? (
+        <div className="border-t border-border/50 px-2 py-1 text-xs">
+          {hasEditDiff ? (
+            <DiffView
+              oldStr={String(tool.input?.old_string ?? '')}
+              newStr={String(tool.input?.new_string ?? '')}
+              filePath={typeof tool.input?.file_path === 'string' ? tool.input.file_path : undefined}
+            />
+          ) : (
+            <>
+              {tool.input ? (
+                <pre
+                  className="max-h-48 overflow-y-auto whitespace-pre-wrap break-words font-mono opacity-80"
+                  data-tool-input=""
+                  data-tool-name={tool.name}
+                >
+                  {tool.name === 'Bash' && typeof tool.input.command === 'string'
+                    ? tool.input.command
+                    : JSON.stringify(tool.input, null, 2)}
+                </pre>
+              ) : null}
+              {tool.output ? (
+                <pre
+                  className={cn(
+                    'mt-0.5 max-h-48 overflow-y-auto whitespace-pre-wrap break-words font-mono',
+                    tool.isError ? 'text-destructive' : 'opacity-80',
+                  )}
+                  data-tool-output=""
+                >
+                  {tool.output}
+                </pre>
+              ) : null}
+            </>
+          )}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export function itemToToolDisplay(item: FreshAgentTranscriptItem): FreshAgentToolDisplay | null {
+  if (item.kind === 'tool_use') {
+    return {
+      id: item.toolUseId,
+      name: item.name,
+      input: asRecord(item.input),
+      status: 'running',
+    }
+  }
+  if (item.kind === 'command') {
+    return {
+      id: item.id,
+      name: 'Bash',
+      input: { command: item.command, ...(item.cwd ? { cwd: item.cwd } : {}) },
+      output: item.output ?? undefined,
+      isError: item.status === 'failed',
+      status: item.status === 'running' ? 'running' : 'complete',
+    }
+  }
+  if (item.kind === 'file_change') {
+    return {
+      id: item.id,
+      name: 'Edit',
+      input: { changes: item.changes },
+      isError: item.status === 'failed',
+      status: item.status === 'running' ? 'running' : 'complete',
+    }
+  }
+  if (item.kind === 'mcp_tool') {
+    return {
+      id: item.id,
+      name: `${item.server}/${item.tool}`,
+      input: asRecord(item.arguments) ?? { arguments: item.arguments },
+      output: item.result !== undefined ? formatJson(item.result) : item.error !== undefined ? formatJson(item.error) : undefined,
+      isError: item.status === 'failed',
+      status: item.status === 'running' ? 'running' : 'complete',
+    }
+  }
+  if (item.kind === 'dynamic_tool') {
+    return {
+      id: item.id,
+      name: item.namespace ? `${item.namespace}.${item.tool}` : item.tool,
+      input: asRecord(item.arguments) ?? { arguments: item.arguments },
+      output: item.contentItems !== undefined ? formatJson(item.contentItems) : undefined,
+      isError: item.status === 'failed' || item.success === false,
+      status: item.status === 'running' ? 'running' : 'complete',
+    }
+  }
+  if (item.kind === 'web_search') {
+    return {
+      id: item.id,
+      name: 'WebSearch',
+      input: { query: item.query, ...(item.action ? { action: item.action } : {}) },
+      status: 'complete',
+    }
+  }
+  if (item.kind === 'image_view') {
+    return {
+      id: item.id,
+      name: 'Read',
+      input: { file_path: item.path },
+      status: 'complete',
+    }
+  }
+  if (item.kind === 'image_generation') {
+    return {
+      id: item.id,
+      name: 'ImageGeneration',
+      input: { prompt: item.revisedPrompt },
+      output: item.savedPath ?? item.result,
+      isError: item.status === 'failed',
+      status: item.status === 'running' ? 'running' : 'complete',
+    }
+  }
+  return null
+}
+
+function renderText(text: string) {
+  const visibleText = stripSystemReminders(text)
+  if (!visibleText) return null
+  return <p className="whitespace-pre-wrap break-words">{visibleText}</p>
+}
+
 export function FreshAgentItemCard({ item }: { item: FreshAgentTranscriptItem }) {
   if (item.kind === 'text' || item.kind === 'thinking') {
-    return (
-      <p className="whitespace-pre-wrap break-words">
-        {item.text}
-      </p>
-    )
+    if (item.kind === 'thinking') {
+      return (
+        <details className="border-l-2 border-l-[hsl(var(--primary))] pl-2.5 text-xs text-muted-foreground">
+          <summary className="cursor-pointer font-medium">Thinking</summary>
+          <div className="mt-1 text-sm">{renderText(item.text)}</div>
+        </details>
+      )
+    }
+    return renderText(item.text)
   }
 
   if (item.kind === 'reasoning') {
@@ -40,68 +251,20 @@ export function FreshAgentItemCard({ item }: { item: FreshAgentTranscriptItem })
     )
   }
 
-  if (item.kind === 'tool_use') {
-    return (
-      <div className="rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
-        <div className="mb-1 font-medium">{item.name}</div>
-        <pre className="overflow-x-auto whitespace-pre-wrap break-words">{formatJson(item.input ?? {})}</pre>
-      </div>
-    )
+  const tool = itemToToolDisplay(item)
+  if (tool) {
+    return <FreshAgentToolBlock tool={tool} />
   }
 
   if (item.kind === 'tool_result') {
     return (
-      <div className="rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
+      <div className="border-l-2 border-l-border px-2 py-1 text-xs">
         <div className="mb-1 flex items-center gap-2 font-medium">
           Tool result
           {item.isError ? <StatusBadge value="error" /> : null}
         </div>
         <pre className="overflow-x-auto whitespace-pre-wrap break-words">{formatJson(item.content)}</pre>
       </div>
-    )
-  }
-
-  if (item.kind === 'command') {
-    return (
-      <div className="rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
-        <div className="mb-1 flex items-center justify-between gap-2">
-          <span className="font-medium">Command</span>
-          <StatusBadge value={item.status} />
-        </div>
-        {item.cwd ? <div className="mb-1 text-muted-foreground">{item.cwd}</div> : null}
-        <pre className="overflow-x-auto whitespace-pre-wrap break-words">$ {item.command}</pre>
-        {item.output ? <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words text-muted-foreground">{item.output}</pre> : null}
-        {typeof item.exitCode === 'number' ? <div className="mt-1 text-muted-foreground">exit {item.exitCode}</div> : null}
-      </div>
-    )
-  }
-
-  if (item.kind === 'file_change') {
-    return (
-      <details className="rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
-        <summary className="cursor-pointer font-medium">
-          File changes <StatusBadge value={item.status} />
-        </summary>
-        <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words">{formatJson(item.changes)}</pre>
-      </details>
-    )
-  }
-
-  if (item.kind === 'mcp_tool' || item.kind === 'dynamic_tool') {
-    const title = item.kind === 'mcp_tool' ? `${item.server}/${item.tool}` : item.tool
-    return (
-      <details className="rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
-        <summary className="cursor-pointer font-medium">
-          {title} <StatusBadge value={item.status} />
-        </summary>
-        <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words">{formatJson(item.arguments)}</pre>
-        {'result' in item && item.result !== undefined ? (
-          <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words text-muted-foreground">{formatJson(item.result)}</pre>
-        ) : null}
-        {'contentItems' in item && item.contentItems ? (
-          <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words text-muted-foreground">{formatJson(item.contentItems)}</pre>
-        ) : null}
-      </details>
     )
   }
 

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -1,5 +1,16 @@
-import type { FreshAgentTurn } from '@shared/fresh-agent-contract'
-import { FreshAgentItemCard } from './FreshAgentItemCard'
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import SlotReel from '@/components/agent-chat/SlotReel'
+import { getToolPreview } from '@/components/agent-chat/tool-preview'
+import { cn } from '@/lib/utils'
+import type { FreshAgentTranscriptItem, FreshAgentTurn } from '@shared/fresh-agent-contract'
+import {
+  FreshAgentItemCard,
+  FreshAgentToolBlock,
+  itemToToolDisplay,
+  stripSystemReminders,
+  type FreshAgentToolDisplay,
+} from './FreshAgentItemCard'
 
 function getTurnLabel(turn: FreshAgentTurn): string {
   switch (turn.role) {
@@ -16,33 +27,277 @@ function getTurnLabel(turn: FreshAgentTurn): string {
   }
 }
 
-export function FreshAgentTranscript({ turns }: { turns: FreshAgentTurn[] }) {
+function isToolLike(item: FreshAgentTranscriptItem): boolean {
+  return item.kind === 'tool_use'
+    || item.kind === 'tool_result'
+    || item.kind === 'command'
+    || item.kind === 'file_change'
+    || item.kind === 'mcp_tool'
+    || item.kind === 'dynamic_tool'
+    || item.kind === 'web_search'
+    || item.kind === 'image_view'
+    || item.kind === 'image_generation'
+}
+
+function formatJson(value: unknown): string {
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value ?? null, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+function buildTools(items: FreshAgentTranscriptItem[]): FreshAgentToolDisplay[] {
+  const tools = new Map<string, FreshAgentToolDisplay>()
+  const orderedIds: string[] = []
+  for (const item of items) {
+    if (item.kind === 'tool_result') {
+      const existing = tools.get(item.toolUseId)
+      if (existing) {
+        tools.set(item.toolUseId, {
+          ...existing,
+          output: formatJson(item.content),
+          isError: item.isError,
+          status: 'complete',
+        })
+      } else {
+        orderedIds.push(item.id)
+        tools.set(item.id, {
+          id: item.id,
+          name: 'Result',
+          output: formatJson(item.content),
+          isError: item.isError,
+          status: 'complete',
+        })
+      }
+      continue
+    }
+    const tool = itemToToolDisplay(item)
+    if (!tool) continue
+    if (!tools.has(tool.id)) orderedIds.push(tool.id)
+    tools.set(tool.id, tool)
+  }
+  return orderedIds.map((id) => tools.get(id)).filter(Boolean) as FreshAgentToolDisplay[]
+}
+
+type RenderBlock =
+  | { kind: 'item'; item: FreshAgentTranscriptItem }
+  | { kind: 'tools'; id: string; tools: FreshAgentToolDisplay[] }
+
+function buildBlocks(items: FreshAgentTranscriptItem[]): RenderBlock[] {
+  const blocks: RenderBlock[] = []
+  let pendingTools: FreshAgentTranscriptItem[] = []
+  const flushTools = () => {
+    if (pendingTools.length === 0) return
+    const tools = buildTools(pendingTools)
+    if (tools.length > 0) {
+      blocks.push({ kind: 'tools', id: pendingTools.map((item) => item.id).join(':'), tools })
+    }
+    pendingTools = []
+  }
+  for (const item of items) {
+    if (isToolLike(item)) {
+      pendingTools.push(item)
+      continue
+    }
+    flushTools()
+    blocks.push({ kind: 'item', item })
+  }
+  flushTools()
+  return blocks
+}
+
+function FreshAgentToolStrip({ tools }: { tools: FreshAgentToolDisplay[] }) {
+  const [expanded, setExpanded] = useState(false)
+  const hasErrors = tools.some((tool) => tool.isError)
+  const allComplete = tools.every((tool) => tool.status === 'complete')
+  const currentTool = [...tools].reverse().find((tool) => tool.status === 'running') ?? tools[tools.length - 1] ?? null
+  const settledText = `${tools.length} tool${tools.length === 1 ? '' : 's'} used`
+
+  if (tools.length === 0) return null
   return (
-    <div className="flex flex-1 flex-col gap-3 overflow-y-auto px-3 py-3" data-context="fresh-agent-transcript">
-      {turns.map((turn) => {
-        const isUser = turn.role === 'user'
-        return (
-          <article
-            key={turn.id}
-            className={isUser
-              ? 'max-w-[92%] self-end rounded-xl bg-primary px-4 py-3 text-primary-foreground'
-              : 'max-w-[96%] self-start rounded-xl bg-muted px-4 py-3'}
-            aria-label={`${getTurnLabel(turn)} transcript turn`}
+    <div role="region" aria-label="Tool strip" className="my-0.5">
+      {!expanded ? (
+        <div
+          className={cn(
+            'flex min-w-0 items-center gap-1 border-l-2 px-2 py-0.5 text-xs',
+            hasErrors ? 'border-l-[hsl(var(--destructive))]' : 'border-l-[hsl(var(--primary))]',
+          )}
+        >
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            className="shrink-0 rounded p-0.5 transition-colors hover:bg-accent/50"
+            aria-label="Toggle tool details"
+            aria-expanded={false}
           >
-            <div className="mb-2 flex items-center justify-between gap-2 text-[11px] uppercase tracking-[0.16em] opacity-70">
-              <span>{getTurnLabel(turn)}</span>
-              {turn.model ? <span>{turn.model}</span> : null}
-            </div>
-            <div className="space-y-2 text-sm">
-              {turn.items.length > 0 ? (
-                turn.items.map((item) => <FreshAgentItemCard key={item.id} item={item} />)
-              ) : (
-                <p className="whitespace-pre-wrap break-words">{turn.summary}</p>
-              )}
-            </div>
-          </article>
-        )
-      })}
+            <ChevronRight className="h-3 w-3" />
+          </button>
+          <SlotReel
+            toolName={allComplete ? null : (currentTool?.name ?? null)}
+            previewText={allComplete ? null : (currentTool ? getToolPreview(currentTool.name, currentTool.input) : null)}
+            settledText={allComplete ? settledText : undefined}
+          />
+        </div>
+      ) : (
+        <>
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            className="ml-1.5 shrink-0 rounded p-0.5 transition-colors hover:bg-accent/50"
+            aria-label="Toggle tool details"
+            aria-expanded={true}
+          >
+            <ChevronRight className="h-3 w-3 rotate-90 transition-transform" />
+          </button>
+          {tools.map((tool) => (
+            <FreshAgentToolBlock key={tool.id} tool={tool} initialExpanded={false} />
+          ))}
+        </>
+      )}
     </div>
   )
 }
+
+function countTools(turn: FreshAgentTurn): number {
+  return buildTools(turn.items.filter(isToolLike)).length
+}
+
+function getTurnSummary(turn: FreshAgentTurn): string {
+  const text = turn.items
+    .filter((item): item is Extract<FreshAgentTranscriptItem, { kind: 'text' }> => item.kind === 'text')
+    .map((item) => stripSystemReminders(item.text))
+    .join(' ')
+    .trim()
+    .replace(/\s+/g, ' ')
+  const base = text || turn.summary || getTurnLabel(turn)
+  const short = base.length > 44 ? `${base.slice(0, 41)}...` : base
+  const toolCount = countTools(turn)
+  const itemCount = turn.items.filter((item) => item.kind === 'text').length
+  const parts: string[] = []
+  if (toolCount > 0) parts.push(`${toolCount} tool${toolCount === 1 ? '' : 's'}`)
+  if (itemCount > 0 && turn.role !== 'user') parts.push(`${itemCount} msg${itemCount === 1 ? '' : 's'}`)
+  return parts.length > 0 ? `${short} -> ${parts.join(', ')}` : short
+}
+
+function CollapsedFreshAgentTurn({ turn }: { turn: FreshAgentTurn }) {
+  const [expanded, setExpanded] = useState(false)
+  const summary = getTurnSummary(turn)
+  if (expanded) {
+    return (
+      <div className="space-y-2">
+        <button
+          type="button"
+          onClick={() => setExpanded(false)}
+          className="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          aria-expanded={true}
+          aria-label="Collapse turn"
+        >
+          <ChevronRight className="h-3 w-3 rotate-90 transition-transform" />
+          <span className="truncate font-mono opacity-70">{summary}</span>
+        </button>
+        <FreshAgentTurnArticle turn={turn} compact={false} />
+      </div>
+    )
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => setExpanded(true)}
+      className="flex w-full items-center gap-1 text-left text-xs text-muted-foreground transition-colors hover:text-foreground"
+      aria-expanded={false}
+      aria-label="Expand turn"
+    >
+      <ChevronRight className="h-3 w-3 shrink-0 transition-transform" />
+      <span className="truncate font-mono">{summary}</span>
+    </button>
+  )
+}
+
+function FreshAgentTurnArticle({ turn, compact }: { turn: FreshAgentTurn; compact: boolean }) {
+  const isUser = turn.role === 'user'
+  const blocks = buildBlocks(turn.items)
+  return (
+    <article
+      className={cn(
+        'w-full border-l-2 py-0.5 pl-2.5 pr-1',
+        isUser ? 'border-l-[hsl(var(--primary))]' : 'border-l-border',
+        compact && 'opacity-95',
+      )}
+      aria-label={`${getTurnLabel(turn)} transcript turn`}
+    >
+      <div className="mb-1 flex items-center justify-between gap-2 text-[11px] uppercase text-muted-foreground">
+        <span>{getTurnLabel(turn)}</span>
+        {turn.model ? <span className="truncate normal-case">{turn.model}</span> : null}
+      </div>
+      <div className="space-y-1.5 text-sm">
+        {blocks.length > 0 ? blocks.map((block) => {
+          if (block.kind === 'tools') return <FreshAgentToolStrip key={block.id} tools={block.tools} />
+          return <FreshAgentItemCard key={block.item.id} item={block.item} />
+        }) : (
+          <p className="whitespace-pre-wrap break-words">{stripSystemReminders(turn.summary)}</p>
+        )}
+      </div>
+    </article>
+  )
+}
+
+export function FreshAgentTranscript({ turns }: { turns: FreshAgentTurn[] }) {
+  const scrollerRef = useRef<HTMLDivElement | null>(null)
+  const [atBottom, setAtBottom] = useState(true)
+  const [newMessages, setNewMessages] = useState(0)
+  const turnKeys = useMemo(() => turns.map((turn) => turn.id).join('|'), [turns])
+
+  useEffect(() => {
+    const node = scrollerRef.current
+    if (!node) return
+    if (atBottom) {
+      node.scrollTop = node.scrollHeight
+      setNewMessages(0)
+    } else {
+      setNewMessages((count) => count + 1)
+    }
+  }, [atBottom, turnKeys])
+
+  const collapsedCutoff = Math.max(0, turns.length - 8)
+
+  return (
+    <div className="relative min-h-0 flex-1">
+      <div
+        ref={scrollerRef}
+        className="flex h-full flex-col gap-3 overflow-y-auto px-3 py-3"
+        data-context="fresh-agent-transcript"
+        onScroll={(event) => {
+          const node = event.currentTarget
+          setAtBottom(node.scrollHeight - node.scrollTop - node.clientHeight < 24)
+        }}
+      >
+        {turns.map((turn, index) => (
+          index < collapsedCutoff
+            ? <CollapsedFreshAgentTurn key={turn.id} turn={turn} />
+            : <FreshAgentTurnArticle key={turn.id} turn={turn} compact={index < collapsedCutoff} />
+        ))}
+      </div>
+      {!atBottom ? (
+        <button
+          type="button"
+          className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-background px-3 py-1 text-xs shadow"
+          onClick={() => {
+            const node = scrollerRef.current
+            if (!node) return
+            node.scrollTop = node.scrollHeight
+            setAtBottom(true)
+            setNewMessages(0)
+          }}
+          aria-label="Scroll to bottom"
+        >
+          <ChevronDown className="h-3 w-3" />
+          {newMessages > 0 ? `${newMessages} new` : 'Bottom'}
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
+export default memo(FreshAgentTranscript)

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -23,7 +23,7 @@ import { buildRestoreError, type RestoreErrorReason } from '@shared/session-cont
 import { FreshAgentApprovalBanner } from './FreshAgentApprovalBanner'
 import FreshAgentQuestionBanner from './FreshAgentQuestionBanner'
 import { FreshAgentTranscript } from './FreshAgentTranscript'
-import { FreshAgentComposer } from './FreshAgentComposer'
+import { FreshAgentComposer, type FreshAgentComposerHandle } from './FreshAgentComposer'
 import { FreshAgentDiffPanel } from './FreshAgentDiffPanel'
 import { FreshAgentSidebar } from './FreshAgentSidebar'
 
@@ -154,6 +154,7 @@ export function FreshAgentView({
   const descriptor = resolveFreshAgentType(paneContent.sessionType)
   const slashCommands = useMemo(() => getFreshAgentSlashCommands(paneContent.sessionType), [paneContent.sessionType])
   const paneContentRef = useRef(paneContent)
+  const composerRef = useRef<FreshAgentComposerHandle | null>(null)
   paneContentRef.current = paneContent
   const restoreTimeoutRef = useRef<number | null>(null)
   const createSentRef = useRef(false)
@@ -660,6 +661,11 @@ export function FreshAgentView({
       && !hasRestoreFailure
       && !['creating', 'starting', 'create-failed', 'exited'].includes(effectiveStatus)
     )
+    const canInterrupt = snapshot?.capabilities?.interrupt === true || (
+      paneContent.provider === 'claude'
+      && Boolean(paneContent.sessionId)
+      && ['connected', 'running', 'idle', 'compacting'].includes(effectiveStatus)
+    )
     const questionAgentLabel = getQuestionAgentLabel(paneContent, descriptor?.label)
     const visibleRestoreFailure = paneContent.provider === 'claude'
       ? claudeSession?.restoreFailureMessage
@@ -668,11 +674,26 @@ export function FreshAgentView({
       ? null
       : (paneContent.restoreError ? getRestoreErrorMessage(paneContent.restoreError.reason) : null)
     const visibleLoadError = visibleRestoreFailure || visiblePaneRestoreFailure || isRestoring ? null : loadError
+    const sendInterrupt = () => {
+      if (!paneContent.sessionId || !canInterrupt) return
+      sendFreshAgentMessage({
+        type: 'freshAgent.interrupt',
+        sessionId: paneContent.sessionId,
+        sessionType: paneContent.sessionType,
+        provider: paneContent.provider,
+      })
+    }
 
     return (
       <div className="flex h-full min-h-0 flex-col" data-context="fresh-agent" data-session-id={paneContent.sessionId}>
         <div className="flex min-h-0 flex-1">
-          <div className="flex min-h-0 flex-1 flex-col">
+          <div
+            className="flex min-h-0 flex-1 flex-col"
+            onClick={(event) => {
+              if (event.target !== event.currentTarget) return
+              composerRef.current?.focus()
+            }}
+          >
             <div className="space-y-2 px-3 pt-3">
               {isRestoring ? (
                 <FreshAgentApprovalBanner text="Restoring session..." />
@@ -778,7 +799,11 @@ export function FreshAgentView({
             </div>
             <FreshAgentTranscript turns={turns} />
             <FreshAgentComposer
+              ref={composerRef}
               disabled={!canSend || !paneContent.sessionId}
+              storageKey={`fresh-agent-draft:${paneContent.sessionType}:${paneContent.sessionId ?? paneContent.createRequestId}`}
+              canInterrupt={canInterrupt && Boolean(paneContent.sessionId)}
+              onInterrupt={sendInterrupt}
               commands={slashCommands}
               onCommand={runSlashCommand}
               onSend={(text) => {

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -5,7 +5,8 @@ import type { FreshAgentPaneContent } from '@/store/paneTypes'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { getWsClient } from '@/lib/ws-client'
 import { getFreshAgentThreadSnapshot } from '@/lib/api'
-import { consumePaneRefreshRequest, mergePaneContent, updatePaneContent } from '@/store/panesSlice'
+import { consumePaneRefreshRequest, mergePaneContent, updatePaneContent, updatePaneTitle } from '@/store/panesSlice'
+import { updateTab } from '@/store/tabsSlice'
 import { clearPendingCreateFailure } from '@/store/freshAgentSlice'
 import { handleFreshAgentTransportEvent, registerFreshAgentCreate } from '@/lib/fresh-agent-ws'
 import {
@@ -20,6 +21,7 @@ import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
 import type { FreshAgentSnapshot } from '@shared/fresh-agent-contract'
 import { getFreshAgentSlashCommands, type FreshAgentSlashCommand } from '@shared/fresh-agent-slash-commands'
 import { buildRestoreError, type RestoreErrorReason } from '@shared/session-contract'
+import { extractTitleFromMessage } from '@shared/title-utils'
 import { FreshAgentApprovalBanner } from './FreshAgentApprovalBanner'
 import FreshAgentQuestionBanner from './FreshAgentQuestionBanner'
 import { FreshAgentTranscript } from './FreshAgentTranscript'
@@ -138,6 +140,8 @@ export function FreshAgentView({
   const pendingCreateFailure = useAppSelector(
     (state) => state.freshAgent?.pendingCreateFailures?.[paneContent.createRequestId],
   )
+  const currentTab = useAppSelector((state) => state.tabs?.tabs?.find((tab) => tab.id === tabId))
+  const tabTitleSetByUser = currentTab?.titleSetByUser ?? false
   const claudeSession = useAppSelector((state) => {
     if (paneContent.provider !== 'claude' || !paneContent.sessionId) return undefined
     const sessionKey = makeFreshAgentSessionKey({
@@ -158,6 +162,17 @@ export function FreshAgentView({
   paneContentRef.current = paneContent
   const restoreTimeoutRef = useRef<number | null>(null)
   const createSentRef = useRef(false)
+  // Auto-title state tracks four things:
+  // 1. whether this mounted pane has already consumed first-message auto-title,
+  // 2. whether we observed a fresh conversation boundary in this mount,
+  // 3. the last create boundary we saw, and
+  // 4. the last stable/effective conversation identity so retries, restores, and materialization
+  //    can preserve latch state for the same conversation instead of reopening it.
+  const autoTitleSentRef = useRef(false)
+  const autoTitleFreshBoundaryRef = useRef(false)
+  const autoTitleCreateRequestIdRef = useRef(paneContent.createRequestId)
+  const autoTitleDurableIdentityRef = useRef<string | null>(null)
+  const autoTitleIdentityRef = useRef<string | null>(null)
   const handledRefreshRequestIdRef = useRef<string | null>(null)
   const preferredResumeSessionId = getPreferredResumeSessionId(claudeSession) ?? paneContent.resumeSessionId
   const snapshotThreadId = paneContent.provider === 'claude'
@@ -178,6 +193,49 @@ export function FreshAgentView({
       && claudeSession?.historyLoaded !== true
       && !hasRestoreFailure,
   )
+  const hasUserTurns = useMemo(() => snapshot?.turns.some((turn) => turn.role === 'user') ?? false, [snapshot?.turns])
+  const autoTitleDurableIdentity = useMemo(() => {
+    const paneSessionRefId = paneContent.sessionRef?.provider === paneContent.provider
+      ? paneContent.sessionRef.sessionId
+      : undefined
+    const stableSnapshotThreadId = snapshotThreadId
+      && (
+        snapshotThreadId !== paneContent.sessionId
+        || (!paneSessionRefId && !preferredResumeSessionId && !paneContent.resumeSessionId)
+      )
+        ? snapshotThreadId
+        : undefined
+    return paneSessionRefId
+      ?? preferredResumeSessionId
+      ?? paneContent.resumeSessionId
+      ?? stableSnapshotThreadId
+      ?? null
+  }, [
+    paneContent.provider,
+    paneContent.resumeSessionId,
+    paneContent.sessionId,
+    paneContent.sessionRef,
+    preferredResumeSessionId,
+    snapshotThreadId,
+  ])
+  const autoTitleIdentity = useMemo(() => {
+    const stableIdentity = autoTitleDurableIdentity
+      ?? paneContent.sessionId
+      ?? paneContent.createRequestId
+    return `${paneContent.sessionType}:${paneContent.provider}:${stableIdentity}`
+  }, [
+    autoTitleDurableIdentity,
+    paneContent.createRequestId,
+    paneContent.provider,
+    paneContent.sessionId,
+    paneContent.sessionType,
+  ])
+  const [snapshotAutoTitleIdentity, setSnapshotAutoTitleIdentity] = useState<string | null>(null)
+  const hasCurrentSnapshot = snapshot !== null && snapshotAutoTitleIdentity === autoTitleIdentity
+  const snapshotConfirmsNoUserTurns = hasCurrentSnapshot && !hasUserTurns
+  const snapshotConfirmsUserTurns = hasCurrentSnapshot && hasUserTurns
+  const currentAutoTitleIdentityRef = useRef(autoTitleIdentity)
+  currentAutoTitleIdentityRef.current = autoTitleIdentity
 
   const sendFreshAgentMessage = useCallback((message: Record<string, unknown>) => {
     const suppressed = typeof window !== 'undefined'
@@ -194,6 +252,58 @@ export function FreshAgentView({
     prevCreateRequestIdRef.current = paneContent.createRequestId
     createSentRef.current = false
   }
+
+  useEffect(() => {
+    if (autoTitleCreateRequestIdRef.current !== paneContent.createRequestId) {
+      const previousAutoTitleIdentity = autoTitleIdentityRef.current
+      const previousDurableIdentity = autoTitleDurableIdentityRef.current
+      autoTitleCreateRequestIdRef.current = paneContent.createRequestId
+      autoTitleDurableIdentityRef.current = autoTitleDurableIdentity
+      autoTitleIdentityRef.current = autoTitleIdentity
+      if (
+        previousAutoTitleIdentity === autoTitleIdentity
+        || (autoTitleDurableIdentity && previousDurableIdentity === autoTitleDurableIdentity)
+      ) {
+        autoTitleFreshBoundaryRef.current = autoTitleFreshBoundaryRef.current || snapshotConfirmsNoUserTurns
+        autoTitleSentRef.current = autoTitleSentRef.current || snapshotConfirmsUserTurns
+      } else {
+        autoTitleFreshBoundaryRef.current = true
+        autoTitleSentRef.current = false
+        setSnapshotAutoTitleIdentity(null)
+      }
+      return
+    }
+    if (autoTitleIdentityRef.current === null) {
+      autoTitleDurableIdentityRef.current = autoTitleDurableIdentity
+      autoTitleIdentityRef.current = autoTitleIdentity
+      autoTitleFreshBoundaryRef.current = !paneContent.sessionId
+        && (paneContent.status === 'creating' || paneContent.status === 'starting')
+      autoTitleSentRef.current = snapshotConfirmsUserTurns
+      return
+    }
+    if (autoTitleIdentityRef.current !== autoTitleIdentity) {
+      autoTitleDurableIdentityRef.current = autoTitleDurableIdentity
+      autoTitleIdentityRef.current = autoTitleIdentity
+      autoTitleFreshBoundaryRef.current = autoTitleFreshBoundaryRef.current || snapshotConfirmsNoUserTurns
+      autoTitleSentRef.current = autoTitleSentRef.current || snapshotConfirmsUserTurns
+      return
+    }
+    if (snapshotConfirmsNoUserTurns && !autoTitleSentRef.current) {
+      autoTitleFreshBoundaryRef.current = true
+    }
+    if (snapshotConfirmsUserTurns) {
+      autoTitleFreshBoundaryRef.current = false
+      autoTitleSentRef.current = true
+    }
+  }, [
+    autoTitleDurableIdentity,
+    autoTitleIdentity,
+    paneContent.createRequestId,
+    paneContent.sessionId,
+    paneContent.status,
+    snapshotConfirmsNoUserTurns,
+    snapshotConfirmsUserTurns,
+  ])
 
   const buildCreateMessage = useCallback((content: FreshAgentPaneContent) => ({
     type: 'freshAgent.create',
@@ -488,10 +598,26 @@ export function FreshAgentView({
     setLoadError(null)
     const sessionId = snapshotThreadId
     const provider = paneContent.provider
+    const requestCreateRequestId = paneContent.createRequestId
+    const requestAutoTitleIdentity = autoTitleIdentity
+    const isStaleSnapshotRequest = () => (
+      paneContentRef.current.createRequestId !== requestCreateRequestId
+      || currentAutoTitleIdentityRef.current !== requestAutoTitleIdentity
+    )
     void getFreshAgentThreadSnapshot(paneContent.sessionType, provider, sessionId, { signal: controller.signal })
       .then((next) => {
+        if (isStaleSnapshotRequest()) return
         const resolved = next as FreshAgentSnapshot
+        const resolvedHasUserTurns = resolved.turns.some((turn) => turn.role === 'user')
+        if (!resolvedHasUserTurns && !autoTitleSentRef.current) {
+          autoTitleFreshBoundaryRef.current = true
+        }
+        if (resolvedHasUserTurns) {
+          autoTitleFreshBoundaryRef.current = false
+          autoTitleSentRef.current = true
+        }
         setSnapshot(resolved)
+        setSnapshotAutoTitleIdentity(requestAutoTitleIdentity)
         const fresh = paneContentRef.current
         const nextStatus = (resolved.status as FreshAgentPaneContent['status']) ?? fresh.status
         const snapshotSessionRef = provider === 'opencode' && resolved.sessionId && resolved.sessionId !== sessionId
@@ -523,6 +649,7 @@ export function FreshAgentView({
       })
       .catch((error: unknown) => {
         if (error instanceof Error && error.name === 'AbortError') return
+        if (isStaleSnapshotRequest()) return
         if (paneContent.provider === 'claude' && claudeSession) {
           setLoadError(null)
           return
@@ -559,6 +686,7 @@ export function FreshAgentView({
     paneContent.status,
     paneContent.sessionType,
     paneId,
+    autoTitleIdentity,
     snapshotThreadId,
     snapshotRefreshNonce,
     tabId,
@@ -808,6 +936,19 @@ export function FreshAgentView({
               onCommand={runSlashCommand}
               onSend={(text) => {
                 if (!paneContent.sessionId || !canSend) return
+                const isFirstMessage = !autoTitleSentRef.current
+                  && (autoTitleFreshBoundaryRef.current || snapshotConfirmsNoUserTurns)
+                if (isFirstMessage) {
+                  autoTitleFreshBoundaryRef.current = false
+                  autoTitleSentRef.current = true
+                  const title = extractTitleFromMessage(text)
+                  if (title) {
+                    dispatch(updatePaneTitle({ tabId, paneId, title, setByUser: false }))
+                    if (!tabTitleSetByUser) {
+                      dispatch(updateTab({ id: tabId, updates: { title } }))
+                    }
+                  }
+                }
                 sendFreshAgentMessage({
                   type: 'freshAgent.send',
                   sessionId: paneContent.sessionId,
@@ -844,8 +985,13 @@ export function FreshAgentView({
     paneContent,
     pendingCreateFailure,
     runSlashCommand,
+    snapshotConfirmsNoUserTurns,
     snapshot,
     slashCommands,
+    dispatch,
+    paneId,
+    tabId,
+    tabTitleSetByUser,
   ])
 
   useEffect(() => {

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -594,6 +594,13 @@ function PickerWrapper({
     | { step: 'directory'; providerType: PanePickerType }
   >({ step: 'type' })
 
+  const getRuntimeSettingsKey = useCallback((providerType: PanePickerType): CodingCliProviderName => {
+    const freshAgentType = resolveFreshAgentType(providerType)
+    if (freshAgentType) return freshAgentType.runtimeProvider as CodingCliProviderName
+    const agentConfig = getAgentChatProviderConfig(providerType)
+    return (agentConfig ? agentConfig.codingCliProvider : providerType) as CodingCliProviderName
+  }, [])
+
   const createContentForType = useCallback((type: PanePickerType, cwd?: string): PaneContent => {
     if (typeof type === 'string' && type.startsWith('ext:')) {
       const extensionName = type.slice(4)
@@ -610,13 +617,10 @@ function PickerWrapper({
         ? getAgentChatProviderConfig(type)
         : undefined
       const providerSettings = agentChatSettings?.providers?.[type]
-      const model = normalizeFreshAgentModel(
-        freshAgentType.sessionType,
-        freshAgentType.runtimeProvider,
-        freshAgentType.runtimeProvider === 'codex'
-          ? settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.model
-          : freshAgentType.defaultModel,
-      )
+      const configuredModel = freshAgentType.runtimeProvider === 'codex' || freshAgentType.runtimeProvider === 'opencode'
+        ? settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.model ?? freshAgentType.defaultModel
+        : freshAgentType.defaultModel
+      const model = normalizeFreshAgentModel(freshAgentType.sessionType, freshAgentType.runtimeProvider, configuredModel) ?? configuredModel
       return {
         kind: 'fresh-agent',
         sessionType: freshAgentType.sessionType,
@@ -638,7 +642,7 @@ function PickerWrapper({
           freshAgentType.sessionType,
           freshAgentType.runtimeProvider,
           model,
-          normalizeAgentChatEffortOverride(providerSettings?.effort),
+          normalizeAgentChatEffortOverride(providerSettings?.effort) ?? freshAgentType.defaultEffort,
         ) ?? freshAgentType.defaultEffort,
         plugins: freshAgentType.runtimeProvider === 'claude' ? agentChatSettings?.defaultPlugins : undefined,
         ...(cwd ? { initialCwd: cwd } : {}),
@@ -734,15 +738,13 @@ function PickerWrapper({
     dispatch(updatePaneContent({ tabId, paneId, content: newContent }))
 
     // Save the selected directory for the provider
-    const agentConfig = getAgentChatProviderConfig(providerType)
-    const freshAgentConfig = resolveFreshAgentType(providerType)
-    const settingsKey = (agentConfig?.codingCliProvider ?? freshAgentConfig?.runtimeProvider ?? providerType) as CodingCliProviderName
+    const settingsKey = getRuntimeSettingsKey(providerType)
     const existingProviderSettings = settings?.codingCli?.providers?.[settingsKey] || {}
     const patch = {
       codingCli: { providers: { [settingsKey]: { ...existingProviderSettings, cwd } } },
     }
     void dispatch(saveServerSettingsPatch(patch))
-  }, [createContentForType, dispatch, paneId, settings, step, tabId])
+  }, [createContentForType, dispatch, getRuntimeSettingsKey, paneId, settings, step, tabId])
 
   const handleCancel = useCallback(() => {
     dispatch(closePaneWithCleanup({ tabId, paneId }))
@@ -751,15 +753,15 @@ function PickerWrapper({
   if (step.step === 'directory') {
     const providerType = step.providerType
     const agentConfig = getAgentChatProviderConfig(providerType)
-    const freshAgentConfig = resolveFreshAgentType(providerType)
-    const providerLabel = agentConfig ? agentConfig.label : (freshAgentConfig?.label ?? getProviderLabel(providerType, extensionEntries))
-    const settingsKey = (agentConfig?.codingCliProvider ?? freshAgentConfig?.runtimeProvider ?? providerType) as CodingCliProviderName
+    const freshAgentType = resolveFreshAgentType(providerType)
+    const providerLabel = agentConfig ? agentConfig.label : getProviderLabel(providerType, extensionEntries)
+    const settingsKey = getRuntimeSettingsKey(providerType)
     const globalDefault = settings?.codingCli?.providers?.[settingsKey]?.cwd
     const defaultCwd = tabPref.defaultCwd ?? globalDefault
     return (
       <DirectoryPicker
         providerType={providerType}
-        providerLabel={providerLabel}
+        providerLabel={freshAgentType?.label ?? providerLabel}
         defaultCwd={defaultCwd}
         tabDirectories={tabPref.tabDirectories}
         globalDefault={globalDefault}

--- a/src/lib/deriveTabName.ts
+++ b/src/lib/deriveTabName.ts
@@ -1,6 +1,13 @@
-import type { PaneNode, PaneContent, TerminalPaneContent, BrowserPaneContent } from '../store/paneTypes'
+import type {
+  PaneNode,
+  PaneContent,
+  TerminalPaneContent,
+  BrowserPaneContent,
+  FreshAgentPaneContent,
+} from '../store/paneTypes'
 import type { ClientExtensionEntry } from '@shared/extension-types'
 import { getProviderLabel, isNonShellMode } from './coding-cli-utils'
+import { getFreshAgentLabel } from './fresh-agent-registry'
 
 /**
  * Collect all leaf pane contents in tree order (left-to-right, top-to-bottom).
@@ -15,6 +22,13 @@ function collectContents(node: PaneNode): PaneContent[] {
  */
 function isCli(content: PaneContent): content is TerminalPaneContent {
   return content.kind === 'terminal' && isNonShellMode(content.mode)
+}
+
+/**
+ * Check if content is a FreshAgent pane.
+ */
+function isFreshAgent(content: PaneContent): content is FreshAgentPaneContent {
+  return content.kind === 'fresh-agent'
 }
 
 /**
@@ -76,8 +90,9 @@ function extractLastDirSegment(path: string): string | null {
 /**
  * Derives a tab name from pane layout content using priority order:
  * 1. First CLI instance (claude or codex mode terminal)
- * 2. First browser
- * 3. First shell terminal (using last directory segment of initialCwd)
+ * 2. First FreshAgent pane (last directory segment of initialCwd, then agent label)
+ * 3. First browser
+ * 4. First shell terminal (using last directory segment of initialCwd)
  */
 export function deriveTabName(layout: PaneNode, extensions?: ClientExtensionEntry[]): string {
   const contents = collectContents(layout)
@@ -88,7 +103,17 @@ export function deriveTabName(layout: PaneNode, extensions?: ClientExtensionEntr
     return getProviderLabel(cli.mode, extensions)
   }
 
-  // Priority 2: First browser
+  // Priority 2: First FreshAgent pane
+  const freshAgent = contents.find(isFreshAgent)
+  if (freshAgent) {
+    if (freshAgent.initialCwd) {
+      const segment = extractLastDirSegment(freshAgent.initialCwd)
+      if (segment) return segment
+    }
+    return getFreshAgentLabel(freshAgent.sessionType)
+  }
+
+  // Priority 3: First browser
   const browser = contents.find(isBrowser)
   if (browser) {
     if (!browser.url) return 'Browser'
@@ -96,7 +121,7 @@ export function deriveTabName(layout: PaneNode, extensions?: ClientExtensionEntr
     return hostname || 'Browser'
   }
 
-  // Priority 3: First shell terminal
+  // Priority 4: First shell terminal
   const shell = contents.find(isShellTerminal)
   if (shell) {
     if (!shell.initialCwd) return 'Shell'
@@ -104,7 +129,7 @@ export function deriveTabName(layout: PaneNode, extensions?: ClientExtensionEntr
     return segment || 'Shell'
   }
 
-  // Priority 4: Picker (when all panes are pickers)
+  // Priority 5: Picker (when all panes are pickers)
   const hasOnlyPickers = contents.every(isPicker)
   if (hasOnlyPickers && contents.length > 0) {
     return 'New Tab'

--- a/test/unit/client/components/TabBar.deriveTitle.test.tsx
+++ b/test/unit/client/components/TabBar.deriveTitle.test.tsx
@@ -294,6 +294,53 @@ describe('TabBar tab title derivation', () => {
     expect(screen.getByText('freshell')).toBeInTheDocument()
   })
 
+  it('derives the visible tab title from a fresh-agent working directory', () => {
+    const store = createStore(
+      {
+        tabs: [
+          {
+            id: 'tab-1',
+            createRequestId: 'tab-1',
+            title: 'Tab 1',
+            titleSetByUser: false,
+            status: 'running',
+            mode: 'shell',
+            shell: 'system',
+            createdAt: Date.now(),
+          },
+        ],
+        activeTabId: 'tab-1',
+      },
+      {
+        layouts: {
+          'tab-1': {
+            type: 'leaf',
+            id: 'pane-1',
+            content: {
+              kind: 'fresh-agent',
+              sessionType: 'freshcodex',
+              provider: 'codex',
+              createRequestId: 'req-1',
+              status: 'idle',
+              initialCwd: '/home/dan/code/freshell',
+            },
+          },
+        },
+        activePane: { 'tab-1': 'pane-1' },
+      },
+    )
+
+    render(
+      <Provider store={store}>
+        <TabBar />
+      </Provider>,
+    )
+
+    expect(screen.getByText('freshell')).toBeInTheDocument()
+    expect(screen.queryByText('Tab 1')).not.toBeInTheDocument()
+    expect(screen.queryByText('Freshcodex')).not.toBeInTheDocument()
+  })
+
   it('prefers CLI over browser when both exist', () => {
     const store = createStore(
       {

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -1,14 +1,9 @@
-import { describe, expect, it } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { FreshAgentTranscript } from '@/components/fresh-agent/FreshAgentTranscript'
 
 describe('FreshAgentTranscript', () => {
-  it('renders a blank transcript when there are no turns', () => {
-    const { container } = render(<FreshAgentTranscript turns={[]} />)
-
-    expect(screen.queryByText('No transcript available yet.')).not.toBeInTheDocument()
-    expect(container.querySelector('[data-context="fresh-agent-transcript"]')).toBeEmptyDOMElement()
-  })
+  afterEach(() => cleanup())
 
   it('renders normalized text turns', () => {
     render(
@@ -25,5 +20,103 @@ describe('FreshAgentTranscript', () => {
 
     expect(screen.getByText('Assistant')).toBeInTheDocument()
     expect(screen.getByText('Hello from Fresh Agent')).toBeInTheDocument()
+  })
+
+  it('renders blank space instead of placeholder text for an empty transcript', () => {
+    const { container } = render(<FreshAgentTranscript turns={[]} />)
+
+    expect(screen.queryByText(/No transcript available yet/i)).not.toBeInTheDocument()
+    expect(container.querySelector('[data-context="fresh-agent-transcript"]')).toBeInTheDocument()
+  })
+
+  it('coalesces paired tool calls into a rolling strip and expands details', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          {
+            id: 'turn-1',
+            role: 'assistant',
+            summary: 'used tools',
+            items: [
+              {
+                id: 'tool-1',
+                kind: 'tool_use',
+                toolUseId: 'call-1',
+                name: 'Bash',
+                input: { command: 'find . -name "*.md"', description: 'Find markdown files' },
+              },
+              {
+                id: 'result-1',
+                kind: 'tool_result',
+                toolUseId: 'call-1',
+                content: 'README.md\nAGENTS.md',
+                isError: false,
+              },
+            ],
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByRole('region', { name: 'Tool strip' })).toHaveTextContent('1 tool used')
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle tool details' }))
+    expect(screen.getByRole('button', { name: 'Bash tool call' })).toHaveTextContent('Bash:')
+    fireEvent.click(screen.getByRole('button', { name: 'Bash tool call' }))
+    expect(screen.getByText('find . -name "*.md"')).toBeInTheDocument()
+    expect(screen.getByText(/README.md/)).toBeInTheDocument()
+  })
+
+  it('strips system reminders and collapses older turns', () => {
+    render(
+      <FreshAgentTranscript
+        turns={Array.from({ length: 9 }, (_, index) => ({
+          id: `turn-${index}`,
+          role: index % 2 === 0 ? 'user' : 'assistant',
+          summary: `turn ${index}`,
+          items: [{
+            id: `item-${index}`,
+            kind: 'text',
+            text: index === 0
+              ? 'visible <system-reminder>hidden internals</system-reminder>'
+              : `message ${index}`,
+          }],
+        }))}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Expand turn' })).toHaveTextContent('visible')
+    expect(screen.queryByText(/hidden internals/)).not.toBeInTheDocument()
+  })
+
+  it('renders reasoning and thinking in disclosures and shows edit diffs', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          {
+            id: 'turn-1',
+            role: 'assistant',
+            summary: 'thinking and editing',
+            items: [
+              { id: 'thinking-1', kind: 'thinking', text: 'private chain' },
+              { id: 'reason-1', kind: 'reasoning', summary: ['summary'], content: ['detail'] },
+              {
+                id: 'edit-1',
+                kind: 'tool_use',
+                toolUseId: 'edit-call',
+                name: 'Edit',
+                input: { file_path: 'README.md', old_string: 'old', new_string: 'new' },
+              },
+              { id: 'edit-result', kind: 'tool_result', toolUseId: 'edit-call', content: 'ok', isError: false },
+            ],
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('Thinking')).toBeInTheDocument()
+    expect(screen.getByText('Reasoning')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle tool details' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit tool call' }))
+    expect(screen.getByRole('figure', { name: 'diff view' })).toHaveAttribute('data-file-path', 'README.md')
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -6,11 +6,13 @@ import panesReducer from '@/store/panesSlice'
 import settingsReducer from '@/store/settingsSlice'
 import freshAgentReducer from '@/store/freshAgentSlice'
 import agentChatReducer from '@/store/agentChatSlice'
+import tabsReducer from '@/store/tabsSlice'
 import { FreshAgentView } from '@/components/fresh-agent/FreshAgentView'
 import { FreshAgentSettingsButton } from '@/components/fresh-agent/FreshAgentSettingsButton'
-import { initLayout, requestPaneRefresh } from '@/store/panesSlice'
+import { initLayout, requestPaneRefresh, updatePaneContent, updatePaneTitle } from '@/store/panesSlice'
 import { useAppSelector } from '@/store/hooks'
 import { sessionInit, setSessionStatus } from '@/store/agentChatSlice'
+import { updateTab } from '@/store/tabsSlice'
 import type { PaneNode } from '@/store/paneTypes'
 
 const CLAUDE_THREAD_ID = '550e8400-e29b-41d4-a716-446655440000'
@@ -41,13 +43,14 @@ vi.mock('@/lib/api', async () => {
   }
 })
 
-function createStore() {
+function createStore(tabTitleSetByUser = false) {
   return configureStore({
     reducer: {
       panes: panesReducer,
       settings: settingsReducer,
       freshAgent: freshAgentReducer,
       agentChat: agentChatReducer,
+      tabs: tabsReducer,
     },
     preloadedState: {
       panes: {
@@ -59,6 +62,21 @@ function createStore() {
         renameRequestPaneId: null,
         zoomedPane: {},
         refreshRequestsByPane: {},
+      },
+      tabs: {
+        tabs: [{
+          id: 'tab-1',
+          createRequestId: 'tab-1',
+          title: tabTitleSetByUser ? 'Pinned title' : 'Tab 1',
+          titleSetByUser: tabTitleSetByUser,
+          status: 'running',
+          mode: 'shell',
+          shell: 'system',
+          createdAt: Date.now(),
+        }],
+        activeTabId: 'tab-1',
+        renameRequestTabId: null,
+        tombstones: [],
       },
     },
   })
@@ -96,6 +114,20 @@ function StoreBackedFreshAgentSettingsButton({
     return layout.content
   })
   return <FreshAgentSettingsButton tabId={tabId} paneId={paneId} paneContent={paneContent} />
+}
+
+function getFreshAgentSessionId() {
+  return document.querySelector('[data-context="fresh-agent"]')?.getAttribute('data-session-id')
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
 }
 
 beforeEach(() => {
@@ -322,7 +354,7 @@ describe('FreshAgentView', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Codex turn')).toBeInTheDocument()
+      expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
     })
 
     wsMock.send.mockClear()
@@ -350,6 +382,882 @@ describe('FreshAgentView', () => {
 
     expect(screen.queryByRole('button', { name: 'Interrupt' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Fork' })).not.toBeInTheDocument()
+  })
+
+  it('auto-titles the fresh-agent pane and tab from the first user message', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-auto-title',
+        sessionId: 'thread-auto-title',
+        status: 'idle',
+        initialCwd: '/home/dan/code/freshell',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex turn')).toBeInTheDocument()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Research tab naming behavior\nUse existing code paths.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('Research tab naming behavior')
+    expect(state.panes.paneTitleSetByUser?.['tab-1']?.['pane-1'] ?? false).toBe(false)
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('Research tab naming behavior')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.titleSetByUser).toBe(false)
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.send',
+      text: 'Research tab naming behavior\nUse existing code paths.',
+    }))
+  })
+
+  it('does not replace a user-set tab title when auto-titling the first fresh-agent message', async () => {
+    const store = createStore(true)
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-auto-title-user-tab',
+        sessionId: 'thread-auto-title-user-tab',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex turn')).toBeInTheDocument()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Do not override my tab title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('Do not override my tab title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('Pinned title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.titleSetByUser).toBe(true)
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.send',
+      text: 'Do not override my tab title',
+    }))
+  })
+
+  it('auto-titles a freshly created freshclaude conversation after freshAgent.created before snapshot history exists', async () => {
+    const store = createStore()
+    apiMock.getFreshAgentThreadSnapshot.mockRejectedValue(new TypeError('Snapshot not ready yet'))
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshclaude',
+        provider: 'claude',
+        createRequestId: 'req-claude-created-auto-title',
+        status: 'creating',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    const onMessage = wsMock.onMessage.mock.calls[0]?.[0]
+    expect(onMessage).toBeTypeOf('function')
+    act(() => {
+      onMessage({
+        type: 'freshAgent.created',
+        requestId: 'req-claude-created-auto-title',
+        sessionId: 'claude-live-session-1',
+        sessionType: 'freshclaude',
+        provider: 'claude',
+        runtimeProvider: 'claude',
+      })
+    })
+
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('claude-live-session-1')
+      expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Fresh Claude title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('Fresh Claude title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('Fresh Claude title')
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.send',
+      sessionId: 'claude-live-session-1',
+      text: 'Fresh Claude title',
+    }))
+  })
+
+  it('auto-titles after freshopencode materializes to a live session id before follow-up snapshot lands', async () => {
+    const store = createStore()
+    apiMock.getFreshAgentThreadSnapshot
+      .mockResolvedValueOnce({
+        sessionId: 'ses_real_materialized_1',
+        status: 'idle',
+        summary: 'OpenCode summary',
+        capabilities: { send: true, interrupt: true, fork: false },
+        turns: [],
+      })
+      .mockImplementationOnce(() => new Promise(() => {}))
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-opencode-materialize-auto-title',
+        sessionId: 'freshopencode-req-materialize',
+        sessionRef: { provider: 'opencode', sessionId: 'freshopencode-req-materialize' },
+        resumeSessionId: 'freshopencode-req-materialize',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('ses_real_materialized_1')
+      expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Materialized OpenCode title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('Materialized OpenCode title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('Materialized OpenCode title')
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.send',
+      sessionId: 'ses_real_materialized_1',
+      text: 'Materialized OpenCode title',
+    }))
+  })
+
+  it('keeps the first auto-title when two sends happen before snapshot user turns arrive', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-auto-title-race',
+        sessionId: 'thread-auto-title-race',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex turn')).toBeInTheDocument()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'First title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Second title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('First title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('First title')
+    expect(wsMock.send.mock.calls).toEqual(expect.arrayContaining([
+      [expect.objectContaining({ type: 'freshAgent.send', text: 'First title' })],
+      [expect.objectContaining({ type: 'freshAgent.send', text: 'Second title' })],
+    ]))
+  })
+
+  it('does not reopen auto-title when the live session handle changes for the same conversation', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshclaude',
+        provider: 'claude',
+        createRequestId: 'req-auto-title-restore',
+        sessionId: 'live-session-1',
+        sessionRef: { provider: 'claude', sessionId: CLAUDE_THREAD_ID },
+        resumeSessionId: CLAUDE_THREAD_ID,
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex turn')).toBeInTheDocument()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'First durable title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    act(() => {
+      store.dispatch(updatePaneContent({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshclaude',
+          provider: 'claude',
+          createRequestId: 'req-auto-title-restore',
+          sessionId: 'live-session-2',
+          sessionRef: { provider: 'claude', sessionId: CLAUDE_THREAD_ID },
+          resumeSessionId: CLAUDE_THREAD_ID,
+          status: 'idle',
+        },
+      }))
+    })
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('live-session-2')
+    })
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Second durable title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('First durable title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('First durable title')
+    expect(wsMock.send.mock.calls).toEqual(expect.arrayContaining([
+      [expect.objectContaining({ type: 'freshAgent.send', sessionId: 'live-session-1', text: 'First durable title' })],
+      [expect.objectContaining({ type: 'freshAgent.send', sessionId: 'live-session-2', text: 'Second durable title' })],
+    ]))
+  })
+
+  it('does not reopen auto-title when a live-only freshclaude pane gains durable identity', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshclaude',
+        provider: 'claude',
+        createRequestId: 'req-auto-title-refinement-bootstrap',
+        status: 'creating',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    wsMock.send.mockClear()
+
+    act(() => {
+      store.dispatch(updatePaneContent({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshclaude',
+          provider: 'claude',
+          createRequestId: 'req-auto-title-refinement',
+          sessionId: 'live-session-refine-1',
+          status: 'idle',
+        },
+      }))
+    })
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('live-session-refine-1')
+      expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
+    })
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'First refined title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    act(() => {
+      store.dispatch(updatePaneContent({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshclaude',
+          provider: 'claude',
+          createRequestId: 'req-auto-title-refinement',
+          sessionId: 'live-session-refine-2',
+          sessionRef: { provider: 'claude', sessionId: CLAUDE_THREAD_ID },
+          resumeSessionId: CLAUDE_THREAD_ID,
+          status: 'idle',
+        },
+      }))
+    })
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('live-session-refine-2')
+    })
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Second refined title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('First refined title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('First refined title')
+    expect(wsMock.send.mock.calls).toEqual(expect.arrayContaining([
+      [expect.objectContaining({ type: 'freshAgent.send', sessionId: 'live-session-refine-1', text: 'First refined title' })],
+      [expect.objectContaining({ type: 'freshAgent.send', sessionId: 'live-session-refine-2', text: 'Second refined title' })],
+    ]))
+  })
+
+  it('does not reopen auto-title when freshopencode materializes a live session id for the same durable thread', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-opencode-auto-title',
+        sessionId: 'freshopencode-req-1',
+        sessionRef: { provider: 'opencode', sessionId: 'freshopencode-req-1' },
+        resumeSessionId: 'freshopencode-req-1',
+        status: 'idle',
+      },
+    }))
+
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValueOnce({
+      sessionId: 'freshopencode-req-1',
+      status: 'idle',
+      summary: 'OpenCode summary',
+      capabilities: { send: true, interrupt: true, fork: false },
+      turns: [{ id: 'turn-1', role: 'assistant', items: [{ id: 'item-1', kind: 'text', text: 'Codex turn' }] }],
+    })
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex turn')).toBeInTheDocument()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'First opencode title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    act(() => {
+      store.dispatch(updatePaneContent({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshopencode',
+          provider: 'opencode',
+          createRequestId: 'req-opencode-auto-title',
+          sessionId: 'ses_real_1',
+          sessionRef: { provider: 'opencode', sessionId: 'freshopencode-req-1' },
+          resumeSessionId: 'freshopencode-req-1',
+          status: 'idle',
+        },
+      }))
+    })
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('ses_real_1')
+    })
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Second opencode title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('First opencode title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('First opencode title')
+    expect(wsMock.send.mock.calls).toEqual(expect.arrayContaining([
+      [expect.objectContaining({ type: 'freshAgent.send', sessionId: 'freshopencode-req-1', text: 'First opencode title' })],
+      [expect.objectContaining({ type: 'freshAgent.send', sessionId: 'ses_real_1', text: 'Second opencode title' })],
+    ]))
+  })
+
+  it('resets auto-title for a genuinely new conversation in the same pane', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-old-conversation',
+        sessionId: 'thread-old-conversation',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex turn')).toBeInTheDocument()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Old title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    act(() => {
+      store.dispatch(updatePaneContent({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+          createRequestId: 'req-new-conversation',
+          sessionId: 'thread-new-conversation',
+          status: 'idle',
+        },
+      }))
+    })
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('thread-new-conversation')
+    })
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'New title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('New title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('New title')
+    expect(wsMock.send.mock.calls).toEqual(expect.arrayContaining([
+      [expect.objectContaining({ type: 'freshAgent.send', sessionId: 'thread-old-conversation', text: 'Old title' })],
+      [expect.objectContaining({ type: 'freshAgent.send', sessionId: 'thread-new-conversation', text: 'New title' })],
+    ]))
+  })
+
+  it('does not reopen auto-title when createRequestId changes but full effective identity stays the same', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-same-identity-old',
+        sessionId: 'thread-same-identity',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex turn')).toBeInTheDocument()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Codex same identity title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    act(() => {
+      store.dispatch(updatePaneContent({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+          createRequestId: 'req-same-identity-new',
+          sessionId: 'thread-same-identity',
+          status: 'idle',
+        },
+      }))
+    })
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('thread-same-identity')
+    })
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Should not replace codex same identity title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('Codex same identity title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('Codex same identity title')
+    expect(wsMock.send.mock.calls).toEqual(expect.arrayContaining([
+      [expect.objectContaining({ type: 'freshAgent.send', sessionId: 'thread-same-identity', text: 'Codex same identity title' })],
+      [expect.objectContaining({ type: 'freshAgent.send', sessionId: 'thread-same-identity', text: 'Should not replace codex same identity title' })],
+    ]))
+  })
+
+  it('does not reopen auto-title when createRequestId changes but durable identity stays the same', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshclaude',
+        provider: 'claude',
+        createRequestId: 'req-same-durable-old',
+        sessionId: 'live-same-durable-1',
+        sessionRef: { provider: 'claude', sessionId: CLAUDE_THREAD_ID },
+        resumeSessionId: CLAUDE_THREAD_ID,
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex turn')).toBeInTheDocument()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Durable title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    act(() => {
+      store.dispatch(updatePaneContent({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshclaude',
+          provider: 'claude',
+          createRequestId: 'req-same-durable-new',
+          sessionId: 'live-same-durable-2',
+          sessionRef: { provider: 'claude', sessionId: CLAUDE_THREAD_ID },
+          resumeSessionId: CLAUDE_THREAD_ID,
+          status: 'idle',
+        },
+      }))
+    })
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('live-same-durable-2')
+    })
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Should not replace durable title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('Durable title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('Durable title')
+    expect(wsMock.send.mock.calls).toEqual(expect.arrayContaining([
+      [expect.objectContaining({ type: 'freshAgent.send', sessionId: 'live-same-durable-1', text: 'Durable title' })],
+      [expect.objectContaining({ type: 'freshAgent.send', sessionId: 'live-same-durable-2', text: 'Should not replace durable title' })],
+    ]))
+  })
+
+  it('resets auto-title for a new conversation even if the stale prior snapshot had user turns', async () => {
+    const store = createStore()
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValueOnce({
+      status: 'idle',
+      summary: 'Codex summary',
+      capabilities: { send: true, interrupt: true, fork: true },
+      turns: [
+        { id: 'turn-user-1', role: 'user', items: [{ id: 'item-user-1', kind: 'text', text: 'Old user turn' }] },
+        { id: 'turn-assistant-1', role: 'assistant', items: [{ id: 'item-assistant-1', kind: 'text', text: 'Old assistant turn' }] },
+      ],
+    })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-stale-snapshot-old',
+        sessionId: 'thread-stale-snapshot-old',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Old assistant turn')).toBeInTheDocument()
+    })
+
+    wsMock.send.mockClear()
+
+    act(() => {
+      store.dispatch(updatePaneContent({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+          createRequestId: 'req-stale-snapshot-new',
+          sessionId: 'thread-stale-snapshot-new',
+          status: 'idle',
+        },
+      }))
+    })
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('thread-stale-snapshot-new')
+    })
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'New stale-safe title' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('New stale-safe title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('New stale-safe title')
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.send',
+      sessionId: 'thread-stale-snapshot-new',
+      text: 'New stale-safe title',
+    }))
+  })
+
+  it('ignores a late stale snapshot with user turns after switching to a new conversation', async () => {
+    const store = createStore()
+    const staleSnapshot = createDeferred<{
+      status: string
+      summary: string
+      capabilities: { send: boolean; interrupt: boolean; fork: boolean }
+      turns: Array<{ id: string; role: 'user' | 'assistant'; items: Array<{ id: string; kind: 'text'; text: string }> }>
+    }>()
+    apiMock.getFreshAgentThreadSnapshot
+      .mockImplementationOnce(() => staleSnapshot.promise as any)
+      .mockImplementationOnce(() => new Promise(() => {}))
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshclaude',
+        provider: 'claude',
+        createRequestId: 'req-stale-old',
+        sessionId: 'sess-stale-old',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('sess-stale-old')
+    })
+
+    act(() => {
+      store.dispatch(updatePaneContent({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshclaude',
+          provider: 'claude',
+          createRequestId: 'req-stale-new',
+          sessionId: 'sess-stale-new',
+          status: 'idle',
+        },
+      }))
+    })
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('sess-stale-new')
+    })
+
+    await act(async () => {
+      staleSnapshot.resolve({
+        status: 'idle',
+        summary: 'Old snapshot',
+        capabilities: { send: true, interrupt: true, fork: true },
+        turns: [
+          { id: 'turn-old-user', role: 'user', items: [{ id: 'item-old-user', kind: 'text', text: 'Old user turn' }] },
+          { id: 'turn-old-assistant', role: 'assistant', items: [{ id: 'item-old-assistant', kind: 'text', text: 'Old assistant turn' }] },
+        ],
+      })
+      await Promise.resolve()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'New conversation title after stale race' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('New conversation title after stale race')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('New conversation title after stale race')
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.send',
+      sessionId: 'sess-stale-new',
+      text: 'New conversation title after stale race',
+    }))
+  })
+
+  it('ignores a late stale codex snapshot failure after switching to a new conversation', async () => {
+    const store = createStore()
+    const staleSnapshot = createDeferred<never>()
+    apiMock.getFreshAgentThreadSnapshot
+      .mockImplementationOnce(() => staleSnapshot.promise as any)
+      .mockImplementationOnce(() => new Promise(() => {}))
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-stale-codex-old',
+        sessionId: 'thread-stale-codex-old',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('thread-stale-codex-old')
+    })
+
+    act(() => {
+      store.dispatch(updatePaneContent({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+          createRequestId: 'req-stale-codex-new',
+          sessionId: 'thread-stale-codex-new',
+          status: 'idle',
+        },
+      }))
+    })
+    await waitFor(() => {
+      expect(getFreshAgentSessionId()).toBe('thread-stale-codex-new')
+    })
+
+    await act(async () => {
+      staleSnapshot.reject(new Error('no rollout found for thread id thread-stale-codex-old'))
+      await Promise.resolve()
+    })
+
+    const layout = store.getState().panes.layouts['tab-1']
+    expect(layout?.type).toBe('leaf')
+    if (layout?.type !== 'leaf' || layout.content.kind !== 'fresh-agent') {
+      throw new Error('Expected fresh-agent leaf')
+    }
+    expect(layout.content.sessionId).toBe('thread-stale-codex-new')
+    expect(layout.content.restoreError).toBeUndefined()
+    expect(screen.queryByText(/durable artifact/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/no rollout found for thread id/i)).not.toBeInTheDocument()
   })
 
   it('shows provider slash commands from the command menu without hidden aliases', async () => {
@@ -898,6 +1806,101 @@ describe('FreshAgentView', () => {
     expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
     expect(wsMock.send).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'freshAgent.create' }))
     expect(screen.queryByText(/failed to parse url/i)).not.toBeInTheDocument()
+  })
+
+  it('does not auto-title an established freshclaude pane when snapshot history is unavailable', async () => {
+    const store = createStore()
+    apiMock.getFreshAgentThreadSnapshot.mockRejectedValue(new TypeError('Failed to parse URL from /api/fresh-agent/threads/claude/sess-1'))
+    store.dispatch(sessionInit({
+      sessionId: 'sess-1',
+      cliSessionId: 'cli-abc',
+      model: 'claude-opus-4-6',
+    }))
+    store.dispatch(setSessionStatus({ sessionId: 'sess-1', status: 'idle' }))
+    store.dispatch(updatePaneTitle({ tabId: 'tab-1', paneId: 'pane-1', title: 'Existing title', setByUser: false }))
+
+    const paneContent = {
+      kind: 'fresh-agent' as const,
+      sessionType: 'freshclaude' as const,
+      provider: 'claude' as const,
+      createRequestId: 'req-established-no-snapshot',
+      sessionId: 'sess-1',
+      status: 'idle' as const,
+      resumeSessionId: 'cli-abc',
+    }
+
+    render(
+      <Provider store={store}>
+        <FreshAgentView tabId="tab-1" paneId="pane-1" paneContent={paneContent} />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Do not retitle this established chat' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('Existing title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('Tab 1')
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.send',
+      sessionId: 'sess-1',
+      text: 'Do not retitle this established chat',
+    }))
+  })
+
+  it('does not auto-title a live-only established freshclaude pane when snapshot history is unavailable', async () => {
+    const store = createStore()
+    apiMock.getFreshAgentThreadSnapshot.mockRejectedValue(new TypeError('Failed to parse URL from /api/fresh-agent/threads/claude/sess-live-only'))
+    store.dispatch(sessionInit({
+      sessionId: 'sess-live-only',
+      model: 'claude-opus-4-6',
+    }))
+    store.dispatch(setSessionStatus({ sessionId: 'sess-live-only', status: 'idle' }))
+    store.dispatch(updatePaneTitle({ tabId: 'tab-1', paneId: 'pane-1', title: 'Existing live-only pane title', setByUser: false }))
+    store.dispatch(updateTab({ id: 'tab-1', updates: { title: 'Existing live-only tab title' } }))
+
+    const paneContent = {
+      kind: 'fresh-agent' as const,
+      sessionType: 'freshclaude' as const,
+      provider: 'claude' as const,
+      createRequestId: 'req-live-only-established',
+      sessionId: 'sess-live-only',
+      status: 'idle' as const,
+    }
+
+    render(
+      <Provider store={store}>
+        <FreshAgentView tabId="tab-1" paneId="pane-1" paneContent={paneContent} />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
+    })
+
+    wsMock.send.mockClear()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Do not retitle this live-only established chat' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const state = store.getState()
+    expect(state.panes.paneTitles?.['tab-1']?.['pane-1']).toBe('Existing live-only pane title')
+    expect(state.tabs.tabs.find((tab) => tab.id === 'tab-1')?.title).toBe('Existing live-only tab title')
+    expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'freshAgent.send',
+      sessionId: 'sess-live-only',
+      text: 'Do not retitle this live-only established chat',
+    }))
   })
 
   it('recreates a lost freshclaude session through fresh-agent transport events with the durable resume id', async () => {

--- a/test/unit/client/lib/deriveTabName.test.ts
+++ b/test/unit/client/lib/deriveTabName.test.ts
@@ -53,4 +53,37 @@ describe('deriveTabName', () => {
 
     expect(deriveTabName(layout)).toBe('Codex')
   })
+
+  it('returns the last working-directory segment for a fresh-agent pane', () => {
+    const layout: PaneNode = {
+      type: 'leaf',
+      id: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        status: 'idle',
+        createRequestId: 'req-1',
+        initialCwd: '/home/dan/code/freshell',
+      },
+    }
+
+    expect(deriveTabName(layout, mockExtensions)).toBe('freshell')
+  })
+
+  it('falls back to the fresh-agent label when there is no working directory', () => {
+    const layout: PaneNode = {
+      type: 'leaf',
+      id: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        status: 'idle',
+        createRequestId: 'req-1',
+      },
+    }
+
+    expect(deriveTabName(layout, mockExtensions)).toBe('Freshopencode')
+  })
 })

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -387,6 +387,53 @@ describe('WsHandler fresh-agent routing', () => {
     }
   })
 
+  it('routes freshAgent.compact through the runtime manager', async () => {
+    const runtimeManager = {
+      create: vi.fn().mockResolvedValue({
+        sessionId: 'codex-session-compact',
+        sessionType: 'freshcodex',
+        runtimeProvider: 'codex',
+      }),
+      subscribe: vi.fn().mockResolvedValue(() => undefined),
+      compact: vi.fn().mockResolvedValue(undefined),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+
+    try {
+      const ws = await connectAndAuth(server)
+      ws.send(JSON.stringify({
+        type: 'freshAgent.create',
+        requestId: 'req-compact',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+      }))
+
+      await vi.waitFor(() => {
+        expect(runtimeManager.create).toHaveBeenCalled()
+      })
+
+      ws.send(JSON.stringify({
+        type: 'freshAgent.compact',
+        sessionId: 'codex-session-compact',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        instructions: 'keep findings',
+      }))
+
+      await vi.waitFor(() => {
+        expect(runtimeManager.compact).toHaveBeenCalledWith({
+          sessionId: 'codex-session-compact',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+        }, { instructions: 'keep findings' })
+      })
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
   it('attaches a persisted fresh-agent session and forwards live adapter events over freshAgent.event', async () => {
     const listeners = new Map<string, (message: unknown) => void>()
     const runtimeManager = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,10 +20,10 @@ function silenceStartupErrors(proxy: HttpProxy.Server) {
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, __dirname, '')
-  const backendPort = env.PORT || '3001'
-  const backendHost = env.VITE_BACKEND_HOST || env.BACKEND_HOST || '127.0.0.1'
+  const backendPort = process.env.PORT || env.PORT || '3001'
+  const backendHost = process.env.VITE_BACKEND_HOST || process.env.BACKEND_HOST || env.VITE_BACKEND_HOST || env.BACKEND_HOST || '127.0.0.1'
   const backendUrl = `http://${backendHost}:${backendPort}`
-  const vitePort = parseInt(env.VITE_PORT || '5173', 10)
+  const vitePort = parseInt(process.env.VITE_PORT || env.VITE_PORT || '5173', 10)
   const allowedHosts = env.VITE_ALLOWED_HOSTS
     ? env.VITE_ALLOWED_HOSTS.split(',').map((h) => h.trim()).filter(Boolean)
     : undefined // Vite's default behavior (localhost + host value)


### PR DESCRIPTION
## Summary
- restore shared FreshAgent transcript polish: compact older turns, rolling tool strip, reasoning/thinking disclosures, and cleaner transcript rendering
- combine slash command support with draft persistence/focus handling in the FreshAgent composer
- carry forward runtime edge fixes for Codex fresh-agent snapshots, fork tracking, and FreshOpenCode defaults

## Verification
- npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.test.tsx test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/panes/PaneContainer.createContent.test.tsx test/unit/server/fresh-agent/codex-adapter.test.ts test/unit/server/fresh-agent/runtime-manager.test.ts test/unit/server/ws-handler-fresh-agent.test.ts
- npm run test:integration -- --run test/unit/server/fresh-agent/codex-adapter.test.ts test/unit/server/fresh-agent/runtime-manager.test.ts test/unit/server/ws-handler-fresh-agent.test.ts
- npm run check
- npm run build
- Playwright smoke on isolated production server :3376: Freshcodex, Freshopencode, Freshclaude settings/slash/submit/refresh paths