### PR TITLE
fix(fresh-agent): remove decorative prose backticks around inline code

### DIFF
--- a/src/components/fresh-agent/FreshAgentItemCard.tsx
+++ b/src/components/fresh-agent/FreshAgentItemCard.tsx
@@ -234,7 +234,7 @@ function renderText(text: string, markdown = false) {
   return (
     <div
       data-markdown-body=""
-      className="prose prose-sm dark:prose-invert max-w-none [&_h1]:my-2 [&_h2]:my-1.5 [&_h3]:my-1.5 [&_p]:my-1 [&_pre]:my-1.5 [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0.5"
+      className="prose prose-sm dark:prose-invert max-w-none [&_h1]:my-2 [&_h2]:my-1.5 [&_h3]:my-1.5 [&_p]:my-1 [&_pre]:my-1.5 [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0.5 [&_code]:before:!content-none [&_code]:after:!content-none"
     >
       <LazyMarkdown content={visibleText} fallback={plain} />
     </div>


### PR DESCRIPTION
Removes the decorative backticks that Tailwind Typography's `prose` CSS injects around inline `<code>` elements in fresh-agent assistant messages.

- Adds `[&_code]:before:!content-none [&_code]:after:!content-none` to the `prose` wrapper.
- This fixes the appearance of LLM-supplied inline-code formatting so the user sees monospaced entries without literal backtick decoration.

Closes #432