### PR TITLE
Fix terminal Escape key input

### DIFF
--- a/scripts/prepare-bundled-node.ts
+++ b/scripts/prepare-bundled-node.ts
@@ -29,7 +29,7 @@ import http from 'http'
 import https from 'https'
 import { createRequire } from 'module'
 import path from 'path'
-import { pipeline } from 'stream/promises'
+import { pipeline } from 'node:stream/promises'
 import { fileURLToPath } from 'url'
 import tar from 'tar'
 

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -1930,6 +1930,19 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
         return false
       }
 
+      if (
+        event.key === 'Escape' &&
+        event.type === 'keydown' &&
+        !event.ctrlKey &&
+        !event.shiftKey &&
+        !event.altKey &&
+        !event.metaKey
+      ) {
+        event.preventDefault()
+        sendInput('\u001b')
+        return false
+      }
+
       const tabSwitchDirection = getTabSwitchShortcutDirection(event)
       if (tabSwitchDirection && event.type === 'keydown' && !event.repeat) {
         event.preventDefault()

--- a/test/e2e/terminal-paste-single-ingress.test.tsx
+++ b/test/e2e/terminal-paste-single-ingress.test.tsx
@@ -267,4 +267,50 @@ describe('terminal paste single-ingress (e2e)', () => {
       data: 'meta-alt paste payload',
     })
   })
+
+  it('sends plain Escape once as terminal input', async () => {
+    const store = createStore()
+    const paneContent: TerminalPaneContent = {
+      kind: 'terminal',
+      createRequestId: 'req-1',
+      status: 'running',
+      mode: 'shell',
+      shell: 'system',
+      terminalId: 'term-1',
+      initialCwd: '/tmp',
+    }
+
+    render(
+      <Provider store={store}>
+        <TerminalView tabId="tab-1" paneId="pane-1" paneContent={paneContent} />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(keyHandler).not.toBeNull()
+    })
+
+    wsMocks.send.mockClear()
+    const preventDefault = vi.fn()
+    const blocked = keyHandler!({
+      key: 'Escape',
+      code: 'Escape',
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      altKey: false,
+      type: 'keydown',
+      repeat: false,
+      preventDefault,
+    } as unknown as KeyboardEvent)
+
+    expect(blocked).toBe(false)
+    expect(preventDefault).toHaveBeenCalled()
+    expect(wsMocks.send).toHaveBeenCalledTimes(1)
+    expect(wsMocks.send).toHaveBeenCalledWith({
+      type: 'terminal.input',
+      terminalId: 'term-1',
+      data: '\u001b',
+    })
+  })
 })

--- a/test/integration/server/logger.separation.test.ts
+++ b/test/integration/server/logger.separation.test.ts
@@ -18,6 +18,7 @@ const REPO_ROOT = path.resolve(__dirname, '../../..')
 const require = createRequire(import.meta.url)
 let TSX_CLI: string | undefined
 const DEFAULT_TEST_TIMEOUT_MS = 120_000
+const FILE_CONTENT_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 5_000
 const ANSI_ESCAPE_PATTERN = /\u001b\[[0-9;]*m/g
 const SOURCE_LOGGER_PROBE = [
   '(async () => {',
@@ -129,7 +130,7 @@ async function startDistLoggerProcess(env: NodeJS.ProcessEnv) {
   )
 }
 
-async function waitForFileContent(filePath: string, pattern: RegExp, timeoutMs = 5000): Promise<string> {
+async function waitForFileContent(filePath: string, pattern: RegExp, timeoutMs = FILE_CONTENT_TIMEOUT_MS): Promise<string> {
   const deadline = Date.now() + timeoutMs
   let lastContent = ''
 

--- a/test/server/fresh-agent-extras.test.ts
+++ b/test/server/fresh-agent-extras.test.ts
@@ -238,7 +238,7 @@ describe('fresh-agent extras router', () => {
         .post('/api/fresh-agent/checkpoints/restore')
         .send({ cwd: dir, id: first.body.id })
         .expect(200)
-      expect(await fsp.readFile(file, 'utf8')).toBe('version one\n')
+      expect((await fsp.readFile(file, 'utf8')).replace(/\r\n/g, '\n')).toBe('version one\n')
       // The cwd itself never became a git repo.
       await expect(fsp.access(path.join(dir, '.git'))).rejects.toThrow()
     })

--- a/test/unit/client/components/TerminalView.keyboard.test.tsx
+++ b/test/unit/client/components/TerminalView.keyboard.test.tsx
@@ -288,6 +288,7 @@ function createKeyboardEvent(key: string, modifiers: { ctrlKey?: boolean; shiftK
     '[': 'BracketLeft',
     ']': 'BracketRight',
     Insert: 'Insert',
+    Escape: 'Escape',
     ArrowLeft: 'ArrowLeft',
     ArrowRight: 'ArrowRight',
     t: 'KeyT',
@@ -874,6 +875,33 @@ describe('TerminalView keyboard handling', () => {
   })
 
   describe('other keys', () => {
+    it('sends plain Escape directly as terminal input', async () => {
+      const { store, tabId, paneId, paneContent } = createTestStore('term-1')
+
+      render(
+        <Provider store={store}>
+          <TerminalView tabId={tabId} paneId={paneId} paneContent={paneContent} />
+        </Provider>
+      )
+
+      await waitFor(() => {
+        expect(capturedKeyHandler).not.toBeNull()
+      })
+
+      const wsSendCountBefore = wsMocks.send.mock.calls.length
+      const event = createKeyboardEvent('Escape')
+      const result = capturedKeyHandler!(event)
+
+      expect(result).toBe(false)
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(wsMocks.send).toHaveBeenCalledTimes(wsSendCountBefore + 1)
+      expect(wsMocks.send).toHaveBeenLastCalledWith({
+        type: 'terminal.input',
+        terminalId: 'term-1',
+        data: '\u001b',
+      })
+    })
+
     it('returns true for unhandled keys to let xterm process them', async () => {
       const { store, tabId, paneId, paneContent } = createTestStore('term-1')
 

--- a/test/unit/server/logger.test.ts
+++ b/test/unit/server/logger.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import os from "os"
 import path from "path"
 import fsp from "fs/promises"
-import { Writable } from "stream"
+import { Writable } from "node:stream"
 
 describe("logger", () => {
   const originalEnv = { ...process.env }


### PR DESCRIPTION
Summary:
- Send unmodified Escape from TerminalView as a single terminal.input payload containing the ESC control byte.
- Add unit and e2e-style ingress regressions for Escape.
- Use explicit node: stream imports uncovered by the coordinated verification run.

Verification:
- npm run check