### PR TITLE
release: v0.7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ```bash
 # Clone the repository at the latest stable release
-git clone --branch v0.7.0 https://github.com/danshapiro/freshell.git
+git clone --branch v0.7.5 https://github.com/danshapiro/freshell.git
 cd freshell
 
 # Install dependencies

--- a/docs/index.html
+++ b/docs/index.html
@@ -1420,7 +1420,7 @@ const content = {
   welcome: [
     { typed: true, prompt: P, command: 'freshell', delay: 700 },
     { html: '' },
-    { html: '  🐚🔥 <span class="t-bold">freshell</span> <span class="t-dim">v0.7.0</span>', delay: 60 },
+    { html: '  🐚🔥 <span class="t-bold">freshell</span> <span class="t-dim">v0.7.5</span>', delay: 60 },
     { html: '  <span class="t-dim">Self-hosted browser terminal multiplexer</span>', delay: 60 },
     { html: '', delay: 200 },
     { html: '  <span class="t-success">✓</span> Multi-tab terminal management', delay: 50 },
@@ -1530,7 +1530,7 @@ const content = {
     { html: '<span class="t-dim"># Start the server</span>', delay: 100 },
     { typed: true, prompt: P, command: 'freshell --port 3000', delay: 600 },
     { html: '', delay: 400 },
-    { html: '🐚🔥 <span class="t-bold">freshell</span> <span class="t-dim">v0.7.0</span>', delay: 60 },
+    { html: '🐚🔥 <span class="t-bold">freshell</span> <span class="t-dim">v0.7.5</span>', delay: 60 },
     { html: '', delay: 200 },
     { html: '<span class="t-dim">Open your browser to connect.</span>', delay: 80 },
     { html: '<span class="t-dim">Run</span> <span class="t-cyan">freshell --help</span> <span class="t-dim">for more options.</span>', delay: 100 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freshell",
-  "version": "0.7.0",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freshell",
-      "version": "0.7.0",
+      "version": "0.7.5",
       "dependencies": {
         "@ai-sdk/google": "^3.0.29",
         "@anthropic-ai/claude-agent-sdk": "^0.2.40",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freshell",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.5",
   "type": "module",
   "bin": {
     "freshell": "dist/server/cli/index.js"


### PR DESCRIPTION
## Summary
- mark the current main candidate as v0.7.5
- update the README install tag and docs mock version text
- keep the release candidate scoped to version-facing metadata only

## Change notes
- Microsoft Amplifier support: Freshell can now launch Amplifier as a coding CLI agent, index and resume Amplifier sessions, show Amplifier activity state, use the Amplifier provider icon, and inject Freshell MCP setup when the Amplifier bundle exposes tool-mcp.
- Session visibility: provider-generated titles are preserved, stale generated-title overrides are cleaned up, Amplifier activity sidecars update session recency, and sidebar/search pagination can reach sessions beyond the first 50 matches.
- Claude titles: Claude-generated session summaries are indexed and preferred correctly without overwriting provider titles.
- Codex reliability: Codex proxy/fork handoffs and large-response handling are hardened.
- Build and repo hygiene: worktree server build output, invalid .git directory detection, and repository root layout are cleaned up.

## Verification
- FRESHELL_TEST_SUMMARY="v0.7.5 release version verify" npm run verify