### PR TITLE
Align fresh-agent pane headers with CLI panes

### DIFF
--- a/docs/superpowers/plans/2026-06-29-freshagent-header-parity.md
+++ b/docs/superpowers/plans/2026-06-29-freshagent-header-parity.md
@@ -2,21 +2,24 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make every fresh-agent pane header match coding CLI pane header structure: lowercase fresh-agent identity first, cwd/branch/context text formatted like CLI panes, then compact controls in a stable order, with no open-terminal control and no separate `ctx` meter.
+**Goal:** Make every fresh-agent pane header match coding CLI pane header structure: one left-to-right text run like `freshcodex freshell (main) 56%`, then compact controls in a stable order, with no open-terminal control and no separate `ctx` meter.
 
-**Architecture:** Keep runtime metadata resolution in `PaneContainer` and render all header chrome in `PaneHeader`. Fresh-agent headers use the same `metaLabel` produced by `formatPaneRuntimeLabel()` as CLI panes; `FreshAgentContextMeter` and fresh-agent tool icons are removed from the pane header so no second context display or tool-icon strip competes with the CLI-style header. The fresh-agent settings gear stays because it is the only pane-local style/model control, but it is ordered with the normal header controls.
+**Architecture:** Keep runtime metadata resolution in `PaneContainer` and render all header chrome in `PaneHeader`. Fresh-agent headers render no leading provider/pane icon; the lowercase `sessionType` is the leftmost visible item, followed by the same `metaLabel` produced by `formatPaneRuntimeLabel()` as CLI panes. The fresh-agent settings gear stays because it is the only pane-local style/model control, but it is ordered before optional refresh and the normal zoom/close controls.
 
 **Tech Stack:** React 18, Redux Toolkit selectors, Vitest + Testing Library, existing lucide icon system.
 
 ## Global Constraints
 
 - The visual target is the attached CLI-agent header: text like `freshell (main) 56%`, then compact controls.
-- For fresh agents, prepend the lowercase session type such as `freshcodex` as the leftmost text item.
+- For fresh agents, render the lowercase session type such as `freshcodex` as the leftmost visible item and render one combined text sequence like `freshcodex freshell (main) 56%`.
+- Fresh-agent headers must not show a leading pane/provider icon before `freshcodex`.
+- Fresh-agent headers must not duplicate the pane title and metadata as `freshcodex freshell freshell (main) 56%`.
 - Context formatting must reuse the CLI runtime metadata format and must not show `ctx`.
 - Remove the fresh-agent open-terminal header button.
 - Apply to all fresh-agent types: `freshclaude`, `freshcodex`, `freshopencode`, and `kilroy`.
 - Preserve the fresh-agent settings gear because pane-local model/style controls still need an access point.
-- Keep control ordering stable: settings gear, refresh, zoom, close for fresh-agent panes; existing terminal search/refresh/zoom/close order stays unchanged.
+- Keep control ordering stable: settings gear, refresh when available, zoom, close for fresh-agent panes; existing terminal search/refresh/zoom/close order stays unchanged.
+- If runtime metadata has no context percent yet, the fresh-agent header may render only the directory and branch text, but it must not fall back to a separate `ctx` meter.
 - Do not restart the self-hosted Freshell server.
 - Use focused tests first, then coordinated full-suite verification before completion.
 
@@ -26,16 +29,16 @@
 
 - Modify `src/components/panes/PaneHeader.tsx`
   - Owns header layout for all pane kinds.
-  - Add fresh-agent left label rendering from `content.sessionType`.
+  - Render fresh-agent left text from `content.sessionType`.
+  - Suppress the normal leading `PaneIcon` only for fresh-agent panes so `content.sessionType` is the leftmost visible item.
+  - For fresh-agent panes, render `metaLabel ?? title` immediately after `content.sessionType`, and do not render a second metadata span in the control cluster.
   - Remove `FreshAgentToolIcons`, `FreshAgentContextMeter`, and `FreshAgentOpenTerminalButton` from the header.
-  - Reorder fresh-agent controls so the settings gear appears before refresh, then zoom, then close.
+  - Reorder fresh-agent controls so the settings gear appears before optional refresh, then zoom, then close.
 - Modify `test/unit/client/components/panes/PaneHeader.test.tsx`
-  - Adds regression coverage for fresh-agent text order, no open-terminal button, no separate context meter, and control order.
+  - Adds regression coverage for fresh-agent text order, no leading pane icon, no duplicate metadata/title, no open-terminal button, no separate context meter, and control order.
   - Keeps existing CLI metadata formatter tests.
-- Remove `src/components/fresh-agent/FreshAgentContextMeter.tsx`
-  - The component exists only for the header-specific meter that is no longer part of the desired design.
-- Remove `test/unit/client/components/fresh-agent/FreshAgentContextMeter.test.tsx`
-  - Remove stale coverage for the deleted meter.
+- Keep `src/components/fresh-agent/FreshAgentContextMeter.tsx` and its focused tests unchanged
+  - The component is no longer used in pane headers, but deleting the component is not required to satisfy this visual change.
 - No `docs/index.html` change
   - This is a pane-header consistency fix, not a new user-facing feature or major static mock change.
 
@@ -48,7 +51,7 @@
 - Consumes: `PaneHeader` props `content`, `metaLabel`, `metaTooltip`, `onRefresh`, `onToggleZoom`, and `onClose`.
 - Produces: failing tests that define the desired header contract before implementation.
 
-- [ ] **Step 1: Update test mocks**
+- [ ] **Step 1: Update test mocks and stale imports**
 
 Add an accessible settings-button stub so action order can be tested by role:
 
@@ -60,14 +63,18 @@ vi.mock('@/components/fresh-agent/FreshAgentSettingsButton', () => ({
 }))
 ```
 
-Remove the `SquareTerminal` lucide mock from this file after the implementation removes the open-terminal button.
+Keep or remove the `SquareTerminal` lucide mock as needed by unchanged tests; the new fresh-agent parity test must assert that no open-terminal control renders.
 
-- [ ] **Step 2: Add failing fresh-agent parity tests**
+Keep `sessionInit` only if the seeded negative tool-icon test uses it. Add `freshAgentSnapshotReceived` if the seeded negative context-meter test uses a snapshot payload.
+
+- [ ] **Step 2: Replace stale fresh-agent tool-icon tests with fresh-agent parity tests**
+
+Remove or rewrite the existing `describe('fresh-agent tool icons')` block in `PaneHeader.test.tsx`. That block currently asserts that header tool icons render from session tools; the new contract is that those tool icons do not render in the header.
 
 Add these tests inside `describe('PaneHeader', () => { describe('rendering', () => { ... }) })`:
 
 ```tsx
-it('renders fresh-agent identity as the leftmost header text before CLI-style metadata', () => {
+it('renders fresh-agent identity as the leftmost visible header item before CLI-style metadata', () => {
   render(
     <Provider store={makeFreshAgentStore()}>
       <PaneHeader
@@ -99,6 +106,8 @@ it('renders fresh-agent identity as the leftmost header text before CLI-style me
 
   expect(banner).toContainElement(identity)
   expect(banner).toContainElement(metadata)
+  expect(screen.queryByTestId('pane-icon')).toBeNull()
+  expect(screen.getAllByText(/freshell/)).toHaveLength(1)
   expect(
     identity.compareDocumentPosition(metadata) & Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBeTruthy()
@@ -136,8 +145,29 @@ it.each([
 })
 
 it('renders fresh-agent controls in settings refresh zoom close order without open-terminal or context-meter controls', () => {
+  const store = makeFreshAgentStore()
+  store.dispatch(sessionInit({
+    sessionId: 'fresh-session-1',
+    sessionType: 'freshcodex',
+    provider: 'codex',
+    tools: [{ name: 'Bash' }, { name: 'Read' }, { name: 'Glob' }, { name: 'WebFetch' }],
+  }))
+  store.dispatch(freshAgentSnapshotReceived({
+    snapshot: makeFreshAgentSnapshot({
+      threadId: 'fresh-session-1',
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      tokenUsage: {
+        inputTokens: 1200,
+        outputTokens: 300,
+        contextTokens: 1500,
+        compactPercent: 56,
+      },
+    }),
+  }))
+
   render(
-    <Provider store={makeFreshAgentStore()}>
+    <Provider store={store}>
       <PaneHeader
         tabId="tab-1"
         paneId="pane-1"
@@ -147,6 +177,7 @@ it('renders fresh-agent controls in settings refresh zoom close order without op
         isActive={true}
         onClose={vi.fn()}
         onRefresh={vi.fn()}
+        onSearch={vi.fn()}
         onToggleZoom={vi.fn()}
         content={{
           kind: 'fresh-agent',
@@ -168,8 +199,49 @@ it('renders fresh-agent controls in settings refresh zoom close order without op
     'Maximize pane',
     'Close pane',
   ])
+  expect(screen.queryByTitle('Bash, Read, Glob, WebFetch')).toBeNull()
+  expect(screen.queryByTestId('terminal-icon')).toBeNull()
+  expect(screen.queryByTestId('filetext-icon')).toBeNull()
+  expect(screen.queryByTestId('filesearch-icon')).toBeNull()
+  expect(screen.queryByTestId('globe-icon')).toBeNull()
+  expect(screen.queryByTitle('Search in terminal')).toBeNull()
   expect(screen.queryByLabelText('Open terminal at session directory')).toBeNull()
   expect(screen.queryByRole('status', { name: /context/i })).toBeNull()
+  expect(screen.queryByText(/ctx/i)).toBeNull()
+})
+
+it('omits refresh from the fresh-agent control order when no refresh handler is provided', () => {
+  render(
+    <Provider store={makeFreshAgentStore()}>
+      <PaneHeader
+        tabId="tab-1"
+        paneId="pane-1"
+        title="freshell"
+        metaLabel="freshell (main)"
+        status="running"
+        isActive={true}
+        onClose={vi.fn()}
+        onToggleZoom={vi.fn()}
+        content={{
+          kind: 'fresh-agent',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+          sessionId: 'fresh-session-1',
+          createRequestId: 'fresh-req-1',
+          status: 'idle',
+        }}
+      />
+    </Provider>,
+  )
+
+  const actionLabels = screen.getAllByRole('button').map((button) => button.getAttribute('aria-label') || button.getAttribute('title'))
+
+  expect(actionLabels).toEqual([
+    'Agent settings',
+    'Maximize pane',
+    'Close pane',
+  ])
+  expect(screen.queryByText(/ctx/i)).toBeNull()
 })
 ```
 
@@ -185,6 +257,8 @@ function makeFreshAgentStore() {
 }
 ```
 
+Add a small `makeFreshAgentSnapshot` fixture helper near the store helper if the test suite does not already have one. It only needs the fields required by `freshAgentSnapshotReceived`.
+
 - [ ] **Step 4: Run the failing test**
 
 Run:
@@ -193,18 +267,16 @@ Run:
 npm run test:vitest -- --run test/unit/client/components/panes/PaneHeader.test.tsx -t "fresh-agent"
 ```
 
-Expected: FAIL because the current header still renders the capitalized chip, tool icons, open-terminal button, and context meter before the desired control order.
+Expected: FAIL because the current header still renders a leading pane icon, duplicates `freshell`, renders the capitalized chip, includes seeded tool icons, includes seeded context status/`ctx`, includes the open-terminal button, and puts controls in the wrong order.
 
 ## Task 2: Implement Header Parity
 
 **Files:**
 - Modify: `src/components/panes/PaneHeader.tsx`
-- Remove: `src/components/fresh-agent/FreshAgentContextMeter.tsx`
-- Remove: `test/unit/client/components/fresh-agent/FreshAgentContextMeter.test.tsx`
 
 **Interfaces:**
 - Consumes: `PaneHeader` props and existing `metaLabel`/`metaTooltip` formatting.
-- Produces: fresh-agent headers with text sequence `freshcodex freshell (main)  56%` and control sequence settings, refresh, zoom, close.
+- Produces: fresh-agent headers with text sequence `freshcodex freshell (main)  56%`, no leading pane icon, no duplicated `freshell`, and control sequence settings, optional refresh, zoom, close.
 
 - [ ] **Step 1: Remove header-only imports and helpers**
 
@@ -251,13 +323,37 @@ Inside `PaneHeader`, before the `return`, add:
 
 Use this for both terminal and fresh-agent refresh rendering so there is one refresh button definition.
 
-- [ ] **Step 3: Render fresh-agent identity as plain left text**
+- [ ] **Step 3: Derive the visible title once**
 
-Change the left title container to include the fresh-agent identity before the visible title:
+Before `return`, derive whether the pane is a fresh-agent pane and which title text should be visible. Fresh-agent panes use the CLI-style metadata label as their main text so the header does not render both `freshell` and `freshell (main)  56%`:
+
+```tsx
+  const isFreshAgentPane = content.kind === 'fresh-agent'
+  const visibleTitle = isFreshAgentPane ? (metaLabel ?? title) : title
+  const visibleTitleTooltip = isFreshAgentPane ? (metaTooltip || metaLabel || title) : title
+```
+
+- [ ] **Step 4: Render fresh-agent identity as the leftmost visible item**
+
+Suppress the normal leading `PaneIcon` for fresh-agent panes:
+
+```tsx
+      {!isFreshAgentPane ? (
+        <PaneIcon
+          content={content}
+          className={cn(
+            'h-4 w-4 flex-shrink-0',
+            content.kind === 'terminal' ? getTerminalStatusIconClassName(status) : undefined,
+          )}
+        />
+      ) : null}
+```
+
+Change the left title container to include the fresh-agent identity before `visibleTitle`:
 
 ```tsx
       <div className="min-w-0 flex flex-1 items-center gap-1.5">
-        {content.kind === 'fresh-agent' && !isRenaming ? (
+        {isFreshAgentPane && !isRenaming ? (
           <span
             className="shrink-0 text-sm text-muted-foreground"
             title={`${content.sessionType} session`}
@@ -278,19 +374,19 @@ Change the left title container to include the fresh-agent identity before the v
             aria-invalid={renameError ? true : undefined}
           />
         ) : (
-          <span className="block min-w-0 truncate" title={title}>
-            {title}
+          <span className="block min-w-0 truncate" title={visibleTitleTooltip}>
+            {visibleTitle}
           </span>
         )}
       </div>
 ```
 
-- [ ] **Step 4: Render metadata immediately before compact controls**
+- [ ] **Step 5: Keep the right-side metadata span for non-fresh panes only**
 
-Keep the existing metadata span:
+Fresh-agent panes render `metaLabel` in the title area. Keep the existing right-side metadata span for CLI terminal panes and other non-fresh panes only:
 
 ```tsx
-        {metaLabel && (
+        {!isFreshAgentPane && metaLabel && (
           <span
             className="max-w-[18rem] truncate text-xs text-muted-foreground text-right"
             title={metaTooltip || metaLabel}
@@ -302,19 +398,19 @@ Keep the existing metadata span:
 
 Do not render `FreshAgentContextMeter`; the metadata span is the only context display in the header.
 
-- [ ] **Step 5: Render controls in the desired order**
+- [ ] **Step 6: Render controls in the desired order**
 
 For terminal panes, keep the existing order:
 
 ```tsx
         {onSearch && content.kind === 'terminal' && (...)}
-        {content.kind !== 'fresh-agent' ? refreshButton : null}
+        {!isFreshAgentPane ? refreshButton : null}
 ```
 
-For fresh-agent panes, render settings before refresh:
+For fresh-agent panes, render settings before optional refresh:
 
 ```tsx
-        {content.kind === 'fresh-agent' && (
+        {isFreshAgentPane && (
           <FreshAgentSettingsButton
             tabId={tabId}
             paneId={paneId}
@@ -322,18 +418,10 @@ For fresh-agent panes, render settings before refresh:
           />
         )}
 
-        {content.kind === 'fresh-agent' ? refreshButton : null}
+        {isFreshAgentPane ? refreshButton : null}
 ```
 
 Then leave the existing zoom and close buttons after this block.
-
-- [ ] **Step 6: Delete the old context meter files**
-
-Remove:
-
-```bash
-git rm src/components/fresh-agent/FreshAgentContextMeter.tsx test/unit/client/components/fresh-agent/FreshAgentContextMeter.test.tsx
-```
 
 - [ ] **Step 7: Run the focused test**
 
@@ -350,20 +438,34 @@ Expected: PASS.
 Run:
 
 ```bash
-git add src/components/panes/PaneHeader.tsx test/unit/client/components/panes/PaneHeader.test.tsx src/components/fresh-agent/FreshAgentContextMeter.tsx test/unit/client/components/fresh-agent/FreshAgentContextMeter.test.tsx
+git add src/components/panes/PaneHeader.tsx test/unit/client/components/panes/PaneHeader.test.tsx
 git commit -m "fix: align fresh-agent pane headers with cli panes"
 ```
 
 ## Task 3: Integration Coverage And Verification
 
 **Files:**
-- Modify: `test/unit/client/components/panes/PaneContainer.test.tsx` only if the existing refresh/materialization tests fail after the header change.
+- Modify: `test/e2e/pane-header-runtime-meta-flow.test.tsx`
+- Modify: `test/unit/client/components/panes/PaneContainer.test.tsx`
 
 **Interfaces:**
 - Consumes: updated `PaneHeader`.
 - Produces: verified behavior through the existing `PaneContainer` integration path.
 
-- [ ] **Step 1: Run PaneHeader and PaneContainer coverage together**
+- [ ] **Step 1: Extend the runtime metadata flow coverage**
+
+In `test/e2e/pane-header-runtime-meta-flow.test.tsx`, extend the existing fresh-agent metadata test to assert that the lowercase fresh-agent identity is present next to the CLI-style metadata after the indexed metadata update:
+
+```tsx
+expect(screen.getByText('freshclaude')).toBeInTheDocument()
+expect(screen.getByText(/freshell \(main\*\)\s+50%/)).toBeInTheDocument()
+```
+
+- [ ] **Step 2: Add a refresh-unavailable PaneContainer regression**
+
+In `test/unit/client/components/panes/PaneContainer.test.tsx`, add a fresh-agent pane case with no `sessionId` and an inactive status such as `idle` or `create-failed`, then assert `screen.queryByTitle('Refresh pane')` is absent. This protects the `settings, optional refresh, zoom, close` contract through the real PaneContainer wiring.
+
+- [ ] **Step 3: Run PaneHeader and PaneContainer coverage together**
 
 Run:
 
@@ -373,7 +475,7 @@ npm run test:vitest -- --run test/unit/client/components/panes/PaneHeader.test.t
 
 Expected: PASS.
 
-- [ ] **Step 2: Run nearby fresh-agent component tests**
+- [ ] **Step 4: Run nearby fresh-agent component and runtime metadata tests**
 
 Run:
 
@@ -383,7 +485,7 @@ npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentS
 
 Expected: PASS.
 
-- [ ] **Step 3: Run typecheck**
+- [ ] **Step 5: Run typecheck**
 
 Run:
 
@@ -393,7 +495,7 @@ npm run typecheck:client
 
 Expected: PASS with no missing import or deleted-file errors.
 
-- [ ] **Step 4: Run diff hygiene**
+- [ ] **Step 6: Run diff hygiene**
 
 Run:
 
@@ -403,18 +505,53 @@ git diff --check
 
 Expected: no output.
 
-- [ ] **Step 5: Commit verification-only test updates if any**
+- [ ] **Step 7: Commit integration coverage**
 
-If Task 3 required test edits, commit them:
+Commit the e2e metadata assertion and any necessary PaneContainer test adjustment:
 
 ```bash
-git add test/unit/client/components/panes/PaneContainer.test.tsx
+git add test/e2e/pane-header-runtime-meta-flow.test.tsx test/unit/client/components/panes/PaneContainer.test.tsx
 git commit -m "test: cover fresh-agent header parity integration"
 ```
 
-If Task 3 did not require file edits, do not create an empty commit.
+## Task 4: Visual Smoke
 
-## Task 4: Final Verification
+**Files:**
+- No expected file edits.
+
+**Interfaces:**
+- Consumes: built or development UI in the worktree.
+- Produces: visual confirmation that the header looks like the attached CLI-agent reference.
+
+- [ ] **Step 1: Start a worktree-only dev server on a unique port**
+
+Start the server from this worktree, bound to `0.0.0.0`, recording the PID in `/tmp` and without touching the self-hosted Freshell process:
+
+```bash
+NODE_ENV=development PORT=3344 npm run dev > /tmp/freshell-header-parity-3344.log 2>&1 & echo $! > /tmp/freshell-header-parity-3344.pid
+```
+
+If port `3344` is in use, choose another unique port and keep the PID/log filenames aligned.
+
+- [ ] **Step 2: Inspect desktop and narrow layouts**
+
+Use the browser or Playwright against the worktree dev server to inspect one CLI pane and one fresh-agent pane. Confirm:
+
+- CLI pane still reads like `freshell (main) 56%` followed by search, refresh, zoom, close.
+- Fresh-agent pane reads like `freshcodex freshell (main) 56%` followed by settings, optional refresh, zoom, close.
+- There is no leading pane icon before `freshcodex`, no open-terminal control, no `ctx` text, and no obvious text/control overlap at desktop or narrow width.
+
+- [ ] **Step 3: Stop only the recorded worktree server PID**
+
+Before stopping, verify the PID belongs to this worktree:
+
+```bash
+ps -fp "$(cat /tmp/freshell-header-parity-3344.pid)"
+kill "$(cat /tmp/freshell-header-parity-3344.pid)"
+rm -f /tmp/freshell-header-parity-3344.pid
+```
+
+## Task 5: Final Verification
 
 **Files:**
 - No expected file edits.

--- a/docs/superpowers/plans/2026-06-29-freshagent-header-parity.md
+++ b/docs/superpowers/plans/2026-06-29-freshagent-header-parity.md
@@ -102,7 +102,7 @@ it('renders fresh-agent identity as the leftmost visible header item before CLI-
 
   const banner = screen.getByRole('banner', { name: 'Pane: freshell' })
   const identity = screen.getByText('freshcodex')
-  const metadata = screen.getByText('freshell (main)  56%')
+  const metadata = screen.getByText(/freshell \(main\)\s+56%/)
 
   expect(banner).toContainElement(identity)
   expect(banner).toContainElement(metadata)

--- a/docs/superpowers/plans/2026-06-29-freshagent-header-parity.md
+++ b/docs/superpowers/plans/2026-06-29-freshagent-header-parity.md
@@ -1,0 +1,453 @@
+# Fresh-Agent Header Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every fresh-agent pane header match coding CLI pane header structure: lowercase fresh-agent identity first, cwd/branch/context text formatted like CLI panes, then compact controls in a stable order, with no open-terminal control and no separate `ctx` meter.
+
+**Architecture:** Keep runtime metadata resolution in `PaneContainer` and render all header chrome in `PaneHeader`. Fresh-agent headers use the same `metaLabel` produced by `formatPaneRuntimeLabel()` as CLI panes; `FreshAgentContextMeter` and fresh-agent tool icons are removed from the pane header so no second context display or tool-icon strip competes with the CLI-style header. The fresh-agent settings gear stays because it is the only pane-local style/model control, but it is ordered with the normal header controls.
+
+**Tech Stack:** React 18, Redux Toolkit selectors, Vitest + Testing Library, existing lucide icon system.
+
+## Global Constraints
+
+- The visual target is the attached CLI-agent header: text like `freshell (main) 56%`, then compact controls.
+- For fresh agents, prepend the lowercase session type such as `freshcodex` as the leftmost text item.
+- Context formatting must reuse the CLI runtime metadata format and must not show `ctx`.
+- Remove the fresh-agent open-terminal header button.
+- Apply to all fresh-agent types: `freshclaude`, `freshcodex`, `freshopencode`, and `kilroy`.
+- Preserve the fresh-agent settings gear because pane-local model/style controls still need an access point.
+- Keep control ordering stable: settings gear, refresh, zoom, close for fresh-agent panes; existing terminal search/refresh/zoom/close order stays unchanged.
+- Do not restart the self-hosted Freshell server.
+- Use focused tests first, then coordinated full-suite verification before completion.
+
+---
+
+## File Structure
+
+- Modify `src/components/panes/PaneHeader.tsx`
+  - Owns header layout for all pane kinds.
+  - Add fresh-agent left label rendering from `content.sessionType`.
+  - Remove `FreshAgentToolIcons`, `FreshAgentContextMeter`, and `FreshAgentOpenTerminalButton` from the header.
+  - Reorder fresh-agent controls so the settings gear appears before refresh, then zoom, then close.
+- Modify `test/unit/client/components/panes/PaneHeader.test.tsx`
+  - Adds regression coverage for fresh-agent text order, no open-terminal button, no separate context meter, and control order.
+  - Keeps existing CLI metadata formatter tests.
+- Remove `src/components/fresh-agent/FreshAgentContextMeter.tsx`
+  - The component exists only for the header-specific meter that is no longer part of the desired design.
+- Remove `test/unit/client/components/fresh-agent/FreshAgentContextMeter.test.tsx`
+  - Remove stale coverage for the deleted meter.
+- No `docs/index.html` change
+  - This is a pane-header consistency fix, not a new user-facing feature or major static mock change.
+
+## Task 1: Fresh-Agent Header Contract Tests
+
+**Files:**
+- Modify: `test/unit/client/components/panes/PaneHeader.test.tsx`
+
+**Interfaces:**
+- Consumes: `PaneHeader` props `content`, `metaLabel`, `metaTooltip`, `onRefresh`, `onToggleZoom`, and `onClose`.
+- Produces: failing tests that define the desired header contract before implementation.
+
+- [ ] **Step 1: Update test mocks**
+
+Add an accessible settings-button stub so action order can be tested by role:
+
+```tsx
+vi.mock('@/components/fresh-agent/FreshAgentSettingsButton', () => ({
+  default: () => (
+    <button type="button" aria-label="Agent settings" title="Agent settings" data-testid="settings-button-stub" />
+  ),
+}))
+```
+
+Remove the `SquareTerminal` lucide mock from this file after the implementation removes the open-terminal button.
+
+- [ ] **Step 2: Add failing fresh-agent parity tests**
+
+Add these tests inside `describe('PaneHeader', () => { describe('rendering', () => { ... }) })`:
+
+```tsx
+it('renders fresh-agent identity as the leftmost header text before CLI-style metadata', () => {
+  render(
+    <Provider store={makeFreshAgentStore()}>
+      <PaneHeader
+        tabId="tab-1"
+        paneId="pane-1"
+        title="freshell"
+        metaLabel="freshell (main)  56%"
+        metaTooltip="Directory: /home/dan/code/freshell"
+        status="running"
+        isActive={true}
+        onClose={vi.fn()}
+        onRefresh={vi.fn()}
+        onToggleZoom={vi.fn()}
+        content={{
+          kind: 'fresh-agent',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+          sessionId: 'fresh-session-1',
+          createRequestId: 'fresh-req-1',
+          status: 'idle',
+        }}
+      />
+    </Provider>,
+  )
+
+  const banner = screen.getByRole('banner', { name: 'Pane: freshell' })
+  const identity = screen.getByText('freshcodex')
+  const metadata = screen.getByText('freshell (main)  56%')
+
+  expect(banner).toContainElement(identity)
+  expect(banner).toContainElement(metadata)
+  expect(
+    identity.compareDocumentPosition(metadata) & Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy()
+})
+
+it.each([
+  ['freshclaude', 'claude'],
+  ['freshcodex', 'codex'],
+  ['freshopencode', 'opencode'],
+  ['kilroy', 'claude'],
+] as const)('renders %s as the fresh-agent header identity', (sessionType, provider) => {
+  render(
+    <Provider store={makeFreshAgentStore()}>
+      <PaneHeader
+        tabId="tab-1"
+        paneId="pane-1"
+        title="freshell"
+        metaLabel="freshell (main)  56%"
+        status="running"
+        isActive={true}
+        onClose={vi.fn()}
+        content={{
+          kind: 'fresh-agent',
+          sessionType,
+          provider,
+          sessionId: `${sessionType}-session`,
+          createRequestId: `${sessionType}-req`,
+          status: 'idle',
+        }}
+      />
+    </Provider>,
+  )
+
+  expect(screen.getByText(sessionType)).toBeInTheDocument()
+})
+
+it('renders fresh-agent controls in settings refresh zoom close order without open-terminal or context-meter controls', () => {
+  render(
+    <Provider store={makeFreshAgentStore()}>
+      <PaneHeader
+        tabId="tab-1"
+        paneId="pane-1"
+        title="freshell"
+        metaLabel="freshell (main)  56%"
+        status="running"
+        isActive={true}
+        onClose={vi.fn()}
+        onRefresh={vi.fn()}
+        onToggleZoom={vi.fn()}
+        content={{
+          kind: 'fresh-agent',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+          sessionId: 'fresh-session-1',
+          createRequestId: 'fresh-req-1',
+          status: 'idle',
+        }}
+      />
+    </Provider>,
+  )
+
+  const actionLabels = screen.getAllByRole('button').map((button) => button.getAttribute('aria-label') || button.getAttribute('title'))
+
+  expect(actionLabels).toEqual([
+    'Agent settings',
+    'Refresh pane',
+    'Maximize pane',
+    'Close pane',
+  ])
+  expect(screen.queryByLabelText('Open terminal at session directory')).toBeNull()
+  expect(screen.queryByRole('status', { name: /context/i })).toBeNull()
+})
+```
+
+- [ ] **Step 3: Add the store helper used by these tests**
+
+Add this helper near the existing helper functions:
+
+```tsx
+function makeFreshAgentStore() {
+  return configureStore({
+    reducer: { freshAgent: freshAgentReducer },
+  })
+}
+```
+
+- [ ] **Step 4: Run the failing test**
+
+Run:
+
+```bash
+npm run test:vitest -- --run test/unit/client/components/panes/PaneHeader.test.tsx -t "fresh-agent"
+```
+
+Expected: FAIL because the current header still renders the capitalized chip, tool icons, open-terminal button, and context meter before the desired control order.
+
+## Task 2: Implement Header Parity
+
+**Files:**
+- Modify: `src/components/panes/PaneHeader.tsx`
+- Remove: `src/components/fresh-agent/FreshAgentContextMeter.tsx`
+- Remove: `test/unit/client/components/fresh-agent/FreshAgentContextMeter.test.tsx`
+
+**Interfaces:**
+- Consumes: `PaneHeader` props and existing `metaLabel`/`metaTooltip` formatting.
+- Produces: fresh-agent headers with text sequence `freshcodex freshell (main)  56%` and control sequence settings, refresh, zoom, close.
+
+- [ ] **Step 1: Remove header-only imports and helpers**
+
+In `src/components/panes/PaneHeader.tsx`, remove:
+
+```tsx
+import { X, Maximize2, Minimize2, Search, RefreshCw, SquareTerminal, Terminal, FileSearch, Globe, FilePen, FileText } from 'lucide-react'
+import { useAppDispatch, useAppSelector } from '@/store/hooks'
+import { splitPane } from '@/store/panesSlice'
+import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
+import FreshAgentContextMeter from '@/components/fresh-agent/FreshAgentContextMeter'
+import { getFreshAgentLabel } from '@/lib/fresh-agent-registry'
+```
+
+Replace the lucide import with:
+
+```tsx
+import { X, Maximize2, Minimize2, Search, RefreshCw } from 'lucide-react'
+```
+
+Delete the hooks import entirely; `PaneHeader` should not read or write Redux state after the header-only helper removals.
+
+Delete the `FRESH_AGENT_TOOL_ICONS`, `FreshAgentToolIcons`, and `FreshAgentOpenTerminalButton` definitions.
+
+- [ ] **Step 2: Add a small action button helper**
+
+Inside `PaneHeader`, before the `return`, add:
+
+```tsx
+  const refreshButton = onRefresh ? (
+    <button
+      onClick={(e) => {
+        e.stopPropagation()
+        onRefresh()
+      }}
+      className="inline-flex h-6 w-6 items-center justify-center rounded opacity-60 hover:opacity-100 transition-opacity sm:h-4 sm:w-4"
+      title="Refresh pane"
+      aria-label="Refresh pane"
+    >
+      <RefreshCw className="h-[18px] w-[18px] sm:h-3 sm:w-3" />
+    </button>
+  ) : null
+```
+
+Use this for both terminal and fresh-agent refresh rendering so there is one refresh button definition.
+
+- [ ] **Step 3: Render fresh-agent identity as plain left text**
+
+Change the left title container to include the fresh-agent identity before the visible title:
+
+```tsx
+      <div className="min-w-0 flex flex-1 items-center gap-1.5">
+        {content.kind === 'fresh-agent' && !isRenaming ? (
+          <span
+            className="shrink-0 text-sm text-muted-foreground"
+            title={`${content.sessionType} session`}
+          >
+            {content.sessionType}
+          </span>
+        ) : null}
+        {isRenaming ? (
+          <input
+            ref={inputRef}
+            className="bg-transparent outline-none w-full min-w-0 text-sm"
+            value={renameValue ?? ''}
+            onChange={(e) => onRenameChange?.(e.target.value)}
+            onBlur={onRenameBlur}
+            onKeyDown={onRenameKeyDown}
+            onClick={(e) => e.stopPropagation()}
+            aria-label="Rename pane"
+            aria-invalid={renameError ? true : undefined}
+          />
+        ) : (
+          <span className="block min-w-0 truncate" title={title}>
+            {title}
+          </span>
+        )}
+      </div>
+```
+
+- [ ] **Step 4: Render metadata immediately before compact controls**
+
+Keep the existing metadata span:
+
+```tsx
+        {metaLabel && (
+          <span
+            className="max-w-[18rem] truncate text-xs text-muted-foreground text-right"
+            title={metaTooltip || metaLabel}
+          >
+            {metaLabel}
+          </span>
+        )}
+```
+
+Do not render `FreshAgentContextMeter`; the metadata span is the only context display in the header.
+
+- [ ] **Step 5: Render controls in the desired order**
+
+For terminal panes, keep the existing order:
+
+```tsx
+        {onSearch && content.kind === 'terminal' && (...)}
+        {content.kind !== 'fresh-agent' ? refreshButton : null}
+```
+
+For fresh-agent panes, render settings before refresh:
+
+```tsx
+        {content.kind === 'fresh-agent' && (
+          <FreshAgentSettingsButton
+            tabId={tabId}
+            paneId={paneId}
+            paneContent={content}
+          />
+        )}
+
+        {content.kind === 'fresh-agent' ? refreshButton : null}
+```
+
+Then leave the existing zoom and close buttons after this block.
+
+- [ ] **Step 6: Delete the old context meter files**
+
+Remove:
+
+```bash
+git rm src/components/fresh-agent/FreshAgentContextMeter.tsx test/unit/client/components/fresh-agent/FreshAgentContextMeter.test.tsx
+```
+
+- [ ] **Step 7: Run the focused test**
+
+Run:
+
+```bash
+npm run test:vitest -- --run test/unit/client/components/panes/PaneHeader.test.tsx -t "fresh-agent"
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 2**
+
+Run:
+
+```bash
+git add src/components/panes/PaneHeader.tsx test/unit/client/components/panes/PaneHeader.test.tsx src/components/fresh-agent/FreshAgentContextMeter.tsx test/unit/client/components/fresh-agent/FreshAgentContextMeter.test.tsx
+git commit -m "fix: align fresh-agent pane headers with cli panes"
+```
+
+## Task 3: Integration Coverage And Verification
+
+**Files:**
+- Modify: `test/unit/client/components/panes/PaneContainer.test.tsx` only if the existing refresh/materialization tests fail after the header change.
+
+**Interfaces:**
+- Consumes: updated `PaneHeader`.
+- Produces: verified behavior through the existing `PaneContainer` integration path.
+
+- [ ] **Step 1: Run PaneHeader and PaneContainer coverage together**
+
+Run:
+
+```bash
+npm run test:vitest -- --run test/unit/client/components/panes/PaneHeader.test.tsx test/unit/client/components/panes/PaneContainer.test.tsx -t "fresh-agent|refresh button"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run nearby fresh-agent component tests**
+
+Run:
+
+```bash
+npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentSettingsButton.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.test.tsx test/e2e/pane-header-runtime-meta-flow.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run typecheck**
+
+Run:
+
+```bash
+npm run typecheck:client
+```
+
+Expected: PASS with no missing import or deleted-file errors.
+
+- [ ] **Step 4: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit verification-only test updates if any**
+
+If Task 3 required test edits, commit them:
+
+```bash
+git add test/unit/client/components/panes/PaneContainer.test.tsx
+git commit -m "test: cover fresh-agent header parity integration"
+```
+
+If Task 3 did not require file edits, do not create an empty commit.
+
+## Task 4: Final Verification
+
+**Files:**
+- No expected file edits.
+
+**Interfaces:**
+- Consumes: all committed implementation work.
+- Produces: final verification evidence for PR readiness.
+
+- [ ] **Step 1: Run coordinated check**
+
+Run:
+
+```bash
+FRESHELL_TEST_SUMMARY='fresh-agent header parity' npm run check
+```
+
+Expected: client, server, and Electron suites pass.
+
+- [ ] **Step 2: Confirm branch state**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -5
+```
+
+Expected: branch is clean, ahead of `main`, with the plan commit and implementation commit(s).
+
+## Self-Review
+
+**Spec coverage:** The plan covers the attached CLI-style shape, leftmost lowercase fresh-agent identity, all fresh-agent session types, context percent formatting through `formatPaneRuntimeLabel()`, removal of the open-terminal control, and focused + broad verification.
+
+**Placeholder scan:** No `TBD`, `TODO`, `implement later`, or unspecified tests remain.
+
+**Type consistency:** The plan uses existing `PaneHeader` prop names and existing fresh-agent content fields: `sessionType`, `provider`, `sessionId`, `createRequestId`, and `status`.

--- a/src/components/panes/PaneHeader.tsx
+++ b/src/components/panes/PaneHeader.tsx
@@ -106,7 +106,10 @@ export default function PaneHeader({
       <div className="min-w-0 flex flex-1 items-center gap-1.5">
         {isFreshAgentPane && !isRenaming ? (
           <span
-            className="shrink-0 text-sm text-muted-foreground"
+            className={cn(
+              'shrink-0 text-sm',
+              busy && status === 'running' ? 'text-blue-500' : 'text-muted-foreground',
+            )}
             title={`${content.sessionType} session`}
           >
             {content.sessionType}

--- a/src/components/panes/PaneHeader.tsx
+++ b/src/components/panes/PaneHeader.tsx
@@ -1,16 +1,11 @@
 import { useRef, useEffect } from 'react'
-import { X, Maximize2, Minimize2, Search, RefreshCw, SquareTerminal, Terminal, FileSearch, Globe, FilePen, FileText } from 'lucide-react'
+import { X, Maximize2, Minimize2, Search, RefreshCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { getTerminalStatusIconClassName } from '@/lib/terminal-status-indicator'
 import type { TerminalStatus } from '@/store/types'
 import type { PaneContent } from '@/store/paneTypes'
-import { useAppDispatch, useAppSelector } from '@/store/hooks'
-import { splitPane } from '@/store/panesSlice'
-import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
 import PaneIcon from '@/components/icons/PaneIcon'
 import FreshAgentSettingsButton from '@/components/fresh-agent/FreshAgentSettingsButton'
-import FreshAgentContextMeter from '@/components/fresh-agent/FreshAgentContextMeter'
-import { getFreshAgentLabel } from '@/lib/fresh-agent-registry'
 
 interface PaneHeaderProps {
   tabId?: string
@@ -35,83 +30,6 @@ interface PaneHeaderProps {
   onDoubleClick?: () => void
   onSearch?: () => void
   onRefresh?: () => void
-}
-
-const FRESH_AGENT_TOOL_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
-  Bash: Terminal,
-  Read: FileText,
-  Write: FilePen,
-  Edit: FilePen,
-  Glob: FileSearch,
-  Grep: FileSearch,
-  WebFetch: Globe,
-  WebSearch: Globe,
-}
-
-function FreshAgentToolIcons({
-  content,
-}: {
-  content: Extract<PaneContent, { kind: 'fresh-agent' }>
-}) {
-  const sessionKey = content.sessionId ? makeFreshAgentSessionKey({
-    sessionId: content.sessionId,
-    sessionType: content.sessionType,
-    provider: content.provider,
-  }) : undefined
-  const tools = useAppSelector((state) =>
-    sessionKey ? state.freshAgent?.sessions?.[sessionKey]?.tools : undefined,
-  )
-
-  if (!tools?.length) return null
-
-  return (
-    <span className="inline-flex shrink-0 items-center gap-0.5 text-muted-foreground/60" title={tools.map((t) => t.name).join(', ')}>
-      {tools.map((tool) => {
-        const Icon = FRESH_AGENT_TOOL_ICONS[tool.name]
-        if (!Icon) return null
-        return <Icon key={tool.name} className="h-3 w-3" aria-label={tool.name} />
-      })}
-    </span>
-  )
-}
-
-function FreshAgentOpenTerminalButton({
-  tabId,
-  paneId,
-  content,
-}: {
-  tabId: string
-  paneId: string
-  content: Extract<PaneContent, { kind: 'fresh-agent' }>
-}) {
-  const dispatch = useAppDispatch()
-
-  return (
-    <button
-      onClick={(e) => {
-        e.stopPropagation()
-        // normalizePaneContent fills createRequestId/status for terminal
-        // inputs; mode 'shell' + cwd is a complete input.
-        dispatch(splitPane({
-          tabId,
-          paneId,
-          direction: 'horizontal',
-          newContent: {
-            kind: 'terminal',
-            mode: 'shell',
-            ...(content.initialCwd ? { initialCwd: content.initialCwd } : {}),
-          } as Parameters<typeof splitPane>[0]['newContent'],
-        }))
-      }}
-      className="inline-flex h-6 w-6 items-center justify-center rounded opacity-60 hover:opacity-100 transition-opacity sm:h-4 sm:w-4"
-      title={content.initialCwd
-        ? `Open terminal pane at ${content.initialCwd}`
-        : 'Open terminal pane at this session’s directory'}
-      aria-label="Open terminal at session directory"
-    >
-      <SquareTerminal className="h-[18px] w-[18px] sm:h-3 sm:w-3" />
-    </button>
-  )
 }
 
 export default function PaneHeader({
@@ -139,6 +57,22 @@ export default function PaneHeader({
   onRefresh,
 }: PaneHeaderProps) {
   const inputRef = useRef<HTMLInputElement>(null)
+  const isFreshAgentPane = content.kind === 'fresh-agent'
+  const visibleTitle = isFreshAgentPane ? (metaLabel ?? title) : title
+  const visibleTitleTooltip = isFreshAgentPane ? (metaTooltip || metaLabel || title) : title
+  const refreshButton = onRefresh ? (
+    <button
+      onClick={(e) => {
+        e.stopPropagation()
+        onRefresh()
+      }}
+      className="inline-flex h-6 w-6 items-center justify-center rounded opacity-60 hover:opacity-100 transition-opacity sm:h-4 sm:w-4"
+      title="Refresh pane"
+      aria-label="Refresh pane"
+    >
+      <RefreshCw className="h-[18px] w-[18px] sm:h-3 sm:w-3" />
+    </button>
+  ) : null
 
   useEffect(() => {
     if (isRenaming && inputRef.current) {
@@ -159,15 +93,25 @@ export default function PaneHeader({
       role="banner"
       aria-label={`Pane: ${title}`}
     >
-      <PaneIcon
-        content={content}
-        className={cn(
-          'h-3.5 w-3.5 shrink-0',
-          busy && status === 'running' ? 'text-blue-500' : getTerminalStatusIconClassName(status),
-        )}
-      />
+      {!isFreshAgentPane ? (
+        <PaneIcon
+          content={content}
+          className={cn(
+            'h-3.5 w-3.5 shrink-0',
+            busy && status === 'running' ? 'text-blue-500' : getTerminalStatusIconClassName(status),
+          )}
+        />
+      ) : null}
 
-      <div className="min-w-0 flex-1">
+      <div className="min-w-0 flex flex-1 items-center gap-1.5">
+        {isFreshAgentPane && !isRenaming ? (
+          <span
+            className="shrink-0 text-sm text-muted-foreground"
+            title={`${content.sessionType} session`}
+          >
+            {content.sessionType}
+          </span>
+        ) : null}
         {isRenaming ? (
           <input
             ref={inputRef}
@@ -181,14 +125,14 @@ export default function PaneHeader({
             aria-invalid={renameError ? true : undefined}
           />
         ) : (
-          <span className="block truncate" title={title}>
-            {title}
+          <span className="block min-w-0 truncate" title={visibleTitleTooltip}>
+            {visibleTitle}
           </span>
         )}
       </div>
 
       <div className="ml-auto flex h-full items-center gap-2">
-        {metaLabel && (
+        {!isFreshAgentPane && metaLabel && (
           <span
             className="max-w-[18rem] truncate text-xs text-muted-foreground text-right"
             title={metaTooltip || metaLabel}
@@ -211,42 +155,17 @@ export default function PaneHeader({
           </button>
         )}
 
-        {onRefresh && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              onRefresh()
-            }}
-            className="inline-flex h-6 w-6 items-center justify-center rounded opacity-60 hover:opacity-100 transition-opacity sm:h-4 sm:w-4"
-            title="Refresh pane"
-            aria-label="Refresh pane"
-          >
-            <RefreshCw className="h-[18px] w-[18px] sm:h-3 sm:w-3" />
-          </button>
-        )}
+        {!isFreshAgentPane ? refreshButton : null}
 
-        {content.kind === 'fresh-agent' && (
-          <>
-            <FreshAgentToolIcons content={content} />
-            {/* Cwd/prompt-derived titles make the three fresh clients look
-                identical — pin the agent identity in the header. */}
-            <span
-              className="shrink-0 rounded-full border border-border/70 px-2 py-0.5 text-2xs text-muted-foreground"
-              title={`${getFreshAgentLabel(content.sessionType)} session`}
-            >
-              {getFreshAgentLabel(content.sessionType)}
-            </span>
-            <FreshAgentContextMeter paneContent={content} />
-            {tabId && paneId ? (
-              <FreshAgentOpenTerminalButton tabId={tabId} paneId={paneId} content={content} />
-            ) : null}
-            <FreshAgentSettingsButton
-              tabId={tabId}
-              paneId={paneId}
-              paneContent={content}
-            />
-          </>
-        )}
+        {isFreshAgentPane ? (
+          <FreshAgentSettingsButton
+            tabId={tabId}
+            paneId={paneId}
+            paneContent={content}
+          />
+        ) : null}
+
+        {isFreshAgentPane ? refreshButton : null}
 
         {onToggleZoom && (
           <button
@@ -272,6 +191,7 @@ export default function PaneHeader({
           }}
           className="inline-flex h-6 w-6 items-center justify-center rounded opacity-60 hover:opacity-100 hover:bg-background/50 transition-opacity sm:h-4 sm:w-4"
           title="Close pane"
+          aria-label="Close pane"
         >
           <X className="h-[18px] w-[18px] sm:h-3 sm:w-3" />
         </button>

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -44,8 +44,9 @@ async function suppressFreshAgentNetworkForActivePane(page: any) {
 }
 
 async function openFreshAgentSettings(page: any, providerName: string) {
+  const headerIdentity = providerName.toLowerCase()
   const pane = page.getByRole('group').filter({
-    has: page.getByText(providerName, { exact: true }),
+    has: page.getByText(headerIdentity, { exact: true }),
   }).last()
   await expect(pane).toBeVisible({ timeout: 10_000 })
 
@@ -890,7 +891,7 @@ test.describe('Fresh Agent', () => {
     await page.getByRole('button', { name: /^Freshcodex$/i }).click()
     await page.getByRole('option').first().click()
     await expect(page.locator('[data-context="fresh-agent"]').last()).toBeVisible()
-    await expect(page.getByText('Freshcodex', { exact: true })).toBeVisible()
+    await expect(page.getByText('freshcodex', { exact: true })).toBeVisible()
 
     await page.evaluate(({ currentTabId, currentPaneId }) => {
       window.__FRESHELL_TEST_HARNESS__?.dispatch({
@@ -915,7 +916,7 @@ test.describe('Fresh Agent', () => {
       currentPaneId: activePaneId,
     })
 
-    await expect(page.getByText('Freshcodex session')).toBeVisible()
+    await expect(page.getByText('Codex transcript')).toBeVisible()
     await expect(page.getByText(/feature\/fresh-agent/)).toBeVisible()
     await expect(page.getByText('README.md')).toBeVisible()
     await expect(page.getByText('review-1')).toBeVisible()
@@ -928,7 +929,7 @@ test.describe('Fresh Agent', () => {
     await page.goto(`${serverInfo.baseUrl}/?token=${serverInfo.token}&e2e=1`)
     await harness.waitForHarness()
     await harness.waitForConnection()
-    await expect(page.getByText('Freshcodex session')).toBeVisible()
+    await expect(page.getByText('Codex transcript')).toBeVisible()
     await expect(page.getByText(/feature\/fresh-agent/)).toBeVisible()
   })
 })

--- a/test/e2e/pane-activity-indicator-flow.test.tsx
+++ b/test/e2e/pane-activity-indicator-flow.test.tsx
@@ -245,6 +245,16 @@ function getVisibleSinglePaneTab() {
   return tab
 }
 
+function expectFreshAgentHeaderBusy(paneHeader: HTMLElement, expectedBusy: boolean) {
+  const identity = within(paneHeader).getByText('freshclaude')
+  const className = identity.getAttribute('class') ?? ''
+  if (expectedBusy) {
+    expect(className).toContain('text-blue-500')
+  } else {
+    expect(className).not.toContain('text-blue-500')
+  }
+}
+
 describe('pane activity indicator flow (e2e)', () => {
   afterEach(() => {
     cleanup()
@@ -321,7 +331,7 @@ describe('pane activity indicator flow (e2e)', () => {
     })
 
     const paneHeader = screen.getByRole('banner', { name: 'Pane: Activity Pane' })
-    expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+    expectFreshAgentHeaderBusy(paneHeader, false)
     expect(within(getVisibleSinglePaneTab()).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
 
     act(() => {
@@ -333,7 +343,7 @@ describe('pane activity indicator flow (e2e)', () => {
       }))
     })
 
-    expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class')).toContain('text-blue-500')
+    expectFreshAgentHeaderBusy(paneHeader, true)
     expect(within(getVisibleSinglePaneTab()).getByTestId('pane-icon').getAttribute('class')).toContain('text-blue-500')
   })
 
@@ -531,7 +541,7 @@ describe('pane activity indicator flow (e2e)', () => {
     })
 
     const paneHeader = screen.getByRole('banner', { name: 'Pane: Activity Pane' })
-    expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
+    expectFreshAgentHeaderBusy(paneHeader, false)
     expect(within(getVisibleSinglePaneTab()).getByTestId('pane-icon').getAttribute('class') ?? '').not.toContain('text-blue-500')
 
     act(() => {
@@ -543,7 +553,7 @@ describe('pane activity indicator flow (e2e)', () => {
       }))
     })
 
-    expect(within(paneHeader).getByTestId('pane-icon').getAttribute('class')).toContain('text-blue-500')
+    expectFreshAgentHeaderBusy(paneHeader, true)
     expect(within(getVisibleSinglePaneTab()).getByTestId('pane-icon').getAttribute('class')).toContain('text-blue-500')
   })
 

--- a/test/e2e/pane-header-runtime-meta-flow.test.tsx
+++ b/test/e2e/pane-header-runtime-meta-flow.test.tsx
@@ -810,6 +810,7 @@ describe('pane header runtime metadata flow (e2e)', () => {
     })
 
     await waitFor(() => {
+      expect(screen.getByText('freshclaude')).toBeInTheDocument()
       expect(screen.getByText(/freshell \(main\*\)\s+50%/)).toBeInTheDocument()
     })
   })

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -2749,7 +2749,7 @@ describe('PaneContainer', () => {
         store,
       )
 
-      expect(screen.getByTitle('Kilroy session')).toHaveTextContent('Kilroy')
+      expect(screen.getByTitle('kilroy session')).toHaveTextContent('kilroy')
       expect(screen.getByText(/freshell \(main\)\s+25%/)).toBeInTheDocument()
     })
 
@@ -3098,6 +3098,32 @@ describe('PaneContainer', () => {
       )
 
       expect(screen.getByTitle('Refresh pane')).toBeInTheDocument()
+    })
+
+    it('does not render refresh button for fresh-agent pane without a session id', () => {
+      const node: PaneNode = {
+        type: 'leaf',
+        id: 'pane-1',
+        content: {
+          kind: 'fresh-agent',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+          createRequestId: 'fresh-req-1',
+          status: 'idle',
+        },
+      }
+
+      const store = createStore({
+        layouts: { 'tab-1': node },
+        activePane: { 'tab-1': 'pane-1' },
+      })
+
+      renderWithStore(
+        <PaneContainer tabId="tab-1" node={node} />,
+        store,
+      )
+
+      expect(screen.queryByTitle('Refresh pane')).toBeNull()
     })
 
     it('clicking refresh button dispatches requestPaneRefresh to Redux store', () => {

--- a/test/unit/client/components/panes/PaneHeader.test.tsx
+++ b/test/unit/client/components/panes/PaneHeader.test.tsx
@@ -3,8 +3,9 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import PaneHeader from '@/components/panes/PaneHeader'
-import freshAgentReducer, { sessionInit } from '@/store/freshAgentSlice'
+import freshAgentReducer, { freshAgentSnapshotReceived, sessionInit } from '@/store/freshAgentSlice'
 import { formatPaneRuntimeLabel, formatPaneRuntimeTooltip } from '@/lib/format-terminal-title-meta'
+import type { FreshAgentSnapshot } from '@shared/fresh-agent-contract'
 
 vi.mock('lucide-react', () => ({
   X: ({ className }: { className?: string }) => (
@@ -52,22 +53,51 @@ vi.mock('@/components/icons/PaneIcon', () => ({
 }))
 
 vi.mock('@/components/fresh-agent/FreshAgentSettingsButton', () => ({
-  default: () => <button data-testid="settings-button-stub" />,
+  default: () => (
+    <button type="button" aria-label="Agent settings" title="Agent settings" data-testid="settings-button-stub" />
+  ),
 }))
 
 function makeTerminalContent(mode = 'shell') {
   return { kind: 'terminal' as const, mode, shell: 'system' as const, createRequestId: 'r1', status: 'running' as const }
 }
 
-function makeFreshAgentContent(sessionId = 'thread-1') {
+function makeFreshAgentStore() {
+  return configureStore({
+    reducer: { freshAgent: freshAgentReducer },
+  })
+}
+
+function makeFreshAgentSnapshot(
+  overrides: Partial<FreshAgentSnapshot> & {
+    threadId: string
+    sessionType: FreshAgentSnapshot['sessionType']
+    provider: FreshAgentSnapshot['provider']
+    tokenUsage: FreshAgentSnapshot['tokenUsage']
+  },
+): FreshAgentSnapshot {
   return {
-    kind: 'fresh-agent' as const,
-    sessionType: 'freshclaude' as const,
-    provider: 'claude' as const,
-    sessionId,
-    createRequestId: 'req-1',
-    status: 'idle' as const,
-  }
+    threadId: overrides.threadId,
+    sessionType: overrides.sessionType,
+    provider: overrides.provider,
+    revision: overrides.revision ?? 1,
+    status: overrides.status ?? 'idle',
+    capabilities: overrides.capabilities ?? {
+      send: true,
+      interrupt: true,
+      approvals: true,
+      questions: true,
+      fork: false,
+    },
+    tokenUsage: overrides.tokenUsage,
+    pendingApprovals: overrides.pendingApprovals ?? [],
+    pendingQuestions: overrides.pendingQuestions ?? [],
+    worktrees: overrides.worktrees ?? [],
+    diffs: overrides.diffs ?? [],
+    childThreads: overrides.childThreads ?? [],
+    turns: overrides.turns ?? [],
+    extensions: overrides.extensions ?? {},
+  } as FreshAgentSnapshot
 }
 
 describe('PaneHeader', () => {
@@ -139,6 +169,181 @@ describe('PaneHeader', () => {
       ).toBeInTheDocument()
       expect(screen.getByTitle('Maximize pane')).toBeInTheDocument()
       expect(screen.getByTitle('Close pane')).toBeInTheDocument()
+    })
+
+    it('renders fresh-agent identity as the leftmost visible header item before CLI-style metadata', () => {
+      render(
+        <Provider store={makeFreshAgentStore()}>
+          <PaneHeader
+            tabId="tab-1"
+            paneId="pane-1"
+            title="freshell"
+            metaLabel="freshell (main)  56%"
+            metaTooltip="Directory: /home/dan/code/freshell"
+            status="running"
+            isActive={true}
+            onClose={vi.fn()}
+            onRefresh={vi.fn()}
+            onToggleZoom={vi.fn()}
+            content={{
+              kind: 'fresh-agent',
+              sessionType: 'freshcodex',
+              provider: 'codex',
+              sessionId: 'fresh-session-1',
+              createRequestId: 'fresh-req-1',
+              status: 'idle',
+            }}
+          />
+        </Provider>,
+      )
+
+      const banner = screen.getByRole('banner', { name: 'Pane: freshell' })
+      const identity = screen.getByText('freshcodex')
+      const metadata = screen.getByText(/freshell \(main\)\s+56%/)
+
+      expect(banner).toContainElement(identity)
+      expect(banner).toContainElement(metadata)
+      expect(screen.queryByTestId('pane-icon')).toBeNull()
+      expect(screen.getAllByText(/freshell/)).toHaveLength(1)
+      expect(
+        identity.compareDocumentPosition(metadata) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy()
+    })
+
+    it.each([
+      ['freshclaude', 'claude'],
+      ['freshcodex', 'codex'],
+      ['freshopencode', 'opencode'],
+      ['kilroy', 'claude'],
+    ] as const)('renders %s as the fresh-agent header identity', (sessionType, provider) => {
+      render(
+        <Provider store={makeFreshAgentStore()}>
+          <PaneHeader
+            tabId="tab-1"
+            paneId="pane-1"
+            title="freshell"
+            metaLabel="freshell (main)  56%"
+            status="running"
+            isActive={true}
+            onClose={vi.fn()}
+            content={{
+              kind: 'fresh-agent',
+              sessionType,
+              provider,
+              sessionId: `${sessionType}-session`,
+              createRequestId: `${sessionType}-req`,
+              status: 'idle',
+            }}
+          />
+        </Provider>,
+      )
+
+      expect(screen.getByText(sessionType)).toBeInTheDocument()
+    })
+
+    it('renders fresh-agent controls in settings refresh zoom close order without open-terminal or context-meter controls', () => {
+      const store = makeFreshAgentStore()
+      store.dispatch(sessionInit({
+        sessionId: 'fresh-session-1',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        tools: [{ name: 'Bash' }, { name: 'Read' }, { name: 'Glob' }, { name: 'WebFetch' }],
+      }))
+      store.dispatch(freshAgentSnapshotReceived({
+        snapshot: makeFreshAgentSnapshot({
+          threadId: 'fresh-session-1',
+          sessionType: 'freshcodex',
+          provider: 'codex',
+          tokenUsage: {
+            inputTokens: 1200,
+            outputTokens: 300,
+            totalTokens: 1500,
+            contextTokens: 1500,
+            compactPercent: 56,
+          },
+        }),
+      }))
+
+      render(
+        <Provider store={store}>
+          <PaneHeader
+            tabId="tab-1"
+            paneId="pane-1"
+            title="freshell"
+            metaLabel="freshell (main)  56%"
+            status="running"
+            isActive={true}
+            onClose={vi.fn()}
+            onRefresh={vi.fn()}
+            onSearch={vi.fn()}
+            onToggleZoom={vi.fn()}
+            content={{
+              kind: 'fresh-agent',
+              sessionType: 'freshcodex',
+              provider: 'codex',
+              sessionId: 'fresh-session-1',
+              createRequestId: 'fresh-req-1',
+              status: 'idle',
+            }}
+          />
+        </Provider>,
+      )
+
+      const actionLabels = screen.getAllByRole('button').map((button) =>
+        button.getAttribute('aria-label') || button.getAttribute('title'),
+      )
+
+      expect(actionLabels).toEqual([
+        'Agent settings',
+        'Refresh pane',
+        'Maximize pane',
+        'Close pane',
+      ])
+      expect(screen.queryByTitle('Bash, Read, Glob, WebFetch')).toBeNull()
+      expect(screen.queryByTestId('terminal-icon')).toBeNull()
+      expect(screen.queryByTestId('filetext-icon')).toBeNull()
+      expect(screen.queryByTestId('filesearch-icon')).toBeNull()
+      expect(screen.queryByTestId('globe-icon')).toBeNull()
+      expect(screen.queryByTitle('Search in terminal')).toBeNull()
+      expect(screen.queryByLabelText('Open terminal at session directory')).toBeNull()
+      expect(screen.queryByRole('status', { name: /context/i })).toBeNull()
+      expect(screen.queryByText(/ctx/i)).toBeNull()
+    })
+
+    it('omits refresh from the fresh-agent control order when no refresh handler is provided', () => {
+      render(
+        <Provider store={makeFreshAgentStore()}>
+          <PaneHeader
+            tabId="tab-1"
+            paneId="pane-1"
+            title="freshell"
+            metaLabel="freshell (main)"
+            status="running"
+            isActive={true}
+            onClose={vi.fn()}
+            onToggleZoom={vi.fn()}
+            content={{
+              kind: 'fresh-agent',
+              sessionType: 'freshcodex',
+              provider: 'codex',
+              sessionId: 'fresh-session-1',
+              createRequestId: 'fresh-req-1',
+              status: 'idle',
+            }}
+          />
+        </Provider>,
+      )
+
+      const actionLabels = screen.getAllByRole('button').map((button) =>
+        button.getAttribute('aria-label') || button.getAttribute('title'),
+      )
+
+      expect(actionLabels).toEqual([
+        'Agent settings',
+        'Maximize pane',
+        'Close pane',
+      ])
+      expect(screen.queryByText(/ctx/i)).toBeNull()
     })
   })
 
@@ -907,55 +1112,4 @@ describe('PaneHeader', () => {
     })
   })
 
-  describe('fresh-agent tool icons', () => {
-    it('renders an icon for each known tool used by the session', () => {
-      const store = configureStore({
-        reducer: { freshAgent: freshAgentReducer },
-      })
-      store.dispatch(sessionInit({
-        sessionId: 'thread-1',
-        sessionType: 'freshclaude',
-        provider: 'claude',
-        tools: [{ name: 'Bash' }, { name: 'Read' }, { name: 'Glob' }, { name: 'WebFetch' }],
-      }))
-
-      render(
-        <Provider store={store}>
-          <PaneHeader
-            title="Claude"
-            status="idle"
-            isActive={true}
-            onClose={vi.fn()}
-            content={makeFreshAgentContent()}
-          />
-        </Provider>,
-      )
-
-      expect(screen.getByTestId('terminal-icon')).toBeInTheDocument()
-      expect(screen.getByTestId('filetext-icon')).toBeInTheDocument()
-      expect(screen.getByTestId('filesearch-icon')).toBeInTheDocument()
-      expect(screen.getByTestId('globe-icon')).toBeInTheDocument()
-      expect(screen.getByTitle('Bash, Read, Glob, WebFetch')).toBeInTheDocument()
-    })
-
-    it('renders no tool icons when the session has no tools', () => {
-      const store = configureStore({
-        reducer: { freshAgent: freshAgentReducer },
-      })
-
-      const { container } = render(
-        <Provider store={store}>
-          <PaneHeader
-            title="Claude"
-            status="idle"
-            isActive={true}
-            onClose={vi.fn()}
-            content={makeFreshAgentContent()}
-          />
-        </Provider>,
-      )
-
-      expect(container.querySelector('[title="Bash"]')).toBeNull()
-    })
-  })
 })

--- a/test/unit/client/components/panes/PaneHeader.test.tsx
+++ b/test/unit/client/components/panes/PaneHeader.test.tsx
@@ -501,6 +501,32 @@ describe('PaneHeader', () => {
       expect(paneIcon.getAttribute('class')).toContain('text-blue-500')
       expect(paneIcon.getAttribute('class')).not.toContain('animate-pulse')
     })
+
+    it('applies blue text color to the fresh-agent identity when busy is true', () => {
+      render(
+        <Provider store={makeFreshAgentStore()}>
+          <PaneHeader
+            title="freshell"
+            status="running"
+            isActive={true}
+            busy={true}
+            onClose={vi.fn()}
+            content={{
+              kind: 'fresh-agent',
+              sessionType: 'freshcodex',
+              provider: 'codex',
+              sessionId: 'fresh-session-1',
+              createRequestId: 'fresh-req-1',
+              status: 'running',
+            }}
+          />
+        </Provider>,
+      )
+
+      const identity = screen.getByText('freshcodex')
+      expect(identity.getAttribute('class')).toContain('text-blue-500')
+      expect(screen.queryByTestId('pane-icon')).toBeNull()
+    })
   })
 
   describe('interactions', () => {


### PR DESCRIPTION
## Summary
- make fresh-agent pane headers use the same compact title/meta pattern as CLI panes
- render the lowercase fresh-agent identity leftmost and remove the Open Terminal/tool/context-meter header controls
- preserve fresh-agent busy indication on the identity text and update unit/e2e/browser coverage

## Verification
- FRESHELL_TEST_SUMMARY='fresh-agent header parity' npm run check
- npm run lint (0 errors, existing warnings only)
- npm run test:e2e:chromium -- test/e2e-browser/specs/fresh-agent.spec.ts
- browser smoke at desktop and narrow widths against isolated worktree dev server
- fresh-eyes review passed twice, including after browser-test updates