### PR TITLE
Fix freshopencode bouncer after assistant completion

### DIFF
--- a/server/fresh-agent/adapters/opencode/serve-events.ts
+++ b/server/fresh-agent/adapters/opencode/serve-events.ts
@@ -45,32 +45,47 @@ export function parseServeEvent(event: unknown): ParsedServeEvent | null {
 
 export type SdkProviderEvent =
   | { type: 'sdk.session.snapshot'; sessionId: string; status: 'running' | 'idle' }
+  | { type: 'sdk.session.changed'; sessionId: string; reason: 'opencode-message' | 'opencode-status' }
   | { type: 'sdk.error'; sessionId: string; message: string }
 
+function opencodeStatusToSnapshotStatus(statusType: string | undefined): 'running' | 'idle' | undefined {
+  switch (statusType) {
+    case 'busy':
+    case 'retry':
+      return 'running'
+    case 'idle':
+      return 'idle'
+    default:
+      return undefined
+  }
+}
+
+function isOpencodeTranscriptEvent(kind: string): boolean {
+  return kind.startsWith('message.')
+}
+
 /** Map a parsed serve event to the `sdk.*` provider event the existing client
- * slice already understands. We deliberately collapse fine-grained part events
- * into a `running` snapshot: the client re-polls the HTTP transcript on every
- * `freshAgent.event`, so this yields live (per-assistant-message) updates with
- * zero client change. `subscribedId` is the id the listener subscribed with
- * (placeholder before materialization, durable `ses_` after). */
+ * slice already understands. Transcript events are invalidations, not lifecycle
+ * state: OpenCode can emit trailing message metadata after a turn is already
+ * idle, and mapping those updates to `running` leaves freshopencode bouncing. */
 export function serveEventToSdk(parsed: ParsedServeEvent, subscribedId: string): SdkProviderEvent | null {
   const props = parsed.properties
   switch (parsed.kind) {
     case 'session.idle':
       return { type: 'sdk.session.snapshot', sessionId: subscribedId, status: 'idle' }
     case 'session.status': {
-      const statusType = stringProperty(props.status, 'type')
-      return { type: 'sdk.session.snapshot', sessionId: subscribedId, status: statusType === 'idle' ? 'idle' : 'running' }
+      const status = opencodeStatusToSnapshotStatus(stringProperty(props.status, 'type'))
+      if (status) return { type: 'sdk.session.snapshot', sessionId: subscribedId, status }
+      return { type: 'sdk.session.changed', sessionId: subscribedId, reason: 'opencode-status' }
     }
-    case 'message.part.delta':
-    case 'message.part.updated':
-    case 'message.updated':
-      return { type: 'sdk.session.snapshot', sessionId: subscribedId, status: 'running' }
     case 'session.error': {
       const message = stringProperty(props.error, 'message') ?? 'OpenCode session error'
       return { type: 'sdk.error', sessionId: subscribedId, message }
     }
     default:
+      if (isOpencodeTranscriptEvent(parsed.kind)) {
+        return { type: 'sdk.session.changed', sessionId: subscribedId, reason: 'opencode-message' }
+      }
       return null
   }
 }

--- a/server/fresh-agent/adapters/opencode/serve-manager.ts
+++ b/server/fresh-agent/adapters/opencode/serve-manager.ts
@@ -10,6 +10,8 @@ import { parseServeEvent, type ParsedServeEvent } from './serve-events.js'
 type OpencodeServeLogger = Pick<pino.Logger, 'warn' | 'error'>
 
 const OWNERSHIP_ENV = 'FRESHELL_OPENCODE_SIDECAR_ID'
+const DEFAULT_IDLE_POLL_MS = 500
+const REQUIRED_IDLE_STATUS_POLLS = 2
 
 export type OpencodeServeManagerOptions = {
   command?: string
@@ -21,18 +23,40 @@ export type OpencodeServeManagerOptions = {
   healthTimeoutMs?: number
   env?: NodeJS.ProcessEnv
   idleShutdownMs?: number
+  idlePollMs?: number
 }
 
 export type OpencodeServeMessage = { info: Record<string, any>; parts: Array<Record<string, any>> }
 export type OpencodeServeMessagePage = { messages: OpencodeServeMessage[]; nextCursor: string | null }
 
 type HealthResponse = { healthy?: boolean }
+type OpencodeStatusMap = Record<string, { type?: unknown }>
 
 function isIdleStatusEvent(event: ParsedServeEvent): boolean {
   if (event.kind !== 'session.status') return false
   const status = event.properties.status
   if (!status || typeof status !== 'object' || Array.isArray(status)) return false
   return (status as Record<string, unknown>).type === 'idle'
+}
+
+function isRunningStatusType(type: unknown): boolean {
+  return type === 'busy' || type === 'retry'
+}
+
+function isIdleStatusType(type: unknown): boolean {
+  return type === 'idle'
+}
+
+function isOpencodeTranscriptEvent(kind: string): boolean {
+  return kind.startsWith('message.')
+}
+
+function eventShowsSessionActivity(event: ParsedServeEvent): boolean {
+  if (isOpencodeTranscriptEvent(event.kind)) return true
+  if (event.kind !== 'session.status') return false
+  const status = event.properties.status
+  if (!status || typeof status !== 'object' || Array.isArray(status)) return false
+  return isRunningStatusType((status as Record<string, unknown>).type)
 }
 
 function isHealthyResponse(body: unknown): body is HealthResponse {
@@ -65,6 +89,7 @@ export class OpencodeServeManager {
   private readonly healthTimeoutMs: number
   private readonly env: NodeJS.ProcessEnv
   private readonly idleShutdownMs: number
+  private readonly idlePollMs: number
   private readonly log: OpencodeServeLogger = logger.child({ component: 'opencode-serve-manager' })
   /** sessionId → emitter of ParsedServeEvent (and a synthetic 'idle' event). */
   private readonly sessionEmitters = new Map<string, EventEmitter>()
@@ -84,6 +109,7 @@ export class OpencodeServeManager {
     this.healthTimeoutMs = options.healthTimeoutMs ?? 20_000
     this.env = options.env ?? process.env
     this.idleShutdownMs = options.idleShutdownMs ?? 15 * 60_000
+    this.idlePollMs = options.idlePollMs ?? DEFAULT_IDLE_POLL_MS
   }
 
   private routeFromCwd(cwd?: string): { cwdKey: string; cwd?: string } {
@@ -313,6 +339,10 @@ export class OpencodeServeManager {
     })
   }
 
+  private async getSessionStatusMap(route: ServeRoute = {}, init?: RequestInit): Promise<OpencodeStatusMap> {
+    return this.json<OpencodeStatusMap>(route, '/session/status', { method: 'GET', ...init })
+  }
+
   async createSession(input: { title?: string; parentID?: string; directory?: string } = {}): Promise<{ id: string; directory?: string; title?: string }> {
     const body: { title?: string; parentID?: string; directory?: string } = {}
     if (input.title !== undefined) body.title = input.title
@@ -438,16 +468,71 @@ export class OpencodeServeManager {
   onceIdle(sessionId: string, timeoutMs: number): Promise<void> {
     return new Promise((resolve, reject) => {
       const emitter = this.emitterFor(sessionId)
-      const timer = setTimeout(() => {
+      let settled = false
+      let observedActivity = false
+      let pollInFlight = false
+      let idleStatusPolls = 0
+
+      const cleanup = () => {
+        clearTimeout(timer)
+        clearInterval(pollTimer)
         emitter.off('event', handler)
-        reject(new Error(`Timed out after ${timeoutMs}ms waiting for OpenCode session ${sessionId} to go idle.`))
+      }
+      const finish = () => {
+        if (settled) return
+        settled = true
+        cleanup()
+        resolve()
+      }
+      const fail = (error: Error) => {
+        if (settled) return
+        settled = true
+        cleanup()
+        reject(error)
+      }
+      const markActivity = () => {
+        observedActivity = true
+        idleStatusPolls = 0
+      }
+      const checkStatusMap = async () => {
+        if (settled || pollInFlight) return
+        pollInFlight = true
+        try {
+          const statuses = await this.getSessionStatusMap(this.routeForSession(sessionId))
+          const status = statuses[sessionId]
+          if (status && isRunningStatusType(status.type)) {
+            markActivity()
+            return
+          }
+          if (observedActivity && (!status || isIdleStatusType(status.type))) {
+            idleStatusPolls += 1
+            if (idleStatusPolls >= REQUIRED_IDLE_STATUS_POLLS) finish()
+            return
+          }
+          idleStatusPolls = 0
+        } catch (err) {
+          this.log.warn({ err, sessionId }, 'OpenCode idle status fallback failed')
+        } finally {
+          pollInFlight = false
+        }
+      }
+
+      const timer = setTimeout(() => {
+        fail(new Error(`Timed out after ${timeoutMs}ms waiting for OpenCode session ${sessionId} to go idle.`))
       }, timeoutMs)
       timer.unref?.()
+
+      const pollTimer = setInterval(() => { void checkStatusMap() }, this.idlePollMs)
+      pollTimer.unref?.()
+
       const handler = (event: ParsedServeEvent) => {
         if (event.kind === 'session.idle' || isIdleStatusEvent(event)) {
-          clearTimeout(timer)
-          emitter.off('event', handler)
-          resolve()
+          finish()
+          return
+        }
+        if (eventShowsSessionActivity(event)) {
+          markActivity()
+          void checkStatusMap()
         }
       }
       emitter.on('event', handler)

--- a/server/fresh-agent/adapters/opencode/serve-manager.ts
+++ b/server/fresh-agent/adapters/opencode/serve-manager.ts
@@ -511,6 +511,7 @@ export class OpencodeServeManager {
           }
           idleStatusPolls = 0
         } catch (err) {
+          idleStatusPolls = 0
           this.log.warn({ err, sessionId }, 'OpenCode idle status fallback failed')
         } finally {
           pollInFlight = false

--- a/server/fresh-agent/adapters/opencode/serve-manager.ts
+++ b/server/fresh-agent/adapters/opencode/serve-manager.ts
@@ -47,12 +47,7 @@ function isIdleStatusType(type: unknown): boolean {
   return type === 'idle'
 }
 
-function isOpencodeTranscriptEvent(kind: string): boolean {
-  return kind.startsWith('message.')
-}
-
-function eventShowsSessionActivity(event: ParsedServeEvent): boolean {
-  if (isOpencodeTranscriptEvent(event.kind)) return true
+function eventShowsRunningStatusActivity(event: ParsedServeEvent): boolean {
   if (event.kind !== 'session.status') return false
   const status = event.properties.status
   if (!status || typeof status !== 'object' || Array.isArray(status)) return false
@@ -472,6 +467,7 @@ export class OpencodeServeManager {
       let observedActivity = false
       let pollInFlight = false
       let idleStatusPolls = 0
+      let warnedStatusFallbackFailure = false
 
       const cleanup = () => {
         clearTimeout(timer)
@@ -512,7 +508,10 @@ export class OpencodeServeManager {
           idleStatusPolls = 0
         } catch (err) {
           idleStatusPolls = 0
-          this.log.warn({ err, sessionId }, 'OpenCode idle status fallback failed')
+          if (!warnedStatusFallbackFailure) {
+            warnedStatusFallbackFailure = true
+            this.log.warn({ err, sessionId }, 'OpenCode idle status fallback failed')
+          }
         } finally {
           pollInFlight = false
         }
@@ -531,7 +530,7 @@ export class OpencodeServeManager {
           finish()
           return
         }
-        if (eventShowsSessionActivity(event)) {
+        if (eventShowsRunningStatusActivity(event)) {
           markActivity()
           void checkStatusMap()
         }

--- a/server/fresh-agent/sdk-events.ts
+++ b/server/fresh-agent/sdk-events.ts
@@ -12,6 +12,11 @@ export type FreshAgentProviderEvent =
     streamingActive?: boolean
     streamingText?: string
   }
+  | {
+    type: 'freshAgent.session.changed'
+    sessionId: string
+    reason?: string
+  }
   | { type: 'freshAgent.session.init'; sessionId: string; cliSessionId?: string; model?: string; cwd?: string; tools?: Array<{ name: string }> }
   | { type: 'freshAgent.session.metadata'; sessionId: string; cliSessionId?: string; model?: string; cwd?: string; tools?: Array<{ name: string }> }
   | { type: 'freshAgent.assistant'; sessionId: string; content: ContentBlock[]; model?: string; usage?: Usage }
@@ -35,6 +40,8 @@ export function normalizeFreshAgentProviderEvent(event: unknown): unknown {
   switch (typed.type) {
     case 'sdk.session.snapshot':
       return { ...providerEvent, type: 'freshAgent.session.snapshot' } as FreshAgentProviderEvent
+    case 'sdk.session.changed':
+      return { ...providerEvent, type: 'freshAgent.session.changed' } as FreshAgentProviderEvent
     case 'sdk.session.init':
       return { ...providerEvent, type: 'freshAgent.session.init' } as FreshAgentProviderEvent
     case 'sdk.session.metadata':

--- a/src/lib/fresh-agent-ws.ts
+++ b/src/lib/fresh-agent-ws.ts
@@ -172,6 +172,8 @@ export function handleFreshAgentTransportEvent(dispatch: AppDispatch, msg: Fresh
         streamingText: event.streamingText as string | undefined,
       }))
       return true
+    case 'freshAgent.session.changed':
+      return true
     case 'freshAgent.session.init':
       dispatch(sessionInit({
         ...locator,

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -156,6 +156,28 @@ function createDeferred<T>() {
   return { promise, resolve, reject }
 }
 
+function freshopencodeSnapshot(text: string, revision: number) {
+  return {
+    sessionType: 'freshopencode',
+    provider: 'opencode',
+    threadId: 'ses_late_change',
+    sessionId: 'ses_late_change',
+    status: 'idle',
+    latestTurnId: 'msg_assistant_1',
+    revision,
+    summary: 'OpenCode done',
+    capabilities: { send: true, interrupt: true, fork: true },
+    pendingApprovals: [],
+    pendingQuestions: [],
+    diffs: [],
+    worktrees: [],
+    turns: [
+      { id: 'msg_user_1', turnId: 'msg_user_1', role: 'user', summary: 'go', items: [{ id: 'user-text', kind: 'text', text: 'go' }] },
+      { id: 'msg_assistant_1', turnId: 'msg_assistant_1', role: 'assistant', summary: text, items: [{ id: 'assistant-text', kind: 'text', text }] },
+    ],
+  }
+}
+
 beforeEach(() => {
   wsMock.send.mockReset()
   wsMock.onMessage.mockReset()
@@ -2946,6 +2968,67 @@ describe('FreshAgentView', () => {
       expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledWith('freshcodex', 'codex', 'thread-refresh', expect.any(Object))
     })
     expect(store.getState().panes.refreshRequestsByPane?.['tab-1']?.['pane-1']).toBeUndefined()
+  })
+
+  it('refreshes freshopencode on session.changed without reopening the bouncer', async () => {
+    const store = createStore()
+    let wsHandler: ((message: any) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler) => {
+      wsHandler = handler
+      return () => {}
+    })
+
+    apiMock.getFreshAgentThreadSnapshot
+      .mockResolvedValueOnce(freshopencodeSnapshot('done', 10))
+      .mockResolvedValueOnce(freshopencodeSnapshot('done updated', 11))
+
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-late-change',
+        sessionId: 'ses_late_change',
+        sessionRef: { provider: 'opencode', sessionId: 'ses_late_change' },
+        resumeSessionId: 'ses_late_change',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('done')).toBeInTheDocument()
+    })
+
+    act(() => {
+      wsHandler?.({
+        type: 'freshAgent.event',
+        sessionId: 'ses_late_change',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        event: {
+          type: 'freshAgent.session.changed',
+          sessionId: 'ses_late_change',
+          reason: 'opencode-message',
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('done updated')).toBeInTheDocument()
+    })
+    expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(2)
+    expect(getFreshAgentPaneContent(store)).toMatchObject({
+      sessionId: 'ses_late_change',
+      status: 'idle',
+    })
   })
 
   it('normalizes obsolete Freshcodex models to the default radio option', async () => {

--- a/test/unit/client/lib/fresh-agent-ws.test.ts
+++ b/test/unit/client/lib/fresh-agent-ws.test.ts
@@ -225,6 +225,44 @@ describe('fresh-agent-ws', () => {
     expect(store.getState().freshAgent.sessions[key]).toBeUndefined()
   })
 
+  it('handles freshAgent.session.changed without mutating idle status', () => {
+    const store = createFreshAgentStore()
+    const sessionId = 'ses_opencode_idle'
+    const key = `freshopencode:opencode:${sessionId}`
+
+    expect(handleFreshAgentMessage(store.dispatch, {
+      type: 'freshAgent.event',
+      sessionId,
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      event: {
+        type: 'freshAgent.session.snapshot',
+        sessionId,
+        latestTurnId: 'msg_assistant_1',
+        status: 'idle',
+        revision: 11,
+      },
+    })).toBe(true)
+
+    expect(handleFreshAgentMessage(store.dispatch, {
+      type: 'freshAgent.event',
+      sessionId,
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      event: {
+        type: 'freshAgent.session.changed',
+        sessionId,
+        reason: 'opencode-message',
+      },
+    })).toBe(true)
+
+    expect(store.getState().freshAgent.sessions[key]).toMatchObject({
+      status: 'idle',
+      latestTurnId: 'msg_assistant_1',
+      historyRevision: 11,
+    })
+  })
+
   it('does not let delayed metadata downgrade newer snapshot identity', () => {
     const store = createFreshAgentStore()
     const sessionId = 'claude-thread-metadata-order'

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -179,11 +179,50 @@ describe('OpenCode serve adapter: create + send', () => {
       await expect(adapter.send?.('freshopencode-unhandled-1', { text: 'boom' })).rejects.toThrow('prompt rejected')
       // Simulating the idle timeout rejection that would otherwise arrive later.
       idleReject(new Error('idle timeout'))
-      await new Promise((r) => setTimeout(r, 10))
-      expect(unhandled).not.toHaveBeenCalled()
-    } finally {
-      process.off('unhandledRejection', unhandled)
-    }
+    await new Promise((r) => setTimeout(r, 10))
+    expect(unhandled).not.toHaveBeenCalled()
+  } finally {
+    process.off('unhandledRejection', unhandled)
+  }
+  })
+
+  it('does not return to running when OpenCode emits a late message update after idle', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+    await adapter.create({ requestId: 'late-update', sessionType: 'freshopencode', provider: 'opencode' })
+
+    const events: unknown[] = []
+    adapter.subscribe?.('freshopencode-late-update', (event) => events.push(event))
+
+    await adapter.send?.('freshopencode-late-update', { text: 'go' })
+    manager._emit('ses_real_1', {
+      kind: 'session.idle',
+      sessionId: 'ses_real_1',
+      properties: { sessionID: 'ses_real_1' },
+      raw: { type: 'session.idle', properties: { sessionID: 'ses_real_1' } },
+    })
+    manager._emit('ses_real_1', {
+      kind: 'message.updated',
+      sessionId: 'ses_real_1',
+      properties: { sessionID: 'ses_real_1', info: { id: 'msg_user_1', role: 'user' } },
+      raw: { type: 'message.updated', properties: { sessionID: 'ses_real_1' } },
+    })
+
+    expect(events).toContainEqual({
+      type: 'sdk.session.snapshot',
+      sessionId: 'freshopencode-late-update',
+      status: 'idle',
+    })
+    expect(events.at(-1)).toEqual({
+      type: 'sdk.session.changed',
+      sessionId: 'freshopencode-late-update',
+      reason: 'opencode-message',
+    })
+    await expect(adapter.getSnapshot?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'freshopencode-late-update',
+    })).resolves.toMatchObject({ status: 'idle' })
   })
 
   it('forwards compact instructions to the serve manager', async () => {

--- a/test/unit/server/fresh-agent/opencode-serve-events.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-events.test.ts
@@ -82,14 +82,68 @@ describe('serveEventToSdk', () => {
     }
     expect(serveEventToSdk(parsed, 'ses_a')).toEqual({ type: 'sdk.session.snapshot', sessionId: 'ses_a', status: 'running' })
   })
-  it('maps message.part.updated to a running snapshot (drives client re-poll)', () => {
+  it('maps message.part.updated to a transcript invalidation (drives client re-poll)', () => {
     const parsed: ParsedServeEvent = {
       kind: 'message.part.updated',
       sessionId: 'ses_a',
       properties: { sessionID: 'ses_a', part: { id: 'p', type: 'text' } },
       raw: { type: 'message.part.updated', properties: { sessionID: 'ses_a', part: { id: 'p', type: 'text' } } },
     }
-    expect(serveEventToSdk(parsed, 'ses_a')).toEqual({ type: 'sdk.session.snapshot', sessionId: 'ses_a', status: 'running' })
+    expect(serveEventToSdk(parsed, 'ses_a')).toEqual({
+      type: 'sdk.session.changed',
+      sessionId: 'ses_a',
+      reason: 'opencode-message',
+    })
+  })
+  it('maps OpenCode transcript mutation events to invalidations instead of running snapshots', () => {
+    for (const kind of ['message.part.delta', 'message.part.updated', 'message.updated', 'message.removed', 'message.part.removed']) {
+      const parsed: ParsedServeEvent = {
+        kind,
+        sessionId: 'ses_a',
+        properties: { sessionID: 'ses_a', info: { id: 'msg_1', role: 'assistant' } },
+        raw: { type: kind, properties: { sessionID: 'ses_a' } },
+      }
+
+      expect(serveEventToSdk(parsed, 'freshopencode-req-1')).toEqual({
+        type: 'sdk.session.changed',
+        sessionId: 'freshopencode-req-1',
+        reason: 'opencode-message',
+      })
+    }
+  })
+  it('maps only active OpenCode session statuses to running', () => {
+    const statusEvent = (statusType: string): ParsedServeEvent => ({
+      kind: 'session.status',
+      sessionId: 'ses_a',
+      properties: { sessionID: 'ses_a', status: { type: statusType } },
+      raw: { type: 'session.status', properties: { sessionID: 'ses_a', status: { type: statusType } } },
+    })
+
+    expect(serveEventToSdk(statusEvent('busy'), 'ses_a')).toEqual({
+      type: 'sdk.session.snapshot',
+      sessionId: 'ses_a',
+      status: 'running',
+    })
+    expect(serveEventToSdk(statusEvent('retry'), 'ses_a')).toEqual({
+      type: 'sdk.session.snapshot',
+      sessionId: 'ses_a',
+      status: 'running',
+    })
+    expect(serveEventToSdk(statusEvent('idle'), 'ses_a')).toEqual({
+      type: 'sdk.session.snapshot',
+      sessionId: 'ses_a',
+      status: 'idle',
+    })
+    expect(serveEventToSdk(statusEvent('completed'), 'ses_a')).toEqual({
+      type: 'sdk.session.changed',
+      sessionId: 'ses_a',
+      reason: 'opencode-status',
+    })
+    expect(serveEventToSdk(statusEvent('unexpected-future-status'), 'ses_a')).toEqual({
+      type: 'sdk.session.changed',
+      sessionId: 'ses_a',
+      reason: 'opencode-status',
+    })
   })
   it('maps session.error to an sdk.error', () => {
     const parsed: ParsedServeEvent = {

--- a/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
@@ -535,6 +535,76 @@ describe('OpencodeServeManager fan-out', () => {
     await expect(idle).rejects.toThrow(/idle/i)
   })
 
+  it('onceIdle resolves when status-map activity drops out of the OpenCode status map', async () => {
+    let statusCalls = 0
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith('/global/health')) return jsonResponse({ healthy: true })
+      if (url.endsWith('/session/status')) {
+        statusCalls += 1
+        return statusCalls === 1
+          ? jsonResponse({ ses_a: { type: 'busy' } })
+          : jsonResponse({})
+      }
+      return jsonResponse({})
+    })
+    const { manager } = makeManager({
+      fetchFn: fetchFn as any,
+      idlePollMs: 5,
+    })
+    await manager.ensureStarted()
+
+    const idle = manager.onceIdle('ses_a', 1000)
+
+    await expect(idle).resolves.toBeUndefined()
+    expect(fetchFn).toHaveBeenCalledWith('http://127.0.0.1:47999/session/status', expect.anything())
+    expect((manager as any).sessionEmitters.get('ses_a')?.listenerCount('event') ?? 0).toBe(0)
+  })
+
+  it('onceIdle does not resolve from status-map absence before observed OpenCode activity', async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith('/global/health')) return jsonResponse({ healthy: true })
+      if (url.endsWith('/session/status')) return jsonResponse({})
+      return jsonResponse({})
+    })
+    const { manager } = makeManager({
+      fetchFn: fetchFn as any,
+      idlePollMs: 5,
+    })
+    await manager.ensureStarted()
+
+    await expect(manager.onceIdle('ses_a', 30)).rejects.toThrow(/idle/i)
+  })
+
+  it('onceIdle does not resolve from a single busy signal plus one empty status-map poll', async () => {
+    let push!: (e: any) => void
+    let statusCalls = 0
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith('/global/health')) return jsonResponse({ healthy: true })
+      if (url.endsWith('/session/status')) {
+        statusCalls += 1
+        if (statusCalls === 1) return jsonResponse({})
+        throw new Error('status map unavailable')
+      }
+      return jsonResponse({})
+    })
+    const { manager } = makeManager({
+      fetchFn: fetchFn as any,
+      connectEventStream: (_url, h) => { push = (e) => h.onEvent(parseEvt(e)); return () => {} },
+      idlePollMs: 5,
+    })
+    await manager.ensureStarted()
+
+    const idle = manager.onceIdle('ses_a', 40)
+    push({ type: 'session.status', properties: { sessionID: 'ses_a', status: { type: 'busy' } } })
+
+    const pending = await Promise.race([
+      idle.then(() => 'resolved', () => 'rejected'),
+      new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 15)),
+    ])
+    expect(pending).toBe('pending')
+    await expect(idle).rejects.toThrow(/idle/i)
+  })
+
   it('onceIdle rejects on timeout', async () => {
     const { manager } = makeManager({ connectEventStream: () => () => {} })
     await manager.ensureStarted()

--- a/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
@@ -605,6 +605,56 @@ describe('OpencodeServeManager fan-out', () => {
     await expect(idle).rejects.toThrow(/idle/i)
   })
 
+  it('onceIdle requires a fresh consecutive idle/absent pair after a status-map poll failure', async () => {
+    let push!: (e: any) => void
+    let statusCalls = 0
+    let allowFifthPoll!: () => void
+    let noteFifthPollStarted!: () => void
+    const fifthPollGate = new Promise<void>((resolve) => {
+      allowFifthPoll = resolve
+    })
+    const fifthPollStarted = new Promise<void>((resolve) => {
+      noteFifthPollStarted = resolve
+    })
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith('/global/health')) return jsonResponse({ healthy: true })
+      if (url.endsWith('/session/status')) {
+        statusCalls += 1
+        if (statusCalls === 1) return jsonResponse({ ses_a: { type: 'busy' } })
+        if (statusCalls === 2) return jsonResponse({})
+        if (statusCalls === 3) throw new Error('status map unavailable')
+        if (statusCalls === 4) return jsonResponse({})
+        if (statusCalls === 5) {
+          noteFifthPollStarted()
+          await fifthPollGate
+          return jsonResponse({})
+        }
+        return jsonResponse({})
+      }
+      return jsonResponse({})
+    })
+    const { manager } = makeManager({
+      fetchFn: fetchFn as any,
+      connectEventStream: (_url, h) => { push = (e) => h.onEvent(parseEvt(e)); return () => {} },
+      idlePollMs: 5,
+    })
+    await manager.ensureStarted()
+
+    const idle = manager.onceIdle('ses_a', 100)
+    push({ type: 'session.status', properties: { sessionID: 'ses_a', status: { type: 'busy' } } })
+
+    await fifthPollStarted
+    const pending = await Promise.race([
+      idle.then(() => 'resolved', () => 'rejected'),
+      new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 15)),
+    ])
+    expect(pending).toBe('pending')
+
+    allowFifthPoll()
+    await expect(idle).resolves.toBeUndefined()
+    expect(statusCalls).toBe(5)
+  }, 1000)
+
   it('onceIdle rejects on timeout', async () => {
     const { manager } = makeManager({ connectEventStream: () => () => {} })
     await manager.ensureStarted()

--- a/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
@@ -575,6 +575,52 @@ describe('OpencodeServeManager fan-out', () => {
     await expect(manager.onceIdle('ses_a', 30)).rejects.toThrow(/idle/i)
   })
 
+  it('onceIdle ignores late message.updated events when the status map stays absent', async () => {
+    let push!: (e: any) => void
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith('/global/health')) return jsonResponse({ healthy: true })
+      if (url.endsWith('/session/status')) return jsonResponse({})
+      return jsonResponse({})
+    })
+    const { manager } = makeManager({
+      fetchFn: fetchFn as any,
+      connectEventStream: (_url, h) => { push = (e) => h.onEvent(parseEvt(e)); return () => {} },
+      idlePollMs: 5,
+    })
+    await manager.ensureStarted()
+
+    const idle = manager.onceIdle('ses_a', 30)
+    push({ type: 'message.updated', properties: { sessionID: 'ses_a', message: { id: 'old-turn' } } })
+
+    await expect(idle).rejects.toThrow(/idle/i)
+  })
+
+  it('onceIdle waits for later running status-map evidence after a late message.updated event', async () => {
+    let push!: (e: any) => void
+    let statusCalls = 0
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith('/global/health')) return jsonResponse({ healthy: true })
+      if (url.endsWith('/session/status')) {
+        statusCalls += 1
+        if (statusCalls <= 2) return jsonResponse({})
+        if (statusCalls === 3) return jsonResponse({ ses_a: { type: 'busy' } })
+        return jsonResponse({})
+      }
+      return jsonResponse({})
+    })
+    const { manager } = makeManager({
+      fetchFn: fetchFn as any,
+      connectEventStream: (_url, h) => { push = (e) => h.onEvent(parseEvt(e)); return () => {} },
+      idlePollMs: 5,
+    })
+    await manager.ensureStarted()
+
+    const idle = manager.onceIdle('ses_a', 80)
+    push({ type: 'message.updated', properties: { sessionID: 'ses_a', message: { id: 'old-turn' } } })
+
+    await expect(idle).resolves.toBeUndefined()
+  })
+
   it('onceIdle does not resolve from a single busy signal plus one empty status-map poll', async () => {
     let push!: (e: any) => void
     let statusCalls = 0
@@ -603,6 +649,28 @@ describe('OpencodeServeManager fan-out', () => {
     ])
     expect(pending).toBe('pending')
     await expect(idle).rejects.toThrow(/idle/i)
+  })
+
+  it('onceIdle warns only once per wait when status-map fallback polling keeps failing', async () => {
+    let push!: (e: any) => void
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith('/global/health')) return jsonResponse({ healthy: true })
+      if (url.endsWith('/session/status')) throw new Error('status map unavailable')
+      return jsonResponse({})
+    })
+    const { manager } = makeManager({
+      fetchFn: fetchFn as any,
+      connectEventStream: (_url, h) => { push = (e) => h.onEvent(parseEvt(e)); return () => {} },
+      idlePollMs: 5,
+    })
+    await manager.ensureStarted()
+
+    const warnSpy = vi.spyOn((manager as any).log, 'warn').mockImplementation(() => undefined)
+    const idle = manager.onceIdle('ses_a', 35)
+    push({ type: 'session.status', properties: { sessionID: 'ses_a', status: { type: 'busy' } } })
+
+    await expect(idle).rejects.toThrow(/idle/i)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
   })
 
   it('onceIdle requires a fresh consecutive idle/absent pair after a status-map poll failure', async () => {

--- a/test/unit/server/ws-fresh-agent-contract.test.ts
+++ b/test/unit/server/ws-fresh-agent-contract.test.ts
@@ -34,6 +34,16 @@ describe('fresh-agent websocket contract', () => {
     })
 
     expect(normalizeFreshAgentProviderEvent({
+      type: 'sdk.session.changed',
+      sessionId: 's1',
+      reason: 'opencode-status',
+    })).toEqual({
+      type: 'freshAgent.session.changed',
+      sessionId: 's1',
+      reason: 'opencode-status',
+    })
+
+    expect(normalizeFreshAgentProviderEvent({
       type: 'freshAgent.status',
       sessionId: 's1',
       status: 'idle',


### PR DESCRIPTION
## Summary
- Treat OpenCode transcript `message.*` events as fresh-agent invalidations instead of running status.
- Keep freshopencode busy/idle status driven only by `session.status` busy/retry/idle and `session.idle`.
- Add a guarded `/session/status` fallback for missing idle events, with regression coverage for stale transcript updates and status-map polling.

## Verification
- `npm run check` on rebased head `84f2331a`
- Coordinator baseline: `full-suite|84f2331adf3aad46def9fc32afa286496e01e1ae|dirty:0|node:v22.21.1|linux|x64`
- Final code review passed
- Fresh-eyes passed