### PR TITLE
Remove unused FreshAgent item import

### DIFF
--- a/src/components/fresh-agent/FreshAgentItemCard.tsx
+++ b/src/components/fresh-agent/FreshAgentItemCard.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Check, ChevronRight, Loader2, X } from 'lucide-react'
 import DiffView from '@/components/agent-chat/DiffView'
 import { getToolPreview } from '@/components/agent-chat/tool-preview'


### PR DESCRIPTION
## Summary
- Remove the unused React memo import from FreshAgentItemCard.

## Verification
- npm run typecheck:client
- npm run test:vitest -- test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
- git diff --check