### PR TITLE
Update Gemini session title prompt to lead with most specific word

### DIFF
--- a/server/ai-prompts.ts
+++ b/server/ai-prompts.ts
@@ -45,7 +45,7 @@ export const PROMPTS = {
     defaultPrompt: [
       'Generate a title for a tab that contains the coding agent for this conversation.',
       'Only the first word or two will show, so most specific and informative words first.',
-      'Start with the repo abbreviated, then the noun. E.g. if we\'re investigating a crash in freshell that happens when you mention sardines, "FS sardine crash investigation" because FS is freshell, sardine is specific, crash is less specific, and investigation is common to almost all tabs.',
+      'E.g. if we\'re investigating a crash in freshell that happens when you mention sardines, "Sardine crash investigation" because sardine is specific, crash is less specific, and investigation is common to almost all tabs.',
       'Return ONLY the title text. No quotes, no markdown, no explanation.',
     ].join('\n'),
     build: (firstMessage: string, customPrompt?: string) => {

--- a/server/ai-prompts.ts
+++ b/server/ai-prompts.ts
@@ -43,8 +43,9 @@ export const PROMPTS = {
     model: AI_CONFIG.model,
     maxOutputTokens: 30,
     defaultPrompt: [
-      'Generate a short title (3-8 words) for a coding assistant conversation.',
-      'The title should describe the task or topic, not the tool being used.',
+      'Generate a title for a tab that contains the coding agent for this conversation.',
+      'Only the first word or two will show, so most specific and informative words first.',
+      'Start with the repo abbreviated, then the noun. E.g. if we\'re investigating a crash in freshell that happens when you mention sardines, "FS sardine crash investigation" because FS is freshell, sardine is specific, crash is less specific, and investigation is common to almost all tabs.',
       'Return ONLY the title text. No quotes, no markdown, no explanation.',
     ].join('\n'),
     build: (firstMessage: string, customPrompt?: string) => {

--- a/test/unit/server/ai-prompts.test.ts
+++ b/test/unit/server/ai-prompts.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect } from 'vitest'
 import { PROMPTS } from '../../../server/ai-prompts'
 
 describe('PROMPTS.sessionTitle', () => {
-  it('uses the repo-abbreviation-first default prompt', () => {
+  it('uses the most-specific-first default prompt', () => {
     expect(PROMPTS.sessionTitle.defaultPrompt).toBe(
       [
         'Generate a title for a tab that contains the coding agent for this conversation.',
         'Only the first word or two will show, so most specific and informative words first.',
-        "Start with the repo abbreviated, then the noun. E.g. if we're investigating a crash in freshell that happens when you mention sardines, \"FS sardine crash investigation\" because FS is freshell, sardine is specific, crash is less specific, and investigation is common to almost all tabs.",
+        "E.g. if we're investigating a crash in freshell that happens when you mention sardines, \"Sardine crash investigation\" because sardine is specific, crash is less specific, and investigation is common to almost all tabs.",
         'Return ONLY the title text. No quotes, no markdown, no explanation.',
       ].join('\n'),
     )

--- a/test/unit/server/ai-prompts.test.ts
+++ b/test/unit/server/ai-prompts.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { PROMPTS } from '../../../server/ai-prompts'
+
+describe('PROMPTS.sessionTitle', () => {
+  it('uses the repo-abbreviation-first default prompt', () => {
+    expect(PROMPTS.sessionTitle.defaultPrompt).toBe(
+      [
+        'Generate a title for a tab that contains the coding agent for this conversation.',
+        'Only the first word or two will show, so most specific and informative words first.',
+        "Start with the repo abbreviated, then the noun. E.g. if we're investigating a crash in freshell that happens when you mention sardines, \"FS sardine crash investigation\" because FS is freshell, sardine is specific, crash is less specific, and investigation is common to almost all tabs.",
+        'Return ONLY the title text. No quotes, no markdown, no explanation.',
+      ].join('\n'),
+    )
+  })
+
+  it('builds the full prompt with the default instructions and the first message', () => {
+    const prompt = PROMPTS.sessionTitle.build('Fix the login redirect bug')
+    expect(prompt).toBe(
+      [
+        PROMPTS.sessionTitle.defaultPrompt,
+        '',
+        'First message from the user:',
+        'Fix the login redirect bug',
+      ].join('\n'),
+    )
+  })
+
+  it('truncates the first message to 2000 characters', () => {
+    const long = 'x'.repeat(3000)
+    const prompt = PROMPTS.sessionTitle.build(long)
+    expect(prompt).toContain('x'.repeat(2000))
+    expect(prompt).not.toContain('x'.repeat(2001))
+  })
+
+  it('uses a custom prompt when provided', () => {
+    const prompt = PROMPTS.sessionTitle.build('hi', 'CUSTOM INSTRUCTIONS')
+    expect(prompt.startsWith('CUSTOM INSTRUCTIONS')).toBe(true)
+    expect(prompt).not.toContain(PROMPTS.sessionTitle.defaultPrompt)
+  })
+})


### PR DESCRIPTION
## What

Updates the default AI session title prompt in `server/ai-prompts.ts` (used by `generateAiSessionTitle` and the auto-naming pass in `server/index.ts`).

The new prompt asks Gemini for tab titles that put the most specific/informative words first, since only the first word or two are visible in a tab:

```
Generate a title for a tab that contains the coding agent for this conversation.
Only the first word or two will show, so most specific and informative words first.
E.g. if we're investigating a crash in freshell that happens when you mention sardines, "Sardine crash investigation" because sardine is specific, crash is less specific, and investigation is common to almost all tabs.
Return ONLY the title text. No quotes, no markdown, no explanation.
```

Titles flow into the session override (`titleSource: 'ai'`) via `configStore.patchSessionOverride` and are broadcast as `terminal.title.updated` to connected clients — unchanged from before.

## Why

The prior prompt produced generic task descriptions ("3-8 words... describe the task or topic"). Tabs only display the first word or two, so leading with the most distinctive word makes sessions easier to distinguish at a glance.

## Tests

- New unit test `test/unit/server/ai-prompts.test.ts` covers the default prompt content, `build()` composition, first-message truncation (2000 chars), and custom-prompt override.
- Related suites pass: `sessions-router-generate-title`, `auto-title`, `title-utils` (43 tests).
- `npm run lint` clean (0 errors), `npm run build:server` (typecheck) clean, `npm run test:integration` coordinated suite green (457 passed).