### PR TITLE
fix: lower default auto-kill idle timeout from 180 to 15 minutes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ npm run test:vitest -- ...  # Repo-owned direct Vitest path for focused passthro
 
 **WebSocket Protocol:** Schema-validated messages using Zod. Handshake flow: client sends `hello` with token → server validates → sends `ready`. Message types include `terminal.create/input/resize/detach/attach` and broadcasts like `sessions.updated`.
 
-**PTY Lifecycle:** Each terminal has a unique ID. Server maintains 64KB scrollback buffer. On attach, client receives buffer snapshot then streams new output. On detach, process continues running (background session). Configurable idle timeout (180 mins default).
+**PTY Lifecycle:** Each terminal has a unique ID. Server maintains 64KB scrollback buffer. On attach, client receives buffer snapshot then streams new output. On detach, process continues running (background session). Configurable idle timeout (15 mins default).
 
 **Claude Session Discovery:** Watches `~/.claude/projects/*/sessions/*.jsonl` for new files. Parses JSONL streams to extract messages, groups by project path.
 

--- a/shared/settings.ts
+++ b/shared/settings.ts
@@ -725,7 +725,7 @@ export function createDefaultServerSettings(options: SettingsDefaultsOptions = {
       debug: options.loggingDebug ?? false,
     },
     safety: {
-      autoKillIdleMinutes: 180,
+      autoKillIdleMinutes: 15,
     },
     terminal: {
       scrollback: 10000,

--- a/src/components/settings/SafetySettings.tsx
+++ b/src/components/settings/SafetySettings.tsx
@@ -498,9 +498,9 @@ export default function SafetySettings({
         <SettingsRow label="Auto-kill idle (minutes)">
           <RangeSlider
             value={settings.safety.autoKillIdleMinutes}
-            min={10}
+            min={5}
             max={720}
-            step={10}
+            step={5}
             format={(v) => String(v)}
             onChange={(v) => {
               applyServerSetting({ safety: { autoKillIdleMinutes: v } })

--- a/test/unit/client/components/SettingsView.behavior.test.tsx
+++ b/test/unit/client/components/SettingsView.behavior.test.tsx
@@ -327,7 +327,7 @@ describe('SettingsView behavior sections', () => {
       const autoKillSlider = getSlider((slider) => {
         const min = slider.getAttribute('min')
         const max = slider.getAttribute('max')
-        return min === '10' && max === '720'
+        return min === '5' && max === '720'
       })
 
       fireEvent.change(autoKillSlider, { target: { value: '300' } })

--- a/test/unit/shared/settings.test.ts
+++ b/test/unit/shared/settings.test.ts
@@ -176,6 +176,7 @@ describe('shared settings contract', () => {
 
     expect(resolved.terminal.fontFamily).toBe('Fira Code')
     expect(resolved.terminal.scrollback).toBe(10000)
+    expect(resolved.safety.autoKillIdleMinutes).toBe(15)
     expect(resolved.sidebar.sortMode).toBe('project')
     expect(resolved.agentChat.defaultPlugins).toEqual([])
   })


### PR DESCRIPTION
## What

Lowers the default `safety.autoKillIdleMinutes` from **180 → 15 minutes**.

## Why

Detached terminals (the result of plain pane/tab close, browser reload, or any websocket disconnect) keep their PTY running in the background and only get reaped once idle ≥ `autoKillIdleMinutes`. At the old 180-minute default these accumulate as running-but-orphaned terminals and push against the 50-terminal cap (`runningCount()` counts detached survivors). Dropping the default to 15 minutes reaps idle detached terminals promptly while still letting actively-producing background jobs (which reset the idle timer on output) survive.

This is a conservative first step — it does **not** change close/detach semantics, only the idle reaping window. Active terminals are unaffected; the timeout remains user-configurable in Settings → Safety.

## Changes
- `shared/settings.ts` — default `autoKillIdleMinutes` 180 → 15
- `src/components/settings/SafetySettings.tsx` — Safety slider `min`/`step` 10 → 5 so the new default is a reachable slider stop
- `AGENTS.md` — update the documented default (180 → 15 mins)
- Tests: pin the default in `settings.test.ts`; update the slider-range selector in `SettingsView.behavior.test.tsx`

## Testing
- `test:vitest` on `shared/settings`, `terminal-lifecycle`, `SettingsView.core`, `SettingsView.behavior` — all green
- `tsc --noEmit` clean
- Existing autokill behavior tests in `terminal-lifecycle.test.ts` (kill at threshold, exempt-while-attached, reset-on-activity, disabled-when-≤0) unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)