### PR TITLE
fix(codex): child lifecycle hardening — launch-leak remediation (stages 1a+1c)

### DIFF
--- a/docs/plans/2026-07-06-codex-launch-leak-remediation-plan.md
+++ b/docs/plans/2026-07-06-codex-launch-leak-remediation-plan.md
@@ -1,330 +1,507 @@
-# Codex Launch-Leak Remediation Plan — Stage 0a/0b + 1a/1c
+# Codex Launch-Leak Remediation Plan — Stage 0a/0b + 1a/1c (v2)
 
-**Date:** 2026-07-06
+**Date:** 2026-07-06 (v2, evening)
 **Target:** freshell `main @ 02f95b70` (TypeScript/Node server)
 **Status:** Plan — not yet implemented
-**Scope:** The four near-term, no-regret items. Follow-ups (resume-TUI boot reaper "1b",
-shared-app-server architecture "Stage 2", read-only WAL monitor) are out of scope here and
-tracked separately.
+**v2 changes:** incorporates all findings from the 2026-07-06 adversarial review
+(factual fixes F1–F6, per-stage design flaws, gaps G1–G6) and the results of the
+log-dampening validation experiment run the same evening (§3). Terminology note:
+`RUST_LOG` is the log-level environment variable of the **codex binary** (OpenAI's
+CLI, which happens to be written in Rust). It is unrelated to any freshell code.
+
+**Scope:** the four near-term items (0a, 0b, 1a, 1c) plus a small observability
+line-item promoted into scope. Follow-ups — durable resume-TUI boot reaper ("1b")
+and the shared-app-server architecture ("Stage 2") — are out of scope and tracked
+separately.
 
 ---
 
-## 1. Problem
+## 1. Problem (corrected model)
 
-Codex CLI intermittently wedges on launch (blocks forever in `futex_wait_queue` while
-opening `~/.codex/logs_2.sqlite`). Root cause is a self-reinforcing loop driven by
-freshell:
+Codex CLI intermittently wedges on launch (blocks in `futex_wait_queue` while opening
+`~/.codex/logs_2.sqlite`). The mechanism, corrected per review F1 and confirmed by
+measurement:
 
-1. **Per-pane codex processes held open forever.** freshell spawns, **per pane**:
-   - one `codex app-server --listen ws://…` via `child_process.spawn(..., { detached: true })`
-     — `server/coding-cli/codex-app-server/runtime.ts:1246-1261`
+1. **Per-pane codex processes hold the log DB open around the clock.** freshell
+   spawns, **per pane**:
+   - one `codex app-server --listen ws://…` via
+     `child_process.spawn(..., { detached: true })` —
+     `server/coding-cli/codex-app-server/runtime.ts:1246-1261`
    - one `codex … resume <uuid>` node-pty — `server/terminal-registry.ts:1592-1600`
-     (recovery re-spawn at `:3694-3700`)
+     (recovery re-spawn `:3694-3700`)
 
-   With ~10 panes attached, 19+ codex processes hold `logs_2.sqlite` open continuously.
-   SQLite can only truncate its WAL when **zero** connections hold the DB, so the WAL can
-   never truncate.
+   With ~10 panes attached: ~19–21 codex processes permanently connected.
 
-2. **TRACE log firehose.** codex is spawned with no log-level env
-   (`runtime.ts:1255-1259` — no `RUST_LOG`), so it persists TRACE-level tracing
-   (dominated by inotify file-OPEN events) into that DB at ~27–56 MB/min while a
-   session is active.
+2. **Log churn, not table growth, floods the WAL.** codex persists tracing rows into
+   `logs_2.sqlite` and **bounds the table per process (~1,000 rows)** — inserts are
+   continuously matched by prune deletes. The table stays small; the **WAL traffic
+   does not**. Measured on this machine (2026-07-06): the live pane population writes
+   **~22 MB/min** of WAL churn, ~99% `TRACE` rows with `target=log` (the Rust `log`
+   facade forwarding **inotify file-event spam**).
 
-Together: the WAL grows unbounded (~5 GB over ~10 days), and a new `codex` launch then
-blocks on the SQLite lock/WAL index and never finishes init.
+3. **The WAL can never reset.** A WAL reset/truncate requires that **no read
+   transaction spans the checkpoint** (review F1: it is *not* "zero connections" —
+   idle connections alone don't pin it; the continuous overlapping read/write activity
+   across ~20 permanent connections does). Under constant churn from many holders, a
+   truncating checkpoint never gets its window; the WAL grows to a multi-GB high-water
+   mark (~5 GB observed over ~10 days).
 
-**Amplifiers (addressed by 1a/1c here; 1b later):**
-- `detached: true` children orphan to init on ungraceful server exit; teardown only runs
-  on graceful `SIGTERM`/`SIGINT` (`server/index.ts:1147-1148`).
-- On reboot the client re-creates every pane (restore-all), spawning a fresh full set on
-  top of any orphans.
-- The startup reaper covers app-servers only, and **throws** on an un-reapable record
-  (`runtime.ts:863-876` → `index.ts:1151-1154` `process.exit(1)`), which can hard-block
-  freshell's own boot — a self-inflicted "won't launch."
+4. **The wedge.** A new `codex` must open that DB; against a multi-GB WAL index and
+   ~20 active connections it blocks in `futex_wait_queue` during init → "won't
+   launch."
 
-**Out of scope / codex-internal:** even with a clean DB, `codex doctor` synchronously
-scans all ~6,000 rollout files ("Checking thread inventory…"). That lives in the codex
-binary; it is excluded from this plan's acceptance gate (upstream ask).
+**Amplifiers (0 addressed here; 1a/1c partially):**
+- `detached: true` children survive ungraceful server exit; teardown runs only on
+  graceful `SIGTERM`/`SIGINT` (`server/index.ts:1147-1148`).
+- On reboot the client re-creates every pane (restore-all) on top of any orphans.
+- The startup reaper covers app-servers only, and can **fail closed**: besides the
+  explicit throw in `assertCodexStartupReaperSucceeded` (`runtime.ts:863-876` →
+  `index.ts:1151-1154` `process.exit(1)`), three additional paths abort boot —
+  `readFile` of a record (`runtime.ts:811`), the `/proc` ownership-proof assert
+  (`:800`, per `:360-379`), and non-ENOENT `readdir` errors (`:803-806`) (review F2).
+
+**Out of scope / codex-internal (upstream asks):** even with a clean DB,
+`codex doctor` synchronously scans all ~6,000 rollout files ("Checking thread
+inventory…"). Excluded from this plan's acceptance gate. Upstream asks: bound own WAL
+(`journal_size_limit`/`wal_autocheckpoint` + periodic passive checkpoints); stop
+persisting inotify events at TRACE by default; lazy thread-inventory scan; a
+documented log-level knob.
 
 ## 2. Hard constraints (design invariants)
 
 - **I1 — Lossless.** Never delete or risk Codex sessions/long-term state
   (`~/.codex/sessions/`, goals, memories, thread graph). Cleanup = checkpoint/VACUUM
-  only, behind a verified backup. Never `rm` live data (including `-wal` files).
-- **I2 — No cap.** Unlimited simultaneous panes is the product's core value. Nothing in
-  this plan limits pane/session count.
-- **I3 — Never touch a live pane.** No teardown/reaper may signal a client-attached pane,
-  especially one with an in-flight turn. The idle reaper's `clients.size > 0` skip
-  (`terminal-registry.ts:1409-1422`) stays intact.
-- **I4 — Never fail-closed at boot.** No fix may introduce a new "won't launch" path.
+  only, behind a **consistent** backup. Never `rm` live data (including `-wal` files).
+- **I2 — No cap.** Unlimited simultaneous panes is the product's core value. Nothing
+  here limits pane/session count.
+- **I3 — Never touch a live pane** in steady-state operation. No reaper/teardown may
+  signal a client-attached pane. The idle reaper's `clients.size > 0` skip
+  (`terminal-registry.ts:1409-1422`) stays intact. **Explicit carve-out:** Stage 0b is
+  a one-time, user-acknowledged **maintenance window** that terminates all codex
+  processes, including live panes (§5). This is declared, consented downtime — not a
+  steady-state behavior.
+- **I4 — Never fail-closed at boot.** No fix may introduce (or leave) a "won't
+  launch" path.
 - **I5 — Accepted tradeoff.** Log dampening thins codex `/feedback` telemetry.
 
 ---
 
-## 3. Stage 0a — Codex spawn-env log dampening
+## 3. Stage 0-pre — Validate the dampening mechanism (BLOCKS 0a implementation)
+
+The v1 plan bet its sequencing on `RUST_LOG=error` gating codex's SQLite log sink.
+The review demanded validation first; the experiment was run 2026-07-06 evening.
+
+**Results so far (evidence, this machine, codex-cli 0.142.5):**
+
+| Test (idle TUI, 78 s, cwd=$HOME, pty) | Attributable rows written |
+|---|---|
+| Control — `RUST_LOG` unset | 1 |
+| Treatment — `RUST_LOG=error` | **1,013** (not silenced; more than control) |
+| Ambient — live pane population, no test proc | ~64k rows/min ≈ **22 MB/min** |
+
+**Conclusions:**
+1. **Plain `RUST_LOG=error` is NOT validated** — initial evidence is negative.
+2. **An idle, freshly-launched TUI is not the firehose.** The firehose is the
+   long-running pane population (insert+prune churn, `TRACE`/`target=log` inotify
+   events). Any acceptance test must use a representative long-running workload.
+3. The binary embeds a default filter string (`codex_cli=info,codex_core=info,…`) and
+   the sink schema (`feedback_log_body`, `bounded_feedback_logs`), so a filter layer
+   exists — the right directive just isn't confirmed yet.
+
+**Required protocol before 0a is implemented (no code until one candidate passes):**
+- Workload: a freshell-spawned codex pane pair (app-server + resume) left running
+  ≥15 min; attribute rows/bytes by `process_uuid`
+  (`SELECT count(*), sum(estimated_bytes) FROM logs WHERE process_uuid=… AND id>…`
+  on a `mode=ro` connection).
+- Candidates, in order:
+  1. `RUST_LOG='log=off'` (or `log=error`) — a **scoped directive** silencing the
+     `log`-facade target that carries ~99% of rows, without touching `codex_*` module
+     levels.
+  2. A codex `-c` config knob (the arg channel already exists:
+     `CODEX_MANAGED_REMOTE_CONFIG_ARGS`, `codex-managed-config.ts:1-4`); candidate
+     keys to probe: `log.level`, `tui.*` logging toggles.
+  3. If neither works: **0a is dropped**, the upstream ask is filed as the only
+     firehose fix, and this plan's protection reduces to 0b + observability + 1a/1c
+     (see §10 residual risk — recurrence to the cliff in days-to-weeks of heavy use,
+     now *detectable* instead of silent).
+- **Pass bar:** ≥90% reduction in the pane pair's attributable bytes over 15 min, and
+  the pane still functions (turn completes, rollout file written).
+
+## 4. Stage 0a — Codex spawn-env log dampening (conditional on §3)
 
 ### Change
 
-New shared helper, applied at both codex spawn paths. Sets a quiet log level **only if
-the operator hasn't set one**.
+One shared helper; the value comes from whichever candidate §3 validated.
 
 ```ts
-// server/coding-cli/codex-log-dampening.ts  (new, ~15 lines + tests)
-export const CODEX_DEFAULT_LOG_LEVEL = 'error' // single tunable
+// server/coding-cli/codex-log-dampening.ts  (new)
+export const CODEX_LOG_DIRECTIVE = 'log=off' // placeholder: whatever §3 validates
 
 export function withCodexLogDampening<T extends NodeJS.ProcessEnv>(env: T): T {
-  const userSet = env.RUST_LOG ?? process.env.RUST_LOG
-  if (userSet && userSet.trim() !== '') return env // never clobber an explicit choice
+  // Consult ONLY the env the child will actually see (review 0a-2: both call sites
+  // already spread process.env, so a separate process.env fallback is dead-or-wrong).
+  if (env.RUST_LOG !== undefined) return env // set — even '' — is an explicit choice
   if (process.env.FRESHELL_CODEX_LOG_DAMPENING === '0') return env // kill switch
-  return { ...env, RUST_LOG: CODEX_DEFAULT_LOG_LEVEL }
+  return { ...env, RUST_LOG: CODEX_LOG_DIRECTIVE }
 }
 ```
 
-Call sites:
+Call sites — **three**, not two (review G1):
 
-1. **App-server spawn** — `runtime.ts:1255-1259`: wrap the env object:
-   `env: withCodexLogDampening({ ...process.env, ...this.env, FRESHELL_CODEX_SIDECAR_ID: ownershipId })`
-2. **Resume-TUI spawn** — inside `buildSpawnSpec` (`terminal-registry.ts:~1059`), applied
-   to the returned `env` **only when the pane mode is codex**. This single site covers
-   both `pty.spawn` consumers (`:1594` primary, `:3694` recovery).
+1. **App-server spawn** — `runtime.ts:1255-1259`:
+   `env: withCodexLogDampening({ ...process.env, ...this.env, FRESHELL_CODEX_SIDECAR_ID: ownershipId })`.
+   Covers all planner-owned and fresh-agent-adapter runtimes (they flow through this
+   constructor — `index.ts:338`, `:372`).
+2. **Resume-TUI spawn** — inside `buildSpawnSpec` (`terminal-registry.ts:~1059`) on
+   the env it returns, **only when the pane mode is codex** (don't thin
+   claude/opencode telemetry). Covers both pty consumers (`:1594` primary, `:3694`
+   recovery; fed at `:1573`/`:3684`).
+3. **`CodingCliSession` spawn** — `server/coding-cli/session-manager.ts:88-92`
+   (spawns `codex exec --json …`/`codex resume …` via
+   `providers/codex.ts:479-501`), currently `env: { ...process.env }` with no
+   dampening. Apply the same helper when the provider is codex.
 
-Optional refinement (validate during acceptance): if codex honors a config-level override
-(e.g. `-c log.level="error"` alongside `CODEX_MANAGED_REMOTE_CONFIG_ARGS`,
-`runtime.ts:1248`), prefer it for the app-server path; keep `RUST_LOG` as the universal
-fallback for both paths.
+If §3 validated the `-c` knob instead of an env var, the helper becomes an args
+helper appended next to `CODEX_MANAGED_REMOTE_CONFIG_ARGS` (same three call sites;
+same guard semantics via an explicit opt-out env).
+
+### Platform note (review G3)
+
+On a native-Windows host, `buildSpawnSpec` wraps codex in `wsl.exe …`
+(`terminal-registry.ts:1127-1139`); an env var set on the Windows-side process does
+not cross into WSL without `WSLENV`. The current deployment is WSL2-native (unaffected),
+but the helper's coverage claim is platform-conditional; add `WSLENV` plumbing or
+document Windows-host as out of scope.
 
 ### Why safe
 
-- Purely additive env; no lifecycle change; no effect on pane count (I2) or boot (I4).
-- Only-if-unset guard: a developer running `RUST_LOG=debug` is never silently overridden.
-- `RUST_LOG` gates codex's tracing subsystem — the thing that fills `logs_2.sqlite`.
-  Sessions/goals/memories/thread-graph are written by normal code paths, not tracing (I1).
+- Additive env/args; no lifecycle change; no effect on pane count (I2) or boot (I4).
+- Only-if-unset guard: a developer's explicit `RUST_LOG` (any value, including empty)
+  is never overridden.
+- Dampening gates codex's tracing sink only; sessions/goals/memories/thread-graph are
+  written by normal code paths, not tracing (I1).
 
 ### Acceptance test
 
-1. Open one codex pane; sample `stat -c%s ~/.codex/logs_2.sqlite-wal` every 30 s for
-   5 min, with and without the helper. **Pass:** growth drops from ~27–56 MB/min to
-   near-zero. **If it does not drop:** codex's SQLite sink isn't gated by `RUST_LOG` —
-   record findings, file the upstream ask, and treat 0a as cosmetic (0b still buys time;
-   Stage 2 remains the structural fix).
-2. Unit test: helper is a no-op when `RUST_LOG` is preset or the kill switch is set.
-3. Launch check: codex TUI still reaches `Ready`; new rollout file still appears.
+1. Repeat the §3 protocol (representative pane pair, 15 min, per-`process_uuid`
+   attribution) with the helper active: ≥90% byte reduction vs an undampened control
+   window run the same evening (controls for ambient variation).
+2. Unit tests: helper is a no-op when `RUST_LOG` is preset (any value incl. `''`) or
+   the kill switch is set; `FRESHELL_CODEX_SIDECAR_ID` and `this.env` overrides are
+   preserved; non-codex modes in `buildSpawnSpec` are untouched (review G5).
+3. Launch check: codex TUI reaches `Ready`; a turn completes; new rollout appears.
 
 ### Rollback
 
-Set `FRESHELL_CODEX_LOG_DAMPENING=0` (no redeploy) or revert the two call sites.
+`FRESHELL_CODEX_LOG_DAMPENING=0` **plus a server restart** (env is read at spawn
+time; there is no live-toggle — review F3), or revert the three call sites.
 
 ### User-facing risk
 
-Codex `/feedback` bug reports carry sparse traces (I5, accepted). Masks — does not fix —
-whatever generates the inotify storm (upstream ask). **Severity: Low.**
+Sparse codex `/feedback` traces (I5, accepted). Masks — does not fix — the inotify
+storm generation (upstream ask). **Severity: Low.**
 
 ---
 
-## 4. Stage 0b — One-time lossless cleanup (operational runbook)
+## 5. Stage 0b — One-time lossless cleanup (maintenance-window runbook)
 
-Reclaims the current bloat (multi-hundred-MB regrowing WAL + ~2.24 GB dead pages inside
-the 6 GB `logs_2.sqlite`) without losing a single row. Run **after** 0a is deployed so
-regrowth is pre-dampened.
+**What this is (honest framing, review 0b-3):** a **declared maintenance window**
+that terminates **all codex processes, including live attached panes**. In-flight
+codex turns are lost (their transcripts up to that point are already on disk in
+rollout files). Long-term state is untouched. Get explicit operator acknowledgment
+before starting. This is the documented I3 carve-out (§2).
+
+**Preconditions (review 0b-4, 0b-5):**
+- **Run from outside freshell** — an ssh/tmux/console session that is *not* a
+  freshell pane. (Otherwise the runbook's own server is in the operator's ancestry
+  and can never be paused/stopped — the ancestry deadlock.)
+- Check for supervisors/watchdogs (`systemd`, pm2, `tsx watch`) that would restart or
+  kill a paused server; prefer **gracefully stopping** the freshell servers for the
+  window (their existing `SIGTERM` teardown reaps their codex children for you,
+  `index.ts:1078-1145`) over `SIGSTOP`. Expect the window to last **minutes** (a
+  ~6 GB VACUUM), not seconds.
 
 ### Runbook (ordered; each step gates the next)
 
-1. **Backup + baseline.** Copy `~/.codex/{logs_2,state_5,goals_1,memories_1}.sqlite*`
-   (keep `.sqlite` + `-wal` + `-shm` together) plus `history.jsonl`, `auth.json`,
-   `config.toml` to a timestamped dir on the same filesystem. Run
-   `PRAGMA integrity_check` on each copied DB (expect `ok`). Record baseline row counts
-   as the restore oracle: `sessions/` file count, `goals_1.thread_goals`,
-   `state_5.threads`, `state_5.thread_spawn_edges`, `memories_1.stage1_outputs/jobs`.
-   (A verified backup from 2026-07-06 exists at `/home/dan/codex-backup-20260706_023506`;
-   make a fresh one anyway — cheap.)
-2. **Reap codex processes only — guarded.** Build the kill set from
-   `lsof ~/.codex/logs_2.sqlite` filtered to codex cmdlines
-   (`codex-linux-x64/vendor`, `app-server`, `resume`), plus their immediate codex
-   wrappers. **Protected-PID guard:** never signal freshell prod/dev servers, amplifier,
-   or the operator shell's ancestry — abort if any protected PID lands in the set.
-   **Dry-run and print the set first.** SIGTERM, wait ~4 s, SIGKILL stragglers.
-3. **Reach 0 holders.** `lsof ~/.codex/logs_2.sqlite` must be empty. If a live freshell
-   server keeps respawning codex children into the window: briefly `SIGSTOP` **only the
-   non-ancestry respawner**, with a guaranteed `SIGCONT` in a `trap`/`finally`; re-reap;
-   proceed. (Never stop a server in the operator's own process ancestry.)
-4. **Checkpoint — never rm.** For each `~/.codex/*.sqlite` with a non-empty `-wal`
-   (do `memories_1` before trusting any "0 rows" reading):
+1. **Consistent backup + baseline (review F4/0b-1).** With writers still live, a
+   plain file copy is *not* guaranteed consistent. Use SQLite's online-consistent
+   mechanisms for the DB backups:
+   `sqlite3 ~/.codex/<db>.sqlite ".backup '<backup-dir>/<db>.sqlite'"` (or
+   `VACUUM INTO`) for each of `logs_2`, `state_5`, `goals_1`, `memories_1`; copy
+   `history.jsonl`, `auth.json`, `config.toml` normally. Verify
+   `PRAGMA integrity_check` = `ok` on every backup. Record **provisional** row counts
+   (final baselines are taken at step 4). Belt-and-braces: after step 3 (0 holders),
+   also take plain file copies (`.sqlite` + `-wal` + `-shm` together) — these are the
+   byte-identical restore set.
+2. **Announce + stop freshell servers (prod and dev — both hold the DB).** Graceful
+   `SIGTERM`; their teardown reaps their codex children. Then **reap stragglers**:
+   kill set from `lsof ~/.codex/logs_2.sqlite` filtered to codex cmdlines; dry-run
+   and print first; protected-PID guard (never the operator's own session ancestry);
+   **SIGTERM first, grace ≥10 s** (codex flushes rollout `.jsonl` appends on TERM —
+   review 0b-3), then SIGKILL survivors.
+3. **Reach 0 holders.** `lsof ~/.codex/logs_2.sqlite` empty. Nothing may respawn
+   (servers are stopped — no SIGSTOP theatrics needed in the normal path).
+4. **Final baselines at 0 holders (review 0b-2).** Row counts: `sessions/` file
+   count, `goals_1.thread_goals`, `state_5.threads`, `state_5.thread_spawn_edges`,
+   `memories_1.*` (checkpoint `memories_1`'s WAL first before trusting counts), and
+   **`logs_2` `count(*)` + `max(id)`** (needed for the VACUUM equality check).
+5. **Checkpoint — never rm.** For each `~/.codex/*.sqlite` with a non-empty `-wal`:
    `PRAGMA busy_timeout=15000; PRAGMA wal_checkpoint(TRUNCATE);`
-5. **Compact.** `VACUUM;` on `logs_2.sqlite` (reclaims the ~2.24 GB free pages; needs
-   0 holders + free disk ≈ DB size — currently ~170 GB free, fine).
-6. **Verify.** `PRAGMA integrity_check` = `ok` on all live DBs; every baseline row count
-   matches; `sessions/` file count unchanged (± legitimately new sessions); holders = 0;
-   `logs_2.sqlite-wal` = 0 bytes; codex TUI launches to `Ready`.
-7. Resume the SIGSTOP'd server (already guaranteed by trap); confirm freshell panes
-   reconnect.
+6. **Compact.** Prefer `VACUUM INTO '<new-file>'` (original untouched; verify the new
+   file, then atomically swap; strictly safer — review 0b-6). Plain in-place `VACUUM`
+   is acceptable (crash mid-VACUUM rolls back transactionally). Requires 0 holders +
+   free disk ≈ DB size.
+7. **Verify.**
+   - `PRAGMA integrity_check` = `ok` on all live DBs.
+   - **`logs_2` row count and `max(id)` equal step 4 exactly** (VACUUM must not change
+     row population — this is the meaningful equality check).
+   - All other counts **≥ step-4 baseline with any delta explained** (nothing should
+     write during the window; an unexplained delta = stop and investigate).
+   - `sessions/` file count unchanged; holders = 0; `logs_2.sqlite-wal` = 0 bytes.
+   - **Never auto-restore on a mismatch** (review 0b-2: a stale-backup restore would
+     itself destroy data). Mismatch = halt, investigate, decide manually.
+8. **Restart freshell servers**; restore-all respawns the (dampened, if 0a landed)
+   generation; spot-check a codex pane reaches `Ready`.
 
 ### Why safe
 
-WAL is *folded into* the main DB (`wal_checkpoint(TRUNCATE)`), never deleted; `VACUUM`
-is lossless; every step is gated behind a verified backup + integrity check + row-count
-equality (I1). Only codex processes are signalled, orphaned/crashed ones at that; live
-freshell servers and attached panes are protected by the guard (I3).
+DB backups are online-consistent (`.backup`/`VACUUM INTO`); the WAL is folded in via
+checkpoint, never deleted; VACUUM preserves all rows (checked by exact `logs_2`
+equality); baselines are taken at a quiesced moment so the oracle is coherent; no
+`sessions/` file is ever touched; restore is a manual decision, never automatic (I1).
 
 ### Rollback
 
-Restore the timestamped backup (byte-identical copies taken while 0 holders).
+Restore the step-1 `.backup` set (consistent by construction) or the step-3 file
+copies (byte-identical, taken at 0 holders).
 
 ### User-facing risk
 
-Seconds-long pause of one respawning server during the checkpoint window; codex panes
-briefly unavailable while their (already-wedged/orphaned) processes are reaped.
-**Severity: Low.**
+All codex panes terminate for the window (minutes); in-flight turns lost; panes
+restore from rollouts afterward. **Severity: Medium** (declared downtime), not "Low"
+(review 0b-5).
 
 ---
 
-## 5. Stage 1a — Crash-safe teardown on server exit
+## 6. Stage 1a — Exception/signal-safe teardown on server exit
+
+*(renamed from "crash-safe" — review 1a-1)*
+
+### What `process.on('exit')` actually covers (honest enumeration)
+
+**Covered:** normal exit (`process.exit()` — both the graceful path `index.ts:1144`
+and the fatal path `:1153`), event-loop drain, default-fatal uncaught
+exceptions/unhandled rejections, and signals we handle (SIGTERM/SIGINT/SIGHUP →
+`shutdown()` → `process.exit`).
+**Not covered:** `SIGKILL`, **V8 OOM abort** (a realistic failure mode for a leaking
+long-lived server), native segfault/abort, unhandled default-fatal signals. Hard-crash
+coverage requires the durable on-disk ownership + boot reaper (follow-up **1b**, out
+of scope) — this stage narrows the orphan window; it does not close it.
 
 ### Change
 
-Today, codex child teardown only runs from the async `shutdown()` on `SIGTERM`/`SIGINT`
-(`index.ts:1147-1148`). A crash, `SIGKILL`-adjacent exit, or `SIGHUP` leaves every
-`detached: true` app-server and resume pty orphaned. Add a best-effort, **synchronous**
-process-group reap bound to true exit paths:
-
-1. **Registry.** A small module (e.g. `server/coding-cli/codex-child-registry.ts`)
-   tracking `{ pid, pgid, kind }` for every codex child freshell spawns:
-   - app-server: pgid == `child.pid` (already captured as `processGroupId`,
-     `runtime.ts:1291-1292`) — register on spawn, deregister in the existing exit handler
-     (`runtime.ts:1533-1575`) and ownership teardown.
+1. **Registry** (`server/coding-cli/codex-child-registry.ts`, new): `{ pid, pgid,
+   kind }` for every codex child.
+   - app-server: pgid == `child.pid` (`processGroupId`, `runtime.ts:1291-1292`).
+     Register on spawn. **Deregister only on confirmed group death** — after
+     `teardownOwnedProcessGroup` returns `true` (`runtime.ts:692-734`), *not* at
+     wrapper exit (`:1533-1575`), which can leave live grandchildren untracked
+     (review 1a-2).
    - resume pty: register `pty.pid` at both spawn sites (`terminal-registry.ts:1594`,
-     `:3694`), deregister on pty exit and in `kill()` (`:3997-4035`).
-2. **Bindings** (installed once, alongside `index.ts:1147-1148`):
-   - `process.on('exit', reapSync)` — synchronously best-effort
-     `process.kill(-pgid, 'SIGKILL')` for each still-registered group, wrapped in
-     try/catch. Guard: never signal `-1`, `0`, `1`, or our own pgid; only pgids we
-     registered. Where cheap, re-verify identity (e.g. `/proc/<pid>/cmdline` contains
-     codex) before signalling to defend against pgid reuse.
-   - `process.on('SIGHUP', …)` — route into the existing graceful `shutdown('SIGHUP')`.
-   - `process.on('uncaughtExceptionMonitor', …)` — **observe/log only.** Never kill.
-3. **Idempotency.** The existing async shutdown path drains the registry as it tears
-   children down (`joinCodexShutdownOwners`, `index.ts:1104-1109`), so `reapSync` at
-   `exit` is a no-op after a clean shutdown.
-
-Explicitly **not** bound to `uncaughtException`: `exit` cannot fire on a recoverable,
-caught error, so a survivable blip can never nuke live panes (I3).
+     `:3694`). **Deregister on the pty's `exit` event**, not in `kill()` (`:4008` only
+     *sends* a signal — review 1a-2).
+2. **Bindings** (installed once, near `index.ts:1147-1148`):
+   - `process.on('exit', reapSync)` — synchronous best-effort
+     `process.kill(-pgid, 'SIGKILL')` per still-registered group, try/catch'd.
+     Guards: only registered pgids; never `-1`/`0`/`1`/our own pgid; cheap sync
+     identity re-check (`/proc/<pid>/cmdline` contains codex) before signalling.
+     **Residual pgid-reuse window:** the sync check-then-kill race is narrower than
+     nothing but wider than the async reaper's fresh-classification
+     (`runtime.ts:698-711`); accepted at process-death time and documented
+     (review 1a-4).
+   - `process.on('SIGHUP', …)` — route into the existing graceful
+     `shutdown('SIGHUP')` (idempotent via `isShuttingDown`, `index.ts:1079`). Add a
+     **hard-exit timeout** to `shutdown()` so a throw from `joinCodexShutdownOwners`
+     (`:1102-1113` has no catch) cannot leave the process alive without ever reaching
+     `process.exit(0)` at `:1144` (review 1a-6).
+   - `process.on('uncaughtExceptionMonitor', …)` — **observe/log only.** The default
+     fatal behavior of `uncaughtException` is left in place; the fatal path then runs
+     `'exit'` → `reapSync`.
+3. **Platform gating (review 1a-3):** negative-pid group kill and `/proc` checks are
+   POSIX/Linux; gate the registry's reap on POSIX and document Windows-host as out of
+   scope (consistent with the sidecar's existing Linux-only stance,
+   `assertUnixSidecarSupport`, `runtime.ts:360-364`).
 
 ### Why safe
 
-- `exit` fires only when the process is genuinely terminating — at which point the
-  children's sockets are dying anyway and their in-flight turns are already lost with the
-  server; reaping them prevents orphan accumulation without touching any live pane (I3).
-- Synchronous, guarded signalling of only-our-own pgids; cannot throw out of the exit
-  path; cannot block boot (I4).
+`exit` cannot fire on a recoverable, *caught* error — a survivable blip can never
+nuke live panes (I3). At true termination the children's transport is dying anyway;
+reaping prevents orphan accumulation. Guarded, synchronous, try/catch'd; cannot block
+boot (I4).
 
-### Acceptance test
+### Acceptance tests (review F6, 1a-5)
 
-1. Start the dev server with ≥2 codex panes; terminate with `SIGHUP` and with a normal
-   exit → `pgrep -f 'codex-linux-x64/vendor'` shows zero survivors from that instance;
-   `lsof ~/.codex/logs_2.sqlite` shows no holders owned by it.
-2. Throw a caught-and-handled exception in a request handler → **all panes stay alive**
-   (I3 regression guard).
-3. `SIGKILL` the server → survivors expected (documented boundary; closed by follow-up
-   1b, out of scope here).
+1. Dev server + ≥2 codex panes; terminate via `SIGHUP` and via normal exit →
+   **zero survivors from that instance**, scoped via the registry contents (or
+   matching `FRESHELL_CODEX_SIDECAR_ID` env in `/proc/<pid>/environ`) — *not* a bare
+   `pgrep` (prod + dev coexist).
+2. **Uncaught-exception test** (replaces v1's vacuous caught-exception test): throw an
+   uncaught exception → process dies → registered groups are gone. Separately assert
+   the I3 property at unit level: no code path signals a registered group while the
+   process is alive.
+3. `SIGKILL` the server → survivors expected; documented boundary (1b's job).
+4. **Empirical check:** verify whether the codex resume TUI exits on pty-master close
+   (kernel SIGHUP). If codex ignores it, resume ptys outlive the server on paths 1a
+   doesn't cover — record the result; it sets 1b's priority (review 1a-5).
 
 ### Rollback
 
-Remove the three listeners (single module); behavior reverts to SIGTERM/SIGINT-only.
+Remove the three listeners + registry wiring; behavior reverts to
+SIGTERM/SIGINT-only.
 
 ### User-facing risk
 
-Removes any accidental "app-server survives a dead server" reattach behavior — durable
-state lives in on-disk rollouts, so the next launch resumes losslessly (I1). SIGHUP now
-tears down a dev server left in a closing terminal (previously it might linger).
+None in steady state. SIGHUP now tears down a dev server left in a closing terminal.
 **Severity: Low.**
 
 ---
 
-## 6. Stage 1c — Startup reaper: log-and-continue (fail-open)
+## 7. Stage 1c — Startup reaper: complete fail-open + minimal observability
 
-### Change
+### Change (review F2, 1c-1..4; G4, G6)
 
-`assertCodexStartupReaperSucceeded` throws when any sidecar ownership record can't be
-classified/reaped (`runtime.ts:863-876`). It is `await`ed before `server.listen`
-(`index.ts:256`), and the throw propagates to `main().catch → process.exit(1)`
-(`index.ts:1151-1154`) — the whole server refuses to boot because one stale JSON record
-was ambiguous. That is a self-inflicted "won't launch" (violates I4).
-
-Replace fail-closed with fail-open:
-
-1. In `runCodexStartupReaper` / its caller: for each record classified `failed` /
-   `indeterminate` / `unreadable`:
-   - log a structured `warn` with the record path, classification, and reason;
-   - **move the record to `~/.freshell/codex-sidecars/quarantine/`** (atomic rename)
-     with a `{ reason, firstSeen, attempts }` sidecar note;
-   - continue.
-2. Delete `assertCodexStartupReaperSucceeded` (or reduce it to a warning aggregator).
-   Startup proceeds unconditionally.
-3. Bounded retry: on each subsequent boot, re-attempt quarantined records (increment
-   `attempts`, give up permanently after e.g. 5, leaving the record for manual review).
-4. Expose the quarantine count via the existing logger/metrics so the (future) monitor
-   can surface it.
+1. **Per-record isolation.** Wrap the *per-record* body of the reap loop
+   (`runtime.ts:808-848`) in try/catch so an unreadable record file (`:811` —
+   permissions, torn write) affects only that record (introduce the `unreadable`
+   classification the plan names but the code lacks). Treat non-ENOENT `readdir`
+   failures (`:803-806`) and an unavailable `/proc` ownership proof (`:800`,
+   `:360-379`) as **degrade-and-continue** (log, skip reaping this boot), not aborts.
+2. **Backstop.** try/catch around the `runCodexStartupReaper` call at `index.ts:256`:
+   log and continue. Boot must never die in the reaper (I4).
+3. **Quarantine — only for provably-dead or unparseable records (review 1c-2).**
+   - Owner PID **provably dead** (`isPidAlive` false) but group unkillable, or record
+     unparseable → move to `~/.freshell/codex-sidecars/quarantine/` (atomic rename;
+     preserve `0600` — records embed command lines and cwd's, review G6) with a
+     `{ reason, firstSeen, attempts }` note.
+   - Owner **alive but identity-mismatched** (`runtime.ts:826-831` — reachable via
+     transient `/proc` races) → **retry in place** with time-based backoff keyed on
+     `firstSeen`. Never quarantine a possibly-live sidecar's only tether — that would
+     mint a permanent, invisible DB holder (the exact leak this plan fights).
+   - Retry semantics are **time-based, not boot-count-based** (review 1c-3): the
+     shared `~/.freshell/codex-sidecars` dir serves prod + dev, and a dev server under
+     `tsx watch` can boot dozens of times an hour. On concurrent boots, rename-ENOENT
+     = the other instance won; treat as success.
+4. **Remove the fail-closed assert.** `assertCodexStartupReaperSucceeded`
+   (`runtime.ts:863-876`) is deleted/reduced to a warning aggregator. **Test impact
+   is a contract inversion, not an update** (review 1c-4): ~8 tests in
+   `test/unit/server/coding-cli/codex-app-server/runtime.test.ts` assert the throwing
+   contract, plus the exported alias `reapOrphanedCodexAppServerSidecarsOnStartup`
+   (`runtime.ts:861`) — rewrite them to assert no-throw + quarantine/backoff behavior.
+5. **Boot-time observability line (review G4 — promoted into scope, ~10 lines).** At
+   every boot (and hourly thereafter on a timer), log one structured line:
+   `codex-log-db: wal_bytes=<stat of logs_2.sqlite-wal> holders=<count via /proc fd scan> quarantined=<n>`
+   with a `warn` if `wal_bytes > 500 MB` or holders exceed a threshold. Read-only:
+   `stat` + `/proc` fd scan; **never opens the SQLite DB, never signals anything.**
+   This converts every silent failure mode in this plan (0a ineffective, 1c orphan,
+   regrowth) into a detectable one.
 
 ### Why safe
 
-The correct worst case for an ambiguous orphan is "one possibly-orphaned sidecar lingers,
-flagged" — never "no server at all" (I4). Quarantining prevents boot-loop churn on a
-permanently bad record. No change to what gets killed (I3): reap decisions still require
-the same ownership proof; we only change what happens when proof is unavailable.
+Fail-open at every layer (I4); reap decisions still require the same ownership proof
+(I3 unchanged); quarantine can no longer orphan a live sidecar's record; the monitor
+is observation-only.
 
-### Acceptance test
+### Acceptance tests
 
-1. Seed a deliberately un-reapable ownership record (e.g. valid JSON pointing at a live
-   PID that fails the ownership proof) → server boots to ready; record lands in
-   `quarantine/`; warning logged; no `process.exit(1)`.
-2. Seed a reapable orphan record → still reaped exactly as before (no regression).
-3. Existing reaper unit tests updated: no-throw contract.
+1. Seed an un-reapable-but-dead record → server boots; record quarantined `0600`;
+   warning logged.
+2. Seed an **unreadable** record file (chmod 000) → server boots; that record
+   isolated; others still processed.
+3. Simulate `/proc` proof unavailable → server boots; reaping skipped with a warning.
+4. Seed an alive-but-mismatched record → retried in place with backoff; **not**
+   quarantined; still present next boot.
+5. Reapable orphan → still reaped exactly as before.
+6. Boot line appears with correct WAL size/holder count against fixtures; `warn`
+   fires above thresholds; verify the monitor holds no fd on the SQLite files.
 
 ### Rollback
 
-Restore the throw (revert one function); quarantine dir is inert.
+Restore the assert (one function); disable the boot line.
 
 ### User-facing risk
 
-On an ambiguous record the server now starts with a possibly-lingering orphan (flagged,
-retried next boot) instead of refusing to start. Strictly better availability.
-**Severity: Low, net-positive.**
+Ambiguous records now linger (flagged, retried with backoff) instead of blocking
+boot. Strictly better availability. **Severity: Low, net-positive.**
 
 ---
 
-## 7. Sequencing
+## 8. Deploy choreography (review G2)
+
+Deploying 0a/1a/1c requires restarting freshell — **prod and dev both** (both hold
+the DB). A restart is itself a pane-recycling event (graceful teardown + restore-all).
+Sequence the whole rollout as **one declared window**:
+
+1. Merge 0a (if §3 validated) + 1a + 1c.
+2. Announce the maintenance window (§5 framing).
+3. Restart/stop both servers → run the **0b runbook** (servers stay stopped through
+   step 7) → restart both servers.
+4. Post-checks: pane reaches `Ready`; boot observability line shows
+   `wal_bytes≈0, holders == 2×(open codex panes)`; over the next day, the hourly line
+   shows WAL bounded (0a working) or growing (0a failed → §10).
+
+## 9. Sequencing & dependencies
 
 ```
-0a (code)  ──►  deploy  ──►  0b (runbook, once)
-1a (code)  ──┐
-1c (code)  ──┴─►  same PR or sibling PRs; independent of each other and of 0a
+§3 validation experiment  ──►  0a implementation (only if a candidate passes)
+1a, 1c                    ──►  independent; implement in parallel with §3
+merge (0a?, 1a, 1c)       ──►  §8 window: stop servers → 0b → restart
+boot/hourly observability ──►  ships inside 1c; watches everything afterward
 ```
 
-- 0a first, then 0b, so the WAL doesn't regrow at firehose rate behind the cleanup.
-- 1a and 1c are independent of 0a/0b and of each other; land in any order.
-- Follow-ups (not in this plan): 1b (durable resume-TUI ownership + boot-reaper
-  coverage — closes the `SIGKILL` boundary left by 1a), Stage 2 (single shared
-  app-server; holders == 1 regardless of pane count — the permanent structural fix),
-  read-only WAL/holder monitor, upstream codex asks (bound own WAL; stop TRACE inotify
-  persistence; lazy thread-inventory scan; documented log-level knob).
+- 0a and 0b remain complementary: 0a (if validated) shrinks churn volume; 0b clears
+  the accumulated WAL/dead pages. Neither reduces holder count — that is Stage 2's
+  job (out of scope).
+- 1b (durable resume-TUI ownership + boot reaper) is the committed follow-up that
+  closes 1a's SIGKILL/OOM boundary.
 
-## 8. Constraint traceability
+## 10. Residual risk (honest statement)
+
+- **Holders remain by design** (I2/I3): ~2 codex processes per open pane keep the DB
+  open around the clock. This plan does not change that.
+- **If §3 validates a knob:** WAL churn ≈ 0; the cliff should not recur before
+  Stage 2 lands. Remaining exposure: the unvalidated-in-production knob (watched by
+  the hourly line) and codex-internal behavior changes on upgrade.
+- **If §3 fails:** churn continues at ~22 MB/min of active use; the WAL re-approaches
+  the cliff in **days-to-weeks**. The observability line makes this loudly visible
+  (500 MB warn threshold ≈ weeks of margin before the ~5 GB wedge), and 0b can be
+  re-run as a stopgap during any maintenance window. Stage 2 (shared app-server,
+  holders==1) becomes urgent and should be scheduled immediately.
+- 1a/1c reduce orphan accumulation and boot fragility but do not change WAL
+  mechanics.
+
+## 11. Constraint traceability (corrected)
 
 | Constraint | Honored by |
 |---|---|
-| I1 lossless | 0b: checkpoint/VACUUM only, verified backup + integrity + row-count oracle; 1a: reaps processes, never data; rollouts remain source of truth |
-| I2 no cap | No stage limits panes; 0a/1a/1c don't touch pane creation |
-| I3 no live-pane kills | 1a binds `exit` (can't fire on recoverable errors), `uncaughtExceptionMonitor` observe-only; 0b protected-PID guard + dry-run; idle-reaper attached-pane skip untouched; 1c changes only the no-proof branch |
-| I4 no new won't-launch | 1c removes the fail-closed boot throw; 0a additive env; 1a exit-path only, try/catch'd |
-| I5 telemetry tradeoff | 0a documented, only-if-unset, kill switch, single tunable |
+| I1 lossless | 0b: online-consistent backups, checkpoint/VACUUM only, exact `logs_2` row/`max(id)` equality check, **no auto-restore**; 1a/1c reap processes, never data; rollouts remain source of truth |
+| I2 no cap | No stage limits panes; observability is read-only |
+| I3 no live-pane kills (steady state) | 1a binds `exit` (cannot fire on recoverable errors), monitor observe-only; 1c reaps only proven-dead owners, retries ambiguity in place; idle-reaper attached-pane skip untouched. **0b is the one declared, consented exception** (maintenance window, §5) — not claimed otherwise |
+| I4 no new won't-launch | 1c: per-record isolation + degrade-and-continue + backstop try/catch (covers `:800`, `:803-806`, `:811`, `:863-876`); 0a additive; 1a exit-path only, try/catch'd |
+| I5 telemetry tradeoff | 0a documented, only-if-unset (incl. `''`), kill switch (restart required — stated honestly) |
 
-## 9. Definition of done
+## 12. Definition of done
 
-1. **0a:** WAL growth with an active codex pane drops to near-zero (measured); helper
-   no-op when `RUST_LOG` preset; TUI reaches `Ready`.
-2. **0b:** integrity `ok` on all DBs; all baseline row counts match; `sessions/` count
-   unchanged; holders 0 at completion; `logs_2.sqlite-wal` 0 bytes; `logs_2.sqlite`
-   shrunk by ~2 GB.
-3. **1a:** SIGHUP/normal exit leaves zero codex survivors; caught exception kills no
-   panes.
-4. **1c:** server reaches ready with an un-reapable record present; record quarantined
-   and logged; reapable orphans still reaped.
+1. **§3:** a documented pass/fail result for each candidate; 0a proceeds only on a
+   pass (≥90% byte reduction on the representative workload).
+2. **0a (if implemented):** acceptance re-run post-deploy passes; unit tests green
+   (incl. `''`-preset, kill switch, `this.env`, sidecar-id preservation, non-codex
+   modes untouched); TUI `Ready` + turn completes.
+3. **0b:** integrity `ok`; `logs_2` rows/`max(id)` exactly equal step-4 baseline;
+   other counts ≥ baseline with deltas explained; `sessions/` count unchanged;
+   holders 0 at completion; WAL 0 bytes; ~2 GB reclaimed; no auto-restore occurred.
+4. **1a:** SIGHUP/normal-exit → zero survivors (registry-scoped assertion);
+   uncaught-exception path reaps; pty-master-close behavior of codex recorded;
+   POSIX-gated; Windows documented out of scope.
+5. **1c:** all six acceptance tests pass, including the three formerly-fatal boot
+   paths; test-suite contract inversions completed; boot/hourly observability line
+   live with thresholds.

--- a/docs/plans/2026-07-06-codex-launch-leak-remediation-plan.md
+++ b/docs/plans/2026-07-06-codex-launch-leak-remediation-plan.md
@@ -1,13 +1,26 @@
-# Codex Launch-Leak Remediation Plan — Stage 0a/0b + 1a/1c (v2)
+# Codex Launch-Leak Remediation Plan — Stage 0a/0b + 1a/1c (v2.1)
 
-**Date:** 2026-07-06 (v2, evening)
-**Target:** freshell `main @ 02f95b70` (TypeScript/Node server)
+**Date:** 2026-07-06 (v2.1, night)
+**Target:** freshell `main` (TypeScript/Node server). Anchors verified at `02f95b70`
+and re-verified at `9f3a5035` (only `providers/codex.ts` `parseTimestampMs` changed;
+no anchor impact). **Re-pin to current main before implementing.**
 **Status:** Plan — not yet implemented
-**v2 changes:** incorporates all findings from the 2026-07-06 adversarial review
-(factual fixes F1–F6, per-stage design flaws, gaps G1–G6) and the results of the
-log-dampening validation experiment run the same evening (§3). Terminology note:
-`RUST_LOG` is the log-level environment variable of the **codex binary** (OpenAI's
-CLI, which happens to be written in Rust). It is unrelated to any freshell code.
+**v2 changes:** folds in the first 2026-07-06 adversarial review (factual fixes
+F1–F6, per-stage design flaws, gaps G1–G6) and the log-dampening validation
+experiment run the same evening (§3).
+**v2.1 changes:** folds in the second-round adversarial review — §3 measurement
+rewritten to a prune-immune metric (blocking #1); 1c quarantine narrowed to
+confirmed-gone groups + quarantine rescan (blocking #2); composite `RUST_LOG`
+directive (#3); backoff/monitor given concrete homes (#4); `logs_2` backup via
+`VACUUM INTO` (#5); dampening-skip observability (#6); executable 1a acceptance
+scoping, specified hard-exit timeout, structural I3 assertion (#7–9); §8 ordering
+reconciled + DoD reclaim figure derived (#10); `id` schema check before the VACUUM
+oracle (#11); anchor drift corrected (WSL wrap `:1141-1149`; ~12 throwing-contract
+test sites; unreferenced alias).
+
+Terminology note: `RUST_LOG` is the log-level environment variable of the **codex
+binary** (OpenAI's CLI, which happens to be written in Rust). It is unrelated to any
+freshell code.
 
 **Scope:** the four near-term items (0a, 0b, 1a, 1c) plus a small observability
 line-item promoted into scope. Follow-ups — durable resume-TUI boot reaper ("1b")
@@ -35,9 +48,10 @@ measurement:
 2. **Log churn, not table growth, floods the WAL.** codex persists tracing rows into
    `logs_2.sqlite` and **bounds the table per process (~1,000 rows)** — inserts are
    continuously matched by prune deletes. The table stays small; the **WAL traffic
-   does not**. Measured on this machine (2026-07-06): the live pane population writes
-   **~22 MB/min** of WAL churn, ~99% `TRACE` rows with `target=log` (the Rust `log`
-   facade forwarding **inotify file-event spam**).
+   does not**. Measured on this machine (2026-07-06, prune-immune incremental
+   sampling): the live pane population writes **~22 MB/min** of WAL churn, ~99%
+   `TRACE` rows with `target=log` (the Rust `log` facade forwarding **inotify
+   file-event spam**).
 
 3. **The WAL can never reset.** A WAL reset/truncate requires that **no read
    transaction spans the checkpoint** (review F1: it is *not* "zero connections" —
@@ -89,64 +103,112 @@ documented log-level knob.
 ## 3. Stage 0-pre — Validate the dampening mechanism (BLOCKS 0a implementation)
 
 The v1 plan bet its sequencing on `RUST_LOG=error` gating codex's SQLite log sink.
-The review demanded validation first; the experiment was run 2026-07-06 evening.
+The first review demanded validation before implementation; an initial experiment was
+run 2026-07-06 evening.
 
-**Results so far (evidence, this machine, codex-cli 0.142.5):**
+### Results so far (evidence, this machine, codex-cli 0.142.5)
 
-| Test (idle TUI, 78 s, cwd=$HOME, pty) | Attributable rows written |
+| Test (idle TUI, 78 s, cwd=$HOME, pty) | Surviving attributable rows (post-prune **lower bound**) |
 |---|---|
 | Control — `RUST_LOG` unset | 1 |
-| Treatment — `RUST_LOG=error` | **1,013** (not silenced; more than control) |
-| Ambient — live pane population, no test proc | ~64k rows/min ≈ **22 MB/min** |
+| Treatment — `RUST_LOG=error` | ≥1,013 — **at the ~1,000-row prune ceiling** |
+| Ambient — live pane population, no test proc | ~64k rows/min ≈ **22 MB/min** (measured incrementally — prune-immune) |
+
+**Measurement caveat (second-review blocking #1, folded in):** codex prunes each
+process's rows to a ~1,000-row bound (§1.2), so an end-of-window
+`count(*) WHERE process_uuid=…` measures **survivors, not writes**. The treatment
+figure sits exactly at the prune ceiling — it means "wrote **at least** 1,013 rows,
+possibly far more." The control-vs-treatment numbers therefore support only the
+**qualitative** conclusion — plain `RUST_LOG=error` demonstrably does **not** silence
+the sink — and cannot quantify rates. The ambient 22 MB/min figure *was* measured
+prune-immune (incremental `max(id)`/`estimated_bytes` deltas over a sampling window)
+and stands.
 
 **Conclusions:**
-1. **Plain `RUST_LOG=error` is NOT validated** — initial evidence is negative.
+1. **Plain `RUST_LOG=error` is NOT validated** — evidence is negative.
 2. **An idle, freshly-launched TUI is not the firehose.** The firehose is the
    long-running pane population (insert+prune churn, `TRACE`/`target=log` inotify
-   events). Any acceptance test must use a representative long-running workload.
-3. The binary embeds a default filter string (`codex_cli=info,codex_core=info,…`) and
-   the sink schema (`feedback_log_body`, `bounded_feedback_logs`), so a filter layer
-   exists — the right directive just isn't confirmed yet.
+   events). Acceptance tests must use a representative long-running workload.
+3. The binary embeds a default filter string
+   (`codex_cli=info,codex_core=info,codex_login=info`) and the sink schema
+   (`feedback_log_body`, `bounded_feedback_logs`), so a filter layer exists — the
+   right directive just isn't confirmed yet.
 
-**Required protocol before 0a is implemented (no code until one candidate passes):**
-- Workload: a freshell-spawned codex pane pair (app-server + resume) left running
-  ≥15 min; attribute rows/bytes by `process_uuid`
-  (`SELECT count(*), sum(estimated_bytes) FROM logs WHERE process_uuid=… AND id>…`
-  on a `mode=ro` connection).
-- Candidates, in order:
-  1. `RUST_LOG='log=off'` (or `log=error`) — a **scoped directive** silencing the
-     `log`-facade target that carries ~99% of rows, without touching `codex_*` module
-     levels.
-  2. A codex `-c` config knob (the arg channel already exists:
-     `CODEX_MANAGED_REMOTE_CONFIG_ARGS`, `codex-managed-config.ts:1-4`); candidate
-     keys to probe: `log.level`, `tui.*` logging toggles.
+### Required protocol before 0a is implemented (no code until one candidate passes)
+
+- **Workload:** a freshell-spawned codex pane pair (app-server + resume) left running
+  ≥15 min under inotify-generating conditions (cwd=$HOME), control and treatment run
+  the same evening.
+- **Metric — prune-immune, one of (second-review #1):**
+  1. **Isolated-holder WAL-growth diff (preferred):** run the window when the test
+     pair are the **only** `logs_2.sqlite` holders (immediately after the 0b quiesce,
+     before restarting the servers — see §8 — or against a scratch `CODEX_HOME`).
+     Sample `stat -c%s logs_2.sqlite-wal` every 10 s; compare total growth,
+     control vs treatment.
+  2. **Incremental insert attribution:** poll `max(id)` every 1 s on a `mode=ro`
+     connection and accumulate new rows/`estimated_bytes` per test `process_uuid`
+     **as they appear**, counting inserts before pruning can delete them.
+- **Candidates, in order:**
+  1. **Composite directive** (second-review #3):
+     `RUST_LOG='codex_cli=info,codex_core=info,codex_login=info,log=off'`.
+     Any `RUST_LOG` value **replaces** the binary's embedded default filter, so a
+     bare `log=off` would silently reset every `codex_*` target — candidate strings
+     must be composites of the embedded default plus the `log=off` (or `log=error`)
+     suppression. **The §3 result record must capture the exact final directive
+     string.**
+  2. A codex `-c` config knob (candidate keys: `log.level`, `tui.*` logging toggles).
+     Plumbing caveat (second-review verification #4): the managed-args channel
+     (`CODEX_MANAGED_REMOTE_CONFIG_ARGS`, `codex-managed-config.ts:1-4`) reaches the
+     app-server spawn unconditionally, but the pty path pushes it **only when
+     `providerSettings.codexAppServer` is present** (`terminal-registry.ts:306`), and
+     spawn site 3 (`codex exec`, `providers/codex.ts:483-501`) has **no `-c` channel
+     at all** — the args-variant of 0a needs new plumbing for sites 2–3.
   3. If neither works: **0a is dropped**, the upstream ask is filed as the only
-     firehose fix, and this plan's protection reduces to 0b + observability + 1a/1c
-     (see §10 residual risk — recurrence to the cliff in days-to-weeks of heavy use,
-     now *detectable* instead of silent).
-- **Pass bar:** ≥90% reduction in the pane pair's attributable bytes over 15 min, and
+     firehose fix (the WAL-growth measurements from this protocol become the issue's
+     evidence), and this plan's protection reduces to 0b + observability + 1a/1c
+     (see §10 — recurrence in days-to-weeks of heavy use, now *detectable* instead of
+     silent).
+- **Pass bar:** ≥90% reduction in **measured write traffic** (WAL growth bytes, or
+  incrementally attributed insert bytes) vs the same-evening undampened control, and
   the pane still functions (turn completes, rollout file written).
 
 ## 4. Stage 0a — Codex spawn-env log dampening (conditional on §3)
 
 ### Change
 
-One shared helper; the value comes from whichever candidate §3 validated.
+One shared helper; the value is whatever §3 validated.
 
 ```ts
 // server/coding-cli/codex-log-dampening.ts  (new)
-export const CODEX_LOG_DIRECTIVE = 'log=off' // placeholder: whatever §3 validates
+// placeholder: exact composite string validated by §3
+export const CODEX_LOG_DIRECTIVE =
+  'codex_cli=info,codex_core=info,codex_login=info,log=off'
 
-export function withCodexLogDampening<T extends NodeJS.ProcessEnv>(env: T): T {
-  // Consult ONLY the env the child will actually see (review 0a-2: both call sites
-  // already spread process.env, so a separate process.env fallback is dead-or-wrong).
-  if (env.RUST_LOG !== undefined) return env // set — even '' — is an explicit choice
-  if (process.env.FRESHELL_CODEX_LOG_DAMPENING === '0') return env // kill switch
+export function withCodexLogDampening<T extends NodeJS.ProcessEnv>(
+  env: T,
+  onSkip?: (reason: string) => void,
+): T {
+  // Consult ONLY the env the child will actually see (both call sites spread
+  // process.env, so a separate process.env fallback is dead-or-wrong).
+  if (env.RUST_LOG !== undefined) {
+    onSkip?.('RUST_LOG preset') // set — even '' — is an explicit choice
+    return env
+  }
+  if (process.env.FRESHELL_CODEX_LOG_DAMPENING === '0') {
+    onSkip?.('kill switch')
+    return env
+  }
   return { ...env, RUST_LOG: CODEX_LOG_DIRECTIVE }
 }
 ```
 
-Call sites — **three**, not two (review G1):
+**Dampening-skip observability (second-review #6):** when the helper skips because
+`RUST_LOG` is preset (e.g. a developer shell exporting `RUST_LOG` for unrelated Rust
+work leaks into every codex child and silently disables dampening), emit one
+structured `warn` per boot (deduped) via the `onSkip` callback. Fail-open must not be
+fail-silent.
+
+Call sites — **three** (review G1):
 
 1. **App-server spawn** — `runtime.ts:1255-1259`:
    `env: withCodexLogDampening({ ...process.env, ...this.env, FRESHELL_CODEX_SIDECAR_ID: ownershipId })`.
@@ -161,34 +223,34 @@ Call sites — **three**, not two (review G1):
    `providers/codex.ts:479-501`), currently `env: { ...process.env }` with no
    dampening. Apply the same helper when the provider is codex.
 
-If §3 validated the `-c` knob instead of an env var, the helper becomes an args
-helper appended next to `CODEX_MANAGED_REMOTE_CONFIG_ARGS` (same three call sites;
-same guard semantics via an explicit opt-out env).
+If §3 validated the `-c` knob instead, the helper becomes an args helper — noting the
+plumbing gaps at sites 2–3 (§3 candidate 2 caveat).
 
-### Platform note (review G3)
+### Platform note (review G3; anchor corrected per second review)
 
-On a native-Windows host, `buildSpawnSpec` wraps codex in `wsl.exe …`
-(`terminal-registry.ts:1127-1139`); an env var set on the Windows-side process does
-not cross into WSL without `WSLENV`. The current deployment is WSL2-native (unaffected),
-but the helper's coverage claim is platform-conditional; add `WSLENV` plumbing or
-document Windows-host as out of scope.
+On a native-Windows host, `buildSpawnSpec` selects Windows-like handling at
+`terminal-registry.ts:1127-1139` and wraps codex in `wsl.exe …` at `:1141-1149`; an
+env var set on the Windows-side process does not cross into WSL without `WSLENV`. The
+current deployment is WSL2-native (unaffected), but the helper's coverage is
+platform-conditional; add `WSLENV` plumbing or document Windows-host as out of scope.
 
 ### Why safe
 
 - Additive env/args; no lifecycle change; no effect on pane count (I2) or boot (I4).
 - Only-if-unset guard: a developer's explicit `RUST_LOG` (any value, including empty)
-  is never overridden.
+  is never overridden — and the skip is logged (see above).
 - Dampening gates codex's tracing sink only; sessions/goals/memories/thread-graph are
   written by normal code paths, not tracing (I1).
 
 ### Acceptance test
 
-1. Repeat the §3 protocol (representative pane pair, 15 min, per-`process_uuid`
-   attribution) with the helper active: ≥90% byte reduction vs an undampened control
-   window run the same evening (controls for ambient variation).
-2. Unit tests: helper is a no-op when `RUST_LOG` is preset (any value incl. `''`) or
-   the kill switch is set; `FRESHELL_CODEX_SIDECAR_ID` and `this.env` overrides are
-   preserved; non-codex modes in `buildSpawnSpec` are untouched (review G5).
+1. Repeat the §3 protocol (representative pane pair, 15 min, prune-immune metric)
+   with the helper active: ≥90% write-traffic reduction vs an undampened control
+   window run the same evening.
+2. Unit tests: helper is a no-op (with `onSkip` fired) when `RUST_LOG` is preset
+   (any value incl. `''`) or the kill switch is set; `FRESHELL_CODEX_SIDECAR_ID` and
+   `this.env` overrides preserved; non-codex modes in `buildSpawnSpec` untouched
+   (review G5); the skip `warn` is emitted once per boot.
 3. Launch check: codex TUI reaches `Ready`; a turn completes; new rollout appears.
 
 ### Rollback
@@ -205,87 +267,99 @@ storm generation (upstream ask). **Severity: Low.**
 
 ## 5. Stage 0b — One-time lossless cleanup (maintenance-window runbook)
 
-**What this is (honest framing, review 0b-3):** a **declared maintenance window**
-that terminates **all codex processes, including live attached panes**. In-flight
-codex turns are lost (their transcripts up to that point are already on disk in
-rollout files). Long-term state is untouched. Get explicit operator acknowledgment
-before starting. This is the documented I3 carve-out (§2).
+**What this is (honest framing):** a **declared maintenance window** that terminates
+**all codex processes, including live attached panes**. In-flight codex turns are
+lost (their transcripts up to that point are already on disk in rollout files).
+Long-term state is untouched. Get explicit operator acknowledgment before starting.
+This is the documented I3 carve-out (§2).
 
-**Preconditions (review 0b-4, 0b-5):**
+**Preconditions:**
 - **Run from outside freshell** — an ssh/tmux/console session that is *not* a
-  freshell pane. (Otherwise the runbook's own server is in the operator's ancestry
-  and can never be paused/stopped — the ancestry deadlock.)
-- Check for supervisors/watchdogs (`systemd`, pm2, `tsx watch`) that would restart or
-  kill a paused server; prefer **gracefully stopping** the freshell servers for the
-  window (their existing `SIGTERM` teardown reaps their codex children for you,
-  `index.ts:1078-1145`) over `SIGSTOP`. Expect the window to last **minutes** (a
-  ~6 GB VACUUM), not seconds.
+  freshell pane (otherwise the runbook's own server is in the operator's ancestry and
+  can never be stopped — the ancestry deadlock).
+- Check for supervisors/watchdogs (`systemd`, pm2, `tsx watch`) that would restart a
+  stopped server mid-window. Expect the window to last **minutes** (a ~6 GB VACUUM),
+  not seconds.
 
 ### Runbook (ordered; each step gates the next)
 
-1. **Consistent backup + baseline (review F4/0b-1).** With writers still live, a
-   plain file copy is *not* guaranteed consistent. Use SQLite's online-consistent
-   mechanisms for the DB backups:
-   `sqlite3 ~/.codex/<db>.sqlite ".backup '<backup-dir>/<db>.sqlite'"` (or
-   `VACUUM INTO`) for each of `logs_2`, `state_5`, `goals_1`, `memories_1`; copy
-   `history.jsonl`, `auth.json`, `config.toml` normally. Verify
-   `PRAGMA integrity_check` = `ok` on every backup. Record **provisional** row counts
-   (final baselines are taken at step 4). Belt-and-braces: after step 3 (0 holders),
-   also take plain file copies (`.sqlite` + `-wal` + `-shm` together) — these are the
-   byte-identical restore set.
-2. **Announce + stop freshell servers (prod and dev — both hold the DB).** Graceful
-   `SIGTERM`; their teardown reaps their codex children. Then **reap stragglers**:
-   kill set from `lsof ~/.codex/logs_2.sqlite` filtered to codex cmdlines; dry-run
-   and print first; protected-PID guard (never the operator's own session ancestry);
-   **SIGTERM first, grace ≥10 s** (codex flushes rollout `.jsonl` appends on TERM —
-   review 0b-3), then SIGKILL survivors.
+1. **Consistent backup + provisional baseline (writers still live).**
+   - `logs_2.sqlite`: **use `VACUUM INTO '<backup-dir>/logs_2.sqlite'`** — SQLite's
+     online `.backup` restarts whenever another connection writes the source; at
+     ~22 MB/min across ~20 writers it may never converge (second-review #5).
+     `VACUUM INTO` takes a single consistent snapshot read.
+   - Low-churn DBs (`state_5`, `goals_1`, `memories_1`):
+     `sqlite3 <db> ".backup '<backup-dir>/<db>.sqlite'"` is fine.
+   - Copy `history.jsonl`, `auth.json`, `config.toml` normally.
+   - Verify `PRAGMA integrity_check` = `ok` on every backup. Record **provisional**
+     row counts (final baselines at step 4).
+2. **Announce + gracefully stop freshell servers (prod and dev — both hold the DB).**
+   `SIGTERM`; their existing teardown (`index.ts:1078-1145` →
+   `registry.shutdownGracefully`, `terminal-registry.ts:4891-4902`) reaps most codex
+   children. Then **reap stragglers** — kill set from `lsof ~/.codex/logs_2.sqlite`
+   filtered to codex cmdlines; dry-run and print first; protected-PID guard (never
+   the operator's own session ancestry); **SIGTERM first, grace ≥10 s** (codex
+   flushes rollout `.jsonl` appends on TERM), then SIGKILL survivors.
+   **This straggler kill is load-bearing, not belt-and-braces** (second review):
+   whether resume TUIs exit on SIGTERM/pty-close is an open question (§6 acceptance
+   4), so plan on stragglers existing.
 3. **Reach 0 holders.** `lsof ~/.codex/logs_2.sqlite` empty. Nothing may respawn
-   (servers are stopped — no SIGSTOP theatrics needed in the normal path).
-4. **Final baselines at 0 holders (review 0b-2).** Row counts: `sessions/` file
-   count, `goals_1.thread_goals`, `state_5.threads`, `state_5.thread_spawn_edges`,
-   `memories_1.*` (checkpoint `memories_1`'s WAL first before trusting counts), and
-   **`logs_2` `count(*)` + `max(id)`** (needed for the VACUUM equality check).
+   (servers are stopped). **Belt-and-braces:** now also take plain file copies
+   (`.sqlite` + `-wal` + `-shm` together) — the byte-identical restore set.
+4. **Final baselines at 0 holders.**
+   - **Schema check first (second-review #11):** verify the `logs` table declares
+     `id INTEGER PRIMARY KEY` (explicit rowid alias) — VACUUM preserves rowids only
+     for such tables; if it is an implicit rowid, drop the `max(id)` oracle and rely
+     on `count(*)` alone.
+   - Row counts: `sessions/` file count, `goals_1.thread_goals`, `state_5.threads`,
+     `state_5.thread_spawn_edges`, `memories_1.*` (checkpoint `memories_1`'s WAL
+     first before trusting counts), and **`logs_2` `count(*)` + `max(id)`** (for the
+     VACUUM equality check).
 5. **Checkpoint — never rm.** For each `~/.codex/*.sqlite` with a non-empty `-wal`:
    `PRAGMA busy_timeout=15000; PRAGMA wal_checkpoint(TRUNCATE);`
 6. **Compact.** Prefer `VACUUM INTO '<new-file>'` (original untouched; verify the new
-   file, then atomically swap; strictly safer — review 0b-6). Plain in-place `VACUUM`
-   is acceptable (crash mid-VACUUM rolls back transactionally). Requires 0 holders +
-   free disk ≈ DB size.
+   file, then atomically swap). Plain in-place `VACUUM` is acceptable (crash
+   mid-VACUUM rolls back transactionally). Requires 0 holders + free disk ≈ DB size.
 7. **Verify.**
    - `PRAGMA integrity_check` = `ok` on all live DBs.
-   - **`logs_2` row count and `max(id)` equal step 4 exactly** (VACUUM must not change
-     row population — this is the meaningful equality check).
+   - **`logs_2` `count(*)` (and `max(id)`, if step 4's schema check passed) equal
+     step 4 exactly** — VACUUM must not change row population.
    - All other counts **≥ step-4 baseline with any delta explained** (nothing should
      write during the window; an unexplained delta = stop and investigate).
    - `sessions/` file count unchanged; holders = 0; `logs_2.sqlite-wal` = 0 bytes.
-   - **Never auto-restore on a mismatch** (review 0b-2: a stale-backup restore would
-     itself destroy data). Mismatch = halt, investigate, decide manually.
+   - **Never auto-restore on a mismatch** (a stale-backup restore would itself
+     destroy data). Mismatch = halt, investigate, decide manually.
+   - Record **disk reclaimed ≈ prior WAL size + vacuumed dead pages** (measured
+     figure — second-review #10; do not assume a fixed "~2 GB").
 8. **Restart freshell servers**; restore-all respawns the (dampened, if 0a landed)
    generation; spot-check a codex pane reaches `Ready`.
 
+*(Optional: between steps 7 and 8 is the ideal window for the §3 isolated-holder
+WAL-growth measurement — the test pair are the only holders.)*
+
 ### Why safe
 
-DB backups are online-consistent (`.backup`/`VACUUM INTO`); the WAL is folded in via
-checkpoint, never deleted; VACUUM preserves all rows (checked by exact `logs_2`
-equality); baselines are taken at a quiesced moment so the oracle is coherent; no
-`sessions/` file is ever touched; restore is a manual decision, never automatic (I1).
+DB backups are snapshot-consistent (`VACUUM INTO`/`.backup` per churn level); the WAL
+is folded in via checkpoint, never deleted; VACUUM preserves all rows (checked by
+exact `logs_2` equality); baselines are taken at a quiesced moment so the oracle is
+coherent; no `sessions/` file is ever touched; restore is a manual decision, never
+automatic (I1).
 
 ### Rollback
 
-Restore the step-1 `.backup` set (consistent by construction) or the step-3 file
+Restore the step-1 snapshot backups (consistent by construction) or the step-3 file
 copies (byte-identical, taken at 0 holders).
 
 ### User-facing risk
 
 All codex panes terminate for the window (minutes); in-flight turns lost; panes
-restore from rollouts afterward. **Severity: Medium** (declared downtime), not "Low"
-(review 0b-5).
+restore from rollouts afterward. **Severity: Medium** (declared downtime).
 
 ---
 
 ## 6. Stage 1a — Exception/signal-safe teardown on server exit
 
-*(renamed from "crash-safe" — review 1a-1)*
+*(renamed from "crash-safe" — first review)*
 
 ### What `process.on('exit')` actually covers (honest enumeration)
 
@@ -305,11 +379,10 @@ of scope) — this stage narrows the orphan window; it does not close it.
    - app-server: pgid == `child.pid` (`processGroupId`, `runtime.ts:1291-1292`).
      Register on spawn. **Deregister only on confirmed group death** — after
      `teardownOwnedProcessGroup` returns `true` (`runtime.ts:692-734`), *not* at
-     wrapper exit (`:1533-1575`), which can leave live grandchildren untracked
-     (review 1a-2).
+     wrapper exit (`:1533-1575`), which can leave live grandchildren untracked.
    - resume pty: register `pty.pid` at both spawn sites (`terminal-registry.ts:1594`,
-     `:3694`). **Deregister on the pty's `exit` event**, not in `kill()` (`:4008` only
-     *sends* a signal — review 1a-2).
+     `:3694`). **Deregister on the pty's `exit` event**, not in `kill()` (`:4008`
+     only *sends* a signal).
 2. **Bindings** (installed once, near `index.ts:1147-1148`):
    - `process.on('exit', reapSync)` — synchronous best-effort
      `process.kill(-pgid, 'SIGKILL')` per still-registered group, try/catch'd.
@@ -317,20 +390,22 @@ of scope) — this stage narrows the orphan window; it does not close it.
      identity re-check (`/proc/<pid>/cmdline` contains codex) before signalling.
      **Residual pgid-reuse window:** the sync check-then-kill race is narrower than
      nothing but wider than the async reaper's fresh-classification
-     (`runtime.ts:698-711`); accepted at process-death time and documented
-     (review 1a-4).
+     (`runtime.ts:698-711`); accepted at process-death time and documented.
    - `process.on('SIGHUP', …)` — route into the existing graceful
-     `shutdown('SIGHUP')` (idempotent via `isShuttingDown`, `index.ts:1079`). Add a
-     **hard-exit timeout** to `shutdown()` so a throw from `joinCodexShutdownOwners`
-     (`:1102-1113` has no catch) cannot leave the process alive without ever reaching
-     `process.exit(0)` at `:1144` (review 1a-6).
+     `shutdown('SIGHUP')` (idempotent via `isShuttingDown`, `index.ts:1079`).
+   - **Hard-exit timeout (specified — second-review #9):** arm a **15 s** timer
+     (`.unref()`d) on `shutdown()` entry — **all three signals** (SIGTERM/SIGINT/
+     SIGHUP share the identical hang exposure at `:1102-1113`) — that calls
+     `process.exit(1)` if teardown hangs. Note: because `shutdown()` is invoked
+     un-awaited (`:1147-1148`), a *throw* from `joinCodexShutdownOwners` already dies
+     via unhandled rejection → `'exit'` → `reapSync`; the timer exists specifically
+     for the **hang** case.
    - `process.on('uncaughtExceptionMonitor', …)` — **observe/log only.** The default
      fatal behavior of `uncaughtException` is left in place; the fatal path then runs
      `'exit'` → `reapSync`.
-3. **Platform gating (review 1a-3):** negative-pid group kill and `/proc` checks are
-   POSIX/Linux; gate the registry's reap on POSIX and document Windows-host as out of
-   scope (consistent with the sidecar's existing Linux-only stance,
-   `assertUnixSidecarSupport`, `runtime.ts:360-364`).
+3. **Platform gating:** negative-pid group kill and `/proc` checks are POSIX/Linux;
+   gate the registry's reap on POSIX and document Windows-host as out of scope
+   (consistent with `assertUnixSidecarSupport`, `runtime.ts:360-364`).
 
 ### Why safe
 
@@ -339,20 +414,26 @@ nuke live panes (I3). At true termination the children's transport is dying anyw
 reaping prevents orphan accumulation. Guarded, synchronous, try/catch'd; cannot block
 boot (I4).
 
-### Acceptance tests (review F6, 1a-5)
+### Acceptance tests (made executable — second-review #7, #8)
 
-1. Dev server + ≥2 codex panes; terminate via `SIGHUP` and via normal exit →
-   **zero survivors from that instance**, scoped via the registry contents (or
-   matching `FRESHELL_CODEX_SIDECAR_ID` env in `/proc/<pid>/environ`) — *not* a bare
-   `pgrep` (prod + dev coexist).
-2. **Uncaught-exception test** (replaces v1's vacuous caught-exception test): throw an
-   uncaught exception → process dies → registered groups are gone. Separately assert
-   the I3 property at unit level: no code path signals a registered group while the
-   process is alive.
+1. Dev server + ≥2 codex panes. **Before termination, snapshot the registry** (a
+   structured log line, or a test-only endpoint, listing registered `{pid, pgid}`).
+   Terminate via `SIGHUP` and via normal exit → every snapshotted pid is gone.
+   Additionally scan surviving processes' `/proc/<pid>/environ` for
+   `FRESHELL_CODEX_SIDECAR_ID` (app-servers — `runtime.ts:1258`) **or**
+   `FRESHELL_TERMINAL_ID` (resume ptys — `terminal-registry.ts:1538`; ptys do **not**
+   carry the sidecar id) matching this instance → none found. (Bare `pgrep` cannot
+   scope to one instance — prod + dev coexist.)
+2. **Uncaught-exception test:** throw an uncaught exception → process dies →
+   snapshotted groups are gone. The I3 property is asserted **structurally** (not as
+   a universal negative): the group-kill primitive has exactly one caller
+   (`reapSync`), and `reapSync` is referenced only from the `'exit'` binding —
+   enforce with a unit/lint test on the module graph.
 3. `SIGKILL` the server → survivors expected; documented boundary (1b's job).
 4. **Empirical check:** verify whether the codex resume TUI exits on pty-master close
    (kernel SIGHUP). If codex ignores it, resume ptys outlive the server on paths 1a
-   doesn't cover — record the result; it sets 1b's priority (review 1a-5).
+   doesn't cover — record the result; it sets 1b's priority and 0b step 2's
+   straggler expectations.
 
 ### Rollback
 
@@ -368,7 +449,7 @@ None in steady state. SIGHUP now tears down a dev server left in a closing termi
 
 ## 7. Stage 1c — Startup reaper: complete fail-open + minimal observability
 
-### Change (review F2, 1c-1..4; G4, G6)
+### Change
 
 1. **Per-record isolation.** Wrap the *per-record* body of the reap loop
    (`runtime.ts:808-848`) in try/catch so an unreadable record file (`:811` —
@@ -378,55 +459,76 @@ None in steady state. SIGHUP now tears down a dev server left in a closing termi
    `:360-379`) as **degrade-and-continue** (log, skip reaping this boot), not aborts.
 2. **Backstop.** try/catch around the `runCodexStartupReaper` call at `index.ts:256`:
    log and continue. Boot must never die in the reaper (I4).
-3. **Quarantine — only for provably-dead or unparseable records (review 1c-2).**
-   - Owner PID **provably dead** (`isPidAlive` false) but group unkillable, or record
-     unparseable → move to `~/.freshell/codex-sidecars/quarantine/` (atomic rename;
-     preserve `0600` — records embed command lines and cwd's, review G6) with a
-     `{ reason, firstSeen, attempts }` note.
-   - Owner **alive but identity-mismatched** (`runtime.ts:826-831` — reachable via
-     transient `/proc` races) → **retry in place** with time-based backoff keyed on
-     `firstSeen`. Never quarantine a possibly-live sidecar's only tether — that would
-     mint a permanent, invisible DB holder (the exact leak this plan fights).
-   - Retry semantics are **time-based, not boot-count-based** (review 1c-3): the
-     shared `~/.freshell/codex-sidecars` dir serves prod + dev, and a dev server under
-     `tsx watch` can boot dozens of times an hour. On concurrent boots, rename-ENOENT
-     = the other instance won; treat as success.
-4. **Remove the fail-closed assert.** `assertCodexStartupReaperSucceeded`
-   (`runtime.ts:863-876`) is deleted/reduced to a warning aggregator. **Test impact
-   is a contract inversion, not an update** (review 1c-4): ~8 tests in
-   `test/unit/server/coding-cli/codex-app-server/runtime.test.ts` assert the throwing
-   contract, plus the exported alias `reapOrphanedCodexAppServerSidecarsOnStartup`
-   (`runtime.ts:861`) — rewrite them to assert no-throw + quarantine/backoff behavior.
-5. **Boot-time observability line (review G4 — promoted into scope, ~10 lines).** At
-   every boot (and hourly thereafter on a timer), log one structured line:
-   `codex-log-db: wal_bytes=<stat of logs_2.sqlite-wal> holders=<count via /proc fd scan> quarantined=<n>`
-   with a `warn` if `wal_bytes > 500 MB` or holders exceed a threshold. Read-only:
+3. **Quarantine — only for records whose process group is confirmed GONE, or
+   unparseable records (second-review blocking #2).**
+   - **Unparseable/corrupt record** → quarantine (nothing to retry against).
+   - **Owner dead + group confirmed gone** → normal happy path (record deleted).
+   - **Owner dead but group STILL ALIVE** (`teardownOwnedProcessGroup` returned
+     `false` — the group survived SIGTERM+SIGKILL, `runtime.ts:714-729`, e.g. a codex
+     process in D-state I/O against the bloated WAL — this incident's exact
+     signature) → **NEVER quarantine.** The record is the only tether to a live DB
+     holder; retry in place with backoff.
+   - **Owner alive but identity-mismatched** (`runtime.ts:826-831` — reachable via
+     transient `/proc` races) → retry in place with backoff.
+   - **Safety net:** each boot, the reaper also **rescans `quarantine/`** for records
+     whose pgid is still alive and promotes them back for retry (no permanent
+     invisible holder can hide there).
+   - Quarantine moves are atomic renames preserving `0600` (records embed command
+     lines and cwd's — review G6), with a `{ reason, firstSeen, attempts }` note.
+4. **Backoff state — concrete home (second-review #4).** Retry state lives in a
+   sidecar file **`<record>.reaper.json`** next to the ownership record (atomic
+   write, `0600`, `{ firstSeen, attempts, lastAttempt }`; `firstSeen` falls back to
+   the record's mtime). It is written only by the reaper, so it cannot race the
+   owning server's own record rewrites (`runtime.ts:1297-1300`). Semantics: the
+   per-boot reap attempt **always runs**; backoff gates only **log escalation**
+   (info→warn after N attempts) and the **hourly** re-attempt frequency (below) — it
+   never defers the boot-time decision. Time-based (keyed on `firstSeen`), so shared
+   prod+dev dirs and `tsx watch` restart storms cannot burn the budget; on concurrent
+   boots, rename-ENOENT = the other instance won (treat as success).
+5. **Observability — concrete home (second-review #4; review G4).** New module
+   **`server/coding-cli/codex-observability.ts`**, started from `index.ts` at boot:
+   emits one structured line at boot and then on an **hourly `setInterval(...).unref()`**
+   timer:
+   `codex-log-db: wal_bytes=<stat logs_2.sqlite-wal> holders=<count via /proc fd scan> quarantined=<n>`
+   with `warn` when `wal_bytes > 500 MB` or holders exceed a threshold. Read-only —
    `stat` + `/proc` fd scan; **never opens the SQLite DB, never signals anything.**
-   This converts every silent failure mode in this plan (0a ineffective, 1c orphan,
-   regrowth) into a detectable one.
+   This module also hosts the hourly retry of live-group records (step 3/4) and the
+   quarantine rescan trigger. Converts every silent failure mode in this plan (0a
+   ineffective, 1c lingering holder, regrowth) into a detectable one.
+6. **Remove the fail-closed assert.** `assertCodexStartupReaperSucceeded`
+   (`runtime.ts:863-876`) is deleted/reduced to a warning aggregator. **Test impact
+   is a contract inversion:** ~12 assertion sites in
+   `test/unit/server/coding-cli/codex-app-server/runtime.test.ts` (`:1440-1787`)
+   assert the throwing contract — rewrite to assert no-throw + quarantine/backoff
+   behavior. The exported alias `reapOrphanedCodexAppServerSidecarsOnStartup`
+   (`runtime.ts:861`) is referenced nowhere (including tests) — delete it.
 
 ### Why safe
 
 Fail-open at every layer (I4); reap decisions still require the same ownership proof
-(I3 unchanged); quarantine can no longer orphan a live sidecar's record; the monitor
-is observation-only.
+(I3 unchanged); quarantine can no longer hide a live process (confirmed-gone-only +
+rescan); the monitor is observation-only.
 
 ### Acceptance tests
 
-1. Seed an un-reapable-but-dead record → server boots; record quarantined `0600`;
-   warning logged.
+1. Seed a record for a dead owner whose group is gone but the record is stale →
+   server boots; record quarantined `0600`; warning logged.
 2. Seed an **unreadable** record file (chmod 000) → server boots; that record
    isolated; others still processed.
 3. Simulate `/proc` proof unavailable → server boots; reaping skipped with a warning.
-4. Seed an alive-but-mismatched record → retried in place with backoff; **not**
-   quarantined; still present next boot.
-5. Reapable orphan → still reaped exactly as before.
-6. Boot line appears with correct WAL size/holder count against fixtures; `warn`
+4. Seed an alive-but-mismatched record → retried in place with backoff state in
+   `<record>.reaper.json`; **not** quarantined; still present next boot.
+5. Seed an owner-dead-**group-alive** record (mock teardown returning `false`) →
+   **not** quarantined; retried; hourly timer re-attempts.
+6. Plant a quarantined record whose pgid is alive → rescan promotes it back for
+   retry.
+7. Reapable orphan → still reaped exactly as before.
+8. Boot line appears with correct WAL size/holder count against fixtures; `warn`
    fires above thresholds; verify the monitor holds no fd on the SQLite files.
 
 ### Rollback
 
-Restore the assert (one function); disable the boot line.
+Restore the assert (one function); disable the observability module.
 
 ### User-facing risk
 
@@ -435,7 +537,7 @@ boot. Strictly better availability. **Severity: Low, net-positive.**
 
 ---
 
-## 8. Deploy choreography (review G2)
+## 8. Deploy choreography (ordering reconciled — second-review #10)
 
 Deploying 0a/1a/1c requires restarting freshell — **prod and dev both** (both hold
 the DB). A restart is itself a pane-recycling event (graceful teardown + restore-all).
@@ -443,9 +545,12 @@ Sequence the whole rollout as **one declared window**:
 
 1. Merge 0a (if §3 validated) + 1a + 1c.
 2. Announce the maintenance window (§5 framing).
-3. Restart/stop both servers → run the **0b runbook** (servers stay stopped through
-   step 7) → restart both servers.
-4. Post-checks: pane reaches `Ready`; boot observability line shows
+3. **Run the 0b runbook from its step 1.** Note the ordering inside 0b: the
+   snapshot backups (step 1) happen **while writers are still live, before the
+   servers stop** (step 2); the servers then remain stopped through step 7.
+4. *(Optional)* run the §3 isolated-holder measurement in the 0 holders window.
+5. Restart both servers (0b step 8).
+6. Post-checks: pane reaches `Ready`; boot observability line shows
    `wal_bytes≈0, holders == 2×(open codex panes)`; over the next day, the hourly line
    shows WAL bounded (0a working) or growing (0a failed → §10).
 
@@ -454,7 +559,7 @@ Sequence the whole rollout as **one declared window**:
 ```
 §3 validation experiment  ──►  0a implementation (only if a candidate passes)
 1a, 1c                    ──►  independent; implement in parallel with §3
-merge (0a?, 1a, 1c)       ──►  §8 window: stop servers → 0b → restart
+merge (0a?, 1a, 1c)       ──►  §8 window: 0b (backups live → stop → clean → restart)
 boot/hourly observability ──►  ships inside 1c; watches everything afterward
 ```
 
@@ -469,39 +574,46 @@ boot/hourly observability ──►  ships inside 1c; watches everything afterwa
 - **Holders remain by design** (I2/I3): ~2 codex processes per open pane keep the DB
   open around the clock. This plan does not change that.
 - **If §3 validates a knob:** WAL churn ≈ 0; the cliff should not recur before
-  Stage 2 lands. Remaining exposure: the unvalidated-in-production knob (watched by
-  the hourly line) and codex-internal behavior changes on upgrade.
+  Stage 2 lands. Remaining exposure: the knob's behavior under codex upgrades
+  (watched by the hourly line).
 - **If §3 fails:** churn continues at ~22 MB/min of active use; the WAL re-approaches
   the cliff in **days-to-weeks**. The observability line makes this loudly visible
-  (500 MB warn threshold ≈ weeks of margin before the ~5 GB wedge), and 0b can be
-  re-run as a stopgap during any maintenance window. Stage 2 (shared app-server,
-  holders==1) becomes urgent and should be scheduled immediately.
+  (500 MB warn threshold ≈ weeks of margin before the ~5 GB wedge), 0b can be re-run
+  as a stopgap during any maintenance window, and the §3 measurements ship with the
+  upstream issue. Stage 2 (shared app-server, holders==1) becomes urgent.
 - 1a/1c reduce orphan accumulation and boot fragility but do not change WAL
   mechanics.
 
-## 11. Constraint traceability (corrected)
+## 11. Constraint traceability
 
 | Constraint | Honored by |
 |---|---|
-| I1 lossless | 0b: online-consistent backups, checkpoint/VACUUM only, exact `logs_2` row/`max(id)` equality check, **no auto-restore**; 1a/1c reap processes, never data; rollouts remain source of truth |
+| I1 lossless | 0b: snapshot-consistent backups (`VACUUM INTO` for the churning DB), checkpoint/VACUUM only, exact `logs_2` row/`max(id)` equality check (schema-verified), **no auto-restore**; 1a/1c reap processes, never data; rollouts remain source of truth |
 | I2 no cap | No stage limits panes; observability is read-only |
-| I3 no live-pane kills (steady state) | 1a binds `exit` (cannot fire on recoverable errors), monitor observe-only; 1c reaps only proven-dead owners, retries ambiguity in place; idle-reaper attached-pane skip untouched. **0b is the one declared, consented exception** (maintenance window, §5) — not claimed otherwise |
-| I4 no new won't-launch | 1c: per-record isolation + degrade-and-continue + backstop try/catch (covers `:800`, `:803-806`, `:811`, `:863-876`); 0a additive; 1a exit-path only, try/catch'd |
-| I5 telemetry tradeoff | 0a documented, only-if-unset (incl. `''`), kill switch (restart required — stated honestly) |
+| I3 no live-pane kills (steady state) | 1a binds `exit` (cannot fire on recoverable errors) with the structural single-caller assertion; monitor observe-only; 1c reaps only with the same ownership proof, retries ambiguity in place, and can no longer hide a live group in quarantine; idle-reaper attached-pane skip untouched. **0b is the one declared, consented exception** (maintenance window, §5) |
+| I4 no new won't-launch | 1c: per-record isolation + degrade-and-continue + backstop try/catch (covers `:800`, `:803-806`, `:811`, `:863-876`); 0a additive; 1a exit-path only, try/catch'd, hard-exit timer bounded |
+| I5 telemetry tradeoff | 0a documented, only-if-unset (incl. `''`), skip-logged, kill switch (restart required — stated honestly) |
 
 ## 12. Definition of done
 
-1. **§3:** a documented pass/fail result for each candidate; 0a proceeds only on a
-   pass (≥90% byte reduction on the representative workload).
+1. **§3:** a documented pass/fail per candidate using the prune-immune metric,
+   including the exact final directive string; 0a proceeds only on a pass (≥90%
+   write-traffic reduction on the representative workload).
 2. **0a (if implemented):** acceptance re-run post-deploy passes; unit tests green
    (incl. `''`-preset, kill switch, `this.env`, sidecar-id preservation, non-codex
-   modes untouched); TUI `Ready` + turn completes.
-3. **0b:** integrity `ok`; `logs_2` rows/`max(id)` exactly equal step-4 baseline;
-   other counts ≥ baseline with deltas explained; `sessions/` count unchanged;
-   holders 0 at completion; WAL 0 bytes; ~2 GB reclaimed; no auto-restore occurred.
-4. **1a:** SIGHUP/normal-exit → zero survivors (registry-scoped assertion);
-   uncaught-exception path reaps; pty-master-close behavior of codex recorded;
-   POSIX-gated; Windows documented out of scope.
-5. **1c:** all six acceptance tests pass, including the three formerly-fatal boot
-   paths; test-suite contract inversions completed; boot/hourly observability line
-   live with thresholds.
+   modes untouched, skip-warn emitted); TUI `Ready` + turn completes.
+3. **0b:** integrity `ok`; `logs_2` `count(*)` (and `max(id)` if schema-verified)
+   exactly equal step-4 baseline; other counts ≥ baseline with deltas explained;
+   `sessions/` count unchanged; holders 0 at completion; WAL 0 bytes; **disk
+   reclaimed ≈ prior WAL size + vacuumed dead pages (measured figure recorded)**;
+   no auto-restore occurred.
+4. **1a:** SIGHUP/normal-exit → zero survivors (registry-snapshot + environ-scan
+   assertion incl. `FRESHELL_TERMINAL_ID` for ptys); uncaught-exception path reaps;
+   structural single-caller assertion in place; 15 s hard-exit timer on all three
+   signals; pty-master-close behavior of codex recorded; POSIX-gated; Windows
+   documented out of scope.
+5. **1c:** all eight acceptance tests pass, including the three formerly-fatal boot
+   paths, the owner-dead-group-alive no-quarantine case, and the quarantine rescan;
+   test-suite contract inversions completed (~12 sites) and the unreferenced alias
+   deleted; boot/hourly observability line live with thresholds from
+   `codex-observability.ts`.

--- a/docs/plans/2026-07-06-codex-launch-leak-remediation-plan.md
+++ b/docs/plans/2026-07-06-codex-launch-leak-remediation-plan.md
@@ -1,0 +1,330 @@
+# Codex Launch-Leak Remediation Plan — Stage 0a/0b + 1a/1c
+
+**Date:** 2026-07-06
+**Target:** freshell `main @ 02f95b70` (TypeScript/Node server)
+**Status:** Plan — not yet implemented
+**Scope:** The four near-term, no-regret items. Follow-ups (resume-TUI boot reaper "1b",
+shared-app-server architecture "Stage 2", read-only WAL monitor) are out of scope here and
+tracked separately.
+
+---
+
+## 1. Problem
+
+Codex CLI intermittently wedges on launch (blocks forever in `futex_wait_queue` while
+opening `~/.codex/logs_2.sqlite`). Root cause is a self-reinforcing loop driven by
+freshell:
+
+1. **Per-pane codex processes held open forever.** freshell spawns, **per pane**:
+   - one `codex app-server --listen ws://…` via `child_process.spawn(..., { detached: true })`
+     — `server/coding-cli/codex-app-server/runtime.ts:1246-1261`
+   - one `codex … resume <uuid>` node-pty — `server/terminal-registry.ts:1592-1600`
+     (recovery re-spawn at `:3694-3700`)
+
+   With ~10 panes attached, 19+ codex processes hold `logs_2.sqlite` open continuously.
+   SQLite can only truncate its WAL when **zero** connections hold the DB, so the WAL can
+   never truncate.
+
+2. **TRACE log firehose.** codex is spawned with no log-level env
+   (`runtime.ts:1255-1259` — no `RUST_LOG`), so it persists TRACE-level tracing
+   (dominated by inotify file-OPEN events) into that DB at ~27–56 MB/min while a
+   session is active.
+
+Together: the WAL grows unbounded (~5 GB over ~10 days), and a new `codex` launch then
+blocks on the SQLite lock/WAL index and never finishes init.
+
+**Amplifiers (addressed by 1a/1c here; 1b later):**
+- `detached: true` children orphan to init on ungraceful server exit; teardown only runs
+  on graceful `SIGTERM`/`SIGINT` (`server/index.ts:1147-1148`).
+- On reboot the client re-creates every pane (restore-all), spawning a fresh full set on
+  top of any orphans.
+- The startup reaper covers app-servers only, and **throws** on an un-reapable record
+  (`runtime.ts:863-876` → `index.ts:1151-1154` `process.exit(1)`), which can hard-block
+  freshell's own boot — a self-inflicted "won't launch."
+
+**Out of scope / codex-internal:** even with a clean DB, `codex doctor` synchronously
+scans all ~6,000 rollout files ("Checking thread inventory…"). That lives in the codex
+binary; it is excluded from this plan's acceptance gate (upstream ask).
+
+## 2. Hard constraints (design invariants)
+
+- **I1 — Lossless.** Never delete or risk Codex sessions/long-term state
+  (`~/.codex/sessions/`, goals, memories, thread graph). Cleanup = checkpoint/VACUUM
+  only, behind a verified backup. Never `rm` live data (including `-wal` files).
+- **I2 — No cap.** Unlimited simultaneous panes is the product's core value. Nothing in
+  this plan limits pane/session count.
+- **I3 — Never touch a live pane.** No teardown/reaper may signal a client-attached pane,
+  especially one with an in-flight turn. The idle reaper's `clients.size > 0` skip
+  (`terminal-registry.ts:1409-1422`) stays intact.
+- **I4 — Never fail-closed at boot.** No fix may introduce a new "won't launch" path.
+- **I5 — Accepted tradeoff.** Log dampening thins codex `/feedback` telemetry.
+
+---
+
+## 3. Stage 0a — Codex spawn-env log dampening
+
+### Change
+
+New shared helper, applied at both codex spawn paths. Sets a quiet log level **only if
+the operator hasn't set one**.
+
+```ts
+// server/coding-cli/codex-log-dampening.ts  (new, ~15 lines + tests)
+export const CODEX_DEFAULT_LOG_LEVEL = 'error' // single tunable
+
+export function withCodexLogDampening<T extends NodeJS.ProcessEnv>(env: T): T {
+  const userSet = env.RUST_LOG ?? process.env.RUST_LOG
+  if (userSet && userSet.trim() !== '') return env // never clobber an explicit choice
+  if (process.env.FRESHELL_CODEX_LOG_DAMPENING === '0') return env // kill switch
+  return { ...env, RUST_LOG: CODEX_DEFAULT_LOG_LEVEL }
+}
+```
+
+Call sites:
+
+1. **App-server spawn** — `runtime.ts:1255-1259`: wrap the env object:
+   `env: withCodexLogDampening({ ...process.env, ...this.env, FRESHELL_CODEX_SIDECAR_ID: ownershipId })`
+2. **Resume-TUI spawn** — inside `buildSpawnSpec` (`terminal-registry.ts:~1059`), applied
+   to the returned `env` **only when the pane mode is codex**. This single site covers
+   both `pty.spawn` consumers (`:1594` primary, `:3694` recovery).
+
+Optional refinement (validate during acceptance): if codex honors a config-level override
+(e.g. `-c log.level="error"` alongside `CODEX_MANAGED_REMOTE_CONFIG_ARGS`,
+`runtime.ts:1248`), prefer it for the app-server path; keep `RUST_LOG` as the universal
+fallback for both paths.
+
+### Why safe
+
+- Purely additive env; no lifecycle change; no effect on pane count (I2) or boot (I4).
+- Only-if-unset guard: a developer running `RUST_LOG=debug` is never silently overridden.
+- `RUST_LOG` gates codex's tracing subsystem — the thing that fills `logs_2.sqlite`.
+  Sessions/goals/memories/thread-graph are written by normal code paths, not tracing (I1).
+
+### Acceptance test
+
+1. Open one codex pane; sample `stat -c%s ~/.codex/logs_2.sqlite-wal` every 30 s for
+   5 min, with and without the helper. **Pass:** growth drops from ~27–56 MB/min to
+   near-zero. **If it does not drop:** codex's SQLite sink isn't gated by `RUST_LOG` —
+   record findings, file the upstream ask, and treat 0a as cosmetic (0b still buys time;
+   Stage 2 remains the structural fix).
+2. Unit test: helper is a no-op when `RUST_LOG` is preset or the kill switch is set.
+3. Launch check: codex TUI still reaches `Ready`; new rollout file still appears.
+
+### Rollback
+
+Set `FRESHELL_CODEX_LOG_DAMPENING=0` (no redeploy) or revert the two call sites.
+
+### User-facing risk
+
+Codex `/feedback` bug reports carry sparse traces (I5, accepted). Masks — does not fix —
+whatever generates the inotify storm (upstream ask). **Severity: Low.**
+
+---
+
+## 4. Stage 0b — One-time lossless cleanup (operational runbook)
+
+Reclaims the current bloat (multi-hundred-MB regrowing WAL + ~2.24 GB dead pages inside
+the 6 GB `logs_2.sqlite`) without losing a single row. Run **after** 0a is deployed so
+regrowth is pre-dampened.
+
+### Runbook (ordered; each step gates the next)
+
+1. **Backup + baseline.** Copy `~/.codex/{logs_2,state_5,goals_1,memories_1}.sqlite*`
+   (keep `.sqlite` + `-wal` + `-shm` together) plus `history.jsonl`, `auth.json`,
+   `config.toml` to a timestamped dir on the same filesystem. Run
+   `PRAGMA integrity_check` on each copied DB (expect `ok`). Record baseline row counts
+   as the restore oracle: `sessions/` file count, `goals_1.thread_goals`,
+   `state_5.threads`, `state_5.thread_spawn_edges`, `memories_1.stage1_outputs/jobs`.
+   (A verified backup from 2026-07-06 exists at `/home/dan/codex-backup-20260706_023506`;
+   make a fresh one anyway — cheap.)
+2. **Reap codex processes only — guarded.** Build the kill set from
+   `lsof ~/.codex/logs_2.sqlite` filtered to codex cmdlines
+   (`codex-linux-x64/vendor`, `app-server`, `resume`), plus their immediate codex
+   wrappers. **Protected-PID guard:** never signal freshell prod/dev servers, amplifier,
+   or the operator shell's ancestry — abort if any protected PID lands in the set.
+   **Dry-run and print the set first.** SIGTERM, wait ~4 s, SIGKILL stragglers.
+3. **Reach 0 holders.** `lsof ~/.codex/logs_2.sqlite` must be empty. If a live freshell
+   server keeps respawning codex children into the window: briefly `SIGSTOP` **only the
+   non-ancestry respawner**, with a guaranteed `SIGCONT` in a `trap`/`finally`; re-reap;
+   proceed. (Never stop a server in the operator's own process ancestry.)
+4. **Checkpoint — never rm.** For each `~/.codex/*.sqlite` with a non-empty `-wal`
+   (do `memories_1` before trusting any "0 rows" reading):
+   `PRAGMA busy_timeout=15000; PRAGMA wal_checkpoint(TRUNCATE);`
+5. **Compact.** `VACUUM;` on `logs_2.sqlite` (reclaims the ~2.24 GB free pages; needs
+   0 holders + free disk ≈ DB size — currently ~170 GB free, fine).
+6. **Verify.** `PRAGMA integrity_check` = `ok` on all live DBs; every baseline row count
+   matches; `sessions/` file count unchanged (± legitimately new sessions); holders = 0;
+   `logs_2.sqlite-wal` = 0 bytes; codex TUI launches to `Ready`.
+7. Resume the SIGSTOP'd server (already guaranteed by trap); confirm freshell panes
+   reconnect.
+
+### Why safe
+
+WAL is *folded into* the main DB (`wal_checkpoint(TRUNCATE)`), never deleted; `VACUUM`
+is lossless; every step is gated behind a verified backup + integrity check + row-count
+equality (I1). Only codex processes are signalled, orphaned/crashed ones at that; live
+freshell servers and attached panes are protected by the guard (I3).
+
+### Rollback
+
+Restore the timestamped backup (byte-identical copies taken while 0 holders).
+
+### User-facing risk
+
+Seconds-long pause of one respawning server during the checkpoint window; codex panes
+briefly unavailable while their (already-wedged/orphaned) processes are reaped.
+**Severity: Low.**
+
+---
+
+## 5. Stage 1a — Crash-safe teardown on server exit
+
+### Change
+
+Today, codex child teardown only runs from the async `shutdown()` on `SIGTERM`/`SIGINT`
+(`index.ts:1147-1148`). A crash, `SIGKILL`-adjacent exit, or `SIGHUP` leaves every
+`detached: true` app-server and resume pty orphaned. Add a best-effort, **synchronous**
+process-group reap bound to true exit paths:
+
+1. **Registry.** A small module (e.g. `server/coding-cli/codex-child-registry.ts`)
+   tracking `{ pid, pgid, kind }` for every codex child freshell spawns:
+   - app-server: pgid == `child.pid` (already captured as `processGroupId`,
+     `runtime.ts:1291-1292`) — register on spawn, deregister in the existing exit handler
+     (`runtime.ts:1533-1575`) and ownership teardown.
+   - resume pty: register `pty.pid` at both spawn sites (`terminal-registry.ts:1594`,
+     `:3694`), deregister on pty exit and in `kill()` (`:3997-4035`).
+2. **Bindings** (installed once, alongside `index.ts:1147-1148`):
+   - `process.on('exit', reapSync)` — synchronously best-effort
+     `process.kill(-pgid, 'SIGKILL')` for each still-registered group, wrapped in
+     try/catch. Guard: never signal `-1`, `0`, `1`, or our own pgid; only pgids we
+     registered. Where cheap, re-verify identity (e.g. `/proc/<pid>/cmdline` contains
+     codex) before signalling to defend against pgid reuse.
+   - `process.on('SIGHUP', …)` — route into the existing graceful `shutdown('SIGHUP')`.
+   - `process.on('uncaughtExceptionMonitor', …)` — **observe/log only.** Never kill.
+3. **Idempotency.** The existing async shutdown path drains the registry as it tears
+   children down (`joinCodexShutdownOwners`, `index.ts:1104-1109`), so `reapSync` at
+   `exit` is a no-op after a clean shutdown.
+
+Explicitly **not** bound to `uncaughtException`: `exit` cannot fire on a recoverable,
+caught error, so a survivable blip can never nuke live panes (I3).
+
+### Why safe
+
+- `exit` fires only when the process is genuinely terminating — at which point the
+  children's sockets are dying anyway and their in-flight turns are already lost with the
+  server; reaping them prevents orphan accumulation without touching any live pane (I3).
+- Synchronous, guarded signalling of only-our-own pgids; cannot throw out of the exit
+  path; cannot block boot (I4).
+
+### Acceptance test
+
+1. Start the dev server with ≥2 codex panes; terminate with `SIGHUP` and with a normal
+   exit → `pgrep -f 'codex-linux-x64/vendor'` shows zero survivors from that instance;
+   `lsof ~/.codex/logs_2.sqlite` shows no holders owned by it.
+2. Throw a caught-and-handled exception in a request handler → **all panes stay alive**
+   (I3 regression guard).
+3. `SIGKILL` the server → survivors expected (documented boundary; closed by follow-up
+   1b, out of scope here).
+
+### Rollback
+
+Remove the three listeners (single module); behavior reverts to SIGTERM/SIGINT-only.
+
+### User-facing risk
+
+Removes any accidental "app-server survives a dead server" reattach behavior — durable
+state lives in on-disk rollouts, so the next launch resumes losslessly (I1). SIGHUP now
+tears down a dev server left in a closing terminal (previously it might linger).
+**Severity: Low.**
+
+---
+
+## 6. Stage 1c — Startup reaper: log-and-continue (fail-open)
+
+### Change
+
+`assertCodexStartupReaperSucceeded` throws when any sidecar ownership record can't be
+classified/reaped (`runtime.ts:863-876`). It is `await`ed before `server.listen`
+(`index.ts:256`), and the throw propagates to `main().catch → process.exit(1)`
+(`index.ts:1151-1154`) — the whole server refuses to boot because one stale JSON record
+was ambiguous. That is a self-inflicted "won't launch" (violates I4).
+
+Replace fail-closed with fail-open:
+
+1. In `runCodexStartupReaper` / its caller: for each record classified `failed` /
+   `indeterminate` / `unreadable`:
+   - log a structured `warn` with the record path, classification, and reason;
+   - **move the record to `~/.freshell/codex-sidecars/quarantine/`** (atomic rename)
+     with a `{ reason, firstSeen, attempts }` sidecar note;
+   - continue.
+2. Delete `assertCodexStartupReaperSucceeded` (or reduce it to a warning aggregator).
+   Startup proceeds unconditionally.
+3. Bounded retry: on each subsequent boot, re-attempt quarantined records (increment
+   `attempts`, give up permanently after e.g. 5, leaving the record for manual review).
+4. Expose the quarantine count via the existing logger/metrics so the (future) monitor
+   can surface it.
+
+### Why safe
+
+The correct worst case for an ambiguous orphan is "one possibly-orphaned sidecar lingers,
+flagged" — never "no server at all" (I4). Quarantining prevents boot-loop churn on a
+permanently bad record. No change to what gets killed (I3): reap decisions still require
+the same ownership proof; we only change what happens when proof is unavailable.
+
+### Acceptance test
+
+1. Seed a deliberately un-reapable ownership record (e.g. valid JSON pointing at a live
+   PID that fails the ownership proof) → server boots to ready; record lands in
+   `quarantine/`; warning logged; no `process.exit(1)`.
+2. Seed a reapable orphan record → still reaped exactly as before (no regression).
+3. Existing reaper unit tests updated: no-throw contract.
+
+### Rollback
+
+Restore the throw (revert one function); quarantine dir is inert.
+
+### User-facing risk
+
+On an ambiguous record the server now starts with a possibly-lingering orphan (flagged,
+retried next boot) instead of refusing to start. Strictly better availability.
+**Severity: Low, net-positive.**
+
+---
+
+## 7. Sequencing
+
+```
+0a (code)  ──►  deploy  ──►  0b (runbook, once)
+1a (code)  ──┐
+1c (code)  ──┴─►  same PR or sibling PRs; independent of each other and of 0a
+```
+
+- 0a first, then 0b, so the WAL doesn't regrow at firehose rate behind the cleanup.
+- 1a and 1c are independent of 0a/0b and of each other; land in any order.
+- Follow-ups (not in this plan): 1b (durable resume-TUI ownership + boot-reaper
+  coverage — closes the `SIGKILL` boundary left by 1a), Stage 2 (single shared
+  app-server; holders == 1 regardless of pane count — the permanent structural fix),
+  read-only WAL/holder monitor, upstream codex asks (bound own WAL; stop TRACE inotify
+  persistence; lazy thread-inventory scan; documented log-level knob).
+
+## 8. Constraint traceability
+
+| Constraint | Honored by |
+|---|---|
+| I1 lossless | 0b: checkpoint/VACUUM only, verified backup + integrity + row-count oracle; 1a: reaps processes, never data; rollouts remain source of truth |
+| I2 no cap | No stage limits panes; 0a/1a/1c don't touch pane creation |
+| I3 no live-pane kills | 1a binds `exit` (can't fire on recoverable errors), `uncaughtExceptionMonitor` observe-only; 0b protected-PID guard + dry-run; idle-reaper attached-pane skip untouched; 1c changes only the no-proof branch |
+| I4 no new won't-launch | 1c removes the fail-closed boot throw; 0a additive env; 1a exit-path only, try/catch'd |
+| I5 telemetry tradeoff | 0a documented, only-if-unset, kill switch, single tunable |
+
+## 9. Definition of done
+
+1. **0a:** WAL growth with an active codex pane drops to near-zero (measured); helper
+   no-op when `RUST_LOG` preset; TUI reaches `Ready`.
+2. **0b:** integrity `ok` on all DBs; all baseline row counts match; `sessions/` count
+   unchanged; holders 0 at completion; `logs_2.sqlite-wal` 0 bytes; `logs_2.sqlite`
+   shrunk by ~2 GB.
+3. **1a:** SIGHUP/normal exit leaves zero codex survivors; caught exception kills no
+   panes.
+4. **1c:** server reaches ready with an un-reapable record present; record quarantined
+   and logged; reapable orphans still reaped.

--- a/docs/plans/2026-07-06-codex-launch-leak-remediation-plan.md
+++ b/docs/plans/2026-07-06-codex-launch-leak-remediation-plan.md
@@ -100,7 +100,14 @@ documented log-level knob.
 
 ---
 
-## 3. Stage 0-pre — Validate the dampening mechanism (BLOCKS 0a implementation)
+## 3. Stage 0-pre — Validate the dampening mechanism (RESOLVED 2026-07-06: ALL CANDIDATES FAILED — 0a DROPPED)
+
+> **Outcome:** the full protocol was run the same night (see
+> `2026-07-06-codex-launch-leak-s3-validation-results.md`). Best candidate
+> achieved −25% vs the ≥90% bar; `RUST_LOG=off` proved the sink ignores the env
+> filter entirely. **Candidate 3 (the drop path) is invoked: 0a is dropped**,
+> the upstream issue is drafted in the results doc, and protection reduces to
+> 0b + 1c observability + 1a/1c, with Stage 2 as the load-bearing fix.
 
 The v1 plan bet its sequencing on `RUST_LOG=error` gating codex's SQLite log sink.
 The first review demanded validation before implementation; an initial experiment was
@@ -172,7 +179,7 @@ and stands.
   incrementally attributed insert bytes) vs the same-evening undampened control, and
   the pane still functions (turn completes, rollout file written).
 
-## 4. Stage 0a — Codex spawn-env log dampening (conditional on §3)
+## 4. Stage 0a — Codex spawn-env log dampening (DROPPED — §3 candidates all failed; retained for reference)
 
 ### Change
 

--- a/docs/plans/2026-07-06-codex-launch-leak-s3-validation-results.md
+++ b/docs/plans/2026-07-06-codex-launch-leak-s3-validation-results.md
@@ -1,0 +1,77 @@
+# §3 Validation Results — Codex Log-Dampening Candidates (FINAL: 0a DROPPED)
+
+**Date:** 2026-07-06 (evening/night)
+**Protocol:** plan v2.1 §3, prune-immune **incremental insert attribution** — poll
+`max(id)` every 1 s on a `mode=ro` connection; accumulate new rows/`estimated_bytes`
+for the test process's `process_uuid` (`pid:<rustpid>:%`) as they appear, counting
+inserts before the per-process ~1,000-row prune can delete them.
+**Workload:** hand-spawned idle codex TUI (codex-cli 0.142.5), cwd=$HOME, real pty
+(`script -qec`), ~200–240 s windows, same machine/evening. (Screening-length windows;
+the full 15-min freshell-pane-pair run is moot given the magnitude of the failures.)
+
+## Results
+
+| Window | Invocation | Rows | Bytes | Dur | Bytes/s | vs control |
+|---|---|---|---|---|---|---|
+| control | `codex` | 27,875 | 4,271,823 | 239 s | 17,874 | — |
+| composite env | `RUST_LOG=codex_cli=info,codex_core=info,codex_login=info,log=off codex` | 22,086 | 3,487,579 | 238 s | 14,654 | **−18%** |
+| feedback off | `codex -c feedback.enabled=false` | 15,978 | 2,663,386 | 199 s | 13,384 | **−25%** |
+| env fully off | `RUST_LOG=off codex` | 16,630 | 2,751,392 | 199 s | 13,827 | **−23%** |
+| snapshot off | `codex -c features.shell_snapshot=false` | 20,027 | 3,202,531 | 199 s | 16,093 | **−10%** |
+
+Pass bar: **≥90% reduction**. Best candidate: −25%. **All candidates FAIL.**
+
+## Interpretation
+
+- `RUST_LOG=off` silences the *entire* env-filter layer, yet the sink still wrote
+  ~14 KB/s. Conclusion: **codex's SQLite feedback sink does not consult the
+  `RUST_LOG` env filter.** It is an always-on flight recorder (the
+  `bounded_feedback_logs` design) with its own hardcoded TRACE-level capture.
+  The 10–25% deltas are window variance and partial upstream effects, not gating.
+- `feedback.enabled=false` gates feedback *upload* ("sending feedback is disabled by
+  configuration"), not capture.
+- `features.shell_snapshot=false` did not stop the `shell_snapshot` TRACE spam
+  observed in surviving rows.
+- Supporting evidence from round 1: rows tagged `TRACE|log|shell_snapshot…`
+  persisted through an explicit `log=off` directive.
+- `codex features list`: `sqlite` is stage **removed** (always-on, cannot be
+  disabled); `shell_snapshot` stable/true; `runtime_metrics` under-development/false.
+
+## Decision (plan §3, candidate 3 — the drop path)
+
+**Stage 0a is DROPPED.** No freshell-side spawn-env/config knob can dampen the sink.
+Protection reduces to:
+- **0b** (lossless cleanup, maintenance window) — clears the accumulated WAL;
+- **1c observability** (shipped): boot + hourly `codex-log-db:` line, warn at
+  WAL > 500 MB / holder threshold — recurrence is now *detectable*, not silent;
+- **1a/1c lifecycle hardening** (shipped) — orphan accumulation and boot fragility
+  fixed;
+- **Stage 2** (shared app-server, holders → 1) becomes the load-bearing fix for WAL
+  growth and should be scheduled;
+- **Upstream issue** (below).
+
+Expected recurrence cadence without Stage 2: WAL re-approaches the multi-GB cliff in
+days-to-weeks of heavy use (~22 MB/min measured across the live pane population;
+~1 MB/min per idle TUI). The 500 MB warn threshold gives weeks of margin.
+
+## Draft upstream issue (file against openai/codex)
+
+**Title:** SQLite feedback log sink is unbounded and cannot be disabled; multi-GB WAL
+wedges new launches under multi-process use
+
+**Body sketch:**
+- `~/.codex/logs_2.sqlite` receives always-on TRACE capture (dominated by
+  inotify/`shell_snapshot` events, ~1 MB/min per idle TUI; 22 MB/min across ~20
+  processes). Not gated by `RUST_LOG` (measured: `RUST_LOG=off` −23%), nor
+  `feedback.enabled=false` (−25%), nor `features.shell_snapshot=false` (−10%).
+- With N long-lived codex processes (host apps that keep app-server/resume sessions
+  open), no truncating checkpoint window ever occurs; the WAL grew to 5 GB in ~10
+  days; new `codex` launches then block in `futex_wait_queue` opening the DB —
+  "codex won't launch."
+- Asks: (1) bound the WAL (`journal_size_limit` + `wal_autocheckpoint` + periodic
+  passive checkpoints from the writer); (2) don't persist inotify/shell_snapshot
+  events at TRACE by default; (3) a documented knob to disable/level the feedback
+  capture; (4) lazy/incremental thread-inventory scan (`codex doctor` currently
+  reads all rollout files synchronously).
+- Evidence: measurement tables above; lifetime insert high-water ~6.4B rows;
+  per-process ~1,000-row prune bound (table stays small — the WAL is the casualty).

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -4,6 +4,7 @@ import fsp from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { CODEX_MANAGED_REMOTE_CONFIG_ARGS } from '../codex-managed-config.js'
+import { deregisterCodexChild, registerCodexChild } from '../codex-child-registry.js'
 import { allocateLocalhostPort, type LoopbackServerEndpoint } from '../../local-port.js'
 import { logger } from '../../logger.js'
 import { resolveLaunchCwd, type LaunchCwdConversion } from '../../launch-cwd.js'
@@ -173,7 +174,25 @@ export type ReapOrphanedSidecarsResult = {
   reapedOwnershipIds: string[]
   ignoredLegacyRecords: string[]
   skippedActiveOwnershipIds: string[]
+  /** Records that hit an unexpected per-record error; retained in place and retried next pass. */
   failedOwnershipIds: string[]
+  /** Record files that could not be read (permissions, torn write); retained in place. */
+  unreadableRecords: string[]
+  /** Records moved to `<metadataDir>/quarantine/` (unparseable, or malformed with no provable live group). */
+  quarantinedRecords: string[]
+  /** Records retried in place with backoff state in `<record>.reaper.json` (never quarantined). */
+  retriedOwnershipIds: string[]
+  /** Quarantined records promoted back into the metadata dir because their process group is alive. */
+  promotedFromQuarantine: string[]
+  /** True when reaping was skipped this pass (metadata dir unreadable or /proc proof unavailable). */
+  reapingSkipped: boolean
+}
+
+/** Backoff state persisted by the reaper (and only the reaper) in `<record>.reaper.json`. */
+export type CodexReaperRetryState = {
+  firstSeen: string
+  attempts: number
+  lastAttempt: string
 }
 
 const DEFAULT_STARTUP_ATTEMPT_LIMIT = 2
@@ -693,6 +712,19 @@ async function teardownOwnedProcessGroup(
   ownership: ActiveOwnership,
   terminateGraceMs: number,
 ): Promise<boolean> {
+  const confirmedGone = await teardownOwnedProcessGroupCore(ownership, terminateGraceMs)
+  // Stage 1a (plan §6): deregister ONLY on confirmed group death (`true` also covers a provably
+  // foreign/reused PGID, which means our child is gone — it must leave the registry so exit-time
+  // reap can never signal the reused group). Wrapper exit does NOT deregister: live grandchildren
+  // keep the group registered until teardown proves it gone.
+  if (confirmedGone) deregisterCodexChild(ownership.metadata.wrapperPid)
+  return confirmedGone
+}
+
+async function teardownOwnedProcessGroupCore(
+  ownership: ActiveOwnership,
+  terminateGraceMs: number,
+): Promise<boolean> {
   const { metadata } = ownership
 
   // Gate the SIGTERM on a FRESH ownership classification rather than mere liveness: a PGID that was
@@ -736,6 +768,7 @@ async function teardownOwnedProcessGroup(
 type ParsedMetadataRecord =
   | { kind: 'valid'; metadata: CodexSidecarOwnershipMetadata }
   | { kind: 'legacy' }
+  | { kind: 'unparseable' }
   | { kind: 'malformedNewSchema'; ownershipId: string }
 
 function isWrapperIdentity(value: unknown): value is WrapperIdentity {
@@ -760,9 +793,11 @@ function parseMetadataRecord(raw: string, metadataPath: string): ParsedMetadataR
   try {
     parsed = JSON.parse(raw)
   } catch {
-    return { kind: 'legacy' }
+    // Not JSON at all: corrupt/torn write. There is nothing to retry against (no process group can
+    // even be extracted), so the reaper quarantines it instead of deleting it as legacy.
+    return { kind: 'unparseable' }
   }
-  if (!parsed || typeof parsed !== 'object') return { kind: 'legacy' }
+  if (!parsed || typeof parsed !== 'object') return { kind: 'unparseable' }
   const candidate = parsed as Partial<CodexSidecarOwnershipMetadata>
   if (candidate.schemaVersion !== OWNERSHIP_SCHEMA_VERSION) return { kind: 'legacy' }
   const ownershipId = typeof candidate.ownershipId === 'string' ? candidate.ownershipId : metadataPath
@@ -784,6 +819,229 @@ function parseMetadataRecord(raw: string, metadataPath: string): ParsedMetadataR
   return { kind: 'valid', metadata: candidate as CodexSidecarOwnershipMetadata }
 }
 
+const QUARANTINE_DIR_NAME = 'quarantine'
+const REAPER_RETRY_SIDECAR_SUFFIX = '.reaper.json'
+const QUARANTINE_NOTE_SUFFIX = '.note.json'
+const HOUR_MS = 60 * 60 * 1000
+/** Retry logging escalates from info to warn once a record has been re-attempted this many times. */
+export const CODEX_REAPER_LOG_ESCALATION_ATTEMPTS = 3
+
+function reaperRetrySidecarPath(metadataPath: string): string {
+  return `${metadataPath}${REAPER_RETRY_SIDECAR_SUFFIX}`
+}
+
+function quarantineDirPath(metadataDir: string): string {
+  return path.join(metadataDir, QUARANTINE_DIR_NAME)
+}
+
+// Retry cadence is time-based, keyed on how long the record has been pending (firstSeen) — never on
+// attempt counts — so shared prod+dev metadata dirs and `tsx watch` restart storms cannot burn the
+// backoff budget. The per-boot reap attempt always runs; this only gates the hourly re-attempts.
+export function codexReaperRetryIntervalMs(pendingAgeMs: number): number {
+  if (pendingAgeMs < 6 * HOUR_MS) return HOUR_MS
+  if (pendingAgeMs < 24 * HOUR_MS) return 3 * HOUR_MS
+  return 6 * HOUR_MS
+}
+
+export function isCodexReaperRetryDue(state: CodexReaperRetryState, nowMs: number = Date.now()): boolean {
+  const firstSeenMs = Date.parse(state.firstSeen)
+  const lastAttemptMs = Date.parse(state.lastAttempt)
+  if (!Number.isFinite(firstSeenMs) || !Number.isFinite(lastAttemptMs)) return true
+  return nowMs - lastAttemptMs >= codexReaperRetryIntervalMs(nowMs - firstSeenMs)
+}
+
+function isCodexReaperRetryState(value: unknown): value is CodexReaperRetryState {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<CodexReaperRetryState>
+  return typeof candidate.firstSeen === 'string'
+    && isNonNegativeInteger(candidate.attempts)
+    && typeof candidate.lastAttempt === 'string'
+}
+
+async function readCodexReaperRetryStateFile(sidecarPath: string): Promise<CodexReaperRetryState | null> {
+  try {
+    const raw = await fsp.readFile(sidecarPath, 'utf8')
+    const parsed: unknown = JSON.parse(raw)
+    return isCodexReaperRetryState(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+// Written only by the reaper, so it cannot race the owning server's own record rewrites. `firstSeen`
+// falls back to the record's mtime so the time-based backoff has a stable anchor for records that
+// predate their sidecar.
+async function recordCodexReaperRetryAttempt(metadataPath: string): Promise<CodexReaperRetryState> {
+  const sidecarPath = reaperRetrySidecarPath(metadataPath)
+  const existing = await readCodexReaperRetryStateFile(sidecarPath)
+  const now = new Date().toISOString()
+  let firstSeen = existing?.firstSeen
+  if (firstSeen === undefined) {
+    const recordStat = await fsp.stat(metadataPath).catch(() => null)
+    firstSeen = recordStat ? recordStat.mtime.toISOString() : now
+  }
+  const state: CodexReaperRetryState = {
+    firstSeen,
+    attempts: (existing?.attempts ?? 0) + 1,
+    lastAttempt: now,
+  }
+  try {
+    await atomicWriteJson(sidecarPath, state)
+  } catch (error) {
+    // Concurrent boots can race this write (rename-ENOENT = the other instance won). Backoff state
+    // is advisory; losing a write must never abort record processing.
+    logger.debug({ sidecarPath, err: error }, 'Codex startup reaper could not persist retry backoff state')
+  }
+  return state
+}
+
+function logCodexReaperRetry(
+  fields: Record<string, unknown>,
+  state: CodexReaperRetryState,
+  why: string,
+): void {
+  const payload = { ...fields, firstSeen: state.firstSeen, attempts: state.attempts, lastAttempt: state.lastAttempt }
+  const message = `Codex startup reaper left an ownership record in place for retry with backoff (${why})`
+  if (state.attempts >= CODEX_REAPER_LOG_ESCALATION_ATTEMPTS) {
+    logger.warn(payload, message)
+  } else {
+    logger.info(payload, message)
+  }
+}
+
+function extractProcessGroupIdBestEffort(raw: string): number | null {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return null
+    const candidate = (parsed as { processGroupId?: unknown }).processGroupId
+    return isPositiveInteger(candidate) ? candidate : null
+  } catch {
+    return null
+  }
+}
+
+// Quarantine is reserved for records the reaper can never act on: unparseable files, or malformed
+// records whose recorded process group cannot be proven alive (second-review blocking #2). Records
+// embed command lines and cwds, so the move preserves 0600. Rename-ENOENT means a concurrent boot
+// handled the record first; treat as success.
+async function quarantineCodexOwnershipRecord(
+  metadataDir: string,
+  metadataPath: string,
+  reason: string,
+): Promise<string | null> {
+  const retryState = await readCodexReaperRetryStateFile(reaperRetrySidecarPath(metadataPath))
+  const recordStat = await fsp.stat(metadataPath).catch(() => null)
+  if (!recordStat) return null
+  const quarantineDir = quarantineDirPath(metadataDir)
+  await fsp.mkdir(quarantineDir, { recursive: true })
+  const quarantinePath = path.join(quarantineDir, path.basename(metadataPath))
+  try {
+    await fsp.rename(metadataPath, quarantinePath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+  await fsp.chmod(quarantinePath, 0o600).catch(() => undefined)
+  await atomicWriteJson(`${quarantinePath}${QUARANTINE_NOTE_SUFFIX}`, {
+    reason,
+    firstSeen: retryState?.firstSeen ?? recordStat.mtime.toISOString(),
+    attempts: retryState?.attempts ?? 0,
+  }).catch((error) => {
+    logger.warn({ quarantinePath, err: error }, 'Codex startup reaper could not write a quarantine note')
+  })
+  await fsp.unlink(reaperRetrySidecarPath(metadataPath)).catch(() => undefined)
+  logger.warn({ metadataPath, quarantinePath, reason }, 'Codex startup reaper quarantined an ownership record')
+  return quarantinePath
+}
+
+// Safety net (second-review blocking #2): a quarantined record must never hide a live DB holder.
+// Every pass promotes quarantined records whose recorded process group is still alive back into the
+// metadata dir so the reaper retries them. Never throws.
+export async function rescanCodexReaperQuarantine(
+  metadataDir?: string,
+): Promise<{ promotedRecords: string[]; quarantinedCount: number }> {
+  const dir = metadataDir ?? defaultMetadataDir()
+  const quarantineDir = quarantineDirPath(dir)
+  const promotedRecords: string[] = []
+  let quarantinedCount = 0
+  let entries: string[]
+  try {
+    entries = await fsp.readdir(quarantineDir)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      logger.warn({ quarantineDir, err: error }, 'Codex reaper quarantine rescan could not read the quarantine directory')
+    }
+    return { promotedRecords, quarantinedCount }
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith('.json') || entry.endsWith(QUARANTINE_NOTE_SUFFIX)) continue
+    quarantinedCount += 1
+    const quarantinePath = path.join(quarantineDir, entry)
+    try {
+      const raw = await fsp.readFile(quarantinePath, 'utf8')
+      const processGroupId = extractProcessGroupIdBestEffort(raw)
+      if (processGroupId === null) continue
+      if (await isProcessGroupGone(processGroupId)) continue
+      const restoredPath = path.join(dir, entry)
+      try {
+        await fsp.rename(quarantinePath, restoredPath)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue // concurrent rescan won
+        throw error
+      }
+      await fsp.chmod(restoredPath, 0o600).catch(() => undefined)
+      await fsp.unlink(`${quarantinePath}${QUARANTINE_NOTE_SUFFIX}`).catch(() => undefined)
+      quarantinedCount -= 1
+      promotedRecords.push(restoredPath)
+      logger.warn(
+        { quarantinePath, restoredPath, processGroupId },
+        'Codex reaper promoted a quarantined ownership record back for retry because its process group is still alive',
+      )
+    } catch (error) {
+      logger.warn({ quarantinePath, err: error }, 'Codex reaper quarantine rescan failed for a record; leaving it quarantined')
+    }
+  }
+  return { promotedRecords, quarantinedCount }
+}
+
+/** Read-only count of quarantined ownership records, for the codex-log-db observability line. */
+export async function countCodexQuarantinedRecords(metadataDir?: string): Promise<number> {
+  const dir = metadataDir ?? defaultMetadataDir()
+  try {
+    const entries = await fsp.readdir(quarantineDirPath(dir))
+    return entries.filter((entry) => entry.endsWith('.json') && !entry.endsWith(QUARANTINE_NOTE_SUFFIX)).length
+  } catch {
+    return 0
+  }
+}
+
+// Used by the hourly observability tick to gate re-running the reaper: the per-boot attempt always
+// runs, but hourly re-attempts follow the time-based backoff above. Sidecars orphaned by a
+// successful reap are cleaned up here so they cannot trigger reaper runs forever.
+export async function hasDueCodexReaperRetries(metadataDir?: string, nowMs: number = Date.now()): Promise<boolean> {
+  const dir = metadataDir ?? defaultMetadataDir()
+  let entries: string[]
+  try {
+    entries = await fsp.readdir(dir)
+  } catch {
+    return false
+  }
+  let due = false
+  for (const entry of entries) {
+    if (!entry.endsWith(REAPER_RETRY_SIDECAR_SUFFIX)) continue
+    const sidecarPath = path.join(dir, entry)
+    const recordPath = sidecarPath.slice(0, -REAPER_RETRY_SIDECAR_SUFFIX.length)
+    const recordExists = await fsp.stat(recordPath).then(() => true, () => false)
+    if (!recordExists) {
+      await fsp.unlink(sidecarPath).catch(() => undefined)
+      continue
+    }
+    const state = await readCodexReaperRetryStateFile(sidecarPath)
+    if (!state || isCodexReaperRetryDue(state, nowMs)) due = true
+  }
+  return due
+}
+
 export async function reapOrphanedCodexAppServerSidecars(
   options: ReapOrphanedSidecarsOptions,
 ): Promise<ReapOrphanedSidecarsResult> {
@@ -793,85 +1051,204 @@ export async function reapOrphanedCodexAppServerSidecars(
     ignoredLegacyRecords: [],
     skippedActiveOwnershipIds: [],
     failedOwnershipIds: [],
+    unreadableRecords: [],
+    quarantinedRecords: [],
+    retriedOwnershipIds: [],
+    promotedFromQuarantine: [],
+    reapingSkipped: false,
   }
+
+  // Safety net first: promote quarantined records whose process group is still alive so this same
+  // pass retries them (a quarantined record must never hide a live DB holder).
+  try {
+    const rescan = await rescanCodexReaperQuarantine(metadataDir)
+    result.promotedFromQuarantine.push(...rescan.promotedRecords)
+  } catch (error) {
+    logger.warn({ metadataDir, err: error }, 'Codex startup reaper quarantine rescan failed; continuing')
+  }
+
   let procOwnershipProofChecked = false
   const ensureProcOwnershipProof = async () => {
     if (procOwnershipProofChecked) return
     await assertProcOwnershipProofAvailable()
     procOwnershipProofChecked = true
   }
-  const entries = await fsp.readdir(metadataDir).catch((error) => {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
-    throw error
-  })
+
+  let entries: string[]
+  try {
+    entries = await fsp.readdir(metadataDir)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return result
+    // Degrade and continue (I4): without the record listing we skip reaping this pass instead of
+    // failing boot. Records stay in place for the hourly retry and the next boot.
+    result.reapingSkipped = true
+    logger.warn(
+      { metadataDir, err: error },
+      'Codex startup reaper could not read the sidecar metadata directory; skipping reaping this pass',
+    )
+    return result
+  }
 
   for (const entry of entries) {
-    if (!entry.endsWith('.json')) continue
+    if (!entry.endsWith('.json') || entry.endsWith(REAPER_RETRY_SIDECAR_SUFFIX)) continue
     const metadataPath = path.join(metadataDir, entry)
-    const raw = await fsp.readFile(metadataPath, 'utf8')
-    const parsed = parseMetadataRecord(raw, metadataPath)
-    if (parsed.kind === 'legacy') {
-      result.ignoredLegacyRecords.push(metadataPath)
-      await fsp.unlink(metadataPath).catch(() => undefined)
-      continue
-    }
-    if (parsed.kind === 'malformedNewSchema') {
-      result.failedOwnershipIds.push(parsed.ownershipId)
-      continue
-    }
-
-    await ensureProcOwnershipProof()
-    const metadata = parsed.metadata
-
-    if (await isPidAlive(metadata.ownerServerPid)) {
-      if (await isOwnerServerProcess(metadata)) {
-        result.skippedActiveOwnershipIds.push(metadata.ownershipId)
-      } else {
-        result.failedOwnershipIds.push(metadata.ownershipId)
+    let ownershipId: string | undefined
+    // Per-record isolation (I4): one bad record affects only itself, never the scan or the boot.
+    try {
+      let raw: string
+      try {
+        raw = await fsp.readFile(metadataPath, 'utf8')
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue // a concurrent boot handled it
+        result.unreadableRecords.push(metadataPath)
+        logger.warn(
+          { metadataPath, err: error },
+          'Codex startup reaper could not read an ownership record; leaving it in place (unreadable)',
+        )
+        continue
       }
-      continue
-    }
 
-    const currentProcessGroupId = await getProcessGroupId('self')
-    if (currentProcessGroupId !== null && metadata.processGroupId === currentProcessGroupId) {
-      result.skippedActiveOwnershipIds.push(metadata.ownershipId)
-      continue
-    }
+      const parsed = parseMetadataRecord(raw, metadataPath)
+      if (parsed.kind === 'legacy') {
+        result.ignoredLegacyRecords.push(metadataPath)
+        await fsp.unlink(metadataPath).catch(() => undefined)
+        continue
+      }
+      if (parsed.kind === 'unparseable') {
+        // Nothing to retry against: no process group can be extracted from a non-JSON record.
+        const quarantinePath = await quarantineCodexOwnershipRecord(metadataDir, metadataPath, 'unparseable-record')
+        if (quarantinePath) result.quarantinedRecords.push(quarantinePath)
+        continue
+      }
+      if (parsed.kind === 'malformedNewSchema') {
+        ownershipId = parsed.ownershipId
+        // Narrowed quarantine (second-review blocking #2): only quarantine when the recorded
+        // process group cannot be proven alive. A malformed record naming a live group is the only
+        // tether to a live DB holder — retry it in place instead, never quarantine it.
+        const processGroupId = extractProcessGroupIdBestEffort(raw)
+        if (processGroupId !== null && !(await isProcessGroupGone(processGroupId))) {
+          const state = await recordCodexReaperRetryAttempt(metadataPath)
+          logCodexReaperRetry(
+            { ownershipId: parsed.ownershipId, metadataPath, processGroupId },
+            state,
+            'malformed record with a live process group',
+          )
+          result.retriedOwnershipIds.push(parsed.ownershipId)
+        } else {
+          const quarantinePath = await quarantineCodexOwnershipRecord(metadataDir, metadataPath, 'malformed-record')
+          if (quarantinePath) result.quarantinedRecords.push(quarantinePath)
+        }
+        continue
+      }
 
-    const ownership: ActiveOwnership = { metadataDir, metadataPath, metadata }
-    const reaped = await teardownOwnedProcessGroup(ownership, options.terminateGraceMs ?? DEFAULT_TERMINATE_GRACE_MS)
-    if (reaped) {
-      result.reapedOwnershipIds.push(metadata.ownershipId)
-    } else {
-      result.failedOwnershipIds.push(metadata.ownershipId)
+      const metadata = parsed.metadata
+      ownershipId = metadata.ownershipId
+
+      try {
+        await ensureProcOwnershipProof()
+      } catch (error) {
+        // Degrade and continue (I4): without the /proc ownership proof no record can be classified
+        // safely (I3), so skip reaping this pass rather than abort boot.
+        result.reapingSkipped = true
+        logger.warn(
+          { metadataDir, err: error },
+          'Codex startup reaper has no usable /proc ownership proof; skipping reaping this pass',
+        )
+        break
+      }
+
+      if (await isPidAlive(metadata.ownerServerPid)) {
+        if (await isOwnerServerProcess(metadata)) {
+          result.skippedActiveOwnershipIds.push(metadata.ownershipId)
+        } else {
+          // Owner pid alive but identity-mismatched (pid reuse or a transient /proc race): retry in
+          // place with backoff — never quarantine a record we could not disprove.
+          const state = await recordCodexReaperRetryAttempt(metadataPath)
+          logCodexReaperRetry(
+            {
+              ownershipId: metadata.ownershipId,
+              metadataPath,
+              ownerServerPid: metadata.ownerServerPid,
+              processGroupId: metadata.processGroupId,
+            },
+            state,
+            'owner pid is alive without a matching identity',
+          )
+          result.retriedOwnershipIds.push(metadata.ownershipId)
+        }
+        continue
+      }
+
+      const currentProcessGroupId = await getProcessGroupId('self')
+      if (currentProcessGroupId !== null && metadata.processGroupId === currentProcessGroupId) {
+        result.skippedActiveOwnershipIds.push(metadata.ownershipId)
+        continue
+      }
+
+      const ownership: ActiveOwnership = { metadataDir, metadataPath, metadata }
+      const reaped = await teardownOwnedProcessGroup(ownership, options.terminateGraceMs ?? DEFAULT_TERMINATE_GRACE_MS)
+      if (reaped) {
+        result.reapedOwnershipIds.push(metadata.ownershipId)
+        await fsp.unlink(reaperRetrySidecarPath(metadataPath)).catch(() => undefined)
+      } else {
+        // Owner dead but the group survived SIGTERM+SIGKILL (e.g. a codex process in D-state I/O
+        // against a bloated WAL — this incident's exact signature), or ownership could not be
+        // verified. NEVER quarantine: this record is the only tether to a potentially live DB
+        // holder. Retry in place with backoff.
+        const state = await recordCodexReaperRetryAttempt(metadataPath)
+        logCodexReaperRetry(
+          {
+            ownershipId: metadata.ownershipId,
+            metadataPath,
+            wrapperPid: metadata.wrapperPid,
+            processGroupId: metadata.processGroupId,
+          },
+          state,
+          'process group survived teardown or ownership was not verified',
+        )
+        result.retriedOwnershipIds.push(metadata.ownershipId)
+      }
+    } catch (error) {
+      result.failedOwnershipIds.push(ownershipId ?? metadataPath)
+      logger.warn(
+        { metadataPath, ownershipId, err: error },
+        'Codex startup reaper failed to process an ownership record; leaving it in place for retry',
+      )
     }
   }
 
   return result
 }
 
+// Boot entry point. Reaping is best-effort: unresolved records are surfaced as a single warning
+// (below) instead of blocking startup — the fail-closed assertCodexStartupReaperSucceeded contract
+// was removed by Stage 1c (I4). The index.ts call site adds a final try/catch backstop.
 export async function runCodexStartupReaper(
   options: ReapOrphanedSidecarsOptions,
 ): Promise<ReapOrphanedSidecarsResult> {
   const result = await reapOrphanedCodexAppServerSidecars(options)
-  assertCodexStartupReaperSucceeded(result)
+  summarizeCodexStartupReaperResult(result)
   return result
 }
 
-export const reapOrphanedCodexAppServerSidecarsOnStartup = runCodexStartupReaper
-
-export function assertCodexStartupReaperSucceeded(result: ReapOrphanedSidecarsResult): void {
-  const failedOwnershipIds = [...new Set(result.failedOwnershipIds)]
-  if (failedOwnershipIds.length === 0) return
-
-  const reasons: string[] = []
-  reasons.push(
-    `failed to reap ${failedOwnershipIds.length} ownership record(s): ${failedOwnershipIds.join(', ')}`,
-  )
-
-  throw new Error(
-    `Codex app-server startup reaper blocked startup: ${reasons.join('; ')}. `
-    + 'Refusing to continue until failed ownership records are handled or verified gone.',
+// Warning aggregator (no throw): replaces the deleted fail-closed assert.
+function summarizeCodexStartupReaperResult(result: ReapOrphanedSidecarsResult): void {
+  const unresolved =
+    result.failedOwnershipIds.length
+    + result.unreadableRecords.length
+    + result.quarantinedRecords.length
+    + result.retriedOwnershipIds.length
+  if (!result.reapingSkipped && unresolved === 0) return
+  logger.warn(
+    {
+      reapingSkipped: result.reapingSkipped,
+      failedOwnershipIds: [...new Set(result.failedOwnershipIds)],
+      unreadableRecords: result.unreadableRecords,
+      quarantinedRecords: result.quarantinedRecords,
+      retriedOwnershipIds: [...new Set(result.retriedOwnershipIds)],
+      promotedFromQuarantine: result.promotedFromQuarantine,
+    },
+    'Codex startup reaper completed with unresolved ownership records; continuing boot (fail-open)',
   )
 }
 
@@ -1261,6 +1638,13 @@ export class CodexAppServerRuntime {
       })
       const childErrorPromise = this.watchChildError(child)
 
+      // Stage 1a (plan §6): track the sidecar's process group (pgid == wrapper pid, spawned
+      // `detached: true`) for exit-time reaping. Deregistered only on CONFIRMED group death in
+      // teardownOwnedProcessGroup — NOT at wrapper exit, which can leave live grandchildren.
+      if (child.pid) {
+        registerCodexChild({ pid: child.pid, pgid: child.pid, kind: 'app-server' })
+      }
+
       // Drain child stdio continuously so verbose app-server or MCP startup logs
       // cannot fill the pipe buffer and stall JSON-RPC request handling.
       child.stdout?.resume()
@@ -1612,6 +1996,9 @@ export class CodexAppServerRuntime {
 
     if (await isProcessGroupGone(ownership.metadata.processGroupId)) {
       await unlinkOwnershipMetadata(ownership)
+      // Stage 1a (plan §6): group death is confirmed here too — drop the registration so exit-time
+      // reap can never signal a reused pid/pgid.
+      deregisterCodexChild(ownership.metadata.wrapperPid)
       if (this.ownership === ownership) {
         this.ownership = null
       }

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -208,7 +208,12 @@ export type ReapOrphanedSidecarsResult = {
 export type CodexReaperRetryState = {
   firstSeen: string
   attempts: number
-  lastAttempt: string
+  /**
+   * Absent for records that were only ever DEFERRED for budget (R2-M2: a deferral is not an
+   * attempt). A state without lastAttempt always tests as due, so the hourly unbudgeted tick
+   * picks deferred records up immediately.
+   */
+  lastAttempt?: string
 }
 
 const DEFAULT_STARTUP_ATTEMPT_LIMIT = 2
@@ -838,6 +843,8 @@ function parseMetadataRecord(raw: string, metadataPath: string): ParsedMetadataR
 const QUARANTINE_DIR_NAME = 'quarantine'
 const REAPER_RETRY_SIDECAR_SUFFIX = '.reaper.json'
 const QUARANTINE_NOTE_SUFFIX = '.note.json'
+/** r2-8: anchored match for atomicWriteJson's tmp naming -- `<file>.tmp-<pid>-<timestamp>`. */
+const ATOMIC_TMP_FILE_PATTERN = /\.tmp-\d+-\d+$/
 const HOUR_MS = 60 * 60 * 1000
 /**
  * Retry logging escalates from info to warn once a record has been PENDING this long (wall-time,
@@ -870,6 +877,8 @@ export function codexReaperRetryIntervalMs(pendingAgeMs: number): number {
 }
 
 export function isCodexReaperRetryDue(state: CodexReaperRetryState, nowMs: number = Date.now()): boolean {
+  // R2-M2: no lastAttempt means the record was deferred without ever being attempted -- always due.
+  if (state.lastAttempt === undefined) return true
   const firstSeenMs = Date.parse(state.firstSeen)
   const lastAttemptMs = Date.parse(state.lastAttempt)
   if (!Number.isFinite(firstSeenMs) || !Number.isFinite(lastAttemptMs)) return true
@@ -891,7 +900,7 @@ function isCodexReaperRetryState(value: unknown): value is CodexReaperRetryState
   const candidate = value as Partial<CodexReaperRetryState>
   return typeof candidate.firstSeen === 'string'
     && isNonNegativeInteger(candidate.attempts)
-    && typeof candidate.lastAttempt === 'string'
+    && (candidate.lastAttempt === undefined || typeof candidate.lastAttempt === 'string')
 }
 
 async function readCodexReaperRetryStateFile(sidecarPath: string): Promise<CodexReaperRetryState | null> {
@@ -924,9 +933,45 @@ async function recordCodexReaperRetryAttempt(metadataPath: string): Promise<Code
   try {
     await atomicWriteJson(sidecarPath, state)
   } catch (error) {
-    // Concurrent boots can race this write (rename-ENOENT = the other instance won). Backoff state
-    // is advisory; losing a write must never abort record processing.
-    logger.debug({ sidecarPath, err: error }, 'Codex startup reaper could not persist retry backoff state')
+    logReaperSidecarWriteFailure(sidecarPath, error)
+  }
+  return state
+}
+
+// r2-9: a PERSISTENTLY unwritable sidecar (e.g. a perms-skewed shared metadata dir) must be
+// visible, not debug-only -- but concurrent boots legitimately race this write (rename-ENOENT =
+// the other instance won) and restart storms must not spam. Warn once per sidecar path per
+// process, then drop to debug. Backoff state stays advisory: losing a write never aborts record
+// processing.
+const warnedReaperSidecarWritePaths = new Set<string>()
+
+function logReaperSidecarWriteFailure(sidecarPath: string, error: unknown): void {
+  if (warnedReaperSidecarWritePaths.has(sidecarPath)) {
+    logger.debug({ sidecarPath, err: error }, 'Codex reaper could not persist retry backoff state')
+    return
+  }
+  warnedReaperSidecarWritePaths.add(sidecarPath)
+  logger.warn({ sidecarPath, err: error }, 'Codex reaper could not persist retry backoff state')
+}
+
+// R2-M2: budget deferral must NOT consume the record's retry budget. Under a tsx-watch restart
+// cadence, counting deferrals as attempts advances lastAttempt on every boot, so tail records
+// would never test as "due" for the hourly UNBUDGETED tick -- permanent teardown starvation. This
+// only guarantees a sidecar exists (firstSeen anchors log escalation and future backoff); it
+// never creates or advances attempts/lastAttempt, so isCodexReaperRetryDue stays true.
+async function recordCodexReaperDeferral(metadataPath: string): Promise<CodexReaperRetryState> {
+  const sidecarPath = reaperRetrySidecarPath(metadataPath)
+  const existing = await readCodexReaperRetryStateFile(sidecarPath)
+  if (existing) return existing // preserve attempts and lastAttempt exactly as they were
+  const recordStat = await fsp.stat(metadataPath).catch(() => null)
+  const state: CodexReaperRetryState = {
+    firstSeen: recordStat ? recordStat.mtime.toISOString() : new Date().toISOString(),
+    attempts: 0,
+  }
+  try {
+    await atomicWriteJson(sidecarPath, state)
+  } catch (error) {
+    logReaperSidecarWriteFailure(sidecarPath, error)
   }
   return state
 }
@@ -985,8 +1030,13 @@ async function quarantineCodexOwnershipRecord(
     await fsp.rename(metadataPath, quarantinePath)
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      // A concurrent boot handled the record first; drop the note we pre-wrote for it.
-      await fsp.unlink(`${quarantinePath}${QUARANTINE_NOTE_SUFFIX}`).catch(() => undefined)
+      // A concurrent boot handled the record first. r2-7: if the WINNER's rename landed at the
+      // quarantine path, the note there now describes the winner's record -- only unlink the note
+      // we pre-wrote when NO record sits at the quarantine path.
+      const winnerRecordPresent = await fsp.stat(quarantinePath).then(() => true, () => false)
+      if (!winnerRecordPresent) {
+        await fsp.unlink(`${quarantinePath}${QUARANTINE_NOTE_SUFFIX}`).catch(() => undefined)
+      }
       return null
     }
     throw error
@@ -995,6 +1045,27 @@ async function quarantineCodexOwnershipRecord(
   await fsp.unlink(reaperRetrySidecarPath(metadataPath)).catch(() => undefined)
   logger.warn({ metadataPath, quarantinePath, reason }, 'Codex startup reaper quarantined an ownership record')
   return quarantinePath
+}
+
+// r2-8: best-effort purge of atomic-write tmp files stranded by a crash mid-write; anything older
+// than an hour can never be renamed into place by its (dead) writer. Never throws.
+async function purgeStaleAtomicTmpFiles(dir: string): Promise<void> {
+  let entries: string[]
+  try {
+    entries = await fsp.readdir(dir)
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    if (!ATOMIC_TMP_FILE_PATTERN.test(entry)) continue
+    try {
+      const tmpPath = path.join(dir, entry)
+      const tmpStat = await fsp.stat(tmpPath)
+      if (Date.now() - tmpStat.mtimeMs >= HOUR_MS) await fsp.unlink(tmpPath)
+    } catch {
+      // best-effort cleanup only
+    }
+  }
 }
 
 // Safety net (second-review blocking #2): a quarantined record must never hide a live DB holder.
@@ -1078,16 +1149,35 @@ export async function hasDueCodexReaperRetries(metadataDir?: string, nowMs: numb
   }
   let due = false
   for (const entry of entries) {
-    if (!entry.endsWith(REAPER_RETRY_SIDECAR_SUFFIX)) continue
-    const sidecarPath = path.join(dir, entry)
-    const recordPath = sidecarPath.slice(0, -REAPER_RETRY_SIDECAR_SUFFIX.length)
-    const recordExists = await fsp.stat(recordPath).then(() => true, () => false)
-    if (!recordExists) {
-      await fsp.unlink(sidecarPath).catch(() => undefined)
+    if (entry.endsWith(REAPER_RETRY_SIDECAR_SUFFIX)) {
+      const sidecarPath = path.join(dir, entry)
+      const recordPath = sidecarPath.slice(0, -REAPER_RETRY_SIDECAR_SUFFIX.length)
+      const recordExists = await fsp.stat(recordPath).then(() => true, () => false)
+      if (!recordExists) {
+        await fsp.unlink(sidecarPath).catch(() => undefined)
+        continue
+      }
+      const state = await readCodexReaperRetryStateFile(sidecarPath)
+      if (!state || isCodexReaperRetryDue(state, nowMs)) due = true
       continue
     }
-    const state = await readCodexReaperRetryStateFile(sidecarPath)
-    if (!state || isCodexReaperRetryDue(state, nowMs)) due = true
+    // r2-6: a record orphaned AFTER boot has no backoff sidecar yet -- without this branch the
+    // hourly tick early-returns forever while the orphan sits there. Any plain .json ownership
+    // record whose ownerServerPid is not provably alive needs a reaper pass (which will tear it
+    // down or write backoff state). Cheap: one read + parse + signal-0 probe per such record.
+    if (!entry.endsWith('.json') || ATOMIC_TMP_FILE_PATTERN.test(entry)) continue
+    const recordPath = path.join(dir, entry)
+    const sidecarExists = await fsp.stat(reaperRetrySidecarPath(recordPath)).then(() => true, () => false)
+    if (sidecarExists) continue // due-ness governed by its sidecar, handled above
+    try {
+      const parsed: unknown = JSON.parse(await fsp.readFile(recordPath, 'utf8'))
+      const ownerServerPid = (parsed as { ownerServerPid?: unknown } | null)?.ownerServerPid
+      if (isPositiveInteger(ownerServerPid) && (await isPidAlive(ownerServerPid))) continue
+      due = true
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue // unlinked mid-scan
+      due = true // unreadable/unparseable: the reaper owns the decision (retry or quarantine)
+    }
   }
   return due
 }
@@ -1108,7 +1198,10 @@ export async function reapOrphanedCodexAppServerSidecars(
     promotedFromQuarantine: [],
     reapingSkipped: false,
   }
-  const nowFn = options.nowFn ?? Date.now
+  // r2-5: the teardown budget measures ELAPSED time -- default to the monotonic clock so a
+  // wall-clock step (NTP, suspend/resume) cannot spuriously exhaust or extend the budget. An
+  // injected nowFn (tests) is used consistently for both the pass start and every check.
+  const nowFn = options.nowFn ?? (() => performance.now())
   const passStartedAt = nowFn()
 
   // Safety net first: promote quarantined records whose process group is still alive so this same
@@ -1119,6 +1212,10 @@ export async function reapOrphanedCodexAppServerSidecars(
   } catch (error) {
     logger.warn({ metadataDir, err: error }, 'Codex startup reaper quarantine rescan failed; continuing')
   }
+
+  // r2-8: stranded atomic-write tmp files land in quarantine/ too (notes and quarantined records
+  // are written atomically); sweep it with the same age gate the main-dir loop applies below.
+  await purgeStaleAtomicTmpFiles(quarantineDirPath(metadataDir))
 
   let procOwnershipProofChecked = false
   const ensureProcOwnershipProof = async () => {
@@ -1145,7 +1242,7 @@ export async function reapOrphanedCodexAppServerSidecars(
   for (const entry of entries) {
     // m9: purge atomic-write tmp files stranded by a crash mid-write; anything older than an hour
     // can never be renamed into place by its (dead) writer. Best-effort, never fatal.
-    if (entry.includes('.tmp-')) {
+    if (ATOMIC_TMP_FILE_PATTERN.test(entry)) {
       try {
         const tmpPath = path.join(metadataDir, entry)
         const tmpStat = await fsp.stat(tmpPath)
@@ -1262,7 +1359,9 @@ export async function reapOrphanedCodexAppServerSidecars(
       // the remaining records. They keep retry state (so they surface in the boot summary and the
       // hourly tick re-attempts them) and are marked deferred — never dropped.
       if (options.teardownBudgetMs !== undefined && nowFn() - passStartedAt > options.teardownBudgetMs) {
-        const state = await recordCodexReaperRetryAttempt(metadataPath)
+        // R2-M2: a deferral is not an attempt -- recordCodexReaperDeferral never bumps attempts
+        // nor advances lastAttempt, so the record stays due for the hourly unbudgeted tick.
+        const state = await recordCodexReaperDeferral(metadataPath)
         logCodexReaperRetry(
           {
             ownershipId: metadata.ownershipId,
@@ -1739,7 +1838,14 @@ export class CodexAppServerRuntime {
       // `detached: true`) for exit-time reaping. Deregistered only on CONFIRMED group death in
       // teardownOwnedProcessGroup — NOT at wrapper exit, which can leave live grandchildren.
       if (child.pid) {
-        registerCodexChild({ pid: child.pid, pgid: child.pid, kind: 'app-server' })
+        registerCodexChild({
+          pid: child.pid,
+          pgid: child.pid,
+          kind: 'app-server',
+          // R2-M1: ownership proof for the registry's dead-pid group-scan fallback -- the spawn
+          // env above injects FRESHELL_CODEX_SIDECAR_ID=<ownershipId> into the whole group.
+          envMarker: { name: 'FRESHELL_CODEX_SIDECAR_ID', value: ownershipId },
+        })
       }
 
       // Drain child stdio continuously so verbose app-server or MCP startup logs

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -168,6 +168,20 @@ export type ReapOrphanedSidecarsOptions = {
   metadataDir?: string
   serverInstanceId: string
   terminateGraceMs?: number
+  /**
+   * Total wall-clock budget for group teardowns (the signal-and-wait part) in one pass. The boot
+   * pass runs pre-listen, so runCodexStartupReaper caps it at CODEX_REAPER_BOOT_BUDGET_MS; records
+   * past the budget skip teardown and are deferred with retry state (surfaced in the summary and
+   * retried by the hourly tick, which stays unbudgeted). Omit for unbudgeted behavior.
+   */
+  teardownBudgetMs?: number
+  /**
+   * Skip records whose per-record retry backoff window has not elapsed (no attempt increment, no
+   * log). Passed by the hourly maintenance tick; boot passes always attempt every record.
+   */
+  respectRetryBackoff?: boolean
+  /** Clock seam for the teardown budget (tests only). */
+  nowFn?: () => number
 }
 
 export type ReapOrphanedSidecarsResult = {
@@ -182,6 +196,8 @@ export type ReapOrphanedSidecarsResult = {
   quarantinedRecords: string[]
   /** Records retried in place with backoff state in `<record>.reaper.json` (never quarantined). */
   retriedOwnershipIds: string[]
+  /** Records whose group teardown was skipped because the pass's teardown time budget ran out. */
+  deferredForBudget: string[]
   /** Quarantined records promoted back into the metadata dir because their process group is alive. */
   promotedFromQuarantine: string[]
   /** True when reaping was skipped this pass (metadata dir unreadable or /proc proof unavailable). */
@@ -823,8 +839,18 @@ const QUARANTINE_DIR_NAME = 'quarantine'
 const REAPER_RETRY_SIDECAR_SUFFIX = '.reaper.json'
 const QUARANTINE_NOTE_SUFFIX = '.note.json'
 const HOUR_MS = 60 * 60 * 1000
-/** Retry logging escalates from info to warn once a record has been re-attempted this many times. */
-export const CODEX_REAPER_LOG_ESCALATION_ATTEMPTS = 3
+/**
+ * Retry logging escalates from info to warn once a record has been PENDING this long (wall-time,
+ * plan §7.4). Never attempt-count based: tsx-watch restart storms and two instances sharing the
+ * metadata dir would burn an attempt budget in minutes.
+ */
+export const CODEX_REAPER_LOG_ESCALATION_MS = 6 * HOUR_MS
+/**
+ * Total group-teardown time budget for the pre-listen BOOT reap pass (panel M2). Each stuck
+ * (D-state) record costs ~2s of signal-and-wait plus two full /proc scans; without a budget every
+ * restart pays that per record. Classification and the quarantine rescan (cheap) always run.
+ */
+export const CODEX_REAPER_BOOT_BUDGET_MS = 3_000
 
 function reaperRetrySidecarPath(metadataPath: string): string {
   return `${metadataPath}${REAPER_RETRY_SIDECAR_SUFFIX}`
@@ -848,6 +874,16 @@ export function isCodexReaperRetryDue(state: CodexReaperRetryState, nowMs: numbe
   const lastAttemptMs = Date.parse(state.lastAttempt)
   if (!Number.isFinite(firstSeenMs) || !Number.isFinite(lastAttemptMs)) return true
   return nowMs - lastAttemptMs >= codexReaperRetryIntervalMs(nowMs - firstSeenMs)
+}
+
+/**
+ * Wall-time log escalation (panel M4): warn only once the record has been pending for
+ * CODEX_REAPER_LOG_ESCALATION_MS. `attempts` stays in the payload as informational context.
+ */
+export function isCodexReaperEscalationDue(state: CodexReaperRetryState, nowMs: number = Date.now()): boolean {
+  const firstSeenMs = Date.parse(state.firstSeen)
+  if (!Number.isFinite(firstSeenMs)) return true // unparseable anchor: escalate rather than hide
+  return nowMs - firstSeenMs >= CODEX_REAPER_LOG_ESCALATION_MS
 }
 
 function isCodexReaperRetryState(value: unknown): value is CodexReaperRetryState {
@@ -902,7 +938,7 @@ function logCodexReaperRetry(
 ): void {
   const payload = { ...fields, firstSeen: state.firstSeen, attempts: state.attempts, lastAttempt: state.lastAttempt }
   const message = `Codex startup reaper left an ownership record in place for retry with backoff (${why})`
-  if (state.attempts >= CODEX_REAPER_LOG_ESCALATION_ATTEMPTS) {
+  if (isCodexReaperEscalationDue(state)) {
     logger.warn(payload, message)
   } else {
     logger.info(payload, message)
@@ -935,13 +971,9 @@ async function quarantineCodexOwnershipRecord(
   const quarantineDir = quarantineDirPath(metadataDir)
   await fsp.mkdir(quarantineDir, { recursive: true })
   const quarantinePath = path.join(quarantineDir, path.basename(metadataPath))
-  try {
-    await fsp.rename(metadataPath, quarantinePath)
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
-    throw error
-  }
-  await fsp.chmod(quarantinePath, 0o600).catch(() => undefined)
+  // m3: write the note BEFORE the rename — a cross-instance quarantine rescan can promote the
+  // record the instant it lands, and a note written after the rename would be stranded as an
+  // orphan. rescanCodexReaperQuarantine also unlinks any note whose record file is absent.
   await atomicWriteJson(`${quarantinePath}${QUARANTINE_NOTE_SUFFIX}`, {
     reason,
     firstSeen: retryState?.firstSeen ?? recordStat.mtime.toISOString(),
@@ -949,6 +981,17 @@ async function quarantineCodexOwnershipRecord(
   }).catch((error) => {
     logger.warn({ quarantinePath, err: error }, 'Codex startup reaper could not write a quarantine note')
   })
+  try {
+    await fsp.rename(metadataPath, quarantinePath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      // A concurrent boot handled the record first; drop the note we pre-wrote for it.
+      await fsp.unlink(`${quarantinePath}${QUARANTINE_NOTE_SUFFIX}`).catch(() => undefined)
+      return null
+    }
+    throw error
+  }
+  await fsp.chmod(quarantinePath, 0o600).catch(() => undefined)
   await fsp.unlink(reaperRetrySidecarPath(metadataPath)).catch(() => undefined)
   logger.warn({ metadataPath, quarantinePath, reason }, 'Codex startup reaper quarantined an ownership record')
   return quarantinePath
@@ -974,7 +1017,14 @@ export async function rescanCodexReaperQuarantine(
     return { promotedRecords, quarantinedCount }
   }
   for (const entry of entries) {
-    if (!entry.endsWith('.json') || entry.endsWith(QUARANTINE_NOTE_SUFFIX)) continue
+    if (entry.endsWith(QUARANTINE_NOTE_SUFFIX)) {
+      // m3: a note without its record is an orphan (quarantine/promote race); unlink it.
+      const recordName = entry.slice(0, -QUARANTINE_NOTE_SUFFIX.length)
+      const recordExists = await fsp.stat(path.join(quarantineDir, recordName)).then(() => true, () => false)
+      if (!recordExists) await fsp.unlink(path.join(quarantineDir, entry)).catch(() => undefined)
+      continue
+    }
+    if (!entry.endsWith('.json')) continue
     quarantinedCount += 1
     const quarantinePath = path.join(quarantineDir, entry)
     try {
@@ -1054,9 +1104,12 @@ export async function reapOrphanedCodexAppServerSidecars(
     unreadableRecords: [],
     quarantinedRecords: [],
     retriedOwnershipIds: [],
+    deferredForBudget: [],
     promotedFromQuarantine: [],
     reapingSkipped: false,
   }
+  const nowFn = options.nowFn ?? Date.now
+  const passStartedAt = nowFn()
 
   // Safety net first: promote quarantined records whose process group is still alive so this same
   // pass retries them (a quarantined record must never hide a live DB holder).
@@ -1090,11 +1143,30 @@ export async function reapOrphanedCodexAppServerSidecars(
   }
 
   for (const entry of entries) {
+    // m9: purge atomic-write tmp files stranded by a crash mid-write; anything older than an hour
+    // can never be renamed into place by its (dead) writer. Best-effort, never fatal.
+    if (entry.includes('.tmp-')) {
+      try {
+        const tmpPath = path.join(metadataDir, entry)
+        const tmpStat = await fsp.stat(tmpPath)
+        if (Date.now() - tmpStat.mtimeMs >= HOUR_MS) await fsp.unlink(tmpPath)
+      } catch {
+        // best-effort cleanup only
+      }
+      continue
+    }
     if (!entry.endsWith('.json') || entry.endsWith(REAPER_RETRY_SIDECAR_SUFFIX)) continue
     const metadataPath = path.join(metadataDir, entry)
     let ownershipId: string | undefined
     // Per-record isolation (I4): one bad record affects only itself, never the scan or the boot.
     try {
+      // m2: hourly (non-boot) passes gate PER RECORD on the time-based backoff — a record that is
+      // not yet due is skipped entirely (no attempt increment, no log), even when another record
+      // being due triggered the pass.
+      if (options.respectRetryBackoff) {
+        const retryState = await readCodexReaperRetryStateFile(reaperRetrySidecarPath(metadataPath))
+        if (retryState && !isCodexReaperRetryDue(retryState)) continue
+      }
       let raw: string
       try {
         raw = await fsp.readFile(metadataPath, 'utf8')
@@ -1186,6 +1258,25 @@ export async function reapOrphanedCodexAppServerSidecars(
       }
 
       const ownership: ActiveOwnership = { metadataDir, metadataPath, metadata }
+      // M2: once the pass's teardown budget is exhausted, skip the signal-and-wait teardown for
+      // the remaining records. They keep retry state (so they surface in the boot summary and the
+      // hourly tick re-attempts them) and are marked deferred — never dropped.
+      if (options.teardownBudgetMs !== undefined && nowFn() - passStartedAt > options.teardownBudgetMs) {
+        const state = await recordCodexReaperRetryAttempt(metadataPath)
+        logCodexReaperRetry(
+          {
+            ownershipId: metadata.ownershipId,
+            metadataPath,
+            wrapperPid: metadata.wrapperPid,
+            processGroupId: metadata.processGroupId,
+            teardownBudgetMs: options.teardownBudgetMs,
+          },
+          state,
+          'teardown budget exhausted this pass; deferred',
+        )
+        result.deferredForBudget.push(metadata.ownershipId)
+        continue
+      }
       const reaped = await teardownOwnedProcessGroup(ownership, options.terminateGraceMs ?? DEFAULT_TERMINATE_GRACE_MS)
       if (reaped) {
         result.reapedOwnershipIds.push(metadata.ownershipId)
@@ -1226,7 +1317,8 @@ export async function reapOrphanedCodexAppServerSidecars(
 export async function runCodexStartupReaper(
   options: ReapOrphanedSidecarsOptions,
 ): Promise<ReapOrphanedSidecarsResult> {
-  const result = await reapOrphanedCodexAppServerSidecars(options)
+  // Boot pass runs pre-listen: cap the total teardown time (panel M2). Callers may override.
+  const result = await reapOrphanedCodexAppServerSidecars({ teardownBudgetMs: CODEX_REAPER_BOOT_BUDGET_MS, ...options })
   summarizeCodexStartupReaperResult(result)
   return result
 }
@@ -1238,6 +1330,7 @@ function summarizeCodexStartupReaperResult(result: ReapOrphanedSidecarsResult): 
     + result.unreadableRecords.length
     + result.quarantinedRecords.length
     + result.retriedOwnershipIds.length
+    + result.deferredForBudget.length
   if (!result.reapingSkipped && unresolved === 0) return
   logger.warn(
     {
@@ -1246,6 +1339,7 @@ function summarizeCodexStartupReaperResult(result: ReapOrphanedSidecarsResult): 
       unreadableRecords: result.unreadableRecords,
       quarantinedRecords: result.quarantinedRecords,
       retriedOwnershipIds: [...new Set(result.retriedOwnershipIds)],
+      deferredForBudget: [...new Set(result.deferredForBudget)],
       promotedFromQuarantine: result.promotedFromQuarantine,
     },
     'Codex startup reaper completed with unresolved ownership records; continuing boot (fail-open)',
@@ -1539,6 +1633,9 @@ export class CodexAppServerRuntime {
     try {
       for await (const entry of dir) {
         if (!entry.isFile() || !entry.name.endsWith('.json')) continue
+        // m5: reaper backoff sidecars and quarantine notes are NOT ownership records; counting
+        // them as malformed would misreport the launch diagnostics.
+        if (entry.name.endsWith(REAPER_RETRY_SIDECAR_SUFFIX) || entry.name.endsWith(QUARANTINE_NOTE_SUFFIX)) continue
         if (total >= LAUNCH_DIAGNOSTIC_METADATA_RECORD_CAP) {
           capReached = true
           break
@@ -1971,6 +2068,20 @@ export class CodexAppServerRuntime {
     if (!ownership) {
       if (child && child.exitCode === null && child.signalCode === null) {
         child.kill('SIGTERM')
+      }
+      // m1: spawn failed before ownership was created, so teardownOwnedProcessGroup will never
+      // run for this child — deregister on its exit (or now, if it already exited) to avoid a
+      // permanent registry leak and a misleading codexChildren snapshot. Children WITH ownership
+      // are deregistered exclusively by confirmed-group-death teardown, never here.
+      const pid = child?.pid
+      if (child && pid) {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          deregisterCodexChild(pid)
+        } else {
+          child.once('exit', () => {
+            deregisterCodexChild(pid)
+          })
+        }
       }
       return
     }

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -969,8 +969,17 @@ async function recordCodexReaperDeferral(metadataPath: string): Promise<CodexRea
     attempts: 0,
   }
   try {
-    await atomicWriteJson(sidecarPath, state)
+    // R3-m3: create-exclusive, NOT atomic-rename. A concurrent instance's
+    // recordCodexReaperRetryAttempt can land between the sidecar read above and this write; a
+    // rename would clobber its attempts/lastAttempt back to zero. `wx` makes the race lose
+    // loudly (EEXIST), in which case the concurrent state wins and is returned as-is.
+    await fsp.writeFile(sidecarPath, `${JSON.stringify(state, null, 2)}\n`, { flag: 'wx', mode: 0o600 })
   } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      const concurrent = await readCodexReaperRetryStateFile(sidecarPath)
+      if (concurrent) return concurrent
+      return state // sidecar appeared but is unreadable/invalid: stay advisory, never throw
+    }
     logReaperSidecarWriteFailure(sidecarPath, error)
   }
   return state

--- a/server/coding-cli/codex-child-registry.ts
+++ b/server/coding-cli/codex-child-registry.ts
@@ -1,0 +1,196 @@
+import fs from 'node:fs'
+import { logger } from '../logger.js'
+
+// Stage 1a (plan §6): in-memory registry of live codex children (app-server sidecar wrappers and
+// codex resume ptys) so `process.on('exit')` can synchronously best-effort SIGKILL any process
+// group that graceful teardown did not confirm dead.
+//
+// Invariants (plan §2):
+// - I3: never signal an unregistered process. The group-kill primitive below has exactly ONE
+//   caller (`reapSync`), and `reapSync` is referenced only from the `'exit'` binding — both are
+//   enforced structurally by test/unit/server/coding-cli/codex-child-registry.test.ts.
+// - I4: nothing here may throw out of an exit path or block boot. Every reap step is per-entry
+//   try/catch'd; registration is a Map write.
+//
+// Platform gating: the negative-pid group kill and the /proc identity re-check are Linux-only
+// (consistent with `assertUnixSidecarSupport` in codex-app-server/runtime.ts). On win32 (and any
+// non-Linux platform) register/deregister still track entries, but `reapSync` does nothing.
+
+export type CodexChildKind = 'app-server' | 'resume-pty'
+
+export type CodexChildEntry = {
+  /** Direct child pid (app-server wrapper pid, or the resume pty's pid). */
+  pid: number
+  /** Process group id. Both child kinds are spawned as group/session leaders, so pgid == pid. */
+  pgid: number
+  kind: CodexChildKind
+}
+
+export type CodexChildRegistryLogger = {
+  warn: (fields: Record<string, unknown>, message: string) => void
+}
+
+export type CodexChildExitHandlerOptions = {
+  /**
+   * Routes SIGHUP into the existing graceful shutdown path (index.ts `shutdown()`, idempotent via
+   * `isShuttingDown`). Invoked with the literal reason 'SIGHUP'.
+   */
+  requestShutdown: (signal: string) => void
+}
+
+/** Minimal process surface, injectable for hermetic tests. */
+export type CodexChildProcessLike = {
+  pid: number
+  on: (event: string, listener: (...args: any[]) => void) => unknown
+}
+
+export type CodexChildRegistryDeps = {
+  platform?: NodeJS.Platform
+  /** Sync read used for /proc/self/stat (own pgid) and /proc/<pid>/cmdline (identity re-check). */
+  readFileSync?: (filePath: string) => Buffer
+  /** The raw signal syscall. Only `killProcessGroupSync` may invoke it with a negative pid. */
+  killSync?: (pid: number, signal: NodeJS.Signals) => void
+  proc?: CodexChildProcessLike
+  log?: CodexChildRegistryLogger
+}
+
+export type CodexChildRegistry = {
+  register: (entry: CodexChildEntry) => void
+  deregister: (pid: number) => boolean
+  snapshot: () => CodexChildEntry[]
+  reapSync: () => void
+  installExitHandlers: (options: CodexChildExitHandlerOptions) => void
+}
+
+/** Parses the pgrp field (field 5) of a `/proc/<pid>/stat` line; comm may contain spaces/parens. */
+function parseStatPgid(stat: string): number | null {
+  const closeParen = stat.lastIndexOf(')')
+  if (closeParen === -1) return null
+  const fields = stat.slice(closeParen + 2).trim().split(/\s+/)
+  const pgrp = Number(fields[2])
+  return Number.isInteger(pgrp) ? pgrp : null
+}
+
+export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): CodexChildRegistry {
+  const platform = deps.platform ?? process.platform
+  const readFileSync = deps.readFileSync ?? ((filePath: string) => fs.readFileSync(filePath))
+  const killSync = deps.killSync ?? ((pid: number, signal: NodeJS.Signals) => process.kill(pid, signal))
+  const proc = deps.proc ?? (process as CodexChildProcessLike)
+  const log = deps.log ?? logger.child({ component: 'codex-child-registry' })
+
+  const children = new Map<number, CodexChildEntry>()
+  let handlersInstalled = false
+
+  function register(entry: CodexChildEntry): void {
+    // Guards (I3): only well-formed, signalable-in-principle entries are ever tracked. pgid <= 1
+    // would make the exit-time kill(-pgid) hit "every process" (-1) / "own group" (0) / init (1).
+    if (!Number.isInteger(entry.pid) || entry.pid <= 0 || !Number.isInteger(entry.pgid) || entry.pgid <= 1) {
+      log.warn({ entry }, 'Refusing to register codex child with invalid pid/pgid')
+      return
+    }
+    // Double-registration of the same pid is safe: latest registration wins (plan §6 idempotency).
+    children.set(entry.pid, { pid: entry.pid, pgid: entry.pgid, kind: entry.kind })
+  }
+
+  function deregister(pid: number): boolean {
+    return children.delete(pid)
+  }
+
+  function snapshot(): CodexChildEntry[] {
+    return [...children.values()].map((entry) => ({ ...entry }))
+  }
+
+  /**
+   * THE group-kill primitive. I3 (structural): its only caller is `reapSync`, which itself runs
+   * only from the `'exit'` binding installed by `installExitHandlers`.
+   */
+  function killProcessGroupSync(pgid: number): void {
+    killSync(-pgid, 'SIGKILL')
+  }
+
+  /**
+   * Synchronous best-effort reap of still-registered codex process groups, for `process.on('exit')`.
+   * After a graceful shutdown the registry has been drained (children deregistered on confirmed
+   * group death / pty exit), so this is a no-op.
+   *
+   * Residual pgid-reuse window (accepted, plan §6): the sync cmdline re-check narrows — but cannot
+   * close — the check-then-kill race. Between reading /proc/<pid>/cmdline and kill(-pgid) the pid
+   * could exit and the pgid be reused. This is narrower than signalling blindly but wider than the
+   * async reaper's fresh ownership classification (runtime.ts classifyOwnedProcessGroup); at
+   * process-death time there is no async alternative.
+   */
+  function reapSync(): void {
+    try {
+      // Linux-only: negative-pid group kill semantics plus the /proc identity re-check. On win32
+      // (and darwin, which lacks /proc) this is a documented no-op.
+      if (platform !== 'linux') return
+
+      // Never signal our own process group. If we cannot prove our own pgid, refuse to signal
+      // anything (fail towards not signalling — I3 over reap completeness).
+      let ownPgid: number | null = null
+      try {
+        ownPgid = parseStatPgid(readFileSync('/proc/self/stat').toString('utf8'))
+      } catch {
+        ownPgid = null
+      }
+      if (ownPgid === null) return
+
+      for (const [pid, entry] of [...children]) {
+        try {
+          children.delete(pid)
+          const { pgid } = entry
+          // Guards (I3): only registered pgids; never -1/0/1, our own pid's group, or our own pgid.
+          if (!Number.isInteger(pgid) || pgid <= 1) continue
+          if (pgid === proc.pid || pgid === ownPgid) continue
+
+          // Cheap sync identity re-check: the registered pid must still be a codex process. A read
+          // failure means the process is gone (nothing to reap); a non-codex cmdline means the pid
+          // was reused (never signal it).
+          let cmdline: string
+          try {
+            cmdline = readFileSync(`/proc/${pid}/cmdline`).toString('utf8')
+          } catch {
+            continue
+          }
+          if (!cmdline.includes('codex')) continue
+
+          killProcessGroupSync(pgid)
+        } catch {
+          // Best-effort per entry: an exit path must never throw (I4).
+        }
+      }
+    } catch {
+      // Never throw out of an exit path (I4).
+    }
+  }
+
+  function installExitHandlers(options: CodexChildExitHandlerOptions): void {
+    if (handlersInstalled) return
+    handlersInstalled = true
+    // 'exit' handlers must be synchronous; reapSync is. This is the ONLY binding that may
+    // reference reapSync (I3, enforced structurally by the unit test).
+    proc.on('exit', reapSync)
+    // SIGHUP joins the existing graceful shutdown path (idempotent via isShuttingDown in index.ts).
+    proc.on('SIGHUP', () => options.requestShutdown('SIGHUP'))
+    // Observe/log ONLY: uncaughtException default-fatal semantics stay untouched; the fatal path
+    // then runs 'exit' -> reapSync.
+    proc.on('uncaughtExceptionMonitor', (error: unknown, origin: unknown) => {
+      try {
+        log.warn({ err: error, origin }, 'Uncaught exception observed; codex children will be reaped on exit')
+      } catch {
+        // Observability must never alter fatal-exception semantics.
+      }
+    })
+  }
+
+  return { register, deregister, snapshot, reapSync, installExitHandlers }
+}
+
+const defaultRegistry = createCodexChildRegistry()
+
+export const registerCodexChild: CodexChildRegistry['register'] = defaultRegistry.register
+export const deregisterCodexChild: CodexChildRegistry['deregister'] = defaultRegistry.deregister
+export const snapshotCodexChildren: CodexChildRegistry['snapshot'] = defaultRegistry.snapshot
+export const reapSync: CodexChildRegistry['reapSync'] = defaultRegistry.reapSync
+export const installCodexChildExitHandlers: CodexChildRegistry['installExitHandlers'] =
+  defaultRegistry.installExitHandlers

--- a/server/coding-cli/codex-child-registry.ts
+++ b/server/coding-cli/codex-child-registry.ts
@@ -8,7 +8,9 @@ import { logger } from '../logger.js'
 // Invariants (plan §2):
 // - I3: never signal an unregistered process. The group-kill primitive below has exactly ONE
 //   caller (`reapSync`), and `reapSync` is referenced only from the `'exit'` binding — both are
-//   enforced structurally by test/unit/server/coding-cli/codex-child-registry.test.ts.
+//   enforced structurally by test/unit/server/coding-cli/codex-child-registry.test.ts. The only
+//   other negative-pid syscall in this module is the signal-0 liveness probe, which delivers
+//   nothing by definition.
 // - I4: nothing here may throw out of an exit path or block boot. Every reap step is per-entry
 //   try/catch'd; registration is a Map write plus a best-effort /proc stat read.
 //
@@ -17,6 +19,12 @@ import { logger } from '../logger.js'
 // non-Linux platform) register/deregister still track entries, but `reapSync` does nothing.
 
 export type CodexChildKind = 'app-server' | 'resume-pty'
+
+export type CodexChildEnvMarker = {
+  /** Env var name injected into the child's environment at spawn (e.g. FRESHELL_TERMINAL_ID). */
+  name: string
+  value: string
+}
 
 export type CodexChildEntry = {
   /** Direct child pid (app-server wrapper pid, or the resume pty's pid). */
@@ -27,9 +35,17 @@ export type CodexChildEntry = {
   /**
    * /proc/<pid>/stat starttime (field 22, clock ticks since boot) captured at registration.
    * Registration is best-effort: undefined when the stat was unreadable/unparseable at register
-   * time, in which case reapSync falls back to the pgrp+cmdline identity checks for this entry.
+   * time, in which case reapSync routes the entry to the ownership-gated group scan (r2-1) —
+   * pgrp+cmdline alone are never trusted for a kill.
    */
   startTimeTicks?: number
+  /**
+   * R2-M1: ownership proof for the dead-pid group-scan fallback. The exact `NAME=VALUE` pair must
+   * be present in a group member's /proc environ before the fallback may conclude the registered
+   * pgid still hosts OUR codex child. Without a recorded marker the fallback never kills (fail
+   * closed): a recycled pgid can host the OTHER server instance's live codex pane.
+   */
+  envMarker?: CodexChildEnvMarker
 }
 
 export type CodexChildRegistryLogger = {
@@ -50,14 +66,27 @@ export type CodexChildProcessLike = {
   on: (event: string, listener: (...args: any[]) => void) => unknown
 }
 
+export type CodexGroupProbeResult = 'alive' | 'gone' | 'unknown'
+
 export type CodexChildRegistryDeps = {
   platform?: NodeJS.Platform
-  /** Sync read used for /proc/<pid>/stat and /proc/<pid>/cmdline identity checks. */
+  /** Sync read used for /proc/<pid>/stat identity checks (small, fixed-size content). */
   readFileSync?: (filePath: string) => Buffer
+  /**
+   * r2-3: bounded sync read used for /proc cmdline/environ on the exit path. Defaults to an
+   * openSync+readSync fixed-buffer read; when only readFileSync is injected (tests), a bounded
+   * wrapper is derived from it.
+   */
+  readFileBoundedSync?: (filePath: string, maxBytes: number) => { data: Buffer; truncated: boolean }
   /** Sync directory listing used only by the dead-pid group-membership fallback scan. */
   readdirSync?: (dirPath: string) => string[]
   /** The raw signal syscall. Only `killProcessGroupSync` may invoke it with a negative pid. */
   killSync?: (pid: number, signal: NodeJS.Signals) => void
+  /**
+   * Signal-0 group liveness probe (delivers NOTHING — error checking only, I3-safe). 'unknown'
+   * covers EPERM and any other non-ESRCH failure: the group may still have members we cannot see.
+   */
+  probeGroupSync?: (pgid: number) => CodexGroupProbeResult
   proc?: CodexChildProcessLike
   log?: CodexChildRegistryLogger
 }
@@ -65,12 +94,34 @@ export type CodexChildRegistryDeps = {
 export type CodexChildRegistry = {
   register: (entry: CodexChildEntry) => void
   deregister: (pid: number) => boolean
+  /**
+   * m8: deregister only when the signal-0 probe confirms the whole group is gone (ESRCH). On
+   * 'alive'/'unknown' (e.g. EPERM) the entry stays registered so exit-time reap still covers it.
+   * On non-Linux platforms (no negative-pid probe semantics guaranteed + reapSync is a no-op
+   * there) deregisters unconditionally.
+   */
+  deregisterIfGroupGone: (pid: number) => boolean
   snapshot: () => CodexChildEntry[]
+  /**
+   * r2-11: steady-state drain — ESRCH-probe every 'resume-pty' entry and deregister confirmed-gone
+   * groups. onExit-time deregistration keeps an entry when its group still had members (or the
+   * probe was inconclusive); if those members die later no event fires, so the hourly
+   * observability tick calls this. Probe-only (signal 0): never signals. Returns drained count.
+   */
+  probeResumePtyGroups: () => number
   reapSync: () => void
   installExitHandlers: (options: CodexChildExitHandlerOptions) => void
 }
 
+/** r2-3: hard byte bound for exit-path /proc cmdline/environ reads. */
+export const PROC_READ_MAX_BYTES = 4096
+
 type ProcStatInfo = { pgrp: number; startTimeTicks: number }
+
+type BoundedRead = { data: Buffer; truncated: boolean }
+
+/** pgid -> live member pids, built at most once per reap pass (r2-4). */
+type ProcGroupIndex = Map<number, number[]>
 
 /**
  * Parses pgrp (field 5) and starttime (field 22) of a `/proc/<pid>/stat` line; comm may contain
@@ -86,11 +137,75 @@ function parseProcStatInfo(stat: string): ProcStatInfo | null {
   return { pgrp, startTimeTicks }
 }
 
+/**
+ * r2-2: codex identity predicate over a NUL-separated /proc cmdline. Some argv token's basename
+ * must be exactly `codex` — argv[0] for the plain binary, any later token for node-wrapper
+ * launches like `node /x/bin/codex`. Substring matches are rejected: `vim codex-notes.md` or a
+ * path that merely contains "codex" (worktree/branch names) must never look like a codex process.
+ *
+ * r2-12 (accepted reap-completeness caveat): a codex binary invoked under a name whose argv
+ * contains no `codex` basename token (renamed copy, busybox-style symlink) is INVISIBLE to
+ * exit-time reap and to the observability holder count. That fails SAFE for I3 — we never signal
+ * what we cannot identify — but stays open for the leak; the async reaper's env-marker ownership
+ * proof (runtime.ts) is the durable backstop for such groups.
+ */
+export function cmdlineHasCodexToken(rawCmdline: string): boolean {
+  for (const token of rawCmdline.split('\0')) {
+    if (token.length === 0) continue
+    if (token.slice(token.lastIndexOf('/') + 1) === 'codex') return true
+  }
+  return false
+}
+
+/**
+ * r2-3: bounded synchronous /proc read for the exit path — openSync + readSync into a fixed
+ * buffer, never fs.readFileSync (a pathological cmdline/environ cannot balloon exit-time memory
+ * or latency). Reads one byte past maxBytes purely to detect truncation.
+ */
+function readProcFileBoundedSync(filePath: string, maxBytes: number): BoundedRead {
+  const fd = fs.openSync(filePath, 'r')
+  try {
+    const buffer = Buffer.allocUnsafe(maxBytes + 1)
+    let total = 0
+    while (total < buffer.length) {
+      const bytesRead = fs.readSync(fd, buffer, total, buffer.length - total, null)
+      if (bytesRead === 0) break
+      total += bytesRead
+    }
+    return { data: buffer.subarray(0, Math.min(total, maxBytes)), truncated: total > maxBytes }
+  } finally {
+    fs.closeSync(fd)
+  }
+}
+
+/**
+ * Default signal-0 group liveness probe. Signal 0 performs error checking only — the kernel
+ * delivers nothing, so this can never kill (I3-safe; the structural test pins the `0`).
+ */
+function defaultProbeGroupSync(pgid: number): CodexGroupProbeResult {
+  try {
+    process.kill(-pgid, 0)
+    return 'alive'
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ESRCH' ? 'gone' : 'unknown'
+  }
+}
+
 export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): CodexChildRegistry {
   const platform = deps.platform ?? process.platform
   const readFileSync = deps.readFileSync ?? ((filePath: string) => fs.readFileSync(filePath))
+  // r2-3: tests that inject only readFileSync get a bounded wrapper derived from it, so the same
+  // fake file map drives both read paths; production uses the fixed-buffer openSync read.
+  const readFileBoundedSync = deps.readFileBoundedSync
+    ?? (deps.readFileSync
+      ? (filePath: string, maxBytes: number): BoundedRead => {
+          const data = readFileSync(filePath)
+          return { data: data.subarray(0, maxBytes), truncated: data.length > maxBytes }
+        }
+      : readProcFileBoundedSync)
   const readdirSync = deps.readdirSync ?? ((dirPath: string) => fs.readdirSync(dirPath))
   const killSync = deps.killSync ?? ((pid: number, signal: NodeJS.Signals) => process.kill(pid, signal))
+  const probeGroupSync = deps.probeGroupSync ?? defaultProbeGroupSync
   const proc = deps.proc ?? (process as CodexChildProcessLike)
   const log = deps.log ?? logger.child({ component: 'codex-child-registry' })
 
@@ -106,8 +221,8 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
     }
     // Pin the pid's identity at registration (panel M1a): entries can outlive a recycled pid by
     // days, so the exit-time reap must be able to prove the pid still names the SAME process.
-    // Best-effort — an unreadable stat stores undefined and that entry falls back to the
-    // pgrp+cmdline checks alone.
+    // Best-effort — an unreadable stat stores undefined and that entry is routed to the
+    // ownership-gated group scan at reap time (r2-1).
     let startTimeTicks: number | undefined
     if (platform === 'linux') {
       try {
@@ -116,12 +231,21 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
         startTimeTicks = undefined
       }
     }
+    // R2-M1: only a well-formed NAME=VALUE marker is recorded; anything else is treated as "no
+    // ownership proof available", which fail-closes the dead-pid group fallback for this entry.
+    const envMarker =
+      entry.envMarker
+      && typeof entry.envMarker.name === 'string' && entry.envMarker.name.length > 0
+      && typeof entry.envMarker.value === 'string' && entry.envMarker.value.length > 0
+        ? { name: entry.envMarker.name, value: entry.envMarker.value }
+        : undefined
     // Double-registration of the same pid is safe: latest registration wins (plan §6 idempotency).
     children.set(entry.pid, {
       pid: entry.pid,
       pgid: entry.pgid,
       kind: entry.kind,
       ...(startTimeTicks !== undefined ? { startTimeTicks } : {}),
+      ...(envMarker ? { envMarker } : {}),
     })
   }
 
@@ -129,8 +253,35 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
     return children.delete(pid)
   }
 
+  function deregisterIfGroupGone(pid: number): boolean {
+    if (platform === 'linux') {
+      const pgid = children.get(pid)?.pgid ?? pid
+      if (probeGroupSync(pgid) !== 'gone') return false
+    }
+    return children.delete(pid)
+  }
+
   function snapshot(): CodexChildEntry[] {
     return [...children.values()].map((entry) => ({ ...entry }))
+  }
+
+  function probeResumePtyGroups(): number {
+    // Linux-only, like reapSync: negative-pid probe semantics are what the drain relies on, and
+    // exit-time reap (the thing stale entries would mislead) is a no-op elsewhere anyway.
+    if (platform !== 'linux') return 0
+    let drained = 0
+    for (const [pid, entry] of [...children]) {
+      if (entry.kind !== 'resume-pty') continue
+      try {
+        if (probeGroupSync(entry.pgid) === 'gone') {
+          children.delete(pid)
+          drained += 1
+        }
+      } catch {
+        // The probe seam must never break the observability tick.
+      }
+    }
+    return drained
   }
 
   /**
@@ -142,41 +293,82 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
   }
 
   /**
-   * Dead-pid fallback (panel M1b): the registered wrapper pid being gone does NOT mean the group
-   * is gone — live grandchildren (the actual DB holders) can survive it, and that is precisely the
-   * case the registry exists for. Bounded sync scan of /proc: kill only when a member of the
-   * registered pgid is provably a codex process; if members exist but none are codex the pgid was
-   * recycled — never signal it. Fully synchronous, per-pid try/catch'd.
+   * r2-4: one bounded /proc walk per reap pass, shared across all dead-pid entries — a single
+   * readdir plus one stat parse per pid, instead of a full rescan per entry. Returns null when
+   * /proc cannot be enumerated (callers fail towards not signalling, I3).
    */
-  function groupHasCodexMemberSync(pgid: number): boolean {
+  function buildProcGroupIndexSync(): ProcGroupIndex | null {
     let names: string[]
     try {
       names = readdirSync('/proc')
     } catch {
-      return false // cannot enumerate: fail towards not signalling (I3)
+      return null
     }
+    const index: ProcGroupIndex = new Map()
     for (const name of names) {
       if (!/^\d+$/.test(name)) continue
       try {
         const info = parseProcStatInfo(readFileSync(`/proc/${name}/stat`).toString('utf8'))
-        if (!info || info.pgrp !== pgid) continue
-        const cmdline = readFileSync(`/proc/${name}/cmdline`).toString('utf8')
-        if (cmdline.includes('codex')) return true
+        if (!info) continue
+        const members = index.get(info.pgrp)
+        if (members) {
+          members.push(Number(name))
+        } else {
+          index.set(info.pgrp, [Number(name)])
+        }
+      } catch {
+        continue // pid vanished mid-scan or unreadable
+      }
+    }
+    return index
+  }
+
+  /**
+   * Dead-pid fallback (panel M1b + R2-M1 ownership gate): the registered wrapper pid being gone
+   * does NOT mean the group is gone — live grandchildren (the actual DB holders) can survive it,
+   * and that is precisely the case the registry exists for. But pgid recycling means membership
+   * plus a codex-looking cmdline is NOT ownership proof (the recycled pgid could host the OTHER
+   * server instance's live codex pane). Kill only when a member of the registered pgid provably
+   * carries the exact env marker this registration injected at spawn. No marker recorded,
+   * unreadable environ, or a marker missing from a TRUNCATED environ read all fail closed.
+   * Fully synchronous, per-pid try/catch'd.
+   */
+  function groupHasOwnedCodexMemberSync(
+    entry: CodexChildEntry,
+    getGroupIndex: () => ProcGroupIndex | null,
+  ): boolean {
+    // R2-M1: without a recorded env marker there is no ownership proof to check — never kill.
+    if (!entry.envMarker) return false
+    const marker = `${entry.envMarker.name}=${entry.envMarker.value}`
+    const index = getGroupIndex()
+    if (!index) return false // cannot enumerate /proc: fail towards not signalling (I3)
+    const members = index.get(entry.pgid)
+    if (!members || members.length === 0) return false // group gone (or fully unreadable)
+    for (const pid of members) {
+      try {
+        // Cheap cmdline prefilter before the (larger) environ read.
+        const cmdline = readFileBoundedSync(`/proc/${pid}/cmdline`, PROC_READ_MAX_BYTES)
+        if (!cmdlineHasCodexToken(cmdline.data.toString('utf8'))) continue
+        // Ownership proof: the exact NAME=VALUE marker injected at spawn. A marker that is absent
+        // from a truncated read could live past the cutoff — that is absence of proof, not proof
+        // of absence, so it never justifies a kill (r2-3 fail-closed).
+        const environ = readFileBoundedSync(`/proc/${pid}/environ`, PROC_READ_MAX_BYTES)
+        if (environ.data.toString('utf8').split('\0').includes(marker)) return true
       } catch {
         continue // member vanished mid-scan or is unreadable: not proof either way
       }
     }
-    return false // no members (group gone) or only non-codex members (pgid recycled)
+    return false // no member carries our marker: never signal
   }
 
   /**
-   * Identity verdict for one registered entry (panel M1a). Kill only when EVERY provable check
-   * passes: recorded starttime matches exactly (when recorded), the pid is still in the registered
-   * process group, and its cmdline still looks like codex. Any mismatch means the entry is stale
-   * (pid recycled — possibly by the OTHER server instance's live codex pane) and must be skipped.
-   * A pid that is gone from /proc routes to the dead-pid group fallback above.
+   * Identity verdict for one registered entry (panel M1a). The live-pid fast path kills only when
+   * EVERY provable check passes: recorded starttime matches exactly, the pid is still in the
+   * registered process group, and its cmdline carries a codex token. Entries without a starttime
+   * pin (r2-1), dead pids, and zombie/unreadable-cmdline wrappers all route to the ownership-gated
+   * group scan above — pgrp+cmdline alone are never grounds to kill.
    */
-  function shouldKillEntrySync(entry: CodexChildEntry): boolean {
+  function shouldKillEntrySync(entry: CodexChildEntry, getGroupIndex: () => ProcGroupIndex | null): boolean {
     let statRaw: string | null
     try {
       statRaw = readFileSync(`/proc/${entry.pid}/stat`).toString('utf8')
@@ -185,26 +377,32 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
     }
     if (statRaw === null) {
       // Registered pid is dead; the group may still hold live codex grandchildren.
-      return groupHasCodexMemberSync(entry.pgid)
+      return groupHasOwnedCodexMemberSync(entry, getGroupIndex)
     }
     const info = parseProcStatInfo(statRaw)
     if (!info) return false // present but unprovable: never signal (I3)
-    if (entry.startTimeTicks !== undefined && info.startTimeTicks !== entry.startTimeTicks) {
+    if (entry.startTimeTicks === undefined) {
+      // r2-1: no identity pin was captured at registration, so the live-pid path cannot prove the
+      // pid was not recycled. Route to the ownership-gated group scan instead of trusting
+      // pgrp+cmdline alone.
+      return groupHasOwnedCodexMemberSync(entry, getGroupIndex)
+    }
+    if (info.startTimeTicks !== entry.startTimeTicks) {
       return false // pid recycled by a different process: stale entry
     }
     if (info.pgrp !== entry.pgid) return false // pid no longer in the registered group: stale entry
-    let cmdline: string
+    let cmdline: BoundedRead
     try {
-      cmdline = readFileSync(`/proc/${entry.pid}/cmdline`).toString('utf8')
+      cmdline = readFileBoundedSync(`/proc/${entry.pid}/cmdline`, PROC_READ_MAX_BYTES)
     } catch {
       // stat readable but cmdline not (e.g. zombie wrapper): treat as dead-pid, scan the group.
-      return groupHasCodexMemberSync(entry.pgid)
+      return groupHasOwnedCodexMemberSync(entry, getGroupIndex)
     }
-    if (cmdline.length === 0) {
+    if (cmdline.data.length === 0) {
       // Zombie wrapper (empty cmdline): the wrapper is dead but grandchildren may live.
-      return groupHasCodexMemberSync(entry.pgid)
+      return groupHasOwnedCodexMemberSync(entry, getGroupIndex)
     }
-    return cmdline.includes('codex')
+    return cmdlineHasCodexToken(cmdline.data.toString('utf8'))
   }
 
   /**
@@ -234,6 +432,14 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
       }
       if (ownPgid === null) return
 
+      // r2-4: the /proc group index for dead-pid fallbacks is built lazily, at most once per pass,
+      // and shared across every entry that needs the group scan.
+      let groupIndex: ProcGroupIndex | null | undefined
+      const getGroupIndex = (): ProcGroupIndex | null => {
+        if (groupIndex === undefined) groupIndex = buildProcGroupIndexSync()
+        return groupIndex
+      }
+
       for (const [pid, entry] of [...children]) {
         try {
           children.delete(pid)
@@ -241,7 +447,7 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
           // Guards (I3): only registered pgids; never -1/0/1, our own pid's group, or our own pgid.
           if (!Number.isInteger(pgid) || pgid <= 1) continue
           if (pgid === proc.pid || pgid === ownPgid) continue
-          if (!shouldKillEntrySync(entry)) continue
+          if (!shouldKillEntrySync(entry, getGroupIndex)) continue
 
           killProcessGroupSync(pgid)
         } catch {
@@ -272,14 +478,26 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
     })
   }
 
-  return { register, deregister, snapshot, reapSync, installExitHandlers }
+  return {
+    register,
+    deregister,
+    deregisterIfGroupGone,
+    snapshot,
+    probeResumePtyGroups,
+    reapSync,
+    installExitHandlers,
+  }
 }
 
 const defaultRegistry = createCodexChildRegistry()
 
 export const registerCodexChild: CodexChildRegistry['register'] = defaultRegistry.register
 export const deregisterCodexChild: CodexChildRegistry['deregister'] = defaultRegistry.deregister
+export const deregisterCodexChildIfGroupGone: CodexChildRegistry['deregisterIfGroupGone'] =
+  defaultRegistry.deregisterIfGroupGone
 export const snapshotCodexChildren: CodexChildRegistry['snapshot'] = defaultRegistry.snapshot
+export const probeRegisteredResumePtyGroups: CodexChildRegistry['probeResumePtyGroups'] =
+  defaultRegistry.probeResumePtyGroups
 export const reapSync: CodexChildRegistry['reapSync'] = defaultRegistry.reapSync
 export const installCodexChildExitHandlers: CodexChildRegistry['installExitHandlers'] =
   defaultRegistry.installExitHandlers

--- a/server/coding-cli/codex-child-registry.ts
+++ b/server/coding-cli/codex-child-registry.ts
@@ -10,7 +10,7 @@ import { logger } from '../logger.js'
 //   caller (`reapSync`), and `reapSync` is referenced only from the `'exit'` binding — both are
 //   enforced structurally by test/unit/server/coding-cli/codex-child-registry.test.ts.
 // - I4: nothing here may throw out of an exit path or block boot. Every reap step is per-entry
-//   try/catch'd; registration is a Map write.
+//   try/catch'd; registration is a Map write plus a best-effort /proc stat read.
 //
 // Platform gating: the negative-pid group kill and the /proc identity re-check are Linux-only
 // (consistent with `assertUnixSidecarSupport` in codex-app-server/runtime.ts). On win32 (and any
@@ -24,6 +24,12 @@ export type CodexChildEntry = {
   /** Process group id. Both child kinds are spawned as group/session leaders, so pgid == pid. */
   pgid: number
   kind: CodexChildKind
+  /**
+   * /proc/<pid>/stat starttime (field 22, clock ticks since boot) captured at registration.
+   * Registration is best-effort: undefined when the stat was unreadable/unparseable at register
+   * time, in which case reapSync falls back to the pgrp+cmdline identity checks for this entry.
+   */
+  startTimeTicks?: number
 }
 
 export type CodexChildRegistryLogger = {
@@ -46,8 +52,10 @@ export type CodexChildProcessLike = {
 
 export type CodexChildRegistryDeps = {
   platform?: NodeJS.Platform
-  /** Sync read used for /proc/self/stat (own pgid) and /proc/<pid>/cmdline (identity re-check). */
+  /** Sync read used for /proc/<pid>/stat and /proc/<pid>/cmdline identity checks. */
   readFileSync?: (filePath: string) => Buffer
+  /** Sync directory listing used only by the dead-pid group-membership fallback scan. */
+  readdirSync?: (dirPath: string) => string[]
   /** The raw signal syscall. Only `killProcessGroupSync` may invoke it with a negative pid. */
   killSync?: (pid: number, signal: NodeJS.Signals) => void
   proc?: CodexChildProcessLike
@@ -62,18 +70,26 @@ export type CodexChildRegistry = {
   installExitHandlers: (options: CodexChildExitHandlerOptions) => void
 }
 
-/** Parses the pgrp field (field 5) of a `/proc/<pid>/stat` line; comm may contain spaces/parens. */
-function parseStatPgid(stat: string): number | null {
+type ProcStatInfo = { pgrp: number; startTimeTicks: number }
+
+/**
+ * Parses pgrp (field 5) and starttime (field 22) of a `/proc/<pid>/stat` line; comm may contain
+ * spaces/parens, so fields are counted after the LAST close paren.
+ */
+function parseProcStatInfo(stat: string): ProcStatInfo | null {
   const closeParen = stat.lastIndexOf(')')
   if (closeParen === -1) return null
   const fields = stat.slice(closeParen + 2).trim().split(/\s+/)
   const pgrp = Number(fields[2])
-  return Number.isInteger(pgrp) ? pgrp : null
+  const startTimeTicks = Number(fields[19])
+  if (!Number.isInteger(pgrp) || !Number.isFinite(startTimeTicks)) return null
+  return { pgrp, startTimeTicks }
 }
 
 export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): CodexChildRegistry {
   const platform = deps.platform ?? process.platform
   const readFileSync = deps.readFileSync ?? ((filePath: string) => fs.readFileSync(filePath))
+  const readdirSync = deps.readdirSync ?? ((dirPath: string) => fs.readdirSync(dirPath))
   const killSync = deps.killSync ?? ((pid: number, signal: NodeJS.Signals) => process.kill(pid, signal))
   const proc = deps.proc ?? (process as CodexChildProcessLike)
   const log = deps.log ?? logger.child({ component: 'codex-child-registry' })
@@ -88,8 +104,25 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
       log.warn({ entry }, 'Refusing to register codex child with invalid pid/pgid')
       return
     }
+    // Pin the pid's identity at registration (panel M1a): entries can outlive a recycled pid by
+    // days, so the exit-time reap must be able to prove the pid still names the SAME process.
+    // Best-effort — an unreadable stat stores undefined and that entry falls back to the
+    // pgrp+cmdline checks alone.
+    let startTimeTicks: number | undefined
+    if (platform === 'linux') {
+      try {
+        startTimeTicks = parseProcStatInfo(readFileSync(`/proc/${entry.pid}/stat`).toString('utf8'))?.startTimeTicks
+      } catch {
+        startTimeTicks = undefined
+      }
+    }
     // Double-registration of the same pid is safe: latest registration wins (plan §6 idempotency).
-    children.set(entry.pid, { pid: entry.pid, pgid: entry.pgid, kind: entry.kind })
+    children.set(entry.pid, {
+      pid: entry.pid,
+      pgid: entry.pgid,
+      kind: entry.kind,
+      ...(startTimeTicks !== undefined ? { startTimeTicks } : {}),
+    })
   }
 
   function deregister(pid: number): boolean {
@@ -109,15 +142,81 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
   }
 
   /**
+   * Dead-pid fallback (panel M1b): the registered wrapper pid being gone does NOT mean the group
+   * is gone — live grandchildren (the actual DB holders) can survive it, and that is precisely the
+   * case the registry exists for. Bounded sync scan of /proc: kill only when a member of the
+   * registered pgid is provably a codex process; if members exist but none are codex the pgid was
+   * recycled — never signal it. Fully synchronous, per-pid try/catch'd.
+   */
+  function groupHasCodexMemberSync(pgid: number): boolean {
+    let names: string[]
+    try {
+      names = readdirSync('/proc')
+    } catch {
+      return false // cannot enumerate: fail towards not signalling (I3)
+    }
+    for (const name of names) {
+      if (!/^\d+$/.test(name)) continue
+      try {
+        const info = parseProcStatInfo(readFileSync(`/proc/${name}/stat`).toString('utf8'))
+        if (!info || info.pgrp !== pgid) continue
+        const cmdline = readFileSync(`/proc/${name}/cmdline`).toString('utf8')
+        if (cmdline.includes('codex')) return true
+      } catch {
+        continue // member vanished mid-scan or is unreadable: not proof either way
+      }
+    }
+    return false // no members (group gone) or only non-codex members (pgid recycled)
+  }
+
+  /**
+   * Identity verdict for one registered entry (panel M1a). Kill only when EVERY provable check
+   * passes: recorded starttime matches exactly (when recorded), the pid is still in the registered
+   * process group, and its cmdline still looks like codex. Any mismatch means the entry is stale
+   * (pid recycled — possibly by the OTHER server instance's live codex pane) and must be skipped.
+   * A pid that is gone from /proc routes to the dead-pid group fallback above.
+   */
+  function shouldKillEntrySync(entry: CodexChildEntry): boolean {
+    let statRaw: string | null
+    try {
+      statRaw = readFileSync(`/proc/${entry.pid}/stat`).toString('utf8')
+    } catch {
+      statRaw = null
+    }
+    if (statRaw === null) {
+      // Registered pid is dead; the group may still hold live codex grandchildren.
+      return groupHasCodexMemberSync(entry.pgid)
+    }
+    const info = parseProcStatInfo(statRaw)
+    if (!info) return false // present but unprovable: never signal (I3)
+    if (entry.startTimeTicks !== undefined && info.startTimeTicks !== entry.startTimeTicks) {
+      return false // pid recycled by a different process: stale entry
+    }
+    if (info.pgrp !== entry.pgid) return false // pid no longer in the registered group: stale entry
+    let cmdline: string
+    try {
+      cmdline = readFileSync(`/proc/${entry.pid}/cmdline`).toString('utf8')
+    } catch {
+      // stat readable but cmdline not (e.g. zombie wrapper): treat as dead-pid, scan the group.
+      return groupHasCodexMemberSync(entry.pgid)
+    }
+    if (cmdline.length === 0) {
+      // Zombie wrapper (empty cmdline): the wrapper is dead but grandchildren may live.
+      return groupHasCodexMemberSync(entry.pgid)
+    }
+    return cmdline.includes('codex')
+  }
+
+  /**
    * Synchronous best-effort reap of still-registered codex process groups, for `process.on('exit')`.
    * After a graceful shutdown the registry has been drained (children deregistered on confirmed
    * group death / pty exit), so this is a no-op.
    *
-   * Residual pgid-reuse window (accepted, plan §6): the sync cmdline re-check narrows — but cannot
-   * close — the check-then-kill race. Between reading /proc/<pid>/cmdline and kill(-pgid) the pid
-   * could exit and the pgid be reused. This is narrower than signalling blindly but wider than the
-   * async reaper's fresh ownership classification (runtime.ts classifyOwnedProcessGroup); at
-   * process-death time there is no async alternative.
+   * Residual pgid-reuse window (accepted, plan §6): the sync starttime+pgrp+cmdline re-check
+   * narrows — but cannot close — the check-then-kill race. Between the /proc reads and kill(-pgid)
+   * the pid could exit and the pgid be reused. This is narrower than signalling blindly but wider
+   * than the async reaper's fresh ownership classification (runtime.ts classifyOwnedProcessGroup);
+   * at process-death time there is no async alternative.
    */
   function reapSync(): void {
     try {
@@ -129,7 +228,7 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
       // anything (fail towards not signalling — I3 over reap completeness).
       let ownPgid: number | null = null
       try {
-        ownPgid = parseStatPgid(readFileSync('/proc/self/stat').toString('utf8'))
+        ownPgid = parseProcStatInfo(readFileSync('/proc/self/stat').toString('utf8'))?.pgrp ?? null
       } catch {
         ownPgid = null
       }
@@ -142,17 +241,7 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
           // Guards (I3): only registered pgids; never -1/0/1, our own pid's group, or our own pgid.
           if (!Number.isInteger(pgid) || pgid <= 1) continue
           if (pgid === proc.pid || pgid === ownPgid) continue
-
-          // Cheap sync identity re-check: the registered pid must still be a codex process. A read
-          // failure means the process is gone (nothing to reap); a non-codex cmdline means the pid
-          // was reused (never signal it).
-          let cmdline: string
-          try {
-            cmdline = readFileSync(`/proc/${pid}/cmdline`).toString('utf8')
-          } catch {
-            continue
-          }
-          if (!cmdline.includes('codex')) continue
+          if (!shouldKillEntrySync(entry)) continue
 
           killProcessGroupSync(pgid)
         } catch {

--- a/server/coding-cli/codex-child-registry.ts
+++ b/server/coding-cli/codex-child-registry.ts
@@ -50,6 +50,11 @@ export type CodexChildEntry = {
 
 export type CodexChildRegistryLogger = {
   warn: (fields: Record<string, unknown>, message: string) => void
+  /**
+   * R3-M1: optional debug hook -- used to distinguish "provably not ours" from "ownership marker
+   * unreachable past a truncated environ read". Absent on minimal injected loggers (no-op then).
+   */
+  debug?: (fields: Record<string, unknown>, message: string) => void
 }
 
 export type CodexChildExitHandlerOptions = {
@@ -113,12 +118,23 @@ export type CodexChildRegistry = {
   installExitHandlers: (options: CodexChildExitHandlerOptions) => void
 }
 
-/** r2-3: hard byte bound for exit-path /proc cmdline/environ reads. */
+/** r2-3: hard byte bound for exit-path /proc cmdline reads. */
 export const PROC_READ_MAX_BYTES = 4096
+
+/**
+ * R3-M1: hard byte bound for exit-path /proc environ reads. Both spawn sites append the ownership
+ * marker LAST in env-spread order (reordering would break override semantics when the dev server
+ * itself runs inside a freshell pane whose parentEnv already carries FRESHELL_TERMINAL_ID), and
+ * real environs on this host run ~5,900 bytes -- so the previous 4096-byte bound left the marker
+ * unreachable on essentially every spawn and the dead-pid group reap silently never fired. Linux
+ * caps a single env string at 128 KiB, so 256 KiB stays a hard bound while comfortably covering
+ * any realistic environ.
+ */
+export const PROC_ENVIRON_READ_MAX_BYTES = 256 * 1024
 
 type ProcStatInfo = { pgrp: number; startTimeTicks: number }
 
-type BoundedRead = { data: Buffer; truncated: boolean }
+export type BoundedRead = { data: Buffer; truncated: boolean }
 
 /** pgid -> live member pids, built at most once per reap pass (r2-4). */
 type ProcGroupIndex = Map<number, number[]>
@@ -162,7 +178,7 @@ export function cmdlineHasCodexToken(rawCmdline: string): boolean {
  * buffer, never fs.readFileSync (a pathological cmdline/environ cannot balloon exit-time memory
  * or latency). Reads one byte past maxBytes purely to detect truncation.
  */
-function readProcFileBoundedSync(filePath: string, maxBytes: number): BoundedRead {
+export function readProcFileBoundedSync(filePath: string, maxBytes: number): BoundedRead {
   const fd = fs.openSync(filePath, 'r')
   try {
     const buffer = Buffer.allocUnsafe(maxBytes + 1)
@@ -351,9 +367,23 @@ export function createCodexChildRegistry(deps: CodexChildRegistryDeps = {}): Cod
         if (!cmdlineHasCodexToken(cmdline.data.toString('utf8'))) continue
         // Ownership proof: the exact NAME=VALUE marker injected at spawn. A marker that is absent
         // from a truncated read could live past the cutoff — that is absence of proof, not proof
-        // of absence, so it never justifies a kill (r2-3 fail-closed).
-        const environ = readFileBoundedSync(`/proc/${pid}/environ`, PROC_READ_MAX_BYTES)
-        if (environ.data.toString('utf8').split('\0').includes(marker)) return true
+        // of absence, so it never justifies a kill (r2-3 fail-closed). R3-M1: the environ bound is
+        // deliberately larger than the cmdline bound because the spawn sites append the marker LAST.
+        const environ = readFileBoundedSync(`/proc/${pid}/environ`, PROC_ENVIRON_READ_MAX_BYTES)
+        const tokens = environ.data.toString('utf8').split('\0')
+        // R3-m2: a truncated read can cut mid-token; the final element is potentially partial and
+        // must never count as proof (`MARKER=valueEXTRA` cut exactly at the bound reads back as
+        // `MARKER=value`).
+        if (environ.truncated) tokens.pop()
+        if (tokens.includes(marker)) return true
+        if (environ.truncated) {
+          // R3-M1: make "marker unreachable past the read bound" distinguishable from "provably
+          // not ours" in the logs. Fail-closed behavior is unchanged either way.
+          log.debug?.(
+            { pid, pgid: entry.pgid, markerName: entry.envMarker.name, maxBytes: PROC_ENVIRON_READ_MAX_BYTES },
+            'Truncated environ read without ownership marker; failing closed (not treated as owned)',
+          )
+        }
       } catch {
         continue // member vanished mid-scan or is unreadable: not proof either way
       }

--- a/server/coding-cli/codex-observability.ts
+++ b/server/coding-cli/codex-observability.ts
@@ -1,0 +1,198 @@
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { logger } from '../logger.js'
+import {
+  countCodexQuarantinedRecords,
+  hasDueCodexReaperRetries,
+  reapOrphanedCodexAppServerSidecars,
+  rescanCodexReaperQuarantine,
+} from './codex-app-server/runtime.js'
+
+// Stage 1c observability (plan §7.5): one structured `codex-log-db:` line at boot and then hourly,
+// plus the hourly retry of pending reaper records and the quarantine rescan trigger.
+//
+// STRICTLY read-only over codex state: `fs.stat` on the WAL and a `/proc/*/fd` readlink scan. This
+// module MUST NOT open the SQLite database and MUST NOT signal any process (I1/I3). Every path is
+// try/catch'd: the monitor can never throw, crash the server, or block boot (I4).
+
+export const CODEX_LOG_DB_FILENAME = 'logs_2.sqlite'
+/** Warn once the WAL exceeds this size (≈ weeks of margin before the ~5 GB launch-wedge cliff). */
+export const CODEX_LOG_DB_WAL_WARN_BYTES = 500 * 1024 * 1024
+/** Warn once this many processes hold the log DB open (~2 per pane; normal is tens, not hundreds). */
+export const CODEX_LOG_DB_HOLDER_WARN_THRESHOLD = 64
+export const CODEX_OBSERVABILITY_INTERVAL_MS = 60 * 60 * 1000
+
+export type CodexObservabilityLogger = {
+  info: (fields: Record<string, unknown>, message: string) => void
+  warn: (fields: Record<string, unknown>, message: string) => void
+}
+
+const defaultLog: CodexObservabilityLogger = logger.child({ component: 'codex-observability' })
+
+export type CodexReaperMaintenanceOptions = {
+  serverInstanceId: string
+  metadataDir?: string
+  terminateGraceMs?: number
+  log?: CodexObservabilityLogger
+}
+
+export type CodexObservabilityOptions = CodexReaperMaintenanceOptions & {
+  codexHome?: string
+  procRoot?: string
+  intervalMs?: number
+  walWarnBytes?: number
+  holderWarnThreshold?: number
+  env?: NodeJS.ProcessEnv
+}
+
+export function resolveCodexHome(env: NodeJS.ProcessEnv = process.env): string {
+  const fromEnv = env.CODEX_HOME?.trim()
+  return fromEnv ? fromEnv : path.join(os.homedir(), '.codex')
+}
+
+export function resolveCodexLogDbPath(codexHome: string): string {
+  return path.join(codexHome, CODEX_LOG_DB_FILENAME)
+}
+
+async function statWalBytes(walPath: string): Promise<number> {
+  try {
+    return (await fsp.stat(walPath)).size
+  } catch {
+    return 0 // missing or unreadable WAL reads as empty; the monitor never throws
+  }
+}
+
+// Counts processes holding the log DB (or its -wal/-shm siblings) open via a read-only /proc fd
+// readlink scan. Unreadable fd tables (EACCES, exited mid-scan) are skipped, never fatal.
+export async function countCodexLogDbHolders(dbPath: string, procRoot = '/proc'): Promise<number> {
+  let entries: string[]
+  try {
+    entries = await fsp.readdir(procRoot)
+  } catch {
+    return 0
+  }
+  let holders = 0
+  await Promise.all(entries.map(async (entry) => {
+    if (!/^\d+$/.test(entry)) return
+    const fdDir = path.join(procRoot, entry, 'fd')
+    let fds: string[]
+    try {
+      fds = await fsp.readdir(fdDir)
+    } catch {
+      return
+    }
+    for (const fd of fds) {
+      let target: string
+      try {
+        target = await fsp.readlink(path.join(fdDir, fd))
+      } catch {
+        continue
+      }
+      if (target === dbPath || target.startsWith(`${dbPath}-`)) {
+        holders += 1
+        return
+      }
+    }
+  }))
+  return holders
+}
+
+export type CodexLogDbStatus = {
+  walBytes: number
+  holders: number
+  quarantined: number
+  warned: boolean
+}
+
+export async function emitCodexLogDbStatus(
+  options: Partial<CodexObservabilityOptions> = {},
+): Promise<CodexLogDbStatus | null> {
+  const log = options.log ?? defaultLog
+  try {
+    const codexHome = options.codexHome ?? resolveCodexHome(options.env)
+    const dbPath = path.resolve(resolveCodexLogDbPath(codexHome))
+    const walPath = `${dbPath}-wal`
+    const [walBytes, holders, quarantined] = await Promise.all([
+      statWalBytes(walPath),
+      countCodexLogDbHolders(dbPath, options.procRoot ?? '/proc'),
+      countCodexQuarantinedRecords(options.metadataDir),
+    ])
+    const walWarnBytes = options.walWarnBytes ?? CODEX_LOG_DB_WAL_WARN_BYTES
+    const holderWarnThreshold = options.holderWarnThreshold ?? CODEX_LOG_DB_HOLDER_WARN_THRESHOLD
+    const warned = walBytes > walWarnBytes || holders > holderWarnThreshold
+    const fields = { walBytes, holders, quarantined, walPath, dbPath }
+    const message = `codex-log-db: wal_bytes=${walBytes} holders=${holders} quarantined=${quarantined}`
+    if (warned) {
+      log.warn(fields, message)
+    } else {
+      log.info(fields, message)
+    }
+    return { walBytes, holders, quarantined, warned }
+  } catch (error) {
+    try {
+      log.warn({ err: error }, 'codex-log-db observability probe failed')
+    } catch {
+      // the monitor never throws
+    }
+    return null
+  }
+}
+
+// Hourly maintenance (plan §7.3–.5): trigger the quarantine rescan and, when any retry-in-place
+// record's time-based backoff window has elapsed (or a quarantined record was just promoted),
+// re-run the reaper. The per-boot reap attempt always runs at startup; backoff gates only this
+// hourly cadence and the reaper's log escalation.
+export async function runCodexReaperMaintenanceTick(options: CodexReaperMaintenanceOptions): Promise<void> {
+  const log = options.log ?? defaultLog
+  try {
+    const { promotedRecords } = await rescanCodexReaperQuarantine(options.metadataDir)
+    const due = await hasDueCodexReaperRetries(options.metadataDir)
+    if (promotedRecords.length === 0 && !due) return
+    await reapOrphanedCodexAppServerSidecars({
+      serverInstanceId: options.serverInstanceId,
+      ...(options.metadataDir !== undefined ? { metadataDir: options.metadataDir } : {}),
+      ...(options.terminateGraceMs !== undefined ? { terminateGraceMs: options.terminateGraceMs } : {}),
+    })
+  } catch (error) {
+    try {
+      log.warn({ err: error }, 'codex reaper hourly retry tick failed')
+    } catch {
+      // the monitor never throws
+    }
+  }
+}
+
+export type CodexObservabilityHandle = { stop(): void }
+
+// Started from server/index.ts at boot. Emits one status line immediately, then hourly on an
+// unref()'d interval timer (it can never hold the process open). Fully fail-open.
+export function startCodexObservability(options: CodexObservabilityOptions): CodexObservabilityHandle {
+  let timer: NodeJS.Timeout | null = null
+  const tick = async (): Promise<void> => {
+    await emitCodexLogDbStatus(options)
+    await runCodexReaperMaintenanceTick(options)
+  }
+  try {
+    void tick()
+    timer = setInterval(() => {
+      void tick()
+    }, options.intervalMs ?? CODEX_OBSERVABILITY_INTERVAL_MS)
+    timer.unref()
+  } catch (error) {
+    try {
+      const log = options.log ?? defaultLog
+      log.warn({ err: error }, 'failed to start codex observability')
+    } catch {
+      // the monitor never throws
+    }
+  }
+  return {
+    stop(): void {
+      if (timer) {
+        clearInterval(timer)
+        timer = null
+      }
+    },
+  }
+}

--- a/server/coding-cli/codex-observability.ts
+++ b/server/coding-cli/codex-observability.ts
@@ -3,6 +3,7 @@ import fsp from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { logger } from '../logger.js'
+import { cmdlineHasCodexToken, probeRegisteredResumePtyGroups } from './codex-child-registry.js'
 import {
   countCodexQuarantinedRecords,
   hasDueCodexReaperRetries,
@@ -129,7 +130,9 @@ export async function countCodexLogDbHolders(
       } catch {
         continue
       }
-      if (!cmdline.includes('codex')) continue
+      // r2-2: same argv-token predicate as the exit-path registry — a path merely containing
+      // "codex" (worktree names, notes files) must not count as a holder.
+      if (!cmdlineHasCodexToken(cmdline)) continue
       const fdDir = path.join(procRoot, pid, 'fd')
       let fds: string[]
       try {
@@ -207,6 +210,14 @@ export async function emitCodexLogDbStatus(
 // ownership-gated reaper, which may signal provably-owned process groups.
 export async function runCodexReaperMaintenanceTick(options: CodexReaperMaintenanceOptions): Promise<void> {
   const log = options.log ?? defaultLog
+  try {
+    // r2-11: steady-state drain of stale resume-pty registry entries (signal-0 probe only; never
+    // signals). onExit-time deregistration keeps an entry when its group still had members or the
+    // probe was inconclusive — if those members die later no event fires, so re-probe hourly here.
+    probeRegisteredResumePtyGroups()
+  } catch {
+    // best-effort; the registry probe must never block the maintenance tick
+  }
   try {
     const { promotedRecords } = await rescanCodexReaperQuarantine(options.metadataDir)
     const due = await hasDueCodexReaperRetries(options.metadataDir)

--- a/server/coding-cli/codex-observability.ts
+++ b/server/coding-cli/codex-observability.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -12,16 +13,25 @@ import {
 // Stage 1c observability (plan §7.5): one structured `codex-log-db:` line at boot and then hourly,
 // plus the hourly retry of pending reaper records and the quarantine rescan trigger.
 //
-// STRICTLY read-only over codex state: `fs.stat` on the WAL and a `/proc/*/fd` readlink scan. This
-// module MUST NOT open the SQLite database and MUST NOT signal any process (I1/I3). Every path is
-// try/catch'd: the monitor can never throw, crash the server, or block boot (I4).
+// The status/emit/count functions below (emitCodexLogDbStatus, countCodexLogDbHolders,
+// statWalBytes) are STRICTLY read-only over codex state — `fs.stat` on the WAL and a `/proc/*/fd`
+// readlink scan — and MUST NOT open the SQLite database or signal any process (I1/I3). The hourly
+// maintenance tick is the one exception by design: it delegates to the ownership-gated reaper in
+// runtime.ts, which owns all signalling decisions. Every path is try/catch'd: the monitor can
+// never throw, crash the server, or block boot (I4).
 
 export const CODEX_LOG_DB_FILENAME = 'logs_2.sqlite'
-/** Warn once the WAL exceeds this size (≈ weeks of margin before the ~5 GB launch-wedge cliff). */
-export const CODEX_LOG_DB_WAL_WARN_BYTES = 500 * 1024 * 1024
+/**
+ * Warn once the WAL exceeds this size. The launch-wedge cliff is ~5 GB and the measured worst-case
+ * churn on the incident machine is ~22 MB/min (accepted until Stage 2), so 2 GiB leaves hours of
+ * margin — not weeks — while keeping the hourly line quiet during known-noisy-but-accepted churn.
+ */
+export const CODEX_LOG_DB_WAL_WARN_BYTES = 2 * 1024 * 1024 * 1024
 /** Warn once this many processes hold the log DB open (~2 per pane; normal is tens, not hundreds). */
 export const CODEX_LOG_DB_HOLDER_WARN_THRESHOLD = 64
 export const CODEX_OBSERVABILITY_INTERVAL_MS = 60 * 60 * 1000
+/** Bounded fan-out for the /proc fd scan: at most this many pids are probed concurrently (M3). */
+export const CODEX_HOLDER_SCAN_CONCURRENCY = 12
 
 export type CodexObservabilityLogger = {
   info: (fields: Record<string, unknown>, message: string) => void
@@ -55,51 +65,100 @@ export function resolveCodexLogDbPath(codexHome: string): string {
   return path.join(codexHome, CODEX_LOG_DB_FILENAME)
 }
 
-async function statWalBytes(walPath: string): Promise<number> {
+// Symlink-proof canonicalization so fd readlink targets (always fully resolved) compare against
+// the same string. Falls back to a plain resolve when the DB does not exist yet.
+function canonicalizeDbPath(dbPath: string): string {
   try {
-    return (await fsp.stat(walPath)).size
+    return fs.realpathSync.native(dbPath)
   } catch {
-    return 0 // missing or unreadable WAL reads as empty; the monitor never throws
+    return path.resolve(dbPath)
+  }
+}
+
+type WalStat = { walBytes: number; walStatFailed: boolean }
+
+// ENOENT genuinely means "no WAL" (an idle or absent DB) and reads as 0. Any OTHER stat failure is
+// reported as walBytes=-1 + walStatFailed so a permission/IO problem can never masquerade as an
+// empty WAL (panel M5).
+async function statWalBytes(walPath: string): Promise<WalStat> {
+  try {
+    return { walBytes: (await fsp.stat(walPath)).size, walStatFailed: false }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { walBytes: 0, walStatFailed: false }
+    return { walBytes: -1, walStatFailed: true }
   }
 }
 
 // Counts processes holding the log DB (or its -wal/-shm siblings) open via a read-only /proc fd
-// readlink scan. Unreadable fd tables (EACCES, exited mid-scan) are skipped, never fatal.
-export async function countCodexLogDbHolders(dbPath: string, procRoot = '/proc'): Promise<number> {
+// readlink scan. Cost-bounded (panel M3): only pids whose cmdline mentions codex are probed (they
+// are the only holders this line cares to count), the server itself is skipped, and at most
+// CODEX_HOLDER_SCAN_CONCURRENCY pids are in flight at once. Unreadable cmdlines/fd tables (EACCES,
+// exited mid-scan) are skipped, never fatal. fd targets of unlinked-but-open files carry a
+// ' (deleted)' suffix which is stripped before comparison.
+export async function countCodexLogDbHolders(
+  dbPath: string,
+  procRoot = '/proc',
+  selfPid: number = process.pid,
+): Promise<number> {
+  const resolvedDbPath = canonicalizeDbPath(dbPath)
   let entries: string[]
   try {
     entries = await fsp.readdir(procRoot)
   } catch {
     return 0
   }
+  const pids = entries.filter((entry) => /^\d+$/.test(entry) && Number(entry) !== selfPid)
+  const matchesDb = (rawTarget: string): boolean => {
+    const target = rawTarget.endsWith(' (deleted)')
+      ? rawTarget.slice(0, -' (deleted)'.length)
+      : rawTarget
+    return target === resolvedDbPath || target.startsWith(`${resolvedDbPath}-`)
+  }
   let holders = 0
-  await Promise.all(entries.map(async (entry) => {
-    if (!/^\d+$/.test(entry)) return
-    const fdDir = path.join(procRoot, entry, 'fd')
-    let fds: string[]
-    try {
-      fds = await fsp.readdir(fdDir)
-    } catch {
-      return
-    }
-    for (const fd of fds) {
-      let target: string
+  let next = 0
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = next
+      next += 1
+      if (index >= pids.length) return
+      const pid = pids[index]
+      // Prefilter: one cheap cmdline read gates the (much more expensive) per-fd readlink walk.
+      let cmdline: string
       try {
-        target = await fsp.readlink(path.join(fdDir, fd))
+        cmdline = (await fsp.readFile(path.join(procRoot, pid, 'cmdline'))).toString('utf8')
       } catch {
         continue
       }
-      if (target === dbPath || target.startsWith(`${dbPath}-`)) {
-        holders += 1
-        return
+      if (!cmdline.includes('codex')) continue
+      const fdDir = path.join(procRoot, pid, 'fd')
+      let fds: string[]
+      try {
+        fds = await fsp.readdir(fdDir)
+      } catch {
+        continue
+      }
+      for (const fd of fds) {
+        let target: string
+        try {
+          target = await fsp.readlink(path.join(fdDir, fd))
+        } catch {
+          continue
+        }
+        if (matchesDb(target)) {
+          holders += 1
+          break
+        }
       }
     }
-  }))
+  }
+  const workerCount = Math.max(1, Math.min(CODEX_HOLDER_SCAN_CONCURRENCY, pids.length))
+  await Promise.all(Array.from({ length: workerCount }, () => worker()))
   return holders
 }
 
 export type CodexLogDbStatus = {
   walBytes: number
+  walStatFailed: boolean
   holders: number
   quarantined: number
   warned: boolean
@@ -111,24 +170,25 @@ export async function emitCodexLogDbStatus(
   const log = options.log ?? defaultLog
   try {
     const codexHome = options.codexHome ?? resolveCodexHome(options.env)
-    const dbPath = path.resolve(resolveCodexLogDbPath(codexHome))
+    const dbPath = canonicalizeDbPath(resolveCodexLogDbPath(codexHome))
     const walPath = `${dbPath}-wal`
-    const [walBytes, holders, quarantined] = await Promise.all([
+    const [walStat, holders, quarantined] = await Promise.all([
       statWalBytes(walPath),
       countCodexLogDbHolders(dbPath, options.procRoot ?? '/proc'),
       countCodexQuarantinedRecords(options.metadataDir),
     ])
+    const { walBytes, walStatFailed } = walStat
     const walWarnBytes = options.walWarnBytes ?? CODEX_LOG_DB_WAL_WARN_BYTES
     const holderWarnThreshold = options.holderWarnThreshold ?? CODEX_LOG_DB_HOLDER_WARN_THRESHOLD
-    const warned = walBytes > walWarnBytes || holders > holderWarnThreshold
-    const fields = { walBytes, holders, quarantined, walPath, dbPath }
+    const warned = walBytes > walWarnBytes || holders > holderWarnThreshold || walStatFailed
+    const fields = { walBytes, walStatFailed, holders, quarantined, walPath, dbPath }
     const message = `codex-log-db: wal_bytes=${walBytes} holders=${holders} quarantined=${quarantined}`
     if (warned) {
       log.warn(fields, message)
     } else {
       log.info(fields, message)
     }
-    return { walBytes, holders, quarantined, warned }
+    return { walBytes, walStatFailed, holders, quarantined, warned }
   } catch (error) {
     try {
       log.warn({ err: error }, 'codex-log-db observability probe failed')
@@ -142,7 +202,9 @@ export async function emitCodexLogDbStatus(
 // Hourly maintenance (plan §7.3–.5): trigger the quarantine rescan and, when any retry-in-place
 // record's time-based backoff window has elapsed (or a quarantined record was just promoted),
 // re-run the reaper. The per-boot reap attempt always runs at startup; backoff gates only this
-// hourly cadence and the reaper's log escalation.
+// hourly cadence (per record, via respectRetryBackoff) and the reaper's log escalation. NOTE:
+// unlike the read-only status functions above, this tick deliberately delegates to the
+// ownership-gated reaper, which may signal provably-owned process groups.
 export async function runCodexReaperMaintenanceTick(options: CodexReaperMaintenanceOptions): Promise<void> {
   const log = options.log ?? defaultLog
   try {
@@ -151,6 +213,8 @@ export async function runCodexReaperMaintenanceTick(options: CodexReaperMaintena
     if (promotedRecords.length === 0 && !due) return
     await reapOrphanedCodexAppServerSidecars({
       serverInstanceId: options.serverInstanceId,
+      // m2: per-record backoff gating — only due records are re-attempted (and re-counted).
+      respectRetryBackoff: true,
       ...(options.metadataDir !== undefined ? { metadataDir: options.metadataDir } : {}),
       ...(options.terminateGraceMs !== undefined ? { terminateGraceMs: options.terminateGraceMs } : {}),
     })
@@ -166,7 +230,8 @@ export async function runCodexReaperMaintenanceTick(options: CodexReaperMaintena
 export type CodexObservabilityHandle = { stop(): void }
 
 // Started from server/index.ts at boot. Emits one status line immediately, then hourly on an
-// unref()'d interval timer (it can never hold the process open). Fully fail-open.
+// unref()'d interval timer (it can never hold the process open). Fully fail-open. index.ts keeps
+// the handle and calls stop() as the first step of shutdown() so a tick cannot race teardown (m7).
 export function startCodexObservability(options: CodexObservabilityOptions): CodexObservabilityHandle {
   let timer: NodeJS.Timeout | null = null
   const tick = async (): Promise<void> => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -94,6 +94,8 @@ import {
   runCodexStartupReaper,
 } from './coding-cli/codex-app-server/runtime.js'
 import { CodexLaunchPlanner } from './coding-cli/codex-app-server/launch-planner.js'
+import { startCodexObservability } from './coding-cli/codex-observability.js'
+import { installCodexChildExitHandlers, snapshotCodexChildren } from './coding-cli/codex-child-registry.js'
 import { registerStaticClientRoutes } from './static-client-routes.js'
 import { joinCodexShutdownOwners } from './shutdown-join.js'
 
@@ -253,7 +255,16 @@ async function main() {
   const opencodeActivity = createOpencodeActivityIntegration({ registry, opencodeProvider })
 
   const sessionRepairService = getSessionRepairService({ skipDiscovery: true })
-  await runCodexStartupReaper({ serverInstanceId })
+  try {
+    await runCodexStartupReaper({ serverInstanceId })
+  } catch (err) {
+    // I4: boot must never die in the reaper. Unresolved records are retried by the hourly
+    // observability tick and on the next boot.
+    log.warn({ err }, 'Codex startup reaper failed; continuing startup (fail-open)')
+  }
+  // Boot + hourly codex-log-db line (WAL size, holder count, quarantine count), hourly retry of
+  // pending reaper records, and the quarantine rescan trigger. Observation-only; unref()'d timer.
+  startCodexObservability({ serverInstanceId })
   const freshAgentModelCapabilityRegistry = new FreshAgentModelCapabilityRegistry()
 
   let sdkBridge: SdkBridge
@@ -1075,11 +1086,25 @@ async function main() {
 
   // Graceful shutdown handler
   let isShuttingDown = false
+  // Stage 1a (plan §6): hard-exit safety net for teardown HANGS. All three handled signals
+  // (SIGTERM/SIGINT/SIGHUP) share the same hang exposure in joinCodexShutdownOwners below. A
+  // *throw* from joinCodexShutdownOwners already dies on its own: shutdown() is invoked un-awaited,
+  // so the rejection is unhandled -> default-fatal -> 'exit' -> reapSync. The timer exists for the
+  // hang case, where teardown never settles and 'exit' would otherwise never fire.
+  const SHUTDOWN_HARD_EXIT_TIMEOUT_MS = 15_000
   const shutdown = async (signal: string) => {
     if (isShuttingDown) return
     isShuttingDown = true
 
-    log.info({ signal }, 'Shutting down...')
+    const hardExitTimer = setTimeout(() => {
+      log.error({ signal, timeoutMs: SHUTDOWN_HARD_EXIT_TIMEOUT_MS }, 'Shutdown hung; forcing process exit')
+      process.exit(1)
+    }, SHUTDOWN_HARD_EXIT_TIMEOUT_MS)
+    hardExitTimer.unref()
+
+    // The codexChildren snapshot is the pre-termination registry listing used by the Stage 1a
+    // acceptance tests (plan §6): every listed {pid, pgid} must be gone after exit.
+    log.info({ signal, codexChildren: snapshotCodexChildren() }, 'Shutting down...')
 
     // 1. Establish terminal creation admission barriers before waiting on terminal teardown.
     terminalCreateAdmissionOpen = false
@@ -1146,6 +1171,11 @@ async function main() {
 
   process.on('SIGTERM', () => shutdown('SIGTERM'))
   process.on('SIGINT', () => shutdown('SIGINT'))
+  // Stage 1a (plan §6): 'exit' -> reapSync (synchronous best-effort SIGKILL of still-registered
+  // codex process groups), SIGHUP -> the same graceful shutdown (idempotent via isShuttingDown),
+  // and uncaughtExceptionMonitor as observe-only (default fatal semantics untouched; the fatal
+  // path then runs 'exit' -> reapSync).
+  installCodexChildExitHandlers({ requestShutdown: (signal) => void shutdown(signal) })
 }
 
 main().catch((err) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1134,9 +1134,16 @@ async function main() {
       })
     })
     // M6: server.close() only stops NEW connections — keep-alive/in-flight sockets would otherwise
-    // hold httpServerClosed open toward the hard-exit budget. Sever them now (Node >=18.2 API,
-    // optional-chained defensively).
-    server.closeAllConnections?.()
+    // hold httpServerClosed open toward the hard-exit budget. r2-10: close idle keep-alive sockets
+    // immediately, but give in-flight HTTP responses a 3s grace before severing everything (WS
+    // panes were already severed by wsHandler.close() above). Node >=18.2 APIs, optional-chained
+    // defensively; the timer is unref()'d and cleared if the server finishes closing first.
+    server.closeIdleConnections?.()
+    const closeAllConnectionsTimer = setTimeout(() => {
+      server.closeAllConnections?.()
+    }, 3_000)
+    closeAllConnectionsTimer.unref()
+    void httpServerClosed.then(() => clearTimeout(closeAllConnectionsTimer))
 
     // 3. Stop any coalesced sessions publish timers
     sessionsSync.shutdown()

--- a/server/index.ts
+++ b/server/index.ts
@@ -264,7 +264,7 @@ async function main() {
   }
   // Boot + hourly codex-log-db line (WAL size, holder count, quarantine count), hourly retry of
   // pending reaper records, and the quarantine rescan trigger. Observation-only; unref()'d timer.
-  startCodexObservability({ serverInstanceId })
+  const codexObservability = startCodexObservability({ serverInstanceId })
   const freshAgentModelCapabilityRegistry = new FreshAgentModelCapabilityRegistry()
 
   let sdkBridge: SdkBridge
@@ -1090,14 +1090,28 @@ async function main() {
   // (SIGTERM/SIGINT/SIGHUP) share the same hang exposure in joinCodexShutdownOwners below. A
   // *throw* from joinCodexShutdownOwners already dies on its own: shutdown() is invoked un-awaited,
   // so the rejection is unhandled -> default-fatal -> 'exit' -> reapSync. The timer exists for the
-  // hang case, where teardown never settles and 'exit' would otherwise never fire.
-  const SHUTDOWN_HARD_EXIT_TIMEOUT_MS = 15_000
+  // hang case, where teardown never settles and 'exit' would otherwise never fire. 30s (panel M6):
+  // a legitimately slow-but-healthy shutdown awaits in-flight HTTP responses plus several bounded
+  // steps that can sum near 15s, so the old 15s budget force-killed healthy teardowns.
+  const SHUTDOWN_HARD_EXIT_TIMEOUT_MS = 30_000
   const shutdown = async (signal: string) => {
     if (isShuttingDown) return
     isShuttingDown = true
 
+    // m7 (first step): stop the hourly codex observability/maintenance tick so it cannot race
+    // teardown (e.g. re-running the reaper while sidecars are being torn down).
+    codexObservability.stop()
+
     const hardExitTimer = setTimeout(() => {
-      log.error({ signal, timeoutMs: SHUTDOWN_HARD_EXIT_TIMEOUT_MS }, 'Shutdown hung; forcing process exit')
+      // May be slow rather than hung — but past the budget we force the exit either way. Write the
+      // final line synchronously too: async pino may not flush before process.exit.
+      const message = `Shutdown did not complete within ${SHUTDOWN_HARD_EXIT_TIMEOUT_MS}ms; forcing exit`
+      try {
+        log.error({ signal, timeoutMs: SHUTDOWN_HARD_EXIT_TIMEOUT_MS }, message)
+      } catch {
+        // stderr below is the fallback
+      }
+      process.stderr.write(`${message}\n`)
       process.exit(1)
     }, SHUTDOWN_HARD_EXIT_TIMEOUT_MS)
     hardExitTimer.unref()
@@ -1119,6 +1133,10 @@ async function main() {
         resolve()
       })
     })
+    // M6: server.close() only stops NEW connections — keep-alive/in-flight sockets would otherwise
+    // hold httpServerClosed open toward the hard-exit budget. Sever them now (Node >=18.2 API,
+    // optional-chained defensively).
+    server.closeAllConnections?.()
 
     // 3. Stop any coalesced sessions publish timers
     sessionsSync.shutdown()
@@ -1164,7 +1182,8 @@ async function main() {
     // 10. Stop session repair service
     await sessionRepairService.stop()
 
-    // 11. Exit cleanly
+    // 11. Exit cleanly (hygiene: the force-exit timer is unref()d, but clear it anyway)
+    clearTimeout(hardExitTimer)
     log.info('Shutdown complete')
     process.exit(0)
   }

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -37,6 +37,7 @@ import type {
 import { getOpencodeEnvOverrides, resolveOpencodeLaunchModel } from './opencode-launch.js'
 import { generateMcpInjection, cleanupMcpConfig } from './mcp/config-writer.js'
 import { CODEX_MANAGED_REMOTE_CONFIG_ARGS } from './coding-cli/codex-managed-config.js'
+import { deregisterCodexChild, registerCodexChild } from './coding-cli/codex-child-registry.js'
 import type { CodexLaunchPlan, CodexLaunchSidecar } from './coding-cli/codex-app-server/launch-planner.js'
 import { isCodexSidecarTeardownError } from './coding-cli/codex-app-server/launch-planner.js'
 import {
@@ -1611,6 +1612,13 @@ export class TerminalRegistry extends EventEmitter {
     }
     endSpawnTimer({ cwd: procCwd })
 
+    // Stage 1a (plan §6): codex resume ptys are spawned as session/group leaders (pgid == pid);
+    // track them for exit-time reaping. Deregistered on the pty's onExit below — kill() only
+    // *sends* a signal, it does not confirm death. Codex panes only.
+    if (opts.mode === 'codex' && ptyProc.pid) {
+      registerCodexChild({ pid: ptyProc.pid, pgid: ptyProc.pid, kind: 'resume-pty' })
+    }
+
     const title = getModeLabel(opts.mode)
 
     const initialCodexDurability: CodexDurabilityRef | undefined = opts.mode === 'codex' && resumeForBinding
@@ -1749,6 +1757,9 @@ export class TerminalRegistry extends EventEmitter {
     })
 
     ptyProc.onExit((e) => {
+      // Stage 1a (plan §6): this pty process is gone — drop it from the codex child registry
+      // before any dispatch guards below. No-op for non-codex ptys and double exits.
+      deregisterCodexChild(ptyProc.pid)
       if (this.hasHandledPtyExit(record, ptyProc)) return
       this.markHandledPtyExit(record, ptyProc)
       if (!record.codexRecoveryFinalClose && record.codexRecoveryRetiringPty === ptyProc) {
@@ -3698,6 +3709,11 @@ export class TerminalRegistry extends EventEmitter {
       cwd: procCwd,
       env: env as any,
     })
+    // Stage 1a (plan §6): recovery ptys are codex resume ptys by construction; same registry
+    // contract as the primary spawn site (deregistered in the onExit handler).
+    if (ptyProc.pid) {
+      registerCodexChild({ pid: ptyProc.pid, pgid: ptyProc.pid, kind: 'resume-pty' })
+    }
     const candidate = { pty: ptyProc, mcpCwd, exited: false, exitCode: undefined as number | undefined }
     this.attachCodexRecoveryPtyHandlers(record, ptyProc, candidate)
     return candidate
@@ -3743,6 +3759,8 @@ export class TerminalRegistry extends EventEmitter {
     })
 
     ptyProc.onExit((event) => {
+      // Stage 1a (plan §6): the pty process is gone — deregister before any dispatch guards.
+      deregisterCodexChild(ptyProc.pid)
       if (this.hasHandledPtyExit(record, ptyProc)) return
       this.markHandledPtyExit(record, ptyProc)
       if (candidate) {

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -37,27 +37,16 @@ import type {
 import { getOpencodeEnvOverrides, resolveOpencodeLaunchModel } from './opencode-launch.js'
 import { generateMcpInjection, cleanupMcpConfig } from './mcp/config-writer.js'
 import { CODEX_MANAGED_REMOTE_CONFIG_ARGS } from './coding-cli/codex-managed-config.js'
-import { deregisterCodexChild, registerCodexChild } from './coding-cli/codex-child-registry.js'
-
 // Stage 1a (plan §6, panel m8): a codex resume pty is a process-GROUP registration (pgid == pid),
 // and the pty leader exiting does not prove the group is gone — descendants (the actual codex log
-// DB holders) can survive it. Deregister only when a signal-0 probe of the group confirms ESRCH;
-// while any member survives the entry stays registered so exit-time reap can still cover it. On
-// non-Linux platforms (no negative-pid probe semantics guaranteed + reapSync is a no-op there)
-// keep the previous unconditional deregistration.
-function deregisterCodexPtyIfGroupGone(pid: number): void {
-  if (process.platform === 'linux') {
-    try {
-      process.kill(-pid, 0)
-      return // group still has members: keep it registered
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
-        return // could not confirm the group is gone (e.g. EPERM): keep it registered
-      }
-    }
-  }
-  deregisterCodexChild(pid)
-}
+// DB holders) can survive it. The registry helper deregisters only when a signal-0 probe of the
+// group confirms ESRCH; 'alive'/EPERM keep the entry registered so exit-time reap still covers it
+// (r2-13b: the logic lives in codex-child-registry.ts behind an injectable probe seam; non-Linux
+// platforms deregister unconditionally there).
+import {
+  deregisterCodexChildIfGroupGone as deregisterCodexPtyIfGroupGone,
+  registerCodexChild,
+} from './coding-cli/codex-child-registry.js'
 import type { CodexLaunchPlan, CodexLaunchSidecar } from './coding-cli/codex-app-server/launch-planner.js'
 import { isCodexSidecarTeardownError } from './coding-cli/codex-app-server/launch-planner.js'
 import {
@@ -1636,7 +1625,14 @@ export class TerminalRegistry extends EventEmitter {
     // track them for exit-time reaping. Deregistered on the pty's onExit below — kill() only
     // *sends* a signal, it does not confirm death. Codex panes only.
     if (opts.mode === 'codex' && ptyProc.pid) {
-      registerCodexChild({ pid: ptyProc.pid, pgid: ptyProc.pid, kind: 'resume-pty' })
+      registerCodexChild({
+        pid: ptyProc.pid,
+        pgid: ptyProc.pid,
+        kind: 'resume-pty',
+        // R2-M1: ownership proof for the registry's dead-pid group-scan fallback —
+        // buildTerminalBaseEnv already put FRESHELL_TERMINAL_ID=<terminalId> into the pty env.
+        envMarker: { name: 'FRESHELL_TERMINAL_ID', value: terminalId },
+      })
     }
 
     const title = getModeLabel(opts.mode)
@@ -3733,7 +3729,13 @@ export class TerminalRegistry extends EventEmitter {
     // Stage 1a (plan §6): recovery ptys are codex resume ptys by construction; same registry
     // contract as the primary spawn site (deregistered in the onExit handler).
     if (ptyProc.pid) {
-      registerCodexChild({ pid: ptyProc.pid, pgid: ptyProc.pid, kind: 'resume-pty' })
+      registerCodexChild({
+        pid: ptyProc.pid,
+        pgid: ptyProc.pid,
+        kind: 'resume-pty',
+        // R2-M1: same ownership proof as the primary spawn site (buildTerminalBaseEnv env).
+        envMarker: { name: 'FRESHELL_TERMINAL_ID', value: record.terminalId },
+      })
     }
     const candidate = { pty: ptyProc, mcpCwd, exited: false, exitCode: undefined as number | undefined }
     this.attachCodexRecoveryPtyHandlers(record, ptyProc, candidate)

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -38,6 +38,26 @@ import { getOpencodeEnvOverrides, resolveOpencodeLaunchModel } from './opencode-
 import { generateMcpInjection, cleanupMcpConfig } from './mcp/config-writer.js'
 import { CODEX_MANAGED_REMOTE_CONFIG_ARGS } from './coding-cli/codex-managed-config.js'
 import { deregisterCodexChild, registerCodexChild } from './coding-cli/codex-child-registry.js'
+
+// Stage 1a (plan §6, panel m8): a codex resume pty is a process-GROUP registration (pgid == pid),
+// and the pty leader exiting does not prove the group is gone — descendants (the actual codex log
+// DB holders) can survive it. Deregister only when a signal-0 probe of the group confirms ESRCH;
+// while any member survives the entry stays registered so exit-time reap can still cover it. On
+// non-Linux platforms (no negative-pid probe semantics guaranteed + reapSync is a no-op there)
+// keep the previous unconditional deregistration.
+function deregisterCodexPtyIfGroupGone(pid: number): void {
+  if (process.platform === 'linux') {
+    try {
+      process.kill(-pid, 0)
+      return // group still has members: keep it registered
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+        return // could not confirm the group is gone (e.g. EPERM): keep it registered
+      }
+    }
+  }
+  deregisterCodexChild(pid)
+}
 import type { CodexLaunchPlan, CodexLaunchSidecar } from './coding-cli/codex-app-server/launch-planner.js'
 import { isCodexSidecarTeardownError } from './coding-cli/codex-app-server/launch-planner.js'
 import {
@@ -1757,9 +1777,10 @@ export class TerminalRegistry extends EventEmitter {
     })
 
     ptyProc.onExit((e) => {
-      // Stage 1a (plan §6): this pty process is gone — drop it from the codex child registry
-      // before any dispatch guards below. No-op for non-codex ptys and double exits.
-      deregisterCodexChild(ptyProc.pid)
+      // Stage 1a (plan §6): the pty leader exited — deregister the group only if it is confirmed
+      // gone (m8), and only for codex panes, mirroring the registration gate above (m6). Runs
+      // before any dispatch guards below; no-op for double exits.
+      if (opts.mode === 'codex') deregisterCodexPtyIfGroupGone(ptyProc.pid)
       if (this.hasHandledPtyExit(record, ptyProc)) return
       this.markHandledPtyExit(record, ptyProc)
       if (!record.codexRecoveryFinalClose && record.codexRecoveryRetiringPty === ptyProc) {
@@ -3759,8 +3780,9 @@ export class TerminalRegistry extends EventEmitter {
     })
 
     ptyProc.onExit((event) => {
-      // Stage 1a (plan §6): the pty process is gone — deregister before any dispatch guards.
-      deregisterCodexChild(ptyProc.pid)
+      // Stage 1a (plan §6): deregister only on confirmed group death (m8), codex-gated to mirror
+      // registration (m6; recovery records are codex by construction). Before any dispatch guards.
+      if (record.mode === 'codex') deregisterCodexPtyIfGroupGone(ptyProc.pid)
       if (this.hasHandledPtyExit(record, ptyProc)) return
       this.markHandledPtyExit(record, ptyProc)
       if (candidate) {

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -6,8 +6,9 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
-  assertCodexStartupReaperSucceeded,
   CodexAppServerRuntime,
+  codexReaperRetryIntervalMs,
+  isCodexReaperRetryDue,
   reapOrphanedCodexAppServerSidecars,
   runCodexStartupReaper,
 } from '../../../../../server/coding-cli/codex-app-server/runtime.js'
@@ -1436,41 +1437,21 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     await expect(fsp.stat(ready.metadataPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('treats unreaped new-schema ownership records as a startup-blocking reaper failure', () => {
-    expect(() => assertCodexStartupReaperSucceeded({
-      reapedOwnershipIds: [],
-      ignoredLegacyRecords: [],
-      skippedActiveOwnershipIds: [],
-      failedOwnershipIds: ['ownership-alpha', 'ownership-beta'],
-    })).toThrow(/startup reaper blocked startup.*failed to reap 2 ownership record.*ownership-alpha.*ownership-beta/i)
-  })
+  it('schedules hourly retries on a time-based backoff keyed on firstSeen, not attempts', () => {
+    const HOUR = 60 * 60 * 1000
+    expect(codexReaperRetryIntervalMs(0)).toBe(HOUR)
+    expect(codexReaperRetryIntervalMs(7 * HOUR)).toBe(3 * HOUR)
+    expect(codexReaperRetryIntervalMs(25 * HOUR)).toBe(6 * HOUR)
 
-  it('allows startup when ownership records still belong to live sidecar owners', () => {
-    expect(() => assertCodexStartupReaperSucceeded({
-      reapedOwnershipIds: [],
-      ignoredLegacyRecords: [],
-      skippedActiveOwnershipIds: ['active-owner'],
-      failedOwnershipIds: [],
-    })).not.toThrow()
-  })
-
-  it('reports failed reaps without treating live active owners as fatal', () => {
-    let thrown: Error | undefined
-
-    try {
-      assertCodexStartupReaperSucceeded({
-        reapedOwnershipIds: [],
-        ignoredLegacyRecords: [],
-        skippedActiveOwnershipIds: ['active-owner'],
-        failedOwnershipIds: ['failed-owner'],
-      })
-    } catch (error) {
-      thrown = error as Error
+    const now = Date.parse('2026-07-06T12:00:00.000Z')
+    const state = {
+      firstSeen: new Date(now - 2 * HOUR).toISOString(),
+      // High attempt counts (tsx-watch restart storms) must not burn the budget:
+      attempts: 50,
+      lastAttempt: new Date(now - 30 * 60 * 1000).toISOString(),
     }
-
-    expect(thrown).toBeDefined()
-    expect(thrown?.message).toContain('failed to reap 1 ownership record(s): failed-owner')
-    expect(thrown?.message).not.toContain('active-owner')
+    expect(isCodexReaperRetryDue(state, now)).toBe(false)
+    expect(isCodexReaperRetryDue({ ...state, lastAttempt: new Date(now - HOUR).toISOString() }, now)).toBe(true)
   })
 
   it('reports a skipped new-schema ownership record when the owner pid is live', async () => {
@@ -1492,12 +1473,11 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     })
 
     expect(result.skippedActiveOwnershipIds).toContain(ready.ownershipId)
-    expect(() => assertCodexStartupReaperSucceeded(result)).not.toThrow()
     await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
     expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
   })
 
-  it('does not treat a live reused owner pid as active without matching owner identity', async () => {
+  it('retries a live reused owner pid without matching identity in place with backoff, never quarantining', async () => {
     const metadataDir = await makeTempDir()
     const runtime = createRuntime({
       metadataDir,
@@ -1520,10 +1500,32 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     })
 
     expect(result.skippedActiveOwnershipIds).not.toContain(ready.ownershipId)
-    expect(result.failedOwnershipIds).toContain(ready.ownershipId)
-    expect(() => assertCodexStartupReaperSucceeded(result)).toThrow(new RegExp(ready.ownershipId))
+    expect(result.retriedOwnershipIds).toContain(ready.ownershipId)
+    expect(result.failedOwnershipIds).not.toContain(ready.ownershipId)
+    expect(result.quarantinedRecords).toEqual([])
     await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
     expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+
+    // Backoff state lives in <record>.reaper.json, written only by the reaper, mode 0600.
+    const sidecarPath = `${ready.metadataPath}.reaper.json`
+    const sidecarStat = await fsp.stat(sidecarPath)
+    expect(sidecarStat.mode & 0o777).toBe(0o600)
+    const state = JSON.parse(await fsp.readFile(sidecarPath, 'utf8'))
+    expect(state.attempts).toBe(1)
+    expect(typeof state.firstSeen).toBe('string')
+    expect(typeof state.lastAttempt).toBe('string')
+
+    // Still present (and retried again) on the next pass: attempts increment, firstSeen is stable.
+    const second = await reapOrphanedCodexAppServerSidecars({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+      terminateGraceMs: 1,
+    })
+    expect(second.retriedOwnershipIds).toContain(ready.ownershipId)
+    const stateAfter = JSON.parse(await fsp.readFile(sidecarPath, 'utf8'))
+    expect(stateAfter.attempts).toBe(2)
+    expect(stateAfter.firstSeen).toBe(state.firstSeen)
+    await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
   })
 
   it('reaps a stale ownership record whose process group was reused by a foreign process', async () => {
@@ -1562,7 +1564,7 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     }
   }, 20_000)
 
-  it('propagates thrown startup reaper failures instead of treating them as warning fallbacks', async () => {
+  it('degrades and continues when the metadata directory scan fails instead of blocking boot', async () => {
     const metadataDir = await makeTempDir()
     const originalReaddir = fsp.readdir.bind(fsp)
     const readdirSpy = vi.spyOn(fsp, 'readdir').mockImplementation(((target: any, options?: any) => {
@@ -1573,16 +1575,18 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     }) as typeof fsp.readdir)
 
     try {
-      await expect(runCodexStartupReaper({
+      const result = await runCodexStartupReaper({
         metadataDir,
         serverInstanceId: 'srv-current',
-      })).rejects.toThrow('simulated startup reaper metadata scan failure')
+      })
+      expect(result.reapingSkipped).toBe(true)
+      expect(result.reapedOwnershipIds).toEqual([])
     } finally {
       readdirSpy.mockRestore()
     }
   })
 
-  it('propagates startup reaper ownership verification failures', async () => {
+  it('isolates ownership verification failures to the affected record instead of blocking boot', async () => {
     const metadataDir = await makeTempDir()
     const runtime = createRuntime({
       metadataDir,
@@ -1610,17 +1614,21 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     }) as typeof fsp.readdir)
 
     try {
-      await expect(runCodexStartupReaper({
+      const result = await runCodexStartupReaper({
         metadataDir,
         serverInstanceId: 'srv-current',
         terminateGraceMs: 1,
-      })).rejects.toThrow('simulated ownership verification proc failure')
+      })
+      expect(result.failedOwnershipIds).toContain(ready.ownershipId)
+      expect(result.reapedOwnershipIds).not.toContain(ready.ownershipId)
+      await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
+      expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
     } finally {
       readdirSpy.mockRestore()
     }
   })
 
-  it('propagates startup reaper process-group signaling failures', async () => {
+  it('isolates process-group signaling failures to the affected record instead of blocking boot', async () => {
     const metadataDir = await makeTempDir()
     const runtime = createRuntime({
       metadataDir,
@@ -1639,18 +1647,20 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     }) as typeof process.kill)
 
     try {
-      await expect(runCodexStartupReaper({
+      const result = await runCodexStartupReaper({
         metadataDir,
         serverInstanceId: 'srv-current',
         terminateGraceMs: 1,
-      })).rejects.toThrow('simulated SIGTERM failure')
+      })
+      expect(result.failedOwnershipIds).toContain(ready.ownershipId)
+      await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
       expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
     } finally {
       killSpy.mockRestore()
     }
   })
 
-  it('propagates startup reaper wait-for-gone diagnostic failures', async () => {
+  it('isolates wait-for-gone diagnostic failures to the affected record instead of blocking boot', async () => {
     const metadataDir = await makeTempDir()
     const runtime = createRuntime({
       metadataDir,
@@ -1676,11 +1686,13 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     }) as typeof fsp.readdir)
 
     try {
-      await expect(runCodexStartupReaper({
+      const result = await runCodexStartupReaper({
         metadataDir,
         serverInstanceId: 'srv-current',
         terminateGraceMs: 1,
-      })).rejects.toThrow('simulated wait-for-gone process scan failure')
+      })
+      expect(result.failedOwnershipIds).toContain(ready.ownershipId)
+      await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
       expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
     } finally {
       readdirSpy.mockRestore()
@@ -1688,7 +1700,7 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     }
   })
 
-  it('propagates startup reaper metadata removal failures', async () => {
+  it('isolates metadata removal failures to the affected record instead of blocking boot', async () => {
     const metadataDir = await makeTempDir()
     const runtime = createRuntime({
       metadataDir,
@@ -1714,11 +1726,12 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     }) as typeof fsp.unlink)
 
     try {
-      await expect(runCodexStartupReaper({
+      const result = await runCodexStartupReaper({
         metadataDir,
         serverInstanceId: 'srv-current',
         terminateGraceMs: 1,
-      })).rejects.toThrow('simulated metadata removal failure')
+      })
+      expect(result.failedOwnershipIds).toContain(ready.ownershipId)
       await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
     } finally {
       unlinkSpy.mockRestore()
@@ -1743,7 +1756,7 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     await expect(fsp.stat(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('retains malformed new-schema ownership records and reports them as startup-blocking failures', async () => {
+  it('quarantines malformed new-schema ownership records with no provable live process group', async () => {
     const metadataDir = await makeTempDir()
     const malformedPath = path.join(metadataDir, 'damaged-new-schema.json')
     await fsp.writeFile(malformedPath, JSON.stringify({
@@ -1758,13 +1771,39 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
       serverInstanceId: 'srv-current',
     })
 
+    const quarantinePath = path.join(metadataDir, 'quarantine', 'damaged-new-schema.json')
     expect(result.ignoredLegacyRecords).not.toContain(malformedPath)
-    expect(result.failedOwnershipIds).toContain('damaged-ownership')
-    await expect(fsp.stat(malformedPath)).resolves.toBeDefined()
-    expect(() => assertCodexStartupReaperSucceeded(result)).toThrow(/damaged-ownership/)
+    expect(result.failedOwnershipIds).toEqual([])
+    expect(result.quarantinedRecords).toContain(quarantinePath)
+    await expect(fsp.stat(malformedPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    const quarantineStat = await fsp.stat(quarantinePath)
+    expect(quarantineStat.mode & 0o777).toBe(0o600)
+    const note = JSON.parse(await fsp.readFile(`${quarantinePath}.note.json`, 'utf8'))
+    expect(note.reason).toBe('malformed-record')
+    expect(typeof note.firstSeen).toBe('string')
+    expect(note.attempts).toBe(0)
   })
 
-  it('retains schema-v1 ownership records with invalid numeric ownership fields', async () => {
+  it('quarantines unparseable (non-JSON) ownership records instead of deleting them', async () => {
+    const metadataDir = await makeTempDir()
+    const corruptPath = path.join(metadataDir, 'torn-write.json')
+    await fsp.writeFile(corruptPath, '{"schemaVersion":1,"ownershipId":"torn', { mode: 0o600 })
+
+    const result = await reapOrphanedCodexAppServerSidecars({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+    })
+
+    const quarantinePath = path.join(metadataDir, 'quarantine', 'torn-write.json')
+    expect(result.ignoredLegacyRecords).toEqual([])
+    expect(result.quarantinedRecords).toContain(quarantinePath)
+    await expect(fsp.stat(corruptPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fsp.stat(quarantinePath)).resolves.toBeDefined()
+    const note = JSON.parse(await fsp.readFile(`${quarantinePath}.note.json`, 'utf8'))
+    expect(note.reason).toBe('unparseable-record')
+  })
+
+  it('quarantines schema-v1 ownership records with invalid numeric ownership fields without signaling', async () => {
     const metadataDir = await makeTempDir()
     const runtime = createRuntime({
       metadataDir,
@@ -1780,11 +1819,151 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
       serverInstanceId: 'srv-current',
     })
 
+    const quarantinePath = path.join(metadataDir, 'quarantine', path.basename(ready.metadataPath))
     expect(result.reapedOwnershipIds).not.toContain(ready.ownershipId)
-    expect(result.failedOwnershipIds).toContain(ready.ownershipId)
-    await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
+    expect(result.quarantinedRecords).toContain(quarantinePath)
+    await expect(fsp.stat(ready.metadataPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fsp.stat(quarantinePath)).resolves.toBeDefined()
     expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
-    expect(() => assertCodexStartupReaperSucceeded(result)).toThrow(new RegExp(ready.ownershipId))
+  })
+
+  const itNonRoot = typeof process.getuid === 'function' && process.getuid() === 0 ? it.skip : it
+
+  itNonRoot('isolates an unreadable ownership record and still processes the others', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-previous',
+    })
+    const ready = await runtime.ensureReady()
+    await markOwnershipRecordStale(ready.metadataPath)
+
+    const unreadablePath = path.join(metadataDir, 'aa-unreadable.json')
+    await fsp.writeFile(unreadablePath, '{"schemaVersion":1}', { mode: 0o000 })
+
+    const result = await runCodexStartupReaper({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+    })
+
+    expect(result.unreadableRecords).toContain(unreadablePath)
+    expect(result.reapedOwnershipIds).toContain(ready.ownershipId)
+    await waitForProcessExit(ready.processPid)
+    await expect(fsp.stat(ready.metadataPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fsp.stat(unreadablePath)).resolves.toBeDefined()
+  })
+
+  it('skips reaping with a warning when the /proc ownership proof is unavailable', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-previous',
+    })
+    const ready = await runtime.ensureReady()
+    await markOwnershipRecordStale(ready.metadataPath)
+    const originalReaddir = fsp.readdir.bind(fsp)
+    const readdirSpy = vi.spyOn(fsp, 'readdir').mockImplementation(((target: any, options?: any) => {
+      if (String(target) === '/proc') {
+        return Promise.reject(new Error('simulated /proc unavailable'))
+      }
+      return originalReaddir(target, options as any) as any
+    }) as typeof fsp.readdir)
+
+    try {
+      const result = await runCodexStartupReaper({
+        metadataDir,
+        serverInstanceId: 'srv-current',
+        terminateGraceMs: 1,
+      })
+      expect(result.reapingSkipped).toBe(true)
+      expect(result.reapedOwnershipIds).toEqual([])
+      await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
+      expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+    } finally {
+      readdirSpy.mockRestore()
+    }
+  })
+
+  it('never quarantines an owner-dead record whose group survives teardown; retries it in place', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-previous',
+    })
+    const ready = await runtime.ensureReady()
+    await markOwnershipRecordStale(ready.metadataPath)
+    const originalKill = process.kill
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      // Swallow the teardown signals so the group "survives" SIGTERM+SIGKILL (D-state simulation —
+      // this incident's exact signature).
+      if (pid === -ready.processGroupId && (signal === 'SIGTERM' || signal === 'SIGKILL')) {
+        return true
+      }
+      return originalKill(pid, signal as any)
+    }) as typeof process.kill)
+
+    try {
+      const result = await reapOrphanedCodexAppServerSidecars({
+        metadataDir,
+        serverInstanceId: 'srv-current',
+        terminateGraceMs: 1,
+      })
+
+      expect(result.retriedOwnershipIds).toContain(ready.ownershipId)
+      expect(result.quarantinedRecords).toEqual([])
+      expect(result.reapedOwnershipIds).not.toContain(ready.ownershipId)
+      await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
+      await expect(
+        fsp.stat(path.join(metadataDir, 'quarantine', path.basename(ready.metadataPath))),
+      ).rejects.toMatchObject({ code: 'ENOENT' })
+      expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+      const state = JSON.parse(await fsp.readFile(`${ready.metadataPath}.reaper.json`, 'utf8'))
+      expect(state.attempts).toBe(1)
+    } finally {
+      killSpy.mockRestore()
+    }
+  })
+
+  it('promotes quarantined records whose process group is still alive back for retry', async () => {
+    const metadataDir = await makeTempDir()
+    const quarantineDir = path.join(metadataDir, 'quarantine')
+    await fsp.mkdir(quarantineDir, { recursive: true })
+    const record = {
+      schemaVersion: 1,
+      ownershipId: 'quarantined-live',
+      serverInstanceId: 'srv-previous',
+      ownerServerPid: 999_999_999,
+      terminalId: null,
+      generation: null,
+      wsUrl: 'ws://127.0.0.1:1',
+      wrapperPid: 999_999_998,
+      // Our own process group: provably alive without spawning anything.
+      processGroupId: await readCurrentProcessGroupId(),
+      wrapperIdentity: { commandLine: ['codex'], cwd: '/tmp', startTimeTicks: 1 },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+    const quarantinedPath = path.join(quarantineDir, 'quarantined-live.json')
+    await fsp.writeFile(quarantinedPath, JSON.stringify(record), { mode: 0o600 })
+    await fsp.writeFile(
+      `${quarantinedPath}.note.json`,
+      JSON.stringify({ reason: 'test-seed', firstSeen: record.createdAt, attempts: 1 }),
+      { mode: 0o600 },
+    )
+
+    const result = await reapOrphanedCodexAppServerSidecars({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+    })
+
+    const restoredPath = path.join(metadataDir, 'quarantined-live.json')
+    expect(result.promotedFromQuarantine).toContain(restoredPath)
+    await expect(fsp.stat(restoredPath)).resolves.toBeDefined()
+    await expect(fsp.stat(quarantinedPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    // Promoted and re-processed the same pass: its group is our own, so it is skipped as active,
+    // not signaled and not re-quarantined.
+    expect(result.skippedActiveOwnershipIds).toContain('quarantined-live')
+    expect(result.quarantinedRecords).toEqual([])
   })
 
   it('does not reap new-schema records for the current process group', async () => {

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -1456,6 +1456,8 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     }
     expect(isCodexReaperRetryDue(state, now)).toBe(false)
     expect(isCodexReaperRetryDue({ ...state, lastAttempt: new Date(now - HOUR).toISOString() }, now)).toBe(true)
+    // R2-M2: a deferral-only sidecar carries no lastAttempt and is ALWAYS due.
+    expect(isCodexReaperRetryDue({ firstSeen: state.firstSeen, attempts: 0 }, now)).toBe(true)
   })
 
   it('escalates retry logging on wall-time pending age, not attempt count (M4)', () => {
@@ -1496,6 +1498,13 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     await writeOrphanRecord('a.json', 'budget-a')
     await writeOrphanRecord('b.json', 'budget-b')
     await writeOrphanRecord('c.json', 'budget-c')
+    // c already has REAL attempt history: a deferral must preserve it untouched (R2-M2).
+    const preservedState = {
+      firstSeen: new Date(Date.now() - 60_000).toISOString(),
+      attempts: 3,
+      lastAttempt: new Date(Date.now() - 30_000).toISOString(),
+    }
+    await fsp.writeFile(path.join(metadataDir, 'c.json.reaper.json'), JSON.stringify(preservedState), { mode: 0o600 })
 
     // Fake clock simulating a slow teardown: the pass starts at 0; the first record's budget check
     // sees 0ms elapsed (attempted), the second sees 4s (over the 3s budget), the third 8s.
@@ -1517,25 +1526,44 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     expect(result.deferredForBudget).toEqual(['budget-b', 'budget-c'])
     for (const name of ['b.json', 'c.json']) {
       await expect(fsp.stat(path.join(metadataDir, name))).resolves.toBeDefined()
-      const state = JSON.parse(await fsp.readFile(path.join(metadataDir, `${name}.reaper.json`), 'utf8'))
-      expect(state.attempts).toBe(1)
     }
+    // R2-M2: a deferral is NOT an attempt. b's freshly-created sidecar has attempts=0 and no
+    // lastAttempt, so the record remains immediately due for the hourly unbudgeted tick.
+    const deferredState = JSON.parse(await fsp.readFile(path.join(metadataDir, 'b.json.reaper.json'), 'utf8'))
+    expect(deferredState.attempts).toBe(0)
+    expect(deferredState.lastAttempt).toBeUndefined()
+    expect(isCodexReaperRetryDue(deferredState)).toBe(true)
+    // R2-M2: c's pre-existing sidecar is preserved exactly (no bump, no advance).
+    const preservedAfter = JSON.parse(await fsp.readFile(path.join(metadataDir, 'c.json.reaper.json'), 'utf8'))
+    expect(preservedAfter).toEqual(preservedState)
     await expect(fsp.stat(path.join(metadataDir, 'a.json'))).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('purges stranded atomic-write tmp files older than an hour (m9)', async () => {
+  it('purges stranded atomic-write tmp files older than an hour in the main dir AND quarantine/ (m9, r2-8)', async () => {
     const metadataDir = await makeTempDir()
+    const quarantineDir = path.join(metadataDir, 'quarantine')
+    await fsp.mkdir(quarantineDir, { recursive: true })
     const stalePath = path.join(metadataDir, 'dead.json.tmp-1234-5678')
     const freshPath = path.join(metadataDir, 'live.json.tmp-1234-9999')
+    // r2-8: '.tmp-' as a mere substring must NOT match — only atomicWriteJson's anchored
+    // `.tmp-<pid>-<timestamp>` suffix does.
+    const lookalikePath = path.join(metadataDir, 'note.tmp-draft')
+    const staleQuarantineTmp = path.join(quarantineDir, 'dead.json.note.json.tmp-1234-5678')
     await fsp.writeFile(stalePath, '{}')
     await fsp.writeFile(freshPath, '{}')
+    await fsp.writeFile(lookalikePath, '{}')
+    await fsp.writeFile(staleQuarantineTmp, '{}')
     const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000)
     await fsp.utimes(stalePath, twoHoursAgo, twoHoursAgo)
+    await fsp.utimes(lookalikePath, twoHoursAgo, twoHoursAgo)
+    await fsp.utimes(staleQuarantineTmp, twoHoursAgo, twoHoursAgo)
 
     await reapOrphanedCodexAppServerSidecars({ metadataDir, serverInstanceId: 'srv-current', terminateGraceMs: 1 })
 
     await expect(fsp.stat(stalePath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fsp.stat(staleQuarantineTmp)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(fsp.stat(freshPath)).resolves.toBeDefined()
+    await expect(fsp.stat(lookalikePath)).resolves.toBeDefined()
   })
 
   it('unlinks orphaned quarantine notes whose record file is absent (m3)', async () => {

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -6,10 +6,14 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
+  CODEX_REAPER_BOOT_BUDGET_MS,
+  CODEX_REAPER_LOG_ESCALATION_MS,
   CodexAppServerRuntime,
   codexReaperRetryIntervalMs,
+  isCodexReaperEscalationDue,
   isCodexReaperRetryDue,
   reapOrphanedCodexAppServerSidecars,
+  rescanCodexReaperQuarantine,
   runCodexStartupReaper,
 } from '../../../../../server/coding-cli/codex-app-server/runtime.js'
 import { allocateLocalhostPort, type LoopbackServerEndpoint } from '../../../../../server/local-port.js'
@@ -1452,6 +1456,105 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     }
     expect(isCodexReaperRetryDue(state, now)).toBe(false)
     expect(isCodexReaperRetryDue({ ...state, lastAttempt: new Date(now - HOUR).toISOString() }, now)).toBe(true)
+  })
+
+  it('escalates retry logging on wall-time pending age, not attempt count (M4)', () => {
+    const HOUR = 60 * 60 * 1000
+    expect(CODEX_REAPER_LOG_ESCALATION_MS).toBe(6 * HOUR)
+    const now = Date.parse('2026-07-06T12:00:00.000Z')
+    // Young record hammered by tsx-watch restarts: high attempts must NOT escalate…
+    const young = {
+      firstSeen: new Date(now - 5 * HOUR).toISOString(),
+      attempts: 50,
+      lastAttempt: new Date(now).toISOString(),
+    }
+    expect(isCodexReaperEscalationDue(young, now)).toBe(false)
+    // …while a record pending past the wall-time threshold escalates even at one attempt.
+    const old = { ...young, firstSeen: new Date(now - 7 * HOUR).toISOString(), attempts: 1 }
+    expect(isCodexReaperEscalationDue(old, now)).toBe(true)
+  })
+
+  it('defers group teardowns past the boot time budget with retry state, without throwing (M2)', async () => {
+    const metadataDir = await makeTempDir()
+    const writeOrphanRecord = async (name: string, ownershipId: string) => {
+      const now = new Date().toISOString()
+      await fsp.writeFile(path.join(metadataDir, name), JSON.stringify({
+        schemaVersion: 1,
+        ownershipId,
+        serverInstanceId: 'srv-previous',
+        ownerServerPid: 999_999_999,
+        terminalId: null,
+        generation: null,
+        wsUrl: 'ws://127.0.0.1:1',
+        wrapperPid: 999_999_998,
+        processGroupId: 999_999_997,
+        wrapperIdentity: { commandLine: ['codex'], cwd: '/tmp', startTimeTicks: 1 },
+        createdAt: now,
+        updatedAt: now,
+      }), { mode: 0o600 })
+    }
+    await writeOrphanRecord('a.json', 'budget-a')
+    await writeOrphanRecord('b.json', 'budget-b')
+    await writeOrphanRecord('c.json', 'budget-c')
+
+    // Fake clock simulating a slow teardown: the pass starts at 0; the first record's budget check
+    // sees 0ms elapsed (attempted), the second sees 4s (over the 3s budget), the third 8s.
+    const times = [0, 0, 4_000, 8_000]
+    let call = 0
+    const nowFn = () => times[Math.min(call++, times.length - 1)]
+
+    const result = await reapOrphanedCodexAppServerSidecars({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+      terminateGraceMs: 1,
+      teardownBudgetMs: CODEX_REAPER_BOOT_BUDGET_MS,
+      nowFn,
+    })
+
+    // Within budget: attempted (owner dead + group gone -> reaped).
+    expect(result.reapedOwnershipIds).toEqual(['budget-a'])
+    // Past budget: deferred, never dropped — records stay in place with retry state written.
+    expect(result.deferredForBudget).toEqual(['budget-b', 'budget-c'])
+    for (const name of ['b.json', 'c.json']) {
+      await expect(fsp.stat(path.join(metadataDir, name))).resolves.toBeDefined()
+      const state = JSON.parse(await fsp.readFile(path.join(metadataDir, `${name}.reaper.json`), 'utf8'))
+      expect(state.attempts).toBe(1)
+    }
+    await expect(fsp.stat(path.join(metadataDir, 'a.json'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('purges stranded atomic-write tmp files older than an hour (m9)', async () => {
+    const metadataDir = await makeTempDir()
+    const stalePath = path.join(metadataDir, 'dead.json.tmp-1234-5678')
+    const freshPath = path.join(metadataDir, 'live.json.tmp-1234-9999')
+    await fsp.writeFile(stalePath, '{}')
+    await fsp.writeFile(freshPath, '{}')
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000)
+    await fsp.utimes(stalePath, twoHoursAgo, twoHoursAgo)
+
+    await reapOrphanedCodexAppServerSidecars({ metadataDir, serverInstanceId: 'srv-current', terminateGraceMs: 1 })
+
+    await expect(fsp.stat(stalePath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fsp.stat(freshPath)).resolves.toBeDefined()
+  })
+
+  it('unlinks orphaned quarantine notes whose record file is absent (m3)', async () => {
+    const metadataDir = await makeTempDir()
+    const quarantineDir = path.join(metadataDir, 'quarantine')
+    await fsp.mkdir(quarantineDir, { recursive: true })
+    const orphanNote = path.join(quarantineDir, 'ghost.json.note.json')
+    await fsp.writeFile(orphanNote, JSON.stringify({ reason: 'unparseable-record' }))
+    // A note whose record IS present must be left alone.
+    const keptRecord = path.join(quarantineDir, 'kept.json')
+    const keptNote = path.join(quarantineDir, 'kept.json.note.json')
+    await fsp.writeFile(keptRecord, 'not json (unparseable, never promoted)')
+    await fsp.writeFile(keptNote, JSON.stringify({ reason: 'unparseable-record' }))
+
+    await rescanCodexReaperQuarantine(metadataDir)
+
+    await expect(fsp.stat(orphanNote)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fsp.stat(keptNote)).resolves.toBeDefined()
+    await expect(fsp.stat(keptRecord)).resolves.toBeDefined()
   })
 
   it('reports a skipped new-schema ownership record when the owner pid is live', async () => {

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -1539,6 +1539,67 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
     await expect(fsp.stat(path.join(metadataDir, 'a.json'))).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
+  it('deferral write never clobbers a concurrent attempt landing between its read and write (R3-m3)', async () => {
+    const metadataDir = await makeTempDir()
+    const now = new Date().toISOString()
+    const recordPath = path.join(metadataDir, 'race.json')
+    await fsp.writeFile(recordPath, JSON.stringify({
+      schemaVersion: 1,
+      ownershipId: 'race-a',
+      serverInstanceId: 'srv-previous',
+      ownerServerPid: 999_999_999,
+      terminalId: null,
+      generation: null,
+      wsUrl: 'ws://127.0.0.1:1',
+      wrapperPid: 999_999_998,
+      processGroupId: 999_999_997,
+      wrapperIdentity: { commandLine: ['codex'], cwd: '/tmp', startTimeTicks: 1 },
+      createdAt: now,
+      updatedAt: now,
+    }), { mode: 0o600 })
+
+    const sidecarPath = `${recordPath}.reaper.json`
+    // The state a CONCURRENT instance's recordCodexReaperRetryAttempt writes between the
+    // deferral's read (no sidecar yet) and its create-exclusive write.
+    const concurrentState = {
+      firstSeen: new Date(Date.now() - 60_000).toISOString(),
+      attempts: 7,
+      lastAttempt: new Date(Date.now() - 1_000).toISOString(),
+    }
+    const realWriteFile = fsp.writeFile.bind(fsp) as typeof fsp.writeFile
+    const writeFileSpy = vi.spyOn(fsp, 'writeFile')
+    writeFileSpy.mockImplementation(async (file, data, options) => {
+      const flag = options && typeof options === 'object' ? (options as { flag?: string }).flag : undefined
+      if (file === sidecarPath && flag === 'wx') {
+        // Simulate the interleaving: the attempt lands first, then the wx write must EEXIST.
+        await realWriteFile(sidecarPath, JSON.stringify(concurrentState), { mode: 0o600 })
+      }
+      return realWriteFile(file, data as Parameters<typeof realWriteFile>[1], options)
+    })
+
+    try {
+      // Fake clock: the pass starts at 0; the single record's budget check sees 4s (over the 3s
+      // budget), so it takes the deferral path and its sidecar write races the concurrent attempt.
+      const times = [0, 4_000]
+      let call = 0
+      const result = await reapOrphanedCodexAppServerSidecars({
+        metadataDir,
+        serverInstanceId: 'srv-current',
+        terminateGraceMs: 1,
+        teardownBudgetMs: CODEX_REAPER_BOOT_BUDGET_MS,
+        nowFn: () => times[Math.min(call++, times.length - 1)],
+      })
+
+      expect(result.deferredForBudget).toEqual(['race-a'])
+      // The concurrent attempt's state wins: attempts/lastAttempt are NOT reset to a fresh
+      // deferral sidecar (which would restart the backoff and re-arm the hourly tick early).
+      const after = JSON.parse(await fsp.readFile(sidecarPath, 'utf8'))
+      expect(after).toEqual(concurrentState)
+    } finally {
+      writeFileSpy.mockRestore()
+    }
+  })
+
   it('purges stranded atomic-write tmp files older than an hour in the main dir AND quarantine/ (m9, r2-8)', async () => {
     const metadataDir = await makeTempDir()
     const quarantineDir = path.join(metadataDir, 'quarantine')

--- a/test/unit/server/coding-cli/codex-child-registry.test.ts
+++ b/test/unit/server/coding-cli/codex-child-registry.test.ts
@@ -5,11 +5,15 @@ import fsp from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { spawn } from 'node:child_process'
 import {
+  cmdlineHasCodexToken,
   createCodexChildRegistry,
+  deregisterCodexChild,
   snapshotCodexChildren,
   type CodexChildEntry,
   type CodexChildProcessLike,
+  type CodexGroupProbeResult,
 } from '../../../../server/coding-cli/codex-child-registry.js'
 import { CodexAppServerRuntime } from '../../../../server/coding-cli/codex-app-server/runtime.js'
 
@@ -50,6 +54,7 @@ function makeHarness(overrides: {
   ownPgid?: number | 'unreadable'
   procPid?: number
   files?: Record<string, string>
+  probeGroupSync?: (pgid: number) => CodexGroupProbeResult
 } = {}) {
   const procPid = overrides.procPid ?? 7_777
   const files = new Map<string, string>(Object.entries(overrides.files ?? {}))
@@ -85,6 +90,7 @@ function makeHarness(overrides: {
     readFileSync,
     readdirSync,
     killSync,
+    ...(overrides.probeGroupSync ? { probeGroupSync: overrides.probeGroupSync } : {}),
     proc,
     log,
   })
@@ -94,6 +100,11 @@ function makeHarness(overrides: {
 function entry(pid: number, kind: CodexChildEntry['kind'] = 'app-server', pgid = pid): CodexChildEntry {
   return { pid, pgid, kind }
 }
+
+// R2-M1 fixtures: the env-marker ownership proof recorded at registration and the exact
+// NAME=VALUE line the group scan must find in a member's /proc environ.
+const MARKER = { name: 'FRESHELL_TERMINAL_ID', value: 'term-1' }
+const MARKER_ENV = 'FRESHELL_TERMINAL_ID=term-1'
 
 describe('codex child registry', () => {
   describe('registration lifecycle', () => {
@@ -121,6 +132,17 @@ describe('codex child registry', () => {
 
       expect(registry.snapshot()).toEqual([
         { pid: 100, pgid: 100, kind: 'app-server', startTimeTicks: 777 },
+        { pid: 200, pgid: 200, kind: 'resume-pty' },
+      ])
+    })
+
+    it('records the env-marker ownership proof and drops malformed markers (R2-M1)', () => {
+      const { registry } = makeHarness()
+      registry.register({ ...entry(100), envMarker: MARKER })
+      registry.register({ ...entry(200, 'resume-pty'), envMarker: { name: '', value: 'x' } })
+
+      expect(registry.snapshot()).toEqual([
+        { pid: 100, pgid: 100, kind: 'app-server', envMarker: MARKER },
         { pid: 200, pgid: 200, kind: 'resume-pty' },
       ])
     })
@@ -176,13 +198,91 @@ describe('codex child registry', () => {
       expect(kills).toHaveLength(1)
     })
 
-    it('kills the group when the registered pid is dead but a live codex member remains (M1b)', () => {
+    it('kills the group when the registered pid is dead and a member carries the env marker (M1b + R2-M1)', () => {
       const { registry, kills, files } = makeHarness()
       // The registered wrapper (pid 200) is gone from /proc, but grandchild 250 still lives in
-      // pgid 200 and is provably codex — this is the D-state-holder case the registry exists for.
+      // pgid 200, looks like codex, AND provably carries the marker this registration injected at
+      // spawn — this is the D-state-holder case the registry exists for.
       files.set('/proc/250/stat', statLine(250, 200, 55))
       files.set('/proc/250/cmdline', '/usr/local/bin/codex\0app-server\0')
-      registry.register(entry(200, 'app-server'))
+      files.set('/proc/250/environ', `HOME=/root\0${MARKER_ENV}\0`)
+      registry.register({ ...entry(200, 'app-server'), envMarker: MARKER })
+
+      registry.reapSync()
+
+      expect(kills).toEqual([{ pid: -200, signal: 'SIGKILL' }])
+    })
+
+    it('never group-kills when no env marker was recorded, even with a codex member present (R2-M1)', () => {
+      const { registry, kills, files } = makeHarness()
+      files.set('/proc/250/stat', statLine(250, 200, 55))
+      files.set('/proc/250/cmdline', '/usr/local/bin/codex\0app-server\0')
+      files.set('/proc/250/environ', `${MARKER_ENV}\0`)
+      registry.register(entry(200, 'app-server')) // no envMarker: no ownership proof exists
+
+      registry.reapSync()
+
+      expect(kills).toEqual([])
+    })
+
+    it('never group-kills when the codex member lacks the exact marker (R2-M1)', () => {
+      const { registry, kills, files } = makeHarness()
+      // pgid recycled: the member is a REAL codex process, but it belongs to someone else (e.g.
+      // the other server instance's live pane) — its environ carries a different marker value.
+      files.set('/proc/250/stat', statLine(250, 200, 55))
+      files.set('/proc/250/cmdline', '/usr/local/bin/codex\0resume\0')
+      files.set('/proc/250/environ', 'FRESHELL_TERMINAL_ID=someone-else\0')
+      registry.register({ ...entry(200, 'app-server'), envMarker: MARKER })
+
+      registry.reapSync()
+
+      expect(kills).toEqual([])
+    })
+
+    it('never group-kills when the member environ is unreadable (R2-M1 fail-closed)', () => {
+      const { registry, kills, files } = makeHarness()
+      files.set('/proc/250/stat', statLine(250, 200, 55))
+      files.set('/proc/250/cmdline', '/usr/local/bin/codex\0')
+      // no /proc/250/environ entry: the read throws (EACCES/ENOENT equivalent)
+      registry.register({ ...entry(200, 'app-server'), envMarker: MARKER })
+
+      registry.reapSync()
+
+      expect(kills).toEqual([])
+    })
+
+    it('never group-kills when the marker sits past the 4096-byte environ bound (r2-3 fail-closed)', () => {
+      const { registry, kills, files } = makeHarness()
+      files.set('/proc/250/stat', statLine(250, 200, 55))
+      files.set('/proc/250/cmdline', '/usr/local/bin/codex\0')
+      files.set('/proc/250/environ', `FILLER=${'A'.repeat(5000)}\0${MARKER_ENV}\0`)
+      registry.register({ ...entry(200, 'app-server'), envMarker: MARKER })
+
+      registry.reapSync()
+
+      expect(kills).toEqual([])
+    })
+
+    it('group-kills when the marker is within the 4096-byte bound of a large environ (r2-3)', () => {
+      const { registry, kills, files } = makeHarness()
+      files.set('/proc/250/stat', statLine(250, 200, 55))
+      files.set('/proc/250/cmdline', '/usr/local/bin/codex\0')
+      files.set('/proc/250/environ', `${MARKER_ENV}\0FILLER=${'A'.repeat(8000)}\0`)
+      registry.register({ ...entry(200, 'app-server'), envMarker: MARKER })
+
+      registry.reapSync()
+
+      expect(kills).toEqual([{ pid: -200, signal: 'SIGKILL' }])
+    })
+
+    it('routes zombie wrappers (empty cmdline) through the ownership-gated group scan (R2-M1)', () => {
+      const { registry, kills, files } = makeHarness()
+      files.set('/proc/200/stat', statLine(200, 200, 44))
+      registry.register({ ...entry(200, 'app-server'), envMarker: MARKER })
+      files.set('/proc/200/cmdline', '') // zombie: stat readable, cmdline empty
+      files.set('/proc/250/stat', statLine(250, 200, 55))
+      files.set('/proc/250/cmdline', '/usr/local/bin/codex\0')
+      files.set('/proc/250/environ', `${MARKER_ENV}\0`)
 
       registry.reapSync()
 
@@ -193,7 +293,10 @@ describe('codex child registry', () => {
       const { registry, kills, files } = makeHarness()
       files.set('/proc/250/stat', statLine(250, 200, 55))
       files.set('/proc/250/cmdline', '/bin/bash\0')
-      registry.register(entry(200, 'app-server'))
+      // Even a (nonsensical) matching marker cannot rescue a non-codex member: the cmdline
+      // prefilter rejects it before the environ is consulted.
+      files.set('/proc/250/environ', `${MARKER_ENV}\0`)
+      registry.register({ ...entry(200, 'app-server'), envMarker: MARKER })
 
       registry.reapSync()
 
@@ -235,17 +338,51 @@ describe('codex child registry', () => {
       expect(kills).toEqual([])
     })
 
-    it('verifies pgrp+cmdline when no starttime was recorded at registration (fallback pin)', () => {
+    it('does not trust the live-pid path without a starttime pin: pgrp+cmdline alone never kill (r2-1)', () => {
       const { registry, kills, files } = makeHarness()
       // No stat available at register time (startTimeTicks undefined)...
-      registry.register(entry(100))
-      // ...but readable at reap time: pgrp matches and cmdline is codex, so the kill proceeds.
+      registry.register({ ...entry(100), envMarker: MARKER })
+      // ...readable at reap time with a codex cmdline — but the pin is missing, so the entry
+      // routes to the ownership-gated group scan, and no member carries the marker.
       files.set('/proc/100/stat', statLine(100, 100, 11))
       files.set('/proc/100/cmdline', 'codex\0')
 
       registry.reapSync()
 
+      expect(kills).toEqual([])
+    })
+
+    it('kills via the group scan when an unpinned live pid provably carries the marker (r2-1 + R2-M1)', () => {
+      const { registry, kills, files } = makeHarness()
+      registry.register({ ...entry(100), envMarker: MARKER })
+      files.set('/proc/100/stat', statLine(100, 100, 11))
+      files.set('/proc/100/cmdline', 'codex\0')
+      files.set('/proc/100/environ', `${MARKER_ENV}\0`)
+
+      registry.reapSync()
+
       expect(kills).toEqual([{ pid: -100, signal: 'SIGKILL' }])
+    })
+
+    it('builds the /proc group index once per pass across dead-pid entries (r2-4)', () => {
+      const { registry, kills, readdirSync, files } = makeHarness()
+      files.set('/proc/250/stat', statLine(250, 200, 55))
+      files.set('/proc/250/cmdline', 'codex\0')
+      files.set('/proc/250/environ', `${MARKER_ENV}\0`)
+      files.set('/proc/350/stat', statLine(350, 300, 66))
+      files.set('/proc/350/cmdline', 'codex\0')
+      files.set('/proc/350/environ', `${MARKER_ENV}\0`)
+      registry.register({ ...entry(200), envMarker: MARKER })
+      registry.register({ ...entry(300), envMarker: MARKER })
+
+      registry.reapSync()
+
+      expect(kills).toEqual([
+        { pid: -200, signal: 'SIGKILL' },
+        { pid: -300, signal: 'SIGKILL' },
+      ])
+      // One readdir for the whole pass, not one per dead-pid entry.
+      expect(readdirSync).toHaveBeenCalledTimes(1)
     })
 
     it('never signals our own process group or our own pid group', () => {
@@ -333,6 +470,87 @@ describe('codex child registry', () => {
     })
   })
 
+  describe('cmdlineHasCodexToken (r2-2)', () => {
+    it('accepts codex argv tokens by basename (plain binary, absolute path, node wrapper)', () => {
+      expect(cmdlineHasCodexToken('codex\0')).toBe(true)
+      expect(cmdlineHasCodexToken('/usr/bin/codex\0resume\0abc\0')).toBe(true)
+      expect(cmdlineHasCodexToken('node\0/x/bin/codex\0app-server\0')).toBe(true)
+    })
+
+    it('rejects substring and path-only matches', () => {
+      expect(cmdlineHasCodexToken('vim\0codex-notes.md\0')).toBe(false)
+      expect(cmdlineHasCodexToken('/home/dan/.worktrees/codex-launch-leak-plan/server/index.ts\0')).toBe(false)
+      expect(cmdlineHasCodexToken('/usr/bin/codex-tui\0')).toBe(false)
+      expect(cmdlineHasCodexToken('bash\0-c\0echo codex\0')).toBe(false)
+      expect(cmdlineHasCodexToken('')).toBe(false)
+    })
+  })
+
+  describe('deregisterIfGroupGone (m8, r2-13b)', () => {
+    it('keeps the entry on alive/unknown probes and deregisters only on a confirmed-gone group', () => {
+      const probeGroupSync = vi.fn((_pgid: number): CodexGroupProbeResult => 'alive')
+      const { registry } = makeHarness({ probeGroupSync })
+      registry.register(entry(100, 'resume-pty'))
+
+      expect(registry.deregisterIfGroupGone(100)).toBe(false) // alive: keep
+      expect(registry.snapshot()).toHaveLength(1)
+
+      probeGroupSync.mockReturnValueOnce('unknown') // e.g. EPERM: cannot confirm, keep
+      expect(registry.deregisterIfGroupGone(100)).toBe(false)
+      expect(registry.snapshot()).toHaveLength(1)
+
+      probeGroupSync.mockReturnValueOnce('gone')
+      expect(registry.deregisterIfGroupGone(100)).toBe(true)
+      expect(registry.snapshot()).toEqual([])
+      expect(probeGroupSync).toHaveBeenCalledWith(100)
+    })
+
+    it('deregisters unconditionally off Linux (no probe semantics there)', () => {
+      const probeGroupSync = vi.fn((_pgid: number): CodexGroupProbeResult => 'alive')
+      const { registry } = makeHarness({ platform: 'win32', probeGroupSync })
+      registry.register(entry(100, 'resume-pty'))
+
+      expect(registry.deregisterIfGroupGone(100)).toBe(true)
+      expect(probeGroupSync).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('probeResumePtyGroups (r2-11)', () => {
+    it('drains confirmed-gone resume-pty groups; never probes app-server entries', () => {
+      const gone = new Set([200])
+      const probeGroupSync = vi.fn((pgid: number): CodexGroupProbeResult => (gone.has(pgid) ? 'gone' : 'alive'))
+      const { registry } = makeHarness({ probeGroupSync })
+      registry.register(entry(100, 'resume-pty')) // alive -> kept
+      registry.register(entry(200, 'resume-pty')) // gone -> drained
+      registry.register(entry(300, 'app-server')) // app-server: owned by teardown, never probed
+
+      expect(registry.probeResumePtyGroups()).toBe(1)
+
+      expect(registry.snapshot().map((child) => child.pid)).toEqual([100, 300])
+      expect(probeGroupSync).toHaveBeenCalledTimes(2)
+      expect(probeGroupSync).not.toHaveBeenCalledWith(300)
+    })
+
+    it('keeps entries whose probe is inconclusive (unknown/EPERM)', () => {
+      const probeGroupSync = vi.fn((_pgid: number): CodexGroupProbeResult => 'unknown')
+      const { registry } = makeHarness({ probeGroupSync })
+      registry.register(entry(200, 'resume-pty'))
+
+      expect(registry.probeResumePtyGroups()).toBe(0)
+      expect(registry.snapshot()).toHaveLength(1)
+    })
+
+    it('is a no-op off Linux', () => {
+      const probeGroupSync = vi.fn((_pgid: number): CodexGroupProbeResult => 'gone')
+      const { registry } = makeHarness({ platform: 'darwin', probeGroupSync })
+      registry.register(entry(200, 'resume-pty'))
+
+      expect(registry.probeResumePtyGroups()).toBe(0)
+      expect(registry.snapshot()).toHaveLength(1)
+      expect(probeGroupSync).not.toHaveBeenCalled()
+    })
+  })
+
   describe('structural I3 assertion (plan §6 acceptance #2)', () => {
     const source = fs.readFileSync(REGISTRY_SOURCE_PATH, 'utf8')
 
@@ -340,7 +558,10 @@ describe('codex child registry', () => {
       // Exactly one negative-pid kill in the module, and it lives inside killProcessGroupSync.
       const negativeKills = source.match(/killSync\(\s*-/g) ?? []
       expect(negativeKills).toHaveLength(1)
-      expect(source.match(/process\.kill\(\s*-/g)).toBeNull()
+      // The ONLY other negative-pid syscall is the signal-0 liveness probe (r2-11/m8), which by
+      // definition delivers nothing — every process.kill(-...) in the module must pass signal 0.
+      const negativeProcessKills = source.match(/process\.kill\(\s*-[^)]*\)/g) ?? []
+      expect(negativeProcessKills).toEqual(['process.kill(-pgid, 0)'])
 
       const primitiveBody = source.slice(
         source.indexOf('function killProcessGroupSync'),
@@ -400,7 +621,9 @@ describe('codex child registry', () => {
   describe('wiring (source-level)', () => {
     it('runtime.ts registers at spawn and deregisters only on confirmed group death', () => {
       const runtimeSource = fs.readFileSync(path.join(SERVER_DIR, 'coding-cli', 'codex-app-server', 'runtime.ts'), 'utf8')
-      expect(runtimeSource).toContain("registerCodexChild({ pid: child.pid, pgid: child.pid, kind: 'app-server' })")
+      expect(runtimeSource).toMatch(
+        /registerCodexChild\(\{\s*pid: child\.pid,\s*pgid: child\.pid,\s*kind: 'app-server',[\s\S]{0,400}?envMarker: \{ name: 'FRESHELL_CODEX_SIDECAR_ID', value: ownershipId \},\s*\}\)/,
+      )
       // Deregistration is gated on teardownOwnedProcessGroup's confirmed-death result…
       expect(runtimeSource).toContain('if (confirmedGone) deregisterCodexChild(ownership.metadata.wrapperPid)')
       // …and the wrapper-exit handler does NOT deregister (grandchildren can outlive the wrapper).
@@ -421,9 +644,15 @@ describe('codex child registry', () => {
     it('terminal-registry.ts registers codex ptys at both spawn sites and deregisters only on confirmed group death', () => {
       const registrySource = fs.readFileSync(path.join(SERVER_DIR, 'terminal-registry.ts'), 'utf8')
       const registrations = registrySource.match(
-        /registerCodexChild\(\{ pid: ptyProc\.pid, pgid: ptyProc\.pid, kind: 'resume-pty' \}\)/g,
+        /registerCodexChild\(\{\s*pid: ptyProc\.pid,\s*pgid: ptyProc\.pid,\s*kind: 'resume-pty',/g,
       ) ?? []
       expect(registrations).toHaveLength(2)
+      // R2-M1: both spawn sites record the FRESHELL_TERMINAL_ID env marker (already present in
+      // the pty env via buildTerminalBaseEnv) as the group-scan ownership proof.
+      const markers = registrySource.match(
+        /envMarker: \{ name: 'FRESHELL_TERMINAL_ID', value: (?:terminalId|record\.terminalId) \}/g,
+      ) ?? []
+      expect(markers).toHaveLength(2)
       // The primary spawn site registers codex panes only.
       expect(registrySource).toContain("if (opts.mode === 'codex' && ptyProc.pid) {")
       // Both spawn-site onExit handlers route through the liveness-probing deregister helper (m8),
@@ -433,8 +662,9 @@ describe('codex child registry', () => {
       expect(deregistrations).toHaveLength(2)
       expect(registrySource).toContain("if (opts.mode === 'codex') deregisterCodexPtyIfGroupGone(ptyProc.pid)")
       expect(registrySource).toContain("if (record.mode === 'codex') deregisterCodexPtyIfGroupGone(ptyProc.pid)")
-      // m8: the helper only deregisters when the group is confirmed gone (ESRCH probe) on Linux.
-      expect(registrySource).toContain('process.kill(-pid, 0)')
+      // m8/r2-13b: the helper (now homed in codex-child-registry.ts behind an injectable probe
+      // seam) only deregisters when the group is confirmed gone; terminal-registry imports it.
+      expect(registrySource).toContain('deregisterCodexChildIfGroupGone as deregisterCodexPtyIfGroupGone')
       const killBody = registrySource.slice(
         registrySource.indexOf('kill(terminalId: string'),
         registrySource.indexOf('private markCodexRecoveryFinalClose'),
@@ -449,7 +679,12 @@ describe('codex child registry', () => {
       expect(indexSource).toContain('hardExitTimer.unref()')
       // M6: slow-but-healthy shutdowns get their connections severed; the force-exit line is also
       // written synchronously (async pino may not flush before exit); the happy path clears the timer.
-      expect(indexSource).toContain('server.closeAllConnections?.()')
+      expect(indexSource).toContain('server.closeIdleConnections?.()')
+      // r2-10: in-flight HTTP responses get a 3s unref()'d grace before closeAllConnections severs
+      // them, cleared as soon as the server finishes closing on its own.
+      expect(indexSource).toMatch(/setTimeout\(\(\) => \{\s*server\.closeAllConnections\?\.\(\)\s*\}, 3_000\)/)
+      expect(indexSource).toContain('closeAllConnectionsTimer.unref()')
+      expect(indexSource).toContain('void httpServerClosed.then(() => clearTimeout(closeAllConnectionsTimer))')
       expect(indexSource).toContain('process.stderr.write(')
       expect(indexSource).toContain('clearTimeout(hardExitTimer)')
       expect(indexSource).toContain("forcing exit")
@@ -473,6 +708,51 @@ describeWithLinuxProc('codex child registry runtime integration', () => {
       tempDirs.delete(dir)
       await fsp.rm(dir, { recursive: true, force: true })
     }))
+  })
+
+  it('deregisters a spawn-failed no-ownership child on its exit (m1, r2-13a)', async () => {
+    const metadataDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-child-registry-'))
+    tempDirs.add(metadataDir)
+    const fakePid = 3_999_999
+    const child = Object.assign(new EventEmitter(), {
+      pid: fakePid,
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      stdout: null,
+      stderr: null,
+      kill: vi.fn(() => true),
+    })
+    const runtime = new CodexAppServerRuntime({
+      metadataDir,
+      startupAttemptLimit: 1,
+      portAllocator: async () => ({ hostname: '127.0.0.1', port: 1 }),
+      // The owner-identity read fails BEFORE any ownership record exists, so ownership teardown
+      // (the usual deregistration point) will never run for this child.
+      processIdentityReader: async () => null,
+      spawnProcess: (() => child) as unknown as typeof spawn,
+    })
+    runtimes.add(runtime)
+
+    await expect(runtime.ensureReady()).rejects.toThrow(/owner identity could not be completely read/)
+
+    try {
+      // Registered at spawn (with the R2-M1 env marker), SIGTERM'd by stopActiveChild, and still
+      // registered while the child has not exited — kill() only sends a signal.
+      expect(snapshotCodexChildren()).toContainEqual(expect.objectContaining({
+        pid: fakePid,
+        pgid: fakePid,
+        kind: 'app-server',
+        envMarker: expect.objectContaining({ name: 'FRESHELL_CODEX_SIDECAR_ID' }),
+      }))
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+
+      child.exitCode = 0
+      child.emit('exit', 0, null)
+
+      expect(snapshotCodexChildren().some((c) => c.pid === fakePid)).toBe(false)
+    } finally {
+      deregisterCodexChild(fakePid)
+    }
   })
 
   it('registers the app-server group at spawn and deregisters on confirmed teardown', async () => {

--- a/test/unit/server/coding-cli/codex-child-registry.test.ts
+++ b/test/unit/server/coding-cli/codex-child-registry.test.ts
@@ -1,0 +1,371 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  createCodexChildRegistry,
+  snapshotCodexChildren,
+  type CodexChildEntry,
+  type CodexChildProcessLike,
+} from '../../../../server/coding-cli/codex-child-registry.js'
+import { CodexAppServerRuntime } from '../../../../server/coding-cli/codex-app-server/runtime.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const SERVER_DIR = path.resolve(__dirname, '../../../../server')
+const REGISTRY_SOURCE_PATH = path.join(SERVER_DIR, 'coding-cli', 'codex-child-registry.ts')
+const FAKE_SERVER_PATH = path.resolve(__dirname, '../../../fixtures/coding-cli/codex-app-server/fake-app-server.mjs')
+
+// Generous startup budget for the real-spawn integration test; mirrors runtime.test.ts (the suite
+// runs with fileParallelism, so freshly-spawned sidecars are CPU-starved under load).
+const REAL_STARTUP_ATTEMPT_TIMEOUT_MS = 5_000
+
+type FakeProc = CodexChildProcessLike & EventEmitter
+
+function makeFakeProc(pid = 7_777): FakeProc {
+  const emitter = new EventEmitter() as FakeProc
+  ;(emitter as { pid: number }).pid = pid
+  return emitter
+}
+
+function statLine(pid: number, pgrp: number): string {
+  // pid (comm) state ppid pgrp ... — comm intentionally contains a space + paren to exercise the
+  // lastIndexOf(')') parse.
+  return `${pid} (no de)s) S 1 ${pgrp} ${pgrp} 0 -1 4194560 100 0 0 0`
+}
+
+function makeHarness(overrides: {
+  platform?: NodeJS.Platform
+  ownPgid?: number | 'unreadable'
+  procPid?: number
+  files?: Record<string, string>
+} = {}) {
+  const procPid = overrides.procPid ?? 7_777
+  const files = new Map<string, string>(Object.entries(overrides.files ?? {}))
+  if (overrides.ownPgid !== 'unreadable') {
+    files.set('/proc/self/stat', statLine(procPid, overrides.ownPgid ?? 4_242))
+  }
+  const kills: Array<{ pid: number; signal: string }> = []
+  const readFileSync = vi.fn((filePath: string): Buffer => {
+    const content = files.get(filePath)
+    if (content === undefined) {
+      const err = new Error(`ENOENT: ${filePath}`) as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      throw err
+    }
+    return Buffer.from(content)
+  })
+  const killSync = vi.fn((pid: number, signal: NodeJS.Signals) => {
+    kills.push({ pid, signal })
+  })
+  const log = { warn: vi.fn() }
+  const proc = makeFakeProc(procPid)
+  const registry = createCodexChildRegistry({
+    platform: overrides.platform ?? 'linux',
+    readFileSync,
+    killSync,
+    proc,
+    log,
+  })
+  return { registry, kills, killSync, readFileSync, log, proc, files }
+}
+
+function entry(pid: number, kind: CodexChildEntry['kind'] = 'app-server', pgid = pid): CodexChildEntry {
+  return { pid, pgid, kind }
+}
+
+describe('codex child registry', () => {
+  describe('registration lifecycle', () => {
+    it('registers, snapshots, and deregisters entries', () => {
+      const { registry } = makeHarness()
+      registry.register(entry(100, 'app-server'))
+      registry.register(entry(200, 'resume-pty'))
+
+      expect(registry.snapshot()).toEqual([
+        { pid: 100, pgid: 100, kind: 'app-server' },
+        { pid: 200, pgid: 200, kind: 'resume-pty' },
+      ])
+
+      expect(registry.deregister(100)).toBe(true)
+      expect(registry.snapshot()).toEqual([{ pid: 200, pgid: 200, kind: 'resume-pty' }])
+      expect(registry.deregister(100)).toBe(false)
+    })
+
+    it('is safe to double-register the same pid (latest registration wins)', () => {
+      const { registry } = makeHarness()
+      registry.register(entry(100, 'app-server'))
+      registry.register({ pid: 100, pgid: 100, kind: 'resume-pty' })
+
+      expect(registry.snapshot()).toEqual([{ pid: 100, pgid: 100, kind: 'resume-pty' }])
+    })
+
+    it('refuses invalid pids and pgids (never track -1/0/1)', () => {
+      const { registry, log } = makeHarness()
+      registry.register({ pid: 0, pgid: 100, kind: 'app-server' })
+      registry.register({ pid: -3, pgid: 100, kind: 'app-server' })
+      registry.register({ pid: 1.5, pgid: 100, kind: 'app-server' })
+      registry.register({ pid: 100, pgid: -1, kind: 'app-server' })
+      registry.register({ pid: 100, pgid: 0, kind: 'app-server' })
+      registry.register({ pid: 100, pgid: 1, kind: 'app-server' })
+
+      expect(registry.snapshot()).toEqual([])
+      expect(log.warn).toHaveBeenCalledTimes(6)
+    })
+
+    it('snapshot returns copies (mutation cannot corrupt the registry)', () => {
+      const { registry } = makeHarness()
+      registry.register(entry(100))
+      const snap = registry.snapshot()
+      snap[0].pgid = -1
+      snap.pop()
+      expect(registry.snapshot()).toEqual([{ pid: 100, pgid: 100, kind: 'app-server' }])
+    })
+  })
+
+  describe('reapSync', () => {
+    it('SIGKILLs only registered entries whose /proc identity still looks like codex', () => {
+      const { registry, kills, files } = makeHarness()
+      files.set('/proc/100/cmdline', '/usr/local/bin/codex\0resume\0abc\0')
+      // pid 200 has no /proc entry (already gone); pid 300 was reused by a non-codex process.
+      files.set('/proc/300/cmdline', '/bin/bash\0')
+      registry.register(entry(100, 'app-server'))
+      registry.register(entry(200, 'resume-pty'))
+      registry.register(entry(300, 'resume-pty'))
+
+      registry.reapSync()
+
+      expect(kills).toEqual([{ pid: -100, signal: 'SIGKILL' }])
+      // The pass drains the registry: a second reap is a no-op.
+      expect(registry.snapshot()).toEqual([])
+      registry.reapSync()
+      expect(kills).toHaveLength(1)
+    })
+
+    it('never signals our own process group or our own pid group', () => {
+      const { registry, kills, files } = makeHarness({ ownPgid: 4_242, procPid: 7_777 })
+      files.set('/proc/555/cmdline', 'codex\0')
+      files.set('/proc/556/cmdline', 'codex\0')
+      registry.register({ pid: 555, pgid: 4_242, kind: 'app-server' }) // own pgid
+      registry.register({ pid: 556, pgid: 7_777, kind: 'app-server' }) // our pid's group
+
+      registry.reapSync()
+
+      expect(kills).toEqual([])
+    })
+
+    it('signals nothing when our own pgid cannot be proven', () => {
+      const { registry, kills, files } = makeHarness({ ownPgid: 'unreadable' })
+      files.set('/proc/100/cmdline', 'codex\0')
+      registry.register(entry(100))
+
+      registry.reapSync()
+
+      expect(kills).toEqual([])
+    })
+
+    it('is a no-op on win32 (register/deregister still track)', () => {
+      const { registry, kills, readFileSync } = makeHarness({ platform: 'win32' })
+      registry.register(entry(100))
+
+      expect(registry.snapshot()).toEqual([{ pid: 100, pgid: 100, kind: 'app-server' }])
+      registry.reapSync()
+      expect(kills).toEqual([])
+      expect(readFileSync).not.toHaveBeenCalled()
+      expect(registry.snapshot()).toEqual([{ pid: 100, pgid: 100, kind: 'app-server' }])
+    })
+
+    it('never throws out of the exit path and keeps reaping after a kill failure', () => {
+      const { registry, killSync, kills, files } = makeHarness()
+      files.set('/proc/100/cmdline', 'codex\0')
+      files.set('/proc/200/cmdline', 'codex\0')
+      killSync.mockImplementationOnce(() => {
+        throw Object.assign(new Error('EPERM'), { code: 'EPERM' })
+      })
+      registry.register(entry(100))
+      registry.register(entry(200))
+
+      expect(() => registry.reapSync()).not.toThrow()
+      // First kill threw; the second entry was still processed.
+      expect(kills).toEqual([{ pid: -200, signal: 'SIGKILL' }])
+    })
+  })
+
+  describe('installExitHandlers', () => {
+    it("binds 'exit' to reapSync itself, routes SIGHUP to shutdown, and observes uncaught exceptions", () => {
+      const { registry, proc, log } = makeHarness()
+      const requestShutdown = vi.fn()
+
+      registry.installExitHandlers({ requestShutdown })
+
+      expect(proc.listeners('exit')).toEqual([registry.reapSync])
+      expect(proc.listenerCount('SIGHUP')).toBe(1)
+      expect(proc.listenerCount('uncaughtExceptionMonitor')).toBe(1)
+
+      proc.emit('SIGHUP')
+      expect(requestShutdown).toHaveBeenCalledExactlyOnceWith('SIGHUP')
+
+      proc.emit('uncaughtExceptionMonitor', new Error('boom'), 'uncaughtException')
+      expect(log.warn).toHaveBeenCalledTimes(1)
+      // Observe-only: the monitor must not trigger shutdown or reap.
+      expect(requestShutdown).toHaveBeenCalledTimes(1)
+    })
+
+    it('is idempotent (double install binds once)', () => {
+      const { registry, proc } = makeHarness()
+      registry.installExitHandlers({ requestShutdown: vi.fn() })
+      registry.installExitHandlers({ requestShutdown: vi.fn() })
+
+      expect(proc.listenerCount('exit')).toBe(1)
+      expect(proc.listenerCount('SIGHUP')).toBe(1)
+      expect(proc.listenerCount('uncaughtExceptionMonitor')).toBe(1)
+    })
+  })
+
+  describe('structural I3 assertion (plan §6 acceptance #2)', () => {
+    const source = fs.readFileSync(REGISTRY_SOURCE_PATH, 'utf8')
+
+    it('the group-kill primitive is the only negative-pid signal and has exactly one caller: reapSync', () => {
+      // Exactly one negative-pid kill in the module, and it lives inside killProcessGroupSync.
+      const negativeKills = source.match(/killSync\(\s*-/g) ?? []
+      expect(negativeKills).toHaveLength(1)
+      expect(source.match(/process\.kill\(\s*-/g)).toBeNull()
+
+      const primitiveBody = source.slice(
+        source.indexOf('function killProcessGroupSync'),
+        source.indexOf('function reapSync'),
+      )
+      expect(primitiveBody).toContain("killSync(-pgid, 'SIGKILL')")
+
+      // killProcessGroupSync appears exactly twice: its definition and its single call site…
+      const references = source.match(/killProcessGroupSync\(/g) ?? []
+      expect(references).toHaveLength(2)
+      // …and the call site is inside reapSync's body.
+      const reapBody = source.slice(
+        source.indexOf('function reapSync'),
+        source.indexOf('function installExitHandlers'),
+      )
+      expect(reapBody.match(/killProcessGroupSync\(/g)).toHaveLength(1)
+    })
+
+    it("reapSync is never invoked directly and is referenced only by the 'exit' binding", () => {
+      // No direct invocation anywhere in the module (the definition is the only `reapSync(` token).
+      const invocations = source.match(/(?<!function )reapSync\(/g) ?? []
+      expect(invocations).toEqual([])
+      // Exactly one handler registration passes reapSync, and it is the 'exit' binding.
+      expect(source.match(/,\s*reapSync\)/g)).toHaveLength(1)
+      expect(source).toContain("proc.on('exit', reapSync)")
+    })
+
+    it('no other server module invokes reapSync', () => {
+      const offenders: string[] = []
+      const walk = (dir: string): void => {
+        for (const dirent of fs.readdirSync(dir, { withFileTypes: true })) {
+          const fullPath = path.join(dir, dirent.name)
+          if (dirent.isDirectory()) {
+            if (dirent.name === 'node_modules') continue
+            walk(fullPath)
+            continue
+          }
+          if (!dirent.name.endsWith('.ts')) continue
+          if (fullPath === REGISTRY_SOURCE_PATH) continue
+          const content = fs.readFileSync(fullPath, 'utf8')
+          // Invocation, or importing the exported reapSync binding (comments may legitimately
+          // *mention* reapSync when documenting the exit path).
+          const invokes = /\breapSync\(/.test(content)
+          const importsBinding = /\{[^}]*\breapSync\b[^}]*\}\s*from\s*'[^']*codex-child-registry/.test(content)
+          if (invokes || importsBinding) {
+            offenders.push(fullPath)
+          }
+        }
+      }
+      walk(SERVER_DIR)
+      expect(offenders).toEqual([])
+    })
+  })
+
+  describe('wiring (source-level)', () => {
+    it('runtime.ts registers at spawn and deregisters only on confirmed group death', () => {
+      const runtimeSource = fs.readFileSync(path.join(SERVER_DIR, 'coding-cli', 'codex-app-server', 'runtime.ts'), 'utf8')
+      expect(runtimeSource).toContain("registerCodexChild({ pid: child.pid, pgid: child.pid, kind: 'app-server' })")
+      // Deregistration is gated on teardownOwnedProcessGroup's confirmed-death result…
+      expect(runtimeSource).toContain('if (confirmedGone) deregisterCodexChild(ownership.metadata.wrapperPid)')
+      // …and the wrapper-exit handler does NOT deregister (grandchildren can outlive the wrapper).
+      const wrapperExitBody = runtimeSource.slice(
+        runtimeSource.indexOf('private attachChildExitHandler'),
+        runtimeSource.indexOf('private async stopActiveChild'),
+      )
+      expect(wrapperExitBody).not.toContain('deregisterCodexChild')
+    })
+
+    it('terminal-registry.ts registers codex ptys at both spawn sites and deregisters in onExit', () => {
+      const registrySource = fs.readFileSync(path.join(SERVER_DIR, 'terminal-registry.ts'), 'utf8')
+      const registrations = registrySource.match(
+        /registerCodexChild\(\{ pid: ptyProc\.pid, pgid: ptyProc\.pid, kind: 'resume-pty' \}\)/g,
+      ) ?? []
+      expect(registrations).toHaveLength(2)
+      // The primary spawn site registers codex panes only.
+      expect(registrySource).toContain("if (opts.mode === 'codex' && ptyProc.pid) {")
+      // Both spawn-site onExit handlers deregister; kill() never does (it only sends a signal).
+      const deregistrations = registrySource.match(/deregisterCodexChild\(ptyProc\.pid\)/g) ?? []
+      expect(deregistrations).toHaveLength(2)
+      const killBody = registrySource.slice(
+        registrySource.indexOf('kill(terminalId: string'),
+        registrySource.indexOf('private markCodexRecoveryFinalClose'),
+      )
+      expect(killBody).not.toContain('deregisterCodexChild')
+    })
+
+    it('index.ts installs the bindings once and arms an unref()d 15s hard-exit timer in shutdown()', () => {
+      const indexSource = fs.readFileSync(path.join(SERVER_DIR, 'index.ts'), 'utf8')
+      expect(indexSource.match(/installCodexChildExitHandlers\(\{/g)).toHaveLength(1)
+      expect(indexSource).toContain('const SHUTDOWN_HARD_EXIT_TIMEOUT_MS = 15_000')
+      expect(indexSource).toContain('hardExitTimer.unref()')
+      expect(indexSource).toContain('process.exit(1)\n    }, SHUTDOWN_HARD_EXIT_TIMEOUT_MS)')
+    })
+  })
+})
+
+const describeWithLinuxProc = process.platform === 'linux' ? describe : describe.skip
+
+describeWithLinuxProc('codex child registry runtime integration', () => {
+  const runtimes = new Set<CodexAppServerRuntime>()
+  const tempDirs = new Set<string>()
+
+  afterEach(async () => {
+    await Promise.all([...runtimes].map(async (runtime) => {
+      runtimes.delete(runtime)
+      await runtime.shutdown()
+    }))
+    await Promise.all([...tempDirs].map(async (dir) => {
+      tempDirs.delete(dir)
+      await fsp.rm(dir, { recursive: true, force: true })
+    }))
+  })
+
+  it('registers the app-server group at spawn and deregisters on confirmed teardown', async () => {
+    const metadataDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-child-registry-'))
+    tempDirs.add(metadataDir)
+    const runtime = new CodexAppServerRuntime({
+      command: process.execPath,
+      commandArgs: [FAKE_SERVER_PATH],
+      metadataDir,
+      startupAttemptTimeoutMs: REAL_STARTUP_ATTEMPT_TIMEOUT_MS,
+    })
+    runtimes.add(runtime)
+
+    const ready = await runtime.ensureReady()
+
+    expect(snapshotCodexChildren()).toContainEqual({
+      pid: ready.processPid,
+      pgid: ready.processPid,
+      kind: 'app-server',
+    })
+
+    await runtime.shutdown()
+
+    expect(snapshotCodexChildren().some((child) => child.pid === ready.processPid)).toBe(false)
+  })
+})

--- a/test/unit/server/coding-cli/codex-child-registry.test.ts
+++ b/test/unit/server/coding-cli/codex-child-registry.test.ts
@@ -10,6 +10,8 @@ import {
   cmdlineHasCodexToken,
   createCodexChildRegistry,
   deregisterCodexChild,
+  PROC_ENVIRON_READ_MAX_BYTES,
+  readProcFileBoundedSync,
   snapshotCodexChildren,
   type CodexChildEntry,
   type CodexChildProcessLike,
@@ -83,7 +85,7 @@ function makeHarness(overrides: {
   const killSync = vi.fn((pid: number, signal: NodeJS.Signals) => {
     kills.push({ pid, signal })
   })
-  const log = { warn: vi.fn() }
+  const log = { warn: vi.fn(), debug: vi.fn() }
   const proc = makeFakeProc(procPid)
   const registry = createCodexChildRegistry({
     platform: overrides.platform ?? 'linux',
@@ -251,11 +253,48 @@ describe('codex child registry', () => {
       expect(kills).toEqual([])
     })
 
-    it('never group-kills when the marker sits past the 4096-byte environ bound (r2-3 fail-closed)', () => {
+    it('never group-kills when the marker sits past the environ read bound (r2-3/R3-M1 fail-closed)', () => {
+      const { registry, kills, files, log } = makeHarness()
+      files.set('/proc/250/stat', statLine(250, 200, 55))
+      files.set('/proc/250/cmdline', '/usr/local/bin/codex\0')
+      // The filler alone exceeds PROC_ENVIRON_READ_MAX_BYTES, so the trailing marker is unreachable.
+      files.set('/proc/250/environ', `FILLER=${'A'.repeat(PROC_ENVIRON_READ_MAX_BYTES)}\0${MARKER_ENV}\0`)
+      registry.register({ ...entry(200, 'app-server'), envMarker: MARKER })
+
+      registry.reapSync()
+
+      expect(kills).toEqual([])
+      // R3-M1: "marker unreachable past the bound" is distinguishable from "provably not ours".
+      expect(log.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ pid: 250, pgid: 200, maxBytes: PROC_ENVIRON_READ_MAX_BYTES }),
+        expect.stringContaining('Truncated environ read without ownership marker'),
+      )
+    })
+
+    it('group-kills when the marker sits at the real-world ~5,900-byte environ position (R3-M1)', () => {
       const { registry, kills, files } = makeHarness()
       files.set('/proc/250/stat', statLine(250, 200, 55))
       files.set('/proc/250/cmdline', '/usr/local/bin/codex\0')
-      files.set('/proc/250/environ', `FILLER=${'A'.repeat(5000)}\0${MARKER_ENV}\0`)
+      // Both spawn sites append the marker LAST in env-spread order and real environs on this host
+      // run ~5,900 bytes; under the old 4096-byte bound this marker was unreachable on essentially
+      // every spawn, so the dead-pid group reap silently never fired.
+      files.set('/proc/250/environ', `FILLER=${'A'.repeat(5_900)}\0${MARKER_ENV}\0`)
+      registry.register({ ...entry(200, 'app-server'), envMarker: MARKER })
+
+      registry.reapSync()
+
+      expect(kills).toEqual([{ pid: -200, signal: 'SIGKILL' }])
+    })
+
+    it('never counts a truncation-torn trailing token as the marker (R3-m2)', () => {
+      const { registry, kills, files } = makeHarness()
+      files.set('/proc/250/stat', statLine(250, 200, 55))
+      files.set('/proc/250/cmdline', '/usr/local/bin/codex\0')
+      // A DIFFERENT env value (`${MARKER_ENV}EXTRA`) cut exactly at the read bound leaves visible
+      // bytes identical to the real marker. The torn final token must never count as ownership
+      // proof, so this member is "not provably ours" and the group is never signalled.
+      const prefix = `FILLER=${'A'.repeat(PROC_ENVIRON_READ_MAX_BYTES - 'FILLER=\0'.length - MARKER_ENV.length)}\0`
+      files.set('/proc/250/environ', `${prefix}${MARKER_ENV}EXTRA\0`)
       registry.register({ ...entry(200, 'app-server'), envMarker: MARKER })
 
       registry.reapSync()
@@ -263,11 +302,11 @@ describe('codex child registry', () => {
       expect(kills).toEqual([])
     })
 
-    it('group-kills when the marker is within the 4096-byte bound of a large environ (r2-3)', () => {
+    it('group-kills when the marker is within the read bound of a truncated environ (r2-3)', () => {
       const { registry, kills, files } = makeHarness()
       files.set('/proc/250/stat', statLine(250, 200, 55))
       files.set('/proc/250/cmdline', '/usr/local/bin/codex\0')
-      files.set('/proc/250/environ', `${MARKER_ENV}\0FILLER=${'A'.repeat(8000)}\0`)
+      files.set('/proc/250/environ', `${MARKER_ENV}\0FILLER=${'A'.repeat(PROC_ENVIRON_READ_MAX_BYTES)}\0`)
       registry.register({ ...entry(200, 'app-server'), envMarker: MARKER })
 
       registry.reapSync()
@@ -483,6 +522,39 @@ describe('codex child registry', () => {
       expect(cmdlineHasCodexToken('/usr/bin/codex-tui\0')).toBe(false)
       expect(cmdlineHasCodexToken('bash\0-c\0echo codex\0')).toBe(false)
       expect(cmdlineHasCodexToken('')).toBe(false)
+    })
+  })
+
+  describe('readProcFileBoundedSync (R3-m4: the production openSync/readSync helper)', () => {
+    it('bounds oversized files, returns small files whole, and throws ENOENT for missing paths', () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'freshell-bounded-read-'))
+      try {
+        const bigPath = path.join(dir, 'big')
+        const smallPath = path.join(dir, 'small')
+        fs.writeFileSync(bigPath, Buffer.alloc(4096 + 500, 0x41))
+        fs.writeFileSync(smallPath, 'MARKER=value\0')
+
+        // Oversized content: exactly maxBytes bytes back, flagged truncated.
+        const big = readProcFileBoundedSync(bigPath, 4096)
+        expect(big.truncated).toBe(true)
+        expect(big.data.length).toBe(4096)
+        expect(big.data.equals(Buffer.alloc(4096, 0x41))).toBe(true)
+
+        // Undersized content: returned whole, not truncated.
+        const small = readProcFileBoundedSync(smallPath, 4096)
+        expect(small.truncated).toBe(false)
+        expect(small.data.toString('utf8')).toBe('MARKER=value\0')
+
+        // Exact-bound content is NOT flagged (the helper reads one byte past to detect overflow).
+        const exact = readProcFileBoundedSync(bigPath, 4096 + 500)
+        expect(exact.truncated).toBe(false)
+        expect(exact.data.length).toBe(4096 + 500)
+
+        // Missing file: the open throws (callers per-pid try/catch and fail closed).
+        expect(() => readProcFileBoundedSync(path.join(dir, 'missing'), 4096)).toThrow(/ENOENT/)
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true })
+      }
     })
   })
 

--- a/test/unit/server/coding-cli/codex-child-registry.test.ts
+++ b/test/unit/server/coding-cli/codex-child-registry.test.ts
@@ -31,10 +31,18 @@ function makeFakeProc(pid = 7_777): FakeProc {
   return emitter
 }
 
-function statLine(pid: number, pgrp: number): string {
-  // pid (comm) state ppid pgrp ... — comm intentionally contains a space + paren to exercise the
-  // lastIndexOf(')') parse.
-  return `${pid} (no de)s) S 1 ${pgrp} ${pgrp} 0 -1 4194560 100 0 0 0`
+// pid (comm) state ppid pgrp sess tty tpgid flags ... starttime(field 22) — comm intentionally
+// contains a space + paren to exercise the lastIndexOf(')') parse. Field 22 (index 19 after the
+// close paren) is starttime.
+function statLine(pid: number, pgrp: number, startTimeTicks = 100): string {
+  const tail = [
+    'S', '1', String(pgrp), String(pgrp), '0', '-1', '4194560',
+    '100', '0', '0', '0', // minflt cminflt majflt cmajflt
+    '5', '3', '0', '0', // utime stime cutime cstime
+    '20', '0', '1', '0', // priority nice threads itrealvalue
+    String(startTimeTicks), '1024', '0', // starttime vsize rss
+  ]
+  return `${pid} (no de)s) ${tail.join(' ')}`
 }
 
 function makeHarness(overrides: {
@@ -58,6 +66,15 @@ function makeHarness(overrides: {
     }
     return Buffer.from(content)
   })
+  // Directory listing derived from the fake file map (dead-pid group fallback scan).
+  const readdirSync = vi.fn((dirPath: string): string[] => {
+    const names = new Set<string>()
+    for (const key of files.keys()) {
+      if (!key.startsWith(`${dirPath}/`)) continue
+      names.add(key.slice(dirPath.length + 1).split('/')[0])
+    }
+    return [...names]
+  })
   const killSync = vi.fn((pid: number, signal: NodeJS.Signals) => {
     kills.push({ pid, signal })
   })
@@ -66,11 +83,12 @@ function makeHarness(overrides: {
   const registry = createCodexChildRegistry({
     platform: overrides.platform ?? 'linux',
     readFileSync,
+    readdirSync,
     killSync,
     proc,
     log,
   })
-  return { registry, kills, killSync, readFileSync, log, proc, files }
+  return { registry, kills, killSync, readFileSync, readdirSync, log, proc, files }
 }
 
 function entry(pid: number, kind: CodexChildEntry['kind'] = 'app-server', pgid = pid): CodexChildEntry {
@@ -92,6 +110,19 @@ describe('codex child registry', () => {
       expect(registry.deregister(100)).toBe(true)
       expect(registry.snapshot()).toEqual([{ pid: 200, pgid: 200, kind: 'resume-pty' }])
       expect(registry.deregister(100)).toBe(false)
+    })
+
+    it('captures the /proc starttime at registration (best-effort identity pin)', () => {
+      const { registry, files } = makeHarness()
+      files.set('/proc/100/stat', statLine(100, 100, 777))
+      registry.register(entry(100))
+      // pid 200 has no readable stat: registration still succeeds without the pin.
+      registry.register(entry(200, 'resume-pty'))
+
+      expect(registry.snapshot()).toEqual([
+        { pid: 100, pgid: 100, kind: 'app-server', startTimeTicks: 777 },
+        { pid: 200, pgid: 200, kind: 'resume-pty' },
+      ])
     })
 
     it('is safe to double-register the same pid (latest registration wins)', () => {
@@ -126,13 +157,14 @@ describe('codex child registry', () => {
   })
 
   describe('reapSync', () => {
-    it('SIGKILLs only registered entries whose /proc identity still looks like codex', () => {
+    it('SIGKILLs only registered entries whose /proc identity still verifies (starttime+pgrp+cmdline)', () => {
       const { registry, kills, files } = makeHarness()
+      files.set('/proc/100/stat', statLine(100, 100, 11))
       files.set('/proc/100/cmdline', '/usr/local/bin/codex\0resume\0abc\0')
-      // pid 200 has no /proc entry (already gone); pid 300 was reused by a non-codex process.
+      // pid 300 was reused by a non-codex process (same pid, non-codex cmdline).
+      files.set('/proc/300/stat', statLine(300, 300, 33))
       files.set('/proc/300/cmdline', '/bin/bash\0')
       registry.register(entry(100, 'app-server'))
-      registry.register(entry(200, 'resume-pty'))
       registry.register(entry(300, 'resume-pty'))
 
       registry.reapSync()
@@ -144,9 +176,83 @@ describe('codex child registry', () => {
       expect(kills).toHaveLength(1)
     })
 
+    it('kills the group when the registered pid is dead but a live codex member remains (M1b)', () => {
+      const { registry, kills, files } = makeHarness()
+      // The registered wrapper (pid 200) is gone from /proc, but grandchild 250 still lives in
+      // pgid 200 and is provably codex — this is the D-state-holder case the registry exists for.
+      files.set('/proc/250/stat', statLine(250, 200, 55))
+      files.set('/proc/250/cmdline', '/usr/local/bin/codex\0app-server\0')
+      registry.register(entry(200, 'app-server'))
+
+      registry.reapSync()
+
+      expect(kills).toEqual([{ pid: -200, signal: 'SIGKILL' }])
+    })
+
+    it('skips a dead pid whose pgid was recycled by non-codex processes (M1b)', () => {
+      const { registry, kills, files } = makeHarness()
+      files.set('/proc/250/stat', statLine(250, 200, 55))
+      files.set('/proc/250/cmdline', '/bin/bash\0')
+      registry.register(entry(200, 'app-server'))
+
+      registry.reapSync()
+
+      expect(kills).toEqual([])
+    })
+
+    it('skips a dead pid whose group has no remaining members', () => {
+      const { registry, kills } = makeHarness()
+      registry.register(entry(200, 'app-server'))
+
+      registry.reapSync()
+
+      expect(kills).toEqual([])
+    })
+
+    it('skips an entry whose recorded starttime no longer matches (pid recycled, M1a)', () => {
+      const { registry, kills, files } = makeHarness()
+      files.set('/proc/100/stat', statLine(100, 100, 11))
+      files.set('/proc/100/cmdline', 'codex\0')
+      registry.register(entry(100))
+      // The pid was recycled: same pid+pgrp+codex-looking cmdline, different starttime — e.g. the
+      // OTHER server instance's live codex pane. Must never be signaled.
+      files.set('/proc/100/stat', statLine(100, 100, 999))
+
+      registry.reapSync()
+
+      expect(kills).toEqual([])
+    })
+
+    it('skips an entry whose pid left the registered process group (M1a)', () => {
+      const { registry, kills, files } = makeHarness()
+      files.set('/proc/100/stat', statLine(100, 100, 11))
+      files.set('/proc/100/cmdline', 'codex\0')
+      registry.register(entry(100))
+      files.set('/proc/100/stat', statLine(100, 999, 11))
+
+      registry.reapSync()
+
+      expect(kills).toEqual([])
+    })
+
+    it('verifies pgrp+cmdline when no starttime was recorded at registration (fallback pin)', () => {
+      const { registry, kills, files } = makeHarness()
+      // No stat available at register time (startTimeTicks undefined)...
+      registry.register(entry(100))
+      // ...but readable at reap time: pgrp matches and cmdline is codex, so the kill proceeds.
+      files.set('/proc/100/stat', statLine(100, 100, 11))
+      files.set('/proc/100/cmdline', 'codex\0')
+
+      registry.reapSync()
+
+      expect(kills).toEqual([{ pid: -100, signal: 'SIGKILL' }])
+    })
+
     it('never signals our own process group or our own pid group', () => {
       const { registry, kills, files } = makeHarness({ ownPgid: 4_242, procPid: 7_777 })
+      files.set('/proc/555/stat', statLine(555, 4_242))
       files.set('/proc/555/cmdline', 'codex\0')
+      files.set('/proc/556/stat', statLine(556, 7_777))
       files.set('/proc/556/cmdline', 'codex\0')
       registry.register({ pid: 555, pgid: 4_242, kind: 'app-server' }) // own pgid
       registry.register({ pid: 556, pgid: 7_777, kind: 'app-server' }) // our pid's group
@@ -158,6 +264,7 @@ describe('codex child registry', () => {
 
     it('signals nothing when our own pgid cannot be proven', () => {
       const { registry, kills, files } = makeHarness({ ownPgid: 'unreadable' })
+      files.set('/proc/100/stat', statLine(100, 100))
       files.set('/proc/100/cmdline', 'codex\0')
       registry.register(entry(100))
 
@@ -179,7 +286,9 @@ describe('codex child registry', () => {
 
     it('never throws out of the exit path and keeps reaping after a kill failure', () => {
       const { registry, killSync, kills, files } = makeHarness()
+      files.set('/proc/100/stat', statLine(100, 100, 11))
       files.set('/proc/100/cmdline', 'codex\0')
+      files.set('/proc/200/stat', statLine(200, 200, 22))
       files.set('/proc/200/cmdline', 'codex\0')
       killSync.mockImplementationOnce(() => {
         throw Object.assign(new Error('EPERM'), { code: 'EPERM' })
@@ -242,7 +351,9 @@ describe('codex child registry', () => {
       // killProcessGroupSync appears exactly twice: its definition and its single call site…
       const references = source.match(/killProcessGroupSync\(/g) ?? []
       expect(references).toHaveLength(2)
-      // …and the call site is inside reapSync's body.
+      // …and the call site is inside reapSync's body. The identity helpers between the primitive
+      // and reapSync (groupHasCodexMemberSync/shouldKillEntrySync) only return verdicts — they
+      // must never signal.
       const reapBody = source.slice(
         source.indexOf('function reapSync'),
         source.indexOf('function installExitHandlers'),
@@ -298,9 +409,16 @@ describe('codex child registry', () => {
         runtimeSource.indexOf('private async stopActiveChild'),
       )
       expect(wrapperExitBody).not.toContain('deregisterCodexChild')
+      // m1: the spawn-failure-before-ownership path deregisters on the child's exit (the only
+      // case where ownership teardown will never run for the child).
+      const stopActiveChildBody = runtimeSource.slice(
+        runtimeSource.indexOf('private async stopActiveChild'),
+        runtimeSource.indexOf('private async waitForOwnershipTeardown'),
+      )
+      expect(stopActiveChildBody).toContain('deregisterCodexChild')
     })
 
-    it('terminal-registry.ts registers codex ptys at both spawn sites and deregisters in onExit', () => {
+    it('terminal-registry.ts registers codex ptys at both spawn sites and deregisters only on confirmed group death', () => {
       const registrySource = fs.readFileSync(path.join(SERVER_DIR, 'terminal-registry.ts'), 'utf8')
       const registrations = registrySource.match(
         /registerCodexChild\(\{ pid: ptyProc\.pid, pgid: ptyProc\.pid, kind: 'resume-pty' \}\)/g,
@@ -308,9 +426,15 @@ describe('codex child registry', () => {
       expect(registrations).toHaveLength(2)
       // The primary spawn site registers codex panes only.
       expect(registrySource).toContain("if (opts.mode === 'codex' && ptyProc.pid) {")
-      // Both spawn-site onExit handlers deregister; kill() never does (it only sends a signal).
-      const deregistrations = registrySource.match(/deregisterCodexChild\(ptyProc\.pid\)/g) ?? []
+      // Both spawn-site onExit handlers route through the liveness-probing deregister helper (m8),
+      // gated with the same codex condition as registration (m6). kill() never deregisters (it
+      // only sends a signal).
+      const deregistrations = registrySource.match(/deregisterCodexPtyIfGroupGone\(ptyProc\.pid\)/g) ?? []
       expect(deregistrations).toHaveLength(2)
+      expect(registrySource).toContain("if (opts.mode === 'codex') deregisterCodexPtyIfGroupGone(ptyProc.pid)")
+      expect(registrySource).toContain("if (record.mode === 'codex') deregisterCodexPtyIfGroupGone(ptyProc.pid)")
+      // m8: the helper only deregisters when the group is confirmed gone (ESRCH probe) on Linux.
+      expect(registrySource).toContain('process.kill(-pid, 0)')
       const killBody = registrySource.slice(
         registrySource.indexOf('kill(terminalId: string'),
         registrySource.indexOf('private markCodexRecoveryFinalClose'),
@@ -318,11 +442,17 @@ describe('codex child registry', () => {
       expect(killBody).not.toContain('deregisterCodexChild')
     })
 
-    it('index.ts installs the bindings once and arms an unref()d 15s hard-exit timer in shutdown()', () => {
+    it('index.ts installs the bindings once and arms an unref()d 30s hard-exit timer in shutdown()', () => {
       const indexSource = fs.readFileSync(path.join(SERVER_DIR, 'index.ts'), 'utf8')
       expect(indexSource.match(/installCodexChildExitHandlers\(\{/g)).toHaveLength(1)
-      expect(indexSource).toContain('const SHUTDOWN_HARD_EXIT_TIMEOUT_MS = 15_000')
+      expect(indexSource).toContain('const SHUTDOWN_HARD_EXIT_TIMEOUT_MS = 30_000')
       expect(indexSource).toContain('hardExitTimer.unref()')
+      // M6: slow-but-healthy shutdowns get their connections severed; the force-exit line is also
+      // written synchronously (async pino may not flush before exit); the happy path clears the timer.
+      expect(indexSource).toContain('server.closeAllConnections?.()')
+      expect(indexSource).toContain('process.stderr.write(')
+      expect(indexSource).toContain('clearTimeout(hardExitTimer)')
+      expect(indexSource).toContain("forcing exit")
       expect(indexSource).toContain('process.exit(1)\n    }, SHUTDOWN_HARD_EXIT_TIMEOUT_MS)')
     })
   })
@@ -358,11 +488,13 @@ describeWithLinuxProc('codex child registry runtime integration', () => {
 
     const ready = await runtime.ensureReady()
 
-    expect(snapshotCodexChildren()).toContainEqual({
+    // The live registration also pins the wrapper's /proc starttime (M1a).
+    expect(snapshotCodexChildren()).toContainEqual(expect.objectContaining({
       pid: ready.processPid,
       pgid: ready.processPid,
       kind: 'app-server',
-    })
+      startTimeTicks: expect.any(Number),
+    }))
 
     await runtime.shutdown()
 

--- a/test/unit/server/coding-cli/codex-observability.test.ts
+++ b/test/unit/server/coding-cli/codex-observability.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { spawn } from 'node:child_process'
 import fsp from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import {
+  deregisterCodexChild,
+  registerCodexChild,
+  snapshotCodexChildren,
+} from '../../../../server/coding-cli/codex-child-registry.js'
 import {
   CODEX_LOG_DB_WAL_WARN_BYTES,
   countCodexLogDbHolders,
@@ -247,9 +253,13 @@ describeWithLinuxProc('codex-observability monitor', () => {
       '501': { fds: [dbPath] }, // codex, holds the db -> counted
       '502': { fds: [dbPath], cmdline: '/usr/bin/some-other-daemon\0' }, // non-codex holder -> skipped
       '503': { fds: [dbPath], cmdline: null }, // unreadable cmdline -> skipped
+      // r2-2: 'codex' as a mere path substring is NOT a codex process -> skipped
+      '504': { fds: [dbPath], cmdline: '/usr/bin/vim\0/home/dan/code/codex-launch-leak-plan/notes.md\0' },
+      // r2-2: node-wrapper launch (argv token basename 'codex') -> counted
+      '505': { fds: [dbPath], cmdline: 'node\0/opt/tools/bin/codex\0app-server\0' },
     })
 
-    expect(await countCodexLogDbHolders(dbPath, procRoot)).toBe(1)
+    expect(await countCodexLogDbHolders(dbPath, procRoot)).toBe(2)
   })
 
   it('skips the server process itself in the holder scan (M3)', async () => {
@@ -331,6 +341,52 @@ describeWithLinuxProc('codex-observability reaper maintenance tick', () => {
     const stateAfter = JSON.parse(await fsp.readFile(`${freshPath}.reaper.json`, 'utf8'))
     expect(stateAfter.attempts).toBe(1)
     expect(stateAfter.lastAttempt).toBe(freshState.lastAttempt)
+  })
+
+  it('detects a sidecar-less orphan record and reaps it on the tick (r2-6)', async () => {
+    const metadataDir = await makeTempDir()
+    // Orphaned AFTER boot: no .reaper.json sidecar exists, owner pid is dead, group is gone.
+    const orphanPath = path.join(metadataDir, 'orphan.json')
+    await fsp.writeFile(orphanPath, JSON.stringify(buildValidOwnershipRecord({ ownershipId: 'obs-orphan' })), { mode: 0o600 })
+    // Control: a sidecar-less record whose owner is provably ALIVE must not be touched.
+    const livePath = path.join(metadataDir, 'live-owner.json')
+    await fsp.writeFile(livePath, JSON.stringify(buildValidOwnershipRecord({
+      ownershipId: 'obs-live-owner',
+      ownerServerPid: process.pid,
+    })), { mode: 0o600 })
+
+    await runCodexReaperMaintenanceTick({ serverInstanceId: 'srv-tick', metadataDir, terminateGraceMs: 1 })
+
+    await expect(fsp.stat(orphanPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fsp.stat(livePath)).resolves.toBeDefined()
+  })
+
+  it('drains stale resume-pty registry entries on the tick (r2-11)', async () => {
+    // A REAL exited detached child: its group is confirmed gone (ESRCH), so the tick must drain it.
+    const deadChild = spawn(process.execPath, ['-e', ''], { detached: true, stdio: 'ignore' })
+    const deadPid = deadChild.pid!
+    await new Promise<void>((resolve) => deadChild.once('exit', () => resolve()))
+    // A REAL live detached group leader: the probe reports alive, so the entry must be kept.
+    const liveChild = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 30000)'], { detached: true, stdio: 'ignore' })
+    liveChild.unref()
+    const livePid = liveChild.pid!
+    registerCodexChild({ pid: deadPid, pgid: deadPid, kind: 'resume-pty' })
+    registerCodexChild({ pid: livePid, pgid: livePid, kind: 'resume-pty' })
+    try {
+      await runCodexReaperMaintenanceTick({ serverInstanceId: 'srv-tick', metadataDir: await makeTempDir(), terminateGraceMs: 1 })
+
+      const pids = snapshotCodexChildren().map((child) => child.pid)
+      expect(pids).not.toContain(deadPid)
+      expect(pids).toContain(livePid)
+    } finally {
+      deregisterCodexChild(deadPid)
+      deregisterCodexChild(livePid)
+      try {
+        process.kill(-livePid, 'SIGKILL')
+      } catch {
+        // already gone
+      }
+    }
   })
 
   it('never throws when the metadata dir is missing', async () => {

--- a/test/unit/server/coding-cli/codex-observability.test.ts
+++ b/test/unit/server/coding-cli/codex-observability.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  CODEX_LOG_DB_WAL_WARN_BYTES,
+  countCodexLogDbHolders,
+  emitCodexLogDbStatus,
+  resolveCodexHome,
+  runCodexReaperMaintenanceTick,
+  startCodexObservability,
+} from '../../../../server/coding-cli/codex-observability.js'
+
+const tempDirs = new Set<string>()
+
+afterEach(async () => {
+  await Promise.all([...tempDirs].map(async (dir) => {
+    tempDirs.delete(dir)
+    await fsp.rm(dir, { recursive: true, force: true })
+  }))
+})
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-obs-'))
+  tempDirs.add(dir)
+  return dir
+}
+
+function createLogSpy() {
+  return { info: vi.fn(), warn: vi.fn() }
+}
+
+async function makeCodexHomeFixture(walBytes: number): Promise<{ codexHome: string; dbPath: string; walPath: string }> {
+  const codexHome = await makeTempDir()
+  const dbPath = path.join(codexHome, 'logs_2.sqlite')
+  const walPath = `${dbPath}-wal`
+  await fsp.writeFile(dbPath, 'not-a-real-db')
+  await fsp.writeFile(walPath, Buffer.alloc(walBytes))
+  return { codexHome, dbPath, walPath }
+}
+
+// Builds a fake /proc root: each key is a pid whose fd dir contains symlinks to the given targets.
+async function makeProcFixture(pidFdTargets: Record<string, string[]>): Promise<string> {
+  const procRoot = await makeTempDir()
+  for (const [pid, targets] of Object.entries(pidFdTargets)) {
+    const fdDir = path.join(procRoot, pid, 'fd')
+    await fsp.mkdir(fdDir, { recursive: true })
+    for (const [index, target] of targets.entries()) {
+      await fsp.symlink(target, path.join(fdDir, String(index + 3)))
+    }
+  }
+  await fsp.mkdir(path.join(procRoot, 'not-a-pid'), { recursive: true })
+  return procRoot
+}
+
+function buildValidOwnershipRecord(overrides: Record<string, unknown> = {}) {
+  const now = new Date().toISOString()
+  return {
+    schemaVersion: 1,
+    ownershipId: 'obs-pending',
+    serverInstanceId: 'srv-previous',
+    ownerServerPid: 999_999_999,
+    terminalId: null,
+    generation: null,
+    wsUrl: 'ws://127.0.0.1:1',
+    wrapperPid: 999_999_998,
+    processGroupId: 999_999_997,
+    wrapperIdentity: { commandLine: ['codex'], cwd: '/tmp', startTimeTicks: 1 },
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
+describe('codex-observability resolveCodexHome', () => {
+  it('resolves the codex home from CODEX_HOME or falls back to ~/.codex', () => {
+    expect(resolveCodexHome({ CODEX_HOME: '/custom/home' } as NodeJS.ProcessEnv)).toBe('/custom/home')
+    expect(resolveCodexHome({ CODEX_HOME: '  ' } as NodeJS.ProcessEnv)).toBe(path.join(os.homedir(), '.codex'))
+    expect(resolveCodexHome({} as NodeJS.ProcessEnv)).toBe(path.join(os.homedir(), '.codex'))
+  })
+
+  it('keeps the documented 500 MB WAL warn threshold', () => {
+    expect(CODEX_LOG_DB_WAL_WARN_BYTES).toBe(500 * 1024 * 1024)
+  })
+})
+
+const describeWithLinuxProc = process.platform === 'linux' ? describe : describe.skip
+
+describeWithLinuxProc('codex-observability monitor', () => {
+  it('emits the codex-log-db status line with WAL size, holder count and quarantine count', async () => {
+    const { codexHome, dbPath, walPath } = await makeCodexHomeFixture(2048)
+    const procRoot = await makeProcFixture({
+      '101': ['/tmp/unrelated-file', dbPath],
+      '102': [walPath],
+      '103': ['/tmp/unrelated-file'],
+    })
+    const metadataDir = await makeTempDir()
+    const quarantineDir = path.join(metadataDir, 'quarantine')
+    await fsp.mkdir(quarantineDir, { recursive: true })
+    await fsp.writeFile(path.join(quarantineDir, 'stale.json'), '{}')
+    await fsp.writeFile(path.join(quarantineDir, 'stale.json.note.json'), '{}')
+
+    const log = createLogSpy()
+    const status = await emitCodexLogDbStatus({ codexHome, metadataDir, procRoot, log })
+
+    expect(status).toEqual({ walBytes: 2048, holders: 2, quarantined: 1, warned: false })
+    expect(log.warn).not.toHaveBeenCalled()
+    expect(log.info).toHaveBeenCalledTimes(1)
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({ walBytes: 2048, holders: 2, quarantined: 1 }),
+      'codex-log-db: wal_bytes=2048 holders=2 quarantined=1',
+    )
+  })
+
+  it('warns when wal_bytes exceeds the threshold', async () => {
+    const { codexHome } = await makeCodexHomeFixture(4096)
+    const log = createLogSpy()
+
+    const status = await emitCodexLogDbStatus({
+      codexHome,
+      metadataDir: await makeTempDir(),
+      procRoot: await makeProcFixture({}),
+      log,
+      walWarnBytes: 1024,
+    })
+
+    expect(status?.warned).toBe(true)
+    expect(log.warn).toHaveBeenCalledTimes(1)
+    expect(log.info).not.toHaveBeenCalled()
+  })
+
+  it('warns when the holder count exceeds the threshold', async () => {
+    const { codexHome, dbPath } = await makeCodexHomeFixture(0)
+    const procRoot = await makeProcFixture({
+      '201': [dbPath],
+      '202': [dbPath],
+    })
+    const log = createLogSpy()
+
+    const status = await emitCodexLogDbStatus({
+      codexHome,
+      metadataDir: await makeTempDir(),
+      procRoot,
+      log,
+      holderWarnThreshold: 1,
+    })
+
+    expect(status).toEqual({ walBytes: 0, holders: 2, quarantined: 0, warned: true })
+    expect(log.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('never throws when the codex home, metadata dir and proc root are all missing', async () => {
+    const log = createLogSpy()
+
+    const status = await emitCodexLogDbStatus({
+      codexHome: '/nonexistent/codex-home',
+      metadataDir: '/nonexistent/metadata',
+      procRoot: '/nonexistent/proc',
+      log,
+    })
+
+    expect(status).toEqual({ walBytes: 0, holders: 0, quarantined: 0, warned: false })
+  })
+
+  it('holds no file descriptor on the sqlite files after probing (read-only monitor)', async () => {
+    const { codexHome, dbPath } = await makeCodexHomeFixture(1024)
+    const log = createLogSpy()
+
+    await emitCodexLogDbStatus({
+      codexHome,
+      metadataDir: await makeTempDir(),
+      procRoot: await makeProcFixture({ '301': [dbPath] }),
+      log,
+    })
+
+    const fds = await fsp.readdir('/proc/self/fd')
+    const targets = await Promise.all(fds.map((fd) => fsp.readlink(`/proc/self/fd/${fd}`).catch(() => '')))
+    expect(targets.filter((target) => target.startsWith(dbPath))).toEqual([])
+  })
+
+  it('ignores unreadable fd directories in the holder scan', async () => {
+    const { dbPath } = await makeCodexHomeFixture(0)
+    const procRoot = await makeProcFixture({ '401': [dbPath] })
+    // A pid dir without an fd subdirectory (readdir will fail for it).
+    await fsp.mkdir(path.join(procRoot, '402'), { recursive: true })
+
+    expect(await countCodexLogDbHolders(dbPath, procRoot)).toBe(1)
+  })
+})
+
+describeWithLinuxProc('codex-observability reaper maintenance tick', () => {
+  it('re-runs the reaper only when a pending record is due under the time-based backoff', async () => {
+    const metadataDir = await makeTempDir()
+    const recordPath = path.join(metadataDir, 'pending.json')
+    await fsp.writeFile(recordPath, JSON.stringify(buildValidOwnershipRecord()), { mode: 0o600 })
+
+    // Not due: the last attempt just happened (interval for a young record is one hour).
+    const now = Date.now()
+    await fsp.writeFile(`${recordPath}.reaper.json`, JSON.stringify({
+      firstSeen: new Date(now - 60_000).toISOString(),
+      attempts: 1,
+      lastAttempt: new Date(now).toISOString(),
+    }), { mode: 0o600 })
+    await runCodexReaperMaintenanceTick({ serverInstanceId: 'srv-tick', metadataDir, terminateGraceMs: 1 })
+    await expect(fsp.stat(recordPath)).resolves.toBeDefined()
+
+    // Due: the last attempt was two hours ago. The record's owner is dead and its group is gone,
+    // so the re-run reaps it exactly like the boot pass would.
+    await fsp.writeFile(`${recordPath}.reaper.json`, JSON.stringify({
+      firstSeen: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+      attempts: 1,
+      lastAttempt: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+    }), { mode: 0o600 })
+    await runCodexReaperMaintenanceTick({ serverInstanceId: 'srv-tick', metadataDir, terminateGraceMs: 1 })
+    await expect(fsp.stat(recordPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('never throws when the metadata dir is missing', async () => {
+    await expect(runCodexReaperMaintenanceTick({
+      serverInstanceId: 'srv-tick',
+      metadataDir: '/nonexistent/metadata',
+      log: createLogSpy(),
+    })).resolves.toBeUndefined()
+  })
+})
+
+describeWithLinuxProc('codex-observability lifecycle', () => {
+  it('emits a boot status line, ticks on the interval, and stop() clears the timer', async () => {
+    const { codexHome } = await makeCodexHomeFixture(0)
+    const metadataDir = await makeTempDir()
+    const log = createLogSpy()
+
+    const handle = startCodexObservability({
+      serverInstanceId: 'srv-obs',
+      codexHome,
+      metadataDir,
+      procRoot: await makeProcFixture({}),
+      intervalMs: 20,
+      log,
+    })
+
+    const deadline = Date.now() + 5_000
+    while (log.info.mock.calls.length < 2 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(log.info.mock.calls.length).toBeGreaterThanOrEqual(2)
+
+    handle.stop()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    const callsAfterStop = log.info.mock.calls.length
+    await new Promise((resolve) => setTimeout(resolve, 80))
+    expect(log.info.mock.calls.length).toBe(callsAfterStop)
+  })
+})

--- a/test/unit/server/coding-cli/codex-observability.test.ts
+++ b/test/unit/server/coding-cli/codex-observability.test.ts
@@ -14,6 +14,7 @@ import {
 const tempDirs = new Set<string>()
 
 afterEach(async () => {
+  vi.restoreAllMocks()
   await Promise.all([...tempDirs].map(async (dir) => {
     tempDirs.delete(dir)
     await fsp.rm(dir, { recursive: true, force: true })
@@ -39,13 +40,26 @@ async function makeCodexHomeFixture(walBytes: number): Promise<{ codexHome: stri
   return { codexHome, dbPath, walPath }
 }
 
-// Builds a fake /proc root: each key is a pid whose fd dir contains symlinks to the given targets.
-async function makeProcFixture(pidFdTargets: Record<string, string[]>): Promise<string> {
+type ProcPidSpec = {
+  fds: string[]
+  /** Written to /proc/<pid>/cmdline; defaults to a codex-looking command line. */
+  cmdline?: string | null
+}
+
+// Builds a fake /proc root: each key is a pid whose fd dir contains symlinks to the given targets
+// and whose cmdline defaults to codex (the M3 prefilter only probes codex processes).
+async function makeProcFixture(pids: Record<string, string[] | ProcPidSpec>): Promise<string> {
   const procRoot = await makeTempDir()
-  for (const [pid, targets] of Object.entries(pidFdTargets)) {
-    const fdDir = path.join(procRoot, pid, 'fd')
+  for (const [pid, value] of Object.entries(pids)) {
+    const spec: ProcPidSpec = Array.isArray(value) ? { fds: value } : value
+    const pidDir = path.join(procRoot, pid)
+    const fdDir = path.join(pidDir, 'fd')
     await fsp.mkdir(fdDir, { recursive: true })
-    for (const [index, target] of targets.entries()) {
+    const cmdline = spec.cmdline === undefined ? '/usr/local/bin/codex\0app-server\0' : spec.cmdline
+    if (cmdline !== null) {
+      await fsp.writeFile(path.join(pidDir, 'cmdline'), cmdline)
+    }
+    for (const [index, target] of spec.fds.entries()) {
       await fsp.symlink(target, path.join(fdDir, String(index + 3)))
     }
   }
@@ -79,8 +93,8 @@ describe('codex-observability resolveCodexHome', () => {
     expect(resolveCodexHome({} as NodeJS.ProcessEnv)).toBe(path.join(os.homedir(), '.codex'))
   })
 
-  it('keeps the documented 500 MB WAL warn threshold', () => {
-    expect(CODEX_LOG_DB_WAL_WARN_BYTES).toBe(500 * 1024 * 1024)
+  it('keeps the 2 GiB WAL warn threshold (hours of margin before the ~5 GB cliff at ~22 MB/min churn)', () => {
+    expect(CODEX_LOG_DB_WAL_WARN_BYTES).toBe(2 * 1024 * 1024 * 1024)
   })
 })
 
@@ -103,11 +117,11 @@ describeWithLinuxProc('codex-observability monitor', () => {
     const log = createLogSpy()
     const status = await emitCodexLogDbStatus({ codexHome, metadataDir, procRoot, log })
 
-    expect(status).toEqual({ walBytes: 2048, holders: 2, quarantined: 1, warned: false })
+    expect(status).toEqual({ walBytes: 2048, walStatFailed: false, holders: 2, quarantined: 1, warned: false })
     expect(log.warn).not.toHaveBeenCalled()
     expect(log.info).toHaveBeenCalledTimes(1)
     expect(log.info).toHaveBeenCalledWith(
-      expect.objectContaining({ walBytes: 2048, holders: 2, quarantined: 1 }),
+      expect.objectContaining({ walBytes: 2048, walStatFailed: false, holders: 2, quarantined: 1 }),
       'codex-log-db: wal_bytes=2048 holders=2 quarantined=1',
     )
   })
@@ -129,6 +143,45 @@ describeWithLinuxProc('codex-observability monitor', () => {
     expect(log.info).not.toHaveBeenCalled()
   })
 
+  it('reports wal_bytes=-1 and walStatFailed when the WAL stat fails for a non-ENOENT reason (M5)', async () => {
+    const { codexHome, walPath } = await makeCodexHomeFixture(1024)
+    const originalStat = fsp.stat.bind(fsp)
+    vi.spyOn(fsp, 'stat').mockImplementation(((target: any, opts?: any) => {
+      if (String(target) === walPath) {
+        return Promise.reject(Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }))
+      }
+      return originalStat(target, opts) as any
+    }) as typeof fsp.stat)
+    const log = createLogSpy()
+
+    const status = await emitCodexLogDbStatus({
+      codexHome,
+      metadataDir: await makeTempDir(),
+      procRoot: await makeProcFixture({}),
+      log,
+    })
+
+    expect(status).toEqual({ walBytes: -1, walStatFailed: true, holders: 0, quarantined: 0, warned: true })
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ walBytes: -1, walStatFailed: true }),
+      expect.stringContaining('wal_bytes=-1'),
+    )
+  })
+
+  it('reads a missing WAL as empty, not as a stat failure', async () => {
+    const codexHome = await makeTempDir() // no db, no wal
+    const log = createLogSpy()
+
+    const status = await emitCodexLogDbStatus({
+      codexHome,
+      metadataDir: await makeTempDir(),
+      procRoot: await makeProcFixture({}),
+      log,
+    })
+
+    expect(status).toEqual({ walBytes: 0, walStatFailed: false, holders: 0, quarantined: 0, warned: false })
+  })
+
   it('warns when the holder count exceeds the threshold', async () => {
     const { codexHome, dbPath } = await makeCodexHomeFixture(0)
     const procRoot = await makeProcFixture({
@@ -145,7 +198,7 @@ describeWithLinuxProc('codex-observability monitor', () => {
       holderWarnThreshold: 1,
     })
 
-    expect(status).toEqual({ walBytes: 0, holders: 2, quarantined: 0, warned: true })
+    expect(status).toEqual({ walBytes: 0, walStatFailed: false, holders: 2, quarantined: 0, warned: true })
     expect(log.warn).toHaveBeenCalledTimes(1)
   })
 
@@ -159,7 +212,7 @@ describeWithLinuxProc('codex-observability monitor', () => {
       log,
     })
 
-    expect(status).toEqual({ walBytes: 0, holders: 0, quarantined: 0, warned: false })
+    expect(status).toEqual({ walBytes: 0, walStatFailed: false, holders: 0, quarantined: 0, warned: false })
   })
 
   it('holds no file descriptor on the sqlite files after probing (read-only monitor)', async () => {
@@ -181,10 +234,43 @@ describeWithLinuxProc('codex-observability monitor', () => {
   it('ignores unreadable fd directories in the holder scan', async () => {
     const { dbPath } = await makeCodexHomeFixture(0)
     const procRoot = await makeProcFixture({ '401': [dbPath] })
-    // A pid dir without an fd subdirectory (readdir will fail for it).
+    // A codex pid dir without an fd subdirectory (readdir will fail for it).
     await fsp.mkdir(path.join(procRoot, '402'), { recursive: true })
+    await fsp.writeFile(path.join(procRoot, '402', 'cmdline'), 'codex\0')
 
     expect(await countCodexLogDbHolders(dbPath, procRoot)).toBe(1)
+  })
+
+  it('prefilters non-codex processes: only codex cmdlines are probed as holders (M3)', async () => {
+    const { dbPath } = await makeCodexHomeFixture(0)
+    const procRoot = await makeProcFixture({
+      '501': { fds: [dbPath] }, // codex, holds the db -> counted
+      '502': { fds: [dbPath], cmdline: '/usr/bin/some-other-daemon\0' }, // non-codex holder -> skipped
+      '503': { fds: [dbPath], cmdline: null }, // unreadable cmdline -> skipped
+    })
+
+    expect(await countCodexLogDbHolders(dbPath, procRoot)).toBe(1)
+  })
+
+  it('skips the server process itself in the holder scan (M3)', async () => {
+    const { dbPath } = await makeCodexHomeFixture(0)
+    const procRoot = await makeProcFixture({
+      [String(process.pid)]: [dbPath],
+      '601': [dbPath],
+    })
+
+    expect(await countCodexLogDbHolders(dbPath, procRoot)).toBe(1)
+  })
+
+  it("matches fd targets that carry the ' (deleted)' suffix (M3)", async () => {
+    const { dbPath } = await makeCodexHomeFixture(0)
+    const procRoot = await makeProcFixture({
+      '701': [`${dbPath} (deleted)`],
+      '702': [`${dbPath}-wal (deleted)`],
+      '703': ['/tmp/unrelated (deleted)'],
+    })
+
+    expect(await countCodexLogDbHolders(dbPath, procRoot)).toBe(2)
   })
 })
 
@@ -213,6 +299,38 @@ describeWithLinuxProc('codex-observability reaper maintenance tick', () => {
     }), { mode: 0o600 })
     await runCodexReaperMaintenanceTick({ serverInstanceId: 'srv-tick', metadataDir, terminateGraceMs: 1 })
     await expect(fsp.stat(recordPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('gates re-attempts per record: a not-yet-due record is untouched even when another is due (m2)', async () => {
+    const metadataDir = await makeTempDir()
+    const now = Date.now()
+
+    // Due record: owner dead, group gone -> gets reaped by the tick.
+    const duePath = path.join(metadataDir, 'due.json')
+    await fsp.writeFile(duePath, JSON.stringify(buildValidOwnershipRecord({ ownershipId: 'obs-due' })), { mode: 0o600 })
+    await fsp.writeFile(`${duePath}.reaper.json`, JSON.stringify({
+      firstSeen: new Date(now - 3 * 60 * 60 * 1000).toISOString(),
+      attempts: 2,
+      lastAttempt: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+    }), { mode: 0o600 })
+
+    // Fresh record: attempted seconds ago -> must be skipped entirely (no attempt increment).
+    const freshPath = path.join(metadataDir, 'fresh.json')
+    await fsp.writeFile(freshPath, JSON.stringify(buildValidOwnershipRecord({ ownershipId: 'obs-fresh' })), { mode: 0o600 })
+    const freshState = {
+      firstSeen: new Date(now - 60_000).toISOString(),
+      attempts: 1,
+      lastAttempt: new Date(now).toISOString(),
+    }
+    await fsp.writeFile(`${freshPath}.reaper.json`, JSON.stringify(freshState), { mode: 0o600 })
+
+    await runCodexReaperMaintenanceTick({ serverInstanceId: 'srv-tick', metadataDir, terminateGraceMs: 1 })
+
+    await expect(fsp.stat(duePath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fsp.stat(freshPath)).resolves.toBeDefined()
+    const stateAfter = JSON.parse(await fsp.readFile(`${freshPath}.reaper.json`, 'utf8'))
+    expect(stateAfter.attempts).toBe(1)
+    expect(stateAfter.lastAttempt).toBe(freshState.lastAttempt)
   })
 
   it('never throws when the metadata dir is missing', async () => {


### PR DESCRIPTION
## What

Codex child-process lifecycle hardening per the remediation plan (stages 1a + 1c):

- New codex child registry (`server/coding-cli/codex-app-server/codex-child-registry.ts`) and observability module (`codex-observability.ts`)
- Lifecycle fixes in `server/coding-cli/codex-app-server/runtime.ts`
- Integration in `server/index.ts` and `server/terminal-registry.ts`
- Includes the plan and S3 validation results docs (`docs/plans/2026-07-06-codex-launch-leak-remediation-plan.md` and `docs/plans/2026-07-06-codex-launch-leak-remediation-s3-validation-results.md`)

## Why

Remediate leaked codex child processes. The work was hardened through 4 rounds of adversarial review (round-1/2/3 findings addressed in follow-up commits on this branch).

## Verification

- Full coordinated suite green on this branch merged with current main: `npm run check` — typecheck + 8,681 tests passed, 0 failed
- New test files: `codex-child-registry.test.ts` (855 lines), `codex-observability.test.ts`, plus expanded `runtime.test.ts`

## Note

This work was originally authored on local main before the PR-only workflow could catch it; this PR moves it through the proper flow.

Generated with Amplifier
