### PR TITLE
fix: floor fractional epoch-ms timestamps at server boundaries

### DIFF
--- a/server/coding-cli/providers/amplifier.ts
+++ b/server/coding-cli/providers/amplifier.ts
@@ -3,7 +3,7 @@ import os from 'os'
 import fsp from 'fs/promises'
 import type { CodingCliProvider } from '../provider.js'
 import { normalizeFirstUserMessage, type NormalizedEvent, type ParsedSessionMeta } from '../types.js'
-import { resolveGitRepoRoot } from '../utils.js'
+import { resolveGitRepoRoot, statMtimeMs } from '../utils.js'
 
 // Amplifier transcripts can grow to tens of MB. For the sidebar's first-user-message
 // preview we only ever read a bounded prefix of the sibling transcript, never the whole file.
@@ -14,7 +14,8 @@ export function defaultAmplifierHome(): string {
 }
 
 function parseTimestampMs(value: unknown): number | undefined {
-  if (typeof value === 'number' && Number.isFinite(value)) return value
+  // Floor numeric passthroughs: downstream read-model schemas require integer epoch-ms.
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.floor(value)
   if (typeof value === 'string' && value.trim()) {
     const parsed = Date.parse(value)
     if (Number.isFinite(parsed)) return parsed
@@ -190,7 +191,7 @@ export const amplifierProvider: CodingCliProvider = {
       sidecars.map(async (name) => {
         try {
           const stat = await fsp.stat(path.join(dir, name))
-          return stat.mtimeMs || stat.mtime.getTime()
+          return statMtimeMs(stat)
         } catch {
           return undefined
         }

--- a/server/coding-cli/providers/claude.ts
+++ b/server/coding-cli/providers/claude.ts
@@ -76,7 +76,8 @@ function toFiniteNumber(value: unknown): number | undefined {
 }
 
 function parseTimestampMs(value: unknown): number | undefined {
-  if (typeof value === 'number' && Number.isFinite(value)) return value
+  // Floor numeric passthroughs: downstream read-model schemas require integer epoch-ms.
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.floor(value)
   if (typeof value === 'string' && value.trim()) {
     const parsed = Date.parse(value)
     if (Number.isFinite(parsed)) return parsed

--- a/server/coding-cli/providers/codex.ts
+++ b/server/coding-cli/providers/codex.ts
@@ -44,7 +44,8 @@ function toFiniteNumber(value: unknown): number | undefined {
 }
 
 function parseTimestampMs(value: unknown): number | undefined {
-  if (typeof value === 'number' && Number.isFinite(value)) return value
+  // Floor numeric passthroughs: downstream read-model schemas require integer epoch-ms.
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.floor(value)
   if (typeof value === 'string' && value.trim()) {
     const parsed = Date.parse(value)
     if (Number.isFinite(parsed)) return parsed

--- a/server/coding-cli/providers/opencode.ts
+++ b/server/coding-cli/providers/opencode.ts
@@ -46,7 +46,9 @@ export function defaultOpencodeDataHome(): string {
 }
 
 function toValidTimestamp(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+  // SQLite columns are dynamically typed, so time_updated/time_created can arrive
+  // as REAL. Downstream read-model schemas require integer epoch-ms, so floor.
+  return typeof value === 'number' && Number.isFinite(value) ? Math.floor(value) : undefined
 }
 
 function sleep(ms: number): Promise<void> {

--- a/server/coding-cli/session-indexer.ts
+++ b/server/coding-cli/session-indexer.ts
@@ -11,7 +11,7 @@ import type { CodingCliProvider } from './provider.js'
 import { makeSessionKey, type CodingCliSession, type CodingCliProviderName, type ParsedSessionTitleSource, type ProjectGroup } from './types.js'
 import { sanitizeCodexTaskEventsForTruncatedSnippet } from './providers/codex.js'
 import { extractClaudeGeneratedTitleFromJsonlObject } from './providers/claude-title.js'
-import { extractUserAuthoredText, resolveGitCheckoutRoot, resolveGitRepoRoot } from './utils.js'
+import { extractUserAuthoredText, resolveGitCheckoutRoot, resolveGitRepoRoot, statMtimeMs } from './utils.js'
 import { diffProjects } from '../sessions-sync/diff.js'
 import type { SessionMetadataStore, SessionMetadataEntry } from '../session-metadata-store.js'
 
@@ -295,7 +295,7 @@ async function readLightweightMeta(
 ): Promise<LightweightFileMeta> {
   try {
     const stat = await fsp.stat(filePath)
-    const mtimeMs = stat.mtimeMs || stat.mtime.getTime()
+    const mtimeMs = statMtimeMs(stat)
     const size = stat.size
     if (size === 0) return { filePath, mtimeMs, size }
 
@@ -340,7 +340,8 @@ async function readLightweightMeta(
           if (typeof c === 'string' && (c.startsWith('/') || (IS_WINDOWS && /^[a-zA-Z]:/.test(c)))) cwd = c
         }
         if (!createdAt && obj?.timestamp) {
-          const parsed = typeof obj.timestamp === 'number' ? obj.timestamp : Date.parse(obj.timestamp)
+          // Floor numeric timestamps: downstream read-model schemas require integer epoch-ms.
+          const parsed = typeof obj.timestamp === 'number' ? Math.floor(obj.timestamp) : Date.parse(obj.timestamp)
           if (Number.isFinite(parsed)) createdAt = parsed
         }
         if (!title) {
@@ -390,7 +391,8 @@ async function readLightweightMeta(
               tailGeneratedTitleFound = true
             }
             if (!lastActivityAt && obj?.timestamp) {
-              const parsed = typeof obj.timestamp === 'number' ? obj.timestamp : Date.parse(obj.timestamp)
+              // Floor numeric timestamps: downstream read-model schemas require integer epoch-ms.
+              const parsed = typeof obj.timestamp === 'number' ? Math.floor(obj.timestamp) : Date.parse(obj.timestamp)
               if (Number.isFinite(parsed)) lastActivityAt = parsed
             }
           } catch { /* skip malformed lines */ }
@@ -885,7 +887,7 @@ export class CodingCliSessionIndexer {
       return
     }
 
-    const mtimeMs = stat.mtimeMs || stat.mtime.getTime()
+    const mtimeMs = statMtimeMs(stat)
     const size = stat.size
     // Newest activity-sidecar mtime (Amplifier transcript.jsonl / events.jsonl). Statted
     // once here and reused by both the re-parse gate and the recency fold below. Only
@@ -972,7 +974,7 @@ export class CodingCliSessionIndexer {
     // Fold real file activity (newest sidecar mtime) into recency so a session that was
     // active/resumed after its metadata timestamps still rises in the recency-sorted
     // sidebar. maxDefined never regresses below the metadata-derived value.
-    lastActivityAt = maxDefined(lastActivityAt, activityMtimeMs) ?? lastActivityAt
+    lastActivityAt = Math.floor(maxDefined(lastActivityAt, activityMtimeMs) ?? 0)
 
     const checkoutRoot = meta.cwd ? await resolveGitCheckoutRoot(meta.cwd) : undefined
     const checkoutPath = checkoutRoot && checkoutRoot !== projectPath ? checkoutRoot : undefined
@@ -1316,7 +1318,7 @@ export class CodingCliSessionIndexer {
             let mtime = statCache.get(cacheKey)
             if (mtime === undefined) {
               const stat = await fsp.stat(filePath)
-              mtime = stat.mtimeMs || stat.mtime.getTime()
+              mtime = statMtimeMs(stat)
               statCache.set(cacheKey, mtime)
             }
             lastActivityAt = mtime

--- a/server/coding-cli/utils.ts
+++ b/server/coding-cli/utils.ts
@@ -115,6 +115,16 @@ export async function resolveGitBranchAndDirty(cwd: string): Promise<{ branch?: 
   }
 }
 
+/**
+ * Integer epoch-ms mtime for a stat result. On some filesystems (e.g. ext4 under
+ * WSL2), fs.Stats.mtimeMs carries sub-millisecond precision and is fractional.
+ * Downstream consumers (shared read-model schemas) require integer epoch-ms, so
+ * we always floor. Falls back to mtime.getTime() when mtimeMs is 0/falsy.
+ */
+export function statMtimeMs(stat: { mtimeMs: number; mtime: Date }): number {
+  return Math.floor(stat.mtimeMs || stat.mtime.getTime())
+}
+
 export function resolveInvocationCwd(envVars: NodeJS.ProcessEnv = process.env): string | undefined {
   const candidate = envVars.INIT_CWD || envVars.PWD
   if (candidate) return candidate

--- a/test/unit/server/coding-cli/amplifier-provider.test.ts
+++ b/test/unit/server/coding-cli/amplifier-provider.test.ts
@@ -74,6 +74,21 @@ describe('amplifier-provider', () => {
     expect(parseAmplifierMetadata('not json')).toEqual({})
   })
 
+  it('parseAmplifierMetadata floors fractional numeric timestamps to integer epoch-ms', () => {
+    // Numeric timestamps can be fractional (sub-ms precision); createdAt and
+    // lastActivityAt are validated downstream with z.number().int().
+    const meta = parseAmplifierMetadata(
+      JSON.stringify({
+        session_id: 's1',
+        working_dir: '/x',
+        created: 1783380081359.8726,
+        description_updated_at: 1783380090000.5,
+      }),
+    )
+    expect(meta.createdAt).toBe(1783380081359)
+    expect(meta.lastActivityAt).toBe(1783380090000)
+  })
+
   it('marks the provider name as an authoritative provider-generated title', () => {
     const meta = parseAmplifierMetadata(
       JSON.stringify({ session_id: 's1', working_dir: '/x', name: 'Real Provider Name' }),
@@ -191,6 +206,31 @@ describe('amplifier-provider', () => {
         expect(typeof amplifierProvider.getActivityMtimeMs).toBe('function')
         const result = await amplifierProvider.getActivityMtimeMs!(metadataPath)
         expect(result).toBe(eventsMtimeMs)
+      } finally {
+        await fsp.rm(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('returns integer epoch-ms even when the sidecar mtime has sub-ms precision', async () => {
+      const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'amplifier-activity-'))
+      try {
+        const metadataPath = path.join(dir, 'metadata.json')
+        const transcriptPath = path.join(dir, 'transcript.jsonl')
+        await fsp.writeFile(metadataPath, JSON.stringify({ session_id: 's', working_dir: '/x' }))
+        await fsp.writeFile(transcriptPath, '{"role":"user","content":"hi"}\n')
+
+        // Set a fractional mtime (sub-ms precision). Filesystems like ext4 (WSL2)
+        // preserve this, making fs.Stats.mtimeMs fractional; downstream schemas
+        // require integer epoch-ms. On coarser filesystems the fraction is dropped
+        // and the assertions still hold.
+        const fractionalSeconds = 1783380081.3598726
+        await fsp.utimes(transcriptPath, fractionalSeconds, fractionalSeconds)
+        const rawMtimeMs = (await fsp.stat(transcriptPath)).mtimeMs
+
+        const result = await amplifierProvider.getActivityMtimeMs!(metadataPath)
+        expect(result).toBeDefined()
+        expect(Number.isInteger(result)).toBe(true)
+        expect(result).toBe(Math.floor(rawMtimeMs))
       } finally {
         await fsp.rm(dir, { recursive: true, force: true })
       }

--- a/test/unit/server/coding-cli/opencode-provider.test.ts
+++ b/test/unit/server/coding-cli/opencode-provider.test.ts
@@ -211,6 +211,42 @@ describe('OpencodeProvider', () => {
     ])
   })
 
+  it('floors fractional sqlite REAL timestamps to integer epoch-ms', async () => {
+    // SQLite columns are dynamically typed: time_updated/time_created can arrive
+    // as REAL. The direct listing path never traverses the indexer's mtime fold,
+    // so the provider itself must emit integer epoch-ms.
+    const dbPath = path.join(tempDir, 'opencode.db')
+    await fsp.writeFile(dbPath, 'fake sqlite file', 'utf8')
+    FakeDatabaseSync.seed(dbPath, {
+      projects: [
+        { id: 'project-1', worktree: '/repo/root' },
+      ],
+      sessions: [
+        {
+          id: 'session-fractional',
+          project_id: 'project-1',
+          parent_id: null,
+          directory: '/repo/root',
+          title: 'Fractional timestamps',
+          time_created: 1783380081359.8726,
+          time_updated: 1783380090000.5,
+          time_archived: null,
+        },
+      ],
+    })
+
+    const provider = new OpencodeProvider(tempDir, { queryRunner: inProcessListingRunner })
+    const sessions = await provider.listSessionsDirect()
+
+    expect(sessions).toEqual([
+      expect.objectContaining({
+        sessionId: 'session-fractional',
+        createdAt: 1783380081359,
+        lastActivityAt: 1783380090000,
+      }),
+    ])
+  })
+
   it('watches OpenCode sqlite database and WAL but not SHM', () => {
     const provider = new OpencodeProvider(tempDir, { queryRunner: inProcessListingRunner })
     const dbPath = path.join(tempDir, 'opencode.db')

--- a/test/unit/server/coding-cli/session-indexer.test.ts
+++ b/test/unit/server/coding-cli/session-indexer.test.ts
@@ -668,6 +668,34 @@ describe('CodingCliSessionIndexer', () => {
       expect(session?.lastActivityAt).toBe(metadataLastActivityAt)
     })
 
+    it('floors fractional activity mtimes so lastActivityAt stays integer epoch-ms', async () => {
+      // fs.Stats.mtimeMs can be fractional (sub-ms precision on WSL2/ext4); the shared
+      // read-model schemas validate lastActivityAt with z.number().int().
+      const file = path.join(tempDir, 'session-fractional.jsonl')
+      await fsp.writeFile(file, JSON.stringify({ cwd: '/project/a', title: 'Deploy' }) + '\n')
+
+      const fractionalActivityMtimeMs = 1_783_380_081_359.8726
+
+      const provider = makeProvider([file], {
+        parseSessionFile: async () => ({
+          cwd: '/project/a',
+          sessionId: 'session-fractional',
+          title: 'Deploy',
+          createdAt: 500,
+          lastActivityAt: 1_000,
+          messageCount: 1,
+        }),
+        getActivityMtimeMs: async () => fractionalActivityMtimeMs,
+      })
+
+      const indexer = new CodingCliSessionIndexer([provider])
+      await indexer.refresh()
+
+      const session = indexer.getProjects()[0]?.sessions[0]
+      expect(session?.lastActivityAt).toBe(1_783_380_081_359)
+      expect(Number.isInteger(session?.lastActivityAt)).toBe(true)
+    })
+
     it('re-parses and advances lastActivityAt when the sidecar grows but metadata.json is byte-identical', async () => {
       const file = path.join(tempDir, 'session-resumed.jsonl')
       await fsp.writeFile(file, JSON.stringify({ cwd: '/project/a', title: 'Deploy' }) + '\n')

--- a/test/unit/server/coding-cli/utils.test.ts
+++ b/test/unit/server/coding-cli/utils.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from 'vitest'
-import { isSystemContext, extractFromIdeContext, extractUserAuthoredText } from '../../../../server/coding-cli/utils'
+import { isSystemContext, extractFromIdeContext, extractUserAuthoredText, statMtimeMs } from '../../../../server/coding-cli/utils'
+
+describe('statMtimeMs()', () => {
+  it('floors fractional mtimeMs (sub-ms precision on WSL2/ext4) to integer epoch-ms', () => {
+    expect(statMtimeMs({ mtimeMs: 1783380081359.8726, mtime: new Date(1783380081359) })).toBe(1783380081359)
+  })
+
+  it('returns integer mtimeMs unchanged', () => {
+    expect(statMtimeMs({ mtimeMs: 1700000000000, mtime: new Date(1700000000000) })).toBe(1700000000000)
+  })
+
+  it('falls back to mtime.getTime() when mtimeMs is 0/falsy', () => {
+    expect(statMtimeMs({ mtimeMs: 0, mtime: new Date(1700000000123) })).toBe(1700000000123)
+  })
+})
 
 describe('isSystemContext()', () => {
   describe('XML-wrapped context', () => {


### PR DESCRIPTION
## What changed

Floor all epoch-ms timestamps at server boundaries so `/api/session-directory` never emits fractional `lastActivityAt` (or other timestamp) values.

## The bug

The client validates `/api/session-directory` responses with `z.number().int()` on `items[].lastActivityAt`. When the server emitted a fractional value, the resulting unhandled `ZodError` rejected the whole response for affected items.

## Root cause

`fs.Stats.mtimeMs` carries sub-millisecond precision on some filesystems (e.g. ext4 under WSL2). Amplifier sidecar mtimes folded into session recency propagated that fractional value straight into `lastActivityAt`.

## Fix strategy

Floor at every timestamp source boundary rather than patching one symptom:

- New `statMtimeMs()` helper (`Math.floor(stat.mtimeMs)` with `mtime.getTime()` fallback), used at all raw stat sites in the session indexer and amplifier provider
- Floor the recency fold so no provider can emit fractional `lastActivityAt`

## Hardening from adversarial review

- opencode SQLite boundary: floor `toValidTimestamp` (REAL columns can hold fractional values)
- `createdAt` / `parseTimestampMs` numeric passthroughs (claude/codex/amplifier)
- Lightweight scan path (indexer head/tail scan)

## Verification

- Full server unit suite: 195 files / 3478 passed, 3 skipped
- `typecheck:server` clean
- Regression tests: helper unit tests, fractional sidecar mtime via `utimes`, fractional fold end-to-end, fractional SQLite row through `listSessionsDirect`, fractional metadata through `parseAmplifierMetadata`

## Breaking changes

None.