### PR TITLE
feat: add fresh agent pane clients

### DIFF
--- a/server/fresh-agent-extras-router.ts
+++ b/server/fresh-agent-extras-router.ts
@@ -1,0 +1,331 @@
+import { Router, json, raw } from 'express'
+import { execFile } from 'node:child_process'
+import { createHash, randomUUID } from 'node:crypto'
+import * as fsp from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { FreshAgentRuntimeProviderSchema, FreshAgentSessionTypeSchema } from '../shared/fresh-agent-contract.js'
+import type { FreshAgentCreateRequest, FreshAgentSessionLocator } from './fresh-agent/runtime-adapter.js'
+
+const ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024
+const EXEC_TIMEOUT_MS = 30_000
+const EXEC_MAX_OUTPUT = 200 * 1024
+const DIFF_MAX_BYTES = 512 * 1024
+
+function sanitizeFilename(name: string): string {
+  const base = path.basename(name).replace(/[^a-zA-Z0-9._-]/g, '_')
+  return base || 'attachment'
+}
+
+function attachmentsDir(): string {
+  return path.join(os.homedir(), '.freshell', 'attachments')
+}
+
+type ExecResult = { output: string; exitCode: number | null; truncated: boolean }
+
+function runCommand(command: string, cwd: string): Promise<ExecResult> {
+  return new Promise((resolve) => {
+    execFile('bash', ['-lc', command], {
+      cwd,
+      timeout: EXEC_TIMEOUT_MS,
+      maxBuffer: EXEC_MAX_OUTPUT,
+      env: process.env,
+    }, (error, stdout, stderr) => {
+      const combined = `${stdout ?? ''}${stderr ? `\n${stderr}` : ''}`.trim()
+      const truncated = combined.length >= EXEC_MAX_OUTPUT
+      const exitCode = error && typeof (error as NodeJS.ErrnoException & { code?: unknown }).code === 'number'
+        ? (error as unknown as { code: number }).code
+        : error ? 1 : 0
+      resolve({
+        output: truncated ? `${combined.slice(0, EXEC_MAX_OUTPUT)}\n[output truncated]` : combined,
+        exitCode,
+        truncated,
+      })
+    })
+  })
+}
+
+function runGitDiff(cwd: string, filePath?: string): Promise<{ diff: string }> {
+  return new Promise((resolve, reject) => {
+    const args = ['diff', '--no-color']
+    if (filePath) args.push('--', filePath)
+    execFile('git', args, { cwd, maxBuffer: DIFF_MAX_BYTES, timeout: 15_000 }, (error, stdout) => {
+      if (error && !stdout) {
+        reject(new Error(`git diff failed: ${error.message}`))
+        return
+      }
+      resolve({ diff: stdout })
+    })
+  })
+}
+
+/* ------------------------------------------------------------------------ *
+ * Checkpoints: per-cwd shadow git repository under ~/.freshell/checkpoints.
+ * The session cwd's own git state is never touched — snapshots live in a
+ * separate --git-dir and use the cwd only as --work-tree. The work-tree's
+ * .gitignore applies, so node_modules and friends stay out of snapshots.
+ * Restore overwrites tracked files to the snapshot state; files created
+ * after the snapshot are left in place (v1 semantics, documented in WORK.md).
+ * ------------------------------------------------------------------------ */
+
+const CHECKPOINT_GIT_TIMEOUT_MS = 60_000
+const CHECKPOINT_LIST_LIMIT = 100
+const CHECKPOINT_IDENTITY = ['-c', 'user.name=freshell', '-c', 'user.email=checkpoints@freshell.local']
+
+function checkpointGitDir(cwd: string): string {
+  const digest = createHash('sha1').update(path.resolve(cwd)).digest('hex').slice(0, 16)
+  return path.join(os.homedir(), '.freshell', 'checkpoints', `${digest}.git`)
+}
+
+function runGit(args: string[], options: { cwd?: string } = {}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('git', args, {
+      cwd: options.cwd ?? os.homedir(),
+      timeout: CHECKPOINT_GIT_TIMEOUT_MS,
+      maxBuffer: 4 * 1024 * 1024,
+    }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`git ${args[0] ?? ''} failed: ${stderr || error.message}`))
+        return
+      }
+      resolve(stdout)
+    })
+  })
+}
+
+async function ensureCheckpointRepo(cwd: string): Promise<string> {
+  const gitDir = checkpointGitDir(cwd)
+  try {
+    await fsp.access(path.join(gitDir, 'HEAD'))
+  } catch {
+    await fsp.mkdir(gitDir, { recursive: true })
+    await runGit(['init', '--bare', '-q', gitDir])
+  }
+  return gitDir
+}
+
+export type CheckpointEntry = { id: string; ts: number; label: string }
+
+async function createCheckpoint(cwd: string, label: string): Promise<CheckpointEntry> {
+  const gitDir = await ensureCheckpointRepo(cwd)
+  const base = [`--git-dir=${gitDir}`, `--work-tree=${cwd}`]
+  await runGit([...base, 'add', '-A'], { cwd })
+  await runGit([...base, ...CHECKPOINT_IDENTITY, 'commit', '--allow-empty', '-q', '-m', label], { cwd })
+  const sha = (await runGit([`--git-dir=${gitDir}`, 'rev-parse', 'HEAD'])).trim()
+  return { id: sha, ts: Math.floor(Date.now() / 1000), label }
+}
+
+async function listCheckpoints(cwd: string): Promise<CheckpointEntry[]> {
+  const gitDir = checkpointGitDir(cwd)
+  try {
+    await fsp.access(path.join(gitDir, 'HEAD'))
+  } catch {
+    return []
+  }
+  let raw: string
+  try {
+    raw = await runGit([
+      `--git-dir=${gitDir}`,
+      'log',
+      `-n`, String(CHECKPOINT_LIST_LIMIT),
+      '--pretty=format:%H%x09%ct%x09%s',
+    ])
+  } catch {
+    // Empty repo (no commits yet).
+    return []
+  }
+  return raw
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const [id, ts, ...rest] = line.split('\t')
+      return { id, ts: Number(ts), label: rest.join('\t') }
+    })
+}
+
+async function restoreCheckpoint(cwd: string, id: string): Promise<void> {
+  if (!/^[0-9a-f]{7,40}$/i.test(id)) {
+    throw new Error('invalid checkpoint id')
+  }
+  const gitDir = await ensureCheckpointRepo(cwd)
+  await runGit([`--git-dir=${gitDir}`, `--work-tree=${cwd}`, 'checkout', '-q', id, '--', '.'], { cwd })
+}
+
+/**
+ * Pane-scoped helper endpoints for the fresh* clients. Auth is provided by the
+ * global httpAuthMiddleware mounted ahead of all /api routes in server/index.ts.
+ *
+ * - POST /attachments?name=    (raw octet-stream)  -> {path}   (saved under ~/.freshell/attachments)
+ * - POST /exec                 {command, cwd}      -> {output, exitCode, truncated}
+ * - GET  /diff?cwd=&path=                          -> {diff}   (git diff for the session cwd)
+ * - POST /checkpoints          {cwd, label}        -> {id, ts, label}
+ * - GET  /checkpoints?cwd=                         -> {checkpoints: CheckpointEntry[]}
+ * - POST /checkpoints/restore  {cwd, id}           -> {restored: true}
+ *
+ * Attachments are raw binary (Content-Type: application/octet-stream) rather
+ * than base64-in-JSON: server/index.ts mounts a global express.json with a
+ * 1mb limit ahead of all /api routes, which would reject larger JSON bodies
+ * before this router's own parser ran. Raw bodies bypass JSON parsing by
+ * content-type, avoid the 1.37x base64 inflation, and are size-capped here.
+ */
+/** Structural slice of FreshAgentRuntimeManager — keeps this router
+ * standalone-testable with a fake and avoids a hard import cycle. */
+export type FreshAgentSendCapable = {
+  send?: (locator: FreshAgentSessionLocator, payload: { text: string; settings?: FreshAgentCreateRequest }) => Promise<unknown>
+}
+
+function parseSendLocator(body: unknown): FreshAgentSessionLocator | null {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return null
+  }
+  const input = body as Record<string, unknown>
+  const sessionId = typeof input.sessionId === 'string' ? input.sessionId : ''
+  const sessionType = FreshAgentSessionTypeSchema.safeParse(input.sessionType)
+  const provider = FreshAgentRuntimeProviderSchema.safeParse(input.provider)
+  if (!sessionId || !sessionType.success || !provider.success) {
+    return null
+  }
+  return { sessionId, sessionType: sessionType.data, provider: provider.data }
+}
+
+export function createFreshAgentExtrasRouter(
+  deps: { freshAgentRuntimeManager?: FreshAgentSendCapable } = {},
+): Router {
+  const router = Router()
+  // Small JSON bodies only (exec/checkpoints); mirrors the global 1mb cap so
+  // the standalone test app exercises the same constraint as production.
+  router.use(json({ limit: '1mb' }))
+
+  router.post(
+    '/attachments',
+    raw({ type: 'application/octet-stream', limit: ATTACHMENT_MAX_BYTES }),
+    async (req, res) => {
+      const name = typeof req.query.name === 'string' ? req.query.name : ''
+      if (!name) {
+        return res.status(400).json({ error: 'name query parameter required' })
+      }
+      const buffer = Buffer.isBuffer(req.body) ? req.body : null
+      if (!buffer || buffer.byteLength === 0) {
+        return res.status(400).json({ error: 'attachment body must be a non-empty application/octet-stream' })
+      }
+      const dir = attachmentsDir()
+      await fsp.mkdir(dir, { recursive: true })
+      const filename = `${randomUUID().slice(0, 8)}-${sanitizeFilename(name)}`
+      const target = path.join(dir, filename)
+      await fsp.writeFile(target, buffer)
+      res.json({ path: target, bytes: buffer.byteLength })
+    },
+  )
+
+  router.post('/exec', async (req, res) => {
+    const command = typeof req.body?.command === 'string' ? req.body.command.trim() : ''
+    const cwd = typeof req.body?.cwd === 'string' && req.body.cwd ? req.body.cwd : os.homedir()
+    if (!command) {
+      return res.status(400).json({ error: 'command is required' })
+    }
+    try {
+      await fsp.access(cwd)
+    } catch {
+      return res.status(400).json({ error: `cwd does not exist: ${cwd}` })
+    }
+    const result = await runCommand(command, cwd)
+    res.json(result)
+  })
+
+  router.get('/diff', async (req, res) => {
+    const cwd = typeof req.query.cwd === 'string' ? req.query.cwd : ''
+    const filePath = typeof req.query.path === 'string' && req.query.path ? req.query.path : undefined
+    if (!cwd) {
+      return res.status(400).json({ error: 'cwd query parameter required' })
+    }
+    try {
+      await fsp.access(cwd)
+    } catch {
+      return res.status(400).json({ error: `cwd does not exist: ${cwd}` })
+    }
+    try {
+      const result = await runGitDiff(cwd, filePath)
+      res.json(result)
+    } catch (error) {
+      res.status(500).json({ error: error instanceof Error ? error.message : 'diff failed' })
+    }
+  })
+
+  // Programmatic prompt injection for automation/testing (MCP `fresh-send`
+  // routes here). Same entrypoint the WS handler uses: runtimeManager.send.
+  router.post('/send', async (req, res) => {
+    const manager = deps.freshAgentRuntimeManager
+    if (!manager?.send) {
+      return res.status(503).json({ error: 'fresh-agent runtime not available on this server' })
+    }
+    const locator = parseSendLocator(req.body)
+    const text = typeof req.body?.text === 'string' ? req.body.text : ''
+    if (!locator || !text) {
+      return res.status(400).json({ error: 'sessionId, sessionType, provider, and text are required' })
+    }
+    const settings = req.body?.settings && typeof req.body.settings === 'object' && !Array.isArray(req.body.settings)
+      ? req.body.settings as FreshAgentCreateRequest
+      : undefined
+    try {
+      await manager.send(locator, { text, ...(settings ? { settings } : {}) })
+      res.json({ sent: true })
+    } catch (error) {
+      res.status(500).json({ error: error instanceof Error ? error.message : 'send failed' })
+    }
+  })
+
+  router.post('/checkpoints', async (req, res) => {
+    const cwd = typeof req.body?.cwd === 'string' ? req.body.cwd : ''
+    const label = typeof req.body?.label === 'string' && req.body.label.trim()
+      ? req.body.label.trim().slice(0, 120)
+      : 'checkpoint'
+    if (!cwd) {
+      return res.status(400).json({ error: 'cwd is required' })
+    }
+    try {
+      await fsp.access(cwd)
+    } catch {
+      return res.status(400).json({ error: `cwd does not exist: ${cwd}` })
+    }
+    try {
+      const entry = await createCheckpoint(cwd, label)
+      res.json(entry)
+    } catch (error) {
+      res.status(500).json({ error: error instanceof Error ? error.message : 'checkpoint failed' })
+    }
+  })
+
+  router.get('/checkpoints', async (req, res) => {
+    const cwd = typeof req.query.cwd === 'string' ? req.query.cwd : ''
+    if (!cwd) {
+      return res.status(400).json({ error: 'cwd query parameter required' })
+    }
+    try {
+      res.json({ checkpoints: await listCheckpoints(cwd) })
+    } catch (error) {
+      res.status(500).json({ error: error instanceof Error ? error.message : 'list failed' })
+    }
+  })
+
+  router.post('/checkpoints/restore', async (req, res) => {
+    const cwd = typeof req.body?.cwd === 'string' ? req.body.cwd : ''
+    const id = typeof req.body?.id === 'string' ? req.body.id : ''
+    if (!cwd || !id) {
+      return res.status(400).json({ error: 'cwd and id are required' })
+    }
+    try {
+      await fsp.access(cwd)
+    } catch {
+      return res.status(400).json({ error: `cwd does not exist: ${cwd}` })
+    }
+    try {
+      await restoreCheckpoint(cwd, id)
+      res.json({ restored: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'restore failed'
+      res.status(message.includes('invalid checkpoint id') ? 400 : 500).json({ error: message })
+    }
+  })
+
+  return router
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+import { createFreshAgentExtrasRouter } from './fresh-agent-extras-router.js'
 import { detectLanIpsAsync } from './bootstrap.js' // Must be first - ensures .env exists before dotenv loads
 import 'dotenv/config'
 import express from 'express'
@@ -624,6 +625,9 @@ async function main() {
     codingCliIndexer,
     terminalViewService: createTerminalViewService({ configStore, registry }),
   }))
+
+  // --- API: fresh-agent extras (attachments, exec, diffs) ---
+  app.use('/api/fresh-agent', createFreshAgentExtrasRouter({ freshAgentRuntimeManager }))
 
   // --- API: AI ---
   app.use('/api/ai', createAiRouter({ registry, perfConfig }))

--- a/server/mcp/freshell-tool.ts
+++ b/server/mcp/freshell-tool.ts
@@ -278,6 +278,7 @@ const ACTION_PARAMS: Record<string, { required: string[]; optional: string[] }> 
   'list-sessions':   { required: [],                          optional: [] },
   'search-sessions': { required: ['query'],                   optional: [] },
   'lan-info':        { required: [],                          optional: [] },
+  'fresh-send':      { required: ['sessionId', 'sessionType', 'provider', 'text'], optional: [] },
   'health':          { required: [],                          optional: [] },
   'help':            { required: [],                          optional: [] },
 }
@@ -569,6 +570,14 @@ async function routeAction(
   const c = client()
 
   switch (action) {
+    // -- Fresh agent (chat client) actions --
+    case 'fresh-send': {
+      const sessionId = requireParam(params, 'sessionId')
+      const sessionType = requireParam(params, 'sessionType')
+      const provider = requireParam(params, 'provider')
+      const text = requireParam(params, 'text')
+      return c.post('/api/fresh-agent/send', { sessionId, sessionType, provider, text })
+    }
     // -- Tab actions --
     case 'new-tab': {
       const { name, mode, shell, cwd, browser, editor, resume, sessionRef: explicitSessionRef, prompt, ...rest } = params || {}

--- a/shared/fresh-agent-slash-commands.ts
+++ b/shared/fresh-agent-slash-commands.ts
@@ -1,12 +1,14 @@
 import type { FreshAgentSessionType } from './fresh-agent.js'
 
-export type FreshAgentSlashCommandAction = 'new' | 'compact'
+export type FreshAgentSlashCommandAction = 'new' | 'compact' | 'fork'
 
 export type FreshAgentSlashCommand = {
   name: string
   description: string
   action: FreshAgentSlashCommandAction
   aliases?: readonly string[]
+  /** Requires the matching capability flag in the thread snapshot to be true. */
+  requiresCapability?: 'fork'
 }
 
 const BASE_COMMANDS = [
@@ -21,6 +23,13 @@ const BASE_COMMANDS = [
     description: 'Ask the agent to compact its current conversation context',
     action: 'compact',
     aliases: ['compress', 'summarize-context'],
+  },
+  {
+    name: 'fork',
+    description: 'Fork this conversation into a new session from this point',
+    action: 'fork',
+    aliases: ['branch'],
+    requiresCapability: 'fork',
   },
 ] as const satisfies readonly FreshAgentSlashCommand[]
 

--- a/src/components/agent-chat/SlotReel.tsx
+++ b/src/components/agent-chat/SlotReel.tsx
@@ -14,6 +14,12 @@ interface ReelSlot {
   current: string
   previous: string | null
   animating: boolean
+  /** Monotonic counter — keys the animated spans so a change that lands
+   * mid-animation remounts them and the CSS animation restarts from frame 0.
+   * (The previous transition-based approach left the outgoing span stuck at
+   * its translated end state when values changed faster than the animation,
+   * so rapid tool sequences froze instead of rolling.) */
+  serial: number
 }
 
 function useReelSlot(value: string): ReelSlot {
@@ -21,6 +27,7 @@ function useReelSlot(value: string): ReelSlot {
     current: value,
     previous: null,
     animating: false,
+    serial: 0,
   })
   const prevValueRef = useRef(value)
 
@@ -29,10 +36,17 @@ function useReelSlot(value: string): ReelSlot {
     const prev = prevValueRef.current
     prevValueRef.current = value
 
-    setSlot({ current: value, previous: prev, animating: true })
+    setSlot((s) => ({
+      current: value,
+      // If a roll is already in flight, the in-flight target becomes the
+      // outgoing value so the reel never skips a frame backwards.
+      previous: s.animating ? s.current : prev,
+      animating: true,
+      serial: s.serial + 1,
+    }))
 
     const timer = setTimeout(() => {
-      setSlot(s => ({ ...s, previous: null, animating: false }))
+      setSlot((s) => ({ ...s, previous: null, animating: false }))
     }, 150)
     return () => clearTimeout(timer)
   }, [value])
@@ -43,20 +57,20 @@ function useReelSlot(value: string): ReelSlot {
 function ReelCell({ slot, className }: { slot: ReelSlot; className?: string }) {
   return (
     <span className={cn('relative inline-flex overflow-hidden', className)}>
-      <span
-        className={cn(
-          'inline-block transition-transform duration-150 ease-out',
-          slot.animating && '-translate-y-full',
-        )}
-      >
-        {slot.previous ?? slot.current}
-      </span>
-      {slot.animating && (
-        <span
-          className="absolute left-0 top-full inline-block transition-transform duration-150 ease-out -translate-y-full"
-        >
-          {slot.current}
-        </span>
+      {slot.animating && slot.previous !== null ? (
+        <>
+          <span key={`out-${slot.serial}`} className="inline-block animate-reel-out">
+            {slot.previous}
+          </span>
+          <span
+            key={`in-${slot.serial}`}
+            className="absolute left-0 top-0 inline-block animate-reel-in"
+          >
+            {slot.current}
+          </span>
+        </>
+      ) : (
+        <span className="inline-block">{slot.current}</span>
       )}
     </span>
   )

--- a/src/components/fresh-agent/FreshAgentActionSheet.tsx
+++ b/src/components/fresh-agent/FreshAgentActionSheet.tsx
@@ -1,0 +1,85 @@
+import { useEffect } from 'react'
+
+export type ActionSheetItem = {
+  label: string
+  disabled?: boolean
+  destructive?: boolean
+  run: () => void
+}
+
+/**
+ * Bottom action sheet for touch devices — the coarse-pointer counterpart of
+ * the floating right-click menu. Fixed to the bottom edge (thumb zone), 48px
+ * rows, safe-area padded, dismissed by backdrop tap or Cancel.
+ */
+export function FreshAgentActionSheet({
+  title,
+  items,
+  onClose,
+}: {
+  title?: string
+  items: ActionSheetItem[]
+  onClose: () => void
+}) {
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <div className="fixed inset-0 z-50" role="presentation">
+      <button
+        type="button"
+        aria-label="Dismiss"
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+      />
+      <div
+        role="menu"
+        aria-label={title ?? 'Actions'}
+        className="absolute inset-x-0 bottom-0 rounded-t-xl border-t border-border bg-popover pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-lg"
+      >
+        <div className="mx-auto mt-2 h-1 w-9 rounded-full bg-border" aria-hidden />
+        {title ? (
+          <div className="truncate px-5 pb-1 pt-2 text-xs text-muted-foreground">{title}</div>
+        ) : null}
+        <div className="px-2 pt-1">
+          {items.map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              role="menuitem"
+              disabled={item.disabled}
+              className={[
+                'block min-h-[3rem] w-full rounded-lg px-4 text-left text-base',
+                item.disabled
+                  ? 'cursor-not-allowed opacity-40'
+                  : item.destructive
+                    ? 'text-destructive active:bg-destructive/10'
+                    : 'active:bg-accent',
+              ].join(' ')}
+              onClick={() => {
+                onClose()
+                if (!item.disabled) item.run()
+              }}
+            >
+              {item.label}
+            </button>
+          ))}
+          <button
+            type="button"
+            className="mt-1 block min-h-[3rem] w-full rounded-lg border-t border-border px-4 text-left text-base text-muted-foreground active:bg-accent"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default FreshAgentActionSheet

--- a/src/components/fresh-agent/FreshAgentApprovalCard.tsx
+++ b/src/components/fresh-agent/FreshAgentApprovalCard.tsx
@@ -1,0 +1,102 @@
+import DiffView from '@/components/agent-chat/DiffView'
+import type { FreshAgentPendingApproval } from '@shared/fresh-agent-contract'
+
+/**
+ * Approval card with an inline preview of what is being approved — the exact
+ * Bash command, an Edit diff, or pretty-printed input for other tools — plus a
+ * session-scoped "always allow" escape hatch handled by the caller.
+ */
+export function FreshAgentApprovalCard({
+  approval,
+  disabled,
+  onAllow,
+  onAlwaysAllow,
+  onDeny,
+}: {
+  approval: FreshAgentPendingApproval
+  disabled?: boolean
+  onAllow: () => void
+  onAlwaysAllow: (toolName: string) => void
+  onDeny: () => void
+}) {
+  const toolName = approval.toolName ?? 'Tool'
+  const input = approval.input ?? {}
+  const command = toolName === 'Bash' && typeof input.command === 'string' ? input.command : null
+  const editDiff = toolName === 'Edit'
+    && typeof input.old_string === 'string'
+    && typeof input.new_string === 'string'
+    ? { oldStr: input.old_string, newStr: input.new_string, filePath: typeof input.file_path === 'string' ? input.file_path : undefined }
+    : null
+
+  return (
+    <div
+      role="alert"
+      aria-label={`Permission request for ${toolName}`}
+      className="rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm"
+    >
+      <div className="flex items-center gap-2 font-medium">
+        <span className="rounded-full border border-amber-500/60 px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-amber-600 dark:text-amber-400">
+          approval
+        </span>
+        <span>{toolName}</span>
+        {approval.blockedPath ? (
+          <span className="truncate font-mono text-xs text-muted-foreground">{approval.blockedPath}</span>
+        ) : null}
+      </div>
+      {approval.decisionReason ? (
+        <p className="mt-1 text-xs text-muted-foreground">{approval.decisionReason}</p>
+      ) : null}
+
+      {command ? (
+        <pre className="mt-2 overflow-x-auto rounded border border-border/60 bg-background/70 px-2 py-1.5 font-mono text-xs">
+          {command}
+        </pre>
+      ) : editDiff ? (
+        <div className="mt-2 text-xs">
+          <DiffView oldStr={editDiff.oldStr} newStr={editDiff.newStr} filePath={editDiff.filePath} />
+        </div>
+      ) : Object.keys(input).length > 0 ? (
+        <pre className="mt-2 max-h-40 overflow-auto rounded border border-border/60 bg-background/70 px-2 py-1.5 font-mono text-xs">
+          {JSON.stringify(input, null, 2)}
+        </pre>
+      ) : null}
+
+      {/* Touch targets ≥44px at base; compact on sm+. flex-1 lets the buttons
+          share the full row width on narrow panes for easy thumbing. */}
+      <div className="mt-2 flex flex-wrap gap-2">
+        <button
+          type="button"
+          aria-label="Allow tool use"
+          disabled={disabled}
+          onClick={onAllow}
+          className="min-h-[2.75rem] flex-1 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50 sm:min-h-0 sm:flex-none sm:px-3 sm:py-1 sm:text-xs"
+        >
+          Allow
+        </button>
+        {approval.toolName ? (
+          <button
+            type="button"
+            aria-label={`Always allow ${toolName} this session`}
+            disabled={disabled}
+            onClick={() => onAlwaysAllow(toolName)}
+            className="min-h-[2.75rem] flex-1 rounded-md border border-border px-4 text-sm disabled:cursor-not-allowed disabled:opacity-50 sm:min-h-0 sm:flex-none sm:px-3 sm:py-1 sm:text-xs"
+            title={`Auto-approve every ${toolName} request for the rest of this session`}
+          >
+            Always allow {toolName} this session
+          </button>
+        ) : null}
+        <button
+          type="button"
+          aria-label="Deny tool use"
+          disabled={disabled}
+          onClick={onDeny}
+          className="min-h-[2.75rem] flex-1 rounded-md border border-border px-4 text-sm text-muted-foreground hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50 sm:min-h-0 sm:flex-none sm:px-3 sm:py-1 sm:text-xs"
+        >
+          Deny
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default FreshAgentApprovalCard

--- a/src/components/fresh-agent/FreshAgentComposer.tsx
+++ b/src/components/fresh-agent/FreshAgentComposer.tsx
@@ -8,13 +8,39 @@ import {
   useState,
   type KeyboardEvent,
 } from 'react'
-import { Command, Send, Square } from 'lucide-react'
+import { Command, File, Folder, Loader2, Paperclip, Send, Square, X } from 'lucide-react'
+import { api } from '@/lib/api'
+import { getAuthToken } from '@/lib/auth'
+import { useCoarsePointer } from '@/lib/pointer'
+import { cn } from '@/lib/utils'
 import type { FreshAgentSlashCommand } from '@shared/fresh-agent-slash-commands'
+
+export type FreshAgentAttachment = {
+  /** Server-side saved path, present once uploaded. */
+  path?: string
+  name: string
+  bytes: number
+  status: 'uploading' | 'ready' | 'error'
+  error?: string
+}
 
 type FreshAgentComposerProps = {
   disabled?: boolean
+  /** State-aware input placeholder (starting / busy / ended / read-only). */
+  placeholder?: string
   storageKey?: string
-  onSend?: (value: string) => void
+  /** Stable key for prompt history persistence (per session type). */
+  historyKey?: string
+  /** Working directory used to resolve @ file mentions. */
+  cwd?: string
+  /** Runtime provider, used to filter attachment types the model can read natively. */
+  provider?: 'claude' | 'codex' | 'opencode'
+  /** Messages queued while the agent is running (owned by the view). */
+  queuedMessages?: readonly string[]
+  onCancelQueued?: (index: number) => void
+  onSend?: (value: string, attachmentPaths: string[]) => void
+  /** `!command` shell escape; absent = feature hidden. */
+  onShellCommand?: (command: string) => void
   onInterrupt?: () => void
   canInterrupt?: boolean
   commands?: readonly FreshAgentSlashCommand[]
@@ -23,9 +49,39 @@ type FreshAgentComposerProps = {
 
 export type FreshAgentComposerHandle = {
   focus: () => void
+  insertText: (text: string) => void
 }
 
-type MenuMode = 'chat' | 'browse'
+type MenuMode = 'chat' | 'browse' | 'files'
+
+type FileSuggestion = {
+  path: string
+  isDirectory: boolean
+}
+
+const HISTORY_LIMIT = 50
+const TEXTUAL_EXTENSIONS = new Set([
+  'txt', 'md', 'markdown', 'csv', 'tsv', 'json', 'yaml', 'yml', 'toml', 'xml', 'html', 'css',
+  'js', 'jsx', 'ts', 'tsx', 'py', 'rs', 'go', 'java', 'c', 'cc', 'cpp', 'h', 'hpp', 'sh', 'bash',
+  'sql', 'diff', 'patch', 'log',
+])
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp'])
+
+/**
+ * Attachments land on disk and are referenced by path, so anything textual is
+ * readable by every provider's file tools. Native media support is what varies.
+ */
+export function attachmentRejection(provider: string | undefined, filename: string): string | null {
+  // Extensionless files (Makefile, Dockerfile, LICENSE…) are treated as text.
+  if (!filename.includes('.')) return null
+  const ext = filename.split('.').pop()?.toLowerCase() ?? ''
+  if (TEXTUAL_EXTENSIONS.has(ext)) return null
+  if (IMAGE_EXTENSIONS.has(ext)) return null
+  if (ext === 'pdf') {
+    return provider === 'claude' ? null : `this model can’t read .pdf — remove it or switch model`
+  }
+  return `.${ext} isn’t supported — attach images, PDFs (claude), or text files`
+}
 
 function getCommandPrefix(value: string): string | null {
   if (!value.startsWith('/')) return null
@@ -41,14 +97,79 @@ function parseSlashCommand(value: string): { name: string; args: string } | null
   return { name: match[1].toLowerCase(), args: match[2]?.trim() ?? '' }
 }
 
+/** Trailing `@token` (start-of-text or whitespace-preceded, no spaces inside). */
+function getMentionToken(value: string): { start: number; token: string } | null {
+  const match = value.match(/(^|\s)@([^\s@]*)$/)
+  if (!match) return null
+  const start = value.length - match[2].length - 1
+  return { start, token: match[2] }
+}
+
+function relativizePath(path: string, cwd?: string): string {
+  if (!cwd) return path
+  const normalizedCwd = cwd.endsWith('/') ? cwd.slice(0, -1) : cwd
+  if (path === normalizedCwd) return '.'
+  if (path.startsWith(`${normalizedCwd}/`)) return path.slice(normalizedCwd.length + 1)
+  return path
+}
+
+function readHistory(historyKey?: string): string[] {
+  if (!historyKey || typeof window === 'undefined') return []
+  try {
+    const raw = window.localStorage.getItem(historyKey)
+    const parsed = raw ? JSON.parse(raw) : []
+    return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+function writeHistory(historyKey: string | undefined, entries: string[]) {
+  if (!historyKey || typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(historyKey, JSON.stringify(entries.slice(0, HISTORY_LIMIT)))
+  } catch {
+    // Persistence is best-effort; recall just won't survive a reload.
+  }
+}
+
+/**
+ * Raw binary upload. Deliberately NOT base64-in-JSON: the server's global
+ * express.json caps JSON bodies at 1mb, so attachments ship as
+ * application/octet-stream (which the JSON parser ignores) with the filename
+ * in the query string. Auth header matches src/lib/api.ts's request().
+ */
+async function uploadAttachment(file: globalThis.File): Promise<{ path: string; bytes: number }> {
+  const headers = new Headers({ 'Content-Type': 'application/octet-stream' })
+  const token = getAuthToken()
+  if (token) headers.set('x-auth-token', token)
+  const res = await fetch(`/api/fresh-agent/attachments?name=${encodeURIComponent(file.name)}`, {
+    method: 'POST',
+    body: file,
+    headers,
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => null) as { error?: string; message?: string } | null
+    throw new Error(data?.error || data?.message || `upload failed (${res.status})`)
+  }
+  return res.json() as Promise<{ path: string; bytes: number }>
+}
+
 export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgentComposerProps>(function FreshAgentComposer({
   disabled = false,
   storageKey,
+  historyKey,
+  cwd,
+  provider,
+  queuedMessages = [],
+  onCancelQueued,
   onSend,
+  onShellCommand,
   onInterrupt,
   canInterrupt = false,
   commands = [],
   onCommand,
+  placeholder,
 }, ref) {
   const [text, setText] = useState(() => {
     if (!storageKey || typeof window === 'undefined') return ''
@@ -57,19 +178,36 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
   const [menuMode, setMenuMode] = useState<MenuMode | null>(null)
   const [filter, setFilter] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const [fileSuggestions, setFileSuggestions] = useState<FileSuggestion[]>([])
+  const [historyIndex, setHistoryIndex] = useState(-1)
+  const [attachments, setAttachments] = useState<FreshAgentAttachment[]>([])
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const filterRef = useRef<HTMLInputElement | null>(null)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const historyRef = useRef<string[]>(readHistory(historyKey))
+  const completionRequestIdRef = useRef(0)
+  // On touch keyboards Enter inserts a newline; the Send button sends. A
+  // paired hardware keyboard on a phone still gets Esc/ArrowUp shortcuts —
+  // only the Enter-to-send gesture is gated on pointer coarseness.
+  const coarsePointer = useCoarsePointer()
 
   useImperativeHandle(ref, () => ({
     focus: () => textareaRef.current?.focus(),
+    insertText: (value: string) => {
+      setText((current) => (current ? `${current.replace(/\s$/, '')} ${value}` : value))
+      requestAnimationFrame(() => textareaRef.current?.focus())
+    },
   }), [])
 
   const chatPrefix = getCommandPrefix(text)
+  const mention = useMemo(() => getMentionToken(text), [text])
+  const isShellInput = onShellCommand !== undefined && text.startsWith('!')
   const activeFilter = menuMode === 'chat' ? (chatPrefix ?? '') : filter.toLowerCase()
   const visibleCommands = useMemo(() => {
     const normalizedFilter = activeFilter.replace(/^\//, '')
     return commands.filter((command) => command.name.includes(normalizedFilter))
   }, [activeFilter, commands])
+  const menuLength = menuMode === 'files' ? fileSuggestions.length : visibleCommands.length
 
   useEffect(() => {
     if (!storageKey || typeof window === 'undefined') return
@@ -89,17 +227,53 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
 
   useEffect(() => {
     setHighlightedIndex(0)
-  }, [activeFilter])
+  }, [activeFilter, fileSuggestions])
 
   useEffect(() => {
+    if (mention !== null) {
+      setMenuMode('files')
+      return
+    }
     if (chatPrefix !== null && text.startsWith('/')) {
       setMenuMode('chat')
       return
     }
-    if (menuMode === 'chat') {
+    if (menuMode === 'chat' || menuMode === 'files') {
       setMenuMode(null)
+      setFileSuggestions([])
     }
-  }, [chatPrefix, menuMode, text])
+  }, [chatPrefix, mention, menuMode, text])
+
+  // Debounced @ mention completion against the files API, anchored at the
+  // session cwd. Mirrors DirectoryPicker's request-id guard so stale responses
+  // never clobber newer ones.
+  useEffect(() => {
+    if (mention === null) return
+    completionRequestIdRef.current += 1
+    const requestId = completionRequestIdRef.current
+    let cancelled = false
+    const base = cwd ? `${cwd.replace(/\/$/, '')}/` : ''
+    const prefix = `${base}${mention.token}`
+    const timer = setTimeout(() => {
+      if (cancelled || completionRequestIdRef.current !== requestId) return
+      void Promise
+        .resolve(api.get<{ suggestions?: FileSuggestion[] }>(
+          `/api/files/complete?prefix=${encodeURIComponent(prefix)}`
+        ))
+        .then((result) => {
+          if (cancelled || completionRequestIdRef.current !== requestId) return
+          setFileSuggestions((result?.suggestions ?? []).slice(0, 15))
+        })
+        .catch(() => {
+          if (cancelled || completionRequestIdRef.current !== requestId) return
+          setFileSuggestions([])
+        })
+    }, 200)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [cwd, mention])
 
   useEffect(() => {
     if (menuMode === 'browse') {
@@ -111,15 +285,26 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
     setMenuMode(null)
     setFilter('')
     setHighlightedIndex(0)
+    setFileSuggestions([])
   }, [])
 
+  const pushHistory = useCallback((value: string) => {
+    const next = [value, ...historyRef.current.filter((entry) => entry !== value)].slice(0, HISTORY_LIMIT)
+    historyRef.current = next
+    writeHistory(historyKey, next)
+    setHistoryIndex(-1)
+  }, [historyKey])
+
   const executeCommand = useCallback((command: FreshAgentSlashCommand, args = '') => {
-    if (disabled) return
+    // /new must stay reachable when the session is dead and the composer is
+    // disabled — it's the way out of an ended session.
+    if (disabled && command.action !== 'new') return
     onCommand?.(command, args)
+    pushHistory(args ? `/${command.name} ${args}` : `/${command.name}`)
     setText('')
     closeMenu()
     requestAnimationFrame(() => textareaRef.current?.focus())
-  }, [closeMenu, disabled, onCommand])
+  }, [closeMenu, disabled, onCommand, pushHistory])
 
   const executeSlashText = useCallback((value: string): boolean => {
     const parsed = parseSlashCommand(value)
@@ -132,20 +317,90 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
     return true
   }, [commands, executeCommand])
 
+  const insertFileSuggestion = useCallback((suggestion: FileSuggestion) => {
+    if (mention === null) return
+    const relative = relativizePath(suggestion.path, cwd)
+    const insertion = suggestion.isDirectory ? `${relative}/` : `${relative} `
+    const replaceStart = suggestion.isDirectory ? mention.start + 1 : mention.start
+    setText((value) => `${value.slice(0, replaceStart)}${insertion}`)
+    if (!suggestion.isDirectory) {
+      closeMenu()
+    }
+    requestAnimationFrame(() => textareaRef.current?.focus())
+  }, [closeMenu, cwd, mention])
+
+  const addFiles = useCallback((files: Iterable<globalThis.File>) => {
+    for (const file of files) {
+      const rejection = attachmentRejection(provider, file.name)
+      if (rejection) {
+        setAttachments((current) => [...current, {
+          name: file.name,
+          bytes: file.size,
+          status: 'error',
+          error: rejection,
+        }])
+        continue
+      }
+      const placeholder: FreshAgentAttachment = { name: file.name, bytes: file.size, status: 'uploading' }
+      setAttachments((current) => [...current, placeholder])
+      void uploadAttachment(file)
+        .then((result) => {
+          setAttachments((current) => current.map((entry) => (
+            entry === placeholder ? { ...entry, status: 'ready', path: result.path } : entry
+          )))
+        })
+        .catch((error: unknown) => {
+          setAttachments((current) => current.map((entry) => (
+            entry === placeholder
+              ? { ...entry, status: 'error', error: error instanceof Error ? error.message : 'upload failed' }
+              : entry
+          )))
+        })
+    }
+  }, [provider])
+
   const sendText = useCallback(() => {
     const trimmed = text.trim()
-    if (!trimmed || disabled) return
+    if (disabled) return
+    if (isShellInput && trimmed.length > 1) {
+      onShellCommand?.(trimmed.slice(1).trim())
+      pushHistory(trimmed)
+      setText('')
+      closeMenu()
+      return
+    }
+    const readyAttachments = attachments.filter((entry) => entry.status === 'ready' && entry.path)
+    if (!trimmed && readyAttachments.length === 0) return
+    if (attachments.some((entry) => entry.status === 'uploading')) return
     if (trimmed.startsWith('/') && executeSlashText(trimmed)) return
-    onSend?.(trimmed)
+    onSend?.(trimmed, readyAttachments.map((entry) => entry.path as string))
+    if (trimmed) pushHistory(trimmed)
+    setAttachments((current) => current.filter((entry) => entry.status === 'error'))
     setText('')
     closeMenu()
-  }, [closeMenu, disabled, executeSlashText, onSend, text])
+  }, [attachments, closeMenu, disabled, executeSlashText, isShellInput, onSend, onShellCommand, pushHistory, text])
+
+  const recallHistory = useCallback((direction: 1 | -1): boolean => {
+    const history = historyRef.current
+    if (history.length === 0) return false
+    if (direction === 1) {
+      const next = Math.min(historyIndex + 1, history.length - 1)
+      setHistoryIndex(next)
+      setText(history[next])
+      return true
+    }
+    if (historyIndex < 0) return false
+    const next = historyIndex - 1
+    setHistoryIndex(next)
+    setText(next < 0 ? '' : history[next])
+    return true
+  }, [historyIndex])
 
   const handleMenuKeyDown = useCallback((event: KeyboardEvent<HTMLElement>) => {
     if (!menuMode) return false
     if (event.key === 'ArrowDown') {
       event.preventDefault()
-      setHighlightedIndex((index) => Math.min(index + 1, Math.max(visibleCommands.length - 1, 0)))
+      setHighlightedIndex((index) => Math.min(index + 1, Math.max(menuLength - 1, 0)))
       return true
     }
     if (event.key === 'ArrowUp') {
@@ -159,7 +414,13 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
       requestAnimationFrame(() => textareaRef.current?.focus())
       return true
     }
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' || (event.key === 'Tab' && menuMode === 'files')) {
+      if (menuMode === 'files') {
+        event.preventDefault()
+        const selected = fileSuggestions[highlightedIndex]
+        if (selected) insertFileSuggestion(selected)
+        return true
+      }
       event.preventDefault()
       const selected = visibleCommands[highlightedIndex]
       if (selected) {
@@ -186,7 +447,10 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
     closeMenu,
     executeCommand,
     executeSlashText,
+    fileSuggestions,
     highlightedIndex,
+    insertFileSuggestion,
+    menuLength,
     menuMode,
     text,
     visibleCommands,
@@ -194,17 +458,22 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
 
   return (
     <form
-      className="relative border-t border-border/60 p-3"
+      className="relative border-t border-border/60 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] sm:pb-3"
       onSubmit={(event) => {
         event.preventDefault()
         sendText()
       }}
+      onDragOver={(event) => event.preventDefault()}
+      onDrop={(event) => {
+        event.preventDefault()
+        if (event.dataTransfer?.files?.length) addFiles(event.dataTransfer.files)
+      }}
     >
-      {menuMode && visibleCommands.length > 0 ? (
+      {menuMode && menuLength > 0 ? (
         <div
           className="absolute bottom-full left-3 mb-2 w-[min(420px,calc(100%-1.5rem))] overflow-hidden rounded-md border border-border/70 bg-popover text-popover-foreground shadow-lg"
           role="menu"
-          aria-label="Slash commands"
+          aria-label={menuMode === 'files' ? 'File suggestions' : 'Slash commands'}
         >
           {menuMode === 'browse' ? (
             <div className="border-b border-border/60 p-2">
@@ -219,14 +488,31 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
               />
             </div>
           ) : null}
-          <div className="max-h-72 overflow-auto py-1">
-            {visibleCommands.map((command, index) => (
+          <div className="max-h-[45vh] overflow-auto overscroll-contain py-1 sm:max-h-72">
+            {menuMode === 'files' ? fileSuggestions.map((suggestion, index) => (
+              <button
+                key={suggestion.path}
+                type="button"
+                role="menuitem"
+                className={[
+                  'flex min-h-[2.75rem] w-full items-center gap-2 px-3 py-1.5 text-left text-sm sm:min-h-0',
+                  index === highlightedIndex ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60',
+                ].join(' ')}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                onClick={() => insertFileSuggestion(suggestion)}
+              >
+                {suggestion.isDirectory
+                  ? <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                  : <File className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />}
+                <span className="truncate font-mono text-xs">{relativizePath(suggestion.path, cwd)}</span>
+              </button>
+            )) : visibleCommands.map((command, index) => (
               <button
                 key={command.name}
                 type="button"
                 role="menuitem"
                 className={[
-                  'flex w-full flex-col px-3 py-2 text-left text-sm',
+                  'flex min-h-[2.75rem] w-full flex-col justify-center px-3 py-2 text-left text-sm sm:min-h-0',
                   index === highlightedIndex ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60',
                 ].join(' ')}
                 onMouseEnter={() => setHighlightedIndex(index)}
@@ -239,11 +525,68 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
           </div>
           <div className="flex gap-3 border-t border-border/60 px-3 py-2 text-xs text-muted-foreground">
             <span>Arrow keys navigate</span>
-            <span>Enter runs</span>
+            <span>Enter {menuMode === 'files' ? 'inserts' : 'runs'}</span>
             {menuMode === 'chat' ? <span>Tab completes</span> : null}
+            {menuMode === 'files' ? <span>Tab inserts</span> : null}
           </div>
         </div>
       ) : null}
+
+      {queuedMessages.length > 0 ? (
+        <div className="mb-2 space-y-1" role="list" aria-label="Queued messages">
+          {queuedMessages.map((message, index) => (
+            <div
+              key={`${index}-${message.slice(0, 16)}`}
+              role="listitem"
+              className="flex items-center gap-2 rounded-md border border-dashed border-border/70 px-2 py-1 text-xs text-muted-foreground"
+            >
+              <span className="shrink-0">queued</span>
+              <span className="min-w-0 flex-1 truncate">{message}</span>
+              {onCancelQueued ? (
+                <button
+                  type="button"
+                  className="-m-2 shrink-0 p-2 hover:text-destructive sm:m-0 sm:p-0"
+                  aria-label={`Remove queued message ${index + 1}`}
+                  onClick={() => onCancelQueued(index)}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {attachments.length > 0 ? (
+        <div className="mb-2 flex flex-wrap gap-1.5" role="list" aria-label="Attachments">
+          {attachments.map((attachment, index) => (
+            <span
+              key={`${attachment.name}-${index}`}
+              role="listitem"
+              className={cn(
+                'inline-flex max-w-full items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs',
+                attachment.status === 'error'
+                  ? 'border-destructive/60 text-destructive'
+                  : 'border-border/70 text-muted-foreground',
+              )}
+              title={attachment.error ?? attachment.path ?? attachment.name}
+            >
+              {attachment.status === 'uploading' ? <Loader2 className="h-3 w-3 animate-spin" aria-label="uploading" /> : null}
+              <span className="truncate">{attachment.name}</span>
+              {attachment.status === 'error' ? <span className="truncate">— {attachment.error}</span> : null}
+              <button
+                type="button"
+                className="-m-2 shrink-0 p-2 hover:text-destructive sm:m-0 sm:p-0"
+                aria-label={`Remove attachment ${attachment.name}`}
+                onClick={() => setAttachments((current) => current.filter((_, i) => i !== index))}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : null}
+
       <div className="flex items-end gap-2">
         <textarea
           ref={textareaRef}
@@ -252,12 +595,37 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
           disabled={disabled}
           rows={1}
           value={text}
-          placeholder={disabled ? 'Read-only session' : 'Send a message'}
-          className="max-h-44 min-h-[40px] flex-1 resize-none rounded-md border border-border/70 bg-background px-3 py-2 text-sm outline-none"
-          onChange={(event) => setText(event.target.value)}
+          placeholder={placeholder ?? (disabled ? 'Read-only session' : 'Send a message — / commands, @ files, ! shell')}
+          className={cn(
+            // text-base at small sizes prevents iOS Safari's zoom-on-focus.
+            'max-h-44 min-h-[44px] flex-1 resize-none rounded-md border border-border/70 bg-background px-3 py-2 text-base outline-none sm:min-h-[40px] sm:text-sm',
+            isShellInput && 'border-warning/60 font-mono',
+          )}
+          onChange={(event) => {
+            setText(event.target.value)
+            setHistoryIndex(-1)
+          }}
+          onPaste={(event) => {
+            if (event.clipboardData?.files?.length) {
+              event.preventDefault()
+              addFiles(event.clipboardData.files)
+            }
+          }}
           onKeyDown={(event) => {
             if (handleMenuKeyDown(event)) return
-            if (event.key === 'Enter' && !event.shiftKey) {
+            if (event.key === 'ArrowUp' && (text === '' || historyIndex >= 0)) {
+              if (recallHistory(1)) {
+                event.preventDefault()
+                return
+              }
+            }
+            if (event.key === 'ArrowDown' && historyIndex >= 0) {
+              if (recallHistory(-1)) {
+                event.preventDefault()
+                return
+              }
+            }
+            if (event.key === 'Enter' && !event.shiftKey && !coarsePointer) {
               event.preventDefault()
               sendText()
             }
@@ -267,11 +635,21 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
             }
           }}
         />
+        <button
+          type="button"
+          disabled={disabled}
+          className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-border/70 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50 sm:h-9 sm:w-9"
+          aria-label="Attach files"
+          title="Attach files — images, PDFs (claude), and text files"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Paperclip className="h-4 w-4" />
+        </button>
         {canInterrupt ? (
           <button
             type="button"
             onClick={onInterrupt}
-            className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-border bg-background text-sm transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-border bg-background text-sm transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 sm:h-10 sm:w-10"
             aria-label="Stop"
           >
             <Square className="h-4 w-4" />
@@ -279,11 +657,10 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
         ) : null}
         <button
           type="button"
-          disabled={disabled || commands.length === 0}
-          className="rounded-md border border-border/70 p-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={commands.length === 0}
+          className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-border/70 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50 sm:h-9 sm:w-9"
           aria-label="Slash commands"
           onClick={() => {
-            if (disabled) return
             setMenuMode((mode) => mode === 'browse' ? null : 'browse')
             setFilter('')
           }}
@@ -293,11 +670,22 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
         <button
           type="submit"
           disabled={disabled}
-          className="inline-flex h-10 w-10 items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex h-11 w-11 items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50 sm:h-10 sm:w-10"
           aria-label="Send"
         >
           <Send className="h-4 w-4" />
         </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          hidden
+          aria-hidden
+          onChange={(event) => {
+            if (event.target.files?.length) addFiles(event.target.files)
+            event.target.value = ''
+          }}
+        />
       </div>
     </form>
   )

--- a/src/components/fresh-agent/FreshAgentContextMeter.tsx
+++ b/src/components/fresh-agent/FreshAgentContextMeter.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef, useState } from 'react'
+import { useAppSelector } from '@/store/hooks'
+import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
+import type { FreshAgentPaneContent } from '@/store/paneTypes'
+import { cn } from '@/lib/utils'
+
+const WARN_PERCENT = 80
+
+function formatTokens(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (value >= 1000) return `${Math.round(value / 1000)}k`
+  return String(value)
+}
+
+/**
+ * Compact context-usage meter for fresh-agent pane headers. Reads the thread
+ * snapshot's tokenUsage and renders a small bar + percent, switching to a
+ * warning treatment near compaction. Hover shows the detail via title on
+ * desktop; tap toggles an inline detail popover (tooltips don't exist on
+ * touch). Renders nothing until the provider reports usable numbers.
+ */
+export function FreshAgentContextMeter({ paneContent }: { paneContent: FreshAgentPaneContent }) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLSpanElement>(null)
+  const tokenUsage = useAppSelector((state) => {
+    if (!paneContent.sessionId) return undefined
+    const key = makeFreshAgentSessionKey({
+      sessionId: paneContent.sessionId,
+      sessionType: paneContent.sessionType,
+      provider: paneContent.provider,
+    })
+    return state.freshAgent?.sessions?.[key]?.snapshot?.tokenUsage
+  })
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: MouseEvent | TouchEvent) => {
+      if (rootRef.current?.contains(event.target as Node)) return
+      setOpen(false)
+    }
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('touchstart', onPointerDown)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('touchstart', onPointerDown)
+    }
+  }, [open])
+
+  if (!tokenUsage) return null
+
+  const percent = typeof tokenUsage.compactPercent === 'number' && Number.isFinite(tokenUsage.compactPercent)
+    ? Math.max(0, Math.min(100, Math.round(tokenUsage.compactPercent)))
+    : null
+  const contextTokens = typeof tokenUsage.contextTokens === 'number' && Number.isFinite(tokenUsage.contextTokens)
+    ? tokenUsage.contextTokens
+    : null
+
+  if (percent === null && contextTokens === null) return null
+
+  const warn = percent !== null && percent >= WARN_PERCENT
+  const detailRows = [
+    contextTokens !== null ? `Context: ${formatTokens(contextTokens)} tokens` : null,
+    percent !== null ? `${percent}% of compaction threshold` : null,
+    `In ${formatTokens(tokenUsage.inputTokens)} / out ${formatTokens(tokenUsage.outputTokens)}`,
+    typeof tokenUsage.costUsd === 'number' && tokenUsage.costUsd > 0
+      ? `$${tokenUsage.costUsd.toFixed(2)}`
+      : null,
+    warn ? 'Compaction soon — /compact to compact now' : null,
+  ].filter((row): row is string => row !== null)
+
+  return (
+    <span ref={rootRef} className="relative inline-flex">
+      <button
+        type="button"
+        title={detailRows.join(' · ')}
+        aria-expanded={open}
+        className="inline-flex min-h-[2rem] items-center rounded px-1 sm:min-h-0 sm:px-0"
+        onClick={(event) => {
+          event.stopPropagation()
+          setOpen((value) => !value)
+        }}
+      >
+        {/* role="status" on a span inside the toggle button: the metric is a
+            live region; the button is just its tap target. jsx-a11y flags
+            this at warn level only — split the elements if it ever errors. */}
+        <span
+          role="status"
+          data-warn={warn ? '' : undefined}
+          aria-label={percent !== null ? `Context ${percent}% full` : `Context ${formatTokens(contextTokens ?? 0)} tokens`}
+          className={cn(
+            'inline-flex shrink-0 items-center gap-1.5 text-2xs',
+            warn ? 'text-warning' : 'text-muted-foreground',
+          )}
+        >
+          {percent !== null ? (
+            <>
+              <span className="h-1 w-9 overflow-hidden rounded-full bg-border" aria-hidden>
+                <span
+                  className={cn('block h-full rounded-full', warn ? 'bg-warning' : 'bg-primary')}
+                  style={{ width: `${percent}%` }}
+                />
+              </span>
+              <span>{percent}%</span>
+            </>
+          ) : (
+            <span>{formatTokens(contextTokens ?? 0)} ctx</span>
+          )}
+        </span>
+      </button>
+      {open ? (
+        <span
+          role="note"
+          aria-label="Context usage detail"
+          className="absolute right-0 top-full z-50 mt-1 block w-max max-w-[min(18rem,calc(100vw-1rem))] rounded-md border border-border bg-card px-3 py-2 text-xs text-foreground shadow-lg"
+        >
+          {detailRows.map((row) => (
+            <span key={row} className="block py-0.5">{row}</span>
+          ))}
+        </span>
+      ) : null}
+    </span>
+  )
+}
+
+export default FreshAgentContextMeter

--- a/src/components/fresh-agent/FreshAgentDiffPanel.tsx
+++ b/src/components/fresh-agent/FreshAgentDiffPanel.tsx
@@ -1,13 +1,131 @@
-export function FreshAgentDiffPanel({ diffs }: { diffs: Array<{ id: string; path?: string; title?: string }> }) {
+import { useCallback, useState } from 'react'
+import { ChevronRight, MessageSquarePlus } from 'lucide-react'
+import { api } from '@/lib/api'
+import { cn } from '@/lib/utils'
+
+type DiffSummary = { id: string; path?: string; title?: string; status?: string }
+
+function classifyLine(line: string): 'add' | 'del' | 'hunk' | 'meta' | 'ctx' {
+  if (line.startsWith('+++') || line.startsWith('---') || line.startsWith('diff ') || line.startsWith('index ')) return 'meta'
+  if (line.startsWith('@@')) return 'hunk'
+  if (line.startsWith('+')) return 'add'
+  if (line.startsWith('-')) return 'del'
+  return 'ctx'
+}
+
+function FreshAgentFileDiff({
+  summary,
+  cwd,
+  onComment,
+}: {
+  summary: DiffSummary
+  cwd?: string
+  onComment?: (text: string) => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const [diff, setDiff] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const load = useCallback(() => {
+    if (!cwd || !summary.path || loading || diff !== null) return
+    setLoading(true)
+    void Promise
+      .resolve(api.get<{ diff: string }>(
+        `/api/fresh-agent/diff?cwd=${encodeURIComponent(cwd)}&path=${encodeURIComponent(summary.path)}`
+      ))
+      .then((result) => setDiff(result?.diff ?? ''))
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : 'Failed to load diff'))
+      .finally(() => setLoading(false))
+  }, [cwd, diff, loading, summary.path])
+
+  const label = summary.title ?? summary.path ?? summary.id
+  const lines = diff !== null && diff.trim() ? diff.split('\n') : null
+
+  return (
+    <div className="border-l-2 border-l-border text-xs">
+      <button
+        type="button"
+        className="flex min-h-[2.75rem] w-full items-center gap-2 rounded-r px-2 py-1 text-left transition-colors hover:bg-accent/50 sm:min-h-0"
+        aria-expanded={expanded}
+        aria-label={`Diff: ${label}`}
+        onClick={() => {
+          setExpanded((value) => !value)
+          if (!expanded) load()
+        }}
+      >
+        <ChevronRight className={cn('h-3 w-3 shrink-0 transition-transform', expanded && 'rotate-90')} />
+        <span className="truncate font-mono">{label}</span>
+        {summary.status ? <span className="ml-auto shrink-0 text-muted-foreground">{summary.status}</span> : null}
+      </button>
+      {expanded ? (
+        <div className="mt-1 overflow-x-auto rounded border border-border/60 bg-background/70 font-mono text-[11px] leading-5">
+          {loading ? <div className="px-3 py-2 text-muted-foreground">Loading diff…</div> : null}
+          {error ? <div className="px-3 py-2 text-destructive">{error}</div> : null}
+          {!loading && !error && lines === null && diff !== null ? (
+            <div className="px-3 py-2 text-muted-foreground">No uncommitted changes for this file.</div>
+          ) : null}
+          {lines?.map((line, index) => {
+            const kind = classifyLine(line)
+            if (kind === 'meta') return null
+            return (
+              <div
+                key={index}
+                className={cn(
+                  'group/line flex items-center whitespace-pre px-3',
+                  kind === 'add' && 'bg-success/10 text-success',
+                  kind === 'del' && 'bg-destructive/10 text-destructive',
+                  kind === 'hunk' && 'bg-muted/60 text-muted-foreground',
+                )}
+              >
+                <span className="min-w-0 flex-1 overflow-hidden text-ellipsis">{line || ' '}</span>
+                {onComment && kind !== 'hunk' ? (
+                  <button
+                    type="button"
+                    // Hover-revealed on desktop; always visible (with a real
+                    // touch target) on no-hover devices.
+                    className="invisible ml-2 shrink-0 p-1.5 text-muted-foreground hover:text-primary group-hover/line:visible sm:p-0 [@media(hover:none)]:visible"
+                    aria-label="Comment on this line for the agent"
+                    title="Comment on this line for the agent"
+                    onClick={() => onComment(`On ${summary.path ?? label} at \`${line.trim()}\`: `)}
+                  >
+                    <MessageSquarePlus className="h-3 w-3" />
+                  </button>
+                ) : null}
+              </div>
+            )
+          })}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * Changed-files panel: summaries come from the thread snapshot; full content
+ * loads on expand from /api/fresh-agent/diff (git diff in the session cwd).
+ * Line comments drop a prefilled mention into the composer via onComment.
+ */
+export function FreshAgentDiffPanel({
+  diffs,
+  cwd,
+  onComment,
+}: {
+  diffs: DiffSummary[]
+  cwd?: string
+  onComment?: (text: string) => void
+}) {
   if (diffs.length === 0) return null
   return (
     <div className="rounded-lg border border-border/60 bg-background/70 p-3">
       <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Diffs</div>
-      <ul className="space-y-1 text-sm">
+      <div className="space-y-1">
         {diffs.map((diff) => (
-          <li key={diff.id}>{diff.title ?? diff.path ?? diff.id}</li>
+          <FreshAgentFileDiff key={diff.id} summary={diff} cwd={cwd} onComment={onComment} />
         ))}
-      </ul>
+      </div>
     </div>
   )
 }
+
+export default FreshAgentDiffPanel

--- a/src/components/fresh-agent/FreshAgentItemCard.tsx
+++ b/src/components/fresh-agent/FreshAgentItemCard.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { Check, ChevronRight, Loader2, X } from 'lucide-react'
 import DiffView from '@/components/agent-chat/DiffView'
 import { getToolPreview } from '@/components/agent-chat/tool-preview'
+import { LazyMarkdown } from '@/components/markdown/LazyMarkdown'
 import type { FreshAgentTranscriptItem } from '@shared/fresh-agent-contract'
 import { cn } from '@/lib/utils'
 
@@ -219,13 +220,41 @@ export function itemToToolDisplay(item: FreshAgentTranscriptItem): FreshAgentToo
   return null
 }
 
-function renderText(text: string) {
+/**
+ * Render visible item text. Assistant-authored text renders as markdown
+ * (matching agent-chat's MessageBubble); user text and thinking stay plain
+ * so literal input is never re-interpreted. The plain <p> doubles as the
+ * Suspense fallback so content is readable while the renderer chunk loads.
+ */
+function renderText(text: string, markdown = false) {
   const visibleText = stripSystemReminders(text)
   if (!visibleText) return null
-  return <p className="whitespace-pre-wrap break-words">{visibleText}</p>
+  const plain = <p className="whitespace-pre-wrap break-words">{visibleText}</p>
+  if (!markdown) return plain
+  return (
+    <div
+      data-markdown-body=""
+      className="prose prose-sm dark:prose-invert max-w-none [&_h1]:my-2 [&_h2]:my-1.5 [&_h3]:my-1.5 [&_p]:my-1 [&_pre]:my-1.5 [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0.5"
+    >
+      <LazyMarkdown content={visibleText} fallback={plain} />
+    </div>
+  )
 }
 
-export function FreshAgentItemCard({ item }: { item: FreshAgentTranscriptItem }) {
+/** Markdown-rendered body for agent-authored text that lives outside item
+ * cards (turn-summary fallbacks, expanded thinking). Keeps every assistant
+ * text path on the same renderer so backticks never show literally. */
+export function FreshAgentMarkdownBody({ text }: { text: string }) {
+  return <>{renderText(text, true)}</>
+}
+
+export function FreshAgentItemCard({
+  item,
+  markdown = false,
+}: {
+  item: FreshAgentTranscriptItem
+  markdown?: boolean
+}) {
   if (item.kind === 'text' || item.kind === 'thinking') {
     if (item.kind === 'thinking') {
       return (
@@ -235,7 +264,7 @@ export function FreshAgentItemCard({ item }: { item: FreshAgentTranscriptItem })
         </details>
       )
     }
-    return renderText(item.text)
+    return renderText(item.text, markdown)
   }
 
   if (item.kind === 'reasoning') {

--- a/src/components/fresh-agent/FreshAgentSettingsButton.tsx
+++ b/src/components/fresh-agent/FreshAgentSettingsButton.tsx
@@ -8,6 +8,7 @@ import {
   getFreshAgentThinkingOptions,
   normalizeFreshAgentEffort,
   normalizeFreshAgentModel,
+  resolveFreshAgentType,
 } from '@/lib/fresh-agent-registry'
 import { cn } from '@/lib/utils'
 
@@ -17,6 +18,27 @@ function getEffectiveFreshAgentModel(content: FreshAgentPaneContent): string | u
 
 function getEffectiveFreshAgentEffort(content: FreshAgentPaneContent): string | undefined {
   return normalizeFreshAgentEffort(content.sessionType, content.provider, getEffectiveFreshAgentModel(content), content.effort)
+}
+
+type PermissionModeOption = { value: string; label: string; description?: string }
+
+/**
+ * Permission modes per runtime provider. 'plan' maps to the Claude SDK's
+ * read-only research mode; codex modes mirror its approval policies.
+ */
+const PERMISSION_MODES_BY_PROVIDER: Record<string, PermissionModeOption[]> = {
+  claude: [
+    { value: 'default', label: 'Default (ask)' },
+    { value: 'acceptEdits', label: 'Accept edits' },
+    { value: 'bypassPermissions', label: 'Bypass permissions' },
+    { value: 'plan', label: 'Plan mode (read-only)', description: 'Research and propose; no edits until approved.' },
+  ],
+  codex: [
+    { value: 'read-only', label: 'Read-only' },
+    { value: 'on-request', label: 'On request' },
+    { value: 'on-failure', label: 'On failure' },
+    { value: 'never', label: 'Never ask (full access)' },
+  ],
 }
 
 export function FreshAgentSettingsButton({
@@ -38,6 +60,14 @@ export function FreshAgentSettingsButton({
   const modelValue = activeModel ?? ''
   const thinkingOptions = getFreshAgentThinkingOptions(paneContent.sessionType, paneContent.provider, activeModel)
   const thinkingValue = getEffectiveFreshAgentEffort(paneContent) ?? ''
+  const descriptor = resolveFreshAgentType(paneContent.sessionType)
+  const permissionModeVisible = descriptor?.settingsVisibility.permissionMode === true
+  const permissionModes = permissionModeVisible
+    ? PERMISSION_MODES_BY_PROVIDER[paneContent.provider] ?? []
+    : []
+  const permissionModeValue = paneContent.permissionMode
+    ?? descriptor?.defaultPermissionMode
+    ?? ''
   const settingsDisabled = paneContent.status === 'running' || paneContent.status === 'compacting'
 
   const close = useCallback(() => setOpen(false), [])
@@ -86,7 +116,7 @@ export function FreshAgentSettingsButton({
       {open ? (
         <div
           ref={popoverRef}
-          className="absolute right-0 top-full z-50 mt-1 w-64 rounded-md border border-border bg-card p-3 text-xs text-foreground shadow-lg"
+          className="absolute right-0 top-full z-50 mt-1 w-[min(16rem,calc(100vw-1rem))] rounded-md border border-border bg-card p-3 text-xs text-foreground shadow-lg"
           role="dialog"
           aria-label="Agent settings"
         >
@@ -99,7 +129,7 @@ export function FreshAgentSettingsButton({
                     <label
                       key={option.value}
                       className={cn(
-                        'flex cursor-pointer items-center gap-2 rounded border border-border/60 px-2 py-1 transition-colors',
+                        'flex min-h-[2.5rem] cursor-pointer items-center gap-2 rounded border border-border/60 px-2 py-1 transition-colors sm:min-h-0',
                         modelValue === option.value ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50',
                         settingsDisabled && 'cursor-not-allowed opacity-60 hover:bg-transparent',
                       )}
@@ -138,7 +168,7 @@ export function FreshAgentSettingsButton({
                 <span className="font-medium">Thinking</span>
                 <select
                   aria-label="Thinking level"
-                  className="w-full rounded border border-border/70 bg-background px-2 py-1 text-xs"
+                  className="min-h-[2.5rem] w-full rounded border border-border/70 bg-background px-2 py-1 text-base sm:min-h-0 sm:text-xs"
                   value={thinkingValue}
                   disabled={settingsDisabled}
                   onChange={(event) => {
@@ -153,6 +183,37 @@ export function FreshAgentSettingsButton({
                     <option key={option.value} value={option.value}>{option.label}</option>
                   ))}
                 </select>
+              </label>
+            ) : null}
+
+            {permissionModes.length > 0 ? (
+              <label className="block space-y-1">
+                <span className="font-medium">Permission mode</span>
+                <select
+                  aria-label="Permission mode"
+                  className="min-h-[2.5rem] w-full rounded border border-border/70 bg-background px-2 py-1 text-base sm:min-h-0 sm:text-xs"
+                  value={permissionModeValue}
+                  disabled={settingsDisabled}
+                  onChange={(event) => {
+                    dispatch(mergePaneContent({
+                      tabId,
+                      paneId,
+                      updates: { permissionMode: event.target.value },
+                    }))
+                  }}
+                >
+                  {permissionModes.map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+                {permissionModes.find((option) => option.value === permissionModeValue)?.description ? (
+                  <span className="block text-[11px] text-muted-foreground">
+                    {permissionModes.find((option) => option.value === permissionModeValue)?.description}
+                  </span>
+                ) : null}
+                <span className="block text-[11px] text-muted-foreground">
+                  Applies from the next message.
+                </span>
               </label>
             ) : null}
           </div>

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -1,16 +1,26 @@
-import { memo, useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronDown, ChevronRight, Loader2 } from 'lucide-react'
 import SlotReel from '@/components/agent-chat/SlotReel'
 import { getToolPreview } from '@/components/agent-chat/tool-preview'
 import { cn } from '@/lib/utils'
 import type { FreshAgentTranscriptItem, FreshAgentTurn } from '@shared/fresh-agent-contract'
 import {
   FreshAgentItemCard,
+  FreshAgentMarkdownBody,
   FreshAgentToolBlock,
   itemToToolDisplay,
   stripSystemReminders,
   type FreshAgentToolDisplay,
 } from './FreshAgentItemCard'
+import {
+  buildTurnActionItems,
+  FreshAgentTurnActions,
+  FreshAgentTurnContextMenu,
+  turnPlainText,
+  type FreshAgentTurnContextMenuState,
+} from './FreshAgentTurnActions'
+import { FreshAgentActionSheet } from './FreshAgentActionSheet'
+import { buildLongPressHandlers, useCoarsePointer } from '@/lib/pointer'
 
 function getTurnLabel(turn: FreshAgentTurn): string {
   switch (turn.role) {
@@ -39,6 +49,14 @@ function isToolLike(item: FreshAgentTranscriptItem): boolean {
     || item.kind === 'image_generation'
 }
 
+/**
+ * Thinking and reasoning roll through the activity strip alongside tools, so a
+ * working turn occupies one line instead of stacking disclosures down the pane.
+ */
+function isActivityLike(item: FreshAgentTranscriptItem): boolean {
+  return isToolLike(item) || item.kind === 'thinking' || item.kind === 'reasoning'
+}
+
 function formatJson(value: unknown): string {
   if (typeof value === 'string') return value
   try {
@@ -48,80 +66,196 @@ function formatJson(value: unknown): string {
   }
 }
 
-function buildTools(items: FreshAgentTranscriptItem[]): FreshAgentToolDisplay[] {
-  const tools = new Map<string, FreshAgentToolDisplay>()
-  const orderedIds: string[] = []
+type ActivityRow =
+  | { type: 'thinking'; id: string; text: string }
+  | { type: 'tool'; tool: FreshAgentToolDisplay }
+
+function buildActivity(items: FreshAgentTranscriptItem[]): ActivityRow[] {
+  const rows: ActivityRow[] = []
+  const toolIndexById = new Map<string, number>()
+  // Providers stream thinking in chunks; consecutive thinking/reasoning items
+  // merge into one row instead of stacking N "Thinking:" fragments.
+  const pushThinking = (id: string, text: string) => {
+    if (!text) return
+    const last = rows[rows.length - 1]
+    if (last?.type === 'thinking') {
+      rows[rows.length - 1] = { ...last, text: `${last.text}\n\n${text}` }
+      return
+    }
+    rows.push({ type: 'thinking', id, text })
+  }
   for (const item of items) {
+    if (item.kind === 'thinking') {
+      pushThinking(item.id, stripSystemReminders(item.text))
+      continue
+    }
+    if (item.kind === 'reasoning') {
+      pushThinking(item.id, item.summary.length > 0 ? item.summary.join('\n') : (item.text ?? ''))
+      continue
+    }
     if (item.kind === 'tool_result') {
-      const existing = tools.get(item.toolUseId)
-      if (existing) {
-        tools.set(item.toolUseId, {
-          ...existing,
-          output: formatJson(item.content),
-          isError: item.isError,
-          status: 'complete',
-        })
+      const index = toolIndexById.get(item.toolUseId)
+      if (index !== undefined) {
+        const existing = rows[index] as Extract<ActivityRow, { type: 'tool' }>
+        rows[index] = {
+          type: 'tool',
+          tool: {
+            ...existing.tool,
+            output: formatJson(item.content),
+            isError: item.isError,
+            status: 'complete',
+          },
+        }
       } else {
-        orderedIds.push(item.id)
-        tools.set(item.id, {
-          id: item.id,
-          name: 'Result',
-          output: formatJson(item.content),
-          isError: item.isError,
-          status: 'complete',
+        toolIndexById.set(item.id, rows.length)
+        rows.push({
+          type: 'tool',
+          tool: {
+            id: item.id,
+            name: 'Result',
+            output: formatJson(item.content),
+            isError: item.isError,
+            status: 'complete',
+          },
         })
       }
       continue
     }
     const tool = itemToToolDisplay(item)
     if (!tool) continue
-    if (!tools.has(tool.id)) orderedIds.push(tool.id)
-    tools.set(tool.id, tool)
+    const existingIndex = toolIndexById.get(tool.id)
+    if (existingIndex !== undefined) {
+      rows[existingIndex] = { type: 'tool', tool }
+    } else {
+      toolIndexById.set(tool.id, rows.length)
+      rows.push({ type: 'tool', tool })
+    }
   }
-  return orderedIds.map((id) => tools.get(id)).filter(Boolean) as FreshAgentToolDisplay[]
+  return rows
+}
+
+function activityTools(rows: ActivityRow[]): FreshAgentToolDisplay[] {
+  return rows
+    .filter((row): row is Extract<ActivityRow, { type: 'tool' }> => row.type === 'tool')
+    .map((row) => row.tool)
+}
+
+const FILE_CHANGING_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit'])
+
+function countFilesChanged(tools: FreshAgentToolDisplay[]): number {
+  const paths = new Set<string>()
+  let anonymous = 0
+  for (const tool of tools) {
+    if (!FILE_CHANGING_TOOLS.has(tool.name)) continue
+    const path = typeof tool.input?.file_path === 'string' ? tool.input.file_path : null
+    if (path) paths.add(path)
+    else anonymous += 1
+  }
+  return paths.size + anonymous
+}
+
+function settledSummary(rows: ActivityRow[]): string {
+  const tools = activityTools(rows)
+  const hasThinking = rows.some((row) => row.type === 'thinking')
+  const filesChanged = countFilesChanged(tools)
+  const parts: string[] = []
+  if (hasThinking) parts.push('thought')
+  if (tools.length > 0) parts.push(`${tools.length} tool${tools.length === 1 ? '' : 's'} used`)
+  if (filesChanged > 0) parts.push(`${filesChanged} file${filesChanged === 1 ? '' : 's'} changed`)
+  return parts.join(' · ') || 'thought'
+}
+
+function thinkingPreview(text: string): string {
+  const flat = text.replace(/\s+/g, ' ').trim()
+  return flat.length > 64 ? `…${flat.slice(-60)}` : flat
 }
 
 type RenderBlock =
   | { kind: 'item'; item: FreshAgentTranscriptItem }
-  | { kind: 'tools'; id: string; tools: FreshAgentToolDisplay[] }
+  | { kind: 'activity'; id: string; rows: ActivityRow[]; endsWithThinking: boolean }
 
 function buildBlocks(items: FreshAgentTranscriptItem[]): RenderBlock[] {
   const blocks: RenderBlock[] = []
-  let pendingTools: FreshAgentTranscriptItem[] = []
-  const flushTools = () => {
-    if (pendingTools.length === 0) return
-    const tools = buildTools(pendingTools)
-    if (tools.length > 0) {
-      blocks.push({ kind: 'tools', id: pendingTools.map((item) => item.id).join(':'), tools })
+  let pending: FreshAgentTranscriptItem[] = []
+  const flush = () => {
+    if (pending.length === 0) return
+    const rows = buildActivity(pending)
+    if (rows.length > 0) {
+      blocks.push({
+        kind: 'activity',
+        id: pending.map((item) => item.id).join(':'),
+        rows,
+        endsWithThinking: rows[rows.length - 1]?.type === 'thinking',
+      })
     }
-    pendingTools = []
+    pending = []
   }
   for (const item of items) {
-    if (isToolLike(item)) {
-      pendingTools.push(item)
+    if (isActivityLike(item)) {
+      pending.push(item)
       continue
     }
-    flushTools()
+    flush()
     blocks.push({ kind: 'item', item })
   }
-  flushTools()
+  flush()
   return blocks
 }
 
-function FreshAgentToolStrip({ tools }: { tools: FreshAgentToolDisplay[] }) {
+function FreshAgentThinkingRow({ text }: { text: string }) {
   const [expanded, setExpanded] = useState(false)
-  const hasErrors = tools.some((tool) => tool.isError)
-  const allComplete = tools.every((tool) => tool.status === 'complete')
-  const currentTool = [...tools].reverse().find((tool) => tool.status === 'running') ?? tools[tools.length - 1] ?? null
-  const settledText = `${tools.length} tool${tools.length === 1 ? '' : 's'} used`
-
-  if (tools.length === 0) return null
   return (
-    <div role="region" aria-label="Tool strip" className="my-0.5">
+    <div className="my-0.5 border-l-2 border-l-[hsl(var(--primary))] text-xs">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-center gap-2 rounded-r px-2 py-0.5 text-left transition-colors hover:bg-accent/50"
+        aria-expanded={expanded}
+        aria-label="Thinking"
+      >
+        <ChevronRight className={cn('h-3 w-3 shrink-0 transition-transform', expanded && 'rotate-90')} />
+        <span className="font-medium">Thinking:</span>
+        <span className="truncate italic text-muted-foreground">{thinkingPreview(text)}</span>
+      </button>
+      {expanded ? (
+        <div className="border-t border-border/50 px-2 py-1 text-sm text-muted-foreground">
+          <FreshAgentMarkdownBody text={text} />
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function FreshAgentActivityStrip({
+  rows,
+  liveTrailingThinking = false,
+}: {
+  rows: ActivityRow[]
+  liveTrailingThinking?: boolean
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const tools = activityTools(rows)
+  const hasErrors = tools.some((tool) => tool.isError)
+  const lastRow = rows[rows.length - 1] ?? null
+  const runningTool = [...tools].reverse().find((tool) => tool.status === 'running') ?? null
+  const thinkingLive = liveTrailingThinking && lastRow?.type === 'thinking'
+  const running = runningTool !== null || thinkingLive
+
+  if (rows.length === 0) return null
+
+  const reelName = runningTool ? runningTool.name : thinkingLive ? 'Thinking' : null
+  const reelPreview = runningTool
+    ? getToolPreview(runningTool.name, runningTool.input)
+    : thinkingLive && lastRow?.type === 'thinking'
+      ? thinkingPreview(lastRow.text)
+      : null
+
+  return (
+    <div role="region" aria-label="Activity strip" className="my-0.5">
       {!expanded ? (
         <div
           className={cn(
-            'flex min-w-0 items-center gap-1 border-l-2 px-2 py-0.5 text-xs',
+            'flex min-w-0 items-center gap-1.5 border-l-2 px-2 py-0.5 text-xs',
             hasErrors ? 'border-l-[hsl(var(--destructive))]' : 'border-l-[hsl(var(--primary))]',
           )}
         >
@@ -129,15 +263,16 @@ function FreshAgentToolStrip({ tools }: { tools: FreshAgentToolDisplay[] }) {
             type="button"
             onClick={() => setExpanded(true)}
             className="shrink-0 rounded p-0.5 transition-colors hover:bg-accent/50"
-            aria-label="Toggle tool details"
+            aria-label="Toggle activity details"
             aria-expanded={false}
           >
             <ChevronRight className="h-3 w-3" />
           </button>
+          {running ? <Loader2 className="h-3 w-3 shrink-0 animate-spin" aria-label="running" /> : null}
           <SlotReel
-            toolName={allComplete ? null : (currentTool?.name ?? null)}
-            previewText={allComplete ? null : (currentTool ? getToolPreview(currentTool.name, currentTool.input) : null)}
-            settledText={allComplete ? settledText : undefined}
+            toolName={running ? reelName : null}
+            previewText={running ? reelPreview : null}
+            settledText={running ? undefined : settledSummary(rows)}
           />
         </div>
       ) : (
@@ -146,13 +281,15 @@ function FreshAgentToolStrip({ tools }: { tools: FreshAgentToolDisplay[] }) {
             type="button"
             onClick={() => setExpanded(false)}
             className="ml-1.5 shrink-0 rounded p-0.5 transition-colors hover:bg-accent/50"
-            aria-label="Toggle tool details"
+            aria-label="Toggle activity details"
             aria-expanded={true}
           >
             <ChevronRight className="h-3 w-3 rotate-90 transition-transform" />
           </button>
-          {tools.map((tool) => (
-            <FreshAgentToolBlock key={tool.id} tool={tool} initialExpanded={false} />
+          {rows.map((row) => (
+            row.type === 'thinking'
+              ? <FreshAgentThinkingRow key={row.id} text={row.text} />
+              : <FreshAgentToolBlock key={row.tool.id} tool={row.tool} initialExpanded={false} />
           ))}
         </>
       )}
@@ -161,7 +298,7 @@ function FreshAgentToolStrip({ tools }: { tools: FreshAgentToolDisplay[] }) {
 }
 
 function countTools(turn: FreshAgentTurn): number {
-  return buildTools(turn.items.filter(isToolLike)).length
+  return activityTools(buildActivity(turn.items.filter(isToolLike))).length
 }
 
 function getTurnSummary(turn: FreshAgentTurn): string {
@@ -181,7 +318,16 @@ function getTurnSummary(turn: FreshAgentTurn): string {
   return parts.length > 0 ? `${short} -> ${parts.join(', ')}` : short
 }
 
-function CollapsedFreshAgentTurn({ turn }: { turn: FreshAgentTurn }) {
+type TurnActionProps = {
+  canFork: boolean
+  onForkFromTurn?: (turnId: string) => void
+  onRewindToTurn?: (turn: FreshAgentTurn) => void
+  onTurnContextMenu?: (event: React.MouseEvent, turn: FreshAgentTurn) => void
+  /** Coarse-pointer path: open the bottom action sheet for this turn. */
+  onOpenActions?: (turn: FreshAgentTurn) => void
+}
+
+function CollapsedFreshAgentTurn({ turn, actions }: { turn: FreshAgentTurn; actions: TurnActionProps }) {
   const [expanded, setExpanded] = useState(false)
   const summary = getTurnSummary(turn)
   if (expanded) {
@@ -197,7 +343,7 @@ function CollapsedFreshAgentTurn({ turn }: { turn: FreshAgentTurn }) {
           <ChevronRight className="h-3 w-3 rotate-90 transition-transform" />
           <span className="truncate font-mono opacity-70">{summary}</span>
         </button>
-        <FreshAgentTurnArticle turn={turn} compact={false} />
+        <FreshAgentTurnArticle turn={turn} compact={false} isLatest={false} actions={actions} />
       </div>
     )
   }
@@ -215,39 +361,120 @@ function CollapsedFreshAgentTurn({ turn }: { turn: FreshAgentTurn }) {
   )
 }
 
-function FreshAgentTurnArticle({ turn, compact }: { turn: FreshAgentTurn; compact: boolean }) {
+function FreshAgentTurnArticle({
+  turn,
+  compact,
+  isLatest,
+  actions,
+}: {
+  turn: FreshAgentTurn
+  compact: boolean
+  isLatest: boolean
+  actions: TurnActionProps
+}) {
   const isUser = turn.role === 'user'
   const blocks = buildBlocks(turn.items)
+  // Long-press opens the action sheet on touch devices (iOS fires no
+  // contextmenu event; Android does — both paths land on onOpenActions and
+  // the second call is a no-op re-set of the same state).
+  const longPress = useMemo(() => (
+    actions.onOpenActions
+      ? buildLongPressHandlers<HTMLElement>(() => actions.onOpenActions?.(turn))
+      : null
+  ), [actions, turn])
   return (
     <article
       className={cn(
-        'w-full border-l-2 py-0.5 pl-2.5 pr-1',
+        'group relative w-full border-l-2 py-0.5 pl-2.5 pr-1',
         isUser ? 'border-l-[hsl(var(--primary))]' : 'border-l-border',
         compact && 'opacity-95',
       )}
       aria-label={`${getTurnLabel(turn)} transcript turn`}
+      onContextMenu={(event) => {
+        // stopPropagation matters: freshell has a global contextmenu handler
+        // that renders the app menu over ours otherwise (live-test finding).
+        if (actions.onOpenActions) {
+          event.preventDefault()
+          event.stopPropagation()
+          actions.onOpenActions(turn)
+          return
+        }
+        if (!actions.onTurnContextMenu) return
+        event.preventDefault()
+        event.stopPropagation()
+        actions.onTurnContextMenu(event, turn)
+      }}
+      {...(longPress ?? {})}
     >
+      <FreshAgentTurnActions
+        turn={turn}
+        canFork={actions.canFork}
+        onForkFromTurn={actions.onForkFromTurn}
+        onRewindToTurn={actions.onRewindToTurn}
+        onOpenActions={actions.onOpenActions}
+      />
       <div className="mb-1 flex items-center justify-between gap-2 text-[11px] uppercase text-muted-foreground">
         <span>{getTurnLabel(turn)}</span>
         {turn.model ? <span className="truncate normal-case">{turn.model}</span> : null}
       </div>
       <div className="space-y-1.5 text-sm">
-        {blocks.length > 0 ? blocks.map((block) => {
-          if (block.kind === 'tools') return <FreshAgentToolStrip key={block.id} tools={block.tools} />
-          return <FreshAgentItemCard key={block.item.id} item={block.item} />
-        }) : (
+        {blocks.length > 0 ? blocks.map((block, blockIndex) => {
+          if (block.kind === 'activity') {
+            return (
+              <FreshAgentActivityStrip
+                key={block.id}
+                rows={block.rows}
+                liveTrailingThinking={isLatest && blockIndex === blocks.length - 1 && block.endsWithThinking}
+              />
+            )
+          }
+          return <FreshAgentItemCard key={block.item.id} item={block.item} markdown={!isUser} />
+        }) : isUser ? (
           <p className="whitespace-pre-wrap break-words">{stripSystemReminders(turn.summary)}</p>
+        ) : (
+          // Summary-only agent turns went through the plain-text path and
+          // showed literal backticks (live-test finding) — render markdown.
+          <FreshAgentMarkdownBody text={turn.summary ?? ''} />
         )}
       </div>
     </article>
   )
 }
 
-export function FreshAgentTranscript({ turns }: { turns: FreshAgentTurn[] }) {
+export function FreshAgentTranscript({
+  turns,
+  canFork = false,
+  onForkFromTurn,
+  onRewindToTurn,
+}: {
+  turns: FreshAgentTurn[]
+  canFork?: boolean
+  onForkFromTurn?: (turnId: string) => void
+  onRewindToTurn?: (turn: FreshAgentTurn) => void
+}) {
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   const [atBottom, setAtBottom] = useState(true)
   const [newMessages, setNewMessages] = useState(0)
+  const [contextMenu, setContextMenu] = useState<FreshAgentTurnContextMenuState>(null)
+  const [sheetTurn, setSheetTurn] = useState<FreshAgentTurn | null>(null)
+  const coarsePointer = useCoarsePointer()
   const turnKeys = useMemo(() => turns.map((turn) => turn.id).join('|'), [turns])
+
+  const handleTurnContextMenu = useCallback((event: React.MouseEvent, turn: FreshAgentTurn) => {
+    setContextMenu({ x: event.clientX, y: event.clientY, turn })
+  }, [])
+
+  const handleOpenActions = useCallback((turn: FreshAgentTurn) => {
+    setSheetTurn(turn)
+  }, [])
+
+  const actions: TurnActionProps = useMemo(() => ({
+    canFork,
+    onForkFromTurn,
+    onRewindToTurn,
+    onTurnContextMenu: coarsePointer ? undefined : handleTurnContextMenu,
+    onOpenActions: coarsePointer ? handleOpenActions : undefined,
+  }), [canFork, coarsePointer, handleOpenActions, handleTurnContextMenu, onForkFromTurn, onRewindToTurn])
 
   useEffect(() => {
     const node = scrollerRef.current
@@ -266,7 +493,7 @@ export function FreshAgentTranscript({ turns }: { turns: FreshAgentTurn[] }) {
     <div className="relative min-h-0 flex-1">
       <div
         ref={scrollerRef}
-        className="flex h-full flex-col gap-3 overflow-y-auto px-3 py-3"
+        className="flex h-full flex-col gap-3 overflow-y-auto overscroll-contain px-3 py-3"
         data-context="fresh-agent-transcript"
         onScroll={(event) => {
           const node = event.currentTarget
@@ -275,10 +502,32 @@ export function FreshAgentTranscript({ turns }: { turns: FreshAgentTurn[] }) {
       >
         {turns.map((turn, index) => (
           index < collapsedCutoff
-            ? <CollapsedFreshAgentTurn key={turn.id} turn={turn} />
-            : <FreshAgentTurnArticle key={turn.id} turn={turn} compact={index < collapsedCutoff} />
+            ? <CollapsedFreshAgentTurn key={turn.id} turn={turn} actions={actions} />
+            : (
+              <FreshAgentTurnArticle
+                key={turn.id}
+                turn={turn}
+                compact={index < collapsedCutoff}
+                isLatest={index === turns.length - 1}
+                actions={actions}
+              />
+            )
         ))}
       </div>
+      <FreshAgentTurnContextMenu
+        state={contextMenu}
+        canFork={canFork}
+        onForkFromTurn={onForkFromTurn}
+        onRewindToTurn={onRewindToTurn}
+        onClose={() => setContextMenu(null)}
+      />
+      {sheetTurn ? (
+        <FreshAgentActionSheet
+          title={turnPlainText(sheetTurn).slice(0, 80) || getTurnLabel(sheetTurn)}
+          items={buildTurnActionItems(sheetTurn, { canFork, onForkFromTurn, onRewindToTurn })}
+          onClose={() => setSheetTurn(null)}
+        />
+      ) : null}
       {!atBottom ? (
         <button
           type="button"

--- a/src/components/fresh-agent/FreshAgentTurnActions.tsx
+++ b/src/components/fresh-agent/FreshAgentTurnActions.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Check, Copy, GitFork, History, MoreHorizontal } from 'lucide-react'
+import { copyText } from '@/lib/clipboard'
+import type { FreshAgentTurn } from '@shared/fresh-agent-contract'
+import { stripSystemReminders } from './FreshAgentItemCard'
+import type { ActionSheetItem } from './FreshAgentActionSheet'
+import { cn } from '@/lib/utils'
+
+export function turnPlainText(turn: FreshAgentTurn): string {
+  const text = turn.items
+    .filter((item): item is Extract<FreshAgentTurn['items'][number], { kind: 'text' }> => item.kind === 'text')
+    .map((item) => stripSystemReminders(item.text))
+    .filter(Boolean)
+    .join('\n\n')
+  return text || stripSystemReminders(turn.summary ?? '')
+}
+
+export type TurnActionCallbacks = {
+  canFork: boolean
+  onForkFromTurn?: (turnId: string) => void
+  onRewindToTurn?: (turn: FreshAgentTurn) => void
+}
+
+/**
+ * One source of truth for what you can do to a turn — consumed by the desktop
+ * context menu and the mobile action sheet so they never drift apart.
+ */
+export function buildTurnActionItems(turn: FreshAgentTurn, callbacks: TurnActionCallbacks): ActionSheetItem[] {
+  return [
+    {
+      label: 'Copy turn text',
+      run: () => { void copyText(turnPlainText(turn)) },
+    },
+    {
+      label: 'Fork conversation from here',
+      disabled: !callbacks.canFork || !callbacks.onForkFromTurn,
+      run: () => callbacks.onForkFromTurn?.(turn.turnId ?? turn.id),
+    },
+    {
+      label: 'Rewind code to here',
+      disabled: callbacks.onRewindToTurn === undefined || turn.role !== 'user',
+      destructive: true,
+      run: () => callbacks.onRewindToTurn?.(turn),
+    },
+  ]
+}
+
+/**
+ * Per-turn affordances. Pointer-capability aware:
+ * - hover/fine: a hover toolbar (copy / fork / rewind) — hidden entirely on
+ *   no-hover devices via the (hover:none) media variant;
+ * - touch/no-hover: an always-visible ⋯ button (44px target) that opens the
+ *   bottom action sheet; long-press on the turn does the same.
+ */
+export function FreshAgentTurnActions({
+  turn,
+  canFork,
+  onForkFromTurn,
+  onRewindToTurn,
+  onOpenActions,
+}: TurnActionCallbacks & {
+  turn: FreshAgentTurn
+  onOpenActions?: (turn: FreshAgentTurn) => void
+}) {
+  const [copied, setCopied] = useState(false)
+  const canRewind = onRewindToTurn !== undefined && turn.role === 'user'
+
+  const handleCopy = useCallback(async () => {
+    const ok = await copyText(turnPlainText(turn))
+    if (ok) {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    }
+  }, [turn])
+
+  return (
+    <>
+      <span
+        role="toolbar"
+        aria-label="Turn actions"
+        className="absolute -top-2.5 right-1 z-10 hidden items-center gap-0.5 rounded-md border border-border bg-popover p-0.5 shadow-md group-hover:inline-flex [@media(hover:none)]:!hidden"
+      >
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          aria-label="Copy turn"
+          title="Copy turn text"
+        >
+          {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
+        </button>
+        {canFork && onForkFromTurn ? (
+          <button
+            type="button"
+            onClick={() => onForkFromTurn(turn.turnId ?? turn.id)}
+            className="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            aria-label="Fork conversation from here"
+            title="Fork conversation from this turn"
+          >
+            <GitFork className="h-3 w-3" />
+          </button>
+        ) : null}
+        {canRewind ? (
+          <button
+            type="button"
+            onClick={() => onRewindToTurn?.(turn)}
+            className="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            aria-label="Rewind code to here"
+            title="Rewind code to the checkpoint taken when this message was sent"
+          >
+            <History className="h-3 w-3" />
+          </button>
+        ) : null}
+      </span>
+      {onOpenActions ? (
+        <button
+          type="button"
+          aria-label="Turn actions menu"
+          className="absolute right-0 top-0 z-10 hidden h-11 w-11 items-center justify-center rounded-md text-muted-foreground active:bg-accent [@media(hover:none)]:inline-flex"
+          onClick={(event) => {
+            event.stopPropagation()
+            onOpenActions(turn)
+          }}
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </button>
+      ) : null}
+    </>
+  )
+}
+
+type ContextMenuState = { x: number; y: number; turn: FreshAgentTurn } | null
+
+/**
+ * Floating right-click menu for fine pointers. Touch devices use
+ * FreshAgentActionSheet instead (same items via buildTurnActionItems).
+ */
+export function FreshAgentTurnContextMenu({
+  state,
+  canFork,
+  onForkFromTurn,
+  onRewindToTurn,
+  onClose,
+}: TurnActionCallbacks & {
+  state: ContextMenuState
+  onClose: () => void
+}) {
+  useEffect(() => {
+    if (!state) return
+    const handle = () => onClose()
+    document.addEventListener('click', handle)
+    document.addEventListener('contextmenu', handle)
+    return () => {
+      document.removeEventListener('click', handle)
+      document.removeEventListener('contextmenu', handle)
+    }
+  }, [onClose, state])
+
+  if (!state) return null
+
+  const items = buildTurnActionItems(state.turn, { canFork, onForkFromTurn, onRewindToTurn })
+
+  return (
+    <div
+      role="menu"
+      aria-label="Turn context menu"
+      className="fixed z-50 min-w-[220px] rounded-md border border-border bg-popover p-1 text-sm shadow-lg"
+      style={{
+        left: Math.min(state.x, typeof window !== 'undefined' ? window.innerWidth - 240 : state.x),
+        top: Math.min(state.y, typeof window !== 'undefined' ? window.innerHeight - 150 : state.y),
+      }}
+    >
+      {items.map((item) => (
+        <button
+          key={item.label}
+          type="button"
+          role="menuitem"
+          disabled={item.disabled}
+          className={cn(
+            'block w-full rounded px-3 py-1.5 text-left transition-colors',
+            item.disabled ? 'cursor-not-allowed opacity-40' : 'hover:bg-accent hover:text-accent-foreground',
+          )}
+          onClick={() => {
+            onClose()
+            if (!item.disabled) item.run()
+          }}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export type { ContextMenuState as FreshAgentTurnContextMenuState }

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { nanoid } from 'nanoid'
-import PermissionBanner from '@/components/agent-chat/PermissionBanner'
 import type { FreshAgentPaneContent } from '@/store/paneTypes'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { getWsClient } from '@/lib/ws-client'
-import { getFreshAgentThreadSnapshot } from '@/lib/api'
+import { api, getFreshAgentThreadSnapshot } from '@/lib/api'
 import { consumePaneRefreshRequest, mergePaneContent, updatePaneContent } from '@/store/panesSlice'
 import { clearPendingCreateFailure } from '@/store/freshAgentSlice'
 import { dismissTabGreen } from '@/store/turnCompletionAttention'
@@ -21,8 +20,15 @@ import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
 import type { FreshAgentSnapshot } from '@shared/fresh-agent-contract'
 import { getFreshAgentSlashCommands, type FreshAgentSlashCommand } from '@shared/fresh-agent-slash-commands'
 import { buildRestoreError, type RestoreErrorReason } from '@shared/session-contract'
+import {
+  checkpointLabelForText,
+  pickCheckpointForTurn,
+  type CheckpointEntry,
+} from '@/lib/fresh-agent-checkpoints'
+import type { FreshAgentTurn } from '@shared/fresh-agent-contract'
 import { finalizeCodingAgentSessionName } from '@/store/codingAgentNaming'
 import { FreshAgentApprovalBanner } from './FreshAgentApprovalBanner'
+import { FreshAgentApprovalCard } from './FreshAgentApprovalCard'
 import FreshAgentQuestionBanner from './FreshAgentQuestionBanner'
 import { FreshAgentTranscript } from './FreshAgentTranscript'
 import { FreshAgentComposer, type FreshAgentComposerHandle } from './FreshAgentComposer'
@@ -30,6 +36,7 @@ import { FreshAgentDiffPanel } from './FreshAgentDiffPanel'
 import { FreshAgentSidebar } from './FreshAgentSidebar'
 
 const EARLY_STATES = new Set(['creating', 'starting'])
+const BUSY_STATES = new Set(['running', 'compacting'])
 
 function getEffectiveFreshAgentModel(content: FreshAgentPaneContent): string | undefined {
   return normalizeFreshAgentModel(content.sessionType, content.provider, content.model)
@@ -65,7 +72,11 @@ function getFreshAgentSnapshotThreadId(
   claudeSession: Parameters<typeof getCanonicalDurableSessionId>[0],
 ): string | undefined {
   if (pane.provider === 'claude') {
-    return getCanonicalDurableSessionId(claudeSession) ?? getCanonicalPaneResumeSessionId(pane)
+    // Snapshot history is keyed by Claude's durable UUID. Runtime-only live
+    // handles stay interactive through the WS transport, but should not hit
+    // the snapshot route or surface history-load errors.
+    return getCanonicalDurableSessionId(claudeSession)
+      ?? getCanonicalPaneResumeSessionId(pane)
   }
   if (EARLY_STATES.has(pane.status)) {
     // While a new session is still being created, avoid reading an older durable ref.
@@ -143,6 +154,12 @@ function readCodexFork(value: unknown): { parentThreadId?: string } | undefined 
   }
 }
 
+function composeOutgoingText(text: string, attachmentPaths: string[]): string {
+  if (attachmentPaths.length === 0) return text
+  const list = attachmentPaths.map((path) => `- ${path}`).join('\n')
+  return `${text ? `${text}\n\n` : ''}Attached files (read them from disk):\n${list}`
+}
+
 export function FreshAgentView({
   tabId,
   paneId,
@@ -170,17 +187,54 @@ export function FreshAgentView({
     })
     return state.freshAgent.sessions[sessionKey] ?? state.agentChat.sessions[paneContent.sessionId]
   })
+  // Provider-agnostic session meta: codex/opencode status and errors flow
+  // through the freshAgent slice too, but the claudeSession selector above is
+  // claude-only — without this, a dead codex/opencode process left the pane
+  // looking healthy (blank pane, enabled composer).
+  const agentSessionMeta = useAppSelector((state) => {
+    if (!paneContent.sessionId) return undefined
+    const sessionKey = makeFreshAgentSessionKey({
+      sessionId: paneContent.sessionId,
+      sessionType: paneContent.sessionType,
+      provider: paneContent.provider,
+    })
+    const session = state.freshAgent.sessions[sessionKey]
+    if (!session) return undefined
+    return {
+      status: session.status as string | undefined,
+      lastError: (session as { lastError?: string }).lastError,
+    }
+  })
   const refreshRequest = useAppSelector((state) => state.panes.refreshRequestsByPane?.[tabId]?.[paneId] ?? null)
   const [snapshot, setSnapshot] = useState<FreshAgentSnapshot | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [snapshotRefreshNonce, setSnapshotRefreshNonce] = useState(0)
+  const [queuedMessages, setQueuedMessages] = useState<string[]>([])
+  // Transient, self-clearing banner for action feedback (rewind, shell errors).
+  const [notice, setNotice] = useState<string | null>(null)
+  // Optimistic echo of the just-sent user message: the transcript renders
+  // snapshot turns only, which left a 2-10s blank gap after send
+  // (live-test finding). Cleared when a snapshot containing the turn lands.
+  const [localEcho, setLocalEcho] = useState<string | null>(null)
+  const localEchoRef = useRef<string | null>(null)
+  localEchoRef.current = localEcho
   const descriptor = resolveFreshAgentType(paneContent.sessionType)
-  const slashCommands = useMemo(() => getFreshAgentSlashCommands(paneContent.sessionType), [paneContent.sessionType])
+  // Capability-gated commands (e.g. /fork) only appear once the snapshot
+  // confirms the provider supports the action.
+  const slashCommands = useMemo(() => (
+    getFreshAgentSlashCommands(paneContent.sessionType).filter((command) => (
+      command.requiresCapability
+        ? snapshot?.capabilities?.[command.requiresCapability] === true
+        : true
+    ))
+  ), [paneContent.sessionType, snapshot?.capabilities])
   const paneContentRef = useRef(paneContent)
   const composerRef = useRef<FreshAgentComposerHandle | null>(null)
   paneContentRef.current = paneContent
   const restoreTimeoutRef = useRef<number | null>(null)
   const createSentRef = useRef(false)
+  // Session-scoped "always allow" tool names; reset with the pane, never persisted.
+  const alwaysAllowToolsRef = useRef<Set<string>>(new Set())
   // Auto-title state tracks four things:
   // 1. whether this mounted pane has already consumed first-message auto-title,
   // 2. whether we observed a fresh conversation boundary in this mount,
@@ -351,6 +405,9 @@ export function FreshAgentView({
     }
     setSnapshot(null)
     setLoadError(null)
+    setQueuedMessages([])
+    setLocalEcho(null)
+    alwaysAllowToolsRef.current.clear()
     dispatch(updatePaneContent({
       tabId,
       paneId,
@@ -367,6 +424,23 @@ export function FreshAgentView({
     }))
   }, [dispatch, paneId, sendFreshAgentMessage, tabId])
 
+  const sendFork = useCallback((atTurnId?: string) => {
+    const current = paneContentRef.current
+    if (!current.sessionId) return
+    // The freshAgent.forked broadcast is matched on createRequestId +
+    // parentSessionId by the listener below, which repoints this pane at
+    // the forked session. atTurnId is best-effort: providers that can't
+    // fork mid-thread fork from the tip.
+    sendFreshAgentMessage({
+      type: 'freshAgent.fork',
+      requestId: current.createRequestId,
+      sessionId: current.sessionId,
+      sessionType: current.sessionType,
+      provider: current.provider,
+      ...(atTurnId ? { input: { atTurnId } } : {}),
+    })
+  }, [sendFreshAgentMessage])
+
   const runSlashCommand = useCallback((command: FreshAgentSlashCommand, args: string) => {
     const current = paneContentRef.current
     if (command.action === 'new') {
@@ -382,8 +456,12 @@ export function FreshAgentView({
         provider: current.provider,
         ...(args ? { instructions: args } : {}),
       })
+      return
     }
-  }, [sendFreshAgentMessage, startNewConversation])
+    if (command.action === 'fork') {
+      sendFork()
+    }
+  }, [sendFork, sendFreshAgentMessage, startNewConversation])
 
   useEffect(() => {
     if (!refreshRequest) return
@@ -635,6 +713,16 @@ export function FreshAgentView({
         }
         setSnapshot(resolved)
         setSnapshotAutoTitleIdentity(requestAutoTitleIdentity)
+        const echo = localEchoRef.current
+        if (echo) {
+          const needle = echo.slice(0, 80)
+          const echoLanded = resolved.turns.some((turn) => (
+            turn.role === 'user' && turn.items.some((item) => (
+              item.kind === 'text' && item.text.includes(needle)
+            ))
+          ))
+          if (echoLanded) setLocalEcho(null)
+        }
         const fresh = paneContentRef.current
         const nextStatus = (resolved.status as FreshAgentPaneContent['status']) ?? fresh.status
         const snapshotSessionRef = provider === 'opencode' && resolved.sessionId && resolved.sessionId !== sessionId
@@ -667,7 +755,10 @@ export function FreshAgentView({
       .catch((error: unknown) => {
         if (error instanceof Error && error.name === 'AbortError') return
         if (isStaleSnapshotRequest()) return
-        if (paneContent.provider === 'claude' && claudeSession) {
+        if (paneContent.provider === 'claude' && claudeSession && isRestoring) {
+          // While a restore is in flight the snapshot legitimately 404s.
+          // Outside of restore, swallowing here left dead Claude sessions as
+          // silent blank panes (live-test finding) — let the error surface.
           setLoadError(null)
           return
         }
@@ -791,6 +882,165 @@ export function FreshAgentView({
     triggerRecovery,
   ])
 
+  const effectiveStatus = paneContent.provider === 'claude'
+    ? (claudeSessionStatus ?? paneContent.status)
+    : (agentSessionMeta?.status ?? paneContent.status)
+  const isBusy = BUSY_STATES.has(effectiveStatus)
+  const sessionEnded = effectiveStatus === 'exited' || effectiveStatus === 'create-failed'
+  const sessionErrorMessage = agentSessionMeta?.lastError ?? null
+
+  // Fallback poll while the agent is (or claims to be) working: if a
+  // transport event is missed, the pane self-heals within a few seconds
+  // instead of stranding on an empty turn with a stop button.
+  useEffect(() => {
+    if (hidden || !paneContent.sessionId) return
+    if (!isBusy && !EARLY_STATES.has(effectiveStatus)) return
+    const timer = window.setInterval(() => {
+      setSnapshotRefreshNonce((value) => value + 1)
+    }, 3000)
+    return () => window.clearInterval(timer)
+  }, [effectiveStatus, hidden, isBusy, paneContent.sessionId])
+
+  useEffect(() => {
+    if (!notice) return
+    const timer = window.setTimeout(() => setNotice(null), 6000)
+    return () => window.clearTimeout(timer)
+  }, [notice])
+
+  /** Core outgoing-message path shared by direct sends and queue flushes. */
+  const sendUserText = useCallback((text: string) => {
+    const current = paneContentRef.current
+    if (!current.sessionId) return
+    // Checkpoint the working tree before the agent acts on this message, so
+    // "rewind code to here" on this turn restores the pre-turn state. Fire and
+    // forget: a failed snapshot must never block the send.
+    if (current.initialCwd) {
+      void Promise
+        .resolve(api.post('/api/fresh-agent/checkpoints', {
+          cwd: current.initialCwd,
+          label: checkpointLabelForText(text),
+        }))
+        .catch(() => { /* surfaced lazily when a rewind finds no checkpoint */ })
+    }
+    const isFirstMessage = !autoTitleSentRef.current
+      && (autoTitleFreshBoundaryRef.current || snapshotConfirmsNoUserTurns)
+    if (isFirstMessage) {
+      autoTitleFreshBoundaryRef.current = false
+      autoTitleSentRef.current = true
+      dispatch(finalizeCodingAgentSessionName({
+        tabId,
+        paneId,
+        provider: current.provider,
+        sessionId: current.sessionId,
+        firstMessage: text,
+      }))
+    }
+    sendFreshAgentMessage({
+      type: 'freshAgent.send',
+      sessionId: current.sessionId,
+      sessionType: current.sessionType,
+      provider: current.provider,
+      text,
+      settings: {
+        ...(current.initialCwd ? { cwd: current.initialCwd } : {}),
+        ...(getEffectiveFreshAgentModel(current) ? { model: getEffectiveFreshAgentModel(current) } : {}),
+        ...(getEffectiveFreshAgentPermissionMode(current) ? { permissionMode: getEffectiveFreshAgentPermissionMode(current) } : {}),
+        ...(current.sandbox ? { sandbox: current.sandbox } : {}),
+        ...(getEffectiveFreshAgentEffort(current) ? { effort: getEffectiveFreshAgentEffort(current) } : {}),
+      },
+    })
+    setLocalEcho(text)
+  }, [dispatch, paneId, sendFreshAgentMessage, snapshotConfirmsNoUserTurns, tabId])
+
+  // Flush queued messages when the turn ends. One flush per status change is
+  // enough: all queued entries are delivered in order for the next turn.
+  useEffect(() => {
+    if (isBusy || queuedMessages.length === 0) return
+    if (!paneContentRef.current.sessionId) return
+    const toSend = queuedMessages
+    setQueuedMessages([])
+    for (const message of toSend) {
+      sendUserText(message)
+    }
+  }, [isBusy, queuedMessages, sendUserText])
+
+  // Session-scoped auto-approval: any pending approval whose tool the user
+  // marked "always allow" is answered immediately.
+  const pendingApprovalsFromSnapshot = snapshot?.pendingApprovals
+  useEffect(() => {
+    if (!pendingApprovalsFromSnapshot || pendingApprovalsFromSnapshot.length === 0) return
+    const current = paneContentRef.current
+    if (!current.sessionId) return
+    for (const approval of pendingApprovalsFromSnapshot) {
+      if (approval.toolName && alwaysAllowToolsRef.current.has(approval.toolName)) {
+        sendFreshAgentMessage({
+          type: 'freshAgent.approval.respond',
+          sessionId: current.sessionId,
+          sessionType: current.sessionType,
+          provider: current.provider,
+          requestId: approval.requestId,
+          decision: { behavior: 'allow', updatedInput: {} },
+        })
+      }
+    }
+  }, [pendingApprovalsFromSnapshot, sendFreshAgentMessage])
+
+  /** `!command` shell escape: run via the extras endpoint, then hand the
+   * command + output to the agent as explicit user-provided context. */
+  const runShellCommand = useCallback((command: string) => {
+    const current = paneContentRef.current
+    void Promise
+      .resolve(api.post<{ output: string; exitCode: number | null; truncated: boolean }>(
+        '/api/fresh-agent/exec',
+        { command, cwd: current.initialCwd },
+      ))
+      .then((result) => {
+        const status = result.exitCode === 0 ? '' : ` (exit ${result.exitCode})`
+        const body = `I ran \`${command}\`${status} in ${current.initialCwd ?? 'the home directory'}. Output:\n\`\`\`\n${result.output || '(no output)'}\n\`\`\``
+        if (isBusy) {
+          setQueuedMessages((queue) => [...queue, body])
+        } else {
+          sendUserText(body)
+        }
+      })
+      .catch((error: unknown) => {
+        setNotice(error instanceof Error ? `Shell command failed: ${error.message}` : 'Shell command failed')
+      })
+  }, [isBusy, sendUserText])
+
+  /** Rewind the working tree to the checkpoint taken when a user turn was
+   * sent. Conversation history is untouched — this is the code half of
+   * rewind; fork-from-turn covers the conversation half. */
+  const rewindToTurn = useCallback((turn: FreshAgentTurn) => {
+    const current = paneContentRef.current
+    if (!current.initialCwd) {
+      setNotice('Rewind unavailable: this session has no working directory.')
+      return
+    }
+    const cwd = current.initialCwd
+    void Promise
+      .resolve(api.get<{ checkpoints: CheckpointEntry[] }>(
+        `/api/fresh-agent/checkpoints?cwd=${encodeURIComponent(cwd)}`,
+      ))
+      .then((result) => {
+        const checkpoint = pickCheckpointForTurn(result?.checkpoints ?? [], snapshot?.turns ?? [], turn)
+        if (!checkpoint) {
+          setNotice('No checkpoint found for that message (it may predate checkpointing).')
+          return
+        }
+        const confirmed = typeof window === 'undefined' || window.confirm(
+          `Rewind code to the state before "${checkpoint.label}"?\n\nTracked files changed since will be overwritten. Files created since are left in place. The conversation is not affected.`,
+        )
+        if (!confirmed) return
+        return Promise
+          .resolve(api.post('/api/fresh-agent/checkpoints/restore', { cwd, id: checkpoint.id }))
+          .then(() => setNotice(`Code rewound to before: "${checkpoint.label}"`))
+      })
+      .catch((error: unknown) => {
+        setNotice(error instanceof Error ? `Rewind failed: ${error.message}` : 'Rewind failed')
+      })
+  }, [snapshot?.turns])
+
   const content = useMemo(() => {
     const turns = snapshot?.turns ?? []
     const pendingApprovals = snapshot?.pendingApprovals ?? []
@@ -800,21 +1050,26 @@ export function FreshAgentView({
     const diffs = snapshot?.diffs ?? []
     const codexReview = readCodexReview(snapshot?.extensions?.codex?.review)
     const codexFork = readCodexFork(snapshot?.extensions?.codex?.fork)
-    const effectiveStatus = paneContent.provider === 'claude'
-      ? (claudeSessionStatus ?? paneContent.status)
-      : paneContent.status
-    const canSend = snapshot?.capabilities?.send === true || (
+    // sessionEnded gates everything: a stale snapshot can still claim
+    // capabilities.send after the provider process died.
+    const canSend = !sessionEnded && (snapshot?.capabilities?.send === true || (
       paneContent.provider === 'claude'
       && Boolean(paneContent.sessionId)
       && !isRestoring
       && !hasRestoreFailure
       && !['creating', 'starting', 'create-failed', 'exited'].includes(effectiveStatus)
-    )
+    ))
     const canInterrupt = snapshot?.capabilities?.interrupt === true || (
       paneContent.provider === 'claude'
       && Boolean(paneContent.sessionId)
       && ['connected', 'running', 'idle', 'compacting'].includes(effectiveStatus)
     )
+    const canFork = snapshot?.capabilities?.fork === true
+    // Providers report capabilities.send=false WHILE BUSY — that must not
+    // disable the composer, or queueing becomes unreachable for codex and
+    // opencode (live-test finding). Disabled = no session, ended, or truly
+    // read-only when idle.
+    const composerDisabled = !paneContent.sessionId || sessionEnded || (!canSend && !isBusy)
     const questionAgentLabel = getQuestionAgentLabel(paneContent, descriptor?.label)
     const visibleRestoreFailure = paneContent.provider === 'claude'
       ? claudeSession?.restoreFailureMessage
@@ -830,6 +1085,20 @@ export function FreshAgentView({
         sessionId: paneContent.sessionId,
         sessionType: paneContent.sessionType,
         provider: paneContent.provider,
+      })
+    }
+    const respondToApproval = (requestId: string | number, allow: boolean) => {
+      dispatch(dismissTabGreen(tabId))
+      if (!paneContent.sessionId) return
+      sendFreshAgentMessage({
+        type: 'freshAgent.approval.respond',
+        sessionId: paneContent.sessionId,
+        sessionType: paneContent.sessionType,
+        provider: paneContent.provider,
+        requestId,
+        decision: allow
+          ? { behavior: 'allow', updatedInput: {} }
+          : { behavior: 'deny', message: 'Denied by user', interrupt: false },
       })
     }
 
@@ -882,41 +1151,31 @@ export function FreshAgentView({
               {visibleRestoreFailure ? <FreshAgentApprovalBanner text={visibleRestoreFailure} /> : null}
               {visiblePaneRestoreFailure ? <FreshAgentApprovalBanner text={visiblePaneRestoreFailure} /> : null}
               {visibleLoadError ? <FreshAgentApprovalBanner text={visibleLoadError} /> : null}
+              {sessionErrorMessage ? <FreshAgentApprovalBanner text={`Agent error: ${sessionErrorMessage}`} /> : null}
+              {sessionEnded ? (
+                <div className="flex items-center justify-between gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm">
+                  <span>This session has ended{sessionErrorMessage ? '' : ' (the agent process exited)'}.</span>
+                  <button
+                    type="button"
+                    className="shrink-0 rounded border border-border/70 px-2 py-1 text-xs"
+                    onClick={startNewConversation}
+                  >
+                    Start new session
+                  </button>
+                </div>
+              ) : null}
+              {notice ? <FreshAgentApprovalBanner text={notice} /> : null}
               {pendingApprovals.map((approval) => (
-                <PermissionBanner
+                <FreshAgentApprovalCard
                   key={String(approval.requestId)}
-                  permission={{
-                    requestId: String(approval.requestId),
-                    subtype: 'can_use_tool',
-                    tool: approval.toolName
-                      ? { name: approval.toolName, input: approval.input }
-                      : undefined,
-                  }}
-                  onAllow={() => {
-                    dispatch(dismissTabGreen(tabId))
-                    if (!paneContent.sessionId) return
-                    sendFreshAgentMessage({
-                      type: 'freshAgent.approval.respond',
-                      sessionId: paneContent.sessionId,
-                      sessionType: paneContent.sessionType,
-                      provider: paneContent.provider,
-                      requestId: approval.requestId,
-                      decision: { behavior: 'allow', updatedInput: {} },
-                    })
-                  }}
-                  onDeny={() => {
-                    dispatch(dismissTabGreen(tabId))
-                    if (!paneContent.sessionId) return
-                    sendFreshAgentMessage({
-                      type: 'freshAgent.approval.respond',
-                      sessionId: paneContent.sessionId,
-                      sessionType: paneContent.sessionType,
-                      provider: paneContent.provider,
-                      requestId: approval.requestId,
-                      decision: { behavior: 'deny', message: 'Denied by user', interrupt: false },
-                    })
-                  }}
+                  approval={approval}
                   disabled={!paneContent.sessionId}
+                  onAllow={() => respondToApproval(approval.requestId, true)}
+                  onAlwaysAllow={(toolName) => {
+                    alwaysAllowToolsRef.current.add(toolName)
+                    respondToApproval(approval.requestId, true)
+                  }}
+                  onDeny={() => respondToApproval(approval.requestId, false)}
                 />
               ))}
               {pendingQuestions.map((question) => (
@@ -947,47 +1206,64 @@ export function FreshAgentView({
                   disabled={!paneContent.sessionId}
                 />
               ))}
-              <FreshAgentDiffPanel diffs={diffs} />
+              <FreshAgentDiffPanel
+                diffs={diffs}
+                cwd={paneContent.initialCwd}
+                onComment={(text) => composerRef.current?.insertText(text)}
+              />
             </div>
-            <FreshAgentTranscript turns={turns} />
+            <FreshAgentTranscript
+              turns={localEcho
+                ? [...turns, {
+                    id: '__local-echo',
+                    turnId: '__local-echo',
+                    role: 'user',
+                    summary: localEcho,
+                    items: [{ id: '__local-echo-item', kind: 'text', text: localEcho }],
+                  } as FreshAgentTurn]
+                : turns}
+              canFork={canFork}
+              onForkFromTurn={(turnId) => sendFork(turnId)}
+              onRewindToTurn={paneContent.initialCwd ? rewindToTurn : undefined}
+            />
             <FreshAgentComposer
               ref={composerRef}
-              disabled={!canSend || !paneContent.sessionId}
+              disabled={composerDisabled}
+              placeholder={
+                sessionEnded
+                  ? 'Session ended — start a new one above or via the ⌘ menu'
+                  : !paneContent.sessionId || EARLY_STATES.has(effectiveStatus)
+                    ? 'Starting session…'
+                    : isBusy
+                      ? 'Agent is working — sends queue for the next turn'
+                      : !canSend
+                        ? 'Read-only session'
+                        : undefined
+              }
               storageKey={`fresh-agent-draft:${paneContent.sessionType}:${paneContent.sessionId ?? paneContent.createRequestId}`}
+              historyKey={`fresh-agent-prompt-history:${paneContent.sessionType}`}
+              cwd={paneContent.initialCwd}
+              provider={paneContent.provider}
+              queuedMessages={queuedMessages}
+              onCancelQueued={(index) => {
+                setQueuedMessages((queue) => queue.filter((_, i) => i !== index))
+              }}
               canInterrupt={canInterrupt && Boolean(paneContent.sessionId)}
               onInterrupt={sendInterrupt}
               commands={slashCommands}
               onCommand={runSlashCommand}
-              onSend={(text) => {
+              onShellCommand={runShellCommand}
+              onSend={(text, attachmentPaths) => {
                 dispatch(dismissTabGreen(tabId))
-                if (!paneContent.sessionId || !canSend) return
-                const isFirstMessage = !autoTitleSentRef.current
-                  && (autoTitleFreshBoundaryRef.current || snapshotConfirmsNoUserTurns)
-                if (isFirstMessage) {
-                  autoTitleFreshBoundaryRef.current = false
-                  autoTitleSentRef.current = true
-                  dispatch(finalizeCodingAgentSessionName({
-                    tabId,
-                    paneId,
-                    provider: paneContent.provider,
-                    sessionId: paneContent.sessionId,
-                    firstMessage: text,
-                  }))
+                if (!paneContent.sessionId || sessionEnded) return
+                if (!canSend && !isBusy) return
+                const outgoing = composeOutgoingText(text, attachmentPaths)
+                if (!outgoing) return
+                if (isBusy) {
+                  setQueuedMessages((queue) => [...queue, outgoing])
+                  return
                 }
-                sendFreshAgentMessage({
-                  type: 'freshAgent.send',
-                  sessionId: paneContent.sessionId,
-                  sessionType: paneContent.sessionType,
-                  provider: paneContent.provider,
-                  text,
-                  settings: {
-                    ...(paneContent.initialCwd ? { cwd: paneContent.initialCwd } : {}),
-                    ...(getEffectiveFreshAgentModel(paneContent) ? { model: getEffectiveFreshAgentModel(paneContent) } : {}),
-                    ...(getEffectiveFreshAgentPermissionMode(paneContent) ? { permissionMode: getEffectiveFreshAgentPermissionMode(paneContent) } : {}),
-                    ...(paneContent.sandbox ? { sandbox: paneContent.sandbox } : {}),
-                    ...(getEffectiveFreshAgentEffort(paneContent) ? { effort: getEffectiveFreshAgentEffort(paneContent) } : {}),
-                  },
-                })
+                sendUserText(outgoing)
               }}
             />
           </div>
@@ -1002,19 +1278,30 @@ export function FreshAgentView({
     )
   }, [
     claudeSession?.restoreFailureMessage,
-    claudeSessionStatus,
     descriptor?.label,
+    effectiveStatus,
     hasRestoreFailure,
+    isBusy,
     isRestoring,
     loadError,
+    localEcho,
+    notice,
     paneContent,
     pendingCreateFailure,
+    queuedMessages,
+    rewindToTurn,
+    runShellCommand,
+    sessionEnded,
+    sessionErrorMessage,
+    startNewConversation,
     runSlashCommand,
-    snapshotConfirmsNoUserTurns,
+    sendFork,
+    sendUserText,
     snapshot,
     slashCommands,
     dispatch,
     paneId,
+    sendFreshAgentMessage,
     tabId,
     tabTitleSetByUser,
   ])

--- a/src/components/panes/PaneHeader.tsx
+++ b/src/components/panes/PaneHeader.tsx
@@ -1,11 +1,15 @@
 import { useRef, useEffect } from 'react'
-import { X, Maximize2, Minimize2, Search, RefreshCw } from 'lucide-react'
+import { X, Maximize2, Minimize2, Search, RefreshCw, SquareTerminal } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { getTerminalStatusIconClassName } from '@/lib/terminal-status-indicator'
 import type { TerminalStatus } from '@/store/types'
 import type { PaneContent } from '@/store/paneTypes'
+import { useAppDispatch } from '@/store/hooks'
+import { splitPane } from '@/store/panesSlice'
 import PaneIcon from '@/components/icons/PaneIcon'
 import FreshAgentSettingsButton from '@/components/fresh-agent/FreshAgentSettingsButton'
+import FreshAgentContextMeter from '@/components/fresh-agent/FreshAgentContextMeter'
+import { getFreshAgentLabel } from '@/lib/fresh-agent-registry'
 
 interface PaneHeaderProps {
   tabId?: string
@@ -30,6 +34,45 @@ interface PaneHeaderProps {
   onDoubleClick?: () => void
   onSearch?: () => void
   onRefresh?: () => void
+}
+
+function FreshAgentOpenTerminalButton({
+  tabId,
+  paneId,
+  content,
+}: {
+  tabId: string
+  paneId: string
+  content: Extract<PaneContent, { kind: 'fresh-agent' }>
+}) {
+  const dispatch = useAppDispatch()
+
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation()
+        // normalizePaneContent fills createRequestId/status for terminal
+        // inputs; mode 'shell' + cwd is a complete input.
+        dispatch(splitPane({
+          tabId,
+          paneId,
+          direction: 'horizontal',
+          newContent: {
+            kind: 'terminal',
+            mode: 'shell',
+            ...(content.initialCwd ? { initialCwd: content.initialCwd } : {}),
+          } as Parameters<typeof splitPane>[0]['newContent'],
+        }))
+      }}
+      className="inline-flex h-6 w-6 items-center justify-center rounded opacity-60 hover:opacity-100 transition-opacity sm:h-4 sm:w-4"
+      title={content.initialCwd
+        ? `Open terminal pane at ${content.initialCwd}`
+        : 'Open terminal pane at this session’s directory'}
+      aria-label="Open terminal at session directory"
+    >
+      <SquareTerminal className="h-[18px] w-[18px] sm:h-3 sm:w-3" />
+    </button>
+  )
 }
 
 export default function PaneHeader({
@@ -144,11 +187,25 @@ export default function PaneHeader({
         )}
 
         {content.kind === 'fresh-agent' && (
-          <FreshAgentSettingsButton
-            tabId={tabId}
-            paneId={paneId}
-            paneContent={content}
-          />
+          <>
+            {/* Cwd/prompt-derived titles make the three fresh clients look
+                identical — pin the agent identity in the header. */}
+            <span
+              className="shrink-0 rounded-full border border-border/70 px-2 py-0.5 text-2xs text-muted-foreground"
+              title={`${getFreshAgentLabel(content.sessionType)} session`}
+            >
+              {getFreshAgentLabel(content.sessionType)}
+            </span>
+            <FreshAgentContextMeter paneContent={content} />
+            {tabId && paneId ? (
+              <FreshAgentOpenTerminalButton tabId={tabId} paneId={paneId} content={content} />
+            ) : null}
+            <FreshAgentSettingsButton
+              tabId={tabId}
+              paneId={paneId}
+              paneContent={content}
+            />
+          </>
         )}
 
         {onToggleZoom && (

--- a/src/lib/fresh-agent-checkpoints.ts
+++ b/src/lib/fresh-agent-checkpoints.ts
@@ -1,0 +1,50 @@
+import type { FreshAgentTurn } from '@shared/fresh-agent-contract'
+
+export type CheckpointEntry = { id: string; ts: number; label: string }
+
+export const CHECKPOINT_LABEL_LIMIT = 120
+
+export function checkpointLabelForText(text: string): string {
+  const flat = text.replace(/\s+/g, ' ').trim()
+  return (flat || 'checkpoint').slice(0, CHECKPOINT_LABEL_LIMIT)
+}
+
+function turnLabel(turn: FreshAgentTurn): string {
+  const text = turn.items
+    .filter((item): item is Extract<FreshAgentTurn['items'][number], { kind: 'text' }> => item.kind === 'text')
+    .map((item) => item.text)
+    .join('\n\n')
+  return checkpointLabelForText(text || turn.summary || '')
+}
+
+/**
+ * Match a user turn to its checkpoint. Checkpoints are created at send time
+ * with the outgoing text as label, so the k-th user turn bearing a given label
+ * corresponds to the k-th oldest checkpoint with that label. Returns null when
+ * no checkpoint matches (e.g. turns sent before this feature existed).
+ */
+export function pickCheckpointForTurn(
+  checkpoints: readonly CheckpointEntry[],
+  turns: readonly FreshAgentTurn[],
+  target: FreshAgentTurn,
+): CheckpointEntry | null {
+  if (target.role !== 'user') return null
+  const label = turnLabel(target)
+  if (!label) return null
+
+  let ordinal = 0
+  for (const turn of turns) {
+    if (turn.role !== 'user') continue
+    if (turnLabel(turn) === label) {
+      if (turn.id === target.id) break
+      ordinal += 1
+    }
+  }
+
+  // git log order is newest-first; we need oldest-first to index by ordinal.
+  const matches = checkpoints
+    .filter((entry) => entry.label === label)
+    .slice()
+    .reverse()
+  return matches[ordinal] ?? null
+}

--- a/src/lib/pointer.ts
+++ b/src/lib/pointer.ts
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react'
+
+const COARSE_QUERY = '(pointer: coarse)'
+
+/**
+ * True when the primary pointer is coarse (finger). Capability-based, not
+ * width-based: an iPad with a trackpad reports fine; a narrow desktop window
+ * reports fine; phones report coarse. Guarded for jsdom/SSR (no matchMedia →
+ * fine pointer, so existing desktop-oriented tests are unaffected).
+ */
+export function isCoarsePointer(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  try {
+    return window.matchMedia(COARSE_QUERY).matches
+  } catch {
+    return false
+  }
+}
+
+/** Reactive variant of isCoarsePointer — follows input-device changes
+ * (e.g. attaching a mouse to a tablet). */
+export function useCoarsePointer(): boolean {
+  const [coarse, setCoarse] = useState(isCoarsePointer)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    let media: MediaQueryList
+    try {
+      media = window.matchMedia(COARSE_QUERY)
+    } catch {
+      return
+    }
+    const onChange = () => setCoarse(media.matches)
+    onChange()
+    // Older WebKit shipped addListener only.
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', onChange)
+      return () => media.removeEventListener('change', onChange)
+    }
+    media.addListener(onChange)
+    return () => media.removeListener(onChange)
+  }, [])
+
+  return coarse
+}
+
+export const LONG_PRESS_MS = 450
+export const LONG_PRESS_MOVE_TOLERANCE_PX = 10
+
+type LongPressHandlers<T extends HTMLElement> = {
+  onTouchStart: (event: React.TouchEvent<T>) => void
+  onTouchMove: (event: React.TouchEvent<T>) => void
+  onTouchEnd: () => void
+  onTouchCancel: () => void
+}
+
+/**
+ * Build long-press touch handlers (no hook state — timer lives in a closure
+ * owned by the caller's ref object so one instance can serve many elements).
+ * Cancels on scroll/drag: any movement beyond the tolerance aborts the press.
+ */
+export function buildLongPressHandlers<T extends HTMLElement>(
+  callback: (event: { clientX: number; clientY: number }) => void,
+): LongPressHandlers<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let startX = 0
+  let startY = 0
+
+  const cancel = () => {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  return {
+    onTouchStart: (event) => {
+      if (event.touches.length !== 1) return
+      const touch = event.touches[0]
+      startX = touch.clientX
+      startY = touch.clientY
+      cancel()
+      timer = setTimeout(() => {
+        timer = null
+        callback({ clientX: startX, clientY: startY })
+      }, LONG_PRESS_MS)
+    },
+    onTouchMove: (event) => {
+      if (timer === null) return
+      const touch = event.touches[0]
+      if (!touch) return
+      const dx = Math.abs(touch.clientX - startX)
+      const dy = Math.abs(touch.clientY - startY)
+      if (dx > LONG_PRESS_MOVE_TOLERANCE_PX || dy > LONG_PRESS_MOVE_TOLERANCE_PX) cancel()
+    },
+    onTouchEnd: cancel,
+    onTouchCancel: cancel,
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -53,11 +53,21 @@ export default {
       },
       animation: {
         'pulse-subtle': 'pulse-subtle 2s ease-in-out infinite',
+        'reel-out': 'reel-out 150ms ease-out forwards',
+        'reel-in': 'reel-in 150ms ease-out forwards',
       },
       keyframes: {
         'pulse-subtle': {
           '0%, 100%': { opacity: 1 },
           '50%': { opacity: 0.7 },
+        },
+        'reel-out': {
+          '0%': { transform: 'translateY(0)', opacity: 1 },
+          '100%': { transform: 'translateY(-100%)', opacity: 0 },
+        },
+        'reel-in': {
+          '0%': { transform: 'translateY(100%)' },
+          '100%': { transform: 'translateY(0)' },
         },
       },
     },

--- a/test/integration/server/test-coordinator.test.ts
+++ b/test/integration/server/test-coordinator.test.ts
@@ -541,7 +541,11 @@ describe('test coordinator CLI', () => {
 
       expect((await waitForExit(holder)).code).toBe(0)
 
-      const activeHolder = await waitForHolder(fixture.storeDir, (holder) => holder.entrypoint.commandKey === commandKey)
+      const activeHolder = await waitForHolder(
+        fixture.storeDir,
+        (holder) => holder.entrypoint.commandKey === commandKey,
+        15_000,
+      )
       expect(activeHolder).toMatchObject({
         entrypoint: {
           commandKey,

--- a/test/server/fresh-agent-extras.test.ts
+++ b/test/server/fresh-agent-extras.test.ts
@@ -1,0 +1,263 @@
+import { afterAll, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import * as fsp from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { createFreshAgentExtrasRouter } from '../../server/fresh-agent-extras-router.js'
+
+function makeApp() {
+  const app = express()
+  app.use('/api/fresh-agent', createFreshAgentExtrasRouter())
+  return app
+}
+
+const createdPaths: string[] = []
+afterAll(async () => {
+  await Promise.all(createdPaths.map((p) => fsp.rm(p, { force: true, recursive: true })))
+})
+
+describe('fresh-agent extras router', () => {
+  describe('POST /attachments', () => {
+    it('saves a raw binary attachment and returns its path', async () => {
+      const res = await request(makeApp())
+        .post('/api/fresh-agent/attachments')
+        .query({ name: 'note.txt' })
+        .set('Content-Type', 'application/octet-stream')
+        .send(Buffer.from('hello attachment'))
+        .expect(200)
+
+      expect(res.body.path).toContain('note.txt')
+      expect(res.body.bytes).toBe('hello attachment'.length)
+      createdPaths.push(res.body.path)
+      const saved = await fsp.readFile(res.body.path, 'utf8')
+      expect(saved).toBe('hello attachment')
+    })
+
+    it('sanitizes hostile filenames', async () => {
+      const res = await request(makeApp())
+        .post('/api/fresh-agent/attachments')
+        .query({ name: '../../etc/passwd' })
+        .set('Content-Type', 'application/octet-stream')
+        .send(Buffer.from('x'))
+        .expect(200)
+
+      createdPaths.push(res.body.path)
+      expect(path.dirname(res.body.path)).toBe(path.join(os.homedir(), '.freshell', 'attachments'))
+      expect(path.basename(res.body.path)).not.toContain('..')
+    })
+
+    it('rejects a missing name and an empty body', async () => {
+      await request(makeApp())
+        .post('/api/fresh-agent/attachments')
+        .set('Content-Type', 'application/octet-stream')
+        .send(Buffer.alloc(0))
+        .expect(400)
+      await request(makeApp())
+        .post('/api/fresh-agent/attachments')
+        .query({ name: 'x.txt' })
+        .set('Content-Type', 'application/octet-stream')
+        .send(Buffer.alloc(0))
+        .expect(400)
+    })
+
+    it('accepts multi-megabyte uploads through a production-shaped app (global 1mb JSON parser)', async () => {
+      // Regression guard: server/index.ts mounts express.json({limit:'1mb'})
+      // globally before this router. Raw octet-stream bodies must bypass it.
+      const app = express()
+      app.use(express.json({ limit: '1mb' }))
+      app.use('/api/fresh-agent', createFreshAgentExtrasRouter())
+
+      const big = Buffer.alloc(2 * 1024 * 1024, 7)
+      const res = await request(app)
+        .post('/api/fresh-agent/attachments')
+        .query({ name: 'big.bin' })
+        .set('Content-Type', 'application/octet-stream')
+        .send(big)
+        .expect(200)
+
+      createdPaths.push(res.body.path)
+      expect(res.body.bytes).toBe(big.byteLength)
+    })
+  })
+
+  describe('POST /exec', () => {
+    it('runs a command in the given cwd and returns output', async () => {
+      const res = await request(makeApp())
+        .post('/api/fresh-agent/exec')
+        .send({ command: 'echo hello-exec && pwd', cwd: os.tmpdir() })
+        .expect(200)
+
+      expect(res.body.output).toContain('hello-exec')
+      expect(res.body.exitCode).toBe(0)
+    })
+
+    it('reports non-zero exit codes with output', async () => {
+      const res = await request(makeApp())
+        .post('/api/fresh-agent/exec')
+        .send({ command: 'echo to-stderr >&2; exit 3', cwd: os.tmpdir() })
+        .expect(200)
+
+      expect(res.body.output).toContain('to-stderr')
+      expect(res.body.exitCode).toBe(3)
+    })
+
+    it('rejects a missing command and a bad cwd', async () => {
+      await request(makeApp())
+        .post('/api/fresh-agent/exec')
+        .send({ cwd: os.tmpdir() })
+        .expect(400)
+      await request(makeApp())
+        .post('/api/fresh-agent/exec')
+        .send({ command: 'true', cwd: '/definitely/not/a/real/dir' })
+        .expect(400)
+    })
+  })
+
+  describe('GET /diff', () => {
+    it('requires cwd and validates it exists', async () => {
+      await request(makeApp()).get('/api/fresh-agent/diff').expect(400)
+      await request(makeApp())
+        .get('/api/fresh-agent/diff')
+        .query({ cwd: '/definitely/not/a/real/dir' })
+        .expect(400)
+    })
+
+    it('returns a diff payload for a git repo cwd', async () => {
+      const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'fresh-extras-'))
+      createdPaths.push(dir)
+      const app = makeApp()
+      // Initialize a repo with one dirty file.
+      const { execFile } = await import('node:child_process')
+      const run = (cmd: string, args: string[]) => new Promise<void>((resolve, reject) => {
+        execFile(cmd, args, { cwd: dir }, (err) => err ? reject(err) : resolve())
+      })
+      await run('git', ['init', '-q'])
+      await fsp.writeFile(path.join(dir, 'a.txt'), 'one\n')
+      await run('git', ['add', '.'])
+      await run('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'init'])
+      await fsp.writeFile(path.join(dir, 'a.txt'), 'two\n')
+
+      const res = await request(app)
+        .get('/api/fresh-agent/diff')
+        .query({ cwd: dir, path: 'a.txt' })
+        .expect(200)
+
+      expect(res.body.diff).toContain('-one')
+      expect(res.body.diff).toContain('+two')
+    })
+  })
+
+  describe('POST /send', () => {
+    it('forwards to the injected runtime manager', async () => {
+      const send = vi.fn().mockResolvedValue(undefined)
+      const app = express()
+      app.use('/api/fresh-agent', createFreshAgentExtrasRouter({ freshAgentRuntimeManager: { send } }))
+
+      await request(app)
+        .post('/api/fresh-agent/send')
+        .send({ sessionId: 's1', sessionType: 'freshclaude', provider: 'claude', text: 'ls the cwd' })
+        .expect(200)
+
+      expect(send).toHaveBeenCalledWith(
+        { sessionId: 's1', sessionType: 'freshclaude', provider: 'claude' },
+        { text: 'ls the cwd' },
+      )
+    })
+
+    it('503s without a runtime manager and 400s on missing fields', async () => {
+      await request(makeApp())
+        .post('/api/fresh-agent/send')
+        .send({ sessionId: 's1', sessionType: 'freshclaude', provider: 'claude', text: 'x' })
+        .expect(503)
+
+      const app = express()
+      app.use('/api/fresh-agent', createFreshAgentExtrasRouter({
+        freshAgentRuntimeManager: { send: vi.fn() },
+      }))
+      await request(app)
+        .post('/api/fresh-agent/send')
+        .send({ sessionId: 's1', sessionType: 'freshclaude', provider: 'claude' })
+        .expect(400)
+      await request(app)
+        .post('/api/fresh-agent/send')
+        .send({ sessionId: 's1', sessionType: 'freshclaude', provider: 'not-real', text: 'x' })
+        .expect(400)
+    })
+
+    it('surfaces manager failures as 500 with the message', async () => {
+      const app = express()
+      app.use('/api/fresh-agent', createFreshAgentExtrasRouter({
+        freshAgentRuntimeManager: { send: vi.fn().mockRejectedValue(new Error('no such session')) },
+      }))
+      const res = await request(app)
+        .post('/api/fresh-agent/send')
+        .send({ sessionId: 'nope', sessionType: 'freshclaude', provider: 'claude', text: 'x' })
+        .expect(500)
+      expect(res.body.error).toContain('no such session')
+    })
+  })
+
+  describe('checkpoints', () => {
+    it('creates, lists, and restores checkpoints without touching the cwd git state', async () => {
+      const { createHash } = await import('node:crypto')
+      const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'fresh-ckpt-'))
+      createdPaths.push(dir)
+      const shadow = path.join(
+        os.homedir(), '.freshell', 'checkpoints',
+        `${createHash('sha1').update(path.resolve(dir)).digest('hex').slice(0, 16)}.git`,
+      )
+      createdPaths.push(shadow)
+      const app = makeApp()
+      const file = path.join(dir, 'main.ts')
+
+      await fsp.writeFile(file, 'version one\n')
+      const first = await request(app)
+        .post('/api/fresh-agent/checkpoints')
+        .send({ cwd: dir, label: 'before refactor' })
+        .expect(200)
+      expect(first.body.id).toMatch(/^[0-9a-f]{40}$/)
+      expect(first.body.label).toBe('before refactor')
+
+      await fsp.writeFile(file, 'version two\n')
+      await request(app)
+        .post('/api/fresh-agent/checkpoints')
+        .send({ cwd: dir, label: 'after refactor' })
+        .expect(200)
+
+      const list = await request(app)
+        .get('/api/fresh-agent/checkpoints')
+        .query({ cwd: dir })
+        .expect(200)
+      expect(list.body.checkpoints).toHaveLength(2)
+      // Newest first, git log order.
+      expect(list.body.checkpoints[0].label).toBe('after refactor')
+      expect(list.body.checkpoints[1].label).toBe('before refactor')
+
+      await request(app)
+        .post('/api/fresh-agent/checkpoints/restore')
+        .send({ cwd: dir, id: first.body.id })
+        .expect(200)
+      expect(await fsp.readFile(file, 'utf8')).toBe('version one\n')
+      // The cwd itself never became a git repo.
+      await expect(fsp.access(path.join(dir, '.git'))).rejects.toThrow()
+    })
+
+    it('lists empty for a cwd with no checkpoints and validates restore ids', async () => {
+      const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'fresh-ckpt-empty-'))
+      createdPaths.push(dir)
+      const app = makeApp()
+
+      const list = await request(app)
+        .get('/api/fresh-agent/checkpoints')
+        .query({ cwd: dir })
+        .expect(200)
+      expect(list.body.checkpoints).toEqual([])
+
+      await request(app)
+        .post('/api/fresh-agent/checkpoints/restore')
+        .send({ cwd: dir, id: 'not-a-sha!' })
+        .expect(400)
+    })
+  })
+})

--- a/test/server/ws-terminal-create-reuse-running-codex.test.ts
+++ b/test/server/ws-terminal-create-reuse-running-codex.test.ts
@@ -6,14 +6,70 @@ import path from 'node:path'
 import { EventEmitter } from 'node:events'
 import WebSocket from 'ws'
 import { WS_PROTOCOL_VERSION } from '../../shared/ws-protocol'
+import { WsHandler } from '../../server/ws-handler'
 import { FakeCodexLaunchPlanner, DEFAULT_CODEX_REMOTE_WS_URL } from '../helpers/coding-cli/fake-codex-launch-planner.js'
 
+const TEST_TIMEOUT_MS = 60_000
 const HOOK_TIMEOUT_MS = 30_000
 const MESSAGE_TIMEOUT_MS = 5_000
 const PROOF_MESSAGE_TIMEOUT_MS = 15_000
 const PROOF_TEST_TIMEOUT_MS = 60_000
 const CODEX_SESSION_ID = 'codex-session-abc-123'
 const CODEX_REMOTE_WS_URL = DEFAULT_CODEX_REMOTE_WS_URL
+
+vi.setConfig({ testTimeout: TEST_TIMEOUT_MS, hookTimeout: HOOK_TIMEOUT_MS })
+
+let activeSockets: WebSocket[] = []
+
+function trackWebSocket(ws: WebSocket): WebSocket {
+  activeSockets.push(ws)
+  return ws
+}
+
+function waitForOpen(ws: WebSocket, timeoutMs = MESSAGE_TIMEOUT_MS): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeout)
+      ws.off('open', onOpen)
+      ws.off('close', onClose)
+      ws.off('error', onError)
+    }
+
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error('Timeout waiting for WebSocket open'))
+    }, timeoutMs)
+
+    const onOpen = () => {
+      cleanup()
+      resolve()
+    }
+
+    const onClose = () => {
+      cleanup()
+      reject(new Error('Socket closed waiting for open'))
+    }
+
+    const onError = (error: Error) => {
+      cleanup()
+      reject(error)
+    }
+
+    if (ws.readyState === WebSocket.OPEN) {
+      onOpen()
+      return
+    }
+
+    if (ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+      onClose()
+      return
+    }
+
+    ws.once('open', onOpen)
+    ws.once('close', onClose)
+    ws.once('error', onError)
+  })
+}
 
 function listen(server: http.Server, timeoutMs = HOOK_TIMEOUT_MS): Promise<{ port: number }> {
   return new Promise((resolve, reject) => {
@@ -110,48 +166,6 @@ function waitForReady(ws: WebSocket): Promise<any> {
   return readyPromise
 }
 
-function waitForOpen(ws: WebSocket, timeoutMs = MESSAGE_TIMEOUT_MS): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      clearTimeout(timeout)
-      ws.off('open', onOpen)
-      ws.off('close', onClose)
-      ws.off('error', onError)
-    }
-
-    const timeout = setTimeout(() => {
-      cleanup()
-      reject(new Error('Timeout waiting for websocket open'))
-    }, timeoutMs)
-
-    const onOpen = () => {
-      cleanup()
-      resolve()
-    }
-    const onClose = () => {
-      cleanup()
-      reject(new Error('Socket closed waiting for open'))
-    }
-    const onError = (error: Error) => {
-      cleanup()
-      reject(error)
-    }
-
-    if (ws.readyState === WebSocket.OPEN) {
-      onOpen()
-      return
-    }
-    if (ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
-      onClose()
-      return
-    }
-
-    ws.once('open', onOpen)
-    ws.once('close', onClose)
-    ws.once('error', onError)
-  })
-}
-
 function collectMessages(ws: WebSocket, durationMs: number): Promise<any[]> {
   return new Promise((resolve) => {
     const messages: any[] = []
@@ -172,6 +186,7 @@ function collectMessages(ws: WebSocket, durationMs: number): Promise<any[]> {
 
 function closeWebSocket(ws: WebSocket, timeoutMs = 1_000): Promise<void> {
   return new Promise((resolve) => {
+    let settled = false
     if (ws.readyState === WebSocket.CLOSED) {
       resolve()
       return
@@ -183,14 +198,20 @@ function closeWebSocket(ws: WebSocket, timeoutMs = 1_000): Promise<void> {
       ws.off('error', onClose)
     }
 
-    const onClose = () => {
+    const finish = () => {
+      if (settled) return
+      settled = true
       cleanup()
       resolve()
     }
 
+    const onClose = () => finish()
+
     const timeout = setTimeout(() => {
-      cleanup()
-      resolve()
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate()
+      }
+      setTimeout(finish, 25)
     }, timeoutMs)
 
     ws.on('close', onClose)
@@ -199,6 +220,29 @@ function closeWebSocket(ws: WebSocket, timeoutMs = 1_000): Promise<void> {
     if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
       ws.close()
     }
+  })
+}
+
+function closeServer(serverToClose: http.Server, timeoutMs = 5_000): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(forceClose)
+      clearTimeout(timeout)
+      resolve()
+    }
+    const forceClose = setTimeout(() => {
+      serverToClose.closeIdleConnections?.()
+      serverToClose.closeAllConnections?.()
+    }, 50)
+    const timeout = setTimeout(() => {
+      serverToClose.closeIdleConnections?.()
+      serverToClose.closeAllConnections?.()
+      finish()
+    }, timeoutMs)
+    serverToClose.close(() => finish())
   })
 }
 
@@ -411,9 +455,8 @@ describe('terminal.create reuse running codex terminal', () => {
     process.env.NODE_ENV = 'test'
     process.env.AUTH_TOKEN = 'testtoken-testtoken'
     process.env.HELLO_TIMEOUT_MS = '5000'
+    activeSockets = []
 
-    vi.resetModules()
-    const { WsHandler } = await import('../../server/ws-handler')
     server = http.createServer((_req, res) => { res.statusCode = 404; res.end() })
     registry = new FakeRegistry(['term-codex-existing'])
     codexLaunchPlanner = new FakeCodexLaunchPlanner()
@@ -430,8 +473,16 @@ describe('terminal.create reuse running codex terminal', () => {
   }, HOOK_TIMEOUT_MS)
 
   afterEach(async () => {
+    const sockets = activeSockets
+    activeSockets = []
+    await Promise.all(sockets.map(async (ws) => {
+      await closeWebSocket(ws, 250).catch(() => undefined)
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate()
+      }
+    }))
     if (server) {
-      await new Promise<void>((resolve) => server!.close(() => resolve()))
+      await closeServer(server)
       server = undefined
     }
     if (originalNodeEnv === undefined) {
@@ -453,7 +504,7 @@ describe('terminal.create reuse running codex terminal', () => {
   }, HOOK_TIMEOUT_MS)
 
   it('reuses existing codex terminal and requires an explicit attach', async () => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       await waitForOpen(ws)
       const helloReady = await waitForReady(ws)
@@ -500,7 +551,7 @@ describe('terminal.create reuse running codex terminal', () => {
   })
 
   it('canonical reuse branch returns created only until explicit attach', async () => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       await waitForOpen(ws)
       await waitForReady(ws)
@@ -540,7 +591,7 @@ describe('terminal.create reuse running codex terminal', () => {
   })
 
   it('rejects raw Codex resume ids on restore instead of creating a fresh terminal', async () => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       await waitForOpen(ws)
       await waitForReady(ws)
@@ -573,7 +624,7 @@ describe('terminal.create reuse running codex terminal', () => {
     ['omitted', undefined],
     ['false', false],
   ] as const)('rejects raw Codex resume ids when restore is %s', async (_label, restore) => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       await waitForOpen(ws)
       await waitForReady(ws)
@@ -603,7 +654,7 @@ describe('terminal.create reuse running codex terminal', () => {
   })
 
   it('existingId branch returns created only and requires explicit attach', async () => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       await waitForOpen(ws)
       const helloReady = await waitForReady(ws)
@@ -659,7 +710,7 @@ describe('terminal.create reuse running codex terminal', () => {
   })
 
   it('does not echo durable session ids from reused codex terminals via terminal.created', async () => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       await waitForOpen(ws)
       await waitForReady(ws)
@@ -680,7 +731,7 @@ describe('terminal.create reuse running codex terminal', () => {
   })
 
   it('creates a fresh codex terminal without persisting a provisional session id', async () => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       await waitForOpen(ws)
       await waitForReady(ws)
@@ -725,7 +776,7 @@ describe('terminal.create reuse running codex terminal', () => {
 
   it('proof-reads captured Codex durability and resumes only after proof succeeds', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-proof-'))
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       const rolloutPath = path.join(tempDir, 'rollout.jsonl')
       await fsp.writeFile(
@@ -784,7 +835,7 @@ describe('terminal.create reuse running codex terminal', () => {
 
   it('proof-reads server-stored Codex durability when the client has not persisted candidate state', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-store-proof-'))
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       const rolloutPath = path.join(tempDir, 'rollout.jsonl')
       await fsp.writeFile(
@@ -846,7 +897,7 @@ describe('terminal.create reuse running codex terminal', () => {
 
   it('does not use server-stored Codex durability for non-restore fresh creates', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-store-fresh-'))
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       const rolloutPath = path.join(tempDir, 'rollout.jsonl')
       await fsp.writeFile(
@@ -901,7 +952,7 @@ describe('terminal.create reuse running codex terminal', () => {
 
   it('fresh-creates with restore failure when server-stored Codex durability cannot be proved', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-store-proof-missing-'))
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       const rolloutPath = path.join(tempDir, 'missing.jsonl')
       registry.durabilityRestoreRecords.push({
@@ -964,7 +1015,7 @@ describe('terminal.create reuse running codex terminal', () => {
 
   it('proof-reads a same-server live Codex candidate before reattaching it', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-proof-live-'))
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       const rolloutPath = path.join(tempDir, 'rollout.jsonl')
       await fsp.writeFile(
@@ -1038,7 +1089,7 @@ describe('terminal.create reuse running codex terminal', () => {
 
   it('does not promote a stale same-server live Codex handle when its candidate differs', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-proof-live-mismatch-'))
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       const rolloutPath = path.join(tempDir, 'rollout.jsonl')
       await fsp.writeFile(
@@ -1108,7 +1159,7 @@ describe('terminal.create reuse running codex terminal', () => {
 
   it('does not resume a captured Codex candidate when proof fails', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-proof-'))
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       const rolloutPath = path.join(tempDir, 'missing.jsonl')
       await waitForOpen(ws)
@@ -1160,7 +1211,7 @@ describe('terminal.create reuse running codex terminal', () => {
 
   it('attaches exact live Codex candidate when captured proof fails and live terminal exists', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-proof-'))
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       const rolloutPath = path.join(tempDir, 'missing-live.jsonl')
       registry.records[0].codexDurability = {
@@ -1199,7 +1250,7 @@ describe('terminal.create reuse running codex terminal', () => {
   })
 
   it('accepts Codex candidate persisted acknowledgements through the dynamic websocket schema', async () => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       await waitForOpen(ws)
       await waitForReady(ws)
@@ -1227,13 +1278,12 @@ describe('terminal.create reuse running codex terminal', () => {
   })
 
   it('reuses canonical owner and repairs duplicate session records before reuse', async () => {
-    const { WsHandler } = await import('../../server/ws-handler')
     const dupeServer = http.createServer((_req, res) => { res.statusCode = 404; res.end() })
     const dupeRegistry = new FakeRegistry(['term-canonical', 'term-duplicate'])
     new WsHandler(dupeServer, dupeRegistry as any, { codexLaunchPlanner: new FakeCodexLaunchPlanner() })
     const info = await listen(dupeServer)
 
-    const ws = new WebSocket(`ws://127.0.0.1:${info.port}/ws`)
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${info.port}/ws`))
     try {
       await waitForOpen(ws)
       await waitForReady(ws)

--- a/test/unit/client/components/agent-chat/SlotReel.test.tsx
+++ b/test/unit/client/components/agent-chat/SlotReel.test.tsx
@@ -1,9 +1,12 @@
-import { describe, it, expect, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, act } from '@testing-library/react'
 import SlotReel from '@/components/agent-chat/SlotReel'
 
 describe('SlotReel', () => {
-  afterEach(cleanup)
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
 
   it('renders tool name badge and preview text', () => {
     render(<SlotReel toolName="Bash" previewText="$ ls -la" />)
@@ -37,13 +40,10 @@ describe('SlotReel', () => {
     const { rerender, container } = render(
       <SlotReel toolName="Bash" previewText="$ echo hi" />
     )
-    // Get the tool badge container (the element with overflow-hidden for animation)
     const nameSlot = container.querySelector('[data-slot="name"]')
     expect(nameSlot).toBeInTheDocument()
 
     rerender(<SlotReel toolName="Read" previewText="/file.ts" />)
-    // After rerender with different tool name, the animation wrapper should
-    // contain the new tool name
     expect(screen.getByText('Read')).toBeInTheDocument()
   })
 
@@ -53,5 +53,35 @@ describe('SlotReel', () => {
     )
     rerender(<SlotReel toolName="Bash" previewText="$ echo 2" />)
     expect(screen.getByText('$ echo 2')).toBeInTheDocument()
+  })
+
+  it('animates with keyed spans so interrupted rolls restart from frame zero', () => {
+    const { rerender, container } = render(
+      <SlotReel toolName="Bash" previewText="one" />
+    )
+    rerender(<SlotReel toolName="Read" previewText="two" />)
+    // Mid-animation both outgoing and incoming spans are present, keyed per change.
+    expect(container.querySelector('.animate-reel-out')).toBeInTheDocument()
+    expect(container.querySelector('.animate-reel-in')).toBeInTheDocument()
+  })
+
+  it('settles on the latest value when changes arrive faster than the animation', () => {
+    vi.useFakeTimers()
+    const { rerender } = render(<SlotReel toolName="Bash" previewText="one" />)
+
+    rerender(<SlotReel toolName="Read" previewText="two" />)
+    act(() => {
+      vi.advanceTimersByTime(50)
+    })
+    // Interrupt the in-flight roll with a third value.
+    rerender(<SlotReel toolName="Grep" previewText="three" />)
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(screen.getByText('Grep')).toBeInTheDocument()
+    expect(screen.getByText('three')).toBeInTheDocument()
+    expect(screen.queryByText('Bash')).not.toBeInTheDocument()
+    expect(screen.queryByText('one')).not.toBeInTheDocument()
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentApprovalCard.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentApprovalCard.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { FreshAgentApprovalCard } from '@/components/fresh-agent/FreshAgentApprovalCard'
+import { attachmentRejection } from '@/components/fresh-agent/FreshAgentComposer'
+
+describe('FreshAgentApprovalCard', () => {
+  afterEach(() => cleanup())
+
+  it('previews the exact Bash command being approved', () => {
+    render(
+      <FreshAgentApprovalCard
+        approval={{
+          requestId: 'req-1',
+          toolName: 'Bash',
+          input: { command: 'git push origin main' },
+        }}
+        onAllow={vi.fn()}
+        onAlwaysAllow={vi.fn()}
+        onDeny={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('alert', { name: 'Permission request for Bash' })).toBeInTheDocument()
+    expect(screen.getByText('git push origin main')).toBeInTheDocument()
+  })
+
+  it('previews Edit approvals as a diff', () => {
+    render(
+      <FreshAgentApprovalCard
+        approval={{
+          requestId: 'req-2',
+          toolName: 'Edit',
+          input: { file_path: 'a.ts', old_string: 'old line', new_string: 'new line' },
+        }}
+        onAllow={vi.fn()}
+        onAlwaysAllow={vi.fn()}
+        onDeny={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('figure', { name: 'diff view' })).toHaveAttribute('data-file-path', 'a.ts')
+  })
+
+  it('wires allow / always-allow / deny', () => {
+    const onAllow = vi.fn()
+    const onAlwaysAllow = vi.fn()
+    const onDeny = vi.fn()
+    render(
+      <FreshAgentApprovalCard
+        approval={{ requestId: 'req-3', toolName: 'Bash', input: { command: 'ls' } }}
+        onAllow={onAllow}
+        onAlwaysAllow={onAlwaysAllow}
+        onDeny={onDeny}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow tool use' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Always allow Bash this session' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Deny tool use' }))
+    expect(onAllow).toHaveBeenCalledTimes(1)
+    expect(onAlwaysAllow).toHaveBeenCalledWith('Bash')
+    expect(onDeny).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('attachmentRejection', () => {
+  it('always allows textual files and images', () => {
+    expect(attachmentRejection('codex', 'notes.md')).toBeNull()
+    expect(attachmentRejection('opencode', 'data.csv')).toBeNull()
+    expect(attachmentRejection('claude', 'shot.png')).toBeNull()
+    expect(attachmentRejection('codex', 'shot.jpeg')).toBeNull()
+  })
+
+  it('allows pdf only for claude', () => {
+    expect(attachmentRejection('claude', 'spec.pdf')).toBeNull()
+    expect(attachmentRejection('codex', 'spec.pdf')).toMatch(/can’t read \.pdf/)
+  })
+
+  it('rejects unsupported media with a actionable message', () => {
+    expect(attachmentRejection('claude', 'demo.mov')).toMatch(/isn’t supported/)
+    expect(attachmentRejection('codex', 'song.mp3')).toMatch(/isn’t supported/)
+  })
+})

--- a/test/unit/client/components/fresh-agent/FreshAgentComposer.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentComposer.test.tsx
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { FreshAgentComposer } from '@/components/fresh-agent/FreshAgentComposer'
+import type { FreshAgentSlashCommand } from '@shared/fresh-agent-slash-commands'
+
+const apiGet = vi.fn()
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGet(...args),
+    post: vi.fn(),
+  },
+}))
+
+const COMMANDS: readonly FreshAgentSlashCommand[] = [
+  { name: 'new', description: 'Start a new conversation in this pane', action: 'new' },
+  { name: 'compact', description: 'Compact the context', action: 'compact' },
+  { name: 'fork', description: 'Fork this conversation', action: 'fork', requiresCapability: 'fork' },
+]
+
+function getInput(): HTMLTextAreaElement {
+  return screen.getByRole('textbox', { name: 'Chat message input' }) as HTMLTextAreaElement
+}
+
+describe('FreshAgentComposer', () => {
+  beforeEach(() => {
+    apiGet.mockReset()
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+  })
+  afterEach(() => cleanup())
+
+  it('opens the slash menu when typing / and runs the highlighted command', () => {
+    const onCommand = vi.fn()
+    render(<FreshAgentComposer commands={COMMANDS} onCommand={onCommand} />)
+
+    fireEvent.change(getInput(), { target: { value: '/for' } })
+    const menu = screen.getByRole('menu', { name: 'Slash commands' })
+    expect(menu).toHaveTextContent('/fork')
+    expect(menu).not.toHaveTextContent('/new')
+
+    fireEvent.keyDown(getInput(), { key: 'Enter' })
+    expect(onCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'fork' }),
+      '',
+    )
+  })
+
+  it('passes arguments through slash command text', () => {
+    const onCommand = vi.fn()
+    render(<FreshAgentComposer commands={COMMANDS} onCommand={onCommand} />)
+
+    fireEvent.change(getInput(), { target: { value: '/compact focus on ws-handler' } })
+    fireEvent.keyDown(getInput(), { key: 'Enter' })
+    expect(onCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'compact' }),
+      'focus on ws-handler',
+    )
+  })
+
+  it('completes @ mentions against the files API anchored at the session cwd', async () => {
+    apiGet.mockResolvedValue({
+      suggestions: [
+        { path: '/home/dan/code/freshell/server', isDirectory: true },
+        { path: '/home/dan/code/freshell/shared/settings.ts', isDirectory: false },
+      ],
+    })
+    const onSend = vi.fn()
+    render(<FreshAgentComposer commands={COMMANDS} onSend={onSend} cwd="/home/dan/code/freshell" />)
+
+    fireEvent.change(getInput(), { target: { value: 'look at @s' } })
+
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith(
+        `/api/files/complete?prefix=${encodeURIComponent('/home/dan/code/freshell/s')}`,
+      )
+    })
+    const menu = await screen.findByRole('menu', { name: 'File suggestions' })
+    expect(menu).toHaveTextContent('server')
+    expect(menu).toHaveTextContent('shared/settings.ts')
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /shared\/settings\.ts/ }))
+    expect(getInput().value).toBe('look at shared/settings.ts ')
+  })
+
+  it('descends into directories on selection and keeps completing', async () => {
+    apiGet.mockResolvedValue({
+      suggestions: [{ path: '/home/dan/code/freshell/server', isDirectory: true }],
+    })
+    render(<FreshAgentComposer commands={COMMANDS} cwd="/home/dan/code/freshell" />)
+
+    fireEvent.change(getInput(), { target: { value: '@se' } })
+    const item = await screen.findByRole('menuitem', { name: /server/ })
+    fireEvent.click(item)
+
+    expect(getInput().value).toBe('@server/')
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith(
+        `/api/files/complete?prefix=${encodeURIComponent('/home/dan/code/freshell/server/')}`,
+      )
+    })
+  })
+
+  it('recalls prompt history with arrow keys from an empty input', () => {
+    const onSend = vi.fn()
+    render(
+      <FreshAgentComposer
+        commands={COMMANDS}
+        onSend={onSend}
+        historyKey="fresh-agent-prompt-history:test"
+      />,
+    )
+
+    fireEvent.change(getInput(), { target: { value: 'first prompt' } })
+    fireEvent.keyDown(getInput(), { key: 'Enter' })
+    fireEvent.change(getInput(), { target: { value: 'second prompt' } })
+    fireEvent.keyDown(getInput(), { key: 'Enter' })
+    expect(onSend).toHaveBeenCalledTimes(2)
+    expect(getInput().value).toBe('')
+
+    fireEvent.keyDown(getInput(), { key: 'ArrowUp' })
+    expect(getInput().value).toBe('second prompt')
+    fireEvent.keyDown(getInput(), { key: 'ArrowUp' })
+    expect(getInput().value).toBe('first prompt')
+    fireEvent.keyDown(getInput(), { key: 'ArrowDown' })
+    expect(getInput().value).toBe('second prompt')
+    fireEvent.keyDown(getInput(), { key: 'ArrowDown' })
+    expect(getInput().value).toBe('')
+  })
+
+  it('persists prompt history per history key', () => {
+    const key = 'fresh-agent-prompt-history:persist-test'
+    const first = render(
+      <FreshAgentComposer commands={COMMANDS} onSend={vi.fn()} historyKey={key} />,
+    )
+    fireEvent.change(getInput(), { target: { value: 'remembered prompt' } })
+    fireEvent.keyDown(getInput(), { key: 'Enter' })
+    first.unmount()
+
+    render(<FreshAgentComposer commands={COMMANDS} onSend={vi.fn()} historyKey={key} />)
+    fireEvent.keyDown(getInput(), { key: 'ArrowUp' })
+    expect(getInput().value).toBe('remembered prompt')
+  })
+
+  it('does not hijack ArrowUp while drafting text', () => {
+    render(
+      <FreshAgentComposer
+        commands={COMMANDS}
+        onSend={vi.fn()}
+        historyKey="fresh-agent-prompt-history:drafting"
+      />,
+    )
+    fireEvent.change(getInput(), { target: { value: 'sent already' } })
+    fireEvent.keyDown(getInput(), { key: 'Enter' })
+
+    fireEvent.change(getInput(), { target: { value: 'a draft in progress' } })
+    fireEvent.keyDown(getInput(), { key: 'ArrowUp' })
+    expect(getInput().value).toBe('a draft in progress')
+  })
+
+  describe('state-aware disabled behavior', () => {
+    it('shows the provided placeholder instead of the generic read-only text', () => {
+      render(
+        <FreshAgentComposer
+          commands={COMMANDS}
+          disabled
+          placeholder="Starting session…"
+        />,
+      )
+      expect(getInput()).toHaveAttribute('placeholder', 'Starting session…')
+    })
+
+    it('falls back to Read-only session when disabled without a placeholder', () => {
+      render(<FreshAgentComposer commands={COMMANDS} disabled />)
+      expect(getInput()).toHaveAttribute('placeholder', 'Read-only session')
+    })
+
+    it('keeps /new reachable from the command menu while disabled', () => {
+      const onCommand = vi.fn()
+      render(<FreshAgentComposer commands={COMMANDS} disabled onCommand={onCommand} />)
+
+      const browse = screen.getByRole('button', { name: 'Slash commands' })
+      expect(browse).toBeEnabled()
+      fireEvent.click(browse)
+      fireEvent.click(screen.getByRole('menuitem', { name: /\/new/ }))
+      expect(onCommand).toHaveBeenCalledWith(expect.objectContaining({ name: 'new' }), '')
+
+      // Other commands stay blocked while disabled.
+      fireEvent.click(browse)
+      fireEvent.click(screen.getByRole('menuitem', { name: /\/compact/ }))
+      expect(onCommand).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/test/unit/client/components/fresh-agent/FreshAgentContextMeter.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentContextMeter.test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import freshAgentReducer, { freshAgentSnapshotReceived } from '@/store/freshAgentSlice'
+import { FreshAgentContextMeter } from '@/components/fresh-agent/FreshAgentContextMeter'
+import type { FreshAgentPaneContent } from '@/store/paneTypes'
+import type { FreshAgentSnapshot } from '@shared/fresh-agent-contract'
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      freshAgent: freshAgentReducer,
+    },
+  })
+}
+
+const PANE_CONTENT = {
+  kind: 'fresh-agent',
+  sessionType: 'freshclaude',
+  provider: 'claude',
+  sessionId: 'thread-1',
+  createRequestId: 'req-1',
+  status: 'connected',
+} as unknown as FreshAgentPaneContent
+
+function makeSnapshot(tokenUsage: FreshAgentSnapshot['tokenUsage']): FreshAgentSnapshot {
+  return {
+    sessionType: 'freshclaude',
+    provider: 'claude',
+    threadId: 'thread-1',
+    revision: 1,
+    status: 'idle',
+    capabilities: {
+      send: true,
+      interrupt: true,
+      approvals: true,
+      questions: true,
+      fork: false,
+    },
+    tokenUsage,
+    pendingApprovals: [],
+    pendingQuestions: [],
+    worktrees: [],
+    diffs: [],
+    childThreads: [],
+    turns: [],
+    extensions: {},
+  } as FreshAgentSnapshot
+}
+
+function renderMeter(store: ReturnType<typeof makeStore>) {
+  return render(
+    <Provider store={store}>
+      <FreshAgentContextMeter paneContent={PANE_CONTENT} />
+    </Provider>,
+  )
+}
+
+describe('FreshAgentContextMeter', () => {
+  afterEach(() => cleanup())
+
+  it('renders percent of compaction threshold from the snapshot', () => {
+    const store = makeStore()
+    store.dispatch(freshAgentSnapshotReceived({
+      snapshot: makeSnapshot({
+        inputTokens: 40_000,
+        outputTokens: 14_000,
+        totalTokens: 54_000,
+        contextTokens: 54_000,
+        compactPercent: 27,
+        costUsd: 1.23,
+      }),
+    }))
+    renderMeter(store)
+
+    const meter = screen.getByRole('status', { name: 'Context 27% full' })
+    expect(meter).toHaveTextContent('27%')
+    expect(meter).not.toHaveAttribute('data-warn')
+    const toggle = meter.closest('button')
+    expect(toggle).toHaveAttribute('title', expect.stringContaining('54k tokens'))
+    expect(toggle).toHaveAttribute('title', expect.stringContaining('$1.23'))
+  })
+
+  it('switches to the warning treatment near compaction', () => {
+    const store = makeStore()
+    store.dispatch(freshAgentSnapshotReceived({
+      snapshot: makeSnapshot({
+        inputTokens: 150_000,
+        outputTokens: 22_000,
+        totalTokens: 172_000,
+        contextTokens: 172_000,
+        compactPercent: 86,
+      }),
+    }))
+    renderMeter(store)
+
+    const meter = screen.getByRole('status', { name: 'Context 86% full' })
+    expect(meter).toHaveAttribute('data-warn')
+    expect(meter.closest('button')).toHaveAttribute('title', expect.stringContaining('Compaction soon'))
+  })
+
+  it('falls back to raw context tokens when no percent is reported', () => {
+    const store = makeStore()
+    store.dispatch(freshAgentSnapshotReceived({
+      snapshot: makeSnapshot({
+        inputTokens: 9_000,
+        outputTokens: 3_000,
+        totalTokens: 12_000,
+        contextTokens: 12_000,
+      }),
+    }))
+    renderMeter(store)
+
+    expect(screen.getByRole('status', { name: 'Context 12k tokens' })).toHaveTextContent('12k ctx')
+  })
+
+  it('renders nothing without usable token data', () => {
+    const store = makeStore()
+    store.dispatch(freshAgentSnapshotReceived({
+      snapshot: makeSnapshot({
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      }),
+    }))
+    const { container } = renderMeter(store)
+    expect(container.querySelector('[role="status"]')).toBeNull()
+  })
+
+  it('renders nothing when the session has no snapshot yet', () => {
+    const store = makeStore()
+    const { container } = renderMeter(store)
+    expect(container.querySelector('[role="status"]')).toBeNull()
+  })
+})

--- a/test/unit/client/components/fresh-agent/FreshAgentMobile.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentMobile.test.tsx
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { FreshAgentActionSheet } from '@/components/fresh-agent/FreshAgentActionSheet'
+import { FreshAgentTranscript } from '@/components/fresh-agent/FreshAgentTranscript'
+import { FreshAgentComposer } from '@/components/fresh-agent/FreshAgentComposer'
+
+vi.mock('@/components/markdown/LazyMarkdown', async () => {
+  const { MarkdownRenderer } = await import('@/components/markdown/MarkdownRenderer')
+  return {
+    LazyMarkdown: ({ content }: { content: string }) => (
+      <MarkdownRenderer content={content} />
+    ),
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  api: { get: vi.fn(), post: vi.fn() },
+}))
+
+function stubCoarsePointer(matches: boolean) {
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+    matches,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }))
+}
+
+const TURNS = [
+  {
+    id: 'turn-1',
+    turnId: 'turn-1',
+    role: 'user' as const,
+    summary: 'ask',
+    items: [{ id: 'item-1', kind: 'text' as const, text: 'fix the bug' }],
+  },
+  {
+    id: 'turn-2',
+    turnId: 'turn-2',
+    role: 'assistant' as const,
+    summary: 'answer',
+    items: [{ id: 'item-2', kind: 'text' as const, text: 'done' }],
+  },
+]
+
+describe('FreshAgentActionSheet', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders items, runs them, and closes', () => {
+    const run = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <FreshAgentActionSheet
+        title="fix the bug"
+        items={[
+          { label: 'Copy turn text', run },
+          { label: 'Rewind code to here', disabled: true, destructive: true, run: vi.fn() },
+        ]}
+        onClose={onClose}
+      />,
+    )
+
+    expect(screen.getByRole('menu', { name: 'fix the bug' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Rewind code to here' })).toBeDisabled()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Copy turn text' }))
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('dismisses via backdrop and Escape', () => {
+    const onClose = vi.fn()
+    render(<FreshAgentActionSheet items={[{ label: 'X', run: vi.fn() }]} onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('coarse-pointer transcript behavior', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('shows the ⋯ trigger and opens the action sheet instead of the floating menu', () => {
+    stubCoarsePointer(true)
+    const onFork = vi.fn()
+    render(<FreshAgentTranscript turns={TURNS} canFork onForkFromTurn={onFork} />)
+
+    const triggers = screen.getAllByRole('button', { name: 'Turn actions menu' })
+    expect(triggers).toHaveLength(2)
+    fireEvent.click(triggers[0])
+
+    const sheet = screen.getByRole('menu', { name: /fix the bug/ })
+    expect(sheet).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Fork conversation from here' }))
+    expect(onFork).toHaveBeenCalledWith('turn-1')
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('routes contextmenu (Android long-press) to the sheet on coarse pointers', () => {
+    stubCoarsePointer(true)
+    render(<FreshAgentTranscript turns={TURNS} canFork={false} />)
+
+    fireEvent.contextMenu(screen.getByRole('article', { name: 'You transcript turn' }))
+    expect(screen.getByRole('menu', { name: /fix the bug/ })).toBeInTheDocument()
+    expect(screen.queryByRole('menu', { name: 'Turn context menu' })).not.toBeInTheDocument()
+  })
+
+  it('keeps the floating context menu on fine pointers', () => {
+    stubCoarsePointer(false)
+    render(<FreshAgentTranscript turns={TURNS} canFork={false} />)
+
+    expect(screen.queryByRole('button', { name: 'Turn actions menu' })).not.toBeInTheDocument()
+    fireEvent.contextMenu(screen.getByRole('article', { name: 'You transcript turn' }))
+    expect(screen.getByRole('menu', { name: 'Turn context menu' })).toBeInTheDocument()
+  })
+})
+
+describe('coarse-pointer composer behavior', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('Enter inserts a newline instead of sending on touch keyboards', () => {
+    stubCoarsePointer(true)
+    const onSend = vi.fn()
+    render(<FreshAgentComposer commands={[]} onSend={onSend} />)
+
+    const input = screen.getByRole('textbox', { name: 'Chat message input' })
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onSend).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(onSend).toHaveBeenCalledWith('hello', [])
+  })
+
+  it('Enter still sends on fine pointers', () => {
+    stubCoarsePointer(false)
+    const onSend = vi.fn()
+    render(<FreshAgentComposer commands={[]} onSend={onSend} />)
+
+    const input = screen.getByRole('textbox', { name: 'Chat message input' })
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onSend).toHaveBeenCalledWith('hello', [])
+  })
+})

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -1,6 +1,19 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { FreshAgentTranscript } from '@/components/fresh-agent/FreshAgentTranscript'
+
+// Render markdown bodies synchronously. The real LazyMarkdown wraps MarkdownRenderer
+// in React.lazy + Suspense; mocking it to render MarkdownRenderer directly removes
+// the fallback->content swap so assertions don't race the chunk load. Matches the
+// mock used by the agent-chat MessageBubble tests.
+vi.mock('@/components/markdown/LazyMarkdown', async () => {
+  const { MarkdownRenderer } = await import('@/components/markdown/MarkdownRenderer')
+  return {
+    LazyMarkdown: ({ content }: { content: string }) => (
+      <MarkdownRenderer content={content} />
+    ),
+  }
+})
 
 describe('FreshAgentTranscript', () => {
   afterEach(() => cleanup())
@@ -22,14 +35,50 @@ describe('FreshAgentTranscript', () => {
     expect(screen.getByText('Hello from Fresh Agent')).toBeInTheDocument()
   })
 
-  it('renders blank space instead of placeholder text for an empty transcript', () => {
-    const { container } = render(<FreshAgentTranscript turns={[]} />)
+  it('renders assistant text as markdown', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          {
+            id: 'turn-1',
+            role: 'assistant',
+            summary: 'markdown turn',
+            items: [{
+              id: 'item-1',
+              kind: 'text',
+              text: '## Root cause\n\nA **bold move** with `attachEpoch` and a [link](https://example.com).',
+            }],
+          },
+        ]}
+      />,
+    )
 
-    expect(screen.queryByText(/No transcript available yet/i)).not.toBeInTheDocument()
-    expect(container.querySelector('[data-context="fresh-agent-transcript"]')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Root cause' })).toBeInTheDocument()
+    expect(screen.getByText('bold move').tagName).toBe('STRONG')
+    expect(screen.getByText('attachEpoch').tagName).toBe('CODE')
+    expect(screen.getByRole('link', { name: /link/ })).toHaveAttribute('href', 'https://example.com')
   })
 
-  it('coalesces paired tool calls into a rolling strip and expands details', () => {
+  it('keeps user text literal, never interpreted as markdown', () => {
+    const { container } = render(
+      <FreshAgentTranscript
+        turns={[
+          {
+            id: 'turn-1',
+            role: 'user',
+            summary: 'user turn',
+            items: [{ id: 'item-1', kind: 'text', text: '**not bold** and # not a heading' }],
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('**not bold** and # not a heading')).toBeInTheDocument()
+    expect(container.querySelector('strong')).toBeNull()
+    expect(container.querySelector('h1')).toBeNull()
+  })
+
+  it('coalesces paired tool calls into the activity strip and expands details', () => {
     render(
       <FreshAgentTranscript
         turns={[
@@ -58,12 +107,165 @@ describe('FreshAgentTranscript', () => {
       />,
     )
 
-    expect(screen.getByRole('region', { name: 'Tool strip' })).toHaveTextContent('1 tool used')
-    fireEvent.click(screen.getByRole('button', { name: 'Toggle tool details' }))
-    expect(screen.getByRole('button', { name: 'Bash tool call' })).toHaveTextContent('Bash:')
+    expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('1 tool used')
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle activity details' }))
     fireEvent.click(screen.getByRole('button', { name: 'Bash tool call' }))
     expect(screen.getByText('find . -name "*.md"')).toBeInTheDocument()
-    expect(screen.getByText(/README.md/)).toBeInTheDocument()
+  })
+
+  it('merges consecutive thinking chunks into one row', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          {
+            id: 'turn-1',
+            role: 'assistant',
+            summary: 'streamed thinking',
+            items: [
+              { id: 'think-1', kind: 'thinking', text: 'first fragment' },
+              { id: 'think-2', kind: 'thinking', text: 'second fragment' },
+              {
+                id: 'tool-1',
+                kind: 'tool_use',
+                toolUseId: 'call-1',
+                name: 'Bash',
+                input: { command: 'true' },
+              },
+              { id: 'result-1', kind: 'tool_result', toolUseId: 'call-1', content: 'ok', isError: false },
+              { id: 'item-1', kind: 'text', text: 'done' },
+            ],
+          },
+        ]}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle activity details' }))
+    const thinkingRows = screen.getAllByRole('button', { name: 'Thinking' })
+    expect(thinkingRows).toHaveLength(1)
+    fireEvent.click(thinkingRows[0])
+    expect(screen.getAllByText(/first fragment/).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText(/second fragment/).length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders summary-only assistant turns as markdown', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          {
+            id: 'turn-1',
+            role: 'assistant',
+            summary: 'use `attachEpoch` to guard the close handler',
+            items: [],
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('attachEpoch').tagName).toBe('CODE')
+  })
+
+  it('folds thinking into the activity strip with tools', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          {
+            id: 'turn-1',
+            role: 'assistant',
+            summary: 'thought then ran',
+            items: [
+              { id: 'think-1', kind: 'thinking', text: 'the race is in the close handler' },
+              {
+                id: 'tool-1',
+                kind: 'tool_use',
+                toolUseId: 'call-1',
+                name: 'Bash',
+                input: { command: 'npm test' },
+              },
+              { id: 'result-1', kind: 'tool_result', toolUseId: 'call-1', content: 'ok', isError: false },
+              { id: 'item-1', kind: 'text', text: 'All green.' },
+            ],
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('thought · 1 tool used')
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle activity details' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Thinking' }))
+    expect(screen.getAllByText('the race is in the close handler').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows a live reel while a tool is running', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          {
+            id: 'turn-1',
+            role: 'assistant',
+            summary: 'running',
+            items: [
+              {
+                id: 'tool-1',
+                kind: 'tool_use',
+                toolUseId: 'call-1',
+                name: 'Bash',
+                input: { command: 'npm run check' },
+              },
+            ],
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByLabelText('running')).toBeInTheDocument()
+    expect(screen.getByText('Bash')).toBeInTheDocument()
+  })
+
+  it('treats trailing thinking in the latest turn as live activity', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          {
+            id: 'turn-1',
+            role: 'assistant',
+            summary: 'thinking',
+            items: [
+              { id: 'think-1', kind: 'thinking', text: 'still reasoning about the fix' },
+            ],
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByLabelText('running')).toBeInTheDocument()
+    expect(screen.getByText('Thinking')).toBeInTheDocument()
+  })
+
+  it('counts files changed in the settled summary', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          {
+            id: 'turn-1',
+            role: 'assistant',
+            summary: 'edited files',
+            items: [
+              {
+                id: 'edit-1',
+                kind: 'tool_use',
+                toolUseId: 'edit-call',
+                name: 'Edit',
+                input: { file_path: 'README.md', old_string: 'a', new_string: 'b' },
+              },
+              { id: 'edit-result', kind: 'tool_result', toolUseId: 'edit-call', content: 'ok', isError: false },
+            ],
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByRole('region', { name: 'Activity strip' }))
+      .toHaveTextContent('1 tool used · 1 file changed')
   })
 
   it('strips system reminders and collapses older turns', () => {
@@ -88,35 +290,68 @@ describe('FreshAgentTranscript', () => {
     expect(screen.queryByText(/hidden internals/)).not.toBeInTheDocument()
   })
 
-  it('renders reasoning and thinking in disclosures and shows edit diffs', () => {
-    render(
-      <FreshAgentTranscript
-        turns={[
-          {
-            id: 'turn-1',
-            role: 'assistant',
-            summary: 'thinking and editing',
-            items: [
-              { id: 'thinking-1', kind: 'thinking', text: 'private chain' },
-              { id: 'reason-1', kind: 'reasoning', summary: ['summary'], content: ['detail'] },
-              {
-                id: 'edit-1',
-                kind: 'tool_use',
-                toolUseId: 'edit-call',
-                name: 'Edit',
-                input: { file_path: 'README.md', old_string: 'old', new_string: 'new' },
-              },
-              { id: 'edit-result', kind: 'tool_result', toolUseId: 'edit-call', content: 'ok', isError: false },
-            ],
-          },
-        ]}
-      />,
-    )
+  describe('turn actions', () => {
+    const TURNS = [
+      {
+        id: 'turn-1',
+        turnId: 'turn-1',
+        role: 'user' as const,
+        summary: 'ask',
+        items: [{ id: 'item-1', kind: 'text' as const, text: 'fix the bug' }],
+      },
+      {
+        id: 'turn-2',
+        turnId: 'turn-2',
+        role: 'assistant' as const,
+        summary: 'answer',
+        items: [{ id: 'item-2', kind: 'text' as const, text: 'done' }],
+      },
+    ]
 
-    expect(screen.getByText('Thinking')).toBeInTheDocument()
-    expect(screen.getByText('Reasoning')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Toggle tool details' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Edit tool call' }))
-    expect(screen.getByRole('figure', { name: 'diff view' })).toHaveAttribute('data-file-path', 'README.md')
+    it('renders a hover toolbar with copy and capability-gated fork', () => {
+      const onFork = vi.fn()
+      render(<FreshAgentTranscript turns={TURNS} canFork onForkFromTurn={onFork} />)
+
+      const toolbars = screen.getAllByRole('toolbar', { name: 'Turn actions' })
+      expect(toolbars).toHaveLength(2)
+      const forkButtons = screen.getAllByRole('button', { name: 'Fork conversation from here' })
+      fireEvent.click(forkButtons[0])
+      expect(onFork).toHaveBeenCalledWith('turn-1')
+    })
+
+    it('hides fork affordances without the capability', () => {
+      render(<FreshAgentTranscript turns={TURNS} canFork={false} />)
+      expect(screen.queryByRole('button', { name: 'Fork conversation from here' })).not.toBeInTheDocument()
+    })
+
+    it('opens a context menu on right-click with fork wired to the turn', () => {
+      const onFork = vi.fn()
+      render(<FreshAgentTranscript turns={TURNS} canFork onForkFromTurn={onFork} />)
+
+      fireEvent.contextMenu(screen.getByRole('article', { name: 'Assistant transcript turn' }))
+      const menu = screen.getByRole('menu', { name: 'Turn context menu' })
+      expect(menu).toHaveTextContent('Copy turn text')
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Fork conversation from here' }))
+      expect(onFork).toHaveBeenCalledWith('turn-2')
+    })
+
+    it('offers rewind only on user turns and passes the turn through', () => {
+      const onRewind = vi.fn()
+      render(<FreshAgentTranscript turns={TURNS} canFork={false} onRewindToTurn={onRewind} />)
+
+      const rewindButtons = screen.getAllByRole('button', { name: 'Rewind code to here' })
+      expect(rewindButtons).toHaveLength(1)
+      fireEvent.click(rewindButtons[0])
+      expect(onRewind).toHaveBeenCalledWith(expect.objectContaining({ id: 'turn-1', role: 'user' }))
+    })
+
+    it('disables rewind in the context menu for assistant turns', () => {
+      const onRewind = vi.fn()
+      render(<FreshAgentTranscript turns={TURNS} canFork={false} onRewindToTurn={onRewind} />)
+
+      fireEvent.contextMenu(screen.getByRole('article', { name: 'Assistant transcript turn' }))
+      const item = screen.getByRole('menuitem', { name: 'Rewind code to here' })
+      expect(item).toBeDisabled()
+    })
   })
 })

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -171,6 +171,9 @@ vi.mock('lucide-react', () => ({
   Square: ({ className }: { className?: string }) => (
     <svg data-testid="square-icon" className={className} />
   ),
+  SquareTerminal: ({ className }: { className?: string }) => (
+    <svg data-testid="square-terminal-icon" className={className} />
+  ),
   Search: ({ className }: { className?: string }) => (
     <svg data-testid="search-icon" className={className} />
   ),
@@ -2671,7 +2674,7 @@ describe('PaneContainer', () => {
         store,
       )
 
-      expect(screen.getByText('Kilroy')).toBeInTheDocument()
+      expect(screen.getByTitle('Kilroy session')).toHaveTextContent('Kilroy')
       expect(screen.getByText(/freshell \(main\)\s+25%/)).toBeInTheDocument()
     })
 

--- a/test/unit/client/components/terminal/terminal-write-queue.test.ts
+++ b/test/unit/client/components/terminal/terminal-write-queue.test.ts
@@ -195,6 +195,7 @@ describe('createTerminalWriteQueue', () => {
     const callbacks: number[] = []
     const rafCallbacks: FrameRequestCallback[] = []
     const line = `${'B'.repeat(1023)}\n`
+    const nowMs = 0
 
     const queue = createTerminalWriteQueue({
       terminalInstanceId: 'surface-live-four-hour-backlog',
@@ -207,6 +208,7 @@ describe('createTerminalWriteQueue', () => {
         return rafCallbacks.length
       },
       cancelFrame: () => {},
+      now: () => nowMs,
     })
 
     for (let index = 0; index < 14_400; index += 1) {

--- a/test/unit/client/lib/fresh-agent-checkpoints.test.ts
+++ b/test/unit/client/lib/fresh-agent-checkpoints.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  checkpointLabelForText,
+  pickCheckpointForTurn,
+  type CheckpointEntry,
+} from '@/lib/fresh-agent-checkpoints'
+import type { FreshAgentTurn } from '@shared/fresh-agent-contract'
+
+function userTurn(id: string, text: string): FreshAgentTurn {
+  return {
+    id,
+    turnId: id,
+    role: 'user',
+    summary: text,
+    items: [{ id: `${id}-item`, kind: 'text', text }],
+  } as FreshAgentTurn
+}
+
+function assistantTurn(id: string): FreshAgentTurn {
+  return {
+    id,
+    turnId: id,
+    role: 'assistant',
+    summary: 'reply',
+    items: [{ id: `${id}-item`, kind: 'text', text: 'done' }],
+  } as FreshAgentTurn
+}
+
+// Newest-first, matching git log order.
+const CHECKPOINTS: CheckpointEntry[] = [
+  { id: 'sha-3', ts: 300, label: 'fix the bug' },
+  { id: 'sha-2', ts: 200, label: 'add a test' },
+  { id: 'sha-1', ts: 100, label: 'fix the bug' },
+]
+
+describe('checkpointLabelForText', () => {
+  it('flattens whitespace and truncates', () => {
+    expect(checkpointLabelForText('  fix\n\nthe   bug  ')).toBe('fix the bug')
+    expect(checkpointLabelForText('x'.repeat(300))).toHaveLength(120)
+    expect(checkpointLabelForText('   ')).toBe('checkpoint')
+  })
+})
+
+describe('pickCheckpointForTurn', () => {
+  it('matches a user turn to its checkpoint by label', () => {
+    const turns = [userTurn('t1', 'add a test'), assistantTurn('t2')]
+    expect(pickCheckpointForTurn(CHECKPOINTS, turns, turns[0])?.id).toBe('sha-2')
+  })
+
+  it('disambiguates duplicate labels by ordinal, oldest first', () => {
+    const turns = [
+      userTurn('t1', 'fix the bug'),
+      assistantTurn('t2'),
+      userTurn('t3', 'fix the bug'),
+    ]
+    expect(pickCheckpointForTurn(CHECKPOINTS, turns, turns[0])?.id).toBe('sha-1')
+    expect(pickCheckpointForTurn(CHECKPOINTS, turns, turns[2])?.id).toBe('sha-3')
+  })
+
+  it('returns null for assistant turns and unmatched labels', () => {
+    const turns = [userTurn('t1', 'never sent before'), assistantTurn('t2')]
+    expect(pickCheckpointForTurn(CHECKPOINTS, turns, turns[1])).toBeNull()
+    expect(pickCheckpointForTurn(CHECKPOINTS, turns, turns[0])).toBeNull()
+  })
+
+  it('matches labels after attachment suffixes the same way send does', () => {
+    const outgoing = 'look at this\n\nAttached files (read them from disk):\n- /tmp/x.png'
+    const label = checkpointLabelForText(outgoing)
+    const turns = [userTurn('t1', outgoing)]
+    const checkpoints: CheckpointEntry[] = [{ id: 'sha-a', ts: 1, label }]
+    expect(pickCheckpointForTurn(checkpoints, turns, turns[0])?.id).toBe('sha-a')
+  })
+})

--- a/test/unit/client/lib/pointer.test.tsx
+++ b/test/unit/client/lib/pointer.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  buildLongPressHandlers,
+  isCoarsePointer,
+  LONG_PRESS_MS,
+  useCoarsePointer,
+} from '@/lib/pointer'
+
+type MediaListener = (event: { matches: boolean }) => void
+
+function mockMatchMedia(matches: boolean) {
+  const listeners = new Set<MediaListener>()
+  const media = {
+    matches,
+    addEventListener: (_: string, listener: MediaListener) => listeners.add(listener),
+    removeEventListener: (_: string, listener: MediaListener) => listeners.delete(listener),
+  }
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(media))
+  return {
+    flip(next: boolean) {
+      media.matches = next
+      listeners.forEach((listener) => listener({ matches: next }))
+    },
+  }
+}
+
+function touchEvent(x: number, y: number) {
+  return { touches: [{ clientX: x, clientY: y }] } as unknown as React.TouchEvent<HTMLElement>
+}
+
+describe('isCoarsePointer / useCoarsePointer', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('defaults to fine pointer when matchMedia is unavailable (jsdom)', () => {
+    expect(isCoarsePointer()).toBe(false)
+    const { result } = renderHook(() => useCoarsePointer())
+    expect(result.current).toBe(false)
+  })
+
+  it('reports coarse pointers and follows device changes', () => {
+    const media = mockMatchMedia(true)
+    const { result } = renderHook(() => useCoarsePointer())
+    expect(result.current).toBe(true)
+    act(() => media.flip(false))
+    expect(result.current).toBe(false)
+  })
+})
+
+describe('buildLongPressHandlers', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fires after the long-press window at the start position', () => {
+    vi.useFakeTimers()
+    const callback = vi.fn()
+    const handlers = buildLongPressHandlers(callback)
+
+    handlers.onTouchStart(touchEvent(40, 60))
+    vi.advanceTimersByTime(LONG_PRESS_MS - 1)
+    expect(callback).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(callback).toHaveBeenCalledWith({ clientX: 40, clientY: 60 })
+  })
+
+  it('cancels when the finger moves (scrolling) or lifts early', () => {
+    vi.useFakeTimers()
+    const callback = vi.fn()
+    const handlers = buildLongPressHandlers(callback)
+
+    handlers.onTouchStart(touchEvent(40, 60))
+    handlers.onTouchMove(touchEvent(40, 90))
+    vi.advanceTimersByTime(LONG_PRESS_MS + 50)
+    expect(callback).not.toHaveBeenCalled()
+
+    handlers.onTouchStart(touchEvent(40, 60))
+    handlers.onTouchEnd()
+    vi.advanceTimersByTime(LONG_PRESS_MS + 50)
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('tolerates sub-threshold jitter', () => {
+    vi.useFakeTimers()
+    const callback = vi.fn()
+    const handlers = buildLongPressHandlers(callback)
+
+    handlers.onTouchStart(touchEvent(40, 60))
+    handlers.onTouchMove(touchEvent(44, 64))
+    vi.advanceTimersByTime(LONG_PRESS_MS)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/unit/server/session-directory/service.test.ts
+++ b/test/unit/server/session-directory/service.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import fsp from 'fs/promises'
 import path from 'path'
 import os from 'os'
@@ -968,23 +968,32 @@ describe('querySessionDirectory file-based search', () => {
     await expect(resultPromise).rejects.toThrow(/aborted/i)
   })
 
-  it('title-tier search completes quickly for many sessions (performance guard)', async () => {
+  it('title-tier search stays metadata-only for many sessions', async () => {
+    const sessionFile = path.join(tempDir, 'title-tier-should-not-read.jsonl')
+    await fsp.writeFile(sessionFile, '{"type":"user","message":{"role":"user","content":"deploy"}}\n')
+    const parseEvent = vi.fn(() => {
+      throw new Error('title-tier search must not scan session files')
+    })
+    const provider = {
+      ...claudeProvider,
+      parseEvent,
+    }
     const sessions = Array.from({ length: 1000 }, (_, i) => makeSession({
       sessionId: `session-${i}`,
       projectPath: '/repo',
       lastActivityAt: 10000 - i,
       title: i % 10 === 0 ? `Deploy session ${i}` : `Other session ${i}`,
+      sourceFile: sessionFile,
     }))
 
-    const start = performance.now()
     const page = await querySessionDirectory({
       projects: [makeProject('/repo', sessions)],
       terminalMeta: [],
+      providers: [provider],
       query: { priority: 'visible', query: 'deploy', tier: 'title' },
     })
-    const elapsed = performance.now() - start
 
     expect(page.items.length).toBeGreaterThan(0)
-    expect(elapsed).toBeLessThan(50)
+    expect(parseEvent).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Add fresh-agent pane client surfaces, action sheets, approvals, context meter, turn actions, and transcript updates.
- Add fresh-agent extras router wiring and MCP/tool support.
- Cover the new behavior with focused client/server tests and deterministic terminal write queue coverage.

## Verification
- `npm run check` passed after rebasing onto current `main`: client, server, and electron suites all green.

Landing via PR per branch policy; local `main` will be realigned to remote after merge.