### PR TITLE
Fix Codex update prompt skip during startup

### DIFF
--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -591,7 +591,7 @@ export type TerminalRecord = {
   codexActiveTurn?: CodexTurnEvent
   codexUnconfirmedInputAt?: number
   codexUnconfirmedInputSource?: 'resume' | 'input'
-  codexInputGate?: { state: 'identity_pending' }
+  codexInputGate?: { state: 'identity_pending'; codexUpdatePromptDismissed?: boolean }
   codexRecovery?: CodexRecoveryOptions
   codexRecoveryAttempt?: Promise<void>
   codexRecoveryAttemptSerial?: number
@@ -640,6 +640,54 @@ function isCodexStartupTerminalControlInput(data: string): boolean {
   if (/^\x1b\[\d{1,4};\d{1,4}R$/.test(data)) return true
   if (/^\x1b\[(?:\?|\>)?[\d;]{0,32}c$/.test(data)) return true
   return /^\x1b\](?:10|11|12|4;\d{1,3});rgb:[0-9a-fA-F]{1,4}\/[0-9a-fA-F]{1,4}\/[0-9a-fA-F]{1,4}(?:\x07|\x1b\\)$/.test(data)
+}
+
+const CODEX_UPDATE_PROMPT_TAIL_CHARS = 8 * 1024
+// eslint-disable-next-line no-control-regex -- terminal snapshots contain ANSI/OSC control bytes.
+const TERMINAL_CONTROL_PATTERN = /\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_]/g
+
+function stripTerminalControls(data: string): string {
+  return data.replace(TERMINAL_CONTROL_PATTERN, '')
+}
+
+function hasCodexUpdatePrompt(snapshot: string): boolean {
+  const tail = snapshot.slice(-CODEX_UPDATE_PROMPT_TAIL_CHARS)
+  const text = stripTerminalControls(tail).replace(/\r/g, '\n')
+  return text.includes('Update available!')
+    && text.includes('github.com/openai/codex/releases/latest')
+    && text.includes('Update now')
+    && text.includes('Skip until next version')
+    && text.includes('Press enter to continue')
+}
+
+function isCodexUpdatePromptInput(data: string): boolean {
+  return data === '1'
+    || data === '2'
+    || data === '3'
+    || data === '1\r'
+    || data === '2\r'
+    || data === '3\r'
+    || data === '1\n'
+    || data === '2\n'
+    || data === '3\n'
+    || data === '\r'
+    || data === '\n'
+    || data === '\r\n'
+    || data === '\x1b[A'
+    || data === '\x1b[B'
+}
+
+function isCodexUpdatePromptDismissInput(data: string): boolean {
+  return data === '\r'
+    || data === '\n'
+    || data === '\r\n'
+    || data.endsWith('\r')
+    || data.endsWith('\n')
+}
+
+function isCodexStartupUpdatePromptInput(record: TerminalRecord, data: string): boolean {
+  if (record.codexInputGate?.codexUpdatePromptDismissed) return false
+  return isCodexUpdatePromptInput(data) && hasCodexUpdatePrompt(record.buffer.snapshot())
 }
 
 export type BindSessionResult =
@@ -3160,8 +3208,11 @@ export class TerminalRegistry extends EventEmitter {
       return { status: 'blocked_codex_lifecycle_loss_pending', terminalId }
     }
     if (term.codexInputGate?.state === 'identity_pending') {
-      if (isCodexStartupTerminalControlInput(data)) {
+      if (isCodexStartupTerminalControlInput(data) || isCodexStartupUpdatePromptInput(term, data)) {
         term.pty.write(data)
+        if (isCodexUpdatePromptDismissInput(data)) {
+          term.codexInputGate.codexUpdatePromptDismissed = true
+        }
         return { status: 'written' }
       }
       return { status: 'blocked_codex_identity_pending', terminalId }

--- a/test/unit/server/terminal-registry.codex-sidecar.test.ts
+++ b/test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -29,6 +29,7 @@ const mockPtyProcess = vi.hoisted(() => {
           emitter.emit('exit', { exitCode: 0 })
         }
       }),
+      _emitData: (data: string) => emitter.emit('data', data),
       _emitExit: (exitCode: number, signal?: number) => emitter.emit('exit', { exitCode, signal }),
     }
     return pty
@@ -265,6 +266,40 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
       terminalId: term.terminalId,
     })
     expect(registry.input(term.terminalId, '\x1b[A')).toEqual({
+      status: 'blocked_codex_identity_pending',
+      terminalId: term.terminalId,
+    })
+  })
+
+  it('allows Codex update prompt menu replies while restore identity is pending', () => {
+    const registry = new TerminalRegistry()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: createFakeSidecar(),
+        },
+      } as any,
+    })
+
+    const pty = mockPtyProcess.instances[0]
+    pty._emitData([
+      '\x1b[1mUpdate available! 0.140.0 -> 0.141.0\x1b[0m\r\n',
+      'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+      '\r\n',
+      '> 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+      '  2. Skip\r\n',
+      '  3. Skip until next version\r\n',
+      '\r\n',
+      'Press enter to continue\r\n',
+    ].join(''))
+
+    expect(registry.input(term.terminalId, '2')).toEqual({ status: 'written' })
+    expect(pty.write).toHaveBeenLastCalledWith('2')
+    expect(registry.input(term.terminalId, '\r')).toEqual({ status: 'written' })
+    expect(pty.write).toHaveBeenLastCalledWith('\r')
+    expect(registry.input(term.terminalId, 'hello\r')).toEqual({
       status: 'blocked_codex_identity_pending',
       terminalId: term.terminalId,
     })


### PR DESCRIPTION
## Summary
- allow Codex update prompt menu input through the startup identity gate only while the update prompt is visible
- mark the update prompt dismissed after Enter so arbitrary input remains blocked until restore identity is captured
- add regression coverage for skipping the update prompt while identity capture is pending

## Verification
- `npm run test:vitest -- --run test/unit/server/terminal-registry.codex-sidecar.test.ts`
- `npm run test:vitest -- --run test/unit/server/terminal-registry.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts`
- `FRESHELL_TEST_SUMMARY='codex update prompt skip gate fix' npm run check`
- temp server smoke: created Codex terminal through WebSocket, saw fake update prompt, sent `2` + Enter, verified no `terminal.input.blocked` and fake Codex received `2\r`