### PR TITLE
Fix mobile long-press menu release

### DIFF
--- a/src/components/context-menu/ContextMenuProvider.tsx
+++ b/src/components/context-menu/ContextMenuProvider.tsx
@@ -1014,15 +1014,19 @@ export function ContextMenuProvider({
     // --- Long-press (touch hold) detection for mobile ---
     let longPressTimer: ReturnType<typeof setTimeout> | null = null
     let touchStartPos: { x: number; y: number } | null = null
+    let suppressNextTouchEnd = false
 
     const handleTouchStart = (e: TouchEvent) => {
       const touch = e.touches[0]
       if (!touch) return
+      suppressNextTouchEnd = false
       touchStartPos = { x: touch.clientX, y: touch.clientY }
 
       longPressTimer = setTimeout(() => {
-        if (!touchStartPos) return
-        const target = document.elementFromPoint(touchStartPos.x, touchStartPos.y) as HTMLElement | null
+        longPressTimer = null
+        const startPos = touchStartPos
+        if (!startPos) return
+        const target = document.elementFromPoint(startPos.x, startPos.y) as HTMLElement | null
         if (!target) return
 
         const contextEl = findContextElement(target)
@@ -1041,8 +1045,9 @@ export function ContextMenuProvider({
         const targetObj = parsed || { kind: 'global' as const }
 
         triggerHapticFeedback()
+        suppressNextTouchEnd = true
         openMenu({
-          position: { x: touchStartPos.x, y: touchStartPos.y },
+          position: { x: startPos.x, y: startPos.y },
           target: targetObj,
           contextElement: contextEl,
           clickTarget: target,
@@ -1062,15 +1067,21 @@ export function ContextMenuProvider({
         clearTimeout(longPressTimer)
         longPressTimer = null
         touchStartPos = null
+        suppressNextTouchEnd = false
       }
     }
 
-    const handleTouchEnd = () => {
+    const handleTouchEnd = (e: TouchEvent) => {
+      const shouldSuppressRelease = suppressNextTouchEnd && e.type === 'touchend'
       if (longPressTimer) {
         clearTimeout(longPressTimer)
         longPressTimer = null
       }
       touchStartPos = null
+      suppressNextTouchEnd = false
+      if (shouldSuppressRelease) {
+        if (e.cancelable) e.preventDefault()
+      }
     }
 
     document.addEventListener('contextmenu', handleContextMenu, true)

--- a/test/unit/client/components/context-menu/ContextMenu.longpress.test.tsx
+++ b/test/unit/client/components/context-menu/ContextMenu.longpress.test.tsx
@@ -119,6 +119,7 @@ function simulateTouch(
     changedTouches: [touch as any],
   })
   target.dispatchEvent(touchEvent)
+  return touchEvent
 }
 
 describe('ContextMenuProvider long-press', () => {
@@ -155,6 +156,36 @@ describe('ContextMenuProvider long-press', () => {
 
     act(() => {
       vi.advanceTimersByTime(500)
+    })
+
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+  })
+
+  it('keeps the menu open when the long-press release lands on a menu item', () => {
+    renderWithProvider(
+      <div data-context={ContextIds.Tab} data-tab-id="tab-1">
+        Tab One
+      </div>
+    )
+
+    const target = screen.getByText('Tab One')
+    elementFromPointMock.mockReturnValue(target)
+
+    act(() => {
+      simulateTouch('touchstart', target, 100, 100)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    const firstItem = screen.getAllByRole('menuitem')[0]
+
+    act(() => {
+      const release = simulateTouch('touchend', firstItem, 100, 100)
+      if (!release.defaultPrevented) {
+        firstItem.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      }
     })
 
     expect(screen.getByRole('menu')).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- keep the mobile context menu open after a successful long-press release
- prevent the release touch from synthesizing an immediate menu-item click
- add a regression test for releasing over the first menu item

## Verification
- npm run lint
- npm run test:vitest -- test/unit/client/components/context-menu/ContextMenu.longpress.test.tsx test/unit/client/components/ContextMenuProvider.test.tsx test/e2e/pane-context-menu-stability.test.tsx test/e2e/terminal-url-context-menu.test.tsx test/e2e/refresh-context-menu-flow.test.tsx
- FRESHELL_TEST_SUMMARY='post-rebase check for mobile long-press PR' npm run check