### PR TITLE
Recover Electron renderer after blank-page crashes

### DIFF
--- a/docs/superpowers/plans/2026-06-28-electron-renderer-recovery.md
+++ b/docs/superpowers/plans/2026-06-28-electron-renderer-recovery.md
@@ -1,0 +1,630 @@
+# Electron Renderer Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent a lost Electron renderer from leaving Freshell on a blank white page, and leave enough durable evidence to diagnose the next renderer loss.
+
+**Architecture:** Keep recovery ownership in the Electron main process because it survives renderer crashes and can observe `webContents` lifecycle events. Add a small durable JSONL logger, a focused renderer supervisor helper, and wire both through the existing `startup.ts` dependency-injected path so unit tests can drive lifecycle events without launching Electron. Crash dump capture is explicitly out of scope for this branch because local dumps may contain sensitive memory; the recovery fix must stand on structured logs and reproducible smoke coverage.
+
+**Tech Stack:** Electron 33, TypeScript NodeNext/ESM, Vitest electron config, Playwright Electron e2e.
+
+## Global Constraints
+
+- Work in `.worktrees/renderer-recovery` on branch `fix/electron-renderer-recovery`.
+- Do not restart the self-hosted Freshell server unless the user says `APPROVED`.
+- Keep Electron imports out of unit-testable DI modules unless the module is Electron-entry-only.
+- Server-side and Electron-side TypeScript uses NodeNext/ESM; relative imports include `.js` extensions.
+- Durable main-process logs are JSONL with `timestamp`, `severity`, `component`, and `event`.
+- Never log auth tokens. URLs written to logs must redact `token` query parameters, and fields with token-bearing names must be replaced with `[REDACTED]`.
+- Recovery must reload/recover only the Electron window renderer. It must not stop or restart the Freshell server.
+- Renderer recovery must be bounded with backoff/circuit-breaker behavior so a crash loop does not spin forever.
+- Tests must prove user-observable recovery, not only implementation details.
+
+---
+
+## File Structure
+
+- Create `electron/main-process-logger.ts`: JSONL logger for Electron main process events and token redaction.
+- Create `test/unit/electron/main-process-logger.test.ts`: logger file creation, JSONL shape, token-bearing key redaction, URL token redaction, fallback stderr logging.
+- Create `electron/renderer-recovery.ts`: attaches `webContents` event handlers, logs renderer loss/load failures/hangs, schedules bounded recovery.
+- Create `test/unit/electron/renderer-recovery.test.ts`: unit coverage for `render-process-gone`, `did-fail-load`, `unresponsive`/`responsive`, backoff, circuit breaker.
+- Modify `electron/startup.ts`: extend `BrowserWindowLike` with the minimal `webContents` shape, accept an optional main-process logger, and call the renderer supervisor when the main window is created.
+- Modify `test/unit/electron/startup.test.ts`: ensure startup wires the supervisor, reloads the same authenticated URL after renderer loss, and does not invoke server start/stop during recovery.
+- Modify `electron/entry.ts`: create the main-process logger and pass it into `runStartup`.
+- Modify `test/e2e-electron/electron-app.test.ts`: add an Electron smoke test in its own describe block with an isolated disposable server that force-crashes the main renderer and verifies Freshell UI returns, privileged IPC still works, and the durable log records recovery.
+
+### Task 1: Durable Electron Main Logging
+
+**Files:**
+- Create: `electron/main-process-logger.ts`
+- Create: `test/unit/electron/main-process-logger.test.ts`
+
+**Interfaces:**
+- Produces: `type ElectronMainLogSeverity = 'debug' | 'info' | 'warn' | 'error'`
+- Produces: `interface ElectronMainLogEntry { severity: ElectronMainLogSeverity; event: string; [key: string]: unknown }`
+- Produces: `interface ElectronMainLogger { log(entry: ElectronMainLogEntry): void }`
+- Produces: `createElectronMainLogger(options: { configDir: string; now?: () => Date; pid?: number }): ElectronMainLogger`
+- Produces: `redactUrlForLog(value: string): string`
+
+- [ ] **Step 1: Write failing logger tests**
+
+Add tests with these cases:
+
+```ts
+it('writes structured JSONL events under configDir/logs', () => {
+  const logger = createElectronMainLogger({
+    configDir,
+    now: () => new Date('2026-06-28T20:58:50.000Z'),
+    pid: 1234,
+  })
+
+  logger.log({
+    severity: 'warn',
+    event: 'main_window_renderer_gone',
+    url: 'http://localhost:3001/?token=secret-token&tab=one',
+    reason: 'crashed',
+  })
+
+  const files = fs.readdirSync(path.join(configDir, 'logs'))
+  expect(files).toEqual(['electron-main.1234.jsonl'])
+  const [line] = fs.readFileSync(path.join(configDir, 'logs', files[0]), 'utf8').trim().split('\n')
+  expect(JSON.parse(line)).toEqual({
+    timestamp: '2026-06-28T20:58:50.000Z',
+    severity: 'warn',
+    component: 'electron-main',
+    event: 'main_window_renderer_gone',
+    url: 'http://localhost:3001/?token=[REDACTED]&tab=one',
+    reason: 'crashed',
+  })
+})
+
+it('falls back to stderr when the log file cannot be written', () => {
+  const error = new Error('EACCES')
+  const appendFileSync = vi.spyOn(fs, 'appendFileSync').mockImplementation(() => { throw error })
+  const stderr = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  const logger = createElectronMainLogger({ configDir, pid: 1234 })
+  logger.log({ severity: 'error', event: 'main_window_recovery_failed', error })
+
+  expect(appendFileSync).toHaveBeenCalled()
+  expect(stderr).toHaveBeenCalledWith(expect.stringContaining('"event":"main_window_recovery_failed"'))
+})
+
+it('redacts token-bearing keys, URL token parameters, and token-like string fragments', () => {
+  const logger = createElectronMainLogger({
+    configDir,
+    now: () => new Date('2026-06-28T20:58:50.000Z'),
+    pid: 1234,
+  })
+
+  logger.log({
+    severity: 'warn',
+    event: 'token_redaction_probe',
+    remoteToken: 'plain-secret',
+    nested: {
+      authToken: 'nested-secret',
+      url: 'http://localhost:3001/?token=query-secret',
+    },
+    error: new Error('failed for token=message-secret'),
+  })
+
+  const line = fs.readFileSync(path.join(configDir, 'logs', 'electron-main.1234.jsonl'), 'utf8').trim()
+  expect(line).not.toContain('plain-secret')
+  expect(line).not.toContain('nested-secret')
+  expect(line).not.toContain('query-secret')
+  expect(line).not.toContain('message-secret')
+  expect(JSON.parse(line)).toMatchObject({
+    remoteToken: '[REDACTED]',
+    nested: {
+      authToken: '[REDACTED]',
+      url: 'http://localhost:3001/?token=[REDACTED]',
+    },
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test:vitest -- --config vitest.electron.config.ts test/unit/electron/main-process-logger.test.ts --run`
+
+Expected: FAIL because `electron/main-process-logger.ts` does not exist.
+
+- [ ] **Step 3: Implement the logger**
+
+Implement `electron/main-process-logger.ts` with `fs.mkdirSync(logDir, { recursive: true })`, `fs.appendFileSync(logPath, JSON.stringify(record) + '\n', 'utf8')`, token redaction through the standard `URL` API, token-bearing key redaction, token-like string fragment redaction, and safe error serialization:
+
+```ts
+function normalizeString(value: string): string {
+  const redactedUrl = looksLikeUrl(value) ? redactUrlForLog(value) : value
+  return redactedUrl.replace(/([?&]?(?:token|authorization|password|secret)=)[^\s&]+/gi, '$1[REDACTED]')
+}
+
+function isTokenBearingKey(key: string): boolean {
+  return /token|authorization|password|secret/i.test(key)
+}
+
+function normalizeValue(value: unknown, key?: string): unknown {
+  if (key && isTokenBearingKey(key)) return '[REDACTED]'
+  if (typeof value === 'string') return normalizeString(value)
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: normalizeString(value.message),
+      stack: value.stack ? normalizeString(value.stack) : undefined,
+    }
+  }
+  if (Array.isArray(value)) return value.map((nested) => normalizeValue(nested))
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([nestedKey, nested]) => [nestedKey, normalizeValue(nested, nestedKey)]))
+  }
+  return value
+}
+```
+
+Token-bearing keys are any case-insensitive key that contains `token`, `authorization`, `password`, or `secret`. When a non-URL string contains a token-like fragment such as `token=...`, redact that fragment before writing it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test:vitest -- --config vitest.electron.config.ts test/unit/electron/main-process-logger.test.ts --run`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add electron/main-process-logger.ts test/unit/electron/main-process-logger.test.ts
+git commit -m "feat(electron): add durable main process logging"
+```
+
+### Task 2: Renderer Lifecycle Supervisor
+
+**Files:**
+- Create: `electron/renderer-recovery.ts`
+- Create: `test/unit/electron/renderer-recovery.test.ts`
+
+**Interfaces:**
+- Consumes: `ElectronMainLogger` from `electron/main-process-logger.ts`
+- Produces: `interface RecoverableBrowserWindow { loadURL(url: string): Promise<void>; show(): void; focus(): void; isDestroyed?: () => boolean; webContents?: RecoverableWebContents }`
+- Produces: `interface RecoverableWebContents { on(event: string, callback: (...args: any[]) => void): void; getURL?: () => string; isDestroyed?: () => boolean; reload?: () => void; forcefullyCrashRenderer?: () => void }`
+- Produces: `registerRendererRecovery(options: RendererRecoveryOptions): void`
+
+- [ ] **Step 1: Write failing supervisor tests**
+
+Add tests with an event-emitting fake window. Cover:
+
+```ts
+it('reloads the crashed renderer when the renderer process is gone', async () => {
+  const window = createRecoverableWindow()
+  const verifyRecovered = vi.fn().mockResolvedValue(undefined)
+  registerRendererRecovery({ window, loadUrl, serverUrl, logger, setTimeout, clearTimeout, verifyRecovered })
+
+  window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+  await timers.runOnlyPendingTimersAsync()
+
+  expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+  expect(window.loadURL).not.toHaveBeenCalled()
+  expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+    severity: 'warn',
+    event: 'main_window_renderer_gone',
+    reason: 'crashed',
+    exitCode: 133,
+  }))
+  expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+    severity: 'info',
+    event: 'main_window_recovery_succeeded',
+  }))
+})
+
+it('recovers clean renderer exits while the main window is expected to stay alive', () => {
+  window.webContents.emit('render-process-gone', {}, { reason: 'clean-exit', exitCode: 0 })
+  expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+  expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+    event: 'main_window_renderer_gone',
+    reason: 'clean-exit',
+    willRecover: true,
+  }))
+})
+
+it('logs did-fail-load and retries only main-frame non-abort failures', async () => {
+  window.webContents.emit('did-fail-load', {}, -102, 'CONNECTION_REFUSED', loadUrl, true)
+  await timers.runOnlyPendingTimersAsync()
+  expect(window.loadURL).toHaveBeenCalledWith(loadUrl)
+
+  window.webContents.emit('did-fail-load', {}, -3, 'ERR_ABORTED', loadUrl, true)
+  expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+    event: 'main_window_navigation_failed',
+    errorCode: -3,
+    willRecover: false,
+  }))
+})
+
+it('recovers after a sustained unresponsive renderer and cancels when responsive returns', async () => {
+  window.webContents.emit('unresponsive')
+  window.webContents.emit('responsive')
+  await timers.advanceTimersByTimeAsync(15_000)
+  expect(window.loadURL).not.toHaveBeenCalled()
+
+  window.webContents.emit('unresponsive')
+  await timers.advanceTimersByTimeAsync(15_000)
+  expect(window.webContents.forcefullyCrashRenderer).toHaveBeenCalled()
+  expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+})
+
+it('stops retrying after the crash-loop circuit breaker opens', async () => {
+  for (let i = 0; i < 4; i += 1) {
+    window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await timers.runOnlyPendingTimersAsync()
+  }
+  expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+    severity: 'error',
+    event: 'main_window_recovery_circuit_open',
+  }))
+})
+
+it('coalesces duplicate failure events while one recovery attempt is in flight', async () => {
+  const verifyRecovered = vi.fn().mockReturnValue(new Promise(() => {}))
+  registerRendererRecovery({ window, loadUrl, serverUrl, logger, setTimeout, clearTimeout, verifyRecovered })
+
+  window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+  window.webContents.emit('did-fail-load', {}, -102, 'CONNECTION_REFUSED', loadUrl, true)
+  await timers.runOnlyPendingTimersAsync()
+
+  expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+  expect(window.loadURL).not.toHaveBeenCalled()
+  expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+    event: 'main_window_recovery_skipped',
+    reason: 'recovery-in-flight',
+  }))
+})
+
+it('does not log success until the recovery verifier resolves', async () => {
+  let resolveVerifier!: () => void
+  const verifyRecovered = vi.fn().mockReturnValue(new Promise<void>((resolve) => { resolveVerifier = resolve }))
+  registerRendererRecovery({ window, loadUrl, serverUrl, logger, setTimeout, clearTimeout, verifyRecovered })
+
+  window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+  await timers.runOnlyPendingTimersAsync()
+
+  expect(logger.log).not.toHaveBeenCalledWith(expect.objectContaining({
+    event: 'main_window_recovery_succeeded',
+  }))
+
+  resolveVerifier()
+  await Promise.resolve()
+  expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+    event: 'main_window_recovery_succeeded',
+  }))
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test:vitest -- --config vitest.electron.config.ts test/unit/electron/renderer-recovery.test.ts --run`
+
+Expected: FAIL because `electron/renderer-recovery.ts` does not exist.
+
+- [ ] **Step 3: Implement the supervisor**
+
+Implement `registerRendererRecovery()` so it:
+- Attaches handlers to `webContents` for `render-process-gone`, `did-fail-load`, `unresponsive`, and `responsive`.
+- Logs `main_window_renderer_gone`, `main_window_initial_load_failed`, `main_window_navigation_failed`, `main_window_unresponsive`, `main_window_responsive`, `main_window_recovery_started`, `main_window_recovery_succeeded`, `main_window_recovery_failed`, `main_window_recovery_skipped`, `main_window_recovery_reload_unavailable`, and `main_window_recovery_circuit_open`.
+- Runs the first recovery attempt immediately. If recovery fails and another event requests recovery, retry attempts use delays `[250, 1000, 3000]` ms and a window of 60 seconds with at most 3 recovery attempts.
+- Calls `window.webContents.reload()` for `render-process-gone` and sustained `unresponsive` recovery because Electron documents reload as the post-crash fresh-renderer path. If `webContents.reload` is unavailable or `webContents` is destroyed, fall back to `window.loadURL(loadUrl)` and log `main_window_recovery_reload_unavailable`.
+- Calls `window.loadURL(loadUrl)` for recoverable main-frame `did-fail-load` events because there may not be a successfully loaded current page to reload.
+- Calls `window.show()` and `window.focus()` on success.
+- Calls an optional `verifyRecovered(): Promise<void>` after the recovery action and before logging `main_window_recovery_succeeded`; the default verifier resolves immediately.
+- Uses `forcefullyCrashRenderer()` before reload only for sustained `unresponsive` recovery.
+- Recovers `clean-exit` while the main window is expected to remain alive. Intentional app/window shutdown is handled by the existing close/quit lifecycle, not by suppressing renderer recovery.
+- Coalesces duplicate lifecycle events while a recovery attempt is in flight.
+- Does not call any server lifecycle APIs.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test:vitest -- --config vitest.electron.config.ts test/unit/electron/renderer-recovery.test.ts --run`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add electron/renderer-recovery.ts test/unit/electron/renderer-recovery.test.ts
+git commit -m "feat(electron): recover lost main renderer"
+```
+
+### Task 3: Wire Recovery Through Startup
+
+**Files:**
+- Modify: `electron/startup.ts`
+- Modify: `test/unit/electron/startup.test.ts`
+
+**Interfaces:**
+- Consumes: `registerRendererRecovery()` from `electron/renderer-recovery.ts`
+- Consumes: `ElectronMainLogger` from `electron/main-process-logger.ts`
+- Produces: `StartupContext.mainProcessLogger?: ElectronMainLogger`
+- Produces: `BrowserWindowLike.webContents?: RecoverableWebContents`
+
+- [ ] **Step 1: Write failing startup integration tests**
+
+Update `createMockWindow()` so it can expose evented `webContents`. Add tests:
+
+```ts
+it('registers renderer recovery for the main window and reloads the crashed renderer', async () => {
+  const mockWindow = createMockWindowWithWebContents()
+  const logger = { log: vi.fn() }
+  const ctx = createDefaultContext({
+    createBrowserWindow: vi.fn().mockReturnValue(mockWindow),
+    mainProcessLogger: logger,
+    rendererRecoveryVerifier: vi.fn().mockResolvedValue(undefined),
+    readEnvToken: vi.fn().mockResolvedValue('env token+with&chars'),
+  })
+
+  const result = await runStartup(ctx)
+  expect(result.type).toBe('main')
+
+  mockWindow.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 9 })
+  await vi.runOnlyPendingTimersAsync()
+
+  expect(mockWindow.webContents.reload).toHaveBeenCalledTimes(1)
+  expect(ctx.serverSpawner.start).toHaveBeenCalledTimes(1)
+  expect(ctx.serverSpawner.stop).not.toHaveBeenCalled()
+})
+
+it('reuses the same authenticated URL for recoverable main-frame load failures', async () => {
+  const mockWindow = createMockWindowWithWebContents()
+  const logger = { log: vi.fn() }
+  const ctx = createDefaultContext({
+    createBrowserWindow: vi.fn().mockReturnValue(mockWindow),
+    mainProcessLogger: logger,
+    rendererRecoveryVerifier: vi.fn().mockResolvedValue(undefined),
+    readEnvToken: vi.fn().mockResolvedValue('env token+with&chars'),
+  })
+
+  const result = await runStartup(ctx)
+  expect(result.type).toBe('main')
+
+  mockWindow.webContents.emit('did-fail-load', {}, -102, 'CONNECTION_REFUSED', 'http://localhost:3001/', true)
+  await vi.runOnlyPendingTimersAsync()
+
+  expect(mockWindow.loadURL).toHaveBeenLastCalledWith('http://localhost:3001?token=env%20token%2Bwith%26chars')
+  expect(ctx.serverSpawner.start).toHaveBeenCalledTimes(1)
+  expect(ctx.serverSpawner.stop).not.toHaveBeenCalled()
+})
+
+it('logs an explicit warning when recovery cannot attach because webContents is unavailable', async () => {
+  const logger = { log: vi.fn() }
+  await runStartup(createDefaultContext({ mainProcessLogger: logger }))
+  expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+    severity: 'warn',
+    event: 'main_window_recovery_unavailable',
+  }))
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test:vitest -- --config vitest.electron.config.ts test/unit/electron/startup.test.ts --run`
+
+Expected: FAIL because `StartupContext.mainProcessLogger` and recovery wiring do not exist.
+
+- [ ] **Step 3: Implement startup wiring**
+
+In `electron/startup.ts`:
+- Import `type ElectronMainLogger` and `registerRendererRecovery`.
+- Extend `BrowserWindowLike` with optional `webContents`.
+- Extend `StartupContext` with `mainProcessLogger?: ElectronMainLogger`.
+- Extend `StartupContext` with `rendererRecoveryVerifier?: () => Promise<void>`.
+- After `loadUrl` is computed and before returning the main result, call `registerRendererRecovery({ window, loadUrl, serverUrl, logger: ctx.mainProcessLogger, verifyRecovered: ctx.rendererRecoveryVerifier })` when a logger is present.
+- If a logger is present but no `window.webContents` exists, log `main_window_recovery_unavailable`.
+- Keep the existing initial `loadURL(loadUrl).catch(...)` path, but route it through `ctx.mainProcessLogger.log({ event: 'main_window_initial_load_failed', ... })` when available.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test:vitest -- --config vitest.electron.config.ts test/unit/electron/startup.test.ts --run`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add electron/startup.ts test/unit/electron/startup.test.ts
+git commit -m "feat(electron): supervise main renderer during startup"
+```
+
+### Task 4: Entry Integration And E2E Crash Recovery Smoke
+
+**Files:**
+- Modify: `electron/entry.ts`
+- Modify: `test/e2e-electron/electron-app.test.ts`
+
+**Interfaces:**
+- Consumes: `createElectronMainLogger()` from `electron/main-process-logger.ts`
+- Consumes: `StartupContext.mainProcessLogger`
+
+- [ ] **Step 1: Write failing e2e smoke**
+
+Add a new `Renderer crash recovery` describe outside the existing `Main window with remote server` describe so it does not inherit that describe's `beforeEach` or read the live `.env` token.
+
+Add this import near the other imports:
+
+```ts
+import { TestServer } from '../e2e-browser/helpers/test-server.js'
+```
+
+```ts
+test.describe('Renderer crash recovery', () => {
+  let app: ElectronApplication | undefined
+  let tmpHome: string | undefined
+  let server: TestServer | undefined
+
+  test.afterEach(async () => {
+    if (app) await app.close().catch(() => {})
+    if (server) await server.stop().catch(() => {})
+    if (tmpHome) fs.rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  test('recovers the main Freshell UI after the renderer process crashes', async () => {
+    server = new TestServer()
+    const serverInfo = await server.start()
+    tmpHome = createTempHome({
+      serverMode: 'remote',
+      port: serverInfo.port,
+      remoteUrl: serverInfo.baseUrl,
+      remoteToken: serverInfo.token,
+      knownServers: [],
+      alwaysAskOnLaunch: false,
+      globalHotkey: 'CommandOrControl+`',
+      startOnLogin: false,
+      minimizeToTray: true,
+      setupCompleted: true,
+    })
+
+    app = await launchApp(tmpHome, true)
+    const mainPage = await app.firstWindow()
+    await mainPage.waitForLoadState('domcontentloaded')
+    await expect(mainPage.locator('text=New Tab').first()).toBeVisible({ timeout: 30_000 })
+
+    await app.evaluate(() => {
+      const { BrowserWindow } = require('electron')
+      const [win] = BrowserWindow.getAllWindows()
+      win.webContents.forcefullyCrashRenderer()
+    })
+
+    const escapedBaseUrl = serverInfo.baseUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const recovered = await waitForWindowUrl(app, new RegExp(escapedBaseUrl), 60_000)
+    await expect(recovered.locator('text=New Tab').first()).toBeVisible({ timeout: 60_000 })
+
+    await app.evaluate(() => {
+      const { shell } = require('electron')
+      const original = shell.openExternal
+      ;(globalThis as any).__testOpenExternal = (url: string) => {
+        ;(globalThis as any).__openedUrl = url
+        return Promise.resolve()
+      }
+      ;(globalThis as any).__restoreOpenExternal = () => {
+        shell.openExternal = original
+      }
+      shell.openExternal = (globalThis as any).__testOpenExternal
+    })
+
+    await recovered.evaluate(async () => {
+      const link = document.createElement('a')
+      link.href = 'https://example.com/freshell-recovery-ipc'
+      link.target = '_blank'
+      link.rel = 'noopener noreferrer'
+      link.textContent = 'recovery ipc link'
+      document.body.appendChild(link)
+      link.dispatchEvent(new MouseEvent('click', { ctrlKey: true, bubbles: true }))
+      await new Promise<void>((resolve) => setTimeout(resolve, 500))
+    })
+
+    await expect.poll(async () =>
+      app.evaluate(() => (globalThis as any).__openedUrl),
+    ).toBe('https://example.com/freshell-recovery-ipc')
+
+    const logDir = path.join(tmpHome, '.freshell', 'logs')
+    await expect.poll(() => {
+      const file = fs.readdirSync(logDir).find((name) => name.startsWith('electron-main.') && name.endsWith('.jsonl'))
+      if (!file) return ''
+      return fs.readFileSync(path.join(logDir, file), 'utf8')
+    }).toContain('main_window_recovery_succeeded')
+  })
+})
+```
+
+- [ ] **Step 2: Run the focused e2e to verify it fails**
+
+Run: `npm run build:client && npm run build:server && npm run build:electron`
+
+Expected: PASS before the e2e run. `build:client` and `build:server` are required because `TestServer` serves `dist/server` and `dist/client`; `build:electron` is required because Playwright launches the Electron entry from `dist/electron`.
+
+Run: `npm run test:e2e:electron -- --grep "recovers the main Freshell UI after the renderer process crashes"`
+
+Expected: FAIL because entry does not create a logger or pass it to startup, and renderer recovery is not active in the real Electron app.
+
+- [ ] **Step 3: Implement entry wiring**
+
+In `electron/entry.ts`:
+- Import `createElectronMainLogger`.
+- Create `const mainProcessLogger = createElectronMainLogger({ configDir })` after `configDir`.
+- Pass `mainProcessLogger` into the `StartupContext`.
+- Log a startup event with app version and `isDev` after `app.whenReady()`.
+
+- [ ] **Step 4: Run focused verification**
+
+Run:
+
+```bash
+npm run test:vitest -- --config vitest.electron.config.ts \
+  test/unit/electron/main-process-logger.test.ts \
+  test/unit/electron/renderer-recovery.test.ts \
+  test/unit/electron/startup.test.ts --run
+npm run build:client && npm run build:server && npm run build:electron
+npm run test:e2e:electron -- --grep "recovers the main Freshell UI after the renderer process crashes"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add electron/entry.ts test/e2e-electron/electron-app.test.ts
+git commit -m "test(electron): cover renderer crash recovery"
+```
+
+### Task 5: Full Verification
+
+**Files:**
+- No new implementation files.
+
+**Interfaces:**
+- Consumes all prior tasks.
+- Produces a verified branch suitable for review.
+
+- [ ] **Step 1: Run coordinated Electron unit suite**
+
+Run: `npm run test:electron`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Electron e2e suite**
+
+Run:
+
+```bash
+npm run build:client && npm run build:server && npm run build:electron
+npm run test:e2e:electron
+```
+
+Expected: PASS. If unrelated pre-existing Electron e2e failures appear, capture exact failures and rerun the focused renderer recovery smoke to separate regression from environment.
+
+- [ ] **Step 3: Run full coordinated check**
+
+Run: `FRESHELL_TEST_SUMMARY="electron renderer recovery branch verification" npm run check`
+
+Expected: PASS. If the shared coordinator is held by another agent, wait for the gate rather than killing the holder.
+
+- [ ] **Step 4: Commit any final test or refactor changes**
+
+Run:
+
+```bash
+git status --short
+git add <only-files-touched-for-this-change>
+git commit -m "chore(electron): verify renderer recovery"
+```
+
+Only run the final commit if Step 1-3 required additional changes.
+
+## Self-Review
+
+- Spec coverage: The plan addresses the observed failure mode (lost renderer), the observed recovery gap (no main-process lifecycle supervision), durable structured logs, bounded recovery, and user-visible e2e coverage. Local crash reporting is intentionally excluded because it needs a separate privacy review.
+- Placeholder scan: No unresolved placeholder text or unspecified tests are present. Each task names exact files, functions, commands, and expected outcomes.
+- Type consistency: `ElectronMainLogger`, `StartupContext.mainProcessLogger`, `BrowserWindowLike.webContents`, and `registerRendererRecovery()` are defined once and reused consistently across tasks.

--- a/docs/superpowers/plans/2026-06-28-electron-renderer-recovery.md
+++ b/docs/superpowers/plans/2026-06-28-electron-renderer-recovery.md
@@ -309,7 +309,7 @@ Expected: FAIL because `electron/renderer-recovery.ts` does not exist.
 
 Implement `registerRendererRecovery()` so it:
 - Attaches handlers to `webContents` for `render-process-gone`, `did-fail-load`, `unresponsive`, and `responsive`.
-- Logs `main_window_renderer_gone`, `main_window_initial_load_failed`, `main_window_navigation_failed`, `main_window_unresponsive`, `main_window_responsive`, `main_window_recovery_started`, `main_window_recovery_succeeded`, `main_window_recovery_failed`, `main_window_recovery_skipped`, `main_window_recovery_reload_unavailable`, and `main_window_recovery_circuit_open`.
+- Logs `main_window_renderer_gone`, `main_window_navigation_failed`, `main_window_unresponsive`, `main_window_responsive`, `main_window_recovery_started`, `main_window_recovery_succeeded`, `main_window_recovery_failed`, `main_window_recovery_skipped`, `main_window_recovery_reload_unavailable`, and `main_window_recovery_circuit_open`. Task 3 owns the initial startup `loadURL().catch(...)` path and its `main_window_initial_load_failed` event.
 - Runs the first recovery attempt immediately. If recovery fails and another event requests recovery, retry attempts use delays `[250, 1000, 3000]` ms and a window of 60 seconds with at most 3 recovery attempts.
 - Calls `window.webContents.reload()` for `render-process-gone` and sustained `unresponsive` recovery because Electron documents reload as the post-crash fresh-renderer path. If `webContents.reload` is unavailable or `webContents` is destroyed, fall back to `window.loadURL(loadUrl)` and log `main_window_recovery_reload_unavailable`.
 - Calls `window.loadURL(loadUrl)` for recoverable main-frame `did-fail-load` events because there may not be a successfully loaded current page to reload.

--- a/electron/entry.ts
+++ b/electron/entry.ts
@@ -37,12 +37,181 @@ import { buildLaunchOptions } from './launch-options.js'
 import { applyProvisioningFile } from './desktop-provisioning.js'
 import { createPortAvailabilityCheck } from './port-check.js'
 import { registerOpenExternalHandler } from './external-url.js'
+import { createElectronMainLogger } from './main-process-logger.js'
 import type { ForcedLaunch, LaunchServerCandidate } from './types.js'
+import type { RecoverableWebContents } from './renderer-recovery.js'
 
 const isPortAvailable = createPortAvailabilityCheck()
 
 const isDev = process.env.ELECTRON_DEV === '1'
 const configDir = path.join(os.homedir(), '.freshell')
+const mainProcessLogger = createElectronMainLogger({ configDir })
+
+type EntryBrowserWindow = InstanceType<typeof BrowserWindow>
+type WindowListener = { event: string; callback: (...args: any[]) => void }
+
+function createRecoverableEntryWindow(
+  options: Record<string, any>,
+  preloadPath: string,
+  onWebContentsChanged: (webContentsId: number) => void,
+): BrowserWindowLike {
+  const windowListeners: WindowListener[] = []
+  const webContentsListeners: WindowListener[] = []
+  let lastLoadUrl: string | undefined
+  let activeWindow: EntryBrowserWindow
+  let replacingWindow = false
+
+  const createNativeWindow = (nativeOptions: Record<string, any>) => {
+    const win = new BrowserWindow({
+      ...nativeOptions,
+      webPreferences: {
+        ...nativeOptions.webPreferences,
+        preload: preloadPath,
+      },
+    })
+
+    for (const { event, callback } of windowListeners) {
+      win.on(event as any, callback)
+    }
+    for (const { event, callback } of webContentsListeners) {
+      win.webContents.on(event as any, callback)
+    }
+
+    onWebContentsChanged(win.webContents.id)
+    return win
+  }
+
+  const getRecoveryUrl = (fallbackWindow: EntryBrowserWindow): string | undefined => {
+    if (lastLoadUrl) return lastLoadUrl
+    try {
+      return fallbackWindow.webContents.getURL()
+    } catch {
+      return undefined
+    }
+  }
+
+  const replaceCrashedWindow = async () => {
+    if (replacingWindow) return
+    replacingWindow = true
+
+    const crashedWindow = activeWindow
+    const recoveryUrl = getRecoveryUrl(crashedWindow)
+    if (!recoveryUrl) {
+      replacingWindow = false
+      return
+    }
+
+    try {
+      const bounds = crashedWindow.getBounds()
+      const wasVisible = crashedWindow.isVisible()
+      const wasFocused = crashedWindow.isFocused()
+      const wasMaximized = crashedWindow.isMaximized()
+      const replacement = createNativeWindow({
+        ...options,
+        x: bounds.x,
+        y: bounds.y,
+        width: bounds.width,
+        height: bounds.height,
+        show: false,
+      })
+
+      activeWindow = replacement
+      await replacement.loadURL(recoveryUrl)
+
+      if (wasMaximized) {
+        replacement.maximize()
+      }
+      if (wasVisible) {
+        replacement.show()
+      }
+      if (wasFocused) {
+        replacement.focus()
+      }
+      if (!crashedWindow.isDestroyed()) {
+        crashedWindow.destroy()
+      }
+    } catch (error) {
+      mainProcessLogger.log({
+        severity: 'error',
+        event: 'main_window_replacement_failed',
+        loadUrl: recoveryUrl,
+        error,
+      })
+    } finally {
+      replacingWindow = false
+    }
+  }
+
+  activeWindow = createNativeWindow(options)
+
+  const webContentsProxy: RecoverableWebContents = {
+    on(event, callback) {
+      webContentsListeners.push({ event, callback })
+      activeWindow.webContents.on(event as any, callback)
+    },
+    getURL() {
+      return activeWindow.webContents.getURL()
+    },
+    isDestroyed() {
+      return activeWindow.webContents.isDestroyed()
+    },
+    reload() {
+      void replaceCrashedWindow()
+    },
+    forcefullyCrashRenderer() {
+      activeWindow.webContents.forcefullyCrashRenderer()
+    },
+  }
+
+  const windowProxy = {
+    get webContents() {
+      return webContentsProxy
+    },
+    loadURL(url: string, loadOptions?: Parameters<EntryBrowserWindow['loadURL']>[1]) {
+      lastLoadUrl = url
+      return activeWindow.loadURL(url, loadOptions)
+    },
+    show() {
+      activeWindow.show()
+    },
+    hide() {
+      activeWindow.hide()
+    },
+    focus() {
+      activeWindow.focus()
+    },
+    maximize() {
+      activeWindow.maximize()
+    },
+    isVisible() {
+      return activeWindow.isVisible()
+    },
+    isFocused() {
+      return activeWindow.isFocused()
+    },
+    isDestroyed() {
+      return activeWindow.isDestroyed()
+    },
+    getBounds() {
+      return activeWindow.getBounds()
+    },
+    isMaximized() {
+      return activeWindow.isMaximized()
+    },
+    isMinimized() {
+      return activeWindow.isMinimized()
+    },
+    restore() {
+      activeWindow.restore()
+    },
+    on(event: string, callback: (...args: any[]) => void) {
+      windowListeners.push({ event, callback })
+      activeWindow.on(event as any, callback)
+    },
+  }
+
+  return windowProxy as BrowserWindowLike
+}
 
 /** True during the wizard flow; prevents app.quit() on window-all-closed. */
 let wizardPhase = true
@@ -58,6 +227,12 @@ async function main(): Promise<void> {
   // Wait for Electron to be ready before creating any BrowserWindow or using
   // Electron APIs that require the app to be initialized.
   await app.whenReady()
+  mainProcessLogger.log({
+    severity: 'info',
+    event: 'electron_main_started',
+    appVersion: app.getVersion(),
+    isDev,
+  })
 
   // Consolidated window-all-closed handler: during the wizard phase we keep
   // the app alive so main() can re-run after the wizard closes. Once the main
@@ -143,6 +318,7 @@ async function main(): Promise<void> {
     port,
     resourcesPath,
     configDir,
+    mainProcessLogger,
     platform: process.platform,
     fetchHealthCheck: (url: string): Promise<boolean> => {
       // Use Node's http module instead of global fetch() — Electron's main
@@ -206,15 +382,13 @@ async function main(): Promise<void> {
       }
     },
     createBrowserWindow: (options) => {
-      const win = new BrowserWindow({
-        ...options,
-        webPreferences: {
-          ...options.webPreferences,
-          preload: path.join(__dirname, 'preload.js'),
+      return createRecoverableEntryWindow(
+        options,
+        path.join(__dirname, 'preload.js'),
+        (webContentsId) => {
+          mainWebContentsId = webContentsId
         },
-      })
-      // Cast to BrowserWindowLike -- Electron's BrowserWindow satisfies the interface
-      return win as unknown as BrowserWindowLike
+      )
     },
     createTray: () => {
       const iconPath = resolveTrayIconPath({

--- a/electron/entry.ts
+++ b/electron/entry.ts
@@ -156,7 +156,7 @@ function createRecoverableEntryWindow(
       return activeWindow.webContents.isDestroyed()
     },
     reload() {
-      void replaceCrashedWindow()
+      return replaceCrashedWindow()
     },
     forcefullyCrashRenderer() {
       activeWindow.webContents.forcefullyCrashRenderer()

--- a/electron/entry.ts
+++ b/electron/entry.ts
@@ -77,7 +77,6 @@ function createRecoverableEntryWindow(
       win.webContents.on(event as any, callback)
     }
 
-    onWebContentsChanged(win.webContents.id)
     return win
   }
 
@@ -94,19 +93,21 @@ function createRecoverableEntryWindow(
     if (replacingWindow) return
     replacingWindow = true
 
-    const crashedWindow = activeWindow
-    const recoveryUrl = getRecoveryUrl(crashedWindow)
-    if (!recoveryUrl) {
-      replacingWindow = false
-      return
-    }
+    let recoveryUrl: string | undefined
+    let replacement: EntryBrowserWindow | undefined
 
     try {
+      const crashedWindow = activeWindow
+      recoveryUrl = getRecoveryUrl(crashedWindow)
+      if (!recoveryUrl) {
+        throw new Error('main window recovery URL unavailable')
+      }
+
       const bounds = crashedWindow.getBounds()
       const wasVisible = crashedWindow.isVisible()
       const wasFocused = crashedWindow.isFocused()
       const wasMaximized = crashedWindow.isMaximized()
-      const replacement = createNativeWindow({
+      replacement = createNativeWindow({
         ...options,
         x: bounds.x,
         y: bounds.y,
@@ -115,8 +116,9 @@ function createRecoverableEntryWindow(
         show: false,
       })
 
-      activeWindow = replacement
       await replacement.loadURL(recoveryUrl)
+      activeWindow = replacement
+      onWebContentsChanged(replacement.webContents.id)
 
       if (wasMaximized) {
         replacement.maximize()
@@ -131,20 +133,28 @@ function createRecoverableEntryWindow(
         crashedWindow.destroy()
       }
     } catch (error) {
+      if (replacement && !replacement.isDestroyed()) {
+        replacement.destroy()
+      }
       mainProcessLogger.log({
         severity: 'error',
         event: 'main_window_replacement_failed',
         loadUrl: recoveryUrl,
         error,
       })
+      throw error
     } finally {
       replacingWindow = false
     }
   }
 
   activeWindow = createNativeWindow(options)
+  onWebContentsChanged(activeWindow.webContents.id)
 
   const webContentsProxy: RecoverableWebContents = {
+    get id() {
+      return activeWindow.webContents.id
+    },
     on(event, callback) {
       webContentsListeners.push({ event, callback })
       activeWindow.webContents.on(event as any, callback)

--- a/electron/main-process-logger.ts
+++ b/electron/main-process-logger.ts
@@ -1,0 +1,130 @@
+import fs from 'fs'
+import path from 'path'
+
+export type ElectronMainLogSeverity = 'debug' | 'info' | 'warn' | 'error'
+
+export interface ElectronMainLogEntry {
+  severity: ElectronMainLogSeverity
+  event: string
+  [key: string]: unknown
+}
+
+export interface ElectronMainLogger {
+  log(entry: ElectronMainLogEntry): void
+}
+
+interface CreateElectronMainLoggerOptions {
+  configDir: string
+  now?: () => Date
+  pid?: number
+}
+
+const COMPONENT = 'electron-main'
+const REDACTED = '[REDACTED]'
+
+function looksLikeUrl(value: string): boolean {
+  try {
+    // Use the standard URL parser so query redaction only runs on real URLs.
+    new URL(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function normalizeString(value: string): string {
+  const redactedUrl = looksLikeUrl(value) ? redactUrlForLog(value) : value
+  return redactedUrl.replace(
+    /([?&]?(?:token|authorization|password|secret)=)[^\s&]+/gi,
+    `$1${REDACTED}`,
+  )
+}
+
+function isTokenBearingKey(key: string): boolean {
+  return /token|authorization|password|secret/i.test(key)
+}
+
+function normalizeValue(value: unknown, key?: string): unknown {
+  if (key && isTokenBearingKey(key)) {
+    return REDACTED
+  }
+
+  if (typeof value === 'string') {
+    return normalizeString(value)
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: normalizeString(value.message),
+      stack: value.stack ? normalizeString(value.stack) : undefined,
+    }
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((nested) => normalizeValue(nested))
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([nestedKey, nestedValue]) => [
+        nestedKey,
+        normalizeValue(nestedValue, nestedKey),
+      ]),
+    )
+  }
+
+  return value
+}
+
+export function redactUrlForLog(value: string): string {
+  try {
+    const url = new URL(value)
+    const keys = new Set(url.searchParams.keys())
+
+    for (const key of keys) {
+      if (isTokenBearingKey(key)) {
+        url.searchParams.set(key, REDACTED)
+      }
+    }
+
+    if (url.password) {
+      url.password = REDACTED
+    }
+
+    return url.toString()
+  } catch {
+    return normalizeString(value)
+  }
+}
+
+export function createElectronMainLogger(
+  options: CreateElectronMainLoggerOptions,
+): ElectronMainLogger {
+  const now = options.now ?? (() => new Date())
+  const pid = options.pid ?? process.pid
+  const logDir = path.join(options.configDir, 'logs')
+  const logPath = path.join(logDir, `${COMPONENT}.${pid}.jsonl`)
+
+  return {
+    log(entry) {
+      const normalizedEntry = Object.fromEntries(
+        Object.entries(entry).map(([key, value]) => [key, normalizeValue(value, key)]),
+      )
+      const record = {
+        ...normalizedEntry,
+        timestamp: now().toISOString(),
+        severity: entry.severity,
+        component: COMPONENT,
+      }
+      const line = JSON.stringify(record)
+
+      try {
+        fs.mkdirSync(logDir, { recursive: true })
+        fs.appendFileSync(logPath, `${line}\n`, 'utf8')
+      } catch {
+        console.error(line)
+      }
+    },
+  }
+}

--- a/electron/renderer-recovery.ts
+++ b/electron/renderer-recovery.ts
@@ -1,4 +1,4 @@
-import type { ElectronMainLogger } from './main-process-logger.js'
+import type { ElectronMainLogEntry, ElectronMainLogger } from './main-process-logger.js'
 
 export interface RecoverableBrowserWindow {
   loadURL(url: string): Promise<void>
@@ -103,7 +103,7 @@ export function registerRendererRecovery(options: RendererRecoveryOptions): void
     attemptTimestamps = attemptTimestamps.filter((timestamp) => now - timestamp < CIRCUIT_WINDOW_MS)
   }
 
-  const logWithContext = (entry: Record<string, unknown>) => {
+  const logWithContext = (entry: ElectronMainLogEntry) => {
     logger.log({
       serverUrl,
       loadUrl,

--- a/electron/renderer-recovery.ts
+++ b/electron/renderer-recovery.ts
@@ -72,6 +72,7 @@ export function registerRendererRecovery(options: RendererRecoveryOptions): void
   let consecutiveFailures = 0
   let unresponsiveTimer: ReturnType<typeof globalThis.setTimeout> | undefined
   let scheduledRecoveryTimer: ReturnType<typeof globalThis.setTimeout> | undefined
+  let scheduledRecoveryRequest: RecoveryRequest | undefined
   let attemptTimestamps: number[] = []
 
   const webContents = window.webContents
@@ -86,6 +87,16 @@ export function registerRendererRecovery(options: RendererRecoveryOptions): void
 
     clearTimeout(unresponsiveTimer)
     unresponsiveTimer = undefined
+  }
+
+  const clearScheduledRecoveryTimer = () => {
+    if (!scheduledRecoveryTimer) {
+      return
+    }
+
+    clearTimeout(scheduledRecoveryTimer)
+    scheduledRecoveryTimer = undefined
+    scheduledRecoveryRequest = undefined
   }
 
   const pruneAttempts = (now: number) => {
@@ -225,8 +236,9 @@ export function registerRendererRecovery(options: RendererRecoveryOptions): void
       return
     }
 
+    scheduledRecoveryRequest = request
     scheduledRecoveryTimer = scheduleTimeout(() => {
-      scheduledRecoveryTimer = undefined
+      clearScheduledRecoveryTimer()
       startRecovery(request)
     }, delayMs)
   }
@@ -307,6 +319,9 @@ export function registerRendererRecovery(options: RendererRecoveryOptions): void
 
   webContents.on('responsive', () => {
     clearUnresponsiveTimer()
+    if (scheduledRecoveryRequest?.trigger === 'unresponsive') {
+      clearScheduledRecoveryTimer()
+    }
     logWithContext({
       severity: 'info',
       event: 'main_window_responsive',

--- a/electron/renderer-recovery.ts
+++ b/electron/renderer-recovery.ts
@@ -12,7 +12,7 @@ export interface RecoverableWebContents {
   on(event: string, callback: (...args: any[]) => void): void
   getURL?: () => string
   isDestroyed?: () => boolean
-  reload?: () => void
+  reload?: () => void | Promise<void>
   forcefullyCrashRenderer?: () => void
 }
 
@@ -132,7 +132,7 @@ export function registerRendererRecovery(options: RendererRecoveryOptions): void
       return
     }
 
-    webContents.reload()
+    await webContents.reload()
   }
 
   const startRecovery = (request: RecoveryRequest) => {

--- a/electron/renderer-recovery.ts
+++ b/electron/renderer-recovery.ts
@@ -9,6 +9,7 @@ export interface RecoverableBrowserWindow {
 }
 
 export interface RecoverableWebContents {
+  readonly id?: number
   on(event: string, callback: (...args: any[]) => void): void
   getURL?: () => string
   isDestroyed?: () => boolean

--- a/electron/renderer-recovery.ts
+++ b/electron/renderer-recovery.ts
@@ -1,0 +1,315 @@
+import type { ElectronMainLogger } from './main-process-logger.js'
+
+export interface RecoverableBrowserWindow {
+  loadURL(url: string): Promise<void>
+  show(): void
+  focus(): void
+  isDestroyed?: () => boolean
+  webContents?: RecoverableWebContents
+}
+
+export interface RecoverableWebContents {
+  on(event: string, callback: (...args: any[]) => void): void
+  getURL?: () => string
+  isDestroyed?: () => boolean
+  reload?: () => void
+  forcefullyCrashRenderer?: () => void
+}
+
+interface RendererRecoveryTimer {
+  setTimeout: typeof globalThis.setTimeout
+  clearTimeout: typeof globalThis.clearTimeout
+}
+
+export interface RendererRecoveryOptions extends RendererRecoveryTimer {
+  window: RecoverableBrowserWindow
+  loadUrl: string
+  serverUrl: string
+  logger: ElectronMainLogger
+  verifyRecovered?: () => Promise<void>
+}
+
+type RecoveryTrigger =
+  | 'render-process-gone'
+  | 'did-fail-load'
+  | 'unresponsive'
+
+type RecoveryMode = 'reload' | 'load-url'
+
+interface RecoveryRequest {
+  trigger: RecoveryTrigger
+  mode: RecoveryMode
+  crashBeforeReload?: boolean
+  metadata?: Record<string, unknown>
+}
+
+const CIRCUIT_WINDOW_MS = 60_000
+const MAX_ATTEMPTS_PER_WINDOW = 3
+const RETRY_DELAYS_MS = [250, 1000, 3000] as const
+const UNRESPONSIVE_THRESHOLD_MS = 15_000
+const ABORTED_NAVIGATION_ERROR_CODE = -3
+
+function isWindowDestroyed(window: RecoverableBrowserWindow): boolean {
+  return window.isDestroyed?.() ?? false
+}
+
+function isWebContentsDestroyed(webContents: RecoverableWebContents | undefined): boolean {
+  return webContents?.isDestroyed?.() ?? false
+}
+
+export function registerRendererRecovery(options: RendererRecoveryOptions): void {
+  const {
+    window,
+    loadUrl,
+    serverUrl,
+    logger,
+    setTimeout: scheduleTimeout,
+    clearTimeout,
+  } = options
+
+  const verifyRecovered = options.verifyRecovered ?? (async () => {})
+  let recoveryInFlight = false
+  let consecutiveFailures = 0
+  let unresponsiveTimer: ReturnType<typeof globalThis.setTimeout> | undefined
+  let scheduledRecoveryTimer: ReturnType<typeof globalThis.setTimeout> | undefined
+  let attemptTimestamps: number[] = []
+
+  const webContents = window.webContents
+  if (!webContents) {
+    return
+  }
+
+  const clearUnresponsiveTimer = () => {
+    if (!unresponsiveTimer) {
+      return
+    }
+
+    clearTimeout(unresponsiveTimer)
+    unresponsiveTimer = undefined
+  }
+
+  const pruneAttempts = (now: number) => {
+    attemptTimestamps = attemptTimestamps.filter((timestamp) => now - timestamp < CIRCUIT_WINDOW_MS)
+  }
+
+  const logWithContext = (entry: Record<string, unknown>) => {
+    logger.log({
+      serverUrl,
+      loadUrl,
+      currentUrl: webContents.getURL?.(),
+      ...entry,
+    })
+  }
+
+  const runRecoveryAction = async (request: RecoveryRequest) => {
+    if (request.mode === 'load-url') {
+      await window.loadURL(loadUrl)
+      return
+    }
+
+    if (request.crashBeforeReload) {
+      webContents.forcefullyCrashRenderer?.()
+    }
+
+    if (!webContents.reload || isWebContentsDestroyed(webContents)) {
+      logWithContext({
+        severity: 'warn',
+        event: 'main_window_recovery_reload_unavailable',
+        trigger: request.trigger,
+      })
+      await window.loadURL(loadUrl)
+      return
+    }
+
+    webContents.reload()
+  }
+
+  const startRecovery = (request: RecoveryRequest) => {
+    recoveryInFlight = true
+    const startedAt = Date.now()
+    attemptTimestamps.push(startedAt)
+    const attempt = attemptTimestamps.length
+
+    logWithContext({
+      severity: 'warn',
+      event: 'main_window_recovery_started',
+      attempt,
+      trigger: request.trigger,
+      mode: request.mode,
+      ...(request.metadata ?? {}),
+    })
+
+    void (async () => {
+      try {
+        if (isWindowDestroyed(window)) {
+          throw new Error('main window destroyed before recovery')
+        }
+
+        await runRecoveryAction(request)
+        await verifyRecovered()
+
+        if (!isWindowDestroyed(window)) {
+          window.show()
+          window.focus()
+        }
+
+        consecutiveFailures = 0
+        logWithContext({
+          severity: 'info',
+          event: 'main_window_recovery_succeeded',
+          attempt,
+          trigger: request.trigger,
+          mode: request.mode,
+          ...(request.metadata ?? {}),
+        })
+      } catch (error) {
+        consecutiveFailures += 1
+        logWithContext({
+          severity: 'error',
+          event: 'main_window_recovery_failed',
+          attempt,
+          trigger: request.trigger,
+          mode: request.mode,
+          ...(request.metadata ?? {}),
+          error,
+        })
+      } finally {
+        recoveryInFlight = false
+      }
+    })()
+  }
+
+  const requestRecovery = (request: RecoveryRequest) => {
+    if (recoveryInFlight) {
+      logWithContext({
+        severity: 'info',
+        event: 'main_window_recovery_skipped',
+        reason: 'recovery-in-flight',
+        trigger: request.trigger,
+        ...(request.metadata ?? {}),
+      })
+      return
+    }
+
+    if (scheduledRecoveryTimer) {
+      logWithContext({
+        severity: 'info',
+        event: 'main_window_recovery_skipped',
+        reason: 'recovery-already-scheduled',
+        trigger: request.trigger,
+        ...(request.metadata ?? {}),
+      })
+      return
+    }
+
+    const now = Date.now()
+    pruneAttempts(now)
+    if (attemptTimestamps.length >= MAX_ATTEMPTS_PER_WINDOW) {
+      logWithContext({
+        severity: 'error',
+        event: 'main_window_recovery_circuit_open',
+        trigger: request.trigger,
+        attemptsInWindow: attemptTimestamps.length,
+        windowMs: CIRCUIT_WINDOW_MS,
+        ...(request.metadata ?? {}),
+      })
+      return
+    }
+
+    const delayMs = consecutiveFailures > 0
+      ? RETRY_DELAYS_MS[Math.min(consecutiveFailures - 1, RETRY_DELAYS_MS.length - 1)]
+      : 0
+
+    if (delayMs === 0) {
+      startRecovery(request)
+      return
+    }
+
+    scheduledRecoveryTimer = scheduleTimeout(() => {
+      scheduledRecoveryTimer = undefined
+      startRecovery(request)
+    }, delayMs)
+  }
+
+  webContents.on('render-process-gone', (_event, details: { reason?: string; exitCode?: number } = {}) => {
+    const metadata = {
+      reason: details.reason ?? 'unknown',
+      exitCode: details.exitCode,
+      willRecover: true,
+    }
+
+    logWithContext({
+      severity: 'warn',
+      event: 'main_window_renderer_gone',
+      ...metadata,
+    })
+
+    requestRecovery({
+      trigger: 'render-process-gone',
+      mode: 'reload',
+      metadata,
+    })
+  })
+
+  webContents.on(
+    'did-fail-load',
+    (
+      _event,
+      errorCode: number,
+      errorDescription: string,
+      validatedUrl: string,
+      isMainFrame: boolean,
+    ) => {
+      const willRecover = isMainFrame && errorCode !== ABORTED_NAVIGATION_ERROR_CODE
+      const metadata = {
+        errorCode,
+        errorDescription,
+        validatedUrl,
+        isMainFrame,
+        willRecover,
+      }
+
+      logWithContext({
+        severity: willRecover ? 'warn' : 'info',
+        event: 'main_window_navigation_failed',
+        ...metadata,
+      })
+
+      if (!willRecover) {
+        return
+      }
+
+      requestRecovery({
+        trigger: 'did-fail-load',
+        mode: 'load-url',
+        metadata,
+      })
+    },
+  )
+
+  webContents.on('unresponsive', () => {
+    clearUnresponsiveTimer()
+    logWithContext({
+      severity: 'warn',
+      event: 'main_window_unresponsive',
+      willRecover: true,
+    })
+
+    unresponsiveTimer = scheduleTimeout(() => {
+      unresponsiveTimer = undefined
+      requestRecovery({
+        trigger: 'unresponsive',
+        mode: 'reload',
+        crashBeforeReload: true,
+      })
+    }, UNRESPONSIVE_THRESHOLD_MS)
+  })
+
+  webContents.on('responsive', () => {
+    clearUnresponsiveTimer()
+    logWithContext({
+      severity: 'info',
+      event: 'main_window_responsive',
+    })
+  })
+}

--- a/electron/startup.ts
+++ b/electron/startup.ts
@@ -1,6 +1,8 @@
 import path from 'path'
 import { buildLocalProbeUrls, discoverLocalServers, normalizeServerUrl } from './launch-discovery.js'
 import { chooseLaunchAction } from './launch-policy.js'
+import type { ElectronMainLogger } from './main-process-logger.js'
+import { registerRendererRecovery, type RecoverableWebContents } from './renderer-recovery.js'
 import { resolveCandidateToken } from './token-resolver.js'
 import type { DesktopConfig, ForcedLaunch, LaunchServerCandidate } from './types.js'
 import type { DaemonManager } from './daemon/daemon-manager.js'
@@ -20,6 +22,7 @@ export interface BrowserWindowLike {
   on(event: string, callback: (...args: any[]) => void): void
   getBounds?(): { x: number; y: number; width: number; height: number }
   isMaximized?(): boolean
+  webContents?: RecoverableWebContents
 }
 
 export interface BrowserWindowConstructor {
@@ -46,6 +49,8 @@ export interface StartupContext {
   /** Read AUTH_TOKEN from the .env file in configDir. Returns undefined if not found. */
   readEnvToken?: (envPath: string) => Promise<string | undefined>
   discoverLaunchCandidates?: () => Promise<LaunchServerCandidate[]>
+  mainProcessLogger?: ElectronMainLogger
+  rendererRecoveryVerifier?: () => Promise<void>
   /**
    * An explicit chooser selection to honor for this launch. When set, startup
    * skips discovery and policy and performs exactly this action.
@@ -147,11 +152,23 @@ async function loadMainWindow(
   }
 
   void window.loadURL(loadUrl).catch((err) => {
+    if (ctx.mainProcessLogger) {
+      ctx.mainProcessLogger.log({
+        severity: 'error',
+        event: 'main_window_initial_load_failed',
+        serverUrl,
+        loadUrl,
+        error: err,
+      })
+      return
+    }
+
     console.error(JSON.stringify({
       severity: 'error',
       component: 'electron-startup',
-      event: 'main_window_load_failed',
+      event: 'main_window_initial_load_failed',
       serverUrl,
+      loadUrl,
       error: err instanceof Error ? err.message : String(err),
     }))
   })
@@ -195,6 +212,27 @@ async function loadMainWindow(
   const updateCheckTimer = setTimeout(() => {
     void ctx.updateManager.checkForUpdates()
   }, 10_000)
+
+  if (ctx.mainProcessLogger) {
+    if (window.webContents) {
+      registerRendererRecovery({
+        window,
+        loadUrl,
+        serverUrl,
+        logger: ctx.mainProcessLogger,
+        verifyRecovered: ctx.rendererRecoveryVerifier,
+        setTimeout,
+        clearTimeout,
+      })
+    } else {
+      ctx.mainProcessLogger.log({
+        severity: 'warn',
+        event: 'main_window_recovery_unavailable',
+        serverUrl,
+        loadUrl,
+      })
+    }
+  }
 
   return { type: 'main', serverUrl, window, updateCheckTimer }
 }

--- a/electron/startup.ts
+++ b/electron/startup.ts
@@ -123,6 +123,14 @@ async function checkRemoteAuthenticated(
   }
 }
 
+function sanitizeStartupFallbackErrorMessage(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err)
+  return message.replace(
+    /([?&]?(?:token|authorization|password|secret)=)[^\s&]+/gi,
+    '[REDACTED]',
+  )
+}
+
 async function loadMainWindow(
   ctx: StartupContext,
   serverUrl: string,
@@ -168,8 +176,7 @@ async function loadMainWindow(
       component: 'electron-startup',
       event: 'main_window_initial_load_failed',
       serverUrl,
-      loadUrl,
-      error: err instanceof Error ? err.message : String(err),
+      error: sanitizeStartupFallbackErrorMessage(err),
     }))
   })
 

--- a/electron/startup.ts
+++ b/electron/startup.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { buildLocalProbeUrls, discoverLocalServers, normalizeServerUrl } from './launch-discovery.js'
 import { chooseLaunchAction } from './launch-policy.js'
-import type { ElectronMainLogger } from './main-process-logger.js'
+import { redactUrlForLog, type ElectronMainLogger } from './main-process-logger.js'
 import { registerRendererRecovery, type RecoverableWebContents } from './renderer-recovery.js'
 import { resolveCandidateToken } from './token-resolver.js'
 import type { DesktopConfig, ForcedLaunch, LaunchServerCandidate } from './types.js'
@@ -175,7 +175,7 @@ async function loadMainWindow(
       severity: 'error',
       component: 'electron-startup',
       event: 'main_window_initial_load_failed',
-      serverUrl,
+      serverUrl: redactUrlForLog(serverUrl),
       error: sanitizeStartupFallbackErrorMessage(err),
     }))
   })

--- a/test/e2e-electron/electron-app.test.ts
+++ b/test/e2e-electron/electron-app.test.ts
@@ -10,6 +10,7 @@ import { test, expect, _electron as electron, type ElectronApplication, type Pag
 import path from 'path'
 import fs from 'fs'
 import os from 'os'
+import { TestServer } from '../e2e-browser/helpers/test-server.js'
 
 const PROJECT_ROOT = path.resolve(import.meta.dirname, '..', '..')
 
@@ -47,6 +48,10 @@ function createTempHome(desktopConfig?: Record<string, unknown>): string {
     )
   }
   return tmpHome
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 function writeDesktopEnv(tmpHome: string): void {
@@ -106,7 +111,13 @@ async function waitForWindowUrl(
   while (Date.now() - start < timeoutMs) {
     for (const win of app.windows()) {
       if (pattern.test(win.url())) {
-        return win
+        try {
+          await win.evaluate(() => true)
+          return win
+        } catch {
+          // A crashed renderer can keep its last URL in Playwright. Keep
+          // polling until Electron exposes the recovered window target.
+        }
       }
     }
     await new Promise(r => setTimeout(r, 500))
@@ -128,6 +139,109 @@ function remoteConfig() {
     setupCompleted: true,
   }
 }
+
+// ---------------------------------------------------------------------------
+// Test: Renderer crash recovery
+// ---------------------------------------------------------------------------
+
+test.describe('Renderer crash recovery', () => {
+  let app: ElectronApplication | undefined
+  let server: TestServer | undefined
+  let tmpHome: string | undefined
+
+  test.afterEach(async () => {
+    if (app) {
+      await app.evaluate(() => {
+        ;(globalThis as any).__restoreOpenExternal?.()
+      }).catch(() => {})
+      await app.close().catch(() => {})
+      app = undefined
+    }
+    if (server) {
+      await server.stop().catch(() => {})
+      server = undefined
+    }
+    if (tmpHome) {
+      fs.rmSync(tmpHome, { recursive: true, force: true })
+      tmpHome = undefined
+    }
+  })
+
+  test('recovers the main Freshell UI after the renderer process crashes', async () => {
+    server = new TestServer()
+    const serverInfo = await server.start()
+    tmpHome = createTempHome({
+      serverMode: 'remote',
+      port: serverInfo.port,
+      remoteUrl: serverInfo.baseUrl,
+      remoteToken: serverInfo.token,
+      knownServers: [],
+      alwaysAskOnLaunch: false,
+      globalHotkey: 'CommandOrControl+`',
+      startOnLogin: false,
+      minimizeToTray: true,
+      setupCompleted: true,
+    })
+
+    app = await launchApp(tmpHome, true)
+    const firstWindow = await app.firstWindow()
+    await firstWindow.waitForLoadState('domcontentloaded')
+    await expect(firstWindow.locator('text=New Tab').first()).toBeVisible({ timeout: 30_000 })
+
+    const crashed = firstWindow.waitForEvent('crash', { timeout: 10_000 }).catch(() => undefined)
+    await app.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0].webContents.forcefullyCrashRenderer()
+    })
+    await crashed
+
+    const recoveredWindow = await waitForWindowUrl(
+      app,
+      new RegExp(`^${escapeRegExp(serverInfo.baseUrl)}(?:[/?#]|$)`),
+      60_000,
+    )
+    await recoveredWindow.waitForLoadState('domcontentloaded')
+    await expect(recoveredWindow.locator('text=New Tab').first()).toBeVisible({ timeout: 30_000 })
+
+    await app.evaluate(({ shell }) => {
+      const original = shell.openExternal
+      ;(globalThis as any).__testOpenExternal = (url: string) => {
+        ;(globalThis as any).__openedUrl = url
+        return Promise.resolve()
+      }
+      ;(globalThis as any).__restoreOpenExternal = () => {
+        shell.openExternal = original
+      }
+      shell.openExternal = (globalThis as any).__testOpenExternal
+    })
+
+    await recoveredWindow.evaluate(async () => {
+      const link = document.createElement('a')
+      link.href = 'https://example.com/freshell-recovery-ipc'
+      link.target = '_blank'
+      link.rel = 'noopener noreferrer'
+      link.textContent = 'test recovery external link'
+      document.body.appendChild(link)
+
+      const event = new MouseEvent('click', { ctrlKey: true, bubbles: true })
+      link.dispatchEvent(event)
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 500))
+    })
+
+    await expect.poll(async () =>
+      app!.evaluate(() => (globalThis as any).__openedUrl),
+    ).toBe('https://example.com/freshell-recovery-ipc')
+
+    await expect.poll(() => {
+      const logsDir = path.join(tmpHome!, '.freshell', 'logs')
+      if (!fs.existsSync(logsDir)) return ''
+      return fs.readdirSync(logsDir)
+        .filter((fileName) => /^electron-main\..*\.jsonl$/.test(fileName))
+        .map((fileName) => fs.readFileSync(path.join(logsDir, fileName), 'utf-8'))
+        .join('\n')
+    }, { timeout: 30_000 }).toContain('main_window_recovery_succeeded')
+  })
+})
 
 // ---------------------------------------------------------------------------
 // Test: Wizard Flow

--- a/test/e2e-electron/electron-app.test.ts
+++ b/test/e2e-electron/electron-app.test.ts
@@ -453,9 +453,7 @@ test.describe('Main window with remote server', () => {
 
     // Patch shell.openExternal in the main process so the test can observe the
     // real IPC flow without actually launching a browser window.
-    await app.evaluate(() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { shell } = require('electron')
+    await app.evaluate(({ shell }) => {
       const original = shell.openExternal
       ;(globalThis as any).__testOpenExternal = (url: string) => {
         ;(globalThis as any).__openedUrl = url

--- a/test/unit/electron/main-process-logger.test.ts
+++ b/test/unit/electron/main-process-logger.test.ts
@@ -1,0 +1,114 @@
+import fs from 'fs'
+import fsp from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createElectronMainLogger } from '../../../electron/main-process-logger.js'
+
+describe('main process logger', () => {
+  let configDir: string
+
+  beforeEach(async () => {
+    configDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'electron-main-logger-'))
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await fsp.rm(configDir, { recursive: true, force: true })
+  })
+
+  it('writes structured JSONL events under configDir/logs', () => {
+    const logger = createElectronMainLogger({
+      configDir,
+      now: () => new Date('2026-06-28T20:58:50.000Z'),
+      pid: 1234,
+    })
+
+    logger.log({
+      severity: 'warn',
+      event: 'main_window_renderer_gone',
+      url: 'http://localhost:3001/?token=secret-token&tab=one',
+      reason: 'crashed',
+    })
+
+    const files = fs.readdirSync(path.join(configDir, 'logs'))
+    expect(files).toEqual(['electron-main.1234.jsonl'])
+    const [line] = fs.readFileSync(path.join(configDir, 'logs', files[0]), 'utf8').trim().split('\n')
+    expect(JSON.parse(line)).toEqual({
+      timestamp: '2026-06-28T20:58:50.000Z',
+      severity: 'warn',
+      component: 'electron-main',
+      event: 'main_window_renderer_gone',
+      url: 'http://localhost:3001/?token=[REDACTED]&tab=one',
+      reason: 'crashed',
+    })
+  })
+
+  it('falls back to stderr when the log file cannot be written', () => {
+    const error = new Error('EACCES for token=file-secret')
+    const appendFileSync = vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {
+      throw error
+    })
+    const stderr = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const logger = createElectronMainLogger({
+      configDir,
+      now: () => new Date('2026-06-28T20:58:50.000Z'),
+      pid: 1234,
+    })
+    logger.log({
+      severity: 'error',
+      event: 'main_window_recovery_failed',
+      url: 'http://localhost:3001/?token=query-secret',
+      error,
+    })
+
+    expect(appendFileSync).toHaveBeenCalled()
+    expect(stderr).toHaveBeenCalledTimes(1)
+    const [line] = stderr.mock.calls[0]
+    expect(JSON.parse(line)).toMatchObject({
+      timestamp: '2026-06-28T20:58:50.000Z',
+      severity: 'error',
+      component: 'electron-main',
+      event: 'main_window_recovery_failed',
+      url: 'http://localhost:3001/?token=[REDACTED]',
+      error: {
+        name: 'Error',
+        message: 'EACCES for token=[REDACTED]',
+        stack: expect.stringContaining('EACCES for token=[REDACTED]'),
+      },
+    })
+  })
+
+  it('redacts token-bearing keys, URL token parameters, and token-like string fragments', () => {
+    const logger = createElectronMainLogger({
+      configDir,
+      now: () => new Date('2026-06-28T20:58:50.000Z'),
+      pid: 1234,
+    })
+
+    logger.log({
+      severity: 'warn',
+      event: 'token_redaction_probe',
+      remoteToken: 'plain-secret',
+      nested: {
+        authToken: 'nested-secret',
+        url: 'http://localhost:3001/?token=query-secret',
+      },
+      error: new Error('failed for token=message-secret'),
+    })
+
+    const line = fs.readFileSync(path.join(configDir, 'logs', 'electron-main.1234.jsonl'), 'utf8').trim()
+    expect(line).not.toContain('plain-secret')
+    expect(line).not.toContain('nested-secret')
+    expect(line).not.toContain('query-secret')
+    expect(line).not.toContain('message-secret')
+    expect(JSON.parse(line)).toMatchObject({
+      remoteToken: '[REDACTED]',
+      nested: {
+        authToken: '[REDACTED]',
+        url: 'http://localhost:3001/?token=[REDACTED]',
+      },
+    })
+  })
+})

--- a/test/unit/electron/renderer-recovery.test.ts
+++ b/test/unit/electron/renderer-recovery.test.ts
@@ -86,6 +86,23 @@ describe('registerRendererRecovery', () => {
     }))
   })
 
+  it('shows and focuses the window after recovery succeeds', async () => {
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+    })
+
+    window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(window.show).toHaveBeenCalledTimes(1)
+    expect(window.focus).toHaveBeenCalledTimes(1)
+  })
+
   it('recovers clean renderer exits while the main window is expected to stay alive', async () => {
     registerRendererRecovery({
       window,
@@ -148,6 +165,108 @@ describe('registerRendererRecovery', () => {
     await vi.advanceTimersByTimeAsync(15_000)
     expect(window.webContents.forcefullyCrashRenderer).toHaveBeenCalledTimes(1)
     expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('backs off before retrying after a failed recovery', async () => {
+    const verifyRecovered = vi.fn()
+      .mockRejectedValueOnce(new Error('recovery failed'))
+      .mockResolvedValueOnce(undefined)
+
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+      verifyRecovered,
+    })
+
+    window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+
+    window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await vi.advanceTimersByTimeAsync(249)
+    expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(window.webContents.reload).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancels queued unresponsive backoff recovery when the renderer becomes responsive', async () => {
+    const verifyRecovered = vi.fn().mockRejectedValueOnce(new Error('recovery failed'))
+
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+      verifyRecovered,
+    })
+
+    window.webContents.emit('unresponsive')
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(window.webContents.forcefullyCrashRenderer).toHaveBeenCalledTimes(1)
+    expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+
+    window.webContents.emit('unresponsive')
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+
+    window.webContents.emit('responsive')
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(window.webContents.forcefullyCrashRenderer).toHaveBeenCalledTimes(1)
+    expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to loadURL and logs when reload is unavailable', async () => {
+    Reflect.deleteProperty(window.webContents, 'reload')
+
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+    })
+
+    window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(window.loadURL).toHaveBeenCalledWith(loadUrl)
+    expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+      severity: 'warn',
+      event: 'main_window_recovery_reload_unavailable',
+      trigger: 'render-process-gone',
+    }))
+  })
+
+  it('falls back to loadURL and logs when webContents is destroyed before reload', async () => {
+    window.webContents.isDestroyed.mockReturnValue(true)
+
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+    })
+
+    window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(window.loadURL).toHaveBeenCalledWith(loadUrl)
+    expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+      severity: 'warn',
+      event: 'main_window_recovery_reload_unavailable',
+      trigger: 'render-process-gone',
+    }))
   })
 
   it('stops retrying after the crash-loop circuit breaker opens', async () => {

--- a/test/unit/electron/renderer-recovery.test.ts
+++ b/test/unit/electron/renderer-recovery.test.ts
@@ -1,0 +1,229 @@
+import { EventEmitter } from 'events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ElectronMainLogger } from '../../../electron/main-process-logger.js'
+import {
+  registerRendererRecovery,
+  type RecoverableBrowserWindow,
+  type RecoverableWebContents,
+} from '../../../electron/renderer-recovery.js'
+
+type MockWebContents = RecoverableWebContents & EventEmitter & {
+  emit: EventEmitter['emit']
+  reload: ReturnType<typeof vi.fn>
+  forcefullyCrashRenderer: ReturnType<typeof vi.fn>
+  getURL: ReturnType<typeof vi.fn>
+  isDestroyed: ReturnType<typeof vi.fn>
+}
+
+type MockWindow = RecoverableBrowserWindow & {
+  loadURL: ReturnType<typeof vi.fn>
+  show: ReturnType<typeof vi.fn>
+  focus: ReturnType<typeof vi.fn>
+  isDestroyed: ReturnType<typeof vi.fn>
+  webContents: MockWebContents
+}
+
+function createRecoverableWindow(loadUrl: string): MockWindow {
+  const webContents = new EventEmitter() as MockWebContents
+  webContents.reload = vi.fn()
+  webContents.forcefullyCrashRenderer = vi.fn()
+  webContents.getURL = vi.fn().mockReturnValue(loadUrl)
+  webContents.isDestroyed = vi.fn().mockReturnValue(false)
+
+  return {
+    loadURL: vi.fn().mockResolvedValue(undefined),
+    show: vi.fn(),
+    focus: vi.fn(),
+    isDestroyed: vi.fn().mockReturnValue(false),
+    webContents,
+  }
+}
+
+describe('registerRendererRecovery', () => {
+  const serverUrl = 'http://localhost:5173'
+  const loadUrl = `${serverUrl}/?token=super-secret`
+  let logger: ElectronMainLogger & { log: ReturnType<typeof vi.fn> }
+  let window: MockWindow
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    logger = { log: vi.fn() }
+    window = createRecoverableWindow(loadUrl)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('reloads the crashed renderer when the renderer process is gone', async () => {
+    const verifyRecovered = vi.fn().mockResolvedValue(undefined)
+
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+      verifyRecovered,
+    })
+
+    window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+    expect(window.loadURL).not.toHaveBeenCalled()
+    expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+      severity: 'warn',
+      event: 'main_window_renderer_gone',
+      reason: 'crashed',
+      exitCode: 133,
+    }))
+    expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+      severity: 'info',
+      event: 'main_window_recovery_succeeded',
+    }))
+  })
+
+  it('recovers clean renderer exits while the main window is expected to stay alive', async () => {
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+    })
+
+    window.webContents.emit('render-process-gone', {}, { reason: 'clean-exit', exitCode: 0 })
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+    expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'main_window_renderer_gone',
+      reason: 'clean-exit',
+      willRecover: true,
+    }))
+  })
+
+  it('logs did-fail-load and retries only main-frame non-abort failures', async () => {
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+    })
+
+    window.webContents.emit('did-fail-load', {}, -102, 'CONNECTION_REFUSED', loadUrl, true)
+    await vi.runOnlyPendingTimersAsync()
+    expect(window.loadURL).toHaveBeenCalledWith(loadUrl)
+
+    window.webContents.emit('did-fail-load', {}, -3, 'ERR_ABORTED', loadUrl, true)
+    expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'main_window_navigation_failed',
+      errorCode: -3,
+      willRecover: false,
+    }))
+  })
+
+  it('recovers after a sustained unresponsive renderer and cancels when responsive returns', async () => {
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+    })
+
+    window.webContents.emit('unresponsive')
+    window.webContents.emit('responsive')
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(window.loadURL).not.toHaveBeenCalled()
+
+    window.webContents.emit('unresponsive')
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(window.webContents.forcefullyCrashRenderer).toHaveBeenCalledTimes(1)
+    expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops retrying after the crash-loop circuit breaker opens', async () => {
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+    })
+
+    for (let index = 0; index < 4; index += 1) {
+      window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+      await vi.runOnlyPendingTimersAsync()
+    }
+
+    expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+      severity: 'error',
+      event: 'main_window_recovery_circuit_open',
+    }))
+  })
+
+  it('coalesces duplicate failure events while one recovery attempt is in flight', async () => {
+    const verifyRecovered = vi.fn().mockReturnValue(new Promise(() => {}))
+
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+      verifyRecovered,
+    })
+
+    window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    window.webContents.emit('did-fail-load', {}, -102, 'CONNECTION_REFUSED', loadUrl, true)
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(window.webContents.reload).toHaveBeenCalledTimes(1)
+    expect(window.loadURL).not.toHaveBeenCalled()
+    expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'main_window_recovery_skipped',
+      reason: 'recovery-in-flight',
+    }))
+  })
+
+  it('does not log success until the recovery verifier resolves', async () => {
+    let resolveVerifier!: () => void
+    const verifyRecovered = vi.fn().mockReturnValue(new Promise<void>((resolve) => {
+      resolveVerifier = resolve
+    }))
+
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+      verifyRecovered,
+    })
+
+    window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(logger.log).not.toHaveBeenCalledWith(expect.objectContaining({
+      event: 'main_window_recovery_succeeded',
+    }))
+
+    resolveVerifier()
+    await Promise.resolve()
+
+    expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'main_window_recovery_succeeded',
+    }))
+  })
+})

--- a/test/unit/electron/renderer-recovery.test.ts
+++ b/test/unit/electron/renderer-recovery.test.ts
@@ -380,4 +380,32 @@ describe('registerRendererRecovery', () => {
     expect(window.show).toHaveBeenCalledTimes(1)
     expect(window.focus).toHaveBeenCalledTimes(1)
   })
+
+  it('logs recovery failure without success when an async renderer reload rejects', async () => {
+    window.webContents.reload.mockRejectedValue(new Error('replacement load failed'))
+
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+    })
+
+    window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.waitFor(() => {
+      expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+        severity: 'error',
+        event: 'main_window_recovery_failed',
+      }))
+    })
+    expect(logger.log).not.toHaveBeenCalledWith(expect.objectContaining({
+      event: 'main_window_recovery_succeeded',
+    }))
+    expect(window.show).not.toHaveBeenCalled()
+    expect(window.focus).not.toHaveBeenCalled()
+  })
 })

--- a/test/unit/electron/renderer-recovery.test.ts
+++ b/test/unit/electron/renderer-recovery.test.ts
@@ -345,4 +345,39 @@ describe('registerRendererRecovery', () => {
       event: 'main_window_recovery_succeeded',
     }))
   })
+
+  it('does not log success until an async renderer reload resolves', async () => {
+    let resolveReload!: () => void
+    window.webContents.reload.mockReturnValue(new Promise<void>((resolve) => {
+      resolveReload = resolve
+    }))
+
+    registerRendererRecovery({
+      window,
+      loadUrl,
+      serverUrl,
+      logger,
+      setTimeout,
+      clearTimeout,
+    })
+
+    window.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(logger.log).not.toHaveBeenCalledWith(expect.objectContaining({
+      event: 'main_window_recovery_succeeded',
+    }))
+    expect(window.show).not.toHaveBeenCalled()
+    expect(window.focus).not.toHaveBeenCalled()
+
+    resolveReload()
+
+    await vi.waitFor(() => {
+      expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+        event: 'main_window_recovery_succeeded',
+      }))
+    })
+    expect(window.show).toHaveBeenCalledTimes(1)
+    expect(window.focus).toHaveBeenCalledTimes(1)
+  })
 })

--- a/test/unit/electron/startup.test.ts
+++ b/test/unit/electron/startup.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EventEmitter } from 'events'
 import path from 'path'
 import { runStartup, type StartupContext, type BrowserWindowLike } from '../../../electron/startup.js'
 import type { DesktopConfig } from '../../../electron/types.js'
@@ -20,6 +21,31 @@ function createMockWindow(): BrowserWindowLike {
     isVisible: vi.fn().mockImplementation(() => visible),
     isFocused: vi.fn().mockImplementation(() => focused),
     on: vi.fn(),
+  }
+}
+
+function createMockWindowWithWebContents(): BrowserWindowLike & {
+  webContents: EventEmitter & {
+    on: ReturnType<typeof vi.fn>
+    reload: ReturnType<typeof vi.fn>
+    getURL: ReturnType<typeof vi.fn>
+    emit: (event: string, ...args: any[]) => boolean
+  }
+} {
+  const window = createMockWindow()
+  const emitter = new EventEmitter()
+  const originalOn = emitter.on.bind(emitter)
+  const originalEmit = emitter.emit.bind(emitter)
+  const webContents = Object.assign(emitter, {
+    on: vi.fn(originalOn),
+    reload: vi.fn(),
+    getURL: vi.fn().mockReturnValue('http://localhost:3001/'),
+    emit: originalEmit,
+  })
+
+  return {
+    ...window,
+    webContents,
   }
 }
 
@@ -624,6 +650,57 @@ describe('runStartup', () => {
     const ctx = createDefaultContext()
     await runStartup(ctx)
     expect(ctx.hotkeyManager.register).toHaveBeenCalledWith('CommandOrControl+`', expect.any(Function))
+  })
+
+  it('registers renderer recovery for the main window and reloads the crashed renderer', async () => {
+    const mockWindow = createMockWindowWithWebContents()
+    const logger = { log: vi.fn() }
+    const ctx = createDefaultContext({
+      createBrowserWindow: vi.fn().mockReturnValue(mockWindow),
+      mainProcessLogger: logger,
+      rendererRecoveryVerifier: vi.fn().mockResolvedValue(undefined),
+      readEnvToken: vi.fn().mockResolvedValue('env token+with&chars'),
+    })
+
+    const result = await runStartup(ctx)
+    expect(result.type).toBe('main')
+
+    mockWindow.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 9 })
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(mockWindow.webContents.reload).toHaveBeenCalledTimes(1)
+    expect(ctx.serverSpawner.start).toHaveBeenCalledTimes(1)
+    expect(ctx.serverSpawner.stop).not.toHaveBeenCalled()
+  })
+
+  it('reuses the same authenticated URL for recoverable main-frame load failures', async () => {
+    const mockWindow = createMockWindowWithWebContents()
+    const logger = { log: vi.fn() }
+    const ctx = createDefaultContext({
+      createBrowserWindow: vi.fn().mockReturnValue(mockWindow),
+      mainProcessLogger: logger,
+      rendererRecoveryVerifier: vi.fn().mockResolvedValue(undefined),
+      readEnvToken: vi.fn().mockResolvedValue('env token+with&chars'),
+    })
+
+    const result = await runStartup(ctx)
+    expect(result.type).toBe('main')
+
+    mockWindow.webContents.emit('did-fail-load', {}, -102, 'CONNECTION_REFUSED', 'http://localhost:3001/', true)
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(mockWindow.loadURL).toHaveBeenLastCalledWith('http://localhost:3001?token=env%20token%2Bwith%26chars')
+    expect(ctx.serverSpawner.start).toHaveBeenCalledTimes(1)
+    expect(ctx.serverSpawner.stop).not.toHaveBeenCalled()
+  })
+
+  it('logs an explicit warning when recovery cannot attach because webContents is unavailable', async () => {
+    const logger = { log: vi.fn() }
+    await runStartup(createDefaultContext({ mainProcessLogger: logger }))
+    expect(logger.log).toHaveBeenCalledWith(expect.objectContaining({
+      severity: 'warn',
+      event: 'main_window_recovery_unavailable',
+    }))
   })
 
   describe('hotkey quake-style toggle', () => {

--- a/test/unit/electron/startup.test.ts
+++ b/test/unit/electron/startup.test.ts
@@ -730,12 +730,25 @@ describe('runStartup', () => {
 
   it('logs a sanitized fallback error when the initial load fails without a main-process logger', async () => {
     const mockWindow = createMockWindow()
-    const error = new Error('failed to load http://localhost:3001?token=token-abc')
+    const error = new Error('failed to load http://remote.example:3001/?token=saved-remote-token&workspace=main')
     ;(mockWindow.loadURL as ReturnType<typeof vi.fn>).mockRejectedValue(error)
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const ctx = createDefaultContext({
+      desktopConfig: {
+        serverMode: 'remote',
+        port: 3001,
+        remoteUrl: 'http://remote.example:3001/?token=saved-remote-token&workspace=main',
+        remoteToken: 'token-abc',
+        knownServers: [],
+        alwaysAskOnLaunch: false,
+        globalHotkey: 'CommandOrControl+`',
+        startOnLogin: false,
+        minimizeToTray: true,
+        setupCompleted: true,
+      },
       createBrowserWindow: vi.fn().mockReturnValue(mockWindow),
-      readEnvToken: vi.fn().mockResolvedValue('token-abc'),
+      fetchHealthCheck: vi.fn().mockResolvedValue(true),
+      fetchAuthenticated: vi.fn().mockResolvedValue(true),
     })
 
     const result = await runStartup(ctx)
@@ -746,16 +759,16 @@ describe('runStartup', () => {
     const [payload] = consoleErrorSpy.mock.calls[0] ?? []
     expect(typeof payload).toBe('string')
     expect(payload).toContain('"event":"main_window_initial_load_failed"')
-    expect(payload).toContain('"serverUrl":"http://localhost:3001"')
-    expect(payload).not.toContain('token=')
+    expect(payload).not.toContain('token=saved-remote-token')
     expect(payload).not.toContain('token-abc')
+    expect(payload).not.toContain('saved-remote-token')
 
     const parsed = JSON.parse(payload as string) as Record<string, unknown>
     expect(parsed).toMatchObject({
       severity: 'error',
       component: 'electron-startup',
       event: 'main_window_initial_load_failed',
-      serverUrl: 'http://localhost:3001',
+      serverUrl: 'http://remote.example:3001/?token=%5BREDACTED%5D&workspace=main',
     })
     expect(parsed).not.toHaveProperty('loadUrl')
 

--- a/test/unit/electron/startup.test.ts
+++ b/test/unit/electron/startup.test.ts
@@ -703,6 +703,65 @@ describe('runStartup', () => {
     }))
   })
 
+  it('logs main_window_initial_load_failed through the main-process logger with the authenticated load URL', async () => {
+    const mockWindow = createMockWindowWithWebContents()
+    const error = new Error('initial load failed')
+    ;(mockWindow.loadURL as ReturnType<typeof vi.fn>).mockRejectedValue(error)
+    const logger = { log: vi.fn() }
+    const ctx = createDefaultContext({
+      createBrowserWindow: vi.fn().mockReturnValue(mockWindow),
+      mainProcessLogger: logger,
+      rendererRecoveryVerifier: vi.fn().mockResolvedValue(undefined),
+      readEnvToken: vi.fn().mockResolvedValue('token-abc'),
+    })
+
+    const result = await runStartup(ctx)
+    expect(result.type).toBe('main')
+    await Promise.resolve()
+
+    expect(logger.log).toHaveBeenCalledWith({
+      severity: 'error',
+      event: 'main_window_initial_load_failed',
+      serverUrl: 'http://localhost:3001',
+      loadUrl: 'http://localhost:3001?token=token-abc',
+      error,
+    })
+  })
+
+  it('logs a sanitized fallback error when the initial load fails without a main-process logger', async () => {
+    const mockWindow = createMockWindow()
+    const error = new Error('failed to load http://localhost:3001?token=token-abc')
+    ;(mockWindow.loadURL as ReturnType<typeof vi.fn>).mockRejectedValue(error)
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const ctx = createDefaultContext({
+      createBrowserWindow: vi.fn().mockReturnValue(mockWindow),
+      readEnvToken: vi.fn().mockResolvedValue('token-abc'),
+    })
+
+    const result = await runStartup(ctx)
+    expect(result.type).toBe('main')
+    await Promise.resolve()
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+    const [payload] = consoleErrorSpy.mock.calls[0] ?? []
+    expect(typeof payload).toBe('string')
+    expect(payload).toContain('"event":"main_window_initial_load_failed"')
+    expect(payload).toContain('"serverUrl":"http://localhost:3001"')
+    expect(payload).not.toContain('token=')
+    expect(payload).not.toContain('token-abc')
+
+    const parsed = JSON.parse(payload as string) as Record<string, unknown>
+    expect(parsed).toMatchObject({
+      severity: 'error',
+      component: 'electron-startup',
+      event: 'main_window_initial_load_failed',
+      serverUrl: 'http://localhost:3001',
+    })
+    expect(parsed).not.toHaveProperty('loadUrl')
+
+    consoleErrorSpy.mockRestore()
+  })
+
   describe('hotkey quake-style toggle', () => {
     it('shows and focuses window when hidden', async () => {
       const mockWindow = createMockWindow()


### PR DESCRIPTION
Summary:
- add durable Electron main-process JSONL logging with redaction
- supervise the main renderer for crash, load-failure, and unresponsive blank-page recovery
- replace unusable crashed BrowserWindows during recovery while preserving external-link IPC
- add focused unit coverage and Electron e2e crash recovery coverage

Verification:
- FRESHELL_TEST_SUMMARY="rebased electron renderer recovery before PR" npm run check
- client: 358 files, 3,878 tests passed
- server: 273 passed / 1 skipped files, 4,142 passed / 9 skipped tests
- electron: 33 files, 347 tests passed