### PR TITLE
Improve fresh agent pane settings and input UX

### DIFF
--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -50,6 +50,11 @@ function escapeSelector(id: string): string {
   return id.replace(/(["\\])/g, '\\$1')
 }
 
+function isEditableShortcutTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  return Boolean(target.closest('input, textarea, select, [contenteditable=""], [contenteditable="true"]'))
+}
+
 interface SortableTabProps {
   tab: Tab
   displayTitle: string
@@ -362,6 +367,7 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.ctrlKey && e.shiftKey && activeTabId) {
+        if (isEditableShortcutTarget(e.target)) return
         const currentIndex = tabs.findIndex((t: Tab) => t.id === activeTabId)
         if (e.key === 'ArrowLeft' && currentIndex > 0) {
           dispatch(reorderTabs({ fromIndex: currentIndex, toIndex: currentIndex - 1 }))

--- a/src/components/fresh-agent/FreshAgentComposer.tsx
+++ b/src/components/fresh-agent/FreshAgentComposer.tsx
@@ -45,11 +45,14 @@ type FreshAgentComposerProps = {
   canInterrupt?: boolean
   commands?: readonly FreshAgentSlashCommand[]
   onCommand?: (command: FreshAgentSlashCommand, args: string) => void
+  focusOnReady?: boolean
+  thinking?: boolean
 }
 
 export type FreshAgentComposerHandle = {
   focus: () => void
   insertText: (text: string) => void
+  appendText: (text: string) => void
 }
 
 type MenuMode = 'chat' | 'browse' | 'files'
@@ -133,6 +136,11 @@ function writeHistory(historyKey: string | undefined, entries: string[]) {
   }
 }
 
+function isTextEntryElement(value: Element | null): boolean {
+  if (!(value instanceof HTMLElement)) return false
+  return Boolean(value.closest('input, textarea, select, [contenteditable=""], [contenteditable="true"]'))
+}
+
 /**
  * Raw binary upload. Deliberately NOT base64-in-JSON: the server's global
  * express.json caps JSON bodies at 1mb, so attachments ship as
@@ -170,6 +178,8 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
   commands = [],
   onCommand,
   placeholder,
+  focusOnReady = false,
+  thinking = false,
 }, ref) {
   const [text, setText] = useState(() => {
     if (!storageKey || typeof window === 'undefined') return ''
@@ -197,7 +207,12 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
       setText((current) => (current ? `${current.replace(/\s$/, '')} ${value}` : value))
       requestAnimationFrame(() => textareaRef.current?.focus())
     },
-  }), [])
+    appendText: (value: string) => {
+      if (disabled) return
+      setText((current) => `${current}${value}`)
+      requestAnimationFrame(() => textareaRef.current?.focus())
+    },
+  }), [disabled])
 
   const chatPrefix = getCommandPrefix(text)
   const mention = useMemo(() => getMentionToken(text), [text])
@@ -217,6 +232,18 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
       window.sessionStorage.removeItem(storageKey)
     }
   }, [storageKey, text])
+
+  useEffect(() => {
+    if (!focusOnReady || disabled) return
+    const frame = requestAnimationFrame(() => {
+      const textarea = textareaRef.current
+      if (!textarea) return
+      const active = document.activeElement
+      if (active && active !== document.body && active !== textarea && isTextEntryElement(active)) return
+      textarea.focus()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [focusOnReady, disabled])
 
   useEffect(() => {
     const textarea = textareaRef.current
@@ -584,6 +611,18 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
               </button>
             </span>
           ))}
+        </div>
+      ) : null}
+
+      {thinking ? (
+        <div
+          className="mb-2 flex justify-center"
+          aria-hidden="true"
+          data-testid="fresh-agent-thinking-bar"
+        >
+          <div className="h-[0.5em] w-[80%] overflow-hidden rounded-sm bg-muted/50">
+            <div className="fresh-agent-thinking-gradient h-full w-2/5" />
+          </div>
         </div>
       ) : null}
 

--- a/src/components/fresh-agent/FreshAgentSettingsButton.tsx
+++ b/src/components/fresh-agent/FreshAgentSettingsButton.tsx
@@ -3,6 +3,7 @@ import { Settings } from 'lucide-react'
 import type { FreshAgentPaneContent } from '@/store/paneTypes'
 import { useAppDispatch } from '@/store/hooks'
 import { mergePaneContent } from '@/store/panesSlice'
+import { saveServerSettingsPatch } from '@/store/settingsThunks'
 import {
   FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE,
   getFreshAgentThinkingOptions,
@@ -71,6 +72,19 @@ export function FreshAgentSettingsButton({
   const settingsDisabled = paneContent.status === 'running' || paneContent.status === 'compacting'
 
   const close = useCallback(() => setOpen(false), [])
+  const persistProviderDefaults = useCallback((defaults: {
+    modelSelection?: { kind: 'exact'; modelId: string }
+    defaultPermissionMode?: string
+    effort?: string
+  }) => {
+    void dispatch(saveServerSettingsPatch({
+      freshAgent: {
+        providers: {
+          [paneContent.sessionType]: defaults,
+        },
+      },
+    }))
+  }, [dispatch, paneContent.sessionType])
 
   useEffect(() => {
     if (!open) return
@@ -154,6 +168,10 @@ export function FreshAgentSettingsButton({
                             paneId,
                             updates: { model: nextModel, effort: nextEffort },
                           }))
+                          persistProviderDefaults({
+                            modelSelection: { kind: 'exact', modelId: nextModel },
+                            ...(nextEffort ? { effort: nextEffort } : {}),
+                          })
                         }}
                       />
                       <span>{option.label}</span>
@@ -172,11 +190,13 @@ export function FreshAgentSettingsButton({
                   value={thinkingValue}
                   disabled={settingsDisabled}
                   onChange={(event) => {
+                    const nextEffort = event.target.value
                     dispatch(mergePaneContent({
                       tabId,
                       paneId,
-                      updates: { effort: event.target.value },
+                      updates: { effort: nextEffort },
                     }))
+                    persistProviderDefaults({ effort: nextEffort })
                   }}
                 >
                   {thinkingOptions.map((option) => (
@@ -195,11 +215,13 @@ export function FreshAgentSettingsButton({
                   value={permissionModeValue}
                   disabled={settingsDisabled}
                   onChange={(event) => {
+                    const nextPermissionMode = event.target.value
                     dispatch(mergePaneContent({
                       tabId,
                       paneId,
-                      updates: { permissionMode: event.target.value },
+                      updates: { permissionMode: nextPermissionMode },
                     }))
+                    persistProviderDefaults({ defaultPermissionMode: nextPermissionMode })
                   }}
                 >
                   {permissionModes.map((option) => (

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -458,7 +458,26 @@ export function FreshAgentTranscript({
   const [contextMenu, setContextMenu] = useState<FreshAgentTurnContextMenuState>(null)
   const [sheetTurn, setSheetTurn] = useState<FreshAgentTurn | null>(null)
   const coarsePointer = useCoarsePointer()
-  const turnKeys = useMemo(() => turns.map((turn) => turn.id).join('|'), [turns])
+  const transcriptSignature = useMemo(() => (
+    turns.map((turn) => {
+      const itemSignature = turn.items.map((item) => {
+        if (item.kind === 'text' || item.kind === 'thinking') {
+          return `${item.id}:${item.kind}:${item.text.length}`
+        }
+        if (item.kind === 'reasoning') {
+          return `${item.id}:${item.kind}:${item.text?.length ?? 0}:${item.summary.join('\n').length}`
+        }
+        if ('status' in item) {
+          return `${item.id}:${item.kind}:${item.status}`
+        }
+        if (item.kind === 'tool_result') {
+          return `${item.id}:${item.kind}:${item.isError ? 'error' : 'ok'}:${formatJson(item.content).length}`
+        }
+        return `${item.id}:${item.kind}`
+      }).join(',')
+      return `${turn.id}:${turn.summary?.length ?? 0}:${itemSignature}`
+    }).join('|')
+  ), [turns])
 
   const handleTurnContextMenu = useCallback((event: React.MouseEvent, turn: FreshAgentTurn) => {
     setContextMenu({ x: event.clientX, y: event.clientY, turn })
@@ -485,7 +504,7 @@ export function FreshAgentTranscript({
     } else {
       setNewMessages((count) => count + 1)
     }
-  }, [atBottom, turnKeys])
+  }, [atBottom, transcriptSignature])
 
   const collapsedCutoff = Math.max(0, turns.length - 8)
 

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
 import { nanoid } from 'nanoid'
 import type { FreshAgentPaneContent } from '@/store/paneTypes'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
@@ -161,6 +170,18 @@ function composeOutgoingText(text: string, attachmentPaths: string[]): string {
   return `${text ? `${text}\n\n` : ''}Attached files (read them from disk):\n${list}`
 }
 
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  return Boolean(target.closest('input, textarea, select, [contenteditable=""], [contenteditable="true"]'))
+}
+
+function isPlainTextKey(event: ReactKeyboardEvent<HTMLElement>): boolean {
+  return event.key.length === 1
+    && !event.ctrlKey
+    && !event.metaKey
+    && !event.altKey
+}
+
 export function FreshAgentView({
   tabId,
   paneId,
@@ -180,8 +201,6 @@ export function FreshAgentView({
   const pendingCreateFailure = useAppSelector(
     (state) => state.freshAgent?.pendingCreateFailures?.[paneContent.createRequestId],
   )
-  const currentTab = useAppSelector((state) => state.tabs?.tabs?.find((tab) => tab.id === tabId))
-  const tabTitleSetByUser = currentTab?.titleSetByUser ?? false
   const claudeSession = useAppSelector((state) => {
     if (paneContent.provider !== 'claude' || !paneContent.sessionId) return undefined
     const sessionKey = makeFreshAgentSessionKey({
@@ -893,6 +912,15 @@ export function FreshAgentView({
   const sessionEnded = effectiveStatus === 'exited' || effectiveStatus === 'create-failed'
   const sessionErrorMessage = agentSessionMeta?.lastError ?? null
 
+  useEffect(() => {
+    if (hidden) return
+    const frame = requestAnimationFrame(() => {
+      if (isEditableTarget(document.activeElement)) return
+      composerRef.current?.focus()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [effectiveStatus, hidden, paneContent.sessionId])
+
   // Fallback poll while the agent is (or claims to be) working: if a
   // transport event is missed, the pane self-heals within a few seconds
   // instead of stranding on an empty turn with a stop button.
@@ -1082,6 +1110,19 @@ export function FreshAgentView({
       ? null
       : (paneContent.restoreError ? getRestoreErrorMessage(paneContent.restoreError.reason) : null)
     const visibleLoadError = visibleRestoreFailure || visiblePaneRestoreFailure || isRestoring ? null : loadError
+    const WatermarkIcon = descriptor?.icon
+    const handlePanePointerUp = (event: ReactPointerEvent<HTMLElement>) => {
+      if (isEditableTarget(event.target)) return
+      if (window.getSelection()?.toString()) return
+      requestAnimationFrame(() => composerRef.current?.focus())
+    }
+    const handlePaneKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+      if (event.defaultPrevented) return
+      if (isEditableTarget(event.target)) return
+      if (!isPlainTextKey(event)) return
+      event.preventDefault()
+      composerRef.current?.appendText(event.key)
+    }
     const sendInterrupt = () => {
       if (!paneContent.sessionId || !canInterrupt) return
       sendFreshAgentMessage({
@@ -1108,19 +1149,22 @@ export function FreshAgentView({
 
     return (
       <div
-        className="flex h-full min-h-0 flex-col"
+        className="relative flex h-full min-h-0 flex-col overflow-hidden"
         data-context="fresh-agent"
         data-session-id={paneContent.sessionId}
         style={{ '--fresh-font-scale': String(freshFontScale) } as CSSProperties}
+        onPointerUpCapture={handlePanePointerUp}
+        onKeyDownCapture={handlePaneKeyDown}
       >
-        <div className="flex min-h-0 flex-1">
-          <div
-            className="flex min-h-0 flex-1 flex-col"
-            onClick={(event) => {
-              if (event.target !== event.currentTarget) return
-              composerRef.current?.focus()
-            }}
-          >
+        {WatermarkIcon ? (
+          <WatermarkIcon
+            className="pointer-events-none absolute left-1/2 top-1/2 z-0 h-[min(34rem,64%)] w-[min(34rem,64%)] -translate-x-1/2 -translate-y-1/2 text-foreground opacity-5"
+            aria-hidden="true"
+            data-testid="fresh-agent-watermark"
+          />
+        ) : null}
+        <div className="relative z-10 flex min-h-0 flex-1">
+          <div className="flex min-h-0 flex-1 flex-col">
             <div className="space-y-2 px-3 pt-3">
               {isRestoring ? (
                 <FreshAgentApprovalBanner text="Restoring session..." />
@@ -1253,6 +1297,8 @@ export function FreshAgentView({
               historyKey={`fresh-agent-prompt-history:${paneContent.sessionType}`}
               cwd={paneContent.initialCwd}
               provider={paneContent.provider}
+              focusOnReady={!hidden}
+              thinking={isBusy}
               queuedMessages={queuedMessages}
               onCancelQueued={(index) => {
                 setQueuedMessages((queue) => queue.filter((_, i) => i !== index))
@@ -1287,9 +1333,11 @@ export function FreshAgentView({
     )
   }, [
     claudeSession?.restoreFailureMessage,
+    descriptor?.icon,
     descriptor?.label,
     effectiveStatus,
     hasRestoreFailure,
+    hidden,
     isBusy,
     isRestoring,
     loadError,
@@ -1312,7 +1360,6 @@ export function FreshAgentView({
     paneId,
     sendFreshAgentMessage,
     tabId,
-    tabTitleSetByUser,
     freshFontScale,
   ])
 

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -619,8 +619,13 @@ function PickerWrapper({
         ? getAgentChatProviderConfig(type)
         : undefined
       const providerSettings = agentChatSettings?.providers?.[type]
+      const providerDefaultModel = typeof providerSettings?.modelSelection?.modelId === 'string'
+        ? providerSettings.modelSelection.modelId
+        : undefined
       const configuredModel = freshAgentType.runtimeProvider === 'codex' || freshAgentType.runtimeProvider === 'opencode'
-        ? settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.model ?? freshAgentType.defaultModel
+        ? providerDefaultModel
+          ?? settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.model
+          ?? freshAgentType.defaultModel
         : freshAgentType.defaultModel
       const model = normalizeFreshAgentModel(freshAgentType.sessionType, freshAgentType.runtimeProvider, configuredModel) ?? configuredModel
       const permissionMode = freshAgentType.settingsVisibility.permissionMode === false

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,26 @@ html {
   height: calc(100% / var(--fresh-font-scale, 1));
 }
 
+@keyframes fresh-agent-thinking-sweep {
+  0%, 100% {
+    transform: translateX(-120%);
+  }
+  50% {
+    transform: translateX(250%);
+  }
+}
+
+.fresh-agent-thinking-gradient {
+  background: linear-gradient(
+    90deg,
+    hsl(var(--primary) / 0),
+    hsl(var(--primary) / 0.28),
+    hsl(var(--accent-foreground) / 0.24),
+    hsl(var(--primary) / 0)
+  );
+  animation: fresh-agent-thinking-sweep 3.6s ease-in-out infinite;
+}
+
 body {
   background: hsl(var(--background));
   color: hsl(var(--foreground));

--- a/test/unit/client/components/TabBar.test.tsx
+++ b/test/unit/client/components/TabBar.test.tsx
@@ -1107,6 +1107,35 @@ describe('TabBar', () => {
       expect(state.tabs[2].id).toBe('tab-3')
     })
 
+    it('does not move tabs for Ctrl+Shift+ArrowRight from a focused textbox', () => {
+      const tab1 = createTab({ id: 'tab-1', title: 'Tab 1' })
+      const tab2 = createTab({ id: 'tab-2', title: 'Tab 2' })
+
+      const store = createStore({
+        tabs: [tab1, tab2],
+        activeTabId: 'tab-1',
+      })
+
+      renderWithStore(<TabBar />, store)
+
+      const textarea = document.createElement('textarea')
+      document.body.appendChild(textarea)
+      try {
+        textarea.focus()
+        fireEvent.keyDown(textarea, {
+          key: 'ArrowRight',
+          ctrlKey: true,
+          shiftKey: true,
+        })
+
+        const state = store.getState().tabs
+        expect(state.tabs[0].id).toBe('tab-1')
+        expect(state.tabs[1].id).toBe('tab-2')
+      } finally {
+        textarea.remove()
+      }
+    })
+
     it('Ctrl+Shift+ArrowLeft moves active tab left', () => {
       const tab1 = createTab({ id: 'tab-1', title: 'Tab 1' })
       const tab2 = createTab({ id: 'tab-2', title: 'Tab 2' })

--- a/test/unit/client/components/fresh-agent/FreshAgentComposer.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentComposer.test.tsx
@@ -157,6 +157,20 @@ describe('FreshAgentComposer', () => {
     expect(getInput().value).toBe('a draft in progress')
   })
 
+  it('focuses the chat input by default when requested and enabled', async () => {
+    render(<FreshAgentComposer commands={COMMANDS} focusOnReady onSend={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(getInput())
+    })
+  })
+
+  it('renders the subtle thinking bar while the agent is working', () => {
+    render(<FreshAgentComposer commands={COMMANDS} thinking onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('fresh-agent-thinking-bar')).toBeInTheDocument()
+  })
+
   describe('state-aware disabled behavior', () => {
     it('shows the provided placeholder instead of the generic read-only text', () => {
       render(

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -241,6 +241,35 @@ describe('FreshAgentTranscript', () => {
     expect(screen.getByText('Thinking')).toBeInTheDocument()
   })
 
+  it('keeps auto-scroll enabled for streamed text when already at the bottom', () => {
+    let scrollHeight = 1000
+    const turns = [{
+      id: 'turn-1',
+      role: 'assistant' as const,
+      summary: 'streaming',
+      items: [{ id: 'item-1', kind: 'text' as const, text: 'first line' }],
+    }]
+    const { container, rerender } = render(<FreshAgentTranscript turns={turns} />)
+    const scroller = container.querySelector('[data-context="fresh-agent-transcript"]') as HTMLDivElement
+
+    Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 200 })
+    Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => scrollHeight })
+    scroller.scrollTop = 800
+    fireEvent.scroll(scroller)
+
+    scrollHeight = 1200
+    rerender(
+      <FreshAgentTranscript
+        turns={[{
+          ...turns[0],
+          items: [{ id: 'item-1', kind: 'text', text: 'first line\nsecond streamed line' }],
+        }]}
+      />,
+    )
+
+    expect(scroller.scrollTop).toBe(1200)
+  })
+
   it('counts files changed in the settled summary', () => {
     render(
       <FreshAgentTranscript

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -27,6 +27,11 @@ const apiMock = vi.hoisted(() => ({
   getFreshAgentThreadSnapshot: vi.fn(),
 }))
 
+const saveServerSettingsPatchSpy = vi.hoisted(() => vi.fn((patch: unknown) => ({
+  type: 'settings/saveServerSettingsPatch',
+  payload: patch,
+})))
+
 vi.mock('@/lib/ws-client', () => ({
   getWsClient: () => wsMock,
 }))
@@ -42,6 +47,10 @@ vi.mock('@/lib/api', async () => {
     getFreshAgentThreadSnapshot: apiMock.getFreshAgentThreadSnapshot,
   }
 })
+
+vi.mock('@/store/settingsThunks', () => ({
+  saveServerSettingsPatch: (patch: unknown) => saveServerSettingsPatchSpy(patch),
+}))
 
 function createStore(tabTitleSetByUser = false) {
   return configureStore({
@@ -135,6 +144,7 @@ beforeEach(() => {
   wsMock.onMessage.mockReset()
   wsMock.onMessage.mockImplementation(() => () => {})
   apiMock.getFreshAgentThreadSnapshot.mockReset()
+  saveServerSettingsPatchSpy.mockClear()
   apiMock.getFreshAgentThreadSnapshot.mockResolvedValue({
     status: 'idle',
     summary: 'Codex summary',
@@ -222,6 +232,39 @@ describe('FreshAgentView', () => {
       requestId: 'question-1',
       answers: { 'How should Claude proceed?': 'Continue' },
     })
+  })
+
+  it('shows the provider watermark behind the workspace and redirects pane typing into the composer', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-watermark',
+        sessionId: 'thread-watermark',
+        status: 'idle',
+        model: 'gpt-5.4-mini',
+        effort: 'medium',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    const textbox = await screen.findByRole('textbox', { name: 'Chat message input' }) as HTMLTextAreaElement
+    await waitFor(() => expect(textbox).not.toBeDisabled())
+    expect(screen.getByTestId('fresh-agent-watermark')).toBeInTheDocument()
+
+    const root = document.querySelector('[data-context="fresh-agent"]') as HTMLElement
+    fireEvent.keyDown(root, { key: 'h' })
+
+    expect(textbox.value).toBe('h')
   })
 
   it('renders Codex review and fork metadata in the shared shell', async () => {
@@ -1585,6 +1628,64 @@ describe('FreshAgentView', () => {
     expect(layout?.type).toBe('leaf')
     expect(layout?.type === 'leaf' && layout.content.kind === 'fresh-agent' ? layout.content.model : null).toBe('gpt-5.4-flash')
     expect(layout?.type === 'leaf' && layout.content.kind === 'fresh-agent' ? layout.content.effort : null).toBe('high')
+    expect(saveServerSettingsPatchSpy).toHaveBeenCalledWith({
+      freshAgent: {
+        providers: {
+          freshcodex: {
+            modelSelection: { kind: 'exact', modelId: 'gpt-5.4-flash' },
+            effort: 'high',
+          },
+        },
+      },
+    })
+  })
+
+  it('persists Freshcodex thinking and permission settings as fresh-agent provider defaults', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-persist-settings',
+        sessionId: 'thread-persist-settings',
+        status: 'idle',
+        model: 'gpt-5.4-flash',
+        permissionMode: 'on-request',
+        effort: 'medium',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentSettingsButton tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Agent settings' }))
+    fireEvent.change(screen.getByRole('combobox', { name: 'Thinking level' }), {
+      target: { value: 'high' },
+    })
+    fireEvent.change(screen.getByRole('combobox', { name: 'Permission mode' }), {
+      target: { value: 'never' },
+    })
+
+    expect(saveServerSettingsPatchSpy).toHaveBeenCalledWith({
+      freshAgent: {
+        providers: {
+          freshcodex: { effort: 'high' },
+        },
+      },
+    })
+    expect(saveServerSettingsPatchSpy).toHaveBeenCalledWith({
+      freshAgent: {
+        providers: {
+          freshcodex: { defaultPermissionMode: 'never' },
+        },
+      },
+    })
   })
 
   it('lets Freshopencode settings choose model and thinking controls from the gear popover', async () => {

--- a/test/unit/client/components/panes/PaneContainer.createContent.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.createContent.test.tsx
@@ -404,6 +404,67 @@ describe('createContentForType with ext: prefix', () => {
     })
   })
 
+  it('starts Freshcodex panes with the persisted fresh-agent provider defaults', async () => {
+    const node = createPickerNode('pane-1')
+    const store = createStore(
+      { layouts: { 'tab-1': node }, activePane: { 'tab-1': 'pane-1' } },
+      [],
+      {
+        codingCli: {
+          enabledProviders: ['codex'],
+          providers: {
+            codex: {
+              model: 'gpt-5.4-mini',
+              permissionMode: 'on-request',
+              cwd: '/workspace/default',
+            },
+          },
+        },
+        freshAgent: {
+          enabled: true,
+          providers: {
+            freshcodex: {
+              modelSelection: { kind: 'exact', modelId: 'gpt-5.4-flash' },
+              defaultPermissionMode: 'never',
+              effort: 'high',
+            },
+          },
+        },
+      },
+      {
+        status: 'ready',
+        platform: 'linux',
+        availableClis: { codex: true },
+      },
+    )
+
+    render(
+      <Provider store={store}>
+        <PaneContainer tabId="tab-1" node={node} />
+      </Provider>,
+    )
+
+    const container = getPickerContainer()
+    fireEvent.keyDown(container, { key: 'x' })
+    fireEvent.transitionEnd(container)
+
+    const input = await screen.findByLabelText('Starting directory for Freshcodex')
+    fireEvent.change(input, { target: { value: '/workspace/project' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => {
+      const paneContent = (store.getState().panes.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>).content
+      expect(paneContent.kind).toBe('fresh-agent')
+      if (paneContent.kind !== 'fresh-agent') return
+      expect(paneContent.sessionType).toBe('freshcodex')
+      expect(paneContent.provider).toBe('codex')
+      expect(paneContent.modelSelection).toEqual({ kind: 'exact', modelId: 'gpt-5.4-flash' })
+      expect(paneContent.model).toBe('gpt-5.4-flash')
+      expect(paneContent.permissionMode).toBe('never')
+      expect(paneContent.effort).toBe('high')
+    })
+  })
+
   it('creates editor content when the editor option is selected', async () => {
     const node = createPickerNode('pane-1')
     const store = createStore(


### PR DESCRIPTION
## Summary
- Persist Fresh agent provider settings from pane gear controls so future panes on the same machine start with the last selected model, effort, and permission mode.
- Keep Fresh agent transcript auto-scroll active while streamed content grows at the bottom.
- Route focused-pane typing into the Fresh agent composer, add the workspace watermark/thinking bar, and preserve normal textarea Ctrl-Shift-Arrow selection behavior.

## Verification
- timeout 25m env FRESHELL_TEST_SUMMARY="pane settings and fresh-agent input UX rebased verification" npm run check
