### PR TITLE
Add GLM 5.2 to freshopencode

### DIFF
--- a/shared/fresh-agent-models.ts
+++ b/shared/fresh-agent-models.ts
@@ -69,6 +69,12 @@ export const FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE = {
       defaultEffort: FRESHOPENCODE_DEFAULT_EFFORT,
     },
     {
+      value: 'opencode-go/glm-5.2',
+      label: 'GLM 5.2',
+      thinkingEfforts: ['minimal', 'low', 'medium', 'high', 'max'],
+      defaultEffort: FRESHOPENCODE_DEFAULT_EFFORT,
+    },
+    {
       value: 'umans-ai-coding-plan/umans-kimi-k2.7',
       label: 'Kimi k2.7',
       thinkingEfforts: ['minimal', 'low', 'medium', 'high', 'max'],

--- a/test/unit/shared/fresh-agent-models.test.ts
+++ b/test/unit/shared/fresh-agent-models.test.ts
@@ -8,7 +8,37 @@ import {
 } from '@shared/fresh-agent-models'
 
 describe('fresh-agent-models freshopencode options', () => {
+  const GLM_5_2_MODEL = 'opencode-go/glm-5.2'
   const KIMI_K2_7_MODEL = 'umans-ai-coding-plan/umans-kimi-k2.7'
+
+  it('includes GLM 5.2 as a selectable Freshopencode model', () => {
+    const option = resolveFreshAgentModelOption('freshopencode', GLM_5_2_MODEL)
+
+    expect(option).toMatchObject({
+      value: GLM_5_2_MODEL,
+      label: 'GLM 5.2',
+      thinkingEfforts: ['minimal', 'low', 'medium', 'high', 'max'],
+      defaultEffort: 'max',
+    })
+  })
+
+  it('normalizes the GLM 5.2 model value for the opencode runtime provider', () => {
+    const normalized = normalizeFreshAgentModel('freshopencode', 'opencode', GLM_5_2_MODEL)
+
+    expect(normalized).toBe(GLM_5_2_MODEL)
+  })
+
+  it('exposes the expected thinking levels for GLM 5.2', () => {
+    const options = getFreshAgentThinkingOptions('freshopencode', 'opencode', GLM_5_2_MODEL)
+
+    expect(options.map((o) => o.value)).toEqual(['minimal', 'low', 'medium', 'high', 'max'])
+  })
+
+  it('lists GLM 5.2 in the static Freshopencode options array', () => {
+    const values = FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE.freshopencode.map((o) => o.value)
+
+    expect(values).toContain(GLM_5_2_MODEL)
+  })
 
   it('includes Kimi k2.7 as a selectable Freshopencode model', () => {
     const option = resolveFreshAgentModelOption('freshopencode', KIMI_K2_7_MODEL)


### PR DESCRIPTION
Adds `opencode-go/glm-5.2` to the freshopencode model picker options and includes unit-test coverage.