### PR TITLE
Fix opencode idle status handling and leaked think tags

### DIFF
--- a/server/fresh-agent/adapters/opencode/normalize.ts
+++ b/server/fresh-agent/adapters/opencode/normalize.ts
@@ -91,6 +91,12 @@ function stripOpencodeRunArgumentQuoting(text: string): string {
   return text
 }
 
+/** OpenCode / Kimi may leak internal reasoning inside `<think>` / `<thinking>` tags.
+ * Strip both the tags and their content so it does not render in the transcript. */
+export function stripThinkTags(text: string): string {
+  return text.replace(/<thinking\b[^>]*>[\s\S]*?<\/thinking>/gi, '').replace(/<think\b[^>]*>[\s\S]*?<\/think>/gi, '').trim()
+}
+
 function itemFromPart(
   part: Record<string, any>,
   fallbackId: string,
@@ -99,11 +105,12 @@ function itemFromPart(
   const id = typeof part.id === 'string' && part.id.length > 0 ? part.id : fallbackId
   if (part.type === 'text') {
     const rawText = typeof part.text === 'string' ? part.text : ''
-    const text = role === 'user' ? stripOpencodeRunArgumentQuoting(rawText) : rawText
+    const stripped = stripThinkTags(rawText)
+    const text = role === 'user' ? stripOpencodeRunArgumentQuoting(stripped) : stripped
     return { id, kind: 'text', text }
   }
   if (part.type === 'reasoning') {
-    const text = typeof part.text === 'string' ? part.text : ''
+    const text = stripThinkTags(typeof part.text === 'string' ? part.text : '')
     return { id, kind: 'reasoning', summary: text ? [text] : [], content: text ? [text] : [], text }
   }
   if (part.type === 'tool') {

--- a/server/fresh-agent/adapters/opencode/normalize.ts
+++ b/server/fresh-agent/adapters/opencode/normalize.ts
@@ -92,9 +92,11 @@ function stripOpencodeRunArgumentQuoting(text: string): string {
 }
 
 /** OpenCode / Kimi may leak internal reasoning inside `<think>` / `<thinking>` tags.
- * Strip both the tags and their content so it does not render in the transcript. */
-export function stripThinkTags(text: string): string {
-  return text.replace(/<thinking\b[^>]*>[\s\S]*?<\/thinking>/gi, '').replace(/<think\b[^>]*>[\s\S]*?<\/think>/gi, '').trim()
+ * Strip both the tags and their content from assistant transcript text.
+ * User input is preserved so legitimate markup the user typed is not lost. */
+function stripThinkTags(text: string): string {
+  const after = text.replace(/<thinking\b[^>]*>[\s\S]*?<\/thinking>/gi, '').replace(/<think\b[^>]*>[\s\S]*?<\/think>/gi, '')
+  return after.length === text.length ? text : after.trim()
 }
 
 function itemFromPart(
@@ -105,12 +107,12 @@ function itemFromPart(
   const id = typeof part.id === 'string' && part.id.length > 0 ? part.id : fallbackId
   if (part.type === 'text') {
     const rawText = typeof part.text === 'string' ? part.text : ''
-    const stripped = stripThinkTags(rawText)
+    const stripped = role === 'user' ? rawText : stripThinkTags(rawText)
     const text = role === 'user' ? stripOpencodeRunArgumentQuoting(stripped) : stripped
     return { id, kind: 'text', text }
   }
   if (part.type === 'reasoning') {
-    const text = stripThinkTags(typeof part.text === 'string' ? part.text : '')
+    const text = typeof part.text === 'string' ? part.text : ''
     return { id, kind: 'reasoning', summary: text ? [text] : [], content: text ? [text] : [], text }
   }
   if (part.type === 'tool') {

--- a/server/fresh-agent/adapters/opencode/serve-manager.ts
+++ b/server/fresh-agent/adapters/opencode/serve-manager.ts
@@ -25,6 +25,13 @@ export type OpencodeServeMessagePage = { messages: OpencodeServeMessage[]; nextC
 
 type HealthResponse = { healthy?: boolean }
 
+function isIdleStatusEvent(event: ParsedServeEvent): boolean {
+  if (event.kind !== 'session.status') return false
+  const status = event.properties.status
+  if (!status || typeof status !== 'object' || Array.isArray(status)) return false
+  return (status as Record<string, unknown>).type === 'idle'
+}
+
 function isHealthyResponse(body: unknown): body is HealthResponse {
   return typeof body === 'object' && body !== null && (body as HealthResponse).healthy !== false
 }
@@ -285,7 +292,7 @@ export class OpencodeServeManager {
       }, timeoutMs)
       timer.unref?.()
       const handler = (event: ParsedServeEvent) => {
-        if (event.kind === 'session.idle') {
+        if (event.kind === 'session.idle' || isIdleStatusEvent(event)) {
           clearTimeout(timer)
           emitter.off('event', handler)
           resolve()

--- a/test/unit/server/fresh-agent/opencode-normalize.test.ts
+++ b/test/unit/server/fresh-agent/opencode-normalize.test.ts
@@ -199,6 +199,29 @@ describe('OpenCode fresh-agent normalization', () => {
     expect(turn.items[0]?.text).toBe('"nested" quotes')
   })
 
+  it('strips leaked <think> and <thinking> tags and their content from text parts', () => {
+    const turn = normalizeOpencodeTurn({
+      info: { id: 'msg-think-tags', role: 'assistant' },
+      parts: [
+        {
+          id: 'part-think',
+          type: 'text',
+          text: 'Before <think>Internal plan\\n1 tool used</think> and after.',
+        },
+        {
+          id: 'part-thinking',
+          type: 'text',
+          text: 'Intro <thinking reason="plan">I could change all instances.</thinking> done.',
+        },
+      ],
+    }, 0)
+
+    expect(turn.items).toEqual([
+      { id: 'part-think', kind: 'text', text: 'Before  and after.' },
+      { id: 'part-thinking', kind: 'text', text: 'Intro  done.' },
+    ])
+  })
+
   it('carries turn-page nextCursor explicitly and keeps export fallback compatibility', () => {
     const explicit = normalizeOpencodeTurnPage({
       threadId: 'ses-page',

--- a/test/unit/server/fresh-agent/opencode-normalize.test.ts
+++ b/test/unit/server/fresh-agent/opencode-normalize.test.ts
@@ -199,14 +199,14 @@ describe('OpenCode fresh-agent normalization', () => {
     expect(turn.items[0]?.text).toBe('"nested" quotes')
   })
 
-  it('strips leaked <think> and <thinking> tags and their content from text parts', () => {
+  it('strips leaked think/thinking tags and their content from assistant text parts', () => {
     const turn = normalizeOpencodeTurn({
       info: { id: 'msg-think-tags', role: 'assistant' },
       parts: [
         {
           id: 'part-think',
           type: 'text',
-          text: 'Before <think>Internal plan\\n1 tool used</think> and after.',
+          text: 'Before <think>Internal plan\n1 tool used</think> and after.',
         },
         {
           id: 'part-thinking',
@@ -219,6 +219,41 @@ describe('OpenCode fresh-agent normalization', () => {
     expect(turn.items).toEqual([
       { id: 'part-think', kind: 'text', text: 'Before  and after.' },
       { id: 'part-thinking', kind: 'text', text: 'Intro  done.' },
+    ])
+  })
+
+
+  it('preserves think tags in user text parts', () => {
+    const turn = normalizeOpencodeTurn({
+      info: { id: 'msg-user-think', role: 'user' },
+      parts: [
+        { id: 'part-user-think', type: 'text', text: 'Why did the assistant say <think>secret</think>?' },
+      ],
+    }, 0)
+
+    expect(turn.items).toEqual([
+      { id: 'part-user-think', kind: 'text', text: 'Why did the assistant say <think>secret</think>?' },
+    ])
+  })
+
+  it('does not trim assistant text that has no leaked think tags', () => {
+    const turn = normalizeOpencodeTurn({
+      info: { id: 'msg-preserve-ws', role: 'assistant' },
+      parts: [{ id: 'part-ws', type: 'text', text: '  leading\n  and trailing  ' }],
+    }, 0)
+
+    expect(turn.items).toEqual([{ id: 'part-ws', kind: 'text', text: '  leading\n  and trailing  ' }])
+  })
+
+  it('leaves reasoning parts untouched', () => {
+    const text = 'I am reasoning about <think> tags.'
+    const turn = normalizeOpencodeTurn({
+      info: { id: 'msg-reasoning', role: 'assistant' },
+      parts: [{ id: 'part-reasoning', type: 'reasoning', text }],
+    }, 0)
+
+    expect(turn.items).toEqual([
+      { id: 'part-reasoning', kind: 'reasoning', summary: [text], content: [text], text },
     ])
   })
 

--- a/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
@@ -212,6 +212,17 @@ describe('OpencodeServeManager fan-out', () => {
     expect((manager as any).sessionEmitters.get('ses_a')?.listenerCount('event') ?? 0).toBe(0)
   })
 
+  it('onceIdle resolves on session.status with idle for that session', async () => {
+    let push!: (e: any) => void
+    const { manager } = makeManager({
+      connectEventStream: (_url, h) => { push = (e) => h.onEvent(parseEvt(e)); return () => {} },
+    })
+    await manager.ensureStarted()
+    const idle = manager.onceIdle('ses_a', 1000)
+    push({ type: 'session.status', properties: { sessionID: 'ses_a', status: { type: 'idle' } } })
+    await expect(idle).resolves.toBeUndefined()
+  })
+
   it('onceIdle rejects on timeout', async () => {
     const { manager } = makeManager({ connectEventStream: () => () => {} })
     await manager.ensureStarted()

--- a/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
@@ -221,6 +221,33 @@ describe('OpencodeServeManager fan-out', () => {
     const idle = manager.onceIdle('ses_a', 1000)
     push({ type: 'session.status', properties: { sessionID: 'ses_a', status: { type: 'idle' } } })
     await expect(idle).resolves.toBeUndefined()
+    expect((manager as any).sessionEmitters.get('ses_a')?.listenerCount('event') ?? 0).toBe(0)
+  })
+
+  it('onceIdle does not resolve on session.status busy for that session', async () => {
+    let push!: (e: any) => void
+    const { manager } = makeManager({
+      connectEventStream: (_url, h) => { push = (e) => h.onEvent(parseEvt(e)); return () => {} },
+    })
+    await manager.ensureStarted()
+    const idle = manager.onceIdle('ses_a', 100)
+    push({ type: 'session.status', properties: { sessionID: 'ses_a', status: { type: 'busy' } } })
+    const pending = await new Promise<string>((resolve) => setTimeout(() => resolve('pending'), 50))
+    expect(pending).toBe('pending')
+    await expect(idle).rejects.toThrow(/idle/i)
+  })
+
+  it('onceIdle does not resolve on session.status idle for a different session', async () => {
+    let push!: (e: any) => void
+    const { manager } = makeManager({
+      connectEventStream: (_url, h) => { push = (e) => h.onEvent(parseEvt(e)); return () => {} },
+    })
+    await manager.ensureStarted()
+    const idle = manager.onceIdle('ses_a', 100)
+    push({ type: 'session.status', properties: { sessionID: 'ses_b', status: { type: 'idle' } } })
+    const pending = await new Promise<string>((resolve) => setTimeout(() => resolve('pending'), 50))
+    expect(pending).toBe('pending')
+    await expect(idle).rejects.toThrow(/idle/i)
   })
 
   it('onceIdle rejects on timeout', async () => {


### PR DESCRIPTION
- OpencodeServeManager.onceIdle now resolves on session.status idle events, matching the activity tracker's interpretation and preventing the freshopencode bouncer from spinning forever.
- The OpenCode normalizer strips leaked <think>/<thinking> content from assistant text parts while preserving user-typed markup and legitimate reasoning parts.
- Adds regression tests for both fixes, including negative cases.