### PR TITLE
Fix fresh-agent header in narrow panes

### DIFF
--- a/src/components/panes/PaneHeader.tsx
+++ b/src/components/panes/PaneHeader.tsx
@@ -79,7 +79,7 @@ export default function PaneHeader({
         e.stopPropagation()
         onRefresh()
       }}
-      className="inline-flex h-6 w-6 items-center justify-center rounded opacity-60 hover:opacity-100 transition-opacity sm:h-4 sm:w-4"
+      className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded opacity-60 hover:opacity-100 transition-opacity sm:h-4 sm:w-4"
       title="Refresh pane"
       aria-label="Refresh pane"
     >
@@ -97,7 +97,8 @@ export default function PaneHeader({
   return (
     <div
       className={cn(
-        'flex items-center gap-2 h-[2.625rem] sm:h-7 px-2 text-sm border-b border-border shrink-0',
+        'pane-header flex h-[2.625rem] shrink-0 items-center border-b border-border text-sm sm:h-7',
+        isFreshAgentPane ? 'pane-header--fresh-agent gap-1.5 px-1.5' : 'gap-2 px-2',
         needsAttention
           ? 'bg-emerald-50 border-l-2 border-l-emerald-500 dark:bg-emerald-900/30'
           : isActive ? 'bg-muted' : 'bg-muted/50 text-muted-foreground'
@@ -116,11 +117,14 @@ export default function PaneHeader({
         />
       ) : null}
 
-      <div className="min-w-0 flex flex-1 items-center gap-1.5">
+      <div className={cn(
+        'min-w-0 flex flex-1 items-center gap-1.5',
+        isFreshAgentPane && 'pane-header-fresh-agent-title',
+      )}>
         {isFreshAgentPane && !isRenaming ? (
           <span
             className={cn(
-              'shrink-0 text-sm',
+              'pane-header-fresh-agent-identity shrink-0 text-sm',
               busy && status === 'running' ? 'text-blue-500' : 'text-muted-foreground',
             )}
             title={`${content.sessionType} session`}
@@ -143,14 +147,14 @@ export default function PaneHeader({
         ) : isFreshAgentPane ? (
           <>
             {freshAgentTitleLabel ? (
-              <span className="block min-w-0 truncate" title={title}>
+              <span className="pane-header-fresh-agent-detail block min-w-0 truncate" title={title}>
                 {freshAgentTitleLabel}
               </span>
             ) : null}
             {freshAgentMetaLabel ? (
               <span
                 className={cn(
-                  'block min-w-0 truncate',
+                  'pane-header-fresh-agent-detail pane-header-fresh-agent-meta block min-w-0 truncate',
                   freshAgentTitleLabel ? 'text-muted-foreground' : undefined,
                 )}
                 title={metaTooltip || freshAgentMetaLabel}
@@ -166,7 +170,10 @@ export default function PaneHeader({
         )}
       </div>
 
-      <div className="ml-auto flex h-full items-center gap-2">
+      <div className={cn(
+        'pane-header-actions ml-auto flex h-full shrink-0 items-center',
+        isFreshAgentPane ? 'gap-1.5' : 'gap-2',
+      )}>
         {!isFreshAgentPane && metaLabel && (
           <span
             className="max-w-[18rem] truncate text-xs text-muted-foreground text-right"
@@ -193,14 +200,20 @@ export default function PaneHeader({
         {!isFreshAgentPane ? refreshButton : null}
 
         {isFreshAgentPane ? (
-          <FreshAgentSettingsButton
-            tabId={tabId}
-            paneId={paneId}
-            paneContent={content}
-          />
+          <div className="pane-header-fresh-agent-optional-action">
+            <FreshAgentSettingsButton
+              tabId={tabId}
+              paneId={paneId}
+              paneContent={content}
+            />
+          </div>
         ) : null}
 
-        {isFreshAgentPane ? refreshButton : null}
+        {isFreshAgentPane && refreshButton ? (
+          <div className="pane-header-fresh-agent-optional-action">
+            {refreshButton}
+          </div>
+        ) : null}
 
         {onToggleZoom && (
           <button
@@ -208,7 +221,10 @@ export default function PaneHeader({
               e.stopPropagation()
               onToggleZoom()
             }}
-            className="inline-flex h-6 w-6 items-center justify-center rounded opacity-60 hover:opacity-100 transition-opacity sm:h-4 sm:w-4"
+            className={cn(
+              'inline-flex h-6 w-6 shrink-0 items-center justify-center rounded opacity-60 hover:opacity-100 transition-opacity sm:h-4 sm:w-4',
+              isFreshAgentPane && 'pane-header-fresh-agent-optional-action',
+            )}
             title={isZoomed ? 'Restore pane' : 'Maximize pane'}
             aria-label={isZoomed ? 'Restore pane' : 'Maximize pane'}
           >
@@ -224,7 +240,7 @@ export default function PaneHeader({
             e.stopPropagation()
             onClose()
           }}
-          className="inline-flex h-6 w-6 items-center justify-center rounded opacity-60 hover:opacity-100 hover:bg-background/50 transition-opacity sm:h-4 sm:w-4"
+          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded opacity-60 hover:opacity-100 hover:bg-background/50 transition-opacity sm:h-4 sm:w-4"
           title="Close pane"
           aria-label="Close pane"
         >

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,71 @@ html {
   font-size: calc(100% * var(--ui-scale, 1.25));
 }
 
+.pane-header {
+  container-type: inline-size;
+  overflow: hidden;
+}
+
+.pane-header-fresh-agent-title {
+  flex: 1 1 auto;
+}
+
+.pane-header-fresh-agent-identity {
+  max-width: 8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pane-header-fresh-agent-detail {
+  flex: 1 1 auto;
+}
+
+.pane-header-fresh-agent-meta {
+  min-width: min-content;
+}
+
+@container (max-width: 280px) {
+  .pane-header--fresh-agent .pane-header-actions {
+    gap: 0.25rem;
+  }
+
+  .pane-header--fresh-agent .pane-header-fresh-agent-optional-action {
+    display: none;
+  }
+
+  .pane-header--fresh-agent .pane-header-fresh-agent-title {
+    gap: 0.35rem;
+  }
+}
+
+@container (max-width: 180px) {
+  .pane-header--fresh-agent .pane-header-fresh-agent-title {
+    gap: 0.2rem;
+  }
+
+  .pane-header--fresh-agent .pane-header-fresh-agent-identity,
+  .pane-header--fresh-agent .pane-header-fresh-agent-detail {
+    font-size: 0.68rem;
+  }
+
+  .pane-header--fresh-agent .pane-header-actions button {
+    height: 1rem;
+    width: 1rem;
+  }
+
+  .pane-header--fresh-agent .pane-header-actions svg {
+    height: 0.75rem;
+    width: 0.75rem;
+  }
+}
+
+@container (max-width: 120px) {
+  .pane-header--fresh-agent .pane-header-fresh-agent-meta {
+    display: none;
+  }
+}
+
 /* Fresh-agent panes use their real pane geometry. Transcript copy inherits the
    terminal font-size setting, while chrome, rails, buttons, and textarea layout
    keep normal responsive UI sizing on desktop and phone. */

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -129,6 +129,57 @@ test.describe('Fresh Agent', () => {
     await expect(page.getByRole('button', { name: /^Freshcodex$/i })).toBeVisible()
   })
 
+  test('fresh-agent header keeps identity visible in a narrow split pane', async ({ freshellPage, page, harness, terminal }) => {
+    await page.setViewportSize({ width: 320, height: 760 })
+    await terminal.waitForTerminal()
+
+    const tabId = await harness.getActiveTabId()
+    expect(tabId).toBeTruthy()
+    const layout = await harness.getPaneLayout(tabId!)
+    expect(layout?.type).toBe('leaf')
+    const paneId = layout.id as string
+
+    await page.evaluate(({ currentTabId, currentPaneId }) => {
+      window.__FRESHELL_TEST_HARNESS__?.setFreshAgentNetworkEffectsSuppressed('pane-narrow-freshcodex', true)
+      window.__FRESHELL_TEST_HARNESS__?.dispatch({
+        type: 'panes/splitPane',
+        payload: {
+          tabId: currentTabId,
+          paneId: currentPaneId,
+          direction: 'horizontal',
+          newPaneId: 'pane-narrow-freshcodex',
+          newContent: {
+            kind: 'fresh-agent',
+            sessionType: 'freshcodex',
+            provider: 'codex',
+            createRequestId: 'req-narrow-freshcodex',
+            sessionId: 'narrow-freshcodex-session',
+            resumeSessionId: 'narrow-freshcodex-session',
+            status: 'idle',
+            initialCwd: '/home/user/code/freshell',
+            settingsDismissed: true,
+          },
+        },
+      })
+      window.__FRESHELL_TEST_HARNESS__?.dispatch({
+        type: 'panes/resizePanes',
+        payload: {
+          tabId: currentTabId,
+          splitId: window.__FRESHELL_TEST_HARNESS__?.getState().panes.layouts[currentTabId].id,
+          sizes: [50, 50],
+        },
+      })
+    }, { currentTabId: tabId!, currentPaneId: paneId })
+
+    const freshcodexPane = page.locator('[data-context="pane"][data-pane-id="pane-narrow-freshcodex"]')
+    await expect(freshcodexPane).toBeVisible({ timeout: 10_000 })
+    const header = freshcodexPane.getByRole('banner', { name: 'Pane: freshell' })
+    await expect(header).toBeVisible()
+
+    await expect(header.getByText('freshcodex', { exact: true })).toBeVisible()
+    await expect(header.getByText('freshell', { exact: true })).toBeVisible()
+  })
+
   test('freshclaude settings use FreshAgent model defaults and create payload', async ({ freshellPage: _freshellPage, page, harness, terminal }) => {
     await terminal.waitForTerminal()
     await enableClaudeAndCodex(page)


### PR DESCRIPTION
## Summary
- keep fresh-agent identity and cwd metadata visible in narrow split pane headers
- hide optional fresh-agent header actions in cramped pane headers before they crowd out labels
- add a browser regression for a narrow split freshcodex pane

## TDD
- Red: new Playwright regression failed because the fresh-agent cwd metadata span was hidden in a 320px viewport split pane
- Green: added pane-header container rules and compact fresh-agent header styling
- Refactor: suppressed fresh-agent network effects in the regression so it only covers header layout

## Verification
- npm run test:e2e:chromium -- test/e2e-browser/specs/fresh-agent.spec.ts --grep "fresh-agent header keeps identity visible"
- npm run test:vitest -- --run test/unit/client/components/panes/PaneHeader.test.tsx test/unit/client/components/panes/PaneContainer.test.tsx
- npm run typecheck:client
- npm run lint
- npm run test:e2e:chromium -- test/e2e-browser/specs/fresh-agent.spec.ts
- FRESHELL_TEST_SUMMARY="fresh-agent narrow header identity followup" npm run check