### PR TITLE
Fix Freshopencode defaults and UI updates

### DIFF
--- a/server/fresh-agent/adapters/opencode/serve-events.ts
+++ b/server/fresh-agent/adapters/opencode/serve-events.ts
@@ -25,6 +25,19 @@ function stringProperty(value: unknown, key: string): string | undefined {
   return typeof candidate === 'string' ? candidate : undefined
 }
 
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined
+}
+
+function opencodeErrorMessage(value: unknown): string | undefined {
+  if (typeof value === 'string') return nonEmptyString(value)
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+  const record = value as Record<string, unknown>
+  return nonEmptyString(record.message)
+    ?? stringProperty(record.data, 'message')
+    ?? nonEmptyString(record.error)
+}
+
 function eventPayload(raw: Record<string, unknown>): Record<string, unknown> | null {
   if (typeof raw.type === 'string') return raw
   const payload = raw.payload
@@ -94,7 +107,7 @@ export function serveEventToSdk(parsed: ParsedServeEvent, subscribedId: string):
       return { type: 'sdk.session.changed', sessionId: subscribedId, reason: 'opencode-status' }
     }
     case 'session.error': {
-      const message = stringProperty(props.error, 'message') ?? 'OpenCode session error'
+      const message = opencodeErrorMessage(props.error) ?? 'OpenCode session error'
       return { type: 'sdk.error', sessionId: subscribedId, message }
     }
     default:

--- a/shared/fresh-agent-models.ts
+++ b/shared/fresh-agent-models.ts
@@ -15,7 +15,7 @@ export type FreshAgentModelOption = {
 export const FRESHCODEX_DEFAULT_MODEL = 'gpt-5.5'
 export const FRESHCODEX_DEFAULT_EFFORT = 'max'
 export const FRESHCLAUDE_DEFAULT_EFFORT = 'high'
-export const FRESHOPENCODE_DEFAULT_MODEL = 'opencode-go/deepseek-v4-flash'
+export const FRESHOPENCODE_DEFAULT_MODEL = 'opencode-go/glm-5.2'
 export const FRESHOPENCODE_DEFAULT_EFFORT = 'max'
 
 export const FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE = {
@@ -58,7 +58,7 @@ export const FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE = {
   freshopencode: [
     {
       value: FRESHOPENCODE_DEFAULT_MODEL,
-      label: 'DeepSeek V4 Flash',
+      label: 'GLM 5.2',
       thinkingEfforts: ['minimal', 'low', 'medium', 'high', 'max'],
       defaultEffort: FRESHOPENCODE_DEFAULT_EFFORT,
     },
@@ -69,8 +69,8 @@ export const FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE = {
       defaultEffort: FRESHOPENCODE_DEFAULT_EFFORT,
     },
     {
-      value: 'opencode-go/glm-5.2',
-      label: 'GLM 5.2',
+      value: 'opencode-go/deepseek-v4-flash',
+      label: 'DeepSeek V4 Flash',
       thinkingEfforts: ['minimal', 'low', 'medium', 'high', 'max'],
       defaultEffort: FRESHOPENCODE_DEFAULT_EFFORT,
     },

--- a/src/components/fresh-agent/FreshAgentSettingsButton.tsx
+++ b/src/components/fresh-agent/FreshAgentSettingsButton.tsx
@@ -26,7 +26,7 @@ import type {
 
 function resolveEffectiveFreshAgentModel(
   content: FreshAgentPaneContent,
-  providerDefaults?: { modelSelection?: { modelId: string } },
+  providerDefaults?: { modelSelection?: { modelId: string }; effort?: string },
 ): string | undefined {
   const configuredModel = content.model
     ?? content.modelSelection?.modelId
@@ -36,13 +36,13 @@ function resolveEffectiveFreshAgentModel(
 
 function getEffectiveFreshAgentEffort(
   content: FreshAgentPaneContent,
-  providerDefaults?: { modelSelection?: { modelId: string } },
+  providerDefaults?: { modelSelection?: { modelId: string }; effort?: string },
 ): string | undefined {
   return normalizeFreshAgentEffort(
     content.sessionType,
     content.provider,
     resolveEffectiveFreshAgentModel(content, providerDefaults),
-    content.effort,
+    content.effort ?? providerDefaults?.effort,
   )
 }
 

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -61,6 +61,7 @@ const SNAPSHOT_INVALIDATING_FRESH_AGENT_EVENTS = new Set([
   'freshAgent.session.changed',
   'freshAgent.session.snapshot',
   'freshAgent.result',
+  'freshAgent.turn.complete',
   'freshAgent.permission.request',
   'freshAgent.permission.cancelled',
   'freshAgent.question.request',
@@ -577,6 +578,7 @@ export function FreshAgentView({
   const [loadError, setLoadError] = useState<string | null>(null)
   const [snapshotRefreshNonce, setSnapshotRefreshNonce] = useState(0)
   const snapshotRefreshTimerRef = useRef<number | null>(null)
+  const snapshotRefreshFollowUpRef = useRef(false)
   const [queuedMessages, setQueuedMessages] = useState<string[]>([])
   // Transient, self-clearing banner for action feedback (rewind, shell errors).
   const [notice, setNotice] = useState<string | null>(null)
@@ -714,12 +716,19 @@ export function FreshAgentView({
     ws.send(message as never)
   }, [paneId, ws])
 
-  const scheduleSnapshotRefresh = useCallback(() => {
-    if (snapshotRefreshTimerRef.current !== null) return
-    snapshotRefreshTimerRef.current = window.setTimeout(() => {
+  const scheduleSnapshotRefresh = useCallback((options?: { followUpIfPending?: boolean }) => {
+    if (snapshotRefreshTimerRef.current !== null) {
+      if (options?.followUpIfPending) snapshotRefreshFollowUpRef.current = true
+      return
+    }
+    const fireRefresh = () => {
       snapshotRefreshTimerRef.current = null
       setSnapshotRefreshNonce((value) => value + 1)
-    }, SNAPSHOT_REFRESH_COALESCE_MS)
+      if (!snapshotRefreshFollowUpRef.current) return
+      snapshotRefreshFollowUpRef.current = false
+      snapshotRefreshTimerRef.current = window.setTimeout(fireRefresh, SNAPSHOT_REFRESH_COALESCE_MS)
+    }
+    snapshotRefreshTimerRef.current = window.setTimeout(fireRefresh, SNAPSHOT_REFRESH_COALESCE_MS)
   }, [])
 
   useEffect(() => () => {
@@ -727,6 +736,7 @@ export function FreshAgentView({
       window.clearTimeout(snapshotRefreshTimerRef.current)
       snapshotRefreshTimerRef.current = null
     }
+    snapshotRefreshFollowUpRef.current = false
   }, [])
 
   const recordPendingSendMetadata = useCallback((requestId: string, patch: PendingSendMetadata) => {
@@ -1170,13 +1180,15 @@ export function FreshAgentView({
         } else {
           recordPendingSendMetadata(message.requestId, { legacyAccepted: true })
         }
-        scheduleSnapshotRefresh()
+        scheduleSnapshotRefresh({ followUpIfPending: true })
       }
       if (
         isSnapshotInvalidatingFreshAgentEvent(message)
         && locatorMatchesPane(message, paneContentRef.current, freshOpenCodeRouteCwdRef.current)
       ) {
-        scheduleSnapshotRefresh()
+        scheduleSnapshotRefresh({
+          followUpIfPending: readMessageEventType(message) === 'freshAgent.turn.complete',
+        })
       }
       if (
         message.type === 'freshAgent.forked'

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -176,7 +176,7 @@ function mergeSnapshotForDisplay(
 
 function resolveEffectiveFreshAgentModel(
   content: FreshAgentPaneContent,
-  providerDefaults?: { modelSelection?: { modelId: string } },
+  providerDefaults?: { modelSelection?: { modelId: string }; effort?: string },
 ): string | undefined {
   const configuredModel = content.model
     ?? content.modelSelection?.modelId
@@ -186,13 +186,13 @@ function resolveEffectiveFreshAgentModel(
 
 function getEffectiveFreshAgentEffort(
   content: FreshAgentPaneContent,
-  providerDefaults?: { modelSelection?: { modelId: string } },
+  providerDefaults?: { modelSelection?: { modelId: string }; effort?: string },
 ): string | undefined {
   return normalizeFreshAgentEffort(
     content.sessionType,
     content.provider,
     resolveEffectiveFreshAgentModel(content, providerDefaults),
-    content.effort,
+    content.effort ?? providerDefaults?.effort,
   )
 }
 

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -607,12 +607,20 @@ function PickerWrapper({
       const providerDefaultModel = typeof providerSettings?.modelSelection?.modelId === 'string'
         ? providerSettings.modelSelection.modelId
         : undefined
+      const runtimeProviderConfiguredModel = settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.model
+      const runtimeProviderModel = typeof runtimeProviderConfiguredModel === 'string'
+        && runtimeProviderConfiguredModel.trim().length > 0
+        ? runtimeProviderConfiguredModel
+        : undefined
       const configuredModel = freshAgentType.runtimeProvider === 'codex' || freshAgentType.runtimeProvider === 'opencode'
         ? providerDefaultModel
-          ?? settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.model
+          ?? runtimeProviderModel
           ?? freshAgentType.defaultModel
         : freshAgentType.defaultModel
       const model = normalizeFreshAgentModel(freshAgentType.sessionType, freshAgentType.runtimeProvider, configuredModel) ?? configuredModel
+      const shouldPersistPaneModel = freshAgentType.runtimeProvider !== 'opencode'
+        || providerDefaultModel !== undefined
+        || runtimeProviderModel !== undefined
       const permissionMode = freshAgentType.settingsVisibility.permissionMode === false
         ? undefined
         : providerSettings?.defaultPermissionMode
@@ -628,7 +636,7 @@ function PickerWrapper({
         createRequestId: nanoid(),
         status: 'creating',
         modelSelection: normalizeFreshAgentModelSelection(providerSettings?.modelSelection),
-        model,
+        ...(shouldPersistPaneModel ? { model } : {}),
         ...(permissionMode ? { permissionMode } : {}),
         sandbox: freshAgentType.runtimeProvider === 'codex'
           ? settings?.codingCli?.providers?.[freshAgentType.runtimeProvider]?.sandbox

--- a/src/store/paneTypes.ts
+++ b/src/store/paneTypes.ts
@@ -42,15 +42,18 @@ export function normalizeFreshAgentPaneModelSelection(args: {
   modelSelection?: unknown
   legacyModel?: unknown
 }): FreshAgentModelSelection | undefined {
-  const selection = normalizeFreshAgentModelSelection(args.modelSelection, args.legacyModel)
+  const explicitSelection = normalizeFreshAgentModelSelection(args.modelSelection)
+  if (explicitSelection) return explicitSelection
+
   if (
     args.sessionType === 'freshopencode'
     && args.provider === 'opencode'
-    && selection?.modelId === LEGACY_FRESHOPENCODE_DEFAULT_MODEL
+    && typeof args.legacyModel === 'string'
+    && args.legacyModel.trim() === LEGACY_FRESHOPENCODE_DEFAULT_MODEL
   ) {
     return undefined
   }
-  return selection
+  return normalizeFreshAgentModelSelection(undefined, args.legacyModel)
 }
 
 export function normalizeFreshAgentEffortOverride(value: unknown): string | undefined {

--- a/src/store/paneTypes.ts
+++ b/src/store/paneTypes.ts
@@ -34,6 +34,25 @@ export function normalizeFreshAgentModelSelection(
   return undefined
 }
 
+const LEGACY_FRESHOPENCODE_DEFAULT_MODEL = 'opencode-go/deepseek-v4-flash'
+
+export function normalizeFreshAgentPaneModelSelection(args: {
+  sessionType?: unknown
+  provider?: unknown
+  modelSelection?: unknown
+  legacyModel?: unknown
+}): FreshAgentModelSelection | undefined {
+  const selection = normalizeFreshAgentModelSelection(args.modelSelection, args.legacyModel)
+  if (
+    args.sessionType === 'freshopencode'
+    && args.provider === 'opencode'
+    && selection?.modelId === LEGACY_FRESHOPENCODE_DEFAULT_MODEL
+  ) {
+    return undefined
+  }
+  return selection
+}
+
 export function normalizeFreshAgentEffortOverride(value: unknown): string | undefined {
   if (typeof value !== 'string') {
     return undefined

--- a/src/store/persistMiddleware.ts
+++ b/src/store/persistMiddleware.ts
@@ -18,7 +18,7 @@ import { LAYOUT_STORAGE_KEY, PANES_STORAGE_KEY, TAB_RECENCY_STORAGE_KEY, TURN_CO
 import { createLogger } from '@/lib/client-logger'
 import { flushPersistedLayoutNow } from './persistControl'
 import { sanitizeSessionRef } from '@shared/session-contract'
-import { normalizeFreshAgentEffortOverride, normalizeFreshAgentModelSelection } from './paneTypes'
+import { normalizeFreshAgentEffortOverride, normalizeFreshAgentPaneModelSelection } from './paneTypes'
 import {
   loadPersistedTabRecency,
   mergeTabRecencyStatesByMax,
@@ -162,7 +162,12 @@ function migratePaneContent(content: any): any {
     }
     return {
       ...rest,
-      modelSelection: normalizeFreshAgentModelSelection(legacyModelSelection, legacyModel),
+      modelSelection: normalizeFreshAgentPaneModelSelection({
+        sessionType: content.sessionType,
+        provider: content.provider,
+        modelSelection: legacyModelSelection,
+        legacyModel,
+      }),
       effort: normalizeFreshAgentEffortOverride(content.effort),
     }
   }

--- a/src/store/persistedState.ts
+++ b/src/store/persistedState.ts
@@ -8,6 +8,7 @@ import {
 } from '@shared/session-contract'
 import { sanitizeCodexDurabilityRef } from '@shared/codex-durability'
 import { migrateLegacyFreshAgentContent, migrateLegacyFreshAgentDurableState } from '@shared/fresh-agent'
+import { normalizeFreshAgentPaneModelSelection } from './paneTypes'
 
 export { LAYOUT_STORAGE_KEY, TABS_STORAGE_KEY, PANES_STORAGE_KEY }
 
@@ -256,9 +257,27 @@ function normalizeFreshAgentContent(content: Record<string, unknown>): Record<st
     rejectNonCanonicalClaudeSessionRef: true,
   })
   const { sessionRef: _legacySessionRef, restoreError: _legacyRestoreError, ...rest } = content
+  const restWithNormalizedModel = content.sessionType === 'freshopencode' && content.provider === 'opencode'
+    ? (() => {
+        const {
+          model: legacyModel,
+          modelSelection: legacyModelSelection,
+          ...withoutModel
+        } = rest
+        return {
+          ...withoutModel,
+          modelSelection: normalizeFreshAgentPaneModelSelection({
+            sessionType: content.sessionType,
+            provider: content.provider,
+            modelSelection: legacyModelSelection,
+            legacyModel,
+          }),
+        }
+      })()
+    : rest
 
   return {
-    ...rest,
+    ...restWithNormalizedModel,
     ...(durableState.sessionRef ? { sessionRef: durableState.sessionRef } : {}),
     ...(('restoreError' in durableState && durableState.restoreError) || existingRestoreError
       ? { restoreError: ('restoreError' in durableState && durableState.restoreError) || existingRestoreError }

--- a/src/store/storage-migration.ts
+++ b/src/store/storage-migration.ts
@@ -35,6 +35,7 @@ import {
 } from '@shared/session-contract'
 import { sanitizeCodexDurabilityRef } from '@shared/codex-durability'
 import { migrateLegacyFreshAgentContent, migrateLegacyFreshAgentDurableState } from '@shared/fresh-agent'
+import { normalizeFreshAgentPaneModelSelection } from './paneTypes'
 
 const log = createLogger('StorageMigration')
 
@@ -222,10 +223,28 @@ function normalizeLayoutNode(node: unknown): unknown {
         rejectNonCanonicalClaudeSessionRef: true,
       })
       const { sessionRef: _legacySessionRef, restoreError: _legacyRestoreError, ...rest } = content
+      const restWithNormalizedModel = content.sessionType === 'freshopencode' && content.provider === 'opencode'
+        ? (() => {
+            const {
+              model: legacyModel,
+              modelSelection: legacyModelSelection,
+              ...withoutModel
+            } = rest
+            return {
+              ...withoutModel,
+              modelSelection: normalizeFreshAgentPaneModelSelection({
+                sessionType: content.sessionType,
+                provider: content.provider,
+                modelSelection: legacyModelSelection,
+                legacyModel,
+              }),
+            }
+          })()
+        : rest
       return {
         ...candidate,
         content: {
-          ...rest,
+          ...restWithNormalizedModel,
           ...(durableState.sessionRef ? { sessionRef: durableState.sessionRef } : {}),
           ...('restoreError' in durableState && durableState.restoreError ? { restoreError: durableState.restoreError } : {}),
         },

--- a/test/integration/client/editor-pane.test.tsx
+++ b/test/integration/client/editor-pane.test.tsx
@@ -114,6 +114,18 @@ vi.mock('lucide-react', () => ({
   Search: ({ className }: { className?: string }) => (
     <svg data-testid="search-icon" className={className} />
   ),
+  RefreshCw: ({ className }: { className?: string }) => (
+    <svg data-testid="refresh-icon" className={className} />
+  ),
+  SquareTerminal: ({ className }: { className?: string }) => (
+    <svg data-testid="square-terminal-icon" className={className} />
+  ),
+  FileSearch: ({ className }: { className?: string }) => (
+    <svg data-testid="file-search-icon" className={className} />
+  ),
+  FilePen: ({ className }: { className?: string }) => (
+    <svg data-testid="file-pen-icon" className={className} />
+  ),
 }))
 
 // Mock TerminalView component to avoid xterm.js dependencies

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -3913,6 +3913,123 @@ describe('FreshAgentView', () => {
     })
   })
 
+  it('performs a follow-up freshopencode refresh when final send acceptance lands during an earlier invalidation debounce', async () => {
+    const store = createStore()
+    let wsHandler: ((message: any) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler) => {
+      wsHandler = handler
+      return () => {}
+    })
+    apiMock.getFreshAgentThreadSnapshot
+      .mockResolvedValueOnce({
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        threadId: 'ses_final_race',
+        status: 'idle',
+        capabilities: { send: true, interrupt: true, fork: true },
+        turns: [],
+      })
+      .mockResolvedValueOnce({
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        threadId: 'ses_final_race',
+        revision: 2,
+        status: 'idle',
+        capabilities: { send: true, interrupt: true, fork: true },
+        turns: [
+          {
+            id: 'turn-final-user',
+            turnId: 'turn-final-user',
+            role: 'user',
+            summary: 'Race final prompt',
+            items: [{ id: 'item-final-user', kind: 'text', text: 'Race final prompt' }],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        threadId: 'ses_final_race',
+        revision: 3,
+        status: 'idle',
+        capabilities: { send: true, interrupt: true, fork: true },
+        turns: [
+          {
+            id: 'turn-final-user',
+            turnId: 'turn-final-user',
+            role: 'user',
+            summary: 'Race final prompt',
+            items: [{ id: 'item-final-user', kind: 'text', text: 'Race final prompt' }],
+          },
+          {
+            id: 'turn-final-assistant',
+            turnId: 'turn-final-assistant',
+            role: 'assistant',
+            summary: 'Final answer after durable history catches up',
+            items: [{ id: 'item-final-assistant', kind: 'text', text: 'Final answer after durable history catches up' }],
+          },
+        ],
+      })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-final-race',
+        sessionId: 'ses_final_race',
+        sessionRef: { provider: 'opencode', sessionId: 'ses_final_race' },
+        resumeSessionId: 'ses_final_race',
+        initialCwd: '/repo/final-race',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'Race final prompt' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    const send = sentFreshAgentMessages('freshAgent.send').at(-1)
+    const requestId = String(send?.requestId)
+
+    act(() => {
+      wsHandler?.({
+        type: 'freshAgent.event',
+        sessionId: 'ses_final_race',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        event: {
+          type: 'freshAgent.session.changed',
+          sessionId: 'ses_final_race',
+          reason: 'opencode-message',
+        },
+      })
+      wsHandler?.({
+        type: 'freshAgent.send.accepted',
+        requestId,
+        sessionId: 'ses_final_race',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        cwd: '/repo/final-race',
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Final answer after durable history catches up')).toBeInTheDocument()
+    })
+    expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(3)
+  })
+
   it('clears stale local echo after an idle recovered snapshot without the submitted turn', async () => {
     const store = createStore()
     let wsHandler: ((message: any) => void) | undefined

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, fireEvent, createEvent, cleanup, act } from '@
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import panesReducer from '@/store/panesSlice'
-import settingsReducer, { updateSettingsLocal } from '@/store/settingsSlice'
+import settingsReducer, { previewServerSettingsPatch, updateSettingsLocal } from '@/store/settingsSlice'
 import freshAgentReducer, { sessionInit, setSessionStatus } from '@/store/freshAgentSlice'
 import tabsReducer from '@/store/tabsSlice'
 import { FreshAgentView } from '@/components/fresh-agent/FreshAgentView'
@@ -1764,6 +1764,47 @@ describe('FreshAgentView', () => {
         provider: 'opencode',
         model: 'opencode-go/glm-5.2',
         modelSelection: { kind: 'exact', modelId: 'opencode-go/glm-5.2' },
+      }))
+    })
+  })
+
+  it('creates Freshopencode panes with the saved provider model when the pane has no model preference', async () => {
+    const store = createStore()
+    store.dispatch(previewServerSettingsPatch({
+      freshAgent: {
+        providers: {
+          freshopencode: {
+            modelSelection: { kind: 'exact', modelId: 'umans-ai-coding-plan/umans-kimi-k2.7' },
+            effort: 'high',
+          },
+        },
+      },
+    }))
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-provider-default-opencode-model',
+        status: 'creating',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(sentFreshAgentMessages('freshAgent.create')).toContainEqual(expect.objectContaining({
+        type: 'freshAgent.create',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        model: 'umans-ai-coding-plan/umans-kimi-k2.7',
+        effort: 'high',
       }))
     })
   })

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -1868,7 +1868,7 @@ describe('PaneContainer', () => {
           expect(paneContent.sessionType).toBe('freshopencode')
           expect(paneContent.provider).toBe('opencode')
           expect(paneContent.initialCwd).toBe('/home/user/freshopencode-project')
-          expect(paneContent.model).toBe('opencode-go/deepseek-v4-flash')
+          expect(paneContent.model).toBe('opencode-go/glm-5.2')
           expect(paneContent.effort).toBe('max')
           expect(paneContent.permissionMode).toBeUndefined()
         }

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -1645,7 +1645,7 @@ describe('PaneContainer', () => {
       providerSettingsByName?: Record<string, { cwd?: string; permissionMode?: string; model?: string; effort?: string }>,
       enabledProviders: string[] = ['claude'],
       availableClis: Record<string, boolean> = { claude: true },
-      freshAgentProviderSettingsByName?: Record<string, { effort?: string }>,
+      freshAgentProviderSettingsByName?: Record<string, { effort?: string; modelSelection?: { kind: 'exact'; modelId: string } }>,
     ) {
       return configureStore({
         reducer: {
@@ -1843,7 +1843,7 @@ describe('PaneContainer', () => {
       })
     })
 
-    it('enables Freshopencode from the picker with OpenCode defaults', async () => {
+    it('enables Freshopencode from the picker without persisting the built-in model fallback', async () => {
       const node = createPickerNode('pane-1')
       const store = createStoreWithClaude(node, undefined, undefined, ['claude', 'opencode'], { claude: true, opencode: true })
       mockApiPost.mockResolvedValueOnce({ valid: true, resolvedPath: '/home/user/freshopencode-project' })
@@ -1868,7 +1868,8 @@ describe('PaneContainer', () => {
           expect(paneContent.sessionType).toBe('freshopencode')
           expect(paneContent.provider).toBe('opencode')
           expect(paneContent.initialCwd).toBe('/home/user/freshopencode-project')
-          expect(paneContent.model).toBe('opencode-go/glm-5.2')
+          expect(paneContent.model).toBeUndefined()
+          expect(paneContent.modelSelection).toBeUndefined()
           expect(paneContent.effort).toBe('max')
           expect(paneContent.permissionMode).toBeUndefined()
         }
@@ -1876,6 +1877,44 @@ describe('PaneContainer', () => {
 
       expect(saveServerSettingsPatchSpy).toHaveBeenCalledWith({
         codingCli: { providers: { opencode: { cwd: '/home/user/freshopencode-project' } } },
+      })
+    })
+
+    it('uses the saved Freshopencode model choice for new panes', async () => {
+      const node = createPickerNode('pane-1')
+      const store = createStoreWithClaude(
+        node,
+        undefined,
+        undefined,
+        ['claude', 'opencode'],
+        { claude: true, opencode: true },
+        { freshopencode: { modelSelection: { kind: 'exact', modelId: 'umans-ai-coding-plan/umans-kimi-k2.7' }, effort: 'high' } },
+      )
+      mockApiPost.mockResolvedValueOnce({ valid: true, resolvedPath: '/home/user/freshopencode-project' })
+
+      renderWithStore(
+        <PaneContainer tabId="tab-1" node={node} />,
+        store
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Freshopencode' }))
+      fireEvent.transitionEnd(getPickerContainer())
+
+      const input = screen.getByLabelText('Starting directory for Freshopencode')
+      fireEvent.change(input, { target: { value: '/home/user/freshopencode-project' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => {
+        const state = store.getState().panes
+        const paneContent = (state.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>).content
+        expect(paneContent.kind).toBe('fresh-agent')
+        if (paneContent.kind === 'fresh-agent') {
+          expect(paneContent.sessionType).toBe('freshopencode')
+          expect(paneContent.provider).toBe('opencode')
+          expect(paneContent.model).toBe('umans-ai-coding-plan/umans-kimi-k2.7')
+          expect(paneContent.modelSelection).toEqual({ kind: 'exact', modelId: 'umans-ai-coding-plan/umans-kimi-k2.7' })
+          expect(paneContent.effort).toBe('high')
+        }
       })
     })
 

--- a/test/unit/client/lib/fresh-agent-ws.test.ts
+++ b/test/unit/client/lib/fresh-agent-ws.test.ts
@@ -5,6 +5,8 @@ import panesReducer, { initLayout, type PanesState } from '@/store/panesSlice'
 import { handleFreshAgentMessage, registerFreshAgentCreate } from '@/lib/fresh-agent-ws'
 import { cancelCreate, _resetCancelledCreates } from '@/lib/create-cancellation'
 import { flushPersistedLayoutNow } from '@/store/persistControl'
+import { normalizeFreshAgentProviderEvent } from '../../../../server/fresh-agent/sdk-events'
+import { parseServeEvent, serveEventToSdk } from '../../../../server/fresh-agent/adapters/opencode/serve-events'
 
 function createFreshAgentStore() {
   return configureStore({
@@ -398,6 +400,57 @@ describe('fresh-agent-ws', () => {
       status: 'idle',
       latestTurnId: 'msg_assistant_1',
       historyRevision: 11,
+    })
+  })
+
+  it('bubbles OpenCode APIError data.message into FreshOpenCode UI-facing state', () => {
+    const store = createFreshAgentStore()
+    const sessionId = 'ses_opencode_billing'
+    const key = `freshopencode:opencode:${sessionId}`
+    const billingMessage = 'Insufficient balance. Manage your billing here: https://opencode.ai/workspace/wrk_01K7GPZSP6NGNSHF5ZHKBTVHVF/billing'
+    const sendEvent = (event: Record<string, unknown>) => handleFreshAgentMessage(store.dispatch, {
+      type: 'freshAgent.event',
+      sessionId,
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      event: { sessionId, ...event },
+    })
+
+    expect(sendEvent({ type: 'freshAgent.session.snapshot', latestTurnId: null, status: 'running', revision: 1 })).toBe(true)
+
+    const parsed = parseServeEvent({
+      type: 'session.error',
+      properties: {
+        sessionID: sessionId,
+        error: {
+          name: 'APIError',
+          data: {
+            message: billingMessage,
+            statusCode: 402,
+            isRetryable: false,
+          },
+        },
+      },
+    })
+    if (!parsed) throw new Error('expected parsed OpenCode session.error')
+
+    const sdkEvent = serveEventToSdk(parsed, sessionId)
+    expect(sdkEvent).toEqual({ type: 'sdk.error', sessionId, message: billingMessage })
+    const normalized = normalizeFreshAgentProviderEvent(sdkEvent)
+    expect(normalized).toEqual({ type: 'freshAgent.error', sessionId, message: billingMessage })
+
+    expect(handleFreshAgentMessage(store.dispatch, {
+      type: 'freshAgent.event',
+      sessionId,
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      event: normalized as Record<string, unknown>,
+    })).toBe(true)
+
+    expect(store.getState().freshAgent.sessions[key]).toMatchObject({
+      status: 'idle',
+      streamingActive: false,
+      lastError: billingMessage,
     })
   })
 

--- a/test/unit/client/store/panesPersistence.test.ts
+++ b/test/unit/client/store/panesPersistence.test.ts
@@ -817,6 +817,43 @@ describe('version 5 migration (drop claude-chat panes)', () => {
     expect(content.modelSelection).toBeUndefined()
     expect(content.effort).toBe('max')
   })
+
+  it('preserves explicit Freshopencode DeepSeek pane selections', () => {
+    localStorage.setItem('freshell.layout.v3', JSON.stringify({
+      version: 3,
+      tabs: { tabs: [{ id: 'tab1', title: 'Tab 1' }], activeTabId: 'tab1' },
+      panes: {
+        version: 6,
+        layouts: {
+          tab1: {
+            type: 'leaf',
+            id: 'pane1',
+            content: {
+              kind: 'fresh-agent',
+              sessionType: 'freshopencode',
+              provider: 'opencode',
+              createRequestId: 'req1',
+              status: 'idle',
+              model: 'opencode-go/deepseek-v4-flash',
+              modelSelection: { kind: 'exact', modelId: 'opencode-go/deepseek-v4-flash' },
+              effort: 'max',
+            },
+          },
+        },
+        activePane: { tab1: 'pane1' },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+      },
+      tombstones: [],
+    }))
+
+    const persisted = loadPersistedPanes()
+    const content = (persisted!.layouts.tab1 as any).content
+
+    expect(content.model).toBeUndefined()
+    expect(content.modelSelection).toEqual({ kind: 'exact', modelId: 'opencode-go/deepseek-v4-flash' })
+    expect(content.effort).toBe('max')
+  })
 })
 
 import { BROWSER_PREFERENCES_STORAGE_KEY } from '../../../../src/store/storage-keys'

--- a/test/unit/client/store/panesPersistence.test.ts
+++ b/test/unit/client/store/panesPersistence.test.ts
@@ -781,6 +781,42 @@ describe('version 5 migration (drop claude-chat panes)', () => {
     })
     expect(content.effort).toBe('high')
   })
+
+  it('drops stale legacy Freshopencode pane defaults instead of preserving DeepSeek', () => {
+    localStorage.setItem('freshell.layout.v3', JSON.stringify({
+      version: 3,
+      tabs: { tabs: [{ id: 'tab1', title: 'Tab 1' }], activeTabId: 'tab1' },
+      panes: {
+        version: 6,
+        layouts: {
+          tab1: {
+            type: 'leaf',
+            id: 'pane1',
+            content: {
+              kind: 'fresh-agent',
+              sessionType: 'freshopencode',
+              provider: 'opencode',
+              createRequestId: 'req1',
+              status: 'idle',
+              model: 'opencode-go/deepseek-v4-flash',
+              effort: 'max',
+            },
+          },
+        },
+        activePane: { tab1: 'pane1' },
+        paneTitles: {},
+        paneTitleSetByUser: {},
+      },
+      tombstones: [],
+    }))
+
+    const persisted = loadPersistedPanes()
+    const content = (persisted!.layouts.tab1 as any).content
+
+    expect(content.model).toBeUndefined()
+    expect(content.modelSelection).toBeUndefined()
+    expect(content.effort).toBe('max')
+  })
 })
 
 import { BROWSER_PREFERENCES_STORAGE_KEY } from '../../../../src/store/storage-keys'

--- a/test/unit/client/store/persisted-state.fresh-agent.test.ts
+++ b/test/unit/client/store/persisted-state.fresh-agent.test.ts
@@ -230,7 +230,7 @@ describe('persistedState fresh-agent migration', () => {
     expect(content.resumeSessionId).toBeUndefined()
   })
 
-  it('drops stale Freshopencode DeepSeek pane selections during persisted layout parsing', () => {
+  it('drops stale Freshopencode DeepSeek legacy model defaults during persisted layout parsing', () => {
     const parsed = parsePersistedLayoutRaw(layoutRaw({
       'tab-1': leaf('pane-freshopencode', {
         kind: 'fresh-agent',
@@ -238,7 +238,7 @@ describe('persistedState fresh-agent migration', () => {
         provider: 'opencode',
         createRequestId: 'req-opencode',
         status: 'idle',
-        modelSelection: { kind: 'exact', modelId: 'opencode-go/deepseek-v4-flash' },
+        model: 'opencode-go/deepseek-v4-flash',
         effort: 'max',
       }),
     }))
@@ -251,6 +251,30 @@ describe('persistedState fresh-agent migration', () => {
       effort: 'max',
     })
     expect(content.modelSelection).toBeUndefined()
+  })
+
+  it('preserves explicit Freshopencode DeepSeek selections during persisted layout parsing', () => {
+    const parsed = parsePersistedLayoutRaw(layoutRaw({
+      'tab-1': leaf('pane-freshopencode', {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-opencode',
+        status: 'idle',
+        model: 'opencode-go/deepseek-v4-flash',
+        modelSelection: { kind: 'exact', modelId: 'opencode-go/deepseek-v4-flash' },
+        effort: 'max',
+      }),
+    }))
+
+    const content = collectLeafContents(parsed!.panes.layouts['tab-1'])[0]
+    expect(content).toMatchObject({
+      kind: 'fresh-agent',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      effort: 'max',
+      modelSelection: { kind: 'exact', modelId: 'opencode-go/deepseek-v4-flash' },
+    })
   })
 
   it('prefers the backup when a pending fresh-agent migration matches the current raw layout without a commit marker', () => {

--- a/test/unit/client/store/persisted-state.fresh-agent.test.ts
+++ b/test/unit/client/store/persisted-state.fresh-agent.test.ts
@@ -230,6 +230,29 @@ describe('persistedState fresh-agent migration', () => {
     expect(content.resumeSessionId).toBeUndefined()
   })
 
+  it('drops stale Freshopencode DeepSeek pane selections during persisted layout parsing', () => {
+    const parsed = parsePersistedLayoutRaw(layoutRaw({
+      'tab-1': leaf('pane-freshopencode', {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-opencode',
+        status: 'idle',
+        modelSelection: { kind: 'exact', modelId: 'opencode-go/deepseek-v4-flash' },
+        effort: 'max',
+      }),
+    }))
+
+    const content = collectLeafContents(parsed!.panes.layouts['tab-1'])[0]
+    expect(content).toMatchObject({
+      kind: 'fresh-agent',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      effort: 'max',
+    })
+    expect(content.modelSelection).toBeUndefined()
+  })
+
   it('prefers the backup when a pending fresh-agent migration matches the current raw layout without a commit marker', () => {
     const backupRaw = layoutRaw({
       'tab-1': leaf('pane-backup', { kind: 'terminal', mode: 'shell' }),

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -25,6 +25,7 @@ vi.mock('../../../../server/fresh-agent/observability.js', async (importOriginal
 vi.mock('../../../../server/logger.js', () => ({ logger: loggerMocks.logger }))
 
 import { createOpencodeFreshAgentAdapter } from '../../../../server/fresh-agent/adapters/opencode/adapter.js'
+import { FRESHOPENCODE_DEFAULT_MODEL } from '../../../../shared/fresh-agent-models.js'
 
 type FakeManager = ReturnType<typeof makeFakeManager>
 
@@ -108,6 +109,22 @@ describe('OpenCode serve adapter: create + send', () => {
       variant: 'high',
     }, { cwd: '/repo' })
     expect(manager.onceIdle).toHaveBeenCalledWith('ses_real_1', expect.any(Number), { cwd: '/repo' })
+  })
+
+  it('uses the Freshopencode default model when create omits an explicit model', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+    await adapter.create({
+      requestId: 'req-default-model', sessionType: 'freshopencode', provider: 'opencode',
+      cwd: '/repo',
+    })
+
+    await adapter.send?.('freshopencode-req-default-model', { text: 'reply ok' })
+
+    expect(FRESHOPENCODE_DEFAULT_MODEL).toBe('opencode-go/glm-5.2')
+    expect(manager.promptAsync).toHaveBeenCalledWith('ses_real_1', expect.objectContaining({
+      model: { providerID: 'opencode-go', modelID: 'glm-5.2' },
+    }), { cwd: '/repo' })
   })
 
   it('attach during an in-flight send reuses the materialized state (no duplicate serve subscription)', async () => {

--- a/test/unit/shared/fresh-agent-models.test.ts
+++ b/test/unit/shared/fresh-agent-models.test.ts
@@ -12,7 +12,16 @@ import {
 
 describe('fresh-agent-models freshopencode options', () => {
   const GLM_5_2_MODEL = 'opencode-go/glm-5.2'
+  const DEEPSEEK_V4_FLASH_MODEL = 'opencode-go/deepseek-v4-flash'
   const KIMI_K2_7_MODEL = 'umans-ai-coding-plan/umans-kimi-k2.7'
+
+  it('uses GLM 5.2 as the Freshopencode default model', () => {
+    expect(FRESHOPENCODE_DEFAULT_MODEL).toBe(GLM_5_2_MODEL)
+    expect(FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE.freshopencode[0]).toMatchObject({
+      value: GLM_5_2_MODEL,
+      label: 'GLM 5.2',
+    })
+  })
 
   it('includes GLM 5.2 as a selectable Freshopencode model', () => {
     const option = resolveFreshAgentModelOption('freshopencode', GLM_5_2_MODEL)
@@ -41,6 +50,13 @@ describe('fresh-agent-models freshopencode options', () => {
     const values = FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE.freshopencode.map((o) => o.value)
 
     expect(values).toContain(GLM_5_2_MODEL)
+  })
+
+  it('keeps DeepSeek V4 Flash selectable without making it the default', () => {
+    const values = FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE.freshopencode.map((o) => o.value)
+
+    expect(values).toContain(DEEPSEEK_V4_FLASH_MODEL)
+    expect(FRESHOPENCODE_DEFAULT_MODEL).not.toBe(DEEPSEEK_V4_FLASH_MODEL)
   })
 
   it('includes Kimi k2.7 as a selectable Freshopencode model', () => {


### PR DESCRIPTION
## Summary
- honor the saved Freshopencode model/effort preference for new panes, using the built-in default only when there is no saved choice
- preserve explicit DeepSeek selections while dropping stale pane-level DeepSeek defaults
- refresh Freshopencode final transcript messages without a browser refresh
- surface OpenCode provider errors such as insufficient balance in the UI
- fix the unrelated lucide icon test mock baseline issue

## Verification
- npm run check