### PR TITLE
fix: pin Windows release runner

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -36,11 +36,11 @@ jobs:
         run: npm run test:electron
 
       - name: Build Electron app
-        if: matrix.os != 'windows-latest'
+        if: runner.os != 'Windows'
         run: npm run electron:build
 
       - name: Upload artifacts
-        if: matrix.os != 'windows-latest'
+        if: runner.os != 'Windows'
         uses: actions/upload-artifact@v4
         with:
           name: electron-${{ matrix.os }}

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -7,8 +7,9 @@ on:
 jobs:
   release:
     strategy:
+      fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- pin Electron release Windows builds to windows-2022 so node-gyp can detect the Visual Studio toolchain
- keep the release matrix from canceling Linux/macOS when one platform fails
- keep the non-publishing Electron build workflow from producing Windows artifacts by checking runner OS instead of the old matrix label

## Why
The first v0.7.5 tag run failed on windows-latest because the runner moved to Windows Server 2025 / Visual Studio 2026, which this repo node-gyp stack does not recognize. Linux and macOS were canceled by matrix fail-fast after Windows failed.

## Verification
- FRESHELL_TEST_SUMMARY="windows release runner fix verify" npm run verify