### PR TITLE
docs: remove Freshclaude settings bubble from static preview

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -547,17 +547,6 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
                   <span class="picker-label">Shell</span>
                   <span class="picker-shortcut">S</span>
                 </button>
-	                  <button class="picker-option">
-	                  <i data-lucide="message-circle" class="picker-lucide"></i>
-	                  <span class="picker-label">Freshclaude</span>
-	                  <span class="picker-shortcut">F</span>
-	                  </button>
-	                </div>
-	                <div class="picker-note">
-	                  <div class="picker-note-title">Freshclaude settings</div>
-	                  <div class="picker-note-line">Model: Provider default tracks the latest Opus release.</div>
-	                  <div class="picker-note-line">Effort: Only live capability-supported levels appear for the selected model.</div>
-	                  <div class="picker-note-line">Pinned legacy model IDs stay visible as unavailable until you change them.</div>
 	                </div>
 	              </div>
 	            </div>


### PR DESCRIPTION
Removes the Freshclaude picker button and settings note from the new-pane type selector in the static HTML preview.