### PR TITLE
fix: keep amplifier tabs restorable

### DIFF
--- a/src/store/persistedState.ts
+++ b/src/store/persistedState.ts
@@ -19,8 +19,8 @@ export const LAYOUT_FRESH_AGENT_COMMIT_MARKER_KEY = `${LAYOUT_STORAGE_KEY}.fresh
 export const LAYOUT_FRESH_AGENT_PENDING_MARKER_KEY = `${LAYOUT_STORAGE_KEY}.fresh-agent-centralization-pending`
 export const LAYOUT_FRESH_AGENT_MIGRATION_ID = 'fresh-agent-centralization'
 
-const zTabMode = z.enum(['shell', 'claude', 'codex', 'opencode', 'gemini', 'kimi'])
-const zCodingCliProvider = z.enum(['claude', 'codex', 'opencode', 'gemini', 'kimi'])
+const zTabMode = z.string().min(1)
+const zCodingCliProvider = z.string().min(1)
 
 const zTab = z.object({
   id: z.string().min(1),

--- a/test/unit/client/store/persistedState.test.ts
+++ b/test/unit/client/store/persistedState.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 
 import {
+  parsePersistedLayoutRaw,
   parsePersistedTabsRaw,
   parsePersistedPanesRaw,
   TABS_STORAGE_KEY,
@@ -144,6 +145,84 @@ describe('persistedState parsers', () => {
       expect(parsed!.tabs.tabs[0].sessionRef).toBeUndefined()
       expect(parsed!.tabs.tabs[0].codingCliSessionId).toBeUndefined()
       expect(parsed!.tabs.tabs[0].claudeSessionId).toBeUndefined()
+    })
+
+    it('accepts Amplifier tabs and preserves their durable session identity', () => {
+      const raw = JSON.stringify({
+        version: TABS_SCHEMA_VERSION,
+        tabs: {
+          activeTabId: 'amplifier-tab',
+          tabs: [{
+            id: 'amplifier-tab',
+            title: 'Amplifier',
+            createdAt: 1,
+            mode: 'amplifier',
+            codingCliProvider: 'amplifier',
+            resumeSessionId: 'amp-session-1',
+          }],
+        },
+      })
+
+      const parsed = parsePersistedTabsRaw(raw)
+      expect(parsed).not.toBeNull()
+      expect(parsed!.tabs.tabs[0]).toEqual(expect.objectContaining({
+        id: 'amplifier-tab',
+        mode: 'amplifier',
+        codingCliProvider: 'amplifier',
+        sessionRef: { provider: 'amplifier', sessionId: 'amp-session-1' },
+      }))
+      expect(parsed!.tabs.tabs[0].resumeSessionId).toBeUndefined()
+    })
+  })
+
+  describe('parsePersistedLayoutRaw', () => {
+    it('does not reject a combined layout because one tab uses Amplifier mode', () => {
+      const raw = JSON.stringify({
+        version: 4,
+        tabs: {
+          activeTabId: 'amplifier-tab',
+          tabs: [{
+            id: 'amplifier-tab',
+            title: 'Amplifier',
+            createdAt: 1,
+            mode: 'amplifier',
+            codingCliProvider: 'amplifier',
+            sessionRef: { provider: 'amplifier', sessionId: 'amp-session-1' },
+          }],
+        },
+        panes: {
+          version: PANES_SCHEMA_VERSION,
+          layouts: {
+            'amplifier-tab': {
+              type: 'leaf',
+              id: 'amplifier-pane',
+              content: {
+                kind: 'terminal',
+                mode: 'amplifier',
+                createRequestId: 'req-amplifier',
+                status: 'running',
+                sessionRef: { provider: 'amplifier', sessionId: 'amp-session-1' },
+              },
+            },
+          },
+          activePane: { 'amplifier-tab': 'amplifier-pane' },
+          paneTitles: {},
+          paneTitleSetByUser: {},
+        },
+        tombstones: [],
+      })
+
+      const parsed = parsePersistedLayoutRaw(raw)
+      expect(parsed).not.toBeNull()
+      expect(parsed!.tabs.tabs[0]).toEqual(expect.objectContaining({
+        id: 'amplifier-tab',
+        mode: 'amplifier',
+        sessionRef: { provider: 'amplifier', sessionId: 'amp-session-1' },
+      }))
+      expect(((parsed!.panes.layouts['amplifier-tab'] as any).content)).toEqual(expect.objectContaining({
+        mode: 'amplifier',
+        sessionRef: { provider: 'amplifier', sessionId: 'amp-session-1' },
+      }))
     })
   })
 


### PR DESCRIPTION
## Summary
- Allow persisted tab mode/provider values to use the current string-based provider model instead of a stale fixed enum
- Add regression coverage for Amplifier tabs in both legacy tab payloads and combined layout payloads

## Verification
- npm run test:vitest -- run test/unit/client/store/persistedState.test.ts
- npm run test:vitest -- run test/unit/client/store/storage-migration.test.ts
- npm run check