### PR TITLE
Fix context menu resume commands before extension hydration

### DIFF
--- a/src/lib/coding-cli-utils.ts
+++ b/src/lib/coding-cli-utils.ts
@@ -60,11 +60,24 @@ export function isNonShellMode(mode?: string): boolean {
 
 export type ResumeCommandProvider = string
 
+const BUILTIN_RESUME_COMMAND_TEMPLATES: Record<string, string[]> = {
+  claude: ['claude', '--resume', '{{sessionId}}'],
+  codex: ['codex', 'resume', '{{sessionId}}'],
+  opencode: ['opencode', '--session', '{{sessionId}}'],
+}
+
+function getResumeCommandTemplate(
+  provider: string,
+  extensions?: ClientExtensionEntry[],
+): string[] | undefined {
+  const ext = extensions?.find(e => e.name === provider && e.category === 'cli')
+  if (ext) return ext.cli?.resumeCommandTemplate
+  return BUILTIN_RESUME_COMMAND_TEMPLATES[provider]
+}
+
 export function isResumeCommandProvider(value?: string, extensions?: ClientExtensionEntry[]): value is ResumeCommandProvider {
   if (!value) return false
-  if (!extensions) return false
-  const ext = extensions.find(e => e.name === value && e.category === 'cli')
-  return !!ext?.cli?.supportsResume
+  return !!getResumeCommandTemplate(value, extensions)
 }
 
 /**
@@ -79,9 +92,9 @@ export function buildResumeCommand(
   extensions?: ClientExtensionEntry[],
 ): string | null {
   if (!sessionId || !provider) return null
-  const ext = extensions?.find(e => e.name === provider && e.category === 'cli')
-  if (!ext?.cli?.resumeCommandTemplate) return null
-  return ext.cli.resumeCommandTemplate
+  const template = getResumeCommandTemplate(provider, extensions)
+  if (!template) return null
+  return template
     .map(arg => arg.replace('{{sessionId}}', sessionId))
     .join(' ')
 }

--- a/test/unit/client/components/ContextMenuProvider.test.tsx
+++ b/test/unit/client/components/ContextMenuProvider.test.tsx
@@ -1515,6 +1515,35 @@ describe('ContextMenuProvider', () => {
     expect(clipboardMocks.copyText).toHaveBeenCalledWith(`claude --resume ${VALID_SESSION_ID}`)
   })
 
+  it('keeps built-in sidebar resume command available before extension registry hydration', async () => {
+    const user = userEvent.setup()
+    const store = createStoreWithSession()
+    store.dispatch({ type: 'extensions/setRegistry', payload: [] })
+    render(
+      <Provider store={store}>
+        <ContextMenuProvider
+          view="terminal"
+          onViewChange={() => {}}
+          onToggleSidebar={() => {}}
+          sidebarCollapsed={false}
+        >
+          <div
+            data-context={ContextIds.SidebarSession}
+            data-session-id={VALID_SESSION_ID}
+            data-provider="claude"
+          >
+            Sidebar Session
+          </div>
+        </ContextMenuProvider>
+      </Provider>
+    )
+
+    await user.pointer({ target: screen.getByText('Sidebar Session'), keys: '[MouseRight]' })
+    await user.click(screen.getByRole('menuitem', { name: 'Copy resume command' }))
+
+    expect(clipboardMocks.copyText).toHaveBeenCalledWith(`claude --resume ${VALID_SESSION_ID}`)
+  })
+
   it('copies session metadata with minute-bucketed open-tab recency', async () => {
     const user = userEvent.setup()
     const store = configureStore({
@@ -1911,6 +1940,85 @@ describe('ContextMenuProvider', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Copy resume command' }))
 
     expect(clipboardMocks.copyText).toHaveBeenCalledWith(`claude --resume ${VALID_SESSION_ID}`)
+  })
+
+  it('keeps built-in pane header resume command available before extension registry hydration', async () => {
+    const user = userEvent.setup()
+    const store = configureStore({
+      reducer: {
+        tabs: tabsReducer,
+        panes: panesReducer,
+        sessions: sessionsReducer,
+        connection: connectionReducer,
+        settings: settingsReducer,
+        extensions: extensionsReducer,
+      },
+      middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware({ serializableCheck: false }),
+      preloadedState: {
+        tabs: {
+          tabs: [
+            {
+              id: 'tab-1',
+              createRequestId: 'tab-1',
+              title: 'Codex',
+              status: 'running',
+              mode: 'codex',
+              createdAt: 1,
+            },
+          ],
+          activeTabId: 'tab-1',
+          renameRequestTabId: null,
+        },
+        extensions: {
+          entries: [],
+        },
+        panes: {
+          layouts: {
+            'tab-1': {
+              type: 'leaf',
+              id: 'pane-1',
+              content: {
+                kind: 'terminal',
+                mode: 'codex',
+                status: 'running',
+                resumeSessionId: 'codex-session-123',
+              },
+            },
+          },
+          activePane: { 'tab-1': 'pane-1' },
+          paneTitles: {},
+        },
+        sessions: {
+          projects: [],
+          expandedProjects: new Set<string>(),
+        },
+        connection: {
+          status: 'ready',
+          platform: null,
+        },
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <ContextMenuProvider
+          view="terminal"
+          onViewChange={() => {}}
+          onToggleSidebar={() => {}}
+          sidebarCollapsed={false}
+        >
+          <div data-context={ContextIds.Pane} data-tab-id="tab-1" data-pane-id="pane-1">
+            Pane Header
+          </div>
+        </ContextMenuProvider>
+      </Provider>
+    )
+
+    await user.pointer({ target: screen.getByText('Pane Header'), keys: '[MouseRight]' })
+    await user.click(screen.getByRole('menuitem', { name: 'Copy resume command' }))
+
+    expect(clipboardMocks.copyText).toHaveBeenCalledWith('codex resume codex-session-123')
   })
 
   it('does not show resume command on shell pane header context menu', async () => {

--- a/test/unit/client/lib/coding-cli-utils.test.ts
+++ b/test/unit/client/lib/coding-cli-utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { buildResumeCommand, isResumeCommandProvider } from '@/lib/coding-cli-utils'
+import type { ClientExtensionEntry } from '@shared/extension-types'
+
+describe('coding CLI resume commands', () => {
+  it('uses built-in resume commands before the extension registry is hydrated', () => {
+    expect(isResumeCommandProvider('claude', [])).toBe(true)
+    expect(buildResumeCommand('claude', 'session-1', [])).toBe('claude --resume session-1')
+    expect(buildResumeCommand('codex', 'thread-1', [])).toBe('codex resume thread-1')
+    expect(buildResumeCommand('opencode', 'ses_1', [])).toBe('opencode --session ses_1')
+  })
+
+  it('prefers an explicit extension registry entry over the built-in fallback', () => {
+    const extensions: ClientExtensionEntry[] = [{
+      name: 'claude',
+      version: '1.0.0',
+      label: 'Custom Claude',
+      description: '',
+      category: 'cli',
+      cli: {
+        supportsResume: true,
+        resumeCommandTemplate: ['custom-claude', 'resume', '{{sessionId}}'],
+      },
+    }]
+
+    expect(buildResumeCommand('claude', 'session-1', extensions)).toBe('custom-claude resume session-1')
+  })
+
+  it('does not fall back when a loaded registry entry lacks resume support', () => {
+    const extensions: ClientExtensionEntry[] = [{
+      name: 'claude',
+      version: '1.0.0',
+      label: 'Custom Claude',
+      description: '',
+      category: 'cli',
+      cli: {},
+    }]
+
+    expect(isResumeCommandProvider('claude', extensions)).toBe(false)
+    expect(buildResumeCommand('claude', 'session-1', extensions)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Root cause
- Commit c7f1942 moved context-menu resume support from hardcoded built-in CLI checks to extension-registry-derived manifest data.
- The server intentionally does not send `extensions.registry` during the WebSocket hello path, and `ContextMenuProvider` can build sidebar/pane-header menus while `extensions.entries` is still empty.
- The tests added in that refactor preloaded mock extension entries, so they did not cover the empty-registry startup state that users hit.

## Fix
- Keep built-in resume command templates for Claude, Codex, and OpenCode as a startup fallback.
- Preserve extension registry precedence once a provider entry is loaded, including honoring loaded providers that do not support resume.
- Add regression coverage for sidebar sessions and pane-header context menus before registry hydration.

## Verification
- `npm run test:vitest -- run test/unit/client/components/ContextMenuProvider.test.tsx`
- `npm run test:vitest -- run test/unit/client/components/ContextMenuProvider.test.tsx test/unit/client/lib/coding-cli-utils.test.ts test/unit/client/context-menu/menu-defs.test.ts test/unit/client/components/context-menu/menu-defs.test.ts`
- `npm run check`
- `npm run lint` (exit 0; existing React hook warnings only)