### PR TITLE
fix: enforce codex thread identity across resume

### DIFF
--- a/docs/superpowers/plans/2026-06-14-codex-thread-identity-invariant.md
+++ b/docs/superpowers/plans/2026-06-14-codex-thread-identity-invariant.md
@@ -1,0 +1,1529 @@
+# Codex Thread Identity Invariant Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make new Codex panes resume the correct Codex thread by construction by treating the Codex thread id as pane identity and terminal ids as disposable live plumbing.
+
+**Architecture:** Freshell already captures Codex `candidateThreadId`, proves it from the rollout file, and persists `sessionRef`; this plan makes that existing identity contract authoritative on every create, attach, input, and resize path. Stale `liveTerminal` handles become recoverable implementation details: if they do not match the pane's expected Codex identity, they are ignored or repaired before any replay or input reaches a PTY.
+
+**Tech Stack:** TypeScript, NodeNext/ESM, React 18, Redux Toolkit, WebSocket protocol schemas with Zod, Vitest, superwstest, Testing Library.
+
+---
+
+## Scope
+
+This plan deliberately ignores heuristic recovery for already-corrupted historical panes. It does not add "latest Codex history", cwd/title/time matching, or prompt-recency guessing. If a pane has no pane-bound `sessionRef`, no pane-bound `codexDurability`, and no matching server-side Codex durability record, it follows the existing restore-unavailable/fresh-terminal path.
+
+The fix is future-facing and invariant-based:
+
+- A Codex pane's expected identity is its canonical `sessionRef.provider === "codex"` plus `sessionRef.sessionId`, or its durable `codexDurability.durableThreadId`.
+- A `liveTerminal.terminalId` is reusable only when the server record proves it is running the same Codex identity.
+- `terminal.attach`, `terminal.input`, and `terminal.resize` cannot operate on terminal id alone when the client knows the pane's expected Codex identity.
+- Mismatch is not a normal user-facing end state. When the client has expected identity, mismatch clears stale live plumbing and triggers restore/create for the expected identity.
+
+## Current Evidence
+
+Existing implementation already has the core Codex identity machinery:
+
+- `shared/codex-durability.ts` defines `candidateThreadId`, `rolloutPath`, `durableThreadId`, and durability states.
+- `server/coding-cli/codex-app-server/remote-proxy.ts` captures candidates from `thread/start` responses and `thread/started` notifications.
+- `server/coding-cli/codex-app-server/durability-store.ts` writes records under `~/.freshell/codex-durability/<terminalId>.json`.
+- `server/coding-cli/codex-app-server/durability-proof.ts` proves the first rollout JSONL record is `session_meta` with matching `payload.id`.
+- `server/terminal-registry.ts` persists candidates, promotes durable sessions, and broadcasts `terminal.session.associated`.
+- `src/components/TerminalView.tsx` persists `terminal.session.associated` and `terminal.codex.durability.updated` into pane/tab state.
+
+The observed incident shows the missing invariant: a pane can still be recreated, attached, or written to through stale live terminal plumbing or stale persisted identity without every path proving it matches the Codex thread the pane should own.
+
+## File Structure
+
+- Modify `shared/ws-protocol.ts`
+  - Add optional `expectedSessionRef?: SessionLocator` to `terminal.attach`, `terminal.input`, and `terminal.resize`.
+  - Add `SESSION_IDENTITY_MISMATCH` to `ErrorCode` and add optional `expectedSessionRef` / `actualSessionRef` fields to `ErrorMessage`.
+
+- Create `server/terminal-session-identity.ts`
+  - Central helper for comparing an expected session locator to a `TerminalRecord`.
+  - Keeps the identity rule out of `ws-handler.ts`.
+
+- Modify `server/ws-handler.ts`
+  - Validate expected identity before terminal stream attach, input, and resize.
+  - Prefer expected Codex `sessionRef` over stale `liveTerminal` during `terminal.create`.
+  - Return a repairable mismatch response without replaying output or writing input.
+
+- Modify `server/coding-cli/codex-app-server/restore-decision.ts`
+  - Make live terminal reuse require same Codex identity when a requested `sessionRef` or durable `codexDurability` exists.
+  - Remove or narrow any fallback where a requested live terminal wins because `codexDurability` is absent.
+
+- Modify `src/components/TerminalView.tsx`
+  - Send expected session identity with `terminal.attach`, `terminal.input`, and `terminal.resize`.
+  - On mismatch, clear stale `liveTerminal`, preserve `sessionRef`/durable `codexDurability`, flush layout, and issue restore/create for the expected session.
+
+- Modify `src/components/terminal-view-utils.ts`
+  - Add a helper that derives the expected session locator from pane content.
+  - Keep the derivation testable outside the large `TerminalView.tsx` component.
+
+- Modify `src/lib/terminal-session-association.ts`
+  - Preserve existing canonical association persistence.
+  - Add regression coverage that `terminal.session.associated` clears stale live-only assumptions and keeps matching durable Codex state.
+
+- Add tests:
+  - `test/unit/server/terminal-session-identity.test.ts`
+  - `test/server/ws-terminal-codex-identity-invariant.test.ts`
+  - `test/unit/client/components/terminal-view-utils.test.ts`
+  - `test/unit/client/components/TerminalView.codex-identity.test.tsx`
+  - Extend `test/server/ws-terminal-create-reuse-running-codex.test.ts`
+
+## Identity Rule
+
+Use this exact rule everywhere:
+
+```ts
+type SessionLocator = {
+  provider: 'codex' | 'claude' | 'opencode'
+  sessionId: string
+}
+
+function terminalMatchesExpectedSession(record: TerminalRecord, expected: SessionLocator | undefined): boolean {
+  if (!expected) return true
+  if (record.mode !== expected.provider) return false
+  if (record.resumeSessionId === expected.sessionId) return true
+  if (record.codexDurability?.state === 'durable' && record.codexDurability.durableThreadId === expected.sessionId) {
+    return true
+  }
+  if (record.codexDurability?.candidate?.candidateThreadId === expected.sessionId) {
+    return true
+  }
+  return false
+}
+```
+
+Non-Codex providers may use `resumeSessionId` only. Codex gets the extra durable/candidate checks because current records already store those identities.
+
+## Task 1: Add Server Identity Helper
+
+**Files:**
+- Create: `server/terminal-session-identity.ts`
+- Test: `test/unit/server/terminal-session-identity.test.ts`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `test/unit/server/terminal-session-identity.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { terminalMatchesExpectedSession } from '../../../server/terminal-session-identity.js'
+
+function record(overrides: Record<string, unknown> = {}) {
+  return {
+    terminalId: 'term-1',
+    mode: 'codex',
+    status: 'running',
+    resumeSessionId: undefined,
+    codexDurability: undefined,
+    ...overrides,
+  } as any
+}
+
+describe('terminalMatchesExpectedSession', () => {
+  it('accepts missing expected identity for backwards-compatible live-only paths', () => {
+    expect(terminalMatchesExpectedSession(record(), undefined)).toBe(true)
+  })
+
+  it('accepts a matching resumeSessionId', () => {
+    expect(terminalMatchesExpectedSession(
+      record({ resumeSessionId: 'thread-1' }),
+      { provider: 'codex', sessionId: 'thread-1' },
+    )).toBe(true)
+  })
+
+  it('accepts a matching durable Codex thread id', () => {
+    expect(terminalMatchesExpectedSession(
+      record({
+        codexDurability: {
+          schemaVersion: 1,
+          state: 'durable',
+          durableThreadId: 'thread-1',
+        },
+      }),
+      { provider: 'codex', sessionId: 'thread-1' },
+    )).toBe(true)
+  })
+
+  it('accepts a matching captured Codex candidate before durable promotion', () => {
+    expect(terminalMatchesExpectedSession(
+      record({
+        codexDurability: {
+          schemaVersion: 1,
+          state: 'captured_pre_turn',
+          candidate: {
+            provider: 'codex',
+            candidateThreadId: 'thread-1',
+            rolloutPath: '/home/dan/.codex/sessions/2026/06/14/rollout-thread-1.jsonl',
+            source: 'thread_start_response',
+            capturedAt: 1,
+          },
+        },
+      }),
+      { provider: 'codex', sessionId: 'thread-1' },
+    )).toBe(true)
+  })
+
+  it('rejects a Codex terminal for the wrong thread', () => {
+    expect(terminalMatchesExpectedSession(
+      record({
+        resumeSessionId: 'thread-old',
+        codexDurability: {
+          schemaVersion: 1,
+          state: 'durable',
+          durableThreadId: 'thread-old',
+        },
+      }),
+      { provider: 'codex', sessionId: 'thread-new' },
+    )).toBe(false)
+  })
+
+  it('rejects a provider mismatch', () => {
+    expect(terminalMatchesExpectedSession(
+      record({ mode: 'opencode', resumeSessionId: 'thread-1' }),
+      { provider: 'codex', sessionId: 'thread-1' },
+    )).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/terminal-session-identity.test.ts --run
+```
+
+Expected: FAIL because `server/terminal-session-identity.ts` does not exist.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `server/terminal-session-identity.ts`:
+
+```ts
+import type { SessionLocator } from '../shared/ws-protocol.js'
+import type { TerminalRecord } from './terminal-registry.js'
+
+export type SessionIdentityMismatch = {
+  code: 'SESSION_IDENTITY_MISMATCH'
+  terminalId: string
+  expectedSessionRef: SessionLocator
+  actualSessionRef?: SessionLocator
+}
+
+export function terminalActualSessionRef(record: Pick<TerminalRecord, 'mode' | 'resumeSessionId' | 'codexDurability'>): SessionLocator | undefined {
+  if (record.mode === 'codex') {
+    const durableThreadId = record.codexDurability?.state === 'durable'
+      ? record.codexDurability.durableThreadId
+      : undefined
+    const candidateThreadId = record.codexDurability?.candidate?.candidateThreadId
+    const sessionId = durableThreadId ?? record.resumeSessionId ?? candidateThreadId
+    return sessionId ? { provider: 'codex', sessionId } : undefined
+  }
+
+  if (record.resumeSessionId && (record.mode === 'claude' || record.mode === 'opencode')) {
+    return { provider: record.mode, sessionId: record.resumeSessionId }
+  }
+
+  return undefined
+}
+
+export function terminalMatchesExpectedSession(
+  record: Pick<TerminalRecord, 'mode' | 'resumeSessionId' | 'codexDurability'>,
+  expectedSessionRef: SessionLocator | undefined,
+): boolean {
+  if (!expectedSessionRef) return true
+  if (record.mode !== expectedSessionRef.provider) return false
+
+  if (record.resumeSessionId === expectedSessionRef.sessionId) return true
+
+  if (expectedSessionRef.provider === 'codex') {
+    if (
+      record.codexDurability?.state === 'durable'
+      && record.codexDurability.durableThreadId === expectedSessionRef.sessionId
+    ) return true
+
+    if (record.codexDurability?.candidate?.candidateThreadId === expectedSessionRef.sessionId) return true
+  }
+
+  return false
+}
+
+export function buildSessionIdentityMismatch(
+  terminalId: string,
+  record: Pick<TerminalRecord, 'mode' | 'resumeSessionId' | 'codexDurability'>,
+  expectedSessionRef: SessionLocator,
+): SessionIdentityMismatch {
+  return {
+    code: 'SESSION_IDENTITY_MISMATCH',
+    terminalId,
+    expectedSessionRef,
+    ...(terminalActualSessionRef(record) ? { actualSessionRef: terminalActualSessionRef(record) } : {}),
+  }
+}
+```
+
+- [ ] **Step 4: Run the unit test**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/server/terminal-session-identity.test.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/terminal-session-identity.ts test/unit/server/terminal-session-identity.test.ts
+git commit -m "test: define terminal session identity matching"
+```
+
+## Task 2: Add Expected Identity To WebSocket Protocol
+
+**Files:**
+- Modify: `shared/ws-protocol.ts`
+- Test: `test/server/ws-protocol.test.ts`
+
+- [ ] **Step 1: Write failing protocol tests**
+
+Append tests to `test/server/ws-protocol.test.ts` near the existing attach/input/resize protocol tests:
+
+```ts
+it('terminal.attach accepts expectedSessionRef', async () => {
+  const { ws, terminalId } = await createTerminal()
+  ws.send(JSON.stringify({
+    type: 'terminal.attach',
+    terminalId,
+    intent: 'viewport_hydrate',
+    cols: 120,
+    rows: 40,
+    expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
+  }))
+  const ready = await waitForMessage(ws, (msg) => msg.type === 'terminal.attach.ready' && msg.terminalId === terminalId)
+  expect(ready.type).toBe('terminal.attach.ready')
+})
+
+it('terminal.input accepts expectedSessionRef', async () => {
+  const { ws, terminalId } = await createTerminal()
+  ws.send(JSON.stringify({
+    type: 'terminal.input',
+    terminalId,
+    data: 'echo hello',
+    expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
+  }))
+  await expectNoInvalidMessage(ws)
+})
+
+it('terminal.resize accepts expectedSessionRef', async () => {
+  const { ws, terminalId } = await createTerminal()
+  ws.send(JSON.stringify({
+    type: 'terminal.resize',
+    terminalId,
+    cols: 120,
+    rows: 40,
+    expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
+  }))
+  await expectNoInvalidMessage(ws)
+})
+```
+
+If the helpers in this file have different names, use the local existing helpers that create a terminal, wait for messages, and assert no protocol validation error. Do not weaken the assertions.
+
+- [ ] **Step 2: Run the failing protocol tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/server/ws-protocol.test.ts --run
+```
+
+Expected: FAIL because the schemas reject `expectedSessionRef`.
+
+- [ ] **Step 3: Extend schemas**
+
+Modify `shared/ws-protocol.ts`:
+
+```ts
+export const TerminalAttachSchema = z.object({
+  type: z.literal('terminal.attach'),
+  terminalId: z.string().min(1),
+  sinceSeq: z.number().int().nonnegative().optional(),
+  maxReplayBytes: z.number().int().positive().optional(),
+  attachRequestId: z.string().min(1).optional(),
+  intent: TerminalAttachIntentSchema,
+  priority: TerminalAttachPrioritySchema.optional(),
+  cols: z.number().int().min(2).max(1000),
+  rows: z.number().int().min(2).max(500),
+  expectedSessionRef: SessionLocatorSchema.optional(),
+})
+
+export const TerminalInputSchema = z.object({
+  type: z.literal('terminal.input'),
+  terminalId: z.string().min(1),
+  data: z.string(),
+  expectedSessionRef: SessionLocatorSchema.optional(),
+})
+
+export const TerminalResizeSchema = z.object({
+  type: z.literal('terminal.resize'),
+  terminalId: z.string().min(1),
+  cols: z.number().int().min(2).max(1000),
+  rows: z.number().int().min(2).max(500),
+  expectedSessionRef: SessionLocatorSchema.optional(),
+})
+```
+
+- [ ] **Step 4: Run protocol tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/server/ws-protocol.test.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/ws-protocol.ts test/server/ws-protocol.test.ts
+git commit -m "feat: carry expected session identity on terminal operations"
+```
+
+## Task 3: Enforce Identity Before Attach/Input/Resize
+
+**Files:**
+- Modify: `server/ws-handler.ts`
+- Modify: `shared/ws-protocol.ts` if an error type is needed
+- Test: `test/server/ws-terminal-codex-identity-invariant.test.ts`
+
+- [ ] **Step 1: Write failing server tests**
+
+Create `test/server/ws-terminal-codex-identity-invariant.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { createTestServer, waitForMessage } from './helpers/ws-test-server.js'
+
+describe('Codex terminal identity invariant', () => {
+  it('rejects attach before replay when terminal id belongs to a different Codex thread', async () => {
+    const app = await createTestServer()
+    const ws = await app.openWs()
+    const terminal = await app.createFakeTerminal({
+      mode: 'codex',
+      terminalId: 'term-old',
+      resumeSessionId: 'thread-old',
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-old',
+      },
+      output: 'old transcript must not replay',
+    })
+
+    ws.send(JSON.stringify({
+      type: 'terminal.attach',
+      terminalId: terminal.terminalId,
+      intent: 'viewport_hydrate',
+      cols: 120,
+      rows: 40,
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+    }))
+
+    const error = await waitForMessage(ws, (msg) => msg.type === 'error' && msg.code === 'SESSION_IDENTITY_MISMATCH')
+    expect(error).toMatchObject({
+      code: 'SESSION_IDENTITY_MISMATCH',
+      terminalId: 'term-old',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+      actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
+    })
+    expect(app.sentMessages()).not.toContainEqual(expect.objectContaining({ type: 'terminal.attach.ready' }))
+    expect(app.sentOutput()).not.toContain('old transcript must not replay')
+  })
+
+  it('rejects input before writing to a mismatched Codex terminal', async () => {
+    const app = await createTestServer()
+    const ws = await app.openWs()
+    const terminal = await app.createFakeTerminal({
+      mode: 'codex',
+      terminalId: 'term-old',
+      resumeSessionId: 'thread-old',
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-old',
+      },
+    })
+
+    ws.send(JSON.stringify({
+      type: 'terminal.input',
+      terminalId: terminal.terminalId,
+      data: 'Repeat the last 5 lines\\n',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+    }))
+
+    const error = await waitForMessage(ws, (msg) => msg.type === 'error' && msg.code === 'SESSION_IDENTITY_MISMATCH')
+    expect(error.terminalId).toBe('term-old')
+    expect(terminal.inputWrites).toEqual([])
+  })
+
+  it('rejects resize before mutating a mismatched Codex terminal', async () => {
+    const app = await createTestServer()
+    const ws = await app.openWs()
+    const terminal = await app.createFakeTerminal({
+      mode: 'codex',
+      terminalId: 'term-old',
+      resumeSessionId: 'thread-old',
+    })
+
+    ws.send(JSON.stringify({
+      type: 'terminal.resize',
+      terminalId: terminal.terminalId,
+      cols: 132,
+      rows: 50,
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+    }))
+
+    const error = await waitForMessage(ws, (msg) => msg.type === 'error' && msg.code === 'SESSION_IDENTITY_MISMATCH')
+    expect(error.terminalId).toBe('term-old')
+    expect(terminal.resizeCalls).toEqual([])
+  })
+})
+```
+
+Use the existing server test helpers in `test/server/ws-protocol.test.ts` or `test/server/ws-terminal-create-reuse-running-codex.test.ts`. If there is no `createFakeTerminal` helper, create a local fake registry/terminal harness in this test that exercises `WsHandler` at the same abstraction level as the neighboring server tests.
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/server/ws-terminal-codex-identity-invariant.test.ts --run
+```
+
+Expected: FAIL because attach/input/resize only validate `terminalId`.
+
+- [ ] **Step 3: Add mismatch guard in `ws-handler.ts`**
+
+Import the helper:
+
+```ts
+import {
+  buildSessionIdentityMismatch,
+  terminalMatchesExpectedSession,
+} from './terminal-session-identity.js'
+```
+
+Add a local guard near the terminal operation handlers:
+
+```ts
+const rejectSessionIdentityMismatch = (
+  ws: AuthedWebSocket,
+  terminalId: string,
+  record: TerminalRecord,
+  expectedSessionRef: SessionLocator | undefined,
+  requestId?: string,
+): boolean => {
+  if (!expectedSessionRef) return false
+  if (terminalMatchesExpectedSession(record, expectedSessionRef)) return false
+
+  const mismatch = buildSessionIdentityMismatch(terminalId, record, expectedSessionRef)
+  recordSessionLifecycleEvent({
+    kind: 'terminal_session_identity_mismatch',
+    provider: expectedSessionRef.provider,
+    terminalId,
+    sessionId: expectedSessionRef.sessionId,
+    operation: 'terminal.operation',
+  })
+  this.sendError(ws, {
+    code: mismatch.code,
+    message: 'Terminal belongs to a different session than the pane expects.',
+    terminalId,
+    requestId,
+    expectedSessionRef: mismatch.expectedSessionRef,
+    actualSessionRef: mismatch.actualSessionRef,
+  })
+  return true
+}
+```
+
+Apply the guard:
+
+```ts
+if (rejectSessionIdentityMismatch(ws, m.terminalId, record, m.expectedSessionRef, m.attachRequestId)) return
+```
+
+before `terminalStreamBroker.attach`.
+
+```ts
+const record = this.registry.get(m.terminalId)
+if (record && rejectSessionIdentityMismatch(ws, m.terminalId, record, m.expectedSessionRef)) return
+const result = this.registry.input(m.terminalId, m.data)
+```
+
+before `registry.input`.
+
+```ts
+const record = this.registry.get(m.terminalId)
+if (record && rejectSessionIdentityMismatch(ws, m.terminalId, record, m.expectedSessionRef)) return
+```
+
+before `registry.resize`.
+
+In `shared/ws-protocol.ts`, extend the protocol error shape:
+
+```ts
+export const ErrorCode = z.enum([
+  'NOT_AUTHENTICATED',
+  'INVALID_MESSAGE',
+  'UNKNOWN_MESSAGE',
+  'INVALID_TERMINAL_ID',
+  'INVALID_SESSION_ID',
+  'RESTORE_UNAVAILABLE',
+  'INVALID_CREATE_REQUEST',
+  'PTY_SPAWN_FAILED',
+  'FILE_WATCHER_ERROR',
+  'INTERNAL_ERROR',
+  'RATE_LIMITED',
+  'UNAUTHORIZED',
+  'PROTOCOL_MISMATCH',
+  'SESSION_IDENTITY_MISMATCH',
+])
+
+export type ErrorMessage = {
+  type: 'error'
+  code: ErrorCode
+  message: string
+  requestId?: string
+  terminalId?: string
+  timestamp: string
+  expectedSessionRef?: SessionLocator
+  actualSessionRef?: SessionLocator
+}
+```
+
+- [ ] **Step 4: Run the focused server tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/server/ws-terminal-codex-identity-invariant.test.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run existing protocol coverage**
+
+Run:
+
+```bash
+npm run test:vitest -- test/server/ws-protocol.test.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/ws-handler.ts server/terminal-session-identity.ts shared/ws-protocol.ts test/server/ws-terminal-codex-identity-invariant.test.ts
+git commit -m "fix: reject stale terminal operations for mismatched sessions"
+```
+
+## Task 4: Make Create Prefer Expected Codex Identity Over Stale Live Handles
+
+**Files:**
+- Modify: `server/ws-handler.ts`
+- Modify: `server/coding-cli/codex-app-server/restore-decision.ts`
+- Test: `test/server/ws-terminal-create-reuse-running-codex.test.ts`
+- Test: `test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts`
+
+- [ ] **Step 1: Write failing create/reuse tests**
+
+Add to `test/server/ws-terminal-create-reuse-running-codex.test.ts`:
+
+```ts
+it('does not reuse a live Codex terminal when sessionRef points at a different thread', async () => {
+  const harness = await createCodexReuseHarness()
+  const old = await harness.createRunningCodexTerminal({
+    terminalId: 'term-old',
+    sessionRef: { provider: 'codex', sessionId: 'thread-old' },
+    codexDurability: {
+      schemaVersion: 1,
+      state: 'durable',
+      durableThreadId: 'thread-old',
+    },
+  })
+
+  harness.ws.send(JSON.stringify({
+    type: 'terminal.create',
+    requestId: 'restore-thread-new',
+    mode: 'codex',
+    cwd: '/home/dan/code/freshell',
+    sessionRef: { provider: 'codex', sessionId: 'thread-new' },
+    liveTerminal: {
+      terminalId: old.terminalId,
+      serverInstanceId: harness.serverInstanceId,
+    },
+    restore: true,
+    tabId: 'tab-1',
+    paneId: 'pane-1',
+  }))
+
+  const created = await harness.waitForCreated('restore-thread-new')
+  expect(created.terminalId).not.toBe(old.terminalId)
+  expect(harness.launches()).toContainEqual(expect.objectContaining({
+    mode: 'codex',
+    resumeSessionId: 'thread-new',
+  }))
+})
+```
+
+Add to `test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts`:
+
+```ts
+it('requires live terminal identity to match requested durable sessionRef', () => {
+  const decision = resolveCodexCreateRestoreDecision({
+    restoreRequested: true,
+    requestedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+    codexDurability: undefined,
+    requestedLiveTerminal: {
+      terminalId: 'term-old',
+      resumeSessionId: 'thread-old',
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-old',
+      },
+    } as any,
+  })
+
+  expect(decision.kind).not.toBe('attach_live')
+})
+```
+
+Adapt helper names to existing test helpers. Keep the assertion: a stale live terminal must not win over `sessionRef`.
+
+- [ ] **Step 2: Run failing tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/server/ws-terminal-create-reuse-running-codex.test.ts test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts --run
+```
+
+Expected: FAIL because a requested live terminal can still be reused without enough identity validation.
+
+- [ ] **Step 3: Tighten create/reuse logic**
+
+In `server/ws-handler.ts`, update the `requestedLiveTerminal()` path so it returns a record only when:
+
+```ts
+if (requestedSessionRef && !terminalMatchesExpectedSession(live, requestedSessionRef)) {
+  recordSessionLifecycleEvent({
+    kind: 'terminal_session_identity_mismatch',
+    provider: requestedSessionRef.provider,
+    terminalId: live.terminalId,
+    sessionId: requestedSessionRef.sessionId,
+    operation: 'terminal.create.liveTerminal',
+  })
+  return undefined
+}
+```
+
+Apply the same check to any branch that attaches a requested live terminal because `codexDurabilityForDecision?.candidate` is absent. The rule is: if `sessionRef` exists, stale `liveTerminal` is ignored; restore/create proceeds from `sessionRef`.
+
+In `restore-decision.ts`, make any `attach_live` decision require a matching expected Codex session when `requestedSessionRef` or durable `codexDurability` is present.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/server/ws-terminal-create-reuse-running-codex.test.ts test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/ws-handler.ts server/coding-cli/codex-app-server/restore-decision.ts test/server/ws-terminal-create-reuse-running-codex.test.ts test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts
+git commit -m "fix: prefer Codex session identity over stale live handles"
+```
+
+## Task 5: Send Expected Identity From TerminalView
+
+**Files:**
+- Modify: `src/components/terminal-view-utils.ts`
+- Modify: `src/components/TerminalView.tsx`
+- Test: `test/unit/client/components/terminal-view-utils.test.ts`
+- Test: `test/unit/client/components/TerminalView.codex-identity.test.tsx`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Add to `test/unit/client/components/terminal-view-utils.test.ts`:
+
+```ts
+import { getExpectedSessionRefForTerminalOperation } from '../../../src/components/terminal-view-utils'
+
+describe('getExpectedSessionRefForTerminalOperation', () => {
+  it('returns canonical sessionRef when present', () => {
+    expect(getExpectedSessionRefForTerminalOperation({
+      mode: 'codex',
+      sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-1',
+      },
+    } as any)).toEqual({ provider: 'codex', sessionId: 'thread-1' })
+  })
+
+  it('returns durable Codex identity when sessionRef is missing', () => {
+    expect(getExpectedSessionRefForTerminalOperation({
+      mode: 'codex',
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-1',
+      },
+    } as any)).toEqual({ provider: 'codex', sessionId: 'thread-1' })
+  })
+
+  it('does not synthesize identity from cwd, title, or liveTerminal', () => {
+    expect(getExpectedSessionRefForTerminalOperation({
+      mode: 'codex',
+      initialCwd: '/home/dan/code/freshell',
+      liveTerminal: { terminalId: 'term-1', serverInstanceId: 'srv-1' },
+    } as any)).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run failing helper tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/terminal-view-utils.test.ts --run
+```
+
+Expected: FAIL because the helper does not exist.
+
+- [ ] **Step 3: Implement helper**
+
+In `src/components/terminal-view-utils.ts`:
+
+```ts
+import type { SessionLocator, TerminalPaneContent } from '@/store/paneTypes'
+
+export function getExpectedSessionRefForTerminalOperation(
+  content: TerminalPaneContent | null | undefined,
+): SessionLocator | undefined {
+  if (!content) return undefined
+  if (content.sessionRef) return content.sessionRef
+
+  if (
+    content.mode === 'codex'
+    && content.codexDurability?.state === 'durable'
+    && content.codexDurability.durableThreadId
+  ) {
+    return { provider: 'codex', sessionId: content.codexDurability.durableThreadId }
+  }
+
+  return undefined
+}
+```
+
+- [ ] **Step 4: Wire helper into TerminalView sends**
+
+In `src/components/TerminalView.tsx`, compute before each send:
+
+```ts
+const expectedSessionRef = getExpectedSessionRefForTerminalOperation(contentRef.current)
+```
+
+Add it to attach:
+
+```ts
+ws.send({
+  type: 'terminal.attach',
+  terminalId: tid,
+  intent: effectiveIntent,
+  cols,
+  rows,
+  sinceSeq,
+  attachRequestId,
+  priority: opts?.priority ?? 'foreground',
+  ...(opts?.maxReplayBytes ? { maxReplayBytes: opts.maxReplayBytes } : {}),
+  ...(expectedSessionRef ? { expectedSessionRef } : {}),
+})
+```
+
+Add it to input:
+
+```ts
+ws.send({
+  type: 'terminal.input',
+  terminalId: tid,
+  data,
+  ...(expectedSessionRef ? { expectedSessionRef } : {}),
+})
+```
+
+Add it to resize:
+
+```ts
+ws.send({
+  type: 'terminal.resize',
+  terminalId: tid,
+  cols: term.cols,
+  rows: term.rows,
+  ...(expectedSessionRef ? { expectedSessionRef } : {}),
+})
+```
+
+- [ ] **Step 5: Write TerminalView message regression test**
+
+Create `test/unit/client/components/TerminalView.codex-identity.test.tsx`:
+
+```ts
+it('sends expected Codex session identity with terminal input', async () => {
+  const ws = renderCodexTerminalView({
+    content: {
+      mode: 'codex',
+      terminalId: 'term-1',
+      sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+      shell: 'system',
+      initialCwd: '/home/dan/code/freshell',
+    },
+  })
+
+  await typeIntoTerminal('hello')
+
+  expect(ws.sentMessages()).toContainEqual(expect.objectContaining({
+    type: 'terminal.input',
+    terminalId: 'term-1',
+    expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
+  }))
+})
+```
+
+Use existing TerminalView render helpers and xterm input helpers. If this repository already covers outbound messages in another TerminalView lifecycle test file, add the case there instead of creating a new harness.
+
+- [ ] **Step 6: Run client tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/terminal-view-utils.test.ts test/unit/client/components/TerminalView.codex-identity.test.tsx --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/terminal-view-utils.ts src/components/TerminalView.tsx test/unit/client/components/terminal-view-utils.test.ts test/unit/client/components/TerminalView.codex-identity.test.tsx
+git commit -m "feat: send pane session identity with terminal operations"
+```
+
+## Task 6: Client Repairs Stale Live Terminal Handles
+
+**Files:**
+- Modify: `src/components/TerminalView.tsx`
+- Modify: `src/store/panesSlice.ts` if a reducer helper is needed
+- Test: `test/unit/client/components/TerminalView.codex-identity.test.tsx`
+
+- [ ] **Step 1: Write failing client repair test**
+
+Add:
+
+```ts
+it('clears stale liveTerminal and recreates expected Codex session after identity mismatch', async () => {
+  const ws = renderCodexTerminalView({
+    content: {
+      mode: 'codex',
+      terminalId: 'term-old',
+      liveTerminal: { terminalId: 'term-old', serverInstanceId: 'srv-1' },
+      sessionRef: { provider: 'codex', sessionId: 'thread-new' },
+      shell: 'system',
+      initialCwd: '/home/dan/code/freshell',
+    },
+  })
+
+  ws.receive({
+    type: 'error',
+    code: 'SESSION_IDENTITY_MISMATCH',
+    message: 'Terminal belongs to a different session than the pane expects.',
+    terminalId: 'term-old',
+    expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+    actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
+  })
+
+  await waitFor(() => {
+    expect(currentPaneContent()).toMatchObject({
+      mode: 'codex',
+      sessionRef: { provider: 'codex', sessionId: 'thread-new' },
+    })
+    expect(currentPaneContent().liveTerminal).toBeUndefined()
+    expect(currentPaneContent().terminalId).toBeUndefined()
+  })
+
+  expect(ws.sentMessages()).toContainEqual(expect.objectContaining({
+    type: 'terminal.create',
+    mode: 'codex',
+    sessionRef: { provider: 'codex', sessionId: 'thread-new' },
+  }))
+})
+```
+
+- [ ] **Step 2: Run failing client test**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/TerminalView.codex-identity.test.tsx --run
+```
+
+Expected: FAIL because mismatch errors are not repaired.
+
+- [ ] **Step 3: Implement repair handling**
+
+In the WebSocket message handler in `TerminalView.tsx`, add:
+
+```ts
+if (
+  msg.type === 'error'
+  && msg.code === 'SESSION_IDENTITY_MISMATCH'
+  && msg.terminalId === tid
+) {
+  const expectedSessionRef = sanitizeSessionRef(msg.expectedSessionRef)
+  if (expectedSessionRef) {
+    updateContent({
+      terminalId: undefined,
+      liveTerminal: undefined,
+      sessionRef: expectedSessionRef,
+    })
+    dispatch(flushPersistedLayoutNow())
+    queueMicrotask(() => {
+      const nextRequestId = nanoid()
+      sendCreate(nextRequestId)
+    })
+  }
+  return
+}
+```
+
+Use local helper names for `updateContent`, request id generation, and `sendCreate`. If `sendCreate` is not in scope at the message handler, extract a small `scheduleRestoreCreateForExpectedSession` callback inside `TerminalView.tsx` that has access to the same refs.
+
+- [ ] **Step 4: Run client repair test**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/TerminalView.codex-identity.test.tsx --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/TerminalView.tsx src/store/panesSlice.ts test/unit/client/components/TerminalView.codex-identity.test.tsx
+git commit -m "fix: repair stale Codex live terminal handles"
+```
+
+## Task 7: Prove Association Flush Is The Persistence Boundary
+
+**Files:**
+- Modify: `src/lib/terminal-session-association.ts`
+- Test: `test/unit/client/lib/terminal-session-association.test.ts`
+- Test: `test/unit/server/terminal-registry.codex-sidecar.test.ts`
+
+- [ ] **Step 1: Write failing client association test**
+
+Add to `test/unit/client/lib/terminal-session-association.test.ts`:
+
+```ts
+it('persists canonical Codex sessionRef and keeps matching durable state on association', () => {
+  const store = createTabsStoreWithPane({
+    tabId: 'tab-1',
+    paneId: 'pane-1',
+    terminalId: 'term-1',
+    content: {
+      mode: 'codex',
+      terminalId: 'term-1',
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-1',
+        candidate: {
+          provider: 'codex',
+          candidateThreadId: 'thread-1',
+          rolloutPath: '/home/dan/.codex/sessions/2026/06/14/rollout-thread-1.jsonl',
+          source: 'thread_start_response',
+          capturedAt: 1,
+        },
+      },
+    },
+  })
+
+  const reconciled = reconcileTerminalSessionAssociation({
+    dispatch: store.dispatch,
+    getState: store.getState,
+    terminalId: 'term-1',
+    sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+  })
+
+  expect(reconciled).toBe(true)
+  expect(selectPaneContent(store.getState(), 'tab-1', 'pane-1')).toMatchObject({
+    sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+    resumeSessionId: undefined,
+    codexDurability: {
+      state: 'durable',
+      durableThreadId: 'thread-1',
+    },
+  })
+})
+```
+
+- [ ] **Step 2: Write failing server association test**
+
+Add to `test/unit/server/terminal-registry.codex-sidecar.test.ts`:
+
+```ts
+it('broadcasts terminal.session.associated only after matching Codex rollout proof succeeds', async () => {
+  const registry = createRegistryWithCodexDurabilityStore()
+  const terminal = await registry.createCodexTerminalWithCandidate({
+    terminalId: 'term-1',
+    candidateThreadId: 'thread-1',
+    rolloutPath: await writeCodexRollout({ threadId: 'thread-1' }),
+  })
+
+  await registry.handleCodexTurnCompletedForTest(terminal.terminalId, {
+    threadId: 'thread-1',
+    turnId: 'turn-1',
+  })
+
+  await vi.waitFor(() => {
+    expect(registry.broadcasts()).toContainEqual(expect.objectContaining({
+      type: 'terminal.session.associated',
+      terminalId: 'term-1',
+      sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+    }))
+  })
+})
+```
+
+Use existing helper names in this file; this test already has many Codex durability helpers.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/lib/terminal-session-association.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts --run
+```
+
+Expected: PASS when the existing association path already satisfies the invariant, or FAIL with a missing pane persistence / missing broadcast assertion.
+
+- [ ] **Step 4: Confirm or apply the association persistence code**
+
+Inspect `src/lib/terminal-session-association.ts`. It must preserve matching durable Codex state with this logic:
+
+```ts
+const nextCodexDurability = sessionRef.provider === 'codex'
+  && content.codexDurability?.state === 'durable'
+  && (
+    content.codexDurability.durableThreadId === sessionRef.sessionId
+    || content.codexDurability.candidate?.candidateThreadId === sessionRef.sessionId
+  )
+    ? content.codexDurability
+    : undefined
+```
+
+Inspect `server/terminal-registry.ts`. It must keep this order after proof success:
+
+```ts
+this.broadcastCodexDurability(record, stored)
+this.broadcastCodexSessionAssociated(record, proof.rolloutProofId)
+```
+
+Do not broadcast association before rollout proof succeeds.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/lib/terminal-session-association.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/terminal-session-association.ts server/terminal-registry.ts test/unit/client/lib/terminal-session-association.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts
+git commit -m "test: lock Codex association persistence boundary"
+```
+
+## Task 8: Incident-Shaped Component E2E Regression
+
+**Files:**
+- Create: `test/e2e/codex-wrong-thread-resume.test.tsx`
+
+- [ ] **Step 1: Write the failing e2e regression**
+
+Create `test/e2e/codex-wrong-thread-resume.test.tsx`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import tabsReducer from '@/store/tabsSlice'
+import panesReducer from '@/store/panesSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
+import connectionReducer from '@/store/connectionSlice'
+import { useAppSelector } from '@/store/hooks'
+import type { PaneNode, TerminalPaneContent } from '@/store/paneTypes'
+import TerminalView from '@/components/TerminalView'
+
+const wsHarness = vi.hoisted(() => {
+  const messageHandlers = new Set<(msg: any) => void>()
+  const restoreRequestIds = new Set<string>()
+  return {
+    send: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    onMessage: vi.fn((handler: (msg: any) => void) => {
+      messageHandlers.add(handler)
+      return () => messageHandlers.delete(handler)
+    }),
+    onReconnect: vi.fn(() => () => {}),
+    addRestoreRequestId(id: string) {
+      restoreRequestIds.add(id)
+    },
+    consumeRestoreRequestId(id: string) {
+      const hasId = restoreRequestIds.has(id)
+      restoreRequestIds.delete(id)
+      return hasId
+    },
+    emit(msg: any) {
+      for (const handler of messageHandlers) handler(msg)
+    },
+    reset() {
+      messageHandlers.clear()
+      restoreRequestIds.clear()
+      this.send.mockClear()
+    },
+  }
+})
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({
+    send: wsHarness.send,
+    connect: wsHarness.connect,
+    onMessage: wsHarness.onMessage,
+    onReconnect: wsHarness.onReconnect,
+  }),
+}))
+
+vi.mock('@/lib/terminal-restore', () => ({
+  addTerminalRestoreRequestId: (id: string) => wsHarness.addRestoreRequestId(id),
+  consumeTerminalRestoreRequestId: (id: string) => wsHarness.consumeRestoreRequestId(id),
+  addTerminalFreshRecoveryRequestId: vi.fn(),
+  consumeTerminalFreshRecoveryRequest: vi.fn(() => undefined),
+}))
+
+vi.mock('@/lib/terminal-themes', () => ({
+  getTerminalTheme: () => ({}),
+}))
+
+vi.mock('@/components/terminal/terminal-runtime', () => ({
+  createTerminalRuntime: () => ({
+    attachAddons: vi.fn(),
+    fit: vi.fn(),
+    findNext: vi.fn(() => false),
+    findPrevious: vi.fn(() => false),
+    clearDecorations: vi.fn(),
+    onDidChangeResults: vi.fn(() => ({ dispose: vi.fn() })),
+    dispose: vi.fn(),
+    webglActive: vi.fn(() => false),
+  }),
+}))
+
+vi.mock('@xterm/xterm', () => {
+  class MockTerminal {
+    options: Record<string, unknown> = {}
+    cols = 80
+    rows = 24
+    open = vi.fn()
+    registerLinkProvider = vi.fn(() => ({ dispose: vi.fn() }))
+    onData = vi.fn(() => ({ dispose: vi.fn() }))
+    onTitleChange = vi.fn(() => ({ dispose: vi.fn() }))
+    attachCustomKeyEventHandler = vi.fn()
+    attachCustomWheelEventHandler = vi.fn()
+    dispose = vi.fn()
+    focus = vi.fn()
+    getSelection = vi.fn(() => '')
+    clear = vi.fn()
+    write = vi.fn((data: string, cb?: () => void) => {
+      cb?.()
+      return data.length
+    })
+    writeln = vi.fn()
+  }
+  return { Terminal: MockTerminal }
+})
+
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
+
+class MockResizeObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+}
+
+function findLeaf(node: PaneNode | undefined, paneId: string): Extract<PaneNode, { type: 'leaf' }> | null {
+  if (!node) return null
+  if (node.type === 'leaf') return node.id === paneId ? node : null
+  return findLeaf(node.children[0], paneId) || findLeaf(node.children[1], paneId)
+}
+
+function TerminalViewFromStore({ tabId, paneId }: { tabId: string; paneId: string }) {
+  const paneContent = useAppSelector((state) => findLeaf(state.panes.layouts[tabId], paneId)?.content ?? null)
+  if (!paneContent || paneContent.kind !== 'terminal') return null
+  return <TerminalView tabId={tabId} paneId={paneId} paneContent={paneContent} />
+}
+
+function createStore(content: TerminalPaneContent) {
+  return configureStore({
+    reducer: {
+      tabs: tabsReducer,
+      panes: panesReducer,
+      settings: settingsReducer,
+      connection: connectionReducer,
+    },
+    preloadedState: {
+      tabs: {
+        tabs: [{
+          id: 'tab-codex',
+          mode: 'codex',
+          status: 'running',
+          title: 'Codex',
+          titleSetByUser: false,
+          createRequestId: 'tab-codex',
+        }],
+        activeTabId: 'tab-codex',
+      },
+      panes: {
+        layouts: {
+          'tab-codex': {
+            type: 'leaf',
+            id: 'pane-codex',
+            content,
+          },
+        },
+        activePane: { 'tab-codex': 'pane-codex' },
+        paneTitles: {},
+      },
+      settings: { settings: defaultSettings, status: 'loaded' },
+      connection: { status: 'ready', error: null, serverInstanceId: 'srv-new' },
+    },
+  })
+}
+
+function sentMessages() {
+  return wsHarness.send.mock.calls.map(([msg]) => msg)
+}
+
+describe('Codex wrong-thread resume regression', () => {
+  beforeEach(() => {
+    wsHarness.reset()
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('repairs stale Codex terminal plumbing instead of continuing the wrong thread', async () => {
+    const store = createStore({
+      kind: 'terminal',
+      createRequestId: 'req-old',
+      status: 'running',
+      mode: 'codex',
+      shell: 'system',
+      terminalId: 'term-old',
+      serverInstanceId: 'srv-new',
+      sessionRef: { provider: 'codex', sessionId: 'thread-new' },
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-new',
+      },
+      initialCwd: '/home/dan/code/freshell',
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalViewFromStore tabId="tab-codex" paneId="pane-codex" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(sentMessages()).toContainEqual(expect.objectContaining({
+        type: 'terminal.attach',
+        terminalId: 'term-old',
+        expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+      }))
+    })
+
+    wsHarness.send.mockClear()
+    wsHarness.emit({
+      type: 'error',
+      code: 'SESSION_IDENTITY_MISMATCH',
+      message: 'Terminal belongs to a different session than the pane expects.',
+      terminalId: 'term-old',
+      timestamp: new Date().toISOString(),
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+      actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
+    })
+
+    await waitFor(() => {
+      expect(sentMessages()).toContainEqual(expect.objectContaining({
+        type: 'terminal.create',
+        mode: 'codex',
+        restore: true,
+        sessionRef: { provider: 'codex', sessionId: 'thread-new' },
+      }))
+    })
+
+    const state = store.getState()
+    const content = findLeaf(state.panes.layouts['tab-codex'], 'pane-codex')?.content
+    expect(content).toMatchObject({
+      kind: 'terminal',
+      mode: 'codex',
+      sessionRef: { provider: 'codex', sessionId: 'thread-new' },
+    })
+    expect((content as TerminalPaneContent).terminalId).toBeUndefined()
+  })
+})
+```
+
+This e2e regression is intentionally component-level because the existing restart recovery e2e tests are component-level. It proves the user-facing reload path: stale terminal plumbing is cleared and the recreate path targets the expected Codex `sessionRef`.
+
+- [ ] **Step 2: Run the failing e2e test**
+
+Run:
+
+```bash
+FRESHELL_TEST_SUMMARY="codex wrong-thread resume e2e" npm run test:vitest -- test/e2e/codex-wrong-thread-resume.test.tsx --run
+```
+
+Expected: FAIL before all identity guards and client repair are wired.
+
+- [ ] **Step 3: Implement only production repair code**
+
+Do not add fixture support for this task. The test file above owns its local mocks and should pass once Tasks 5 and 6 are implemented.
+
+- [ ] **Step 4: Run e2e regression**
+
+Run:
+
+```bash
+FRESHELL_TEST_SUMMARY="codex wrong-thread resume e2e" npm run test:vitest -- test/e2e/codex-wrong-thread-resume.test.tsx --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/e2e/codex-wrong-thread-resume.test.tsx
+git commit -m "test: cover Codex wrong-thread resume regression"
+```
+
+## Task 9: Full Verification
+
+**Files:**
+- No production file changes unless verification exposes failures.
+
+- [ ] **Step 1: Run status check**
+
+Run:
+
+```bash
+npm run test:status
+```
+
+Expected: coordinator is idle or shows a reusable green baseline. If another agent holds the broad gate, wait rather than killing it.
+
+- [ ] **Step 2: Run focused suites**
+
+Run:
+
+```bash
+npm run test:vitest -- \
+  test/unit/server/terminal-session-identity.test.ts \
+  test/server/ws-terminal-codex-identity-invariant.test.ts \
+  test/server/ws-terminal-create-reuse-running-codex.test.ts \
+  test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts \
+  test/unit/client/components/terminal-view-utils.test.ts \
+  test/unit/client/components/TerminalView.codex-identity.test.tsx \
+  test/unit/client/lib/terminal-session-association.test.ts \
+  test/unit/server/terminal-registry.codex-sidecar.test.ts \
+  --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run repo check**
+
+Run:
+
+```bash
+FRESHELL_TEST_SUMMARY="codex thread identity invariant final check" npm run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect git diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: only files listed in this plan are changed.
+
+- [ ] **Step 5: Final commit if verification caused changes**
+
+```bash
+git add shared/ws-protocol.ts server src test
+git commit -m "fix: enforce Codex thread identity invariant"
+```
+
+## Self-Review
+
+- Spec coverage: The plan covers the requested non-legacy approach. It uses the existing Codex durability system, makes it authoritative for create/attach/input/resize, rejects stale live terminal reuse, and repairs stale handles from the client.
+- Placeholder scan: There is no heuristic recovery, no "latest history" matching, and no deferred legacy resolver. Test snippets identify the exact user-visible failure: input must not reach the old thread and restore must target the expected thread.
+- Type consistency: The plan consistently uses `expectedSessionRef`, `sessionRef`, `candidateThreadId`, `durableThreadId`, and `SESSION_IDENTITY_MISMATCH`.
+- Known implementation adjustment: Some test helper names in snippets may need to map onto the repo's existing fixtures. Preserve the behavior and assertion shape when adapting helper names.

--- a/docs/superpowers/plans/2026-06-14-codex-thread-identity-invariant.md
+++ b/docs/superpowers/plans/2026-06-14-codex-thread-identity-invariant.md
@@ -191,18 +191,13 @@ git commit -m "test: define canonical terminal session identity"
 
 - [ ] **Step 1: Write failing protocol tests**
 
-Add schema tests proving `terminal.attach`, `terminal.input`, and `terminal.resize` accept:
+Add schema tests proving `terminal.attach`, `terminal.input`, and `terminal.resize` parse and preserve:
 
 ```ts
 expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' }
 ```
 
-Add an error-shape test proving `ErrorMessage` can include:
-
-```ts
-expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
-actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
-```
+The assertion must inspect the parsed result, not only `safeParse().success`, because the current non-strict Zod object schemas silently strip unknown keys. Add a protocol enum test proving `ErrorCode` accepts `SESSION_IDENTITY_MISMATCH`. Do not add a tautological runtime test for the `ErrorMessage` TypeScript type; Task 3 proves the server actually emits the mismatch fields.
 
 - [ ] **Step 2: Run failing protocol tests**
 
@@ -210,7 +205,7 @@ actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
 npm run test:vitest -- test/server/ws-protocol.test.ts --run
 ```
 
-Expected: FAIL because the schemas reject `expectedSessionRef` and the error enum lacks `SESSION_IDENTITY_MISMATCH`.
+Expected: FAIL because parsed attach/input/resize messages do not retain `expectedSessionRef`, and the error enum lacks `SESSION_IDENTITY_MISMATCH`.
 
 - [ ] **Step 3: Extend schemas**
 
@@ -473,9 +468,7 @@ Do not derive expected identity from `codexDurability`.
 export function getExpectedSessionRefForTerminalOperation(
   content: TerminalPaneContent | null | undefined,
 ): SessionLocator | undefined {
-  return content?.sessionRef?.provider === 'codex'
-    ? content.sessionRef
-    : content?.sessionRef
+  return content?.sessionRef
 }
 ```
 
@@ -590,7 +583,6 @@ git commit -m "fix: ignore stale Codex identity broadcasts"
 - Modify: `src/store/panesSlice.ts`
 - Modify: `src/components/TerminalView.tsx`
 - Test: `test/unit/client/components/TerminalView.codex-identity.test.tsx`
-- Test: `test/e2e/codex-wrong-thread-resume.test.tsx`
 
 - [ ] **Step 1: Write failing repair tests**
 
@@ -608,7 +600,6 @@ Cover:
 ```bash
 npm run test:vitest -- \
   test/unit/client/components/TerminalView.codex-identity.test.tsx \
-  test/e2e/codex-wrong-thread-resume.test.tsx \
   --run
 ```
 
@@ -655,7 +646,6 @@ On `SESSION_IDENTITY_MISMATCH`:
 ```bash
 npm run test:vitest -- \
   test/unit/client/components/TerminalView.codex-identity.test.tsx \
-  test/e2e/codex-wrong-thread-resume.test.tsx \
   --run
 ```
 
@@ -664,7 +654,7 @@ Expected: PASS.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add src/store/panesSlice.ts src/components/TerminalView.tsx test/unit/client/components/TerminalView.codex-identity.test.tsx test/e2e/codex-wrong-thread-resume.test.tsx
+git add src/store/panesSlice.ts src/components/TerminalView.tsx test/unit/client/components/TerminalView.codex-identity.test.tsx
 git commit -m "fix: repair stale Codex runtime plumbing"
 ```
 
@@ -793,12 +783,18 @@ Expected: coordinator is idle or shows a reusable green baseline. If another age
 - [ ] **Step 2: Run focused suites**
 
 ```bash
-npm run test:vitest -- \
+FRESHELL_TEST_SUMMARY="codex identity focused server" npm run test:vitest -- \
   test/unit/server/terminal-session-identity.test.ts \
+  test/server/ws-protocol.test.ts \
   test/server/ws-terminal-codex-identity-invariant.test.ts \
   test/server/ws-terminal-create-reuse-running-codex.test.ts \
   test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts \
   test/server/agent-codex-identity-invariant.test.ts \
+  --run
+```
+
+```bash
+FRESHELL_TEST_SUMMARY="codex identity focused client" npm run test:vitest -- \
   test/unit/client/components/terminal-view-utils.test.ts \
   test/unit/client/components/TerminalView.codex-identity.test.tsx \
   test/unit/client/lib/terminal-session-association.test.ts \
@@ -807,6 +803,8 @@ npm run test:vitest -- \
   test/e2e/codex-wrong-thread-resume.test.tsx \
   --run
 ```
+
+Keep server-owned and default-owned targets in separate invocations. The coordinated `test:vitest` passthrough routes mixed ownership through the default config, which excludes `test/server/**` and `test/unit/server/**`.
 
 Expected: PASS.
 
@@ -840,4 +838,5 @@ git commit -m "fix: enforce Codex thread identity invariant"
 - Load-bearing fixes: Every falsified load-bearing assumption now changes a task: side-effect gates move inside operation owners, create reuse is centralized, REST/MCP/CLI paths are in scope, broadcasts are identity-aware, and tab-registry/cross-tab sync drops stale runtime fields.
 - Non-legacy approach: The plan still ignores heuristic recovery. When canonical `sessionRef` is absent, Freshell refuses to guess.
 - Test shape: Tests protect the incident behavior directly: input/replay must not reach the old thread, stale runtime plumbing must be cleared, and restore/create must target the expected Codex `sessionRef`.
+- PR callout: Removing `proof_failed_attach_live_candidate` intentionally reduces Codex live-terminal reuse when rollout proof fails, because resuming the wrong thread is worse than a fresh/restore-unavailable path. The eventual PR description should make this behavior change explicit.
 - Known implementation adjustment: Helper and fixture names must follow the repo's existing test harnesses. Preserve the behavior and assertion shape when adapting names.

--- a/docs/superpowers/plans/2026-06-14-codex-thread-identity-invariant.md
+++ b/docs/superpowers/plans/2026-06-14-codex-thread-identity-invariant.md
@@ -106,6 +106,7 @@ The load-bearing review falsified several assumptions in the first plan. The imp
   - `test/unit/client/store/panesSlice.test.ts`
   - `test/unit/client/store/crossTabSync.test.ts`
   - `test/unit/client/components/TabsView.test.tsx`
+  - `test/e2e/tabs-view-flow.test.tsx`
   - `test/e2e/codex-wrong-thread-resume.test.tsx`
 
 ## Identity Rule
@@ -152,7 +153,7 @@ Cover these cases:
 - Codex candidate-only durability does not match expected identity for side effects.
 - Codex durable state with a mismatched `resumeSessionId` does not match.
 - Provider mismatch fails.
-- Mismatch payload includes expected and actual canonical identities when actual exists.
+- A helper such as `buildSessionIdentityMismatchDetails(record, expectedSessionRef)` returns the mismatch payload fields: `expectedSessionRef` and `actualSessionRef` when `buildTerminalSessionRef(record)` can prove an actual canonical identity.
 
 - [ ] **Step 2: Run failing test**
 
@@ -164,7 +165,7 @@ Expected: FAIL because the helper does not exist.
 
 - [ ] **Step 3: Implement helper**
 
-The helper must call `buildTerminalSessionRef(record)` rather than duplicating Codex candidate/durability rules. That keeps side-effect identity aligned with the registry's canonical binding behavior.
+The helper must call `buildTerminalSessionRef(record)` rather than duplicating Codex candidate/durability rules. That keeps side-effect identity aligned with the registry's canonical binding behavior. Export a concrete mismatch-detail builder from this module so `ws-handler.ts`, broker, and REST paths do not each hand-roll expected/actual payload construction.
 
 - [ ] **Step 4: Run tests**
 
@@ -633,11 +634,12 @@ It must:
 On `SESSION_IDENTITY_MISMATCH`:
 
 - validate `msg.expectedSessionRef`
-- generate new request id
+- confirm the pane still owns `staleTerminalId` and has no repair already pending for that stale terminal; if the check fails, return before creating a new request id
+- generate new request id only after the guard passes
 - mark it as restore via `addTerminalRestoreRequestId(newRequestId)`
-- update `requestIdRef.current`
 - clear terminal refs/checkpoints for the stale terminal
 - dispatch reducer
+- update `requestIdRef.current` only after dispatching a repair that still applies
 - do not manually call `sendCreate`; let the create effect run from `createRequestId`
 
 - [ ] **Step 5: Run focused tests**
@@ -666,6 +668,7 @@ git commit -m "fix: repair stale Codex runtime plumbing"
 - Test: `test/unit/client/store/panesSlice.test.ts`
 - Test: `test/unit/client/components/TabsView.test.tsx`
 - Test: `test/unit/client/store/crossTabSync.test.ts`
+- Test: `test/e2e/tabs-view-flow.test.tsx`
 
 - [ ] **Step 1: Write failing tab-registry tests**
 
@@ -674,6 +677,7 @@ Cover:
 - A registry record with `sessionRef: thread-new` and same-server `liveTerminal: term-old` does not hydrate `terminalId: term-old` unless the live handle is proven/declared matching.
 - A registry record without `sessionRef` may still use liveTerminal for non-Codex live-only behavior.
 - `tab-registry-snapshot` still publishes `liveTerminal` for UI discovery, but consumers treat it as runtime plumbing.
+- Update the existing `tabs-view-flow` case `opens same-server tab copies with an explicit live terminal handle` so a copied pane with canonical `sessionRef` does not copy `terminalId` from an unproven same-server `liveTerminal`; it should rely on canonical restore/create instead.
 
 - [ ] **Step 2: Write failing cross-tab tests**
 
@@ -690,6 +694,7 @@ npm run test:vitest -- \
   test/unit/client/store/panesSlice.test.ts \
   test/unit/client/components/TabsView.test.tsx \
   test/unit/client/store/crossTabSync.test.ts \
+  test/e2e/tabs-view-flow.test.tsx \
   --run
 ```
 
@@ -714,6 +719,7 @@ npm run test:vitest -- \
   test/unit/client/store/panesSlice.test.ts \
   test/unit/client/components/TabsView.test.tsx \
   test/unit/client/store/crossTabSync.test.ts \
+  test/e2e/tabs-view-flow.test.tsx \
   --run
 ```
 
@@ -722,7 +728,7 @@ Expected: PASS.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add src/components/TabsView.tsx src/store/panesSlice.ts test/unit/client/store/panesSlice.test.ts test/unit/client/components/TabsView.test.tsx test/unit/client/store/crossTabSync.test.ts
+git add src/components/TabsView.tsx src/store/panesSlice.ts test/unit/client/store/panesSlice.test.ts test/unit/client/components/TabsView.test.tsx test/unit/client/store/crossTabSync.test.ts test/e2e/tabs-view-flow.test.tsx
 git commit -m "fix: keep canonical Codex identity across tab sync"
 ```
 
@@ -803,6 +809,7 @@ FRESHELL_TEST_SUMMARY="codex identity focused client" npm run test:vitest -- \
   test/unit/client/store/panesSlice.test.ts \
   test/unit/client/components/TabsView.test.tsx \
   test/unit/client/store/crossTabSync.test.ts \
+  test/e2e/tabs-view-flow.test.tsx \
   test/e2e/codex-wrong-thread-resume.test.tsx \
   --run
 ```

--- a/docs/superpowers/plans/2026-06-14-codex-thread-identity-invariant.md
+++ b/docs/superpowers/plans/2026-06-14-codex-thread-identity-invariant.md
@@ -90,7 +90,7 @@ The load-bearing review falsified several assumptions in the first plan. The imp
   - Refuse conflicting `terminal.session.associated` updates for panes that already have a different canonical `sessionRef`.
   - Provide an atomic reducer for Codex identity mismatch repair.
 
-- Modify `src/lib/tab-registry-snapshot.ts`, `src/components/TabsView.tsx`, and cross-tab merge code in `src/store/panesSlice.ts`
+- Modify `src/components/TabsView.tsx` and cross-tab merge code in `src/store/panesSlice.ts`; inspect `src/lib/tab-registry-snapshot.ts` to preserve its output contract unless explicit server-validated live-handle proof metadata is added.
   - Preserve canonical `sessionRef` over live runtime fields.
   - Discard or quarantine same-server `liveTerminal` handles when they are paired with a canonical `sessionRef` that has not been server-validated.
 
@@ -103,6 +103,7 @@ The load-bearing review falsified several assumptions in the first plan. The imp
   - `test/unit/client/components/terminal-view-utils.test.ts`
   - `test/unit/client/components/TerminalView.codex-identity.test.tsx`
   - `test/unit/client/lib/terminal-session-association.test.ts`
+  - `test/unit/client/store/panesSlice.test.ts`
   - `test/unit/client/store/crossTabSync.test.ts`
   - `test/unit/client/components/TabsView.test.tsx`
   - `test/e2e/codex-wrong-thread-resume.test.tsx`
@@ -112,10 +113,7 @@ The load-bearing review falsified several assumptions in the first plan. The imp
 Use this rule for side-effecting operations:
 
 ```ts
-type SessionLocator = {
-  provider: string
-  sessionId: string
-}
+import type { SessionLocator } from '../shared/ws-protocol.js'
 
 function canonicalActualSessionRef(record: TerminalRecord): SessionLocator | undefined {
   return buildTerminalSessionRef(record)
@@ -451,6 +449,7 @@ Add helpers that:
 - Return `undefined` for Codex durability-only content.
 - Include outbound `liveTerminal` only when no canonical `sessionRef` exists, or when the caller explicitly allows a live handle after server validation.
 - Build attach/input/resize payloads with `expectedSessionRef` whenever canonical identity exists.
+- Update the existing `getCreateSessionStateFromRef` expectation that currently returns both `sessionRef` and `liveTerminal`; the new assertion must prove a canonical `sessionRef` suppresses unproven outbound `liveTerminal`.
 
 - [ ] **Step 2: Run failing helper tests**
 
@@ -661,9 +660,10 @@ git commit -m "fix: repair stale Codex runtime plumbing"
 ## Task 9: Harden Tab Registry And Cross-Tab Sync
 
 **Files:**
-- Modify: `src/lib/tab-registry-snapshot.ts`
+- Inspect: `src/lib/tab-registry-snapshot.ts`
 - Modify: `src/components/TabsView.tsx`
 - Modify: `src/store/panesSlice.ts`
+- Test: `test/unit/client/store/panesSlice.test.ts`
 - Test: `test/unit/client/components/TabsView.test.tsx`
 - Test: `test/unit/client/store/crossTabSync.test.ts`
 
@@ -687,6 +687,7 @@ Cover:
 
 ```bash
 npm run test:vitest -- \
+  test/unit/client/store/panesSlice.test.ts \
   test/unit/client/components/TabsView.test.tsx \
   test/unit/client/store/crossTabSync.test.ts \
   --run
@@ -710,6 +711,7 @@ In cross-tab merge:
 
 ```bash
 npm run test:vitest -- \
+  test/unit/client/store/panesSlice.test.ts \
   test/unit/client/components/TabsView.test.tsx \
   test/unit/client/store/crossTabSync.test.ts \
   --run
@@ -720,7 +722,7 @@ Expected: PASS.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add src/lib/tab-registry-snapshot.ts src/components/TabsView.tsx src/store/panesSlice.ts test/unit/client/components/TabsView.test.tsx test/unit/client/store/crossTabSync.test.ts
+git add src/components/TabsView.tsx src/store/panesSlice.ts test/unit/client/store/panesSlice.test.ts test/unit/client/components/TabsView.test.tsx test/unit/client/store/crossTabSync.test.ts
 git commit -m "fix: keep canonical Codex identity across tab sync"
 ```
 
@@ -798,6 +800,7 @@ FRESHELL_TEST_SUMMARY="codex identity focused client" npm run test:vitest -- \
   test/unit/client/components/terminal-view-utils.test.ts \
   test/unit/client/components/TerminalView.codex-identity.test.tsx \
   test/unit/client/lib/terminal-session-association.test.ts \
+  test/unit/client/store/panesSlice.test.ts \
   test/unit/client/components/TabsView.test.tsx \
   test/unit/client/store/crossTabSync.test.ts \
   test/e2e/codex-wrong-thread-resume.test.tsx \
@@ -838,5 +841,5 @@ git commit -m "fix: enforce Codex thread identity invariant"
 - Load-bearing fixes: Every falsified load-bearing assumption now changes a task: side-effect gates move inside operation owners, create reuse is centralized, REST/MCP/CLI paths are in scope, broadcasts are identity-aware, and tab-registry/cross-tab sync drops stale runtime fields.
 - Non-legacy approach: The plan still ignores heuristic recovery. When canonical `sessionRef` is absent, Freshell refuses to guess.
 - Test shape: Tests protect the incident behavior directly: input/replay must not reach the old thread, stale runtime plumbing must be cleared, and restore/create must target the expected Codex `sessionRef`.
-- PR callout: Removing `proof_failed_attach_live_candidate` intentionally reduces Codex live-terminal reuse when rollout proof fails, because resuming the wrong thread is worse than a fresh/restore-unavailable path. The eventual PR description should make this behavior change explicit.
+- PR callout: Removing `proof_failed_attach_live_candidate` intentionally reduces Codex live-terminal reuse when rollout proof fails, because resuming the wrong thread is worse than a fresh/restore-unavailable path. Omitting unproven outbound `liveTerminal` when canonical `sessionRef` exists also disables the same-server live-handle fast path across providers; reuse should happen through server-side canonical lookup instead. The eventual PR description should make both behavior changes explicit.
 - Known implementation adjustment: Helper and fixture names must follow the repo's existing test harnesses. Preserve the behavior and assertion shape when adapting names.

--- a/docs/superpowers/plans/2026-06-14-codex-thread-identity-invariant.md
+++ b/docs/superpowers/plans/2026-06-14-codex-thread-identity-invariant.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make new Codex panes resume the correct Codex thread by construction by treating the Codex thread id as pane identity and terminal ids as disposable live plumbing.
+**Goal:** Make new Freshell Codex panes resume the correct Codex thread by construction. A pane's canonical Codex `sessionRef` is the identity. Terminal ids, same-server live handles, tab/pane ids, and Codex durability records are evidence or plumbing, not pane identity.
 
-**Architecture:** Freshell already captures Codex `candidateThreadId`, proves it from the rollout file, and persists `sessionRef`; this plan makes that existing identity contract authoritative on every create, attach, input, and resize path. Stale `liveTerminal` handles become recoverable implementation details: if they do not match the pane's expected Codex identity, they are ignored or repaired before any replay or input reaches a PTY.
+**Architecture:** The implementation must make canonical identity authoritative at every place a stale terminal could be reused, replayed, written to, or rebound into a pane. When canonical identity is missing, Freshell must prefer a restore-unavailable/fresh-safe path over guessing. Resuming the wrong Codex thread is worse than refusing to resume.
 
 **Tech Stack:** TypeScript, NodeNext/ESM, React 18, Redux Toolkit, WebSocket protocol schemas with Zod, Vitest, superwstest, Testing Library.
 
@@ -12,264 +12,163 @@
 
 ## Scope
 
-This plan deliberately ignores heuristic recovery for already-corrupted historical panes. It does not add "latest Codex history", cwd/title/time matching, or prompt-recency guessing. If a pane has no pane-bound `sessionRef`, no pane-bound `codexDurability`, and no matching server-side Codex durability record, it follows the existing restore-unavailable/fresh-terminal path.
+This plan deliberately ignores heuristic recovery for already-corrupted historical panes. It does not add "latest Codex history", cwd/title/time matching, prompt-recency guessing, or a legacy resolver.
 
-The fix is future-facing and invariant-based:
+The fixed invariant for future sessions is:
 
-- A Codex pane's expected identity is its canonical `sessionRef.provider === "codex"` plus `sessionRef.sessionId`, or its durable `codexDurability.durableThreadId`.
-- A `liveTerminal.terminalId` is reusable only when the server record proves it is running the same Codex identity.
-- `terminal.attach`, `terminal.input`, and `terminal.resize` cannot operate on terminal id alone when the client knows the pane's expected Codex identity.
-- Mismatch is not a normal user-facing end state. When the client has expected identity, mismatch clears stale live plumbing and triggers restore/create for the expected identity.
+- A Codex pane's expected identity is only a canonical `sessionRef` with `provider === "codex"` and a non-empty `sessionId`.
+- `codexDurability` is restore evidence. It may help prove or resume a session, but it is not enough by itself to authorize attach/input/resize or live-terminal reuse for a pane.
+- A `candidateThreadId` is never authoritative for user replay/input/resize. Candidate state can trigger proof or block input while proof runs, but cannot authorize side effects.
+- A `liveTerminal` handle, `terminalId`, `serverInstanceId`, `tabId`, and `paneId` are never identity. They can be reused only after the server proves the live terminal's canonical identity matches the expected `sessionRef`.
+- Mismatch is recoverable when the client has a canonical expected identity: clear stale runtime plumbing, keep `sessionRef`, bump `createRequestId`, and let the normal create effect restore that session.
+- Mismatch is an error only when Freshell cannot determine a canonical target without guessing.
 
-## Current Evidence
+## Load-Bearing Review Findings
 
-Existing implementation already has the core Codex identity machinery:
+The load-bearing review falsified several assumptions in the first plan. The implementation must account for all of these facts:
 
-- `shared/codex-durability.ts` defines `candidateThreadId`, `rolloutPath`, `durableThreadId`, and durability states.
-- `server/coding-cli/codex-app-server/remote-proxy.ts` captures candidates from `thread/start` responses and `thread/started` notifications.
-- `server/coding-cli/codex-app-server/durability-store.ts` writes records under `~/.freshell/codex-durability/<terminalId>.json`.
-- `server/coding-cli/codex-app-server/durability-proof.ts` proves the first rollout JSONL record is `session_meta` with matching `payload.id`.
-- `server/terminal-registry.ts` persists candidates, promotes durable sessions, and broadcasts `terminal.session.associated`.
-- `src/components/TerminalView.tsx` persists `terminal.session.associated` and `terminal.codex.durability.updated` into pane/tab state.
-
-The observed incident shows the missing invariant: a pane can still be recreated, attached, or written to through stale live terminal plumbing or stale persisted identity without every path proving it matches the Codex thread the pane should own.
+- Candidate-only Codex identity is not safe for side effects. Current `restore-decision.ts` can return `proof_failed_attach_live_candidate`, and `ws-handler.ts` can then attach that live terminal even after proof fails.
+- `TerminalRecord.mode`, `resumeSessionId`, and `codexDurability` are not a complete actual-identity authority by themselves. `buildTerminalSessionRef` already refuses Codex identity unless `resumeSessionId` and durable state agree, and the registry also has a binding authority.
+- `terminal.attach`, `terminal.input`, and `terminal.resize` currently operate by `terminalId` only. `TerminalStreamBroker.attach` mutates attach/resize/replay state internally after an async lock.
+- All `terminal.create` reuse returns currently funnel through `attachReusedTerminal`, which is the right central server gate. The request-id caches currently store only `requestId -> terminalId`, so the gate must validate cached reuse too.
+- `restore-decision.ts` does not accept an arbitrary requested live terminal object. Requested live handle validation belongs in `ws-handler.ts` unless the decision API is intentionally redesigned.
+- Client association and durability messages are currently accepted by `terminalId`. A stale `terminal.session.associated` can overwrite pane `sessionRef`, and stale `terminal.codex.durability.updated` can reintroduce stale durability.
+- `TerminalView` has multiple outbound attach/input/resize send sites. `contentRef` is synchronized by effect, not guaranteed current during render, so send helpers should read current pane state from Redux or a deliberately updated ref boundary.
+- Mismatch repair cannot just clear fields and send `terminal.create`. `terminal.created` is request-id gated, and the create effect reruns on `createRequestId`. Repair needs an explicit request-id-bumped transition.
+- Pane content has no `liveTerminal` field. Persisted stale live plumbing is `terminalId`, `serverInstanceId`, and `streamId`; outbound `liveTerminal` is derived from those fields.
+- REST/MCP/CLI paths are in scope. `/api/panes/:id/attach` can bind a pane to a caller-supplied terminal id, and `/api/panes/:id/send-keys` writes through `registry.input` without expected identity.
+- Durability-store fallback by `terminalId` / `tabId` / `paneId` is not pane identity. It must not be used to choose a Codex session when the pane lacks canonical `sessionRef`.
+- Tab-registry snapshots publish both `sessionRef` and `liveTerminal`; `TabsView` restores same-server `liveTerminal` without validating it against `sessionRef`. Cross-tab merge can reintroduce stale runtime fields unless hardened.
 
 ## File Structure
 
 - Modify `shared/ws-protocol.ts`
   - Add optional `expectedSessionRef?: SessionLocator` to `terminal.attach`, `terminal.input`, and `terminal.resize`.
-  - Add `SESSION_IDENTITY_MISMATCH` to `ErrorCode` and add optional `expectedSessionRef` / `actualSessionRef` fields to `ErrorMessage`.
+  - Add `SESSION_IDENTITY_MISMATCH` to `ErrorCode`.
+  - Add optional `expectedSessionRef` and `actualSessionRef` to `ErrorMessage`.
 
 - Create `server/terminal-session-identity.ts`
-  - Central helper for comparing an expected session locator to a `TerminalRecord`.
-  - Keeps the identity rule out of `ws-handler.ts`.
+  - Central server helper for actual canonical identity.
+  - Uses `buildTerminalSessionRef(record)` for canonical identity.
+  - Does not treat Codex candidate identity as a side-effect authority.
 
 - Modify `server/ws-handler.ts`
-  - Validate expected identity before terminal stream attach, input, and resize.
-  - Prefer expected Codex `sessionRef` over stale `liveTerminal` during `terminal.create`.
-  - Return a repairable mismatch response without replaying output or writing input.
+  - Validate identity before and during attach/input/resize operations.
+  - Centralize create reuse authorization in `attachReusedTerminal`.
+  - Reject or ignore stale live-terminal/request-id reuse when expected identity does not match.
+  - Stop using durability-store fallback to infer a restore target when no canonical `sessionRef` exists.
+
+- Modify `server/terminal-stream/broker.ts`
+  - Accept an optional expected identity predicate/session ref for attach.
+  - Re-check identity inside the broker terminal lock immediately before `registry.attach`, resize, and replay.
+
+- Modify `server/terminal-registry.ts`
+  - Add identity-aware `input` and `resize` variants or options.
+  - Keep `buildTerminalSessionRef` as the canonical actual identity source for side effects.
 
 - Modify `server/coding-cli/codex-app-server/restore-decision.ts`
-  - Make live terminal reuse require same Codex identity when a requested `sessionRef` or durable `codexDurability` exists.
-  - Remove or narrow any fallback where a requested live terminal wins because `codexDurability` is absent.
+  - Remove proof-failed live-candidate attach as an allowed restore result, or keep the type only for non-side-effect diagnostics. A failed proof must not attach/replay/write to a Codex terminal as a restored pane.
 
-- Modify `src/components/TerminalView.tsx`
-  - Send expected session identity with `terminal.attach`, `terminal.input`, and `terminal.resize`.
-  - On mismatch, clear stale `liveTerminal`, preserve `sessionRef`/durable `codexDurability`, flush layout, and issue restore/create for the expected session.
+- Modify `server/agent-api/router.ts`
+  - Enforce expected identity on `/api/panes/:id/attach` and `/api/panes/:id/send-keys`.
+  - Allow terminal-id-only attach/send only for non-Codex terminals or for panes without canonical Codex identity, according to tests.
+
+- Modify `server/mcp/freshell-tool.ts` and `server/cli/index.ts`
+  - Pass `sessionRef`/expected identity through attach and send-keys when available.
+  - Make Codex terminal attach by raw terminal id require matching identity or fail clearly.
 
 - Modify `src/components/terminal-view-utils.ts`
-  - Add a helper that derives the expected session locator from pane content.
-  - Keep the derivation testable outside the large `TerminalView.tsx` component.
+  - Add helpers for expected identity, operation message construction, stale runtime clearing, and safe live-terminal inclusion.
+  - Do not derive expected operation identity from `codexDurability` alone.
 
-- Modify `src/lib/terminal-session-association.ts`
-  - Preserve existing canonical association persistence.
-  - Add regression coverage that `terminal.session.associated` clears stale live-only assumptions and keeps matching durable Codex state.
+- Modify `src/components/TerminalView.tsx`
+  - Use centralized helpers for every attach/input/resize send.
+  - Guard stale association/durability broadcasts against existing canonical `sessionRef`.
+  - Repair identity mismatch by bumping `createRequestId`, clearing `terminalId`/`serverInstanceId`/`streamId`, preserving `sessionRef`, and relying on the normal create effect.
+
+- Modify `src/lib/terminal-session-association.ts` and `src/store/panesSlice.ts`
+  - Refuse conflicting `terminal.session.associated` updates for panes that already have a different canonical `sessionRef`.
+  - Provide an atomic reducer for Codex identity mismatch repair.
+
+- Modify `src/lib/tab-registry-snapshot.ts`, `src/components/TabsView.tsx`, and cross-tab merge code in `src/store/panesSlice.ts`
+  - Preserve canonical `sessionRef` over live runtime fields.
+  - Discard or quarantine same-server `liveTerminal` handles when they are paired with a canonical `sessionRef` that has not been server-validated.
 
 - Add tests:
   - `test/unit/server/terminal-session-identity.test.ts`
   - `test/server/ws-terminal-codex-identity-invariant.test.ts`
+  - `test/server/ws-terminal-create-reuse-running-codex.test.ts`
+  - `test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts`
+  - `test/server/agent-codex-identity-invariant.test.ts`
   - `test/unit/client/components/terminal-view-utils.test.ts`
   - `test/unit/client/components/TerminalView.codex-identity.test.tsx`
-  - Extend `test/server/ws-terminal-create-reuse-running-codex.test.ts`
+  - `test/unit/client/lib/terminal-session-association.test.ts`
+  - `test/unit/client/store/crossTabSync.test.ts`
+  - `test/unit/client/components/TabsView.test.tsx`
+  - `test/e2e/codex-wrong-thread-resume.test.tsx`
 
 ## Identity Rule
 
-Use this exact rule everywhere:
+Use this rule for side-effecting operations:
 
 ```ts
 type SessionLocator = {
-  provider: 'codex' | 'claude' | 'opencode'
+  provider: string
   sessionId: string
 }
 
-function terminalMatchesExpectedSession(record: TerminalRecord, expected: SessionLocator | undefined): boolean {
-  if (!expected) return true
-  if (record.mode !== expected.provider) return false
-  if (record.resumeSessionId === expected.sessionId) return true
-  if (record.codexDurability?.state === 'durable' && record.codexDurability.durableThreadId === expected.sessionId) {
-    return true
-  }
-  if (record.codexDurability?.candidate?.candidateThreadId === expected.sessionId) {
-    return true
-  }
-  return false
+function canonicalActualSessionRef(record: TerminalRecord): SessionLocator | undefined {
+  return buildTerminalSessionRef(record)
+}
+
+function terminalMatchesExpectedSession(
+  record: TerminalRecord,
+  expectedSessionRef: SessionLocator | undefined,
+): boolean {
+  if (!expectedSessionRef) return true
+  const actual = canonicalActualSessionRef(record)
+  return actual?.provider === expectedSessionRef.provider
+    && actual.sessionId === expectedSessionRef.sessionId
 }
 ```
 
-Non-Codex providers may use `resumeSessionId` only. Codex gets the extra durable/candidate checks because current records already store those identities.
+Do not add candidate acceptance here. Candidate state is pre-proof evidence and can only trigger proof/recovery/blocking behavior.
 
-## Task 1: Add Server Identity Helper
+Durability-only behavior:
+
+- `codexDurability.state === "durable"` can be used by create/restore code as proof evidence when a pane already has matching canonical `sessionRef`, or to promote an association when proof is server-owned.
+- A pane without canonical `sessionRef` is not restored from durability fallback for this future-facing invariant. It follows restore-unavailable/fresh-safe behavior.
+
+## Task 1: Define Canonical Server Identity
 
 **Files:**
 - Create: `server/terminal-session-identity.ts`
 - Test: `test/unit/server/terminal-session-identity.test.ts`
 
-- [ ] **Step 1: Write the failing unit tests**
+- [ ] **Step 1: Write failing unit tests**
 
-Create `test/unit/server/terminal-session-identity.test.ts`:
+Cover these cases:
 
-```ts
-import { describe, expect, it } from 'vitest'
-import { terminalMatchesExpectedSession } from '../../../server/terminal-session-identity.js'
+- Missing expected identity returns match for backwards-compatible non-Codex paths.
+- Codex durable identity matches only when `buildTerminalSessionRef(record)` returns the same `{ provider: "codex", sessionId }`.
+- Codex candidate-only durability does not match expected identity for side effects.
+- Codex durable state with a mismatched `resumeSessionId` does not match.
+- Provider mismatch fails.
+- Mismatch payload includes expected and actual canonical identities when actual exists.
 
-function record(overrides: Record<string, unknown> = {}) {
-  return {
-    terminalId: 'term-1',
-    mode: 'codex',
-    status: 'running',
-    resumeSessionId: undefined,
-    codexDurability: undefined,
-    ...overrides,
-  } as any
-}
-
-describe('terminalMatchesExpectedSession', () => {
-  it('accepts missing expected identity for backwards-compatible live-only paths', () => {
-    expect(terminalMatchesExpectedSession(record(), undefined)).toBe(true)
-  })
-
-  it('accepts a matching resumeSessionId', () => {
-    expect(terminalMatchesExpectedSession(
-      record({ resumeSessionId: 'thread-1' }),
-      { provider: 'codex', sessionId: 'thread-1' },
-    )).toBe(true)
-  })
-
-  it('accepts a matching durable Codex thread id', () => {
-    expect(terminalMatchesExpectedSession(
-      record({
-        codexDurability: {
-          schemaVersion: 1,
-          state: 'durable',
-          durableThreadId: 'thread-1',
-        },
-      }),
-      { provider: 'codex', sessionId: 'thread-1' },
-    )).toBe(true)
-  })
-
-  it('accepts a matching captured Codex candidate before durable promotion', () => {
-    expect(terminalMatchesExpectedSession(
-      record({
-        codexDurability: {
-          schemaVersion: 1,
-          state: 'captured_pre_turn',
-          candidate: {
-            provider: 'codex',
-            candidateThreadId: 'thread-1',
-            rolloutPath: '/home/dan/.codex/sessions/2026/06/14/rollout-thread-1.jsonl',
-            source: 'thread_start_response',
-            capturedAt: 1,
-          },
-        },
-      }),
-      { provider: 'codex', sessionId: 'thread-1' },
-    )).toBe(true)
-  })
-
-  it('rejects a Codex terminal for the wrong thread', () => {
-    expect(terminalMatchesExpectedSession(
-      record({
-        resumeSessionId: 'thread-old',
-        codexDurability: {
-          schemaVersion: 1,
-          state: 'durable',
-          durableThreadId: 'thread-old',
-        },
-      }),
-      { provider: 'codex', sessionId: 'thread-new' },
-    )).toBe(false)
-  })
-
-  it('rejects a provider mismatch', () => {
-    expect(terminalMatchesExpectedSession(
-      record({ mode: 'opencode', resumeSessionId: 'thread-1' }),
-      { provider: 'codex', sessionId: 'thread-1' },
-    )).toBe(false)
-  })
-})
-```
-
-- [ ] **Step 2: Run the failing test**
-
-Run:
+- [ ] **Step 2: Run failing test**
 
 ```bash
 npm run test:vitest -- test/unit/server/terminal-session-identity.test.ts --run
 ```
 
-Expected: FAIL because `server/terminal-session-identity.ts` does not exist.
+Expected: FAIL because the helper does not exist.
 
-- [ ] **Step 3: Implement the helper**
+- [ ] **Step 3: Implement helper**
 
-Create `server/terminal-session-identity.ts`:
+The helper must call `buildTerminalSessionRef(record)` rather than duplicating Codex candidate/durability rules. That keeps side-effect identity aligned with the registry's canonical binding behavior.
 
-```ts
-import type { SessionLocator } from '../shared/ws-protocol.js'
-import type { TerminalRecord } from './terminal-registry.js'
-
-export type SessionIdentityMismatch = {
-  code: 'SESSION_IDENTITY_MISMATCH'
-  terminalId: string
-  expectedSessionRef: SessionLocator
-  actualSessionRef?: SessionLocator
-}
-
-export function terminalActualSessionRef(record: Pick<TerminalRecord, 'mode' | 'resumeSessionId' | 'codexDurability'>): SessionLocator | undefined {
-  if (record.mode === 'codex') {
-    const durableThreadId = record.codexDurability?.state === 'durable'
-      ? record.codexDurability.durableThreadId
-      : undefined
-    const candidateThreadId = record.codexDurability?.candidate?.candidateThreadId
-    const sessionId = durableThreadId ?? record.resumeSessionId ?? candidateThreadId
-    return sessionId ? { provider: 'codex', sessionId } : undefined
-  }
-
-  if (record.resumeSessionId && (record.mode === 'claude' || record.mode === 'opencode')) {
-    return { provider: record.mode, sessionId: record.resumeSessionId }
-  }
-
-  return undefined
-}
-
-export function terminalMatchesExpectedSession(
-  record: Pick<TerminalRecord, 'mode' | 'resumeSessionId' | 'codexDurability'>,
-  expectedSessionRef: SessionLocator | undefined,
-): boolean {
-  if (!expectedSessionRef) return true
-  if (record.mode !== expectedSessionRef.provider) return false
-
-  if (record.resumeSessionId === expectedSessionRef.sessionId) return true
-
-  if (expectedSessionRef.provider === 'codex') {
-    if (
-      record.codexDurability?.state === 'durable'
-      && record.codexDurability.durableThreadId === expectedSessionRef.sessionId
-    ) return true
-
-    if (record.codexDurability?.candidate?.candidateThreadId === expectedSessionRef.sessionId) return true
-  }
-
-  return false
-}
-
-export function buildSessionIdentityMismatch(
-  terminalId: string,
-  record: Pick<TerminalRecord, 'mode' | 'resumeSessionId' | 'codexDurability'>,
-  expectedSessionRef: SessionLocator,
-): SessionIdentityMismatch {
-  return {
-    code: 'SESSION_IDENTITY_MISMATCH',
-    terminalId,
-    expectedSessionRef,
-    ...(terminalActualSessionRef(record) ? { actualSessionRef: terminalActualSessionRef(record) } : {}),
-  }
-}
-```
-
-- [ ] **Step 4: Run the unit test**
-
-Run:
+- [ ] **Step 4: Run tests**
 
 ```bash
 npm run test:vitest -- test/unit/server/terminal-session-identity.test.ts --run
@@ -281,7 +180,7 @@ Expected: PASS.
 
 ```bash
 git add server/terminal-session-identity.ts test/unit/server/terminal-session-identity.test.ts
-git commit -m "test: define terminal session identity matching"
+git commit -m "test: define canonical terminal session identity"
 ```
 
 ## Task 2: Add Expected Identity To WebSocket Protocol
@@ -292,96 +191,32 @@ git commit -m "test: define terminal session identity matching"
 
 - [ ] **Step 1: Write failing protocol tests**
 
-Append tests to `test/server/ws-protocol.test.ts` near the existing attach/input/resize protocol tests:
+Add schema tests proving `terminal.attach`, `terminal.input`, and `terminal.resize` accept:
 
 ```ts
-it('terminal.attach accepts expectedSessionRef', async () => {
-  const { ws, terminalId } = await createTerminal()
-  ws.send(JSON.stringify({
-    type: 'terminal.attach',
-    terminalId,
-    intent: 'viewport_hydrate',
-    cols: 120,
-    rows: 40,
-    expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
-  }))
-  const ready = await waitForMessage(ws, (msg) => msg.type === 'terminal.attach.ready' && msg.terminalId === terminalId)
-  expect(ready.type).toBe('terminal.attach.ready')
-})
-
-it('terminal.input accepts expectedSessionRef', async () => {
-  const { ws, terminalId } = await createTerminal()
-  ws.send(JSON.stringify({
-    type: 'terminal.input',
-    terminalId,
-    data: 'echo hello',
-    expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
-  }))
-  await expectNoInvalidMessage(ws)
-})
-
-it('terminal.resize accepts expectedSessionRef', async () => {
-  const { ws, terminalId } = await createTerminal()
-  ws.send(JSON.stringify({
-    type: 'terminal.resize',
-    terminalId,
-    cols: 120,
-    rows: 40,
-    expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
-  }))
-  await expectNoInvalidMessage(ws)
-})
+expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' }
 ```
 
-If the helpers in this file have different names, use the local existing helpers that create a terminal, wait for messages, and assert no protocol validation error. Do not weaken the assertions.
+Add an error-shape test proving `ErrorMessage` can include:
 
-- [ ] **Step 2: Run the failing protocol tests**
+```ts
+expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
+```
 
-Run:
+- [ ] **Step 2: Run failing protocol tests**
 
 ```bash
 npm run test:vitest -- test/server/ws-protocol.test.ts --run
 ```
 
-Expected: FAIL because the schemas reject `expectedSessionRef`.
+Expected: FAIL because the schemas reject `expectedSessionRef` and the error enum lacks `SESSION_IDENTITY_MISMATCH`.
 
 - [ ] **Step 3: Extend schemas**
 
-Modify `shared/ws-protocol.ts`:
-
-```ts
-export const TerminalAttachSchema = z.object({
-  type: z.literal('terminal.attach'),
-  terminalId: z.string().min(1),
-  sinceSeq: z.number().int().nonnegative().optional(),
-  maxReplayBytes: z.number().int().positive().optional(),
-  attachRequestId: z.string().min(1).optional(),
-  intent: TerminalAttachIntentSchema,
-  priority: TerminalAttachPrioritySchema.optional(),
-  cols: z.number().int().min(2).max(1000),
-  rows: z.number().int().min(2).max(500),
-  expectedSessionRef: SessionLocatorSchema.optional(),
-})
-
-export const TerminalInputSchema = z.object({
-  type: z.literal('terminal.input'),
-  terminalId: z.string().min(1),
-  data: z.string(),
-  expectedSessionRef: SessionLocatorSchema.optional(),
-})
-
-export const TerminalResizeSchema = z.object({
-  type: z.literal('terminal.resize'),
-  terminalId: z.string().min(1),
-  cols: z.number().int().min(2).max(1000),
-  rows: z.number().int().min(2).max(500),
-  expectedSessionRef: SessionLocatorSchema.optional(),
-})
-```
+Add `expectedSessionRef: SessionLocatorSchema.optional()` to attach/input/resize. Add `SESSION_IDENTITY_MISMATCH` to `ErrorCode`. Extend `ErrorMessage` with optional `expectedSessionRef` and `actualSessionRef`.
 
 - [ ] **Step 4: Run protocol tests**
-
-Run:
 
 ```bash
 npm run test:vitest -- test/server/ws-protocol.test.ts --run
@@ -396,234 +231,57 @@ git add shared/ws-protocol.ts test/server/ws-protocol.test.ts
 git commit -m "feat: carry expected session identity on terminal operations"
 ```
 
-## Task 3: Enforce Identity Before Attach/Input/Resize
+## Task 3: Enforce Identity At Side-Effect Boundaries
 
 **Files:**
 - Modify: `server/ws-handler.ts`
-- Modify: `shared/ws-protocol.ts` if an error type is needed
+- Modify: `server/terminal-stream/broker.ts`
+- Modify: `server/terminal-registry.ts`
 - Test: `test/server/ws-terminal-codex-identity-invariant.test.ts`
 
 - [ ] **Step 1: Write failing server tests**
 
-Create `test/server/ws-terminal-codex-identity-invariant.test.ts`:
+Test all three side effects:
 
-```ts
-import { describe, expect, it } from 'vitest'
-import { createTestServer, waitForMessage } from './helpers/ws-test-server.js'
+- `terminal.attach` with expected `thread-new` against live Codex `thread-old` returns `SESSION_IDENTITY_MISMATCH` and does not send `terminal.attach.ready` or replay old output.
+- `terminal.input` with expected `thread-new` against live Codex `thread-old` returns `SESSION_IDENTITY_MISMATCH` and does not call `pty.write`.
+- `terminal.resize` with expected `thread-new` against live Codex `thread-old` returns `SESSION_IDENTITY_MISMATCH` and does not resize.
 
-describe('Codex terminal identity invariant', () => {
-  it('rejects attach before replay when terminal id belongs to a different Codex thread', async () => {
-    const app = await createTestServer()
-    const ws = await app.openWs()
-    const terminal = await app.createFakeTerminal({
-      mode: 'codex',
-      terminalId: 'term-old',
-      resumeSessionId: 'thread-old',
-      codexDurability: {
-        schemaVersion: 1,
-        state: 'durable',
-        durableThreadId: 'thread-old',
-      },
-      output: 'old transcript must not replay',
-    })
+Also test candidate-only Codex durability:
 
-    ws.send(JSON.stringify({
-      type: 'terminal.attach',
-      terminalId: terminal.terminalId,
-      intent: 'viewport_hydrate',
-      cols: 120,
-      rows: 40,
-      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
-    }))
+- A terminal with `codexDurability.state === "captured_pre_turn"` and matching candidate id must not satisfy expected identity for attach/input/resize.
 
-    const error = await waitForMessage(ws, (msg) => msg.type === 'error' && msg.code === 'SESSION_IDENTITY_MISMATCH')
-    expect(error).toMatchObject({
-      code: 'SESSION_IDENTITY_MISMATCH',
-      terminalId: 'term-old',
-      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
-      actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
-    })
-    expect(app.sentMessages()).not.toContainEqual(expect.objectContaining({ type: 'terminal.attach.ready' }))
-    expect(app.sentOutput()).not.toContain('old transcript must not replay')
-  })
-
-  it('rejects input before writing to a mismatched Codex terminal', async () => {
-    const app = await createTestServer()
-    const ws = await app.openWs()
-    const terminal = await app.createFakeTerminal({
-      mode: 'codex',
-      terminalId: 'term-old',
-      resumeSessionId: 'thread-old',
-      codexDurability: {
-        schemaVersion: 1,
-        state: 'durable',
-        durableThreadId: 'thread-old',
-      },
-    })
-
-    ws.send(JSON.stringify({
-      type: 'terminal.input',
-      terminalId: terminal.terminalId,
-      data: 'Repeat the last 5 lines\\n',
-      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
-    }))
-
-    const error = await waitForMessage(ws, (msg) => msg.type === 'error' && msg.code === 'SESSION_IDENTITY_MISMATCH')
-    expect(error.terminalId).toBe('term-old')
-    expect(terminal.inputWrites).toEqual([])
-  })
-
-  it('rejects resize before mutating a mismatched Codex terminal', async () => {
-    const app = await createTestServer()
-    const ws = await app.openWs()
-    const terminal = await app.createFakeTerminal({
-      mode: 'codex',
-      terminalId: 'term-old',
-      resumeSessionId: 'thread-old',
-    })
-
-    ws.send(JSON.stringify({
-      type: 'terminal.resize',
-      terminalId: terminal.terminalId,
-      cols: 132,
-      rows: 50,
-      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
-    }))
-
-    const error = await waitForMessage(ws, (msg) => msg.type === 'error' && msg.code === 'SESSION_IDENTITY_MISMATCH')
-    expect(error.terminalId).toBe('term-old')
-    expect(terminal.resizeCalls).toEqual([])
-  })
-})
-```
-
-Use the existing server test helpers in `test/server/ws-protocol.test.ts` or `test/server/ws-terminal-create-reuse-running-codex.test.ts`. If there is no `createFakeTerminal` helper, create a local fake registry/terminal harness in this test that exercises `WsHandler` at the same abstraction level as the neighboring server tests.
-
-- [ ] **Step 2: Run the failing tests**
-
-Run:
+- [ ] **Step 2: Run failing tests**
 
 ```bash
 npm run test:vitest -- test/server/ws-terminal-codex-identity-invariant.test.ts --run
 ```
 
-Expected: FAIL because attach/input/resize only validate `terminalId`.
+Expected: FAIL because operations currently use `terminalId` only.
 
-- [ ] **Step 3: Add mismatch guard in `ws-handler.ts`**
+- [ ] **Step 3: Implement identity mismatch responses**
 
-Import the helper:
+Add a single server mismatch builder. Log a structured lifecycle event with:
 
-```ts
-import {
-  buildSessionIdentityMismatch,
-  terminalMatchesExpectedSession,
-} from './terminal-session-identity.js'
-```
+- operation
+- terminalId
+- expected provider/session id
+- actual provider/session id when available
 
-Add a local guard near the terminal operation handlers:
+The server must return `SESSION_IDENTITY_MISMATCH` before replay/write/resize.
 
-```ts
-const rejectSessionIdentityMismatch = (
-  ws: AuthedWebSocket,
-  terminalId: string,
-  record: TerminalRecord,
-  expectedSessionRef: SessionLocator | undefined,
-  requestId?: string,
-): boolean => {
-  if (!expectedSessionRef) return false
-  if (terminalMatchesExpectedSession(record, expectedSessionRef)) return false
+- [ ] **Step 4: Re-check inside side-effect owners**
 
-  const mismatch = buildSessionIdentityMismatch(terminalId, record, expectedSessionRef)
-  recordSessionLifecycleEvent({
-    kind: 'terminal_session_identity_mismatch',
-    provider: expectedSessionRef.provider,
-    terminalId,
-    sessionId: expectedSessionRef.sessionId,
-    operation: 'terminal.operation',
-  })
-  this.sendError(ws, {
-    code: mismatch.code,
-    message: 'Terminal belongs to a different session than the pane expects.',
-    terminalId,
-    requestId,
-    expectedSessionRef: mismatch.expectedSessionRef,
-    actualSessionRef: mismatch.actualSessionRef,
-  })
-  return true
-}
-```
+Do not rely only on a pre-call check in `ws-handler.ts`.
 
-Apply the guard:
+- `TerminalStreamBroker.attach` must accept expected identity or a predicate and evaluate it inside the terminal lock immediately before `registry.attach`, before resize, and before replay.
+- `TerminalRegistry.input` must accept expected identity or expose `inputIfSessionMatches`.
+- `TerminalRegistry.resize` must accept expected identity or expose `resizeIfSessionMatches`.
 
-```ts
-if (rejectSessionIdentityMismatch(ws, m.terminalId, record, m.expectedSessionRef, m.attachRequestId)) return
-```
-
-before `terminalStreamBroker.attach`.
-
-```ts
-const record = this.registry.get(m.terminalId)
-if (record && rejectSessionIdentityMismatch(ws, m.terminalId, record, m.expectedSessionRef)) return
-const result = this.registry.input(m.terminalId, m.data)
-```
-
-before `registry.input`.
-
-```ts
-const record = this.registry.get(m.terminalId)
-if (record && rejectSessionIdentityMismatch(ws, m.terminalId, record, m.expectedSessionRef)) return
-```
-
-before `registry.resize`.
-
-In `shared/ws-protocol.ts`, extend the protocol error shape:
-
-```ts
-export const ErrorCode = z.enum([
-  'NOT_AUTHENTICATED',
-  'INVALID_MESSAGE',
-  'UNKNOWN_MESSAGE',
-  'INVALID_TERMINAL_ID',
-  'INVALID_SESSION_ID',
-  'RESTORE_UNAVAILABLE',
-  'INVALID_CREATE_REQUEST',
-  'PTY_SPAWN_FAILED',
-  'FILE_WATCHER_ERROR',
-  'INTERNAL_ERROR',
-  'RATE_LIMITED',
-  'UNAUTHORIZED',
-  'PROTOCOL_MISMATCH',
-  'SESSION_IDENTITY_MISMATCH',
-])
-
-export type ErrorMessage = {
-  type: 'error'
-  code: ErrorCode
-  message: string
-  requestId?: string
-  terminalId?: string
-  timestamp: string
-  expectedSessionRef?: SessionLocator
-  actualSessionRef?: SessionLocator
-}
-```
-
-- [ ] **Step 4: Run the focused server tests**
-
-Run:
+- [ ] **Step 5: Run focused tests**
 
 ```bash
 npm run test:vitest -- test/server/ws-terminal-codex-identity-invariant.test.ts --run
-```
-
-Expected: PASS.
-
-- [ ] **Step 5: Run existing protocol coverage**
-
-Run:
-
-```bash
-npm run test:vitest -- test/server/ws-protocol.test.ts --run
 ```
 
 Expected: PASS.
@@ -631,11 +289,11 @@ Expected: PASS.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add server/ws-handler.ts server/terminal-session-identity.ts shared/ws-protocol.ts test/server/ws-terminal-codex-identity-invariant.test.ts
-git commit -m "fix: reject stale terminal operations for mismatched sessions"
+git add shared/ws-protocol.ts server/ws-handler.ts server/terminal-stream/broker.ts server/terminal-registry.ts server/terminal-session-identity.ts test/server/ws-terminal-codex-identity-invariant.test.ts
+git commit -m "fix: enforce session identity at terminal side effects"
 ```
 
-## Task 4: Make Create Prefer Expected Codex Identity Over Stale Live Handles
+## Task 4: Make Create Reuse Identity-Gated
 
 **Files:**
 - Modify: `server/ws-handler.ts`
@@ -645,107 +303,132 @@ git commit -m "fix: reject stale terminal operations for mismatched sessions"
 
 - [ ] **Step 1: Write failing create/reuse tests**
 
-Add to `test/server/ws-terminal-create-reuse-running-codex.test.ts`:
+Cover these branches:
 
-```ts
-it('does not reuse a live Codex terminal when sessionRef points at a different thread', async () => {
-  const harness = await createCodexReuseHarness()
-  const old = await harness.createRunningCodexTerminal({
-    terminalId: 'term-old',
-    sessionRef: { provider: 'codex', sessionId: 'thread-old' },
-    codexDurability: {
-      schemaVersion: 1,
-      state: 'durable',
-      durableThreadId: 'thread-old',
-    },
-  })
+- Requested `liveTerminal` for `thread-old` with `sessionRef` `thread-new` is ignored. Create/restore targets `thread-new`.
+- Cached request-id reuse for `thread-old` with current request `sessionRef` `thread-new` is rejected or ignored, not returned.
+- Canonical running-terminal reuse for matching `thread-new` still works.
+- Same-server live handle without `sessionRef` does not invent Codex identity.
 
-  harness.ws.send(JSON.stringify({
-    type: 'terminal.create',
-    requestId: 'restore-thread-new',
-    mode: 'codex',
-    cwd: '/home/dan/code/freshell',
-    sessionRef: { provider: 'codex', sessionId: 'thread-new' },
-    liveTerminal: {
-      terminalId: old.terminalId,
-      serverInstanceId: harness.serverInstanceId,
-    },
-    restore: true,
-    tabId: 'tab-1',
-    paneId: 'pane-1',
-  }))
+- [ ] **Step 2: Write failing restore-decision tests**
 
-  const created = await harness.waitForCreated('restore-thread-new')
-  expect(created.terminalId).not.toBe(old.terminalId)
-  expect(harness.launches()).toContainEqual(expect.objectContaining({
-    mode: 'codex',
-    resumeSessionId: 'thread-new',
-  }))
-})
-```
+Update the restore-decision tests to match the real API boundary:
 
-Add to `test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts`:
+- `resolveCodexCreateRestoreDecision` accepts `findLiveTerminalByCandidate`, not an arbitrary requested live terminal.
+- Proof failure must not return a side-effecting `proof_failed_attach_live_candidate` decision. It should return `proof_failed_fresh_create` or another non-side-effect result.
+- Proof success can return a live terminal only after proof promotes the durable session id.
 
-```ts
-it('requires live terminal identity to match requested durable sessionRef', () => {
-  const decision = resolveCodexCreateRestoreDecision({
-    restoreRequested: true,
-    requestedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
-    codexDurability: undefined,
-    requestedLiveTerminal: {
-      terminalId: 'term-old',
-      resumeSessionId: 'thread-old',
-      codexDurability: {
-        schemaVersion: 1,
-        state: 'durable',
-        durableThreadId: 'thread-old',
-      },
-    } as any,
-  })
-
-  expect(decision.kind).not.toBe('attach_live')
-})
-```
-
-Adapt helper names to existing test helpers. Keep the assertion: a stale live terminal must not win over `sessionRef`.
-
-- [ ] **Step 2: Run failing tests**
-
-Run:
+- [ ] **Step 3: Run failing tests**
 
 ```bash
-npm run test:vitest -- test/server/ws-terminal-create-reuse-running-codex.test.ts test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts --run
+npm run test:vitest -- \
+  test/server/ws-terminal-create-reuse-running-codex.test.ts \
+  test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts \
+  --run
 ```
 
-Expected: FAIL because a requested live terminal can still be reused without enough identity validation.
+Expected: FAIL on stale live/cached reuse and proof-failed live candidate behavior.
 
-- [ ] **Step 3: Tighten create/reuse logic**
+- [ ] **Step 4: Centralize create reuse authorization**
 
-In `server/ws-handler.ts`, update the `requestedLiveTerminal()` path so it returns a record only when:
+Make `attachReusedTerminal(record)` the one identity gate for every reuse branch, including:
+
+- existing request-id cache
+- existing-after-config request-id cache
+- requested live terminal
+- proof-promoted live terminal
+- canonical running terminal by session
+
+`attachReusedTerminal` must receive the current expected `sessionRef` and refuse mismatched records before sending `terminal.created` or remembering `requestId -> terminalId`.
+
+- [ ] **Step 5: Fix request-id idempotency**
+
+Store or validate an identity fingerprint with created request ids:
 
 ```ts
-if (requestedSessionRef && !terminalMatchesExpectedSession(live, requestedSessionRef)) {
-  recordSessionLifecycleEvent({
-    kind: 'terminal_session_identity_mismatch',
-    provider: requestedSessionRef.provider,
-    terminalId: live.terminalId,
-    sessionId: requestedSessionRef.sessionId,
-    operation: 'terminal.create.liveTerminal',
-  })
-  return undefined
+type CreatedTerminalRequestBinding = {
+  terminalId: string
+  expectedSessionKey?: string
 }
 ```
 
-Apply the same check to any branch that attaches a requested live terminal because `codexDurabilityForDecision?.candidate` is absent. The rule is: if `sessionRef` exists, stale `liveTerminal` is ignored; restore/create proceeds from `sessionRef`.
+If the same request id is later used with a different expected session key, do not return the cached terminal.
 
-In `restore-decision.ts`, make any `attach_live` decision require a matching expected Codex session when `requestedSessionRef` or durable `codexDurability` is present.
+- [ ] **Step 6: Remove unsafe durability fallback**
+
+When Codex `restore === true` and there is no canonical `sessionRef`, do not read durability by `terminalId`/`tabId`/`paneId` to pick a thread. Return restore unavailable. Keep durability proof only when it is already tied to the pane's canonical `sessionRef`.
+
+- [ ] **Step 7: Run focused tests**
+
+```bash
+npm run test:vitest -- \
+  test/server/ws-terminal-create-reuse-running-codex.test.ts \
+  test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts \
+  --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/ws-handler.ts server/coding-cli/codex-app-server/restore-decision.ts test/server/ws-terminal-create-reuse-running-codex.test.ts test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts
+git commit -m "fix: gate Codex create reuse by canonical identity"
+```
+
+## Task 5: Cover REST, MCP, And CLI Terminal Paths
+
+**Files:**
+- Modify: `server/agent-api/router.ts`
+- Modify: `server/mcp/freshell-tool.ts`
+- Modify: `server/cli/index.ts`
+- Test: `test/server/agent-codex-identity-invariant.test.ts`
+- Extend: `test/server/agent-panes-write.test.ts`
+- Extend: `test/server/agent-send-keys.test.ts`
+
+- [ ] **Step 1: Write failing API tests**
+
+Cover:
+
+- `/api/panes/:id/attach` cannot attach a Codex terminal whose canonical identity differs from the pane's existing `sessionRef`.
+- `/api/panes/:id/send-keys` cannot write to a Codex terminal when the pane has a conflicting canonical `sessionRef`.
+- Existing shell/non-Codex attach/send behavior remains unchanged.
+- MCP `attach` and CLI `attach` pass enough expected identity or receive the same server-side rejection.
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+npm run test:vitest -- \
+  test/server/agent-codex-identity-invariant.test.ts \
+  test/server/agent-panes-write.test.ts \
+  test/server/agent-send-keys.test.ts \
+  --run
+```
+
+Expected: FAIL because attach/send-keys currently operate by terminal id.
+
+- [ ] **Step 3: Implement API identity enforcement**
+
+In `server/agent-api/router.ts`:
+
+- Resolve pane content before attach/send.
+- If pane has canonical Codex `sessionRef`, require target terminal actual identity to match before attach/send.
+- If request includes `sessionRef`, validate it against the target terminal and preserve it in pane content.
+- If pane has no canonical Codex `sessionRef`, do not infer one from `codexDurability` or terminal id.
+
+In MCP and CLI:
+
+- Include `sessionRef` where the tool can derive it from pane/session context.
+- Surface `SESSION_IDENTITY_MISMATCH` as an actionable error.
 
 - [ ] **Step 4: Run focused tests**
 
-Run:
-
 ```bash
-npm run test:vitest -- test/server/ws-terminal-create-reuse-running-codex.test.ts test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts --run
+npm run test:vitest -- \
+  test/server/agent-codex-identity-invariant.test.ts \
+  test/server/agent-panes-write.test.ts \
+  test/server/agent-send-keys.test.ts \
+  --run
 ```
 
 Expected: PASS.
@@ -753,11 +436,11 @@ Expected: PASS.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add server/ws-handler.ts server/coding-cli/codex-app-server/restore-decision.ts test/server/ws-terminal-create-reuse-running-codex.test.ts test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts
-git commit -m "fix: prefer Codex session identity over stale live handles"
+git add server/agent-api/router.ts server/mcp/freshell-tool.ts server/cli/index.ts test/server/agent-codex-identity-invariant.test.ts test/server/agent-panes-write.test.ts test/server/agent-send-keys.test.ts
+git commit -m "fix: enforce Codex identity on agent terminal APIs"
 ```
 
-## Task 5: Send Expected Identity From TerminalView
+## Task 6: Centralize Client Operation Sends
 
 **Files:**
 - Modify: `src/components/terminal-view-utils.ts`
@@ -767,162 +450,65 @@ git commit -m "fix: prefer Codex session identity over stale live handles"
 
 - [ ] **Step 1: Write failing helper tests**
 
-Add to `test/unit/client/components/terminal-view-utils.test.ts`:
+Add helpers that:
 
-```ts
-import { getExpectedSessionRefForTerminalOperation } from '../../../src/components/terminal-view-utils'
-
-describe('getExpectedSessionRefForTerminalOperation', () => {
-  it('returns canonical sessionRef when present', () => {
-    expect(getExpectedSessionRefForTerminalOperation({
-      mode: 'codex',
-      sessionRef: { provider: 'codex', sessionId: 'thread-1' },
-      codexDurability: {
-        schemaVersion: 1,
-        state: 'durable',
-        durableThreadId: 'thread-1',
-      },
-    } as any)).toEqual({ provider: 'codex', sessionId: 'thread-1' })
-  })
-
-  it('returns durable Codex identity when sessionRef is missing', () => {
-    expect(getExpectedSessionRefForTerminalOperation({
-      mode: 'codex',
-      codexDurability: {
-        schemaVersion: 1,
-        state: 'durable',
-        durableThreadId: 'thread-1',
-      },
-    } as any)).toEqual({ provider: 'codex', sessionId: 'thread-1' })
-  })
-
-  it('does not synthesize identity from cwd, title, or liveTerminal', () => {
-    expect(getExpectedSessionRefForTerminalOperation({
-      mode: 'codex',
-      initialCwd: '/home/dan/code/freshell',
-      liveTerminal: { terminalId: 'term-1', serverInstanceId: 'srv-1' },
-    } as any)).toBeUndefined()
-  })
-})
-```
+- Return expected operation identity only from canonical `content.sessionRef`.
+- Return `undefined` for Codex durability-only content.
+- Include outbound `liveTerminal` only when no canonical `sessionRef` exists, or when the caller explicitly allows a live handle after server validation.
+- Build attach/input/resize payloads with `expectedSessionRef` whenever canonical identity exists.
 
 - [ ] **Step 2: Run failing helper tests**
-
-Run:
 
 ```bash
 npm run test:vitest -- test/unit/client/components/terminal-view-utils.test.ts --run
 ```
 
-Expected: FAIL because the helper does not exist.
+Expected: FAIL because helpers do not exist.
 
 - [ ] **Step 3: Implement helper**
 
-In `src/components/terminal-view-utils.ts`:
+Do not derive expected identity from `codexDurability`.
 
 ```ts
-import type { SessionLocator, TerminalPaneContent } from '@/store/paneTypes'
-
 export function getExpectedSessionRefForTerminalOperation(
   content: TerminalPaneContent | null | undefined,
 ): SessionLocator | undefined {
-  if (!content) return undefined
-  if (content.sessionRef) return content.sessionRef
-
-  if (
-    content.mode === 'codex'
-    && content.codexDurability?.state === 'durable'
-    && content.codexDurability.durableThreadId
-  ) {
-    return { provider: 'codex', sessionId: content.codexDurability.durableThreadId }
-  }
-
-  return undefined
+  return content?.sessionRef?.provider === 'codex'
+    ? content.sessionRef
+    : content?.sessionRef
 }
 ```
 
-- [ ] **Step 4: Wire helper into TerminalView sends**
+Keep the provider generic, but tests must pin Codex behavior.
 
-In `src/components/TerminalView.tsx`, compute before each send:
+- [ ] **Step 4: Replace TerminalView call sites**
 
-```ts
-const expectedSessionRef = getExpectedSessionRefForTerminalOperation(contentRef.current)
-```
+Every TerminalView operation send must use the central helper:
 
-Add it to attach:
+- `sendInput`
+- Shift+Enter direct input
+- resize send
+- attach send
 
-```ts
-ws.send({
-  type: 'terminal.attach',
-  terminalId: tid,
-  intent: effectiveIntent,
-  cols,
-  rows,
-  sinceSeq,
-  attachRequestId,
-  priority: opts?.priority ?? 'foreground',
-  ...(opts?.maxReplayBytes ? { maxReplayBytes: opts.maxReplayBytes } : {}),
-  ...(expectedSessionRef ? { expectedSessionRef } : {}),
-})
-```
+The current TerminalView send sites to cover are the input helper, resize, direct Shift+Enter input, and attach. Keep firewall setup input outside TerminalView either intentionally exempted in tests or covered separately.
 
-Add it to input:
+- [ ] **Step 5: Write TerminalView outbound tests**
 
-```ts
-ws.send({
-  type: 'terminal.input',
-  terminalId: tid,
-  data,
-  ...(expectedSessionRef ? { expectedSessionRef } : {}),
-})
-```
+Test:
 
-Add it to resize:
-
-```ts
-ws.send({
-  type: 'terminal.resize',
-  terminalId: tid,
-  cols: term.cols,
-  rows: term.rows,
-  ...(expectedSessionRef ? { expectedSessionRef } : {}),
-})
-```
-
-- [ ] **Step 5: Write TerminalView message regression test**
-
-Create `test/unit/client/components/TerminalView.codex-identity.test.tsx`:
-
-```ts
-it('sends expected Codex session identity with terminal input', async () => {
-  const ws = renderCodexTerminalView({
-    content: {
-      mode: 'codex',
-      terminalId: 'term-1',
-      sessionRef: { provider: 'codex', sessionId: 'thread-1' },
-      shell: 'system',
-      initialCwd: '/home/dan/code/freshell',
-    },
-  })
-
-  await typeIntoTerminal('hello')
-
-  expect(ws.sentMessages()).toContainEqual(expect.objectContaining({
-    type: 'terminal.input',
-    terminalId: 'term-1',
-    expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
-  }))
-})
-```
-
-Use existing TerminalView render helpers and xterm input helpers. If this repository already covers outbound messages in another TerminalView lifecycle test file, add the case there instead of creating a new harness.
+- attach includes expected Codex `sessionRef`
+- normal input includes expected Codex `sessionRef`
+- Shift+Enter input includes expected Codex `sessionRef`
+- resize includes expected Codex `sessionRef`
+- durability-only Codex content does not send expected identity and does not send a guessed session id
 
 - [ ] **Step 6: Run client tests**
 
-Run:
-
 ```bash
-npm run test:vitest -- test/unit/client/components/terminal-view-utils.test.ts test/unit/client/components/TerminalView.codex-identity.test.tsx --run
+npm run test:vitest -- \
+  test/unit/client/components/terminal-view-utils.test.ts \
+  test/unit/client/components/TerminalView.codex-identity.test.tsx \
+  --run
 ```
 
 Expected: PASS.
@@ -931,239 +517,62 @@ Expected: PASS.
 
 ```bash
 git add src/components/terminal-view-utils.ts src/components/TerminalView.tsx test/unit/client/components/terminal-view-utils.test.ts test/unit/client/components/TerminalView.codex-identity.test.tsx
-git commit -m "feat: send pane session identity with terminal operations"
+git commit -m "feat: send canonical session identity with terminal operations"
 ```
 
-## Task 6: Client Repairs Stale Live Terminal Handles
-
-**Files:**
-- Modify: `src/components/TerminalView.tsx`
-- Modify: `src/store/panesSlice.ts` if a reducer helper is needed
-- Test: `test/unit/client/components/TerminalView.codex-identity.test.tsx`
-
-- [ ] **Step 1: Write failing client repair test**
-
-Add:
-
-```ts
-it('clears stale liveTerminal and recreates expected Codex session after identity mismatch', async () => {
-  const ws = renderCodexTerminalView({
-    content: {
-      mode: 'codex',
-      terminalId: 'term-old',
-      liveTerminal: { terminalId: 'term-old', serverInstanceId: 'srv-1' },
-      sessionRef: { provider: 'codex', sessionId: 'thread-new' },
-      shell: 'system',
-      initialCwd: '/home/dan/code/freshell',
-    },
-  })
-
-  ws.receive({
-    type: 'error',
-    code: 'SESSION_IDENTITY_MISMATCH',
-    message: 'Terminal belongs to a different session than the pane expects.',
-    terminalId: 'term-old',
-    expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
-    actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
-  })
-
-  await waitFor(() => {
-    expect(currentPaneContent()).toMatchObject({
-      mode: 'codex',
-      sessionRef: { provider: 'codex', sessionId: 'thread-new' },
-    })
-    expect(currentPaneContent().liveTerminal).toBeUndefined()
-    expect(currentPaneContent().terminalId).toBeUndefined()
-  })
-
-  expect(ws.sentMessages()).toContainEqual(expect.objectContaining({
-    type: 'terminal.create',
-    mode: 'codex',
-    sessionRef: { provider: 'codex', sessionId: 'thread-new' },
-  }))
-})
-```
-
-- [ ] **Step 2: Run failing client test**
-
-Run:
-
-```bash
-npm run test:vitest -- test/unit/client/components/TerminalView.codex-identity.test.tsx --run
-```
-
-Expected: FAIL because mismatch errors are not repaired.
-
-- [ ] **Step 3: Implement repair handling**
-
-In the WebSocket message handler in `TerminalView.tsx`, add:
-
-```ts
-if (
-  msg.type === 'error'
-  && msg.code === 'SESSION_IDENTITY_MISMATCH'
-  && msg.terminalId === tid
-) {
-  const expectedSessionRef = sanitizeSessionRef(msg.expectedSessionRef)
-  if (expectedSessionRef) {
-    updateContent({
-      terminalId: undefined,
-      liveTerminal: undefined,
-      sessionRef: expectedSessionRef,
-    })
-    dispatch(flushPersistedLayoutNow())
-    queueMicrotask(() => {
-      const nextRequestId = nanoid()
-      sendCreate(nextRequestId)
-    })
-  }
-  return
-}
-```
-
-Use local helper names for `updateContent`, request id generation, and `sendCreate`. If `sendCreate` is not in scope at the message handler, extract a small `scheduleRestoreCreateForExpectedSession` callback inside `TerminalView.tsx` that has access to the same refs.
-
-- [ ] **Step 4: Run client repair test**
-
-Run:
-
-```bash
-npm run test:vitest -- test/unit/client/components/TerminalView.codex-identity.test.tsx --run
-```
-
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/components/TerminalView.tsx src/store/panesSlice.ts test/unit/client/components/TerminalView.codex-identity.test.tsx
-git commit -m "fix: repair stale Codex live terminal handles"
-```
-
-## Task 7: Prove Association Flush Is The Persistence Boundary
+## Task 7: Guard Client Association And Durability Broadcasts
 
 **Files:**
 - Modify: `src/lib/terminal-session-association.ts`
+- Modify: `src/store/panesSlice.ts`
+- Modify: `src/components/TerminalView.tsx`
 - Test: `test/unit/client/lib/terminal-session-association.test.ts`
-- Test: `test/unit/server/terminal-registry.codex-sidecar.test.ts`
+- Test: `test/unit/client/components/TerminalView.codex-identity.test.tsx`
 
-- [ ] **Step 1: Write failing client association test**
+- [ ] **Step 1: Write failing association tests**
 
-Add to `test/unit/client/lib/terminal-session-association.test.ts`:
+Cover:
 
-```ts
-it('persists canonical Codex sessionRef and keeps matching durable state on association', () => {
-  const store = createTabsStoreWithPane({
-    tabId: 'tab-1',
-    paneId: 'pane-1',
-    terminalId: 'term-1',
-    content: {
-      mode: 'codex',
-      terminalId: 'term-1',
-      codexDurability: {
-        schemaVersion: 1,
-        state: 'durable',
-        durableThreadId: 'thread-1',
-        candidate: {
-          provider: 'codex',
-          candidateThreadId: 'thread-1',
-          rolloutPath: '/home/dan/.codex/sessions/2026/06/14/rollout-thread-1.jsonl',
-          source: 'thread_start_response',
-          capturedAt: 1,
-        },
-      },
-    },
-  })
+- Existing pane `sessionRef: thread-new` plus `terminal.session.associated` for same terminal id but `thread-old` must not overwrite the pane.
+- Matching association still persists canonical identity and clears raw `resumeSessionId`.
+- Conflicting association returns a clear status so callers can repair or ignore it.
 
-  const reconciled = reconcileTerminalSessionAssociation({
-    dispatch: store.dispatch,
-    getState: store.getState,
-    terminalId: 'term-1',
-    sessionRef: { provider: 'codex', sessionId: 'thread-1' },
-  })
+- [ ] **Step 2: Write failing durability broadcast tests**
 
-  expect(reconciled).toBe(true)
-  expect(selectPaneContent(store.getState(), 'tab-1', 'pane-1')).toMatchObject({
-    sessionRef: { provider: 'codex', sessionId: 'thread-1' },
-    resumeSessionId: undefined,
-    codexDurability: {
-      state: 'durable',
-      durableThreadId: 'thread-1',
-    },
-  })
-})
-```
+Cover:
 
-- [ ] **Step 2: Write failing server association test**
+- Existing pane `sessionRef: thread-new` plus durability update for `thread-old` is ignored and does not update pane or tab durability.
+- Matching durable update is preserved.
+- Candidate-only update is persisted only as evidence when no canonical sessionRef exists, and never changes expected operation identity.
 
-Add to `test/unit/server/terminal-registry.codex-sidecar.test.ts`:
-
-```ts
-it('broadcasts terminal.session.associated only after matching Codex rollout proof succeeds', async () => {
-  const registry = createRegistryWithCodexDurabilityStore()
-  const terminal = await registry.createCodexTerminalWithCandidate({
-    terminalId: 'term-1',
-    candidateThreadId: 'thread-1',
-    rolloutPath: await writeCodexRollout({ threadId: 'thread-1' }),
-  })
-
-  await registry.handleCodexTurnCompletedForTest(terminal.terminalId, {
-    threadId: 'thread-1',
-    turnId: 'turn-1',
-  })
-
-  await vi.waitFor(() => {
-    expect(registry.broadcasts()).toContainEqual(expect.objectContaining({
-      type: 'terminal.session.associated',
-      terminalId: 'term-1',
-      sessionRef: { provider: 'codex', sessionId: 'thread-1' },
-    }))
-  })
-})
-```
-
-Use existing helper names in this file; this test already has many Codex durability helpers.
-
-- [ ] **Step 3: Run focused tests**
-
-Run:
+- [ ] **Step 3: Run failing tests**
 
 ```bash
-npm run test:vitest -- test/unit/client/lib/terminal-session-association.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts --run
+npm run test:vitest -- \
+  test/unit/client/lib/terminal-session-association.test.ts \
+  test/unit/client/components/TerminalView.codex-identity.test.tsx \
+  --run
 ```
 
-Expected: PASS when the existing association path already satisfies the invariant, or FAIL with a missing pane persistence / missing broadcast assertion.
+Expected: FAIL because association/durability currently reconcile by terminal id.
 
-- [ ] **Step 4: Confirm or apply the association persistence code**
+- [ ] **Step 4: Implement guards**
 
-Inspect `src/lib/terminal-session-association.ts`. It must preserve matching durable Codex state with this logic:
+`reconcileTerminalSessionAssociation` must refuse a conflicting update when matched pane content already has a different canonical `sessionRef`.
 
-```ts
-const nextCodexDurability = sessionRef.provider === 'codex'
-  && content.codexDurability?.state === 'durable'
-  && (
-    content.codexDurability.durableThreadId === sessionRef.sessionId
-    || content.codexDurability.candidate?.candidateThreadId === sessionRef.sessionId
-  )
-    ? content.codexDurability
-    : undefined
-```
+`TerminalView` durability handling must compare durability durable/candidate ids against existing `sessionRef`:
 
-Inspect `server/terminal-registry.ts`. It must keep this order after proof success:
-
-```ts
-this.broadcastCodexDurability(record, stored)
-this.broadcastCodexSessionAssociated(record, proof.rolloutProofId)
-```
-
-Do not broadcast association before rollout proof succeeds.
+- durable id matches sessionRef: accept
+- candidate id matches sessionRef but state is not durable: store only if needed, but do not treat as expected identity
+- durable/candidate conflicts with sessionRef: ignore, log structured warning, and do not send candidate persisted ack
 
 - [ ] **Step 5: Run focused tests**
 
-Run:
-
 ```bash
-npm run test:vitest -- test/unit/client/lib/terminal-session-association.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts --run
+npm run test:vitest -- \
+  test/unit/client/lib/terminal-session-association.test.ts \
+  test/unit/client/components/TerminalView.codex-identity.test.tsx \
+  --run
 ```
 
 Expected: PASS.
@@ -1171,280 +580,189 @@ Expected: PASS.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add src/lib/terminal-session-association.ts server/terminal-registry.ts test/unit/client/lib/terminal-session-association.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts
-git commit -m "test: lock Codex association persistence boundary"
+git add src/lib/terminal-session-association.ts src/store/panesSlice.ts src/components/TerminalView.tsx test/unit/client/lib/terminal-session-association.test.ts test/unit/client/components/TerminalView.codex-identity.test.tsx
+git commit -m "fix: ignore stale Codex identity broadcasts"
 ```
 
-## Task 8: Incident-Shaped Component E2E Regression
+## Task 8: Repair Stale Runtime Plumbing With A Request-Id Transition
+
+**Files:**
+- Modify: `src/store/panesSlice.ts`
+- Modify: `src/components/TerminalView.tsx`
+- Test: `test/unit/client/components/TerminalView.codex-identity.test.tsx`
+- Test: `test/e2e/codex-wrong-thread-resume.test.tsx`
+
+- [ ] **Step 1: Write failing repair tests**
+
+Cover:
+
+- On `SESSION_IDENTITY_MISMATCH`, pane keeps `sessionRef: thread-new`.
+- Pane clears `terminalId`, `serverInstanceId`, and `streamId`.
+- Pane receives a new `createRequestId`.
+- Pane status becomes `creating`.
+- The next `terminal.create` sent by the normal create effect includes `restore: true` and `sessionRef: thread-new`.
+- Duplicate mismatch errors for the same stale terminal id do not create multiple competing request ids.
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+npm run test:vitest -- \
+  test/unit/client/components/TerminalView.codex-identity.test.tsx \
+  test/e2e/codex-wrong-thread-resume.test.tsx \
+  --run
+```
+
+Expected: FAIL because mismatch repair does not exist.
+
+- [ ] **Step 3: Add atomic reducer**
+
+Add a reducer such as:
+
+```ts
+repairCodexIdentityMismatch({
+  tabId,
+  paneId,
+  staleTerminalId,
+  expectedSessionRef,
+  createRequestId,
+})
+```
+
+It must:
+
+- no-op if pane no longer has `staleTerminalId`
+- no-op if pane has a different canonical `sessionRef`
+- clear runtime plumbing: `terminalId`, `serverInstanceId`, `streamId`
+- preserve `sessionRef`
+- preserve matching durable `codexDurability` only when it is durable and matches sessionRef
+- set `createRequestId`
+- set status `creating`
+
+- [ ] **Step 4: Wire TerminalView to reducer**
+
+On `SESSION_IDENTITY_MISMATCH`:
+
+- validate `msg.expectedSessionRef`
+- generate new request id
+- mark it as restore via `addTerminalRestoreRequestId(newRequestId)`
+- update `requestIdRef.current`
+- clear terminal refs/checkpoints for the stale terminal
+- dispatch reducer
+- do not manually call `sendCreate`; let the create effect run from `createRequestId`
+
+- [ ] **Step 5: Run focused tests**
+
+```bash
+npm run test:vitest -- \
+  test/unit/client/components/TerminalView.codex-identity.test.tsx \
+  test/e2e/codex-wrong-thread-resume.test.tsx \
+  --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/store/panesSlice.ts src/components/TerminalView.tsx test/unit/client/components/TerminalView.codex-identity.test.tsx test/e2e/codex-wrong-thread-resume.test.tsx
+git commit -m "fix: repair stale Codex runtime plumbing"
+```
+
+## Task 9: Harden Tab Registry And Cross-Tab Sync
+
+**Files:**
+- Modify: `src/lib/tab-registry-snapshot.ts`
+- Modify: `src/components/TabsView.tsx`
+- Modify: `src/store/panesSlice.ts`
+- Test: `test/unit/client/components/TabsView.test.tsx`
+- Test: `test/unit/client/store/crossTabSync.test.ts`
+
+- [ ] **Step 1: Write failing tab-registry tests**
+
+Cover:
+
+- A registry record with `sessionRef: thread-new` and same-server `liveTerminal: term-old` does not hydrate `terminalId: term-old` unless the live handle is proven/declared matching.
+- A registry record without `sessionRef` may still use liveTerminal for non-Codex live-only behavior.
+- `tab-registry-snapshot` still publishes `liveTerminal` for UI discovery, but consumers treat it as runtime plumbing.
+
+- [ ] **Step 2: Write failing cross-tab tests**
+
+Cover:
+
+- Incoming pane content cannot overwrite local canonical `sessionRef` with a different `sessionRef`.
+- Incoming `terminalId`/`serverInstanceId`/`streamId` are discarded when they conflict with local canonical Codex `sessionRef`.
+- Matching canonical session can still merge safe non-runtime fields.
+
+- [ ] **Step 3: Run failing tests**
+
+```bash
+npm run test:vitest -- \
+  test/unit/client/components/TabsView.test.tsx \
+  test/unit/client/store/crossTabSync.test.ts \
+  --run
+```
+
+Expected: FAIL because same-server live handles and cross-tab merge currently allow stale runtime fields.
+
+- [ ] **Step 4: Implement sync hardening**
+
+In `TabsView`:
+
+- If sanitized payload has canonical `sessionRef`, do not hydrate `terminalId` from `liveTerminal` unless there is a server-validated matching proof in the record. If no such proof exists, leave `terminalId` undefined and let create/restore target the sessionRef.
+
+In cross-tab merge:
+
+- canonical `sessionRef` wins over incoming runtime fields
+- conflicting runtime fields are dropped
+- `codexDurability` is retained only when it matches canonical `sessionRef`
+
+- [ ] **Step 5: Run focused tests**
+
+```bash
+npm run test:vitest -- \
+  test/unit/client/components/TabsView.test.tsx \
+  test/unit/client/store/crossTabSync.test.ts \
+  --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/tab-registry-snapshot.ts src/components/TabsView.tsx src/store/panesSlice.ts test/unit/client/components/TabsView.test.tsx test/unit/client/store/crossTabSync.test.ts
+git commit -m "fix: keep canonical Codex identity across tab sync"
+```
+
+## Task 10: Incident-Shaped End-To-End Regression
 
 **Files:**
 - Create: `test/e2e/codex-wrong-thread-resume.test.tsx`
 
-- [ ] **Step 1: Write the failing e2e regression**
+- [ ] **Step 1: Write the regression**
 
-Create `test/e2e/codex-wrong-thread-resume.test.tsx`:
+Model the incident:
 
-```ts
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, waitFor } from '@testing-library/react'
-import { Provider } from 'react-redux'
-import { configureStore } from '@reduxjs/toolkit'
-import tabsReducer from '@/store/tabsSlice'
-import panesReducer from '@/store/panesSlice'
-import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
-import connectionReducer from '@/store/connectionSlice'
-import { useAppSelector } from '@/store/hooks'
-import type { PaneNode, TerminalPaneContent } from '@/store/paneTypes'
-import TerminalView from '@/components/TerminalView'
+- Pane has canonical `sessionRef: thread-new`.
+- Pane has stale runtime plumbing `terminalId: term-old`, `serverInstanceId`, and `streamId`.
+- Client first tries attach/input with `expectedSessionRef: thread-new`.
+- Server emits `SESSION_IDENTITY_MISMATCH` with actual `thread-old`.
+- Client clears stale runtime plumbing, bumps `createRequestId`, and sends restore create for `thread-new`.
+- Test asserts no input goes to `term-old` after mismatch.
 
-const wsHarness = vi.hoisted(() => {
-  const messageHandlers = new Set<(msg: any) => void>()
-  const restoreRequestIds = new Set<string>()
-  return {
-    send: vi.fn(),
-    connect: vi.fn().mockResolvedValue(undefined),
-    onMessage: vi.fn((handler: (msg: any) => void) => {
-      messageHandlers.add(handler)
-      return () => messageHandlers.delete(handler)
-    }),
-    onReconnect: vi.fn(() => () => {}),
-    addRestoreRequestId(id: string) {
-      restoreRequestIds.add(id)
-    },
-    consumeRestoreRequestId(id: string) {
-      const hasId = restoreRequestIds.has(id)
-      restoreRequestIds.delete(id)
-      return hasId
-    },
-    emit(msg: any) {
-      for (const handler of messageHandlers) handler(msg)
-    },
-    reset() {
-      messageHandlers.clear()
-      restoreRequestIds.clear()
-      this.send.mockClear()
-    },
-  }
-})
+Use the existing component-level e2e style in `test/e2e/terminal-restart-recovery.test.tsx`.
 
-vi.mock('@/lib/ws-client', () => ({
-  getWsClient: () => ({
-    send: wsHarness.send,
-    connect: wsHarness.connect,
-    onMessage: wsHarness.onMessage,
-    onReconnect: wsHarness.onReconnect,
-  }),
-}))
-
-vi.mock('@/lib/terminal-restore', () => ({
-  addTerminalRestoreRequestId: (id: string) => wsHarness.addRestoreRequestId(id),
-  consumeTerminalRestoreRequestId: (id: string) => wsHarness.consumeRestoreRequestId(id),
-  addTerminalFreshRecoveryRequestId: vi.fn(),
-  consumeTerminalFreshRecoveryRequest: vi.fn(() => undefined),
-}))
-
-vi.mock('@/lib/terminal-themes', () => ({
-  getTerminalTheme: () => ({}),
-}))
-
-vi.mock('@/components/terminal/terminal-runtime', () => ({
-  createTerminalRuntime: () => ({
-    attachAddons: vi.fn(),
-    fit: vi.fn(),
-    findNext: vi.fn(() => false),
-    findPrevious: vi.fn(() => false),
-    clearDecorations: vi.fn(),
-    onDidChangeResults: vi.fn(() => ({ dispose: vi.fn() })),
-    dispose: vi.fn(),
-    webglActive: vi.fn(() => false),
-  }),
-}))
-
-vi.mock('@xterm/xterm', () => {
-  class MockTerminal {
-    options: Record<string, unknown> = {}
-    cols = 80
-    rows = 24
-    open = vi.fn()
-    registerLinkProvider = vi.fn(() => ({ dispose: vi.fn() }))
-    onData = vi.fn(() => ({ dispose: vi.fn() }))
-    onTitleChange = vi.fn(() => ({ dispose: vi.fn() }))
-    attachCustomKeyEventHandler = vi.fn()
-    attachCustomWheelEventHandler = vi.fn()
-    dispose = vi.fn()
-    focus = vi.fn()
-    getSelection = vi.fn(() => '')
-    clear = vi.fn()
-    write = vi.fn((data: string, cb?: () => void) => {
-      cb?.()
-      return data.length
-    })
-    writeln = vi.fn()
-  }
-  return { Terminal: MockTerminal }
-})
-
-vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
-
-class MockResizeObserver {
-  observe = vi.fn()
-  disconnect = vi.fn()
-  unobserve = vi.fn()
-}
-
-function findLeaf(node: PaneNode | undefined, paneId: string): Extract<PaneNode, { type: 'leaf' }> | null {
-  if (!node) return null
-  if (node.type === 'leaf') return node.id === paneId ? node : null
-  return findLeaf(node.children[0], paneId) || findLeaf(node.children[1], paneId)
-}
-
-function TerminalViewFromStore({ tabId, paneId }: { tabId: string; paneId: string }) {
-  const paneContent = useAppSelector((state) => findLeaf(state.panes.layouts[tabId], paneId)?.content ?? null)
-  if (!paneContent || paneContent.kind !== 'terminal') return null
-  return <TerminalView tabId={tabId} paneId={paneId} paneContent={paneContent} />
-}
-
-function createStore(content: TerminalPaneContent) {
-  return configureStore({
-    reducer: {
-      tabs: tabsReducer,
-      panes: panesReducer,
-      settings: settingsReducer,
-      connection: connectionReducer,
-    },
-    preloadedState: {
-      tabs: {
-        tabs: [{
-          id: 'tab-codex',
-          mode: 'codex',
-          status: 'running',
-          title: 'Codex',
-          titleSetByUser: false,
-          createRequestId: 'tab-codex',
-        }],
-        activeTabId: 'tab-codex',
-      },
-      panes: {
-        layouts: {
-          'tab-codex': {
-            type: 'leaf',
-            id: 'pane-codex',
-            content,
-          },
-        },
-        activePane: { 'tab-codex': 'pane-codex' },
-        paneTitles: {},
-      },
-      settings: { settings: defaultSettings, status: 'loaded' },
-      connection: { status: 'ready', error: null, serverInstanceId: 'srv-new' },
-    },
-  })
-}
-
-function sentMessages() {
-  return wsHarness.send.mock.calls.map(([msg]) => msg)
-}
-
-describe('Codex wrong-thread resume regression', () => {
-  beforeEach(() => {
-    wsHarness.reset()
-    vi.stubGlobal('ResizeObserver', MockResizeObserver)
-    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
-      cb(0)
-      return 1
-    })
-    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
-  })
-
-  afterEach(() => {
-    cleanup()
-    vi.restoreAllMocks()
-    vi.unstubAllGlobals()
-  })
-
-  it('repairs stale Codex terminal plumbing instead of continuing the wrong thread', async () => {
-    const store = createStore({
-      kind: 'terminal',
-      createRequestId: 'req-old',
-      status: 'running',
-      mode: 'codex',
-      shell: 'system',
-      terminalId: 'term-old',
-      serverInstanceId: 'srv-new',
-      sessionRef: { provider: 'codex', sessionId: 'thread-new' },
-      codexDurability: {
-        schemaVersion: 1,
-        state: 'durable',
-        durableThreadId: 'thread-new',
-      },
-      initialCwd: '/home/dan/code/freshell',
-    })
-
-    render(
-      <Provider store={store}>
-        <TerminalViewFromStore tabId="tab-codex" paneId="pane-codex" />
-      </Provider>,
-    )
-
-    await waitFor(() => {
-      expect(sentMessages()).toContainEqual(expect.objectContaining({
-        type: 'terminal.attach',
-        terminalId: 'term-old',
-        expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
-      }))
-    })
-
-    wsHarness.send.mockClear()
-    wsHarness.emit({
-      type: 'error',
-      code: 'SESSION_IDENTITY_MISMATCH',
-      message: 'Terminal belongs to a different session than the pane expects.',
-      terminalId: 'term-old',
-      timestamp: new Date().toISOString(),
-      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
-      actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
-    })
-
-    await waitFor(() => {
-      expect(sentMessages()).toContainEqual(expect.objectContaining({
-        type: 'terminal.create',
-        mode: 'codex',
-        restore: true,
-        sessionRef: { provider: 'codex', sessionId: 'thread-new' },
-      }))
-    })
-
-    const state = store.getState()
-    const content = findLeaf(state.panes.layouts['tab-codex'], 'pane-codex')?.content
-    expect(content).toMatchObject({
-      kind: 'terminal',
-      mode: 'codex',
-      sessionRef: { provider: 'codex', sessionId: 'thread-new' },
-    })
-    expect((content as TerminalPaneContent).terminalId).toBeUndefined()
-  })
-})
-```
-
-This e2e regression is intentionally component-level because the existing restart recovery e2e tests are component-level. It proves the user-facing reload path: stale terminal plumbing is cleared and the recreate path targets the expected Codex `sessionRef`.
-
-- [ ] **Step 2: Run the failing e2e test**
-
-Run:
+- [ ] **Step 2: Run failing e2e**
 
 ```bash
 FRESHELL_TEST_SUMMARY="codex wrong-thread resume e2e" npm run test:vitest -- test/e2e/codex-wrong-thread-resume.test.tsx --run
 ```
 
-Expected: FAIL before all identity guards and client repair are wired.
+Expected: FAIL before the implementation tasks are complete.
 
-- [ ] **Step 3: Implement only production repair code**
+- [ ] **Step 3: Run passing e2e**
 
-Do not add fixture support for this task. The test file above owns its local mocks and should pass once Tasks 5 and 6 are implemented.
-
-- [ ] **Step 4: Run e2e regression**
-
-Run:
+After Tasks 1-9:
 
 ```bash
 FRESHELL_TEST_SUMMARY="codex wrong-thread resume e2e" npm run test:vitest -- test/e2e/codex-wrong-thread-resume.test.tsx --run
@@ -1452,21 +770,19 @@ FRESHELL_TEST_SUMMARY="codex wrong-thread resume e2e" npm run test:vitest -- tes
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
 git add test/e2e/codex-wrong-thread-resume.test.tsx
 git commit -m "test: cover Codex wrong-thread resume regression"
 ```
 
-## Task 9: Full Verification
+## Task 11: Full Verification
 
 **Files:**
 - No production file changes unless verification exposes failures.
 
 - [ ] **Step 1: Run status check**
-
-Run:
 
 ```bash
 npm run test:status
@@ -1476,26 +792,25 @@ Expected: coordinator is idle or shows a reusable green baseline. If another age
 
 - [ ] **Step 2: Run focused suites**
 
-Run:
-
 ```bash
 npm run test:vitest -- \
   test/unit/server/terminal-session-identity.test.ts \
   test/server/ws-terminal-codex-identity-invariant.test.ts \
   test/server/ws-terminal-create-reuse-running-codex.test.ts \
   test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts \
+  test/server/agent-codex-identity-invariant.test.ts \
   test/unit/client/components/terminal-view-utils.test.ts \
   test/unit/client/components/TerminalView.codex-identity.test.tsx \
   test/unit/client/lib/terminal-session-association.test.ts \
-  test/unit/server/terminal-registry.codex-sidecar.test.ts \
+  test/unit/client/components/TabsView.test.tsx \
+  test/unit/client/store/crossTabSync.test.ts \
+  test/e2e/codex-wrong-thread-resume.test.tsx \
   --run
 ```
 
 Expected: PASS.
 
 - [ ] **Step 3: Run repo check**
-
-Run:
 
 ```bash
 FRESHELL_TEST_SUMMARY="codex thread identity invariant final check" npm run check
@@ -1504,8 +819,6 @@ FRESHELL_TEST_SUMMARY="codex thread identity invariant final check" npm run chec
 Expected: PASS.
 
 - [ ] **Step 4: Inspect git diff**
-
-Run:
 
 ```bash
 git status --short
@@ -1523,7 +836,8 @@ git commit -m "fix: enforce Codex thread identity invariant"
 
 ## Self-Review
 
-- Spec coverage: The plan covers the requested non-legacy approach. It uses the existing Codex durability system, makes it authoritative for create/attach/input/resize, rejects stale live terminal reuse, and repairs stale handles from the client.
-- Placeholder scan: There is no heuristic recovery, no "latest history" matching, and no deferred legacy resolver. Test snippets identify the exact user-visible failure: input must not reach the old thread and restore must target the expected thread.
-- Type consistency: The plan consistently uses `expectedSessionRef`, `sessionRef`, `candidateThreadId`, `durableThreadId`, and `SESSION_IDENTITY_MISMATCH`.
-- Known implementation adjustment: Some test helper names in snippets may need to map onto the repo's existing fixtures. Preserve the behavior and assertion shape when adapting helper names.
+- Spec coverage: The revised plan no longer relies on candidate-only identity, durability-only identity, same-server live handles, request-id cache identity, or terminal id as proof.
+- Load-bearing fixes: Every falsified load-bearing assumption now changes a task: side-effect gates move inside operation owners, create reuse is centralized, REST/MCP/CLI paths are in scope, broadcasts are identity-aware, and tab-registry/cross-tab sync drops stale runtime fields.
+- Non-legacy approach: The plan still ignores heuristic recovery. When canonical `sessionRef` is absent, Freshell refuses to guess.
+- Test shape: Tests protect the incident behavior directly: input/replay must not reach the old thread, stale runtime plumbing must be cleared, and restore/create must target the expected Codex `sessionRef`.
+- Known implementation adjustment: Helper and fixture names must follow the repo's existing test harnesses. Preserve the behavior and assertion shape when adapting names.

--- a/server/agent-api/router.ts
+++ b/server/agent-api/router.ts
@@ -15,6 +15,7 @@ import {
 import { INVALID_RAW_CODEX_RESUME_MESSAGE } from '../coding-cli/codex-app-server/restore-decision.js'
 import { makeSessionKey } from '../coding-cli/types.js'
 import { terminalIdFromCreateError, UnknownTerminalModeError, type ProviderSettings, type TerminalInputResult } from '../terminal-registry.js'
+import { buildSessionIdentityMismatchDetails, terminalMatchesExpectedSession } from '../terminal-session-identity.js'
 import { MAX_TERMINAL_TITLE_OVERRIDE_LENGTH } from '../terminals-router.js'
 import { logger } from '../logger.js'
 import { ok, approx, fail } from './response.js'
@@ -189,7 +190,44 @@ function assertCodexCreateTerminalRunning(terminal: { status?: unknown }): void 
   }
 }
 
+function formatSessionRef(sessionRef: ReturnType<typeof sanitizeSessionRef> | undefined): string {
+  if (!sessionRef) return 'unknown session'
+  return `${sessionRef.provider}:${sessionRef.sessionId}`
+}
+
+function sessionIdentityMismatchMessage(
+  expectedSessionRef: ReturnType<typeof sanitizeSessionRef> | undefined,
+  actualSessionRef: ReturnType<typeof sanitizeSessionRef> | undefined,
+): string {
+  const expected = formatSessionRef(expectedSessionRef)
+  if (!actualSessionRef) {
+    return `Terminal session identity mismatch. Expected ${expected}, but the target terminal could not prove that identity.`
+  }
+  return `Terminal session identity mismatch. Expected ${expected}, got ${formatSessionRef(actualSessionRef)}.`
+}
+
+function paneCanonicalSessionRef(
+  layoutStore: any,
+  paneId: string,
+): ReturnType<typeof sanitizeSessionRef> {
+  return sanitizeSessionRef(layoutStore.getPaneSnapshot?.(paneId)?.paneContent?.sessionRef)
+}
+
+function expectedPaneSessionRefForTerminal(
+  layoutStore: any,
+  paneId: string,
+  terminalMode: unknown,
+  requestedSessionRef: ReturnType<typeof sanitizeSessionRef>,
+): ReturnType<typeof sanitizeSessionRef> {
+  const paneSessionRef = paneCanonicalSessionRef(layoutStore, paneId)
+  if (paneSessionRef) return paneSessionRef
+  return acceptedSessionRefForMode(requestedSessionRef, typeof terminalMode === 'string' ? terminalMode : '')
+}
+
 function terminalInputFailureMessage(result: Exclude<TerminalInputResult, { status: 'written' }>): string {
+  if (result.status === 'session_identity_mismatch') {
+    return sessionIdentityMismatchMessage(result.expectedSessionRef, result.actualSessionRef)
+  }
   if (result.status === 'blocked_codex_identity_pending') {
     return 'Codex restore identity is not ready yet.'
   }
@@ -217,6 +255,11 @@ function shouldWaitForCodexIdentity(payload: Record<string, unknown>): boolean {
 
 function registrySupportsEvents(registry: any): registry is {
   input: (terminalId: string, data: string) => TerminalInputResult
+  inputIfSessionMatches?: (
+    terminalId: string,
+    data: string,
+    expectedSessionRef?: ReturnType<typeof sanitizeSessionRef>,
+  ) => TerminalInputResult
   on: (event: string, handler: (...args: any[]) => void) => void
   off: (event: string, handler: (...args: any[]) => void) => void
 } {
@@ -227,9 +270,17 @@ async function sendTerminalInput(
   registry: any,
   terminalId: string,
   data: string,
-  options: { waitForCodexIdentity?: boolean } = {},
+  options: {
+    expectedSessionRef?: ReturnType<typeof sanitizeSessionRef>
+    waitForCodexIdentity?: boolean
+  } = {},
 ): Promise<TerminalInputResult> {
-  const first = registry.input(terminalId, data) as TerminalInputResult
+  const send = () => (
+    typeof registry.inputIfSessionMatches === 'function'
+      ? registry.inputIfSessionMatches(terminalId, data, options.expectedSessionRef)
+      : registry.input(terminalId, data)
+  ) as TerminalInputResult
+  const first = send()
   if (first.status !== 'blocked_codex_identity_pending' || !options.waitForCodexIdentity) {
     return first
   }
@@ -252,7 +303,7 @@ async function sendTerminalInput(
     }
     const retry = () => {
       if (settled) return
-      const next = registry.input(terminalId, data) as TerminalInputResult
+      const next = send()
       if (next.status === 'blocked_codex_identity_pending') return
       finish(next)
     }
@@ -1336,6 +1387,17 @@ export function createAgentApiRouter({
     const tabId = target?.tabId
     if (!tabId) return res.status(404).json(fail('pane not found'))
     const attachedTerminal = registry.get?.(terminalId)
+    const requestedSessionRef = sanitizeSessionRef(req.body?.sessionRef)
+    const expectedSessionRef = expectedPaneSessionRefForTerminal(
+      layoutStore,
+      paneId,
+      attachedTerminal?.mode ?? req.body?.mode,
+      requestedSessionRef,
+    )
+    if (attachedTerminal && expectedSessionRef && !terminalMatchesExpectedSession(attachedTerminal, expectedSessionRef)) {
+      const { actualSessionRef } = buildSessionIdentityMismatchDetails(attachedTerminal, expectedSessionRef)
+      return res.status(409).json(fail(sessionIdentityMismatchMessage(expectedSessionRef, actualSessionRef)))
+    }
     const content = {
       kind: 'terminal',
       terminalId,
@@ -1343,6 +1405,7 @@ export function createAgentApiRouter({
       mode: req.body?.mode || attachedTerminal?.mode || 'shell',
       shell: req.body?.shell || attachedTerminal?.shell || 'system',
       createRequestId: nanoid(),
+      ...(expectedSessionRef ? { sessionRef: expectedSessionRef } : {}),
     }
     layoutStore.attachPaneContent(tabId, paneId, content)
     wsHandler?.broadcastUiCommand({ command: 'pane.attach', payload: { tabId, paneId, content } })
@@ -1370,13 +1433,23 @@ export function createAgentApiRouter({
     const paneId = resolved.paneId || req.params.id
     const payload = req.body || {}
     const data = payload.data ?? payload.keys ?? payload.text ?? ''
-    let terminalId = layoutStore.resolvePaneToTerminal?.(paneId)
+    const paneSnapshot = layoutStore.getPaneSnapshot?.(paneId)
+    let terminalId = paneSnapshot?.terminalId || layoutStore.resolvePaneToTerminal?.(paneId)
     if (!terminalId && layoutStore.resolveTarget) {
       const target = layoutStore.resolveTarget(paneId)
       if (target?.paneId) terminalId = layoutStore.resolvePaneToTerminal?.(target.paneId)
     }
     if (!terminalId) return res.status(404).json(fail('terminal not found'))
+    const terminal = registry.get?.(terminalId)
+    const requestedSessionRef = sanitizeSessionRef(payload.sessionRef)
+    const expectedSessionRef = expectedPaneSessionRefForTerminal(
+      layoutStore,
+      paneId,
+      terminal?.mode ?? paneSnapshot?.paneContent?.mode,
+      requestedSessionRef,
+    )
     const inputResult = await sendTerminalInput(registry, terminalId, data, {
+      expectedSessionRef,
       waitForCodexIdentity: shouldWaitForCodexIdentity(payload),
     })
     if (inputResult.status !== 'written') {

--- a/server/cli/commands/sendKeys.ts
+++ b/server/cli/commands/sendKeys.ts
@@ -1,6 +1,16 @@
 import { translateKeys } from '../keys.js'
 
-export async function runCommand(opts: { target: string; keys: string[] }, client: any) {
+export async function runCommand(
+  opts: {
+    target: string
+    keys: string[]
+    sessionRef?: { provider: string; sessionId: string }
+  },
+  client: any,
+) {
   const data = translateKeys(opts.keys)
-  return client.post(`/api/panes/${encodeURIComponent(opts.target)}/send-keys`, { data })
+  return client.post(`/api/panes/${encodeURIComponent(opts.target)}/send-keys`, {
+    data,
+    ...(opts.sessionRef ? { sessionRef: opts.sessionRef } : {}),
+  })
 }

--- a/server/cli/index.ts
+++ b/server/cli/index.ts
@@ -138,7 +138,7 @@ function resolveSessionRefFlag(mode: unknown, raw: unknown): { rejected: boolean
     process.exitCode = 1
     return { rejected: true }
   }
-  if (typeof mode !== 'string' || mode !== provider) {
+  if (mode !== undefined && (typeof mode !== 'string' || mode !== provider)) {
     writeError('--session-ref provider must match --mode.')
     process.exitCode = 1
     return { rejected: true }
@@ -622,6 +622,8 @@ async function main() {
       const parsedSendKeys = partitionSendKeysArgs(args, targetFromFlag)
       let target: string | undefined = parsedSendKeys.target
       const literal = isTruthy(getFlag(flags, 'l', 'literal'))
+      const sessionRefResult = resolveSessionRefFlag(undefined, getFlag(flags, 'session-ref'))
+      if (sessionRefResult.rejected) return
       const keyArgs = parsedSendKeys.keyArgs
       if (!target) {
         const resolved = await resolvePaneTarget(client, undefined)
@@ -635,11 +637,14 @@ async function main() {
       }
       if (literal) {
         const data = keyArgs.join(' ')
-        const res = await client.post(`/api/panes/${encodeURIComponent(target)}/send-keys`, { data })
+        const res = await client.post(`/api/panes/${encodeURIComponent(target)}/send-keys`, {
+          data,
+          ...(sessionRefResult.sessionRef ? { sessionRef: sessionRefResult.sessionRef } : {}),
+        })
         writeJson(res)
         return
       }
-      const res = await sendKeysCommand({ target, keys: keyArgs }, client)
+      const res = await sendKeysCommand({ target, keys: keyArgs, sessionRef: sessionRefResult.sessionRef }, client)
       writeJson(res)
       return
     }
@@ -842,6 +847,8 @@ async function main() {
         process.exitCode = 1
         return
       }
+      const sessionRefResult = resolveSessionRefFlag(undefined, getFlag(flags, 'session-ref'))
+      if (sessionRefResult.rejected) return
       let target = (getFlag(flags, 'p', 'pane', 'target') as string | undefined) || args[1]
       const resolved = await resolvePaneTarget(client, target)
       if (!resolved.pane?.id) {
@@ -849,7 +856,10 @@ async function main() {
         process.exitCode = 1
         return
       }
-      const res = await client.post(`/api/panes/${encodeURIComponent(resolved.pane.id)}/attach`, { terminalId })
+      const res = await client.post(`/api/panes/${encodeURIComponent(resolved.pane.id)}/attach`, {
+        terminalId,
+        ...(sessionRefResult.sessionRef ? { sessionRef: sessionRefResult.sessionRef } : {}),
+      })
       writeJson(res)
       return
     }

--- a/server/coding-cli/codex-app-server/restore-decision.ts
+++ b/server/coding-cli/codex-app-server/restore-decision.ts
@@ -1,7 +1,5 @@
-import type { SessionRef, RestoreError } from '../../../shared/session-contract.js'
-import { buildRestoreError } from '../../../shared/session-contract.js'
+import type { SessionRef } from '../../../shared/session-contract.js'
 import type { CodexCandidateIdentity, CodexDurabilityRef } from '../../../shared/codex-durability.js'
-import { proofCodexRollout, type CodexRolloutProofResult } from './durability-proof.js'
 
 type MaybePromise<T> = T | Promise<T>
 
@@ -21,31 +19,10 @@ export type RejectCodexCreateRestoreDecision = {
 export type CodexCreateRestorePlan =
   | RejectCodexCreateRestoreDecision
   | { kind: 'fresh_codex_launch' }
-  | { kind: 'proof_existing_candidate_first'; candidate: CodexCandidateIdentity }
   | { kind: 'durable_session_ref_resume'; sessionRef: SessionRef & { provider: 'codex' }; sessionId: string }
 
 export type CodexCreateRestoreDecision<TLiveTerminal extends CodexLiveRestoreTerminal = CodexLiveRestoreTerminal> =
-  | Exclude<CodexCreateRestorePlan, { kind: 'proof_existing_candidate_first' }>
-  | {
-    kind: 'proof_succeeded_resume_durable'
-    candidate: CodexCandidateIdentity
-    proof: Extract<CodexRolloutProofResult, { ok: true }>
-    sessionId: string
-    liveTerminal?: TLiveTerminal
-  }
-  | {
-    kind: 'proof_failed_attach_live_candidate'
-    candidate: CodexCandidateIdentity
-    proof: Extract<CodexRolloutProofResult, { ok: false }>
-    liveTerminal: TLiveTerminal
-  }
-  | {
-    kind: 'proof_failed_fresh_create'
-    candidate: CodexCandidateIdentity
-    proof: Extract<CodexRolloutProofResult, { ok: false }>
-    clearCodexDurability: true
-    restoreError: RestoreError
-  }
+  | CodexCreateRestorePlan
 
 export const INVALID_RAW_CODEX_RESUME_MESSAGE =
   'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.'
@@ -76,23 +53,6 @@ export function planCodexCreateRestoreDecision(input: {
     }
   }
 
-  const durableSessionId = input.restoreRequested ? getDurableCodexSessionId(input.codexDurability) : undefined
-  if (durableSessionId) {
-    return {
-      kind: 'durable_session_ref_resume',
-      sessionRef: { provider: 'codex', sessionId: durableSessionId },
-      sessionId: durableSessionId,
-    }
-  }
-
-  const candidate = input.codexDurability?.candidate
-  if (input.restoreRequested && candidate && !input.legacyResumeSessionId) {
-    return {
-      kind: 'proof_existing_candidate_first',
-      candidate,
-    }
-  }
-
   if (input.restoreRequested) {
     return {
       kind: 'reject_missing_codex_session_ref',
@@ -110,51 +70,10 @@ export async function resolveCodexCreateRestoreDecision<TLiveTerminal extends Co
     legacyResumeSessionId?: string
     sessionRef?: SessionRef
     codexDurability?: CodexDurabilityRef
-    proofRollout?: (input: { rolloutPath: string; candidateThreadId: string }) => Promise<CodexRolloutProofResult>
     findLiveTerminalByCandidate?: (candidate: CodexCandidateIdentity) => MaybePromise<TLiveTerminal | undefined>
   },
 ): Promise<CodexCreateRestoreDecision<TLiveTerminal>> {
-  const plan = planCodexCreateRestoreDecision(input)
-  if (plan.kind !== 'proof_existing_candidate_first') {
-    return plan
-  }
-
-  const candidate = plan.candidate
-  const proof = await (input.proofRollout ?? proofCodexRollout)({
-    rolloutPath: candidate.rolloutPath,
-    candidateThreadId: candidate.candidateThreadId,
-  })
-  const returnedLiveTerminal = await input.findLiveTerminalByCandidate?.(candidate)
-  const liveTerminal = returnedLiveTerminal && isExactLiveCodexCandidate(returnedLiveTerminal, candidate)
-    ? returnedLiveTerminal
-    : undefined
-
-  if (proof.ok) {
-    return {
-      kind: 'proof_succeeded_resume_durable',
-      candidate,
-      proof,
-      sessionId: proof.rolloutProofId,
-      ...(liveTerminal ? { liveTerminal } : {}),
-    }
-  }
-
-  if (liveTerminal) {
-    return {
-      kind: 'proof_failed_attach_live_candidate',
-      candidate,
-      proof,
-      liveTerminal,
-    }
-  }
-
-  return {
-    kind: 'proof_failed_fresh_create',
-    candidate,
-    proof,
-    clearCodexDurability: true,
-    restoreError: buildRestoreError('durable_artifact_missing'),
-  }
+  return planCodexCreateRestoreDecision(input)
 }
 
 function isCodexSessionRef(value: SessionRef | undefined): value is SessionRef & { provider: 'codex' } {
@@ -163,10 +82,6 @@ function isCodexSessionRef(value: SessionRef | undefined): value is SessionRef &
 
 function hasRawLegacyResume(value: string | undefined): boolean {
   return typeof value === 'string' && value.length > 0
-}
-
-function getDurableCodexSessionId(value: CodexDurabilityRef | undefined): string | undefined {
-  return value?.state === 'durable' ? value.durableThreadId : undefined
 }
 
 export function isExactLiveCodexCandidate(

--- a/server/mcp/freshell-tool.ts
+++ b/server/mcp/freshell-tool.ts
@@ -264,14 +264,14 @@ const ACTION_PARAMS: Record<string, { required: string[]; optional: string[] }> 
   'resize-pane':     { required: ['target'],                  optional: ['x', 'y', 'sizes'] },
   'swap-pane':       { required: ['target', 'with'],          optional: [] },
   'respawn-pane':    { required: ['target'],                  optional: ['mode', 'shell', 'cwd', 'resume', 'sessionRef'] },
-  'send-keys':       { required: [],                          optional: ['target', 'keys', 'literal'] },
+  'send-keys':       { required: [],                          optional: ['target', 'keys', 'literal', 'sessionRef'] },
   'capture-pane':    { required: [],                          optional: ['target', 'S', 'J', 'e'] },
   'wait-for':        { required: [],                          optional: ['target', 'pattern', 'stable', 'exit', 'prompt', 'timeout'] },
   'run':             { required: ['command'],                 optional: ['capture', 'detached', 'timeout', 'name', 'cwd'] },
   'summarize':       { required: [],                          optional: ['target'] },
   'display':         { required: [],                          optional: ['target', 'format'] },
   'list-terminals':  { required: [],                          optional: [] },
-  'attach':          { required: ['target', 'terminalId'],    optional: [] },
+  'attach':          { required: ['target', 'terminalId'],    optional: ['sessionRef'] },
   'open-browser':    { required: ['url'],                     optional: ['name'] },
   'navigate':        { required: ['target', 'url'],           optional: [] },
   'screenshot':      { required: ['scope'],                   optional: ['target', 'name'] },
@@ -389,7 +389,7 @@ Pane commands:
   respawn-pane    Restart a pane's terminal. Params: target, mode?, shell?, cwd?, resume?, sessionRef?
 
 Terminal I/O:
-  send-keys       Send input to a pane. Params: target, keys, literal?
+  send-keys       Send input to a pane. Params: target, keys, literal?, sessionRef?
                   Token mode (default): keys=["ls","ENTER"] translates ENTER to \\r, C-C to Ctrl-C, etc.
                   Literal mode: keys="your prompt text here", literal=true sends raw string.
                   IMPORTANT: Always use literal mode for natural-language prompts or multi-word text.
@@ -403,7 +403,7 @@ Terminal I/O:
   summarize       Get AI summary of a terminal. Params: target (pane ID)
   display         Format info about a pane. Params: target?, format (#S=tab name, #P=pane ID, #I=tab ID, #{pane_index}, #{terminal_id}, #{pane_type})
   list-terminals  List all terminal processes.
-  attach          Attach a terminal to a pane. Params: target (pane ID), terminalId
+  attach          Attach a terminal to a pane. Params: target (pane ID), terminalId, sessionRef?
 
 Browser/navigation:
   open-browser    Open a URL in a new browser tab to display web pages or images.
@@ -713,6 +713,7 @@ async function routeAction(
       const paneId = resolved.pane.id
       const keys = params?.keys
       const literal = params?.literal
+      const sessionRef = params?.sessionRef
       let data: string
       if (literal && typeof keys === 'string') {
         // Literal mode: send raw string
@@ -726,7 +727,10 @@ async function routeAction(
       } else {
         throw new MissingParamError('keys')
       }
-      return c.post(`/api/panes/${encodeURIComponent(paneId)}/send-keys`, { data })
+      return c.post(`/api/panes/${encodeURIComponent(paneId)}/send-keys`, {
+        data,
+        ...(sessionRef ? { sessionRef } : {}),
+      })
     }
     case 'capture-pane': {
       const rawTarget = params?.target as string | undefined
@@ -782,7 +786,11 @@ async function routeAction(
     case 'attach': {
       const target = requireParam(params, 'target')
       const terminalId = requireParam(params, 'terminalId')
-      return c.post(`/api/panes/${encodeURIComponent(target)}/attach`, { terminalId })
+      const sessionRef = params?.sessionRef
+      return c.post(`/api/panes/${encodeURIComponent(target)}/attach`, {
+        terminalId,
+        ...(sessionRef ? { sessionRef } : {}),
+      })
     }
 
     // -- Browser --

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -46,6 +46,10 @@ import type { CodexRemoteProxyCandidate } from './coding-cli/codex-app-server/re
 import type { CodexTurnEvent } from './coding-cli/codex-app-server/client.js'
 import { collectShutdownFailures, throwShutdownFailures } from './shutdown-join.js'
 import { recordSessionLifecycleEvent } from './session-observability.js'
+import {
+  buildSessionIdentityMismatchDetails,
+  terminalMatchesExpectedSession,
+} from './terminal-session-identity.js'
 
 const MAX_WS_BUFFERED_AMOUNT = Number(process.env.MAX_WS_BUFFERED_AMOUNT || 2 * 1024 * 1024)
 const DEFAULT_MAX_SCROLLBACK_CHARS = Number(process.env.MAX_SCROLLBACK_CHARS || 512 * 1024)
@@ -605,6 +609,12 @@ export type TerminalRecord = {
 
 export type TerminalInputResult =
   | { status: 'written' }
+  | {
+    status: 'session_identity_mismatch'
+    terminalId: string
+    expectedSessionRef: SessionLocator
+    actualSessionRef?: SessionLocator
+  }
   | { status: 'blocked_codex_identity_pending'; terminalId: string }
   | { status: 'blocked_codex_identity_capture_timeout'; terminalId: string }
   | { status: 'blocked_codex_identity_unavailable'; terminalId: string; reason?: string }
@@ -613,6 +623,16 @@ export type TerminalInputResult =
   | { status: 'blocked_codex_lifecycle_loss_pending'; terminalId: string }
   | { status: 'no_terminal' }
   | { status: 'not_running' }
+
+export type TerminalResizeResult =
+  | { status: 'resized' | 'unchanged' }
+  | {
+    status: 'session_identity_mismatch'
+    terminalId: string
+    expectedSessionRef: SessionLocator
+    actualSessionRef?: SessionLocator
+  }
+  | { status: 'missing' | 'not_running' }
 
 function isCodexStartupTerminalControlInput(data: string): boolean {
   if (data.length === 0 || data.length > 128) return false
@@ -3088,9 +3108,34 @@ export class TerminalRegistry extends EventEmitter {
     return true
   }
 
+  private buildSessionIdentityMismatchResult(
+    term: TerminalRecord,
+    expectedSessionRef: SessionLocator | undefined,
+  ): Extract<TerminalInputResult, { status: 'session_identity_mismatch' }> | undefined {
+    if (!expectedSessionRef || terminalMatchesExpectedSession(term, expectedSessionRef)) {
+      return undefined
+    }
+    return {
+      status: 'session_identity_mismatch',
+      terminalId: term.terminalId,
+      expectedSessionRef,
+      ...buildSessionIdentityMismatchDetails(term, expectedSessionRef),
+    }
+  }
+
   input(terminalId: string, data: string): TerminalInputResult {
+    return this.inputIfSessionMatches(terminalId, data)
+  }
+
+  inputIfSessionMatches(
+    terminalId: string,
+    data: string,
+    expectedSessionRef?: SessionLocator,
+  ): TerminalInputResult {
     const term = this.terminals.get(terminalId)
     if (!term) return { status: 'no_terminal' }
+    const mismatch = this.buildSessionIdentityMismatchResult(term, expectedSessionRef)
+    if (mismatch) return mismatch
     if (
       term.mode === 'codex'
       && term.codexDurability?.state === 'non_restorable'
@@ -3173,9 +3218,22 @@ export class TerminalRegistry extends EventEmitter {
   }
 
   resize(terminalId: string, cols: number, rows: number): boolean {
+    const result = this.resizeIfSessionMatches(terminalId, cols, rows)
+    return result.status === 'resized' || result.status === 'unchanged'
+  }
+
+  resizeIfSessionMatches(
+    terminalId: string,
+    cols: number,
+    rows: number,
+    expectedSessionRef?: SessionLocator,
+  ): TerminalResizeResult {
     const term = this.terminals.get(terminalId)
-    if (!term || term.status !== 'running') return false
-    if (term.cols === cols && term.rows === rows) return true
+    if (!term) return { status: 'missing' }
+    const mismatch = this.buildSessionIdentityMismatchResult(term, expectedSessionRef)
+    if (mismatch) return mismatch
+    if (term.status !== 'running') return { status: 'not_running' }
+    if (term.cols === cols && term.rows === rows) return { status: 'unchanged' }
     term.cols = cols
     term.rows = rows
     try {
@@ -3183,7 +3241,7 @@ export class TerminalRegistry extends EventEmitter {
     } catch (err) {
       logger.debug({ err, terminalId }, 'resize failed')
     }
-    return true
+    return { status: 'resized' }
   }
 
   kill(terminalId: string): boolean {

--- a/server/terminal-session-identity.ts
+++ b/server/terminal-session-identity.ts
@@ -1,0 +1,35 @@
+import type { SessionLocator } from '../shared/ws-protocol.js'
+import { buildTerminalSessionRef, type TerminalRecord } from './terminal-registry.js'
+
+type TerminalSessionIdentityRecord = Pick<TerminalRecord, 'mode' | 'resumeSessionId' | 'codexDurability'>
+
+export type SessionIdentityMismatchDetails = {
+  expectedSessionRef?: SessionLocator
+  actualSessionRef?: SessionLocator
+}
+
+export function canonicalActualSessionRef(
+  record: TerminalSessionIdentityRecord,
+): SessionLocator | undefined {
+  return buildTerminalSessionRef(record)
+}
+
+export function terminalMatchesExpectedSession(
+  record: TerminalSessionIdentityRecord,
+  expectedSessionRef: SessionLocator | undefined,
+): boolean {
+  if (!expectedSessionRef) return true
+  const actualSessionRef = canonicalActualSessionRef(record)
+  return actualSessionRef?.provider === expectedSessionRef.provider
+    && actualSessionRef.sessionId === expectedSessionRef.sessionId
+}
+
+export function buildSessionIdentityMismatchDetails(
+  record: TerminalSessionIdentityRecord,
+  expectedSessionRef: SessionLocator | undefined,
+): SessionIdentityMismatchDetails {
+  return {
+    ...(expectedSessionRef ? { expectedSessionRef } : {}),
+    ...(canonicalActualSessionRef(record) ? { actualSessionRef: canonicalActualSessionRef(record) } : {}),
+  }
+}

--- a/server/terminal-session-identity.ts
+++ b/server/terminal-session-identity.ts
@@ -28,8 +28,9 @@ export function buildSessionIdentityMismatchDetails(
   record: TerminalSessionIdentityRecord,
   expectedSessionRef: SessionLocator | undefined,
 ): SessionIdentityMismatchDetails {
+  const actualSessionRef = canonicalActualSessionRef(record)
   return {
     ...(expectedSessionRef ? { expectedSessionRef } : {}),
-    ...(canonicalActualSessionRef(record) ? { actualSessionRef: canonicalActualSessionRef(record) } : {}),
+    ...(actualSessionRef ? { actualSessionRef } : {}),
   }
 }

--- a/server/terminal-stream/broker.ts
+++ b/server/terminal-stream/broker.ts
@@ -124,6 +124,19 @@ type PerfEventLogger = (
   context: Record<string, unknown>,
   level?: PerfLevel,
 ) => void
+type AttachRequest = {
+  ws: LiveWebSocket
+  terminalId: string
+  intent: AttachIntent
+  cols: number
+  rows: number
+  sinceSeq: number | undefined
+  expectedSessionRef?: SessionLocator
+  attachRequestId?: string
+  maxReplayBytes?: number
+  priority: AttachPriority
+  terminalOutputBatchV1: boolean
+}
 type ReplayGapReason = 'replay_window_exceeded' | 'replay_budget_exceeded' | 'queue_overflow'
 type ReplayBackpressurePayloadFields = {
   seqStart?: number
@@ -249,38 +262,66 @@ export class TerminalStreamBroker {
     cols: number,
     rows: number,
     sinceSeq: number | undefined,
-    expectedSessionRefOrAttachRequestId?: SessionLocator | string,
-    attachRequestIdOrMaxReplayBytes?: string | number,
-    maxReplayBytesOrPriority?: number | AttachPriority,
-    priorityOrTerminalOutputBatchV1: AttachPriority | boolean = 'foreground',
+    attachRequestId?: string,
+    maxReplayBytes?: number,
+    priority: AttachPriority = 'foreground',
     terminalOutputBatchV1 = false,
   ): Promise<AttachResult> {
-    const totalArgs = arguments.length
-    const usesExplicitExpectedSessionRef = Boolean(
-      expectedSessionRefOrAttachRequestId
-      && typeof expectedSessionRefOrAttachRequestId === 'object'
-      && 'provider' in expectedSessionRefOrAttachRequestId
-      && 'sessionId' in expectedSessionRefOrAttachRequestId
-    )
-    const usesNewSignature = usesExplicitExpectedSessionRef || totalArgs >= 11
-    const expectedSessionRef = usesExplicitExpectedSessionRef
-      ? expectedSessionRefOrAttachRequestId as SessionLocator
-      : undefined
-    const attachRequestId = usesNewSignature
-      ? (typeof attachRequestIdOrMaxReplayBytes === 'string' ? attachRequestIdOrMaxReplayBytes : undefined)
-      : (typeof expectedSessionRefOrAttachRequestId === 'string' ? expectedSessionRefOrAttachRequestId : undefined)
-    const maxReplayBytes = usesNewSignature
-      ? (typeof maxReplayBytesOrPriority === 'number' ? maxReplayBytesOrPriority : undefined)
-      : (typeof attachRequestIdOrMaxReplayBytes === 'number' ? attachRequestIdOrMaxReplayBytes : undefined)
-    const priority = (
-      usesNewSignature
-        ? (typeof priorityOrTerminalOutputBatchV1 === 'string' ? priorityOrTerminalOutputBatchV1 : 'foreground')
-        : (typeof maxReplayBytesOrPriority === 'string' ? maxReplayBytesOrPriority : 'foreground')
-    ) as AttachPriority
-    const batchV1 = usesNewSignature
-      ? terminalOutputBatchV1
-      : (typeof priorityOrTerminalOutputBatchV1 === 'boolean' ? priorityOrTerminalOutputBatchV1 : false)
+    return this.attachInternal({
+      ws,
+      terminalId,
+      intent,
+      cols,
+      rows,
+      sinceSeq,
+      attachRequestId,
+      maxReplayBytes,
+      priority,
+      terminalOutputBatchV1,
+    })
+  }
 
+  async attachWithExpectedSession(
+    ws: LiveWebSocket,
+    terminalId: string,
+    intent: AttachIntent,
+    cols: number,
+    rows: number,
+    sinceSeq: number | undefined,
+    expectedSessionRef: SessionLocator | undefined,
+    attachRequestId?: string,
+    maxReplayBytes?: number,
+    priority: AttachPriority = 'foreground',
+    terminalOutputBatchV1 = false,
+  ): Promise<AttachResult> {
+    return this.attachInternal({
+      ws,
+      terminalId,
+      intent,
+      cols,
+      rows,
+      sinceSeq,
+      expectedSessionRef,
+      attachRequestId,
+      maxReplayBytes,
+      priority,
+      terminalOutputBatchV1,
+    })
+  }
+
+  private async attachInternal({
+    ws,
+    terminalId,
+    intent,
+    cols,
+    rows,
+    sinceSeq,
+    expectedSessionRef,
+    attachRequestId,
+    maxReplayBytes,
+    priority,
+    terminalOutputBatchV1,
+  }: AttachRequest): Promise<AttachResult> {
     if (!isTerminalStreamAttachRequestIdWithinSerializedBudget(attachRequestId)) {
       return 'invalid_attach_request_id'
     }
@@ -355,7 +396,7 @@ export class TerminalStreamBroker {
       }
 
       const attachment = existingAttachment ?? this.getOrCreateAttachment(terminalState, ws, terminalId)
-      attachment.terminalOutputBatchV1 = batchV1
+      attachment.terminalOutputBatchV1 = terminalOutputBatchV1
 
       if (attachment.flushTimer) {
         clearTimeout(attachment.flushTimer)

--- a/server/terminal-stream/broker.ts
+++ b/server/terminal-stream/broker.ts
@@ -249,12 +249,38 @@ export class TerminalStreamBroker {
     cols: number,
     rows: number,
     sinceSeq: number | undefined,
-    expectedSessionRef: SessionLocator | undefined,
-    attachRequestId?: string,
-    maxReplayBytes?: number,
-    priority: AttachPriority = 'foreground',
+    expectedSessionRefOrAttachRequestId?: SessionLocator | string,
+    attachRequestIdOrMaxReplayBytes?: string | number,
+    maxReplayBytesOrPriority?: number | AttachPriority,
+    priorityOrTerminalOutputBatchV1: AttachPriority | boolean = 'foreground',
     terminalOutputBatchV1 = false,
   ): Promise<AttachResult> {
+    const totalArgs = arguments.length
+    const usesExplicitExpectedSessionRef = Boolean(
+      expectedSessionRefOrAttachRequestId
+      && typeof expectedSessionRefOrAttachRequestId === 'object'
+      && 'provider' in expectedSessionRefOrAttachRequestId
+      && 'sessionId' in expectedSessionRefOrAttachRequestId
+    )
+    const usesNewSignature = usesExplicitExpectedSessionRef || totalArgs >= 11
+    const expectedSessionRef = usesExplicitExpectedSessionRef
+      ? expectedSessionRefOrAttachRequestId as SessionLocator
+      : undefined
+    const attachRequestId = usesNewSignature
+      ? (typeof attachRequestIdOrMaxReplayBytes === 'string' ? attachRequestIdOrMaxReplayBytes : undefined)
+      : (typeof expectedSessionRefOrAttachRequestId === 'string' ? expectedSessionRefOrAttachRequestId : undefined)
+    const maxReplayBytes = usesNewSignature
+      ? (typeof maxReplayBytesOrPriority === 'number' ? maxReplayBytesOrPriority : undefined)
+      : (typeof attachRequestIdOrMaxReplayBytes === 'number' ? attachRequestIdOrMaxReplayBytes : undefined)
+    const priority = (
+      usesNewSignature
+        ? (typeof priorityOrTerminalOutputBatchV1 === 'string' ? priorityOrTerminalOutputBatchV1 : 'foreground')
+        : (typeof maxReplayBytesOrPriority === 'string' ? maxReplayBytesOrPriority : 'foreground')
+    ) as AttachPriority
+    const batchV1 = usesNewSignature
+      ? terminalOutputBatchV1
+      : (typeof priorityOrTerminalOutputBatchV1 === 'boolean' ? priorityOrTerminalOutputBatchV1 : false)
+
     if (!isTerminalStreamAttachRequestIdWithinSerializedBudget(attachRequestId)) {
       return 'invalid_attach_request_id'
     }
@@ -329,7 +355,7 @@ export class TerminalStreamBroker {
       }
 
       const attachment = existingAttachment ?? this.getOrCreateAttachment(terminalState, ws, terminalId)
-      attachment.terminalOutputBatchV1 = terminalOutputBatchV1
+      attachment.terminalOutputBatchV1 = batchV1
 
       if (attachment.flushTimer) {
         clearTimeout(attachment.flushTimer)

--- a/server/terminal-stream/broker.ts
+++ b/server/terminal-stream/broker.ts
@@ -1,6 +1,11 @@
 import WebSocket from 'ws'
 import type { LiveWebSocket } from '../ws-handler.js'
 import { buildTerminalSessionRef, type TerminalRegistry } from '../terminal-registry.js'
+import type { SessionLocator } from '../../shared/ws-protocol.js'
+import {
+  buildSessionIdentityMismatchDetails,
+  terminalMatchesExpectedSession,
+} from '../terminal-session-identity.js'
 import { logger } from '../logger.js'
 import { logTerminalStreamPerfEvent, type TerminalStreamPerfEvent } from '../perf-logger.js'
 import type { TerminalOutputRawEvent } from './registry-events.js'
@@ -95,6 +100,15 @@ const TERMINAL_REPLAY_RETENTION_LOG_RATE_LIMIT_MS = Math.max(
 type PerfLevel = 'debug' | 'info' | 'warn' | 'error'
 type AttachIntent = 'viewport_hydrate' | 'keepalive_delta' | 'transport_reconnect'
 type AttachPriority = 'foreground' | 'background'
+type AttachResult =
+  | 'attached'
+  | 'duplicate'
+  | 'missing'
+  | 'invalid_attach_request_id'
+  | {
+    status: 'session_identity_mismatch'
+    actualSessionRef?: SessionLocator
+  }
 type ReplayGapRange = {
   fromSeq: number
   toSeq: number
@@ -235,19 +249,28 @@ export class TerminalStreamBroker {
     cols: number,
     rows: number,
     sinceSeq: number | undefined,
+    expectedSessionRef: SessionLocator | undefined,
     attachRequestId?: string,
     maxReplayBytes?: number,
     priority: AttachPriority = 'foreground',
     terminalOutputBatchV1 = false,
-  ): Promise<'attached' | 'duplicate' | 'missing' | 'invalid_attach_request_id'> {
+  ): Promise<AttachResult> {
     if (!isTerminalStreamAttachRequestIdWithinSerializedBudget(attachRequestId)) {
       return 'invalid_attach_request_id'
     }
 
     const normalizedSinceSeq = sinceSeq === undefined || sinceSeq === 0 ? 0 : sinceSeq
-    let result: 'attached' | 'duplicate' | 'missing' | 'invalid_attach_request_id' = 'attached'
+    let result: AttachResult = 'attached'
 
     await this.withTerminalLock(terminalId, async () => {
+      const currentRecord = this.registry.get(terminalId)
+      if (currentRecord && expectedSessionRef && !terminalMatchesExpectedSession(currentRecord, expectedSessionRef)) {
+        result = {
+          status: 'session_identity_mismatch',
+          actualSessionRef: buildSessionIdentityMismatchDetails(currentRecord, expectedSessionRef).actualSessionRef,
+        }
+        return
+      }
       const existingState = this.terminals.get(terminalId)
       const existingAttachment = existingState?.clients.get(ws)
       if (attachRequestId && existingAttachment?.activeAttachRequestId === attachRequestId) {
@@ -272,7 +295,24 @@ export class TerminalStreamBroker {
         )
 
       const terminalState = existingState ?? this.getOrCreateTerminalState(terminalId)
-      if (shouldResize && !this.registry.resize(terminalId, cols, rows)) {
+      const resizeResult = shouldResize
+        ? (
+          typeof (this.registry as { resizeIfSessionMatches?: unknown }).resizeIfSessionMatches === 'function'
+            ? this.registry.resizeIfSessionMatches(terminalId, cols, rows, expectedSessionRef)
+            : (this.registry.resize(terminalId, cols, rows)
+                ? { status: 'resized' as const }
+                : { status: 'missing' as const })
+        )
+        : { status: 'unchanged' as const }
+      if (resizeResult.status === 'session_identity_mismatch') {
+        this.registry.detach(terminalId, ws)
+        result = {
+          status: 'session_identity_mismatch',
+          actualSessionRef: resizeResult.actualSessionRef,
+        }
+        return
+      }
+      if (shouldResize && resizeResult.status !== 'resized' && resizeResult.status !== 'unchanged') {
         this.registry.detach(terminalId, ws)
         result = 'missing'
         return
@@ -320,6 +360,16 @@ export class TerminalStreamBroker {
         ? 'geometry_authority_unknown' as const
         : undefined
       const effectiveSinceSeq = replayResetReason ? 0 : normalizedSinceSeq
+
+      const replayRecord = this.registry.get(terminalId)
+      if (replayRecord && expectedSessionRef && !terminalMatchesExpectedSession(replayRecord, expectedSessionRef)) {
+        this.registry.detach(terminalId, ws)
+        result = {
+          status: 'session_identity_mismatch',
+          actualSessionRef: buildSessionIdentityMismatchDetails(replayRecord, expectedSessionRef).actualSessionRef,
+        }
+        return
+      }
 
       const replay = terminalState.replayRing.replaySince(effectiveSinceSeq)
       let replayFrames = replay.frames

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -2424,19 +2424,59 @@ export class WsHandler {
           return
         }
 
-        const attachResult = await this.terminalStreamBroker.attach(
-          ws,
-          m.terminalId,
-          m.intent,
-          m.cols,
-          m.rows,
-          m.sinceSeq,
-          expectedSessionRef,
-          m.attachRequestId,
-          m.maxReplayBytes,
-          m.priority ?? 'foreground',
-          state.supportsTerminalOutputBatchV1,
-        )
+        const attachBroker = this.terminalStreamBroker as {
+          attach: (
+            ws: LiveWebSocket,
+            terminalId: string,
+            intent: 'viewport_hydrate' | 'keepalive_delta' | 'transport_reconnect',
+            cols: number,
+            rows: number,
+            sinceSeq: number | undefined,
+            attachRequestId?: string,
+            maxReplayBytes?: number,
+            priority?: 'foreground' | 'background',
+            terminalOutputBatchV1?: boolean,
+          ) => Promise<any>
+          attachWithExpectedSession?: (
+            ws: LiveWebSocket,
+            terminalId: string,
+            intent: 'viewport_hydrate' | 'keepalive_delta' | 'transport_reconnect',
+            cols: number,
+            rows: number,
+            sinceSeq: number | undefined,
+            expectedSessionRef: { provider: string; sessionId: string } | undefined,
+            attachRequestId?: string,
+            maxReplayBytes?: number,
+            priority?: 'foreground' | 'background',
+            terminalOutputBatchV1?: boolean,
+          ) => Promise<any>
+        }
+        const attachResult = typeof attachBroker.attachWithExpectedSession === 'function'
+          ? await attachBroker.attachWithExpectedSession(
+            ws,
+            m.terminalId,
+            m.intent,
+            m.cols,
+            m.rows,
+            m.sinceSeq,
+            expectedSessionRef,
+            m.attachRequestId,
+            m.maxReplayBytes,
+            m.priority ?? 'foreground',
+            state.supportsTerminalOutputBatchV1,
+          )
+          : await attachBroker.attach(
+            ws,
+            m.terminalId,
+            m.intent,
+            m.cols,
+            m.rows,
+            m.sinceSeq,
+            m.attachRequestId,
+            m.maxReplayBytes,
+            m.priority ?? 'foreground',
+            state.supportsTerminalOutputBatchV1,
+          )
         if (attachResult === 'invalid_attach_request_id') {
           this.sendError(ws, {
             code: 'INVALID_MESSAGE',

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -10,7 +10,7 @@ import { buildTerminalSessionRef, modeSupportsResume, terminalIdFromCreateError 
 import type { TerminalRecord, TerminalRegistry, TerminalMode } from './terminal-registry.js'
 import { configStore, type ConfigReadError, type UserConfig } from './config-store.js'
 import type { CodingCliSessionManager } from './coding-cli/session-manager.js'
-import type { ProjectGroup } from './coding-cli/types.js'
+import { makeSessionKey, type CodingCliProviderName, type ProjectGroup } from './coding-cli/types.js'
 import type { TerminalMeta } from './terminal-metadata-service.js'
 import type { SessionRepairService } from './session-scanner/service.js'
 import type { SessionScanResult, SessionRepairResult } from './session-scanner/types.js'
@@ -97,6 +97,10 @@ import {
 } from './coding-cli/codex-app-server/restore-decision.js'
 import { sendJsonMessage } from './ws-send.js'
 import {
+  buildSessionIdentityMismatchDetails,
+  terminalMatchesExpectedSession,
+} from './terminal-session-identity.js'
+import {
   makeFreshAgentProviderErrorEvent,
   normalizeFreshAgentProviderEvent,
 } from './fresh-agent/sdk-events.js'
@@ -162,6 +166,11 @@ type WsErrorLogEntry = {
   suppressedCount: number
   firstRequestId?: string
   lastRequestId?: string
+}
+
+type CreatedTerminalRequestBinding = {
+  terminalId: string
+  expectedSessionKey?: string
 }
 
 export type WsHandlerOptions = {
@@ -428,7 +437,7 @@ type ClientState = {
   supportsUiScreenshotV1: boolean
   supportsTerminalOutputBatchV1: boolean
   attachedTerminalIds: Set<string>
-  createdByRequestId: Map<string, string>
+  createdByRequestId: Map<string, CreatedTerminalRequestBinding | typeof REPAIR_PENDING_SENTINEL>
   claudeFreshSessionIdByRequestId: Map<string, string>
   terminalCreateTimestamps: number[]
   codingCliSessions: Set<string>
@@ -502,7 +511,10 @@ export class WsHandler {
   private freshAgentRuntimeManager?: FreshAgentRuntimeManagerLike
   private terminalStreamBroker: TerminalStreamBroker
   private terminalCreateLocks = new Map<string, Promise<void>>()
-  private createdTerminalByRequestId = new Map<string, string>()
+  private createdTerminalByRequestId = new Map<string, CreatedTerminalRequestBinding>()
+  private sdkCreateLocks = new Map<string, Promise<void>>()
+  private createdSdkSessionByRequestId = new Map<string, string>()
+  private sdkSessionByCreateOwnerKey = new Map<string, string>()
   private freshAgentCreateLocks = new Map<string, Promise<void>>()
   private createdFreshAgentByRequestId = new Map<string, FreshAgentCreatedRecord>()
   private screenshotRequests = new Map<string, PendingScreenshot>()
@@ -786,8 +798,15 @@ export class WsHandler {
     return this.connections.size
   }
 
-  private rememberCreatedRequestId(requestId: string, terminalId: string): void {
-    this.createdTerminalByRequestId.set(requestId, terminalId)
+  private rememberCreatedRequestId(
+    requestId: string,
+    terminalId: string,
+    expectedSessionKey?: string,
+  ): void {
+    this.createdTerminalByRequestId.set(requestId, {
+      terminalId,
+      ...(expectedSessionKey ? { expectedSessionKey } : {}),
+    })
   }
 
   private forgetCreatedRequestId(requestId: string): void {
@@ -795,22 +814,69 @@ export class WsHandler {
   }
 
   private forgetCreatedRequestIdsForTerminal(terminalId: string): void {
-    for (const [requestId, cachedTerminalId] of this.createdTerminalByRequestId) {
-      if (cachedTerminalId === terminalId) {
+    for (const [requestId, binding] of this.createdTerminalByRequestId) {
+      if (binding.terminalId === terminalId) {
         this.createdTerminalByRequestId.delete(requestId)
       }
     }
   }
 
-  private resolveCreatedTerminalId(requestId: string): string | undefined {
+  private createdRequestBindingMatchesExpectedSession(
+    binding: CreatedTerminalRequestBinding,
+    expectedSessionKey: string | undefined,
+  ): boolean {
+    return binding.expectedSessionKey === expectedSessionKey
+  }
+
+  private resolveCreatedTerminalBinding(
+    requestId: string,
+    expectedSessionKey: string | undefined,
+  ): CreatedTerminalRequestBinding | undefined {
     const cached = this.createdTerminalByRequestId.get(requestId)
-    if (!cached) return undefined
-    const record = this.registry.get(cached)
+    if (!cached || !this.createdRequestBindingMatchesExpectedSession(cached, expectedSessionKey)) {
+      return undefined
+    }
+    const record = this.registry.get(cached.terminalId)
     if (!record) {
       this.createdTerminalByRequestId.delete(requestId)
       return undefined
     }
     return cached
+  }
+
+  private expectedSessionKey(expectedSessionRef: { provider: string; sessionId: string } | undefined): string | undefined {
+    if (!expectedSessionRef) return undefined
+    return makeSessionKey(expectedSessionRef.provider as CodingCliProviderName, expectedSessionRef.sessionId)
+  }
+
+  private sendSessionIdentityMismatch(
+    ws: LiveWebSocket,
+    params: {
+      operation: 'terminal.attach' | 'terminal.input' | 'terminal.resize'
+      requestId?: string
+      terminalId: string
+      expectedSessionRef: { provider: string; sessionId: string }
+      record: Pick<TerminalRecord, 'mode' | 'resumeSessionId' | 'codexDurability'>
+      attemptedInputBytes?: number
+    },
+  ): void {
+    const details = buildSessionIdentityMismatchDetails(params.record, params.expectedSessionRef)
+    log.warn({
+      connectionId: ws.connectionId,
+      terminalId: params.terminalId,
+      operation: params.operation,
+      expectedSessionRef: details.expectedSessionRef,
+      actualSessionRef: details.actualSessionRef,
+      ...(params.attemptedInputBytes !== undefined ? { attemptedInputBytes: params.attemptedInputBytes } : {}),
+    }, 'Terminal operation rejected due to canonical session identity mismatch')
+    this.sendError(ws, {
+      code: 'SESSION_IDENTITY_MISMATCH',
+      message: 'Terminal session does not match the expected session.',
+      requestId: params.requestId,
+      terminalId: params.terminalId,
+      expectedSessionRef: details.expectedSessionRef,
+      actualSessionRef: details.actualSessionRef,
+    })
   }
 
   private async planCodexLaunch(
@@ -1350,7 +1416,14 @@ export class WsHandler {
 
   private sendError(
     ws: LiveWebSocket,
-    params: { code: z.infer<typeof ErrorCode>; message: string; requestId?: string; terminalId?: string }
+    params: {
+      code: z.infer<typeof ErrorCode>
+      message: string
+      requestId?: string
+      terminalId?: string
+      expectedSessionRef?: { provider: string; sessionId: string }
+      actualSessionRef?: { provider: string; sessionId: string }
+    },
   ) {
     this.recordWsErrorLog(ws, params)
     this.send(ws, {
@@ -1359,6 +1432,8 @@ export class WsHandler {
       message: params.message,
       requestId: params.requestId,
       terminalId: params.terminalId,
+      expectedSessionRef: params.expectedSessionRef,
+      actualSessionRef: params.actualSessionRef,
       timestamp: nowIso(),
     })
   }
@@ -1677,6 +1752,10 @@ export class WsHandler {
         let error = false
         let rateLimited = false
         const requestedSessionRef = normalizeUiSessionLocator(m.sessionRef)
+        const expectedSessionRef = requestedSessionRef && requestedSessionRef.provider === m.mode
+          ? requestedSessionRef
+          : undefined
+        const expectedSessionKey = this.expectedSessionKey(expectedSessionRef)
         if (
           m.recoveryIntent === 'fresh_after_restore_unavailable'
           && (
@@ -1697,49 +1776,22 @@ export class WsHandler {
           return
         }
         const hasReusableRequestedLiveTerminal = Boolean(
-          m.liveTerminal?.serverInstanceId === this.serverInstanceId
+          (m.mode !== 'codex' || expectedSessionRef)
+          && m.liveTerminal?.serverInstanceId === this.serverInstanceId
             && m.liveTerminal.terminalId
             && (() => {
               const live = this.registry.get(m.liveTerminal.terminalId)
               return live && live.status === 'running' && live.mode === m.mode
             })(),
         )
-        let codexDurabilityForDecision = m.codexDurability
-        let codexDurabilityStoreRecordTerminalId: string | undefined
-        if (m.mode === 'codex' && m.restore === true && !requestedSessionRef && !codexDurabilityForDecision) {
-          try {
-            const restoreRecord = await this.registry.readCodexDurabilityRecordForRestoreLocator({
-              ...(m.liveTerminal?.terminalId ? { terminalId: m.liveTerminal.terminalId } : {}),
-              ...(m.tabId ? { tabId: m.tabId } : {}),
-              ...(m.paneId ? { paneId: m.paneId } : {}),
-              ...(m.liveTerminal?.serverInstanceId ? { serverInstanceId: m.liveTerminal.serverInstanceId } : {}),
-            })
-            codexDurabilityForDecision = restoreRecord?.durability
-            codexDurabilityStoreRecordTerminalId = restoreRecord?.terminalId
-          } catch (err) {
-            error = true
-            log.warn({
-              err,
-              requestId: m.requestId,
-              connectionId: ws.connectionId,
-              tabId: m.tabId,
-              paneId: m.paneId,
-              terminalId: m.liveTerminal?.terminalId,
-            }, 'Failed to resolve Codex durability record for restore locator')
-            this.sendError(ws, {
-              code: 'RESTORE_UNAVAILABLE',
-              message: 'Codex restore identity is ambiguous or unavailable.',
-              requestId: m.requestId,
-            })
-            endCreateTimer({ error, rateLimited })
-            return
-          }
-        }
+        const codexDurabilityForDecision = m.mode === 'codex' && expectedSessionRef
+          ? m.codexDurability
+          : undefined
         const codexRestorePlan = m.mode === 'codex'
           ? planCodexCreateRestoreDecision({
             restoreRequested: m.restore === true,
             legacyResumeSessionId: m.resumeSessionId,
-            sessionRef: requestedSessionRef,
+            sessionRef: expectedSessionRef,
             codexDurability: codexDurabilityForDecision,
           })
           : undefined
@@ -1785,7 +1837,6 @@ export class WsHandler {
           endCreateTimer({ error, rateLimited })
           return
         }
-        const hasCodexCapturedRestoreState = codexRestorePlan?.kind === 'proof_existing_candidate_first'
         if (
           m.restore === true
           && modeSupportsResume(m.mode as TerminalMode)
@@ -1806,7 +1857,6 @@ export class WsHandler {
         if (
           m.restore === true
           && modeSupportsResume(m.mode as TerminalMode)
-          && !hasCodexCapturedRestoreState
           && !hasReusableRequestedLiveTerminal
           && (
             !requestedSessionRef
@@ -1838,11 +1888,13 @@ export class WsHandler {
           await this.withTerminalCreateLock(
             this.terminalCreateLockKey(m.mode as TerminalMode, m.requestId, effectiveResumeSessionId),
             async () => {
-              const resolveExistingRequestTerminalId = (requestId: string): string | undefined => {
+              const resolveExistingRequestBinding = (
+                requestId: string,
+              ): CreatedTerminalRequestBinding | typeof REPAIR_PENDING_SENTINEL | undefined => {
                 const local = state.createdByRequestId.get(requestId)
                 if (local === REPAIR_PENDING_SENTINEL) return REPAIR_PENDING_SENTINEL
-                if (local) return local
-                const cached = this.resolveCreatedTerminalId(requestId)
+                if (local) return this.createdRequestBindingMatchesExpectedSession(local, expectedSessionKey) ? local : undefined
+                const cached = this.resolveCreatedTerminalBinding(requestId, expectedSessionKey)
                 if (cached) {
                   state.createdByRequestId.set(requestId, cached)
                 }
@@ -1876,7 +1928,34 @@ export class WsHandler {
 
               const attachReusedTerminal = async (
                 record: TerminalRecord,
+                opts: { reuseSource: string; allowCodexWithoutExpectedSession?: boolean },
               ): Promise<boolean> => {
+                if (
+                  expectedSessionRef
+                  && !terminalMatchesExpectedSession(record, expectedSessionRef)
+                ) {
+                  log.warn({
+                    requestId: m.requestId,
+                    connectionId: ws.connectionId,
+                    terminalId: record.terminalId,
+                    reuseSource: opts.reuseSource,
+                    ...buildSessionIdentityMismatchDetails(record, expectedSessionRef),
+                  }, 'Ignoring terminal reuse candidate with mismatched canonical session identity')
+                  return false
+                }
+                if (
+                  m.mode === 'codex'
+                  && !expectedSessionRef
+                  && !opts.allowCodexWithoutExpectedSession
+                ) {
+                  log.warn({
+                    requestId: m.requestId,
+                    connectionId: ws.connectionId,
+                    terminalId: record.terminalId,
+                    reuseSource: opts.reuseSource,
+                  }, 'Ignoring Codex terminal reuse candidate without a canonical expected session')
+                  return false
+                }
                 const sent = await sendCreateResult({
                   ws,
                   requestId: m.requestId,
@@ -1885,8 +1964,12 @@ export class WsHandler {
                 if (!sent) {
                   return false
                 }
-                state.createdByRequestId.set(m.requestId, record.terminalId)
-                this.rememberCreatedRequestId(m.requestId, record.terminalId)
+                const binding = {
+                  terminalId: record.terminalId,
+                  ...(expectedSessionKey ? { expectedSessionKey } : {}),
+                }
+                state.createdByRequestId.set(m.requestId, binding)
+                this.rememberCreatedRequestId(m.requestId, record.terminalId, expectedSessionKey)
                 terminalId = record.terminalId
                 reused = true
                 const sessionRef = buildTerminalSessionRef(record)
@@ -1910,85 +1993,32 @@ export class WsHandler {
                 const live = this.registry.get(m.liveTerminal.terminalId)
                 return live && live.status === 'running' && live.mode === m.mode ? live : undefined
               }
-              const requestedLiveCodexCandidate = (candidate: {
-                candidateThreadId: string
-                rolloutPath: string
-              }): TerminalRecord | undefined => {
-                const live = requestedLiveTerminal()
-                if (!live) return undefined
-                const liveCandidate = live.codexDurability?.candidate
-                if (
-                  liveCandidate?.candidateThreadId !== candidate.candidateThreadId
-                  || liveCandidate?.rolloutPath !== candidate.rolloutPath
-                ) {
-                  log.warn({
-                    requestId: m.requestId,
-                    connectionId: ws.connectionId,
-                    terminalId: live.terminalId,
-                    requestedCandidateThreadId: candidate.candidateThreadId,
-                    liveCandidateThreadId: liveCandidate?.candidateThreadId,
-                  }, 'Ignoring stale Codex live terminal handle with mismatched restore candidate')
-                  return undefined
-                }
-                return live
-              }
-              const broadcastCodexSessionAssociated = (associatedTerminalId: string, sessionId: string) => {
-                this.broadcast({
-                  type: 'terminal.session.associated',
-                  terminalId: associatedTerminalId,
-                  sessionRef: {
-                    provider: 'codex',
-                    sessionId,
-                  },
-                })
-              }
-              const broadcastCodexDurabilityUpdated = (associatedTerminalId: string, durability: unknown) => {
-                this.broadcast({
-                  type: 'terminal.codex.durability.updated',
-                  terminalId: associatedTerminalId,
-                  durability,
-                })
-              }
 
-              const existingId = resolveExistingRequestTerminalId(m.requestId)
-              if (existingId) {
-                if (existingId === REPAIR_PENDING_SENTINEL) {
+              const existingBinding = resolveExistingRequestBinding(m.requestId)
+              if (existingBinding) {
+                if (existingBinding === REPAIR_PENDING_SENTINEL) {
                   log.debug({ requestId: m.requestId, connectionId: ws.connectionId },
                     'terminal.create already in progress (repair pending), ignoring duplicate')
                   return
                 }
-                const existing = this.registry.get(existingId)
+                const existing = this.registry.get(existingBinding.terminalId)
                 if (existing) {
-                  await attachReusedTerminal(existing)
-                  return
+                  const attached = await attachReusedTerminal(existing, {
+                    reuseSource: 'request_id_cache',
+                    allowCodexWithoutExpectedSession: true,
+                  })
+                  if (attached) return
                 }
                 // If it no longer exists, fall through and create a new one.
                 state.createdByRequestId.delete(m.requestId)
                 this.forgetCreatedRequestId(m.requestId)
               }
-
-              let clearCodexDurabilityOnCreate = false
-              let restoreErrorOnCreate: RestoreError | undefined
-              let codexDurabilityStoreRecordToDeleteOnSuccessfulUse: string | undefined
-              const deleteCodexDurabilityStoreRecord = async (recordTerminalId: string | undefined, reason: string) => {
-                if (!recordTerminalId) return
-                await this.registry.deleteCodexDurabilityStoreRecord(recordTerminalId, reason)
-                if (codexDurabilityStoreRecordToDeleteOnSuccessfulUse === recordTerminalId) {
-                  codexDurabilityStoreRecordToDeleteOnSuccessfulUse = undefined
-                }
-              }
               if (m.mode === 'codex') {
                 const decision = await resolveCodexCreateRestoreDecision({
                   restoreRequested: m.restore === true,
                   legacyResumeSessionId: m.resumeSessionId,
-                  sessionRef: requestedSessionRef,
+                  sessionRef: expectedSessionRef,
                   codexDurability: codexDurabilityForDecision,
-                  findLiveTerminalByCandidate: (candidate) => (
-                    this.registry.findRunningCodexTerminalByCandidate(
-                      candidate.candidateThreadId,
-                      candidate.rolloutPath,
-                    ) ?? requestedLiveCodexCandidate(candidate)
-                  ),
                 })
 
                 if (
@@ -2008,95 +2038,15 @@ export class WsHandler {
                   effectiveResumeSessionId = decision.sessionId
                 } else if (decision.kind === 'fresh_codex_launch') {
                   effectiveResumeSessionId = undefined
-                } else if (decision.kind === 'proof_succeeded_resume_durable') {
-                  const { candidate, liveTerminal: live } = decision
-                  if (live) {
-                    if (codexDurabilityStoreRecordTerminalId && codexDurabilityStoreRecordTerminalId !== live.terminalId) {
-                      await deleteCodexDurabilityStoreRecord(
-                        codexDurabilityStoreRecordTerminalId,
-                        'restore_proof_succeeded_attached_live',
-                      )
-                    }
-                    const promoted = typeof this.registry.promoteCodexDurabilityFromCreateProof === 'function'
-                      ? await this.registry.promoteCodexDurabilityFromCreateProof(live.terminalId, decision.sessionId)
-                      : undefined
-                    const bound = promoted ?? this.registry.bindSession?.(live.terminalId, 'codex', decision.sessionId, 'association')
-                    if (!bound || bound.ok) {
-                      if (!promoted) {
-                        live.resumeSessionId = decision.sessionId
-                        live.codexDurability = {
-                          schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
-                          state: 'durable',
-                          durableThreadId: decision.sessionId,
-                        }
-                      }
-                      broadcastCodexDurabilityUpdated(live.terminalId, live.codexDurability ?? {
-                        schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
-                        state: 'durable',
-                        durableThreadId: decision.sessionId,
-                      })
-                      await attachReusedTerminal(live)
-                      broadcastCodexSessionAssociated(live.terminalId, decision.sessionId)
-                      return
-                    }
-                    log.warn({
-                      requestId: m.requestId,
-                      connectionId: ws.connectionId,
-                      terminalId: live.terminalId,
-                      sessionId: decision.sessionId,
-                      reason: bound.reason,
-                    }, 'Codex captured restore state proved durable but live terminal binding failed')
-                  }
-                  effectiveResumeSessionId = decision.sessionId
-                  codexDurabilityStoreRecordToDeleteOnSuccessfulUse = codexDurabilityStoreRecordTerminalId
-                  log.info({
-                    requestId: m.requestId,
-                    connectionId: ws.connectionId,
-                    candidateThreadId: candidate.candidateThreadId,
-                    rolloutPath: candidate.rolloutPath,
-                  }, 'Codex captured restore state proved durable during terminal.create')
-                } else if (decision.kind === 'proof_failed_attach_live_candidate') {
-                  const { candidate, proof, liveTerminal: live } = decision
-                  log.warn({
-                    requestId: m.requestId,
-                    connectionId: ws.connectionId,
-                    candidateThreadId: candidate.candidateThreadId,
-                    rolloutPath: candidate.rolloutPath,
-                    reason: proof.reason,
-                  }, 'Codex captured restore state could not be proved during terminal.create')
-                  if (codexDurabilityStoreRecordTerminalId && codexDurabilityStoreRecordTerminalId !== live.terminalId) {
-                    await deleteCodexDurabilityStoreRecord(
-                      codexDurabilityStoreRecordTerminalId,
-                      'restore_proof_failed_attached_live',
-                    )
-                  }
-                  await attachReusedTerminal(live)
-                  return
-                } else if (decision.kind === 'proof_failed_fresh_create') {
-                  const { candidate, proof } = decision
-                  log.warn({
-                    requestId: m.requestId,
-                    connectionId: ws.connectionId,
-                    candidateThreadId: candidate.candidateThreadId,
-                    rolloutPath: candidate.rolloutPath,
-                    reason: proof.reason,
-                  }, 'Codex captured restore state could not be proved during terminal.create')
-                  await deleteCodexDurabilityStoreRecord(
-                    codexDurabilityStoreRecordTerminalId,
-                    'restore_proof_failed_fresh_create',
-                  )
-                  clearCodexDurabilityOnCreate = decision.clearCodexDurability
-                  restoreErrorOnCreate = decision.restoreError
-                  effectiveResumeSessionId = undefined
                 }
               }
 
-              if (!codexDurabilityForDecision?.candidate) {
-                const live = requestedLiveTerminal()
-                if (live) {
-                  await attachReusedTerminal(live)
-                  return
-                }
+              const live = requestedLiveTerminal()
+              if (live) {
+                const attached = await attachReusedTerminal(live, {
+                  reuseSource: 'requested_live_terminal',
+                })
+                if (attached) return
               }
 
               if (modeSupportsResume(m.mode as TerminalMode) && effectiveResumeSessionId) {
@@ -2118,12 +2068,10 @@ export class WsHandler {
                   )
                 }
                 if (existing) {
-                  await deleteCodexDurabilityStoreRecord(
-                    codexDurabilityStoreRecordToDeleteOnSuccessfulUse,
-                    'restore_proof_succeeded_attached_existing',
-                  )
-                  await attachReusedTerminal(existing)
-                  return
+                  const attached = await attachReusedTerminal(existing, {
+                    reuseSource: 'canonical_session_owner',
+                  })
+                  if (attached) return
                 }
               }
 
@@ -2133,17 +2081,20 @@ export class WsHandler {
                 : undefined
 
               // Re-check idempotency after async config loading in case another create won the race.
-              const existingAfterConfigId = resolveExistingRequestTerminalId(m.requestId)
-              if (existingAfterConfigId) {
-                if (existingAfterConfigId === REPAIR_PENDING_SENTINEL) {
+              const existingAfterConfigBinding = resolveExistingRequestBinding(m.requestId)
+              if (existingAfterConfigBinding) {
+                if (existingAfterConfigBinding === REPAIR_PENDING_SENTINEL) {
                   log.debug({ requestId: m.requestId, connectionId: ws.connectionId },
                     'terminal.create already in progress (repair pending), ignoring duplicate')
                   return
                 }
-                const existing = this.registry.get(existingAfterConfigId)
+                const existing = this.registry.get(existingAfterConfigBinding.terminalId)
                 if (existing) {
-                  await attachReusedTerminal(existing)
-                  return
+                  const attached = await attachReusedTerminal(existing, {
+                    reuseSource: 'request_id_cache_after_config',
+                    allowCodexWithoutExpectedSession: true,
+                  })
+                  if (attached) return
                 }
                 state.createdByRequestId.delete(m.requestId)
                 this.forgetCreatedRequestId(m.requestId)
@@ -2185,12 +2136,10 @@ export class WsHandler {
                   )
                 }
                 if (existing) {
-                  await deleteCodexDurabilityStoreRecord(
-                    codexDurabilityStoreRecordToDeleteOnSuccessfulUse,
-                    'restore_proof_succeeded_attached_existing',
-                  )
-                  await attachReusedTerminal(existing)
-                  return
+                  const attached = await attachReusedTerminal(existing, {
+                    reuseSource: 'canonical_session_owner_after_config',
+                  })
+                  if (attached) return
                 }
               }
 
@@ -2338,10 +2287,6 @@ export class WsHandler {
                   })
                 }
               }
-              await deleteCodexDurabilityStoreRecord(
-                codexDurabilityStoreRecordToDeleteOnSuccessfulUse,
-                'restore_proof_succeeded_created_replacement',
-              )
               this.assertTerminalCreateAccepted()
 
               if (m.mode !== 'shell' && typeof m.cwd === 'string' && m.cwd.trim()) {
@@ -2351,15 +2296,17 @@ export class WsHandler {
                 })
               }
 
-              state.createdByRequestId.set(m.requestId, record.terminalId)
-              this.rememberCreatedRequestId(m.requestId, record.terminalId)
+              const createdBinding = {
+                terminalId: record.terminalId,
+                ...(expectedSessionKey ? { expectedSessionKey } : {}),
+              }
+              state.createdByRequestId.set(m.requestId, createdBinding)
+              this.rememberCreatedRequestId(m.requestId, record.terminalId, expectedSessionKey)
 
               const sent = await sendCreateResult({
                 ws,
                 requestId: m.requestId,
                 record,
-                clearCodexDurability: clearCodexDurabilityOnCreate,
-                restoreError: restoreErrorOnCreate,
               })
               if (!sent) {
                 // Terminal may still exist even if created delivery failed (for
@@ -2368,10 +2315,6 @@ export class WsHandler {
                 this.broadcastTerminalsChanged()
                 return
               }
-              if (m.mode === 'codex' && effectiveResumeSessionId) {
-                broadcastCodexSessionAssociated(record.terminalId, effectiveResumeSessionId)
-              }
-
               recordSessionLifecycleEvent({
                 kind: 'terminal_created',
                 requestId: m.requestId,
@@ -2439,6 +2382,7 @@ export class WsHandler {
         }
 
         const record = this.registry.get(m.terminalId)
+        const expectedSessionRef = normalizeUiSessionLocator(m.expectedSessionRef)
         if (!record) {
           recordSessionLifecycleEvent({
             kind: 'invalid_terminal_id_without_session_ref',
@@ -2469,6 +2413,16 @@ export class WsHandler {
           })
           return
         }
+        if (expectedSessionRef && !terminalMatchesExpectedSession(record, expectedSessionRef)) {
+          this.sendSessionIdentityMismatch(ws, {
+            operation: 'terminal.attach',
+            requestId: m.attachRequestId,
+            terminalId: record.terminalId,
+            expectedSessionRef,
+            record,
+          })
+          return
+        }
 
         const attachResult = await this.terminalStreamBroker.attach(
           ws,
@@ -2477,6 +2431,7 @@ export class WsHandler {
           m.cols,
           m.rows,
           m.sinceSeq,
+          expectedSessionRef,
           m.attachRequestId,
           m.maxReplayBytes,
           m.priority ?? 'foreground',
@@ -2521,6 +2476,18 @@ export class WsHandler {
           })
           return
         }
+        if (typeof attachResult === 'object' && attachResult.status === 'session_identity_mismatch') {
+          if (expectedSessionRef) {
+            this.sendSessionIdentityMismatch(ws, {
+              operation: 'terminal.attach',
+              requestId: m.attachRequestId,
+              terminalId: m.terminalId,
+              expectedSessionRef,
+              record: this.registry.get(m.terminalId) ?? record,
+            })
+          }
+          return
+        }
         if (attachResult === 'duplicate') return
         state.attachedTerminalIds.add(m.terminalId)
         return
@@ -2546,7 +2513,23 @@ export class WsHandler {
       }
 
       case 'terminal.input': {
-        const result = this.registry.input(m.terminalId, m.data)
+        const expectedSessionRef = normalizeUiSessionLocator(m.expectedSessionRef)
+        const result = typeof this.registry.inputIfSessionMatches === 'function'
+          ? this.registry.inputIfSessionMatches(m.terminalId, m.data, expectedSessionRef)
+          : this.registry.input(m.terminalId, m.data)
+        if (result.status === 'session_identity_mismatch') {
+          const record = this.registry.get(m.terminalId)
+          if (record && expectedSessionRef) {
+            this.sendSessionIdentityMismatch(ws, {
+              operation: 'terminal.input',
+              terminalId: m.terminalId,
+              expectedSessionRef,
+              record,
+              attemptedInputBytes: Buffer.byteLength(m.data, 'utf8'),
+            })
+            return
+          }
+        }
         if (result.status === 'blocked_codex_identity_pending') {
           log.debug({
             terminalId: m.terminalId,
@@ -2656,8 +2639,25 @@ export class WsHandler {
       }
 
       case 'terminal.resize': {
-        const ok = this.registry.resize(m.terminalId, m.cols, m.rows)
-        if (!ok) {
+        const expectedSessionRef = normalizeUiSessionLocator(m.expectedSessionRef)
+        const result = typeof this.registry.resizeIfSessionMatches === 'function'
+          ? this.registry.resizeIfSessionMatches(m.terminalId, m.cols, m.rows, expectedSessionRef)
+          : (this.registry.resize(m.terminalId, m.cols, m.rows)
+              ? { status: 'resized' as const }
+              : { status: 'missing' as const })
+        if (result.status === 'session_identity_mismatch') {
+          const record = this.registry.get(m.terminalId)
+          if (record && expectedSessionRef) {
+            this.sendSessionIdentityMismatch(ws, {
+              operation: 'terminal.resize',
+              terminalId: m.terminalId,
+              expectedSessionRef,
+              record,
+            })
+            return
+          }
+        }
+        if (result.status !== 'resized' && result.status !== 'unchanged') {
           if (!this.registry.get(m.terminalId)) {
             recordSessionLifecycleEvent({
               kind: 'invalid_terminal_id_without_session_ref',

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -22,6 +22,7 @@ export const ErrorCode = z.enum([
   'INVALID_MESSAGE',
   'UNKNOWN_MESSAGE',
   'INVALID_TERMINAL_ID',
+  'SESSION_IDENTITY_MISMATCH',
   'INVALID_SESSION_ID',
   'RESTORE_UNAVAILABLE',
   'INVALID_CREATE_REQUEST',
@@ -294,6 +295,7 @@ export const TerminalAttachPrioritySchema = z.enum([
 export const TerminalAttachSchema = z.object({
   type: z.literal('terminal.attach'),
   terminalId: z.string().min(1),
+  expectedSessionRef: SessionLocatorSchema.optional(),
   sinceSeq: z.number().int().nonnegative().optional(),
   maxReplayBytes: z.number().int().positive().optional(),
   attachRequestId: z.string().min(1).optional(),
@@ -311,12 +313,14 @@ export const TerminalDetachSchema = z.object({
 export const TerminalInputSchema = z.object({
   type: z.literal('terminal.input'),
   terminalId: z.string().min(1),
+  expectedSessionRef: SessionLocatorSchema.optional(),
   data: z.string(),
 })
 
 export const TerminalResizeSchema = z.object({
   type: z.literal('terminal.resize'),
   terminalId: z.string().min(1),
+  expectedSessionRef: SessionLocatorSchema.optional(),
   cols: z.number().int().min(2).max(1000),
   rows: z.number().int().min(2).max(500),
 })
@@ -563,6 +567,8 @@ export type ErrorMessage = {
   message: string
   requestId?: string
   terminalId?: string
+  expectedSessionRef?: SessionLocator
+  actualSessionRef?: SessionLocator
   timestamp: string
 }
 

--- a/src/components/TabsView.tsx
+++ b/src/components/TabsView.tsx
@@ -123,14 +123,15 @@ export function sanitizePaneSnapshot(
     const codexDurability = mode === 'codex'
       ? sanitizeCodexDurabilityRef(payload.codexDurability)
       : undefined
+    const includeLiveTerminal = sameServer && !sessionRef
     return {
       kind: 'terminal',
       mode,
       shell: (payload.shell as 'system' | 'cmd' | 'powershell' | 'wsl') || 'system',
       sessionRef,
       ...(codexDurability ? { codexDurability } : {}),
-      terminalId: sameServer ? liveTerminal?.terminalId : undefined,
-      serverInstanceId: record.serverInstanceId,
+      terminalId: includeLiveTerminal ? liveTerminal?.terminalId : undefined,
+      serverInstanceId: includeLiveTerminal ? record.serverInstanceId : undefined,
       initialCwd: payload.initialCwd as string | undefined,
     }
   }

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -12,7 +12,13 @@ import {
 import { shallowEqual } from 'react-redux'
 import { useAppDispatch, useAppSelector, useAppStore } from '@/store/hooks'
 import { updateTab, switchToNextTab, switchToPrevTab } from '@/store/tabsSlice'
-import { consumePaneRefreshRequest, splitPane, updatePaneContent, updatePaneTitle } from '@/store/panesSlice'
+import {
+  consumePaneRefreshRequest,
+  repairCodexIdentityMismatch,
+  splitPane,
+  updatePaneContent,
+  updatePaneTitle,
+} from '@/store/panesSlice'
 import { updateSessionActivity } from '@/store/sessionActivitySlice'
 import { recordPaneTabActivity } from '@/store/tabRecencySlice'
 import { updateSettingsLocal } from '@/store/settingsSlice'
@@ -24,7 +30,13 @@ import { isFatalConnectionErrorCode } from '@/store/connectionSlice'
 import { flushPersistedLayoutNow } from '@/store/persistControl'
 import { getWsClient } from '@/lib/ws-client'
 import { getTerminalTheme } from '@/lib/terminal-themes'
-import { getCreateSessionStateFromRef } from '@/components/terminal-view-utils'
+import {
+  buildCodexIdentityMismatchRepairContent,
+  buildTerminalAttachMessage,
+  buildTerminalInputMessage,
+  buildTerminalResizeMessage,
+  getCreateSessionStateFromRef,
+} from '@/components/terminal-view-utils'
 import { reconcileTerminalSessionAssociation } from '@/lib/terminal-session-association'
 import { copyText, readText } from '@/lib/clipboard'
 import { registerTerminalActions } from '@/lib/pane-action-registry'
@@ -189,6 +201,13 @@ function buildSessionAssociationContentUpdates(
     resumeSessionId: undefined,
     codexDurability,
   }
+}
+
+function sessionRefsEqual(
+  left?: { provider?: string; sessionId?: string },
+  right?: { provider?: string; sessionId?: string },
+): boolean {
+  return left?.provider === right?.provider && left?.sessionId === right?.sessionId
 }
 
 type TerminalInputBlockedReason =
@@ -1017,7 +1036,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
   const sendInput = useCallback((data: string) => {
     const tid = terminalIdRef.current
     if (!tid) return
-    ws.send({ type: 'terminal.input', terminalId: tid, data })
+    ws.send(buildTerminalInputMessage(contentRef.current, tid, data))
   }, [ws])
 
   const translateScrollLinesToInput = useCallback((term: Terminal, lines: number): boolean => {
@@ -1322,7 +1341,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             suppressNextMatchingResizeRef.current = null
           } else if (!matchesLastSentViewport && !suppressNetworkEffects) {
             syncGeometryEpochForViewport(tid, term.cols, term.rows)
-            ws.send({ type: 'terminal.resize', terminalId: tid, cols: term.cols, rows: term.rows })
+            ws.send(buildTerminalResizeMessage(contentRef.current, tid, term.cols, term.rows))
             rememberSentViewport(tid, term.cols, term.rows)
             lastSentViewportRef.current = { terminalId: tid, cols: term.cols, rows: term.rows }
           }
@@ -2469,8 +2488,8 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       ? { terminalId: tid, cols, rows }
       : null
 
-    ws.send({
-      type: 'terminal.attach',
+    ws.send(buildTerminalAttachMessage({
+      content: contentRef.current,
       terminalId: tid,
       intent: effectiveIntent,
       cols,
@@ -2479,7 +2498,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       attachRequestId,
       priority: opts?.priority ?? 'foreground',
       ...(opts?.maxReplayBytes ? { maxReplayBytes: opts.maxReplayBytes } : {}),
-    })
+    }))
     rememberSentViewport(tid, cols, rows)
     lastSentViewportRef.current = { terminalId: tid, cols, rows }
     if (surfaceQuarantined) {
@@ -3540,13 +3559,13 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
 
           const attachSessionRef = (msg as { sessionRef?: TerminalPaneContent['sessionRef'] }).sessionRef
           if (attachSessionRef) {
-            const reconciled = reconcileTerminalSessionAssociation({
+            const associationResult = reconcileTerminalSessionAssociation({
               dispatch,
               getState: appStore.getState,
               terminalId: tid,
               sessionRef: attachSessionRef,
             })
-            if (reconciled) {
+            if (associationResult === 'reconciled') {
               syncContentRefWithSessionAssociation(attachSessionRef)
             }
           }
@@ -3614,13 +3633,13 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             ...(msg.restoreError ? { restoreError: msg.restoreError } : {}),
           })
           if (createdSessionRef) {
-            const reconciled = reconcileTerminalSessionAssociation({
+            const associationResult = reconcileTerminalSessionAssociation({
               dispatch,
               getState: appStore.getState,
               terminalId: newId,
               sessionRef: createdSessionRef,
             })
-            if (reconciled) {
+            if (associationResult === 'reconciled') {
               syncContentRefWithSessionAssociation(createdSessionRef)
             }
           }
@@ -3730,26 +3749,42 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
 
         // Handle one-time session association from the authoritative canonical sessionRef.
         if (msg.type === 'terminal.session.associated' && msg.terminalId === tid) {
-          const reconciled = reconcileTerminalSessionAssociation({
+          const associationResult = reconcileTerminalSessionAssociation({
             dispatch,
             getState: appStore.getState,
             terminalId: tid,
             sessionRef: msg.sessionRef,
           })
-          if (debugRef.current && reconciled) {
+          if (debugRef.current && associationResult === 'reconciled') {
             log.debug('[TRACE resumeSessionId] terminal.session.associated reconciled', {
               paneId: paneIdRef.current,
               terminalId: tid,
               sessionRef: msg.sessionRef,
             })
           }
-          if (reconciled) {
+          if (associationResult === 'reconciled') {
             syncContentRefWithSessionAssociation(msg.sessionRef)
           }
         }
 
         if (msg.type === 'terminal.codex.durability.updated' && msg.terminalId === tid) {
           const durability = msg.durability
+          const currentSessionRef = contentRef.current?.sessionRef
+          const durableMatchesCanonicalSession = currentSessionRef?.provider === 'codex'
+            && durability?.state === 'durable'
+            && durability.durableThreadId === currentSessionRef.sessionId
+          const candidateMatchesCanonicalSession = currentSessionRef?.provider === 'codex'
+            && durability?.candidate?.candidateThreadId === currentSessionRef.sessionId
+          if (currentSessionRef?.provider === 'codex' && !durableMatchesCanonicalSession && !candidateMatchesCanonicalSession) {
+            log.warn('Ignoring stale codex durability update for pane canonical session', {
+              tabId,
+              paneId: paneIdRef.current,
+              terminalId: tid,
+              expectedSessionRef: currentSessionRef,
+              durability,
+            })
+            return
+          }
           updateContent({ codexDurability: durability })
           const currentTab = tabHasSinglePaneRef.current ? tabRef.current : undefined
           if (currentTab) {
@@ -3782,6 +3817,59 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             lastInputBlockedNoticeRef.current = { reason, at: now }
             writeLocalXtermNotice(term, `\r\n[${terminalInputBlockedNotice(reason)}]\r\n`)
           }
+          return
+        }
+
+        if (msg.type === 'error' && msg.code === 'SESSION_IDENTITY_MISMATCH' && msg.terminalId === tid) {
+          const staleTerminalId = tid
+          const current = contentRef.current
+          const expectedSessionRef = sanitizeSessionRef(msg.expectedSessionRef)
+          if (!staleTerminalId || !current || current.terminalId !== staleTerminalId || !expectedSessionRef || !sessionRefsEqual(current.sessionRef, expectedSessionRef)) {
+            writeLocalXtermNotice(term, `\r\n[Resume blocked] ${msg.message || 'Terminal session identity mismatch.'}\r\n`)
+            return
+          }
+
+          const newRequestId = nanoid()
+          const repairContent = buildCodexIdentityMismatchRepairContent(current, expectedSessionRef, newRequestId)
+          if (!repairContent) return
+
+          consumeTerminalRestoreRequestId(requestIdRef.current)
+          addTerminalRestoreRequestId(newRequestId)
+          requestIdRef.current = newRequestId
+          launchAttemptRef.current = null
+          clearQuarantineRepair()
+          currentAttachRef.current = null
+          clearRateLimitRetry()
+          setIsAttaching(false)
+          dispatch(clearPaneRuntimeActivity({ paneId: paneIdRef.current }))
+          clearTerminalCursor(staleTerminalId)
+          resetParserAppliedSurface()
+          forgetSentViewport(staleTerminalId)
+          lastSentViewportRef.current = null
+          terminalIdRef.current = undefined
+          deferredAttachStateRef.current = {
+            mode: 'none',
+            pendingIntent: null,
+            pendingSinceSeq: 0,
+            pendingReason: 'initial_hydrate',
+          }
+          applySeqState(createAttachSeqState())
+          contentRef.current = {
+            ...current,
+            ...repairContent,
+          }
+          dispatch(repairCodexIdentityMismatch({
+            tabId,
+            paneId: paneIdRef.current,
+            staleTerminalId,
+            expectedSessionRef,
+            createRequestId: newRequestId,
+          }))
+          const currentTab = tabRef.current
+          if (currentTab) {
+            dispatch(updateTab({ id: currentTab.id, updates: { status: 'creating' } }))
+          }
+          writeLocalXtermNotice(term, '\r\n[Reconnecting to the expected Codex session...]\r\n')
           return
         }
 

--- a/src/components/terminal-view-utils.ts
+++ b/src/components/terminal-view-utils.ts
@@ -129,10 +129,7 @@ export function buildCodexIdentityMismatchRepairContent(
   if (!content) return undefined
   const matchingDurableCodexIdentity = expectedSessionRef.provider === 'codex'
     && content.codexDurability?.state === 'durable'
-    && (
-      content.codexDurability.durableThreadId === expectedSessionRef.sessionId
-      || content.codexDurability.candidate?.candidateThreadId === expectedSessionRef.sessionId
-    )
+    && content.codexDurability.durableThreadId === expectedSessionRef.sessionId
       ? content.codexDurability
       : undefined
   return {

--- a/src/components/terminal-view-utils.ts
+++ b/src/components/terminal-view-utils.ts
@@ -1,4 +1,4 @@
-import type { TerminalPaneContent } from '@/store/paneTypes'
+import type { SessionLocator, TerminalPaneContent } from '@/store/paneTypes'
 
 export type TerminalContentRef = { current: TerminalPaneContent | null }
 
@@ -14,20 +14,134 @@ export function getCreateSessionStateFromRef(ref: TerminalContentRef): {
     serverInstanceId: string
   }
 } {
-  const sessionRef = ref.current?.sessionRef
-  const codexDurability = ref.current?.codexDurability
-  const terminalId = ref.current?.terminalId
-  const serverInstanceId = ref.current?.serverInstanceId
+  const content = ref.current
+  const sessionRef = getExpectedSessionRefForTerminalOperation(content)
+  const codexDurability = content?.codexDurability
+  const liveTerminal = getSafeLiveTerminalForCreate(content)
   return {
     ...(sessionRef ? { sessionRef } : {}),
     ...(!sessionRef && codexDurability ? { codexDurability } : {}),
-    ...(terminalId && serverInstanceId
-      ? {
-          liveTerminal: {
-            terminalId,
-            serverInstanceId,
-          },
-        }
-      : {}),
+    ...(liveTerminal ? { liveTerminal } : {}),
+  }
+}
+
+export function getExpectedSessionRefForTerminalOperation(
+  content: TerminalPaneContent | null | undefined,
+): SessionLocator | undefined {
+  return content?.sessionRef
+}
+
+export function getSafeLiveTerminalForCreate(
+  content: TerminalPaneContent | null | undefined,
+  options: { allowLiveTerminalWithSessionRef?: boolean } = {},
+): { terminalId: string; serverInstanceId: string } | undefined {
+  if (!content?.terminalId || !content.serverInstanceId) return undefined
+  if (content.sessionRef && !options.allowLiveTerminalWithSessionRef) return undefined
+  return {
+    terminalId: content.terminalId,
+    serverInstanceId: content.serverInstanceId,
+  }
+}
+
+export function buildTerminalInputMessage(
+  content: TerminalPaneContent | null | undefined,
+  terminalId: string,
+  data: string,
+): {
+  type: 'terminal.input'
+  terminalId: string
+  data: string
+  expectedSessionRef?: SessionLocator
+} {
+  const expectedSessionRef = getExpectedSessionRefForTerminalOperation(content)
+  return {
+    type: 'terminal.input',
+    terminalId,
+    data,
+    ...(expectedSessionRef ? { expectedSessionRef } : {}),
+  }
+}
+
+export function buildTerminalResizeMessage(
+  content: TerminalPaneContent | null | undefined,
+  terminalId: string,
+  cols: number,
+  rows: number,
+): {
+  type: 'terminal.resize'
+  terminalId: string
+  cols: number
+  rows: number
+  expectedSessionRef?: SessionLocator
+} {
+  const expectedSessionRef = getExpectedSessionRefForTerminalOperation(content)
+  return {
+    type: 'terminal.resize',
+    terminalId,
+    cols,
+    rows,
+    ...(expectedSessionRef ? { expectedSessionRef } : {}),
+  }
+}
+
+export function buildTerminalAttachMessage(input: {
+  content: TerminalPaneContent | null | undefined
+  terminalId: string
+  intent: 'viewport_hydrate' | 'keepalive_delta' | 'transport_reconnect'
+  cols: number
+  rows: number
+  sinceSeq: number
+  attachRequestId: string
+  priority: 'foreground' | 'background'
+  maxReplayBytes?: number
+}): {
+  type: 'terminal.attach'
+  terminalId: string
+  intent: 'viewport_hydrate' | 'keepalive_delta' | 'transport_reconnect'
+  cols: number
+  rows: number
+  sinceSeq: number
+  attachRequestId: string
+  priority: 'foreground' | 'background'
+  maxReplayBytes?: number
+  expectedSessionRef?: SessionLocator
+} {
+  const expectedSessionRef = getExpectedSessionRefForTerminalOperation(input.content)
+  return {
+    type: 'terminal.attach',
+    terminalId: input.terminalId,
+    intent: input.intent,
+    cols: input.cols,
+    rows: input.rows,
+    sinceSeq: input.sinceSeq,
+    attachRequestId: input.attachRequestId,
+    priority: input.priority,
+    ...(input.maxReplayBytes ? { maxReplayBytes: input.maxReplayBytes } : {}),
+    ...(expectedSessionRef ? { expectedSessionRef } : {}),
+  }
+}
+
+export function buildCodexIdentityMismatchRepairContent(
+  content: TerminalPaneContent | null | undefined,
+  expectedSessionRef: SessionLocator,
+  createRequestId: string,
+): Partial<TerminalPaneContent> | undefined {
+  if (!content) return undefined
+  const matchingDurableCodexIdentity = expectedSessionRef.provider === 'codex'
+    && content.codexDurability?.state === 'durable'
+    && (
+      content.codexDurability.durableThreadId === expectedSessionRef.sessionId
+      || content.codexDurability.candidate?.candidateThreadId === expectedSessionRef.sessionId
+    )
+      ? content.codexDurability
+      : undefined
+  return {
+    terminalId: undefined,
+    serverInstanceId: undefined,
+    streamId: undefined,
+    createRequestId,
+    status: 'creating',
+    sessionRef: expectedSessionRef,
+    codexDurability: matchingDurableCodexIdentity,
   }
 }

--- a/src/lib/terminal-session-association.ts
+++ b/src/lib/terminal-session-association.ts
@@ -50,15 +50,14 @@ function terminalPaneNeedsDurableIdentityUpdate(content: TerminalPaneContent, se
   if (!(
     sessionRef.provider === 'codex'
     && content.codexDurability?.state === 'durable'
-    && (
-      content.codexDurability.durableThreadId === sessionRef.sessionId
-      || content.codexDurability.candidate?.candidateThreadId === sessionRef.sessionId
-    )
+    && content.codexDurability.durableThreadId === sessionRef.sessionId
   )) {
     return content.codexDurability !== undefined
   }
   return false
 }
+
+export type TerminalSessionAssociationReconcileStatus = 'ignored' | 'reconciled' | 'conflict'
 
 export function reconcileTerminalSessionAssociation({
   dispatch,
@@ -70,13 +69,14 @@ export function reconcileTerminalSessionAssociation({
   getState: () => SessionAssociationState
   terminalId?: string
   sessionRef?: unknown
-}): boolean {
-  if (!terminalId) return false
+}): TerminalSessionAssociationReconcileStatus {
+  if (!terminalId) return 'ignored'
   const sessionRef = sanitizeSessionRef(rawSessionRef)
-  if (!sessionRef) return false
+  if (!sessionRef) return 'ignored'
 
   const state = getState()
   let matchedAnyPane = false
+  let conflictingPane = false
   let shouldFlush = false
   const matchedSinglePaneTabs: Array<{ tabId: string; content: TerminalPaneContent }> = []
   for (const [tabId, layout] of Object.entries(state.panes.layouts)) {
@@ -85,6 +85,10 @@ export function reconcileTerminalSessionAssociation({
     if (matches.length === 0) continue
 
     matchedAnyPane = true
+    if (matches.some(({ content }) => content.sessionRef && !sessionRefsEqual(content.sessionRef, sessionRef))) {
+      conflictingPane = true
+      continue
+    }
     if (matches.some(({ content }) => terminalPaneNeedsDurableIdentityUpdate(content, sessionRef))) {
       shouldFlush = true
     }
@@ -93,7 +97,8 @@ export function reconcileTerminalSessionAssociation({
     }
   }
 
-  if (!matchedAnyPane) return false
+  if (conflictingPane) return 'conflict'
+  if (!matchedAnyPane) return 'ignored'
 
   dispatch(reconcileTerminalSessionRefByTerminalId({ terminalId, sessionRef }))
 
@@ -111,10 +116,7 @@ export function reconcileTerminalSessionAssociation({
     })
     const nextTabCodexDurability = sessionRef.provider === 'codex'
       && tab.codexDurability?.state === 'durable'
-      && (
-        tab.codexDurability.durableThreadId === sessionRef.sessionId
-        || tab.codexDurability.candidate?.candidateThreadId === sessionRef.sessionId
-      )
+      && tab.codexDurability.durableThreadId === sessionRef.sessionId
       ? tab.codexDurability
       : undefined
     const tabUpdates = {
@@ -135,5 +137,5 @@ export function reconcileTerminalSessionAssociation({
   if (shouldFlush) {
     dispatch(flushPersistedLayoutNow())
   }
-  return true
+  return 'reconciled'
 }

--- a/src/store/panesSlice.ts
+++ b/src/store/panesSlice.ts
@@ -522,6 +522,19 @@ function codexDurabilityMatchesCanonicalSession(
   )
 }
 
+function pickCanonicalCodexDurability(
+  localContent: TerminalPaneContent,
+  incomingContent: TerminalPaneContent,
+  sessionRef: { provider?: string; sessionId?: string } | undefined,
+): TerminalPaneContent['codexDurability'] | undefined {
+  if (codexDurabilityMatchesCanonicalSession(localContent.codexDurability, sessionRef)) {
+    return localContent.codexDurability
+  }
+  return codexDurabilityMatchesCanonicalSession(incomingContent.codexDurability, sessionRef)
+    ? incomingContent.codexDurability
+    : undefined
+}
+
 function preserveLocalCanonicalTerminalIdentity(
   localContent: TerminalPaneContent,
   incomingContent: TerminalPaneContent,
@@ -530,14 +543,14 @@ function preserveLocalCanonicalTerminalIdentity(
   if (!localSessionRef) return incomingContent
   return {
     ...incomingContent,
+    createRequestId: localContent.createRequestId,
+    status: localContent.status,
     sessionRef: localSessionRef,
     resumeSessionId: undefined,
     terminalId: localContent.terminalId,
     serverInstanceId: localContent.serverInstanceId,
     streamId: localContent.streamId,
-    codexDurability: codexDurabilityMatchesCanonicalSession(incomingContent.codexDurability, localSessionRef)
-      ? incomingContent.codexDurability
-      : undefined,
+    codexDurability: pickCanonicalCodexDurability(localContent, incomingContent, localSessionRef),
   }
 }
 

--- a/src/store/panesSlice.ts
+++ b/src/store/panesSlice.ts
@@ -9,6 +9,7 @@ import {
   type PaneContentInput,
   type PaneNode,
   type PaneRefreshRequest,
+  type TerminalPaneContent,
 } from './paneTypes'
 import { derivePaneTitle } from '@/lib/derivePaneTitle'
 import { matchesDerivedPaneTitle } from '@/lib/pane-title'
@@ -510,6 +511,36 @@ function sessionRefsEqual(left?: { provider?: string; sessionId?: string }, righ
   return left?.provider === right?.provider && left?.sessionId === right?.sessionId
 }
 
+function codexDurabilityMatchesCanonicalSession(
+  codexDurability: TerminalPaneContent['codexDurability'],
+  sessionRef: { provider?: string; sessionId?: string } | undefined,
+): boolean {
+  return Boolean(
+    sessionRef?.provider === 'codex'
+    && codexDurability?.state === 'durable'
+    && codexDurability.durableThreadId === sessionRef.sessionId,
+  )
+}
+
+function preserveLocalCanonicalTerminalIdentity(
+  localContent: TerminalPaneContent,
+  incomingContent: TerminalPaneContent,
+): TerminalPaneContent {
+  const localSessionRef = sanitizeSessionRef(localContent.sessionRef)
+  if (!localSessionRef) return incomingContent
+  return {
+    ...incomingContent,
+    sessionRef: localSessionRef,
+    resumeSessionId: undefined,
+    terminalId: localContent.terminalId,
+    serverInstanceId: localContent.serverInstanceId,
+    streamId: localContent.streamId,
+    codexDurability: codexDurabilityMatchesCanonicalSession(incomingContent.codexDurability, localSessionRef)
+      ? incomingContent.codexDurability
+      : undefined,
+  }
+}
+
 function reconcileRefreshRequestsForTab(state: PanesState, tabId: string) {
   const tabRequests = state.refreshRequestsByPane?.[tabId]
   if (!tabRequests) return
@@ -557,6 +588,7 @@ function mergeTerminalState(
   // If both leaves, apply smart merge for terminal and fresh-agent content
   if (incoming.type === 'leaf' && local.type === 'leaf') {
     if (incoming.content?.kind === 'terminal' && local.content?.kind === 'terminal') {
+      const localSessionRef = sanitizeSessionRef(local.content.sessionRef)
       if (incoming.content.createRequestId === local.content.createRequestId) {
         // Same createRequestId: prefer local if it has terminalId and
         // incoming is still creating (not exited). Exit state must propagate.
@@ -588,6 +620,13 @@ function mergeTerminalState(
         // regenerated its ID (e.g. after INVALID_TERMINAL_ID). Stale remote
         // state must not overwrite the active reconnection.
         return local
+      }
+
+      if (localSessionRef) {
+        return {
+          ...incoming,
+          content: preserveLocalCanonicalTerminalIdentity(local.content, incoming.content),
+        }
       }
     }
 
@@ -1551,14 +1590,7 @@ export const panesSlice = createSlice({
             content.sessionRef = canonicalSessionRef
           }
           content.resumeSessionId = undefined
-          if (!(
-            canonicalSessionRef.provider === 'codex'
-            && content.codexDurability?.state === 'durable'
-            && (
-              content.codexDurability.durableThreadId === canonicalSessionRef.sessionId
-              || content.codexDurability.candidate?.candidateThreadId === canonicalSessionRef.sessionId
-            )
-          )) {
+          if (!codexDurabilityMatchesCanonicalSession(content.codexDurability, canonicalSessionRef)) {
             content.codexDurability = undefined
           }
           clearRestoreFallbackAttemptForPane(state, tabId, node.id)
@@ -1586,6 +1618,8 @@ export const panesSlice = createSlice({
             const staleTerminalId = node.content.terminalId
             const nextRequestId = nanoid()
             node.content.terminalId = undefined
+            node.content.serverInstanceId = undefined
+            node.content.streamId = undefined
             node.content.status = 'creating'
             node.content.createRequestId = nextRequestId
             if (!sanitizeSessionRef(node.content.sessionRef)) {
@@ -1616,6 +1650,48 @@ export const panesSlice = createSlice({
       for (const [tabId, layout] of Object.entries(state.layouts)) {
         clearDeadInNode(layout, tabId)
       }
+    },
+
+    repairCodexIdentityMismatch: (
+      state,
+      action: PayloadAction<{
+        tabId: string
+        paneId: string
+        staleTerminalId: string
+        expectedSessionRef: { provider: string; sessionId: string }
+        createRequestId: string
+      }>
+    ) => {
+      const { tabId, paneId, staleTerminalId, expectedSessionRef, createRequestId } = action.payload
+      const root = state.layouts[tabId]
+      if (!root) return
+
+      function repairNode(node: PaneNode): void {
+        if (node.type === 'leaf') {
+          if (node.id !== paneId || node.content.kind !== 'terminal') return
+          if (node.content.terminalId !== staleTerminalId) return
+          if (!sessionRefsEqual(node.content.sessionRef, expectedSessionRef)) return
+
+          node.content.terminalId = undefined
+          node.content.serverInstanceId = undefined
+          node.content.streamId = undefined
+          node.content.status = 'creating'
+          node.content.createRequestId = createRequestId
+          node.content.sessionRef = expectedSessionRef
+          node.content.codexDurability = codexDurabilityMatchesCanonicalSession(
+            node.content.codexDurability,
+            expectedSessionRef,
+          )
+            ? node.content.codexDurability
+            : undefined
+          clearRestoreFallbackAttemptForPane(state, tabId, paneId)
+          return
+        }
+        repairNode(node.children[0])
+        repairNode(node.children[1])
+      }
+
+      repairNode(root)
     },
   },
 })
@@ -1649,6 +1725,7 @@ export const {
   clearPaneRenameRequest,
   toggleZoom,
   clearDeadTerminals,
+  repairCodexIdentityMismatch,
 } = panesSlice.actions
 
 export default panesSlice.reducer

--- a/test/e2e/codex-wrong-thread-resume.test.tsx
+++ b/test/e2e/codex-wrong-thread-resume.test.tsx
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import tabsReducer from '@/store/tabsSlice'
+import panesReducer from '@/store/panesSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
+import connectionReducer from '@/store/connectionSlice'
+import { useAppSelector } from '@/store/hooks'
+import type { PaneNode, TerminalPaneContent } from '@/store/paneTypes'
+import TerminalView from '@/components/TerminalView'
+
+const wsHarness = vi.hoisted(() => {
+  const messageHandlers = new Set<(msg: any) => void>()
+  const restoreRequestIds = new Set<string>()
+  const send = vi.fn()
+  const connect = vi.fn().mockResolvedValue(undefined)
+  const onMessage = vi.fn((handler: (msg: any) => void) => {
+    messageHandlers.add(handler)
+    return () => messageHandlers.delete(handler)
+  })
+  const onReconnect = vi.fn(() => () => {})
+  return {
+    send,
+    connect,
+    onMessage,
+    onReconnect,
+    emit(msg: any) {
+      for (const handler of [...messageHandlers]) handler(msg)
+    },
+    addRestoreRequestId(id: string) {
+      restoreRequestIds.add(id)
+    },
+    consumeRestoreRequestId(id: string) {
+      if (!restoreRequestIds.has(id)) return false
+      restoreRequestIds.delete(id)
+      return true
+    },
+    reset() {
+      messageHandlers.clear()
+      restoreRequestIds.clear()
+      send.mockClear()
+      connect.mockClear()
+      onMessage.mockClear()
+      onReconnect.mockClear()
+    },
+  }
+})
+
+const runtimeHarness = vi.hoisted(() => ({
+  terminals: [] as any[],
+}))
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({
+    send: wsHarness.send,
+    connect: wsHarness.connect,
+    onMessage: wsHarness.onMessage,
+    onReconnect: wsHarness.onReconnect,
+  }),
+}))
+
+vi.mock('@/lib/terminal-restore', () => ({
+  addTerminalRestoreRequestId: (id: string) => wsHarness.addRestoreRequestId(id),
+  consumeTerminalRestoreRequestId: (id: string) => wsHarness.consumeRestoreRequestId(id),
+  addTerminalFreshRecoveryRequestId: vi.fn(),
+  consumeTerminalFreshRecoveryRequest: vi.fn(() => undefined),
+}))
+
+vi.mock('@/lib/terminal-themes', () => ({
+  getTerminalTheme: () => ({}),
+}))
+
+vi.mock('@/components/terminal/terminal-runtime', () => ({
+  createTerminalRuntime: () => ({
+    attachAddons: vi.fn(),
+    fit: vi.fn(),
+    findNext: vi.fn(() => false),
+    findPrevious: vi.fn(() => false),
+    clearDecorations: vi.fn(),
+    onDidChangeResults: vi.fn(() => ({ dispose: vi.fn() })),
+    dispose: vi.fn(),
+    webglActive: vi.fn(() => false),
+  }),
+}))
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    options: Record<string, unknown> = {}
+    cols = 80
+    rows = 24
+    private dataHandler?: (data: string) => void
+    open = vi.fn()
+    registerLinkProvider = vi.fn(() => ({ dispose: vi.fn() }))
+    onData = vi.fn((handler: (data: string) => void) => {
+      this.dataHandler = handler
+      return { dispose: vi.fn() }
+    })
+    onTitleChange = vi.fn(() => ({ dispose: vi.fn() }))
+    attachCustomKeyEventHandler = vi.fn()
+    attachCustomWheelEventHandler = vi.fn()
+    dispose = vi.fn()
+    focus = vi.fn()
+    getSelection = vi.fn(() => '')
+    clear = vi.fn()
+    write = vi.fn((data: string, cb?: () => void) => {
+      cb?.()
+      return data.length
+    })
+    writeln = vi.fn()
+
+    emitData(data: string) {
+      this.dataHandler?.(data)
+    }
+
+    constructor() {
+      runtimeHarness.terminals.push(this)
+    }
+  },
+}))
+
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
+
+class MockResizeObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+}
+
+function findLeaf(node: PaneNode | undefined, paneId: string): Extract<PaneNode, { type: 'leaf' }> | null {
+  if (!node) return null
+  if (node.type === 'leaf') return node.id === paneId ? node : null
+  return findLeaf(node.children[0], paneId) || findLeaf(node.children[1], paneId)
+}
+
+function TerminalViewFromStore({ tabId, paneId }: { tabId: string; paneId: string }) {
+  const paneContent = useAppSelector((state) => findLeaf(state.panes.layouts[tabId], paneId)?.content ?? null)
+  if (!paneContent || paneContent.kind !== 'terminal') return null
+  return <TerminalView tabId={tabId} paneId={paneId} paneContent={paneContent} />
+}
+
+function createStore(content: TerminalPaneContent) {
+  return configureStore({
+    reducer: {
+      tabs: tabsReducer,
+      panes: panesReducer,
+      settings: settingsReducer,
+      connection: connectionReducer,
+    },
+    preloadedState: {
+      tabs: {
+        tabs: [{
+          id: 'tab-1',
+          mode: content.mode,
+          status: content.status,
+          title: 'Codex',
+          titleSetByUser: false,
+          createRequestId: content.createRequestId,
+        }],
+        activeTabId: 'tab-1',
+      },
+      panes: {
+        layouts: {
+          'tab-1': {
+            type: 'leaf',
+            id: 'pane-1',
+            content,
+          },
+        },
+        activePane: { 'tab-1': 'pane-1' },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      },
+      settings: { settings: defaultSettings, status: 'loaded' },
+      connection: { status: 'connected', error: null, serverInstanceId: 'srv-local' },
+    } as any,
+  })
+}
+
+function sentMessages() {
+  return wsHarness.send.mock.calls.map(([msg]) => msg)
+}
+
+describe('codex wrong-thread resume e2e', () => {
+  beforeEach(() => {
+    wsHarness.reset()
+    runtimeHarness.terminals.length = 0
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('clears stale runtime plumbing and restores the canonical Codex session without sending input to the old thread', async () => {
+    const store = createStore({
+      kind: 'terminal',
+      createRequestId: 'req-old',
+      status: 'running',
+      mode: 'codex',
+      shell: 'system',
+      terminalId: 'term-old',
+      serverInstanceId: 'srv-old',
+      streamId: 'stream-old',
+      sessionRef: {
+        provider: 'codex',
+        sessionId: 'thread-new',
+      },
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-new',
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalViewFromStore tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(sentMessages().some((msg) => msg?.type === 'terminal.attach' && msg.terminalId === 'term-old')).toBe(true)
+    })
+
+    wsHarness.send.mockClear()
+
+    act(() => {
+      wsHarness.emit({
+        type: 'error',
+        code: 'SESSION_IDENTITY_MISMATCH',
+        terminalId: 'term-old',
+        expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+        actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
+        message: 'wrong thread',
+      })
+    })
+
+    await waitFor(() => {
+      const pane = findLeaf(store.getState().panes.layouts['tab-1'], 'pane-1')
+      expect((pane?.content as TerminalPaneContent).terminalId).toBeUndefined()
+      expect((pane?.content as TerminalPaneContent).status).toBe('creating')
+    })
+
+    const createMessage = sentMessages().find((msg) => msg?.type === 'terminal.create')
+    expect(createMessage).toMatchObject({
+      type: 'terminal.create',
+      restore: true,
+      sessionRef: { provider: 'codex', sessionId: 'thread-new' },
+    })
+
+    act(() => {
+      wsHarness.emit({
+        type: 'terminal.created',
+        requestId: createMessage.requestId,
+        terminalId: 'term-new',
+      })
+    })
+
+    await waitFor(() => {
+      expect(sentMessages().some((msg) => msg?.type === 'terminal.attach' && msg.terminalId === 'term-new')).toBe(true)
+    })
+
+    const term = runtimeHarness.terminals[0]
+    act(() => {
+      term.emitData('hello')
+    })
+
+    expect(sentMessages().some((msg) => msg?.type === 'terminal.input' && msg.terminalId === 'term-old')).toBe(false)
+    expect(sentMessages()).toContainEqual({
+      type: 'terminal.input',
+      terminalId: 'term-new',
+      data: 'hello',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+    })
+  })
+})

--- a/test/e2e/tabs-view-flow.test.tsx
+++ b/test/e2e/tabs-view-flow.test.tsx
@@ -224,7 +224,7 @@ describe('tabs view flow', () => {
     expect(copiedLayout?.content?.terminalId).toBeUndefined()
   })
 
-  it('opens same-server tab copies with an explicit live terminal handle', () => {
+  it('opens same-server tab copies without hydrating an unproven live terminal handle when a canonical sessionRef exists', () => {
     const store = configureStore({
       reducer: {
         tabs: tabsReducer,
@@ -287,7 +287,7 @@ describe('tabs view flow', () => {
       provider: 'codex',
       sessionId: 'codex-session-456',
     })
-    expect(copiedLayout?.content?.terminalId).toBe('term-local-1')
-    expect(copiedLayout?.content?.serverInstanceId).toBe('srv-local')
+    expect(copiedLayout?.content?.terminalId).toBeUndefined()
+    expect(copiedLayout?.content?.serverInstanceId).toBeUndefined()
   })
 })

--- a/test/server/agent-codex-identity-invariant.test.ts
+++ b/test/server/agent-codex-identity-invariant.test.ts
@@ -1,0 +1,98 @@
+import { expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { createAgentApiRouter } from '../../server/agent-api/router'
+import { CODEX_DURABILITY_SCHEMA_VERSION } from '../../shared/codex-durability.js'
+
+function durableCodexTerminal(sessionId: string) {
+  return {
+    mode: 'codex',
+    shell: 'system',
+    resumeSessionId: sessionId,
+    codexDurability: {
+      schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
+      state: 'durable',
+      durableThreadId: sessionId,
+    },
+  }
+}
+
+it('rejects attaching a Codex terminal whose canonical identity conflicts with the pane sessionRef', async () => {
+  const app = express()
+  app.use(express.json())
+  const attachPaneContent = vi.fn()
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      attachPaneContent,
+      resolveTarget: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+      getPaneSnapshot: () => ({
+        tabId: 'tab_1',
+        paneId: 'pane_1',
+        paneContent: {
+          kind: 'terminal',
+          terminalId: 'term_new',
+          sessionRef: { provider: 'codex', sessionId: 'thread-new' },
+        },
+      }),
+    } as any,
+    registry: {
+      get: () => durableCodexTerminal('thread-old'),
+    } as any,
+    wsHandler: { broadcastUiCommand: vi.fn() },
+  }))
+
+  const res = await request(app)
+    .post('/api/panes/pane_1/attach')
+    .send({ terminalId: 'term_old' })
+
+  expect(res.status).toBe(409)
+  expect(res.body.status).toBe('error')
+  expect(res.body.message).toContain('Expected codex:thread-new, got codex:thread-old')
+  expect(attachPaneContent).not.toHaveBeenCalled()
+})
+
+it('rejects send-keys when the pane sessionRef conflicts with the target Codex terminal', async () => {
+  const inputIfSessionMatches = vi.fn(() => ({
+    status: 'session_identity_mismatch',
+    terminalId: 'term_old',
+    expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+    actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
+  }))
+  const rawInput = vi.fn()
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      resolvePaneToTerminal: () => 'term_old',
+      getPaneSnapshot: () => ({
+        tabId: 'tab_1',
+        paneId: 'pane_1',
+        terminalId: 'term_old',
+        paneContent: {
+          kind: 'terminal',
+          terminalId: 'term_old',
+          sessionRef: { provider: 'codex', sessionId: 'thread-new' },
+        },
+      }),
+    } as any,
+    registry: {
+      get: () => durableCodexTerminal('thread-old'),
+      input: rawInput,
+      inputIfSessionMatches,
+    } as any,
+  }))
+
+  const res = await request(app)
+    .post('/api/panes/pane_1/send-keys')
+    .send({ data: 'ls\r' })
+
+  expect(res.status).toBe(409)
+  expect(res.body.status).toBe('error')
+  expect(res.body.message).toContain('Expected codex:thread-new, got codex:thread-old')
+  expect(inputIfSessionMatches).toHaveBeenCalledWith(
+    'term_old',
+    'ls\r',
+    { provider: 'codex', sessionId: 'thread-new' },
+  )
+  expect(rawInput).not.toHaveBeenCalled()
+})

--- a/test/server/agent-panes-write.test.ts
+++ b/test/server/agent-panes-write.test.ts
@@ -4,6 +4,7 @@ import request from 'supertest'
 import { createAgentApiRouter } from '../../server/agent-api/router'
 import { FakeCodexLaunchPlanner } from '../helpers/coding-cli/fake-codex-launch-planner.js'
 import { INVALID_RAW_CODEX_RESUME_MESSAGE } from '../../server/coding-cli/codex-app-server/restore-decision.js'
+import { CODEX_DURABILITY_SCHEMA_VERSION } from '../../shared/codex-durability.js'
 
 it('splits a pane horizontally', async () => {
   const app = express()
@@ -531,6 +532,47 @@ it('preserves attached shell metadata for non-system terminals', async () => {
     terminalId: 'term_1',
     mode: 'shell',
     shell: 'powershell',
+  }))
+})
+
+it('persists an explicit canonical sessionRef when attaching a matching Codex terminal', async () => {
+  const app = express()
+  app.use(express.json())
+  const attachPaneContent = vi.fn()
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      attachPaneContent,
+      resolveTarget: () => ({ tabId: 'tab_1', paneId: 'pane_1' }),
+      getPaneSnapshot: () => ({
+        tabId: 'tab_1',
+        paneId: 'pane_1',
+        paneContent: { kind: 'terminal' },
+      }),
+    } as any,
+    registry: {
+      get: () => ({
+        mode: 'codex',
+        shell: 'system',
+        resumeSessionId: 'thread-1',
+        codexDurability: {
+          schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
+          state: 'durable',
+          durableThreadId: 'thread-1',
+        },
+      }),
+    } as any,
+    wsHandler: { broadcastUiCommand: vi.fn() },
+  }))
+
+  const res = await request(app)
+    .post('/api/panes/pane_1/attach')
+    .send({ terminalId: 'term_1', sessionRef: { provider: 'codex', sessionId: 'thread-1' } })
+
+  expect(res.status).toBe(200)
+  expect(attachPaneContent).toHaveBeenCalledWith('tab_1', 'pane_1', expect.objectContaining({
+    terminalId: 'term_1',
+    mode: 'codex',
+    sessionRef: { provider: 'codex', sessionId: 'thread-1' },
   }))
 })
 

--- a/test/server/agent-send-keys.test.ts
+++ b/test/server/agent-send-keys.test.ts
@@ -129,3 +129,36 @@ it('waits for Codex identity capture before sending a seeded prompt when request
   expect(res.body.status).toBe('ok')
   expect(input).toHaveBeenLastCalledWith('term_1', 'build the thing\r')
 })
+
+it('passes the pane canonical sessionRef to the registry identity gate', async () => {
+  const inputIfSessionMatches = vi.fn(() => ({ status: 'written' }))
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: {
+      resolvePaneToTerminal: () => 'term_1',
+      getPaneSnapshot: () => ({
+        tabId: 'tab_1',
+        paneId: 'pane_1',
+        terminalId: 'term_1',
+        paneContent: {
+          kind: 'terminal',
+          terminalId: 'term_1',
+          sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+        },
+      }),
+    },
+    registry: {
+      get: () => ({ mode: 'codex' }),
+      input: vi.fn(() => ({ status: 'written' })),
+      inputIfSessionMatches,
+    },
+  }))
+
+  const res = await request(app).post('/api/panes/p1/send-keys').send({ data: 'ls\r' })
+  expect(res.body.status).toBe('ok')
+  expect(inputIfSessionMatches).toHaveBeenCalledWith('term_1', 'ls\r', {
+    provider: 'codex',
+    sessionId: 'thread-1',
+  })
+})

--- a/test/server/ws-protocol.test.ts
+++ b/test/server/ws-protocol.test.ts
@@ -7,7 +7,11 @@ import {
   ClaudeActivityListResponseSchema,
   ClaudeActivityUpdatedSchema,
   ClaudeActivityListSchema,
+  ErrorCode,
   HelloSchema,
+  TerminalAttachSchema,
+  TerminalInputSchema,
+  TerminalResizeSchema,
   TerminalTurnCompleteSchema,
 } from '../../shared/ws-protocol.js'
 import {
@@ -19,6 +23,48 @@ import {
 const TEST_TIMEOUT_MS = 30_000
 const HOOK_TIMEOUT_MS = 30_000
 vi.setConfig({ testTimeout: TEST_TIMEOUT_MS, hookTimeout: HOOK_TIMEOUT_MS })
+
+describe('websocket protocol schemas', () => {
+  it('preserves expectedSessionRef on terminal.attach', () => {
+    const parsed = TerminalAttachSchema.parse({
+      type: 'terminal.attach',
+      terminalId: 'term-1',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
+      intent: 'viewport_hydrate',
+      cols: 120,
+      rows: 40,
+    })
+
+    expect(parsed.expectedSessionRef).toEqual({ provider: 'codex', sessionId: 'thread-1' })
+  })
+
+  it('preserves expectedSessionRef on terminal.input', () => {
+    const parsed = TerminalInputSchema.parse({
+      type: 'terminal.input',
+      terminalId: 'term-1',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
+      data: 'echo test',
+    })
+
+    expect(parsed.expectedSessionRef).toEqual({ provider: 'codex', sessionId: 'thread-1' })
+  })
+
+  it('preserves expectedSessionRef on terminal.resize', () => {
+    const parsed = TerminalResizeSchema.parse({
+      type: 'terminal.resize',
+      terminalId: 'term-1',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
+      cols: 120,
+      rows: 40,
+    })
+
+    expect(parsed.expectedSessionRef).toEqual({ provider: 'codex', sessionId: 'thread-1' })
+  })
+
+  it('accepts SESSION_IDENTITY_MISMATCH as an error code', () => {
+    expect(ErrorCode.parse('SESSION_IDENTITY_MISMATCH')).toBe('SESSION_IDENTITY_MISMATCH')
+  })
+})
 
 // Mock the config-store module before importing ws-handler
 const mockConfigStore = vi.hoisted(() => ({

--- a/test/server/ws-terminal-codex-identity-invariant.test.ts
+++ b/test/server/ws-terminal-codex-identity-invariant.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi } from 'vitest'
+import http from 'http'
+import WebSocket from 'ws'
+import { WsHandler } from '../../server/ws-handler.js'
+import { CODEX_DURABILITY_SCHEMA_VERSION } from '../../shared/codex-durability.js'
+import {
+  buildSessionIdentityMismatchDetails,
+  terminalMatchesExpectedSession,
+} from '../../server/terminal-session-identity.js'
+
+class FakeBuffer {
+  snapshot() {
+    return 'stale output'
+  }
+}
+
+function createAuthenticatedState() {
+  return {
+    authenticated: true,
+    supportsUiScreenshotV1: false,
+    supportsTerminalOutputBatchV1: false,
+    attachedTerminalIds: new Set<string>(),
+    createdByRequestId: new Map(),
+    claudeFreshSessionIdByRequestId: new Map(),
+    terminalCreateTimestamps: [],
+    codingCliSessions: new Set<string>(),
+    codingCliSubscriptions: new Map(),
+    sdkSessions: new Set<string>(),
+    sdkSubscriptions: new Map(),
+    sdkSessionTargets: new Map(),
+    freshAgentSubscriptions: new Map(),
+    wsErrorLogs: new Map(),
+    interestedSessions: new Set<string>(),
+    sidebarOpenSessionKeys: new Set<string>(),
+  }
+}
+
+function createOpenFakeWs(connectionId: string, sent: any[]) {
+  return {
+    readyState: WebSocket.OPEN,
+    bufferedAmount: 0,
+    connectionId,
+    send: vi.fn((payload: string, cb?: (err?: Error) => void) => {
+      sent.push(JSON.parse(payload))
+      cb?.()
+    }),
+    close: vi.fn(),
+  }
+}
+
+class FakeRegistry {
+  attachCalls: Array<{ terminalId: string }> = []
+  inputCalls: Array<{ terminalId: string; data: string }> = []
+  resizeCalls: Array<{ terminalId: string; cols: number; rows: number }> = []
+
+  constructor(private record: any) {}
+
+  get(terminalId: string) {
+    return terminalId === this.record.terminalId ? this.record : null
+  }
+
+  attach(terminalId: string, _ws: any) {
+    if (terminalId !== this.record.terminalId) return null
+    this.attachCalls.push({ terminalId })
+    return this.record
+  }
+
+  detach() {
+    return true
+  }
+
+  inputIfSessionMatches(terminalId: string, data: string, expectedSessionRef?: { provider: string; sessionId: string }) {
+    if (terminalId !== this.record.terminalId) return { status: 'no_terminal' as const }
+    if (expectedSessionRef && !terminalMatchesExpectedSession(this.record, expectedSessionRef)) {
+      return {
+        status: 'session_identity_mismatch' as const,
+        terminalId,
+        ...buildSessionIdentityMismatchDetails(this.record, expectedSessionRef),
+      }
+    }
+    this.inputCalls.push({ terminalId, data })
+    return { status: 'written' as const }
+  }
+
+  resizeIfSessionMatches(terminalId: string, cols: number, rows: number, expectedSessionRef?: { provider: string; sessionId: string }) {
+    if (terminalId !== this.record.terminalId) return { status: 'missing' as const }
+    if (expectedSessionRef && !terminalMatchesExpectedSession(this.record, expectedSessionRef)) {
+      return {
+        status: 'session_identity_mismatch' as const,
+        terminalId,
+        ...buildSessionIdentityMismatchDetails(this.record, expectedSessionRef),
+      }
+    }
+    this.resizeCalls.push({ terminalId, cols, rows })
+    return { status: 'resized' as const }
+  }
+
+  resize(terminalId: string, cols: number, rows: number) {
+    const result = this.resizeIfSessionMatches(terminalId, cols, rows)
+    return result.status === 'resized'
+  }
+
+  input(terminalId: string, data: string) {
+    return this.inputIfSessionMatches(terminalId, data)
+  }
+
+  list() {
+    return []
+  }
+}
+
+describe('ws terminal codex identity invariant', () => {
+  it('rejects attach, input, and resize when canonical Codex identity mismatches', async () => {
+    process.env.AUTH_TOKEN = 'testtoken-testtoken'
+    const record = {
+      terminalId: 'term-old',
+      createdAt: Date.now(),
+      title: 'Codex',
+      mode: 'codex',
+      shell: 'system',
+      status: 'running',
+      cols: 80,
+      rows: 24,
+      resumeSessionId: 'thread-old',
+      codexDurability: {
+        schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
+        state: 'durable',
+        durableThreadId: 'thread-old',
+      },
+      buffer: new FakeBuffer(),
+      clients: new Set(),
+    }
+    const registry = new FakeRegistry(record)
+    const handler = new WsHandler(http.createServer(), registry as any)
+    const sent: any[] = []
+    const ws = createOpenFakeWs('conn-1', sent)
+    const state = createAuthenticatedState()
+
+    await (handler as any).onMessage(ws, state, Buffer.from(JSON.stringify({
+      type: 'terminal.attach',
+      terminalId: 'term-old',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+      intent: 'viewport_hydrate',
+      cols: 120,
+      rows: 40,
+      attachRequestId: 'attach-1',
+      sinceSeq: 0,
+    })))
+    await (handler as any).onMessage(ws, state, Buffer.from(JSON.stringify({
+      type: 'terminal.input',
+      terminalId: 'term-old',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+      data: 'echo wrong thread',
+    })))
+    await (handler as any).onMessage(ws, state, Buffer.from(JSON.stringify({
+      type: 'terminal.resize',
+      terminalId: 'term-old',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+      cols: 100,
+      rows: 30,
+    })))
+
+    expect(sent).toEqual([
+      expect.objectContaining({
+        type: 'error',
+        code: 'SESSION_IDENTITY_MISMATCH',
+        requestId: 'attach-1',
+        terminalId: 'term-old',
+        expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+        actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
+      }),
+      expect.objectContaining({
+        type: 'error',
+        code: 'SESSION_IDENTITY_MISMATCH',
+        terminalId: 'term-old',
+        expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+        actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
+      }),
+      expect.objectContaining({
+        type: 'error',
+        code: 'SESSION_IDENTITY_MISMATCH',
+        terminalId: 'term-old',
+        expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+        actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
+      }),
+    ])
+    expect(sent.some((msg) => msg.type === 'terminal.attach.ready')).toBe(false)
+    expect(registry.attachCalls).toHaveLength(0)
+    expect(registry.inputCalls).toHaveLength(0)
+    expect(registry.resizeCalls).toHaveLength(0)
+  })
+
+  it('does not treat candidate-only Codex durability as side-effect authority', async () => {
+    process.env.AUTH_TOKEN = 'testtoken-testtoken'
+    const record = {
+      terminalId: 'term-candidate',
+      createdAt: Date.now(),
+      title: 'Codex',
+      mode: 'codex',
+      shell: 'system',
+      status: 'running',
+      cols: 80,
+      rows: 24,
+      resumeSessionId: 'thread-candidate',
+      codexDurability: {
+        schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
+        state: 'proof_checking',
+        candidate: {
+          provider: 'codex',
+          candidateThreadId: 'thread-candidate',
+          rolloutPath: '/tmp/freshell-rollout.jsonl',
+          source: 'restored_client_state',
+          capturedAt: 1,
+        },
+      },
+      buffer: new FakeBuffer(),
+      clients: new Set(),
+    }
+    const registry = new FakeRegistry(record)
+    const handler = new WsHandler(http.createServer(), registry as any)
+    const sent: any[] = []
+    const ws = createOpenFakeWs('conn-2', sent)
+    const state = createAuthenticatedState()
+
+    await (handler as any).onMessage(ws, state, Buffer.from(JSON.stringify({
+      type: 'terminal.input',
+      terminalId: 'term-candidate',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-candidate' },
+      data: 'echo still blocked',
+    })))
+
+    expect(sent).toEqual([
+      expect.objectContaining({
+        type: 'error',
+        code: 'SESSION_IDENTITY_MISMATCH',
+        terminalId: 'term-candidate',
+        expectedSessionRef: { provider: 'codex', sessionId: 'thread-candidate' },
+      }),
+    ])
+    expect(registry.inputCalls).toHaveLength(0)
+  })
+})

--- a/test/server/ws-terminal-create-reuse-running-codex.test.ts
+++ b/test/server/ws-terminal-create-reuse-running-codex.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { EventEmitter } from 'node:events'
 import WebSocket from 'ws'
+import { CODEX_DURABILITY_SCHEMA_VERSION } from '../../shared/codex-durability.js'
 import { WS_PROTOCOL_VERSION } from '../../shared/ws-protocol'
 import { WsHandler } from '../../server/ws-handler'
 import { FakeCodexLaunchPlanner, DEFAULT_CODEX_REMOTE_WS_URL } from '../helpers/coding-cli/fake-codex-launch-planner.js'
@@ -295,6 +296,11 @@ class FakeRegistry extends EventEmitter {
       cols: 80,
       rows: 24,
       resumeSessionId: CODEX_SESSION_ID,
+      codexDurability: {
+        schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
+        state: 'durable',
+        durableThreadId: CODEX_SESSION_ID,
+      },
       clients: new Set<WebSocket>(),
     }))
   }
@@ -503,7 +509,7 @@ describe('terminal.create reuse running codex terminal', () => {
     vi.useRealTimers()
   }, HOOK_TIMEOUT_MS)
 
-  it('reuses existing codex terminal and requires an explicit attach', async () => {
+  it('treats same-server Codex live handles without a canonical sessionRef as a fresh create', async () => {
     const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
       await waitForOpen(ws)
@@ -527,7 +533,7 @@ describe('terminal.create reuse running codex terminal', () => {
       expect(created.terminalId).toBe('term-codex-existing')
       expect(preAttachMsgs.some((m) => m.type === 'terminal.attach.ready' && m.terminalId === created.terminalId)).toBe(false)
       expect(registry.attachCalls).toHaveLength(0)
-      expect(registry.createCalls).toHaveLength(0)
+      expect(registry.createCalls).toHaveLength(1)
 
       const attachReadyPromise = waitForMessage(ws,
         (m) => m.type === 'terminal.attach.ready' && m.attachRequestId === 'reuse-existing-codex-attach',
@@ -774,127 +780,6 @@ describe('terminal.create reuse running codex terminal', () => {
     }
   })
 
-  it('proof-reads captured Codex durability and resumes only after proof succeeds', async () => {
-    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-proof-'))
-    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
-    try {
-      const rolloutPath = path.join(tempDir, 'rollout.jsonl')
-      await fsp.writeFile(
-        rolloutPath,
-        '{"type":"session_meta","payload":{"id":"thread-proved"}}\n',
-        'utf8',
-      )
-      await waitForOpen(ws, PROOF_MESSAGE_TIMEOUT_MS)
-      await waitForReady(ws)
-
-      const requestId = 'codex-proved-reopen'
-      const createdPromise = waitForMessage(
-        ws,
-        (m) => m.type === 'terminal.created' && m.requestId === requestId,
-        PROOF_MESSAGE_TIMEOUT_MS,
-      )
-      const associatedPromise = waitForMessage(ws, (m) => (
-        m.type === 'terminal.session.associated'
-        && m.sessionRef?.provider === 'codex'
-        && m.sessionRef?.sessionId === 'thread-proved'
-      ), PROOF_MESSAGE_TIMEOUT_MS)
-      ws.send(JSON.stringify({
-        type: 'terminal.create',
-        requestId,
-        mode: 'codex',
-        restore: true,
-        codexDurability: {
-          schemaVersion: 1,
-          state: 'captured_pre_turn',
-          candidate: {
-            provider: 'codex',
-            candidateThreadId: 'thread-proved',
-            rolloutPath,
-            source: 'thread_started_notification',
-            capturedAt: Date.now(),
-          },
-        },
-      }))
-
-      const created = await createdPromise
-      const associated = await associatedPromise
-      expect(created).not.toHaveProperty('effectiveResumeSessionId')
-      expect(associated.terminalId).toBe(created.terminalId)
-      expect(codexLaunchPlanner.planCreateCalls[0]).toMatchObject({
-        resumeSessionId: 'thread-proved',
-      })
-      expect(registry.createCalls[0]).toMatchObject({
-        mode: 'codex',
-        resumeSessionId: 'thread-proved',
-      })
-    } finally {
-      await closeWebSocket(ws)
-      await fsp.rm(tempDir, { recursive: true, force: true })
-    }
-  }, PROOF_TEST_TIMEOUT_MS)
-
-  it('proof-reads server-stored Codex durability when the client has not persisted candidate state', async () => {
-    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-store-proof-'))
-    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
-    try {
-      const rolloutPath = path.join(tempDir, 'rollout.jsonl')
-      await fsp.writeFile(
-        rolloutPath,
-        '{"type":"session_meta","payload":{"id":"thread-store-proved"}}\n',
-        'utf8',
-      )
-      registry.durabilityRestoreRecords.push({
-        terminalId: 'old-store-terminal',
-        tabId: 'tab-bridge',
-        paneId: 'pane-bridge',
-        durability: {
-          schemaVersion: 1,
-          state: 'captured_pre_turn',
-          candidate: {
-            provider: 'codex',
-            candidateThreadId: 'thread-store-proved',
-            rolloutPath,
-            source: 'thread_started_notification',
-            capturedAt: Date.now(),
-          },
-        },
-      })
-      await waitForOpen(ws, PROOF_MESSAGE_TIMEOUT_MS)
-      await waitForReady(ws)
-
-      const requestId = 'codex-store-proved-reopen'
-      const createdPromise = waitForMessage(
-        ws,
-        (m) => m.type === 'terminal.created' && m.requestId === requestId,
-        PROOF_MESSAGE_TIMEOUT_MS,
-      )
-      ws.send(JSON.stringify({
-        type: 'terminal.create',
-        requestId,
-        mode: 'codex',
-        restore: true,
-        tabId: 'tab-bridge',
-        paneId: 'pane-bridge',
-      }))
-
-      await createdPromise
-      expect(codexLaunchPlanner.planCreateCalls[0]).toMatchObject({
-        resumeSessionId: 'thread-store-proved',
-      })
-      expect(registry.createCalls[0]).toMatchObject({
-        mode: 'codex',
-        resumeSessionId: 'thread-store-proved',
-      })
-      expect(registry.deletedDurabilityRecords).toEqual([{
-        terminalId: 'old-store-terminal',
-        reason: 'restore_proof_succeeded_created_replacement',
-      }])
-    } finally {
-      await closeWebSocket(ws)
-      await fsp.rm(tempDir, { recursive: true, force: true })
-    }
-  }, PROOF_TEST_TIMEOUT_MS)
-
   it('does not use server-stored Codex durability for non-restore fresh creates', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-store-fresh-'))
     const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
@@ -950,11 +835,48 @@ describe('terminal.create reuse running codex terminal', () => {
     }
   })
 
-  it('fresh-creates with restore failure when server-stored Codex durability cannot be proved', async () => {
-    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-store-proof-missing-'))
+  it('rejects restore requests that only provide client candidate durability', async () => {
     const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
-      const rolloutPath = path.join(tempDir, 'missing.jsonl')
+      await waitForOpen(ws)
+      await waitForReady(ws)
+
+      const requestId = 'codex-candidate-only-restore'
+      const errorPromise = waitForMessage(ws, (m) => m.type === 'error' && m.requestId === requestId)
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'codex',
+        restore: true,
+        codexDurability: {
+          schemaVersion: 1,
+          state: 'captured_pre_turn',
+          candidate: {
+            provider: 'codex',
+            candidateThreadId: 'thread-store-missing',
+            rolloutPath: '/tmp/missing.jsonl',
+            source: 'thread_started_notification',
+            capturedAt: Date.now(),
+          },
+        },
+      }))
+
+      await expect(errorPromise).resolves.toMatchObject({
+        type: 'error',
+        requestId,
+        code: 'RESTORE_UNAVAILABLE',
+        message: 'Restore requires a canonical session reference.',
+      })
+      expect(codexLaunchPlanner.planCreateCalls).toHaveLength(0)
+      expect(registry.createCalls).toHaveLength(0)
+    } finally {
+      await closeWebSocket(ws)
+    }
+  }, PROOF_TEST_TIMEOUT_MS)
+
+  it('rejects restore requests that rely on server-stored durability without a canonical sessionRef', async () => {
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
+    try {
       registry.durabilityRestoreRecords.push({
         terminalId: 'old-store-terminal',
         tabId: 'tab-bridge',
@@ -964,18 +886,22 @@ describe('terminal.create reuse running codex terminal', () => {
           state: 'captured_pre_turn',
           candidate: {
             provider: 'codex',
-            candidateThreadId: 'thread-store-missing',
-            rolloutPath,
+            candidateThreadId: 'thread-store-proved',
+            rolloutPath: '/tmp/rollout.jsonl',
             source: 'thread_started_notification',
             capturedAt: Date.now(),
           },
         },
       })
-      await waitForOpen(ws)
+      await waitForOpen(ws, PROOF_MESSAGE_TIMEOUT_MS)
       await waitForReady(ws)
 
-      const requestId = 'codex-store-unproved-reopen'
-      const createdPromise = waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === requestId)
+      const requestId = 'codex-store-proved-reopen'
+      const errorPromise = waitForMessage(
+        ws,
+        (m) => m.type === 'error' && m.requestId === requestId,
+        PROOF_MESSAGE_TIMEOUT_MS,
+      )
       ws.send(JSON.stringify({
         type: 'terminal.create',
         requestId,
@@ -985,130 +911,28 @@ describe('terminal.create reuse running codex terminal', () => {
         paneId: 'pane-bridge',
       }))
 
-      const created = await createdPromise
-      expect(created).toMatchObject({
-        type: 'terminal.created',
+      await expect(errorPromise).resolves.toMatchObject({
+        type: 'error',
         requestId,
-        clearCodexDurability: true,
-        restoreError: {
-          code: 'RESTORE_UNAVAILABLE',
-          reason: 'durable_artifact_missing',
-        },
+        code: 'RESTORE_UNAVAILABLE',
+        message: 'Restore requires a canonical session reference.',
       })
-      expect(codexLaunchPlanner.planCreateCalls[0]).toMatchObject({
-        resumeSessionId: undefined,
-      })
-      expect(registry.createCalls[0]).toMatchObject({
-        mode: 'codex',
-        resumeSessionId: undefined,
-      })
-      expect(registry.deletedDurabilityRecords).toEqual([{
-        terminalId: 'old-store-terminal',
-        reason: 'restore_proof_failed_fresh_create',
-      }])
-      expect(registry.durabilityRestoreRecords).toHaveLength(0)
-    } finally {
-      await closeWebSocket(ws)
-      await fsp.rm(tempDir, { recursive: true, force: true })
-    }
-  })
-
-  it('proof-reads a same-server live Codex candidate before reattaching it', async () => {
-    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-proof-live-'))
-    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
-    try {
-      const rolloutPath = path.join(tempDir, 'rollout.jsonl')
-      await fsp.writeFile(
-        rolloutPath,
-        '{"type":"session_meta","payload":{"id":"thread-live-proved"}}\n',
-        'utf8',
-      )
-      registry.records[0].resumeSessionId = undefined
-      registry.records[0].codexDurability = {
-        schemaVersion: 1,
-        state: 'durability_unproven_after_completion',
-        candidate: {
-          provider: 'codex',
-          candidateThreadId: 'thread-live-proved',
-          rolloutPath,
-          source: 'thread_started_notification',
-          capturedAt: Date.now(),
-        },
-        turnCompletedAt: Date.now(),
-      }
-      await waitForOpen(ws)
-      const helloReady = await waitForReady(ws)
-
-      const requestId = 'codex-proved-live-reopen'
-      const createdPromise = waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === requestId)
-      const associatedPromise = waitForMessage(ws, (m) => (
-        m.type === 'terminal.session.associated'
-        && m.terminalId === 'term-codex-existing'
-        && m.sessionRef?.sessionId === 'thread-live-proved'
-      ))
-      const durabilityPromise = waitForMessage(ws, (m) => (
-        m.type === 'terminal.codex.durability.updated'
-        && m.terminalId === 'term-codex-existing'
-        && m.durability?.state === 'durable'
-        && m.durability?.durableThreadId === 'thread-live-proved'
-      ))
-      const terminalsChangedPromise = waitForMessage(ws, (m) => m.type === 'terminals.changed')
-      ws.send(JSON.stringify({
-        type: 'terminal.create',
-        requestId,
-        mode: 'codex',
-        restore: true,
-        liveTerminal: {
-          terminalId: 'term-codex-existing',
-          serverInstanceId: helloReady.serverInstanceId,
-        },
-        codexDurability: registry.records[0].codexDurability,
-      }))
-
-      const created = await createdPromise
-      await associatedPromise
-      await durabilityPromise
-      await terminalsChangedPromise
-      expect(created.terminalId).toBe('term-codex-existing')
-      expect(registry.records[0].resumeSessionId).toBe('thread-live-proved')
-      expect(registry.records[0].codexDurability).toMatchObject({
-        state: 'durable',
-        durableThreadId: 'thread-live-proved',
-      })
-      expect(registry.promoteCalls).toEqual([{
-        terminalId: 'term-codex-existing',
-        durableThreadId: 'thread-live-proved',
-      }])
       expect(codexLaunchPlanner.planCreateCalls).toHaveLength(0)
       expect(registry.createCalls).toHaveLength(0)
+      expect(registry.durabilityRestoreRecords).toHaveLength(1)
     } finally {
       await closeWebSocket(ws)
-      await fsp.rm(tempDir, { recursive: true, force: true })
     }
-  })
+  }, PROOF_TEST_TIMEOUT_MS)
 
-  it('does not promote a stale same-server live Codex handle when its candidate differs', async () => {
-    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-proof-live-mismatch-'))
+  it('ignores stale same-server live Codex handles and resumes the canonical sessionRef instead', async () => {
     const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {
-      const rolloutPath = path.join(tempDir, 'rollout.jsonl')
-      await fsp.writeFile(
-        rolloutPath,
-        '{"type":"session_meta","payload":{"id":"thread-proved-mismatch"}}\n',
-        'utf8',
-      )
-      registry.records[0].resumeSessionId = undefined
+      registry.records[0].resumeSessionId = 'thread-old'
       registry.records[0].codexDurability = {
-        schemaVersion: 1,
-        state: 'durability_unproven_after_completion',
-        candidate: {
-          provider: 'codex',
-          candidateThreadId: 'different-live-thread',
-          rolloutPath,
-          source: 'thread_started_notification',
-          capturedAt: Date.now(),
-        },
-        turnCompletedAt: Date.now(),
+        schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
+        state: 'durable',
+        durableThreadId: 'thread-old',
       }
       await waitForOpen(ws, PROOF_MESSAGE_TIMEOUT_MS)
       const helloReady = await waitForReady(ws)
@@ -1124,130 +948,26 @@ describe('terminal.create reuse running codex terminal', () => {
         requestId,
         mode: 'codex',
         restore: true,
+        sessionRef: { provider: 'codex', sessionId: CODEX_SESSION_ID },
         liveTerminal: {
           terminalId: 'term-codex-existing',
           serverInstanceId: helloReady.serverInstanceId,
-        },
-        codexDurability: {
-          schemaVersion: 1,
-          state: 'durability_unproven_after_completion',
-          candidate: {
-            provider: 'codex',
-            candidateThreadId: 'thread-proved-mismatch',
-            rolloutPath,
-            source: 'thread_started_notification',
-            capturedAt: Date.now(),
-          },
-          turnCompletedAt: Date.now(),
         },
       }))
 
       await createdPromise
       expect(registry.promoteCalls).toEqual([])
       expect(codexLaunchPlanner.planCreateCalls[0]).toMatchObject({
-        resumeSessionId: 'thread-proved-mismatch',
+        resumeSessionId: CODEX_SESSION_ID,
       })
       expect(registry.createCalls[0]).toMatchObject({
         mode: 'codex',
-        resumeSessionId: 'thread-proved-mismatch',
+        resumeSessionId: CODEX_SESSION_ID,
       })
     } finally {
       await closeWebSocket(ws)
-      await fsp.rm(tempDir, { recursive: true, force: true })
     }
   }, PROOF_TEST_TIMEOUT_MS)
-
-  it('does not resume a captured Codex candidate when proof fails', async () => {
-    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-proof-'))
-    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
-    try {
-      const rolloutPath = path.join(tempDir, 'missing.jsonl')
-      await waitForOpen(ws)
-      await waitForReady(ws)
-
-      const requestId = 'codex-unproved-reopen'
-      const createdPromise = waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === requestId)
-      ws.send(JSON.stringify({
-        type: 'terminal.create',
-        requestId,
-        mode: 'codex',
-        restore: true,
-        codexDurability: {
-          schemaVersion: 1,
-          state: 'durability_unproven_after_completion',
-          candidate: {
-            provider: 'codex',
-            candidateThreadId: 'thread-missing',
-            rolloutPath,
-            source: 'thread_started_notification',
-            capturedAt: Date.now(),
-          },
-          turnCompletedAt: Date.now(),
-        },
-      }))
-
-      const created = await createdPromise
-      expect(created).toMatchObject({
-        type: 'terminal.created',
-        requestId,
-        clearCodexDurability: true,
-        restoreError: {
-          code: 'RESTORE_UNAVAILABLE',
-          reason: 'durable_artifact_missing',
-        },
-      })
-      expect(codexLaunchPlanner.planCreateCalls[0]).toMatchObject({
-        resumeSessionId: undefined,
-      })
-      expect(registry.createCalls[0]).toMatchObject({
-        mode: 'codex',
-        resumeSessionId: undefined,
-      })
-    } finally {
-      await closeWebSocket(ws)
-      await fsp.rm(tempDir, { recursive: true, force: true })
-    }
-  })
-
-  it('attaches exact live Codex candidate when captured proof fails and live terminal exists', async () => {
-    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-ws-codex-proof-'))
-    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
-    try {
-      const rolloutPath = path.join(tempDir, 'missing-live.jsonl')
-      registry.records[0].codexDurability = {
-        schemaVersion: 1,
-        state: 'durability_unproven_after_completion',
-        candidate: {
-          provider: 'codex',
-          candidateThreadId: 'thread-live-unproved',
-          rolloutPath,
-          source: 'thread_started_notification',
-          capturedAt: Date.now(),
-        },
-        turnCompletedAt: Date.now(),
-      }
-      await waitForOpen(ws)
-      await waitForReady(ws)
-
-      const requestId = 'codex-unproved-live-reopen'
-      const createdPromise = waitForMessage(ws, (m) => m.type === 'terminal.created' && m.requestId === requestId)
-      ws.send(JSON.stringify({
-        type: 'terminal.create',
-        requestId,
-        mode: 'codex',
-        restore: true,
-        codexDurability: registry.records[0].codexDurability,
-      }))
-
-      const created = await createdPromise
-      expect(created.terminalId).toBe('term-codex-existing')
-      expect(codexLaunchPlanner.planCreateCalls).toHaveLength(0)
-      expect(registry.createCalls).toHaveLength(0)
-    } finally {
-      await closeWebSocket(ws)
-      await fsp.rm(tempDir, { recursive: true, force: true })
-    }
-  })
 
   it('accepts Codex candidate persisted acknowledgements through the dynamic websocket schema', async () => {
     const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))

--- a/test/unit/client/components/TabsView.test.tsx
+++ b/test/unit/client/components/TabsView.test.tsx
@@ -215,6 +215,69 @@ describe('TabsView', () => {
     })
   })
 
+  it('does not hydrate same-server live terminal ids when a registry pane already has a canonical Codex sessionRef', () => {
+    const store = configureStore({
+      reducer: {
+        tabs: tabsReducer,
+        panes: panesReducer,
+        tabRegistry: tabRegistryReducer,
+        connection: connectionReducer,
+      },
+    })
+    store.dispatch(setServerInstanceId('srv-local'))
+    store.dispatch(setTabRegistrySnapshot({
+      localOpen: [],
+      remoteOpen: [{
+        tabKey: 'remote:codex-local',
+        tabId: 'codex-local',
+        serverInstanceId: 'srv-local',
+        deviceId: 'remote',
+        deviceLabel: 'remote-device',
+        tabName: 'codex local',
+        status: 'open',
+        revision: 1,
+        createdAt: 1,
+        updatedAt: 2,
+        paneCount: 1,
+        titleSetByUser: false,
+        panes: [{
+          paneId: 'pane-codex',
+          kind: 'terminal',
+          payload: {
+            mode: 'codex',
+            sessionRef: {
+              provider: 'codex',
+              sessionId: 'thread-1',
+            },
+            liveTerminal: {
+              terminalId: 'term-local-1',
+              serverInstanceId: 'srv-local',
+            },
+          },
+        }],
+      }],
+      closed: [],
+    }))
+
+    render(
+      <Provider store={store}>
+        <TabsView />
+      </Provider>,
+    )
+
+    fireEvent.click(screen.getByLabelText('remote-device: codex local'))
+
+    const copiedTab = store.getState().tabs.tabs.find((tab) => tab.title === 'codex local')
+    expect(copiedTab).toBeDefined()
+    const copiedLayout = copiedTab ? (store.getState().panes.layouts[copiedTab.id] as any) : undefined
+    expect(copiedLayout?.content?.sessionRef).toEqual({
+      provider: 'codex',
+      sessionId: 'thread-1',
+    })
+    expect(copiedLayout?.content?.terminalId).toBeUndefined()
+    expect(copiedLayout?.content?.serverInstanceId).toBeUndefined()
+  })
+
   it('shows context menu on right-click with appropriate items', () => {
     const store = createStore()
     render(
@@ -374,7 +437,7 @@ describe('TabsView', () => {
       provider: 'codex',
       sessionId: 'codex-session-123',
     })
-    expect(layout?.content?.serverInstanceId).toBe('srv-remote')
+    expect(layout?.content?.serverInstanceId).toBeUndefined()
   })
 
   it('shows pane kind icons with distinct colors', () => {

--- a/test/unit/client/components/TerminalView.codex-identity.test.tsx
+++ b/test/unit/client/components/TerminalView.codex-identity.test.tsx
@@ -1,0 +1,378 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import tabsReducer from '@/store/tabsSlice'
+import panesReducer from '@/store/panesSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
+import connectionReducer from '@/store/connectionSlice'
+import turnCompletionReducer from '@/store/turnCompletionSlice'
+import paneRuntimeActivityReducer from '@/store/paneRuntimeActivitySlice'
+import { useAppSelector } from '@/store/hooks'
+import type { PaneNode, TerminalPaneContent } from '@/store/paneTypes'
+import TerminalView from '@/components/TerminalView'
+
+const wsHarness = vi.hoisted(() => {
+  const messageHandlers = new Set<(msg: any) => void>()
+  const restoreRequestIds = new Set<string>()
+  const send = vi.fn()
+  const connect = vi.fn().mockResolvedValue(undefined)
+  const onMessage = vi.fn((handler: (msg: any) => void) => {
+    messageHandlers.add(handler)
+    return () => messageHandlers.delete(handler)
+  })
+  const onReconnect = vi.fn(() => () => {})
+  return {
+    send,
+    connect,
+    onMessage,
+    onReconnect,
+    emit(msg: any) {
+      for (const handler of [...messageHandlers]) handler(msg)
+    },
+    addRestoreRequestId(id: string) {
+      restoreRequestIds.add(id)
+    },
+    consumeRestoreRequestId(id: string) {
+      if (!restoreRequestIds.has(id)) return false
+      restoreRequestIds.delete(id)
+      return true
+    },
+    reset() {
+      messageHandlers.clear()
+      restoreRequestIds.clear()
+      send.mockClear()
+      connect.mockClear()
+      onMessage.mockClear()
+      onReconnect.mockClear()
+    },
+  }
+})
+
+const runtimeHarness = vi.hoisted(() => ({
+  terminals: [] as any[],
+}))
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({
+    send: wsHarness.send,
+    connect: wsHarness.connect,
+    onMessage: wsHarness.onMessage,
+    onReconnect: wsHarness.onReconnect,
+  }),
+}))
+
+vi.mock('@/lib/terminal-restore', () => ({
+  addTerminalRestoreRequestId: (id: string) => wsHarness.addRestoreRequestId(id),
+  consumeTerminalRestoreRequestId: (id: string) => wsHarness.consumeRestoreRequestId(id),
+  addTerminalFreshRecoveryRequestId: vi.fn(),
+  consumeTerminalFreshRecoveryRequest: vi.fn(() => undefined),
+}))
+
+vi.mock('@/lib/terminal-themes', () => ({
+  getTerminalTheme: () => ({}),
+}))
+
+vi.mock('@/components/terminal/terminal-runtime', () => ({
+  createTerminalRuntime: () => ({
+    attachAddons: vi.fn(),
+    fit: vi.fn(),
+    findNext: vi.fn(() => false),
+    findPrevious: vi.fn(() => false),
+    clearDecorations: vi.fn(),
+    onDidChangeResults: vi.fn(() => ({ dispose: vi.fn() })),
+    dispose: vi.fn(),
+    webglActive: vi.fn(() => false),
+  }),
+}))
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    options: Record<string, unknown> = {}
+    cols = 80
+    rows = 24
+    private dataHandler?: (data: string) => void
+    open = vi.fn()
+    registerLinkProvider = vi.fn(() => ({ dispose: vi.fn() }))
+    onData = vi.fn((handler: (data: string) => void) => {
+      this.dataHandler = handler
+      return { dispose: vi.fn() }
+    })
+    onTitleChange = vi.fn(() => ({ dispose: vi.fn() }))
+    attachCustomKeyEventHandler = vi.fn()
+    attachCustomWheelEventHandler = vi.fn()
+    dispose = vi.fn()
+    focus = vi.fn()
+    getSelection = vi.fn(() => '')
+    clear = vi.fn()
+    write = vi.fn((data: string, cb?: () => void) => {
+      cb?.()
+      return data.length
+    })
+    writeln = vi.fn()
+
+    emitData(data: string) {
+      this.dataHandler?.(data)
+    }
+
+    constructor() {
+      runtimeHarness.terminals.push(this)
+    }
+  },
+}))
+
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
+
+class MockResizeObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+}
+
+function findLeaf(node: PaneNode | undefined, paneId: string): Extract<PaneNode, { type: 'leaf' }> | null {
+  if (!node) return null
+  if (node.type === 'leaf') return node.id === paneId ? node : null
+  return findLeaf(node.children[0], paneId) || findLeaf(node.children[1], paneId)
+}
+
+function TerminalViewFromStore({ tabId, paneId }: { tabId: string; paneId: string }) {
+  const paneContent = useAppSelector((state) => findLeaf(state.panes.layouts[tabId], paneId)?.content ?? null)
+  if (!paneContent || paneContent.kind !== 'terminal') return null
+  return <TerminalView tabId={tabId} paneId={paneId} paneContent={paneContent} />
+}
+
+function createStore(content: TerminalPaneContent) {
+  return configureStore({
+    reducer: {
+      tabs: tabsReducer,
+      panes: panesReducer,
+      settings: settingsReducer,
+      connection: connectionReducer,
+      turnCompletion: turnCompletionReducer,
+      paneRuntimeActivity: paneRuntimeActivityReducer,
+    },
+    preloadedState: {
+      tabs: {
+        tabs: [{
+          id: 'tab-1',
+          mode: content.mode,
+          status: content.status,
+          title: 'Codex',
+          titleSetByUser: false,
+          createRequestId: content.createRequestId,
+        }],
+        activeTabId: 'tab-1',
+      },
+      panes: {
+        layouts: {
+          'tab-1': {
+            type: 'leaf',
+            id: 'pane-1',
+            content,
+          },
+        },
+        activePane: { 'tab-1': 'pane-1' },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      },
+      settings: { settings: defaultSettings, status: 'loaded' },
+      connection: { status: 'connected', error: null, serverInstanceId: 'srv-local' },
+    } as any,
+  })
+}
+
+function sentMessages() {
+  return wsHarness.send.mock.calls.map(([msg]) => msg)
+}
+
+describe('TerminalView codex identity', () => {
+  beforeEach(() => {
+    wsHarness.reset()
+    runtimeHarness.terminals.length = 0
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('includes expectedSessionRef on attach, resize, and input for canonical Codex panes', async () => {
+    const store = createStore({
+      kind: 'terminal',
+      createRequestId: 'req-1',
+      status: 'running',
+      mode: 'codex',
+      shell: 'system',
+      terminalId: 'term-1',
+      serverInstanceId: 'srv-local',
+      sessionRef: {
+        provider: 'codex',
+        sessionId: 'thread-1',
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalViewFromStore tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(sentMessages().some((msg) => msg?.type === 'terminal.attach' && msg.terminalId === 'term-1')).toBe(true)
+    })
+    await waitFor(() => {
+      expect(sentMessages().some((msg) => msg?.type === 'terminal.resize' && msg.terminalId === 'term-1')).toBe(true)
+    })
+
+    const term = runtimeHarness.terminals[0]
+    act(() => {
+      term.emitData('hello')
+    })
+
+    expect(sentMessages()).toContainEqual(expect.objectContaining({
+      type: 'terminal.attach',
+      terminalId: 'term-1',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
+    }))
+    expect(sentMessages()).toContainEqual(expect.objectContaining({
+      type: 'terminal.resize',
+      terminalId: 'term-1',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
+    }))
+    expect(sentMessages()).toContainEqual({
+      type: 'terminal.input',
+      terminalId: 'term-1',
+      data: 'hello',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
+    })
+  })
+
+  it('omits expectedSessionRef when only Codex durability evidence exists', async () => {
+    const store = createStore({
+      kind: 'terminal',
+      createRequestId: 'req-2',
+      status: 'running',
+      mode: 'codex',
+      shell: 'system',
+      terminalId: 'term-2',
+      serverInstanceId: 'srv-local',
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'captured_pre_turn',
+        candidate: {
+          provider: 'codex',
+          candidateThreadId: 'thread-candidate',
+          rolloutPath: '/tmp/rollout.jsonl',
+          source: 'thread_started_notification',
+          capturedAt: 1,
+        },
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalViewFromStore tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(sentMessages().some((msg) => msg?.type === 'terminal.attach' && msg.terminalId === 'term-2')).toBe(true)
+    })
+
+    const term = runtimeHarness.terminals[0]
+    act(() => {
+      term.emitData('hello')
+    })
+
+    const attach = sentMessages().find((msg) => msg?.type === 'terminal.attach' && msg.terminalId === 'term-2')
+    const input = sentMessages().find((msg) => msg?.type === 'terminal.input' && msg.terminalId === 'term-2')
+    expect(attach?.expectedSessionRef).toBeUndefined()
+    expect(input?.expectedSessionRef).toBeUndefined()
+  })
+
+  it('repairs stale runtime plumbing on SESSION_IDENTITY_MISMATCH and reissues a restore create', async () => {
+    const store = createStore({
+      kind: 'terminal',
+      createRequestId: 'req-old',
+      status: 'running',
+      mode: 'codex',
+      shell: 'system',
+      terminalId: 'term-old',
+      serverInstanceId: 'srv-old',
+      streamId: 'stream-old',
+      sessionRef: {
+        provider: 'codex',
+        sessionId: 'thread-new',
+      },
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-new',
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalViewFromStore tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(sentMessages().some((msg) => msg?.type === 'terminal.attach' && msg.terminalId === 'term-old')).toBe(true)
+    })
+
+    wsHarness.send.mockClear()
+
+    act(() => {
+      wsHarness.emit({
+        type: 'error',
+        code: 'SESSION_IDENTITY_MISMATCH',
+        terminalId: 'term-old',
+        expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+        actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
+        message: 'wrong thread',
+      })
+    })
+
+    await waitFor(() => {
+      const leaf = findLeaf(store.getState().panes.layouts['tab-1'], 'pane-1')
+      expect(leaf?.content.kind).toBe('terminal')
+      expect((leaf?.content as TerminalPaneContent).terminalId).toBeUndefined()
+      expect((leaf?.content as TerminalPaneContent).status).toBe('creating')
+    })
+
+    const createMessages = sentMessages().filter((msg) => msg?.type === 'terminal.create')
+    expect(createMessages).toHaveLength(1)
+    expect(createMessages[0]).toMatchObject({
+      type: 'terminal.create',
+      mode: 'codex',
+      restore: true,
+      sessionRef: { provider: 'codex', sessionId: 'thread-new' },
+    })
+    expect(sentMessages().some((msg) => msg?.type === 'terminal.attach' && msg.terminalId === 'term-old')).toBe(false)
+
+    act(() => {
+      wsHarness.emit({
+        type: 'error',
+        code: 'SESSION_IDENTITY_MISMATCH',
+        terminalId: 'term-old',
+        expectedSessionRef: { provider: 'codex', sessionId: 'thread-new' },
+        actualSessionRef: { provider: 'codex', sessionId: 'thread-old' },
+        message: 'wrong thread',
+      })
+    })
+
+    expect(sentMessages().filter((msg) => msg?.type === 'terminal.create')).toHaveLength(1)
+  })
+})

--- a/test/unit/client/components/terminal-view-utils.test.ts
+++ b/test/unit/client/components/terminal-view-utils.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import type { TerminalPaneContent } from '@/store/paneTypes'
-import { getCreateSessionStateFromRef, getResumeSessionIdFromRef } from '@/components/terminal-view-utils'
+import {
+  buildCodexIdentityMismatchRepairContent,
+  buildTerminalAttachMessage,
+  buildTerminalInputMessage,
+  buildTerminalResizeMessage,
+  getCreateSessionStateFromRef,
+  getExpectedSessionRefForTerminalOperation,
+  getResumeSessionIdFromRef,
+} from '@/components/terminal-view-utils'
 
 describe('terminal-view-utils', () => {
   it('reads the latest resumeSessionId from the ref', () => {
@@ -26,7 +34,7 @@ describe('terminal-view-utils', () => {
     expect(getResumeSessionIdFromRef(ref)).toBe('new-session')
   })
 
-  it('returns explicit live terminal handles separately from the durable sessionRef', () => {
+  it('suppresses unproven live terminal handles when a canonical sessionRef exists', () => {
     const ref: { current: TerminalPaneContent | null } = {
       current: {
         kind: 'terminal',
@@ -47,10 +55,6 @@ describe('terminal-view-utils', () => {
       sessionRef: {
         provider: 'codex',
         sessionId: 'codex-session-1',
-      },
-      liveTerminal: {
-        terminalId: 'term-live-1',
-        serverInstanceId: 'srv-local',
       },
     })
   })
@@ -93,5 +97,135 @@ describe('terminal-view-utils', () => {
         sessionId: '019e2a0c-7cef-7281-94df-d0d05d7b9ac3',
       },
     })
+  })
+
+  it('returns expected operation identity only from canonical sessionRef', () => {
+    const content: TerminalPaneContent = {
+      kind: 'terminal',
+      createRequestId: 'req-4',
+      status: 'running',
+      mode: 'codex',
+      shell: 'system',
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'captured_pre_turn',
+        candidate: {
+          provider: 'codex',
+          candidateThreadId: 'candidate-only',
+          rolloutPath: '/tmp/rollout.jsonl',
+          source: 'thread_started_notification',
+          capturedAt: 1,
+        },
+      },
+    }
+
+    expect(getExpectedSessionRefForTerminalOperation(content)).toBeUndefined()
+
+    content.sessionRef = { provider: 'codex', sessionId: 'thread-1' }
+    expect(getExpectedSessionRefForTerminalOperation(content)).toEqual({
+      provider: 'codex',
+      sessionId: 'thread-1',
+    })
+  })
+
+  it('builds attach, input, and resize messages with expectedSessionRef when canonical identity exists', () => {
+    const content: TerminalPaneContent = {
+      kind: 'terminal',
+      createRequestId: 'req-5',
+      status: 'running',
+      mode: 'codex',
+      shell: 'system',
+      sessionRef: { provider: 'codex', sessionId: 'thread-2' },
+    }
+
+    expect(buildTerminalInputMessage(content, 'term-1', 'hello')).toEqual({
+      type: 'terminal.input',
+      terminalId: 'term-1',
+      data: 'hello',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-2' },
+    })
+    expect(buildTerminalResizeMessage(content, 'term-1', 100, 30)).toEqual({
+      type: 'terminal.resize',
+      terminalId: 'term-1',
+      cols: 100,
+      rows: 30,
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-2' },
+    })
+    expect(buildTerminalAttachMessage({
+      content,
+      terminalId: 'term-1',
+      intent: 'viewport_hydrate',
+      cols: 100,
+      rows: 30,
+      sinceSeq: 0,
+      attachRequestId: 'attach-1',
+      priority: 'foreground',
+    })).toEqual({
+      type: 'terminal.attach',
+      terminalId: 'term-1',
+      intent: 'viewport_hydrate',
+      cols: 100,
+      rows: 30,
+      sinceSeq: 0,
+      attachRequestId: 'attach-1',
+      priority: 'foreground',
+      expectedSessionRef: { provider: 'codex', sessionId: 'thread-2' },
+    })
+  })
+
+  it('builds mismatch repair content that preserves only matching durable Codex identity', () => {
+    const repair = buildCodexIdentityMismatchRepairContent({
+      kind: 'terminal',
+      createRequestId: 'req-old',
+      status: 'running',
+      mode: 'codex',
+      shell: 'system',
+      terminalId: 'term-old',
+      serverInstanceId: 'srv-1',
+      streamId: 'stream-1',
+      sessionRef: { provider: 'codex', sessionId: 'thread-3' },
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-3',
+      },
+    }, { provider: 'codex', sessionId: 'thread-3' }, 'req-new')
+
+    expect(repair).toEqual({
+      terminalId: undefined,
+      serverInstanceId: undefined,
+      streamId: undefined,
+      createRequestId: 'req-new',
+      status: 'creating',
+      sessionRef: { provider: 'codex', sessionId: 'thread-3' },
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-3',
+      },
+    })
+
+    const candidateOnlyRepair = buildCodexIdentityMismatchRepairContent({
+      kind: 'terminal',
+      createRequestId: 'req-old',
+      status: 'running',
+      mode: 'codex',
+      shell: 'system',
+      terminalId: 'term-old',
+      sessionRef: { provider: 'codex', sessionId: 'thread-3' },
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'captured_pre_turn',
+        candidate: {
+          provider: 'codex',
+          candidateThreadId: 'thread-3',
+          rolloutPath: '/tmp/rollout.jsonl',
+          source: 'thread_started_notification',
+          capturedAt: 1,
+        },
+      },
+    }, { provider: 'codex', sessionId: 'thread-3' }, 'req-new')
+
+    expect(candidateOnlyRepair?.codexDurability).toBeUndefined()
   })
 })

--- a/test/unit/client/lib/terminal-session-association.test.ts
+++ b/test/unit/client/lib/terminal-session-association.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import { reconcileTerminalSessionAssociation } from '@/lib/terminal-session-association'
+
+function createState(content: Record<string, unknown>) {
+  return {
+    panes: {
+      layouts: {
+        'tab-1': {
+          type: 'leaf',
+          id: 'pane-1',
+          content,
+        },
+      },
+    },
+    tabs: {
+      tabs: [{
+        id: 'tab-1',
+        title: 'Tab 1',
+        status: 'running',
+      }],
+    },
+  } as any
+}
+
+describe('terminal-session-association', () => {
+  it('returns conflict and refuses to overwrite an existing canonical sessionRef', () => {
+    const dispatch = vi.fn()
+    const result = reconcileTerminalSessionAssociation({
+      dispatch,
+      getState: () => createState({
+        kind: 'terminal',
+        terminalId: 'term-1',
+        createRequestId: 'req-1',
+        status: 'running',
+        mode: 'codex',
+        shell: 'system',
+        sessionRef: { provider: 'codex', sessionId: 'thread-new' },
+      }),
+      terminalId: 'term-1',
+      sessionRef: { provider: 'codex', sessionId: 'thread-old' },
+    })
+
+    expect(result).toBe('conflict')
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('reconciles matching canonical identity and clears legacy resumeSessionId', () => {
+    const dispatch = vi.fn()
+    const result = reconcileTerminalSessionAssociation({
+      dispatch,
+      getState: () => createState({
+        kind: 'terminal',
+        terminalId: 'term-1',
+        createRequestId: 'req-1',
+        status: 'running',
+        mode: 'codex',
+        shell: 'system',
+        resumeSessionId: 'legacy-thread',
+        sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+        codexDurability: {
+          schemaVersion: 1,
+          state: 'durable',
+          durableThreadId: 'thread-1',
+        },
+      }),
+      terminalId: 'term-1',
+      sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+    })
+
+    expect(result).toBe('reconciled')
+    expect(dispatch).toHaveBeenCalled()
+  })
+
+  it('ignores unmatched panes cleanly', () => {
+    const dispatch = vi.fn()
+    const result = reconcileTerminalSessionAssociation({
+      dispatch,
+      getState: () => createState({
+        kind: 'terminal',
+        terminalId: 'term-2',
+        createRequestId: 'req-1',
+        status: 'running',
+        mode: 'codex',
+        shell: 'system',
+      }),
+      terminalId: 'term-1',
+      sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+    })
+
+    expect(result).toBe('ignored')
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/client/store/crossTabSync.test.ts
+++ b/test/unit/client/store/crossTabSync.test.ts
@@ -196,10 +196,18 @@ describe('crossTabSync', () => {
             kind: 'terminal',
             mode: 'codex',
             createRequestId: 'req-a',
-            status: 'creating',
+            status: 'running',
+            terminalId: 'term-local',
+            serverInstanceId: 'srv-local',
+            streamId: 'stream-local',
             sessionRef: {
               provider: 'codex',
               sessionId: 'thread-1',
+            },
+            codexDurability: {
+              schemaVersion: 1,
+              state: 'durable',
+              durableThreadId: 'thread-1',
             },
           },
         } as any,
@@ -244,13 +252,20 @@ describe('crossTabSync', () => {
 
     const layout = store.getState().panes.layouts['tab-1'] as any
     expect(layout.content).toMatchObject({
+      createRequestId: 'req-a',
+      status: 'running',
       sessionRef: {
         provider: 'codex',
         sessionId: 'thread-1',
       },
-      terminalId: undefined,
-      serverInstanceId: undefined,
-      streamId: undefined,
+      terminalId: 'term-local',
+      serverInstanceId: 'srv-local',
+      streamId: 'stream-local',
+      codexDurability: {
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-1',
+      },
     })
   })
 

--- a/test/unit/client/store/crossTabSync.test.ts
+++ b/test/unit/client/store/crossTabSync.test.ts
@@ -182,6 +182,78 @@ describe('crossTabSync', () => {
     expect(layout.content.resumeSessionId).toBe('123e4567-e89b-42d3-a456-426614174000')
   })
 
+  it('drops incoming Codex runtime fields when the local pane already has a canonical sessionRef', () => {
+    const store = configureStore({
+      reducer: { tabs: tabsReducer, panes: panesReducer },
+    })
+
+    store.dispatch(hydratePanes({
+      layouts: {
+        'tab-1': {
+          type: 'leaf',
+          id: 'pane-a',
+          content: {
+            kind: 'terminal',
+            mode: 'codex',
+            createRequestId: 'req-a',
+            status: 'creating',
+            sessionRef: {
+              provider: 'codex',
+              sessionId: 'thread-1',
+            },
+          },
+        } as any,
+      },
+      activePane: { 'tab-1': 'pane-a' },
+      paneTitles: {},
+    }))
+
+    cleanups.push(installCrossTabSync(store as any))
+
+    const remoteRaw = JSON.stringify({
+      version: 3,
+      tabs: { activeTabId: null, tabs: [] },
+      panes: {
+        version: 6,
+        layouts: {
+          'tab-1': {
+            type: 'leaf',
+            id: 'pane-a',
+            content: {
+              kind: 'terminal',
+              mode: 'codex',
+              createRequestId: 'req-b',
+              status: 'running',
+              terminalId: 'term-remote',
+              serverInstanceId: 'srv-remote',
+              streamId: 'stream-remote',
+              sessionRef: {
+                provider: 'codex',
+                sessionId: 'thread-old',
+              },
+            },
+          },
+        },
+        activePane: { 'tab-1': 'pane-a' },
+        paneTitles: {},
+      },
+      tombstones: [],
+    })
+
+    window.dispatchEvent(new StorageEvent('storage', { key: LAYOUT_STORAGE_KEY, newValue: remoteRaw }))
+
+    const layout = store.getState().panes.layouts['tab-1'] as any
+    expect(layout.content).toMatchObject({
+      sessionRef: {
+        provider: 'codex',
+        sessionId: 'thread-1',
+      },
+      terminalId: undefined,
+      serverInstanceId: undefined,
+      streamId: undefined,
+    })
+  })
+
   it('dedupes identical persisted payloads delivered via both storage and BroadcastChannel', () => {
     const dispatchSpy = vi.fn()
     const storeLike = {

--- a/test/unit/client/store/panesSlice.test.ts
+++ b/test/unit/client/store/panesSlice.test.ts
@@ -2923,10 +2923,18 @@ describe('panesSlice', () => {
       const localState = stateWithLeaf('pane-canonical', {
         kind: 'terminal',
         createRequestId: 'req-1',
-        status: 'creating',
+        status: 'running',
         mode: 'codex',
         shell: 'system',
+        terminalId: 'term-local',
+        serverInstanceId: 'srv-local',
+        streamId: 'stream-local',
         sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+        codexDurability: {
+          schemaVersion: 1,
+          state: 'durable',
+          durableThreadId: 'thread-1',
+        },
       })
 
       const incoming: PanesState = {
@@ -2965,12 +2973,18 @@ describe('panesSlice', () => {
       const leaf = merged.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>
       expect(leaf.content).toMatchObject({
         kind: 'terminal',
+        createRequestId: 'req-1',
+        status: 'running',
         sessionRef: { provider: 'codex', sessionId: 'thread-1' },
-        terminalId: undefined,
-        serverInstanceId: undefined,
-        streamId: undefined,
+        terminalId: 'term-local',
+        serverInstanceId: 'srv-local',
+        streamId: 'stream-local',
+        codexDurability: {
+          schemaVersion: 1,
+          state: 'durable',
+          durableThreadId: 'thread-1',
+        },
       })
-      expect((leaf.content as TerminalPaneContent).codexDurability).toBeUndefined()
     })
 
     it('TerminalPaneContent has required lifecycle fields', () => {

--- a/test/unit/client/store/panesSlice.test.ts
+++ b/test/unit/client/store/panesSlice.test.ts
@@ -23,6 +23,7 @@ import panesReducer, {
   toggleZoom,
   clearDeadTerminals,
   restartFreshAgentCreate,
+  repairCodexIdentityMismatch,
   PanesState,
 } from '../../../../src/store/panesSlice'
 import type { PaneNode, PaneContent, TerminalPaneContent, BrowserPaneContent, EditorPaneContent, ExtensionPaneContent } from '../../../../src/store/paneTypes'
@@ -2868,11 +2869,110 @@ describe('panesSlice', () => {
       const leaf2 = next.layouts['tab-2'] as Extract<PaneNode, { type: 'leaf' }>
       expect((leaf2.content as TerminalPaneContent).createRequestId).not.toBe('original-req-2')
       expect((leaf2.content as TerminalPaneContent).terminalId).toBeUndefined()
+      expect((leaf2.content as TerminalPaneContent).serverInstanceId).toBeUndefined()
+      expect((leaf2.content as TerminalPaneContent).streamId).toBeUndefined()
       expect((leaf2.content as TerminalPaneContent).status).toBe('creating')
     })
   })
 
+  describe('repairCodexIdentityMismatch', () => {
+    it('clears stale runtime plumbing and preserves only matching durable identity', () => {
+      const state = stateWithLeaf('pane-codex', {
+        kind: 'terminal',
+        createRequestId: 'req-old',
+        status: 'running',
+        mode: 'codex',
+        shell: 'system',
+        terminalId: 'term-old',
+        serverInstanceId: 'srv-1',
+        streamId: 'stream-1',
+        sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+        codexDurability: {
+          schemaVersion: 1,
+          state: 'durable',
+          durableThreadId: 'thread-1',
+        },
+      })
+
+      const next = panesReducer(state, repairCodexIdentityMismatch({
+        tabId: 'tab-1',
+        paneId: 'pane-codex',
+        staleTerminalId: 'term-old',
+        expectedSessionRef: { provider: 'codex', sessionId: 'thread-1' },
+        createRequestId: 'req-new',
+      }))
+
+      const leaf = next.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>
+      const content = leaf.content as TerminalPaneContent
+      expect(content.terminalId).toBeUndefined()
+      expect(content.serverInstanceId).toBeUndefined()
+      expect(content.streamId).toBeUndefined()
+      expect(content.createRequestId).toBe('req-new')
+      expect(content.status).toBe('creating')
+      expect(content.sessionRef).toEqual({ provider: 'codex', sessionId: 'thread-1' })
+      expect(content.codexDurability).toEqual({
+        schemaVersion: 1,
+        state: 'durable',
+        durableThreadId: 'thread-1',
+      })
+    })
+  })
+
   describe('PaneContent types', () => {
+    it('preserves local canonical Codex identity over incoming runtime fields during hydration', () => {
+      const localState = stateWithLeaf('pane-canonical', {
+        kind: 'terminal',
+        createRequestId: 'req-1',
+        status: 'creating',
+        mode: 'codex',
+        shell: 'system',
+        sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+      })
+
+      const incoming: PanesState = {
+        layouts: {
+          'tab-1': {
+            type: 'leaf',
+            id: 'pane-canonical',
+            content: {
+              kind: 'terminal',
+              createRequestId: 'req-2',
+              status: 'running',
+              mode: 'codex',
+              shell: 'system',
+              terminalId: 'term-remote',
+              serverInstanceId: 'srv-remote',
+              streamId: 'stream-remote',
+              sessionRef: { provider: 'codex', sessionId: 'thread-other' },
+              codexDurability: {
+                schemaVersion: 1,
+                state: 'durable',
+                durableThreadId: 'thread-other',
+              },
+            },
+          },
+        },
+        activePane: localState.activePane,
+        paneTitles: {},
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      }
+
+      const merged = panesReducer(localState, hydratePanes(incoming))
+      const leaf = merged.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>
+      expect(leaf.content).toMatchObject({
+        kind: 'terminal',
+        sessionRef: { provider: 'codex', sessionId: 'thread-1' },
+        terminalId: undefined,
+        serverInstanceId: undefined,
+        streamId: undefined,
+      })
+      expect((leaf.content as TerminalPaneContent).codexDurability).toBeUndefined()
+    })
+
     it('TerminalPaneContent has required lifecycle fields', () => {
       const content: TerminalPaneContent = {
         kind: 'terminal',

--- a/test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/restore-decision.test.ts
@@ -1,50 +1,32 @@
 import { describe, expect, it, vi } from 'vitest'
-import { CODEX_DURABILITY_SCHEMA_VERSION, type CodexCandidateIdentity, type CodexDurabilityRef } from '../../../../../shared/codex-durability.js'
+import { CODEX_DURABILITY_SCHEMA_VERSION, type CodexDurabilityRef } from '../../../../../shared/codex-durability.js'
 import {
   INVALID_RAW_CODEX_RESUME_MESSAGE,
   MISSING_CODEX_SESSION_REF_MESSAGE,
+  isExactLiveCodexCandidate,
   planCodexCreateRestoreDecision,
   resolveCodexCreateRestoreDecision,
   type CodexLiveRestoreTerminal,
 } from '../../../../../server/coding-cli/codex-app-server/restore-decision.js'
-import type { CodexRolloutProofResult } from '../../../../../server/coding-cli/codex-app-server/durability-proof.js'
 
-const candidate: CodexCandidateIdentity = {
-  provider: 'codex',
-  candidateThreadId: 'thread-1',
-  rolloutPath: '/tmp/freshell-codex/rollout.jsonl',
-  source: 'restored_client_state',
-  capturedAt: 1,
-}
-
-const durability: CodexDurabilityRef = {
+const candidateDurability: CodexDurabilityRef = {
   schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
   state: 'durability_unproven_after_completion',
-  candidate,
+  candidate: {
+    provider: 'codex',
+    candidateThreadId: 'thread-candidate',
+    rolloutPath: '/tmp/freshell-codex/rollout.jsonl',
+    source: 'restored_client_state',
+    capturedAt: 1,
+  },
   turnCompletedAt: 2,
 }
 
 const durableDurability: CodexDurabilityRef = {
   schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
   state: 'durable',
-  candidate,
   durableThreadId: 'thread-durable',
   turnCompletedAt: 3,
-}
-
-const proofOk: CodexRolloutProofResult = {
-  ok: true,
-  candidateThreadId: candidate.candidateThreadId,
-  rolloutPath: candidate.rolloutPath,
-  rolloutProofId: candidate.candidateThreadId,
-}
-
-const proofMissing: CodexRolloutProofResult = {
-  ok: false,
-  reason: 'missing',
-  message: 'Codex rollout proof file does not exist.',
-  candidateThreadId: candidate.candidateThreadId,
-  rolloutPath: candidate.rolloutPath,
 }
 
 describe('Codex create/restore decision', () => {
@@ -69,7 +51,7 @@ describe('Codex create/restore decision', () => {
     })
   })
 
-  it('rejects restore requests without sessionRef, durable ref, or candidate', () => {
+  it('requires a canonical sessionRef for Codex restore', () => {
     expect(planCodexCreateRestoreDecision({ restoreRequested: true })).toEqual({
       kind: 'reject_missing_codex_session_ref',
       code: 'RESTORE_UNAVAILABLE',
@@ -77,15 +59,14 @@ describe('Codex create/restore decision', () => {
     })
   })
 
-  it('routes canonical sessionRef restores without using candidate proof', async () => {
-    const proofRollout = vi.fn(async () => proofOk)
+  it('routes canonical sessionRef restores directly', async () => {
+    const findLiveTerminalByCandidate = vi.fn()
 
     const decision = await resolveCodexCreateRestoreDecision({
       restoreRequested: true,
-      legacyResumeSessionId: 'thread-raw',
       sessionRef: { provider: 'codex', sessionId: 'thread-durable' },
-      codexDurability: durability,
-      proofRollout,
+      codexDurability: candidateDurability,
+      findLiveTerminalByCandidate,
     })
 
     expect(decision).toEqual({
@@ -93,25 +74,38 @@ describe('Codex create/restore decision', () => {
       sessionRef: { provider: 'codex', sessionId: 'thread-durable' },
       sessionId: 'thread-durable',
     })
-    expect(proofRollout).not.toHaveBeenCalled()
+    expect(findLiveTerminalByCandidate).not.toHaveBeenCalled()
   })
 
-  it('uses durable Codex durability state as a canonical restore sessionRef', () => {
+  it('ignores durable Codex durability without a canonical sessionRef', () => {
     expect(planCodexCreateRestoreDecision({
       restoreRequested: true,
-      codexDurability: {
-        schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
-        state: 'durable',
-        durableThreadId: 'thread-durable',
-      },
+      codexDurability: durableDurability,
     })).toEqual({
-      kind: 'durable_session_ref_resume',
-      sessionRef: { provider: 'codex', sessionId: 'thread-durable' },
-      sessionId: 'thread-durable',
+      kind: 'reject_missing_codex_session_ref',
+      code: 'RESTORE_UNAVAILABLE',
+      message: MISSING_CODEX_SESSION_REF_MESSAGE,
     })
   })
 
-  it('uses explicit sessionRef before durable Codex durability state', () => {
+  it('ignores candidate Codex durability without a canonical sessionRef', async () => {
+    const findLiveTerminalByCandidate = vi.fn()
+
+    const decision = await resolveCodexCreateRestoreDecision({
+      restoreRequested: true,
+      codexDurability: candidateDurability,
+      findLiveTerminalByCandidate,
+    })
+
+    expect(decision).toEqual({
+      kind: 'reject_missing_codex_session_ref',
+      code: 'RESTORE_UNAVAILABLE',
+      message: MISSING_CODEX_SESSION_REF_MESSAGE,
+    })
+    expect(findLiveTerminalByCandidate).not.toHaveBeenCalled()
+  })
+
+  it('uses explicit sessionRef before any durability evidence', () => {
     expect(planCodexCreateRestoreDecision({
       restoreRequested: true,
       sessionRef: { provider: 'codex', sessionId: 'thread-explicit' },
@@ -123,55 +117,14 @@ describe('Codex create/restore decision', () => {
     })
   })
 
-  it('uses durable Codex durability state before candidate proof', async () => {
-    const proofRollout = vi.fn(async () => proofOk)
-
-    const decision = await resolveCodexCreateRestoreDecision({
-      restoreRequested: true,
-      codexDurability: durableDurability,
-      proofRollout,
-    })
-
-    expect(decision).toEqual({
-      kind: 'durable_session_ref_resume',
-      sessionRef: { provider: 'codex', sessionId: 'thread-durable' },
-      sessionId: 'thread-durable',
-    })
-    expect(proofRollout).not.toHaveBeenCalled()
-  })
-
-  it('rejects raw legacy resume ids even when durable Codex durability is present without sessionRef', () => {
-    expect(planCodexCreateRestoreDecision({
-      restoreRequested: true,
-      legacyResumeSessionId: 'thread-raw',
-      codexDurability: durableDurability,
-    })).toEqual({
-      kind: 'reject_invalid_raw_codex_resume_request',
-      code: 'INVALID_MESSAGE',
-      message: INVALID_RAW_CODEX_RESUME_MESSAGE,
-    })
-  })
-
-  it('plans candidate proof before a restored candidate can become durable', () => {
-    expect(planCodexCreateRestoreDecision({
-      restoreRequested: true,
-      codexDurability: durability,
-    })).toEqual({
-      kind: 'proof_existing_candidate_first',
-      candidate,
-    })
-  })
-
-  it('ignores captured Codex candidates for non-restore fresh creates', () => {
+  it('fresh-creates when restore is not requested, even if durability is present', () => {
     expect(planCodexCreateRestoreDecision({
       restoreRequested: false,
-      codexDurability: durability,
+      codexDurability: candidateDurability,
     })).toEqual({
       kind: 'fresh_codex_launch',
     })
-  })
 
-  it('ignores durable Codex durability state for non-restore fresh creates', () => {
     expect(planCodexCreateRestoreDecision({
       restoreRequested: false,
       codexDurability: durableDurability,
@@ -180,100 +133,21 @@ describe('Codex create/restore decision', () => {
     })
   })
 
-  it('uses exact rollout proof as the durable session id and returns a matching live terminal when present', async () => {
+  it('matches exact live candidates only by rollout path and candidate thread id', () => {
     const liveTerminal: CodexLiveRestoreTerminal = {
       terminalId: 'term-live',
       createdAt: 10,
-      codexDurability: durability,
+      codexDurability: candidateDurability,
     }
 
-    const decision = await resolveCodexCreateRestoreDecision({
-      restoreRequested: true,
-      codexDurability: durability,
-      proofRollout: async () => proofOk,
-      findLiveTerminalByCandidate: () => liveTerminal,
-    })
+    expect(isExactLiveCodexCandidate(liveTerminal, {
+      candidateThreadId: 'thread-candidate',
+      rolloutPath: '/tmp/freshell-codex/rollout.jsonl',
+    })).toBe(true)
 
-    expect(decision).toEqual({
-      kind: 'proof_succeeded_resume_durable',
-      candidate,
-      proof: proofOk,
-      sessionId: 'thread-1',
-      liveTerminal,
-    })
-  })
-
-  it('attaches the exact live candidate when proof fails but the terminal still exists', async () => {
-    const liveTerminal: CodexLiveRestoreTerminal = {
-      terminalId: 'term-unproved-live',
-      createdAt: 10,
-      codexDurability: durability,
-    }
-
-    const decision = await resolveCodexCreateRestoreDecision({
-      restoreRequested: true,
-      codexDurability: durability,
-      proofRollout: async () => proofMissing,
-      findLiveTerminalByCandidate: () => liveTerminal,
-    })
-
-    expect(decision).toEqual({
-      kind: 'proof_failed_attach_live_candidate',
-      candidate,
-      proof: proofMissing,
-      liveTerminal,
-    })
-  })
-
-  it('fresh-creates with a restore-failed marker when candidate proof fails and no exact live terminal exists', async () => {
-    const decision = await resolveCodexCreateRestoreDecision({
-      restoreRequested: true,
-      codexDurability: durability,
-      proofRollout: async () => proofMissing,
-      findLiveTerminalByCandidate: () => undefined,
-    })
-
-    expect(decision).toEqual({
-      kind: 'proof_failed_fresh_create',
-      candidate,
-      proof: proofMissing,
-      clearCodexDurability: true,
-      restoreError: {
-        code: 'RESTORE_UNAVAILABLE',
-        reason: 'durable_artifact_missing',
-      },
-    })
-  })
-
-  it('does not accept a loose live terminal candidate returned by the caller', async () => {
-    const looseLiveTerminal: CodexLiveRestoreTerminal = {
-      terminalId: 'term-loose-live',
-      createdAt: 10,
-      codexDurability: {
-        ...durability,
-        candidate: {
-          ...candidate,
-          candidateThreadId: 'thread-other',
-        },
-      },
-    }
-
-    const decision = await resolveCodexCreateRestoreDecision({
-      restoreRequested: true,
-      codexDurability: durability,
-      proofRollout: async () => proofMissing,
-      findLiveTerminalByCandidate: () => looseLiveTerminal,
-    })
-
-    expect(decision).toEqual({
-      kind: 'proof_failed_fresh_create',
-      candidate,
-      proof: proofMissing,
-      clearCodexDurability: true,
-      restoreError: {
-        code: 'RESTORE_UNAVAILABLE',
-        reason: 'durable_artifact_missing',
-      },
-    })
+    expect(isExactLiveCodexCandidate(liveTerminal, {
+      candidateThreadId: 'thread-other',
+      rolloutPath: '/tmp/freshell-codex/rollout.jsonl',
+    })).toBe(false)
   })
 })

--- a/test/unit/server/terminal-session-identity.test.ts
+++ b/test/unit/server/terminal-session-identity.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { CODEX_DURABILITY_SCHEMA_VERSION } from '../../../shared/codex-durability.js'
+import {
+  buildSessionIdentityMismatchDetails,
+  canonicalActualSessionRef,
+  terminalMatchesExpectedSession,
+} from '../../../server/terminal-session-identity.js'
+
+describe('terminal-session-identity', () => {
+  it('treats missing expected identity as a backwards-compatible match', () => {
+    expect(terminalMatchesExpectedSession({
+      mode: 'shell',
+    } as any, undefined)).toBe(true)
+  })
+
+  it('matches canonical durable Codex identity only when registry identity proves it', () => {
+    const record = {
+      mode: 'codex',
+      resumeSessionId: 'thread-durable',
+      codexDurability: {
+        schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
+        state: 'durable',
+        durableThreadId: 'thread-durable',
+      },
+    } as const
+
+    expect(canonicalActualSessionRef(record as any)).toEqual({
+      provider: 'codex',
+      sessionId: 'thread-durable',
+    })
+    expect(terminalMatchesExpectedSession(record as any, {
+      provider: 'codex',
+      sessionId: 'thread-durable',
+    })).toBe(true)
+  })
+
+  it('does not match Codex candidate-only durability for side effects', () => {
+    expect(terminalMatchesExpectedSession({
+      mode: 'codex',
+      resumeSessionId: 'thread-candidate',
+      codexDurability: {
+        schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
+        state: 'proof_checking',
+        candidate: {
+          provider: 'codex',
+          candidateThreadId: 'thread-candidate',
+          rolloutPath: '/tmp/rollout.jsonl',
+          source: 'restored_client_state',
+          capturedAt: 1,
+        },
+      },
+    } as any, {
+      provider: 'codex',
+      sessionId: 'thread-candidate',
+    })).toBe(false)
+  })
+
+  it('does not match Codex durable state when resumeSessionId disagrees', () => {
+    expect(terminalMatchesExpectedSession({
+      mode: 'codex',
+      resumeSessionId: 'thread-old',
+      codexDurability: {
+        schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
+        state: 'durable',
+        durableThreadId: 'thread-new',
+      },
+    } as any, {
+      provider: 'codex',
+      sessionId: 'thread-new',
+    })).toBe(false)
+  })
+
+  it('fails on provider mismatch', () => {
+    expect(terminalMatchesExpectedSession({
+      mode: 'opencode',
+      resumeSessionId: 'session-1',
+    } as any, {
+      provider: 'codex',
+      sessionId: 'session-1',
+    })).toBe(false)
+  })
+
+  it('builds mismatch details from the canonical actual identity only', () => {
+    expect(buildSessionIdentityMismatchDetails({
+      mode: 'codex',
+      resumeSessionId: 'thread-old',
+      codexDurability: {
+        schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
+        state: 'durable',
+        durableThreadId: 'thread-old',
+      },
+    } as any, {
+      provider: 'codex',
+      sessionId: 'thread-new',
+    })).toEqual({
+      expectedSessionRef: {
+        provider: 'codex',
+        sessionId: 'thread-new',
+      },
+      actualSessionRef: {
+        provider: 'codex',
+        sessionId: 'thread-old',
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- carry canonical Codex session identity through terminal attach, input, and resize requests
- reject stale runtime handles server-side and repair mismatched pane state instead of resuming the wrong thread
- add unit, server, and e2e coverage for wrong-thread resume, cross-tab merges, and same-server hydration

## Testing
- `npm run check` on the rebased branch: fails only on `test/integration/real/coding-cli-session-contract.test.ts` because of an order-dependent Claude live-provider stdout mismatch in the full suite
- `npm run test:vitest -- --config vitest.server.config.ts --run test/integration/real/coding-cli-session-contract.test.ts` on this branch: pass
- same isolated real-provider command on `main`: pass