### PR TITLE
Fix Codex startup update prompt handling

### DIFF
--- a/docs/superpowers/plans/2026-06-29-codex-startup-update-prompt.md
+++ b/docs/superpowers/plans/2026-06-29-codex-startup-update-prompt.md
@@ -1,6 +1,6 @@
 # Codex Startup Update Prompt Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Status:** Implemented on `fix/codex-managed-update-prompt`. This document is retained as the completed implementation runbook, not as pending instructions. A final review changed Task 2 from the original freshness-TTL design to the shipped TTL-free design: once Freshell has detected the Codex startup update prompt, the prompt remains answerable until the user chooses an option or the Codex input gate is cleared.
 
 **Goal:** Allow users and supported automation surfaces to accept, skip, or run Codex CLI startup updates in terminal-mode Codex panes while Freshell is still waiting for Codex restore identity capture.
 
@@ -65,7 +65,7 @@
 - Produces: visible terminal launch args that contain only `-c`, `features.apps=false`.
 - Produces: hidden app-server launch args that contain only `-c`, `features.apps=false`.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 In `test/unit/server/terminal-registry.test.ts`, change the managed remote-launch expectation so only `features.apps=false` is asserted in the first four arg positions and the update-check flag is explicitly absent:
 
@@ -87,7 +87,7 @@ expect(args).not.toContain('check_for_update_on_startup=false')
 expect(args.indexOf('features.apps=false')).toBeLessThan(args.indexOf('app-server'))
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run:
 
@@ -97,7 +97,7 @@ npm run test:vitest -- run test/unit/server/terminal-registry.test.ts test/unit/
 
 Expected: FAIL because visible terminal launch args still include `check_for_update_on_startup=false`.
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 Change `server/coding-cli/codex-managed-config.ts` to:
 
@@ -108,7 +108,7 @@ export const CODEX_MANAGED_REMOTE_CONFIG_ARGS = [
 ] as const
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run:
 
@@ -118,7 +118,7 @@ npm run test:vitest -- run test/unit/server/terminal-registry.test.ts test/unit/
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add server/coding-cli/codex-managed-config.ts test/unit/server/terminal-registry.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -138,14 +138,14 @@ git commit -m "fix(codex): keep managed update checks enabled"
 - Produces: per-terminal `codexInputGate` union with:
   - `state: 'identity_pending'`
   - optional live `startupOutputTail`
-  - optional `startupUpdatePrompt` with `detectedAt` and `lastMatchedAt`
-  - `state: 'update_running'` with `startedAt`
+  - optional `startupUpdatePrompt: true`
+  - `state: 'update_running'`
 - Produces helper behavior:
-  - `observeCodexStartupOutput(record, data, now)` updates a bounded live-output tail only while identity is pending.
+  - `observeCodexStartupOutput(record, data)` updates a bounded live-output tail only while identity is pending.
   - `hasCodexStartupUpdatePrompt(text)` detects the update prompt without requiring `Update available!`.
-  - `handleCodexStartupUpdatePromptInput(record, data, now)` forwards only menu/control input and transitions state.
+  - `handleCodexStartupUpdatePromptInput(record, data)` forwards only menu/control input and transitions state.
 
-- [ ] **Step 1: Write failing update-prompt tests**
+- [x] **Step 1: Write failing update-prompt tests**
 
 In `test/unit/server/terminal-registry.codex-sidecar.test.ts`, replace the existing `allows Codex update prompt menu replies while restore identity is pending` test and add focused tests covering:
 
@@ -334,7 +334,7 @@ it('blocks update prompt arrow navigation rather than tracking highlight state',
 })
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run:
 
@@ -344,7 +344,7 @@ npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test
 
 Expected: FAIL because the current detector requires `Update available!`, scans scrollback at input time, and has no live prompt state.
 
-- [ ] **Step 3: Implement live prompt state**
+- [x] **Step 3: Implement live prompt state**
 
 In `server/terminal-registry.ts`, replace the old `codexUpdatePromptDismissed` field and scrollback input detector with these concepts:
 
@@ -355,14 +355,10 @@ type CodexInputGate =
   | {
       state: 'identity_pending'
       startupOutputTail?: string
-      startupUpdatePrompt?: {
-        detectedAt: number
-        lastMatchedAt: number
-      }
+      startupUpdatePrompt?: true
     }
   | {
       state: 'update_running'
-      startedAt: number
     }
 ```
 
@@ -372,35 +368,35 @@ Use a bounded live-output tail:
 
 ```ts
 const CODEX_STARTUP_UPDATE_PROMPT_TAIL_CHARS = 8 * 1024
-const CODEX_STARTUP_UPDATE_PROMPT_TTL_MS = 10 * 60 * 1000
 ```
 
 Normalize terminal text with existing `stripTerminalControls()` and newline-preserving whitespace normalization: convert `\r` to `\n` and normalize spaces/tabs, but do not collapse newlines because the detector anchors on line starts. Implement `hasCodexStartupUpdatePrompt(text: string)` so it requires all of:
 
 ```ts
 text.includes('github.com/openai/codex/releases/latest')
-/(?:^|\n)\s*[›> ]*\s*1[.)]\s*Update now\s*\(runs\s+`?[^`\n]*(?:npm|bun|brew)[^`\n]*`?\)/i
-/(?:^|\n)\s*[›> ]*\s*2[.)]\s*Skip\b/i
-/(?:^|\n)\s*[›> ]*\s*3[.)]\s*Skip until next version\b/i
+/(?:^|\n)[ \t]*[›>]?[ \t]*1[.)][ \t]*Update now[ \t]*\(runs[ \t]+`?[^`\n]*(?:npm|bun|brew)[^`\n]*`?\)/i
+/(?:^|\n)[ \t]*[›>]?[ \t]*2[.)][ \t]*Skip\b/i
+/(?:^|\n)[ \t]*[›>]?[ \t]*3[.)][ \t]*Skip until next version\b/i
 /Press\s+enter\s+to\s+continue/i
 ```
 
-Add `observeCodexStartupOutput(record, data, now)` and call it from both PTY `onData` handlers immediately after `record.buffer.append(data)` and before `this.emit('terminal.output.raw', ...)` or any direct client send path. It should update `startupOutputTail` only when `record.codexInputGate?.state === 'identity_pending'`, and set or refresh `startupUpdatePrompt` when `hasCodexStartupUpdatePrompt()` matches the live tail.
+Add `observeCodexStartupOutput(record, data)` and call it from both PTY `onData` handlers immediately after `record.buffer.append(data)` and before `this.emit('terminal.output.raw', ...)` or any direct client send path. It should update `startupOutputTail` only when `record.codexInputGate?.state === 'identity_pending'`, and set `startupUpdatePrompt` when `hasCodexStartupUpdatePrompt()` matches the live tail.
 
 Implement prompt input handling:
 
 ```ts
-function isCodexStartupUpdatePromptFresh(gate: CodexInputGate | undefined, now: number): boolean {
+function hasActiveCodexStartupUpdatePrompt(gate: CodexInputGate | undefined): boolean {
   return gate?.state === 'identity_pending'
     && !!gate.startupUpdatePrompt
-    && now - gate.startupUpdatePrompt.lastMatchedAt <= CODEX_STARTUP_UPDATE_PROMPT_TTL_MS
 }
 ```
+
+Do not expire a detected startup update prompt on wall-clock time alone. The visible Codex prompt remains answerable even if the user leaves it idle for a long time; otherwise Freshell can age into a state where menu selections are blocked while candidate capture remains paused.
 
 Do not forward arrow keys in this special state. Numeric keys complete immediately. If a combined numeric+newline payload such as `2\r` or `3\n` arrives, forward only the numeric byte because the numeric byte completes the Codex menu selection:
 
 ```ts
-'1', '1\r', '1\n', '1\r\n' -> write '1', set codexInputGate = { state: 'update_running', startedAt: now }
+'1', '1\r', '1\n', '1\r\n' -> write '1', set codexInputGate = { state: 'update_running' }
 '2', '2\r', '2\n', '2\r\n' -> write '2', clear startup update prompt/tail, stay identity_pending
 '3', '3\r', '3\n', '3\r\n' -> write '3', clear startup update prompt/tail, stay identity_pending
 ```
@@ -408,12 +404,12 @@ Do not forward arrow keys in this special state. Numeric keys complete immediate
 Bare Enter/newline accepts Codex's default `Update now` selection:
 
 ```ts
-'\r', '\n', '\r\n' -> write original enter byte, set update_running
+'\r', '\n', '\r\n' -> write original enter byte, set codexInputGate = { state: 'update_running' }
 ```
 
 Do not accept normal text. Do not forward arrow navigation. Do not use `record.buffer.snapshot()` for prompt detection. Preserve the existing `isCodexStartupTerminalControlInput(data)` path for cursor reports, device attributes, focus, and OSC color replies while identity is pending.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run:
 
@@ -423,11 +419,11 @@ npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test
 
 Expected: PASS.
 
-- [ ] **Step 5: Refactor**
+- [x] **Step 5: Refactor**
 
 Keep helper names specific to startup update prompts. Do not introduce a generic interstitial framework unless tests force it.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add server/terminal-registry.ts test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -451,7 +447,7 @@ git commit -m "fix(codex): gate startup update prompt from live output"
 - Produces: `pauseCandidateCapture?(reason: string): void` and `resumeCandidateCapture?(reason: string): void` on `CodexLaunchSidecar`.
 - Produces: terminal registry calls to pause when a live update prompt is detected or updater lifecycle begins, and resume when skip/skip-until-next-version returns to normal identity capture.
 
-- [ ] **Step 1: Write failing remote-proxy timer tests**
+- [x] **Step 1: Write failing remote-proxy timer tests**
 
 In `test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts`, add tests with fake timers that prove:
 
@@ -467,11 +463,11 @@ proxy.resumeCandidateCapture('startup_update_prompt_skipped')
 
 re-arms the timer so a later timeout still fires if no candidate is persisted.
 
-- [ ] **Step 2: Write failing launch-planner sidecar exposure test**
+- [x] **Step 2: Write failing launch-planner sidecar exposure test**
 
 In `test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts`, extend the fake proxy to expose pause/resume spies and assert the planned sidecar forwards `pauseCandidateCapture()` and `resumeCandidateCapture()` to the proxy.
 
-- [ ] **Step 3: Write failing terminal-registry pause/resume tests**
+- [x] **Step 3: Write failing terminal-registry pause/resume tests**
 
 In `test/unit/server/terminal-registry.codex-sidecar.test.ts`, extend `createFakeSidecar()` to include `pauseCandidateCapture` and `resumeCandidateCapture` spies. Add tests proving:
 
@@ -494,7 +490,7 @@ registry.input(term.terminalId, '1')
 expect(sidecar.resumeCandidateCapture).not.toHaveBeenCalled()
 ```
 
-- [ ] **Step 4: Run tests to verify they fail**
+- [x] **Step 4: Run tests to verify they fail**
 
 Run:
 
@@ -504,7 +500,7 @@ npm run test:vitest -- run test/unit/server/coding-cli/codex-app-server/remote-p
 
 Expected: FAIL because pause/rearm hooks do not exist.
 
-- [ ] **Step 5: Implement pause/rearm hooks**
+- [x] **Step 5: Implement pause/rearm hooks**
 
 In `server/coding-cli/codex-app-server/remote-proxy.ts`, add public methods:
 
@@ -547,7 +543,7 @@ private clearCodexInputGate(record: TerminalRecord): void {
 
 Use it on candidate capture/failure, terminal finalization, and PTY recovery replacement so prompt/updater state cannot leak across terminal generations. For `update_running`, do not resume candidate capture before clearing; the updater path is intentionally not returning to the old capture deadline.
 
-- [ ] **Step 6: Run tests to verify they pass**
+- [x] **Step 6: Run tests to verify they pass**
 
 Run:
 
@@ -557,7 +553,7 @@ npm run test:vitest -- run test/unit/server/coding-cli/codex-app-server/remote-p
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add server/coding-cli/codex-app-server/remote-proxy.ts server/coding-cli/codex-app-server/launch-planner.ts server/terminal-registry.ts test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -578,7 +574,7 @@ git commit -m "fix(codex): pause identity timeout for startup update prompt"
   - normal terminal input forwarding while `update_running`
   - pre-identity exits without a preceding update selection still follow existing failure behavior
 
-- [ ] **Step 1: Write failing lifecycle tests**
+- [x] **Step 1: Write failing lifecycle tests**
 
 Add tests in `test/unit/server/terminal-registry.codex-sidecar.test.ts`:
 
@@ -644,7 +640,7 @@ it('keeps the candidate capture timeout paused during update prompt and updater 
 
 Keep the existing timeout test that proves no update prompt still returns `blocked_codex_identity_capture_timeout` after `candidate_capture_timeout`.
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run:
 
@@ -654,7 +650,7 @@ npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test
 
 Expected: FAIL because `update_running` input is still blocked.
 
-- [ ] **Step 3: Implement updater lifecycle behavior**
+- [x] **Step 3: Implement updater lifecycle behavior**
 
 In `inputIfSessionMatches()`, before the `identity_pending` block, add explicit `update_running` handling that writes normal terminal input without marking Codex unconfirmed user prompt input:
 
@@ -679,7 +675,7 @@ The helper must preserve the current perf accounting, `lastActivityAt`, `pty.wri
 
 Do not ignore `candidate_capture_timeout` in the repair handler. Task 3 prevents that timeout from firing during an active update prompt/updater by pausing the proxy timer. If the timeout event is received, keep the existing failure behavior.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run:
 
@@ -689,7 +685,7 @@ npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add server/terminal-registry.ts test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -712,7 +708,7 @@ git commit -m "fix(codex): treat startup update as updater lifecycle"
   - `keys: string[]` becomes `translateKeys(keys.map(String))`.
   - `keys: string` becomes `translateKeys([keys])`.
 
-- [ ] **Step 1: Write failing REST normalization tests**
+- [x] **Step 1: Write failing REST normalization tests**
 
 In `test/server/agent-send-keys.test.ts`, add:
 
@@ -752,7 +748,7 @@ it('normalizes REST send-keys token arrays through the shared key translator', a
 
 Also keep the existing `data` raw-path test unchanged.
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run:
 
@@ -762,7 +758,7 @@ npm run test:vitest -- run test/server/agent-send-keys.test.ts
 
 Expected: FAIL because the REST route currently forwards `keys` raw.
 
-- [ ] **Step 3: Implement normalization**
+- [x] **Step 3: Implement normalization**
 
 In `server/agent-api/router.ts`, add:
 
@@ -794,7 +790,7 @@ with:
 const data = normalizeTerminalInputPayload(payload)
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run:
 
@@ -804,7 +800,7 @@ npm run test:vitest -- run test/server/agent-send-keys.test.ts
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add server/agent-api/router.ts test/server/agent-send-keys.test.ts
@@ -822,7 +818,7 @@ git commit -m "fix(agent-api): normalize REST send-keys tokens"
 - Consumes all previous tasks.
 - Produces a coherent branch diff with focused and broad verification evidence.
 
-- [ ] **Step 1: Run the focused regression suite**
+- [x] **Step 1: Run the focused regression suite**
 
 Run:
 
@@ -832,7 +828,7 @@ npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test
 
 Expected: PASS.
 
-- [ ] **Step 2: Run project check through the coordinator**
+- [x] **Step 2: Run project check through the coordinator**
 
 Run:
 
@@ -842,7 +838,7 @@ FRESHELL_TEST_SUMMARY="codex startup update prompt regression verification" npm 
 
 Expected: PASS.
 
-- [ ] **Step 3: Inspect final diff**
+- [x] **Step 3: Inspect final diff**
 
 Run:
 
@@ -853,7 +849,7 @@ git diff --check origin/main...HEAD
 
 Expected: no whitespace errors; diff is limited to the files listed in this plan plus the plan file.
 
-- [ ] **Step 4: Commit any final fixes**
+- [x] **Step 4: Commit any final fixes**
 
 If Step 1, Step 2, or Step 3 requires fixes, make the minimal fix, re-run the affected focused test, and commit:
 

--- a/docs/superpowers/plans/2026-06-29-codex-startup-update-prompt.md
+++ b/docs/superpowers/plans/2026-06-29-codex-startup-update-prompt.md
@@ -1,0 +1,886 @@
+# Codex Startup Update Prompt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users and supported automation surfaces to accept, skip, or run Codex CLI startup updates in terminal-mode Codex panes while Freshell is still waiting for Codex restore identity capture.
+
+**Architecture:** Keep the visible-TUI fix in the server-side terminal input gate because all terminal-mode PTY writes route through `TerminalRegistry.inputIfSessionMatches()`. Replace scrollback-time prompt detection with live-output startup prompt state stored per terminal, and model `Update now` as an updater lifecycle rather than a restored Codex session. Pause the Codex remote proxy's candidate-capture deadline while a visible startup update prompt/updater is active, then re-arm it when startup resumes.
+
+**Tech Stack:** Node.js/TypeScript ESM, Express, node-pty, Vitest, existing Freshell fake PTY test harness.
+
+## Global Constraints
+
+- Worktree: `/home/dan/code/freshell/.worktrees/codex-managed-update-prompt` on branch `fix/codex-managed-update-prompt`.
+- Do not create or open a PR without explicit user approval.
+- Do not restart the self-hosted Freshell server.
+- Preserve unrelated changes from other agents.
+- Use Red-Green-Refactor TDD for behavior changes.
+- Server uses NodeNext/ESM; relative imports must include `.js` extensions.
+- Freshell must not set `check_for_update_on_startup=false` for visible managed Codex terminal launches.
+- Hidden managed Codex app-server launch config must not disable update checks; source validation shows current `codex app-server` bypasses the interactive TUI update prompt path.
+- Do not use retained terminal scrollback as the active update-prompt signal.
+- Codex update-prompt numeric keys `1`, `2`, and `3` are completed selections.
+- While identity is pending, Freshell does not forward update-prompt arrow navigation; it accepts numeric selections and bare Enter for the default `Update now` selection only.
+- While restore identity is pending, normal prompt text remains blocked unless the terminal has explicitly entered the updater lifecycle.
+- REST `send-keys` token strings must normalize consistently with CLI/MCP key token handling.
+
+---
+
+## File Structure
+
+- Modify `server/terminal-registry.ts`
+  - Owns PTY output observation, per-terminal Codex input-gate state, menu input forwarding, updater-lifecycle transition, candidate-timeout handling, and normal/updater input writes.
+- Modify `server/coding-cli/codex-app-server/remote-proxy.ts`
+  - Owns pausing and re-arming the candidate-capture timer while the visible terminal is blocked on Codex's startup update prompt/updater.
+- Modify `server/coding-cli/codex-app-server/launch-planner.ts`
+  - Exposes the remote proxy pause/rearm hook through `CodexLaunchSidecar`.
+- Modify `server/coding-cli/codex-managed-config.ts`
+  - Remove the accidental `check_for_update_on_startup=false` managed launch config.
+- Modify `server/agent-api/router.ts`
+  - Normalize REST `keys` token strings via the shared CLI key translator while preserving `data` and `text` raw behavior.
+- Modify `test/unit/server/terminal-registry.codex-sidecar.test.ts`
+  - Regression and state-machine coverage for update prompt detection, chunked output, stale output, menu selections, updater lifecycle, and candidate timeouts.
+- Modify `test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts`
+  - Coverage for pausing and re-arming the candidate-capture timeout.
+- Modify `test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts`
+  - Coverage that sidecars expose the proxy candidate-capture pause/rearm hook.
+- Modify `test/unit/server/terminal-registry.test.ts`
+  - Assert managed remote Codex launches keep `features.apps=false` but no longer disable update checks.
+- Modify `test/unit/server/coding-cli/codex-app-server/runtime.test.ts`
+  - Assert managed app-server launches keep `features.apps=false` and no longer disable update checks.
+- Modify `test/server/agent-send-keys.test.ts`
+  - Assert REST `keys: "ENTER"` and `keys: ["2", "ENTER"]` normalize through shared token handling.
+
+---
+
+### Task 1: Stop Disabling Managed Codex Update Checks
+
+**Files:**
+- Modify: `server/coding-cli/codex-managed-config.ts`
+- Modify: `test/unit/server/terminal-registry.test.ts`
+- Modify: `test/unit/server/coding-cli/codex-app-server/runtime.test.ts`
+
+**Interfaces:**
+- Consumes: existing `CODEX_MANAGED_REMOTE_CONFIG_ARGS` constant.
+- Produces: visible terminal launch args that contain only `-c`, `features.apps=false`.
+- Produces: hidden app-server launch args that contain only `-c`, `features.apps=false`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/unit/server/terminal-registry.test.ts`, change the managed remote-launch expectation so only `features.apps=false` is asserted in the first four arg positions and the update-check flag is explicitly absent:
+
+```ts
+expect(spec.args.slice(0, 4)).toEqual([
+  '--remote',
+  'ws://127.0.0.1:4567',
+  '-c',
+  'features.apps=false',
+])
+expect(spec.args).not.toContain('check_for_update_on_startup=false')
+expectCodexMcpArgs(spec.args)
+```
+
+In `test/unit/server/coding-cli/codex-app-server/runtime.test.ts`, keep the `features.apps=false` assertions and replace the update-check expectations with:
+
+```ts
+expect(args).not.toContain('check_for_update_on_startup=false')
+expect(args.indexOf('features.apps=false')).toBeLessThan(args.indexOf('app-server'))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/terminal-registry.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+```
+
+Expected: FAIL because visible terminal launch args still include `check_for_update_on_startup=false`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Change `server/coding-cli/codex-managed-config.ts` to:
+
+```ts
+export const CODEX_MANAGED_REMOTE_CONFIG_ARGS = [
+  '-c',
+  'features.apps=false',
+] as const
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/terminal-registry.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/coding-cli/codex-managed-config.ts test/unit/server/terminal-registry.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+git commit -m "fix(codex): keep managed update checks enabled"
+```
+
+---
+
+### Task 2: Add Live Update-Prompt Gate State
+
+**Files:**
+- Modify: `server/terminal-registry.ts`
+- Modify: `test/unit/server/terminal-registry.codex-sidecar.test.ts`
+
+**Interfaces:**
+- Consumes: existing `TerminalRecord.codexInputGate`, PTY `onData`, and `inputIfSessionMatches()`.
+- Produces: per-terminal `codexInputGate` union with:
+  - `state: 'identity_pending'`
+  - optional live `startupOutputTail`
+  - optional `startupUpdatePrompt` with `detectedAt` and `lastMatchedAt`
+  - `state: 'update_running'` with `startedAt`
+- Produces helper behavior:
+  - `observeCodexStartupOutput(record, data, now)` updates a bounded live-output tail only while identity is pending.
+  - `hasCodexStartupUpdatePrompt(text)` detects the update prompt without requiring `Update available!`.
+  - `handleCodexStartupUpdatePromptInput(record, data, now)` forwards only menu/control input and transitions state.
+
+- [ ] **Step 1: Write failing update-prompt tests**
+
+In `test/unit/server/terminal-registry.codex-sidecar.test.ts`, replace the existing `allows Codex update prompt menu replies while restore identity is pending` test and add focused tests covering:
+
+```ts
+it('allows Codex update prompt menu replies without the optional update banner', () => {
+  const registry = new TerminalRegistry()
+  const term = registry.create({
+    mode: 'codex',
+    providerSettings: {
+      codexAppServer: {
+        wsUrl: 'ws://127.0.0.1:43123',
+        sidecar: createFakeSidecar(),
+      },
+    } as any,
+  })
+
+  const pty = mockPtyProcess.instances[0]
+  pty._emitData([
+    'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+    '\r\n',
+    '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+    '  2. Skip\r\n',
+    '  3. Skip until next version\r\n',
+    '\r\n',
+    'Press enter to continue\r\n',
+  ].join(''))
+
+  expect(registry.input(term.terminalId, '2')).toEqual({ status: 'written' })
+  expect(pty.write).toHaveBeenLastCalledWith('2')
+  expect(registry.input(term.terminalId, 'hello\r')).toEqual({
+    status: 'blocked_codex_identity_pending',
+    terminalId: term.terminalId,
+  })
+})
+```
+
+```ts
+it('detects the Codex update prompt across split PTY chunks with terminal controls', () => {
+  const registry = new TerminalRegistry()
+  const term = registry.create({
+    mode: 'codex',
+    providerSettings: {
+      codexAppServer: {
+        wsUrl: 'ws://127.0.0.1:43123',
+        sidecar: createFakeSidecar(),
+      },
+    } as any,
+  })
+
+  const pty = mockPtyProcess.instances[0]
+  pty._emitData('\x1b[1mRelease notes: https://github.com/openai/codex/releases/latest\x1b[0m\r\n')
+  pty._emitData('› 1. Update now (runs `npm install -g @openai/codex`)\r\n')
+  pty._emitData('  2. Skip\r\n')
+  pty._emitData('  3. Skip until next version\r\n')
+  pty._emitData('Press enter to continue\r\n')
+
+  expect(registry.input(term.terminalId, '\r')).toEqual({ status: 'written' })
+  expect(pty.write).toHaveBeenLastCalledWith('\r')
+})
+```
+
+```ts
+it('updates startup prompt state before any client-visible output can trigger reentrant input', () => {
+  const registry = new TerminalRegistry()
+  const term = registry.create({
+    mode: 'codex',
+    providerSettings: {
+      codexAppServer: {
+        wsUrl: 'ws://127.0.0.1:43123',
+        sidecar: createFakeSidecar(),
+      },
+    } as any,
+  })
+
+  const pty = mockPtyProcess.instances[0]
+  const client = {
+    readyState: 1,
+    send: vi.fn((payload: string) => {
+      if (payload.includes('Press enter to continue')) {
+        registry.input(term.terminalId, '2')
+      }
+    }),
+    close: vi.fn(),
+  } as any
+
+  registry.attach(term.terminalId, client)
+  pty._emitData([
+    'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+    '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+    '  2. Skip\r\n',
+    '  3. Skip until next version\r\n',
+    'Press enter to continue\r\n',
+  ].join(''))
+
+  expect(pty.write).toHaveBeenCalledWith('2')
+})
+```
+
+```ts
+it('does not open the Codex identity gate for similar non-prompt release text', () => {
+  const registry = new TerminalRegistry()
+  const term = registry.create({
+    mode: 'codex',
+    providerSettings: {
+      codexAppServer: {
+        wsUrl: 'ws://127.0.0.1:43123',
+        sidecar: createFakeSidecar(),
+      },
+    } as any,
+  })
+
+  const pty = mockPtyProcess.instances[0]
+  pty._emitData([
+    'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+    'Press enter to continue reading the changelog\r\n',
+  ].join(''))
+
+  expect(registry.input(term.terminalId, '\r')).toEqual({
+    status: 'blocked_codex_identity_pending',
+    terminalId: term.terminalId,
+  })
+})
+```
+
+```ts
+it('does not reuse stale update prompt output after a skip selection', () => {
+  const registry = new TerminalRegistry()
+  const term = registry.create({
+    mode: 'codex',
+    providerSettings: {
+      codexAppServer: {
+        wsUrl: 'ws://127.0.0.1:43123',
+        sidecar: createFakeSidecar(),
+      },
+    } as any,
+  })
+
+  const pty = mockPtyProcess.instances[0]
+  pty._emitData([
+    'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+    '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+    '  2. Skip\r\n',
+    '  3. Skip until next version\r\n',
+    'Press enter to continue\r\n',
+  ].join(''))
+
+  expect(registry.input(term.terminalId, '2')).toEqual({ status: 'written' })
+  pty._emitData('Codex starting normally now\r\n')
+
+  expect(registry.input(term.terminalId, '\r')).toEqual({
+    status: 'blocked_codex_identity_pending',
+    terminalId: term.terminalId,
+  })
+})
+```
+
+```ts
+it('blocks update prompt arrow navigation rather than tracking highlight state', () => {
+  const registry = new TerminalRegistry()
+  const term = registry.create({
+    mode: 'codex',
+    providerSettings: {
+      codexAppServer: {
+        wsUrl: 'ws://127.0.0.1:43123',
+        sidecar: createFakeSidecar(),
+      },
+    } as any,
+  })
+
+  const pty = mockPtyProcess.instances[0]
+  pty._emitData([
+    'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+    '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+    '  2. Skip\r\n',
+    '  3. Skip until next version\r\n',
+    'Press enter to continue\r\n',
+  ].join(''))
+
+  expect(registry.input(term.terminalId, '\x1b[B')).toEqual({
+    status: 'blocked_codex_identity_pending',
+    terminalId: term.terminalId,
+  })
+  expect(registry.input(term.terminalId, '\r')).toEqual({ status: 'written' })
+  expect(pty.write).toHaveBeenLastCalledWith('\r')
+  expect(registry.input(term.terminalId, 'y\r')).toEqual({ status: 'written' })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test.ts -t "Codex update prompt|similar non-prompt|stale update prompt|arrow navigation"
+```
+
+Expected: FAIL because the current detector requires `Update available!`, scans scrollback at input time, and has no live prompt state.
+
+- [ ] **Step 3: Implement live prompt state**
+
+In `server/terminal-registry.ts`, replace the old `codexUpdatePromptDismissed` field and scrollback input detector with these concepts:
+
+```ts
+type CodexStartupUpdateChoice = 'update_now' | 'skip' | 'skip_until_next_version'
+
+type CodexInputGate =
+  | {
+      state: 'identity_pending'
+      startupOutputTail?: string
+      startupUpdatePrompt?: {
+        detectedAt: number
+        lastMatchedAt: number
+      }
+    }
+  | {
+      state: 'update_running'
+      startedAt: number
+    }
+```
+
+Update `TerminalRecord` to use `codexInputGate?: CodexInputGate`.
+
+Use a bounded live-output tail:
+
+```ts
+const CODEX_STARTUP_UPDATE_PROMPT_TAIL_CHARS = 8 * 1024
+const CODEX_STARTUP_UPDATE_PROMPT_TTL_MS = 10 * 60 * 1000
+```
+
+Normalize terminal text with existing `stripTerminalControls()` and whitespace normalization. Implement `hasCodexStartupUpdatePrompt(text: string)` so it requires all of:
+
+```ts
+text.includes('github.com/openai/codex/releases/latest')
+/(?:^|\n)\s*[›> ]*\s*1[.)]\s*Update now\s*\(runs\s+`?[^`\n]*(?:npm|bun|brew)[^`\n]*`?\)/i
+/(?:^|\n)\s*[›> ]*\s*2[.)]\s*Skip\b/i
+/(?:^|\n)\s*[›> ]*\s*3[.)]\s*Skip until next version\b/i
+/Press\s+enter\s+to\s+continue/i
+```
+
+Add `observeCodexStartupOutput(record, data, now)` and call it from both PTY `onData` handlers immediately after `record.buffer.append(data)` and before `this.emit('terminal.output.raw', ...)` or any direct client send path. It should update `startupOutputTail` only when `record.codexInputGate?.state === 'identity_pending'`, and set or refresh `startupUpdatePrompt` when `hasCodexStartupUpdatePrompt()` matches the live tail.
+
+Implement prompt input handling:
+
+```ts
+function isCodexStartupUpdatePromptFresh(gate: CodexInputGate | undefined, now: number): boolean {
+  return gate?.state === 'identity_pending'
+    && !!gate.startupUpdatePrompt
+    && now - gate.startupUpdatePrompt.lastMatchedAt <= CODEX_STARTUP_UPDATE_PROMPT_TTL_MS
+}
+```
+
+Do not forward arrow keys in this special state. Numeric keys complete immediately. If a combined numeric+newline payload such as `2\r` or `3\n` arrives, forward only the numeric byte because the numeric byte completes the Codex menu selection:
+
+```ts
+'1', '1\r', '1\n', '1\r\n' -> write '1', set codexInputGate = { state: 'update_running', startedAt: now }
+'2', '2\r', '2\n', '2\r\n' -> write '2', clear startup update prompt/tail, stay identity_pending
+'3', '3\r', '3\n', '3\r\n' -> write '3', clear startup update prompt/tail, stay identity_pending
+```
+
+Bare Enter/newline accepts Codex's default `Update now` selection:
+
+```ts
+'\r', '\n', '\r\n' -> write original enter byte, set update_running
+```
+
+Do not accept normal text. Do not forward arrow navigation. Do not use `record.buffer.snapshot()` for prompt detection.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test.ts -t "Codex update prompt|similar non-prompt|stale update prompt|arrow navigation"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Refactor**
+
+Keep helper names specific to startup update prompts. Do not introduce a generic interstitial framework unless tests force it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/terminal-registry.ts test/unit/server/terminal-registry.codex-sidecar.test.ts
+git commit -m "fix(codex): gate startup update prompt from live output"
+```
+
+---
+
+### Task 3: Pause Candidate Capture During Update Prompt and Updater
+
+**Files:**
+- Modify: `server/coding-cli/codex-app-server/remote-proxy.ts`
+- Modify: `server/coding-cli/codex-app-server/launch-planner.ts`
+- Modify: `server/terminal-registry.ts`
+- Modify: `test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts`
+- Modify: `test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts`
+- Modify: `test/unit/server/terminal-registry.codex-sidecar.test.ts`
+
+**Interfaces:**
+- Consumes: `CodexRemoteProxy` candidate-capture timer.
+- Produces: `pauseCandidateCapture?(reason: string): void` and `resumeCandidateCapture?(reason: string): void` on `CodexLaunchSidecar`.
+- Produces: terminal registry calls to pause when a live update prompt is detected or updater lifecycle begins, and resume when skip/skip-until-next-version returns to normal identity capture.
+
+- [ ] **Step 1: Write failing remote-proxy timer tests**
+
+In `test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts`, add tests with fake timers that prove:
+
+```ts
+proxy.pauseCandidateCapture('startup_update_prompt')
+```
+
+prevents `candidate_capture_timeout` from firing while paused, including if a new client connection arrives and would normally call the timer-arm helper, and:
+
+```ts
+proxy.resumeCandidateCapture('startup_update_prompt_skipped')
+```
+
+re-arms the timer so a later timeout still fires if no candidate is persisted.
+
+- [ ] **Step 2: Write failing launch-planner sidecar exposure test**
+
+In `test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts`, extend the fake proxy to expose pause/resume spies and assert the planned sidecar forwards `pauseCandidateCapture()` and `resumeCandidateCapture()` to the proxy.
+
+- [ ] **Step 3: Write failing terminal-registry pause/resume tests**
+
+In `test/unit/server/terminal-registry.codex-sidecar.test.ts`, extend `createFakeSidecar()` to include `pauseCandidateCapture` and `resumeCandidateCapture` spies. Add tests proving:
+
+```ts
+pty._emitData(<complete update prompt>)
+expect(sidecar.pauseCandidateCapture).toHaveBeenCalledWith('codex_startup_update_prompt')
+```
+
+and:
+
+```ts
+registry.input(term.terminalId, '2')
+expect(sidecar.resumeCandidateCapture).toHaveBeenCalledWith('codex_startup_update_skipped')
+```
+
+and:
+
+```ts
+registry.input(term.terminalId, '1')
+expect(sidecar.resumeCandidateCapture).not.toHaveBeenCalled()
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts -t "candidate capture|startup update|pause|resume"
+```
+
+Expected: FAIL because pause/rearm hooks do not exist.
+
+- [ ] **Step 5: Implement pause/rearm hooks**
+
+In `server/coding-cli/codex-app-server/remote-proxy.ts`, add public methods:
+
+```ts
+private candidateCapturePaused = false
+
+pauseCandidateCapture(reason: string): void {
+  if (!this.requireCandidatePersistence) return
+  if (this.candidatePersisted || this.candidateCaptureFailed) return
+  this.candidateCapturePaused = true
+  this.clearCandidateCaptureTimer()
+  log.info({ reason }, 'Paused Codex restore identity candidate-capture timeout')
+}
+
+resumeCandidateCapture(reason: string): void {
+  if (!this.requireCandidatePersistence) return
+  if (this.candidatePersisted || this.candidateCaptureFailed) return
+  this.candidateCapturePaused = false
+  this.ensureCandidateCaptureTimer()
+  log.info({ reason }, 'Resumed Codex restore identity candidate-capture timeout')
+}
+```
+
+Update `ensureCandidateCaptureTimer()` so it returns without arming when `candidateCapturePaused` is true.
+
+Expose those methods through `CodexLaunchProxy`, `CodexLaunchSidecar`, and the launch-planner sidecar object.
+
+In `server/terminal-registry.ts`, call `record.codexSidecar?.pauseCandidateCapture?.('codex_startup_update_prompt')` only the first time a live update prompt is detected for that prompt instance. On skip or skip-until-next-version, call `record.codexSidecar?.resumeCandidateCapture?.('codex_startup_update_skipped')`. Do not resume on `Update now`; the terminal is expected to run updater and exit/restart instead of capturing identity.
+
+Add a small central reset helper for terminal gate state:
+
+```ts
+private clearCodexInputGate(record: TerminalRecord): void {
+  if (record.codexInputGate?.state === 'identity_pending' && record.codexInputGate.startupUpdatePrompt) {
+    record.codexSidecar?.resumeCandidateCapture?.('codex_input_gate_cleared')
+  }
+  record.codexInputGate = undefined
+}
+```
+
+Use it on candidate capture/failure, terminal finalization, and PTY recovery replacement so prompt/updater state cannot leak across terminal generations. For `update_running`, do not resume candidate capture before clearing; the updater path is intentionally not returning to the old capture deadline.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts -t "candidate capture|startup update|pause|resume"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/coding-cli/codex-app-server/remote-proxy.ts server/coding-cli/codex-app-server/launch-planner.ts server/terminal-registry.ts test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts test/unit/server/terminal-registry.codex-sidecar.test.ts
+git commit -m "fix(codex): pause identity timeout for startup update prompt"
+```
+
+---
+
+### Task 4: Handle Update-Now as Updater Lifecycle
+
+**Files:**
+- Modify: `server/terminal-registry.ts`
+- Modify: `test/unit/server/terminal-registry.codex-sidecar.test.ts`
+
+**Interfaces:**
+- Consumes: `codexInputGate.state === 'update_running'` from Task 2.
+- Produces:
+  - normal terminal input forwarding while `update_running`
+  - pre-identity exits without a preceding update selection still follow existing failure behavior
+
+- [ ] **Step 1: Write failing lifecycle tests**
+
+Add tests in `test/unit/server/terminal-registry.codex-sidecar.test.ts`:
+
+```ts
+it('allows updater input after selecting Update now from the startup prompt', () => {
+  const registry = new TerminalRegistry()
+  const term = registry.create({
+    mode: 'codex',
+    providerSettings: {
+      codexAppServer: {
+        wsUrl: 'ws://127.0.0.1:43123',
+        sidecar: createFakeSidecar(),
+      },
+    } as any,
+  })
+
+  const pty = mockPtyProcess.instances[0]
+  pty._emitData([
+    'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+    '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+    '  2. Skip\r\n',
+    '  3. Skip until next version\r\n',
+    'Press enter to continue\r\n',
+  ].join(''))
+
+  expect(registry.input(term.terminalId, '1')).toEqual({ status: 'written' })
+  expect(pty.write).toHaveBeenLastCalledWith('1')
+  expect(registry.input(term.terminalId, 'y\r')).toEqual({ status: 'written' })
+  expect(pty.write).toHaveBeenLastCalledWith('y\r')
+})
+```
+
+```ts
+it('keeps the candidate capture timeout paused during update prompt and updater lifecycle', async () => {
+  const registry = new TerminalRegistry()
+  const sidecar = createFakeSidecar()
+  const term = registry.create({
+    mode: 'codex',
+    providerSettings: {
+      codexAppServer: {
+        wsUrl: 'ws://127.0.0.1:43123',
+        sidecar,
+      },
+    } as any,
+  })
+
+  const pty = mockPtyProcess.instances[0]
+  pty._emitData([
+    'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+    '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+    '  2. Skip\r\n',
+    '  3. Skip until next version\r\n',
+    'Press enter to continue\r\n',
+  ].join(''))
+
+  expect(sidecar.pauseCandidateCapture).toHaveBeenCalledWith('codex_startup_update_prompt')
+
+  expect(registry.input(term.terminalId, '1')).toEqual({ status: 'written' })
+  expect(sidecar.resumeCandidateCapture).not.toHaveBeenCalled()
+  expect(registry.input(term.terminalId, 'y\r')).toEqual({ status: 'written' })
+})
+```
+
+Keep the existing timeout test that proves no update prompt still returns `blocked_codex_identity_capture_timeout` after `candidate_capture_timeout`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test.ts -t "updater input|candidate capture timeout|identity capture timeout"
+```
+
+Expected: FAIL because `update_running` input is still blocked.
+
+- [ ] **Step 3: Implement updater lifecycle behavior**
+
+In `inputIfSessionMatches()`, before the `identity_pending` block, add explicit `update_running` handling that writes normal terminal input without marking Codex unconfirmed user prompt input:
+
+```ts
+if (term.codexInputGate?.state === 'update_running') {
+  this.writeTerminalInput(term, data, { markCodexUnconfirmedInput: false })
+  return { status: 'written' }
+}
+```
+
+Refactor the normal terminal write path into a private helper:
+
+```ts
+private writeTerminalInput(
+  record: TerminalRecord,
+  data: string,
+  options: { markCodexUnconfirmedInput?: boolean } = {},
+): void
+```
+
+The helper must preserve the current perf accounting, `lastActivityAt`, `pty.write(data)`, and `terminal.input.raw` event behavior. The normal path should call it with default behavior. The updater path should call it with `markCodexUnconfirmedInput: false`.
+
+Do not ignore `candidate_capture_timeout` in the repair handler. Task 3 prevents that timeout from firing during an active update prompt/updater by pausing the proxy timer. If the timeout event is received, keep the existing failure behavior.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test.ts -t "updater input|candidate capture timeout|identity capture timeout"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/terminal-registry.ts test/unit/server/terminal-registry.codex-sidecar.test.ts
+git commit -m "fix(codex): treat startup update as updater lifecycle"
+```
+
+---
+
+### Task 5: Normalize REST Send-Keys Tokens
+
+**Files:**
+- Modify: `server/agent-api/router.ts`
+- Modify: `test/server/agent-send-keys.test.ts`
+
+**Interfaces:**
+- Consumes: `translateKeys(keys: string[])` from `server/cli/keys.js`.
+- Produces: REST `/api/panes/:paneId/send-keys` normalization:
+  - `data` remains raw and takes precedence.
+  - `text` remains raw.
+  - `keys: string[]` becomes `translateKeys(keys.map(String))`.
+  - `keys: string` becomes `translateKeys([keys])`.
+
+- [ ] **Step 1: Write failing REST normalization tests**
+
+In `test/server/agent-send-keys.test.ts`, add:
+
+```ts
+it('normalizes REST send-keys token strings through the shared key translator', async () => {
+  const input = vi.fn(() => ({ status: 'written' }))
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { resolvePaneToTerminal: () => 'term_1' },
+    registry: { input },
+  }))
+
+  const res = await request(app).post('/api/panes/p1/send-keys').send({ keys: 'ENTER' })
+
+  expect(res.body.status).toBe('ok')
+  expect(input).toHaveBeenCalledWith('term_1', '\r')
+})
+```
+
+```ts
+it('normalizes REST send-keys token arrays through the shared key translator', async () => {
+  const input = vi.fn(() => ({ status: 'written' }))
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { resolvePaneToTerminal: () => 'term_1' },
+    registry: { input },
+  }))
+
+  const res = await request(app).post('/api/panes/p1/send-keys').send({ keys: ['2', 'ENTER'] })
+
+  expect(res.body.status).toBe('ok')
+  expect(input).toHaveBeenCalledWith('term_1', '2\r')
+})
+```
+
+Also keep the existing `data` raw-path test unchanged.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/server/agent-send-keys.test.ts
+```
+
+Expected: FAIL because the REST route currently forwards `keys` raw.
+
+- [ ] **Step 3: Implement normalization**
+
+In `server/agent-api/router.ts`, add:
+
+```ts
+import { translateKeys } from '../cli/keys.js'
+```
+
+Add a local helper:
+
+```ts
+function normalizeTerminalInputPayload(payload: Record<string, unknown>): string {
+  if (typeof payload.data === 'string') return payload.data
+  if (Array.isArray(payload.keys)) return translateKeys(payload.keys.map(String))
+  if (typeof payload.keys === 'string') return translateKeys([payload.keys])
+  if (typeof payload.text === 'string') return payload.text
+  return ''
+}
+```
+
+Replace:
+
+```ts
+const data = payload.data ?? payload.keys ?? payload.text ?? ''
+```
+
+with:
+
+```ts
+const data = normalizeTerminalInputPayload(payload)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/server/agent-send-keys.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/agent-api/router.ts test/server/agent-send-keys.test.ts
+git commit -m "fix(agent-api): normalize REST send-keys tokens"
+```
+
+---
+
+### Task 6: Integrated Verification and Refactor
+
+**Files:**
+- Modify only if focused or broad verification exposes a real issue.
+
+**Interfaces:**
+- Consumes all previous tasks.
+- Produces a coherent branch diff with focused and broad verification evidence.
+
+- [ ] **Step 1: Run the focused regression suite**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test.ts test/unit/server/terminal-registry.test.ts test/unit/server/coding-cli/codex-app-server/runtime.test.ts test/server/agent-send-keys.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run project check through the coordinator**
+
+Run:
+
+```bash
+FRESHELL_TEST_SUMMARY="codex startup update prompt regression verification" npm run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+```
+
+Expected: no whitespace errors; diff is limited to the files listed in this plan plus the plan file.
+
+- [ ] **Step 4: Commit any final fixes**
+
+If Step 1, Step 2, or Step 3 requires fixes, make the minimal fix, re-run the affected focused test, and commit:
+
+```bash
+git add <changed-files>
+git commit -m "fix(codex): harden startup update prompt handling"
+```
+
+If no changes are required, do not create an empty commit.
+
+---
+
+## Self-Review
+
+1. Spec coverage:
+   - Removing update suppression: Task 1.
+   - Live prompt state instead of scrollback: Task 2.
+   - Numeric keys as completed selections: Task 2.
+   - Skip returns to identity capture: Task 2.
+   - Update prompt pauses candidate timeout: Task 3.
+   - Update now enters updater lifecycle and can accept updater input: Task 4.
+   - Candidate timeout does not kill a waiting update prompt/updater: Task 3 and Task 4.
+   - Normal text remains blocked while identity is pending: Task 2.
+   - REST key normalization: Task 5.
+   - Broad verification: Task 6.
+2. Placeholder scan:
+   - No TBD/TODO placeholders.
+   - Every task has concrete files, test commands, expected failure/pass behavior, and implementation guidance.
+3. Type consistency:
+   - `CodexInputGate`, `CodexStartupUpdateChoice`, `startupUpdatePrompt`, and `update_running` names are consistent across tasks.

--- a/docs/superpowers/plans/2026-06-29-codex-startup-update-prompt.md
+++ b/docs/superpowers/plans/2026-06-29-codex-startup-update-prompt.md
@@ -339,7 +339,7 @@ it('blocks update prompt arrow navigation rather than tracking highlight state',
 Run:
 
 ```bash
-npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test.ts -t "Codex update prompt|similar non-prompt|stale update prompt|arrow navigation"
+npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test.ts -t "Codex update prompt|startup prompt state|similar non-prompt|stale update prompt|arrow navigation|terminal startup control"
 ```
 
 Expected: FAIL because the current detector requires `Update available!`, scans scrollback at input time, and has no live prompt state.
@@ -375,7 +375,7 @@ const CODEX_STARTUP_UPDATE_PROMPT_TAIL_CHARS = 8 * 1024
 const CODEX_STARTUP_UPDATE_PROMPT_TTL_MS = 10 * 60 * 1000
 ```
 
-Normalize terminal text with existing `stripTerminalControls()` and whitespace normalization. Implement `hasCodexStartupUpdatePrompt(text: string)` so it requires all of:
+Normalize terminal text with existing `stripTerminalControls()` and newline-preserving whitespace normalization: convert `\r` to `\n` and normalize spaces/tabs, but do not collapse newlines because the detector anchors on line starts. Implement `hasCodexStartupUpdatePrompt(text: string)` so it requires all of:
 
 ```ts
 text.includes('github.com/openai/codex/releases/latest')
@@ -411,14 +411,14 @@ Bare Enter/newline accepts Codex's default `Update now` selection:
 '\r', '\n', '\r\n' -> write original enter byte, set update_running
 ```
 
-Do not accept normal text. Do not forward arrow navigation. Do not use `record.buffer.snapshot()` for prompt detection.
+Do not accept normal text. Do not forward arrow navigation. Do not use `record.buffer.snapshot()` for prompt detection. Preserve the existing `isCodexStartupTerminalControlInput(data)` path for cursor reports, device attributes, focus, and OSC color replies while identity is pending.
 
 - [ ] **Step 4: Run tests to verify they pass**
 
 Run:
 
 ```bash
-npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test.ts -t "Codex update prompt|similar non-prompt|stale update prompt|arrow navigation"
+npm run test:vitest -- run test/unit/server/terminal-registry.codex-sidecar.test.ts -t "Codex update prompt|startup prompt state|similar non-prompt|stale update prompt|arrow navigation|terminal startup control"
 ```
 
 Expected: PASS.
@@ -530,7 +530,7 @@ resumeCandidateCapture(reason: string): void {
 
 Update `ensureCandidateCaptureTimer()` so it returns without arming when `candidateCapturePaused` is true.
 
-Expose those methods through `CodexLaunchProxy`, `CodexLaunchSidecar`, and the launch-planner sidecar object.
+Expose those methods through `CodexLaunchProxy`, `CodexLaunchSidecar`, the launch-planner sidecar object, and the `TerminalRecord.codexSidecar` `Pick<CodexLaunchSidecar, ...>` in `server/terminal-registry.ts`.
 
 In `server/terminal-registry.ts`, call `record.codexSidecar?.pauseCandidateCapture?.('codex_startup_update_prompt')` only the first time a live update prompt is detected for that prompt instance. On skip or skip-until-next-version, call `record.codexSidecar?.resumeCandidateCapture?.('codex_startup_update_skipped')`. Do not resume on `Update now`; the terminal is expected to run updater and exit/restart instead of capturing identity.
 

--- a/docs/superpowers/plans/2026-06-29-codex-startup-update-prompt.md
+++ b/docs/superpowers/plans/2026-06-29-codex-startup-update-prompt.md
@@ -374,7 +374,7 @@ Normalize terminal text with existing `stripTerminalControls()` and newline-pres
 
 ```ts
 text.includes('github.com/openai/codex/releases/latest')
-/(?:^|\n)[ \t]*[›>]?[ \t]*1[.)][ \t]*Update now[ \t]*\(runs[ \t]+`?[^`\n]*(?:npm|bun|brew)[^`\n]*`?\)/i
+/(?:^|\n)[ \t]*[›>]?[ \t]*1[.)][ \t]*Update now[ \t]*\(runs[ \t]+[^)\n]+\)/i
 /(?:^|\n)[ \t]*[›>]?[ \t]*2[.)][ \t]*Skip\b/i
 /(?:^|\n)[ \t]*[›>]?[ \t]*3[.)][ \t]*Skip until next version\b/i
 /Press\s+enter\s+to\s+continue/i

--- a/server/agent-api/router.ts
+++ b/server/agent-api/router.ts
@@ -25,6 +25,7 @@ import { resolveScreenshotOutputPath } from './screenshot-path.js'
 import { sanitizeSessionRef } from '../../shared/session-contract.js'
 import type { LayoutStore } from './layout-store.js'
 import type { FreshAgentRuntimeProvider, FreshAgentSessionType } from '../../shared/fresh-agent.js'
+import { translateKeys } from '../cli/keys.js'
 import type {
   FreshAgentSessionLocator,
   FreshAgentThreadLocator,
@@ -236,6 +237,14 @@ function acceptedSessionRefForMode(
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0
+}
+
+function normalizeTerminalInputPayload(payload: Record<string, unknown>): string {
+  if (typeof payload.data === 'string') return payload.data
+  if (Array.isArray(payload.keys)) return translateKeys(payload.keys.map(String))
+  if (typeof payload.keys === 'string') return translateKeys([payload.keys])
+  if (typeof payload.text === 'string') return payload.text
+  return ''
 }
 
 async function adoptCodexLaunch(
@@ -1746,7 +1755,7 @@ export function createAgentApiRouter({
       }
     }
     const payload = req.body || {}
-    const data = payload.data ?? payload.keys ?? payload.text ?? ''
+    const data = normalizeTerminalInputPayload(payload)
     const paneSnapshot = layoutStore.getPaneSnapshot?.(paneId)
     let terminalId = paneSnapshot?.terminalId || layoutStore.resolvePaneToTerminal?.(paneId)
     if (!terminalId && layoutStore.resolveTarget) {

--- a/server/coding-cli/codex-app-server/launch-planner.ts
+++ b/server/coding-cli/codex-app-server/launch-planner.ts
@@ -29,6 +29,8 @@ type CodexRuntimeLike = Pick<
 export type CodexLaunchSidecar = {
   adopt(input: { terminalId: string; generation: number }): Promise<void>
   markCandidatePersisted?(): void
+  pauseCandidateCapture?(reason: string): void
+  resumeCandidateCapture?(reason: string): void
   onCandidate?(handler: (candidate: CodexRemoteProxyCandidate) => void): () => void
   onTurnStarted?(handler: (event: CodexTurnEvent) => void): () => void
   onTurnCompleted?(handler: (event: CodexTurnEvent) => void): () => void
@@ -73,6 +75,8 @@ type CodexLaunchProxy = Pick<
   | 'start'
   | 'close'
   | 'markCandidatePersisted'
+  | 'pauseCandidateCapture'
+  | 'resumeCandidateCapture'
   | 'onCandidate'
   | 'onTurnStarted'
   | 'onTurnCompleted'
@@ -237,6 +241,8 @@ export class CodexLaunchPlanner {
         this.failedSidecarShutdowns.delete(sidecar)
       },
       markCandidatePersisted: () => getProxy()?.markCandidatePersisted(),
+      pauseCandidateCapture: (reason) => getProxy()?.pauseCandidateCapture(reason),
+      resumeCandidateCapture: (reason) => getProxy()?.resumeCandidateCapture(reason),
       onCandidate: (handler) => getProxy()?.onCandidate(handler) ?? (() => undefined),
       onTurnStarted: (handler) => getProxy()?.onTurnStarted(handler) ?? (() => undefined),
       onTurnCompleted: (handler) => getProxy()?.onTurnCompleted(handler) ?? (() => undefined),

--- a/server/coding-cli/codex-app-server/remote-proxy.ts
+++ b/server/coding-cli/codex-app-server/remote-proxy.ts
@@ -60,6 +60,7 @@ export class CodexRemoteProxy {
   private endpoint: LoopbackServerEndpoint | null = null
   private candidatePersisted = false
   private candidateCaptureFailed = false
+  private candidateCapturePaused = false
   private candidateCaptureTimer: NodeJS.Timeout | null = null
   private readonly pendingTurnStarts = new Set<PendingTurnStart>()
   private readonly connections = new Set<ProxyConnection>()
@@ -149,6 +150,22 @@ export class CodexRemoteProxy {
       connection.client.close()
       connection.upstream.close()
     }
+  }
+
+  pauseCandidateCapture(reason: string): void {
+    if (!this.requireCandidatePersistence) return
+    if (this.candidatePersisted || this.candidateCaptureFailed) return
+    this.candidateCapturePaused = true
+    this.clearCandidateCaptureTimer()
+    log.info({ reason }, 'Paused Codex restore identity candidate-capture timeout')
+  }
+
+  resumeCandidateCapture(reason: string): void {
+    if (!this.requireCandidatePersistence) return
+    if (this.candidatePersisted || this.candidateCaptureFailed) return
+    this.candidateCapturePaused = false
+    this.ensureCandidateCaptureTimer()
+    log.info({ reason }, 'Resumed Codex restore identity candidate-capture timeout')
   }
 
   onCandidate(handler: (candidate: CodexRemoteProxyCandidate) => void): () => void {
@@ -457,7 +474,7 @@ export class CodexRemoteProxy {
 
   private ensureCandidateCaptureTimer(): void {
     if (!this.requireCandidatePersistence) return
-    if (this.candidatePersisted || this.candidateCaptureTimer) return
+    if (this.candidatePersisted || this.candidateCaptureFailed || this.candidateCapturePaused || this.candidateCaptureTimer) return
     this.candidateCaptureTimer = setTimeout(() => {
       this.failCandidateCapture('Freshell timed out before Codex restore identity was captured.')
     }, this.candidateCaptureTimeoutMs)

--- a/server/coding-cli/codex-managed-config.ts
+++ b/server/coding-cli/codex-managed-config.ts
@@ -1,6 +1,4 @@
 export const CODEX_MANAGED_REMOTE_CONFIG_ARGS = [
   '-c',
   'features.apps=false',
-  '-c',
-  'check_for_update_on_startup=false',
 ] as const

--- a/server/coding-cli/codex-managed-config.ts
+++ b/server/coding-cli/codex-managed-config.ts
@@ -1,1 +1,6 @@
-export const CODEX_MANAGED_REMOTE_CONFIG_ARGS = ['-c', 'features.apps=false'] as const
+export const CODEX_MANAGED_REMOTE_CONFIG_ARGS = [
+  '-c',
+  'features.apps=false',
+  '-c',
+  'check_for_update_on_startup=false',
+] as const

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -3271,6 +3271,35 @@ export class TerminalRegistry extends EventEmitter {
     return this.inputIfSessionMatches(terminalId, data)
   }
 
+  private writeTerminalInput(
+    record: TerminalRecord,
+    data: string,
+    options: { markCodexUnconfirmedInput?: boolean } = {},
+  ): void {
+    const now = Date.now()
+    record.lastActivityAt = now
+    if (record.perf) {
+      record.perf.inBytes += data.length
+      record.perf.inChunks += 1
+      record.perf.lastInputBytes = data.length
+      record.perf.pendingInputBytes += data.length
+      record.perf.pendingInputCount += 1
+      if (record.perf.pendingInputAt === undefined) {
+        record.perf.pendingInputAt = now
+      }
+    }
+    if (record.mode === 'codex' && options.markCodexUnconfirmedInput !== false) {
+      record.codexUnconfirmedInputAt = now
+      record.codexUnconfirmedInputSource = 'input'
+    }
+    record.pty.write(data)
+    this.emit('terminal.input.raw', {
+      terminalId: record.terminalId,
+      data,
+      at: now,
+    } satisfies TerminalInputRawEvent)
+  }
+
   inputIfSessionMatches(
     terminalId: string,
     data: string,
@@ -3312,28 +3341,11 @@ export class TerminalRegistry extends EventEmitter {
       if (handleCodexStartupUpdatePromptInput(term, data, now)) return { status: 'written' }
       return { status: 'blocked_codex_identity_pending', terminalId }
     }
-    const now = Date.now()
-    term.lastActivityAt = now
-    if (term.perf) {
-      term.perf.inBytes += data.length
-      term.perf.inChunks += 1
-      term.perf.lastInputBytes = data.length
-      term.perf.pendingInputBytes += data.length
-      term.perf.pendingInputCount += 1
-      if (term.perf.pendingInputAt === undefined) {
-        term.perf.pendingInputAt = now
-      }
+    if (term.codexInputGate?.state === 'update_running') {
+      this.writeTerminalInput(term, data, { markCodexUnconfirmedInput: false })
+      return { status: 'written' }
     }
-    if (term.mode === 'codex') {
-      term.codexUnconfirmedInputAt = now
-      term.codexUnconfirmedInputSource = 'input'
-    }
-    term.pty.write(data)
-    this.emit('terminal.input.raw', {
-      terminalId,
-      data,
-      at: now,
-    } satisfies TerminalInputRawEvent)
+    this.writeTerminalInput(term, data)
     return { status: 'written' }
   }
 

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -664,7 +664,6 @@ type CodexInputGate =
     }
 
 const CODEX_STARTUP_UPDATE_PROMPT_TAIL_CHARS = 8 * 1024
-const CODEX_STARTUP_UPDATE_PROMPT_TTL_MS = 10 * 60 * 1000
 const CODEX_STARTUP_UPDATE_CHOICE_BY_KEY: Record<'1' | '2' | '3', CodexStartupUpdateChoice> = {
   '1': 'update_now',
   '2': 'skip',
@@ -707,10 +706,9 @@ function observeCodexStartupOutput(record: TerminalRecord, data: string, now: nu
   }
 }
 
-function isCodexStartupUpdatePromptFresh(gate: CodexInputGate | undefined, now: number): boolean {
+function hasActiveCodexStartupUpdatePrompt(gate: CodexInputGate | undefined): boolean {
   return gate?.state === 'identity_pending'
     && !!gate.startupUpdatePrompt
-    && now - gate.startupUpdatePrompt.lastMatchedAt <= CODEX_STARTUP_UPDATE_PROMPT_TTL_MS
 }
 
 function parseCodexStartupUpdatePromptChoice(data: string): { key: '1' | '2' | '3'; choice: CodexStartupUpdateChoice } | undefined {
@@ -727,7 +725,7 @@ function clearCodexStartupUpdatePromptState(gate: Extract<CodexInputGate, { stat
 
 function handleCodexStartupUpdatePromptInput(record: TerminalRecord, data: string, now: number): boolean {
   const gate = record.codexInputGate
-  if (!isCodexStartupUpdatePromptFresh(gate, now) || gate?.state !== 'identity_pending') return false
+  if (!hasActiveCodexStartupUpdatePrompt(gate) || gate?.state !== 'identity_pending') return false
 
   const choice = parseCodexStartupUpdatePromptChoice(data)
   if (choice) {

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -593,7 +593,7 @@ export type TerminalRecord = {
   codexActiveTurn?: CodexTurnEvent
   codexUnconfirmedInputAt?: number
   codexUnconfirmedInputSource?: 'resume' | 'input'
-  codexInputGate?: { state: 'identity_pending'; codexUpdatePromptDismissed?: boolean }
+  codexInputGate?: CodexInputGate
   codexRecovery?: CodexRecoveryOptions
   codexRecoveryAttempt?: Promise<void>
   codexRecoveryAttemptSerial?: number
@@ -645,7 +645,29 @@ function isCodexStartupTerminalControlInput(data: string): boolean {
   return /^\x1b\](?:10|11|12|4;\d{1,3});rgb:[0-9a-fA-F]{1,4}\/[0-9a-fA-F]{1,4}\/[0-9a-fA-F]{1,4}(?:\x07|\x1b\\)$/.test(data)
 }
 
-const CODEX_UPDATE_PROMPT_TAIL_CHARS = 8 * 1024
+type CodexStartupUpdateChoice = 'update_now' | 'skip' | 'skip_until_next_version'
+
+type CodexInputGate =
+  | {
+      state: 'identity_pending'
+      startupOutputTail?: string
+      startupUpdatePrompt?: {
+        detectedAt: number
+        lastMatchedAt: number
+      }
+    }
+  | {
+      state: 'update_running'
+      startedAt: number
+    }
+
+const CODEX_STARTUP_UPDATE_PROMPT_TAIL_CHARS = 8 * 1024
+const CODEX_STARTUP_UPDATE_PROMPT_TTL_MS = 10 * 60 * 1000
+const CODEX_STARTUP_UPDATE_CHOICE_BY_KEY: Record<'1' | '2' | '3', CodexStartupUpdateChoice> = {
+  '1': 'update_now',
+  '2': 'skip',
+  '3': 'skip_until_next_version',
+}
 // eslint-disable-next-line no-control-regex -- terminal snapshots contain ANSI/OSC control bytes.
 const TERMINAL_CONTROL_PATTERN = /\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_]/g
 
@@ -653,44 +675,72 @@ function stripTerminalControls(data: string): string {
   return data.replace(TERMINAL_CONTROL_PATTERN, '')
 }
 
-function hasCodexUpdatePrompt(snapshot: string): boolean {
-  const tail = snapshot.slice(-CODEX_UPDATE_PROMPT_TAIL_CHARS)
-  const text = stripTerminalControls(tail).replace(/\r/g, '\n')
-  return text.includes('Update available!')
-    && text.includes('github.com/openai/codex/releases/latest')
-    && text.includes('Update now')
-    && text.includes('Skip until next version')
-    && text.includes('Press enter to continue')
+function normalizeCodexStartupUpdatePromptText(data: string): string {
+  return stripTerminalControls(data)
+    .replace(/\r/g, '\n')
+    .replace(/[ \t]+/g, ' ')
 }
 
-function isCodexUpdatePromptInput(data: string): boolean {
-  return data === '1'
-    || data === '2'
-    || data === '3'
-    || data === '1\r'
-    || data === '2\r'
-    || data === '3\r'
-    || data === '1\n'
-    || data === '2\n'
-    || data === '3\n'
-    || data === '\r'
-    || data === '\n'
-    || data === '\r\n'
-    || data === '\x1b[A'
-    || data === '\x1b[B'
+function hasCodexStartupUpdatePrompt(text: string): boolean {
+  const normalized = normalizeCodexStartupUpdatePromptText(text)
+  return normalized.includes('github.com/openai/codex/releases/latest')
+    && /(?:^|\n)\s*[\u203a> ]*\s*1[.)]\s*Update now\s*\(runs\s+`?[^`\n]*(?:npm|bun|brew)[^`\n]*`?\)/i.test(normalized)
+    && /(?:^|\n)\s*[\u203a> ]*\s*2[.)]\s*Skip\b/i.test(normalized)
+    && /(?:^|\n)\s*[\u203a> ]*\s*3[.)]\s*Skip until next version\b/i.test(normalized)
+    && /Press\s+enter\s+to\s+continue/i.test(normalized)
 }
 
-function isCodexUpdatePromptDismissInput(data: string): boolean {
-  return data === '\r'
-    || data === '\n'
-    || data === '\r\n'
-    || data.endsWith('\r')
-    || data.endsWith('\n')
+function observeCodexStartupOutput(record: TerminalRecord, data: string, now: number): void {
+  const gate = record.codexInputGate
+  if (gate?.state !== 'identity_pending') return
+  gate.startupOutputTail = `${gate.startupOutputTail ?? ''}${data}`.slice(-CODEX_STARTUP_UPDATE_PROMPT_TAIL_CHARS)
+  if (!hasCodexStartupUpdatePrompt(gate.startupOutputTail)) return
+  gate.startupUpdatePrompt = {
+    detectedAt: gate.startupUpdatePrompt?.detectedAt ?? now,
+    lastMatchedAt: now,
+  }
 }
 
-function isCodexStartupUpdatePromptInput(record: TerminalRecord, data: string): boolean {
-  if (record.codexInputGate?.codexUpdatePromptDismissed) return false
-  return isCodexUpdatePromptInput(data) && hasCodexUpdatePrompt(record.buffer.snapshot())
+function isCodexStartupUpdatePromptFresh(gate: CodexInputGate | undefined, now: number): boolean {
+  return gate?.state === 'identity_pending'
+    && !!gate.startupUpdatePrompt
+    && now - gate.startupUpdatePrompt.lastMatchedAt <= CODEX_STARTUP_UPDATE_PROMPT_TTL_MS
+}
+
+function parseCodexStartupUpdatePromptChoice(data: string): { key: '1' | '2' | '3'; choice: CodexStartupUpdateChoice } | undefined {
+  const match = /^([123])(?:\r\n|\r|\n)?$/.exec(data)
+  if (!match) return undefined
+  const key = match[1] as '1' | '2' | '3'
+  return { key, choice: CODEX_STARTUP_UPDATE_CHOICE_BY_KEY[key] }
+}
+
+function clearCodexStartupUpdatePromptState(gate: Extract<CodexInputGate, { state: 'identity_pending' }>): void {
+  gate.startupOutputTail = undefined
+  gate.startupUpdatePrompt = undefined
+}
+
+function handleCodexStartupUpdatePromptInput(record: TerminalRecord, data: string, now: number): boolean {
+  const gate = record.codexInputGate
+  if (!isCodexStartupUpdatePromptFresh(gate, now) || gate?.state !== 'identity_pending') return false
+
+  const choice = parseCodexStartupUpdatePromptChoice(data)
+  if (choice) {
+    record.pty.write(choice.key)
+    if (choice.choice === 'update_now') {
+      record.codexInputGate = { state: 'update_running', startedAt: now }
+    } else {
+      clearCodexStartupUpdatePromptState(gate)
+    }
+    return true
+  }
+
+  if (data === '\r' || data === '\n' || data === '\r\n') {
+    record.pty.write(data)
+    record.codexInputGate = { state: 'update_running', startedAt: now }
+    return true
+  }
+
+  return false
 }
 
 export type BindSessionResult =
@@ -1581,6 +1631,7 @@ export class TerminalRegistry extends EventEmitter {
       const now = Date.now()
       record.lastActivityAt = now
       record.buffer.append(data)
+      observeCodexStartupOutput(record, data, now)
       this.emit('terminal.output.raw', {
         terminalId,
         data,
@@ -3053,6 +3104,7 @@ export class TerminalRegistry extends EventEmitter {
       const now = Date.now()
       record.lastActivityAt = now
       record.buffer.append(data)
+      observeCodexStartupOutput(record, data, now)
       this.emit('terminal.output.raw', {
         terminalId: record.terminalId,
         data,
@@ -3236,13 +3288,12 @@ export class TerminalRegistry extends EventEmitter {
       return { status: 'blocked_codex_lifecycle_loss_pending', terminalId }
     }
     if (term.codexInputGate?.state === 'identity_pending') {
-      if (isCodexStartupTerminalControlInput(data) || isCodexStartupUpdatePromptInput(term, data)) {
+      const now = Date.now()
+      if (isCodexStartupTerminalControlInput(data)) {
         term.pty.write(data)
-        if (isCodexUpdatePromptDismissInput(data)) {
-          term.codexInputGate.codexUpdatePromptDismissed = true
-        }
         return { status: 'written' }
       }
+      if (handleCodexStartupUpdatePromptInput(term, data, now)) return { status: 'written' }
       return { status: 'blocked_codex_identity_pending', terminalId }
     }
     const now = Date.now()

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -681,7 +681,7 @@ function normalizeCodexStartupUpdatePromptText(data: string): string {
 function hasCodexStartupUpdatePrompt(text: string): boolean {
   const normalized = normalizeCodexStartupUpdatePromptText(text)
   return normalized.includes('github.com/openai/codex/releases/latest')
-    && /(?:^|\n)[ \t]*[\u203a>]?[ \t]*1[.)][ \t]*Update now[ \t]*\(runs[ \t]+`?[^`\n]*(?:npm|bun|brew)[^`\n]*`?\)/i.test(normalized)
+    && /(?:^|\n)[ \t]*[\u203a>]?[ \t]*1[.)][ \t]*Update now[ \t]*\(runs[ \t]+[^)\n]+\)/i.test(normalized)
     && /(?:^|\n)[ \t]*[\u203a>]?[ \t]*2[.)][ \t]*Skip\b/i.test(normalized)
     && /(?:^|\n)[ \t]*[\u203a>]?[ \t]*3[.)][ \t]*Skip until next version\b/i.test(normalized)
     && /Press\s+enter\s+to\s+continue/i.test(normalized)

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -2998,6 +2998,7 @@ export class TerminalRegistry extends EventEmitter {
       const oldPty = record.pty
       const oldSidecar = record.codexSidecar
       record.codexRecoveryRetiringPty = oldPty
+      this.clearCodexInputGate(record)
       if (oldSidecar) {
         try {
           await this.trackSidecarShutdown(
@@ -3027,7 +3028,6 @@ export class TerminalRegistry extends EventEmitter {
 
       record.codexSidecarLifecycleUnsubscribe?.()
       record.codexSidecarLifecycleUnsubscribe = undefined
-      this.clearCodexInputGate(record)
       record.pty = candidate.pty
       this.emit('terminal.stream.replaced', {
         terminalId: record.terminalId,

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -653,14 +653,10 @@ type CodexInputGate =
   | {
       state: 'identity_pending'
       startupOutputTail?: string
-      startupUpdatePrompt?: {
-        detectedAt: number
-        lastMatchedAt: number
-      }
+      startupUpdatePrompt?: true
     }
   | {
       state: 'update_running'
-      startedAt: number
     }
 
 const CODEX_STARTUP_UPDATE_PROMPT_TAIL_CHARS = 8 * 1024
@@ -685,22 +681,19 @@ function normalizeCodexStartupUpdatePromptText(data: string): string {
 function hasCodexStartupUpdatePrompt(text: string): boolean {
   const normalized = normalizeCodexStartupUpdatePromptText(text)
   return normalized.includes('github.com/openai/codex/releases/latest')
-    && /(?:^|\n)\s*[\u203a> ]*\s*1[.)]\s*Update now\s*\(runs\s+`?[^`\n]*(?:npm|bun|brew)[^`\n]*`?\)/i.test(normalized)
-    && /(?:^|\n)\s*[\u203a> ]*\s*2[.)]\s*Skip\b/i.test(normalized)
-    && /(?:^|\n)\s*[\u203a> ]*\s*3[.)]\s*Skip until next version\b/i.test(normalized)
+    && /(?:^|\n)[ \t]*[\u203a>]?[ \t]*1[.)][ \t]*Update now[ \t]*\(runs[ \t]+`?[^`\n]*(?:npm|bun|brew)[^`\n]*`?\)/i.test(normalized)
+    && /(?:^|\n)[ \t]*[\u203a>]?[ \t]*2[.)][ \t]*Skip\b/i.test(normalized)
+    && /(?:^|\n)[ \t]*[\u203a>]?[ \t]*3[.)][ \t]*Skip until next version\b/i.test(normalized)
     && /Press\s+enter\s+to\s+continue/i.test(normalized)
 }
 
-function observeCodexStartupOutput(record: TerminalRecord, data: string, now: number): void {
+function observeCodexStartupOutput(record: TerminalRecord, data: string): void {
   const gate = record.codexInputGate
   if (gate?.state !== 'identity_pending') return
   gate.startupOutputTail = `${gate.startupOutputTail ?? ''}${data}`.slice(-CODEX_STARTUP_UPDATE_PROMPT_TAIL_CHARS)
   if (!hasCodexStartupUpdatePrompt(gate.startupOutputTail)) return
   const firstDetection = !gate.startupUpdatePrompt
-  gate.startupUpdatePrompt = {
-    detectedAt: gate.startupUpdatePrompt?.detectedAt ?? now,
-    lastMatchedAt: now,
-  }
+  gate.startupUpdatePrompt = true
   if (firstDetection) {
     record.codexSidecar?.pauseCandidateCapture?.('codex_startup_update_prompt')
   }
@@ -723,7 +716,7 @@ function clearCodexStartupUpdatePromptState(gate: Extract<CodexInputGate, { stat
   gate.startupUpdatePrompt = undefined
 }
 
-function handleCodexStartupUpdatePromptInput(record: TerminalRecord, data: string, now: number): boolean {
+function handleCodexStartupUpdatePromptInput(record: TerminalRecord, data: string): boolean {
   const gate = record.codexInputGate
   if (!hasActiveCodexStartupUpdatePrompt(gate) || gate?.state !== 'identity_pending') return false
 
@@ -731,7 +724,7 @@ function handleCodexStartupUpdatePromptInput(record: TerminalRecord, data: strin
   if (choice) {
     record.pty.write(choice.key)
     if (choice.choice === 'update_now') {
-      record.codexInputGate = { state: 'update_running', startedAt: now }
+      record.codexInputGate = { state: 'update_running' }
     } else {
       record.codexSidecar?.resumeCandidateCapture?.('codex_startup_update_skipped')
       clearCodexStartupUpdatePromptState(gate)
@@ -741,7 +734,7 @@ function handleCodexStartupUpdatePromptInput(record: TerminalRecord, data: strin
 
   if (data === '\r' || data === '\n' || data === '\r\n') {
     record.pty.write(data)
-    record.codexInputGate = { state: 'update_running', startedAt: now }
+    record.codexInputGate = { state: 'update_running' }
     return true
   }
 
@@ -1644,7 +1637,7 @@ export class TerminalRegistry extends EventEmitter {
       const now = Date.now()
       record.lastActivityAt = now
       record.buffer.append(data)
-      observeCodexStartupOutput(record, data, now)
+      observeCodexStartupOutput(record, data)
       this.emit('terminal.output.raw', {
         terminalId,
         data,
@@ -3118,7 +3111,7 @@ export class TerminalRegistry extends EventEmitter {
       const now = Date.now()
       record.lastActivityAt = now
       record.buffer.append(data)
-      observeCodexStartupOutput(record, data, now)
+      observeCodexStartupOutput(record, data)
       this.emit('terminal.output.raw', {
         terminalId: record.terminalId,
         data,
@@ -3331,12 +3324,11 @@ export class TerminalRegistry extends EventEmitter {
       return { status: 'blocked_codex_lifecycle_loss_pending', terminalId }
     }
     if (term.codexInputGate?.state === 'identity_pending') {
-      const now = Date.now()
       if (isCodexStartupTerminalControlInput(data)) {
         term.pty.write(data)
         return { status: 'written' }
       }
-      if (handleCodexStartupUpdatePromptInput(term, data, now)) return { status: 'written' }
+      if (handleCodexStartupUpdatePromptInput(term, data)) return { status: 'written' }
       return { status: 'blocked_codex_identity_pending', terminalId }
     }
     if (term.codexInputGate?.state === 'update_running') {

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -577,6 +577,8 @@ export type TerminalRecord = {
     | 'watchPath'
     | 'unwatchPath'
     | 'markCandidatePersisted'
+    | 'pauseCandidateCapture'
+    | 'resumeCandidateCapture'
     | 'readThreadTurn'
     | 'listThreadTurns'
   >
@@ -695,9 +697,13 @@ function observeCodexStartupOutput(record: TerminalRecord, data: string, now: nu
   if (gate?.state !== 'identity_pending') return
   gate.startupOutputTail = `${gate.startupOutputTail ?? ''}${data}`.slice(-CODEX_STARTUP_UPDATE_PROMPT_TAIL_CHARS)
   if (!hasCodexStartupUpdatePrompt(gate.startupOutputTail)) return
+  const firstDetection = !gate.startupUpdatePrompt
   gate.startupUpdatePrompt = {
     detectedAt: gate.startupUpdatePrompt?.detectedAt ?? now,
     lastMatchedAt: now,
+  }
+  if (firstDetection) {
+    record.codexSidecar?.pauseCandidateCapture?.('codex_startup_update_prompt')
   }
 }
 
@@ -729,6 +735,7 @@ function handleCodexStartupUpdatePromptInput(record: TerminalRecord, data: strin
     if (choice.choice === 'update_now') {
       record.codexInputGate = { state: 'update_running', startedAt: now }
     } else {
+      record.codexSidecar?.resumeCandidateCapture?.('codex_startup_update_skipped')
       clearCodexStartupUpdatePromptState(gate)
     }
     return true
@@ -1425,12 +1432,20 @@ export class TerminalRegistry extends EventEmitter {
     })
   }
 
+  private clearCodexInputGate(record: TerminalRecord): void {
+    if (record.codexInputGate?.state === 'identity_pending' && record.codexInputGate.startupUpdatePrompt) {
+      record.codexSidecar?.resumeCandidateCapture?.('codex_input_gate_cleared')
+    }
+    record.codexInputGate = undefined
+  }
+
   private finishTerminalPtyExit(
     record: TerminalRecord,
     event: { exitCode: number; signal?: number },
   ): void {
     this.clearCodexPendingCleanExitFinalizer(record)
     this.markCodexRecoveryFinalClose(record)
+    this.clearCodexInputGate(record)
     record.status = 'exited'
     record.exitCode = event.exitCode
     const now = Date.now()
@@ -2149,8 +2164,8 @@ export class TerminalRegistry extends EventEmitter {
     }
     const storedDurability = this.codexDurabilityRecordToRef(stored)
     record.codexDurability = storedDurability
-    record.codexInputGate = undefined
     record.codexSidecar?.markCandidatePersisted?.()
+    this.clearCodexInputGate(record)
     this.armCodexRolloutWatch(record)
     logger.info({
       terminalId,
@@ -2184,7 +2199,7 @@ export class TerminalRegistry extends EventEmitter {
     }
     try {
       const stored = await this.writeCodexDurability(record, durability)
-      record.codexInputGate = undefined
+      this.clearCodexInputGate(record)
       this.broadcastCodexDurability(record, stored)
     } catch (err) {
       logger.error({ err, terminalId, reason }, 'Failed to persist non-restorable Codex identity state')
@@ -3012,6 +3027,7 @@ export class TerminalRegistry extends EventEmitter {
 
       record.codexSidecarLifecycleUnsubscribe?.()
       record.codexSidecarLifecycleUnsubscribe = undefined
+      this.clearCodexInputGate(record)
       record.pty = candidate.pty
       this.emit('terminal.stream.replaced', {
         terminalId: record.terminalId,
@@ -3342,8 +3358,8 @@ export class TerminalRegistry extends EventEmitter {
   releaseCodexInputGateForTest(terminalId: string): boolean {
     const term = this.terminals.get(terminalId)
     if (!term) return false
-    term.codexInputGate = undefined
     term.codexSidecar?.markCandidatePersisted?.()
+    this.clearCodexInputGate(term)
     return true
   }
 
@@ -3382,6 +3398,7 @@ export class TerminalRegistry extends EventEmitter {
       return true
     }
     this.markCodexRecoveryFinalClose(term)
+    this.clearCodexInputGate(term)
     cleanupMcpConfig(terminalId, term.mode, term.mcpCwd)
     try {
       term.pty.kill()

--- a/test/server/agent-send-keys.test.ts
+++ b/test/server/agent-send-keys.test.ts
@@ -16,6 +16,36 @@ it('sends input to a pane terminal', async () => {
   expect(res.body.status).toBe('ok')
 })
 
+it('normalizes REST send-keys token strings through the shared key translator', async () => {
+  const input = vi.fn(() => ({ status: 'written' }))
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { resolvePaneToTerminal: () => 'term_1' },
+    registry: { input },
+  }))
+
+  const res = await request(app).post('/api/panes/p1/send-keys').send({ keys: 'ENTER' })
+
+  expect(res.body.status).toBe('ok')
+  expect(input).toHaveBeenCalledWith('term_1', '\r')
+})
+
+it('normalizes REST send-keys token arrays through the shared key translator', async () => {
+  const input = vi.fn(() => ({ status: 'written' }))
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { resolvePaneToTerminal: () => 'term_1' },
+    registry: { input },
+  }))
+
+  const res = await request(app).post('/api/panes/p1/send-keys').send({ keys: ['2', 'ENTER'] })
+
+  expect(res.body.status).toBe('ok')
+  expect(input).toHaveBeenCalledWith('term_1', '2\r')
+})
+
 it('resolves tmux-style target to a pane before sending', async () => {
   const input = vi.fn(() => ({ status: 'written' }))
   const app = express()

--- a/test/server/agent-send-keys.test.ts
+++ b/test/server/agent-send-keys.test.ts
@@ -5,15 +5,50 @@ import request from 'supertest'
 import { createAgentApiRouter } from '../../server/agent-api/router'
 
 it('sends input to a pane terminal', async () => {
+  const input = vi.fn(() => ({ status: 'written' }))
   const app = express()
   app.use(express.json())
   app.use('/api', createAgentApiRouter({
     layoutStore: { resolvePaneToTerminal: () => 'term_1' },
-    registry: { input: () => ({ status: 'written' }) },
+    registry: { input },
   }))
 
   const res = await request(app).post('/api/panes/p1/send-keys').send({ data: 'ls\r' })
   expect(res.body.status).toBe('ok')
+  expect(input).toHaveBeenCalledWith('term_1', 'ls\r')
+})
+
+it('prefers raw data over keys when both are supplied', async () => {
+  const input = vi.fn(() => ({ status: 'written' }))
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { resolvePaneToTerminal: () => 'term_1' },
+    registry: { input },
+  }))
+
+  const res = await request(app).post('/api/panes/p1/send-keys').send({
+    data: 'raw ENTER',
+    keys: 'ENTER',
+  })
+
+  expect(res.body.status).toBe('ok')
+  expect(input).toHaveBeenCalledWith('term_1', 'raw ENTER')
+})
+
+it('preserves raw text fallback when data and keys are absent', async () => {
+  const input = vi.fn(() => ({ status: 'written' }))
+  const app = express()
+  app.use(express.json())
+  app.use('/api', createAgentApiRouter({
+    layoutStore: { resolvePaneToTerminal: () => 'term_1' },
+    registry: { input },
+  }))
+
+  const res = await request(app).post('/api/panes/p1/send-keys').send({ text: 'plain text' })
+
+  expect(res.body.status).toBe('ok')
+  expect(input).toHaveBeenCalledWith('term_1', 'plain text')
 })
 
 it('normalizes REST send-keys token strings through the shared key translator', async () => {

--- a/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
@@ -126,7 +126,7 @@ function createPlanner(
     proxyFactory: (options: FakeProxyOptions) => {
       const proxy = new FakeProxy(options)
       proxies.push(proxy)
-      return proxy as any
+      return proxy
     },
   })
 }
@@ -425,8 +425,8 @@ describe('CodexLaunchPlanner', () => {
 
     const plan = await planner.planCreate({ cwd: '/repo/pause' })
 
-    ;(plan.sidecar as any).pauseCandidateCapture('startup_update_prompt')
-    ;(plan.sidecar as any).resumeCandidateCapture('startup_update_prompt_skipped')
+    plan.sidecar.pauseCandidateCapture!('startup_update_prompt')
+    plan.sidecar.resumeCandidateCapture!('startup_update_prompt_skipped')
 
     expect(proxies[0].pauseCandidateCapture).toHaveBeenCalledWith('startup_update_prompt')
     expect(proxies[0].resumeCandidateCapture).toHaveBeenCalledWith('startup_update_prompt_skipped')

--- a/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
@@ -90,6 +90,8 @@ class FakeProxy {
   readonly wsUrl: string
   readonly upstreamWsUrl: string
   readonly requireCandidatePersistence: boolean
+  readonly pauseCandidateCapture = vi.fn()
+  readonly resumeCandidateCapture = vi.fn()
 
   constructor(options: FakeProxyOptions) {
     this.upstreamWsUrl = options.upstreamWsUrl
@@ -414,5 +416,21 @@ describe('CodexLaunchPlanner', () => {
     await planner.planCreate({ resumeSessionId: 'thread-ready', cwd: '/repo/resume' })
 
     expect(runtime.ensureReadyCwdCalls).toEqual(['/repo/resume'])
+  })
+
+  it('forwards candidate capture pause and resume through the sidecar', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43026', 'thread-pause')
+    const proxies: FakeProxy[] = []
+    const planner = createPlanner(() => runtime as any, proxies)
+
+    const plan = await planner.planCreate({ cwd: '/repo/pause' })
+
+    ;(plan.sidecar as any).pauseCandidateCapture('startup_update_prompt')
+    ;(plan.sidecar as any).resumeCandidateCapture('startup_update_prompt_skipped')
+
+    expect(proxies[0].pauseCandidateCapture).toHaveBeenCalledWith('startup_update_prompt')
+    expect(proxies[0].resumeCandidateCapture).toHaveBeenCalledWith('startup_update_prompt_skipped')
+
+    await plan.sidecar.shutdown()
   })
 })

--- a/test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts
@@ -1,5 +1,5 @@
 import WebSocket, { WebSocketServer } from 'ws'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { CodexRemoteProxy } from '../../../../../server/coding-cli/codex-app-server/remote-proxy.js'
 
 type UpstreamHandle = {
@@ -14,15 +14,19 @@ const upstreams = new Set<UpstreamHandle>()
 const proxies = new Set<CodexRemoteProxy>()
 
 afterEach(async () => {
-  await Promise.all([...proxies].map(async (proxy) => {
-    proxies.delete(proxy)
-    await proxy.close()
-  }))
-  await Promise.all([...upstreams].map(async (upstream) => {
-    upstreams.delete(upstream)
-    for (const socket of upstream.sockets) socket.close()
-    await new Promise<void>((resolve) => upstream.server.close(() => resolve()))
-  }))
+  try {
+    await Promise.all([...proxies].map(async (proxy) => {
+      proxies.delete(proxy)
+      await proxy.close()
+    }))
+    await Promise.all([...upstreams].map(async (upstream) => {
+      upstreams.delete(upstream)
+      for (const socket of upstream.sockets) socket.close()
+      await new Promise<void>((resolve) => upstream.server.close(() => resolve()))
+    }))
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
 async function startUpstream(handler?: (socket: WebSocket, message: any) => void): Promise<UpstreamHandle> {
@@ -323,6 +327,46 @@ describe('CodexRemoteProxy', () => {
     await delay(50)
 
     expect(upstream.messages).toHaveLength(0)
+    expect(repairTriggers).toContainEqual({ kind: 'candidate_capture_timeout' })
+  })
+
+  it('pauses candidate capture timeout and ignores timer rearm attempts while paused', () => {
+    vi.useFakeTimers()
+    const proxy = new CodexRemoteProxy({
+      upstreamWsUrl: 'ws://127.0.0.1:1',
+      candidateCaptureTimeoutMs: 1_000,
+    })
+    proxies.add(proxy)
+    const repairTriggers: unknown[] = []
+    proxy.onRepairTrigger((event) => repairTriggers.push(event))
+
+    ;(proxy as any).ensureCandidateCaptureTimer()
+    proxy.pauseCandidateCapture('startup_update_prompt')
+    ;(proxy as any).ensureCandidateCaptureTimer()
+
+    vi.advanceTimersByTime(5_000)
+
+    expect(repairTriggers).toEqual([])
+  })
+
+  it('resumes candidate capture timeout so a later timeout still fires', () => {
+    vi.useFakeTimers()
+    const proxy = new CodexRemoteProxy({
+      upstreamWsUrl: 'ws://127.0.0.1:1',
+      candidateCaptureTimeoutMs: 1_000,
+    })
+    proxies.add(proxy)
+    const repairTriggers: unknown[] = []
+    proxy.onRepairTrigger((event) => repairTriggers.push(event))
+
+    proxy.pauseCandidateCapture('startup_update_prompt')
+    ;(proxy as any).ensureCandidateCaptureTimer()
+    vi.advanceTimersByTime(5_000)
+    expect(repairTriggers).toEqual([])
+
+    proxy.resumeCandidateCapture('startup_update_prompt_skipped')
+    vi.advanceTimersByTime(1_000)
+
     expect(repairTriggers).toContainEqual({ kind: 'candidate_capture_timeout' })
   })
 

--- a/test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts
@@ -352,23 +352,20 @@ describe('CodexRemoteProxy', () => {
     await socketClosed(tui)
   })
 
-  it('resumes candidate capture timeout so a later timeout still fires', () => {
-    vi.useFakeTimers()
-    const proxy = new CodexRemoteProxy({
-      upstreamWsUrl: 'ws://127.0.0.1:1',
-      candidateCaptureTimeoutMs: 1_000,
+  it('resumes candidate capture timeout so a later timeout still fires', async () => {
+    const upstream = await startUpstream()
+    const proxy = await startProxy(upstream.wsUrl, {
+      candidateCaptureTimeoutMs: 20,
     })
-    proxies.add(proxy)
     const repairTriggers: unknown[] = []
     proxy.onRepairTrigger((event) => repairTriggers.push(event))
 
     proxy.pauseCandidateCapture('startup_update_prompt')
-    ;(proxy as any).ensureCandidateCaptureTimer()
-    vi.advanceTimersByTime(5_000)
+    await delay(50)
     expect(repairTriggers).toEqual([])
 
     proxy.resumeCandidateCapture('startup_update_prompt_skipped')
-    vi.advanceTimersByTime(1_000)
+    await delay(50)
 
     expect(repairTriggers).toContainEqual({ kind: 'candidate_capture_timeout' })
   })

--- a/test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts
@@ -330,23 +330,26 @@ describe('CodexRemoteProxy', () => {
     expect(repairTriggers).toContainEqual({ kind: 'candidate_capture_timeout' })
   })
 
-  it('pauses candidate capture timeout and ignores timer rearm attempts while paused', () => {
-    vi.useFakeTimers()
-    const proxy = new CodexRemoteProxy({
-      upstreamWsUrl: 'ws://127.0.0.1:1',
-      candidateCaptureTimeoutMs: 1_000,
+  it('keeps candidate capture paused when a real client connection would otherwise rearm the timer', async () => {
+    const upstream = await startUpstream()
+    const proxy = await startProxy(upstream.wsUrl, {
+      candidateCaptureTimeoutMs: 20,
     })
-    proxies.add(proxy)
     const repairTriggers: unknown[] = []
     proxy.onRepairTrigger((event) => repairTriggers.push(event))
 
-    ;(proxy as any).ensureCandidateCaptureTimer()
     proxy.pauseCandidateCapture('startup_update_prompt')
-    ;(proxy as any).ensureCandidateCaptureTimer()
+    const tui = await connect(proxy.wsUrl)
 
-    vi.advanceTimersByTime(5_000)
+    await delay(50)
 
+    expect(tui.readyState).toBe(WebSocket.OPEN)
+    expect(upstream.sockets.size).toBe(1)
+    expect(upstream.messages).toEqual([])
     expect(repairTriggers).toEqual([])
+
+    tui.close()
+    await socketClosed(tui)
   })
 
   it('resumes candidate capture timeout so a later timeout still fires', () => {
@@ -368,6 +371,60 @@ describe('CodexRemoteProxy', () => {
     vi.advanceTimersByTime(1_000)
 
     expect(repairTriggers).toContainEqual({ kind: 'candidate_capture_timeout' })
+  })
+
+  it('leaves pause and resume as no-ops after candidate persistence', () => {
+    vi.useFakeTimers()
+    const proxy = new CodexRemoteProxy({
+      upstreamWsUrl: 'ws://127.0.0.1:1',
+      candidateCaptureTimeoutMs: 1_000,
+    })
+    proxies.add(proxy)
+    const repairTriggers: unknown[] = []
+    proxy.onRepairTrigger((event) => repairTriggers.push(event))
+
+    proxy.markCandidatePersisted()
+    proxy.pauseCandidateCapture('after_persistence')
+    proxy.resumeCandidateCapture('after_persistence')
+    vi.advanceTimersByTime(5_000)
+
+    expect(repairTriggers).toEqual([])
+  })
+
+  it('leaves pause and resume as no-ops after candidate timeout failure', () => {
+    vi.useFakeTimers()
+    const proxy = new CodexRemoteProxy({
+      upstreamWsUrl: 'ws://127.0.0.1:1',
+      candidateCaptureTimeoutMs: 1_000,
+    })
+    proxies.add(proxy)
+    const repairTriggers: unknown[] = []
+    proxy.onRepairTrigger((event) => repairTriggers.push(event))
+
+    proxy.failCandidateCapture()
+    proxy.pauseCandidateCapture('after_timeout_failure')
+    proxy.resumeCandidateCapture('after_timeout_failure')
+    vi.advanceTimersByTime(5_000)
+
+    expect(repairTriggers).toEqual([{ kind: 'candidate_capture_timeout' }])
+  })
+
+  it('leaves pause and resume as no-ops when candidate persistence is not required', () => {
+    vi.useFakeTimers()
+    const proxy = new CodexRemoteProxy({
+      upstreamWsUrl: 'ws://127.0.0.1:1',
+      candidateCaptureTimeoutMs: 1_000,
+      requireCandidatePersistence: false,
+    })
+    proxies.add(proxy)
+    const repairTriggers: unknown[] = []
+    proxy.onRepairTrigger((event) => repairTriggers.push(event))
+
+    proxy.pauseCandidateCapture('durable_resume')
+    proxy.resumeCandidateCapture('durable_resume')
+    vi.advanceTimersByTime(5_000)
+
+    expect(repairTriggers).toEqual([])
   })
 
   it('does not arm the no-client candidate-capture timeout for durable resumes', async () => {

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -310,9 +310,8 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
 
     expect(args).toContain('-c')
     expect(args).toContain('features.apps=false')
-    expect(args).toContain('check_for_update_on_startup=false')
+    expect(args).not.toContain('check_for_update_on_startup=false')
     expect(args.indexOf('features.apps=false')).toBeLessThan(args.indexOf('app-server'))
-    expect(args.indexOf('check_for_update_on_startup=false')).toBeLessThan(args.indexOf('app-server'))
     expect(args).toContain('--listen')
   })
 

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -292,7 +292,7 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     expect(runtime.status()).toBe('running')
   })
 
-  it('disables Codex apps while starting Freshell-managed app-server processes', async () => {
+  it('uses managed Codex config while starting Freshell-managed app-server processes', async () => {
     const tempDir = await makeTempDir()
     const argLogPath = path.join(tempDir, 'argv.json')
     const runtime = createRuntime({
@@ -310,7 +310,9 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
 
     expect(args).toContain('-c')
     expect(args).toContain('features.apps=false')
+    expect(args).toContain('check_for_update_on_startup=false')
     expect(args.indexOf('features.apps=false')).toBeLessThan(args.indexOf('app-server'))
+    expect(args.indexOf('check_for_update_on_startup=false')).toBeLessThan(args.indexOf('app-server'))
     expect(args).toContain('--listen')
   })
 

--- a/test/unit/server/terminal-registry.codex-sidecar.test.ts
+++ b/test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -169,10 +169,13 @@ function createCandidateExitPlanCreate() {
   return planCreate
 }
 
-function emitCodexStartupUpdatePrompt(pty: { _emitData(data: string): void }): void {
+function emitCodexStartupUpdatePrompt(
+  pty: { _emitData(data: string): void },
+  command = 'npm install -g @openai/codex',
+): void {
   pty._emitData([
     'Release notes: https://github.com/openai/codex/releases/latest\r\n',
-    '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+    `› 1. Update now (runs \`${command}\`)\r\n`,
     '  2. Skip\r\n',
     '  3. Skip until next version\r\n',
     'Press enter to continue\r\n',
@@ -639,6 +642,28 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
 
     expect(registry.input(term.terminalId, '\r')).toEqual({ status: 'written' })
     expect(pty.write).toHaveBeenLastCalledWith('\r')
+  })
+
+  it.each([
+    ['standalone Unix', "sh -c 'curl -fsSL https://chatgpt.com/codex/install.sh | sh'"],
+    ['standalone Windows', "powershell -ExecutionPolicy Bypass -c 'irm https://chatgpt.com/codex/install.ps1 | iex'"],
+  ])('detects the Codex update prompt for %s install commands', (_label, command) => {
+    const registry = new TerminalRegistry()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: createFakeSidecar(),
+        },
+      } as any,
+    })
+
+    const pty = mockPtyProcess.instances[0]
+    emitCodexStartupUpdatePrompt(pty, command)
+
+    expect(registry.input(term.terminalId, '2')).toEqual({ status: 'written' })
+    expect(pty.write).toHaveBeenLastCalledWith('2')
   })
 
   it('keeps a detected Codex update prompt answerable after a long idle', () => {

--- a/test/unit/server/terminal-registry.codex-sidecar.test.ts
+++ b/test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -521,9 +521,17 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
     expect(registry.get(term.terminalId)?.codexInputGate).toBeUndefined()
   })
 
-  it('resumes paused candidate capture when recovery replacement clears a stale startup update gate', async () => {
+  it('resumes paused candidate capture before retiring sidecar shutdown during recovery replacement', async () => {
     const registry = new TerminalRegistry()
-    const currentSidecar = createFakeSidecar()
+    const order: string[] = []
+    const currentSidecar = createFakeSidecar({
+      shutdown: async () => {
+        order.push('shutdown')
+      },
+    })
+    currentSidecar.resumeCandidateCapture.mockImplementation(() => {
+      order.push('resume')
+    })
     const replacementSidecar = createFakeSidecar()
     const planCreate = vi.fn(async () => ({
       sessionId: 'thread-1',
@@ -555,6 +563,8 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
 
     await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: term.terminalId, generation: 1 }))
     expect(currentSidecar.resumeCandidateCapture).toHaveBeenCalledWith('codex_input_gate_cleared')
+    expect(currentSidecar.shutdown).toHaveBeenCalledTimes(1)
+    expect(order).toEqual(['resume', 'shutdown'])
     expect(registry.get(term.terminalId)?.codexInputGate).toBeUndefined()
   })
 

--- a/test/unit/server/terminal-registry.codex-sidecar.test.ts
+++ b/test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -169,6 +169,16 @@ function createCandidateExitPlanCreate() {
   return planCreate
 }
 
+function emitCodexStartupUpdatePrompt(pty: { _emitData(data: string): void }): void {
+  pty._emitData([
+    'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+    '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+    '  2. Skip\r\n',
+    '  3. Skip until next version\r\n',
+    'Press enter to continue\r\n',
+  ].join(''))
+}
+
 describe('TerminalRegistry Codex sidecar ownership', () => {
   beforeEach(() => {
     mockPtyProcess.instances = []
@@ -377,6 +387,175 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
 
     expect(sidecar.resumeCandidateCapture).not.toHaveBeenCalled()
     expect(pty.write).toHaveBeenLastCalledWith('1')
+  })
+
+  it('resumes candidate capture when the Codex startup update choice skips until next version', () => {
+    const registry = new TerminalRegistry()
+    const sidecar = createFakeSidecar()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar,
+        },
+      } as any,
+    })
+
+    const pty = mockPtyProcess.instances[0]
+    emitCodexStartupUpdatePrompt(pty)
+
+    expect(registry.input(term.terminalId, '3')).toEqual({ status: 'written' })
+
+    expect(sidecar.resumeCandidateCapture).toHaveBeenCalledWith('codex_startup_update_skipped')
+    expect(pty.write).toHaveBeenLastCalledWith('3')
+    expect(registry.input(term.terminalId, 'hello\r')).toEqual({
+      status: 'blocked_codex_identity_pending',
+      terminalId: term.terminalId,
+    })
+  })
+
+  it('resumes paused candidate capture when candidate capture succeeds and clears the startup update gate', async () => {
+    const durabilityDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-durability-'))
+    try {
+      const registry = new TerminalRegistry(undefined, undefined, undefined, {
+        codexDurabilityStore: new CodexDurabilityStore({ dir: durabilityDir }),
+        serverInstanceId: 'srv-test',
+      })
+      const sidecar = createFakeSidecar()
+      const term = registry.create({
+        mode: 'codex',
+        providerSettings: {
+          codexAppServer: {
+            wsUrl: 'ws://127.0.0.1:43123',
+            sidecar,
+          },
+        } as any,
+      })
+      emitCodexStartupUpdatePrompt(mockPtyProcess.instances[0])
+      sidecar.resumeCandidateCapture.mockClear()
+
+      sidecar.emitCandidate({
+        source: 'thread_start_response',
+        thread: {
+          id: 'thread-cleanup-success',
+          path: path.join(durabilityDir, 'rollout.jsonl'),
+          ephemeral: false,
+        },
+      })
+
+      await vi.waitFor(() => expect(sidecar.markCandidatePersisted).toHaveBeenCalledTimes(1))
+      expect(sidecar.resumeCandidateCapture).toHaveBeenCalledWith('codex_input_gate_cleared')
+      expect(registry.get(term.terminalId)?.codexInputGate).toBeUndefined()
+    } finally {
+      await removeTempDir(durabilityDir)
+    }
+  })
+
+  it('resumes paused candidate capture when candidate capture persistence fails and clears the startup update gate', async () => {
+    const durabilityDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-durability-'))
+    class StoreWithFirstWriteFailure extends CodexDurabilityStore {
+      override async write(...args: Parameters<CodexDurabilityStore['write']>) {
+        if (args[0].candidate?.candidateThreadId === 'thread-cleanup-failure') {
+          throw new Error('candidate write failed')
+        }
+        return super.write(...args)
+      }
+    }
+
+    try {
+      const registry = new TerminalRegistry(undefined, undefined, undefined, {
+        codexDurabilityStore: new StoreWithFirstWriteFailure({ dir: durabilityDir }),
+        serverInstanceId: 'srv-test',
+      })
+      const sidecar = createFakeSidecar()
+      const term = registry.create({
+        mode: 'codex',
+        providerSettings: {
+          codexAppServer: {
+            wsUrl: 'ws://127.0.0.1:43123',
+            sidecar,
+          },
+        } as any,
+      })
+      emitCodexStartupUpdatePrompt(mockPtyProcess.instances[0])
+      sidecar.resumeCandidateCapture.mockClear()
+
+      sidecar.emitCandidate({
+        source: 'thread_start_response',
+        thread: {
+          id: 'thread-cleanup-failure',
+          path: path.join(durabilityDir, 'rollout.jsonl'),
+          ephemeral: false,
+        },
+      })
+
+      await vi.waitFor(() => expect(registry.get(term.terminalId)?.status).toBe('exited'))
+      expect(sidecar.resumeCandidateCapture).toHaveBeenCalledWith('codex_input_gate_cleared')
+      expect(registry.get(term.terminalId)?.codexInputGate).toBeUndefined()
+    } finally {
+      await removeTempDir(durabilityDir)
+    }
+  })
+
+  it('resumes paused candidate capture when terminal finalization clears the startup update gate', async () => {
+    const registry = new TerminalRegistry()
+    const sidecar = createFakeSidecar()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar,
+        },
+      } as any,
+    })
+    const pty = mockPtyProcess.instances[0]
+    emitCodexStartupUpdatePrompt(pty)
+    sidecar.resumeCandidateCapture.mockClear()
+
+    pty._emitExit(0)
+
+    await vi.waitFor(() => expect(registry.get(term.terminalId)?.status).toBe('exited'))
+    expect(sidecar.resumeCandidateCapture).toHaveBeenCalledWith('codex_input_gate_cleared')
+    expect(registry.get(term.terminalId)?.codexInputGate).toBeUndefined()
+  })
+
+  it('resumes paused candidate capture when recovery replacement clears a stale startup update gate', async () => {
+    const registry = new TerminalRegistry()
+    const currentSidecar = createFakeSidecar()
+    const replacementSidecar = createFakeSidecar()
+    const planCreate = vi.fn(async () => ({
+      sessionId: 'thread-1',
+      remote: { wsUrl: 'ws://127.0.0.1:43124' },
+      sidecar: replacementSidecar,
+    }))
+    const term = registry.create({
+      mode: 'codex',
+      resumeSessionId: 'thread-1',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: currentSidecar,
+          recovery: { planCreate, retryDelayMs: 0 },
+        },
+      } as any,
+    })
+    const record = registry.get(term.terminalId)! as any
+    record.codexInputGate = {
+      state: 'identity_pending',
+      createdAt: Date.now(),
+      startupUpdatePrompt: {
+        detectedAt: Date.now(),
+        lastMatchedAt: Date.now(),
+      },
+    }
+
+    currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })
+
+    await vi.waitFor(() => expect(replacementSidecar.adopt).toHaveBeenCalledWith({ terminalId: term.terminalId, generation: 1 }))
+    expect(currentSidecar.resumeCandidateCapture).toHaveBeenCalledWith('codex_input_gate_cleared')
+    expect(registry.get(term.terminalId)?.codexInputGate).toBeUndefined()
   })
 
   it('detects the Codex update prompt across split PTY chunks with terminal controls', () => {

--- a/test/unit/server/terminal-registry.codex-sidecar.test.ts
+++ b/test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -389,6 +389,60 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
     expect(pty.write).toHaveBeenLastCalledWith('1')
   })
 
+  it('allows updater input after selecting Update now from the startup prompt', () => {
+    const registry = new TerminalRegistry()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: createFakeSidecar(),
+        },
+      } as any,
+    })
+
+    const pty = mockPtyProcess.instances[0]
+    const rawInputs: Array<{ terminalId: string; data: string; at: number }> = []
+    registry.on('terminal.input.raw', (event) => {
+      rawInputs.push(event)
+    })
+    emitCodexStartupUpdatePrompt(pty)
+
+    expect(registry.input(term.terminalId, '1')).toEqual({ status: 'written' })
+    expect(pty.write).toHaveBeenLastCalledWith('1')
+    expect(registry.input(term.terminalId, 'y\r')).toEqual({ status: 'written' })
+    expect(pty.write).toHaveBeenLastCalledWith('y\r')
+    expect(registry.get(term.terminalId)?.codexUnconfirmedInputAt).toBeUndefined()
+    expect(registry.get(term.terminalId)?.codexUnconfirmedInputSource).toBeUndefined()
+    expect(rawInputs).toContainEqual(expect.objectContaining({
+      terminalId: term.terminalId,
+      data: 'y\r',
+      at: expect.any(Number),
+    }))
+  })
+
+  it('keeps the candidate capture timeout paused during update prompt and updater lifecycle', () => {
+    const registry = new TerminalRegistry()
+    const sidecar = createFakeSidecar()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar,
+        },
+      } as any,
+    })
+
+    const pty = mockPtyProcess.instances[0]
+    emitCodexStartupUpdatePrompt(pty)
+
+    expect(sidecar.pauseCandidateCapture).toHaveBeenCalledWith('codex_startup_update_prompt')
+    expect(registry.input(term.terminalId, '1')).toEqual({ status: 'written' })
+    expect(sidecar.resumeCandidateCapture).not.toHaveBeenCalled()
+    expect(registry.input(term.terminalId, 'y\r')).toEqual({ status: 'written' })
+  })
+
   it('resumes candidate capture when the Codex startup update choice skips until next version', () => {
     const registry = new TerminalRegistry()
     const sidecar = createFakeSidecar()

--- a/test/unit/server/terminal-registry.codex-sidecar.test.ts
+++ b/test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -645,6 +645,37 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
     expect(pty.write).toHaveBeenLastCalledWith('\r')
   })
 
+  it('keeps a detected Codex update prompt answerable after a long idle', () => {
+    const now = new Date('2026-06-29T12:00:00.000Z').getTime()
+    const dateNow = vi.spyOn(Date, 'now')
+    try {
+      dateNow.mockReturnValue(now)
+      const sidecar = createFakeSidecar()
+      const registry = new TerminalRegistry()
+      const term = registry.create({
+        mode: 'codex',
+        providerSettings: {
+          codexAppServer: {
+            wsUrl: 'ws://127.0.0.1:43123',
+            sidecar,
+          },
+        } as any,
+      })
+
+      const pty = mockPtyProcess.instances[0]
+      emitCodexStartupUpdatePrompt(pty)
+      sidecar.resumeCandidateCapture.mockClear()
+
+      dateNow.mockReturnValue(now + (20 * 60 * 1000))
+      expect(registry.input(term.terminalId, '3')).toEqual({ status: 'written' })
+
+      expect(pty.write).toHaveBeenLastCalledWith('3')
+      expect(sidecar.resumeCandidateCapture).toHaveBeenCalledWith('codex_startup_update_skipped')
+    } finally {
+      dateNow.mockRestore()
+    }
+  })
+
   it('updates startup prompt state before any client-visible output can trigger reentrant input', () => {
     const registry = new TerminalRegistry()
     const term = registry.create({

--- a/test/unit/server/terminal-registry.codex-sidecar.test.ts
+++ b/test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -92,6 +92,8 @@ function createFakeSidecar(options: {
     adopt: vi.fn(options.adopt ?? (async () => undefined)),
     shutdown: vi.fn(options.shutdown ?? (async () => undefined)),
     markCandidatePersisted: vi.fn(),
+    pauseCandidateCapture: vi.fn(),
+    resumeCandidateCapture: vi.fn(),
     watchPath: vi.fn(async (targetPath: string) => ({ path: targetPath })),
     unwatchPath: vi.fn(async () => undefined),
     onCandidate: vi.fn((handler: (event: any) => void) => {
@@ -289,12 +291,13 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
 
   it('allows Codex update prompt menu replies without the optional update banner', () => {
     const registry = new TerminalRegistry()
+    const sidecar = createFakeSidecar()
     const term = registry.create({
       mode: 'codex',
       providerSettings: {
         codexAppServer: {
           wsUrl: 'ws://127.0.0.1:43123',
-          sidecar: createFakeSidecar(),
+          sidecar,
         },
       } as any,
     })
@@ -310,12 +313,70 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
       'Press enter to continue\r\n',
     ].join(''))
 
+    expect(sidecar.pauseCandidateCapture).toHaveBeenCalledWith('codex_startup_update_prompt')
+
     expect(registry.input(term.terminalId, '2')).toEqual({ status: 'written' })
+    expect(sidecar.resumeCandidateCapture).toHaveBeenCalledWith('codex_startup_update_skipped')
     expect(pty.write).toHaveBeenLastCalledWith('2')
     expect(registry.input(term.terminalId, 'hello\r')).toEqual({
       status: 'blocked_codex_identity_pending',
       terminalId: term.terminalId,
     })
+  })
+
+  it('pauses candidate capture once when a Codex startup update prompt is detected', () => {
+    const registry = new TerminalRegistry()
+    const sidecar = createFakeSidecar()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar,
+        },
+      } as any,
+    })
+
+    const pty = mockPtyProcess.instances[0]
+    pty._emitData([
+      'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+      '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+      '  2. Skip\r\n',
+      '  3. Skip until next version\r\n',
+      'Press enter to continue\r\n',
+    ].join(''))
+    pty._emitData('Still waiting at the same update prompt\r\n')
+
+    expect(sidecar.pauseCandidateCapture).toHaveBeenCalledTimes(1)
+    expect(sidecar.pauseCandidateCapture).toHaveBeenCalledWith('codex_startup_update_prompt')
+  })
+
+  it('does not resume candidate capture when the Codex startup update choice starts the updater', () => {
+    const registry = new TerminalRegistry()
+    const sidecar = createFakeSidecar()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar,
+        },
+      } as any,
+    })
+
+    const pty = mockPtyProcess.instances[0]
+    pty._emitData([
+      'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+      '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+      '  2. Skip\r\n',
+      '  3. Skip until next version\r\n',
+      'Press enter to continue\r\n',
+    ].join(''))
+
+    expect(registry.input(term.terminalId, '1')).toEqual({ status: 'written' })
+
+    expect(sidecar.resumeCandidateCapture).not.toHaveBeenCalled()
+    expect(pty.write).toHaveBeenLastCalledWith('1')
   })
 
   it('detects the Codex update prompt across split PTY chunks with terminal controls', () => {

--- a/test/unit/server/terminal-registry.codex-sidecar.test.ts
+++ b/test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -606,11 +606,7 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
     const record = registry.get(term.terminalId)! as any
     record.codexInputGate = {
       state: 'identity_pending',
-      createdAt: Date.now(),
-      startupUpdatePrompt: {
-        detectedAt: Date.now(),
-        lastMatchedAt: Date.now(),
-      },
+      startupUpdatePrompt: true,
     }
 
     currentSidecar.emitLifecycleLoss({ method: 'thread/closed', threadId: 'thread-1' })

--- a/test/unit/server/terminal-registry.codex-sidecar.test.ts
+++ b/test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -287,7 +287,7 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
     })
   })
 
-  it('allows Codex update prompt menu replies while restore identity is pending', () => {
+  it('allows Codex update prompt menu replies without the optional update banner', () => {
     const registry = new TerminalRegistry()
     const term = registry.create({
       mode: 'codex',
@@ -301,10 +301,9 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
 
     const pty = mockPtyProcess.instances[0]
     pty._emitData([
-      '\x1b[1mUpdate available! 0.140.0 -> 0.141.0\x1b[0m\r\n',
       'Release notes: https://github.com/openai/codex/releases/latest\r\n',
       '\r\n',
-      '> 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+      '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
       '  2. Skip\r\n',
       '  3. Skip until next version\r\n',
       '\r\n',
@@ -313,12 +312,152 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
 
     expect(registry.input(term.terminalId, '2')).toEqual({ status: 'written' })
     expect(pty.write).toHaveBeenLastCalledWith('2')
-    expect(registry.input(term.terminalId, '\r')).toEqual({ status: 'written' })
-    expect(pty.write).toHaveBeenLastCalledWith('\r')
     expect(registry.input(term.terminalId, 'hello\r')).toEqual({
       status: 'blocked_codex_identity_pending',
       terminalId: term.terminalId,
     })
+  })
+
+  it('detects the Codex update prompt across split PTY chunks with terminal controls', () => {
+    const registry = new TerminalRegistry()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: createFakeSidecar(),
+        },
+      } as any,
+    })
+
+    const pty = mockPtyProcess.instances[0]
+    pty._emitData('\x1b[1mRelease notes: https://github.com/openai/codex/releases/latest\x1b[0m\r\n')
+    pty._emitData('› 1. Update now (runs `npm install -g @openai/codex`)\r\n')
+    pty._emitData('  2. Skip\r\n')
+    pty._emitData('  3. Skip until next version\r\n')
+    pty._emitData('Press enter to continue\r\n')
+
+    expect(registry.input(term.terminalId, '\r')).toEqual({ status: 'written' })
+    expect(pty.write).toHaveBeenLastCalledWith('\r')
+  })
+
+  it('updates startup prompt state before any client-visible output can trigger reentrant input', () => {
+    const registry = new TerminalRegistry()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: createFakeSidecar(),
+        },
+      } as any,
+    })
+
+    const pty = mockPtyProcess.instances[0]
+    const client = {
+      readyState: 1,
+      send: vi.fn((payload: string) => {
+        if (payload.includes('Press enter to continue')) {
+          registry.input(term.terminalId, '2')
+        }
+      }),
+      close: vi.fn(),
+    } as any
+
+    registry.attach(term.terminalId, client)
+    pty._emitData([
+      'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+      '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+      '  2. Skip\r\n',
+      '  3. Skip until next version\r\n',
+      'Press enter to continue\r\n',
+    ].join(''))
+
+    expect(pty.write).toHaveBeenCalledWith('2')
+  })
+
+  it('does not open the Codex identity gate for similar non-prompt release text', () => {
+    const registry = new TerminalRegistry()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: createFakeSidecar(),
+        },
+      } as any,
+    })
+
+    const pty = mockPtyProcess.instances[0]
+    pty._emitData([
+      'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+      'Press enter to continue reading the changelog\r\n',
+    ].join(''))
+
+    expect(registry.input(term.terminalId, '\r')).toEqual({
+      status: 'blocked_codex_identity_pending',
+      terminalId: term.terminalId,
+    })
+  })
+
+  it('does not reuse stale update prompt output after a skip selection', () => {
+    const registry = new TerminalRegistry()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: createFakeSidecar(),
+        },
+      } as any,
+    })
+
+    const pty = mockPtyProcess.instances[0]
+    pty._emitData([
+      'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+      '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+      '  2. Skip\r\n',
+      '  3. Skip until next version\r\n',
+      'Press enter to continue\r\n',
+    ].join(''))
+
+    expect(registry.input(term.terminalId, '2')).toEqual({ status: 'written' })
+    pty._emitData('Codex starting normally now\r\n')
+
+    expect(registry.input(term.terminalId, '\r')).toEqual({
+      status: 'blocked_codex_identity_pending',
+      terminalId: term.terminalId,
+    })
+  })
+
+  it('blocks update prompt arrow navigation rather than tracking highlight state', () => {
+    const registry = new TerminalRegistry()
+    const term = registry.create({
+      mode: 'codex',
+      providerSettings: {
+        codexAppServer: {
+          wsUrl: 'ws://127.0.0.1:43123',
+          sidecar: createFakeSidecar(),
+        },
+      } as any,
+    })
+
+    const pty = mockPtyProcess.instances[0]
+    pty._emitData([
+      'Release notes: https://github.com/openai/codex/releases/latest\r\n',
+      '› 1. Update now (runs `npm install -g @openai/codex`)\r\n',
+      '  2. Skip\r\n',
+      '  3. Skip until next version\r\n',
+      'Press enter to continue\r\n',
+    ].join(''))
+
+    expect(registry.input(term.terminalId, '\x1b[B')).toEqual({
+      status: 'blocked_codex_identity_pending',
+      terminalId: term.terminalId,
+    })
+    expect(registry.input(term.terminalId, '\r')).toEqual({ status: 'written' })
+    expect(pty.write).toHaveBeenLastCalledWith('\r')
+    expect(registry.input(term.terminalId, 'y\r')).toEqual({ status: 'written' })
   })
 
   it('keeps reporting the Codex identity capture timeout after closing the failed terminal', async () => {

--- a/test/unit/server/terminal-registry.test.ts
+++ b/test/unit/server/terminal-registry.test.ts
@@ -962,7 +962,7 @@ describe('buildSpawnSpec Unix paths', () => {
       expect(spec.args.slice(-2)).toEqual(['resume', 'session-123'])
     })
 
-    it('disables Codex apps for Freshell-managed remote launches', () => {
+    it('uses managed Codex config for Freshell-managed remote launches', () => {
       delete process.env.CODEX_CMD
 
       const spec = buildSpawnSpec('codex', '/home/user/project', 'system', undefined, {
@@ -971,21 +971,24 @@ describe('buildSpawnSpec Unix paths', () => {
         },
       })
 
-      expect(spec.args.slice(0, 4)).toEqual([
+      expect(spec.args.slice(0, 6)).toEqual([
         '--remote',
         'ws://127.0.0.1:4567',
         '-c',
         'features.apps=false',
+        '-c',
+        'check_for_update_on_startup=false',
       ])
       expectCodexMcpArgs(spec.args)
     })
 
-    it('does not disable Codex apps for ordinary Codex launches', () => {
+    it('does not apply managed Codex config to ordinary Codex launches', () => {
       delete process.env.CODEX_CMD
 
       const spec = buildSpawnSpec('codex', '/home/user/project', 'system')
 
       expect(spec.args).not.toContain('features.apps=false')
+      expect(spec.args).not.toContain('check_for_update_on_startup=false')
       expect(spec.args).not.toContain('--remote')
       expectCodexMcpArgs(spec.args)
     })

--- a/test/unit/server/terminal-registry.test.ts
+++ b/test/unit/server/terminal-registry.test.ts
@@ -971,14 +971,13 @@ describe('buildSpawnSpec Unix paths', () => {
         },
       })
 
-      expect(spec.args.slice(0, 6)).toEqual([
+      expect(spec.args.slice(0, 4)).toEqual([
         '--remote',
         'ws://127.0.0.1:4567',
         '-c',
         'features.apps=false',
-        '-c',
-        'check_for_update_on_startup=false',
       ])
+      expect(spec.args).not.toContain('check_for_update_on_startup=false')
       expectCodexMcpArgs(spec.args)
     })
 


### PR DESCRIPTION
## Summary
- detect Codex startup update prompts from live PTY output while restore identity capture is pending
- allow update prompt choices and keep updater lifecycle from poisoning Codex identity tracking
- pause and rearm candidate capture around update prompts and normalize REST send-keys tokens

## Verification
- FRESHELL_TEST_SUMMARY="pre-pr codex startup update prompt landing verification" npm run check
- Fresh Eyes final review passed