### PR TITLE
Fix Claude generated session titles

### DIFF
--- a/docs/superpowers/plans/2026-07-04-claude-generated-session-title.md
+++ b/docs/superpowers/plans/2026-07-04-claude-generated-session-title.md
@@ -1,0 +1,744 @@
+# Claude Generated Session Title Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Claude Code session rows use Claude's generated `type:"summary"` name as the session title instead of falling back to the first user prompt.
+
+**Architecture:** Add a Claude-provider title helper for generated-name records, have the Claude parser return both the chosen title and whether it came from provider-generated metadata, and make the indexer treat provider-generated titles as authoritative over Freshell's directory and first-message fallback overrides. Keep Gemini AI titles, explicit user renames, legacy titles, and sourceless legacy overrides ahead of parsed provider-generated titles; keep lightweight indexing provider-scoped so non-Claude session formats cannot be mis-titled by Claude-only records.
+
+**Tech Stack:** TypeScript, NodeNext ESM imports with `.js` suffixes, Vitest, existing `CodingCliSessionIndexer`.
+
+## Global Constraints
+
+- Work in `.worktrees/claude-code-generated-title` on branch `fix/claude-code-generated-title`.
+- Do not restart the self-hosted Freshell server.
+- Preserve unrelated changes from other agents.
+- Keep behavior scoped to Claude Code JSONL session title extraction and title precedence.
+- Use Red-Green-Refactor TDD for behavior changes.
+- Do not skip, weaken, or delete tests.
+- Server imports must use NodeNext-compatible `.js` relative extensions.
+- End-user docs are not required; this fixes existing session naming behavior without adding UI or a visible feature.
+
+---
+
+## Load-Bearing Findings Applied
+
+- Local validation found only one `type:"summary"` sample, [test/fixtures/sessions/real-corrupted.jsonl](/home/dan/code/freshell/.worktrees/claude-code-generated-title/test/fixtures/sessions/real-corrupted.jsonl:6). The implementation supports that known Claude Code shape and the tests lock the regression; broader Claude corpus coverage remains a residual format risk.
+- Existing sourced `sessionOverrides.titleOverride` values mask parsed titles today. The fix must bypass only automatic directory/first-message fallbacks when the parsed title is provider-generated, while preserving explicit `titleSource:"user"`, `titleSource:"ai"`, `titleSource:"legacy"`, and sourceless legacy overrides.
+- The lightweight scanner is generic. Claude generated-title extraction must be passed only for Claude providers.
+- The current lightweight head loop and tail loop can stop before seeing a summary record. The fix must scan complete head lines and continue the tail scan until both newest timestamp and generated title are found, or the bounded tail is exhausted.
+- Claude-specific title logic belongs under `server/coding-cli/providers/`, not in the generic `server/title-utils.ts` module.
+
+## File Structure
+
+- Create `server/coding-cli/providers/claude-title.ts`: Claude-only helper that extracts generated display names from `type:"summary"` JSONL records.
+- Modify `server/coding-cli/types.ts`: add an internal parsed-title source marker for provider-generated titles.
+- Modify `server/coding-cli/providers/claude.ts`: return Claude generated summary titles above prompt/explicit fallback titles, use the latest summary record when multiple exist, and mark them as provider-generated.
+- Modify `server/coding-cli/session-indexer.ts`: carry parsed-title source through cache entries, let provider-generated titles beat only `dir`/`first-message` automatic overrides, scan truncated Claude files for generated titles, and provider-scope lightweight generated-title extraction.
+- Modify `test/unit/server/coding-cli/claude-provider.test.ts`: cover parser title precedence and source marking.
+- Modify `test/unit/server/coding-cli/session-indexer.test.ts`: cover source-aware override precedence, truncated full enrichment, provider-scoped lightweight indexing, and tail-loop robustness.
+
+## Task 1: Full Claude Parser Generated Title
+
+**Files:**
+- Create: `server/coding-cli/providers/claude-title.ts`
+- Modify: `server/coding-cli/types.ts`
+- Modify: `server/coding-cli/providers/claude.ts`
+- Test: `test/unit/server/coding-cli/claude-provider.test.ts`
+
+**Interfaces:**
+- Produces: `extractClaudeGeneratedTitleFromJsonlObject(obj: unknown, maxLen?: number): string | undefined`
+- Produces: `type ParsedSessionTitleSource = 'provider-generated'`
+- Consumes: existing `extractTitleFromMessage(content: string, maxLen?: number): string`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Add these tests inside `describe('parseSessionContent() - title extraction', ...)` in `test/unit/server/coding-cli/claude-provider.test.ts`:
+
+```ts
+    it('uses Claude generated summary records as the session title over the prompt fallback', () => {
+      const meta = parseSessionContent([
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'can you take a look at this?' } }),
+        JSON.stringify({ type: 'summary', summary: 'Auth Redirect Fix' }),
+      ].join('\n'))
+
+      expect(meta.title).toBe('Auth Redirect Fix')
+      expect(meta.titleSource).toBe('provider-generated')
+      expect(meta.summary).toBe('Auth Redirect Fix')
+      expect(meta.firstUserMessage).toBe('can you take a look at this?')
+    })
+
+    it('keeps Claude rename records ahead of generated summary titles', () => {
+      const meta = parseSessionContent([
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'can you take a look at this?' } }),
+        JSON.stringify({ type: 'summary', summary: 'Auth Redirect Fix' }),
+        JSON.stringify({ type: 'agent-name', agentName: 'Agent Name' }),
+        JSON.stringify({ type: 'custom-title', customTitle: 'Pinned Name' }),
+      ].join('\n'))
+
+      expect(meta.title).toBe('Pinned Name')
+      expect(meta.titleSource).toBe('provider-generated')
+      expect(meta.summary).toBe('Auth Redirect Fix')
+    })
+
+    it('uses the latest Claude generated summary record when multiple summary records exist', () => {
+      const meta = parseSessionContent([
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'can you take a look at this?' } }),
+        JSON.stringify({ type: 'summary', summary: 'Initial Investigation' }),
+        JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Done' }] } }),
+        JSON.stringify({ type: 'summary', summary: 'Auth Redirect Fix' }),
+      ].join('\n'))
+
+      expect(meta.title).toBe('Auth Redirect Fix')
+      expect(meta.titleSource).toBe('provider-generated')
+    })
+```
+
+- [ ] **Step 2: Run parser tests and verify red**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/coding-cli/claude-provider.test.ts --config config/vitest/vitest.server.config.ts
+```
+
+Expected: FAIL for `uses Claude generated summary records as the session title over the prompt fallback`, with received title `can you take a look at this?` and no `titleSource`.
+
+- [ ] **Step 3: Add the Claude title helper**
+
+Create `server/coding-cli/providers/claude-title.ts`:
+
+```ts
+import { extractTitleFromMessage } from '../../title-utils.js'
+
+export function extractClaudeGeneratedTitleFromJsonlObject(obj: unknown, maxLen = 200): string | undefined {
+  const record = obj as { type?: unknown; summary?: unknown }
+  if (record?.type !== 'summary') return undefined
+  if (typeof record.summary !== 'string' || !record.summary.trim()) return undefined
+  const title = extractTitleFromMessage(record.summary, maxLen)
+  return title || undefined
+}
+```
+
+- [ ] **Step 4: Add the parsed-title source type**
+
+In `server/coding-cli/types.ts`, add this near the other session metadata types:
+
+```ts
+export type ParsedSessionTitleSource = 'provider-generated'
+```
+
+Then add the optional field to both `ParsedSessionMeta` and the local `JsonlMeta` interface in `server/coding-cli/providers/claude.ts`:
+
+```ts
+  titleSource?: ParsedSessionTitleSource
+```
+
+- [ ] **Step 5: Use generated titles in the Claude parser**
+
+In `server/coding-cli/providers/claude.ts`:
+
+1. Add:
+
+```ts
+import { extractClaudeGeneratedTitleFromJsonlObject } from './claude-title.js'
+```
+
+2. Add `let generatedSummaryTitle: string | undefined` near the existing `let title`, `let customTitle`, and `let agentName` declarations.
+3. Inside the JSONL record loop, after custom-title/agent-name handling, add:
+
+```ts
+    const generatedTitle = extractClaudeGeneratedTitleFromJsonlObject(obj, 200)
+    if (generatedTitle) {
+      generatedSummaryTitle = generatedTitle
+    }
+```
+
+This intentionally keeps the latest generated summary title in file order so full parsing matches the lightweight tail scan when multiple summary records exist.
+
+4. Before the return object, add:
+
+```ts
+  const resolvedTitle = customTitle ?? agentName ?? generatedSummaryTitle ?? title
+  const titleSource = customTitle || agentName || generatedSummaryTitle ? 'provider-generated' : undefined
+```
+
+5. Change the returned title fields to:
+
+```ts
+    title: resolvedTitle,
+    titleSource,
+```
+
+- [ ] **Step 6: Run parser tests and verify green**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/coding-cli/claude-provider.test.ts --config config/vitest/vitest.server.config.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 1**
+
+Run:
+
+```bash
+git add server/coding-cli/providers/claude-title.ts server/coding-cli/types.ts server/coding-cli/providers/claude.ts test/unit/server/coding-cli/claude-provider.test.ts
+git commit -m "fix: use claude generated summary as session title"
+```
+
+## Task 2: Source-Aware Indexer Precedence And Truncated Files
+
+**Files:**
+- Modify: `server/coding-cli/session-indexer.ts`
+- Test: `test/unit/server/coding-cli/session-indexer.test.ts`
+
+**Interfaces:**
+- Consumes: `ParsedSessionMeta.titleSource`
+- Consumes: `extractClaudeGeneratedTitleFromJsonlObject(obj: unknown, maxLen?: number): string | undefined`
+- Produces: cached title source used only by the server-side indexer.
+
+- [ ] **Step 1: Write failing override precedence tests**
+
+Add these tests near the existing metadata-store title tests in `test/unit/server/coding-cli/session-indexer.test.ts`:
+
+```ts
+    it('lets a provider-generated parsed title beat a first-message automatic override', async () => {
+      const fileA = path.join(tempDir, 'session-provider-title.jsonl')
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a' }) + '\n')
+
+      vi.mocked(configStore.snapshot).mockResolvedValue({
+        sessionOverrides: {
+          [makeSessionKey('claude', 'session-provider-title')]: {
+            titleOverride: 'Prompt fallback title',
+            titleSource: 'first-message',
+          },
+        },
+        settings: { codingCli: { enabledProviders: ['claude'], providers: {} } },
+      })
+
+      const provider = makeProvider([fileA], {
+        parseSessionFile: async () => ({
+          cwd: '/project/a',
+          title: 'Auth Redirect Fix',
+          titleSource: 'provider-generated',
+        }),
+      })
+
+      const indexer = new CodingCliSessionIndexer([provider])
+      await indexer.refresh()
+
+      expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('Auth Redirect Fix')
+    })
+
+    it('keeps a finalized ai override ahead of a provider-generated parsed title', async () => {
+      const fileA = path.join(tempDir, 'session-ai-title.jsonl')
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a' }) + '\n')
+
+      vi.mocked(configStore.snapshot).mockResolvedValue({
+        sessionOverrides: {
+          [makeSessionKey('claude', 'session-ai-title')]: {
+            titleOverride: 'Gemini Generated Title',
+            titleSource: 'ai',
+          },
+        },
+        settings: { codingCli: { enabledProviders: ['claude'], providers: {} } },
+      })
+
+      const provider = makeProvider([fileA], {
+        parseSessionFile: async () => ({
+          cwd: '/project/a',
+          title: 'Auth Redirect Fix',
+          titleSource: 'provider-generated',
+        }),
+      })
+
+      const indexer = new CodingCliSessionIndexer([provider])
+      await indexer.refresh()
+
+      expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('Gemini Generated Title')
+    })
+
+    it('keeps an explicit user override ahead of a provider-generated parsed title', async () => {
+      const fileA = path.join(tempDir, 'session-user-title.jsonl')
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a' }) + '\n')
+
+      vi.mocked(configStore.snapshot).mockResolvedValue({
+        sessionOverrides: {
+          [makeSessionKey('claude', 'session-user-title')]: {
+            titleOverride: 'My Rename',
+            titleSource: 'user',
+          },
+        },
+        settings: { codingCli: { enabledProviders: ['claude'], providers: {} } },
+      })
+
+      const provider = makeProvider([fileA], {
+        parseSessionFile: async () => ({
+          cwd: '/project/a',
+          title: 'Auth Redirect Fix',
+          titleSource: 'provider-generated',
+        }),
+      })
+
+      const indexer = new CodingCliSessionIndexer([provider])
+      await indexer.refresh()
+
+      expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('My Rename')
+    })
+```
+
+- [ ] **Step 2: Write failing truncated-file scan test**
+
+Add this test near the same title tests:
+
+```ts
+    it('finds a Claude generated title in the middle of a truncated full-enrichment file', async () => {
+      const fileA = path.join(tempDir, 'large-claude-summary.jsonl')
+      const beforeSummary = Array.from({ length: 150 }, (_, i) =>
+        JSON.stringify({ type: 'noise', payload: `${i}:${'x'.repeat(1024)}` }),
+      )
+      const afterSummary = Array.from({ length: 180 }, (_, i) =>
+        JSON.stringify({ type: 'noise', payload: `${i}:${'y'.repeat(1024)}` }),
+      )
+      await fsp.writeFile(fileA, [
+        JSON.stringify({
+          type: 'system',
+          subtype: 'init',
+          session_id: 'large-claude-summary',
+          cwd: '/project/a',
+          timestamp: '2026-01-01T09:00:00.000Z',
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: 'Prompt fallback title' },
+          timestamp: '2026-01-01T09:01:00.000Z',
+        }),
+        ...beforeSummary,
+        JSON.stringify({ type: 'summary', summary: 'Auth Redirect Fix' }),
+        ...afterSummary,
+      ].join('\n'))
+
+      const { parseSessionContent } = await import('../../../../server/coding-cli/providers/claude')
+      const provider = makeProvider([fileA], {
+        parseSessionFile: async (content) => parseSessionContent(content),
+      })
+
+      const indexer = new CodingCliSessionIndexer([provider])
+      await indexer.refresh()
+
+      expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('Auth Redirect Fix')
+    })
+```
+
+- [ ] **Step 3: Run indexer tests and verify red**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/coding-cli/session-indexer.test.ts --config config/vitest/vitest.server.config.ts
+```
+
+Expected: FAIL for provider-generated override precedence and/or truncated summary discovery.
+
+- [ ] **Step 4: Carry title source through cached sessions**
+
+In `server/coding-cli/session-indexer.ts`:
+
+1. Import the helper and type:
+
+```ts
+import { extractClaudeGeneratedTitleFromJsonlObject } from './providers/claude-title.js'
+import type { ParsedSessionTitleSource } from './types.js'
+```
+
+2. Add `titleSource?: ParsedSessionTitleSource` to `CachedSessionEntry` and `LightweightFileMeta`.
+3. Update `resolveSessionTitle` use in `updateCacheEntry` so it also computes a matching source:
+
+```ts
+    let resolvedTitleSource: ParsedSessionTitleSource | undefined
+    if (parsedTitle) {
+      resolvedTitleSource = meta.titleSource
+    } else if (sameSession && previous?.title) {
+      resolvedTitleSource = cached?.titleSource
+    }
+```
+
+4. Store `titleSource: resolvedTitleSource` on the cache entry.
+
+- [ ] **Step 5: Make dir and first-message overrides yield to provider-generated titles**
+
+In `server/coding-cli/session-indexer.ts`, change `applyOverride` to accept the cached source:
+
+```ts
+function applyOverride(
+  session: CodingCliSession,
+  ov: SessionOverride | undefined,
+  titleSource?: ParsedSessionTitleSource,
+): CodingCliSession | null {
+  if (ov?.deleted) return null
+  const shouldApplyTitleOverride =
+    !!ov?.titleOverride &&
+    !(titleSource === 'provider-generated' && (ov.titleSource === 'dir' || ov.titleSource === 'first-message'))
+  return {
+    ...session,
+    title: shouldApplyTitleOverride ? ov?.titleOverride : session.title,
+    summary: ov?.summaryOverride || session.summary,
+    createdAt: ov?.createdAtOverride ?? session.createdAt,
+    archived: ov?.archived ?? session.archived ?? false,
+  }
+}
+```
+
+Then update the call site in `buildProjectGroups`:
+
+```ts
+      const merged = applyOverride(cached.baseSession, ov, cached.titleSource)
+```
+
+- [ ] **Step 6: Add a safe truncated-file scan for Claude generated titles**
+
+In `server/coding-cli/session-indexer.ts`, add:
+
+```ts
+async function scanFileForClaudeGeneratedTitle(filePath: string): Promise<string | undefined> {
+  try {
+    const fd = await fsp.open(filePath, 'r')
+    try {
+      const stat = await fd.stat()
+      const chunkSize = 64 * 1024
+      const buf = Buffer.alloc(chunkSize)
+      let position = 0
+      let pending = ''
+      let latestTitle: string | undefined
+      while (position < stat.size) {
+        const { bytesRead } = await fd.read(buf, 0, Math.min(chunkSize, stat.size - position), position)
+        if (bytesRead <= 0) break
+        position += bytesRead
+        pending += buf.subarray(0, bytesRead).toString('utf8')
+        const lines = pending.split(/\r?\n/)
+        pending = lines.pop() ?? ''
+        for (const line of lines) {
+          if (!line) continue
+          try {
+            const title = extractClaudeGeneratedTitleFromJsonlObject(JSON.parse(line), 200)
+            if (title) latestTitle = title
+          } catch {
+            // Skip malformed session lines.
+          }
+        }
+      }
+      if (pending) {
+        try {
+          latestTitle = extractClaudeGeneratedTitleFromJsonlObject(JSON.parse(pending), 200) ?? latestTitle
+        } catch {
+          // Skip malformed trailing line.
+        }
+      }
+      return latestTitle
+    } finally {
+      await fd.close()
+    }
+  } catch {
+    return undefined
+  }
+  return undefined
+}
+```
+
+This scan intentionally reads a truncated Claude file in 64 KiB chunks and returns the latest generated title in file order. It only runs for truncated Claude files whose normal snippet parse did not already find a provider-generated title.
+
+After `provider.parseSessionFile(snippet.content, filePath)` in `updateCacheEntry`, add:
+
+```ts
+    if (snippet.truncated && provider.name === 'claude' && meta.titleSource !== 'provider-generated') {
+      const generatedTitle = await scanFileForClaudeGeneratedTitle(filePath)
+      if (generatedTitle) {
+        meta.title = generatedTitle
+        meta.titleSource = 'provider-generated'
+      }
+    }
+```
+
+- [ ] **Step 7: Run indexer tests and verify green**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/coding-cli/session-indexer.test.ts --config config/vitest/vitest.server.config.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 2**
+
+Run:
+
+```bash
+git add server/coding-cli/session-indexer.ts test/unit/server/coding-cli/session-indexer.test.ts
+git commit -m "fix: prefer claude provider titles over automatic overrides"
+```
+
+## Task 3: Provider-Scoped Lightweight Generated Titles
+
+**Files:**
+- Modify: `server/coding-cli/session-indexer.ts`
+- Test: `test/unit/server/coding-cli/session-indexer.test.ts`
+
+**Interfaces:**
+- Consumes: `extractClaudeGeneratedTitleFromJsonlObject`
+- Preserves: existing prompt-title extraction for non-Claude providers.
+
+- [ ] **Step 1: Write failing lightweight Claude tail test**
+
+Add this test near the existing lightweight title tests in `test/unit/server/coding-cli/session-indexer.test.ts`:
+
+```ts
+  it('extracts a lightweight Claude generated summary title from the tail even when a later timestamp follows it', async () => {
+    const files: string[] = []
+    const olderSessionId = 'older-claude-summary-session'
+    const olderFile = path.join(tempDir, `${olderSessionId}.jsonl`)
+    const laterTimestamp = new Date(2026, 0, 1, 9, 3).toISOString()
+    await fsp.writeFile(olderFile, [
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: olderSessionId,
+        cwd: '/project/claude-summary',
+        timestamp: new Date(2026, 0, 1, 9).toISOString(),
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: { role: 'user', content: 'can you look at this bug?' },
+        timestamp: new Date(2026, 0, 1, 9, 1).toISOString(),
+      }),
+      'x'.repeat(5000),
+      JSON.stringify({
+        type: 'summary',
+        summary: 'Auth Redirect Fix',
+        timestamp: new Date(2026, 0, 1, 9, 2).toISOString(),
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Done' }] },
+        timestamp: laterTimestamp,
+      }),
+    ].join('\n'))
+    await fsp.utimes(olderFile, new Date(2026, 0, 1), new Date(2026, 0, 1))
+    files.push(olderFile)
+
+    for (let i = 0; i < 151; i += 1) {
+      const file = path.join(tempDir, `recent-claude-${i}.jsonl`)
+      await fsp.writeFile(file, JSON.stringify({
+        cwd: `/project/${i}`,
+        title: `Recent ${i}`,
+        timestamp: new Date(2026, 3, 5, 12, i).toISOString(),
+      }) + '\n')
+      files.push(file)
+    }
+
+    vi.mocked(configStore.snapshot).mockResolvedValue({
+      sessionOverrides: {},
+      settings: { codingCli: { enabledProviders: ['claude'], providers: {} } },
+    })
+
+    const indexer = new CodingCliSessionIndexer([makeProvider(files)], { fullScanIntervalMs: 0 })
+    await indexer.refresh()
+
+    const olderSession = indexer.getProjects()
+      .flatMap((group) => group.sessions)
+      .find((session) => session.sessionId === olderSessionId)
+
+    expect(olderSession?.title).toBe('Auth Redirect Fix')
+    expect(olderSession?.lastActivityAt).toBe(Date.parse(laterTimestamp))
+  })
+```
+
+- [ ] **Step 2: Write failing non-Claude guard test**
+
+Add this test near the same lightweight title tests:
+
+```ts
+  it('does not use Claude summary records as lightweight generated titles for non-Claude providers', async () => {
+    const files: string[] = []
+    const olderSessionId = 'older-codex-summary-shaped-session'
+    const olderFile = path.join(tempDir, `${olderSessionId}.jsonl`)
+    await fsp.writeFile(olderFile, [
+      JSON.stringify({
+        sessionId: olderSessionId,
+        cwd: '/project/not-claude',
+        role: 'user',
+        content: 'Prompt fallback title',
+        timestamp: new Date(2026, 0, 1, 9).toISOString(),
+      }),
+      JSON.stringify({
+        type: 'summary',
+        summary: 'Should Not Become Title',
+        timestamp: new Date(2026, 0, 1, 9, 1).toISOString(),
+      }),
+    ].join('\n'))
+    await fsp.utimes(olderFile, new Date(2026, 0, 1), new Date(2026, 0, 1))
+    files.push(olderFile)
+
+    for (let i = 0; i < 151; i += 1) {
+      const file = path.join(tempDir, `recent-codex-${i}.jsonl`)
+      await fsp.writeFile(file, JSON.stringify({
+        cwd: `/project/${i}`,
+        title: `Recent ${i}`,
+        timestamp: new Date(2026, 3, 5, 12, i).toISOString(),
+      }) + '\n')
+      files.push(file)
+    }
+
+    vi.mocked(configStore.snapshot).mockResolvedValue({
+      sessionOverrides: {},
+      settings: { codingCli: { enabledProviders: ['codex'], providers: {} } },
+    })
+
+    const provider = makeProvider(files, { name: 'codex' })
+    const indexer = new CodingCliSessionIndexer([provider], { fullScanIntervalMs: 0 })
+    await indexer.refresh()
+
+    const olderSession = indexer.getProjects()
+      .flatMap((group) => group.sessions)
+      .find((session) => session.sessionId === olderSessionId)
+
+    expect(olderSession?.title).toBe('Prompt fallback title')
+  })
+```
+
+- [ ] **Step 3: Run indexer tests and verify red**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/coding-cli/session-indexer.test.ts --config config/vitest/vitest.server.config.ts
+```
+
+Expected: FAIL for the Claude lightweight summary test.
+
+- [ ] **Step 4: Provider-scope generated title extraction in lightweight metadata**
+
+In `server/coding-cli/session-indexer.ts`:
+
+1. Change `readLightweightMeta` to accept an optional extractor:
+
+```ts
+async function readLightweightMeta(
+  filePath: string,
+  options: { generatedTitleExtractor?: (obj: unknown, maxLen?: number) => string | undefined } = {},
+): Promise<LightweightFileMeta> {
+```
+
+2. Add `let generatedTitle: string | undefined` beside the existing `let title`.
+3. In the head loop, after parsing `obj`, add:
+
+```ts
+        if (!generatedTitle) {
+          generatedTitle = options.generatedTitleExtractor?.(obj, 200)
+        }
+```
+
+4. Remove the `if (sessionId && cwd && title && createdAt) break` early exit, because complete head lines are bounded to 4KB.
+5. In the tail loop, keep scanning until both `lastActivityAt` and `generatedTitle` are known:
+
+```ts
+            if (!generatedTitle) {
+              generatedTitle = options.generatedTitleExtractor?.(obj, 200)
+            }
+            if (!lastActivityAt && obj?.timestamp) {
+              const parsed = typeof obj.timestamp === 'number' ? obj.timestamp : Date.parse(obj.timestamp)
+              if (Number.isFinite(parsed)) lastActivityAt = parsed
+            }
+            if (lastActivityAt && generatedTitle) break
+```
+
+6. Return the generated title and source when present:
+
+```ts
+      return {
+        filePath,
+        mtimeMs,
+        size,
+        sessionId,
+        cwd,
+        title: generatedTitle ?? title,
+        titleSource: generatedTitle ? 'provider-generated' : undefined,
+        createdAt,
+        lastActivityAt,
+      }
+```
+
+7. In `lightweightScan`, call `readLightweightMeta` with the Claude extractor only for Claude:
+
+```ts
+        readLightweightMeta(filePath, {
+          generatedTitleExtractor: provider.name === 'claude' ? extractClaudeGeneratedTitleFromJsonlObject : undefined,
+        }).then((meta) => ({ provider, meta })),
+```
+
+8. Store `titleSource: meta.titleSource` on each lightweight cache entry.
+
+- [ ] **Step 5: Run indexer tests and verify green**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/coding-cli/session-indexer.test.ts --config config/vitest/vitest.server.config.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run focused regression suite**
+
+Run:
+
+```bash
+npm run test:vitest -- run test/unit/server/coding-cli/claude-provider.test.ts test/unit/server/coding-cli/session-indexer.test.ts test/server/sessions-router-generate-title.test.ts --config config/vitest/vitest.server.config.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 3**
+
+Run:
+
+```bash
+git add server/coding-cli/session-indexer.ts test/unit/server/coding-cli/session-indexer.test.ts
+git commit -m "fix: index claude generated titles on cold start"
+```
+
+## Final Verification
+
+- [ ] Run:
+
+```bash
+npm run build:server
+```
+
+Expected: PASS.
+
+- [ ] Run:
+
+```bash
+npm run check
+```
+
+Expected: PASS.
+
+- [ ] Run:
+
+```bash
+npm run verify
+```
+
+Expected: PASS.
+
+## Self-Review
+
+1. Spec coverage: Task 1 fixes the full Claude parser; Task 2 fixes visible-title precedence when stored automatic overrides exist and handles truncated full-enrichment files; Task 3 fixes cold-start lightweight rows that may not be enriched immediately.
+2. No silent deferrals: The production parser and production indexer consume real JSONL session records; no fake provider path replaces production behavior. The only residual risk is the breadth of current Claude Code summary-record formats beyond the locally available fixture.
+3. Placeholder scan: No `TBD`, `TODO`, or deferred implementation remains.
+4. Type consistency: The helper signature, parsed-title source marker, cache source marker, and tests all use `provider-generated`; all runtime imports include `.js` suffixes.

--- a/server/coding-cli/providers/claude-title.ts
+++ b/server/coding-cli/providers/claude-title.ts
@@ -1,0 +1,9 @@
+import { extractTitleFromMessage } from '../../title-utils.js'
+
+export function extractClaudeGeneratedTitleFromJsonlObject(obj: unknown, maxLen = 200): string | undefined {
+  const record = obj as { type?: unknown; summary?: unknown }
+  if (record?.type !== 'summary') return undefined
+  if (typeof record.summary !== 'string' || !record.summary.trim()) return undefined
+  const title = extractTitleFromMessage(record.summary, maxLen)
+  return title || undefined
+}

--- a/server/coding-cli/providers/claude.ts
+++ b/server/coding-cli/providers/claude.ts
@@ -5,9 +5,10 @@ import { extractTitleFromMessage } from '../../title-utils.js'
 import { isValidClaudeSessionId } from '../../claude-session-id.js'
 import { getClaudeHome } from '../../claude-home.js'
 import type { CodingCliProvider } from '../provider.js'
-import { normalizeFirstUserMessage, type NormalizedEvent, type ParsedSessionMeta, type TokenSummary } from '../types.js'
+import { normalizeFirstUserMessage, type NormalizedEvent, type ParsedSessionMeta, type ParsedSessionTitleSource, type TokenSummary } from '../types.js'
 import { parseClaudeEvent, isMessageEvent, isResultEvent, isToolResultContent, isToolUseContent, isTextContent } from '../../claude-stream-types.js'
 import { looksLikePath, extractUserAuthoredText, resolveGitRepoRoot } from '../utils.js'
+import { extractClaudeGeneratedTitleFromJsonlObject } from './claude-title.js'
 
 export type JsonlMeta = {
   sessionId?: string
@@ -15,6 +16,7 @@ export type JsonlMeta = {
   createdAt?: number
   lastActivityAt?: number
   title?: string
+  titleSource?: ParsedSessionTitleSource
   summary?: string
   firstUserMessage?: string
   messageCount?: number
@@ -328,6 +330,7 @@ export function parseSessionContent(content: string, options: ParseSessionOption
   let title: string | undefined
   let customTitle: string | undefined
   let agentName: string | undefined
+  let generatedSummaryTitle: string | undefined
   let summary: string | undefined
   let firstUserMessage: string | undefined
   let gitBranch: string | undefined
@@ -408,6 +411,10 @@ export function parseSessionContent(content: string, options: ParseSessionOption
     }
     if (obj?.type === 'agent-name' && typeof obj?.agentName === 'string' && obj.agentName.trim()) {
       agentName = obj.agentName.trim().slice(0, 200)
+    }
+    const generatedTitle = extractClaudeGeneratedTitleFromJsonlObject(obj, 200)
+    if (generatedTitle) {
+      generatedSummaryTitle = generatedTitle
     }
 
     if (!firstUserMessage) {
@@ -493,12 +500,16 @@ export function parseSessionContent(content: string, options: ParseSessionOption
     }
   }
 
+  const resolvedTitle = customTitle ?? agentName ?? generatedSummaryTitle ?? title
+  const titleSource = customTitle || agentName || generatedSummaryTitle ? 'provider-generated' : undefined
+
   return {
     sessionId,
     cwd,
     createdAt,
     lastActivityAt,
-    title: customTitle ?? agentName ?? title,
+    title: resolvedTitle,
+    titleSource,
     summary,
     firstUserMessage,
     messageCount: lines.length,

--- a/server/coding-cli/session-indexer.ts
+++ b/server/coding-cli/session-indexer.ts
@@ -8,8 +8,9 @@ import { getPerfConfig, startPerfTimer } from '../perf-logger.js'
 import { configStore, SessionOverride } from '../config-store.js'
 import { extractTitleFromMessage } from '../title-utils.js'
 import type { CodingCliProvider } from './provider.js'
-import { makeSessionKey, type CodingCliSession, type CodingCliProviderName, type ProjectGroup } from './types.js'
+import { makeSessionKey, type CodingCliSession, type CodingCliProviderName, type ParsedSessionTitleSource, type ProjectGroup } from './types.js'
 import { sanitizeCodexTaskEventsForTruncatedSnippet } from './providers/codex.js'
+import { extractClaudeGeneratedTitleFromJsonlObject } from './providers/claude-title.js'
 import { extractUserAuthoredText, resolveGitCheckoutRoot, resolveGitRepoRoot } from './utils.js'
 import { diffProjects } from '../sessions-sync/diff.js'
 import type { SessionMetadataStore, SessionMetadataEntry } from '../session-metadata-store.js'
@@ -114,6 +115,53 @@ export async function scanFileForUserTextMessages(filePath: string): Promise<boo
   return false
 }
 
+async function scanFileForClaudeGeneratedTitle(filePath: string): Promise<string | undefined> {
+  try {
+    const fd = await fsp.open(filePath, 'r')
+    try {
+      const stat = await fd.stat()
+      const chunkSize = 64 * 1024
+      const buf = Buffer.alloc(chunkSize)
+      let position = 0
+      let pending = ''
+      let latestTitle: string | undefined
+
+      while (position < stat.size) {
+        const { bytesRead } = await fd.read(buf, 0, Math.min(chunkSize, stat.size - position), position)
+        if (bytesRead <= 0) break
+        position += bytesRead
+        pending += buf.subarray(0, bytesRead).toString('utf8')
+        const lines = pending.split(/\r?\n/)
+        pending = lines.pop() ?? ''
+
+        for (const line of lines) {
+          if (!line) continue
+          try {
+            const title = extractClaudeGeneratedTitleFromJsonlObject(JSON.parse(line), 200)
+            if (title) latestTitle = title
+          } catch {
+            // Skip malformed session lines.
+          }
+        }
+      }
+
+      if (pending) {
+        try {
+          latestTitle = extractClaudeGeneratedTitleFromJsonlObject(JSON.parse(pending), 200) ?? latestTitle
+        } catch {
+          // Skip malformed trailing lines.
+        }
+      }
+
+      return latestTitle
+    } finally {
+      await fd.close()
+    }
+  } catch {
+    return undefined
+  }
+}
+
 function isPathWithin(basePath: string, targetPath: string): boolean {
   const relative = path.relative(basePath, targetPath)
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
@@ -153,11 +201,17 @@ export function isSubagentSession(filePath: string): boolean {
   return normalized.includes('/.claude/') || normalized.includes('\\.claude\\')
 }
 
-function applyOverride(session: CodingCliSession, ov: SessionOverride | undefined): CodingCliSession | null {
+function applyOverride(
+  session: CodingCliSession,
+  ov: SessionOverride | undefined,
+  titleSource?: ParsedSessionTitleSource,
+): CodingCliSession | null {
   if (ov?.deleted) return null
+  const shouldApplyTitleOverride = !!ov?.titleOverride
+    && !(titleSource === 'provider-generated' && (ov.titleSource === 'dir' || ov.titleSource === 'first-message'))
   return {
     ...session,
-    title: ov?.titleOverride || session.title,
+    title: shouldApplyTitleOverride ? ov.titleOverride : session.title,
     summary: ov?.summaryOverride || session.summary,
     createdAt: ov?.createdAtOverride ?? session.createdAt,
     archived: ov?.archived ?? session.archived ?? false,
@@ -221,6 +275,7 @@ type LightweightFileMeta = {
   sessionId?: string
   cwd?: string
   title?: string
+  titleSource?: ParsedSessionTitleSource
   createdAt?: number
   lastActivityAt?: number
 }
@@ -336,6 +391,7 @@ type CachedSessionEntry = {
   mtimeMs: number
   size: number
   baseSession: CodingCliSession | null
+  titleSource?: ParsedSessionTitleSource
   /** True when populated by a lightweight scan and not yet fully enriched. */
   lightweight?: boolean
 }
@@ -831,6 +887,13 @@ export class CodingCliSessionIndexer {
         tailMeta?.codexTaskEvents,
       )
     }
+    if (snippet.truncated && provider.name === 'claude' && meta.titleSource !== 'provider-generated') {
+      const generatedTitle = await scanFileForClaudeGeneratedTitle(filePath)
+      if (generatedTitle) {
+        meta.title = generatedTitle
+        meta.titleSource = 'provider-generated'
+      }
+    }
     if (!meta.cwd) {
       this.fileCache.set(cacheKey, {
         provider: provider.name,
@@ -849,6 +912,12 @@ export class CodingCliSessionIndexer {
     const storedTitle = normalizeTitle(sessionMetadata[metaKey]?.derivedTitle)
     const parsedTitle = normalizeTitle(meta.title)
     const resolvedTitle = resolveSessionTitle(parsedTitle, sameSession ? previous?.title : undefined, storedTitle)
+    let resolvedTitleSource: ParsedSessionTitleSource | undefined
+    if (parsedTitle) {
+      resolvedTitleSource = meta.titleSource
+    } else if (sameSession && previous?.title) {
+      resolvedTitleSource = cached?.titleSource
+    }
     const appendOnlyReparse = sameSession && size >= (cached?.size ?? 0)
     const createdAt = appendOnlyReparse
       ? minDefined(previous?.createdAt, meta.createdAt)
@@ -892,6 +961,7 @@ export class CodingCliSessionIndexer {
       mtimeMs,
       size,
       baseSession,
+      titleSource: resolvedTitleSource,
     })
     this.sessionKeyToFilePath.set(makeSessionKey(provider.name, sessionId), filePath)
   }
@@ -1020,7 +1090,7 @@ export class CodingCliSessionIndexer {
           }
         }
       }
-      const merged = applyOverride(cached.baseSession, ov)
+      const merged = applyOverride(cached.baseSession, ov, cached.titleSource)
       if (!merged) continue
       const metaKey = makeSessionKey(merged.provider, merged.sessionId)
       const meta = sessionMetadata[metaKey]

--- a/server/coding-cli/session-indexer.ts
+++ b/server/coding-cli/session-indexer.ts
@@ -280,11 +280,18 @@ type LightweightFileMeta = {
   lastActivityAt?: number
 }
 
+type LightweightMetaOptions = {
+  generatedTitleExtractor?: (obj: unknown) => string | undefined
+}
+
 /**
  * Read just the head and tail of a session file to extract sidebar-ready metadata.
  * Head gives sessionId, cwd, title; tail gives lastActivityAt for correct sort ordering.
  */
-async function readLightweightMeta(filePath: string): Promise<LightweightFileMeta> {
+async function readLightweightMeta(
+  filePath: string,
+  options: LightweightMetaOptions = {},
+): Promise<LightweightFileMeta> {
   try {
     const stat = await fsp.stat(filePath)
     const mtimeMs = stat.mtimeMs || stat.mtime.getTime()
@@ -309,11 +316,18 @@ async function readLightweightMeta(filePath: string): Promise<LightweightFileMet
       let sessionId: string | undefined
       let cwd: string | undefined
       let title: string | undefined
+      let titleSource: ParsedSessionTitleSource | undefined
       let createdAt: number | undefined
 
       for (const line of headLines) {
         let obj: any
         try { obj = JSON.parse(line) } catch { continue }
+
+        const generatedTitle = options.generatedTitleExtractor?.(obj)
+        if (generatedTitle) {
+          title = generatedTitle
+          titleSource = 'provider-generated'
+        }
 
         if (!sessionId) {
           sessionId = obj?.sessionId || obj?.session_id
@@ -358,26 +372,33 @@ async function readLightweightMeta(filePath: string): Promise<LightweightFileMet
             }
           }
         }
-        if (sessionId && cwd && title && createdAt) break
       }
 
       // Parse tail backwards for lastActivityAt (skip timestampless records like file-history-snapshot)
       let lastActivityAt: number | undefined
       if (tailBuf) {
         const tailLines = tailBuf.toString('utf8').split('\n').filter(Boolean)
+        let tailGeneratedTitleFound = false
         for (let i = tailLines.length - 1; i >= 0; i--) {
           try {
             const obj = JSON.parse(tailLines[i])
-            if (obj?.timestamp) {
+            const generatedTitle = options.generatedTitleExtractor?.(obj)
+            if (generatedTitle && !tailGeneratedTitleFound) {
+              title = generatedTitle
+              titleSource = 'provider-generated'
+              tailGeneratedTitleFound = true
+            }
+            if (!lastActivityAt && obj?.timestamp) {
               const parsed = typeof obj.timestamp === 'number' ? obj.timestamp : Date.parse(obj.timestamp)
-              if (Number.isFinite(parsed)) { lastActivityAt = parsed; break }
+              if (Number.isFinite(parsed)) lastActivityAt = parsed
             }
           } catch { /* skip malformed lines */ }
+          if (lastActivityAt && (!options.generatedTitleExtractor || tailGeneratedTitleFound)) break
         }
       }
       if (!lastActivityAt) lastActivityAt = createdAt
 
-      return { filePath, mtimeMs, size, sessionId, cwd, title, createdAt, lastActivityAt }
+      return { filePath, mtimeMs, size, sessionId, cwd, title, titleSource, createdAt, lastActivityAt }
     } finally {
       await fd.close()
     }
@@ -1181,7 +1202,11 @@ export class CodingCliSessionIndexer {
     for (let i = 0; i < allFiles.length; i += LIGHTWEIGHT_SCAN_CONCURRENCY) {
       const batch = allFiles.slice(i, i + LIGHTWEIGHT_SCAN_CONCURRENCY)
       const results = await Promise.all(batch.map(({ provider, filePath }) =>
-        readLightweightMeta(filePath).then((meta) => ({ provider, meta })),
+        readLightweightMeta(filePath, {
+          generatedTitleExtractor: provider.name === 'claude'
+            ? extractClaudeGeneratedTitleFromJsonlObject
+            : undefined,
+        }).then((meta) => ({ provider, meta })),
       ))
       metas.push(...results)
     }
@@ -1218,6 +1243,7 @@ export class CodingCliSessionIndexer {
         mtimeMs: meta.mtimeMs,
         size: meta.size,
         baseSession,
+        titleSource: meta.titleSource,
         lightweight: true,
       })
       this.sessionKeyToFilePath.set(makeSessionKey(provider.name, sessionId), meta.filePath)

--- a/server/coding-cli/types.ts
+++ b/server/coding-cli/types.ts
@@ -97,6 +97,8 @@ export interface TokenPayload {
   totalCost?: number             // USD
 }
 
+export type ParsedSessionTitleSource = 'provider-generated'
+
 /**
  * Session-level token aggregate used for runtime metadata.
  * `TokenPayload` above remains the live event payload shape.
@@ -137,6 +139,7 @@ export interface ParsedSessionMeta {
   createdAt?: number
   lastActivityAt?: number
   title?: string
+  titleSource?: ParsedSessionTitleSource
   summary?: string
   firstUserMessage?: string
   messageCount?: number

--- a/test/unit/server/coding-cli/claude-provider.test.ts
+++ b/test/unit/server/coding-cli/claude-provider.test.ts
@@ -693,6 +693,43 @@ describe('claude provider cross-platform tests', () => {
       const meta = parseSessionContent(content)
       expect(meta.title).toBeUndefined()
     })
+
+    it('uses Claude generated summary records as the session title over the prompt fallback', () => {
+      const meta = parseSessionContent([
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'can you take a look at this?' } }),
+        JSON.stringify({ type: 'summary', summary: 'Auth Redirect Fix' }),
+      ].join('\n'))
+
+      expect(meta.title).toBe('Auth Redirect Fix')
+      expect(meta.titleSource).toBe('provider-generated')
+      expect(meta.summary).toBe('Auth Redirect Fix')
+      expect(meta.firstUserMessage).toBe('can you take a look at this?')
+    })
+
+    it('keeps Claude rename records ahead of generated summary titles', () => {
+      const meta = parseSessionContent([
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'can you take a look at this?' } }),
+        JSON.stringify({ type: 'summary', summary: 'Auth Redirect Fix' }),
+        JSON.stringify({ type: 'agent-name', agentName: 'Agent Name' }),
+        JSON.stringify({ type: 'custom-title', customTitle: 'Pinned Name' }),
+      ].join('\n'))
+
+      expect(meta.title).toBe('Pinned Name')
+      expect(meta.titleSource).toBe('provider-generated')
+      expect(meta.summary).toBe('Auth Redirect Fix')
+    })
+
+    it('uses the latest Claude generated summary record when multiple summary records exist', () => {
+      const meta = parseSessionContent([
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'can you take a look at this?' } }),
+        JSON.stringify({ type: 'summary', summary: 'Initial Investigation' }),
+        JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Done' }] } }),
+        JSON.stringify({ type: 'summary', summary: 'Auth Redirect Fix' }),
+      ].join('\n'))
+
+      expect(meta.title).toBe('Auth Redirect Fix')
+      expect(meta.titleSource).toBe('provider-generated')
+    })
   })
 
   describe('parseSessionContent() - summary extraction', () => {

--- a/test/unit/server/coding-cli/session-indexer.test.ts
+++ b/test/unit/server/coding-cli/session-indexer.test.ts
@@ -2227,6 +2227,185 @@ describe('CodingCliSessionIndexer', () => {
     expect(olderSession?.title).toBe('Investigate sidebar visibility')
   })
 
+  it('extracts a lightweight Claude generated summary title from the tail even when a later timestamp follows it', async () => {
+    const files: string[] = []
+    for (let i = 0; i < 151; i += 1) {
+      const file = path.join(tempDir, `recent-claude-${i}.jsonl`)
+      await fsp.writeFile(file, [
+        JSON.stringify({
+          type: 'system',
+          subtype: 'init',
+          session_id: `recent-claude-${i}`,
+          cwd: `/project/${i}`,
+          timestamp: new Date(2026, 3, 5, 12, i).toISOString(),
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: `Recent Claude task ${i}` },
+          timestamp: new Date(2026, 3, 5, 12, i, 1).toISOString(),
+        }),
+      ].join('\n'))
+      files.push(file)
+    }
+
+    const olderSessionId = 'older-claude-summary'
+    const olderFile = path.join(tempDir, `${olderSessionId}.jsonl`)
+    await fsp.writeFile(olderFile, [
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: olderSessionId,
+        cwd: '/project/older-claude',
+        timestamp: new Date(2026, 0, 1, 9).toISOString(),
+      }),
+      ...Array.from({ length: 6 }, (_, i) =>
+        JSON.stringify({ type: 'noise', payload: `${i}:${'x'.repeat(1024)}` }),
+      ),
+      JSON.stringify({
+        type: 'summary',
+        summary: 'Auth Redirect Fix',
+        timestamp: new Date(2026, 0, 1, 9, 1).toISOString(),
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: 'Working' },
+        timestamp: new Date(2026, 0, 1, 9, 2).toISOString(),
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: 'Done' },
+        timestamp: new Date(2026, 0, 1, 9, 3).toISOString(),
+      }),
+    ].join('\n'))
+    files.push(olderFile)
+
+    const indexer = new CodingCliSessionIndexer([makeProvider(files)], { fullScanIntervalMs: 0 })
+    await indexer.refresh()
+
+    const olderSession = indexer.getProjects()
+      .flatMap((group) => group.sessions)
+      .find((session) => session.sessionId === olderSessionId)
+
+    expect(olderSession?.title).toBe('Auth Redirect Fix')
+    expect(olderSession?.lastActivityAt).toBe(Date.parse(new Date(2026, 0, 1, 9, 3).toISOString()))
+  })
+
+  it('keeps the newest lightweight Claude tail timestamp when no generated summary is present', async () => {
+    const files: string[] = []
+    for (let i = 0; i < 151; i += 1) {
+      const file = path.join(tempDir, `recent-claude-nosummary-${i}.jsonl`)
+      await fsp.writeFile(file, [
+        JSON.stringify({
+          type: 'system',
+          subtype: 'init',
+          session_id: `recent-claude-nosummary-${i}`,
+          cwd: `/project/${i}`,
+          timestamp: new Date(2026, 3, 5, 12, i).toISOString(),
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: `Recent Claude task ${i}` },
+          timestamp: new Date(2026, 3, 5, 12, i, 1).toISOString(),
+        }),
+      ].join('\n'))
+      files.push(file)
+    }
+
+    const olderSessionId = 'older-claude-nosummary'
+    const newestTimestamp = new Date(2026, 0, 1, 9, 3).toISOString()
+    const olderFile = path.join(tempDir, `${olderSessionId}.jsonl`)
+    await fsp.writeFile(olderFile, [
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: olderSessionId,
+        cwd: '/project/older-claude-nosummary',
+        timestamp: new Date(2026, 0, 1, 9).toISOString(),
+      }),
+      ...Array.from({ length: 6 }, (_, i) =>
+        JSON.stringify({ type: 'noise', payload: `${i}:${'x'.repeat(1024)}` }),
+      ),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: 'Working' },
+        timestamp: new Date(2026, 0, 1, 9, 1).toISOString(),
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: 'Still working' },
+        timestamp: new Date(2026, 0, 1, 9, 2).toISOString(),
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: 'Done' },
+        timestamp: newestTimestamp,
+      }),
+    ].join('\n'))
+    files.push(olderFile)
+
+    const indexer = new CodingCliSessionIndexer([makeProvider(files)], { fullScanIntervalMs: 0 })
+    await indexer.refresh()
+
+    const olderSession = indexer.getProjects()
+      .flatMap((group) => group.sessions)
+      .find((session) => session.sessionId === olderSessionId)
+
+    expect(olderSession?.title).toBeUndefined()
+    expect(olderSession?.lastActivityAt).toBe(Date.parse(newestTimestamp))
+  })
+
+  it('does not use Claude summary records as lightweight generated titles for non-Claude providers', async () => {
+    const files: string[] = []
+    const codexSessionId = 'codex-summary-record'
+    const codexFile = path.join(tempDir, `${codexSessionId}.jsonl`)
+    await fsp.writeFile(codexFile, [
+      JSON.stringify({ type: 'session_meta', payload: { id: codexSessionId, cwd: '/project/codex' } }),
+      ...Array.from({ length: 6 }, (_, i) =>
+        JSON.stringify({ type: 'noise', payload: `${i}:${'x'.repeat(1024)}` }),
+      ),
+      JSON.stringify({ type: 'summary', summary: 'Should Stay Provider Scoped' }),
+      JSON.stringify({ timestamp: new Date(2026, 0, 1, 9, 1).toISOString(), type: 'turn_context' }),
+    ].join('\n'))
+    await fsp.utimes(codexFile, new Date(2026, 0, 1), new Date(2026, 0, 1))
+    files.push(codexFile)
+
+    for (let i = 0; i < 151; i += 1) {
+      const file = path.join(tempDir, `recent-codex-scoped-${i}.jsonl`)
+      await fsp.writeFile(file, [
+        JSON.stringify({ type: 'session_meta', payload: { id: `recent-codex-scoped-${i}`, cwd: `/project/${i}` } }),
+        JSON.stringify({
+          timestamp: new Date(2026, 3, 5, 12, i).toISOString(),
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: `Recent task ${i}` }],
+          },
+        }),
+      ].join('\n'))
+      files.push(file)
+    }
+
+    vi.mocked(configStore.snapshot).mockResolvedValue({
+      sessionOverrides: {},
+      settings: { codingCli: { enabledProviders: ['codex'], providers: {} } },
+    })
+
+    const provider = makeProvider(files, {
+      name: 'codex',
+      parseSessionFile: codexProvider.parseSessionFile,
+    })
+
+    const indexer = new CodingCliSessionIndexer([provider], { fullScanIntervalMs: 0 })
+    await indexer.refresh()
+
+    const codexSession = indexer.getProjects()
+      .flatMap((group) => group.sessions)
+      .find((session) => session.sessionId === codexSessionId)
+
+    expect(codexSession?.title).toBeUndefined()
+  })
+
   it('does not synthesize a lightweight title from older system-context user records', async () => {
     const files: string[] = []
     const systemOnlyId = 'system-only'

--- a/test/unit/server/coding-cli/session-indexer.test.ts
+++ b/test/unit/server/coding-cli/session-indexer.test.ts
@@ -2001,6 +2001,127 @@ describe('CodingCliSessionIndexer', () => {
       expect(olderSession?.title).toBe('Sticky old title')
     })
 
+    it('lets a provider-generated parsed title beat a first-message automatic override', async () => {
+      const fileA = path.join(tempDir, 'session-provider-title.jsonl')
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a' }) + '\n')
+
+      vi.mocked(configStore.snapshot).mockResolvedValue({
+        sessionOverrides: {
+          [makeSessionKey('claude', 'session-provider-title')]: {
+            titleOverride: 'Prompt fallback title',
+            titleSource: 'first-message',
+          },
+        },
+        settings: { codingCli: { enabledProviders: ['claude'], providers: {} } },
+      })
+
+      const provider = makeProvider([fileA], {
+        parseSessionFile: async () => ({
+          cwd: '/project/a',
+          title: 'Auth Redirect Fix',
+          titleSource: 'provider-generated',
+        }),
+      })
+
+      const indexer = new CodingCliSessionIndexer([provider])
+      await indexer.refresh()
+
+      expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('Auth Redirect Fix')
+    })
+
+    it('keeps a finalized ai override ahead of a provider-generated parsed title', async () => {
+      const fileA = path.join(tempDir, 'session-ai-title.jsonl')
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a' }) + '\n')
+
+      vi.mocked(configStore.snapshot).mockResolvedValue({
+        sessionOverrides: {
+          [makeSessionKey('claude', 'session-ai-title')]: {
+            titleOverride: 'Gemini Generated Title',
+            titleSource: 'ai',
+          },
+        },
+        settings: { codingCli: { enabledProviders: ['claude'], providers: {} } },
+      })
+
+      const provider = makeProvider([fileA], {
+        parseSessionFile: async () => ({
+          cwd: '/project/a',
+          title: 'Auth Redirect Fix',
+          titleSource: 'provider-generated',
+        }),
+      })
+
+      const indexer = new CodingCliSessionIndexer([provider])
+      await indexer.refresh()
+
+      expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('Gemini Generated Title')
+    })
+
+    it('keeps an explicit user override ahead of a provider-generated parsed title', async () => {
+      const fileA = path.join(tempDir, 'session-user-title.jsonl')
+      await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a' }) + '\n')
+
+      vi.mocked(configStore.snapshot).mockResolvedValue({
+        sessionOverrides: {
+          [makeSessionKey('claude', 'session-user-title')]: {
+            titleOverride: 'My Rename',
+            titleSource: 'user',
+          },
+        },
+        settings: { codingCli: { enabledProviders: ['claude'], providers: {} } },
+      })
+
+      const provider = makeProvider([fileA], {
+        parseSessionFile: async () => ({
+          cwd: '/project/a',
+          title: 'Auth Redirect Fix',
+          titleSource: 'provider-generated',
+        }),
+      })
+
+      const indexer = new CodingCliSessionIndexer([provider])
+      await indexer.refresh()
+
+      expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('My Rename')
+    })
+
+    it('finds a Claude generated title in the middle of a truncated full-enrichment file', async () => {
+      const fileA = path.join(tempDir, 'large-claude-summary.jsonl')
+      const beforeSummary = Array.from({ length: 150 }, (_, i) =>
+        JSON.stringify({ type: 'noise', payload: `${i}:${'x'.repeat(1024)}` }),
+      )
+      const afterSummary = Array.from({ length: 180 }, (_, i) =>
+        JSON.stringify({ type: 'noise', payload: `${i}:${'y'.repeat(1024)}` }),
+      )
+      await fsp.writeFile(fileA, [
+        JSON.stringify({
+          type: 'system',
+          subtype: 'init',
+          session_id: 'large-claude-summary',
+          cwd: '/project/a',
+          timestamp: '2026-01-01T09:00:00.000Z',
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: 'Prompt fallback title' },
+          timestamp: '2026-01-01T09:01:00.000Z',
+        }),
+        ...beforeSummary,
+        JSON.stringify({ type: 'summary', summary: 'Auth Redirect Fix' }),
+        ...afterSummary,
+      ].join('\n'))
+
+      const { parseSessionContent } = await import('../../../../server/coding-cli/providers/claude')
+      const provider = makeProvider([fileA], {
+        parseSessionFile: async (content) => parseSessionContent(content),
+      })
+
+      const indexer = new CodingCliSessionIndexer([provider])
+      await indexer.refresh()
+
+      expect(indexer.getProjects()[0]?.sessions[0]?.title).toBe('Auth Redirect Fix')
+    })
+
     it('persists a newly parsed non-empty title to the metadata store', async () => {
       const fileA = path.join(tempDir, 'session-b.jsonl')
       await fsp.writeFile(fileA, JSON.stringify({ cwd: '/project/a', title: 'Fresh title' }) + '\n')


### PR DESCRIPTION
## Summary
- Parse Claude Code JSONL summary records as provider-generated session titles
- Preserve user/AI/manual title overrides while letting provider titles beat fallback titles
- Add cold-start and truncated-file indexing coverage for generated titles

## Verification
- npm run build:server
- npm run check
- npm run verify