### PR TITLE
test: make real provider contract tests opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,12 @@ npm run test:status         # Show active holder, latest results, and advisory b
 npm run test:vitest -- ...  # Repo-owned direct Vitest path for focused passthrough work
 ```
 
+External provider contract tests (`test/integration/real/`) spawn real `claude`, `codex`, and `opencode` binaries to verify external provider behavior, not Freshell code. They are opt-in and skipped by default to avoid blocking the coordinated suite on environment-dependent flakiness:
+```bash
+FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1 npm run test:vitest -- \
+  run test/integration/real/ --config vitest.server.config.ts
+```
+
 ## Architecture
 
 ### Tech Stack

--- a/test/integration/real/codex-app-server-readiness-contract.test.ts
+++ b/test/integration/real/codex-app-server-readiness-contract.test.ts
@@ -1,4 +1,16 @@
 // @vitest-environment node
+//
+// This file spawns the REAL Codex app-server binary and verifies EXTERNAL
+// provider behavior (durable thread lifecycle, resume readiness, display ID
+// stability). It does NOT test Freshell code. It is gated by
+// FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1 because it is environment-dependent,
+// can flake due to external process behavior, and must not block the
+// coordinated suite.
+//
+// To run it: FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1 npm run test:vitest -- \
+//   run test/integration/real/codex-app-server-readiness-contract.test.ts \
+//   --config vitest.server.config.ts
+//
 import fsp from 'node:fs/promises'
 import { execFile } from 'node:child_process'
 import os from 'node:os'
@@ -211,7 +223,8 @@ function isDurableReadinessEvidence(event: CodexThreadLifecycleEvent, threadId: 
 }
 
 const codexProbe = await codexAvailability()
-const describeCodex = codexProbe.ready ? describe : describe.skip
+const realProviderContractsEnabled = process.env.FRESHELL_RUN_REAL_PROVIDER_CONTRACTS === '1'
+const describeCodex = (codexProbe.ready && realProviderContractsEnabled) ? describe : describe.skip
 
 function readUserMessageTexts(item: Record<string, unknown>): string[] {
   const contentTexts = Array.isArray(item.content)
@@ -265,7 +278,7 @@ async function waitForSessionArtifact(codexHome: string, threadId: string, timeo
   throw new Error('Timed out waiting for the durable Codex session artifact.')
 }
 
-describeCodex(`real Codex app-server durable readiness contract${codexProbe.ready ? '' : ` (${codexProbe.reason})`}`, () => {
+describeCodex(`real Codex app-server durable readiness contract${codexProbe.ready ? '' : ` (${codexProbe.reason})`}${realProviderContractsEnabled ? '' : ` (opt-in: FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1)`}`, () => {
   it('emits current-generation lifecycle evidence when a durable thread is resumed', async () => {
     const { codexHome, root } = await seedIsolatedCodexHome()
     const promptNonce = `freshell-readiness-contract-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`

--- a/test/integration/real/coding-cli-session-contract.test.ts
+++ b/test/integration/real/coding-cli-session-contract.test.ts
@@ -1,4 +1,23 @@
 // @vitest-environment node
+//
+// This file has two kinds of tests:
+//
+// 1. Freshell tests (always run): "loads the checked-in lab note facts" and
+//    "emits provenance-gated ownership reports" validate Freshell's own
+//    checked-in lab note and harness process-ownership reporting.
+//
+// 2. External provider contract tests (opt-in): The codex, claude, and
+//    opencode sections below spawn the REAL provider binaries and verify
+//    EXTERNAL provider behavior (session identity, transcript durability,
+//    rename semantics) against the checked-in lab note. They do NOT test
+//    Freshell code. They are gated by FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1
+//    because they are environment-dependent, can flake due to external
+//    process behavior, and must not block the coordinated suite.
+//
+//    To run them: FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1 npm run test:vitest -- \
+//      run test/integration/real/coding-cli-session-contract.test.ts \
+//      --config vitest.server.config.ts
+//
 import fsp from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -142,6 +161,11 @@ const claudeProbe = await claudeAvailability()
 const opencodeProbe = opencodeAvailability()
 const itWithProcOwnership = process.platform === 'linux' ? it : it.skip
 
+const realProviderContractsEnabled = process.env.FRESHELL_RUN_REAL_PROVIDER_CONTRACTS === '1'
+const realProviderSkipReason = realProviderContractsEnabled
+  ? ''
+  : 'Skipping external provider contract tests: set FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1 to run them.'
+
 describe.sequential('coding cli real provider session contract', () => {
   it('loads the checked-in lab note facts and date rationale', async () => {
     expect(note.capturedOn).toBe('2026-04-26')
@@ -182,8 +206,8 @@ describe.sequential('coding cli real provider session contract', () => {
     }
   }, 30_000)
 
-  const describeCodex = codexProbe.ready ? describe.sequential : describe.skip
-  describeCodex(`codex${codexProbe.ready ? '' : ` (${codexProbe.reason})`}`, () => {
+  const describeCodex = (codexProbe.ready && realProviderContractsEnabled) ? describe.sequential : describe.skip
+  describeCodex(`codex${codexProbe.ready ? '' : ` (${codexProbe.reason})`}${realProviderContractsEnabled ? '' : ` (opt-in: FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1)`}`, () => {
     it('detects a local binary and uses the expected remote bootstrap forms', async () => {
       const codexPath = requireAvailableBinary(codexBinary, codexProbe)
       expectLocalBinary(codexBinary)
@@ -267,8 +291,8 @@ describe.sequential('coding cli real provider session contract', () => {
 
   })
 
-  const describeClaude = claudeProbe.ready ? describe.sequential : describe.skip
-  describeClaude(`claude${claudeProbe.ready ? '' : ` (${claudeProbe.reason})`}`, () => {
+  const describeClaude = (claudeProbe.ready && realProviderContractsEnabled) ? describe.sequential : describe.skip
+  describeClaude(`claude${claudeProbe.ready ? '' : ` (${claudeProbe.reason})`}${realProviderContractsEnabled ? '' : ` (opt-in: FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1)`}`, () => {
     it('detects a local binary and version', async () => {
       requireAvailableBinary(claudeBinary, claudeProbe)
       expectLocalBinary(claudeBinary)
@@ -585,8 +609,8 @@ describe.sequential('coding cli real provider session contract', () => {
     }, 180_000)
   })
 
-  const describeOpencode = opencodeProbe.ready ? describe.sequential : describe.skip
-  describeOpencode(`opencode${opencodeProbe.ready ? '' : ` (${opencodeProbe.reason})`}`, () => {
+  const describeOpencode = (opencodeProbe.ready && realProviderContractsEnabled) ? describe.sequential : describe.skip
+  describeOpencode(`opencode${opencodeProbe.ready ? '' : ` (${opencodeProbe.reason})`}${realProviderContractsEnabled ? '' : ` (opt-in: FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1)`}`, () => {
     it('detects a local binary and version', async () => {
       requireAvailableBinary(opencodeBinary, opencodeProbe)
       expectLocalBinary(opencodeBinary)


### PR DESCRIPTION
## What

Make the real-provider contract tests in `test/integration/real/` opt-in via `FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1`, so they no longer block the coordinated suite on environment-dependent flakiness.

## Why

These tests spawn the **real** `claude`, `codex`, and `opencode` binaries to verify **external provider behavior** (session identity, transcript durability, rename semantics, app-server lifecycle) against checked-in lab note facts. They do **not** test Freshell code.

Because they depend on external process behavior, they can flake — e.g. the claude UUID-backed transcripts test (`kata agp8`) times out waiting for the real `claude` process to exit when it leaves background work running past stdout EOF. Such flakes must not block the coordinated suite.

## Changes

- **`test/integration/real/coding-cli-session-contract.test.ts`**: Gate the codex, claude, and opencode `describe` blocks behind `FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1`. The Freshell tests in the same file (lab note loader, ownership report) remain always-on. Added header comment explaining the distinction.
- **`test/integration/real/codex-app-server-readiness-contract.test.ts`**: Gate the entire `describe` block (it's purely external — spawns real codex app-server). Added header comment.
- **`AGENTS.md`**: Document the env var in the Testing section.

## Verification

- Without env var: 2 Freshell tests pass, 8 external-provider tests skipped (coding-cli-session-contract); 1 skipped (codex-app-server-readiness).
- With env var: all 10 tests run and pass.
- Server suite: 270 files pass, 2 skipped, 4048 tests pass, 19 skipped, 0 failures.
- Build + typecheck: clean.

Kata: `agp8`