### PR TITLE
fix(fresh-agent): remove OpenCode CLI run-argument quoting from user messages

### DIFF
--- a/server/fresh-agent/adapters/opencode/normalize.ts
+++ b/server/fresh-agent/adapters/opencode/normalize.ts
@@ -79,10 +79,21 @@ function normalizePatchChanges(files: unknown): Record<string, unknown>[] {
     .filter((value): value is Record<string, unknown> => Boolean(value))
 }
 
-function itemFromPart(part: Record<string, any>, fallbackId: string): FreshAgentTranscriptItem | undefined {
+function stripSurroundingQuotes(text: string): string {
+  if (text.length >= 2 && text.startsWith('"') && text.endsWith('"')) return text.slice(1, -1)
+  return text
+}
+
+function itemFromPart(
+  part: Record<string, any>,
+  fallbackId: string,
+  role?: FreshAgentTurn['role'],
+): FreshAgentTranscriptItem | undefined {
   const id = typeof part.id === 'string' && part.id.length > 0 ? part.id : fallbackId
   if (part.type === 'text') {
-    return { id, kind: 'text', text: typeof part.text === 'string' ? part.text : '' }
+    const rawText = typeof part.text === 'string' ? part.text : ''
+    const text = role === 'user' ? stripSurroundingQuotes(rawText) : rawText
+    return { id, kind: 'text', text }
   }
   if (part.type === 'reasoning') {
     const text = typeof part.text === 'string' ? part.text : ''
@@ -175,9 +186,10 @@ function collectOpencodePartMetadata(messages: NonNullable<OpencodeExport['messa
 export function normalizeOpencodeTurn(message: NonNullable<OpencodeExport['messages']>[number], ordinal: number): FreshAgentTurn {
   const info = message.info ?? {}
   const id = typeof info.id === 'string' && info.id.length > 0 ? info.id : `message-${ordinal}`
+  const role: FreshAgentTurn['role'] = info.role === 'user' || info.role === 'assistant' || info.role === 'system' || info.role === 'tool' ? info.role : undefined
   const parts = Array.isArray(message.parts) ? message.parts : []
   const items = parts
-    .map((part, index) => itemFromPart(part, `${id}:part-${index}`))
+    .map((part, index) => itemFromPart(part, `${id}:part-${index}`, role))
     .filter((item): item is FreshAgentTranscriptItem => Boolean(item))
   const textSummary = items.find((item) => item.kind === 'text')?.text
   const reasoningSummary = items.find((item) => item.kind === 'reasoning')?.summary?.[0]
@@ -187,7 +199,7 @@ export function normalizeOpencodeTurn(message: NonNullable<OpencodeExport['messa
     messageId: id,
     ordinal,
     source: 'durable',
-    role: info.role === 'user' || info.role === 'assistant' || info.role === 'system' || info.role === 'tool' ? info.role : undefined,
+    role,
     timestamp: typeof info.time?.created === 'number' ? new Date(info.time.created).toISOString() : undefined,
     model: modelFromInfo(info),
     summary: textSummary ?? reasoningSummary ?? '',

--- a/server/fresh-agent/adapters/opencode/normalize.ts
+++ b/server/fresh-agent/adapters/opencode/normalize.ts
@@ -79,7 +79,14 @@ function normalizePatchChanges(files: unknown): Record<string, unknown>[] {
     .filter((value): value is Record<string, unknown> => Boolean(value))
 }
 
-function stripSurroundingQuotes(text: string): string {
+/**
+ * The OpenCode `run` subcommand stores a single positional prompt that
+ * contains spaces by wrapping it in literal double quotes. Other input paths
+ * (interactive composer, API-level sends, ACP) store the text as-is. We can
+ * therefore remove one outer pair of double quotes deterministically for user
+ * text turns without touching assistant text or legitimate inline quoting.
+ */
+function stripOpencodeRunArgumentQuoting(text: string): string {
   if (text.length >= 2 && text.startsWith('"') && text.endsWith('"')) return text.slice(1, -1)
   return text
 }
@@ -92,7 +99,7 @@ function itemFromPart(
   const id = typeof part.id === 'string' && part.id.length > 0 ? part.id : fallbackId
   if (part.type === 'text') {
     const rawText = typeof part.text === 'string' ? part.text : ''
-    const text = role === 'user' ? stripSurroundingQuotes(rawText) : rawText
+    const text = role === 'user' ? stripOpencodeRunArgumentQuoting(rawText) : rawText
     return { id, kind: 'text', text }
   }
   if (part.type === 'reasoning') {

--- a/test/unit/server/fresh-agent/opencode-normalize.test.ts
+++ b/test/unit/server/fresh-agent/opencode-normalize.test.ts
@@ -157,6 +157,48 @@ describe('OpenCode fresh-agent normalization', () => {
     })
   })
 
+  it('strips surrounding quotes from user text parts added by the OpenCode CLI', () => {
+    const turn = normalizeOpencodeTurn({
+      info: { id: 'msg-user-quoted', role: 'user' },
+      parts: [{ id: 'part-user-quoted', type: 'text', text: '"Do a directory listing."' }],
+    }, 0)
+
+    expect(turn.role).toBe('user')
+    expect(turn.items).toEqual([
+      { id: 'part-user-quoted', kind: 'text', text: 'Do a directory listing.' },
+    ])
+    expect(turn.summary).toBe('Do a directory listing.')
+  })
+
+  it('leaves unquoted user text parts unchanged', () => {
+    const turn = normalizeOpencodeTurn({
+      info: { id: 'msg-user-plain', role: 'user' },
+      parts: [{ id: 'part-user-plain', type: 'text', text: 'Do a directory listing.' }],
+    }, 0)
+
+    expect(turn.items[0]?.text).toBe('Do a directory listing.')
+    expect(turn.summary).toBe('Do a directory listing.')
+  })
+
+  it('does not strip surrounding quotes from assistant text parts', () => {
+    const turn = normalizeOpencodeTurn({
+      info: { id: 'msg-assistant-quoted', role: 'assistant' },
+      parts: [{ id: 'part-assistant-quoted', type: 'text', text: '"Hello, world."' }],
+    }, 0)
+
+    expect(turn.role).toBe('assistant')
+    expect(turn.items[0]?.text).toBe('"Hello, world."')
+  })
+
+  it('strips only one pair of surrounding quotes from user text parts', () => {
+    const turn = normalizeOpencodeTurn({
+      info: { id: 'msg-user-nested', role: 'user' },
+      parts: [{ id: 'part-user-nested', type: 'text', text: '""nested" quotes"' }],
+    }, 0)
+
+    expect(turn.items[0]?.text).toBe('"nested" quotes')
+  })
+
   it('carries turn-page nextCursor explicitly and keeps export fallback compatibility', () => {
     const explicit = normalizeOpencodeTurnPage({
       threadId: 'ses-page',


### PR DESCRIPTION
The OpenCode `run` subcommand deterministically wraps a single positional prompt argument in literal double quotes when it contains spaces. Freshell's freshopencode adapter uses exactly that invocation path, so all user messages sent (or previously sent) through it arrive in history with outer quotes.

This change removes one outer pair of double quotes from user text parts only, and only during OpenCode normalization. Assistant text and messages from non-CLI input paths are left untouched.

Closes #430
