### PR TITLE
Add Claude Code-style Fresh Agent mono theme

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -449,7 +449,7 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
 .fresh-rail-line { font-size: 13px; line-height: 1.45; overflow-wrap: anywhere; color: hsl(var(--foreground)); }
 .fresh-style-control { display: flex; align-items: center; justify-content: space-between; gap: 10px; border: 1px solid hsl(var(--border)); border-radius: 6px; background: hsl(var(--background) / .78); padding: 6px 8px; }
 .fresh-style-control span { color: hsl(var(--muted-foreground)); font-size: 10px; letter-spacing: .1em; text-transform: uppercase; }
-.fresh-style-control strong { color: hsl(var(--foreground)); font-family: Georgia, Cambria, 'Times New Roman', Times, serif; font-size: 13px; font-weight: 650; }
+.fresh-style-control strong { color: hsl(var(--foreground)); font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace; font-size: 13px; font-weight: 650; }
 
 @media (max-width: 768px) {
   .fresh-mock { display: flex; flex-direction: column; }
@@ -691,7 +691,7 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
               </div>
             </div>
             <aside class="fresh-rail">
-              <div class="fresh-rail-section"><div class="fresh-rail-title">Settings</div><div class="fresh-style-control" aria-label="Fresh Agent style setting"><span>Style</span><strong>Serif</strong></div></div>
+              <div class="fresh-rail-section"><div class="fresh-rail-title">Settings</div><div class="fresh-style-control" aria-label="Fresh Agent style setting"><span>Style</span><strong>Mono</strong></div></div>
               <div class="fresh-rail-section"><div class="fresh-rail-title">Review</div><div class="fresh-rail-line">pending</div><div class="fresh-rail-line">review-responsive-display</div></div>
               <div class="fresh-rail-section"><div class="fresh-rail-title">Fork lineage</div><div class="fresh-rail-line">parent-thread-with-long-identifier</div></div>
               <div class="fresh-rail-section"><div class="fresh-rail-title">Worktrees</div><div class="fresh-rail-line">codex/fresh-client-responsive-display</div></div>

--- a/shared/settings.ts
+++ b/shared/settings.ts
@@ -47,7 +47,7 @@ const FRESH_AGENT_FONT_SCALE_MAX = 2
 // Fresh-agent panes render 50% larger than the base UI by default.
 export const FRESH_AGENT_FONT_SCALE_DEFAULT = 1.5
 export const FRESH_AGENT_FONT_SCALE_OPTIONS = [1, 1.25, 1.5, 1.75, 2] as const
-export const FRESH_AGENT_STYLE_VALUES = ['sans', 'serif'] as const
+export const FRESH_AGENT_STYLE_VALUES = ['sans', 'serif', 'mono'] as const
 export type FreshAgentStyle = (typeof FRESH_AGENT_STYLE_VALUES)[number]
 export const DEFAULT_FRESH_AGENT_STYLE: FreshAgentStyle = 'sans'
 

--- a/src/components/fresh-agent/FreshAgentSettingsButton.tsx
+++ b/src/components/fresh-agent/FreshAgentSettingsButton.tsx
@@ -167,7 +167,7 @@ export function FreshAgentSettingsButton({
               >
                 {FRESH_AGENT_STYLE_VALUES.map((style) => (
                   <option key={style} value={style}>
-                    {style === 'sans' ? 'Sans' : 'Serif'}
+                    {style === 'sans' ? 'Sans' : style === 'mono' ? 'Mono' : 'Serif'}
                   </option>
                 ))}
               </select>

--- a/src/index.css
+++ b/src/index.css
@@ -894,7 +894,7 @@ html {
   border-color: var(--fresh-agent-accent);
 }
 
-.fresh-agent-style-mono :where(.fresh-agent-approval-button-primary, .fresh-agent-composer-action[type="submit"]) {
+.fresh-agent-style-mono .fresh-agent-approval-button-primary {
   background: var(--fresh-agent-accent);
   border-color: var(--fresh-agent-accent);
   color: var(--fresh-agent-surface);
@@ -1093,6 +1093,19 @@ html {
 
 .fresh-agent-style-mono .fresh-agent-composer-action {
   background: var(--fresh-agent-panel-surface);
+}
+
+.fresh-agent-style-mono .fresh-agent-composer-action[type="submit"] {
+  background: var(--fresh-agent-accent);
+  border-color: var(--fresh-agent-accent);
+  color: var(--fresh-agent-surface);
+  text-shadow: none;
+}
+
+.fresh-agent-style-mono .fresh-agent-composer-action[type="submit"]:hover:not(:disabled) {
+  background: var(--fresh-agent-accent);
+  border-color: var(--fresh-agent-accent);
+  color: var(--fresh-agent-surface);
 }
 
 .fresh-agent-style-mono .fresh-agent-composer-menu,

--- a/src/index.css
+++ b/src/index.css
@@ -637,6 +637,30 @@ html {
   --fresh-agent-copy-font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   --fresh-agent-meta-font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   --fresh-agent-mono-font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --fresh-agent-surface: #fbfcf8;
+  --fresh-agent-panel-surface: #f2f6ee;
+  --fresh-agent-subtle-surface: #e8f0e3;
+  --fresh-agent-raised-surface: #eef4e9;
+  --fresh-agent-border: rgba(23, 111, 46, 0.28);
+  --fresh-agent-border-strong: rgba(23, 111, 46, 0.48);
+  --fresh-agent-accent: #176f2e;
+  --fresh-agent-accent-soft: rgba(23, 111, 46, 0.1);
+  --fresh-agent-danger: #b42318;
+  --fresh-agent-danger-soft: rgba(180, 35, 24, 0.1);
+  --fresh-agent-success: #176f2e;
+  --fresh-agent-success-soft: rgba(23, 111, 46, 0.1);
+  --fresh-agent-text: #17301d;
+  --fresh-agent-muted-text: #4f6b55;
+  --fresh-agent-soft-text: #657c6a;
+  --fresh-agent-terminal-text-shadow: none;
+  --fresh-agent-watermark-opacity: 0;
+  background: var(--fresh-agent-surface);
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  text-shadow: var(--fresh-agent-terminal-text-shadow);
+}
+
+.dark .fresh-agent-style-mono {
   --fresh-agent-surface: #0a0a0a;
   --fresh-agent-panel-surface: #0d0d0d;
   --fresh-agent-subtle-surface: #131313;
@@ -652,27 +676,11 @@ html {
   --fresh-agent-text: #39ff14;
   --fresh-agent-muted-text: #5c9e4c;
   --fresh-agent-soft-text: #4a8a3c;
-  --fresh-agent-watermark-opacity: 0.04;
-  position: relative;
-  background: var(--fresh-agent-surface);
-  color: var(--fresh-agent-text);
-  font-family: var(--fresh-agent-copy-font-family);
-  text-shadow: 0 0 1px rgba(57, 255, 20, 0.25);
+  --fresh-agent-terminal-text-shadow: 0 0 1px rgba(57, 255, 20, 0.25);
 }
 
-.fresh-agent-style-mono::after {
-  content: "";
-  pointer-events: none;
-  position: absolute;
-  inset: 0;
-  background: repeating-linear-gradient(
-    to bottom,
-    transparent,
-    transparent 2px,
-    rgba(57, 255, 20, 0.03) 2px,
-    rgba(57, 255, 20, 0.03) 4px
-  );
-  z-index: 50;
+.fresh-agent-style-mono .fresh-agent-watermark {
+  display: none;
 }
 
 .fresh-agent-style-mono .fresh-agent-transcript-copy {

--- a/src/index.css
+++ b/src/index.css
@@ -400,7 +400,7 @@ html {
   color: var(--fresh-agent-text);
 }
 
-.fresh-agent-style-serif :where(.fresh-agent-approval-button-primary, .fresh-agent-composer-action[type="submit"]) {
+.fresh-agent-style-serif .fresh-agent-approval-button-primary {
   background: var(--fresh-agent-text);
   border-color: var(--fresh-agent-text);
   color: var(--fresh-agent-surface);
@@ -591,6 +591,18 @@ html {
 
 .fresh-agent-style-serif .fresh-agent-composer-action {
   background: var(--fresh-agent-panel-surface);
+}
+
+.fresh-agent-style-serif .fresh-agent-composer-action[type="submit"] {
+  background: var(--fresh-agent-text);
+  border-color: var(--fresh-agent-text);
+  color: var(--fresh-agent-surface);
+}
+
+.fresh-agent-style-serif .fresh-agent-composer-action[type="submit"]:hover:not(:disabled) {
+  background: var(--fresh-agent-text);
+  border-color: var(--fresh-agent-text);
+  color: var(--fresh-agent-surface);
 }
 
 .fresh-agent-style-serif .fresh-agent-composer-menu,

--- a/src/index.css
+++ b/src/index.css
@@ -637,46 +637,46 @@ html {
   --fresh-agent-copy-font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   --fresh-agent-meta-font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   --fresh-agent-mono-font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-  --fresh-agent-surface: #fbfcf8;
-  --fresh-agent-panel-surface: #f2f6ee;
-  --fresh-agent-subtle-surface: #e8f0e3;
-  --fresh-agent-raised-surface: #eef4e9;
-  --fresh-agent-border: rgba(23, 111, 46, 0.28);
-  --fresh-agent-border-strong: rgba(23, 111, 46, 0.48);
-  --fresh-agent-accent: #176f2e;
-  --fresh-agent-accent-soft: rgba(23, 111, 46, 0.1);
+  --fresh-agent-surface: #fbfaf7;
+  --fresh-agent-panel-surface: #f6f3ed;
+  --fresh-agent-subtle-surface: #eee8df;
+  --fresh-agent-raised-surface: #fffdf8;
+  --fresh-agent-border: rgba(91, 75, 60, 0.22);
+  --fresh-agent-border-strong: rgba(91, 75, 60, 0.38);
+  --fresh-agent-accent: #a04f33;
+  --fresh-agent-accent-soft: rgba(160, 79, 51, 0.11);
   --fresh-agent-danger: #b42318;
   --fresh-agent-danger-soft: rgba(180, 35, 24, 0.1);
-  --fresh-agent-success: #176f2e;
-  --fresh-agent-success-soft: rgba(23, 111, 46, 0.1);
-  --fresh-agent-text: #17301d;
-  --fresh-agent-muted-text: #4f6b55;
-  --fresh-agent-soft-text: #657c6a;
-  --fresh-agent-terminal-text-shadow: none;
+  --fresh-agent-success: #2f7d55;
+  --fresh-agent-success-soft: rgba(47, 125, 85, 0.11);
+  --fresh-agent-text: #24211d;
+  --fresh-agent-muted-text: #665d54;
+  --fresh-agent-soft-text: #857a70;
+  --fresh-agent-radius: 0.375rem;
+  --fresh-agent-radius-tight: 0.25rem;
   --fresh-agent-watermark-opacity: 0;
   background: var(--fresh-agent-surface);
   color: var(--fresh-agent-text);
   font-family: var(--fresh-agent-copy-font-family);
-  text-shadow: var(--fresh-agent-terminal-text-shadow);
+  text-shadow: none;
 }
 
 .dark .fresh-agent-style-mono {
-  --fresh-agent-surface: #0a0a0a;
-  --fresh-agent-panel-surface: #0d0d0d;
-  --fresh-agent-subtle-surface: #131313;
-  --fresh-agent-raised-surface: #101010;
-  --fresh-agent-border: rgba(57, 255, 20, 0.3);
-  --fresh-agent-border-strong: rgba(57, 255, 20, 0.55);
-  --fresh-agent-accent: #39ff14;
-  --fresh-agent-accent-soft: rgba(57, 255, 20, 0.12);
-  --fresh-agent-danger: #ff5555;
-  --fresh-agent-danger-soft: rgba(255, 85, 85, 0.12);
-  --fresh-agent-success: #39ff14;
-  --fresh-agent-success-soft: rgba(57, 255, 20, 0.12);
-  --fresh-agent-text: #39ff14;
-  --fresh-agent-muted-text: #5c9e4c;
-  --fresh-agent-soft-text: #4a8a3c;
-  --fresh-agent-terminal-text-shadow: 0 0 1px rgba(57, 255, 20, 0.25);
+  --fresh-agent-surface: #181715;
+  --fresh-agent-panel-surface: #211f1c;
+  --fresh-agent-subtle-surface: #2b2824;
+  --fresh-agent-raised-surface: #25221f;
+  --fresh-agent-border: rgba(232, 224, 215, 0.16);
+  --fresh-agent-border-strong: rgba(232, 224, 215, 0.28);
+  --fresh-agent-accent: #e09a78;
+  --fresh-agent-accent-soft: rgba(224, 154, 120, 0.14);
+  --fresh-agent-danger: #f2847d;
+  --fresh-agent-danger-soft: rgba(242, 132, 125, 0.14);
+  --fresh-agent-success: #86c39a;
+  --fresh-agent-success-soft: rgba(134, 195, 154, 0.13);
+  --fresh-agent-text: #ebe3da;
+  --fresh-agent-muted-text: #b9afa5;
+  --fresh-agent-soft-text: #92887e;
 }
 
 .fresh-agent-style-mono .fresh-agent-watermark {
@@ -716,7 +716,7 @@ html {
 }
 
 .fresh-agent-style-mono .fresh-agent-transcript-scroll {
-  gap: 0;
+  gap: 0.2rem;
   padding: 0.75rem 1rem 1rem;
 }
 
@@ -730,7 +730,7 @@ html {
 .fresh-agent-style-mono .fresh-agent-turn {
   border-left: 0;
   border-top: 1px solid var(--fresh-agent-border);
-  padding: 0.85rem 0 1rem;
+  padding: 0.9rem 0 1rem;
 }
 
 .fresh-agent-style-mono .fresh-agent-turn[data-turn-continuation="true"] {
@@ -746,13 +746,13 @@ html {
 
 .fresh-agent-style-mono .fresh-agent-turn-header {
   color: var(--fresh-agent-soft-text);
-  font-size: 0.55rem;
+  font-size: 0.62rem;
   font-weight: 500;
-  letter-spacing: 0.08em;
+  letter-spacing: 0;
   line-height: 1.25;
   margin-bottom: 0.5rem;
   max-width: 100%;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .fresh-agent-style-mono .fresh-agent-turn-header span:first-child {
@@ -775,6 +775,7 @@ html {
 .fresh-agent-style-mono .fresh-agent-turn[data-turn-role="user"] .fresh-agent-transcript-copy {
   background: var(--fresh-agent-subtle-surface);
   border-left: 2px solid var(--fresh-agent-accent);
+  border-radius: var(--fresh-agent-radius);
   padding: 0.6rem 0.8rem;
 }
 
@@ -790,7 +791,7 @@ html {
 ) {
   background: var(--fresh-agent-panel-surface);
   border: 1px solid var(--fresh-agent-border);
-  border-radius: 0;
+  border-radius: var(--fresh-agent-radius);
   color: var(--fresh-agent-text);
   box-shadow: none;
 }
@@ -815,11 +816,11 @@ html {
 ) {
   color: var(--fresh-agent-accent);
   font-family: var(--fresh-agent-meta-font-family);
-  font-size: 0.55rem;
+  font-size: 0.65rem;
   font-weight: 500;
-  letter-spacing: 0.1em;
+  letter-spacing: 0;
   line-height: 1.2;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .fresh-agent-style-mono .fresh-agent-approval-heading {
@@ -830,7 +831,7 @@ html {
 .fresh-agent-style-mono .fresh-agent-status-badge {
   border: 1px solid var(--fresh-agent-border-strong);
   color: var(--fresh-agent-accent);
-  border-radius: 0;
+  border-radius: var(--fresh-agent-radius-tight);
 }
 
 .fresh-agent-style-mono .fresh-agent-approval-tool {
@@ -856,7 +857,7 @@ html {
 ) {
   background: var(--fresh-agent-surface);
   border: 1px solid var(--fresh-agent-border);
-  border-radius: 0;
+  border-radius: var(--fresh-agent-radius);
   color: var(--fresh-agent-muted-text);
   font-family: var(--fresh-agent-mono-font-family);
 }
@@ -871,13 +872,13 @@ html {
 ) {
   background: transparent;
   border: 1px solid var(--fresh-agent-border);
-  border-radius: 0;
+  border-radius: var(--fresh-agent-radius-tight);
   color: var(--fresh-agent-muted-text);
   font-family: var(--fresh-agent-meta-font-family);
   font-size: 0.65rem;
   font-weight: 500;
   letter-spacing: 0;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .fresh-agent-style-mono :where(
@@ -933,7 +934,7 @@ html {
 .fresh-agent-style-mono .fresh-agent-composer-filter-input {
   background: var(--fresh-agent-surface);
   border: 1px solid var(--fresh-agent-border);
-  border-radius: 0;
+  border-radius: var(--fresh-agent-radius-tight);
   color: var(--fresh-agent-text);
   caret-color: var(--fresh-agent-accent);
 }
@@ -959,9 +960,9 @@ html {
 .fresh-agent-style-mono .fresh-agent-activity-summary [role="status"] {
   color: var(--fresh-agent-soft-text);
   font-family: var(--fresh-agent-meta-font-family);
-  font-size: 0.55rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 0.6rem;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .fresh-agent-style-mono .fresh-agent-activity-summary [data-slot="name"] {
@@ -977,7 +978,7 @@ html {
 }
 
 .fresh-agent-style-mono :where(.fresh-agent-tool-trigger, .fresh-agent-thinking-trigger, .fresh-agent-file-diff-trigger) {
-  border-radius: 0;
+  border-radius: var(--fresh-agent-radius-tight);
   color: var(--fresh-agent-soft-text);
   padding-bottom: 0.15rem;
   padding-top: 0.15rem;
@@ -1014,7 +1015,7 @@ html {
 .fresh-agent-style-mono .fresh-agent-thinking-body {
   background: var(--fresh-agent-panel-surface);
   border: 1px solid var(--fresh-agent-border);
-  border-radius: 0;
+  border-radius: var(--fresh-agent-radius);
   color: var(--fresh-agent-muted-text);
   font-family: var(--fresh-agent-copy-font-family);
 }
@@ -1058,7 +1059,7 @@ html {
 .fresh-agent-style-mono .fresh-agent-sidebar-section {
   background: transparent;
   border: 1px solid var(--fresh-agent-border);
-  border-radius: 0;
+  border-radius: var(--fresh-agent-radius);
 }
 
 .fresh-agent-style-mono .fresh-agent-sidebar-list {
@@ -1077,7 +1078,7 @@ html {
 .fresh-agent-style-mono .fresh-agent-composer-input {
   background: var(--fresh-agent-panel-surface);
   border: 1px solid var(--fresh-agent-border);
-  border-radius: 0;
+  border-radius: var(--fresh-agent-radius);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fresh-agent-border) 45%, transparent);
   color: var(--fresh-agent-text);
   font-family: var(--fresh-agent-copy-font-family);
@@ -1099,7 +1100,7 @@ html {
 .fresh-agent-style-mono .fresh-agent-attachment {
   background: var(--fresh-agent-panel-surface);
   border: 1px solid var(--fresh-agent-border);
-  border-radius: 0;
+  border-radius: var(--fresh-agent-radius);
   color: var(--fresh-agent-muted-text);
 }
 
@@ -1122,7 +1123,7 @@ html {
 .fresh-agent-style-mono .fresh-agent-scroll-bottom {
   background: var(--fresh-agent-panel-surface);
   border: 1px solid var(--fresh-agent-border);
-  border-radius: 0;
+  border-radius: var(--fresh-agent-radius);
   bottom: 0.8rem;
   box-shadow: none;
   color: var(--fresh-agent-muted-text);

--- a/src/index.css
+++ b/src/index.css
@@ -633,6 +633,501 @@ html {
   background: var(--fresh-agent-subtle-surface);
 }
 
+.fresh-agent-style-mono {
+  --fresh-agent-copy-font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --fresh-agent-meta-font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --fresh-agent-mono-font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --fresh-agent-surface: #0a0a0a;
+  --fresh-agent-panel-surface: #0d0d0d;
+  --fresh-agent-subtle-surface: #131313;
+  --fresh-agent-raised-surface: #101010;
+  --fresh-agent-border: rgba(57, 255, 20, 0.3);
+  --fresh-agent-border-strong: rgba(57, 255, 20, 0.55);
+  --fresh-agent-accent: #39ff14;
+  --fresh-agent-accent-soft: rgba(57, 255, 20, 0.12);
+  --fresh-agent-danger: #ff5555;
+  --fresh-agent-danger-soft: rgba(255, 85, 85, 0.12);
+  --fresh-agent-success: #39ff14;
+  --fresh-agent-success-soft: rgba(57, 255, 20, 0.12);
+  --fresh-agent-text: #39ff14;
+  --fresh-agent-muted-text: #5c9e4c;
+  --fresh-agent-soft-text: #4a8a3c;
+  --fresh-agent-watermark-opacity: 0.04;
+  position: relative;
+  background: var(--fresh-agent-surface);
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  text-shadow: 0 0 1px rgba(57, 255, 20, 0.25);
+}
+
+.fresh-agent-style-mono::after {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent,
+    transparent 2px,
+    rgba(57, 255, 20, 0.03) 2px,
+    rgba(57, 255, 20, 0.03) 4px
+  );
+  z-index: 50;
+}
+
+.fresh-agent-style-mono .fresh-agent-transcript-copy {
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  line-height: 1.5;
+}
+
+.fresh-agent-style-mono :where(button, input, select),
+.fresh-agent-style-mono .fresh-agent-sidebar,
+.fresh-agent-style-mono .fresh-agent-sidebar-section,
+.fresh-agent-style-mono .fresh-agent-turn-header,
+.fresh-agent-style-mono .fresh-agent-activity-strip,
+.fresh-agent-style-mono .fresh-agent-tool-block,
+.fresh-agent-style-mono .fresh-agent-diff-panel,
+.fresh-agent-style-mono .fresh-agent-composer-menu {
+  font-family: var(--fresh-agent-meta-font-family);
+}
+
+.fresh-agent-style-mono textarea {
+  font-family: var(--fresh-agent-copy-font-family);
+  line-height: 1.5;
+}
+
+.fresh-agent-style-mono .fresh-agent-transcript-copy [data-markdown-body] :where(pre, code) {
+  font-family: var(--fresh-agent-mono-font-family);
+  letter-spacing: 0;
+}
+
+.fresh-agent-style-mono .fresh-agent-layout,
+.fresh-agent-style-mono .fresh-agent-main {
+  background: var(--fresh-agent-surface);
+}
+
+.fresh-agent-style-mono .fresh-agent-transcript-scroll {
+  gap: 0;
+  padding: 0.75rem 1rem 1rem;
+}
+
+.fresh-agent-style-mono .fresh-agent-top-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem 0;
+}
+
+.fresh-agent-style-mono .fresh-agent-turn {
+  border-left: 0;
+  border-top: 1px solid var(--fresh-agent-border);
+  padding: 0.85rem 0 1rem;
+}
+
+.fresh-agent-style-mono .fresh-agent-turn[data-turn-continuation="true"] {
+  border-top: 0;
+  margin-top: -0.8rem;
+  padding-top: 0;
+}
+
+.fresh-agent-style-mono .fresh-agent-turn:first-child {
+  border-top: 0;
+  padding-top: 0.1rem;
+}
+
+.fresh-agent-style-mono .fresh-agent-turn-header {
+  color: var(--fresh-agent-soft-text);
+  font-size: 0.55rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.25;
+  margin-bottom: 0.5rem;
+  max-width: 100%;
+  text-transform: uppercase;
+}
+
+.fresh-agent-style-mono .fresh-agent-turn-header span:first-child {
+  max-width: 60%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fresh-agent-style-mono .fresh-agent-turn > .fresh-agent-transcript-copy,
+.fresh-agent-style-mono .fresh-agent-activity-strip {
+  max-width: 100%;
+}
+
+.fresh-agent-style-mono .fresh-agent-turn[data-turn-role="user"] .fresh-agent-turn-header {
+  color: var(--fresh-agent-accent);
+  margin-bottom: 0.25rem;
+}
+
+.fresh-agent-style-mono .fresh-agent-turn[data-turn-role="user"] .fresh-agent-transcript-copy {
+  background: var(--fresh-agent-subtle-surface);
+  border-left: 2px solid var(--fresh-agent-accent);
+  padding: 0.6rem 0.8rem;
+}
+
+.fresh-agent-style-mono :where(
+  .fresh-agent-banner,
+  .fresh-agent-summary-card,
+  .fresh-agent-error-card,
+  .fresh-agent-session-ended-card,
+  .fresh-agent-approval-card,
+  .fresh-agent-question-card,
+  .fresh-agent-diff-panel,
+  .fresh-agent-inline-card
+) {
+  background: var(--fresh-agent-panel-surface);
+  border: 1px solid var(--fresh-agent-border);
+  border-radius: 0;
+  color: var(--fresh-agent-text);
+  box-shadow: none;
+}
+
+.fresh-agent-style-mono :where(.fresh-agent-banner, .fresh-agent-summary-card) {
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  line-height: 1.5;
+}
+
+.fresh-agent-style-mono .fresh-agent-approval-card,
+.fresh-agent-style-mono .fresh-agent-question-card,
+.fresh-agent-style-mono .fresh-agent-diff-panel {
+  padding: 0.75rem 0.85rem;
+}
+
+.fresh-agent-style-mono :where(
+  .fresh-agent-approval-heading,
+  .fresh-agent-question-heading,
+  .fresh-agent-diff-title,
+  .fresh-agent-sidebar-title
+) {
+  color: var(--fresh-agent-accent);
+  font-family: var(--fresh-agent-meta-font-family);
+  font-size: 0.55rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.fresh-agent-style-mono .fresh-agent-approval-heading {
+  text-transform: none;
+}
+
+.fresh-agent-style-mono .fresh-agent-approval-kicker,
+.fresh-agent-style-mono .fresh-agent-status-badge {
+  border: 1px solid var(--fresh-agent-border-strong);
+  color: var(--fresh-agent-accent);
+  border-radius: 0;
+}
+
+.fresh-agent-style-mono .fresh-agent-approval-tool {
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.fresh-agent-style-mono .fresh-agent-approval-reason,
+.fresh-agent-style-mono .fresh-agent-question-text {
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.fresh-agent-style-mono :where(
+  .fresh-agent-approval-preview,
+  .fresh-agent-tool-body,
+  .fresh-agent-file-diff-body,
+  [data-diff]
+) {
+  background: var(--fresh-agent-surface);
+  border: 1px solid var(--fresh-agent-border);
+  border-radius: 0;
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-mono-font-family);
+}
+
+.fresh-agent-style-mono :where(
+  .fresh-agent-approval-button,
+  .fresh-agent-question-option,
+  .fresh-agent-question-submit,
+  .fresh-agent-error-action,
+  .fresh-agent-session-ended-action,
+  .fresh-agent-composer-action
+) {
+  background: transparent;
+  border: 1px solid var(--fresh-agent-border);
+  border-radius: 0;
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-meta-font-family);
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.fresh-agent-style-mono :where(
+  .fresh-agent-approval-button,
+  .fresh-agent-question-option,
+  .fresh-agent-question-submit,
+  .fresh-agent-error-action,
+  .fresh-agent-session-ended-action,
+  .fresh-agent-composer-action
+):hover:not(:disabled) {
+  background: var(--fresh-agent-accent-soft);
+  color: var(--fresh-agent-text);
+  border-color: var(--fresh-agent-accent);
+}
+
+.fresh-agent-style-mono :where(.fresh-agent-approval-button-primary, .fresh-agent-composer-action[type="submit"]) {
+  background: var(--fresh-agent-accent);
+  border-color: var(--fresh-agent-accent);
+  color: var(--fresh-agent-surface);
+  text-shadow: none;
+}
+
+.fresh-agent-style-mono .fresh-agent-approval-button-deny:hover:not(:disabled) {
+  background: var(--fresh-agent-danger-soft);
+  color: var(--fresh-agent-danger);
+  border-color: var(--fresh-agent-danger);
+}
+
+.fresh-agent-style-mono .fresh-agent-question-heading svg {
+  color: var(--fresh-agent-accent);
+}
+
+.fresh-agent-style-mono .fresh-agent-question-option {
+  background: var(--fresh-agent-surface);
+  min-width: 7.4rem;
+}
+
+.fresh-agent-style-mono .fresh-agent-question-option span:first-child {
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.fresh-agent-style-mono .fresh-agent-question-option span:last-child {
+  color: var(--fresh-agent-soft-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  font-size: 0.58rem;
+  line-height: 1.35;
+}
+
+.fresh-agent-style-mono .fresh-agent-question-input,
+.fresh-agent-style-mono .fresh-agent-composer-filter-input {
+  background: var(--fresh-agent-surface);
+  border: 1px solid var(--fresh-agent-border);
+  border-radius: 0;
+  color: var(--fresh-agent-text);
+  caret-color: var(--fresh-agent-accent);
+}
+
+.fresh-agent-style-mono .fresh-agent-activity-strip {
+  margin: 0.4rem 0 0.55rem;
+}
+
+.fresh-agent-style-mono .fresh-agent-activity-summary,
+.fresh-agent-style-mono .fresh-agent-thinking-row,
+.fresh-agent-style-mono .fresh-agent-thinking-details,
+.fresh-agent-style-mono .fresh-agent-tool-block,
+.fresh-agent-style-mono .fresh-agent-tool-result,
+.fresh-agent-style-mono .fresh-agent-file-diff {
+  border-left-color: var(--fresh-agent-border);
+}
+
+.fresh-agent-style-mono .fresh-agent-activity-summary {
+  color: var(--fresh-agent-soft-text);
+  padding: 0.1rem 0 0.1rem 0.7rem;
+}
+
+.fresh-agent-style-mono .fresh-agent-activity-summary [role="status"] {
+  color: var(--fresh-agent-soft-text);
+  font-family: var(--fresh-agent-meta-font-family);
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.fresh-agent-style-mono .fresh-agent-activity-summary [data-slot="name"] {
+  background: transparent;
+  color: var(--fresh-agent-accent);
+  padding: 0;
+}
+
+.fresh-agent-style-mono .fresh-agent-tool-block {
+  color: var(--fresh-agent-soft-text);
+  font-size: 0.58rem;
+  margin: 0.35rem 0 0.45rem;
+}
+
+.fresh-agent-style-mono :where(.fresh-agent-tool-trigger, .fresh-agent-thinking-trigger, .fresh-agent-file-diff-trigger) {
+  border-radius: 0;
+  color: var(--fresh-agent-soft-text);
+  padding-bottom: 0.15rem;
+  padding-top: 0.15rem;
+}
+
+.fresh-agent-style-mono :where(.fresh-agent-tool-trigger, .fresh-agent-thinking-trigger, .fresh-agent-file-diff-trigger):hover {
+  background: var(--fresh-agent-accent-soft);
+  color: var(--fresh-agent-text);
+}
+
+.fresh-agent-style-mono .fresh-agent-tool-name,
+.fresh-agent-style-mono .fresh-agent-file-diff-label {
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-meta-font-family);
+}
+
+.fresh-agent-style-mono .fresh-agent-tool-preview,
+.fresh-agent-style-mono .fresh-agent-tool-result-summary,
+.fresh-agent-style-mono .fresh-agent-file-diff-status {
+  color: var(--fresh-agent-soft-text);
+  font-family: var(--fresh-agent-meta-font-family);
+}
+
+.fresh-agent-style-mono .fresh-agent-tool-status svg[aria-label="complete"] {
+  color: var(--fresh-agent-success);
+}
+
+.fresh-agent-style-mono .fresh-agent-tool-pre {
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-mono-font-family);
+  line-height: 1.55;
+}
+
+.fresh-agent-style-mono .fresh-agent-thinking-body {
+  background: var(--fresh-agent-panel-surface);
+  border: 1px solid var(--fresh-agent-border);
+  border-radius: 0;
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-copy-font-family);
+}
+
+.fresh-agent-style-mono .fresh-agent-diff-title {
+  margin-bottom: 0.55rem;
+}
+
+.fresh-agent-style-mono .fresh-agent-file-diff-body {
+  color: var(--fresh-agent-muted-text);
+  line-height: 1.65;
+}
+
+.fresh-agent-style-mono [data-diff] {
+  background: var(--fresh-agent-surface);
+}
+
+.fresh-agent-style-mono [data-diff] .bg-red-500\/10,
+.fresh-agent-style-mono .fresh-agent-file-diff-body .bg-destructive\/10 {
+  background: var(--fresh-agent-danger-soft);
+  color: var(--fresh-agent-danger);
+}
+
+.fresh-agent-style-mono [data-diff] .bg-green-500\/10,
+.fresh-agent-style-mono .fresh-agent-file-diff-body .bg-success\/10 {
+  background: var(--fresh-agent-success-soft);
+  color: var(--fresh-agent-success);
+}
+
+.fresh-agent-style-mono [data-diff] .text-muted-foreground,
+.fresh-agent-style-mono .fresh-agent-file-diff-body .text-muted-foreground {
+  color: var(--fresh-agent-soft-text);
+}
+
+.fresh-agent-style-mono .fresh-agent-sidebar {
+  background: var(--fresh-agent-panel-surface);
+  border-color: var(--fresh-agent-border);
+  color: var(--fresh-agent-muted-text);
+}
+
+.fresh-agent-style-mono .fresh-agent-sidebar-section {
+  background: transparent;
+  border: 1px solid var(--fresh-agent-border);
+  border-radius: 0;
+}
+
+.fresh-agent-style-mono .fresh-agent-sidebar-list {
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.fresh-agent-style-mono .fresh-agent-composer {
+  background: var(--fresh-agent-surface);
+  border-top: 1px solid var(--fresh-agent-border);
+  padding: 0.75rem 1rem max(env(safe-area-inset-bottom), 0.75rem);
+}
+
+.fresh-agent-style-mono .fresh-agent-composer-input {
+  background: var(--fresh-agent-panel-surface);
+  border: 1px solid var(--fresh-agent-border);
+  border-radius: 0;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fresh-agent-border) 45%, transparent);
+  color: var(--fresh-agent-text);
+  font-family: var(--fresh-agent-copy-font-family);
+  line-height: 1.5;
+  caret-color: var(--fresh-agent-accent);
+}
+
+.fresh-agent-style-mono .fresh-agent-composer-input::placeholder {
+  color: var(--fresh-agent-soft-text);
+  opacity: 0.7;
+}
+
+.fresh-agent-style-mono .fresh-agent-composer-action {
+  background: var(--fresh-agent-panel-surface);
+}
+
+.fresh-agent-style-mono .fresh-agent-composer-menu,
+.fresh-agent-style-mono .fresh-agent-queued-message,
+.fresh-agent-style-mono .fresh-agent-attachment {
+  background: var(--fresh-agent-panel-surface);
+  border: 1px solid var(--fresh-agent-border);
+  border-radius: 0;
+  color: var(--fresh-agent-muted-text);
+}
+
+.fresh-agent-style-mono .fresh-agent-composer-menu-item {
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-meta-font-family);
+}
+
+.fresh-agent-style-mono .fresh-agent-composer-menu-item:hover,
+.fresh-agent-style-mono .fresh-agent-composer-menu-item.bg-accent {
+  background: var(--fresh-agent-accent-soft);
+  color: var(--fresh-agent-text);
+}
+
+.fresh-agent-style-mono .fresh-agent-composer-menu-help {
+  border-color: var(--fresh-agent-border);
+  color: var(--fresh-agent-soft-text);
+}
+
+.fresh-agent-style-mono .fresh-agent-scroll-bottom {
+  background: var(--fresh-agent-panel-surface);
+  border: 1px solid var(--fresh-agent-border);
+  border-radius: 0;
+  bottom: 0.8rem;
+  box-shadow: none;
+  color: var(--fresh-agent-muted-text);
+  font-family: var(--fresh-agent-meta-font-family);
+  left: auto;
+  right: 1rem;
+  transform: none;
+}
+
+.fresh-agent-style-mono .fresh-agent-thinking-bar > div {
+  background: var(--fresh-agent-subtle-surface);
+}
+
 .fresh-agent-composer {
   container-type: inline-size;
   padding-right: max(env(safe-area-inset-right), 4.25rem);

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -58,6 +58,41 @@ async function openFreshAgentSettings(page: any, providerName: string) {
   return dialog
 }
 
+async function expectFreshAgentSubmitButtonContrasted(
+  root: any,
+  expectedBackgroundVariable = '--fresh-agent-text',
+) {
+  const styles = await root.locator('.fresh-agent-composer-action[type="submit"]').evaluate((node: HTMLElement, backgroundVariable: string) => {
+    const pane = node.closest('[data-context="fresh-agent"]') as HTMLElement | null
+    if (!pane) {
+      throw new Error('Fresh Agent pane root not found')
+    }
+
+    const resolveColor = (value: string) => {
+      const probe = document.createElement('span')
+      probe.style.color = value.trim()
+      document.body.appendChild(probe)
+      const color = getComputedStyle(probe).color
+      probe.remove()
+      return color
+    }
+
+    const buttonStyle = getComputedStyle(node)
+    const paneStyle = getComputedStyle(pane)
+    return {
+      backgroundColor: buttonStyle.backgroundColor,
+      color: buttonStyle.color,
+      expectedBackgroundColor: resolveColor(paneStyle.getPropertyValue(backgroundVariable)),
+      expectedColor: resolveColor(paneStyle.getPropertyValue('--fresh-agent-surface')),
+      panelBackgroundColor: resolveColor(paneStyle.getPropertyValue('--fresh-agent-panel-surface')),
+    }
+  }, expectedBackgroundVariable)
+
+  expect(styles.backgroundColor).toBe(styles.expectedBackgroundColor)
+  expect(styles.color).toBe(styles.expectedColor)
+  expect(styles.backgroundColor).not.toBe(styles.panelBackgroundColor)
+}
+
 test.describe('Fresh Agent', () => {
   test('pane picker hides fresh clients by default even when their CLIs are enabled', async ({ freshellPage, page, terminal }) => {
     await terminal.waitForTerminal()
@@ -307,6 +342,7 @@ test.describe('Fresh Agent', () => {
     const composerButtonFont = await freshcodexRoot.locator('.fresh-agent-composer-action').first()
       .evaluate((node) => getComputedStyle(node).fontFamily)
     expect(composerButtonFont.toLowerCase()).toContain('ibm plex mono')
+    await expectFreshAgentSubmitButtonContrasted(freshcodexRoot)
     const chromeFont = await page.locator('[data-context="tab-add"]').evaluate((node) => getComputedStyle(node).fontFamily)
     expect(chromeFont.toLowerCase()).not.toContain('georgia')
     expect(chromeFont.toLowerCase()).not.toContain('literata')
@@ -405,6 +441,10 @@ test.describe('Fresh Agent', () => {
 
     dialog = await openFreshAgentSettings(page, 'Freshcodex')
     await expect(dialog.getByRole('combobox', { name: /^Style$/i })).toHaveValue('serif')
+    await dialog.getByRole('combobox', { name: /^Style$/i }).selectOption('mono')
+    const monoRoot = page.locator('[data-context="fresh-agent"][data-style="mono"]').last()
+    await expect(monoRoot).toBeVisible({ timeout: 10_000 })
+    await expectFreshAgentSubmitButtonContrasted(monoRoot, '--fresh-agent-accent')
   })
 
   test('freshclaude banners render through the fresh-agent pane surface and answer over WS', async ({ freshellPage, page, harness, terminal }) => {

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -374,6 +374,31 @@ describe('FreshAgentView', () => {
     expect(root).toHaveClass('fresh-agent-style-serif')
   })
 
+  it('applies the mono terminal style to the view root', async () => {
+    const store = createStore()
+    render(
+      <Provider store={store}>
+        <FreshAgentView
+          tabId="tab-1"
+          paneId="pane-1"
+          paneContent={{
+            kind: 'fresh-agent',
+            sessionType: 'freshcodex',
+            provider: 'codex',
+            createRequestId: 'req-render-mono',
+            sessionId: 'thread-render-mono',
+            status: 'idle',
+            style: 'mono',
+          }}
+        />
+      </Provider>,
+    )
+
+    const root = await waitFor(() => document.querySelector('[data-context="fresh-agent"]') as HTMLElement)
+    expect(root).toHaveAttribute('data-style', 'mono')
+    expect(root).toHaveClass('fresh-agent-style-mono')
+  })
+
   it('exposes a durable sessionRef as the fresh-agent context session id', async () => {
     const store = createStore()
     render(
@@ -2740,6 +2765,45 @@ describe('FreshAgentView', () => {
       freshAgent: {
         providers: {
           freshcodex: { style: 'serif' },
+        },
+      },
+    })
+  })
+
+  it('lets a Freshcodex pane choose the mono terminal style', async () => {
+    const store = createStore()
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-mono-style',
+        sessionId: 'thread-mono-style',
+        status: 'idle',
+        style: 'sans',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentSettingsButton tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Agent settings' }))
+    const styleSelect = screen.getByRole('combobox', { name: 'Style' })
+    expect(Array.from(styleSelect.querySelectorAll('option')).map((option) => option.textContent)).toEqual(['Sans', 'Serif', 'Mono'])
+
+    fireEvent.change(styleSelect, { target: { value: 'mono' } })
+
+    const layout = store.getState().panes.layouts['tab-1']
+    expect(layout?.type === 'leaf' && layout.content.kind === 'fresh-agent' ? layout.content.style : null).toBe('mono')
+    expect(saveServerSettingsPatchSpy).toHaveBeenCalledWith({
+      freshAgent: {
+        providers: {
+          freshcodex: { style: 'mono' },
         },
       },
     })

--- a/test/unit/shared/settings.test.ts
+++ b/test/unit/shared/settings.test.ts
@@ -208,13 +208,35 @@ describe('shared settings contract', () => {
     expect(merged.freshAgent.providers.freshclaude?.style).toBe('sans')
   })
 
+  it('accepts mono as a fresh-agent provider style default', () => {
+    const parsed = buildServerSettingsPatchSchema().parse({
+      freshAgent: {
+        providers: {
+          freshcodex: { style: 'mono' },
+        },
+      },
+    })
+
+    expect(parsed.freshAgent?.providers?.freshcodex).toEqual({ style: 'mono' })
+
+    const merged = mergeServerSettings(createDefaultServerSettings({ loggingDebug: false }), {
+      freshAgent: {
+        providers: {
+          freshcodex: { style: 'mono' },
+        },
+      },
+    })
+
+    expect(merged.freshAgent.providers.freshcodex?.style).toBe('mono')
+  })
+
   it('rejects invalid fresh-agent provider style defaults', () => {
     const schema = buildServerSettingsPatchSchema()
 
     expect(schema.safeParse({
       freshAgent: {
         providers: {
-          freshcodex: { style: 'mono' },
+          freshcodex: { style: 'script' },
         },
       },
     }).success).toBe(false)
@@ -222,7 +244,7 @@ describe('shared settings contract', () => {
     const merged = mergeServerSettings(createDefaultServerSettings({ loggingDebug: false }), {
       freshAgent: {
         providers: {
-          freshcodex: { style: 'mono' as any },
+          freshcodex: { style: 'script' as any },
         },
       },
     })


### PR DESCRIPTION
## Summary

- Adds the `mono` Fresh Agent style to settings validation, the settings menu, docs, and unit coverage.
- Reworks the mono style to match a Claude Code-like light/dark responsive interface instead of a VT100/CRT treatment.
- Removes the mono scanline and watermark treatment, and fixes styled send-button contrast for mono and serif modes.
- Adds browser e2e coverage for Fresh Agent style persistence and styled send-button contrast.

## Validation

- `npm run test:vitest -- test/unit/shared/settings.test.ts test/unit/client/components/fresh-agent/FreshAgentView.test.tsx --run`
- `PORT=3346 npm run build`
- `npm run test:e2e:chromium -- test/e2e-browser/specs/fresh-agent.spec.ts -g "style setting persists per Fresh Agent pane type"`

## Fresh Eyes

- Review cycle 1 passed the mono-style change and surfaced the serif send-button contrast regression.
- Review cycle 2 failed on missing e2e coverage for styled send-button contrast.
- Review cycle 3 passed after the contrast e2e coverage was added.
