### PR TITLE
Fix fresh agent cwd routing

### DIFF
--- a/docs/superpowers/plans/2026-06-19-freshopencode-cwd-scoped-serve.md
+++ b/docs/superpowers/plans/2026-06-19-freshopencode-cwd-scoped-serve.md
@@ -43,6 +43,7 @@ Implementation updates required by this amendment:
 Task-level override checklist:
 
 - Task 2 must update `OpencodeServeManagerOptions`, `RunningServe`, `ensureStarted`, `start`, HTTP helpers, `shutdown`, and child-close cleanup for cwd-scoped sidecars. On child close, delete emitters for sessions mapped to that cwd; when the closing sidecar is the default route, also delete unmapped emitters, because no-cwd restored sessions use the default route.
+- Task 2 must add an optional `env?: NodeJS.ProcessEnv` manager option. Spawn env should be `{ ...(options.env ?? process.env), [FRESHELL_OPENCODE_SIDECAR_ID]: ownershipId }`, so real-provider tests can use isolated OpenCode homes without mutating global `process.env`.
 - Task 2 must clear successful `startPromiseByCwd` entries after a sidecar has moved into `runningByCwd`.
 - Task 2 must add tests proving:
   - `createSession({ directory })` spawns `opencode serve` with that `cwd`.
@@ -203,6 +204,8 @@ git commit -m "test: pin freshopencode serve cwd contract"
 - Produces:
   - `ensureStarted(input?: { cwd?: string }): Promise<{ baseUrl: string }>`
   - `rememberSessionCwd(sessionId: string, cwd?: string): void`
+  - `OpencodeServeManagerOptions.env?: NodeJS.ProcessEnv`
+  - `OpencodeServeManagerOptions.idleShutdownMs?: number`
   - Existing public methods still work, with optional route argument where session ids need a restored cwd fallback.
 
 - [ ] **Step 1: Add cwd route types and maps**
@@ -223,6 +226,8 @@ type RunningServe = {
   stopEventStream: () => void
   cwdKey: string
   cwd?: string
+  idleTimer?: NodeJS.Timeout
+  activeRequests: number
 }
 
 type ServeRoute = {
@@ -248,6 +253,15 @@ with:
   private readonly startAbortByCwd = new Map<string, AbortController>()
   private readonly cwdByKey = new Map<string, string | undefined>()
   private readonly sessionCwdById = new Map<string, string>()
+  private readonly env: NodeJS.ProcessEnv
+  private readonly idleShutdownMs: number
+```
+
+Add these constructor fields:
+
+```ts
+    this.env = options.env ?? process.env
+    this.idleShutdownMs = options.idleShutdownMs ?? 15 * 60_000
 ```
 
 - [ ] **Step 2: Add cwd normalization and session routing helpers**
@@ -283,6 +297,49 @@ Add these private helpers inside `OpencodeServeManager`:
       this.sessionCwdById.delete(sessionId)
       this.sessionEmitters.delete(sessionId)
     }
+    if (cwdKey === DEFAULT_CWD_KEY) {
+      for (const sessionId of this.sessionEmitters.keys()) {
+        if (!this.sessionCwdById.has(sessionId)) this.sessionEmitters.delete(sessionId)
+      }
+    }
+  }
+
+  private clearIdleTimer(running: RunningServe): void {
+    if (!running.idleTimer) return
+    clearTimeout(running.idleTimer)
+    running.idleTimer = undefined
+  }
+
+  private scheduleIdleShutdown(running: RunningServe): void {
+    this.clearIdleTimer(running)
+    if (running.cwdKey === DEFAULT_CWD_KEY || this.idleShutdownMs <= 0 || running.activeRequests > 0) return
+    running.idleTimer = setTimeout(() => {
+      if (running.activeRequests > 0) return
+      if (this.runningByCwd.get(running.cwdKey) !== running) return
+      this.runningByCwd.delete(running.cwdKey)
+      this.startPromiseByCwd.delete(running.cwdKey)
+      this.forgetSessionsForCwd(running.cwdKey)
+      try { running.stopEventStream() } catch { /* ignore */ }
+      void killOwnedProcesses(running.child, running.ownershipId, this.log)
+    }, this.idleShutdownMs)
+    running.idleTimer.unref?.()
+  }
+
+  private async withRunning<T>(
+    route: { cwdKey: string; cwd?: string },
+    fn: (baseUrl: string) => Promise<T>,
+  ): Promise<T> {
+    const { baseUrl } = await this.ensureStarted({ cwd: route.cwd })
+    const running = this.runningByCwd.get(route.cwdKey)
+    if (!running) return fn(baseUrl)
+    this.clearIdleTimer(running)
+    running.activeRequests += 1
+    try {
+      return await fn(baseUrl)
+    } finally {
+      running.activeRequests -= 1
+      this.scheduleIdleShutdown(running)
+    }
   }
 ```
 
@@ -307,6 +364,7 @@ Replace `ensureStarted()` with:
       this.startPromiseByCwd.set(route.cwdKey, promise)
     }
     const next = await this.startPromiseByCwd.get(route.cwdKey)!
+    this.startPromiseByCwd.delete(route.cwdKey)
     return { baseUrl: next.baseUrl }
   }
 ```
@@ -328,7 +386,7 @@ Change the `start` signature and spawn options:
         ['serve', '--hostname', endpoint.hostname, '--port', String(endpoint.port)],
         {
           ...(route.cwd ? { cwd: route.cwd } : {}),
-          env: { ...process.env, [OWNERSHIP_ENV]: ownershipId },
+          env: { ...this.env, [OWNERSHIP_ENV]: ownershipId },
           stdio: ['ignore', 'pipe', 'pipe'],
         },
       ) as unknown as ChildProcessWithoutNullStreams
@@ -342,6 +400,7 @@ Change the `start` signature and spawn options:
           this.runningByCwd.delete(route.cwdKey)
           this.startPromiseByCwd.delete(route.cwdKey)
           this.startAbortByCwd.delete(route.cwdKey)
+          this.clearIdleTimer(running)
           try { running.stopEventStream() } catch { /* ignore */ }
           void killOwnedProcesses(running.child, running.ownershipId, this.log)
           this.forgetSessionsForCwd(route.cwdKey)
@@ -362,8 +421,9 @@ Change the `start` signature and spawn options:
           })
         : this.startDefaultEventStream(baseUrl)
 
-      const running: RunningServe = { baseUrl, ownershipId, child, stopEventStream, cwdKey: route.cwdKey, cwd: route.cwd }
+      const running: RunningServe = { baseUrl, ownershipId, child, stopEventStream, cwdKey: route.cwdKey, cwd: route.cwd, activeRequests: 0 }
       this.runningByCwd.set(route.cwdKey, running)
+      this.scheduleIdleShutdown(running)
       return running
     } catch (err) {
       if (child) this.stopChild(child)
@@ -393,15 +453,19 @@ Replace `requireBase` and `json` with:
     requestPath: string,
     init?: RequestInit & { notFoundValue?: T },
   ): Promise<T> {
-    const base = await this.requireBase(route)
-    const res = await this.fetchFn(`${base}${requestPath}`, init)
-    if (!res.ok && res.status !== 204) {
-      if (res.status === 404 && init?.notFoundValue !== undefined) return init.notFoundValue
-      const text = await res.text().catch(() => '')
-      throw new Error(`opencode serve ${init?.method ?? 'GET'} ${requestPath} → ${res.status} ${text}`)
-    }
-    if (res.status === 204) return undefined as T
-    return (await res.json()) as T
+    const resolved = route.sessionId
+      ? this.routeForSession(route.sessionId, route)
+      : this.routeFromCwd(route.cwd)
+    return this.withRunning(resolved, async (base) => {
+      const res = await this.fetchFn(`${base}${requestPath}`, init)
+      if (!res.ok && res.status !== 204) {
+        if (res.status === 404 && init?.notFoundValue !== undefined) return init.notFoundValue
+        const text = await res.text().catch(() => '')
+        throw new Error(`opencode serve ${init?.method ?? 'GET'} ${requestPath} → ${res.status} ${text}`)
+      }
+      if (res.status === 204) return undefined as T
+      return (await res.json()) as T
+    })
   }
 ```
 
@@ -427,7 +491,11 @@ Update each caller:
   }
 
   async getSession(id: string, route: ServeRoute = {}): Promise<Record<string, any>> {
-    return this.json({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}`, { method: 'GET' })
+    const session = await this.json<Record<string, any>>({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}`, { method: 'GET' })
+    if (typeof session?.directory === 'string' && session.directory.length > 0) {
+      this.rememberSessionCwd(id, session.directory)
+    }
+    return session
   }
 
   async promptAsync(
@@ -455,18 +523,17 @@ Update each caller:
   }
 
   async compact(id: string, body?: { instructions?: string }, route: ServeRoute = {}): Promise<void> {
-    await this.json({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}/compact`, {
+    await this.json({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}/summarize`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body ?? {}),
     })
   }
 
-  async fork(id: string, route: ServeRoute = {}): Promise<{ id: string }> {
-    const child = await this.json<{ id: string }>({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}/fork`, { method: 'POST' })
+  async fork(id: string, route: ServeRoute = {}): Promise<{ id: string; directory?: string }> {
+    const child = await this.json<{ id: string; directory?: string }>({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}/fork`, { method: 'POST' })
     if (typeof child.id === 'string') {
-      const parentRoute = this.routeForSession(id, route)
-      this.rememberSessionCwd(child.id, parentRoute.cwd)
+      this.rememberSessionCwd(child.id, child.directory)
     }
     return child
   }
@@ -476,20 +543,22 @@ Update `listMessages`:
 
 ```ts
   async listMessages(id: string, query: { limit?: number; before?: string }, route: ServeRoute = {}): Promise<OpencodeServeMessagePage> {
-    const base = await this.requireBase({ ...route, sessionId: id })
-    const params = new URLSearchParams()
-    if (typeof query.limit === 'number') params.set('limit', String(query.limit))
-    if (query.before) params.set('before', query.before)
-    const qs = params.toString()
-    const url = `${base}/session/${encodeURIComponent(id)}/message${qs ? `?${qs}` : ''}`
-    const res = await this.fetchFn(url, { method: 'GET' })
-    if (!res.ok) {
-      const text = await res.text().catch(() => '')
-      throw new Error(`opencode serve GET messages → ${res.status} ${text}`)
-    }
-    const messages = (await res.json()) as OpencodeServeMessage[]
-    const nextCursor = res.headers.get('x-next-cursor') || null
-    return { messages: Array.isArray(messages) ? messages : [], nextCursor }
+    const resolved = this.routeForSession(id, route)
+    return this.withRunning(resolved, async (base) => {
+      const params = new URLSearchParams()
+      if (typeof query.limit === 'number') params.set('limit', String(query.limit))
+      if (query.before) params.set('before', query.before)
+      const qs = params.toString()
+      const url = `${base}/session/${encodeURIComponent(id)}/message${qs ? `?${qs}` : ''}`
+      const res = await this.fetchFn(url, { method: 'GET' })
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`opencode serve GET messages → ${res.status} ${text}`)
+      }
+      const messages = (await res.json()) as OpencodeServeMessage[]
+      const nextCursor = res.headers.get('x-next-cursor') || null
+      return { messages: Array.isArray(messages) ? messages : [], nextCursor }
+    })
   }
 ```
 
@@ -517,6 +586,7 @@ Replace `shutdown()` with:
     this.startPromiseByCwd.clear()
     this.startAbortByCwd.clear()
     await Promise.all(running.map(async (entry) => {
+      this.clearIdleTimer(entry)
       try { entry.stopEventStream() } catch { /* ignore */ }
       await killOwnedProcesses(entry.child, entry.ownershipId, this.log)
     }))
@@ -581,10 +651,15 @@ git commit -m "fix: scope opencode serve processes by cwd"
 In `test/unit/server/fresh-agent/opencode-serve-adapter.test.ts`, add `rememberSessionCwd` to `makeFakeManager()`:
 
 ```ts
+    createSession: vi.fn(async (input?: { directory?: string }) => ({
+      id: 'ses_real_1',
+      ...(input?.directory ? { directory: input.directory } : {}),
+      title: 'T',
+    })),
     rememberSessionCwd: vi.fn(),
 ```
 
-Then update `FakeManager` automatically through the existing `ReturnType`.
+Replace the old always-`/repo` fake `createSession` with the conditional version above, then update `FakeManager` automatically through the existing `ReturnType`.
 
 - [ ] **Step 2: Add failing test for attach cwd registration**
 
@@ -779,18 +854,28 @@ Update control methods:
 Update history calls:
 
 ```ts
-      const { exported, revision } = await assembleExport(realId, { limit: DEFAULT_SNAPSHOT_TURN_LIMIT }, { cwd: liveState?.cwd ?? thread.cwd })
+      const route = cwdRoute(liveState?.cwd ?? thread.cwd)
+      const { exported, revision } = route
+        ? await assembleExport(realId, { limit: DEFAULT_SNAPSHOT_TURN_LIMIT }, route)
+        : await assembleExport(realId, { limit: DEFAULT_SNAPSHOT_TURN_LIMIT })
 ```
 
 ```ts
-      const { exported, nextCursor, revision } = await assembleExport(realId, {
+      const route = cwdRoute(liveState?.cwd ?? thread.cwd)
+      const pageQuery = {
         limit: typeof query.limit === 'number' ? query.limit : DEFAULT_SNAPSHOT_TURN_LIMIT,
         before: typeof query.cursor === 'string' ? query.cursor : undefined,
-      }, { cwd: liveState?.cwd ?? thread.cwd })
+      }
+      const { exported, nextCursor, revision } = route
+        ? await assembleExport(realId, pageQuery, route)
+        : await assembleExport(realId, pageQuery)
 ```
 
 ```ts
-      const message = await serveManager.getMessage(realId, thread.turnId, { cwd: liveState?.cwd ?? thread.cwd })
+      const route = cwdRoute(liveState?.cwd ?? thread.cwd)
+      const message = route
+        ? await serveManager.getMessage(realId, thread.turnId, route)
+        : await serveManager.getMessage(realId, thread.turnId)
 ```
 
 - [ ] **Step 6: Update existing adapter expectations for cwd-aware calls**
@@ -833,32 +918,22 @@ git commit -m "fix: route freshopencode operations with pane cwd"
 - Consumes: real `opencode` binary if available.
 - Produces: a no-LLM regression proving OpenCode stores new session `directory` as the selected cwd even when Freshell process cwd is different.
 
-- [ ] **Step 1: Add imports for temporary directories and SQLite**
+- [ ] **Step 1: Add isolated OpenCode helper imports**
 
 At the top of `test/integration/server/opencode-serve-real-provider-smoke.test.ts`, add:
 
 ```ts
-import { DatabaseSync } from 'node:sqlite'
 import fs from 'node:fs/promises'
-import os from 'node:os'
-import path from 'node:path'
+import {
+  ProbeWorkspace,
+  seedOpencodeHomes,
+  waitForOpencodeDbSession,
+} from '../../../test/helpers/coding-cli/real-session-contract-harness.js'
 ```
 
-- [ ] **Step 2: Add helper to read OpenCode session directory**
+- [ ] **Step 2: Use the existing temp workspace and DB wait helpers**
 
-Add below the `describeReal` constant:
-
-```ts
-function readOpencodeSessionDirectory(dbPath: string, sessionId: string): string | undefined {
-  const db = new DatabaseSync(dbPath)
-  try {
-    const row = db.prepare('select directory from session where id = ? limit 1').get(sessionId) as { directory?: string } | null
-    return row?.directory
-  } finally {
-    db.close()
-  }
-}
-```
+Do not add a static top-level `node:sqlite` import. `waitForOpencodeDbSession()` already uses the repo's supported dynamic/read-only SQLite path and waits for the OpenCode DB row to exist.
 
 - [ ] **Step 3: Add no-LLM cwd regression test**
 
@@ -866,34 +941,27 @@ Add this test inside `describe('OpencodeServeManager lifecycle', ...)`:
 
 ```ts
       it('creates first-run sessions in the requested cwd, not the Freshell process cwd', async () => {
-        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-opencode-real-cwd-'))
-        const requestedCwd = path.join(root, 'requested-project')
-        const dataHome = path.join(root, 'xdg-data')
-        const configHome = path.join(root, 'xdg-config')
-        await Promise.all([
-          fs.mkdir(requestedCwd, { recursive: true }),
-          fs.mkdir(dataHome, { recursive: true }),
-          fs.mkdir(configHome, { recursive: true }),
-        ])
-        const previousDataHome = process.env.XDG_DATA_HOME
-        const previousConfigHome = process.env.XDG_CONFIG_HOME
-        process.env.XDG_DATA_HOME = dataHome
-        process.env.XDG_CONFIG_HOME = configHome
-        const manager = new OpencodeServeManager()
+        const workspace = await ProbeWorkspace.create('freshell-opencode-real-cwd-')
+        const requestedCwd = workspace.inTemp('requested-project')
+        const homes = await seedOpencodeHomes(workspace)
+        const manager = new OpencodeServeManager({
+          env: {
+            ...process.env,
+            XDG_DATA_HOME: homes.dataHome,
+            XDG_CONFIG_HOME: homes.configHome,
+          },
+        })
         try {
+          await fs.mkdir(requestedCwd, { recursive: true })
           const session = await manager.createSession({ directory: requestedCwd })
           expect(session.id).toMatch(/^ses_/)
           expect(session.directory).toBe(requestedCwd)
 
-          const dbPath = path.join(dataHome, 'opencode', 'opencode.db')
-          expect(readOpencodeSessionDirectory(dbPath, session.id)).toBe(requestedCwd)
+          const row = await waitForOpencodeDbSession(homes.dbPath, session.id)
+          expect(row.directory).toBe(requestedCwd)
         } finally {
           await manager.shutdown()
-          if (previousDataHome === undefined) delete process.env.XDG_DATA_HOME
-          else process.env.XDG_DATA_HOME = previousDataHome
-          if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME
-          else process.env.XDG_CONFIG_HOME = previousConfigHome
-          await fs.rm(root, { recursive: true, force: true })
+          await workspace.cleanup()
         }
       }, 60_000)
 ```

--- a/docs/superpowers/plans/2026-06-19-freshopencode-cwd-scoped-serve.md
+++ b/docs/superpowers/plans/2026-06-19-freshopencode-cwd-scoped-serve.md
@@ -1,0 +1,945 @@
+# Freshopencode Cwd-Scoped Serve Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Freshopencode first-run sessions start in the directory the user selected, not in the Freshell server checkout.
+
+**Architecture:** OpenCode `serve` is cwd-bound: OpenCode 1.17.8 records new sessions in the serve process cwd even when `POST /session` includes a different `directory`. Replace the single global serve process inside `OpencodeServeManager` with cwd-scoped serve processes and route every session operation to the sidecar that owns that session. Keep the existing adapter surface stable; only add optional cwd routing where existing restored-session paths need it.
+
+**Tech Stack:** Node.js/TypeScript, ESM with `.js` relative imports, Vitest server config, Express/supertest for existing agent API coverage, OpenCode CLI `serve`.
+
+## Global Constraints
+
+- Server uses NodeNext/ESM; relative imports must include `.js` extensions.
+- Do not restart the self-hosted Freshell server without explicit user approval containing the word `APPROVED`.
+- Do not use broad kill patterns; stop only owned PIDs or ownership-tagged OpenCode serve processes.
+- Preserve unrelated worktree changes from other agents.
+- Use red/green/refactor TDD; do not skip tests or reduce coverage.
+- Keep behavior changes on this dedicated worktree branch and commit focused, atomic changes.
+- Prefer integration/end-to-end tests that prove the user-visible contract.
+
+---
+
+## File Structure
+
+- Modify: `server/fresh-agent/adapters/opencode/serve-manager.ts`
+  - Own cwd-scoped OpenCode serve processes.
+  - Normalize cwd keys.
+  - Route session HTTP calls to the sidecar for that session.
+  - Clean up only the sidecar and emitters for the cwd that exits.
+- Modify: `server/fresh-agent/adapters/opencode/adapter.ts`
+  - Preserve cwd on create/resume/attach.
+  - Pass cwd fallbacks into serve-manager methods for restored sessions whose session id was not created in this process.
+- Modify: `test/unit/server/fresh-agent/opencode-serve-manager.test.ts`
+  - Pin cwd-scoped spawn behavior and per-session routing.
+- Modify: `test/unit/server/fresh-agent/opencode-serve-adapter.test.ts`
+  - Pin attach/resume cwd propagation into manager session operations.
+- Modify: `test/integration/server/opencode-serve-real-provider-smoke.test.ts`
+  - Add a no-LLM real-provider regression: `POST /session` from a manager whose process cwd is not the selected cwd must still produce an OpenCode session whose directory is the selected cwd.
+
+## Task 1: Pin The OpenCode Serve Cwd Contract
+
+**Files:**
+- Modify: `test/unit/server/fresh-agent/opencode-serve-manager.test.ts`
+
+**Interfaces:**
+- Consumes: existing `OpencodeServeManager.createSession(input: { directory?: string })`
+- Produces: failing tests that require `OpencodeServeManager` to spawn serve with `cwd: input.directory`
+
+- [ ] **Step 1: Write the failing unit test for first materialization cwd**
+
+Add this test in `describe('OpencodeServeManager lifecycle', ...)` after `lazily spawns one serve, health-gates, and reuses it across ensureStarted calls`:
+
+```ts
+  it('starts the serve process in the requested session directory before creating the first session', async () => {
+    const calls: Array<{ url: string; init: any }> = []
+    const fetchFn = vi.fn(async (url: string, init: any) => {
+      calls.push({ url, init })
+      if (url.endsWith('/global/health')) return jsonResponse({ healthy: true, version: '1.17.8' })
+      if (url.endsWith('/session') && init?.method === 'POST') {
+        return jsonResponse({ id: 'ses_project_x', directory: '/project-x', title: 'Project X' })
+      }
+      return jsonResponse({})
+    })
+    const { manager, spawnFn } = makeManager({ fetchFn: fetchFn as any })
+
+    const session = await manager.createSession({ directory: '/project-x' })
+
+    expect(session).toMatchObject({ id: 'ses_project_x', directory: '/project-x' })
+    expect(spawnFn).toHaveBeenCalledWith(
+      'opencode',
+      ['serve', '--hostname', '127.0.0.1', '--port', '47999'],
+      expect.objectContaining({
+        cwd: '/project-x',
+        env: expect.objectContaining({ FRESHELL_OPENCODE_SIDECAR_ID: expect.any(String) }),
+      }),
+    )
+    expect(calls.find((call) => call.url.endsWith('/session'))).toMatchObject({
+      url: 'http://127.0.0.1:47999/session',
+      init: expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ directory: '/project-x' }),
+      }),
+    })
+  })
+```
+
+- [ ] **Step 2: Write the failing unit test for separate cwd sidecars**
+
+Add this test in the same describe block:
+
+```ts
+  it('uses separate serve processes for sessions created in different directories', async () => {
+    const childA = fakeChild()
+    const childB = fakeChild()
+    const spawnFn = vi.fn()
+      .mockReturnValueOnce(childA)
+      .mockReturnValueOnce(childB)
+    const fetchFn = vi.fn(async (url: string, init: any) => {
+      if (url === 'http://127.0.0.1:47999/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:48000/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:47999/session' && init?.method === 'POST') {
+        return jsonResponse({ id: 'ses_a', directory: '/project-a' })
+      }
+      if (url === 'http://127.0.0.1:48000/session' && init?.method === 'POST') {
+        return jsonResponse({ id: 'ses_b', directory: '/project-b' })
+      }
+      return jsonResponse({})
+    })
+    const manager = new OpencodeServeManager({
+      spawnFn: spawnFn as any,
+      fetchFn: fetchFn as any,
+      allocatePort: vi.fn()
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 47999 })
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 48000 }),
+      connectEventStream: () => () => {},
+      healthTimeoutMs: 1000,
+    })
+
+    await expect(manager.createSession({ directory: '/project-a' })).resolves.toMatchObject({ id: 'ses_a' })
+    await expect(manager.createSession({ directory: '/project-b' })).resolves.toMatchObject({ id: 'ses_b' })
+
+    expect(spawnFn).toHaveBeenCalledTimes(2)
+    expect(spawnFn).toHaveBeenNthCalledWith(
+      1,
+      'opencode',
+      ['serve', '--hostname', '127.0.0.1', '--port', '47999'],
+      expect.objectContaining({ cwd: '/project-a' }),
+    )
+    expect(spawnFn).toHaveBeenNthCalledWith(
+      2,
+      'opencode',
+      ['serve', '--hostname', '127.0.0.1', '--port', '48000'],
+      expect.objectContaining({ cwd: '/project-b' }),
+    )
+  })
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+npm run test:vitest -- --config vitest.server.config.ts test/unit/server/fresh-agent/opencode-serve-manager.test.ts --run
+```
+
+Expected: FAIL. The first new test should show `spawnFn` was called without `cwd`. The second new test should show only one spawn/port was used for both directories.
+
+- [ ] **Step 4: Commit the red tests**
+
+```bash
+git add test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+git commit -m "test: pin freshopencode serve cwd contract"
+```
+
+## Task 2: Make OpencodeServeManager Cwd-Scoped
+
+**Files:**
+- Modify: `server/fresh-agent/adapters/opencode/serve-manager.ts`
+- Test: `test/unit/server/fresh-agent/opencode-serve-manager.test.ts`
+
+**Interfaces:**
+- Consumes: `createSession(input: { title?: string; parentID?: string; directory?: string })`
+- Produces:
+  - `ensureStarted(input?: { cwd?: string }): Promise<{ baseUrl: string }>`
+  - `rememberSessionCwd(sessionId: string, cwd?: string): void`
+  - Existing public methods still work, with optional route argument where session ids need a restored cwd fallback.
+
+- [ ] **Step 1: Add cwd route types and maps**
+
+In `server/fresh-agent/adapters/opencode/serve-manager.ts`, add the `node:path` import and replace the single-running fields with cwd-keyed state:
+
+```ts
+import path from 'node:path'
+```
+
+Replace the current `RunningServe` type with:
+
+```ts
+type RunningServe = {
+  baseUrl: string
+  ownershipId: string
+  child: ChildProcessWithoutNullStreams
+  stopEventStream: () => void
+  cwdKey: string
+  cwd?: string
+}
+
+type ServeRoute = {
+  cwd?: string
+}
+
+const DEFAULT_CWD_KEY = '<inherit-process-cwd>'
+```
+
+Replace:
+
+```ts
+  private running: RunningServe | undefined
+  private startPromise: Promise<RunningServe> | undefined
+  private startAbort: AbortController | undefined
+```
+
+with:
+
+```ts
+  private readonly runningByCwd = new Map<string, RunningServe>()
+  private readonly startPromiseByCwd = new Map<string, Promise<RunningServe>>()
+  private readonly startAbortByCwd = new Map<string, AbortController>()
+  private readonly cwdByKey = new Map<string, string | undefined>()
+  private readonly sessionCwdById = new Map<string, string>()
+```
+
+- [ ] **Step 2: Add cwd normalization and session routing helpers**
+
+Add these private helpers inside `OpencodeServeManager`:
+
+```ts
+  private routeFromCwd(cwd?: string): { cwdKey: string; cwd?: string } {
+    const trimmed = typeof cwd === 'string' && cwd.trim().length > 0 ? cwd.trim() : undefined
+    if (!trimmed) return { cwdKey: DEFAULT_CWD_KEY }
+    const resolved = path.resolve(trimmed)
+    return { cwdKey: resolved, cwd: resolved }
+  }
+
+  private routeForSession(sessionId: string, fallback?: ServeRoute): { cwdKey: string; cwd?: string } {
+    const existingKey = this.sessionCwdById.get(sessionId)
+    if (existingKey) {
+      return { cwdKey: existingKey, cwd: this.cwdByKey.get(existingKey) }
+    }
+    return this.routeFromCwd(fallback?.cwd)
+  }
+
+  rememberSessionCwd(sessionId: string, cwd?: string): void {
+    if (!sessionId) return
+    const route = this.routeFromCwd(cwd)
+    this.cwdByKey.set(route.cwdKey, route.cwd)
+    this.sessionCwdById.set(sessionId, route.cwdKey)
+  }
+
+  private forgetSessionsForCwd(cwdKey: string): void {
+    for (const [sessionId, sessionCwdKey] of this.sessionCwdById.entries()) {
+      if (sessionCwdKey !== cwdKey) continue
+      this.sessionCwdById.delete(sessionId)
+      this.sessionEmitters.delete(sessionId)
+    }
+  }
+```
+
+- [ ] **Step 3: Replace `ensureStarted` and `start` with cwd-aware versions**
+
+Replace `ensureStarted()` with:
+
+```ts
+  async ensureStarted(input: ServeRoute = {}): Promise<{ baseUrl: string }> {
+    if (this.shutdownRequested) {
+      throw new Error('opencode serve manager is shutting down')
+    }
+    const route = this.routeFromCwd(input.cwd)
+    this.cwdByKey.set(route.cwdKey, route.cwd)
+    const running = this.runningByCwd.get(route.cwdKey)
+    if (running) return { baseUrl: running.baseUrl }
+    if (!this.startPromiseByCwd.has(route.cwdKey)) {
+      const promise = this.start(route).catch((err) => {
+        this.startPromiseByCwd.delete(route.cwdKey)
+        throw err
+      })
+      this.startPromiseByCwd.set(route.cwdKey, promise)
+    }
+    const next = await this.startPromiseByCwd.get(route.cwdKey)!
+    return { baseUrl: next.baseUrl }
+  }
+```
+
+Change the `start` signature and spawn options:
+
+```ts
+  private async start(route: { cwdKey: string; cwd?: string }): Promise<RunningServe> {
+    const startAbort = new AbortController()
+    this.startAbortByCwd.set(route.cwdKey, startAbort)
+    const startSignal = startAbort.signal
+    let child: ChildProcessWithoutNullStreams | undefined
+    try {
+      const endpoint = await this.allocatePort()
+      const baseUrl = `http://${endpoint.hostname}:${endpoint.port}`
+      const ownershipId = randomUUID()
+      child = this.spawnFn(
+        this.command,
+        ['serve', '--hostname', endpoint.hostname, '--port', String(endpoint.port)],
+        {
+          ...(route.cwd ? { cwd: route.cwd } : {}),
+          env: { ...process.env, [OWNERSHIP_ENV]: ownershipId },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      ) as unknown as ChildProcessWithoutNullStreams
+      child.stdout?.on('data', () => {})
+      child.stderr?.on('data', () => {})
+      child.on('error', (err) => this.log.error({ err }, 'opencode serve process error'))
+      child.on('close', (code) => {
+        this.log.warn({ code }, 'opencode serve exited')
+        const running = this.runningByCwd.get(route.cwdKey)
+        if (running && running.child === child) {
+          this.runningByCwd.delete(route.cwdKey)
+          this.startPromiseByCwd.delete(route.cwdKey)
+          this.startAbortByCwd.delete(route.cwdKey)
+          try { running.stopEventStream() } catch { /* ignore */ }
+          void killOwnedProcesses(running.child, running.ownershipId, this.log)
+          this.forgetSessionsForCwd(route.cwdKey)
+        }
+      })
+
+      await this.waitForHealth(baseUrl, child, startSignal)
+
+      if (this.shutdownRequested || startSignal.aborted) {
+        this.stopChild(child)
+        throw new Error('opencode serve startup was aborted')
+      }
+
+      const stopEventStream = this.connectEventStream
+        ? this.connectEventStream(`${baseUrl}/event`, {
+            onEvent: (e) => this.dispatchEvent(e),
+            onError: (err) => this.log.warn({ err }, 'opencode serve event stream error'),
+          })
+        : this.startDefaultEventStream(baseUrl)
+
+      const running: RunningServe = { baseUrl, ownershipId, child, stopEventStream, cwdKey: route.cwdKey, cwd: route.cwd }
+      this.runningByCwd.set(route.cwdKey, running)
+      return running
+    } catch (err) {
+      if (child) this.stopChild(child)
+      this.startPromiseByCwd.delete(route.cwdKey)
+      throw err
+    } finally {
+      if (this.startAbortByCwd.get(route.cwdKey) === startAbort) this.startAbortByCwd.delete(route.cwdKey)
+    }
+  }
+```
+
+- [ ] **Step 4: Route HTTP helpers by cwd or session id**
+
+Replace `requireBase` and `json` with:
+
+```ts
+  private async requireBase(input: ServeRoute & { sessionId?: string } = {}): Promise<string> {
+    const route = input.sessionId
+      ? this.routeForSession(input.sessionId, input)
+      : this.routeFromCwd(input.cwd)
+    const { baseUrl } = await this.ensureStarted({ cwd: route.cwd })
+    return baseUrl
+  }
+
+  private async json<T>(
+    route: ServeRoute & { sessionId?: string },
+    requestPath: string,
+    init?: RequestInit & { notFoundValue?: T },
+  ): Promise<T> {
+    const base = await this.requireBase(route)
+    const res = await this.fetchFn(`${base}${requestPath}`, init)
+    if (!res.ok && res.status !== 204) {
+      if (res.status === 404 && init?.notFoundValue !== undefined) return init.notFoundValue
+      const text = await res.text().catch(() => '')
+      throw new Error(`opencode serve ${init?.method ?? 'GET'} ${requestPath} → ${res.status} ${text}`)
+    }
+    if (res.status === 204) return undefined as T
+    return (await res.json()) as T
+  }
+```
+
+Update each caller:
+
+```ts
+  async createSession(input: { title?: string; parentID?: string; directory?: string } = {}): Promise<{ id: string; directory?: string; title?: string }> {
+    const body: { title?: string; parentID?: string; directory?: string } = {}
+    if (input.title !== undefined) body.title = input.title
+    if (input.parentID !== undefined) body.parentID = input.parentID
+    if (input.directory !== undefined) body.directory = input.directory
+    const session = await this.json<{ id: string; directory?: string; title?: string }>(
+      { cwd: input.directory },
+      '/session',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    )
+    if (typeof session.id === 'string') this.rememberSessionCwd(session.id, input.directory)
+    return session
+  }
+
+  async getSession(id: string, route: ServeRoute = {}): Promise<Record<string, any>> {
+    return this.json({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}`, { method: 'GET' })
+  }
+
+  async promptAsync(
+    id: string,
+    body: { parts: Array<Record<string, unknown>>; model?: { providerID: string; modelID: string }; variant?: string; agent?: string },
+    route: ServeRoute = {},
+  ): Promise<void> {
+    await this.json({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}/prompt_async`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  async getMessage(id: string, messageId: string, route: ServeRoute = {}): Promise<OpencodeServeMessage | null> {
+    return this.json<OpencodeServeMessage | null>(
+      { ...route, sessionId: id },
+      `/session/${encodeURIComponent(id)}/message/${encodeURIComponent(messageId)}`,
+      { method: 'GET', notFoundValue: null },
+    )
+  }
+
+  async abort(id: string, route: ServeRoute = {}): Promise<void> {
+    await this.json({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}/abort`, { method: 'POST' })
+  }
+
+  async compact(id: string, body?: { instructions?: string }, route: ServeRoute = {}): Promise<void> {
+    await this.json({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}/compact`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body ?? {}),
+    })
+  }
+
+  async fork(id: string, route: ServeRoute = {}): Promise<{ id: string }> {
+    const child = await this.json<{ id: string }>({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}/fork`, { method: 'POST' })
+    if (typeof child.id === 'string') {
+      const parentRoute = this.routeForSession(id, route)
+      this.rememberSessionCwd(child.id, parentRoute.cwd)
+    }
+    return child
+  }
+```
+
+Update `listMessages`:
+
+```ts
+  async listMessages(id: string, query: { limit?: number; before?: string }, route: ServeRoute = {}): Promise<OpencodeServeMessagePage> {
+    const base = await this.requireBase({ ...route, sessionId: id })
+    const params = new URLSearchParams()
+    if (typeof query.limit === 'number') params.set('limit', String(query.limit))
+    if (query.before) params.set('before', query.before)
+    const qs = params.toString()
+    const url = `${base}/session/${encodeURIComponent(id)}/message${qs ? `?${qs}` : ''}`
+    const res = await this.fetchFn(url, { method: 'GET' })
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new Error(`opencode serve GET messages → ${res.status} ${text}`)
+    }
+    const messages = (await res.json()) as OpencodeServeMessage[]
+    const nextCursor = res.headers.get('x-next-cursor') || null
+    return { messages: Array.isArray(messages) ? messages : [], nextCursor }
+  }
+```
+
+- [ ] **Step 5: Update shutdown and inspection behavior**
+
+Replace `shutdown()` with:
+
+```ts
+  async shutdown(): Promise<void> {
+    this.shutdownRequested = true
+    for (const controller of this.startAbortByCwd.values()) {
+      controller.abort()
+    }
+
+    const starts = [...this.startPromiseByCwd.values()]
+    if (starts.length > 0) {
+      await Promise.all(starts.map(async (promise) => {
+        try { await promise } catch { /* ignore startup errors */ }
+      }))
+      this.startPromiseByCwd.clear()
+    }
+
+    const running = [...this.runningByCwd.values()]
+    this.runningByCwd.clear()
+    this.startPromiseByCwd.clear()
+    this.startAbortByCwd.clear()
+    await Promise.all(running.map(async (entry) => {
+      try { entry.stopEventStream() } catch { /* ignore */ }
+      await killOwnedProcesses(entry.child, entry.ownershipId, this.log)
+    }))
+    this.sessionEmitters.clear()
+    this.sessionCwdById.clear()
+    this.cwdByKey.clear()
+  }
+
+  /** @internal test/inspection accessor */
+  get baseUrlOrUndefined(): string | undefined {
+    return [...this.runningByCwd.values()][0]?.baseUrl
+  }
+```
+
+- [ ] **Step 6: Update existing tests for private state names**
+
+In `test/unit/server/fresh-agent/opencode-serve-manager.test.ts`, replace assertions that inspect `(manager as any).running` and `(manager as any).startPromise`:
+
+```ts
+    expect((manager as any).runningByCwd.size).toBe(0)
+    expect((manager as any).startPromiseByCwd.size).toBe(0)
+```
+
+Replace the child-exit cleanup test assertions:
+
+```ts
+    expect((manager as any).sessionEmitters.size).toBe(0)
+    expect((manager as any).runningByCwd.size).toBe(0)
+```
+
+- [ ] **Step 7: Run tests to verify the manager change**
+
+Run:
+
+```bash
+npm run test:vitest -- --config vitest.server.config.ts test/unit/server/fresh-agent/opencode-serve-manager.test.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the manager implementation**
+
+```bash
+git add server/fresh-agent/adapters/opencode/serve-manager.ts test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+git commit -m "fix: scope opencode serve processes by cwd"
+```
+
+## Task 3: Route Adapter Operations With Preserved Cwd
+
+**Files:**
+- Modify: `server/fresh-agent/adapters/opencode/adapter.ts`
+- Modify: `test/unit/server/fresh-agent/opencode-serve-adapter.test.ts`
+
+**Interfaces:**
+- Consumes:
+  - `OpencodeServeManager.rememberSessionCwd(sessionId: string, cwd?: string): void`
+  - Optional route arguments on `getSession`, `listMessages`, `getMessage`, `promptAsync`, `abort`, `compact`, and `fork`
+- Produces: restored or attached freshopencode sessions use their pane cwd when the manager has not seen their session id yet.
+
+- [ ] **Step 1: Extend the fake manager test double**
+
+In `test/unit/server/fresh-agent/opencode-serve-adapter.test.ts`, add `rememberSessionCwd` to `makeFakeManager()`:
+
+```ts
+    rememberSessionCwd: vi.fn(),
+```
+
+Then update `FakeManager` automatically through the existing `ReturnType`.
+
+- [ ] **Step 2: Add failing test for attach cwd registration**
+
+Add this test in `describe('OpenCode serve adapter: history reads', ...)` before `getSnapshot assembles HTTP messages into the normalized transcript`:
+
+```ts
+  it('remembers cwd when attaching a durable OpenCode session', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+
+    await adapter.attach?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      sessionId: 'ses_existing_cwd',
+      cwd: '/repo/from-pane',
+    })
+
+    expect(manager.rememberSessionCwd).toHaveBeenCalledWith('ses_existing_cwd', '/repo/from-pane')
+  })
+```
+
+- [ ] **Step 3: Add failing test for restored send cwd routing**
+
+Add this test in `describe('OpenCode serve adapter: create + send', ...)`:
+
+```ts
+  it('passes restored cwd when sending to an attached durable session', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+
+    await adapter.attach?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      sessionId: 'ses_attached_send',
+      cwd: '/repo/restored-worktree',
+    })
+    await adapter.send?.('ses_attached_send', { text: 'continue' })
+
+    expect(manager.promptAsync).toHaveBeenCalledWith(
+      'ses_attached_send',
+      { parts: [{ type: 'text', text: 'continue' }] },
+      { cwd: '/repo/restored-worktree' },
+    )
+  })
+```
+
+- [ ] **Step 4: Run adapter tests to verify failure**
+
+Run:
+
+```bash
+npm run test:vitest -- --config vitest.server.config.ts test/unit/server/fresh-agent/opencode-serve-adapter.test.ts --run
+```
+
+Expected: FAIL. The first new test should show `rememberSessionCwd` was not called. The second should show `promptAsync` was called without the route argument.
+
+- [ ] **Step 5: Implement adapter cwd propagation**
+
+In `server/fresh-agent/adapters/opencode/adapter.ts`, add these helpers near `sendResult`:
+
+```ts
+  function cwdRoute(cwd?: string): { cwd?: string } | undefined {
+    return typeof cwd === 'string' && cwd.trim().length > 0 ? { cwd } : undefined
+  }
+
+  async function promptAsyncForState(
+    state: OpencodeSessionState,
+    realId: string,
+    body: Parameters<OpencodeServeManager['promptAsync']>[1],
+  ): Promise<void> {
+    const route = cwdRoute(state.cwd)
+    if (route) {
+      await serveManager.promptAsync(realId, body, route)
+      return
+    }
+    await serveManager.promptAsync(realId, body)
+  }
+
+  async function abortForState(state: OpencodeSessionState): Promise<void> {
+    if (!state.realSessionId) return
+    const route = cwdRoute(state.cwd)
+    if (route) {
+      await serveManager.abort(state.realSessionId, route)
+      return
+    }
+    await serveManager.abort(state.realSessionId)
+  }
+
+  async function compactForState(state: OpencodeSessionState, input?: { instructions?: string }): Promise<void> {
+    if (!state.realSessionId) return
+    const route = cwdRoute(state.cwd)
+    if (route) {
+      await serveManager.compact(state.realSessionId, input, route)
+      return
+    }
+    await serveManager.compact(state.realSessionId, input)
+  }
+
+  async function forkForState(state: OpencodeSessionState): Promise<{ id: string }> {
+    if (!state.realSessionId) throw new FreshAgentLostSessionError(`OpenCode session ${state.placeholderId} has not materialized; cannot fork.`)
+    const route = cwdRoute(state.cwd)
+    return route
+      ? await serveManager.fork(state.realSessionId, route)
+      : await serveManager.fork(state.realSessionId)
+  }
+```
+
+Update `materializeOrSend` prompt call:
+
+```ts
+      await promptAsyncForState(state, realId, {
+        parts: [{ type: 'text', text }],
+        ...(splitOpencodeModel(modelStr) ? { model: splitOpencodeModel(modelStr)! } : {}),
+        ...(effort ? { variant: effort } : {}),
+      })
+```
+
+Update `assembleExport` signature and calls:
+
+```ts
+  async function assembleExport(
+    realSessionId: string,
+    query: { limit?: number; before?: string },
+    route: { cwd?: string } = {},
+  ): Promise<{ exported: OpencodeExport; nextCursor: string | null; revision: number }> {
+    const [session, page] = await Promise.all([
+      serveManager.getSession(realSessionId, route).then(
+        (session) => session,
+        () => ({} as Record<string, unknown>),
+      ),
+      serveManager.listMessages(realSessionId, query, route),
+    ])
+    const sessionTime = session && typeof session === 'object' ? session.time : undefined
+    const sessionTimeUpdated = sessionTime && typeof sessionTime === 'object' && !Array.isArray(sessionTime)
+      ? (sessionTime as Record<string, unknown>).updated
+      : undefined
+    const revision = Number.isFinite(Number(sessionTimeUpdated)) ? Number(sessionTimeUpdated) : page.messages.length
+    const exported: OpencodeExport = {
+      info: { id: realSessionId, ...(session ?? {}) },
+      messages: page.messages.map((m) => ({ info: m.info, parts: m.parts })),
+    }
+    return { exported, nextCursor: page.nextCursor, revision }
+  }
+```
+
+Update `attach(locator)`:
+
+```ts
+    async attach(locator) {
+      const existing = sessions.get(locator.sessionId)
+      if (existing) {
+        if (locator.cwd) {
+          existing.cwd = locator.cwd
+          if (existing.realSessionId) serveManager.rememberSessionCwd(existing.realSessionId, locator.cwd)
+        }
+        remember(existing)
+        return { sessionId: locator.sessionId, sessionRef: { provider: 'opencode', sessionId: locator.sessionId } }
+      }
+      if (isPlaceholderOpencodeSessionId(locator.sessionId) || !isRealOpencodeSessionId(locator.sessionId)) {
+        throw new FreshAgentLostSessionError(`OpenCode session ${locator.sessionId} is not a durable OpenCode session.`)
+      }
+      const state: OpencodeSessionState = {
+        placeholderId: locator.sessionId,
+        realSessionId: locator.sessionId,
+        cwd: locator.cwd,
+        status: 'idle',
+        events: new EventEmitter(),
+        sendQueue: Promise.resolve(),
+      }
+      if (locator.cwd) serveManager.rememberSessionCwd(locator.sessionId, locator.cwd)
+      remember(state)
+      bindServeStream(state)
+      return { sessionId: locator.sessionId, sessionRef: { provider: 'opencode', sessionId: locator.sessionId } }
+    },
+```
+
+Update control methods:
+
+```ts
+      await abortForState(state).catch((err) => log.warn({ err }, 'abort failed'))
+```
+
+```ts
+        () => compactForState(state, hasInstructions ? { instructions } : undefined),
+        () => compactForState(state, hasInstructions ? { instructions } : undefined),
+```
+
+```ts
+      const child = await forkForState(state)
+```
+
+Update history calls:
+
+```ts
+      const { exported, revision } = await assembleExport(realId, { limit: DEFAULT_SNAPSHOT_TURN_LIMIT }, { cwd: liveState?.cwd ?? thread.cwd })
+```
+
+```ts
+      const { exported, nextCursor, revision } = await assembleExport(realId, {
+        limit: typeof query.limit === 'number' ? query.limit : DEFAULT_SNAPSHOT_TURN_LIMIT,
+        before: typeof query.cursor === 'string' ? query.cursor : undefined,
+      }, { cwd: liveState?.cwd ?? thread.cwd })
+```
+
+```ts
+      const message = await serveManager.getMessage(realId, thread.turnId, { cwd: liveState?.cwd ?? thread.cwd })
+```
+
+- [ ] **Step 6: Update existing adapter expectations for cwd-aware calls**
+
+In `test/unit/server/fresh-agent/opencode-serve-adapter.test.ts`, update the first test's `promptAsync` expectation because that pane was created with `cwd: '/repo'`:
+
+```ts
+    expect(manager.promptAsync).toHaveBeenCalledWith('ses_real_1', {
+      parts: [{ type: 'text', text: 'reply ok' }],
+      model: { providerID: 'umans-ai-coding-plan', modelID: 'umans-kimi-k2.7' },
+      variant: 'high',
+    }, { cwd: '/repo' })
+```
+
+Leave no-cwd expectations as two-argument calls; the helper above deliberately does not pass a third `{}` argument when no cwd is known.
+
+- [ ] **Step 7: Run adapter tests**
+
+Run:
+
+```bash
+npm run test:vitest -- --config vitest.server.config.ts test/unit/server/fresh-agent/opencode-serve-adapter.test.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit adapter routing**
+
+```bash
+git add server/fresh-agent/adapters/opencode/adapter.ts test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+git commit -m "fix: route freshopencode operations with pane cwd"
+```
+
+## Task 4: Add Real No-LLM Regression Coverage
+
+**Files:**
+- Modify: `test/integration/server/opencode-serve-real-provider-smoke.test.ts`
+
+**Interfaces:**
+- Consumes: real `opencode` binary if available.
+- Produces: a no-LLM regression proving OpenCode stores new session `directory` as the selected cwd even when Freshell process cwd is different.
+
+- [ ] **Step 1: Add imports for temporary directories and SQLite**
+
+At the top of `test/integration/server/opencode-serve-real-provider-smoke.test.ts`, add:
+
+```ts
+import { DatabaseSync } from 'node:sqlite'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+```
+
+- [ ] **Step 2: Add helper to read OpenCode session directory**
+
+Add below the `describeReal` constant:
+
+```ts
+function readOpencodeSessionDirectory(dbPath: string, sessionId: string): string | undefined {
+  const db = new DatabaseSync(dbPath)
+  try {
+    const row = db.prepare('select directory from session where id = ? limit 1').get(sessionId) as { directory?: string } | null
+    return row?.directory
+  } finally {
+    db.close()
+  }
+}
+```
+
+- [ ] **Step 3: Add no-LLM cwd regression test**
+
+Add this test inside `describe('OpencodeServeManager lifecycle', ...)`:
+
+```ts
+      it('creates first-run sessions in the requested cwd, not the Freshell process cwd', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-opencode-real-cwd-'))
+        const requestedCwd = path.join(root, 'requested-project')
+        const dataHome = path.join(root, 'xdg-data')
+        const configHome = path.join(root, 'xdg-config')
+        await Promise.all([
+          fs.mkdir(requestedCwd, { recursive: true }),
+          fs.mkdir(dataHome, { recursive: true }),
+          fs.mkdir(configHome, { recursive: true }),
+        ])
+        const previousDataHome = process.env.XDG_DATA_HOME
+        const previousConfigHome = process.env.XDG_CONFIG_HOME
+        process.env.XDG_DATA_HOME = dataHome
+        process.env.XDG_CONFIG_HOME = configHome
+        const manager = new OpencodeServeManager()
+        try {
+          const session = await manager.createSession({ directory: requestedCwd })
+          expect(session.id).toMatch(/^ses_/)
+          expect(session.directory).toBe(requestedCwd)
+
+          const dbPath = path.join(dataHome, 'opencode', 'opencode.db')
+          expect(readOpencodeSessionDirectory(dbPath, session.id)).toBe(requestedCwd)
+        } finally {
+          await manager.shutdown()
+          if (previousDataHome === undefined) delete process.env.XDG_DATA_HOME
+          else process.env.XDG_DATA_HOME = previousDataHome
+          if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME
+          else process.env.XDG_CONFIG_HOME = previousConfigHome
+          await fs.rm(root, { recursive: true, force: true })
+        }
+      }, 60_000)
+```
+
+- [ ] **Step 4: Run real-provider smoke test**
+
+Run:
+
+```bash
+npm run test:vitest -- --config vitest.server.config.ts test/integration/server/opencode-serve-real-provider-smoke.test.ts --run
+```
+
+Expected when `opencode` is installed: PASS. Expected when `opencode` is unavailable: suite reports skipped tests, not failure.
+
+- [ ] **Step 5: Commit real regression coverage**
+
+```bash
+git add test/integration/server/opencode-serve-real-provider-smoke.test.ts
+git commit -m "test: cover freshopencode real cwd materialization"
+```
+
+## Task 5: Focused And Broad Verification
+
+**Files:**
+- No code changes.
+
+**Interfaces:**
+- Consumes: completed Tasks 1-4.
+- Produces: verified branch ready for review/PR.
+
+- [ ] **Step 1: Run focused freshopencode tests**
+
+Run:
+
+```bash
+npm run test:vitest -- --config vitest.server.config.ts test/unit/server/fresh-agent/opencode-serve-manager.test.ts test/unit/server/fresh-agent/opencode-serve-adapter.test.ts test/integration/server/opencode-serve-real-provider-smoke.test.ts --run
+```
+
+Expected: PASS, or real-provider smoke skipped only if `opencode` is unavailable.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run coordinated full check**
+
+Run:
+
+```bash
+FRESHELL_TEST_SUMMARY="verify freshopencode cwd-scoped serve fix" npm run check
+```
+
+Expected: PASS. If another agent holds the coordinator gate, wait for the coordinated run instead of killing the holder.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git log --oneline -5
+```
+
+Expected:
+- `git diff --check` has no output.
+- `git status --short` shows only intended files before the final commit, or clean after the final commit.
+- Recent commits are the focused task commits from this plan.
+
+- [ ] **Step 5: Commit final verification note if any files changed**
+
+If no files changed during verification, do not create an empty commit. If a test-only adjustment was needed, commit it:
+
+```bash
+git add server/fresh-agent/adapters/opencode/serve-manager.ts server/fresh-agent/adapters/opencode/adapter.ts test/unit/server/fresh-agent/opencode-serve-manager.test.ts test/unit/server/fresh-agent/opencode-serve-adapter.test.ts test/integration/server/opencode-serve-real-provider-smoke.test.ts
+git commit -m "chore: finalize freshopencode cwd-scoped serve"
+```
+
+## Self-Review
+
+- Spec coverage: The plan covers first-run freshopencode cwd, real OpenCode behavior, the manager architecture that caused the bug, restored/attached session routing, sidecar cleanup, and broad verification.
+- Placeholder scan: No task uses `TBD`, `TODO`, `implement later`, or a generic “write tests” instruction without concrete test code.
+- Type consistency: `ServeRoute`, `rememberSessionCwd`, and the optional route arguments are introduced in Task 2 and consumed by Task 3 with the same names and shapes.

--- a/docs/superpowers/plans/2026-06-19-freshopencode-cwd-scoped-serve.md
+++ b/docs/superpowers/plans/2026-06-19-freshopencode-cwd-scoped-serve.md
@@ -18,6 +18,27 @@
 - Keep behavior changes on this dedicated worktree branch and commit focused, atomic changes.
 - Prefer integration/end-to-end tests that prove the user-visible contract.
 
+## Load-Bearing Validation Amendments
+
+These amendments supersede any conflicting task text below:
+
+- OpenCode 1.17.8 uses persisted `session.directory` as the execution/tool cwd for existing session-scoped operations. Fixing session creation directory is the critical user-visible fix.
+- Existing session-scoped operations can be sent through any healthy serve process because OpenCode loads the session row and routes by stored `directory`; cwd routing is still useful when Freshell already knows cwd, but restored no-cwd paths must remain valid through the default route.
+- Freshopencode cannot assume every restored/attached durable session has pane cwd available. When cwd is missing, do not fail the operation; use the default serve route for existing session endpoints, and remember cwd if a later `getSession` or `fork` response exposes a `directory`.
+- OpenCode 1.17.8 does not expose a JSON `/session/:id/compact` endpoint. Freshell compaction must call the current `/session/:id/summarize` route.
+- A sidecar per cwd must not live forever by default. Add a configurable idle shutdown timer for non-default cwd-scoped sidecars and cancel/reschedule it around operations.
+- Project-local OpenCode config is intentionally selected by the user's cwd. Preserve inherited global credentials/config environment, but expect provider/model/project config to vary by selected cwd.
+
+Implementation updates required by this amendment:
+
+- In `OpencodeServeManager`, add an optional constructor setting such as `idleShutdownMs` and default it to a nonzero idle timeout for cwd-scoped sidecars. Tests may set it to `0` or a small value.
+- Do not route an existing session with unknown cwd to a guessed project cwd. Use the default serve route and let OpenCode's session middleware route by stored `directory`.
+- When `getSession()` or `fork()` returns a `directory`, call `rememberSessionCwd()` for that session id.
+- Change `compact()` to POST `/session/:id/summarize`.
+- Add manager tests for `/summarize`, no-cwd restored-session routing through the default serve, returned-directory remembering, and idle sidecar shutdown.
+- Add adapter tests for both known-cwd restored sends and no-cwd restored sends. The no-cwd case should call manager methods without a third `{ cwd }` argument.
+- In the real-provider regression, prefer the existing isolated real-session harness helpers so `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, and DB path are temp-scoped and the suite remains single-threaded.
+
 ---
 
 ## File Structure

--- a/docs/superpowers/plans/2026-06-19-freshopencode-cwd-scoped-serve.md
+++ b/docs/superpowers/plans/2026-06-19-freshopencode-cwd-scoped-serve.md
@@ -31,6 +31,7 @@ These amendments supersede any conflicting task text below:
 
 Implementation updates required by this amendment:
 
+- Treat concrete code snippets later in this plan as subordinate to this section. If a snippet still calls `/compact`, omits idle shutdown, forgets returned `directory`, or unconditionally passes `{ cwd: undefined }`, implement the corrected behavior below instead.
 - In `OpencodeServeManager`, add an optional constructor setting such as `idleShutdownMs` and default it to a nonzero idle timeout for cwd-scoped sidecars. Tests may set it to `0` or a small value.
 - Do not route an existing session with unknown cwd to a guessed project cwd. Use the default serve route and let OpenCode's session middleware route by stored `directory`.
 - When `getSession()` or `fork()` returns a `directory`, call `rememberSessionCwd()` for that session id.
@@ -38,6 +39,24 @@ Implementation updates required by this amendment:
 - Add manager tests for `/summarize`, no-cwd restored-session routing through the default serve, returned-directory remembering, and idle sidecar shutdown.
 - Add adapter tests for both known-cwd restored sends and no-cwd restored sends. The no-cwd case should call manager methods without a third `{ cwd }` argument.
 - In the real-provider regression, prefer the existing isolated real-session harness helpers so `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, and DB path are temp-scoped and the suite remains single-threaded.
+
+Task-level override checklist:
+
+- Task 2 must update `OpencodeServeManagerOptions`, `RunningServe`, `ensureStarted`, `start`, HTTP helpers, `shutdown`, and child-close cleanup for cwd-scoped sidecars. On child close, delete emitters for sessions mapped to that cwd; when the closing sidecar is the default route, also delete unmapped emitters, because no-cwd restored sessions use the default route.
+- Task 2 must clear successful `startPromiseByCwd` entries after a sidecar has moved into `runningByCwd`.
+- Task 2 must add tests proving:
+  - `createSession({ directory })` spawns `opencode serve` with that `cwd`.
+  - different directories get different sidecars/ports.
+  - `compact()` posts to `/session/:id/summarize`.
+  - `getSession()` remembers a returned `directory`.
+  - `fork()` remembers the returned child `directory`, not just the parent route.
+  - existing-session calls with no known cwd use the default serve route.
+  - default sidecar close clears unmapped emitters, while non-default sidecar close only clears emitters for sessions mapped to that cwd.
+  - idle shutdown stops non-default sidecars after the configured timeout and does not stop the default sidecar.
+- Task 3 must update `makeFakeManager().createSession` so it returns `directory: input.directory` only when a test actually created the pane with cwd, or else update every existing arity-strict manager expectation affected by the new route argument. Do not leave tests with a fake manager that always returns `/repo` while claiming no-cwd calls stay two-argument.
+- Task 3 must ensure helper calls omit the route argument entirely when no cwd is known. History helpers must not pass `{ cwd: undefined }`.
+- Task 3 must update all existing adapter expectations affected by known cwd routing, including `promptAsync`, `abort`, `compact`, `fork`, `getSession`, `listMessages`, and `getMessage`.
+- Task 4 must avoid a static top-level `node:sqlite` import in the real-provider smoke. Use existing helper functions such as `seedOpencodeHomes()` and `waitForOpencodeDbSession()` or the same dynamic/read-only pattern already used by OpenCode history code.
 
 ---
 

--- a/server/agent-api/router.ts
+++ b/server/agent-api/router.ts
@@ -87,7 +87,7 @@ const FRESH_AGENT_SEND_IDLE_TIMEOUT_MS = 600_000
 
 async function waitForFreshAgentIdle(
   runtimeManager: NonNullable<FreshAgentRuntimeManagerLike>,
-  locator: { sessionType: string; provider: string; threadId: string },
+  locator: { sessionType: string; provider: string; threadId: string; cwd?: string },
   deadline: number,
 ): Promise<{ status: string; deadlineMissed: boolean }> {
   while (Date.now() < deadline) {
@@ -97,6 +97,25 @@ async function waitForFreshAgentIdle(
     await new Promise((r) => setTimeout(r, 200))
   }
   return { status: 'unknown', deadlineMissed: true }
+}
+
+function freshAgentPaneCwd(content: Record<string, unknown>): string | undefined {
+  const cwd = content.initialCwd
+  return typeof cwd === 'string' && cwd.trim().length > 0 ? cwd : undefined
+}
+
+function freshAgentPaneSendSettings(content: Record<string, unknown>): Record<string, unknown> | undefined {
+  const settings = {
+    cwd: freshAgentPaneCwd(content),
+    model: typeof content.model === 'string' && content.model.trim().length > 0 ? content.model : undefined,
+    permissionMode: typeof content.permissionMode === 'string' && content.permissionMode.trim().length > 0
+      ? content.permissionMode
+      : undefined,
+    sandbox: typeof content.sandbox === 'string' && content.sandbox.trim().length > 0 ? content.sandbox : undefined,
+    effort: typeof content.effort === 'string' && content.effort.trim().length > 0 ? content.effort : undefined,
+  }
+  const defined = Object.fromEntries(Object.entries(settings).filter(([, value]) => value !== undefined))
+  return Object.keys(defined).length > 0 ? defined : undefined
 }
 
 function combineWithCleanupError(primary: unknown, cleanupError: unknown): Error {
@@ -883,7 +902,12 @@ export function createAgentApiRouter({
       const c = paneSnapshot.paneContent || {}
       if (!freshAgentRuntimeManager) return res.status(503).json(fail('fresh-agent runtime not available on this server'))
       try {
-        const snapshot = await freshAgentRuntimeManager.getSnapshot({ sessionType: c.sessionType, provider: c.provider, threadId: c.sessionId })
+        const snapshot = await freshAgentRuntimeManager.getSnapshot({
+          sessionType: c.sessionType,
+          provider: c.provider,
+          threadId: c.sessionId,
+          cwd: freshAgentPaneCwd(c),
+        })
         return res.type('text/plain').send(renderFreshAgentTranscript(snapshot))
       } catch (err: any) {
         return res.status(agentRouteErrorStatus(err)).json(fail(err?.message || 'fresh-agent capture failed'))
@@ -938,7 +962,12 @@ export function createAgentApiRouter({
       while (true) {
         let status: string | undefined
         try {
-          const snap = await freshAgentRuntimeManager.getSnapshot({ sessionType: c.sessionType, provider: c.provider, threadId: c.sessionId })
+          const snap = await freshAgentRuntimeManager.getSnapshot({
+            sessionType: c.sessionType,
+            provider: c.provider,
+            threadId: c.sessionId,
+            cwd: freshAgentPaneCwd(c),
+          })
           status = snap?.status
         } catch (err) {
           return res.status(freshAgentErrorStatus(err)).json(fail(errorMessage(err)))
@@ -1638,9 +1667,24 @@ export function createAgentApiRouter({
       const text = String(req.body?.data ?? req.body?.keys ?? req.body?.text ?? '')
       if (!text) return res.status(400).json(fail('text is required'))
       if (!freshAgentRuntimeManager) return res.status(503).json(fail('fresh-agent runtime not available on this server'))
-      const locator = { sessionId: c.sessionId as string, sessionType: c.sessionType as string, provider: c.provider as string } as FreshAgentSessionLocator
-      const runSend = () => freshAgentRuntimeManager.send(locator, { text })
-      const snapshotLocator = { sessionType: c.sessionType as string, provider: c.provider as string, threadId: c.sessionId as string }
+      const cwd = freshAgentPaneCwd(c)
+      const settings = freshAgentPaneSendSettings(c)
+      const locator = {
+        sessionId: c.sessionId as string,
+        sessionType: c.sessionType as string,
+        provider: c.provider as string,
+        ...(cwd ? { cwd } : {}),
+      } as FreshAgentSessionLocator
+      const runSend = () => freshAgentRuntimeManager.send(locator, {
+        text,
+        ...(settings ? { settings } : {}),
+      })
+      const snapshotLocator = {
+        sessionType: c.sessionType as string,
+        provider: c.provider as string,
+        threadId: c.sessionId as string,
+        ...(cwd ? { cwd } : {}),
+      }
       try {
         let result
         try {

--- a/server/fresh-agent/adapters/codex/adapter.ts
+++ b/server/fresh-agent/adapters/codex/adapter.ts
@@ -186,6 +186,32 @@ export function createCodexFreshAgentAdapter(deps: {
   const runtimeResumeGenerationByThread = new Map<string, number>()
   const modelByTurnByThread = new Map<string, Map<string, string>>()
 
+  const rememberThreadSettings = (
+    threadId: string,
+    settings?: Partial<FreshAgentCreateRequest>,
+  ): Partial<FreshAgentCreateRequest> | undefined => {
+    if (!settings) return settingsByThread.get(threadId)
+    const definedSettings = Object.fromEntries(
+      Object.entries(settings).filter(([, value]) => value !== undefined),
+    ) as Partial<FreshAgentCreateRequest>
+    if (Object.keys(definedSettings).length === 0) return settingsByThread.get(threadId)
+    const merged = {
+      ...settingsByThread.get(threadId),
+      ...definedSettings,
+    }
+    settingsByThread.set(threadId, merged)
+    return merged
+  }
+
+  const settingsFromLocator = (
+    locator: { sessionType?: FreshAgentCreateRequest['sessionType']; cwd?: string },
+  ): Partial<FreshAgentCreateRequest> | undefined => {
+    const cwd = typeof locator.cwd === 'string' && locator.cwd.trim().length > 0
+      ? locator.cwd
+      : undefined
+    return cwd ? { sessionType: locator.sessionType, cwd } : undefined
+  }
+
   const rememberRuntimeThread = (threadId: string, runtime: CodexRuntimePort) => {
     runtimeByThread.set(threadId, runtime)
     const threadIds = threadIdsByRuntime.get(runtime) ?? new Set<string>()
@@ -228,6 +254,7 @@ export function createCodexFreshAgentAdapter(deps: {
   }
 
   const ensureRuntime = async (sessionId: string, settings?: Partial<FreshAgentCreateRequest>): Promise<CodexRuntimePort> => {
+    const effectiveSettings = rememberThreadSettings(sessionId, settings)
     const existing = getExistingRuntime(sessionId)
     if (existing) return existing
     const inflight = runtimeResumeByThread.get(sessionId)
@@ -245,14 +272,14 @@ export function createCodexFreshAgentAdapter(deps: {
     }
     resumePromise = (async () => {
       try {
-        const resumed = await runtime.resumeThread(toCodexResumeInput(sessionId, settings))
+        const resumed = await runtime.resumeThread(toCodexResumeInput(sessionId, effectiveSettings))
         if ((runtimeResumeGenerationByThread.get(sessionId) ?? 0) !== resumeGeneration) {
           await discardOwnedRuntime()
           throw new Error(`Codex app-server runtime resume was cancelled for freshcodex session ${sessionId}.`)
         }
         rememberRuntimeThread(resumed.threadId, runtime)
-        if (settings) {
-          settingsByThread.set(resumed.threadId, settings)
+        if (effectiveSettings) {
+          settingsByThread.set(resumed.threadId, effectiveSettings)
         }
         return runtime
       } catch (error) {
@@ -335,8 +362,13 @@ export function createCodexFreshAgentAdapter(deps: {
       return { sessionId: resumed.threadId, sessionRef: { provider: 'codex', sessionId: resumed.threadId } }
     },
 
+    attach(locator) {
+      rememberThreadSettings(locator.sessionId, settingsFromLocator(locator))
+      return { sessionId: locator.sessionId, sessionRef: { provider: 'codex', sessionId: locator.sessionId } }
+    },
+
     async subscribe(sessionId, listener) {
-      const runtime = await ensureRuntime(sessionId)
+      const runtime = await ensureRuntime(sessionId, settingsByThread.get(sessionId))
       if (!runtime.onThreadLifecycle) {
         throw new Error('Codex app-server runtime does not support thread lifecycle subscriptions.')
       }
@@ -477,7 +509,10 @@ export function createCodexFreshAgentAdapter(deps: {
     },
 
     async getSnapshot(thread, revision) {
-      const runtime = await ensureRuntime(thread.threadId)
+      const runtime = await ensureRuntime(
+        thread.threadId,
+        settingsFromLocator(thread) ?? settingsByThread.get(thread.threadId),
+      )
       let rawSnapshot: Record<string, any>
       try {
         rawSnapshot = await runtime.readThread({ threadId: thread.threadId, includeTurns: true })
@@ -515,7 +550,10 @@ export function createCodexFreshAgentAdapter(deps: {
     },
 
     async getTurnPage(thread, query) {
-      const runtime = await ensureRuntime(thread.threadId)
+      const runtime = await ensureRuntime(
+        thread.threadId,
+        settingsFromLocator(thread) ?? settingsByThread.get(thread.threadId),
+      )
       const rawPage = await runtime.listThreadTurns({
         threadId: thread.threadId,
         cursor: typeof query.cursor === 'string' ? query.cursor : undefined,
@@ -531,7 +569,10 @@ export function createCodexFreshAgentAdapter(deps: {
     },
 
     async getTurnBody(thread, revision) {
-      const runtime = await ensureRuntime(thread.threadId)
+      const runtime = await ensureRuntime(
+        thread.threadId,
+        settingsFromLocator(thread) ?? settingsByThread.get(thread.threadId),
+      )
       const rawTurn = await runtime.readThreadTurn({
         threadId: thread.threadId,
         turnId: thread.turnId,

--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -86,6 +86,57 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
     return sessionId ? { sessionId, sessionRef: { provider: 'opencode', sessionId } } : undefined
   }
 
+  function cwdRoute(cwd?: string): { cwd: string } | undefined {
+    return typeof cwd === 'string' && cwd.trim().length > 0 ? { cwd } : undefined
+  }
+
+  async function promptAsyncForState(
+    state: OpencodeSessionState,
+    realId: string,
+    body: Parameters<OpencodeServeManager['promptAsync']>[1],
+  ): Promise<void> {
+    const route = cwdRoute(state.cwd)
+    if (route) {
+      await serveManager.promptAsync(realId, body, route)
+      return
+    }
+    await serveManager.promptAsync(realId, body)
+  }
+
+  async function abortForState(state: OpencodeSessionState): Promise<void> {
+    if (!state.realSessionId) return
+    const route = cwdRoute(state.cwd)
+    if (route) {
+      await serveManager.abort(state.realSessionId, route)
+      return
+    }
+    await serveManager.abort(state.realSessionId)
+  }
+
+  async function compactForState(state: OpencodeSessionState, input?: { instructions?: string }): Promise<void> {
+    if (!state.realSessionId) return
+    const route = cwdRoute(state.cwd)
+    if (route) {
+      await serveManager.compact(state.realSessionId, input, route)
+      return
+    }
+    if (input) {
+      await serveManager.compact(state.realSessionId, input)
+      return
+    }
+    await serveManager.compact(state.realSessionId)
+  }
+
+  async function forkForState(state: OpencodeSessionState): Promise<{ id: string }> {
+    if (!state.realSessionId) {
+      throw new FreshAgentLostSessionError(`OpenCode session ${state.placeholderId} has not materialized; cannot fork.`)
+    }
+    const route = cwdRoute(state.cwd)
+    return route
+      ? await serveManager.fork(state.realSessionId, route)
+      : await serveManager.fork(state.realSessionId)
+  }
+
   /** Bridge serve SSE events for this state's real session into the state's
    * own EventEmitter, mapped to sdk.* and stamped with the placeholder id the
    * client first subscribed with. */
@@ -126,7 +177,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
     // later rejection cannot become an unhandled rejection.
     void idle.catch(() => {})
     try {
-      await serveManager.promptAsync(realId, {
+      await promptAsyncForState(state, realId, {
         parts: [{ type: 'text', text }],
         ...(splitOpencodeModel(modelStr) ? { model: splitOpencodeModel(modelStr)! } : {}),
         ...(effort ? { variant: effort } : {}),
@@ -144,13 +195,17 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
     return sendResult(state.realSessionId)
   }
 
-  async function assembleExport(realSessionId: string, query: { limit?: number; before?: string }): Promise<{ exported: OpencodeExport; nextCursor: string | null; revision: number }> {
+  async function assembleExport(
+    realSessionId: string,
+    query: { limit?: number; before?: string },
+    route?: { cwd: string },
+  ): Promise<{ exported: OpencodeExport; nextCursor: string | null; revision: number }> {
     const [session, page] = await Promise.all([
-      serveManager.getSession(realSessionId).then(
+      (route ? serveManager.getSession(realSessionId, route) : serveManager.getSession(realSessionId)).then(
         (session) => session,
         () => ({} as Record<string, unknown>),
       ),
-      serveManager.listMessages(realSessionId, query),
+      route ? serveManager.listMessages(realSessionId, query, route) : serveManager.listMessages(realSessionId, query),
     ])
     const sessionTime = session && typeof session === 'object' ? session.time : undefined
     const sessionTimeUpdated = sessionTime && typeof sessionTime === 'object' && !Array.isArray(sessionTime)
@@ -217,14 +272,25 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
 
     async attach(locator) {
       const existing = sessions.get(locator.sessionId)
-      if (existing) { remember(existing); return { sessionId: locator.sessionId, sessionRef: { provider: 'opencode', sessionId: locator.sessionId } } }
+      if (existing) {
+        if (locator.cwd) {
+          existing.cwd = locator.cwd
+          if (existing.realSessionId) serveManager.rememberSessionCwd(existing.realSessionId, locator.cwd)
+        }
+        remember(existing)
+        return { sessionId: locator.sessionId, sessionRef: { provider: 'opencode', sessionId: locator.sessionId } }
+      }
       if (isPlaceholderOpencodeSessionId(locator.sessionId) || !isRealOpencodeSessionId(locator.sessionId)) {
         throw new FreshAgentLostSessionError(`OpenCode session ${locator.sessionId} is not a durable OpenCode session.`)
       }
       const state: OpencodeSessionState = {
-        placeholderId: locator.sessionId, realSessionId: locator.sessionId, status: 'idle',
+        placeholderId: locator.sessionId,
+        realSessionId: locator.sessionId,
+        cwd: locator.cwd,
+        status: 'idle',
         events: new EventEmitter(), sendQueue: Promise.resolve(),
       }
+      if (locator.cwd) serveManager.rememberSessionCwd(locator.sessionId, locator.cwd)
       remember(state)
       bindServeStream(state)
       return { sessionId: locator.sessionId, sessionRef: { provider: 'opencode', sessionId: locator.sessionId } }
@@ -249,7 +315,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
 
     async interrupt(sessionId) {
       const state = requireState(sessionId)
-      if (state.realSessionId) await serveManager.abort(state.realSessionId).catch((err) => log.warn({ err }, 'abort failed'))
+      await abortForState(state).catch((err) => log.warn({ err }, 'abort failed'))
       state.status = 'idle'
       state.events.emit('event', { type: 'sdk.session.snapshot', sessionId: state.placeholderId, status: 'idle' })
     },
@@ -260,8 +326,8 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       const instructions = input?.instructions
       const hasInstructions = instructions !== undefined
       const run = state.sendQueue.then(
-        () => (hasInstructions ? serveManager.compact(state.realSessionId!, { instructions }) : serveManager.compact(state.realSessionId!)),
-        () => (hasInstructions ? serveManager.compact(state.realSessionId!, { instructions }) : serveManager.compact(state.realSessionId!)),
+        () => compactForState(state, hasInstructions ? { instructions } : undefined),
+        () => compactForState(state, hasInstructions ? { instructions } : undefined),
       )
       state.sendQueue = run.catch(() => undefined)
       await run
@@ -269,8 +335,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
 
     async fork(sessionId) {
       const state = requireState(sessionId)
-      if (!state.realSessionId) throw new FreshAgentLostSessionError(`OpenCode session ${sessionId} has not materialized; cannot fork.`)
-      const child = await serveManager.fork(state.realSessionId)
+      const child = await forkForState(state)
       const childState: OpencodeSessionState = {
         placeholderId: child.id,
         realSessionId: child.id,
@@ -303,7 +368,10 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
         })
       }
       const realId = durableId(thread.threadId)
-      const { exported, revision } = await assembleExport(realId, { limit: DEFAULT_SNAPSHOT_TURN_LIMIT })
+      const route = cwdRoute(liveState?.cwd ?? thread.cwd)
+      const { exported, revision } = route
+        ? await assembleExport(realId, { limit: DEFAULT_SNAPSHOT_TURN_LIMIT }, route)
+        : await assembleExport(realId, { limit: DEFAULT_SNAPSHOT_TURN_LIMIT })
       return normalizeOpencodeSnapshot({
         sessionType: 'freshopencode', threadId: thread.threadId,
         exported: { ...exported, info: { ...(exported.info ?? {}), time: { ...((exported.info?.time) ?? {}), updated: revision } } },
@@ -317,10 +385,14 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
         return normalizeOpencodeTurnPage({ threadId: thread.threadId, exported: { messages: [] }, revision: Number(query.revision) || 0, nextCursor: null })
       }
       const realId = durableId(thread.threadId)
-      const { exported, nextCursor, revision } = await assembleExport(realId, {
+      const route = cwdRoute(liveState?.cwd ?? thread.cwd)
+      const pageQuery = {
         limit: typeof query.limit === 'number' ? query.limit : DEFAULT_SNAPSHOT_TURN_LIMIT,
         before: typeof query.cursor === 'string' ? query.cursor : undefined,
-      })
+      }
+      const { exported, nextCursor, revision } = route
+        ? await assembleExport(realId, pageQuery, route)
+        : await assembleExport(realId, pageQuery)
       return normalizeOpencodeTurnPage({ threadId: thread.threadId, exported, revision, nextCursor })
     },
 
@@ -328,7 +400,10 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       const liveState = sessions.get(thread.threadId)
       if (liveState && !liveState.realSessionId) return null
       const realId = durableId(thread.threadId)
-      const message = await serveManager.getMessage(realId, thread.turnId)
+      const route = cwdRoute(liveState?.cwd ?? thread.cwd)
+      const message = route
+        ? await serveManager.getMessage(realId, thread.turnId, route)
+        : await serveManager.getMessage(realId, thread.turnId)
       if (!message) return null
       return normalizeOpencodeTurnBody({ threadId: thread.threadId, exported: { messages: [{ info: message.info, parts: message.parts }] }, turnId: thread.turnId, revision })
     },

--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -127,7 +127,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
     await serveManager.compact(state.realSessionId)
   }
 
-  async function forkForState(state: OpencodeSessionState): Promise<{ id: string }> {
+  async function forkForState(state: OpencodeSessionState): Promise<{ id: string; directory?: string }> {
     if (!state.realSessionId) {
       throw new FreshAgentLostSessionError(`OpenCode session ${state.placeholderId} has not materialized; cannot fork.`)
     }
@@ -339,7 +339,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       const childState: OpencodeSessionState = {
         placeholderId: child.id,
         realSessionId: child.id,
-        cwd: state.cwd,
+        cwd: child.directory ?? state.cwd,
         model: state.model,
         effort: state.effort,
         status: 'idle',

--- a/server/fresh-agent/adapters/opencode/serve-manager.ts
+++ b/server/fresh-agent/adapters/opencode/serve-manager.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { EventEmitter } from 'node:events'
+import path from 'node:path'
 import type pino from 'pino'
 import { allocateLocalhostPort, type LoopbackServerEndpoint } from '../../../local-port.js'
 import { logger } from '../../../logger.js'
@@ -18,6 +19,8 @@ export type OpencodeServeManagerOptions = {
   /** Override the SSE consumer for tests. Returns an unsubscribe fn. */
   connectEventStream?: (url: string, handlers: { onEvent: (e: ParsedServeEvent) => void; onError: (err: unknown) => void }) => () => void
   healthTimeoutMs?: number
+  env?: NodeJS.ProcessEnv
+  idleShutdownMs?: number
 }
 
 export type OpencodeServeMessage = { info: Record<string, any>; parts: Array<Record<string, any>> }
@@ -41,7 +44,17 @@ type RunningServe = {
   ownershipId: string
   child: ChildProcessWithoutNullStreams
   stopEventStream: () => void
+  cwdKey: string
+  cwd?: string
+  idleTimer?: NodeJS.Timeout
+  activeRequests: number
 }
+
+type ServeRoute = {
+  cwd?: string
+}
+
+const DEFAULT_CWD_KEY = '<inherit-process-cwd>'
 
 export class OpencodeServeManager {
   private readonly command: string
@@ -50,12 +63,16 @@ export class OpencodeServeManager {
   private readonly allocatePort: () => Promise<LoopbackServerEndpoint>
   private readonly connectEventStream?: OpencodeServeManagerOptions['connectEventStream']
   private readonly healthTimeoutMs: number
+  private readonly env: NodeJS.ProcessEnv
+  private readonly idleShutdownMs: number
   private readonly log: OpencodeServeLogger = logger.child({ component: 'opencode-serve-manager' })
   /** sessionId → emitter of ParsedServeEvent (and a synthetic 'idle' event). */
   private readonly sessionEmitters = new Map<string, EventEmitter>()
-  private running: RunningServe | undefined
-  private startPromise: Promise<RunningServe> | undefined
-  private startAbort: AbortController | undefined
+  private readonly runningByCwd = new Map<string, RunningServe>()
+  private readonly startPromiseByCwd = new Map<string, Promise<RunningServe>>()
+  private readonly startAbortByCwd = new Map<string, AbortController>()
+  private readonly cwdByKey = new Map<string, string | undefined>()
+  private readonly sessionCwdById = new Map<string, string>()
   private shutdownRequested = false
 
   constructor(options: OpencodeServeManagerOptions = {}) {
@@ -65,26 +82,107 @@ export class OpencodeServeManager {
     this.allocatePort = options.allocatePort ?? allocateLocalhostPort
     this.connectEventStream = options.connectEventStream
     this.healthTimeoutMs = options.healthTimeoutMs ?? 20_000
+    this.env = options.env ?? process.env
+    this.idleShutdownMs = options.idleShutdownMs ?? 15 * 60_000
   }
 
-  async ensureStarted(): Promise<{ baseUrl: string }> {
+  private routeFromCwd(cwd?: string): { cwdKey: string; cwd?: string } {
+    const trimmed = typeof cwd === 'string' && cwd.trim().length > 0 ? cwd.trim() : undefined
+    if (!trimmed) return { cwdKey: DEFAULT_CWD_KEY }
+    const resolved = path.resolve(trimmed)
+    return { cwdKey: resolved, cwd: resolved }
+  }
+
+  private routeForSession(sessionId: string, fallback?: ServeRoute): { cwdKey: string; cwd?: string } {
+    const existingKey = this.sessionCwdById.get(sessionId)
+    if (existingKey) {
+      return { cwdKey: existingKey, ...(this.cwdByKey.get(existingKey) ? { cwd: this.cwdByKey.get(existingKey) } : {}) }
+    }
+    return this.routeFromCwd(fallback?.cwd)
+  }
+
+  rememberSessionCwd(sessionId: string, cwd?: string): void {
+    if (!sessionId) return
+    const route = this.routeFromCwd(cwd)
+    this.cwdByKey.set(route.cwdKey, route.cwd)
+    this.sessionCwdById.set(sessionId, route.cwdKey)
+  }
+
+  private forgetSessionsForCwd(cwdKey: string): void {
+    for (const [sessionId, sessionCwdKey] of this.sessionCwdById.entries()) {
+      if (sessionCwdKey !== cwdKey) continue
+      this.sessionCwdById.delete(sessionId)
+      this.sessionEmitters.delete(sessionId)
+    }
+    if (cwdKey === DEFAULT_CWD_KEY) {
+      for (const sessionId of this.sessionEmitters.keys()) {
+        if (!this.sessionCwdById.has(sessionId)) this.sessionEmitters.delete(sessionId)
+      }
+    }
+  }
+
+  private clearIdleTimer(running: RunningServe): void {
+    if (!running.idleTimer) return
+    clearTimeout(running.idleTimer)
+    running.idleTimer = undefined
+  }
+
+  private scheduleIdleShutdown(running: RunningServe): void {
+    this.clearIdleTimer(running)
+    if (running.cwdKey === DEFAULT_CWD_KEY || this.idleShutdownMs <= 0 || running.activeRequests > 0) return
+    running.idleTimer = setTimeout(() => {
+      running.idleTimer = undefined
+      if (running.activeRequests > 0) return
+      if (this.runningByCwd.get(running.cwdKey) !== running) return
+      this.runningByCwd.delete(running.cwdKey)
+      this.startPromiseByCwd.delete(running.cwdKey)
+      this.startAbortByCwd.delete(running.cwdKey)
+      try { running.stopEventStream() } catch { /* ignore */ }
+      void killOwnedProcesses(running.child, running.ownershipId, this.log)
+    }, this.idleShutdownMs)
+    running.idleTimer.unref?.()
+  }
+
+  private async withRunning<T>(
+    route: { cwdKey: string; cwd?: string },
+    fn: (baseUrl: string) => Promise<T>,
+  ): Promise<T> {
+    const { baseUrl } = await this.ensureStarted(route.cwd ? { cwd: route.cwd } : {})
+    const running = this.runningByCwd.get(route.cwdKey)
+    if (!running) return fn(baseUrl)
+    this.clearIdleTimer(running)
+    running.activeRequests += 1
+    try {
+      return await fn(baseUrl)
+    } finally {
+      running.activeRequests -= 1
+      this.scheduleIdleShutdown(running)
+    }
+  }
+
+  async ensureStarted(input: ServeRoute = {}): Promise<{ baseUrl: string }> {
     if (this.shutdownRequested) {
       throw new Error('opencode serve manager is shutting down')
     }
-    if (this.running) return { baseUrl: this.running.baseUrl }
-    if (!this.startPromise) {
-      this.startPromise = this.start().catch((err) => {
-        this.startPromise = undefined
+    const route = this.routeFromCwd(input.cwd)
+    this.cwdByKey.set(route.cwdKey, route.cwd)
+    const running = this.runningByCwd.get(route.cwdKey)
+    if (running) return { baseUrl: running.baseUrl }
+    if (!this.startPromiseByCwd.has(route.cwdKey)) {
+      const promise = this.start(route).catch((err) => {
+        this.startPromiseByCwd.delete(route.cwdKey)
         throw err
       })
+      this.startPromiseByCwd.set(route.cwdKey, promise)
     }
-    const running = await this.startPromise
-    return { baseUrl: running.baseUrl }
+    const next = await this.startPromiseByCwd.get(route.cwdKey)!
+    this.startPromiseByCwd.delete(route.cwdKey)
+    return { baseUrl: next.baseUrl }
   }
 
-  private async start(): Promise<RunningServe> {
+  private async start(route: { cwdKey: string; cwd?: string }): Promise<RunningServe> {
     const startAbort = new AbortController()
-    this.startAbort = startAbort
+    this.startAbortByCwd.set(route.cwdKey, startAbort)
     const startSignal = startAbort.signal
     let child: ChildProcessWithoutNullStreams | undefined
     try {
@@ -94,24 +192,30 @@ export class OpencodeServeManager {
       child = this.spawnFn(
         this.command,
         ['serve', '--hostname', endpoint.hostname, '--port', String(endpoint.port)],
-        { env: { ...process.env, [OWNERSHIP_ENV]: ownershipId }, stdio: ['ignore', 'pipe', 'pipe'] },
+        {
+          ...(route.cwd ? { cwd: route.cwd } : {}),
+          env: { ...this.env, [OWNERSHIP_ENV]: ownershipId },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
       ) as unknown as ChildProcessWithoutNullStreams
       // Drain stdout/stderr so the child's pipe buffers never back-pressure
       // and stall the serve process. Diagnostics are captured below before health.
       child.stdout?.on('data', () => {})
       child.stderr?.on('data', () => {})
       child.on('error', (err) => this.log.error({ err }, 'opencode serve process error'))
-    child.on('close', (code) => {
-      this.log.warn({ code }, 'opencode serve exited')
-      if (this.running && this.running.child === child) {
-        const running = this.running
-        this.running = undefined
-        this.startPromise = undefined
-        try { running.stopEventStream() } catch { /* ignore */ }
-        void killOwnedProcesses(running.child, running.ownershipId, this.log)
-        this.sessionEmitters.clear()
-      }
-    })
+      child.on('close', (code) => {
+        this.log.warn({ code }, 'opencode serve exited')
+        const runningEntry = this.runningByCwd.get(route.cwdKey)
+        if (runningEntry && runningEntry.child === child) {
+          this.runningByCwd.delete(route.cwdKey)
+          this.startPromiseByCwd.delete(route.cwdKey)
+          this.startAbortByCwd.delete(route.cwdKey)
+          this.clearIdleTimer(runningEntry)
+          try { runningEntry.stopEventStream() } catch { /* ignore */ }
+          void killOwnedProcesses(runningEntry.child, runningEntry.ownershipId, this.log)
+          this.forgetSessionsForCwd(route.cwdKey)
+        }
+      })
 
       await this.waitForHealth(baseUrl, child, startSignal)
 
@@ -127,15 +231,24 @@ export class OpencodeServeManager {
           })
         : this.startDefaultEventStream(baseUrl)
 
-      const running: RunningServe = { baseUrl, ownershipId, child, stopEventStream }
-      this.running = running
+      const running: RunningServe = {
+        baseUrl,
+        ownershipId,
+        child,
+        stopEventStream,
+        cwdKey: route.cwdKey,
+        ...(route.cwd ? { cwd: route.cwd } : {}),
+        activeRequests: 0,
+      }
+      this.runningByCwd.set(route.cwdKey, running)
+      this.scheduleIdleShutdown(running)
       return running
     } catch (err) {
       if (child) this.stopChild(child)
-      this.startPromise = undefined
+      this.startPromiseByCwd.delete(route.cwdKey)
       throw err
     } finally {
-      if (this.startAbort === startAbort) this.startAbort = undefined
+      if (this.startAbortByCwd.get(route.cwdKey) === startAbort) this.startAbortByCwd.delete(route.cwdKey)
     }
   }
 
@@ -180,21 +293,24 @@ export class OpencodeServeManager {
   }
 
   // ── HTTP client ────────────────────────────────────────────────────────
-  private async requireBase(): Promise<string> {
-    const { baseUrl } = await this.ensureStarted()
-    return baseUrl
-  }
-
-  private async json<T>(path: string, init?: RequestInit & { notFoundValue?: T }): Promise<T> {
-    const base = await this.requireBase()
-    const res = await this.fetchFn(`${base}${path}`, init)
-    if (!res.ok && res.status !== 204) {
-      if (res.status === 404 && init?.notFoundValue !== undefined) return init.notFoundValue
-      const text = await res.text().catch(() => '')
-      throw new Error(`opencode serve ${init?.method ?? 'GET'} ${path} → ${res.status} ${text}`)
-    }
-    if (res.status === 204) return undefined as T
-    return (await res.json()) as T
+  private async json<T>(
+    route: ServeRoute & { sessionId?: string },
+    requestPath: string,
+    init?: RequestInit & { notFoundValue?: T },
+  ): Promise<T> {
+    const resolved = route.sessionId
+      ? this.routeForSession(route.sessionId, route)
+      : this.routeFromCwd(route.cwd)
+    return this.withRunning(resolved, async (base) => {
+      const res = await this.fetchFn(`${base}${requestPath}`, init)
+      if (!res.ok && res.status !== 204) {
+        if (res.status === 404 && init?.notFoundValue !== undefined) return init.notFoundValue
+        const text = await res.text().catch(() => '')
+        throw new Error(`opencode serve ${init?.method ?? 'GET'} ${requestPath} → ${res.status} ${text}`)
+      }
+      if (res.status === 204) return undefined as T
+      return (await res.json()) as T
+    })
   }
 
   async createSession(input: { title?: string; parentID?: string; directory?: string } = {}): Promise<{ id: string; directory?: string; title?: string }> {
@@ -202,63 +318,90 @@ export class OpencodeServeManager {
     if (input.title !== undefined) body.title = input.title
     if (input.parentID !== undefined) body.parentID = input.parentID
     if (input.directory !== undefined) body.directory = input.directory
-    return this.json('/session', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-    })
+    const session = await this.json<{ id: string; directory?: string; title?: string }>(
+      input.directory ? { cwd: input.directory } : {},
+      '/session',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    )
+    if (typeof session.id === 'string') this.rememberSessionCwd(session.id, session.directory ?? input.directory)
+    return session
   }
 
-  async getSession(id: string): Promise<Record<string, any>> {
-    return this.json(`/session/${encodeURIComponent(id)}`, { method: 'GET' })
-  }
-
-  async promptAsync(id: string, body: { parts: Array<Record<string, unknown>>; model?: { providerID: string; modelID: string }; variant?: string; agent?: string }): Promise<void> {
-    await this.json(`/session/${encodeURIComponent(id)}/prompt_async`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-    })
-  }
-
-  async listMessages(id: string, query: { limit?: number; before?: string }): Promise<OpencodeServeMessagePage> {
-    const base = await this.requireBase()
-    const params = new URLSearchParams()
-    if (typeof query.limit === 'number') params.set('limit', String(query.limit))
-    if (query.before) params.set('before', query.before)
-    const qs = params.toString()
-    const url = `${base}/session/${encodeURIComponent(id)}/message${qs ? `?${qs}` : ''}`
-    const res = await this.fetchFn(url, { method: 'GET' })
-    if (!res.ok) {
-      const text = await res.text().catch(() => '')
-      throw new Error(`opencode serve GET messages → ${res.status} ${text}`)
+  async getSession(id: string, route: ServeRoute = {}): Promise<Record<string, any>> {
+    const session = await this.json<Record<string, any>>(
+      { ...route, sessionId: id },
+      `/session/${encodeURIComponent(id)}`,
+      { method: 'GET' },
+    )
+    if (typeof session?.directory === 'string' && session.directory.length > 0) {
+      this.rememberSessionCwd(id, session.directory)
     }
-    const messages = (await res.json()) as OpencodeServeMessage[]
-    const nextCursor = res.headers.get('x-next-cursor') || null
-    return { messages: Array.isArray(messages) ? messages : [], nextCursor }
+    return session
   }
 
-  async getMessage(id: string, messageId: string): Promise<OpencodeServeMessage | null> {
+  async promptAsync(
+    id: string,
+    body: { parts: Array<Record<string, unknown>>; model?: { providerID: string; modelID: string }; variant?: string; agent?: string },
+    route: ServeRoute = {},
+  ): Promise<void> {
+    await this.json({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}/prompt_async`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  async listMessages(id: string, query: { limit?: number; before?: string }, route: ServeRoute = {}): Promise<OpencodeServeMessagePage> {
+    const resolved = this.routeForSession(id, route)
+    return this.withRunning(resolved, async (base) => {
+      const params = new URLSearchParams()
+      if (typeof query.limit === 'number') params.set('limit', String(query.limit))
+      if (query.before) params.set('before', query.before)
+      const qs = params.toString()
+      const url = `${base}/session/${encodeURIComponent(id)}/message${qs ? `?${qs}` : ''}`
+      const res = await this.fetchFn(url, { method: 'GET' })
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`opencode serve GET messages → ${res.status} ${text}`)
+      }
+      const messages = (await res.json()) as OpencodeServeMessage[]
+      const nextCursor = res.headers.get('x-next-cursor') || null
+      return { messages: Array.isArray(messages) ? messages : [], nextCursor }
+    })
+  }
+
+  async getMessage(id: string, messageId: string, route: ServeRoute = {}): Promise<OpencodeServeMessage | null> {
     return this.json<OpencodeServeMessage | null>(
+      { ...route, sessionId: id },
       `/session/${encodeURIComponent(id)}/message/${encodeURIComponent(messageId)}`,
       { method: 'GET', notFoundValue: null },
     )
   }
 
-  async abort(id: string): Promise<void> {
-    await this.json(`/session/${encodeURIComponent(id)}/abort`, { method: 'POST' })
+  async abort(id: string, route: ServeRoute = {}): Promise<void> {
+    await this.json({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}/abort`, { method: 'POST' })
   }
 
-  async compact(id: string, body?: { instructions?: string }): Promise<void> {
-    await this.json(`/session/${encodeURIComponent(id)}/compact`, {
+  async compact(id: string, body?: { instructions?: string }, route: ServeRoute = {}): Promise<void> {
+    await this.json({ ...route, sessionId: id }, `/session/${encodeURIComponent(id)}/summarize`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body ?? {}),
     })
   }
 
-  async fork(id: string): Promise<{ id: string }> {
-    return this.json(`/session/${encodeURIComponent(id)}/fork`, { method: 'POST' })
+  async fork(id: string, route: ServeRoute = {}): Promise<{ id: string; directory?: string }> {
+    const child = await this.json<{ id: string; directory?: string }>(
+      { ...route, sessionId: id },
+      `/session/${encodeURIComponent(id)}/fork`,
+      { method: 'POST' },
+    )
+    if (typeof child.id === 'string') this.rememberSessionCwd(child.id, child.directory)
+    return child
   }
 
   // ── SSE fan-out (Task A3 adds subscribe/onceIdle) ──────────────────────
@@ -355,27 +498,35 @@ export class OpencodeServeManager {
 
   async shutdown(): Promise<void> {
     this.shutdownRequested = true
-    this.startAbort?.abort()
-
-    // Reap any in-flight start() so it terminates its child and any start
-    // promise settles before we touch the running sidecar.
-    if (this.startPromise) {
-      try { await this.startPromise } catch { /* ignore startup errors */ }
-      this.startPromise = undefined
+    for (const controller of this.startAbortByCwd.values()) {
+      controller.abort()
     }
 
-    const running = this.running
-    this.running = undefined
-    this.startPromise = undefined
-    if (!running) return
-    try { running.stopEventStream() } catch { /* ignore */ }
-    await killOwnedProcesses(running.child, running.ownershipId, this.log)
+    const starts = [...this.startPromiseByCwd.values()]
+    if (starts.length > 0) {
+      await Promise.all(starts.map(async (promise) => {
+        try { await promise } catch { /* ignore startup errors */ }
+      }))
+      this.startPromiseByCwd.clear()
+    }
+
+    const running = [...this.runningByCwd.values()]
+    this.runningByCwd.clear()
+    this.startPromiseByCwd.clear()
+    this.startAbortByCwd.clear()
+    await Promise.all(running.map(async (entry) => {
+      this.clearIdleTimer(entry)
+      try { entry.stopEventStream() } catch { /* ignore */ }
+      await killOwnedProcesses(entry.child, entry.ownershipId, this.log)
+    }))
     this.sessionEmitters.clear()
+    this.sessionCwdById.clear()
+    this.cwdByKey.clear()
   }
 
   /** @internal test/inspection accessor */
   get baseUrlOrUndefined(): string | undefined {
-    return this.running?.baseUrl
+    return [...this.runningByCwd.values()][0]?.baseUrl
   }
 }
 

--- a/server/fresh-agent/adapters/opencode/serve-manager.ts
+++ b/server/fresh-agent/adapters/opencode/serve-manager.ts
@@ -400,7 +400,16 @@ export class OpencodeServeManager {
       `/session/${encodeURIComponent(id)}/fork`,
       { method: 'POST' },
     )
-    if (typeof child.id === 'string') this.rememberSessionCwd(child.id, child.directory)
+    if (typeof child.id === 'string') {
+      const returnedDirectory = typeof child.directory === 'string' && child.directory.trim().length > 0
+        ? child.directory
+        : undefined
+      const fallbackDirectory = typeof route.cwd === 'string' && route.cwd.trim().length > 0
+        ? route.cwd
+        : undefined
+      const childDirectory = returnedDirectory ?? fallbackDirectory
+      if (childDirectory) this.rememberSessionCwd(child.id, childDirectory)
+    }
     return child
   }
 

--- a/server/fresh-agent/router.ts
+++ b/server/fresh-agent/router.ts
@@ -143,9 +143,11 @@ export function createFreshAgentRouter(deps: {
     const query = z.object({
       priority: ReadModelPrioritySchema.optional(),
       revision: z.coerce.number().int().nonnegative().optional(),
+      cwd: z.string().trim().min(1).optional(),
     }).safeParse({
       priority: typeof req.query.priority === 'string' ? req.query.priority : undefined,
       revision: typeof req.query.revision === 'string' ? req.query.revision : undefined,
+      cwd: typeof req.query.cwd === 'string' ? req.query.cwd : undefined,
     })
 
     if (!params.success || !query.success) {
@@ -165,6 +167,7 @@ export function createFreshAgentRouter(deps: {
           provider: params.data.provider,
           threadId: params.data.threadId,
           revision: query.data.revision,
+          cwd: query.data.cwd,
         }),
       })
       setResponsePerfContext(res, {
@@ -184,6 +187,7 @@ export function createFreshAgentRouter(deps: {
       cursor: typeof req.query.cursor === 'string' ? req.query.cursor : undefined,
       priority: typeof req.query.priority === 'string' ? req.query.priority : undefined,
       revision: typeof req.query.revision === 'string' ? req.query.revision : undefined,
+      cwd: typeof req.query.cwd === 'string' ? req.query.cwd : undefined,
       limit: typeof req.query.limit === 'string' ? Number(req.query.limit) : undefined,
       includeBodies: typeof req.query.includeBodies === 'string' ? req.query.includeBodies : undefined,
     })
@@ -207,6 +211,7 @@ export function createFreshAgentRouter(deps: {
           cursor: query.data.cursor,
           priority: query.data.priority,
           revision: query.data.revision,
+          cwd: query.data.cwd,
           limit: query.data.limit,
           includeBodies: query.data.includeBodies,
         }),
@@ -226,6 +231,7 @@ export function createFreshAgentRouter(deps: {
     const params = TurnParamsSchema.safeParse(req.params)
     const query = FreshAgentThreadTurnBodyQuerySchema.safeParse({
       revision: typeof req.query.revision === 'string' ? req.query.revision : undefined,
+      cwd: typeof req.query.cwd === 'string' ? req.query.cwd : undefined,
     })
     if (!params.success || !query.success) {
       return res.status(400).json({
@@ -240,6 +246,7 @@ export function createFreshAgentRouter(deps: {
         provider: params.data.provider,
         threadId: params.data.threadId,
         turnId: params.data.turnId,
+        cwd: query.data.cwd,
         revision: query.data.revision,
       })
       if (!turn) {

--- a/server/fresh-agent/runtime-adapter.ts
+++ b/server/fresh-agent/runtime-adapter.ts
@@ -37,12 +37,14 @@ export type FreshAgentThreadLocator = {
   sessionType: FreshAgentSessionType
   provider: FreshAgentRuntimeProvider
   threadId: string
+  cwd?: string
 }
 
 export type FreshAgentSessionLocator = {
   sessionType: FreshAgentSessionType
   provider: FreshAgentRuntimeProvider
   sessionId: string
+  cwd?: string
 }
 
 export type FreshAgentInputImage =

--- a/server/fresh-agent/runtime-manager.ts
+++ b/server/fresh-agent/runtime-manager.ts
@@ -239,6 +239,7 @@ export class FreshAgentRuntimeManager {
     sessionType: FreshAgentSessionType
     provider: FreshAgentRuntimeProvider
     threadId: string
+    cwd?: string
     revision?: number
   }) {
     const registration = this.requireRegistration(input.sessionType, input.provider)
@@ -249,6 +250,7 @@ export class FreshAgentRuntimeManager {
       sessionType: input.sessionType,
       provider: input.provider,
       threadId: input.threadId,
+      cwd: input.cwd,
     }, input.revision)
     const parsed = FreshAgentSnapshotSchema.safeParse(snapshot)
     if (!parsed.success) {
@@ -261,6 +263,7 @@ export class FreshAgentRuntimeManager {
     sessionType: FreshAgentSessionType
     provider: FreshAgentRuntimeProvider
     threadId: string
+    cwd?: string
     cursor?: string
     priority?: string
     revision: number
@@ -272,7 +275,7 @@ export class FreshAgentRuntimeManager {
       throw new FreshAgentRuntimeUnavailableError(`No fresh-agent turn-page adapter registered for ${input.sessionType}`)
     }
     const page = await registration.adapter.getTurnPage(
-      { sessionType: input.sessionType, provider: input.provider, threadId: input.threadId },
+      { sessionType: input.sessionType, provider: input.provider, threadId: input.threadId, cwd: input.cwd },
       input,
     )
     const parsed = FreshAgentTurnPageSchema.safeParse(page)
@@ -287,6 +290,7 @@ export class FreshAgentRuntimeManager {
     provider: FreshAgentRuntimeProvider
     threadId: string
     turnId: string
+    cwd?: string
     revision: number
   }) {
     const registration = this.requireRegistration(input.sessionType, input.provider)
@@ -298,6 +302,7 @@ export class FreshAgentRuntimeManager {
         sessionType: input.sessionType,
         provider: input.provider,
         threadId: input.threadId,
+        cwd: input.cwd,
         turnId: input.turnId,
       },
       input.revision,

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -3158,7 +3158,12 @@ export class WsHandler {
           this.sendError(ws, { code: 'INTERNAL_ERROR', message: this.freshAgentUnavailableMessage() })
           return
         }
-        const locator = { sessionId: m.sessionId, sessionType: m.sessionType, provider: m.provider }
+        const locator = {
+          sessionId: m.sessionId,
+          sessionType: m.sessionType,
+          provider: m.provider,
+          ...(m.cwd ? { cwd: m.cwd } : {}),
+        }
         try {
           await Promise.resolve(manager.attach(locator))
           this.authorizeFreshAgentSession(state, locator)

--- a/shared/read-models.ts
+++ b/shared/read-models.ts
@@ -78,6 +78,7 @@ export const FreshAgentThreadTurnsQuerySchema = z.object({
   cursor: z.string().min(1).optional(),
   priority: ReadModelPrioritySchema.optional(),
   revision: z.coerce.number().int().nonnegative(),
+  cwd: z.string().trim().min(1).optional(),
   limit: z.number().int().positive().max(MAX_FRESH_AGENT_THREAD_TURNS).optional(),
   includeBodies: z.union([
     z.boolean(),
@@ -87,6 +88,7 @@ export const FreshAgentThreadTurnsQuerySchema = z.object({
 
 export const FreshAgentThreadTurnBodyQuerySchema = z.object({
   revision: z.coerce.number().int().nonnegative(),
+  cwd: z.string().trim().min(1).optional(),
 })
 
 export const RestoreStaleRevisionResponseSchema = z.object({

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -425,6 +425,7 @@ export const FreshAgentAttachSchema = z.object({
   sessionType: z.enum(['freshclaude', 'freshcodex', 'kilroy', 'freshopencode']),
   provider: z.enum(['claude', 'codex', 'opencode']),
   resumeSessionId: z.string().optional(),
+  cwd: z.string().optional(),
 })
 
 export const FreshAgentSendSchema = z.object({

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -675,6 +675,7 @@ export function FreshAgentView({
         sessionType: current.sessionType,
         provider: current.provider,
         resumeSessionId: current.resumeSessionId,
+        cwd: current.initialCwd,
       })
       setSnapshotRefreshNonce((value) => value + 1)
     } else if (!hidden && (current.status === 'creating' || current.status === 'starting')) {
@@ -787,8 +788,9 @@ export function FreshAgentView({
       sessionType: paneContent.sessionType,
       provider: paneContent.provider,
       resumeSessionId: paneContent.resumeSessionId,
+      cwd: paneContent.initialCwd,
     })
-  }, [hidden, paneContent.provider, paneContent.resumeSessionId, paneContent.sessionId, paneContent.sessionType])
+  }, [hidden, paneContent.initialCwd, paneContent.provider, paneContent.resumeSessionId, paneContent.sessionId, paneContent.sessionType])
 
   useEffect(() => {
     if (typeof ws.onMessage !== 'function') return
@@ -918,7 +920,11 @@ export function FreshAgentView({
       || paneContentRef.current.sessionType !== requestSessionType
       || snapshotThreadIdRef.current !== sessionId
     )
-    void getFreshAgentThreadSnapshot(requestSessionType, provider, sessionId, { signal: controller.signal })
+    const requestCwd = paneContentRef.current.initialCwd
+    void getFreshAgentThreadSnapshot(requestSessionType, provider, sessionId, {
+      signal: controller.signal,
+      ...(requestCwd ? { cwd: requestCwd } : {}),
+    })
       .then((next) => {
         if (isStaleSnapshotRequest()) return
         const snapshotIdentity = currentAutoTitleIdentityRef.current

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -309,13 +309,14 @@ export async function getFreshAgentThreadSnapshot(
   sessionType: string,
   provider: string,
   threadId: string,
-  query: { revision?: number; signal?: AbortSignal } = {},
+  query: { revision?: number; cwd?: string; signal?: AbortSignal } = {},
   options: ApiRequestOptions = {},
 ): Promise<any> {
   const signal = query.signal ?? options.signal
   const data = await api.get(
     `/api/fresh-agent/threads/${encodeURIComponent(sessionType)}/${encodeURIComponent(provider)}/${encodeURIComponent(threadId)}${buildQueryString([
       ['revision', query.revision],
+      ['cwd', query.cwd],
     ])}`,
     { ...options, signal },
   )
@@ -334,6 +335,7 @@ export async function getFreshAgentTurnPage(
     cursor?: string
     priority?: string
     revision: number
+    cwd?: string
     limit?: number
     includeBodies?: boolean
     signal?: AbortSignal
@@ -346,6 +348,7 @@ export async function getFreshAgentTurnPage(
       ['revision', query.revision],
       ['cursor', query.cursor],
       ['priority', query.priority],
+      ['cwd', query.cwd],
       ['limit', query.limit],
       ['includeBodies', query.includeBodies ? 'true' : undefined],
     ])}`,
@@ -363,13 +366,14 @@ export async function getFreshAgentTurnBody(
   provider: string,
   threadId: string,
   turnId: string,
-  query: { revision: number; signal?: AbortSignal },
+  query: { revision: number; cwd?: string; signal?: AbortSignal },
   options: ApiRequestOptions = {},
 ): Promise<any> {
   const signal = query.signal ?? options.signal
   const data = await api.get(
     `/api/fresh-agent/threads/${encodeURIComponent(sessionType)}/${encodeURIComponent(provider)}/${encodeURIComponent(threadId)}/turns/${encodeURIComponent(turnId)}${buildQueryString([
       ['revision', query.revision],
+      ['cwd', query.cwd],
     ])}`,
     { ...options, signal },
   )

--- a/src/store/freshAgentThunks.ts
+++ b/src/store/freshAgentThunks.ts
@@ -12,6 +12,7 @@ type FreshAgentThreadThunkLocator = {
   sessionType: FreshAgentSessionType
   provider: FreshAgentRuntimeProvider
   sessionId: string
+  cwd?: string
 }
 
 const inFlightControllers = new Set<AbortController>()
@@ -47,6 +48,7 @@ export const loadFreshAgentThreadTurns = createAsyncThunk(
           cursor: input.cursor,
           limit: input.limit,
           includeBodies: input.includeBodies,
+          cwd: input.cwd,
           signal: controller.signal,
         },
       )
@@ -88,6 +90,7 @@ export const loadFreshAgentTurnBody = createAsyncThunk(
         input.turnId,
         {
           revision: input.revision,
+          cwd: input.cwd,
           signal: controller.signal,
         },
       )

--- a/test/integration/server/opencode-serve-real-provider-smoke.test.ts
+++ b/test/integration/server/opencode-serve-real-provider-smoke.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import express from 'express'
 import request from 'supertest'
@@ -10,7 +11,12 @@ import { LayoutStore } from '../../../server/agent-api/layout-store.js'
 import { FreshAgentRuntimeManager } from '../../../server/fresh-agent/runtime-manager.js'
 import { createFreshAgentProviderRegistry } from '../../../server/fresh-agent/provider-registry.js'
 import { createOpencodeFreshAgentAdapter } from '../../../server/fresh-agent/adapters/opencode/adapter.js'
-import { resolveProviderBinary } from '../../../test/helpers/coding-cli/real-session-contract-harness.js'
+import {
+  ProbeWorkspace,
+  resolveProviderBinary,
+  seedOpencodeHomes,
+  waitForOpencodeDbSession,
+} from '../../../test/helpers/coding-cli/real-session-contract-harness.js'
 
 const opencode = await resolveProviderBinary('opencode')
 const KIMI = 'umans-ai-coding-plan/umans-kimi-k2.7'
@@ -33,6 +39,31 @@ describeReal(
           }
         } finally {
           await manager.shutdown()
+        }
+      }, 60_000)
+
+      it('creates first-run sessions in the requested cwd, not the Freshell process cwd', async () => {
+        const workspace = await ProbeWorkspace.create('freshell-opencode-real-cwd-')
+        const requestedCwd = workspace.inTemp('requested-project')
+        const homes = await seedOpencodeHomes(workspace)
+        const manager = new OpencodeServeManager({
+          env: {
+            ...process.env,
+            XDG_DATA_HOME: homes.dataHome,
+            XDG_CONFIG_HOME: homes.configHome,
+          },
+        })
+        try {
+          await fs.mkdir(requestedCwd, { recursive: true })
+          const session = await manager.createSession({ directory: requestedCwd })
+          expect(session.id).toMatch(/^ses_/)
+          expect(session.directory).toBe(requestedCwd)
+
+          const row = await waitForOpencodeDbSession(homes.dbPath, session.id)
+          expect(row.directory).toBe(requestedCwd)
+        } finally {
+          await manager.shutdown()
+          await workspace.cleanup()
         }
       }, 60_000)
     })

--- a/test/server/agent-api-fresh-agent.test.ts
+++ b/test/server/agent-api-fresh-agent.test.ts
@@ -124,6 +124,37 @@ describe('agent-api fresh-agent: send-keys', () => {
     )
   })
 
+  it('passes the pane cwd back to the runtime when sending to a fresh-agent pane', async () => {
+    const freshAgentRuntimeManager = {
+      create: vi.fn(async () => ({
+        sessionId: 'codex-thread-cwd',
+        sessionType: 'freshcodex',
+        runtimeProvider: 'codex',
+        sessionRef: { provider: 'codex', sessionId: 'codex-thread-cwd' },
+      })),
+      send: vi.fn(async () => undefined),
+      attach: vi.fn(async () => ({ sessionId: 'codex-thread-cwd' })),
+      getSnapshot: vi.fn(async () => ({ status: 'idle', turns: [] })),
+    }
+    const { app } = makeApp({ freshAgentRuntimeManager })
+    const created = await request(app).post('/api/tabs').send({ agent: 'codex', cwd: '/repo/persisted-worktree' })
+    const paneId = created.body.data.paneId
+
+    const res = await request(app).post(`/api/panes/${paneId}/send-keys`).send({ data: 'Check cwd' })
+
+    expect(res.status).toBe(200)
+    expect(freshAgentRuntimeManager.send).toHaveBeenCalledWith(
+      { sessionId: 'codex-thread-cwd', sessionType: 'freshcodex', provider: 'codex', cwd: '/repo/persisted-worktree' },
+      { text: 'Check cwd', settings: { cwd: '/repo/persisted-worktree' } },
+    )
+    expect(freshAgentRuntimeManager.getSnapshot).toHaveBeenCalledWith({
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      threadId: 'codex-thread-cwd',
+      cwd: '/repo/persisted-worktree',
+    })
+  })
+
   it('attaches on a lost session before retrying send (cross-process orchestration)', async () => {
     const send = vi.fn().mockRejectedValueOnce(new FreshAgentLostSessionError('not tracked')).mockResolvedValueOnce({ sessionId: 'ses_real_1' })
     const attach = vi.fn(async () => ({ sessionId: 'ses_real_1' }))

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -586,6 +586,7 @@ describe('FreshAgentView', () => {
             provider: 'codex',
             createRequestId: 'req-restored-codex',
             sessionRef: { provider: 'codex', sessionId: 'thread-from-ref' },
+            initialCwd: '/repo/from-ref',
             status: 'connected',
           }}
         />
@@ -593,7 +594,12 @@ describe('FreshAgentView', () => {
     )
 
     await waitFor(() => {
-      expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledWith('freshcodex', 'codex', 'thread-from-ref', expect.any(Object))
+      expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledWith(
+        'freshcodex',
+        'codex',
+        'thread-from-ref',
+        expect.objectContaining({ cwd: '/repo/from-ref' }),
+      )
     })
     expect(await screen.findByText('Codex turn')).toBeInTheDocument()
   })

--- a/test/unit/client/lib/api.test.ts
+++ b/test/unit/client/lib/api.test.ts
@@ -220,23 +220,23 @@ describe('visible-first read-model helpers', () => {
       .mockResolvedValueOnce(mockJson(codexContractTurnPage))
       .mockResolvedValueOnce(mockJson(codexContractTurnBody))
 
-    await getFreshAgentThreadSnapshot('freshcodex', 'codex', 'thread-1', { revision: 7, signal })
-    await getFreshAgentTurnPage('freshcodex', 'codex', 'thread-1', { revision: 7, cursor: 'cursor-1', limit: 20 }, { signal })
-    await getFreshAgentTurnBody('freshcodex', 'codex', 'thread-1', 'turn-1', { revision: 7, signal })
+    await getFreshAgentThreadSnapshot('freshcodex', 'codex', 'thread-1', { revision: 7, cwd: '/repo/worktree', signal })
+    await getFreshAgentTurnPage('freshcodex', 'codex', 'thread-1', { revision: 7, cursor: 'cursor-1', cwd: '/repo/worktree', limit: 20 }, { signal })
+    await getFreshAgentTurnBody('freshcodex', 'codex', 'thread-1', 'turn-1', { revision: 7, cwd: '/repo/worktree', signal })
 
     expect(mockFetch).toHaveBeenNthCalledWith(
       1,
-      '/api/fresh-agent/threads/freshcodex/codex/thread-1?revision=7',
+      '/api/fresh-agent/threads/freshcodex/codex/thread-1?revision=7&cwd=%2Frepo%2Fworktree',
       expect.objectContaining({ signal, headers: expect.any(Headers) }),
     )
     expect(mockFetch).toHaveBeenNthCalledWith(
       2,
-      '/api/fresh-agent/threads/freshcodex/codex/thread-1/turns?revision=7&cursor=cursor-1&limit=20',
+      '/api/fresh-agent/threads/freshcodex/codex/thread-1/turns?revision=7&cursor=cursor-1&cwd=%2Frepo%2Fworktree&limit=20',
       expect.objectContaining({ signal, headers: expect.any(Headers) }),
     )
     expect(mockFetch).toHaveBeenNthCalledWith(
       3,
-      '/api/fresh-agent/threads/freshcodex/codex/thread-1/turns/turn-1?revision=7',
+      '/api/fresh-agent/threads/freshcodex/codex/thread-1/turns/turn-1?revision=7&cwd=%2Frepo%2Fworktree',
       expect.objectContaining({ signal, headers: expect.any(Headers) }),
     )
   })

--- a/test/unit/server/fresh-agent/codex-adapter.test.ts
+++ b/test/unit/server/fresh-agent/codex-adapter.test.ts
@@ -257,6 +257,41 @@ describe('Codex fresh-agent adapter', () => {
     expect(runtime.shutdown).toHaveBeenCalledTimes(1)
   })
 
+  it('lazily resumes a Codex runtime in the saved cwd before reading a persisted thread after server reload', async () => {
+    const runtime = {
+      startThread: vi.fn(),
+      resumeThread: vi.fn().mockResolvedValue({
+        threadId: 'thread-existing-cwd',
+        wsUrl: 'ws://127.0.0.1:43123',
+      }),
+      readThread: vi.fn().mockResolvedValue({
+        thread: makeCodexThread('thread-existing-cwd'),
+      }),
+      listThreadTurns: vi.fn(),
+      readThreadTurn: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    }
+    const adapter = createCodexFreshAgentAdapter({ runtimeFactory: vi.fn(() => runtime) as any })
+
+    await expect(adapter.getSnapshot?.({
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      threadId: 'thread-existing-cwd',
+      cwd: '/repo/persisted-worktree',
+    } as any, 7)).resolves.toMatchObject({
+      provider: 'codex',
+      threadId: 'thread-existing-cwd',
+    })
+
+    expect(runtime.resumeThread).toHaveBeenCalledWith({
+      threadId: 'thread-existing-cwd',
+      cwd: '/repo/persisted-worktree',
+    })
+
+    await adapter.shutdown?.()
+    expect(runtime.shutdown).toHaveBeenCalledTimes(1)
+  })
+
   it('dedupes concurrent lazy runtime resumes for the same persisted thread', async () => {
     let resolveResume: ((value: { threadId: string; wsUrl: string }) => void) | undefined
     const resumePromise = new Promise<{ threadId: string; wsUrl: string }>((resolve) => {

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -24,7 +24,7 @@ function makeFakeManager() {
     getSession: vi.fn(async () => ({ id: 'ses_real_1', title: 'T', time: { updated: 5 } })),
     abort: vi.fn(async () => undefined),
     compact: vi.fn(async () => undefined),
-    fork: vi.fn(async () => ({ id: 'ses_child_1' })),
+    fork: vi.fn(async (): Promise<{ id: string; directory?: string }> => ({ id: 'ses_child_1' })),
     onceIdle: vi.fn(async () => undefined),
     subscribe: vi.fn((id: string, listener: (e: unknown) => void) => {
       const e = emitterFor(id)
@@ -346,6 +346,32 @@ describe('OpenCode serve adapter: control', () => {
       'ses_child_1',
       expect.objectContaining({ parts: [{ type: 'text', text: 'child continue' }] }),
       { cwd: '/repo/control' },
+    )
+  })
+
+  it('routes forked children through the returned child directory when present', async () => {
+    const manager = makeFakeManager()
+    manager.fork.mockResolvedValueOnce({ id: 'ses_child_1', directory: '/repo/child' })
+    const adapter = makeAdapter(manager)
+
+    await adapter.attach?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      sessionId: 'ses_parent',
+      cwd: '/repo/parent',
+    })
+
+    await expect(adapter.fork?.('ses_parent')).resolves.toEqual({
+      sessionId: 'ses_child_1',
+      sessionRef: { provider: 'opencode', sessionId: 'ses_child_1' },
+    })
+    await adapter.send?.('ses_child_1', { text: 'child turn' })
+
+    expect(manager.fork).toHaveBeenCalledWith('ses_parent', { cwd: '/repo/parent' })
+    expect(manager.promptAsync).toHaveBeenCalledWith(
+      'ses_child_1',
+      expect.objectContaining({ parts: [{ type: 'text', text: 'child turn' }] }),
+      { cwd: '/repo/child' },
     )
   })
 

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -12,7 +12,12 @@ function makeFakeManager() {
     return e
   }
   return {
-    createSession: vi.fn(async () => ({ id: 'ses_real_1', directory: '/repo', title: 'T' })),
+    createSession: vi.fn(async (input?: { directory?: string }) => ({
+      id: 'ses_real_1',
+      ...(input?.directory ? { directory: input.directory } : {}),
+      title: 'T',
+    })),
+    rememberSessionCwd: vi.fn(),
     promptAsync: vi.fn(async () => undefined),
     listMessages: vi.fn(async () => ({ messages: [], nextCursor: null })),
     getMessage: vi.fn(async () => null),
@@ -57,7 +62,7 @@ describe('OpenCode serve adapter: create + send', () => {
       parts: [{ type: 'text', text: 'reply ok' }],
       model: { providerID: 'umans-ai-coding-plan', modelID: 'umans-kimi-k2.7' },
       variant: 'high',
-    })
+    }, { cwd: '/repo' })
     expect(manager.onceIdle).toHaveBeenCalledWith('ses_real_1', expect.any(Number))
   })
 
@@ -92,6 +97,47 @@ describe('OpenCode serve adapter: create + send', () => {
     await adapter.send?.('freshopencode-cwd-1', { text: 'hi' })
     expect(manager.createSession).toHaveBeenCalledTimes(1)
     expect(manager.createSession).toHaveBeenLastCalledWith({ directory: '/project-x' })
+    expect(manager.promptAsync).toHaveBeenCalledWith(
+      'ses_real_1',
+      expect.objectContaining({ parts: [{ type: 'text', text: 'hi' }] }),
+      { cwd: '/project-x' },
+    )
+  })
+
+  it('passes restored cwd when sending to an attached durable session', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+
+    await adapter.attach?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      sessionId: 'ses_attached_send',
+      cwd: '/repo/restored-worktree',
+    })
+    await adapter.send?.('ses_attached_send', { text: 'continue' })
+
+    expect(manager.promptAsync).toHaveBeenCalledWith(
+      'ses_attached_send',
+      { parts: [{ type: 'text', text: 'continue' }] },
+      { cwd: '/repo/restored-worktree' },
+    )
+  })
+
+  it('keeps attached no-cwd sessions sendable without a route argument', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+
+    await adapter.attach?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      sessionId: 'ses_attached_nocwd',
+    })
+    await adapter.send?.('ses_attached_nocwd', { text: 'continue' })
+
+    expect(manager.promptAsync).toHaveBeenCalledWith(
+      'ses_attached_nocwd',
+      { parts: [{ type: 'text', text: 'continue' }] },
+    )
   })
 
   it('recovers from a failed send and still processes later sends', async () => {
@@ -156,38 +202,73 @@ describe('OpenCode serve adapter: history reads', () => {
     { info: { id: 'msg_assistant_1', role: 'assistant', providerID: 'umans-ai-coding-plan', modelID: 'umans-kimi-k2.7' }, parts: [{ id: 'p2', type: 'text', text: 'ok' }] },
   ]
 
+  it('remembers cwd when attaching a durable OpenCode session', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+
+    await adapter.attach?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      sessionId: 'ses_existing_cwd',
+      cwd: '/repo/from-pane',
+    })
+
+    expect(manager.rememberSessionCwd).toHaveBeenCalledWith('ses_existing_cwd', '/repo/from-pane')
+  })
+
   it('getSnapshot assembles HTTP messages into the normalized transcript', async () => {
     const manager = makeFakeManager()
     manager.getSession = vi.fn(async () => ({ id: 'ses_real_1', title: 'Kimi chat', time: { updated: 12 } }))
     manager.listMessages = vi.fn(async () => ({ messages, nextCursor: null }))
     const adapter = makeAdapter(manager)
-    await adapter.attach?.({ sessionType: 'freshopencode', provider: 'opencode', sessionId: 'ses_real_1' })
+    await adapter.attach?.({ sessionType: 'freshopencode', provider: 'opencode', sessionId: 'ses_real_1', cwd: '/repo/history' })
     await expect(adapter.getSnapshot?.({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_real_1' })).resolves.toMatchObject({
       sessionId: 'ses_real_1', summary: 'Kimi chat', revision: 12,
       turns: [{ turnId: 'msg_user_1', role: 'user', summary: 'reply ok' }, { turnId: 'msg_assistant_1', role: 'assistant', summary: 'ok' }],
     })
-    expect(manager.listMessages).toHaveBeenCalledWith('ses_real_1', { limit: 200 })
+    expect(manager.getSession).toHaveBeenCalledWith('ses_real_1', { cwd: '/repo/history' })
+    expect(manager.listMessages).toHaveBeenCalledWith('ses_real_1', { limit: 200 }, { cwd: '/repo/history' })
+  })
+
+  it('omits history route arguments when no cwd is known', async () => {
+    const manager = makeFakeManager()
+    manager.getSession = vi.fn(async () => ({ id: 'ses_real_1', title: 'Kimi chat', time: { updated: 12 } }))
+    manager.listMessages = vi.fn(async () => ({ messages, nextCursor: null }))
+    manager.getMessage = vi.fn(async () => messages[1])
+    const adapter = makeAdapter(manager)
+
+    await adapter.attach?.({ sessionType: 'freshopencode', provider: 'opencode', sessionId: 'ses_real_1' })
+    await adapter.getSnapshot?.({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_real_1' })
+    await adapter.getTurnPage?.({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_real_1' }, { limit: 1, revision: 0 })
+    await adapter.getTurnBody?.({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_real_1', turnId: 'msg_assistant_1' }, 12)
+
+    expect(manager.getSession).toHaveBeenNthCalledWith(1, 'ses_real_1')
+    expect(manager.getSession).toHaveBeenNthCalledWith(2, 'ses_real_1')
+    expect(manager.listMessages).toHaveBeenNthCalledWith(1, 'ses_real_1', { limit: 200 })
+    expect(manager.listMessages).toHaveBeenNthCalledWith(2, 'ses_real_1', { limit: 1, before: undefined })
+    expect(manager.getMessage).toHaveBeenCalledWith('ses_real_1', 'msg_assistant_1')
   })
 
   it('getTurnPage forwards cursor as before= and returns nextCursor from the header', async () => {
     const manager = makeFakeManager()
     manager.listMessages = vi.fn(async () => ({ messages: messages.slice(0, 1), nextCursor: 'NEXT' }))
     const adapter = makeAdapter(manager)
-    await adapter.attach?.({ sessionType: 'freshopencode', provider: 'opencode', sessionId: 'ses_real_1' })
+    await adapter.attach?.({ sessionType: 'freshopencode', provider: 'opencode', sessionId: 'ses_real_1', cwd: '/repo/history' })
     const page = await adapter.getTurnPage?.({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_real_1' }, { cursor: 'CUR', limit: 1, revision: 0 })
     expect(page).toMatchObject({ nextCursor: 'NEXT', turns: [{ turnId: 'msg_user_1' }] })
-    expect(manager.listMessages).toHaveBeenCalledWith('ses_real_1', { limit: 1, before: 'CUR' })
+    expect(manager.getSession).toHaveBeenCalledWith('ses_real_1', { cwd: '/repo/history' })
+    expect(manager.listMessages).toHaveBeenCalledWith('ses_real_1', { limit: 1, before: 'CUR' }, { cwd: '/repo/history' })
   })
 
   it('getTurnBody fetches a single message and normalizes it', async () => {
     const manager = makeFakeManager()
     manager.getMessage = vi.fn(async () => messages[1])
     const adapter = makeAdapter(manager)
-    await adapter.attach?.({ sessionType: 'freshopencode', provider: 'opencode', sessionId: 'ses_real_1' })
+    await adapter.attach?.({ sessionType: 'freshopencode', provider: 'opencode', sessionId: 'ses_real_1', cwd: '/repo/history' })
     await expect(adapter.getTurnBody?.({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_real_1', turnId: 'msg_assistant_1' }, 12)).resolves.toMatchObject({
       turnId: 'msg_assistant_1', role: 'assistant', items: expect.arrayContaining([expect.objectContaining({ kind: 'text', text: 'ok' })]),
     })
-    expect(manager.getMessage).toHaveBeenCalledWith('ses_real_1', 'msg_assistant_1')
+    expect(manager.getMessage).toHaveBeenCalledWith('ses_real_1', 'msg_assistant_1', { cwd: '/repo/history' })
   })
 
   it('reports fork capability true and approvals/questions false', async () => {
@@ -195,7 +276,7 @@ describe('OpenCode serve adapter: history reads', () => {
     manager.getSession = vi.fn(async () => ({ id: 'ses_real_1', time: { updated: 1 } }))
     manager.listMessages = vi.fn(async () => ({ messages: [], nextCursor: null }))
     const adapter = makeAdapter(manager)
-    await adapter.attach?.({ sessionType: 'freshopencode', provider: 'opencode', sessionId: 'ses_real_1' })
+    await adapter.attach?.({ sessionType: 'freshopencode', provider: 'opencode', sessionId: 'ses_real_1', cwd: '/repo/history' })
     const snap: any = await adapter.getSnapshot?.({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_real_1' })
     expect(snap.capabilities).toMatchObject({ fork: true, approvals: false, questions: false })
   })
@@ -237,6 +318,35 @@ describe('OpenCode serve adapter: control', () => {
     } finally {
       off()
     }
+  })
+
+  it('routes control operations through the known cwd', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+
+    await adapter.attach?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      sessionId: 'ses_known_cwd',
+      cwd: '/repo/control',
+    })
+
+    await adapter.interrupt?.('ses_known_cwd')
+    await adapter.compact?.('ses_known_cwd', { instructions: 'trim' })
+    await expect(adapter.fork?.('ses_known_cwd')).resolves.toEqual({
+      sessionId: 'ses_child_1',
+      sessionRef: { provider: 'opencode', sessionId: 'ses_child_1' },
+    })
+    await adapter.send?.('ses_child_1', { text: 'child continue' })
+
+    expect(manager.abort).toHaveBeenCalledWith('ses_known_cwd', { cwd: '/repo/control' })
+    expect(manager.compact).toHaveBeenCalledWith('ses_known_cwd', { instructions: 'trim' }, { cwd: '/repo/control' })
+    expect(manager.fork).toHaveBeenCalledWith('ses_known_cwd', { cwd: '/repo/control' })
+    expect(manager.promptAsync).toHaveBeenCalledWith(
+      'ses_child_1',
+      expect.objectContaining({ parts: [{ type: 'text', text: 'child continue' }] }),
+      { cwd: '/repo/control' },
+    )
   })
 
   it('shutdown delegates to the serve manager', async () => {

--- a/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
@@ -393,7 +393,7 @@ describe('OpencodeServeManager HTTP client', () => {
         return jsonResponse({ id: 'ses_project', directory: '/project-a' })
       }
       if (url === 'http://127.0.0.1:48000/session/ses_unknown' && init?.method === 'GET') {
-        return jsonResponse({ id: 'ses_unknown', title: 'Unknown' })
+        throw new Error('unknown session lookup must not hit cwd sidecar')
       }
       if (url === 'http://127.0.0.1:47999/global/health') return jsonResponse({ healthy: true })
       if (url === 'http://127.0.0.1:47999/session/ses_unknown' && init?.method === 'GET') {
@@ -422,6 +422,7 @@ describe('OpencodeServeManager HTTP client', () => {
       expect.objectContaining({ cwd: '/project-a' }),
     )
     expect(spawnFn.mock.calls[1]?.[2]).not.toHaveProperty('cwd')
+    expect(fetchFn).not.toHaveBeenCalledWith('http://127.0.0.1:48000/session/ses_unknown', expect.anything())
     expect(fetchFn).toHaveBeenCalledWith('http://127.0.0.1:47999/session/ses_unknown', expect.anything())
   })
 })
@@ -578,7 +579,7 @@ describe('OpencodeServeManager fan-out', () => {
     expect((manager as any).sessionEmitters.has('ses_project')).toBe(true)
   })
 
-  it('non-default sidecar close does not delete unrelated default emitters', async () => {
+  it('non-default sidecar close removes its mapped emitter and preserves unrelated default emitters', async () => {
     const childDefault = fakeChild()
     const childProject = fakeChild()
     const spawnFn = vi.fn()
@@ -614,9 +615,12 @@ describe('OpencodeServeManager fan-out', () => {
     await manager.compact('ses_project')
     manager.subscribe('ses_project', () => {})
     expect(spawnFn).toHaveBeenCalledTimes(2)
+    expect((manager as any).sessionEmitters.has('ses_default')).toBe(true)
+    expect((manager as any).sessionEmitters.has('ses_project')).toBe(true)
 
     childProject.emit('close', 1)
 
+    expect((manager as any).sessionEmitters.has('ses_project')).toBe(false)
     expect((manager as any).sessionEmitters.has('ses_default')).toBe(true)
   })
 

--- a/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
@@ -58,6 +58,83 @@ describe('OpencodeServeManager lifecycle', () => {
     expect(fetchFn).toHaveBeenCalledWith('http://127.0.0.1:47999/global/health', expect.anything())
   })
 
+  it('starts the serve process in the requested session directory before creating the first session', async () => {
+    const calls: Array<{ url: string; init: any }> = []
+    const fetchFn = vi.fn(async (url: string, init: any) => {
+      calls.push({ url, init })
+      if (url.endsWith('/global/health')) return jsonResponse({ healthy: true, version: '1.17.8' })
+      if (url.endsWith('/session') && init?.method === 'POST') {
+        return jsonResponse({ id: 'ses_project_x', directory: '/project-x', title: 'Project X' })
+      }
+      return jsonResponse({})
+    })
+    const { manager, spawnFn } = makeManager({ fetchFn: fetchFn as any })
+
+    const session = await manager.createSession({ directory: '/project-x' })
+
+    expect(session).toMatchObject({ id: 'ses_project_x', directory: '/project-x' })
+    expect(spawnFn).toHaveBeenCalledWith(
+      'opencode',
+      ['serve', '--hostname', '127.0.0.1', '--port', '47999'],
+      expect.objectContaining({
+        cwd: '/project-x',
+        env: expect.objectContaining({ FRESHELL_OPENCODE_SIDECAR_ID: expect.any(String) }),
+      }),
+    )
+    expect(calls.find((call) => call.url.endsWith('/session'))).toMatchObject({
+      url: 'http://127.0.0.1:47999/session',
+      init: expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ directory: '/project-x' }),
+      }),
+    })
+  })
+
+  it('uses separate serve processes for sessions created in different directories', async () => {
+    const childA = fakeChild()
+    const childB = fakeChild()
+    const spawnFn = vi.fn()
+      .mockReturnValueOnce(childA)
+      .mockReturnValueOnce(childB)
+    const fetchFn = vi.fn(async (url: string, init: any) => {
+      if (url === 'http://127.0.0.1:47999/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:48000/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:47999/session' && init?.method === 'POST') {
+        return jsonResponse({ id: 'ses_a', directory: '/project-a' })
+      }
+      if (url === 'http://127.0.0.1:48000/session' && init?.method === 'POST') {
+        return jsonResponse({ id: 'ses_b', directory: '/project-b' })
+      }
+      return jsonResponse({})
+    })
+    const manager = new OpencodeServeManager({
+      spawnFn: spawnFn as any,
+      fetchFn: fetchFn as any,
+      allocatePort: vi.fn()
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 47999 })
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 48000 }),
+      connectEventStream: () => () => {},
+      healthTimeoutMs: 1000,
+    })
+
+    await expect(manager.createSession({ directory: '/project-a' })).resolves.toMatchObject({ id: 'ses_a' })
+    await expect(manager.createSession({ directory: '/project-b' })).resolves.toMatchObject({ id: 'ses_b' })
+
+    expect(spawnFn).toHaveBeenCalledTimes(2)
+    expect(spawnFn).toHaveBeenNthCalledWith(
+      1,
+      'opencode',
+      ['serve', '--hostname', '127.0.0.1', '--port', '47999'],
+      expect.objectContaining({ cwd: '/project-a' }),
+    )
+    expect(spawnFn).toHaveBeenNthCalledWith(
+      2,
+      'opencode',
+      ['serve', '--hostname', '127.0.0.1', '--port', '48000'],
+      expect.objectContaining({ cwd: '/project-b' }),
+    )
+  })
+
   it('shuts down by killing the spawned process and refuses further use until restarted', async () => {
     const { manager, child } = makeManager()
     await manager.ensureStarted()
@@ -182,6 +259,171 @@ describe('OpencodeServeManager HTTP client', () => {
     const { manager } = makeManager({ fetchFn: fetchFn as any })
     await expect(manager.getMessage('ses_x', 'broken')).rejects.toThrow(/opencode serve GET .*\/message\/broken → 500/)
   })
+
+  it('posts summarize requests to a cwd sidecar learned from getSession', async () => {
+    const calls: Array<{ url: string; init: any }> = []
+    const childDefault = fakeChild()
+    const childProject = fakeChild()
+    const spawnFn = vi.fn()
+      .mockReturnValueOnce(childDefault)
+      .mockReturnValueOnce(childProject)
+    const fetchFn = vi.fn(async (url: string, init: any) => {
+      calls.push({ url, init })
+      if (url === 'http://127.0.0.1:47999/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:47999/session/ses_known' && init?.method === 'GET') {
+        return jsonResponse({ id: 'ses_known', directory: '/project-a', title: 'Known' })
+      }
+      if (url === 'http://127.0.0.1:47999/session/ses_known/compact' && init?.method === 'POST') {
+        return jsonResponse({}, { status: 204 })
+      }
+      if (url === 'http://127.0.0.1:48000/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:48000/session/ses_known/summarize' && init?.method === 'POST') {
+        return jsonResponse({}, { status: 204 })
+      }
+      return jsonResponse({}, { status: 404 })
+    })
+    const manager = new OpencodeServeManager({
+      spawnFn: spawnFn as any,
+      fetchFn: fetchFn as any,
+      allocatePort: vi.fn()
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 47999 })
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 48000 }),
+      connectEventStream: () => () => {},
+      healthTimeoutMs: 1000,
+    })
+
+    await expect(manager.getSession('ses_known')).resolves.toMatchObject({ id: 'ses_known', directory: '/project-a' })
+    await manager.compact('ses_known', { instructions: 'keep it short' })
+
+    expect(spawnFn).toHaveBeenCalledTimes(2)
+    expect(spawnFn.mock.calls[0]?.[2]).not.toHaveProperty('cwd')
+    expect(spawnFn).toHaveBeenNthCalledWith(
+      2,
+      'opencode',
+      ['serve', '--hostname', '127.0.0.1', '--port', '48000'],
+      expect.objectContaining({ cwd: '/project-a' }),
+    )
+    expect(calls.find((call) => call.url.endsWith('/summarize'))).toMatchObject({
+      url: 'http://127.0.0.1:48000/session/ses_known/summarize',
+      init: expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ instructions: 'keep it short' }),
+      }),
+    })
+    expect(calls.some((call) => call.url.endsWith('/compact'))).toBe(false)
+  })
+
+  it('remembers the forked child directory for later requests instead of keeping the parent route', async () => {
+    const calls: Array<{ url: string; init: any }> = []
+    const childDefault = fakeChild()
+    const childParent = fakeChild()
+    const childFork = fakeChild()
+    const spawnFn = vi.fn()
+      .mockReturnValueOnce(childDefault)
+      .mockReturnValueOnce(childParent)
+      .mockReturnValueOnce(childFork)
+    const fetchFn = vi.fn(async (url: string, init: any) => {
+      calls.push({ url, init })
+      if (url === 'http://127.0.0.1:47999/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:47999/session/ses_parent' && init?.method === 'GET') {
+        return jsonResponse({ id: 'ses_parent', directory: '/parent' })
+      }
+      if (url === 'http://127.0.0.1:47999/session/ses_parent/fork' && init?.method === 'POST') {
+        return jsonResponse({ id: 'ses_child', directory: '/child' })
+      }
+      if (url === 'http://127.0.0.1:47999/session/ses_child/compact' && init?.method === 'POST') {
+        return jsonResponse({}, { status: 204 })
+      }
+      if (url === 'http://127.0.0.1:48000/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:48000/session/ses_parent/fork' && init?.method === 'POST') {
+        return jsonResponse({ id: 'ses_child', directory: '/child' })
+      }
+      if (url === 'http://127.0.0.1:48001/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:48001/session/ses_child/summarize' && init?.method === 'POST') {
+        return jsonResponse({}, { status: 204 })
+      }
+      return jsonResponse({}, { status: 404 })
+    })
+    const manager = new OpencodeServeManager({
+      spawnFn: spawnFn as any,
+      fetchFn: fetchFn as any,
+      allocatePort: vi.fn()
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 47999 })
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 48000 })
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 48001 }),
+      connectEventStream: () => () => {},
+      healthTimeoutMs: 1000,
+    })
+
+    await expect(manager.getSession('ses_parent')).resolves.toMatchObject({ id: 'ses_parent', directory: '/parent' })
+    await expect(manager.fork('ses_parent')).resolves.toMatchObject({ id: 'ses_child', directory: '/child' })
+    await manager.compact('ses_child', { instructions: 'child summary' })
+
+    expect(spawnFn).toHaveBeenCalledTimes(3)
+    expect(spawnFn).toHaveBeenNthCalledWith(
+      2,
+      'opencode',
+      ['serve', '--hostname', '127.0.0.1', '--port', '48000'],
+      expect.objectContaining({ cwd: '/parent' }),
+    )
+    expect(spawnFn).toHaveBeenNthCalledWith(
+      3,
+      'opencode',
+      ['serve', '--hostname', '127.0.0.1', '--port', '48001'],
+      expect.objectContaining({ cwd: '/child' }),
+    )
+    expect(calls.find((call) => call.url.endsWith('/session/ses_child/summarize'))).toMatchObject({
+      url: 'http://127.0.0.1:48001/session/ses_child/summarize',
+      init: expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ instructions: 'child summary' }),
+      }),
+    })
+  })
+
+  it('uses the default serve route for unknown existing sessions even after cwd sidecars exist', async () => {
+    const childProject = fakeChild()
+    const childDefault = fakeChild()
+    const spawnFn = vi.fn()
+      .mockReturnValueOnce(childProject)
+      .mockReturnValueOnce(childDefault)
+    const fetchFn = vi.fn(async (url: string, init: any) => {
+      if (url === 'http://127.0.0.1:48000/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:48000/session' && init?.method === 'POST') {
+        return jsonResponse({ id: 'ses_project', directory: '/project-a' })
+      }
+      if (url === 'http://127.0.0.1:48000/session/ses_unknown' && init?.method === 'GET') {
+        return jsonResponse({ id: 'ses_unknown', title: 'Unknown' })
+      }
+      if (url === 'http://127.0.0.1:47999/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:47999/session/ses_unknown' && init?.method === 'GET') {
+        return jsonResponse({ id: 'ses_unknown', title: 'Unknown' })
+      }
+      return jsonResponse({}, { status: 404 })
+    })
+    const manager = new OpencodeServeManager({
+      spawnFn: spawnFn as any,
+      fetchFn: fetchFn as any,
+      allocatePort: vi.fn()
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 48000 })
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 47999 }),
+      connectEventStream: () => () => {},
+      healthTimeoutMs: 1000,
+    })
+
+    await expect(manager.createSession({ directory: '/project-a' })).resolves.toMatchObject({ id: 'ses_project' })
+    await expect(manager.getSession('ses_unknown')).resolves.toMatchObject({ id: 'ses_unknown' })
+
+    expect(spawnFn).toHaveBeenCalledTimes(2)
+    expect(spawnFn).toHaveBeenNthCalledWith(
+      1,
+      'opencode',
+      ['serve', '--hostname', '127.0.0.1', '--port', '48000'],
+      expect.objectContaining({ cwd: '/project-a' }),
+    )
+    expect(spawnFn.mock.calls[1]?.[2]).not.toHaveProperty('cwd')
+    expect(fetchFn).toHaveBeenCalledWith('http://127.0.0.1:47999/session/ses_unknown', expect.anything())
+  })
 })
 
 describe('OpencodeServeManager fan-out', () => {
@@ -291,6 +533,138 @@ describe('OpencodeServeManager fan-out', () => {
     expect(child.kill).toHaveBeenCalled()
     expect((manager as any).sessionEmitters.size).toBe(0)
     expect((manager as any).running).toBeUndefined()
+  })
+
+  it('default sidecar close clears unmapped emitters but preserves mapped cwd sessions', async () => {
+    const childDefault = fakeChild()
+    const childProject = fakeChild()
+    const spawnFn = vi.fn()
+      .mockReturnValueOnce(childDefault)
+      .mockReturnValueOnce(childProject)
+    const fetchFn = vi.fn(async (url: string, init: any) => {
+      if (url === 'http://127.0.0.1:47999/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:47999/session/ses_project' && init?.method === 'GET') {
+        return jsonResponse({ id: 'ses_project', directory: '/project-a' })
+      }
+      if (url === 'http://127.0.0.1:47999/session/ses_project/compact' && init?.method === 'POST') {
+        return jsonResponse({}, { status: 204 })
+      }
+      if (url === 'http://127.0.0.1:48000/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:48000/session/ses_project/summarize' && init?.method === 'POST') {
+        return jsonResponse({}, { status: 204 })
+      }
+      return jsonResponse({}, { status: 404 })
+    })
+    const manager = new OpencodeServeManager({
+      spawnFn: spawnFn as any,
+      fetchFn: fetchFn as any,
+      allocatePort: vi.fn()
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 47999 })
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 48000 }),
+      connectEventStream: () => () => {},
+      healthTimeoutMs: 1000,
+    })
+
+    await manager.ensureStarted()
+    manager.subscribe('ses_default', () => {})
+    await manager.getSession('ses_project')
+    await manager.compact('ses_project')
+    manager.subscribe('ses_project', () => {})
+    expect(spawnFn).toHaveBeenCalledTimes(2)
+
+    childDefault.emit('close', 1)
+
+    expect((manager as any).sessionEmitters.has('ses_default')).toBe(false)
+    expect((manager as any).sessionEmitters.has('ses_project')).toBe(true)
+  })
+
+  it('non-default sidecar close does not delete unrelated default emitters', async () => {
+    const childDefault = fakeChild()
+    const childProject = fakeChild()
+    const spawnFn = vi.fn()
+      .mockReturnValueOnce(childDefault)
+      .mockReturnValueOnce(childProject)
+    const fetchFn = vi.fn(async (url: string, init: any) => {
+      if (url === 'http://127.0.0.1:47999/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:47999/session/ses_project' && init?.method === 'GET') {
+        return jsonResponse({ id: 'ses_project', directory: '/project-a' })
+      }
+      if (url === 'http://127.0.0.1:47999/session/ses_project/compact' && init?.method === 'POST') {
+        return jsonResponse({}, { status: 204 })
+      }
+      if (url === 'http://127.0.0.1:48000/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:48000/session/ses_project/summarize' && init?.method === 'POST') {
+        return jsonResponse({}, { status: 204 })
+      }
+      return jsonResponse({}, { status: 404 })
+    })
+    const manager = new OpencodeServeManager({
+      spawnFn: spawnFn as any,
+      fetchFn: fetchFn as any,
+      allocatePort: vi.fn()
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 47999 })
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 48000 }),
+      connectEventStream: () => () => {},
+      healthTimeoutMs: 1000,
+    })
+
+    await manager.ensureStarted()
+    manager.subscribe('ses_default', () => {})
+    await manager.getSession('ses_project')
+    await manager.compact('ses_project')
+    manager.subscribe('ses_project', () => {})
+    expect(spawnFn).toHaveBeenCalledTimes(2)
+
+    childProject.emit('close', 1)
+
+    expect((manager as any).sessionEmitters.has('ses_default')).toBe(true)
+  })
+
+  it('idles out cwd sidecars without stopping the default serve', async () => {
+    vi.useFakeTimers()
+    try {
+      const childDefault = fakeChild()
+      const childProject = fakeChild()
+      const spawnFn = vi.fn()
+        .mockReturnValueOnce(childDefault)
+        .mockReturnValueOnce(childProject)
+      const fetchFn = vi.fn(async (url: string, init: any) => {
+        if (url === 'http://127.0.0.1:47999/global/health') return jsonResponse({ healthy: true })
+        if (url === 'http://127.0.0.1:47999/session/ses_project' && init?.method === 'GET') {
+          return jsonResponse({ id: 'ses_project', directory: '/project-a' })
+        }
+        if (url === 'http://127.0.0.1:47999/session/ses_project/compact' && init?.method === 'POST') {
+          return jsonResponse({}, { status: 204 })
+        }
+        if (url === 'http://127.0.0.1:48000/global/health') return jsonResponse({ healthy: true })
+        if (url === 'http://127.0.0.1:48000/session/ses_project/summarize' && init?.method === 'POST') {
+          return jsonResponse({}, { status: 204 })
+        }
+        return jsonResponse({}, { status: 404 })
+      })
+      const manager = new OpencodeServeManager({
+        spawnFn: spawnFn as any,
+        fetchFn: fetchFn as any,
+        allocatePort: vi.fn()
+          .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 47999 })
+          .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 48000 }),
+        connectEventStream: () => () => {},
+        healthTimeoutMs: 1000,
+        idleShutdownMs: 50,
+      } as any)
+
+      await manager.ensureStarted()
+      await manager.getSession('ses_project')
+      await manager.compact('ses_project')
+      expect(spawnFn).toHaveBeenCalledTimes(2)
+
+      await vi.advanceTimersByTimeAsync(51)
+
+      expect(childProject.kill).toHaveBeenCalled()
+      expect(childDefault.kill).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('parses multi-line SSE data blocks by joining data: lines', async () => {

--- a/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
@@ -176,8 +176,8 @@ describe('OpencodeServeManager lifecycle', () => {
     await expect(started).rejects.toThrow(/opencode serve startup was aborted|opencode serve did not become healthy/)
     await shutdown
     expect(child.kill).toHaveBeenCalled()
-    expect((manager as any).running).toBeUndefined()
-    expect((manager as any).startPromise).toBeUndefined()
+    expect((manager as any).runningByCwd.size).toBe(0)
+    expect((manager as any).startPromiseByCwd.size).toBe(0)
   })
 })
 
@@ -533,7 +533,7 @@ describe('OpencodeServeManager fan-out', () => {
     expect(stopStream).toHaveBeenCalled()
     expect(child.kill).toHaveBeenCalled()
     expect((manager as any).sessionEmitters.size).toBe(0)
-    expect((manager as any).running).toBeUndefined()
+    expect((manager as any).runningByCwd.size).toBe(0)
   })
 
   it('default sidecar close clears unmapped emitters but preserves mapped cwd sessions', async () => {

--- a/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
@@ -381,6 +381,48 @@ describe('OpencodeServeManager HTTP client', () => {
     })
   })
 
+  it('falls back to the fork route cwd when the fork response omits directory', async () => {
+    const calls: Array<{ url: string; init: any }> = []
+    const childParent = fakeChild()
+    const spawnFn = vi.fn().mockReturnValueOnce(childParent)
+    const fetchFn = vi.fn(async (url: string, init: any) => {
+      calls.push({ url, init })
+      if (url === 'http://127.0.0.1:47999/global/health') return jsonResponse({ healthy: true })
+      if (url === 'http://127.0.0.1:47999/session/ses_parent/fork' && init?.method === 'POST') {
+        return jsonResponse({ id: 'ses_child' })
+      }
+      if (url === 'http://127.0.0.1:47999/session/ses_child/summarize' && init?.method === 'POST') {
+        return jsonResponse({}, { status: 204 })
+      }
+      if (url.includes('/session/ses_child/summarize')) {
+        throw new Error(`child summarize should stay on parent cwd route, got ${url}`)
+      }
+      return jsonResponse({}, { status: 404 })
+    })
+    const manager = new OpencodeServeManager({
+      spawnFn: spawnFn as any,
+      fetchFn: fetchFn as any,
+      allocatePort: vi.fn()
+        .mockResolvedValueOnce({ hostname: '127.0.0.1', port: 47999 }),
+      connectEventStream: () => () => {},
+      healthTimeoutMs: 1000,
+    })
+
+    await expect(manager.fork('ses_parent', { cwd: '/parent' })).resolves.toMatchObject({ id: 'ses_child' })
+    await manager.compact('ses_child', { instructions: 'child summary' })
+
+    expect(spawnFn).toHaveBeenCalledTimes(1)
+    expect(spawnFn).toHaveBeenCalledWith(
+      'opencode',
+      ['serve', '--hostname', '127.0.0.1', '--port', '47999'],
+      expect.objectContaining({ cwd: '/parent' }),
+    )
+    expect(calls.find((call) => call.url.endsWith('/session/ses_child/summarize'))).toMatchObject({
+      url: 'http://127.0.0.1:47999/session/ses_child/summarize',
+      init: expect.objectContaining({ method: 'POST' }),
+    })
+  })
+
   it('uses the default serve route for unknown existing sessions even after cwd sidecars exist', async () => {
     const childProject = fakeChild()
     const childDefault = fakeChild()

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -670,6 +670,7 @@ describe('WsHandler fresh-agent routing', () => {
         sessionType: 'freshclaude',
         provider: 'claude',
         resumeSessionId: 'cli-session-attached',
+        cwd: '/repo/restored-worktree',
       }))
 
       await vi.waitFor(() => {
@@ -677,14 +678,25 @@ describe('WsHandler fresh-agent routing', () => {
           sessionId: 'claude-session-attached',
           sessionType: 'freshclaude',
           provider: 'claude',
+          cwd: '/repo/restored-worktree',
         })
         expect(runtimeManager.subscribe).toHaveBeenCalledWith(
-          { sessionId: 'claude-session-attached', sessionType: 'freshclaude', provider: 'claude' },
+          {
+            sessionId: 'claude-session-attached',
+            sessionType: 'freshclaude',
+            provider: 'claude',
+            cwd: '/repo/restored-worktree',
+          },
           expect.any(Function),
         )
       })
 
-      listeners.get(JSON.stringify({ sessionId: 'claude-session-attached', sessionType: 'freshclaude', provider: 'claude' }))?.({ kind: 'thread.updated', revision: 2 })
+      listeners.get(JSON.stringify({
+        sessionId: 'claude-session-attached',
+        sessionType: 'freshclaude',
+        provider: 'claude',
+        cwd: '/repo/restored-worktree',
+      }))?.({ kind: 'thread.updated', revision: 2 })
 
       await vi.waitFor(() => {
         expect(seenMessages).toContainEqual({


### PR DESCRIPTION
## Summary
- Scope freshopencode `opencode serve` sidecars by working directory and remember session cwd for later operations.
- Pass pane cwd through fresh-agent REST/WS/runtime paths so freshopencode and freshcodex restored sessions run in the intended directory.
- Add focused unit coverage plus real OpenCode smoke coverage for cwd materialization and routing.

## Verification
- `FRESHELL_TEST_SUMMARY="verify rebased freshopencode cwd-scoped serve fix before PR" npm run check`
- Final Fresh Eyes delta review passed before the delayed landing window.
