### PR TITLE
Complete Fresh Agent serif styling

### DIFF
--- a/src/components/fresh-agent/FreshAgentApprovalBanner.tsx
+++ b/src/components/fresh-agent/FreshAgentApprovalBanner.tsx
@@ -1,6 +1,6 @@
 export function FreshAgentApprovalBanner({ text }: { text: string }) {
   return (
-    <div role="alert" className="rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm">
+    <div role="alert" className="fresh-agent-banner rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm">
       {text}
     </div>
   )

--- a/src/components/fresh-agent/FreshAgentApprovalCard.tsx
+++ b/src/components/fresh-agent/FreshAgentApprovalCard.tsx
@@ -32,44 +32,44 @@ export function FreshAgentApprovalCard({
     <div
       role="alert"
       aria-label={`Permission request for ${toolName}`}
-      className="rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm"
+      className="fresh-agent-approval-card rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm"
     >
-      <div className="flex items-center gap-2 font-medium">
-        <span className="rounded-full border border-amber-500/60 px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-amber-600 dark:text-amber-400">
+      <div className="fresh-agent-approval-heading flex items-center gap-2 font-medium">
+        <span className="fresh-agent-approval-kicker rounded-full border border-amber-500/60 px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-amber-600 dark:text-amber-400">
           approval
         </span>
-        <span>{toolName}</span>
+        <span className="fresh-agent-approval-tool">{toolName}</span>
         {approval.blockedPath ? (
-          <span className="truncate font-mono text-xs text-muted-foreground">{approval.blockedPath}</span>
+          <span className="fresh-agent-approval-path truncate font-mono text-xs text-muted-foreground">{approval.blockedPath}</span>
         ) : null}
       </div>
       {approval.decisionReason ? (
-        <p className="mt-1 text-xs text-muted-foreground">{approval.decisionReason}</p>
+        <p className="fresh-agent-approval-reason mt-1 text-xs text-muted-foreground">{approval.decisionReason}</p>
       ) : null}
 
       {command ? (
-        <pre className="mt-2 overflow-x-auto rounded border border-border/60 bg-background/70 px-2 py-1.5 font-mono text-xs">
+        <pre className="fresh-agent-approval-preview mt-2 overflow-x-auto rounded border border-border/60 bg-background/70 px-2 py-1.5 font-mono text-xs">
           {command}
         </pre>
       ) : editDiff ? (
-        <div className="mt-2 text-xs">
+        <div className="fresh-agent-approval-preview mt-2 text-xs">
           <DiffView oldStr={editDiff.oldStr} newStr={editDiff.newStr} filePath={editDiff.filePath} />
         </div>
       ) : Object.keys(input).length > 0 ? (
-        <pre className="mt-2 max-h-40 overflow-auto rounded border border-border/60 bg-background/70 px-2 py-1.5 font-mono text-xs">
+        <pre className="fresh-agent-approval-preview mt-2 max-h-40 overflow-auto rounded border border-border/60 bg-background/70 px-2 py-1.5 font-mono text-xs">
           {JSON.stringify(input, null, 2)}
         </pre>
       ) : null}
 
       {/* Touch targets ≥44px at base; compact on sm+. flex-1 lets the buttons
           share the full row width on narrow panes for easy thumbing. */}
-      <div className="mt-2 flex flex-wrap gap-2">
+      <div className="fresh-agent-approval-actions mt-2 flex flex-wrap gap-2">
         <button
           type="button"
           aria-label="Allow tool use"
           disabled={disabled}
           onClick={onAllow}
-          className="min-h-[2.75rem] flex-1 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50 sm:min-h-0 sm:flex-none sm:px-3 sm:py-1 sm:text-xs"
+          className="fresh-agent-approval-button fresh-agent-approval-button-primary min-h-[2.75rem] flex-1 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50 sm:min-h-0 sm:flex-none sm:px-3 sm:py-1 sm:text-xs"
         >
           Allow
         </button>
@@ -79,7 +79,7 @@ export function FreshAgentApprovalCard({
             aria-label={`Always allow ${toolName} this session`}
             disabled={disabled}
             onClick={() => onAlwaysAllow(toolName)}
-            className="min-h-[2.75rem] flex-1 rounded-md border border-border px-4 text-sm disabled:cursor-not-allowed disabled:opacity-50 sm:min-h-0 sm:flex-none sm:px-3 sm:py-1 sm:text-xs"
+            className="fresh-agent-approval-button min-h-[2.75rem] flex-1 rounded-md border border-border px-4 text-sm disabled:cursor-not-allowed disabled:opacity-50 sm:min-h-0 sm:flex-none sm:px-3 sm:py-1 sm:text-xs"
             title={`Auto-approve every ${toolName} request for the rest of this session`}
           >
             Always allow {toolName} this session
@@ -90,7 +90,7 @@ export function FreshAgentApprovalCard({
           aria-label="Deny tool use"
           disabled={disabled}
           onClick={onDeny}
-          className="min-h-[2.75rem] flex-1 rounded-md border border-border px-4 text-sm text-muted-foreground hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50 sm:min-h-0 sm:flex-none sm:px-3 sm:py-1 sm:text-xs"
+          className="fresh-agent-approval-button fresh-agent-approval-button-deny min-h-[2.75rem] flex-1 rounded-md border border-border px-4 text-sm text-muted-foreground hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50 sm:min-h-0 sm:flex-none sm:px-3 sm:py-1 sm:text-xs"
         >
           Deny
         </button>

--- a/src/components/fresh-agent/FreshAgentComposer.tsx
+++ b/src/components/fresh-agent/FreshAgentComposer.tsx
@@ -498,31 +498,31 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
     >
       {menuMode && menuLength > 0 ? (
         <div
-          className="absolute bottom-full left-3 mb-2 w-[min(420px,calc(100%-1.5rem))] overflow-hidden rounded-md border border-border/70 bg-popover text-popover-foreground shadow-lg"
+          className="fresh-agent-composer-menu absolute bottom-full left-3 mb-2 w-[min(420px,calc(100%-1.5rem))] overflow-hidden rounded-md border border-border/70 bg-popover text-popover-foreground shadow-lg"
           role="menu"
           aria-label={menuMode === 'files' ? 'File suggestions' : 'Slash commands'}
         >
           {menuMode === 'browse' ? (
-            <div className="border-b border-border/60 p-2">
+            <div className="fresh-agent-composer-menu-filter border-b border-border/60 p-2">
               <input
                 ref={filterRef}
                 value={filter}
                 onChange={(event) => setFilter(event.target.value)}
                 onKeyDown={handleMenuKeyDown}
-                className="w-full rounded border border-border/70 bg-background px-2 py-1 text-sm outline-none"
+                className="fresh-agent-composer-filter-input w-full rounded border border-border/70 bg-background px-2 py-1 text-sm outline-none"
                 aria-label="Filter slash commands"
                 placeholder="Filter commands..."
               />
             </div>
           ) : null}
-          <div className="max-h-[45vh] overflow-auto overscroll-contain py-1 sm:max-h-72">
+          <div className="fresh-agent-composer-menu-list max-h-[45vh] overflow-auto overscroll-contain py-1 sm:max-h-72">
             {menuMode === 'files' ? fileSuggestions.map((suggestion, index) => (
               <button
                 key={suggestion.path}
                 type="button"
                 role="menuitem"
                 className={[
-                  'flex min-h-[2.75rem] w-full items-center gap-2 px-3 py-1.5 text-left text-sm sm:min-h-0',
+                  'fresh-agent-composer-menu-item flex min-h-[2.75rem] w-full items-center gap-2 px-3 py-1.5 text-left text-sm sm:min-h-0',
                   index === highlightedIndex ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60',
                 ].join(' ')}
                 onMouseEnter={() => setHighlightedIndex(index)}
@@ -539,7 +539,7 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
                 type="button"
                 role="menuitem"
                 className={[
-                  'flex min-h-[2.75rem] w-full flex-col justify-center px-3 py-2 text-left text-sm sm:min-h-0',
+                  'fresh-agent-composer-menu-item flex min-h-[2.75rem] w-full flex-col justify-center px-3 py-2 text-left text-sm sm:min-h-0',
                   index === highlightedIndex ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60',
                 ].join(' ')}
                 onMouseEnter={() => setHighlightedIndex(index)}
@@ -550,7 +550,7 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
               </button>
             ))}
           </div>
-          <div className="flex gap-3 border-t border-border/60 px-3 py-2 text-xs text-muted-foreground">
+          <div className="fresh-agent-composer-menu-help flex gap-3 border-t border-border/60 px-3 py-2 text-xs text-muted-foreground">
             <span>Arrow keys navigate</span>
             <span>Enter {menuMode === 'files' ? 'inserts' : 'runs'}</span>
             {menuMode === 'chat' ? <span>Tab completes</span> : null}
@@ -560,12 +560,12 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
       ) : null}
 
       {queuedMessages.length > 0 ? (
-        <div className="mb-2 space-y-1" role="list" aria-label="Queued messages">
+        <div className="fresh-agent-queued-messages mb-2 space-y-1" role="list" aria-label="Queued messages">
           {queuedMessages.map((message, index) => (
             <div
               key={`${index}-${message.slice(0, 16)}`}
               role="listitem"
-              className="flex items-center gap-2 rounded-md border border-dashed border-border/70 px-2 py-1 text-xs text-muted-foreground"
+              className="fresh-agent-queued-message flex items-center gap-2 rounded-md border border-dashed border-border/70 px-2 py-1 text-xs text-muted-foreground"
             >
               <span className="shrink-0">queued</span>
               <span className="min-w-0 flex-1 truncate">{message}</span>
@@ -585,13 +585,13 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
       ) : null}
 
       {attachments.length > 0 ? (
-        <div className="mb-2 flex flex-wrap gap-1.5" role="list" aria-label="Attachments">
+        <div className="fresh-agent-attachments mb-2 flex flex-wrap gap-1.5" role="list" aria-label="Attachments">
           {attachments.map((attachment, index) => (
             <span
               key={`${attachment.name}-${index}`}
               role="listitem"
               className={cn(
-                'inline-flex max-w-full items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs',
+                'fresh-agent-attachment inline-flex max-w-full items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs',
                 attachment.status === 'error'
                   ? 'border-destructive/60 text-destructive'
                   : 'border-border/70 text-muted-foreground',
@@ -615,7 +615,7 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
       ) : null}
 
       <div
-        className="mb-2 flex h-[0.5em] justify-center"
+        className="fresh-agent-thinking-bar mb-2 flex h-[0.5em] justify-center"
         aria-hidden="true"
         data-state={thinking ? 'active' : 'idle'}
         data-testid="fresh-agent-thinking-bar"
@@ -641,7 +641,7 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
           placeholder={placeholder ?? (disabled ? 'Read-only session' : 'Send a message — / commands, @ files, ! shell')}
           className={cn(
             // text-base at small sizes prevents iOS Safari's zoom-on-focus.
-            'max-h-44 min-h-[44px] flex-1 resize-none rounded-md border border-border/70 bg-background px-3 py-2 text-base outline-none sm:min-h-[40px] sm:text-sm',
+            'fresh-agent-composer-input max-h-44 min-h-[44px] flex-1 resize-none rounded-md border border-border/70 bg-background px-3 py-2 text-base outline-none sm:min-h-[40px] sm:text-sm',
             isShellInput && 'border-warning/60 font-mono',
           )}
           onChange={(event) => {

--- a/src/components/fresh-agent/FreshAgentDiffPanel.tsx
+++ b/src/components/fresh-agent/FreshAgentDiffPanel.tsx
@@ -43,10 +43,10 @@ function FreshAgentFileDiff({
   const lines = diff !== null && diff.trim() ? diff.split('\n') : null
 
   return (
-    <div className="min-w-0 border-l-2 border-l-border text-xs">
+    <div className="fresh-agent-file-diff min-w-0 border-l-2 border-l-border text-xs">
       <button
         type="button"
-        className="flex min-h-[2.75rem] w-full min-w-0 items-center gap-2 rounded-r px-2 py-1 text-left transition-colors hover:bg-accent/50 sm:min-h-0"
+        className="fresh-agent-file-diff-trigger flex min-h-[2.75rem] w-full min-w-0 items-center gap-2 rounded-r px-2 py-1 text-left transition-colors hover:bg-accent/50 sm:min-h-0"
         aria-expanded={expanded}
         aria-label={`Diff: ${label}`}
         onClick={() => {
@@ -55,11 +55,11 @@ function FreshAgentFileDiff({
         }}
       >
         <ChevronRight className={cn('h-3 w-3 shrink-0 transition-transform', expanded && 'rotate-90')} />
-        <span className="min-w-0 flex-1 truncate font-mono">{label}</span>
-        {summary.status ? <span className="ml-auto shrink-0 text-muted-foreground">{summary.status}</span> : null}
+        <span className="fresh-agent-file-diff-label min-w-0 flex-1 truncate font-mono">{label}</span>
+        {summary.status ? <span className="fresh-agent-file-diff-status ml-auto shrink-0 text-muted-foreground">{summary.status}</span> : null}
       </button>
       {expanded ? (
-        <div className="mt-1 overflow-x-auto rounded border border-border/60 bg-background/70 font-mono text-[11px] leading-5">
+        <div className="fresh-agent-file-diff-body mt-1 overflow-x-auto rounded border border-border/60 bg-background/70 font-mono text-[11px] leading-5">
           {loading ? <div className="px-3 py-2 text-muted-foreground">Loading diff…</div> : null}
           {error ? <div className="px-3 py-2 text-destructive">{error}</div> : null}
           {!loading && !error && lines === null && diff !== null ? (
@@ -117,9 +117,9 @@ export function FreshAgentDiffPanel({
 }) {
   if (diffs.length === 0) return null
   return (
-    <div className="min-w-0 overflow-hidden rounded-lg border border-border/60 bg-background/70 p-3">
-      <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Diffs</div>
-      <div className="space-y-1">
+    <div className="fresh-agent-diff-panel min-w-0 overflow-hidden rounded-lg border border-border/60 bg-background/70 p-3">
+      <div className="fresh-agent-diff-title mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Diffs</div>
+      <div className="fresh-agent-diff-list space-y-1">
         {diffs.map((diff) => (
           <FreshAgentFileDiff key={diff.id} summary={diff} cwd={cwd} onComment={onComment} />
         ))}

--- a/src/components/fresh-agent/FreshAgentItemCard.tsx
+++ b/src/components/fresh-agent/FreshAgentItemCard.tsx
@@ -42,7 +42,7 @@ function summarizeResult(name: string, output?: string, isError?: boolean): stri
 function StatusBadge({ value }: { value?: string }) {
   if (!value) return null
   return (
-    <span className="rounded-full border border-border/70 bg-background/80 px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+    <span className="fresh-agent-status-badge rounded-full border border-border/70 bg-background/80 px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
       {value}
     </span>
   )
@@ -78,33 +78,33 @@ export function FreshAgentToolBlock({
   return (
     <div
       className={cn(
-        'my-0.5 border-l-2 text-xs',
+        'fresh-agent-tool-block my-0.5 border-l-2 text-xs',
         tool.isError ? 'border-l-[hsl(var(--destructive))]' : 'border-l-[hsl(var(--primary))]',
       )}
     >
       <button
         type="button"
         onClick={() => setExpanded((value) => !value)}
-        className="flex w-full items-center gap-2 rounded-r px-2 py-0.5 text-left transition-colors hover:bg-accent/50"
+        className="fresh-agent-tool-trigger flex w-full items-center gap-2 rounded-r px-2 py-0.5 text-left transition-colors hover:bg-accent/50"
         aria-expanded={expanded}
         aria-label={`${tool.name} tool call`}
       >
         <ChevronRight className={cn('h-3 w-3 shrink-0 transition-transform', expanded && 'rotate-90')} />
-        <span className="font-medium">{tool.name}:</span>
-        {preview ? <span className="truncate font-mono text-muted-foreground">{preview}</span> : null}
+        <span className="fresh-agent-tool-name font-medium">{tool.name}:</span>
+        {preview ? <span className="fresh-agent-tool-preview truncate font-mono text-muted-foreground">{preview}</span> : null}
         {resultSummary ? (
-          <span className={cn('shrink-0 text-muted-foreground', tool.isError && 'text-destructive')}>
+          <span className={cn('fresh-agent-tool-result-summary shrink-0 text-muted-foreground', tool.isError && 'text-destructive')}>
             ({resultSummary})
           </span>
         ) : null}
-        <span className="ml-auto shrink-0">
+        <span className="fresh-agent-tool-status ml-auto shrink-0">
           {tool.status === 'running' ? <Loader2 className="h-3 w-3 animate-spin" aria-label="running" /> : null}
           {tool.status === 'complete' && !tool.isError ? <Check className="h-3 w-3 text-green-500" aria-label="complete" /> : null}
           {tool.status === 'complete' && tool.isError ? <X className="h-3 w-3 text-destructive" aria-label="error" /> : null}
         </span>
       </button>
       {expanded ? (
-        <div className="border-t border-border/50 px-2 py-1 text-xs">
+        <div className="fresh-agent-tool-body border-t border-border/50 px-2 py-1 text-xs">
           {hasEditDiff ? (
             <DiffView
               oldStr={String(tool.input?.old_string ?? '')}
@@ -115,7 +115,7 @@ export function FreshAgentToolBlock({
             <>
               {tool.input ? (
                 <pre
-                  className="max-h-48 overflow-y-auto whitespace-pre-wrap break-words font-mono opacity-80"
+                  className="fresh-agent-tool-pre max-h-48 overflow-y-auto whitespace-pre-wrap break-words font-mono opacity-80"
                   data-tool-input=""
                   data-tool-name={tool.name}
                 >
@@ -127,7 +127,7 @@ export function FreshAgentToolBlock({
               {tool.output ? (
                 <pre
                   className={cn(
-                    'mt-0.5 max-h-48 overflow-y-auto whitespace-pre-wrap break-words font-mono',
+                    'fresh-agent-tool-pre mt-0.5 max-h-48 overflow-y-auto whitespace-pre-wrap break-words font-mono',
                     tool.isError ? 'text-destructive' : 'opacity-80',
                   )}
                   data-tool-output=""
@@ -248,6 +248,25 @@ export function FreshAgentMarkdownBody({ text }: { text: string }) {
   return <>{renderText(text, true)}</>
 }
 
+function FreshAgentThinkingDisclosure({ text }: { text: string }) {
+  const [expanded, setExpanded] = useState(false)
+  return (
+    <div className="fresh-agent-thinking-details border-l-2 border-l-[hsl(var(--primary))] text-xs text-muted-foreground">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-center gap-2 rounded-r px-2 py-0.5 text-left font-medium transition-colors hover:bg-accent/50"
+        aria-expanded={expanded}
+        aria-label="Thinking"
+      >
+        <ChevronRight className={cn('h-3 w-3 shrink-0 transition-transform', expanded && 'rotate-90')} />
+        <span>Thinking</span>
+      </button>
+      {expanded ? <div className="px-2 py-1 text-sm">{renderText(text)}</div> : null}
+    </div>
+  )
+}
+
 export function FreshAgentItemCard({
   item,
   markdown = false,
@@ -257,12 +276,7 @@ export function FreshAgentItemCard({
 }) {
   if (item.kind === 'text' || item.kind === 'thinking') {
     if (item.kind === 'thinking') {
-      return (
-        <details className="border-l-2 border-l-[hsl(var(--primary))] pl-2.5 text-xs text-muted-foreground">
-          <summary className="cursor-pointer font-medium">Thinking</summary>
-          <div className="mt-1 text-sm">{renderText(item.text)}</div>
-        </details>
-      )
+      return <FreshAgentThinkingDisclosure text={item.text} />
     }
     return renderText(item.text, markdown)
   }
@@ -270,7 +284,7 @@ export function FreshAgentItemCard({
   if (item.kind === 'reasoning') {
     const summary = item.summary.length > 0 ? item.summary.join('\n') : item.text
     return (
-      <details className="rounded-md border border-border/60 bg-background/70 px-3 py-2">
+      <details className="fresh-agent-inline-card fresh-agent-reasoning-card rounded-md border border-border/60 bg-background/70 px-3 py-2">
         <summary className="cursor-pointer text-xs font-medium">Reasoning</summary>
         {summary ? <p className="mt-2 whitespace-pre-wrap text-sm">{summary}</p> : null}
         {item.content.length > 0 ? (
@@ -287,7 +301,7 @@ export function FreshAgentItemCard({
 
   if (item.kind === 'tool_result') {
     return (
-      <div className="border-l-2 border-l-border px-2 py-1 text-xs">
+      <div className="fresh-agent-tool-result border-l-2 border-l-border px-2 py-1 text-xs">
         <div className="mb-1 flex items-center gap-2 font-medium">
           Tool result
           {item.isError ? <StatusBadge value="error" /> : null}
@@ -299,7 +313,7 @@ export function FreshAgentItemCard({
 
   if (item.kind === 'collab_agent') {
     return (
-      <div className="rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
+      <div className="fresh-agent-inline-card rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
         <div className="mb-1 flex items-center justify-between gap-2">
           <span className="font-medium">{item.tool}</span>
           <StatusBadge value={item.status} />
@@ -313,7 +327,7 @@ export function FreshAgentItemCard({
 
   if (item.kind === 'web_search') {
     return (
-      <div className="rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
+      <div className="fresh-agent-inline-card rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
         <div className="font-medium">Web search</div>
         <div className="mt-1 whitespace-pre-wrap">{item.query}</div>
       </div>
@@ -322,7 +336,7 @@ export function FreshAgentItemCard({
 
   if (item.kind === 'image_view') {
     return (
-      <div className="rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
+      <div className="fresh-agent-inline-card rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
         <div className="font-medium">Image</div>
         <div className="mt-1 break-all text-muted-foreground">{item.path}</div>
       </div>
@@ -331,7 +345,7 @@ export function FreshAgentItemCard({
 
   if (item.kind === 'image_generation') {
     return (
-      <div className="rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
+      <div className="fresh-agent-inline-card rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
         <div className="mb-1 flex items-center justify-between gap-2">
           <span className="font-medium">Image generation</span>
           <StatusBadge value={item.displayStatus ?? item.status} />
@@ -345,7 +359,7 @@ export function FreshAgentItemCard({
 
   if (item.kind === 'review_mode') {
     return (
-      <div className="rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
+      <div className="fresh-agent-inline-card rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
         {item.event === 'entered' ? 'Entered review mode' : 'Exited review mode'}
         {item.review ? <span className="text-muted-foreground"> · {item.review}</span> : null}
       </div>
@@ -353,7 +367,7 @@ export function FreshAgentItemCard({
   }
 
   return (
-    <div className="rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
+    <div className="fresh-agent-inline-card rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
       Context compaction
     </div>
   )

--- a/src/components/fresh-agent/FreshAgentQuestionBanner.tsx
+++ b/src/components/fresh-agent/FreshAgentQuestionBanner.tsx
@@ -30,9 +30,9 @@ function SingleSelectQuestion({
   }, [showOther])
 
   return (
-    <div className="space-y-2">
-      <p className="text-sm font-medium">{question.question}</p>
-      <div className="flex flex-wrap gap-2">
+    <div className="fresh-agent-question-block space-y-2">
+      <p className="fresh-agent-question-text text-sm font-medium">{question.question}</p>
+      <div className="fresh-agent-question-options flex flex-wrap gap-2">
         {question.options.map((option) => (
           <button
             key={option.label}
@@ -40,7 +40,7 @@ function SingleSelectQuestion({
             onClick={() => onSelect(option.label)}
             disabled={disabled}
             className={cn(
-              'px-3 py-1.5 text-xs rounded-md border transition-colors',
+              'fresh-agent-question-option px-3 py-1.5 text-xs rounded-md border transition-colors',
               'bg-sky-600/10 border-sky-500/30 hover:bg-sky-600/20 hover:border-sky-500/50',
               'disabled:opacity-50',
             )}
@@ -57,7 +57,7 @@ function SingleSelectQuestion({
           onClick={() => setShowOther(true)}
           disabled={disabled}
           className={cn(
-            'px-3 py-1.5 text-xs rounded-md border transition-colors',
+            'fresh-agent-question-option fresh-agent-question-option-other px-3 py-1.5 text-xs rounded-md border transition-colors',
             'bg-muted/50 border-border hover:bg-muted',
             'disabled:opacity-50',
           )}
@@ -67,21 +67,21 @@ function SingleSelectQuestion({
         </button>
       </div>
       {showOther ? (
-        <div className="flex items-center gap-2">
+        <div className="fresh-agent-question-other flex items-center gap-2">
           <input
             ref={otherInputRef}
             type="text"
             value={otherText}
             onChange={(event) => setOtherText(event.target.value)}
             placeholder="Type your answer..."
-            className="flex-1 rounded border bg-background px-2 py-1 text-xs"
+            className="fresh-agent-question-input flex-1 rounded border bg-background px-2 py-1 text-xs"
           />
           <button
             type="button"
             onClick={() => otherText.trim() && onSelect(otherText.trim())}
             disabled={disabled || !otherText.trim()}
             className={cn(
-              'px-3 py-1 text-xs rounded font-medium',
+              'fresh-agent-question-submit px-3 py-1 text-xs rounded font-medium',
               'bg-sky-600 text-white hover:bg-sky-700',
               'disabled:opacity-50',
             )}
@@ -120,9 +120,9 @@ function MultiSelectQuestion({
   }, [onSelect, selected])
 
   return (
-    <div className="space-y-2">
-      <p className="text-sm font-medium">{question.question}</p>
-      <div className="flex flex-wrap gap-2">
+    <div className="fresh-agent-question-block space-y-2">
+      <p className="fresh-agent-question-text text-sm font-medium">{question.question}</p>
+      <div className="fresh-agent-question-options flex flex-wrap gap-2">
         {question.options.map((option) => (
           <button
             key={option.label}
@@ -130,7 +130,7 @@ function MultiSelectQuestion({
             onClick={() => toggle(option.label)}
             disabled={disabled}
             className={cn(
-              'px-3 py-1.5 text-xs rounded-md border transition-colors',
+              'fresh-agent-question-option px-3 py-1.5 text-xs rounded-md border transition-colors',
               selected.has(option.label)
                 ? 'bg-sky-600/30 border-sky-500/60 ring-1 ring-sky-500/40'
                 : 'bg-sky-600/10 border-sky-500/30 hover:bg-sky-600/20',
@@ -151,7 +151,7 @@ function MultiSelectQuestion({
         onClick={handleSubmit}
         disabled={disabled || selected.size === 0}
         className={cn(
-          'px-3 py-1 text-xs rounded font-medium',
+          'fresh-agent-question-submit px-3 py-1 text-xs rounded font-medium',
           'bg-sky-600 text-white hover:bg-sky-700',
           'disabled:opacity-50',
         )}
@@ -191,11 +191,11 @@ function FreshAgentQuestionBanner({
 
   return (
     <div
-      className="rounded-lg border border-sky-500/50 bg-sky-500/10 p-3 space-y-3"
+      className="fresh-agent-question-card rounded-lg border border-sky-500/50 bg-sky-500/10 p-3 space-y-3"
       role="region"
       aria-label={regionLabel}
     >
-      <div className="flex items-center gap-2 text-sm font-medium">
+      <div className="fresh-agent-question-heading flex items-center gap-2 text-sm font-medium">
         <MessageCircleQuestion className="h-4 w-4 text-sky-500" />
         <span>{heading}</span>
       </div>
@@ -230,7 +230,7 @@ function FreshAgentQuestionBanner({
           }}
           disabled={disabled}
           className={cn(
-            'px-4 py-1.5 text-xs rounded font-medium',
+            'fresh-agent-question-submit px-4 py-1.5 text-xs rounded font-medium',
             'bg-sky-600 text-white hover:bg-sky-700',
             'disabled:opacity-50',
           )}

--- a/src/components/fresh-agent/FreshAgentSidebar.tsx
+++ b/src/components/fresh-agent/FreshAgentSidebar.tsx
@@ -20,7 +20,7 @@ export function FreshAgentSidebar({
       <div className="fresh-agent-sidebar-content">
       {codexReview ? (
         <section className="fresh-agent-sidebar-section">
-          <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Review</div>
+          <div className="fresh-agent-sidebar-title mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Review</div>
           <ul className="fresh-agent-sidebar-list space-y-1 text-sm">
             {codexReview.status ? <li>{codexReview.status}</li> : null}
             {codexReview.id ? <li>{codexReview.id}</li> : null}
@@ -29,7 +29,7 @@ export function FreshAgentSidebar({
       ) : null}
       {codexFork?.parentThreadId ? (
         <section className="fresh-agent-sidebar-section">
-          <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Fork lineage</div>
+          <div className="fresh-agent-sidebar-title mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Fork lineage</div>
           <ul className="fresh-agent-sidebar-list space-y-1 text-sm">
             <li>Parent thread</li>
             <li>{codexFork.parentThreadId}</li>
@@ -38,7 +38,7 @@ export function FreshAgentSidebar({
       ) : null}
       {worktrees.length > 0 ? (
         <section className="fresh-agent-sidebar-section">
-          <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Worktrees</div>
+          <div className="fresh-agent-sidebar-title mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Worktrees</div>
           <ul className="fresh-agent-sidebar-list space-y-1 text-sm">
             {worktrees.map((worktree) => (
               <li key={worktree.id}>{worktree.branch ? `${worktree.branch} · ` : ''}{worktree.path}</li>
@@ -48,7 +48,7 @@ export function FreshAgentSidebar({
       ) : null}
       {childThreads.length > 0 ? (
         <section className="fresh-agent-sidebar-section">
-          <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Child Threads</div>
+          <div className="fresh-agent-sidebar-title mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Child Threads</div>
           <ul className="fresh-agent-sidebar-list space-y-1 text-sm">
             {childThreads.map((thread) => (
               <li key={thread.id}>{thread.title ?? thread.threadId}</li>

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -165,14 +165,9 @@ function settledSummary(rows: ActivityRow[]): string {
   return parts.join(' · ') || 'thought'
 }
 
-function thinkingPreview(text: string): string {
-  const flat = text.replace(/\s+/g, ' ').trim()
-  return flat.length > 64 ? `…${flat.slice(-60)}` : flat
-}
-
 type RenderBlock =
   | { kind: 'item'; item: FreshAgentTranscriptItem }
-  | { kind: 'activity'; id: string; rows: ActivityRow[]; endsWithThinking: boolean }
+  | { kind: 'activity'; id: string; rows: ActivityRow[] }
 
 function buildBlocks(items: FreshAgentTranscriptItem[]): RenderBlock[] {
   const blocks: RenderBlock[] = []
@@ -185,7 +180,6 @@ function buildBlocks(items: FreshAgentTranscriptItem[]): RenderBlock[] {
         kind: 'activity',
         id: pending.map((item) => item.id).join(':'),
         rows,
-        endsWithThinking: rows[rows.length - 1]?.type === 'thinking',
       })
     }
     pending = []
@@ -205,20 +199,19 @@ function buildBlocks(items: FreshAgentTranscriptItem[]): RenderBlock[] {
 function FreshAgentThinkingRow({ text }: { text: string }) {
   const [expanded, setExpanded] = useState(false)
   return (
-    <div className="my-0.5 border-l-2 border-l-[hsl(var(--primary))] text-xs">
+    <div className="fresh-agent-thinking-row my-0.5 border-l-2 border-l-[hsl(var(--primary))] text-xs">
       <button
         type="button"
         onClick={() => setExpanded((value) => !value)}
-        className="flex w-full items-center gap-2 rounded-r px-2 py-0.5 text-left transition-colors hover:bg-accent/50"
+        className="fresh-agent-thinking-trigger flex w-full items-center gap-2 rounded-r px-2 py-0.5 text-left transition-colors hover:bg-accent/50"
         aria-expanded={expanded}
         aria-label="Thinking"
       >
         <ChevronRight className={cn('h-3 w-3 shrink-0 transition-transform', expanded && 'rotate-90')} />
-        <span className="font-medium">Thinking:</span>
-        <span className="truncate italic text-muted-foreground">{thinkingPreview(text)}</span>
+        <span className="font-medium">Thinking</span>
       </button>
       {expanded ? (
-        <div className="border-t border-border/50 px-2 py-1 text-sm text-muted-foreground">
+        <div className="fresh-agent-thinking-body border-t border-border/50 px-2 py-1 text-sm text-muted-foreground">
           <FreshAgentMarkdownBody text={text} />
         </div>
       ) : null}
@@ -228,34 +221,32 @@ function FreshAgentThinkingRow({ text }: { text: string }) {
 
 function FreshAgentActivityStrip({
   rows,
-  liveTrailingThinking = false,
+  live = false,
 }: {
   rows: ActivityRow[]
-  liveTrailingThinking?: boolean
+  live?: boolean
 }) {
   const [expanded, setExpanded] = useState(false)
   const tools = activityTools(rows)
   const hasErrors = tools.some((tool) => tool.isError)
   const lastRow = rows[rows.length - 1] ?? null
   const runningTool = [...tools].reverse().find((tool) => tool.status === 'running') ?? null
-  const thinkingLive = liveTrailingThinking && lastRow?.type === 'thinking'
-  const running = runningTool !== null || thinkingLive
+  const thinkingLive = live && lastRow?.type === 'thinking'
+  const liveTool = !thinkingLive && live ? (tools[tools.length - 1] ?? null) : null
+  const activeTool = runningTool ?? liveTool
+  const running = activeTool !== null || thinkingLive
 
   if (rows.length === 0) return null
 
-  const reelName = runningTool ? runningTool.name : thinkingLive ? 'Thinking' : null
-  const reelPreview = runningTool
-    ? getToolPreview(runningTool.name, runningTool.input)
-    : thinkingLive && lastRow?.type === 'thinking'
-      ? thinkingPreview(lastRow.text)
-      : null
+  const reelName = activeTool ? activeTool.name : thinkingLive ? 'Thinking' : null
+  const reelPreview = activeTool ? getToolPreview(activeTool.name, activeTool.input) : null
 
   return (
-    <div role="region" aria-label="Activity strip" className="my-0.5">
+    <div role="region" aria-label="Activity strip" className="fresh-agent-activity-strip my-0.5">
       {!expanded ? (
         <div
           className={cn(
-            'flex min-w-0 items-center gap-1.5 border-l-2 px-2 py-0.5 text-xs',
+            'fresh-agent-activity-summary flex min-w-0 items-center gap-1.5 border-l-2 px-2 py-0.5 text-xs',
             hasErrors ? 'border-l-[hsl(var(--destructive))]' : 'border-l-[hsl(var(--primary))]',
           )}
         >
@@ -282,7 +273,7 @@ function FreshAgentActivityStrip({
           />
         </div>
       ) : (
-        <>
+        <div className="fresh-agent-activity-details">
           <button
             type="button"
             onClick={() => setExpanded(false)}
@@ -297,7 +288,7 @@ function FreshAgentActivityStrip({
               ? <FreshAgentThinkingRow key={row.id} text={row.text} />
               : <FreshAgentToolBlock key={row.tool.id} tool={row.tool} initialExpanded={false} />
           ))}
-        </>
+        </div>
       )}
     </div>
   )
@@ -348,7 +339,7 @@ function CollapsedFreshAgentTurn({
   const summary = getTurnSummary(turn, agentLabel)
   if (expanded) {
     return (
-      <div className="space-y-2">
+      <div className="fresh-agent-collapsed-turn-expanded space-y-2">
         <button
           type="button"
           onClick={() => setExpanded(false)}
@@ -366,6 +357,9 @@ function CollapsedFreshAgentTurn({
           actions={actions}
           agentLabel={agentLabel}
           showModel={showModel}
+          showHeader
+          continuation={false}
+          isStreaming={false}
         />
       </div>
     )
@@ -374,7 +368,7 @@ function CollapsedFreshAgentTurn({
     <button
       type="button"
       onClick={() => setExpanded(true)}
-      className="flex w-full items-center gap-1 text-left text-xs text-muted-foreground transition-colors hover:text-foreground"
+      className="fresh-agent-collapsed-turn flex w-full items-center gap-1 text-left text-xs text-muted-foreground transition-colors hover:text-foreground"
       aria-expanded={false}
       aria-label="Expand turn"
     >
@@ -391,6 +385,9 @@ function FreshAgentTurnArticle({
   actions,
   agentLabel,
   showModel,
+  showHeader,
+  continuation,
+  isStreaming,
 }: {
   turn: FreshAgentTurn
   compact: boolean
@@ -398,10 +395,16 @@ function FreshAgentTurnArticle({
   actions: TurnActionProps
   agentLabel?: string
   showModel: boolean
+  showHeader: boolean
+  continuation: boolean
+  isStreaming: boolean
 }) {
   const isUser = turn.role === 'user'
   const blocks = buildBlocks(turn.items)
   const turnLabel = getTurnLabel(turn, agentLabel)
+  const lastActivityBlockIndex = blocks.reduce((lastIndex, block, index) => (
+    block.kind === 'activity' ? index : lastIndex
+  ), -1)
   // Long-press opens the action sheet on touch devices (iOS fires no
   // contextmenu event; Android does — both paths land on onOpenActions and
   // the second call is a no-op re-set of the same state).
@@ -413,10 +416,13 @@ function FreshAgentTurnArticle({
   return (
     <article
       className={cn(
-        'group relative w-full border-l-2 py-0.5 pl-2.5 pr-1',
+        'fresh-agent-turn group relative mt-3 w-full border-l-2 py-0.5 pl-2.5 pr-1 first:mt-0',
         isUser ? 'border-l-[hsl(var(--primary))]' : 'border-l-border',
         compact && 'opacity-95',
+        continuation && 'mt-1.5',
       )}
+      data-turn-role={turn.role}
+      data-turn-continuation={continuation ? 'true' : 'false'}
       aria-label={`${turnLabel} transcript turn`}
       onContextMenu={(event) => {
         // stopPropagation matters: freshell has a global contextmenu handler
@@ -441,18 +447,21 @@ function FreshAgentTurnArticle({
         onRewindToTurn={actions.onRewindToTurn}
         onOpenActions={actions.onOpenActions}
       />
-      <div className="fresh-agent-turn-header mb-1 flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
-        <span>{turnLabel}</span>
-        {showModel && turn.model ? <span className="truncate">{turn.model}</span> : null}
-      </div>
+      {showHeader ? (
+        <div className="fresh-agent-turn-header mb-1 flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+          <span>{turnLabel}</span>
+          {showModel && turn.model ? <span className="truncate">{turn.model}</span> : null}
+        </div>
+      ) : null}
       <div className="fresh-agent-transcript-copy space-y-1.5">
         {blocks.length > 0 ? blocks.map((block, blockIndex) => {
           if (block.kind === 'activity') {
+            const blockEndsWithThinking = block.rows[block.rows.length - 1]?.type === 'thinking'
             return (
               <FreshAgentActivityStrip
                 key={block.id}
                 rows={block.rows}
-                liveTrailingThinking={isLatest && blockIndex === blocks.length - 1 && block.endsWithThinking}
+                live={isLatest && blockIndex === lastActivityBlockIndex && (isStreaming || blockEndsWithThinking)}
               />
             )
           }
@@ -474,6 +483,7 @@ export function FreshAgentTranscript({
   canFork = false,
   agentLabel,
   showModel = false,
+  isStreaming = false,
   onForkFromTurn,
   onRewindToTurn,
 }: {
@@ -481,6 +491,7 @@ export function FreshAgentTranscript({
   canFork?: boolean
   agentLabel?: string
   showModel?: boolean
+  isStreaming?: boolean
   onForkFromTurn?: (turnId: string) => void
   onRewindToTurn?: (turn: FreshAgentTurn) => void
 }) {
@@ -544,7 +555,7 @@ export function FreshAgentTranscript({
     <div className="relative min-h-0 flex-1">
       <div
         ref={scrollerRef}
-        className="flex h-full flex-col gap-3 overflow-x-hidden overflow-y-auto overscroll-contain px-3 py-3"
+        className="fresh-agent-transcript-scroll flex h-full flex-col gap-0 overflow-x-hidden overflow-y-auto overscroll-contain px-3 py-3"
         data-context="fresh-agent-transcript"
         onScroll={(event) => {
           const node = event.currentTarget
@@ -555,7 +566,7 @@ export function FreshAgentTranscript({
           index < collapsedCutoff
             ? (
               <CollapsedFreshAgentTurn
-                key={turn.id}
+                key={`${turn.id}:${index}`}
                 turn={turn}
                 actions={actions}
                 agentLabel={agentLabel}
@@ -564,13 +575,16 @@ export function FreshAgentTranscript({
             )
             : (
               <FreshAgentTurnArticle
-                key={turn.id}
+                key={`${turn.id}:${index}`}
                 turn={turn}
                 compact={index < collapsedCutoff}
                 isLatest={index === turns.length - 1}
                 actions={actions}
                 agentLabel={agentLabel}
                 showModel={showModel}
+                showHeader={index === collapsedCutoff || turns[index - 1]?.role !== turn.role}
+                continuation={index > collapsedCutoff && turns[index - 1]?.role === turn.role}
+                isStreaming={isStreaming}
               />
             )
         ))}
@@ -592,7 +606,7 @@ export function FreshAgentTranscript({
       {!atBottom ? (
         <button
           type="button"
-          className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-background px-3 py-1 text-xs shadow"
+          className="fresh-agent-scroll-bottom absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-background px-3 py-1 text-xs shadow"
           onClick={() => {
             const node = scrollerRef.current
             if (!node) return

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -1343,22 +1343,22 @@ export function FreshAgentView({
         ) : null}
         <div className={`${hasSidebarMetadata ? 'fresh-agent-layout--with-sidebar ' : ''}fresh-agent-layout relative z-10 min-h-0 flex-1`}>
           <div className="fresh-agent-main flex min-h-0 flex-1 flex-col">
-            <div className="space-y-2 px-3 pt-3">
+            <div className="fresh-agent-top-stack space-y-2 px-3 pt-3">
               {isRestoring ? (
                 <FreshAgentApprovalBanner text="Restoring session..." />
               ) : null}
               {snapshot?.summary ? (
-                <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+                <div className="fresh-agent-summary-card rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
                   {snapshot.summary}
                 </div>
               ) : null}
               {pendingCreateFailure || paneContent.createError ? (
-                <div className="flex items-center justify-between gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm">
+                <div className="fresh-agent-error-card flex items-center justify-between gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm">
                   <FreshAgentApprovalBanner text={(pendingCreateFailure ?? paneContent.createError)?.message ?? 'Create failed'} />
                   {(pendingCreateFailure ?? paneContent.createError)?.retryable ? (
                     <button
                       type="button"
-                      className="rounded border border-border/70 px-2 py-1"
+                      className="fresh-agent-error-action rounded border border-border/70 px-2 py-1"
                       onClick={() => {
                         const nextRequestId = nanoid()
                         dispatch(updatePaneContent({
@@ -1384,11 +1384,11 @@ export function FreshAgentView({
               {visibleLoadError ? <FreshAgentApprovalBanner text={visibleLoadError} /> : null}
               {sessionErrorMessage ? <FreshAgentApprovalBanner text={`Agent error: ${sessionErrorMessage}`} /> : null}
               {sessionEnded ? (
-                <div className="flex items-center justify-between gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm">
+                <div className="fresh-agent-session-ended-card flex items-center justify-between gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm">
                   <span>This session has ended{sessionErrorMessage ? '' : ' (the agent process exited)'}.</span>
                   <button
                     type="button"
-                    className="shrink-0 rounded border border-border/70 px-2 py-1 text-xs"
+                    className="fresh-agent-session-ended-action shrink-0 rounded border border-border/70 px-2 py-1 text-xs"
                     onClick={startNewConversation}
                   >
                     Start new session
@@ -1456,6 +1456,7 @@ export function FreshAgentView({
               canFork={canFork}
               agentLabel={descriptor?.label}
               showModel={showTranscriptModel}
+              isStreaming={isBusy}
               onForkFromTurn={(turnId) => sendFork(turnId)}
               onRewindToTurn={paneContent.initialCwd ? rewindToTurn : undefined}
             />

--- a/src/index.css
+++ b/src/index.css
@@ -98,19 +98,33 @@ html {
   letter-spacing: 0;
 }
 
+.fresh-agent-turn[data-turn-continuation="true"] {
+  padding-top: 0;
+}
+
 .fresh-agent-watermark {
   opacity: var(--fresh-agent-watermark-opacity);
 }
 
 .fresh-agent-style-serif {
   --fresh-agent-copy-font-family: "Literata", "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, Cambria, "Times New Roman", Times, serif;
-  --fresh-agent-meta-font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --fresh-agent-surface: #ffffff;
-  --fresh-agent-panel-surface: #fbfaf8;
-  --fresh-agent-subtle-surface: #f6f2ec;
-  --fresh-agent-border: color-mix(in srgb, hsl(var(--border)) 72%, #b47d3c 28%);
-  --fresh-agent-text: #221f1b;
-  --fresh-agent-muted-text: #696159;
+  --fresh-agent-meta-font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --fresh-agent-mono-font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --fresh-agent-surface: #fff;
+  --fresh-agent-panel-surface: #fbfaf7;
+  --fresh-agent-subtle-surface: #f1eee7;
+  --fresh-agent-raised-surface: #f7f4ee;
+  --fresh-agent-border: #d7d1c6;
+  --fresh-agent-border-strong: #bfb6a8;
+  --fresh-agent-accent: #8a673f;
+  --fresh-agent-accent-soft: #f6efe4;
+  --fresh-agent-danger: #8f3f37;
+  --fresh-agent-danger-soft: #faeeee;
+  --fresh-agent-success: #4d7459;
+  --fresh-agent-success-soft: #edf5ed;
+  --fresh-agent-text: #1d1a16;
+  --fresh-agent-muted-text: #635d54;
+  --fresh-agent-soft-text: #7a7368;
   --fresh-agent-watermark-opacity: 0.004;
   background: var(--fresh-agent-surface);
   color: var(--fresh-agent-text);
@@ -118,24 +132,38 @@ html {
 }
 
 .dark .fresh-agent-style-serif {
-  --fresh-agent-surface: #141311;
-  --fresh-agent-panel-surface: #1c1a17;
-  --fresh-agent-subtle-surface: #25211d;
-  --fresh-agent-border: color-mix(in srgb, hsl(var(--border)) 74%, #c59b6a 26%);
+  --fresh-agent-surface: #12110f;
+  --fresh-agent-panel-surface: #1a1815;
+  --fresh-agent-subtle-surface: #24211d;
+  --fresh-agent-raised-surface: #201d19;
+  --fresh-agent-border: #443d34;
+  --fresh-agent-border-strong: #746757;
+  --fresh-agent-accent: #d4b081;
+  --fresh-agent-accent-soft: #2b241c;
+  --fresh-agent-danger: #e19a90;
+  --fresh-agent-danger-soft: #2c1f1d;
+  --fresh-agent-success: #a8c7a5;
+  --fresh-agent-success-soft: #1f2b20;
   --fresh-agent-text: #f4efe7;
-  --fresh-agent-muted-text: #b8aea2;
+  --fresh-agent-muted-text: #bdb2a5;
+  --fresh-agent-soft-text: #a99d90;
   --fresh-agent-watermark-opacity: 0.006;
 }
 
 .fresh-agent-style-serif .fresh-agent-transcript-copy {
   color: var(--fresh-agent-text);
   font-family: var(--fresh-agent-copy-font-family);
-  line-height: 1.42;
+  line-height: 1.66;
 }
 
 .fresh-agent-style-serif :where(button, input, select),
 .fresh-agent-style-serif .fresh-agent-sidebar,
-.fresh-agent-style-serif .fresh-agent-sidebar-section {
+.fresh-agent-style-serif .fresh-agent-sidebar-section,
+.fresh-agent-style-serif .fresh-agent-turn-header,
+.fresh-agent-style-serif .fresh-agent-activity-strip,
+.fresh-agent-style-serif .fresh-agent-tool-block,
+.fresh-agent-style-serif .fresh-agent-diff-panel,
+.fresh-agent-style-serif .fresh-agent-composer-menu {
   font-family: var(--fresh-agent-meta-font-family);
 }
 
@@ -147,16 +175,29 @@ html {
 .fresh-agent-style-serif .fresh-agent-transcript-copy [data-markdown-body] :where(h1, h2, h3, h4) {
   color: var(--fresh-agent-text);
   font-family: var(--fresh-agent-copy-font-family);
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: 0;
+}
+
+.fresh-agent-style-serif .fresh-agent-transcript-copy [data-markdown-body] :where(h1, h2) {
+  line-height: 1.38;
+  margin-bottom: 0.9rem;
+  margin-top: 0;
+}
+
+.fresh-agent-style-serif .fresh-agent-transcript-copy [data-markdown-body] h2 {
+  font-size: 1.38em;
 }
 
 .fresh-agent-style-serif .fresh-agent-transcript-copy [data-markdown-body] :where(p, li, blockquote) {
   color: var(--fresh-agent-text);
+  margin-bottom: 0.85rem;
+  margin-top: 0;
 }
 
 .fresh-agent-style-serif .fresh-agent-transcript-copy [data-markdown-body] :where(pre, code) {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-family: var(--fresh-agent-mono-font-family);
+  letter-spacing: 0;
 }
 
 .fresh-agent-style-serif .fresh-agent-sidebar,
@@ -164,8 +205,431 @@ html {
   border-color: var(--fresh-agent-border);
 }
 
-.fresh-agent-style-serif .fresh-agent-sidebar-section,
 .fresh-agent-style-serif .fresh-agent-transcript-copy [data-markdown-body] blockquote {
+  background: var(--fresh-agent-subtle-surface);
+}
+
+.fresh-agent-style-serif .fresh-agent-layout,
+.fresh-agent-style-serif .fresh-agent-main {
+  background: var(--fresh-agent-surface);
+}
+
+.fresh-agent-style-serif .fresh-agent-top-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1.2rem 1.4rem 0;
+}
+
+.fresh-agent-style-serif .fresh-agent-transcript-scroll {
+  gap: 0;
+  padding: 1rem 1.5rem 1.2rem;
+}
+
+.fresh-agent-style-serif .fresh-agent-turn {
+  border-left: 0;
+  border-top: 1px solid var(--fresh-agent-border);
+  padding: 1.15rem 0 1.3rem;
+}
+
+.fresh-agent-style-serif .fresh-agent-turn[data-turn-continuation="true"] {
+  border-top: 0;
+  margin-top: -1.05rem;
+  padding-top: 0;
+}
+
+.fresh-agent-style-serif .fresh-agent-turn:first-child {
+  border-top: 0;
+  padding-top: 0.15rem;
+}
+
+.fresh-agent-style-serif .fresh-agent-turn-header {
+  color: var(--fresh-agent-soft-text);
+  font-size: 0.58rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  line-height: 1.25;
+  margin-bottom: 0.7rem;
+  max-width: 82ch;
+}
+
+.fresh-agent-style-serif .fresh-agent-turn-header span:first-child {
+  max-width: 60%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fresh-agent-style-serif .fresh-agent-turn > .fresh-agent-transcript-copy,
+.fresh-agent-style-serif .fresh-agent-activity-strip {
+  max-width: 82ch;
+}
+
+.fresh-agent-style-serif .fresh-agent-turn[data-turn-role="user"] .fresh-agent-turn-header {
+  margin-bottom: 0.35rem;
+}
+
+.fresh-agent-style-serif .fresh-agent-turn[data-turn-role="user"] .fresh-agent-transcript-copy {
+  background: linear-gradient(
+    to right,
+    var(--fresh-agent-subtle-surface),
+    color-mix(in srgb, var(--fresh-agent-subtle-surface) 72%, transparent) 58%,
+    transparent 100%
+  );
+  border-left: 2px solid var(--fresh-agent-border-strong);
+  padding: 0.8rem 1rem;
+}
+
+.fresh-agent-style-serif .fresh-agent-turn[data-turn-role="user"] .fresh-agent-transcript-copy :where(p, [data-markdown-body] p) {
+  font-size: 1.08em;
+  font-weight: 500;
+  line-height: 1.42;
+  margin: 0;
+}
+
+.fresh-agent-style-serif :where(
+  .fresh-agent-banner,
+  .fresh-agent-summary-card,
+  .fresh-agent-error-card,
+  .fresh-agent-session-ended-card,
+  .fresh-agent-approval-card,
+  .fresh-agent-question-card,
+  .fresh-agent-diff-panel,
+  .fresh-agent-inline-card
+) {
+  background: var(--fresh-agent-panel-surface);
+  border-color: var(--fresh-agent-border);
+  border-radius: 0.25rem;
+  color: var(--fresh-agent-text);
+  box-shadow: none;
+}
+
+.fresh-agent-style-serif :where(.fresh-agent-banner, .fresh-agent-summary-card) {
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  line-height: 1.5;
+}
+
+.fresh-agent-style-serif .fresh-agent-approval-card,
+.fresh-agent-style-serif .fresh-agent-question-card,
+.fresh-agent-style-serif .fresh-agent-diff-panel {
+  padding: 0.85rem 0.9rem;
+}
+
+.fresh-agent-style-serif :where(
+  .fresh-agent-approval-heading,
+  .fresh-agent-question-heading,
+  .fresh-agent-diff-title,
+  .fresh-agent-sidebar-title
+) {
+  color: var(--fresh-agent-soft-text);
+  font-family: var(--fresh-agent-meta-font-family);
+  font-size: 0.58rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.fresh-agent-style-serif .fresh-agent-approval-heading {
+  color: var(--fresh-agent-text);
+  text-transform: none;
+}
+
+.fresh-agent-style-serif .fresh-agent-approval-kicker,
+.fresh-agent-style-serif .fresh-agent-status-badge {
+  border-color: var(--fresh-agent-border-strong);
+  color: var(--fresh-agent-accent);
+}
+
+.fresh-agent-style-serif .fresh-agent-approval-tool {
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.fresh-agent-style-serif .fresh-agent-approval-reason,
+.fresh-agent-style-serif .fresh-agent-question-text {
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.fresh-agent-style-serif :where(
+  .fresh-agent-approval-preview,
+  .fresh-agent-tool-body,
+  .fresh-agent-file-diff-body,
+  [data-diff]
+) {
+  background: var(--fresh-agent-surface);
+  border-color: var(--fresh-agent-border);
+  border-radius: 0.18rem;
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-mono-font-family);
+}
+
+.fresh-agent-style-serif :where(
+  .fresh-agent-approval-button,
+  .fresh-agent-question-option,
+  .fresh-agent-question-submit,
+  .fresh-agent-error-action,
+  .fresh-agent-session-ended-action,
+  .fresh-agent-composer-action
+) {
+  background: transparent;
+  border-color: var(--fresh-agent-border);
+  border-radius: 0.22rem;
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-meta-font-family);
+  font-size: 0.62rem;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.fresh-agent-style-serif :where(
+  .fresh-agent-approval-button,
+  .fresh-agent-question-option,
+  .fresh-agent-question-submit,
+  .fresh-agent-error-action,
+  .fresh-agent-session-ended-action,
+  .fresh-agent-composer-action
+):hover:not(:disabled) {
+  background: var(--fresh-agent-accent-soft);
+  color: var(--fresh-agent-text);
+}
+
+.fresh-agent-style-serif :where(.fresh-agent-approval-button-primary, .fresh-agent-composer-action[type="submit"]) {
+  background: var(--fresh-agent-text);
+  border-color: var(--fresh-agent-text);
+  color: var(--fresh-agent-surface);
+}
+
+.fresh-agent-style-serif .fresh-agent-approval-button-deny:hover:not(:disabled) {
+  background: var(--fresh-agent-danger-soft);
+  color: var(--fresh-agent-danger);
+}
+
+.fresh-agent-style-serif .fresh-agent-question-heading svg {
+  color: var(--fresh-agent-accent);
+}
+
+.fresh-agent-style-serif .fresh-agent-question-option {
+  background: var(--fresh-agent-surface);
+  min-width: 7.4rem;
+}
+
+.fresh-agent-style-serif .fresh-agent-question-option span:first-child {
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.fresh-agent-style-serif .fresh-agent-question-option span:last-child {
+  color: var(--fresh-agent-soft-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  font-size: 0.58rem;
+  line-height: 1.35;
+}
+
+.fresh-agent-style-serif .fresh-agent-question-input,
+.fresh-agent-style-serif .fresh-agent-composer-filter-input {
+  background: var(--fresh-agent-surface);
+  border-color: var(--fresh-agent-border);
+  color: var(--fresh-agent-text);
+}
+
+.fresh-agent-style-serif .fresh-agent-activity-strip {
+  margin: 0.55rem 0 0.7rem;
+}
+
+.fresh-agent-style-serif .fresh-agent-activity-summary,
+.fresh-agent-style-serif .fresh-agent-thinking-row,
+.fresh-agent-style-serif .fresh-agent-thinking-details,
+.fresh-agent-style-serif .fresh-agent-tool-block,
+.fresh-agent-style-serif .fresh-agent-tool-result,
+.fresh-agent-style-serif .fresh-agent-file-diff {
+  border-left-color: var(--fresh-agent-border);
+}
+
+.fresh-agent-style-serif .fresh-agent-activity-summary {
+  color: var(--fresh-agent-soft-text);
+  padding: 0.15rem 0 0.15rem 0.8rem;
+}
+
+.fresh-agent-style-serif .fresh-agent-activity-summary [role="status"] {
+  color: var(--fresh-agent-soft-text);
+  font-family: var(--fresh-agent-meta-font-family);
+  font-size: 0.58rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.fresh-agent-style-serif .fresh-agent-activity-summary [data-slot="name"] {
+  background: transparent;
+  color: var(--fresh-agent-accent);
+  padding: 0;
+}
+
+.fresh-agent-style-serif .fresh-agent-tool-block {
+  color: var(--fresh-agent-soft-text);
+  font-size: 0.58rem;
+  margin: 0.4rem 0 0.5rem;
+}
+
+.fresh-agent-style-serif :where(.fresh-agent-tool-trigger, .fresh-agent-thinking-trigger, .fresh-agent-file-diff-trigger) {
+  border-radius: 0 0.18rem 0.18rem 0;
+  color: var(--fresh-agent-soft-text);
+  padding-bottom: 0.2rem;
+  padding-top: 0.2rem;
+}
+
+.fresh-agent-style-serif :where(.fresh-agent-tool-trigger, .fresh-agent-thinking-trigger, .fresh-agent-file-diff-trigger):hover {
+  background: var(--fresh-agent-accent-soft);
+  color: var(--fresh-agent-text);
+}
+
+.fresh-agent-style-serif .fresh-agent-tool-name,
+.fresh-agent-style-serif .fresh-agent-file-diff-label {
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-meta-font-family);
+}
+
+.fresh-agent-style-serif .fresh-agent-tool-preview,
+.fresh-agent-style-serif .fresh-agent-tool-result-summary,
+.fresh-agent-style-serif .fresh-agent-file-diff-status {
+  color: var(--fresh-agent-soft-text);
+  font-family: var(--fresh-agent-meta-font-family);
+}
+
+.fresh-agent-style-serif .fresh-agent-tool-status svg[aria-label="complete"] {
+  color: var(--fresh-agent-success);
+}
+
+.fresh-agent-style-serif .fresh-agent-tool-pre {
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-mono-font-family);
+  line-height: 1.55;
+}
+
+.fresh-agent-style-serif .fresh-agent-thinking-body {
+  background: var(--fresh-agent-panel-surface);
+  border-color: var(--fresh-agent-border);
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-copy-font-family);
+}
+
+.fresh-agent-style-serif .fresh-agent-diff-title {
+  margin-bottom: 0.6rem;
+}
+
+.fresh-agent-style-serif .fresh-agent-file-diff-body {
+  color: var(--fresh-agent-muted-text);
+  line-height: 1.65;
+}
+
+.fresh-agent-style-serif [data-diff] {
+  background: var(--fresh-agent-surface);
+}
+
+.fresh-agent-style-serif [data-diff] .bg-red-500\/10,
+.fresh-agent-style-serif .fresh-agent-file-diff-body .bg-destructive\/10 {
+  background: var(--fresh-agent-danger-soft);
+  color: var(--fresh-agent-danger);
+}
+
+.fresh-agent-style-serif [data-diff] .bg-green-500\/10,
+.fresh-agent-style-serif .fresh-agent-file-diff-body .bg-success\/10 {
+  background: var(--fresh-agent-success-soft);
+  color: var(--fresh-agent-success);
+}
+
+.fresh-agent-style-serif [data-diff] .text-muted-foreground,
+.fresh-agent-style-serif .fresh-agent-file-diff-body .text-muted-foreground {
+  color: var(--fresh-agent-soft-text);
+}
+
+.fresh-agent-style-serif .fresh-agent-sidebar {
+  background: var(--fresh-agent-panel-surface);
+  border-color: var(--fresh-agent-border);
+  color: var(--fresh-agent-muted-text);
+}
+
+.fresh-agent-style-serif .fresh-agent-sidebar-section {
+  background: transparent;
+  border-color: var(--fresh-agent-border);
+}
+
+.fresh-agent-style-serif .fresh-agent-sidebar-list {
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+
+.fresh-agent-style-serif .fresh-agent-composer {
+  background: var(--fresh-agent-surface);
+  border-top-color: var(--fresh-agent-border);
+  padding: 0.95rem 1.4rem max(env(safe-area-inset-bottom), 0.95rem);
+}
+
+.fresh-agent-style-serif .fresh-agent-composer-input {
+  background: var(--fresh-agent-panel-surface);
+  border-color: var(--fresh-agent-border);
+  border-radius: 0.25rem;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fresh-agent-border) 45%, transparent);
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  line-height: 1.5;
+}
+
+.fresh-agent-style-serif .fresh-agent-composer-input::placeholder {
+  color: var(--fresh-agent-soft-text);
+}
+
+.fresh-agent-style-serif .fresh-agent-composer-action {
+  background: var(--fresh-agent-panel-surface);
+}
+
+.fresh-agent-style-serif .fresh-agent-composer-menu,
+.fresh-agent-style-serif .fresh-agent-queued-message,
+.fresh-agent-style-serif .fresh-agent-attachment {
+  background: var(--fresh-agent-panel-surface);
+  border-color: var(--fresh-agent-border);
+  color: var(--fresh-agent-muted-text);
+}
+
+.fresh-agent-style-serif .fresh-agent-composer-menu-item {
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-meta-font-family);
+}
+
+.fresh-agent-style-serif .fresh-agent-composer-menu-item:hover,
+.fresh-agent-style-serif .fresh-agent-composer-menu-item.bg-accent {
+  background: var(--fresh-agent-accent-soft);
+  color: var(--fresh-agent-text);
+}
+
+.fresh-agent-style-serif .fresh-agent-composer-menu-help {
+  border-color: var(--fresh-agent-border);
+  color: var(--fresh-agent-soft-text);
+}
+
+.fresh-agent-style-serif .fresh-agent-scroll-bottom {
+  background: var(--fresh-agent-panel-surface);
+  border-color: var(--fresh-agent-border);
+  bottom: 0.9rem;
+  box-shadow: none;
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-meta-font-family);
+  left: auto;
+  right: 1.25rem;
+  transform: none;
+}
+
+.fresh-agent-style-serif .fresh-agent-thinking-bar > div {
   background: var(--fresh-agent-subtle-surface);
 }
 

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -149,6 +149,21 @@ test.describe('Fresh Agent', () => {
       return settings?.freshAgent?.providers?.freshcodex?.style ?? null
     }).toBe('serif')
 
+    await page.route('**/api/fresh-agent/diff*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          diff: [
+            'diff --git a/src/index.css b/src/index.css',
+            '@@ -1,3 +1,3 @@',
+            '-.old { color: blue; }',
+            '+.fresh-agent-style-serif { color: #1d1a16; }',
+            ' context line',
+          ].join('\n'),
+        }),
+      })
+    })
     await page.route('**/api/fresh-agent/threads/freshcodex/codex/style-thread*', async (route) => {
       await route.fulfill({
         status: 200,
@@ -161,19 +176,58 @@ test.describe('Fresh Agent', () => {
           revision: 1,
           latestTurnId: 'turn-style',
           status: 'idle',
-          summary: 'Serif style summary',
-          capabilities: { send: true, interrupt: true, approvals: false, questions: false, fork: true },
+          summary: '',
+          capabilities: { send: true, interrupt: true, approvals: true, questions: true, fork: true },
           settings: { model: 'gpt-5.4-flash', permissionMode: 'on-request', effort: 'high', plugins: [] },
           tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 },
-          pendingApprovals: [],
-          pendingQuestions: [],
-          turns: [{
-            id: 'turn-style',
-            turnId: 'turn-style',
-            role: 'assistant',
-            summary: 'Serif transcript line',
-            items: [{ id: 'item-style', kind: 'text', text: 'Serif transcript line' }],
+          pendingApprovals: [{
+            requestId: 'approval-style',
+            toolName: 'Bash',
+            input: { command: 'git diff -- src/index.css' },
+            decisionReason: 'Review command output before continuing.',
           }],
+          pendingQuestions: [{
+            requestId: 'question-style',
+            questions: [{
+              header: 'Direction',
+              question: 'Which style should apply?',
+              options: [
+                { label: 'Serif', description: 'Use the reference visual' },
+                { label: 'Sans', description: 'Keep current UI' },
+              ],
+              multiSelect: false,
+            }],
+          }],
+          worktrees: [{ id: 'wt-style', path: '/tmp/freshell', branch: 'freshagent-serif-full-style' }],
+          diffs: [{ id: 'diff-style', path: 'src/index.css', title: 'src/index.css', status: 'modified' }],
+          turns: [
+            {
+              id: 'turn-style-user',
+              turnId: 'turn-style-user',
+              role: 'user',
+              summary: 'Apply the reference treatment',
+              items: [{ id: 'item-style-user', kind: 'text', text: 'Apply the reference treatment.' }],
+            },
+            {
+              id: 'turn-style',
+              turnId: 'turn-style',
+              role: 'assistant',
+              summary: 'Serif transcript line',
+              items: [
+                { id: 'item-style', kind: 'text', text: '## Serif transcript line\n\nThe transcript uses the serif reference treatment.' },
+                { id: 'think-style', kind: 'thinking', text: 'private style reasoning should stay hidden' },
+                { id: 'tool-style', kind: 'tool_use', toolUseId: 'tool-style-call', name: 'Bash', input: { command: 'rg FreshAgent src' } },
+                { id: 'result-style', kind: 'tool_result', toolUseId: 'tool-style-call', content: 'src/components/fresh-agent/FreshAgentView.tsx', isError: false },
+              ],
+            },
+            {
+              id: 'turn-style-continuation',
+              turnId: 'turn-style-continuation',
+              role: 'assistant',
+              summary: 'Continuation line',
+              items: [{ id: 'item-style-continuation', kind: 'text', text: 'The continuation should not repeat the agent label.' }],
+            },
+          ],
         }),
       })
     })
@@ -224,7 +278,15 @@ test.describe('Fresh Agent', () => {
 
     const transcript = freshcodexRoot.locator('.fresh-agent-transcript-copy').first()
     await expect(transcript).toBeVisible({ timeout: 10_000 })
-    await expect(transcript.getByText('Serif transcript line')).toBeVisible()
+    await expect(freshcodexRoot.getByText('Serif transcript line')).toBeVisible()
+    await expect(freshcodexRoot.getByText('private style reasoning should stay hidden')).toHaveCount(0)
+    await expect(freshcodexRoot.locator('.fresh-agent-turn-header', { hasText: 'Freshcodex' })).toHaveCount(1)
+    await expect(freshcodexRoot.locator('[data-turn-continuation="true"]')).toHaveCount(1)
+    await freshcodexRoot.getByRole('button', { name: 'Toggle activity details' }).click()
+    await expect(freshcodexRoot.getByText('private style reasoning should stay hidden')).toHaveCount(0)
+    await freshcodexRoot.getByRole('button', { name: 'Thinking' }).click()
+    await expect(freshcodexRoot.getByText('private style reasoning should stay hidden')).toBeVisible()
+    await freshcodexRoot.getByRole('button', { name: /Diff: src\/index\.css/ }).click()
     const transcriptFont = await transcript.evaluate((node) => getComputedStyle(node).fontFamily)
     expect(transcriptFont.toLowerCase()).toContain('georgia')
     const rootFont = await freshcodexRoot.evaluate((node) => getComputedStyle(node).fontFamily)
@@ -232,6 +294,24 @@ test.describe('Fresh Agent', () => {
     const composerFont = await freshcodexRoot.getByRole('textbox', { name: 'Chat message input' })
       .evaluate((node) => getComputedStyle(node).fontFamily)
     expect(composerFont.toLowerCase()).toContain('georgia')
+    const toolFont = await freshcodexRoot.locator('.fresh-agent-tool-block').first()
+      .evaluate((node) => getComputedStyle(node).fontFamily)
+    expect(toolFont.toLowerCase()).toContain('ibm plex mono')
+    const approvalBackground = await freshcodexRoot.locator('.fresh-agent-approval-card').first()
+      .evaluate((node) => getComputedStyle(node).backgroundColor)
+    expect(approvalBackground).toBe('rgb(251, 250, 247)')
+    const questionBackground = await freshcodexRoot.locator('.fresh-agent-question-card').first()
+      .evaluate((node) => getComputedStyle(node).backgroundColor)
+    expect(questionBackground).toBe('rgb(251, 250, 247)')
+    const diffBackground = await freshcodexRoot.locator('.fresh-agent-diff-panel').first()
+      .evaluate((node) => getComputedStyle(node).backgroundColor)
+    expect(diffBackground).toBe('rgb(251, 250, 247)')
+    const composerButtonFont = await freshcodexRoot.locator('.fresh-agent-composer-action').first()
+      .evaluate((node) => getComputedStyle(node).fontFamily)
+    expect(composerButtonFont.toLowerCase()).toContain('ibm plex mono')
+    const chromeFont = await page.locator('[data-context="tab-add"]').evaluate((node) => getComputedStyle(node).fontFamily)
+    expect(chromeFont.toLowerCase()).not.toContain('georgia')
+    expect(chromeFont.toLowerCase()).not.toContain('literata')
     const watermarkOpacity = await freshcodexRoot.getByTestId('fresh-agent-watermark')
       .evaluate((node) => Number(getComputedStyle(node).opacity))
     expect(watermarkOpacity).toBeLessThanOrEqual(0.004)

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -210,7 +210,9 @@ describe('FreshAgentTranscript', () => {
     )
 
     expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('thought · 1 tool used')
+    expect(screen.queryByText('the race is in the close handler')).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Toggle activity details' }))
+    expect(screen.queryByText('the race is in the close handler')).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Thinking' }))
     expect(screen.getAllByText('the race is in the close handler').length).toBeGreaterThanOrEqual(1)
   })
@@ -260,6 +262,114 @@ describe('FreshAgentTranscript', () => {
 
     expect(screen.getByLabelText('running')).toBeInTheDocument()
     expect(screen.getByText('Thinking')).toBeInTheDocument()
+    expect(screen.queryByText('still reasoning about the fix')).not.toBeInTheDocument()
+  })
+
+  it('keeps the latest completed tool in the live reel while the turn is still streaming', () => {
+    render(
+      <FreshAgentTranscript
+        isStreaming
+        turns={[
+          {
+            id: 'turn-1',
+            role: 'assistant',
+            summary: 'streaming after tool',
+            items: [
+              {
+                id: 'tool-1',
+                kind: 'tool_use',
+                toolUseId: 'call-1',
+                name: 'Read',
+                input: { file_path: 'src/App.tsx' },
+              },
+              { id: 'result-1', kind: 'tool_result', toolUseId: 'call-1', content: 'ok', isError: false },
+              { id: 'item-1', kind: 'text', text: 'I found the relevant file.' },
+            ],
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByLabelText('running')).toBeInTheDocument()
+    expect(screen.getByText('Read')).toBeInTheDocument()
+    expect(screen.queryByText('1 tool used')).not.toBeInTheDocument()
+  })
+
+  it('shows the speaker label once for consecutive turns from the same role', () => {
+    const { container } = render(
+      <FreshAgentTranscript
+        agentLabel="freshclaude"
+        turns={[
+          {
+            id: 'turn-user-1',
+            role: 'user',
+            items: [{ id: 'item-user-1', kind: 'text', text: 'First request' }],
+          },
+          {
+            id: 'turn-agent-1',
+            role: 'assistant',
+            items: [{ id: 'item-agent-1', kind: 'text', text: 'First response line' }],
+          },
+          {
+            id: 'turn-agent-2',
+            role: 'assistant',
+            items: [{ id: 'item-agent-2', kind: 'text', text: 'Second response line' }],
+          },
+          {
+            id: 'turn-agent-3',
+            role: 'assistant',
+            items: [{ id: 'item-agent-3', kind: 'text', text: 'Third response line' }],
+          },
+          {
+            id: 'turn-user-2',
+            role: 'user',
+            items: [{ id: 'item-user-2', kind: 'text', text: 'Follow-up' }],
+          },
+          {
+            id: 'turn-agent-4',
+            role: 'assistant',
+            items: [{ id: 'item-agent-4', kind: 'text', text: 'Fresh response group' }],
+          },
+        ]}
+      />,
+    )
+
+    const visibleHeaders = Array.from(container.querySelectorAll('.fresh-agent-turn-header'))
+      .map((node) => node.textContent)
+    expect(visibleHeaders.filter((text) => text === 'freshclaude')).toHaveLength(2)
+    expect(container.querySelectorAll('[data-turn-continuation="true"]')).toHaveLength(2)
+  })
+
+  it('tolerates duplicate provider turn ids without duplicate React keys', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      render(
+        <FreshAgentTranscript
+          turns={[
+            {
+              id: 'provider-duplicate',
+              role: 'user',
+              items: [{ id: 'item-user', kind: 'text', text: 'First duplicate id turn' }],
+            },
+            {
+              id: 'provider-duplicate',
+              role: 'assistant',
+              items: [{ id: 'item-agent', kind: 'text', text: 'Second duplicate id turn' }],
+            },
+          ]}
+        />,
+      )
+
+      expect(screen.getByText('First duplicate id turn')).toBeInTheDocument()
+      expect(screen.getByText('Second duplicate id turn')).toBeInTheDocument()
+      expect(consoleError).not.toHaveBeenCalledWith(
+        expect.stringContaining('Encountered two children with the same key'),
+        expect.anything(),
+        expect.anything(),
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 
   it('keeps auto-scroll enabled for streamed text when already at the bottom', () => {


### PR DESCRIPTION
## Summary
- extend the Fresh Agent serif style beyond transcript fonts to tool use blocks, approval/question cards, diffs, composer, sidebar details, colors, and spacing
- scope serif styling to opted-in Fresh Agent panes only, leaving the surrounding Freshell chrome untouched
- add e2e coverage for serif pane rendering across nested Fresh Agent surfaces

## Verification
- npm run typecheck:client
- npm run lint
- npm run test:vitest -- test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.test.tsx test/unit/client/components/fresh-agent/FreshAgentApprovalCard.test.tsx --run
- npm run test:e2e:chromium -- --grep "style setting persists per Fresh Agent pane type"
- FRESHELL_TEST_SUMMARY="freshagent serif full style rebased" npm run check