### PR TITLE
feat(fresh-agent): configurable fresh client font size, +50% default

### DIFF
--- a/shared/settings.ts
+++ b/shared/settings.ts
@@ -42,6 +42,11 @@ const PANE_SNAP_THRESHOLD_MIN = 0
 const PANE_SNAP_THRESHOLD_MAX = 8
 const SIDEBAR_WIDTH_MIN = 200
 const SIDEBAR_WIDTH_MAX = 500
+const FRESH_AGENT_FONT_SCALE_MIN = 1
+const FRESH_AGENT_FONT_SCALE_MAX = 2
+// Fresh-agent panes render 50% larger than the base UI by default.
+export const FRESH_AGENT_FONT_SCALE_DEFAULT = 1.5
+export const FRESH_AGENT_FONT_SCALE_OPTIONS = [1, 1.25, 1.5, 1.75, 2] as const
 
 const TERMINAL_LOCAL_KEYS = [
   'fontSize',
@@ -69,6 +74,7 @@ const AGENT_CHAT_LOCAL_KEYS = [
   'showThinking',
   'showTools',
   'showTimecodes',
+  'fontScale',
 ] as const
 
 export type ThemeMode = (typeof THEME_VALUES)[number]
@@ -202,11 +208,13 @@ export type LocalSettings = {
     showThinking: boolean
     showTools: boolean
     showTimecodes: boolean
+    fontScale: number
   }
   agentChat: {
     showThinking: boolean
     showTools: boolean
     showTimecodes: boolean
+    fontScale: number
   }
   notifications: {
     soundEnabled: boolean
@@ -408,6 +416,17 @@ function normalizeRoundedClampedNumber(value: unknown, min: number, max: number)
   return Math.round(normalized)
 }
 
+function normalizeFreshAgentFontScale(value: unknown): number {
+  return (
+    normalizeClampedNumber(value, FRESH_AGENT_FONT_SCALE_MIN, FRESH_AGENT_FONT_SCALE_MAX)
+    ?? FRESH_AGENT_FONT_SCALE_DEFAULT
+  )
+}
+
+function normalizeLocalFreshAgent(value: LocalSettings['freshAgent']): LocalSettings['freshAgent'] {
+  return { ...value, fontScale: normalizeFreshAgentFontScale(value.fontScale) }
+}
+
 function normalizeExtractedLocalSeed(patch: Record<string, unknown>): LocalSettingsPatch | undefined {
   const normalized: LocalSettingsPatch = {}
 
@@ -539,6 +558,14 @@ function normalizeExtractedLocalSeed(patch: Record<string, unknown>): LocalSetti
     }
     if (typeof patch.agentChat.showTimecodes === 'boolean') {
       agentChat.showTimecodes = patch.agentChat.showTimecodes as boolean
+    }
+    const normalizedFontScale = normalizeClampedNumber(
+      patch.agentChat.fontScale,
+      FRESH_AGENT_FONT_SCALE_MIN,
+      FRESH_AGENT_FONT_SCALE_MAX,
+    )
+    if (normalizedFontScale !== undefined) {
+      agentChat.fontScale = normalizedFontScale
     }
     if (Object.keys(agentChat).length > 0) {
       normalized.agentChat = agentChat
@@ -810,11 +837,13 @@ export const defaultLocalSettings: LocalSettings = {
     showThinking: false,
     showTools: false,
     showTimecodes: false,
+    fontScale: FRESH_AGENT_FONT_SCALE_DEFAULT,
   },
   agentChat: {
     showThinking: false,
     showTools: false,
     showTimecodes: false,
+    fontScale: FRESH_AGENT_FONT_SCALE_DEFAULT,
   },
   notifications: {
     soundEnabled: true,
@@ -1165,8 +1194,8 @@ export function resolveLocalSettings(patch?: LocalSettingsPatch): LocalSettings 
       sortMode: normalizeLocalSortMode(patch?.sidebar?.sortMode),
       worktreeGrouping: normalizeWorktreeGrouping(patch?.sidebar?.worktreeGrouping),
     },
-    freshAgent: mergeDefined(defaultLocalSettings.freshAgent, freshAgentPatch),
-    agentChat: mergeDefined(defaultLocalSettings.agentChat, freshAgentPatch),
+    freshAgent: normalizeLocalFreshAgent(mergeDefined(defaultLocalSettings.freshAgent, freshAgentPatch)),
+    agentChat: normalizeLocalFreshAgent(mergeDefined(defaultLocalSettings.agentChat, freshAgentPatch)),
     notifications: mergeDefined(defaultLocalSettings.notifications, patch?.notifications),
   }
 }

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { nanoid } from 'nanoid'
 import type { FreshAgentPaneContent } from '@/store/paneTypes'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
@@ -17,6 +17,7 @@ import { paneRefreshTargetMatchesContent } from '@/lib/pane-utils'
 import { getCanonicalDurableSessionId, getPreferredResumeSessionId } from '@/store/persistControl'
 import { isValidClaudeSessionId } from '@/lib/claude-session-id'
 import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
+import { FRESH_AGENT_FONT_SCALE_DEFAULT } from '@shared/settings'
 import type { FreshAgentSnapshot } from '@shared/fresh-agent-contract'
 import { getFreshAgentSlashCommands, type FreshAgentSlashCommand } from '@shared/fresh-agent-slash-commands'
 import { buildRestoreError, type RestoreErrorReason } from '@shared/session-contract'
@@ -173,6 +174,9 @@ export function FreshAgentView({
 }) {
   const dispatch = useAppDispatch()
   const ws = getWsClient()
+  const freshFontScale = useAppSelector(
+    (state) => state.settings.settings.freshAgent?.fontScale,
+  ) ?? FRESH_AGENT_FONT_SCALE_DEFAULT
   const pendingCreateFailure = useAppSelector(
     (state) => state.freshAgent?.pendingCreateFailures?.[paneContent.createRequestId],
   )
@@ -1103,7 +1107,12 @@ export function FreshAgentView({
     }
 
     return (
-      <div className="flex h-full min-h-0 flex-col" data-context="fresh-agent" data-session-id={paneContent.sessionId}>
+      <div
+        className="flex h-full min-h-0 flex-col"
+        data-context="fresh-agent"
+        data-session-id={paneContent.sessionId}
+        style={{ '--fresh-font-scale': String(freshFontScale) } as CSSProperties}
+      >
         <div className="flex min-h-0 flex-1">
           <div
             className="flex min-h-0 flex-1 flex-col"
@@ -1304,6 +1313,7 @@ export function FreshAgentView({
     sendFreshAgentMessage,
     tabId,
     tabTitleSetByUser,
+    freshFontScale,
   ])
 
   useEffect(() => {

--- a/src/components/settings/WorkspaceSettings.tsx
+++ b/src/components/settings/WorkspaceSettings.tsx
@@ -10,6 +10,7 @@ import type {
   AttentionDismiss,
 } from '@/store/types'
 import { parseNormalizedLineList } from '@shared/string-list'
+import { FRESH_AGENT_FONT_SCALE_OPTIONS, FRESH_AGENT_FONT_SCALE_DEFAULT } from '@shared/settings'
 import type { SettingsSectionProps } from './settings-types'
 import {
   SettingsSection,
@@ -310,6 +311,31 @@ export default function WorkspaceSettings({
               })
             }}
           />
+        </SettingsRow>
+        <SettingsRow
+          label="Font size"
+          description="Scale the text in fresh-agent panes (Freshclaude, Freshcodex, and friends)."
+        >
+          <select
+            aria-label="Fresh agent font size"
+            value={String(
+              settings.freshAgent?.fontScale ?? settings.agentChat?.fontScale ?? FRESH_AGENT_FONT_SCALE_DEFAULT,
+            )}
+            onChange={(e) => {
+              const fontScale = Number(e.target.value)
+              applyLocalSetting({
+                freshAgent: { fontScale },
+                agentChat: { fontScale },
+              })
+            }}
+            className="h-10 w-full px-3 text-sm bg-muted border-0 rounded-md focus:outline-none focus:ring-1 focus:ring-border md:h-8 md:w-auto"
+          >
+            {FRESH_AGENT_FONT_SCALE_OPTIONS.map((scale) => (
+              <option key={scale} value={String(scale)}>
+                {`${Math.round(scale * 100)}%`}
+              </option>
+            ))}
+          </select>
         </SettingsRow>
       </SettingsSection>
 

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,18 @@ html {
   font-size: calc(100% * var(--ui-scale, 1.25));
 }
 
+/* Fresh-agent panes render at a user-configurable scale (Settings → Workspace →
+   Fresh agent → Font size; default 150%). FreshAgentView sets --fresh-font-scale
+   on the pane root. `zoom` scales the whole pane proportionally so every text
+   size — including markdown prose and responsive variants — grows together; the
+   width/height compensation keeps the (block-filling) pane exactly inside its
+   slot instead of overflowing by the scale factor. */
+[data-context="fresh-agent"] {
+  zoom: var(--fresh-font-scale, 1);
+  width: calc(100% / var(--fresh-font-scale, 1));
+  height: calc(100% / var(--fresh-font-scale, 1));
+}
+
 body {
   background: hsl(var(--background));
   color: hsl(var(--foreground));

--- a/src/store/browserPreferencesPersistence.ts
+++ b/src/store/browserPreferencesPersistence.ts
@@ -131,6 +131,7 @@ export function buildLocalSettingsPatch(localSettings: LocalSettings): LocalSett
   assignChangedScalar(freshAgent, localSettings.freshAgent, defaultLocalSettings.freshAgent, 'showThinking')
   assignChangedScalar(freshAgent, localSettings.freshAgent, defaultLocalSettings.freshAgent, 'showTools')
   assignChangedScalar(freshAgent, localSettings.freshAgent, defaultLocalSettings.freshAgent, 'showTimecodes')
+  assignChangedScalar(freshAgent, localSettings.freshAgent, defaultLocalSettings.freshAgent, 'fontScale')
   if (Object.keys(freshAgent).length > 0) {
     patch.freshAgent = freshAgent
     patch.agentChat = freshAgent

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -253,6 +253,96 @@ test.describe('Fresh Agent', () => {
     })
   })
 
+  test('renders the fresh-agent pane at the configured font scale without clipping the composer', async ({ freshellPage, page, harness, terminal }) => {
+    await terminal.waitForTerminal()
+    const { tabId, paneId } = await getActiveLeaf(harness)
+    const sessionId = '44444444-4444-4444-8444-444444444444'
+
+    await page.route(`**/api/fresh-agent/threads/freshclaude/claude/${sessionId}*`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          sessionType: 'freshclaude',
+          provider: 'claude',
+          threadId: sessionId,
+          sessionId,
+          revision: 1,
+          latestTurnId: null,
+          status: 'idle',
+          summary: 'Scaled summary line',
+          capabilities: { send: true, interrupt: true, approvals: true, questions: true, fork: false },
+          settings: { model: 'claude-opus-4-6', permissionMode: 'default', plugins: [] },
+          tokenUsage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0 },
+          pendingApprovals: [],
+          pendingQuestions: [],
+          turns: [],
+          extensions: {
+            claude: {
+              liveSessionId: sessionId,
+              cliSessionId: sessionId,
+            },
+          },
+        }),
+      })
+    })
+
+    await page.evaluate(({ currentTabId, currentPaneId, currentSessionId }) => {
+      window.__FRESHELL_TEST_HARNESS__?.dispatch({
+        type: 'panes/updatePaneContent',
+        payload: {
+          tabId: currentTabId,
+          paneId: currentPaneId,
+          content: {
+            kind: 'fresh-agent',
+            sessionType: 'freshclaude',
+            provider: 'claude',
+            createRequestId: 'req-e2e-fontscale',
+            sessionId: currentSessionId,
+            sessionRef: { provider: 'claude', sessionId: currentSessionId },
+            resumeSessionId: currentSessionId,
+            status: 'idle',
+            settingsDismissed: true,
+          },
+        },
+      })
+    }, { currentTabId: tabId, currentPaneId: paneId, currentSessionId: sessionId })
+
+    const paneRoot = page.locator('[data-context="fresh-agent"]')
+    await expect(paneRoot).toBeVisible({ timeout: 10_000 })
+
+    const readScale = () =>
+      paneRoot.evaluate((el) => getComputedStyle(el).getPropertyValue('--fresh-font-scale').trim())
+
+    // The fresh-agent panes default to 150% (the +50% larger default).
+    expect(await readScale()).toBe('1.5')
+
+    const textLine = page.getByText('Scaled summary line')
+    await expect(textLine).toBeVisible()
+    const heightAt150 = (await textLine.boundingBox())!.height
+
+    // No clipping: the composer textarea stays within the pane at the larger scale.
+    const composer = paneRoot.locator('textarea').first()
+    await expect(composer).toBeVisible()
+    const paneBox = (await paneRoot.boundingBox())!
+    const composerBox = (await composer.boundingBox())!
+    expect(composerBox.y + composerBox.height).toBeLessThanOrEqual(paneBox.y + paneBox.height + 2)
+
+    // Shrinking the setting to 100% scales the rendered transcript down ~1.5x.
+    await page.evaluate(() => {
+      window.__FRESHELL_TEST_HARNESS__?.dispatch({
+        type: 'settings/updateSettingsLocal',
+        payload: { freshAgent: { fontScale: 1 }, agentChat: { fontScale: 1 } },
+      })
+    })
+    await expect.poll(readScale).toBe('1')
+    const heightAt100 = (await textLine.boundingBox())!.height
+
+    const ratio = heightAt150 / heightAt100
+    expect(ratio).toBeGreaterThan(1.35)
+    expect(ratio).toBeLessThan(1.65)
+  })
+
   test('browser user can create and resume Freshcodex with worktree, review, and fork metadata in the shared pane', async ({ freshellPage, page, harness, terminal, serverInfo }) => {
     await terminal.waitForTerminal()
     await enableClaudeAndCodex(page)

--- a/test/unit/client/components/SettingsView.agent-chat.test.tsx
+++ b/test/unit/client/components/SettingsView.agent-chat.test.tsx
@@ -127,6 +127,38 @@ describe('SettingsView fresh agent settings', () => {
     expect(store.getState().settings.settings.agentChat.showTimecodes).toBe(true)
   })
 
+  it('renders the Font size dropdown defaulting to 150% (50% larger)', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    const select = screen.getByLabelText('Fresh agent font size') as HTMLSelectElement
+    expect(select).toBeInTheDocument()
+    expect(select.value).toBe('1.5')
+    expect(screen.getByRole('option', { name: '150%' })).toBeInTheDocument()
+  })
+
+  it('reflects a preloaded fresh agent font scale', () => {
+    const store = createSettingsViewStore({
+      settings: { freshAgent: { fontScale: 2 }, agentChat: { fontScale: 2 } },
+    })
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    expect((screen.getByLabelText('Fresh agent font size') as HTMLSelectElement).value).toBe('2')
+  })
+
+  it('changing the Font size dropdown updates freshAgent and agentChat in the store', () => {
+    const store = createSettingsViewStore()
+    renderSettingsView(store)
+    switchSettingsTab('Workspace')
+
+    fireEvent.change(screen.getByLabelText('Fresh agent font size'), { target: { value: '1.75' } })
+
+    expect(store.getState().settings.settings.freshAgent.fontScale).toBe(1.75)
+    expect(store.getState().settings.settings.agentChat.fontScale).toBe(1.75)
+  })
+
   it('toggling off a previously-on setting sets it to false', () => {
     const store = createSettingsViewStore({
       settings: { freshAgent: { showThinking: true }, agentChat: { showThinking: true } },

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, fireEvent, cleanup, act } from '@testing-libra
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import panesReducer from '@/store/panesSlice'
-import settingsReducer from '@/store/settingsSlice'
+import settingsReducer, { updateSettingsLocal } from '@/store/settingsSlice'
 import freshAgentReducer from '@/store/freshAgentSlice'
 import agentChatReducer from '@/store/agentChatSlice'
 import tabsReducer from '@/store/tabsSlice'
@@ -2449,5 +2449,54 @@ describe('FreshAgentView', () => {
       expect(leaf.content.sessionId).toBe('runtime-id')
       expect(leaf.content.modelSelection).toEqual({ kind: 'exact', modelId: 'ui-selected-model' })
     })
+  })
+})
+
+describe('FreshAgentView font scale', () => {
+  const freshClaudePane = {
+    kind: 'fresh-agent',
+    sessionType: 'freshclaude',
+    provider: 'claude',
+    createRequestId: 'req-1',
+    sessionId: CLAUDE_THREAD_ID,
+    status: 'connected',
+  } as const
+
+  it('applies the default 50%-larger font scale to the fresh-agent pane root', async () => {
+    const store = createStore()
+    render(
+      <Provider store={store}>
+        <FreshAgentView tabId="tab-1" paneId="pane-1" paneContent={freshClaudePane} />
+      </Provider>,
+    )
+
+    const root = document.querySelector('[data-context="fresh-agent"]') as HTMLElement
+    expect(root).toBeTruthy()
+    expect(root.style.getPropertyValue('--fresh-font-scale')).toBe('1.5')
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+  })
+
+  it('updates the fresh-agent pane font scale live when the setting changes', async () => {
+    const store = createStore()
+    render(
+      <Provider store={store}>
+        <FreshAgentView tabId="tab-1" paneId="pane-1" paneContent={freshClaudePane} />
+      </Provider>,
+    )
+
+    const root = document.querySelector('[data-context="fresh-agent"]') as HTMLElement
+    expect(root.style.getPropertyValue('--fresh-font-scale')).toBe('1.5')
+
+    await act(async () => {
+      store.dispatch(updateSettingsLocal({
+        freshAgent: { fontScale: 1.25 },
+        agentChat: { fontScale: 1.25 },
+      }))
+    })
+
+    expect(root.style.getPropertyValue('--fresh-font-scale')).toBe('1.25')
   })
 })

--- a/test/unit/client/store/browserPreferencesPersistence.test.ts
+++ b/test/unit/client/store/browserPreferencesPersistence.test.ts
@@ -220,4 +220,38 @@ describe('browserPreferencesPersistence', () => {
     const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
     expect(bp.settings?.agentChat).toBeUndefined()
   })
+
+  it('persists freshAgent.fontScale (mirrored to agentChat) when changed from the default', () => {
+    const store = createStore()
+
+    store.dispatch(updateSettingsLocal({
+      freshAgent: { fontScale: 1.75 },
+      agentChat: { fontScale: 1.75 },
+    }))
+
+    vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings.freshAgent).toEqual({ fontScale: 1.75 })
+    expect(bp.settings.agentChat).toEqual({ fontScale: 1.75 })
+
+    const rehydrated = resolveLocalSettings(bp.settings)
+    expect(rehydrated.freshAgent.fontScale).toBe(1.75)
+    expect(rehydrated.agentChat.fontScale).toBe(1.75)
+  })
+
+  it('does not persist freshAgent.fontScale when left at the default', () => {
+    const store = createStore()
+
+    store.dispatch(updateSettingsLocal({
+      freshAgent: { fontScale: 1.5 },
+      agentChat: { fontScale: 1.5 },
+    }))
+
+    vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
+
+    const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
+    expect(bp.settings?.freshAgent).toBeUndefined()
+    expect(bp.settings?.agentChat).toBeUndefined()
+  })
 })

--- a/test/unit/shared/settings.test.ts
+++ b/test/unit/shared/settings.test.ts
@@ -424,4 +424,51 @@ describe('shared settings contract', () => {
     const schema = buildServerSettingsPatchSchema()
     expect(schema.safeParse({ panes: { multirowTabs: true } }).success).toBe(false)
   })
+
+  describe('fresh-agent font scale', () => {
+    it('defaults the fresh-agent font scale to 1.5 (50% larger)', () => {
+      const resolved = resolveLocalSettings(undefined)
+      expect(resolved.freshAgent.fontScale).toBe(1.5)
+      expect(resolved.agentChat.fontScale).toBe(1.5)
+    })
+
+    it('resolves a configured fresh-agent font scale and mirrors it to agentChat', () => {
+      const resolved = resolveLocalSettings({ freshAgent: { fontScale: 1.75 } })
+      expect(resolved.freshAgent.fontScale).toBe(1.75)
+      expect(resolved.agentChat.fontScale).toBe(1.75)
+    })
+
+    it('accepts the fresh-agent font scale through the legacy agentChat alias', () => {
+      const resolved = resolveLocalSettings({ agentChat: { fontScale: 1.25 } })
+      expect(resolved.freshAgent.fontScale).toBe(1.25)
+      expect(resolved.agentChat.fontScale).toBe(1.25)
+    })
+
+    it('clamps an out-of-range fresh-agent font scale into the supported range', () => {
+      expect(resolveLocalSettings({ freshAgent: { fontScale: 5 } }).freshAgent.fontScale).toBe(2)
+      expect(resolveLocalSettings({ freshAgent: { fontScale: 0.1 } }).freshAgent.fontScale).toBe(1)
+    })
+
+    it('falls back to the default when the fresh-agent font scale is not a finite number', () => {
+      expect(
+        resolveLocalSettings({
+          freshAgent: { fontScale: 'big' as unknown as number },
+        }).freshAgent.fontScale,
+      ).toBe(1.5)
+    })
+
+    it('exposes the resolved fresh-agent font scale in composed settings', () => {
+      const resolved = composeResolvedSettings(
+        createDefaultServerSettings({ loggingDebug: false }),
+        resolveLocalSettings({ freshAgent: { fontScale: 2 } }),
+      )
+      expect(resolved.freshAgent.fontScale).toBe(2)
+    })
+
+    it('clamps the fresh-agent font scale when extracting a legacy local seed', () => {
+      expect(
+        extractLegacyLocalSettingsSeed({ agentChat: { fontScale: 9 } } as Record<string, unknown>),
+      ).toEqual({ agentChat: { fontScale: 2 } })
+    })
+  })
 })


### PR DESCRIPTION
## What & why

Fresh* agent panes (Freshclaude, Freshcodex, Freshopencode, and feature-flagged fresh clients) now render **50% larger by default**, and the size is **configurable** via a new **Font size** dropdown in **Settings → Workspace → Fresh agent** (100% / 125% / 150% / 175% / 200%, default 150%).

## How it works

- **Setting:** `LocalSettings.freshAgent.fontScale` (device-local display preference, like `uiScale`), mirrored to the legacy `agentChat` alias. Default `1.5`, clamped to `[1, 2]`, persisted to browser preferences and rehydrated through the normal local-settings path.
- **Rendering:** `FreshAgentView` sets `--fresh-font-scale` on the pane root (`[data-context="fresh-agent"]`). A single scoped CSS rule applies `zoom: var(--fresh-font-scale)` with `width/height: calc(100% / var(...))` compensation. Using `zoom` (rather than per-utility font-size overrides) scales the *whole* pane proportionally — including markdown prose, arbitrary `text-[11px]` badges, and responsive `sm:` variants — with no per-class enumeration to keep in sync. The compensation keeps the block-filling pane exactly inside its slot (the pane content area is a definite-height `flex-1` box with `overflow-hidden`), so nothing clips. The pane title bar is left unscaled, matching other panes.
- **UI:** a `<select>` dropdown in the existing Fresh agent settings section, dispatching `applyLocalSetting` (local-only, no server round-trip).

## Tests

- **shared settings contract** — defaults to 1.5, resolves/mirrors `freshAgent`↔`agentChat`, clamps out-of-range, falls back on non-finite, surfaces in composed settings, and clamps in the legacy seed.
- **browser-preference persistence** — persists `fontScale` (mirrored) when changed, omits it at default.
- **settings dropdown UI** — renders defaulting to 150%, reflects a preloaded value, updates the store on change.
- **FreshAgentView** — root receives the scale from settings and updates **live** when the setting changes (guards the memo-deps wiring).
- **e2e-browser** — a real Chromium test asserts the pane defaults to `--fresh-font-scale: 1.5`, that rendered text scales ~1.5× vs 100%, and that the composer is **not clipped** at the larger scale.

Full coordinated suite green; typecheck and lint clean; e2e-browser font-scale test and all 6 screenshot baselines pass (the settings-view baseline captures the Appearance tab, so the new Workspace row doesn't shift it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)