### PR TITLE
fix(client): centralize terminal detach so abandoned subscriptions are released

### DIFF
--- a/docs/plans/2026-07-25-terminal-attach-leak.md
+++ b/docs/plans/2026-07-25-terminal-attach-leak.md
@@ -603,7 +603,20 @@ describe('terminalDetachMiddleware', () => {
 
   it('detaches the stale terminal on codex identity repair', () => {
     const store = createStore()
-    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-stale') }))
+    // The preloaded content MUST carry a sessionRef equal to the action's
+    // expectedSessionRef: repairCodexIdentityMismatch (panesSlice.ts:1778)
+    // guards on sessionRefsEqual(node.content.sessionRef, expectedSessionRef)
+    // and no-ops otherwise, so a bare terminalContent() would never trigger
+    // the repair (and therefore never drop the reference).
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        ...terminalContent('term-stale'),
+        mode: 'codex' as const,
+        sessionRef: { provider: 'codex' as const, sessionId: 'session-1' },
+      },
+    }))
     mockSend.mockClear()
     store.dispatch(repairCodexIdentityMismatch({
       tabId: 'tab-1',
@@ -1269,14 +1282,14 @@ Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.co
 ### Task 11: gate `attachTerminal` on layout membership (close-during-create fix)
 
 **Files:**
-- Modify: `src/components/TerminalView.tsx` (`attachTerminal()`, line ~2564)
+- Modify: `src/components/TerminalView.tsx` (`attachTerminal()`, declared at ~:2430; its `ws.send` is at ~:2564)
 - Modify: `test/unit/client/components/TerminalView.lifecycle.test.tsx`
 
 **Interfaces:**
 - Consumes: `collectAllTerminalIds` from `@/lib/pane-utils` (Task 1); the current Redux state read imperatively inside the component (use react-redux's `useStore()` — `const store = useStore()` — unless TerminalView already has an imperative state-access pattern; match the file's existing pattern if one exists).
 - Produces: `attachTerminal` becomes a silent no-op for any terminalId not currently referenced by `state.panes.layouts`.
 
-**Why (validated in the load-bearing stage, validator-G4):** the server does not auto-attach on create; the client's `terminal.created` handler writes the id into layouts (`updateContent`, :3799) and then attaches (:3842). If the pane's layout removal is dispatched after the create was sent but before `terminal.created` is processed, `updateContent` no-ops yet the attach still fires — a subscription for an id the layouts never contained, invisible to the middleware diff, leaked until the socket closes. Gating at `attachTerminal` (the single attach choke point, :2564) closes that race AND the sub-millisecond quarantine-repair re-attach race (:797-819). Every legitimate attach passes the gate: the created handler dispatches `updateContent` synchronously before attaching, and mount/refresh/hydration attaches use ids the layouts already reference.
+**Why (validated in the load-bearing stage, validator-G4):** the server does not auto-attach on create; the client's `terminal.created` handler writes the id into layouts (`updateContent`, :3799) and then attaches (:3842). If the pane's layout removal is dispatched after the create was sent but before `terminal.created` is processed, `updateContent` no-ops yet the attach still fires — a subscription for an id the layouts never contained, invisible to the middleware diff, leaked until the socket closes. Gating at `attachTerminal` (the single attach choke point, declared at :2430) closes that race AND the sub-millisecond quarantine-repair re-attach race (:797-819). Every legitimate attach passes the gate: the created handler dispatches `updateContent` synchronously before attaching, and mount/refresh/hydration attaches use ids the layouts already reference.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -1298,14 +1311,14 @@ Expected: the new test FAILS — attach is currently sent unconditionally.
 
 - [ ] **Step 3: Write minimal implementation**
 
-In `src/components/TerminalView.tsx`, add the imports (`collectAllTerminalIds` from `@/lib/pane-utils`; `useStore` from react-redux if no imperative state access exists yet) and, at the top of `attachTerminal()` (:2564) before any send:
+In `src/components/TerminalView.tsx`, add the import of `collectAllTerminalIds` from `@/lib/pane-utils` (no new store import is needed: the component already holds `const appStore = useAppStore()` at :517, used imperatively elsewhere, e.g. :3733) and, at the top of `attachTerminal()` (declared at :2430 — its terminal-id parameter is named `tid`; the `ws.send` it guards is at :2564) before any send:
 
 ```ts
     // Never attach a terminal the layouts no longer reference: the layout-diff
     // middleware can only release subscriptions it saw acquired. Covers the
     // close-during-create race and stale deferred re-attach timers.
-    const layouts = store.getState().panes.layouts
-    if (!collectAllTerminalIds(layouts).has(terminalId)) {
+    const layouts = appStore.getState().panes.layouts
+    if (!collectAllTerminalIds(layouts).has(tid)) {
       return
     }
 ```

--- a/docs/plans/2026-07-25-terminal-attach-leak.md
+++ b/docs/plans/2026-07-25-terminal-attach-leak.md
@@ -871,14 +871,19 @@ and inside the `configureStore({...})` call:
 
 In `test/e2e/tab-focus-behavior.test.tsx`: same addition to its `createStore` (`configureStore` at ~line 78, currently no `middleware:` key).
 
-Run both suites — they must still be green (double-send is not asserted anywhere yet):
+Run both suites. Three pre-existing tests go RED here — they assert exact detach/kill counts, and the middleware now duplicates the component's sends:
 
 Run: `npm run test:vitest -- run test/unit/client/components/TabBar.test.tsx test/e2e/tab-focus-behavior.test.tsx --config config/vitest/vitest.config.ts`
-Expected: PASS.
+Expected: FAIL —
+- TabBar `'close button detaches every terminal in split pane layout'` (:671-707): `expect(mockSend).toHaveBeenCalledTimes(2)` at :698 now sees 4 calls (component + middleware each detach `term-a`/`term-b`);
+- TabBar `'shift+click kills every terminal in split pane layout'` (:709-746): `toHaveBeenCalledTimes(2)` at :737 now sees 4 calls (2 component kills + 2 middleware detaches — the component's raw `ws.send` kills set no release marks until Step 4);
+- e2e `'closing a split tab detaches all pane terminals'` (:237-336): the strict filtered `toEqual` at :332-335 now sees `['term-a','term-b','term-a','term-b']`.
+
+The single-terminal tests at :593 and :632 stay green (`toHaveBeenCalledWith` is count-insensitive), as does the `expect(mockSend).not.toHaveBeenCalled()` test at :765 (its layout never contains a terminal id, so the middleware diff is empty). This RED is exactly the double-send bug this task fixes — do NOT "fix" these three tests (their assertions are correct); they go green in Step 4 when the component's own sends are removed. Proceed to Step 2.
 
 - [ ] **Step 2: Write the failing tests**
 
-In `test/unit/client/components/TabBar.test.tsx`, inside the `describe('tab interactions')` block (starts ~:530), add two tests. Reuse the exact same store construction, render helper, and close-button interaction code as the existing test `'close button sends detach message when pane has terminalId'` at :593 (same preloaded layout with `terminalId: 'term-1'`, same `fireEvent.click` on the close button; the file's hoisted ws send mock is the `expect` target — match the local mock variable name used at :627):
+In `test/unit/client/components/TabBar.test.tsx`, inside the `describe('tab interactions')` block (starts ~:530), add two tests. For the first, reuse the exact same store construction, render helper, and close-button interaction code as the existing test `'close button sends detach message when pane has terminalId'` at :593 — its preloaded layout uses `terminalId: 'term-123'`, and the file's hoisted ws send mock is the `expect` target (match the local mock variable name used at :626). For the second, reuse the setup of `'shift+click on close button sends kill message'` at :632 — its fixture uses `terminalId: 'term-456'` and clicks the close button with `{ shiftKey: true }`:
 
 ```ts
   it('plain close sends exactly one terminal.detach per terminal', () => {
@@ -886,16 +891,16 @@ In `test/unit/client/components/TabBar.test.tsx`, inside the `describe('tab inte
     const detachMessages = sendMock.mock.calls
       .map(([msg]) => msg as { type?: string; terminalId?: string })
       .filter((msg) => msg?.type === 'terminal.detach')
-    expect(detachMessages).toEqual([{ type: 'terminal.detach', terminalId: 'term-1' }])
+    expect(detachMessages).toEqual([{ type: 'terminal.detach', terminalId: 'term-123' }])
   })
 
   it('shift close sends terminal.kill and no terminal.detach', () => {
-    // ...same setup, but close click with { shiftKey: true }...
+    // ...same setup + shift-click as the test at :632...
     const sentTypes = sendMock.mock.calls
       .map(([msg]) => (msg as { type?: string })?.type)
     expect(sentTypes).toContain('terminal.kill')
     expect(sentTypes).not.toContain('terminal.detach')
-    expect(sendMock).toHaveBeenCalledWith({ type: 'terminal.kill', terminalId: 'term-1' })
+    expect(sendMock).toHaveBeenCalledWith({ type: 'terminal.kill', terminalId: 'term-456' })
   })
 ```
 
@@ -906,7 +911,8 @@ In `test/unit/client/components/TabBar.test.tsx`, inside the `describe('tab inte
 Run: `npm run test:vitest -- run test/unit/client/components/TabBar.test.tsx --config config/vitest/vitest.config.ts`
 Expected: FAIL —
 - exactly-once test: TWO detach messages (component + middleware);
-- shift test: a `terminal.detach` appears (middleware fires because the raw kill send sets no release mark).
+- shift test: a `terminal.detach` appears (middleware fires because the raw kill send sets no release mark);
+- plus the two split-layout exact-count tests (:698, :737) still RED from Step 1 — they stay RED until Step 4.
 
 - [ ] **Step 4: Fix the component**
 
@@ -935,7 +941,7 @@ If `ws` (from `const ws = useMemo(() => getWsClient(), [])` at :182) is now unus
 - [ ] **Step 5: Run TabBar + e2e suites to verify green**
 
 Run: `npm run test:vitest -- run test/unit/client/components/TabBar.test.tsx test/e2e/tab-focus-behavior.test.tsx --config config/vitest/vitest.config.ts`
-Expected: PASS — the pre-existing detach assertions (:593 single-terminal, :671 split-layout multi-terminal, e2e :330-334 ordered multi-terminal) now pass via the middleware, proving plain-close semantics are unchanged.
+Expected: PASS — the pre-existing detach assertions (:593 single-terminal, :671 split-layout multi-terminal, e2e :330-334 ordered multi-terminal), including the three exact-count tests that were RED from Step 1, now pass via the middleware alone, proving plain-close semantics are unchanged.
 
 - [ ] **Step 6: Commit**
 
@@ -1086,12 +1092,14 @@ Site D — close pane (~:1223-1229):
         },
 ```
 
-- [ ] **Step 1: Add the middleware to the test store**
+- [ ] **Step 1: Add the middleware to the target test store helper**
 
-In `test/unit/client/components/ContextMenuProvider.test.tsx`, extend the existing `configureStore` `middleware:` option (it currently only tunes `getDefaultMiddleware`) with `.concat(terminalDetachMiddleware)` and add the import, exactly as in Task 7 Step 1.
+`test/unit/client/components/ContextMenuProvider.test.tsx` has SIX store-creation helpers (`createTestStore` :93, `createStoreWithSession` :173, `createStoreWithSidebarWindowAgentSession` :247, `createStoreWithOverlappingSessionWindows` :365, `createStoreWithBrowserPane` :492, `createStoreWithTerminalPane` :556). Add the import and extend the `configureStore` `middleware:` option with `.concat(terminalDetachMiddleware)` (exactly as in Task 7 Step 1) in ONE helper only: `createStoreWithTerminalPane` (:556) — the helper backing the :2286 test that Step 2 extends.
+
+Do NOT add it to `createTestStore` or file-wide: the test `'does not kill or overwrite a pane that changes while reopen metadata is pending'` (:1275, built on `createTestStore`) dispatches `updatePaneContent` replacing a terminal pane with a browser pane and then asserts `expect(wsMocks.send).not.toHaveBeenCalled()` (:1343); the middleware would emit a `terminal.detach` for the replaced terminal and break that strict-zero assertion. (If Step 5's full-file run surfaces another test that relied on a component send removed in Step 4, extend that test's specific helper the same way rather than reverting the component change.)
 
 Run: `npm run test:vitest -- run test/unit/client/components/ContextMenuProvider.test.tsx --config config/vitest/vitest.config.ts`
-Expected: PASS.
+Expected: PASS — the :2286 test's `toHaveBeenCalledWith` detach assertion is count-insensitive, so the middleware's added (temporarily duplicate) send does not break it.
 
 - [ ] **Step 2: Write the failing test**
 
@@ -1224,22 +1232,13 @@ Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.co
 
 **Interfaces:**
 - Consumes: `terminalDetachMiddleware` (Task 4).
-- Produces: previously-tautological detach assertions (the test hand-rolled `wsMocks.send({ type: 'terminal.detach', ... })` itself at :107, :197, :276) become genuine proof that the store emits the detach.
+- Produces: the hand-rolled `wsMocks.send({ type: 'terminal.detach', ... })` calls (:107, :197, :276) are deleted; test 1's existing detach assertion (:112) plus NEW detach assertions added to tests 2 and 3 (which today assert only `tabs.tabs[0].terminalId`) become genuine proof that the store emits the detach.
 
 - [ ] **Step 1: Convert the tests (RED first)**
 
-In `test/e2e/replace-pane.test.tsx`:
+In `test/e2e/replace-pane.test.tsx` (three tests, at :88, :176, :238 — only the FIRST currently asserts on sends, at :112; the other two assert only `tabs.tabs[0].terminalId`, at :206 and :285):
 
-1. Add the middleware to `createStore` (the `configureStore` at ~:28 has no `middleware:` key):
-
-```ts
-import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
-```
-```ts
-    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(terminalDetachMiddleware),
-```
-
-2. In each of the three tests (at :88, :176, :238), DELETE the hand-rolled send block, e.g. at ~:103-108:
+1. In each of the three tests, DELETE ONLY the hand-rolled `wsMocks.send({ type: 'terminal.detach', terminalId: ... })` call (:107, :197, :276). KEEP the rest of each simulate block — in the :176 and :238 tests the same `if`-block also dispatches `updateTab({ ... terminalId: undefined })` (:200, :279); nothing in the middleware replaces those (`terminalDetachMiddleware` never touches `tabs` state), so deleting them would permanently break the `tabs.tabs[0].terminalId` assertions. In the :88 test the `if`-block wraps only the send, so the whole `if` can go:
 
 ```ts
     // Simulate what ContextMenuProvider does: detach terminal, then dispatch replacePane
@@ -1257,16 +1256,32 @@ becomes:
     expect(paneContent?.kind).toBe('terminal')
 ```
 
-(keep the `replacePane` / `closePane` dispatch and the existing `expect(wsMocks.send).toHaveBeenCalledWith({ type: 'terminal.detach', terminalId: 'term-1' })` assertions — they are now satisfied only if the middleware really emits).
+In the :176 and :238 tests, remove only the `wsMocks.send(...)` line inside the block and keep the surrounding `if` with its `updateTab` dispatch.
 
-To honor RED: make the deletions FIRST without adding the middleware, run the file, and confirm the three assertions fail; then add the middleware concat and re-run.
+2. ADD a detach assertion to the :176 and :238 tests (they have none today), mirroring the existing one at :112 and using each test's own preloaded terminal id from its layout fixture:
+
+```ts
+    // replace TERMINAL_ID with the terminalId string from this test's preloaded layout
+    expect(wsMocks.send).toHaveBeenCalledWith({ type: 'terminal.detach', terminalId: TERMINAL_ID })
+```
+
+3. Keep the `replacePane` / `closePane` dispatches and the existing assertion at :112 (`toHaveBeenCalledWith({ type: 'terminal.detach', terminalId: 'term-1' })`) — after this step, all three detach assertions can only be satisfied by the middleware.
+
+4. To honor RED: run the file now, BEFORE adding the middleware, and confirm all three detach assertions fail (nothing emits the detach any more). Then add the middleware to `createStore` (the `configureStore` at ~:28 has no `middleware:` key) and re-run:
+
+```ts
+import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
+```
+```ts
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(terminalDetachMiddleware),
+```
 
 Caveat for the test at :238 ("closing pane with matching terminal"): if it dispatches `closePane` on a single-leaf layout, the reducer is a no-op and the middleware will not fire — in that case restructure that one test's preloaded layout to a two-pane split (mirror the split-layout literal already used elsewhere in the same file) so the close actually removes the pane.
 
 - [ ] **Step 2: Run RED then GREEN**
 
 Run: `npm run test:vitest -- run test/e2e/replace-pane.test.tsx --config config/vitest/vitest.config.ts`
-Expected: FAIL after deletions (3 tests), PASS after the middleware concat.
+Expected: FAIL before the middleware concat (three detach assertions: :112 plus the two added in item 2), PASS after the middleware concat.
 
 - [ ] **Step 3: Commit**
 

--- a/docs/plans/2026-07-25-terminal-attach-leak.md
+++ b/docs/plans/2026-07-25-terminal-attach-leak.md
@@ -35,6 +35,10 @@
 
 **Why skip `clearDeadTerminals` / `clearTerminalLiveHandles`:** these two actions (src/store/panesSlice.ts:1724, :1754) strip terminalIds ONLY for terminals the server itself reported dead or unrecoverable (payloads come from `terminal.inventory` / `terminals.changed` handling in App.tsx:883-885, :1044-1049). There is no live subscription to release, and detaching would generate a server error frame per corpse. This is not a scope reduction: the spec's goal (server-side reapability) is vacuous for terminals the server already reaped. `repairCodexIdentityMismatch` is deliberately NOT skipped — its stale terminal is typically still live and leaked.
 
+**Close-during-create race (found in load-bearing validation):** the server does NOT auto-attach on `terminal.create` — the subscription is created only by the client's `terminal.created` handler (src/components/TerminalView.tsx:3754-3844), which writes the id into layouts via `updateContent` (:3799, synchronous dispatch) and then calls `attachTerminal` (:3842). If the pane is closed after the create is sent and `terminal.created` is processed in the dispatch→React-commit window, `updateContent` no-ops (pane node gone) yet `attachTerminal` still fires — a subscription for an id the layouts never contained, invisible to the middleware diff and leaked until disconnect. Task 11 closes this by gating `attachTerminal` on layout membership (`collectAllTerminalIds`); the same gate closes the sub-millisecond quarantine-repair re-attach race (TerminalView.tsx:797-819). Any residual acquisition leak is bounded to the connection lifetime: the server clears every subscription per-socket on close (server/ws-handler.ts:1219 `detachAllForSocket`).
+
+**Validated server semantics the design relies on** (load-bearing validation 2026-07-25; assumption ledger + evidence reports live in the workflow logs dir): subscriptions are a per-connection `Set` — one detach fully clears them and `hasClients` is `clients.size > 0` (server/terminal-registry.ts:584, :4302), so a sole-client detach makes the terminal reaper-eligible; detach for a live terminal that isn't attached (or was already detached) succeeds benignly — only unknown ids draw an error frame (server/ws-handler.ts:2820-2836), which the client consumes benignly (no `console.error`; at most a `clearTerminalLiveHandles` dispatch, itself skip-listed — so no detach feedback loop is possible); `recoverableTerminalIds` are emitted only for terminals with `clients.size === 0` (PTY-exit and idle-kill paths, terminal-registry.ts:1502, :1424-1432), confirming the skip-list is not a preserved leak; terminal ids are minted server-side (`nanoid()`, terminal-registry.ts:1570) and `TerminalCreateSchema` is `.strict()` with no client-supplied id, underwriting the release-marks design.
+
 ## File Structure
 
 | File | Action | Responsibility |
@@ -48,7 +52,7 @@
 | `src/components/TabBar.tsx` | Modify | Remove plain-close detach loop; shift-close uses `sendTerminalKill` |
 | `src/components/panes/PaneContainer.tsx` | Modify | Remove detach send in `handleClose` |
 | `src/components/context-menu/ContextMenuProvider.tsx` | Modify | Remove 3 detach sends; kill site uses `sendTerminalKill` |
-| `src/components/TerminalView.tsx` | Modify | Opencode self-heal kill (line 2910) uses `sendTerminalKill` |
+| `src/components/TerminalView.tsx` | Modify | Opencode self-heal kill (line 2910) uses `sendTerminalKill`; `attachTerminal` gated on layout membership (Task 11) |
 | `src/components/BackgroundSessions.tsx` | Modify | Kill button uses `sendTerminalKill` |
 | `test/unit/client/lib/collect-all-terminal-ids.test.ts` | Create | Helper tests |
 | `test/unit/client/lib/terminal-release-marks.test.ts` | Create | Marks module tests |
@@ -60,6 +64,7 @@
 | `test/unit/client/components/ContextMenuProvider.test.tsx` | Modify | Middleware in test store |
 | `test/e2e/tab-focus-behavior.test.tsx` | Modify | Middleware in test store (assertions unchanged) |
 | `test/e2e/replace-pane.test.tsx` | Modify | Convert tautological hand-rolled detach sends into real middleware-backed assertions |
+| `test/unit/client/components/TerminalView.lifecycle.test.tsx` | Modify | Close-during-create: no attach for a pane no longer in layouts (Task 11) |
 
 ---
 
@@ -1261,7 +1266,67 @@ Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.co
 
 ---
 
-### Task 11: full verification
+### Task 11: gate `attachTerminal` on layout membership (close-during-create fix)
+
+**Files:**
+- Modify: `src/components/TerminalView.tsx` (`attachTerminal()`, line ~2564)
+- Modify: `test/unit/client/components/TerminalView.lifecycle.test.tsx`
+
+**Interfaces:**
+- Consumes: `collectAllTerminalIds` from `@/lib/pane-utils` (Task 1); the current Redux state read imperatively inside the component (use react-redux's `useStore()` — `const store = useStore()` — unless TerminalView already has an imperative state-access pattern; match the file's existing pattern if one exists).
+- Produces: `attachTerminal` becomes a silent no-op for any terminalId not currently referenced by `state.panes.layouts`.
+
+**Why (validated in the load-bearing stage, validator-G4):** the server does not auto-attach on create; the client's `terminal.created` handler writes the id into layouts (`updateContent`, :3799) and then attaches (:3842). If the pane's layout removal is dispatched after the create was sent but before `terminal.created` is processed, `updateContent` no-ops yet the attach still fires — a subscription for an id the layouts never contained, invisible to the middleware diff, leaked until the socket closes. Gating at `attachTerminal` (the single attach choke point, :2564) closes that race AND the sub-millisecond quarantine-repair re-attach race (:797-819). Every legitimate attach passes the gate: the created handler dispatches `updateContent` synchronously before attaching, and mount/refresh/hydration attaches use ids the layouts already reference.
+
+- [ ] **Step 1: Write the failing test**
+
+In `test/unit/client/components/TerminalView.lifecycle.test.tsx`, locate the existing test that exercises the create → `terminal.created` → attach flow (it delivers a `terminal.created` message and asserts a `terminal.attach` send for the new id). Add a sibling test reusing that test's setup verbatim: `it('does not attach when the pane was removed before terminal.created arrives')` — after the create request is sent but BEFORE delivering `terminal.created`, dispatch the layout removal for the pane's tab through the test store (`removeLayout`/`closeTab`, matching how the harness manipulates layouts), then deliver the `terminal.created` message and assert that NO `{ type: 'terminal.attach', terminalId: <newId> }` is ever sent:
+
+```ts
+    const attachMessages = sendMock.mock.calls
+      .map(([msg]) => msg as { type?: string; terminalId?: string })
+      .filter((msg) => msg?.type === 'terminal.attach' && msg.terminalId === newId)
+    expect(attachMessages).toHaveLength(0)
+```
+
+(`sendMock` = the file's actual hoisted ws send mock name.) If the harness cannot deliver a created message after a store change while the component is still mounted, fall back to any deterministic path through `attachTerminal` with the id absent from layouts (e.g. remove the layout via store dispatch, then trigger the component's refresh/re-attach path and assert no re-attach send).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx --config config/vitest/vitest.config.ts` (timeout: this file is large — allow up to 10 minutes)
+Expected: the new test FAILS — attach is currently sent unconditionally.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/components/TerminalView.tsx`, add the imports (`collectAllTerminalIds` from `@/lib/pane-utils`; `useStore` from react-redux if no imperative state access exists yet) and, at the top of `attachTerminal()` (:2564) before any send:
+
+```ts
+    // Never attach a terminal the layouts no longer reference: the layout-diff
+    // middleware can only release subscriptions it saw acquired. Covers the
+    // close-during-create race and stale deferred re-attach timers.
+    const layouts = store.getState().panes.layouts
+    if (!collectAllTerminalIds(layouts).has(terminalId)) {
+      return
+    }
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx --config config/vitest/vitest.config.ts` (allow up to 10 minutes)
+Expected: PASS — the new test plus every pre-existing lifecycle test. If a pre-existing test fails because its store genuinely lacks a layout entry for the terminal it attaches, fix that TEST's preloaded layouts to include the pane (matching production, where every mounted TerminalView has a layout node) — never weaken the gate.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx
+git commit -m "fix(client): gate terminal attach on layout membership to close create-race leak" -m "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+```
+
+---
+
+### Task 12: full verification
 
 **Files:** none new.
 
@@ -1311,10 +1376,13 @@ Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.co
 | TerminalView unmount | every unmount that drops the reference does so via a layouts change (restoreLayout/hydratePanes/removeLayout/closePane), caught by the diff; unmount WITHOUT a state change (tab switch) still references the terminal and must NOT detach — background attach is intentional (`registerForBackgroundHydration`) | Task 4 (all diff tests); "no layouts change ⇒ no send" test |
 | Multi-pane guard ("another pane still displays the same terminal") | set-diff over ALL layouts | Task 4 refcount test |
 | Explicit tab-close semantics unchanged | plain close ⇒ middleware emits detach on same dispatch; Shift ⇒ `sendTerminalKill` | Task 6 (pre-existing assertions kept passing + 2 new tests) |
+| Close-during-create race (subscription acquired for an id never present in layouts — found by load-bearing validation, falsified assumption A9) | `attachTerminal` gated on layout membership via `collectAllTerminalIds`; also closes the quarantine-repair re-attach timer race | Task 11 no-attach-after-removal test |
 | Scope guard: no server changes | no server/crates file appears in the File Structure | — |
 
 **1b. No silent deferrals** — the only mocked boundary is `@/lib/ws-client` in unit tests; the production wire path (`getWsClient().send`) is exercised unmocked in the app and the message shape matches the server's Zod schema (shared/ws-protocol.ts:348). No stub is left standing in for production behavior; the production store registration itself is behavior-tested (Task 5). The clearDead/clearLiveHandles skip is an explicit, documented design decision (dead terminals have no subscription), not a deferral.
 
 **2. Placeholder scan** — the two component-test steps (Tasks 6-8) intentionally reference the neighbouring test's setup by exact line number instead of duplicating unquotable file-local harness code; all assertions, all production code, and all new modules are given in full. No TBD/TODO items remain.
 
-**3. Type consistency** — `collectAllTerminalIds(layouts: Record<string, PaneNode | undefined>): Set<string>` (Task 1) matches its uses in Task 4; `markTerminalReleased`/`consumeTerminalReleaseMark`/`resetTerminalReleaseMarks` (Task 2) match Tasks 3-4 and the dom.ts wiring; `sendTerminalKill(terminalId: string): void` (Task 3) matches Tasks 6, 8, 9; `terminalDetachMiddleware: Middleware` (Task 4) matches every concat site (Tasks 5-8, 10).
+**3. Type consistency** — `collectAllTerminalIds(layouts: Record<string, PaneNode | undefined>): Set<string>` (Task 1) matches its uses in Task 4; `markTerminalReleased`/`consumeTerminalReleaseMark`/`resetTerminalReleaseMarks` (Task 2) match Tasks 3-4 and the dom.ts wiring; `sendTerminalKill(terminalId: string): void` (Task 3) matches Tasks 6, 8, 9; `terminalDetachMiddleware: Middleware` (Task 4) matches every concat site (Tasks 5-8, 10); `collectAllTerminalIds` (Task 1) is also consumed by the Task 11 attach gate with the same `Record<string, PaneNode | undefined> -> Set<string>` signature.
+
+**4. Load-bearing validation (2026-07-25)** — the plan's silent dependencies were verified against the actual server and client code (assumption ledger + evidence reports in the workflow logs dir). Verified: set-based per-connection subscriptions with one-detach-full-clear; benign detach of live-but-unattached terminals (covers the Task 5→8 transitional double-detach); benign client handling of the detach error frame (no console.error, no feedback loop — the only follow-on dispatch, `clearTerminalLiveHandles`, is skip-listed); `recoverableTerminalIds` emitted only at `clients.size === 0` (the skip-list preserves no leak); server-minted, never-reused terminal ids (release-marks safety); no transient drop-then-readd layout flow (immediate detach is safe); no re-attach path for dropped ids; per-socket cleanup on disconnect. Falsified: "every subscription's id appears in layouts" — the close-during-create race acquires an invisible subscription; fixed by Task 11's attach gate.

--- a/docs/plans/2026-07-25-terminal-attach-leak.md
+++ b/docs/plans/2026-07-25-terminal-attach-leak.md
@@ -1,0 +1,1320 @@
+# Terminal Attach Leak Fix Implementation Plan
+
+> **For agentic workers:** This plan is executed task-by-task by the
+> workflow's execute stage: a fresh implementer per task, with a spec +
+> quality review after each task. Steps use checkbox (`- [ ]`) syntax
+> for tracking.
+
+**Goal:** Whenever the client stops referencing a terminal by ANY path (pane re-point, pane recreate, pane/tab close, split removal, layout replacement), send `terminal.detach` for the old terminalId — refcount-guarded across all pane layouts — so the server sees `hasClients=false` and its idle reaper can collect abandoned terminals.
+
+**Architecture:** A new Redux middleware (`terminalDetachMiddleware`) diffs the set of terminalIds referenced across ALL pane layouts before/after every action and sends `terminal.detach` for every id that drops out. This single choke point covers every leak path uniformly (component gestures, keyboard shortcuts, `ui-commands`, REST/MCP agent API, layout restores). The triplicated caller-side detach sends in TabBar/PaneContainer/ContextMenuProvider are removed (the middleware now emits the identical message on the same dispatch). A tiny release-marks module suppresses redundant detaches for terminals that were just explicitly killed. The set-based diff gives the multi-pane guard for free: a terminalId referenced by two panes only detaches when the LAST reference disappears.
+
+**Tech Stack:** React 18, Redux Toolkit (middleware), TypeScript, Vitest + Testing Library (jsdom).
+
+## Global Constraints
+
+- **Client-side fix ONLY.** Do NOT touch server idle-kill logic (`crates/freshell-terminal/src/registry.rs`, `crates/freshell-server/`, `server/terminal-registry.ts`) and do NOT address the separate PTY-output-bumps-`last_activity_at` hole — both explicitly out of scope.
+- **Explicit tab-close semantics unchanged:** plain close ⇒ `terminal.detach` is still sent for each of the tab's terminals; Shift+click ⇒ `terminal.kill`. (After this plan, the detach is emitted by the middleware on the same `closeTab` dispatch instead of by TabBar directly — same message, same trigger, now refcount-guarded.)
+- The detach-then-reattach in `TerminalView.runRefreshAttach` (src/components/TerminalView.tsx:2607) is a same-terminal refresh, NOT a release. It stays in the component untouched; the layout diff never fires for it (the id never leaves the layouts).
+- `terminal.detach` wire shape is exactly `{ type: 'terminal.detach', terminalId }` (shared/ws-protocol.ts:348-351). The server replies with an error for a non-existent terminal (test/server/ws-protocol.test.ts:1425) — the middleware must not detach ids dropped by the dead-terminal census actions (`clearDeadTerminals`, `clearTerminalLiveHandles`).
+- Red-Green-Refactor TDD for every task. Focused test runs: `npm run test:vitest -- run <paths> --config config/vitest/vitest.config.ts` (this default config governs `test/unit/client/**` AND `test/e2e/*.test.tsx`). Never raw `npx vitest`. Broad runs go through the coordinator gate (`npm test` / `npm run check`; check `npm run test:status` first).
+- Client test setup (`test/setup/dom.ts`) makes ANY `console.error` a test failure and calls `resetWsClientForTests()` after each test. The new middleware must never `console.error` and must keep all diff state derived from `getState()` (no module-scope diff state). The only module-scope state introduced (release marks) gets a reset hook wired into `dom.ts`.
+- Work happens in this worktree (`.worktrees/terminal-attach-leak`, branch `fix/terminal-attach-leak`). Never restart the self-hosted freshell server; never use broad kill patterns.
+- Commit messages: conventional commits, each with the Amplifier co-author trailer (shown in every commit step below).
+- Test-id hygiene: terminal ids are server-generated nanoids and never reused in production — the release-marks design depends on this (a stale mark can only ever suppress a detach for a terminal that no longer needs one).
+
+## Design Notes (context for every task)
+
+**Where the leak is:** `terminal.attach` is sent from exactly one place (`attachTerminal()`, src/components/TerminalView.tsx:2564). `terminal.detach` today is sent only from explicit gestures: TabBar close (src/components/TabBar.tsx:315), PaneContainer close (src/components/panes/PaneContainer.tsx:341), and three ContextMenuProvider actions (src/components/context-menu/ContextMenuProvider.tsx:301, :311, :1226). TerminalView never detaches on unmount (cleanup at :4422-4430) nor when `terminalId` changes (ref-sync effect at :959-989). Every other reference-dropping path — `updatePaneContent` re-point, `repairCodexIdentityMismatch`, `closeTab` via keyboard/ui-commands/agent API, split-subtree removal, `restoreLayout`/`hydratePanes` — leaks the subscription, so the server's idle reaper sees `hasClients=true` forever (observed in production 2026-07-25: 10 orphaned CLI terminals idle 10.8h–22.6h against a 3h threshold).
+
+**Why a middleware:** `src/store/layoutMirrorMiddleware.ts` already proves the derive-from-layouts pattern (state diff after `next(action)`, sends WS via `getWsClient()`). `state.panes.layouts` is the single source of truth for "which terminals does the client reference"; diffing it catches all 7+ leak paths with one mechanism and makes the multi-pane guard structural (duplicate references ARE possible via `openSessionTab({ terminalId, forceNew: true })`, src/store/tabsSlice.ts:675-716).
+
+**Why remove the component sends:** with the middleware in place they become double-detaches, and they lack the refcount guard (today TabBar detaches a terminal even if another tab still shows it). The middleware emits the identical message on the identical dispatch, so observable semantics are preserved — proven by keeping the existing component-level test assertions passing with the middleware concat'd into their test stores.
+
+**Why release marks:** kill sites (`TabBar` shift-close, `ContextMenuProvider.tsx:930` session-reopen, `TerminalView.tsx:2910` opencode self-heal, `BackgroundSessions.tsx:120`) send `terminal.kill`; the subsequent layout change would make the middleware send a redundant `terminal.detach` for a terminal the server just removed (server replies with an error for non-existent terminals). `sendTerminalKill()` marks the id as released; the middleware consumes the mark and skips.
+
+**Why skip `clearDeadTerminals` / `clearTerminalLiveHandles`:** these two actions (src/store/panesSlice.ts:1724, :1754) strip terminalIds ONLY for terminals the server itself reported dead or unrecoverable (payloads come from `terminal.inventory` / `terminals.changed` handling in App.tsx:883-885, :1044-1049). There is no live subscription to release, and detaching would generate a server error frame per corpse. This is not a scope reduction: the spec's goal (server-side reapability) is vacuous for terminals the server already reaped. `repairCodexIdentityMismatch` is deliberately NOT skipped — its stale terminal is typically still live and leaked.
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/lib/pane-utils.ts` | Modify | Add `collectAllTerminalIds(layouts)` — union of terminal ids across all tab layouts |
+| `src/lib/terminal-release-marks.ts` | Create | Module-scope set of terminal ids already released by an explicit send (kill); consumed by the middleware |
+| `src/lib/terminal-kill.ts` | Create | `sendTerminalKill(terminalId)` — mark released + send `terminal.kill` (single home for all kill sends) |
+| `src/store/terminalDetachMiddleware.ts` | Create | Layout-diff middleware that emits `terminal.detach` for dropped references |
+| `src/store/store.ts` | Modify | Register the middleware |
+| `test/setup/dom.ts` | Modify | Reset release marks after each test |
+| `src/components/TabBar.tsx` | Modify | Remove plain-close detach loop; shift-close uses `sendTerminalKill` |
+| `src/components/panes/PaneContainer.tsx` | Modify | Remove detach send in `handleClose` |
+| `src/components/context-menu/ContextMenuProvider.tsx` | Modify | Remove 3 detach sends; kill site uses `sendTerminalKill` |
+| `src/components/TerminalView.tsx` | Modify | Opencode self-heal kill (line 2910) uses `sendTerminalKill` |
+| `src/components/BackgroundSessions.tsx` | Modify | Kill button uses `sendTerminalKill` |
+| `test/unit/client/lib/collect-all-terminal-ids.test.ts` | Create | Helper tests |
+| `test/unit/client/lib/terminal-release-marks.test.ts` | Create | Marks module tests |
+| `test/unit/client/lib/terminal-kill.test.ts` | Create | Kill helper tests |
+| `test/unit/client/store/terminalDetachMiddleware.test.ts` | Create | Core middleware behavior (all leak paths + guards) |
+| `test/unit/client/store/storeDetachRegistration.test.ts` | Create | Production store registers the middleware |
+| `test/unit/client/components/TabBar.test.tsx` | Modify | Middleware in test store; exactly-once + shift-no-detach tests |
+| `test/unit/client/components/panes/PaneContainer.test.tsx` | Modify | Middleware in test store; exactly-once test |
+| `test/unit/client/components/ContextMenuProvider.test.tsx` | Modify | Middleware in test store |
+| `test/e2e/tab-focus-behavior.test.tsx` | Modify | Middleware in test store (assertions unchanged) |
+| `test/e2e/replace-pane.test.tsx` | Modify | Convert tautological hand-rolled detach sends into real middleware-backed assertions |
+
+---
+
+### Task 1: `collectAllTerminalIds` layout helper
+
+**Files:**
+- Modify: `src/lib/pane-utils.ts` (append after `collectTerminalIds`, which ends at line ~112 of the current file; `collectTerminalIds(node: PaneNode): string[]` sits at lines 30-42)
+- Test: `test/unit/client/lib/collect-all-terminal-ids.test.ts` (create)
+
+**Interfaces:**
+- Consumes: existing `collectTerminalIds(node: PaneNode): string[]` and `PaneNode` type from `@/store/paneTypes` (already imported at the top of pane-utils.ts).
+- Produces: `collectAllTerminalIds(layouts: Record<string, PaneNode | undefined>): Set<string>` exported from `@/lib/pane-utils` — Tasks 4+ rely on this exact name and signature.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/client/lib/collect-all-terminal-ids.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { collectAllTerminalIds } from '@/lib/pane-utils'
+import type { PaneNode } from '@/store/paneTypes'
+
+function terminalLeaf(paneId: string, terminalId?: string): PaneNode {
+  return {
+    type: 'leaf',
+    id: paneId,
+    content: {
+      kind: 'terminal',
+      mode: 'shell',
+      status: 'running',
+      createRequestId: `req-${paneId}`,
+      ...(terminalId ? { terminalId } : {}),
+    },
+  }
+}
+
+describe('collectAllTerminalIds', () => {
+  it('returns an empty set for no layouts', () => {
+    expect(collectAllTerminalIds({})).toEqual(new Set())
+  })
+
+  it('collects ids across multiple tab layouts', () => {
+    const layouts: Record<string, PaneNode | undefined> = {
+      'tab-1': terminalLeaf('pane-1', 'term-a'),
+      'tab-2': terminalLeaf('pane-2', 'term-b'),
+    }
+    expect(collectAllTerminalIds(layouts)).toEqual(new Set(['term-a', 'term-b']))
+  })
+
+  it('walks split trees', () => {
+    const layouts: Record<string, PaneNode | undefined> = {
+      'tab-1': {
+        type: 'split',
+        id: 'split-1',
+        direction: 'horizontal',
+        sizes: [50, 50],
+        children: [terminalLeaf('pane-1', 'term-a'), terminalLeaf('pane-2', 'term-b')],
+      },
+    }
+    expect(collectAllTerminalIds(layouts)).toEqual(new Set(['term-a', 'term-b']))
+  })
+
+  it('dedupes a terminal referenced by two layouts', () => {
+    const layouts: Record<string, PaneNode | undefined> = {
+      'tab-1': terminalLeaf('pane-1', 'term-dup'),
+      'tab-2': terminalLeaf('pane-2', 'term-dup'),
+    }
+    expect(collectAllTerminalIds(layouts)).toEqual(new Set(['term-dup']))
+  })
+
+  it('ignores undefined layouts, non-terminal panes, and terminals without ids', () => {
+    const layouts: Record<string, PaneNode | undefined> = {
+      'tab-1': undefined,
+      'tab-2': { type: 'leaf', id: 'pane-x', content: { kind: 'picker' } },
+      'tab-3': terminalLeaf('pane-y'), // no terminalId yet (creating)
+    }
+    expect(collectAllTerminalIds(layouts)).toEqual(new Set())
+  })
+})
+```
+
+If the `PaneNode` split-literal above fails typecheck because of extra/missing fields, mirror the exact split-node shape used in `test/e2e/replace-pane.test.tsx` (it builds split `PaneNode` literals the same way).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/collect-all-terminal-ids.test.ts --config config/vitest/vitest.config.ts`
+Expected: FAIL — `collectAllTerminalIds` is not exported from `@/lib/pane-utils`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/lib/pane-utils.ts` (directly after the existing `collectTerminalIds` function):
+
+```ts
+/**
+ * Union of every terminalId referenced by any pane in any tab layout.
+ * This is the client's complete "terminals I currently reference" set —
+ * the primitive the detach middleware diffs to spot dropped references.
+ */
+export function collectAllTerminalIds(
+  layouts: Record<string, PaneNode | undefined>
+): Set<string> {
+  const ids = new Set<string>()
+  for (const layout of Object.values(layouts)) {
+    if (!layout) continue
+    for (const terminalId of collectTerminalIds(layout)) {
+      ids.add(terminalId)
+    }
+  }
+  return ids
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/collect-all-terminal-ids.test.ts --config config/vitest/vitest.config.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/pane-utils.ts test/unit/client/lib/collect-all-terminal-ids.test.ts
+git commit -m "feat(client): add collectAllTerminalIds layout helper" -m "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+```
+
+---
+
+### Task 2: terminal release marks module
+
+**Files:**
+- Create: `src/lib/terminal-release-marks.ts`
+- Modify: `test/setup/dom.ts` (add reset call to the existing `afterEach`)
+- Test: `test/unit/client/lib/terminal-release-marks.test.ts` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces (from `@/lib/terminal-release-marks`):
+  - `markTerminalReleased(terminalId: string): void`
+  - `consumeTerminalReleaseMark(terminalId: string): boolean` — returns true (and clears the mark) if the id was marked
+  - `resetTerminalReleaseMarks(): void` — test hygiene
+  Tasks 3, 4, and the global test setup rely on these exact names.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/client/lib/terminal-release-marks.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  markTerminalReleased,
+  consumeTerminalReleaseMark,
+  resetTerminalReleaseMarks,
+} from '@/lib/terminal-release-marks'
+
+describe('terminal release marks', () => {
+  beforeEach(() => {
+    resetTerminalReleaseMarks()
+  })
+
+  it('consume returns false for an unmarked terminal', () => {
+    expect(consumeTerminalReleaseMark('term-1')).toBe(false)
+  })
+
+  it('consume returns true exactly once for a marked terminal', () => {
+    markTerminalReleased('term-1')
+    expect(consumeTerminalReleaseMark('term-1')).toBe(true)
+    expect(consumeTerminalReleaseMark('term-1')).toBe(false)
+  })
+
+  it('marks are independent per terminal id', () => {
+    markTerminalReleased('term-1')
+    expect(consumeTerminalReleaseMark('term-2')).toBe(false)
+    expect(consumeTerminalReleaseMark('term-1')).toBe(true)
+  })
+
+  it('reset clears all marks', () => {
+    markTerminalReleased('term-1')
+    resetTerminalReleaseMarks()
+    expect(consumeTerminalReleaseMark('term-1')).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/terminal-release-marks.test.ts --config config/vitest/vitest.config.ts`
+Expected: FAIL — module `@/lib/terminal-release-marks` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/lib/terminal-release-marks.ts`:
+
+```ts
+/**
+ * Terminal ids whose server-side subscription has already been (or is about
+ * to be) released by an explicit send — currently terminal.kill. The detach
+ * middleware consumes a mark instead of sending a redundant terminal.detach
+ * for a terminal the server just removed (the server replies with an error
+ * for detach on a non-existent terminal).
+ *
+ * Terminal ids are server-generated and never reused, so a stale mark can
+ * only ever suppress a detach for a terminal that no longer needs one.
+ */
+const releasedTerminalIds = new Set<string>()
+
+export function markTerminalReleased(terminalId: string): void {
+  releasedTerminalIds.add(terminalId)
+}
+
+export function consumeTerminalReleaseMark(terminalId: string): boolean {
+  return releasedTerminalIds.delete(terminalId)
+}
+
+export function resetTerminalReleaseMarks(): void {
+  releasedTerminalIds.clear()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/terminal-release-marks.test.ts --config config/vitest/vitest.config.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Wire the reset into global test hygiene**
+
+In `test/setup/dom.ts`, extend the imports (currently `import { resetWsClientForTests } from '@/lib/ws-client'` at the top of the file):
+
+```ts
+import { resetTerminalReleaseMarks } from '@/lib/terminal-release-marks'
+```
+
+and in the existing `afterEach` (the one that starts with `resetWsClientForTests()`, around line 118), add the reset immediately after it:
+
+```ts
+afterEach(() => {
+  resetWsClientForTests()
+  resetTerminalReleaseMarks()
+  // ... rest of the existing afterEach unchanged (console.error trap etc.)
+```
+
+- [ ] **Step 6: Run the two new suites plus one existing suite to prove setup still works**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/terminal-release-marks.test.ts test/unit/client/lib/collect-all-terminal-ids.test.ts test/unit/client/lib/terminal-attach-policy.test.ts --config config/vitest/vitest.config.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/terminal-release-marks.ts test/unit/client/lib/terminal-release-marks.test.ts test/setup/dom.ts
+git commit -m "feat(client): add terminal release-marks module with global test reset" -m "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+```
+
+---
+
+### Task 3: `sendTerminalKill` helper
+
+**Files:**
+- Create: `src/lib/terminal-kill.ts`
+- Test: `test/unit/client/lib/terminal-kill.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `getWsClient()` from `@/lib/ws-client` (`send(msg: unknown): void`); `markTerminalReleased` from Task 2.
+- Produces: `sendTerminalKill(terminalId: string): void` from `@/lib/terminal-kill` — Tasks 6, 8, 9 replace raw `ws.send({ type: 'terminal.kill', ... })` calls with this.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/client/lib/terminal-kill.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { sendTerminalKill } from '@/lib/terminal-kill'
+import {
+  consumeTerminalReleaseMark,
+  resetTerminalReleaseMarks,
+} from '@/lib/terminal-release-marks'
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }))
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({ send: mockSend }),
+}))
+
+describe('sendTerminalKill', () => {
+  beforeEach(() => {
+    mockSend.mockClear()
+    resetTerminalReleaseMarks()
+  })
+
+  it('sends the terminal.kill message', () => {
+    sendTerminalKill('term-1')
+    expect(mockSend).toHaveBeenCalledWith({ type: 'terminal.kill', terminalId: 'term-1' })
+  })
+
+  it('marks the terminal released before sending', () => {
+    sendTerminalKill('term-1')
+    expect(consumeTerminalReleaseMark('term-1')).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/terminal-kill.test.ts --config config/vitest/vitest.config.ts`
+Expected: FAIL — module `@/lib/terminal-kill` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/lib/terminal-kill.ts`:
+
+```ts
+import { getWsClient } from './ws-client'
+import { markTerminalReleased } from './terminal-release-marks'
+
+/**
+ * Send terminal.kill for a terminal, marking it released first so the
+ * detach middleware does not follow up with a redundant terminal.detach
+ * when the pane reference disappears from the layouts.
+ *
+ * Every terminal.kill send in the client goes through here.
+ */
+export function sendTerminalKill(terminalId: string): void {
+  markTerminalReleased(terminalId)
+  getWsClient().send({ type: 'terminal.kill', terminalId })
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/terminal-kill.test.ts --config config/vitest/vitest.config.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/terminal-kill.ts test/unit/client/lib/terminal-kill.test.ts
+git commit -m "feat(client): add sendTerminalKill helper that marks terminals released" -m "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+```
+
+---
+
+### Task 4: `terminalDetachMiddleware` (core)
+
+**Files:**
+- Create: `src/store/terminalDetachMiddleware.ts`
+- Test: `test/unit/client/store/terminalDetachMiddleware.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `collectAllTerminalIds` (Task 1), `consumeTerminalReleaseMark` (Task 2), `getWsClient` from `@/lib/ws-client`, action creators `clearDeadTerminals` / `clearTerminalLiveHandles` from `./panesSlice` (both exported — see src/store/panesSlice.ts export block at ~:1822-1856).
+- Produces: `terminalDetachMiddleware: Middleware` exported from `@/store/terminalDetachMiddleware` — Tasks 5–8 and 10 concat this into stores.
+
+Verified action payloads used in the tests below (from src/store/panesSlice.ts):
+- `initLayout({ tabId, content, paneId? })` (:870)
+- `updatePaneContent({ tabId, paneId, content })` (:1309)
+- `splitPane({ tabId, paneId, direction, newContent, newPaneId? })` (:927)
+- `closePane({ tabId, paneId })` (:1039 — no-op on single-leaf layouts)
+- `replacePane({ tabId, paneId })` (:1266 — content becomes `{ kind: 'picker' }`)
+- `removeLayout({ tabId })` (:1537 — the tab-close cascade target)
+- `clearDeadTerminals({ liveTerminalIds })` (:1724)
+- `clearTerminalLiveHandles({ terminalIds })` (:1754)
+- `repairCodexIdentityMismatch({ tabId, paneId, staleTerminalId, expectedSessionRef, createRequestId })` (:1778)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/unit/client/store/terminalDetachMiddleware.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+import panesReducer, {
+  initLayout,
+  updatePaneContent,
+  splitPane,
+  closePane,
+  replacePane,
+  removeLayout,
+  clearDeadTerminals,
+  clearTerminalLiveHandles,
+  repairCodexIdentityMismatch,
+} from '@/store/panesSlice'
+import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
+import {
+  markTerminalReleased,
+  resetTerminalReleaseMarks,
+} from '@/lib/terminal-release-marks'
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }))
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({ send: mockSend }),
+}))
+
+function createStore() {
+  return configureStore({
+    reducer: { panes: panesReducer },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(terminalDetachMiddleware),
+  })
+}
+
+function terminalContent(terminalId: string, createRequestId = `req-${terminalId}`) {
+  return {
+    kind: 'terminal' as const,
+    mode: 'shell' as const,
+    status: 'running' as const,
+    terminalId,
+    createRequestId,
+  }
+}
+
+function detachedIds(): string[] {
+  return mockSend.mock.calls
+    .map(([msg]) => msg as { type?: string; terminalId?: string })
+    .filter((msg) => msg?.type === 'terminal.detach')
+    .map((msg) => msg.terminalId as string)
+}
+
+beforeEach(() => {
+  mockSend.mockClear()
+  resetTerminalReleaseMarks()
+})
+
+describe('terminalDetachMiddleware', () => {
+  it('does not send anything when layouts only grow', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-a') }))
+    store.dispatch(splitPane({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      direction: 'horizontal',
+      newContent: terminalContent('term-b'),
+      newPaneId: 'pane-2',
+    }))
+    expect(detachedIds()).toEqual([])
+  })
+
+  it('does not send anything for actions that do not touch pane layouts', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-a') }))
+    mockSend.mockClear()
+    store.dispatch({ type: 'test/noop' })
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('detaches the old terminal when a pane is re-pointed to a new terminal', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-old') }))
+    mockSend.mockClear()
+    store.dispatch(updatePaneContent({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-new') }))
+    expect(detachedIds()).toEqual(['term-old'])
+  })
+
+  it('detaches when a pane is replaced with the picker', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-a') }))
+    mockSend.mockClear()
+    store.dispatch(replacePane({ tabId: 'tab-1', paneId: 'pane-1' }))
+    expect(detachedIds()).toEqual(['term-a'])
+  })
+
+  it('detaches when a split pane is closed', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-a') }))
+    store.dispatch(splitPane({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      direction: 'horizontal',
+      newContent: terminalContent('term-b'),
+      newPaneId: 'pane-2',
+    }))
+    mockSend.mockClear()
+    store.dispatch(closePane({ tabId: 'tab-1', paneId: 'pane-2' }))
+    expect(detachedIds()).toEqual(['term-b'])
+  })
+
+  it('detaches every terminal in a removed layout (tab close cascade)', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-a') }))
+    store.dispatch(splitPane({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      direction: 'vertical',
+      newContent: terminalContent('term-b'),
+      newPaneId: 'pane-2',
+    }))
+    mockSend.mockClear()
+    store.dispatch(removeLayout({ tabId: 'tab-1' }))
+    expect(detachedIds().sort()).toEqual(['term-a', 'term-b'])
+  })
+
+  it('does NOT detach a terminal still referenced by another tab (refcount guard)', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-dup', 'req-1') }))
+    store.dispatch(initLayout({ tabId: 'tab-2', paneId: 'pane-2', content: terminalContent('term-dup', 'req-2') }))
+    mockSend.mockClear()
+    store.dispatch(removeLayout({ tabId: 'tab-1' }))
+    expect(detachedIds()).toEqual([])
+    store.dispatch(removeLayout({ tabId: 'tab-2' }))
+    expect(detachedIds()).toEqual(['term-dup'])
+  })
+
+  it('sends a single detach when one action drops multiple references to the same terminal', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-dup', 'req-1') }))
+    store.dispatch(splitPane({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      direction: 'horizontal',
+      newContent: terminalContent('term-dup', 'req-2'),
+      newPaneId: 'pane-2',
+    }))
+    mockSend.mockClear()
+    store.dispatch(removeLayout({ tabId: 'tab-1' }))
+    expect(detachedIds()).toEqual(['term-dup'])
+  })
+
+  it('skips detach for terminals dropped by clearDeadTerminals (server already reaped them)', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-dead') }))
+    mockSend.mockClear()
+    store.dispatch(clearDeadTerminals({ liveTerminalIds: [] }))
+    expect(detachedIds()).toEqual([])
+  })
+
+  it('skips detach for terminals dropped by clearTerminalLiveHandles (recoverable-loss path)', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-lost') }))
+    mockSend.mockClear()
+    store.dispatch(clearTerminalLiveHandles({ terminalIds: ['term-lost'] }))
+    expect(detachedIds()).toEqual([])
+  })
+
+  it('detaches the stale terminal on codex identity repair', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-stale') }))
+    mockSend.mockClear()
+    store.dispatch(repairCodexIdentityMismatch({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      staleTerminalId: 'term-stale',
+      expectedSessionRef: { provider: 'codex', sessionId: 'session-1' },
+      createRequestId: 'req-repair',
+    }))
+    expect(detachedIds()).toEqual(['term-stale'])
+  })
+
+  it('skips detach for a terminal marked released (explicit kill), consuming the mark', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-k') }))
+    mockSend.mockClear()
+    markTerminalReleased('term-k')
+    store.dispatch(replacePane({ tabId: 'tab-1', paneId: 'pane-1' }))
+    expect(detachedIds()).toEqual([])
+
+    // The mark was consumed: a fresh reference drop for the same id detaches again.
+    store.dispatch(updatePaneContent({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-k', 'req-k2') }))
+    mockSend.mockClear()
+    store.dispatch(replacePane({ tabId: 'tab-1', paneId: 'pane-1' }))
+    expect(detachedIds()).toEqual(['term-k'])
+  })
+})
+```
+
+Note: if `initLayout`'s `paneId` option or the `terminalContent` literal trips the `PaneContentInput` type, adapt the literal minimally (e.g. add `shell: 'system' as const`) — do not change the assertions.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test:vitest -- run test/unit/client/store/terminalDetachMiddleware.test.ts --config config/vitest/vitest.config.ts`
+Expected: FAIL — module `@/store/terminalDetachMiddleware` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/store/terminalDetachMiddleware.ts`:
+
+```ts
+import type { Middleware } from '@reduxjs/toolkit'
+import { getWsClient } from '@/lib/ws-client'
+import { collectAllTerminalIds } from '@/lib/pane-utils'
+import { consumeTerminalReleaseMark } from '@/lib/terminal-release-marks'
+import { clearDeadTerminals, clearTerminalLiveHandles } from './panesSlice'
+import type { PaneNode } from './paneTypes'
+
+type PanesStateSlice = { panes: { layouts: Record<string, PaneNode | undefined> } }
+
+/**
+ * These actions strip terminalIds ONLY for terminals the server itself
+ * reported dead or unrecoverable (terminal.inventory / terminals.changed).
+ * There is no live subscription to release, and the server replies with an
+ * error for terminal.detach on a non-existent terminal — so skip them.
+ */
+const skipDetachActionTypes = new Set<string>([
+  clearDeadTerminals.type,
+  clearTerminalLiveHandles.type,
+])
+
+/**
+ * Detach reconciler: whenever an action makes a terminalId disappear from
+ * ALL pane layouts, the client no longer references that terminal and must
+ * release its server-side attach subscription — otherwise the server sees
+ * hasClients=true forever and its idle reaper can never collect the
+ * terminal. The set diff over every layout is what guards the multi-pane
+ * case: a terminal referenced by two panes only detaches when the LAST
+ * reference goes away.
+ *
+ * Stateless by design (derives everything from getState) — safe under the
+ * test suite's per-test ws-client reset.
+ */
+export const terminalDetachMiddleware: Middleware = (store) => (next) => (action) => {
+  const beforeLayouts = (store.getState() as PanesStateSlice).panes.layouts
+  const result = next(action)
+  const afterLayouts = (store.getState() as PanesStateSlice).panes.layouts
+  if (afterLayouts === beforeLayouts) return result
+
+  const actionType = (action as { type?: unknown }).type
+  if (typeof actionType === 'string' && skipDetachActionTypes.has(actionType)) {
+    return result
+  }
+
+  const before = collectAllTerminalIds(beforeLayouts)
+  if (before.size === 0) return result
+  const after = collectAllTerminalIds(afterLayouts)
+
+  for (const terminalId of before) {
+    if (after.has(terminalId)) continue
+    if (consumeTerminalReleaseMark(terminalId)) continue
+    getWsClient().send({ type: 'terminal.detach', terminalId })
+  }
+  return result
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test:vitest -- run test/unit/client/store/terminalDetachMiddleware.test.ts --config config/vitest/vitest.config.ts`
+Expected: PASS (12 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/terminalDetachMiddleware.ts test/unit/client/store/terminalDetachMiddleware.test.ts
+git commit -m "feat(client): add terminalDetachMiddleware releasing dropped terminal references" -m "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+```
+
+---
+
+### Task 5: register the middleware in the production store
+
+**Files:**
+- Modify: `src/store/store.ts` (middleware concat list at lines ~62-77)
+- Test: `test/unit/client/store/storeDetachRegistration.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `terminalDetachMiddleware` (Task 4).
+- Produces: production store behavior — every reference drop in the real app now emits `terminal.detach`. (Between this task and Tasks 6–8 the components still ALSO send detach, so production would transiently double-detach; that is harmless — the server treats a second detach of a live terminal as a no-op subscriber removal — and is resolved by Tasks 6–8.)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/client/store/storeDetachRegistration.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }))
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({
+    send: mockSend,
+    connect: vi.fn().mockResolvedValue(undefined),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    onReconnect: vi.fn().mockReturnValue(() => {}),
+    onDisconnect: vi.fn().mockReturnValue(() => {}),
+  }),
+  resetWsClientForTests: vi.fn(),
+}))
+
+import { store } from '@/store/store'
+import { initLayout, removeLayout } from '@/store/panesSlice'
+
+describe('production store', () => {
+  it('registers terminalDetachMiddleware (removing a layout emits terminal.detach)', () => {
+    store.dispatch(initLayout({
+      tabId: 'detach-reg-tab',
+      paneId: 'detach-reg-pane',
+      content: {
+        kind: 'terminal',
+        mode: 'shell',
+        status: 'running',
+        terminalId: 'detach-reg-term',
+        createRequestId: 'detach-reg-req',
+      },
+    }))
+    mockSend.mockClear()
+    store.dispatch(removeLayout({ tabId: 'detach-reg-tab' }))
+    expect(mockSend).toHaveBeenCalledWith({ type: 'terminal.detach', terminalId: 'detach-reg-term' })
+  })
+})
+```
+
+Note: mocking `resetWsClientForTests` is required because `test/setup/dom.ts` imports it from the same mocked module. If other middleware (layoutMirror) emits additional messages during the dispatches, that is fine — the assertion uses `toHaveBeenCalledWith`, not exact call counts.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:vitest -- run test/unit/client/store/storeDetachRegistration.test.ts --config config/vitest/vitest.config.ts`
+Expected: FAIL — no `terminal.detach` sent (middleware not registered).
+
+- [ ] **Step 3: Register the middleware**
+
+In `src/store/store.ts`, add the import next to the other middleware imports:
+
+```ts
+import { terminalDetachMiddleware } from './terminalDetachMiddleware'
+```
+
+and add it to the `.concat(...)` list after `layoutMirrorMiddleware`:
+
+```ts
+      layoutMirrorMiddleware,
+      terminalDetachMiddleware,
+      sessionActivityPersistMiddleware,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:vitest -- run test/unit/client/store/storeDetachRegistration.test.ts --config config/vitest/vitest.config.ts`
+Expected: PASS.
+
+Also run the one existing test that imports the production store, to confirm no interference:
+
+Run: `npm run test:vitest -- run test/unit/client/fresh-agent-only-ui-state.test.ts --config config/vitest/vitest.config.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/store.ts test/unit/client/store/storeDetachRegistration.test.ts
+git commit -m "feat(client): register terminalDetachMiddleware in production store" -m "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+```
+
+---
+
+### Task 6: TabBar — middleware-backed close semantics
+
+**Files:**
+- Modify: `src/components/TabBar.tsx` (close handler at lines ~311-324)
+- Modify: `test/unit/client/components/TabBar.test.tsx` (store helper + tests at :593 and :671)
+- Modify: `test/e2e/tab-focus-behavior.test.tsx` (store helper at ~:77; detach assertions at :330-334 stay unchanged)
+
+**Interfaces:**
+- Consumes: `sendTerminalKill` (Task 3), `terminalDetachMiddleware` (Task 4).
+- Produces: TabBar plain close relies on the middleware for detach; shift-close still kills. User-visible semantics unchanged.
+
+Current handler (src/components/TabBar.tsx:311-324, verbatim):
+
+```tsx
+        onClose={(e) => {
+          const terminalIds = getTerminalIdsForTab(tab)
+          if (terminalIds.length > 0) {
+            const messageType = e.shiftKey ? 'terminal.kill' : 'terminal.detach'
+            for (const terminalId of terminalIds) {
+              ws.send({
+                type: messageType,
+                terminalId,
+              })
+            }
+          }
+          dispatch(closeTab(tab.id))
+        }}
+```
+
+- [ ] **Step 1: Add the middleware to both test stores**
+
+In `test/unit/client/components/TabBar.test.tsx`: the file's `configureStore` helper currently has no `middleware:` key. Add one:
+
+```ts
+import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
+```
+
+and inside the `configureStore({...})` call:
+
+```ts
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(terminalDetachMiddleware),
+```
+
+In `test/e2e/tab-focus-behavior.test.tsx`: same addition to its `createStore` (`configureStore` at ~line 78, currently no `middleware:` key).
+
+Run both suites — they must still be green (double-send is not asserted anywhere yet):
+
+Run: `npm run test:vitest -- run test/unit/client/components/TabBar.test.tsx test/e2e/tab-focus-behavior.test.tsx --config config/vitest/vitest.config.ts`
+Expected: PASS.
+
+- [ ] **Step 2: Write the failing tests**
+
+In `test/unit/client/components/TabBar.test.tsx`, inside the `describe('tab interactions')` block (starts ~:530), add two tests. Reuse the exact same store construction, render helper, and close-button interaction code as the existing test `'close button sends detach message when pane has terminalId'` at :593 (same preloaded layout with `terminalId: 'term-1'`, same `fireEvent.click` on the close button; the file's hoisted ws send mock is the `expect` target — match the local mock variable name used at :627):
+
+```ts
+  it('plain close sends exactly one terminal.detach per terminal', () => {
+    // ...same setup + plain close click as the test at :593...
+    const detachMessages = sendMock.mock.calls
+      .map(([msg]) => msg as { type?: string; terminalId?: string })
+      .filter((msg) => msg?.type === 'terminal.detach')
+    expect(detachMessages).toEqual([{ type: 'terminal.detach', terminalId: 'term-1' }])
+  })
+
+  it('shift close sends terminal.kill and no terminal.detach', () => {
+    // ...same setup, but close click with { shiftKey: true }...
+    const sentTypes = sendMock.mock.calls
+      .map(([msg]) => (msg as { type?: string })?.type)
+    expect(sentTypes).toContain('terminal.kill')
+    expect(sentTypes).not.toContain('terminal.detach')
+    expect(sendMock).toHaveBeenCalledWith({ type: 'terminal.kill', terminalId: 'term-1' })
+  })
+```
+
+(`sendMock` here stands for the file's actual hoisted ws send mock — use its real name.)
+
+- [ ] **Step 3: Run to verify both fail**
+
+Run: `npm run test:vitest -- run test/unit/client/components/TabBar.test.tsx --config config/vitest/vitest.config.ts`
+Expected: FAIL —
+- exactly-once test: TWO detach messages (component + middleware);
+- shift test: a `terminal.detach` appears (middleware fires because the raw kill send sets no release mark).
+
+- [ ] **Step 4: Fix the component**
+
+In `src/components/TabBar.tsx`, add the import:
+
+```ts
+import { sendTerminalKill } from '@/lib/terminal-kill'
+```
+
+and replace the close handler body:
+
+```tsx
+        onClose={(e) => {
+          if (e.shiftKey) {
+            const terminalIds = getTerminalIdsForTab(tab)
+            for (const terminalId of terminalIds) {
+              sendTerminalKill(terminalId)
+            }
+          }
+          dispatch(closeTab(tab.id))
+        }}
+```
+
+If `ws` (from `const ws = useMemo(() => getWsClient(), [])` at :182) is now unused in this file, remove it and drop it from the `renderSortableTab` `useCallback` dependency list (:352). If it is still used elsewhere in the file, leave it.
+
+- [ ] **Step 5: Run TabBar + e2e suites to verify green**
+
+Run: `npm run test:vitest -- run test/unit/client/components/TabBar.test.tsx test/e2e/tab-focus-behavior.test.tsx --config config/vitest/vitest.config.ts`
+Expected: PASS — the pre-existing detach assertions (:593 single-terminal, :671 split-layout multi-terminal, e2e :330-334 ordered multi-terminal) now pass via the middleware, proving plain-close semantics are unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/TabBar.tsx test/unit/client/components/TabBar.test.tsx test/e2e/tab-focus-behavior.test.tsx
+git commit -m "fix(client): route TabBar close detach through terminalDetachMiddleware" -m "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+```
+
+---
+
+### Task 7: PaneContainer — remove caller-side detach
+
+**Files:**
+- Modify: `src/components/panes/PaneContainer.tsx` (`handleClose` at lines ~336-343)
+- Modify: `test/unit/client/components/panes/PaneContainer.test.tsx` (store helper + `describe('terminal cleanup on pane close')` at :420)
+
+**Interfaces:**
+- Consumes: `terminalDetachMiddleware` (Task 4).
+- Produces: pane close detach flows through the middleware (also covering the previously-leaking keyboard/`ui-commands`/agent-API close paths, which dispatch the same `closePaneWithCleanup` thunk).
+
+Current code (src/components/panes/PaneContainer.tsx:336-343, verbatim head):
+
+```tsx
+  const handleClose = useCallback((paneId: string, content: PaneContent) => {
+    // Clean up terminal process if this pane has one
+    if (content.kind === 'terminal' && content.terminalId) {
+      ws.send({
+        type: 'terminal.detach',
+        terminalId: content.terminalId,
+      })
+    }
+```
+
+- [ ] **Step 1: Add the middleware to the test store**
+
+In `test/unit/client/components/panes/PaneContainer.test.tsx`, the `configureStore` helper already has a `middleware:` key that only tunes `getDefaultMiddleware` options. Extend it with `.concat(terminalDetachMiddleware)`:
+
+```ts
+import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
+```
+
+```ts
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ /* keep the existing options object unchanged */ }).concat(terminalDetachMiddleware),
+```
+
+Run: `npm run test:vitest -- run test/unit/client/components/panes/PaneContainer.test.tsx --config config/vitest/vitest.config.ts`
+Expected: PASS (nothing asserts single-send yet; the negative tests at :466/:507 involve panes without terminal ids, so the middleware stays silent there).
+
+- [ ] **Step 2: Write the failing test**
+
+Inside `describe('terminal cleanup on pane close')` (:420), add — reusing the setup and close interaction of the existing test at :421 verbatim, changing only the assertions:
+
+```ts
+  it('sends exactly one terminal.detach when closing a pane with terminalId', () => {
+    // ...same setup + close interaction as the test at :421...
+    const detachMessages = sendMock.mock.calls
+      .map(([msg]) => msg as { type?: string; terminalId?: string })
+      .filter((msg) => msg?.type === 'terminal.detach')
+    expect(detachMessages).toHaveLength(1)
+  })
+```
+
+(`sendMock` = the file's actual hoisted ws send mock name.)
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `npm run test:vitest -- run test/unit/client/components/panes/PaneContainer.test.tsx --config config/vitest/vitest.config.ts`
+Expected: FAIL — two detach messages (component + middleware).
+
+- [ ] **Step 4: Fix the component**
+
+In `src/components/panes/PaneContainer.tsx`, delete the detach block from `handleClose` (keep everything else in the function — the dispatch of `closePaneWithCleanup` etc. is unchanged):
+
+```tsx
+  const handleClose = useCallback((paneId: string, content: PaneContent) => {
+```
+
+(the `if (content.kind === 'terminal' && content.terminalId) { ws.send({ type: 'terminal.detach', ... }) }` block is removed; the middleware fires on the resulting `closePane`/`closeTab` state change — note `closePaneWithCleanup` escalates single-leaf layouts to `closeTab`, so the `closePane` single-leaf no-op case is covered). If `content` or `ws` becomes unused, clean up per lint.
+
+- [ ] **Step 5: Run to verify green**
+
+Run: `npm run test:vitest -- run test/unit/client/components/panes/PaneContainer.test.tsx --config config/vitest/vitest.config.ts`
+Expected: PASS — including the pre-existing positive tests (:421, :555/:592) now satisfied by the middleware, and the negative tests (:466 no-terminalId, :507 browser pane) still negative.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/panes/PaneContainer.tsx test/unit/client/components/panes/PaneContainer.test.tsx
+git commit -m "fix(client): route pane-close detach through terminalDetachMiddleware" -m "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+```
+
+---
+
+### Task 8: ContextMenuProvider — remove caller-side detaches, mark the kill
+
+**Files:**
+- Modify: `src/components/context-menu/ContextMenuProvider.tsx` (four sites: ~:298-303, ~:306-315, ~:929-930, ~:1223-1229)
+- Modify: `test/unit/client/components/ContextMenuProvider.test.tsx` (store helper + test at :2286)
+
+**Interfaces:**
+- Consumes: `sendTerminalKill` (Task 3), `terminalDetachMiddleware` (Task 4).
+- Produces: context-menu replace/close flows rely on the middleware; the session-reopen kill is release-marked.
+
+The four current sites (verbatim):
+
+Site A — replace pane (~:298-303):
+```tsx
+    if (content?.kind === 'terminal' && content.terminalId) {
+      ws.send({ type: 'terminal.detach', terminalId: content.terminalId })
+    }
+    dispatch(replacePane({ tabId, paneId }))
+```
+
+Site B — close tab (~:306-315):
+```tsx
+  const closeTabById = useCallback((tabId: string) => {
+    const layout = panes[tabId]
+    if (layout) {
+      const terminalIds = collectTerminalIds(layout)
+      for (const terminalId of terminalIds) {
+        ws.send({ type: 'terminal.detach', terminalId })
+      }
+    }
+    dispatch(closeTab(tabId))
+  }, [dispatch, panes, ws])
+```
+
+Site C — session-reopen kill (~:929-930):
+```tsx
+    if (latest.content.kind === 'terminal' && latest.content.terminalId) {
+      ws.send({ type: 'terminal.kill', terminalId: latest.content.terminalId })
+    } else if (latest.content.kind === 'fresh-agent' && latest.content.sessionId) {
+```
+
+Site D — close pane (~:1223-1229):
+```tsx
+        closePane: (tabId, paneId) => {
+          const content = panes[tabId] ? findPaneContent(panes[tabId], paneId) : null
+          if (content?.kind === 'terminal' && content.terminalId) {
+            ws.send({ type: 'terminal.detach', terminalId: content.terminalId })
+          }
+          dispatch(closePaneWithCleanup({ tabId, paneId }))
+        },
+```
+
+- [ ] **Step 1: Add the middleware to the test store**
+
+In `test/unit/client/components/ContextMenuProvider.test.tsx`, extend the existing `configureStore` `middleware:` option (it currently only tunes `getDefaultMiddleware`) with `.concat(terminalDetachMiddleware)` and add the import, exactly as in Task 7 Step 1.
+
+Run: `npm run test:vitest -- run test/unit/client/components/ContextMenuProvider.test.tsx --config config/vitest/vitest.config.ts`
+Expected: PASS.
+
+- [ ] **Step 2: Write the failing test**
+
+Next to the existing `it('detaches terminal and replaces pane with picker via context menu')` (:2286), add — reusing that test's setup and menu interaction verbatim, changing only the assertions:
+
+```ts
+  it('sends exactly one terminal.detach when replacing a pane via context menu', async () => {
+    // ...same setup + "Replace pane" menu interaction as the test at :2286...
+    const detachMessages = sendMock.mock.calls
+      .map(([msg]) => msg as { type?: string; terminalId?: string })
+      .filter((msg) => msg?.type === 'terminal.detach')
+    expect(detachMessages).toHaveLength(1)
+  })
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `npm run test:vitest -- run test/unit/client/components/ContextMenuProvider.test.tsx --config config/vitest/vitest.config.ts`
+Expected: FAIL — two detach messages.
+
+- [ ] **Step 4: Fix the component**
+
+In `src/components/context-menu/ContextMenuProvider.tsx`:
+
+Add the import:
+```ts
+import { sendTerminalKill } from '@/lib/terminal-kill'
+```
+
+Site A becomes:
+```tsx
+    dispatch(replacePane({ tabId, paneId }))
+```
+
+Site B becomes:
+```tsx
+  const closeTabById = useCallback((tabId: string) => {
+    dispatch(closeTab(tabId))
+  }, [dispatch])
+```
+
+Site C becomes:
+```tsx
+    if (latest.content.kind === 'terminal' && latest.content.terminalId) {
+      sendTerminalKill(latest.content.terminalId)
+    } else if (latest.content.kind === 'fresh-agent' && latest.content.sessionId) {
+```
+
+Site D becomes:
+```tsx
+        closePane: (tabId, paneId) => {
+          dispatch(closePaneWithCleanup({ tabId, paneId }))
+        },
+```
+
+Clean up any now-unused locals/imports (`collectTerminalIds`, `findPaneContent`, `panes`, `ws`) ONLY if they have no other uses in the file — check each before removing; adjust `useCallback` dependency arrays accordingly.
+
+- [ ] **Step 5: Run to verify green**
+
+Run: `npm run test:vitest -- run test/unit/client/components/ContextMenuProvider.test.tsx test/e2e/refresh-context-menu-flow.test.tsx --config config/vitest/vitest.config.ts`
+Expected: PASS. (`refresh-context-menu-flow` covers the TerminalView refresh detach ordering, which this task must not disturb.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/context-menu/ContextMenuProvider.tsx test/unit/client/components/ContextMenuProvider.test.tsx
+git commit -m "fix(client): route context-menu detach through terminalDetachMiddleware and mark reopen kill" -m "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+```
+
+---
+
+### Task 9: remaining kill sites use `sendTerminalKill`
+
+**Files:**
+- Modify: `src/components/TerminalView.tsx` (line ~2910, opencode replay-window self-heal)
+- Modify: `src/components/BackgroundSessions.tsx` (line ~120, Kill button)
+
+**Interfaces:**
+- Consumes: `sendTerminalKill` (Task 3).
+- Produces: every `terminal.kill` in the client now sets a release mark (uniform rule; prevents a follow-up detach for the self-healed terminal when its pane is later recreated).
+
+- [ ] **Step 1: Make the mechanical replacements**
+
+In `src/components/TerminalView.tsx`, add the import and replace line ~2910:
+
+```ts
+import { sendTerminalKill } from '@/lib/terminal-kill'
+```
+
+```tsx
+      sendTerminalKill(terminalId)
+```
+
+(was `ws.send({ type: 'terminal.kill', terminalId })`).
+
+In `src/components/BackgroundSessions.tsx`, add the same import and replace line ~120:
+
+```tsx
+                    onClick={() => sendTerminalKill(t.terminalId)}
+```
+
+(was `onClick={() => ws.send({ type: 'terminal.kill', terminalId: t.terminalId })}`). If `ws` becomes unused in BackgroundSessions, remove its `useMemo(() => getWsClient(), [])` and import.
+
+The wire message is byte-identical, and both files' tests mock `@/lib/ws-client` — `sendTerminalKill` routes through the same mocked `getWsClient()`, so existing kill assertions keep passing unchanged. That is the (existing) test coverage for this step; the mark behavior itself is covered by Task 3's unit tests and Task 4's marked-release middleware test.
+
+- [ ] **Step 2: Run the affected suites**
+
+Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx --config config/vitest/vitest.config.ts` (timeout: this file is large — allow up to 10 minutes)
+Expected: PASS.
+
+Then find and run any BackgroundSessions test file (search `test/unit/client` for `BackgroundSessions`); if one exists, run it — Expected: PASS. If none exists, note that in the commit body.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/TerminalView.tsx src/components/BackgroundSessions.tsx
+git commit -m "refactor(client): route remaining terminal.kill sends through sendTerminalKill" -m "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+```
+
+---
+
+### Task 10: make replace-pane e2e assertions real
+
+**Files:**
+- Modify: `test/e2e/replace-pane.test.tsx`
+
+**Interfaces:**
+- Consumes: `terminalDetachMiddleware` (Task 4).
+- Produces: previously-tautological detach assertions (the test hand-rolled `wsMocks.send({ type: 'terminal.detach', ... })` itself at :107, :197, :276) become genuine proof that the store emits the detach.
+
+- [ ] **Step 1: Convert the tests (RED first)**
+
+In `test/e2e/replace-pane.test.tsx`:
+
+1. Add the middleware to `createStore` (the `configureStore` at ~:28 has no `middleware:` key):
+
+```ts
+import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
+```
+```ts
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(terminalDetachMiddleware),
+```
+
+2. In each of the three tests (at :88, :176, :238), DELETE the hand-rolled send block, e.g. at ~:103-108:
+
+```ts
+    // Simulate what ContextMenuProvider does: detach terminal, then dispatch replacePane
+    const paneContent = findPaneContent(store.getState().panes.layouts['tab-1'], 'pane-1')
+    expect(paneContent?.kind).toBe('terminal')
+    if (paneContent?.kind === 'terminal' && paneContent.terminalId) {
+      wsMocks.send({ type: 'terminal.detach', terminalId: paneContent.terminalId })
+    }
+```
+
+becomes:
+
+```ts
+    const paneContent = findPaneContent(store.getState().panes.layouts['tab-1'], 'pane-1')
+    expect(paneContent?.kind).toBe('terminal')
+```
+
+(keep the `replacePane` / `closePane` dispatch and the existing `expect(wsMocks.send).toHaveBeenCalledWith({ type: 'terminal.detach', terminalId: 'term-1' })` assertions — they are now satisfied only if the middleware really emits).
+
+To honor RED: make the deletions FIRST without adding the middleware, run the file, and confirm the three assertions fail; then add the middleware concat and re-run.
+
+Caveat for the test at :238 ("closing pane with matching terminal"): if it dispatches `closePane` on a single-leaf layout, the reducer is a no-op and the middleware will not fire — in that case restructure that one test's preloaded layout to a two-pane split (mirror the split-layout literal already used elsewhere in the same file) so the close actually removes the pane.
+
+- [ ] **Step 2: Run RED then GREEN**
+
+Run: `npm run test:vitest -- run test/e2e/replace-pane.test.tsx --config config/vitest/vitest.config.ts`
+Expected: FAIL after deletions (3 tests), PASS after the middleware concat.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/e2e/replace-pane.test.tsx
+git commit -m "test(e2e): assert replace-pane detach from the middleware instead of hand-rolling it" -m "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+```
+
+---
+
+### Task 11: full verification
+
+**Files:** none new.
+
+- [ ] **Step 1: Lint**
+
+Run: `npm run lint`
+Expected: clean (fix any unused-variable fallout from Tasks 6-9 with `npm run lint:fix` or targeted edits, then re-run).
+
+- [ ] **Step 2: Coordinated full suite (typecheck + both vitest configs)**
+
+First check the gate: `npm run test:status` — if another agent holds it, wait (do NOT kill a foreign holder).
+
+Run: `FRESHELL_TEST_SUMMARY="terminal-attach-leak: middleware-based detach reconciler" npm run check` (timeout: allow up to 30 minutes)
+Expected: typecheck clean, full suite green.
+
+- [ ] **Step 3: Fix anything that fails, then re-run until green**
+
+Likely fallout candidates and their fixes:
+- Tests that build stores with the panes reducer and mock `@/lib/ws-client` may now observe extra `terminal.detach` sends if they drop terminal references mid-test. Fix by adjusting the assertion to filter message types (never by weakening the middleware).
+- Tests that do NOT mock `@/lib/ws-client` but dispatch reference-dropping panes actions through the PRODUCTION store would hit a real `WsClient` — `test/setup/dom.ts` resets the singleton per test and jsdom has no live socket; sends queue harmlessly. Only act if a failure actually appears.
+
+- [ ] **Step 4: Commit any test-fallout fixes**
+
+```bash
+git add -A
+git commit -m "test(client): align remaining suites with middleware-based terminal detach" -m "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+```
+
+(Skip this commit if Step 3 required no changes.)
+
+---
+
+## Self-Review Record
+
+**1. Spec coverage** — every leak path in the spec maps to a covering mechanism + test:
+
+| Spec path | Mechanism | Test |
+|---|---|---|
+| Pane re-pointed to a new terminal (resume session into pane) | middleware diff on `updatePaneContent` | Task 4 "re-pointed" test |
+| Dead-terminal recreate (`clearTerminalContentForRecreate` via `clearDeadTerminals`/`clearTerminalLiveHandles`) | deliberately skipped — the terminal is server-reported dead/unrecoverable; no subscription exists to release and detach would only draw server error frames. Design Notes documents this; it preserves the spec's outcome (reapability) rather than reducing scope | Task 4 skip tests |
+| Codex identity repair (live stale terminal) | middleware diff on `repairCodexIdentityMismatch` | Task 4 repair test |
+| Pane closed (button, context menu, keyboard, ui-commands, agent API) | all paths dispatch `closePaneWithCleanup` → `closePane`/`closeTab`; middleware diff | Task 4 close test; Task 7 component tests |
+| Split-pane removed | middleware diff sees every leaf of a removed subtree | Task 4 removeLayout multi-terminal test |
+| Tab closed (any path incl. keyboard/API, previously leaking) | `closeTab` → `removeLayout`; middleware diff | Task 4 removeLayout tests; Task 6 TabBar tests; tab-focus e2e |
+| TerminalView unmount | every unmount that drops the reference does so via a layouts change (restoreLayout/hydratePanes/removeLayout/closePane), caught by the diff; unmount WITHOUT a state change (tab switch) still references the terminal and must NOT detach — background attach is intentional (`registerForBackgroundHydration`) | Task 4 (all diff tests); "no layouts change ⇒ no send" test |
+| Multi-pane guard ("another pane still displays the same terminal") | set-diff over ALL layouts | Task 4 refcount test |
+| Explicit tab-close semantics unchanged | plain close ⇒ middleware emits detach on same dispatch; Shift ⇒ `sendTerminalKill` | Task 6 (pre-existing assertions kept passing + 2 new tests) |
+| Scope guard: no server changes | no server/crates file appears in the File Structure | — |
+
+**1b. No silent deferrals** — the only mocked boundary is `@/lib/ws-client` in unit tests; the production wire path (`getWsClient().send`) is exercised unmocked in the app and the message shape matches the server's Zod schema (shared/ws-protocol.ts:348). No stub is left standing in for production behavior; the production store registration itself is behavior-tested (Task 5). The clearDead/clearLiveHandles skip is an explicit, documented design decision (dead terminals have no subscription), not a deferral.
+
+**2. Placeholder scan** — the two component-test steps (Tasks 6-8) intentionally reference the neighbouring test's setup by exact line number instead of duplicating unquotable file-local harness code; all assertions, all production code, and all new modules are given in full. No TBD/TODO items remain.
+
+**3. Type consistency** — `collectAllTerminalIds(layouts: Record<string, PaneNode | undefined>): Set<string>` (Task 1) matches its uses in Task 4; `markTerminalReleased`/`consumeTerminalReleaseMark`/`resetTerminalReleaseMarks` (Task 2) match Tasks 3-4 and the dom.ts wiring; `sendTerminalKill(terminalId: string): void` (Task 3) matches Tasks 6, 8, 9; `terminalDetachMiddleware: Middleware` (Task 4) matches every concat site (Tasks 5-8, 10).

--- a/src/components/BackgroundSessions.tsx
+++ b/src/components/BackgroundSessions.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect } from 'react'
 import { nanoid } from 'nanoid'
-import { getWsClient } from '@/lib/ws-client'
+import { sendTerminalKill } from '@/lib/terminal-kill'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
@@ -22,7 +22,6 @@ function formatAge(ms: number): string {
 
 export default function BackgroundSessions() {
   const dispatch = useAppDispatch()
-  const ws = useMemo(() => getWsClient(), [])
   const terminals = useAppSelector((state) => (
     (state as any).terminalDirectory?.windows?.background?.items ?? EMPTY_TERMINALS
   )) as BackgroundTerminal[]
@@ -117,7 +116,7 @@ export default function BackgroundSessions() {
                   <Button
                     size="sm"
                     variant="destructive"
-                    onClick={() => ws.send({ type: 'terminal.kill', terminalId: t.terminalId })}
+                    onClick={() => sendTerminalKill(t.terminalId)}
                   >
                     Kill
                   </Button>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -3,8 +3,8 @@ import { cn } from '@/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { addTab, closeTab, setActiveTab, reorderTabs, clearTabRenameRequest } from '@/store/tabsSlice'
 import { dismissTabGreen } from '@/store/turnCompletionAttention'
-import { getWsClient } from '@/lib/ws-client'
 import { getTabDisplayTitle } from '@/lib/tab-title'
+import { sendTerminalKill } from '@/lib/terminal-kill'
 import { collectPaneEntries, collectTerminalIds } from '@/lib/pane-utils'
 import { getBusyPaneIdsForTab } from '@/lib/pane-activity'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -179,8 +179,6 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
   const multirowTabs = useAppSelector((s) => s.settings?.settings?.panes?.multirowTabs ?? false)
   const extensions = useAppSelector((s) => s.extensions?.entries)
 
-  const ws = useMemo(() => getWsClient(), [])
-
   // Compute display title for a single tab
   // Priority: user-set title > programmatically-set title (e.g., from Claude) > derived name
   const getDisplayTitle = useCallback(
@@ -310,14 +308,10 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
           }
         }}
         onClose={(e) => {
-          const terminalIds = getTerminalIdsForTab(tab)
-          if (terminalIds.length > 0) {
-            const messageType = e.shiftKey ? 'terminal.kill' : 'terminal.detach'
+          if (e.shiftKey) {
+            const terminalIds = getTerminalIdsForTab(tab)
             for (const terminalId of terminalIds) {
-              ws.send({
-                type: messageType,
-                terminalId,
-              })
+              sendTerminalKill(terminalId)
             }
           }
           dispatch(closeTab(tab.id))
@@ -350,7 +344,6 @@ export default function TabBar({ sidebarCollapsed, onToggleSidebar }: TabBarProp
     renameValue,
     renamingId,
     tabAttentionStyle,
-    ws,
   ])
 
   useEffect(() => {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -29,6 +29,7 @@ import { focusNextTerminalSearchMatch, focusPreviousTerminalSearchMatch, loadTer
 import { isFatalConnectionErrorCode } from '@/store/connectionSlice'
 import { flushPersistedLayoutNow } from '@/store/persistControl'
 import { getWsClient } from '@/lib/ws-client'
+import { sendTerminalKill } from '@/lib/terminal-kill'
 import { getTerminalTheme } from '@/lib/terminal-themes'
 import {
   buildCodexIdentityMismatchRepairContent,
@@ -2907,7 +2908,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       lastSentViewportRef.current = null
       applySeqState(createAttachSeqState())
       writeLocalXtermNotice(term, '\r\n[Restarting OpenCode session because the saved terminal replay is no longer available]\r\n')
-      ws.send({ type: 'terminal.kill', terminalId })
+      sendTerminalKill(terminalId)
       return true
     }
 

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -66,7 +66,7 @@ import {
   type DeferredAttachReason,
   type TerminalAttachPriority,
 } from '@/lib/terminal-attach-policy'
-import { paneRefreshTargetMatchesContent } from '@/lib/pane-utils'
+import { collectAllTerminalIds, paneRefreshTargetMatchesContent } from '@/lib/pane-utils'
 import { getInstalledPerfAuditBridge } from '@/lib/perf-audit-bridge'
 import {
   beginAttach,
@@ -2434,6 +2434,13 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     opts?: AttachTerminalOptions,
   ) => {
     if (suppressNetworkEffects) return
+    // Never attach a terminal the layouts no longer reference: the layout-diff
+    // middleware can only release subscriptions it saw acquired. Covers the
+    // close-during-create race and stale deferred re-attach timers.
+    const layouts = appStore.getState().panes.layouts
+    if (!collectAllTerminalIds(layouts).has(tid)) {
+      return
+    }
     const term = termRef.current
     if (!term) return
     const runtime = runtimeRef.current
@@ -2581,6 +2588,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
   }, [
     suppressNetworkEffects,
     ws,
+    appStore,
     applySeqState,
     buildCheckpointReplayInput,
     clearQuarantineRepair,

--- a/src/components/context-menu/ContextMenuProvider.tsx
+++ b/src/components/context-menu/ContextMenuProvider.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/store/panesSlice'
 import { setProjectExpanded } from '@/store/sessionsSlice'
 import { getWsClient } from '@/lib/ws-client'
+import { sendTerminalKill } from '@/lib/terminal-kill'
 import { api, setSessionMetadata } from '@/lib/api'
 import { refreshActiveSessionWindow } from '@/store/sessionsThunks'
 import { getAuthToken } from '@/lib/auth'
@@ -295,24 +296,12 @@ export function ContextMenuProvider({
   }, [dispatch])
 
   const replacePaneAction = useCallback((tabId: string, paneId: string) => {
-    if (!panes[tabId]) return
-    const content = findPaneContent(panes[tabId], paneId)
-    if (content?.kind === 'terminal' && content.terminalId) {
-      ws.send({ type: 'terminal.detach', terminalId: content.terminalId })
-    }
     dispatch(replacePane({ tabId, paneId }))
-  }, [dispatch, panes, ws])
+  }, [dispatch])
 
   const closeTabById = useCallback((tabId: string) => {
-    const layout = panes[tabId]
-    if (layout) {
-      const terminalIds = collectTerminalIds(layout)
-      for (const terminalId of terminalIds) {
-        ws.send({ type: 'terminal.detach', terminalId })
-      }
-    }
     dispatch(closeTab(tabId))
-  }, [dispatch, panes, ws])
+  }, [dispatch])
 
   const reopenClosedTabAction = useCallback(() => {
     dispatch(reopenClosedTab())
@@ -927,7 +916,7 @@ export function ContextMenuProvider({
     )
 
     if (latest.content.kind === 'terminal' && latest.content.terminalId) {
-      ws.send({ type: 'terminal.kill', terminalId: latest.content.terminalId })
+      sendTerminalKill(latest.content.terminalId)
     } else if (latest.content.kind === 'fresh-agent' && latest.content.sessionId) {
       const cwd = getFreshOpenCodeRouteCwd(
         latest.content,
@@ -1221,10 +1210,6 @@ export function ContextMenuProvider({
         resetSplit: (tabId, splitId) => dispatch(resetSplit({ tabId, splitId })),
         swapSplit: (tabId, splitId) => dispatch(swapSplit({ tabId, splitId })),
         closePane: (tabId, paneId) => {
-          const content = panes[tabId] ? findPaneContent(panes[tabId], paneId) : null
-          if (content?.kind === 'terminal' && content.terminalId) {
-            ws.send({ type: 'terminal.detach', terminalId: content.terminalId })
-          }
           dispatch(closePaneWithCleanup({ tabId, paneId }))
         },
         getTerminalActions: getTerminalActions,

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -335,13 +335,8 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
   }, [])
 
   const handleClose = useCallback((paneId: string, content: PaneContent) => {
-    // Clean up terminal process if this pane has one
-    if (content.kind === 'terminal' && content.terminalId) {
-      ws.send({
-        type: 'terminal.detach',
-        terminalId: content.terminalId,
-      })
-    }
+    // Terminal detach is handled by terminalDetachMiddleware, which reconciles
+    // dropped terminal references on the resulting layout change.
     if (content.kind === 'fresh-agent') {
       clearDraft(paneId)
       const pendingCreate = freshAgentPendingCreates[content.createRequestId]

--- a/src/lib/pane-utils.ts
+++ b/src/lib/pane-utils.ts
@@ -41,6 +41,24 @@ export function collectTerminalIds(node: PaneNode): string[] {
   ]
 }
 
+/**
+ * Union of every terminalId referenced by any pane in any tab layout.
+ * This is the client's complete "terminals I currently reference" set —
+ * the primitive the detach middleware diffs to spot dropped references.
+ */
+export function collectAllTerminalIds(
+  layouts: Record<string, PaneNode | undefined>
+): Set<string> {
+  const ids = new Set<string>()
+  for (const layout of Object.values(layouts)) {
+    if (!layout) continue
+    for (const terminalId of collectTerminalIds(layout)) {
+      ids.add(terminalId)
+    }
+  }
+  return ids
+}
+
 export function collectPaneContents(node: PaneNode): PaneContent[] {
   if (node.type === 'leaf') {
     return [node.content]

--- a/src/lib/terminal-kill.ts
+++ b/src/lib/terminal-kill.ts
@@ -1,0 +1,14 @@
+import { getWsClient } from './ws-client'
+import { markTerminalReleased } from './terminal-release-marks'
+
+/**
+ * Send terminal.kill for a terminal, marking it released first so the
+ * detach middleware does not follow up with a redundant terminal.detach
+ * when the pane reference disappears from the layouts.
+ *
+ * Every terminal.kill send in the client goes through here.
+ */
+export function sendTerminalKill(terminalId: string): void {
+  markTerminalReleased(terminalId)
+  getWsClient().send({ type: 'terminal.kill', terminalId })
+}

--- a/src/lib/terminal-kill.ts
+++ b/src/lib/terminal-kill.ts
@@ -6,7 +6,8 @@ import { markTerminalReleased } from './terminal-release-marks'
  * detach middleware does not follow up with a redundant terminal.detach
  * when the pane reference disappears from the layouts.
  *
- * Every terminal.kill send in the client goes through here.
+ * Every production terminal.kill send in the client goes through here.
+ * (Test harness escape hatch sendWsMessage in App.tsx can bypass it.)
  */
 export function sendTerminalKill(terminalId: string): void {
   markTerminalReleased(terminalId)

--- a/src/lib/terminal-release-marks.ts
+++ b/src/lib/terminal-release-marks.ts
@@ -7,6 +7,9 @@
  *
  * Terminal ids are server-generated and never reused, so a stale mark can
  * only ever suppress a detach for a terminal that no longer needs one.
+ * Marks for terminals never referenced by any layout (e.g. background session
+ * kills) are intentionally left unconsumed — benign because terminal ids are
+ * never reused.
  */
 const releasedTerminalIds = new Set<string>()
 

--- a/src/lib/terminal-release-marks.ts
+++ b/src/lib/terminal-release-marks.ts
@@ -1,0 +1,23 @@
+/**
+ * Terminal ids whose server-side subscription has already been (or is about
+ * to be) released by an explicit send — currently terminal.kill. The detach
+ * middleware consumes a mark instead of sending a redundant terminal.detach
+ * for a terminal the server just removed (the server replies with an error
+ * for detach on a non-existent terminal).
+ *
+ * Terminal ids are server-generated and never reused, so a stale mark can
+ * only ever suppress a detach for a terminal that no longer needs one.
+ */
+const releasedTerminalIds = new Set<string>()
+
+export function markTerminalReleased(terminalId: string): void {
+  releasedTerminalIds.add(terminalId)
+}
+
+export function consumeTerminalReleaseMark(terminalId: string): boolean {
+  return releasedTerminalIds.delete(terminalId)
+}
+
+export function resetTerminalReleaseMarks(): void {
+  releasedTerminalIds.clear()
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -26,6 +26,7 @@ import { sessionActivityPersistMiddleware } from './sessionActivityPersistence'
 import { browserPreferencesPersistenceMiddleware } from './browserPreferencesPersistence'
 import { createLogger } from '@/lib/client-logger'
 import { layoutMirrorMiddleware } from './layoutMirrorMiddleware'
+import { terminalDetachMiddleware } from './terminalDetachMiddleware'
 import { serverSettingsSaveStateMiddleware } from './settingsThunks'
 import { tabFallbackIdentityMiddleware } from './tabFallbackIdentityMiddleware'
 import {
@@ -73,6 +74,7 @@ export const store = configureStore({
       serverSettingsSaveStateMiddleware,
       browserPreferencesPersistenceMiddleware,
       layoutMirrorMiddleware,
+      terminalDetachMiddleware,
       sessionActivityPersistMiddleware,
     ),
 })

--- a/src/store/terminalDetachMiddleware.ts
+++ b/src/store/terminalDetachMiddleware.ts
@@ -1,0 +1,54 @@
+import type { Middleware } from '@reduxjs/toolkit'
+import { getWsClient } from '@/lib/ws-client'
+import { collectAllTerminalIds } from '@/lib/pane-utils'
+import { consumeTerminalReleaseMark } from '@/lib/terminal-release-marks'
+import { clearDeadTerminals, clearTerminalLiveHandles } from './panesSlice'
+import type { PaneNode } from './paneTypes'
+
+type PanesStateSlice = { panes: { layouts: Record<string, PaneNode | undefined> } }
+
+/**
+ * These actions strip terminalIds ONLY for terminals the server itself
+ * reported dead or unrecoverable (terminal.inventory / terminals.changed).
+ * There is no live subscription to release, and the server replies with an
+ * error for terminal.detach on a non-existent terminal — so skip them.
+ */
+const skipDetachActionTypes = new Set<string>([
+  clearDeadTerminals.type,
+  clearTerminalLiveHandles.type,
+])
+
+/**
+ * Detach reconciler: whenever an action makes a terminalId disappear from
+ * ALL pane layouts, the client no longer references that terminal and must
+ * release its server-side attach subscription — otherwise the server sees
+ * hasClients=true forever and its idle reaper can never collect the
+ * terminal. The set diff over every layout is what guards the multi-pane
+ * case: a terminal referenced by two panes only detaches when the LAST
+ * reference goes away.
+ *
+ * Stateless by design (derives everything from getState) — safe under the
+ * test suite's per-test ws-client reset.
+ */
+export const terminalDetachMiddleware: Middleware = (store) => (next) => (action) => {
+  const beforeLayouts = (store.getState() as PanesStateSlice).panes.layouts
+  const result = next(action)
+  const afterLayouts = (store.getState() as PanesStateSlice).panes.layouts
+  if (afterLayouts === beforeLayouts) return result
+
+  const actionType = (action as { type?: unknown }).type
+  if (typeof actionType === 'string' && skipDetachActionTypes.has(actionType)) {
+    return result
+  }
+
+  const before = collectAllTerminalIds(beforeLayouts)
+  if (before.size === 0) return result
+  const after = collectAllTerminalIds(afterLayouts)
+
+  for (const terminalId of before) {
+    if (after.has(terminalId)) continue
+    if (consumeTerminalReleaseMark(terminalId)) continue
+    getWsClient().send({ type: 'terminal.detach', terminalId })
+  }
+  return result
+}

--- a/test/e2e/replace-pane.test.tsx
+++ b/test/e2e/replace-pane.test.tsx
@@ -189,7 +189,7 @@ describe('replace pane (e2e)', () => {
       // Verify tab.terminalId is set
       expect(store.getState().tabs.tabs[0].terminalId).toBe('term-1')
 
-      // Simulate what replacePaneAction does: detach + clear stale tab.terminalId + dispatch
+      // Simulate what replacePaneAction does: clear stale tab.terminalId + dispatch (terminalDetachMiddleware emits detach)
       const content = findPaneContent(store.getState().panes.layouts['tab-1'], 'pane-1')
       if (content?.kind === 'terminal' && content.terminalId) {
         const tab = store.getState().tabs.tabs.find((t) => t.id === 'tab-1')
@@ -270,7 +270,7 @@ describe('replace pane (e2e)', () => {
       }
       const store = createStore(layout, { tabTerminalId: 'term-1' })
 
-      // Simulate PaneContainer.handleClose: detach + clear stale + dispatch closePane
+      // Simulate PaneContainer.handleClose: clear stale + dispatch closePane (terminalDetachMiddleware emits detach)
       const content = findPaneContent(store.getState().panes.layouts['tab-1'], 'pane-1')
       if (content?.kind === 'terminal' && content.terminalId) {
         const tab = store.getState().tabs.tabs.find((t) => t.id === 'tab-1')

--- a/test/e2e/replace-pane.test.tsx
+++ b/test/e2e/replace-pane.test.tsx
@@ -5,6 +5,7 @@ import panesReducer, { closePane, replacePane, updatePaneTitle } from '@/store/p
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import connectionReducer from '@/store/connectionSlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
+import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
 import { findPaneContent } from '@/lib/pane-utils'
 import type { PaneNode } from '@/store/paneTypes'
 
@@ -33,6 +34,7 @@ function createStore(layout: PaneNode, opts?: { paneTitleSetByUser?: Record<stri
       connection: connectionReducer,
       turnCompletion: turnCompletionReducer,
     },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(terminalDetachMiddleware),
     preloadedState: {
       tabs: {
         tabs: [
@@ -100,12 +102,8 @@ describe('replace pane (e2e)', () => {
     }
     const store = createStore(layout)
 
-    // Simulate what ContextMenuProvider does: detach terminal, then dispatch replacePane
     const paneContent = findPaneContent(store.getState().panes.layouts['tab-1'], 'pane-1')
     expect(paneContent?.kind).toBe('terminal')
-    if (paneContent?.kind === 'terminal' && paneContent.terminalId) {
-      wsMocks.send({ type: 'terminal.detach', terminalId: paneContent.terminalId })
-    }
     store.dispatch(replacePane({ tabId: 'tab-1', paneId: 'pane-1' }))
 
     // Verify terminal.detach was sent
@@ -194,13 +192,15 @@ describe('replace pane (e2e)', () => {
       // Simulate what replacePaneAction does: detach + clear stale tab.terminalId + dispatch
       const content = findPaneContent(store.getState().panes.layouts['tab-1'], 'pane-1')
       if (content?.kind === 'terminal' && content.terminalId) {
-        wsMocks.send({ type: 'terminal.detach', terminalId: content.terminalId })
         const tab = store.getState().tabs.tabs.find((t) => t.id === 'tab-1')
         if (tab?.terminalId === content.terminalId) {
           store.dispatch(updateTab({ id: 'tab-1', updates: { terminalId: undefined } }))
         }
       }
       store.dispatch(replacePane({ tabId: 'tab-1', paneId: 'pane-1' }))
+
+      // Verify terminal.detach was sent (by the middleware)
+      expect(wsMocks.send).toHaveBeenCalledWith({ type: 'terminal.detach', terminalId: 'term-1' })
 
       // tab.terminalId should be cleared
       expect(store.getState().tabs.tabs[0].terminalId).toBeUndefined()
@@ -273,13 +273,15 @@ describe('replace pane (e2e)', () => {
       // Simulate PaneContainer.handleClose: detach + clear stale + dispatch closePane
       const content = findPaneContent(store.getState().panes.layouts['tab-1'], 'pane-1')
       if (content?.kind === 'terminal' && content.terminalId) {
-        wsMocks.send({ type: 'terminal.detach', terminalId: content.terminalId })
         const tab = store.getState().tabs.tabs.find((t) => t.id === 'tab-1')
         if (tab?.terminalId === content.terminalId) {
           store.dispatch(updateTab({ id: 'tab-1', updates: { terminalId: undefined } }))
         }
       }
       store.dispatch(closePane({ tabId: 'tab-1', paneId: 'pane-1' }))
+
+      // Verify terminal.detach was sent (by the middleware)
+      expect(wsMocks.send).toHaveBeenCalledWith({ type: 'terminal.detach', terminalId: 'term-1' })
 
       // tab.terminalId should be cleared
       expect(store.getState().tabs.tabs[0].terminalId).toBeUndefined()

--- a/test/e2e/tab-focus-behavior.test.tsx
+++ b/test/e2e/tab-focus-behavior.test.tsx
@@ -10,6 +10,7 @@ import connectionReducer from '@/store/connectionSlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
 import TabBar from '@/components/TabBar'
 import TerminalView from '@/components/TerminalView'
+import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
 import type { TerminalPaneContent } from '@/store/paneTypes'
 
 const wsMocks = vi.hoisted(() => ({
@@ -83,6 +84,7 @@ function createStore(activeTabId: string = 'tab-1') {
       connection: connectionReducer,
       turnCompletion: turnCompletionReducer,
     },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(terminalDetachMiddleware),
     preloadedState: {
       tabs: {
         tabs: [
@@ -243,6 +245,7 @@ describe('tab focus behavior (e2e)', () => {
         connection: connectionReducer,
         turnCompletion: turnCompletionReducer,
       },
+      middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(terminalDetachMiddleware),
       preloadedState: {
         tabs: {
           tabs: [

--- a/test/setup/dom.ts
+++ b/test/setup/dom.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/vitest'
 import { afterEach, beforeEach, vi } from 'vitest'
 import { enableMapSet } from 'immer'
 import { resetWsClientForTests } from '@/lib/ws-client'
+import { resetTerminalReleaseMarks } from '@/lib/terminal-release-marks'
 
 enableMapSet()
 
@@ -123,6 +124,7 @@ beforeEach(() => {
 
 afterEach(() => {
   resetWsClientForTests()
+  resetTerminalReleaseMarks()
   errorSpy?.mockRestore()
   errorSpy = null
 

--- a/test/unit/client/components/ContextMenuProvider.test.tsx
+++ b/test/unit/client/components/ContextMenuProvider.test.tsx
@@ -12,6 +12,7 @@ import settingsReducer from '@/store/settingsSlice'
 import extensionsReducer from '@/store/extensionsSlice'
 import tabRecencyReducer from '@/store/tabRecencySlice'
 import freshAgentReducer, { sessionInit } from '@/store/freshAgentSlice'
+import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
 import { ContextMenuProvider } from '@/components/context-menu/ContextMenuProvider'
 import type { ClientExtensionEntry } from '@shared/extension-types'
 
@@ -564,7 +565,7 @@ function createStoreWithTerminalPane() {
       extensions: extensionsReducer,
     },
     middleware: (getDefaultMiddleware) =>
-      getDefaultMiddleware({ serializableCheck: false }),
+      getDefaultMiddleware({ serializableCheck: false }).concat(terminalDetachMiddleware),
     preloadedState: {
       tabs: {
         tabs: [
@@ -2321,6 +2322,38 @@ describe('ContextMenuProvider', () => {
 
       // Verify pane content no longer has the old terminal
       // (tab.terminalId was removed; terminal ownership is in pane content only)
+    })
+
+    it('sends exactly one terminal.detach when replacing a pane via context menu', async () => {
+      const user = userEvent.setup()
+      wsMocks.send.mockClear()
+
+      const store = createStoreWithTerminalPane()
+
+      render(
+        <Provider store={store}>
+          <ContextMenuProvider
+            view="terminal"
+            onViewChange={() => {}}
+            onToggleSidebar={() => {}}
+            sidebarCollapsed={false}
+          >
+            <div data-context={ContextIds.Terminal} data-tab-id="tab-1" data-pane-id="pane-1">
+              Terminal Content
+            </div>
+          </ContextMenuProvider>
+        </Provider>
+      )
+
+      await user.pointer({ target: screen.getByText('Terminal Content'), keys: '[MouseRight]' })
+      expect(screen.getByRole('menu')).toBeInTheDocument()
+
+      await user.click(screen.getByRole('menuitem', { name: 'Replace pane' }))
+
+      const detachMessages = wsMocks.send.mock.calls
+        .map(([msg]) => msg as { type?: string; terminalId?: string })
+        .filter((msg) => msg?.type === 'terminal.detach')
+      expect(detachMessages).toHaveLength(1)
     })
 
   })

--- a/test/unit/client/components/TabBar.test.tsx
+++ b/test/unit/client/components/TabBar.test.tsx
@@ -9,6 +9,7 @@ import opencodeActivityReducer, { type OpencodeActivityState } from '@/store/ope
 import panesReducer from '@/store/panesSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
+import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
 import type { Tab } from '@/store/types'
 import type { PaneNode } from '@/store/paneTypes'
 import {
@@ -149,6 +150,7 @@ function createStore(
       settings: settingsReducer,
       turnCompletion: turnCompletionReducer,
     },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(terminalDetachMiddleware),
     preloadedState: {
       tabs: {
         tabs: [],
@@ -666,6 +668,85 @@ describe('TabBar', () => {
         type: 'terminal.kill',
         terminalId: 'term-456',
       })
+    })
+
+    it('plain close sends exactly one terminal.detach per terminal', () => {
+      const tab = createTab({
+        id: 'tab-1',
+        title: 'Tab 1',
+      })
+
+      const store = createStore(
+        { tabs: [tab], activeTabId: 'tab-1' },
+        {},
+        {
+          layouts: {
+            'tab-1': {
+              type: 'leaf',
+              id: 'pane-1',
+              content: {
+                kind: 'terminal',
+                mode: 'shell',
+                shell: 'system',
+                status: 'running',
+                createRequestId: 'req-pane-1',
+                terminalId: 'term-123',
+              },
+            },
+          },
+          activePane: { 'tab-1': 'pane-1' },
+        },
+      )
+
+      renderWithStore(<TabBar />, store)
+
+      const closeButton = screen.getByTitle('Close (Shift+Click to kill)')
+      fireEvent.click(closeButton)
+
+      const detachMessages = mockSend.mock.calls
+        .map(([msg]) => msg as { type?: string; terminalId?: string })
+        .filter((msg) => msg?.type === 'terminal.detach')
+      expect(detachMessages).toEqual([{ type: 'terminal.detach', terminalId: 'term-123' }])
+    })
+
+    it('shift close sends terminal.kill and no terminal.detach', () => {
+      const tab = createTab({
+        id: 'tab-1',
+        title: 'Tab 1',
+      })
+
+      const store = createStore(
+        { tabs: [tab], activeTabId: 'tab-1' },
+        {},
+        {
+          layouts: {
+            'tab-1': {
+              type: 'leaf',
+              id: 'pane-1',
+              content: {
+                kind: 'terminal',
+                mode: 'shell',
+                shell: 'system',
+                status: 'running',
+                createRequestId: 'req-pane-1',
+                terminalId: 'term-456',
+              },
+            },
+          },
+          activePane: { 'tab-1': 'pane-1' },
+        },
+      )
+
+      renderWithStore(<TabBar />, store)
+
+      const closeButton = screen.getByTitle('Close (Shift+Click to kill)')
+      fireEvent.click(closeButton, { shiftKey: true })
+
+      const sentTypes = mockSend.mock.calls
+        .map(([msg]) => (msg as { type?: string })?.type)
+      expect(sentTypes).toContain('terminal.kill')
+      expect(sentTypes).not.toContain('terminal.detach')
+      expect(mockSend).toHaveBeenCalledWith({ type: 'terminal.kill', terminalId: 'term-456' })
     })
 
     it('close button detaches every terminal in split pane layout', () => {

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -3,7 +3,7 @@ import { act, render, cleanup, waitFor } from '@testing-library/react'
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
 import tabsReducer, { setActiveTab } from '@/store/tabsSlice'
-import panesReducer, { requestPaneRefresh } from '@/store/panesSlice'
+import panesReducer, { removeLayout, requestPaneRefresh } from '@/store/panesSlice'
 import settingsReducer, { defaultSettings, updateSettingsLocal } from '@/store/settingsSlice'
 import connectionReducer, { setStatus as setConnectionStatus } from '@/store/connectionSlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
@@ -3883,6 +3883,37 @@ describe('TerminalView lifecycle updates', () => {
         rows: expect.any(Number),
         attachRequestId: expect.any(String),
       }))
+    })
+
+    it('does not attach when the pane was removed before terminal.created arrives', async () => {
+      const { requestId, store, tabId } = await renderTerminalHarness({
+        status: 'creating',
+        hidden: false,
+        clearSends: false,
+        requestId: 'req-v2-close-race',
+      })
+
+      expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'terminal.create',
+        requestId,
+      }))
+
+      // Pane closed after the create was sent but before terminal.created arrives:
+      // the tab's layout is removed, so the layouts never reference the new id.
+      act(() => {
+        store.dispatch(removeLayout({ tabId }))
+      })
+
+      wsMocks.send.mockClear()
+      const newId = 'term-close-race-1'
+      act(() => {
+        messageHandler!({ type: 'terminal.created', requestId, terminalId: newId, createdAt: Date.now() })
+      })
+
+      const attachMessages = wsMocks.send.mock.calls
+        .map(([msg]) => msg as { type?: string; terminalId?: string })
+        .filter((msg) => msg?.type === 'terminal.attach' && msg.terminalId === newId)
+      expect(attachMessages).toHaveLength(0)
     })
 
     it('terminal.created always triggers explicit attach with viewport', async () => {

--- a/test/unit/client/components/TerminalView.visibility.test.tsx
+++ b/test/unit/client/components/TerminalView.visibility.test.tsx
@@ -7,7 +7,7 @@ import panesReducer from '@/store/panesSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import connectionReducer from '@/store/connectionSlice'
 import sessionActivityReducer from '@/store/sessionActivitySlice'
-import type { TerminalPaneContent } from '@/store/paneTypes'
+import type { PaneNode, TerminalPaneContent } from '@/store/paneTypes'
 
 const wsMocks = vi.hoisted(() => ({
   send: vi.fn(),
@@ -85,7 +85,7 @@ vi.mock('@/components/terminal/terminal-runtime', () => ({
 // Must import after mocks
 import TerminalView from '@/components/TerminalView'
 
-function createStore() {
+function createStore(layouts: Record<string, PaneNode> = {}) {
   return configureStore({
     reducer: {
       tabs: tabsReducer,
@@ -106,7 +106,7 @@ function createStore() {
         activeTabId: 'tab-1',
       },
       panes: {
-        layouts: {},
+        layouts,
         activePane: {},
         paneTitles: {},
       },
@@ -190,8 +190,13 @@ describe('TerminalView visibility CSS classes', () => {
     const cancelRafSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
 
     try {
-      const store = createStore()
       const content = { ...createTerminalContent(), terminalId: 'term-1' }
+      // The attach gate (layout-membership check) requires the terminal id to be
+      // referenced by the layouts, matching the production invariant that a
+      // rendered pane's terminal always appears in the layout tree.
+      const store = createStore({
+        'tab-1': { type: 'leaf', id: 'pane-1', content },
+      })
       const { rerender } = render(
         <Provider store={store}>
           <TerminalView tabId="tab-1" paneId="pane-1" paneContent={content} hidden={true} />

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -20,6 +20,7 @@ import type { FreshAgentSessionState, FreshAgentState } from '@/store/freshAgent
 import type { FreshAgentSnapshot } from '@shared/fresh-agent-contract'
 import type { ClientExtensionEntry } from '@shared/extension-types'
 import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
+import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
 
 const defaultCliExtensions: ClientExtensionEntry[] = [
   {
@@ -323,7 +324,7 @@ function createStore(
         serializableCheck: {
           ignoredPaths: ['sessions.expandedProjects'],
         },
-      }),
+      }).concat(terminalDetachMiddleware),
     preloadedState: {
       panes: {
         layouts: {},
@@ -461,6 +462,50 @@ describe('PaneContainer', () => {
         type: 'terminal.detach',
         terminalId: terminalId,
       })
+    })
+
+    it('sends exactly one terminal.detach when closing a pane with terminalId', () => {
+      const pane1Id = 'pane-1'
+      const pane2Id = 'pane-2'
+      const terminalId = 'term-123'
+
+      const rootNode: PaneNode = {
+        type: 'split',
+        id: 'split-1',
+        direction: 'horizontal',
+        sizes: [50, 50],
+        children: [
+          {
+            type: 'leaf',
+            id: pane1Id,
+            content: createTerminalContent({ terminalId }),
+          },
+          {
+            type: 'leaf',
+            id: pane2Id,
+            content: createTerminalContent({ terminalId: 'term-456' }),
+          },
+        ],
+      }
+
+      const store = createStore({
+        layouts: { 'tab-1': rootNode },
+        activePane: { 'tab-1': pane1Id },
+      })
+
+      renderWithStore(
+        <PaneContainer tabId="tab-1" node={rootNode} />,
+        store
+      )
+
+      // Click the close button on the first pane
+      const closeButtons = screen.getAllByTitle('Close pane')
+      fireEvent.click(closeButtons[0])
+
+      const detachMessages = mockSend.mock.calls
+        .map(([msg]) => msg as { type?: string; terminalId?: string })
+        .filter((msg) => msg?.type === 'terminal.detach')
+      expect(detachMessages).toHaveLength(1)
     })
 
     it('does not send terminal.detach when closing a pane without terminalId', () => {

--- a/test/unit/client/lib/collect-all-terminal-ids.test.ts
+++ b/test/unit/client/lib/collect-all-terminal-ids.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { collectAllTerminalIds } from '@/lib/pane-utils'
+import type { PaneNode } from '@/store/paneTypes'
+
+function terminalLeaf(paneId: string, terminalId?: string): PaneNode {
+  return {
+    type: 'leaf',
+    id: paneId,
+    content: {
+      kind: 'terminal',
+      mode: 'shell',
+      status: 'running',
+      createRequestId: `req-${paneId}`,
+      ...(terminalId ? { terminalId } : {}),
+    },
+  }
+}
+
+describe('collectAllTerminalIds', () => {
+  it('returns an empty set for no layouts', () => {
+    expect(collectAllTerminalIds({})).toEqual(new Set())
+  })
+
+  it('collects ids across multiple tab layouts', () => {
+    const layouts: Record<string, PaneNode | undefined> = {
+      'tab-1': terminalLeaf('pane-1', 'term-a'),
+      'tab-2': terminalLeaf('pane-2', 'term-b'),
+    }
+    expect(collectAllTerminalIds(layouts)).toEqual(new Set(['term-a', 'term-b']))
+  })
+
+  it('walks split trees', () => {
+    const layouts: Record<string, PaneNode | undefined> = {
+      'tab-1': {
+        type: 'split',
+        id: 'split-1',
+        direction: 'horizontal',
+        sizes: [50, 50],
+        children: [terminalLeaf('pane-1', 'term-a'), terminalLeaf('pane-2', 'term-b')],
+      },
+    }
+    expect(collectAllTerminalIds(layouts)).toEqual(new Set(['term-a', 'term-b']))
+  })
+
+  it('dedupes a terminal referenced by two layouts', () => {
+    const layouts: Record<string, PaneNode | undefined> = {
+      'tab-1': terminalLeaf('pane-1', 'term-dup'),
+      'tab-2': terminalLeaf('pane-2', 'term-dup'),
+    }
+    expect(collectAllTerminalIds(layouts)).toEqual(new Set(['term-dup']))
+  })
+
+  it('ignores undefined layouts, non-terminal panes, and terminals without ids', () => {
+    const layouts: Record<string, PaneNode | undefined> = {
+      'tab-1': undefined,
+      'tab-2': { type: 'leaf', id: 'pane-x', content: { kind: 'picker' } },
+      'tab-3': terminalLeaf('pane-y'), // no terminalId yet (creating)
+    }
+    expect(collectAllTerminalIds(layouts)).toEqual(new Set())
+  })
+})

--- a/test/unit/client/lib/terminal-kill.test.ts
+++ b/test/unit/client/lib/terminal-kill.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { sendTerminalKill } from '@/lib/terminal-kill'
+import {
+  consumeTerminalReleaseMark,
+  resetTerminalReleaseMarks,
+} from '@/lib/terminal-release-marks'
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }))
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({ send: mockSend }),
+}))
+
+describe('sendTerminalKill', () => {
+  beforeEach(() => {
+    mockSend.mockClear()
+    resetTerminalReleaseMarks()
+  })
+
+  it('sends the terminal.kill message', () => {
+    sendTerminalKill('term-1')
+    expect(mockSend).toHaveBeenCalledWith({ type: 'terminal.kill', terminalId: 'term-1' })
+  })
+
+  it('marks the terminal released before sending', () => {
+    sendTerminalKill('term-1')
+    expect(consumeTerminalReleaseMark('term-1')).toBe(true)
+  })
+})

--- a/test/unit/client/lib/terminal-release-marks.test.ts
+++ b/test/unit/client/lib/terminal-release-marks.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  markTerminalReleased,
+  consumeTerminalReleaseMark,
+  resetTerminalReleaseMarks,
+} from '@/lib/terminal-release-marks'
+
+describe('terminal release marks', () => {
+  beforeEach(() => {
+    resetTerminalReleaseMarks()
+  })
+
+  it('consume returns false for an unmarked terminal', () => {
+    expect(consumeTerminalReleaseMark('term-1')).toBe(false)
+  })
+
+  it('consume returns true exactly once for a marked terminal', () => {
+    markTerminalReleased('term-1')
+    expect(consumeTerminalReleaseMark('term-1')).toBe(true)
+    expect(consumeTerminalReleaseMark('term-1')).toBe(false)
+  })
+
+  it('marks are independent per terminal id', () => {
+    markTerminalReleased('term-1')
+    expect(consumeTerminalReleaseMark('term-2')).toBe(false)
+    expect(consumeTerminalReleaseMark('term-1')).toBe(true)
+  })
+
+  it('reset clears all marks', () => {
+    markTerminalReleased('term-1')
+    resetTerminalReleaseMarks()
+    expect(consumeTerminalReleaseMark('term-1')).toBe(false)
+  })
+})

--- a/test/unit/client/store/storeDetachRegistration.test.ts
+++ b/test/unit/client/store/storeDetachRegistration.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }))
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({
+    send: mockSend,
+    connect: vi.fn().mockResolvedValue(undefined),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    onReconnect: vi.fn().mockReturnValue(() => {}),
+    onDisconnect: vi.fn().mockReturnValue(() => {}),
+  }),
+  resetWsClientForTests: vi.fn(),
+}))
+
+import { store } from '@/store/store'
+import { initLayout, removeLayout } from '@/store/panesSlice'
+
+describe('production store', () => {
+  it('registers terminalDetachMiddleware (removing a layout emits terminal.detach)', () => {
+    store.dispatch(initLayout({
+      tabId: 'detach-reg-tab',
+      paneId: 'detach-reg-pane',
+      content: {
+        kind: 'terminal',
+        mode: 'shell',
+        status: 'running',
+        terminalId: 'detach-reg-term',
+        createRequestId: 'detach-reg-req',
+      },
+    }))
+    mockSend.mockClear()
+    store.dispatch(removeLayout({ tabId: 'detach-reg-tab' }))
+    expect(mockSend).toHaveBeenCalledWith({ type: 'terminal.detach', terminalId: 'detach-reg-term' })
+  })
+})

--- a/test/unit/client/store/terminalDetachMiddleware.test.ts
+++ b/test/unit/client/store/terminalDetachMiddleware.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+import panesReducer, {
+  initLayout,
+  updatePaneContent,
+  splitPane,
+  closePane,
+  replacePane,
+  removeLayout,
+  clearDeadTerminals,
+  clearTerminalLiveHandles,
+  repairCodexIdentityMismatch,
+} from '@/store/panesSlice'
+import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
+import {
+  markTerminalReleased,
+  resetTerminalReleaseMarks,
+} from '@/lib/terminal-release-marks'
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }))
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({ send: mockSend }),
+}))
+
+function createStore() {
+  return configureStore({
+    reducer: { panes: panesReducer },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(terminalDetachMiddleware),
+  })
+}
+
+function terminalContent(terminalId: string, createRequestId = `req-${terminalId}`) {
+  return {
+    kind: 'terminal' as const,
+    mode: 'shell' as const,
+    status: 'running' as const,
+    terminalId,
+    createRequestId,
+  }
+}
+
+function detachedIds(): string[] {
+  return mockSend.mock.calls
+    .map(([msg]) => msg as { type?: string; terminalId?: string })
+    .filter((msg) => msg?.type === 'terminal.detach')
+    .map((msg) => msg.terminalId as string)
+}
+
+beforeEach(() => {
+  mockSend.mockClear()
+  resetTerminalReleaseMarks()
+})
+
+describe('terminalDetachMiddleware', () => {
+  it('does not send anything when layouts only grow', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-a') }))
+    store.dispatch(splitPane({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      direction: 'horizontal',
+      newContent: terminalContent('term-b'),
+      newPaneId: 'pane-2',
+    }))
+    expect(detachedIds()).toEqual([])
+  })
+
+  it('does not send anything for actions that do not touch pane layouts', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-a') }))
+    mockSend.mockClear()
+    store.dispatch({ type: 'test/noop' })
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('detaches the old terminal when a pane is re-pointed to a new terminal', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-old') }))
+    mockSend.mockClear()
+    store.dispatch(updatePaneContent({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-new') }))
+    expect(detachedIds()).toEqual(['term-old'])
+  })
+
+  it('detaches when a pane is replaced with the picker', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-a') }))
+    mockSend.mockClear()
+    store.dispatch(replacePane({ tabId: 'tab-1', paneId: 'pane-1' }))
+    expect(detachedIds()).toEqual(['term-a'])
+  })
+
+  it('detaches when a split pane is closed', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-a') }))
+    store.dispatch(splitPane({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      direction: 'horizontal',
+      newContent: terminalContent('term-b'),
+      newPaneId: 'pane-2',
+    }))
+    mockSend.mockClear()
+    store.dispatch(closePane({ tabId: 'tab-1', paneId: 'pane-2' }))
+    expect(detachedIds()).toEqual(['term-b'])
+  })
+
+  it('detaches every terminal in a removed layout (tab close cascade)', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-a') }))
+    store.dispatch(splitPane({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      direction: 'vertical',
+      newContent: terminalContent('term-b'),
+      newPaneId: 'pane-2',
+    }))
+    mockSend.mockClear()
+    store.dispatch(removeLayout({ tabId: 'tab-1' }))
+    expect(detachedIds().sort()).toEqual(['term-a', 'term-b'])
+  })
+
+  it('does NOT detach a terminal still referenced by another tab (refcount guard)', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-dup', 'req-1') }))
+    store.dispatch(initLayout({ tabId: 'tab-2', paneId: 'pane-2', content: terminalContent('term-dup', 'req-2') }))
+    mockSend.mockClear()
+    store.dispatch(removeLayout({ tabId: 'tab-1' }))
+    expect(detachedIds()).toEqual([])
+    store.dispatch(removeLayout({ tabId: 'tab-2' }))
+    expect(detachedIds()).toEqual(['term-dup'])
+  })
+
+  it('sends a single detach when one action drops multiple references to the same terminal', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-dup', 'req-1') }))
+    store.dispatch(splitPane({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      direction: 'horizontal',
+      newContent: terminalContent('term-dup', 'req-2'),
+      newPaneId: 'pane-2',
+    }))
+    mockSend.mockClear()
+    store.dispatch(removeLayout({ tabId: 'tab-1' }))
+    expect(detachedIds()).toEqual(['term-dup'])
+  })
+
+  it('skips detach for terminals dropped by clearDeadTerminals (server already reaped them)', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-dead') }))
+    mockSend.mockClear()
+    store.dispatch(clearDeadTerminals({ liveTerminalIds: [] }))
+    expect(detachedIds()).toEqual([])
+  })
+
+  it('skips detach for terminals dropped by clearTerminalLiveHandles (recoverable-loss path)', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-lost') }))
+    mockSend.mockClear()
+    store.dispatch(clearTerminalLiveHandles({ terminalIds: ['term-lost'] }))
+    expect(detachedIds()).toEqual([])
+  })
+
+  it('detaches the stale terminal on codex identity repair', () => {
+    const store = createStore()
+    // The preloaded content MUST carry a sessionRef equal to the action's
+    // expectedSessionRef: repairCodexIdentityMismatch (panesSlice.ts:1778)
+    // guards on sessionRefsEqual(node.content.sessionRef, expectedSessionRef)
+    // and no-ops otherwise, so a bare terminalContent() would never trigger
+    // the repair (and therefore never drop the reference).
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        ...terminalContent('term-stale'),
+        mode: 'codex' as const,
+        sessionRef: { provider: 'codex' as const, sessionId: 'session-1' },
+      },
+    }))
+    mockSend.mockClear()
+    store.dispatch(repairCodexIdentityMismatch({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      staleTerminalId: 'term-stale',
+      expectedSessionRef: { provider: 'codex', sessionId: 'session-1' },
+      createRequestId: 'req-repair',
+    }))
+    expect(detachedIds()).toEqual(['term-stale'])
+  })
+
+  it('skips detach for a terminal marked released (explicit kill), consuming the mark', () => {
+    const store = createStore()
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-k') }))
+    mockSend.mockClear()
+    markTerminalReleased('term-k')
+    store.dispatch(replacePane({ tabId: 'tab-1', paneId: 'pane-1' }))
+    expect(detachedIds()).toEqual([])
+
+    // The mark was consumed: a fresh reference drop for the same id detaches again.
+    store.dispatch(updatePaneContent({ tabId: 'tab-1', paneId: 'pane-1', content: terminalContent('term-k', 'req-k2') }))
+    mockSend.mockClear()
+    store.dispatch(replacePane({ tabId: 'tab-1', paneId: 'pane-1' }))
+    expect(detachedIds()).toEqual(['term-k'])
+  })
+})


### PR DESCRIPTION
## Problem

The server auto-kills idle DETACHED terminals (enforce_idle_kills, settings.safety.autoKillIdleMinutes, swept every 30s), but any attached subscriber exempts a terminal regardless of idle time. The client only sent terminal.detach on explicit tab close (TabBar); when a pane stopped referencing a terminal by any other path (pane re-point on session resume, dead-terminal recreate, pane close, unmount), the attach subscription leaked for the life of the WS connection. The server saw hasClients=true forever and never reaped. 

**Observed in production 2026-07-25:** 10 orphaned CLI terminals idle 10.8–22.6h against a 3h threshold, all with hasClients=true; a server bounce then killed them, losing session state.

## Fix (client-side only)

Replace the scattered per-site detach sends with one central store middleware (detach watcher) that diffs the pane layouts on every state change and sends terminal.detach for any terminalId that disappeared from all layouts.

**Adds:**
- A helper walking all layouts to collect referenced terminal IDs
- A "release marks" module so intentional kills don't trigger redundant detaches
- A shared kill helper used by all kill sites
- Removal of the three duplicated component-level detach sends
- An attach gate so the client never attaches to a terminal that is not present in the layout (closes a close-during-create race found during the load-bearing assumption audit)

**Unchanged:** Explicit tab-close semantics (close = detach, shift+click = kill) and server idle-kill logic remain untouched.

## Verification

✅ TDD throughout (subagent-driven, per-task spec + code-quality review)
✅ Full verification green: lint clean, typecheck clean, ~8,500 tests passing across both suites
✅ Independent whole-branch review and fresh-eyes delta review both PASSED with zero blocking issues
✅ Plan doc: docs/plans/2026-07-25-terminal-attach-leak.md

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)