### PR TITLE
Fix Fresh Agent serif QA issues

### DIFF
--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -22,12 +22,12 @@ import {
 import { FreshAgentActionSheet } from './FreshAgentActionSheet'
 import { buildLongPressHandlers, useCoarsePointer } from '@/lib/pointer'
 
-function getTurnLabel(turn: FreshAgentTurn): string {
+function getTurnLabel(turn: FreshAgentTurn, agentLabel?: string): string {
   switch (turn.role) {
     case 'user':
       return 'You'
     case 'assistant':
-      return 'Assistant'
+      return agentLabel ?? 'Assistant'
     case 'system':
       return 'System'
     case 'tool':
@@ -307,14 +307,14 @@ function countTools(turn: FreshAgentTurn): number {
   return activityTools(buildActivity(turn.items.filter(isToolLike))).length
 }
 
-function getTurnSummary(turn: FreshAgentTurn): string {
+function getTurnSummary(turn: FreshAgentTurn, agentLabel?: string): string {
   const text = turn.items
     .filter((item): item is Extract<FreshAgentTranscriptItem, { kind: 'text' }> => item.kind === 'text')
     .map((item) => stripSystemReminders(item.text))
     .join(' ')
     .trim()
     .replace(/\s+/g, ' ')
-  const base = text || turn.summary || getTurnLabel(turn)
+  const base = text || turn.summary || getTurnLabel(turn, agentLabel)
   const short = base.length > 44 ? `${base.slice(0, 41)}...` : base
   const toolCount = countTools(turn)
   const itemCount = turn.items.filter((item) => item.kind === 'text').length
@@ -333,9 +333,19 @@ type TurnActionProps = {
   onOpenActions?: (turn: FreshAgentTurn) => void
 }
 
-function CollapsedFreshAgentTurn({ turn, actions }: { turn: FreshAgentTurn; actions: TurnActionProps }) {
+function CollapsedFreshAgentTurn({
+  turn,
+  actions,
+  agentLabel,
+  showModel,
+}: {
+  turn: FreshAgentTurn
+  actions: TurnActionProps
+  agentLabel?: string
+  showModel: boolean
+}) {
   const [expanded, setExpanded] = useState(false)
-  const summary = getTurnSummary(turn)
+  const summary = getTurnSummary(turn, agentLabel)
   if (expanded) {
     return (
       <div className="space-y-2">
@@ -349,7 +359,14 @@ function CollapsedFreshAgentTurn({ turn, actions }: { turn: FreshAgentTurn; acti
           <ChevronRight className="h-3 w-3 rotate-90 transition-transform" />
           <span className="truncate font-mono opacity-70">{summary}</span>
         </button>
-        <FreshAgentTurnArticle turn={turn} compact={false} isLatest={false} actions={actions} />
+        <FreshAgentTurnArticle
+          turn={turn}
+          compact={false}
+          isLatest={false}
+          actions={actions}
+          agentLabel={agentLabel}
+          showModel={showModel}
+        />
       </div>
     )
   }
@@ -372,14 +389,19 @@ function FreshAgentTurnArticle({
   compact,
   isLatest,
   actions,
+  agentLabel,
+  showModel,
 }: {
   turn: FreshAgentTurn
   compact: boolean
   isLatest: boolean
   actions: TurnActionProps
+  agentLabel?: string
+  showModel: boolean
 }) {
   const isUser = turn.role === 'user'
   const blocks = buildBlocks(turn.items)
+  const turnLabel = getTurnLabel(turn, agentLabel)
   // Long-press opens the action sheet on touch devices (iOS fires no
   // contextmenu event; Android does — both paths land on onOpenActions and
   // the second call is a no-op re-set of the same state).
@@ -395,7 +417,7 @@ function FreshAgentTurnArticle({
         isUser ? 'border-l-[hsl(var(--primary))]' : 'border-l-border',
         compact && 'opacity-95',
       )}
-      aria-label={`${getTurnLabel(turn)} transcript turn`}
+      aria-label={`${turnLabel} transcript turn`}
       onContextMenu={(event) => {
         // stopPropagation matters: freshell has a global contextmenu handler
         // that renders the app menu over ours otherwise (live-test finding).
@@ -419,9 +441,9 @@ function FreshAgentTurnArticle({
         onRewindToTurn={actions.onRewindToTurn}
         onOpenActions={actions.onOpenActions}
       />
-      <div className="mb-1 flex items-center justify-between gap-2 text-[11px] uppercase text-muted-foreground">
-        <span>{getTurnLabel(turn)}</span>
-        {turn.model ? <span className="truncate normal-case">{turn.model}</span> : null}
+      <div className="fresh-agent-turn-header mb-1 flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+        <span>{turnLabel}</span>
+        {showModel && turn.model ? <span className="truncate">{turn.model}</span> : null}
       </div>
       <div className="fresh-agent-transcript-copy space-y-1.5">
         {blocks.length > 0 ? blocks.map((block, blockIndex) => {
@@ -450,11 +472,15 @@ function FreshAgentTurnArticle({
 export function FreshAgentTranscript({
   turns,
   canFork = false,
+  agentLabel,
+  showModel = false,
   onForkFromTurn,
   onRewindToTurn,
 }: {
   turns: FreshAgentTurn[]
   canFork?: boolean
+  agentLabel?: string
+  showModel?: boolean
   onForkFromTurn?: (turnId: string) => void
   onRewindToTurn?: (turn: FreshAgentTurn) => void
 }) {
@@ -527,7 +553,15 @@ export function FreshAgentTranscript({
       >
         {turns.map((turn, index) => (
           index < collapsedCutoff
-            ? <CollapsedFreshAgentTurn key={turn.id} turn={turn} actions={actions} />
+            ? (
+              <CollapsedFreshAgentTurn
+                key={turn.id}
+                turn={turn}
+                actions={actions}
+                agentLabel={agentLabel}
+                showModel={showModel}
+              />
+            )
             : (
               <FreshAgentTurnArticle
                 key={turn.id}
@@ -535,6 +569,8 @@ export function FreshAgentTranscript({
                 compact={index < collapsedCutoff}
                 isLatest={index === turns.length - 1}
                 actions={actions}
+                agentLabel={agentLabel}
+                showModel={showModel}
               />
             )
         ))}
@@ -548,7 +584,7 @@ export function FreshAgentTranscript({
       />
       {sheetTurn ? (
         <FreshAgentActionSheet
-          title={turnPlainText(sheetTurn).slice(0, 80) || getTurnLabel(sheetTurn)}
+          title={turnPlainText(sheetTurn).slice(0, 80) || getTurnLabel(sheetTurn, agentLabel)}
           items={buildTurnActionItems(sheetTurn, { canFork, onForkFromTurn, onRewindToTurn })}
           onClose={() => setSheetTurn(null)}
         />

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -248,6 +248,11 @@ export function FreshAgentView({
       ?? state.settings.settings.agentChat?.providers?.[paneContent.sessionType]
       ?? state.settings.serverSettings?.agentChat?.providers?.[paneContent.sessionType],
   )
+  const showTranscriptModel = useAppSelector(
+    (state) => state.settings.settings.freshAgent?.showTimecodes
+      ?? state.settings.settings.agentChat?.showTimecodes
+      ?? false,
+  )
   const activeStyle = normalizeFreshAgentStyle(
     paneContent.style ?? providerDefaults?.style ?? DEFAULT_FRESH_AGENT_STYLE,
   )
@@ -1224,11 +1229,11 @@ export function FreshAgentView({
       && !hasRestoreFailure
       && !['creating', 'starting', 'create-failed', 'exited'].includes(effectiveStatus)
     ))
-    const canInterrupt = snapshot?.capabilities?.interrupt === true || (
+    const canInterrupt = isBusy && (snapshot?.capabilities?.interrupt === true || (
       paneContent.provider === 'claude'
       && Boolean(paneContent.sessionId)
-      && ['connected', 'running', 'idle', 'compacting'].includes(effectiveStatus)
-    )
+      && ['connected', 'running', 'compacting'].includes(effectiveStatus)
+    ))
     const canFork = snapshot?.capabilities?.fork === true
     // Providers report capabilities.send=false WHILE BUSY — that must not
     // disable the composer, or queueing becomes unreachable for codex and
@@ -1295,7 +1300,7 @@ export function FreshAgentView({
       >
         {WatermarkIcon ? (
           <WatermarkIcon
-            className="pointer-events-none absolute left-1/2 top-1/2 z-0 h-[min(34rem,64%)] w-[min(34rem,64%)] -translate-x-1/2 -translate-y-1/2 text-foreground opacity-[0.01]"
+            className="fresh-agent-watermark pointer-events-none absolute left-1/2 top-1/2 z-0 h-[min(34rem,64%)] w-[min(34rem,64%)] -translate-x-1/2 -translate-y-1/2 text-foreground"
             aria-hidden="true"
             data-testid="fresh-agent-watermark"
           />
@@ -1413,6 +1418,8 @@ export function FreshAgentView({
                   } as FreshAgentTurn]
                 : turns}
               canFork={canFork}
+              agentLabel={descriptor?.label}
+              showModel={showTranscriptModel}
               onForkFromTurn={(turnId) => sendFork(turnId)}
               onRewindToTurn={paneContent.initialCwd ? rewindToTurn : undefined}
             />
@@ -1488,6 +1495,7 @@ export function FreshAgentView({
     runShellCommand,
     sessionEnded,
     sessionErrorMessage,
+    showTranscriptModel,
     startNewConversation,
     runSlashCommand,
     sendFork,

--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,7 @@ html {
   --fresh-agent-border: hsl(var(--border) / 0.6);
   --fresh-agent-text: hsl(var(--foreground));
   --fresh-agent-muted-text: hsl(var(--muted-foreground));
+  --fresh-agent-watermark-opacity: 0.01;
 }
 
 .fresh-agent-layout {
@@ -92,8 +93,17 @@ html {
   line-height: inherit;
 }
 
+.fresh-agent-turn-header {
+  font-family: var(--fresh-agent-meta-font-family);
+  letter-spacing: 0;
+}
+
+.fresh-agent-watermark {
+  opacity: var(--fresh-agent-watermark-opacity);
+}
+
 .fresh-agent-style-serif {
-  --fresh-agent-copy-font-family: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  --fresh-agent-copy-font-family: "Literata", "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, Cambria, "Times New Roman", Times, serif;
   --fresh-agent-meta-font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --fresh-agent-surface: #ffffff;
   --fresh-agent-panel-surface: #fbfaf8;
@@ -101,8 +111,10 @@ html {
   --fresh-agent-border: color-mix(in srgb, hsl(var(--border)) 72%, #b47d3c 28%);
   --fresh-agent-text: #221f1b;
   --fresh-agent-muted-text: #696159;
+  --fresh-agent-watermark-opacity: 0.004;
   background: var(--fresh-agent-surface);
   color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-copy-font-family);
 }
 
 .dark .fresh-agent-style-serif {
@@ -112,12 +124,24 @@ html {
   --fresh-agent-border: color-mix(in srgb, hsl(var(--border)) 74%, #c59b6a 26%);
   --fresh-agent-text: #f4efe7;
   --fresh-agent-muted-text: #b8aea2;
+  --fresh-agent-watermark-opacity: 0.006;
 }
 
 .fresh-agent-style-serif .fresh-agent-transcript-copy {
   color: var(--fresh-agent-text);
   font-family: var(--fresh-agent-copy-font-family);
   line-height: 1.42;
+}
+
+.fresh-agent-style-serif :where(button, input, select),
+.fresh-agent-style-serif .fresh-agent-sidebar,
+.fresh-agent-style-serif .fresh-agent-sidebar-section {
+  font-family: var(--fresh-agent-meta-font-family);
+}
+
+.fresh-agent-style-serif textarea {
+  font-family: var(--fresh-agent-copy-font-family);
+  line-height: 1.5;
 }
 
 .fresh-agent-style-serif .fresh-agent-transcript-copy [data-markdown-body] :where(h1, h2, h3, h4) {

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -227,6 +227,14 @@ test.describe('Fresh Agent', () => {
     await expect(transcript.getByText('Serif transcript line')).toBeVisible()
     const transcriptFont = await transcript.evaluate((node) => getComputedStyle(node).fontFamily)
     expect(transcriptFont.toLowerCase()).toContain('georgia')
+    const rootFont = await freshcodexRoot.evaluate((node) => getComputedStyle(node).fontFamily)
+    expect(rootFont.toLowerCase()).toContain('georgia')
+    const composerFont = await freshcodexRoot.getByRole('textbox', { name: 'Chat message input' })
+      .evaluate((node) => getComputedStyle(node).fontFamily)
+    expect(composerFont.toLowerCase()).toContain('georgia')
+    const watermarkOpacity = await freshcodexRoot.getByTestId('fresh-agent-watermark')
+      .evaluate((node) => Number(getComputedStyle(node).opacity))
+    expect(watermarkOpacity).toBeLessThanOrEqual(0.004)
 
     await page.keyboard.press('Escape')
     await page.evaluate(() => {

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -35,6 +35,26 @@ describe('FreshAgentTranscript', () => {
     expect(screen.getByText('Hello from Fresh Agent')).toBeInTheDocument()
   })
 
+  it('uses the pane agent label for assistant turns when provided', () => {
+    render(
+      <FreshAgentTranscript
+        agentLabel="Freshcodex"
+        turns={[
+          {
+            id: 'turn-1',
+            role: 'assistant',
+            model: 'gpt-5.4-flash',
+            items: [{ id: 'item-1', kind: 'text', text: 'Label check' }],
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('Freshcodex')).toBeInTheDocument()
+    expect(screen.queryByText('Assistant')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Freshcodex transcript turn')).toBeInTheDocument()
+  })
+
   it('renders assistant text as markdown', () => {
     render(
       <FreshAgentTranscript

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -315,6 +315,63 @@ describe('FreshAgentView', () => {
     expect(root).toHaveClass('fresh-agent-style-serif')
   })
 
+  it('only exposes the stop action while the agent is working', async () => {
+    const store = createStore()
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValueOnce({
+      status: 'idle',
+      capabilities: { send: true, interrupt: true, fork: false },
+      turns: [],
+    })
+
+    render(
+      <Provider store={store}>
+        <FreshAgentView
+          tabId="tab-1"
+          paneId="pane-1"
+          paneContent={{
+            kind: 'fresh-agent',
+            sessionType: 'freshclaude',
+            provider: 'claude',
+            createRequestId: 'req-stop-idle',
+            sessionId: CLAUDE_THREAD_ID,
+            status: 'idle',
+          }}
+        />
+      </Provider>,
+    )
+
+    await screen.findByRole('textbox', { name: 'Chat message input' })
+    expect(screen.queryByRole('button', { name: 'Stop' })).not.toBeInTheDocument()
+
+    cleanup()
+
+    const runningStore = createStore()
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValueOnce({
+      status: 'running',
+      capabilities: { send: false, interrupt: true, fork: false },
+      turns: [],
+    })
+
+    render(
+      <Provider store={runningStore}>
+        <FreshAgentView
+          tabId="tab-1"
+          paneId="pane-1"
+          paneContent={{
+            kind: 'fresh-agent',
+            sessionType: 'freshclaude',
+            provider: 'claude',
+            createRequestId: 'req-stop-running',
+            sessionId: CLAUDE_RESTORE_THREAD_ID,
+            status: 'running',
+          }}
+        />
+      </Provider>,
+    )
+
+    expect(await screen.findByRole('button', { name: 'Stop' })).toBeEnabled()
+  })
+
   it('renders Codex review and fork metadata in the shared shell', async () => {
     const store = createStore()
     apiMock.getFreshAgentThreadSnapshot.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- apply serif styling across the full Fresh Agent pane and composer
- label assistant transcript turns with the pane agent name instead of generic Assistant
- hide Stop while a Fresh Agent pane is idle
- reduce provider watermark opacity for serif light/dark modes

## Verification
- npm run check
- git diff --check
- browser QA on local worktree server: Freshclaude, Freshell shell, Freshopencode; shell accepted echo freshagent-style-qa; light/dark screenshots checked