### PR TITLE
Fix editor relative path completion root

### DIFF
--- a/server/files-router.ts
+++ b/server/files-router.ts
@@ -6,6 +6,7 @@ import {
   isPathAllowed,
   isReachableDirectory,
   normalizeUserPath,
+  sanitizeUserPathInput,
   toFilesystemPath,
 } from './path-utils.js'
 import { detectPlatform } from './platform.js'
@@ -30,6 +31,25 @@ async function resolveUserFilesystemPath(input: string): Promise<string> {
   return toFilesystemPath(normalizedPath, flavor)
 }
 
+function readRequestString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function isAbsoluteUserPath(input: string): boolean {
+  const cleaned = sanitizeUserPathInput(input)
+  if (!cleaned) return false
+  return cleaned.startsWith('~') || path.posix.isAbsolute(cleaned) || path.win32.isAbsolute(cleaned)
+}
+
+function resolveCompletionInput(prefix: string, root?: string): string {
+  const cleanedRoot = root ? sanitizeUserPathInput(root) : ''
+  if (!cleanedRoot || isAbsoluteUserPath(prefix)) return prefix
+
+  const { normalizedPath: rootPath, flavor } = normalizeUserPath(cleanedRoot)
+  const pathModule = getPathModuleForFlavor(flavor)
+  return pathModule.resolve(rootPath, sanitizeUserPathInput(prefix))
+}
+
 export function createFilesRouter(deps: FilesRouterDeps): Router {
   const { configStore, codingCliIndexer, registry } = deps
   const router = Router()
@@ -40,7 +60,14 @@ export function createFilesRouter(deps: FilesRouterDeps): Router {
    * When allowedFilePaths is empty/undefined, all paths are allowed (backward compatible).
    */
   async function validatePath(req: Request, res: Response, next: NextFunction) {
-    const filePath = (req.query.path as string) || (req.query.prefix as string) || req.body?.path
+    const queryPath = readRequestString(req.query.path)
+    const queryPrefix = readRequestString(req.query.prefix)
+    const queryRoot = readRequestString(req.query.root)
+    const bodyPath = readRequestString(req.body?.path)
+    const completionPath = queryPrefix
+      ? resolveCompletionInput(queryPrefix, queryRoot)
+      : undefined
+    const filePath = queryPath || completionPath || bodyPath
     if (!filePath) {
       return next()
     }
@@ -139,13 +166,15 @@ export function createFilesRouter(deps: FilesRouterDeps): Router {
   })
 
   router.get('/complete', validatePath, async (req, res) => {
-    const prefix = req.query.prefix as string
+    const prefix = readRequestString(req.query.prefix)
+    const root = readRequestString(req.query.root)
     const dirsOnly = req.query.dirs === 'true' || req.query.dirs === '1'
     if (!prefix) {
       return res.status(400).json({ error: 'prefix query parameter required' })
     }
 
-    const { normalizedPath, flavor } = normalizeUserPath(prefix)
+    const completionInput = resolveCompletionInput(prefix, root)
+    const { normalizedPath, flavor } = normalizeUserPath(completionInput)
     const pathModule = getPathModuleForFlavor(flavor)
     const resolvedFsPath = await toFilesystemPath(normalizedPath, flavor)
 

--- a/test/unit/server/files-router.test.ts
+++ b/test/unit/server/files-router.test.ts
@@ -328,12 +328,42 @@ describe('files-router path validation', () => {
       expect(res.status).toBe(200)
     })
 
+    it('anchors relative completion prefixes to the root query parameter', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+      mockStat.mockRejectedValue({ code: 'ENOENT' })
+      mockReaddir.mockResolvedValue([
+        { name: 'src', isDirectory: () => true },
+        { name: 'notes.md', isDirectory: () => false },
+      ])
+
+      const res = await request(app)
+        .get('/api/files/complete')
+        .query({ prefix: 's', root: '/home/user/projects' })
+
+      expect(res.status).toBe(200)
+      expect(mockReaddir).toHaveBeenCalledWith('/home/user/projects', { withFileTypes: true })
+      expect(res.body.suggestions).toEqual([
+        { path: '/home/user/projects/src', isDirectory: true },
+      ])
+    })
+
     it('blocks completion outside allowed directory', async () => {
       mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
 
       const res = await request(app)
         .get('/api/files/complete')
         .query({ prefix: '/etc/pass' })
+
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('Path not allowed')
+    })
+
+    it('blocks root-anchored relative completion that escapes allowed directories', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/home/user/projects'] })
+
+      const res = await request(app)
+        .get('/api/files/complete')
+        .query({ prefix: '../secret', root: '/home/user/projects' })
 
       expect(res.status).toBe(403)
       expect(res.body.error).toBe('Path not allowed')


### PR DESCRIPTION
## Summary
- Anchor relative /api/files/complete prefixes to the optional root query parameter.
- Validate the root-anchored completion path against allowedFilePaths so relative traversal is still blocked.
- Add server regression coverage for root-anchored completion and escape attempts.

## Verification
- npm run test:vitest -- test/unit/server/files-router.test.ts --run
- npm run check