### PR TITLE
Improve Fresh Agent responsive layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -435,7 +435,7 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
 .fresh-turn { border-left: 2px solid hsl(var(--border)); padding-left: 10px; margin-bottom: 14px; }
 .fresh-turn.user { border-left-color: hsl(var(--foreground)); }
 .fresh-role { font-size: 11px; text-transform: uppercase; color: hsl(var(--muted-foreground)); margin-bottom: 6px; }
-.fresh-copy { font-size: 22px; line-height: 1.42; color: hsl(var(--foreground)); }
+.fresh-copy { font-size: 16px; line-height: 1.25; color: hsl(var(--foreground)); }
 .fresh-activity { font: 11px 'JetBrains Mono', monospace; color: hsl(var(--muted-foreground)); margin-bottom: 6px; }
 .fresh-composer { border-top: 1px solid hsl(var(--border) / .6); padding: 10px 12px; display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: end; }
 .fresh-thinking { grid-column: 1 / -1; height: 7px; width: 80%; justify-self: center; border-radius: 2px; overflow: hidden; background: hsl(var(--muted)); }
@@ -675,11 +675,11 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
           <div class="pane-header active"><svg class="icon" viewBox="-0.27 -0.23 16.55 16.55" fill="currentColor"><path d="M14.949 6.547a3.94 3.94 0 0 0-.348-3.273 4.11 4.11 0 0 0-4.4-1.934A4.1 4.1 0 0 0 8.423.2 4.15 4.15 0 0 0 6.305.086a4.1 4.1 0 0 0-1.891.948 4.04 4.04 0 0 0-1.158 1.753 4.1 4.1 0 0 0-1.563.679A4 4 0 0 0 .554 4.72a3.99 3.99 0 0 0 .502 4.731 3.94 3.94 0 0 0 .346 3.274 4.11 4.11 0 0 0 4.402 1.933c.382.425.852.764 1.377.995.526.231 1.095.35 1.67.346 1.78.002 3.358-1.132 3.901-2.804a4.1 4.1 0 0 0 1.563-.68 4 4 0 0 0 1.14-1.253 3.99 3.99 0 0 0-.506-4.716m-6.097 8.406a3.05 3.05 0 0 1-1.945-.694l.096-.054 3.23-1.838a.53.53 0 0 0 .265-.455v-4.49l1.366.778q.02.011.025.035v3.722c-.003 1.653-1.361 2.992-3.037 2.996m-6.53-2.75a2.95 2.95 0 0 1-.36-2.01l.095.057L5.29 12.09a.53.53 0 0 0 .527 0l3.949-2.246v1.555a.05.05 0 0 1-.022.041L6.473 13.3c-1.454.826-3.311.335-4.15-1.098m-.85-6.94A3.02 3.02 0 0 1 3.07 3.949v3.785a.51.51 0 0 0 .262.451l3.93 2.237-1.366.779a.05.05 0 0 1-.048 0L2.585 9.342a2.98 2.98 0 0 1-1.113-4.094zm11.216 2.571L8.747 5.576l1.362-.776a.05.05 0 0 1 .048 0l3.265 1.86a3 3 0 0 1 1.173 1.207 2.96 2.96 0 0 1-.27 3.2 3.05 3.05 0 0 1-1.36.997V8.279a.52.52 0 0 0-.276-.445m1.36-2.015-.097-.057-3.226-1.855a.53.53 0 0 0-.53 0L6.249 6.153V4.598a.04.04 0 0 1 .019-.04L9.533 2.7a3.07 3.07 0 0 1 3.257.139c.474.325.843.778 1.066 1.303.223.526.289 1.103.191 1.664zM5.503 8.575 4.139 7.8a.05.05 0 0 1-.026-.037V4.049c0-.57.166-1.127.476-1.607s.752-.864 1.275-1.105a3.08 3.08 0 0 1 3.234.41l-.096.054-3.23 1.838a.53.53 0 0 0-.265.455zm.742-1.577 1.758-1 1.762 1v2l-1.755 1-1.762-1z"/></svg><span class="pane-header-title">Freshcodex</span><span class="pane-header-meta">~/code/freshell</span><div class="pane-btns"><span class="pane-btn"><i data-lucide="refresh-cw" class="icon-xs"></i></span><span class="pane-btn"><i data-lucide="settings" class="icon-xs"></i></span><span class="pane-btn"><i data-lucide="maximize-2" class="icon-xs"></i></span><span class="pane-btn"><i data-lucide="x" class="icon-xs"></i></span></div></div>
           <div class="fresh-mock">
             <div class="fresh-main">
-              <div class="fresh-summary">Freshcodex session with bounded metadata rail.</div>
+              <div class="fresh-summary">Freshcodex session with bounded metadata rail and terminal-sized transcript text.</div>
               <div class="fresh-diffs"><div class="fresh-diffs-title">Diffs</div>src/components/fresh-agent/FreshAgentView.tsx</div>
               <div class="fresh-transcript">
                 <div class="fresh-turn user"><div class="fresh-role">You</div><div class="fresh-copy">What layout should Fresh clients use on desktop and phone?</div></div>
-                <div class="fresh-turn"><div class="fresh-role">Assistant</div><div class="fresh-activity">thought · 1 tool used</div><div class="fresh-copy">The pane keeps real geometry. Transcript text scales; metadata becomes a rail only when the pane has enough width.</div></div>
+                <div class="fresh-turn"><div class="fresh-role">Assistant</div><div class="fresh-activity">thought · 1 tool used</div><div class="fresh-copy">The pane keeps real geometry. Transcript text follows the terminal font size; metadata becomes a rail only when the pane has enough width.</div></div>
               </div>
               <div class="fresh-composer">
                 <div class="fresh-thinking"><span></span></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -421,6 +421,41 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
 .sv-session-time { font-size: 12px; color: hsl(var(--muted-foreground)); margin-left: auto; }
 .sv-session-summary { font-size: 12px; color: hsl(var(--muted-foreground)); margin-top: 4px; line-height: 1.5; }
 .sv-session-cwd { font-size: 11px; color: var(--t-dim); margin-top: 3px; font-family: 'JetBrains Mono', monospace; }
+
+/* ========== Fresh Agent Mock ========== */
+.fresh-mock { flex: 1; min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr) minmax(220px, 260px); overflow: hidden; background: hsl(var(--background)); }
+.fresh-main { min-width: 0; min-height: 0; display: flex; flex-direction: column; }
+.fresh-summary, .fresh-diffs {
+  margin: 12px 12px 0; border: 1px solid hsl(var(--border) / .65); border-radius: 6px;
+  background: hsl(var(--background) / .85); color: hsl(var(--muted-foreground)); font-size: 13px; padding: 10px 12px;
+}
+.fresh-diffs { color: hsl(var(--foreground)); font-family: 'JetBrains Mono', monospace; font-size: 11px; }
+.fresh-diffs-title, .fresh-rail-title { font-size: 10px; letter-spacing: .16em; text-transform: uppercase; color: hsl(var(--muted-foreground)); margin-bottom: 8px; font-family: inherit; }
+.fresh-transcript { min-height: 0; flex: 1; overflow-x: hidden; overflow-y: auto; padding: 14px 12px; }
+.fresh-turn { border-left: 2px solid hsl(var(--border)); padding-left: 10px; margin-bottom: 14px; }
+.fresh-turn.user { border-left-color: hsl(var(--foreground)); }
+.fresh-role { font-size: 11px; text-transform: uppercase; color: hsl(var(--muted-foreground)); margin-bottom: 6px; }
+.fresh-copy { font-size: 22px; line-height: 1.42; color: hsl(var(--foreground)); }
+.fresh-activity { font: 11px 'JetBrains Mono', monospace; color: hsl(var(--muted-foreground)); margin-bottom: 6px; }
+.fresh-composer { border-top: 1px solid hsl(var(--border) / .6); padding: 10px 12px; display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: end; }
+.fresh-thinking { grid-column: 1 / -1; height: 7px; width: 80%; justify-self: center; border-radius: 2px; overflow: hidden; background: hsl(var(--muted)); }
+.fresh-thinking span { display: block; height: 100%; width: 40%; background: linear-gradient(90deg, transparent, hsl(var(--foreground) / .22), transparent); }
+.fresh-input { min-height: 38px; border: 1px solid hsl(var(--border)); border-radius: 6px; display: flex; align-items: center; padding: 0 12px; color: hsl(var(--muted-foreground)); font-size: 13px; }
+.fresh-actions { display: flex; gap: 8px; }
+.fresh-action { width: 38px; height: 38px; border: 1px solid hsl(var(--border)); border-radius: 6px; display: flex; align-items: center; justify-content: center; color: hsl(var(--foreground)); }
+.fresh-action.send { background: hsl(var(--foreground)); color: hsl(var(--background)); border-color: hsl(var(--foreground)); }
+.fresh-rail { min-width: 0; border-left: 1px solid hsl(var(--border) / .6); background: hsl(var(--muted) / .2); padding: 12px; overflow: auto; }
+.fresh-rail-section + .fresh-rail-section { margin-top: 14px; }
+.fresh-rail-line { font-size: 13px; line-height: 1.45; overflow-wrap: anywhere; color: hsl(var(--foreground)); }
+
+@media (max-width: 768px) {
+  .fresh-mock { display: flex; flex-direction: column; }
+  .fresh-rail { order: -1; max-height: 120px; border-left: 0; border-bottom: 1px solid hsl(var(--border) / .6); display: flex; gap: 10px; padding: 10px 12px; }
+  .fresh-rail-section { min-width: 170px; border: 1px solid hsl(var(--border) / .55); border-radius: 6px; padding: 8px; }
+  .fresh-composer { grid-template-columns: minmax(0, 1fr); padding-right: 76px; }
+  .fresh-actions { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .fresh-action { width: 100%; }
+}
 </style>
 </head>
 <body>
@@ -634,11 +669,30 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
         </div>
       </div>
 
-      <!-- Get Started -->
+      <!-- Fresh Agent -->
       <div class="tab-panel" id="panel-start">
         <div class="pane">
-          <div class="pane-header active"><i data-lucide="terminal" class="icon"></i><span class="pane-header-title">Terminal — zsh</span><span class="pane-header-meta">~</span><div class="pane-btns"><span class="pane-btn"><i data-lucide="maximize-2" class="icon-xs"></i></span><span class="pane-btn"><i data-lucide="x" class="icon-xs"></i></span></div></div>
-          <div class="terminal" id="term-start"></div>
+          <div class="pane-header active"><svg class="icon" viewBox="-0.27 -0.23 16.55 16.55" fill="currentColor"><path d="M14.949 6.547a3.94 3.94 0 0 0-.348-3.273 4.11 4.11 0 0 0-4.4-1.934A4.1 4.1 0 0 0 8.423.2 4.15 4.15 0 0 0 6.305.086a4.1 4.1 0 0 0-1.891.948 4.04 4.04 0 0 0-1.158 1.753 4.1 4.1 0 0 0-1.563.679A4 4 0 0 0 .554 4.72a3.99 3.99 0 0 0 .502 4.731 3.94 3.94 0 0 0 .346 3.274 4.11 4.11 0 0 0 4.402 1.933c.382.425.852.764 1.377.995.526.231 1.095.35 1.67.346 1.78.002 3.358-1.132 3.901-2.804a4.1 4.1 0 0 0 1.563-.68 4 4 0 0 0 1.14-1.253 3.99 3.99 0 0 0-.506-4.716m-6.097 8.406a3.05 3.05 0 0 1-1.945-.694l.096-.054 3.23-1.838a.53.53 0 0 0 .265-.455v-4.49l1.366.778q.02.011.025.035v3.722c-.003 1.653-1.361 2.992-3.037 2.996m-6.53-2.75a2.95 2.95 0 0 1-.36-2.01l.095.057L5.29 12.09a.53.53 0 0 0 .527 0l3.949-2.246v1.555a.05.05 0 0 1-.022.041L6.473 13.3c-1.454.826-3.311.335-4.15-1.098m-.85-6.94A3.02 3.02 0 0 1 3.07 3.949v3.785a.51.51 0 0 0 .262.451l3.93 2.237-1.366.779a.05.05 0 0 1-.048 0L2.585 9.342a2.98 2.98 0 0 1-1.113-4.094zm11.216 2.571L8.747 5.576l1.362-.776a.05.05 0 0 1 .048 0l3.265 1.86a3 3 0 0 1 1.173 1.207 2.96 2.96 0 0 1-.27 3.2 3.05 3.05 0 0 1-1.36.997V8.279a.52.52 0 0 0-.276-.445m1.36-2.015-.097-.057-3.226-1.855a.53.53 0 0 0-.53 0L6.249 6.153V4.598a.04.04 0 0 1 .019-.04L9.533 2.7a3.07 3.07 0 0 1 3.257.139c.474.325.843.778 1.066 1.303.223.526.289 1.103.191 1.664zM5.503 8.575 4.139 7.8a.05.05 0 0 1-.026-.037V4.049c0-.57.166-1.127.476-1.607s.752-.864 1.275-1.105a3.08 3.08 0 0 1 3.234.41l-.096.054-3.23 1.838a.53.53 0 0 0-.265.455zm.742-1.577 1.758-1 1.762 1v2l-1.755 1-1.762-1z"/></svg><span class="pane-header-title">Freshcodex</span><span class="pane-header-meta">~/code/freshell</span><div class="pane-btns"><span class="pane-btn"><i data-lucide="refresh-cw" class="icon-xs"></i></span><span class="pane-btn"><i data-lucide="settings" class="icon-xs"></i></span><span class="pane-btn"><i data-lucide="maximize-2" class="icon-xs"></i></span><span class="pane-btn"><i data-lucide="x" class="icon-xs"></i></span></div></div>
+          <div class="fresh-mock">
+            <div class="fresh-main">
+              <div class="fresh-summary">Freshcodex session with bounded metadata rail.</div>
+              <div class="fresh-diffs"><div class="fresh-diffs-title">Diffs</div>src/components/fresh-agent/FreshAgentView.tsx</div>
+              <div class="fresh-transcript">
+                <div class="fresh-turn user"><div class="fresh-role">You</div><div class="fresh-copy">What layout should Fresh clients use on desktop and phone?</div></div>
+                <div class="fresh-turn"><div class="fresh-role">Assistant</div><div class="fresh-activity">thought · 1 tool used</div><div class="fresh-copy">The pane keeps real geometry. Transcript text scales; metadata becomes a rail only when the pane has enough width.</div></div>
+              </div>
+              <div class="fresh-composer">
+                <div class="fresh-thinking"><span></span></div>
+                <div class="fresh-input">Agent is working — sends queue for the next turn</div>
+                <div class="fresh-actions"><div class="fresh-action"><i data-lucide="paperclip" class="icon-xs"></i></div><div class="fresh-action"><i data-lucide="square" class="icon-xs"></i></div><div class="fresh-action"><i data-lucide="command" class="icon-xs"></i></div><div class="fresh-action send"><i data-lucide="send" class="icon-xs"></i></div></div>
+              </div>
+            </div>
+            <aside class="fresh-rail">
+              <div class="fresh-rail-section"><div class="fresh-rail-title">Review</div><div class="fresh-rail-line">pending</div><div class="fresh-rail-line">review-responsive-display</div></div>
+              <div class="fresh-rail-section"><div class="fresh-rail-title">Fork lineage</div><div class="fresh-rail-line">parent-thread-with-long-identifier</div></div>
+              <div class="fresh-rail-section"><div class="fresh-rail-title">Worktrees</div><div class="fresh-rail-line">codex/fresh-client-responsive-display</div></div>
+            </aside>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/fresh-agent/FreshAgentComposer.tsx
+++ b/src/components/fresh-agent/FreshAgentComposer.tsx
@@ -485,7 +485,7 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
 
   return (
     <form
-      className="relative border-t border-border/60 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] sm:pb-3"
+      className="fresh-agent-composer relative border-t border-border/60 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] sm:pb-3"
       onSubmit={(event) => {
         event.preventDefault()
         sendText()
@@ -614,19 +614,23 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
         </div>
       ) : null}
 
-      {thinking ? (
+      <div
+        className="mb-2 flex h-[0.5em] justify-center"
+        aria-hidden="true"
+        data-state={thinking ? 'active' : 'idle'}
+        data-testid="fresh-agent-thinking-bar"
+      >
         <div
-          className="mb-2 flex justify-center"
-          aria-hidden="true"
-          data-testid="fresh-agent-thinking-bar"
+          className={cn(
+            'h-full w-[80%] overflow-hidden rounded-sm bg-muted/50 transition-opacity duration-150',
+            thinking ? 'opacity-100' : 'opacity-0',
+          )}
         >
-          <div className="h-[0.5em] w-[80%] overflow-hidden rounded-sm bg-muted/50">
-            <div className="fresh-agent-thinking-gradient h-full w-2/5" />
-          </div>
+          <div className="fresh-agent-thinking-gradient h-full w-2/5" />
         </div>
-      ) : null}
+      </div>
 
-      <div className="flex items-end gap-2">
+      <div className="fresh-agent-composer-row">
         <textarea
           ref={textareaRef}
           name="message"
@@ -674,46 +678,52 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
             }
           }}
         />
-        <button
-          type="button"
-          disabled={disabled}
-          className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-border/70 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50 sm:h-9 sm:w-9"
-          aria-label="Attach files"
-          title="Attach files — images, PDFs (claude), and text files"
-          onClick={() => fileInputRef.current?.click()}
-        >
-          <Paperclip className="h-4 w-4" />
-        </button>
-        {canInterrupt ? (
+        <div className="fresh-agent-composer-actions">
+          <button
+            type="button"
+            disabled={disabled}
+            className="fresh-agent-composer-action inline-flex h-11 w-11 items-center justify-center rounded-md border border-border/70 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50 sm:h-9 sm:w-9"
+            aria-label="Attach files"
+            title="Attach files — images, PDFs (claude), and text files"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Paperclip className="h-4 w-4" />
+          </button>
           <button
             type="button"
             onClick={onInterrupt}
-            className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-border bg-background text-sm transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 sm:h-10 sm:w-10"
+            disabled={!canInterrupt}
+            tabIndex={canInterrupt ? undefined : -1}
+            aria-hidden={canInterrupt ? undefined : true}
+            className={cn(
+              'fresh-agent-composer-action inline-flex h-11 w-11 items-center justify-center rounded-md border border-border bg-background text-sm transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 sm:h-10 sm:w-10',
+              !canInterrupt && 'invisible',
+            )}
             aria-label="Stop"
           >
             <Square className="h-4 w-4" />
           </button>
-        ) : null}
-        <button
-          type="button"
-          disabled={commands.length === 0}
-          className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-border/70 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50 sm:h-9 sm:w-9"
-          aria-label="Slash commands"
-          onClick={() => {
-            setMenuMode((mode) => mode === 'browse' ? null : 'browse')
-            setFilter('')
-          }}
-        >
-          <Command className="h-4 w-4" />
-        </button>
-        <button
-          type="submit"
-          disabled={disabled}
-          className="inline-flex h-11 w-11 items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50 sm:h-10 sm:w-10"
-          aria-label="Send"
-        >
-          <Send className="h-4 w-4" />
-        </button>
+          <button
+            type="button"
+            disabled={commands.length === 0}
+            className="fresh-agent-composer-action inline-flex h-11 w-11 items-center justify-center rounded-md border border-border/70 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50 sm:h-9 sm:w-9"
+            aria-label="Slash commands"
+            onClick={() => {
+              setMenuMode((mode) => mode === 'browse' ? null : 'browse')
+              setFilter('')
+            }}
+          >
+            <Command className="h-4 w-4" />
+          </button>
+          <button
+            type="submit"
+            disabled={disabled}
+            className="fresh-agent-composer-action inline-flex h-11 w-11 items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50 sm:h-10 sm:w-10"
+            aria-label="Send"
+          >
+            <Send className="h-4 w-4" />
+          </button>
+        </div>
         <input
           ref={fileInputRef}
           type="file"

--- a/src/components/fresh-agent/FreshAgentDiffPanel.tsx
+++ b/src/components/fresh-agent/FreshAgentDiffPanel.tsx
@@ -43,10 +43,10 @@ function FreshAgentFileDiff({
   const lines = diff !== null && diff.trim() ? diff.split('\n') : null
 
   return (
-    <div className="border-l-2 border-l-border text-xs">
+    <div className="min-w-0 border-l-2 border-l-border text-xs">
       <button
         type="button"
-        className="flex min-h-[2.75rem] w-full items-center gap-2 rounded-r px-2 py-1 text-left transition-colors hover:bg-accent/50 sm:min-h-0"
+        className="flex min-h-[2.75rem] w-full min-w-0 items-center gap-2 rounded-r px-2 py-1 text-left transition-colors hover:bg-accent/50 sm:min-h-0"
         aria-expanded={expanded}
         aria-label={`Diff: ${label}`}
         onClick={() => {
@@ -55,7 +55,7 @@ function FreshAgentFileDiff({
         }}
       >
         <ChevronRight className={cn('h-3 w-3 shrink-0 transition-transform', expanded && 'rotate-90')} />
-        <span className="truncate font-mono">{label}</span>
+        <span className="min-w-0 flex-1 truncate font-mono">{label}</span>
         {summary.status ? <span className="ml-auto shrink-0 text-muted-foreground">{summary.status}</span> : null}
       </button>
       {expanded ? (
@@ -117,7 +117,7 @@ export function FreshAgentDiffPanel({
 }) {
   if (diffs.length === 0) return null
   return (
-    <div className="rounded-lg border border-border/60 bg-background/70 p-3">
+    <div className="min-w-0 overflow-hidden rounded-lg border border-border/60 bg-background/70 p-3">
       <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Diffs</div>
       <div className="space-y-1">
         {diffs.map((diff) => (

--- a/src/components/fresh-agent/FreshAgentSidebar.tsx
+++ b/src/components/fresh-agent/FreshAgentSidebar.tsx
@@ -16,29 +16,30 @@ export function FreshAgentSidebar({
     && !codexFork
   ) return null
   return (
-    <aside className="w-full max-w-xs space-y-3 border-l border-border/60 bg-muted/20 p-3">
+    <aside className="fresh-agent-sidebar bg-muted/20" aria-label="Fresh agent metadata">
+      <div className="fresh-agent-sidebar-content">
       {codexReview ? (
-        <section>
+        <section className="fresh-agent-sidebar-section">
           <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Review</div>
-          <ul className="space-y-1 text-sm">
+          <ul className="fresh-agent-sidebar-list space-y-1 text-sm">
             {codexReview.status ? <li>{codexReview.status}</li> : null}
             {codexReview.id ? <li>{codexReview.id}</li> : null}
           </ul>
         </section>
       ) : null}
       {codexFork?.parentThreadId ? (
-        <section>
+        <section className="fresh-agent-sidebar-section">
           <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Fork lineage</div>
-          <ul className="space-y-1 text-sm">
+          <ul className="fresh-agent-sidebar-list space-y-1 text-sm">
             <li>Parent thread</li>
             <li>{codexFork.parentThreadId}</li>
           </ul>
         </section>
       ) : null}
       {worktrees.length > 0 ? (
-        <section>
+        <section className="fresh-agent-sidebar-section">
           <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Worktrees</div>
-          <ul className="space-y-1 text-sm">
+          <ul className="fresh-agent-sidebar-list space-y-1 text-sm">
             {worktrees.map((worktree) => (
               <li key={worktree.id}>{worktree.branch ? `${worktree.branch} · ` : ''}{worktree.path}</li>
             ))}
@@ -46,15 +47,16 @@ export function FreshAgentSidebar({
         </section>
       ) : null}
       {childThreads.length > 0 ? (
-        <section>
+        <section className="fresh-agent-sidebar-section">
           <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Child Threads</div>
-          <ul className="space-y-1 text-sm">
+          <ul className="fresh-agent-sidebar-list space-y-1 text-sm">
             {childThreads.map((thread) => (
               <li key={thread.id}>{thread.title ?? thread.threadId}</li>
             ))}
           </ul>
         </section>
       ) : null}
+      </div>
     </aside>
   )
 }

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -268,7 +268,13 @@ function FreshAgentActivityStrip({
           >
             <ChevronRight className="h-3 w-3" />
           </button>
-          {running ? <Loader2 className="h-3 w-3 shrink-0 animate-spin" aria-label="running" /> : null}
+          <span
+            className="fresh-agent-activity-status-slot"
+            data-testid="fresh-agent-activity-status-slot"
+            aria-hidden={running ? undefined : true}
+          >
+            {running ? <Loader2 className="h-3 w-3 animate-spin" aria-label="running" /> : null}
+          </span>
           <SlotReel
             toolName={running ? reelName : null}
             previewText={running ? reelPreview : null}
@@ -417,7 +423,7 @@ function FreshAgentTurnArticle({
         <span>{getTurnLabel(turn)}</span>
         {turn.model ? <span className="truncate normal-case">{turn.model}</span> : null}
       </div>
-      <div className="space-y-1.5 text-sm">
+      <div className="fresh-agent-transcript-copy space-y-1.5">
         {blocks.length > 0 ? blocks.map((block, blockIndex) => {
           if (block.kind === 'activity') {
             return (
@@ -512,7 +518,7 @@ export function FreshAgentTranscript({
     <div className="relative min-h-0 flex-1">
       <div
         ref={scrollerRef}
-        className="flex h-full flex-col gap-3 overflow-y-auto overscroll-contain px-3 py-3"
+        className="flex h-full flex-col gap-3 overflow-x-hidden overflow-y-auto overscroll-contain px-3 py-3"
         data-context="fresh-agent-transcript"
         onScroll={(event) => {
           const node = event.currentTarget

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -26,7 +26,6 @@ import { paneRefreshTargetMatchesContent } from '@/lib/pane-utils'
 import { getCanonicalDurableSessionId, getPreferredResumeSessionId } from '@/store/persistControl'
 import { isValidClaudeSessionId } from '@/lib/claude-session-id'
 import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
-import { FRESH_AGENT_FONT_SCALE_DEFAULT } from '@shared/settings'
 import type { FreshAgentSnapshot } from '@shared/fresh-agent-contract'
 import { getFreshAgentSlashCommands, type FreshAgentSlashCommand } from '@shared/fresh-agent-slash-commands'
 import { buildRestoreError, type RestoreErrorReason } from '@shared/session-contract'
@@ -195,9 +194,9 @@ export function FreshAgentView({
 }) {
   const dispatch = useAppDispatch()
   const ws = getWsClient()
-  const freshFontScale = useAppSelector(
-    (state) => state.settings.settings.freshAgent?.fontScale,
-  ) ?? FRESH_AGENT_FONT_SCALE_DEFAULT
+  const terminalFontSize = useAppSelector(
+    (state) => state.settings.settings.terminal?.fontSize,
+  ) ?? 16
   const pendingCreateFailure = useAppSelector(
     (state) => state.freshAgent?.pendingCreateFailures?.[paneContent.createRequestId],
   )
@@ -1156,7 +1155,7 @@ export function FreshAgentView({
         className="fresh-agent-pane relative flex h-full min-h-0 flex-col overflow-hidden"
         data-context="fresh-agent"
         data-session-id={paneContent.sessionId}
-        style={{ '--fresh-font-scale': String(freshFontScale) } as CSSProperties}
+        style={{ '--fresh-transcript-font-size': `${terminalFontSize}px` } as CSSProperties}
         onPointerUpCapture={handlePanePointerUp}
         onKeyDownCapture={handlePaneKeyDown}
       >
@@ -1364,7 +1363,7 @@ export function FreshAgentView({
     paneId,
     sendFreshAgentMessage,
     tabId,
-    freshFontScale,
+    terminalFontSize,
   ])
 
   useEffect(() => {

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -1082,6 +1082,10 @@ export function FreshAgentView({
     const diffs = snapshot?.diffs ?? []
     const codexReview = readCodexReview(snapshot?.extensions?.codex?.review)
     const codexFork = readCodexFork(snapshot?.extensions?.codex?.fork)
+    const hasSidebarMetadata = worktrees.length > 0
+      || childThreads.length > 0
+      || Boolean(codexReview)
+      || Boolean(codexFork)
     // sessionEnded gates everything: a stale snapshot can still claim
     // capabilities.send after the provider process died.
     const canSend = !sessionEnded && (snapshot?.capabilities?.send === true || (
@@ -1149,7 +1153,7 @@ export function FreshAgentView({
 
     return (
       <div
-        className="relative flex h-full min-h-0 flex-col overflow-hidden"
+        className="fresh-agent-pane relative flex h-full min-h-0 flex-col overflow-hidden"
         data-context="fresh-agent"
         data-session-id={paneContent.sessionId}
         style={{ '--fresh-font-scale': String(freshFontScale) } as CSSProperties}
@@ -1163,8 +1167,8 @@ export function FreshAgentView({
             data-testid="fresh-agent-watermark"
           />
         ) : null}
-        <div className="fresh-agent-scaled-content relative z-10 flex min-h-0">
-          <div className="flex min-h-0 flex-1 flex-col">
+        <div className={`${hasSidebarMetadata ? 'fresh-agent-layout--with-sidebar ' : ''}fresh-agent-layout relative z-10 min-h-0 flex-1`}>
+          <div className="fresh-agent-main flex min-h-0 flex-1 flex-col">
             <div className="space-y-2 px-3 pt-3">
               {isRestoring ? (
                 <FreshAgentApprovalBanner text="Restoring session..." />

--- a/src/components/settings/WorkspaceSettings.tsx
+++ b/src/components/settings/WorkspaceSettings.tsx
@@ -10,7 +10,6 @@ import type {
   AttentionDismiss,
 } from '@/store/types'
 import { parseNormalizedLineList } from '@shared/string-list'
-import { FRESH_AGENT_FONT_SCALE_OPTIONS, FRESH_AGENT_FONT_SCALE_DEFAULT } from '@shared/settings'
 import type { SettingsSectionProps } from './settings-types'
 import {
   SettingsSection,
@@ -311,31 +310,6 @@ export default function WorkspaceSettings({
               })
             }}
           />
-        </SettingsRow>
-        <SettingsRow
-          label="Font size"
-          description="Scale the text in fresh-agent panes (Freshclaude, Freshcodex, and friends)."
-        >
-          <select
-            aria-label="Fresh agent font size"
-            value={String(
-              settings.freshAgent?.fontScale ?? settings.agentChat?.fontScale ?? FRESH_AGENT_FONT_SCALE_DEFAULT,
-            )}
-            onChange={(e) => {
-              const fontScale = Number(e.target.value)
-              applyLocalSetting({
-                freshAgent: { fontScale },
-                agentChat: { fontScale },
-              })
-            }}
-            className="h-10 w-full px-3 text-sm bg-muted border-0 rounded-md focus:outline-none focus:ring-1 focus:ring-border md:h-8 md:w-auto"
-          >
-            {FRESH_AGENT_FONT_SCALE_OPTIONS.map((scale) => (
-              <option key={scale} value={String(scale)}>
-                {`${Math.round(scale * 100)}%`}
-              </option>
-            ))}
-          </select>
         </SettingsRow>
       </SettingsSection>
 

--- a/src/index.css
+++ b/src/index.css
@@ -15,12 +15,12 @@ html {
   font-size: calc(100% * var(--ui-scale, 1.25));
 }
 
-/* Fresh-agent panes use their real pane geometry at every font scale. Only
-   transcript copy scales with the Fresh agent font setting, so chrome, rails,
-   buttons, and textarea layout remain responsive on desktop and phone. */
+/* Fresh-agent panes use their real pane geometry. Transcript copy inherits the
+   terminal font-size setting, while chrome, rails, buttons, and textarea layout
+   keep normal responsive UI sizing on desktop and phone. */
 .fresh-agent-pane {
   container-type: inline-size;
-  --fresh-transcript-font-size: calc(0.875rem * var(--fresh-font-scale, 1));
+  --fresh-transcript-font-size: 16px;
 }
 
 .fresh-agent-layout {
@@ -71,7 +71,7 @@ html {
 
 .fresh-agent-transcript-copy {
   font-size: var(--fresh-transcript-font-size);
-  line-height: 1.45;
+  line-height: 1.25;
 }
 
 .fresh-agent-transcript-copy [data-markdown-body] {

--- a/src/index.css
+++ b/src/index.css
@@ -15,23 +15,172 @@ html {
   font-size: calc(100% * var(--ui-scale, 1.25));
 }
 
-/* Fresh-agent panes render at a user-configurable scale (Settings -> Workspace
-   -> Fresh agent -> Font size; default 150%). Keep the pane root at full size
-   and scale only its content surface; shrinking the root itself leaves blank
-   space in the surrounding pane layout. */
-.fresh-agent-scaled-content {
-  transform: scale(var(--fresh-font-scale, 1));
-  transform-origin: top left;
-  width: calc(100% / var(--fresh-font-scale, 1));
-  height: calc(100% / var(--fresh-font-scale, 1));
+/* Fresh-agent panes use their real pane geometry at every font scale. Only
+   transcript copy scales with the Fresh agent font setting, so chrome, rails,
+   buttons, and textarea layout remain responsive on desktop and phone. */
+.fresh-agent-pane {
+  container-type: inline-size;
+  --fresh-transcript-font-size: calc(0.875rem * var(--fresh-font-scale, 1));
+}
+
+.fresh-agent-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+.fresh-agent-main {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  order: 2;
+}
+
+.fresh-agent-sidebar {
+  border-bottom: 1px solid hsl(var(--border) / 0.6);
+  flex: 0 0 auto;
+  max-height: 8rem;
+  min-height: 0;
+  min-width: 0;
+  order: 1;
+  overflow: auto;
+  padding: 0.6rem 0.75rem;
+}
+
+.fresh-agent-sidebar-content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  min-width: 0;
+}
+
+.fresh-agent-sidebar-section {
+  border: 1px solid hsl(var(--border) / 0.58);
+  border-radius: 0.35rem;
+  min-width: min(100%, 12rem);
+  padding: 0.45rem 0.55rem;
+}
+
+.fresh-agent-sidebar-list {
+  overflow-wrap: anywhere;
+}
+
+.fresh-agent-transcript-copy {
+  font-size: var(--fresh-transcript-font-size);
+  line-height: 1.45;
+}
+
+.fresh-agent-transcript-copy [data-markdown-body] {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.fresh-agent-transcript-copy [data-markdown-body] :where(p, li, blockquote, pre, code) {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.fresh-agent-composer {
+  container-type: inline-size;
+  padding-right: max(env(safe-area-inset-right), 4.25rem);
+}
+
+.fresh-agent-composer-row {
+  align-items: end;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.fresh-agent-composer-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.5rem;
+}
+
+.fresh-agent-composer-action {
+  flex: 0 0 auto;
+}
+
+.fresh-agent-activity-status-slot {
+  align-items: center;
+  display: inline-flex;
+  flex: 0 0 0.75rem;
+  height: 0.75rem;
+  justify-content: center;
+  width: 0.75rem;
+}
+
+@container (max-width: 520px) {
+  .fresh-agent-composer-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .fresh-agent-composer-actions {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .fresh-agent-composer-action {
+    width: 100% !important;
+  }
+}
+
+@container (min-width: 900px) {
+  .fresh-agent-layout--with-sidebar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(12rem, 17rem);
+  }
+
+  .fresh-agent-main {
+    order: 0;
+  }
+
+  .fresh-agent-sidebar {
+    border-bottom: 0;
+    border-left: 1px solid hsl(var(--border) / 0.6);
+    height: 100%;
+    max-height: none;
+    order: 0;
+    padding: 0.75rem;
+  }
+
+  .fresh-agent-sidebar-content {
+    display: block;
+  }
+
+  .fresh-agent-sidebar-section {
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+  }
+
+  .fresh-agent-sidebar-section + .fresh-agent-sidebar-section {
+    margin-top: 0.75rem;
+  }
+
+  .fresh-agent-layout--with-sidebar .fresh-agent-composer {
+    padding-right: 0.75rem;
+  }
+}
+
+@container (min-width: 1180px) {
+  .fresh-agent-layout--with-sidebar {
+    grid-template-columns: minmax(0, 1fr) minmax(14rem, 18rem);
+  }
 }
 
 @keyframes fresh-agent-thinking-sweep {
   0%, 100% {
-    transform: translateX(-120%);
+    transform: translateX(0%);
   }
   50% {
-    transform: translateX(250%);
+    transform: translateX(150%);
   }
 }
 

--- a/src/store/browserPreferencesPersistence.ts
+++ b/src/store/browserPreferencesPersistence.ts
@@ -131,7 +131,6 @@ export function buildLocalSettingsPatch(localSettings: LocalSettings): LocalSett
   assignChangedScalar(freshAgent, localSettings.freshAgent, defaultLocalSettings.freshAgent, 'showThinking')
   assignChangedScalar(freshAgent, localSettings.freshAgent, defaultLocalSettings.freshAgent, 'showTools')
   assignChangedScalar(freshAgent, localSettings.freshAgent, defaultLocalSettings.freshAgent, 'showTimecodes')
-  assignChangedScalar(freshAgent, localSettings.freshAgent, defaultLocalSettings.freshAgent, 'fontScale')
   if (Object.keys(freshAgent).length > 0) {
     patch.freshAgent = freshAgent
     patch.agentChat = freshAgent

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -255,7 +255,7 @@ test.describe('Fresh Agent', () => {
     })
   })
 
-  test('renders the fresh-agent pane at the configured font scale without clipping the composer', async ({ freshellPage, page, harness, terminal }) => {
+  test('renders the fresh-agent transcript at the terminal font size without clipping the composer', async ({ freshellPage, page, harness, terminal }) => {
     await terminal.waitForTerminal()
     const { tabId, paneId } = await getActiveLeaf(harness)
     const sessionId = '44444444-4444-4444-8444-444444444444'
@@ -272,7 +272,7 @@ test.describe('Fresh Agent', () => {
           revision: 1,
           latestTurnId: null,
           status: 'idle',
-          summary: 'Scaled summary line',
+          summary: 'Terminal-sized summary line',
           capabilities: { send: true, interrupt: true, approvals: true, questions: true, fork: false },
           settings: { model: 'claude-opus-4-6', permissionMode: 'default', plugins: [] },
           tokenUsage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0 },
@@ -282,8 +282,8 @@ test.describe('Fresh Agent', () => {
             id: 'turn-scaled',
             turnId: 'turn-scaled',
             role: 'assistant',
-            summary: 'Scaled transcript line',
-            items: [{ id: 'item-scaled', kind: 'text', text: 'Scaled transcript line' }],
+            summary: 'Terminal-sized transcript line',
+            items: [{ id: 'item-scaled', kind: 'text', text: 'Terminal-sized transcript line' }],
           }],
           extensions: {
             claude: {
@@ -305,7 +305,7 @@ test.describe('Fresh Agent', () => {
             kind: 'fresh-agent',
             sessionType: 'freshclaude',
             provider: 'claude',
-            createRequestId: 'req-e2e-fontscale',
+            createRequestId: 'req-e2e-terminal-font-size',
             sessionId: currentSessionId,
             sessionRef: { provider: 'claude', sessionId: currentSessionId },
             resumeSessionId: currentSessionId,
@@ -319,15 +319,14 @@ test.describe('Fresh Agent', () => {
     const paneRoot = page.locator('[data-context="fresh-agent"]')
     await expect(paneRoot).toBeVisible({ timeout: 10_000 })
 
-    const readScale = () =>
-      paneRoot.evaluate((el) => getComputedStyle(el).getPropertyValue('--fresh-font-scale').trim())
+    const readTranscriptFontSize = () =>
+      paneRoot.evaluate((el) => getComputedStyle(el).getPropertyValue('--fresh-transcript-font-size').trim())
 
-    // The fresh-agent panes default to 150% (the +50% larger default).
-    expect(await readScale()).toBe('1.5')
+    expect(await readTranscriptFontSize()).toBe('16px')
 
     const textLine = paneRoot
       .locator('article[aria-label="Assistant transcript turn"] p')
-      .filter({ hasText: 'Scaled transcript line' })
+      .filter({ hasText: 'Terminal-sized transcript line' })
       .first()
     await expect(textLine).toBeVisible()
     const readPositiveTextHeight = async () => {
@@ -338,12 +337,12 @@ test.describe('Fresh Agent', () => {
         if (height > 0) return height
         await page.waitForTimeout(50)
       }
-      throw new Error('Scaled transcript line did not have a measurable height')
+      throw new Error('Terminal-sized transcript line did not have a measurable height')
     }
-    const heightAt150 = await readPositiveTextHeight()
+    const heightAt16 = await readPositiveTextHeight()
 
     // No clipping or hidden geometry growth: the composer textarea and responsive
-    // layout stay within the pane at the larger transcript scale.
+    // layout stay within the pane when transcript text follows terminal sizing.
     const composer = paneRoot.locator('textarea').first()
     await expect(composer).toBeVisible()
     const layout = paneRoot.locator('.fresh-agent-layout')
@@ -358,19 +357,20 @@ test.describe('Fresh Agent', () => {
     const transcript = paneRoot.locator('[data-context="fresh-agent-transcript"]')
     await expect.poll(async () => transcript.evaluate((el) => el.scrollWidth - el.clientWidth)).toBeLessThanOrEqual(1)
 
-    // Shrinking the setting to 100% scales the rendered transcript down ~1.5x.
+    // Changing the terminal font size updates the transcript size. The legacy
+    // freshAgent.fontScale setting no longer drives Fresh Agent body text.
     await page.evaluate(() => {
       window.__FRESHELL_TEST_HARNESS__?.dispatch({
         type: 'settings/updateSettingsLocal',
-        payload: { freshAgent: { fontScale: 1 }, agentChat: { fontScale: 1 } },
+        payload: { terminal: { fontSize: 20 }, freshAgent: { fontScale: 2 }, agentChat: { fontScale: 2 } },
       })
     })
-    await expect.poll(readScale).toBe('1')
-    const heightAt100 = await readPositiveTextHeight()
+    await expect.poll(readTranscriptFontSize).toBe('20px')
+    const heightAt20 = await readPositiveTextHeight()
 
-    const ratio = heightAt150 / heightAt100
-    expect(ratio).toBeGreaterThan(1.35)
-    expect(ratio).toBeLessThan(1.65)
+    const ratio = heightAt20 / heightAt16
+    expect(ratio).toBeGreaterThan(1.15)
+    expect(ratio).toBeLessThan(1.35)
   })
 
   test('browser user can create and resume Freshcodex with worktree, review, and fork metadata in the shared pane', async ({ freshellPage, page, harness, terminal, serverInfo }) => {

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -278,7 +278,13 @@ test.describe('Fresh Agent', () => {
           tokenUsage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0 },
           pendingApprovals: [],
           pendingQuestions: [],
-          turns: [],
+          turns: [{
+            id: 'turn-scaled',
+            turnId: 'turn-scaled',
+            role: 'assistant',
+            summary: 'Scaled transcript line',
+            items: [{ id: 'item-scaled', kind: 'text', text: 'Scaled transcript line' }],
+          }],
           extensions: {
             claude: {
               liveSessionId: sessionId,
@@ -319,21 +325,38 @@ test.describe('Fresh Agent', () => {
     // The fresh-agent panes default to 150% (the +50% larger default).
     expect(await readScale()).toBe('1.5')
 
-    const textLine = page.getByText('Scaled summary line')
+    const textLine = paneRoot
+      .locator('article[aria-label="Assistant transcript turn"] p')
+      .filter({ hasText: 'Scaled transcript line' })
+      .first()
     await expect(textLine).toBeVisible()
-    const heightAt150 = (await textLine.boundingBox())!.height
+    const readPositiveTextHeight = async () => {
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        const height = await textLine
+          .evaluate((el) => el.getBoundingClientRect().height)
+          .catch(() => 0)
+        if (height > 0) return height
+        await page.waitForTimeout(50)
+      }
+      throw new Error('Scaled transcript line did not have a measurable height')
+    }
+    const heightAt150 = await readPositiveTextHeight()
 
-    // No clipping: the composer textarea stays within the pane at the larger scale.
+    // No clipping or hidden geometry growth: the composer textarea and responsive
+    // layout stay within the pane at the larger transcript scale.
     const composer = paneRoot.locator('textarea').first()
     await expect(composer).toBeVisible()
-    const scaledContent = paneRoot.locator('.fresh-agent-scaled-content')
-    await expect(scaledContent).toBeVisible()
+    const layout = paneRoot.locator('.fresh-agent-layout')
+    await expect(layout).toBeVisible()
     const paneBox = (await paneRoot.boundingBox())!
-    const scaledBox = (await scaledContent.boundingBox())!
-    expect(scaledBox.width).toBeGreaterThanOrEqual(paneBox.width - 2)
-    expect(scaledBox.height).toBeGreaterThanOrEqual(paneBox.height - 2)
+    const layoutBox = (await layout.boundingBox())!
+    expect(layoutBox.width).toBeLessThanOrEqual(paneBox.width + 2)
+    expect(layoutBox.height).toBeLessThanOrEqual(paneBox.height + 2)
     const composerBox = (await composer.boundingBox())!
     expect(composerBox.y + composerBox.height).toBeLessThanOrEqual(paneBox.y + paneBox.height + 2)
+    await expect.poll(async () => paneRoot.evaluate((el) => el.scrollWidth - el.clientWidth)).toBeLessThanOrEqual(1)
+    const transcript = paneRoot.locator('[data-context="fresh-agent-transcript"]')
+    await expect.poll(async () => transcript.evaluate((el) => el.scrollWidth - el.clientWidth)).toBeLessThanOrEqual(1)
 
     // Shrinking the setting to 100% scales the rendered transcript down ~1.5x.
     await page.evaluate(() => {
@@ -343,7 +366,7 @@ test.describe('Fresh Agent', () => {
       })
     })
     await expect.poll(readScale).toBe('1')
-    const heightAt100 = (await textLine.boundingBox())!.height
+    const heightAt100 = await readPositiveTextHeight()
 
     const ratio = heightAt150 / heightAt100
     expect(ratio).toBeGreaterThan(1.35)
@@ -399,7 +422,8 @@ test.describe('Fresh Agent', () => {
     }, activePaneId)
     await page.getByRole('button', { name: /^Freshcodex$/i }).click()
     await page.getByRole('option').first().click()
-    await expect(page.getByRole('group', { name: /pane: freshcodex/i }).last()).toBeVisible()
+    await expect(page.locator('[data-context="fresh-agent"]').last()).toBeVisible()
+    await expect(page.getByText('Freshcodex', { exact: true })).toBeVisible()
 
     await page.evaluate(({ currentTabId, currentPaneId }) => {
       window.__FRESHELL_TEST_HARNESS__?.dispatch({

--- a/test/e2e-browser/specs/mobile-viewport.spec.ts
+++ b/test/e2e-browser/specs/mobile-viewport.spec.ts
@@ -125,7 +125,20 @@ test.describe('Mobile Viewport', () => {
     }, paneId)
 
     const sessionId = '44444444-4444-4444-8444-444444444444'
-    await routeFreshClaudeSnapshot(page, sessionId)
+    await routeFreshClaudeSnapshot(page, sessionId, {
+      summary: 'Mobile fresh-agent overflow check',
+      turns: [{
+        id: 'turn-mobile-layout',
+        turnId: 'turn-mobile-layout',
+        role: 'assistant',
+        summary: 'mobile layout',
+        items: [{
+          id: 'item-mobile-layout',
+          kind: 'text',
+          text: 'Fresh client transcript text should wrap on a phone without creating a horizontal scrollbar, even when the message contains src/components/fresh-agent/FreshAgentView.tsx.',
+        }],
+      }],
+    })
 
     await page.evaluate(({ currentTabId, currentPaneId, currentSessionId }) => {
       const harness = window.__FRESHELL_TEST_HARNESS__
@@ -164,6 +177,19 @@ test.describe('Mobile Viewport', () => {
     // Verify the chat input is visible
     const input = pane.getByRole('textbox', { name: /chat message input/i })
     await expect(input).toBeVisible()
+
+    const paneRoot = page.locator('[data-context="fresh-agent"]')
+    const transcript = paneRoot.locator('[data-context="fresh-agent-transcript"]')
+    await expect.poll(async () => paneRoot.evaluate((el) => el.scrollWidth - el.clientWidth)).toBeLessThanOrEqual(1)
+    await expect.poll(async () => transcript.evaluate((el) => el.scrollWidth - el.clientWidth)).toBeLessThanOrEqual(1)
+
+    const addPaneButton = page.getByRole('button', { name: /^add pane$/i })
+    await expect(addPaneButton).toBeVisible()
+    const sendBox = await sendBtn.boundingBox()
+    const addPaneBox = await addPaneButton.boundingBox()
+    expect(sendBox).not.toBeNull()
+    expect(addPaneBox).not.toBeNull()
+    expect(sendBox!.x + sendBox!.width).toBeLessThanOrEqual(addPaneBox!.x - 4)
   })
 
   test('permission banner buttons are visible and functional on mobile', async ({ freshellPage, page, harness, terminal }) => {

--- a/test/unit/client/components/SettingsView.agent-chat.test.tsx
+++ b/test/unit/client/components/SettingsView.agent-chat.test.tsx
@@ -127,36 +127,13 @@ describe('SettingsView fresh agent settings', () => {
     expect(store.getState().settings.settings.agentChat.showTimecodes).toBe(true)
   })
 
-  it('renders the Font size dropdown defaulting to 150% (50% larger)', () => {
+  it('does not render a separate Fresh agent font size dropdown', () => {
     const store = createSettingsViewStore()
     renderSettingsView(store)
     switchSettingsTab('Workspace')
 
-    const select = screen.getByLabelText('Fresh agent font size') as HTMLSelectElement
-    expect(select).toBeInTheDocument()
-    expect(select.value).toBe('1.5')
-    expect(screen.getByRole('option', { name: '150%' })).toBeInTheDocument()
-  })
-
-  it('reflects a preloaded fresh agent font scale', () => {
-    const store = createSettingsViewStore({
-      settings: { freshAgent: { fontScale: 2 }, agentChat: { fontScale: 2 } },
-    })
-    renderSettingsView(store)
-    switchSettingsTab('Workspace')
-
-    expect((screen.getByLabelText('Fresh agent font size') as HTMLSelectElement).value).toBe('2')
-  })
-
-  it('changing the Font size dropdown updates freshAgent and agentChat in the store', () => {
-    const store = createSettingsViewStore()
-    renderSettingsView(store)
-    switchSettingsTab('Workspace')
-
-    fireEvent.change(screen.getByLabelText('Fresh agent font size'), { target: { value: '1.75' } })
-
-    expect(store.getState().settings.settings.freshAgent.fontScale).toBe(1.75)
-    expect(store.getState().settings.settings.agentChat.fontScale).toBe(1.75)
+    expect(screen.queryByLabelText('Fresh agent font size')).not.toBeInTheDocument()
+    expect(screen.queryByText('Scale the text in fresh-agent panes (Freshclaude, Freshcodex, and friends).')).not.toBeInTheDocument()
   })
 
   it('toggling off a previously-on setting sets it to false', () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentComposer.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentComposer.test.tsx
@@ -165,10 +165,14 @@ describe('FreshAgentComposer', () => {
     })
   })
 
-  it('renders the subtle thinking bar while the agent is working', () => {
-    render(<FreshAgentComposer commands={COMMANDS} thinking onSend={vi.fn()} />)
+  it('keeps the subtle thinking bar slot stable when work starts and stops', () => {
+    const { rerender } = render(<FreshAgentComposer commands={COMMANDS} onSend={vi.fn()} />)
 
+    expect(screen.getByTestId('fresh-agent-thinking-bar')).toHaveAttribute('data-state', 'idle')
+
+    rerender(<FreshAgentComposer commands={COMMANDS} thinking onSend={vi.fn()} />)
     expect(screen.getByTestId('fresh-agent-thinking-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('fresh-agent-thinking-bar')).toHaveAttribute('data-state', 'active')
   })
 
   describe('state-aware disabled behavior', () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -196,7 +196,7 @@ describe('FreshAgentTranscript', () => {
   })
 
   it('shows a live reel while a tool is running', () => {
-    render(
+    const { container } = render(
       <FreshAgentTranscript
         turns={[
           {
@@ -219,6 +219,7 @@ describe('FreshAgentTranscript', () => {
 
     expect(screen.getByLabelText('running')).toBeInTheDocument()
     expect(screen.getByText('Bash')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="fresh-agent-activity-status-slot"]')).toBeTruthy()
   })
 
   it('treats trailing thinking in the latest turn as live activity', () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -2553,7 +2553,7 @@ describe('FreshAgentView', () => {
   })
 })
 
-describe('FreshAgentView font scale', () => {
+describe('FreshAgentView transcript font size', () => {
   const freshClaudePane = {
     kind: 'fresh-agent',
     sessionType: 'freshclaude',
@@ -2563,7 +2563,7 @@ describe('FreshAgentView font scale', () => {
     status: 'connected',
   } as const
 
-  it('applies the default 50%-larger font scale without transforming pane geometry', async () => {
+  it('inherits the default terminal font size without transforming pane geometry', async () => {
     const store = createStore()
     render(
       <Provider store={store}>
@@ -2573,7 +2573,8 @@ describe('FreshAgentView font scale', () => {
 
     const root = document.querySelector('[data-context="fresh-agent"]') as HTMLElement
     expect(root).toBeTruthy()
-    expect(root.style.getPropertyValue('--fresh-font-scale')).toBe('1.5')
+    expect(root.style.getPropertyValue('--fresh-transcript-font-size')).toBe('16px')
+    expect(root.style.getPropertyValue('--fresh-font-scale')).toBe('')
     expect(root.querySelector('.fresh-agent-layout')).toBeTruthy()
     expect(root.querySelector('.fresh-agent-scaled-content')).toBeNull()
 
@@ -2582,7 +2583,7 @@ describe('FreshAgentView font scale', () => {
     })
   })
 
-  it('updates the fresh-agent pane font scale live when the setting changes', async () => {
+  it('updates the transcript font size live when the terminal font size changes', async () => {
     const store = createStore()
     render(
       <Provider store={store}>
@@ -2591,15 +2592,14 @@ describe('FreshAgentView font scale', () => {
     )
 
     const root = document.querySelector('[data-context="fresh-agent"]') as HTMLElement
-    expect(root.style.getPropertyValue('--fresh-font-scale')).toBe('1.5')
+    expect(root.style.getPropertyValue('--fresh-transcript-font-size')).toBe('16px')
 
     await act(async () => {
       store.dispatch(updateSettingsLocal({
-        freshAgent: { fontScale: 1.25 },
-        agentChat: { fontScale: 1.25 },
+        terminal: { fontSize: 20 },
       }))
     })
 
-    expect(root.style.getPropertyValue('--fresh-font-scale')).toBe('1.25')
+    expect(root.style.getPropertyValue('--fresh-transcript-font-size')).toBe('20px')
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -2563,7 +2563,7 @@ describe('FreshAgentView font scale', () => {
     status: 'connected',
   } as const
 
-  it('applies the default 50%-larger font scale to the fresh-agent pane root', async () => {
+  it('applies the default 50%-larger font scale without transforming pane geometry', async () => {
     const store = createStore()
     render(
       <Provider store={store}>
@@ -2574,7 +2574,8 @@ describe('FreshAgentView font scale', () => {
     const root = document.querySelector('[data-context="fresh-agent"]') as HTMLElement
     expect(root).toBeTruthy()
     expect(root.style.getPropertyValue('--fresh-font-scale')).toBe('1.5')
-    expect(root.querySelector('.fresh-agent-scaled-content')).toBeTruthy()
+    expect(root.querySelector('.fresh-agent-layout')).toBeTruthy()
+    expect(root.querySelector('.fresh-agent-scaled-content')).toBeNull()
 
     await act(async () => {
       await Promise.resolve()

--- a/test/unit/client/store/browserPreferencesPersistence.test.ts
+++ b/test/unit/client/store/browserPreferencesPersistence.test.ts
@@ -221,7 +221,7 @@ describe('browserPreferencesPersistence', () => {
     expect(bp.settings?.agentChat).toBeUndefined()
   })
 
-  it('persists freshAgent.fontScale (mirrored to agentChat) when changed from the default', () => {
+  it('does not persist deprecated freshAgent.fontScale values', () => {
     const store = createStore()
 
     store.dispatch(updateSettingsLocal({
@@ -232,26 +232,27 @@ describe('browserPreferencesPersistence', () => {
     vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
 
     const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
-    expect(bp.settings.freshAgent).toEqual({ fontScale: 1.75 })
-    expect(bp.settings.agentChat).toEqual({ fontScale: 1.75 })
-
-    const rehydrated = resolveLocalSettings(bp.settings)
-    expect(rehydrated.freshAgent.fontScale).toBe(1.75)
-    expect(rehydrated.agentChat.fontScale).toBe(1.75)
+    expect(bp.settings?.freshAgent).toBeUndefined()
+    expect(bp.settings?.agentChat).toBeUndefined()
   })
 
-  it('does not persist freshAgent.fontScale when left at the default', () => {
+  it('still accepts legacy freshAgent.fontScale records when rehydrating old preferences', () => {
     const store = createStore()
 
     store.dispatch(updateSettingsLocal({
-      freshAgent: { fontScale: 1.5 },
-      agentChat: { fontScale: 1.5 },
+      freshAgent: { showTools: true },
+      agentChat: { showTools: true },
     }))
 
     vi.advanceTimersByTime(BROWSER_PREFERENCES_PERSIST_DEBOUNCE_MS)
 
     const bp = JSON.parse(localStorage.getItem(BROWSER_PREFERENCES_STORAGE_KEY) || '{}')
-    expect(bp.settings?.freshAgent).toBeUndefined()
-    expect(bp.settings?.agentChat).toBeUndefined()
+    const rehydrated = resolveLocalSettings({
+      ...bp.settings,
+      freshAgent: { ...bp.settings.freshAgent, fontScale: 1.75 },
+      agentChat: { ...bp.settings.agentChat, fontScale: 1.75 },
+    })
+    expect(rehydrated.freshAgent.fontScale).toBe(1.75)
+    expect(rehydrated.agentChat.fontScale).toBe(1.75)
   })
 })

--- a/test/unit/shared/settings.test.ts
+++ b/test/unit/shared/settings.test.ts
@@ -425,31 +425,31 @@ describe('shared settings contract', () => {
     expect(schema.safeParse({ panes: { multirowTabs: true } }).success).toBe(false)
   })
 
-  describe('fresh-agent font scale', () => {
-    it('defaults the fresh-agent font scale to 1.5 (50% larger)', () => {
+  describe('legacy fresh-agent font scale settings', () => {
+    it('keeps the legacy fresh-agent font scale default for old stored settings', () => {
       const resolved = resolveLocalSettings(undefined)
       expect(resolved.freshAgent.fontScale).toBe(1.5)
       expect(resolved.agentChat.fontScale).toBe(1.5)
     })
 
-    it('resolves a configured fresh-agent font scale and mirrors it to agentChat', () => {
+    it('resolves a configured legacy fresh-agent font scale and mirrors it to agentChat', () => {
       const resolved = resolveLocalSettings({ freshAgent: { fontScale: 1.75 } })
       expect(resolved.freshAgent.fontScale).toBe(1.75)
       expect(resolved.agentChat.fontScale).toBe(1.75)
     })
 
-    it('accepts the fresh-agent font scale through the legacy agentChat alias', () => {
+    it('accepts the legacy fresh-agent font scale through the agentChat alias', () => {
       const resolved = resolveLocalSettings({ agentChat: { fontScale: 1.25 } })
       expect(resolved.freshAgent.fontScale).toBe(1.25)
       expect(resolved.agentChat.fontScale).toBe(1.25)
     })
 
-    it('clamps an out-of-range fresh-agent font scale into the supported range', () => {
+    it('clamps an out-of-range legacy fresh-agent font scale into the supported range', () => {
       expect(resolveLocalSettings({ freshAgent: { fontScale: 5 } }).freshAgent.fontScale).toBe(2)
       expect(resolveLocalSettings({ freshAgent: { fontScale: 0.1 } }).freshAgent.fontScale).toBe(1)
     })
 
-    it('falls back to the default when the fresh-agent font scale is not a finite number', () => {
+    it('falls back to the default when the legacy fresh-agent font scale is not a finite number', () => {
       expect(
         resolveLocalSettings({
           freshAgent: { fontScale: 'big' as unknown as number },
@@ -457,7 +457,7 @@ describe('shared settings contract', () => {
       ).toBe(1.5)
     })
 
-    it('exposes the resolved fresh-agent font scale in composed settings', () => {
+    it('keeps the resolved legacy fresh-agent font scale in composed settings', () => {
       const resolved = composeResolvedSettings(
         createDefaultServerSettings({ loggingDebug: false }),
         resolveLocalSettings({ freshAgent: { fontScale: 2 } }),
@@ -465,7 +465,7 @@ describe('shared settings contract', () => {
       expect(resolved.freshAgent.fontScale).toBe(2)
     })
 
-    it('clamps the fresh-agent font scale when extracting a legacy local seed', () => {
+    it('clamps the legacy fresh-agent font scale when extracting a local seed', () => {
       expect(
         extractLegacyLocalSettingsSeed({ agentChat: { fontScale: 9 } } as Record<string, unknown>),
       ).toEqual({ agentChat: { fontScale: 2 } })


### PR DESCRIPTION
## Summary
- Reworks Fresh Agent pane geometry so the transcript, composer, and metadata rail fit desktop and phone without horizontal overflow.
- Makes transcript text inherit the terminal font size setting and removes the separate Fresh Agent font-size control/persistence path.
- Updates the static docs mock and focused unit/e2e coverage for the responsive layout and terminal-font behavior.

## Test Plan
- npm run check
