### PR TITLE
fix(build): emit full server dist in worktrees (per-worktree tsBuildInfoFile)

### DIFF
--- a/test/unit/server/tsconfig-server-buildinfo.test.ts
+++ b/test/unit/server/tsconfig-server-buildinfo.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Regression guard for the server incremental-build cache location.
+ *
+ * Worktrees symlink `node_modules` to the primary checkout. If
+ * `tsBuildInfoFile` lives under `node_modules/.cache`, tsc's incremental
+ * state is SHARED across every worktree, so `npm run build:server` in a fresh
+ * worktree (empty `dist/`) reads the primary checkout's "already emitted"
+ * state and skips emitting — producing a partial `dist/` (e.g. a missing
+ * `opencode-listing-runner.js`). The compiled-worker integration tests then
+ * fail, but ONLY inside a worktree — CI's fresh checkout never catches it.
+ *
+ * Keeping the buildinfo inside the per-worktree `outDir` ties the incremental
+ * cache lifetime to the output: an empty `dist/` means no buildinfo, which
+ * forces a full emit. This unit test runs in CI and fails fast if the cache
+ * is ever moved back into shared `node_modules`.
+ */
+describe('tsconfig.server incremental build cache', () => {
+  const tsconfig = JSON.parse(
+    readFileSync(path.join(process.cwd(), 'tsconfig.server.json'), 'utf8'),
+  ) as { compilerOptions?: { tsBuildInfoFile?: string; outDir?: string } }
+  const compilerOptions = tsconfig.compilerOptions ?? {}
+  const buildInfoFile = String(compilerOptions.tsBuildInfoFile ?? '')
+  const outDir = String(compilerOptions.outDir ?? './dist')
+
+  it('does not store tsBuildInfoFile under the symlink-shared node_modules', () => {
+    expect(buildInfoFile).not.toBe('')
+    expect(buildInfoFile).not.toMatch(/(^|[\\/])node_modules([\\/]|$)/)
+  })
+
+  it('co-locates tsBuildInfoFile inside the per-worktree outDir', () => {
+    const normalize = (p: string) => p.replace(/^\.\//, '').replace(/\/+$/, '')
+    const info = normalize(buildInfoFile)
+    const out = normalize(outDir)
+    expect(info === out || info.startsWith(`${out}/`)).toBe(true)
+  })
+})

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "incremental": true,
-    "tsBuildInfoFile": "./node_modules/.cache/tsconfig.server.tsbuildinfo",
+    "tsBuildInfoFile": "./dist/tsconfig.server.tsbuildinfo",
     "declaration": true,
     "sourceMap": true
   },


### PR DESCRIPTION
## Summary
`tsconfig.server.json` stored `tsBuildInfoFile` under `node_modules/.cache`, which worktrees symlink to the primary checkout — so tsc's incremental state was **shared across every worktree**. A fresh worktree's `npm run build:server` (empty `dist/`) read the primary checkout's "already emitted" state and **skipped emitting**, producing a partial `dist/` missing `opencode-listing-runner.js`. The two compiled-worker integration tests (`opencode-listing-compiled-worker`, `bootstrap-env-root.compiled-start`) then failed **only inside worktrees** — CI's fresh checkout never caught it.

**Fix:** co-locate the incremental cache with its output (`./dist/tsconfig.server.tsbuildinfo`) so an empty `dist/` forces a full emit. Adds a regression guard unit test that fails if the cache ever moves back into shared `node_modules`.

## Testing
- Repro (before): fresh-worktree `build:server` emitted 67 `.js`, no worker; 2 compiled-worker tests failed.
- After: full emit (206 `.js`), worker present; both tests pass.
- Full coordinated suite green in a worktree: client 3886, server 4323 (+26 skipped), electron 347 — **0 failures**; typecheck + lint clean.

_Note: `tsconfig.client`/electron tsconfigs use the same shared-cache path but typecheck `--noEmit`, so they don't cause emit gaps; left as-is to keep this minimal._
