### PR TITLE
Fix OpenCode replay playback coalescing

### DIFF
--- a/docs/superpowers/plans/2026-06-15-opencode-replay-playback-coalescing.md
+++ b/docs/superpowers/plans/2026-06-15-opencode-replay-playback-coalescing.md
@@ -23,7 +23,7 @@
 - Create: `test/e2e-browser/specs/opencode-replay-write-progression.spec.ts`
   - Mount a real browser `TerminalView`, feed a barrier-heavy replay batch through the test WebSocket path, and assert real xterm writes are bounded.
 - Modify: `test/unit/client/components/TerminalView.lifecycle.test.tsx`
-  - Replace the old expectation that barrier segments produce separate xterm writes.
+  - Replace the old synchronous-RAF barrier test with deferred-RAF tests that can observe queued coalescing.
   - Keep the committed red OpenCode replay regression test.
   - Add a direct `A`, stripped segment, `B` checkpoint-safety regression.
 - No change: `src/components/terminal/terminal-write-queue.ts`
@@ -79,6 +79,7 @@ it('preserves parser barrier checkpoints while allowing terminal.output.batch wr
   const { terminalId, term } = await renderTerminalHarness({
     status: 'running',
     terminalId: 'term-output-batch-barrier',
+    serverInstanceId: 'server-output-batch-barrier-coalesced',
   })
   const attachRequestId = latestAttachRequestIdForTerminal(terminalId)
   const streamId = latestStreamIdByTerminal.get(terminalId)
@@ -111,7 +112,7 @@ it('preserves parser barrier checkpoints while allowing terminal.output.batch wr
   expect(delayedCallbacks).toEqual([])
   expect(loadTerminalSurfaceCheckpoint(terminalId, {
     streamId,
-    serverInstanceId: 'server-instance',
+    serverInstanceId: 'server-output-batch-barrier-coalesced',
   })).toBeNull()
 
   act(() => {
@@ -121,7 +122,7 @@ it('preserves parser barrier checkpoints while allowing terminal.output.batch wr
   expect(delayedCallbacks.map(({ data }) => data)).toEqual(['aBc'])
   expect(loadTerminalSurfaceCheckpoint(terminalId, {
     streamId,
-    serverInstanceId: 'server-instance',
+    serverInstanceId: 'server-output-batch-barrier-coalesced',
   })).toBeNull()
 
   act(() => {
@@ -130,7 +131,7 @@ it('preserves parser barrier checkpoints while allowing terminal.output.batch wr
 
   expect(loadTerminalSurfaceCheckpoint(terminalId, {
     streamId,
-    serverInstanceId: 'server-instance',
+    serverInstanceId: 'server-output-batch-barrier-coalesced',
   })?.parserAppliedSeq).toBe(3)
 })
 ```
@@ -150,7 +151,7 @@ it('does not checkpoint across a stripped middle batch segment when adjacent ren
   const { terminalId, term } = await renderTerminalHarness({
     status: 'running',
     terminalId: 'term-output-batch-stripped-middle-coalesced',
-    mode: 'opencode',
+    mode: 'codex',
     serverInstanceId: 'server-output-batch-stripped-middle-coalesced',
   })
   const attachRequestId = latestAttachRequestIdForTerminal(terminalId)
@@ -584,17 +585,29 @@ test.describe('OpenCode replay write progression', () => {
 
     await expect.poll(async () => {
       const submitted = (await harness.getTerminalWriteEvents())
-        .filter((event) => event.phase === 'submitted' && event.terminalId === snapshot.terminalId)
+        .filter((event) =>
+          event.phase === 'submitted'
+          && event.terminalId === snapshot.terminalId
+          && replay.data.includes(event.data)
+        )
       return submitted.map((event) => event.data).join('')
     }, { timeout: 15_000 }).toBe(replay.data)
 
     const submitted = (await harness.getTerminalWriteEvents())
-      .filter((event) => event.phase === 'submitted' && event.terminalId === snapshot.terminalId)
+      .filter((event) =>
+        event.phase === 'submitted'
+        && event.terminalId === snapshot.terminalId
+        && replay.data.includes(event.data)
+      )
     expect(submitted.length).toBeLessThanOrEqual(2)
 
     await expect.poll(async () => {
       const written = (await harness.getTerminalWriteEvents())
-        .filter((event) => event.phase === 'written' && event.terminalId === snapshot.terminalId)
+        .filter((event) =>
+          event.phase === 'written'
+          && event.terminalId === snapshot.terminalId
+          && replay.data.includes(event.data)
+        )
       return written.map((event) => event.data).join('')
     }, { timeout: 15_000 }).toBe(replay.data)
   })

--- a/docs/superpowers/plans/2026-06-15-opencode-replay-playback-coalescing.md
+++ b/docs/superpowers/plans/2026-06-15-opencode-replay-playback-coalescing.md
@@ -90,6 +90,7 @@ it('preserves parser barrier checkpoints while allowing terminal.output.batch wr
     if (onWritten) delayedCallbacks.push({ data: chunk, callback: onWritten })
   })
 
+  rafCallbacks.length = 0
   act(() => {
     messageHandler!({
       type: 'terminal.output.batch',
@@ -165,6 +166,7 @@ it('does not checkpoint across a stripped middle batch segment when adjacent ren
     if (onWritten) delayedCallbacks.push({ data: chunk, callback: onWritten })
   })
 
+  rafCallbacks.length = 0
   act(() => {
     messageHandler!({
       type: 'terminal.output.batch',
@@ -513,10 +515,9 @@ type TerminalSnapshot = {
 }
 
 function createOpenCodeLikeReplay(seqBase: number) {
+  const marker = '__FRESHELL_REPLAY_PROGRESS__'
   const chunks = Array.from({ length: 96 }, (_unused, index) => (
-    index % 2 === 0
-      ? `\x1b[${30 + (index % 8)}m`
-      : `tok${index.toString().padStart(2, '0')}`
+    `\x1b[${30 + (index % 8)}m${marker}${index.toString().padStart(2, '0')}`
   ))
   const data = chunks.join('')
   const segments = chunks.map((chunk, index) => ({
@@ -526,7 +527,7 @@ function createOpenCodeLikeReplay(seqBase: number) {
     rawFrameCount: 1,
     barrier: 'control',
   }))
-  return { chunks, data, segments }
+  return { chunks, data, marker, segments }
 }
 
 test.describe('OpenCode replay write progression', () => {
@@ -588,7 +589,7 @@ test.describe('OpenCode replay write progression', () => {
         .filter((event) =>
           event.phase === 'submitted'
           && event.terminalId === snapshot.terminalId
-          && replay.data.includes(event.data)
+          && event.data.includes(replay.marker)
         )
       return submitted.map((event) => event.data).join('')
     }, { timeout: 15_000 }).toBe(replay.data)
@@ -597,7 +598,7 @@ test.describe('OpenCode replay write progression', () => {
       .filter((event) =>
         event.phase === 'submitted'
         && event.terminalId === snapshot.terminalId
-        && replay.data.includes(event.data)
+        && event.data.includes(replay.marker)
       )
     expect(submitted.length).toBeLessThanOrEqual(2)
 
@@ -606,7 +607,7 @@ test.describe('OpenCode replay write progression', () => {
         .filter((event) =>
           event.phase === 'written'
           && event.terminalId === snapshot.terminalId
-          && replay.data.includes(event.data)
+          && event.data.includes(replay.marker)
         )
       return written.map((event) => event.data).join('')
     }, { timeout: 15_000 }).toBe(replay.data)

--- a/docs/superpowers/plans/2026-06-15-opencode-replay-playback-coalescing.md
+++ b/docs/superpowers/plans/2026-06-15-opencode-replay-playback-coalescing.md
@@ -1,0 +1,407 @@
+# OpenCode Replay Playback Coalescing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore fast OpenCode replay playback by allowing parser-barrier-heavy terminal output to reach xterm in bounded coalesced writes while preserving parser checkpoint ordering and attach completion safety.
+
+**Architecture:** Keep the terminal write-scope gate and xterm acknowledgement sequencing introduced by the recent playback safety work. Change the client batch replay path so parser barriers no longer force hard xterm write boundaries; barrier metadata still controls checkpoint callbacks, but adjacent renderable segments can coalesce through `TerminalWriteQueue`. No server protocol or PTY lifecycle changes are required for this fix.
+
+**Tech Stack:** React 18, TypeScript, xterm.js, Vitest, Testing Library, Freshell WebSocket terminal output protocol.
+
+---
+
+## File Structure
+
+- Modify: `src/components/TerminalView.tsx`
+  - Remove the `disableWriteCoalescing` control path from accepted terminal output submission.
+  - Keep per-segment parser checkpoint callbacks for `terminal.output.batch` barrier segments.
+- Modify: `test/unit/client/components/TerminalView.lifecycle.test.tsx`
+  - Replace the old expectation that barrier segments produce separate xterm writes.
+  - Keep the committed red regression test that reproduces the OpenCode slow replay failure.
+  - Verify stripped/no-write barrier cases still hold checkpoints until safe.
+- No change: `src/components/terminal/terminal-write-queue.ts`
+  - The queue already coalesces adjacent compatible writes and preserves callback order.
+- No change: `server/terminal-stream/output-batch.ts`
+  - Server batching can be optimized later, but the user-facing regression is caused by client-side hard write boundaries.
+
+## Baseline Evidence
+
+- Temp report: `/tmp/freshell-opencode-playback-investigation-20260615/baseline-slow-playback-data.md`
+- Red test commit: `7895df4a test: cover barrier-heavy replay coalescing`
+- Current failure:
+
+```text
+Expected submitted replay to equal the full 96-segment data payload.
+Received only the first 5-byte segment, "\x1b[30m", after one replay flush.
+```
+
+## Task 1: Update The Parser-Barrier Write Expectation
+
+**Files:**
+- Modify: `test/unit/client/components/TerminalView.lifecycle.test.tsx`
+
+- [ ] **Step 1: Replace the old split-write assertion with a coalescing assertion**
+
+Find the test named:
+
+```ts
+it('splits terminal.output.batch writes around parser barrier segments', async () => {
+```
+
+Replace the test name and final expectation with:
+
+```ts
+it('preserves parser barrier checkpoints while allowing terminal.output.batch writes to coalesce', async () => {
+  const { terminalId, term } = await renderTerminalHarness({
+    status: 'running',
+    terminalId: 'term-output-batch-barrier',
+  })
+  const attachRequestId = latestAttachRequestIdForTerminal(terminalId)
+  const streamId = latestStreamIdByTerminal.get(terminalId)
+
+  term.write.mockClear()
+  act(() => {
+    messageHandler!({
+      type: 'terminal.output.batch',
+      terminalId,
+      streamId,
+      attachRequestId,
+      source: 'replay',
+      seqStart: 1,
+      seqEnd: 3,
+      data: 'aBc',
+      serializedBytes: 256,
+      segments: [
+        { seqStart: 1, seqEnd: 1, endOffset: 1, rawFrameCount: 1 },
+        { seqStart: 2, seqEnd: 2, endOffset: 2, rawFrameCount: 1, barrier: 'control' },
+        { seqStart: 3, seqEnd: 3, endOffset: 3, rawFrameCount: 1 },
+      ],
+    })
+  })
+
+  expect(terminalWriteStrings(term)).toEqual(['aBc'])
+  expect(loadTerminalSurfaceCheckpoint(terminalId, {
+    streamId,
+    serverInstanceId: 'server-instance',
+  })?.parserAppliedSeq).toBe(3)
+})
+```
+
+- [ ] **Step 2: Run the focused old/new expectation**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx -t "preserves parser barrier checkpoints" --run
+```
+
+Expected before production changes: fail because the terminal still writes `['a', 'B', 'c']`.
+
+- [ ] **Step 3: Commit the test expectation update**
+
+Run:
+
+```bash
+git add test/unit/client/components/TerminalView.lifecycle.test.tsx
+git commit -m "test: expect parser barriers to coalesce terminal writes"
+```
+
+Expected:
+
+```text
+[test/opencode-playback-coalescing <sha>] test: expect parser barriers to coalesce terminal writes
+```
+
+## Task 2: Let Parser-Barrier Segments Use Normal Write Coalescing
+
+**Files:**
+- Modify: `src/components/TerminalView.tsx`
+
+- [ ] **Step 1: Remove the accepted-output flag that turns parser barriers into hard xterm write barriers**
+
+In `submitAcceptedOutput`, replace this input type:
+
+```ts
+const submitAcceptedOutput = (input: {
+  raw: string
+  seqStart: number
+  seqEnd: number
+  attachRequestId?: string
+  mode: TerminalPaneContent['mode']
+  previousSeqState: AttachSeqState
+  outputSource: TerminalOutputSource
+  parserAppliedSeq: number
+  completedAttach: boolean
+  disableWriteCoalescing?: boolean
+}) => {
+```
+
+with:
+
+```ts
+const submitAcceptedOutput = (input: {
+  raw: string
+  seqStart: number
+  seqEnd: number
+  attachRequestId?: string
+  mode: TerminalPaneContent['mode']
+  previousSeqState: AttachSeqState
+  outputSource: TerminalOutputSource
+  parserAppliedSeq: number
+  completedAttach: boolean
+}) => {
+```
+
+- [ ] **Step 2: Remove the special coalescing override from `handleTerminalOutput`**
+
+Replace this queue option block:
+
+```ts
+{
+  mode: input.outputSource,
+  generation: input.attachRequestId,
+  coalesce: input.disableWriteCoalescing ? false : undefined,
+},
+```
+
+with:
+
+```ts
+{
+  mode: input.outputSource,
+  generation: input.attachRequestId,
+},
+```
+
+- [ ] **Step 3: Stop passing `disableWriteCoalescing` for batch barrier segments**
+
+Replace the barrier segment submission block:
+
+```ts
+submitAcceptedOutput({
+  raw: segment.data,
+  seqStart: segment.seqStart,
+  seqEnd: segment.seqEnd,
+  attachRequestId: msg.attachRequestId,
+  mode,
+  previousSeqState: acceptedSegment.previousState,
+  outputSource,
+  parserAppliedSeq: acceptedSegment.parserAppliedSeq,
+  completedAttach: completedAttachOnBatch && index === batchSegments.length - 1,
+  disableWriteCoalescing: true,
+})
+```
+
+with:
+
+```ts
+submitAcceptedOutput({
+  raw: segment.data,
+  seqStart: segment.seqStart,
+  seqEnd: segment.seqEnd,
+  attachRequestId: msg.attachRequestId,
+  mode,
+  previousSeqState: acceptedSegment.previousState,
+  outputSource,
+  parserAppliedSeq: acceptedSegment.parserAppliedSeq,
+  completedAttach: completedAttachOnBatch && index === batchSegments.length - 1,
+})
+```
+
+- [ ] **Step 4: Run the OpenCode regression test**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx -t "replays barrier-heavy OpenCode batches" --run
+```
+
+Expected after production changes:
+
+```text
+✓ test/unit/client/components/TerminalView.lifecycle.test.tsx > TerminalView lifecycle > ... > replays barrier-heavy OpenCode batches as bounded writes while holding checkpoints until xterm applies them
+```
+
+- [ ] **Step 5: Run the parser-barrier focused test**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx -t "preserves parser barrier checkpoints" --run
+```
+
+Expected after production changes:
+
+```text
+✓ test/unit/client/components/TerminalView.lifecycle.test.tsx > TerminalView lifecycle > ... > preserves parser barrier checkpoints while allowing terminal.output.batch writes to coalesce
+```
+
+- [ ] **Step 6: Commit the client fix**
+
+Run:
+
+```bash
+git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx
+git commit -m "fix: coalesce parser-barrier terminal replay writes"
+```
+
+Expected:
+
+```text
+[test/opencode-playback-coalescing <sha>] fix: coalesce parser-barrier terminal replay writes
+```
+
+## Task 3: Verify Existing Replay Safety Cases
+
+**Files:**
+- Test only: `test/unit/client/components/TerminalView.lifecycle.test.tsx`
+- Test only: `src/components/terminal/terminal-write-queue.ts`
+
+- [ ] **Step 1: Run the terminal lifecycle tests around output batching**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run
+```
+
+Expected:
+
+```text
+Test Files  1 passed
+```
+
+The important protected behaviors in this file are:
+
+```text
+replays barrier-heavy OpenCode batches as bounded writes while holding checkpoints until xterm applies them
+does not checkpoint a stripped terminal.output.batch BEL segment as parser-applied
+completes attach when replay ends in a stripped terminal.output.batch BEL segment without checkpointing it
+queues stripped terminal.output.batch replay completion behind earlier replay write callbacks
+does not checkpoint a mixed renderable and stripped terminal.output.batch segment as parser-applied
+```
+
+- [ ] **Step 2: Run the write queue tests**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/terminal/terminal-write-queue.test.ts --run
+```
+
+Expected:
+
+```text
+Test Files  1 passed
+```
+
+- [ ] **Step 3: Re-run the synthetic baseline measurement manually from the regression test result**
+
+Use the OpenCode regression test evidence:
+
+```text
+Before fix: 96 barrier segments required 96 xterm writes, 96 xterm callbacks, and 96 RAF flushes.
+After fix: the same 96 barrier segments should submit the full replay payload in no more than 2 xterm writes before checkpointing.
+```
+
+The red test checks the after-fix invariant directly:
+
+```ts
+const submittedReplay = delayedCallbacks.map(({ data: chunk }) => chunk).join('')
+expect(submittedReplay).toBe(data)
+expect(delayedCallbacks.length).toBeLessThanOrEqual(2)
+```
+
+- [ ] **Step 4: Commit any verification-only test adjustment**
+
+If no files changed during verification, do not create a commit.
+
+If a test assertion needed a legitimate adjustment, run:
+
+```bash
+git add test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/terminal/terminal-write-queue.test.ts
+git commit -m "test: verify terminal replay coalescing safety"
+```
+
+Expected only when files changed:
+
+```text
+[test/opencode-playback-coalescing <sha>] test: verify terminal replay coalescing safety
+```
+
+## Task 4: Final Verification And Branch Finish
+
+**Files:**
+- No source edits expected.
+
+- [ ] **Step 1: Check the branch diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat origin/main...HEAD
+git log --oneline origin/main..HEAD
+```
+
+Expected:
+
+```text
+git status --short
+# no output
+
+git diff --stat origin/main...HEAD
+# includes src/components/TerminalView.tsx and test/unit/client/components/TerminalView.lifecycle.test.tsx
+```
+
+- [ ] **Step 2: Run the repo-supported status check before any broad suite**
+
+Run:
+
+```bash
+npm run test:status
+```
+
+Expected:
+
+```text
+No active broad test holder, or a reusable recent passing baseline is reported.
+```
+
+If another agent holds the coordinator, wait rather than killing it.
+
+- [ ] **Step 3: Run coordinated verification**
+
+Run:
+
+```bash
+FRESHELL_TEST_SUMMARY="OpenCode replay coalescing verification" npm run check
+```
+
+Expected:
+
+```text
+typecheck passes
+coordinated test suite passes
+```
+
+- [ ] **Step 4: Do not create a PR without explicit user approval**
+
+Stop with the branch committed locally and report:
+
+```text
+Branch test/opencode-playback-coalescing is committed and verified.
+No PR was created because repo instructions require explicit approval.
+```
+
+## Self-Review Checklist
+
+- Spec coverage: The plan targets the slow playback regression only. It leaves the tab-switch reload issue out of scope because the user narrowed the request to slow playback.
+- Placeholder scan: No unfinished placeholders or unspecified test instructions remain.
+- Type consistency: `disableWriteCoalescing` is removed from the `submitAcceptedOutput` input type, from the queue options, and from the batch barrier call site in the same task.
+- Safety: No production deploy, production restart, live host mutation, or PR creation is included.
+- Test design: The highest-value test is the existing OpenCode-style lifecycle replay regression test. The old split-write test is updated to protect parser checkpoint behavior rather than the harmful write-boundary behavior.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-15-opencode-replay-playback-coalescing.md`. The selected execution path for "the usual" is subagent-driven implementation with review checkpoints, followed by Fresh Eyes review of the resulting delta.

--- a/docs/superpowers/plans/2026-06-15-opencode-replay-playback-coalescing.md
+++ b/docs/superpowers/plans/2026-06-15-opencode-replay-playback-coalescing.md
@@ -4,9 +4,9 @@
 
 **Goal:** Restore fast OpenCode replay playback by allowing parser-barrier-heavy terminal output to reach xterm in bounded coalesced writes while preserving parser checkpoint ordering and attach completion safety.
 
-**Architecture:** Keep the terminal write-scope gate and xterm acknowledgement sequencing introduced by the recent playback safety work. Change the client batch replay path so parser barriers no longer force hard xterm write boundaries; barrier metadata still controls checkpoint callbacks, but adjacent renderable segments can coalesce through `TerminalWriteQueue`. No server protocol or PTY lifecycle changes are required for this fix.
+**Architecture:** Keep the terminal write-scope gate and xterm acknowledgement sequencing introduced by the recent playback safety work. Change the client batch replay path so parser barriers no longer force hard xterm write boundaries; barrier metadata still controls checkpoint callbacks, while adjacent renderable segments coalesce through `TerminalWriteQueue`. Add e2e-only write/callback recording so a browser regression test verifies real `Terminal.write` progression without changing server protocol or production logging.
 
-**Tech Stack:** React 18, TypeScript, xterm.js, Vitest, Testing Library, Freshell WebSocket terminal output protocol.
+**Tech Stack:** React 18, TypeScript, xterm.js 6.0.0, Vitest, Testing Library, Playwright, Freshell WebSocket terminal output protocol.
 
 ---
 
@@ -14,28 +14,46 @@
 
 - Modify: `src/components/TerminalView.tsx`
   - Remove the `disableWriteCoalescing` control path from accepted terminal output submission.
+  - Record e2e-only terminal write submitted/written events through `window.__FRESHELL_TEST_HARNESS__`.
   - Keep per-segment parser checkpoint callbacks for `terminal.output.batch` barrier segments.
+- Modify: `src/lib/test-harness.ts`
+  - Add e2e-only terminal write event storage and accessors.
+- Modify: `test/e2e-browser/helpers/test-harness.ts`
+  - Add Playwright helper methods for terminal write events.
+- Create: `test/e2e-browser/specs/opencode-replay-write-progression.spec.ts`
+  - Mount a real browser `TerminalView`, feed a barrier-heavy replay batch through the test WebSocket path, and assert real xterm writes are bounded.
 - Modify: `test/unit/client/components/TerminalView.lifecycle.test.tsx`
   - Replace the old expectation that barrier segments produce separate xterm writes.
-  - Keep the committed red regression test that reproduces the OpenCode slow replay failure.
-  - Verify stripped/no-write barrier cases still hold checkpoints until safe.
+  - Keep the committed red OpenCode replay regression test.
+  - Add a direct `A`, stripped segment, `B` checkpoint-safety regression.
 - No change: `src/components/terminal/terminal-write-queue.ts`
   - The queue already coalesces adjacent compatible writes and preserves callback order.
 - No change: `server/terminal-stream/output-batch.ts`
-  - Server batching can be optimized later, but the user-facing regression is caused by client-side hard write boundaries.
+  - Server batching can be optimized later, but this fix removes the client-side hard write boundary causing the observed slowdown.
 
-## Baseline Evidence
+## Baseline And Load-Bearing Evidence
 
-- Temp report: `/tmp/freshell-opencode-playback-investigation-20260615/baseline-slow-playback-data.md`
+- Temp baseline report: `/tmp/freshell-opencode-playback-investigation-20260615/baseline-slow-playback-data.md`
 - Red test commit: `7895df4a test: cover barrier-heavy replay coalescing`
-- Current failure:
+- Current red failure:
 
 ```text
 Expected submitted replay to equal the full 96-segment data payload.
 Received only the first 5-byte segment, "\x1b[30m", after one replay flush.
 ```
 
-## Task 1: Update The Parser-Barrier Write Expectation
+- Load-bearing validation results:
+
+```text
+A2 confirmed: installed @xterm/xterm 6.0.0 applies concatenated writes in order and invokes callbacks after parsing.
+A3 confirmed: barrier metadata is parser classification, not a protocol-level xterm write boundary.
+A4 confirmed: one replay write scope around a coalesced write still suppresses external side effects.
+A5/A6 structurally confirmed but missing a direct TerminalView regression for renderable + stripped + renderable coalescing.
+A1 inconclusive from existing artifacts: local logs do not prove real OpenCode write progression.
+A7 confirmed as a plan gap: focused Vitest + coordinated suite are not enough without browser/xterm write-progression evidence.
+```
+
+## Task 1: Update Terminal Lifecycle Regression Coverage
 
 **Files:**
 - Modify: `test/unit/client/components/TerminalView.lifecycle.test.tsx`
@@ -48,7 +66,7 @@ Find the test named:
 it('splits terminal.output.batch writes around parser barrier segments', async () => {
 ```
 
-Replace the test name and final expectation with:
+Replace the whole test with:
 
 ```ts
 it('preserves parser barrier checkpoints while allowing terminal.output.batch writes to coalesce', async () => {
@@ -87,29 +105,121 @@ it('preserves parser barrier checkpoints while allowing terminal.output.batch wr
 })
 ```
 
-- [ ] **Step 2: Run the focused old/new expectation**
+- [ ] **Step 2: Add the stripped-middle checkpoint regression**
+
+Add this test immediately after the parser barrier coalescing test:
+
+```ts
+it('does not checkpoint across a stripped middle batch segment when adjacent renderable segments coalesce', async () => {
+  const rafCallbacks: FrameRequestCallback[] = []
+  requestAnimationFrameSpy?.mockImplementation((cb: FrameRequestCallback) => {
+    rafCallbacks.push(cb)
+    return rafCallbacks.length
+  })
+
+  const { terminalId, term } = await renderTerminalHarness({
+    status: 'running',
+    terminalId: 'term-output-batch-stripped-middle-coalesced',
+    mode: 'opencode',
+    serverInstanceId: 'server-output-batch-stripped-middle-coalesced',
+  })
+  const attachRequestId = latestAttachRequestIdForTerminal(terminalId)
+  const streamId = latestStreamIdByTerminal.get(terminalId)
+  expect(attachRequestId).toBeTruthy()
+  expect(streamId).toBeTruthy()
+
+  const delayedCallbacks: Array<{ data: string; callback: () => void }> = []
+  term.write.mockClear()
+  term.write.mockImplementation((chunk: string, onWritten?: () => void) => {
+    if (onWritten) delayedCallbacks.push({ data: chunk, callback: onWritten })
+  })
+
+  act(() => {
+    messageHandler!({
+      type: 'terminal.output.batch',
+      terminalId,
+      streamId,
+      attachRequestId,
+      source: 'replay',
+      seqStart: 1,
+      seqEnd: 3,
+      data: 'A\x07B',
+      serializedBytes: 256,
+      segments: [
+        { seqStart: 1, seqEnd: 1, endOffset: 1, rawFrameCount: 1 },
+        { seqStart: 2, seqEnd: 2, endOffset: 2, rawFrameCount: 1, barrier: 'turn_complete' },
+        { seqStart: 3, seqEnd: 3, endOffset: 3, rawFrameCount: 1 },
+      ],
+    })
+  })
+
+  expect(delayedCallbacks).toEqual([])
+  expect(loadTerminalSurfaceCheckpoint(terminalId, {
+    streamId,
+    serverInstanceId: 'server-output-batch-stripped-middle-coalesced',
+  })).toBeNull()
+
+  act(() => {
+    rafCallbacks.shift()?.(16)
+  })
+
+  expect(delayedCallbacks.map(({ data }) => data)).toEqual(['AB'])
+  expect(loadTerminalSurfaceCheckpoint(terminalId, {
+    streamId,
+    serverInstanceId: 'server-output-batch-stripped-middle-coalesced',
+  })).toBeNull()
+
+  act(() => {
+    delayedCallbacks[0]?.callback()
+  })
+
+  expect(loadTerminalSurfaceCheckpoint(terminalId, {
+    streamId,
+    serverInstanceId: 'server-output-batch-stripped-middle-coalesced',
+  })?.parserAppliedSeq).toBe(1)
+
+  wsMocks.send.mockClear()
+  act(() => {
+    reconnectHandler?.()
+  })
+
+  expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+    type: 'terminal.attach',
+    terminalId,
+    sinceSeq: 1,
+  }))
+})
+```
+
+- [ ] **Step 3: Run both focused red tests**
 
 Run:
 
 ```bash
-npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx -t "preserves parser barrier checkpoints" --run
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx -t "preserves parser barrier checkpoints|stripped middle batch segment|replays barrier-heavy OpenCode batches" --run
 ```
 
-Expected before production changes: fail because the terminal still writes `['a', 'B', 'c']`.
+Expected before production changes:
 
-- [ ] **Step 3: Commit the test expectation update**
+```text
+FAIL replays barrier-heavy OpenCode batches as bounded writes while holding checkpoints until xterm applies them
+FAIL preserves parser barrier checkpoints while allowing terminal.output.batch writes to coalesce
+FAIL does not checkpoint across a stripped middle batch segment when adjacent renderable segments coalesce
+```
+
+- [ ] **Step 4: Commit the lifecycle test update**
 
 Run:
 
 ```bash
 git add test/unit/client/components/TerminalView.lifecycle.test.tsx
-git commit -m "test: expect parser barriers to coalesce terminal writes"
+git commit -m "test: expect parser barrier replay writes to coalesce"
 ```
 
 Expected:
 
 ```text
-[test/opencode-playback-coalescing <sha>] test: expect parser barriers to coalesce terminal writes
+[test/opencode-playback-coalescing <sha>] test: expect parser barrier replay writes to coalesce
 ```
 
 ## Task 2: Let Parser-Barrier Segments Use Normal Write Coalescing
@@ -208,35 +318,21 @@ submitAcceptedOutput({
 })
 ```
 
-- [ ] **Step 4: Run the OpenCode regression test**
+- [ ] **Step 4: Run the focused lifecycle tests**
 
 Run:
 
 ```bash
-npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx -t "replays barrier-heavy OpenCode batches" --run
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx -t "preserves parser barrier checkpoints|stripped middle batch segment|replays barrier-heavy OpenCode batches" --run
 ```
 
 Expected after production changes:
 
 ```text
-✓ test/unit/client/components/TerminalView.lifecycle.test.tsx > TerminalView lifecycle > ... > replays barrier-heavy OpenCode batches as bounded writes while holding checkpoints until xterm applies them
+Test Files  1 passed
 ```
 
-- [ ] **Step 5: Run the parser-barrier focused test**
-
-Run:
-
-```bash
-npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx -t "preserves parser barrier checkpoints" --run
-```
-
-Expected after production changes:
-
-```text
-✓ test/unit/client/components/TerminalView.lifecycle.test.tsx > TerminalView lifecycle > ... > preserves parser barrier checkpoints while allowing terminal.output.batch writes to coalesce
-```
-
-- [ ] **Step 6: Commit the client fix**
+- [ ] **Step 5: Commit the client coalescing fix**
 
 Run:
 
@@ -251,13 +347,288 @@ Expected:
 [test/opencode-playback-coalescing <sha>] fix: coalesce parser-barrier terminal replay writes
 ```
 
-## Task 3: Verify Existing Replay Safety Cases
+## Task 3: Add Browser Write-Progression Coverage
+
+**Files:**
+- Modify: `src/lib/test-harness.ts`
+- Modify: `src/components/TerminalView.tsx`
+- Modify: `test/e2e-browser/helpers/test-harness.ts`
+- Create: `test/e2e-browser/specs/opencode-replay-write-progression.spec.ts`
+
+- [ ] **Step 1: Extend the e2e harness type and storage**
+
+In `src/lib/test-harness.ts`, add this exported type after the imports:
+
+```ts
+export type TerminalWriteEvent = {
+  terminalId?: string
+  paneId?: string
+  phase: 'submitted' | 'written'
+  chars: number
+  data: string
+  at: number
+}
+```
+
+Add these optional methods to `FreshellTestHarness`:
+
+```ts
+  recordTerminalWrite?: (event: TerminalWriteEvent) => void
+  getTerminalWriteEvents?: () => TerminalWriteEvent[]
+  clearTerminalWriteEvents?: () => void
+```
+
+Inside `installTestHarness`, add storage next to `sentWsMessages`:
+
+```ts
+  const terminalWriteEvents: TerminalWriteEvent[] = []
+```
+
+Add these methods to the `window.__FRESHELL_TEST_HARNESS__` object:
+
+```ts
+    recordTerminalWrite: (event: TerminalWriteEvent) => {
+      terminalWriteEvents.push({ ...event })
+      if (terminalWriteEvents.length > 1000) terminalWriteEvents.shift()
+    },
+    getTerminalWriteEvents: () => [...terminalWriteEvents],
+    clearTerminalWriteEvents: () => {
+      terminalWriteEvents.length = 0
+    },
+```
+
+- [ ] **Step 2: Record actual xterm writes in `TerminalView`**
+
+In the `createTerminalWriteQueue` call in `src/components/TerminalView.tsx`, replace:
+
+```ts
+      write: (data, onWritten) => {
+        try {
+          term.write(data, onWritten)
+        } catch {
+          // disposed
+          onWritten?.()
+        }
+      },
+```
+
+with:
+
+```ts
+      write: (data, onWritten) => {
+        const recordForTest = (phase: 'submitted' | 'written') => {
+          window.__FRESHELL_TEST_HARNESS__?.recordTerminalWrite?.({
+            terminalId: terminalIdRef.current,
+            paneId,
+            phase,
+            chars: data.length,
+            data,
+            at: performance.now(),
+          })
+        }
+        const completeWrite = () => {
+          recordForTest('written')
+          onWritten?.()
+        }
+        recordForTest('submitted')
+        try {
+          term.write(data, completeWrite)
+        } catch {
+          // disposed
+          completeWrite()
+        }
+      },
+```
+
+- [ ] **Step 3: Add Playwright helper methods**
+
+In `test/e2e-browser/helpers/test-harness.ts`, import the event type:
+
+```ts
+import type { TerminalWriteEvent } from '@/lib/test-harness'
+```
+
+Add these methods to `TestHarness`:
+
+```ts
+  async getTerminalWriteEvents(): Promise<TerminalWriteEvent[]> {
+    return this.page.evaluate(() => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      if (!harness) throw new Error('Test harness not installed')
+      return harness.getTerminalWriteEvents?.() ?? []
+    })
+  }
+
+  async clearTerminalWriteEvents(): Promise<void> {
+    await this.page.evaluate(() => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      if (!harness) throw new Error('Test harness not installed')
+      harness.clearTerminalWriteEvents?.()
+    })
+  }
+```
+
+- [ ] **Step 4: Create the browser replay write-progression spec**
+
+Create `test/e2e-browser/specs/opencode-replay-write-progression.spec.ts`:
+
+```ts
+import { expect, test } from '../helpers/fixtures.js'
+
+const terminalId = 'term-e2e-opencode-replay-write-progression'
+const streamId = 'stream-e2e-opencode-replay-write-progression'
+const paneId = 'pane-e2e-opencode-replay-write-progression'
+
+function createOpenCodeLikeReplay() {
+  const chunks = Array.from({ length: 96 }, (_unused, index) => (
+    index % 2 === 0
+      ? `\x1b[${30 + (index % 8)}m`
+      : `tok${index.toString().padStart(2, '0')}`
+  ))
+  const data = chunks.join('')
+  const segments = chunks.map((chunk, index) => ({
+    seqStart: index + 1,
+    seqEnd: index + 1,
+    endOffset: chunks.slice(0, index + 1).join('').length,
+    rawFrameCount: 1,
+    barrier: 'control',
+  }))
+  return { chunks, data, segments }
+}
+
+test.describe('OpenCode replay write progression', () => {
+  test('submits barrier-heavy replay to real xterm in bounded writes', async ({ page, serverInfo, harness }) => {
+    await page.goto(`${serverInfo.baseUrl}/?token=${serverInfo.token}&e2e=1`)
+    await harness.waitForHarness()
+    await harness.waitForConnection()
+
+    await page.evaluate(({ tabId, paneId: targetPaneId, terminalId: targetTerminalId }) => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      if (!harness) throw new Error('Freshell test harness is not installed')
+      harness.dispatch({
+        type: 'tabs/addTab',
+        payload: {
+          id: tabId,
+          title: 'OpenCode replay write progression',
+          mode: 'opencode',
+          status: 'running',
+        },
+      })
+      harness.dispatch({
+        type: 'panes/initLayout',
+        payload: {
+          tabId,
+          paneId: targetPaneId,
+          content: {
+            kind: 'terminal',
+            mode: 'opencode',
+            shell: 'system',
+            terminalId: targetTerminalId,
+            status: 'running',
+          },
+        },
+      })
+    }, {
+      tabId: 'tab-e2e-opencode-replay-write-progression',
+      paneId,
+      terminalId,
+    })
+
+    await page.locator('.xterm').first().waitFor({ state: 'visible', timeout: 15_000 })
+    await page.waitForFunction((targetTerminalId) => (
+      window.__FRESHELL_TEST_HARNESS__?.getTerminalBuffer(targetTerminalId) !== null
+    ), terminalId, { timeout: 15_000 })
+
+    const attach = await page.waitForFunction((targetTerminalId) => {
+      const sent = window.__FRESHELL_TEST_HARNESS__?.getSentWsMessages?.() ?? []
+      return sent.find((msg: any) =>
+        msg?.type === 'terminal.attach'
+        && msg.terminalId === targetTerminalId
+        && typeof msg.attachRequestId === 'string'
+      ) ?? null
+    }, terminalId, { timeout: 15_000 })
+      .then((handle) => handle.jsonValue() as Promise<{ attachRequestId: string }>)
+
+    const replay = createOpenCodeLikeReplay()
+    await harness.clearTerminalWriteEvents()
+
+    await harness.receiveWsMessage({
+      type: 'terminal.attach.ready',
+      terminalId,
+      streamId,
+      headSeq: replay.chunks.length,
+      replayFromSeq: 1,
+      replayToSeq: replay.chunks.length,
+      attachRequestId: attach.attachRequestId,
+    })
+    await harness.receiveWsMessage({
+      type: 'terminal.output.batch',
+      terminalId,
+      streamId,
+      attachRequestId: attach.attachRequestId,
+      source: 'replay',
+      seqStart: 1,
+      seqEnd: replay.chunks.length,
+      data: replay.data,
+      serializedBytes: replay.data.length + 512,
+      segments: replay.segments,
+    })
+
+    await expect.poll(async () => {
+      const submitted = (await harness.getTerminalWriteEvents())
+        .filter((event) => event.phase === 'submitted' && event.terminalId === terminalId)
+      return submitted.map((event) => event.data).join('')
+    }, { timeout: 15_000 }).toBe(replay.data)
+
+    const submitted = (await harness.getTerminalWriteEvents())
+      .filter((event) => event.phase === 'submitted' && event.terminalId === terminalId)
+    expect(submitted.length).toBeLessThanOrEqual(2)
+
+    await expect.poll(async () => {
+      const written = (await harness.getTerminalWriteEvents())
+        .filter((event) => event.phase === 'written' && event.terminalId === terminalId)
+      return written.map((event) => event.data).join('')
+    }, { timeout: 15_000 }).toBe(replay.data)
+  })
+})
+```
+
+- [ ] **Step 5: Run the new e2e probe**
+
+Run:
+
+```bash
+npm run test:e2e:chromium -- test/e2e-browser/specs/opencode-replay-write-progression.spec.ts --workers=1
+```
+
+Expected after the client fix:
+
+```text
+1 passed
+```
+
+- [ ] **Step 6: Commit the browser write-progression coverage**
+
+Run:
+
+```bash
+git add src/lib/test-harness.ts src/components/TerminalView.tsx test/e2e-browser/helpers/test-harness.ts test/e2e-browser/specs/opencode-replay-write-progression.spec.ts
+git commit -m "test: cover OpenCode replay write progression in browser"
+```
+
+Expected:
+
+```text
+[test/opencode-playback-coalescing <sha>] test: cover OpenCode replay write progression in browser
+```
+
+## Task 4: Verify Existing Replay Safety Cases
 
 **Files:**
 - Test only: `test/unit/client/components/TerminalView.lifecycle.test.tsx`
 - Test only: `src/components/terminal/terminal-write-queue.ts`
 
-- [ ] **Step 1: Run the terminal lifecycle tests around output batching**
+- [ ] **Step 1: Run the terminal lifecycle suite**
 
 Run:
 
@@ -269,16 +640,6 @@ Expected:
 
 ```text
 Test Files  1 passed
-```
-
-The important protected behaviors in this file are:
-
-```text
-replays barrier-heavy OpenCode batches as bounded writes while holding checkpoints until xterm applies them
-does not checkpoint a stripped terminal.output.batch BEL segment as parser-applied
-completes attach when replay ends in a stripped terminal.output.batch BEL segment without checkpointing it
-queues stripped terminal.output.batch replay completion behind earlier replay write callbacks
-does not checkpoint a mixed renderable and stripped terminal.output.batch segment as parser-applied
 ```
 
 - [ ] **Step 2: Run the write queue tests**
@@ -295,31 +656,42 @@ Expected:
 Test Files  1 passed
 ```
 
-- [ ] **Step 3: Re-run the synthetic baseline measurement manually from the regression test result**
+- [ ] **Step 3: Run the attach sequence state tests**
 
-Use the OpenCode regression test evidence:
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/lib/terminal-attach-seq-state.test.ts --run
+```
+
+Expected:
 
 ```text
-Before fix: 96 barrier segments required 96 xterm writes, 96 xterm callbacks, and 96 RAF flushes.
-After fix: the same 96 barrier segments should submit the full replay payload in no more than 2 xterm writes before checkpointing.
+Test Files  1 passed
 ```
 
-The red test checks the after-fix invariant directly:
+- [ ] **Step 4: Run the browser write-progression e2e again**
 
-```ts
-const submittedReplay = delayedCallbacks.map(({ data: chunk }) => chunk).join('')
-expect(submittedReplay).toBe(data)
-expect(delayedCallbacks.length).toBeLessThanOrEqual(2)
+Run:
+
+```bash
+npm run test:e2e:chromium -- test/e2e-browser/specs/opencode-replay-write-progression.spec.ts --workers=1
 ```
 
-- [ ] **Step 4: Commit any verification-only test adjustment**
+Expected:
+
+```text
+1 passed
+```
+
+- [ ] **Step 5: Commit any legitimate verification-only adjustment**
 
 If no files changed during verification, do not create a commit.
 
-If a test assertion needed a legitimate adjustment, run:
+If an assertion needed a legitimate adjustment, run:
 
 ```bash
-git add test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/terminal/terminal-write-queue.test.ts
+git add test/unit/client/components/TerminalView.lifecycle.test.tsx test/e2e-browser/specs/opencode-replay-write-progression.spec.ts
 git commit -m "test: verify terminal replay coalescing safety"
 ```
 
@@ -329,7 +701,7 @@ Expected only when files changed:
 [test/opencode-playback-coalescing <sha>] test: verify terminal replay coalescing safety
 ```
 
-## Task 4: Final Verification And Branch Finish
+## Task 5: Final Verification And Branch Finish
 
 **Files:**
 - No source edits expected.
@@ -351,7 +723,7 @@ git status --short
 # no output
 
 git diff --stat origin/main...HEAD
-# includes src/components/TerminalView.tsx and test/unit/client/components/TerminalView.lifecycle.test.tsx
+# includes TerminalView, test harness, lifecycle tests, and the e2e spec
 ```
 
 - [ ] **Step 2: Run the repo-supported status check before any broad suite**
@@ -397,10 +769,11 @@ No PR was created because repo instructions require explicit approval.
 ## Self-Review Checklist
 
 - Spec coverage: The plan targets the slow playback regression only. It leaves the tab-switch reload issue out of scope because the user narrowed the request to slow playback.
+- Load-bearing coverage: The plan now includes direct coverage for the two validation gaps: stripped middle segment checkpointing and real browser/xterm write progression.
 - Placeholder scan: No unfinished placeholders or unspecified test instructions remain.
-- Type consistency: `disableWriteCoalescing` is removed from the `submitAcceptedOutput` input type, from the queue options, and from the batch barrier call site in the same task.
-- Safety: No production deploy, production restart, live host mutation, or PR creation is included.
-- Test design: The highest-value test is the existing OpenCode-style lifecycle replay regression test. The old split-write test is updated to protect parser checkpoint behavior rather than the harmful write-boundary behavior.
+- Type consistency: `disableWriteCoalescing` is removed from the `submitAcceptedOutput` input type, queue options, and batch barrier call site in the same task.
+- Safety: No production deploy, production restart, live host mutation, or PR creation is included. Playwright starts an isolated test server through existing test helpers.
+- Test design: Unit tests protect client ordering and checkpoint contracts; the browser e2e test protects the real `Terminal.write` progression that caused visible slow playback.
 
 ## Execution Handoff
 

--- a/docs/superpowers/plans/2026-06-15-opencode-replay-playback-coalescing.md
+++ b/docs/superpowers/plans/2026-06-15-opencode-replay-playback-coalescing.md
@@ -70,6 +70,12 @@ Replace the whole test with:
 
 ```ts
 it('preserves parser barrier checkpoints while allowing terminal.output.batch writes to coalesce', async () => {
+  const rafCallbacks: FrameRequestCallback[] = []
+  requestAnimationFrameSpy?.mockImplementation((cb: FrameRequestCallback) => {
+    rafCallbacks.push(cb)
+    return rafCallbacks.length
+  })
+
   const { terminalId, term } = await renderTerminalHarness({
     status: 'running',
     terminalId: 'term-output-batch-barrier',
@@ -77,7 +83,12 @@ it('preserves parser barrier checkpoints while allowing terminal.output.batch wr
   const attachRequestId = latestAttachRequestIdForTerminal(terminalId)
   const streamId = latestStreamIdByTerminal.get(terminalId)
 
+  const delayedCallbacks: Array<{ data: string; callback: () => void }> = []
   term.write.mockClear()
+  term.write.mockImplementation((chunk: string, onWritten?: () => void) => {
+    if (onWritten) delayedCallbacks.push({ data: chunk, callback: onWritten })
+  })
+
   act(() => {
     messageHandler!({
       type: 'terminal.output.batch',
@@ -97,7 +108,26 @@ it('preserves parser barrier checkpoints while allowing terminal.output.batch wr
     })
   })
 
-  expect(terminalWriteStrings(term)).toEqual(['aBc'])
+  expect(delayedCallbacks).toEqual([])
+  expect(loadTerminalSurfaceCheckpoint(terminalId, {
+    streamId,
+    serverInstanceId: 'server-instance',
+  })).toBeNull()
+
+  act(() => {
+    rafCallbacks.shift()?.(16)
+  })
+
+  expect(delayedCallbacks.map(({ data }) => data)).toEqual(['aBc'])
+  expect(loadTerminalSurfaceCheckpoint(terminalId, {
+    streamId,
+    serverInstanceId: 'server-instance',
+  })).toBeNull()
+
+  act(() => {
+    delayedCallbacks[0]?.callback()
+  })
+
   expect(loadTerminalSurfaceCheckpoint(terminalId, {
     streamId,
     serverInstanceId: 'server-instance',
@@ -475,11 +505,13 @@ Create `test/e2e-browser/specs/opencode-replay-write-progression.spec.ts`:
 ```ts
 import { expect, test } from '../helpers/fixtures.js'
 
-const terminalId = 'term-e2e-opencode-replay-write-progression'
-const streamId = 'stream-e2e-opencode-replay-write-progression'
-const paneId = 'pane-e2e-opencode-replay-write-progression'
+type TerminalSnapshot = {
+  terminalId: string
+  streamId: string
+  attachRequestId: string
+}
 
-function createOpenCodeLikeReplay() {
+function createOpenCodeLikeReplay(seqBase: number) {
   const chunks = Array.from({ length: 96 }, (_unused, index) => (
     index % 2 === 0
       ? `\x1b[${30 + (index % 8)}m`
@@ -487,8 +519,8 @@ function createOpenCodeLikeReplay() {
   ))
   const data = chunks.join('')
   const segments = chunks.map((chunk, index) => ({
-    seqStart: index + 1,
-    seqEnd: index + 1,
+    seqStart: seqBase + index,
+    seqEnd: seqBase + index,
     endOffset: chunks.slice(0, index + 1).join('').length,
     rawFrameCount: 1,
     barrier: 'control',
@@ -497,78 +529,54 @@ function createOpenCodeLikeReplay() {
 }
 
 test.describe('OpenCode replay write progression', () => {
-  test('submits barrier-heavy replay to real xterm in bounded writes', async ({ page, serverInfo, harness }) => {
-    await page.goto(`${serverInfo.baseUrl}/?token=${serverInfo.token}&e2e=1`)
-    await harness.waitForHarness()
-    await harness.waitForConnection()
+  test('submits barrier-heavy replay to real xterm in bounded writes', async ({ freshellPage, harness, terminal }) => {
+    const page = freshellPage
+    await terminal.waitForPrompt({ timeout: 30_000 })
 
-    await page.evaluate(({ tabId, paneId: targetPaneId, terminalId: targetTerminalId }) => {
+    const snapshot = await page.waitForFunction((): TerminalSnapshot | null => {
       const harness = window.__FRESHELL_TEST_HARNESS__
-      if (!harness) throw new Error('Freshell test harness is not installed')
-      harness.dispatch({
-        type: 'tabs/addTab',
-        payload: {
-          id: tabId,
-          title: 'OpenCode replay write progression',
-          mode: 'opencode',
-          status: 'running',
-        },
-      })
-      harness.dispatch({
-        type: 'panes/initLayout',
-        payload: {
-          tabId,
-          paneId: targetPaneId,
-          content: {
-            kind: 'terminal',
-            mode: 'opencode',
-            shell: 'system',
-            terminalId: targetTerminalId,
-            status: 'running',
-          },
-        },
-      })
-    }, {
-      tabId: 'tab-e2e-opencode-replay-write-progression',
-      paneId,
-      terminalId,
-    })
-
-    await page.locator('.xterm').first().waitFor({ state: 'visible', timeout: 15_000 })
-    await page.waitForFunction((targetTerminalId) => (
-      window.__FRESHELL_TEST_HARNESS__?.getTerminalBuffer(targetTerminalId) !== null
-    ), terminalId, { timeout: 15_000 })
-
-    const attach = await page.waitForFunction((targetTerminalId) => {
-      const sent = window.__FRESHELL_TEST_HARNESS__?.getSentWsMessages?.() ?? []
-      return sent.find((msg: any) =>
+      const state = harness?.getState()
+      const activeTabId = state?.tabs?.activeTabId
+      const findTerminal = (node: any): any => {
+        if (!node) return undefined
+        if (node.type === 'leaf' && node.content?.kind === 'terminal') return node.content
+        if (node.type === 'split') return findTerminal(node.children?.[0]) ?? findTerminal(node.children?.[1])
+        return undefined
+      }
+      const content = findTerminal(state?.panes?.layouts?.[activeTabId])
+      if (
+        typeof content?.terminalId !== 'string'
+        || typeof content?.streamId !== 'string'
+      ) {
+        return null
+      }
+      const sent = harness?.getSentWsMessages?.() ?? []
+      const attach = [...sent].reverse().find((msg: any) =>
         msg?.type === 'terminal.attach'
-        && msg.terminalId === targetTerminalId
+        && msg.terminalId === content.terminalId
         && typeof msg.attachRequestId === 'string'
-      ) ?? null
-    }, terminalId, { timeout: 15_000 })
-      .then((handle) => handle.jsonValue() as Promise<{ attachRequestId: string }>)
+      )
+      if (!attach) return null
+      return {
+        terminalId: content.terminalId,
+        streamId: content.streamId,
+        attachRequestId: attach.attachRequestId,
+      }
+    }, { timeout: 30_000 })
+      .then((handle) => handle.jsonValue() as Promise<TerminalSnapshot>)
 
-    const replay = createOpenCodeLikeReplay()
+    const seqBase = 100_000
+    const replay = createOpenCodeLikeReplay(seqBase)
     await harness.clearTerminalWriteEvents()
 
     await harness.receiveWsMessage({
-      type: 'terminal.attach.ready',
-      terminalId,
-      streamId,
-      headSeq: replay.chunks.length,
-      replayFromSeq: 1,
-      replayToSeq: replay.chunks.length,
-      attachRequestId: attach.attachRequestId,
-    })
-    await harness.receiveWsMessage({
       type: 'terminal.output.batch',
-      terminalId,
-      streamId,
-      attachRequestId: attach.attachRequestId,
+      terminalId: snapshot.terminalId,
+      streamId: snapshot.streamId,
+      attachRequestId: snapshot.attachRequestId,
       source: 'replay',
-      seqStart: 1,
-      seqEnd: replay.chunks.length,
+      seqStart: seqBase,
+      seqEnd: seqBase + replay.chunks.length - 1,
       data: replay.data,
       serializedBytes: replay.data.length + 512,
       segments: replay.segments,
@@ -576,17 +584,17 @@ test.describe('OpenCode replay write progression', () => {
 
     await expect.poll(async () => {
       const submitted = (await harness.getTerminalWriteEvents())
-        .filter((event) => event.phase === 'submitted' && event.terminalId === terminalId)
+        .filter((event) => event.phase === 'submitted' && event.terminalId === snapshot.terminalId)
       return submitted.map((event) => event.data).join('')
     }, { timeout: 15_000 }).toBe(replay.data)
 
     const submitted = (await harness.getTerminalWriteEvents())
-      .filter((event) => event.phase === 'submitted' && event.terminalId === terminalId)
+      .filter((event) => event.phase === 'submitted' && event.terminalId === snapshot.terminalId)
     expect(submitted.length).toBeLessThanOrEqual(2)
 
     await expect.poll(async () => {
       const written = (await harness.getTerminalWriteEvents())
-        .filter((event) => event.phase === 'written' && event.terminalId === terminalId)
+        .filter((event) => event.phase === 'written' && event.terminalId === snapshot.terminalId)
       return written.map((event) => event.data).join('')
     }, { timeout: 15_000 }).toBe(replay.data)
   })

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -2922,7 +2922,6 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           outputSource: TerminalOutputSource
           parserAppliedSeq: number
           completedAttach: boolean
-          disableWriteCoalescing?: boolean
         }) => {
           let raw = input.raw
           const frameOverlapsReplay = input.outputSource === 'replay' || Boolean(
@@ -2984,7 +2983,6 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             {
               mode: input.outputSource,
               generation: input.attachRequestId,
-              coalesce: input.disableWriteCoalescing ? false : undefined,
             },
           )
           if (
@@ -3228,7 +3226,6 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
               outputSource,
               parserAppliedSeq: acceptedSegment.parserAppliedSeq,
               completedAttach: completedAttachOnBatch && index === batchSegments.length - 1,
-              disableWriteCoalescing: true,
             })
           })
           return

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -1712,14 +1712,18 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       terminalInstanceId,
       write: (data, onWritten) => {
         const recordForTest = (phase: 'submitted' | 'written') => {
-          window.__FRESHELL_TEST_HARNESS__?.recordTerminalWrite?.({
-            terminalId: terminalIdRef.current,
-            paneId,
-            phase,
-            chars: data.length,
-            data,
-            at: performance.now(),
-          })
+          try {
+            window.__FRESHELL_TEST_HARNESS__?.recordTerminalWrite?.({
+              terminalId: terminalIdRef.current,
+              paneId,
+              phase,
+              chars: data.length,
+              data,
+              at: performance.now(),
+            })
+          } catch {
+            // Test harness failures must never break the terminal write path.
+          }
         }
         const completeWrite = () => {
           recordForTest('written')
@@ -1730,7 +1734,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           term.write(data, completeWrite)
         } catch {
           // disposed
-          completeWrite()
+          onWritten?.()
         }
       },
     })

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -1711,11 +1711,26 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     const writeQueue = createTerminalWriteQueue({
       terminalInstanceId,
       write: (data, onWritten) => {
+        const recordForTest = (phase: 'submitted' | 'written') => {
+          window.__FRESHELL_TEST_HARNESS__?.recordTerminalWrite?.({
+            terminalId: terminalIdRef.current,
+            paneId,
+            phase,
+            chars: data.length,
+            data,
+            at: performance.now(),
+          })
+        }
+        const completeWrite = () => {
+          recordForTest('written')
+          onWritten?.()
+        }
+        recordForTest('submitted')
         try {
-          term.write(data, onWritten)
+          term.write(data, completeWrite)
         } catch {
           // disposed
-          onWritten?.()
+          completeWrite()
         }
       },
     })

--- a/src/lib/test-harness.ts
+++ b/src/lib/test-harness.ts
@@ -11,6 +11,9 @@ export type TerminalWriteEvent = {
   at: number
 }
 
+const MAX_TERMINAL_WRITE_EVENTS = 1000
+const MAX_TERMINAL_WRITE_EVENT_BYTES = 1024 * 1024
+
 export interface FreshellTestHarness {
   getState: () => ReturnType<typeof appStore.getState>
   dispatch: typeof appStore.dispatch
@@ -81,6 +84,7 @@ export function installTestHarness(
   const suppressedTerminalPaneIds = new Set<string>()
   const sentWsMessages: unknown[] = []
   const terminalWriteEvents: TerminalWriteEvent[] = []
+  let terminalWriteEventBytes = 0
   const recordSentWsMessage = (msg: unknown) => {
     try {
       sentWsMessages.push(JSON.parse(JSON.stringify(msg)))
@@ -145,12 +149,22 @@ export function installTestHarness(
     },
     recordSentWsMessage,
     recordTerminalWrite: (event: TerminalWriteEvent) => {
-      terminalWriteEvents.push({ ...event })
-      if (terminalWriteEvents.length > 1000) terminalWriteEvents.shift()
+      const retainedEvent = { ...event }
+      terminalWriteEvents.push(retainedEvent)
+      terminalWriteEventBytes += retainedEvent.data.length
+      while (
+        terminalWriteEvents.length > MAX_TERMINAL_WRITE_EVENTS
+        || terminalWriteEventBytes > MAX_TERMINAL_WRITE_EVENT_BYTES
+      ) {
+        const removedEvent = terminalWriteEvents.shift()
+        if (!removedEvent) break
+        terminalWriteEventBytes -= removedEvent.data.length
+      }
     },
     getTerminalWriteEvents: () => [...terminalWriteEvents],
     clearTerminalWriteEvents: () => {
       terminalWriteEvents.length = 0
+      terminalWriteEventBytes = 0
     },
   }
 }

--- a/src/lib/test-harness.ts
+++ b/src/lib/test-harness.ts
@@ -2,6 +2,15 @@ import type { store as appStore } from '@/store/store'
 import type { PerfAuditSnapshot } from '@/lib/perf-audit-bridge'
 import type { ServerMessage } from '@shared/ws-protocol'
 
+export type TerminalWriteEvent = {
+  terminalId?: string
+  paneId?: string
+  phase: 'submitted' | 'written'
+  chars: number
+  data: string
+  at: number
+}
+
 export interface FreshellTestHarness {
   getState: () => ReturnType<typeof appStore.getState>
   dispatch: typeof appStore.dispatch
@@ -24,6 +33,9 @@ export interface FreshellTestHarness {
   getSentWsMessages?: () => unknown[]
   clearSentWsMessages?: () => void
   recordSentWsMessage?: (msg: unknown) => void
+  recordTerminalWrite?: (event: TerminalWriteEvent) => void
+  getTerminalWriteEvents?: () => TerminalWriteEvent[]
+  clearTerminalWriteEvents?: () => void
 }
 
 declare global {
@@ -68,6 +80,7 @@ export function installTestHarness(
     || (window as { __FRESHELL_SUPPRESS_ALL_FRESH_AGENT_NETWORK_EFFECTS__?: boolean }).__FRESHELL_SUPPRESS_ALL_FRESH_AGENT_NETWORK_EFFECTS__ === true
   const suppressedTerminalPaneIds = new Set<string>()
   const sentWsMessages: unknown[] = []
+  const terminalWriteEvents: TerminalWriteEvent[] = []
   const recordSentWsMessage = (msg: unknown) => {
     try {
       sentWsMessages.push(JSON.parse(JSON.stringify(msg)))
@@ -131,5 +144,13 @@ export function installTestHarness(
       sentWsMessages.length = 0
     },
     recordSentWsMessage,
+    recordTerminalWrite: (event: TerminalWriteEvent) => {
+      terminalWriteEvents.push({ ...event })
+      if (terminalWriteEvents.length > 1000) terminalWriteEvents.shift()
+    },
+    getTerminalWriteEvents: () => [...terminalWriteEvents],
+    clearTerminalWriteEvents: () => {
+      terminalWriteEvents.length = 0
+    },
   }
 }

--- a/test/e2e-browser/helpers/test-harness.ts
+++ b/test/e2e-browser/helpers/test-harness.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 import type { PerfAuditSnapshot } from '@/lib/perf-audit-bridge'
+import type { TerminalWriteEvent } from '@/lib/test-harness'
 
 /**
  * Helpers for interacting with the Freshell test harness from Playwright tests.
@@ -97,6 +98,22 @@ export class TestHarness {
       const harness = window.__FRESHELL_TEST_HARNESS__
       if (!harness) throw new Error('Test harness not installed')
       harness.clearSentWsMessages?.()
+    })
+  }
+
+  async getTerminalWriteEvents(): Promise<TerminalWriteEvent[]> {
+    return this.page.evaluate(() => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      if (!harness) throw new Error('Test harness not installed')
+      return harness.getTerminalWriteEvents?.() ?? []
+    })
+  }
+
+  async clearTerminalWriteEvents(): Promise<void> {
+    await this.page.evaluate(() => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      if (!harness) throw new Error('Test harness not installed')
+      harness.clearTerminalWriteEvents?.()
     })
   }
 

--- a/test/e2e-browser/specs/opencode-replay-write-progression.spec.ts
+++ b/test/e2e-browser/specs/opencode-replay-write-progression.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from '../helpers/fixtures.js'
+
+type TerminalSnapshot = {
+  terminalId: string
+  streamId: string
+  attachRequestId: string
+}
+
+function createOpenCodeLikeReplay(seqBase: number) {
+  const marker = '__FRESHELL_REPLAY_PROGRESS__'
+  const chunks = Array.from({ length: 96 }, (_unused, index) => (
+    `\x1b[${30 + (index % 8)}m${marker}${(seqBase + index).toString()}`
+  ))
+  const data = chunks.join('')
+  const segments = chunks.map((chunk, index) => ({
+    seqStart: seqBase + index,
+    seqEnd: seqBase + index,
+    endOffset: chunks.slice(0, index + 1).join('').length,
+    rawFrameCount: 1,
+    barrier: 'control' as const,
+  }))
+  return { chunks, data, marker, segments }
+}
+
+test.describe('OpenCode replay write progression', () => {
+  test('submits barrier-heavy replay to real xterm in bounded writes', async ({ freshellPage, harness, terminal }) => {
+    const page = freshellPage
+    await terminal.waitForPrompt({ timeout: 30_000 })
+
+    const snapshot = await page.waitForFunction((): TerminalSnapshot | null => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      const state = harness?.getState()
+      const activeTabId = state?.tabs?.activeTabId
+      const findTerminal = (node: any): any => {
+        if (!node) return undefined
+        if (node.type === 'leaf' && node.content?.kind === 'terminal') return node.content
+        if (node.type === 'split') return findTerminal(node.children?.[0]) ?? findTerminal(node.children?.[1])
+        return undefined
+      }
+      const content = findTerminal(state?.panes?.layouts?.[activeTabId])
+      if (
+        typeof content?.terminalId !== 'string'
+        || typeof content?.streamId !== 'string'
+      ) {
+        return null
+      }
+      const sent = harness?.getSentWsMessages?.() ?? []
+      const attach = [...sent].reverse().find((msg: any) =>
+        msg?.type === 'terminal.attach'
+        && msg.terminalId === content.terminalId
+        && typeof msg.attachRequestId === 'string'
+      )
+      if (!attach) return null
+      return {
+        terminalId: content.terminalId,
+        streamId: content.streamId,
+        attachRequestId: attach.attachRequestId,
+      }
+    }, { timeout: 30_000 })
+      .then((handle) => handle.jsonValue() as Promise<TerminalSnapshot>)
+
+    const seqBase = 100_000
+    const replay = createOpenCodeLikeReplay(seqBase)
+    await harness.clearTerminalWriteEvents()
+
+    await harness.receiveWsMessage({
+      type: 'terminal.output.batch',
+      terminalId: snapshot.terminalId,
+      streamId: snapshot.streamId,
+      attachRequestId: snapshot.attachRequestId,
+      source: 'replay',
+      seqStart: seqBase,
+      seqEnd: seqBase + replay.chunks.length - 1,
+      data: replay.data,
+      serializedBytes: replay.data.length + 512,
+      segments: replay.segments,
+    })
+
+    await expect.poll(async () => {
+      const submitted = (await harness.getTerminalWriteEvents())
+        .filter((event) =>
+          event.phase === 'submitted'
+          && event.terminalId === snapshot.terminalId
+          && event.data.includes(replay.marker)
+        )
+      return submitted.map((event) => event.data).join('')
+    }, { timeout: 15_000 }).toBe(replay.data)
+
+    const submitted = (await harness.getTerminalWriteEvents())
+      .filter((event) =>
+        event.phase === 'submitted'
+        && event.terminalId === snapshot.terminalId
+        && event.data.includes(replay.marker)
+      )
+    expect(submitted.length).toBeLessThanOrEqual(2)
+
+    await expect.poll(async () => {
+      const written = (await harness.getTerminalWriteEvents())
+        .filter((event) =>
+          event.phase === 'written'
+          && event.terminalId === snapshot.terminalId
+          && event.data.includes(replay.marker)
+        )
+      return written.map((event) => event.data).join('')
+    }, { timeout: 15_000 }).toBe(replay.data)
+  })
+})

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -5101,15 +5101,28 @@ describe('TerminalView lifecycle updates', () => {
       }))
     })
 
-    it('splits terminal.output.batch writes around parser barrier segments', async () => {
+    it('preserves parser barrier checkpoints while allowing terminal.output.batch writes to coalesce', async () => {
+      const rafCallbacks: FrameRequestCallback[] = []
+      requestAnimationFrameSpy?.mockImplementation((cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      })
+
       const { terminalId, term } = await renderTerminalHarness({
         status: 'running',
         terminalId: 'term-output-batch-barrier',
+        serverInstanceId: 'server-output-batch-barrier-coalesced',
       })
       const attachRequestId = latestAttachRequestIdForTerminal(terminalId)
       const streamId = latestStreamIdByTerminal.get(terminalId)
 
+      const delayedCallbacks: Array<{ data: string; callback: () => void }> = []
       term.write.mockClear()
+      term.write.mockImplementation((chunk: string, onWritten?: () => void) => {
+        if (onWritten) delayedCallbacks.push({ data: chunk, callback: onWritten })
+      })
+
+      rafCallbacks.length = 0
       act(() => {
         messageHandler!({
           type: 'terminal.output.batch',
@@ -5129,7 +5142,111 @@ describe('TerminalView lifecycle updates', () => {
         })
       })
 
-      expect(terminalWriteStrings(term)).toEqual(['a', 'B', 'c'])
+      expect(delayedCallbacks).toEqual([])
+      expect(loadTerminalSurfaceCheckpoint(terminalId, {
+        streamId,
+        serverInstanceId: 'server-output-batch-barrier-coalesced',
+      })).toBeNull()
+
+      act(() => {
+        rafCallbacks.shift()?.(16)
+      })
+
+      expect(delayedCallbacks.map(({ data }) => data)).toEqual(['aBc'])
+      expect(loadTerminalSurfaceCheckpoint(terminalId, {
+        streamId,
+        serverInstanceId: 'server-output-batch-barrier-coalesced',
+      })).toBeNull()
+
+      act(() => {
+        delayedCallbacks[0]?.callback()
+      })
+
+      expect(loadTerminalSurfaceCheckpoint(terminalId, {
+        streamId,
+        serverInstanceId: 'server-output-batch-barrier-coalesced',
+      })?.parserAppliedSeq).toBe(3)
+    })
+
+    it('does not checkpoint across a stripped middle batch segment when adjacent renderable segments coalesce', async () => {
+      const rafCallbacks: FrameRequestCallback[] = []
+      requestAnimationFrameSpy?.mockImplementation((cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      })
+
+      const { terminalId, term } = await renderTerminalHarness({
+        status: 'running',
+        terminalId: 'term-output-batch-stripped-middle-coalesced',
+        mode: 'codex',
+        serverInstanceId: 'server-output-batch-stripped-middle-coalesced',
+      })
+      const attachRequestId = latestAttachRequestIdForTerminal(terminalId)
+      const streamId = latestStreamIdByTerminal.get(terminalId)
+      expect(attachRequestId).toBeTruthy()
+      expect(streamId).toBeTruthy()
+
+      const delayedCallbacks: Array<{ data: string; callback: () => void }> = []
+      term.write.mockClear()
+      term.write.mockImplementation((chunk: string, onWritten?: () => void) => {
+        if (onWritten) delayedCallbacks.push({ data: chunk, callback: onWritten })
+      })
+
+      rafCallbacks.length = 0
+      act(() => {
+        messageHandler!({
+          type: 'terminal.output.batch',
+          terminalId,
+          streamId,
+          attachRequestId,
+          source: 'replay',
+          seqStart: 1,
+          seqEnd: 3,
+          data: 'A\x07B',
+          serializedBytes: 256,
+          segments: [
+            { seqStart: 1, seqEnd: 1, endOffset: 1, rawFrameCount: 1 },
+            { seqStart: 2, seqEnd: 2, endOffset: 2, rawFrameCount: 1, barrier: 'turn_complete' },
+            { seqStart: 3, seqEnd: 3, endOffset: 3, rawFrameCount: 1 },
+          ],
+        })
+      })
+
+      expect(delayedCallbacks).toEqual([])
+      expect(loadTerminalSurfaceCheckpoint(terminalId, {
+        streamId,
+        serverInstanceId: 'server-output-batch-stripped-middle-coalesced',
+      })).toBeNull()
+
+      act(() => {
+        rafCallbacks.shift()?.(16)
+      })
+
+      expect(delayedCallbacks.map(({ data }) => data)).toEqual(['AB'])
+      expect(loadTerminalSurfaceCheckpoint(terminalId, {
+        streamId,
+        serverInstanceId: 'server-output-batch-stripped-middle-coalesced',
+      })).toBeNull()
+
+      act(() => {
+        delayedCallbacks[0]?.callback()
+      })
+
+      expect(loadTerminalSurfaceCheckpoint(terminalId, {
+        streamId,
+        serverInstanceId: 'server-output-batch-stripped-middle-coalesced',
+      })?.parserAppliedSeq).toBe(1)
+
+      wsMocks.send.mockClear()
+      act(() => {
+        reconnectHandler?.()
+      })
+
+      expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'terminal.attach',
+        terminalId,
+        sinceSeq: 1,
+      }))
     })
 
     it('replays barrier-heavy OpenCode batches as bounded writes while holding checkpoints until xterm applies them', async () => {

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -5132,6 +5132,112 @@ describe('TerminalView lifecycle updates', () => {
       expect(terminalWriteStrings(term)).toEqual(['a', 'B', 'c'])
     })
 
+    it('replays barrier-heavy OpenCode batches as bounded writes while holding checkpoints until xterm applies them', async () => {
+      const rafCallbacks: FrameRequestCallback[] = []
+      requestAnimationFrameSpy?.mockImplementation((cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      })
+
+      const { terminalId, term, queryByText, store } = await renderTerminalHarness({
+        status: 'running',
+        terminalId: 'term-output-batch-opencode-heavy-replay',
+        mode: 'opencode',
+        serverInstanceId: 'server-output-batch-opencode-heavy-replay',
+        ackInitialAttach: false,
+        clearSends: false,
+      })
+      act(() => {
+        store.dispatch(setConnectionStatus('ready'))
+      })
+
+      const attach = sentMessages()
+        .find((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId)
+      const attachRequestId = attach?.attachRequestId
+      const streamId = 'stream-output-batch-opencode-heavy-replay'
+      expect(attachRequestId).toBeTruthy()
+
+      const chunks = Array.from({ length: 96 }, (_unused, index) => (
+        index % 2 === 0
+          ? `\x1b[${30 + (index % 8)}m`
+          : `tok${index.toString().padStart(2, '0')}`
+      ))
+      const data = chunks.join('')
+      const segments = chunks.map((chunk, index) => ({
+        seqStart: index + 1,
+        seqEnd: index + 1,
+        endOffset: chunks.slice(0, index + 1).join('').length,
+        rawFrameCount: 1,
+        barrier: 'control',
+      }))
+
+      act(() => {
+        messageHandler!({
+          type: 'terminal.attach.ready',
+          terminalId,
+          streamId,
+          headSeq: chunks.length,
+          replayFromSeq: 1,
+          replayToSeq: chunks.length,
+          attachRequestId,
+        })
+      })
+      expect(queryByText('Recovering terminal output...')).not.toBeNull()
+
+      const delayedCallbacks: Array<{ data: string; callback: () => void }> = []
+      rafCallbacks.length = 0
+      term.write.mockClear()
+      term.write.mockImplementation((chunk: string, onWritten?: () => void) => {
+        if (onWritten) delayedCallbacks.push({ data: chunk, callback: onWritten })
+      })
+
+      act(() => {
+        messageHandler!({
+          type: 'terminal.output.batch',
+          terminalId,
+          streamId,
+          attachRequestId,
+          source: 'replay',
+          seqStart: 1,
+          seqEnd: chunks.length,
+          data,
+          serializedBytes: data.length + 512,
+          segments,
+        })
+      })
+
+      expect(term.write).not.toHaveBeenCalled()
+      expect(loadTerminalSurfaceCheckpoint(terminalId, {
+        streamId,
+        serverInstanceId: 'server-output-batch-opencode-heavy-replay',
+      })).toBeNull()
+
+      act(() => {
+        rafCallbacks.shift()?.(16)
+      })
+
+      const submittedReplay = delayedCallbacks.map(({ data: chunk }) => chunk).join('')
+      expect(submittedReplay).toBe(data)
+      expect(delayedCallbacks.length).toBeLessThanOrEqual(2)
+      expect(loadTerminalSurfaceCheckpoint(terminalId, {
+        streamId,
+        serverInstanceId: 'server-output-batch-opencode-heavy-replay',
+      })).toBeNull()
+      expect(queryByText('Recovering terminal output...')).not.toBeNull()
+
+      act(() => {
+        delayedCallbacks.forEach(({ callback }) => callback())
+      })
+
+      await waitFor(() => {
+        expect(queryByText('Recovering terminal output...')).toBeNull()
+      })
+      expect(loadTerminalSurfaceCheckpoint(terminalId, {
+        streamId,
+        serverInstanceId: 'server-output-batch-opencode-heavy-replay',
+      })?.parserAppliedSeq).toBe(chunks.length)
+    })
+
     it('does not checkpoint a stripped terminal.output.batch BEL segment as parser-applied', async () => {
       const { terminalId, term } = await renderTerminalHarness({
         status: 'running',


### PR DESCRIPTION
## Summary

- Coalesce parser-barrier-heavy OpenCode replay writes through the existing terminal write queue instead of forcing one `Terminal.write` per segment.
- Preserve per-segment side effects, parser-applied checkpoint callbacks, stripped-output lost-range clamping, and attach-completion ordering.
- Add unit and browser regression coverage for barrier-heavy replay and real xterm write progression.

## Root Cause

Recent playback safety work preserved checkpoints by disabling write coalescing around parser barriers. OpenCode replay can contain many tiny barrier-adjacent segments, so this serialized replay into many tiny xterm writes and caused very slow visible playback.

## Verification

- `npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/terminal/terminal-write-queue.test.ts test/unit/client/lib/terminal-attach-seq-state.test.ts --run`
- `npm run test:e2e:chromium -- test/e2e-browser/specs/opencode-replay-write-progression.spec.ts --workers=1`
- `FRESHELL_TEST_SUMMARY="OpenCode replay coalescing verification after origin/main merge" npm run check`
- Fresh Eyes review passed after merging current `origin/main`.
