### PR TITLE
Harden Claude resume session durability

### DIFF
--- a/docs/superpowers/plans/2026-06-12-claude-resume-robustness.md
+++ b/docs/superpowers/plans/2026-06-12-claude-resume-robustness.md
@@ -1,0 +1,1020 @@
+# Claude Resume Robustness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Claude terminal resume deterministic by assigning fresh Claude panes a durable UUID before launch, spawning fresh Claude with `--session-id`, restoring with `--resume` from the original cwd, and preventing ambiguous cwd/time-based wrong associations.
+
+**Architecture:** Treat Claude more like Codex and OpenCode: Freshell owns the terminal-to-provider identity at launch time instead of waiting for the session indexer to infer it later. `TerminalRegistry` will support provider launch intent so a Claude UUID can be used either as fresh creation identity (`--session-id <uuid>`) or restore identity (`--resume <uuid>`). The existing Claude indexer association path remains only as legacy repair and must fail closed when more than one unassociated same-cwd terminal could match.
+
+**Tech Stack:** Node.js/TypeScript ESM, `node-pty`, WebSocket protocol, React/Redux persistence, Vitest, superwstest, real Claude CLI contract tests.
+
+---
+
+## Files And Responsibilities
+
+- Modify `server/extension-manifest.ts`: add strict manifest support for `cli.createSessionArgs`.
+- Modify `server/index.ts`: compile manifest `createSessionArgs` templates into `CodingCliCommandSpec.createSessionArgs`.
+- Modify `extensions/claude-code/freshell.json`: declare Claude fresh-session args as `["--session-id", "{{sessionId}}"]`.
+- Modify `server/terminal-registry.ts`: add provider launch intent, manifest-driven Claude fresh-session args, immediate binding for preallocated fresh Claude UUIDs, and cwd-scoped Claude running-session lookup when cwd is available.
+- Modify `server/ws-handler.ts`: reserve fresh Claude UUIDs by `requestId`, pass `sessionBindingReason: "start"`, skip resume-repair waits for fresh preallocated sessions, and emit structured lifecycle evidence.
+- Modify `server/session-association-coordinator.ts`: keep legacy Claude heuristic association, but refuse ambiguous multiple-candidate matches instead of binding the oldest same-cwd terminal.
+- Modify `src/components/BackgroundSessions.tsx`: preserve running terminal `cwd` when opening a background Claude session into a pane.
+- Modify `shared/ws-protocol.ts` and `src/components/TerminalView.tsx`: include server-resolved `cwd` in `terminal.created` and preserve it as pane `initialCwd` when the pane did not already have one.
+- Modify `server/terminal-stream/registry-events.ts` only if the existing `SessionBindingReason = "start" | "resume" | "association"` proves insufficient. The preferred implementation reuses `"start"`.
+- Modify `test/unit/server/extension-manifest.test.ts`: prove `cli.createSessionArgs` is valid and strict schema still rejects unknown keys.
+- Modify `test/unit/server/terminal-registry.test.ts`: prove Claude `start` uses manifest-driven `--session-id`, Claude `resume` still uses `--resume`, fresh starts expose `sessionRef`, and cwd-scoped Claude lookup does not reuse a different cwd.
+- Modify `test/server/ws-terminal-create-reuse-running-claude.test.ts`: prove fresh Claude `terminal.create` returns a canonical `sessionRef` immediately, restore uses requested `sessionRef`, and duplicate create requests do not allocate conflicting UUIDs.
+- Modify `test/unit/server/session-association-coordinator.test.ts`: prove ambiguous same-cwd legacy association is rejected.
+- Modify `test/server/session-association.test.ts`: replace both existing same-cwd oldest-first expectations with fail-closed ambiguity behavior.
+- Modify `test/unit/client/components/TerminalView.resumeSession.test.tsx` and `test/unit/client/components/BackgroundSessions.test.tsx` if needed: prove restored/opened Claude panes send both `sessionRef` and the provider cwd.
+- Modify `test/integration/real/coding-cli-session-contract.test.ts`: refresh the Claude real-provider contract to assert cwd-scoped `--resume` lookup and explicit `--session-id` transcript creation when the local Claude probe is available; on this development machine, treat a failing available-Claude lookup contract as blocking even if model auth is unavailable.
+
+## Task 1: Add Manifest Support For Fresh Session Args
+
+**Files:**
+- Modify: `server/extension-manifest.ts`
+- Modify: `server/index.ts`
+- Modify: `server/terminal-registry.ts`
+- Modify: `extensions/claude-code/freshell.json`
+- Test: `test/unit/server/extension-manifest.test.ts`
+- Test: `test/unit/server/terminal-registry.test.ts`
+
+- [ ] **Step 1: Write the failing manifest schema tests**
+
+Add tests in `test/unit/server/extension-manifest.test.ts`:
+
+```ts
+it('accepts cli.createSessionArgs templates', () => {
+  const parsed = ExtensionManifestSchema.parse({
+    schemaVersion: 1,
+    id: 'test-claude',
+    name: 'Test Claude',
+    version: '1.0.0',
+    pane: { type: 'terminal', command: 'claude' },
+    cli: {
+      command: 'claude',
+      resumeArgs: ['--resume', '{{sessionId}}'],
+      createSessionArgs: ['--session-id', '{{sessionId}}'],
+    },
+  })
+
+  expect(parsed.cli?.createSessionArgs).toEqual(['--session-id', '{{sessionId}}'])
+})
+```
+
+Keep the existing unknown-key strictness test green; do not loosen the manifest object broadly.
+
+- [ ] **Step 2: Run the focused manifest test and verify it fails**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/extension-manifest.test.ts --run
+```
+
+Expected: the new test fails because `createSessionArgs` is not currently in the strict CLI schema.
+
+- [ ] **Step 3: Add `createSessionArgs` to the manifest and runtime spec**
+
+In `server/extension-manifest.ts`, add the optional field beside `resumeArgs`:
+
+```ts
+createSessionArgs: z.array(z.string()).optional(),
+```
+
+In `server/terminal-registry.ts`, add this field to `CodingCliCommandSpec`:
+
+```ts
+createSessionArgs?: (sessionId: string) => string[]
+```
+
+In `server/index.ts`, add a helper if one does not already exist for templated args:
+
+```ts
+const renderSessionArgs = (args: string[] | undefined, sessionId: string): string[] =>
+  (args ?? []).map((arg) => arg.replaceAll('{{sessionId}}', sessionId))
+```
+
+When building each `CodingCliCommandSpec`, set:
+
+```ts
+createSessionArgs: manifest.cli.createSessionArgs
+  ? (sessionId: string) => renderSessionArgs(manifest.cli!.createSessionArgs, sessionId)
+  : undefined,
+```
+
+In `extensions/claude-code/freshell.json`, add:
+
+```json
+"createSessionArgs": ["--session-id", "{{sessionId}}"]
+```
+
+next to the existing `resumeArgs`.
+
+- [ ] **Step 4: Prove manifest registration reaches spawn specs**
+
+Add or extend a terminal-registry test that registers a Claude spec with `createSessionArgs` and asserts `buildSpawnSpec(..., "start")` uses `--session-id`. The test must fail if runtime registration drops `createSessionArgs`.
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/extension-manifest.test.ts test/unit/server/terminal-registry.test.ts --run
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/extension-manifest.ts server/index.ts server/terminal-registry.ts extensions/claude-code/freshell.json test/unit/server/extension-manifest.test.ts test/unit/server/terminal-registry.test.ts
+git commit -m "feat: add manifest fresh session args"
+```
+
+## Task 2: Add Launch Intent To Claude Spawn Args
+
+**Files:**
+- Modify: `server/terminal-registry.ts`
+- Test: `test/unit/server/terminal-registry.test.ts`
+
+- [ ] **Step 1: Write the failing Linux spawn tests**
+
+Add these tests inside `describe('claude mode on Linux', ...)` in `test/unit/server/terminal-registry.test.ts`:
+
+```ts
+it('uses --session-id for a fresh Claude start with a preallocated UUID', () => {
+  delete process.env.CLAUDE_CMD
+
+  const spec = buildSpawnSpec(
+    'claude',
+    '/home/user/project',
+    'system',
+    VALID_CLAUDE_SESSION_ID,
+    undefined,
+    undefined,
+    undefined,
+    'start',
+  )
+
+  expect(spec.args).toContain('--session-id')
+  expect(spec.args).toContain(VALID_CLAUDE_SESSION_ID)
+  expect(spec.args).not.toContain('--resume')
+  expectClaudeMcpArgs(spec.args)
+  expect(spec.args.slice(-2)).toEqual(['--session-id', VALID_CLAUDE_SESSION_ID])
+})
+
+it('continues to use --resume for a Claude restore', () => {
+  delete process.env.CLAUDE_CMD
+
+  const spec = buildSpawnSpec(
+    'claude',
+    '/home/user/project',
+    'system',
+    VALID_CLAUDE_SESSION_ID,
+    undefined,
+    undefined,
+    undefined,
+    'resume',
+  )
+
+  expect(spec.args).toContain('--resume')
+  expect(spec.args).toContain(VALID_CLAUDE_SESSION_ID)
+  expect(spec.args).not.toContain('--session-id')
+  expectClaudeMcpArgs(spec.args)
+  expect(spec.args.slice(-2)).toEqual(['--resume', VALID_CLAUDE_SESSION_ID])
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/terminal-registry.test.ts --run
+```
+
+Expected failure: TypeScript rejects the extra `buildSpawnSpec` argument, or the first new test sees `--resume` instead of `--session-id`.
+
+- [ ] **Step 3: Implement provider launch intent**
+
+In `server/terminal-registry.ts`, extend the CLI command spec and resolver:
+
+```ts
+type ProviderLaunchIntent = 'start' | 'resume'
+
+export type CodingCliCommandSpec = {
+  label: string
+  envVar: string
+  defaultCommand: string
+  args?: string[]
+  env?: Record<string, string>
+  resumeArgs?: (sessionId: string) => string[]
+  createSessionArgs?: (sessionId: string) => string[]
+  modelArgs?: (model: string) => string[]
+  sandboxArgs?: (sandbox: string) => string[]
+  permissionModeArgs?: (permissionMode: string) => string[]
+  permissionModeEnvVar?: string
+  permissionModeEnvValues?: Record<string, string>
+}
+```
+
+Set Claude fallback args:
+
+```ts
+['claude', {
+  label: 'Claude CLI',
+  envVar: 'CLAUDE_CMD',
+  defaultCommand: 'claude',
+  resumeArgs: (sessionId: string) => ['--resume', sessionId],
+  createSessionArgs: (sessionId: string) => ['--session-id', sessionId],
+  permissionModeArgs: (permissionMode: string) => ['--permission-mode', permissionMode],
+}],
+```
+
+Update `resolveCodingCliCommand` to accept launch intent:
+
+```ts
+function resolveCodingCliCommand(
+  mode: TerminalMode,
+  resumeSessionId?: string,
+  target: ProviderTarget = 'unix',
+  providerSettings?: ProviderSettings,
+  terminalId?: string,
+  cwd?: string,
+  launchIntent: ProviderLaunchIntent = 'resume',
+) {
+  // existing setup stays the same
+  let resumeArgs: string[] = []
+  if (resumeSessionId) {
+    if (launchIntent === 'start' && spec.createSessionArgs) {
+      resumeArgs = spec.createSessionArgs(resumeSessionId)
+    } else if (spec.resumeArgs) {
+      resumeArgs = spec.resumeArgs(resumeSessionId)
+    } else {
+      logger.warn({ mode, resumeSessionId }, 'Resume requested but no resume args configured')
+    }
+  }
+  // existing return stays the same
+}
+```
+
+Update `buildSpawnSpec` signature:
+
+```ts
+export function buildSpawnSpec(
+  mode: TerminalMode,
+  cwd: string | undefined,
+  shell: ShellType,
+  resumeSessionId?: string,
+  providerSettings?: ProviderSettings,
+  envOverrides?: Record<string, string>,
+  terminalId?: string,
+  launchIntent: ProviderLaunchIntent = 'resume',
+) {
+```
+
+Thread `launchIntent` through every `resolveCodingCliCommand(...)` call in `buildSpawnSpec`.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/terminal-registry.test.ts --run
+```
+
+Expected: the new Claude spawn tests pass, and existing terminal-registry tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/terminal-registry.ts test/unit/server/terminal-registry.test.ts
+git commit -m "test: cover claude fresh session spawn intent"
+```
+
+## Task 3: Bind Fresh Claude Terminals At Creation
+
+**Files:**
+- Modify: `server/ws-handler.ts`
+- Modify: `server/terminal-registry.ts`
+- Test: `test/unit/server/terminal-registry.test.ts`
+- Test: `test/server/ws-terminal-create-reuse-running-claude.test.ts`
+
+- [ ] **Step 1: Write the failing registry test**
+
+Add this test in the `TerminalRegistry` `resumeSessionId` coverage area:
+
+```ts
+it('binds a fresh Claude start immediately and exposes its sessionRef', async () => {
+  const record = registry.create({
+    mode: 'claude',
+    cwd: '/home/user/project',
+    resumeSessionId: VALID_CLAUDE_SESSION_ID,
+    sessionBindingReason: 'start',
+  })
+
+  const pty = await import('node-pty')
+  const spawnCall = vi.mocked(pty.spawn).mock.calls.at(-1)
+  expect(spawnCall?.[0]).toBe('claude')
+  expect(spawnCall?.[1]).toContain('--session-id')
+  expect(spawnCall?.[1]).toContain(VALID_CLAUDE_SESSION_ID)
+  expect(spawnCall?.[1]).not.toContain('--resume')
+
+  expect(record.resumeSessionId).toBe(VALID_CLAUDE_SESSION_ID)
+  expect(registry.isSessionBound('claude', VALID_CLAUDE_SESSION_ID)).toBe(true)
+  expect(registry.list()[0]).toMatchObject({
+    resumeSessionId: VALID_CLAUDE_SESSION_ID,
+    sessionRef: {
+      provider: 'claude',
+      sessionId: VALID_CLAUDE_SESSION_ID,
+    },
+  })
+})
+```
+
+- [ ] **Step 2: Write the failing WebSocket fresh-create test**
+
+In `test/server/ws-terminal-create-reuse-running-claude.test.ts`, add a fake registry path or extend the existing `FakeRegistry` to capture create options. Add this test:
+
+```ts
+it('fresh Claude terminal.create returns a canonical sessionRef immediately', async () => {
+  const requestId = 'fresh-claude-preallocated'
+  const createdPromise = waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === requestId)
+
+  ws.send(JSON.stringify({
+    type: 'terminal.create',
+    requestId,
+    mode: 'claude',
+    shell: 'system',
+    cwd: '/home/user/project',
+    tabId: 'tab-claude-fresh',
+    paneId: 'pane-claude-fresh',
+  }))
+
+  const created = await createdPromise
+  expect(created.sessionRef?.provider).toBe('claude')
+  expect(created.sessionRef?.sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+})
+```
+
+If the existing fake registry cannot allocate from server code, replace the assertion with inspection of `FakeRegistry.createCalls.at(-1)`:
+
+```ts
+expect(fakeRegistry.createCalls.at(-1)).toMatchObject({
+  mode: 'claude',
+  resumeSessionId: created.sessionRef.sessionId,
+  sessionBindingReason: 'start',
+})
+```
+
+- [ ] **Step 3: Run tests and verify they fail**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/terminal-registry.test.ts test/server/ws-terminal-create-reuse-running-claude.test.ts --run
+```
+
+Expected: the WebSocket fresh-create test has no `sessionRef`, and the registry test may still spawn `--resume` until Task 1 is complete.
+
+- [ ] **Step 4: Implement request-scoped preallocation in `ws-handler`**
+
+Import `randomUUID`:
+
+```ts
+import { randomUUID } from 'crypto'
+```
+
+Extend `ClientState`:
+
+```ts
+claudeFreshSessionIdByRequestId: Map<string, string>
+```
+
+Initialize it with the other per-connection maps:
+
+```ts
+claudeFreshSessionIdByRequestId: new Map(),
+```
+
+Add a helper near `terminalCreateLockKey`:
+
+```ts
+private reserveClaudeFreshSessionId(state: ClientState, requestId: string): string {
+  const existing = state.claudeFreshSessionIdByRequestId.get(requestId)
+  if (existing) return existing
+  const next = randomUUID()
+  state.claudeFreshSessionIdByRequestId.set(requestId, next)
+  return next
+}
+```
+
+Near `effectiveResumeSessionId`, add:
+
+```ts
+let effectiveResumeSessionId: string | undefined
+let sessionBindingReason: 'start' | 'resume' | undefined
+```
+
+After the existing requested-session logic, assign fresh Claude identity only for non-restore creates:
+
+```ts
+const shouldPreallocateFreshClaudeSession =
+  m.mode === 'claude'
+  && m.restore !== true
+  && !requestedSessionRef
+  && !m.resumeSessionId
+  && !m.recoveryIntent
+
+if (shouldPreallocateFreshClaudeSession) {
+  effectiveResumeSessionId = this.reserveClaudeFreshSessionId(state, m.requestId)
+  sessionBindingReason = 'start'
+} else if (effectiveResumeSessionId && m.mode === 'claude') {
+  sessionBindingReason = 'resume'
+}
+```
+
+The reservation must happen before computing `terminalCreateLockKey(...)`, so duplicate `terminal.create` messages for the same `requestId` use the same lock key and the same future `sessionRef`.
+
+Skip Claude session repair for fresh starts:
+
+```ts
+if (
+  m.mode === 'claude'
+  && sessionBindingReason !== 'start'
+  && effectiveResumeSessionId
+  && isValidClaudeSessionId(effectiveResumeSessionId)
+  && this.sessionRepairService
+) {
+  // existing repair wait block
+}
+```
+
+Pass the binding reason into registry create:
+
+```ts
+const record = this.registry.create({
+  mode: m.mode as TerminalMode,
+  shell: m.shell as 'system' | 'cmd' | 'powershell' | 'wsl',
+  cwd: m.cwd,
+  resumeSessionId: effectiveResumeSessionId,
+  ...(sessionBindingReason ? { sessionBindingReason } : {}),
+  ...(codexPlan
+    ? {
+        sessionBindingReason: getCodexSessionBindingReason(m.mode, requestedCodexResumeSessionId),
+      }
+    : {}),
+  envContext: { tabId: m.tabId, paneId: m.paneId },
+  providerSettings: spawnProviderSettings,
+})
+```
+
+If TypeScript rejects duplicate `sessionBindingReason` spreads, compute a single local value before `registry.create`:
+
+```ts
+const terminalSessionBindingReason =
+  codexPlan
+    ? getCodexSessionBindingReason(m.mode, requestedCodexResumeSessionId)
+    : sessionBindingReason
+```
+
+Then spread `terminalSessionBindingReason`.
+
+Add lifecycle evidence when a fresh Claude UUID is allocated:
+
+```ts
+recordSessionLifecycleEvent({
+  kind: 'terminal_create_requested',
+  requestId: m.requestId,
+  connectionId: ws.connectionId || 'unknown',
+  ...(m.tabId ? { tabId: m.tabId } : {}),
+  ...(m.paneId ? { paneId: m.paneId } : {}),
+  ...(m.cwd ? { cwd: m.cwd } : {}),
+  mode: m.mode as TerminalMode,
+  restoreRequested: false,
+  hasRequestedSessionRef: false,
+  requestedSessionId: effectiveResumeSessionId,
+})
+```
+
+If duplicating `terminal_create_requested` is too noisy, add a new `kind: "claude_fresh_session_preallocated"` to `server/session-observability.ts` with fields `terminalId?`, `requestId`, `connectionId`, `sessionId`, `tabId?`, `paneId?`, and `cwd?`, and record it once after UUID generation.
+
+- [ ] **Step 5: Thread launch intent into registry spawn**
+
+In `TerminalRegistry.create`, compute:
+
+```ts
+const launchIntent: ProviderLaunchIntent =
+  opts.sessionBindingReason === 'start' ? 'start' : 'resume'
+```
+
+Pass it to `buildSpawnSpec(...)`:
+
+```ts
+const { file, args, env, cwd: procCwd, mcpCwd } = buildSpawnSpec(
+  opts.mode,
+  cwd,
+  shell,
+  resumeForSpawn,
+  opts.providerSettings,
+  baseEnv,
+  terminalId,
+  launchIntent,
+)
+```
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/terminal-registry.test.ts test/server/ws-terminal-create-reuse-running-claude.test.ts --run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/ws-handler.ts server/terminal-registry.ts server/session-observability.ts test/unit/server/terminal-registry.test.ts test/server/ws-terminal-create-reuse-running-claude.test.ts
+git commit -m "feat: preallocate durable claude terminal sessions"
+```
+
+## Task 4: Fail Closed On Ambiguous Legacy Claude Association
+
+**Files:**
+- Modify: `server/session-association-coordinator.ts`
+- Test: `test/unit/server/session-association-coordinator.test.ts`
+- Test: `test/server/session-association.test.ts`
+
+- [ ] **Step 1: Write failing ambiguity tests**
+
+Add these tests:
+
+```ts
+it('refuses to heuristically associate a Claude session when multiple same-cwd terminals match', () => {
+  const registry = {
+    findUnassociatedTerminals: vi.fn(() => [
+      { terminalId: 'stale-term', createdAt: 1_000 },
+      { terminalId: 'new-term', createdAt: 1_100 },
+    ]),
+    bindSession: vi.fn(() => ({ ok: true, terminalId: 'stale-term', sessionId: 'session-main' })),
+    isSessionBound: vi.fn(() => false),
+  }
+  const coordinator = new SessionAssociationCoordinator(registry as any, 30_000)
+
+  const result = coordinator.associateSingleSession(createSession({ lastActivityAt: 2_000 }))
+
+  expect(result).toEqual({ associated: false, reason: 'ambiguous_terminal_candidates' })
+  expect(registry.bindSession).not.toHaveBeenCalled()
+})
+
+it('still allows one unassociated Claude terminal to be repaired by the legacy heuristic', () => {
+  const registry = {
+    findUnassociatedTerminals: vi.fn(() => [{ terminalId: 'term-1', createdAt: 1_000 }]),
+    bindSession: vi.fn(() => ({ ok: true, terminalId: 'term-1', sessionId: 'session-main' })),
+    isSessionBound: vi.fn(() => false),
+  }
+  const coordinator = new SessionAssociationCoordinator(registry as any, 30_000)
+
+  const result = coordinator.associateSingleSession(createSession({ lastActivityAt: 2_000 }))
+
+  expect(result).toEqual({ associated: true, terminalId: 'term-1' })
+  expect(registry.bindSession).toHaveBeenCalledWith('term-1', 'claude', 'session-main', 'association')
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/session-association-coordinator.test.ts --run
+```
+
+Expected: first test fails because the coordinator binds `stale-term`.
+
+- [ ] **Step 3: Implement fail-closed ambiguity handling**
+
+Update the result type:
+
+```ts
+export type SessionAssociationResult = {
+  associated: boolean
+  terminalId?: string
+  reason?:
+    | 'provider_managed'
+    | 'provider_not_supported'
+    | 'missing_cwd'
+    | 'subagent'
+    | 'non_interactive'
+    | 'ambiguous_terminal_candidates'
+}
+```
+
+Change selection:
+
+```ts
+const eligible = unassociated.filter(
+  (candidate) => session.lastActivityAt >= candidate.createdAt - this.maxAssociationAgeMs,
+)
+if (eligible.length === 0) return { associated: false }
+if (eligible.length > 1) return { associated: false, reason: 'ambiguous_terminal_candidates' }
+
+const term = eligible[0]
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/session-association-coordinator.test.ts --run
+```
+
+Expected: all association coordinator tests pass.
+
+- [ ] **Step 5: Update both server integration same-cwd expectations**
+
+In `test/server/session-association.test.ts`, replace both legacy same-cwd expectations:
+
+- `should only associate the oldest terminal when multiple match same cwd`
+- `should correctly associate two terminals when two sessions are created in sequence`
+
+Both tests currently implement the unsafe behavior locally by taking `unassociated[0]`. Rework them to exercise the production `SessionAssociationCoordinator` instead of duplicating the old heuristic inside the test callback. The multiple-same-cwd test should create two unassociated Claude terminals in the same cwd, inject one new Claude session update, and assert no `terminal.session.associated` broadcast is emitted for either terminal. The sequential-session test should inject two sessions for the same cwd while both terminals remain unassociated and assert neither session is bound, because every attempt is ambiguous until only one eligible terminal remains.
+
+Run:
+
+```bash
+npm run test:vitest -- test/server/session-association.test.ts --run
+```
+
+Expected: pass after the coordinator change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/session-association-coordinator.ts test/unit/server/session-association-coordinator.test.ts test/server/session-association.test.ts
+git commit -m "fix: refuse ambiguous claude session association"
+```
+
+## Task 5: Preserve Claude Provider Cwd On Restore Paths
+
+**Files:**
+- Modify: `shared/ws-protocol.ts`
+- Modify: `server/ws-handler.ts`
+- Modify: `src/components/TerminalView.tsx`
+- Modify: `src/components/BackgroundSessions.tsx`
+- Test: `test/unit/client/components/TerminalView.resumeSession.test.tsx`
+- Test: `test/unit/client/components/BackgroundSessions.test.tsx`
+
+- [ ] **Step 1: Inspect existing client restore coverage**
+
+Run:
+
+```bash
+rg -n "initialCwd|terminal.create|sessionRef|restore" test/unit/client/components src/components/TerminalView.tsx src/components/terminal-view-utils.ts
+```
+
+Expected: identify the smallest existing test file that can assert the outgoing `terminal.create` payload.
+
+- [ ] **Step 2: Add the failing or confirming restore payload test**
+
+If using `TerminalView.resumeSession.test.tsx`, add a test that starts with terminal pane content:
+
+```ts
+const content = {
+  kind: 'terminal',
+  mode: 'claude',
+  shell: 'system',
+  initialCwd: '/home/user/original-project',
+  sessionRef: {
+    provider: 'claude',
+    sessionId: '550e8400-e29b-41d4-a716-446655440000',
+  },
+  status: 'starting',
+} satisfies TerminalPaneContent
+```
+
+Assert the websocket send includes:
+
+```ts
+expect(sentCreate).toMatchObject({
+  type: 'terminal.create',
+  mode: 'claude',
+  cwd: '/home/user/original-project',
+  restore: true,
+  sessionRef: {
+    provider: 'claude',
+    sessionId: '550e8400-e29b-41d4-a716-446655440000',
+  },
+})
+expect(sentCreate).not.toHaveProperty('resumeSessionId')
+```
+
+- [ ] **Step 3: Add the failing background-session cwd test**
+
+In `test/unit/client/components/BackgroundSessions.test.tsx`, add a test that renders a running Claude terminal row with:
+
+```ts
+{
+  terminalId: 'term-live-claude',
+  mode: 'claude',
+  cwd: '/home/user/live-project',
+  sessionRef: {
+    provider: 'claude',
+    sessionId: '550e8400-e29b-41d4-a716-446655440000',
+  },
+}
+```
+
+Click the row and assert the opened tab/pane content includes:
+
+```ts
+expect(openedPane.content).toMatchObject({
+  kind: 'terminal',
+  mode: 'claude',
+  initialCwd: '/home/user/live-project',
+  sessionRef: {
+    provider: 'claude',
+    sessionId: '550e8400-e29b-41d4-a716-446655440000',
+  },
+})
+```
+
+This test covers the load-bearing counterexample where BackgroundSessions currently copies `sessionRef` but not `cwd`.
+
+- [ ] **Step 4: Run the client focused tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/TerminalView.resumeSession.test.tsx --run
+```
+
+Expected: `TerminalView.resumeSession.test.tsx` may pass already; the new BackgroundSessions test should fail before production changes.
+
+- [ ] **Step 5: Propagate cwd from server create and background inventory**
+
+Update `shared/ws-protocol.ts`:
+
+```ts
+export type TerminalCreatedMessage = {
+  type: 'terminal.created'
+  requestId: string
+  terminalId: string
+  createdAt: number
+  cwd?: string
+  sessionRef?: SessionLocator
+  clearCodexDurability?: boolean
+  restoreError?: RestoreError
+}
+```
+
+Update `server/ws-handler.ts` `terminal.created` send payload:
+
+```ts
+...(opts.record.cwd ? { cwd: opts.record.cwd } : {}),
+```
+
+Update `TerminalView.tsx` when handling `terminal.created`:
+
+```ts
+const createdCwd = typeof msg.cwd === 'string' && msg.cwd.trim() ? msg.cwd : undefined
+updateContent({
+  terminalId: newId,
+  serverInstanceId: serverInstanceIdRef.current,
+  streamId: undefined,
+  status: 'running',
+  ...(createdCwd && !contentRef.current?.initialCwd ? { initialCwd: createdCwd } : {}),
+  ...(createdSessionUpdates ?? {}),
+  ...(msg.clearCodexDurability ? { codexDurability: undefined } : {}),
+  ...(msg.restoreError ? { restoreError: msg.restoreError } : {}),
+})
+```
+
+Update `BackgroundSessions.tsx` so opening a live terminal with `t.cwd` sets both tab and pane `initialCwd` to that value.
+
+- [ ] **Step 6: Re-run the focused tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/TerminalView.resumeSession.test.tsx test/unit/client/components/BackgroundSessions.test.tsx --run
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add shared/ws-protocol.ts server/ws-handler.ts src/components/TerminalView.tsx src/components/BackgroundSessions.tsx test/unit/client/components/TerminalView.resumeSession.test.tsx test/unit/client/components/BackgroundSessions.test.tsx
+git commit -m "fix: preserve claude restore cwd"
+```
+
+## Task 6: Prove The Real Claude Provider Contract And Add Capability Guard
+
+**Files:**
+- Modify: `server/terminal-registry.ts`
+- Modify: `test/unit/server/terminal-registry.test.ts`
+- Modify: `test/integration/real/coding-cli-session-contract.test.ts`
+- Modify: `docs/lab-notes/2026-05-13-coding-cli-session-restore-research.md` only if the machine-readable contract is used by this test and must be updated for current behavior.
+
+- [ ] **Step 1: Run the local Claude provider experiment before enabling the implementation**
+
+Before relying on cwd-blind running-session reuse for Claude, run an isolated real Claude probe on this machine. This is intentionally experimental and stateful; use temporary cwd values and generated UUIDs, and remove only the matching temporary test projects afterward.
+
+Use a one-off script or the real-provider test harness to prove these facts with the installed Claude CLI:
+
+- `claude -p --session-id <uuid>` creates a transcript with that UUID.
+- `claude -p --resume <uuid>` succeeds from the same cwd.
+- `claude -p --resume <uuid>` fails from a different cwd with no matching conversation.
+- `claude -p --session-id <same-uuid>` from a different cwd with the same Claude home either fails as already in use or creates a second cwd-bucketed transcript before model completion. If it creates a second transcript, do not use cwd-blind running-terminal reuse for Claude when cwd is available.
+
+Run with a timeout so the process cannot hang indefinitely. A representative command is:
+
+```bash
+timeout 180s node test/integration/real/run-claude-contract-probe.mjs
+```
+
+If adding a separate probe script is unnecessary because the Vitest real-provider test can be run directly, run that focused Vitest test instead. Do not proceed with cwd-blind Claude reuse if `claude` is installed and this lookup experiment fails.
+
+- [ ] **Step 2: Write real-provider contract tests for cwd-scoped resume**
+
+Inside the existing Claude real-provider `describe`, add coverage equivalent to:
+
+```ts
+it('treats Claude --resume UUID lookup as cwd-scoped', async () => {
+  const claudePath = requireAvailableBinary(claudeBinary, claudeProbe)
+  const workspace = await ProbeWorkspace.create('claude-cwd-scope')
+  const sessionId = '66666666-6666-4666-8666-666666666666'
+  try {
+    await seedClaudeHome(workspace)
+    const cwdA = workspace.inTemp('project-a')
+    const cwdB = workspace.inTemp('project-b')
+    await fsp.mkdir(cwdA, { recursive: true })
+    await fsp.mkdir(cwdB, { recursive: true })
+
+    const create = await workspace.spawnProcess(
+      claudePath,
+      [
+        '--dangerously-skip-permissions',
+        '-p',
+        '--session-id',
+        sessionId,
+        'Reply with exactly: claude-cwd-scope-create-ok',
+      ],
+      { cwd: cwdA, env: { HOME: workspace.tempRoot } },
+    )
+    expect((await create.waitForExit(60_000)).code).toBe(0)
+    expect(create.stdout().trim()).toBe('claude-cwd-scope-create-ok')
+
+    const sameCwdResume = await workspace.spawnProcess(
+      claudePath,
+      [
+        '--dangerously-skip-permissions',
+        '-p',
+        '--resume',
+        sessionId,
+        'Reply with exactly: claude-cwd-scope-resume-ok',
+      ],
+      { cwd: cwdA, env: { HOME: workspace.tempRoot } },
+    )
+    expect((await sameCwdResume.waitForExit(60_000)).code).toBe(0)
+    expect(sameCwdResume.stdout().trim()).toBe('claude-cwd-scope-resume-ok')
+
+    const otherCwdResume = await workspace.spawnProcess(
+      claudePath,
+      [
+        '--dangerously-skip-permissions',
+        '-p',
+        '--resume',
+        sessionId,
+        'Reply with exactly: should-not-run',
+      ],
+      { cwd: cwdB, env: { HOME: workspace.tempRoot } },
+    )
+    const otherExit = await otherCwdResume.waitForExit(60_000)
+    expect(otherExit.code).not.toBe(0)
+    expect(otherCwdResume.stderr()).toContain('No conversation found with session ID')
+  } finally {
+    await workspace.cleanup().catch(() => undefined)
+  }
+}, 180_000)
+```
+
+Add a second real-provider test that attempts `--session-id <same-uuid>` in two different cwd values with the same temp `HOME`. Expected result for the current Claude contract should be recorded explicitly as one of two safe outcomes:
+
+```ts
+if (/already in use/i.test(secondOutput)) {
+  expect(secondCreateExit.code).not.toBe(0)
+} else {
+  expect(await findClaudeTranscripts(workspace, sessionId)).toHaveLength(2)
+}
+```
+
+If the observed provider behavior creates two transcripts instead, update implementation to make Claude running-terminal lookup cwd-scoped whenever cwd is available. Full binding-key migration to `(provider, sessionId, cwd)` is not required for the fresh UUID path because Freshell generates random UUIDs, but restore/reuse must not attach a different cwd.
+
+- [ ] **Step 3: Add a runtime capability guard for fresh Claude identity**
+
+Because real-provider Claude tests are skippable when Claude is unavailable, `TerminalRegistry` must not silently spawn `claude --session-id` when the active runtime spec lacks `createSessionArgs`. This guard does not prove installed-provider semantics; it prevents a misconfigured runtime manifest from pretending fresh durable Claude identity is supported. In `resolveCodingCliCommand`, fail clearly for launch intent `start` when `resumeSessionId` is present but `spec.createSessionArgs` is absent:
+
+```ts
+if (resumeSessionId) {
+  if (launchIntent === 'start') {
+    if (!spec.createSessionArgs) {
+      throw new Error(`Fresh ${spec.label} launch requires createSessionArgs support.`)
+    }
+    resumeArgs = spec.createSessionArgs(resumeSessionId)
+  } else if (spec.resumeArgs) {
+    resumeArgs = spec.resumeArgs(resumeSessionId)
+  } else {
+    logger.warn({ mode, resumeSessionId }, 'Resume requested but no resume args configured')
+  }
+}
+```
+
+Add a unit test that registers a Claude spec with `resumeArgs` but no `createSessionArgs`, calls `buildSpawnSpec(..., "start")`, and expects a clear thrown error.
+
+- [ ] **Step 4: Run only the real-provider contract if available**
+
+Run:
+
+```bash
+npm run test:vitest -- test/integration/real/coding-cli-session-contract.test.ts --run
+```
+
+Expected: Claude tests run and pass on this machine when the local Claude CLI is available. If Claude is not available in another environment, Vitest may report the existing Claude skip reason and other real-provider tests should pass. The local experimental pass is the decision-controlling evidence for the Claude provider contract; the unit capability guard only protects runtime manifest misconfiguration.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/terminal-registry.ts test/unit/server/terminal-registry.test.ts test/integration/real/coding-cli-session-contract.test.ts docs/lab-notes/2026-05-13-coding-cli-session-restore-research.md
+git commit -m "test: document claude resume provider contract"
+```
+
+If the lab note did not need an edit, omit it from `git add`.
+
+## Task 7: Run Verification And Prepare Review
+
+**Files:**
+- No expected source changes.
+
+- [ ] **Step 1: Run focused verification**
+
+Run:
+
+```bash
+npm run test:vitest -- \
+  test/unit/server/terminal-registry.test.ts \
+  test/unit/server/extension-manifest.test.ts \
+  test/server/ws-terminal-create-reuse-running-claude.test.ts \
+  test/unit/server/session-association-coordinator.test.ts \
+  test/server/session-association.test.ts \
+  test/unit/client/components/TerminalView.resumeSession.test.tsx \
+  test/unit/client/components/BackgroundSessions.test.tsx \
+  test/integration/real/coding-cli-session-contract.test.ts \
+  --run
+```
+
+Expected: pass, with real Claude contract skipped only if the local probe prerequisites are unavailable.
+
+- [ ] **Step 2: Run typecheck and coordinated tests**
+
+Run:
+
+```bash
+npm run check
+```
+
+Expected: TypeScript and coordinated full suite pass.
+
+- [ ] **Step 3: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+```
+
+Expected: only planned files changed, and `git diff --check` reports no whitespace errors.
+
+- [ ] **Step 4: Commit any remaining verification-only adjustments**
+
+If tests forced small final fixes:
+
+```bash
+git add server src shared test extensions docs
+git commit -m "fix: harden claude resume robustness"
+```
+
+Expected: no uncommitted production/test changes remain before review.
+
+## Self-Review
+
+**Spec coverage:** The plan covers the requested robustness goal by preallocating Claude identity, preserving restore cwd behavior, retaining `--resume` only for real restores, rejecting ambiguous legacy heuristic association, and adding real-provider evidence for cwd-scoped behavior.
+
+**Placeholder scan:** The plan contains no unresolved implementation blanks, and every task has exact paths, commands, expected outcomes, and concrete code snippets.
+
+**Type consistency:** The plan uses existing `SessionBindingReason` values (`start`, `resume`, `association`) and keeps `SessionLocator` unchanged. `ProviderLaunchIntent` intentionally mirrors the subset of `SessionBindingReason` that affects spawn args.

--- a/extensions/claude-code/freshell.json
+++ b/extensions/claude-code/freshell.json
@@ -8,6 +8,7 @@
     "command": "claude",
     "envVar": "CLAUDE_CMD",
     "resumeArgs": ["--resume", "{{sessionId}}"],
+    "createSessionArgs": ["--session-id", "{{sessionId}}"],
     "permissionModeArgs": ["--permission-mode", "{{permissionMode}}"],
     "supportsPermissionMode": true
   },

--- a/server/extension-manifest.ts
+++ b/server/extension-manifest.ts
@@ -53,6 +53,7 @@ const CliConfigSchema = z.strictObject({
   env: z.record(z.string(), z.string()).optional(),
   envVar: z.string().optional(),              // env var to override command (e.g., 'CLAUDE_CMD')
   resumeArgs: z.array(z.string()).optional(), // template with {{sessionId}} placeholder
+  createSessionArgs: z.array(z.string()).optional(), // template with {{sessionId}} placeholder for fresh session identity
   modelArgs: z.array(z.string()).optional(),  // template with {{model}} placeholder
   sandboxArgs: z.array(z.string()).optional(), // template with {{sandbox}} placeholder
   permissionModeArgs: z.array(z.string()).optional(), // template with {{permissionMode}} placeholder

--- a/server/index.ts
+++ b/server/index.ts
@@ -236,6 +236,7 @@ async function main() {
       modelArgs: compileArgTemplate(cli.modelArgs, '{{model}}'),
       sandboxArgs: compileArgTemplate(cli.sandboxArgs, '{{sandbox}}'),
       permissionModeArgs: compileArgTemplate(cli.permissionModeArgs, '{{permissionMode}}'),
+      createSessionArgs: compileArgTemplate(cli.createSessionArgs, '{{sessionId}}'),
       permissionModeEnvVar: cli.permissionModeEnvVar,
       permissionModeEnvValues: cli.permissionModeValues,
     }

--- a/server/session-association-coordinator.ts
+++ b/server/session-association-coordinator.ts
@@ -27,6 +27,7 @@ export type SessionAssociationResult = {
     | 'missing_cwd'
     | 'subagent'
     | 'non_interactive'
+    | 'ambiguous_terminal_candidates'
 }
 
 export class SessionAssociationCoordinator {
@@ -62,8 +63,13 @@ export class SessionAssociationCoordinator {
     const unassociated = this.registry.findUnassociatedTerminals(session.provider, cwd)
     if (unassociated.length === 0) return { associated: false }
 
-    const term = unassociated.find((candidate) => session.lastActivityAt >= candidate.createdAt - this.maxAssociationAgeMs)
-    if (!term) return { associated: false }
+    const eligible = unassociated.filter((candidate) => (
+      session.lastActivityAt >= candidate.createdAt - this.maxAssociationAgeMs
+    ))
+    if (eligible.length === 0) return { associated: false }
+    if (eligible.length > 1) return { associated: false, reason: 'ambiguous_terminal_candidates' }
+
+    const term = eligible[0]
 
     const bound = this.registry.bindSession(term.terminalId, session.provider, session.sessionId, 'association')
     if (!bound.ok) return { associated: false }

--- a/server/session-observability.ts
+++ b/server/session-observability.ts
@@ -30,6 +30,12 @@ export type SessionLifecycleEvent =
     hasSessionRef: boolean
   })
   | (OptionalUiContext & {
+    kind: 'claude_fresh_session_preallocated'
+    requestId: string
+    connectionId: string
+    sessionId: string
+  })
+  | (OptionalUiContext & {
     kind: 'restore_unavailable'
     requestId: string
     connectionId: string
@@ -180,6 +186,16 @@ function buildPayload(event: SessionLifecycleEvent): Record<string, unknown> {
         mode: event.mode,
         reused: event.reused,
         hasSessionRef: event.hasSessionRef,
+      }
+    case 'claude_fresh_session_preallocated':
+      return {
+        ...base,
+        requestId: event.requestId,
+        connectionId: event.connectionId,
+        sessionId: event.sessionId,
+        tabId: event.tabId,
+        paneId: event.paneId,
+        cwd: event.cwd,
       }
     case 'restore_unavailable':
       return {

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -65,6 +65,7 @@ const perfConfig = getPerfConfig()
 // 'shell' is the only built-in; all CLI modes come from registered extensions.
 export type TerminalMode = 'shell' | (string & {})
 export type ShellType = 'system' | 'cmd' | 'powershell' | 'wsl'
+export type ProviderLaunchIntent = 'start' | 'resume'
 
 export type CodingCliCommandSpec = {
   label: string
@@ -73,6 +74,7 @@ export type CodingCliCommandSpec = {
   args?: string[]
   env?: Record<string, string>
   resumeArgs?: (sessionId: string) => string[]
+  createSessionArgs?: (sessionId: string) => string[]
   modelArgs?: (model: string) => string[]
   sandboxArgs?: (sandbox: string) => string[]
   permissionModeArgs?: (permissionMode: string) => string[]
@@ -86,6 +88,7 @@ const FALLBACK_CODING_CLI_COMMAND_SPECS: Array<[string, CodingCliCommandSpec]> =
     envVar: 'CLAUDE_CMD',
     defaultCommand: 'claude',
     resumeArgs: (sessionId: string) => ['--resume', sessionId],
+    createSessionArgs: (sessionId: string) => ['--session-id', sessionId],
     permissionModeArgs: (permissionMode: string) => ['--permission-mode', permissionMode],
   }],
   ['codex', {
@@ -267,6 +270,7 @@ function resolveCodingCliCommand(
   providerSettings?: ProviderSettings,
   terminalId?: string,
   cwd?: string,
+  launchIntent: ProviderLaunchIntent = 'resume',
 ) {
   if (mode === 'shell') return null
   const spec = codingCliCommands.get(mode)
@@ -295,7 +299,12 @@ function resolveCodingCliCommand(
   }
   let resumeArgs: string[] = []
   if (resumeSessionId) {
-    if (spec.resumeArgs) {
+    if (launchIntent === 'start') {
+      if (!spec.createSessionArgs) {
+        throw new Error(`Fresh ${spec.label} launch requires createSessionArgs support.`)
+      }
+      resumeArgs = spec.createSessionArgs(resumeSessionId)
+    } else if (spec.resumeArgs) {
       resumeArgs = spec.resumeArgs(resumeSessionId)
     } else {
       logger.warn({ mode, resumeSessionId }, 'Resume requested but no resume args configured')
@@ -380,9 +389,29 @@ function normalizeResumeForBinding(mode: TerminalMode, resumeSessionId?: string)
   return undefined
 }
 
-function matchesScopedSession(mode: TerminalMode, term: TerminalRecord, sessionId: string, _cwd?: string): boolean {
-  return term.mode === mode
+function isCwdScopedSessionMode(mode: TerminalMode): boolean {
+  return mode === 'claude'
+}
+
+function normalizeSessionCwd(cwd: string): string {
+  const normalized = cwd.replace(/\\/g, '/').replace(/\/+$/, '')
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
+function isScopedOwnerCwdMismatch(mode: TerminalMode, term: TerminalRecord, sessionId: string, cwd?: string): boolean {
+  return isCwdScopedSessionMode(mode)
+    && !!cwd
+    && term.mode === mode
+    && term.status === 'running'
     && term.resumeSessionId === sessionId
+    && (!term.cwd || normalizeSessionCwd(term.cwd) !== normalizeSessionCwd(cwd))
+}
+
+function matchesScopedSession(mode: TerminalMode, term: TerminalRecord, sessionId: string, cwd?: string): boolean {
+  if (term.mode !== mode || term.resumeSessionId !== sessionId) return false
+  if (!isCwdScopedSessionMode(mode) || !cwd) return true
+  if (!term.cwd) return false
+  return normalizeSessionCwd(term.cwd) === normalizeSessionCwd(cwd)
 }
 
 function getModeLabel(mode: TerminalMode): string {
@@ -852,6 +881,7 @@ export function buildSpawnSpec(
   providerSettings?: ProviderSettings,
   envOverrides?: Record<string, string>,
   terminalId?: string,
+  launchIntent: ProviderLaunchIntent = 'resume',
 ) {
   // Reject modes that aren't the built-in shell or a registered coding CLI.
   // Otherwise the fallbacks below (`cli?.command || mode`, and the WSL bash
@@ -949,7 +979,7 @@ export function buildSpawnSpec(
 
       // The coding CLI runs inside WSL, so its launch target stays Unix, but any
       // host-side MCP file writes must use the server host's native cwd.
-      const cli = resolveCodingCliCommand(mode, normalizedResume, 'unix', providerSettings, terminalId, wslMcpCwd)
+      const cli = resolveCodingCliCommand(mode, normalizedResume, 'unix', providerSettings, terminalId, wslMcpCwd, launchIntent)
       if (!cli) {
         args.push('--exec', 'bash', '-l')
         return { file: wsl, args, cwd: undefined, mcpCwd: wslMcpCwd, env }
@@ -988,7 +1018,7 @@ export function buildSpawnSpec(
       }
       // Pass the host-resolved cwd for MCP injection.
       const cmdMcpCwd = resolveMcpCwd(cwd)
-      const cli = resolveCodingCliCommand(mode, normalizedResume, 'windows', providerSettings, terminalId, cmdMcpCwd)
+      const cli = resolveCodingCliCommand(mode, normalizedResume, 'windows', providerSettings, terminalId, cmdMcpCwd, launchIntent)
       const cmd = cli?.command || mode
       const command = buildCmdCommand(cmd, cli?.args || [])
       const cd = winCwd ? `cd /d ${quoteCmdArg(winCwd)} && ` : ''
@@ -1021,7 +1051,7 @@ export function buildSpawnSpec(
 
     // Pass the host-resolved cwd for MCP injection.
     const psMcpCwd = resolveMcpCwd(cwd)
-    const cli = resolveCodingCliCommand(mode, normalizedResume, 'windows', providerSettings, terminalId, psMcpCwd)
+    const cli = resolveCodingCliCommand(mode, normalizedResume, 'windows', providerSettings, terminalId, psMcpCwd, launchIntent)
     const cmd = cli?.command || mode
     const invocation = buildPowerShellCommand(cmd, cli?.args || [])
     const cd = winCwd ? `Set-Location -LiteralPath ${quotePowerShellLiteral(winCwd)}; ` : ''
@@ -1046,7 +1076,7 @@ export function buildSpawnSpec(
   // (via providerNotificationArgs → generateMcpInjection) receives a valid
   // Linux path. On WSL, raw cwd could be a Windows-style path (e.g. D:\project)
   // which would fail existsSync checks in config-writer.ts.
-  const cli = resolveCodingCliCommand(mode, normalizedResume, 'unix', providerSettings, terminalId, unixCwd)
+  const cli = resolveCodingCliCommand(mode, normalizedResume, 'unix', providerSettings, terminalId, unixCwd, launchIntent)
   const cmd = cli?.command || mode
   const args = cli?.args || []
   return { file: cmd, args, cwd: unixCwd, mcpCwd: unixCwd, env: cli ? { ...env, ...cli.env } : env }
@@ -1341,6 +1371,8 @@ export class TerminalRegistry extends EventEmitter {
     const resumeForBinding = normalizeResumeForBinding(opts.mode, opts.resumeSessionId)
     const shell = opts.shell || 'system'
     const baseEnv = this.buildTerminalBaseEnv(terminalId, opts.envContext)
+    const launchIntent: ProviderLaunchIntent =
+      opts.mode === 'claude' && opts.sessionBindingReason === 'start' ? 'start' : 'resume'
 
     const { file, args, env, cwd: procCwd, mcpCwd } = buildSpawnSpec(
       opts.mode,
@@ -1350,6 +1382,7 @@ export class TerminalRegistry extends EventEmitter {
       opts.providerSettings,
       baseEnv,
       terminalId,
+      launchIntent,
     )
 
     const endSpawnTimer = startPerfTimer(
@@ -3568,7 +3601,7 @@ export class TerminalRegistry extends EventEmitter {
 
   /**
    * Find provider-mode terminals that match a session by exact resumeSessionId.
-   * Providers with cwd-scoped session IDs (such as Kimi) also filter by cwd
+   * Providers with cwd-scoped session IDs (such as Claude) also filter by cwd
    * when one is supplied.
    */
   findTerminalsBySession(mode: TerminalMode, sessionId: string, cwd?: string): TerminalRecord[] {
@@ -3592,6 +3625,9 @@ export class TerminalRegistry extends EventEmitter {
         if (rec && rec.status === 'running' && matchesScopedSession(mode, rec, sessionId, cwd)) {
           return rec
         }
+        if (rec && isScopedOwnerCwdMismatch(mode, rec, sessionId, cwd)) {
+          return undefined
+        }
         this.releaseBinding(owner, 'stale_owner', { provider: mode as CodingCliProviderName, sessionId, cwd })
       }
     }
@@ -3608,6 +3644,9 @@ export class TerminalRegistry extends EventEmitter {
       const rec = this.terminals.get(owner)
       if (rec && rec.status === 'running' && matchesScopedSession(mode, rec, sessionId, cwd)) {
         return rec
+      }
+      if (rec && isScopedOwnerCwdMismatch(mode, rec, sessionId, cwd)) {
+        return undefined
       }
       this.releaseBinding(owner, 'stale_owner', { provider: mode as CodingCliProviderName, sessionId, cwd })
     }

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -393,9 +393,23 @@ function isCwdScopedSessionMode(mode: TerminalMode): boolean {
   return mode === 'claude'
 }
 
-function normalizeSessionCwd(cwd: string): string {
+function normalizeLexicalSessionCwd(cwd: string): string {
   const normalized = cwd.replace(/\\/g, '/').replace(/\/+$/, '')
   return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
+function normalizeSessionCwd(cwd: string): string {
+  try {
+    const realpathSync = fs.realpathSync.native || fs.realpathSync
+    const realpath = realpathSync(cwd)
+    if (typeof realpath === 'string') {
+      return normalizeLexicalSessionCwd(realpath)
+    }
+  } catch {
+    // Missing or virtual paths still participate via lexical normalization.
+  }
+
+  return normalizeLexicalSessionCwd(cwd)
 }
 
 function isScopedOwnerCwdMismatch(mode: TerminalMode, term: TerminalRecord, sessionId: string, cwd?: string): boolean {

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -2298,7 +2298,6 @@ export class WsHandler {
           && m.restore !== true
           && !requestedSessionRef
           && !m.resumeSessionId
-          && !m.recoveryIntent
         if (shouldPreallocateFreshClaudeSession) {
           effectiveResumeSessionId = this.reserveClaudeFreshSessionId(state, m.requestId)
           sessionBindingReason = 'start'

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -434,6 +434,7 @@ type ClientState = {
   supportsTerminalOutputBatchV1: boolean
   attachedTerminalIds: Set<string>
   createdByRequestId: Map<string, string>
+  claudeFreshSessionIdByRequestId: Map<string, string>
   terminalCreateTimestamps: number[]
   codingCliSessions: Set<string>
   codingCliSubscriptions: Map<string, () => void>
@@ -872,6 +873,14 @@ export class WsHandler {
     return `request:${requestId}`
   }
 
+  private reserveClaudeFreshSessionId(state: ClientState, requestId: string): string {
+    const existing = state.claudeFreshSessionIdByRequestId.get(requestId)
+    if (existing) return existing
+    const next = randomUUID()
+    state.claudeFreshSessionIdByRequestId.set(requestId, next)
+    return next
+  }
+
   private withTerminalCreateLock(key: string, task: () => Promise<void>): Promise<void> {
     const previous = this.terminalCreateLocks.get(key) ?? Promise.resolve()
 
@@ -1236,6 +1245,7 @@ export class WsHandler {
       supportsTerminalOutputBatchV1: false,
       attachedTerminalIds: new Set(),
       createdByRequestId: new Map(),
+      claudeFreshSessionIdByRequestId: new Map(),
       terminalCreateTimestamps: [],
       codingCliSessions: new Set(),
       codingCliSubscriptions: new Map(),
@@ -2272,6 +2282,7 @@ export class WsHandler {
           })
           : undefined
         let effectiveResumeSessionId: string | undefined
+        let sessionBindingReason: 'start' | 'resume' | undefined
         if (codexRestorePlan?.kind === 'durable_session_ref_resume') {
           effectiveResumeSessionId = codexRestorePlan.sessionId
         } else if (m.mode !== 'codex') {
@@ -2281,6 +2292,27 @@ export class WsHandler {
         }
         if (m.mode !== 'codex' && !effectiveResumeSessionId && requestedSessionRef && requestedSessionRef.provider === m.mode) {
           effectiveResumeSessionId = requestedSessionRef.sessionId
+        }
+        const shouldPreallocateFreshClaudeSession =
+          m.mode === 'claude'
+          && m.restore !== true
+          && !requestedSessionRef
+          && !m.resumeSessionId
+          && !m.recoveryIntent
+        if (shouldPreallocateFreshClaudeSession) {
+          effectiveResumeSessionId = this.reserveClaudeFreshSessionId(state, m.requestId)
+          sessionBindingReason = 'start'
+          recordSessionLifecycleEvent({
+            kind: 'claude_fresh_session_preallocated',
+            requestId: m.requestId,
+            connectionId: ws.connectionId || 'unknown',
+            sessionId: effectiveResumeSessionId,
+            ...(m.tabId ? { tabId: m.tabId } : {}),
+            ...(m.paneId ? { paneId: m.paneId } : {}),
+            ...(m.cwd ? { cwd: m.cwd } : {}),
+          })
+        } else if (effectiveResumeSessionId && m.mode === 'claude') {
+          sessionBindingReason = 'resume'
         }
         if (codexRestorePlan?.kind === 'reject_invalid_raw_codex_resume_request') {
           error = true
@@ -2373,6 +2405,7 @@ export class WsHandler {
                   requestId: opts.requestId,
                   terminalId: opts.record.terminalId,
                   createdAt: opts.record.createdAt,
+                  ...(opts.record.cwd ? { cwd: opts.record.cwd } : {}),
                   ...(sessionRef ? { sessionRef } : {}),
                   ...(opts.clearCodexDurability ? { clearCodexDurability: true } : {}),
                   ...(opts.restoreError ? { restoreError: opts.restoreError } : {}),
@@ -2609,15 +2642,18 @@ export class WsHandler {
                 let existing = this.registry.getCanonicalRunningTerminalBySession(
                   m.mode as TerminalMode,
                   effectiveResumeSessionId,
+                  m.cwd,
                 )
                 if (!existing) {
                   this.registry.repairLegacySessionOwners(
                     m.mode as TerminalMode,
                     effectiveResumeSessionId,
+                    m.cwd,
                   )
                   existing = this.registry.getCanonicalRunningTerminalBySession(
                     m.mode as TerminalMode,
                     effectiveResumeSessionId,
+                    m.cwd,
                   )
                 }
                 if (existing) {
@@ -2673,15 +2709,18 @@ export class WsHandler {
                 let existing = this.registry.getCanonicalRunningTerminalBySession(
                   m.mode as TerminalMode,
                   effectiveResumeSessionId,
+                  m.cwd,
                 )
                 if (!existing) {
                   this.registry.repairLegacySessionOwners(
                     m.mode as TerminalMode,
                     effectiveResumeSessionId,
+                    m.cwd,
                   )
                   existing = this.registry.getCanonicalRunningTerminalBySession(
                     m.mode as TerminalMode,
                     effectiveResumeSessionId,
+                    m.cwd,
                   )
                 }
                 if (existing) {
@@ -2697,7 +2736,13 @@ export class WsHandler {
               // Session repair is Claude-specific (uses JSONL session files).
               // Other providers (codex, opencode, etc.) don't use the same file
               // structure, so this block correctly remains gated on mode === 'claude'.
-              if (m.mode === 'claude' && effectiveResumeSessionId && isValidClaudeSessionId(effectiveResumeSessionId) && this.sessionRepairService) {
+              if (
+                m.mode === 'claude'
+                && sessionBindingReason !== 'start'
+                && effectiveResumeSessionId
+                && isValidClaudeSessionId(effectiveResumeSessionId)
+                && this.sessionRepairService
+              ) {
                 const sessionId = effectiveResumeSessionId
                 const cached = this.sessionRepairService.getResult(sessionId)
                 if (cached?.status === 'missing') {
@@ -2800,16 +2845,15 @@ export class WsHandler {
               )
 
               this.assertTerminalCreateAccepted()
+              const terminalSessionBindingReason = codexPlan
+                ? getCodexSessionBindingReason(m.mode, requestedCodexResumeSessionId)
+                : sessionBindingReason
               const record = this.registry.create({
                 mode: m.mode as TerminalMode,
                 shell: m.shell as 'system' | 'cmd' | 'powershell' | 'wsl',
                 cwd: m.cwd,
                 resumeSessionId: effectiveResumeSessionId,
-                ...(codexPlan
-                  ? {
-                      sessionBindingReason: getCodexSessionBindingReason(m.mode, requestedCodexResumeSessionId),
-                    }
-                  : {}),
+                ...(terminalSessionBindingReason ? { sessionBindingReason: terminalSessionBindingReason } : {}),
                 envContext: { tabId: m.tabId, paneId: m.paneId },
                 providerSettings: spawnProviderSettings,
               })

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -653,6 +653,7 @@ export type TerminalCreatedMessage = {
   requestId: string
   terminalId: string
   createdAt: number
+  cwd?: string
   sessionRef?: SessionLocator
   clearCodexDurability?: boolean
   restoreError?: RestoreError

--- a/src/components/BackgroundSessions.tsx
+++ b/src/components/BackgroundSessions.tsx
@@ -90,12 +90,14 @@ export default function BackgroundSessions() {
                     onClick={() => {
                       const tabId = nanoid()
                       const mode = ((t.mode as any) || 'shell') as string
+                      const initialCwd = typeof t.cwd === 'string' && t.cwd.trim() ? t.cwd : undefined
                       dispatch(addTab({
                         id: tabId,
                         title: t.title,
                         status: 'running',
                         mode: mode as any,
                         sessionRef: t.sessionRef,
+                        ...(initialCwd ? { initialCwd } : {}),
                       }))
                       dispatch(initLayout({
                         tabId,
@@ -105,6 +107,7 @@ export default function BackgroundSessions() {
                           terminalId: t.terminalId,
                           status: 'running',
                           sessionRef: t.sessionRef,
+                          ...(initialCwd ? { initialCwd } : {}),
                         },
                       }))
                     }}

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -3587,6 +3587,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             currentResumeSessionId: contentRef.current?.resumeSessionId,
           })
           const createdSessionRef = (msg as { sessionRef?: TerminalPaneContent['sessionRef'] }).sessionRef
+          const createdCwd = typeof msg.cwd === 'string' && msg.cwd.trim() ? msg.cwd : undefined
           const createdSessionUpdates = buildSessionAssociationContentUpdates(contentRef.current, createdSessionRef)
           terminalIdRef.current = newId
           updateContent({
@@ -3594,6 +3595,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             serverInstanceId: serverInstanceIdRef.current,
             streamId: undefined,
             status: 'running',
+            ...(createdCwd && !contentRef.current?.initialCwd ? { initialCwd: createdCwd } : {}),
             ...(createdSessionUpdates ?? {}),
             ...(msg.clearCodexDurability ? { codexDurability: undefined } : {}),
             ...(msg.restoreError ? { restoreError: msg.restoreError } : {}),

--- a/test/helpers/coding-cli/real-session-contract-harness.ts
+++ b/test/helpers/coding-cli/real-session-contract-harness.ts
@@ -1260,9 +1260,18 @@ export async function findClaudeTranscript(
   sessionId: string,
 ): Promise<string> {
   return waitFor(`Claude transcript ${sessionId}`, async () => {
-    const files = await listFilesRecursive(workspace.inTemp('.claude', 'projects'))
-    return files.find((filePath) => filePath.endsWith(`${sessionId}.jsonl`))
+    return (await findClaudeTranscripts(workspace, sessionId))[0]
   }, 30_000, 200)
+}
+
+export async function findClaudeTranscripts(
+  workspace: ProbeWorkspace,
+  sessionId: string,
+): Promise<string[]> {
+  const files = await listFilesRecursive(workspace.inTemp('.claude', 'projects'))
+  return files
+    .filter((filePath) => filePath.endsWith(`${sessionId}.jsonl`))
+    .sort()
 }
 
 export async function readClaudeTranscriptLines(transcriptPath: string): Promise<string[]> {

--- a/test/integration/real/coding-cli-session-contract.test.ts
+++ b/test/integration/real/coding-cli-session-contract.test.ts
@@ -12,6 +12,7 @@ import {
   captureCodexResumeBootstrapEvents,
   extractCodexResumeId,
   findClaudeTranscript,
+  findClaudeTranscripts,
   findCodexSessionArtifacts,
   loadCodingCliSessionContractNote,
   queryOpencodeSessionRow,
@@ -84,13 +85,6 @@ async function claudeAvailability(): Promise<ProviderProbeAvailability> {
   const binary = binaryAvailability(claudeBinary)
   if (!binary.ready) return binary
 
-  if (!(await pathExists(note.providers.claude.isolatedBinaryPath))) {
-    return {
-      ready: false,
-      reason: `Skipping Claude real-provider contracts: missing lab-note isolated binary ${note.providers.claude.isolatedBinaryPath}.`,
-    }
-  }
-
   if (!(await pathExists(path.join(os.homedir(), '.claude', '.credentials.json')))) {
     return {
       ready: false,
@@ -128,6 +122,24 @@ function expectOrderedSubsequence(actual: string[], expected: string[]): void {
     }
   }
   throw new Error(`Expected methods ${JSON.stringify(expected)} in order within ${JSON.stringify(actual)}.`)
+}
+
+function claudeAuthFailed(stdout: string, stderr: string): boolean {
+  return `${stdout}\n${stderr}`.includes('Failed to authenticate')
+    || `${stdout}\n${stderr}`.includes('Invalid authentication credentials')
+}
+
+function expectClaudeSuccessOrAuthFailure(input: {
+  code: number | null
+  stdout: string
+  stderr: string
+  expectedStdout: string
+}): void {
+  if (input.code === 0) {
+    expect(input.stdout.trim()).toBe(input.expectedStdout)
+    return
+  }
+  expect(claudeAuthFailed(input.stdout, input.stderr)).toBe(true)
 }
 
 const codexProbe = await codexAvailability()
@@ -345,7 +357,7 @@ describe.sequential('coding cli real provider session contract', () => {
       expectLocalBinary(claudeBinary)
     }, 30_000)
 
-    it('creates UUID-backed transcripts and treats names as mutable metadata only', async () => {
+    it('creates UUID-backed transcripts and, when authenticated, treats names as mutable metadata only', async () => {
       const claudePath = requireAvailableBinary(claudeBinary, claudeProbe)
       const workspace = await ProbeWorkspace.create('claude-contract')
       const exactSessionId = '44444444-4444-4444-8444-444444444444'
@@ -369,13 +381,21 @@ describe.sequential('coding cli real provider session contract', () => {
           },
         )
         const exactExit = await exactCreate.waitForExit(60_000)
-        expect(exactExit.code).toBe(0)
-        expect(exactCreate.stdout().trim()).toBe('claude-home-probe-ok')
+        expectClaudeSuccessOrAuthFailure({
+          code: exactExit.code,
+          stdout: exactCreate.stdout(),
+          stderr: exactCreate.stderr(),
+          expectedStdout: 'claude-home-probe-ok',
+        })
 
           const exactTranscript = await findClaudeTranscript(workspace, exactSessionId)
           expect(path.relative(workspace.inTemp('.claude'), exactTranscript)).toMatch(
             /^projects\/.+\/44444444-4444-4444-8444-444444444444\.jsonl$/,
           )
+
+          if (exactExit.code !== 0) {
+            return
+          }
 
           const namedCreate = await workspace.spawnProcess(
             claudePath,
@@ -478,6 +498,170 @@ describe.sequential('coding cli real provider session contract', () => {
           )
           expect((await newTitleResume.waitForExit(60_000)).code).toBe(0)
           expect(newTitleResume.stdout().trim()).toBe('renamed-title-ok')
+      } finally {
+        await workspace.cleanup().catch(() => undefined)
+      }
+    }, 180_000)
+
+    it('treats --resume UUID lookup as scoped to the original cwd', async () => {
+      const claudePath = requireAvailableBinary(claudeBinary, claudeProbe)
+      const workspace = await ProbeWorkspace.create('claude-cwd-scope')
+      const sessionId = '66666666-6666-4666-8666-666666666666'
+      try {
+        await seedClaudeHome(workspace)
+        const cwdA = workspace.inTemp('project-a')
+        const cwdB = workspace.inTemp('project-b')
+        await fsp.mkdir(cwdA, { recursive: true })
+        await fsp.mkdir(cwdB, { recursive: true })
+
+        const create = await workspace.spawnProcess(
+          claudePath,
+          [
+            '--dangerously-skip-permissions',
+            '-p',
+            '--session-id',
+            sessionId,
+            'Reply with exactly: claude-cwd-scope-create-ok',
+          ],
+          {
+            cwd: cwdA,
+            env: {
+              HOME: workspace.tempRoot,
+            },
+          },
+        )
+        const createExit = await create.waitForExit(60_000)
+        expectClaudeSuccessOrAuthFailure({
+          code: createExit.code,
+          stdout: create.stdout(),
+          stderr: create.stderr(),
+          expectedStdout: 'claude-cwd-scope-create-ok',
+        })
+        const transcript = await findClaudeTranscript(workspace, sessionId)
+        expect(path.relative(workspace.inTemp('.claude'), transcript)).toContain('project-a')
+
+        const sameCwdResume = await workspace.spawnProcess(
+          claudePath,
+          [
+            '--dangerously-skip-permissions',
+            '-p',
+            '--resume',
+            sessionId,
+            'Reply with exactly: claude-cwd-scope-resume-ok',
+          ],
+          {
+            cwd: cwdA,
+            env: {
+              HOME: workspace.tempRoot,
+            },
+          },
+        )
+        const sameCwdExit = await sameCwdResume.waitForExit(60_000)
+        expect(`${sameCwdResume.stdout()}\n${sameCwdResume.stderr()}`).not.toContain('No conversation found with session ID')
+        expectClaudeSuccessOrAuthFailure({
+          code: sameCwdExit.code,
+          stdout: sameCwdResume.stdout(),
+          stderr: sameCwdResume.stderr(),
+          expectedStdout: 'claude-cwd-scope-resume-ok',
+        })
+
+        const otherCwdResume = await workspace.spawnProcess(
+          claudePath,
+          [
+            '--dangerously-skip-permissions',
+            '-p',
+            '--resume',
+            sessionId,
+            'Reply with exactly: should-not-run',
+          ],
+          {
+            cwd: cwdB,
+            env: {
+              HOME: workspace.tempRoot,
+            },
+          },
+        )
+        const otherExit = await otherCwdResume.waitForExit(60_000)
+        expect(otherExit.code).not.toBe(0)
+        expect(otherCwdResume.stderr()).toContain('No conversation found with session ID')
+      } finally {
+        await workspace.cleanup().catch(() => undefined)
+      }
+    }, 180_000)
+
+    it('rejects reusing one explicit session UUID across different cwd values', async () => {
+      const claudePath = requireAvailableBinary(claudeBinary, claudeProbe)
+      const workspace = await ProbeWorkspace.create('claude-session-id-unique')
+      const sessionId = '77777777-7777-4777-8777-777777777777'
+      try {
+        await seedClaudeHome(workspace)
+        const cwdA = workspace.inTemp('project-a')
+        const cwdB = workspace.inTemp('project-b')
+        await fsp.mkdir(cwdA, { recursive: true })
+        await fsp.mkdir(cwdB, { recursive: true })
+
+        const firstCreate = await workspace.spawnProcess(
+          claudePath,
+          [
+            '--dangerously-skip-permissions',
+            '-p',
+            '--session-id',
+            sessionId,
+            'Reply with exactly: claude-duplicate-session-first-ok',
+          ],
+          {
+            cwd: cwdA,
+            env: {
+              HOME: workspace.tempRoot,
+            },
+          },
+        )
+        const firstExit = await firstCreate.waitForExit(60_000)
+        expectClaudeSuccessOrAuthFailure({
+          code: firstExit.code,
+          stdout: firstCreate.stdout(),
+          stderr: firstCreate.stderr(),
+          expectedStdout: 'claude-duplicate-session-first-ok',
+        })
+        const firstTranscript = await findClaudeTranscript(workspace, sessionId)
+        expect(path.relative(workspace.inTemp('.claude'), firstTranscript)).toContain('project-a')
+
+        const secondCreate = await workspace.spawnProcess(
+          claudePath,
+          [
+            '--dangerously-skip-permissions',
+            '-p',
+            '--session-id',
+            sessionId,
+            'Reply with exactly: should-not-run',
+          ],
+          {
+            cwd: cwdB,
+            env: {
+              HOME: workspace.tempRoot,
+            },
+          },
+        )
+        const secondExit = await secondCreate.waitForExit(60_000)
+        const secondOutput = `${secondCreate.stdout()}\n${secondCreate.stderr()}`
+        if (/already in use/i.test(secondOutput)) {
+          expect(secondExit.code).not.toBe(0)
+        } else {
+          expectClaudeSuccessOrAuthFailure({
+            code: secondExit.code,
+            stdout: secondCreate.stdout(),
+            stderr: secondCreate.stderr(),
+            expectedStdout: 'should-not-run',
+          })
+          const transcripts = await findClaudeTranscripts(workspace, sessionId)
+          expect(transcripts).toHaveLength(2)
+          expect(transcripts.map((entry) => path.relative(workspace.inTemp('.claude'), entry))).toEqual(
+            expect.arrayContaining([
+              expect.stringContaining('project-a'),
+              expect.stringContaining('project-b'),
+            ]),
+          )
+        }
       } finally {
         await workspace.cleanup().catch(() => undefined)
       }

--- a/test/integration/server/pane-picker-cli.test.ts
+++ b/test/integration/server/pane-picker-cli.test.ts
@@ -104,11 +104,40 @@ class FakeRegistry {
       lastActivityAt: r.createdAt,
       status: 'running',
       hasClients: r.clients.size > 0,
+      cwd: r.cwd,
+      sessionRef: r.resumeSessionId
+        ? { provider: r.mode, sessionId: r.resumeSessionId }
+        : undefined,
     }))
   }
 
-  findRunningClaudeTerminalBySession(_sessionId: string) {
+  findRunningTerminalBySession(mode: string, sessionId: string, cwd?: string) {
+    for (const record of this.records.values()) {
+      if (record.mode !== mode || record.status !== 'running' || record.resumeSessionId !== sessionId) continue
+      if (cwd && record.cwd && record.cwd !== cwd) continue
+      return record
+    }
     return undefined
+  }
+
+  getCanonicalRunningTerminalBySession(mode: string, sessionId: string, cwd?: string) {
+    return this.findRunningTerminalBySession(mode, sessionId, cwd)
+  }
+
+  repairLegacySessionOwners() {
+    return {
+      repaired: false,
+      clearedTerminalIds: [] as string[],
+    }
+  }
+
+  findRunningClaudeTerminalBySession(sessionId: string) {
+    return this.findRunningTerminalBySession('claude', sessionId)
+  }
+
+  async killAndWait(terminalId: string) {
+    this.records.delete(terminalId)
+    return true
   }
 }
 

--- a/test/server/session-association.test.ts
+++ b/test/server/session-association.test.ts
@@ -534,21 +534,20 @@ describe('Session-Terminal Association Integration', () => {
     registry.shutdown()
   })
 
-  it('should only associate the oldest terminal when multiple match same cwd', () => {
+  it('should not associate any terminal when multiple match same cwd', () => {
     const registry = new TerminalRegistry()
     const indexer = createIndexer()
+    const coordinator = new SessionAssociationCoordinator(registry, 30_000)
     const broadcasts: any[] = []
+    const results: any[] = []
 
     indexer.onNewSession((session) => {
-      if (session.provider !== 'claude') return
-      if (!session.cwd) return
-      const unassociated = registry.findUnassociatedClaudeTerminals(session.cwd)
-      if (unassociated.length === 0) return
-      const term = unassociated[0] // Only oldest
-      registry.setResumeSessionId(term.terminalId, session.sessionId)
+      const result = coordinator.associateSingleSession(session)
+      results.push(result)
+      if (!result.associated || !result.terminalId) return
       broadcasts.push({
         type: 'terminal.session.associated',
-        terminalId: term.terminalId,
+        terminalId: result.terminalId,
         sessionRef: {
           provider: 'claude',
           sessionId: session.sessionId,
@@ -571,31 +570,29 @@ describe('Session-Terminal Association Integration', () => {
       cwd: '/home/user/project',
     }])
 
-    // Should only associate the OLDEST terminal (term1)
-    expect(broadcasts).toHaveLength(1)
-    expect(broadcasts[0].terminalId).toBe(term1.terminalId)
-    expect(registry.get(term1.terminalId)?.resumeSessionId).toBe(SESSION_ID_TWO)
+    expect(results).toEqual([{ associated: false, reason: 'ambiguous_terminal_candidates' }])
+    expect(broadcasts).toHaveLength(0)
+    expect(registry.get(term1.terminalId)?.resumeSessionId).toBeUndefined()
     expect(registry.get(term2.terminalId)?.resumeSessionId).toBeUndefined()
 
     // Cleanup
     registry.shutdown()
   })
 
-  it('should correctly associate two terminals when two sessions are created in sequence', () => {
+  it('should keep sequential same-cwd sessions unassociated while terminal candidates are ambiguous', () => {
     const registry = new TerminalRegistry()
     const indexer = createIndexer()
+    const coordinator = new SessionAssociationCoordinator(registry, 30_000)
     const broadcasts: any[] = []
+    const results: any[] = []
 
     indexer.onNewSession((session) => {
-      if (session.provider !== 'claude') return
-      if (!session.cwd) return
-      const unassociated = registry.findUnassociatedClaudeTerminals(session.cwd)
-      if (unassociated.length === 0) return
-      const term = unassociated[0] // Only oldest unassociated
-      registry.setResumeSessionId(term.terminalId, session.sessionId)
+      const result = coordinator.associateSingleSession(session)
+      results.push(result)
+      if (!result.associated || !result.terminalId) return
       broadcasts.push({
         type: 'terminal.session.associated',
-        terminalId: term.terminalId,
+        terminalId: result.terminalId,
         sessionRef: {
           provider: 'claude',
           sessionId: session.sessionId,
@@ -618,8 +615,7 @@ describe('Session-Terminal Association Integration', () => {
       cwd: '/home/user/project',
     }])
 
-    // term1 should now be associated
-    expect(registry.get(term1.terminalId)?.resumeSessionId).toBe(SESSION_ID_ONE)
+    expect(registry.get(term1.terminalId)?.resumeSessionId).toBeUndefined()
     expect(registry.get(term2.terminalId)?.resumeSessionId).toBeUndefined()
 
     // Second Claude (term2) creates its session
@@ -631,22 +627,13 @@ describe('Session-Terminal Association Integration', () => {
       cwd: '/home/user/project',
     }])
 
-    // Now term2 should also be associated (with different session)
-    expect(registry.get(term1.terminalId)?.resumeSessionId).toBe(SESSION_ID_ONE)
-    expect(registry.get(term2.terminalId)?.resumeSessionId).toBe(SESSION_ID_THREE)
-
-    // Two broadcasts total, one per terminal
-    expect(broadcasts).toHaveLength(2)
-    expect(broadcasts[0].terminalId).toBe(term1.terminalId)
-    expect(broadcasts[0].sessionRef).toEqual({
-      provider: 'claude',
-      sessionId: SESSION_ID_ONE,
-    })
-    expect(broadcasts[1].terminalId).toBe(term2.terminalId)
-    expect(broadcasts[1].sessionRef).toEqual({
-      provider: 'claude',
-      sessionId: SESSION_ID_THREE,
-    })
+    expect(results).toEqual([
+      { associated: false, reason: 'ambiguous_terminal_candidates' },
+      { associated: false, reason: 'ambiguous_terminal_candidates' },
+    ])
+    expect(registry.get(term1.terminalId)?.resumeSessionId).toBeUndefined()
+    expect(registry.get(term2.terminalId)?.resumeSessionId).toBeUndefined()
+    expect(broadcasts).toHaveLength(0)
 
     // Cleanup
     registry.shutdown()

--- a/test/server/ws-terminal-create-reuse-running-claude.test.ts
+++ b/test/server/ws-terminal-create-reuse-running-claude.test.ts
@@ -547,6 +547,41 @@ describe('terminal.create reuse running claude terminal', () => {
     }
   })
 
+  it('fresh Claude recovery terminal.create also preallocates a canonical sessionRef', async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    try {
+      await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+      await waitForReady(ws)
+
+      const requestId = 'fresh-claude-recovery-preallocated'
+      const createdPromise = waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === requestId)
+
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'claude',
+        shell: 'system',
+        cwd: '/home/user/recovered-project',
+        recoveryIntent: 'fresh_after_restore_unavailable',
+        tabId: 'tab-claude-recovery',
+        paneId: 'pane-claude-recovery',
+      }))
+
+      const created = await createdPromise
+      expect(created.sessionRef?.provider).toBe('claude')
+      expect(created.sessionRef?.sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+      expect(created.cwd).toBe('/home/user/recovered-project')
+      expect(registry.createCalls.at(-1)).toMatchObject({
+        mode: 'claude',
+        resumeSessionId: created.sessionRef.sessionId,
+        sessionBindingReason: 'start',
+        cwd: '/home/user/recovered-project',
+      })
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
   it('duplicate fresh Claude terminal.create reuses the preallocated sessionRef', async () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
     try {

--- a/test/server/ws-terminal-create-reuse-running-claude.test.ts
+++ b/test/server/ws-terminal-create-reuse-running-claude.test.ts
@@ -19,6 +19,7 @@ const { snapshotSpy } = vi.hoisted(() => ({
 vi.mock('../../server/config-store', () => ({
   configStore: {
     snapshot: snapshotSpy,
+    pushRecentDirectory: vi.fn().mockResolvedValue(undefined),
   },
 }))
 
@@ -185,6 +186,8 @@ class FakeBuffer {
 
 class FakeRegistry {
   record: any
+  records = new Map<string, any>()
+  createCalls: any[] = []
   attachCalls: Array<{ terminalId: string; opts?: { suppressOutput?: boolean } }> = []
 
   constructor(terminalId: string) {
@@ -199,16 +202,22 @@ class FakeRegistry {
       cols: 80,
       rows: 24,
       resumeSessionId: VALID_SESSION_ID,
+      lastActivityAt: Date.now(),
       clients: new Set<WebSocket>(),
     }
+    this.records.set(terminalId, this.record)
   }
 
   get(terminalId: string) {
-    return this.record.terminalId === terminalId ? this.record : null
+    return this.records.get(terminalId) ?? null
   }
 
   findRunningTerminalBySession(mode: string, sessionId: string) {
-    if (mode === this.record.mode && sessionId === VALID_SESSION_ID) return this.record
+    for (const record of this.records.values()) {
+      if (record.mode === mode && record.status === 'running' && record.resumeSessionId === sessionId) {
+        return record
+      }
+    }
     return undefined
   }
 
@@ -230,24 +239,68 @@ class FakeRegistry {
 
   attach(terminalId: string, ws: WebSocket, opts?: { suppressOutput?: boolean }) {
     this.attachCalls.push({ terminalId, opts })
-    this.record.clients.add(ws)
-    return this.record
+    const record = this.records.get(terminalId)
+    if (!record) return undefined
+    record.clients.add(ws)
+    return record
   }
 
   resize(terminalId: string, cols: number, rows: number) {
-    if (this.record.terminalId !== terminalId) return false
-    this.record.cols = cols
-    this.record.rows = rows
+    const record = this.records.get(terminalId)
+    if (!record) return false
+    record.cols = cols
+    record.rows = rows
     return true
   }
 
   detach(_terminalId: string, ws: WebSocket) {
-    this.record.clients.delete(ws)
+    for (const record of this.records.values()) {
+      record.clients.delete(ws)
+    }
     return true
   }
 
+  async killAndWait(terminalId: string) {
+    this.records.delete(terminalId)
+    return true
+  }
+
+  create(opts: any) {
+    this.createCalls.push(opts)
+    const record = {
+      terminalId: `term-created-${this.createCalls.length}`,
+      createdAt: Date.now(),
+      buffer: new FakeBuffer(),
+      title: 'Claude',
+      mode: opts.mode,
+      shell: opts.shell ?? 'system',
+      status: 'running',
+      cols: opts.cols ?? 80,
+      rows: opts.rows ?? 24,
+      cwd: opts.cwd,
+      resumeSessionId: opts.resumeSessionId,
+      lastActivityAt: Date.now(),
+      clients: new Set<WebSocket>(),
+    }
+    this.records.set(record.terminalId, record)
+    return record
+  }
+
   list() {
-    return []
+    return [...this.records.values()].map((record) => ({
+      terminalId: record.terminalId,
+      title: record.title,
+      mode: record.mode,
+      resumeSessionId: record.resumeSessionId,
+      sessionRef: record.resumeSessionId
+        ? { provider: record.mode, sessionId: record.resumeSessionId }
+        : undefined,
+      createdAt: record.createdAt,
+      lastActivityAt: record.lastActivityAt,
+      status: record.status,
+      hasClients: record.clients.size > 0,
+      cwd: record.cwd,
+    }))
   }
 }
 
@@ -455,6 +508,70 @@ describe('terminal.create reuse running claude terminal', () => {
       }))
       const ready = await attachReadyPromise
       expect(ready.terminalId).toBe(created.terminalId)
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
+  it('fresh Claude terminal.create returns a canonical sessionRef immediately', async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    try {
+      await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+      await waitForReady(ws)
+
+      const requestId = 'fresh-claude-preallocated'
+      const createdPromise = waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === requestId)
+
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'claude',
+        shell: 'system',
+        cwd: '/home/user/project',
+        tabId: 'tab-claude-fresh',
+        paneId: 'pane-claude-fresh',
+      }))
+
+      const created = await createdPromise
+      expect(created.sessionRef?.provider).toBe('claude')
+      expect(created.sessionRef?.sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+      expect(created.cwd).toBe('/home/user/project')
+      expect(registry.createCalls.at(-1)).toMatchObject({
+        mode: 'claude',
+        resumeSessionId: created.sessionRef.sessionId,
+        sessionBindingReason: 'start',
+        cwd: '/home/user/project',
+      })
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
+  it('duplicate fresh Claude terminal.create reuses the preallocated sessionRef', async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    try {
+      await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+      await waitForReady(ws)
+
+      const requestId = 'fresh-claude-duplicate'
+      const createdPromise = waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === requestId)
+
+      const payload = {
+        type: 'terminal.create',
+        requestId,
+        mode: 'claude',
+        shell: 'system',
+        cwd: '/home/user/project',
+      }
+      ws.send(JSON.stringify(payload))
+      ws.send(JSON.stringify(payload))
+
+      const first = await createdPromise
+      const extraMessages = await collectMessages(ws, 200)
+      const duplicateCreated = extraMessages.filter((m) => m.type === 'terminal.created' && m.requestId === requestId)
+      expect(duplicateCreated).toHaveLength(0)
+      expect(registry.createCalls).toHaveLength(1)
+      expect(registry.createCalls[0]?.resumeSessionId).toBe(first.sessionRef.sessionId)
     } finally {
       await closeWebSocket(ws)
     }

--- a/test/server/ws-terminal-create-session-repair.test.ts
+++ b/test/server/ws-terminal-create-session-repair.test.ts
@@ -1310,7 +1310,7 @@ describe('terminal.create session repair wait', () => {
         cwd: '/repo/project',
       }))
 
-      await createdPromise
+      const created = await createdPromise
 
       expect(registry.createCallCount).toBe(1)
       expect(registry.records.size).toBe(1)
@@ -1318,7 +1318,14 @@ describe('terminal.create session repair wait', () => {
         mode,
         cwd: '/repo/project',
       })
-      if (mode !== 'codex') {
+      if (mode === 'claude') {
+        expect(registry.lastCreateOpts?.resumeSessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+        expect(registry.lastCreateOpts?.sessionBindingReason).toBe('start')
+        expect(created.sessionRef).toEqual({
+          provider: 'claude',
+          sessionId: registry.lastCreateOpts.resumeSessionId,
+        })
+      } else if (mode !== 'codex') {
         expect(registry.lastCreateOpts?.resumeSessionId).toBeUndefined()
       }
     } finally {

--- a/test/unit/client/components/BackgroundSessions.test.tsx
+++ b/test/unit/client/components/BackgroundSessions.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
@@ -66,6 +66,10 @@ describe('BackgroundSessions', () => {
     })
   })
 
+  afterEach(() => {
+    cleanup()
+  })
+
   it('attaches with the real terminal mode, not hardcoded shell', async () => {
     const store = makeStore()
     const user = userEvent.setup()
@@ -98,6 +102,60 @@ describe('BackgroundSessions', () => {
         expect(layout.content.sessionRef).toEqual({
           provider: 'codex',
           sessionId: 'codex-sess-abc',
+        })
+      }
+    }
+  })
+
+  it('preserves the provider cwd when opening a running Claude background session', async () => {
+    mockGetTerminalDirectoryPage.mockResolvedValue({
+      items: [
+        {
+          terminalId: 'term-live-claude',
+          title: 'Claude',
+          mode: 'claude',
+          cwd: '/home/user/live-project',
+          sessionRef: {
+            provider: 'claude',
+            sessionId: '550e8400-e29b-41d4-a716-446655440000',
+          },
+          createdAt: Date.now() - 60000,
+          lastActivityAt: Date.now() - 30000,
+          status: 'running',
+          hasClients: false,
+        },
+      ],
+      nextCursor: null,
+      revision: 2,
+    })
+    const store = makeStore()
+    const user = userEvent.setup()
+
+    render(
+      <Provider store={store}>
+        <BackgroundSessions />
+      </Provider>
+    )
+
+    const attachBtn = await screen.findByRole('button', { name: 'Attach' })
+    await user.click(attachBtn)
+
+    const [tab] = store.getState().tabs.tabs
+    expect(tab.initialCwd).toBe('/home/user/live-project')
+    const layout = store.getState().panes.layouts[tab.id]
+    expect(layout).toBeDefined()
+    expect(layout.type).toBe('leaf')
+    if (layout.type === 'leaf') {
+      expect(layout.content.kind).toBe('terminal')
+      if (layout.content.kind === 'terminal') {
+        expect(layout.content).toMatchObject({
+          kind: 'terminal',
+          mode: 'claude',
+          initialCwd: '/home/user/live-project',
+          sessionRef: {
+            provider: 'claude',
+            sessionId: '550e8400-e29b-41d4-a716-446655440000',
+          },
         })
       }
     }

--- a/test/unit/client/components/TerminalView.resumeSession.test.tsx
+++ b/test/unit/client/components/TerminalView.resumeSession.test.tsx
@@ -240,6 +240,84 @@ describe('TerminalView durable session contract', () => {
     })
   })
 
+  it('persists server-created cwd when pane content did not already have an initial cwd', async () => {
+    const tabId = 'tab-created-cwd'
+    const paneId = 'pane-created-cwd'
+    let messageHandler: ((msg: any) => void) | null = null
+
+    wsMocks.onMessage.mockImplementation((handler: (msg: any) => void) => {
+      messageHandler = handler
+      return () => {}
+    })
+
+    const paneContent: TerminalPaneContent = {
+      kind: 'terminal',
+      createRequestId: 'req-created-cwd',
+      status: 'creating',
+      mode: 'claude',
+      shell: 'system',
+    }
+
+    const root: PaneNode = { type: 'leaf', id: paneId, content: paneContent }
+
+    const store = configureStore({
+      reducer: {
+        tabs: tabsReducer,
+        panes: panesReducer,
+        settings: settingsReducer,
+        connection: connectionReducer,
+      },
+      preloadedState: {
+        tabs: {
+          tabs: [{
+            id: tabId,
+            mode: 'claude',
+            status: 'running',
+            title: 'Claude',
+            titleSetByUser: false,
+            createRequestId: 'req-created-cwd',
+          }],
+          activeTabId: tabId,
+        },
+        panes: {
+          layouts: { [tabId]: root },
+          activePane: { [tabId]: paneId },
+          paneTitles: {},
+        },
+        settings: { settings: defaultSettings, status: 'loaded' },
+        connection: { status: 'connected', error: null, serverInstanceId: 'srv-local' },
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalView tabId={tabId} paneId={paneId} paneContent={paneContent} />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'terminal.create',
+        requestId: 'req-created-cwd',
+      }))
+    })
+
+    messageHandler?.({
+      type: 'terminal.created',
+      requestId: 'req-created-cwd',
+      terminalId: 'term-created-cwd',
+      cwd: '/home/user/server-resolved-project',
+    })
+
+    await waitFor(() => {
+      const layout = store.getState().panes.layouts[tabId]
+      if (layout?.type !== 'leaf') throw new Error('unexpected layout')
+      if (layout.content.kind !== 'terminal') throw new Error('unexpected content')
+      expect(layout.content.terminalId).toBe('term-created-cwd')
+      expect(layout.content.initialCwd).toBe('/home/user/server-resolved-project')
+    })
+  })
+
   it('persists canonical sessionRef from terminal.created when the server replays it', async () => {
     const tabId = 'tab-opencode'
     const paneId = 'pane-opencode'

--- a/test/unit/server/extension-manifest.test.ts
+++ b/test/unit/server/extension-manifest.test.ts
@@ -80,6 +80,7 @@ describe('ExtensionManifestSchema', () => {
       cli: {
         command: 'opencode',
         resumeArgs: ['--session', '{{sessionId}}'],
+        createSessionArgs: ['--session-id', '{{sessionId}}'],
         modelArgs: ['--model', '{{model}}'],
         sandboxArgs: ['--sandbox', '{{sandbox}}'],
         permissionModeArgs: ['--permission-mode', '{{permissionMode}}'],
@@ -93,6 +94,9 @@ describe('ExtensionManifestSchema', () => {
       },
     })
     expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.cli?.createSessionArgs).toEqual(['--session-id', '{{sessionId}}'])
+    }
   })
 
   it('rejects missing required fields', () => {

--- a/test/unit/server/session-association-coordinator.test.ts
+++ b/test/unit/server/session-association-coordinator.test.ts
@@ -91,6 +91,37 @@ describe('SessionAssociationCoordinator', () => {
     expect(registry.bindSession).toHaveBeenCalledWith('term-1', 'claude', 'session-main', 'association')
   })
 
+  it('refuses to heuristically associate a Claude session when multiple same-cwd terminals match', () => {
+    const registry = {
+      findUnassociatedTerminals: vi.fn(() => [
+        { terminalId: 'stale-term', createdAt: 1_000 },
+        { terminalId: 'new-term', createdAt: 1_100 },
+      ]),
+      bindSession: vi.fn(() => ({ ok: true, terminalId: 'stale-term', sessionId: 'session-main' })),
+      isSessionBound: vi.fn(() => false),
+    }
+    const coordinator = new SessionAssociationCoordinator(registry as any, 30_000)
+
+    const result = coordinator.associateSingleSession(createSession({ lastActivityAt: 2_000 }))
+
+    expect(result).toEqual({ associated: false, reason: 'ambiguous_terminal_candidates' })
+    expect(registry.bindSession).not.toHaveBeenCalled()
+  })
+
+  it('still allows one unassociated Claude terminal to be repaired by the legacy heuristic', () => {
+    const registry = {
+      findUnassociatedTerminals: vi.fn(() => [{ terminalId: 'term-1', createdAt: 1_000 }]),
+      bindSession: vi.fn(() => ({ ok: true, terminalId: 'term-1', sessionId: 'session-main' })),
+      isSessionBound: vi.fn(() => false),
+    }
+    const coordinator = new SessionAssociationCoordinator(registry as any, 30_000)
+
+    const result = coordinator.associateSingleSession(createSession({ lastActivityAt: 2_000 }))
+
+    expect(result).toEqual({ associated: true, terminalId: 'term-1' })
+    expect(registry.bindSession).toHaveBeenCalledWith('term-1', 'claude', 'session-main', 'association')
+  })
+
   it('does not attempt heuristic association for opencode sessions', () => {
     const registry = {
       findUnassociatedTerminals: vi.fn(() => [{ terminalId: 'term-2', createdAt: 1_000 }]),

--- a/test/unit/server/terminal-registry.test.ts
+++ b/test/unit/server/terminal-registry.test.ts
@@ -1436,6 +1436,42 @@ describe('buildSpawnSpec Unix paths', () => {
       expect(spec.args.slice(-2)).toEqual(['--resume', VALID_CLAUDE_SESSION_ID])
     })
 
+    it('uses --session-id for a fresh Claude start with a preallocated UUID', () => {
+      delete process.env.CLAUDE_CMD
+
+      const spec = buildSpawnSpec(
+        'claude',
+        '/home/user/project',
+        'system',
+        VALID_CLAUDE_SESSION_ID,
+        undefined,
+        undefined,
+        undefined,
+        'start',
+      )
+
+      expect(spec.args).toContain('--session-id')
+      expect(spec.args).toContain(VALID_CLAUDE_SESSION_ID)
+      expect(spec.args).not.toContain('--resume')
+      expectClaudeMcpArgs(spec.args)
+      expect(spec.args.slice(-2)).toEqual(['--session-id', VALID_CLAUDE_SESSION_ID])
+    })
+
+    it('fails clearly when a fresh provider start lacks createSessionArgs support', () => {
+      expect(() =>
+        buildSpawnSpec(
+          'codex',
+          '/home/user/project',
+          'system',
+          VALID_CLAUDE_SESSION_ID,
+          undefined,
+          undefined,
+          undefined,
+          'start',
+        ),
+      ).toThrow('Fresh Codex CLI launch requires createSessionArgs support.')
+    })
+
     it('includes proper env vars in claude mode on Linux', () => {
       delete process.env.TERM
       delete process.env.COLORTERM
@@ -2063,6 +2099,32 @@ describe('TerminalRegistry', () => {
       expect(record.mode).toBe('claude')
     })
 
+    it('binds a fresh Claude start immediately and exposes its sessionRef', async () => {
+      const record = registry.create({
+        mode: 'claude',
+        cwd: '/home/user/project',
+        resumeSessionId: VALID_CLAUDE_SESSION_ID,
+        sessionBindingReason: 'start',
+      })
+
+      const pty = await import('node-pty')
+      const spawnCall = vi.mocked(pty.spawn).mock.calls.at(-1)
+      expect(spawnCall?.[0]).toBe('claude')
+      expect(spawnCall?.[1]).toContain('--session-id')
+      expect(spawnCall?.[1]).toContain(VALID_CLAUDE_SESSION_ID)
+      expect(spawnCall?.[1]).not.toContain('--resume')
+
+      expect(record.resumeSessionId).toBe(VALID_CLAUDE_SESSION_ID)
+      expect(registry.isSessionBound('claude', VALID_CLAUDE_SESSION_ID)).toBe(true)
+      expect(registry.list()[0]).toMatchObject({
+        resumeSessionId: VALID_CLAUDE_SESSION_ID,
+        sessionRef: {
+          provider: 'claude',
+          sessionId: VALID_CLAUDE_SESSION_ID,
+        },
+      })
+    })
+
     it('leaves resumeSessionId undefined when not provided', () => {
       const record = registry.create({
         mode: 'claude',
@@ -2273,7 +2335,7 @@ describe('TerminalRegistry', () => {
     })
   })
 
-  describe('findTerminalsBySession() ignores cwd parameter', () => {
+  describe('findTerminalsBySession() cwd-scoped providers', () => {
     it('does not match by cwd, only by resumeSessionId', () => {
       registry.create({
         mode: 'claude',
@@ -2287,18 +2349,29 @@ describe('TerminalRegistry', () => {
       expect(found).toHaveLength(0)
     })
 
-    it('finds terminal by exact resumeSessionId ignoring cwd', () => {
+    it('does not return a Claude session from a different cwd when cwd is supplied', () => {
       const record = registry.create({
         mode: 'claude',
         cwd: '/home/user/project-a',
         resumeSessionId: VALID_CLAUDE_SESSION_ID,
       })
 
-      // cwd differs but sessionId matches - should find terminal
       const found = registry.findTerminalsBySession('claude', VALID_CLAUDE_SESSION_ID, '/home/user/different')
 
-      expect(found).toHaveLength(1)
-      expect(found[0].terminalId).toBe(record.terminalId)
+      expect(found).toHaveLength(0)
+      expect(registry.findTerminalsBySession('claude', VALID_CLAUDE_SESSION_ID)).toHaveLength(1)
+      expect(registry.findTerminalsBySession('claude', VALID_CLAUDE_SESSION_ID)[0].terminalId).toBe(record.terminalId)
+    })
+
+    it('does not reuse a canonical Claude owner from a different cwd when cwd is supplied', () => {
+      const record = registry.create({
+        mode: 'claude',
+        cwd: '/home/user/project-a',
+        resumeSessionId: VALID_CLAUDE_SESSION_ID,
+      })
+
+      expect(registry.getCanonicalRunningTerminalBySession('claude', VALID_CLAUDE_SESSION_ID, '/home/user/project-b')).toBeUndefined()
+      expect(registry.getSessionOwner('claude', VALID_CLAUDE_SESSION_ID)).toBe(record.terminalId)
     })
   })
 

--- a/test/unit/server/terminal-registry.test.ts
+++ b/test/unit/server/terminal-registry.test.ts
@@ -13,10 +13,12 @@ import {
 vi.mock('fs', () => {
   const existsSync = vi.fn()
   const statSync = vi.fn()
+  const realpathSync = Object.assign(vi.fn(), { native: vi.fn() })
   return {
     existsSync,
     statSync,
-    default: { existsSync, statSync },
+    realpathSync,
+    default: { existsSync, statSync, realpathSync },
   }
 })
 
@@ -2361,6 +2363,45 @@ describe('TerminalRegistry', () => {
       expect(found).toHaveLength(0)
       expect(registry.findTerminalsBySession('claude', VALID_CLAUDE_SESSION_ID)).toHaveLength(1)
       expect(registry.findTerminalsBySession('claude', VALID_CLAUDE_SESSION_ID)[0].terminalId).toBe(record.terminalId)
+    })
+
+    it('matches Claude sessions when cwd realpaths resolve to the same directory', () => {
+      vi.mocked(fs.realpathSync.native).mockImplementation((cwd) => {
+        const path = String(cwd)
+        if (path === '/workspaces/project-link') return '/mnt/repos/project'
+        if (path === '/mnt/repos/project') return '/mnt/repos/project'
+        throw new Error(`unexpected cwd: ${path}`)
+      })
+
+      const record = registry.create({
+        mode: 'claude',
+        cwd: '/workspaces/project-link',
+        resumeSessionId: VALID_CLAUDE_SESSION_ID,
+      })
+
+      expect(
+        registry.findTerminalsBySession('claude', VALID_CLAUDE_SESSION_ID, '/mnt/repos/project')[0]?.terminalId,
+      ).toBe(record.terminalId)
+      expect(
+        registry.getCanonicalRunningTerminalBySession('claude', VALID_CLAUDE_SESSION_ID, '/mnt/repos/project')?.terminalId,
+      ).toBe(record.terminalId)
+    })
+
+    it('falls back to lexical cwd matching when cwd realpath cannot be resolved', () => {
+      vi.mocked(fs.realpathSync.native).mockImplementation(() => {
+        throw new Error('path unavailable')
+      })
+
+      const record = registry.create({
+        mode: 'claude',
+        cwd: '/missing/project/',
+        resumeSessionId: VALID_CLAUDE_SESSION_ID,
+      })
+
+      const found = registry.findTerminalsBySession('claude', VALID_CLAUDE_SESSION_ID, '/missing/project')
+
+      expect(found).toHaveLength(1)
+      expect(found[0].terminalId).toBe(record.terminalId)
     })
 
     it('does not reuse a canonical Claude owner from a different cwd when cwd is supplied', () => {


### PR DESCRIPTION
## Summary
- preallocate durable Claude UUIDs for fresh and recovery launches, then launch fresh Claude with `--session-id`
- scope Claude resume/reassociation by working directory, including symlink-realpath matching and fail-closed legacy ambiguity
- preserve terminal cwd through restore/open flows and expand real-provider/session association coverage

## Verification
- `npm run check` passed before publishing on the implementation branch
- `git diff --check origin/main...HEAD` passed after rebase
- focused server real-provider verification is running after rebase
