### PR TITLE
Fix fresh-agent message pinning and send echo

### DIFF
--- a/server/fresh-agent/adapters/codex/normalize.ts
+++ b/server/fresh-agent/adapters/codex/normalize.ts
@@ -760,7 +760,7 @@ export function normalizeCodexThreadSnapshot(input: {
     threadId: input.threadId,
     revision: input.revision,
     status: input.status,
-    summary: input.rawSnapshot.summary ?? input.rawSnapshot.thread?.preview ?? input.transcript.turns[0]?.summary ?? '',
+    summary: input.rawSnapshot.summary ?? input.rawSnapshot.thread?.preview ?? '',
     capabilities: {
       send: !isRunning,
       interrupt: isRunning,

--- a/src/components/fresh-agent/FreshAgentComposer.tsx
+++ b/src/components/fresh-agent/FreshAgentComposer.tsx
@@ -561,27 +561,25 @@ export const FreshAgentComposer = forwardRef<FreshAgentComposerHandle, FreshAgen
       ) : null}
 
       {queuedMessages.length > 0 ? (
-        <div className="fresh-agent-queued-messages mb-2 space-y-1" role="list" aria-label="Queued messages">
-          {queuedMessages.map((message, index) => (
-            <div
-              key={`${index}-${message.slice(0, 16)}`}
-              role="listitem"
-              className="fresh-agent-queued-message flex items-center gap-2 rounded-md border border-dashed border-border/70 px-2 py-1 text-xs text-muted-foreground"
-            >
-              <span className="shrink-0">queued</span>
-              <span className="min-w-0 flex-1 truncate">{message}</span>
-              {onCancelQueued ? (
+        <div className="fresh-agent-queued-message mb-2 flex items-center gap-2 rounded-md border border-dashed border-border/70 px-2 py-1 text-xs text-muted-foreground">
+          <span role="status" aria-label="Queued messages" className="min-w-0 flex-1">
+            {queuedMessages.length} queued
+          </span>
+          {onCancelQueued ? (
+            <span className="flex shrink-0 items-center gap-1" role="group" aria-label="Queued message actions">
+              {queuedMessages.map((_, index) => (
                 <button
+                  key={index}
                   type="button"
-                  className="-m-2 shrink-0 p-2 hover:text-destructive sm:m-0 sm:p-0"
+                  className="-m-2 p-2 hover:text-destructive sm:m-0 sm:p-0"
                   aria-label={`Remove queued message ${index + 1}`}
                   onClick={() => onCancelQueued(index)}
                 >
                   <X className="h-3 w-3" />
                 </button>
-              ) : null}
-            </div>
-          ))}
+              ))}
+            </span>
+          ) : null}
         </div>
       ) : null}
 

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -100,19 +100,32 @@ function localEchoLanded(
   turns: readonly FreshAgentTurn[],
   echo: LocalEcho,
   pending?: PendingSendMetadata,
+  options: {
+    allowTextMatch?: boolean
+    previousTurns?: readonly FreshAgentTurn[]
+  } = {},
 ): boolean {
   const needle = echo.text.slice(0, 80)
   const submittedTurnId = echo.submittedTurnId ?? pending?.submittedTurnId
-  if (submittedTurnId) {
-    return turns.some((turn) => (
-      turn.role === 'user'
-      && getFreshAgentDisplayTurnKey(turn) === submittedTurnId
-    ))
-  }
-  if (pending && !pending.legacyAccepted) return false
+  const previousTurnKeys = options.previousTurns
+    ? new Set(options.previousTurns.map(getTurnKey))
+    : null
+  const canMatchText = Boolean(needle) && (
+    options.allowTextMatch === true
+    || pending?.legacyAccepted === true
+    || !pending
+  )
   return turns.some((turn) => (
     turn.role === 'user'
-    && freshAgentTurnText(turn).includes(needle)
+    && (
+      (submittedTurnId ? getFreshAgentDisplayTurnKey(turn) === submittedTurnId : false)
+      || (turn as { requestId?: unknown }).requestId === echo.requestId
+      || (
+        canMatchText
+        && (!previousTurnKeys || !previousTurnKeys.has(getTurnKey(turn)))
+        && freshAgentTurnText(turn).includes(needle)
+      )
+    )
   ))
 }
 
@@ -1238,14 +1251,18 @@ export function FreshAgentView({
           autoTitleFreshBoundaryRef.current = false
           autoTitleSentRef.current = true
         }
-        const displaySnapshot = mergeSnapshotForDisplay(snapshotRef.current, resolved)
-        const snapshotAccepted = displaySnapshot !== snapshotRef.current
+        const previousSnapshot = snapshotRef.current
+        const displaySnapshot = mergeSnapshotForDisplay(previousSnapshot, resolved)
+        const snapshotAccepted = displaySnapshot !== previousSnapshot
         commitSnapshot(displaySnapshot)
         setSnapshotAutoTitleIdentity(snapshotIdentity)
         const echo = localEchoRef.current
         const echoPendingMetadata = echo ? pendingSendMetadataRef.current.get(echo.requestId) : undefined
         const landedEcho = echo
-          ? localEchoLanded(displaySnapshot.turns, echo, echoPendingMetadata)
+          ? localEchoLanded(displaySnapshot.turns, echo, echoPendingMetadata, {
+              allowTextMatch: snapshotAccepted,
+              previousTurns: previousSnapshot?.turns,
+            })
           : false
         const staleEcho = echo
           ? snapshotAccepted && shouldClearStaleLocalEcho(displaySnapshot, echo, echoPendingMetadata)

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -1758,11 +1758,6 @@ export function FreshAgentView({
               {isRestoring ? (
                 <FreshAgentApprovalBanner text="Restoring session..." />
               ) : null}
-              {snapshot?.summary ? (
-                <div className="fresh-agent-summary-card rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
-                  {snapshot.summary}
-                </div>
-              ) : null}
               {pendingCreateFailure || paneContent.createError ? (
                 <div className="fresh-agent-error-card flex items-center justify-between gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm">
                   <FreshAgentApprovalBanner text={(pendingCreateFailure ?? paneContent.createError)?.message ?? 'Create failed'} />

--- a/test/unit/client/components/fresh-agent/FreshAgentComposer.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentComposer.test.tsx
@@ -207,6 +207,30 @@ describe('FreshAgentComposer', () => {
     expect(screen.getByRole('tooltip')).toHaveTextContent('Send message')
   })
 
+  it('shows queued message counts without pinning queued text above the composer', () => {
+    const onCancelQueued = vi.fn()
+    render(
+      <FreshAgentComposer
+        commands={COMMANDS}
+        queuedMessages={[
+          'Do not pin my newest message at the bottom',
+          'Keep this queued follow-up private until expanded',
+        ]}
+        onCancelQueued={onCancelQueued}
+      />,
+    )
+
+    const queuedStatus = screen.getByRole('status', { name: 'Queued messages' })
+    expect(queuedStatus).toHaveTextContent('2 queued')
+    expect(screen.queryByText('Do not pin my newest message at the bottom')).not.toBeInTheDocument()
+    expect(screen.queryByText('Keep this queued follow-up private until expanded')).not.toBeInTheDocument()
+
+    const removeButtons = screen.getAllByRole('button', { name: /Remove queued message/ })
+    expect(removeButtons).toHaveLength(2)
+    fireEvent.click(removeButtons[0])
+    expect(onCancelQueued).toHaveBeenCalledWith(0)
+  })
+
   describe('state-aware disabled behavior', () => {
     it('shows the provided placeholder instead of the generic read-only text', () => {
       render(

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -460,6 +460,42 @@ describe('FreshAgentView', () => {
     expect(screen.getByText(new Date('2026-06-15T12:34:56.000Z').toLocaleTimeString())).toBeInTheDocument()
   })
 
+  it('does not pin the provider snapshot summary above the transcript', async () => {
+    const store = createStore()
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValueOnce({
+      status: 'idle',
+      summary: 'Do not pin this session summary',
+      capabilities: { send: true, interrupt: true, fork: false },
+      turns: [{
+        id: 'turn-summary-visibility',
+        turnId: 'turn-summary-visibility',
+        role: 'assistant',
+        summary: 'Visible transcript answer',
+        items: [{ id: 'item-summary-visibility', kind: 'text', text: 'Visible transcript answer' }],
+      }],
+    })
+
+    render(
+      <Provider store={store}>
+        <FreshAgentView
+          tabId="tab-1"
+          paneId="pane-1"
+          paneContent={{
+            kind: 'fresh-agent',
+            sessionType: 'freshclaude',
+            provider: 'claude',
+            createRequestId: 'req-no-summary-pin',
+            sessionId: CLAUDE_THREAD_ID,
+            status: 'connected',
+          }}
+        />
+      </Provider>,
+    )
+
+    expect(await screen.findByText('Visible transcript answer')).toBeInTheDocument()
+    expect(screen.queryByText('Do not pin this session summary')).not.toBeInTheDocument()
+  })
+
   it('shows the provider watermark behind the workspace and redirects pane typing into the composer', async () => {
     const store = createStore()
     store.dispatch(initLayout({

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -4010,6 +4010,103 @@ describe('FreshAgentView', () => {
     expect(getFreshAgentPaneContent(store).pendingLocalEcho).toBeUndefined()
   })
 
+  it('clears local echo as soon as a fresh snapshot contains the submitted text', async () => {
+    const store = createStore()
+    let wsHandler: ((message: any) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler) => {
+      wsHandler = handler
+      return () => {}
+    })
+    apiMock.getFreshAgentThreadSnapshot
+      .mockResolvedValueOnce({
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        threadId: 'ses_echo_landed_by_text',
+        revision: 1,
+        status: 'idle',
+        capabilities: { send: true, interrupt: true, fork: true },
+        turns: [],
+      })
+      .mockResolvedValueOnce({
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        threadId: 'ses_echo_landed_by_text',
+        revision: 2,
+        status: 'running',
+        capabilities: { send: false, interrupt: true, fork: true },
+        turns: [
+          {
+            id: 'turn-real-user',
+            turnId: 'turn-real-user',
+            role: 'user',
+            summary: 'Do the thing',
+            items: [{ id: 'item-real-user', kind: 'text', text: 'Do the thing' }],
+          },
+          {
+            id: 'turn-real-assistant',
+            turnId: 'turn-real-assistant',
+            role: 'assistant',
+            summary: 'Working',
+            items: [{ id: 'item-real-assistant', kind: 'text', text: 'Working' }],
+          },
+        ],
+      })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-echo-landed-by-text',
+        sessionId: 'ses_echo_landed_by_text',
+        sessionRef: { provider: 'opencode', sessionId: 'ses_echo_landed_by_text' },
+        resumeSessionId: 'ses_echo_landed_by_text',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Do the thing' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    const send = sentFreshAgentMessages('freshAgent.send').at(-1)
+    const requestId = String(send?.requestId)
+    expect(screen.getByText('Do the thing')).toBeInTheDocument()
+
+    act(() => {
+      wsHandler?.({
+        type: 'freshAgent.event',
+        sessionId: 'ses_echo_landed_by_text',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        event: {
+          type: 'freshAgent.session.snapshot',
+          sessionId: 'ses_echo_landed_by_text',
+          status: 'running',
+          latestTurnId: 'turn-real-assistant',
+          revision: 2,
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Working')).toBeInTheDocument()
+    })
+    expect(screen.getAllByText('Do the thing')).toHaveLength(1)
+    expect(getFreshAgentPaneContent(store).pendingLocalEcho).toBeUndefined()
+    expect(sentFreshAgentMessages('freshAgent.send').at(-1)?.requestId).toBe(requestId)
+  })
+
   it('keeps local echo when an older snapshot response is ignored after send acceptance', async () => {
     const store = createStore()
     let wsHandler: ((message: any) => void) | undefined

--- a/test/unit/server/fresh-agent/codex-normalize.test.ts
+++ b/test/unit/server/fresh-agent/codex-normalize.test.ts
@@ -85,6 +85,28 @@ describe('Codex fresh-agent normalization', () => {
     expect(snapshot.diffs[0]).toMatchObject({ path: 'src/app.ts' })
   })
 
+  it('does not promote the first transcript turn into a snapshot summary', () => {
+    const snapshot = normalizeCodexThreadSnapshot({
+      threadId: 'thread-codex-1',
+      revision: 1,
+      status: 'idle',
+      transcript: {
+        turns: [
+          {
+            id: 'turn-user-1',
+            turnId: 'turn-user-1',
+            role: 'user',
+            summary: 'Do not pin the first user request',
+            items: [{ id: 'turn-user-1:item-0', kind: 'text', text: 'Do not pin the first user request' }],
+          },
+        ],
+      },
+      rawSnapshot: {},
+    })
+
+    expect(snapshot.summary).toBe('')
+  })
+
   it('surfaces the Codex turn model in the shared turn state for single-row turns', () => {
     const turn = normalizeCodexTurn({
       id: 'turn-1',


### PR DESCRIPTION
Fixes fresh-agent pane message pinning so only the scrolled-off most-recent message pin remains, removes the bottom submitted-message pin, stops Codex from promoting the first turn into a pinned summary, and clears the temporary submitted-message echo as soon as the real transcript catches up. Verified with npm run lint and npm run check.