### PR TITLE
Add fresh clients toggle and restore snapshot fallback

### DIFF
--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -1325,6 +1325,10 @@ export class WsHandler {
     return 'Fresh Agent runtime is not enabled'
   }
 
+  private freshClientsEnabled(settings?: ServerSettings): boolean {
+    return settings?.freshAgent?.enabled ?? settings?.agentChat?.enabled ?? false
+  }
+
   private sendFreshAgentSubscriptionError(ws: LiveWebSocket, locator: FreshAgentLocator, error: unknown): void {
     this.safeSend(ws, this.freshAgentEventMessage(locator, {
       type: 'sdk.error',
@@ -3523,6 +3527,18 @@ export class WsHandler {
               sessionId: cached.sessionId,
               sessionType: cached.sessionType,
               provider: cached.runtimeProvider,
+            })
+            return
+          }
+
+          const cfg = await awaitConfig()
+          if (!this.freshClientsEnabled(cfg.settings)) {
+            this.send(ws, {
+              type: 'freshAgent.create.failed',
+              requestId: m.requestId,
+              code: 'FRESH_CLIENTS_DISABLED',
+              message: 'Fresh clients are disabled',
+              retryable: true,
             })
             return
           }

--- a/shared/settings.ts
+++ b/shared/settings.ts
@@ -144,11 +144,13 @@ export type ServerSettings = {
     customEditorCommand?: string
   }
   freshAgent: {
+    enabled: boolean
     initialSetupDone?: boolean
     defaultPlugins: string[]
     providers: Partial<Record<string, AgentChatProviderDefaults>>
   }
   agentChat: {
+    enabled: boolean
     initialSetupDone?: boolean
     defaultPlugins: string[]
     providers: Partial<Record<string, AgentChatProviderDefaults>>
@@ -284,6 +286,39 @@ function mergeRecordOfObjects<T extends Record<string, unknown>>(
   for (const [key, value] of Object.entries(patch || {})) {
     merged[key] = mergeOwnKeys((merged[key] || {}) as T, value || {})
   }
+  return merged
+}
+
+function mergeFreshAgentAliasObjects(
+  agentChatInput: Record<string, unknown> | null | undefined,
+  freshAgentInput: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null {
+  if (!agentChatInput && !freshAgentInput) {
+    return null
+  }
+
+  const merged: Record<string, unknown> = { ...(agentChatInput || {}), ...(freshAgentInput || {}) }
+  const rawAgentChatProviders = agentChatInput && isRecord(agentChatInput.providers)
+    ? agentChatInput.providers
+    : null
+  const rawFreshAgentProviders = freshAgentInput && isRecord(freshAgentInput.providers)
+    ? freshAgentInput.providers
+    : null
+
+  if (rawAgentChatProviders || rawFreshAgentProviders) {
+    const providers: Record<string, unknown> = {}
+    for (const [providerName, providerPatch] of Object.entries(rawAgentChatProviders || {})) {
+      providers[providerName] = providerPatch
+    }
+    for (const [providerName, providerPatch] of Object.entries(rawFreshAgentProviders || {})) {
+      const existingProviderPatch = providers[providerName]
+      providers[providerName] = isRecord(existingProviderPatch) && isRecord(providerPatch)
+        ? { ...existingProviderPatch, ...providerPatch }
+        : providerPatch
+    }
+    merged.providers = providers
+  }
+
   return merged
 }
 
@@ -610,11 +645,13 @@ export function buildServerSettingsSchema(validCliProviders?: readonly string[])
       customEditorCommand: z.string().optional(),
     }).strict(),
     freshAgent: z.object({
+      enabled: z.boolean(),
       initialSetupDone: z.boolean().optional(),
       defaultPlugins: z.array(z.string()),
       providers: z.record(z.string(), createAgentChatProviderDefaultsPatchSchema()),
     }).strict(),
     agentChat: z.object({
+      enabled: z.boolean(),
       initialSetupDone: z.boolean().optional(),
       defaultPlugins: z.array(z.string()),
       providers: z.record(z.string(), createAgentChatProviderDefaultsSchema()),
@@ -659,11 +696,13 @@ export function buildServerSettingsPatchSchema(validCliProviders?: readonly stri
       customEditorCommand: z.string().optional(),
     }).strict().optional(),
     freshAgent: z.object({
+      enabled: z.coerce.boolean().optional(),
       initialSetupDone: z.boolean().optional(),
       defaultPlugins: z.array(z.string()).optional(),
       providers: z.record(z.string(), createAgentChatProviderDefaultsPatchSchema()).optional(),
     }).strict().optional(),
     agentChat: z.object({
+      enabled: z.coerce.boolean().optional(),
       initialSetupDone: z.boolean().optional(),
       defaultPlugins: z.array(z.string()).optional(),
       providers: z.record(z.string(), createAgentChatProviderDefaultsPatchSchema()).optional(),
@@ -716,10 +755,12 @@ export function createDefaultServerSettings(options: SettingsDefaultsOptions = {
       externalEditor: 'auto',
     },
     freshAgent: {
+      enabled: false,
       defaultPlugins: [],
       providers: {},
     },
     agentChat: {
+      enabled: false,
       defaultPlugins: [],
       providers: {},
     },
@@ -934,14 +975,15 @@ function sanitizeServerSettingsPatch(patch: ServerSettingsPatch): ServerSettings
     }
   }
 
-  const rawFreshAgent = isRecord(candidate.freshAgent)
-    ? candidate.freshAgent
-    : isRecord(candidate.agentChat)
-      ? candidate.agentChat
-      : null
+  const rawAgentChatInput = isRecord(candidate.agentChat) ? candidate.agentChat : null
+  const rawFreshAgentInput = isRecord(candidate.freshAgent) ? candidate.freshAgent : null
+  const rawFreshAgent = mergeFreshAgentAliasObjects(rawAgentChatInput, rawFreshAgentInput)
 
   if (rawFreshAgent) {
     const freshAgent: ServerSettingsPatch['freshAgent'] = {}
+    if (hasOwn(rawFreshAgent, 'enabled')) {
+      freshAgent.enabled = !!rawFreshAgent.enabled
+    }
     if (hasOwn(rawFreshAgent, 'initialSetupDone') && typeof rawFreshAgent.initialSetupDone === 'boolean') {
       freshAgent.initialSetupDone = rawFreshAgent.initialSetupDone
     }
@@ -1260,11 +1302,10 @@ export function extractLegacyLocalSettingsSeed(
     }
     maybeAssignNested(patch, 'sidebar', sidebarPatch)
   }
-  const rawFreshAgentLocal = isRecord(raw.freshAgent)
-    ? raw.freshAgent
-    : isRecord(raw.agentChat)
-      ? raw.agentChat
-      : undefined
+  const rawFreshAgentLocal = mergeFreshAgentAliasObjects(
+    isRecord(raw.agentChat) ? raw.agentChat : null,
+    isRecord(raw.freshAgent) ? raw.freshAgent : null,
+  )
   if (rawFreshAgentLocal) {
     const freshAgentPatch = pickKeys(rawFreshAgentLocal, AGENT_CHAT_LOCAL_KEYS)
     maybeAssignNested(patch, 'freshAgent', freshAgentPatch)
@@ -1313,11 +1354,10 @@ export function stripLocalSettings(
     }
   }
 
-  const rawFreshAgent = isRecord(raw.freshAgent)
-    ? raw.freshAgent
-    : isRecord(raw.agentChat)
-      ? raw.agentChat
-      : undefined
+  const rawFreshAgent = mergeFreshAgentAliasObjects(
+    isRecord(raw.agentChat) ? raw.agentChat : null,
+    isRecord(raw.freshAgent) ? raw.freshAgent : null,
+  )
   if (rawFreshAgent) {
     const strippedFreshAgent = omitKeys(rawFreshAgent, AGENT_CHAT_LOCAL_KEYS)
     if (Object.keys(strippedFreshAgent).length > 0) {

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -56,6 +56,21 @@ function getCanonicalPaneResumeSessionId(pane: FreshAgentPaneContent): string | 
   return undefined
 }
 
+function getFreshAgentSnapshotThreadId(
+  pane: FreshAgentPaneContent,
+  claudeSession: Parameters<typeof getCanonicalDurableSessionId>[0],
+): string | undefined {
+  if (pane.provider === 'claude') {
+    return getCanonicalDurableSessionId(claudeSession) ?? getCanonicalPaneResumeSessionId(pane)
+  }
+  if (EARLY_STATES.has(pane.status)) {
+    // While a new session is still being created, avoid reading an older durable ref.
+    return pane.sessionId
+  }
+  return pane.sessionId
+    ?? (pane.sessionRef?.provider === pane.provider ? pane.sessionRef.sessionId : undefined)
+}
+
 function getCreatedResumeSessionId(
   current: FreshAgentPaneContent,
   message: { sessionId: string; sessionRef?: { provider: string; sessionId: string } },
@@ -175,9 +190,7 @@ export function FreshAgentView({
   const autoTitleIdentityRef = useRef<string | null>(null)
   const handledRefreshRequestIdRef = useRef<string | null>(null)
   const preferredResumeSessionId = getPreferredResumeSessionId(claudeSession) ?? paneContent.resumeSessionId
-  const snapshotThreadId = paneContent.provider === 'claude'
-    ? getCanonicalDurableSessionId(claudeSession) ?? getCanonicalPaneResumeSessionId(paneContent)
-    : paneContent.sessionId
+  const snapshotThreadId = getFreshAgentSnapshotThreadId(paneContent, claudeSession)
   const hasRestoreFailure = Boolean(
     paneContent.provider === 'claude'
       && paneContent.sessionId

--- a/src/components/panes/PanePicker.tsx
+++ b/src/components/panes/PanePicker.tsx
@@ -101,6 +101,9 @@ export default function PanePicker({ onSelect, onCancel, isOnlyPane, tabId, pane
   const featureFlags = useAppSelector((s) => s.connection?.featureFlags ?? EMPTY_FEATURE_FLAGS)
   const enabledProviders = useAppSelector((s) => s.settings?.settings?.codingCli?.enabledProviders ?? EMPTY_ENABLED_PROVIDERS)
   const disabledExtensions = useAppSelector((s) => s.settings?.settings?.extensions?.disabled ?? EMPTY_ENABLED_PROVIDERS)
+  const freshClientsEnabled = useAppSelector((s) => (
+    s.settings?.settings?.freshAgent?.enabled ?? s.settings?.settings?.agentChat?.enabled ?? false
+  ))
   const extensionEntries = useAppSelector((s) => s.extensions?.entries ?? EMPTY_EXTENSION_ENTRIES)
 
   const options = useMemo(() => {
@@ -114,7 +117,7 @@ export default function PanePicker({ onSelect, onCancel, isOnlyPane, tabId, pane
     const shellOptions = isWindowsLike(platform) ? windowsShellOptions : [shellOption]
 
     // Agent chat options: only show if underlying CLI is available, enabled, and not hidden by feature flag
-    const visibleAgentChatConfigs = getVisibleAgentChatConfigs(featureFlags)
+    const visibleAgentChatConfigs = freshClientsEnabled ? getVisibleAgentChatConfigs(featureFlags) : []
     const agentChatOptions: PickerOption[] = visibleAgentChatConfigs
       .filter((config) => availableClis[config.codingCliProvider] && enabledProviders.includes(config.codingCliProvider) && !disabledExtensions.includes(config.codingCliProvider))
       .map((config) => ({
@@ -124,18 +127,20 @@ export default function PanePicker({ onSelect, onCancel, isOnlyPane, tabId, pane
         shortcut: config.pickerShortcut,
         afterCli: config.pickerAfterCli,
       }))
-    const otherFreshAgentOptions: PickerOption[] = FRESH_AGENT_REGISTRY
-      .filter((entry) => !visibleAgentChatConfigs.some((config) => config.name === entry.sessionType))
-      .filter((entry) => !entry.disabled)
-      .filter((entry) => !entry.hidden || featureFlags[entry.featureFlag ?? entry.sessionType] === true)
-      .filter((entry) => availableClis[entry.runtimeProvider] && enabledProviders.includes(entry.runtimeProvider) && !disabledExtensions.includes(entry.runtimeProvider))
-      .map((entry) => ({
-        type: entry.sessionType as PanePickerType,
-        label: entry.label,
-        icon: entry.icon,
-        shortcut: entry.pickerShortcut,
-        afterCli: entry.pickerAfterCli,
-      }))
+    const otherFreshAgentOptions: PickerOption[] = freshClientsEnabled
+      ? FRESH_AGENT_REGISTRY
+          .filter((entry) => !visibleAgentChatConfigs.some((config) => config.name === entry.sessionType))
+          .filter((entry) => !entry.disabled)
+          .filter((entry) => !entry.hidden || featureFlags[entry.featureFlag ?? entry.sessionType] === true)
+          .filter((entry) => availableClis[entry.runtimeProvider] && enabledProviders.includes(entry.runtimeProvider) && !disabledExtensions.includes(entry.runtimeProvider))
+          .map((entry) => ({
+            type: entry.sessionType as PanePickerType,
+            label: entry.label,
+            icon: entry.icon,
+            shortcut: entry.pickerShortcut,
+            afterCli: entry.pickerAfterCli,
+          }))
+      : []
 
     const allFreshAgentOptions = [...agentChatOptions, ...otherFreshAgentOptions]
     const agentChatBefore = allFreshAgentOptions.filter((o) => !o.afterCli)
@@ -153,7 +158,7 @@ export default function PanePicker({ onSelect, onCancel, isOnlyPane, tabId, pane
 
     // Order: agent chat (before), CLIs, agent chat (after), Editor, Browser, Shell(s), Extensions
     return [...agentChatBefore, ...cliOptions, ...agentChatAfter, ...nonShellOptions, ...shellOptions, ...extensionOptions]
-  }, [platform, availableClis, featureFlags, enabledProviders, disabledExtensions, extensionEntries])
+  }, [platform, availableClis, featureFlags, enabledProviders, disabledExtensions, freshClientsEnabled, extensionEntries])
 
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null)
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)

--- a/src/components/settings/WorkspaceSettings.tsx
+++ b/src/components/settings/WorkspaceSettings.tsx
@@ -263,6 +263,21 @@ export default function WorkspaceSettings({
       </SettingsSection>
 
       <SettingsSection title="Fresh agent" description="Display settings for fresh-agent panes">
+        <SettingsRow
+          label="Enable fresh clients (experimental)"
+          description="Show Freshclaude, Freshcodex, Freshopencode, and feature-flagged fresh clients in the pane picker."
+        >
+          <Toggle
+            checked={settings.freshAgent?.enabled ?? settings.agentChat?.enabled ?? false}
+            onChange={(checked) => {
+              applyServerSetting({
+                freshAgent: { enabled: checked },
+                agentChat: { enabled: checked },
+              })
+            }}
+            aria-label="Enable fresh clients (experimental)"
+          />
+        </SettingsRow>
         <SettingsRow label="Show thinking">
           <Toggle
             checked={settings.freshAgent?.showThinking ?? settings.agentChat?.showThinking ?? false}

--- a/test/e2e-browser/specs/agent-chat.spec.ts
+++ b/test/e2e-browser/specs/agent-chat.spec.ts
@@ -87,13 +87,31 @@ test.describe('Agent Chat', () => {
         payload: { claude: true },
       })
       harness?.dispatch({
-        type: 'settings/updateSettingsLocal',
+        type: 'settings/previewServerSettingsPatch',
         payload: {
           codingCli: {
             enabledProviders: ['claude'],
           },
+          freshAgent: {
+            enabled: true,
+          },
+          agentChat: {
+            enabled: true,
+          },
         },
       })
+    })
+  }
+
+  async function suppressFreshAgentNetworkForActivePane(page: any) {
+    await page.evaluate(() => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      const state = harness?.getState()
+      const tabId = state?.tabs?.activeTabId
+      const paneId = tabId ? state?.panes?.activePane?.[tabId] : null
+      if (paneId) {
+        harness?.setAgentChatNetworkEffectsSuppressed(paneId, true)
+      }
     })
   }
 
@@ -171,6 +189,7 @@ test.describe('Agent Chat', () => {
 
     await harness.clearSentWsMessages()
     const picker = await openPanePicker(page)
+    await suppressFreshAgentNetworkForActivePane(page)
     await picker.getByRole('button', { name: /^Freshclaude$/i }).click({ force: true })
     await confirmFreshclaudeDirectory(page, serverInfo.homeDir)
 
@@ -195,9 +214,9 @@ test.describe('Agent Chat', () => {
 
     await expect.poll(async () => {
       const sent = await harness.getSentWsMessages()
-      return sent.find((msg: any) => msg?.type === 'sdk.create') ?? null
+      return sent.find((msg: any) => msg?.type === 'freshAgent.create') ?? null
     }).toMatchObject({
-      type: 'sdk.create',
+      type: 'freshAgent.create',
       model: 'opus',
     })
   })
@@ -242,14 +261,15 @@ test.describe('Agent Chat', () => {
 
     await harness.clearSentWsMessages()
     const picker = await openPanePicker(page)
+    await suppressFreshAgentNetworkForActivePane(page)
     await picker.getByRole('button', { name: /^Freshclaude$/i }).click({ force: true })
     await confirmFreshclaudeDirectory(page, serverInfo.homeDir)
 
     await expect.poll(async () => {
       const sent = await harness.getSentWsMessages()
-      return sent.find((msg: any) => msg?.type === 'sdk.create') ?? null
+      return sent.find((msg: any) => msg?.type === 'freshAgent.create') ?? null
     }).toMatchObject({
-      type: 'sdk.create',
+      type: 'freshAgent.create',
       model: 'opus',
     })
 

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -7,13 +7,20 @@ async function enableClaudeAndCodex(page: any) {
       type: 'connection/setAvailableClis',
       payload: { claude: true, codex: true },
     })
-    harness?.dispatch({
-      type: 'settings/updateSettingsLocal',
-      payload: {
-        codingCli: {
-          enabledProviders: ['claude', 'codex'],
-        },
+    const patchPayload = {
+      codingCli: {
+        enabledProviders: ['claude', 'codex'],
       },
+      freshAgent: {
+        enabled: true,
+      },
+      agentChat: {
+        enabled: true,
+      },
+    }
+    harness?.dispatch({
+      type: 'settings/previewServerSettingsPatch',
+      payload: patchPayload,
     })
   })
 }
@@ -34,6 +41,31 @@ async function getActiveLeaf(harness: any) {
 }
 
 test.describe('Fresh Agent', () => {
+  test('pane picker hides fresh clients by default even when their CLIs are enabled', async ({ freshellPage, page, terminal }) => {
+    await terminal.waitForTerminal()
+    await page.evaluate(() => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      harness?.dispatch({
+        type: 'connection/setAvailableClis',
+        payload: { claude: true, codex: true, opencode: true },
+      })
+      harness?.dispatch({
+        type: 'settings/previewServerSettingsPatch',
+        payload: {
+          codingCli: {
+            enabledProviders: ['claude', 'codex', 'opencode'],
+          },
+        },
+      })
+    })
+
+    await openPanePicker(page)
+    await expect(page.getByRole('button', { name: /^Freshclaude$/i })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /^Freshcodex$/i })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /^Freshopencode$/i })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /^Kilroy$/i })).toHaveCount(0)
+  })
+
   test('pane picker shows Freshclaude and Freshcodex when their CLIs are enabled', async ({ freshellPage, page, terminal }) => {
     await terminal.waitForTerminal()
     await enableClaudeAndCodex(page)
@@ -46,7 +78,7 @@ test.describe('Fresh Agent', () => {
   test('freshclaude banners render through the fresh-agent pane surface and answer over WS', async ({ freshellPage, page, harness, terminal }) => {
     await terminal.waitForTerminal()
     const { tabId, paneId } = await getActiveLeaf(harness)
-    const sessionId = 'freshclaude-thread-1'
+    const sessionId = '33333333-3333-4333-8333-333333333333'
 
     await page.route(`**/api/fresh-agent/threads/freshclaude/claude/${sessionId}*`, async (route) => {
       await route.fulfill({
@@ -118,6 +150,7 @@ test.describe('Fresh Agent', () => {
             provider: 'claude',
             createRequestId: 'req-e2e-permission',
             sessionId: currentSessionId,
+            sessionRef: { provider: 'claude', sessionId: currentSessionId },
             resumeSessionId: currentSessionId,
             status: 'idle',
             settingsDismissed: true,
@@ -218,7 +251,7 @@ test.describe('Fresh Agent', () => {
     }, activePaneId)
     await page.getByRole('button', { name: /^Freshcodex$/i }).click()
     await page.getByRole('option').first().click()
-    await expect(page.locator('[data-context="fresh-agent"]').getByText('Starting session', { exact: true }).first()).toBeVisible()
+    await expect(page.getByRole('group', { name: /pane: freshcodex/i }).last()).toBeVisible()
 
     await page.evaluate(({ currentTabId, currentPaneId }) => {
       window.__FRESHELL_TEST_HARNESS__?.dispatch({
@@ -232,6 +265,7 @@ test.describe('Fresh Agent', () => {
             provider: 'codex',
             createRequestId: 'req-codex-browser',
             sessionId: 'thread-codex',
+            sessionRef: { provider: 'codex', sessionId: 'thread-codex' },
             resumeSessionId: 'thread-codex',
             status: 'connected',
           },
@@ -249,6 +283,9 @@ test.describe('Fresh Agent', () => {
     await expect(page.getByText('pending')).toBeVisible()
     await expect(page.getByText('thread-parent-1')).toBeVisible()
 
+    await page.evaluate(() => {
+      window.__FRESHELL_TEST_HARNESS__?.dispatch({ type: 'persist/flushNow' })
+    })
     await page.goto(`${serverInfo.baseUrl}/?token=${serverInfo.token}&e2e=1`)
     await harness.waitForHarness()
     await harness.waitForConnection()

--- a/test/e2e-browser/specs/settings-persistence-split.spec.ts
+++ b/test/e2e-browser/specs/settings-persistence-split.spec.ts
@@ -59,10 +59,16 @@ async function enableFreshclaude(page: any): Promise<void> {
       payload: { claude: true },
     })
     harness?.dispatch({
-      type: 'settings/updateSettingsLocal',
+      type: 'settings/previewServerSettingsPatch',
       payload: {
         codingCli: {
           enabledProviders: ['claude'],
+        },
+        freshAgent: {
+          enabled: true,
+        },
+        agentChat: {
+          enabled: true,
         },
       },
     })
@@ -132,9 +138,22 @@ async function confirmFreshclaudeDirectory(page: any, cwd: string) {
   await directoryInput.waitFor({ state: 'hidden', timeout: 10_000 })
 }
 
+async function suppressFreshAgentNetworkForActivePane(page: any): Promise<void> {
+  await page.evaluate(() => {
+    const harness = window.__FRESHELL_TEST_HARNESS__
+    const state = harness?.getState()
+    const tabId = state?.tabs?.activeTabId
+    const paneId = tabId ? state?.panes?.activePane?.[tabId] : null
+    if (paneId) {
+      harness?.setAgentChatNetworkEffectsSuppressed(paneId, true)
+    }
+  })
+}
+
 async function createFreshclaudePane(page: any, cwd: string): Promise<void> {
   const initialCount = await page.getByRole('group', { name: /pane: freshclaude/i }).count()
   const picker = await openPanePicker(page)
+  await suppressFreshAgentNetworkForActivePane(page)
   await picker.getByRole('button', { name: /^Freshclaude$/i }).click({ force: true })
   await confirmFreshclaudeDirectory(page, cwd)
   await expect.poll(async () => (
@@ -325,7 +344,7 @@ test.describe('Settings Persistence Split', () => {
 
     await expect.poll(async () => {
       const sent = await getSentWsMessages(page)
-      const create = sent.find((message) => message?.type === 'sdk.create')
+      const create = sent.find((message) => message?.type === 'freshAgent.create')
       return create
         ? {
             model: create.model ?? null,
@@ -357,7 +376,7 @@ test.describe('Settings Persistence Split', () => {
 
     await expect.poll(async () => {
       const sent = await getSentWsMessages(page)
-      const create = sent.find((message) => message?.type === 'sdk.create')
+      const create = sent.find((message) => message?.type === 'freshAgent.create')
       return create
         ? {
             model: create.model ?? null,
@@ -435,7 +454,7 @@ test.describe('Settings Persistence Split', () => {
 
     await expect.poll(async () => {
       const sent = await getSentWsMessages(page)
-      const create = sent.find((message) => message?.type === 'sdk.create')
+      const create = sent.find((message) => message?.type === 'freshAgent.create')
       return create
         ? {
             model: create.model ?? null,
@@ -470,7 +489,7 @@ test.describe('Settings Persistence Split', () => {
 
     await expect.poll(async () => {
       const sent = await getSentWsMessages(page)
-      const create = sent.find((message) => message?.type === 'sdk.create')
+      const create = sent.find((message) => message?.type === 'freshAgent.create')
       return create
         ? {
             model: create.model ?? null,
@@ -550,7 +569,7 @@ test.describe('Settings Persistence Split', () => {
 
     await expect.poll(async () => {
       const sent = await getSentWsMessages(page)
-      const create = sent.find((message) => message?.type === 'sdk.create')
+      const create = sent.find((message) => message?.type === 'freshAgent.create')
       return create
         ? {
             model: create.model ?? null,
@@ -625,7 +644,7 @@ test.describe('Settings Persistence Split', () => {
     await expect(page.getByText('Selected model claude-opus-4-6 is no longer available.')).toBeVisible()
     await expect.poll(async () => {
       const sent = await getSentWsMessages(page)
-      return sent.filter((message) => message?.type === 'sdk.create').length
+      return sent.filter((message) => message?.type === 'freshAgent.create').length
     }).toBe(0)
 
     const dialog = await openFreshclaudeSettings(page)
@@ -709,7 +728,7 @@ test.describe('Settings Persistence Split', () => {
 
     await expect.poll(async () => {
       const sent = await getSentWsMessages(page)
-      const create = sent.find((message) => message?.type === 'sdk.create')
+      const create = sent.find((message) => message?.type === 'freshAgent.create')
       return create
         ? {
             model: create.model ?? null,

--- a/test/e2e-browser/specs/settings.spec.ts
+++ b/test/e2e-browser/specs/settings.spec.ts
@@ -18,10 +18,16 @@ test.describe('Settings', () => {
         payload: { claude: true },
       })
       harness?.dispatch({
-        type: 'settings/updateSettingsLocal',
+        type: 'settings/previewServerSettingsPatch',
         payload: {
           codingCli: {
             enabledProviders: ['claude'],
+          },
+          freshAgent: {
+            enabled: true,
+          },
+          agentChat: {
+            enabled: true,
           },
         },
       })
@@ -44,6 +50,18 @@ test.describe('Settings', () => {
     const picker = page.getByRole('toolbar', { name: /pane type picker/i }).last()
     await expect(picker).toBeVisible({ timeout: 10_000 })
     return picker
+  }
+
+  async function suppressFreshAgentNetworkForActivePane(page: any) {
+    await page.evaluate(() => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      const state = harness?.getState()
+      const tabId = state?.tabs?.activeTabId
+      const paneId = tabId ? state?.panes?.activePane?.[tabId] : null
+      if (paneId) {
+        harness?.setAgentChatNetworkEffectsSuppressed(paneId, true)
+      }
+    })
   }
 
   async function openFreshclaudeSettings(page: any) {
@@ -324,12 +342,13 @@ test.describe('Settings', () => {
 
     await harness.clearSentWsMessages()
     const picker = await openPanePicker(page)
+    await suppressFreshAgentNetworkForActivePane(page)
     await picker.getByRole('button', { name: /^Freshclaude$/i }).click({ force: true })
     await confirmFreshclaudeDirectory(page, serverInfo.homeDir)
 
     await expect.poll(async () => {
       const sent = await harness.getSentWsMessages()
-      const create = sent.find((message: any) => message?.type === 'sdk.create')
+      const create = sent.find((message: any) => message?.type === 'freshAgent.create')
       return create
         ? {
             model: create.model ?? null,
@@ -412,6 +431,7 @@ test.describe('Settings', () => {
 
     await harness.clearSentWsMessages()
     const picker = await openPanePicker(page)
+    await suppressFreshAgentNetworkForActivePane(page)
     await picker.getByRole('button', { name: /^Freshclaude$/i }).click({ force: true })
     await confirmFreshclaudeDirectory(page, serverInfo.homeDir)
 
@@ -420,7 +440,7 @@ test.describe('Settings', () => {
     await expect(createFailedAlert).toContainText('Probe failed upstream')
     await expect.poll(async () => {
       const sent = await harness.getSentWsMessages()
-      return sent.filter((message: any) => message?.type === 'sdk.create').length
+      return sent.filter((message: any) => message?.type === 'freshAgent.create').length
     }).toBe(0)
 
     const dialog = await openFreshclaudeSettings(page)
@@ -433,7 +453,7 @@ test.describe('Settings', () => {
 
     await expect.poll(async () => {
       const sent = await harness.getSentWsMessages()
-      const create = sent.find((message: any) => message?.type === 'sdk.create')
+      const create = sent.find((message: any) => message?.type === 'freshAgent.create')
       return create
         ? {
             model: create.model ?? null,

--- a/test/unit/client/components/SettingsView.agent-chat.test.tsx
+++ b/test/unit/client/components/SettingsView.agent-chat.test.tsx
@@ -6,6 +6,7 @@ import {
   renderSettingsView,
   switchSettingsTab,
 } from './settings-view-test-utils'
+import { api } from '@/lib/api'
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -21,7 +22,10 @@ installSettingsViewHooks({ fakeTimers: true, mockFonts: true })
 
 function getToggle(labelText: string) {
   const label = screen.getByText(labelText)
-  const row = label.closest('div[class*="flex"]')
+  let row: HTMLElement | null = label.parentElement
+  while (row && !row.querySelector('[role="switch"]')) {
+    row = row.parentElement
+  }
   if (!row) throw new Error(`Row with label "${labelText}" not found`)
   return row.querySelector('[role="switch"]') as HTMLElement
 }
@@ -36,11 +40,12 @@ describe('SettingsView fresh agent settings', () => {
     expect(screen.getByText('Display settings for fresh-agent panes')).toBeInTheDocument()
   })
 
-  it('renders Show thinking, Show tools, and Show timecodes toggles', () => {
+  it('renders the enable switch, Show thinking, Show tools, and Show timecodes toggles', () => {
     const store = createSettingsViewStore()
     renderSettingsView(store)
     switchSettingsTab('Workspace')
 
+    expect(getToggle('Enable fresh clients (experimental)')).toBeInTheDocument()
     expect(getToggle('Show thinking')).toBeInTheDocument()
     expect(getToggle('Show tools')).toBeInTheDocument()
     expect(getToggle('Show timecodes & model')).toBeInTheDocument()
@@ -51,6 +56,7 @@ describe('SettingsView fresh agent settings', () => {
     renderSettingsView(store)
     switchSettingsTab('Workspace')
 
+    expect(getToggle('Enable fresh clients (experimental)')).toHaveAttribute('aria-checked', 'false')
     expect(getToggle('Show thinking')).toHaveAttribute('aria-checked', 'false')
     expect(getToggle('Show tools')).toHaveAttribute('aria-checked', 'false')
     expect(getToggle('Show timecodes & model')).toHaveAttribute('aria-checked', 'false')
@@ -66,6 +72,26 @@ describe('SettingsView fresh agent settings', () => {
     expect(getToggle('Show thinking')).toHaveAttribute('aria-checked', 'true')
     expect(getToggle('Show tools')).toHaveAttribute('aria-checked', 'true')
     expect(getToggle('Show timecodes & model')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('toggling Enable fresh clients updates server-backed settings', async () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    fireEvent.click(getToggle('Enable fresh clients (experimental)'))
+
+    expect(store.getState().settings.settings.freshAgent.enabled).toBe(true)
+    expect(store.getState().settings.settings.agentChat.enabled).toBe(true)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(api.patch).toHaveBeenCalledWith('/api/settings', {
+      freshAgent: { enabled: true },
+      agentChat: { enabled: true },
+    })
   })
 
   it('toggling Show thinking updates the store to true', () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -285,6 +285,32 @@ describe('FreshAgentView', () => {
     expect(screen.getByRole('region', { name: /question from codex/i })).toHaveTextContent('Codex has a question')
   })
 
+  it('loads a non-Claude fresh-agent snapshot from durable sessionRef after persistence strips sessionId', async () => {
+    const store = createStore()
+
+    render(
+      <Provider store={store}>
+        <FreshAgentView
+          tabId="tab-1"
+          paneId="pane-1"
+          paneContent={{
+            kind: 'fresh-agent',
+            sessionType: 'freshcodex',
+            provider: 'codex',
+            createRequestId: 'req-restored-codex',
+            sessionRef: { provider: 'codex', sessionId: 'thread-from-ref' },
+            status: 'connected',
+          }}
+        />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledWith('freshcodex', 'codex', 'thread-from-ref', expect.any(Object))
+    })
+    expect(await screen.findByText('Codex turn')).toBeInTheDocument()
+  })
+
   it('acquires a session id for a new non-Claude fresh-agent pane after freshAgent.created', async () => {
     const store = createStore()
     store.dispatch(initLayout({
@@ -2078,6 +2104,56 @@ describe('FreshAgentView', () => {
       expect(leaf.content.status).toBe('connected')
     })
     unmount()
+  })
+
+  it('allows retrying a disabled fresh-client create after settings change', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-disabled-create',
+        status: 'creating',
+        sessionRef: { provider: 'codex', sessionId: 'codex-thread-disabled' },
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    const onMessage = wsMock.onMessage.mock.calls[0]?.[0]
+    act(() => {
+      onMessage({
+        type: 'freshAgent.create.failed',
+        requestId: 'req-disabled-create',
+        code: 'FRESH_CLIENTS_DISABLED',
+        message: 'Fresh clients are disabled',
+        retryable: true,
+      })
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => {
+      const leaf = store.getState().panes.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>
+      expect(leaf.content.kind).toBe('fresh-agent')
+      if (leaf.content.kind === 'fresh-agent') {
+        expect(leaf.content.status).toBe('creating')
+        expect(leaf.content.createError).toBeUndefined()
+        expect(leaf.content.createRequestId).not.toBe('req-disabled-create')
+        expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
+          type: 'freshAgent.create',
+          requestId: leaf.content.createRequestId,
+          resumeSessionId: 'codex-thread-disabled',
+        }))
+      }
+    })
   })
 
   it('surfaces a missing Freshcodex rollout as a restore error instead of replacing the thread', async () => {

--- a/test/unit/client/components/panes/PaneContainer.createContent.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.createContent.test.tsx
@@ -275,7 +275,11 @@ describe('createContentForType with ext: prefix', () => {
     const store = createStore(
       { layouts: { 'tab-1': node }, activePane: { 'tab-1': 'pane-1' } },
       [],
-      {},
+      {
+        codingCli: { enabledProviders: ['claude'] },
+        freshAgent: { enabled: true },
+        agentChat: { enabled: true },
+      },
       {
         status: 'ready',
         platform: 'linux',
@@ -350,6 +354,7 @@ describe('createContentForType with ext: prefix', () => {
           providers: { claude: { cwd: '/workspace/default' } },
         },
         agentChat: {
+          enabled: true,
           defaultPlugins: ['planner', 'sandbox'],
           providers: {
             freshclaude: {
@@ -359,6 +364,7 @@ describe('createContentForType with ext: prefix', () => {
             },
           },
         },
+        freshAgent: { enabled: true },
       },
       {
         status: 'ready',

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -1646,7 +1646,13 @@ describe('PaneContainer', () => {
                 providers: providerSettingsByName ?? (providerSettings ? { claude: providerSettings } : {}),
               },
               freshAgent: {
+                enabled: true,
                 providers: freshAgentProviderSettingsByName ?? {},
+              },
+              agentChat: {
+                enabled: true,
+                defaultPlugins: [],
+                providers: {},
               },
               logging: { debug: false },
             },

--- a/test/unit/client/components/panes/PanePicker.test.tsx
+++ b/test/unit/client/components/panes/PanePicker.test.tsx
@@ -58,6 +58,7 @@ function createStore(overrides?: {
   enabledProviders?: string[]
   extensions?: ClientExtensionEntry[]
   featureFlags?: Record<string, boolean>
+  freshClientsEnabled?: boolean
 }) {
   return configureStore({
     reducer: {
@@ -99,6 +100,12 @@ function createStore(overrides?: {
           codingCli: {
             enabledProviders: (overrides?.enabledProviders ?? []) as any[],
             providers: {},
+          },
+          freshAgent: {
+            enabled: overrides?.freshClientsEnabled ?? false,
+          },
+          agentChat: {
+            enabled: overrides?.freshClientsEnabled ?? false,
           },
           logging: { debug: false },
         },
@@ -227,6 +234,7 @@ describe('PanePicker', () => {
         availableClis: { claude: true, codex: true },
         enabledProviders: ['claude', 'codex'],
         extensions: defaultCliExtensions,
+        freshClientsEnabled: true,
       })
       const buttons = screen.getAllByRole('button')
       const labels = buttons.map(b => b.getAttribute('aria-label'))
@@ -246,6 +254,7 @@ describe('PanePicker', () => {
         enabledProviders: ['claude', 'codex'],
         extensions: defaultCliExtensions,
         featureFlags: { kilroy: true },
+        freshClientsEnabled: true,
       })
       const buttons = screen.getAllByRole('button')
       const labels = buttons.map(b => b.getAttribute('aria-label'))
@@ -259,6 +268,34 @@ describe('PanePicker', () => {
       expect(labels[5]).toBe('Editor')
       expect(labels[6]).toBe('Browser')
       expect(labels[7]).toBe('Shell')
+    })
+
+    it('hides all fresh clients by default even when their CLIs are available and enabled', () => {
+      renderPicker({
+        availableClis: { claude: true, codex: true, opencode: true },
+        enabledProviders: ['claude', 'codex', 'opencode'],
+        extensions: [...defaultCliExtensions, mockOpencodeExt],
+        featureFlags: { kilroy: true },
+      })
+
+      expect(screen.queryByRole('button', { name: 'Freshclaude' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Freshcodex' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Freshopencode' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Kilroy' })).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Claude CLI' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Codex CLI' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument()
+    })
+
+    it('shows Freshopencode when fresh clients and OpenCode are enabled', () => {
+      renderPicker({
+        availableClis: { opencode: true },
+        enabledProviders: ['opencode'],
+        extensions: [mockOpencodeExt],
+        freshClientsEnabled: true,
+      })
+
+      expect(screen.getByRole('button', { name: 'Freshopencode' })).toBeInTheDocument()
     })
 
     it('shows only non-CLI options when no CLIs are available', () => {
@@ -599,6 +636,7 @@ describe('PanePicker', () => {
         availableClis: { claude: true, codex: true },
         enabledProviders: ['claude', 'codex'],
         extensions: defaultCliExtensions,
+        freshClientsEnabled: true,
       })
 
       const rows = screen.getAllByTestId('pane-picker-option-row')

--- a/test/unit/server/config-store.test.ts
+++ b/test/unit/server/config-store.test.ts
@@ -1199,7 +1199,7 @@ describe('ConfigStore', () => {
     })
 
     it('defaultSettings includes empty agentChat providers', () => {
-      expect(defaultSettings.agentChat).toEqual({ defaultPlugins: [], providers: {} })
+      expect(defaultSettings.agentChat).toEqual({ enabled: false, defaultPlugins: [], providers: {} })
     })
 
     it('migrates legacy flat freshclaude settings to agentChat.providers.freshclaude on load', async () => {

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -2,11 +2,34 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import http from 'http'
 import WebSocket from 'ws'
 
+vi.mock('../../../server/config-store.js', () => ({
+  configStore: {
+    snapshot: vi.fn(),
+    pushRecentDirectory: vi.fn().mockResolvedValue([]),
+  },
+}))
+
 import { WsHandler } from '../../../server/ws-handler.js'
 import { TerminalRegistry } from '../../../server/terminal-registry.js'
+import { configStore } from '../../../server/config-store.js'
+import { createDefaultServerSettings } from '../../../shared/settings.js'
 import { WS_PROTOCOL_VERSION } from '../../../shared/ws-protocol.js'
 
 const TEST_AUTH_TOKEN = 'testtoken-testtoken'
+
+function makeUserConfig(freshClientsEnabled: boolean) {
+  const settings = createDefaultServerSettings({ loggingDebug: false })
+  settings.freshAgent.enabled = freshClientsEnabled
+  settings.agentChat.enabled = freshClientsEnabled
+  return {
+    version: 1 as const,
+    settings,
+    sessionOverrides: {},
+    terminalOverrides: {},
+    projectColors: {},
+    recentDirectories: [],
+  }
+}
 
 describe('WsHandler fresh-agent routing', () => {
   let originalAuthToken: string | undefined
@@ -14,6 +37,7 @@ describe('WsHandler fresh-agent routing', () => {
   beforeEach(() => {
     originalAuthToken = process.env.AUTH_TOKEN
     process.env.AUTH_TOKEN = TEST_AUTH_TOKEN
+    vi.mocked(configStore.snapshot).mockResolvedValue(makeUserConfig(true))
   })
 
   async function createServer(options: Record<string, unknown> = {}) {
@@ -94,6 +118,50 @@ describe('WsHandler fresh-agent routing', () => {
     }
   })
 
+  it('rejects freshAgent.create without touching the runtime manager when fresh clients are disabled', async () => {
+    vi.mocked(configStore.snapshot).mockResolvedValue(makeUserConfig(false))
+    const runtimeManager = {
+      create: vi.fn().mockResolvedValue({
+        sessionId: 'codex-session-disabled',
+        sessionType: 'freshcodex',
+        runtimeProvider: 'codex',
+      }),
+      subscribe: vi.fn().mockResolvedValue(() => undefined),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+
+    try {
+      const ws = await connectAndAuth(server)
+      const seenMessages: any[] = []
+      ws.on('message', (data) => {
+        seenMessages.push(JSON.parse(data.toString()))
+      })
+
+      ws.send(JSON.stringify({
+        type: 'freshAgent.create',
+        requestId: 'req-disabled',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        cwd: '/workspace',
+      }))
+
+      await vi.waitFor(() => {
+        expect(seenMessages).toContainEqual(expect.objectContaining({
+          type: 'freshAgent.create.failed',
+          requestId: 'req-disabled',
+          code: 'FRESH_CLIENTS_DISABLED',
+          message: 'Fresh clients are disabled',
+          retryable: true,
+        }))
+        expect(runtimeManager.create).not.toHaveBeenCalled()
+      })
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
   it('replays duplicate freshAgent.create request ids without creating duplicate runtime sessions', async () => {
     const runtimeManager = {
       create: vi.fn().mockResolvedValue({
@@ -146,6 +214,60 @@ describe('WsHandler fresh-agent routing', () => {
             runtimeProvider: 'codex',
           }),
         ])
+        expect(runtimeManager.create).toHaveBeenCalledTimes(1)
+      })
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('replays duplicate freshAgent.create request ids even after fresh clients are disabled', async () => {
+    const runtimeManager = {
+      create: vi.fn().mockResolvedValue({
+        sessionId: 'codex-session-idempotent-disabled',
+        sessionType: 'freshcodex',
+        runtimeProvider: 'codex',
+      }),
+      subscribe: vi.fn().mockResolvedValue(() => undefined),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+
+    try {
+      const ws = await connectAndAuth(server)
+      const seenMessages: any[] = []
+      ws.on('message', (data) => {
+        seenMessages.push(JSON.parse(data.toString()))
+      })
+
+      const createMessage = {
+        type: 'freshAgent.create',
+        requestId: 'req-idempotent-disabled',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        cwd: '/workspace',
+      }
+
+      ws.send(JSON.stringify(createMessage))
+      await vi.waitFor(() => {
+        expect(seenMessages.filter((message) => message.type === 'freshAgent.created')).toHaveLength(1)
+      })
+
+      vi.mocked(configStore.snapshot).mockResolvedValue(makeUserConfig(false))
+      ws.send(JSON.stringify(createMessage))
+
+      await vi.waitFor(() => {
+        const created = seenMessages.filter((message) => message.type === 'freshAgent.created')
+        expect(created).toHaveLength(2)
+        expect(created[1]).toEqual(expect.objectContaining({
+          requestId: 'req-idempotent-disabled',
+          sessionId: 'codex-session-idempotent-disabled',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+          runtimeProvider: 'codex',
+        }))
+        expect(seenMessages.some((message) => message.type === 'freshAgent.create.failed')).toBe(false)
         expect(runtimeManager.create).toHaveBeenCalledTimes(1)
       })
     } finally {

--- a/test/unit/shared/settings.test.ts
+++ b/test/unit/shared/settings.test.ts
@@ -94,6 +94,55 @@ describe('shared settings contract', () => {
     }).success).toBe(false)
   })
 
+  it('defaults fresh clients off and accepts a server-backed enable switch', () => {
+    const defaults = createDefaultServerSettings({ loggingDebug: false })
+
+    expect(defaults.freshAgent.enabled).toBe(false)
+    expect(defaults.agentChat.enabled).toBe(false)
+
+    const parsed = buildServerSettingsPatchSchema().parse({
+      freshAgent: { enabled: true },
+    })
+    expect(parsed.freshAgent?.enabled).toBe(true)
+
+    const merged = mergeServerSettings(defaults, {
+      freshAgent: { enabled: true },
+    })
+    expect(merged.freshAgent.enabled).toBe(true)
+    expect(merged.agentChat.enabled).toBe(true)
+  })
+
+  it('merges freshAgent and agentChat alias patches before sanitizing', () => {
+    const merged = mergeServerSettings(createDefaultServerSettings({ loggingDebug: false }), {
+      freshAgent: {
+        enabled: true,
+        providers: {
+          freshclaude: { effort: 'max' },
+        },
+      },
+      agentChat: {
+        defaultPlugins: ['planner'],
+        providers: {
+          freshclaude: {
+            modelSelection: { kind: 'tracked', modelId: 'opus[1m]' },
+          },
+        },
+      },
+    })
+
+    expect(merged.freshAgent).toMatchObject({
+      enabled: true,
+      defaultPlugins: ['planner'],
+      providers: {
+        freshclaude: {
+          modelSelection: { kind: 'tracked', modelId: 'opus[1m]' },
+          effort: 'max',
+        },
+      },
+    })
+    expect(merged.agentChat).toEqual(merged.freshAgent)
+  })
+
   it('rejects representative local-only fields in the server patch schema', () => {
     const schema = buildServerSettingsPatchSchema()
 


### PR DESCRIPTION
Default fresh clients off behind a Workspace settings switch, hide fresh-agent picker entries unless enabled, and reject disabled fresh-agent creates at the websocket boundary.

Fresh* clients are still pretty buggy and experimental, so this intentionally keeps them turned off by default while preserving an opt-in path.

Also preserve non-Claude fresh-agent transcript loading after persisted state drops transient sessionId by falling back to durable sessionRef once creation is complete.
