### PR TITLE
Replace flaky real Codex durability resume test

### DIFF
--- a/test/integration/real/coding-cli-session-contract.test.ts
+++ b/test/integration/real/coding-cli-session-contract.test.ts
@@ -9,11 +9,8 @@ import {
   CodexRpcProbeClient,
   ProbeWorkspace,
   captureCodexBootstrapEvents,
-  captureCodexResumeBootstrapEvents,
-  extractCodexResumeId,
   findClaudeTranscript,
   findClaudeTranscripts,
-  findCodexSessionArtifacts,
   loadCodingCliSessionContractNote,
   queryOpencodeSessionRow,
   readClaudeTranscriptLines,
@@ -25,8 +22,6 @@ import {
   startCodexAppServer,
   startOpencodeServe,
   waitForCodexSessionArtifact,
-  waitForCodexShellSnapshot,
-  waitForFileSizeIncrease,
   waitForAnyHttpBusyStatus,
   waitForJsonResponse,
   waitForJsonLine,
@@ -270,84 +265,6 @@ describe.sequential('coding cli real provider session contract', () => {
       }
     }, 180_000)
 
-    it('stays live-only until the durable artifact exists, then restores via the artifact id', async () => {
-      const codexPath = requireAvailableBinary(codexBinary, codexProbe)
-      const workspace = await ProbeWorkspace.create('codex-durable')
-      try {
-        await seedCodexHome(workspace)
-
-        const liveOnlyAppServer = await startCodexAppServer(workspace, codexPath)
-        const liveOnlyClient = await CodexRpcProbeClient.connect(liveOnlyAppServer.wsUrl)
-        await liveOnlyClient.initialize()
-        const liveOnlyThread = await liveOnlyClient.startThread(process.cwd())
-
-        const snapshotPath = await waitForCodexShellSnapshot(workspace)
-        expect(path.relative(workspace.inTemp('.codex'), snapshotPath)).toMatch(/^shell_snapshots\/.+\.sh$/)
-        expect(liveOnlyThread.thread.id).toMatch(/[0-9a-f-]{36}/)
-
-        expect(await findCodexSessionArtifacts(workspace)).toEqual([])
-        await liveOnlyClient.close()
-        await liveOnlyAppServer.process.stop()
-
-        const createAppServer = await startCodexAppServer(workspace, codexPath)
-        const createClient = await CodexRpcProbeClient.connect(createAppServer.wsUrl)
-        await createClient.initialize()
-        const createdThread = await createClient.startThread(process.cwd())
-        await createClient.startTurn(createdThread.thread.id, 'Reply with exactly: codex-contract-alpha')
-        await createClient.waitForNotification(
-          'turn/completed',
-          (notification) => notification.params?.threadId === createdThread.thread.id,
-          120_000,
-        )
-
-        const artifactPath = await waitForCodexSessionArtifact(workspace)
-        expect(path.relative(workspace.inTemp('.codex'), artifactPath)).toMatch(
-          /^sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-.+\.jsonl$/,
-        )
-        await createClient.close()
-        await createAppServer.process.stop()
-
-        const resumeId = extractCodexResumeId(artifactPath)
-        const sizeBeforeResume = (await fsp.stat(artifactPath)).size
-
-        const resumeBootstrapEvents = await captureCodexResumeBootstrapEvents(
-          workspace,
-          codexPath,
-          resumeId,
-        )
-        expectOrderedSubsequence(resumeBootstrapEvents, [
-          'connection',
-          'initialize',
-          'initialized',
-          'thread/read',
-          'model/list',
-          'thread/resume',
-        ])
-        expect(resumeBootstrapEvents).toContain('account/read')
-        expect(resumeBootstrapEvents).not.toContain('thread/start')
-
-        const resumedAppServer = await startCodexAppServer(workspace, codexPath)
-        const resumedClient = await CodexRpcProbeClient.connect(resumedAppServer.wsUrl)
-        await resumedClient.initialize()
-        const resumedThread = await resumedClient.resumeThread(resumeId, process.cwd())
-        expect(resumedThread.thread.id).toBe(resumeId)
-        await resumedClient.startTurn(resumeId, 'Reply with exactly: codex-contract-beta')
-        await resumedClient.waitForNotification(
-          'turn/completed',
-          (notification) => notification.params?.threadId === resumeId,
-          120_000,
-        )
-
-        const resumedSize = await waitForFileSizeIncrease(artifactPath, sizeBeforeResume, 60_000)
-        expect(resumedSize).toBeGreaterThan(sizeBeforeResume)
-        expect(await findCodexSessionArtifacts(workspace)).toEqual([artifactPath])
-
-        await resumedClient.close()
-        await resumedAppServer.process.stop()
-      } finally {
-        await workspace.cleanup().catch(() => undefined)
-      }
-    }, 180_000)
   })
 
   const describeClaude = claudeProbe.ready ? describe.sequential : describe.skip

--- a/test/integration/server/codex-session-flow.test.ts
+++ b/test/integration/server/codex-session-flow.test.ts
@@ -61,14 +61,21 @@ function remoteUrlFromArgs(args) {
   return args[index + 1]
 }
 
+function resumeIdFromArgs(args) {
+  const index = args.indexOf('resume')
+  if (index === -1 || index === args.length - 1) return undefined
+  return args[index + 1]
+}
+
+const codexArgs = process.argv.slice(2)
 const argLogPath = process.env.FAKE_CODEX_ARG_LOG
 if (argLogPath) {
-  fs.writeFileSync(argLogPath, JSON.stringify(process.argv.slice(2)), 'utf8')
+  fs.writeFileSync(argLogPath, JSON.stringify(codexArgs), 'utf8')
 }
 
 appendJsonLine(process.env.FAKE_CODEX_LAUNCH_LOG, {
   pid: process.pid,
-  args: process.argv.slice(2),
+  args: codexArgs,
 })
 
 let isFirstLaunch = false
@@ -81,7 +88,8 @@ if (process.env.FAKE_CODEX_FIRST_LAUNCH_CLAIM_PATH) {
   }
 }
 
-const remoteUrl = remoteUrlFromArgs(process.argv.slice(2))
+const remoteUrl = remoteUrlFromArgs(codexArgs)
+const resumeId = resumeIdFromArgs(codexArgs)
 let remoteSocket
 let remoteMessageId = 1
 let remoteThreadId
@@ -93,8 +101,10 @@ if (process.env.FAKE_CODEX_CONNECT_REMOTE === '1' && remoteUrl) {
     remoteSocket.on('open', () => {
       remoteSocket.send(JSON.stringify({
         id: remoteMessageId++,
-        method: 'thread/start',
-        params: { cwd: process.cwd() },
+        method: resumeId ? 'thread/resume' : 'thread/start',
+        params: resumeId
+          ? { threadId: resumeId, cwd: process.cwd() }
+          : { cwd: process.cwd() },
       }))
     })
     remoteSocket.on('message', (raw) => {
@@ -467,11 +477,12 @@ describeLinux('Codex Session Flow Integration', () => {
     }
   })
 
-  it('captures a fresh Codex restore identity from the fake TUI and promotes it after turn completion', async () => {
+  it('keeps fresh Codex live-only until rollout proof, then restores via durable sessionRef', async () => {
     const testDir = await fsp.mkdtemp(path.join(tempDir, 'fresh-durable-flow-'))
     const rolloutPath = path.join(testDir, 'rollout.jsonl')
     const remoteLogPath = path.join(testDir, 'remote.jsonl')
     const launchLogPath = path.join(testDir, 'codex-launches.jsonl')
+    const threadOperationLogPath = path.join(testDir, 'thread-operations.jsonl')
     const previousConnectRemote = process.env.FAKE_CODEX_CONNECT_REMOTE
     const previousRemoteDelay = process.env.FAKE_CODEX_REMOTE_CONNECT_DELAY_MS
     const previousRemoteLog = process.env.FAKE_CODEX_REMOTE_LOG
@@ -483,12 +494,14 @@ describeLinux('Codex Session Flow Integration', () => {
     process.env.FAKE_CODEX_STAY_ALIVE = '1'
     process.env.FAKE_CODEX_LAUNCH_LOG = launchLogPath
     process.env.FAKE_CODEX_APP_SERVER_BEHAVIOR = JSON.stringify({
+      appendThreadOperationLogPath: threadOperationLogPath,
       threadStartThreadId: 'thread-fake-tui-durable',
       threadStartRolloutPath: rolloutPath,
       writeRolloutOnMethods: {
         'turn/start': {
           path: rolloutPath,
           threadId: 'thread-fake-tui-durable',
+          append: true,
         },
       },
       notificationsAfterMethods: {
@@ -504,6 +517,8 @@ describeLinux('Codex Session Flow Integration', () => {
     })
 
     const ws = await createAuthenticatedWs(port)
+    let freshTerminalId: string | undefined
+    let restoredTerminalId: string | undefined
 
     try {
       ws.send(JSON.stringify({
@@ -523,7 +538,9 @@ describeLinux('Codex Session Flow Integration', () => {
       if (created.type === 'error') {
         throw new Error(`terminal.create failed: ${created.message}`)
       }
+      freshTerminalId = created.terminalId
 
+      expect(created.sessionRef).toBeUndefined()
       await vi.waitFor(() => {
         expect(registry.get(created.terminalId)?.codexDurability).toMatchObject({
           state: 'captured_pre_turn',
@@ -537,6 +554,11 @@ describeLinux('Codex Session Flow Integration', () => {
         line.pid === registry.get(created.terminalId)?.pty.pid
         && line.message?.result?.thread?.id === 'thread-fake-tui-durable'
       ))
+      await waitForJsonLine(threadOperationLogPath, (line) => (
+        line.method === 'thread/start'
+        && line.threadId === 'thread-fake-tui-durable'
+      ))
+      expect((await readJsonLines(threadOperationLogPath)).some((line) => line.method === 'thread/resume')).toBe(false)
 
       ws.send(JSON.stringify({
         type: 'terminal.input',
@@ -558,7 +580,72 @@ describeLinux('Codex Session Flow Integration', () => {
         sessionId: 'thread-fake-tui-durable',
       })
       expect(await fsp.readFile(rolloutPath, 'utf8')).toContain('"thread-fake-tui-durable"')
+
+      const sizeBeforeRestore = (await fsp.stat(rolloutPath)).size
+      await registry.killAndWait(created.terminalId)
+      freshTerminalId = undefined
+
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId: 'test-req-codex-restore-after-proof',
+        mode: 'codex',
+        cwd: testDir,
+        restore: true,
+        sessionRef: {
+          provider: 'codex',
+          sessionId: 'thread-fake-tui-durable',
+        },
+      }))
+
+      const restored = await waitForMessage(
+        ws,
+        (msg) => (
+          msg.requestId === 'test-req-codex-restore-after-proof'
+          && (msg.type === 'terminal.created' || msg.type === 'error')
+        ),
+      )
+      if (restored.type === 'error') {
+        throw new Error(`terminal.create restore failed: ${restored.message}`)
+      }
+      restoredTerminalId = restored.terminalId
+
+      expect(restored.sessionRef).toEqual({
+        provider: 'codex',
+        sessionId: 'thread-fake-tui-durable',
+      })
+      const restoredRecord = registry.get(restored.terminalId)
+      expect(restoredRecord?.resumeSessionId).toBe('thread-fake-tui-durable')
+      const restoredLaunch = await waitForJsonLine(launchLogPath, (line) => line.pid === restoredRecord?.pty.pid)
+      expect(restoredLaunch.args).toContain('resume')
+      expect(restoredLaunch.args).toContain('thread-fake-tui-durable')
+
+      await waitForJsonLine(threadOperationLogPath, (line) => (
+        line.method === 'thread/resume'
+        && line.threadId === 'thread-fake-tui-durable'
+      ))
+      const operations = await readJsonLines(threadOperationLogPath)
+      expect(operations.filter((line) => line.method === 'thread/start').map((line) => line.threadId)).toEqual([
+        'thread-fake-tui-durable',
+      ])
+      expect(operations.filter((line) => line.method === 'thread/resume').map((line) => line.threadId)).toEqual([
+        'thread-fake-tui-durable',
+      ])
+
+      ws.send(JSON.stringify({
+        type: 'terminal.input',
+        terminalId: restored.terminalId,
+        data: 'hello after restore\r',
+      }))
+      await vi.waitFor(async () => {
+        expect((await fsp.stat(rolloutPath)).size).toBeGreaterThan(sizeBeforeRestore)
+      })
     } finally {
+      if (restoredTerminalId) {
+        await registry.killAndWait(restoredTerminalId).catch(() => undefined)
+      }
+      if (freshTerminalId) {
+        await registry.killAndWait(freshTerminalId).catch(() => undefined)
+      }
       await closeWebSocket(ws)
       if (previousConnectRemote === undefined) delete process.env.FAKE_CODEX_CONNECT_REMOTE
       else process.env.FAKE_CODEX_CONNECT_REMOTE = previousConnectRemote


### PR DESCRIPTION
## Summary
- remove the live Codex durable resume contract that was primarily testing upstream Codex behavior
- extend the deterministic Codex session-flow integration test to cover live-only launch, rollout proof promotion, and durable `thread/resume` restore
- teach the fake Codex executable to send `thread/resume` when launched with `resume <id>`

## Tests
- npm run test:vitest -- --config vitest.server.config.ts test/integration/server/codex-session-flow.test.ts --run -t "keeps fresh Codex live-only until rollout proof"
- npm run test:vitest -- --config vitest.server.config.ts test/integration/server/codex-session-flow.test.ts --run
- npm run test:vitest -- --config vitest.server.config.ts test/integration/real/coding-cli-session-contract.test.ts --run -t "loads the checked-in lab note facts"
- npm run check