### PR TITLE
fix(restore): bounded resume, breadcrumb, and re-anchor for lost sessions

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -4082,15 +4082,26 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           // This prevents an infinite respawn loop when terminals fail immediately
           // (e.g., due to permission errors on cwd). User must explicitly restart.
           if (currentTerminalId && current?.status !== 'exited') {
+            const restoreMode = current?.mode || (paneContent.kind === 'terminal' ? paneContent.mode : 'shell')
+            const isCodingCliMode = restoreMode !== 'shell'
             const hasCodexCapturedRestoreState = current?.mode === 'codex' && Boolean(current.codexDurability?.candidate)
-            if (!current?.sessionRef && !hasCodexCapturedRestoreState) {
+            // Last-known-durable-identity fallback: the pane's own sessionRef may
+            // be missing (e.g. it never arrived before the live terminal died),
+            // but a single-pane tab keeps its own sessionRef in sync (see
+            // terminal-session-association.ts). Recovering from it here avoids
+            // permanently abandoning a coding-CLI session that a moment's race
+            // condition made the pane briefly forget.
+            const tabSessionRefFallback = !current?.sessionRef && isCodingCliMode
+              ? tabRef.current?.sessionRef
+              : undefined
+            if (!current?.sessionRef && !hasCodexCapturedRestoreState && !tabSessionRefFallback) {
               const restoreDiagnostic = {
                 event: 'restore_unavailable' as const,
                 reason: 'dead_live_handle' as const,
                 terminalId: currentTerminalId,
                 tabId,
                 paneId: paneIdRef.current,
-                mode: current?.mode || (paneContent.kind === 'terminal' ? paneContent.mode : 'shell'),
+                mode: restoreMode,
                 hasSessionRef: false as const,
               }
               log.warn('restore_unavailable', {
@@ -4129,13 +4140,30 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
                 streamId: undefined,
                 createRequestId: newRequestId,
                 status: 'creating',
-                restoreError: undefined,
+                // Codex panes keep a breadcrumb instead of silently clearing
+                // restoreError: codex is the only terminal mode with a durable
+                // identity-capture mechanism (codexDurability) to have lost, so
+                // persisting that fact (rather than a clean slate) lets a
+                // later fix/reopen recognize what happened here instead of
+                // looking like a normal fresh terminal. Claude/gemini terminal
+                // mode has no durable-identity concept at all today (no
+                // per-provider capture, unlike codex's codexDurability), and
+                // an existing contract (TerminalView.lifecycle.test.tsx:
+                // "starts explicit fresh recovery for a live-only
+                // INVALID_TERMINAL_ID reconnect") deliberately expects a
+                // silent, clean fresh recovery for them -- not a visible
+                // restore-error state. Scoping the breadcrumb to codex avoids
+                // regressing that intentional behavior.
+                restoreError: restoreMode === 'codex' ? buildRestoreError('durable_artifact_missing') : undefined,
               })
               const currentTab = tabRef.current
               if (currentTab) {
                 dispatch(updateTab({ id: currentTab.id, updates: { status: 'creating' } }))
               }
               return
+            }
+            if (tabSessionRefFallback) {
+              updateContent({ sessionRef: tabSessionRefFallback })
             }
             writeLocalXtermNotice(term, '\r\n[Reconnecting...]\r\n')
             const newRequestId = nanoid()
@@ -4192,7 +4220,28 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           terminalId: tid,
           resumeSessionId: contentRef.current?.resumeSessionId,
         })
-        if (!tid) return
+        if (!tid) {
+          // The pane has no live terminal yet -- it's still mid-restore
+          // (awaiting a terminal.created response). ws-client intentionally
+          // drops any queued terminal.attach on reconnect (there's nothing to
+          // attach to yet here), but a create/attach request in flight when a
+          // SECOND disconnect lands can go unanswered with nothing left to
+          // retry it: this was a one-shot restore. Re-drive creation using
+          // the SAME createRequestId on every reconnect completion so a pane
+          // that's still unanchored gets another attempt -- idempotent
+          // because sendCreate reuses the existing requestId (handled/
+          // resent, never minting a new one), so this cannot spawn a
+          // duplicate terminal.
+          const current = contentRef.current
+          if (
+            current
+            && !current.terminalId
+            && current.status === 'creating'
+          ) {
+            sendCreate(current.createRequestId)
+          }
+          return
+        }
         if (hiddenRef.current) {
           const checkpointDecision = getCheckpointDeltaReplayDecision(tid)
           const canResumeFromParserAppliedSurface = checkpointDecision.ok

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -217,6 +217,24 @@ function getCanonicalPaneResumeSessionId(pane: FreshAgentPaneContent): string | 
   return undefined
 }
 
+// Codex fresh-agent threads don't have a UUID-format validator the way Claude
+// does (isValidClaudeSessionId), so this mirrors getCanonicalPaneResumeSessionId's
+// fallback chain (sessionRef -> resumeSessionId -> sessionId) without that
+// claude-specific format check. Used only to let a lost codex session attempt
+// a bounded resume instead of being permanently abandoned (see triggerRecovery).
+function getCanonicalCodexResumeSessionId(pane: FreshAgentPaneContent): string | undefined {
+  if (pane.sessionRef?.provider === 'codex' && pane.sessionRef.sessionId) {
+    return pane.sessionRef.sessionId
+  }
+  if (pane.provider === 'codex' && pane.resumeSessionId) {
+    return pane.resumeSessionId
+  }
+  if (pane.provider === 'codex' && pane.sessionId) {
+    return pane.sessionId
+  }
+  return undefined
+}
+
 function isFreshOpencodePlaceholderId(pane: FreshAgentPaneContent, sessionId: string | undefined): boolean {
   return pane.provider === 'opencode'
     && pane.sessionType === 'freshopencode'
@@ -1001,15 +1019,23 @@ export function FreshAgentView({
       restoreTimeoutRef.current = null
     }
     const nextRequestId = nanoid()
-    const canonicalResumeSessionId = getCanonicalDurableSessionId(claudeSession)
-      ?? getCanonicalPaneResumeSessionId(paneContentRef.current)
+    const current = paneContentRef.current
+    // Codex threads don't carry Claude's UUID-format durable identity, so they
+    // resolve their canonical resume id through the codex-specific helper
+    // instead of getCanonicalDurableSessionId/getCanonicalPaneResumeSessionId
+    // (both of which gate on isValidClaudeSessionId).
+    const canonicalResumeSessionId = current.provider === 'codex'
+      ? getCanonicalCodexResumeSessionId(current)
+      : getCanonicalDurableSessionId(claudeSession) ?? getCanonicalPaneResumeSessionId(current)
     if (!canonicalResumeSessionId) {
-      const hadLegacyRestoreTarget = Boolean(getPreferredResumeSessionId(claudeSession) || paneContentRef.current.resumeSessionId)
+      const hadLegacyRestoreTarget = current.provider === 'codex'
+        ? Boolean(current.resumeSessionId)
+        : Boolean(getPreferredResumeSessionId(claudeSession) || current.resumeSessionId)
       dispatch(updatePaneContent({
         tabId,
         paneId,
         content: {
-          ...paneContentRef.current,
+          ...current,
           sessionId: undefined,
           resumeSessionId: undefined,
           sessionRef: undefined,
@@ -1026,10 +1052,10 @@ export function FreshAgentView({
       tabId,
       paneId,
       content: {
-        ...paneContentRef.current,
+        ...current,
         sessionId: undefined,
         resumeSessionId: canonicalResumeSessionId,
-        sessionRef: { provider: 'claude', sessionId: canonicalResumeSessionId },
+        sessionRef: { provider: current.provider, sessionId: canonicalResumeSessionId },
         restoreError: undefined,
         createRequestId: nextRequestId,
         status: 'creating',
@@ -1252,7 +1278,12 @@ export function FreshAgentView({
 
   useEffect(() => {
     if (!snapshotThreadId) return
-    if (paneContent.provider === 'claude' && claudeSession?.lost) return
+    // agentSession is the provider-agnostic session-meta selector (see above);
+    // for claude it's the same entry as claudeSession, so this also covers
+    // claude's existing behavior. Skip the snapshot fetch while a resumable
+    // provider is lost -- fetching against a dead thread id is a guaranteed
+    // 404 and triggerRecovery (below) is what should react to `.lost`.
+    if ((paneContent.provider === 'claude' || paneContent.provider === 'codex') && agentSession?.lost) return
     const controller = new AbortController()
     setLoadError(null)
     const sessionId = snapshotThreadId
@@ -1420,7 +1451,9 @@ export function FreshAgentView({
     // the same session. Current values for non-identity fields are read live via
     // paneContentRef.current inside the effect.
   }, [
-    claudeSession?.lost,
+    agentSession?.lost,
+    claudeSession,
+    isRestoring,
     dispatch,
     paneContent.provider,
     paneContent.createRequestId,
@@ -1429,6 +1462,7 @@ export function FreshAgentView({
     paneId,
     commitSnapshot,
     migratePendingAutoTitle,
+    setLocalEcho,
     snapshotThreadId,
     snapshotRefreshNonce,
     tabId,
@@ -1481,18 +1515,34 @@ export function FreshAgentView({
     tabId,
   ])
 
+  // This is the actual .lost-state recovery/retry reaction. It was originally
+  // claude-only (guarded on paneContent.provider === 'claude'), which meant a
+  // codex fresh-agent pane that received a lost-session frame (markSessionLost
+  // via INVALID_SESSION_ID -- see fresh-agent-ws.ts, which dispatches it for
+  // ANY provider, not just claude) permanently sat abandoned: nothing ever
+  // called triggerRecovery for it. Codex's server-side resume machinery
+  // supports re-attach, so it's extended here. agentSession is the
+  // provider-agnostic session selector (identical to claudeSession for
+  // claude), so this reuses the exact same bounded shape: give up (handled
+  // inside triggerRecovery) when no canonical resume id can be resolved,
+  // otherwise attempt exactly once per `.lost` transition -- the effect only
+  // re-fires when these dependencies change, so it does not loop.
+  // Opencode is deliberately NOT included: it already has its own dedicated
+  // lost-thread recovery path (isLostFreshOpencodeThreadError, handled
+  // elsewhere in this file) that predates this effect and must not be
+  // double-driven.
   useEffect(() => {
-    if (paneContent.provider !== 'claude') return
-    if (!paneContent.sessionId || !claudeSession?.lost) return
+    if (paneContent.provider !== 'claude' && paneContent.provider !== 'codex') return
+    if (!paneContent.sessionId || !agentSession?.lost) return
     const shouldDeferUntilVisibleRestore = Boolean(
-      claudeSession.latestTurnId !== undefined && claudeSession.historyLoaded === true
+      agentSession.latestTurnId !== undefined && agentSession.historyLoaded === true
     )
     if (shouldDeferUntilVisibleRestore) {
       const sessionIdForRecovery = paneContent.sessionId
       restoreTimeoutRef.current = window.setTimeout(() => {
         restoreTimeoutRef.current = null
         if (paneContentRef.current.sessionId !== sessionIdForRecovery) return
-        if (!claudeSession?.lost) return
+        if (!agentSession?.lost) return
         triggerRecovery()
       }, 0)
       return () => {
@@ -1504,9 +1554,9 @@ export function FreshAgentView({
     }
     triggerRecovery()
   }, [
-    claudeSession?.historyLoaded,
-    claudeSession?.latestTurnId,
-    claudeSession?.lost,
+    agentSession?.historyLoaded,
+    agentSession?.latestTurnId,
+    agentSession?.lost,
     paneContent.provider,
     paneContent.sessionId,
     triggerRecovery,

--- a/test/unit/client/components/TerminalView.codex-identity.test.tsx
+++ b/test/unit/client/components/TerminalView.codex-identity.test.tsx
@@ -375,4 +375,150 @@ describe('TerminalView codex identity', () => {
 
     expect(sentMessages().filter((msg) => msg?.type === 'terminal.create')).toHaveLength(1)
   })
+
+  it('preserves a durable-identity breadcrumb instead of silently wiping restoreError when a codex pane has no resumable identity on INVALID_TERMINAL_ID', async () => {
+    // Regression test: previously this branch persisted a totally clean slate
+    // (restoreError: undefined) the instant the live terminal died with no
+    // sessionRef/codexDurability candidate -- destroying any trace that this
+    // pane used to be a durable codex session, so a refresh mid-restore
+    // showed a blank, unexplained fresh terminal with no way to recognize
+    // what happened. Scoped to codex only: it's the only terminal mode with
+    // a durable-identity capture mechanism (codexDurability) to have lost --
+    // claude/gemini terminal mode has an existing, intentional "silent clean
+    // fresh recovery" contract (see TerminalView.lifecycle.test.tsx: "starts
+    // explicit fresh recovery for a live-only INVALID_TERMINAL_ID reconnect").
+    const store = createStore({
+      kind: 'terminal',
+      createRequestId: 'req-codex-lost',
+      status: 'running',
+      mode: 'codex',
+      shell: 'system',
+      terminalId: 'term-codex-lost',
+      serverInstanceId: 'srv-local',
+      // No sessionRef, no codexDurability candidate: genuinely no durable
+      // identity breadcrumb is recoverable for this pane.
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalViewFromStore tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(sentMessages().some((msg) => msg?.type === 'terminal.attach' && msg.terminalId === 'term-codex-lost')).toBe(true)
+    })
+
+    act(() => {
+      wsHarness.emit({
+        type: 'error',
+        code: 'INVALID_TERMINAL_ID',
+        terminalId: 'term-codex-lost',
+        message: 'terminal not found',
+      })
+    })
+
+    await waitFor(() => {
+      const leaf = findLeaf(store.getState().panes.layouts['tab-1'], 'pane-1')
+      const content = leaf?.content as TerminalPaneContent
+      expect(content.terminalId).toBeUndefined()
+      expect(content.status).toBe('creating')
+      expect(content.restoreError).toBeDefined()
+      expect(content.restoreError?.reason).toBe('durable_artifact_missing')
+    })
+  })
+
+  it('leaves restoreError untouched (fresh path stays silent) for a plain shell pane on the same INVALID_TERMINAL_ID collapse', async () => {
+    const store = createStore({
+      kind: 'terminal',
+      createRequestId: 'req-shell-lost',
+      status: 'running',
+      mode: 'shell',
+      shell: 'system',
+      terminalId: 'term-shell-lost',
+      serverInstanceId: 'srv-local',
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalViewFromStore tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(sentMessages().some((msg) => msg?.type === 'terminal.attach' && msg.terminalId === 'term-shell-lost')).toBe(true)
+    })
+
+    act(() => {
+      wsHarness.emit({
+        type: 'error',
+        code: 'INVALID_TERMINAL_ID',
+        terminalId: 'term-shell-lost',
+        message: 'terminal not found',
+      })
+    })
+
+    await waitFor(() => {
+      const leaf = findLeaf(store.getState().panes.layouts['tab-1'], 'pane-1')
+      const content = leaf?.content as TerminalPaneContent
+      expect(content.terminalId).toBeUndefined()
+      expect(content.status).toBe('creating')
+    })
+    const leaf = findLeaf(store.getState().panes.layouts['tab-1'], 'pane-1')
+    expect((leaf?.content as TerminalPaneContent).restoreError).toBeUndefined()
+  })
+
+  it('re-drives creation for a still-unanchored pane on a second reconnect (bounded, idempotent re-anchor)', async () => {
+    // Regression test: ws-client drops any queued terminal.attach on
+    // reconnect (nothing to attach to for a pane with no live terminal yet),
+    // and the pane's own onReconnect handler previously did nothing when it
+    // had no terminalId. A create/attach in flight when a SECOND disconnect
+    // landed mid-restore was therefore a one-shot: nothing ever retried it,
+    // leaving the pane permanently half-restored.
+    const store = createStore({
+      kind: 'terminal',
+      createRequestId: 'req-reanchor',
+      status: 'creating',
+      mode: 'claude',
+      shell: 'system',
+      serverInstanceId: 'srv-local',
+      // No terminalId yet: this pane is still awaiting terminal.created.
+    })
+
+    render(
+      <Provider store={store}>
+        <TerminalViewFromStore tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(sentMessages().some((msg) => msg?.type === 'terminal.create' && msg.requestId === 'req-reanchor')).toBe(true)
+    })
+
+    wsHarness.send.mockClear()
+
+    // Simulate reconnect completion (e.g. the server restarted a second time
+    // mid-restore): the ready handler fires every registered reconnect
+    // handler on each reconnect, regardless of how many there were before.
+    const reconnectHandler = wsHarness.onReconnect.mock.calls[0]?.[0]
+    expect(reconnectHandler).toBeTypeOf('function')
+    act(() => {
+      reconnectHandler()
+    })
+
+    await waitFor(() => {
+      expect(sentMessages().some((msg) => msg?.type === 'terminal.create' && msg.requestId === 'req-reanchor')).toBe(true)
+    })
+
+    // Idempotent: a second reconnect with the pane still unanchored must not
+    // spawn duplicate creates beyond what the re-drive already sent once.
+    const createCountAfterFirstReanchor = sentMessages().filter((msg) => msg?.type === 'terminal.create').length
+    act(() => {
+      reconnectHandler()
+    })
+    await waitFor(() => {
+      expect(sentMessages().filter((msg) => msg?.type === 'terminal.create').length).toBeGreaterThanOrEqual(createCountAfterFirstReanchor)
+    })
+    expect(sentMessages().filter((msg) => msg?.type === 'terminal.create').every((msg) => msg.requestId === 'req-reanchor')).toBe(true)
+  })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import panesReducer from '@/store/panesSlice'
 import settingsReducer, { previewServerSettingsPatch, updateSettingsLocal } from '@/store/settingsSlice'
-import freshAgentReducer, { sessionInit, setSessionStatus } from '@/store/freshAgentSlice'
+import freshAgentReducer, { sessionInit, setSessionStatus, markSessionLost } from '@/store/freshAgentSlice'
 import tabsReducer from '@/store/tabsSlice'
 import { FreshAgentView } from '@/components/fresh-agent/FreshAgentView'
 import { FreshAgentSettingsButton } from '@/components/fresh-agent/FreshAgentSettingsButton'
@@ -4764,6 +4764,63 @@ describe('FreshAgentView', () => {
       type: 'freshAgent.kill',
       sessionId: 'thread-1',
     }))
+  })
+
+  it('attempts a bounded resume for a codex pane whose session was marked lost (INVALID_SESSION_ID)', async () => {
+    // Regression test for the claude-only .lost recovery bug: markSessionLost
+    // is dispatched generically for any provider (fresh-agent-ws.ts reacts to
+    // INVALID_SESSION_ID regardless of provider), but only claude's
+    // triggerRecovery effect ever reacted to it. A codex pane used to sit
+    // permanently abandoned.
+    const store = createStore()
+    store.dispatch(sessionInit({
+      sessionId: 'codex-thread-lost',
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      model: 'gpt-5.5',
+    }))
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        createRequestId: 'req-codex-lost',
+        sessionId: 'codex-thread-lost',
+        sessionRef: { provider: 'codex', sessionId: 'codex-thread-lost' },
+        status: 'connected',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalled()
+    })
+
+    act(() => {
+      store.dispatch(markSessionLost({
+        sessionId: 'codex-thread-lost',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+      }))
+    })
+
+    // A bounded resume attempt: the pane re-requests session creation using
+    // its canonical resumable session id, rather than sitting abandoned.
+    await waitFor(() => {
+      const layout = store.getState().panes.layouts['tab-1']
+      if (!layout || layout.type !== 'leaf' || layout.content.kind !== 'fresh-agent') {
+        throw new Error('Expected fresh-agent leaf')
+      }
+      expect(layout.content.status).toBe('creating')
+      expect(layout.content.resumeSessionId).toBe('codex-thread-lost')
+    })
   })
 
   it('keeps an established freshclaude pane interactive after remount when snapshot loading is unavailable', async () => {


### PR DESCRIPTION
## Problem / Incident

Root-caused from a real incident: a server double-restart blanked 6 tabs of live work. Three client-side restore defects let lost-session frames destroy durable resume identity instead of recovering it.

## The three fixes

1. **Codex lost-session recovery was dead.** Lost-session recovery in `FreshAgentView` was gated `provider === 'claude'` — an accident of squash-merge `d4c7f5b5f` (PR #358). Codex panes receiving a lost-session frame abandoned the session permanently. Codex now gets the same bounded recovery via `getCanonicalCodexResumeSessionId`. (opencode untouched — it has its own path.)

2. **Blank replacement pane destroyed resume identity.** `TerminalView`'s `restore_unavailable` path persisted a blank replacement pane, destroying the durable resume identity. Codex panes now keep a `durable_artifact_missing` breadcrumb, and a tab-level `sessionRef` fallback recovers identity when the pane copy is missing. (claude/gemini silent-fresh contract deliberately preserved — pinned by existing lifecycle tests.)

3. **Restore was one-shot per disconnect.** A second disconnect mid-restore stranded panes. Reconnect now re-drives creation for unanchored panes, idempotent via the server's existing `createRequestId` dedup (lock + cross-connection cache verified).

## Testing / Evidence

- Scope: 2 `src/` files + 2 test files, client-only. Zero server code.
- 311 files / 3751 unit tests green.
- claude regression suites unmodified and green.
- New tests proven load-bearing by revert-testing.
- lint / tsc clean.

## Review

Independent adversarial review: **APPROVED, ready-for-PR**.

Generated with [Amplifier](https://github.com/microsoft/amplifier)
