### PR TITLE
Fix Fresh Agent body context menu reopen actions

### DIFF
--- a/src/components/context-menu/ContextMenuProvider.tsx
+++ b/src/components/context-menu/ContextMenuProvider.tsx
@@ -74,6 +74,7 @@ const EMPTY_OPENCODE_ACTIVITY_BY_ID = {}
 const EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID: Record<string, PaneRuntimeActivityRecord> = {}
 
 const log = createLogger('ContextMenuProvider')
+const KNOWN_CONTEXT_IDS = new Set(Object.values(ContextIds) as ContextId[])
 
 
 type MenuState = {
@@ -99,19 +100,21 @@ type ContextMenuProviderProps = {
   children: React.ReactNode
 }
 
+function isKnownContextId(value: string | undefined): value is ContextId {
+  return !!value && KNOWN_CONTEXT_IDS.has(value as ContextId)
+}
+
 function findContextElement(start: HTMLElement | null): HTMLElement | null {
   let node: HTMLElement | null = start
   while (node) {
-    if (node.dataset?.context) return node
+    if (isKnownContextId(node.dataset?.context)) return node
     node = node.parentElement
   }
   return null
 }
 
 function resolveContextId(value: string | undefined): ContextId {
-  if (!value) return ContextIds.Global
-  const allowed = new Set(Object.values(ContextIds) as ContextId[])
-  return allowed.has(value as ContextId) ? (value as ContextId) : ContextIds.Global
+  return isKnownContextId(value) ? value : ContextIds.Global
 }
 
 function hasWaitingPrompt(

--- a/src/components/context-menu/context-menu-types.ts
+++ b/src/components/context-menu/context-menu-types.ts
@@ -19,7 +19,7 @@ export type ContextTarget =
   | { kind: 'agent-chat'; sessionId: string }
   | {
       kind: 'fresh-agent'
-      sessionId: string
+      sessionId?: string
       tabId?: string
       paneId?: string
       provider?: string

--- a/src/components/context-menu/context-menu-utils.ts
+++ b/src/components/context-menu/context-menu-utils.ts
@@ -87,7 +87,7 @@ export function parseContextTarget(contextId: ContextId, data: ContextDataset): 
     case ContextIds.AgentChat:
       return data.sessionId ? { kind: 'agent-chat', sessionId: data.sessionId } : null
     case ContextIds.FreshAgent:
-      return data.sessionId
+      return data.sessionId || (data.tabId && data.paneId)
         ? {
             kind: 'fresh-agent',
             sessionId: data.sessionId,

--- a/src/components/context-menu/menu-defs.ts
+++ b/src/components/context-menu/menu-defs.ts
@@ -743,11 +743,13 @@ export function buildMenuItems(target: ContextTarget, ctx: MenuBuildContext): Me
       items.push(...buildReopenPaneAsItem(target.tabId, target.paneId, paneContent, tab, ctx))
     }
 
-    // Session metadata at the bottom
-    items.push(
-      { type: 'separator', id: 'fc-session-sep' },
-      { type: 'item', id: 'fc-copy-session', label: 'Copy session ID', onSelect: () => actions.copySessionId(target.sessionId) },
-    )
+    const sessionId = target.sessionId
+    if (sessionId) {
+      items.push(
+        { type: 'separator', id: 'fc-session-sep' },
+        { type: 'item', id: 'fc-copy-session', label: 'Copy session ID', onSelect: () => actions.copySessionId(sessionId) },
+      )
+    }
 
     return items
   }

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -406,6 +406,8 @@ export function FreshAgentView({
   const handledRefreshRequestIdRef = useRef<string | null>(null)
   const preferredResumeSessionId = getPreferredResumeSessionId(claudeSession) ?? paneContent.resumeSessionId
   const snapshotThreadId = getFreshAgentSnapshotThreadId(paneContent, claudeSession)
+  const snapshotThreadIdRef = useRef(snapshotThreadId)
+  snapshotThreadIdRef.current = snapshotThreadId
   const hasRestoreFailure = Boolean(
     paneContent.provider === 'claude'
       && paneContent.sessionId
@@ -904,15 +906,18 @@ export function FreshAgentView({
     setLoadError(null)
     const sessionId = snapshotThreadId
     const provider = paneContent.provider
+    const requestSessionType = paneContent.sessionType
     const requestCreateRequestId = paneContent.createRequestId
-    const requestAutoTitleIdentity = autoTitleIdentity
     const isStaleSnapshotRequest = () => (
       paneContentRef.current.createRequestId !== requestCreateRequestId
-      || currentAutoTitleIdentityRef.current !== requestAutoTitleIdentity
+      || paneContentRef.current.provider !== provider
+      || paneContentRef.current.sessionType !== requestSessionType
+      || snapshotThreadIdRef.current !== sessionId
     )
-    void getFreshAgentThreadSnapshot(paneContent.sessionType, provider, sessionId, { signal: controller.signal })
+    void getFreshAgentThreadSnapshot(requestSessionType, provider, sessionId, { signal: controller.signal })
       .then((next) => {
         if (isStaleSnapshotRequest()) return
+        const snapshotIdentity = currentAutoTitleIdentityRef.current
         const resolved = next as FreshAgentSnapshot
         const resolvedHasUserTurns = resolved.turns.some((turn) => turn.role === 'user')
         if (!resolvedHasUserTurns && !autoTitleSentRef.current) {
@@ -924,7 +929,7 @@ export function FreshAgentView({
         }
         const displaySnapshot = mergeSnapshotForDisplay(snapshotRef.current, resolved)
         commitSnapshot(displaySnapshot)
-        setSnapshotAutoTitleIdentity(requestAutoTitleIdentity)
+        setSnapshotAutoTitleIdentity(snapshotIdentity)
         const echo = localEchoRef.current
         if (echo) {
           const needle = echo.slice(0, 80)
@@ -1033,7 +1038,6 @@ export function FreshAgentView({
     paneContent.sessionId,
     paneContent.sessionType,
     paneId,
-    autoTitleIdentity,
     commitSnapshot,
     migratePendingAutoTitle,
     snapshotThreadId,
@@ -1342,6 +1346,9 @@ export function FreshAgentView({
       event.preventDefault()
       composerRef.current?.appendText(event.key)
     }
+    const contextSessionId = paneContent.sessionId
+      ?? (paneContent.sessionRef?.provider === paneContent.provider ? paneContent.sessionRef.sessionId : undefined)
+      ?? paneContent.resumeSessionId
     const sendInterrupt = () => {
       if (!paneContent.sessionId || !canInterrupt) return
       sendFreshAgentMessage({
@@ -1376,7 +1383,7 @@ export function FreshAgentView({
         data-style={activeStyle}
         data-tab-id={tabId}
         data-pane-id={paneId}
-        data-session-id={paneContent.sessionId}
+        data-session-id={contextSessionId}
         data-provider={paneContent.provider}
         data-session-type={paneContent.sessionType}
         style={{ '--fresh-transcript-font-size': `${terminalFontSize}px` } as CSSProperties}

--- a/test/unit/client/components/ContextMenuProvider.test.tsx
+++ b/test/unit/client/components/ContextMenuProvider.test.tsx
@@ -71,6 +71,7 @@ vi.mock('@/lib/clipboard', () => ({
 }))
 
 const VALID_SESSION_ID = '550e8400-e29b-41d4-a716-446655440000'
+const CODEX_THREAD_ID = '019ec8c9-2b12-7001-a11d-e2e089860320'
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void
@@ -1029,6 +1030,78 @@ describe('ContextMenuProvider', () => {
     expect(store.getState().tabs.tabs[0].sessionMetadataByKey).toEqual({
       [`claude:${VALID_SESSION_ID}`]: {
         sessionType: 'claude',
+      },
+    })
+  })
+
+  it('reopens a restored FreshCodex pane when right-clicking transcript body content', async () => {
+    const user = userEvent.setup()
+    const store = createTestStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        provider: 'codex',
+        sessionType: 'freshcodex',
+        status: 'idle',
+        createRequestId: 'req-freshcodex',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: CODEX_THREAD_ID,
+        },
+        initialCwd: '/test/project',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <ContextMenuProvider
+          view="terminal"
+          onViewChange={() => {}}
+          onToggleSidebar={() => {}}
+          sidebarCollapsed={false}
+        >
+          <div
+            data-context={ContextIds.FreshAgent}
+            data-tab-id="tab-1"
+            data-pane-id="pane-1"
+            data-provider="codex"
+            data-session-type="freshcodex"
+          >
+            <div data-context="fresh-agent-transcript">FreshCodex transcript body</div>
+          </div>
+        </ContextMenuProvider>
+      </Provider>,
+    )
+
+    await user.pointer({ target: screen.getByText('FreshCodex transcript body'), keys: '[MouseRight]' })
+    await user.click(await screen.findByRole('menuitem', { name: 'Reopen as Codex CLI' }))
+
+    await waitFor(() => {
+      expect(apiMocks.setSessionMetadata).toHaveBeenCalledWith(
+        'codex',
+        CODEX_THREAD_ID,
+        'codex',
+        { sessionTypeSource: 'explicit' },
+      )
+    })
+
+    expect(store.getState().panes.layouts['tab-1']).toMatchObject({
+      type: 'leaf',
+      content: {
+        kind: 'terminal',
+        mode: 'codex',
+        sessionRef: {
+          provider: 'codex',
+          sessionId: CODEX_THREAD_ID,
+        },
+        initialCwd: '/test/project',
+      },
+    })
+    expect(store.getState().tabs.tabs[0].sessionMetadataByKey).toEqual({
+      [`codex:${CODEX_THREAD_ID}`]: {
+        sessionType: 'codex',
       },
     })
   })

--- a/test/unit/client/components/context-menu/context-menu-utils.test.ts
+++ b/test/unit/client/components/context-menu/context-menu-utils.test.ts
@@ -72,4 +72,31 @@ describe('parseContextTarget', () => {
       sessionType: 'freshclaude',
     })
   })
+
+  it('parseContextTarget for FreshAgent accepts pane identity without a DOM session id', () => {
+    const result = parseContextTarget(ContextIds.FreshAgent, {
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      provider: 'codex',
+      sessionType: 'freshcodex',
+    })
+
+    expect(result).toEqual({
+      kind: 'fresh-agent',
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      sessionId: undefined,
+      provider: 'codex',
+      sessionType: 'freshcodex',
+    })
+  })
+
+  it('parseContextTarget for FreshAgent returns null without session or pane identity', () => {
+    const result = parseContextTarget(ContextIds.FreshAgent, {
+      provider: 'codex',
+      sessionType: 'freshcodex',
+    })
+
+    expect(result).toBeNull()
+  })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -319,6 +319,31 @@ describe('FreshAgentView', () => {
     expect(root).toHaveClass('fresh-agent-style-serif')
   })
 
+  it('exposes a durable sessionRef as the fresh-agent context session id', async () => {
+    const store = createStore()
+    render(
+      <Provider store={store}>
+        <FreshAgentView
+          tabId="tab-1"
+          paneId="pane-1"
+          paneContent={{
+            kind: 'fresh-agent',
+            sessionType: 'freshcodex',
+            provider: 'codex',
+            createRequestId: 'req-context-session',
+            status: 'idle',
+            sessionRef: {
+              provider: 'codex',
+              sessionId: '019ec8c9-2b12-7001-a11d-e2e089860320',
+            },
+          }}
+        />
+      </Provider>,
+    )
+
+    await waitFor(() => expect(getFreshAgentSessionId()).toBe('019ec8c9-2b12-7001-a11d-e2e089860320'))
+  })
+
   it('only exposes the stop action while the agent is working', async () => {
     const store = createStore()
     apiMock.getFreshAgentThreadSnapshot.mockResolvedValueOnce({

--- a/test/unit/client/context-menu/menu-defs.test.ts
+++ b/test/unit/client/context-menu/menu-defs.test.ts
@@ -121,6 +121,33 @@ function getTerminalItem(items: ReturnType<typeof buildMenuItems>, id: string) {
   return item
 }
 
+const REOPEN_SESSION_TYPE_CASES = [
+  {
+    provider: 'claude',
+    cliSessionType: 'claude',
+    freshSessionType: 'freshclaude',
+    sessionId: '550e8400-e29b-41d4-a716-446655440000',
+    cliToFreshLabel: 'Reopen as freshclaude',
+    freshToCliLabel: 'Reopen as Claude CLI',
+  },
+  {
+    provider: 'codex',
+    cliSessionType: 'codex',
+    freshSessionType: 'freshcodex',
+    sessionId: 'codex-thread-1',
+    cliToFreshLabel: 'Reopen as freshcodex',
+    freshToCliLabel: 'Reopen as Codex CLI',
+  },
+  {
+    provider: 'opencode',
+    cliSessionType: 'opencode',
+    freshSessionType: 'freshopencode',
+    sessionId: 'ses_opencode_1',
+    cliToFreshLabel: 'Reopen as freshopencode',
+    freshToCliLabel: 'Reopen as OpenCode CLI',
+  },
+] as const
+
 describe('context menu global view labels', () => {
   it('includes renamed views and new tabs view in global menu', () => {
     const items = buildMenuItems(
@@ -275,6 +302,80 @@ describe('buildMenuItems - refresh items', () => {
 })
 
 describe('buildMenuItems - reopen as paired session flavor', () => {
+  for (const entry of REOPEN_SESSION_TYPE_CASES) {
+    it(`adds ${entry.cliToFreshLabel} to a ${entry.cliSessionType} CLI terminal body menu`, () => {
+      const actions = createActions()
+      const items = buildMenuItems(
+        { kind: 'terminal', tabId: 'tab-1', paneId: 'pane-1' },
+        makeCtx(actions, {
+          paneLayouts: {
+            'tab-1': {
+              type: 'leaf',
+              id: 'pane-1',
+              content: {
+                kind: 'terminal',
+                mode: entry.cliSessionType,
+                sessionRef: { provider: entry.provider, sessionId: entry.sessionId },
+                createRequestId: 'req-1',
+                status: 'running',
+              },
+            },
+          },
+        }),
+      )
+
+      const item = getTerminalItem(items, 'reopen-pane-as-session-type')
+      expect(item.label).toBe(entry.cliToFreshLabel)
+      item.onSelect()
+      expect(actions.reopenPaneAsSessionTarget).toHaveBeenCalledWith(expect.objectContaining({
+        provider: entry.provider,
+        sessionId: entry.sessionId,
+        sourceSessionType: entry.cliSessionType,
+        targetSessionType: entry.freshSessionType,
+      }))
+    })
+
+    it(`adds ${entry.freshToCliLabel} to a ${entry.freshSessionType} body menu using pane state`, () => {
+      const actions = createActions()
+      const items = buildMenuItems(
+        {
+          kind: 'fresh-agent',
+          tabId: 'tab-1',
+          paneId: 'pane-1',
+          provider: entry.provider,
+          sessionType: entry.freshSessionType,
+        },
+        makeCtx(actions, {
+          paneLayouts: {
+            'tab-1': {
+              type: 'leaf',
+              id: 'pane-1',
+              content: {
+                kind: 'fresh-agent',
+                sessionType: entry.freshSessionType,
+                provider: entry.provider,
+                sessionRef: { provider: entry.provider, sessionId: entry.sessionId },
+                createRequestId: 'req-1',
+                status: 'idle',
+              },
+            },
+          },
+        }),
+      )
+
+      const item = getTerminalItem(items, 'reopen-pane-as-session-type')
+      expect(item.label).toBe(entry.freshToCliLabel)
+      item.onSelect()
+      expect(actions.reopenPaneAsSessionTarget).toHaveBeenCalledWith(expect.objectContaining({
+        provider: entry.provider,
+        sessionId: entry.sessionId,
+        sourceSessionType: entry.freshSessionType,
+        targetSessionType: entry.cliSessionType,
+      }))
+      expect(items.some((candidate) => candidate.type === 'item' && candidate.id === 'fc-copy-session')).toBe(false)
+    })
+  }
+
   it('adds Reopen as freshclaude to a Claude CLI terminal body menu with a durable target payload', () => {
     const actions = createActions()
     const items = buildMenuItems(

--- a/test/unit/client/lib/session-flavor-reopen.test.ts
+++ b/test/unit/client/lib/session-flavor-reopen.test.ts
@@ -11,7 +11,90 @@ const tab = {
   createRequestId: 'tab-req',
 } as any
 
+const REOPEN_SESSION_TYPE_CASES = [
+  {
+    provider: 'claude',
+    cliSessionType: 'claude',
+    freshSessionType: 'freshclaude',
+    sessionId: '550e8400-e29b-41d4-a716-446655440000',
+    freshLabel: 'Reopen as freshclaude',
+    cliLabel: 'Reopen as Claude CLI',
+  },
+  {
+    provider: 'codex',
+    cliSessionType: 'codex',
+    freshSessionType: 'freshcodex',
+    sessionId: 'codex-thread-1',
+    freshLabel: 'Reopen as freshcodex',
+    cliLabel: 'Reopen as Codex CLI',
+  },
+  {
+    provider: 'opencode',
+    cliSessionType: 'opencode',
+    freshSessionType: 'freshopencode',
+    sessionId: 'ses_opencode_1',
+    freshLabel: 'Reopen as freshopencode',
+    cliLabel: 'Reopen as OpenCode CLI',
+  },
+] as const
+
 describe('resolveReopenPaneSessionTarget', () => {
+  for (const entry of REOPEN_SESSION_TYPE_CASES) {
+    it(`resolves ${entry.cliSessionType} CLI panes to ${entry.freshSessionType}`, () => {
+      const content: PaneContent = {
+        kind: 'terminal',
+        mode: entry.cliSessionType,
+        terminalId: 'term-1',
+        createRequestId: 'req-1',
+        status: 'running',
+        sessionRef: { provider: entry.provider, sessionId: entry.sessionId },
+        initialCwd: '/repo',
+      }
+
+      expect(resolveReopenPaneSessionTarget({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content,
+        tab,
+        activity: { isBusy: false },
+      })).toMatchObject({
+        sourceSessionType: entry.cliSessionType,
+        targetSessionType: entry.freshSessionType,
+        provider: entry.provider,
+        sessionId: entry.sessionId,
+        label: entry.freshLabel,
+        disabled: false,
+      })
+    })
+
+    it(`resolves ${entry.freshSessionType} panes to ${entry.cliSessionType} CLI`, () => {
+      const content: PaneContent = {
+        kind: 'fresh-agent',
+        sessionType: entry.freshSessionType,
+        provider: entry.provider,
+        sessionRef: { provider: entry.provider, sessionId: entry.sessionId },
+        createRequestId: 'req-1',
+        status: 'idle',
+        initialCwd: '/repo',
+      }
+
+      expect(resolveReopenPaneSessionTarget({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content,
+        tab,
+        activity: { isBusy: false },
+      })).toMatchObject({
+        sourceSessionType: entry.freshSessionType,
+        targetSessionType: entry.cliSessionType,
+        provider: entry.provider,
+        sessionId: entry.sessionId,
+        label: entry.cliLabel,
+        disabled: false,
+      })
+    })
+  }
+
   it('resolves a Claude CLI pane to freshclaude using canonical sessionRef', () => {
     const content: PaneContent = {
       kind: 'terminal',


### PR DESCRIPTION
Summary:
- Route right-clicks from Fresh Agent transcript body content to the Fresh Agent pane context instead of falling back to the global menu.
- Let Fresh Agent pane reopen actions use pane state and durable session refs when the DOM has no live session id.
- Cover Claude, Codex, and OpenCode CLI/Fresh Agent reopen pairs.

Tests:
- npm run test:vitest -- test/unit/client/components/context-menu/context-menu-utils.test.ts test/unit/client/context-menu/menu-defs.test.ts test/unit/client/lib/session-flavor-reopen.test.ts test/unit/client/components/ContextMenuProvider.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.test.tsx --run
- npm run typecheck:client
- git diff --check
- npm run check