### PR TITLE
Build Intel macOS Electron installers

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-2022]
+        os: [macos-13, macos-latest, ubuntu-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-2022]
+        os: [macos-13, macos-latest, ubuntu-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Add `macos-13` to the Electron release/build matrices so the RC publishes an Intel macOS DMG in addition to the Apple Silicon DMG

## Verification

- FRESHELL_TEST_SUMMARY="macos x64 electron installer matrix verify" npm run verify
