### PR TITLE
Confirm before serving from non-main branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ npm run build               # Full build (client + server)
 npm run build:client        # Vite build → dist/client
 npm run build:server        # TypeScript compile → dist/server
 npm run serve               # Build and run production server
+# `npm run serve` prompts before serving from a non-main branch; use
+# `FRESHELL_ALLOW_NON_MAIN_SERVE=1 npm run serve` only when intentional.
 # Note: `npm run build` is guarded — it will refuse to overwrite dist/
 # if a production server is detected on the configured PORT. Use
 # `npm run check` for safe verification, or build from a worktree.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ npm run dev     # Development with hot reload
 npm run serve   # Production build and run
 ```
 
+`npm run serve` is intended for `main`. If you run it from another branch, Freshell asks for confirmation in an interactive terminal and refuses in non-interactive shells unless `FRESHELL_ALLOW_NON_MAIN_SERVE=1` is set.
+
 ## Keyboard Shortcuts
 
 <!-- Canonical source: src/lib/keyboard-shortcuts.ts -->

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "scripts": {
     "predev": "tsx scripts/run-with-default-port.ts tsx scripts/precheck.ts",
-    "preserve": "tsx scripts/precheck.ts",
     "dev": "tsx scripts/run-with-default-port.ts concurrently -n client,server -c blue,green \"vite\" \"tsx watch server/index.ts\"",
     "dev:client": "vite",
     "dev:server": "tsx scripts/run-with-default-port.ts tsx watch server/index.ts",
@@ -33,7 +32,8 @@
     "electron:build:win": "tsx scripts/assert-native-windows-build.ts && npm run build && npm run build:electron && npm run build:wizard && npm run build:launch-chooser && npm run prepare:bundled-node && electron-builder --win nsis --publish never",
     "prepare:bundled-node": "tsx scripts/prepare-bundled-node.ts",
     "start": "cross-env NODE_ENV=production node dist/server/index.js",
-    "serve": "npm run build && npm run start",
+    "serve:precheck": "cross-env FRESHELL_PRECHECK_INTENT=serve tsx scripts/precheck.ts",
+    "serve": "npm run serve:precheck && npm run build && npm run start",
     "test": "tsx scripts/testing/test-coordinator.ts run test",
     "test:balanced": "tsx scripts/run-standard-tests.ts",
     "test:sequential": "vitest run && vitest run --config vitest.server.config.ts && vitest run --config vitest.electron.config.ts",

--- a/scripts/precheck.ts
+++ b/scripts/precheck.ts
@@ -14,6 +14,7 @@ import { execFileSync } from 'child_process'
 import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { createRequire } from 'module'
+import { createInterface } from 'readline/promises'
 import { runUpdateCheck, shouldSkipUpdateCheck } from '../server/updater/index.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -40,6 +41,54 @@ function getCurrentBranch(): string | undefined {
     }).trim() || undefined
   } catch {
     return undefined
+  }
+}
+
+function isServePrecheck(): boolean {
+  return process.env.FRESHELL_PRECHECK_INTENT === 'serve'
+}
+
+function allowsNonMainServe(): boolean {
+  const value = process.env.FRESHELL_ALLOW_NON_MAIN_SERVE?.trim().toLowerCase()
+  return value === '1' || value === 'true' || value === 'yes'
+}
+
+function formatBranchForMessage(branch: string | undefined): string {
+  return branch ? `branch "${branch}"` : 'an unknown Git branch'
+}
+
+async function confirmServeFromNonMain(branch: string | undefined): Promise<boolean> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  try {
+    const answer = await rl.question(
+      `You are about to serve Freshell from ${formatBranchForMessage(branch)}, not "main". Continue? [y/N] `,
+    )
+    const normalized = answer.trim().toLowerCase()
+    return normalized === 'y' || normalized === 'yes'
+  } finally {
+    rl.close()
+  }
+}
+
+async function confirmServeBranchIfNeeded(branch: string | undefined): Promise<void> {
+  if (!isServePrecheck() || branch === 'main' || allowsNonMainServe()) {
+    return
+  }
+
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    console.error(`\n\x1b[31m✖ Refusing to run npm run serve from ${formatBranchForMessage(branch)} without confirmation.\x1b[0m`)
+    console.error('Check out main first, or set FRESHELL_ALLOW_NON_MAIN_SERVE=1 if this is intentional.\n')
+    process.exit(1)
+  }
+
+  const confirmed = await confirmServeFromNonMain(branch)
+  if (!confirmed) {
+    console.error('\nServe cancelled. Check out main before serving Freshell.\n')
+    process.exit(1)
   }
 }
 
@@ -194,8 +243,11 @@ async function checkVitePort(): Promise<PortCheckResult> {
 }
 
 async function main(): Promise<void> {
+  const currentBranch = getCurrentBranch()
+  await confirmServeBranchIfNeeded(currentBranch)
+
   // 1. Check for updates first (before anything else can fail)
-  if (!shouldSkipUpdateCheck({ branch: getCurrentBranch() })) {
+  if (!shouldSkipUpdateCheck({ branch: currentBranch })) {
     const currentVersion = getPackageVersion()
     const updateResult = await runUpdateCheck(currentVersion)
 
@@ -226,7 +278,7 @@ async function main(): Promise<void> {
   }
 
   // 3. Check for port conflicts
-  // Only check Vite port in dev mode (predev), not production (preserve)
+  // Only check Vite port in dev mode (predev), not production (serve:precheck)
   const isDevMode = process.env.npm_lifecycle_event === 'predev'
 
   const serverCheck = await checkServerPort(SERVER_PORT)


### PR DESCRIPTION
## Summary
- replace the implicit npm `preserve` lifecycle hook with explicit `serve:precheck` intent for `npm run serve`
- require confirmation before serving from non-main branches, with `FRESHELL_ALLOW_NON_MAIN_SERVE=1` as the noninteractive override
- document the serve branch guard in README and AGENTS

## Verification
- `npm run serve:precheck` exits 1 on a non-main branch in a noninteractive shell
- `FRESHELL_ALLOW_NON_MAIN_SERVE=1 PORT=43191 VITE_PORT=43192 npm run serve:precheck`
- `PORT=43191 VITE_PORT=43192 npm run predev`
- interactive TTY prompt cancels on `n`
- `npm run typecheck`