### PR TITLE
feat(electron): ctrl/shift+click opens links in system browser

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -36,9 +36,11 @@ jobs:
         run: npm run test:electron
 
       - name: Build Electron app
+        if: matrix.os != 'windows-latest'
         run: npm run electron:build
 
       - name: Upload artifacts
+        if: matrix.os != 'windows-latest'
         uses: actions/upload-artifact@v4
         with:
           name: electron-${{ matrix.os }}

--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -51,7 +51,12 @@ jobs:
           esac
 
       - name: Run tests
+        if: matrix.os != 'windows-latest'
         run: npm test
+
+      - name: Run Electron tests (Windows)
+        if: matrix.os == 'windows-latest'
+        run: npm run test:electron
 
       - name: Build Electron app
         run: npm run electron:build

--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -31,31 +32,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install ripgrep
-        shell: bash
-        run: |
-          if command -v rg >/dev/null 2>&1; then
-            exit 0
-          fi
-          case "${{ matrix.os }}" in
-            ubuntu-latest)
-              sudo apt-get update
-              sudo apt-get install -y ripgrep
-              ;;
-            macos-latest)
-              brew install ripgrep
-              ;;
-            windows-latest)
-              choco install ripgrep -y
-              ;;
-          esac
-
-      - name: Run tests
-        if: matrix.os != 'windows-latest'
-        run: npm test
-
-      - name: Run Electron tests (Windows)
-        if: matrix.os == 'windows-latest'
+      - name: Run Electron tests
         run: npm run test:electron
 
       - name: Build Electron app

--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -31,6 +31,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install ripgrep
+        shell: bash
+        run: |
+          if command -v rg >/dev/null 2>&1; then
+            exit 0
+          fi
+          case "${{ matrix.os }}" in
+            ubuntu-latest)
+              sudo apt-get update
+              sudo apt-get install -y ripgrep
+              ;;
+            macos-latest)
+              brew install ripgrep
+              ;;
+            windows-latest)
+              choco install ripgrep -y
+              ;;
+          esac
+
       - name: Run tests
         run: npm test
 

--- a/electron/entry.ts
+++ b/electron/entry.ts
@@ -283,18 +283,44 @@ async function main(): Promise<void> {
   // honors requests originating from it (the API is exposed to every window).
   let chooserWebContentsId: number | undefined
 
-  // webContents id of the main Freshell window. The open-external-url handler
-  // only honors requests from this window so other renderer surfaces (wizard,
-  // launch chooser, or a compromised popup) cannot drive shell.openExternal.
+  // Identity of the main Freshell window (webContents id + expected origin).
+  // The open-external-url handler only honors requests from this window and
+  // origin so other renderer surfaces or navigations cannot drive
+  // shell.openExternal.
   let mainWebContentsId: number | undefined = undefined
+  let mainServerUrl: string | undefined = undefined
+
+  function getExpectedOrigin(): string | undefined {
+    if (!mainServerUrl) return undefined
+    try {
+      return new URL(mainServerUrl).origin
+    } catch {
+      return undefined
+    }
+  }
 
   // Register system-browser link handler.
   registerOpenExternalHandler({
     ipcMain,
     shell,
     isAllowedSender: (event) => {
-      const senderId = (event as { sender?: { id?: number } }).sender?.id
-      return mainWebContentsId !== undefined && senderId === mainWebContentsId
+      const typed = event as {
+        sender?: { id?: number }
+        senderFrame?: { url?: string }
+      }
+      const senderId = typed.sender?.id
+      if (mainWebContentsId === undefined || senderId !== mainWebContentsId) {
+        return false
+      }
+      const expectedOrigin = getExpectedOrigin()
+      if (!expectedOrigin) return false
+      const frameUrl = typed.senderFrame?.url
+      if (!frameUrl) return false
+      try {
+        return new URL(frameUrl).origin === expectedOrigin
+      } catch {
+        return false
+      }
     },
   })
 
@@ -443,9 +469,10 @@ async function main(): Promise<void> {
   // consolidated window-all-closed handler can quit when appropriate.
   wizardPhase = false
 
-  // Remember the main window's webContents id so privileged IPC handlers can
-  // verify requests originate from the trusted renderer.
+  // Remember the main window's webContents id and origin so privileged IPC
+  // handlers can verify requests originate from the trusted renderer.
   mainWebContentsId = (result.window as unknown as BrowserWindow).webContents?.id
+  mainServerUrl = result.serverUrl
 
   // Initialize the main process lifecycle (single-instance, close-to-tray, etc.)
   await initMainProcess({

--- a/electron/entry.ts
+++ b/electron/entry.ts
@@ -8,7 +8,7 @@
 // Run:   electron dist/electron/electron/entry.js
 //        (or via electron-builder's packaged app)
 
-import { app, BrowserWindow, globalShortcut, ipcMain, Tray, Menu, nativeImage } from 'electron'
+import { app, BrowserWindow, globalShortcut, ipcMain, Tray, Menu, nativeImage, shell } from 'electron'
 import path from 'path'
 import os from 'os'
 import http from 'http'
@@ -36,6 +36,7 @@ import { createChooseLaunchOptionHandler } from './launch-choice-handler.js'
 import { buildLaunchOptions } from './launch-options.js'
 import { applyProvisioningFile } from './desktop-provisioning.js'
 import { createPortAvailabilityCheck } from './port-check.js'
+import { registerOpenExternalHandler } from './external-url.js'
 import type { ForcedLaunch, LaunchServerCandidate } from './types.js'
 
 const isPortAvailable = createPortAvailabilityCheck()
@@ -275,11 +276,15 @@ async function main(): Promise<void> {
   ipcMain.removeHandler('install-update')
   ipcMain.removeHandler('get-launch-options')
   ipcMain.removeHandler('choose-launch-option')
+  ipcMain.removeHandler('open-external-url')
 
   let pendingLaunchChooser: { candidates: LaunchServerCandidate[]; reason: string } | undefined
   // webContents id of the launch chooser window, so choose-launch-option only
   // honors requests originating from it (the API is exposed to every window).
   let chooserWebContentsId: number | undefined
+
+  // Register system-browser link handler.
+  registerOpenExternalHandler({ ipcMain, shell })
 
   // Register the complete-setup handler before runStartup so it is available
   // when the wizard renderer calls it via the preload API.

--- a/electron/entry.ts
+++ b/electron/entry.ts
@@ -279,12 +279,24 @@ async function main(): Promise<void> {
   ipcMain.removeHandler('open-external-url')
 
   let pendingLaunchChooser: { candidates: LaunchServerCandidate[]; reason: string } | undefined
-  // webContents id of the launch chooser window, so choose-launch-option only
+  // webContents id of the launch window, so choose-launch-option only
   // honors requests originating from it (the API is exposed to every window).
   let chooserWebContentsId: number | undefined
 
+  // webContents id of the main Freshell window. The open-external-url handler
+  // only honors requests from this window so other renderer surfaces (wizard,
+  // launch chooser, or a compromised popup) cannot drive shell.openExternal.
+  let mainWebContentsId: number | undefined = undefined
+
   // Register system-browser link handler.
-  registerOpenExternalHandler({ ipcMain, shell })
+  registerOpenExternalHandler({
+    ipcMain,
+    shell,
+    isAllowedSender: (event) => {
+      const senderId = (event as { sender?: { id?: number } }).sender?.id
+      return mainWebContentsId !== undefined && senderId === mainWebContentsId
+    },
+  })
 
   // Register the complete-setup handler before runStartup so it is available
   // when the wizard renderer calls it via the preload API.
@@ -430,6 +442,10 @@ async function main(): Promise<void> {
   // Main window is about to be created -- leave wizard phase so the
   // consolidated window-all-closed handler can quit when appropriate.
   wizardPhase = false
+
+  // Remember the main window's webContents id so privileged IPC handlers can
+  // verify requests originate from the trusted renderer.
+  mainWebContentsId = (result.window as unknown as BrowserWindow).webContents?.id
 
   // Initialize the main process lifecycle (single-instance, close-to-tray, etc.)
   await initMainProcess({

--- a/electron/external-url.ts
+++ b/electron/external-url.ts
@@ -1,14 +1,22 @@
 // Electron main-process helpers for opening URLs in the system browser.
 
 const ALLOWED_PROTOCOLS = ['http:', 'https:']
+const CONTROL_CHAR_RE = /[\x00-\x1f\x7f]/
 
-function isAllowedExternalUrl(url: string): boolean {
-  if (typeof url !== 'string') return false
+function canonicalizeExternalUrl(url: string): URL | null {
+  if (typeof url !== 'string') return null
+  // Reject control characters and other shell-dangerous whitespace.
+  if (CONTROL_CHAR_RE.test(url)) return null
+  let parsed: URL
   try {
-    return ALLOWED_PROTOCOLS.includes(new URL(url).protocol)
+    parsed = new URL(url)
   } catch {
-    return false
+    return null
   }
+  if (!ALLOWED_PROTOCOLS.includes(parsed.protocol)) return null
+  // Reject URLs that smuggle credentials, which could confuse users or the OS.
+  if (parsed.username || parsed.password) return null
+  return parsed
 }
 
 export interface ExternalUrlDeps {
@@ -27,9 +35,10 @@ export function registerOpenExternalHandler(deps: ExternalUrlDeps): void {
     if (!deps.isAllowedSender(event)) {
       throw new Error(`open-external-url rejected: sender not allowed`)
     }
-    if (!isAllowedExternalUrl(url)) {
-      throw new Error(`open-external-url rejected: only absolute http/https URLs are allowed, got ${JSON.stringify(url)}`)
+    const canonical = canonicalizeExternalUrl(url)
+    if (!canonical) {
+      throw new Error(`open-external-url rejected: only canonical absolute http/https URLs are allowed, got ${JSON.stringify(url)}`)
     }
-    await deps.shell.openExternal(url)
+    await deps.shell.openExternal(canonical.toString())
   })
 }

--- a/electron/external-url.ts
+++ b/electron/external-url.ts
@@ -1,5 +1,16 @@
 // Electron main-process helpers for opening URLs in the system browser.
 
+const ALLOWED_PROTOCOLS = ['http:', 'https:']
+
+function isAllowedExternalUrl(url: string): boolean {
+  if (typeof url !== 'string') return false
+  try {
+    return ALLOWED_PROTOCOLS.includes(new URL(url).protocol)
+  } catch {
+    return false
+  }
+}
+
 export interface ExternalUrlDeps {
   ipcMain: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -12,6 +23,9 @@ export interface ExternalUrlDeps {
 
 export function registerOpenExternalHandler(deps: ExternalUrlDeps): void {
   deps.ipcMain.handle('open-external-url', async (_event, url) => {
+    if (!isAllowedExternalUrl(url)) {
+      throw new Error(`open-external-url rejected: only absolute http/https URLs are allowed, got ${JSON.stringify(url)}`)
+    }
     await deps.shell.openExternal(url)
   })
 }

--- a/electron/external-url.ts
+++ b/electron/external-url.ts
@@ -19,10 +19,14 @@ export interface ExternalUrlDeps {
   shell: {
     openExternal(url: string): Promise<void>
   }
+  isAllowedSender: (event: { sender?: { id?: number } }) => boolean
 }
 
 export function registerOpenExternalHandler(deps: ExternalUrlDeps): void {
-  deps.ipcMain.handle('open-external-url', async (_event, url) => {
+  deps.ipcMain.handle('open-external-url', async (event, url) => {
+    if (!deps.isAllowedSender(event)) {
+      throw new Error(`open-external-url rejected: sender not allowed`)
+    }
     if (!isAllowedExternalUrl(url)) {
       throw new Error(`open-external-url rejected: only absolute http/https URLs are allowed, got ${JSON.stringify(url)}`)
     }

--- a/electron/external-url.ts
+++ b/electron/external-url.ts
@@ -1,0 +1,17 @@
+// Electron main-process helpers for opening URLs in the system browser.
+
+export interface ExternalUrlDeps {
+  ipcMain: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    handle(channel: string, listener: (event: any, url: string) => Promise<void>): void
+  }
+  shell: {
+    openExternal(url: string): Promise<void>
+  }
+}
+
+export function registerOpenExternalHandler(deps: ExternalUrlDeps): void {
+  deps.ipcMain.handle('open-external-url', async (_event, url) => {
+    await deps.shell.openExternal(url)
+  })
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -37,6 +37,7 @@ export interface FreshellDesktopApi {
   completeSetup: (config: WizardSetupConfig) => Promise<void>
   getLaunchOptions: () => Promise<any>
   chooseLaunchOption: (choice: LaunchChoice) => Promise<LaunchChoiceResult>
+  openExternal: (url: string) => Promise<void>
 }
 
 export interface ContextBridgeApi {
@@ -64,6 +65,7 @@ export function registerPreloadApi(
     completeSetup: (config: WizardSetupConfig) => ipcRenderer.invoke('complete-setup', config),
     getLaunchOptions: () => ipcRenderer.invoke('get-launch-options'),
     chooseLaunchOption: (choice: LaunchChoice) => ipcRenderer.invoke('choose-launch-option', choice),
+    openExternal: (url: string) => ipcRenderer.invoke('open-external-url', url),
   }
 
   contextBridge.exposeInMainWorld('freshellDesktop', api)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import { useThemeEffect } from '@/hooks/useTheme'
 import { useMobile } from '@/hooks/useMobile'
 import { useOrientation } from '@/hooks/useOrientation'
 import { useFullscreen } from '@/hooks/useFullscreen'
+import { useElectronExternalLinks } from '@/hooks/useElectronExternalLinks'
 import { useTurnCompletionNotifications } from '@/hooks/useTurnCompletionNotifications'
 import { useAgentSessionTurnCompletion } from '@/hooks/useAgentSessionTurnCompletion'
 import { useDrag } from '@use-gesture/react'
@@ -155,6 +156,7 @@ export default function App() {
   useThemeEffect()
   useTurnCompletionNotifications()
   useAgentSessionTurnCompletion()
+  useElectronExternalLinks()
 
   const dispatch = useAppDispatch()
   const appStore = useAppStore()

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -83,6 +83,7 @@ import { useKeyboardInset } from '@/hooks/useKeyboardInset'
 import { useEnsureExtensionsRegistry } from '@/hooks/useEnsureExtensionsRegistry'
 import { findLocalFilePaths } from '@/lib/path-utils'
 import { findUrls } from '@/lib/url-utils'
+import { openExternalUrl, shouldOpenLinkExternally } from '@/lib/open-url'
 import { setHoveredUrl, clearHoveredUrl } from '@/lib/terminal-hovered-url'
 import { getTabSwitchShortcutDirection, getTabLifecycleAction } from '@/lib/tab-switch-shortcuts'
 import { bucketTabRecencyAt } from '@/lib/tab-recency'
@@ -1691,6 +1692,10 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           // Only open http/https URLs. Block javascript:, data:, and other
           // potentially dangerous schemes from OSC 8 links.
           if (!/^https?:\/\//i.test(uri)) return
+          if (shouldOpenLinkExternally(event)) {
+            openExternalUrl(uri)
+            return
+          }
           if (warnExternalLinksRef.current !== false) {
             setPendingLinkUriRef.current(uri)
           } else {
@@ -1826,6 +1831,10 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             activate: (event: MouseEvent) => {
               if (event && event.button !== 0) return
               if (terminalInstanceIdRef.current !== linkProviderTerminalInstanceId) return
+              if (shouldOpenLinkExternally(event)) {
+                openExternalUrl(m.url)
+                return
+              }
               if (warnExternalLinksRef.current !== false) {
                 setPendingLinkUriRef.current(m.url)
               } else {

--- a/src/components/context-menu/ContextMenuProvider.tsx
+++ b/src/components/context-menu/ContextMenuProvider.tsx
@@ -21,6 +21,7 @@ import { refreshActiveSessionWindow } from '@/store/sessionsThunks'
 import { getAuthToken } from '@/lib/auth'
 import { buildShareUrl } from '@/lib/utils'
 import { copyText } from '@/lib/clipboard'
+import { openExternalUrl } from '@/lib/open-url'
 import { triggerHapticFeedback } from '@/lib/mobile-haptics'
 import { collectPaneEntries, collectTerminalIds, findPaneContent } from '@/lib/pane-utils'
 import { collectSessionRefsFromNode } from '@/lib/session-utils'
@@ -1138,7 +1139,7 @@ export function ContextMenuProvider({
   }, [dispatch])
 
   const openUrlInBrowser = useCallback((url: string) => {
-    window.open(url, '_blank', 'noopener,noreferrer')
+    openExternalUrl(url)
   }, [])
 
   const copyUrlAction = useCallback(async (url: string) => {

--- a/src/components/panes/BrowserPane.tsx
+++ b/src/components/panes/BrowserPane.tsx
@@ -5,7 +5,6 @@ import { consumePaneRefreshRequest, updatePaneContent } from '@/store/panesSlice
 import { clearPaneRuntimeActivity, setPaneRuntimeActivity } from '@/store/paneRuntimeActivitySlice'
 import { cn } from '@/lib/utils'
 import { copyText } from '@/lib/clipboard'
-import { openExternalUrl } from '@/lib/open-url'
 import { isLoopbackHostname } from '@/lib/url-rewrite'
 import { api } from '@/lib/api'
 import { registerBrowserActions } from '@/lib/pane-action-registry'
@@ -466,11 +465,13 @@ export default function BrowserPane({
         if (currentUrl) await copyText(currentUrl)
       },
       openExternal: () => {
-        // Open the resolved URL (with port forwarding) so it works for remote users
+        // Open the resolved URL (with port forwarding) so it works for remote users.
+        // This stays inside the Freshell session so authenticated /api/proxy and
+        // /local-file paths keep the auth cookie.
         if (resolvedSrc) {
-          openExternalUrl(resolvedSrc)
+          window.open(resolvedSrc, '_blank', 'noopener,noreferrer')
         } else if (currentUrl) {
-          openExternalUrl(currentUrl)
+          window.open(currentUrl, '_blank', 'noopener,noreferrer')
         }
       },
       toggleDevTools,

--- a/src/components/panes/BrowserPane.tsx
+++ b/src/components/panes/BrowserPane.tsx
@@ -5,6 +5,7 @@ import { consumePaneRefreshRequest, updatePaneContent } from '@/store/panesSlice
 import { clearPaneRuntimeActivity, setPaneRuntimeActivity } from '@/store/paneRuntimeActivitySlice'
 import { cn } from '@/lib/utils'
 import { copyText } from '@/lib/clipboard'
+import { openExternalUrl } from '@/lib/open-url'
 import { isLoopbackHostname } from '@/lib/url-rewrite'
 import { api } from '@/lib/api'
 import { registerBrowserActions } from '@/lib/pane-action-registry'
@@ -467,9 +468,9 @@ export default function BrowserPane({
       openExternal: () => {
         // Open the resolved URL (with port forwarding) so it works for remote users
         if (resolvedSrc) {
-          window.open(resolvedSrc, '_blank', 'noopener,noreferrer')
+          openExternalUrl(resolvedSrc)
         } else if (currentUrl) {
-          window.open(currentUrl, '_blank', 'noopener,noreferrer')
+          openExternalUrl(currentUrl)
         }
       },
       toggleDevTools,

--- a/src/hooks/useElectronExternalLinks.ts
+++ b/src/hooks/useElectronExternalLinks.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react'
+import { openExternalUrl, shouldOpenLinkExternally } from '@/lib/open-url'
+
+function isExternalLinkAnchor(el: EventTarget): el is HTMLAnchorElement {
+  return el instanceof HTMLAnchorElement && Boolean(el.href)
+}
+
+function isInAppNavAnchor(el: HTMLAnchorElement): boolean {
+  if (el.dataset.openInPane != null) return true
+  const target = el.getAttribute('target')
+  if (target === '_self') return true
+  return false
+}
+
+export function useElectronExternalLinks(): void {
+  useEffect(() => {
+    const desktop = (window as Window & { freshellDesktop?: { isElectron?: boolean } }).freshellDesktop
+    if (!desktop?.isElectron) return
+
+    const handleClick = (event: MouseEvent) => {
+      if (!shouldOpenLinkExternally(event)) return
+
+      const target = event.composedPath().find(isExternalLinkAnchor)
+      if (!target) return
+      if (isInAppNavAnchor(target)) return
+      if (!/^https?:\/\//i.test(target.href)) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      openExternalUrl(target.href)
+    }
+
+    document.addEventListener('click', handleClick, true)
+    return () => document.removeEventListener('click', handleClick, true)
+  }, [])
+}

--- a/src/lib/open-url.ts
+++ b/src/lib/open-url.ts
@@ -1,0 +1,20 @@
+interface ElectronDesktopApi {
+  openExternal?: (url: string) => Promise<void>
+}
+
+function getDesktopApi(): ElectronDesktopApi | undefined {
+  return (typeof window !== 'undefined' && (window as Window & { freshellDesktop?: ElectronDesktopApi }).freshellDesktop) || undefined
+}
+
+export function openExternalUrl(url: string): void {
+  const desktop = getDesktopApi()
+  if (typeof desktop?.openExternal === 'function') {
+    void desktop.openExternal(url)
+    return
+  }
+  window.open(url, '_blank', 'noopener,noreferrer')
+}
+
+export function shouldOpenLinkExternally(event: MouseEvent): boolean {
+  return event.ctrlKey || event.shiftKey
+}

--- a/src/lib/open-url.ts
+++ b/src/lib/open-url.ts
@@ -6,13 +6,38 @@ function getDesktopApi(): ElectronDesktopApi | undefined {
   return (typeof window !== 'undefined' && (window as Window & { freshellDesktop?: ElectronDesktopApi }).freshellDesktop) || undefined
 }
 
+function toAbsoluteUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    // Already absolute; preserve the caller's formatting.
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return url
+    }
+  } catch {
+    // Not absolute — fall through to resolve against the page URL.
+  }
+  try {
+    return new URL(url, window.location.href).toString()
+  } catch {
+    return url
+  }
+}
+
 export function openExternalUrl(url: string): void {
-  const desktop = getDesktopApi()
-  if (typeof desktop?.openExternal === 'function') {
-    void desktop.openExternal(url)
+  if (typeof url !== 'string') {
+    console.warn('openExternalUrl: expected a string URL, got', typeof url)
     return
   }
-  window.open(url, '_blank', 'noopener,noreferrer')
+
+  const absoluteUrl = toAbsoluteUrl(url)
+  const desktop = getDesktopApi()
+  if (typeof desktop?.openExternal === 'function') {
+    desktop.openExternal(absoluteUrl).catch((err: unknown) => {
+      console.warn('Failed to open external URL via Electron:', absoluteUrl, err)
+    })
+    return
+  }
+  window.open(absoluteUrl, '_blank', 'noopener,noreferrer')
 }
 
 export function shouldOpenLinkExternally(event: MouseEvent): boolean {

--- a/test/e2e-electron/electron-app.test.ts
+++ b/test/e2e-electron/electron-app.test.ts
@@ -331,25 +331,30 @@ test.describe('Main window with remote server', () => {
     await mainPage.screenshot({ path: 'test-results/main-03-launcher.png' })
   })
 
-  test('ctrl-clicking an external link calls the Electron openExternal bridge', async () => {
+  test('ctrl-clicking an external link uses the system browser', async () => {
     app = await launchApp(tmpHome)
     const mainPage = await app.firstWindow()
     await mainPage.waitForLoadState('domcontentloaded')
     await mainPage.waitForTimeout(3000)
 
-    // Inject a link and override the preload-exposed bridge so we can observe
-    // the system-browser request without actually opening a browser window.
-    const openedUrl = await mainPage.evaluate(async () => {
-      let captured: string | null = null
-      ;(window as any).freshellDesktop = {
-        ...(window as any).freshellDesktop,
-        isElectron: true,
-        openExternal: (url: string) => {
-          captured = url
-          return Promise.resolve()
-        },
+    // Patch shell.openExternal in the main process so the test can observe the
+    // real IPC flow without actually launching a browser window.
+    await app.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { shell } = require('electron')
+      const original = shell.openExternal
+      ;(globalThis as any).__testOpenExternal = (url: string) => {
+        ;(globalThis as any).__openedUrl = url
+        return Promise.resolve()
       }
+      ;(globalThis as any).__restoreOpenExternal = () => {
+        shell.openExternal = original
+      }
+      shell.openExternal = (globalThis as any).__testOpenExternal
+    })
 
+    // Inject an external link and ctrl-click it in the main renderer.
+    await mainPage.evaluate(async () => {
       const link = document.createElement('a')
       link.href = 'https://example.com/freshell-test-link'
       link.target = '_blank'
@@ -357,16 +362,15 @@ test.describe('Main window with remote server', () => {
       link.textContent = 'test external link'
       document.body.appendChild(link)
 
-      await new Promise<void>((resolve) => {
-        const event = new MouseEvent('click', { ctrlKey: true, bubbles: true })
-        link.dispatchEvent(event)
-        // Let the capture handler and microtask queue run.
-        requestAnimationFrame(() => resolve())
-      })
+      const event = new MouseEvent('click', { ctrlKey: true, bubbles: true })
+      link.dispatchEvent(event)
 
-      return captured
+      // Wait for the IPC round-trip.
+      await new Promise<void>((resolve) => setTimeout(resolve, 500))
     })
 
-    expect(openedUrl).toBe('https://example.com/freshell-test-link')
+    await expect.poll(async () =>
+      app.evaluate(() => (globalThis as any).__openedUrl),
+    ).toBe('https://example.com/freshell-test-link')
   })
 })

--- a/test/e2e-electron/electron-app.test.ts
+++ b/test/e2e-electron/electron-app.test.ts
@@ -330,4 +330,43 @@ test.describe('Main window with remote server', () => {
 
     await mainPage.screenshot({ path: 'test-results/main-03-launcher.png' })
   })
+
+  test('ctrl-clicking an external link calls the Electron openExternal bridge', async () => {
+    app = await launchApp(tmpHome)
+    const mainPage = await app.firstWindow()
+    await mainPage.waitForLoadState('domcontentloaded')
+    await mainPage.waitForTimeout(3000)
+
+    // Inject a link and override the preload-exposed bridge so we can observe
+    // the system-browser request without actually opening a browser window.
+    const openedUrl = await mainPage.evaluate(async () => {
+      let captured: string | null = null
+      ;(window as any).freshellDesktop = {
+        ...(window as any).freshellDesktop,
+        isElectron: true,
+        openExternal: (url: string) => {
+          captured = url
+          return Promise.resolve()
+        },
+      }
+
+      const link = document.createElement('a')
+      link.href = 'https://example.com/freshell-test-link'
+      link.target = '_blank'
+      link.rel = 'noopener noreferrer'
+      link.textContent = 'test external link'
+      document.body.appendChild(link)
+
+      await new Promise<void>((resolve) => {
+        const event = new MouseEvent('click', { ctrlKey: true, bubbles: true })
+        link.dispatchEvent(event)
+        // Let the capture handler and microtask queue run.
+        requestAnimationFrame(() => resolve())
+      })
+
+      return captured
+    })
+
+    expect(openedUrl).toBe('https://example.com/freshell-test-link')
+  })
 })

--- a/test/unit/client/components/TerminalView.urlClick.test.tsx
+++ b/test/unit/client/components/TerminalView.urlClick.test.tsx
@@ -9,6 +9,7 @@ import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import connectionReducer from '@/store/connectionSlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
 import { getHoveredUrl, clearHoveredUrl } from '@/lib/terminal-hovered-url'
+import { openExternalUrl } from '@/lib/open-url'
 import type { TerminalPaneContent } from '@/store/paneTypes'
 import type { AppSettings } from '@/store/types'
 
@@ -21,6 +22,13 @@ const wsMocks = vi.hoisted(() => ({
 
 vi.mock('@/lib/ws-client', () => ({
   getWsClient: () => wsMocks,
+}))
+
+const openExternalUrlMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/open-url', () => ({
+  openExternalUrl: openExternalUrlMock,
+  shouldOpenLinkExternally: (event: MouseEvent) => event.ctrlKey || event.shiftKey,
 }))
 
 vi.mock('@/hooks/useNotificationSound', () => ({
@@ -170,6 +178,7 @@ describe('TerminalView URL click behavior', () => {
   beforeEach(() => {
     terminalInstances.length = 0
     registeredLinkProviders.length = 0
+    openExternalUrlMock.mockClear()
     windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
     vi.stubGlobal('ResizeObserver', MockResizeObserver)
   })
@@ -211,6 +220,75 @@ describe('TerminalView URL click behavior', () => {
         })
       }
     })
+    expect(windowOpenSpy).not.toHaveBeenCalled()
+  })
+
+  it('OSC 8 linkHandler.activate with ctrl held opens URL externally and does not split pane', async () => {
+    const store = createStore({ terminal: { ...defaultSettings.terminal, warnExternalLinks: false } })
+
+    render(
+      <Provider store={store}>
+        <TerminalView tabId="tab-1" paneId="pane-1" paneContent={paneContent} hidden={false} />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(terminalInstances).toHaveLength(1)
+    })
+
+    const handler = getLinkHandler()
+    act(() => {
+      handler.activate(new MouseEvent('click', { ctrlKey: true }), 'https://example.com')
+    })
+
+    expect(openExternalUrlMock).toHaveBeenCalledWith('https://example.com')
+    expect(store.getState().panes.layouts['tab-1'].type).toBe('leaf')
+    expect(windowOpenSpy).not.toHaveBeenCalled()
+  })
+
+  it('OSC 8 linkHandler.activate with shift held opens URL externally and does not split pane', async () => {
+    const store = createStore({ terminal: { ...defaultSettings.terminal, warnExternalLinks: false } })
+
+    render(
+      <Provider store={store}>
+        <TerminalView tabId="tab-1" paneId="pane-1" paneContent={paneContent} hidden={false} />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(terminalInstances).toHaveLength(1)
+    })
+
+    const handler = getLinkHandler()
+    act(() => {
+      handler.activate(new MouseEvent('click', { shiftKey: true }), 'https://example.com')
+    })
+
+    expect(openExternalUrlMock).toHaveBeenCalledWith('https://example.com')
+    expect(store.getState().panes.layouts['tab-1'].type).toBe('leaf')
+    expect(windowOpenSpy).not.toHaveBeenCalled()
+  })
+
+  it('OSC 8 linkHandler.activate with warnExternalLinks=true and ctrl held bypasses modal and opens externally', async () => {
+    const store = createStore()
+
+    render(
+      <Provider store={store}>
+        <TerminalView tabId="tab-1" paneId="pane-1" paneContent={paneContent} hidden={false} />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(terminalInstances).toHaveLength(1)
+    })
+
+    const handler = getLinkHandler()
+    act(() => {
+      handler.activate(new MouseEvent('click', { ctrlKey: true }), 'https://example.com/page')
+    })
+
+    expect(openExternalUrlMock).toHaveBeenCalledWith('https://example.com/page')
+    expect(screen.queryByText('Open external link?')).not.toBeInTheDocument()
     expect(windowOpenSpy).not.toHaveBeenCalled()
   })
 
@@ -397,6 +475,33 @@ describe('TerminalView URL click behavior', () => {
         })
       }
     })
+  })
+
+  it('URL link provider activate with ctrl held opens URL externally', async () => {
+    const store = createStore({ terminal: { ...defaultSettings.terminal, warnExternalLinks: false } })
+
+    render(
+      <Provider store={store}>
+        <TerminalView tabId="tab-1" paneId="pane-1" paneContent={paneContent} hidden={false} />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(registeredLinkProviders.length).toBeGreaterThanOrEqual(2)
+    })
+
+    const urlProvider = getUrlLinkProvider()
+    let links: any[] | undefined
+    urlProvider.provideLinks(1, (provided) => {
+      links = provided
+    })
+
+    act(() => {
+      links![0].activate(new MouseEvent('click', { ctrlKey: true }))
+    })
+
+    expect(openExternalUrlMock).toHaveBeenCalledWith('https://detected.example.com')
+    expect(store.getState().panes.layouts['tab-1'].type).toBe('leaf')
   })
 
   it('URL link provider hover sets hovered URL in module and data attribute', async () => {

--- a/test/unit/client/hooks/useElectronExternalLinks.test.tsx
+++ b/test/unit/client/hooks/useElectronExternalLinks.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { useElectronExternalLinks } from '@/hooks/useElectronExternalLinks'
+
+const openExternalUrlMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/open-url', () => ({
+  openExternalUrl: openExternalUrlMock,
+  shouldOpenLinkExternally: (event: MouseEvent) => event.ctrlKey || event.shiftKey,
+}))
+
+function TestHarness() {
+  useElectronExternalLinks()
+  return <a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a>
+}
+
+describe('useElectronExternalLinks', () => {
+  beforeEach(() => {
+    openExternalUrlMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does nothing in a normal browser', () => {
+    vi.stubGlobal('freshellDesktop', undefined)
+    const addEventListenerSpy = vi.spyOn(document, 'addEventListener')
+    const { container } = render(<TestHarness />)
+    const link = container.querySelector('a')!
+    const clickEvent = new MouseEvent('click', { ctrlKey: true, bubbles: true })
+
+    link.dispatchEvent(clickEvent)
+
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith('click', expect.any(Function), true)
+    expect(openExternalUrlMock).not.toHaveBeenCalled()
+    addEventListenerSpy.mockRestore()
+  })
+
+  it('opens external https links on ctrl+click in Electron', () => {
+    vi.stubGlobal('freshellDesktop', { isElectron: true })
+    const { container } = render(<TestHarness />)
+    const link = container.querySelector('a')!
+    const clickEvent = new MouseEvent('click', { ctrlKey: true, bubbles: true })
+
+    link.dispatchEvent(clickEvent)
+
+    expect(openExternalUrlMock).toHaveBeenCalledWith('https://example.com/')
+  })
+
+  it('opens external https links on shift+click in Electron', () => {
+    vi.stubGlobal('freshellDesktop', { isElectron: true })
+    const { container } = render(<TestHarness />)
+    const link = container.querySelector('a')!
+    const clickEvent = new MouseEvent('click', { shiftKey: true, bubbles: true })
+
+    link.dispatchEvent(clickEvent)
+
+    expect(openExternalUrlMock).toHaveBeenCalledWith('https://example.com/')
+  })
+
+  it('ignores plain left-clicks in Electron', () => {
+    vi.stubGlobal('freshellDesktop', { isElectron: true })
+    const { container } = render(<TestHarness />)
+    const link = container.querySelector('a')!
+    const clickEvent = new MouseEvent('click', { bubbles: true })
+
+    link.dispatchEvent(clickEvent)
+
+    expect(openExternalUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-http anchors in Electron', () => {
+    vi.stubGlobal('freshellDesktop', { isElectron: true })
+    function TestHarnessWithMail() {
+      useElectronExternalLinks()
+      return <a href="mailto:test@example.com">email</a>
+    }
+    const { container } = render(<TestHarnessWithMail />)
+    const link = container.querySelector('a')!
+    const clickEvent = new MouseEvent('click', { ctrlKey: true, bubbles: true })
+
+    link.dispatchEvent(clickEvent)
+
+    expect(openExternalUrlMock).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/client/hooks/useElectronExternalLinks.test.tsx
+++ b/test/unit/client/hooks/useElectronExternalLinks.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, cleanup } from '@testing-library/react'
 import { useElectronExternalLinks } from '@/hooks/useElectronExternalLinks'
 
 const openExternalUrlMock = vi.hoisted(() => vi.fn())
@@ -16,10 +16,12 @@ function TestHarness() {
 
 describe('useElectronExternalLinks', () => {
   beforeEach(() => {
+    cleanup()
     openExternalUrlMock.mockClear()
   })
 
   afterEach(() => {
+    cleanup()
     vi.unstubAllGlobals()
   })
 

--- a/test/unit/client/lib/open-url.test.ts
+++ b/test/unit/client/lib/open-url.test.ts
@@ -38,4 +38,50 @@ describe('openExternalUrl', () => {
 
     expect(windowOpenSpy).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer')
   })
+
+  it('resolves relative URLs against window.location when using openExternal', () => {
+    const openExternal = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('freshellDesktop', { openExternal, isElectron: true })
+    vi.stubGlobal('location', { href: 'https://freshell.example.com:3001/pane/tab-1' })
+
+    openExternalUrl('/api/proxy/http/8080/')
+
+    expect(openExternal).toHaveBeenCalledWith('https://freshell.example.com:3001/api/proxy/http/8080/')
+  })
+
+  it('resolves relative URLs against window.location when falling back to window.open', () => {
+    vi.stubGlobal('freshellDesktop', undefined)
+    vi.stubGlobal('location', { href: 'https://freshell.example.com:3001/' })
+
+    openExternalUrl('/api/proxy/http/8080/')
+
+    expect(windowOpenSpy).toHaveBeenCalledWith('https://freshell.example.com:3001/api/proxy/http/8080/', '_blank', 'noopener,noreferrer')
+  })
+
+  it('logs a warning but does not throw when openExternal rejects', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const openExternal = vi.fn().mockRejectedValue(new Error('OS refused'))
+    vi.stubGlobal('freshellDesktop', { openExternal, isElectron: true })
+
+    openExternalUrl('https://example.com')
+
+    // Wait for the promise rejection to be caught.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(openExternal).toHaveBeenCalledWith('https://example.com')
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Failed to open external URL via Electron:',
+      'https://example.com',
+      expect.any(Error),
+    )
+    consoleWarnSpy.mockRestore()
+  })
+
+  it('ignores non-string URLs', () => {
+    vi.stubGlobal('freshellDesktop', undefined)
+
+    openExternalUrl(undefined as unknown as string)
+
+    expect(windowOpenSpy).not.toHaveBeenCalled()
+  })
 })

--- a/test/unit/client/lib/open-url.test.ts
+++ b/test/unit/client/lib/open-url.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { openExternalUrl } from '@/lib/open-url'
+
+describe('openExternalUrl', () => {
+  let windowOpenSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+  })
+
+  afterEach(() => {
+    windowOpenSpy.mockRestore()
+    vi.unstubAllGlobals()
+  })
+
+  it('uses window.freshellDesktop.openExternal when available', () => {
+    const openExternal = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('freshellDesktop', { openExternal, isElectron: true })
+
+    openExternalUrl('https://example.com')
+
+    expect(openExternal).toHaveBeenCalledWith('https://example.com')
+    expect(windowOpenSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to window.open when freshellDesktop is unavailable', () => {
+    vi.stubGlobal('freshellDesktop', undefined)
+
+    openExternalUrl('https://example.com')
+
+    expect(windowOpenSpy).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer')
+  })
+
+  it('falls back to window.open when freshellDesktop.openExternal is not a function', () => {
+    vi.stubGlobal('freshellDesktop', { isElectron: true })
+
+    openExternalUrl('https://example.com')
+
+    expect(windowOpenSpy).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer')
+  })
+})

--- a/test/unit/electron/external-url.test.ts
+++ b/test/unit/electron/external-url.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { registerOpenExternalHandler, type ExternalUrlDeps } from '../../../electron/external-url.js'
+
+describe('registerOpenExternalHandler', () => {
+  let deps: ExternalUrlDeps
+  let handler: (event: unknown, url: string) => Promise<void>
+
+  beforeEach(() => {
+    deps = {
+      ipcMain: {
+        handle: vi.fn((channel: string, fn: (event: unknown, url: string) => Promise<void>) => {
+          if (channel === 'open-external-url') {
+            handler = fn
+          }
+        }),
+      },
+      shell: {
+        openExternal: vi.fn().mockResolvedValue(undefined),
+      },
+    }
+    registerOpenExternalHandler(deps)
+  })
+
+  it('registers open-external-url IPC handler', () => {
+    expect(deps.ipcMain.handle).toHaveBeenCalledWith('open-external-url', expect.any(Function))
+  })
+
+  it('opens https URLs with shell.openExternal', async () => {
+    await handler({}, 'https://example.com')
+    expect(deps.shell.openExternal).toHaveBeenCalledWith('https://example.com')
+  })
+
+  it('opens http URLs with shell.openExternal', async () => {
+    await handler({}, 'http://example.com')
+    expect(deps.shell.openExternal).toHaveBeenCalledWith('http://example.com')
+  })
+})

--- a/test/unit/electron/external-url.test.ts
+++ b/test/unit/electron/external-url.test.ts
@@ -28,12 +28,17 @@ describe('registerOpenExternalHandler', () => {
 
   it('opens https URLs with shell.openExternal', async () => {
     await handler({ sender: { id: 42 } }, 'https://example.com')
-    expect(deps.shell.openExternal).toHaveBeenCalledWith('https://example.com')
+    expect(deps.shell.openExternal).toHaveBeenCalledWith('https://example.com/')
   })
 
   it('opens http URLs with shell.openExternal', async () => {
     await handler({ sender: { id: 42 } }, 'http://example.com')
-    expect(deps.shell.openExternal).toHaveBeenCalledWith('http://example.com')
+    expect(deps.shell.openExternal).toHaveBeenCalledWith('http://example.com/')
+  })
+
+  it('canonicalizes an https URL with a path and query', async () => {
+    await handler({ sender: { id: 42 } }, 'https://example.com/foo?bar=1')
+    expect(deps.shell.openExternal).toHaveBeenCalledWith('https://example.com/foo?bar=1')
   })
 
   it('rejects requests from disallowed senders', async () => {
@@ -47,22 +52,32 @@ describe('registerOpenExternalHandler', () => {
   })
 
   it('rejects non-string URLs', async () => {
-    await expect(handler({ sender: { id: 42 } }, undefined as unknown as string)).rejects.toThrow(/only absolute http\/https URLs are allowed/)
+    await expect(handler({ sender: { id: 42 } }, undefined as unknown as string)).rejects.toThrow(/canonical absolute http\/https URLs are allowed/)
     expect(deps.shell.openExternal).not.toHaveBeenCalled()
   })
 
   it('rejects file: URLs', async () => {
-    await expect(handler({ sender: { id: 42 } }, 'file:///etc/passwd')).rejects.toThrow(/only absolute http\/https URLs are allowed/)
+    await expect(handler({ sender: { id: 42 } }, 'file:///etc/passwd')).rejects.toThrow(/canonical absolute http\/https URLs are allowed/)
     expect(deps.shell.openExternal).not.toHaveBeenCalled()
   })
 
   it('rejects javascript: URLs', async () => {
-    await expect(handler({ sender: { id: 42 } }, 'javascript:alert(1)')).rejects.toThrow(/only absolute http\/https URLs are allowed/)
+    await expect(handler({ sender: { id: 42 } }, 'javascript:alert(1)')).rejects.toThrow(/canonical absolute http\/https URLs are allowed/)
     expect(deps.shell.openExternal).not.toHaveBeenCalled()
   })
 
   it('rejects relative URLs', async () => {
-    await expect(handler({ sender: { id: 42 } }, '/api/proxy/http/8080/')).rejects.toThrow(/only absolute http\/https URLs are allowed/)
+    await expect(handler({ sender: { id: 42 } }, '/api/proxy/http/8080/')).rejects.toThrow(/canonical absolute http\/https URLs are allowed/)
+    expect(deps.shell.openExternal).not.toHaveBeenCalled()
+  })
+
+  it('rejects URLs containing control characters', async () => {
+    await expect(handler({ sender: { id: 42 } }, 'https://example.com\n/evil')).rejects.toThrow(/canonical absolute http\/https URLs are allowed/)
+    expect(deps.shell.openExternal).not.toHaveBeenCalled()
+  })
+
+  it('rejects URLs with embedded credentials', async () => {
+    await expect(handler({ sender: { id: 42 } }, 'https://user:pass@example.com/')).rejects.toThrow(/canonical absolute http\/https URLs are allowed/)
     expect(deps.shell.openExternal).not.toHaveBeenCalled()
   })
 })

--- a/test/unit/electron/external-url.test.ts
+++ b/test/unit/electron/external-url.test.ts
@@ -34,4 +34,24 @@ describe('registerOpenExternalHandler', () => {
     await handler({}, 'http://example.com')
     expect(deps.shell.openExternal).toHaveBeenCalledWith('http://example.com')
   })
+
+  it('rejects non-string URLs', async () => {
+    await expect(handler({}, undefined as unknown as string)).rejects.toThrow(/only absolute http\/https URLs are allowed/)
+    expect(deps.shell.openExternal).not.toHaveBeenCalled()
+  })
+
+  it('rejects file: URLs', async () => {
+    await expect(handler({}, 'file:///etc/passwd')).rejects.toThrow(/only absolute http\/https URLs are allowed/)
+    expect(deps.shell.openExternal).not.toHaveBeenCalled()
+  })
+
+  it('rejects javascript: URLs', async () => {
+    await expect(handler({}, 'javascript:alert(1)')).rejects.toThrow(/only absolute http\/https URLs are allowed/)
+    expect(deps.shell.openExternal).not.toHaveBeenCalled()
+  })
+
+  it('rejects relative URLs', async () => {
+    await expect(handler({}, '/api/proxy/http/8080/')).rejects.toThrow(/only absolute http\/https URLs are allowed/)
+    expect(deps.shell.openExternal).not.toHaveBeenCalled()
+  })
 })

--- a/test/unit/electron/external-url.test.ts
+++ b/test/unit/electron/external-url.test.ts
@@ -3,12 +3,12 @@ import { registerOpenExternalHandler, type ExternalUrlDeps } from '../../../elec
 
 describe('registerOpenExternalHandler', () => {
   let deps: ExternalUrlDeps
-  let handler: (event: unknown, url: string) => Promise<void>
+  let handler: (event: { sender?: { id?: number } }, url: string) => Promise<void>
 
   beforeEach(() => {
     deps = {
       ipcMain: {
-        handle: vi.fn((channel: string, fn: (event: unknown, url: string) => Promise<void>) => {
+        handle: vi.fn((channel: string, fn: (event: { sender?: { id?: number } }, url: string) => Promise<void>) => {
           if (channel === 'open-external-url') {
             handler = fn
           }
@@ -17,6 +17,7 @@ describe('registerOpenExternalHandler', () => {
       shell: {
         openExternal: vi.fn().mockResolvedValue(undefined),
       },
+      isAllowedSender: (event) => event.sender?.id === 42,
     }
     registerOpenExternalHandler(deps)
   })
@@ -26,32 +27,42 @@ describe('registerOpenExternalHandler', () => {
   })
 
   it('opens https URLs with shell.openExternal', async () => {
-    await handler({}, 'https://example.com')
+    await handler({ sender: { id: 42 } }, 'https://example.com')
     expect(deps.shell.openExternal).toHaveBeenCalledWith('https://example.com')
   })
 
   it('opens http URLs with shell.openExternal', async () => {
-    await handler({}, 'http://example.com')
+    await handler({ sender: { id: 42 } }, 'http://example.com')
     expect(deps.shell.openExternal).toHaveBeenCalledWith('http://example.com')
   })
 
+  it('rejects requests from disallowed senders', async () => {
+    await expect(handler({ sender: { id: 99 } }, 'https://example.com')).rejects.toThrow(/sender not allowed/)
+    expect(deps.shell.openExternal).not.toHaveBeenCalled()
+  })
+
+  it('rejects requests when sender id is missing', async () => {
+    await expect(handler({}, 'https://example.com')).rejects.toThrow(/sender not allowed/)
+    expect(deps.shell.openExternal).not.toHaveBeenCalled()
+  })
+
   it('rejects non-string URLs', async () => {
-    await expect(handler({}, undefined as unknown as string)).rejects.toThrow(/only absolute http\/https URLs are allowed/)
+    await expect(handler({ sender: { id: 42 } }, undefined as unknown as string)).rejects.toThrow(/only absolute http\/https URLs are allowed/)
     expect(deps.shell.openExternal).not.toHaveBeenCalled()
   })
 
   it('rejects file: URLs', async () => {
-    await expect(handler({}, 'file:///etc/passwd')).rejects.toThrow(/only absolute http\/https URLs are allowed/)
+    await expect(handler({ sender: { id: 42 } }, 'file:///etc/passwd')).rejects.toThrow(/only absolute http\/https URLs are allowed/)
     expect(deps.shell.openExternal).not.toHaveBeenCalled()
   })
 
   it('rejects javascript: URLs', async () => {
-    await expect(handler({}, 'javascript:alert(1)')).rejects.toThrow(/only absolute http\/https URLs are allowed/)
+    await expect(handler({ sender: { id: 42 } }, 'javascript:alert(1)')).rejects.toThrow(/only absolute http\/https URLs are allowed/)
     expect(deps.shell.openExternal).not.toHaveBeenCalled()
   })
 
   it('rejects relative URLs', async () => {
-    await expect(handler({}, '/api/proxy/http/8080/')).rejects.toThrow(/only absolute http\/https URLs are allowed/)
+    await expect(handler({ sender: { id: 42 } }, '/api/proxy/http/8080/')).rejects.toThrow(/only absolute http\/https URLs are allowed/)
     expect(deps.shell.openExternal).not.toHaveBeenCalled()
   })
 })

--- a/test/unit/electron/preload.test.ts
+++ b/test/unit/electron/preload.test.ts
@@ -43,6 +43,7 @@ describe('Preload API', () => {
       'isElectron',
       'onUpdateAvailable',
       'onUpdateDownloaded',
+      'openExternal',
       'platform',
       'setGlobalHotkey',
     ])
@@ -62,6 +63,7 @@ describe('Preload API', () => {
     expect(typeof exposedApi.completeSetup).toBe('function')
     expect(typeof exposedApi.getLaunchOptions).toBe('function')
     expect(typeof exposedApi.chooseLaunchOption).toBe('function')
+    expect(typeof exposedApi.openExternal).toBe('function')
   })
 
   it('getServerMode invokes correct IPC channel', () => {
@@ -107,5 +109,10 @@ describe('Preload API', () => {
     }
     exposedApi.chooseLaunchOption(choice)
     expect(mockIpcRenderer.invoke).toHaveBeenCalledWith('choose-launch-option', choice)
+  })
+
+  it('openExternal invokes correct IPC channel with URL', () => {
+    exposedApi.openExternal('https://example.com')
+    expect(mockIpcRenderer.invoke).toHaveBeenCalledWith('open-external-url', 'https://example.com')
   })
 })


### PR DESCRIPTION
Adds Electron support for opening ctrl-clicked/shift-clicked HTTP(S) links in the system browser, with IPC sender/origin validation and URL canonicalization.