### PR TITLE
Fix legacy Freshopencode placeholder restore

### DIFF
--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -198,6 +198,58 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
     }
   }
 
+  async function resolveLegacyPlaceholderResume(input: FreshAgentCreateRequest, placeholderId: string): Promise<OpencodeSessionState> {
+    const context = input.legacyRestoreContext
+    const title = typeof context?.title === 'string' ? context.title : undefined
+    const createdAt = typeof context?.createdAt === 'number' ? context.createdAt : undefined
+    const updatedAt = typeof context?.updatedAt === 'number' ? context.updatedAt : undefined
+    if (!input.cwd || (!title && createdAt === undefined && updatedAt === undefined)) {
+      throw new FreshAgentLostSessionError(`OpenCode session ${placeholderId} is not a durable OpenCode session.`)
+    }
+
+    let resolved: Awaited<ReturnType<OpencodeHistoryReader['resolveLegacySession']>>
+    try {
+      resolved = await historyReader.resolveLegacySession({
+        cwd: input.cwd,
+        title,
+        createdAt,
+        updatedAt,
+      })
+    } catch (error) {
+      logHistoryWarning(
+        'legacy_placeholder_resolve_failed',
+        'OpenCode legacy placeholder resolution failed.',
+        { error, sessionId: placeholderId, extra: { cwd: input.cwd, title, createdAt, updatedAt } },
+      )
+      throw new FreshAgentLostSessionError(`OpenCode session ${placeholderId} is not a durable OpenCode session.`)
+    }
+
+    if (!resolved?.id || !isRealOpencodeSessionId(resolved.id)) {
+      throw new FreshAgentLostSessionError(`OpenCode session ${placeholderId} is not a durable OpenCode session.`)
+    }
+
+    log.info({
+      messageClass: 'legacy_placeholder_resolved',
+      placeholderSessionId: placeholderId,
+      sessionId: resolved.id,
+      cwd: input.cwd,
+      title,
+    }, 'Resolved legacy Freshopencode placeholder to durable OpenCode session.')
+
+    const state: OpencodeSessionState = {
+      placeholderId,
+      realSessionId: resolved.id,
+      cwd: resolved.directory ?? input.cwd,
+      model: input.model,
+      effort: input.effort,
+      status: 'idle',
+      events: new EventEmitter(),
+      sendQueue: Promise.resolve(),
+    }
+    remember(state)
+    return state
+  }
+
   function runCli(
     args: string[],
     cwd?: string,
@@ -354,7 +406,11 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       const normalized = normalizeOpencodeInput(input)
       const sessionId = normalized.resumeSessionId
       if (!sessionId) throw new Error('OpenCode resume requires a session id.')
-      if (isPlaceholderOpencodeSessionId(sessionId) || !isRealOpencodeSessionId(sessionId)) {
+      if (isPlaceholderOpencodeSessionId(sessionId)) {
+        const state = await resolveLegacyPlaceholderResume(normalized, sessionId)
+        return { sessionId: state.realSessionId!, sessionRef: { provider: 'opencode', sessionId: state.realSessionId! } }
+      }
+      if (!isRealOpencodeSessionId(sessionId)) {
         throw new FreshAgentLostSessionError(`OpenCode session ${sessionId} is not a durable OpenCode session.`)
       }
       const state: OpencodeSessionState = {

--- a/server/fresh-agent/adapters/opencode/history-query.ts
+++ b/server/fresh-agent/adapters/opencode/history-query.ts
@@ -18,17 +18,26 @@ export type OpencodeTurnBodyResult = {
   revision: number
 }
 
+export type OpencodeLegacySessionResolveInput = {
+  cwd?: string
+  title?: string
+  createdAt?: number
+  updatedAt?: number
+}
+
 export type OpencodeHistoryExportPage = OpencodeHistoryPage & OpencodeExport
 export type OpencodeHistoryTurnBody = OpencodeTurnBodyResult & NonNullable<OpencodeExport['messages']>[number]
 
 export type OpencodeHistoryReadRequest =
   | { type: 'session_info'; sessionId: string }
+  | { type: 'legacy_session'; query: OpencodeLegacySessionResolveInput }
   | { type: 'snapshot_page'; sessionId: string; limit?: number }
   | { type: 'turn_page'; sessionId: string; query?: { cursor?: string; limit?: number } }
   | { type: 'turn_body'; sessionId: string; turnId: string }
 
 export type OpencodeHistoryReadResult =
   | { type: 'session_info'; sessionInfo: OpencodeSessionInfo }
+  | { type: 'legacy_session'; sessionInfo: OpencodeSessionInfo }
   | { type: 'snapshot_page'; page: OpencodeHistoryExportPage }
   | { type: 'turn_page'; page: OpencodeHistoryExportPage }
   | { type: 'turn_body'; body: OpencodeHistoryTurnBody }
@@ -80,6 +89,38 @@ type HydratedMessage = NonNullable<OpencodeExport['messages']>[number]
 const OPENCODE_DB_BUSY_TIMEOUT_MS = 5000
 
 export const DEFAULT_SNAPSHOT_TURN_LIMIT = 200
+
+const LEGACY_PLACEHOLDER_LOOKAHEAD_MS = 24 * 60 * 60_000
+const LEGACY_PLACEHOLDER_LOOKBEHIND_MS = 5 * 60_000
+const LEGACY_PLACEHOLDER_CANDIDATE_LIMIT = 50
+const LEGACY_TITLE_STOP_WORDS = new Set([
+  'the',
+  'and',
+  'for',
+  'from',
+  'into',
+  'onto',
+  'that',
+  'this',
+  'with',
+  'your',
+  'ours',
+  'mine',
+  'have',
+  'has',
+  'had',
+  'are',
+  'was',
+  'were',
+  'can',
+  'cannot',
+  'cant',
+  'dont',
+  'list',
+  'all',
+  'each',
+  'one',
+])
 
 const SESSION_REQUIRED_COLUMNS = [
   'id',
@@ -199,6 +240,36 @@ function numberValue(value: unknown): number | undefined {
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function normalizedTitleTokens(value: unknown): Set<string> {
+  const text = stringValue(value)
+  if (!text) return new Set()
+  const tokens = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 3 && !LEGACY_TITLE_STOP_WORDS.has(token))
+    .map((token) => token.endsWith('s') && token.length > 4 ? token.slice(0, -1) : token)
+  return new Set(tokens)
+}
+
+function titleOverlapScore(left: Set<string>, right: Set<string>): number {
+  let overlap = 0
+  for (const token of left) {
+    if (right.has(token)) overlap += 1
+  }
+  return overlap
+}
+
+function hasLegacyTitleMatch(queryTokens: Set<string>, candidateTitle: unknown): boolean {
+  if (queryTokens.size === 0) return true
+  const candidateTokens = normalizedTitleTokens(candidateTitle)
+  if (candidateTokens.size === 0) return false
+  const overlap = titleOverlapScore(queryTokens, candidateTokens)
+  const requiredOverlap = Math.min(2, queryTokens.size, candidateTokens.size)
+  return overlap >= requiredOverlap
 }
 
 function setIfString(target: Record<string, unknown>, key: string, value: unknown): void {
@@ -414,6 +485,52 @@ export function readOpencodeSessionInfo(
   })
 }
 
+export function resolveOpencodeLegacySession(
+  db: DatabaseLike,
+  input: OpencodeLegacySessionResolveInput,
+): OpencodeSessionInfo | undefined {
+  const cwd = stringValue(input.cwd)
+  if (!cwd) return undefined
+  const createdAt = numberValue(input.createdAt)
+  const updatedAt = numberValue(input.updatedAt)
+  const titleTokens = normalizedTitleTokens(input.title)
+  if (createdAt === undefined && updatedAt === undefined && titleTokens.size === 0) return undefined
+
+  return withReadTransaction(db, () => {
+    const sessionColumns = requireColumns(db, 'session', SESSION_REQUIRED_COLUMNS)
+    const filters = ['s.id LIKE ?', 's.directory = ?']
+    const params: unknown[] = ['ses_%', cwd]
+
+    if (sessionColumns.has('time_archived')) {
+      filters.push('s.time_archived IS NULL')
+    }
+    if (sessionColumns.has('parent_id')) {
+      filters.push('s.parent_id IS NULL')
+    }
+    const anchor = createdAt ?? updatedAt
+    if (anchor !== undefined) {
+      filters.push('s.time_created >= ?')
+      params.push(anchor - LEGACY_PLACEHOLDER_LOOKBEHIND_MS)
+      filters.push('s.time_created <= ?')
+      params.push(anchor + LEGACY_PLACEHOLDER_LOOKAHEAD_MS)
+    }
+
+    const rows = db.prepare(`
+      SELECT ${sessionSelectList(sessionColumns)}
+      FROM session s
+      WHERE ${filters.join('\n        AND ')}
+      ORDER BY s.time_created DESC, s.id DESC
+      LIMIT ?
+    `).all(...params, LEGACY_PLACEHOLDER_CANDIDATE_LIMIT) as SessionRow[]
+
+    const matches = rows
+      .filter((row) => hasLegacyTitleMatch(titleTokens, row.title))
+      .map(hydrateSessionInfo)
+
+    return matches.length === 1 ? matches[0] : undefined
+  })
+}
+
 export function readOpencodeSnapshotPage(
   db: DatabaseLike,
   input: { sessionId: string; limit?: number },
@@ -519,6 +636,10 @@ export async function runOpencodeHistoryQuery(
       case 'session_info': {
         const sessionInfo = readOpencodeSessionInfo(db, { sessionId: input.request.sessionId })
         return sessionInfo ? { type: 'session_info', sessionInfo } : undefined
+      }
+      case 'legacy_session': {
+        const sessionInfo = resolveOpencodeLegacySession(db, input.request.query)
+        return sessionInfo ? { type: 'legacy_session', sessionInfo } : undefined
       }
       case 'snapshot_page': {
         const page = readOpencodeSnapshotPage(db, {

--- a/server/fresh-agent/adapters/opencode/history-runner.ts
+++ b/server/fresh-agent/adapters/opencode/history-runner.ts
@@ -1,6 +1,7 @@
 import { Worker } from 'node:worker_threads'
 import type {
   OpencodeHistoryPage,
+  OpencodeLegacySessionResolveInput,
   OpencodeHistoryReadRequest,
   OpencodeHistoryReadResult,
   OpencodeHistoryTurnBody,
@@ -19,6 +20,7 @@ import {
 
 export type OpencodeHistoryReader = {
   readSessionInfo(sessionId: string): Promise<OpencodeSessionInfo | undefined>
+  resolveLegacySession(input: OpencodeLegacySessionResolveInput): Promise<OpencodeSessionInfo | undefined>
   readSnapshotPage(sessionId: string, limit?: number): Promise<OpencodeHistoryPage | undefined>
   readTurnPage(sessionId: string, query: { cursor?: string; limit?: number }): Promise<OpencodeHistoryPage | undefined>
   readTurnBody(sessionId: string, turnId: string): Promise<OpencodeTurnBodyResult | undefined>
@@ -86,6 +88,8 @@ function isReadResult(value: unknown): value is OpencodeHistoryReadResult {
   if (!isObject(value) || typeof value.type !== 'string') return false
   switch (value.type) {
     case 'session_info':
+      return isObject(value.sessionInfo)
+    case 'legacy_session':
       return isObject(value.sessionInfo)
     case 'snapshot_page':
     case 'turn_page':
@@ -205,6 +209,9 @@ export function createWorkerHistoryReader(
     async readSessionInfo(sessionId) {
       return resultForType(await run({ type: 'session_info', sessionId }), 'session_info')?.sessionInfo
     },
+    async resolveLegacySession(input) {
+      return resultForType(await run({ type: 'legacy_session', query: input }), 'legacy_session')?.sessionInfo
+    },
     async readSnapshotPage(sessionId, limit) {
       return resultForType(await run({ type: 'snapshot_page', sessionId, limit }), 'snapshot_page')?.page
     },
@@ -228,6 +235,9 @@ export function createInProcessHistoryReader(options: { dbPath: string }): Openc
   return {
     async readSessionInfo(sessionId) {
       return resultForType(await run({ type: 'session_info', sessionId }), 'session_info')?.sessionInfo
+    },
+    async resolveLegacySession(input) {
+      return resultForType(await run({ type: 'legacy_session', query: input }), 'legacy_session')?.sessionInfo
     },
     async readSnapshotPage(sessionId, limit) {
       return resultForType(await run({ type: 'snapshot_page', sessionId, limit }), 'snapshot_page')?.page

--- a/server/fresh-agent/runtime-adapter.ts
+++ b/server/fresh-agent/runtime-adapter.ts
@@ -6,6 +6,11 @@ export type FreshAgentCreateRequest = {
   sessionType: FreshAgentSessionType
   provider?: FreshAgentRuntimeProvider
   cwd?: string
+  legacyRestoreContext?: {
+    title?: string
+    createdAt?: number
+    updatedAt?: number
+  }
   resumeSessionId?: string
   sessionRef?: { provider: string; sessionId: string }
   model?: string

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -3589,6 +3589,7 @@ export class WsHandler {
               sessionType: m.sessionType,
               provider: m.provider,
               cwd: m.cwd,
+              legacyRestoreContext: m.legacyRestoreContext,
               resumeSessionId: m.resumeSessionId,
               sessionRef: m.sessionRef,
               model: m.model,

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -467,6 +467,11 @@ export const FreshAgentCreateSchema = z.object({
   sessionType: z.enum(['freshclaude', 'freshcodex', 'kilroy', 'freshopencode']),
   provider: z.enum(['claude', 'codex', 'opencode']).optional(),
   cwd: z.string().optional(),
+  legacyRestoreContext: z.object({
+    title: z.string().min(1).optional(),
+    createdAt: z.number().finite().optional(),
+    updatedAt: z.number().finite().optional(),
+  }).optional(),
   resumeSessionId: z.string().optional(),
   model: z.string().optional(),
   permissionMode: z.string().optional(),

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -76,6 +76,13 @@ function getCanonicalPaneResumeSessionId(pane: FreshAgentPaneContent): string | 
   return undefined
 }
 
+function isFreshOpencodePlaceholderId(pane: FreshAgentPaneContent, sessionId: string | undefined): boolean {
+  return pane.provider === 'opencode'
+    && pane.sessionType === 'freshopencode'
+    && typeof sessionId === 'string'
+    && sessionId.startsWith('freshopencode-')
+}
+
 function getFreshAgentSnapshotThreadId(
   pane: FreshAgentPaneContent,
   claudeSession: Parameters<typeof getCanonicalDurableSessionId>[0],
@@ -91,8 +98,15 @@ function getFreshAgentSnapshotThreadId(
     // While a new session is still being created, avoid reading an older durable ref.
     return pane.sessionId
   }
+  const sessionRefId = pane.sessionRef?.provider === pane.provider ? pane.sessionRef.sessionId : undefined
+  if (!pane.sessionId && isFreshOpencodePlaceholderId(pane, sessionRefId)) {
+    // Legacy Freshopencode panes could persist only the placeholder sessionRef.
+    // Let freshAgent.create/resume repair it before snapshot loading; otherwise
+    // the placeholder 404 races the promotion and marks the pane unrecoverable.
+    return undefined
+  }
   return pane.sessionId
-    ?? (pane.sessionRef?.provider === pane.provider ? pane.sessionRef.sessionId : undefined)
+    ?? sessionRefId
 }
 
 function getCreatedResumeSessionId(
@@ -103,6 +117,25 @@ function getCreatedResumeSessionId(
   if (message.sessionRef?.provider === current.provider) return message.sessionRef.sessionId
   if (current.provider === 'claude' && !isValidClaudeSessionId(message.sessionId)) return undefined
   return message.sessionId
+}
+
+function buildLegacyRestoreContext(tab: { title?: string; createdAt?: number; updatedAt?: number } | undefined) {
+  if (!tab) return undefined
+  const title = typeof tab.title === 'string' && tab.title.trim().length > 0
+    ? tab.title.trim()
+    : undefined
+  const createdAt = typeof tab.createdAt === 'number' && Number.isFinite(tab.createdAt)
+    ? tab.createdAt
+    : undefined
+  const updatedAt = typeof tab.updatedAt === 'number' && Number.isFinite(tab.updatedAt)
+    ? tab.updatedAt
+    : undefined
+  if (!title && createdAt === undefined && updatedAt === undefined) return undefined
+  return {
+    ...(title ? { title } : {}),
+    ...(createdAt !== undefined ? { createdAt } : {}),
+    ...(updatedAt !== undefined ? { updatedAt } : {}),
+  }
 }
 
 function getQuestionAgentLabel(paneContent: FreshAgentPaneContent, descriptorLabel?: string): string {
@@ -210,6 +243,9 @@ export function FreshAgentView({
   const pendingCreateFailure = useAppSelector(
     (state) => state.freshAgent?.pendingCreateFailures?.[paneContent.createRequestId],
   )
+  const tabRestoreSource = useAppSelector((state) => (
+    state.tabs?.tabs?.find((tab) => tab.id === tabId)
+  ))
   const claudeSession = useAppSelector((state) => {
     if (paneContent.provider !== 'claude' || !paneContent.sessionId) return undefined
     const sessionKey = makeFreshAgentSessionKey({
@@ -427,22 +463,28 @@ export function FreshAgentView({
     snapshotConfirmsUserTurns,
   ])
 
-  const buildCreateMessage = useCallback((content: FreshAgentPaneContent) => ({
-    type: 'freshAgent.create',
-    requestId: content.createRequestId,
-    sessionType: content.sessionType,
-    provider: content.provider,
-    cwd: content.initialCwd,
-    resumeSessionId: content.resumeSessionId
-      ?? (content.sessionRef?.provider === content.provider ? content.sessionRef.sessionId : undefined),
-    sessionRef: content.sessionRef,
-    modelSelection: content.modelSelection,
-    model: getEffectiveFreshAgentModel(content),
-    ...(getEffectiveFreshAgentPermissionMode(content) ? { permissionMode: getEffectiveFreshAgentPermissionMode(content) } : {}),
-    sandbox: content.sandbox,
-    effort: getEffectiveFreshAgentEffort(content),
-    plugins: content.plugins,
-  } as const), [])
+  const buildCreateMessage = useCallback((content: FreshAgentPaneContent) => {
+    const legacyRestoreContext = content.provider === 'opencode'
+      ? buildLegacyRestoreContext(tabRestoreSource)
+      : undefined
+    return {
+      type: 'freshAgent.create',
+      requestId: content.createRequestId,
+      sessionType: content.sessionType,
+      provider: content.provider,
+      cwd: content.initialCwd,
+      ...(legacyRestoreContext ? { legacyRestoreContext } : {}),
+      resumeSessionId: content.resumeSessionId
+        ?? (content.sessionRef?.provider === content.provider ? content.sessionRef.sessionId : undefined),
+      sessionRef: content.sessionRef,
+      modelSelection: content.modelSelection,
+      model: getEffectiveFreshAgentModel(content),
+      ...(getEffectiveFreshAgentPermissionMode(content) ? { permissionMode: getEffectiveFreshAgentPermissionMode(content) } : {}),
+      sandbox: content.sandbox,
+      effort: getEffectiveFreshAgentEffort(content),
+      plugins: content.plugins,
+    } as const
+  }, [tabRestoreSource])
 
   const startNewConversation = useCallback(() => {
     const current = paneContentRef.current

--- a/test/e2e-browser/specs/freshopencode-db-history.spec.ts
+++ b/test/e2e-browser/specs/freshopencode-db-history.spec.ts
@@ -3,6 +3,7 @@ import fsp from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { DatabaseSync } from 'node:sqlite'
 import { openPanePicker } from '../helpers/pane-picker.js'
 import { TestHarness } from '../helpers/test-harness.js'
 import { TestServer } from '../helpers/test-server.js'
@@ -138,6 +139,108 @@ async function sendFreshAgentPrompt(page: Page, prompt: string): Promise<void> {
   await page.getByRole('button', { name: 'Send' }).click()
 }
 
+async function seedLegacyOpencodeSession(input: {
+  sharedOpencodeDataDir: string
+  cwd: string
+  sessionId: string
+  title: string
+  prompt: string
+  response: string
+  createdAt: number
+}): Promise<void> {
+  await fsp.mkdir(input.sharedOpencodeDataDir, { recursive: true })
+  const db = new DatabaseSync(path.join(input.sharedOpencodeDataDir, 'opencode.db'))
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS project (
+        id text PRIMARY KEY,
+        worktree text
+      );
+      CREATE TABLE IF NOT EXISTS session (
+        id text PRIMARY KEY,
+        project_id text NOT NULL,
+        workspace_id text,
+        parent_id text,
+        slug text NOT NULL,
+        directory text NOT NULL,
+        path text,
+        title text NOT NULL,
+        version text NOT NULL,
+        share_url text,
+        summary_additions integer,
+        summary_deletions integer,
+        summary_files integer,
+        summary_diffs text,
+        metadata text,
+        cost real NOT NULL DEFAULT 0,
+        tokens_input integer NOT NULL DEFAULT 0,
+        tokens_output integer NOT NULL DEFAULT 0,
+        tokens_reasoning integer NOT NULL DEFAULT 0,
+        tokens_cache_read integer NOT NULL DEFAULT 0,
+        tokens_cache_write integer NOT NULL DEFAULT 0,
+        revert text,
+        permission text,
+        agent text,
+        model text NOT NULL,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        time_compacting integer,
+        time_archived integer
+      );
+      CREATE TABLE IF NOT EXISTS message (
+        id text PRIMARY KEY,
+        session_id text NOT NULL,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        data text NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS part (
+        id text PRIMARY KEY,
+        message_id text NOT NULL,
+        session_id text NOT NULL,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        data text NOT NULL
+      );
+    `)
+    db.prepare('INSERT OR REPLACE INTO project (id, worktree) VALUES (?, ?)').run('proj-legacy', input.cwd)
+    db.prepare(`
+      INSERT OR REPLACE INTO session (
+        id, project_id, workspace_id, parent_id, slug, directory, path, title, version,
+        share_url, summary_additions, summary_deletions, summary_files, summary_diffs,
+        metadata, cost, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read,
+        tokens_cache_write, revert, permission, agent, model, time_created, time_updated,
+        time_compacting, time_archived
+      )
+      VALUES (?, 'proj-legacy', NULL, NULL, ?, ?, ?, ?, 'fake-opencode-e2e',
+        NULL, 0, 0, 0, NULL, NULL, 0, 0, 0, 0, 0, 0, NULL, NULL, 'fake',
+        ?, ?, ?, NULL, NULL)
+    `).run(
+      input.sessionId,
+      input.sessionId,
+      input.cwd,
+      input.cwd,
+      input.title,
+      JSON.stringify({ providerID: 'opencode', modelID: 'fake-opencode' }),
+      input.createdAt,
+      input.createdAt + 2_000,
+    )
+
+    const userMessageId = `${input.sessionId}_legacy_user`
+    const assistantMessageId = `${input.sessionId}_legacy_assistant`
+    db.prepare('INSERT OR REPLACE INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)')
+      .run(userMessageId, input.sessionId, input.createdAt, input.createdAt, JSON.stringify({ role: 'user' }))
+    db.prepare('INSERT OR REPLACE INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)')
+      .run(`${userMessageId}_part`, userMessageId, input.sessionId, input.createdAt, input.createdAt, JSON.stringify({ type: 'text', text: input.prompt }))
+    db.prepare('INSERT OR REPLACE INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)')
+      .run(assistantMessageId, input.sessionId, input.createdAt + 1_000, input.createdAt + 1_000, JSON.stringify({ role: 'assistant' }))
+    db.prepare('INSERT OR REPLACE INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)')
+      .run(`${assistantMessageId}_part`, assistantMessageId, input.sessionId, input.createdAt + 1_000, input.createdAt + 1_000, JSON.stringify({ type: 'text', text: input.response }))
+  } finally {
+    db.close()
+  }
+}
+
 test.describe('Freshopencode DB history restore', () => {
   test.setTimeout(180_000)
 
@@ -269,6 +372,108 @@ test.describe('Freshopencode DB history restore', () => {
         },
         status: 'idle',
       })
+    } finally {
+      await server.stop().catch(() => {})
+      await fsp.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  test('repairs a persisted legacy placeholder from a unique DB session', async ({ page }) => {
+    const sharedRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-freshopencode-legacy-'))
+    const binDir = path.join(sharedRoot, 'bin')
+    const logsDir = path.join(sharedRoot, 'logs')
+    const auditLogPath = path.join(sharedRoot, 'fake-opencode-audit.jsonl')
+    const sharedOpencodeDataDir = path.join(sharedRoot, 'opencode-data')
+    const cwd = path.join(sharedRoot, 'project')
+    const sessionId = 'ses_legacy_unique'
+    const placeholderId = 'freshopencode--legacyUnique'
+    const prompt = 'Which skills come from public repos'
+    const response = 'Only the unique legacy DB session should render'
+    const tabCreatedAt = Date.now()
+    await fsp.mkdir(cwd, { recursive: true })
+    await installFakeOpencode(binDir)
+    await seedLegacyOpencodeSession({
+      sharedOpencodeDataDir,
+      cwd,
+      sessionId,
+      title: 'Skills from public repos',
+      prompt,
+      response,
+      createdAt: tabCreatedAt + 60_000,
+    })
+
+    const server = new TestServer(createServerOptions({
+      binDir,
+      auditLogPath,
+      logsDir,
+      sharedOpencodeDataDir,
+      env: {
+        FAKE_OPENCODE_TRUNCATE_EXPORT: '1',
+      },
+    }))
+
+    try {
+      const info = await server.start()
+      await page.goto(`${info.baseUrl}/?token=${info.token}&e2e=1`)
+      const harness = new TestHarness(page)
+      await harness.waitForHarness()
+      await harness.waitForConnection()
+      await enableFreshOpencode(page)
+
+      await page.evaluate(({ cwd, placeholderId, tabCreatedAt }) => {
+        const harness = window.__FRESHELL_TEST_HARNESS__
+        harness?.dispatch({
+          type: 'tabs/addTab',
+          payload: {
+            id: 'tab-legacy-freshopencode',
+            title: 'Identifying skills from GitHub repos',
+            mode: 'shell',
+            status: 'running',
+          },
+        })
+        harness?.dispatch({
+          type: 'tabs/updateTab',
+          payload: {
+            id: 'tab-legacy-freshopencode',
+            updates: {
+              title: 'Identifying skills from GitHub repos',
+              createdAt: tabCreatedAt,
+            },
+          },
+        })
+        harness?.dispatch({
+          type: 'panes/initLayout',
+          payload: {
+            tabId: 'tab-legacy-freshopencode',
+            paneId: 'pane-legacy-freshopencode',
+            content: {
+              kind: 'fresh-agent',
+              sessionType: 'freshopencode',
+              provider: 'opencode',
+              createRequestId: '-legacyUnique',
+              sessionRef: { provider: 'opencode', sessionId: placeholderId },
+              initialCwd: cwd,
+              status: 'connected',
+            },
+          },
+        })
+        harness?.dispatch({ type: 'tabs/setActiveTab', payload: 'tab-legacy-freshopencode' })
+      }, { cwd, placeholderId, tabCreatedAt })
+
+      await expect(page.getByText(prompt)).toBeVisible({ timeout: 30_000 })
+      await expect(page.getByText(response)).toBeVisible({ timeout: 30_000 })
+      await expect.poll(async () => getFreshOpencodePaneState(page), { timeout: 30_000 }).toMatchObject({
+        sessionId,
+        resumeSessionId: sessionId,
+        sessionRef: {
+          provider: 'opencode',
+          sessionId,
+        },
+      })
+
+      const auditEvents = await readAuditEvents(auditLogPath)
+      expect(auditEvents.some((event) => event.event === 'export')).toBe(false)
+      expect(auditEvents.some((event) => event.event === 'run')).toBe(false)
     } finally {
       await server.stop().catch(() => {})
       await fsp.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -490,6 +490,57 @@ describe('FreshAgentView', () => {
     })
   })
 
+  it('sends tab restore context when recreating a legacy freshopencode placeholder', async () => {
+    const store = createStore()
+    store.dispatch(updateTab({
+      id: 'tab-1',
+      updates: {
+        title: 'Identifying skills from GitHub repos',
+        createdAt: 1_781_291_230_743,
+      },
+    }))
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: '-gP4qyCL7bwp8-xbw9G7b',
+        sessionRef: { provider: 'opencode', sessionId: 'freshopencode--gP4qyCL7bwp8-xbw9G7b' },
+        initialCwd: '/home/dan/code',
+        status: 'connected',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(sentFreshAgentMessages('freshAgent.create').at(-1)).toMatchObject({
+        requestId: '-gP4qyCL7bwp8-xbw9G7b',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        cwd: '/home/dan/code',
+        resumeSessionId: 'freshopencode--gP4qyCL7bwp8-xbw9G7b',
+        legacyRestoreContext: {
+          title: 'Identifying skills from GitHub repos',
+          createdAt: 1_781_291_230_743,
+          updatedAt: expect.any(Number),
+        },
+      })
+    })
+    expect(apiMock.getFreshAgentThreadSnapshot).not.toHaveBeenCalledWith(
+      'freshopencode',
+      'opencode',
+      'freshopencode--gP4qyCL7bwp8-xbw9G7b',
+      expect.any(Object),
+    )
+  })
+
   it('clears a restored Freshopencode placeholder when history reports FRESH_AGENT_LOST_SESSION', async () => {
     const store = createStore()
     apiMock.getFreshAgentThreadSnapshot.mockRejectedValueOnce({

--- a/test/unit/server/fresh-agent/opencode-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-adapter.test.ts
@@ -57,6 +57,7 @@ function deferred<T = void>() {
 function makeHistoryReader(overrides: Partial<OpencodeHistoryReader> = {}): OpencodeHistoryReader {
   return {
     readSessionInfo: vi.fn().mockRejectedValue(new OpencodeHistoryReaderError('missing_db', 'missing db')),
+    resolveLegacySession: vi.fn().mockResolvedValue(undefined),
     readSnapshotPage: vi.fn().mockRejectedValue(new OpencodeHistoryReaderError('missing_db', 'missing db')),
     readTurnPage: vi.fn().mockRejectedValue(new OpencodeHistoryReaderError('missing_db', 'missing db')),
     readTurnBody: vi.fn().mockRejectedValue(new OpencodeHistoryReaderError('missing_db', 'missing db')),
@@ -263,6 +264,64 @@ describe('OpenCode fresh-agent adapter', () => {
 
     expect(historyReader.readSessionInfo).toHaveBeenCalledWith('ses_restored_1')
     expect(cwdCalls[0]).toBe('/db/resume-repo')
+  })
+
+  it('promotes a restored legacy freshopencode placeholder to a unique DB session on resume', async () => {
+    const restoredExport = {
+      ...exportedSession,
+      info: { ...exportedSession.info, id: 'ses_legacy_real', title: 'Skills from public repos' },
+    }
+    const historyReader = makeHistoryReader({
+      resolveLegacySession: vi.fn().mockResolvedValue({
+        id: 'ses_legacy_real',
+        directory: '/home/dan/code',
+        title: 'Skills from public repos',
+        time: { created: 1_781_294_496_953, updated: 1_781_301_483_332 },
+      }),
+      readSnapshotPage: vi.fn().mockResolvedValue({
+        exported: restoredExport,
+        ...restoredExport,
+        revision: 1_781_301_483_332,
+        nextCursor: null,
+        hasMoreBefore: false,
+      }),
+    })
+    const adapter = createOpencodeFreshAgentAdapter({
+      spawnFn: makeSpawn({}).spawnFn as any,
+      historyReader,
+    })
+
+    const resumed = await adapter.resume?.({
+      requestId: '-gP4qyCL7bwp8-xbw9G7b',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      cwd: '/home/dan/code',
+      resumeSessionId: 'freshopencode--gP4qyCL7bwp8-xbw9G7b',
+      legacyRestoreContext: {
+        title: 'Identifying skills from GitHub repos',
+        createdAt: 1_781_291_230_743,
+        updatedAt: 1_781_291_259_546,
+      },
+    })
+
+    expect(resumed).toEqual({
+      sessionId: 'ses_legacy_real',
+      sessionRef: { provider: 'opencode', sessionId: 'ses_legacy_real' },
+    })
+    expect(historyReader.resolveLegacySession).toHaveBeenCalledWith({
+      cwd: '/home/dan/code',
+      title: 'Identifying skills from GitHub repos',
+      createdAt: 1_781_291_230_743,
+      updatedAt: 1_781_291_259_546,
+    })
+    await expect(adapter.getSnapshot?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'freshopencode--gP4qyCL7bwp8-xbw9G7b',
+    })).resolves.toMatchObject({
+      sessionId: 'ses_legacy_real',
+      summary: 'Skills from public repos',
+    })
   })
 
   it('uses DB history before export and does not call truncated export when DB succeeds', async () => {

--- a/test/unit/server/fresh-agent/opencode-history-query.test.ts
+++ b/test/unit/server/fresh-agent/opencode-history-query.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   encodeOpencodeCursor,
+  resolveOpencodeLegacySession,
   readOpencodeSessionInfo,
   readOpencodeSnapshotPage,
   readOpencodeTurnBody,
@@ -435,6 +436,80 @@ describe('OpenCode DB history query', () => {
       const body = readOpencodeTurnBody(db, { sessionId, turnId: 'primary-message-2' })
       expect(body?.parts.map((part) => part.id)).toEqual(['primary-part-2'])
       expect(readOpencodeTurnBody(db, { sessionId, turnId: 'other-message-1' })).toBeNull()
+    } finally {
+      db.close()
+    }
+  })
+
+  it('resolves a legacy freshopencode placeholder to one same-cwd title/time candidate', () => {
+    const db = createDatabase()
+    try {
+      createOpenCodeSchema(db)
+      insertSession(db, {
+        id: 'ses_legacy_match',
+        directory: '/home/dan/code',
+        title: 'Skills from public repos',
+        timeCreated: baseTime + 54 * 60_000,
+        timeUpdated: baseTime + 2 * 60 * 60_000,
+      })
+      insertSession(db, {
+        id: 'ses_same_cwd_unrelated',
+        directory: '/home/dan/code',
+        title: 'Audit build install scripts',
+        timeCreated: baseTime + 55 * 60_000,
+        timeUpdated: baseTime + 56 * 60_000,
+      })
+      insertSession(db, {
+        id: 'ses_old_same_title',
+        directory: '/home/dan/code',
+        title: 'Skills from old repos',
+        timeCreated: baseTime - 7 * 24 * 60 * 60_000,
+        timeUpdated: baseTime - 7 * 24 * 60 * 60_000,
+      })
+      insertSession(db, {
+        id: 'ses_other_cwd_same_title',
+        directory: '/home/dan/other',
+        title: 'Skills from public repos',
+        timeCreated: baseTime + 54 * 60_000,
+        timeUpdated: baseTime + 2 * 60 * 60_000,
+      })
+
+      const resolved = resolveOpencodeLegacySession(db, {
+        cwd: '/home/dan/code',
+        title: 'Identifying skills from GitHub repos',
+        createdAt: baseTime,
+        updatedAt: baseTime + 30_000,
+      })
+
+      expect(resolved?.id).toBe('ses_legacy_match')
+      expect(resolved?.directory).toBe('/home/dan/code')
+    } finally {
+      db.close()
+    }
+  })
+
+  it('does not resolve an ambiguous legacy freshopencode placeholder', () => {
+    const db = createDatabase()
+    try {
+      createOpenCodeSchema(db)
+      insertSession(db, {
+        id: 'ses_legacy_match_a',
+        directory: '/home/dan/code',
+        title: 'Skills from public repos',
+        timeCreated: baseTime + 54 * 60_000,
+      })
+      insertSession(db, {
+        id: 'ses_legacy_match_b',
+        directory: '/home/dan/code',
+        title: 'Public repo skills inventory',
+        timeCreated: baseTime + 55 * 60_000,
+      })
+
+      expect(resolveOpencodeLegacySession(db, {
+        cwd: '/home/dan/code',
+        title: 'Identifying skills from GitHub repos',
+        createdAt: baseTime,
+      })).toBeUndefined()
     } finally {
       db.close()
     }

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -97,6 +97,11 @@ describe('WsHandler fresh-agent routing', () => {
         sessionType: 'freshcodex',
         provider: 'codex',
         cwd: '/workspace',
+        legacyRestoreContext: {
+          title: 'Legacy title',
+          createdAt: 1_781_291_230_743,
+          updatedAt: 1_781_291_259_546,
+        },
       }))
       ws.send(JSON.stringify({
         type: 'terminal.create',
@@ -108,6 +113,11 @@ describe('WsHandler fresh-agent routing', () => {
         expect(runtimeManager.create).toHaveBeenCalledWith(expect.objectContaining({
           sessionType: 'freshcodex',
           provider: 'codex',
+          legacyRestoreContext: {
+            title: 'Legacy title',
+            createdAt: 1_781_291_230_743,
+            updatedAt: 1_781_291_259_546,
+          },
         }))
         expect(seenMessages.some((message) => message.type === 'freshAgent.created')).toBe(true)
       })


### PR DESCRIPTION
Summary:
- Resolve legacy Freshopencode placeholder session refs to unique OpenCode DB ses_* sessions using cwd/title/time context.
- Avoid snapshotting placeholder IDs before create/resume promotion, preventing false lost-session state.
- Add unit and e2e coverage for placeholder repair.

Tests:
- npm run check
- npm run test:e2e:chromium -- test/e2e-browser/specs/freshopencode-db-history.spec.ts