### PR TITLE
Generalize fresh-agent header bar to all providers

### DIFF
--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -139,27 +139,48 @@ function findIndexedSessionById(
   return undefined
 }
 
-function resolveFreshClaudeRuntimeMeta(
+function resolveFreshAgentRuntimeMeta(
   indexedProjects: ProjectGroup[],
   content: FreshAgentPaneContent,
   session: FreshAgentSessionState | undefined,
 ): PaneRuntimeMeta | undefined {
-  if (content.provider !== 'claude') return undefined
-
   const provider = content.provider
-  const indexedSessionId = getPreferredResumeSessionId(session) ?? content.resumeSessionId
-  if (!provider || !indexedSessionId) return undefined
+  const sessionId = getPreferredResumeSessionId(session) ?? content.resumeSessionId
 
-  const indexed = findIndexedSessionById(indexedProjects, provider, indexedSessionId)
-  if (!indexed) return undefined
+  if (provider && sessionId) {
+    const indexed = findIndexedSessionById(indexedProjects, provider, sessionId)
+    if (indexed) {
+      return {
+        cwd: indexed.cwd,
+        checkoutRoot: indexed.projectPath,
+        repoRoot: indexed.projectPath,
+        branch: indexed.gitBranch,
+        isDirty: indexed.isDirty,
+        tokenUsage: indexed.tokenUsage,
+      }
+    }
+  }
 
+  if (!session) return undefined
+
+  let branch: string | undefined
+  if (session.snapshot?.worktrees?.length) {
+    branch = session.snapshot.worktrees[0].branch
+  }
+
+  const snapshotTokenUsage = session.snapshot?.tokenUsage
   return {
-    cwd: indexed.cwd,
-    checkoutRoot: indexed.projectPath,
-    repoRoot: indexed.projectPath,
-    branch: indexed.gitBranch,
-    isDirty: indexed.isDirty,
-    tokenUsage: indexed.tokenUsage,
+    cwd: session.cwd,
+    checkoutRoot: session.cwd,
+    branch,
+    tokenUsage: snapshotTokenUsage && {
+      inputTokens: snapshotTokenUsage.inputTokens,
+      outputTokens: snapshotTokenUsage.outputTokens,
+      cachedTokens: snapshotTokenUsage.cachedTokens ?? 0,
+      totalTokens: snapshotTokenUsage.totalTokens,
+      ...(snapshotTokenUsage.contextTokens !== undefined && { contextTokens: snapshotTokenUsage.contextTokens }),
+      ...(snapshotTokenUsage.compactPercent !== undefined && { compactPercent: snapshotTokenUsage.compactPercent }),
+    },
   }
 }
 
@@ -430,25 +451,21 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
           initialCwd: paneInitialCwd,
         })
         : node.content.kind === 'fresh-agent'
-          ? (
-            node.content.provider === 'claude'
+          ? resolveFreshAgentRuntimeMeta(
+            indexedProjects,
+            {
+              ...node.content,
+              effort: normalizeFreshAgentEffort(
+                node.content.sessionType,
+                node.content.provider,
+                node.content.model,
+                node.content.effort,
+              ),
+            },
+            node.content.sessionId
+              ? freshAgentSessions[`${node.content.sessionType}:${node.content.provider}:${node.content.sessionId}`]
+              : undefined,
           )
-            ? resolveFreshClaudeRuntimeMeta(
-              indexedProjects,
-              {
-                ...node.content,
-                effort: normalizeFreshAgentEffort(
-                  node.content.sessionType,
-                  node.content.provider,
-                  node.content.model,
-                  node.content.effort,
-                ),
-              },
-              node.content.sessionId
-                ? freshAgentSessions[`${node.content.sessionType}:${node.content.provider}:${node.content.sessionId}`]
-                : undefined,
-            )
-            : undefined
         : undefined
     const paneMetaLabel =
       paneRuntimeMeta

--- a/src/components/panes/PaneHeader.tsx
+++ b/src/components/panes/PaneHeader.tsx
@@ -1,11 +1,12 @@
 import { useRef, useEffect } from 'react'
-import { X, Maximize2, Minimize2, Search, RefreshCw, SquareTerminal } from 'lucide-react'
+import { X, Maximize2, Minimize2, Search, RefreshCw, SquareTerminal, Terminal, FileSearch, Globe, FilePen, FileText } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { getTerminalStatusIconClassName } from '@/lib/terminal-status-indicator'
 import type { TerminalStatus } from '@/store/types'
 import type { PaneContent } from '@/store/paneTypes'
-import { useAppDispatch } from '@/store/hooks'
+import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { splitPane } from '@/store/panesSlice'
+import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
 import PaneIcon from '@/components/icons/PaneIcon'
 import FreshAgentSettingsButton from '@/components/fresh-agent/FreshAgentSettingsButton'
 import FreshAgentContextMeter from '@/components/fresh-agent/FreshAgentContextMeter'
@@ -34,6 +35,44 @@ interface PaneHeaderProps {
   onDoubleClick?: () => void
   onSearch?: () => void
   onRefresh?: () => void
+}
+
+const FRESH_AGENT_TOOL_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  Bash: Terminal,
+  Read: FileText,
+  Write: FilePen,
+  Edit: FilePen,
+  Glob: FileSearch,
+  Grep: FileSearch,
+  WebFetch: Globe,
+  WebSearch: Globe,
+}
+
+function FreshAgentToolIcons({
+  content,
+}: {
+  content: Extract<PaneContent, { kind: 'fresh-agent' }>
+}) {
+  const sessionKey = content.sessionId ? makeFreshAgentSessionKey({
+    sessionId: content.sessionId,
+    sessionType: content.sessionType,
+    provider: content.provider,
+  }) : undefined
+  const tools = useAppSelector((state) =>
+    sessionKey ? state.freshAgent?.sessions?.[sessionKey]?.tools : undefined,
+  )
+
+  if (!tools?.length) return null
+
+  return (
+    <span className="inline-flex shrink-0 items-center gap-0.5 text-muted-foreground/60" title={tools.map((t) => t.name).join(', ')}>
+      {tools.map((tool) => {
+        const Icon = FRESH_AGENT_TOOL_ICONS[tool.name]
+        if (!Icon) return null
+        return <Icon key={tool.name} className="h-3 w-3" aria-label={tool.name} />
+      })}
+    </span>
+  )
 }
 
 function FreshAgentOpenTerminalButton({
@@ -188,6 +227,7 @@ export default function PaneHeader({
 
         {content.kind === 'fresh-agent' && (
           <>
+            <FreshAgentToolIcons content={content} />
             {/* Cwd/prompt-derived titles make the three fresh clients look
                 identical — pin the agent identity in the header. */}
             <span

--- a/test/unit/client/components/panes/Pane.test.tsx
+++ b/test/unit/client/components/panes/Pane.test.tsx
@@ -23,6 +23,12 @@ vi.mock('lucide-react', () => ({
   RefreshCw: ({ className }: { className?: string }) => (
     <svg data-testid="refresh-icon" className={className} />
   ),
+  Terminal: () => null,
+  FileText: () => null,
+  Globe: () => null,
+  SquareTerminal: () => null,
+  FilePen: () => null,
+  FileSearch: () => null,
 }))
 
 vi.mock('@/components/icons/PaneIcon', () => ({

--- a/test/unit/client/components/panes/PaneContainer.createContent.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.createContent.test.tsx
@@ -73,6 +73,8 @@ vi.mock('lucide-react', () => ({
   Square: ({ className }: { className?: string }) => <svg data-testid="square-icon" className={className} />,
   Search: ({ className }: { className?: string }) => <svg data-testid="search-icon" className={className} />,
   RefreshCw: ({ className }: { className?: string }) => <svg data-testid="refresh-icon" className={className} />,
+  FilePen: () => null,
+  FileSearch: () => null,
 }))
 
 vi.mock('@/components/TerminalView', () => ({ default: mockTerminalView }))

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -17,6 +17,7 @@ import { markTabAttention, markPaneAttention } from '@/store/turnCompletionSlice
 import type { PanesState } from '@/store/panesSlice'
 import type { PaneNode, PaneContent, EditorPaneContent } from '@/store/paneTypes'
 import type { FreshAgentSessionState, FreshAgentState } from '@/store/freshAgentTypes'
+import type { FreshAgentSnapshot } from '@shared/fresh-agent-contract'
 import type { ClientExtensionEntry } from '@shared/extension-types'
 import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
 
@@ -180,6 +181,8 @@ vi.mock('lucide-react', () => ({
   Settings: ({ className }: { className?: string }) => (
     <svg data-testid="settings-icon" className={className} />
   ),
+  FilePen: () => null,
+  FileSearch: () => null,
 }))
 
 // Mock TerminalView component to avoid xterm.js dependencies
@@ -264,6 +267,36 @@ function createFreshClaudeSession(
     totalOutputTokens: 0,
     ...overrides,
   }
+}
+
+function makeSnapshot(
+  opts: {
+    tokenUsage: FreshAgentSnapshot['tokenUsage']
+    worktrees?: FreshAgentSnapshot['worktrees']
+  },
+): FreshAgentSnapshot {
+  return {
+    sessionType: 'freshclaude',
+    provider: 'claude',
+    threadId: 'thread-1',
+    revision: 1,
+    status: 'idle',
+    capabilities: {
+      send: true,
+      interrupt: true,
+      approvals: true,
+      questions: true,
+      fork: false,
+    },
+    tokenUsage: opts.tokenUsage,
+    pendingApprovals: [],
+    pendingQuestions: [],
+    worktrees: opts.worktrees ?? [],
+    diffs: [],
+    childThreads: [],
+    turns: [],
+    extensions: {},
+  } as FreshAgentSnapshot
 }
 
 function createStore(
@@ -2681,6 +2714,238 @@ describe('PaneContainer', () => {
       expect(screen.getByText(/freshell \(main\)\s+25%/)).toBeInTheDocument()
     })
 
+  })
+
+  describe('FreshAgent runtime metadata snapshot fallback', () => {
+    it('derives header meta from session.snapshot for a non-Claude provider (codex)', () => {
+      const node: PaneNode = {
+        type: 'leaf',
+        id: 'pane-codex',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+          createRequestId: 'req-codex',
+          sessionId: 'codex-sess-1',
+          status: 'idle',
+        },
+      }
+
+      const store = createStore(
+        {
+          layouts: { 'tab-1': node },
+          activePane: { 'tab-1': 'pane-codex' },
+        },
+        {},
+        { projects: [] },
+        {
+          sessions: {
+            [makeFreshAgentSessionKey({
+              sessionType: 'freshcodex',
+              provider: 'codex',
+              sessionId: 'codex-sess-1',
+            })]: createFreshClaudeSession({
+              sessionId: 'codex-sess-1',
+              sessionType: 'freshcodex',
+              provider: 'codex',
+              cwd: '/home/user/code/freshell',
+              snapshot: makeSnapshot({
+                tokenUsage: {
+                  inputTokens: 100,
+                  outputTokens: 50,
+                  cachedTokens: 20,
+                  totalTokens: 170,
+                  compactPercent: 30,
+                },
+                worktrees: [{ id: 'wt-1', path: '/home/user/code/freshell', branch: 'dev' }],
+              }),
+            }),
+          },
+        },
+      )
+
+      renderWithStore(
+        <PaneContainer tabId="tab-1" node={node} />,
+        store,
+      )
+
+      const meta = screen.getByText(/freshell \(dev\)\s+30%/)
+      expect(meta).toBeInTheDocument()
+      expect(meta).toHaveAttribute(
+        'title',
+        'Directory: /home/user/code/freshell\nbranch: dev',
+      )
+    })
+
+    it('falls back to session.snapshot for a Claude pane with no indexed session', () => {
+      const node: PaneNode = {
+        type: 'leaf',
+        id: 'pane-claude-fallback',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshclaude',
+          provider: 'claude',
+          createRequestId: 'req-claude',
+          sessionId: 'claude-sess-1',
+          status: 'idle',
+        },
+      }
+
+      const store = createStore(
+        {
+          layouts: { 'tab-1': node },
+          activePane: { 'tab-1': 'pane-claude-fallback' },
+        },
+        {},
+        { projects: [] },
+        {
+          sessions: {
+            [makeFreshAgentSessionKey({
+              sessionType: 'freshclaude',
+              provider: 'claude',
+              sessionId: 'claude-sess-1',
+            })]: createFreshClaudeSession({
+              sessionId: 'claude-sess-1',
+              cwd: '/home/user/code/myproject',
+              snapshot: makeSnapshot({
+                tokenUsage: {
+                  inputTokens: 200,
+                  outputTokens: 100,
+                  totalTokens: 300,
+                  compactPercent: 45,
+                },
+                worktrees: [{ id: 'wt-1', path: '/home/user/code/myproject', branch: 'feature-x' }],
+              }),
+            }),
+          },
+        },
+      )
+
+      renderWithStore(
+        <PaneContainer tabId="tab-1" node={node} />,
+        store,
+      )
+
+      const meta = screen.getByText(/myproject \(feature-x\)\s+45%/)
+      expect(meta).toBeInTheDocument()
+      expect(meta).toHaveAttribute(
+        'title',
+        'Directory: /home/user/code/myproject\nbranch: feature-x',
+      )
+    })
+
+    it('shapes tokenUsage from session.snapshot, defaulting cachedTokens to 0 and passing through compactPercent', () => {
+      const node: PaneNode = {
+        type: 'leaf',
+        id: 'pane-opencode',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshopencode',
+          provider: 'opencode',
+          createRequestId: 'req-opencode',
+          sessionId: 'opencode-sess-1',
+          status: 'idle',
+        },
+      }
+
+      const store = createStore(
+        {
+          layouts: { 'tab-1': node },
+          activePane: { 'tab-1': 'pane-opencode' },
+        },
+        {},
+        { projects: [] },
+        {
+          sessions: {
+            [makeFreshAgentSessionKey({
+              sessionType: 'freshopencode',
+              provider: 'opencode',
+              sessionId: 'opencode-sess-1',
+            })]: createFreshClaudeSession({
+              sessionId: 'opencode-sess-1',
+              sessionType: 'freshopencode',
+              provider: 'opencode',
+              cwd: '/home/user/code/workdir',
+              snapshot: makeSnapshot({
+                tokenUsage: {
+                  inputTokens: 500,
+                  outputTokens: 250,
+                  totalTokens: 750,
+                  compactPercent: 60,
+                },
+                worktrees: [{ id: 'wt-1', path: '/home/user/code/workdir', branch: 'main' }],
+              }),
+            }),
+          },
+        },
+      )
+
+      renderWithStore(
+        <PaneContainer tabId="tab-1" node={node} />,
+        store,
+      )
+
+      const meta = screen.getByText(/workdir \(main\)\s+60%/)
+      expect(meta).toBeInTheDocument()
+      expect(meta).toHaveAttribute(
+        'title',
+        'Directory: /home/user/code/workdir\nbranch: main',
+      )
+    })
+
+    it('omits the percent label when session.snapshot tokenUsage has no compactPercent', () => {
+      const node: PaneNode = {
+        type: 'leaf',
+        id: 'pane-opencode-no-pct',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshopencode',
+          provider: 'opencode',
+          createRequestId: 'req-opencode-2',
+          sessionId: 'opencode-sess-2',
+          status: 'idle',
+        },
+      }
+
+      const store = createStore(
+        {
+          layouts: { 'tab-1': node },
+          activePane: { 'tab-1': 'pane-opencode-no-pct' },
+        },
+        {},
+        { projects: [] },
+        {
+          sessions: {
+            [makeFreshAgentSessionKey({
+              sessionType: 'freshopencode',
+              provider: 'opencode',
+              sessionId: 'opencode-sess-2',
+            })]: createFreshClaudeSession({
+              sessionId: 'opencode-sess-2',
+              sessionType: 'freshopencode',
+              provider: 'opencode',
+              cwd: '/home/user/code/notedir',
+              snapshot: makeSnapshot({
+                tokenUsage: {
+                  inputTokens: 10,
+                  outputTokens: 5,
+                  totalTokens: 15,
+                },
+                worktrees: [{ id: 'wt-1', path: '/home/user/code/notedir', branch: 'trunk' }],
+              }),
+            }),
+          },
+        },
+      )
+
+      renderWithStore(
+        <PaneContainer tabId="tab-1" node={node} />,
+        store,
+      )
+
+      expect(screen.getByText(/notedir \(trunk\)/)).toBeInTheDocument()
+      expect(screen.queryByText(/%\s*$/)).not.toBeInTheDocument()
+    })
   })
 
   describe('refresh button integration', () => {

--- a/test/unit/client/components/panes/PaneHeader.test.tsx
+++ b/test/unit/client/components/panes/PaneHeader.test.tsx
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
 import PaneHeader from '@/components/panes/PaneHeader'
+import freshAgentReducer, { sessionInit } from '@/store/freshAgentSlice'
 import { formatPaneRuntimeLabel, formatPaneRuntimeTooltip } from '@/lib/format-terminal-title-meta'
 
 vi.mock('lucide-react', () => ({
@@ -22,6 +25,24 @@ vi.mock('lucide-react', () => ({
   RefreshCw: ({ className }: { className?: string }) => (
     <svg data-testid="refresh-icon" className={className} />
   ),
+  Terminal: ({ className }: { className?: string }) => (
+    <svg data-testid="terminal-icon" className={className} />
+  ),
+  FileSearch: ({ className }: { className?: string }) => (
+    <svg data-testid="filesearch-icon" className={className} />
+  ),
+  Globe: ({ className }: { className?: string }) => (
+    <svg data-testid="globe-icon" className={className} />
+  ),
+  FilePen: ({ className }: { className?: string }) => (
+    <svg data-testid="filepen-icon" className={className} />
+  ),
+  FileText: ({ className }: { className?: string }) => (
+    <svg data-testid="filetext-icon" className={className} />
+  ),
+  SquareTerminal: ({ className }: { className?: string }) => (
+    <svg data-testid="square-terminal-icon" className={className} />
+  ),
 }))
 
 vi.mock('@/components/icons/PaneIcon', () => ({
@@ -30,8 +51,23 @@ vi.mock('@/components/icons/PaneIcon', () => ({
   ),
 }))
 
+vi.mock('@/components/fresh-agent/FreshAgentSettingsButton', () => ({
+  default: () => <button data-testid="settings-button-stub" />,
+}))
+
 function makeTerminalContent(mode = 'shell') {
   return { kind: 'terminal' as const, mode, shell: 'system' as const, createRequestId: 'r1', status: 'running' as const }
+}
+
+function makeFreshAgentContent(sessionId = 'thread-1') {
+  return {
+    kind: 'fresh-agent' as const,
+    sessionType: 'freshclaude' as const,
+    provider: 'claude' as const,
+    sessionId,
+    createRequestId: 'req-1',
+    status: 'idle' as const,
+  }
 }
 
 describe('PaneHeader', () => {
@@ -868,6 +904,58 @@ describe('PaneHeader', () => {
 
       fireEvent.click(screen.getByTitle('Maximize pane'))
       expect(onToggleZoom).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('fresh-agent tool icons', () => {
+    it('renders an icon for each known tool used by the session', () => {
+      const store = configureStore({
+        reducer: { freshAgent: freshAgentReducer },
+      })
+      store.dispatch(sessionInit({
+        sessionId: 'thread-1',
+        sessionType: 'freshclaude',
+        provider: 'claude',
+        tools: [{ name: 'Bash' }, { name: 'Read' }, { name: 'Glob' }, { name: 'WebFetch' }],
+      }))
+
+      render(
+        <Provider store={store}>
+          <PaneHeader
+            title="Claude"
+            status="idle"
+            isActive={true}
+            onClose={vi.fn()}
+            content={makeFreshAgentContent()}
+          />
+        </Provider>,
+      )
+
+      expect(screen.getByTestId('terminal-icon')).toBeInTheDocument()
+      expect(screen.getByTestId('filetext-icon')).toBeInTheDocument()
+      expect(screen.getByTestId('filesearch-icon')).toBeInTheDocument()
+      expect(screen.getByTestId('globe-icon')).toBeInTheDocument()
+      expect(screen.getByTitle('Bash, Read, Glob, WebFetch')).toBeInTheDocument()
+    })
+
+    it('renders no tool icons when the session has no tools', () => {
+      const store = configureStore({
+        reducer: { freshAgent: freshAgentReducer },
+      })
+
+      const { container } = render(
+        <Provider store={store}>
+          <PaneHeader
+            title="Claude"
+            status="idle"
+            isActive={true}
+            onClose={vi.fn()}
+            content={makeFreshAgentContent()}
+          />
+        </Provider>,
+      )
+
+      expect(container.querySelector('[title="Bash"]')).toBeNull()
     })
   })
 })

--- a/test/unit/client/components/panes/PaneLayout.test.tsx
+++ b/test/unit/client/components/panes/PaneLayout.test.tsx
@@ -93,6 +93,8 @@ vi.mock('lucide-react', () => ({
   RefreshCw: ({ className }: { className?: string }) => (
     <svg data-testid="refresh-icon" className={className} />
   ),
+  FilePen: () => null,
+  FileSearch: () => null,
 }))
 
 // Mock PaneIcon to avoid transitive dependency issues


### PR DESCRIPTION
## Summary

Generalizes the fresh-agent header bar to display runtime metadata (cwd, branch, token usage) for **all** fresh-agent providers (claude, codex, opencode), not just Claude. Also adds per-session tool icons to the header.

### Changes

**`PaneContainer.tsx` — `resolveFreshAgentRuntimeMeta`**
- Renamed from `resolveFreshClaudeRuntimeMeta` (Claude-only) to work for all providers
- Indexed-session path now runs for any provider with a resumable session ID (previously gated on `provider === 'claude'`)
- **Snapshot fallback:** when no indexed session is found, falls back to `session.snapshot` data — deriving `cwd` from `session.cwd`, `branch` from `session.snapshot.worktrees[0].branch`, and shaping `tokenUsage` from `session.snapshot.tokenUsage` (with `cachedTokens ?? 0` default, conditional `contextTokens`/`compactPercent` passthrough)

**`PaneHeader.tsx` — `FreshAgentToolIcons`**
- New component renders compact icons for tools used by the session (Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch)
- Reads `state.freshAgent.sessions[key].tools` via targeted selector
- Renders null when no tools or no session

### Test coverage
- 4 new tests for the snapshot fallback path: codex provider, Claude-with-no-indexed-session, opencode with/without `compactPercent`
- 2 existing tests for tool icons in `PaneHeader.test.tsx`
- Fixed `lucide-react` mock stubs in 4 test files (added `FilePen`, `FileSearch`, and where needed `Terminal`/`FileText`/`Globe`/`SquareTerminal`)

### Fresheyes
- **Round 1:** 2 blocking issues found -- (1) broken test mocks missing `FilePen`/`FileSearch` exports, (2) zero test coverage for snapshot fallback
- **Round 2:** PASS -- correctness, type safety, test coverage, no breaking changes, no performance concerns

### Verification
```
npx tsc --noEmit                     # clean
npm run test:vitest -- run test/unit/client/components/panes/   # 17 files, 385 tests passed
npm run lint                         # 0 errors
```
