### PR TITLE
chore: disable superpowers plugin for the repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,3 @@
 {
-  "enabledPlugins": {
-    "superpowers@claude-plugins-official": true
-  }
+  "enabledPlugins": {}
 }


### PR DESCRIPTION
## What

Remove the `superpowers@claude-plugins-official` entry from the repo's committed `.claude/settings.json`:

```diff
-  "enabledPlugins": {
-    "superpowers@claude-plugins-official": true
-  }
+  "enabledPlugins": {}
```

## Why

The superpowers plugin ships a `SessionStart` hook that injected a `<EXTREMELY_IMPORTANT>` "you have superpowers / you MUST invoke skills" block into context at the start of every Claude Code session, and auto-enabled the `superpowers:`-namespaced skills for this project. That drove skills (e.g. brainstorming) to be invoked unprompted. Dropping the entry stops both the injection and the auto-enablement for anyone using this repo.

## Scope / impact

- Tooling/config only — no production code, no build or test surface touched.
- Personal `~/.claude/skills/` copies (brainstorming, TDD, writing-plans, etc.) are unaffected and remain available when invoked explicitly.
- Reversible by restoring the entry (or re-enabling the plugin via `/plugin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)