### PR TITLE
Fix Fresh agent scaled pane whitespace

### DIFF
--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -1158,12 +1158,12 @@ export function FreshAgentView({
       >
         {WatermarkIcon ? (
           <WatermarkIcon
-            className="pointer-events-none absolute left-1/2 top-1/2 z-0 h-[min(34rem,64%)] w-[min(34rem,64%)] -translate-x-1/2 -translate-y-1/2 text-foreground opacity-5"
+            className="pointer-events-none absolute left-1/2 top-1/2 z-0 h-[min(34rem,64%)] w-[min(34rem,64%)] -translate-x-1/2 -translate-y-1/2 text-foreground opacity-[0.01]"
             aria-hidden="true"
             data-testid="fresh-agent-watermark"
           />
         ) : null}
-        <div className="relative z-10 flex min-h-0 flex-1">
+        <div className="fresh-agent-scaled-content relative z-10 flex min-h-0">
           <div className="flex min-h-0 flex-1 flex-col">
             <div className="space-y-2 px-3 pt-3">
               {isRestoring ? (

--- a/src/index.css
+++ b/src/index.css
@@ -15,14 +15,13 @@ html {
   font-size: calc(100% * var(--ui-scale, 1.25));
 }
 
-/* Fresh-agent panes render at a user-configurable scale (Settings → Workspace →
-   Fresh agent → Font size; default 150%). FreshAgentView sets --fresh-font-scale
-   on the pane root. `zoom` scales the whole pane proportionally so every text
-   size — including markdown prose and responsive variants — grows together; the
-   width/height compensation keeps the (block-filling) pane exactly inside its
-   slot instead of overflowing by the scale factor. */
-[data-context="fresh-agent"] {
-  zoom: var(--fresh-font-scale, 1);
+/* Fresh-agent panes render at a user-configurable scale (Settings -> Workspace
+   -> Fresh agent -> Font size; default 150%). Keep the pane root at full size
+   and scale only its content surface; shrinking the root itself leaves blank
+   space in the surrounding pane layout. */
+.fresh-agent-scaled-content {
+  transform: scale(var(--fresh-font-scale, 1));
+  transform-origin: top left;
   width: calc(100% / var(--fresh-font-scale, 1));
   height: calc(100% / var(--fresh-font-scale, 1));
 }

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -326,7 +326,12 @@ test.describe('Fresh Agent', () => {
     // No clipping: the composer textarea stays within the pane at the larger scale.
     const composer = paneRoot.locator('textarea').first()
     await expect(composer).toBeVisible()
+    const scaledContent = paneRoot.locator('.fresh-agent-scaled-content')
+    await expect(scaledContent).toBeVisible()
     const paneBox = (await paneRoot.boundingBox())!
+    const scaledBox = (await scaledContent.boundingBox())!
+    expect(scaledBox.width).toBeGreaterThanOrEqual(paneBox.width - 2)
+    expect(scaledBox.height).toBeGreaterThanOrEqual(paneBox.height - 2)
     const composerBox = (await composer.boundingBox())!
     expect(composerBox.y + composerBox.height).toBeLessThanOrEqual(paneBox.y + paneBox.height + 2)
 

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -2574,6 +2574,7 @@ describe('FreshAgentView font scale', () => {
     const root = document.querySelector('[data-context="fresh-agent"]') as HTMLElement
     expect(root).toBeTruthy()
     expect(root.style.getPropertyValue('--fresh-font-scale')).toBe('1.5')
+    expect(root.querySelector('.fresh-agent-scaled-content')).toBeTruthy()
 
     await act(async () => {
       await Promise.resolve()


### PR DESCRIPTION
## Summary
- Change the Fresh agent watermark opacity to 1%.
- Move Fresh agent font scaling from the pane root to the inner content surface so scaled panes still fill their slot.
- Add unit and browser coverage for the scaled content wrapper and no right/bottom whitespace regression.

## Tests
- npm run test:vitest -- test/unit/client/components/fresh-agent/FreshAgentView.test.tsx --run
- npm run test:e2e:chromium -- test/e2e-browser/specs/fresh-agent.spec.ts -g "configured font scale"
- npm run typecheck
- npm run lint
- npm run check