### PR TITLE
Fix fresh-agent transcript activity regressions

### DIFF
--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -196,6 +196,92 @@ function buildBlocks(items: FreshAgentTranscriptItem[]): RenderBlock[] {
   return blocks
 }
 
+function isActivityOnlyTurn(turn: FreshAgentTurn): boolean {
+  return turn.items.length > 0 && turn.items.every(isActivityLike)
+}
+
+function mergeActivityOnlyTurns(previous: FreshAgentTurn, next: FreshAgentTurn): FreshAgentTurn {
+  return {
+    ...next,
+    id: `${previous.id}:${next.id}`,
+    turnId: next.turnId ?? next.id,
+    summary: [previous.summary, next.summary].filter(Boolean).join('\n\n'),
+    items: [...previous.items, ...next.items],
+    model: next.model ?? previous.model,
+    timestamp: next.timestamp ?? previous.timestamp,
+  }
+}
+
+function coalesceActivityOnlyTurns(turns: FreshAgentTurn[]): FreshAgentTurn[] {
+  const coalesced: FreshAgentTurn[] = []
+  for (const turn of turns) {
+    const previous = coalesced[coalesced.length - 1]
+    if (
+      previous
+      && turn.role !== 'user'
+      && previous.role === turn.role
+      && isActivityOnlyTurn(previous)
+      && isActivityOnlyTurn(turn)
+    ) {
+      coalesced[coalesced.length - 1] = mergeActivityOnlyTurns(previous, turn)
+      continue
+    }
+    coalesced.push(turn)
+  }
+  return coalesced
+}
+
+function normalizeActivityRows(rows: ActivityRow[], live: boolean): ActivityRow[] {
+  const runningToolIds = rows
+    .filter((row): row is Extract<ActivityRow, { type: 'tool' }> => row.type === 'tool' && row.tool.status === 'running')
+    .map((row) => row.tool.id)
+  const activeRunningToolId = live ? (runningToolIds.at(-1) ?? null) : null
+
+  let changed = false
+  const settledRows = rows.map((row) => {
+    if (
+      row.type !== 'tool'
+      || row.tool.status !== 'running'
+      || row.tool.id === activeRunningToolId
+    ) {
+      return row
+    }
+    changed = true
+    return {
+      type: 'tool' as const,
+      tool: {
+        ...row.tool,
+        status: 'complete' as const,
+      },
+    }
+  })
+  return changed ? settledRows : rows
+}
+
+function selectLiveActivityBlockId(turns: FreshAgentTurn[], isStreaming: boolean): string | null {
+  let latestActivityBlockId: string | null = null
+  let latestTrailingThinkingBlockId: string | null = null
+
+  turns.forEach((turn, turnIndex) => {
+    const blocks = buildBlocks(turn.items)
+    for (const block of blocks) {
+      if (block.kind === 'activity') {
+        latestActivityBlockId = block.id
+      }
+    }
+
+    if (turnIndex === turns.length - 1) {
+      const lastBlock = blocks[blocks.length - 1]
+      if (lastBlock?.kind === 'activity' && lastBlock.rows.at(-1)?.type === 'thinking') {
+        latestTrailingThinkingBlockId = lastBlock.id
+      }
+    }
+  })
+
+  if (isStreaming) return latestActivityBlockId
+  return latestTrailingThinkingBlockId
+}
+
 function FreshAgentThinkingRow({ text }: { text: string }) {
   const [expanded, setExpanded] = useState(false)
   return (
@@ -227,16 +313,19 @@ function FreshAgentActivityStrip({
   live?: boolean
 }) {
   const [expanded, setExpanded] = useState(false)
-  const tools = activityTools(rows)
+  const displayRows = useMemo(() => (
+    normalizeActivityRows(rows, live)
+  ), [live, rows])
+  const tools = activityTools(displayRows)
   const hasErrors = tools.some((tool) => tool.isError)
-  const lastRow = rows[rows.length - 1] ?? null
-  const runningTool = [...tools].reverse().find((tool) => tool.status === 'running') ?? null
+  const lastRow = displayRows[displayRows.length - 1] ?? null
+  const runningTool = live ? [...tools].reverse().find((tool) => tool.status === 'running') ?? null : null
   const thinkingLive = live && lastRow?.type === 'thinking'
   const liveTool = !thinkingLive && live ? (tools[tools.length - 1] ?? null) : null
   const activeTool = runningTool ?? liveTool
-  const running = activeTool !== null || thinkingLive
+  const running = live && (activeTool !== null || thinkingLive)
 
-  if (rows.length === 0) return null
+  if (displayRows.length === 0) return null
 
   const reelName = activeTool ? activeTool.name : thinkingLive ? 'Thinking' : null
   const reelPreview = activeTool ? getToolPreview(activeTool.name, activeTool.input) : null
@@ -269,7 +358,7 @@ function FreshAgentActivityStrip({
           <SlotReel
             toolName={running ? reelName : null}
             previewText={running ? reelPreview : null}
-            settledText={running ? undefined : settledSummary(rows)}
+            settledText={running ? undefined : settledSummary(displayRows)}
           />
         </div>
       ) : (
@@ -283,7 +372,7 @@ function FreshAgentActivityStrip({
           >
             <ChevronRight className="h-3 w-3 rotate-90 transition-transform" />
           </button>
-          {rows.map((row) => (
+          {displayRows.map((row) => (
             row.type === 'thinking'
               ? <FreshAgentThinkingRow key={row.id} text={row.text} />
               : <FreshAgentToolBlock key={row.tool.id} tool={row.tool} initialExpanded={false} />
@@ -292,27 +381,6 @@ function FreshAgentActivityStrip({
       )}
     </div>
   )
-}
-
-function countTools(turn: FreshAgentTurn): number {
-  return activityTools(buildActivity(turn.items.filter(isToolLike))).length
-}
-
-function getTurnSummary(turn: FreshAgentTurn, agentLabel?: string): string {
-  const text = turn.items
-    .filter((item): item is Extract<FreshAgentTranscriptItem, { kind: 'text' }> => item.kind === 'text')
-    .map((item) => stripSystemReminders(item.text))
-    .join(' ')
-    .trim()
-    .replace(/\s+/g, ' ')
-  const base = text || turn.summary || getTurnLabel(turn, agentLabel)
-  const short = base.length > 44 ? `${base.slice(0, 41)}...` : base
-  const toolCount = countTools(turn)
-  const itemCount = turn.items.filter((item) => item.kind === 'text').length
-  const parts: string[] = []
-  if (toolCount > 0) parts.push(`${toolCount} tool${toolCount === 1 ? '' : 's'}`)
-  if (itemCount > 0 && turn.role !== 'user') parts.push(`${itemCount} msg${itemCount === 1 ? '' : 's'}`)
-  return parts.length > 0 ? `${short} -> ${parts.join(', ')}` : short
 }
 
 type TurnActionProps = {
@@ -324,87 +392,26 @@ type TurnActionProps = {
   onOpenActions?: (turn: FreshAgentTurn) => void
 }
 
-function CollapsedFreshAgentTurn({
-  turn,
-  actions,
-  agentLabel,
-  showModel,
-}: {
-  turn: FreshAgentTurn
-  actions: TurnActionProps
-  agentLabel?: string
-  showModel: boolean
-}) {
-  const [expanded, setExpanded] = useState(false)
-  const summary = getTurnSummary(turn, agentLabel)
-  if (expanded) {
-    return (
-      <div className="fresh-agent-collapsed-turn-expanded space-y-2">
-        <button
-          type="button"
-          onClick={() => setExpanded(false)}
-          className="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-          aria-expanded={true}
-          aria-label="Collapse turn"
-        >
-          <ChevronRight className="h-3 w-3 rotate-90 transition-transform" />
-          <span className="truncate font-mono opacity-70">{summary}</span>
-        </button>
-        <FreshAgentTurnArticle
-          turn={turn}
-          compact={false}
-          isLatest={false}
-          actions={actions}
-          agentLabel={agentLabel}
-          showModel={showModel}
-          showHeader
-          continuation={false}
-          isStreaming={false}
-        />
-      </div>
-    )
-  }
-  return (
-    <button
-      type="button"
-      onClick={() => setExpanded(true)}
-      className="fresh-agent-collapsed-turn flex w-full items-center gap-1 text-left text-xs text-muted-foreground transition-colors hover:text-foreground"
-      aria-expanded={false}
-      aria-label="Expand turn"
-    >
-      <ChevronRight className="h-3 w-3 shrink-0 transition-transform" />
-      <span className="truncate font-mono">{summary}</span>
-    </button>
-  )
-}
-
 function FreshAgentTurnArticle({
   turn,
-  compact,
-  isLatest,
   actions,
   agentLabel,
   showModel,
   showHeader,
   continuation,
-  isStreaming,
+  liveActivityBlockId,
 }: {
   turn: FreshAgentTurn
-  compact: boolean
-  isLatest: boolean
   actions: TurnActionProps
   agentLabel?: string
   showModel: boolean
   showHeader: boolean
   continuation: boolean
-  isStreaming: boolean
+  liveActivityBlockId: string | null
 }) {
   const isUser = turn.role === 'user'
   const blocks = buildBlocks(turn.items)
   const turnLabel = getTurnLabel(turn, agentLabel)
-  const lastActivityBlockIndex = blocks.reduce((lastIndex, block, index) => (
-    block.kind === 'activity' ? index : lastIndex
-  ), -1)
   // Long-press opens the action sheet on touch devices (iOS fires no
   // contextmenu event; Android does — both paths land on onOpenActions and
   // the second call is a no-op re-set of the same state).
@@ -418,7 +425,6 @@ function FreshAgentTurnArticle({
       className={cn(
         'fresh-agent-turn group relative mt-3 w-full border-l-2 py-0.5 pl-2.5 pr-1 first:mt-0',
         isUser ? 'border-l-[hsl(var(--primary))]' : 'border-l-border',
-        compact && 'opacity-95',
         continuation && 'mt-1.5',
       )}
       data-turn-role={turn.role}
@@ -454,14 +460,13 @@ function FreshAgentTurnArticle({
         </div>
       ) : null}
       <div className="fresh-agent-transcript-copy space-y-1.5">
-        {blocks.length > 0 ? blocks.map((block, blockIndex) => {
+        {blocks.length > 0 ? blocks.map((block) => {
           if (block.kind === 'activity') {
-            const blockEndsWithThinking = block.rows[block.rows.length - 1]?.type === 'thinking'
             return (
               <FreshAgentActivityStrip
                 key={block.id}
                 rows={block.rows}
-                live={isLatest && blockIndex === lastActivityBlockIndex && (isStreaming || blockEndsWithThinking)}
+                live={block.id === liveActivityBlockId}
               />
             )
           }
@@ -501,6 +506,8 @@ export function FreshAgentTranscript({
   const [contextMenu, setContextMenu] = useState<FreshAgentTurnContextMenuState>(null)
   const [sheetTurn, setSheetTurn] = useState<FreshAgentTurn | null>(null)
   const coarsePointer = useCoarsePointer()
+  const displayTurns = useMemo(() => coalesceActivityOnlyTurns(turns), [turns])
+  const liveActivityBlockId = useMemo(() => selectLiveActivityBlockId(displayTurns, isStreaming), [displayTurns, isStreaming])
   const transcriptSignature = useMemo(() => (
     turns.map((turn) => {
       const itemSignature = turn.items.map((item) => {
@@ -549,8 +556,6 @@ export function FreshAgentTranscript({
     }
   }, [atBottom, transcriptSignature])
 
-  const collapsedCutoff = Math.max(0, turns.length - 8)
-
   return (
     <div className="relative min-h-0 flex-1">
       <div
@@ -562,31 +567,17 @@ export function FreshAgentTranscript({
           setAtBottom(node.scrollHeight - node.scrollTop - node.clientHeight < 24)
         }}
       >
-        {turns.map((turn, index) => (
-          index < collapsedCutoff
-            ? (
-              <CollapsedFreshAgentTurn
-                key={`${turn.id}:${index}`}
-                turn={turn}
-                actions={actions}
-                agentLabel={agentLabel}
-                showModel={showModel}
-              />
-            )
-            : (
-              <FreshAgentTurnArticle
-                key={`${turn.id}:${index}`}
-                turn={turn}
-                compact={index < collapsedCutoff}
-                isLatest={index === turns.length - 1}
-                actions={actions}
-                agentLabel={agentLabel}
-                showModel={showModel}
-                showHeader={index === collapsedCutoff || turns[index - 1]?.role !== turn.role}
-                continuation={index > collapsedCutoff && turns[index - 1]?.role === turn.role}
-                isStreaming={isStreaming}
-              />
-            )
+        {displayTurns.map((turn, index) => (
+          <FreshAgentTurnArticle
+            key={`${turn.id}:${index}`}
+            turn={turn}
+            actions={actions}
+            agentLabel={agentLabel}
+            showModel={showModel}
+            showHeader={index === 0 || displayTurns[index - 1]?.role !== turn.role}
+            continuation={index > 0 && displayTurns[index - 1]?.role === turn.role}
+            liveActivityBlockId={liveActivityBlockId}
+          />
         ))}
       </div>
       <FreshAgentTurnContextMenu

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -52,6 +52,48 @@ const EARLY_STATES = new Set(['creating', 'starting'])
 const BUSY_STATES = new Set(['running', 'compacting'])
 const log = createLogger('FreshAgentView')
 
+function getSnapshotIdentity(snapshot: FreshAgentSnapshot): string | null {
+  if (!snapshot.sessionType || !snapshot.provider || !snapshot.threadId) return null
+  return `${snapshot.sessionType}:${snapshot.provider}:${snapshot.threadId}`
+}
+
+function getTurnKey(turn: FreshAgentTurn): string {
+  return (turn as { turnId?: string }).turnId ?? turn.id
+}
+
+function isSnapshotInFlight(snapshot: FreshAgentSnapshot): boolean {
+  return snapshot.status === 'running' || snapshot.status === 'compacting'
+}
+
+function mergeSnapshotForDisplay(
+  previous: FreshAgentSnapshot | null,
+  next: FreshAgentSnapshot,
+): FreshAgentSnapshot {
+  if (!previous) return next
+  const previousIdentity = getSnapshotIdentity(previous)
+  const nextIdentity = getSnapshotIdentity(next)
+  if (!previousIdentity || previousIdentity !== nextIdentity) return next
+  if (
+    typeof previous.revision === 'number'
+    && typeof next.revision === 'number'
+    && next.revision < previous.revision
+  ) {
+    return previous
+  }
+  if (next.turns.length >= previous.turns.length || !isSnapshotInFlight(next)) return next
+
+  const nextByKey = new Map(next.turns.map((turn) => [getTurnKey(turn), turn]))
+  const previousKeys = new Set(previous.turns.map(getTurnKey))
+  const mergedTurns = previous.turns.map((turn) => nextByKey.get(getTurnKey(turn)) ?? turn)
+  for (const turn of next.turns) {
+    if (!previousKeys.has(getTurnKey(turn))) {
+      mergedTurns.push(turn)
+    }
+  }
+
+  return { ...next, turns: mergedTurns }
+}
+
 function getEffectiveFreshAgentModel(content: FreshAgentPaneContent): string | undefined {
   return normalizeFreshAgentModel(content.sessionType, content.provider, content.model)
 }
@@ -316,6 +358,11 @@ export function FreshAgentView({
   })
   const refreshRequest = useAppSelector((state) => state.panes.refreshRequestsByPane?.[tabId]?.[paneId] ?? null)
   const [snapshot, setSnapshot] = useState<FreshAgentSnapshot | null>(null)
+  const snapshotRef = useRef<FreshAgentSnapshot | null>(null)
+  const commitSnapshot = useCallback((next: FreshAgentSnapshot | null) => {
+    snapshotRef.current = next
+    setSnapshot(next)
+  }, [])
   const [loadError, setLoadError] = useState<string | null>(null)
   const [snapshotRefreshNonce, setSnapshotRefreshNonce] = useState(0)
   const [queuedMessages, setQueuedMessages] = useState<string[]>([])
@@ -537,7 +584,7 @@ export function FreshAgentView({
         provider: current.provider,
       })
     }
-    setSnapshot(null)
+    commitSnapshot(null)
     setLoadError(null)
     setQueuedMessages([])
     setLocalEcho(null)
@@ -557,7 +604,7 @@ export function FreshAgentView({
         status: 'creating',
       },
     }))
-  }, [dispatch, paneId, sendFreshAgentMessage, tabId])
+  }, [commitSnapshot, dispatch, paneId, sendFreshAgentMessage, tabId])
 
   const sendFork = useCallback((atTurnId?: string) => {
     const current = paneContentRef.current
@@ -605,7 +652,7 @@ export function FreshAgentView({
     if (!paneRefreshTargetMatchesContent(refreshRequest.target, current)) return
 
     handledRefreshRequestIdRef.current = refreshRequest.requestId
-    setSnapshot(null)
+    commitSnapshot(null)
     setLoadError(null)
 
     if (current.sessionId) {
@@ -629,7 +676,7 @@ export function FreshAgentView({
     }
 
     dispatch(consumePaneRefreshRequest({ tabId, paneId, requestId: refreshRequest.requestId }))
-  }, [buildCreateMessage, dispatch, hidden, paneId, refreshRequest, sendFreshAgentMessage, tabId])
+  }, [buildCreateMessage, commitSnapshot, dispatch, hidden, paneId, refreshRequest, sendFreshAgentMessage, tabId])
 
   const triggerRecovery = useCallback(() => {
     if (restoreTimeoutRef.current !== null) {
@@ -827,7 +874,7 @@ export function FreshAgentView({
             provider: paneContent.provider,
           })
         }
-        setSnapshot(null)
+        commitSnapshot(null)
         dispatch(updatePaneContent({
           tabId,
           paneId,
@@ -848,7 +895,7 @@ export function FreshAgentView({
       }
     })
     return unsubscribe
-  }, [dispatch, migratePendingAutoTitle, paneContent, paneContent.createRequestId, paneId, sendFreshAgentMessage, tabId, ws])
+  }, [commitSnapshot, dispatch, migratePendingAutoTitle, paneContent, paneContent.createRequestId, paneId, sendFreshAgentMessage, tabId, ws])
 
   useEffect(() => {
     if (!snapshotThreadId) return
@@ -875,12 +922,13 @@ export function FreshAgentView({
           autoTitleFreshBoundaryRef.current = false
           autoTitleSentRef.current = true
         }
-        setSnapshot(resolved)
+        const displaySnapshot = mergeSnapshotForDisplay(snapshotRef.current, resolved)
+        commitSnapshot(displaySnapshot)
         setSnapshotAutoTitleIdentity(requestAutoTitleIdentity)
         const echo = localEchoRef.current
         if (echo) {
           const needle = echo.slice(0, 80)
-          const echoLanded = resolved.turns.some((turn) => (
+          const echoLanded = displaySnapshot.turns.some((turn) => (
             turn.role === 'user' && turn.items.some((item) => (
               item.kind === 'text' && item.text.includes(needle)
             ))
@@ -932,7 +980,7 @@ export function FreshAgentView({
         if (paneContent.provider === 'codex' && isUnmaterializedCodexThreadError(error)) {
           const fresh = paneContentRef.current
           setLoadError(null)
-          setSnapshot(null)
+          commitSnapshot(null)
           dispatch(updatePaneContent({
             tabId,
             paneId,
@@ -951,7 +999,7 @@ export function FreshAgentView({
         if (paneContent.provider === 'opencode' && isLostFreshOpencodeThreadError(error)) {
           const fresh = paneContentRef.current
           setLoadError(null)
-          setSnapshot(null)
+          commitSnapshot(null)
           dispatch(updatePaneContent({
             tabId,
             paneId,
@@ -986,6 +1034,7 @@ export function FreshAgentView({
     paneContent.sessionType,
     paneId,
     autoTitleIdentity,
+    commitSnapshot,
     migratePendingAutoTitle,
     snapshotThreadId,
     snapshotRefreshNonce,

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -540,6 +540,7 @@ test.describe('Fresh Agent', () => {
     await terminal.waitForTerminal()
     const { tabId, paneId } = await getActiveLeaf(harness)
     const sessionId = '44444444-4444-4444-8444-444444444444'
+    await suppressFreshAgentNetworkForActivePane(page)
 
     await page.route(`**/api/fresh-agent/threads/freshclaude/claude/${sessionId}*`, async (route) => {
       await route.fulfill({
@@ -606,7 +607,7 @@ test.describe('Fresh Agent', () => {
     expect(await readTranscriptFontSize()).toBe('16px')
 
     const textLine = paneRoot
-      .locator('article[aria-label="Assistant transcript turn"] p')
+      .locator('article[aria-label="Freshclaude transcript turn"] p')
       .filter({ hasText: 'Terminal-sized transcript line' })
       .first()
     await expect(textLine).toBeVisible()

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -220,6 +220,7 @@ describe('FreshAgentTranscript', () => {
   it('shows a live reel while a tool is running', () => {
     const { container } = render(
       <FreshAgentTranscript
+        isStreaming
         turns={[
           {
             id: 'turn-1',
@@ -295,6 +296,127 @@ describe('FreshAgentTranscript', () => {
     expect(screen.queryByText('1 tool used')).not.toBeInTheDocument()
   })
 
+  it('shows only the latest activity block as running while an assistant response streams across turns', () => {
+    render(
+      <FreshAgentTranscript
+        isStreaming
+        turns={[
+          {
+            id: 'turn-user-1',
+            role: 'user',
+            summary: 'request',
+            items: [{ id: 'item-user-1', kind: 'text', text: 'Check these files' }],
+          },
+          {
+            id: 'turn-agent-read-1',
+            role: 'assistant',
+            summary: 'Read',
+            items: [
+              {
+                id: 'tool-read-1',
+                kind: 'tool_use',
+                toolUseId: 'call-read-1',
+                name: 'Read',
+                input: { file_path: 'src/one.ts' },
+              },
+            ],
+          },
+          {
+            id: 'turn-agent-text-1',
+            role: 'assistant',
+            summary: 'first note',
+            items: [{ id: 'item-agent-1', kind: 'text', text: 'I checked the first file.' }],
+          },
+          {
+            id: 'turn-agent-read-2',
+            role: 'assistant',
+            summary: 'Read',
+            items: [
+              {
+                id: 'tool-read-2',
+                kind: 'tool_use',
+                toolUseId: 'call-read-2',
+                name: 'Read',
+                input: { file_path: 'src/two.ts' },
+              },
+            ],
+          },
+          {
+            id: 'turn-agent-text-2',
+            role: 'assistant',
+            summary: 'second note',
+            items: [{ id: 'item-agent-2', kind: 'text', text: 'Still checking.' }],
+          },
+        ]}
+      />,
+    )
+
+    const strips = screen.getAllByRole('region', { name: 'Activity strip' })
+    expect(strips).toHaveLength(2)
+    expect(screen.getAllByLabelText('running')).toHaveLength(1)
+    expect(strips[0]).toHaveTextContent('1 tool used')
+  })
+
+  it('coalesces consecutive activity-only assistant turns into one live activity strip', () => {
+    render(
+      <FreshAgentTranscript
+        isStreaming
+        turns={[
+          {
+            id: 'turn-user-1',
+            role: 'user',
+            summary: 'request',
+            items: [{ id: 'item-user-1', kind: 'text', text: 'Read these files' }],
+          },
+          {
+            id: 'turn-agent-read-1',
+            role: 'assistant',
+            summary: 'Read',
+            items: [{
+              id: 'tool-read-1',
+              kind: 'tool_use',
+              toolUseId: 'call-read-1',
+              name: 'Read',
+              input: { file_path: 'src/one.ts' },
+            }],
+          },
+          {
+            id: 'turn-agent-read-2',
+            role: 'assistant',
+            summary: 'Read',
+            items: [{
+              id: 'tool-read-2',
+              kind: 'tool_use',
+              toolUseId: 'call-read-2',
+              name: 'Read',
+              input: { file_path: 'src/two.ts' },
+            }],
+          },
+          {
+            id: 'turn-agent-read-3',
+            role: 'assistant',
+            summary: 'Read',
+            items: [{
+              id: 'tool-read-3',
+              kind: 'tool_use',
+              toolUseId: 'call-read-3',
+              name: 'Read',
+              input: { file_path: 'src/three.ts' },
+            }],
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    expect(screen.getAllByLabelText('running')).toHaveLength(1)
+    expect(screen.getByText('src/three.ts')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle activity details' }))
+    expect(screen.getAllByLabelText('running')).toHaveLength(1)
+    expect(screen.getAllByLabelText('complete')).toHaveLength(2)
+  })
+
   it('shows the speaker label once for consecutive turns from the same role', () => {
     const { container } = render(
       <FreshAgentTranscript
@@ -338,6 +460,32 @@ describe('FreshAgentTranscript', () => {
       .map((node) => node.textContent)
     expect(visibleHeaders.filter((text) => text === 'freshclaude')).toHaveLength(2)
     expect(container.querySelectorAll('[data-turn-continuation="true"]')).toHaveLength(2)
+  })
+
+  it('keeps completed long transcripts expanded instead of replacing older turns with summary rows', () => {
+    const turns = Array.from({ length: 10 }, (_, index) => ({
+      id: `turn-${index}`,
+      role: index % 2 === 0 ? 'user' as const : 'assistant' as const,
+      items: [{
+        id: `item-${index}`,
+        kind: 'text' as const,
+        text: index % 2 === 0 ? `User note ${index}` : `Agent reply ${index}`,
+      }],
+    }))
+
+    const { container } = render(
+      <FreshAgentTranscript
+        agentLabel="freshclaude"
+        turns={turns}
+      />,
+    )
+
+    for (let index = 0; index < turns.length; index += 1) {
+      expect(screen.getByText(index % 2 === 0 ? `User note ${index}` : `Agent reply ${index}`)).toBeInTheDocument()
+    }
+    expect(screen.queryByRole('button', { name: 'Expand turn' })).not.toBeInTheDocument()
+    expect(container.querySelector('.fresh-agent-collapsed-turn')).toBeNull()
+    expect(container.querySelectorAll('.fresh-agent-turn')).toHaveLength(10)
   })
 
   it('tolerates duplicate provider turn ids without duplicate React keys', () => {
@@ -428,16 +576,16 @@ describe('FreshAgentTranscript', () => {
       .toHaveTextContent('1 tool used · 1 file changed')
   })
 
-  it('strips system reminders and collapses older turns', () => {
+  it('strips system reminders without collapsing older turns', () => {
     render(
       <FreshAgentTranscript
         turns={Array.from({ length: 9 }, (_, index) => ({
           id: `turn-${index}`,
-          role: index % 2 === 0 ? 'user' : 'assistant',
+          role: index % 2 === 0 ? 'user' as const : 'assistant' as const,
           summary: `turn ${index}`,
           items: [{
             id: `item-${index}`,
-            kind: 'text',
+            kind: 'text' as const,
             text: index === 0
               ? 'visible <system-reminder>hidden internals</system-reminder>'
               : `message ${index}`,
@@ -446,7 +594,8 @@ describe('FreshAgentTranscript', () => {
       />,
     )
 
-    expect(screen.getByRole('button', { name: 'Expand turn' })).toHaveTextContent('visible')
+    expect(screen.getByText('visible')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Expand turn' })).not.toBeInTheDocument()
     expect(screen.queryByText(/hidden internals/)).not.toBeInTheDocument()
   })
 

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -1758,6 +1758,300 @@ describe('FreshAgentView', () => {
     expect(screen.getByText('Loaded assistant turn')).toBeInTheDocument()
   })
 
+  it('preserves loaded transcript history when a submit refresh returns only the in-flight turn', async () => {
+    const store = createStore()
+    let onMessage: ((message: Record<string, unknown>) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler: (message: Record<string, unknown>) => void) => {
+      onMessage = handler
+      return () => {}
+    })
+    apiMock.getFreshAgentThreadSnapshot
+      .mockResolvedValueOnce({
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        threadId: 'thread-partial-refresh',
+        status: 'idle',
+        summary: 'Loaded history',
+        capabilities: { send: true, interrupt: true, fork: true },
+        turns: [
+          {
+            id: 'turn-old-user',
+            turnId: 'turn-old-user',
+            role: 'user',
+            summary: 'Older user request',
+            items: [{ id: 'item-old-user', kind: 'text', text: 'Older user request' }],
+          },
+          {
+            id: 'turn-old-assistant',
+            turnId: 'turn-old-assistant',
+            role: 'assistant',
+            summary: 'Older assistant answer',
+            items: [{ id: 'item-old-assistant', kind: 'text', text: 'Older assistant answer' }],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        threadId: 'thread-partial-refresh',
+        status: 'running',
+        summary: 'Partial in-flight turn',
+        capabilities: { send: false, interrupt: true, fork: true },
+        turns: [
+          {
+            id: 'turn-new-user',
+            turnId: 'turn-new-user',
+            role: 'user',
+            summary: 'New user request',
+            items: [{ id: 'item-new-user', kind: 'text', text: 'New user request' }],
+          },
+        ],
+      })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-partial-refresh',
+        sessionId: 'thread-partial-refresh',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Older assistant answer')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'New user request' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(screen.getByText('Older user request')).toBeInTheDocument()
+    expect(screen.getByText('Older assistant answer')).toBeInTheDocument()
+
+    expect(onMessage).toBeTypeOf('function')
+    act(() => {
+      onMessage?.({
+        type: 'freshAgent.event',
+        sessionId: 'thread-partial-refresh',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        event: {
+          type: 'sdk.session.snapshot',
+          sessionId: 'thread-partial-refresh',
+          latestTurnId: 'turn-new-user',
+          status: 'running',
+          revision: 2,
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(2)
+    })
+    expect(screen.getByText('Older user request')).toBeInTheDocument()
+    expect(screen.getByText('Older assistant answer')).toBeInTheDocument()
+    expect(screen.getByText('New user request')).toBeInTheDocument()
+  })
+
+  it('replaces prior history when a settled same-session snapshot intentionally has fewer turns', async () => {
+    const store = createStore()
+    let onMessage: ((message: Record<string, unknown>) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler: (message: Record<string, unknown>) => void) => {
+      onMessage = handler
+      return () => {}
+    })
+    apiMock.getFreshAgentThreadSnapshot
+      .mockResolvedValueOnce({
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        threadId: 'thread-authoritative-refresh',
+        revision: 1,
+        status: 'idle',
+        summary: 'Loaded history',
+        capabilities: { send: true, interrupt: true, fork: true },
+        turns: [
+          {
+            id: 'turn-prior-user',
+            turnId: 'turn-prior-user',
+            role: 'user',
+            summary: 'Prior user request',
+            items: [{ id: 'item-prior-user', kind: 'text', text: 'Prior user request' }],
+          },
+          {
+            id: 'turn-prior-assistant',
+            turnId: 'turn-prior-assistant',
+            role: 'assistant',
+            summary: 'Prior assistant answer',
+            items: [{ id: 'item-prior-assistant', kind: 'text', text: 'Prior assistant answer' }],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        threadId: 'thread-authoritative-refresh',
+        revision: 2,
+        status: 'idle',
+        summary: 'Authoritative shorter history',
+        capabilities: { send: true, interrupt: true, fork: true },
+        turns: [
+          {
+            id: 'turn-authoritative-user',
+            turnId: 'turn-authoritative-user',
+            role: 'user',
+            summary: 'Authoritative replacement request',
+            items: [{ id: 'item-authoritative-user', kind: 'text', text: 'Authoritative replacement request' }],
+          },
+        ],
+      })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-authoritative-refresh',
+        sessionId: 'thread-authoritative-refresh',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Prior assistant answer')).toBeInTheDocument()
+    })
+
+    expect(onMessage).toBeTypeOf('function')
+    act(() => {
+      onMessage?.({
+        type: 'freshAgent.event',
+        sessionId: 'thread-authoritative-refresh',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        event: {
+          type: 'sdk.session.snapshot',
+          sessionId: 'thread-authoritative-refresh',
+          latestTurnId: 'turn-authoritative-user',
+          status: 'idle',
+          revision: 2,
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Authoritative replacement request')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Prior user request')).not.toBeInTheDocument()
+    expect(screen.queryByText('Prior assistant answer')).not.toBeInTheDocument()
+  })
+
+  it('ignores an older same-session snapshot revision after newer history is already rendered', async () => {
+    const store = createStore()
+    let onMessage: ((message: Record<string, unknown>) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler: (message: Record<string, unknown>) => void) => {
+      onMessage = handler
+      return () => {}
+    })
+    apiMock.getFreshAgentThreadSnapshot
+      .mockResolvedValueOnce({
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        threadId: 'thread-stale-revision',
+        revision: 8,
+        status: 'idle',
+        summary: 'Current history',
+        capabilities: { send: true, interrupt: true, fork: true },
+        turns: [
+          {
+            id: 'turn-current',
+            turnId: 'turn-current',
+            role: 'assistant',
+            summary: 'Current rendered answer',
+            items: [{ id: 'item-current', kind: 'text', text: 'Current rendered answer' }],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        threadId: 'thread-stale-revision',
+        revision: 7,
+        status: 'running',
+        summary: 'Stale history',
+        capabilities: { send: false, interrupt: true, fork: true },
+        turns: [
+          {
+            id: 'turn-stale',
+            turnId: 'turn-stale',
+            role: 'assistant',
+            summary: 'Stale older answer',
+            items: [{ id: 'item-stale', kind: 'text', text: 'Stale older answer' }],
+          },
+        ],
+      })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-stale-revision',
+        sessionId: 'thread-stale-revision',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Current rendered answer')).toBeInTheDocument()
+    })
+
+    expect(onMessage).toBeTypeOf('function')
+    act(() => {
+      onMessage?.({
+        type: 'freshAgent.event',
+        sessionId: 'thread-stale-revision',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        event: {
+          type: 'sdk.session.snapshot',
+          sessionId: 'thread-stale-revision',
+          latestTurnId: 'turn-stale',
+          status: 'running',
+          revision: 7,
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(2)
+    })
+    expect(screen.getByText('Current rendered answer')).toBeInTheDocument()
+    expect(screen.queryByText('Stale older answer')).not.toBeInTheDocument()
+  })
+
   it('resets auto-title for a new conversation even if the stale prior snapshot had user turns', async () => {
     const store = createStore()
     apiMock.getFreshAgentThreadSnapshot.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- restore full fresh-agent transcript rendering without auto-collapsing older turns
- keep only one live activity spinner across streaming assistant activity blocks
- coalesce consecutive activity-only assistant tool turns into one rolling activity strip

## Verification
- npm run test:vitest -- test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.test.tsx --run
- npm run test:e2e:chromium -- fresh-agent.spec.ts
- FRESHELL_TEST_SUMMARY='freshagent activity strip spinner coalescing regression' npm run check
- npm run lint
- git diff --check
- Playwright visual audit on 5177: consecutive Read turns render as one collapsed activity strip with one spinner