### PR TITLE
Require user approval before creating PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Freshell is a self-hosted, browser-accessible terminal multiplexer and session o
 - Always work in a worktree (in \.worktrees\)
 - Before creating a new worktree, ensure the repo-supported test suite is green on the intended base. If the suite is not green, pause before creating the worktree and notify the user with the failing command and failure summary.
 - New behavior changes start on a worktree branch from `origin/main` and are submitted as PRs targeting `main`.
+- Do not create or open a PR until the user explicitly approves PR creation for that branch/change. Preparing a branch, committing locally, and pushing the branch is fine; stop before `gh pr create` or any equivalent PR creation step unless approval is explicit.
 - Everything goes through a PR — never push behavior changes directly to `origin/main`.
 - Merge PRs once their required checks pass, then bring `origin/main` down to local `main`. Self-merging your own PRs is the norm. The only exception is a PR the user has said needs someone else to approve it first — leave those unmerged.
 - Many agents may be working in the worktree at the same time. If you see activity from other agents (for example test runs or file changes), respect it.
@@ -40,7 +41,7 @@ Freshell is a self-hosted, browser-accessible terminal multiplexer and session o
 - `main` is the only integration branch. Local `main` should track the merged state of `origin/main`.
 - Author changes in dedicated `.worktrees/<slug>` worktrees on feature branches created from `origin/main`.
 - Do not commit behavior changes directly to local `main` or push them directly to `origin/main`.
-- When a change is ready, push the feature branch, open a PR targeting `main`, wait for required checks, merge the PR, then update local `main` from `origin/main`.
+- When a change is ready, push the feature branch, ask the user for explicit approval to create the PR, open a PR targeting `main` only after that approval, wait for required checks, merge the PR, then update local `main` from `origin/main`.
 - Update local `main` with a fast-forward pull or merge only. If local `main` has local-only commits, a dirty worktree, or cannot fast-forward, stop and resolve that explicitly instead of creating a local merge commit.
 - Delete or retire obsolete local `dev` worktrees/branches after confirming they are not running the self-hosted Freshell process.
 


### PR DESCRIPTION
## Summary
- Require explicit user approval before creating or opening PRs.
- Update the branch workflow to stop after pushing until PR creation is approved.

## Tests
- git diff --check
- Not run: documentation-only change