### PR TITLE
chore: delete orphaned snapshot-restore lease mechanism; document legacy repair fields

### DIFF
--- a/crates/freshell-protocol/src/client_messages.rs
+++ b/crates/freshell-protocol/src/client_messages.rs
@@ -200,15 +200,27 @@ pub struct TerminalCreate {
     pub request_id: String,
     pub mode: String,
     pub shell: Shell,
+    /// Legacy client repair hint (Codex durability state). Consumed by the
+    /// legacy TS server (`server/ws-handler.ts:351-354`); deliberately ignored
+    /// by the Rust server, superseded by `pane.reconcile` verdicts. Retained
+    /// for frozen-wire compat.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub codex_durability: Option<CodexDurability>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
+    /// Legacy client repair hint (same-instance live-terminal reattach ref).
+    /// Consumed by the legacy TS server; deliberately ignored by the Rust
+    /// server, superseded by `pane.reconcile` verdicts. Retained for
+    /// frozen-wire compat.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub live_terminal: Option<LiveTerminalRef>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pane_id: Option<String>,
-    /// const `"fresh_after_restore_unavailable"`.
+    /// const `"fresh_after_restore_unavailable"`. Legacy client repair hint;
+    /// consumed by the legacy TS server; deliberately ignored by the Rust
+    /// server, superseded by `pane.reconcile` verdicts (intent documented at
+    /// `freshell-ws/src/terminal.rs:506-513`). Retained for frozen-wire
+    /// compat.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recovery_intent: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/freshell-ws/src/tabs_persist.rs
+++ b/crates/freshell-ws/src/tabs_persist.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
 use std::sync::{LazyLock, Mutex};
 
 use serde_json::{json, Value};
@@ -627,9 +628,8 @@ fn read_device_overview_locked(
 /// this module. Held across the ENTIRE read-plan-mutate cycle, so concurrent
 /// pushes to the SAME or DIFFERENT devices can never race directory
 /// enumeration, eviction, or removal — the critical data-loss defect (`:678`)
-/// — and so each reader cannot observe a half-pruned directory. A restore's
-/// eviction lease bridges its separately locked selection, marker, create,
-/// and acknowledgement operations. `Mutex::new(())` needs no lazy init.
+/// — and so each reader cannot observe a half-pruned directory.
+/// `Mutex::new(())` needs no lazy init.
 /// Restores/pushes are low-frequency and this lock guards only the filesystem
 /// cycle (in-memory registry work already dropped its own lock), so contention
 /// is negligible.
@@ -639,11 +639,6 @@ fn read_device_overview_locked(
 /// that acquires it (the pub readers self-lock and only call lock-free private
 /// helpers), so there is no nested acquisition to deadlock on.
 static PERSIST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// Device directories protected by a restore that spans multiple individually
-/// locked filesystem operations and async process/delivery work.
-static ACTIVE_RESTORE_DIRS: LazyLock<Mutex<HashMap<PathBuf, usize>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[cfg(test)]
 static INJECTED_DELETE_FAILURES: LazyLock<Mutex<std::collections::HashSet<PathBuf>>> =
@@ -663,44 +658,6 @@ fn injected_delete_failure(_path: &Path) -> Option<std::io::Error> {
         ));
     }
     None
-}
-
-/// Restore-scoped eviction lease. It holds no mutex across await points; the
-/// eviction planner consults the counted directory set while holding its own
-/// short persistence lock.
-#[must_use]
-pub struct SnapshotRestoreLease {
-    device_dir: PathBuf,
-}
-
-pub fn protect_snapshot_device(root: &Path, device_id: &str) -> Option<SnapshotRestoreLease> {
-    let device_dir = device_dir_for(root, device_id)?;
-    let mut active = ACTIVE_RESTORE_DIRS
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *active.entry(device_dir.clone()).or_default() += 1;
-    Some(SnapshotRestoreLease { device_dir })
-}
-
-impl Drop for SnapshotRestoreLease {
-    fn drop(&mut self) {
-        let mut active = ACTIVE_RESTORE_DIRS
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(count) = active.get_mut(&self.device_dir) {
-            *count -= 1;
-            if *count == 0 {
-                active.remove(&self.device_dir);
-            }
-        }
-    }
-}
-
-fn restore_protects(device_dir: &Path) -> bool {
-    ACTIVE_RESTORE_DIRS
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .contains_key(device_dir)
 }
 
 /// Run `f` under the process-wide snapshot-persistence lock. This is THE ONE

--- a/crates/freshell-ws/src/tabs_persist_retention.rs
+++ b/crates/freshell-ws/src/tabs_persist_retention.rs
@@ -62,12 +62,12 @@ fn scan_device_dir(path: PathBuf) -> DeviceDirHealth {
 }
 
 /// Enforce MAX_SNAPSHOT_DEVICES before a write. New targets reserve one slot;
-/// existing targets also repair a previously over-cap root. Lease-protected
-/// restores, the write target, and — fail-loud, campaign P2.17 defect 1 —
-/// any dir holding unreadable generation files are never candidates: corrupt
-/// dirs are forensic evidence, not the cheapest victim. If no cleanly
-/// parseable victim remains, fail the incoming write with `WouldBlock`
-/// rather than destroying evidence or creating another directory.
+/// existing targets also repair a previously over-cap root. The write target
+/// and — fail-loud, campaign P2.17 defect 1 — any dir holding unreadable
+/// generation files are never candidates: corrupt dirs are forensic evidence,
+/// not the cheapest victim. If no cleanly parseable victim remains, fail the
+/// incoming write with `WouldBlock` rather than destroying evidence or
+/// creating another directory.
 pub(super) fn enforce_device_cap(root: &Path, target_dir: &Path) -> std::io::Result<()> {
     let target_exists = target_dir.exists();
     let entries = match std::fs::read_dir(root) {
@@ -95,7 +95,7 @@ pub(super) fn enforce_device_cap(root: &Path, target_dir: &Path) -> std::io::Res
     let mut corrupt_exempt = 0usize;
     let mut candidates: Vec<(i64, PathBuf)> = Vec::new();
     for d in dirs {
-        if d.path == *target_dir || restore_protects(&d.path) {
+        if d.path == *target_dir {
             continue;
         }
         if d.unreadable > 0 {
@@ -116,7 +116,7 @@ pub(super) fn enforce_device_cap(root: &Path, target_dir: &Path) -> std::io::Res
                 "tabs_snapshot_device_cap_unenforceable: no cleanly-parseable eviction candidate remains; failing the incoming write instead of destroying evidence");
             return Err(std::io::Error::new(
                 std::io::ErrorKind::WouldBlock,
-                "snapshot device cap is exhausted: remaining candidates are protected by active restores or hold unreadable (corrupt) generations; refusing to evict",
+                "snapshot device cap is exhausted: remaining candidates hold unreadable (corrupt) generations; refusing to evict",
             ));
         };
         tracing::warn!(target: "freshell_ws::tabs", path = %victim.display(),

--- a/crates/freshell-ws/src/tabs_persist_tests.rs
+++ b/crates/freshell-ws/src/tabs_persist_tests.rs
@@ -686,40 +686,6 @@ fn device_delete_failure_does_not_create_over_cap_directory() {
 }
 
 #[test]
-fn all_lease_protected_devices_make_new_write_retryable_without_exceeding_cap() {
-    let dir = tempfile::tempdir().unwrap();
-    for index in 0..MAX_SNAPSHOT_DEVICES {
-        put(
-            dir.path(),
-            &format!("dev-{index:03}"),
-            "c1",
-            1,
-            1000 + index as i64,
-            vec![open_record(&format!("dev-{index:03}:t"), "t", 1)],
-        );
-    }
-    let leases: Vec<_> = (0..MAX_SNAPSHOT_DEVICES)
-        .map(|index| {
-            protect_snapshot_device(dir.path(), &format!("dev-{index:03}"))
-                .expect("seeded device gets a lease")
-        })
-        .collect();
-
-    put(
-        dir.path(),
-        "dev-blocked",
-        "c1",
-        1,
-        9999,
-        vec![open_record("dev-blocked:t", "blocked", 1)],
-    );
-
-    assert_eq!(leases.len(), MAX_SNAPSHOT_DEVICES);
-    assert!(!device_dir_for(dir.path(), "dev-blocked").unwrap().exists());
-    assert_eq!(devices(dir.path()).len(), MAX_SNAPSHOT_DEVICES);
-}
-
-#[test]
 fn generation_id_is_stable_and_selects_the_right_generation() {
     let dir = tempfile::tempdir().unwrap();
     put(


### PR DESCRIPTION
Post-campaign dead-code audit cleanup. Two commits:

1. Deletes the orphaned snapshot-restore eviction-protection mechanism (SnapshotRestoreLease, protect_snapshot_device, restore_protects, ACTIVE_RESTORE_DIRS, the retention planner's protection branch + its test; −77 net lines) — its only producer was the operator-restore endpoint deleted in PR #537/kata h9vt, making the protection vacuous; the WouldBlock eviction error remains reachable via the corrupt-dir forensic exemption and was reworded accordingly.

2. Documents the three deliberately-unused legacy repair fields on TerminalCreate (codex_durability/live_terminal/recovery_intent — consumed by the legacy TS server, superseded by pane.reconcile verdicts on Rust, retained for frozen-wire compat).

Verification: fmt/clippy clean, freshell-ws 255 tests green (exactly the one deleted test removed), test:port 38/38, coordinated JS suite green.