### PR TITLE
feat(fresh-agent): add Kimi k2.7 as a Freshopencode model option

### DIFF
--- a/shared/fresh-agent-models.ts
+++ b/shared/fresh-agent-models.ts
@@ -68,6 +68,12 @@ export const FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE = {
       thinkingEfforts: ['minimal', 'low', 'medium', 'high', 'max'],
       defaultEffort: FRESHOPENCODE_DEFAULT_EFFORT,
     },
+    {
+      value: 'umans-ai-coding-plan/umans-kimi-k2.7',
+      label: 'Kimi k2.7',
+      thinkingEfforts: ['minimal', 'low', 'medium', 'high', 'max'],
+      defaultEffort: FRESHOPENCODE_DEFAULT_EFFORT,
+    },
   ],
 } as const satisfies Record<FreshAgentSessionType, readonly FreshAgentModelOption[]>
 

--- a/test/unit/shared/fresh-agent-models.test.ts
+++ b/test/unit/shared/fresh-agent-models.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE,
+  getFreshAgentThinkingOptions,
+  normalizeFreshAgentModel,
+  resolveFreshAgentModelOption,
+} from '@shared/fresh-agent-models'
+
+describe('fresh-agent-models freshopencode options', () => {
+  const KIMI_K2_7_MODEL = 'umans-ai-coding-plan/umans-kimi-k2.7'
+
+  it('includes Kimi k2.7 as a selectable Freshopencode model', () => {
+    const option = resolveFreshAgentModelOption('freshopencode', KIMI_K2_7_MODEL)
+
+    expect(option).toMatchObject({
+      value: KIMI_K2_7_MODEL,
+      label: 'Kimi k2.7',
+      thinkingEfforts: ['minimal', 'low', 'medium', 'high', 'max'],
+      defaultEffort: 'max',
+    })
+  })
+
+  it('normalizes the Kimi k2.7 model value for the opencode runtime provider', () => {
+    const normalized = normalizeFreshAgentModel('freshopencode', 'opencode', KIMI_K2_7_MODEL)
+
+    expect(normalized).toBe(KIMI_K2_7_MODEL)
+  })
+
+  it('exposes the expected thinking levels for Kimi k2.7', () => {
+    const options = getFreshAgentThinkingOptions('freshopencode', 'opencode', KIMI_K2_7_MODEL)
+
+    expect(options.map((o) => o.value)).toEqual(['minimal', 'low', 'medium', 'high', 'max'])
+  })
+
+  it('lists Kimi k2.7 in the static Freshopencode options array', () => {
+    const values = FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE.freshopencode.map((o) => o.value)
+
+    expect(values).toContain(KIMI_K2_7_MODEL)
+  })
+})


### PR DESCRIPTION
Adds the Kimi k2.7 model (powered by Umans AI Coding plan) to the Freshopencode runtime model picker.

- Model: `umans-ai-coding-plan/umans-kimi-k2.7`
- Label: `Kimi k2.7`
- Thinking efforts: minimal/low/medium/high/max (default max)

Includes unit tests for selection, normalization, and thinking-level derivation.