### PR TITLE
chore(e2e): stop auto-opening Playwright HTML report on local failures

### DIFF
--- a/test/e2e-browser/playwright.config.ts
+++ b/test/e2e-browser/playwright.config.ts
@@ -96,7 +96,11 @@ export default defineConfig({
   workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI
     ? [['html', { open: 'never' }], ['github']]
-    : [['html', { open: 'on-failure' }]],
+    : // 'never' locally too: many concurrent agents run this suite, and
+      // 'on-failure' auto-opens a report browser page (localhost:9323) at the
+      // user on every failing run. View reports on demand with
+      // `npx playwright show-report`.
+      [['html', { open: 'never' }]],
   timeout: 60_000,
   expect: {
     timeout: 10_000,

--- a/test/e2e-electron/playwright.electron.config.ts
+++ b/test/e2e-electron/playwright.electron.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
   workers: 1,
   reporter: process.env.CI
     ? [['html', { open: 'never' }], ['github']]
-    : [['html', { open: 'on-failure' }]],
+    : // 'never' locally too: many concurrent agents run this suite, and
+      // 'on-failure' auto-opens a report browser page (localhost:9323) at the
+      // user on every failing run. View reports on demand with
+      // `npx playwright show-report`.
+      [['html', { open: 'never' }]],
   timeout: 120_000, // Electron startup can be slow
   expect: {
     timeout: 15_000,


### PR DESCRIPTION
Stops the Playwright HTML reporter from auto-opening a browser page (localhost:9323, deep-linked `#?testId=...`) on every failing local run. Many concurrent agents run the e2e suites in this repo, so failing runs kept popping report pages at the user.

- Local (non-CI) reporter changed from `open: 'on-failure'` to `open: 'never'` in both e2e configs
- Reports are still written to `playwright-report/` — view on demand with `npx playwright show-report`
- CI behavior unchanged

User-approved direct-ship; PR route required by branch protection.

Generated with [Amplifier](https://github.com/microsoft/amplifier)