### PR TITLE
Add directory creation to picker

### DIFF
--- a/server/files-router.ts
+++ b/server/files-router.ts
@@ -215,6 +215,39 @@ export function createFilesRouter(deps: FilesRouterDeps): Router {
     return res.json({ valid: ok, resolvedPath })
   })
 
+  router.post('/mkdir', validatePath, async (req, res) => {
+    const pathInput = req.body?.path
+    if (!pathInput || typeof pathInput !== 'string') {
+      return res.status(400).json({ error: 'path is required' })
+    }
+
+    const trimmed = pathInput.trim()
+    if (!trimmed) {
+      return res.status(400).json({ error: 'path is required' })
+    }
+
+    const { normalizedPath, flavor } = normalizeUserPath(trimmed)
+    const resolvedFsPath = await toFilesystemPath(normalizedPath, flavor)
+
+    try {
+      const existing = await fsp.stat(resolvedFsPath).catch(() => null)
+      if (existing) {
+        if (existing.isDirectory()) {
+          return res.json({ created: true, existed: true, resolvedPath: normalizedPath })
+        }
+        return res.status(409).json({ error: 'Path exists but is not a directory' })
+      }
+
+      await fsp.mkdir(resolvedFsPath, { recursive: true })
+      return res.json({ created: true, existed: false, resolvedPath: normalizedPath })
+    } catch (err: any) {
+      if (err.code === 'EACCES' || err.code === 'EPERM') {
+        return res.status(403).json({ error: 'Permission denied' })
+      }
+      return res.status(500).json({ error: err.message })
+    }
+  })
+
   router.post('/open', validatePath, async (req, res) => {
     const { path: filePath, reveal, line, column } = req.body || {}
     if (!filePath) {

--- a/server/files-router.ts
+++ b/server/files-router.ts
@@ -230,17 +230,19 @@ export function createFilesRouter(deps: FilesRouterDeps): Router {
     const resolvedFsPath = await toFilesystemPath(normalizedPath, flavor)
 
     try {
-      const existing = await fsp.stat(resolvedFsPath).catch(() => null)
-      if (existing) {
-        if (existing.isDirectory()) {
+      await fsp.mkdir(resolvedFsPath, { recursive: true })
+      return res.json({ created: true, existed: false, resolvedPath: normalizedPath })
+    } catch (err: any) {
+      if (err.code === 'EEXIST') {
+        const stat = await fsp.stat(resolvedFsPath).catch(() => null)
+        if (stat?.isDirectory()) {
           return res.json({ created: true, existed: true, resolvedPath: normalizedPath })
         }
         return res.status(409).json({ error: 'Path exists but is not a directory' })
       }
-
-      await fsp.mkdir(resolvedFsPath, { recursive: true })
-      return res.json({ created: true, existed: false, resolvedPath: normalizedPath })
-    } catch (err: any) {
+      if (err.code === 'ENOTDIR') {
+        return res.status(409).json({ error: 'Path exists but is not a directory' })
+      }
       if (err.code === 'EACCES' || err.code === 'EPERM') {
         return res.status(403).json({ error: 'Permission denied' })
       }

--- a/src/components/panes/DirectoryPicker.tsx
+++ b/src/components/panes/DirectoryPicker.tsx
@@ -219,7 +219,7 @@ export default function DirectoryPicker({
     } catch (error) {
       if (createRequestIdRef.current !== createId) return
       if (isApiError(error) && error.status === 403) {
-        setError('path not allowed')
+        setError(error.message === 'Permission denied' ? 'permission denied' : 'path not allowed')
         return
       }
       if (isApiError(error) && error.status === 409) {
@@ -267,6 +267,10 @@ export default function DirectoryPicker({
 
     if (event.key === 'Enter') {
       event.preventDefault()
+      if (event.shiftKey) {
+        void handleCreate()
+        return
+      }
       const selected = activeIndex >= 0 ? suggestions[activeIndex] : undefined
       void handleConfirm(selected || inputValue)
     }
@@ -274,6 +278,13 @@ export default function DirectoryPicker({
 
   const hasSuggestions = suggestions.length > 0
   const activeDescendant = hasSuggestions && activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined
+
+  const trimmedInput = inputValue.trim()
+  const isKnownDirectory = useMemo(() => {
+    if (!trimmedInput) return false
+    return candidates.includes(trimmedInput) || suggestions.includes(trimmedInput)
+  }, [trimmedInput, candidates, suggestions])
+  const showCreateButton = trimmedInput && !isKnownDirectory
 
   return (
     <div className="h-full w-full p-4 flex items-center justify-center">
@@ -316,7 +327,7 @@ export default function DirectoryPicker({
           spellCheck={false}
         />
 
-        {inputValue.trim() && (
+        {showCreateButton && (
           <div className="flex items-center gap-2">
             <button
               type="button"

--- a/src/components/panes/DirectoryPicker.tsx
+++ b/src/components/panes/DirectoryPicker.tsx
@@ -65,6 +65,8 @@ export default function DirectoryPicker({
   const [activeIndex, setActiveIndex] = useState(-1)
   const [error, setError] = useState<string | null>(null)
   const [isValidating, setIsValidating] = useState(false)
+  const [isCreating, setIsCreating] = useState(false)
+  const createRequestIdRef = useRef(0)
 
   const pathMode = useMemo(() => isPathInput(inputValue), [inputValue])
 
@@ -198,6 +200,40 @@ export default function DirectoryPicker({
     }
   }, [inputValue, onConfirm])
 
+  const handleCreate = useCallback(async () => {
+    const nextPath = inputValue.trim()
+    if (!nextPath) {
+      setError('directory not found')
+      return
+    }
+
+    setError(null)
+    setIsCreating(true)
+    createRequestIdRef.current += 1
+    const createId = createRequestIdRef.current
+
+    try {
+      const result = await api.post<{ created: boolean; existed?: boolean; resolvedPath?: string }>('/api/files/mkdir', { path: nextPath })
+      if (createRequestIdRef.current !== createId) return
+      onConfirm(result.resolvedPath || nextPath)
+    } catch (error) {
+      if (createRequestIdRef.current !== createId) return
+      if (isApiError(error) && error.status === 403) {
+        setError('path not allowed')
+        return
+      }
+      if (isApiError(error) && error.status === 409) {
+        setError('path exists but is not a directory')
+        return
+      }
+      setError('could not create directory')
+    } finally {
+      if (createRequestIdRef.current === createId) {
+        setIsCreating(false)
+      }
+    }
+  }, [inputValue, onConfirm])
+
   const handleInputKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Escape') {
       event.preventDefault()
@@ -263,6 +299,7 @@ export default function DirectoryPicker({
             setInputValue(event.target.value)
             setActiveIndex(-1)
             setError(null)
+            setIsCreating(false)
           }}
           onKeyDown={handleInputKeyDown}
           role="combobox"
@@ -278,6 +315,19 @@ export default function DirectoryPicker({
           placeholder="e.g. ~/projects/my-app"
           spellCheck={false}
         />
+
+        {inputValue.trim() && (
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => { void handleCreate() }}
+              disabled={isCreating}
+              className="text-xs px-3 py-1.5 rounded border bg-primary text-primary-foreground hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+            >
+              {isCreating ? 'Creating...' : 'Create directory'}
+            </button>
+          </div>
+        )}
 
         {hasSuggestions ? (
           <ul

--- a/test/unit/client/components/panes/DirectoryPicker.test.tsx
+++ b/test/unit/client/components/panes/DirectoryPicker.test.tsx
@@ -368,5 +368,46 @@ describe('DirectoryPicker', () => {
       })
       expect(onConfirm).toHaveBeenCalledTimes(1)
     })
+
+    it('hides create button when path matches a known candidate', async () => {
+      mockApiGet.mockResolvedValueOnce({ directories: ['/tmp/existing'] })
+      renderDirectoryPicker({ defaultCwd: '' })
+
+      const input = screen.getByLabelText('Starting directory for Claude')
+      fireEvent.change(input, { target: { value: '/tmp/existing' } })
+
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: 'Create directory' })).not.toBeInTheDocument()
+      })
+    })
+
+    it('shows permission denied error for OS permission failures', async () => {
+      mockApiGet.mockResolvedValueOnce({ directories: [] })
+      mockApiPost.mockRejectedValueOnce({ status: 403, message: 'Permission denied' })
+      renderDirectoryPicker({ defaultCwd: '' })
+
+      const input = screen.getByLabelText('Starting directory for Claude')
+      fireEvent.change(input, { target: { value: '/root/denied' } })
+
+      const createButton = screen.getByRole('button', { name: 'Create directory' })
+      fireEvent.click(createButton)
+
+      expect(await screen.findByText('permission denied')).toBeInTheDocument()
+    })
+
+    it('triggers create on Shift+Enter', async () => {
+      mockApiGet.mockResolvedValueOnce({ directories: [] })
+      mockApiPost.mockResolvedValueOnce({ created: true, resolvedPath: '/tmp/shift-enter' })
+      const { onConfirm } = renderDirectoryPicker({ defaultCwd: '' })
+
+      const input = screen.getByLabelText('Starting directory for Claude')
+      fireEvent.change(input, { target: { value: '/tmp/shift-enter' } })
+      fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
+
+      await waitFor(() => {
+        expect(mockApiPost).toHaveBeenCalledWith('/api/files/mkdir', { path: '/tmp/shift-enter' })
+      })
+      expect(onConfirm).toHaveBeenCalledWith('/tmp/shift-enter')
+    })
   })
 })

--- a/test/unit/client/components/panes/DirectoryPicker.test.tsx
+++ b/test/unit/client/components/panes/DirectoryPicker.test.tsx
@@ -247,4 +247,126 @@ describe('DirectoryPicker', () => {
       expect(input).toHaveValue('/code/tab-preferred')
     })
   })
+
+  describe('create directory button', () => {
+    it('shows create button when input is not empty', async () => {
+      mockApiGet.mockResolvedValueOnce({ directories: [] })
+      renderDirectoryPicker({ defaultCwd: '' })
+
+      const input = screen.getByLabelText('Starting directory for Claude')
+      fireEvent.change(input, { target: { value: '/tmp/new-dir' } })
+
+      expect(screen.getByRole('button', { name: 'Create directory' })).toBeInTheDocument()
+    })
+
+    it('hides create button when input is empty', () => {
+      mockApiGet.mockResolvedValueOnce({ directories: [] })
+      renderDirectoryPicker({ defaultCwd: '' })
+
+      expect(screen.queryByRole('button', { name: 'Create directory' })).not.toBeInTheDocument()
+    })
+
+    it('creates directory and confirms on success', async () => {
+      mockApiGet.mockResolvedValueOnce({ directories: [] })
+      mockApiPost.mockResolvedValueOnce({ created: true, resolvedPath: '/tmp/new-dir' })
+      const { onConfirm } = renderDirectoryPicker({ defaultCwd: '' })
+
+      const input = screen.getByLabelText('Starting directory for Claude')
+      fireEvent.change(input, { target: { value: '/tmp/new-dir' } })
+
+      const createButton = screen.getByRole('button', { name: 'Create directory' })
+      fireEvent.click(createButton)
+
+      await waitFor(() => {
+        expect(mockApiPost).toHaveBeenCalledWith('/api/files/mkdir', { path: '/tmp/new-dir' })
+      })
+      expect(onConfirm).toHaveBeenCalledWith('/tmp/new-dir')
+    })
+
+    it('shows creating state while request is in flight', async () => {
+      mockApiGet.mockResolvedValueOnce({ directories: [] })
+      let resolveMkdir: (value: unknown) => void
+      mockApiPost.mockReturnValueOnce(new Promise((resolve) => { resolveMkdir = resolve }))
+      renderDirectoryPicker({ defaultCwd: '' })
+
+      const input = screen.getByLabelText('Starting directory for Claude')
+      fireEvent.change(input, { target: { value: '/tmp/new-project' } })
+
+      const createButton = screen.getByRole('button', { name: 'Create directory' })
+      fireEvent.click(createButton)
+
+      expect(screen.getByRole('button', { name: 'Creating...' })).toBeDisabled()
+
+      resolveMkdir!({ created: true, resolvedPath: '/tmp/new-project' })
+    })
+
+    it('shows error when path is not allowed', async () => {
+      mockApiGet.mockResolvedValueOnce({ directories: [] })
+      mockApiPost.mockRejectedValueOnce({ status: 403, message: 'Path not allowed' })
+      renderDirectoryPicker({ defaultCwd: '' })
+
+      const input = screen.getByLabelText('Starting directory for Claude')
+      fireEvent.change(input, { target: { value: '/etc/hosts' } })
+
+      const createButton = screen.getByRole('button', { name: 'Create directory' })
+      fireEvent.click(createButton)
+
+      expect(await screen.findByText('path not allowed')).toBeInTheDocument()
+    })
+
+    it('shows error when path exists as a file', async () => {
+      mockApiGet.mockResolvedValueOnce({ directories: [] })
+      mockApiPost.mockRejectedValueOnce({ status: 409 })
+      renderDirectoryPicker({ defaultCwd: '' })
+
+      const input = screen.getByLabelText('Starting directory for Claude')
+      fireEvent.change(input, { target: { value: '/tmp/existing-file' } })
+
+      const createButton = screen.getByRole('button', { name: 'Create directory' })
+      fireEvent.click(createButton)
+
+      expect(await screen.findByText('path exists but is not a directory')).toBeInTheDocument()
+    })
+
+    it('shows generic error when creation fails', async () => {
+      mockApiGet.mockResolvedValueOnce({ directories: [] })
+      mockApiPost.mockRejectedValueOnce(new Error('Network error'))
+      renderDirectoryPicker({ defaultCwd: '' })
+
+      const input = screen.getByLabelText('Starting directory for Claude')
+      fireEvent.change(input, { target: { value: '/tmp/will-fail' } })
+
+      const createButton = screen.getByRole('button', { name: 'Create directory' })
+      fireEvent.click(createButton)
+
+      expect(await screen.findByText('could not create directory')).toBeInTheDocument()
+    })
+
+    it('ignores stale create responses', async () => {
+      mockApiGet.mockResolvedValueOnce({ directories: [] })
+      let resolveFirst: (value: unknown) => void
+      let resolveSecond: (value: unknown) => void
+      mockApiPost
+        .mockReturnValueOnce(new Promise((resolve) => { resolveFirst = resolve }))
+        .mockReturnValueOnce(new Promise((resolve) => { resolveSecond = resolve }))
+      const { onConfirm } = renderDirectoryPicker({ defaultCwd: '' })
+
+      const input = screen.getByLabelText('Starting directory for Claude')
+
+      fireEvent.change(input, { target: { value: '/tmp/dir-a' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Create directory' }))
+
+      fireEvent.change(input, { target: { value: '/tmp/dir-b' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Create directory' }))
+
+      resolveFirst!({ created: true, resolvedPath: '/tmp/dir-a' })
+      await Promise.resolve()
+
+      resolveSecond!({ created: true, resolvedPath: '/tmp/dir-b' })
+      await waitFor(() => {
+        expect(onConfirm).toHaveBeenCalledWith('/tmp/dir-b')
+      })
+      expect(onConfirm).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/test/unit/server/files-router.test.ts
+++ b/test/unit/server/files-router.test.ts
@@ -429,4 +429,113 @@ describe('files-router path validation', () => {
       expect(res.body.error).toBe('Path not allowed')
     })
   })
+
+  describe('POST /api/files/mkdir', () => {
+    it('creates a new directory', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockStat.mockRejectedValueOnce({ code: 'ENOENT' })
+      mockMkdir.mockResolvedValueOnce(undefined)
+
+      const res = await request(app)
+        .post('/api/files/mkdir')
+        .send({ path: '/home/user/new-project' })
+
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ created: true, existed: false, resolvedPath: expect.any(String) })
+    })
+
+    it('returns existed:true when directory already exists', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockStat.mockResolvedValueOnce({ isDirectory: () => true })
+
+      const res = await request(app)
+        .post('/api/files/mkdir')
+        .send({ path: '/home/user/existing' })
+
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ created: true, existed: true, resolvedPath: expect.any(String) })
+      expect(mockMkdir).not.toHaveBeenCalled()
+    })
+
+    it('returns 409 when path exists as a file', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockStat.mockResolvedValueOnce({ isDirectory: () => false })
+
+      const res = await request(app)
+        .post('/api/files/mkdir')
+        .send({ path: '/home/user/file.txt' })
+
+      expect(res.status).toBe(409)
+      expect(res.body.error).toBe('Path exists but is not a directory')
+    })
+
+    it('returns 403 when path is outside allowed directories', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+
+      const res = await request(app)
+        .post('/api/files/mkdir')
+        .send({ path: '/etc/evil' })
+
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('Path not allowed')
+    })
+
+    it('creates directory inside allowed directory', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+      mockStat.mockRejectedValueOnce({ code: 'ENOENT' })
+      mockMkdir.mockResolvedValueOnce(undefined)
+
+      const res = await request(app)
+        .post('/api/files/mkdir')
+        .send({ path: '/home/user/projects/subdir' })
+
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ created: true, existed: false, resolvedPath: expect.any(String) })
+    })
+
+    it('returns 400 when path is missing', async () => {
+      const res = await request(app)
+        .post('/api/files/mkdir')
+        .send({})
+
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('path is required')
+    })
+
+    it('returns 400 when path is empty', async () => {
+      const res = await request(app)
+        .post('/api/files/mkdir')
+        .send({ path: '   ' })
+
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('path is required')
+    })
+
+    it('expands tilde in path', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockStat.mockRejectedValueOnce({ code: 'ENOENT' })
+      mockMkdir.mockResolvedValueOnce(undefined)
+
+      const homeDir = os.homedir()
+      const res = await request(app)
+        .post('/api/files/mkdir')
+        .send({ path: '~/new-project' })
+
+      expect(res.status).toBe(200)
+      expect(mockMkdir).toHaveBeenCalledWith(path.join(homeDir, 'new-project'), { recursive: true })
+    })
+
+    it('returns 403 when permission is denied', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockStat.mockRejectedValueOnce({ code: 'ENOENT' })
+      mockMkdir.mockRejectedValueOnce(Object.assign(new Error('Permission denied'), { code: 'EACCES' }))
+
+      const res = await request(app)
+        .post('/api/files/mkdir')
+        .send({ path: '/root/cant-create' })
+
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('Permission denied')
+    })
+  })
 })

--- a/test/unit/server/files-router.test.ts
+++ b/test/unit/server/files-router.test.ts
@@ -433,7 +433,6 @@ describe('files-router path validation', () => {
   describe('POST /api/files/mkdir', () => {
     it('creates a new directory', async () => {
       mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
-      mockStat.mockRejectedValueOnce({ code: 'ENOENT' })
       mockMkdir.mockResolvedValueOnce(undefined)
 
       const res = await request(app)
@@ -446,6 +445,7 @@ describe('files-router path validation', () => {
 
     it('returns existed:true when directory already exists', async () => {
       mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockMkdir.mockRejectedValueOnce({ code: 'EEXIST' })
       mockStat.mockResolvedValueOnce({ isDirectory: () => true })
 
       const res = await request(app)
@@ -454,11 +454,11 @@ describe('files-router path validation', () => {
 
       expect(res.status).toBe(200)
       expect(res.body).toEqual({ created: true, existed: true, resolvedPath: expect.any(String) })
-      expect(mockMkdir).not.toHaveBeenCalled()
     })
 
     it('returns 409 when path exists as a file', async () => {
       mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockMkdir.mockRejectedValueOnce({ code: 'EEXIST' })
       mockStat.mockResolvedValueOnce({ isDirectory: () => false })
 
       const res = await request(app)
@@ -482,7 +482,6 @@ describe('files-router path validation', () => {
 
     it('creates directory inside allowed directory', async () => {
       mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
-      mockStat.mockRejectedValueOnce({ code: 'ENOENT' })
       mockMkdir.mockResolvedValueOnce(undefined)
 
       const res = await request(app)
@@ -513,7 +512,6 @@ describe('files-router path validation', () => {
 
     it('expands tilde in path', async () => {
       mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
-      mockStat.mockRejectedValueOnce({ code: 'ENOENT' })
       mockMkdir.mockResolvedValueOnce(undefined)
 
       const homeDir = os.homedir()
@@ -527,7 +525,6 @@ describe('files-router path validation', () => {
 
     it('returns 403 when permission is denied', async () => {
       mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
-      mockStat.mockRejectedValueOnce({ code: 'ENOENT' })
       mockMkdir.mockRejectedValueOnce(Object.assign(new Error('Permission denied'), { code: 'EACCES' }))
 
       const res = await request(app)
@@ -536,6 +533,30 @@ describe('files-router path validation', () => {
 
       expect(res.status).toBe(403)
       expect(res.body.error).toBe('Permission denied')
+    })
+
+    it('returns 409 when a parent path component is a file (ENOTDIR)', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockMkdir.mockRejectedValueOnce(Object.assign(new Error('Not a directory'), { code: 'ENOTDIR' }))
+
+      const res = await request(app)
+        .post('/api/files/mkdir')
+        .send({ path: '/tmp/file.txt/subdir' })
+
+      expect(res.status).toBe(409)
+      expect(res.body.error).toBe('Path exists but is not a directory')
+    })
+
+    it('returns 500 with generic error for unexpected failures', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })
+      mockMkdir.mockRejectedValueOnce(Object.assign(new Error('No space left on device'), { code: 'ENOSPC' }))
+
+      const res = await request(app)
+        .post('/api/files/mkdir')
+        .send({ path: '/tmp/full' })
+
+      expect(res.status).toBe(500)
+      expect(res.body.error).toBe('No space left on device')
     })
   })
 })


### PR DESCRIPTION
## Summary
- Add a mkdir file API endpoint for creating selected working directories.
- Add a Create directory action to the directory picker, including Shift+Enter support and known-directory hiding.
- Harden mkdir conflict and permission handling with unit coverage.

## Verification
- npm run test:vitest -- test/unit/client/components/panes/DirectoryPicker.test.tsx
- npm run test:server -- --run test/unit/server/files-router.test.ts