### PR TITLE
Restore Freshopencode history from OpenCode DB

### DIFF
--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -1,13 +1,28 @@
 import { EventEmitter } from 'node:events'
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
-import type { FreshAgentCreateRequest, FreshAgentRuntimeAdapter, FreshAgentThreadLocator } from '../../runtime-adapter.js'
+import path from 'node:path'
+import type {
+  FreshAgentCreateRequest,
+  FreshAgentRuntimeAdapter,
+  FreshAgentSendResult,
+  FreshAgentThreadLocator,
+} from '../../runtime-adapter.js'
+import { FreshAgentLostSessionError } from '../../runtime-manager.js'
 import { normalizeFreshAgentEffort, normalizeFreshAgentModel } from '../../../../shared/fresh-agent-models.js'
 import { logger } from '../../../logger.js'
+import { defaultOpencodeDataHome } from '../../../coding-cli/providers/opencode.js'
 import {
+  type OpencodeExport,
   normalizeOpencodeSnapshot,
   normalizeOpencodeTurnBody,
   normalizeOpencodeTurnPage,
 } from './normalize.js'
+import { DEFAULT_SNAPSHOT_TURN_LIMIT } from './history-query.js'
+import {
+  createWorkerHistoryReader,
+  OpencodeHistoryReaderError,
+  type OpencodeHistoryReader,
+} from './history-runner.js'
 
 type SpawnFn = typeof spawn
 
@@ -20,7 +35,20 @@ type OpencodeSessionState = {
   status: string
   activeProcess?: ChildProcessWithoutNullStreams
   events: EventEmitter
+  sendQueue: Promise<unknown>
 }
+
+type CreateOpencodeFreshAgentAdapterOptions = {
+  command?: string
+  spawnFn?: SpawnFn
+  runTimeoutMs?: number
+  historyReader?: OpencodeHistoryReader
+  dbPath?: string
+  dataHome?: string
+}
+
+const OPENCODE_REAL_SESSION_ID = /^ses_/
+const OPENCODE_PLACEHOLDER_SESSION_ID = /^freshopencode-/
 
 function makePlaceholderId(requestId: string): string {
   return `freshopencode-${requestId}`
@@ -30,22 +58,43 @@ function splitModel(value: string | undefined): string | undefined {
   return value && value.trim().length > 0 ? value : undefined
 }
 
-function parseRunEvents(stdout: string): { sessionId?: string } {
+function isRealOpencodeSessionId(sessionId: string): boolean {
+  return OPENCODE_REAL_SESSION_ID.test(sessionId)
+}
+
+function isPlaceholderOpencodeSessionId(sessionId: string): boolean {
+  return OPENCODE_PLACEHOLDER_SESSION_ID.test(sessionId)
+}
+
+function parseRunEvents(stdout: string): { sessionId?: string; ambiguousSessionIds?: string[] } {
+  const sessionIds = new Set<string>()
   for (const line of stdout.split(/\r?\n/)) {
     if (!line.trim().startsWith('{')) continue
     try {
       const event = JSON.parse(line)
-      if (typeof event?.sessionID === 'string') return { sessionId: event.sessionID }
+      if (
+        event
+        && typeof event === 'object'
+        && !Array.isArray(event)
+        && typeof event.sessionID === 'string'
+        && isRealOpencodeSessionId(event.sessionID)
+      ) {
+        sessionIds.add(event.sessionID)
+      }
     } catch {
       // Ignore non-JSON formatted output around raw event lines.
     }
   }
+  if (sessionIds.size === 1) return { sessionId: [...sessionIds][0] }
+  if (sessionIds.size > 1) return { ambiguousSessionIds: [...sessionIds] }
   return {}
 }
 
-function parseExportOutput(stdout: string): unknown {
+function parseExportOutput(stdout: string): OpencodeExport {
   const jsonStart = stdout.indexOf('{')
-  if (jsonStart < 0) return undefined
+  if (jsonStart < 0) {
+    throw new Error('OpenCode export output did not contain JSON.')
+  }
   return JSON.parse(stdout.slice(jsonStart))
 }
 
@@ -58,14 +107,12 @@ function normalizeOpencodeInput(input: FreshAgentCreateRequest): FreshAgentCreat
   }
 }
 
-export function createOpencodeFreshAgentAdapter(options: {
-  command?: string
-  spawnFn?: SpawnFn
-  runTimeoutMs?: number
-} = {}): FreshAgentRuntimeAdapter {
+export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgentAdapterOptions = {}): FreshAgentRuntimeAdapter {
   const command = options.command ?? 'opencode'
   const spawnFn = options.spawnFn ?? spawn
   const runTimeoutMs = options.runTimeoutMs ?? 180_000
+  const dbPath = options.dbPath ?? path.join(options.dataHome ?? defaultOpencodeDataHome(), 'opencode.db')
+  const historyReader = options.historyReader ?? createWorkerHistoryReader({ dbPath })
   const log = logger.child({ component: 'freshopencode-adapter' })
   const sessions = new Map<string, OpencodeSessionState>()
 
@@ -77,9 +124,78 @@ export function createOpencodeFreshAgentAdapter(options: {
   function requireState(sessionId: string): OpencodeSessionState {
     const state = sessions.get(sessionId)
     if (!state) {
-      throw new Error(`OpenCode fresh-agent session ${sessionId} is not available.`)
+      throw new FreshAgentLostSessionError(`OpenCode fresh-agent session ${sessionId} is not available.`)
     }
     return state
+  }
+
+  function requireDurableSession(threadId: string): {
+    sessionId: string
+    cwd?: string
+    status: string
+    model?: string
+    effort?: string
+  } {
+    const state = sessions.get(threadId)
+    if (state) {
+      if (!state.realSessionId) {
+        throw new FreshAgentLostSessionError(`OpenCode fresh-agent placeholder ${threadId} has not materialized.`)
+      }
+      return {
+        sessionId: state.realSessionId,
+        cwd: state.cwd,
+        status: state.status,
+        model: state.model,
+        effort: state.effort,
+      }
+    }
+    if (isPlaceholderOpencodeSessionId(threadId)) {
+      throw new FreshAgentLostSessionError(`OpenCode fresh-agent placeholder ${threadId} is not restorable.`)
+    }
+    if (!isRealOpencodeSessionId(threadId)) {
+      throw new FreshAgentLostSessionError(`OpenCode fresh-agent session ${threadId} is not a durable OpenCode session.`)
+    }
+    return { sessionId: threadId, status: 'idle' }
+  }
+
+  function sendResult(sessionId: string | undefined): FreshAgentSendResult {
+    return sessionId
+      ? { sessionId, sessionRef: { provider: 'opencode', sessionId } }
+      : undefined
+  }
+
+  function canFallbackToExport(error: unknown): boolean {
+    return error instanceof OpencodeHistoryReaderError
+      && (error.reason === 'missing_db' || error.reason === 'sqlite_unavailable')
+  }
+
+  function logHistoryWarning(
+    messageClass: string,
+    message: string,
+    options: { error?: unknown; sessionId?: string; extra?: Record<string, unknown> } = {},
+  ): void {
+    log.warn({
+      ...(options.error instanceof Error ? { err: options.error } : {}),
+      messageClass,
+      ...(options.error instanceof OpencodeHistoryReaderError ? { reason: options.error.reason } : {}),
+      ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+      ...(options.extra ?? {}),
+    }, message)
+  }
+
+  async function hydrateSessionInfo(state: OpencodeSessionState, sessionId: string, scope: 'materialize' | 'attach' | 'resume'): Promise<void> {
+    try {
+      const info = await historyReader.readSessionInfo(sessionId)
+      if (typeof info?.directory === 'string' && info.directory.length > 0) {
+        state.cwd = info.directory
+      }
+    } catch (error) {
+      logHistoryWarning(
+        'history_session_info_unavailable',
+        'OpenCode session info could not be read from history database.',
+        { error, sessionId, extra: { scope } },
+      )
+    }
   }
 
   function runCli(
@@ -137,9 +253,8 @@ export function createOpencodeFreshAgentAdapter(options: {
     })
   }
 
-  async function exportSession(state: OpencodeSessionState): Promise<any | undefined> {
-    if (!state.realSessionId) return undefined
-    const { stdout } = await runCli(['export', state.realSessionId], state.cwd)
+  async function exportSession(sessionId: string, cwd?: string): Promise<OpencodeExport> {
+    const { stdout } = await runCli(['export', sessionId], cwd)
     return parseExportOutput(stdout)
   }
 
@@ -147,7 +262,7 @@ export function createOpencodeFreshAgentAdapter(options: {
     state: OpencodeSessionState,
     text: string,
     settings?: Partial<FreshAgentCreateRequest>,
-  ): Promise<void> {
+  ): Promise<FreshAgentSendResult> {
     const normalized = settings
       ? normalizeOpencodeInput({
           requestId: state.placeholderId,
@@ -169,12 +284,28 @@ export function createOpencodeFreshAgentAdapter(options: {
     ]
     state.status = 'running'
     state.events.emit('event', { type: 'sdk.session.snapshot', sessionId: state.placeholderId, status: 'running' })
+    const effectiveCwd = normalized?.cwd ?? state.cwd
     try {
-      const { stdout } = await runCli(args, normalized?.cwd ?? state.cwd, state, runTimeoutMs)
+      const { stdout } = await runCli(args, effectiveCwd, state, runTimeoutMs)
       const parsed = parseRunEvents(stdout)
-      if (parsed.sessionId && !state.realSessionId) {
-        state.realSessionId = parsed.sessionId
-        remember(state)
+      if (!state.realSessionId) {
+        if (parsed.sessionId) {
+          state.realSessionId = parsed.sessionId
+          await hydrateSessionInfo(state, parsed.sessionId, 'materialize')
+          remember(state)
+        } else if (parsed.ambiguousSessionIds?.length) {
+          logHistoryWarning(
+            'ambiguous_run_session_id',
+            'OpenCode run emitted multiple top-level session ids; leaving placeholder unmaterialized.',
+            { sessionId: state.placeholderId, extra: { candidateSessionIds: parsed.ambiguousSessionIds } },
+          )
+        } else {
+          logHistoryWarning(
+            'missing_run_session_id',
+            'OpenCode run did not emit an authoritative top-level session id; leaving placeholder unmaterialized.',
+            { sessionId: state.placeholderId },
+          )
+        }
       }
     } catch (error) {
       state.status = 'idle'
@@ -185,6 +316,20 @@ export function createOpencodeFreshAgentAdapter(options: {
     state.effort = effort
     state.status = 'idle'
     state.events.emit('event', { type: 'sdk.session.snapshot', sessionId: state.placeholderId, status: 'idle' })
+    return sendResult(state.realSessionId)
+  }
+
+  function exportedWithRevision(exported: OpencodeExport, revision: number): OpencodeExport {
+    return {
+      ...exported,
+      info: {
+        ...(exported.info ?? {}),
+        time: {
+          ...(exported.info?.time ?? {}),
+          updated: revision,
+        },
+      },
+    }
   }
 
   return {
@@ -199,6 +344,7 @@ export function createOpencodeFreshAgentAdapter(options: {
         effort: normalized.effort,
         status: 'idle',
         events: new EventEmitter(),
+        sendQueue: Promise.resolve(),
       }
       remember(state)
       return { sessionId: state.placeholderId, sessionRef: { provider: 'opencode', sessionId: state.placeholderId } }
@@ -208,6 +354,9 @@ export function createOpencodeFreshAgentAdapter(options: {
       const normalized = normalizeOpencodeInput(input)
       const sessionId = normalized.resumeSessionId
       if (!sessionId) throw new Error('OpenCode resume requires a session id.')
+      if (isPlaceholderOpencodeSessionId(sessionId) || !isRealOpencodeSessionId(sessionId)) {
+        throw new FreshAgentLostSessionError(`OpenCode session ${sessionId} is not a durable OpenCode session.`)
+      }
       const state: OpencodeSessionState = {
         placeholderId: sessionId,
         realSessionId: sessionId,
@@ -216,24 +365,31 @@ export function createOpencodeFreshAgentAdapter(options: {
         effort: normalized.effort,
         status: 'idle',
         events: new EventEmitter(),
+        sendQueue: Promise.resolve(),
       }
       remember(state)
+      await hydrateSessionInfo(state, sessionId, 'resume')
       return { sessionId, sessionRef: { provider: 'opencode', sessionId } }
     },
 
-    attach(locator) {
+    async attach(locator) {
       const existing = sessions.get(locator.sessionId)
       if (existing) {
         remember(existing)
         return { sessionId: locator.sessionId, sessionRef: { provider: 'opencode', sessionId: locator.sessionId } }
+      }
+      if (isPlaceholderOpencodeSessionId(locator.sessionId) || !isRealOpencodeSessionId(locator.sessionId)) {
+        throw new FreshAgentLostSessionError(`OpenCode session ${locator.sessionId} is not a durable OpenCode session.`)
       }
       const state: OpencodeSessionState = {
         placeholderId: locator.sessionId,
         realSessionId: locator.sessionId,
         status: 'idle',
         events: new EventEmitter(),
+        sendQueue: Promise.resolve(),
       }
       remember(state)
+      await hydrateSessionInfo(state, locator.sessionId, 'attach')
       return { sessionId: locator.sessionId, sessionRef: { provider: 'opencode', sessionId: locator.sessionId } }
     },
 
@@ -246,7 +402,12 @@ export function createOpencodeFreshAgentAdapter(options: {
 
     async send(sessionId, input) {
       const state = requireState(sessionId)
-      await materializeOrSend(state, input.text, input.settings)
+      const run = state.sendQueue.then(
+        () => materializeOrSend(state, input.text, input.settings),
+        () => materializeOrSend(state, input.text, input.settings),
+      )
+      state.sendQueue = run.catch(() => undefined)
+      return await run
     },
 
     interrupt(sessionId) {
@@ -259,7 +420,12 @@ export function createOpencodeFreshAgentAdapter(options: {
     async compact(sessionId, input) {
       const state = requireState(sessionId)
       const suffix = input?.instructions ? ` ${input.instructions.trim()}` : ''
-      await materializeOrSend(state, `/compact${suffix}`)
+      const run = state.sendQueue.then(
+        () => materializeOrSend(state, `/compact${suffix}`),
+        () => materializeOrSend(state, `/compact${suffix}`),
+      )
+      state.sendQueue = run.catch(() => undefined)
+      await run
     },
 
     kill(sessionId) {
@@ -271,26 +437,76 @@ export function createOpencodeFreshAgentAdapter(options: {
     },
 
     async getSnapshot(thread: FreshAgentThreadLocator) {
-      const state = sessions.get(thread.threadId) ?? {
-        placeholderId: thread.threadId,
-        realSessionId: thread.threadId,
-        status: 'idle',
-        events: new EventEmitter(),
+      const durable = requireDurableSession(thread.threadId)
+      let exported: OpencodeExport
+      try {
+        const page = await historyReader.readSnapshotPage(durable.sessionId, DEFAULT_SNAPSHOT_TURN_LIMIT)
+        if (!page) {
+          throw new FreshAgentLostSessionError(`OpenCode session ${durable.sessionId} was not found in history.`)
+        }
+        exported = exportedWithRevision(page.exported, page.revision)
+      } catch (error) {
+        if (!canFallbackToExport(error)) {
+          if (error instanceof OpencodeHistoryReaderError) {
+            logHistoryWarning(
+              'history_snapshot_failed',
+              'OpenCode snapshot history read failed.',
+              { error, sessionId: durable.sessionId },
+            )
+          }
+          throw error
+        }
+        logHistoryWarning(
+          'history_snapshot_unavailable',
+          'OpenCode snapshot history is unavailable; falling back to export.',
+          { error, sessionId: durable.sessionId },
+        )
+        exported = await exportSession(durable.sessionId, durable.cwd)
       }
-      const exported = await exportSession(state).catch(() => undefined)
       return normalizeOpencodeSnapshot({
         sessionType: 'freshopencode',
         threadId: thread.threadId,
         exported,
-        status: state.status,
-        model: state.model,
-        effort: state.effort,
+        status: durable.status,
+        model: durable.model,
+        effort: durable.effort,
       })
     },
 
     async getTurnPage(thread, query) {
-      const state = requireState(thread.threadId)
-      const exported = await exportSession(state).catch(() => undefined)
+      const durable = requireDurableSession(thread.threadId)
+      try {
+        const page = await historyReader.readTurnPage(durable.sessionId, {
+          cursor: typeof query.cursor === 'string' ? query.cursor : undefined,
+          limit: typeof query.limit === 'number' ? query.limit : undefined,
+        })
+        if (!page) {
+          throw new FreshAgentLostSessionError(`OpenCode session ${durable.sessionId} was not found in history.`)
+        }
+        return normalizeOpencodeTurnPage({
+          threadId: thread.threadId,
+          exported: page.exported,
+          revision: page.revision,
+          nextCursor: page.nextCursor,
+        })
+      } catch (error) {
+        if (!canFallbackToExport(error)) {
+          if (error instanceof OpencodeHistoryReaderError) {
+            logHistoryWarning(
+              'history_turn_page_failed',
+              'OpenCode turn page history read failed.',
+              { error, sessionId: durable.sessionId },
+            )
+          }
+          throw error
+        }
+        logHistoryWarning(
+          'history_turn_page_unavailable',
+          'OpenCode turn page history is unavailable; falling back to export.',
+          { error, sessionId: durable.sessionId },
+        )
+      }
+      const exported = await exportSession(durable.sessionId, durable.cwd)
       return normalizeOpencodeTurnPage({
         threadId: thread.threadId,
         exported,
@@ -299,8 +515,34 @@ export function createOpencodeFreshAgentAdapter(options: {
     },
 
     async getTurnBody(thread, revision) {
-      const state = requireState(thread.threadId)
-      const exported = await exportSession(state).catch(() => undefined)
+      const durable = requireDurableSession(thread.threadId)
+      try {
+        const body = await historyReader.readTurnBody(durable.sessionId, thread.turnId)
+        if (!body) return null
+        return normalizeOpencodeTurnBody({
+          threadId: thread.threadId,
+          exported: { messages: [body.message] },
+          turnId: thread.turnId,
+          revision: body.revision,
+        })
+      } catch (error) {
+        if (!canFallbackToExport(error)) {
+          if (error instanceof OpencodeHistoryReaderError) {
+            logHistoryWarning(
+              'history_turn_body_failed',
+              'OpenCode turn body history read failed.',
+              { error, sessionId: durable.sessionId },
+            )
+          }
+          throw error
+        }
+        logHistoryWarning(
+          'history_turn_body_unavailable',
+          'OpenCode turn body history is unavailable; falling back to export.',
+          { error, sessionId: durable.sessionId },
+        )
+      }
+      const exported = await exportSession(durable.sessionId, durable.cwd)
       return normalizeOpencodeTurnBody({
         threadId: thread.threadId,
         exported,

--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -437,6 +437,16 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
     },
 
     async getSnapshot(thread: FreshAgentThreadLocator) {
+      const liveState = sessions.get(thread.threadId)
+      if (liveState && !liveState.realSessionId) {
+        return normalizeOpencodeSnapshot({
+          sessionType: 'freshopencode',
+          threadId: thread.threadId,
+          status: liveState.status,
+          model: liveState.model,
+          effort: liveState.effort,
+        })
+      }
       const durable = requireDurableSession(thread.threadId)
       let exported: OpencodeExport
       try {
@@ -474,6 +484,15 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
     },
 
     async getTurnPage(thread, query) {
+      const liveState = sessions.get(thread.threadId)
+      if (liveState && !liveState.realSessionId) {
+        return normalizeOpencodeTurnPage({
+          threadId: thread.threadId,
+          exported: { messages: [] },
+          revision: Number(query.revision) || 0,
+          nextCursor: null,
+        })
+      }
       const durable = requireDurableSession(thread.threadId)
       try {
         const page = await historyReader.readTurnPage(durable.sessionId, {
@@ -515,6 +534,10 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
     },
 
     async getTurnBody(thread, revision) {
+      const liveState = sessions.get(thread.threadId)
+      if (liveState && !liveState.realSessionId) {
+        return null
+      }
       const durable = requireDurableSession(thread.threadId)
       try {
         const body = await historyReader.readTurnBody(durable.sessionId, thread.turnId)

--- a/server/fresh-agent/adapters/opencode/history-query.ts
+++ b/server/fresh-agent/adapters/opencode/history-query.ts
@@ -1,0 +1,547 @@
+import type { OpencodeExport } from './normalize.js'
+
+export type OpencodeSessionInfo = NonNullable<OpencodeExport['info']> & {
+  id: string
+  directory?: string
+}
+
+export type OpencodeHistoryPage = {
+  exported: OpencodeExport
+  revision: number
+  nextCursor: string | null
+  hasMoreBefore: boolean
+  totalMessages?: number
+}
+
+export type OpencodeTurnBodyResult = {
+  message: NonNullable<OpencodeExport['messages']>[number]
+  revision: number
+}
+
+export type OpencodeHistoryExportPage = OpencodeHistoryPage & OpencodeExport
+export type OpencodeHistoryTurnBody = OpencodeTurnBodyResult & NonNullable<OpencodeExport['messages']>[number]
+
+export type OpencodeHistoryReadRequest =
+  | { type: 'session_info'; sessionId: string }
+  | { type: 'snapshot_page'; sessionId: string; limit?: number }
+  | { type: 'turn_page'; sessionId: string; query?: { cursor?: string; limit?: number } }
+  | { type: 'turn_body'; sessionId: string; turnId: string }
+
+export type OpencodeHistoryReadResult =
+  | { type: 'session_info'; sessionInfo: OpencodeSessionInfo }
+  | { type: 'snapshot_page'; page: OpencodeHistoryExportPage }
+  | { type: 'turn_page'; page: OpencodeHistoryExportPage }
+  | { type: 'turn_body'; body: OpencodeHistoryTurnBody }
+
+type StatementLike = {
+  all: (...params: any[]) => unknown[]
+  get: (...params: any[]) => unknown
+}
+
+type DatabaseLike = {
+  exec: (sql: string) => unknown
+  prepare: (sql: string) => StatementLike
+}
+
+type SessionRow = Record<string, unknown> & {
+  id?: unknown
+  directory?: unknown
+  title?: unknown
+  model?: unknown
+  cost?: unknown
+  tokens_input?: unknown
+  tokens_output?: unknown
+  tokens_reasoning?: unknown
+  tokens_cache_read?: unknown
+  tokens_cache_write?: unknown
+  time_created?: unknown
+  time_updated?: unknown
+}
+
+type MessageRow = {
+  id: unknown
+  session_id: unknown
+  time_created: unknown
+  time_updated: unknown
+  data: unknown
+}
+
+type PartRow = {
+  id: unknown
+  message_id: unknown
+  session_id: unknown
+  time_created: unknown
+  time_updated: unknown
+  data: unknown
+}
+
+type HydratedMessage = NonNullable<OpencodeExport['messages']>[number]
+
+const OPENCODE_DB_BUSY_TIMEOUT_MS = 5000
+
+export const DEFAULT_SNAPSHOT_TURN_LIMIT = 200
+
+const SESSION_REQUIRED_COLUMNS = [
+  'id',
+  'directory',
+  'title',
+  'model',
+  'cost',
+  'tokens_input',
+  'tokens_output',
+  'tokens_reasoning',
+  'tokens_cache_read',
+  'tokens_cache_write',
+  'time_created',
+  'time_updated',
+] as const
+
+const SESSION_OPTIONAL_COLUMNS = [
+  'project_id',
+  'workspace_id',
+  'parent_id',
+  'slug',
+  'path',
+  'version',
+  'share_url',
+  'summary_additions',
+  'summary_deletions',
+  'summary_files',
+  'summary_diffs',
+  'metadata',
+  'revert',
+  'permission',
+  'agent',
+  'time_compacting',
+  'time_archived',
+] as const
+
+const MESSAGE_REQUIRED_COLUMNS = [
+  'id',
+  'session_id',
+  'time_created',
+  'time_updated',
+  'data',
+] as const
+
+const PART_REQUIRED_COLUMNS = [
+  'id',
+  'message_id',
+  'session_id',
+  'time_created',
+  'time_updated',
+  'data',
+] as const
+
+export class OpencodeHistorySchemaError extends Error {
+  readonly code = 'OPENCODE_HISTORY_SCHEMA_ERROR'
+  readonly table: string
+  readonly missingColumns: string[]
+
+  constructor(table: string, missingColumns: string[]) {
+    super(`OpenCode history table "${table}" is missing required columns: ${missingColumns.join(', ')}`)
+    this.name = 'OpencodeHistorySchemaError'
+    this.table = table
+    this.missingColumns = missingColumns
+  }
+}
+
+function inspectColumns(db: DatabaseLike, table: string): Set<string> {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: unknown }>
+  return new Set(rows.map((row) => row.name).filter((name): name is string => typeof name === 'string'))
+}
+
+function requireColumns(db: DatabaseLike, table: string, required: readonly string[]): Set<string> {
+  const columns = inspectColumns(db, table)
+  const missingColumns = required.filter((column) => !columns.has(column))
+  if (missingColumns.length > 0) {
+    throw new OpencodeHistorySchemaError(table, missingColumns)
+  }
+  return columns
+}
+
+function requireHistorySchema(db: DatabaseLike): { sessionColumns: Set<string> } {
+  const sessionColumns = requireColumns(db, 'session', SESSION_REQUIRED_COLUMNS)
+  requireColumns(db, 'message', MESSAGE_REQUIRED_COLUMNS)
+  requireColumns(db, 'part', PART_REQUIRED_COLUMNS)
+  return { sessionColumns }
+}
+
+function normalizeLimit(value: number | undefined, defaultValue: number): number {
+  if (!Number.isFinite(value) || value === undefined) return defaultValue
+  return Math.max(1, Math.min(defaultValue, Math.trunc(value)))
+}
+
+function parseJsonText(value: unknown, label: string): unknown {
+  if (value === null || value === undefined) return undefined
+  if (typeof value !== 'string') return value
+  if (value.length === 0) return undefined
+  try {
+    return JSON.parse(value)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to parse OpenCode ${label} JSON: ${message}`)
+  }
+}
+
+function parseJsonObject(value: unknown, label: string): Record<string, unknown> {
+  const parsed = parseJsonText(value, label)
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : {}
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'bigint') return Number(value)
+  return undefined
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function setIfString(target: Record<string, unknown>, key: string, value: unknown): void {
+  const str = stringValue(value)
+  if (str !== undefined) target[key] = str
+}
+
+function setIfNumber(target: Record<string, unknown>, key: string, value: unknown): void {
+  const number = numberValue(value)
+  if (number !== undefined) target[key] = number
+}
+
+function sessionSelectList(columns: Set<string>): string {
+  const names = [...SESSION_REQUIRED_COLUMNS, ...SESSION_OPTIONAL_COLUMNS]
+  return names
+    .map((column) => columns.has(column) ? `s.${column} AS ${column}` : `NULL AS ${column}`)
+    .join(', ')
+}
+
+function readSessionRow(db: DatabaseLike, sessionId: string, columns: Set<string>): SessionRow | undefined {
+  return db.prepare(`
+    SELECT ${sessionSelectList(columns)}
+    FROM session s
+    WHERE s.id = ?
+    LIMIT 1
+  `).get(sessionId) as SessionRow | undefined
+}
+
+function hydrateSessionInfo(row: SessionRow): OpencodeSessionInfo {
+  const info: Record<string, unknown> = {
+    id: String(row.id),
+    tokens: {
+      input: numberValue(row.tokens_input) ?? 0,
+      output: numberValue(row.tokens_output) ?? 0,
+      reasoning: numberValue(row.tokens_reasoning) ?? 0,
+      cache: {
+        read: numberValue(row.tokens_cache_read) ?? 0,
+        write: numberValue(row.tokens_cache_write) ?? 0,
+      },
+    },
+    time: {
+      created: numberValue(row.time_created) ?? 0,
+      updated: numberValue(row.time_updated) ?? 0,
+    },
+  }
+
+  setIfString(info, 'directory', row.directory)
+  setIfString(info, 'title', row.title)
+  setIfString(info, 'projectID', row.project_id)
+  setIfString(info, 'workspaceID', row.workspace_id)
+  setIfString(info, 'parentID', row.parent_id)
+  setIfString(info, 'slug', row.slug)
+  setIfString(info, 'path', row.path)
+  setIfString(info, 'version', row.version)
+  setIfString(info, 'shareURL', row.share_url)
+  setIfString(info, 'permission', row.permission)
+  setIfString(info, 'agent', row.agent)
+  setIfNumber(info, 'cost', row.cost)
+
+  const model = parseJsonText(row.model, 'session.model')
+  if (model !== undefined) info.model = model
+
+  const metadata = parseJsonText(row.metadata, 'session.metadata')
+  if (metadata !== undefined) info.metadata = metadata
+
+  const summaryDiffs = parseJsonText(row.summary_diffs, 'session.summary_diffs')
+  const summary = {
+    additions: numberValue(row.summary_additions) ?? 0,
+    deletions: numberValue(row.summary_deletions) ?? 0,
+    files: numberValue(row.summary_files) ?? 0,
+    ...(summaryDiffs !== undefined ? { diffs: summaryDiffs } : {}),
+  }
+  if (
+    summary.additions !== 0
+    || summary.deletions !== 0
+    || summary.files !== 0
+    || 'diffs' in summary
+  ) {
+    info.summary = summary
+  }
+
+  const revert = parseJsonText(row.revert, 'session.revert')
+  if (revert !== undefined) info.revert = revert
+
+  const compacting = numberValue(row.time_compacting)
+  const archived = numberValue(row.time_archived)
+  const time = info.time as Record<string, unknown>
+  if (compacting !== undefined) time.compacting = compacting
+  if (archived !== undefined) time.archived = archived
+
+  return info as OpencodeSessionInfo
+}
+
+function hydrateMessage(row: MessageRow, parts: Record<string, unknown>[]): HydratedMessage {
+  const data = parseJsonObject(row.data, 'message.data')
+  return {
+    info: {
+      ...data,
+      id: String(row.id),
+      sessionID: String(row.session_id),
+      time: {
+        created: numberValue(row.time_created) ?? 0,
+        updated: numberValue(row.time_updated) ?? 0,
+      },
+    },
+    parts,
+  }
+}
+
+function hydratePart(row: PartRow): Record<string, unknown> {
+  const data = parseJsonObject(row.data, 'part.data')
+  return {
+    ...data,
+    id: String(row.id),
+    sessionID: String(row.session_id),
+    messageID: String(row.message_id),
+    time: {
+      created: numberValue(row.time_created) ?? 0,
+      updated: numberValue(row.time_updated) ?? 0,
+    },
+  }
+}
+
+function readPartsByMessageId(
+  db: DatabaseLike,
+  sessionId: string,
+  messageIds: readonly string[],
+): Map<string, Record<string, unknown>[]> {
+  const partsByMessageId = new Map<string, Record<string, unknown>[]>()
+  if (messageIds.length === 0) return partsByMessageId
+  const placeholders = messageIds.map(() => '?').join(', ')
+  const rows = db.prepare(`
+    SELECT id, message_id, session_id, time_created, time_updated, data
+    FROM part
+    WHERE session_id = ?
+      AND message_id IN (${placeholders})
+    ORDER BY id ASC
+  `).all(sessionId, ...messageIds) as PartRow[]
+  for (const row of rows) {
+    const messageId = String(row.message_id)
+    const parts = partsByMessageId.get(messageId) ?? []
+    parts.push(hydratePart(row))
+    partsByMessageId.set(messageId, parts)
+  }
+  return partsByMessageId
+}
+
+function hydrateMessages(db: DatabaseLike, sessionId: string, rows: MessageRow[]): HydratedMessage[] {
+  const messageIds = rows.map((row) => String(row.id))
+  const partsByMessageId = readPartsByMessageId(db, sessionId, messageIds)
+  return rows.map((row) => hydrateMessage(row, partsByMessageId.get(String(row.id)) ?? []))
+}
+
+function countMessages(db: DatabaseLike, sessionId: string): number | undefined {
+  const row = db.prepare('SELECT COUNT(*) AS count FROM message WHERE session_id = ?').get(sessionId) as { count?: unknown } | undefined
+  return numberValue(row?.count)
+}
+
+function revisionFromInfo(info: OpencodeSessionInfo): number {
+  const updated = numberValue((info.time as Record<string, unknown> | undefined)?.updated)
+  return Math.max(0, Math.trunc(updated ?? 0))
+}
+
+function makePage(
+  exported: OpencodeExport,
+  metadata: Omit<OpencodeHistoryPage, 'exported'>,
+): OpencodeHistoryExportPage {
+  return {
+    ...exported,
+    exported,
+    ...metadata,
+  }
+}
+
+function withReadTransaction<T>(db: DatabaseLike, read: () => T): T {
+  db.exec('BEGIN')
+  try {
+    const result = read()
+    db.exec('COMMIT')
+    return result
+  } catch (error) {
+    try {
+      db.exec('ROLLBACK')
+    } catch {
+      // Ignore rollback failures and preserve the original read error.
+    }
+    throw error
+  }
+}
+
+export function encodeOpencodeCursor(input: { time: number; id: string } | { timeCreated: number; id: string }): string {
+  const time = 'time' in input ? input.time : input.timeCreated
+  return Buffer.from(JSON.stringify({ time, id: input.id }), 'utf8').toString('base64url')
+}
+
+function decodeOpencodeCursor(cursor: string): { time: number; id: string } {
+  const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as { time?: unknown; timeCreated?: unknown; id?: unknown }
+  const time = numberValue(parsed.time) ?? numberValue(parsed.timeCreated)
+  if (time === undefined || typeof parsed.id !== 'string' || parsed.id.length === 0) {
+    throw new Error('Invalid OpenCode history cursor.')
+  }
+  return { time, id: parsed.id }
+}
+
+export function readOpencodeSessionInfo(
+  db: DatabaseLike,
+  input: { sessionId: string },
+): OpencodeSessionInfo | undefined {
+  const sessionColumns = requireColumns(db, 'session', SESSION_REQUIRED_COLUMNS)
+  const row = readSessionRow(db, input.sessionId, sessionColumns)
+  return row ? hydrateSessionInfo(row) : undefined
+}
+
+export function readOpencodeSnapshotPage(
+  db: DatabaseLike,
+  input: { sessionId: string; limit?: number },
+): OpencodeHistoryExportPage | undefined {
+  const { sessionColumns } = requireHistorySchema(db)
+  const limit = normalizeLimit(input.limit, DEFAULT_SNAPSHOT_TURN_LIMIT)
+  return withReadTransaction(db, () => {
+    const sessionRow = readSessionRow(db, input.sessionId, sessionColumns)
+    if (!sessionRow) return undefined
+    const info = hydrateSessionInfo(sessionRow)
+    const rows = db.prepare(`
+      SELECT id, session_id, time_created, time_updated, data
+      FROM message
+      WHERE session_id = ?
+      ORDER BY time_created DESC, id DESC
+      LIMIT ?
+    `).all(input.sessionId, limit + 1) as MessageRow[]
+    const pageRows = rows.slice(0, limit).reverse()
+    const messages = hydrateMessages(db, input.sessionId, pageRows)
+    const exported = { info, messages }
+    return makePage(exported, {
+      revision: revisionFromInfo(info),
+      nextCursor: null,
+      hasMoreBefore: rows.length > limit,
+      totalMessages: countMessages(db, input.sessionId),
+    })
+  })
+}
+
+export function readOpencodeTurnPage(
+  db: DatabaseLike,
+  input: { sessionId: string; cursor?: string; limit?: number },
+): OpencodeHistoryExportPage | undefined {
+  const { sessionColumns } = requireHistorySchema(db)
+  const limit = normalizeLimit(input.limit, DEFAULT_SNAPSHOT_TURN_LIMIT)
+  const cursor = input.cursor ? decodeOpencodeCursor(input.cursor) : undefined
+  return withReadTransaction(db, () => {
+    const sessionRow = readSessionRow(db, input.sessionId, sessionColumns)
+    if (!sessionRow) return undefined
+    const info = hydrateSessionInfo(sessionRow)
+    const cursorClause = cursor
+      ? 'AND (time_created > ? OR (time_created = ? AND id > ?))'
+      : ''
+    const cursorParams = cursor ? [cursor.time, cursor.time, cursor.id] : []
+    const rows = db.prepare(`
+      SELECT id, session_id, time_created, time_updated, data
+      FROM message
+      WHERE session_id = ?
+        ${cursorClause}
+      ORDER BY time_created ASC, id ASC
+      LIMIT ?
+    `).all(input.sessionId, ...cursorParams, limit + 1) as MessageRow[]
+    const pageRows = rows.slice(0, limit)
+    const messages = hydrateMessages(db, input.sessionId, pageRows)
+    const lastRow = pageRows.at(-1)
+    const nextCursor = rows.length > limit && lastRow
+      ? encodeOpencodeCursor({ time: numberValue(lastRow.time_created) ?? 0, id: String(lastRow.id) })
+      : null
+    const exported = { info, messages }
+    return makePage(exported, {
+      revision: revisionFromInfo(info),
+      nextCursor,
+      hasMoreBefore: Boolean(cursor),
+      totalMessages: countMessages(db, input.sessionId),
+    })
+  })
+}
+
+export function readOpencodeTurnBody(
+  db: DatabaseLike,
+  input: { sessionId: string; turnId: string },
+): OpencodeHistoryTurnBody | null {
+  const { sessionColumns } = requireHistorySchema(db)
+  return withReadTransaction(db, () => {
+    const sessionRow = readSessionRow(db, input.sessionId, sessionColumns)
+    if (!sessionRow) return null
+    const info = hydrateSessionInfo(sessionRow)
+    const row = db.prepare(`
+      SELECT id, session_id, time_created, time_updated, data
+      FROM message
+      WHERE session_id = ?
+        AND id = ?
+      LIMIT 1
+    `).get(input.sessionId, input.turnId) as MessageRow | undefined
+    if (!row) return null
+    const message = hydrateMessages(db, input.sessionId, [row])[0]
+    return {
+      ...message,
+      message,
+      revision: revisionFromInfo(info),
+    }
+  })
+}
+
+export async function runOpencodeHistoryQuery(
+  input: { dbPath: string; request: OpencodeHistoryReadRequest },
+): Promise<OpencodeHistoryReadResult | undefined> {
+  const { DatabaseSync } = await import('node:sqlite')
+  const db = new DatabaseSync(input.dbPath, { readOnly: true })
+  try {
+    db.exec(`PRAGMA busy_timeout = ${OPENCODE_DB_BUSY_TIMEOUT_MS}`)
+    switch (input.request.type) {
+      case 'session_info': {
+        const sessionInfo = readOpencodeSessionInfo(db, { sessionId: input.request.sessionId })
+        return sessionInfo ? { type: 'session_info', sessionInfo } : undefined
+      }
+      case 'snapshot_page': {
+        const page = readOpencodeSnapshotPage(db, {
+          sessionId: input.request.sessionId,
+          limit: input.request.limit,
+        })
+        return page ? { type: 'snapshot_page', page } : undefined
+      }
+      case 'turn_page': {
+        const page = readOpencodeTurnPage(db, {
+          sessionId: input.request.sessionId,
+          cursor: input.request.query?.cursor,
+          limit: input.request.query?.limit,
+        })
+        return page ? { type: 'turn_page', page } : undefined
+      }
+      case 'turn_body': {
+        const body = readOpencodeTurnBody(db, {
+          sessionId: input.request.sessionId,
+          turnId: input.request.turnId,
+        })
+        return body ? { type: 'turn_body', body } : undefined
+      }
+    }
+  } finally {
+    db.close()
+  }
+}

--- a/server/fresh-agent/adapters/opencode/history-query.ts
+++ b/server/fresh-agent/adapters/opencode/history-query.ts
@@ -407,18 +407,20 @@ export function readOpencodeSessionInfo(
   db: DatabaseLike,
   input: { sessionId: string },
 ): OpencodeSessionInfo | undefined {
-  const sessionColumns = requireColumns(db, 'session', SESSION_REQUIRED_COLUMNS)
-  const row = readSessionRow(db, input.sessionId, sessionColumns)
-  return row ? hydrateSessionInfo(row) : undefined
+  return withReadTransaction(db, () => {
+    const sessionColumns = requireColumns(db, 'session', SESSION_REQUIRED_COLUMNS)
+    const row = readSessionRow(db, input.sessionId, sessionColumns)
+    return row ? hydrateSessionInfo(row) : undefined
+  })
 }
 
 export function readOpencodeSnapshotPage(
   db: DatabaseLike,
   input: { sessionId: string; limit?: number },
 ): OpencodeHistoryExportPage | undefined {
-  const { sessionColumns } = requireHistorySchema(db)
   const limit = normalizeLimit(input.limit, DEFAULT_SNAPSHOT_TURN_LIMIT)
   return withReadTransaction(db, () => {
+    const { sessionColumns } = requireHistorySchema(db)
     const sessionRow = readSessionRow(db, input.sessionId, sessionColumns)
     if (!sessionRow) return undefined
     const info = hydrateSessionInfo(sessionRow)
@@ -445,15 +447,15 @@ export function readOpencodeTurnPage(
   db: DatabaseLike,
   input: { sessionId: string; cursor?: string; limit?: number },
 ): OpencodeHistoryExportPage | undefined {
-  const { sessionColumns } = requireHistorySchema(db)
   const limit = normalizeLimit(input.limit, DEFAULT_SNAPSHOT_TURN_LIMIT)
   const cursor = input.cursor ? decodeOpencodeCursor(input.cursor) : undefined
   return withReadTransaction(db, () => {
+    const { sessionColumns } = requireHistorySchema(db)
     const sessionRow = readSessionRow(db, input.sessionId, sessionColumns)
     if (!sessionRow) return undefined
     const info = hydrateSessionInfo(sessionRow)
     const cursorClause = cursor
-      ? 'AND (time_created > ? OR (time_created = ? AND id > ?))'
+      ? 'AND (time_created < ? OR (time_created = ? AND id < ?))'
       : ''
     const cursorParams = cursor ? [cursor.time, cursor.time, cursor.id] : []
     const rows = db.prepare(`
@@ -461,20 +463,20 @@ export function readOpencodeTurnPage(
       FROM message
       WHERE session_id = ?
         ${cursorClause}
-      ORDER BY time_created ASC, id ASC
+      ORDER BY time_created DESC, id DESC
       LIMIT ?
     `).all(input.sessionId, ...cursorParams, limit + 1) as MessageRow[]
     const pageRows = rows.slice(0, limit)
-    const messages = hydrateMessages(db, input.sessionId, pageRows)
-    const lastRow = pageRows.at(-1)
-    const nextCursor = rows.length > limit && lastRow
-      ? encodeOpencodeCursor({ time: numberValue(lastRow.time_created) ?? 0, id: String(lastRow.id) })
+    const messages = hydrateMessages(db, input.sessionId, [...pageRows].reverse())
+    const oldestReturnedRow = pageRows.at(-1)
+    const nextCursor = rows.length > limit && oldestReturnedRow
+      ? encodeOpencodeCursor({ time: numberValue(oldestReturnedRow.time_created) ?? 0, id: String(oldestReturnedRow.id) })
       : null
     const exported = { info, messages }
     return makePage(exported, {
       revision: revisionFromInfo(info),
       nextCursor,
-      hasMoreBefore: Boolean(cursor),
+      hasMoreBefore: rows.length > limit,
       totalMessages: countMessages(db, input.sessionId),
     })
   })
@@ -484,8 +486,8 @@ export function readOpencodeTurnBody(
   db: DatabaseLike,
   input: { sessionId: string; turnId: string },
 ): OpencodeHistoryTurnBody | null {
-  const { sessionColumns } = requireHistorySchema(db)
   return withReadTransaction(db, () => {
+    const { sessionColumns } = requireHistorySchema(db)
     const sessionRow = readSessionRow(db, input.sessionId, sessionColumns)
     if (!sessionRow) return null
     const info = hydrateSessionInfo(sessionRow)

--- a/server/fresh-agent/adapters/opencode/history-runner.ts
+++ b/server/fresh-agent/adapters/opencode/history-runner.ts
@@ -1,0 +1,245 @@
+import { Worker } from 'node:worker_threads'
+import type {
+  OpencodeHistoryPage,
+  OpencodeHistoryReadRequest,
+  OpencodeHistoryReadResult,
+  OpencodeHistoryTurnBody,
+  OpencodeSessionInfo,
+  OpencodeTurnBodyResult,
+} from './history-query.js'
+import { runOpencodeHistoryQuery } from './history-query.js'
+// Importing the worker module on the main thread (or a Vitest worker) is safe:
+// its auto-run is sentinel-guarded, so this import never spawns/posts anything.
+import {
+  OPENCODE_HISTORY_WORKER_KIND,
+  type OpencodeHistoryFailureReason,
+  type OpencodeHistoryWorkerResponse,
+  type SerializedHistoryError,
+} from './history-worker.js'
+
+export type OpencodeHistoryReader = {
+  readSessionInfo(sessionId: string): Promise<OpencodeSessionInfo | undefined>
+  readSnapshotPage(sessionId: string, limit?: number): Promise<OpencodeHistoryPage | undefined>
+  readTurnPage(sessionId: string, query: { cursor?: string; limit?: number }): Promise<OpencodeHistoryPage | undefined>
+  readTurnBody(sessionId: string, turnId: string): Promise<OpencodeTurnBodyResult | undefined>
+}
+
+type WorkerLike = {
+  on(event: 'message', listener: (value: unknown) => void): unknown
+  on(event: 'error', listener: (err: Error) => void): unknown
+  on(event: 'exit', listener: (code: number) => void): unknown
+  terminate(): Promise<number> | void
+}
+
+export type WorkerSpawnOptions = { workerData: unknown; execArgv: string[] }
+
+export type CreateWorkerHistoryReaderOptions = {
+  dbPath: string
+  /** Injectable for unit tests; default spawns a real worker_threads Worker. */
+  spawn?: (workerUrl: URL, options: WorkerSpawnOptions) => WorkerLike
+  /** Override the query-module URL (used by off-thread fixtures). */
+  queryModuleUrl?: string
+  /** Hard timeout for a single history query. Default 15 s. */
+  timeoutMs?: number
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000
+const SELF_EXT = import.meta.url.endsWith('.ts') ? '.ts' : '.js'
+const WORKER_EXECARGV = [...process.execArgv, '--disable-warning=ExperimentalWarning']
+const FAILURE_REASONS = new Set<OpencodeHistoryFailureReason>([
+  'missing_db',
+  'sqlite_unavailable',
+  'schema_mismatch',
+  'not_found',
+  'read_error',
+])
+
+function defaultWorkerUrl(): URL {
+  return new URL(`./history-worker${SELF_EXT}`, import.meta.url)
+}
+
+function defaultQueryModuleUrl(): string {
+  return new URL(`./history-query${SELF_EXT}`, import.meta.url).href
+}
+
+function defaultSpawn(workerUrl: URL, options: WorkerSpawnOptions): WorkerLike {
+  return new Worker(workerUrl, options)
+}
+
+export class OpencodeHistoryReaderError extends Error {
+  readonly reason: OpencodeHistoryFailureReason
+  readonly workerError?: SerializedHistoryError
+
+  constructor(reason: OpencodeHistoryFailureReason, message: string, workerError?: SerializedHistoryError) {
+    super(message)
+    this.name = 'OpencodeHistoryReaderError'
+    this.reason = reason
+    this.workerError = workerError
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isReadResult(value: unknown): value is OpencodeHistoryReadResult {
+  if (!isObject(value) || typeof value.type !== 'string') return false
+  switch (value.type) {
+    case 'session_info':
+      return isObject(value.sessionInfo)
+    case 'snapshot_page':
+    case 'turn_page':
+      return isObject(value.page)
+    case 'turn_body':
+      return isObject(value.body)
+    default:
+      return false
+  }
+}
+
+function isSerializedError(value: unknown): value is SerializedHistoryError {
+  return isObject(value)
+    && typeof value.name === 'string'
+    && typeof value.message === 'string'
+}
+
+function isOkMessage(value: unknown): value is Extract<OpencodeHistoryWorkerResponse, { ok: true }> {
+  return isObject(value)
+    && value.ok === true
+    && isReadResult(value.result)
+}
+
+function isErrMessage(value: unknown): value is Extract<OpencodeHistoryWorkerResponse, { ok: false }> {
+  return isObject(value)
+    && value.ok === false
+    && typeof value.reason === 'string'
+    && FAILURE_REASONS.has(value.reason as OpencodeHistoryFailureReason)
+    && (value.error === undefined || isSerializedError(value.error))
+}
+
+function resultForType<T extends OpencodeHistoryReadResult['type']>(
+  result: OpencodeHistoryReadResult | undefined,
+  type: T,
+): Extract<OpencodeHistoryReadResult, { type: T }> | undefined {
+  if (!result) return undefined
+  if (result.type !== type) {
+    throw new Error(`OpenCode history worker returned ${result.type} for ${type} request`)
+  }
+  return result as Extract<OpencodeHistoryReadResult, { type: T }>
+}
+
+export function createWorkerHistoryReader(
+  options: CreateWorkerHistoryReaderOptions,
+): OpencodeHistoryReader {
+  const spawn = options.spawn ?? defaultSpawn
+  const queryModuleUrl = options.queryModuleUrl ?? defaultQueryModuleUrl()
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const workerUrl = defaultWorkerUrl()
+  const dbPath = options.dbPath
+
+  function run(request: OpencodeHistoryReadRequest): Promise<OpencodeHistoryReadResult | undefined> {
+    return new Promise<OpencodeHistoryReadResult | undefined>((resolve, reject) => {
+      const worker = spawn(workerUrl, {
+        workerData: {
+          kind: OPENCODE_HISTORY_WORKER_KIND,
+          queryModuleUrl,
+          dbPath,
+          request,
+        },
+        execArgv: WORKER_EXECARGV,
+      })
+      let settled = false
+      let timer: NodeJS.Timeout | undefined
+
+      const cleanup = () => {
+        if (timer) clearTimeout(timer)
+        try { void worker.terminate() } catch { /* ignore */ }
+      }
+      const settleResolve = (result: OpencodeHistoryReadResult | undefined) => {
+        if (settled) return
+        settled = true
+        cleanup()
+        resolve(result)
+      }
+      const settleReject = (error: Error) => {
+        if (settled) return
+        settled = true
+        cleanup()
+        reject(error)
+      }
+
+      timer = setTimeout(
+        () => settleReject(new OpencodeHistoryReaderError(
+          'read_error',
+          `OpenCode history worker timed out after ${timeoutMs}ms`,
+        )),
+        timeoutMs,
+      )
+      if (typeof timer.unref === 'function') timer.unref()
+
+      worker.on('message', (value: unknown) => {
+        if (isOkMessage(value)) {
+          settleResolve(value.result)
+          return
+        }
+        if (isErrMessage(value)) {
+          if (value.reason === 'not_found') {
+            settleResolve(undefined)
+            return
+          }
+          settleReject(new OpencodeHistoryReaderError(
+            value.reason,
+            value.error?.message || `OpenCode history worker failed: ${value.reason}`,
+            value.error,
+          ))
+          return
+        }
+        settleReject(new Error('OpenCode history worker sent a malformed message'))
+      })
+      worker.on('error', (err: Error) => settleReject(err))
+      worker.on('exit', (code: number) => settleReject(new Error(`OpenCode history worker exited (code ${code}) before responding`)))
+    })
+  }
+
+  return {
+    async readSessionInfo(sessionId) {
+      return resultForType(await run({ type: 'session_info', sessionId }), 'session_info')?.sessionInfo
+    },
+    async readSnapshotPage(sessionId, limit) {
+      return resultForType(await run({ type: 'snapshot_page', sessionId, limit }), 'snapshot_page')?.page
+    },
+    async readTurnPage(sessionId, query) {
+      return resultForType(await run({ type: 'turn_page', sessionId, query }), 'turn_page')?.page
+    },
+    async readTurnBody(sessionId, turnId) {
+      return resultForType(await run({ type: 'turn_body', sessionId, turnId }), 'turn_body')?.body
+    },
+  }
+}
+
+export const createWorkerOpencodeHistoryReader = createWorkerHistoryReader
+
+/** Runs history queries on the caller's thread. Intended for tests and fallbacks. */
+export function createInProcessHistoryReader(options: { dbPath: string }): OpencodeHistoryReader {
+  async function run(request: OpencodeHistoryReadRequest): Promise<OpencodeHistoryReadResult | undefined> {
+    return runOpencodeHistoryQuery({ dbPath: options.dbPath, request })
+  }
+
+  return {
+    async readSessionInfo(sessionId) {
+      return resultForType(await run({ type: 'session_info', sessionId }), 'session_info')?.sessionInfo
+    },
+    async readSnapshotPage(sessionId, limit) {
+      return resultForType(await run({ type: 'snapshot_page', sessionId, limit }), 'snapshot_page')?.page
+    },
+    async readTurnPage(sessionId, query) {
+      return resultForType(await run({ type: 'turn_page', sessionId, query }), 'turn_page')?.page
+    },
+    async readTurnBody(sessionId, turnId) {
+      const body = resultForType(await run({ type: 'turn_body', sessionId, turnId }), 'turn_body')?.body
+      return body ? { message: body.message, revision: body.revision } as OpencodeTurnBodyResult & OpencodeHistoryTurnBody : undefined
+    },
+  }
+}
+
+export const createInProcessOpencodeHistoryReader = createInProcessHistoryReader

--- a/server/fresh-agent/adapters/opencode/history-worker.ts
+++ b/server/fresh-agent/adapters/opencode/history-worker.ts
@@ -1,0 +1,125 @@
+import fsp from 'node:fs/promises'
+import { parentPort, workerData } from 'node:worker_threads'
+import type {
+  OpencodeHistoryReadRequest,
+  OpencodeHistoryReadResult,
+  OpencodeHistorySchemaError,
+} from './history-query.js'
+
+export const OPENCODE_HISTORY_WORKER_KIND = 'opencode-history-worker'
+
+export type OpencodeHistoryFailureReason =
+  | 'missing_db'
+  | 'sqlite_unavailable'
+  | 'schema_mismatch'
+  | 'not_found'
+  | 'read_error'
+
+export type WorkerHistoryInput = {
+  kind: typeof OPENCODE_HISTORY_WORKER_KIND
+  queryModuleUrl: string
+  dbPath: string
+  request: OpencodeHistoryReadRequest
+}
+
+export type SerializedHistoryError = {
+  name: string
+  message: string
+  code?: string
+  table?: string
+  missingColumns?: string[]
+}
+
+export type OpencodeHistoryWorkerResponse =
+  | { ok: true; result: OpencodeHistoryReadResult }
+  | { ok: false; reason: OpencodeHistoryFailureReason; error?: SerializedHistoryError }
+
+function serializeError(error: unknown): SerializedHistoryError {
+  if (!(error instanceof Error)) {
+    return { name: 'Error', message: String(error) }
+  }
+  const details = error as Partial<OpencodeHistorySchemaError> & { code?: unknown }
+  return {
+    name: error.name,
+    message: error.message,
+    ...(typeof details.code === 'string' ? { code: details.code } : {}),
+    ...(typeof details.table === 'string' ? { table: details.table } : {}),
+    ...(Array.isArray(details.missingColumns) ? { missingColumns: details.missingColumns } : {}),
+  }
+}
+
+function isSqliteUnavailableError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const code = (error as { code?: unknown }).code
+  return code === 'ERR_UNKNOWN_BUILTIN_MODULE'
+    || error.message.includes('node:sqlite')
+    || error.message.includes('No such built-in module')
+}
+
+function classifyError(error: unknown): OpencodeHistoryFailureReason {
+  if (isSqliteUnavailableError(error)) return 'sqlite_unavailable'
+  if (
+    error instanceof Error
+    && (
+      error.name === 'OpencodeHistorySchemaError'
+      || (error as { code?: unknown }).code === 'OPENCODE_HISTORY_SCHEMA_ERROR'
+    )
+  ) {
+    return 'schema_mismatch'
+  }
+  return 'read_error'
+}
+
+async function databaseExists(dbPath: string): Promise<boolean> {
+  try {
+    await fsp.access(dbPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Run the selected history query by dynamically importing the exact resolved
+ * query-module URL (.ts in dev/test, .js in prod) supplied by the spawning code.
+ */
+export async function executeHistory(input: {
+  queryModuleUrl: string
+  dbPath: string
+  request: OpencodeHistoryReadRequest
+}): Promise<OpencodeHistoryWorkerResponse> {
+  if (!await databaseExists(input.dbPath)) {
+    return { ok: false, reason: 'missing_db' }
+  }
+
+  try {
+    const mod = await import(input.queryModuleUrl) as typeof import('./history-query.js')
+    const result = await mod.runOpencodeHistoryQuery({
+      dbPath: input.dbPath,
+      request: input.request,
+    })
+    if (!result) return { ok: false, reason: 'not_found' }
+    return { ok: true, result }
+  } catch (error) {
+    return {
+      ok: false,
+      reason: classifyError(error),
+      error: serializeError(error),
+    }
+  }
+}
+
+// Auto-run ONLY when spawned by our runner. Vitest server tests run inside worker
+// threads, so importing this module must not post to Vitest's parent port.
+if (parentPort && (workerData as Partial<WorkerHistoryInput> | undefined)?.kind === OPENCODE_HISTORY_WORKER_KIND) {
+  const port = parentPort
+  executeHistory(workerData as WorkerHistoryInput)
+    .then((response) => port.postMessage(response))
+    .catch((error: unknown) => {
+      port.postMessage({
+        ok: false,
+        reason: classifyError(error),
+        error: serializeError(error),
+      } satisfies OpencodeHistoryWorkerResponse)
+    })
+}

--- a/server/fresh-agent/adapters/opencode/normalize.ts
+++ b/server/fresh-agent/adapters/opencode/normalize.ts
@@ -15,6 +15,11 @@ export type OpencodeExport = {
 }
 
 const STRUCTURAL_PART_TYPES = new Set(['step-start', 'step-finish'])
+const VISIBLE_PART_TYPES = new Set(['text', 'reasoning', 'tool', 'file', 'patch', 'compaction'])
+
+type OpencodeExportWithPageMetadata = OpencodeExport & {
+  nextCursor?: string | null
+}
 
 function modelFromInfo(info: Record<string, any> | undefined): string | undefined {
   const providerId = info?.providerID ?? info?.model?.providerID
@@ -64,7 +69,11 @@ function normalizePatchChange(value: unknown): Record<string, unknown> | undefin
 }
 
 function normalizePatchChanges(files: unknown): Record<string, unknown>[] {
-  const values = Array.isArray(files) ? files : [files]
+  const values = Array.isArray(files)
+    ? files
+    : (typeof files === 'string' || (files && typeof files === 'object' && !Array.isArray(files)))
+        ? [files]
+        : []
   return values
     .map((value) => normalizePatchChange(value))
     .filter((value): value is Record<string, unknown> => Boolean(value))
@@ -113,6 +122,10 @@ function itemFromPart(part: Record<string, any>, fallbackId: string): FreshAgent
 function collectOpencodePartMetadata(messages: NonNullable<OpencodeExport['messages']>): Record<string, unknown> {
   const structuralPartTypes: Array<{ type: string; id?: string; messageId?: string }> = []
   const unsupportedPartTypes: Array<{ type: string; id?: string; messageId?: string }> = []
+  const structuralParts: Array<{ messageId?: string; part: Record<string, any> }> = []
+  const unsupportedParts: Array<{ messageId?: string; part: Record<string, any> }> = []
+  const fileParts: Array<{ messageId?: string; part: Record<string, any> }> = []
+  const compactionParts: Array<{ messageId?: string; part: Record<string, any> }> = []
   const structuralPartCounts: Record<string, number> = {}
 
   messages.forEach((message) => {
@@ -126,20 +139,36 @@ function collectOpencodePartMetadata(messages: NonNullable<OpencodeExport['messa
         ...(typeof part.id === 'string' ? { id: part.id } : {}),
         ...(messageId ? { messageId } : {}),
       }
+      const rawEntry = {
+        ...(messageId ? { messageId } : {}),
+        part,
+      }
       if (STRUCTURAL_PART_TYPES.has(type)) {
         structuralPartTypes.push(entry)
+        structuralParts.push(rawEntry)
         structuralPartCounts[type] = (structuralPartCounts[type] ?? 0) + 1
         return
       }
-      if (!['text', 'reasoning', 'tool', 'file', 'patch', 'compaction'].includes(type)) {
+      if (type === 'file') {
+        fileParts.push(rawEntry)
+        return
+      }
+      if (type === 'compaction') {
+        compactionParts.push(rawEntry)
+        return
+      }
+      if (!VISIBLE_PART_TYPES.has(type)) {
         unsupportedPartTypes.push(entry)
+        unsupportedParts.push(rawEntry)
       }
     })
   })
 
   return {
-    ...(structuralPartTypes.length > 0 ? { structuralPartTypes, structuralPartCounts } : {}),
-    ...(unsupportedPartTypes.length > 0 ? { unsupportedPartTypes } : {}),
+    ...(structuralPartTypes.length > 0 ? { structuralPartTypes, structuralPartCounts, structuralParts } : {}),
+    ...(unsupportedPartTypes.length > 0 ? { unsupportedPartTypes, unsupportedParts } : {}),
+    ...(fileParts.length > 0 ? { fileParts } : {}),
+    ...(compactionParts.length > 0 ? { compactionParts } : {}),
   }
 }
 
@@ -216,11 +245,14 @@ export function normalizeOpencodeSnapshot(input: {
 
 export function normalizeOpencodeTurnPage(input: {
   threadId: string
-  exported?: OpencodeExport
+  exported?: OpencodeExportWithPageMetadata
   revision: number
+  nextCursor?: string | null
 }): FreshAgentTurnPage {
   const messages = Array.isArray(input.exported?.messages) ? input.exported.messages : []
-  const nextCursor = (input.exported as { nextCursor?: unknown } | undefined)?.nextCursor
+  const nextCursor = Object.prototype.hasOwnProperty.call(input, 'nextCursor')
+    ? input.nextCursor
+    : input.exported?.nextCursor
   return {
     sessionType: 'freshopencode',
     provider: 'opencode',

--- a/server/fresh-agent/adapters/opencode/normalize.ts
+++ b/server/fresh-agent/adapters/opencode/normalize.ts
@@ -6,13 +6,15 @@ import type {
   FreshAgentTurnPage,
 } from '../../../../shared/fresh-agent-contract.js'
 
-type OpencodeExport = {
+export type OpencodeExport = {
   info?: Record<string, any>
   messages?: Array<{
     info?: Record<string, any>
     parts?: Array<Record<string, any>>
   }>
 }
+
+const STRUCTURAL_PART_TYPES = new Set(['step-start', 'step-finish'])
 
 function modelFromInfo(info: Record<string, any> | undefined): string | undefined {
   const providerId = info?.providerID ?? info?.model?.providerID
@@ -38,6 +40,36 @@ function tokenUsage(info: Record<string, any> | undefined): FreshAgentSnapshot['
   }
 }
 
+function fileAttachmentTarget(part: Record<string, any>): string {
+  for (const key of ['filename', 'name', 'url', 'path']) {
+    if (typeof part[key] === 'string' && part[key].trim().length > 0) return part[key].trim()
+  }
+  return 'unknown file'
+}
+
+function normalizePatchChange(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value === 'string' && value.length > 0) return { path: value }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+  const record = value as Record<string, unknown>
+  const change: Record<string, unknown> = { ...record }
+  if (typeof change.path !== 'string') {
+    const path = typeof record.file === 'string'
+      ? record.file
+      : typeof record.name === 'string'
+        ? record.name
+        : undefined
+    if (path) change.path = path
+  }
+  return change
+}
+
+function normalizePatchChanges(files: unknown): Record<string, unknown>[] {
+  const values = Array.isArray(files) ? files : [files]
+  return values
+    .map((value) => normalizePatchChange(value))
+    .filter((value): value is Record<string, unknown> => Boolean(value))
+}
+
 function itemFromPart(part: Record<string, any>, fallbackId: string): FreshAgentTranscriptItem | undefined {
   const id = typeof part.id === 'string' && part.id.length > 0 ? part.id : fallbackId
   if (part.type === 'text') {
@@ -60,7 +92,55 @@ function itemFromPart(part: Record<string, any>, fallbackId: string): FreshAgent
       success: state.status === 'completed' ? true : undefined,
     }
   }
+  if (part.type === 'file') {
+    return { id, kind: 'text', text: `Attached file: ${fileAttachmentTarget(part)}` }
+  }
+  if (part.type === 'patch') {
+    return {
+      id,
+      kind: 'file_change',
+      status: 'completed',
+      changes: normalizePatchChanges(part.files),
+      extensions: { opencode: part },
+    }
+  }
+  if (part.type === 'compaction') {
+    return { id, kind: 'context_compaction' }
+  }
   return undefined
+}
+
+function collectOpencodePartMetadata(messages: NonNullable<OpencodeExport['messages']>): Record<string, unknown> {
+  const structuralPartTypes: Array<{ type: string; id?: string; messageId?: string }> = []
+  const unsupportedPartTypes: Array<{ type: string; id?: string; messageId?: string }> = []
+  const structuralPartCounts: Record<string, number> = {}
+
+  messages.forEach((message) => {
+    const messageId = typeof message.info?.id === 'string' ? message.info.id : undefined
+    const parts = Array.isArray(message.parts) ? message.parts : []
+    parts.forEach((part) => {
+      const type = typeof part.type === 'string' ? part.type : undefined
+      if (!type) return
+      const entry = {
+        type,
+        ...(typeof part.id === 'string' ? { id: part.id } : {}),
+        ...(messageId ? { messageId } : {}),
+      }
+      if (STRUCTURAL_PART_TYPES.has(type)) {
+        structuralPartTypes.push(entry)
+        structuralPartCounts[type] = (structuralPartCounts[type] ?? 0) + 1
+        return
+      }
+      if (!['text', 'reasoning', 'tool', 'file', 'patch', 'compaction'].includes(type)) {
+        unsupportedPartTypes.push(entry)
+      }
+    })
+  })
+
+  return {
+    ...(structuralPartTypes.length > 0 ? { structuralPartTypes, structuralPartCounts } : {}),
+    ...(unsupportedPartTypes.length > 0 ? { unsupportedPartTypes } : {}),
+  }
 }
 
 export function normalizeOpencodeTurn(message: NonNullable<OpencodeExport['messages']>[number], ordinal: number): FreshAgentTurn {
@@ -99,6 +179,7 @@ export function normalizeOpencodeSnapshot(input: {
   const turns = messages.map((message, index) => normalizeOpencodeTurn(message, index))
   const sessionModel = modelFromInfo(info) ?? input.model
   const durableSessionId = typeof info.id === 'string' && info.id.length > 0 ? info.id : input.threadId
+  const opencodeExtensions = collectOpencodePartMetadata(messages)
   return {
     sessionType: input.sessionType,
     provider: 'opencode',
@@ -129,7 +210,7 @@ export function normalizeOpencodeSnapshot(input: {
     diffs: [],
     childThreads: [],
     turns,
-    extensions: { opencode: {} },
+    extensions: { opencode: opencodeExtensions },
   }
 }
 
@@ -139,12 +220,13 @@ export function normalizeOpencodeTurnPage(input: {
   revision: number
 }): FreshAgentTurnPage {
   const messages = Array.isArray(input.exported?.messages) ? input.exported.messages : []
+  const nextCursor = (input.exported as { nextCursor?: unknown } | undefined)?.nextCursor
   return {
     sessionType: 'freshopencode',
     provider: 'opencode',
     threadId: input.threadId,
     revision: input.revision,
-    nextCursor: null,
+    nextCursor: typeof nextCursor === 'string' ? nextCursor : null,
     turns: messages.map((message, index) => normalizeOpencodeTurn(message, index)),
   }
 }

--- a/server/fresh-agent/runtime-adapter.ts
+++ b/server/fresh-agent/runtime-adapter.ts
@@ -23,6 +23,11 @@ export type FreshAgentCreateResult = {
   sessionRef?: { provider: string; sessionId: string }
 }
 
+export type FreshAgentSendResult = void | {
+  sessionId?: string
+  sessionRef?: { provider: string; sessionId: string }
+}
+
 export type FreshAgentThreadLocator = {
   sessionType: FreshAgentSessionType
   provider: FreshAgentRuntimeProvider
@@ -46,7 +51,7 @@ export interface FreshAgentRuntimeAdapter {
   resume?(input: FreshAgentCreateRequest): Promise<{ sessionId: string; sessionRef?: { provider: string; sessionId: string } }>
   attach?(locator: FreshAgentSessionLocator): Promise<{ sessionId: string; sessionRef?: { provider: string; sessionId: string } }> | { sessionId: string; sessionRef?: { provider: string; sessionId: string } }
   subscribe?(sessionId: string, listener: (message: unknown) => void): Promise<() => void> | (() => void)
-  send?(sessionId: string, input: { text: string; images?: FreshAgentInputImage[]; settings?: FreshAgentCreateRequest }): Promise<void> | void
+  send?(sessionId: string, input: { text: string; images?: FreshAgentInputImage[]; settings?: FreshAgentCreateRequest }): Promise<FreshAgentSendResult> | FreshAgentSendResult
   interrupt?(sessionId: string): Promise<void> | void
   compact?(sessionId: string, input?: { instructions?: string }): Promise<void> | void
   kill?(sessionId: string): Promise<boolean> | boolean

--- a/server/fresh-agent/runtime-manager.ts
+++ b/server/fresh-agent/runtime-manager.ts
@@ -15,6 +15,7 @@ import type {
   FreshAgentCreateResult,
   FreshAgentInputImage,
   FreshAgentRuntimeAdapter,
+  FreshAgentSendResult,
   FreshAgentSessionLocator,
 } from './runtime-adapter.js'
 
@@ -143,12 +144,23 @@ export class FreshAgentRuntimeManager {
     return await record.adapter.subscribe(locator.sessionId, listener)
   }
 
-  async send(locator: FreshAgentSessionLocator, input: { text: string; images?: FreshAgentInputImage[]; settings?: FreshAgentCreateRequest }) {
+  async send(
+    locator: FreshAgentSessionLocator,
+    input: { text: string; images?: FreshAgentInputImage[]; settings?: FreshAgentCreateRequest },
+  ): Promise<FreshAgentSendResult> {
     const record = this.requireSession(locator)
     if (!record.adapter.send) {
       throw new FreshAgentUnsupportedCapabilityError(`Send is not supported for ${record.sessionType}`)
     }
-    await record.adapter.send(locator.sessionId, input)
+    const result = await record.adapter.send(locator.sessionId, input)
+    if (result?.sessionId && result.sessionId !== locator.sessionId) {
+      this.sessions.set(this.key({
+        sessionType: locator.sessionType,
+        provider: record.runtimeProvider,
+        sessionId: result.sessionId,
+      }), record)
+    }
+    return result
   }
 
   async interrupt(locator: FreshAgentSessionLocator) {

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -3674,6 +3674,11 @@ export class WsHandler {
         try {
           const result = await manager.send(locator, { text: m.text, images: m.images, settings: m.settings })
           if (result?.sessionId && result.sessionId !== m.sessionId) {
+            this.ensureFreshAgentSubscription(ws, state, {
+              sessionId: result.sessionId,
+              sessionType: m.sessionType,
+              provider: m.provider,
+            })
             this.send(ws, {
               type: 'freshAgent.session.materialized',
               previousSessionId: m.sessionId,

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -124,13 +124,18 @@ type FreshAgentRuntimeManagerLike = {
   create: (input: any) => Promise<any>
   attach: (input: any) => any
   subscribe?: (locator: any, listener: (message: unknown) => void) => Promise<() => void> | (() => void)
-  send?: (locator: any, input: any) => Promise<void> | void
+  send?: (locator: any, input: any) => Promise<FreshAgentSendResult> | FreshAgentSendResult
   interrupt?: (locator: any) => Promise<void> | void
   compact?: (locator: any, input?: { instructions?: string }) => Promise<void> | void
   resolveApproval?: (locator: any, requestId: string | number, decision: Record<string, unknown>) => Promise<void> | void
   answerQuestion?: (locator: any, requestId: string | number, answers: Record<string, string>) => Promise<void> | void
   kill?: (locator: any) => Promise<boolean> | boolean
   fork?: (locator: any, input?: Record<string, unknown>) => Promise<unknown> | unknown
+}
+
+type FreshAgentSendResult = void | {
+  sessionId?: string
+  sessionRef?: { provider: string; sessionId: string }
 }
 
 type FreshAgentLocator = {
@@ -3667,7 +3672,17 @@ export class WsHandler {
         }
         const locator = { sessionId: m.sessionId, sessionType: m.sessionType, provider: m.provider }
         try {
-          await manager.send(locator, { text: m.text, images: m.images, settings: m.settings })
+          const result = await manager.send(locator, { text: m.text, images: m.images, settings: m.settings })
+          if (result?.sessionId && result.sessionId !== m.sessionId) {
+            this.send(ws, {
+              type: 'freshAgent.session.materialized',
+              previousSessionId: m.sessionId,
+              sessionId: result.sessionId,
+              sessionType: m.sessionType,
+              provider: m.provider,
+              sessionRef: result.sessionRef ?? { provider: m.provider, sessionId: result.sessionId },
+            })
+          }
         } catch (error) {
           this.sendError(ws, { code: 'INTERNAL_ERROR', message: errorMessage(error) })
         }

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -937,6 +937,7 @@ export type FreshAgentServerMessage =
   | { type: 'freshAgent.created'; requestId: string; sessionId: string; sessionType: string; provider: string; runtimeProvider: string; sessionRef?: { provider: string; sessionId: string } }
   | { type: 'freshAgent.create.failed'; requestId: string; code: string; message: string; retryable?: boolean }
   | { type: 'freshAgent.event'; sessionId: string; sessionType: string; provider: string; event: unknown }
+  | { type: 'freshAgent.session.materialized'; previousSessionId: string; sessionId: string; sessionType: string; provider: string; sessionRef?: { provider: string; sessionId: string } }
   | { type: 'freshAgent.forked'; requestId?: string; parentSessionId: string; sessionId: string; sessionType: string; provider: string; runtimeProvider: string; sessionRef?: { provider: string; sessionId: string } }
   | { type: 'freshAgent.killed'; sessionId: string; sessionType: string; provider: string; success: boolean }
 

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -127,6 +127,16 @@ function isUnmaterializedCodexThreadError(error: unknown): boolean {
     && (error as { message: string }).message.includes('no rollout found for thread id')
 }
 
+function isLostFreshOpencodeThreadError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const status = 'status' in error ? (error as { status?: unknown }).status : undefined
+  const details = 'details' in error ? (error as { details?: unknown }).details : undefined
+  const code = details && typeof details === 'object' && 'code' in details
+    ? (details as { code?: unknown }).code
+    : undefined
+  return status === 404 && code === 'FRESH_AGENT_LOST_SESSION'
+}
+
 function getRestoreErrorMessage(reason: RestoreErrorReason): string {
   switch (reason) {
     case 'invalid_legacy_restore_target':
@@ -655,6 +665,27 @@ export function FreshAgentView({
         }))
       }
       if (
+        message.type === 'freshAgent.session.materialized'
+        && message.previousSessionId === paneContentRef.current.sessionId
+        && message.sessionType === paneContentRef.current.sessionType
+        && message.provider === paneContentRef.current.provider
+      ) {
+        const current = paneContentRef.current
+        const sessionRef = message.sessionRef ?? { provider: message.provider, sessionId: message.sessionId }
+        setSnapshotRefreshNonce((value) => value + 1)
+        dispatch(updatePaneContent({
+          tabId,
+          paneId,
+          content: {
+            ...current,
+            sessionId: message.sessionId,
+            sessionRef,
+            resumeSessionId: message.sessionId,
+            restoreError: undefined,
+          },
+        }))
+      }
+      if (
         message.type === 'freshAgent.event'
         && message.sessionId === paneContent.sessionId
         && message.sessionType === paneContent.sessionType
@@ -795,6 +826,26 @@ export function FreshAgentView({
               ...fresh,
               sessionId: undefined,
               sessionRef: undefined,
+              createRequestId: nanoid(),
+              status: 'idle',
+              createError: undefined,
+              restoreError: buildRestoreError('durable_artifact_missing'),
+            },
+          }))
+          return
+        }
+        if (paneContent.provider === 'opencode' && isLostFreshOpencodeThreadError(error)) {
+          const fresh = paneContentRef.current
+          setLoadError(null)
+          setSnapshot(null)
+          dispatch(updatePaneContent({
+            tabId,
+            paneId,
+            content: {
+              ...fresh,
+              sessionId: undefined,
+              sessionRef: undefined,
+              resumeSessionId: undefined,
               createRequestId: nanoid(),
               status: 'idle',
               createError: undefined,

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -278,6 +278,7 @@ export function FreshAgentView({
   const autoTitleCreateRequestIdRef = useRef(paneContent.createRequestId)
   const autoTitleDurableIdentityRef = useRef<string | null>(null)
   const autoTitleIdentityRef = useRef<string | null>(null)
+  const pendingAutoTitleBySessionIdRef = useRef<Map<string, string>>(new Map())
   const handledRefreshRequestIdRef = useRef<string | null>(null)
   const preferredResumeSessionId = getPreferredResumeSessionId(claudeSession) ?? paneContent.resumeSessionId
   const snapshotThreadId = getFreshAgentSnapshotThreadId(paneContent, claudeSession)
@@ -349,6 +350,24 @@ export function FreshAgentView({
     }
     ws.send(message as never)
   }, [paneId, ws])
+
+  const migratePendingAutoTitle = useCallback((
+    previousSessionId: string | undefined,
+    nextSessionId: string | undefined,
+    provider: string,
+  ) => {
+    if (!previousSessionId || !nextSessionId || previousSessionId === nextSessionId) return
+    const firstMessage = pendingAutoTitleBySessionIdRef.current.get(previousSessionId)
+    if (!firstMessage) return
+    pendingAutoTitleBySessionIdRef.current.delete(previousSessionId)
+    dispatch(finalizeCodingAgentSessionName({
+      tabId,
+      paneId,
+      provider,
+      sessionId: nextSessionId,
+      firstMessage,
+    }))
+  }, [dispatch, paneId, tabId])
 
   const prevCreateRequestIdRef = useRef(paneContent.createRequestId)
   if (prevCreateRequestIdRef.current !== paneContent.createRequestId) {
@@ -440,6 +459,7 @@ export function FreshAgentView({
     setQueuedMessages([])
     setLocalEcho(null)
     alwaysAllowToolsRef.current.clear()
+    pendingAutoTitleBySessionIdRef.current.clear()
     dispatch(updatePaneContent({
       tabId,
       paneId,
@@ -672,6 +692,7 @@ export function FreshAgentView({
       ) {
         const current = paneContentRef.current
         const sessionRef = message.sessionRef ?? { provider: message.provider, sessionId: message.sessionId }
+        migratePendingAutoTitle(current.sessionId, message.sessionId, message.provider)
         setSnapshotRefreshNonce((value) => value + 1)
         dispatch(updatePaneContent({
           tabId,
@@ -737,7 +758,7 @@ export function FreshAgentView({
       }
     })
     return unsubscribe
-  }, [dispatch, paneContent, paneContent.createRequestId, paneId, sendFreshAgentMessage, tabId, ws])
+  }, [dispatch, migratePendingAutoTitle, paneContent, paneContent.createRequestId, paneId, sendFreshAgentMessage, tabId, ws])
 
   useEffect(() => {
     if (!snapshotThreadId) return
@@ -784,6 +805,9 @@ export function FreshAgentView({
         const nextSessionId = snapshotSessionRef?.sessionId ?? fresh.sessionId
         const nextSessionRef = snapshotSessionRef ?? fresh.sessionRef
         const nextResumeSessionId = snapshotSessionRef?.sessionId ?? fresh.resumeSessionId ?? sessionId
+        if (snapshotSessionRef) {
+          migratePendingAutoTitle(fresh.sessionId, snapshotSessionRef.sessionId, provider)
+        }
         if (
           nextStatus === fresh.status
           && nextSessionId === fresh.sessionId
@@ -872,6 +896,7 @@ export function FreshAgentView({
     paneContent.sessionType,
     paneId,
     autoTitleIdentity,
+    migratePendingAutoTitle,
     snapshotThreadId,
     snapshotRefreshNonce,
     tabId,
@@ -1009,6 +1034,7 @@ export function FreshAgentView({
     if (isFirstMessage) {
       autoTitleFreshBoundaryRef.current = false
       autoTitleSentRef.current = true
+      pendingAutoTitleBySessionIdRef.current.set(current.sessionId, text)
       dispatch(finalizeCodingAgentSessionName({
         tabId,
         paneId,

--- a/src/lib/fresh-agent-ws.ts
+++ b/src/lib/fresh-agent-ws.ts
@@ -32,7 +32,19 @@ type FreshAgentCreateFailedMessage = {
   retryable?: boolean
 }
 
-type FreshAgentClientMessage = FreshAgentCreatedMessage | FreshAgentCreateFailedMessage
+type FreshAgentSessionMaterializedMessage = {
+  type: 'freshAgent.session.materialized'
+  previousSessionId: string
+  sessionId: string
+  sessionType: FreshAgentSessionType
+  provider: FreshAgentRuntimeProvider
+  sessionRef?: SessionRef
+}
+
+type FreshAgentClientMessage =
+  | FreshAgentCreatedMessage
+  | FreshAgentCreateFailedMessage
+  | FreshAgentSessionMaterializedMessage
 
 interface FreshAgentMessageSink {
   send: (msg: unknown) => void
@@ -99,6 +111,8 @@ export function handleFreshAgentMessage(dispatch: AppDispatch, msg: Record<strin
       }))
       return true
     }
+    case 'freshAgent.session.materialized':
+      return true
     case 'freshAgent.event':
       return handleFreshAgentTransportEvent(dispatch, msg as FreshAgentEventMessage)
     default:
@@ -171,4 +185,10 @@ export function handleFreshAgentTransportEvent(dispatch: AppDispatch, msg: Fresh
   }
 }
 
-export type { FreshAgentClientMessage, FreshAgentCreatedMessage, FreshAgentCreateFailedMessage, FreshAgentEventMessage }
+export type {
+  FreshAgentClientMessage,
+  FreshAgentCreatedMessage,
+  FreshAgentCreateFailedMessage,
+  FreshAgentEventMessage,
+  FreshAgentSessionMaterializedMessage,
+}

--- a/test/e2e-browser/fixtures/fake-opencode.cjs
+++ b/test/e2e-browser/fixtures/fake-opencode.cjs
@@ -10,6 +10,9 @@ function argValue(name) {
   return process.argv[index + 1]
 }
 
+const argv = process.argv.slice(2)
+const command = argv[0]
+
 function appendAudit(payload) {
   const auditPath = process.env.FAKE_OPENCODE_AUDIT_LOG
   if (!auditPath) return
@@ -27,6 +30,325 @@ if (process.argv.includes('--version') || process.argv.includes('version')) {
   process.exit(0)
 }
 
+const dataHome = process.env.XDG_DATA_HOME
+  ? path.join(process.env.XDG_DATA_HOME, 'opencode')
+  : path.join(os.homedir(), '.local', 'share', 'opencode')
+const dbPath = path.join(dataHome, 'opencode.db')
+
+function openDatabase() {
+  fs.mkdirSync(dataHome, { recursive: true })
+  const { DatabaseSync } = require('node:sqlite')
+  const db = new DatabaseSync(dbPath)
+  db.exec('PRAGMA busy_timeout = 5000')
+  return db
+}
+
+function ensureSchema(db) {
+  db.exec(`
+      CREATE TABLE IF NOT EXISTS project (
+        id text PRIMARY KEY,
+        worktree text
+      );
+      CREATE TABLE IF NOT EXISTS session (
+        id text PRIMARY KEY,
+        project_id text NOT NULL,
+        workspace_id text,
+        parent_id text,
+        slug text NOT NULL,
+        directory text NOT NULL,
+        path text,
+        title text NOT NULL,
+        version text NOT NULL,
+        share_url text,
+        summary_additions integer,
+        summary_deletions integer,
+        summary_files integer,
+        summary_diffs text,
+        metadata text,
+        cost real NOT NULL DEFAULT 0,
+        tokens_input integer NOT NULL DEFAULT 0,
+        tokens_output integer NOT NULL DEFAULT 0,
+        tokens_reasoning integer NOT NULL DEFAULT 0,
+        tokens_cache_read integer NOT NULL DEFAULT 0,
+        tokens_cache_write integer NOT NULL DEFAULT 0,
+        revert text,
+        permission text,
+        agent text,
+        model text NOT NULL,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        time_compacting integer,
+        time_archived integer
+      );
+      CREATE TABLE IF NOT EXISTS message (
+        id text PRIMARY KEY,
+        session_id text NOT NULL,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        data text NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS part (
+        id text PRIMARY KEY,
+        message_id text NOT NULL,
+        session_id text NOT NULL,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        data text NOT NULL
+      );
+    `)
+}
+
+function sessionModel() {
+  return JSON.stringify({ providerID: 'opencode', modelID: 'fake-opencode' })
+}
+
+function insertSession(db, input) {
+  db.prepare('INSERT OR REPLACE INTO project (id, worktree) VALUES (?, ?)').run(input.projectId, input.directory)
+  db.prepare(`
+      INSERT OR REPLACE INTO session
+        (
+          id, project_id, workspace_id, parent_id, slug, directory, path, title, version,
+          share_url, summary_additions, summary_deletions, summary_files, summary_diffs,
+          metadata, cost, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read,
+          tokens_cache_write, revert, permission, agent, model, time_created, time_updated,
+          time_compacting, time_archived
+        )
+      VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, NULL, 0, 0, 0, NULL, NULL, 0, 0, 0, 0, 0, 0, NULL, NULL, ?, ?, ?, ?, NULL, NULL)
+    `).run(
+      input.sessionId,
+      input.projectId,
+      input.parentId ?? null,
+      input.slug,
+      input.directory,
+      input.directory,
+      input.title,
+      'fake-opencode-e2e',
+      'fake',
+      sessionModel(),
+      input.createdAt,
+      input.updatedAt,
+    )
+}
+
+function countMessages(db, sessionId) {
+  const row = db.prepare('SELECT COUNT(*) AS count FROM message WHERE session_id = ?').get(sessionId)
+  return Number(row?.count ?? 0)
+}
+
+function insertTextMessage(db, input) {
+  db.prepare(`
+      INSERT OR REPLACE INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(
+      input.messageId,
+      input.sessionId,
+      input.now,
+      input.now,
+      JSON.stringify({ role: input.role }),
+    )
+  db.prepare(`
+      INSERT OR REPLACE INTO part (id, message_id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(
+      input.partId,
+      input.messageId,
+      input.sessionId,
+      input.now,
+      input.now,
+      JSON.stringify({ type: 'text', text: input.text }),
+    )
+}
+
+function serverProjectDirectory() {
+  if (process.env.FAKE_OPENCODE_PROJECT_CWD) return process.env.FAKE_OPENCODE_PROJECT_CWD
+  try {
+    return path.dirname(fs.realpathSync(dataHome))
+  } catch {
+    return process.cwd()
+  }
+}
+
+function seedServerDatabase(rootSessionId, childSessionId) {
+  const now = Date.now()
+  const directory = serverProjectDirectory()
+  const db = openDatabase()
+  try {
+    ensureSchema(db)
+    insertSession(db, {
+      sessionId: rootSessionId,
+      projectId: 'proj-test',
+      parentId: null,
+      slug: rootSessionId,
+      directory,
+      title: `Root ${rootSessionId}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+    insertSession(db, {
+      sessionId: childSessionId,
+      projectId: 'proj-test',
+      parentId: rootSessionId,
+      slug: childSessionId,
+      directory,
+      title: `Child ${childSessionId}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+  } finally {
+    db.close()
+  }
+}
+
+function seedRunDatabase(input) {
+  const db = openDatabase()
+  try {
+    ensureSchema(db)
+    const existing = db.prepare('SELECT time_created FROM session WHERE id = ?').get(input.sessionId)
+    const sequence = countMessages(db, input.sessionId) + 1
+    const userTime = Date.now()
+    const assistantTime = userTime + 1
+    insertSession(db, {
+      sessionId: input.sessionId,
+      projectId: 'proj-run',
+      parentId: null,
+      slug: input.sessionId,
+      directory: process.cwd(),
+      title: `Freshopencode ${input.sessionId}`,
+      createdAt: Number(existing?.time_created ?? userTime),
+      updatedAt: assistantTime,
+    })
+    const userMessageId = `${input.sessionId}_msg_${sequence}_user`
+    const assistantMessageId = `${input.sessionId}_msg_${sequence + 1}_assistant`
+    insertTextMessage(db, {
+      sessionId: input.sessionId,
+      messageId: userMessageId,
+      partId: `${userMessageId}_part_text`,
+      role: 'user',
+      text: input.prompt,
+      now: userTime,
+    })
+    insertTextMessage(db, {
+      sessionId: input.sessionId,
+      messageId: assistantMessageId,
+      partId: `${assistantMessageId}_part_text`,
+      role: 'assistant',
+      text: input.responseText,
+      now: assistantTime,
+    })
+    return { userMessageId, assistantMessageId, assistantPartId: `${assistantMessageId}_part_text`, assistantTime }
+  } finally {
+    db.close()
+  }
+}
+
+function parseJsonText(value) {
+  if (typeof value !== 'string' || value.length === 0) return undefined
+  return JSON.parse(value)
+}
+
+function readExport(sessionId) {
+  const db = openDatabase()
+  try {
+    ensureSchema(db)
+    const infoRow = db.prepare('SELECT * FROM session WHERE id = ?').get(sessionId)
+    if (!infoRow) return { info: { id: sessionId }, messages: [] }
+    const messageRows = db.prepare(`
+      SELECT id, session_id, time_created, time_updated, data
+      FROM message
+      WHERE session_id = ?
+      ORDER BY time_created ASC, id ASC
+    `).all(sessionId)
+    const messages = messageRows.map((message) => {
+      const partRows = db.prepare(`
+        SELECT id, message_id, session_id, time_created, time_updated, data
+        FROM part
+        WHERE session_id = ? AND message_id = ?
+        ORDER BY id ASC
+      `).all(sessionId, message.id)
+      return {
+        info: {
+          ...(parseJsonText(message.data) ?? {}),
+          id: message.id,
+          sessionID: message.session_id,
+          time: { created: message.time_created, updated: message.time_updated },
+        },
+        parts: partRows.map((part) => ({
+          ...(parseJsonText(part.data) ?? {}),
+          id: part.id,
+          sessionID: part.session_id,
+          messageID: part.message_id,
+          time: { created: part.time_created, updated: part.time_updated },
+        })),
+      }
+    })
+    return {
+      info: {
+        id: infoRow.id,
+        directory: infoRow.directory,
+        title: infoRow.title,
+        model: parseJsonText(infoRow.model),
+        tokens: {
+          input: infoRow.tokens_input,
+          output: infoRow.tokens_output,
+          reasoning: infoRow.tokens_reasoning,
+          cache: { read: infoRow.tokens_cache_read, write: infoRow.tokens_cache_write },
+        },
+        time: { created: infoRow.time_created, updated: infoRow.time_updated },
+      },
+      messages,
+    }
+  } finally {
+    db.close()
+  }
+}
+
+if (command === 'run') {
+  const sessionId = argValue('--session') || `ses_run_${Date.now()}_${process.pid}`
+  const prompt = typeof argv[1] === 'string' && !argv[1].startsWith('-') ? argv[1] : ''
+  const responseText = process.env.FAKE_OPENCODE_RESPONSE_TEXT || `Fake OpenCode response: ${prompt}`
+  const seeded = seedRunDatabase({ sessionId, prompt, responseText })
+  const omitRunSessionId = process.env.FAKE_OPENCODE_RUN_NO_SESSION_ID === '1'
+  appendAudit({
+    event: 'run',
+    sessionId,
+    prompt,
+    omitRunSessionId,
+    dbPath,
+  })
+  if (!omitRunSessionId) {
+    process.stdout.write(JSON.stringify({
+      type: 'text',
+      timestamp: seeded.assistantTime,
+      sessionID: sessionId,
+      part: {
+        id: seeded.assistantPartId,
+        sessionID: sessionId,
+        messageID: seeded.assistantMessageId,
+        type: 'text',
+        text: responseText,
+      },
+    }) + '\n')
+  } else {
+    process.stdout.write(JSON.stringify({
+      type: 'text',
+      timestamp: seeded.assistantTime,
+      part: { type: 'text', text: responseText },
+    }) + '\n')
+  }
+  process.exit(0)
+}
+
+if (command === 'export') {
+  const sessionId = argv[1]
+  appendAudit({ event: 'export', sessionId, dbPath })
+  if (process.env.FAKE_OPENCODE_TRUNCATE_EXPORT === '1') {
+    process.stdout.write(`Exporting session: ${sessionId}\n{"info":`)
+    process.exit(0)
+  }
+  process.stdout.write(`Exporting session: ${sessionId}\n${JSON.stringify(readExport(sessionId))}\n`)
+  process.exit(0)
+}
+
 const hostname = argValue('--hostname') || '127.0.0.1'
 const port = Number(argValue('--port'))
 const sessionArg = argValue('--session')
@@ -39,51 +361,8 @@ if (!Number.isInteger(port) || port <= 0 || port > 65535) {
 
 const rootSessionId = sessionArg || `ses_root_${port}`
 const childSessionId = `ses_child_${rootSessionId.replace(/[^a-zA-Z0-9_]/g, '_')}`
-const now = Math.floor(Date.now() / 1000)
-const dataHome = process.env.XDG_DATA_HOME
-  ? path.join(process.env.XDG_DATA_HOME, 'opencode')
-  : path.join(os.homedir(), '.local', 'share', 'opencode')
-const dbPath = path.join(dataHome, 'opencode.db')
 
-function seedDatabase() {
-  fs.mkdirSync(dataHome, { recursive: true })
-  const { DatabaseSync } = require('node:sqlite')
-  const db = new DatabaseSync(dbPath)
-  try {
-    db.exec('PRAGMA busy_timeout = 5000')
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS project (
-        id text PRIMARY KEY,
-        worktree text
-      );
-      CREATE TABLE IF NOT EXISTS session (
-        id text PRIMARY KEY,
-        parent_id text,
-        project_id text,
-        directory text,
-        title text,
-        time_created integer,
-        time_updated integer,
-        time_archived integer
-      );
-    `)
-    db.prepare('INSERT OR REPLACE INTO project (id, worktree) VALUES (?, ?)').run('proj-test', process.cwd())
-    db.prepare(`
-      INSERT OR REPLACE INTO session
-        (id, parent_id, project_id, directory, title, time_created, time_updated, time_archived)
-      VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
-    `).run(rootSessionId, null, 'proj-test', process.cwd(), `Root ${rootSessionId}`, now, now)
-    db.prepare(`
-      INSERT OR REPLACE INTO session
-        (id, parent_id, project_id, directory, title, time_created, time_updated, time_archived)
-      VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
-    `).run(childSessionId, rootSessionId, 'proj-test', process.cwd(), `Child ${childSessionId}`, now, now)
-  } finally {
-    db.close()
-  }
-}
-
-seedDatabase()
+seedServerDatabase(rootSessionId, childSessionId)
 
 appendAudit({
   event: 'launch',

--- a/test/e2e-browser/specs/freshopencode-db-history.spec.ts
+++ b/test/e2e-browser/specs/freshopencode-db-history.spec.ts
@@ -1,0 +1,277 @@
+import { expect, test, type Page } from '@playwright/test'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { openPanePicker } from '../helpers/pane-picker.js'
+import { TestHarness } from '../helpers/test-harness.js'
+import { TestServer } from '../helpers/test-server.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const fakeOpencodeSource = path.resolve(__dirname, '../fixtures/fake-opencode.cjs')
+
+type FakeAuditEvent = {
+  event?: string
+  sessionId?: string
+  prompt?: string
+  omitRunSessionId?: boolean
+}
+
+type FreshOpencodePaneState = {
+  sessionId?: string
+  resumeSessionId?: string
+  status?: string
+  sessionRef?: { provider?: string; sessionId?: string }
+}
+
+async function installFakeOpencode(binDir: string): Promise<void> {
+  await fsp.mkdir(binDir, { recursive: true })
+  const target = path.join(binDir, 'opencode')
+  await fsp.copyFile(fakeOpencodeSource, target)
+  await fsp.chmod(target, 0o755)
+}
+
+function createSetupHome(sharedOpencodeDataDir: string) {
+  return async (homeDir: string): Promise<void> => {
+    const xdgShare = path.join(homeDir, '.local', 'share')
+    const opencodeLink = path.join(xdgShare, 'opencode')
+    const freshellDir = path.join(homeDir, '.freshell')
+    await fsp.mkdir(xdgShare, { recursive: true })
+    await fsp.mkdir(freshellDir, { recursive: true })
+    await fsp.mkdir(sharedOpencodeDataDir, { recursive: true })
+    await fsp.rm(opencodeLink, { recursive: true, force: true }).catch(() => {})
+    await fsp.symlink(sharedOpencodeDataDir, opencodeLink, 'dir')
+    await fsp.writeFile(path.join(freshellDir, 'config.json'), JSON.stringify({
+      version: 1,
+      settings: {
+        codingCli: {
+          enabledProviders: ['opencode'],
+          providers: {
+            opencode: {},
+          },
+        },
+        freshAgent: { enabled: true },
+        agentChat: { enabled: true },
+      },
+    }, null, 2))
+  }
+}
+
+function createServerOptions(input: {
+  binDir: string
+  auditLogPath: string
+  logsDir: string
+  sharedOpencodeDataDir: string
+  env?: Record<string, string>
+}) {
+  return {
+    setupHome: createSetupHome(input.sharedOpencodeDataDir),
+    env: {
+      PATH: `${input.binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      FAKE_OPENCODE_AUDIT_LOG: input.auditLogPath,
+      FRESHELL_LOG_DIR: input.logsDir,
+      ...(input.env ?? {}),
+    },
+  }
+}
+
+async function readAuditEvents(auditLogPath: string): Promise<FakeAuditEvent[]> {
+  try {
+    const text = await fsp.readFile(auditLogPath, 'utf8')
+    return text.split('\n').filter(Boolean).map((line) => JSON.parse(line) as FakeAuditEvent)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  }
+}
+
+async function enableFreshOpencode(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const harness = window.__FRESHELL_TEST_HARNESS__
+    harness?.dispatch({
+      type: 'connection/setAvailableClis',
+      payload: { opencode: true },
+    })
+    harness?.dispatch({
+      type: 'settings/previewServerSettingsPatch',
+      payload: {
+        codingCli: { enabledProviders: ['opencode'] },
+        freshAgent: { enabled: true },
+        agentChat: { enabled: true },
+      },
+    })
+  })
+}
+
+async function createFreshopencodePane(page: Page, cwd: string): Promise<void> {
+  const picker = await openPanePicker(page)
+  await picker.getByRole('button', { name: /^Freshopencode$/i }).click({ force: true })
+  const directoryInput = page.getByLabel(/^Starting directory for Freshopencode$/i)
+  await expect(directoryInput).toBeVisible({ timeout: 15_000 })
+  await directoryInput.fill(cwd)
+  await directoryInput.press('Enter')
+  await expect(page.locator('[data-context="fresh-agent"]').last()).toBeVisible({ timeout: 15_000 })
+}
+
+async function getFreshOpencodePaneState(page: Page): Promise<FreshOpencodePaneState> {
+  return page.evaluate(() => {
+    const state = window.__FRESHELL_TEST_HARNESS__?.getState()
+    const activeTabId = state?.tabs?.activeTabId
+    const findFreshOpencode = (node: any): any => {
+      if (!node) return undefined
+      if (node.type === 'leaf' && node.content?.kind === 'fresh-agent' && node.content.provider === 'opencode') {
+        return node.content
+      }
+      if (node.type === 'split') return findFreshOpencode(node.children?.[0]) ?? findFreshOpencode(node.children?.[1])
+      return undefined
+    }
+    return findFreshOpencode(state?.panes?.layouts?.[activeTabId]) ?? {}
+  })
+}
+
+async function sendFreshAgentPrompt(page: Page, prompt: string): Promise<void> {
+  const textbox = page.getByRole('textbox', { name: 'Chat message input' })
+  await expect(textbox).toBeVisible({ timeout: 15_000 })
+  await expect(textbox).not.toBeDisabled({ timeout: 15_000 })
+  await textbox.fill(prompt)
+  await page.getByRole('button', { name: 'Send' }).click()
+}
+
+test.describe('Freshopencode DB history restore', () => {
+  test.setTimeout(180_000)
+
+  test('restores Freshopencode turns from DB history when export is truncated', async ({ page }) => {
+    const sharedRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-freshopencode-db-'))
+    const binDir = path.join(sharedRoot, 'bin')
+    const logsDir = path.join(sharedRoot, 'logs')
+    const auditLogPath = path.join(sharedRoot, 'fake-opencode-audit.jsonl')
+    const sharedOpencodeDataDir = path.join(sharedRoot, 'opencode-data')
+    const cwd = path.join(sharedRoot, 'project')
+    const prompt = 'Persist this Freshopencode DB turn'
+    const response = 'Freshopencode DB response survived reload'
+    await fsp.mkdir(cwd, { recursive: true })
+    await installFakeOpencode(binDir)
+
+    const server = new TestServer(createServerOptions({
+      binDir,
+      auditLogPath,
+      logsDir,
+      sharedOpencodeDataDir,
+      env: {
+        FAKE_OPENCODE_TRUNCATE_EXPORT: '1',
+        FAKE_OPENCODE_RESPONSE_TEXT: response,
+      },
+    }))
+
+    try {
+      const info = await server.start()
+      await page.goto(`${info.baseUrl}/?token=${info.token}&e2e=1`)
+      const harness = new TestHarness(page)
+      await harness.waitForHarness()
+      await harness.waitForConnection()
+      await enableFreshOpencode(page)
+      await createFreshopencodePane(page, cwd)
+
+      await expect.poll(async () => getFreshOpencodePaneState(page), { timeout: 15_000 }).toMatchObject({
+        sessionId: expect.stringMatching(/^freshopencode-/),
+      })
+
+      await sendFreshAgentPrompt(page, prompt)
+
+      await expect(page.getByText(response)).toBeVisible({ timeout: 30_000 })
+      await expect(page.getByText(prompt)).toBeVisible({ timeout: 30_000 })
+
+      await expect.poll(async () => getFreshOpencodePaneState(page), { timeout: 30_000 }).toMatchObject({
+        sessionId: expect.stringMatching(/^ses_/),
+        resumeSessionId: expect.stringMatching(/^ses_/),
+        sessionRef: {
+          provider: 'opencode',
+          sessionId: expect.stringMatching(/^ses_/),
+        },
+      })
+      const beforeReload = await getFreshOpencodePaneState(page)
+      expect(beforeReload.sessionRef?.sessionId).toBe(beforeReload.sessionId)
+
+      await page.evaluate(() => {
+        window.__FRESHELL_TEST_HARNESS__?.dispatch({ type: 'persist/flushNow' })
+      })
+      await page.reload()
+      await harness.waitForHarness()
+      await harness.waitForConnection()
+
+      await expect(page.getByText(prompt)).toBeVisible({ timeout: 30_000 })
+      await expect(page.getByText(response)).toBeVisible({ timeout: 30_000 })
+      await expect.poll(async () => getFreshOpencodePaneState(page), { timeout: 30_000 }).toMatchObject({
+        sessionId: beforeReload.sessionId,
+        resumeSessionId: beforeReload.sessionId,
+        sessionRef: {
+          provider: 'opencode',
+          sessionId: beforeReload.sessionId,
+        },
+      })
+
+      const auditEvents = await readAuditEvents(auditLogPath)
+      expect(auditEvents.some((event) => event.event === 'run' && event.prompt === prompt)).toBe(true)
+      expect(auditEvents.some((event) => event.event === 'export')).toBe(false)
+    } finally {
+      await server.stop().catch(() => {})
+      await fsp.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  test('does not materialize Freshopencode from DB rows without top-level run sessionID', async ({ page }) => {
+    const sharedRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-freshopencode-no-session-id-'))
+    const binDir = path.join(sharedRoot, 'bin')
+    const logsDir = path.join(sharedRoot, 'logs')
+    const auditLogPath = path.join(sharedRoot, 'fake-opencode-audit.jsonl')
+    const sharedOpencodeDataDir = path.join(sharedRoot, 'opencode-data')
+    const cwd = path.join(sharedRoot, 'project')
+    const prompt = 'Do not infer my session id'
+    await fsp.mkdir(cwd, { recursive: true })
+    await installFakeOpencode(binDir)
+
+    const server = new TestServer(createServerOptions({
+      binDir,
+      auditLogPath,
+      logsDir,
+      sharedOpencodeDataDir,
+      env: {
+        FAKE_OPENCODE_RUN_NO_SESSION_ID: '1',
+      },
+    }))
+
+    try {
+      const info = await server.start()
+      await page.goto(`${info.baseUrl}/?token=${info.token}&e2e=1`)
+      const harness = new TestHarness(page)
+      await harness.waitForHarness()
+      await harness.waitForConnection()
+      await enableFreshOpencode(page)
+      await createFreshopencodePane(page, cwd)
+
+      await sendFreshAgentPrompt(page, prompt)
+
+      await expect.poll(async () => {
+        const events = await readAuditEvents(auditLogPath)
+        return events.find((event) => event.event === 'run' && event.prompt === prompt) ?? null
+      }, { timeout: 30_000 }).toMatchObject({
+        sessionId: expect.stringMatching(/^ses_/),
+        omitRunSessionId: true,
+      })
+
+      await expect.poll(async () => getFreshOpencodePaneState(page), { timeout: 30_000 }).toMatchObject({
+        sessionId: expect.stringMatching(/^freshopencode-/),
+        resumeSessionId: expect.stringMatching(/^freshopencode-/),
+        sessionRef: {
+          provider: 'opencode',
+          sessionId: expect.stringMatching(/^freshopencode-/),
+        },
+        status: 'idle',
+      })
+    } finally {
+      await server.stop().catch(() => {})
+      await fsp.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+})

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -129,6 +129,25 @@ function getFreshAgentSessionId() {
   return document.querySelector('[data-context="fresh-agent"]')?.getAttribute('data-session-id')
 }
 
+function getFreshAgentPaneContent(store: ReturnType<typeof createStore>) {
+  const layout = store.getState().panes.layouts['tab-1']
+  if (!layout || layout.type !== 'leaf' || layout.content.kind !== 'fresh-agent') {
+    throw new Error('Expected fresh-agent leaf content')
+  }
+  return layout.content
+}
+
+function sentFreshAgentMessages(type: string) {
+  return wsMock.send.mock.calls
+    .map(([message]) => message)
+    .filter((message): message is Record<string, unknown> => (
+      !!message
+      && typeof message === 'object'
+      && !Array.isArray(message)
+      && (message as { type?: unknown }).type === type
+    ))
+}
+
 function createDeferred<T>() {
   let resolve!: (value: T) => void
   let reject!: (error?: unknown) => void
@@ -397,6 +416,119 @@ describe('FreshAgentView', () => {
     await waitFor(() => {
       expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledWith('freshcodex', 'codex', 'thread-created', expect.any(Object))
     })
+  })
+
+  it('promotes Freshopencode panes when freshAgent.session.materialized arrives', async () => {
+    const store = createStore()
+    let onMessage: ((message: Record<string, unknown>) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler) => {
+      onMessage = handler
+      return () => {}
+    })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-opencode-materialize',
+        sessionId: 'freshopencode-req-opencode-materialize',
+        sessionRef: { provider: 'opencode', sessionId: 'freshopencode-req-opencode-materialize' },
+        resumeSessionId: 'freshopencode-req-opencode-materialize',
+        status: 'idle',
+        model: 'opencode-go/deepseek-v4-flash',
+        effort: 'max',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    const textbox = await screen.findByRole('textbox', { name: 'Chat message input' })
+    fireEvent.change(textbox, { target: { value: 'before materialized' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(sentFreshAgentMessages('freshAgent.send').at(-1)).toMatchObject({
+      sessionId: 'freshopencode-req-opencode-materialize',
+    })
+
+    await waitFor(() => {
+      expect(onMessage).toBeTypeOf('function')
+    })
+    act(() => {
+      onMessage?.({
+        type: 'freshAgent.session.materialized',
+        previousSessionId: 'freshopencode-req-opencode-materialize',
+        sessionId: 'ses_real_materialized_1',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        sessionRef: { provider: 'opencode', sessionId: 'ses_real_materialized_1' },
+      })
+    })
+
+    await waitFor(() => {
+      const content = getFreshAgentPaneContent(store)
+      expect(content.sessionId).toBe('ses_real_materialized_1')
+      expect(content.sessionRef).toEqual({ provider: 'opencode', sessionId: 'ses_real_materialized_1' })
+      expect(content.resumeSessionId).toBe('ses_real_materialized_1')
+      expect(content.restoreError).toBeUndefined()
+    })
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'after materialized' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(sentFreshAgentMessages('freshAgent.send').at(-1)).toMatchObject({
+      sessionId: 'ses_real_materialized_1',
+    })
+  })
+
+  it('clears a restored Freshopencode placeholder when history reports FRESH_AGENT_LOST_SESSION', async () => {
+    const store = createStore()
+    apiMock.getFreshAgentThreadSnapshot.mockRejectedValueOnce({
+      status: 404,
+      message: 'OpenCode fresh-agent placeholder freshopencode-restored is not restorable.',
+      details: {
+        code: 'FRESH_AGENT_LOST_SESSION',
+      },
+    })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-restored-opencode',
+        sessionId: 'freshopencode-restored',
+        sessionRef: { provider: 'opencode', sessionId: 'freshopencode-restored' },
+        resumeSessionId: 'freshopencode-restored',
+        status: 'connected',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      const content = getFreshAgentPaneContent(store)
+      expect(content.sessionId).toBeUndefined()
+      expect(content.sessionRef).toBeUndefined()
+      expect(content.resumeSessionId).toBeUndefined()
+      expect(content.status).toBe('idle')
+      expect(content.restoreError).toEqual({
+        code: 'RESTORE_UNAVAILABLE',
+        reason: 'durable_artifact_missing',
+      })
+    })
+    expect(sentFreshAgentMessages('freshAgent.create')).toHaveLength(0)
+    expect(sentFreshAgentMessages('freshAgent.attach')).toHaveLength(1)
   })
 
   it('sends through fresh-agent WS actions with pane settings when available', async () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -25,6 +25,7 @@ const wsMock = vi.hoisted(() => ({
 
 const apiMock = vi.hoisted(() => ({
   getFreshAgentThreadSnapshot: vi.fn(),
+  post: vi.fn(),
 }))
 
 const saveServerSettingsPatchSpy = vi.hoisted(() => vi.fn((patch: unknown) => ({
@@ -44,6 +45,7 @@ vi.mock('@/lib/api', async () => {
   const actual = await vi.importActual<typeof import('@/lib/api')>('@/lib/api')
   return {
     ...actual,
+    api: { ...actual.api, post: apiMock.post },
     getFreshAgentThreadSnapshot: apiMock.getFreshAgentThreadSnapshot,
   }
 })
@@ -163,6 +165,8 @@ beforeEach(() => {
   wsMock.onMessage.mockReset()
   wsMock.onMessage.mockImplementation(() => () => {})
   apiMock.getFreshAgentThreadSnapshot.mockReset()
+  apiMock.post.mockReset()
+  apiMock.post.mockResolvedValue({ title: null, source: 'none' })
   saveServerSettingsPatchSpy.mockClear()
   apiMock.getFreshAgentThreadSnapshot.mockResolvedValue({
     status: 'idle',
@@ -1058,6 +1062,11 @@ describe('FreshAgentView', () => {
 
   it('does not reopen auto-title when freshopencode materializes a live session id for the same durable thread', async () => {
     const store = createStore()
+    let onMessage: ((message: Record<string, unknown>) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler: (message: Record<string, unknown>) => void) => {
+      onMessage = handler
+      return () => {}
+    })
     store.dispatch(initLayout({
       tabId: 'tab-1',
       paneId: 'pane-1',
@@ -1098,24 +1107,30 @@ describe('FreshAgentView', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
 
+    await waitFor(() => {
+      expect(apiMock.post).toHaveBeenCalledWith(
+        '/api/sessions/opencode%3Afreshopencode-req-1/generate-title',
+        { firstMessage: 'First opencode title' },
+      )
+      expect(onMessage).toBeTypeOf('function')
+    })
+
     act(() => {
-      store.dispatch(updatePaneContent({
-        tabId: 'tab-1',
-        paneId: 'pane-1',
-        content: {
-          kind: 'fresh-agent',
-          sessionType: 'freshopencode',
-          provider: 'opencode',
-          createRequestId: 'req-opencode-auto-title',
-          sessionId: 'ses_real_1',
-          sessionRef: { provider: 'opencode', sessionId: 'freshopencode-req-1' },
-          resumeSessionId: 'freshopencode-req-1',
-          status: 'idle',
-        },
-      }))
+      onMessage?.({
+        type: 'freshAgent.session.materialized',
+        previousSessionId: 'freshopencode-req-1',
+        sessionId: 'ses_real_1',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        sessionRef: { provider: 'opencode', sessionId: 'ses_real_1' },
+      })
     })
     await waitFor(() => {
       expect(getFreshAgentSessionId()).toBe('ses_real_1')
+      expect(apiMock.post).toHaveBeenCalledWith(
+        '/api/sessions/opencode%3Ases_real_1/generate-title',
+        { firstMessage: 'First opencode title' },
+      )
     })
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {

--- a/test/unit/client/lib/fresh-agent-ws.test.ts
+++ b/test/unit/client/lib/fresh-agent-ws.test.ts
@@ -91,6 +91,23 @@ describe('fresh-agent-ws', () => {
     })
   })
 
+  it('recognizes freshAgent.session.materialized as a handled fresh-agent message', () => {
+    const store = configureStore({
+      reducer: {
+        freshAgent: freshAgentReducer,
+      },
+    })
+
+    expect(handleFreshAgentMessage(store.dispatch, {
+      type: 'freshAgent.session.materialized',
+      previousSessionId: 'freshopencode-req-1',
+      sessionId: 'ses_real_1',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      sessionRef: { provider: 'opencode', sessionId: 'ses_real_1' },
+    })).toBe(true)
+  })
+
   it('projects Claude freshAgent.event snapshot and lost-session transport updates into fresh-agent session state', () => {
     const store = configureStore({
       reducer: {

--- a/test/unit/server/fresh-agent/opencode-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-adapter.test.ts
@@ -3,11 +3,15 @@ import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
 
 import { createOpencodeFreshAgentAdapter } from '../../../../server/fresh-agent/adapters/opencode/adapter.js'
+import { OpencodeHistoryReaderError, type OpencodeHistoryReader } from '../../../../server/fresh-agent/adapters/opencode/history-runner.js'
+import { FreshAgentLostSessionError } from '../../../../server/fresh-agent/runtime-manager.js'
 
 function makeSpawn(fixtures: Record<string, { stdout: string; stderr?: string; code?: number }>) {
   const calls: string[][] = []
-  const spawnFn = vi.fn((_command: string, args: string[]) => {
+  const cwdCalls: Array<string | undefined> = []
+  const spawnFn = vi.fn((_command: string, args: string[], options?: { cwd?: string }) => {
     calls.push(args)
+    cwdCalls.push(options?.cwd)
     const child = new EventEmitter() as any
     child.stdout = new PassThrough()
     child.stderr = new PassThrough()
@@ -23,7 +27,7 @@ function makeSpawn(fixtures: Record<string, { stdout: string; stderr?: string; c
     })
     return child
   })
-  return { spawnFn, calls }
+  return { spawnFn, calls, cwdCalls }
 }
 
 function makeHangingSpawn() {
@@ -38,6 +42,26 @@ function makeHangingSpawn() {
     return true
   })
   return { spawnFn: vi.fn(() => child), child }
+}
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function makeHistoryReader(overrides: Partial<OpencodeHistoryReader> = {}): OpencodeHistoryReader {
+  return {
+    readSessionInfo: vi.fn().mockRejectedValue(new OpencodeHistoryReaderError('missing_db', 'missing db')),
+    readSnapshotPage: vi.fn().mockRejectedValue(new OpencodeHistoryReaderError('missing_db', 'missing db')),
+    readTurnPage: vi.fn().mockRejectedValue(new OpencodeHistoryReaderError('missing_db', 'missing db')),
+    readTurnBody: vi.fn().mockRejectedValue(new OpencodeHistoryReaderError('missing_db', 'missing db')),
+    ...overrides,
+  }
 }
 
 const exportedSession = {
@@ -73,7 +97,10 @@ describe('OpenCode fresh-agent adapter', () => {
         stdout: `Exporting session: ses_real_1\n${JSON.stringify(exportedSession)}`,
       },
     })
-    const adapter = createOpencodeFreshAgentAdapter({ spawnFn: spawnFn as any })
+    const adapter = createOpencodeFreshAgentAdapter({
+      spawnFn: spawnFn as any,
+      historyReader: makeHistoryReader(),
+    })
 
     const created = await adapter.create({
       requestId: 'req-1',
@@ -89,7 +116,10 @@ describe('OpenCode fresh-agent adapter', () => {
       sessionRef: { provider: 'opencode', sessionId: 'freshopencode-req-1' },
     })
 
-    await adapter.send?.('freshopencode-req-1', { text: 'reply ok' })
+    await expect(adapter.send?.('freshopencode-req-1', { text: 'reply ok' })).resolves.toEqual({
+      sessionId: 'ses_real_1',
+      sessionRef: { provider: 'opencode', sessionId: 'ses_real_1' },
+    })
     expect((spawnFn.mock.results[0].value as any).stdin.end).toHaveBeenCalled()
     expect(calls[0]).toEqual([
       'run',
@@ -129,7 +159,10 @@ describe('OpenCode fresh-agent adapter', () => {
         stdout: '{"type":"step_start","sessionID":"ses_real_2"}\n',
       },
     })
-    const adapter = createOpencodeFreshAgentAdapter({ spawnFn: spawnFn as any })
+    const adapter = createOpencodeFreshAgentAdapter({
+      spawnFn: spawnFn as any,
+      historyReader: makeHistoryReader(),
+    })
     await adapter.create({
       requestId: 'req-2',
       sessionType: 'freshopencode',
@@ -150,18 +183,22 @@ describe('OpenCode fresh-agent adapter', () => {
       ...exportedSession,
       info: { ...exportedSession.info, id: 'ses_restored_1' },
     }
-    const { spawnFn, calls } = makeSpawn({
+    const historyReader = makeHistoryReader({
+      readSessionInfo: vi.fn().mockResolvedValue({ id: 'ses_restored_1', directory: '/db/repo' }),
+      readTurnBody: vi.fn().mockResolvedValue({
+        message: restoredExport.messages[1],
+        revision: 12,
+      }),
+    })
+    const { spawnFn, calls, cwdCalls } = makeSpawn({
       'run reply ok --format json --session ses_restored_1': {
         stdout: '{"type":"step_start","sessionID":"ses_restored_1"}\n',
       },
       'run /compact keep decisions --format json --session ses_restored_1': {
         stdout: '{"type":"step_start","sessionID":"ses_restored_1"}\n',
       },
-      'export ses_restored_1': {
-        stdout: `Exporting session: ses_restored_1\n${JSON.stringify(restoredExport)}`,
-      },
     })
-    const adapter = createOpencodeFreshAgentAdapter({ spawnFn: spawnFn as any })
+    const adapter = createOpencodeFreshAgentAdapter({ spawnFn: spawnFn as any, historyReader })
 
     await adapter.attach?.({
       sessionType: 'freshopencode',
@@ -187,6 +224,8 @@ describe('OpenCode fresh-agent adapter', () => {
       '--session',
       'ses_restored_1',
     ])
+    expect(cwdCalls[0]).toBe('/db/repo')
+    expect(cwdCalls[1]).toBe('/db/repo')
     await expect(adapter.getTurnBody?.({
       sessionType: 'freshopencode',
       provider: 'opencode',
@@ -200,6 +239,203 @@ describe('OpenCode fresh-agent adapter', () => {
         expect.objectContaining({ kind: 'text', text: 'ok' }),
       ]),
     })
+    expect(historyReader.readTurnBody).toHaveBeenCalledWith('ses_restored_1', 'msg_assistant_1')
+  })
+
+  it('hydrates a resumed restored session cwd from DB before later runs', async () => {
+    const historyReader = makeHistoryReader({
+      readSessionInfo: vi.fn().mockResolvedValue({ id: 'ses_restored_1', directory: '/db/resume-repo' }),
+    })
+    const { spawnFn, cwdCalls } = makeSpawn({
+      'run reply ok --format json --session ses_restored_1 --model opencode-go/deepseek-v4-flash --variant max': {
+        stdout: '{"type":"step_start","sessionID":"ses_restored_1"}\n',
+      },
+    })
+    const adapter = createOpencodeFreshAgentAdapter({ spawnFn: spawnFn as any, historyReader })
+
+    await adapter.resume?.({
+      requestId: 'req-resume',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      resumeSessionId: 'ses_restored_1',
+    })
+    await adapter.send?.('ses_restored_1', { text: 'reply ok' })
+
+    expect(historyReader.readSessionInfo).toHaveBeenCalledWith('ses_restored_1')
+    expect(cwdCalls[0]).toBe('/db/resume-repo')
+  })
+
+  it('uses DB history before export and does not call truncated export when DB succeeds', async () => {
+    const historyReader = makeHistoryReader({
+      readSessionInfo: vi.fn().mockResolvedValue({ id: 'ses_real_1', directory: '/repo' }),
+      readSnapshotPage: vi.fn().mockResolvedValue({
+        exported: exportedSession,
+        revision: 12,
+        nextCursor: null,
+        hasMoreBefore: false,
+      }),
+    })
+    const { spawnFn, calls } = makeSpawn({
+      'run reply ok --format json --model opencode-go/deepseek-v4-flash --variant max': {
+        stdout: '{"type":"step_start","sessionID":"ses_real_1"}\n',
+      },
+      'export ses_real_1': {
+        stdout: '{"info":{"id":"ses_real_1"},"messages":[',
+      },
+    })
+    const adapter = createOpencodeFreshAgentAdapter({ spawnFn: spawnFn as any, historyReader })
+    await adapter.create({
+      requestId: 'req-db-first',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+    })
+
+    await adapter.send?.('freshopencode-req-db-first', { text: 'reply ok' })
+    await expect(adapter.getSnapshot?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'freshopencode-req-db-first',
+    }, 12)).resolves.toMatchObject({
+      sessionId: 'ses_real_1',
+      revision: 12,
+      turns: [
+        { turnId: 'msg_user_1' },
+        { turnId: 'msg_assistant_1' },
+      ],
+    })
+
+    expect(historyReader.readSnapshotPage).toHaveBeenCalledWith('ses_real_1', 200)
+    expect(calls.some((args) => args[0] === 'export')).toBe(false)
+  })
+
+  it('only materializes from top-level ses-prefixed run sessionID values', async () => {
+    const historyReader = makeHistoryReader()
+    const { spawnFn, calls } = makeSpawn({
+      'run reply ok --format json --model opencode-go/deepseek-v4-flash --variant max': {
+        stdout: [
+          JSON.stringify({
+            type: 'part',
+            part: { state: { metadata: { sessionId: 'ses_child_1' } } },
+          }),
+          JSON.stringify({ type: 'step_start', sessionID: 'not-a-session' }),
+          '',
+        ].join('\n'),
+      },
+    })
+    const adapter = createOpencodeFreshAgentAdapter({ spawnFn: spawnFn as any, historyReader })
+    await adapter.create({
+      requestId: 'req-nested',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+    })
+
+    await expect(adapter.send?.('freshopencode-req-nested', { text: 'reply ok' })).resolves.toBeUndefined()
+    await expect(adapter.getSnapshot?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'freshopencode-req-nested',
+    }, 0)).rejects.toBeInstanceOf(FreshAgentLostSessionError)
+    expect(historyReader.readSessionInfo).not.toHaveBeenCalled()
+    expect(calls.some((args) => args[0] === 'export')).toBe(false)
+  })
+
+  it('leaves placeholders unmaterialized when run output has no authoritative top-level sessionID', async () => {
+    const historyReader = makeHistoryReader()
+    const { spawnFn, calls } = makeSpawn({
+      'run reply ok --format json --model opencode-go/deepseek-v4-flash --variant max': {
+        stdout: '{"type":"text","part":{"text":"ok"}}\n',
+      },
+    })
+    const adapter = createOpencodeFreshAgentAdapter({ spawnFn: spawnFn as any, historyReader })
+    await adapter.create({
+      requestId: 'req-no-session-id',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      cwd: '/repo',
+    })
+
+    await expect(adapter.send?.('freshopencode-req-no-session-id', { text: 'reply ok' })).resolves.toBeUndefined()
+    await expect(adapter.getSnapshot?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'freshopencode-req-no-session-id',
+    }, 0)).rejects.toBeInstanceOf(FreshAgentLostSessionError)
+    expect(historyReader.readSessionInfo).not.toHaveBeenCalled()
+    expect(historyReader.readSnapshotPage).not.toHaveBeenCalled()
+    expect(calls.some((args) => args[0] === 'export')).toBe(false)
+  })
+
+  it('serializes concurrent first sends so the second uses the materialized session', async () => {
+    const firstClose = deferred()
+    const calls: string[][] = []
+    const spawnFn = vi.fn((_command: string, args: string[]) => {
+      calls.push(args)
+      const child = new EventEmitter() as any
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.stdin = new PassThrough()
+      child.stdin.end = vi.fn()
+      child.kill = vi.fn()
+      const complete = () => {
+        child.stdout.end('{"type":"step_start","sessionID":"ses_real_1"}\n')
+        child.stderr.end('')
+        child.emit('close', 0)
+      }
+      if (args[1] === 'first') {
+        void firstClose.promise.then(complete)
+      } else {
+        queueMicrotask(complete)
+      }
+      return child
+    })
+    const adapter = createOpencodeFreshAgentAdapter({
+      spawnFn: spawnFn as any,
+      historyReader: makeHistoryReader({
+        readSessionInfo: vi.fn().mockResolvedValue({ id: 'ses_real_1', directory: '/repo' }),
+      }),
+    })
+    await adapter.create({
+      requestId: 'req-queue',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+    })
+
+    const first = adapter.send?.('freshopencode-req-queue', { text: 'first' })
+    const second = adapter.send?.('freshopencode-req-queue', { text: 'second' })
+    await vi.waitFor(() => expect(spawnFn).toHaveBeenCalledTimes(1))
+    firstClose.resolve()
+    await Promise.all([first, second])
+
+    expect(calls[1].slice(0, 6)).toEqual([
+      'run',
+      'second',
+      '--format',
+      'json',
+      '--session',
+      'ses_real_1',
+    ])
+  })
+
+  it('throws for restored freshopencode placeholders without calling export', async () => {
+    const historyReader = makeHistoryReader()
+    const { spawnFn, calls } = makeSpawn({
+      'export freshopencode-restored': {
+        stdout: JSON.stringify(exportedSession),
+      },
+    })
+    const adapter = createOpencodeFreshAgentAdapter({ spawnFn: spawnFn as any, historyReader })
+
+    await expect(adapter.attach?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      sessionId: 'freshopencode-restored',
+    })).rejects.toBeInstanceOf(FreshAgentLostSessionError)
+    await expect(adapter.getSnapshot?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'freshopencode-restored',
+    }, 0)).rejects.toBeInstanceOf(FreshAgentLostSessionError)
+    expect(calls).toEqual([])
   })
 
   it('accepts partial per-turn settings from the client send path', async () => {
@@ -208,7 +444,10 @@ describe('OpenCode fresh-agent adapter', () => {
         stdout: '{"type":"step_start","sessionID":"ses_real_3"}\n',
       },
     })
-    const adapter = createOpencodeFreshAgentAdapter({ spawnFn: spawnFn as any })
+    const adapter = createOpencodeFreshAgentAdapter({
+      spawnFn: spawnFn as any,
+      historyReader: makeHistoryReader(),
+    })
     await adapter.create({
       requestId: 'req-3',
       sessionType: 'freshopencode',
@@ -239,7 +478,11 @@ describe('OpenCode fresh-agent adapter', () => {
 
   it('times out and terminates stuck OpenCode runs', async () => {
     const { spawnFn, child } = makeHangingSpawn()
-    const adapter = createOpencodeFreshAgentAdapter({ spawnFn: spawnFn as any, runTimeoutMs: 5 })
+    const adapter = createOpencodeFreshAgentAdapter({
+      spawnFn: spawnFn as any,
+      historyReader: makeHistoryReader(),
+      runTimeoutMs: 5,
+    })
     await adapter.create({
       requestId: 'req-timeout',
       sessionType: 'freshopencode',

--- a/test/unit/server/fresh-agent/opencode-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-adapter.test.ts
@@ -308,6 +308,42 @@ describe('OpenCode fresh-agent adapter', () => {
     expect(calls.some((args) => args[0] === 'export')).toBe(false)
   })
 
+  it('returns an empty live snapshot for a newly-created placeholder before first materialization', async () => {
+    const historyReader = makeHistoryReader()
+    const { spawnFn, calls } = makeSpawn({
+      'export freshopencode-req-empty': {
+        stdout: JSON.stringify(exportedSession),
+      },
+    })
+    const adapter = createOpencodeFreshAgentAdapter({ spawnFn: spawnFn as any, historyReader })
+    await adapter.create({
+      requestId: 'req-empty',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      model: 'opencode-go/deepseek-v4-flash',
+      effort: 'max',
+    })
+
+    await expect(adapter.getSnapshot?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'freshopencode-req-empty',
+    }, 0)).resolves.toMatchObject({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'freshopencode-req-empty',
+      sessionId: 'freshopencode-req-empty',
+      status: 'idle',
+      turns: [],
+      settings: {
+        model: 'opencode-go/deepseek-v4-flash',
+        effort: 'max',
+      },
+    })
+    expect(historyReader.readSnapshotPage).not.toHaveBeenCalled()
+    expect(calls).toEqual([])
+  })
+
   it('only materializes from top-level ses-prefixed run sessionID values', async () => {
     const historyReader = makeHistoryReader()
     const { spawnFn, calls } = makeSpawn({
@@ -334,8 +370,12 @@ describe('OpenCode fresh-agent adapter', () => {
       sessionType: 'freshopencode',
       provider: 'opencode',
       threadId: 'freshopencode-req-nested',
-    }, 0)).rejects.toBeInstanceOf(FreshAgentLostSessionError)
+    }, 0)).resolves.toMatchObject({
+      sessionId: 'freshopencode-req-nested',
+      turns: [],
+    })
     expect(historyReader.readSessionInfo).not.toHaveBeenCalled()
+    expect(historyReader.readSnapshotPage).not.toHaveBeenCalled()
     expect(calls.some((args) => args[0] === 'export')).toBe(false)
   })
 
@@ -359,7 +399,10 @@ describe('OpenCode fresh-agent adapter', () => {
       sessionType: 'freshopencode',
       provider: 'opencode',
       threadId: 'freshopencode-req-no-session-id',
-    }, 0)).rejects.toBeInstanceOf(FreshAgentLostSessionError)
+    }, 0)).resolves.toMatchObject({
+      sessionId: 'freshopencode-req-no-session-id',
+      turns: [],
+    })
     expect(historyReader.readSessionInfo).not.toHaveBeenCalled()
     expect(historyReader.readSnapshotPage).not.toHaveBeenCalled()
     expect(calls.some((args) => args[0] === 'export')).toBe(false)

--- a/test/unit/server/fresh-agent/opencode-history-query.test.ts
+++ b/test/unit/server/fresh-agent/opencode-history-query.test.ts
@@ -18,6 +18,7 @@ type DatabaseSyncConstructor = SqliteModule['DatabaseSync']
 type DatabaseSyncInstance = InstanceType<DatabaseSyncConstructor>
 
 const sessionId = 'ses_opencode_db_history'
+const otherSessionId = 'ses_other_opencode_db_history'
 const baseTime = 1_779_557_095_000
 const modelFixture = {
   providerID: 'opencode-go',
@@ -166,19 +167,31 @@ describe('OpenCode DB history query', () => {
     )
   }
 
-  function insertMessage(db: DatabaseSyncInstance, messageId: string, createdOffset: number, data: Record<string, unknown>): void {
+  function insertMessage(
+    db: DatabaseSyncInstance,
+    messageId: string,
+    createdOffset: number,
+    data: Record<string, unknown>,
+    targetSessionId = sessionId,
+  ): void {
     const createdAt = baseTime + createdOffset
     db.prepare(`
       INSERT INTO message (id, session_id, time_created, time_updated, data)
       VALUES (?, ?, ?, ?, ?)
-    `).run(messageId, sessionId, createdAt, createdAt + 17, JSON.stringify(data))
+    `).run(messageId, targetSessionId, createdAt, createdAt + 17, JSON.stringify(data))
   }
 
-  function insertPart(db: DatabaseSyncInstance, partId: string, messageId: string, data: Record<string, unknown>): void {
+  function insertPart(
+    db: DatabaseSyncInstance,
+    partId: string,
+    messageId: string,
+    data: Record<string, unknown>,
+    targetSessionId = sessionId,
+  ): void {
     db.prepare(`
       INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
       VALUES (?, ?, ?, ?, ?, ?)
-    `).run(partId, messageId, sessionId, baseTime + 50_000, baseTime + 50_017, JSON.stringify(data))
+    `).run(partId, messageId, targetSessionId, baseTime + 50_000, baseTime + 50_017, JSON.stringify(data))
   }
 
   function seedConversation(db: DatabaseSyncInstance): void {
@@ -303,6 +316,79 @@ describe('OpenCode DB history query', () => {
     }
   })
 
+  it('uses message id as a cursor tie-breaker when messages share a timestamp', () => {
+    const db = createDatabase()
+    try {
+      createOpenCodeSchema(db)
+      insertSession(db)
+      insertMessage(db, 'message-a', 1_000, { role: 'user' })
+      insertPart(db, 'part-a', 'message-a', { type: 'text', text: 'First message.' })
+      insertMessage(db, 'message-b', 2_000, { role: 'assistant' })
+      insertPart(db, 'part-b', 'message-b', { type: 'text', text: 'First duplicate timestamp message.' })
+      insertMessage(db, 'message-c', 2_000, { role: 'user' })
+      insertPart(db, 'part-c', 'message-c', { type: 'text', text: 'Second duplicate timestamp message.' })
+      insertMessage(db, 'message-d', 3_000, { role: 'assistant' })
+      insertPart(db, 'part-d', 'message-d', { type: 'text', text: 'Final message.' })
+
+      const first = readOpencodeTurnPage(db, { sessionId, limit: 2 })
+      const expectedCursor = encodeOpencodeCursor({ timeCreated: baseTime + 2_000, id: 'message-b' })
+
+      expect(first.messages.map((message) => message.info.id)).toEqual(['message-a', 'message-b'])
+      expect(first.nextCursor).toBe(expectedCursor)
+
+      const second = readOpencodeTurnPage(db, { sessionId, limit: 2, cursor: first.nextCursor })
+      expect(second.messages.map((message) => message.info.id)).toEqual(['message-c', 'message-d'])
+      expect(second.nextCursor).toBeNull()
+
+      const pagedIds = [...first.messages, ...second.messages].map((message) => message.info.id)
+      expect(pagedIds).toEqual(['message-a', 'message-b', 'message-c', 'message-d'])
+      expect(new Set(pagedIds).size).toBe(pagedIds.length)
+    } finally {
+      db.close()
+    }
+  })
+
+  it('isolates snapshot, page, and body reads to the requested session', () => {
+    const db = createDatabase()
+    try {
+      createOpenCodeSchema(db)
+      insertSession(db, { title: 'Primary session' })
+      insertSession(db, {
+        id: otherSessionId,
+        title: 'Interleaved other session',
+        directory: '/repo/other-opencode',
+        timeCreated: baseTime + 500,
+        timeUpdated: baseTime + 3_500,
+      })
+
+      insertMessage(db, 'primary-message-1', 1_000, { role: 'user' })
+      insertPart(db, 'primary-part-1', 'primary-message-1', { type: 'text', text: 'Primary first.' })
+      insertMessage(db, 'other-message-1', 1_500, { role: 'assistant' }, otherSessionId)
+      insertPart(db, 'other-part-1', 'other-message-1', { type: 'text', text: 'Other first.' }, otherSessionId)
+      insertMessage(db, 'primary-message-2', 2_000, { role: 'assistant' })
+      insertPart(db, 'primary-part-2', 'primary-message-2', { type: 'text', text: 'Primary second.' })
+      insertMessage(db, 'other-message-2', 2_500, { role: 'user' }, otherSessionId)
+      insertPart(db, 'other-part-2', 'other-message-2', { type: 'text', text: 'Other second.' }, otherSessionId)
+
+      const snapshot = readOpencodeSnapshotPage(db, { sessionId, limit: 10 })
+      expect(snapshot.messages.map((message) => message.info.id)).toEqual(['primary-message-1', 'primary-message-2'])
+      expect(snapshot.messages.flatMap((message) => message.parts).map((part) => part.id)).toEqual([
+        'primary-part-1',
+        'primary-part-2',
+      ])
+
+      const page = readOpencodeTurnPage(db, { sessionId, limit: 10 })
+      expect(page.messages.map((message) => message.info.id)).toEqual(['primary-message-1', 'primary-message-2'])
+      expect(page.nextCursor).toBeNull()
+
+      const body = readOpencodeTurnBody(db, { sessionId, turnId: 'primary-message-2' })
+      expect(body?.parts.map((part) => part.id)).toEqual(['primary-part-2'])
+      expect(readOpencodeTurnBody(db, { sessionId, turnId: 'other-message-1' })).toBeNull()
+    } finally {
+      db.close()
+    }
+  })
+
   it('reads a turn body with JSON-parsed parts ordered by part id', () => {
     const db = createDatabase()
     try {
@@ -389,6 +475,30 @@ describe('OpenCode DB history query', () => {
       expect((caught as { missingColumns?: unknown }).missingColumns).toEqual(
         expect.arrayContaining(['directory', 'time_updated']),
       )
+    } finally {
+      db.close()
+    }
+  })
+
+  it('throws a typed schema error when a message required column is missing', () => {
+    const db = createDatabase()
+    try {
+      createOpenCodeSchema(db)
+      db.exec('ALTER TABLE message DROP COLUMN data')
+      insertSession(db)
+
+      let caught: unknown
+      try {
+        readOpencodeTurnPage(db, { sessionId, limit: 2 })
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).toBeInstanceOf(Error)
+      expect((caught as Error).name).toBe('OpencodeHistorySchemaError')
+      expect((caught as { code?: unknown }).code).toBe('OPENCODE_HISTORY_SCHEMA_ERROR')
+      expect((caught as { table?: unknown }).table).toBe('message')
+      expect((caught as { missingColumns?: unknown }).missingColumns).toEqual(expect.arrayContaining(['data']))
     } finally {
       db.close()
     }

--- a/test/unit/server/fresh-agent/opencode-history-query.test.ts
+++ b/test/unit/server/fresh-agent/opencode-history-query.test.ts
@@ -1,0 +1,439 @@
+import path from 'path'
+import os from 'os'
+import fsp from 'fs/promises'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  encodeOpencodeCursor,
+  readOpencodeSessionInfo,
+  readOpencodeSnapshotPage,
+  readOpencodeTurnBody,
+  readOpencodeTurnPage,
+} from '../../../../server/fresh-agent/adapters/opencode/history-query.js'
+
+vi.unmock('node:sqlite')
+
+type SqliteModule = typeof import('node:sqlite')
+type DatabaseSyncConstructor = SqliteModule['DatabaseSync']
+type DatabaseSyncInstance = InstanceType<DatabaseSyncConstructor>
+
+const sessionId = 'ses_opencode_db_history'
+const baseTime = 1_779_557_095_000
+const modelFixture = {
+  providerID: 'opencode-go',
+  id: 'deepseek-v4-flash',
+  variant: 'max',
+}
+
+describe('OpenCode DB history query', () => {
+  let tempDir: string
+  let DatabaseSync: DatabaseSyncConstructor
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-opencode-history-query-'))
+    DatabaseSync = (await import('node:sqlite')).DatabaseSync
+  })
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true })
+  })
+
+  function createDatabase(name = 'opencode.db'): DatabaseSyncInstance {
+    return new DatabaseSync(path.join(tempDir, name))
+  }
+
+  function createOpenCodeSchema(db: DatabaseSyncInstance): void {
+    db.exec(`
+      CREATE TABLE session (
+        id text PRIMARY KEY,
+        project_id text NOT NULL,
+        workspace_id text,
+        parent_id text,
+        slug text NOT NULL,
+        directory text NOT NULL,
+        path text,
+        title text NOT NULL,
+        version text NOT NULL,
+        share_url text,
+        summary_additions integer,
+        summary_deletions integer,
+        summary_files integer,
+        summary_diffs text,
+        metadata text,
+        cost real NOT NULL DEFAULT 0,
+        tokens_input integer NOT NULL DEFAULT 0,
+        tokens_output integer NOT NULL DEFAULT 0,
+        tokens_reasoning integer NOT NULL DEFAULT 0,
+        tokens_cache_read integer NOT NULL DEFAULT 0,
+        tokens_cache_write integer NOT NULL DEFAULT 0,
+        revert text,
+        permission text,
+        agent text,
+        model text,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        time_compacting integer,
+        time_archived integer
+      );
+      CREATE TABLE message (
+        id text PRIMARY KEY,
+        session_id text NOT NULL,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        data text NOT NULL
+      );
+      CREATE TABLE part (
+        id text PRIMARY KEY,
+        message_id text NOT NULL,
+        session_id text NOT NULL,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        data text NOT NULL
+      );
+    `)
+  }
+
+  function insertSession(db: DatabaseSyncInstance, overrides: {
+    id?: string
+    directory?: string
+    title?: string
+    model?: unknown
+    timeCreated?: number
+    timeUpdated?: number
+  } = {}): void {
+    db.prepare(`
+      INSERT INTO session (
+        id,
+        project_id,
+        workspace_id,
+        parent_id,
+        slug,
+        directory,
+        path,
+        title,
+        version,
+        share_url,
+        summary_additions,
+        summary_deletions,
+        summary_files,
+        summary_diffs,
+        metadata,
+        cost,
+        tokens_input,
+        tokens_output,
+        tokens_reasoning,
+        tokens_cache_read,
+        tokens_cache_write,
+        revert,
+        permission,
+        agent,
+        model,
+        time_created,
+        time_updated,
+        time_compacting,
+        time_archived
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      overrides.id ?? sessionId,
+      'project-1',
+      'workspace-1',
+      null,
+      'opencode-db-history',
+      overrides.directory ?? '/repo/opencode',
+      '/repo/opencode/.opencode/session',
+      overrides.title ?? 'Review DB history reads',
+      '1.16.2',
+      null,
+      7,
+      2,
+      3,
+      JSON.stringify([{ file: 'src/app.ts', additions: 7, deletions: 2 }]),
+      JSON.stringify({ source: 'unit-test' }),
+      0.42,
+      111,
+      222,
+      33,
+      44,
+      55,
+      null,
+      'ask',
+      'build',
+      JSON.stringify(overrides.model ?? modelFixture),
+      overrides.timeCreated ?? baseTime,
+      overrides.timeUpdated ?? baseTime + 9_000,
+      null,
+      null,
+    )
+  }
+
+  function insertMessage(db: DatabaseSyncInstance, messageId: string, createdOffset: number, data: Record<string, unknown>): void {
+    const createdAt = baseTime + createdOffset
+    db.prepare(`
+      INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(messageId, sessionId, createdAt, createdAt + 17, JSON.stringify(data))
+  }
+
+  function insertPart(db: DatabaseSyncInstance, partId: string, messageId: string, data: Record<string, unknown>): void {
+    db.prepare(`
+      INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(partId, messageId, sessionId, baseTime + 50_000, baseTime + 50_017, JSON.stringify(data))
+  }
+
+  function seedConversation(db: DatabaseSyncInstance): void {
+    createOpenCodeSchema(db)
+    insertSession(db)
+
+    insertMessage(db, 'message-1', 1_000, { role: 'user' })
+    insertPart(db, 'part-1', 'message-1', { type: 'text', text: 'Summarize the project state.' })
+
+    insertMessage(db, 'message-2', 2_000, {
+      role: 'assistant',
+      providerID: 'opencode-go',
+      modelID: 'deepseek-v4-flash',
+    })
+    insertPart(db, 'part-2', 'message-2', { type: 'text', text: 'The project is ready for a DB reader.' })
+
+    insertMessage(db, 'message-3', 3_000, { role: 'user' })
+    insertPart(db, 'part-3', 'message-3', {
+      type: 'file',
+      path: 'server/fresh-agent/adapters/opencode/history-query.ts',
+      mime: 'text/typescript',
+      content: 'export {}',
+    })
+
+    insertMessage(db, 'message-4', 4_000, {
+      role: 'assistant',
+      providerID: 'opencode-go',
+      modelID: 'deepseek-v4-flash',
+    })
+    insertPart(db, 'part-4', 'message-4', {
+      type: 'patch',
+      files: [{ path: 'server/fresh-agent/adapters/opencode/history-query.ts', additions: 12, deletions: 0 }],
+      diff: 'diff --git a/history-query.ts b/history-query.ts',
+    })
+
+    insertMessage(db, 'message-5', 5_000, { role: 'assistant' })
+    insertPart(db, 'part-5', 'message-5', {
+      type: 'compaction',
+      summary: 'Compacted earlier DB history context.',
+      beforeTokens: 10_000,
+      afterTokens: 3_500,
+    })
+  }
+
+  it('reads session info with parsed model JSON, token fields, and millisecond timestamps', () => {
+    const db = createDatabase()
+    try {
+      createOpenCodeSchema(db)
+      insertSession(db, {
+        title: 'Typed session metadata',
+        directory: '/workspace/project',
+        timeCreated: baseTime + 101,
+        timeUpdated: baseTime + 202,
+      })
+
+      const info = readOpencodeSessionInfo(db, { sessionId })
+
+      expect(info).toMatchObject({
+        id: sessionId,
+        directory: '/workspace/project',
+        title: 'Typed session metadata',
+        model: modelFixture,
+        tokens: {
+          input: 111,
+          output: 222,
+          reasoning: 33,
+          cache: {
+            read: 44,
+            write: 55,
+          },
+        },
+        cost: 0.42,
+        time: {
+          created: baseTime + 101,
+          updated: baseTime + 202,
+        },
+      })
+      expect(typeof info.model).toBe('object')
+    } finally {
+      db.close()
+    }
+  })
+
+  it('reads the newest snapshot messages in chronological order and reports older history', () => {
+    const db = createDatabase()
+    try {
+      seedConversation(db)
+
+      const page = readOpencodeSnapshotPage(db, { sessionId, limit: 3 })
+
+      expect(page.info).toMatchObject({ id: sessionId, title: 'Review DB history reads' })
+      expect(page.messages.map((message) => message.info.id)).toEqual(['message-3', 'message-4', 'message-5'])
+      expect(page.messages.map((message) => message.info.time.created)).toEqual([
+        baseTime + 3_000,
+        baseTime + 4_000,
+        baseTime + 5_000,
+      ])
+      expect(page.hasMoreBefore).toBe(true)
+    } finally {
+      db.close()
+    }
+  })
+
+  it('pages turns chronologically with an opaque cursor', () => {
+    const db = createDatabase()
+    try {
+      seedConversation(db)
+
+      const first = readOpencodeTurnPage(db, { sessionId, limit: 2 })
+      const expectedCursor = encodeOpencodeCursor({ timeCreated: baseTime + 2_000, id: 'message-2' })
+
+      expect(first.messages.map((message) => message.info.id)).toEqual(['message-1', 'message-2'])
+      expect(first.nextCursor).toBe(expectedCursor)
+      expect(first.nextCursor).not.toContain('message-2')
+
+      const second = readOpencodeTurnPage(db, { sessionId, limit: 2, cursor: first.nextCursor })
+      expect(second.messages.map((message) => message.info.id)).toEqual(['message-3', 'message-4'])
+      expect(second.nextCursor).toEqual(expect.any(String))
+      expect(second.nextCursor).not.toEqual(first.nextCursor)
+    } finally {
+      db.close()
+    }
+  })
+
+  it('reads a turn body with JSON-parsed parts ordered by part id', () => {
+    const db = createDatabase()
+    try {
+      createOpenCodeSchema(db)
+      insertSession(db)
+      insertMessage(db, 'message-body', 1_000, { role: 'assistant', providerID: 'opencode-go', modelID: 'deepseek-v4-flash' })
+      insertPart(db, 'part-c-text', 'message-body', { type: 'text', text: 'Finished.' })
+      insertPart(db, 'part-a-file', 'message-body', {
+        type: 'file',
+        path: 'src/App.tsx',
+        content: 'export function App() {}',
+      })
+      insertPart(db, 'part-b-patch', 'message-body', {
+        type: 'patch',
+        files: [{ path: 'src/App.tsx', additions: 1, deletions: 0 }],
+        diff: '@@ -0,0 +1 @@',
+      })
+
+      const body = readOpencodeTurnBody(db, { sessionId, turnId: 'message-body' })
+
+      expect(body).toMatchObject({
+        info: {
+          id: 'message-body',
+          role: 'assistant',
+          providerID: 'opencode-go',
+          modelID: 'deepseek-v4-flash',
+          time: {
+            created: baseTime + 1_000,
+            updated: baseTime + 1_017,
+          },
+        },
+      })
+      expect(body?.parts.map((part) => part.id)).toEqual(['part-a-file', 'part-b-patch', 'part-c-text'])
+      expect(body?.parts).toEqual([
+        expect.objectContaining({ id: 'part-a-file', type: 'file', path: 'src/App.tsx' }),
+        expect.objectContaining({ id: 'part-b-patch', type: 'patch', files: [{ path: 'src/App.tsx', additions: 1, deletions: 0 }] }),
+        expect.objectContaining({ id: 'part-c-text', type: 'text', text: 'Finished.' }),
+      ])
+    } finally {
+      db.close()
+    }
+  })
+
+  it('throws a typed schema error when required columns are missing instead of returning blank history', () => {
+    const db = createDatabase()
+    try {
+      db.exec(`
+        CREATE TABLE session (
+          id text PRIMARY KEY,
+          project_id text NOT NULL,
+          slug text NOT NULL,
+          title text NOT NULL,
+          version text NOT NULL,
+          time_created integer NOT NULL
+        );
+        CREATE TABLE message (
+          id text PRIMARY KEY,
+          session_id text NOT NULL,
+          time_created integer NOT NULL,
+          time_updated integer NOT NULL,
+          data text NOT NULL
+        );
+        CREATE TABLE part (
+          id text PRIMARY KEY,
+          message_id text NOT NULL,
+          session_id text NOT NULL,
+          time_created integer NOT NULL,
+          time_updated integer NOT NULL,
+          data text NOT NULL
+        );
+      `)
+
+      let caught: unknown
+      try {
+        readOpencodeSnapshotPage(db, { sessionId, limit: 3 })
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).toBeInstanceOf(Error)
+      expect((caught as Error).name).toBe('OpencodeHistorySchemaError')
+      expect((caught as { code?: unknown }).code).toBe('OPENCODE_HISTORY_SCHEMA_ERROR')
+      expect((caught as { table?: unknown }).table).toBe('session')
+      expect((caught as { missingColumns?: unknown }).missingColumns).toEqual(
+        expect.arrayContaining(['directory', 'time_updated']),
+      )
+    } finally {
+      db.close()
+    }
+  })
+
+  it('parses message and part JSON strings and preserves file, patch, and compaction fixtures for normalization', () => {
+    const db = createDatabase()
+    try {
+      seedConversation(db)
+
+      const page = readOpencodeSnapshotPage(db, { sessionId, limit: 5 })
+
+      expect(page.messages[1].info).toMatchObject({
+        id: 'message-2',
+        role: 'assistant',
+        providerID: 'opencode-go',
+        modelID: 'deepseek-v4-flash',
+      })
+      expect(typeof page.messages[1].info).toBe('object')
+      expect(page.messages.flatMap((message) => message.parts).filter((part) => part.type === 'file')).toEqual([
+        expect.objectContaining({
+          id: 'part-3',
+          type: 'file',
+          path: 'server/fresh-agent/adapters/opencode/history-query.ts',
+          content: 'export {}',
+        }),
+      ])
+      expect(page.messages.flatMap((message) => message.parts).filter((part) => part.type === 'patch')).toEqual([
+        expect.objectContaining({
+          id: 'part-4',
+          type: 'patch',
+          files: [{ path: 'server/fresh-agent/adapters/opencode/history-query.ts', additions: 12, deletions: 0 }],
+        }),
+      ])
+      expect(page.messages.flatMap((message) => message.parts).filter((part) => part.type === 'compaction')).toEqual([
+        expect.objectContaining({
+          id: 'part-5',
+          type: 'compaction',
+          summary: 'Compacted earlier DB history context.',
+          beforeTokens: 10_000,
+          afterTokens: 3_500,
+        }),
+      ])
+    } finally {
+      db.close()
+    }
+  })
+})

--- a/test/unit/server/fresh-agent/opencode-history-query.test.ts
+++ b/test/unit/server/fresh-agent/opencode-history-query.test.ts
@@ -43,6 +43,23 @@ describe('OpenCode DB history query', () => {
     return new DatabaseSync(path.join(tempDir, name))
   }
 
+  function instrumentReadDatabase(db: DatabaseSyncInstance): { reader: Parameters<typeof readOpencodeSessionInfo>[0]; events: string[] } {
+    const events: string[] = []
+    return {
+      events,
+      reader: {
+        exec(sql: string) {
+          events.push(sql.trim())
+          return db.exec(sql)
+        },
+        prepare(sql: string) {
+          events.push(`PREPARE:${sql.trim()}`)
+          return db.prepare(sql) as any
+        },
+      },
+    }
+  }
+
   function createOpenCodeSchema(db: DatabaseSyncInstance): void {
     db.exec(`
       CREATE TABLE session (
@@ -275,6 +292,34 @@ describe('OpenCode DB history query', () => {
     }
   })
 
+  it('wraps schema inspection and reads in a transaction for each public read helper', () => {
+    const db = createDatabase()
+    try {
+      seedConversation(db)
+      const { reader, events } = instrumentReadDatabase(db)
+      const reads: Array<[string, () => unknown]> = [
+        ['session info', () => readOpencodeSessionInfo(reader, { sessionId })],
+        ['snapshot page', () => readOpencodeSnapshotPage(reader, { sessionId, limit: 2 })],
+        ['turn page', () => readOpencodeTurnPage(reader, { sessionId, limit: 2 })],
+        ['turn body', () => readOpencodeTurnBody(reader, { sessionId, turnId: 'message-4' })],
+      ]
+
+      for (const [_label, read] of reads) {
+        events.length = 0
+        read()
+        const beginIndex = events.indexOf('BEGIN')
+        const commitIndex = events.indexOf('COMMIT')
+        const firstSchemaPrepareIndex = events.findIndex((event) => event.startsWith('PREPARE:PRAGMA table_info'))
+
+        expect(beginIndex).toBe(0)
+        expect(firstSchemaPrepareIndex).toBeGreaterThan(beginIndex)
+        expect(commitIndex).toBeGreaterThan(firstSchemaPrepareIndex)
+      }
+    } finally {
+      db.close()
+    }
+  })
+
   it('reads the newest snapshot messages in chronological order and reports older history', () => {
     const db = createDatabase()
     try {
@@ -295,22 +340,28 @@ describe('OpenCode DB history query', () => {
     }
   })
 
-  it('pages turns chronologically with an opaque cursor', () => {
+  it('loads the newest turn page first and uses an opaque cursor for older history', () => {
     const db = createDatabase()
     try {
       seedConversation(db)
 
       const first = readOpencodeTurnPage(db, { sessionId, limit: 2 })
-      const expectedCursor = encodeOpencodeCursor({ timeCreated: baseTime + 2_000, id: 'message-2' })
+      const expectedCursor = encodeOpencodeCursor({ timeCreated: baseTime + 4_000, id: 'message-4' })
 
-      expect(first.messages.map((message) => message.info.id)).toEqual(['message-1', 'message-2'])
+      expect(first.messages.map((message) => message.info.id)).toEqual(['message-4', 'message-5'])
       expect(first.nextCursor).toBe(expectedCursor)
-      expect(first.nextCursor).not.toContain('message-2')
+      expect(first.nextCursor).not.toContain('message-4')
+      expect(first.hasMoreBefore).toBe(true)
 
       const second = readOpencodeTurnPage(db, { sessionId, limit: 2, cursor: first.nextCursor })
-      expect(second.messages.map((message) => message.info.id)).toEqual(['message-3', 'message-4'])
+      expect(second.messages.map((message) => message.info.id)).toEqual(['message-2', 'message-3'])
       expect(second.nextCursor).toEqual(expect.any(String))
       expect(second.nextCursor).not.toEqual(first.nextCursor)
+
+      const third = readOpencodeTurnPage(db, { sessionId, limit: 2, cursor: second.nextCursor })
+      expect(third.messages.map((message) => message.info.id)).toEqual(['message-1'])
+      expect(third.nextCursor).toBeNull()
+      expect(third.hasMoreBefore).toBe(false)
     } finally {
       db.close()
     }
@@ -331,16 +382,16 @@ describe('OpenCode DB history query', () => {
       insertPart(db, 'part-d', 'message-d', { type: 'text', text: 'Final message.' })
 
       const first = readOpencodeTurnPage(db, { sessionId, limit: 2 })
-      const expectedCursor = encodeOpencodeCursor({ timeCreated: baseTime + 2_000, id: 'message-b' })
+      const expectedCursor = encodeOpencodeCursor({ timeCreated: baseTime + 2_000, id: 'message-c' })
 
-      expect(first.messages.map((message) => message.info.id)).toEqual(['message-a', 'message-b'])
+      expect(first.messages.map((message) => message.info.id)).toEqual(['message-c', 'message-d'])
       expect(first.nextCursor).toBe(expectedCursor)
 
       const second = readOpencodeTurnPage(db, { sessionId, limit: 2, cursor: first.nextCursor })
-      expect(second.messages.map((message) => message.info.id)).toEqual(['message-c', 'message-d'])
+      expect(second.messages.map((message) => message.info.id)).toEqual(['message-a', 'message-b'])
       expect(second.nextCursor).toBeNull()
 
-      const pagedIds = [...first.messages, ...second.messages].map((message) => message.info.id)
+      const pagedIds = [...second.messages, ...first.messages].map((message) => message.info.id)
       expect(pagedIds).toEqual(['message-a', 'message-b', 'message-c', 'message-d'])
       expect(new Set(pagedIds).size).toBe(pagedIds.length)
     } finally {

--- a/test/unit/server/fresh-agent/opencode-history-runner.test.ts
+++ b/test/unit/server/fresh-agent/opencode-history-runner.test.ts
@@ -1,0 +1,217 @@
+import { EventEmitter } from 'events'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createWorkerHistoryReader,
+  OpencodeHistoryReaderError,
+} from '../../../../server/fresh-agent/adapters/opencode/history-runner.js'
+
+class FakeWorker extends EventEmitter {
+  terminated = 0
+  postedData: unknown
+  execArgv: string[]
+
+  constructor(public url: URL, public options: { workerData: unknown; execArgv: string[] }) {
+    super()
+    this.postedData = options.workerData
+    this.execArgv = options.execArgv
+  }
+
+  terminate() {
+    this.terminated += 1
+    return Promise.resolve(0)
+  }
+
+  emitMessage(message: unknown) { this.emit('message', message) }
+  emitError(error: Error) { this.emit('error', error) }
+  emitExit(code: number) { this.emit('exit', code) }
+}
+
+function makeReader(overrides: Partial<Parameters<typeof createWorkerHistoryReader>[0]> = {}) {
+  const workers: FakeWorker[] = []
+  const spawn = vi.fn((url: URL, options: { workerData: unknown; execArgv: string[] }) => {
+    const worker = new FakeWorker(url, options)
+    workers.push(worker)
+    return worker
+  })
+  const reader = createWorkerHistoryReader({
+    dbPath: '/tmp/opencode.db',
+    spawn: spawn as any,
+    timeoutMs: 50,
+    ...overrides,
+  })
+  return { reader, workers, spawn }
+}
+
+describe('createWorkerHistoryReader', () => {
+  it('resolves session info from an ok message and terminates the worker', async () => {
+    const { reader, workers } = makeReader()
+    const promise = reader.readSessionInfo('ses-1')
+    await Promise.resolve()
+
+    workers[0].emitMessage({
+      ok: true,
+      result: {
+        type: 'session_info',
+        sessionInfo: { id: 'ses-1', title: 'History' },
+      },
+    })
+
+    await expect(promise).resolves.toMatchObject({ id: 'ses-1', title: 'History' })
+    expect(workers[0].terminated).toBe(1)
+  })
+
+  it('passes dbPath, request, queryModuleUrl, sentinel kind, and warning-suppression execArgv', async () => {
+    const { reader, workers } = makeReader()
+    const promise = reader.readTurnPage('ses-1', { cursor: 'opaque-cursor', limit: 3 })
+    await Promise.resolve()
+
+    const data = workers[0].postedData as any
+    expect(data.kind).toBe('opencode-history-worker')
+    expect(data.dbPath).toBe('/tmp/opencode.db')
+    expect(String(data.queryModuleUrl)).toContain('history-query')
+    expect(data.request).toEqual({
+      type: 'turn_page',
+      sessionId: 'ses-1',
+      query: { cursor: 'opaque-cursor', limit: 3 },
+    })
+    expect(workers[0].execArgv).toEqual([...process.execArgv, '--disable-warning=ExperimentalWarning'])
+
+    workers[0].emitMessage({
+      ok: true,
+      result: {
+        type: 'turn_page',
+        page: {
+          exported: { messages: [] },
+          revision: 1,
+          nextCursor: null,
+          hasMoreBefore: false,
+        },
+      },
+    })
+    await promise
+  })
+
+  it('resolves not_found responses as undefined', async () => {
+    const { reader, workers } = makeReader()
+    const promise = reader.readTurnBody('ses-1', 'missing-turn')
+    await Promise.resolve()
+
+    workers[0].emitMessage({ ok: false, reason: 'not_found' })
+
+    await expect(promise).resolves.toBeUndefined()
+    expect(workers[0].terminated).toBe(1)
+  })
+
+  it.each([
+    ['missing_db', { ok: false, reason: 'missing_db' }],
+    ['schema_mismatch', {
+      ok: false,
+      reason: 'schema_mismatch',
+      error: {
+        name: 'OpencodeHistorySchemaError',
+        message: 'missing columns',
+        code: 'OPENCODE_HISTORY_SCHEMA_ERROR',
+        table: 'session',
+        missingColumns: ['directory'],
+      },
+    }],
+    ['read_error', { ok: false, reason: 'read_error', error: { name: 'Error', message: 'boom' } }],
+  ] as const)('rejects %s responses with the typed failure reason', async (reason, message) => {
+    const { reader, workers } = makeReader()
+    const promise = reader.readSessionInfo('ses-1')
+    await Promise.resolve()
+
+    workers[0].emitMessage(message)
+
+    let caught: unknown
+    try {
+      await promise
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(OpencodeHistoryReaderError)
+    expect(caught).toMatchObject({ reason })
+  })
+
+  it.each([
+    ['ok:true without result', { ok: true }],
+    ['ok:true with malformed result', { ok: true, result: { type: 'session_info' } }],
+    ['ok:false without reason', { ok: false }],
+    ['ok:false with unknown reason', { ok: false, reason: 'other_error' }],
+    ['no ok key', { result: {} }],
+  ])('rejects malformed worker messages (%s)', async (_label, message) => {
+    const { reader, workers } = makeReader()
+    const promise = reader.readSessionInfo('ses-1')
+    await Promise.resolve()
+
+    workers[0].emitMessage(message)
+
+    await expect(promise).rejects.toThrow(/malformed/i)
+    expect(workers[0].terminated).toBe(1)
+  })
+
+  it('rejects on a worker error event and terminates', async () => {
+    const { reader, workers } = makeReader()
+    const promise = reader.readSessionInfo('ses-1')
+    await Promise.resolve()
+
+    workers[0].emitError(new Error('worker crashed'))
+
+    await expect(promise).rejects.toThrow(/worker crashed/)
+    expect(workers[0].terminated).toBe(1)
+  })
+
+  it('rejects when the worker exits before sending a message', async () => {
+    const { reader, workers } = makeReader()
+    const promise = reader.readSessionInfo('ses-1')
+    await Promise.resolve()
+
+    workers[0].emitExit(1)
+
+    await expect(promise).rejects.toThrow(/exit/i)
+  })
+
+  it('rejects and terminates on timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      const { reader, workers } = makeReader({ timeoutMs: 25 })
+      const promise = reader.readSessionInfo('ses-1')
+      await Promise.resolve()
+      const caughtPromise = promise.then(
+        () => undefined,
+        (error: unknown) => error,
+      )
+
+      await vi.advanceTimersByTimeAsync(30)
+
+      const caught = await caughtPromise
+      expect(caught).toBeInstanceOf(OpencodeHistoryReaderError)
+      expect(caught).toMatchObject({ reason: 'read_error' })
+      expect(workers[0].terminated).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects if a worker returns a different result type than requested', async () => {
+    const { reader, workers } = makeReader()
+    const promise = reader.readSessionInfo('ses-1')
+    await Promise.resolve()
+
+    workers[0].emitMessage({
+      ok: true,
+      result: {
+        type: 'turn_page',
+        page: {
+          exported: { messages: [] },
+          revision: 1,
+          nextCursor: null,
+          hasMoreBefore: false,
+        },
+      },
+    })
+
+    await expect(promise).rejects.toThrow(/returned turn_page/)
+  })
+})

--- a/test/unit/server/fresh-agent/opencode-history-worker.test.ts
+++ b/test/unit/server/fresh-agent/opencode-history-worker.test.ts
@@ -1,0 +1,225 @@
+import path from 'path'
+import os from 'os'
+import fsp from 'fs/promises'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  executeHistory,
+  OPENCODE_HISTORY_WORKER_KIND,
+} from '../../../../server/fresh-agent/adapters/opencode/history-worker.js'
+
+vi.unmock('node:sqlite')
+
+type SqliteModule = typeof import('node:sqlite')
+type DatabaseSyncConstructor = SqliteModule['DatabaseSync']
+type DatabaseSyncInstance = InstanceType<DatabaseSyncConstructor>
+
+const queryModuleUrl = new URL('../../../../server/fresh-agent/adapters/opencode/history-query.ts', import.meta.url).href
+
+describe('opencode history worker executeHistory', () => {
+  let tempDir: string
+  let DatabaseSync: DatabaseSyncConstructor
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-opencode-history-worker-'))
+    DatabaseSync = (await import('node:sqlite')).DatabaseSync
+  })
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true })
+  })
+
+  function createDatabase(name = 'opencode.db'): DatabaseSyncInstance {
+    return new DatabaseSync(path.join(tempDir, name))
+  }
+
+  function createOpenCodeSchema(db: DatabaseSyncInstance): void {
+    db.exec(`
+      CREATE TABLE session (
+        id text PRIMARY KEY,
+        directory text NOT NULL,
+        title text NOT NULL,
+        model text,
+        cost real NOT NULL DEFAULT 0,
+        tokens_input integer NOT NULL DEFAULT 0,
+        tokens_output integer NOT NULL DEFAULT 0,
+        tokens_reasoning integer NOT NULL DEFAULT 0,
+        tokens_cache_read integer NOT NULL DEFAULT 0,
+        tokens_cache_write integer NOT NULL DEFAULT 0,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL
+      );
+      CREATE TABLE message (
+        id text PRIMARY KEY,
+        session_id text NOT NULL,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        data text NOT NULL
+      );
+      CREATE TABLE part (
+        id text PRIMARY KEY,
+        message_id text NOT NULL,
+        session_id text NOT NULL,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        data text NOT NULL
+      );
+    `)
+  }
+
+  function insertSession(db: DatabaseSyncInstance, overrides: { id?: string; model?: string } = {}): void {
+    db.prepare(`
+      INSERT INTO session (
+        id,
+        directory,
+        title,
+        model,
+        cost,
+        tokens_input,
+        tokens_output,
+        tokens_reasoning,
+        tokens_cache_read,
+        tokens_cache_write,
+        time_created,
+        time_updated
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      overrides.id ?? 'ses-history-worker',
+      '/repo',
+      'Worker fixture',
+      overrides.model ?? JSON.stringify({ providerID: 'opencode-go', id: 'deepseek-v4-flash' }),
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      1000,
+      2000,
+    )
+  }
+
+  it('dynamically imports the query module and returns a structured result', async () => {
+    const dbPath = path.join(tempDir, 'opencode.db')
+    const db = createDatabase()
+    try {
+      createOpenCodeSchema(db)
+      insertSession(db)
+    } finally {
+      db.close()
+    }
+
+    const response = await executeHistory({
+      queryModuleUrl,
+      dbPath,
+      request: { type: 'session_info', sessionId: 'ses-history-worker' },
+    })
+
+    expect(response).toMatchObject({
+      ok: true,
+      result: {
+        type: 'session_info',
+        sessionInfo: { id: 'ses-history-worker', title: 'Worker fixture' },
+      },
+    })
+  })
+
+  it('returns missing_db before importing the query module', async () => {
+    const response = await executeHistory({
+      queryModuleUrl,
+      dbPath: path.join(tempDir, 'missing-opencode.db'),
+      request: { type: 'session_info', sessionId: 'missing' },
+    })
+
+    expect(response).toEqual({ ok: false, reason: 'missing_db' })
+  })
+
+  it('returns not_found when the query has no matching session', async () => {
+    const dbPath = path.join(tempDir, 'opencode.db')
+    const db = createDatabase()
+    try {
+      createOpenCodeSchema(db)
+    } finally {
+      db.close()
+    }
+
+    const response = await executeHistory({
+      queryModuleUrl,
+      dbPath,
+      request: { type: 'session_info', sessionId: 'missing-session' },
+    })
+
+    expect(response).toEqual({ ok: false, reason: 'not_found' })
+  })
+
+  it('returns schema_mismatch with typed schema details', async () => {
+    const dbPath = path.join(tempDir, 'opencode.db')
+    const db = createDatabase()
+    try {
+      db.exec(`
+        CREATE TABLE session (
+          id text PRIMARY KEY,
+          title text NOT NULL,
+          model text,
+          cost real NOT NULL DEFAULT 0,
+          tokens_input integer NOT NULL DEFAULT 0,
+          tokens_output integer NOT NULL DEFAULT 0,
+          tokens_reasoning integer NOT NULL DEFAULT 0,
+          tokens_cache_read integer NOT NULL DEFAULT 0,
+          tokens_cache_write integer NOT NULL DEFAULT 0,
+          time_created integer NOT NULL,
+          time_updated integer NOT NULL
+        );
+      `)
+    } finally {
+      db.close()
+    }
+
+    const response = await executeHistory({
+      queryModuleUrl,
+      dbPath,
+      request: { type: 'session_info', sessionId: 'ses-history-worker' },
+    })
+
+    expect(response).toMatchObject({
+      ok: false,
+      reason: 'schema_mismatch',
+      error: {
+        name: 'OpencodeHistorySchemaError',
+        code: 'OPENCODE_HISTORY_SCHEMA_ERROR',
+        table: 'session',
+        missingColumns: expect.arrayContaining(['directory']),
+      },
+    })
+  })
+
+  it('returns read_error with serialized error details for non-schema read failures', async () => {
+    const dbPath = path.join(tempDir, 'opencode.db')
+    const db = createDatabase()
+    try {
+      createOpenCodeSchema(db)
+      insertSession(db, { model: '{not-json' })
+    } finally {
+      db.close()
+    }
+
+    const response = await executeHistory({
+      queryModuleUrl,
+      dbPath,
+      request: { type: 'session_info', sessionId: 'ses-history-worker' },
+    })
+
+    expect(response).toMatchObject({
+      ok: false,
+      reason: 'read_error',
+      error: { name: 'Error' },
+    })
+    expect(response.ok === false ? response.error?.message : '').toContain('Failed to parse OpenCode session.model JSON')
+  })
+
+  it('does not auto-run on import under the threaded test runtime because of the sentinel guard', () => {
+    expect(typeof executeHistory).toBe('function')
+    expect(OPENCODE_HISTORY_WORKER_KIND).toBe('opencode-history-worker')
+    expect(queryModuleUrl).toContain('history-query')
+  })
+})

--- a/test/unit/server/fresh-agent/opencode-normalize.test.ts
+++ b/test/unit/server/fresh-agent/opencode-normalize.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  normalizeOpencodeSnapshot,
+  normalizeOpencodeTurn,
+  normalizeOpencodeTurnPage,
+} from '../../../../server/fresh-agent/adapters/opencode/normalize.js'
+import {
+  FreshAgentSnapshotSchema,
+  FreshAgentTurnPageSchema,
+} from '../../../../shared/fresh-agent-contract.js'
+
+describe('OpenCode fresh-agent normalization', () => {
+  it('maps file, patch, and compaction parts to shared transcript items', () => {
+    const turn = normalizeOpencodeTurn({
+      info: { id: 'msg-1', role: 'assistant' },
+      parts: [
+        {
+          id: 'part-file',
+          type: 'file',
+          filename: 'notes.md',
+          mime: 'text/markdown',
+          content: '# Notes',
+        },
+        {
+          id: 'part-patch',
+          type: 'patch',
+          files: [
+            'src/a.ts',
+            { file: 'src/b.ts', additions: 2, deletions: 1 },
+          ],
+          diff: '@@ -1 +1 @@',
+        },
+        {
+          id: 'part-compaction',
+          type: 'compaction',
+          summary: 'Compacted older OpenCode context.',
+        },
+      ],
+    }, 0)
+
+    expect(turn.items).toEqual([
+      {
+        id: 'part-file',
+        kind: 'text',
+        text: 'Attached file: notes.md',
+      },
+      {
+        id: 'part-patch',
+        kind: 'file_change',
+        status: 'completed',
+        changes: [
+          { path: 'src/a.ts' },
+          { file: 'src/b.ts', path: 'src/b.ts', additions: 2, deletions: 1 },
+        ],
+        extensions: {
+          opencode: expect.objectContaining({
+            id: 'part-patch',
+            type: 'patch',
+            diff: '@@ -1 +1 @@',
+          }),
+        },
+      },
+      {
+        id: 'part-compaction',
+        kind: 'context_compaction',
+      },
+    ])
+  })
+
+  it('guards missing patch files and returns an empty completed file change', () => {
+    const turn = normalizeOpencodeTurn({
+      info: { id: 'msg-patch' },
+      parts: [{ id: 'part-patch-empty', type: 'patch', diff: '@@ empty @@' }],
+    }, 0)
+
+    expect(turn.items).toEqual([
+      {
+        id: 'part-patch-empty',
+        kind: 'file_change',
+        status: 'completed',
+        changes: [],
+        extensions: {
+          opencode: expect.objectContaining({
+            id: 'part-patch-empty',
+            type: 'patch',
+            diff: '@@ empty @@',
+          }),
+        },
+      },
+    ])
+  })
+
+  it('omits structural and unknown parts from visible items while preserving raw payloads in snapshot extensions', () => {
+    const snapshot = normalizeOpencodeSnapshot({
+      sessionType: 'freshopencode',
+      threadId: 'ses-extensions',
+      exported: {
+        info: { id: 'ses-extensions', title: 'Extension payloads', time: { updated: 7 } },
+        messages: [
+          {
+            info: { id: 'msg-structural', role: 'assistant' },
+            parts: [
+              { id: 'part-step-start', type: 'step-start', phase: 'tooling', index: 1 },
+              { id: 'part-step-finish', type: 'step-finish', phase: 'tooling', duration: 23 },
+              { id: 'part-unknown', type: 'custom-opencode-part', value: { nested: true } },
+              { id: 'part-file', type: 'file', path: 'src/file.ts', mime: 'text/typescript' },
+              { id: 'part-compaction', type: 'compaction', summary: 'Trimmed context.' },
+            ],
+          },
+        ],
+      },
+    })
+
+    const parsed = FreshAgentSnapshotSchema.parse(snapshot)
+    expect(parsed.turns[0]?.items.map((item) => item.id)).toEqual(['part-file', 'part-compaction'])
+    expect(parsed.extensions.opencode).toMatchObject({
+      structuralPartTypes: [
+        { type: 'step-start', id: 'part-step-start', messageId: 'msg-structural' },
+        { type: 'step-finish', id: 'part-step-finish', messageId: 'msg-structural' },
+      ],
+      structuralPartCounts: {
+        'step-start': 1,
+        'step-finish': 1,
+      },
+      structuralParts: [
+        {
+          messageId: 'msg-structural',
+          part: { id: 'part-step-start', type: 'step-start', phase: 'tooling', index: 1 },
+        },
+        {
+          messageId: 'msg-structural',
+          part: { id: 'part-step-finish', type: 'step-finish', phase: 'tooling', duration: 23 },
+        },
+      ],
+      unsupportedPartTypes: [
+        { type: 'custom-opencode-part', id: 'part-unknown', messageId: 'msg-structural' },
+      ],
+      unsupportedParts: [
+        {
+          messageId: 'msg-structural',
+          part: { id: 'part-unknown', type: 'custom-opencode-part', value: { nested: true } },
+        },
+      ],
+      fileParts: [
+        {
+          messageId: 'msg-structural',
+          part: { id: 'part-file', type: 'file', path: 'src/file.ts', mime: 'text/typescript' },
+        },
+      ],
+      compactionParts: [
+        {
+          messageId: 'msg-structural',
+          part: { id: 'part-compaction', type: 'compaction', summary: 'Trimmed context.' },
+        },
+      ],
+    })
+  })
+
+  it('carries turn-page nextCursor explicitly and keeps export fallback compatibility', () => {
+    const explicit = normalizeOpencodeTurnPage({
+      threadId: 'ses-page',
+      exported: { messages: [], nextCursor: 'fallback-cursor' },
+      revision: 3,
+      nextCursor: 'explicit-cursor',
+    })
+    expect(FreshAgentTurnPageSchema.parse(explicit).nextCursor).toBe('explicit-cursor')
+
+    const explicitNull = normalizeOpencodeTurnPage({
+      threadId: 'ses-page',
+      exported: { messages: [], nextCursor: 'fallback-cursor' },
+      revision: 3,
+      nextCursor: null,
+    })
+    expect(FreshAgentTurnPageSchema.parse(explicitNull).nextCursor).toBeNull()
+
+    const fallback = normalizeOpencodeTurnPage({
+      threadId: 'ses-page',
+      exported: { messages: [], nextCursor: 'fallback-cursor' },
+      revision: 3,
+    })
+    expect(FreshAgentTurnPageSchema.parse(fallback).nextCursor).toBe('fallback-cursor')
+  })
+})

--- a/test/unit/server/fresh-agent/runtime-manager.test.ts
+++ b/test/unit/server/fresh-agent/runtime-manager.test.ts
@@ -182,6 +182,67 @@ describe('FreshAgentRuntimeManager', () => {
     expect(codexAdapter.compact).toHaveBeenCalledWith('thread-compact-1', { instructions: 'keep decisions' })
   })
 
+  it('registers adapter send aliases while keeping the original placeholder routable', async () => {
+    const opencodeAdapter = {
+      create: vi.fn().mockResolvedValue({
+        sessionId: 'freshopencode-req-alias',
+        sessionRef: { provider: 'opencode', sessionId: 'freshopencode-req-alias' },
+      }),
+      send: vi.fn()
+        .mockResolvedValueOnce({
+          sessionId: 'ses_real_1',
+          sessionRef: { provider: 'opencode', sessionId: 'ses_real_1' },
+        })
+        .mockResolvedValueOnce({
+          sessionId: 'ses_real_1',
+          sessionRef: { provider: 'opencode', sessionId: 'ses_real_1' },
+        })
+        .mockResolvedValueOnce({
+          sessionId: 'ses_real_1',
+          sessionRef: { provider: 'opencode', sessionId: 'ses_real_1' },
+        }),
+    }
+    const registry = createFreshAgentProviderRegistry([
+      {
+        sessionType: 'freshopencode',
+        runtimeProvider: 'opencode',
+        adapter: opencodeAdapter as any,
+      },
+    ])
+    const manager = new FreshAgentRuntimeManager({ registry })
+    await manager.create({ requestId: 'req-alias', sessionType: 'freshopencode' })
+
+    await expect(manager.send({
+      sessionId: 'freshopencode-req-alias',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+    }, { text: 'first' })).resolves.toEqual({
+      sessionId: 'ses_real_1',
+      sessionRef: { provider: 'opencode', sessionId: 'ses_real_1' },
+    })
+
+    await expect(manager.send({
+      sessionId: 'freshopencode-req-alias',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+    }, { text: 'via placeholder' })).resolves.toEqual({
+      sessionId: 'ses_real_1',
+      sessionRef: { provider: 'opencode', sessionId: 'ses_real_1' },
+    })
+    await expect(manager.send({
+      sessionId: 'ses_real_1',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+    }, { text: 'via real id' })).resolves.toEqual({
+      sessionId: 'ses_real_1',
+      sessionRef: { provider: 'opencode', sessionId: 'ses_real_1' },
+    })
+
+    expect(opencodeAdapter.send).toHaveBeenNthCalledWith(1, 'freshopencode-req-alias', { text: 'first' })
+    expect(opencodeAdapter.send).toHaveBeenNthCalledWith(2, 'freshopencode-req-alias', { text: 'via placeholder' })
+    expect(opencodeAdapter.send).toHaveBeenNthCalledWith(3, 'ses_real_1', { text: 'via real id' })
+  })
+
   it('hydrates adapter state when attaching a restored session before send and compact', async () => {
     const opencodeAdapter = {
       create: vi.fn().mockResolvedValue({ sessionId: 'opencode-created-1' }),

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -462,6 +462,77 @@ describe('WsHandler fresh-agent routing', () => {
     }
   })
 
+  it('emits freshAgent.session.materialized when send returns a new session id', async () => {
+    const runtimeManager = {
+      create: vi.fn().mockResolvedValue({
+        sessionId: 'freshopencode-req-1',
+        sessionType: 'freshopencode',
+        runtimeProvider: 'opencode',
+        sessionRef: { provider: 'opencode', sessionId: 'freshopencode-req-1' },
+      }),
+      subscribe: vi.fn().mockResolvedValue(() => undefined),
+      send: vi.fn().mockResolvedValue({
+        sessionId: 'ses_real_1',
+        sessionRef: { provider: 'opencode', sessionId: 'ses_real_1' },
+      }),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+
+    try {
+      const ws = await connectAndAuth(server)
+      const seenMessages: any[] = []
+      ws.on('message', (data) => {
+        seenMessages.push(JSON.parse(data.toString()))
+      })
+
+      ws.send(JSON.stringify({
+        type: 'freshAgent.create',
+        requestId: 'req-materialize',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+      }))
+
+      await vi.waitFor(() => {
+        expect(seenMessages).toContainEqual(expect.objectContaining({
+          type: 'freshAgent.created',
+          sessionId: 'freshopencode-req-1',
+        }))
+      })
+
+      ws.send(JSON.stringify({
+        type: 'freshAgent.send',
+        sessionId: 'freshopencode-req-1',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        text: 'Ship it',
+      }))
+
+      await vi.waitFor(() => {
+        expect(runtimeManager.send).toHaveBeenCalledWith({
+          sessionId: 'freshopencode-req-1',
+          sessionType: 'freshopencode',
+          provider: 'opencode',
+        }, {
+          text: 'Ship it',
+          images: undefined,
+          settings: undefined,
+        })
+        expect(seenMessages).toContainEqual({
+          type: 'freshAgent.session.materialized',
+          previousSessionId: 'freshopencode-req-1',
+          sessionId: 'ses_real_1',
+          sessionType: 'freshopencode',
+          provider: 'opencode',
+          sessionRef: { provider: 'opencode', sessionId: 'ses_real_1' },
+        })
+      })
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
   it('routes freshAgent.compact through the runtime manager', async () => {
     const runtimeManager = {
       create: vi.fn().mockResolvedValue({

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -517,6 +517,10 @@ describe('WsHandler fresh-agent routing', () => {
           images: undefined,
           settings: undefined,
         })
+        expect(runtimeManager.subscribe).toHaveBeenCalledWith(
+          { sessionId: 'ses_real_1', sessionType: 'freshopencode', provider: 'opencode' },
+          expect.any(Function),
+        )
         expect(seenMessages).toContainEqual({
           type: 'freshAgent.session.materialized',
           previousSessionId: 'freshopencode-req-1',


### PR DESCRIPTION
## Summary
- read Freshopencode/OpenCode session history from the OpenCode SQLite database before falling back to export
- materialize placeholder Freshopencode sessions only from authoritative run output and wire alias promotion through server, WebSocket, and client state
- add fake OpenCode DB support plus e2e regression coverage for DB-backed restore and non-inferred placeholders

## Verification
- npm run check
- npm run test:e2e:chromium -- test/e2e-browser/specs/freshopencode-db-history.spec.ts
- focused Vitest suites for OpenCode history, adapter, runtime manager, WebSocket, client FreshAgentView, and protocol contracts

## Follow-up
- Kata ywwf tracks the unrelated stale initialCwd OpenCode restart recovery failure found during verification.