### PR TITLE
Publish Electron installers on release tags

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -36,11 +36,9 @@ jobs:
         run: npm run test:electron
 
       - name: Build Electron app
-        if: runner.os != 'Windows'
         run: npm run electron:build
 
       - name: Upload artifacts
-        if: runner.os != 'Windows'
         uses: actions/upload-artifact@v4
         with:
           name: electron-${{ matrix.os }}

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -28,7 +28,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build and publish Electron app
+      - name: Build Electron app
         run: npm run electron:build
+
+      - name: Upload installers to GitHub Release
+        shell: bash
+        run: npx tsx scripts/upload-electron-release-assets.ts "$GITHUB_REF_NAME" release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/upload-electron-release-assets.ts
+++ b/scripts/upload-electron-release-assets.ts
@@ -1,0 +1,119 @@
+import { execFileSync } from 'child_process'
+import { existsSync, readdirSync, statSync } from 'fs'
+import path from 'path'
+
+const INSTALLER_EXTENSIONS = new Set(['.AppImage', '.deb', '.dmg', '.exe'])
+
+export interface ReleaseAssetDiscoveryOptions {
+  exists?: (filePath: string) => boolean
+  readDir?: (dirPath: string) => string[]
+  stat?: (filePath: string) => { isFile(): boolean }
+}
+
+export interface UploadElectronReleaseAssetsOptions extends ReleaseAssetDiscoveryOptions {
+  execFile?: typeof execFileSync
+  ghBin?: string
+}
+
+function log(level: 'info' | 'error', event: string, details: Record<string, unknown>): void {
+  const payload = {
+    severity: level,
+    event,
+    ...details,
+  }
+  const line = JSON.stringify(payload)
+  if (level === 'error') {
+    console.error(line)
+    return
+  }
+  console.log(line)
+}
+
+function installerExtension(fileName: string): string | undefined {
+  if (fileName.endsWith('.AppImage')) {
+    return '.AppImage'
+  }
+  const ext = path.extname(fileName)
+  return INSTALLER_EXTENSIONS.has(ext) ? ext : undefined
+}
+
+export function discoverElectronInstallerAssets(
+  releaseDir: string,
+  options: ReleaseAssetDiscoveryOptions = {},
+): string[] {
+  const exists = options.exists ?? existsSync
+  const readDir = options.readDir ?? readdirSync
+  const stat = options.stat ?? statSync
+
+  if (!exists(releaseDir)) {
+    throw new Error(`Electron release directory does not exist: ${releaseDir}`)
+  }
+
+  const assets = readDir(releaseDir)
+    .filter((entry) => installerExtension(entry))
+    .map((entry) => path.join(releaseDir, entry))
+    .filter((assetPath) => stat(assetPath).isFile())
+    .sort((a, b) => a.localeCompare(b))
+
+  if (assets.length === 0) {
+    throw new Error(`No Electron installer assets found in ${releaseDir}`)
+  }
+
+  return assets
+}
+
+export function uploadElectronReleaseAssets(
+  tagName: string,
+  releaseDir: string,
+  options: UploadElectronReleaseAssetsOptions = {},
+): string[] {
+  const execFile = options.execFile ?? execFileSync
+  const ghBin = options.ghBin ?? 'gh'
+  const assets = discoverElectronInstallerAssets(releaseDir, options)
+
+  log('info', 'electron_release_assets_uploading', {
+    tagName,
+    releaseDir,
+    assetCount: assets.length,
+    assets: assets.map((asset) => path.basename(asset)),
+  })
+
+  execFile(ghBin, ['release', 'upload', tagName, ...assets, '--clobber'], {
+    stdio: 'inherit',
+  })
+
+  log('info', 'electron_release_assets_uploaded', {
+    tagName,
+    assetCount: assets.length,
+  })
+
+  return assets
+}
+
+function isMainModule(): boolean {
+  const entryPoint = process.argv[1]
+  return Boolean(entryPoint && /upload-electron-release-assets\.(ts|js)$/.test(entryPoint))
+}
+
+if (isMainModule()) {
+  const tagName = process.argv[2] ?? process.env.GITHUB_REF_NAME
+  const releaseDir = path.resolve(process.argv[3] ?? 'release')
+
+  if (!tagName) {
+    log('error', 'electron_release_assets_missing_tag', {
+      message: 'Pass the release tag as the first argument or set GITHUB_REF_NAME.',
+    })
+    process.exit(1)
+  }
+
+  try {
+    uploadElectronReleaseAssets(tagName, releaseDir)
+  } catch (error) {
+    log('error', 'electron_release_assets_upload_failed', {
+      tagName,
+      releaseDir,
+      message: error instanceof Error ? error.message : String(error),
+    })
+    process.exit(1)
+  }
+}

--- a/test/unit/electron/release-assets.test.ts
+++ b/test/unit/electron/release-assets.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+import path from 'path'
+import {
+  discoverElectronInstallerAssets,
+  uploadElectronReleaseAssets,
+} from '../../../scripts/upload-electron-release-assets.js'
+
+const fileStat = { isFile: () => true }
+const directoryStat = { isFile: () => false }
+
+describe('Electron release asset upload', () => {
+  it('selects only installer files from the Electron release directory', () => {
+    const releaseDir = path.join('/tmp', 'freshell-release')
+
+    const assets = discoverElectronInstallerAssets(releaseDir, {
+      exists: () => true,
+      readDir: () => [
+        'Freshell Setup 0.7.5.exe',
+        'Freshell-0.7.5.dmg',
+        'Freshell-0.7.5.dmg.blockmap',
+        'Freshell-0.7.5.AppImage',
+        'freshell_0.7.5_amd64.deb',
+        'latest.yml',
+        'mac',
+      ],
+      stat: (assetPath) => path.basename(assetPath) === 'mac' ? directoryStat : fileStat,
+    })
+
+    expect(assets).toEqual([
+      path.join(releaseDir, 'Freshell Setup 0.7.5.exe'),
+      path.join(releaseDir, 'freshell_0.7.5_amd64.deb'),
+      path.join(releaseDir, 'Freshell-0.7.5.AppImage'),
+      path.join(releaseDir, 'Freshell-0.7.5.dmg'),
+    ])
+  })
+
+  it('fails fast when a build produced no installer files', () => {
+    expect(() =>
+      discoverElectronInstallerAssets('/tmp/empty-release', {
+        exists: () => true,
+        readDir: () => ['builder-effective-config.yaml', 'linux-unpacked'],
+        stat: () => fileStat,
+      }),
+    ).toThrow(/No Electron installer assets found/)
+  })
+
+  it('uploads installers with separate arguments so paths with spaces are safe', () => {
+    const execFile = vi.fn()
+    const releaseDir = path.join('/tmp', 'freshell-release')
+
+    const assets = uploadElectronReleaseAssets('v0.7.5', releaseDir, {
+      execFile: execFile as unknown as typeof import('child_process').execFileSync,
+      ghBin: 'gh',
+      exists: () => true,
+      readDir: () => ['Freshell Setup 0.7.5.exe', 'Freshell-0.7.5.dmg'],
+      stat: () => fileStat,
+    })
+
+    expect(assets).toEqual([
+      path.join(releaseDir, 'Freshell Setup 0.7.5.exe'),
+      path.join(releaseDir, 'Freshell-0.7.5.dmg'),
+    ])
+    expect(execFile).toHaveBeenCalledWith(
+      'gh',
+      [
+        'release',
+        'upload',
+        'v0.7.5',
+        path.join(releaseDir, 'Freshell Setup 0.7.5.exe'),
+        path.join(releaseDir, 'Freshell-0.7.5.dmg'),
+        '--clobber',
+      ],
+      { stdio: 'inherit' },
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Upload built Electron installer files to the GitHub Release after each tag build
- Include Windows in the Electron artifact workflow instead of skipping the installer build/upload
- Add a tested helper so installer paths with spaces are uploaded safely

## Verification

- npm run test:vitest -- --config config/vitest/vitest.electron.config.ts test/unit/electron/release-assets.test.ts --run
- npm run test:electron
- FRESHELL_TEST_SUMMARY="electron release installer assets verify" npm run verify
