### PR TITLE
Fix Intel macOS Electron release runner

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest, ubuntu-latest, windows-2022]
+        os: [macos-15-intel, macos-latest, ubuntu-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest, ubuntu-latest, windows-2022]
+        os: [macos-15-intel, macos-latest, ubuntu-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- switch Electron build and release workflows from the retired Intel macOS runner label to `macos-15-intel`
- keep both macOS installer targets: Intel plus Apple Silicon

## Verification
- `FRESHELL_TEST_SUMMARY="macos intel runner label verify" npm run verify`
  - client: 357 files / 3886 tests passed
  - server: 282 files / 4333 tests passed / 16 skipped
  - electron: 34 files / 350 tests passed