### PR TITLE
Fix hidden OpenCode white page after browser refresh

### DIFF
--- a/docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
+++ b/docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
@@ -23,7 +23,7 @@
 - Browser refresh of a hidden OpenCode tab commonly restores an existing live `terminalId`, not a new hidden `terminal.created` path.
 - A hidden `terminal.created` immediate attach would bypass the hydration queue's visible-first, single-active-pane policy, so the fix should not add that behavior.
 - `terminal.attach` with an expected session is only safe when the client/session association matches server ownership. The existing restored path already reconciles session ownership before attach.
-- The e2e regression must assert rendered terminal buffer content after reveal; session id and stdin checks alone do not catch a white terminal surface.
+- The e2e regression must force `replay_window_exceeded` by overflowing the replay ring, then assert the restored hidden OpenCode pane is relaunched with a new terminal id and rendered terminal buffer content after reveal. Session id and stdin checks alone do not catch a white terminal surface.
 
 ---
 
@@ -126,15 +126,28 @@ it('recreates a hidden restored OpenCode pane when background viewport hydration
     })
   })
 
+  let replacementRequestId: string | undefined
   await waitFor(() => {
     const layout = store.getState().panes.layouts[tabId]
     expect(layout?.type).toBe('leaf')
     if (layout?.type !== 'leaf' || layout.content.kind !== 'terminal') {
       throw new Error('expected terminal pane')
     }
+    expect(layout.content.terminalId).toBeUndefined()
     expect(layout.content.status).toBe('creating')
     expect(layout.content.sessionRef).toEqual(sessionRef)
-    expect(layout.content.createRequestId).not.toBe('req-opencode-hidden-gap')
+    replacementRequestId = layout.content.createRequestId
+    expect(replacementRequestId).not.toBe('req-opencode-hidden-gap')
+  })
+
+  await waitFor(() => {
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'terminal.create',
+      requestId: replacementRequestId,
+      mode: 'opencode',
+      sessionRef,
+      restore: true,
+    }))
   })
 })
 ```
@@ -179,26 +192,83 @@ Expected: PASS. This confirms hidden OpenCode gaps repair, the visible repair st
 - Modify: `test/e2e-browser/specs/opencode-restart-recovery.spec.ts:614-765`
 
 **Interfaces:**
-- Consumes: existing `recovers a hidden OpenCode sessionRef when association lands while the browser is closed` scenario and `TestHarness.getTerminalBuffer`.
-- Produces: an assertion that a restored hidden OpenCode pane has rendered terminal output after reveal, not only a valid session id.
+- Consumes: existing `recovers a hidden OpenCode sessionRef when association lands while the browser is closed` scenario, per-test server env overrides, `waitForRestoreLaunches`, and `TestHarness.getTerminalBuffer`.
+- Produces: assertions that a forced hidden `replay_window_exceeded` gap relaunches OpenCode on a new terminal id and renders terminal output after reveal.
 
-- [ ] **Step 1: Write the e2e assertion**
+- [ ] **Step 1: Allow per-test replay-ring sizing**
 
-In `recovers a hidden OpenCode sessionRef when association lands while the browser is closed`, after revealing the OpenCode tab and asserting the restored `terminalId` and `sessionRef`, add a buffer assertion:
+Extend this spec-local helper input:
 
 ```ts
-await expect.poll(async () => {
-  const buffer = await restoreHarness.getTerminalBuffer(afterRefresh.terminalId)
-  return buffer?.trim() ?? ''
-}, {
-  timeout: 30_000,
-  message: 'expected restored hidden OpenCode pane to render terminal content after reveal',
-}).not.toBe('')
+function createServerOptions(input: {
+  binDir: string
+  auditLogPath: string
+  logsDir: string
+  sharedOpencodeDataDir: string
+  fakeOpencodeSessionEventGatePath?: string
+  port?: number
+  token?: string
+  env?: Record<string, string>
+}) {
 ```
 
-This uses the fake OpenCode fixture's startup output and stdin echo as the rendered signal.
+and spread `input.env` into the returned `env` object after the existing defaults:
 
-- [ ] **Step 2: Run the e2e-browser scenario**
+```ts
+      FRESHELL_LOG_DIR: input.logsDir,
+      ...(input.env ?? {}),
+```
+
+This keeps other tests unchanged while letting this scenario lower the coding CLI replay ring.
+
+- [ ] **Step 2: Force the hidden replay-window gap**
+
+In `recovers a hidden OpenCode sessionRef when association lands while the browser is closed`, pass a small scrollback/replay budget into `createServerOptions`:
+
+```ts
+env: {
+  MAX_SCROLLBACK_CHARS: String(64 * 1024),
+  CODING_CLI_MIN_REPLAY_RING_MAX_BYTES: String(64 * 1024),
+},
+```
+
+After `expectedSessionId` is known and before the existing `hidden-before-refresh` input, send a large payload:
+
+```ts
+await sendInputToTerminals(page, [beforeAssociation], `hidden-overflow-${'x'.repeat(96 * 1024)}`)
+```
+
+Then keep the existing smaller `hidden-before-refresh` send and audit wait. The large fake OpenCode stdin echo overflows the reduced ring; the smaller input gives the existing audit a compact stable marker.
+
+- [ ] **Step 3: Stop requiring the stale hidden terminal id before reveal**
+
+In the restored-page hidden wait, keep the assertions for active shell tab, OpenCode tab sessionRef, content mode, and content sessionRef, but remove `content.terminalId === expectedTerminalId`. Once the hidden background queue repairs the gap, the content may already be creating or running with a replacement terminal id before the user clicks the tab.
+
+- [ ] **Step 4: Assert relaunch and rendered output after reveal**
+
+After revealing the OpenCode tab and calling `waitForOpenCodeSessions`, change the terminal id assertion from equality to replacement:
+
+```ts
+expect(afterRefresh.terminalId).toBeTruthy()
+expect(afterRefresh.terminalId).not.toBe(beforeAssociation.terminalId)
+```
+
+Then assert a restore launch occurred and the replacement terminal rendered fake OpenCode output:
+
+```ts
+await waitForRestoreLaunches(auditLogPath, [expectedSessionId])
+await expect.poll(async () => {
+  const buffer = await restoreHarness.getTerminalBuffer(afterRefresh.terminalId)
+  return buffer ?? ''
+}, {
+  timeout: 30_000,
+  message: 'expected restored hidden OpenCode pane to render terminal content after replay-window repair',
+}).toContain(`fake opencode ready root=${expectedSessionId}`)
+```
+
+Keep the existing `hidden-after-refresh` stdin audit after these assertions.
+
+- [ ] **Step 5: Run the e2e-browser scenario**
 
 Run:
 
@@ -208,7 +278,7 @@ npm run test:e2e:chromium -- test/e2e-browser/specs/opencode-restart-recovery.sp
 
 Expected after Task 1: PASS.
 
-- [ ] **Step 3: Run OpenCode restart recovery browser coverage**
+- [ ] **Step 6: Run OpenCode restart recovery browser coverage**
 
 Run:
 
@@ -218,16 +288,25 @@ npm run test:e2e:chromium -- test/e2e-browser/specs/opencode-restart-recovery.sp
 
 Expected: PASS.
 
-### Task 3: Final Verification
+### Task 3: Commit And Final Verification
 
 **Files:**
-- Verify only.
+- Commit and verify only.
 
 **Interfaces:**
-- Consumes: committed implementation work.
+- Consumes: completed Task 1 and Task 2 implementation work.
 - Produces: evidence that the branch is ready for final review.
 
-- [ ] **Step 1: Run targeted unit coverage**
+- [ ] **Step 1: Commit the focused change**
+
+Run:
+
+```bash
+git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx test/e2e-browser/specs/opencode-restart-recovery.spec.ts docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
+git commit -m "fix: repair hidden opencode refresh hydration"
+```
+
+- [ ] **Step 2: Run targeted unit coverage**
 
 Run:
 
@@ -237,7 +316,7 @@ npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.t
 
 Expected: PASS.
 
-- [ ] **Step 2: Run targeted browser coverage**
+- [ ] **Step 3: Run targeted browser coverage**
 
 Run:
 
@@ -247,7 +326,7 @@ npm run test:e2e:chromium -- test/e2e-browser/specs/opencode-restart-recovery.sp
 
 Expected: PASS.
 
-- [ ] **Step 3: Run repo-supported verification**
+- [ ] **Step 4: Run repo-supported verification**
 
 Run:
 
@@ -257,14 +336,10 @@ npm run check
 
 Expected: PASS.
 
-- [ ] **Step 4: Commit the focused change**
+- [ ] **Step 5: Commit any fixes needed after verification**
 
-Run:
+If verification requires edits, make the smallest fix, rerun the covering test, then amend or add a focused follow-up commit. Do not leave the branch dirty.
 
-```bash
-git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx test/e2e-browser/specs/opencode-restart-recovery.spec.ts docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
-git commit -m "fix: repair hidden opencode refresh hydration"
-```
 
 ## Self-Review
 

--- a/docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
+++ b/docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
@@ -168,7 +168,7 @@ Do not broaden the behavior to `replay_budget_exceeded`, non-OpenCode modes, or 
 Run:
 
 ```bash
-npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output|recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output|background hydrates an untrusted hidden running pane with a viewport attach"
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output|recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output|background hydrates a trusted hidden reconnect from rendered high-water with background priority"
 ```
 
 Expected: PASS. This confirms hidden OpenCode gaps repair, the visible repair still works, and hidden background hydration still uses the queue.
@@ -232,7 +232,7 @@ Expected: PASS.
 Run:
 
 ```bash
-npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output|recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output|background hydrates an untrusted hidden running pane with a viewport attach"
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output|recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output|background hydrates a trusted hidden reconnect from rendered high-water with background priority"
 ```
 
 Expected: PASS.

--- a/docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
+++ b/docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Prevent restored OpenCode CLI panes from becoming visually blank after browser refresh by ensuring hidden restored OpenCode PTYs get an immediate terminal-emulation attach.
+**Goal:** Prevent restored OpenCode CLI panes from becoming visually blank after browser refresh by repairing unrecoverable hidden viewport hydration gaps instead of leaving the restored pane attached to stale output state.
 
-**Architecture:** Keep the existing visible replay-gap repair path. Add one OpenCode-specific hidden-create branch in `TerminalView`: restored hidden OpenCode terminals should perform a background `viewport_hydrate` attach as soon as `terminal.created` arrives, while ordinary hidden terminals keep deferring until reveal. Tests prove the behavior at the lifecycle boundary and through an OpenCode refresh/reveal flow.
+**Architecture:** Keep the existing hydration queue and the visible OpenCode replay-gap repair path. Extend that same durable OpenCode replacement behavior to hidden `viewport_hydrate` attaches when the server reports `replay_window_exceeded` from `sinceSeq: 0`. Do not bypass the queue by attaching hidden `terminal.created` events directly; the reproduced browser-refresh path restores an existing `terminalId` and hydrates it while hidden or on reveal.
 
 **Tech Stack:** React 18, Redux Toolkit, xterm.js, Vitest, Playwright e2e-browser harness, Freshell WebSocket terminal protocol.
 
@@ -16,129 +16,162 @@
 - Use NodeNext/ESM-compatible imports; relative server imports must keep `.js` extensions.
 - Preserve existing hidden terminal behavior for shell, Codex, Claude, Gemini, and Kimi.
 - Tests must prove behavior, not static strings.
-- Commit each completed task.
+- Commit focused implementation work before final verification.
+
+## Load-Bearing Amendments
+
+- Browser refresh of a hidden OpenCode tab commonly restores an existing live `terminalId`, not a new hidden `terminal.created` path.
+- A hidden `terminal.created` immediate attach would bypass the hydration queue's visible-first, single-active-pane policy, so the fix should not add that behavior.
+- `terminal.attach` with an expected session is only safe when the client/session association matches server ownership. The existing restored path already reconciles session ownership before attach.
+- The e2e regression must assert rendered terminal buffer content after reveal; session id and stdin checks alone do not catch a white terminal surface.
 
 ---
 
 ## File Structure
 
-- Modify `src/components/TerminalView.tsx`: add the OpenCode hidden restored attach policy in the `terminal.created` handler.
-- Modify `test/unit/client/components/TerminalView.lifecycle.test.tsx`: add focused lifecycle regression coverage and keep existing hidden-create expectations for non-OpenCode terminals.
-- Modify `test/e2e-browser/specs/opencode-restart-recovery.spec.ts`: extend OpenCode refresh coverage to prove a hidden restored OpenCode pane is visibly hydrated after reveal.
+- Modify `src/components/TerminalView.tsx`: let hidden OpenCode `viewport_hydrate` replay-window gaps enter the existing durable replacement flow.
+- Modify `test/unit/client/components/TerminalView.lifecycle.test.tsx`: add focused lifecycle regression coverage for hidden background viewport hydration gaps.
+- Modify `test/e2e-browser/specs/opencode-restart-recovery.spec.ts`: extend hidden OpenCode refresh coverage to prove the revealed restored pane renders terminal output.
 
-### Task 1: OpenCode Hidden Restore Attach Policy
+### Task 1: Hidden OpenCode Replay-Gap Repair
 
 **Files:**
-- Modify: `src/components/TerminalView.tsx:3601-3685`
-- Modify: `test/unit/client/components/TerminalView.lifecycle.test.tsx:3705-3736`
+- Modify: `src/components/TerminalView.tsx:3341-3378`
+- Modify: `test/unit/client/components/TerminalView.lifecycle.test.tsx:7468-7715`
 
 **Interfaces:**
-- Consumes: `launchAttemptRef.current.restore`, `contentRef.current.mode`, `contentRef.current.sessionRef`, and existing `attachTerminal(tid, intent, opts)`.
-- Produces: hidden restored OpenCode panes send `terminal.attach` with `intent: 'viewport_hydrate'`, `priority: 'background'`, and `sinceSeq: 0` immediately after `terminal.created`.
+- Consumes: `terminal.output.gap`, `currentAttachRef.current`, `contentRef.current.sessionRef`, `hiddenRef.current`, and `beginOpenCodeReplacementAfterExit`.
+- Produces: hidden restored OpenCode panes replace the stale PTY when a full viewport hydrate cannot replay from seq `0`.
 
 - [ ] **Step 1: Write the failing lifecycle test**
 
-Add this test immediately after `hidden create path defers attach until visible and measured` in `test/unit/client/components/TerminalView.lifecycle.test.tsx`:
+Add a unit test near the existing visible OpenCode replay-gap replacement test:
 
 ```tsx
-it('hidden restored OpenCode create attaches in the background before reveal', async () => {
-  const sessionRef = { provider: 'opencode', sessionId: 'ses_hidden_restore_owner' } as const
-  restoreMocks.consumeTerminalRestoreRequestId.mockImplementation((id: string) => id === 'req-v2-hidden-opencode-restore')
+it('recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output', async () => {
+  const sessionRef = { provider: 'opencode', sessionId: 'ses_hidden_replay_gap' } as const
+  const addedRestoreIds = new Set<string>()
+  restoreMocks.addTerminalRestoreRequestId.mockImplementation((id: string) => {
+    addedRestoreIds.add(id)
+  })
+  restoreMocks.consumeTerminalRestoreRequestId.mockImplementation((id: string) => {
+    if (addedRestoreIds.has(id)) {
+      addedRestoreIds.delete(id)
+      return true
+    }
+    return false
+  })
 
-  const { requestId } = await renderTerminalHarness({
-    status: 'creating',
-    hidden: true,
+  const { store, tabId, terminalId } = await renderTerminalHarness({
+    status: 'running',
+    terminalId: 'term-opencode-hidden-gap',
     mode: 'opencode',
-    requestId: 'req-v2-hidden-opencode-restore',
+    hidden: true,
+    clearSends: false,
+    requestId: 'req-opencode-hidden-gap',
     sessionRef,
   })
 
   wsMocks.send.mockClear()
   act(() => {
+    getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])
+  })
+
+  let attach: any
+  await waitFor(() => {
+    attach = wsMocks.send.mock.calls
+      .map(([msg]) => msg)
+      .find((msg) =>
+        msg?.type === 'terminal.attach'
+        && msg?.terminalId === terminalId
+        && msg?.intent === 'viewport_hydrate'
+        && msg?.priority === 'background'
+      )
+    expect(attach?.attachRequestId).toBeTruthy()
+  })
+
+  act(() => {
     messageHandler!({
-      type: 'terminal.created',
-      requestId,
-      terminalId: 'term-hidden-opencode-restore',
-      createdAt: Date.now(),
-      sessionRef,
+      type: 'terminal.attach.ready',
+      terminalId,
+      headSeq: 120,
+      replayFromSeq: 42,
+      replayToSeq: 120,
+      attachRequestId: attach.attachRequestId,
+    })
+  })
+  act(() => {
+    messageHandler!({
+      type: 'terminal.output.gap',
+      terminalId,
+      fromSeq: 1,
+      toSeq: 41,
+      reason: 'replay_window_exceeded',
+      attachRequestId: attach.attachRequestId,
+    } as any)
+  })
+
+  await waitFor(() => {
+    expect(wsMocks.send).toHaveBeenCalledWith({
+      type: 'terminal.kill',
+      terminalId,
+    })
+  })
+
+  act(() => {
+    messageHandler!({
+      type: 'terminal.exit',
+      terminalId,
+      exitCode: 0,
     })
   })
 
   await waitFor(() => {
-    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'terminal.attach',
-      terminalId: 'term-hidden-opencode-restore',
-      intent: 'viewport_hydrate',
-      priority: 'background',
-      sinceSeq: 0,
-      attachRequestId: expect.any(String),
-    }))
+    const layout = store.getState().panes.layouts[tabId]
+    expect(layout?.type).toBe('leaf')
+    if (layout?.type !== 'leaf' || layout.content.kind !== 'terminal') {
+      throw new Error('expected terminal pane')
+    }
+    expect(layout.content.status).toBe('creating')
+    expect(layout.content.sessionRef).toEqual(sessionRef)
+    expect(layout.content.createRequestId).not.toBe('req-opencode-hidden-gap')
   })
 })
 ```
+
+Also import `getHydrationQueue` from `@/lib/hydration-queue` in the test file.
 
 - [ ] **Step 2: Run the new test and verify it fails**
 
 Run:
 
 ```bash
-npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "hidden restored OpenCode create attaches in the background before reveal"
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output"
 ```
 
-Expected: FAIL because hidden `terminal.created` currently stores a deferred attach and sends no `terminal.attach`.
+Expected: FAIL because `isUnrecoverableOpenCodeViewportHydrate` currently requires `!hiddenRef.current`, so the hidden gap writes a local output notice instead of replacing the stale OpenCode PTY.
 
-- [ ] **Step 3: Implement the OpenCode-only hidden attach branch**
+- [ ] **Step 3: Implement the hidden OpenCode repair branch**
 
-In `src/components/TerminalView.tsx`, replace the hidden branch in the `terminal.created` handler with this shape:
+In `src/components/TerminalView.tsx`, remove the `!hiddenRef.current` requirement from `isUnrecoverableOpenCodeViewportHydrate`. Keep the other guards:
 
-```tsx
-const createdRestoreLaunch = launchAttemptRef.current?.terminalId === newId
-  && launchAttemptRef.current.restore === true
-const currentSessionRef = contentRef.current?.sessionRef
-const shouldBackgroundHydrateHiddenOpenCode = hiddenRef.current
-  && createdRestoreLaunch
-  && contentRef.current?.mode === 'opencode'
-  && currentSessionRef?.provider === 'opencode'
+- `msg.reason === 'replay_window_exceeded'`
+- current attach intent is `viewport_hydrate`
+- attach `sinceSeq` is `0`
+- pane mode is `opencode`
+- `sessionRef.provider === 'opencode'`
 
-if (hiddenRef.current && shouldBackgroundHydrateHiddenOpenCode) {
-  attachTerminal(newId, 'viewport_hydrate', {
-    clearViewportFirst: true,
-    priority: 'background',
-    ...viewportHydrateReplayOptions(contentRef.current),
-  })
-} else if (hiddenRef.current) {
-  deferredAttachStateRef.current = {
-    mode: 'waiting_for_geometry',
-    pendingIntent: 'viewport_hydrate',
-    pendingSinceSeq: 0,
-    pendingReason: 'terminal_created',
-  }
-  setIsAttaching(false)
-} else {
-  attachTerminal(newId, 'viewport_hydrate', { clearViewportFirst: true })
-}
-```
-
-Keep this logic after `updateContent(...)` and session association reconciliation so `contentRef.current.sessionRef` has the canonical OpenCode session before the branch runs.
+Do not broaden the behavior to `replay_budget_exceeded`, non-OpenCode modes, or delta attaches.
 
 - [ ] **Step 4: Run focused lifecycle coverage**
 
 Run:
 
 ```bash
-npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "hidden create path defers attach until visible and measured|hidden restored OpenCode create attaches in the background before reveal|recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output"
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output|recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output|background hydrates an untrusted hidden running pane with a viewport attach"
 ```
 
-Expected: PASS. This confirms ordinary hidden creates still defer, OpenCode restored hidden creates attach immediately, and existing visible replay-gap replacement still works.
-
-- [ ] **Step 5: Commit Task 1**
-
-Run:
-
-```bash
-git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx
-git commit -m "fix: hydrate hidden restored opencode panes"
-```
+Expected: PASS. This confirms hidden OpenCode gaps repair, the visible repair still works, and hidden background hydration still uses the queue.
 
 ### Task 2: Browser Refresh Visual Regression Coverage
 
@@ -146,33 +179,24 @@ git commit -m "fix: hydrate hidden restored opencode panes"
 - Modify: `test/e2e-browser/specs/opencode-restart-recovery.spec.ts:614-765`
 
 **Interfaces:**
-- Consumes: existing `recovers a hidden OpenCode sessionRef when association lands while the browser is closed` scenario, `TestHarness`, and `getPaneSnapshots`.
-- Produces: an assertion that a restored hidden OpenCode pane has rendered terminal output after it is revealed, not only a valid session id.
+- Consumes: existing `recovers a hidden OpenCode sessionRef when association lands while the browser is closed` scenario and `TestHarness.getTerminalBuffer`.
+- Produces: an assertion that a restored hidden OpenCode pane has rendered terminal output after reveal, not only a valid session id.
 
-- [ ] **Step 1: Write the failing e2e assertion**
+- [ ] **Step 1: Write the e2e assertion**
 
-In `recovers a hidden OpenCode sessionRef when association lands while the browser is closed`, after the restored page reveals the OpenCode tab and before sending `hidden-after-refresh`, add:
+In `recovers a hidden OpenCode sessionRef when association lands while the browser is closed`, after revealing the OpenCode tab and asserting the restored `terminalId` and `sessionRef`, add a buffer assertion:
 
 ```ts
 await expect.poll(async () => {
-  return restorePage!.evaluate((targetTabId) => {
-    const harness = window.__FRESHELL_TEST_HARNESS__
-    const state = harness?.getState()
-    const findTerminal = (node: any): any => {
-      if (!node) return undefined
-      if (node.type === 'leaf' && node.content?.kind === 'terminal') return node.content
-      if (node.type === 'split') return findTerminal(node.children?.[0]) ?? findTerminal(node.children?.[1])
-      return undefined
-    }
-    const content = findTerminal(state?.panes?.layouts?.[targetTabId])
-    if (!content?.terminalId) return ''
-    return harness?.getTerminalBuffer?.(content.terminalId)?.trim() ?? ''
-  }, tabId)
+  const buffer = await restoreHarness.getTerminalBuffer(afterRefresh.terminalId)
+  return buffer?.trim() ?? ''
 }, {
   timeout: 30_000,
   message: 'expected restored hidden OpenCode pane to render terminal content after reveal',
 }).not.toBe('')
 ```
+
+This uses the fake OpenCode fixture's startup output and stdin echo as the rendered signal.
 
 - [ ] **Step 2: Run the e2e-browser scenario**
 
@@ -182,13 +206,9 @@ Run:
 npm run test:e2e:chromium -- test/e2e-browser/specs/opencode-restart-recovery.spec.ts -g "recovers a hidden OpenCode sessionRef when association lands while the browser is closed"
 ```
 
-Expected before Task 1 implementation: FAIL intermittently or time out when hidden restored OpenCode has no terminal-emulation owner. Expected after Task 1: PASS.
+Expected after Task 1: PASS.
 
-- [ ] **Step 3: Adjust only if harness naming differs**
-
-If TypeScript reports the terminal buffer helper under a different name, inspect the harness type and update the call to the existing helper. Do not add a new test-only harness API unless the helper is genuinely absent.
-
-- [ ] **Step 4: Run OpenCode restart recovery browser coverage**
+- [ ] **Step 3: Run OpenCode restart recovery browser coverage**
 
 Run:
 
@@ -198,22 +218,13 @@ npm run test:e2e:chromium -- test/e2e-browser/specs/opencode-restart-recovery.sp
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit Task 2**
-
-Run:
-
-```bash
-git add test/e2e-browser/specs/opencode-restart-recovery.spec.ts
-git commit -m "test: cover opencode hidden refresh rendering"
-```
-
 ### Task 3: Final Verification
 
 **Files:**
 - Verify only.
 
 **Interfaces:**
-- Consumes: commits from Tasks 1 and 2.
+- Consumes: committed implementation work.
 - Produces: evidence that the branch is ready for final review.
 
 - [ ] **Step 1: Run targeted unit coverage**
@@ -221,7 +232,7 @@ git commit -m "test: cover opencode hidden refresh rendering"
 Run:
 
 ```bash
-npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "hidden create path defers attach until visible and measured|hidden restored OpenCode create attaches in the background before reveal|recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output"
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output|recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output|background hydrates an untrusted hidden running pane with a viewport attach"
 ```
 
 Expected: PASS.
@@ -246,19 +257,19 @@ npm run check
 
 Expected: PASS.
 
-- [ ] **Step 4: Commit any verification-only plan updates**
+- [ ] **Step 4: Commit the focused change**
 
-If and only if the plan checkbox state is updated during execution, run:
+Run:
 
 ```bash
-git add docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
-git commit -m "docs: update opencode restore plan progress"
+git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx test/e2e-browser/specs/opencode-restart-recovery.spec.ts docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
+git commit -m "fix: repair hidden opencode refresh hydration"
 ```
 
 ## Self-Review
 
-Spec coverage: The plan fixes the OpenCode CLI refresh white-page path by ensuring hidden restored OpenCode PTYs have an immediate xterm owner, keeps the existing replay-gap repair, and adds unit plus browser regression coverage.
+Spec coverage: The corrected plan protects the OpenCode CLI refresh white-page path by replacing a stale restored OpenCode PTY when hidden full-viewport hydration cannot replay startup output, and it adds both lifecycle and browser-buffer coverage.
 
 Placeholder scan: No `TBD`, `TODO`, or undefined implementation placeholder remains.
 
-Type consistency: The plan uses existing `TerminalPaneContent['sessionRef']`, `attachTerminal`, `viewportHydrateReplayOptions`, `launchAttemptRef`, and `terminal.attach` message fields already present in `TerminalView`.
+Type consistency: The plan uses existing `TerminalPaneContent['sessionRef']`, `currentAttachRef`, `beginOpenCodeReplacementAfterExit`, hydration queue, and `terminal.attach` message fields already present in `TerminalView`.

--- a/docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
+++ b/docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
@@ -197,7 +197,37 @@ Expected: PASS. This confirms hidden OpenCode gaps repair, the visible repair st
 
 - [ ] **Step 1: Allow per-test replay-ring sizing**
 
-Extend this spec-local helper input:
+Extend this spec-local setup helper so a test can seed terminal scrollback in the isolated home:
+
+```ts
+function createSetupHome(
+  sharedOpencodeDataDir: string,
+  options: { terminalScrollback?: number } = {},
+) {
+  return async (homeDir: string): Promise<void> => {
+    const xdgShare = path.join(homeDir, '.local', 'share')
+    const freshellDir = path.join(homeDir, '.freshell')
+    const opencodeLink = path.join(xdgShare, 'opencode')
+    await fsp.mkdir(xdgShare, { recursive: true })
+    await fsp.mkdir(freshellDir, { recursive: true })
+    await fsp.mkdir(sharedOpencodeDataDir, { recursive: true })
+    await fsp.rm(opencodeLink, { recursive: true, force: true }).catch(() => {})
+    await fsp.symlink(sharedOpencodeDataDir, opencodeLink, 'dir')
+    if (typeof options.terminalScrollback === 'number') {
+      await fsp.writeFile(path.join(freshellDir, 'config.json'), JSON.stringify({
+        version: 1,
+        settings: {
+          terminal: { scrollback: options.terminalScrollback },
+        },
+      }, null, 2))
+    }
+  }
+}
+```
+
+`TestServer` later calls `ensureSetupWizardBypassConfig`, which preserves this setup-provided `settings.terminal.scrollback` while adding the network bootstrap fields.
+
+Then extend `createServerOptions` input:
 
 ```ts
 function createServerOptions(input: {
@@ -208,26 +238,33 @@ function createServerOptions(input: {
   fakeOpencodeSessionEventGatePath?: string
   port?: number
   token?: string
+  terminalScrollback?: number
   env?: Record<string, string>
 }) {
 ```
 
-and spread `input.env` into the returned `env` object after the existing defaults:
+Pass the scrollback option into `setupHome`, and spread `input.env` into the returned `env` object after the existing defaults:
+
+```ts
+    setupHome: createSetupHome(input.sharedOpencodeDataDir, {
+      terminalScrollback: input.terminalScrollback,
+    }),
+```
 
 ```ts
       FRESHELL_LOG_DIR: input.logsDir,
       ...(input.env ?? {}),
 ```
 
-This keeps other tests unchanged while letting this scenario lower the coding CLI replay ring.
+This keeps other tests unchanged while letting this scenario lower the real replay ring: `terminal.scrollback: 200` computes below the registry's 64 KiB floor, and `CODING_CLI_MIN_REPLAY_RING_MAX_BYTES=64 KiB` prevents the OpenCode floor from raising it back to the default 32 MiB.
 
 - [ ] **Step 2: Force the hidden replay-window gap**
 
 In `recovers a hidden OpenCode sessionRef when association lands while the browser is closed`, pass a small scrollback/replay budget into `createServerOptions`:
 
 ```ts
+terminalScrollback: 200,
 env: {
-  MAX_SCROLLBACK_CHARS: String(64 * 1024),
   CODING_CLI_MIN_REPLAY_RING_MAX_BYTES: String(64 * 1024),
 },
 ```

--- a/docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
+++ b/docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
@@ -1,0 +1,264 @@
+# OpenCode Refresh Restore White Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent restored OpenCode CLI panes from becoming visually blank after browser refresh by ensuring hidden restored OpenCode PTYs get an immediate terminal-emulation attach.
+
+**Architecture:** Keep the existing visible replay-gap repair path. Add one OpenCode-specific hidden-create branch in `TerminalView`: restored hidden OpenCode terminals should perform a background `viewport_hydrate` attach as soon as `terminal.created` arrives, while ordinary hidden terminals keep deferring until reveal. Tests prove the behavior at the lifecycle boundary and through an OpenCode refresh/reveal flow.
+
+**Tech Stack:** React 18, Redux Toolkit, xterm.js, Vitest, Playwright e2e-browser harness, Freshell WebSocket terminal protocol.
+
+## Global Constraints
+
+- Work in `/home/dan/code/freshell/.worktrees/opencode-refresh-restore-white-page` on branch `fix/opencode-refresh-restore-white-page`.
+- Keep the change scoped to OpenCode CLI terminal restore/hydration; do not change fresh-agent or `freshopencode`.
+- Do not restart the self-hosted Freshell server.
+- Use NodeNext/ESM-compatible imports; relative server imports must keep `.js` extensions.
+- Preserve existing hidden terminal behavior for shell, Codex, Claude, Gemini, and Kimi.
+- Tests must prove behavior, not static strings.
+- Commit each completed task.
+
+---
+
+## File Structure
+
+- Modify `src/components/TerminalView.tsx`: add the OpenCode hidden restored attach policy in the `terminal.created` handler.
+- Modify `test/unit/client/components/TerminalView.lifecycle.test.tsx`: add focused lifecycle regression coverage and keep existing hidden-create expectations for non-OpenCode terminals.
+- Modify `test/e2e-browser/specs/opencode-restart-recovery.spec.ts`: extend OpenCode refresh coverage to prove a hidden restored OpenCode pane is visibly hydrated after reveal.
+
+### Task 1: OpenCode Hidden Restore Attach Policy
+
+**Files:**
+- Modify: `src/components/TerminalView.tsx:3601-3685`
+- Modify: `test/unit/client/components/TerminalView.lifecycle.test.tsx:3705-3736`
+
+**Interfaces:**
+- Consumes: `launchAttemptRef.current.restore`, `contentRef.current.mode`, `contentRef.current.sessionRef`, and existing `attachTerminal(tid, intent, opts)`.
+- Produces: hidden restored OpenCode panes send `terminal.attach` with `intent: 'viewport_hydrate'`, `priority: 'background'`, and `sinceSeq: 0` immediately after `terminal.created`.
+
+- [ ] **Step 1: Write the failing lifecycle test**
+
+Add this test immediately after `hidden create path defers attach until visible and measured` in `test/unit/client/components/TerminalView.lifecycle.test.tsx`:
+
+```tsx
+it('hidden restored OpenCode create attaches in the background before reveal', async () => {
+  const sessionRef = { provider: 'opencode', sessionId: 'ses_hidden_restore_owner' } as const
+  restoreMocks.consumeTerminalRestoreRequestId.mockImplementation((id: string) => id === 'req-v2-hidden-opencode-restore')
+
+  const { requestId } = await renderTerminalHarness({
+    status: 'creating',
+    hidden: true,
+    mode: 'opencode',
+    requestId: 'req-v2-hidden-opencode-restore',
+    sessionRef,
+  })
+
+  wsMocks.send.mockClear()
+  act(() => {
+    messageHandler!({
+      type: 'terminal.created',
+      requestId,
+      terminalId: 'term-hidden-opencode-restore',
+      createdAt: Date.now(),
+      sessionRef,
+    })
+  })
+
+  await waitFor(() => {
+    expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'terminal.attach',
+      terminalId: 'term-hidden-opencode-restore',
+      intent: 'viewport_hydrate',
+      priority: 'background',
+      sinceSeq: 0,
+      attachRequestId: expect.any(String),
+    }))
+  })
+})
+```
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "hidden restored OpenCode create attaches in the background before reveal"
+```
+
+Expected: FAIL because hidden `terminal.created` currently stores a deferred attach and sends no `terminal.attach`.
+
+- [ ] **Step 3: Implement the OpenCode-only hidden attach branch**
+
+In `src/components/TerminalView.tsx`, replace the hidden branch in the `terminal.created` handler with this shape:
+
+```tsx
+const createdRestoreLaunch = launchAttemptRef.current?.terminalId === newId
+  && launchAttemptRef.current.restore === true
+const currentSessionRef = contentRef.current?.sessionRef
+const shouldBackgroundHydrateHiddenOpenCode = hiddenRef.current
+  && createdRestoreLaunch
+  && contentRef.current?.mode === 'opencode'
+  && currentSessionRef?.provider === 'opencode'
+
+if (hiddenRef.current && shouldBackgroundHydrateHiddenOpenCode) {
+  attachTerminal(newId, 'viewport_hydrate', {
+    clearViewportFirst: true,
+    priority: 'background',
+    ...viewportHydrateReplayOptions(contentRef.current),
+  })
+} else if (hiddenRef.current) {
+  deferredAttachStateRef.current = {
+    mode: 'waiting_for_geometry',
+    pendingIntent: 'viewport_hydrate',
+    pendingSinceSeq: 0,
+    pendingReason: 'terminal_created',
+  }
+  setIsAttaching(false)
+} else {
+  attachTerminal(newId, 'viewport_hydrate', { clearViewportFirst: true })
+}
+```
+
+Keep this logic after `updateContent(...)` and session association reconciliation so `contentRef.current.sessionRef` has the canonical OpenCode session before the branch runs.
+
+- [ ] **Step 4: Run focused lifecycle coverage**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "hidden create path defers attach until visible and measured|hidden restored OpenCode create attaches in the background before reveal|recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output"
+```
+
+Expected: PASS. This confirms ordinary hidden creates still defer, OpenCode restored hidden creates attach immediately, and existing visible replay-gap replacement still works.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx
+git commit -m "fix: hydrate hidden restored opencode panes"
+```
+
+### Task 2: Browser Refresh Visual Regression Coverage
+
+**Files:**
+- Modify: `test/e2e-browser/specs/opencode-restart-recovery.spec.ts:614-765`
+
+**Interfaces:**
+- Consumes: existing `recovers a hidden OpenCode sessionRef when association lands while the browser is closed` scenario, `TestHarness`, and `getPaneSnapshots`.
+- Produces: an assertion that a restored hidden OpenCode pane has rendered terminal output after it is revealed, not only a valid session id.
+
+- [ ] **Step 1: Write the failing e2e assertion**
+
+In `recovers a hidden OpenCode sessionRef when association lands while the browser is closed`, after the restored page reveals the OpenCode tab and before sending `hidden-after-refresh`, add:
+
+```ts
+await expect.poll(async () => {
+  return restorePage!.evaluate((targetTabId) => {
+    const harness = window.__FRESHELL_TEST_HARNESS__
+    const state = harness?.getState()
+    const findTerminal = (node: any): any => {
+      if (!node) return undefined
+      if (node.type === 'leaf' && node.content?.kind === 'terminal') return node.content
+      if (node.type === 'split') return findTerminal(node.children?.[0]) ?? findTerminal(node.children?.[1])
+      return undefined
+    }
+    const content = findTerminal(state?.panes?.layouts?.[targetTabId])
+    if (!content?.terminalId) return ''
+    return harness?.getTerminalBuffer?.(content.terminalId)?.trim() ?? ''
+  }, tabId)
+}, {
+  timeout: 30_000,
+  message: 'expected restored hidden OpenCode pane to render terminal content after reveal',
+}).not.toBe('')
+```
+
+- [ ] **Step 2: Run the e2e-browser scenario**
+
+Run:
+
+```bash
+npm run test:e2e:chromium -- test/e2e-browser/specs/opencode-restart-recovery.spec.ts -g "recovers a hidden OpenCode sessionRef when association lands while the browser is closed"
+```
+
+Expected before Task 1 implementation: FAIL intermittently or time out when hidden restored OpenCode has no terminal-emulation owner. Expected after Task 1: PASS.
+
+- [ ] **Step 3: Adjust only if harness naming differs**
+
+If TypeScript reports the terminal buffer helper under a different name, inspect the harness type and update the call to the existing helper. Do not add a new test-only harness API unless the helper is genuinely absent.
+
+- [ ] **Step 4: Run OpenCode restart recovery browser coverage**
+
+Run:
+
+```bash
+npm run test:e2e:chromium -- test/e2e-browser/specs/opencode-restart-recovery.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add test/e2e-browser/specs/opencode-restart-recovery.spec.ts
+git commit -m "test: cover opencode hidden refresh rendering"
+```
+
+### Task 3: Final Verification
+
+**Files:**
+- Verify only.
+
+**Interfaces:**
+- Consumes: commits from Tasks 1 and 2.
+- Produces: evidence that the branch is ready for final review.
+
+- [ ] **Step 1: Run targeted unit coverage**
+
+Run:
+
+```bash
+npm run test:vitest -- test/unit/client/components/TerminalView.lifecycle.test.tsx --run -t "hidden create path defers attach until visible and measured|hidden restored OpenCode create attaches in the background before reveal|recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run targeted browser coverage**
+
+Run:
+
+```bash
+npm run test:e2e:chromium -- test/e2e-browser/specs/opencode-restart-recovery.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run repo-supported verification**
+
+Run:
+
+```bash
+npm run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit any verification-only plan updates**
+
+If and only if the plan checkbox state is updated during execution, run:
+
+```bash
+git add docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
+git commit -m "docs: update opencode restore plan progress"
+```
+
+## Self-Review
+
+Spec coverage: The plan fixes the OpenCode CLI refresh white-page path by ensuring hidden restored OpenCode PTYs have an immediate xterm owner, keeps the existing replay-gap repair, and adds unit plus browser regression coverage.
+
+Placeholder scan: No `TBD`, `TODO`, or undefined implementation placeholder remains.
+
+Type consistency: The plan uses existing `TerminalPaneContent['sessionRef']`, `attachTerminal`, `viewportHydrateReplayOptions`, `launchAttemptRef`, and `terminal.attach` message fields already present in `TerminalView`.

--- a/docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
+++ b/docs/superpowers/plans/2026-06-17-opencode-refresh-restore-white-page.md
@@ -246,9 +246,16 @@ In the restored-page hidden wait, keep the assertions for active shell tab, Open
 
 - [ ] **Step 4: Assert relaunch and rendered output after reveal**
 
-After revealing the OpenCode tab and calling `waitForOpenCodeSessions`, change the terminal id assertion from equality to replacement:
+After revealing the OpenCode tab, wait specifically for a running replacement terminal id:
 
 ```ts
+const [afterRefresh] = await waitForRunningTerminals(restorePage, [opencodeTab.tabId], {
+  [opencodeTab.tabId]: beforeAssociation.terminalId,
+})
+expect(afterRefresh.sessionRef).toEqual({
+  provider: 'opencode',
+  sessionId: expectedSessionId,
+})
 expect(afterRefresh.terminalId).toBeTruthy()
 expect(afterRefresh.terminalId).not.toBe(beforeAssociation.terminalId)
 ```

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -3370,7 +3370,6 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           const isUnrecoverableOpenCodeViewportHydrate = msg.reason === 'replay_window_exceeded'
             && currentAttachRef.current?.intent === 'viewport_hydrate'
             && currentAttachRef.current.sinceSeq === 0
-            && !hiddenRef.current
             && contentRef.current?.mode === 'opencode'
             && contentRef.current.sessionRef?.provider === 'opencode'
           if (isUnrecoverableOpenCodeViewportHydrate && beginOpenCodeReplacementAfterExit(tid)) {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -2667,6 +2667,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
   useEffect(() => {
     if (suppressNetworkEffects) return
     if (!isTerminal || !terminalContent) return
+    if (shouldWaitForProviderBehavior) return
     const termCandidate = termRef.current
     if (!termCandidate) return
     const term = termCandidate
@@ -4213,6 +4214,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     isTerminal,
     paneId,
     suppressNetworkEffects,
+    shouldWaitForProviderBehavior,
     terminalContent?.createRequestId,
     updateContent,
     ws,

--- a/test/e2e-browser/specs/opencode-restart-recovery.spec.ts
+++ b/test/e2e-browser/specs/opencode-restart-recovery.spec.ts
@@ -3,6 +3,8 @@ import fsp from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import WebSocket from 'ws'
+import { WS_PROTOCOL_VERSION } from '../../../shared/ws-protocol.js'
 import { TestHarness } from '../helpers/test-harness.js'
 import { TestServer } from '../helpers/test-server.js'
 
@@ -39,14 +41,27 @@ async function installFakeOpencode(binDir: string): Promise<void> {
   await fsp.chmod(target, 0o755)
 }
 
-function createSetupHome(sharedOpencodeDataDir: string) {
+function createSetupHome(
+  sharedOpencodeDataDir: string,
+  options: { terminalScrollback?: number } = {},
+) {
   return async (homeDir: string): Promise<void> => {
     const xdgShare = path.join(homeDir, '.local', 'share')
+    const freshellDir = path.join(homeDir, '.freshell')
     const opencodeLink = path.join(xdgShare, 'opencode')
     await fsp.mkdir(xdgShare, { recursive: true })
+    await fsp.mkdir(freshellDir, { recursive: true })
     await fsp.mkdir(sharedOpencodeDataDir, { recursive: true })
     await fsp.rm(opencodeLink, { recursive: true, force: true }).catch(() => {})
     await fsp.symlink(sharedOpencodeDataDir, opencodeLink, 'dir')
+    if (typeof options.terminalScrollback === 'number') {
+      await fsp.writeFile(path.join(freshellDir, 'config.json'), JSON.stringify({
+        version: 1,
+        settings: {
+          terminal: { scrollback: options.terminalScrollback },
+        },
+      }, null, 2))
+    }
   }
 }
 
@@ -58,16 +73,21 @@ function createServerOptions(input: {
   fakeOpencodeSessionEventGatePath?: string
   port?: number
   token?: string
+  terminalScrollback?: number
+  env?: Record<string, string>
 }) {
   return {
     ...(input.port ? { port: input.port } : {}),
     ...(input.token ? { token: input.token } : {}),
-    setupHome: createSetupHome(input.sharedOpencodeDataDir),
+    setupHome: createSetupHome(input.sharedOpencodeDataDir, {
+      terminalScrollback: input.terminalScrollback,
+    }),
     env: {
       PATH: `${input.binDir}${path.delimiter}${process.env.PATH ?? ''}`,
       FAKE_OPENCODE_AUDIT_LOG: input.auditLogPath,
       ...(input.fakeOpencodeSessionEventGatePath ? { FAKE_OPENCODE_SESSION_EVENT_GATE_PATH: input.fakeOpencodeSessionEventGatePath } : {}),
       FRESHELL_LOG_DIR: input.logsDir,
+      ...(input.env ?? {}),
     },
   }
 }
@@ -239,6 +259,81 @@ async function sendInputToTerminals(page: any, snapshots: PaneSnapshot[], label 
       })
     }
   }, { items: snapshots, inputLabel: label })
+}
+
+async function sendTerminalInputOverWs(input: {
+  wsUrl: string
+  token: string
+  terminalId: string
+  data: string
+}): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(input.wsUrl)
+    let settled = false
+    const timeout = setTimeout(() => {
+      if (settled) return
+      settled = true
+      ws.terminate()
+      reject(new Error(`Timed out sending terminal input over websocket for ${input.terminalId}`))
+    }, 10_000)
+
+    const finish = (error?: Error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      ws.removeAllListeners()
+      try {
+        ws.close()
+      } catch {
+        // ignore close failures in test cleanup
+      }
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    }
+
+    ws.on('open', () => {
+      ws.send(JSON.stringify({
+        type: 'hello',
+        token: input.token,
+        protocolVersion: WS_PROTOCOL_VERSION,
+      }))
+    })
+
+    ws.on('message', (raw) => {
+      const message = JSON.parse(String(raw))
+      if (message?.type === 'ready') {
+        ws.send(JSON.stringify({
+          type: 'terminal.input',
+          terminalId: input.terminalId,
+          data: input.data,
+        }), (error) => {
+          if (error) {
+            finish(error)
+            return
+          }
+          setTimeout(() => finish(), 250)
+        })
+        return
+      }
+      if (message?.type === 'terminal.input.blocked') {
+        finish(new Error(`Terminal input blocked for ${input.terminalId}: ${JSON.stringify(message)}`))
+        return
+      }
+      if (message?.type === 'error') {
+        finish(new Error(`Websocket input error for ${input.terminalId}: ${JSON.stringify(message)}`))
+      }
+    })
+
+    ws.on('error', (error) => finish(error instanceof Error ? error : new Error(String(error))))
+    ws.on('close', () => {
+      if (!settled) {
+        finish(new Error(`Websocket closed before terminal input completed for ${input.terminalId}`))
+      }
+    })
+  })
 }
 
 async function closeTab(page: any, tabId: string): Promise<void> {
@@ -626,6 +721,10 @@ test.describe('OpenCode restart recovery', () => {
       logsDir,
       sharedOpencodeDataDir,
       fakeOpencodeSessionEventGatePath: sessionEventGatePath,
+      terminalScrollback: 200,
+      env: {
+        CODING_CLI_MIN_REPLAY_RING_MAX_BYTES: String(64 * 1024),
+      },
     }))
 
     let restorePage: typeof page | undefined
@@ -652,6 +751,7 @@ test.describe('OpenCode restart recovery', () => {
       const launch = await waitForInitialOpenCodeLaunch(auditLogPath)
       const expectedSessionId = launch.rootSessionId!
 
+      await sendInputToTerminals(page, [beforeAssociation], `hidden-overflow-${'x'.repeat(96 * 1024)}`)
       await sendInputToTerminals(page, [beforeAssociation], 'hidden-before-refresh')
       await waitForStdinAudit(auditLogPath, [{
         tabId: opencodeTab.tabId,
@@ -683,6 +783,26 @@ test.describe('OpenCode restart recovery', () => {
 
       const context = page.context()
       await page.close()
+      for (let index = 0; index < 3; index += 1) {
+        const hiddenOverflowAfterCloseLabel = `hidden-overflow-after-close-${index}-${'x'.repeat(40 * 1024)}`
+        await sendTerminalInputOverWs({
+          wsUrl: info.wsUrl,
+          token: info.token,
+          terminalId: beforeAssociation.terminalId!,
+          data: `${hiddenOverflowAfterCloseLabel} ${opencodeTab.tabId}\n`,
+        })
+      }
+      const hiddenAfterCloseMarker = 'hidden-after-close-marker'
+      await sendTerminalInputOverWs({
+        wsUrl: info.wsUrl,
+        token: info.token,
+        terminalId: beforeAssociation.terminalId!,
+        data: `${hiddenAfterCloseMarker} ${opencodeTab.tabId}\n`,
+      })
+      await waitForStdinAudit(auditLogPath, [{
+        tabId: opencodeTab.tabId,
+        sessionId: expectedSessionId,
+      }], hiddenAfterCloseMarker)
       await fsp.writeFile(sessionEventGatePath, 'release\n', 'utf8')
       await waitForSessionEventsEmitted(auditLogPath, expectedSessionId)
       await expect.poll(async () => {
@@ -706,7 +826,7 @@ test.describe('OpenCode restart recovery', () => {
       await restoreHarness.waitForHarness()
       await restoreHarness.waitForConnection()
 
-      await restorePage.waitForFunction(({ tabId, shellTabId, expectedTerminalId, expectedSessionId }) => {
+      await restorePage.waitForFunction(({ tabId, shellTabId, expectedSessionId }) => {
         const state = window.__FRESHELL_TEST_HARNESS__?.getState()
         const findTerminal = (node: any): any => {
           if (!node) return undefined
@@ -720,13 +840,11 @@ test.describe('OpenCode restart recovery', () => {
           && tab?.sessionRef?.provider === 'opencode'
           && tab.sessionRef.sessionId === expectedSessionId
           && content?.mode === 'opencode'
-          && content.terminalId === expectedTerminalId
           && content.sessionRef?.provider === 'opencode'
           && content.sessionRef.sessionId === expectedSessionId
       }, {
         tabId: opencodeTab.tabId,
         shellTabId: shellTab.tabId,
-        expectedTerminalId: beforeAssociation.terminalId,
         expectedSessionId,
       }, { timeout: 30_000 })
 
@@ -747,12 +865,23 @@ test.describe('OpenCode restart recovery', () => {
       }, { timeout: TAB_REGISTRY_SYNC_INTERVAL_MS + 10_000 }).toBe(true)
 
       await restorePage.locator(`[data-context="tab"][data-tab-id="${opencodeTab.tabId}"]`).click()
-      const [afterRefresh] = await waitForOpenCodeSessions(restorePage, [opencodeTab.tabId])
-      expect(afterRefresh.terminalId).toBe(beforeAssociation.terminalId)
+      const [afterRefresh] = await waitForRunningTerminals(restorePage, [opencodeTab.tabId], {
+        [opencodeTab.tabId]: beforeAssociation.terminalId,
+      })
       expect(afterRefresh.sessionRef).toEqual({
         provider: 'opencode',
         sessionId: expectedSessionId,
       })
+      expect(afterRefresh.terminalId).toBeTruthy()
+      expect(afterRefresh.terminalId).not.toBe(beforeAssociation.terminalId)
+      await waitForRestoreLaunches(auditLogPath, [expectedSessionId])
+      await expect.poll(async () => {
+        const buffer = await restoreHarness.getTerminalBuffer(afterRefresh.terminalId!)
+        return buffer ?? ''
+      }, {
+        timeout: 30_000,
+        message: 'expected restored hidden OpenCode pane to render terminal content after replay-window repair',
+      }).toContain(`fake opencode ready root=${expectedSessionId}`)
       await sendInputToTerminals(restorePage, [afterRefresh], 'hidden-after-refresh')
       await waitForStdinAudit(auditLogPath, [{
         tabId: opencodeTab.tabId,

--- a/test/e2e-browser/specs/opencode-restart-recovery.spec.ts
+++ b/test/e2e-browser/specs/opencode-restart-recovery.spec.ts
@@ -98,6 +98,7 @@ async function addTerminalTab(page: any, input: {
   requestId: string
   mode: 'opencode' | 'shell'
   title: string
+  cwd?: string
 }): Promise<void> {
   await page.evaluate((payload) => {
     const harness = window.__FRESHELL_TEST_HARNESS__
@@ -123,6 +124,7 @@ async function addTerminalTab(page: any, input: {
           shell: 'system',
           createRequestId: payload.requestId,
           status: 'creating',
+          ...(payload.cwd ? { initialCwd: payload.cwd } : {}),
         },
       },
     })
@@ -454,7 +456,9 @@ async function runRestartScenario(input: {
   const logsDir = path.join(sharedRoot, 'logs')
   const auditLogPath = path.join(sharedRoot, 'fake-opencode-audit.jsonl')
   const sharedOpencodeDataDir = path.join(sharedRoot, 'opencode-data')
+  const sharedCwd = path.join(sharedRoot, 'project')
   await installFakeOpencode(binDir)
+  await fsp.mkdir(sharedCwd, { recursive: true })
 
   const server1 = new TestServer(createServerOptions({
     binDir,
@@ -479,13 +483,13 @@ async function runRestartScenario(input: {
     ]
 
     for (const tab of opencodeTabs) {
-      await addTerminalTab(input.page, tab)
+      await addTerminalTab(input.page, { ...tab, cwd: sharedCwd })
       await waitForOpenCodeSessions(input.page, [tab.tabId])
     }
 
     const shellTab = { tabId: 'tab-shell-mixed', paneId: 'pane-shell-mixed', requestId: 'req-shell-mixed', mode: 'shell' as const, title: 'Shell Mixed' }
     if (input.includeShellPane) {
-      await addTerminalTab(input.page, shellTab)
+      await addTerminalTab(input.page, { ...shellTab, cwd: sharedCwd })
       await waitForRunningTerminals(input.page, [shellTab.tabId])
     }
 

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -19,7 +19,7 @@ import {
   loadTerminalSurfaceCheckpoint,
   saveTerminalSurfaceCheckpoint,
 } from '@/lib/terminal-cursor'
-import { resetHydrationQueueForTests } from '@/lib/hydration-queue'
+import { getHydrationQueue, resetHydrationQueueForTests } from '@/lib/hydration-queue'
 import { createPerfAuditBridge, installPerfAuditBridge } from '@/lib/perf-audit-bridge'
 import { TERMINAL_CURSOR_STORAGE_KEY } from '@/store/storage-keys'
 import {
@@ -7702,6 +7702,115 @@ describe('TerminalView lifecycle updates', () => {
         expect(layout.content.sessionRef).toEqual(sessionRef)
         replacementRequestId = layout.content.createRequestId
         expect(replacementRequestId).not.toBe('req-opencode-focus-gap')
+      })
+
+      await waitFor(() => {
+        expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+          type: 'terminal.create',
+          requestId: replacementRequestId,
+          mode: 'opencode',
+          sessionRef,
+          restore: true,
+        }))
+      })
+    })
+
+    it('recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output', async () => {
+      const sessionRef = { provider: 'opencode', sessionId: 'ses_hidden_replay_gap' } as const
+      const addedRestoreIds = new Set<string>()
+      restoreMocks.addTerminalRestoreRequestId.mockImplementation((id: string) => {
+        addedRestoreIds.add(id)
+      })
+      restoreMocks.consumeTerminalRestoreRequestId.mockImplementation((id: string) => {
+        if (addedRestoreIds.has(id)) {
+          addedRestoreIds.delete(id)
+          return true
+        }
+        return false
+      })
+
+      const { store, tabId, paneId, terminalId, rerender } = await renderTerminalHarness({
+        status: 'running',
+        terminalId: 'term-opencode-hidden-gap',
+        mode: 'opencode',
+        hidden: true,
+        clearSends: false,
+        requestId: 'req-opencode-hidden-gap',
+        sessionRef,
+      })
+
+      wsMocks.send.mockClear()
+      act(() => {
+        getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])
+      })
+
+      let attach: any
+      await waitFor(() => {
+        attach = wsMocks.send.mock.calls
+          .map(([msg]) => msg)
+          .find((msg) =>
+            msg?.type === 'terminal.attach'
+            && msg?.terminalId === terminalId
+            && msg?.intent === 'viewport_hydrate'
+            && msg?.priority === 'background'
+          )
+        expect(attach?.attachRequestId).toBeTruthy()
+      })
+
+      act(() => {
+        messageHandler!({
+          type: 'terminal.attach.ready',
+          terminalId,
+          headSeq: 120,
+          replayFromSeq: 42,
+          replayToSeq: 120,
+          attachRequestId: attach.attachRequestId,
+        })
+      })
+      act(() => {
+        messageHandler!({
+          type: 'terminal.output.gap',
+          terminalId,
+          fromSeq: 1,
+          toSeq: 41,
+          reason: 'replay_window_exceeded',
+          attachRequestId: attach.attachRequestId,
+        } as any)
+      })
+
+      await waitFor(() => {
+        expect(wsMocks.send).toHaveBeenCalledWith({
+          type: 'terminal.kill',
+          terminalId,
+        })
+      })
+
+      act(() => {
+        messageHandler!({
+          type: 'terminal.exit',
+          terminalId,
+          exitCode: 0,
+        })
+      })
+
+      rerender(
+        <Provider store={store}>
+          <TerminalViewFromStore tabId={tabId} paneId={paneId} hidden />
+        </Provider>,
+      )
+
+      let replacementRequestId: string | undefined
+      await waitFor(() => {
+        const layout = store.getState().panes.layouts[tabId]
+        expect(layout?.type).toBe('leaf')
+        if (layout?.type !== 'leaf' || layout.content.kind !== 'terminal') {
+          throw new Error('expected terminal pane')
+        }
+        expect(layout.content.terminalId).toBeUndefined()
+        expect(layout.content.status).toBe('creating')
+        expect(layout.content.sessionRef).toEqual(sessionRef)
+        replacementRequestId = layout.content.createRequestId
+        expect(replacementRequestId).not.toBe('req-opencode-hidden-gap')
       })
 
       await waitFor(() => {

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -120,6 +120,7 @@ import TerminalView, {
   __resetLastSentViewportCacheForTests,
   isEngagementInput,
 } from '@/components/TerminalView'
+import { resetEnsureExtensionsRegistryCacheForTests } from '@/hooks/useEnsureExtensionsRegistry'
 
 describe('isEngagementInput (real-keystroke detection)', () => {
   it('treats printable characters and Enter as engagement', () => {
@@ -343,6 +344,7 @@ describe('TerminalView lifecycle updates', () => {
     terminalThemeMocks.getTerminalTheme.mockReturnValue({})
     restoreMocks.consumeTerminalRestoreRequestId.mockReset()
     restoreMocks.consumeTerminalRestoreRequestId.mockReturnValue(false)
+    resetEnsureExtensionsRegistryCacheForTests()
     terminalInstances.length = 0
     runtimeMocks.instances.length = 0
     wsMocks.onMessage.mockImplementation((callback: (msg: any) => void) => {
@@ -3539,6 +3541,8 @@ describe('TerminalView lifecycle updates', () => {
       sessionRef?: TerminalPaneContent['sessionRef']
       serverInstanceId?: string
       streamId?: string
+      waitForMessageHandler?: boolean
+      waitForTerminalInstance?: boolean
     }) {
       const tabId = 'tab-v2-stream'
       const paneId = 'pane-v2-stream'
@@ -3615,12 +3619,16 @@ describe('TerminalView lifecycle updates', () => {
         </Provider>
       )
 
-      await waitFor(() => {
-        expect(messageHandler).not.toBeNull()
-      })
-      await waitFor(() => {
-        expect(terminalInstances.length).toBeGreaterThan(0)
-      })
+      if (opts?.waitForMessageHandler !== false) {
+        await waitFor(() => {
+          expect(messageHandler).not.toBeNull()
+        })
+      }
+      if (opts?.waitForTerminalInstance !== false) {
+        await waitFor(() => {
+          expect(terminalInstances.length).toBeGreaterThan(0)
+        })
+      }
 
       if (opts?.ackInitialAttach !== false && initialStatus === 'running' && terminalId && !opts?.hidden) {
         const initialAttach = wsMocks.send.mock.calls
@@ -7171,6 +7179,78 @@ describe('TerminalView lifecycle updates', () => {
           terminalId,
           sinceSeq: 0,
           intent: 'viewport_hydrate',
+          attachRequestId: expect.any(String),
+        }))
+      })
+      expect(wsMocks.send.mock.calls
+        .map(([msg]) => msg)
+        .filter((msg) => msg?.type === 'terminal.resize' && msg?.terminalId === terminalId)).toHaveLength(0)
+    })
+
+    it('arms hidden OpenCode viewport hydration after provider registry readiness', async () => {
+      localStorage.setItem('freshell.auth-token', 'test-token')
+      let resolveExtensionsFetch: (response: Response) => void = () => {}
+      const extensionsFetch = new Promise<Response>((resolve) => {
+        resolveExtensionsFetch = resolve
+      })
+      const fetchMock = vi.fn(() => extensionsFetch)
+      vi.stubGlobal('fetch', fetchMock)
+
+      const sessionRef = { provider: 'opencode', sessionId: 'ses_delayed_registry' } as const
+      const { store, tabId, paneId, terminalId, rerender } = await renderTerminalHarness({
+        status: 'running',
+        terminalId: 'term-opencode-delayed-registry',
+        mode: 'opencode',
+        hidden: true,
+        clearSends: false,
+        ackInitialAttach: false,
+        sessionRef,
+        waitForMessageHandler: false,
+        waitForTerminalInstance: false,
+      })
+
+      expect(terminalInstances).toHaveLength(0)
+      expect(wsMocks.send.mock.calls
+        .map(([msg]) => msg)
+        .filter((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId)).toHaveLength(0)
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalled()
+      })
+      expect(String(fetchMock.mock.calls[0]?.[0])).toMatch(/\/api\/extensions$/)
+
+      const readPaneContent = () => {
+        const layout = store.getState().panes.layouts[tabId]
+        return layout && layout.type === 'leaf' && layout.content.kind === 'terminal' ? layout.content : null
+      }
+      const renderVisibility = (isHidden: boolean) => (
+        <Provider store={store}>
+          <TerminalView tabId={tabId} paneId={paneId} paneContent={readPaneContent()!} hidden={isHidden} />
+        </Provider>
+      )
+
+      wsMocks.send.mockClear()
+      await act(async () => {
+        resolveExtensionsFetch(new Response(JSON.stringify([]), { status: 200 }))
+      })
+
+      await waitFor(() => {
+        expect(terminalInstances.length).toBeGreaterThan(0)
+      })
+      expect(wsMocks.send.mock.calls
+        .map(([msg]) => msg)
+        .filter((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId)).toHaveLength(0)
+
+      wsMocks.send.mockClear()
+      await act(async () => {
+        rerender(renderVisibility(false))
+      })
+
+      await waitFor(() => {
+        expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+          type: 'terminal.attach',
+          terminalId,
+          intent: 'viewport_hydrate',
+          priority: 'foreground',
           attachRequestId: expect.any(String),
         }))
       })


### PR DESCRIPTION
## Root Cause

When a hidden OpenCode pane is hydrated after a browser refresh, two race conditions combine to produce a permanent white page:

1. **Unrecoverable viewport hydrate blocked by hidden check**: When a replay gap exceeds the viewport window (`replay_window_exceeded`), the `isUnrecoverableOpenCodeViewportHydrate` predicate requires `!hiddenRef.current`. A hidden pane can never satisfy this condition, so it never enters the replacement path — it stays stuck showing nothing.

2. **Attach race before extensions registry loads**: The "Create or attach to backend terminal" useEffect fires before the extensions registry is ready (`shouldWaitForProviderBehavior` is true). This causes a premature attach attempt that races with the OpenCode sidecar initialization, producing a broken terminal state.

## Fix (two parts)

**Part 1 — Allow hidden OpenCode viewport hydrations to enter replacement path:**
Remove `!hiddenRef.current` from `isUnrecoverableOpenCodeViewportHydrate` in `src/components/TerminalView.tsx`. Hidden panes with replay gaps can now trigger `beginOpenCodeReplacementAfterExit`, which re-creates the terminal session once the pane becomes visible.

**Part 2 — Guard create/attach useEffect against provider-behavior wait:**
Add `if (shouldWaitForProviderBehavior) return` to the "Create or attach to backend terminal" useEffect. This prevents the attach race until the extensions registry has loaded, ensuring the OpenCode sidecar is ready before any terminal attach is attempted.

## Tests

- **Unit**: `test/unit/client/components/TerminalView.lifecycle.test.tsx` — 126 tests covering the hidden viewport hydration path and the provider-behavior wait guard.
- **E2e**: `test/e2e-browser/specs/opencode-restart-recovery.spec.ts` — 5 Playwright tests covering OpenCode pane recovery across browser refresh, server restart, and hidden-pane association scenarios.

## Rebase status

Rebased cleanly onto `origin/main` (54 commits behind). Only one main commit touched `TerminalView.tsx` (`#444` electron link-clicking, unrelated area). No conflicts.

Kata: y1xn