### PR TITLE
fix terminal warm tab replay and backpressure

### DIFF
--- a/docs/superpowers/plans/2026-06-02-warm-tab-delta-replay-and-backpressure.md
+++ b/docs/superpowers/plans/2026-06-02-warm-tab-delta-replay-and-backpressure.md
@@ -1,0 +1,147 @@
+# Warm Tab Delta Replay And Backpressure Plan
+
+## Goal
+
+Switching back to a tab that already has a rendered terminal screen should be fast and non-destructive. If the tab has changed while hidden, Freshell should keep the old screen visible and stream only the missing output from the last sequence the browser actually rendered.
+
+At the same time, hidden/background catch-up should not flood the shared browser WebSocket. Freshell should keep streaming hidden panes when possible, but foreground panes must stay responsive and background replay must pause before it creates enough buffered data to trigger a backpressure reconnect.
+
+## Plain-English Problem
+
+The old behavior mixed up two different facts:
+
+- "The server has output through sequence N."
+- "The browser has rendered output through sequence N."
+
+Only the second fact is safe to use for warm tab switching. If the client trusts a server cursor or a saved cursor before xterm has actually rendered that output, it can skip text. If the client distrusts a screen that is already rendered, it clears the terminal and replays old output, producing the visible flash/reload back to the same image.
+
+The server also used to send attach replay directly during attach. A noisy old hidden pane could dump a large replay into the WebSocket path at the wrong time, increasing shared backpressure and making the active tab worse.
+
+## Proposal
+
+Use a rendered-surface cursor on the client:
+
+- Track the highest terminal sequence after the xterm write callback fires.
+- Treat the mounted xterm surface as trusted only after output has actually rendered.
+- Persist the cursor only after render, not when output is merely received.
+- On warm reveal, if the mounted surface is trusted, attach with `transport_reconnect` from the rendered high-water and do not clear the terminal.
+- On explicit pane refresh, browser reload/remount, terminal identity replacement, or first hydration without a trusted surface, keep full `viewport_hydrate` from zero.
+- On flaky network reconnect, do not full reset if the screen is trusted; reconnect from the rendered high-water.
+
+Use priority-aware replay on the server:
+
+- Add optional `priority: 'foreground' | 'background'` to `terminal.attach`.
+- Default missing priority to foreground for compatibility.
+- Stream attach replay through the broker flush path instead of synchronously dumping frames during attach.
+- Keep replay state as a cursor on the attachment, not as a per-client replay backlog.
+- Pause background replay when `ws.bufferedAmount` is above the background threshold.
+- Continue foreground replay/live output unless the existing hard backpressure protections apply.
+
+## Implemented Files
+
+- `src/lib/terminal-attach-policy.ts`
+  - Central reveal policy for trusted warm surfaces, explicit refresh, and untrusted hydrate.
+
+- `src/components/TerminalView.tsx`
+  - Adds rendered high-water tracking based on xterm write completion.
+  - Uses rendered high-water for `keepalive_delta` and `transport_reconnect`.
+  - Keeps full hydrate for explicit refresh and untrusted surfaces.
+  - Registers trusted hidden reconnects for background catch-up without changing untrusted hidden remount behavior.
+  - Sends attach priority.
+
+- `src/lib/hydration-queue.ts`
+  - Allows explicitly queued late registrations to advance after the initial queue has already started.
+
+- `shared/ws-protocol.ts`
+  - Adds optional attach priority schema.
+
+- `server/ws-handler.ts`
+  - Passes attach priority to the terminal stream broker.
+
+- `server/terminal-stream/types.ts`
+  - Adds attachment priority and replay cursor state.
+
+- `server/terminal-stream/constants.ts`
+  - Adds background buffered pause and retry constants.
+
+- `server/terminal-stream/replay-ring.ts`
+  - Adds bounded replay batch reads for cursor-based replay streaming.
+
+- `server/terminal-stream/broker.ts`
+  - Streams attach replay through scheduled flushes.
+  - Pauses background replay under buffered socket pressure.
+  - Preserves foreground delivery under background pressure.
+
+## Key Behavior Rules
+
+- Warm tab reveal with a trusted rendered screen:
+  - Do not clear xterm.
+  - Attach with `transport_reconnect`.
+  - Use `sinceSeq` equal to the rendered high-water.
+  - Priority is foreground.
+
+- Hidden background catch-up with a trusted rendered screen:
+  - Attach with `keepalive_delta`.
+  - Use `sinceSeq` equal to the rendered high-water.
+  - Priority is background.
+
+- Hidden/untrusted reveal:
+  - Attach with `viewport_hydrate`.
+  - Use `sinceSeq: 0`.
+  - Clear only when doing foreground full hydrate.
+
+- Explicit pane refresh:
+  - Always full hydrate.
+  - Use `sinceSeq: 0`.
+  - Clear/replay by user request.
+
+- Browser reload or React remount:
+  - Saved cursor alone is not trusted.
+  - Full hydrate is allowed because the mounted rendered surface is gone.
+
+- Flaky internet reconnect:
+  - If the rendered surface is trusted, reconnect from rendered high-water.
+  - If not trusted, reconnect from zero.
+
+## Validation Findings
+
+- Ordinary hidden-but-mounted xterm buffers survive tab switches, so warm reveal can preserve the image.
+- Persisted cursor or `terminal.attach.ready.headSeq` does not prove the browser rendered that sequence.
+- The cursor must advance only after xterm write completion.
+- A hidden reconnect can happen while lifecycle state is not cleanly `live`; the trusted rendered surface must be considered directly.
+- Attach replay should not be stored as a per-client frame backlog. A replay cursor is safer under long/noisy sessions.
+- Background priority must pause based on shared socket buffered amount, while foreground delivery still drains.
+- Late trusted hidden reconnects need an explicit queue path; ordinary untrusted hidden remounts should still wait for reveal unless they were already queued before the active tab became ready.
+
+## Verification Run
+
+These commands passed in `.worktrees/warm-tab-delta-replay`:
+
+```bash
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run
+npm run test:vitest -- test/unit/client/lib/terminal-attach-policy.test.ts --run
+npm run test:vitest -- test/unit/server/terminal-stream/replay-ring.test.ts --run
+npm run test:vitest -- test/unit/server/ws-handler-backpressure.test.ts --run
+npm run test:vitest -- test/e2e/terminal-create-attach-ordering.test.tsx --run
+npm run test:vitest -- test/e2e/terminal-settings-remount-scrollback.test.tsx --run
+npm run test:vitest -- test/e2e/codex-refresh-rehydrate-flow.test.tsx --run
+npm run typecheck
+npm run build
+```
+
+Repo baseline note: the pre-worktree `npm run check` baseline was already red with unrelated Sidebar and PaneContainer failures. Those failures were not introduced by this work.
+
+## Remaining Recommended Verification
+
+- Run the coordinated full check after the unrelated baseline failures are resolved or accepted as known:
+
+```bash
+FRESHELL_TEST_SUMMARY="warm tab delta replay and backpressure" npm run check
+```
+
+- Run a private-server manual repro with a long noisy coding-agent tab:
+  - Start a worktree server on a unique port.
+  - Create a long-output terminal/coding-agent session.
+  - Switch to another tab while output continues.
+  - Switch back.
+  - Expected: existing terminal image stays visible; no clear-and-replay flash; catch-up starts from rendered high-water.

--- a/server/terminal-stream/broker.ts
+++ b/server/terminal-stream/broker.ts
@@ -7,6 +7,8 @@ import type { TerminalOutputRawEvent } from './registry-events.js'
 import { ClientOutputQueue, isGapEvent, type GapEvent } from './client-output-queue.js'
 import { ReplayRing, type ReplayFrame } from './replay-ring.js'
 import {
+  TERMINAL_BACKGROUND_BUFFERED_PAUSE_BYTES,
+  TERMINAL_BACKGROUND_RETRY_FLUSH_MS,
   TERMINAL_STREAM_BATCH_MAX_BYTES,
   TERMINAL_STREAM_RETRY_FLUSH_MS,
   TERMINAL_WS_CATASTROPHIC_BUFFERED_BYTES,
@@ -21,6 +23,7 @@ const CODING_CLI_MIN_REPLAY_RING_MAX_BYTES = Number(
 
 type PerfLevel = 'debug' | 'info' | 'warn' | 'error'
 type AttachIntent = 'viewport_hydrate' | 'keepalive_delta' | 'transport_reconnect'
+type AttachPriority = 'foreground' | 'background'
 type PerfEventLogger = (
   event: TerminalStreamPerfEvent,
   context: Record<string, unknown>,
@@ -84,6 +87,7 @@ export class TerminalStreamBroker {
     sinceSeq: number | undefined,
     attachRequestId?: string,
     maxReplayBytes?: number,
+    priority: AttachPriority = 'foreground',
   ): Promise<'attached' | 'duplicate' | 'missing'> {
     const normalizedSinceSeq = sinceSeq === undefined || sinceSeq === 0 ? 0 : sinceSeq
     let result: 'attached' | 'duplicate' | 'missing' = 'attached'
@@ -127,7 +131,9 @@ export class TerminalStreamBroker {
       }
 
       attachment.mode = 'attaching'
+      attachment.priority = priority
       attachment.activeAttachRequestId = attachRequestId
+      attachment.replayCursor = null
       attachment.attachStaging = []
       attachment.queue.clear()
 
@@ -236,25 +242,17 @@ export class TerminalStreamBroker {
         }
       }
 
-      for (const frame of replayFrames) {
-        if (!this.sendFrame(ws, terminalId, frame, attachment.activeAttachRequestId)) return
-        attachment.lastSeq = Math.max(attachment.lastSeq, frame.seqEnd)
-      }
-
       const staged = attachment.attachStaging.filter((frame) => frame.seqStart > replayToSeq)
       attachment.attachStaging = []
+      attachment.replayCursor = replayFrames.length > 0
+        ? { nextSeq: replayFromSeq, toSeq: replayToSeq }
+        : null
       for (const frame of staged) {
-        if (!this.sendFrame(ws, terminalId, frame, attachment.activeAttachRequestId)) return
-        attachment.lastSeq = Math.max(attachment.lastSeq, frame.seqEnd)
+        attachment.queue.enqueue(frame)
       }
 
       attachment.mode = 'live'
-      const residual = attachment.attachStaging.filter((frame) => frame.seqStart > attachment.lastSeq)
-      attachment.attachStaging = []
-      for (const frame of residual) {
-        attachment.queue.enqueue(frame)
-      }
-      if (attachment.queue.pendingBytes() > 0) {
+      if (attachment.replayCursor || attachment.queue.pendingBytes() > 0) {
         this.scheduleFlush(terminalId, attachment)
       }
     })
@@ -357,7 +355,9 @@ export class TerminalStreamBroker {
       attachment = {
         ws,
         mode: 'live',
+        priority: 'foreground',
         queue: new ClientOutputQueue(),
+        replayCursor: null,
         attachStaging: [],
         lastSeq: 0,
         flushTimer: null,
@@ -421,9 +421,26 @@ export class TerminalStreamBroker {
         this.detach(terminalId, ws)
         return
       }
-      if (attachment.queue.pendingBytes() > 0) {
+      if (this.hasPendingAttachmentOutput(attachment)) {
         this.scheduleFlush(terminalId, attachment, TERMINAL_STREAM_RETRY_FLUSH_MS)
       }
+      return
+    }
+
+    const wsBuffered = ws.bufferedAmount as number | undefined
+    if (
+      attachment.priority === 'background'
+      && typeof wsBuffered === 'number'
+      && wsBuffered > TERMINAL_BACKGROUND_BUFFERED_PAUSE_BYTES
+    ) {
+      if (this.hasPendingAttachmentOutput(attachment)) {
+        this.scheduleFlush(terminalId, attachment, TERMINAL_BACKGROUND_RETRY_FLUSH_MS)
+      }
+      return
+    }
+
+    if (attachment.replayCursor) {
+      this.flushReplayCursor(terminalId, attachment)
       return
     }
 
@@ -469,6 +486,63 @@ export class TerminalStreamBroker {
     if (attachment.queue.pendingBytes() > 0) {
       this.scheduleFlush(terminalId, attachment)
     }
+  }
+
+  private flushReplayCursor(terminalId: string, attachment: BrokerClientAttachment): void {
+    const cursor = attachment.replayCursor
+    if (!cursor) return
+
+    const terminalState = this.terminals.get(terminalId)
+    if (!terminalState) {
+      attachment.replayCursor = null
+      return
+    }
+
+    const attachRequestId = attachment.activeAttachRequestId
+    const replay = terminalState.replayRing.replayBatchSince(
+      cursor.nextSeq - 1,
+      TERMINAL_STREAM_BATCH_MAX_BYTES,
+      cursor.toSeq,
+    )
+
+    if (replay.missedFromSeq !== undefined) {
+      const replayFromSeq = replay.frames.length > 0
+        ? replay.frames[0].seqStart
+        : Math.min(cursor.toSeq + 1, terminalState.replayRing.headSeq() + 1)
+      const missedToSeq = Math.min(cursor.toSeq, replayFromSeq - 1)
+      if (missedToSeq >= replay.missedFromSeq) {
+        if (!this.sendReplayGap(
+          attachment.ws,
+          terminalId,
+          replay.missedFromSeq,
+          missedToSeq,
+          attachRequestId,
+        )) return
+        attachment.lastSeq = Math.max(attachment.lastSeq, missedToSeq)
+        cursor.nextSeq = missedToSeq + 1
+      }
+    }
+
+    for (const frame of replay.frames) {
+      if (!this.sendFrame(attachment.ws, terminalId, frame, attachRequestId)) return
+      attachment.lastSeq = Math.max(attachment.lastSeq, frame.seqEnd)
+      cursor.nextSeq = frame.seqEnd + 1
+    }
+
+    if (cursor.nextSeq > cursor.toSeq || replay.frames.length === 0) {
+      attachment.replayCursor = null
+    }
+
+    if (this.hasPendingAttachmentOutput(attachment)) {
+      const replayFlushDelay = attachment.priority === 'foreground'
+        ? 0
+        : TERMINAL_STREAM_RETRY_FLUSH_MS
+      this.scheduleFlush(terminalId, attachment, replayFlushDelay)
+    }
+  }
+
+  private hasPendingAttachmentOutput(attachment: BrokerClientAttachment): boolean {
+    return Boolean(attachment.replayCursor) || attachment.queue.pendingBytes() > 0
   }
 
   private catastrophicBlocked(terminalId: string, attachment: BrokerClientAttachment): boolean {
@@ -555,6 +629,31 @@ export class TerminalStreamBroker {
       fromSeq: gap.fromSeq,
       toSeq: gap.toSeq,
       reason: gap.reason,
+      ...(attachRequestId ? { attachRequestId } : {}),
+    })
+  }
+
+  private sendReplayGap(
+    ws: LiveWebSocket,
+    terminalId: string,
+    fromSeq: number,
+    toSeq: number,
+    attachRequestId?: string,
+  ): boolean {
+    this.perfEventLogger('terminal_stream_gap', {
+      terminalId,
+      connectionId: ws.connectionId,
+      fromSeq,
+      toSeq,
+      reason: 'replay_window_exceeded',
+    }, 'warn')
+
+    return this.safeSend(ws, {
+      type: 'terminal.output.gap',
+      terminalId,
+      fromSeq,
+      toSeq,
+      reason: 'replay_window_exceeded',
       ...(attachRequestId ? { attachRequestId } : {}),
     })
   }

--- a/server/terminal-stream/constants.ts
+++ b/server/terminal-stream/constants.ts
@@ -19,3 +19,13 @@ export const TERMINAL_STREAM_RETRY_FLUSH_MS = Math.max(
   1,
   Number(process.env.TERMINAL_STREAM_RETRY_FLUSH_MS || 50),
 )
+
+export const TERMINAL_BACKGROUND_BUFFERED_PAUSE_BYTES = Math.max(
+  1024,
+  Number(process.env.TERMINAL_BACKGROUND_BUFFERED_PAUSE_BYTES || 512 * 1024),
+)
+
+export const TERMINAL_BACKGROUND_RETRY_FLUSH_MS = Math.max(
+  1,
+  Number(process.env.TERMINAL_BACKGROUND_RETRY_FLUSH_MS || 100),
+)

--- a/server/terminal-stream/replay-ring.ts
+++ b/server/terminal-stream/replay-ring.ts
@@ -74,7 +74,49 @@ export class ReplayRing {
       ? normalizedSinceSeq + 1
       : undefined
 
-    const frames = this.frames.filter((frame) => frame.seqEnd > normalizedSinceSeq)
+    const frames = this.frames.slice(this.firstFrameIndexAfter(normalizedSinceSeq))
+    return { frames, missedFromSeq }
+  }
+
+  replayBatchSince(
+    sinceSeq: number | undefined,
+    maxBytes: number,
+    toSeq?: number,
+  ): { frames: ReplayFrame[]; missedFromSeq?: number } {
+    const normalizedSinceSeq = sinceSeq === undefined || sinceSeq === 0 ? 0 : sinceSeq
+    const normalizedMaxBytes = Number.isFinite(maxBytes) && maxBytes > 0 ? Math.floor(maxBytes) : 0
+    const normalizedToSeq = typeof toSeq === 'number' && Number.isFinite(toSeq)
+      ? Math.max(0, Math.floor(toSeq))
+      : Number.POSITIVE_INFINITY
+
+    if (this.frames.length === 0) {
+      if (normalizedSinceSeq < this.head) {
+        return { frames: [], missedFromSeq: normalizedSinceSeq + 1 }
+      }
+      return { frames: [] }
+    }
+
+    const tail = this.frames[0].seqStart
+    const missedFromSeq = normalizedSinceSeq < tail - 1
+      ? normalizedSinceSeq + 1
+      : undefined
+    const frames: ReplayFrame[] = []
+    let budget = normalizedMaxBytes
+
+    if (budget <= 0) {
+      return { frames, missedFromSeq }
+    }
+
+    const startIndex = this.firstFrameIndexAfter(normalizedSinceSeq)
+    for (let i = startIndex; i < this.frames.length; i += 1) {
+      const frame = this.frames[i]
+      if (frame.seqStart > normalizedToSeq) break
+      if (frame.bytes > budget && frames.length > 0) break
+      frames.push(frame)
+      budget -= frame.bytes
+      if (budget <= 0) break
+    }
+
     return { frames, missedFromSeq }
   }
 
@@ -95,6 +137,20 @@ export class ReplayRing {
       if (!removed) break
       this.totalBytes -= removed.bytes
     }
+  }
+
+  private firstFrameIndexAfter(seq: number): number {
+    let low = 0
+    let high = this.frames.length
+    while (low < high) {
+      const mid = Math.floor((low + high) / 2)
+      if (this.frames[mid].seqEnd <= seq) {
+        low = mid + 1
+      } else {
+        high = mid
+      }
+    }
+    return low
   }
 
   private decodeUtf8Fatal(bytes: Uint8Array): string | null {

--- a/server/terminal-stream/types.ts
+++ b/server/terminal-stream/types.ts
@@ -3,11 +3,19 @@ import type { ClientOutputQueue } from './client-output-queue.js'
 import type { ReplayFrame, ReplayRing } from './replay-ring.js'
 
 export type BrokerClientMode = 'attaching' | 'live'
+export type BrokerClientPriority = 'foreground' | 'background'
+
+export type ReplayCursor = {
+  nextSeq: number
+  toSeq: number
+}
 
 export type BrokerClientAttachment = {
   ws: LiveWebSocket
   mode: BrokerClientMode
+  priority: BrokerClientPriority
   queue: ClientOutputQueue
+  replayCursor: ReplayCursor | null
   attachStaging: ReplayFrame[]
   lastSeq: number
   flushTimer: NodeJS.Timeout | null

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -3023,6 +3023,7 @@ export class WsHandler {
           m.sinceSeq,
           m.attachRequestId,
           m.maxReplayBytes,
+          m.priority ?? 'foreground',
         )
         if (attachResult === 'missing') {
           const latestRecord = this.registry.get(m.terminalId)

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -272,6 +272,11 @@ export const TerminalAttachIntentSchema = z.enum([
   'transport_reconnect',
 ])
 
+export const TerminalAttachPrioritySchema = z.enum([
+  'foreground',
+  'background',
+])
+
 export const TerminalAttachSchema = z.object({
   type: z.literal('terminal.attach'),
   terminalId: z.string().min(1),
@@ -279,6 +284,7 @@ export const TerminalAttachSchema = z.object({
   maxReplayBytes: z.number().int().positive().optional(),
   attachRequestId: z.string().min(1).optional(),
   intent: TerminalAttachIntentSchema,
+  priority: TerminalAttachPrioritySchema.optional(),
   cols: z.number().int().min(2).max(1000),
   rows: z.number().int().min(2).max(500),
 })

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -37,6 +37,11 @@ import {
 } from '@/lib/terminal-restore'
 import { isTerminalPasteShortcut } from '@/lib/terminal-input-policy'
 import { clearTerminalCursor, loadTerminalCursor, saveTerminalCursor } from '@/lib/terminal-cursor'
+import {
+  resolveRevealAttachPlan,
+  type DeferredAttachReason,
+  type TerminalAttachPriority,
+} from '@/lib/terminal-attach-policy'
 import { paneRefreshTargetMatchesContent } from '@/lib/pane-utils'
 import { getInstalledPerfAuditBridge } from '@/lib/perf-audit-bridge'
 import {
@@ -265,6 +270,7 @@ type DeferredAttachState = {
   mode: 'none' | 'waiting_for_geometry' | 'attaching' | 'live'
   pendingIntent: AttachIntent | null
   pendingSinceSeq: number
+  pendingReason: DeferredAttachReason
 }
 
 type LaunchAttemptState = {
@@ -470,6 +476,8 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
   const requestIdRef = useRef<string>(terminalContent?.createRequestId || '')
   const terminalIdRef = useRef<string | undefined>(terminalContent?.terminalId)
   const seqStateRef = useRef<AttachSeqState>(createAttachSeqState())
+  const renderedSeqRef = useRef(0)
+  const hasTrustedSurfaceRef = useRef(false)
   const attachCounterRef = useRef(0)
   const currentAttachRef = useRef<{
     requestId: string
@@ -497,6 +505,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     mode: 'none',
     pendingIntent: null,
     pendingSinceSeq: 0,
+    pendingReason: 'initial_hydrate',
   })
   const contentRef = useRef<TerminalPaneContent | null>(terminalContent)
   const providerBehaviorRef = useRef(providerBehavior)
@@ -504,20 +513,27 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
   const handledRefreshRequestIdRef = useRef<string | null>(null)
   const hasMountedRefreshEffectRef = useRef(false)
 
-  const applySeqState = useCallback((
-    nextState: AttachSeqState,
-    options?: { terminalId?: string; persistCursor?: boolean },
-  ) => {
-    const previousLastSeq = seqStateRef.current.lastSeq
+  const applySeqState = useCallback((nextState: AttachSeqState) => {
     seqStateRef.current = nextState
-    if (
-      options?.persistCursor
-      && options.terminalId
-      && nextState.lastSeq > 0
-      && nextState.lastSeq > previousLastSeq
-    ) {
-      saveTerminalCursor(options.terminalId, nextState.lastSeq)
+  }, [])
+
+  const resetRenderedSurface = useCallback((seq = 0) => {
+    renderedSeqRef.current = Math.max(0, Math.floor(Number.isFinite(seq) ? seq : 0))
+    hasTrustedSurfaceRef.current = false
+  }, [])
+
+  const markRenderedSeq = useCallback((terminalId: string | undefined, seq: number) => {
+    if (!terminalId || !Number.isFinite(seq)) return
+    const renderedSeq = Math.max(0, Math.floor(seq))
+    if (renderedSeq <= renderedSeqRef.current) {
+      if (renderedSeq > 0) {
+        hasTrustedSurfaceRef.current = true
+      }
+      return
     }
+    renderedSeqRef.current = renderedSeq
+    hasTrustedSurfaceRef.current = true
+    saveTerminalCursor(terminalId, renderedSeq)
   }, [])
 
   // Keep refs in sync with props
@@ -535,6 +551,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       }
       terminalIdRef.current = terminalContent.terminalId
       if (terminalContent.terminalId !== prevTerminalId) {
+        resetRenderedSurface()
         forgetSentViewport(prevTerminalId)
         const cachedViewport = terminalContent.terminalId
           ? lastSentViewportByTerminal.get(terminalContent.terminalId)
@@ -550,7 +567,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       requestIdRef.current = terminalContent.createRequestId
       contentRef.current = terminalContent
     }
-  }, [terminalContent, paneId, applySeqState])
+  }, [terminalContent, paneId, applySeqState, resetRenderedSurface])
 
   // Register terminal buffer accessor with test harness (for E2E tests).
   // Uses xterm.js Terminal.buffer.active API which works with all renderers
@@ -1050,6 +1067,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     mode: TerminalPaneContent['mode'],
     tid: string | undefined,
     allowReplies: boolean,
+    onRendered?: () => void,
   ) => {
     const startup = extractTerminalStartupProbes(raw, startupProbeStateRef.current, {
       foreground: resolvedThemeRef.current.foreground,
@@ -1076,7 +1094,9 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     }
 
     if (cleaned) {
-      enqueueTerminalWrite(cleaned)
+      enqueueTerminalWrite(cleaned, onRendered)
+    } else {
+      onRendered?.()
     }
 
     for (const event of osc.events) {
@@ -1604,6 +1624,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       mode: 'live',
       pendingIntent: null,
       pendingSinceSeq: 0,
+      pendingReason: 'initial_hydrate',
     }
     const queue = getHydrationQueue()
     if (hiddenRef.current) {
@@ -1612,6 +1633,17 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       queue.onActiveTabReady(tabId, tabOrderRef.current)
     }
   }, [paneId, tabId])
+
+  const registerForBackgroundHydration = useCallback((options?: { queueIfStarted?: boolean }) => {
+    if (hydrationRegisteredRef.current) return
+    hydrationRegisteredRef.current = true
+    const setBgTriggered = setBackgroundHydrationTriggered
+    getHydrationQueue().register({
+      tabId,
+      paneId: paneIdRef.current,
+      trigger: () => setBgTriggered(true),
+    }, options)
+  }, [tabId])
 
   const isCurrentAttachMessage = useCallback((msg: {
     type: string
@@ -1642,6 +1674,8 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       suppressNextMatchingResize?: boolean
       skipPreAttachFit?: boolean
       maxReplayBytes?: number
+      priority?: TerminalAttachPriority
+      sinceSeq?: number
     },
   ) => {
     if (suppressNetworkEffects) return
@@ -1660,14 +1694,15 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     setIsAttaching(true)
     setTruncatedHistoryGap(null)
 
-    const persistedSeq = loadTerminalCursor(tid)
-    const deltaSeq = Math.max(seqStateRef.current.lastSeq, persistedSeq)
+    const renderedSeq = hasTrustedSurfaceRef.current ? renderedSeqRef.current : 0
+    const deltaSeq = Math.max(0, Math.floor(opts?.sinceSeq ?? renderedSeq))
     const sinceSeq = intent === 'viewport_hydrate' ? 0 : deltaSeq
 
     // Startup probes must not leak across attach generations.
     resetStartupProbeParser()
 
     if (intent === 'viewport_hydrate') {
+      resetRenderedSurface()
       if (opts?.clearViewportFirst) {
         try {
           termRef.current?.clear()
@@ -1685,6 +1720,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       mode: 'attaching',
       pendingIntent: intent,
       pendingSinceSeq: sinceSeq,
+      pendingReason: opts?.priority === 'background' ? 'background_catchup' : 'initial_hydrate',
     }
 
     const attachRequestId = `${paneIdRef.current}:${++attachCounterRef.current}:${nanoid(6)}`
@@ -1708,11 +1744,12 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       rows,
       sinceSeq,
       attachRequestId,
+      priority: opts?.priority ?? 'foreground',
       ...(opts?.maxReplayBytes ? { maxReplayBytes: opts.maxReplayBytes } : {}),
     })
     rememberSentViewport(tid, cols, rows)
     lastSentViewportRef.current = { terminalId: tid, cols, rows }
-  }, [suppressNetworkEffects, ws, applySeqState, resetStartupProbeParser])
+  }, [suppressNetworkEffects, ws, applySeqState, resetRenderedSurface, resetStartupProbeParser])
 
   const runRefreshAttach = useCallback((request: PaneRefreshRequest | null | undefined) => {
     if (suppressNetworkEffects) return false
@@ -1733,6 +1770,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
         mode: 'waiting_for_geometry',
         pendingIntent: 'viewport_hydrate',
         pendingSinceSeq: 0,
+        pendingReason: 'explicit_refresh',
       }
       setIsAttaching(false)
     } else {
@@ -1784,11 +1822,19 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           hydrationRegisteredRef.current = false
         }
         getHydrationQueue().onActiveTabChanged(tabId, tabOrderRef.current)
-        attachTerminal(tid, deferred.pendingIntent, {
-          clearViewportFirst: deferred.pendingIntent === 'viewport_hydrate',
+        const revealPlan = resolveRevealAttachPlan({
+          pendingIntent: deferred.pendingIntent,
+          pendingReason: deferred.pendingReason,
+          hasTrustedSurface: hasTrustedSurfaceRef.current,
+          renderedSeq: renderedSeqRef.current,
+        })
+        attachTerminal(tid, revealPlan.intent, {
+          clearViewportFirst: revealPlan.clearViewportFirst,
+          priority: revealPlan.priority,
+          ...(typeof revealPlan.sinceSeq === 'number' ? { sinceSeq: revealPlan.sinceSeq } : {}),
           suppressNextMatchingResize: true,
           skipPreAttachFit: true,
-          ...(deferred.pendingIntent === 'viewport_hydrate'
+          ...(revealPlan.intent === 'viewport_hydrate'
             ? viewportHydrateReplayOptions(contentRef.current)
             : undefined),
         })
@@ -1796,7 +1842,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       }
       requestTerminalLayout({ fit: true, resize: true })
     }
-  }, [hidden, isTerminal, requestTerminalLayout, attachTerminal])
+  }, [hidden, isTerminal, paneId, requestTerminalLayout, tabId, attachTerminal])
 
   // Background hydration: triggered by the hydration queue for hidden tabs
   useEffect(() => {
@@ -1804,7 +1850,19 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     setBackgroundHydrationTriggered(false)
     const tid = terminalIdRef.current
     if (!tid || !hiddenRef.current) return
-    attachTerminal(tid, 'viewport_hydrate', { clearViewportFirst: true })
+    if (hasTrustedSurfaceRef.current && renderedSeqRef.current > 0) {
+      attachTerminal(tid, 'keepalive_delta', {
+        clearViewportFirst: false,
+        priority: 'background',
+        sinceSeq: renderedSeqRef.current,
+      })
+      return
+    }
+    attachTerminal(tid, 'viewport_hydrate', {
+      clearViewportFirst: true,
+      priority: 'background',
+      ...viewportHydrateReplayOptions(contentRef.current),
+    })
   }, [backgroundHydrationTriggered, attachTerminal])
 
   // Create or attach to backend terminal
@@ -1924,6 +1982,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
         mode: 'none',
         pendingIntent: null,
         pendingSinceSeq: 0,
+        pendingReason: 'initial_hydrate',
       }
       setIsAttaching(false)
       setTruncatedHistoryGap(null)
@@ -1971,6 +2030,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
         mode: 'none',
         pendingIntent: null,
         pendingSinceSeq: 0,
+        pendingReason: 'initial_hydrate',
       }
       setIsAttaching(true)
       setTruncatedHistoryGap(null)
@@ -2000,6 +2060,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           mode: 'none',
           pendingIntent: null,
           pendingSinceSeq: 0,
+          pendingReason: 'initial_hydrate',
         }
         dispatch(clearPaneRuntimeActivity({ paneId: paneIdRef.current }))
         if (terminalId) {
@@ -2066,6 +2127,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
 
           if (tid && frameDecision.freshReset) {
             clearTerminalCursor(tid)
+            resetRenderedSurface()
           }
           let raw = msg.data || ''
           const mode = contentRef.current?.mode || 'shell'
@@ -2088,7 +2150,19 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             startupProbeStateRef.current = replayDiscard.resumeState
           }
           raw = replayDiscard.raw
-          handleTerminalOutput(raw, mode, tid, !frameOverlapsReplay)
+          const completedAttachOnFrame = !frameDecision.state.pendingReplay
+            && (Boolean(previousSeqState.pendingReplay) || previousSeqState.awaitingFreshSequence)
+          const completeRenderedFrame = () => {
+            markRenderedSeq(tid, frameDecision.state.lastSeq)
+            if (completedAttachOnFrame) {
+              setIsAttaching(false)
+              markAttachComplete()
+            }
+          }
+          handleTerminalOutput(raw, mode, tid, !frameOverlapsReplay, completeRenderedFrame)
+          if (completedAttachOnFrame && frameOverlapsReplay) {
+            resetStartupProbeParser({ discardReplayRemainder: true })
+          }
           if (
             raw.length > 0
             && !terminalFirstOutputMarkedRef.current
@@ -2103,16 +2177,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             })
             terminalFirstOutputMarkedRef.current = true
           }
-          applySeqState(frameDecision.state, { terminalId: tid, persistCursor: true })
-          const completedAttachOnFrame = !frameDecision.state.pendingReplay
-            && (Boolean(previousSeqState.pendingReplay) || previousSeqState.awaitingFreshSequence)
-          if (completedAttachOnFrame) {
-            if (frameOverlapsReplay) {
-              resetStartupProbeParser({ discardReplayRemainder: true })
-            }
-            setIsAttaching(false)
-            markAttachComplete()
-          }
+          applySeqState(frameDecision.state)
         }
 
         if (msg.type === 'terminal.output.gap' && msg.terminalId === tid) {
@@ -2157,7 +2222,8 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           }
           const previousSeqState = seqStateRef.current
           const nextSeqState = onOutputGap(previousSeqState, { fromSeq: msg.fromSeq, toSeq: msg.toSeq })
-          applySeqState(nextSeqState, { terminalId: tid, persistCursor: true })
+          applySeqState(nextSeqState)
+          markRenderedSeq(tid, nextSeqState.lastSeq)
           const completedAttachOnGap = !nextSeqState.pendingReplay
             && (Boolean(previousSeqState.pendingReplay) || previousSeqState.awaitingFreshSequence)
           if (completedAttachOnGap) {
@@ -2206,10 +2272,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             replayFromSeq: msg.replayFromSeq,
             replayToSeq: msg.replayToSeq,
           })
-          applySeqState(nextSeqState, {
-            terminalId: tid,
-            persistCursor: !nextSeqState.pendingReplay,
-          })
+          applySeqState(nextSeqState)
           setIsAttaching(Boolean(nextSeqState.pendingReplay))
           if (!nextSeqState.pendingReplay) {
             markAttachComplete()
@@ -2291,6 +2354,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
               mode: 'waiting_for_geometry',
               pendingIntent: 'viewport_hydrate',
               pendingSinceSeq: 0,
+              pendingReason: 'terminal_created',
             }
             setIsAttaching(false)
           } else {
@@ -2336,6 +2400,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             mode: 'none',
             pendingIntent: null,
             pendingSinceSeq: 0,
+            pendingReason: 'initial_hydrate',
           }
           dispatch(clearPaneRuntimeActivity({ paneId: paneIdRef.current }))
           clearTerminalCursor(tid)
@@ -2535,6 +2600,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
                 mode: 'none',
                 pendingIntent: null,
                 pendingSinceSeq: 0,
+                pendingReason: 'initial_hydrate',
               }
               applySeqState(createAttachSeqState())
               updateContent({
@@ -2575,6 +2641,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
               mode: 'none',
               pendingIntent: null,
               pendingSinceSeq: 0,
+              pendingReason: 'initial_hydrate',
             }
             applySeqState(createAttachSeqState())
             updateContent({
@@ -2602,9 +2669,21 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
         })
         if (!tid) return
         if (hiddenRef.current) {
-          deferredAttachStateRef.current = deferredAttachStateRef.current.mode === 'live'
-            ? { mode: 'waiting_for_geometry', pendingIntent: 'transport_reconnect', pendingSinceSeq: seqStateRef.current.lastSeq }
-            : { mode: 'waiting_for_geometry', pendingIntent: 'viewport_hydrate', pendingSinceSeq: 0 }
+          const canResumeFromRenderedSurface = hasTrustedSurfaceRef.current && renderedSeqRef.current > 0
+          deferredAttachStateRef.current = deferredAttachStateRef.current.mode === 'live' || canResumeFromRenderedSurface
+            ? {
+                mode: 'waiting_for_geometry',
+                pendingIntent: 'transport_reconnect',
+                pendingSinceSeq: renderedSeqRef.current,
+                pendingReason: 'transport_reconnect',
+              }
+            : {
+                mode: 'waiting_for_geometry',
+                pendingIntent: 'viewport_hydrate',
+                pendingSinceSeq: 0,
+                pendingReason: 'hidden_reveal',
+              }
+          registerForBackgroundHydration({ queueIfStarted: canResumeFromRenderedSurface })
           return
         }
         attachTerminal(tid, 'transport_reconnect')
@@ -2634,21 +2713,24 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
 
       if (currentTerminalId) {
         if (hiddenRef.current) {
-          deferredAttachStateRef.current = deferredAttachStateRef.current.mode === 'live'
-            ? { mode: 'waiting_for_geometry', pendingIntent: 'transport_reconnect', pendingSinceSeq: seqStateRef.current.lastSeq }
-            : { mode: 'waiting_for_geometry', pendingIntent: 'viewport_hydrate', pendingSinceSeq: 0 }
+          const canResumeFromRenderedSurface = hasTrustedSurfaceRef.current && renderedSeqRef.current > 0
+          deferredAttachStateRef.current = deferredAttachStateRef.current.mode === 'live' || canResumeFromRenderedSurface
+            ? {
+                mode: 'waiting_for_geometry',
+                pendingIntent: 'transport_reconnect',
+                pendingSinceSeq: renderedSeqRef.current,
+                pendingReason: 'transport_reconnect',
+              }
+            : {
+                mode: 'waiting_for_geometry',
+                pendingIntent: 'viewport_hydrate',
+                pendingSinceSeq: 0,
+                pendingReason: 'hidden_reveal',
+              }
           setIsAttaching(false)
 
           // Register with hydration queue for progressive background hydration
-          if (!hydrationRegisteredRef.current && deferredAttachStateRef.current.pendingIntent === 'viewport_hydrate') {
-            hydrationRegisteredRef.current = true
-            const setBgTriggered = setBackgroundHydrationTriggered
-            getHydrationQueue().register({
-              tabId,
-              paneId: paneIdRef.current,
-              trigger: () => setBgTriggered(true),
-            })
-          }
+          registerForBackgroundHydration()
         } else {
           const intent: AttachIntent = deferredAttachStateRef.current.mode === 'live'
             ? 'keepalive_delta'
@@ -2662,6 +2744,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           mode: 'none',
           pendingIntent: null,
           pendingSinceSeq: 0,
+          pendingReason: 'initial_hydrate',
         }
         sendCreate(createRequestId)
       }
@@ -2705,7 +2788,10 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     dispatch,
     handleTerminalOutput,
     attachTerminal,
+    markRenderedSeq,
     markAttachComplete,
+    registerForBackgroundHydration,
+    resetRenderedSurface,
     resetStartupProbeParser,
     runRefreshAttach,
     syncContentRefWithSessionAssociation,

--- a/src/lib/hydration-queue.ts
+++ b/src/lib/hydration-queue.ts
@@ -9,7 +9,7 @@ type HydrationEntry = {
 
 type HydrationQueue = {
   /** Register a tab that needs background hydration. */
-  register: (entry: HydrationEntry) => void
+  register: (entry: HydrationEntry, options?: { queueIfStarted?: boolean }) => void
   /** Unregister a tab (e.g., on unmount). */
   unregister: (paneId: string) => void
   /** Signal that the active tab's initial hydration is complete. Starts the queue. */
@@ -63,9 +63,13 @@ export function createHydrationQueue(): HydrationQueue {
   }
 
   return {
-    register(entry) {
+    register(entry, options) {
       if (disposed) return
       entries.set(entry.paneId, entry)
+      if (options?.queueIfStarted && started && activePane !== entry.paneId && !queue.includes(entry.paneId)) {
+        queue.push(entry.paneId)
+        advance()
+      }
     },
 
     unregister(paneId) {

--- a/src/lib/terminal-attach-policy.ts
+++ b/src/lib/terminal-attach-policy.ts
@@ -1,0 +1,61 @@
+export type TerminalAttachIntent = 'viewport_hydrate' | 'keepalive_delta' | 'transport_reconnect'
+export type TerminalAttachPriority = 'foreground' | 'background'
+
+export type DeferredAttachReason =
+  | 'hidden_reveal'
+  | 'initial_hydrate'
+  | 'terminal_created'
+  | 'transport_reconnect'
+  | 'explicit_refresh'
+  | 'background_catchup'
+
+export type RevealAttachPolicyInput = {
+  pendingIntent: TerminalAttachIntent
+  pendingReason: DeferredAttachReason
+  hasTrustedSurface: boolean
+  renderedSeq: number
+}
+
+export type RevealAttachPlan = {
+  intent: TerminalAttachIntent
+  clearViewportFirst: boolean
+  priority: TerminalAttachPriority
+  sinceSeq?: number
+}
+
+function normalizeSeq(seq: number): number {
+  if (!Number.isFinite(seq)) return 0
+  return Math.max(0, Math.floor(seq))
+}
+
+export function resolveRevealAttachPlan(input: RevealAttachPolicyInput): RevealAttachPlan {
+  const renderedSeq = normalizeSeq(input.renderedSeq)
+
+  if (input.pendingIntent !== 'viewport_hydrate') {
+    return {
+      intent: input.pendingIntent,
+      clearViewportFirst: false,
+      priority: 'foreground',
+      ...(input.hasTrustedSurface && renderedSeq > 0 ? { sinceSeq: renderedSeq } : {}),
+    }
+  }
+
+  if (
+    input.pendingReason !== 'explicit_refresh'
+    && input.hasTrustedSurface
+    && renderedSeq > 0
+  ) {
+    return {
+      intent: 'transport_reconnect',
+      clearViewportFirst: false,
+      priority: 'foreground',
+      sinceSeq: renderedSeq,
+    }
+  }
+
+  return {
+    intent: 'viewport_hydrate',
+    clearViewportFirst: true,
+    priority: 'foreground',
+  }
+}

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -15,6 +15,7 @@ import { flushPersistedLayoutNow } from '@/store/persistControl'
 import { useAppSelector } from '@/store/hooks'
 import type { PaneNode, TerminalPaneContent } from '@/store/paneTypes'
 import { __resetTerminalCursorCacheForTests } from '@/lib/terminal-cursor'
+import { resetHydrationQueueForTests } from '@/lib/hydration-queue'
 import { createPerfAuditBridge, installPerfAuditBridge } from '@/lib/perf-audit-bridge'
 import { TERMINAL_CURSOR_STORAGE_KEY } from '@/store/storage-keys'
 import {
@@ -80,7 +81,9 @@ vi.mock('@xterm/xterm', () => {
     open = vi.fn()
     loadAddon = vi.fn()
     registerLinkProvider = vi.fn(() => ({ dispose: vi.fn() }))
-    write = vi.fn()
+    write = vi.fn((_data: string, onWritten?: () => void) => {
+      onWritten?.()
+    })
     writeln = vi.fn()
     clear = vi.fn()
     dispose = vi.fn()
@@ -245,6 +248,7 @@ describe('TerminalView lifecycle updates', () => {
     clearLocalStorageForTest()
     __resetTerminalCursorCacheForTests()
     __resetLastSentViewportCacheForTests()
+    resetHydrationQueueForTests()
     resetPersistedLayoutCacheForTests()
     resetPersistFlushListenersForTests()
     latestAttachRequestIdByTerminal.clear()
@@ -289,6 +293,7 @@ describe('TerminalView lifecycle updates', () => {
     vi.unstubAllGlobals()
     clearLocalStorageForTest()
     __resetTerminalCursorCacheForTests()
+    resetHydrationQueueForTests()
     delete window.__FRESHELL_TEST_HARNESS__
     requestAnimationFrameSpy?.mockRestore()
     cancelAnimationFrameSpy?.mockRestore()
@@ -4083,7 +4088,7 @@ describe('TerminalView lifecycle updates', () => {
       }))
     })
 
-    it('keeps reconnect attach on high-water cursor when reconnect fires during remount hydration', async () => {
+    it('keeps reconnect attach at zero during remount hydration until a rendered surface is trusted', async () => {
       setLocalStorageItemForTest(TERMINAL_CURSOR_STORAGE_KEY, JSON.stringify({
         'term-v2-reconnect-during-hydration': {
           seq: 11,
@@ -4121,12 +4126,12 @@ describe('TerminalView lifecycle updates', () => {
       expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
         type: 'terminal.attach',
         terminalId,
-        sinceSeq: 11,
+        sinceSeq: 0,
         attachRequestId: expect.any(String),
       }))
     })
 
-    it('keeps viewport replay output when reconnect attach starts before the viewport replay arrives', async () => {
+    it('does not trust persisted high-water when reconnect starts before viewport replay renders', async () => {
       setLocalStorageItemForTest(TERMINAL_CURSOR_STORAGE_KEY, JSON.stringify({
         'term-v2-overlapping-attach-ready': {
           seq: 12,
@@ -4146,9 +4151,10 @@ describe('TerminalView lifecycle updates', () => {
       expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
         type: 'terminal.attach',
         terminalId,
-        sinceSeq: 12,
+        sinceSeq: 0,
         attachRequestId: expect.any(String),
       }))
+      const reconnectAttachRequestId = latestAttachRequestIdForTerminal(terminalId)
 
       act(() => {
         messageHandler!({
@@ -4157,6 +4163,7 @@ describe('TerminalView lifecycle updates', () => {
           headSeq: 12,
           replayFromSeq: 1,
           replayToSeq: 12,
+          attachRequestId: reconnectAttachRequestId,
         })
         messageHandler!({
           type: 'terminal.output',
@@ -4164,6 +4171,7 @@ describe('TerminalView lifecycle updates', () => {
           seqStart: 1,
           seqEnd: 1,
           data: 'history-1',
+          attachRequestId: reconnectAttachRequestId,
         })
         messageHandler!({
           type: 'terminal.output',
@@ -4171,6 +4179,7 @@ describe('TerminalView lifecycle updates', () => {
           seqStart: 6,
           seqEnd: 6,
           data: 'history-6',
+          attachRequestId: reconnectAttachRequestId,
         })
         messageHandler!({
           type: 'terminal.output',
@@ -4178,6 +4187,7 @@ describe('TerminalView lifecycle updates', () => {
           seqStart: 12,
           seqEnd: 12,
           data: 'history-12',
+          attachRequestId: reconnectAttachRequestId,
         })
       })
 
@@ -4187,7 +4197,7 @@ describe('TerminalView lifecycle updates', () => {
       expect(writes).toContain('history-12')
     })
 
-    it('preserves persisted high-water when a hydration replay starts at sequence 1', async () => {
+    it('uses rendered replay high-water when persisted cursor is ahead of a fresh hydrate', async () => {
       setLocalStorageItemForTest(TERMINAL_CURSOR_STORAGE_KEY, JSON.stringify({
         'term-v2-seq-reset': {
           seq: 12,
@@ -4207,7 +4217,7 @@ describe('TerminalView lifecycle updates', () => {
       expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
         type: 'terminal.attach',
         terminalId,
-        sinceSeq: 12,
+        sinceSeq: 3,
         attachRequestId: expect.any(String),
       }))
     })
@@ -4280,7 +4290,7 @@ describe('TerminalView lifecycle updates', () => {
       expect(attach).not.toHaveProperty('maxReplayBytes')
     })
 
-    it('revealing a hidden running pane sends a viewport attach with sinceSeq=0', async () => {
+    it('revealing an untrusted hidden running pane sends a viewport attach with sinceSeq=0', async () => {
       const { store, tabId, paneId, terminalId, rerender } = await renderTerminalHarness({
         status: 'running',
         terminalId: 'term-bootstrap-gap',
@@ -4305,6 +4315,129 @@ describe('TerminalView lifecycle updates', () => {
       })
       expect(attach?.sinceSeq).toBe(0)
       expect(attach?.attachRequestId).toBeTruthy()
+    })
+
+    it('revealing a trusted hidden running pane reconnects from rendered high-water without clearing', async () => {
+      const { store, tabId, paneId, terminalId, rerender, term } = await renderTerminalHarness({
+        status: 'running',
+        terminalId: 'term-warm-reveal-rendered',
+        clearSends: false,
+      })
+
+      const initialAttachRequestId = latestAttachRequestIdForTerminal(terminalId)
+      expect(initialAttachRequestId).toBeTruthy()
+
+      act(() => {
+        messageHandler!({
+          type: 'terminal.attach.ready',
+          terminalId,
+          headSeq: 0,
+          replayFromSeq: 1,
+          replayToSeq: 0,
+          attachRequestId: initialAttachRequestId,
+        })
+        messageHandler!({
+          type: 'terminal.output',
+          terminalId,
+          seqStart: 1,
+          seqEnd: 3,
+          data: 'rendered-before-hide',
+          attachRequestId: initialAttachRequestId,
+        })
+      })
+
+      expect(term.write.mock.calls.map(([data]: [string]) => data).join('')).toContain('rendered-before-hide')
+      wsMocks.send.mockClear()
+      term.clear.mockClear()
+
+      const readPaneContent = () => {
+        const layout = store.getState().panes.layouts[tabId]
+        return layout && layout.type === 'leaf' && layout.content.kind === 'terminal' ? layout.content : null
+      }
+      const renderVisibility = (isHidden: boolean) => (
+        <Provider store={store}>
+          <TerminalView tabId={tabId} paneId={paneId} paneContent={readPaneContent()!} hidden={isHidden} />
+        </Provider>
+      )
+
+      rerender(
+        renderVisibility(true),
+      )
+      reconnectHandler?.()
+
+      rerender(
+        renderVisibility(false),
+      )
+
+      await waitFor(() => {
+        expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+          type: 'terminal.attach',
+          terminalId,
+          intent: 'transport_reconnect',
+          sinceSeq: 3,
+          priority: 'foreground',
+          attachRequestId: expect.any(String),
+        }))
+      })
+      expect(term.clear).not.toHaveBeenCalled()
+    })
+
+    it('background hydrates a trusted hidden reconnect from rendered high-water with background priority', async () => {
+      const { store, tabId, paneId, terminalId, rerender, term } = await renderTerminalHarness({
+        status: 'running',
+        terminalId: 'term-background-rendered',
+        clearSends: false,
+      })
+
+      const initialAttachRequestId = latestAttachRequestIdForTerminal(terminalId)
+      expect(initialAttachRequestId).toBeTruthy()
+
+      act(() => {
+        messageHandler!({
+          type: 'terminal.attach.ready',
+          terminalId,
+          headSeq: 0,
+          replayFromSeq: 1,
+          replayToSeq: 0,
+          attachRequestId: initialAttachRequestId,
+        })
+        messageHandler!({
+          type: 'terminal.output',
+          terminalId,
+          seqStart: 1,
+          seqEnd: 3,
+          data: 'rendered-before-background',
+          attachRequestId: initialAttachRequestId,
+        })
+      })
+
+      expect(term.write.mock.calls.map(([data]: [string]) => data).join('')).toContain('rendered-before-background')
+      wsMocks.send.mockClear()
+
+      const readPaneContent = () => {
+        const layout = store.getState().panes.layouts[tabId]
+        return layout && layout.type === 'leaf' && layout.content.kind === 'terminal' ? layout.content : null
+      }
+      rerender(
+        <Provider store={store}>
+          <TerminalView tabId={tabId} paneId={paneId} paneContent={readPaneContent()!} hidden />
+        </Provider>,
+      )
+
+      act(() => {
+        reconnectHandler?.()
+      })
+
+      await waitFor(() => {
+        expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+          type: 'terminal.attach',
+          terminalId,
+          intent: 'keepalive_delta',
+          sinceSeq: 3,
+          priority: 'background',
+          attachRequestId: expect.any(String),
+        }))
+      })
     })
 
     it('recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output', async () => {
@@ -4735,7 +4868,7 @@ describe('TerminalView lifecycle updates', () => {
       expect(writes).toContain('LIVE')
     })
 
-    it('updates attach sequence from terminal.attach.ready after terminal.created (broker no-replay sentinel)', async () => {
+    it('does not trust terminal.attach.ready head sequence until output renders', async () => {
       const { requestId, term } = await renderTerminalHarness({ status: 'creating' })
 
       act(() => {
@@ -4767,7 +4900,7 @@ describe('TerminalView lifecycle updates', () => {
       expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
         type: 'terminal.attach',
         terminalId: 'term-v2-created',
-        sinceSeq: 7,
+        sinceSeq: 0,
         attachRequestId: expect.any(String),
       }))
     })

--- a/test/unit/client/lib/terminal-attach-policy.test.ts
+++ b/test/unit/client/lib/terminal-attach-policy.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { resolveRevealAttachPlan } from '@/lib/terminal-attach-policy'
+
+describe('terminal attach policy', () => {
+  it('promotes viewport hydrate to delta reconnect from a trusted rendered high-water mark', () => {
+    expect(resolveRevealAttachPlan({
+      pendingIntent: 'viewport_hydrate',
+      pendingReason: 'hidden_reveal',
+      hasTrustedSurface: true,
+      renderedSeq: 41,
+    })).toEqual({
+      intent: 'transport_reconnect',
+      clearViewportFirst: false,
+      priority: 'foreground',
+      sinceSeq: 41,
+    })
+  })
+
+  it('keeps full viewport hydrate when the mounted surface is not trusted', () => {
+    expect(resolveRevealAttachPlan({
+      pendingIntent: 'viewport_hydrate',
+      pendingReason: 'hidden_reveal',
+      hasTrustedSurface: false,
+      renderedSeq: 41,
+    })).toEqual({
+      intent: 'viewport_hydrate',
+      clearViewportFirst: true,
+      priority: 'foreground',
+    })
+  })
+
+  it('keeps full viewport hydrate for explicit user pane refresh', () => {
+    expect(resolveRevealAttachPlan({
+      pendingIntent: 'viewport_hydrate',
+      pendingReason: 'explicit_refresh',
+      hasTrustedSurface: true,
+      renderedSeq: 41,
+    })).toEqual({
+      intent: 'viewport_hydrate',
+      clearViewportFirst: true,
+      priority: 'foreground',
+    })
+  })
+
+  it('preserves transport reconnect intent and uses rendered high-water as sinceSeq', () => {
+    expect(resolveRevealAttachPlan({
+      pendingIntent: 'transport_reconnect',
+      pendingReason: 'transport_reconnect',
+      hasTrustedSurface: true,
+      renderedSeq: 41,
+    })).toEqual({
+      intent: 'transport_reconnect',
+      clearViewportFirst: false,
+      priority: 'foreground',
+      sinceSeq: 41,
+    })
+  })
+})

--- a/test/unit/server/terminal-stream/replay-ring.test.ts
+++ b/test/unit/server/terminal-stream/replay-ring.test.ts
@@ -53,6 +53,21 @@ describe('ReplayRing', () => {
     expect(replay.frames[1].seqEnd).toBe(3)
   })
 
+  it('returns bounded replay batches without materializing the full replay window', () => {
+    const ring = new ReplayRing(1024)
+    ring.append('aa')
+    ring.append('bb')
+    ring.append('cc')
+    ring.append('dd')
+
+    const firstBatch = ring.replayBatchSince(0, 4, 4)
+    expect(firstBatch.frames.map((f) => f.data)).toEqual(['aa', 'bb'])
+    expect(firstBatch.missedFromSeq).toBeUndefined()
+
+    const secondBatch = ring.replayBatchSince(firstBatch.frames.at(-1)?.seqEnd, 4, 4)
+    expect(secondBatch.frames.map((f) => f.data)).toEqual(['cc', 'dd'])
+  })
+
   it('reports replay miss when requested sequence is older than tail', () => {
     const ring = new ReplayRing(2)
     ring.append('1')

--- a/test/unit/server/ws-handler-backpressure.test.ts
+++ b/test/unit/server/ws-handler-backpressure.test.ts
@@ -426,6 +426,157 @@ describe('TerminalStreamBroker catastrophic bufferedAmount handling', () => {
     broker.close()
   })
 
+  it('streams attach replay through the flush queue instead of synchronously dumping every replay frame', async () => {
+    const registry = new FakeBrokerRegistry()
+    const broker = new TerminalStreamBroker(registry as any, vi.fn())
+    registry.createTerminal('term-replay-batched')
+
+    const wsSeed = createMockWs()
+    await broker.attach(wsSeed as any, 'term-replay-batched', 'viewport_hydrate', 80, 24, 0, 'seed-attach')
+
+    for (let i = 1; i <= 20; i += 1) {
+      registry.emit('terminal.output.raw', {
+        terminalId: 'term-replay-batched',
+        data: `frame-${i};`,
+        at: Date.now(),
+      })
+    }
+
+    const wsReplay = createMockWs()
+    await broker.attach(wsReplay as any, 'term-replay-batched', 'transport_reconnect', 80, 24, 0, 'replay-attach')
+
+    const outputsBeforeFlush = wsReplay.send.mock.calls
+      .map(([raw]) => (typeof raw === 'string' ? JSON.parse(raw) : raw))
+      .filter((payload) => payload?.type === 'terminal.output')
+    expect(outputsBeforeFlush).toHaveLength(0)
+
+    vi.advanceTimersByTime(5)
+
+    const outputsAfterFlush = wsReplay.send.mock.calls
+      .map(([raw]) => (typeof raw === 'string' ? JSON.parse(raw) : raw))
+      .filter((payload) => payload?.type === 'terminal.output')
+    expect(outputsAfterFlush.length).toBeGreaterThan(0)
+    expect(outputsAfterFlush.map((payload) => String(payload.data)).join('')).toContain('frame-20;')
+
+    broker.close()
+  })
+
+  it('drains foreground replay batches without the background pacing delay', async () => {
+    const registry = new FakeBrokerRegistry()
+    const broker = new TerminalStreamBroker(registry as any, vi.fn())
+    registry.createTerminal('term-foreground-replay')
+
+    const wsSeed = createMockWs()
+    await broker.attach(wsSeed as any, 'term-foreground-replay', 'viewport_hydrate', 80, 24, 0, 'seed-attach')
+
+    const chunk = 'x'.repeat(Math.floor(MAX_REALTIME_MESSAGE_BYTES / 2))
+    for (let i = 1; i <= 4; i += 1) {
+      registry.emit('terminal.output.raw', {
+        terminalId: 'term-foreground-replay',
+        data: `foreground-frame-${i};${chunk}`,
+        at: Date.now(),
+      })
+    }
+
+    const wsReplay = createMockWs()
+    await broker.attach(wsReplay as any, 'term-foreground-replay', 'transport_reconnect', 80, 24, 0, 'foreground-attach')
+    for (let i = 0; i < 4; i += 1) {
+      vi.advanceTimersByTime(1)
+    }
+
+    const outputs = wsReplay.send.mock.calls
+      .map(([raw]) => (typeof raw === 'string' ? JSON.parse(raw) : raw))
+      .filter((payload) => payload?.type === 'terminal.output')
+    expect(outputs.map((payload) => String(payload.data)).join('')).toContain('foreground-frame-4;')
+
+    broker.close()
+  })
+
+  it('pauses background replay when socket bufferedAmount is above the background threshold without closing', async () => {
+    const registry = new FakeBrokerRegistry()
+    const broker = new TerminalStreamBroker(registry as any, vi.fn())
+    registry.createTerminal('term-background-paused')
+
+    const wsSeed = createMockWs()
+    await broker.attach(wsSeed as any, 'term-background-paused', 'viewport_hydrate', 80, 24, 0, 'seed-attach')
+    for (let i = 1; i <= 10; i += 1) {
+      registry.emit('terminal.output.raw', {
+        terminalId: 'term-background-paused',
+        data: `hidden-frame-${i};`,
+        at: Date.now(),
+      })
+    }
+
+    const wsReplay = createMockWs({ bufferedAmount: 768 * 1024 })
+    const closeSpy = vi.spyOn(wsReplay, 'close')
+    await broker.attach(
+      wsReplay as any,
+      'term-background-paused',
+      'keepalive_delta',
+      80,
+      24,
+      0,
+      'background-attach',
+      undefined,
+      'background',
+    )
+
+    vi.advanceTimersByTime(100)
+
+    const outputsWhileBlocked = wsReplay.send.mock.calls
+      .map(([raw]) => (typeof raw === 'string' ? JSON.parse(raw) : raw))
+      .filter((payload) => payload?.type === 'terminal.output')
+    expect(outputsWhileBlocked).toHaveLength(0)
+    expect(closeSpy).not.toHaveBeenCalled()
+
+    wsReplay.bufferedAmount = 0
+    vi.advanceTimersByTime(100)
+
+    const outputsAfterDrain = wsReplay.send.mock.calls
+      .map(([raw]) => (typeof raw === 'string' ? JSON.parse(raw) : raw))
+      .filter((payload) => payload?.type === 'terminal.output')
+    expect(outputsAfterDrain.length).toBeGreaterThan(0)
+    expect(outputsAfterDrain.map((payload) => String(payload.data)).join('')).toContain('hidden-frame-10;')
+    expect(closeSpy).not.toHaveBeenCalled()
+
+    broker.close()
+  })
+
+  it('foreground attach on the same terminal can drain after a paused background attach', async () => {
+    const registry = new FakeBrokerRegistry()
+    const broker = new TerminalStreamBroker(registry as any, vi.fn())
+    registry.createTerminal('term-promoted')
+
+    const wsSeed = createMockWs()
+    await broker.attach(wsSeed as any, 'term-promoted', 'viewport_hydrate', 80, 24, 0, 'seed-attach')
+    for (let i = 1; i <= 12; i += 1) {
+      registry.emit('terminal.output.raw', {
+        terminalId: 'term-promoted',
+        data: `promoted-frame-${i};`,
+        at: Date.now(),
+      })
+    }
+
+    const ws = createMockWs({ bufferedAmount: 768 * 1024 })
+    await broker.attach(ws as any, 'term-promoted', 'keepalive_delta', 80, 24, 0, 'background-attach', undefined, 'background')
+    vi.advanceTimersByTime(100)
+    expect(ws.send.mock.calls
+      .map(([raw]) => (typeof raw === 'string' ? JSON.parse(raw) : raw))
+      .filter((payload) => payload?.type === 'terminal.output')).toHaveLength(0)
+
+    await broker.attach(ws as any, 'term-promoted', 'transport_reconnect', 80, 24, 0, 'foreground-attach', undefined, 'foreground')
+    vi.advanceTimersByTime(5)
+
+    const outputs = ws.send.mock.calls
+      .map(([raw]) => (typeof raw === 'string' ? JSON.parse(raw) : raw))
+      .filter((payload) => payload?.type === 'terminal.output')
+    expect(outputs.length).toBeGreaterThan(0)
+    expect(outputs.every((payload) => payload.attachRequestId === 'foreground-attach')).toBe(true)
+    expect(outputs.map((payload) => String(payload.data)).join('')).toContain('promoted-frame-12;')
+
+    broker.close()
+  })
+
   it('emits terminal_stream_replay_hit, terminal_stream_queue_pressure, and terminal_stream_gap on overflow', async () => {
     const registry = new FakeBrokerRegistry()
     const perfSpy = vi.fn()
@@ -491,6 +642,7 @@ describe('TerminalStreamBroker catastrophic bufferedAmount handling', () => {
 
     const wsReplay = createMockWs()
     await broker.attach(wsReplay as any, 'term-replay-budget', 'viewport_hydrate', 80, 24, 0)
+    vi.advanceTimersByTime(5)
 
     const payloads = wsReplay.send.mock.calls
       .map(([raw]) => (typeof raw === 'string' ? JSON.parse(raw) : raw))
@@ -522,6 +674,7 @@ describe('TerminalStreamBroker catastrophic bufferedAmount handling', () => {
 
     const wsReplay = createMockWs()
     await broker.attach(wsReplay as any, 'term-coding-floor', 'viewport_hydrate', 80, 24, 0)
+    vi.advanceTimersByTime(5)
 
     const payloads = wsReplay.send.mock.calls
       .map(([raw]) => (typeof raw === 'string' ? JSON.parse(raw) : raw))
@@ -553,6 +706,7 @@ describe('TerminalStreamBroker catastrophic bufferedAmount handling', () => {
 
     const wsReplay = createMockWs()
     await broker.attach(wsReplay as any, 'term-oversized-tail', 'viewport_hydrate', 80, 24, 0)
+    vi.advanceTimersByTime(5)
 
     const payloads = wsReplay.send.mock.calls
       .map(([raw]) => (typeof raw === 'string' ? JSON.parse(raw) : raw))


### PR DESCRIPTION
## Summary
- track terminal replay from the highest sequence actually rendered by xterm, so warm tab reveals can reconnect from the visible screen without clear-and-replay flash
- stream attach replay through a broker replay cursor with foreground/background priority and background bufferedAmount pausing
- add focused lifecycle, attach-policy, replay-ring, and backpressure coverage plus the plan doc

## Verification
- npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run
- npm run test:vitest -- test/unit/client/lib/terminal-attach-policy.test.ts --run
- npm run test:vitest -- test/unit/server/terminal-stream/replay-ring.test.ts --run
- npm run test:vitest -- test/unit/server/ws-handler-backpressure.test.ts --run
- npm run test:vitest -- test/e2e/terminal-create-attach-ordering.test.tsx --run
- npm run test:vitest -- test/e2e/terminal-settings-remount-scrollback.test.tsx --run
- npm run test:vitest -- test/e2e/codex-refresh-rehydrate-flow.test.tsx --run
- npm run typecheck
- npm run build
- git diff --check origin/main...HEAD

## Known Existing Issues
- npm run lint still fails on pre-existing src/components/fresh-agent/FreshAgentSettingsButton.tsx:87 a11y error plus existing warnings
- broad npm run check baseline was already red with unrelated Sidebar/PaneContainer failures

## Review
- ran 3 independent Fresh Eyes passes; all passed after minor fixes from pass 1 and pass 2
