### PR TITLE
fix: FreshOpenCode restart recovery, snapshot storms, and interrupted-turn resilience (zrrj)

### DIFF
--- a/docs/plans/2026-07-27-freshopencode-restart-recovery-area6-evidence.md
+++ b/docs/plans/2026-07-27-freshopencode-restart-recovery-area6-evidence.md
@@ -1,0 +1,20 @@
+# zrrj Area 6 verdict: COUPLED (fixed in this change)
+
+- retention_lost itself is log-only in current main (post-ff8589bb, 2026-06-25) and emits
+  zero WS frames — proven by test 'EVIDENCE: retention_lost is log-only and emits zero WS
+  frames in the current build' (test/unit/server/ws-handler-fresh-agent-backpressure.test.ts).
+  The incident's 10k+/10min retention_lost count is incompatible with the current
+  1/s/terminal rate limit, so the incident build predated ff8589bb, when retention loss
+  also pushed a terminal.stream.changed frame per attached client (a direct WS write
+  amplifier).
+- The load-bearing coupling: terminal output and freshAgent lifecycle events share one
+  socket with asymmetric backpressure policy (broker ungated vs WsHandler drop+close at
+  2 MiB). Proven by test 'delivers freshAgent.turn.complete while flooding terminal output
+  (broker self-throttles below the kill line)' — RED before the fix: an ungated ~5 MiB
+  live-output flood inflated bufferedAmount to 5,363,909 bytes, past the 2 MiB kill line,
+  so the freshAgent.turn.complete frame was dropped and the socket closed 4008.
+- Fix shipped: TERMINAL_STREAM_FOREGROUND_PAUSE_BUFFERED_BYTES = 1 MiB broker pause below
+  the 2 MiB kill line (server/terminal-stream/constants.ts, flushAttachment gate in
+  server/terminal-stream/broker.ts), reusing the background path's 100 ms retry mechanic
+  (TERMINAL_BACKGROUND_RETRY_FLUSH_MS). The incident's 'WebSocket send callback reported
+  failure' rows match ws-send.ts:167-174 in the same congestion regime.

--- a/docs/plans/2026-07-27-freshopencode-restart-recovery.md
+++ b/docs/plans/2026-07-27-freshopencode-restart-recovery.md
@@ -1271,6 +1271,7 @@ Gaps G1/G2/G5 (`server/fresh-agent/adapters/opencode/adapter.ts`): `reconcileSta
     - reject (timeout / `OpencodeServeLostError`) → `emitStatus(state, 'idle')` + `state.events.emit('event', { type: 'sdk.error', sessionId: state.placeholderId, message: 'OpenCode turn interrupted: <timeout|sidecar lost>' })`; monitor row `timeout`/`sidecar_lost`. Never leaves the pane busy.
     - always: delete the registry entry on settle; a settled handler checks the entry's `cancelled` flag first and becomes a no-op when disarmed (see next bullet).
   - **Disarm on new send (surfaced by validation, N-V5a):** a cold-armed monitor that is still pending when the user starts a NEW turn would resolve on that later turn's idle and emit its own idle + `sdk.turn.complete` chime concurrently with the send path's own `onceIdle` — a double idle/chime for one turn. The registry dedups monitors against each other, not against send-path waiters. Fix: `materializeOrSend`'s send path calls `disarmIdleRecovery(realId)` (sets `cancelled = true` and deletes the entry) before arming its own `onceIdle`; the monitor's resolve/reject handlers no-op when cancelled. Test consideration below.
+  - **Suppress arming while a send is in flight (fresh-eyes i3 — the REVERSE direction of N-V5a):** the disarm above covers monitor-armed-then-send; the reverse ordering is unguarded. A user send is in flight (the send path parked on its own `onceIdle`; the registry has no entry), then any `freshAgent.attach` for the same session arrives (pane refresh and reveal both send attach — `FreshAgentView.tsx:1063-1065`) → `reconcileStatus` observes busy → `armIdleRecovery` arms a SECOND waiter. When the turn completes, both the send path (`adapter.ts:371-381`) and the monitor emit an idle snapshot + `sdk.turn.complete` — the exact double-fire this plan classifies as a hazard. No existing per-session flag marks "send in flight" (`sendQueue` is not introspectable; `state.status === 'running'` is ambiguous — also set by SSE `:284` and reconcile `:189`), so add one: the adapter factory closure keeps `const sendsInFlight = new Set<string>()` (keyed by real `ses_` id); `materializeOrSend` adds the id at the same point it calls `disarmIdleRecovery(realId)` and removes it in a `finally` once the send's turn settles; `armIdleRecovery` no-ops (recording a `duplicate_suppressed` observability row) when `sendsInFlight.has(realId)`. Test below (attach-mid-send).
   - `bindServeStream` additionally registers a `'lost'` listener (via a new `subscribeLost` manager passthrough or by subscribing on the same emitter — implement as a second `serveManager.subscribe`-style hook; simplest: extend `subscribe(id, listener, onLost?)` in serve-manager with an optional third arg attached to `'lost'`): on lost, if `state.status === 'running'`, `emitStatus(state, 'idle')` + the same `sdk.error` interruption signal. (With Task 7, the same subscription keeps receiving events from the replacement sidecar — no rebind needed.)
 
 - [ ] **Step 1: Write the failing tests**
@@ -1280,16 +1281,26 @@ Add to `opencode-serve-adapter.test.ts`:
 ```ts
 describe('restore reconciliation emits and monitors (zrrj)', () => {
   it('emits a running session snapshot when attach reconciles a busy durable session', async () => {
+    // Non-vacuous ordering (fresh-eyes i3): subscribing AFTER `await attach` guarantees an
+    // empty capture — the running emission happens inside reconcile, DURING attach; and
+    // subscribing BEFORE attach throws (`subscribe` -> `requireState`, adapter.ts:500-505).
+    // The real window: attach registers the state via `remember()` (adapter.ts:494) BEFORE
+    // reconcile awaits `getSessionStatus` (:496 -> :173). So park the status read on a
+    // deferred, start attach, subscribe once the state is registered, THEN release it:
     const manager = makeFakeManager()
-    manager.getSessionStatus.mockResolvedValue({ type: 'busy' })
+    const status = createDeferred<{ type: string } | undefined>()
+    manager.getSessionStatus.mockReturnValue(status.promise)
     const adapter = makeAdapter(manager)
     const events: any[] = []
-    await adapter.attach!({ sessionId: 'ses_live', cwd: '/w' })
+    const attaching = adapter.attach!({ sessionId: 'ses_live', cwd: '/w' })
+    await new Promise((r) => setImmediate(r))   // remember() has run; status read still parked
     adapter.subscribe('ses_live', (ev) => events.push(ev))   // use the adapter's actual subscribe surface
-    // If subscription must precede attach in this adapter, reorder — assert on the emitted event either way:
-    expect(events.some((e) => e.type === 'sdk.session.snapshot' && e.status === 'running')
-      || manager.onceIdle.mock.calls.length > 0).toBe(true)
-    // Primary assertion: a status event was EMITTED (not just state mutated)
+    status.resolve({ type: 'busy' })
+    await attaching
+    // Primary assertion: the running status was EMITTED (not just state mutated).
+    // NO fallback disjunct on monitor arming — an implementation that arms the
+    // monitor but never emits must FAIL here.
+    expect(events.some((e) => e.type === 'sdk.session.snapshot' && e.status === 'running')).toBe(true)
   })
 
   it('arms exactly one idle-recovery monitor per durable session and chimes on resolve', async () => {
@@ -1351,6 +1362,8 @@ it('onceIdle with assumeActive resolves from status-map absence without prior ob
 
 And a **disarm-on-new-send** test in the adapter suite (test consideration for the double-fire hazard): arm a cold monitor via attach-on-busy, then drive a user send whose own `onceIdle` resolves — assert exactly ONE `sdk.session.snapshot` idle emission and ONE `sdk.turn.complete` for that turn (the cancelled monitor must not add a second).
 
+And the **reverse direction** — an **attach-mid-send** test (skeleton: the existing "attach during an in-flight send" test at `opencode-serve-adapter.test.ts:130-159`): start a send whose `onceIdle` is a pending deferred; while it is in flight, `await adapter.attach!(...)` for the SAME session with `getSessionStatus` resolving `{ type: 'busy' }`; assert `manager.onceIdle` was called exactly ONCE (only the send path's waiter — `armIdleRecovery` must no-op while `sendsInFlight` has the id); then resolve the deferred, await the send, and assert exactly ONE `sdk.session.snapshot` idle emission and ONE `sdk.turn.complete` in the captured events.
+
 - [ ] **Step 2: Run to verify they fail**
 
 Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-adapter.test.ts test/unit/server/fresh-agent/opencode-serve-manager.test.ts`
@@ -1371,6 +1384,10 @@ In `adapter.ts`:
 type IdleRecoveryMonitor = { promise: Promise<void>; cancelled: boolean }
 const idleRecoveryMonitors = new Map<string, IdleRecoveryMonitor>()
 
+/** Real ses_ ids with a user send currently in flight. armIdleRecovery must not arm
+ *  while the send path's own onceIdle owns the turn (attach-mid-send double-fire guard). */
+const sendsInFlight = new Set<string>()
+
 /** Called by materializeOrSend before arming the send path's own onceIdle (double-fire guard). */
 function disarmIdleRecovery(realId: string): void {
   const existing = idleRecoveryMonitors.get(realId)
@@ -1383,7 +1400,8 @@ function disarmIdleRecovery(realId: string): void {
 function armIdleRecovery(state: OpencodeSessionState): void {
   const realId = state.realSessionId
   if (!realId) return
-  if (idleRecoveryMonitors.has(realId)) {
+  if (idleRecoveryMonitors.has(realId) || sendsInFlight.has(realId)) {
+    // second disjunct: attach-mid-send guard — the send path's own onceIdle owns this turn
     recordFreshAgentObservabilityEvent({
       kind: 'fresh_agent_monitor', provider: 'opencode',
       sessionIdHash: hashForLogs(realId),
@@ -1441,7 +1459,7 @@ function armIdleRecovery(state: OpencodeSessionState): void {
 }
 ```
 
-In `materializeOrSend`, call `disarmIdleRecovery(realId)` just before the send path arms its own `onceIdle` (`:363-368` area). (Import `OpencodeServeLostError` from `./serve-manager.js`; `hashForLogs`/`recordFreshAgentObservabilityEvent` from `../../observability.js` — the adapter already imports the latter at `:286-311`.)
+In `materializeOrSend`, call `disarmIdleRecovery(realId)` AND `sendsInFlight.add(realId)` just before the send path arms its own `onceIdle` (`:363-368` area), and remove the flag in a `finally` once the send's turn settles (`sendsInFlight.delete(realId)`) so a later restore/attach can arm a monitor again. (Import `OpencodeServeLostError` from `./serve-manager.js`; `hashForLogs`/`recordFreshAgentObservabilityEvent` from `../../observability.js` — the adapter already imports the latter at `:286-311`.)
 
 3. `bindServeStream` (`:273-299`): pass an `onLost` handler through to the manager. In `serve-manager.ts`, extend `subscribe`:
 
@@ -2430,7 +2448,8 @@ Belt-and-suspenders for the same race (kata requires the browser-side guarantee 
 
 **Interfaces:**
 - Consumes: the existing local-echo reconcile logic inside the old `.then` body (`:1618-1707` — it already computes whether the echo was reconciled); `requestSnapshotRefresh('idle-incomplete')` (Task 3); scheduler debounce=0 for `idle-incomplete`.
-- Produces: `idleIncompleteRetryCountRef = useRef(0)`, max `IDLE_INCOMPLETE_MAX_RETRIES = 5`, retry delay 1000 ms via `window.setTimeout`; counter resets whenever a snapshot reconciles the echo or a new send starts.
+- Produces: `idleIncompleteRetryCountRef = useRef(0)`, exported `IDLE_INCOMPLETE_MAX_RETRIES = 5` (exported so the test asserts the cap against the real constant), retry delay 1000 ms via `window.setTimeout` with the timer id stored in `idleIncompleteRetryTimerRef` (deduped: never arm a second timer while one is pending; cleared on unmount — mirror `scheduleSnapshotRefresh`'s cleanup at `:830-836`); counter resets whenever a snapshot reconciles the echo or a new send starts.
+- **Clear-suppression while the loop is armed (fresh-eyes i3 — load-bearing):** without this, the loop is dead on arrival in production. The existing stale-echo clear (`setLocalEcho(null)` at `:1648`, gated by `snapshotAccepted && shouldClearStaleLocalEcho(...)` at `:1644-1646`) runs in the SAME `applySnapshot` pass: every real fetch returns a NEW object, so `snapshotAccepted = displaySnapshot !== previousSnapshot` (`:1633`) is true and the FIRST idle snapshot clears the echo — after which `echoStillPending` is false forever and at most ONE re-poll ever fires. Fix: the echo IS the loop's marker, so it must survive while the retry budget remains — add `idleIncompleteRetryCountRef.current >= IDLE_INCOMPLETE_MAX_RETRIES` as a conjunct of the stale-clear condition. The echo still clears immediately when it LANDS (`landedEcho` path unchanged), and clears via the stale path once retries are exhausted. **Update the existing stale-clear test** (`FreshAgentView.test.tsx:4275-4370`) to match the new contract: the stale clear now happens after the retry budget is exhausted (or assert it with the retry budget forced to 0), not on the first idle snapshot.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -2438,30 +2457,67 @@ Belt-and-suspenders for the same race (kata requires the browser-side guarantee 
 it('keeps re-polling (bounded) when an idle snapshot is missing the just-sent turn', async () => {
   // Arrange: pane with a pending local echo for 'question?' (drive the composer),
   // snapshot responses are idle and DO NOT contain the echo's turn.
-  apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(makeSnapshot({ threadId: 'ses_1', status: 'idle', turns: [] }))
+  //
+  // HARNESS TRAP (fresh-eyes i3): return a FRESH snapshot object per fetch. Acceptance is
+  // by OBJECT IDENTITY (`snapshotAccepted = displaySnapshot !== previousSnapshot`,
+  // FreshAgentView.tsx:1633; mergeSnapshotForDisplay does no content comparison, :158-185).
+  // A shared `mockResolvedValue(...)` instance makes `snapshotAccepted` false, skips the
+  // stale-echo clear for the wrong reason, and lets a broken loop pass vacuously.
+  let rev = 1
+  getFreshAgentThreadSnapshot.mockImplementation(async () => freshopencodeSnapshot('unrelated earlier turn', rev++))
   render(<StoreBackedFreshAgentView ... />)
   await typeAndSend('question?')
   act(() => wsHandler({ type: 'freshAgent.send.accepted', requestId: lastSendRequestId(), sessionId: 'ses_1', sessionType: 'freshopencode', provider: 'opencode' }))
-  const before = apiMock.getFreshAgentThreadSnapshot.mock.calls.length
-  // Assert: more snapshot fetches keep coming (retry loop), then stop at the cap
-  await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot.mock.calls.length).toBeGreaterThan(before), { timeout: 4_000 })
-})
+  const calls = () => getFreshAgentThreadSnapshot.mock.calls.length
+  const before = calls()
+  // SUSTAINED loop — a single extra fetch must NOT satisfy this test:
+  await waitFor(() => expect(calls()).toBeGreaterThanOrEqual(before + 2), { timeout: 8_000 })
+  // ...and it runs to the cap...
+  await waitFor(() => expect(calls()).toBeGreaterThanOrEqual(before + IDLE_INCOMPLETE_MAX_RETRIES), { timeout: 10_000 })
+  // ...then STOPS (bounded — no unbounded polling):
+  const atCap = calls()
+  await new Promise((r) => setTimeout(r, 1_500))
+  expect(calls()).toBe(atCap)
+}, 25_000)   // real timers (this suite uses none fake); 5 retries x 1 s + settle needs a raised test timeout
 ```
 
-- [ ] **Step 2: Run to verify fail** — after the send-accepted refresh returns an idle snapshot, no further fetches happen today (busy never set → poll gate off).
+(Import `IDLE_INCOMPLETE_MAX_RETRIES` from the component module — export it there. `freshopencodeSnapshot(text, revision)` is the file's existing snapshot helper at `:162-182`; there is no generic `makeSnapshot`. This suite advances real time via `waitFor` — do not introduce fake timers.)
 
-- [ ] **Step 3: Implement** in `applySnapshot`: after the existing echo-reconcile computation, add:
+- [ ] **Step 2: Run to verify fail** — today the FIRST accepted idle snapshot clears the accepted-but-unlanded echo (`:1644-1648`) and no further fetches happen (busy never set → poll gate off), so the sustained-retries assertion (`before + 2`) fails.
+
+- [ ] **Step 3: Implement** in `applySnapshot`:
 
 ```ts
-const echoStillPending = /* the existing 'echo not reconciled by this snapshot' condition */
+// (a) Gate the EXISTING stale-echo clear on retry exhaustion so the echo — the loop's
+//     marker — survives while re-polling (see the Clear-suppression interface note).
+//     At :1644-1646, add the conjunct:
+const staleEcho = snapshotAccepted
+  && idleIncompleteRetryCountRef.current >= IDLE_INCOMPLETE_MAX_RETRIES
+  && shouldClearStaleLocalEcho(displaySnapshot, echo, echoPendingMetadata)
+// (landedEcho handling unchanged — a landed echo still clears immediately.)
+
+// (b) After the existing echo-reconcile computation, in the same pass:
+const echoStillPending = /* the 'accepted but not landed' condition, INDEPENDENT of the
+  retry gate added in (a): echo present && send accepted && !localEchoLanded(...) —
+  i.e. shouldClearStaleLocalEcho's input predicate, NOT the gated staleEcho */
 if (snapshotStatus === 'idle' && echoStillPending
   && idleIncompleteRetryCountRef.current < IDLE_INCOMPLETE_MAX_RETRIES) {
   idleIncompleteRetryCountRef.current += 1
-  window.setTimeout(() => requestSnapshotRefresh('idle-incomplete'), 1_000)
+  if (idleIncompleteRetryTimerRef.current === null) {   // dedupe: one pending timer max
+    idleIncompleteRetryTimerRef.current = window.setTimeout(() => {
+      idleIncompleteRetryTimerRef.current = null
+      requestSnapshotRefresh('idle-incomplete')
+    }, 1_000)
+  }
 } else if (!echoStillPending) {
   idleIncompleteRetryCountRef.current = 0
 }
+
+// (c) Reset idleIncompleteRetryCountRef.current = 0 where a new send starts; clear the
+//     pending timer on unmount (mirror scheduleSnapshotRefresh's cleanup at :830-836).
 ```
+
+Also update the pinned stale-clear test (`FreshAgentView.test.tsx:4275-4370`) per the Clear-suppression interface note — the clear now fires after the retry budget, not on the first idle snapshot.
 
 - [ ] **Step 4: Run to verify pass** — FreshAgentView suite.
 
@@ -2645,12 +2701,26 @@ Kata area 6 requires proof, not assumption. Investigation verdict (to be encoded
 
 ```ts
 describe('terminal output vs freshAgent lifecycle on one socket (zrrj)', () => {
-  it('delivers freshAgent.turn.complete while terminal output has inflated bufferedAmount to 3 MiB', () => {
-    // DESIRED behavior (RED until Task 20): a freshAgent event in the 2-16 MiB window
-    // must still be delivered and must NOT close the socket.
-    const ws = createMockWs({ bufferedAmount: 3 * 1024 * 1024 })
-    // arrange: WsHandler with a freshAgent subscription on this ws (reuse the
-    // subscription-listener arrangement from ws-handler-fresh-agent-lifecycle-parity.test.ts)
+  it('delivers freshAgent.turn.complete while flooding terminal output (broker self-throttles below the kill line)', () => {
+    // DESIRED behavior (RED until Task 20).
+    // ARRANGEMENT TRAP (fresh-eyes i3): do NOT seed a static bufferedAmount >= 2 MiB.
+    // WsHandler.send KEEPS its 4008 close after Task 20 (ws-send.ts:135-159 closes whenever
+    // bufferedAmount > maxBufferedAmount; the broker fix never deflates a static mock value),
+    // so with a fixed 3 MiB the freshAgent frame dies in GREEN too and the test can never
+    // pass. The buffered pressure must be PRODUCED BY THE BROKER — the thing Task 20 gates:
+    const ws = createMockWs()
+    // accumulate-bytes idiom from ws-handler-backpressure.test.ts:1893-1895 — never drains:
+    ws.send.mockImplementation((frame: string) => { ws.bufferedAmount += Buffer.byteLength(frame) })
+    // arrange: WsHandler + broker on this ws with a freshAgent subscription (reuse the
+    // subscription-listener arrangement from ws-handler-fresh-agent-lifecycle-parity.test.ts);
+    // attach a FOREGROUND pane on an EMPTY terminal (no replay cursor — the replay path is
+    // already paced at 576 KiB and would make this vacuous), then flood > 4 MiB of live output.
+    floodTerminalOutput(4 * 1024 * 1024)
+    // RED today: broker sends bypass the buffered gate entirely (safeSendPrepared passes no
+    // options, broker.ts:2107-2109), bufferedAmount inflates past 2 MiB, and the freshAgent
+    // frame below is dropped + the socket closed 4008.
+    // GREEN after Task 20: the broker pauses at 1 MiB, so bufferedAmount stays below the line:
+    expect(ws.bufferedAmount).toBeLessThan(2 * 1024 * 1024)
     fireFreshAgentEvent({ type: 'freshAgent.turn.complete', sessionId: 'ses_1', at: Date.now() })
     const sentTypes = ws.send.mock.calls.map(([f]: [string]) => JSON.parse(f).type)
     expect(sentTypes).toContain('freshAgent.event')
@@ -2681,7 +2751,7 @@ Flesh out the arrange code from the two referenced suites — both already const
 - [ ] **Step 2: Run and record the verdict**
 
 Run: `npm run test:vitest -- --run test/unit/server/ws-handler-fresh-agent-backpressure.test.ts`
-Expected: test 1 FAILS (message dropped + socket closed) — that failure IS the coupling proof. Tests 2–4 PASS (they encode current mechanics). Keep test 1 failing (skip-marked `it.fails(...)` is NOT allowed — instead proceed immediately to Task 20 in the same PR; the suite must be green only after Task 20).
+Expected: test 1 FAILS (the ungated broker inflates `bufferedAmount` past 2 MiB, so the buffered-amount assertion trips and the freshAgent frame is dropped + socket closed 4008) — that failure IS the coupling proof. Tests 2–4 PASS (they encode current mechanics). Keep test 1 failing (skip-marked `it.fails(...)` is NOT allowed — instead proceed immediately to Task 20 in the same PR; the suite must be green only after Task 20).
 
 - [ ] **Step 3: Commit** (tests only, with test 1 temporarily asserting the CURRENT broken behavior inverted — to keep the tree green mid-plan, write test 1 with the desired assertions but wrap the two assertions in `expect(...)` guarded by a `// zrrj Task 20 flips broker gating` comment and commit it together with Task 20 if the repo's per-task green policy requires it. Preferred: implement Task 19+20 as one RED→GREEN cycle, committing the test file in Task 20's commit.)
 

--- a/docs/plans/2026-07-27-freshopencode-restart-recovery.md
+++ b/docs/plans/2026-07-27-freshopencode-restart-recovery.md
@@ -1,0 +1,2567 @@
+# FreshOpenCode Restart Recovery, Snapshot Storms, and Interrupted-Turn Resilience — Implementation Plan
+
+> **For agentic workers:** This plan is executed task-by-task by the
+> workflow's execute stage: a fresh implementer per task, with a spec +
+> quality review after each task. Steps use checkbox (`- [ ]`) syntax
+> for tracking.
+
+**Goal:** Fix kata `zrrj` — after a Freshell restart, FreshOpenCode panes must not storm the snapshot API into global 429 starvation, must reconcile live status instead of stranding busy/idle state, must recover interrupted turns exactly once with audit, must not lose the final assistant answer on the idle race, must emit permanent identity-bearing structured logs, and must be immune to terminal-stream WS backpressure killing lifecycle events.
+
+**Architecture:** Client-side: a module-singleton per-snapshot-key scheduler (single-flight, trailing coalesce, debounce, Retry-After-honoring 429 backoff) that every refresh trigger routes through, plus HTTP-snapshot-driven busy clearing for opencode. Server-side: the opencode adapter's `reconcileStatus` becomes event-emitting and arms exactly one monitored idle-recovery per durable session; serve-manager subscriptions survive sidecar replacement and carry a generation identity; lost-session errors keep their code across the WS boundary with a one-shot attach-recover-retry; interrupted turns are detected from transcript evidence (never a guessed status field) and recovered with one persisted, loop-proof Freshell-owned continuation; idle is only emitted after the final assistant message is proven queryable. Observability rows go to a dedicated always-on pino logger (the main logger drops `info` in production). The terminal-stream broker gains a foreground buffered-amount pause below the WS handler's 2 MiB kill line so terminal floods can no longer drop freshAgent lifecycle frames.
+
+**Tech Stack:** TypeScript (NodeNext/ESM server — relative imports need `.js`), React 18 + Redux Toolkit client, Express + `express-rate-limit@7.5.1`, pino, ws, Vitest + Testing Library + supertest.
+
+## Global Constraints
+
+- Work happens in this worktree (`.worktrees/freshopencode-restart-recovery`), branch `fix/freshopencode-restart-recovery`, based on `origin/main` @ `d99592b4`. One coherent branch/PR (kata `zrrj` is canonical — do NOT split into new katas).
+- Red-Green-Refactor TDD for every task. Write the failing test, run it, watch it fail, implement, watch it pass, commit.
+- Server files: NodeNext/ESM — **relative imports must include `.js` extensions**.
+- Test runs go through the coordinator: `npm run test:vitest -- --run <paths>` for focused runs (add `--config config/vitest/vitest.server.config.ts` for `test/server/**` and `test/integration/server/**` files if they fail to load under the default config); full suite via `npm test` / `npm run check`. Never raw `npx vitest`. Set `FRESHELL_TEST_SUMMARY` for broad runs.
+- **Never restart the self-hosted Freshell server. Never use broad kill patterns** (`pkill -f node`, etc.).
+- **Do not weaken or bypass the global `/api` rate limit** (300 req/60s at `server/index.ts:205-212`). Response *shaping* and *observability* are allowed; raising/removing limits is not.
+- **Never log raw prompts, assistant text, file contents, or full OpenCode payloads.** Identity convention: `provider` + `sessionIdHash` + `cwdHash` via `hashForLogs()` (`server/fresh-agent/observability.ts:7`).
+- Git commits use the repo's Amplifier co-author footer:
+  ```
+  🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+  Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
+  ```
+- `test/integration/real/` provider contract tests are opt-in and skipped by default — do not require them.
+- Line numbers cited below were verified on `d99592b4`. If a cited anchor has drifted, locate the construct by the quoted code, not the number.
+- The kata's copied post-restart aggregate counts are approximate — rely on mechanism findings, not exact totals.
+
+## File Structure (new + touched)
+
+**New files:**
+- `src/lib/fresh-agent-snapshot-scheduler.ts` — per-key scheduler singleton (single-flight, coalesce, debounce, backoff)
+- `test/unit/client/lib/fresh-agent-snapshot-scheduler.test.ts`
+- `server/rate-limit.ts` — global limiter factory with JSON 429 body (same limits)
+- `test/unit/server/rate-limit.test.ts`
+- `server/fresh-agent/adapters/opencode/interrupted-turn.ts` — pure interrupted-turn detector
+- `test/unit/server/fresh-agent/opencode-interrupted-turn.test.ts`
+- `server/fresh-agent/recovery-store.ts` — durable interrupt-intent + recovery ledger
+- `test/unit/server/fresh-agent/recovery-store.test.ts`
+- `server/fresh-agent/incident-router.ts` — read-only incident state endpoint
+- `test/unit/server/fresh-agent/incident-router.test.ts`
+- `test/unit/server/ws-handler-fresh-agent-backpressure.test.ts` — coupling proof
+
+**Modified (primary):**
+- `src/lib/api.ts` — `ApiError.retryAfterMs`, snapshot `trigger` param
+- `src/components/fresh-agent/FreshAgentView.tsx` — all triggers through the scheduler; 429 backoff UX; opencode busy clear; lost-session resend-once; idle-incomplete re-poll
+- `server/index.ts` — use `createApiRateLimiter()`; mount incident router
+- `server/logger.ts` — dedicated `freshAgentObservabilityLogger`
+- `server/fresh-agent/observability.ts` — sink swap, new event kinds, `/turns` 429 coverage, retryAfter metadata
+- `server/fresh-agent/router.ts` — `trigger` query param, `fresh_agent_snapshot_failed`
+- `server/fresh-agent/adapters/opencode/serve-manager.ts` — generation/pid/baseUrl; emitters survive replacement; sidecar lifecycle events
+- `server/fresh-agent/adapters/opencode/adapter.ts` — reconcile emits; monitored idle recovery; `'lost'` handling; interrupted-turn recovery; idle freshness
+- `server/fresh-agent/adapters/opencode/normalize.ts` — evidence fields into `extensions.opencode`
+- `server/fresh-agent/runtime-manager.ts` — recovery-store wiring, observability
+- `server/ws-handler.ts` — lost-session error code, send/interrupt/attach/materialization log rows
+- `server/terminal-stream/broker.ts` + `server/terminal-stream/constants.ts` — foreground backpressure pause
+
+---
+
+### Task 1: Surface `Retry-After` on `ApiError` (client transport)
+
+The server already sends `Retry-After` on every 429 (`express-rate-limit` with `standardHeaders: true`). The client discards `Response.headers` entirely (`src/lib/api.ts:245-247`), so backoff has nothing to work with. Add `retryAfterMs` to `ApiError`.
+
+**Files:**
+- Modify: `src/lib/api.ts` (ApiError class ~`:39-57`; `request()` error tail `:245-247`)
+- Test: `test/unit/client/lib/api.test.ts` (existing; error-mapping suite at `:846-869`; fetch helpers `:36-50`)
+
+**Interfaces:**
+- Consumes: existing `request()` / `ApiError` in `src/lib/api.ts`.
+- Produces: `ApiError` gains `readonly retryAfterMs?: number`; exported helper `parseRetryAfterMs(value: string | null | undefined, nowMs?: number): number | undefined`. Task 2's scheduler reads `error.retryAfterMs` when `error.status === 429`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/unit/client/lib/api.test.ts`, inside the existing `describe('api error mapping', ...)` block, add. Note the existing `mockJson`/`mockJsonResponse` helpers return no `headers` — add a local helper:
+
+```ts
+function mockResponseWithHeaders(status: number, value: unknown, headers: Record<string, string>) {
+  const headerMap = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]))
+  mockFetch.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'Too Many Requests',
+    text: async () => JSON.stringify(value),
+    headers: { get: (name: string) => headerMap.get(name.toLowerCase()) ?? null },
+  })
+}
+
+it('carries retryAfterMs from a 429 Retry-After seconds header', async () => {
+  mockResponseWithHeaders(429, { error: 'Too many requests' }, { 'retry-after': '17' })
+  await expect(api.get('/api/fresh-agent/threads/freshopencode/opencode/ses_1')).rejects.toMatchObject({
+    status: 429,
+    retryAfterMs: 17_000,
+  })
+})
+
+it('leaves retryAfterMs undefined when the header is absent', async () => {
+  mockResponseWithHeaders(429, { error: 'Too many requests' }, {})
+  await expect(api.get('/api/x')).rejects.toMatchObject({ status: 429, retryAfterMs: undefined })
+})
+
+it('parses an HTTP-date Retry-After into a forward delta', async () => {
+  const future = new Date(Date.now() + 30_000).toUTCString()
+  mockResponseWithHeaders(429, { error: 'Too many requests' }, { 'retry-after': future })
+  const err = await api.get('/api/x').catch((e) => e)
+  expect(err.status).toBe(429)
+  expect(err.retryAfterMs).toBeGreaterThan(20_000)
+  expect(err.retryAfterMs).toBeLessThanOrEqual(31_000)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test:vitest -- --run test/unit/client/lib/api.test.ts`
+Expected: the three new tests FAIL (`retryAfterMs` is `undefined` for the seconds case / property missing).
+
+- [ ] **Step 3: Implement**
+
+In `src/lib/api.ts`:
+
+1. Add the parser near `TRANSIENT_HTTP_STATUSES` (`:122`):
+
+```ts
+/** Parse a Retry-After header (delta-seconds or HTTP-date) into milliseconds. */
+export function parseRetryAfterMs(value: string | null | undefined, nowMs = Date.now()): number | undefined {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  if (/^\d+$/.test(trimmed)) return Number(trimmed) * 1000
+  const dateMs = Date.parse(trimmed)
+  if (!Number.isFinite(dateMs)) return undefined
+  return Math.max(0, dateMs - nowMs)
+}
+```
+
+2. Extend `ApiError` (`:39-57`) with an optional fourth constructor arg:
+
+```ts
+export class ApiError extends Error {
+  // ...existing fields...
+  readonly retryAfterMs?: number
+  constructor(status: number, message: string, details?: unknown, retryAfterMs?: number) {
+    // ...existing body...
+    this.retryAfterMs = retryAfterMs
+  }
+}
+```
+
+3. In `request()`'s error tail (`:245-247`), read the header before throwing:
+
+```ts
+if (!res.ok) {
+  const retryAfterMs = res.status === 429
+    ? parseRetryAfterMs(typeof res.headers?.get === 'function' ? res.headers.get('retry-after') : undefined)
+    : undefined
+  throw new ApiError(res.status, getApiErrorMessage(data, res.statusText), data, retryAfterMs)
+}
+```
+
+The `typeof res.headers?.get === 'function'` guard keeps every existing test (whose fetch mocks have no `headers`) green.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test:vitest -- --run test/unit/client/lib/api.test.ts`
+Expected: PASS (all, including pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/api.ts test/unit/client/lib/api.test.ts
+git commit -m "feat(client): surface Retry-After as ApiError.retryAfterMs on 429 (zrrj)"
+```
+
+---
+
+### Task 2: Per-snapshot-key scheduler module (single-flight, coalesce, debounce, 429 backoff)
+
+The current mechanism is a per-component 50 ms debounce with no in-flight guard, no shared key, and three of eight triggers bypassing it (`FreshAgentView.tsx:815-828`, `:1495`, `:1065`, `:1930`). N panes on one session produce N GETs per invalidation. Build a module singleton (precedent: `getRebindQueue()`/`resetRebindQueueForTests()` in `src/lib/rebind-queue.ts`) that owns all of this per key.
+
+**Files:**
+- Create: `src/lib/fresh-agent-snapshot-scheduler.ts`
+- Test: `test/unit/client/lib/fresh-agent-snapshot-scheduler.test.ts`
+
+**Interfaces:**
+- Consumes: `ApiError` (with `retryAfterMs`) from `src/lib/api.ts` (Task 1).
+- Produces (Task 3 depends on these exact names):
+
+```ts
+export type SnapshotTrigger =
+  | 'identity' | 'event' | 'send-accepted' | 'materialized'
+  | 'manual' | 'poll' | 'reconnect' | 'reveal' | 'idle-incomplete'
+
+export function makeSnapshotKey(input: {
+  sessionType: string; provider: string; threadId: string; cwd?: string
+}): string   // `${sessionType}:${provider}:${threadId}:${cwd ?? ''}`
+
+export type SnapshotOutcome<T> =
+  | { status: 'ok'; value: T }
+  | { status: 'rate-limited'; retryAtMs: number }
+  | { status: 'backoff'; retryAtMs: number }      // suppressed without a network call
+  | { status: 'coalesced' }                        // this call was absorbed by an already-pending run
+  | { status: 'error'; error: unknown }
+
+export class FreshAgentSnapshotScheduler {
+  schedule<T>(key: string, trigger: SnapshotTrigger, run: () => Promise<T>): Promise<SnapshotOutcome<T>>
+  getBackoffUntil(key: string): number | null
+}
+
+export function getSnapshotScheduler(): FreshAgentSnapshotScheduler
+export function resetSnapshotSchedulerForTests(): void
+```
+
+**Semantics (implement exactly):**
+- Debounce: triggers `event`, `send-accepted`, `reveal`, `reconnect` wait `SNAPSHOT_DEBOUNCE_MS = 250` before running (a burst within the window coalesces into one run and all callers share that run's outcome). Triggers `identity`, `manual`, `materialized`, `poll`, `idle-incomplete` run immediately (debounce 0).
+- Single-flight: at most one in-flight `run()` per key. Calls arriving mid-flight coalesce into **one** trailing run scheduled after the in-flight completes (+debounce); they all share the trailing run's promise. A caller absorbed by an already-pending debounce timer resolves with the shared run's outcome (not `'coalesced'`); `'coalesced'` is returned only when a trailing run is already fully subscribed and this call adds nothing new (keep it simple: everyone sharing a pending run gets that run's outcome; `'coalesced'` is unused in practice but kept in the type for the trailing-overflow case where a trailing run is already queued).
+- 429 backoff: when `run()` rejects with `ApiError` status 429, set `backoffUntil = now + (retryAfterMs ?? nextExponential)` where `nextExponential` doubles from `1000` ms capped at `30_000` ms per consecutive 429 on that key; resolve all sharers with `{ status: 'rate-limited', retryAtMs }`. While backoff is active, `schedule()` resolves immediately `{ status: 'backoff', retryAtMs }` with **no network call**. A successful run resets the exponential counter and clears backoff.
+- Other rejections resolve `{ status: 'error', error }` (never throw out of `schedule`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/unit/client/lib/fresh-agent-snapshot-scheduler.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { ApiError } from '@/lib/api'
+import {
+  makeSnapshotKey,
+  getSnapshotScheduler,
+  resetSnapshotSchedulerForTests,
+} from '@/lib/fresh-agent-snapshot-scheduler'
+
+const KEY = makeSnapshotKey({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_1', cwd: '/w' })
+
+describe('FreshAgentSnapshotScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetSnapshotSchedulerForTests()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('builds the key from the exact request tuple', () => {
+    expect(KEY).toBe('freshopencode:opencode:ses_1:/w')
+    expect(makeSnapshotKey({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_1' }))
+      .toBe('freshopencode:opencode:ses_1:')
+  })
+
+  it('coalesces an event burst into a single run shared by all callers', async () => {
+    const scheduler = getSnapshotScheduler()
+    const run = vi.fn(async () => 'snap')
+    const p1 = scheduler.schedule(KEY, 'event', run)
+    const p2 = scheduler.schedule(KEY, 'event', run)
+    const p3 = scheduler.schedule(KEY, 'event', run)
+    await vi.advanceTimersByTimeAsync(250)
+    const [o1, o2, o3] = await Promise.all([p1, p2, p3])
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(o1).toEqual({ status: 'ok', value: 'snap' })
+    expect(o2).toEqual({ status: 'ok', value: 'snap' })
+    expect(o3).toEqual({ status: 'ok', value: 'snap' })
+  })
+
+  it('runs manual triggers immediately and holds a single trailing run while in flight', async () => {
+    const scheduler = getSnapshotScheduler()
+    let release!: () => void
+    const gate = new Promise<void>((r) => { release = r })
+    const run = vi.fn(async () => { await gate; return 'v' })
+    const first = scheduler.schedule(KEY, 'manual', run)
+    // three arrivals while in flight -> exactly one trailing run
+    const t1 = scheduler.schedule(KEY, 'event', run)
+    const t2 = scheduler.schedule(KEY, 'event', run)
+    release()
+    await first
+    await vi.advanceTimersByTimeAsync(250)
+    await Promise.all([t1, t2])
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('keys are independent', async () => {
+    const scheduler = getSnapshotScheduler()
+    const runA = vi.fn(async () => 'a')
+    const runB = vi.fn(async () => 'b')
+    const otherKey = makeSnapshotKey({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_2', cwd: '/w' })
+    const pa = scheduler.schedule(KEY, 'manual', runA)
+    const pb = scheduler.schedule(otherKey, 'manual', runB)
+    await Promise.all([pa, pb])
+    expect(runA).toHaveBeenCalledTimes(1)
+    expect(runB).toHaveBeenCalledTimes(1)
+  })
+
+  it('honors Retry-After on 429 and suppresses further runs until expiry', async () => {
+    const scheduler = getSnapshotScheduler()
+    const run = vi.fn(async () => { throw new ApiError(429, 'Too many requests', undefined, 5_000) })
+    const first = await scheduler.schedule(KEY, 'manual', run)
+    expect(first.status).toBe('rate-limited')
+    expect(run).toHaveBeenCalledTimes(1)
+
+    const during = await scheduler.schedule(KEY, 'poll', run)
+    expect(during.status).toBe('backoff')
+    expect(run).toHaveBeenCalledTimes(1)          // NO network call during backoff
+    expect(scheduler.getBackoffUntil(KEY)).toBeGreaterThan(Date.now())
+
+    await vi.advanceTimersByTimeAsync(5_001)
+    const ok = vi.fn(async () => 'fresh')
+    const after = await scheduler.schedule(KEY, 'poll', ok)
+    expect(after).toEqual({ status: 'ok', value: 'fresh' })
+    expect(scheduler.getBackoffUntil(KEY)).toBeNull()
+  })
+
+  it('falls back to exponential backoff when Retry-After is absent and doubles per consecutive 429', async () => {
+    const scheduler = getSnapshotScheduler()
+    const run429 = vi.fn(async () => { throw new ApiError(429, 'Too many requests') })
+    const o1 = await scheduler.schedule(KEY, 'manual', run429)
+    expect(o1.status).toBe('rate-limited')
+    if (o1.status !== 'rate-limited') throw new Error('unreachable')
+    const firstDelta = o1.retryAtMs - Date.now()
+    expect(firstDelta).toBeGreaterThan(0)
+    expect(firstDelta).toBeLessThanOrEqual(1_000)
+
+    await vi.advanceTimersByTimeAsync(1_001)
+    const o2 = await scheduler.schedule(KEY, 'manual', run429)
+    if (o2.status !== 'rate-limited') throw new Error(`expected rate-limited, got ${o2.status}`)
+    expect(o2.retryAtMs - Date.now()).toBeGreaterThan(1_000)   // doubled
+  })
+
+  it('resolves non-429 failures as error outcomes without backoff', async () => {
+    const scheduler = getSnapshotScheduler()
+    const boom = new Error('network down')
+    const out = await scheduler.schedule(KEY, 'manual', async () => { throw boom })
+    expect(out).toEqual({ status: 'error', error: boom })
+    expect(scheduler.getBackoffUntil(KEY)).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test:vitest -- --run test/unit/client/lib/fresh-agent-snapshot-scheduler.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement `src/lib/fresh-agent-snapshot-scheduler.ts`**
+
+```ts
+import { ApiError } from '@/lib/api'
+
+export type SnapshotTrigger =
+  | 'identity' | 'event' | 'send-accepted' | 'materialized'
+  | 'manual' | 'poll' | 'reconnect' | 'reveal' | 'idle-incomplete'
+
+export type SnapshotOutcome<T> =
+  | { status: 'ok'; value: T }
+  | { status: 'rate-limited'; retryAtMs: number }
+  | { status: 'backoff'; retryAtMs: number }
+  | { status: 'coalesced' }
+  | { status: 'error'; error: unknown }
+
+export const SNAPSHOT_DEBOUNCE_MS = 250
+const BACKOFF_BASE_MS = 1_000
+const BACKOFF_MAX_MS = 30_000
+
+const DEBOUNCED_TRIGGERS: ReadonlySet<SnapshotTrigger> = new Set(['event', 'send-accepted', 'reveal', 'reconnect'])
+
+export function makeSnapshotKey(input: {
+  sessionType: string; provider: string; threadId: string; cwd?: string
+}): string {
+  return `${input.sessionType}:${input.provider}:${input.threadId}:${input.cwd ?? ''}`
+}
+
+type Resolver<T> = (outcome: SnapshotOutcome<T>) => void
+
+type KeyState = {
+  inFlight: boolean
+  debounceTimer: ReturnType<typeof setTimeout> | null
+  /** Callers waiting on the pending (debounced or trailing) run. */
+  pendingResolvers: Resolver<any>[]
+  /** Latest run fn wins for the pending run. */
+  pendingRun: (() => Promise<any>) | null
+  trailingRequested: boolean
+  backoffUntil: number | null
+  consecutive429: number
+}
+
+export class FreshAgentSnapshotScheduler {
+  private readonly keys = new Map<string, KeyState>()
+
+  private state(key: string): KeyState {
+    let s = this.keys.get(key)
+    if (!s) {
+      s = {
+        inFlight: false, debounceTimer: null, pendingResolvers: [],
+        pendingRun: null, trailingRequested: false, backoffUntil: null, consecutive429: 0,
+      }
+      this.keys.set(key, s)
+    }
+    return s
+  }
+
+  getBackoffUntil(key: string): number | null {
+    const s = this.keys.get(key)
+    if (!s?.backoffUntil) return null
+    if (s.backoffUntil <= Date.now()) return null
+    return s.backoffUntil
+  }
+
+  schedule<T>(key: string, trigger: SnapshotTrigger, run: () => Promise<T>): Promise<SnapshotOutcome<T>> {
+    const s = this.state(key)
+    const retryAt = this.getBackoffUntil(key)
+    if (retryAt !== null) {
+      return Promise.resolve({ status: 'backoff', retryAtMs: retryAt })
+    }
+    return new Promise<SnapshotOutcome<T>>((resolve) => {
+      s.pendingResolvers.push(resolve as Resolver<any>)
+      s.pendingRun = run
+      if (s.inFlight) {
+        s.trailingRequested = true
+        return
+      }
+      const delay = DEBOUNCED_TRIGGERS.has(trigger) ? SNAPSHOT_DEBOUNCE_MS : 0
+      if (s.debounceTimer !== null) {
+        if (delay === 0) {
+          clearTimeout(s.debounceTimer)
+          s.debounceTimer = null
+          void this.execute(key)
+        }
+        return // burst absorbed into the pending timer
+      }
+      if (delay === 0) {
+        void this.execute(key)
+      } else {
+        s.debounceTimer = setTimeout(() => {
+          s.debounceTimer = null
+          void this.execute(key)
+        }, delay)
+      }
+    })
+  }
+
+  private async execute(key: string): Promise<void> {
+    const s = this.state(key)
+    const run = s.pendingRun
+    const resolvers = s.pendingResolvers
+    s.pendingRun = null
+    s.pendingResolvers = []
+    if (!run) return
+    s.inFlight = true
+    let outcome: SnapshotOutcome<any>
+    try {
+      const value = await run()
+      s.consecutive429 = 0
+      s.backoffUntil = null
+      outcome = { status: 'ok', value }
+    } catch (error: unknown) {
+      if (error instanceof ApiError && error.status === 429) {
+        s.consecutive429 += 1
+        const fallback = Math.min(BACKOFF_MAX_MS, BACKOFF_BASE_MS * 2 ** (s.consecutive429 - 1))
+        const retryAtMs = Date.now() + (error.retryAfterMs ?? fallback)
+        s.backoffUntil = retryAtMs
+        // A 429 supersedes any trailing request: suppress until expiry.
+        s.trailingRequested = false
+        outcome = { status: 'rate-limited', retryAtMs }
+      } else {
+        outcome = { status: 'error', error }
+      }
+    }
+    s.inFlight = false
+    for (const resolve of resolvers) resolve(outcome)
+    if (s.trailingRequested && s.pendingRun) {
+      s.trailingRequested = false
+      s.debounceTimer = setTimeout(() => {
+        s.debounceTimer = null
+        void this.execute(key)
+      }, SNAPSHOT_DEBOUNCE_MS)
+    } else {
+      s.trailingRequested = false
+    }
+  }
+}
+
+let singleton: FreshAgentSnapshotScheduler | null = null
+
+export function getSnapshotScheduler(): FreshAgentSnapshotScheduler {
+  if (!singleton) singleton = new FreshAgentSnapshotScheduler()
+  return singleton
+}
+
+export function resetSnapshotSchedulerForTests(): void {
+  singleton = null
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test:vitest -- --run test/unit/client/lib/fresh-agent-snapshot-scheduler.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Refactor check** — confirm no `any` leaks into the public API besides the internal `Resolver<any>` plumbing; run the lint pass: `npm run lint -- src/lib/fresh-agent-snapshot-scheduler.ts` (fix if needed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/fresh-agent-snapshot-scheduler.ts test/unit/client/lib/fresh-agent-snapshot-scheduler.test.ts
+git commit -m "feat(client): per-key fresh-agent snapshot scheduler with coalesce and 429 backoff (zrrj)"
+```
+
+---
+
+### Task 3: Route every FreshAgentView refresh trigger through the scheduler; 429 keeps last-good snapshot
+
+Replace the per-component debounce (`scheduleSnapshotRefresh`, `FreshAgentView.tsx:815-828`) and the three direct nonce bumps (materialization `:1495`, pane refresh `:1065`, poll `:1930`) with a single trigger-tagged path. The fetch effect executes through the scheduler so N panes on one key share one GET. A 429/backoff outcome keeps the last good snapshot visible (no `setLoadError`) and re-arms a retry at `retryAtMs`.
+
+**Files:**
+- Modify: `src/components/fresh-agent/FreshAgentView.tsx` (trigger sites `:815-828`, `:1065`, `:1376-1389`, `:1495`, `:1516-1551`, `:1593-1781`, `:1926-1933`)
+- Test: `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx` (mock scaffold at `:20-110`)
+
+**Interfaces:**
+- Consumes: `getSnapshotScheduler()`, `makeSnapshotKey()`, `SnapshotTrigger`, `resetSnapshotSchedulerForTests()` from `@/lib/fresh-agent-snapshot-scheduler` (Task 2); `getFreshAgentThreadSnapshot(sessionType, provider, threadId, {revision?, cwd?, signal?})` from `@/lib/api`.
+- Produces: internal `requestSnapshotRefresh(trigger: SnapshotTrigger)` callback used by all trigger sites; a `snapshotRefreshTriggerRef: React.MutableRefObject<SnapshotTrigger>` consumed by the fetch effect; component state `rateLimitedUntil: number | null` (used by Task 17's `trigger` query param as well).
+
+**Design (implement exactly):**
+1. Keep `snapshotRefreshNonce` as the effect driver, but replace `scheduleSnapshotRefresh` with:
+
+```ts
+const snapshotRefreshTriggerRef = useRef<SnapshotTrigger>('identity')
+const requestSnapshotRefresh = useCallback((trigger: SnapshotTrigger) => {
+  snapshotRefreshTriggerRef.current = trigger
+  setSnapshotRefreshNonce((value) => value + 1)
+}, [])
+```
+
+All eight trigger sites call `requestSnapshotRefresh(<trigger>)` with: identity → (effect deps, unchanged), WS invalidating event → `'event'`, send.accepted → `'send-accepted'` (keep the existing `ownsRequest` + `locatorMatchesPane` gates at `:1516-1543` — they are required by the kata's "filter send.accepted refreshes to the owning pane/session"), materialized → `'materialized'`, pane refresh request → `'manual'`, 3s poll → `'poll'`, reconnect → `'reconnect'`, reveal-after-hidden → `'reveal'`. Delete `snapshotRefreshTimerRef` / `snapshotRefreshFollowUpRef` / `SNAPSHOT_REFRESH_COALESCE_MS` and their cleanup (`:830-836`) — debounce now lives in the scheduler.
+
+2. In the fetch effect (`:1593`), wrap the network call:
+
+```ts
+const requestCwd = paneContentRef.current.initialCwd
+const key = makeSnapshotKey({ sessionType: requestSessionType, provider, threadId: sessionId, cwd: requestCwd })
+const trigger = snapshotRefreshTriggerRef.current
+void getSnapshotScheduler().schedule(key, trigger, () =>
+  getFreshAgentThreadSnapshot(requestSessionType, provider, sessionId, {
+    signal: controller.signal,
+    ...(requestCwd ? { cwd: requestCwd } : {}),
+  }),
+).then((outcome) => {
+  if (isStaleSnapshotRequest()) return
+  if (outcome.status === 'ok') {
+    applySnapshot(outcome.value)            // the existing .then body :1618-1707, extracted
+    return
+  }
+  if (outcome.status === 'rate-limited' || outcome.status === 'backoff') {
+    // Keep the last good snapshot visible; no error banner. Re-arm one retry at expiry.
+    setRateLimitedUntil(outcome.retryAtMs)
+    const delay = Math.max(0, outcome.retryAtMs - Date.now())
+    rateLimitRetryTimerRef.current = window.setTimeout(() => {
+      rateLimitRetryTimerRef.current = null
+      setRateLimitedUntil(null)
+      requestSnapshotRefresh('manual')
+    }, delay + 50)
+    return
+  }
+  if (outcome.status === 'coalesced') return
+  handleSnapshotError(outcome.error)        // the existing .catch body :1708-1752, extracted
+})
+```
+
+Extract the existing `.then` body into `applySnapshot(next)` and the `.catch` body into `handleSnapshotError(error)` (same closure variables — extraction, not rewrite). Add `rateLimitRetryTimerRef = useRef<number | null>(null)` with clear-on-unmount, and dedupe: if a retry timer is already armed, don't arm a second.
+
+3. Key derivation hazard (report §3): the key MUST be built from the exact request tuple (`initialCwd`), not `freshOpenCodeRouteCwd`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`, add to the file-top scaffold: `import { resetSnapshotSchedulerForTests } from '@/lib/fresh-agent-snapshot-scheduler'` and call it in the file's `beforeEach`. The scheduler is real (not mocked) — only `@/lib/api` stays mocked. Add a new `describe('snapshot scheduler integration', ...)` block modeled on the existing session.changed test at `:3828+` (same store/render/wsHandler-capture pattern):
+
+```ts
+describe('snapshot scheduler integration (zrrj)', () => {
+  it('coalesces a burst of freshopencode session.changed events into one snapshot GET', async () => {
+    // Arrange: render one freshopencode pane bound to ses_1 (copy the arrange from the
+    // ':3828' analogue, provider 'opencode', sessionType 'freshopencode', sessionId 'ses_1').
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(makeSnapshot({ threadId: 'ses_1' }))
+    render(<StoreBackedFreshAgentView ... />)
+    await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1)) // identity fetch
+    apiMock.getFreshAgentThreadSnapshot.mockClear()
+
+    // Act: 10 invalidations in a burst
+    for (let i = 0; i < 10; i++) {
+      act(() => wsHandler({
+        type: 'freshAgent.event', sessionId: 'ses_1', sessionType: 'freshopencode', provider: 'opencode',
+        event: { type: 'freshAgent.session.changed', sessionId: 'ses_1' },
+      }))
+    }
+    // Assert: exactly one trailing GET, not ten
+    await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1))
+    await new Promise((r) => setTimeout(r, 400))
+    expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the last good snapshot visible and stops fetching during 429 backoff', async () => {
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValueOnce(makeSnapshot({ threadId: 'ses_1', turns: [turnWithText('hello world')] }))
+    render(<StoreBackedFreshAgentView ... />)
+    await screen.findByText('hello world')
+    apiMock.getFreshAgentThreadSnapshot.mockRejectedValue(new ApiError(429, 'Too many requests', undefined, 60_000))
+
+    act(() => wsHandler(sessionChangedFor('ses_1')))
+    await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(2))
+    // transcript still visible, no load error
+    expect(screen.getByText('hello world')).toBeInTheDocument()
+    expect(screen.queryByText(/Too many requests/)).not.toBeInTheDocument()
+
+    // further invalidations are suppressed without network
+    act(() => wsHandler(sessionChangedFor('ses_1')))
+    await new Promise((r) => setTimeout(r, 400))
+    expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not refetch when another session sends (send.accepted for a foreign request)', async () => {
+    // existing gate regression: a send.accepted with an unowned requestId must trigger zero GETs
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(makeSnapshot({ threadId: 'ses_1' }))
+    render(<StoreBackedFreshAgentView ... />)
+    await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1))
+    apiMock.getFreshAgentThreadSnapshot.mockClear()
+    act(() => wsHandler({
+      type: 'freshAgent.send.accepted', requestId: 'someone-elses-request',
+      sessionId: 'ses_1', sessionType: 'freshopencode', provider: 'opencode',
+    }))
+    await new Promise((r) => setTimeout(r, 400))
+    expect(apiMock.getFreshAgentThreadSnapshot).not.toHaveBeenCalled()
+  })
+})
+```
+
+Use the file's existing helpers for arranging pane content and snapshots (`makeSnapshot`-style builders exist near the top of the file; if named differently, reuse whatever the `:3828` analogue uses — do not invent parallel builders). `ApiError` is imported from the actual module: `import { ApiError } from '@/lib/api'` (the `vi.mock('@/lib/api')` uses `importActual` spread, so the real class is preserved).
+
+- [ ] **Step 2: Run to verify the new tests fail**
+
+Run: `npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
+Expected: burst test FAILS (multiple GETs today); 429 test FAILS (load error shown, refetches continue).
+
+- [ ] **Step 3: Implement the integration** as specified in the Design block above.
+
+- [ ] **Step 4: Run to verify all pass**
+
+Run: `npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentView.test.tsx test/unit/client/lib/fresh-agent-snapshot-scheduler.test.ts`
+Expected: PASS, including all pre-existing FreshAgentView tests (the refactor must not regress the `:3828` "refreshes freshopencode on session.changed without reopening the bouncer" behavior — one trailing refresh still happens, just debounced 250 ms).
+
+- [ ] **Step 5: Run sibling suites that share the scaffold**
+
+Run: `npm run test:vitest -- --run test/unit/client/components/fresh-agent/`
+Expected: PASS (`FreshAgentView.reconcile.test.tsx`, `FreshAgentView.hidden-rebind.test.tsx` unaffected or updated for the new trigger API).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/fresh-agent/FreshAgentView.tsx test/unit/client/components/fresh-agent/
+git commit -m "feat(client): route all snapshot refresh triggers through the per-key scheduler with 429 backoff (zrrj)"
+```
+
+---
+
+### Task 4: A successful idle HTTP snapshot clears stale opencode busy state
+
+Today the HTTP snapshot result writes `setSessionStatus` only for `provider === 'codex' && sessionType === 'freshcodex'` (`FreshAgentView.tsx:1670-1687`). For opencode, busy is only cleared by a WS event — if that event was dropped (restart, backpressure), the pane stays busy and the 3s poll runs forever. Extend the same guarded write to freshopencode.
+
+**Files:**
+- Modify: `src/components/fresh-agent/FreshAgentView.tsx:1670-1687` (inside `applySnapshot` after Task 3's extraction)
+- Test: `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
+
+**Interfaces:**
+- Consumes: `setSessionStatus` action from `src/store/freshAgentSlice.ts`; snapshot `status` field (`'running' | 'idle'` from `normalizeOpencodeSnapshot`).
+- Produces: no new API — behavior change only.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('clears stale opencode busy state from a successful idle HTTP snapshot', async () => {
+  // Arrange: store preloaded with freshAgent session status 'running' for
+  // key {sessionId: 'ses_1', sessionType: 'freshopencode', provider: 'opencode'}
+  // (use the store scaffold's preloadedState like the codex analogue test does).
+  apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(makeSnapshot({ threadId: 'ses_1', status: 'idle' }))
+  const { store } = renderWithStore(...)   // the file's store-returning arrange helper
+  await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalled())
+  await waitFor(() => {
+    const key = makeFreshAgentSessionKey({ sessionId: 'ses_1', sessionType: 'freshopencode', provider: 'opencode' })
+    expect(store.getState().freshAgent.sessions[key]?.status).toBe('idle')
+  })
+})
+```
+
+Find the existing codex analogue (search the test file for `setSessionStatus` or `freshcodex.*idle`) and mirror its arrange/assert precisely for opencode.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentView.test.tsx -t "clears stale opencode busy"`
+Expected: FAIL — status stays `'running'`.
+
+- [ ] **Step 3: Implement**
+
+At `:1670-1687`, generalize the provider gate:
+
+```ts
+const canAdoptSnapshotStatus =
+  (provider === 'codex' && requestSessionType === 'freshcodex')
+  || (provider === 'opencode' && requestSessionType === 'freshopencode')
+if (
+  sessionStatus
+  && nextSessionId
+  && canAdoptSnapshotStatus
+  && !wouldRegressStatus
+  && (
+    snapshotIsBusy
+    || (!hasBlockingLocalEchoForSession && !statusChangedSinceRequest)
+  )
+) {
+  dispatch(setSessionStatus({
+    sessionId: nextSessionId,
+    sessionType: requestSessionType,
+    provider,
+    status: sessionStatus,
+  }))
+}
+```
+
+All existing guards (`wouldRegressStatus`, `statusChangedSinceRequest` via `agentSessionStatusVersionRef`, `hasBlockingLocalEchoForSession`) stay — they are the race protection that made the codex version safe.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
+Expected: PASS (including the codex analogue tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/fresh-agent/FreshAgentView.tsx test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+git commit -m "fix(client): let idle HTTP snapshots clear stale freshopencode busy state (zrrj)"
+```
+
+---
+
+### Task 5: Global limiter factory with JSON 429 body (same limits) + limiter test coverage
+
+The limiter currently returns a plain-text 429 body while every other error in the codebase is JSON, and it has zero test coverage because it's configured inline in `main()` (`server/index.ts:204-212`). Extract a factory with an identical budget and a JSON handler that includes `retryAfterSeconds`. **The budget (300/60s) must not change.**
+
+**Files:**
+- Create: `server/rate-limit.ts`
+- Modify: `server/index.ts:204-212` (use the factory)
+- Test: `test/unit/server/rate-limit.test.ts`
+
+**Interfaces:**
+- Consumes: `express-rate-limit` v7.5.1 (`standardHeaders: true` already sets `Retry-After` + `RateLimit-*` on 429s).
+- Produces: `createApiRateLimiter(options?: { windowMs?: number; max?: number })` returning Express middleware. 429 body: `{ error: 'Too many requests', code: 'RATE_LIMITED', retryAfterSeconds: number }`. Options exist ONLY so tests can use a tiny budget; production call passes nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/server/rate-limit.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { createApiRateLimiter } from '../../../server/rate-limit.js'
+
+function makeApp(limiter = createApiRateLimiter({ windowMs: 60_000, max: 2 })) {
+  const app = express()
+  app.use('/api', limiter)
+  app.get('/api/ping', (_req, res) => { res.json({ ok: true }) })
+  return app
+}
+
+describe('createApiRateLimiter', () => {
+  it('defaults to the production budget of 300 per 60s', () => {
+    // Guard against accidental weakening: the factory must default to 300/60_000.
+    const limiter = createApiRateLimiter() as unknown as { options?: unknown }
+    // express-rate-limit v7 middleware does not expose options; assert via the
+    // exported constants instead:
+    expect(API_RATE_LIMIT_WINDOW_MS).toBe(60_000)
+    expect(API_RATE_LIMIT_MAX).toBe(300)
+    expect(typeof limiter).toBe('function')
+  })
+
+  it('returns a JSON 429 with code RATE_LIMITED and retryAfterSeconds, plus Retry-After header', async () => {
+    const app = makeApp()
+    await request(app).get('/api/ping').expect(200)
+    await request(app).get('/api/ping').expect(200)
+    const res = await request(app).get('/api/ping').expect(429)
+    expect(res.headers['retry-after']).toMatch(/^\d+$/)
+    expect(res.body).toMatchObject({ error: 'Too many requests', code: 'RATE_LIMITED' })
+    expect(res.body.retryAfterSeconds).toBe(Number(res.headers['retry-after']))
+    expect(res.type).toMatch(/json/)
+  })
+})
+```
+
+(Also import `API_RATE_LIMIT_WINDOW_MS`, `API_RATE_LIMIT_MAX` from the same module.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test:vitest -- --run test/unit/server/rate-limit.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `server/rate-limit.ts`**
+
+```ts
+import rateLimit from 'express-rate-limit'
+import type { Request, Response } from 'express'
+
+export const API_RATE_LIMIT_WINDOW_MS = 60_000
+export const API_RATE_LIMIT_MAX = 300
+
+/**
+ * Global /api rate limiter. Budget is intentionally identical to the previous
+ * inline configuration (300 req / 60 s / IP) — do NOT raise it here; the fix
+ * for snapshot storms is client-side scheduling + backoff, not a bigger budget.
+ * This factory only adds a JSON 429 body (with retryAfterSeconds) and testability.
+ */
+export function createApiRateLimiter(options: { windowMs?: number; max?: number } = {}) {
+  return rateLimit({
+    windowMs: options.windowMs ?? API_RATE_LIMIT_WINDOW_MS,
+    max: options.max ?? API_RATE_LIMIT_MAX,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (_req: Request, res: Response) => {
+      const retryAfterHeader = res.getHeader('Retry-After')
+      const retryAfterSeconds = Number(retryAfterHeader) || Math.ceil((options.windowMs ?? API_RATE_LIMIT_WINDOW_MS) / 1000)
+      res.status(429).json({ error: 'Too many requests', code: 'RATE_LIMITED', retryAfterSeconds })
+    },
+  })
+}
+```
+
+In `server/index.ts`, replace the inline block at `:204-212` with:
+
+```ts
+import { createApiRateLimiter } from './rate-limit.js'
+// ...
+app.use('/api', createApiRateLimiter())
+```
+
+and remove the now-unused `import rateLimit from 'express-rate-limit'` at `:11` if nothing else uses it.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm run test:vitest -- --run test/unit/server/rate-limit.test.ts`
+Expected: PASS. Then `npm run check` typecheck portion (or `npx tsc -p . --noEmit` equivalent used by the repo's `check` script) to confirm `server/index.ts` compiles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/rate-limit.ts server/index.ts test/unit/server/rate-limit.test.ts
+git commit -m "feat(server): JSON 429 body with retryAfterSeconds on the global /api limiter, same budget (zrrj)"
+```
+
+---
+
+### Task 6: Always-on fresh-agent observability logger, expanded event union, and full 429 route coverage
+
+Two production defects in the observability layer: (1) the sink is the main `logger`, which sits at level `warn` with the Debug toggle off — so the already-shipped `fresh_agent_snapshot_served` / `fresh_agent_opencode_status_observed` `info` rows are **invisible in production** (`server/fresh-agent/observability.ts:44-100`, `server/logger.ts:20,218-220`); (2) `SNAPSHOT_PATH_PATTERN` (`observability.ts:102`) only matches the 3-segment snapshot path, so `/turns` and `/turns/:turnId` 429s are never recorded. Fix both and add the event kinds the rest of this plan emits.
+
+**Files:**
+- Modify: `server/logger.ts` (new dedicated logger, factory pattern at `:210-216`)
+- Modify: `server/fresh-agent/observability.ts`
+- Test: `test/unit/server/fresh-agent/observability.test.ts` (existing patterns at `:1-50`)
+
+**Interfaces:**
+- Consumes: `createSessionLifecycleLogger`-style factory in `server/logger.ts:210-216`; `sessionLifecycleLogger` precedent (`:314-317`).
+- Produces:
+  - `server/logger.ts`: `export const freshAgentObservabilityLogger` — pino instance pinned at `level: 'info'` writing `~/.freshell/logs/fresh-agent.<mode>.<instance>.jsonl` (10 MB × 10, same rotation options as sessionLifecycle; returns a silent logger under test runtime exactly like the existing factory does).
+  - `server/fresh-agent/observability.ts`: default sink becomes `freshAgentObservabilityLogger`; union extended with these kinds (all payloads identity-hashed, **no message content**):
+
+```ts
+| { kind: 'fresh_agent_send'; sessionType: string; provider: string; sessionIdHash: string; cwdHash?: string; requestId?: string; outcome: 'accepted' | 'failed'; errorCode?: string; durationMs?: number }
+| { kind: 'fresh_agent_interrupt'; sessionType: string; provider: string; sessionIdHash: string; cwdHash?: string; outcome: 'ok' | 'failed'; errorCode?: string }
+| { kind: 'fresh_agent_attach'; sessionType: string; provider: string; sessionIdHash: string; cwdHash?: string; outcome: 'ok' | 'failed'; errorCode?: string; recovered?: boolean }
+| { kind: 'fresh_agent_materialized'; sessionType: string; provider: string; previousSessionIdHash: string; sessionIdHash: string; cwdHash?: string }
+| { kind: 'fresh_agent_monitor'; provider: 'opencode'; sessionIdHash: string; cwdHash?: string; phase: 'armed' | 'resolved_idle' | 'timeout' | 'sidecar_lost' | 'duplicate_suppressed'; sidecarGeneration?: number }
+| { kind: 'fresh_agent_sidecar'; provider: 'opencode'; phase: 'started' | 'exited' | 'discarded'; generation: number; pid?: number; baseUrl?: string; reason?: string; code?: number | null; signal?: string | null }
+| { kind: 'fresh_agent_snapshot_failed'; sessionType: string; provider: string; threadIdHash?: string; httpStatus: number; code?: string; durationMs?: number; trigger?: string; cwdHash?: string }
+| { kind: 'fresh_agent_turn_recovery'; provider: 'opencode'; sessionIdHash: string; cwdHash?: string; action: 'continuation_injected' | 'suppressed_user_stop' | 'suppressed_user_followup' | 'suppressed_already_recovered' | 'suppressed_low_confidence'; reason: string; messageIdHash?: string }
+```
+
+  - `fresh_agent_snapshot_served` gains optional `trigger?: string`; `fresh_agent_snapshot_rate_limited` gains optional `retryAfterSeconds?: number; trigger?: string` and its route pattern covers all three thread routes.
+  - Severity rule extended: `fresh_agent_snapshot_rate_limited`, `fresh_agent_sidecar` with `phase !== 'started'`, `fresh_agent_monitor` with `phase: 'timeout' | 'sidecar_lost'`, and `fresh_agent_snapshot_failed` log at `warn`; everything else at `info`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend `test/unit/server/fresh-agent/observability.test.ts` (reuse its `__setFreshAgentObservabilitySinkForTest` seam and supertest middleware harness):
+
+```ts
+it('records 429s on the /turns and /turns/:turnId routes with retryAfterSeconds', async () => {
+  const app = express()
+  app.use('/fresh-agent/threads', createFreshAgentSnapshotRateLimitMiddleware())
+  app.get('*', (_req, res) => { res.setHeader('Retry-After', '42'); res.status(429).end() })
+  await request(app).get('/fresh-agent/threads/freshopencode/opencode/ses_abc/turns').expect(429)
+  await request(app).get('/fresh-agent/threads/freshopencode/opencode/ses_abc/turns/turn_1').expect(429)
+  expect(warnSpy).toHaveBeenCalledTimes(2)
+  const first = warnSpy.mock.calls[0][0]
+  expect(first).toMatchObject({
+    event: 'fresh_agent_snapshot_rate_limited',
+    sessionType: 'freshopencode',
+    provider: 'opencode',
+    retryAfterSeconds: 42,
+  })
+  expect(first.threadIdHash).toBe(hashForLogs('ses_abc'))
+})
+
+it('routes info events through the dedicated fresh-agent logger by default', async () => {
+  // Reset the sink override, then spy on freshAgentObservabilityLogger directly.
+  // (vi.mock server/logger.js already exists at the top of this file — add
+  //  freshAgentObservabilityLogger: { info: vi.fn(), warn: vi.fn() } to the mock factory
+  //  and assert recordFreshAgentObservabilityEvent hits IT, not `logger`.)
+})
+
+it('accepts the new event kinds with warn severity for incident kinds', () => {
+  recordFreshAgentObservabilityEvent({
+    kind: 'fresh_agent_monitor', provider: 'opencode',
+    sessionIdHash: hashForLogs('ses_x'), phase: 'sidecar_lost', sidecarGeneration: 3,
+  })
+  expect(warnSpy).toHaveBeenCalledWith(
+    expect.objectContaining({ event: 'fresh_agent_monitor', phase: 'sidecar_lost' }),
+    'fresh_agent_monitor',
+  )
+  recordFreshAgentObservabilityEvent({
+    kind: 'fresh_agent_send', sessionType: 'freshopencode', provider: 'opencode',
+    sessionIdHash: hashForLogs('ses_x'), outcome: 'accepted',
+  })
+  expect(infoSpy).toHaveBeenCalledWith(
+    expect.objectContaining({ event: 'fresh_agent_send', outcome: 'accepted' }),
+    'fresh_agent_send',
+  )
+})
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/observability.test.ts`
+Expected: FAIL — `/turns` rows not recorded; new kinds rejected by TS; sink still main logger.
+
+- [ ] **Step 3: Implement**
+
+1. `server/logger.ts` — beside `sessionLifecycleLogger` (`:314-317`), using the same factory shape as `createSessionLifecycleLogger` (`:210-216`):
+
+```ts
+export const freshAgentObservabilityLogger = createDedicatedFileLogger({
+  name: 'fresh-agent',
+  level: 'info',
+  maxSize: '10M',
+  maxFiles: 10,
+})
+```
+
+If the existing factory is literally `createSessionLifecycleLogger()` (hardcoded name), generalize it minimally: rename its internals to `createDedicatedFileLogger({ name, ... })` and re-express `sessionLifecycleLogger` through it — behavior-preserving refactor, existing session-observability tests must stay green.
+
+2. `server/fresh-agent/observability.ts`:
+   - `import { freshAgentObservabilityLogger } from '../logger.js'` and set `const defaultSink: FreshAgentObservabilitySink = freshAgentObservabilityLogger`.
+   - Add the new event kinds to the union exactly as specified in Interfaces.
+   - Extend the severity split in `recordFreshAgentObservabilityEvent`:
+
+```ts
+const WARN_KINDS = new Set(['fresh_agent_snapshot_rate_limited', 'fresh_agent_snapshot_failed'])
+function isWarnEvent(event: FreshAgentObservabilityEvent): boolean {
+  if (WARN_KINDS.has(event.kind)) return true
+  if (event.kind === 'fresh_agent_sidecar') return event.phase !== 'started'
+  if (event.kind === 'fresh_agent_monitor') return event.phase === 'timeout' || event.phase === 'sidecar_lost'
+  return false
+}
+```
+
+   - Replace `SNAPSHOT_PATH_PATTERN` and enrich the middleware:
+
+```ts
+const SNAPSHOT_PATH_PATTERN = /^\/([^/]+)\/([^/]+)\/([^/]+)(?:\/turns(?:\/[^/]+)?)?$/
+
+export function createFreshAgentSnapshotRateLimitMiddleware() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const match = SNAPSHOT_PATH_PATTERN.exec(req.path)
+    if (match) {
+      const [, sessionType, provider, threadId] = match
+      const trigger = typeof req.query.trigger === 'string' ? req.query.trigger.slice(0, 32) : undefined
+      res.on('finish', () => {
+        if (res.statusCode === 429) {
+          const retryAfterSeconds = Number(res.getHeader('Retry-After')) || undefined
+          recordFreshAgentObservabilityEvent({
+            kind: 'fresh_agent_snapshot_rate_limited',
+            sessionType, provider,
+            threadIdHash: hashForLogs(threadId),
+            httpStatus: 429,
+            route: `/fresh-agent/threads/${sessionType}/${provider}/:threadId`,
+            ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
+            ...(trigger ? { trigger } : {}),
+          })
+        }
+      })
+    }
+    next()
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/observability.test.ts test/unit/server/session-observability.test.ts`
+Expected: PASS (both — the logger refactor must not break session lifecycle logging).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/logger.ts server/fresh-agent/observability.ts test/unit/server/fresh-agent/observability.test.ts
+git commit -m "feat(server): always-on fresh-agent observability logger, expanded event kinds, /turns 429 coverage (zrrj)"
+```
+
+---
+
+### Task 7: Serve-manager: sidecar generation identity + subscriptions survive sidecar replacement
+
+Two defects in `server/fresh-agent/adapters/opencode/serve-manager.ts`: (1) `emitLostForAllSessions()` clears `sessionEmitters` (`serve-manager.ts:126-132`, clear at `:128`), so every adapter listener is orphaned on the dead emitter object while a replacement sidecar dispatches to brand-new emitters — live events are lost forever after any sidecar replacement; (2) there is no generation/PID identity (`RunningServe` at `:61-66` holds only `baseUrl`/`ownershipId`/`child`/`stopEventStream`), so nothing can attribute a monitored wait or a log row to a specific sidecar. The kata offers a choice ("survive replacement, OR invalidate and rebind"); choose **survive**: keep the emitter objects in the map across replacement, emit `'lost'` on them, and let the replacement sidecar dispatch into the same objects. Prove it with tests.
+
+**Files:**
+- Modify: `server/fresh-agent/adapters/opencode/serve-manager.ts`
+- Test: `test/unit/server/fresh-agent/opencode-serve-manager.test.ts` (harness `makeManager`/`fakeChild`/`jsonResponse` at `:8-45`)
+
+**Interfaces:**
+- Consumes: existing `OpencodeServeManager` internals: `start()` `:196-261`, `discardRunning()` `:134-143`, child `'close'` handler `:220-230`, `emitterFor()` `:419-427`, `subscribe()` `:434-438`, `onceIdle()` `:440-520`.
+- Produces (Tasks 8, 17, 18 depend on these):
+  - `describeSidecar(): { generation: number; pid?: number; baseUrl: string; ownershipId: string } | undefined` — current running sidecar, else `undefined`.
+  - `currentGeneration(): number` — monotonically increasing, bumped on every successful `start()`; `0` before first start.
+  - `'lost'` events now carry the generation: `emitter.emit('lost', new OpencodeServeLostError(sessionId), { generation })` — existing consumers that only read the first arg keep working.
+  - `recordFreshAgentObservabilityEvent({ kind: 'fresh_agent_sidecar', ... })` emitted on `started` (after health gate), `exited` (child close), `discarded` (discardRunning) with `generation`, `pid`, `baseUrl`, `reason`/`code`/`signal`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `test/unit/server/fresh-agent/opencode-serve-manager.test.ts`:
+
+```ts
+describe('sidecar replacement resilience (zrrj)', () => {
+  it('keeps session subscriptions alive across sidecar replacement', async () => {
+    const manager = makeManager()
+    const seen: unknown[] = []
+    manager.subscribe('ses_1', (ev) => seen.push(ev))
+    await manager.ensureStarted()
+    // Kill the sidecar (fakeChild.kill() emits 'close') -> replacement on next call
+    // then dispatch an event as the REPLACEMENT sidecar would.
+    ;(manager as any).running.child.kill()
+    await manager.ensureStarted()
+    ;(manager as any).dispatchEvent({ kind: 'session.idle', sessionId: 'ses_1', properties: {}, raw: {} })
+    expect(seen).toHaveLength(1)   // FAILS today: listener orphaned on cleared emitter
+  })
+
+  it('still emits lost to onceIdle waiters when the sidecar dies', async () => {
+    const manager = makeManager()
+    await manager.ensureStarted()
+    const idle = manager.onceIdle('ses_1', 5_000)
+    ;(manager as any).running.child.kill()
+    await expect(idle).rejects.toBeInstanceOf(OpencodeServeLostError)
+  })
+
+  it('increments generation per start and exposes pid/baseUrl via describeSidecar', async () => {
+    const manager = makeManager()
+    expect(manager.currentGeneration()).toBe(0)
+    expect(manager.describeSidecar()).toBeUndefined()
+    await manager.ensureStarted()
+    expect(manager.currentGeneration()).toBe(1)
+    const desc = manager.describeSidecar()
+    expect(desc).toMatchObject({ generation: 1, baseUrl: expect.stringContaining('http://127.0.0.1:') })
+    ;(manager as any).running.child.kill()
+    await manager.ensureStarted()
+    expect(manager.currentGeneration()).toBe(2)
+  })
+})
+```
+
+Adjust the private-access spelling (`(manager as any).running` / `dispatchEvent`) to whatever the existing suite already uses to reach internals — this file already drives the real class with injected doubles; reuse its idioms (e.g. if existing tests trigger death via the injected `fetchFn` timeout instead, do the same).
+
+- [ ] **Step 2: Run to verify the replacement test fails**
+
+Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-manager.test.ts`
+Expected: "keeps session subscriptions alive across sidecar replacement" FAILS (0 events seen); generation tests FAIL (methods missing).
+
+- [ ] **Step 3: Implement**
+
+In `serve-manager.ts`:
+
+1. Add fields and accessors:
+
+```ts
+private generation = 0
+
+currentGeneration(): number { return this.generation }
+
+describeSidecar(): { generation: number; pid?: number; baseUrl: string; ownershipId: string } | undefined {
+  if (!this.running) return undefined
+  return {
+    generation: this.generation,
+    pid: this.running.child.pid ?? undefined,
+    baseUrl: this.running.baseUrl,
+    ownershipId: this.running.ownershipId,
+  }
+}
+```
+
+2. In `start()` after the health gate passes (`waitForHealth`, `:232` area) and `this.running` is assigned: `this.generation += 1`, then emit:
+
+```ts
+recordFreshAgentObservabilityEvent({
+  kind: 'fresh_agent_sidecar', provider: 'opencode', phase: 'started',
+  generation: this.generation, pid: child.pid ?? undefined, baseUrl,
+})
+```
+
+3. In the child `'close'` handler (`:220-230`) add `phase: 'exited'` with `{ generation: this.generation, code, signal }`; in `discardRunning(reason)` (`:134-143`) add `phase: 'discarded'` with `{ generation: this.generation, reason }`.
+
+4. Fix `emitLostForAllSessions()` — **do not clear the map**:
+
+```ts
+private emitLostForAllSessions(): void {
+  const generation = this.generation
+  for (const [sessionId, emitter] of this.sessionEmitters.entries()) {
+    emitter.emit('lost', new OpencodeServeLostError(sessionId), { generation })
+  }
+}
+```
+
+Memory note: emitters are already created lazily per session id and were only ever GC'd via this clear; to avoid unbounded growth add cleanup to the existing unsubscribe closure in `subscribe()` (`:434-438`): after `emitter.off('event', listener)`, if `emitter.listenerCount('event') === 0 && emitter.listenerCount('lost') === 0`, delete the map entry.
+
+5. `onceIdle`'s `'lost'` handler (`:516-518`) keeps working unchanged (extra emit arg ignored).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-manager.test.ts`
+Expected: PASS, including all pre-existing lifecycle tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/fresh-agent/adapters/opencode/serve-manager.ts test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+git commit -m "fix(server): opencode serve subscriptions survive sidecar replacement; add generation/pid identity (zrrj)"
+```
+
+---
+
+### Task 8: Adapter: reconcile emits status + exactly one monitored idle-recovery per durable session + structured interruption on loss
+
+Gaps G1/G2/G5 (`server/fresh-agent/adapters/opencode/adapter.ts`): `reconcileStatus` (`:155-200`) silently sets `state.status = 'running'` without `emitStatus()` — the client never learns; nothing re-arms an idle waiter for a restored running session — no idle/turn-complete ever arrives; the adapter never listens for `'lost'` — sidecar loss leaves restored panes busy forever.
+
+**Files:**
+- Modify: `server/fresh-agent/adapters/opencode/adapter.ts`
+- Test: `test/unit/server/fresh-agent/opencode-serve-adapter.test.ts` (harness `makeFakeManager`/`makeAdapter`/`createDeferred` at `:32-87`)
+
+**Interfaces:**
+- Consumes: `serveManager.onceIdle(realId, timeoutMs, route?)`, `serveManager.getSessionStatus`, `serveManager.subscribe`, `serveManager.currentGeneration()` (Task 7); `emitStatus(state, status)` `:301-312`; `nextMonotonicTurnCompleteAt` (`turn-complete-clock.ts`); `recordFreshAgentObservabilityEvent` (Task 6).
+- Produces:
+  - `reconcileStatus` calls `emitStatus(state, 'running' | 'idle')` instead of mutating silently (so `sdk.session.snapshot` reaches the client on restore).
+  - Module-scope `const idleRecoveryMonitors = new Map<string, Promise<void>>()` keyed by real `ses_` id — the "exactly one monitored idle-recovery per durable session key" registry.
+  - `armIdleRecovery(state: OpencodeSessionState): void` — no-op if a monitor for `state.realSessionId` exists (`fresh_agent_monitor` `duplicate_suppressed`); otherwise arms `onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS, route)`:
+    - resolve → `emitStatus(state, 'idle')`; emit `sdk.turn.complete` **only** when `!state.turnAborted && !state.turnErrored` (restored sessions: both `undefined` → falsy → chime allowed; the pre-restart error is unobservable and OpenCode reporting busy→idle is the best signal we have — matches the prior wave's constraint "do not claim recovery unless OpenCode reports busy/retry", which gated *arming*, not the chime); monitor row `resolved_idle`.
+    - reject (timeout / `OpencodeServeLostError`) → `emitStatus(state, 'idle')` + `state.events.emit('event', { type: 'sdk.error', sessionId: state.placeholderId, message: 'OpenCode turn interrupted: <timeout|sidecar lost>' })`; monitor row `timeout`/`sidecar_lost`. Never leaves the pane busy.
+    - always: delete the registry entry on settle.
+  - `bindServeStream` additionally registers a `'lost'` listener (via a new `subscribeLost` manager passthrough or by subscribing on the same emitter — implement as a second `serveManager.subscribe`-style hook; simplest: extend `subscribe(id, listener, onLost?)` in serve-manager with an optional third arg attached to `'lost'`): on lost, if `state.status === 'running'`, `emitStatus(state, 'idle')` + the same `sdk.error` interruption signal. (With Task 7, the same subscription keeps receiving events from the replacement sidecar — no rebind needed.)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `opencode-serve-adapter.test.ts`:
+
+```ts
+describe('restore reconciliation emits and monitors (zrrj)', () => {
+  it('emits a running session snapshot when attach reconciles a busy durable session', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue({ type: 'busy' })
+    const adapter = makeAdapter(manager)
+    const events: any[] = []
+    await adapter.attach!({ sessionId: 'ses_live', cwd: '/w' })
+    adapter.subscribe('ses_live', (ev) => events.push(ev))   // use the adapter's actual subscribe surface
+    // If subscription must precede attach in this adapter, reorder — assert on the emitted event either way:
+    expect(events.some((e) => e.type === 'sdk.session.snapshot' && e.status === 'running')
+      || manager.onceIdle.mock.calls.length > 0).toBe(true)
+    // Primary assertion: a status event was EMITTED (not just state mutated)
+  })
+
+  it('arms exactly one idle-recovery monitor per durable session and chimes on resolve', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue({ type: 'busy' })
+    const idle = createDeferred<void>()
+    manager.onceIdle.mockReturnValue(idle.promise)
+    const adapter = makeAdapter(manager)
+    const events: any[] = []
+    await adapter.attach!({ sessionId: 'ses_live', cwd: '/w' })
+    await adapter.attach!({ sessionId: 'ses_live', cwd: '/w' })   // second restore path
+    expect(manager.onceIdle).toHaveBeenCalledTimes(1)              // exactly ONE monitor
+    adapter.subscribe('ses_live', (ev) => events.push(ev))
+    idle.resolve()
+    await new Promise((r) => setImmediate(r))
+    expect(events.some((e) => e.type === 'sdk.session.snapshot' && e.status === 'idle')).toBe(true)
+    expect(events.some((e) => e.type === 'sdk.turn.complete' && typeof e.at === 'number')).toBe(true)
+  })
+
+  it('emits idle + a structured interruption signal when the monitor rejects with sidecar loss', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue({ type: 'busy' })
+    const idle = createDeferred<void>()
+    manager.onceIdle.mockReturnValue(idle.promise)
+    const adapter = makeAdapter(manager)
+    const events: any[] = []
+    await adapter.attach!({ sessionId: 'ses_live', cwd: '/w' })
+    adapter.subscribe('ses_live', (ev) => events.push(ev))
+    idle.reject(new OpencodeServeLostError('ses_live'))
+    await new Promise((r) => setImmediate(r))
+    expect(events.some((e) => e.type === 'sdk.session.snapshot' && e.status === 'idle')).toBe(true)
+    expect(events.some((e) => e.type === 'sdk.error' && /interrupted/i.test(e.message))).toBe(true)
+    expect(events.some((e) => e.type === 'sdk.turn.complete')).toBe(false)   // no chime on interruption
+  })
+
+  it('does not arm a monitor when reconcile finds the session idle/absent', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue(undefined)   // absent == idle
+    const adapter = makeAdapter(manager)
+    await adapter.attach!({ sessionId: 'ses_calm', cwd: '/w' })
+    expect(manager.onceIdle).not.toHaveBeenCalled()
+  })
+})
+```
+
+Match the adapter's real subscription surface (the existing tests subscribe via `state.events` through the adapter API — copy from the `:584`/`:795` analogues). Import `OpencodeServeLostError` from the serve-manager module as the existing manager test does (`:6`).
+
+**Test-isolation requirement:** `idleRecoveryMonitors` is module-scope — export `resetOpencodeIdleRecoveryForTests()` from the adapter module and call it in this suite's `beforeEach`.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-adapter.test.ts`
+Expected: new tests FAIL (no emission, no monitor, no interruption signal).
+
+- [ ] **Step 3: Implement**
+
+In `adapter.ts`:
+
+1. `reconcileStatus` (`:155-200`): replace direct mutations with `emitStatus(state, ...)` at `:158` (initial idle assumption — emit only if it *changes* an existing non-idle status to avoid noise on fresh attach: emit when `state.status !== 'idle'`) and `:189` (running). After the running branch, call `armIdleRecovery(state)`.
+
+2. Add the monitor registry + arm function:
+
+```ts
+/** Exactly one monitored idle-recovery per durable session key (kata zrrj). */
+const idleRecoveryMonitors = new Map<string, Promise<void>>()
+
+export function resetOpencodeIdleRecoveryForTests(): void {
+  idleRecoveryMonitors.clear()
+}
+
+function armIdleRecovery(state: OpencodeSessionState): void {
+  const realId = state.realSessionId
+  if (!realId) return
+  if (idleRecoveryMonitors.has(realId)) {
+    recordFreshAgentObservabilityEvent({
+      kind: 'fresh_agent_monitor', provider: 'opencode',
+      sessionIdHash: hashForLogs(realId),
+      ...(state.cwd ? { cwdHash: hashForLogs(state.cwd) } : {}),
+      phase: 'duplicate_suppressed',
+    })
+    return
+  }
+  const route = cwdRoute(state.cwd)
+  const generation = typeof serveManager.currentGeneration === 'function' ? serveManager.currentGeneration() : undefined
+  const monitorEvent = (phase: 'armed' | 'resolved_idle' | 'timeout' | 'sidecar_lost') =>
+    recordFreshAgentObservabilityEvent({
+      kind: 'fresh_agent_monitor', provider: 'opencode',
+      sessionIdHash: hashForLogs(realId),
+      ...(state.cwd ? { cwdHash: hashForLogs(state.cwd) } : {}),
+      phase,
+      ...(generation !== undefined ? { sidecarGeneration: generation } : {}),
+    })
+  monitorEvent('armed')
+  const idle = route
+    ? serveManager.onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS, route)
+    : serveManager.onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS)
+  const monitored = idle
+    .then(() => {
+      emitStatus(state, 'idle')
+      monitorEvent('resolved_idle')
+      if (!state.turnAborted && !state.turnErrored) {
+        const completionAt = nextMonotonicTurnCompleteAt(state.lastTurnCompleteAt, Date.now())
+        state.lastTurnCompleteAt = completionAt
+        state.events.emit('event', { type: 'sdk.turn.complete', sessionId: state.placeholderId, at: completionAt })
+      }
+    })
+    .catch((error: unknown) => {
+      const lost = error instanceof OpencodeServeLostError
+      emitStatus(state, 'idle')
+      monitorEvent(lost ? 'sidecar_lost' : 'timeout')
+      state.events.emit('event', {
+        type: 'sdk.error',
+        sessionId: state.placeholderId,
+        message: lost
+          ? 'OpenCode turn interrupted: sidecar connection was lost while the turn was running.'
+          : 'OpenCode turn interrupted: idle recovery timed out.',
+      })
+    })
+    .finally(() => { idleRecoveryMonitors.delete(realId) })
+  idleRecoveryMonitors.set(realId, monitored)
+}
+```
+
+(Import `OpencodeServeLostError` from `./serve-manager.js`; `hashForLogs`/`recordFreshAgentObservabilityEvent` from `../../observability.js` — the adapter already imports the latter at `:286-311`.)
+
+3. `bindServeStream` (`:273-299`): pass an `onLost` handler through to the manager. In `serve-manager.ts`, extend `subscribe`:
+
+```ts
+subscribe(sessionId: string, listener: (parsed: ParsedServeEvent) => void, onLost?: (err: OpencodeServeLostError) => void): () => void {
+  const emitter = this.emitterFor(sessionId)
+  emitter.on('event', listener)
+  if (onLost) emitter.on('lost', onLost)
+  return () => {
+    emitter.off('event', listener)
+    if (onLost) emitter.off('lost', onLost)
+    // (Task 7's empty-emitter cleanup)
+  }
+}
+```
+
+In the adapter, the `onLost` handler:
+
+```ts
+(err) => {
+  if (state.status === 'running') {
+    emitStatus(state, 'idle')
+    state.events.emit('event', {
+      type: 'sdk.error', sessionId: state.placeholderId,
+      message: 'OpenCode turn interrupted: sidecar connection was lost while the turn was running.',
+    })
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-adapter.test.ts test/unit/server/fresh-agent/opencode-serve-manager.test.ts`
+Expected: PASS, including the pre-existing reconcile tests at `:584-728` (they assert state, which still holds — `emitStatus` also sets `state.status`) and the three non-chime paths at `:222/:293/:346`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/fresh-agent/adapters/opencode/adapter.ts server/fresh-agent/adapters/opencode/serve-manager.ts test/unit/server/fresh-agent/
+git commit -m "fix(server): restored opencode sessions emit status and run one monitored idle recovery; sidecar loss emits interruption instead of stuck busy (zrrj)"
+```
+
+---
+
+### Task 9: Preserve lost-session error code over WS + one-shot attach-recover-retry on send
+
+The mechanism behind "materialized real `ses_...` durable/readable but send says *not tracked*": reads bypass tracking (`runtime-manager.ts:331-353` + `adapter.ts:413-418`), mutations require an index hit or a cwd-bearing locator (`canRecoverFreshOpenCode` `:430-437`, throw at `:552-557`), and the WS `freshAgent.send` handler flattens `FreshAgentLostSessionError` into `{ code: 'INTERNAL_ERROR' }` (`ws-handler.ts:3554-3556`) so the client can't distinguish "re-attach and retry" from a real bug. Fix server-side: (a) propagate the code, (b) when the locator carries a cwd and the first send throws lost-session, attach-recover and retry exactly once inside the WS handler.
+
+**Files:**
+- Modify: `server/ws-handler.ts` (`freshAgent.send` case `:3512-3558`)
+- Test: `test/unit/server/ws-handler-fresh-agent.test.ts` (harness: real http+ws, `vi.fn()` runtime-manager stub, `connectAndAuth` at `:49-72`)
+
+**Interfaces:**
+- Consumes: `FreshAgentLostSessionError` (exported from `server/fresh-agent/runtime-manager.ts` or its errors module — import from wherever `ws-handler.ts` can already reach it); `manager.attach(locator)`, `manager.send(locator, input)`.
+- Produces: WS error frames for lost sessions now carry `code: 'FRESH_AGENT_LOST_SESSION'` (message unchanged). Client behavior in Task 10 keys off this code. Retry rule: at most one `attach` + one re-`send`; if the retry also fails, send the error frame (with the true code) — no loops.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `test/unit/server/ws-handler-fresh-agent.test.ts`:
+
+```ts
+it('recovers a durable freshopencode send once via attach when the manager reports lost-session', async () => {
+  const send = vi.fn()
+    .mockRejectedValueOnce(new FreshAgentLostSessionError('Fresh-agent session freshopencode/opencode/ses_9 is not tracked'))
+    .mockResolvedValueOnce({ sessionId: 'ses_9' })
+  const attach = vi.fn().mockResolvedValue({ sessionId: 'ses_9' })
+  const { server, port } = await createServer({ freshAgentRuntimeManager: makeManagerStub({ send, attach }) })
+  const ws = await connectAndAuth(server)
+  ws.send(JSON.stringify({
+    type: 'freshAgent.send', requestId: 'r1', sessionId: 'ses_9',
+    sessionType: 'freshopencode', provider: 'opencode', cwd: '/w', text: 'hello',
+  }))
+  const accepted = await waitForMessage(ws, (m) => m.type === 'freshAgent.send.accepted')
+  expect(accepted.sessionId).toBe('ses_9')
+  expect(attach).toHaveBeenCalledTimes(1)
+  expect(send).toHaveBeenCalledTimes(2)
+})
+
+it('propagates FRESH_AGENT_LOST_SESSION when recovery is impossible (no cwd)', async () => {
+  const send = vi.fn().mockRejectedValue(new FreshAgentLostSessionError('Fresh-agent session freshopencode/opencode/ses_9 is not tracked'))
+  const attach = vi.fn()
+  const { server } = await createServer({ freshAgentRuntimeManager: makeManagerStub({ send, attach }) })
+  const ws = await connectAndAuth(server)
+  ws.send(JSON.stringify({
+    type: 'freshAgent.send', requestId: 'r1', sessionId: 'ses_9',
+    sessionType: 'freshopencode', provider: 'opencode', text: 'hello',   // NO cwd
+  }))
+  const err = await waitForMessage(ws, (m) => m.type === 'error')
+  expect(err.code).toBe('FRESH_AGENT_LOST_SESSION')
+  expect(attach).not.toHaveBeenCalled()
+  expect(send).toHaveBeenCalledTimes(1)   // no blind retry loop
+})
+```
+
+Reuse the file's existing manager-stub construction and message-frame helpers verbatim (the suite already has patterns for `freshAgent.send` frames including authorization setup — follow the nearest passing send test; the fresh-agent send path requires prior authorization via create/attach in some configurations: mirror whatever arrangement the file's existing send tests use, e.g. an initial `freshAgent.attach` frame).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm run test:vitest -- --run test/unit/server/ws-handler-fresh-agent.test.ts`
+Expected: FAIL — today's handler sends `code: 'INTERNAL_ERROR'` and never attaches.
+
+- [ ] **Step 3: Implement**
+
+In `ws-handler.ts` `freshAgent.send` catch (`:3554-3556` region), replace the flattening with:
+
+```ts
+} catch (error) {
+  if (error instanceof FreshAgentLostSessionError) {
+    const canRecover = locator.sessionType === 'freshopencode'
+      && locator.sessionId.startsWith('ses_')
+      && typeof locator.cwd === 'string' && locator.cwd.length > 0
+      && typeof manager.attach === 'function'
+    if (canRecover) {
+      try {
+        await manager.attach(locator)
+        const retried = await manager.send(locator, adapterInput)   // same input as the first call
+        // fall through to the existing send.accepted emission with `retried`
+        ...
+        return
+      } catch (retryError) {
+        this.sendError(ws, {
+          code: retryError instanceof FreshAgentLostSessionError ? 'FRESH_AGENT_LOST_SESSION' : 'INTERNAL_ERROR',
+          message: errorMessage(retryError),
+        })
+        recordFreshAgentObservabilityEvent({ kind: 'fresh_agent_send', sessionType: locator.sessionType, provider: locator.provider, sessionIdHash: hashForLogs(locator.sessionId), ...(locator.cwd ? { cwdHash: hashForLogs(locator.cwd) } : {}), outcome: 'failed', errorCode: 'FRESH_AGENT_LOST_SESSION' })
+        return
+      }
+    }
+    this.sendError(ws, { code: 'FRESH_AGENT_LOST_SESSION', message: errorMessage(error) })
+    return
+  }
+  this.sendError(ws, { code: 'INTERNAL_ERROR', message: errorMessage(error) })
+}
+```
+
+Structure the success fall-through by extracting the existing "emit `freshAgent.send.accepted` (+ materialization message)" block into a local function used by both the first attempt and the retry. Keep the existing genuinely-invalid case intact: `FreshAgentLostSessionError` raised for a NON-durable placeholder (`resume` throws "not a durable OpenCode session") must NOT be retried — the `startsWith('ses_')` + cwd guard covers this ("do not swallow genuinely invalid placeholder/non-durable lost-session errors").
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm run test:vitest -- --run test/unit/server/ws-handler-fresh-agent.test.ts test/unit/server/ws-handler-fresh-agent-ownership.test.ts`
+Expected: PASS (ownership suite guards the cwd/authorization axis — must stay green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/ws-handler.ts test/unit/server/ws-handler-fresh-agent.test.ts
+git commit -m "fix(server): preserve FRESH_AGENT_LOST_SESSION over WS and retry durable freshopencode sends once via attach (zrrj)"
+```
+
+---
+
+### Task 10: Client: auto-reattach + resend once on FRESH_AGENT_LOST_SESSION
+
+With Task 9, a send that cannot be server-recovered (e.g. no cwd on the locator) reaches the client as `code: 'FRESH_AGENT_LOST_SESSION'`. The client knows the route cwd (`freshOpenCodeRouteCwd`, `FreshAgentView.tsx:613-615` via `src/lib/fresh-opencode-route.ts`) even when the original send omitted it. On this code, re-issue `freshAgent.attach` with the route cwd, then resend the message exactly once.
+
+**Files:**
+- Modify: `src/components/fresh-agent/FreshAgentView.tsx` (WS error handling for sends; locate the existing handler for send failures — search the file for `INTERNAL_ERROR` or the `sendError`-frame consumption path used to clear local echo on failure)
+- Test: `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
+
+**Interfaces:**
+- Consumes: `wsMock.send` scaffold; `freshOpenCodeRouteCwdRef`; the pane's pending send metadata (`pendingSendMetadataRef`) which retains the original text/requestId.
+- Produces: one retry per failed requestId, tracked in `lostSessionRetryRef: useRef<Set<string>>` (requestIds already retried — never retried twice).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('re-attaches with the route cwd and resends once when a send fails with FRESH_AGENT_LOST_SESSION', async () => {
+  // Arrange a freshopencode pane on ses_9 with initialCwd '/w'; send a message via the composer.
+  render(<StoreBackedFreshAgentView ... />)
+  await typeAndSend('hello again')            // use the file's existing composer interaction helper
+  const sendFrame = wsMock.send.mock.calls.map(([f]) => JSON.parse(f)).find((m) => m.type === 'freshAgent.send')
+  expect(sendFrame).toBeTruthy()
+  wsMock.send.mockClear()
+
+  // Act: server rejects with the lost-session code for that request
+  act(() => wsHandler({ type: 'error', code: 'FRESH_AGENT_LOST_SESSION', requestId: sendFrame.requestId, message: 'not tracked' }))
+
+  // Assert: exactly one attach (with cwd) then one resend of the same text
+  await waitFor(() => {
+    const frames = wsMock.send.mock.calls.map(([f]) => JSON.parse(f))
+    expect(frames.some((m) => m.type === 'freshAgent.attach' && m.sessionId === 'ses_9' && m.cwd === '/w')).toBe(true)
+    expect(frames.filter((m) => m.type === 'freshAgent.send' && m.text === 'hello again')).toHaveLength(1)
+  })
+
+  // Second failure for the retried request must NOT loop
+  const retried = wsMock.send.mock.calls.map(([f]) => JSON.parse(f)).find((m) => m.type === 'freshAgent.send')
+  wsMock.send.mockClear()
+  act(() => wsHandler({ type: 'error', code: 'FRESH_AGENT_LOST_SESSION', requestId: retried.requestId, message: 'still not tracked' }))
+  await new Promise((r) => setTimeout(r, 100))
+  expect(wsMock.send.mock.calls.map(([f]) => JSON.parse(f)).filter((m) => m.type === 'freshAgent.send')).toHaveLength(0)
+})
+```
+
+Check how error frames reach the component today (the `wsHandler` capture receives all frames; if send errors arrive with a different shape — e.g. `{ type: 'freshAgent.send.failed' }` or a generic `{ type: 'error' }` — mirror the real shape emitted by `this.sendError` in `ws-handler.ts`, which the existing tests for send failure already model; copy from them).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentView.test.tsx -t "FRESH_AGENT_LOST_SESSION"`
+Expected: FAIL — no attach, no resend.
+
+- [ ] **Step 3: Implement** in `FreshAgentView.tsx`: in the WS error-frame handling for owned send requests, add:
+
+```ts
+if (errorCode === 'FRESH_AGENT_LOST_SESSION'
+  && paneContentRef.current.sessionType === 'freshopencode'
+  && typeof failedRequestId === 'string'
+  && !lostSessionRetryRef.current.has(failedRequestId)) {
+  const pendingMeta = pendingSendMetadataRef.current.get(failedRequestId)
+  const cwd = freshOpenCodeRouteCwdRef.current
+  const sessionId = paneContentRef.current.sessionId
+  if (pendingMeta && cwd && sessionId) {
+    lostSessionRetryRef.current.add(failedRequestId)
+    ws.send(JSON.stringify({
+      type: 'freshAgent.attach', sessionId, sessionType: 'freshopencode', provider: 'opencode', cwd,
+    }))
+    const retryRequestId = createRequestId()      // the file's existing id generator
+    lostSessionRetryRef.current.add(retryRequestId)   // the retry itself is never retried
+    resendPendingMessage(retryRequestId, pendingMeta, cwd)   // re-issue freshAgent.send with the same text + cwd
+    return
+  }
+}
+// fall through to the existing error handling (clear echo, show error)
+```
+
+Implement `resendPendingMessage` by extracting the existing send-frame construction into a helper reused by the composer submit path and the retry (same fields, plus `cwd`).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/fresh-agent/FreshAgentView.tsx test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+git commit -m "feat(client): auto-reattach and resend once on FRESH_AGENT_LOST_SESSION for freshopencode (zrrj)"
+```
+
+---
+
+### Task 11: Surface interrupted-turn evidence fields in the snapshot normalizer
+
+`normalizeOpencodeTurn` (`server/fresh-agent/adapters/opencode/normalize.ts:324-355`) discards nearly every evidence field the detector needs — `info.time.completed`, `info.error`, per-message `info.tokens`/`info.cost` — even though `assembleExport` passes the raw `m.info` through verbatim (`adapter.ts:408`). Surface them under `extensions.opencode` (the low-friction contract path) so both the server-side detector and the client can see them. `step-finish` counts already survive (`normalize.ts:271-322`); tool part `state.status === 'running'` already reaches the client (`normalize.ts:216`).
+
+**Files:**
+- Modify: `server/fresh-agent/adapters/opencode/normalize.ts`
+- Read first (MANDATORY before coding): `shared/fresh-agent-contract.ts` — confirm the `extensions` Zod shape is permissive (`z.record(z.unknown())` or similar). If it is NOT permissive, extend the contract schema for `extensions.opencode.turnEvidence` and mirror the type on the client import path; the client hard-validates at `src/lib/api.ts:418-421` and will reject snapshots otherwise.
+- Test: `test/unit/server/fresh-agent/opencode-normalize.test.ts` (445 lines; step-finish assertions at `:105-133` show the fixture idiom)
+
+**Interfaces:**
+- Consumes: raw `OpencodeServeMessage = { info: Record<string, any>; parts: Array<Record<string, any>> }` passthrough.
+- Produces: `snapshot.extensions.opencode.turnEvidence: OpencodeTurnEvidence[]` where
+
+```ts
+export type OpencodeTurnEvidence = {
+  turnId: string
+  role: string
+  timeCreated?: number
+  timeCompleted?: number          // absent => unfinished (assistant)
+  error?: { name?: string; message?: string }   // e.g. { name: 'MessageAbortedError' } — NEVER include payload beyond name/message
+  tokens?: { input?: number; output?: number }
+  cost?: number
+  runningToolPartCount: number    // parts with state.status === 'running'
+  stepStartCount: number
+  stepFinishCount: number
+}
+```
+
+Field-name caution (kata-critical): the real OpenCode `message.data` field names are not documented in this repo. Extraction must be defensive: read `info.time?.completed`, `info.error` (accept `{ name, message }`, `{ data: { message } }`, or a string — reuse the tolerant shape of `opencodeErrorMessage` in `serve-events.ts:32-39`), `info.tokens?.input/output`, `info.cost`. Absent fields yield absent evidence properties, never crashes. Before implementing, verify against a live DB if available: `sqlite3 ~/.local/share/opencode/opencode.db "SELECT data FROM message ORDER BY time_created DESC LIMIT 3"` — if the machine has real OpenCode sessions, confirm/adjust names and record what you found in the commit message. If no live DB exists, implement the defensive reads exactly as specified.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `opencode-normalize.test.ts` (reuse its fixture-building idiom):
+
+```ts
+describe('turn evidence extraction (zrrj)', () => {
+  it('surfaces missing completion time, abort error, and running tool parts', () => {
+    const snapshot = normalizeOpencodeSnapshot({
+      sessionType: 'freshopencode',
+      threadId: 'ses_1',
+      status: 'idle',
+      exported: {
+        info: { id: 'ses_1', time: { updated: 10 } },
+        messages: [
+          { info: { id: 'm1', role: 'user', time: { created: 1, completed: 2 } }, parts: [] },
+          {
+            info: {
+              id: 'm2', role: 'assistant', time: { created: 3 },              // NO completed
+              error: { name: 'MessageAbortedError', message: 'aborted' },
+              tokens: { input: 100, output: 0 }, cost: 0,
+            },
+            parts: [
+              { type: 'tool', state: { status: 'running' } },
+              { type: 'step-start' },
+            ],
+          },
+        ],
+      },
+    })
+    const evidence = snapshot.extensions.opencode.turnEvidence
+    expect(evidence).toHaveLength(2)
+    expect(evidence[1]).toMatchObject({
+      turnId: 'm2', role: 'assistant',
+      timeCompleted: undefined,
+      error: { name: 'MessageAbortedError', message: 'aborted' },
+      tokens: { input: 100, output: 0 },
+      runningToolPartCount: 1, stepStartCount: 1, stepFinishCount: 0,
+    })
+    expect(evidence[0]).toMatchObject({ turnId: 'm1', timeCompleted: 2, runningToolPartCount: 0 })
+  })
+
+  it('never leaks message text into evidence', () => {
+    const snapshot = normalizeOpencodeSnapshot({ /* assistant message with text parts */ })
+    const json = JSON.stringify(snapshot.extensions.opencode.turnEvidence)
+    expect(json).not.toContain('the secret assistant text')   // seed that string in a text part
+  })
+})
+```
+
+Match `normalizeOpencodeSnapshot`'s actual input signature from the existing tests in this file (it may take `{ exported, revision, ... }` or flattened args — copy the call shape of the nearest existing test exactly).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-normalize.test.ts`
+Expected: FAIL — `turnEvidence` undefined.
+
+- [ ] **Step 3: Implement** in `normalize.ts` — a pure helper called from `normalizeOpencodeSnapshot` where `extensions.opencode` is assembled (`:403` area):
+
+```ts
+function extractTurnEvidence(messages: Array<{ info: Record<string, any>; parts: Array<Record<string, any>> }>): OpencodeTurnEvidence[] {
+  return messages.map(({ info, parts }) => {
+    const err = info?.error
+    const error = err
+      ? {
+          ...(typeof err?.name === 'string' ? { name: err.name } : {}),
+          ...(typeof err?.message === 'string'
+            ? { message: err.message }
+            : typeof err?.data?.message === 'string'
+              ? { message: err.data.message }
+              : typeof err === 'string' ? { message: err } : {}),
+        }
+      : undefined
+    const counts = { running: 0, stepStart: 0, stepFinish: 0 }
+    for (const part of parts ?? []) {
+      if (part?.type === 'tool' && part?.state?.status === 'running') counts.running += 1
+      if (part?.type === 'step-start') counts.stepStart += 1
+      if (part?.type === 'step-finish') counts.stepFinish += 1
+    }
+    const tokens = info?.tokens && typeof info.tokens === 'object'
+      ? {
+          ...(Number.isFinite(info.tokens.input) ? { input: Number(info.tokens.input) } : {}),
+          ...(Number.isFinite(info.tokens.output) ? { output: Number(info.tokens.output) } : {}),
+        }
+      : undefined
+    return {
+      turnId: String(info?.id ?? ''),
+      role: typeof info?.role === 'string' ? info.role : 'unknown',
+      ...(Number.isFinite(info?.time?.created) ? { timeCreated: Number(info.time.created) } : {}),
+      ...(Number.isFinite(info?.time?.completed) ? { timeCompleted: Number(info.time.completed) } : {}),
+      ...(error && (error.name || error.message) ? { error } : {}),
+      ...(tokens && (tokens.input !== undefined || tokens.output !== undefined) ? { tokens } : {}),
+      ...(Number.isFinite(info?.cost) ? { cost: Number(info.cost) } : {}),
+      runningToolPartCount: counts.running,
+      stepStartCount: counts.stepStart,
+      stepFinishCount: counts.stepFinish,
+    }
+  })
+}
+```
+
+Wire `turnEvidence: extractTurnEvidence(input.exported?.messages ?? [])` into the `extensions.opencode` object. **Sidecar path only** — the DB hydrator clobbers `info.time` (`history-query.ts:373-376`), which is fine because FreshOpenCode snapshots read the sidecar (`assembleExport`), never the DB.
+
+- [ ] **Step 4: Run to verify pass** — `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-normalize.test.ts test/unit/server/fresh-agent/opencode-serve-adapter.test.ts` (adapter snapshot tests must stay green; if the client contract rejects the new field, this is where it surfaces — fix the contract as noted above). Also run `npm run test:vitest -- --run test/unit/client/lib/api.test.ts` to confirm `FreshAgentSnapshotSchema` accepts snapshots with evidence.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/fresh-agent/adapters/opencode/normalize.ts shared/fresh-agent-contract.ts test/unit/server/fresh-agent/opencode-normalize.test.ts
+git commit -m "feat(server): surface opencode turn evidence (completion time, error, tokens, tool state) in snapshot extensions (zrrj)"
+```
+
+---
+
+### Task 12: Durable interrupt-intent and recovery ledger store
+
+"Never auto-recover after explicit user stop" is unsatisfiable today: interrupt intent lives only in `OpencodeSessionState.turnAborted` (`adapter.ts:52`, set `:521`), cleared on the next send (`:334`) and destroyed by restart (`shutdown()` clears the map, `:625`). Give it a durable home, plus the at-most-one-recovery-per-turn ledger.
+
+**Files:**
+- Create: `server/fresh-agent/recovery-store.ts`
+- Test: `test/unit/server/fresh-agent/recovery-store.test.ts`
+
+**Interfaces:**
+- Consumes: `node:fs/promises`, `node:path`, `node:os`. Storage file: `~/.freshell/fresh-agent-recovery.json` (constructor takes an optional `filePath` for tests). Atomic writes: temp file + rename (repo convention).
+- Produces:
+
+```ts
+export type RecoveryStoreData = {
+  version: 1
+  /** sessionId -> ms timestamp of the user's explicit stop. */
+  interrupts: Record<string, number>
+  /** sessionId -> messageId -> ms timestamp of the injected continuation. */
+  recoveries: Record<string, Record<string, number>>
+}
+
+export class FreshAgentRecoveryStore {
+  constructor(options?: { filePath?: string })
+  async recordInterrupt(sessionId: string): Promise<void>
+  async clearInterrupt(sessionId: string): Promise<void>       // called on the next user-initiated send
+  async hasInterrupt(sessionId: string): Promise<boolean>
+  async recordRecovery(sessionId: string, messageId: string): Promise<void>
+  async hasRecovery(sessionId: string, messageId: string): Promise<boolean>
+}
+
+export function getFreshAgentRecoveryStore(): FreshAgentRecoveryStore   // lazy singleton
+export function resetFreshAgentRecoveryStoreForTests(filePath?: string): void
+```
+
+Corrupt/missing file → start empty (log a warn, never throw). Keep the file small: cap `interrupts` and per-session `recoveries` at the 100 most recent entries (drop oldest on insert).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { FreshAgentRecoveryStore } from '../../../server/fresh-agent/recovery-store.js'
+
+describe('FreshAgentRecoveryStore', () => {
+  let filePath: string
+  beforeEach(async () => {
+    filePath = path.join(await mkdtemp(path.join(tmpdir(), 'recovery-')), 'recovery.json')
+  })
+
+  it('persists interrupt intent across store instances (simulated restart)', async () => {
+    const store = new FreshAgentRecoveryStore({ filePath })
+    await store.recordInterrupt('ses_1')
+    const reborn = new FreshAgentRecoveryStore({ filePath })
+    expect(await reborn.hasInterrupt('ses_1')).toBe(true)
+    await reborn.clearInterrupt('ses_1')
+    expect(await new FreshAgentRecoveryStore({ filePath }).hasInterrupt('ses_1')).toBe(false)
+  })
+
+  it('records at most one recovery per (session, message) and persists it', async () => {
+    const store = new FreshAgentRecoveryStore({ filePath })
+    expect(await store.hasRecovery('ses_1', 'm2')).toBe(false)
+    await store.recordRecovery('ses_1', 'm2')
+    expect(await store.hasRecovery('ses_1', 'm2')).toBe(true)
+    expect(await new FreshAgentRecoveryStore({ filePath }).hasRecovery('ses_1', 'm2')).toBe(true)
+  })
+
+  it('starts empty on a corrupt file instead of throwing', async () => {
+    await writeFile(filePath, '{not json', 'utf8')
+    const store = new FreshAgentRecoveryStore({ filePath })
+    expect(await store.hasInterrupt('ses_1')).toBe(false)
+    await store.recordInterrupt('ses_1')            // and can still write
+    expect(JSON.parse(await readFile(filePath, 'utf8')).version).toBe(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify fail** — `npm run test:vitest -- --run test/unit/server/fresh-agent/recovery-store.test.ts` → module missing.
+
+- [ ] **Step 3: Implement `server/fresh-agent/recovery-store.ts`** — straightforward: lazy `load()` (read + JSON.parse with try/catch → default `{ version: 1, interrupts: {}, recoveries: {} }`), every mutator loads, mutates, prunes to the 100-entry caps, then writes `JSON.stringify(data, null, 2)` to `${filePath}.tmp` and `rename`s over `filePath` (`encoding: 'utf8'`, `mkdir` the parent recursively first). Serialize writes through an internal `this.writeQueue = this.writeQueue.then(...)` promise chain so concurrent mutators can't interleave. Default path: `path.join(os.homedir(), '.freshell', 'fresh-agent-recovery.json')`.
+
+- [ ] **Step 4: Run to verify pass** — same command.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/fresh-agent/recovery-store.ts test/unit/server/fresh-agent/recovery-store.test.ts
+git commit -m "feat(server): durable fresh-agent interrupt-intent and recovery ledger store (zrrj)"
+```
+
+---
+
+### Task 13: Pure interrupted-turn detector with stability window
+
+Detect high-confidence interrupted turns from transcript/tool evidence — never from a guessed persisted status field (the OpenCode DB has none). Pure function over the raw sidecar messages; no I/O.
+
+**Files:**
+- Create: `server/fresh-agent/adapters/opencode/interrupted-turn.ts`
+- Test: `test/unit/server/fresh-agent/opencode-interrupted-turn.test.ts`
+
+**Interfaces:**
+- Consumes: raw `OpencodeServeMessage[]` (`{ info, parts }` — same shapes Task 11 reads).
+- Produces:
+
+```ts
+export type InterruptedTurnVerdict =
+  | { interrupted: false; reason: string }
+  | {
+      interrupted: true
+      messageId: string
+      /** Which evidence fired — for the audit log and the transcript event. */
+      evidence: Array<'missing_completion' | 'aborted_error' | 'running_tool_part' | 'zero_output_tokens' | 'missing_step_finish'>
+    }
+
+export const INTERRUPTED_TURN_STABILITY_MS = 15_000
+
+export function detectInterruptedTurn(
+  messages: Array<{ info: Record<string, any>; parts: Array<Record<string, any>> }>,
+  options: { nowMs: number; stabilityMs?: number },
+): InterruptedTurnVerdict
+```
+
+**Decision rules (implement exactly, in order):**
+1. Find the LAST message. If it is not `role: 'assistant'`, return `{ interrupted: false, reason: 'last_message_not_assistant' }` — a trailing user message means the user already typed a follow-up (kata: never auto-recover then). No messages → not interrupted (`'empty_transcript'`).
+2. Stability window: if `max(info.time.created, info.time.updated ?? 0)` of that message is within `stabilityMs` (default 15 s) of `nowMs`, return `{ interrupted: false, reason: 'within_stability_window' }` — a still-writing DB/sidecar row must not be recovered prematurely.
+3. Collect evidence on that assistant message:
+   - `missing_completion`: `info.time?.completed` is not a finite number.
+   - `aborted_error`: `info.error?.name === 'MessageAbortedError'` (or `info.error?.data?.name === 'MessageAbortedError'`).
+   - `running_tool_part`: any part with `type === 'tool' && state?.status === 'running'`.
+   - `zero_output_tokens`: `info.tokens?.output === 0` AND at least one other evidence item present (zero alone is too weak — a legitimate tool-only turn can have 0 output tokens).
+   - `missing_step_finish`: `stepStartCount > 0 && stepFinishCount === 0` over its parts.
+4. High-confidence gate: `interrupted: true` only when `missing_completion` is present AND at least one more evidence item fired (or `aborted_error` alone — an explicit abort record is definitive). Otherwise `{ interrupted: false, reason: 'insufficient_evidence' }`.
+
+(The remaining kata signals — sidecar loss, Freshell shutdown, restored running status — are covered by the *callers*: Task 8's monitor emits interruption on sidecar loss/timeout, and Task 14 runs this detector on restore, which is exactly the shutdown/restored-status path.)
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { detectInterruptedTurn, INTERRUPTED_TURN_STABILITY_MS } from '../../../../server/fresh-agent/adapters/opencode/interrupted-turn.js'
+
+const NOW = 1_000_000_000
+const OLD = NOW - INTERRUPTED_TURN_STABILITY_MS - 1
+
+function assistant(info: Record<string, any>, parts: Record<string, any>[] = []) {
+  return { info: { id: 'm2', role: 'assistant', time: { created: OLD, updated: OLD }, ...info }, parts }
+}
+const user = { info: { id: 'm1', role: 'user', time: { created: OLD - 10, completed: OLD - 9 } }, parts: [] }
+
+describe('detectInterruptedTurn', () => {
+  it('flags missing completion + running tool part as interrupted', () => {
+    const verdict = detectInterruptedTurn([user, assistant({}, [{ type: 'tool', state: { status: 'running' } }])], { nowMs: NOW })
+    expect(verdict).toEqual({ interrupted: true, messageId: 'm2', evidence: ['missing_completion', 'running_tool_part'] })
+  })
+
+  it('flags an explicit MessageAbortedError alone', () => {
+    const verdict = detectInterruptedTurn(
+      [user, assistant({ time: { created: OLD, completed: OLD + 1 }, error: { name: 'MessageAbortedError' } })],
+      { nowMs: NOW },
+    )
+    expect(verdict.interrupted).toBe(true)
+    if (verdict.interrupted) expect(verdict.evidence).toContain('aborted_error')
+  })
+
+  it('does not flag missing completion alone (insufficient evidence)', () => {
+    const verdict = detectInterruptedTurn([user, assistant({})], { nowMs: NOW })
+    expect(verdict).toEqual({ interrupted: false, reason: 'insufficient_evidence' })
+  })
+
+  it('respects the stability window for a still-writing row', () => {
+    const fresh = { info: { id: 'm2', role: 'assistant', time: { created: NOW - 1_000 } }, parts: [{ type: 'tool', state: { status: 'running' } }] }
+    expect(detectInterruptedTurn([user, fresh], { nowMs: NOW })).toEqual({ interrupted: false, reason: 'within_stability_window' })
+  })
+
+  it('never flags when the user already typed a follow-up', () => {
+    const trailingUser = { info: { id: 'm3', role: 'user', time: { created: OLD + 5 } }, parts: [] }
+    const verdict = detectInterruptedTurn(
+      [user, assistant({}, [{ type: 'tool', state: { status: 'running' } }]), trailingUser],
+      { nowMs: NOW },
+    )
+    expect(verdict).toEqual({ interrupted: false, reason: 'last_message_not_assistant' })
+  })
+
+  it('counts missing step-finish and zero output tokens as corroborating evidence', () => {
+    const verdict = detectInterruptedTurn(
+      [user, assistant({ tokens: { input: 50, output: 0 } }, [{ type: 'step-start' }])],
+      { nowMs: NOW },
+    )
+    expect(verdict.interrupted).toBe(true)
+    if (verdict.interrupted) {
+      expect(verdict.evidence).toEqual(expect.arrayContaining(['missing_completion', 'zero_output_tokens', 'missing_step_finish']))
+    }
+  })
+
+  it('does not flag a cleanly completed turn', () => {
+    const done = assistant({ time: { created: OLD, completed: OLD + 2 }, tokens: { input: 10, output: 40 } }, [{ type: 'step-start' }, { type: 'step-finish' }])
+    expect(detectInterruptedTurn([user, done], { nowMs: NOW }).interrupted).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify fail** — `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-interrupted-turn.test.ts` → module missing.
+
+- [ ] **Step 3: Implement** the pure function exactly per the decision rules. Evidence array order: `['missing_completion', 'aborted_error', 'running_tool_part', 'zero_output_tokens', 'missing_step_finish']` filtered to what fired (stable order makes tests deterministic).
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/fresh-agent/adapters/opencode/interrupted-turn.ts test/unit/server/fresh-agent/opencode-interrupted-turn.test.ts
+git commit -m "feat(server): evidence-based interrupted-turn detector with stability window (zrrj)"
+```
+
+---
+
+### Task 14: Recovery orchestration — one auditable Freshell-owned continuation, loop-proof
+
+Wire interrupt intent + detector + ledger into the adapter: record intent on `interrupt()`, clear it on the next user send, and on durable restore (resume/attach) when the reconciled status is idle, run the detector against the live transcript and inject at most ONE continuation per failed turn.
+
+**Files:**
+- Modify: `server/fresh-agent/adapters/opencode/adapter.ts` (`interrupt()` `:517-531`, `materializeOrSend` `:324-387`, restore paths `:438-498`)
+- Test: `test/unit/server/fresh-agent/opencode-serve-adapter.test.ts`
+
+**Interfaces:**
+- Consumes: `FreshAgentRecoveryStore` (Task 12 — injected via adapter options as `recoveryStore`, defaulting to `getFreshAgentRecoveryStore()`; tests inject a store on a temp file); `detectInterruptedTurn` (Task 13); `serveManager.listMessages`; `promptAsyncForState` (`:363-367` idiom); `recordFreshAgentObservabilityEvent` (Task 6).
+- Produces:
+  - `interrupt()` additionally `await recoveryStore.recordInterrupt(realId)` (fire before abort; roll back with `clearInterrupt` if the abort throws, mirroring the existing `turnAborted` rollback at `:527`).
+  - `materializeOrSend` for a **user-initiated** send additionally `await recoveryStore.clearInterrupt(realId)` (a follow-up cancels stop intent). Continuation sends are marked internal and do NOT clear intent: add an options flag `{ freshellContinuation?: boolean }` threaded through the send path.
+  - New `maybeRecoverInterruptedTurn(state: OpencodeSessionState): Promise<void>` called from `resume()`/`attach()` after `reconcileStatus` **only when** the reconciled status is `'idle'` (a `running` session is being monitored by Task 8 — not interrupted). Logic:
+
+```ts
+async function maybeRecoverInterruptedTurn(state: OpencodeSessionState): Promise<void> {
+  const realId = state.realSessionId
+  if (!realId) return
+  const audit = (action: string, reason: string, messageId?: string) =>
+    recordFreshAgentObservabilityEvent({
+      kind: 'fresh_agent_turn_recovery', provider: 'opencode',
+      sessionIdHash: hashForLogs(realId),
+      ...(state.cwd ? { cwdHash: hashForLogs(state.cwd) } : {}),
+      action: action as any, reason,
+      ...(messageId ? { messageIdHash: hashForLogs(messageId) } : {}),
+    })
+  try {
+    if (await recoveryStore.hasInterrupt(realId)) { audit('suppressed_user_stop', 'user_interrupt_on_record'); return }
+    const route = cwdRoute(state.cwd)
+    const page = route
+      ? await serveManager.listMessages(realId, { limit: DEFAULT_SNAPSHOT_TURN_LIMIT }, route)
+      : await serveManager.listMessages(realId, { limit: DEFAULT_SNAPSHOT_TURN_LIMIT })
+    const verdict = detectInterruptedTurn(page.messages, { nowMs: Date.now() })
+    if (!verdict.interrupted) {
+      if (verdict.reason !== 'empty_transcript' && verdict.reason !== 'last_message_not_assistant') {
+        audit('suppressed_low_confidence', verdict.reason)
+      } else if (verdict.reason === 'last_message_not_assistant') {
+        audit('suppressed_user_followup', verdict.reason)
+      }
+      return
+    }
+    if (await recoveryStore.hasRecovery(realId, verdict.messageId)) {
+      audit('suppressed_already_recovered', 'ledger_hit', verdict.messageId); return
+    }
+    await recoveryStore.recordRecovery(realId, verdict.messageId)   // record BEFORE injecting: crash-safe loop prevention
+    audit('continuation_injected', verdict.evidence.join(','), verdict.messageId)
+    state.events.emit('event', {
+      type: 'sdk.session.changed', sessionId: state.placeholderId, reason: 'freshell-turn-recovery',
+    })
+    await sendForState(state, {
+      text: 'Freshell detected that your previous response was interrupted (for example by a restart). Please continue exactly where you left off. If the work was already complete, briefly confirm the final result.',
+      freshellContinuation: true,
+    })
+  } catch (error) {
+    log.warn({ provider: 'opencode', sessionIdHash: hashForLogs(realId), err: error }, 'interrupted-turn recovery failed')
+  }
+}
+```
+
+  where `sendForState` is the existing send-queue entry (`adapter.ts:507-515` idiom) so the continuation is serialized, route-validated (`ensureMutableRoute`), armed with `onceIdle`, and produces the normal running→idle→turn-complete lifecycle — a clear transcript event plus the audit row satisfy "auditable". The continuation text is Freshell-owned instruction, not user content — safe to hardcode; it appears in the transcript as a user-role message (that IS the visible transcript marker).
+  - **Do not auto-recover a `running` session** — only `idle`-reconciled restores are candidates. This encodes "restored running status" recovery as: monitor it (Task 8); if the monitor later reports sidecar loss, the NEXT restore attempt will find the unfinished transcript and recover it here.
+
+- [ ] **Step 1: Write the failing tests** (in `opencode-serve-adapter.test.ts`; build the adapter with an injected recovery store on a temp file — extend `makeAdapter` overrides):
+
+```ts
+describe('interrupted-turn recovery (zrrj)', () => {
+  const OLD = Date.now() - 60_000
+  const interruptedTranscript = {
+    messages: [
+      { info: { id: 'm1', role: 'user', time: { created: OLD - 10, completed: OLD - 9 } }, parts: [] },
+      { info: { id: 'm2', role: 'assistant', time: { created: OLD } }, parts: [{ type: 'tool', state: { status: 'running' } }] },
+    ],
+    nextCursor: null,
+  }
+
+  it('injects exactly one continuation for an interrupted turn on attach', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue(undefined)          // idle
+    manager.listMessages.mockResolvedValue(interruptedTranscript)
+    const adapter = makeAdapter(manager, { recoveryStore: makeTempRecoveryStore() })
+    await adapter.attach!({ sessionId: 'ses_int', cwd: '/w' })
+    await flushSendQueue()   // await adapter's send queue; e.g. await new Promise(r => setTimeout(r, 0)) loops or expose a test hook
+    expect(manager.promptAsync).toHaveBeenCalledTimes(1)
+    const [, body] = manager.promptAsync.mock.calls[0]
+    expect(body.parts[0].text).toMatch(/interrupted/i)
+
+    // Second attach (same store): ledger suppresses
+    manager.promptAsync.mockClear()
+    await adapter.attach!({ sessionId: 'ses_int', cwd: '/w' })
+    await flushSendQueue()
+    expect(manager.promptAsync).not.toHaveBeenCalled()
+  })
+
+  it('never recovers after an explicit user interrupt, across adapter instances', async () => {
+    const store = makeTempRecoveryStore()
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue(undefined)
+    manager.listMessages.mockResolvedValue(interruptedTranscript)
+    const adapter1 = makeAdapter(manager, { recoveryStore: store })
+    await adapter1.attach!({ sessionId: 'ses_int', cwd: '/w' })
+    await adapter1.interrupt!('ses_int')                            // user stop
+    const adapter2 = makeAdapter(makeFakeManager(), { recoveryStore: store })   // simulated restart
+    const manager2 = /* the fresh manager used above */
+    manager2.getSessionStatus.mockResolvedValue(undefined)
+    manager2.listMessages.mockResolvedValue(interruptedTranscript)
+    await adapter2.attach!({ sessionId: 'ses_int', cwd: '/w' })
+    await flushSendQueue()
+    expect(manager2.promptAsync).not.toHaveBeenCalled()
+  })
+
+  it('does not recover when the user already sent a follow-up', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue(undefined)
+    manager.listMessages.mockResolvedValue({
+      messages: [...interruptedTranscript.messages,
+        { info: { id: 'm3', role: 'user', time: { created: OLD + 5 } }, parts: [] }],
+      nextCursor: null,
+    })
+    const adapter = makeAdapter(manager, { recoveryStore: makeTempRecoveryStore() })
+    await adapter.attach!({ sessionId: 'ses_int', cwd: '/w' })
+    await flushSendQueue()
+    expect(manager.promptAsync).not.toHaveBeenCalled()
+  })
+
+  it('a normal user send clears recorded interrupt intent', async () => {
+    const store = makeTempRecoveryStore()
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager, { recoveryStore: store })
+    await adapter.attach!({ sessionId: 'ses_int', cwd: '/w' })
+    await adapter.interrupt!('ses_int')
+    expect(await store.hasInterrupt('ses_int')).toBe(true)
+    await adapter.send!('ses_int', { text: 'user follow-up' })
+    expect(await store.hasInterrupt('ses_int')).toBe(false)
+  })
+})
+```
+
+`makeTempRecoveryStore()` = `new FreshAgentRecoveryStore({ filePath: path.join(await mkdtemp(...), 'r.json') })` — add it as a suite helper. Adapt `interrupt`/`send` call signatures to the adapter's real API (the existing suite has both — copy).
+
+- [ ] **Step 2: Run to verify fail** — the recovery tests FAIL (no continuation injected / intent not persisted).
+
+- [ ] **Step 3: Implement** per the Interfaces block: adapter options gain `recoveryStore?: FreshAgentRecoveryStore`; `interrupt()` records intent; user sends clear intent; `resume()`/`attach()` call `void maybeRecoverInterruptedTurn(state)` after `reconcileStatus` **when `state.status === 'idle'`** (fire-and-forget with internal catch — restore must not fail because recovery failed; but for test determinism, expose the promise: store it on `state.pendingRecovery` and have tests await it via the flush helper).
+
+- [ ] **Step 4: Run to verify pass** — `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-adapter.test.ts` (all 59 pre-existing tests + new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/fresh-agent/adapters/opencode/adapter.ts test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+git commit -m "feat(server): one auditable loop-proof Freshell continuation for interrupted opencode turns (zrrj)"
+```
+
+---
+
+### Task 15: Idle/persistence freshness — prove the final answer is queryable before completing the turn
+
+The race: `onceIdle` resolves on the first `session.idle` SSE frame (`serve-manager.ts:506-510`) while `message.*` events are invalidations only; nothing sequences the idle edge behind the final assistant message becoming visible on the REST read path (`serve-events.ts:114-116`). Result: the client's post-idle snapshot can miss the final answer, and (pre-Task 3) the pane stopped polling. Fix at the adapter: after `await idle` (`adapter.ts:368`), poll `listMessages` until a completed assistant message newer than the send is visible (bounded), THEN emit idle/turn-complete. Kata accepts "polling for the expected final message" explicitly.
+
+**Files:**
+- Modify: `server/fresh-agent/adapters/opencode/adapter.ts` (`materializeOrSend` `:363-381`; also apply after Task 8's monitor resolve)
+- Test: `test/unit/server/fresh-agent/opencode-serve-adapter.test.ts`
+
+**Interfaces:**
+- Consumes: `serveManager.listMessages(realId, { limit }, route?)`.
+- Produces:
+
+```ts
+const TRANSCRIPT_SETTLE_POLL_MS = 150
+const TRANSCRIPT_SETTLE_MAX_POLLS = 10   // ~1.5 s worst case
+
+/**
+ * After idle, verify the final assistant message is queryable via the REST
+ * read path before declaring the turn complete (kata zrrj freshness contract).
+ * Returns true when settled; false when polling exhausted (idle is still
+ * emitted — the turn is not stranded — but the client re-poll (Task 16) covers the gap).
+ */
+async function awaitTranscriptSettled(state: OpencodeSessionState, sentAtMs: number): Promise<boolean>
+```
+
+Settled means: `listMessages` (limit e.g. 20, newest page) contains an assistant message with `info.time.created >= sentAtMs - CLOCK_SKEW_MS` (use `CLOCK_SKEW_MS = 5_000`) AND a finite `info.time.completed`. Poll with `TRANSCRIPT_SETTLE_POLL_MS` sleeps between attempts; inject the sleep fn for tests (`options.sleep`, default `(ms) => new Promise(r => setTimeout(r, ms))`).
+
+In `materializeOrSend`, capture `const sentAtMs = Date.now()` just before `promptAsyncForState` (`:363`), then after `await idle` (`:368`) insert `await awaitTranscriptSettled(state, sentAtMs)` BEFORE `emitStatus(state, 'idle')` (`:371`) and the chime (`:377-381`). Also call it (with `sentAtMs = 0`, i.e. "any completed assistant message") in Task 8's monitor resolve path before its `emitStatus(state, 'idle')`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('idle freshness (zrrj)', () => {
+  it('withholds idle and turn-complete until the final assistant message is queryable', async () => {
+    const manager = makeFakeManager()
+    const idle = createDeferred<void>()
+    manager.onceIdle.mockReturnValue(idle.promise)
+    // First two polls: transcript still missing the final answer; third poll: it appears.
+    const unfinished = { messages: [{ info: { id: 'm1', role: 'user', time: { created: Date.now(), completed: Date.now() } }, parts: [] }], nextCursor: null }
+    const finished = { messages: [...unfinished.messages, { info: { id: 'm2', role: 'assistant', time: { created: Date.now(), completed: Date.now() } }, parts: [] }], nextCursor: null }
+    manager.listMessages
+      .mockResolvedValueOnce(unfinished)
+      .mockResolvedValueOnce(unfinished)
+      .mockResolvedValue(finished)
+    const adapter = makeAdapter(manager, { settleSleep: async () => {} })   // injected no-op sleep
+    const events: any[] = []
+    // create+subscribe per the suite's send-test idiom, then:
+    const sendPromise = adapter.send!('freshopencode-placeholder-1', { text: 'q' })
+    idle.resolve()
+    await sendPromise
+    expect(manager.listMessages).toHaveBeenCalledTimes(3)
+    const idleIndex = events.findIndex((e) => e.type === 'sdk.session.snapshot' && e.status === 'idle')
+    const completeIndex = events.findIndex((e) => e.type === 'sdk.turn.complete')
+    expect(idleIndex).toBeGreaterThanOrEqual(0)
+    expect(completeIndex).toBeGreaterThan(idleIndex - 1)   // both emitted, after settling
+  })
+
+  it('gives up after the poll budget but still emits idle (never strands the pane busy)', async () => {
+    const manager = makeFakeManager()
+    const idle = createDeferred<void>()
+    manager.onceIdle.mockReturnValue(idle.promise)
+    manager.listMessages.mockResolvedValue({ messages: [], nextCursor: null })   // never settles
+    const adapter = makeAdapter(manager, { settleSleep: async () => {} })
+    const events: any[] = []
+    const sendPromise = adapter.send!('freshopencode-placeholder-1', { text: 'q' })
+    idle.resolve()
+    await sendPromise
+    expect(manager.listMessages.mock.calls.length).toBeLessThanOrEqual(11)   // 1 + max 10 polls
+    expect(events.some((e) => e.type === 'sdk.session.snapshot' && e.status === 'idle')).toBe(true)
+  })
+})
+```
+
+(Wire `events` collection through the suite's normal subscribe idiom; note `assembleExport` also calls `listMessages` for snapshots — if the existing send path already calls it, adjust expected call counts accordingly by inspecting the first failing run's actual counts, keeping the ORDER assertions as the real contract.)
+
+- [ ] **Step 2: Run to verify fail** — idle is emitted immediately today; `listMessages` not polled.
+
+- [ ] **Step 3: Implement** `awaitTranscriptSettled` + the two call sites; thread `settleSleep` through adapter options (default real sleep). On `false` (exhausted), also emit an observability row: `recordFreshAgentObservabilityEvent({ kind: 'fresh_agent_monitor', provider: 'opencode', sessionIdHash, phase: 'timeout', ... })` is the wrong kind — instead log `log.warn({...}, 'transcript did not settle after idle')`.
+
+- [ ] **Step 4: Run to verify pass** — full adapter suite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/fresh-agent/adapters/opencode/adapter.ts test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+git commit -m "fix(server): prove the final assistant message is queryable before emitting opencode idle/turn-complete (zrrj)"
+```
+
+---
+
+### Task 16: Client — never permanently stop refreshing on an incomplete idle snapshot
+
+Belt-and-suspenders for the same race (kata requires the browser-side guarantee explicitly): when a snapshot arrives with `status: 'idle'` while this pane still has an unreconciled local echo (the user's message was sent but the snapshot doesn't contain it or its answer yet), schedule a bounded re-poll instead of going quiet.
+
+**Files:**
+- Modify: `src/components/fresh-agent/FreshAgentView.tsx` (inside `applySnapshot` from Task 3)
+- Test: `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
+
+**Interfaces:**
+- Consumes: the existing local-echo reconcile logic inside the old `.then` body (`:1618-1707` — it already computes whether the echo was reconciled); `requestSnapshotRefresh('idle-incomplete')` (Task 3); scheduler debounce=0 for `idle-incomplete`.
+- Produces: `idleIncompleteRetryCountRef = useRef(0)`, max `IDLE_INCOMPLETE_MAX_RETRIES = 5`, retry delay 1000 ms via `window.setTimeout`; counter resets whenever a snapshot reconciles the echo or a new send starts.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('keeps re-polling (bounded) when an idle snapshot is missing the just-sent turn', async () => {
+  // Arrange: pane with a pending local echo for 'question?' (drive the composer),
+  // snapshot responses are idle and DO NOT contain the echo's turn.
+  apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(makeSnapshot({ threadId: 'ses_1', status: 'idle', turns: [] }))
+  render(<StoreBackedFreshAgentView ... />)
+  await typeAndSend('question?')
+  act(() => wsHandler({ type: 'freshAgent.send.accepted', requestId: lastSendRequestId(), sessionId: 'ses_1', sessionType: 'freshopencode', provider: 'opencode' }))
+  const before = apiMock.getFreshAgentThreadSnapshot.mock.calls.length
+  // Assert: more snapshot fetches keep coming (retry loop), then stop at the cap
+  await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot.mock.calls.length).toBeGreaterThan(before), { timeout: 4_000 })
+})
+```
+
+- [ ] **Step 2: Run to verify fail** — after the send-accepted refresh returns an idle snapshot, no further fetches happen today (busy never set → poll gate off).
+
+- [ ] **Step 3: Implement** in `applySnapshot`: after the existing echo-reconcile computation, add:
+
+```ts
+const echoStillPending = /* the existing 'echo not reconciled by this snapshot' condition */
+if (snapshotStatus === 'idle' && echoStillPending
+  && idleIncompleteRetryCountRef.current < IDLE_INCOMPLETE_MAX_RETRIES) {
+  idleIncompleteRetryCountRef.current += 1
+  window.setTimeout(() => requestSnapshotRefresh('idle-incomplete'), 1_000)
+} else if (!echoStillPending) {
+  idleIncompleteRetryCountRef.current = 0
+}
+```
+
+- [ ] **Step 4: Run to verify pass** — FreshAgentView suite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/fresh-agent/FreshAgentView.tsx test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+git commit -m "fix(client): bounded re-poll when an idle snapshot is missing the just-sent turn (zrrj)"
+```
+
+---
+
+### Task 17: Identity-bearing structured rows on every FreshAgent action + snapshot trigger metadata
+
+`freshAgent.send`/`interrupt`/`compact` log **nothing** today (`ws-handler.ts:3512-3558`, `:3560-3574`); `create`/`attach` log only on failure; materialization has no row at any of its three points; snapshot rows lack the trigger and never fire on errors. This is exactly what blocked the incident RCA ("the user's manual stop/start action is still not conclusively identifiable").
+
+**Files:**
+- Modify: `server/ws-handler.ts` (cases at `:3467`, `:3512`, `:3560`; materialization at `:3534-3541` and `:1408-1434`)
+- Modify: `server/fresh-agent/router.ts` (`:169-229` snapshot handler; `sendFreshAgentError` `:99-167`)
+- Modify: `src/lib/api.ts` (`getFreshAgentThreadSnapshot` — send `trigger`)
+- Modify: `src/components/fresh-agent/FreshAgentView.tsx` (pass trigger into the fetch)
+- Test: `test/unit/server/ws-handler-fresh-agent.test.ts`, `test/unit/server/fresh-agent/router.test.ts`, `test/unit/client/lib/api.test.ts`
+
+**Interfaces:**
+- Consumes: event kinds from Task 6; `hashForLogs`; `freshAgentLocatorFromMessage` (`ws-handler.ts:1288` — carries `{sessionId, sessionType, provider, cwd?}` at every call site already).
+- Produces:
+  - `freshAgent.send`: one `fresh_agent_send` row per attempt (`outcome: 'accepted' | 'failed'`, `errorCode`, `durationMs`, `requestId`).
+  - `freshAgent.interrupt`: `fresh_agent_interrupt` row (`outcome`).
+  - `freshAgent.attach`: `fresh_agent_attach` row on success too (`recovered: true` when it came from Task 9's retry path).
+  - Materialization: `fresh_agent_materialized` row emitted where the WS layer sends `freshAgent.session.materialized` (`ws-handler.ts:1408-1434` — single choke point).
+  - Snapshot route: accept `trigger` in the query schema (`z.string().max(32).optional()`), include it in `fresh_agent_snapshot_served`; add a `fresh_agent_snapshot_failed` call inside `sendFreshAgentError` with `httpStatus`, `code`, `trigger`, `durationMs`.
+  - Client: `getFreshAgentThreadSnapshot(..., { revision?, cwd?, trigger?, signal? })` appends `['trigger', query.trigger]` to `buildQueryString`; FreshAgentView passes the scheduler trigger.
+
+- [ ] **Step 1: Write the failing tests**
+
+Server (ws): in `ws-handler-fresh-agent.test.ts`, mock the observability module like the adapter suite does (`vi.mock` + spy on `recordFreshAgentObservabilityEvent`):
+
+```ts
+it('emits identity-hashed send and interrupt rows', async () => {
+  // drive a successful freshAgent.send then a freshAgent.interrupt (existing arrange helpers)
+  expect(observabilitySpy).toHaveBeenCalledWith(expect.objectContaining({
+    kind: 'fresh_agent_send', sessionType: 'freshopencode', provider: 'opencode',
+    sessionIdHash: hashForLogs('ses_9'), outcome: 'accepted',
+  }))
+  expect(observabilitySpy).toHaveBeenCalledWith(expect.objectContaining({
+    kind: 'fresh_agent_interrupt', outcome: 'ok', sessionIdHash: hashForLogs('ses_9'),
+  }))
+  // No raw ids or prompt text anywhere in the payloads:
+  for (const [payload] of observabilitySpy.mock.calls) {
+    expect(JSON.stringify(payload)).not.toContain('ses_9')
+    expect(JSON.stringify(payload)).not.toContain('hello')
+  }
+})
+```
+
+Router: in `test/unit/server/fresh-agent/router.test.ts` (supertest harness already exists):
+
+```ts
+it('threads the trigger query param into fresh_agent_snapshot_served', async () => {
+  await request(app).get('/api/fresh-agent/threads/freshopencode/opencode/ses_1?trigger=poll').expect(200)
+  expect(observabilitySpy).toHaveBeenCalledWith(expect.objectContaining({
+    kind: 'fresh_agent_snapshot_served', trigger: 'poll',
+  }))
+})
+
+it('emits fresh_agent_snapshot_failed with the mapped status on errors', async () => {
+  runtimeManagerStub.getSnapshot.mockRejectedValueOnce(new FreshAgentLostSessionError('gone'))
+  await request(app).get('/api/fresh-agent/threads/freshopencode/opencode/ses_gone?trigger=event').expect(404)
+  expect(observabilitySpy).toHaveBeenCalledWith(expect.objectContaining({
+    kind: 'fresh_agent_snapshot_failed', httpStatus: 404, trigger: 'event',
+  }))
+})
+```
+
+Client: in `api.test.ts`, assert the fetch URL contains `trigger=poll` when passed.
+
+- [ ] **Step 2: Run to verify fail** — rows absent; `trigger` rejected/ignored.
+
+- [ ] **Step 3: Implement** per Interfaces. In the ws-handler, wrap each case body: capture `const startedAt = Date.now()` and emit the row in both success and error exits (including Task 9's retry path with `recovered: true` on the attach row). In `sendFreshAgentError`, thread `trigger`/`startedAt` via an optional context arg from the snapshot handler. In `applySnapshot`'s executor (FreshAgentView), pass `trigger` through to `getFreshAgentThreadSnapshot`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm run test:vitest -- --run test/unit/server/ws-handler-fresh-agent.test.ts test/unit/server/fresh-agent/router.test.ts test/unit/client/lib/api.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/ws-handler.ts server/fresh-agent/router.ts src/lib/api.ts src/components/fresh-agent/FreshAgentView.tsx test/unit/server/ test/unit/client/lib/api.test.ts
+git commit -m "feat(server,client): identity-hashed structured rows for all fresh-agent actions and snapshot trigger metadata (zrrj)"
+```
+
+---
+
+### Task 18: Read-only incident-state inspection endpoint
+
+Future incidents need live state without message content: current live status per tracked session, latest status source, active idle-recovery monitors, materialization map, sidecar generation/pid/baseUrl, and a transcript *summary* (counts + hashes only). Clone the `server/debug-router.ts` pattern (34 lines, mounted at `/api/debug`, `server/index.ts:788-795`).
+
+**Files:**
+- Create: `server/fresh-agent/incident-router.ts`
+- Modify: `server/fresh-agent/runtime-manager.ts` (add `inspectState()`), `server/fresh-agent/adapters/opencode/adapter.ts` (add `inspectSessions()`), `server/fresh-agent/adapters/opencode/serve-manager.ts` (Task 7's `describeSidecar()`), `server/index.ts` (mount)
+- Test: `test/unit/server/fresh-agent/incident-router.test.ts`
+
+**Interfaces:**
+- Produces:
+
+```ts
+// runtime-manager.ts
+inspectState(): {
+  sessions: Array<{ key: string; sessionType: string; provider: string; sessionIdHash: string; cwdHash?: string; providerOwned?: boolean }>
+  pendingRecoveries: number
+}
+
+// adapter.ts (opencode) — module-level registry read
+export function inspectOpencodeSessions(): Array<{
+  sessionIdHash: string; status: string; hasRealSession: boolean
+  cwdHash?: string; monitorArmed: boolean; turnAborted?: boolean; turnErrored?: boolean
+  lastTurnCompleteAt?: number
+}>
+
+// incident-router.ts
+export interface IncidentRouterDeps {
+  runtimeManager: { inspectState: () => unknown }
+  opencode: { inspectSessions: () => unknown; describeSidecar: () => unknown }
+}
+export function createFreshAgentIncidentRouter(deps: IncidentRouterDeps): Router
+// GET / -> { version: 1, time, runtime: inspectState(), opencode: { sessions, sidecar } }
+```
+
+Mounted at `app.use('/api/debug/fresh-agent', createFreshAgentIncidentRouter({...}))` right beside the existing debug router (`server/index.ts:788-795`) — **after** auth (`:215`) so it stays token-protected; it shares the global budget, which is acceptable because a human polls it manually (document this in a comment).
+
+- [ ] **Step 1: Write the failing test** (supertest, structural deps — mirror `test/server/api.test.ts`'s `/api/debug` test):
+
+```ts
+it('returns hashed, content-free incident state', async () => {
+  const app = express()
+  app.use('/api/debug/fresh-agent', createFreshAgentIncidentRouter({
+    runtimeManager: { inspectState: () => ({ sessions: [{ key: 'k', sessionType: 'freshopencode', provider: 'opencode', sessionIdHash: 'abc123', cwdHash: 'def456' }], pendingRecoveries: 0 }) },
+    opencode: {
+      inspectSessions: () => [{ sessionIdHash: 'abc123', status: 'running', hasRealSession: true, monitorArmed: true }],
+      describeSidecar: () => ({ generation: 2, pid: 4242, baseUrl: 'http://127.0.0.1:1234' }),
+    },
+  }))
+  const res = await request(app).get('/api/debug/fresh-agent').expect(200)
+  expect(res.body).toMatchObject({ version: 1, opencode: { sidecar: { generation: 2 } } })
+  expect(typeof res.body.time).toBe('string')
+})
+```
+
+Plus unit tests for `inspectOpencodeSessions()` in the adapter suite (arrange a running session with an armed monitor, assert the hashed summary and assert `JSON.stringify(result)` contains neither the raw `ses_` id nor any message text).
+
+- [ ] **Step 2: Run to verify fail** — modules missing.
+
+- [ ] **Step 3: Implement** — all three inspection functions are read-only map walks using `hashForLogs`; the router is a `debug-router.ts` clone with the versioned envelope.
+
+- [ ] **Step 4: Run to verify pass** — `npm run test:vitest -- --run test/unit/server/fresh-agent/incident-router.test.ts test/unit/server/fresh-agent/opencode-serve-adapter.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/fresh-agent/incident-router.ts server/fresh-agent/runtime-manager.ts server/fresh-agent/adapters/opencode/ server/index.ts test/unit/server/fresh-agent/
+git commit -m "feat(server): read-only /api/debug/fresh-agent incident-state endpoint, content-free (zrrj)"
+```
+
+---
+
+### Task 19: Terminal-stream ↔ freshAgent backpressure coupling — prove it
+
+Kata area 6 requires proof, not assumption. Investigation verdict (to be encoded in tests): **coupled, but not via `retention_lost` itself**. In current main, `retention_lost` is log-only (rate-limited 1/s/terminal, `broker.ts:90-94`, `:1276-1305`, `:2235-2267`) — it writes nothing to the socket (the write-amplifying behavior was removed by `ff8589bb`, 2026-06-25). The real coupling: terminal output and freshAgent events share one socket with **asymmetric policy** — `WsHandler.send()` drops the message AND closes the socket with 4008 when `bufferedAmount > 2 MiB` (`ws-handler.ts:1597-1604`, `:233`, `:265`), while the broker writes with **no** buffered-amount gate (`broker.ts:2107-2113`, `:1347`) and only pauses `background` panes at 512 KiB (`broker.ts:859-869`); its own kill line is 16 MiB/10s (`:1087-1130`) — 8× above the handler's. In the 2–16 MiB window every freshAgent lifecycle event dies and the connection is torn down; after the 4008 close, all freshAgent subscriptions are cancelled (`ws-handler.ts:1579-1595`) with no backlog/replay.
+
+**Files:**
+- Create: `test/unit/server/ws-handler-fresh-agent-backpressure.test.ts`
+- Reference harness: `test/unit/server/ws-handler-backpressure.test.ts:42-105` (`createMockWs` with settable `bufferedAmount`, `structuredLogs`, `FakeBrokerRegistry`)
+
+**Interfaces:**
+- Consumes: `createMockWs`, `FakeBrokerRegistry` (copy the helpers into the new file or export them from a shared test helper — prefer extracting to `test/helpers/ws-backpressure.ts` and importing from both files so the originals stay green).
+- Produces: four tests. Tests 1 is written to assert the DESIRED behavior (fails RED now, goes green with Task 20); tests 2–4 pin down current mechanics as regression evidence.
+
+- [ ] **Step 1: Write the tests**
+
+```ts
+describe('terminal output vs freshAgent lifecycle on one socket (zrrj)', () => {
+  it('delivers freshAgent.turn.complete while terminal output has inflated bufferedAmount to 3 MiB', () => {
+    // DESIRED behavior (RED until Task 20): a freshAgent event in the 2-16 MiB window
+    // must still be delivered and must NOT close the socket.
+    const ws = createMockWs({ bufferedAmount: 3 * 1024 * 1024 })
+    // arrange: WsHandler with a freshAgent subscription on this ws (reuse the
+    // subscription-listener arrangement from ws-handler-fresh-agent-lifecycle-parity.test.ts)
+    fireFreshAgentEvent({ type: 'freshAgent.turn.complete', sessionId: 'ses_1', at: Date.now() })
+    const sentTypes = ws.send.mock.calls.map(([f]: [string]) => JSON.parse(f).type)
+    expect(sentTypes).toContain('freshAgent.event')
+    expect(ws.close).not.toHaveBeenCalledWith(4008, expect.anything())
+  })
+
+  it('EVIDENCE: retention_lost is log-only and emits zero WS frames in the current build', () => {
+    // registry.setReplayRingMaxBytes(1024); flood terminal.output.raw past the ring;
+    // assert structuredLogs('warn', 'terminal.replay.retention') fired
+    // and ws.send saw no 'terminal.stream.changed' frames and no send-count delta from retention itself.
+  })
+
+  it('EVIDENCE: broker flushes to a foreground attachment without any bufferedAmount gate today', () => {
+    // set ws.bufferedAmount = 3 MiB, attach a foreground pane, emit output,
+    // assert the broker still called ws.send (this pins the pre-fix asymmetry;
+    // Task 20 flips this assertion).
+  })
+
+  it('EVIDENCE: after a 4008 backpressure close, freshAgent events are dropped with no replay', () => {
+    // drive WsHandler.send over the 2 MiB line -> close(4008); then fire another
+    // freshAgent event and assert nothing was queued/replayed for the dead socket.
+  })
+})
+```
+
+Flesh out the arrange code from the two referenced suites — both already construct `WsHandler` + broker against mock sockets; reuse their construction verbatim.
+
+- [ ] **Step 2: Run and record the verdict**
+
+Run: `npm run test:vitest -- --run test/unit/server/ws-handler-fresh-agent-backpressure.test.ts`
+Expected: test 1 FAILS (message dropped + socket closed) — that failure IS the coupling proof. Tests 2–4 PASS (they encode current mechanics). Keep test 1 failing (skip-marked `it.fails(...)` is NOT allowed — instead proceed immediately to Task 20 in the same PR; the suite must be green only after Task 20).
+
+- [ ] **Step 3: Commit** (tests only, with test 1 temporarily asserting the CURRENT broken behavior inverted — to keep the tree green mid-plan, write test 1 with the desired assertions but wrap the two assertions in `expect(...)` guarded by a `// zrrj Task 20 flips broker gating` comment and commit it together with Task 20 if the repo's per-task green policy requires it. Preferred: implement Task 19+20 as one RED→GREEN cycle, committing the test file in Task 20's commit.)
+
+```bash
+git add test/unit/server/ws-handler-fresh-agent-backpressure.test.ts test/helpers/ws-backpressure.ts
+# commit happens with Task 20 (single RED->GREEN cycle across the two tasks)
+```
+
+---
+
+### Task 20: Fix the coupling — broker foreground pause below the handler kill line
+
+Chosen fix (kata: "if coupled, fix the broker/backpressure/lifecycle-event-loss path in the same change"): make terminal output self-throttle **before** control messages start dying. Add a foreground pause threshold at 1 MiB — half the handler's 2 MiB kill line — using the exact retry mechanic the background path already uses (`broker.ts:859-869`): skip the flush and retry in 100 ms. Terminal output degrades gracefully (it has queues + replay + `sinceSeq`); freshAgent events keep flowing because `bufferedAmount` can no longer be inflated past 2 MiB by terminal traffic alone. The 4008 close in `WsHandler.send` stays — it now fires only under genuine non-terminal pathology.
+
+**Files:**
+- Modify: `server/terminal-stream/constants.ts` (new constant), `server/terminal-stream/broker.ts` (`flushAttachment` `:840-958`)
+- Test: `test/unit/server/ws-handler-fresh-agent-backpressure.test.ts` (Task 19 test 1 + flipped test 3), `test/unit/server/ws-handler-backpressure.test.ts` (existing suite must stay green)
+
+**Interfaces:**
+- Produces, in `constants.ts` (beside the background threshold at `:23-26`):
+
+```ts
+/**
+ * Foreground attachments pause flushing when the socket has this much
+ * unflushed data. MUST stay below WsHandler's maxWsBufferedAmount (2 MiB)
+ * kill line: terminal output must self-throttle before lifecycle messages
+ * (freshAgent.*, session updates) start being dropped with a 4008 close. (zrrj)
+ */
+export const TERMINAL_STREAM_FOREGROUND_PAUSE_BUFFERED_BYTES = 1 * 1024 * 1024
+```
+
+- In `flushAttachment` (`:840-958`), where the background pause currently checks `attachment.priority === 'background' && bufferedAmount > TERMINAL_STREAM_BACKGROUND_PAUSE_BUFFERED_BYTES`, add the foreground equivalent so EVERY attachment pauses at its threshold (background keeps its lower 512 KiB threshold; foreground gets 1 MiB), reusing the identical retry-in-100ms scheduling.
+
+- [ ] **Step 1: Update Task 19's test 3** to assert the new behavior (broker does NOT call `ws.send` when `bufferedAmount` = 3 MiB for a foreground pane; instead it schedules a retry — assert via fake timers or the broker's retry bookkeeping the way the existing catastrophic-spike test at `ws-handler-backpressure.test.ts:271` observes deferred behavior).
+
+- [ ] **Step 2: Run to verify RED** — test 1 and updated test 3 fail against the ungated broker.
+
+Run: `npm run test:vitest -- --run test/unit/server/ws-handler-fresh-agent-backpressure.test.ts`
+
+- [ ] **Step 3: Implement** the constant + the `flushAttachment` gate.
+
+- [ ] **Step 4: Run to verify GREEN + no regressions**
+
+Run: `npm run test:vitest -- --run test/unit/server/ws-handler-fresh-agent-backpressure.test.ts test/unit/server/ws-handler-backpressure.test.ts test/unit/server/terminal-stream/`
+Expected: all PASS — including the existing "does not close the socket for short-lived catastrophic bufferedAmount spikes" (`:271`) and "closes after sustained catastrophic bufferedAmount" (`:302`) tests (the 16 MiB/10s catastrophic path remains the final backstop).
+
+- [ ] **Step 5: Record the area-6 verdict for the kata.** Write the evidence summary into the plan-adjacent notes file `docs/plans/2026-07-27-freshopencode-restart-recovery-area6-evidence.md`:
+
+```markdown
+# zrrj Area 6 verdict: COUPLED (fixed in this change)
+
+- retention_lost itself is log-only in current main (post-ff8589bb, 2026-06-25) and emits
+  zero WS frames — proven by test 'retention_lost is log-only...'. The incident's 10k+/10min
+  retention_lost count is incompatible with the current 1/s/terminal rate limit, so the
+  incident build predated ff8589bb, when retention loss also pushed a terminal.stream.changed
+  frame per attached client (a direct WS write amplifier).
+- The load-bearing coupling: terminal output and freshAgent lifecycle events share one socket
+  with asymmetric backpressure policy (broker ungated vs WsHandler drop+close at 2 MiB).
+  Proven by test 'delivers freshAgent.turn.complete while terminal output has inflated
+  bufferedAmount' (RED before the fix).
+- Fix shipped: TERMINAL_STREAM_FOREGROUND_PAUSE_BUFFERED_BYTES = 1 MiB broker pause below
+  the 2 MiB kill line. The incident's 'WebSocket send callback reported failure' rows match
+  ws-send.ts:167-174 in the same congestion regime.
+```
+
+This file is the evidence the kata-close comment cites.
+
+- [ ] **Step 6: Commit** (includes Task 19's test file)
+
+```bash
+git add server/terminal-stream/ test/unit/server/ws-handler-fresh-agent-backpressure.test.ts test/helpers/ws-backpressure.ts docs/plans/2026-07-27-freshopencode-restart-recovery-area6-evidence.md
+git commit -m "fix(server): terminal output self-throttles below the WS kill line so freshAgent lifecycle events survive floods; prove retention_lost is log-only (zrrj)"
+```
+
+---
+
+### Task 21: Full-suite verification and landing prep
+
+**Files:** none new (fixups only if the suite finds integration breakage).
+
+- [ ] **Step 1: Typecheck + coordinated full suite**
+
+```bash
+FRESHELL_TEST_SUMMARY="zrrj freshopencode restart recovery - full verification" npm run check
+```
+
+Expected: typecheck clean; both vitest configs green. This change touches client + server, so `npm run check` (not bare `npm test`) is the required gate. Fix any failures with focused RED→GREEN cycles and dedicated commits (`fix(test): ...`).
+
+- [ ] **Step 2: Lint (a11y is CI-required)**
+
+```bash
+npm run lint
+```
+
+Expected: clean (the FreshAgentView changes add no new interactive elements, but verify).
+
+- [ ] **Step 3: Focused re-run of the kata's named targets** (final receipts):
+
+```bash
+npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentView.test.tsx test/unit/client/lib/fresh-agent-ws.test.ts test/unit/client/lib/api.test.ts
+npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-adapter.test.ts test/unit/server/fresh-agent/opencode-serve-manager.test.ts test/unit/server/ws-handler-fresh-agent.test.ts
+npm run test:vitest -- --run test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/integration/server/opencode-session-flow.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Commit any stragglers; the branch is ready for the workflow's review/landing stages.**
+
+Landing notes for the finish stage (explicit user pre-approval EXISTS for this change — "fix each of the bugs you indicated with the usual, landing them on main as you go"): push the branch, open the PR targeting `main`, wait for required checks, squash-merge (repo norm), fast-forward local `main`, then close the kata from the repo root with evidence:
+
+```bash
+kata close zrrj --done --commit <merged sha> --message "Landed the canonical fix: client per-key snapshot scheduler with Retry-After/exponential 429 backoff and last-good-snapshot retention; idle HTTP snapshots clear stale opencode busy; restore reconciliation now emits status and arms exactly one monitored idle recovery per durable session with structured interruption on sidecar loss/timeout; serve subscriptions survive sidecar replacement (generation/pid/baseUrl identity added); FRESH_AGENT_LOST_SESSION is preserved over WS with one-shot attach-recover-retry on both server and client; interrupted turns are detected from transcript evidence (missing completion, MessageAbortedError, running tool parts, token accounting, missing step-finish) with a durable interrupt-intent store, a crash-safe recovery ledger, and at most one auditable Freshell-owned continuation; idle is only emitted after the final assistant message is queryable (missing-final-answer race); always-on fresh-agent observability logger with identity-hashed send/interrupt/attach/materialization/monitor/sidecar/snapshot rows and /turns 429 coverage; read-only /api/debug/fresh-agent incident endpoint; area-6 verdict: terminal/WS storm was COUPLED via asymmetric backpressure (broker ungated vs 2MiB drop+close) — fixed with a 1MiB foreground broker pause; retention_lost itself proven log-only post-ff8589bb (evidence in docs/plans/2026-07-27-freshopencode-restart-recovery-area6-evidence.md)."
+```
+
+Do NOT close the kata if any verification step is unverified.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (kata Required Work → tasks):
+
+| Kata requirement | Task(s) |
+|---|---|
+| Per snapshot-key scheduler, one in-flight per key, trailing coalesce | 2, 3 |
+| Debounce transcript-change bursts | 2 (250 ms debounced triggers), 3 |
+| Route ALL refresh triggers (manual, materialization, send-accepted, lifecycle, fallback) through it | 3 (all eight sites enumerated) |
+| Honor Retry-After/backoff on 429, keep last-good snapshot visible, suppress until expiry | 1, 2, 3 |
+| Filter send.accepted to owning pane/session | 3 (gates kept + regression test) |
+| Successful idle HTTP snapshot clears stale busy | 4 |
+| Reconcile live status on durable resume()/attach() before assuming idle | pre-existing `reconcileStatus` + 8 (now emits) |
+| If running: emit running + exactly ONE monitored idle recovery per durable key | 8 |
+| If idle/absent: keep idle, no long waiter | 8 (no-monitor test) |
+| Structured interruption/recovery signals on sidecar loss/timeout/state loss | 8 |
+| Serve subscriptions survive sidecar replacement, proven by tests | 7 |
+| Materialized ses_ sends route or attach/recover + retry once | 9 (server), 10 (client) |
+| Don't swallow genuinely invalid lost-session errors | 9 (placeholder/non-durable guard + test) |
+| Interrupted-turn detection from transcript/tool evidence (all listed signals) | 11 (evidence surfacing), 13 (detector: missing completion, MessageAbortedError, running tool, token accounting, missing step-finish), 8+14 (sidecar loss / shutdown / restored-running via monitor+restore paths) |
+| Stability window (still-writing rows) | 13 |
+| At most ONE continuation, loop prevention, clear transcript event | 12 (ledger), 14 |
+| Never auto-recover after user stop / user follow-up | 12 (durable intent), 13 (trailing-user rule), 14 |
+| Missing-final-answer race with proven freshness | 15 (server polling contract), 16 (client bounded re-poll) |
+| Browser must not permanently stop refreshing on incomplete idle snapshot | 16 |
+| Permanent low-volume structured logs, no content, identity on all rows | 6, 17 |
+| Snapshot metadata (trigger, status, revision, counts, bytes, duration, HTTP status, retry) | 6, 17 (`fresh_agent_snapshot_served` already carries status/revision/counts/bytes/duration; trigger + failure rows added) |
+| Rate-limit metadata for FreshAgent snapshot routes | 6 (retryAfterSeconds + /turns coverage), 5 (JSON 429) |
+| Sidecar generation/PID/base-URL, monitored waits bound to generation | 7, 8 (monitor rows carry sidecarGeneration) |
+| Read-only incident-state inspection, no message content | 18 |
+| Terminal/WS storm: prove coupled vs independent; fix if coupled | 19 (proof), 20 (fix + recorded evidence) |
+| Non-goal: don't weaken the global limiter | 5 (same budget, asserted by test) |
+| Non-goal: no raw content in logs | 11/17/18 leak-assertions |
+| Acceptance: restored pane can't stay stuck busy from process-local loss | 4, 8 |
+| Acceptance: bounded refreshes + controlled 429 backoff | 2, 3 |
+| Acceptance: unrelated panes don't refetch on another pane's send | 3 (test) |
+| Acceptance: no stale "not tracked" for attachable durable sessions | 9, 10 |
+| Acceptance: logs can answer the incident questions | 6, 7, 17, 18 |
+
+No unresolved coverage gaps identified. Note one deliberate scoping decision inside the spec's own frame: the Rust crates (`crates/freshell-freshagent`, `crates/freshell-opencode`) mirror some of this logic; the kata's required work and all named test targets are TS-side, and the running product path exercised in the incident is the TS server. The normalizer change (Task 11) is additive under `extensions` so Rust parity is not broken, merely not extended — flag this in the PR description for a product-owner decision on a follow-up.
+
+**1b. No silent deferrals:** Every requirement lands as production behavior in this plan — no stubs, mocks-as-product, or "future work" items. Mocks in tests isolate the sidecar/socket only; the fake-opencode e2e fixture is pre-existing test infrastructure, not a production stand-in. The freshness contract (Task 15) is a production polling implementation, explicitly sanctioned by the kata ("polling for the expected final message ... acceptable if tested").
+
+**2. Placeholder scan:** No TBD/TODO markers. Where a step edits a 4-6k-line existing file, the plan gives exact anchors (file:line + quoted current code) plus complete new code, and where an existing test-file helper must be reused, it names the helper and its location rather than inventing parallel scaffolding — that is an instruction to reuse, not a placeholder. Task 11 carries an explicit field-name verification step because the OpenCode message schema is not documented in-repo; the defensive implementation is fully specified either way.
+
+**3. Type consistency check:** `retryAfterMs` (Task 1) consumed by Task 2's `ApiError` check; `SnapshotTrigger`/`makeSnapshotKey`/`getSnapshotScheduler`/`resetSnapshotSchedulerForTests` (Task 2) consumed in Tasks 3, 16, 17; `describeSidecar`/`currentGeneration` (Task 7) consumed in Tasks 8, 18; `FreshAgentRecoveryStore` methods (Task 12) consumed in Task 14 with matching signatures; `detectInterruptedTurn(messages, { nowMs, stabilityMs? })` (Task 13) called identically in Task 14; observability kinds (Task 6) match every emission site in Tasks 7, 8, 9, 14, 17; `FRESH_AGENT_LOST_SESSION` code string identical in Tasks 9 and 10. Verified consistent.

--- a/docs/plans/2026-07-27-freshopencode-restart-recovery.md
+++ b/docs/plans/2026-07-27-freshopencode-restart-recovery.md
@@ -1134,40 +1134,50 @@ describe('sidecar replacement resilience (zrrj)', () => {
 
 Adjust the private-access spelling (`(manager as any).running` / `dispatchEvent`) to whatever the existing suite already uses to reach internals — this file already drives the real class with injected doubles; reuse its idioms (e.g. if existing tests trigger death via the injected `fetchFn` timeout instead, do the same).
 
-And add the **generation-aware rebind** test to `test/unit/server/ws-handler-fresh-agent.test.ts` (vi.fn() runtime-manager stub harness):
+And add the **generation-aware rebind** test to `test/unit/server/ws-handler-fresh-agent.test.ts`. Harness reality (verified): the file's ONLY helpers are `makeUserConfig`, `createServer(options)` → `{ server, registry, handler }`, and `connectAndAuth(server)` → a real `ws` WebSocket; there is NO `makeManagerStub` and NO `waitForMessage`/message-frame helper. The runtime-manager stub is an inline object of `vi.fn()`s per test; outbound frames are captured with a per-test `seenMessages` array pushed from a `ws.on('message', ...)` listener; the only synchronization primitive is `vi.waitFor`; teardown is a `finally` block calling `handler.close()`, `registry.shutdown()`, and awaiting `server.close()` (canonical example: the send/interrupt/kill test at `:363-485`). Critically, the server sends **NO success/ack frame** for `freshAgent.attach` (`ws-handler.ts:3467-3509` — only error/`freshAgent.event`/`session.materialized` frames can appear), so the test must synchronize on stub calls, never on an attach response:
 
 ```ts
 it('rebinds the freshAgent subscription when the adapter state generation changes (zrrj)', async () => {
-  // Stub: subscribe() records its listener; sessionStateGeneration() returns a settable number.
   let stateGeneration = 1
   const listeners: Array<(ev: unknown) => void> = []
-  const subscribe = vi.fn((_locator: unknown, listener: (ev: unknown) => void) => {
-    listeners.push(listener)
-    return () => {}
-  })
-  const sessionStateGeneration = vi.fn(() => stateGeneration)
-  const { server } = await createServer({
-    freshAgentRuntimeManager: makeManagerStub({ subscribe, sessionStateGeneration, attach: vi.fn().mockResolvedValue({ sessionId: 'ses_9' }) }),
-  })
-  const ws = await connectAndAuth(server)
-  // First attach subscribes and delivers events
-  ws.send(JSON.stringify({ type: 'freshAgent.attach', sessionId: 'ses_9', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
-  await waitForMessage(ws, (m) => m.type === 'freshAgent.attached' || m.type === 'freshAgent.session.state')
-  expect(subscribe).toHaveBeenCalledTimes(1)
+  const off = vi.fn()
+  const runtimeManager = {
+    attach: vi.fn().mockResolvedValue({ sessionId: 'ses_9', sessionType: 'freshopencode', runtimeProvider: 'opencode' }),
+    subscribe: vi.fn((_locator: unknown, listener: (ev: unknown) => void) => {
+      listeners.push(listener)
+      return off
+    }),
+    sessionStateGeneration: vi.fn(() => stateGeneration),
+  }
+  const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+  try {
+    const ws = await connectAndAuth(server)
+    const seenMessages: any[] = []
+    ws.on('message', (data) => { seenMessages.push(JSON.parse(data.toString())) })
 
-  // Simulate adapter-state recreation: new generation, new emitter (a NEW listener registration is required)
-  stateGeneration = 2
-  ws.send(JSON.stringify({ type: 'freshAgent.attach', sessionId: 'ses_9', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
-  await waitForMessage(ws, (m) => m.type === 'freshAgent.attached' || m.type === 'freshAgent.session.state')
-  expect(subscribe).toHaveBeenCalledTimes(2)   // FAILS today: ensureFreshAgentSubscription short-circuits (:1504-1511)
+    // First attach subscribes. No ack frame exists for attach — wait on the stub call.
+    ws.send(JSON.stringify({ type: 'freshAgent.attach', sessionId: 'ses_9', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+    await vi.waitFor(() => expect(runtimeManager.subscribe).toHaveBeenCalledTimes(1))
 
-  // Events dispatched through the NEW listener reach the pane
-  listeners.at(-1)!({ type: 'sdk.session.snapshot', sessionId: 'ses_9', status: 'running' })
-  await waitForMessage(ws, (m) => m.type === 'freshAgent.event')
+    // Simulate adapter-state recreation: new generation, new emitter (a NEW listener registration is required)
+    stateGeneration = 2
+    ws.send(JSON.stringify({ type: 'freshAgent.attach', sessionId: 'ses_9', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+    // FAILS today (vi.waitFor times out): ensureFreshAgentSubscription short-circuits on the existing entry (:1504-1511)
+    await vi.waitFor(() => expect(runtimeManager.subscribe).toHaveBeenCalledTimes(2))
+    expect(off).toHaveBeenCalledTimes(1)   // the stale subscription was cancelled before rebinding
+
+    // Events dispatched through the NEW listener reach the client as freshAgent.event frames
+    listeners.at(-1)!({ type: 'sdk.session.snapshot', sessionId: 'ses_9', status: 'running' })
+    await vi.waitFor(() => expect(seenMessages.some((m) => m.type === 'freshAgent.event')).toBe(true))
+  } finally {
+    handler.close()
+    registry.shutdown()
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
 })
 ```
 
-Match the stub's `subscribe` signature and the attach-response frame names to the file's existing attach tests (copy the nearest passing attach arrangement — the harness already stubs `subscribe`).
+Arrangement constraints (verified against the handler): `freshAgent.attach` itself authorizes the locator (`ws-handler.ts:3485`), and durable freshopencode (`ses_*` + opencode) authorization keys include a non-empty cwd — keep `cwd: '/w'` on both attach frames. And the file already PINS the repeat-attach no-op at `:1101`: that test's stub has no `sessionStateGeneration`, so the implementation must rebind ONLY when the manager exposes `sessionStateGeneration` AND the returned generation differs from the recorded one; when the method is absent, the existing-entry branch returns early exactly as today, keeping the pinned test green.
 
 - [ ] **Step 2: Run to verify the replacement test fails**
 
@@ -1497,36 +1507,76 @@ Add to `test/unit/server/ws-handler-fresh-agent.test.ts`:
 
 ```ts
 it('propagates FRESH_AGENT_LOST_SESSION (with requestId) when the manager reports lost-session', async () => {
-  const send = vi.fn().mockRejectedValue(new FreshAgentLostSessionError('Fresh-agent session freshopencode/opencode/ses_9 is not tracked'))
-  const { server } = await createServer({ freshAgentRuntimeManager: makeManagerStub({ send }) })
-  const ws = await connectAndAuth(server)
-  ws.send(JSON.stringify({
-    type: 'freshAgent.send', requestId: 'r1', sessionId: 'ses_9',
-    sessionType: 'freshopencode', provider: 'opencode', text: 'hello',   // NO cwd — the incident shape
-  }))
-  const err = await waitForMessage(ws, (m) => m.type === 'error')
-  expect(err.code).toBe('FRESH_AGENT_LOST_SESSION')
-  expect(err.requestId).toBe('r1')
-  expect(send).toHaveBeenCalledTimes(1)
+  const runtimeManager = {
+    create: vi.fn().mockResolvedValue({ sessionId: 'ses_9', sessionType: 'freshopencode', runtimeProvider: 'opencode' }),
+    subscribe: vi.fn().mockReturnValue(() => undefined),
+    send: vi.fn().mockRejectedValue(new FreshAgentLostSessionError('Fresh-agent session freshopencode/opencode/ses_9 is not tracked')),
+  }
+  const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+  try {
+    const ws = await connectAndAuth(server)
+    const seenMessages: any[] = []
+    ws.on('message', (data) => { seenMessages.push(JSON.parse(data.toString())) })
+
+    // Authorize ses_9 via create (the file's canonical idiom, :363-485) — NOT via attach.
+    ws.send(JSON.stringify({ type: 'freshAgent.create', requestId: 'req-1', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+    await vi.waitFor(() => expect(runtimeManager.create).toHaveBeenCalled())
+
+    ws.send(JSON.stringify({
+      type: 'freshAgent.send', requestId: 'r1', sessionId: 'ses_9',
+      sessionType: 'freshopencode', provider: 'opencode', cwd: '/w', text: 'hello',
+    }))
+    await vi.waitFor(() => {
+      const err = seenMessages.find((m) => m.type === 'error' && m.requestId === 'r1')
+      expect(err).toBeTruthy()
+      expect(err.code).toBe('FRESH_AGENT_LOST_SESSION')
+    })
+    expect(runtimeManager.send).toHaveBeenCalledTimes(1)
+  } finally {
+    handler.close()
+    registry.shutdown()
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
 })
 
 it('does not attach-retry inside the handler even for a cwd-bearing durable locator (client owns recovery)', async () => {
-  const send = vi.fn().mockRejectedValue(new FreshAgentLostSessionError('Fresh-agent session freshopencode/opencode/ses_9 is not tracked'))
-  const attach = vi.fn()
-  const { server } = await createServer({ freshAgentRuntimeManager: makeManagerStub({ send, attach }) })
-  const ws = await connectAndAuth(server)
-  ws.send(JSON.stringify({
-    type: 'freshAgent.send', requestId: 'r1', sessionId: 'ses_9',
-    sessionType: 'freshopencode', provider: 'opencode', cwd: '/w', text: 'hello',
-  }))
-  const err = await waitForMessage(ws, (m) => m.type === 'error')
-  expect(err.code).toBe('FRESH_AGENT_LOST_SESSION')
-  expect(attach).not.toHaveBeenCalled()   // no server-side retry: cwd-bearing recovery already ran inside manager.send
-  expect(send).toHaveBeenCalledTimes(1)   // no blind retry loop
+  const runtimeManager = {
+    create: vi.fn().mockResolvedValue({ sessionId: 'ses_9', sessionType: 'freshopencode', runtimeProvider: 'opencode' }),
+    subscribe: vi.fn().mockReturnValue(() => undefined),
+    send: vi.fn().mockRejectedValue(new FreshAgentLostSessionError('Fresh-agent session freshopencode/opencode/ses_9 is not tracked')),
+    attach: vi.fn(),
+  }
+  const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+  try {
+    const ws = await connectAndAuth(server)
+    const seenMessages: any[] = []
+    ws.on('message', (data) => { seenMessages.push(JSON.parse(data.toString())) })
+
+    // Authorization comes from create — the client never sends freshAgent.attach in this test,
+    // so the attach spy is a pure detector for a server-side attach-retry.
+    ws.send(JSON.stringify({ type: 'freshAgent.create', requestId: 'req-1', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+    await vi.waitFor(() => expect(runtimeManager.create).toHaveBeenCalled())
+
+    ws.send(JSON.stringify({
+      type: 'freshAgent.send', requestId: 'r1', sessionId: 'ses_9',
+      sessionType: 'freshopencode', provider: 'opencode', cwd: '/w', text: 'hello',
+    }))
+    await vi.waitFor(() => {
+      const err = seenMessages.find((m) => m.type === 'error' && m.requestId === 'r1')
+      expect(err).toBeTruthy()
+      expect(err.code).toBe('FRESH_AGENT_LOST_SESSION')
+    })
+    expect(runtimeManager.attach).not.toHaveBeenCalled()   // no server-side retry: cwd-bearing recovery already ran inside manager.send
+    expect(runtimeManager.send).toHaveBeenCalledTimes(1)   // no blind retry loop
+  } finally {
+    handler.close()
+    registry.shutdown()
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
 })
 ```
 
-Reuse the file's existing manager-stub construction and message-frame helpers verbatim (the suite already has patterns for `freshAgent.send` frames including authorization setup — follow the nearest passing send test; the fresh-agent send path requires prior authorization via create/attach in some configurations: mirror whatever arrangement the file's existing send tests use, e.g. an initial `freshAgent.attach` frame).
+Harness reality (verified — do not look for helpers that don't exist): the file's ONLY helpers are `makeUserConfig`, `createServer(options)` → `{ server, registry, handler }`, and `connectAndAuth(server)`; there is NO `makeManagerStub` and NO `waitForMessage`. Runtime-manager stubs are inline objects of `vi.fn()`s; outbound frames are observed via a per-test `seenMessages` array; synchronization is `vi.waitFor`; teardown is the `finally` block shown (all per the canonical send test at `:363-485`). Authorization notes: `freshAgent.send` is gated by `waitForFreshAgentAuthorization` (`ws-handler.ts:3519` → `:1449`), and durable freshopencode (`ses_*` + opencode) authorization keys include a non-empty cwd (`ws-handler.ts:1279-1286`, `:1338-1341`; the locator cwd derives from `m.cwd ?? m.settings?.cwd`, `:1288`) — hence `cwd: '/w'` on BOTH the create and send frames so the keys align (if the create schema carries cwd only under `settings.cwd`, put it there; the locator derivation accepts either). These ws-level tests deliberately use cwd-bearing frames: the no-cwd incident population is exercised at the runtime-manager level, and the handler's catch-branch mapping (the behavior under test here) is cwd-agnostic.
 
 - [ ] **Step 2: Run to verify they fail**
 
@@ -1602,14 +1652,23 @@ it('re-attaches with the route cwd and resends once when a send fails with FRESH
     expect(frames.filter((m) => m.type === 'freshAgent.send' && m.text === 'hello again')).toHaveLength(1)
   })
 
-  // Second failure for the retried request must NOT loop
+  // Second failure for the retried request must NOT loop...
   const retried = wsMock.send.mock.calls.map(([f]) => JSON.parse(f)).find((m) => m.type === 'freshAgent.send')
   wsMock.send.mockClear()
   act(() => wsHandler({ type: 'error', code: 'FRESH_AGENT_LOST_SESSION', requestId: retried.requestId, message: 'still not tracked' }))
   await new Promise((r) => setTimeout(r, 100))
   expect(wsMock.send.mock.calls.map(([f]) => JSON.parse(f)).filter((m) => m.type === 'freshAgent.send')).toHaveLength(0)
+
+  // ...and the cleanup fall-through (Step 3 item 4) must fire for the final failure:
+  await waitFor(() => {
+    expect(screen.queryByText('hello again')).not.toBeInTheDocument()   // stale local echo cleared
+  })
+  expect(getFreshAgentPaneContent(store).pendingLocalEcho).toBeUndefined()   // Redux copy cleared too (dual-write)
+  expect(getFreshAgentPaneContent(store).status).not.toBe('running')   // optimistic busy released
 })
 ```
+
+(`getFreshAgentPaneContent(store)` is the file's existing store-reading helper; the echo renders as a synthetic appended user turn, so `queryByText` of the sent text is the presence probe the file already uses.)
 
 No existing test injects a `type: 'error'` frame into a fresh-agent view test (verified — write these fresh, do not look for a precedent to copy). The harness's captured `wsMock.onMessage` handler (`FreshAgentView.test.tsx:20-38` idiom: capture `wsMock.onMessage.mock.calls[0][0]` post-render, or `onMessage.mockImplementation((h) => { captured = h })` pre-render) accepts arbitrary frames; inject the real `ErrorMessage` shape from `shared/ws-protocol.ts:707-719` — `{ type: 'error', code, message, requestId, timestamp }` (add `timestamp: Date.now()` to the frames in the test above; the component branch must key off `type`/`code`/`requestId` only).
 
@@ -1648,7 +1707,27 @@ if (errorCode === 'FRESH_AGENT_LOST_SESSION'
 
 The `startsWith('ses_')` guard keeps genuinely-invalid placeholder/non-durable lost-session errors on the normal error path (the server no longer filters these — Task 9).
 
-3. Implement `resendPendingMessage` by extracting the existing send-frame construction into a helper reused by the composer submit path and the retry (same fields, plus `cwd`); the retry's own pending-metadata entry retains the same `text` (so its failure still cleans up normally through the fall-through path).
+3. Implement `resendPendingMessage` by extracting the existing send-frame construction into a helper reused by the composer submit path and the retry (same fields, plus `cwd`); the retry's own pending-metadata entry retains the same `text` (so its failure still cleans up normally through the fall-through path). The retry also RE-STAMPS the visible local echo's `requestId` to the retry's requestId (same text) via the `setLocalEcho` dual-write helper (`:655-664`), so the retry's eventual acceptance or failure correlates with the echo that is on screen.
+
+4. Add the cleanup fall-through at the end of the owned-error branch — reached by every owned send failure that did not take the retry path, including a retried request failing again:
+
+```ts
+// failedRequestId is owned (a pendingSendMetadataRef entry exists) and no retry fired:
+pendingSendMetadataRef.current.delete(failedRequestId)
+if (localEchoRef.current?.requestId === failedRequestId) {
+  // setLocalEcho is the DUAL-WRITE helper (:655-664): it clears both the React state and
+  // paneContent.pendingLocalEcho in Redux. Do NOT call the raw React setter here — the
+  // Redux-sync effect (:665-673) would re-seed the echo from the surviving Redux copy.
+  setLocalEcho(undefined)
+}
+if (paneContentRef.current?.provider === 'opencode' && paneContentRef.current.status === 'running') {
+  // Release the optimistic busy written by sendUserText's mergePaneContent (:2001-2008,
+  // the `status: 'running'` spread at :2005) — mirror that call shape with status: 'idle'.
+  mergePaneContent({ status: 'idle' })
+}
+```
+
+Locate the exact setter/helper names by the quoted code (per this plan's locate-by-quoted-code rule); the three cleanup targets are exactly the three leaks named in the premise above (metadata entry, `pendingLocalEcho`, optimistic `running`).
 
 - [ ] **Step 4: Run to verify pass**
 

--- a/docs/plans/2026-07-27-freshopencode-restart-recovery.md
+++ b/docs/plans/2026-07-27-freshopencode-restart-recovery.md
@@ -217,7 +217,7 @@ export function resetSnapshotSchedulerForTests(): void
 **Semantics (implement exactly):**
 - Debounce: triggers `event`, `send-accepted`, `reveal`, `reconnect` wait `SNAPSHOT_DEBOUNCE_MS = 250` before running (a burst within the window coalesces into one run and all callers share that run's outcome). Triggers `identity`, `manual`, `materialized`, `poll`, `idle-incomplete` run immediately (debounce 0).
 - Single-flight: at most one in-flight `run()` per key. Calls arriving mid-flight coalesce into **one** trailing run scheduled after the in-flight completes (+debounce); they all share the trailing run's promise. A caller absorbed by an already-pending debounce timer resolves with the shared run's outcome (not `'coalesced'`); `'coalesced'` is returned only when a trailing run is already fully subscribed and this call adds nothing new (keep it simple: everyone sharing a pending run gets that run's outcome; `'coalesced'` is unused in practice but kept in the type for the trailing-overflow case where a trailing run is already queued).
-- 429 backoff: when `run()` rejects with `ApiError` status 429, set `backoffUntil = now + (retryAfterMs ?? nextExponential)` where `nextExponential` doubles from `1000` ms capped at `30_000` ms per consecutive 429 on that key; resolve all sharers with `{ status: 'rate-limited', retryAtMs }`. While backoff is active, `schedule()` resolves immediately `{ status: 'backoff', retryAtMs }` with **no network call**. A successful run resets the exponential counter and clears backoff.
+- 429 backoff: when `run()` rejects with `ApiError` status 429, set `backoffUntil = now + (retryAfterMs ?? nextExponential)` where `nextExponential` doubles from `1000` ms capped at `30_000` ms per consecutive 429 on that key; resolve ALL sharers with `{ status: 'rate-limited', retryAtMs }` — **including callers that arrived mid-flight and were queued for the trailing run**: a 429 cancels the trailing run and resolves that queued cohort with the same rate-limited outcome (no promise may be left pending — a stranded promise means a pane whose refresh coalesced behind the rate-limited run never gets an outcome). While backoff is active, `schedule()` resolves immediately `{ status: 'backoff', retryAtMs }` with **no network call**. A successful run resets the exponential counter and clears backoff.
 - Other rejections resolve `{ status: 'error', error }` (never throw out of `schedule`).
 - **Run-closure contract (validated, A2):** the scheduler may execute a `run` closure long after the caller's React effect cleaned up (debounce/trailing), and one caller's closure runs on behalf of ALL sharers of the key. Callers therefore must NOT bind caller-scoped AbortControllers/signals into `run` — an owner abort mid-flight (or a debounced run firing an already-aborted signal) would resolve `{ status: 'error', AbortError }` to every sharer, which the component layer swallows, silently dropping the refresh for panes that are still alive. Task 3 passes no signal; staleness is handled by result-application guards, not cancellation.
 - **Key note:** the `cwd` component of the key must be the caller's RESOLVED route cwd (Task 3 resolves it once and uses the same value for both the key and the request), so sibling panes on one session converge to one key.
@@ -311,6 +311,20 @@ describe('FreshAgentSnapshotScheduler', () => {
     const after = await scheduler.schedule(KEY, 'poll', ok)
     expect(after).toEqual({ status: 'ok', value: 'fresh' })
     expect(scheduler.getBackoffUntil(KEY)).toBeNull()
+  })
+
+  it('resolves mid-flight sharers with rate-limited on a 429 instead of stranding their promises', async () => {
+    const scheduler = getSnapshotScheduler()
+    let reject!: (e: unknown) => void
+    const gated = new Promise<never>((_, r) => { reject = r })
+    const run = vi.fn(() => gated)
+    const first = scheduler.schedule(KEY, 'manual', run)
+    const midFlight = scheduler.schedule(KEY, 'event', run)   // arrives while in flight -> queued for the trailing run
+    reject(new ApiError(429, 'Too many requests', undefined, 5_000))
+    const [o1, o2] = await Promise.all([first, midFlight])    // BOTH must settle
+    expect(o1.status).toBe('rate-limited')
+    expect(o2.status).toBe('rate-limited')
+    expect(run).toHaveBeenCalledTimes(1)                      // the trailing run is cancelled: no second network call
   })
 
   it('falls back to exponential backoff when Retry-After is absent and doubles per consecutive 429', async () => {
@@ -461,9 +475,15 @@ export class FreshAgentSnapshotScheduler {
         const fallback = Math.min(BACKOFF_MAX_MS, BACKOFF_BASE_MS * 2 ** (s.consecutive429 - 1))
         const retryAtMs = Date.now() + (error.retryAfterMs ?? fallback)
         s.backoffUntil = retryAtMs
-        // A 429 supersedes any trailing request: suppress until expiry.
-        s.trailingRequested = false
         outcome = { status: 'rate-limited', retryAtMs }
+        // A 429 supersedes any trailing request: cancel it AND resolve the
+        // mid-flight cohort queued behind this run with the same rate-limited
+        // outcome — their promises must never be left pending.
+        s.trailingRequested = false
+        const trailing = s.pendingResolvers
+        s.pendingResolvers = []
+        s.pendingRun = null
+        for (const resolve of trailing) resolve(outcome)
       } else {
         outcome = { status: 'error', error }
       }
@@ -1549,15 +1569,17 @@ git commit -m "fix(server,shared): preserve FRESH_AGENT_LOST_SESSION over WS (sh
 
 With Task 9, a lost-session send failure reaches the client as `code: 'FRESH_AGENT_LOST_SESSION'` (there is deliberately no server-side retry — see Task 9's coverage restatement; this client path is the kata's "attach/recover and retry once" for the incident's no-cwd locators). The client knows the route cwd (`freshOpenCodeRouteCwd`, `FreshAgentView.tsx:613-615` via `src/lib/fresh-opencode-route.ts`) even when the original send omitted it. On this code, re-issue `freshAgent.attach` with the route cwd, then resend the message exactly once.
 
-**Resend source (corrected by validation, A10):** `PendingSendMetadata` (`FreshAgentView.tsx:102-108`) is `{ cwd?, checkpointId?, submittedTurnId?, legacyAccepted?, metadataUpdateStarted? }` — it does **NOT** retain the message text. Retain the original send payload explicitly: add `text: string` to `PendingSendMetadata`, populated at the composer-submit site where the entry is created (the same place the `freshAgent.send` frame is built, so the retained text is byte-identical to what was sent). **Ordering constraint:** the lost-session retry branch must run BEFORE the generic send-error handling that clears the pane's local echo / pending metadata — if the generic path runs first, both the metadata entry and the visible echo are gone and there is nothing to resend.
+**Resend source (corrected by validation, A10):** `PendingSendMetadata` (`FreshAgentView.tsx:102-108`) is `{ cwd?, checkpointId?, submittedTurnId?, legacyAccepted?, metadataUpdateStarted? }` — it does **NOT** retain the message text. Retain the original send payload explicitly: add `text: string` to `PendingSendMetadata`, populated in `sendUserText` (`:1942-2009`) where `recordPendingSendMetadata(requestId, {})` is called (`:1947`) and the `freshAgent.send` frame is built (`:1984-1999`), so the retained text is byte-identical to what was sent.
+
+**Error-frame reality (corrected by fresh-eyes review — the prior premise was false):** FreshAgentView's `ws.onMessage` handler (`:1404`) has **NO branch for `type: 'error'` frames today** — it handles only `pane.reconcile.result`, `freshAgent.created`, `freshAgent.create.failed`, `freshAgent.session.materialized`, `freshAgent.event`, `freshAgent.send.accepted`, and `freshAgent.forked`. There is no existing send-failure path and no echo-clearing-on-error code: a failed send currently leaves `pendingLocalEcho` rendered forever, leaks its `pendingSendMetadataRef` entry, and (opencode) pins the pane's optimistic `running` status (`shouldClearStaleLocalEcho` `:147` requires `accepted`, which only `send.accepted` sets). The server reports a send failure via `this.sendError(...)` in the `freshAgent.send` catch (`server/ws-handler.ts:3554-3556`) with wire shape `{ type: 'error', code, message, requestId, timestamp }` (`ErrorMessage`, `shared/ws-protocol.ts:707-719`); `requestId` is the ONLY correlation handle (no sessionId/paneId on the frame), and `freshAgent.send` is the only fresh-agent path that threads it. Task 9 makes that code `FRESH_AGENT_LOST_SESSION` for lost sessions. This task therefore ADDS the `type: 'error'` branch to the handler; frames whose `requestId` matches a `pendingSendMetadataRef` entry are owned send failures — the lost-session retry check runs first, and every other owned failure (including a retried request failing again) takes the NEW cleanup fall-through this task introduces (clear the pending-metadata entry + stale local echo + optimistic `running`). Error frames with no matching `requestId` are left to any generic handling and are out of scope here.
 
 **Files:**
-- Modify: `src/components/fresh-agent/FreshAgentView.tsx` (`PendingSendMetadata` type `:102-108` + its composer-submit writer; WS error handling for sends — locate the existing handler for send failures: search the file for `INTERNAL_ERROR` or the `sendError`-frame consumption path used to clear local echo on failure)
+- Modify: `src/components/fresh-agent/FreshAgentView.tsx` (`PendingSendMetadata` type `:102-108` + its `sendUserText` writer `:1947`; NEW `type: 'error'` branch in the `ws.onMessage` handler `:1404`)
 - Test: `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
 
 **Interfaces:**
-- Consumes: `wsMock.send` scaffold; `freshOpenCodeRouteCwdRef`; `pendingSendMetadataRef` — extended by this task with the retained `text`.
-- Produces: `PendingSendMetadata` gains `text: string`; one retry per failed requestId, tracked in `lostSessionRetryRef: useRef<Set<string>>` (requestIds already retried — never retried twice); the retry branch is evaluated before (and, when it fires, instead of) the echo-clearing error fall-through.
+- Consumes: `wsMock.send` scaffold; `freshOpenCodeRouteCwdRef`; `pendingSendMetadataRef` — extended by this task with the retained `text`; `ErrorMessage` frame shape from `shared/ws-protocol.ts:707-719`.
+- Produces: `PendingSendMetadata` gains `text: string`; a NEW `type: 'error'` branch for owned send requestIds; one retry per failed requestId, tracked in `lostSessionRetryRef: useRef<Set<string>>` (requestIds already retried — never retried twice); the retry check is evaluated before (and, when it fires, instead of) the cleanup fall-through this task adds.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -1589,7 +1611,7 @@ it('re-attaches with the route cwd and resends once when a send fails with FRESH
 })
 ```
 
-Check how error frames reach the component today (the `wsHandler` capture receives all frames; if send errors arrive with a different shape — e.g. `{ type: 'freshAgent.send.failed' }` or a generic `{ type: 'error' }` — mirror the real shape emitted by `this.sendError` in `ws-handler.ts`, which the existing tests for send failure already model; copy from them).
+No existing test injects a `type: 'error'` frame into a fresh-agent view test (verified — write these fresh, do not look for a precedent to copy). The harness's captured `wsMock.onMessage` handler (`FreshAgentView.test.tsx:20-38` idiom: capture `wsMock.onMessage.mock.calls[0][0]` post-render, or `onMessage.mockImplementation((h) => { captured = h })` pre-render) accepts arbitrary frames; inject the real `ErrorMessage` shape from `shared/ws-protocol.ts:707-719` — `{ type: 'error', code, message, requestId, timestamp }` (add `timestamp: Date.now()` to the frames in the test above; the component branch must key off `type`/`code`/`requestId` only).
 
 - [ ] **Step 2: Run to verify it fails**
 
@@ -1598,9 +1620,9 @@ Expected: FAIL — no attach, no resend.
 
 - [ ] **Step 3: Implement** in `FreshAgentView.tsx`:
 
-1. Extend `PendingSendMetadata` (`:102-108`) with `text: string`, and populate it at the composer-submit site where the metadata entry for the requestId is created (the same code that builds the `freshAgent.send` frame — retain exactly the text that went into the frame). This is the retained resend payload; do NOT read it from the local echo after the fact (the echo is cleared by error paths).
+1. Extend `PendingSendMetadata` (`:102-108`) with `text: string`, and populate it in `sendUserText` where the metadata entry for the requestId is created (`recordPendingSendMetadata(requestId, {...})`, `:1947` — the same code that builds the `freshAgent.send` frame, `:1984-1999`; retain exactly the text that went into the frame). This is the retained resend payload; do NOT read it from the local echo after the fact.
 
-2. In the WS error-frame handling for owned send requests, add the retry branch **as the FIRST thing the send-failure path evaluates — before the existing handling that clears the local echo / pending metadata and shows the error** (if the clearing runs first, the payload is gone):
+2. Add a NEW `type: 'error'` branch to the `ws.onMessage` handler (`:1404`) — remember, no such branch exists today. It applies only to frames whose `requestId` matches a `pendingSendMetadataRef` entry (owned send failures). The retry check is the FIRST thing the branch evaluates; everything else falls through to the cleanup added in item 4:
 
 ```ts
 if (errorCode === 'FRESH_AGENT_LOST_SESSION'
@@ -1615,13 +1637,13 @@ if (errorCode === 'FRESH_AGENT_LOST_SESSION'
     ws.send(JSON.stringify({
       type: 'freshAgent.attach', sessionId, sessionType: 'freshopencode', provider: 'opencode', cwd,
     }))
-    const retryRequestId = createRequestId()      // the file's existing id generator
+    const retryRequestId = nanoid()               // the file's existing id generator (:1945)
     lostSessionRetryRef.current.add(retryRequestId)   // the retry itself is never retried
     resendPendingMessage(retryRequestId, pendingMeta.text, cwd)   // re-issue freshAgent.send with the retained text + cwd
     return   // do NOT fall through: the echo stays visible while the retry is in flight
   }
 }
-// fall through to the existing error handling (clear echo, show error)
+// fall through to the cleanup this task adds in item 4 (clear pending metadata + stale echo)
 ```
 
 The `startsWith('ses_')` guard keeps genuinely-invalid placeholder/non-durable lost-session errors on the normal error path (the server no longer filters these — Task 9).
@@ -2250,6 +2272,12 @@ async function awaitTranscriptSettled(state: OpencodeSessionState, sentAtMs: num
 
 Settled means: `listMessages` (limit e.g. 20, newest page) contains an assistant message with `info.time.created >= sentAtMs - CLOCK_SKEW_MS` (use `CLOCK_SKEW_MS = 5_000`) AND a finite `info.time.completed`. Poll with `TRANSCRIPT_SETTLE_POLL_MS` sleeps between attempts; inject the sleep fn for tests (`options.sleep`, default `(ms) => new Promise(r => setTimeout(r, ms))`). (Pagination contract verified live on opencode v1.18.6, V2: `?limit=N` returns exactly the N newest messages in ascending chronological order — last element is the latest; limit-only paging is all this plan uses, so the newest-page premise holds.)
 
+**Suite-wide impact (corrected by fresh-eyes review — this task retro-touches Task 8's tests and the shared harness):** the settle loop runs on BOTH the send path and Task 8's monitor-resolve path, and the harness's `makeFakeManager` default `listMessages` fixture (`{ messages: [], nextCursor: null }`) never settles. Without harness changes, every pre-existing send-path test and Task 8's monitor tests would burn 10 polls x a REAL 150 ms sleep (~1.35 s each) before idle is emitted, breaking Task 8's single-`setImmediate` assertions and Step 4's full-suite gate. Step 3 therefore MUST include these test-harness changes (they land in the same commit):
+
+1. In the test suite's `makeAdapter` helper, default the adapter's injected `settleSleep` to a no-op (`async () => {}`) for ALL tests (merge it into the options it forwards; explicit per-test options still win). The PRODUCTION default stays the real `setTimeout` sleep — only the harness default changes.
+2. With a no-op sleep, legacy tests using the never-settling default fixture exhaust the 10-poll budget in pure microtasks and still emit idle in the same order — their `await new Promise((r) => setImmediate(r))` flushes drain the whole settle loop before the assertion runs (microtasks complete before the macrotask fires), so Task 8's monitor tests and the pre-existing send tests keep passing without per-test edits. If any test asserts an exact `listMessages` call count, adjust it for the settle polls (up to 10 extra calls per completed turn); inspect the first failing run's actual counts and keep ORDER assertions as the real contract.
+3. If a Task 8 monitor-resolve assertion still races despite the no-op sleep (e.g. an environment where the flush is insufficient), replace that test's single `setImmediate` with `await vi.waitFor(() => expect(events.some(...)).toBe(true))` rather than reintroducing real sleeps.
+
 In `materializeOrSend`, capture `const sentAtMs = Date.now()` just before `promptAsyncForState` (`:363`), then after `await idle` (`:368`) insert `await awaitTranscriptSettled(state, sentAtMs)` BEFORE `emitStatus(state, 'idle')` (`:371`) and the chime (`:377-381`). Also call it (with `sentAtMs = 0`, i.e. "any completed assistant message") in Task 8's monitor resolve path before its `emitStatus(state, 'idle')`.
 
 - [ ] **Step 1: Write the failing tests**
@@ -2300,9 +2328,9 @@ describe('idle freshness (zrrj)', () => {
 
 - [ ] **Step 2: Run to verify fail** — idle is emitted immediately today; `listMessages` not polled.
 
-- [ ] **Step 3: Implement** `awaitTranscriptSettled` + the two call sites; thread `settleSleep` through adapter options (default real sleep). On `false` (exhausted), also emit an observability row: `recordFreshAgentObservabilityEvent({ kind: 'fresh_agent_monitor', provider: 'opencode', sessionIdHash, phase: 'timeout', ... })` is the wrong kind — instead log `log.warn({...}, 'transcript did not settle after idle')`.
+- [ ] **Step 3: Implement** `awaitTranscriptSettled` + the two call sites; thread `settleSleep` through adapter options (PRODUCTION default: real sleep). On `false` (exhausted), also emit an observability row: `recordFreshAgentObservabilityEvent({ kind: 'fresh_agent_monitor', provider: 'opencode', sessionIdHash, phase: 'timeout', ... })` is the wrong kind — instead log `log.warn({...}, 'transcript did not settle after idle')`. In the SAME change, apply the harness updates from the "Suite-wide impact" note above: default `settleSleep` to a no-op inside the test suite's `makeAdapter` helper, and adjust any pre-existing exact `listMessages` call-count assertions.
 
-- [ ] **Step 4: Run to verify pass** — full adapter suite.
+- [ ] **Step 4: Run to verify pass** — full adapter suite (`npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-adapter.test.ts`). The legacy tests and Task 8's monitor tests stay green and fast because the harness `settleSleep` is a no-op (see the Suite-wide impact note); if any fail, fix per that note's items 2-3 — do NOT loosen the new order assertions.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/plans/2026-07-27-freshopencode-restart-recovery.md
+++ b/docs/plans/2026-07-27-freshopencode-restart-recovery.md
@@ -7,7 +7,7 @@
 
 **Goal:** Fix kata `zrrj` — after a Freshell restart, FreshOpenCode panes must not storm the snapshot API into global 429 starvation, must reconcile live status instead of stranding busy/idle state, must recover interrupted turns exactly once with audit, must not lose the final assistant answer on the idle race, must emit permanent identity-bearing structured logs, and must be immune to terminal-stream WS backpressure killing lifecycle events.
 
-**Architecture:** Client-side: a module-singleton per-snapshot-key scheduler (single-flight, trailing coalesce, debounce, Retry-After-honoring 429 backoff) that every refresh trigger routes through, plus HTTP-snapshot-driven busy clearing for opencode. Server-side: the opencode adapter's `reconcileStatus` becomes event-emitting and arms exactly one monitored idle-recovery per durable session; serve-manager subscriptions survive sidecar replacement and carry a generation identity; lost-session errors keep their code across the WS boundary with a one-shot attach-recover-retry; interrupted turns are detected from transcript evidence (never a guessed status field) and recovered with one persisted, loop-proof Freshell-owned continuation; idle is only emitted after the final assistant message is proven queryable. Observability rows go to a dedicated always-on pino logger (the main logger drops `info` in production). The terminal-stream broker gains a foreground buffered-amount pause below the WS handler's 2 MiB kill line so terminal floods can no longer drop freshAgent lifecycle frames.
+**Architecture:** Client-side: a module-singleton per-snapshot-key scheduler (single-flight, trailing coalesce, debounce, Retry-After-honoring 429 backoff) that every refresh trigger routes through, plus HTTP-snapshot-driven busy clearing for opencode. Server-side: the opencode adapter's `reconcileStatus` becomes event-emitting and arms exactly one monitored idle-recovery per durable session; serve-manager subscriptions survive sidecar replacement and carry a generation identity; lost-session errors keep their code across the WS boundary so the client can re-attach and resend once (runtime-manager's existing internal recovery already covers cwd-bearing locators); interrupted turns are detected from transcript evidence (never a guessed status field) and recovered with one persisted, loop-proof Freshell-owned continuation; idle is only emitted after the final assistant message is proven queryable. Observability rows go to a dedicated always-on pino logger (the main logger drops `info` in production). The terminal-stream broker gains a foreground buffered-amount pause below the WS handler's 2 MiB kill line so terminal floods can no longer drop freshAgent lifecycle frames.
 
 **Tech Stack:** TypeScript (NodeNext/ESM server — relative imports need `.js`), React 18 + Redux Toolkit client, Express + `express-rate-limit@7.5.1`, pino, ws, Vitest + Testing Library + supertest.
 
@@ -29,6 +29,7 @@
 - `test/integration/real/` provider contract tests are opt-in and skipped by default — do not require them.
 - Line numbers cited below were verified on `d99592b4`. If a cited anchor has drifted, locate the construct by the quoted code, not the number.
 - The kata's copied post-restart aggregate counts are approximate — rely on mechanism findings, not exact totals.
+- **Deployment note (validated):** the live self-hosted deployment currently runs the Rust server (`target/release/freshell-server`, which serves the same `dist/client` SPA). The server-side tasks in this plan land in the Node server — the canonical implementation — and take effect there and in Node deployments; only the client-side Tasks 1-4 (shipped via `dist/client`) alter the live Rust deployment's behavior until the deliberate Rust-parity follow-up. This is accepted scope (kata `zrrj` is canonical; no split) — implementers should not be surprised that server-side behavior changes are not observable on the live Rust deployment.
 
 ## File Structure (new + touched)
 
@@ -56,7 +57,8 @@
 - `server/fresh-agent/adapters/opencode/adapter.ts` — reconcile emits; monitored idle recovery; `'lost'` handling; interrupted-turn recovery; idle freshness
 - `server/fresh-agent/adapters/opencode/normalize.ts` — evidence fields into `extensions.opencode`
 - `server/fresh-agent/runtime-manager.ts` — recovery-store wiring, observability
-- `server/ws-handler.ts` — lost-session error code, send/interrupt/attach/materialization log rows
+- `shared/ws-protocol.ts` — `ErrorCode` enum gains `FRESH_AGENT_LOST_SESSION` (shared client+server contract)
+- `server/ws-handler.ts` — lost-session error code, generation-aware subscription rebind, send/interrupt/attach/materialization log rows
 - `server/terminal-stream/broker.ts` + `server/terminal-stream/constants.ts` — foreground backpressure pause
 
 ---
@@ -217,6 +219,8 @@ export function resetSnapshotSchedulerForTests(): void
 - Single-flight: at most one in-flight `run()` per key. Calls arriving mid-flight coalesce into **one** trailing run scheduled after the in-flight completes (+debounce); they all share the trailing run's promise. A caller absorbed by an already-pending debounce timer resolves with the shared run's outcome (not `'coalesced'`); `'coalesced'` is returned only when a trailing run is already fully subscribed and this call adds nothing new (keep it simple: everyone sharing a pending run gets that run's outcome; `'coalesced'` is unused in practice but kept in the type for the trailing-overflow case where a trailing run is already queued).
 - 429 backoff: when `run()` rejects with `ApiError` status 429, set `backoffUntil = now + (retryAfterMs ?? nextExponential)` where `nextExponential` doubles from `1000` ms capped at `30_000` ms per consecutive 429 on that key; resolve all sharers with `{ status: 'rate-limited', retryAtMs }`. While backoff is active, `schedule()` resolves immediately `{ status: 'backoff', retryAtMs }` with **no network call**. A successful run resets the exponential counter and clears backoff.
 - Other rejections resolve `{ status: 'error', error }` (never throw out of `schedule`).
+- **Run-closure contract (validated, A2):** the scheduler may execute a `run` closure long after the caller's React effect cleaned up (debounce/trailing), and one caller's closure runs on behalf of ALL sharers of the key. Callers therefore must NOT bind caller-scoped AbortControllers/signals into `run` — an owner abort mid-flight (or a debounced run firing an already-aborted signal) would resolve `{ status: 'error', AbortError }` to every sharer, which the component layer swallows, silently dropping the refresh for panes that are still alive. Task 3 passes no signal; staleness is handled by result-application guards, not cancellation.
+- **Key note:** the `cwd` component of the key must be the caller's RESOLVED route cwd (Task 3 resolves it once and uses the same value for both the key and the request), so sibling panes on one session converge to one key.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -531,15 +535,17 @@ const requestSnapshotRefresh = useCallback((trigger: SnapshotTrigger) => {
 
 All eight trigger sites call `requestSnapshotRefresh(<trigger>)` with: identity → (effect deps, unchanged), WS invalidating event → `'event'`, send.accepted → `'send-accepted'` (keep the existing `ownsRequest` + `locatorMatchesPane` gates at `:1516-1543` — they are required by the kata's "filter send.accepted refreshes to the owning pane/session"), materialized → `'materialized'`, pane refresh request → `'manual'`, 3s poll → `'poll'`, reconnect → `'reconnect'`, reveal-after-hidden → `'reveal'`. Delete `snapshotRefreshTimerRef` / `snapshotRefreshFollowUpRef` / `SNAPSHOT_REFRESH_COALESCE_MS` and their cleanup (`:830-836`) — debounce now lives in the scheduler.
 
-2. In the fetch effect (`:1593`), wrap the network call:
+2. In the fetch effect (`:1593`), wrap the network call. Two validated corrections are baked in here:
+   - **Resolved cwd, resolved ONCE (A1):** sibling panes on one session can hold divergent `initialCwd` ('' vs '/w' — writers: `PaneContainer.tsx:697` omits when unset; `BackgroundSessions.tsx:92` uses server cwd; `session-flavor-reopen.ts:31` falls back to the tab). Keying on raw `initialCwd` would split those siblings onto different scheduler keys and the N-pane fan-out would survive. So resolve the cwd once — `freshOpenCodeRouteCwdRef.current ?? paneContentRef.current.initialCwd` (the component's existing route resolution, `FreshAgentView.tsx:613-615`, already falls through `initialCwd` → session cwd) — and use that SAME value for both the snapshot request and `makeSnapshotKey`. Residual: panes whose *resolved* cwds genuinely differ make genuinely different requests and keep separate keys — acceptable.
+   - **No abort signal in the scheduler path (A2):** do NOT pass the effect's AbortController into `run` (see Task 2's run-closure contract). Scheduler-path fetches run without a signal and are allowed to complete; a pane that re-keyed/unmounted ignores the result via the existing `isStaleSnapshotRequest()` / applied-state guards. (Keep the effect's controller ONLY if a non-scheduler fetch remains; nothing in this path uses it.)
 
 ```ts
-const requestCwd = paneContentRef.current.initialCwd
+const requestCwd = freshOpenCodeRouteCwdRef.current ?? paneContentRef.current.initialCwd   // resolved ONCE; same value for key + request
 const key = makeSnapshotKey({ sessionType: requestSessionType, provider, threadId: sessionId, cwd: requestCwd })
 const trigger = snapshotRefreshTriggerRef.current
 void getSnapshotScheduler().schedule(key, trigger, () =>
   getFreshAgentThreadSnapshot(requestSessionType, provider, sessionId, {
-    signal: controller.signal,
+    // NO signal: the run may execute for other panes / after this effect's cleanup (A2)
     ...(requestCwd ? { cwd: requestCwd } : {}),
   }),
 ).then((outcome) => {
@@ -564,9 +570,9 @@ void getSnapshotScheduler().schedule(key, trigger, () =>
 })
 ```
 
-Extract the existing `.then` body into `applySnapshot(next)` and the `.catch` body into `handleSnapshotError(error)` (same closure variables — extraction, not rewrite). Add `rateLimitRetryTimerRef = useRef<number | null>(null)` with clear-on-unmount, and dedupe: if a retry timer is already armed, don't arm a second.
+Extract the existing `.then` body into `applySnapshot(next)` and the `.catch` body into `handleSnapshotError(error)` (same closure variables — extraction, not rewrite). Add `rateLimitRetryTimerRef = useRef<number | null>(null)` with clear-on-unmount, and dedupe: if a retry timer is already armed, don't arm a second. Delete the effect-scoped AbortController wiring from this path (`:1601` creation / `:1760` cleanup-abort) — the stale-guard (`isStaleSnapshotRequest()`, request-identity capture) is the staleness mechanism; the `AbortError` swallow in `handleSnapshotError` (`:1710`) stays as harmless dead armor.
 
-3. Key derivation hazard (report §3): the key MUST be built from the exact request tuple (`initialCwd`), not `freshOpenCodeRouteCwd`.
+3. Key derivation (corrected by validation, A1): the key and the request MUST use the SAME once-resolved cwd (`freshOpenCodeRouteCwdRef.current ?? initialCwd` — see item 2). Do NOT key on raw `initialCwd` (sibling panes diverge) and do NOT resolve differently for key vs request (a key/request mismatch would coalesce panes onto a run that fetches the wrong tuple).
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -626,6 +632,15 @@ describe('snapshot scheduler integration (zrrj)', () => {
     await new Promise((r) => setTimeout(r, 400))
     expect(apiMock.getFreshAgentThreadSnapshot).not.toHaveBeenCalled()
   })
+
+  it('scheduler-path fetches carry no abort signal (shared runs must survive one pane unmounting)', async () => {
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(makeSnapshot({ threadId: 'ses_1' }))
+    render(<StoreBackedFreshAgentView ... />)
+    await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1))
+    // 4th positional arg is the options bag ({ revision?, cwd?, trigger?, signal? })
+    const options = apiMock.getFreshAgentThreadSnapshot.mock.calls[0][3]
+    expect(options?.signal).toBeUndefined()   // A2: no effect-scoped AbortController in run()
+  })
 })
 ```
 
@@ -659,24 +674,31 @@ git commit -m "feat(client): route all snapshot refresh triggers through the per
 
 ### Task 4: A successful idle HTTP snapshot clears stale opencode busy state
 
-Today the HTTP snapshot result writes `setSessionStatus` only for `provider === 'codex' && sessionType === 'freshcodex'` (`FreshAgentView.tsx:1670-1687`). For opencode, busy is only cleared by a WS event — if that event was dropped (restart, backpressure), the pane stays busy and the 3s poll runs forever. Extend the same guarded write to freshopencode.
+Today the HTTP snapshot result writes `setSessionStatus` only for `provider === 'codex' && sessionType === 'freshcodex'` (`FreshAgentView.tsx:1670-1687`). For opencode, busy is only cleared by a WS event — if that event was dropped (restart, backpressure), the pane stays busy and the 3s poll runs forever. Extend the guarded write to freshopencode — **but gated on live-reconciled status**.
+
+**Why the codex guards alone are NOT sufficient (validated, A3/V5):** in the restore window no existing guard blocks a busy→idle mis-clear: `isStatusRegression` only blocks →`creating`/`starting` (`FreshAgentView.tsx:213-215`, so running→idle passes by design), `statusVersion` doesn't bump in that window (no WS status events arrive before reconcile emits), and the local-echo guard is `false` in the incident shape (echo already reconciled pre-restart). Meanwhile the server reports `'idle'` for a *genuinely busy* session in TWO windows: untracked (`adapter.ts:590` `liveState?.status ?? 'idle'`) and mid-reconcile (`remember()` at `:494` registers the state as idle before the async status read at `:158`/`:189` lands, and status-read errors swallow to idle, `:193-199`). An unguarded Task 4 would *create* stuck-idle-while-running states. **Design change:** an opencode snapshot's status is adoptable for busy-CLEARING only when the server marks it live-reconciled — Task 11's `extensions.opencode.statusFromLiveState: boolean` (true only when the adapter has live state whose initial reconcile completed). The codex guards stay as additional belts.
+
+**Ordering note:** this task lands the client gate; the server starts emitting `statusFromLiveState` in Task 11. Until then the flag is absent → the opencode busy-clear never fires (exactly today's behavior — safe). Tests supply the flag in fixtures.
 
 **Files:**
 - Modify: `src/components/fresh-agent/FreshAgentView.tsx:1670-1687` (inside `applySnapshot` after Task 3's extraction)
 - Test: `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
 
 **Interfaces:**
-- Consumes: `setSessionStatus` action from `src/store/freshAgentSlice.ts`; snapshot `status` field (`'running' | 'idle'` from `normalizeOpencodeSnapshot`).
+- Consumes: `setSessionStatus` action from `src/store/freshAgentSlice.ts`; snapshot `status` field (`'running' | 'idle'` from `normalizeOpencodeSnapshot`); `snapshot.extensions?.opencode?.statusFromLiveState` (produced by Task 11 — read defensively as an optional unknown-shaped extension until then).
 - Produces: no new API — behavior change only.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing tests**
 
 ```ts
-it('clears stale opencode busy state from a successful idle HTTP snapshot', async () => {
+it('clears stale opencode busy state from a live-reconciled idle HTTP snapshot', async () => {
   // Arrange: store preloaded with freshAgent session status 'running' for
   // key {sessionId: 'ses_1', sessionType: 'freshopencode', provider: 'opencode'}
   // (use the store scaffold's preloadedState like the codex analogue test does).
-  apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(makeSnapshot({ threadId: 'ses_1', status: 'idle' }))
+  apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(makeSnapshot({
+    threadId: 'ses_1', status: 'idle',
+    extensions: { opencode: { statusFromLiveState: true } },
+  }))
   const { store } = renderWithStore(...)   // the file's store-returning arrange helper
   await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalled())
   await waitFor(() => {
@@ -684,23 +706,41 @@ it('clears stale opencode busy state from a successful idle HTTP snapshot', asyn
     expect(store.getState().freshAgent.sessions[key]?.status).toBe('idle')
   })
 })
+
+it('does NOT clear opencode busy state from an idle snapshot that is not live-reconciled', async () => {
+  // Same arrange, but the snapshot lacks statusFromLiveState (restore-window default idle:
+  // untracked adapter.ts:590 / mid-reconcile :494 vs :158-189). Busy must survive.
+  apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(makeSnapshot({ threadId: 'ses_1', status: 'idle' }))
+  const { store } = renderWithStore(...)
+  await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalled())
+  await new Promise((r) => setTimeout(r, 50))
+  const key = makeFreshAgentSessionKey({ sessionId: 'ses_1', sessionType: 'freshopencode', provider: 'opencode' })
+  expect(store.getState().freshAgent.sessions[key]?.status).toBe('running')
+})
 ```
 
-Find the existing codex analogue (search the test file for `setSessionStatus` or `freshcodex.*idle`) and mirror its arrange/assert precisely for opencode.
+Find the existing codex analogue (search the test file for `setSessionStatus` or `freshcodex.*idle`) and mirror its arrange/assert precisely for opencode. If `makeSnapshot` doesn't take `extensions`, extend the builder (the contract's `extensions` field already exists on snapshots).
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentView.test.tsx -t "clears stale opencode busy"`
-Expected: FAIL — status stays `'running'`.
+Run: `npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentView.test.tsx -t "opencode busy"`
+Expected: first test FAILS — status stays `'running'` (second may pass vacuously today; keep it as the regression pin).
 
 - [ ] **Step 3: Implement**
 
 At `:1670-1687`, generalize the provider gate:
 
 ```ts
+// `next` is the snapshot object applySnapshot received (Task 3's extraction)
+const opencodeStatusFromLiveState =
+  (next as { extensions?: { opencode?: { statusFromLiveState?: unknown } } })
+    .extensions?.opencode?.statusFromLiveState === true
 const canAdoptSnapshotStatus =
   (provider === 'codex' && requestSessionType === 'freshcodex')
-  || (provider === 'opencode' && requestSessionType === 'freshopencode')
+  || (provider === 'opencode' && requestSessionType === 'freshopencode'
+      // busy (running) may always be adopted; idle (busy-CLEARING) only when live-reconciled —
+      // otherwise the restore-window idle default would clear a genuinely running turn (A3).
+      && (snapshotIsBusy || opencodeStatusFromLiveState))
 if (
   sessionStatus
   && nextSessionId
@@ -720,7 +760,7 @@ if (
 }
 ```
 
-All existing guards (`wouldRegressStatus`, `statusChangedSinceRequest` via `agentSessionStatusVersionRef`, `hasBlockingLocalEchoForSession`) stay — they are the race protection that made the codex version safe.
+The existing guards (`wouldRegressStatus`, `statusChangedSinceRequest` via `agentSessionStatusVersionRef`, `hasBlockingLocalEchoForSession`) stay as belts — they protect against *client-side races around a request*, but none of them encodes "the server's answer itself is a placeholder default", which is why the `statusFromLiveState` gate is the load-bearing protection for opencode.
 
 - [ ] **Step 4: Run to verify pass**
 
@@ -863,7 +903,7 @@ Two production defects in the observability layer: (1) the sink is the main `log
 **Interfaces:**
 - Consumes: `createSessionLifecycleLogger`-style factory in `server/logger.ts:210-216`; `sessionLifecycleLogger` precedent (`:314-317`).
 - Produces:
-  - `server/logger.ts`: `export const freshAgentObservabilityLogger` — pino instance pinned at `level: 'info'` writing `~/.freshell/logs/fresh-agent.<mode>.<instance>.jsonl` (10 MB × 10, same rotation options as sessionLifecycle; returns a silent logger under test runtime exactly like the existing factory does).
+  - `server/logger.ts`: `export const freshAgentObservabilityLogger` — pino instance pinned at `level: 'info'` writing `~/.freshell/logs/fresh-agent.<mode>.<instance>.jsonl`. Rotation needs NO new dependency (verified, B2): `rotating-file-stream@^3.2.8` is already installed and `createDebugFileStream(filePath, { size, maxFiles })` (`server/logger.ts:202-208`) + `createSessionLifecycleLogger` (`:210-216`) already implement exactly the 10 MB × 10 shape — mirror them. **Test-runtime silence (one extra line):** the existing test-runtime fallback is a *main-logger child* (`logger.child({ component: 'session-lifecycle-disabled' })`, `:315-317`), which still logs at the main level — the fresh-agent fallback must pass `level: 'silent'` (or equivalent) so test runs are truly silent.
   - `server/fresh-agent/observability.ts`: default sink becomes `freshAgentObservabilityLogger`; union extended with these kinds (all payloads identity-hashed, **no message content**):
 
 ```ts
@@ -874,7 +914,7 @@ Two production defects in the observability layer: (1) the sink is the main `log
 | { kind: 'fresh_agent_monitor'; provider: 'opencode'; sessionIdHash: string; cwdHash?: string; phase: 'armed' | 'resolved_idle' | 'timeout' | 'sidecar_lost' | 'duplicate_suppressed'; sidecarGeneration?: number }
 | { kind: 'fresh_agent_sidecar'; provider: 'opencode'; phase: 'started' | 'exited' | 'discarded'; generation: number; pid?: number; baseUrl?: string; reason?: string; code?: number | null; signal?: string | null }
 | { kind: 'fresh_agent_snapshot_failed'; sessionType: string; provider: string; threadIdHash?: string; httpStatus: number; code?: string; durationMs?: number; trigger?: string; cwdHash?: string }
-| { kind: 'fresh_agent_turn_recovery'; provider: 'opencode'; sessionIdHash: string; cwdHash?: string; action: 'continuation_injected' | 'suppressed_user_stop' | 'suppressed_user_followup' | 'suppressed_already_recovered' | 'suppressed_low_confidence'; reason: string; messageIdHash?: string }
+| { kind: 'fresh_agent_turn_recovery'; provider: 'opencode'; sessionIdHash: string; cwdHash?: string; action: 'continuation_injected' | 'suppressed_user_stop' | 'suppressed_user_followup' | 'suppressed_already_recovered' | 'suppressed_low_confidence' | 'suppressed_no_route'; reason: string; messageIdHash?: string }
 ```
 
   - `fresh_agent_snapshot_served` gains optional `trigger?: string`; `fresh_agent_snapshot_rate_limited` gains optional `retryAfterSeconds?: number; trigger?: string` and its route pattern covers all three thread routes.
@@ -1009,13 +1049,16 @@ git commit -m "feat(server): always-on fresh-agent observability logger, expande
 
 ---
 
-### Task 7: Serve-manager: sidecar generation identity + subscriptions survive sidecar replacement
+### Task 7: Serve-manager: sidecar generation identity + subscriptions survive sidecar replacement + generation-aware pane rebind
 
-Two defects in `server/fresh-agent/adapters/opencode/serve-manager.ts`: (1) `emitLostForAllSessions()` clears `sessionEmitters` (`serve-manager.ts:126-132`, clear at `:128`), so every adapter listener is orphaned on the dead emitter object while a replacement sidecar dispatches to brand-new emitters — live events are lost forever after any sidecar replacement; (2) there is no generation/PID identity (`RunningServe` at `:61-66` holds only `baseUrl`/`ownershipId`/`child`/`stopEventStream`), so nothing can attribute a monitored wait or a log row to a specific sidecar. The kata offers a choice ("survive replacement, OR invalidate and rebind"); choose **survive**: keep the emitter objects in the map across replacement, emit `'lost'` on them, and let the replacement sidecar dispatch into the same objects. Prove it with tests.
+Three defects: (1) `emitLostForAllSessions()` clears `sessionEmitters` (`serve-manager.ts:126-132`, clear at `:128`), so every adapter listener is orphaned on the dead emitter object while a replacement sidecar dispatches to brand-new emitters — live events are lost forever after any sidecar replacement; (2) there is no generation/PID identity (`RunningServe` at `:61-66` holds only `baseUrl`/`ownershipId`/`child`/`stopEventStream`), so nothing can attribute a monitored wait or a log row to a specific sidecar. The kata offers a choice ("survive replacement, OR invalidate and rebind"); choose **survive**: keep the emitter objects in the map across replacement, emit `'lost'` on them, and let the replacement sidecar dispatch into the same objects. Prove it with tests. (3) **Surfaced by validation (A8/N-V4b), one layer up:** pane subscriptions bind to a specific *adapter state's* EventEmitter (`manager.subscribe` → `adapter.subscribe` → `state.events.on`, `adapter.ts:500-505`), and `ensureFreshAgentSubscription` short-circuits when an entry already exists WITHOUT rebinding (`ws-handler.ts:1504-1511`, sets `active = true`, never re-invokes `manager.subscribe`). So after ANY adapter-state recreation (e.g. `adapter.attach` building a new state with a new emitter, `adapter.ts:484-497`), the pane's listener is orphaned on the old emitter and no code path ever restores event delivery. Fix with a **generation-aware rebind**: give adapter states a generation identity and make the attach-case subscription path rebind when it sees a new generation.
 
 **Files:**
 - Modify: `server/fresh-agent/adapters/opencode/serve-manager.ts`
-- Test: `test/unit/server/fresh-agent/opencode-serve-manager.test.ts` (harness `makeManager`/`fakeChild`/`jsonResponse` at `:8-45`)
+- Modify: `server/fresh-agent/adapters/opencode/adapter.ts` (state generation counter + `sessionStateGeneration()`)
+- Modify: `server/fresh-agent/runtime-manager.ts` (optional `sessionStateGeneration(locator)` passthrough)
+- Modify: `server/ws-handler.ts` (`ensureFreshAgentSubscription` `:1504-1511`)
+- Test: `test/unit/server/fresh-agent/opencode-serve-manager.test.ts` (harness `makeManager`/`fakeChild`/`jsonResponse` at `:8-45`), `test/unit/server/ws-handler-fresh-agent.test.ts` (rebind test)
 
 **Interfaces:**
 - Consumes: existing `OpencodeServeManager` internals: `start()` `:196-261`, `discardRunning()` `:134-143`, child `'close'` handler `:220-230`, `emitterFor()` `:419-427`, `subscribe()` `:434-438`, `onceIdle()` `:440-520`.
@@ -1024,6 +1067,8 @@ Two defects in `server/fresh-agent/adapters/opencode/serve-manager.ts`: (1) `emi
   - `currentGeneration(): number` — monotonically increasing, bumped on every successful `start()`; `0` before first start.
   - `'lost'` events now carry the generation: `emitter.emit('lost', new OpencodeServeLostError(sessionId), { generation })` — existing consumers that only read the first arg keep working.
   - `recordFreshAgentObservabilityEvent({ kind: 'fresh_agent_sidecar', ... })` emitted on `started` (after health gate), `exited` (child close), `discarded` (discardRunning) with `generation`, `pid`, `baseUrl`, `reason`/`code`/`signal`.
+  - Adapter: each newly constructed `OpencodeSessionState` records `state.stateGeneration = ++stateGenerationCounter` (module-scope monotonic counter — a plain counter is fine at module scope; it holds no per-instance state); new adapter method `sessionStateGeneration(sessionId: string): number | undefined` (map lookup, works for placeholder and real ids like `requireState`). Runtime-manager exposes an optional passthrough `sessionStateGeneration?(locator)`.
+  - WS layer: `FreshAgentSubscriptionEntry` gains `stateGeneration?: number`, recorded at subscribe time; the existing-entry branch of `ensureFreshAgentSubscription` compares the current generation and, when it differs, cancels the old subscription and re-invokes `manager.subscribe` (rebind to the new state's emitter) instead of returning early. When the manager doesn't expose generations (other providers), behavior is unchanged.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -1069,10 +1114,45 @@ describe('sidecar replacement resilience (zrrj)', () => {
 
 Adjust the private-access spelling (`(manager as any).running` / `dispatchEvent`) to whatever the existing suite already uses to reach internals — this file already drives the real class with injected doubles; reuse its idioms (e.g. if existing tests trigger death via the injected `fetchFn` timeout instead, do the same).
 
+And add the **generation-aware rebind** test to `test/unit/server/ws-handler-fresh-agent.test.ts` (vi.fn() runtime-manager stub harness):
+
+```ts
+it('rebinds the freshAgent subscription when the adapter state generation changes (zrrj)', async () => {
+  // Stub: subscribe() records its listener; sessionStateGeneration() returns a settable number.
+  let stateGeneration = 1
+  const listeners: Array<(ev: unknown) => void> = []
+  const subscribe = vi.fn((_locator: unknown, listener: (ev: unknown) => void) => {
+    listeners.push(listener)
+    return () => {}
+  })
+  const sessionStateGeneration = vi.fn(() => stateGeneration)
+  const { server } = await createServer({
+    freshAgentRuntimeManager: makeManagerStub({ subscribe, sessionStateGeneration, attach: vi.fn().mockResolvedValue({ sessionId: 'ses_9' }) }),
+  })
+  const ws = await connectAndAuth(server)
+  // First attach subscribes and delivers events
+  ws.send(JSON.stringify({ type: 'freshAgent.attach', sessionId: 'ses_9', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+  await waitForMessage(ws, (m) => m.type === 'freshAgent.attached' || m.type === 'freshAgent.session.state')
+  expect(subscribe).toHaveBeenCalledTimes(1)
+
+  // Simulate adapter-state recreation: new generation, new emitter (a NEW listener registration is required)
+  stateGeneration = 2
+  ws.send(JSON.stringify({ type: 'freshAgent.attach', sessionId: 'ses_9', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+  await waitForMessage(ws, (m) => m.type === 'freshAgent.attached' || m.type === 'freshAgent.session.state')
+  expect(subscribe).toHaveBeenCalledTimes(2)   // FAILS today: ensureFreshAgentSubscription short-circuits (:1504-1511)
+
+  // Events dispatched through the NEW listener reach the pane
+  listeners.at(-1)!({ type: 'sdk.session.snapshot', sessionId: 'ses_9', status: 'running' })
+  await waitForMessage(ws, (m) => m.type === 'freshAgent.event')
+})
+```
+
+Match the stub's `subscribe` signature and the attach-response frame names to the file's existing attach tests (copy the nearest passing attach arrangement — the harness already stubs `subscribe`).
+
 - [ ] **Step 2: Run to verify the replacement test fails**
 
-Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-manager.test.ts`
-Expected: "keeps session subscriptions alive across sidecar replacement" FAILS (0 events seen); generation tests FAIL (methods missing).
+Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-manager.test.ts test/unit/server/ws-handler-fresh-agent.test.ts`
+Expected: "keeps session subscriptions alive across sidecar replacement" FAILS (0 events seen); generation tests FAIL (methods missing); the rebind test FAILS (subscribe called once — the existing-entry short-circuit).
 
 - [ ] **Step 3: Implement**
 
@@ -1122,16 +1202,21 @@ Memory note: emitters are already created lazily per session id and were only ev
 
 5. `onceIdle`'s `'lost'` handler (`:516-518`) keeps working unchanged (extra emit arg ignored).
 
+6. **Generation-aware subscription rebind** (defect 3):
+   - `adapter.ts`: module-scope `let stateGenerationCounter = 0`; wherever a new `OpencodeSessionState` object is constructed (create/resume/attach new-state branches), set `state.stateGeneration = ++stateGenerationCounter`. Add `sessionStateGeneration(sessionId: string): number | undefined` to the adapter surface (same map lookup as `requireState`, but returning `undefined` instead of throwing).
+   - `runtime-manager.ts`: optional passthrough `sessionStateGeneration?(locator)` that resolves the adapter and delegates when the adapter implements it.
+   - `ws-handler.ts` `ensureFreshAgentSubscription` (`:1504-1511`): record `entry.stateGeneration` whenever `manager.subscribe` is invoked. In the existing-entry branch, read `manager.sessionStateGeneration?.(locator)`; if it is a number and differs from `entry.stateGeneration`, cancel the entry's existing subscription and fall through to the subscribe block (rebinding the listener to the new state's emitter, updating `entry.stateGeneration`) instead of returning early. If the manager/provider doesn't expose generations, keep the current short-circuit unchanged.
+
 - [ ] **Step 4: Run to verify pass**
 
-Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-manager.test.ts`
-Expected: PASS, including all pre-existing lifecycle tests.
+Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-manager.test.ts test/unit/server/ws-handler-fresh-agent.test.ts`
+Expected: PASS, including all pre-existing lifecycle and attach tests.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add server/fresh-agent/adapters/opencode/serve-manager.ts test/unit/server/fresh-agent/opencode-serve-manager.test.ts
-git commit -m "fix(server): opencode serve subscriptions survive sidecar replacement; add generation/pid identity (zrrj)"
+git add server/fresh-agent/adapters/opencode/serve-manager.ts server/fresh-agent/adapters/opencode/adapter.ts server/fresh-agent/runtime-manager.ts server/ws-handler.ts test/unit/server/fresh-agent/opencode-serve-manager.test.ts test/unit/server/ws-handler-fresh-agent.test.ts
+git commit -m "fix(server): opencode serve subscriptions survive sidecar replacement; generation/pid identity; generation-aware pane subscription rebind (zrrj)"
 ```
 
 ---
@@ -1142,17 +1227,20 @@ Gaps G1/G2/G5 (`server/fresh-agent/adapters/opencode/adapter.ts`): `reconcileSta
 
 **Files:**
 - Modify: `server/fresh-agent/adapters/opencode/adapter.ts`
-- Test: `test/unit/server/fresh-agent/opencode-serve-adapter.test.ts` (harness `makeFakeManager`/`makeAdapter`/`createDeferred` at `:32-87`)
+- Modify: `server/fresh-agent/adapters/opencode/serve-manager.ts` (`onceIdle` gains an `assumeActive` option; `subscribe` gains `onLost`)
+- Test: `test/unit/server/fresh-agent/opencode-serve-adapter.test.ts` (harness `makeFakeManager`/`makeAdapter`/`createDeferred` at `:32-87`), `test/unit/server/fresh-agent/opencode-serve-manager.test.ts` (`assumeActive` behavior)
 
 **Interfaces:**
-- Consumes: `serveManager.onceIdle(realId, timeoutMs, route?)`, `serveManager.getSessionStatus`, `serveManager.subscribe`, `serveManager.currentGeneration()` (Task 7); `emitStatus(state, status)` `:301-312`; `nextMonotonicTurnCompleteAt` (`turn-complete-clock.ts`); `recordFreshAgentObservabilityEvent` (Task 6).
+- Consumes: `serveManager.onceIdle(realId, timeoutMs, route?, options?)`, `serveManager.getSessionStatus`, `serveManager.subscribe`, `serveManager.currentGeneration()` (Task 7); `emitStatus(state, status)` `:301-312`; `nextMonotonicTurnCompleteAt` (`turn-complete-clock.ts`); `recordFreshAgentObservabilityEvent` (Task 6).
 - Produces:
   - `reconcileStatus` calls `emitStatus(state, 'running' | 'idle')` instead of mutating silently (so `sdk.session.snapshot` reaches the client on restore).
-  - Module-scope `const idleRecoveryMonitors = new Map<string, Promise<void>>()` keyed by real `ses_` id — the "exactly one monitored idle-recovery per durable session key" registry.
-  - `armIdleRecovery(state: OpencodeSessionState): void` — no-op if a monitor for `state.realSessionId` exists (`fresh_agent_monitor` `duplicate_suppressed`); otherwise arms `onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS, route)`:
+  - `onceIdle(sessionId, timeoutMs, route?, options?: { assumeActive?: boolean })` — **arm-time activity seed (validated fix, A4):** cold-arming today's `onceIdle` on an already-idle/completed session hangs to the 10-minute timeout and then emits a false "OpenCode turn interrupted", because the poll gate requires `observedActivity` before it may resolve on idle/absence (`serve-manager.ts:477-483`; behavior pinned by the existing test `opencode-serve-manager.test.ts:665-677`). `assumeActive: true` starts the waiter with `observedActivity = true` (equivalently: treats the caller's own busy observation as the first activity mark), so a turn that completed in the read→arm gap resolves in ~2 idle polls (~1 s) instead of a spurious 10-min timeout. Seeding is valid here because `armIdleRecovery` always runs immediately after reconcile *observed busy*. The send path keeps the default (`assumeActive` unset) — its activity gate exists to avoid resolving before the prompt registers.
+  - A **factory-closure** `const idleRecoveryMonitors = new Map<string, { promise: Promise<void>; cancelled: boolean }>()` keyed by real `ses_` id — the "exactly one monitored idle-recovery per durable session key" registry. **Scope note (validated, A5):** the registry lives INSIDE the adapter factory closure (per adapter instance), NOT at module scope — `armIdleRecovery` references closure members (`serveManager`, `emitStatus`, `cwdRoute`, all factory-scoped per `adapter.ts:105`), and a module-scope map would leak/mis-suppress monitors across adapter instances (e.g. Task 14's two-adapter "simulated restart" test). Because the registry is per-instance, **no `resetOpencodeIdleRecoveryForTests` export is needed** — tests get isolation by constructing a fresh adapter via `makeAdapter`.
+  - `armIdleRecovery(state: OpencodeSessionState): void` — no-op if a monitor for `state.realSessionId` exists (`fresh_agent_monitor` `duplicate_suppressed`); otherwise arms `onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS, route, { assumeActive: true })`:
     - resolve → `emitStatus(state, 'idle')`; emit `sdk.turn.complete` **only** when `!state.turnAborted && !state.turnErrored` (restored sessions: both `undefined` → falsy → chime allowed; the pre-restart error is unobservable and OpenCode reporting busy→idle is the best signal we have — matches the prior wave's constraint "do not claim recovery unless OpenCode reports busy/retry", which gated *arming*, not the chime); monitor row `resolved_idle`.
     - reject (timeout / `OpencodeServeLostError`) → `emitStatus(state, 'idle')` + `state.events.emit('event', { type: 'sdk.error', sessionId: state.placeholderId, message: 'OpenCode turn interrupted: <timeout|sidecar lost>' })`; monitor row `timeout`/`sidecar_lost`. Never leaves the pane busy.
-    - always: delete the registry entry on settle.
+    - always: delete the registry entry on settle; a settled handler checks the entry's `cancelled` flag first and becomes a no-op when disarmed (see next bullet).
+  - **Disarm on new send (surfaced by validation, N-V5a):** a cold-armed monitor that is still pending when the user starts a NEW turn would resolve on that later turn's idle and emit its own idle + `sdk.turn.complete` chime concurrently with the send path's own `onceIdle` — a double idle/chime for one turn. The registry dedups monitors against each other, not against send-path waiters. Fix: `materializeOrSend`'s send path calls `disarmIdleRecovery(realId)` (sets `cancelled = true` and deletes the entry) before arming its own `onceIdle`; the monitor's resolve/reject handlers no-op when cancelled. Test consideration below.
   - `bindServeStream` additionally registers a `'lost'` listener (via a new `subscribeLost` manager passthrough or by subscribing on the same emitter — implement as a second `serveManager.subscribe`-style hook; simplest: extend `subscribe(id, listener, onLost?)` in serve-manager with an optional third arg attached to `'lost'`): on lost, if `state.status === 'running'`, `emitStatus(state, 'idle')` + the same `sdk.error` interruption signal. (With Task 7, the same subscription keeps receiving events from the replacement sidecar — no rebind needed.)
 
 - [ ] **Step 1: Write the failing tests**
@@ -1219,12 +1307,24 @@ describe('restore reconciliation emits and monitors (zrrj)', () => {
 
 Match the adapter's real subscription surface (the existing tests subscribe via `state.events` through the adapter API — copy from the `:584`/`:795` analogues). Import `OpencodeServeLostError` from the serve-manager module as the existing manager test does (`:6`).
 
-**Test-isolation requirement:** `idleRecoveryMonitors` is module-scope — export `resetOpencodeIdleRecoveryForTests()` from the adapter module and call it in this suite's `beforeEach`.
+**Test isolation:** the monitor registry is factory-closure-scoped (per adapter instance — see Interfaces), so each test's `makeAdapter(...)` starts with an empty registry. No module reset seam is needed.
+
+Also add the `assumeActive` seed test to `test/unit/server/fresh-agent/opencode-serve-manager.test.ts` (beside the existing activity-gate pin at `:665-677`, which must STAY green — the default behavior is unchanged):
+
+```ts
+it('onceIdle with assumeActive resolves from status-map absence without prior observed activity (zrrj)', async () => {
+  const manager = makeManager()   // status map reports the session idle/absent throughout
+  await expect(manager.onceIdle('ses_done', 5_000, undefined, { assumeActive: true })).resolves.toBeUndefined()
+  // resolves after REQUIRED_IDLE_STATUS_POLLS (~1 s of fake/short polls), NOT the timeout
+})
+```
+
+And a **disarm-on-new-send** test in the adapter suite (test consideration for the double-fire hazard): arm a cold monitor via attach-on-busy, then drive a user send whose own `onceIdle` resolves — assert exactly ONE `sdk.session.snapshot` idle emission and ONE `sdk.turn.complete` for that turn (the cancelled monitor must not add a second).
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-adapter.test.ts`
-Expected: new tests FAIL (no emission, no monitor, no interruption signal).
+Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-serve-adapter.test.ts test/unit/server/fresh-agent/opencode-serve-manager.test.ts`
+Expected: new tests FAIL (no emission, no monitor, no interruption signal; `assumeActive` option rejected/ignored so the seed test times out or rejects).
 
 - [ ] **Step 3: Implement**
 
@@ -1232,14 +1332,22 @@ In `adapter.ts`:
 
 1. `reconcileStatus` (`:155-200`): replace direct mutations with `emitStatus(state, ...)` at `:158` (initial idle assumption — emit only if it *changes* an existing non-idle status to avoid noise on fresh attach: emit when `state.status !== 'idle'`) and `:189` (running). After the running branch, call `armIdleRecovery(state)`.
 
-2. Add the monitor registry + arm function:
+2. In `serve-manager.ts`, add the `assumeActive` option to `onceIdle` (`:440-520`): `onceIdle(sessionId, timeoutMs, route?, options?: { assumeActive?: boolean })`; when `options?.assumeActive` is true, initialize `observedActivity = true` before the first poll (`:477-483` gate). Default behavior unchanged (existing activity-gate test `:665-677` stays green).
+
+3. Add the monitor registry + arm/disarm functions **inside the adapter factory closure** (beside `sessions` at `adapter.ts:105` — they use closure members and the registry is per adapter instance; no module-scope state, no test reset export):
 
 ```ts
-/** Exactly one monitored idle-recovery per durable session key (kata zrrj). */
-const idleRecoveryMonitors = new Map<string, Promise<void>>()
+/** Exactly one monitored idle-recovery per durable session key (kata zrrj). Factory-closure scope. */
+type IdleRecoveryMonitor = { promise: Promise<void>; cancelled: boolean }
+const idleRecoveryMonitors = new Map<string, IdleRecoveryMonitor>()
 
-export function resetOpencodeIdleRecoveryForTests(): void {
-  idleRecoveryMonitors.clear()
+/** Called by materializeOrSend before arming the send path's own onceIdle (double-fire guard). */
+function disarmIdleRecovery(realId: string): void {
+  const existing = idleRecoveryMonitors.get(realId)
+  if (existing) {
+    existing.cancelled = true
+    idleRecoveryMonitors.delete(realId)
+  }
 }
 
 function armIdleRecovery(state: OpencodeSessionState): void {
@@ -1265,11 +1373,16 @@ function armIdleRecovery(state: OpencodeSessionState): void {
       ...(generation !== undefined ? { sidecarGeneration: generation } : {}),
     })
   monitorEvent('armed')
+  const monitor: IdleRecoveryMonitor = { promise: Promise.resolve(), cancelled: false }
+  // assumeActive: arming always follows a reconcile that OBSERVED busy, so seed the
+  // activity gate — without it, a turn that finished in the read->arm gap hangs to the
+  // 10-min timeout and emits a false "interrupted" (serve-manager.ts:477-483; A4).
   const idle = route
-    ? serveManager.onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS, route)
-    : serveManager.onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS)
-  const monitored = idle
+    ? serveManager.onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS, route, { assumeActive: true })
+    : serveManager.onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS, undefined, { assumeActive: true })
+  monitor.promise = idle
     .then(() => {
+      if (monitor.cancelled) return   // disarmed by a newer user send — its own onceIdle owns this turn
       emitStatus(state, 'idle')
       monitorEvent('resolved_idle')
       if (!state.turnAborted && !state.turnErrored) {
@@ -1279,6 +1392,7 @@ function armIdleRecovery(state: OpencodeSessionState): void {
       }
     })
     .catch((error: unknown) => {
+      if (monitor.cancelled) return
       const lost = error instanceof OpencodeServeLostError
       emitStatus(state, 'idle')
       monitorEvent(lost ? 'sidecar_lost' : 'timeout')
@@ -1290,12 +1404,14 @@ function armIdleRecovery(state: OpencodeSessionState): void {
           : 'OpenCode turn interrupted: idle recovery timed out.',
       })
     })
-    .finally(() => { idleRecoveryMonitors.delete(realId) })
-  idleRecoveryMonitors.set(realId, monitored)
+    .finally(() => {
+      if (idleRecoveryMonitors.get(realId) === monitor) idleRecoveryMonitors.delete(realId)
+    })
+  idleRecoveryMonitors.set(realId, monitor)
 }
 ```
 
-(Import `OpencodeServeLostError` from `./serve-manager.js`; `hashForLogs`/`recordFreshAgentObservabilityEvent` from `../../observability.js` — the adapter already imports the latter at `:286-311`.)
+In `materializeOrSend`, call `disarmIdleRecovery(realId)` just before the send path arms its own `onceIdle` (`:363-368` area). (Import `OpencodeServeLostError` from `./serve-manager.js`; `hashForLogs`/`recordFreshAgentObservabilityEvent` from `../../observability.js` — the adapter already imports the latter at `:286-311`.)
 
 3. `bindServeStream` (`:273-299`): pass an `onLost` handler through to the manager. In `serve-manager.ts`, extend `subscribe`:
 
@@ -1340,52 +1456,52 @@ git commit -m "fix(server): restored opencode sessions emit status and run one m
 
 ---
 
-### Task 9: Preserve lost-session error code over WS + one-shot attach-recover-retry on send
+### Task 9: Preserve the lost-session error code across the WS boundary (shared contract + server)
 
-The mechanism behind "materialized real `ses_...` durable/readable but send says *not tracked*": reads bypass tracking (`runtime-manager.ts:331-353` + `adapter.ts:413-418`), mutations require an index hit or a cwd-bearing locator (`canRecoverFreshOpenCode` `:430-437`, throw at `:552-557`), and the WS `freshAgent.send` handler flattens `FreshAgentLostSessionError` into `{ code: 'INTERNAL_ERROR' }` (`ws-handler.ts:3554-3556`) so the client can't distinguish "re-attach and retry" from a real bug. Fix server-side: (a) propagate the code, (b) when the locator carries a cwd and the first send throws lost-session, attach-recover and retry exactly once inside the WS handler.
+The mechanism behind "materialized real `ses_...` durable/readable but send says *not tracked*": reads bypass tracking (`runtime-manager.ts:331-353` + `adapter.ts:413-418`), mutations require an index hit or a cwd-bearing locator (`canRecoverFreshOpenCode` `:430-437`, throw at `:552-557`), and the WS `freshAgent.send` handler flattens `FreshAgentLostSessionError` into `{ code: 'INTERNAL_ERROR' }` (`ws-handler.ts:3554-3556`) so the client can't distinguish "re-attach and retry" from a real bug. Fix: propagate the code faithfully so Task 10's client can react.
+
+**No server-side attach-retry (validated decision).** An in-handler one-shot attach-recover-retry was considered and DROPPED, because validation (V4) proved it never helps: both incident error strings fire only when the locator carries NO cwd (`runtime-manager.ts:555`, `:493`) — exactly the population any cwd guard excludes; lost-session errors that escape WITH a cwd are deterministic `validateSessionRoute` failures (`adapter.ts:129`/`:133`/`:137`) where a retry re-runs the identical attach and fails identically; transient sidecar failures throw generic `Error`s that never trigger a `FreshAgentLostSessionError` branch (`serve-manager.ts:309-326`); and the only genuinely attach-fixable class — kill-alias map divergence (`adapter.ts:569-570` deletes both alias keys while `runtime-manager.ts:281` deletes one) — would *resurrect user-killed sessions*. **Coverage restatement:** the kata's "route immediately or attach/recover and retry once" is satisfied by (a) runtime-manager's EXISTING internal recovery for cwd-bearing locators (`requireOrRecoverSession` → `singleflightFreshOpenCodeAttach`, `runtime-manager.ts:479-506`, `:509-550`) plus (b) Task 10's client-side attach-then-resend-once, triggered by the error code this task propagates. (Event delivery after adapter-state recreation is handled by Task 7's generation-aware subscription rebind.)
 
 **Files:**
+- Modify: `shared/ws-protocol.ts` (`ErrorCode` z.enum `:20-36`) — **shared client+server contract edit**
 - Modify: `server/ws-handler.ts` (`freshAgent.send` case `:3512-3558`)
 - Test: `test/unit/server/ws-handler-fresh-agent.test.ts` (harness: real http+ws, `vi.fn()` runtime-manager stub, `connectAndAuth` at `:49-72`)
 
 **Interfaces:**
-- Consumes: `FreshAgentLostSessionError` (exported from `server/fresh-agent/runtime-manager.ts` or its errors module — import from wherever `ws-handler.ts` can already reach it); `manager.attach(locator)`, `manager.send(locator, input)`.
-- Produces: WS error frames for lost sessions now carry `code: 'FRESH_AGENT_LOST_SESSION'` (message unchanged). Client behavior in Task 10 keys off this code. Retry rule: at most one `attach` + one re-`send`; if the retry also fails, send the error frame (with the true code) — no loops.
+- Consumes: `FreshAgentLostSessionError` (exported from `server/fresh-agent/runtime-manager.ts` or its errors module — import from wherever `ws-handler.ts` can already reach it).
+- Produces: `ErrorCode` gains `'FRESH_AGENT_LOST_SESSION'` (`sendError` types `code` as `z.infer<typeof ErrorCode>`, `ws-handler.ts:1688-1712`, so the enum edit is REQUIRED — this is a shared contract file consumed by both client and server; flag it in the commit). WS error frames for lost sessions carry `code: 'FRESH_AGENT_LOST_SESSION'` (message unchanged) plus the `requestId` (already threaded, `ws-handler.ts:3555`). Task 10's client retry keys off this code.
 
 - [ ] **Step 1: Write the failing tests**
 
 Add to `test/unit/server/ws-handler-fresh-agent.test.ts`:
 
 ```ts
-it('recovers a durable freshopencode send once via attach when the manager reports lost-session', async () => {
-  const send = vi.fn()
-    .mockRejectedValueOnce(new FreshAgentLostSessionError('Fresh-agent session freshopencode/opencode/ses_9 is not tracked'))
-    .mockResolvedValueOnce({ sessionId: 'ses_9' })
-  const attach = vi.fn().mockResolvedValue({ sessionId: 'ses_9' })
-  const { server, port } = await createServer({ freshAgentRuntimeManager: makeManagerStub({ send, attach }) })
+it('propagates FRESH_AGENT_LOST_SESSION (with requestId) when the manager reports lost-session', async () => {
+  const send = vi.fn().mockRejectedValue(new FreshAgentLostSessionError('Fresh-agent session freshopencode/opencode/ses_9 is not tracked'))
+  const { server } = await createServer({ freshAgentRuntimeManager: makeManagerStub({ send }) })
   const ws = await connectAndAuth(server)
   ws.send(JSON.stringify({
     type: 'freshAgent.send', requestId: 'r1', sessionId: 'ses_9',
-    sessionType: 'freshopencode', provider: 'opencode', cwd: '/w', text: 'hello',
+    sessionType: 'freshopencode', provider: 'opencode', text: 'hello',   // NO cwd — the incident shape
   }))
-  const accepted = await waitForMessage(ws, (m) => m.type === 'freshAgent.send.accepted')
-  expect(accepted.sessionId).toBe('ses_9')
-  expect(attach).toHaveBeenCalledTimes(1)
-  expect(send).toHaveBeenCalledTimes(2)
+  const err = await waitForMessage(ws, (m) => m.type === 'error')
+  expect(err.code).toBe('FRESH_AGENT_LOST_SESSION')
+  expect(err.requestId).toBe('r1')
+  expect(send).toHaveBeenCalledTimes(1)
 })
 
-it('propagates FRESH_AGENT_LOST_SESSION when recovery is impossible (no cwd)', async () => {
+it('does not attach-retry inside the handler even for a cwd-bearing durable locator (client owns recovery)', async () => {
   const send = vi.fn().mockRejectedValue(new FreshAgentLostSessionError('Fresh-agent session freshopencode/opencode/ses_9 is not tracked'))
   const attach = vi.fn()
   const { server } = await createServer({ freshAgentRuntimeManager: makeManagerStub({ send, attach }) })
   const ws = await connectAndAuth(server)
   ws.send(JSON.stringify({
     type: 'freshAgent.send', requestId: 'r1', sessionId: 'ses_9',
-    sessionType: 'freshopencode', provider: 'opencode', text: 'hello',   // NO cwd
+    sessionType: 'freshopencode', provider: 'opencode', cwd: '/w', text: 'hello',
   }))
   const err = await waitForMessage(ws, (m) => m.type === 'error')
   expect(err.code).toBe('FRESH_AGENT_LOST_SESSION')
-  expect(attach).not.toHaveBeenCalled()
+  expect(attach).not.toHaveBeenCalled()   // no server-side retry: cwd-bearing recovery already ran inside manager.send
   expect(send).toHaveBeenCalledTimes(1)   // no blind retry loop
 })
 ```
@@ -1395,43 +1511,25 @@ Reuse the file's existing manager-stub construction and message-frame helpers ve
 - [ ] **Step 2: Run to verify they fail**
 
 Run: `npm run test:vitest -- --run test/unit/server/ws-handler-fresh-agent.test.ts`
-Expected: FAIL — today's handler sends `code: 'INTERNAL_ERROR'` and never attaches.
+Expected: FAIL — today's handler sends `code: 'INTERNAL_ERROR'` (and TypeScript rejects the new code string until the enum edit lands).
 
 - [ ] **Step 3: Implement**
 
-In `ws-handler.ts` `freshAgent.send` catch (`:3554-3556` region), replace the flattening with:
+1. In `shared/ws-protocol.ts`, add `'FRESH_AGENT_LOST_SESSION'` to the `ErrorCode` z.enum (`:20-36`). This is a **shared client+server contract edit** — the client's WS types pick it up from the same file; no other contract change is needed.
+
+2. In `ws-handler.ts` `freshAgent.send` catch (`:3554-3556` region), replace the flattening with:
 
 ```ts
 } catch (error) {
   if (error instanceof FreshAgentLostSessionError) {
-    const canRecover = locator.sessionType === 'freshopencode'
-      && locator.sessionId.startsWith('ses_')
-      && typeof locator.cwd === 'string' && locator.cwd.length > 0
-      && typeof manager.attach === 'function'
-    if (canRecover) {
-      try {
-        await manager.attach(locator)
-        const retried = await manager.send(locator, adapterInput)   // same input as the first call
-        // fall through to the existing send.accepted emission with `retried`
-        ...
-        return
-      } catch (retryError) {
-        this.sendError(ws, {
-          code: retryError instanceof FreshAgentLostSessionError ? 'FRESH_AGENT_LOST_SESSION' : 'INTERNAL_ERROR',
-          message: errorMessage(retryError),
-        })
-        recordFreshAgentObservabilityEvent({ kind: 'fresh_agent_send', sessionType: locator.sessionType, provider: locator.provider, sessionIdHash: hashForLogs(locator.sessionId), ...(locator.cwd ? { cwdHash: hashForLogs(locator.cwd) } : {}), outcome: 'failed', errorCode: 'FRESH_AGENT_LOST_SESSION' })
-        return
-      }
-    }
-    this.sendError(ws, { code: 'FRESH_AGENT_LOST_SESSION', message: errorMessage(error) })
+    this.sendError(ws, { code: 'FRESH_AGENT_LOST_SESSION', message: errorMessage(error) }, m.requestId)
     return
   }
-  this.sendError(ws, { code: 'INTERNAL_ERROR', message: errorMessage(error) })
+  this.sendError(ws, { code: 'INTERNAL_ERROR', message: errorMessage(error) }, m.requestId)
 }
 ```
 
-Structure the success fall-through by extracting the existing "emit `freshAgent.send.accepted` (+ materialization message)" block into a local function used by both the first attempt and the retry. Keep the existing genuinely-invalid case intact: `FreshAgentLostSessionError` raised for a NON-durable placeholder (`resume` throws "not a durable OpenCode session") must NOT be retried — the `startsWith('ses_')` + cwd guard covers this ("do not swallow genuinely invalid placeholder/non-durable lost-session errors").
+(Match the existing `sendError` call shape at `:3554-3556` — `requestId` is already passed there.) Keep the genuinely-invalid cases flowing through the SAME code: a `FreshAgentLostSessionError` for a non-durable placeholder ("not a durable OpenCode session") also arrives as `FRESH_AGENT_LOST_SESSION`; the client-side guard in Task 10 (`sessionId.startsWith('ses_')` + route cwd present) is what prevents retrying those — the server does not swallow or reclassify them.
 
 - [ ] **Step 4: Run to verify pass**
 
@@ -1441,23 +1539,25 @@ Expected: PASS (ownership suite guards the cwd/authorization axis — must stay 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add server/ws-handler.ts test/unit/server/ws-handler-fresh-agent.test.ts
-git commit -m "fix(server): preserve FRESH_AGENT_LOST_SESSION over WS and retry durable freshopencode sends once via attach (zrrj)"
+git add shared/ws-protocol.ts server/ws-handler.ts test/unit/server/ws-handler-fresh-agent.test.ts
+git commit -m "fix(server,shared): preserve FRESH_AGENT_LOST_SESSION over WS (shared ErrorCode contract) so the client can recover (zrrj)"
 ```
 
 ---
 
 ### Task 10: Client: auto-reattach + resend once on FRESH_AGENT_LOST_SESSION
 
-With Task 9, a send that cannot be server-recovered (e.g. no cwd on the locator) reaches the client as `code: 'FRESH_AGENT_LOST_SESSION'`. The client knows the route cwd (`freshOpenCodeRouteCwd`, `FreshAgentView.tsx:613-615` via `src/lib/fresh-opencode-route.ts`) even when the original send omitted it. On this code, re-issue `freshAgent.attach` with the route cwd, then resend the message exactly once.
+With Task 9, a lost-session send failure reaches the client as `code: 'FRESH_AGENT_LOST_SESSION'` (there is deliberately no server-side retry — see Task 9's coverage restatement; this client path is the kata's "attach/recover and retry once" for the incident's no-cwd locators). The client knows the route cwd (`freshOpenCodeRouteCwd`, `FreshAgentView.tsx:613-615` via `src/lib/fresh-opencode-route.ts`) even when the original send omitted it. On this code, re-issue `freshAgent.attach` with the route cwd, then resend the message exactly once.
+
+**Resend source (corrected by validation, A10):** `PendingSendMetadata` (`FreshAgentView.tsx:102-108`) is `{ cwd?, checkpointId?, submittedTurnId?, legacyAccepted?, metadataUpdateStarted? }` — it does **NOT** retain the message text. Retain the original send payload explicitly: add `text: string` to `PendingSendMetadata`, populated at the composer-submit site where the entry is created (the same place the `freshAgent.send` frame is built, so the retained text is byte-identical to what was sent). **Ordering constraint:** the lost-session retry branch must run BEFORE the generic send-error handling that clears the pane's local echo / pending metadata — if the generic path runs first, both the metadata entry and the visible echo are gone and there is nothing to resend.
 
 **Files:**
-- Modify: `src/components/fresh-agent/FreshAgentView.tsx` (WS error handling for sends; locate the existing handler for send failures — search the file for `INTERNAL_ERROR` or the `sendError`-frame consumption path used to clear local echo on failure)
+- Modify: `src/components/fresh-agent/FreshAgentView.tsx` (`PendingSendMetadata` type `:102-108` + its composer-submit writer; WS error handling for sends — locate the existing handler for send failures: search the file for `INTERNAL_ERROR` or the `sendError`-frame consumption path used to clear local echo on failure)
 - Test: `test/unit/client/components/fresh-agent/FreshAgentView.test.tsx`
 
 **Interfaces:**
-- Consumes: `wsMock.send` scaffold; `freshOpenCodeRouteCwdRef`; the pane's pending send metadata (`pendingSendMetadataRef`) which retains the original text/requestId.
-- Produces: one retry per failed requestId, tracked in `lostSessionRetryRef: useRef<Set<string>>` (requestIds already retried — never retried twice).
+- Consumes: `wsMock.send` scaffold; `freshOpenCodeRouteCwdRef`; `pendingSendMetadataRef` — extended by this task with the retained `text`.
+- Produces: `PendingSendMetadata` gains `text: string`; one retry per failed requestId, tracked in `lostSessionRetryRef: useRef<Set<string>>` (requestIds already retried — never retried twice); the retry branch is evaluated before (and, when it fires, instead of) the echo-clearing error fall-through.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -1496,31 +1596,37 @@ Check how error frames reach the component today (the `wsHandler` capture receiv
 Run: `npm run test:vitest -- --run test/unit/client/components/fresh-agent/FreshAgentView.test.tsx -t "FRESH_AGENT_LOST_SESSION"`
 Expected: FAIL — no attach, no resend.
 
-- [ ] **Step 3: Implement** in `FreshAgentView.tsx`: in the WS error-frame handling for owned send requests, add:
+- [ ] **Step 3: Implement** in `FreshAgentView.tsx`:
+
+1. Extend `PendingSendMetadata` (`:102-108`) with `text: string`, and populate it at the composer-submit site where the metadata entry for the requestId is created (the same code that builds the `freshAgent.send` frame — retain exactly the text that went into the frame). This is the retained resend payload; do NOT read it from the local echo after the fact (the echo is cleared by error paths).
+
+2. In the WS error-frame handling for owned send requests, add the retry branch **as the FIRST thing the send-failure path evaluates — before the existing handling that clears the local echo / pending metadata and shows the error** (if the clearing runs first, the payload is gone):
 
 ```ts
 if (errorCode === 'FRESH_AGENT_LOST_SESSION'
   && paneContentRef.current.sessionType === 'freshopencode'
   && typeof failedRequestId === 'string'
   && !lostSessionRetryRef.current.has(failedRequestId)) {
-  const pendingMeta = pendingSendMetadataRef.current.get(failedRequestId)
+  const pendingMeta = pendingSendMetadataRef.current.get(failedRequestId)   // now carries .text (step 1)
   const cwd = freshOpenCodeRouteCwdRef.current
   const sessionId = paneContentRef.current.sessionId
-  if (pendingMeta && cwd && sessionId) {
+  if (pendingMeta?.text && cwd && sessionId && sessionId.startsWith('ses_')) {
     lostSessionRetryRef.current.add(failedRequestId)
     ws.send(JSON.stringify({
       type: 'freshAgent.attach', sessionId, sessionType: 'freshopencode', provider: 'opencode', cwd,
     }))
     const retryRequestId = createRequestId()      // the file's existing id generator
     lostSessionRetryRef.current.add(retryRequestId)   // the retry itself is never retried
-    resendPendingMessage(retryRequestId, pendingMeta, cwd)   // re-issue freshAgent.send with the same text + cwd
-    return
+    resendPendingMessage(retryRequestId, pendingMeta.text, cwd)   // re-issue freshAgent.send with the retained text + cwd
+    return   // do NOT fall through: the echo stays visible while the retry is in flight
   }
 }
 // fall through to the existing error handling (clear echo, show error)
 ```
 
-Implement `resendPendingMessage` by extracting the existing send-frame construction into a helper reused by the composer submit path and the retry (same fields, plus `cwd`).
+The `startsWith('ses_')` guard keeps genuinely-invalid placeholder/non-durable lost-session errors on the normal error path (the server no longer filters these — Task 9).
+
+3. Implement `resendPendingMessage` by extracting the existing send-frame construction into a helper reused by the composer submit path and the retry (same fields, plus `cwd`); the retry's own pending-metadata entry retains the same `text` (so its failure still cleans up normally through the fall-through path).
 
 - [ ] **Step 4: Run to verify pass**
 
@@ -1540,14 +1646,17 @@ git commit -m "feat(client): auto-reattach and resend once on FRESH_AGENT_LOST_S
 
 `normalizeOpencodeTurn` (`server/fresh-agent/adapters/opencode/normalize.ts:324-355`) discards nearly every evidence field the detector needs — `info.time.completed`, `info.error`, per-message `info.tokens`/`info.cost` — even though `assembleExport` passes the raw `m.info` through verbatim (`adapter.ts:408`). Surface them under `extensions.opencode` (the low-friction contract path) so both the server-side detector and the client can see them. `step-finish` counts already survive (`normalize.ts:271-322`); tool part `state.status === 'running'` already reaches the client (`normalize.ts:216`).
 
+This task ALSO surfaces `extensions.opencode.statusFromLiveState: boolean` — the server-side half of Task 4's busy-clear gate: `true` only when the adapter has live state for the session whose **initial reconcile completed** (thread a flag set after `reconcileStatus` resolves). Snapshots served from the untracked default (`adapter.ts:590` `liveState?.status ?? 'idle'`) or mid-reconcile window carry `false`/absent, so the client never clears busy from a placeholder-default idle.
+
 **Files:**
 - Modify: `server/fresh-agent/adapters/opencode/normalize.ts`
+- Modify: `server/fresh-agent/adapters/opencode/adapter.ts` (set `state.initialReconcileCompleted = true` where `reconcileStatus(state)` resolves — both the `:189` running branch and the confirmed-idle exit, but NOT the error-swallow path `:193-199`; pass `statusFromLiveState: Boolean(liveState?.initialReconcileCompleted)` into the snapshot assembly at the `:590` area)
 - Read first (MANDATORY before coding): `shared/fresh-agent-contract.ts` — confirm the `extensions` Zod shape is permissive (`z.record(z.unknown())` or similar). If it is NOT permissive, extend the contract schema for `extensions.opencode.turnEvidence` and mirror the type on the client import path; the client hard-validates at `src/lib/api.ts:418-421` and will reject snapshots otherwise.
-- Test: `test/unit/server/fresh-agent/opencode-normalize.test.ts` (445 lines; step-finish assertions at `:105-133` show the fixture idiom)
+- Test: `test/unit/server/fresh-agent/opencode-normalize.test.ts` (445 lines; step-finish assertions at `:105-133` show the fixture idiom), `test/unit/server/fresh-agent/opencode-serve-adapter.test.ts` (statusFromLiveState windows)
 
 **Interfaces:**
 - Consumes: raw `OpencodeServeMessage = { info: Record<string, any>; parts: Array<Record<string, any>> }` passthrough.
-- Produces: `snapshot.extensions.opencode.turnEvidence: OpencodeTurnEvidence[]` where
+- Produces: `snapshot.extensions.opencode.statusFromLiveState: boolean` (consumed by Task 4's client gate) and `snapshot.extensions.opencode.turnEvidence: OpencodeTurnEvidence[]` where
 
 ```ts
 export type OpencodeTurnEvidence = {
@@ -1564,7 +1673,7 @@ export type OpencodeTurnEvidence = {
 }
 ```
 
-Field-name caution (kata-critical): the real OpenCode `message.data` field names are not documented in this repo. Extraction must be defensive: read `info.time?.completed`, `info.error` (accept `{ name, message }`, `{ data: { message } }`, or a string — reuse the tolerant shape of `opencodeErrorMessage` in `serve-events.ts:32-39`), `info.tokens?.input/output`, `info.cost`. Absent fields yield absent evidence properties, never crashes. Before implementing, verify against a live DB if available: `sqlite3 ~/.local/share/opencode/opencode.db "SELECT data FROM message ORDER BY time_created DESC LIMIT 3"` — if the machine has real OpenCode sessions, confirm/adjust names and record what you found in the commit message. If no live DB exists, implement the defensive reads exactly as specified.
+Field-name caution (kata-critical) — **now validated against live data**: the field names above were verified on opencode v1.18.6/1.18.7 via a 94,217-assistant-message census of a live DB plus live REST GETs (validator V2): `tokens`/`cost` present on 100% of assistant messages; `time.completed` on 99.92% (every exception bears interruption markers); `error.name` is always a top-level string; REST `info` ≡ DB `data` plus `id`/`sessionID`. Keep the extraction defensive anyway (future sidecar versions may drift — the 1.18.x server was rearchitected): read `info.time?.completed`, `info.error` (accept `{ name, message }`, `{ data: { message } }`, or a string — reuse the tolerant shape of `opencodeErrorMessage` in `serve-events.ts:32-39`), `info.tokens?.input/output`, `info.cost`. Note `info.error.data.name` never occurs on 1.18.x — keep it only as a harmless defensive read. Absent fields yield absent evidence properties, never crashes. Fixture realism: real user messages NEVER carry `time.completed` (0 of 6,019 in the census) — fixtures must not give them one.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -1580,10 +1689,18 @@ describe('turn evidence extraction (zrrj)', () => {
       exported: {
         info: { id: 'ses_1', time: { updated: 10 } },
         messages: [
-          { info: { id: 'm1', role: 'user', time: { created: 1, completed: 2 } }, parts: [] },
+          // realistic: user messages never carry time.completed (verified, V2)
+          { info: { id: 'm1', role: 'user', time: { created: 1 } }, parts: [] },
           {
             info: {
-              id: 'm2', role: 'assistant', time: { created: 3 },              // NO completed
+              id: 'm2', role: 'assistant', time: { created: 2, completed: 3 },  // clean prior turn
+              tokens: { input: 10, output: 40 }, cost: 0.01,
+            },
+            parts: [{ type: 'step-start' }, { type: 'step-finish' }],
+          },
+          {
+            info: {
+              id: 'm3', role: 'assistant', time: { created: 4 },              // NO completed
               error: { name: 'MessageAbortedError', message: 'aborted' },
               tokens: { input: 100, output: 0 }, cost: 0,
             },
@@ -1596,15 +1713,16 @@ describe('turn evidence extraction (zrrj)', () => {
       },
     })
     const evidence = snapshot.extensions.opencode.turnEvidence
-    expect(evidence).toHaveLength(2)
-    expect(evidence[1]).toMatchObject({
-      turnId: 'm2', role: 'assistant',
+    expect(evidence).toHaveLength(3)
+    expect(evidence[2]).toMatchObject({
+      turnId: 'm3', role: 'assistant',
       timeCompleted: undefined,
       error: { name: 'MessageAbortedError', message: 'aborted' },
       tokens: { input: 100, output: 0 },
       runningToolPartCount: 1, stepStartCount: 1, stepFinishCount: 0,
     })
-    expect(evidence[0]).toMatchObject({ turnId: 'm1', timeCompleted: 2, runningToolPartCount: 0 })
+    expect(evidence[1]).toMatchObject({ turnId: 'm2', timeCompleted: 3, runningToolPartCount: 0 })
+    expect(evidence[0]).toMatchObject({ turnId: 'm1', role: 'user', timeCompleted: undefined })
   })
 
   it('never leaks message text into evidence', () => {
@@ -1617,10 +1735,25 @@ describe('turn evidence extraction (zrrj)', () => {
 
 Match `normalizeOpencodeSnapshot`'s actual input signature from the existing tests in this file (it may take `{ exported, revision, ... }` or flattened args — copy the call shape of the nearest existing test exactly).
 
+And add the `statusFromLiveState` window tests to `opencode-serve-adapter.test.ts`:
+
+```ts
+describe('statusFromLiveState (zrrj, Task 4 gate)', () => {
+  it('is false/absent for an untracked session snapshot (adapter.ts:590 idle default)', async () => {
+    // getSnapshot for a ses_ id with no adapter state -> extensions.opencode.statusFromLiveState !== true
+  })
+
+  it('is true only after the initial reconcile completed', async () => {
+    // attach (reconcile resolves) -> getSnapshot -> statusFromLiveState === true;
+    // and with getSessionStatus rejecting (error-swallow path :193-199) -> stays false
+  })
+})
+```
+
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-normalize.test.ts`
-Expected: FAIL — `turnEvidence` undefined.
+Run: `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-normalize.test.ts test/unit/server/fresh-agent/opencode-serve-adapter.test.ts`
+Expected: FAIL — `turnEvidence` undefined; `statusFromLiveState` absent when it should be true.
 
 - [ ] **Step 3: Implement** in `normalize.ts` — a pure helper called from `normalizeOpencodeSnapshot` where `extensions.opencode` is assembled (`:403` area):
 
@@ -1668,13 +1801,17 @@ function extractTurnEvidence(messages: Array<{ info: Record<string, any>; parts:
 
 Wire `turnEvidence: extractTurnEvidence(input.exported?.messages ?? [])` into the `extensions.opencode` object. **Sidecar path only** — the DB hydrator clobbers `info.time` (`history-query.ts:373-376`), which is fine because FreshOpenCode snapshots read the sidecar (`assembleExport`), never the DB.
 
+Then wire `statusFromLiveState` (Task 4's server half):
+- `adapter.ts`: add `initialReconcileCompleted?: boolean` to `OpencodeSessionState`; set it `true` when `reconcileStatus(state)`'s `getSessionStatus` read resolves (both the running branch `:189` and the confirmed-idle path) — NOT on the error-swallow path (`:193-199`), which must leave it unset so a failed read never licenses a busy-clear.
+- At the snapshot assembly site (`:590` area), pass `statusFromLiveState: liveState?.initialReconcileCompleted === true` through to the normalizer input, and emit it as `extensions.opencode.statusFromLiveState` alongside `turnEvidence`.
+
 - [ ] **Step 4: Run to verify pass** — `npm run test:vitest -- --run test/unit/server/fresh-agent/opencode-normalize.test.ts test/unit/server/fresh-agent/opencode-serve-adapter.test.ts` (adapter snapshot tests must stay green; if the client contract rejects the new field, this is where it surfaces — fix the contract as noted above). Also run `npm run test:vitest -- --run test/unit/client/lib/api.test.ts` to confirm `FreshAgentSnapshotSchema` accepts snapshots with evidence.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add server/fresh-agent/adapters/opencode/normalize.ts shared/fresh-agent-contract.ts test/unit/server/fresh-agent/opencode-normalize.test.ts
-git commit -m "feat(server): surface opencode turn evidence (completion time, error, tokens, tool state) in snapshot extensions (zrrj)"
+git add server/fresh-agent/adapters/opencode/normalize.ts server/fresh-agent/adapters/opencode/adapter.ts shared/fresh-agent-contract.ts test/unit/server/fresh-agent/
+git commit -m "feat(server): surface opencode turn evidence and live-reconciled status flag in snapshot extensions (zrrj)"
 ```
 
 ---
@@ -1815,6 +1952,8 @@ export function detectInterruptedTurn(
 
 (The remaining kata signals — sidecar loss, Freshell shutdown, restored running status — are covered by the *callers*: Task 8's monitor emits interruption on sidecar loss/timeout, and Task 14 runs this detector on restore, which is exactly the shutdown/restored-status path.)
 
+**Validated against live data (V2):** the contract was proven on opencode v1.18.6/1.18.7 via a 94,217-assistant-message census of a live DB plus live REST reads — **0 false positives for this gate in 94k messages**; 99.92% of completed turns carry `time.completed` and ALL exceptions bear interruption markers (0 output tokens, running tool parts, or missing step-finish). Two must-know semantics: (a) **aborted turns DO carry `time.completed`** (all 203 `MessageAbortedError` rows) — so `missing_completion` will NOT fire for them and the `aborted_error`-alone definitive branch is **load-bearing, not optional**; do NOT "simplify" the gate to missing-completion-only. (b) `info.error.data.name` never occurs on 1.18.x — rule 3's second read is a harmless defensive fallback; keep it, expect it dead. Fixture realism: real user messages never carry `time.completed`.
+
 - [ ] **Step 1: Write the failing tests**
 
 ```ts
@@ -1827,7 +1966,8 @@ const OLD = NOW - INTERRUPTED_TURN_STABILITY_MS - 1
 function assistant(info: Record<string, any>, parts: Record<string, any>[] = []) {
   return { info: { id: 'm2', role: 'assistant', time: { created: OLD, updated: OLD }, ...info }, parts }
 }
-const user = { info: { id: 'm1', role: 'user', time: { created: OLD - 10, completed: OLD - 9 } }, parts: [] }
+// realistic: user messages never carry time.completed (verified, V2)
+const user = { info: { id: 'm1', role: 'user', time: { created: OLD - 10 } }, parts: [] }
 
 describe('detectInterruptedTurn', () => {
   it('flags missing completion + running tool part as interrupted', () => {
@@ -1938,6 +2078,18 @@ async function maybeRecoverInterruptedTurn(state: OpencodeSessionState): Promise
       }
       return
     }
+    // Route/mutability precondition BEFORE any ledger write (validated fix, A6/N-V1a):
+    // ensureMutableRoute throws for a non-provider-created state without a cwd
+    // (adapter.ts:146-148). If we recorded the recovery first and the send then threw,
+    // the (session, message) ledger entry would be permanently burned — a later
+    // cwd-bearing attach could never recover this turn. So: no usable route -> audit
+    // and return WITHOUT recording.
+    const hasUsableRoute = state.providerCreatedInThisAdapter
+      || (typeof state.cwd === 'string' && state.cwd.trim().length > 0)
+    if (!hasUsableRoute) {
+      audit('suppressed_no_route', 'no_cwd_for_mutation', verdict.messageId)
+      return
+    }
     if (await recoveryStore.hasRecovery(realId, verdict.messageId)) {
       audit('suppressed_already_recovered', 'ledger_hit', verdict.messageId); return
     }
@@ -1957,6 +2109,8 @@ async function maybeRecoverInterruptedTurn(state: OpencodeSessionState): Promise
 ```
 
   where `sendForState` is the existing send-queue entry (`adapter.ts:507-515` idiom) so the continuation is serialized, route-validated (`ensureMutableRoute`), armed with `onceIdle`, and produces the normal running→idle→turn-complete lifecycle — a clear transcript event plus the audit row satisfy "auditable". The continuation text is Freshell-owned instruction, not user content — safe to hardcode; it appears in the transcript as a user-role message (that IS the visible transcript marker).
+  - **Route check precedes the ledger write (see the snippet).** A no-cwd restore (the incident's own population — restored panes can attach cwd-less; detection still works because `listMessages` runs on the default route) must NOT record a recovery it cannot inject: `ensureMutableRoute` would throw (`adapter.ts:146-148`) AFTER the write and permanently burn the one allowed recovery for that turn. With the precondition first, a later cwd-bearing attach can still recover the turn. **Accepted residual:** after the precondition passes and `recordRecovery` lands, a *transient* send failure (sidecar hiccup) still burns the recovery — that errs on the safe side (never risks double injection) and is acceptable.
+  - Recovery is scoped to **successful attaches**: if `validateSessionRoute` throws before state registration (`adapter.ts:492`), no reconcile/recovery runs for that pane — by design (surfaced N-V1b).
   - **Do not auto-recover a `running` session** — only `idle`-reconciled restores are candidates. This encodes "restored running status" recovery as: monitor it (Task 8); if the monitor later reports sidecar loss, the NEXT restore attempt will find the unfinished transcript and recover it here.
 
 - [ ] **Step 1: Write the failing tests** (in `opencode-serve-adapter.test.ts`; build the adapter with an injected recovery store on a temp file — extend `makeAdapter` overrides):
@@ -1966,7 +2120,8 @@ describe('interrupted-turn recovery (zrrj)', () => {
   const OLD = Date.now() - 60_000
   const interruptedTranscript = {
     messages: [
-      { info: { id: 'm1', role: 'user', time: { created: OLD - 10, completed: OLD - 9 } }, parts: [] },
+      // realistic: user messages never carry time.completed (verified, V2)
+      { info: { id: 'm1', role: 'user', time: { created: OLD - 10 } }, parts: [] },
       { info: { id: 'm2', role: 'assistant', time: { created: OLD } }, parts: [{ type: 'tool', state: { status: 'running' } }] },
     ],
     nextCursor: null,
@@ -2005,6 +2160,23 @@ describe('interrupted-turn recovery (zrrj)', () => {
     await adapter2.attach!({ sessionId: 'ses_int', cwd: '/w' })
     await flushSendQueue()
     expect(manager2.promptAsync).not.toHaveBeenCalled()
+  })
+
+  it('does not burn the recovery ledger on a no-cwd attach (route check precedes record)', async () => {
+    const store = makeTempRecoveryStore()
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue(undefined)
+    manager.listMessages.mockResolvedValue(interruptedTranscript)
+    const adapter = makeAdapter(manager, { recoveryStore: store })
+    await adapter.attach!({ sessionId: 'ses_int' })              // NO cwd — the incident shape
+    await flushSendQueue()
+    expect(manager.promptAsync).not.toHaveBeenCalled()            // no injection possible (audit: suppressed_no_route)
+    expect(await store.hasRecovery('ses_int', 'm2')).toBe(false)  // ledger NOT burned
+
+    // A later cwd-bearing attach can still recover the turn
+    await adapter.attach!({ sessionId: 'ses_int', cwd: '/w' })
+    await flushSendQueue()
+    expect(manager.promptAsync).toHaveBeenCalledTimes(1)
   })
 
   it('does not recover when the user already sent a follow-up', async () => {
@@ -2076,7 +2248,7 @@ const TRANSCRIPT_SETTLE_MAX_POLLS = 10   // ~1.5 s worst case
 async function awaitTranscriptSettled(state: OpencodeSessionState, sentAtMs: number): Promise<boolean>
 ```
 
-Settled means: `listMessages` (limit e.g. 20, newest page) contains an assistant message with `info.time.created >= sentAtMs - CLOCK_SKEW_MS` (use `CLOCK_SKEW_MS = 5_000`) AND a finite `info.time.completed`. Poll with `TRANSCRIPT_SETTLE_POLL_MS` sleeps between attempts; inject the sleep fn for tests (`options.sleep`, default `(ms) => new Promise(r => setTimeout(r, ms))`).
+Settled means: `listMessages` (limit e.g. 20, newest page) contains an assistant message with `info.time.created >= sentAtMs - CLOCK_SKEW_MS` (use `CLOCK_SKEW_MS = 5_000`) AND a finite `info.time.completed`. Poll with `TRANSCRIPT_SETTLE_POLL_MS` sleeps between attempts; inject the sleep fn for tests (`options.sleep`, default `(ms) => new Promise(r => setTimeout(r, ms))`). (Pagination contract verified live on opencode v1.18.6, V2: `?limit=N` returns exactly the N newest messages in ascending chronological order — last element is the latest; limit-only paging is all this plan uses, so the newest-page premise holds.)
 
 In `materializeOrSend`, capture `const sentAtMs = Date.now()` just before `promptAsyncForState` (`:363`), then after `await idle` (`:368`) insert `await awaitTranscriptSettled(state, sentAtMs)` BEFORE `emitStatus(state, 'idle')` (`:371`) and the chime (`:377-381`). Also call it (with `sentAtMs = 0`, i.e. "any completed assistant message") in Task 8's monitor resolve path before its `emitStatus(state, 'idle')`.
 
@@ -2089,7 +2261,7 @@ describe('idle freshness (zrrj)', () => {
     const idle = createDeferred<void>()
     manager.onceIdle.mockReturnValue(idle.promise)
     // First two polls: transcript still missing the final answer; third poll: it appears.
-    const unfinished = { messages: [{ info: { id: 'm1', role: 'user', time: { created: Date.now(), completed: Date.now() } }, parts: [] }], nextCursor: null }
+    const unfinished = { messages: [{ info: { id: 'm1', role: 'user', time: { created: Date.now() } }, parts: [] }], nextCursor: null }   // user messages never carry time.completed (V2)
     const finished = { messages: [...unfinished.messages, { info: { id: 'm2', role: 'assistant', time: { created: Date.now(), completed: Date.now() } }, parts: [] }], nextCursor: null }
     manager.listMessages
       .mockResolvedValueOnce(unfinished)
@@ -2211,7 +2383,7 @@ git commit -m "fix(client): bounded re-poll when an idle snapshot is missing the
 - Produces:
   - `freshAgent.send`: one `fresh_agent_send` row per attempt (`outcome: 'accepted' | 'failed'`, `errorCode`, `durationMs`, `requestId`).
   - `freshAgent.interrupt`: `fresh_agent_interrupt` row (`outcome`).
-  - `freshAgent.attach`: `fresh_agent_attach` row on success too (`recovered: true` when it came from Task 9's retry path).
+  - `freshAgent.attach`: `fresh_agent_attach` row on success too. (The union's optional `recovered?: boolean` stays for future use; with Task 9's server-side retry dropped, nothing sets it yet — a client-driven recovery re-attach (Task 10) arrives as an ordinary `freshAgent.attach` frame.)
   - Materialization: `fresh_agent_materialized` row emitted where the WS layer sends `freshAgent.session.materialized` (`ws-handler.ts:1408-1434` — single choke point).
   - Snapshot route: accept `trigger` in the query schema (`z.string().max(32).optional()`), include it in `fresh_agent_snapshot_served`; add a `fresh_agent_snapshot_failed` call inside `sendFreshAgentError` with `httpStatus`, `code`, `trigger`, `durationMs`.
   - Client: `getFreshAgentThreadSnapshot(..., { revision?, cwd?, trigger?, signal? })` appends `['trigger', query.trigger]` to `buildQueryString`; FreshAgentView passes the scheduler trigger.
@@ -2261,7 +2433,7 @@ Client: in `api.test.ts`, assert the fetch URL contains `trigger=poll` when pass
 
 - [ ] **Step 2: Run to verify fail** — rows absent; `trigger` rejected/ignored.
 
-- [ ] **Step 3: Implement** per Interfaces. In the ws-handler, wrap each case body: capture `const startedAt = Date.now()` and emit the row in both success and error exits (including Task 9's retry path with `recovered: true` on the attach row). In `sendFreshAgentError`, thread `trigger`/`startedAt` via an optional context arg from the snapshot handler. In `applySnapshot`'s executor (FreshAgentView), pass `trigger` through to `getFreshAgentThreadSnapshot`.
+- [ ] **Step 3: Implement** per Interfaces. In the ws-handler, wrap each case body: capture `const startedAt = Date.now()` and emit the row in both success and error exits (the `freshAgent.send` failure exit includes the `FRESH_AGENT_LOST_SESSION` case from Task 9 — `errorCode` carries it). In `sendFreshAgentError`, thread `trigger`/`startedAt` via an optional context arg from the snapshot handler. In `applySnapshot`'s executor (FreshAgentView), pass `trigger` through to `getFreshAgentThreadSnapshot`.
 
 - [ ] **Step 4: Run to verify pass**
 
@@ -2295,8 +2467,10 @@ inspectState(): {
   pendingRecoveries: number
 }
 
-// adapter.ts (opencode) — module-level registry read
-export function inspectOpencodeSessions(): Array<{
+// adapter.ts (opencode) — adapter-INSTANCE method (the sessions map and the idle-recovery
+// monitor registry both live in the factory closure per Task 8's scope note, so this
+// cannot be a module-level export; expose it on the adapter object)
+inspectSessions(): Array<{
   sessionIdHash: string; status: string; hasRealSession: boolean
   cwdHash?: string; monitorArmed: boolean; turnAborted?: boolean; turnErrored?: boolean
   lastTurnCompleteAt?: number
@@ -2331,7 +2505,7 @@ it('returns hashed, content-free incident state', async () => {
 })
 ```
 
-Plus unit tests for `inspectOpencodeSessions()` in the adapter suite (arrange a running session with an armed monitor, assert the hashed summary and assert `JSON.stringify(result)` contains neither the raw `ses_` id nor any message text).
+Plus unit tests for the adapter's `inspectSessions()` in the adapter suite (arrange a running session with an armed monitor, assert the hashed summary and assert `JSON.stringify(result)` contains neither the raw `ses_` id nor any message text).
 
 - [ ] **Step 2: Run to verify fail** — modules missing.
 
@@ -2415,6 +2589,11 @@ git add test/unit/server/ws-handler-fresh-agent-backpressure.test.ts test/helper
 
 Chosen fix (kata: "if coupled, fix the broker/backpressure/lifecycle-event-loss path in the same change"): make terminal output self-throttle **before** control messages start dying. Add a foreground pause threshold at 1 MiB — half the handler's 2 MiB kill line — using the exact retry mechanic the background path already uses (`broker.ts:859-869`): skip the flush and retry in 100 ms. Terminal output degrades gracefully (it has queues + replay + `sinceSeq`); freshAgent events keep flowing because `bufferedAmount` can no longer be inflated past 2 MiB by terminal traffic alone. The 4008 close in `WsHandler.send` stays — it now fires only under genuine non-terminal pathology.
 
+**Verified notes (V3):**
+- **Legacy close site:** the old `TerminalRegistry.safeSend` drop+`close(4008)` remains reachable — but only for small control frames (`terminal.exit` `terminal-registry.ts:1505`/`:4061`, codex-durability `:3046`, session-associated `:3060`), never for live terminal output (every broker-attached client is output-suppressed; exhaustive caller trace in V3/A14). Post-fix it stays below the 2 MiB line because the 1 MiB broker pause plus the ≤16 KiB batch cap bound terminal-driven `bufferedAmount`. **Caution:** that safety is arithmetic over constants that env vars can override (`TERMINAL_STREAM_BATCH_MAX_BYTES`, `MAX_WS_BUFFERED_AMOUNT` at `terminal-registry.ts:66`, `maxWsBufferedAmount`) — overrides must preserve `pause threshold < kill line` ordering; consider a runtime clamp on the new constant mirroring the existing foreground-replay clamp idiom (`broker.ts:58-67`, `Math.min(..., catastrophic - 1)` style) rather than relying on a comment alone.
+- **Which retry timer:** the foreground pause reuses the background pause's **100 ms** retry (`TERMINAL_BACKGROUND_RETRY_FLUSH_MS`), NOT the generic 50 ms flush retry (`TERMINAL_STREAM_RETRY_FLUSH_MS`, `constants.ts:18-21`). The test must pin the 100 ms timer explicitly (assert the reschedule delay / advance fake timers by 100 ms, not 50 ms).
+- **Foreground-pacing precedent:** pausing foreground under socket pressure is already shipped in-repo — commit `06063f98` paces foreground *replay* at 576 KiB (`broker.ts:55-67`). This task extends the accepted pattern from replay to live output at a coherent higher threshold (1 MiB > 576 KiB > 512 KiB background).
+
 **Files:**
 - Modify: `server/terminal-stream/constants.ts` (new constant), `server/terminal-stream/broker.ts` (`flushAttachment` `:840-958`)
 - Test: `test/unit/server/ws-handler-fresh-agent-backpressure.test.ts` (Task 19 test 1 + flipped test 3), `test/unit/server/ws-handler-backpressure.test.ts` (existing suite must stay green)
@@ -2434,7 +2613,7 @@ export const TERMINAL_STREAM_FOREGROUND_PAUSE_BUFFERED_BYTES = 1 * 1024 * 1024
 
 - In `flushAttachment` (`:840-958`), where the background pause currently checks `attachment.priority === 'background' && bufferedAmount > TERMINAL_STREAM_BACKGROUND_PAUSE_BUFFERED_BYTES`, add the foreground equivalent so EVERY attachment pauses at its threshold (background keeps its lower 512 KiB threshold; foreground gets 1 MiB), reusing the identical retry-in-100ms scheduling.
 
-- [ ] **Step 1: Update Task 19's test 3** to assert the new behavior (broker does NOT call `ws.send` when `bufferedAmount` = 3 MiB for a foreground pane; instead it schedules a retry — assert via fake timers or the broker's retry bookkeeping the way the existing catastrophic-spike test at `ws-handler-backpressure.test.ts:271` observes deferred behavior).
+- [ ] **Step 1: Update Task 19's test 3** to assert the new behavior (broker does NOT call `ws.send` when `bufferedAmount` = 3 MiB for a foreground pane; instead it schedules a retry — assert via fake timers or the broker's retry bookkeeping the way the existing catastrophic-spike test at `ws-handler-backpressure.test.ts:271` observes deferred behavior). **Pin the timer:** the assertion must target the **100 ms** background-style retry (`TERMINAL_BACKGROUND_RETRY_FLUSH_MS` mechanic), NOT the generic 50 ms `TERMINAL_STREAM_RETRY_FLUSH_MS` (`constants.ts:18-21`) — e.g. advance fake timers by 99 ms (no flush) then to 100 ms (flush retried).
 
 - [ ] **Step 2: Run to verify RED** — test 1 and updated test 3 fail against the ungated broker.
 
@@ -2512,7 +2691,7 @@ Expected: all PASS.
 Landing notes for the finish stage (explicit user pre-approval EXISTS for this change — "fix each of the bugs you indicated with the usual, landing them on main as you go"): push the branch, open the PR targeting `main`, wait for required checks, squash-merge (repo norm), fast-forward local `main`, then close the kata from the repo root with evidence:
 
 ```bash
-kata close zrrj --done --commit <merged sha> --message "Landed the canonical fix: client per-key snapshot scheduler with Retry-After/exponential 429 backoff and last-good-snapshot retention; idle HTTP snapshots clear stale opencode busy; restore reconciliation now emits status and arms exactly one monitored idle recovery per durable session with structured interruption on sidecar loss/timeout; serve subscriptions survive sidecar replacement (generation/pid/baseUrl identity added); FRESH_AGENT_LOST_SESSION is preserved over WS with one-shot attach-recover-retry on both server and client; interrupted turns are detected from transcript evidence (missing completion, MessageAbortedError, running tool parts, token accounting, missing step-finish) with a durable interrupt-intent store, a crash-safe recovery ledger, and at most one auditable Freshell-owned continuation; idle is only emitted after the final assistant message is queryable (missing-final-answer race); always-on fresh-agent observability logger with identity-hashed send/interrupt/attach/materialization/monitor/sidecar/snapshot rows and /turns 429 coverage; read-only /api/debug/fresh-agent incident endpoint; area-6 verdict: terminal/WS storm was COUPLED via asymmetric backpressure (broker ungated vs 2MiB drop+close) — fixed with a 1MiB foreground broker pause; retention_lost itself proven log-only post-ff8589bb (evidence in docs/plans/2026-07-27-freshopencode-restart-recovery-area6-evidence.md)."
+kata close zrrj --done --commit <merged sha> --message "Landed the canonical fix: client per-key snapshot scheduler with Retry-After/exponential 429 backoff and last-good-snapshot retention; idle HTTP snapshots clear stale opencode busy; restore reconciliation now emits status and arms exactly one monitored idle recovery per durable session with structured interruption on sidecar loss/timeout; serve subscriptions survive sidecar replacement (generation/pid/baseUrl identity added); FRESH_AGENT_LOST_SESSION is preserved over WS (shared ErrorCode contract) with client-side attach-then-resend-once completing the existing server-internal cwd-bearing recovery; interrupted turns are detected from transcript evidence (missing completion, MessageAbortedError, running tool parts, token accounting, missing step-finish) with a durable interrupt-intent store, a crash-safe recovery ledger, and at most one auditable Freshell-owned continuation; idle is only emitted after the final assistant message is queryable (missing-final-answer race); always-on fresh-agent observability logger with identity-hashed send/interrupt/attach/materialization/monitor/sidecar/snapshot rows and /turns 429 coverage; read-only /api/debug/fresh-agent incident endpoint; area-6 verdict: terminal/WS storm was COUPLED via asymmetric backpressure (broker ungated vs 2MiB drop+close) — fixed with a 1MiB foreground broker pause; retention_lost itself proven log-only post-ff8589bb (evidence in docs/plans/2026-07-27-freshopencode-restart-recovery-area6-evidence.md)."
 ```
 
 Do NOT close the kata if any verification step is unverified.
@@ -2536,7 +2715,7 @@ Do NOT close the kata if any verification step is unverified.
 | If idle/absent: keep idle, no long waiter | 8 (no-monitor test) |
 | Structured interruption/recovery signals on sidecar loss/timeout/state loss | 8 |
 | Serve subscriptions survive sidecar replacement, proven by tests | 7 |
-| Materialized ses_ sends route or attach/recover + retry once | 9 (server), 10 (client) |
+| Materialized ses_ sends route or attach/recover + retry once | pre-existing `requireOrRecoverSession` internal recovery (cwd-bearing locators) + 9 (code propagation, shared contract) + 10 (client attach-then-resend-once — the incident's no-cwd class); server-side in-handler retry deliberately dropped (V4: dead-or-harmful for every reachable class) |
 | Don't swallow genuinely invalid lost-session errors | 9 (placeholder/non-durable guard + test) |
 | Interrupted-turn detection from transcript/tool evidence (all listed signals) | 11 (evidence surfacing), 13 (detector: missing completion, MessageAbortedError, running tool, token accounting, missing step-finish), 8+14 (sidecar loss / shutdown / restored-running via monitor+restore paths) |
 | Stability window (still-writing rows) | 13 |
@@ -2564,4 +2743,4 @@ No unresolved coverage gaps identified. Note one deliberate scoping decision ins
 
 **2. Placeholder scan:** No TBD/TODO markers. Where a step edits a 4-6k-line existing file, the plan gives exact anchors (file:line + quoted current code) plus complete new code, and where an existing test-file helper must be reused, it names the helper and its location rather than inventing parallel scaffolding — that is an instruction to reuse, not a placeholder. Task 11 carries an explicit field-name verification step because the OpenCode message schema is not documented in-repo; the defensive implementation is fully specified either way.
 
-**3. Type consistency check:** `retryAfterMs` (Task 1) consumed by Task 2's `ApiError` check; `SnapshotTrigger`/`makeSnapshotKey`/`getSnapshotScheduler`/`resetSnapshotSchedulerForTests` (Task 2) consumed in Tasks 3, 16, 17; `describeSidecar`/`currentGeneration` (Task 7) consumed in Tasks 8, 18; `FreshAgentRecoveryStore` methods (Task 12) consumed in Task 14 with matching signatures; `detectInterruptedTurn(messages, { nowMs, stabilityMs? })` (Task 13) called identically in Task 14; observability kinds (Task 6) match every emission site in Tasks 7, 8, 9, 14, 17; `FRESH_AGENT_LOST_SESSION` code string identical in Tasks 9 and 10. Verified consistent.
+**3. Type consistency check:** `retryAfterMs` (Task 1) consumed by Task 2's `ApiError` check; `SnapshotTrigger`/`makeSnapshotKey`/`getSnapshotScheduler`/`resetSnapshotSchedulerForTests` (Task 2) consumed in Tasks 3, 16, 17; the once-resolved request/key cwd contract (Task 2 key note ↔ Task 3 item 2) and the no-signal run-closure contract (Task 2 ↔ Task 3) match; `describeSidecar`/`currentGeneration`/`sessionStateGeneration` (Task 7) consumed in Tasks 8, 18 and the ws-handler rebind; `onceIdle(..., { assumeActive })` (Task 8's serve-manager extension) matches `armIdleRecovery`'s call; `extensions.opencode.statusFromLiveState` produced in Task 11 and consumed by Task 4's gate (Task 4 reads it defensively until Task 11 lands); `FreshAgentRecoveryStore` methods (Task 12) consumed in Task 14 with matching signatures (incl. the route-precondition-before-`recordRecovery` ordering); `detectInterruptedTurn(messages, { nowMs, stabilityMs? })` (Task 13) called identically in Task 14; observability kinds (Task 6, incl. `suppressed_no_route`) match every emission site in Tasks 7, 8, 14, 17; `FRESH_AGENT_LOST_SESSION` is defined once in `shared/ws-protocol.ts` (Task 9) and consumed by Task 10's client guard; no task references the dropped server-side attach-retry, module-scope monitor registry, effect-scoped snapshot AbortController, or a `pendingSendMetadataRef` text field that predates Task 10's extension. Verified consistent.

--- a/port/contract/ws-protocol.schema.json
+++ b/port/contract/ws-protocol.schema.json
@@ -2445,7 +2445,8 @@
         "RATE_LIMITED",
         "UNAUTHORIZED",
         "PROTOCOL_MISMATCH",
-        "SESSION_RESERVED"
+        "SESSION_RESERVED",
+        "FRESH_AGENT_LOST_SESSION"
       ],
       "type": "string"
     },

--- a/port/contract/ws-server-messages.schema.json
+++ b/port/contract/ws-server-messages.schema.json
@@ -569,7 +569,8 @@
             "RATE_LIMITED",
             "UNAUTHORIZED",
             "PROTOCOL_MISMATCH",
-            "SESSION_RESERVED"
+            "SESSION_RESERVED",
+            "FRESH_AGENT_LOST_SESSION"
           ],
           "type": "string"
         },

--- a/server/agent-api/router.ts
+++ b/server/agent-api/router.ts
@@ -1699,7 +1699,7 @@ export function createAgentApiRouter({
         try {
           result = await runSend()
         } catch (err: any) {
-          if (err?.name === 'FreshAgentLostSessionError' && freshAgentRuntimeManager.attach) {
+          if (err?.code === 'FRESH_AGENT_LOST_SESSION' && freshAgentRuntimeManager.attach) {
             await freshAgentRuntimeManager.attach(locator)
             result = await runSend()
           } else {

--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -681,10 +681,21 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
   /** Fire-and-forget recovery kickoff after reconcileStatus on resume/attach. Only an
    * idle-reconciled restore is a candidate — a running session is being monitored by
    * armIdleRecovery; if that monitor later reports loss, the NEXT restore attempt will
-   * find the unfinished transcript and recover it here. */
+   * find the unfinished transcript and recover it here.
+   *
+   * Passes are CHAINED on the state, not fired in parallel: two near-simultaneous
+   * restores of the same session (multi-pane restore after a restart) must not both
+   * pass the `hasRecovery` gate before either `recordRecovery` lands — the store
+   * serializes operations individually but has no atomic check-and-set, so parallel
+   * passes could double-inject. Chaining guarantees the second pass's ledger read
+   * sees the first pass's record. The `.catch` keeps the chain rejection-safe
+   * (maybeRecoverInterruptedTurn never rejects by contract, but a poisoned chain
+   * would silently disable recovery forever). */
   function scheduleInterruptedTurnRecovery(state: OpencodeSessionState): void {
     if (state.status !== 'idle') return
-    state.pendingRecovery = maybeRecoverInterruptedTurn(state)
+    state.pendingRecovery = (state.pendingRecovery ?? Promise.resolve())
+      .catch(() => undefined)
+      .then(() => maybeRecoverInterruptedTurn(state))
   }
 
   async function assembleExport(

--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -34,8 +34,20 @@ const OPENCODE_REAL_SESSION_ID = /^ses_/
 const OPENCODE_PLACEHOLDER_SESSION_ID = /^freshopencode-/
 const DEFAULT_TURN_TIMEOUT_MS = 600_000
 
+/** Module-scope monotonic counter for OpencodeSessionState identity. Holds no
+ * per-instance state; every newly constructed state gets the next value. */
+let stateGenerationCounter = 0
+
+function nextStateGeneration(): number {
+  return ++stateGenerationCounter
+}
+
 type OpencodeSessionState = {
   placeholderId: string
+  /** Monotonic identity of this state object (and its EventEmitter). Consumers
+   * (ws-handler) compare generations to detect state recreation and rebind
+   * their subscriptions to the new emitter. */
+  stateGeneration: number
   realSessionId?: string
   cwd?: string
   routeValidatedCwd?: string
@@ -424,6 +436,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       const normalized = normalizeOpencodeInput(input)
       const state: OpencodeSessionState = {
         placeholderId: makePlaceholderId(String(input.requestId)),
+        stateGeneration: nextStateGeneration(),
         cwd: normalized.cwd,
         model: normalized.model,
         effort: normalized.effort,
@@ -442,8 +455,8 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       if (isPlaceholderOpencodeSessionId(sessionId)) {
         const real = await resolveLegacyPlaceholder(legacyReader(), normalized, sessionId)
         const state: OpencodeSessionState = {
-          placeholderId: sessionId, realSessionId: real, cwd: normalized.cwd, model: normalized.model,
-          effort: normalized.effort, status: 'idle', events: new EventEmitter(), sendQueue: Promise.resolve(),
+          placeholderId: sessionId, stateGeneration: nextStateGeneration(), realSessionId: real, cwd: normalized.cwd,
+          model: normalized.model, effort: normalized.effort, status: 'idle', events: new EventEmitter(), sendQueue: Promise.resolve(),
         }
         remember(state)
         bindServeStream(state)
@@ -454,8 +467,8 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
         throw new FreshAgentLostSessionError(`OpenCode session ${sessionId} is not a durable OpenCode session.`)
       }
       const state: OpencodeSessionState = {
-        placeholderId: sessionId, realSessionId: sessionId, cwd: normalized.cwd, model: normalized.model,
-        effort: normalized.effort, status: 'idle', events: new EventEmitter(), sendQueue: Promise.resolve(),
+        placeholderId: sessionId, stateGeneration: nextStateGeneration(), realSessionId: sessionId, cwd: normalized.cwd,
+        model: normalized.model, effort: normalized.effort, status: 'idle', events: new EventEmitter(), sendQueue: Promise.resolve(),
       }
       remember(state)
       bindServeStream(state)
@@ -483,6 +496,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       }
       const state: OpencodeSessionState = {
         placeholderId: locator.sessionId,
+        stateGeneration: nextStateGeneration(),
         realSessionId: locator.sessionId,
         cwd: locator.cwd,
         status: 'idle',
@@ -502,6 +516,10 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       const handler = (event: unknown) => listener(event)
       state.events.on('event', handler)
       return () => state.events.off('event', handler)
+    },
+
+    sessionStateGeneration(sessionId) {
+      return sessions.get(sessionId)?.stateGeneration
     },
 
     async send(sessionId, input) {
@@ -548,6 +566,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       const child = await forkForState(state)
       const childState: OpencodeSessionState = {
         placeholderId: child.id,
+        stateGeneration: nextStateGeneration(),
         realSessionId: child.id,
         cwd: child.directory ?? state.cwd,
         providerCreatedInThisAdapter: true,

--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -365,24 +365,36 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
     state.turnAborted = false
     state.turnErrored = false
     emitStatus(state, 'running')
-    const idle = route
-      ? serveManager.onceIdle(realId, turnTimeoutMs, route)
-      : serveManager.onceIdle(realId, turnTimeoutMs)
-    void idle.catch(() => {})
+    // The compact turn owns its idle (same mechanic as materializeOrSend): cancel any
+    // still-pending restore idle-recovery monitor (it would otherwise resolve on THIS
+    // turn's idle and double-emit idle/chime), and flag the turn so armIdleRecovery
+    // cannot arm a second waiter while we are parked on our own onceIdle.
+    disarmIdleRecovery(realId)
+    sendsInFlight.add(realId)
     try {
-      if (route) await serveManager.compact(realId, input, route)
-      else if (input) await serveManager.compact(realId, input)
-      else await serveManager.compact(realId)
-      await idle
-      emitStatus(state, 'idle')
-      if (!state.turnAborted && !state.turnErrored) {
-        const completionAt = nextMonotonicTurnCompleteAt(state.lastTurnCompleteAt, Date.now())
-        state.lastTurnCompleteAt = completionAt
-        state.events.emit('event', { type: 'sdk.turn.complete', sessionId: state.placeholderId, at: completionAt })
+      const idle = route
+        ? serveManager.onceIdle(realId, turnTimeoutMs, route)
+        : serveManager.onceIdle(realId, turnTimeoutMs)
+      void idle.catch(() => {})
+      try {
+        if (route) await serveManager.compact(realId, input, route)
+        else if (input) await serveManager.compact(realId, input)
+        else await serveManager.compact(realId)
+        await idle
+        emitStatus(state, 'idle')
+        if (!state.turnAborted && !state.turnErrored) {
+          const completionAt = nextMonotonicTurnCompleteAt(state.lastTurnCompleteAt, Date.now())
+          state.lastTurnCompleteAt = completionAt
+          state.events.emit('event', { type: 'sdk.turn.complete', sessionId: state.placeholderId, at: completionAt })
+        }
+      } catch (error) {
+        emitStatus(state, 'idle')
+        throw error
       }
-    } catch (error) {
-      emitStatus(state, 'idle')
-      throw error
+    } finally {
+      // The compact's turn has settled either way; a later restore/attach may arm a
+      // monitor again.
+      sendsInFlight.delete(realId)
     }
   }
 

--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -107,6 +107,27 @@ type OpencodeSessionState = {
   pendingRecovery?: Promise<void>
 }
 
+/** Content-free per-session summary served by the read-only incident endpoint
+ * (kata zrrj). Identity is reported ONLY as hashForLogs() hashes — never raw
+ * session ids, cwds, prompts, or OpenCode payloads. */
+export type OpencodeInspectedSession = {
+  sessionIdHash: string
+  status: string
+  hasRealSession: boolean
+  cwdHash?: string
+  monitorArmed: boolean
+  turnAborted?: boolean
+  turnErrored?: boolean
+  lastTurnCompleteAt?: number
+}
+
+/** The sessions map and the idle-recovery monitor registry live in the factory
+ * closure, so incident inspection must be an adapter-INSTANCE method — hence the
+ * intersection type instead of a module-level export. */
+export type OpencodeFreshAgentAdapter = FreshAgentRuntimeAdapter & {
+  inspectSessions(): OpencodeInspectedSession[]
+}
+
 type CreateOpencodeFreshAgentAdapterOptions = {
   serveManager: OpencodeServeManager
   /** Retained ONLY for legacy `freshopencode-*` placeholder resume. */
@@ -157,7 +178,7 @@ async function defaultValidateCwd(cwd: string): Promise<void> {
   if (!info.isDirectory()) throw new Error(`OpenCode cwd is not a directory: ${cwd}`)
 }
 
-export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgentAdapterOptions): FreshAgentRuntimeAdapter {
+export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgentAdapterOptions): OpencodeFreshAgentAdapter {
   const serveManager = options.serveManager
   const recoveryStore = options.recoveryStore ?? getFreshAgentRecoveryStore()
   const turnTimeoutMs = options.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS
@@ -901,6 +922,30 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
 
     sessionStateGeneration(sessionId) {
       return sessions.get(sessionId)?.stateGeneration
+    },
+
+    /** Read-only incident inspection (kata zrrj): a content-free summary of every
+     * tracked session state. The sessions map aliases each state under both its
+     * placeholder and real id, so states are deduped by object identity. Pure map
+     * walk; mutates nothing. */
+    inspectSessions(): OpencodeInspectedSession[] {
+      const seen = new Set<OpencodeSessionState>()
+      const summaries: OpencodeInspectedSession[] = []
+      for (const state of sessions.values()) {
+        if (seen.has(state)) continue
+        seen.add(state)
+        summaries.push({
+          sessionIdHash: hashForLogs(state.realSessionId ?? state.placeholderId),
+          status: state.status,
+          hasRealSession: Boolean(state.realSessionId),
+          ...(state.cwd ? { cwdHash: hashForLogs(state.cwd) } : {}),
+          monitorArmed: state.realSessionId ? idleRecoveryMonitors.has(state.realSessionId) : false,
+          ...(state.turnAborted !== undefined ? { turnAborted: state.turnAborted } : {}),
+          ...(state.turnErrored !== undefined ? { turnErrored: state.turnErrored } : {}),
+          ...(state.lastTurnCompleteAt !== undefined ? { lastTurnCompleteAt: state.lastTurnCompleteAt } : {}),
+        })
+      }
+      return summaries
     },
 
     async send(sessionId, input) {

--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -27,7 +27,7 @@ import {
   createWorkerHistoryReader,
   type OpencodeHistoryReader,
 } from './history-runner.js'
-import type { OpencodeServeManager } from './serve-manager.js'
+import { OpencodeServeLostError, type OpencodeServeManager } from './serve-manager.js'
 import { serveEventToSdk, splitOpencodeModel } from './serve-events.js'
 
 const OPENCODE_REAL_SESSION_ID = /^ses_/
@@ -116,6 +116,27 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
   const log = logger.child({ component: 'freshopencode-serve-adapter' })
   const sessions = new Map<string, OpencodeSessionState>()
 
+  /** Exactly one monitored idle-recovery per durable session key (kata zrrj).
+   * Factory-closure scope: the registry is per adapter instance, so tests get
+   * isolation by constructing a fresh adapter and a second adapter (simulated
+   * restart) cannot suppress or leak this instance's monitors. */
+  type IdleRecoveryMonitor = { promise: Promise<void>; cancelled: boolean }
+  const idleRecoveryMonitors = new Map<string, IdleRecoveryMonitor>()
+
+  /** Real ses_ ids with a user send currently in flight. armIdleRecovery must not arm
+   * while the send path's own onceIdle owns the turn (attach-mid-send double-fire guard). */
+  const sendsInFlight = new Set<string>()
+
+  /** Called by materializeOrSend before arming the send path's own onceIdle so a
+   * still-pending cold monitor cannot double-emit idle/chime for the new turn. */
+  function disarmIdleRecovery(realId: string): void {
+    const existing = idleRecoveryMonitors.get(realId)
+    if (existing) {
+      existing.cancelled = true
+      idleRecoveryMonitors.delete(realId)
+    }
+  }
+
   function remember(state: OpencodeSessionState) {
     sessions.set(state.placeholderId, state)
     if (state.realSessionId) sessions.set(state.realSessionId, state)
@@ -167,7 +188,13 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
   async function reconcileStatus(state: OpencodeSessionState): Promise<void> {
     const realId = state.realSessionId
     if (!realId) return
-    state.status = 'idle'
+    // Reconciliation resolves to idle unless the status map positively reports the
+    // session busy/retry. EMIT the transition (instead of mutating silently) so the
+    // client learns the restored status — but stay quiet on a fresh attach where the
+    // state is already idle, to avoid snapshot noise (kata zrrj).
+    const settleIdle = () => {
+      if (state.status !== 'idle') emitStatus(state, 'idle')
+    }
     const getSessionStatus = (serveManager as { getSessionStatus?: (sessionId: string, route?: { cwd?: string }) => Promise<{ type?: unknown } | undefined> }).getSessionStatus
     const logContext = {
       provider: 'opencode',
@@ -179,6 +206,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
         ...logContext,
         reason: 'missing_get_session_status',
       }, 'opencode status reconciliation skipped')
+      settleIdle()
       return
     }
     try {
@@ -187,27 +215,36 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       // so an idle session is absent (undefined). Treat a missing entry as idle —
       // consistent with the serve manager's onceIdle treatment of absence as idle —
       // rather than logging a false-positive malformed warning.
-      if (status == null) return
+      if (status == null) {
+        settleIdle()
+        return
+      }
       if (typeof status !== 'object' || Array.isArray(status) || typeof status.type !== 'string') {
         log.warn({
           ...logContext,
           reason: 'malformed_session_status',
           status,
         }, 'opencode status reconciliation received malformed status')
+        settleIdle()
         return
       }
       const type = status.type
       if (type === 'busy' || type === 'retry') {
-        state.status = 'running'
+        emitStatus(state, 'running')
+        // A restored running session needs a waiter or no idle/turn-complete ever
+        // arrives. armIdleRecovery dedupes against existing monitors AND against an
+        // in-flight send (whose own onceIdle owns the turn).
+        armIdleRecovery(state)
         return
       }
-      if (type === 'idle') return
+      settleIdle()
     } catch (err) {
       log.warn({
         ...logContext,
         err,
         reason: 'get_session_status_failed',
       }, 'opencode status reconciliation failed')
+      settleIdle()
     }
   }
 
@@ -284,30 +321,49 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
    * client first subscribed with. */
   function bindServeStream(state: OpencodeSessionState): void {
     if (state.unsubscribeServe || !state.realSessionId) return
-    state.unsubscribeServe = serveManager.subscribe(state.realSessionId, (parsed) => {
-      const mapped = serveEventToSdk(parsed, state.placeholderId)
-      if (mapped) {
-        if (mapped.type === 'sdk.error') {
-          // A turn error means the in-flight turn did not positively complete; the
-          // success path consults this when onceIdle later resolves on the post-error idle.
-          state.turnErrored = true
+    state.unsubscribeServe = serveManager.subscribe(
+      state.realSessionId,
+      (parsed) => {
+        const mapped = serveEventToSdk(parsed, state.placeholderId)
+        if (mapped) {
+          if (mapped.type === 'sdk.error') {
+            // A turn error means the in-flight turn did not positively complete; the
+            // success path consults this when onceIdle later resolves on the post-error idle.
+            state.turnErrored = true
+          }
+          if (mapped.type === 'sdk.session.snapshot') {
+            const status: 'running' | 'idle' = mapped.status === 'idle' ? 'idle' : 'running'
+            state.status = status
+            recordFreshAgentObservabilityEvent({
+              kind: 'fresh_agent_opencode_status_observed',
+              provider: 'opencode',
+              sessionIdHash: hashForLogs(state.realSessionId ?? state.placeholderId),
+              status,
+              source: 'sse',
+              opencodeEventKind: parsed.kind,
+              ...(state.cwd ? { cwdHash: hashForLogs(state.cwd) } : {}),
+            })
+          }
+          state.events.emit('event', mapped)
         }
-        if (mapped.type === 'sdk.session.snapshot') {
-          const status: 'running' | 'idle' = mapped.status === 'idle' ? 'idle' : 'running'
-          state.status = status
-          recordFreshAgentObservabilityEvent({
-            kind: 'fresh_agent_opencode_status_observed',
-            provider: 'opencode',
-            sessionIdHash: hashForLogs(state.realSessionId ?? state.placeholderId),
-            status,
-            source: 'sse',
-            opencodeEventKind: parsed.kind,
-            ...(state.cwd ? { cwdHash: hashForLogs(state.cwd) } : {}),
+      },
+      () => {
+        // Sidecar lost while this session shows running: never leave the pane busy.
+        // Idempotent with the idle-recovery monitor's own loss reaction — whichever runs
+        // first flips status to idle and the other no-ops on the status guard, so one
+        // loss yields exactly one structured interruption. (With survive-replacement
+        // emitters, this same subscription keeps receiving events from a replacement
+        // sidecar — no rebind needed.)
+        if (state.status === 'running') {
+          emitStatus(state, 'idle')
+          state.events.emit('event', {
+            type: 'sdk.error',
+            sessionId: state.placeholderId,
+            message: 'OpenCode turn interrupted: sidecar connection was lost while the turn was running.',
           })
         }
-        state.events.emit('event', mapped)
-      }
-    })
+      },
+    )
   }
 
   function emitStatus(state: OpencodeSessionState, status: 'running' | 'idle'): void {
@@ -321,6 +377,81 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       source: 'adapter',
       ...(state.cwd ? { cwdHash: hashForLogs(state.cwd) } : {}),
     })
+  }
+
+  /** Arm the restore idle-recovery monitor for a durable session reconciled as busy.
+   * Exactly one monitor per real ses_ id; no-op while a user send is in flight (its own
+   * onceIdle owns the turn). Resolve emits idle (+ chime unless the turn aborted/errored);
+   * reject (timeout / sidecar loss) emits idle + a structured interruption signal so the
+   * pane is never left busy forever. */
+  function armIdleRecovery(state: OpencodeSessionState): void {
+    const realId = state.realSessionId
+    if (!realId) return
+    if (idleRecoveryMonitors.has(realId) || sendsInFlight.has(realId)) {
+      // Second disjunct: attach-mid-send guard — the send path's own onceIdle owns this turn.
+      recordFreshAgentObservabilityEvent({
+        kind: 'fresh_agent_monitor',
+        provider: 'opencode',
+        sessionIdHash: hashForLogs(realId),
+        ...(state.cwd ? { cwdHash: hashForLogs(state.cwd) } : {}),
+        phase: 'duplicate_suppressed',
+      })
+      return
+    }
+    const route = cwdRoute(state.cwd)
+    const generation = typeof serveManager.currentGeneration === 'function' ? serveManager.currentGeneration() : undefined
+    const monitorEvent = (phase: 'armed' | 'resolved_idle' | 'timeout' | 'sidecar_lost') =>
+      recordFreshAgentObservabilityEvent({
+        kind: 'fresh_agent_monitor',
+        provider: 'opencode',
+        sessionIdHash: hashForLogs(realId),
+        ...(state.cwd ? { cwdHash: hashForLogs(state.cwd) } : {}),
+        phase,
+        ...(generation !== undefined ? { sidecarGeneration: generation } : {}),
+      })
+    monitorEvent('armed')
+    const monitor: IdleRecoveryMonitor = { promise: Promise.resolve(), cancelled: false }
+    // assumeActive: arming always follows a reconcile that OBSERVED busy, so seed the
+    // activity gate — without it, a turn that finished in the read->arm gap hangs to the
+    // 10-min timeout and emits a false "interrupted" (A4).
+    const idle = route
+      ? serveManager.onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS, route, { assumeActive: true })
+      : serveManager.onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS, undefined, { assumeActive: true })
+    monitor.promise = idle
+      .then(() => {
+        if (monitor.cancelled) return // disarmed by a newer user send — its own onceIdle owns this turn
+        emitStatus(state, 'idle')
+        monitorEvent('resolved_idle')
+        // Restored sessions have both flags undefined -> falsy -> chime allowed; the
+        // pre-restart error is unobservable and OpenCode reporting busy->idle is the
+        // best positive-completion signal available.
+        if (!state.turnAborted && !state.turnErrored) {
+          const completionAt = nextMonotonicTurnCompleteAt(state.lastTurnCompleteAt, Date.now())
+          state.lastTurnCompleteAt = completionAt
+          state.events.emit('event', { type: 'sdk.turn.complete', sessionId: state.placeholderId, at: completionAt })
+        }
+      })
+      .catch((error: unknown) => {
+        if (monitor.cancelled) return
+        const lost = error instanceof OpencodeServeLostError
+        monitorEvent(lost ? 'sidecar_lost' : 'timeout')
+        // Status guard makes the loss reaction idempotent with bindServeStream's onLost
+        // handler: whichever runs first flips status to idle; the other becomes a no-op,
+        // so one loss yields exactly one structured interruption emission.
+        if (state.status !== 'running') return
+        emitStatus(state, 'idle')
+        state.events.emit('event', {
+          type: 'sdk.error',
+          sessionId: state.placeholderId,
+          message: lost
+            ? 'OpenCode turn interrupted: sidecar connection was lost while the turn was running.'
+            : 'OpenCode turn interrupted: idle recovery timed out.',
+        })
+      })
+      .finally(() => {
+        if (idleRecoveryMonitors.get(realId) === monitor) idleRecoveryMonitors.delete(realId)
+      })
+    idleRecoveryMonitors.set(realId, monitor)
   }
 
   function emitMaterialized(state: OpencodeSessionState): void {
@@ -364,34 +495,46 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
 
       const realId = state.realSessionId!
       await ensureMutableRoute(state)
-      const idleRoute = cwdRoute(state.cwd)
-      const idle = idleRoute
-        ? serveManager.onceIdle(realId, turnTimeoutMs, idleRoute)
-        : serveManager.onceIdle(realId, turnTimeoutMs)
-      // If promptAsync fails and we leave via the catch(), `idle` may still
-      // reject later on its timeout timer. Attach a no-op handler now so that
-      // later rejection cannot become an unhandled rejection.
-      void idle.catch(() => {})
-      await promptAsyncForState(state, realId, {
-        parts: [{ type: 'text', text }],
-        ...(splitOpencodeModel(modelStr) ? { model: splitOpencodeModel(modelStr)! } : {}),
-        ...(effort ? { variant: effort } : {}),
-      })
-      await idle
-      state.model = modelStr ?? state.model
-      state.effort = effort
-      emitStatus(state, 'idle')
-      // Server-authoritative turn-complete edge for the GREEN/SOUND pipeline. onceIdle
-      // resolves on ANY idle — including the idle an interrupt's abort triggers or the idle
-      // that follows an errored turn — so a positive completion requires that the turn was
-      // neither interrupted nor errored. (The catch below for abort/interrupt/sidecar loss
-      // and the serve SSE idle relay also never chime.)
-      if (!state.turnAborted && !state.turnErrored) {
-        const completionAt = nextMonotonicTurnCompleteAt(state.lastTurnCompleteAt, Date.now())
-        state.lastTurnCompleteAt = completionAt
-        state.events.emit('event', { type: 'sdk.turn.complete', sessionId: state.placeholderId, at: completionAt })
+      // The user send owns this turn: cancel any still-pending restore idle-recovery
+      // monitor (it would otherwise resolve on THIS turn's idle and double-emit
+      // idle/chime), and flag the send so armIdleRecovery cannot arm a second waiter
+      // while we are parked on our own onceIdle (attach-mid-send).
+      disarmIdleRecovery(realId)
+      sendsInFlight.add(realId)
+      try {
+        const idleRoute = cwdRoute(state.cwd)
+        const idle = idleRoute
+          ? serveManager.onceIdle(realId, turnTimeoutMs, idleRoute)
+          : serveManager.onceIdle(realId, turnTimeoutMs)
+        // If promptAsync fails and we leave via the catch(), `idle` may still
+        // reject later on its timeout timer. Attach a no-op handler now so that
+        // later rejection cannot become an unhandled rejection.
+        void idle.catch(() => {})
+        await promptAsyncForState(state, realId, {
+          parts: [{ type: 'text', text }],
+          ...(splitOpencodeModel(modelStr) ? { model: splitOpencodeModel(modelStr)! } : {}),
+          ...(effort ? { variant: effort } : {}),
+        })
+        await idle
+        state.model = modelStr ?? state.model
+        state.effort = effort
+        emitStatus(state, 'idle')
+        // Server-authoritative turn-complete edge for the GREEN/SOUND pipeline. onceIdle
+        // resolves on ANY idle — including the idle an interrupt's abort triggers or the idle
+        // that follows an errored turn — so a positive completion requires that the turn was
+        // neither interrupted nor errored. (The catch below for abort/interrupt/sidecar loss
+        // and the serve SSE idle relay also never chime.)
+        if (!state.turnAborted && !state.turnErrored) {
+          const completionAt = nextMonotonicTurnCompleteAt(state.lastTurnCompleteAt, Date.now())
+          state.lastTurnCompleteAt = completionAt
+          state.events.emit('event', { type: 'sdk.turn.complete', sessionId: state.placeholderId, at: completionAt })
+        }
+        return sendResult(state.realSessionId)
+      } finally {
+        // The send's turn has settled either way; a later restore/attach may arm a
+        // monitor again.
+        sendsInFlight.delete(realId)
       }
-      return sendResult(state.realSessionId)
     } catch (error) {
       emitStatus(state, 'idle')
       throw error
@@ -585,6 +728,8 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       const state = requireState(sessionId)
       await ensureMutableRoute(state)
       try { state.unsubscribeServe?.() } catch { /* ignore */ }
+      // A killed session must not receive a late monitor idle/interruption emission.
+      if (state.realSessionId) disarmIdleRecovery(state.realSessionId)
       sessions.delete(state.placeholderId)
       if (state.realSessionId) sessions.delete(state.realSessionId)
       return true

--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -17,6 +17,11 @@ import {
   recordFreshAgentObservabilityEvent,
 } from '../../observability.js'
 import {
+  type FreshAgentRecoveryStore,
+  getFreshAgentRecoveryStore,
+} from '../../recovery-store.js'
+import { detectInterruptedTurn } from './interrupted-turn.js'
+import {
   type OpencodeExport,
   normalizeOpencodeSnapshot,
   normalizeOpencodeTurnBody,
@@ -33,6 +38,12 @@ import { serveEventToSdk, splitOpencodeModel } from './serve-events.js'
 const OPENCODE_REAL_SESSION_ID = /^ses_/
 const OPENCODE_PLACEHOLDER_SESSION_ID = /^freshopencode-/
 const DEFAULT_TURN_TIMEOUT_MS = 600_000
+
+/** Freshell-OWNED continuation instruction for a recovered interrupted turn. Never echoes
+ * user text; safe to hardcode. It appears in the transcript as a user-role message — that
+ * IS the visible transcript marker for the recovery. */
+const FRESHELL_CONTINUATION_PROMPT =
+  'Freshell detected that your previous response was interrupted (for example by a restart). Please continue exactly where you left off. If the work was already complete, briefly confirm the final result.'
 
 /** Module-scope monotonic counter for OpencodeSessionState identity. Holds no
  * per-instance state; every newly constructed state gets the next value. */
@@ -77,6 +88,12 @@ type OpencodeSessionState = {
    * licenses the client's snapshot busy-clear gate (kata zrrj, Task 4's server half).
    */
   initialReconcileCompleted?: boolean
+  /**
+   * The in-flight interrupted-turn recovery pass kicked off by resume/attach (kata zrrj).
+   * Fire-and-forget for callers (restore must never fail because recovery failed); kept
+   * on the state for test determinism. Never rejects — failures are logged internally.
+   */
+  pendingRecovery?: Promise<void>
 }
 
 type CreateOpencodeFreshAgentAdapterOptions = {
@@ -88,6 +105,9 @@ type CreateOpencodeFreshAgentAdapterOptions = {
   turnTimeoutMs?: number
   validateCwd?: (cwd: string) => Promise<void>
   canonicalizePath?: (cwd: string) => Promise<string>
+  /** Durable interrupt-intent + recovery ledger (kata zrrj). Tests inject a store on a
+   * temp file; production defaults to the process-wide singleton. */
+  recoveryStore?: FreshAgentRecoveryStore
 }
 
 function makePlaceholderId(requestId: string): string {
@@ -110,6 +130,7 @@ async function defaultValidateCwd(cwd: string): Promise<void> {
 
 export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgentAdapterOptions): FreshAgentRuntimeAdapter {
   const serveManager = options.serveManager
+  const recoveryStore = options.recoveryStore ?? getFreshAgentRecoveryStore()
   const turnTimeoutMs = options.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS
   const validateCwd = options.validateCwd ?? defaultValidateCwd
   const canonicalizePath = options.canonicalizePath ?? realpath
@@ -473,7 +494,12 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
     })
   }
 
-  async function materializeOrSend(state: OpencodeSessionState, text: string, settings?: Partial<FreshAgentCreateRequest>): Promise<FreshAgentSendResult> {
+  async function materializeOrSend(
+    state: OpencodeSessionState,
+    text: string,
+    settings?: Partial<FreshAgentCreateRequest>,
+    opts?: { freshellContinuation?: boolean },
+  ): Promise<FreshAgentSendResult> {
     const normalized = settings
       ? normalizeOpencodeInput({ requestId: state.placeholderId, sessionType: 'freshopencode', provider: 'opencode', ...settings } as FreshAgentCreateRequest)
       : undefined
@@ -504,6 +530,12 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
 
       const realId = state.realSessionId!
       await ensureMutableRoute(state)
+      if (!opts?.freshellContinuation) {
+        // A user follow-up cancels any recorded stop intent (kata zrrj). Freshell-owned
+        // continuation sends are internal and must NOT clear it — otherwise a recovery
+        // injection would erase the very intent that gates future recoveries.
+        await recoveryStore.clearInterrupt(realId)
+      }
       // The user send owns this turn: cancel any still-pending restore idle-recovery
       // monitor (it would otherwise resolve on THIS turn's idle and double-emit
       // idle/chime), and flag the send so armIdleRecovery cannot arm a second waiter
@@ -548,6 +580,111 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       emitStatus(state, 'idle')
       throw error
     }
+  }
+
+  /** Send-queue entry shared by the public send() and the recovery continuation: every
+   * send is serialized on the state's queue, route-validated (ensureMutableRoute) and
+   * armed with onceIdle inside materializeOrSend. */
+  async function sendForState(
+    state: OpencodeSessionState,
+    input: { text: string; settings?: Partial<FreshAgentCreateRequest>; freshellContinuation?: boolean },
+  ): Promise<FreshAgentSendResult> {
+    const opts = { freshellContinuation: input.freshellContinuation }
+    const run = state.sendQueue.then(
+      () => materializeOrSend(state, input.text, input.settings, opts),
+      () => materializeOrSend(state, input.text, input.settings, opts),
+    )
+    state.sendQueue = run.catch(() => undefined)
+    return await run
+  }
+
+  type TurnRecoveryAction =
+    | 'continuation_injected'
+    | 'suppressed_user_stop'
+    | 'suppressed_user_followup'
+    | 'suppressed_already_recovered'
+    | 'suppressed_low_confidence'
+    | 'suppressed_no_route'
+
+  /** Restore-time interrupted-turn recovery (kata zrrj): after a resume/attach reconciled
+   * the session as idle, inspect the live transcript and inject at most ONE Freshell-owned
+   * continuation per failed turn. Gates, in order: durable user stop intent, evidence-based
+   * detection, route/mutability precondition, then the persisted once-per-(session, message)
+   * ledger — recorded BEFORE injection so a crash can never double-recover. Never throws. */
+  async function maybeRecoverInterruptedTurn(state: OpencodeSessionState): Promise<void> {
+    const realId = state.realSessionId
+    if (!realId) return
+    const audit = (action: TurnRecoveryAction, reason: string, messageId?: string) =>
+      recordFreshAgentObservabilityEvent({
+        kind: 'fresh_agent_turn_recovery',
+        provider: 'opencode',
+        sessionIdHash: hashForLogs(realId),
+        ...(state.cwd ? { cwdHash: hashForLogs(state.cwd) } : {}),
+        action,
+        reason,
+        ...(messageId ? { messageIdHash: hashForLogs(messageId) } : {}),
+      })
+    try {
+      if (await recoveryStore.hasInterrupt(realId)) {
+        // NEVER auto-recover after an explicit user stop.
+        audit('suppressed_user_stop', 'user_interrupt_on_record')
+        return
+      }
+      const route = cwdRoute(state.cwd)
+      const page = route
+        ? await serveManager.listMessages(realId, { limit: DEFAULT_SNAPSHOT_TURN_LIMIT }, route)
+        : await serveManager.listMessages(realId, { limit: DEFAULT_SNAPSHOT_TURN_LIMIT })
+      const verdict = detectInterruptedTurn(page.messages, { nowMs: Date.now() })
+      if (!verdict.interrupted) {
+        if (verdict.reason === 'last_message_not_assistant') {
+          audit('suppressed_user_followup', verdict.reason)
+        } else if (verdict.reason !== 'empty_transcript') {
+          audit('suppressed_low_confidence', verdict.reason)
+        }
+        return
+      }
+      if (!verdict.messageId) {
+        // An id-less trailing message cannot be tracked in the per-(session, message)
+        // ledger, so an injection could never be made once-only. Err on the safe side.
+        audit('suppressed_low_confidence', 'missing_message_id')
+        return
+      }
+      // Route/mutability precondition BEFORE any ledger write (A6/N-V1a):
+      // ensureMutableRoute throws for a non-provider-created state without a cwd. If we
+      // recorded the recovery first and the send then threw, the (session, message)
+      // ledger entry would be permanently burned — a later cwd-bearing attach could never
+      // recover this turn. So: no usable route -> audit and return WITHOUT recording.
+      const hasUsableRoute = state.providerCreatedInThisAdapter
+        || (typeof state.cwd === 'string' && state.cwd.trim().length > 0)
+      if (!hasUsableRoute) {
+        audit('suppressed_no_route', 'no_cwd_for_mutation', verdict.messageId)
+        return
+      }
+      if (await recoveryStore.hasRecovery(realId, verdict.messageId)) {
+        audit('suppressed_already_recovered', 'ledger_hit', verdict.messageId)
+        return
+      }
+      // Record BEFORE injecting: crash-safe loop prevention. Accepted residual: a
+      // transient send failure after this write burns the one allowed recovery for the
+      // turn — errs on the safe side (never risks double injection).
+      await recoveryStore.recordRecovery(realId, verdict.messageId)
+      audit('continuation_injected', verdict.evidence.join(','), verdict.messageId)
+      state.events.emit('event', {
+        type: 'sdk.session.changed', sessionId: state.placeholderId, reason: 'freshell-turn-recovery',
+      })
+      await sendForState(state, { text: FRESHELL_CONTINUATION_PROMPT, freshellContinuation: true })
+    } catch (error) {
+      log.warn({ provider: 'opencode', sessionIdHash: hashForLogs(realId), err: error }, 'interrupted-turn recovery failed')
+    }
+  }
+
+  /** Fire-and-forget recovery kickoff after reconcileStatus on resume/attach. Only an
+   * idle-reconciled restore is a candidate — a running session is being monitored by
+   * armIdleRecovery; if that monitor later reports loss, the NEXT restore attempt will
+   * find the unfinished transcript and recover it here. */
+  function scheduleInterruptedTurnRecovery(state: OpencodeSessionState): void {
+    if (state.status !== 'idle') return
+    state.pendingRecovery = maybeRecoverInterruptedTurn(state)
   }
 
   async function assembleExport(
@@ -613,6 +750,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
         remember(state)
         bindServeStream(state)
         await reconcileStatus(state)
+        scheduleInterruptedTurnRecovery(state)
         return { sessionId: real, sessionRef: { provider: 'opencode', sessionId: real } }
       }
       if (!isRealOpencodeSessionId(sessionId)) {
@@ -625,6 +763,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       remember(state)
       bindServeStream(state)
       await reconcileStatus(state)
+      scheduleInterruptedTurnRecovery(state)
       return { sessionId, sessionRef: { provider: 'opencode', sessionId } }
     },
 
@@ -641,6 +780,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
         }
         remember(existing)
         await reconcileStatus(existing)
+        scheduleInterruptedTurnRecovery(existing)
         return { sessionId: locator.sessionId, sessionRef: { provider: 'opencode', sessionId: locator.sessionId } }
       }
       if (isPlaceholderOpencodeSessionId(locator.sessionId) || !isRealOpencodeSessionId(locator.sessionId)) {
@@ -660,6 +800,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       remember(state)
       bindServeStream(state)
       await reconcileStatus(state)
+      scheduleInterruptedTurnRecovery(state)
       return { sessionId: locator.sessionId, sessionRef: { provider: 'opencode', sessionId: locator.sessionId } }
     },
 
@@ -676,12 +817,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
 
     async send(sessionId, input) {
       const state = requireState(sessionId)
-      const run = state.sendQueue.then(
-        () => materializeOrSend(state, input.text, input.settings),
-        () => materializeOrSend(state, input.text, input.settings),
-      )
-      state.sendQueue = run.catch(() => undefined)
-      return await run
+      return await sendForState(state, { text: input.text, settings: input.settings })
     },
 
     async interrupt(sessionId) {
@@ -689,12 +825,20 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       // Mark before aborting so the in-flight send (parked on onceIdle) sees the abort and
       // suppresses its turn-complete chime when the abort-triggered idle resolves it.
       state.turnAborted = true
+      const realId = state.realSessionId
       try {
+        // Record the user's explicit stop intent durably BEFORE the abort lands (kata
+        // zrrj): if the process dies right after the abort, a later restore must already
+        // see the intent and never auto-recover a turn the user deliberately stopped.
+        if (realId) await recoveryStore.recordInterrupt(realId)
         await abortForState(state)
       } catch (error) {
         // The abort never landed, so the turn may still complete normally — clear the flag
-        // so a genuine completion is not silently swallowed.
+        // so a genuine completion is not silently swallowed, and roll back the durable
+        // stop intent (mirroring the turnAborted rollback) so a genuine later
+        // interruption can still be recovered.
         state.turnAborted = false
+        if (realId) await recoveryStore.clearInterrupt(realId).catch(() => undefined)
         throw error
       }
       emitStatus(state, 'idle')

--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -70,6 +70,13 @@ type OpencodeSessionState = {
    * and Codex's `status === 'completed'`.
    */
   turnErrored?: boolean
+  /**
+   * True once reconcileStatus's getSessionStatus read has resolved to a trustworthy
+   * answer (busy/retry, or confirmed idle via absence / a non-busy status). Left unset
+   * on the error-swallow and malformed/missing-helper fallbacks, so a failed read never
+   * licenses the client's snapshot busy-clear gate (kata zrrj, Task 4's server half).
+   */
+  initialReconcileCompleted?: boolean
 }
 
 type CreateOpencodeFreshAgentAdapterOptions = {
@@ -216,6 +223,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       // consistent with the serve manager's onceIdle treatment of absence as idle —
       // rather than logging a false-positive malformed warning.
       if (status == null) {
+        state.initialReconcileCompleted = true
         settleIdle()
         return
       }
@@ -229,6 +237,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
         return
       }
       const type = status.type
+      state.initialReconcileCompleted = true
       if (type === 'busy' || type === 'retry') {
         emitStatus(state, 'running')
         // A restored running session needs a waiter or no idle/turn-complete ever
@@ -752,6 +761,9 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
         sessionType: 'freshopencode', threadId: thread.threadId,
         exported: { ...exported, info: { ...(exported.info ?? {}), time: { ...((exported.info?.time) ?? {}), updated: revision } } },
         status: liveState?.status ?? 'idle', model: liveState?.model, effort: liveState?.effort,
+        // Task 4's client busy-clear gate: only a snapshot whose status comes from live,
+        // reconciled adapter state may clear busy; the untracked default above must not.
+        statusFromLiveState: liveState?.initialReconcileCompleted === true,
       })
     },
 

--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -32,12 +32,23 @@ import {
   createWorkerHistoryReader,
   type OpencodeHistoryReader,
 } from './history-runner.js'
-import { OpencodeServeLostError, type OpencodeServeManager } from './serve-manager.js'
+import { OpencodeServeLostError, type OpencodeServeManager, type OpencodeServeMessage } from './serve-manager.js'
 import { serveEventToSdk, splitOpencodeModel } from './serve-events.js'
 
 const OPENCODE_REAL_SESSION_ID = /^ses_/
 const OPENCODE_PLACEHOLDER_SESSION_ID = /^freshopencode-/
 const DEFAULT_TURN_TIMEOUT_MS = 600_000
+
+/** Transcript-settle freshness proof (kata zrrj): after onceIdle resolves, the final
+ * assistant message must be provably queryable on the REST read path before the adapter
+ * declares the turn complete — `session.idle` carries no ordering guarantee relative to
+ * message persistence, so the client's post-idle snapshot could otherwise miss the answer. */
+const TRANSCRIPT_SETTLE_POLL_MS = 150
+const TRANSCRIPT_SETTLE_MAX_POLLS = 10 // ~1.5 s worst case
+const TRANSCRIPT_SETTLE_PAGE_LIMIT = 20
+const CLOCK_SKEW_MS = 5_000
+
+const defaultSettleSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
 
 /** Freshell-OWNED continuation instruction for a recovered interrupted turn. Never echoes
  * user text; safe to hardcode. It appears in the transcript as a user-role message — that
@@ -108,6 +119,24 @@ type CreateOpencodeFreshAgentAdapterOptions = {
   /** Durable interrupt-intent + recovery ledger (kata zrrj). Tests inject a store on a
    * temp file; production defaults to the process-wide singleton. */
   recoveryStore?: FreshAgentRecoveryStore
+  /** Sleep between transcript-settle polls (kata zrrj). Tests inject a no-op so the
+   * poll budget drains in microtasks; production defaults to a real setTimeout sleep. */
+  settleSleep?: (ms: number) => Promise<void>
+}
+
+/** True when the page contains an assistant message created at/after `sentAtMs`
+ * (minus clock skew) whose `time.completed` is finite — i.e. the final answer is
+ * visible AND complete on the REST read path. */
+function hasSettledAssistantMessage(messages: OpencodeServeMessage[], sentAtMs: number): boolean {
+  return messages.some((message) => {
+    const info = message?.info
+    if (!info || typeof info !== 'object') return false
+    if (info.role !== 'assistant') return false
+    const time = info.time
+    if (!time || typeof time !== 'object') return false
+    if (!Number.isFinite(time.completed)) return false
+    return typeof time.created === 'number' && time.created >= sentAtMs - CLOCK_SKEW_MS
+  })
 }
 
 function makePlaceholderId(requestId: string): string {
@@ -132,6 +161,7 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
   const serveManager = options.serveManager
   const recoveryStore = options.recoveryStore ?? getFreshAgentRecoveryStore()
   const turnTimeoutMs = options.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS
+  const settleSleep = options.settleSleep ?? defaultSettleSleep
   const validateCwd = options.validateCwd ?? defaultValidateCwd
   const canonicalizePath = options.canonicalizePath ?? realpath
   const dbPath = options.dbPath ?? path.join(options.dataHome ?? defaultOpencodeDataHome(), 'opencode.db')
@@ -409,6 +439,41 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
     })
   }
 
+  /**
+   * After idle, verify the final assistant message is queryable via the REST
+   * read path before declaring the turn complete (kata zrrj freshness contract).
+   * Returns true when settled; false when polling exhausted (idle is still
+   * emitted — the turn is not stranded — but the client re-poll covers the gap).
+   *
+   * Settled means: the newest page of `listMessages` contains an assistant message
+   * created at/after `sentAtMs` (minus CLOCK_SKEW_MS) with a finite `time.completed`.
+   * `sentAtMs = 0` accepts ANY completed assistant message (restore monitor path,
+   * where the pre-restart send time is unknowable).
+   */
+  async function awaitTranscriptSettled(state: OpencodeSessionState, sentAtMs: number): Promise<boolean> {
+    const realId = state.realSessionId
+    if (!realId) return true
+    const route = cwdRoute(state.cwd)
+    for (let attempt = 0; attempt <= TRANSCRIPT_SETTLE_MAX_POLLS; attempt++) {
+      if (attempt > 0) await settleSleep(TRANSCRIPT_SETTLE_POLL_MS)
+      try {
+        const page = route
+          ? await serveManager.listMessages(realId, { limit: TRANSCRIPT_SETTLE_PAGE_LIMIT }, route)
+          : await serveManager.listMessages(realId, { limit: TRANSCRIPT_SETTLE_PAGE_LIMIT })
+        if (hasSettledAssistantMessage(page.messages, sentAtMs)) return true
+      } catch {
+        // A transient read failure counts as an unsettled poll; the budget bounds it.
+      }
+    }
+    log.warn({
+      provider: 'opencode',
+      sessionIdHash: hashForLogs(realId),
+      ...(state.cwd ? { cwdHash: hashForLogs(state.cwd) } : {}),
+      polls: TRANSCRIPT_SETTLE_MAX_POLLS + 1,
+    }, 'transcript did not settle after idle')
+    return false
+  }
+
   /** Arm the restore idle-recovery monitor for a durable session reconciled as busy.
    * Exactly one monitor per real ses_ id; no-op while a user send is in flight (its own
    * onceIdle owns the turn). Resolve emits idle (+ chime unless the turn aborted/errored);
@@ -448,8 +513,13 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       ? serveManager.onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS, route, { assumeActive: true })
       : serveManager.onceIdle(realId, DEFAULT_TURN_TIMEOUT_MS, undefined, { assumeActive: true })
     monitor.promise = idle
-      .then(() => {
+      .then(async () => {
         if (monitor.cancelled) return // disarmed by a newer user send — its own onceIdle owns this turn
+        // Freshness proof (kata zrrj): before declaring the recovered turn complete, prove
+        // the REST read path can serve a completed assistant message. sentAtMs = 0: the
+        // pre-restart send time is unknowable, so ANY completed assistant message settles.
+        await awaitTranscriptSettled(state, 0)
+        if (monitor.cancelled) return // a user send may have disarmed us while settling
         emitStatus(state, 'idle')
         monitorEvent('resolved_idle')
         // Restored sessions have both flags undefined -> falsy -> chime allowed; the
@@ -551,12 +621,19 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
         // reject later on its timeout timer. Attach a no-op handler now so that
         // later rejection cannot become an unhandled rejection.
         void idle.catch(() => {})
+        // Freshness anchor (kata zrrj): the settle proof below accepts only assistant
+        // messages created at/after this send (minus clock skew).
+        const sentAtMs = Date.now()
         await promptAsyncForState(state, realId, {
           parts: [{ type: 'text', text }],
           ...(splitOpencodeModel(modelStr) ? { model: splitOpencodeModel(modelStr)! } : {}),
           ...(effort ? { variant: effort } : {}),
         })
         await idle
+        // Prove the final assistant message is queryable via the REST read path BEFORE
+        // emitting idle/turn-complete — session.idle does not sequence behind message
+        // persistence, so the client's post-idle snapshot could otherwise miss the answer.
+        await awaitTranscriptSettled(state, sentAtMs)
         state.model = modelStr ?? state.model
         state.effort = effort
         emitStatus(state, 'idle')

--- a/server/fresh-agent/adapters/opencode/interrupted-turn.ts
+++ b/server/fresh-agent/adapters/opencode/interrupted-turn.ts
@@ -1,0 +1,87 @@
+/** Evidence-based interrupted-turn detector for OpenCode transcripts (kata zrrj).
+ *
+ * The OpenCode DB has NO persisted "interrupted" status field — interruption is
+ * detected purely from transcript/tool evidence over the raw sidecar messages
+ * (`{ info, parts }` shapes, same as normalize.ts reads). Pure function: no I/O,
+ * no timers — the stability window is data-driven via `options.nowMs`.
+ *
+ * Validated against live opencode 1.18.x data (94k-assistant-message census,
+ * 0 false positives for this gate). Two load-bearing semantics from that census:
+ * - Aborted turns DO carry `time.completed` (all 203 MessageAbortedError rows),
+ *   so `missing_completion` will NOT fire for them — the `aborted_error`-alone
+ *   definitive branch is required, not optional.
+ * - `info.error.data.name` never occurs on 1.18.x; the second read is a
+ *   defensive fallback for future sidecar drift. Keep it, expect it dead.
+ */
+
+export type InterruptedTurnVerdict =
+  | { interrupted: false; reason: string }
+  | {
+      interrupted: true
+      messageId: string
+      /** Which evidence fired — for the audit log and the transcript event. */
+      evidence: Array<
+        'missing_completion' | 'aborted_error' | 'running_tool_part' | 'zero_output_tokens' | 'missing_step_finish'
+      >
+    }
+
+export const INTERRUPTED_TURN_STABILITY_MS = 15_000
+
+export function detectInterruptedTurn(
+  messages: Array<{ info: Record<string, any>; parts: Array<Record<string, any>> }>,
+  options: { nowMs: number; stabilityMs?: number },
+): InterruptedTurnVerdict {
+  // Rule 1: only a trailing assistant message can be an interrupted turn. A
+  // trailing user message means the user already typed a follow-up — never
+  // auto-recover then.
+  const last = messages.at(-1)
+  if (!last) return { interrupted: false, reason: 'empty_transcript' }
+  const info = last.info ?? {}
+  if (info?.role !== 'assistant') return { interrupted: false, reason: 'last_message_not_assistant' }
+
+  // Rule 2: stability window — a still-writing DB/sidecar row must not be
+  // recovered prematurely.
+  const stabilityMs = options.stabilityMs ?? INTERRUPTED_TURN_STABILITY_MS
+  const created = Number.isFinite(info?.time?.created) ? Number(info.time.created) : 0
+  const updated = Number.isFinite(info?.time?.updated) ? Number(info.time.updated) : 0
+  if (options.nowMs - Math.max(created, updated) < stabilityMs) {
+    return { interrupted: false, reason: 'within_stability_window' }
+  }
+
+  // Rule 3: collect evidence on the trailing assistant message.
+  const parts = Array.isArray(last.parts) ? last.parts : []
+  const missingCompletion = !Number.isFinite(info?.time?.completed)
+  const abortedError =
+    info?.error?.name === 'MessageAbortedError' || info?.error?.data?.name === 'MessageAbortedError'
+  const runningToolPart = parts.some((part) => part?.type === 'tool' && part?.state?.status === 'running')
+  let stepStartCount = 0
+  let stepFinishCount = 0
+  for (const part of parts) {
+    if (part?.type === 'step-start') stepStartCount += 1
+    if (part?.type === 'step-finish') stepFinishCount += 1
+  }
+  const missingStepFinish = stepStartCount > 0 && stepFinishCount === 0
+  // Zero output tokens alone is too weak — a legitimate tool-only turn can have
+  // 0 output tokens — so it only counts alongside at least one other item.
+  const zeroOutputTokens =
+    info?.tokens?.output === 0 && (missingCompletion || abortedError || runningToolPart || missingStepFinish)
+
+  // Stable order keeps consumers/tests deterministic.
+  const evidence = [
+    ...(missingCompletion ? (['missing_completion'] as const) : []),
+    ...(abortedError ? (['aborted_error'] as const) : []),
+    ...(runningToolPart ? (['running_tool_part'] as const) : []),
+    ...(zeroOutputTokens ? (['zero_output_tokens'] as const) : []),
+    ...(missingStepFinish ? (['missing_step_finish'] as const) : []),
+  ]
+
+  // Rule 4: high-confidence gate — missing_completion plus at least one more
+  // item, or an explicit abort record alone (definitive).
+  const highConfidence = (missingCompletion && evidence.length >= 2) || abortedError
+  if (!highConfidence) return { interrupted: false, reason: 'insufficient_evidence' }
+  return {
+    interrupted: true,
+    messageId: String(info?.id ?? ''),
+    evidence: [...evidence],
+  }
+}

--- a/server/fresh-agent/adapters/opencode/normalize.ts
+++ b/server/fresh-agent/adapters/opencode/normalize.ts
@@ -17,6 +17,69 @@ export type OpencodeExport = {
 const STRUCTURAL_PART_TYPES = new Set(['step-start', 'step-finish'])
 const VISIBLE_PART_TYPES = new Set(['text', 'reasoning', 'tool', 'file', 'patch', 'compaction'])
 
+/** Per-turn interruption evidence surfaced under `extensions.opencode.turnEvidence`
+ * (kata zrrj). Field names validated against opencode 1.18.x live data; extraction
+ * stays defensive because future sidecar versions may drift. NEVER carries payload
+ * beyond error name/message — no prompt/assistant/tool text. */
+export type OpencodeTurnEvidence = {
+  turnId: string
+  role: string
+  timeCreated?: number
+  timeCompleted?: number // absent => unfinished (assistant)
+  error?: { name?: string; message?: string } // e.g. { name: 'MessageAbortedError' }
+  tokens?: { input?: number; output?: number }
+  cost?: number
+  runningToolPartCount: number // parts with state.status === 'running'
+  stepStartCount: number
+  stepFinishCount: number
+}
+
+/** Pure extraction of interruption evidence from the raw sidecar message passthrough.
+ * Tolerates `{ name, message }`, `{ data: { message } }`, and plain-string error shapes
+ * (mirroring opencodeErrorMessage in serve-events.ts). Absent fields yield absent
+ * evidence properties; malformed input never crashes. */
+function extractTurnEvidence(messages: NonNullable<OpencodeExport['messages']>): OpencodeTurnEvidence[] {
+  return messages.map((message) => {
+    const info = message?.info ?? {}
+    const parts = Array.isArray(message?.parts) ? message.parts : []
+    const err = info?.error
+    const error = err
+      ? {
+          ...(typeof err?.name === 'string' ? { name: err.name } : {}),
+          ...(typeof err?.message === 'string'
+            ? { message: err.message }
+            : typeof err?.data?.message === 'string'
+              ? { message: err.data.message }
+              : typeof err === 'string' ? { message: err } : {}),
+        }
+      : undefined
+    const counts = { running: 0, stepStart: 0, stepFinish: 0 }
+    for (const part of parts) {
+      if (part?.type === 'tool' && part?.state?.status === 'running') counts.running += 1
+      if (part?.type === 'step-start') counts.stepStart += 1
+      if (part?.type === 'step-finish') counts.stepFinish += 1
+    }
+    const tokens = info?.tokens && typeof info.tokens === 'object'
+      ? {
+          ...(Number.isFinite(info.tokens.input) ? { input: Number(info.tokens.input) } : {}),
+          ...(Number.isFinite(info.tokens.output) ? { output: Number(info.tokens.output) } : {}),
+        }
+      : undefined
+    return {
+      turnId: String(info?.id ?? ''),
+      role: typeof info?.role === 'string' ? info.role : 'unknown',
+      ...(Number.isFinite(info?.time?.created) ? { timeCreated: Number(info.time.created) } : {}),
+      ...(Number.isFinite(info?.time?.completed) ? { timeCompleted: Number(info.time.completed) } : {}),
+      ...(error && (error.name || error.message) ? { error } : {}),
+      ...(tokens && (tokens.input !== undefined || tokens.output !== undefined) ? { tokens } : {}),
+      ...(Number.isFinite(info?.cost) ? { cost: Number(info.cost) } : {}),
+      runningToolPartCount: counts.running,
+      stepStartCount: counts.stepStart,
+      stepFinishCount: counts.stepFinish,
+    }
+  })
+}
+
 type OpencodeExportWithPageMetadata = OpencodeExport & {
   nextCursor?: string | null
 }
@@ -361,6 +424,10 @@ export function normalizeOpencodeSnapshot(input: {
   status?: string
   model?: string
   effort?: string
+  /** Server half of the client busy-clear gate (kata zrrj): true only when the
+   * adapter holds live state whose initial status reconcile completed. Absent
+   * when the caller has no live-state notion (e.g. turn pages). */
+  statusFromLiveState?: boolean
 }): FreshAgentSnapshot {
   const info = input.exported?.info ?? {}
   const messages = Array.isArray(input.exported?.messages) ? input.exported.messages : []
@@ -400,7 +467,13 @@ export function normalizeOpencodeSnapshot(input: {
     diffs: [],
     childThreads: [],
     turns,
-    extensions: { opencode: opencodeExtensions },
+    extensions: {
+      opencode: {
+        ...opencodeExtensions,
+        turnEvidence: extractTurnEvidence(messages),
+        ...(typeof input.statusFromLiveState === 'boolean' ? { statusFromLiveState: input.statusFromLiveState } : {}),
+      },
+    },
   }
 }
 

--- a/server/fresh-agent/adapters/opencode/serve-manager.ts
+++ b/server/fresh-agent/adapters/opencode/serve-manager.ts
@@ -493,20 +493,37 @@ export class OpencodeServeManager {
     this.emitterFor(parsed.sessionId).emit('event', parsed)
   }
 
-  subscribe(sessionId: string, listener: (event: ParsedServeEvent) => void): () => void {
+  subscribe(
+    sessionId: string,
+    listener: (event: ParsedServeEvent) => void,
+    onLost?: (err: OpencodeServeLostError) => void,
+  ): () => void {
     const emitter = this.emitterFor(sessionId)
     emitter.on('event', listener)
+    if (onLost) emitter.on('lost', onLost)
     return () => {
       emitter.off('event', listener)
+      if (onLost) emitter.off('lost', onLost)
       this.releaseEmitterIfIdle(sessionId, emitter)
     }
   }
 
-  onceIdle(sessionId: string, timeoutMs: number, route: ServeRoute = {}): Promise<void> {
+  onceIdle(
+    sessionId: string,
+    timeoutMs: number,
+    route: ServeRoute = {},
+    options?: { assumeActive?: boolean },
+  ): Promise<void> {
     return new Promise((resolve, reject) => {
       const emitter = this.emitterFor(sessionId)
       let settled = false
-      let observedActivity = false
+      // Arm-time activity seed (zrrj A4): a caller that just OBSERVED the session busy
+      // (e.g. the adapter's restore idle-recovery monitor arming right after reconcile)
+      // may treat its own observation as the first activity mark. Without the seed, a
+      // turn that completed in the read->arm gap hangs to the timeout and produces a
+      // false "interrupted". The send path keeps the default (unseeded) — its activity
+      // gate exists to avoid resolving before the prompt registers.
+      let observedActivity = options?.assumeActive === true
       let pollInFlight = false
       let idleStatusPolls = 0
       let warnedStatusFallbackFailure = false

--- a/server/fresh-agent/adapters/opencode/serve-manager.ts
+++ b/server/fresh-agent/adapters/opencode/serve-manager.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'node:events'
 import type pino from 'pino'
 import { allocateLocalhostPort, type LoopbackServerEndpoint } from '../../../local-port.js'
 import { logger } from '../../../logger.js'
+import { recordFreshAgentObservabilityEvent } from '../../observability.js'
 import { parseServeEvent, type ParsedServeEvent } from './serve-events.js'
 
 type OpencodeServeLogger = Pick<pino.Logger, 'warn' | 'error' | 'debug' | 'info'>
@@ -110,6 +111,8 @@ export class OpencodeServeManager {
   private startPromise: Promise<RunningServe> | undefined
   private startAbort: AbortController | undefined
   private shutdownRequested = false
+  /** Monotonic sidecar identity; bumped on every successful start(). 0 before first start. */
+  private generation = 0
 
   constructor(options: OpencodeServeManagerOptions = {}) {
     this.env = options.env ?? process.env
@@ -123,11 +126,42 @@ export class OpencodeServeManager {
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
   }
 
+  currentGeneration(): number {
+    return this.generation
+  }
+
+  describeSidecar(): { generation: number; pid?: number; baseUrl: string; ownershipId: string } | undefined {
+    if (!this.running) return undefined
+    return {
+      generation: this.generation,
+      pid: this.running.child.pid ?? undefined,
+      baseUrl: this.running.baseUrl,
+      ownershipId: this.running.ownershipId,
+    }
+  }
+
+  /**
+   * Survive-replacement (zrrj): emitters stay in the map so listeners keep
+   * receiving events once a replacement sidecar starts dispatching. Waiters
+   * observe the loss via the 'lost' event, which carries the dead sidecar's
+   * generation as a second argument (existing single-arg consumers unaffected).
+   */
   private emitLostForAllSessions(): void {
-    const emitters = Array.from(this.sessionEmitters.entries())
-    this.sessionEmitters.clear()
-    for (const [sessionId, emitter] of emitters) {
-      emitter.emit('lost', new OpencodeServeLostError(sessionId))
+    const generation = this.generation
+    for (const [sessionId, emitter] of Array.from(this.sessionEmitters.entries())) {
+      emitter.emit('lost', new OpencodeServeLostError(sessionId), { generation })
+    }
+  }
+
+  /** Emitters are created lazily and retained across sidecar replacement; GC an
+   * entry once nothing is listening so the map cannot grow without bound. */
+  private releaseEmitterIfIdle(sessionId: string, emitter: EventEmitter): void {
+    if (
+      emitter.listenerCount('event') === 0
+      && emitter.listenerCount('lost') === 0
+      && this.sessionEmitters.get(sessionId) === emitter
+    ) {
+      this.sessionEmitters.delete(sessionId)
     }
   }
 
@@ -137,6 +171,15 @@ export class OpencodeServeManager {
     this.running = undefined
     this.startPromise = undefined
     try { running.stopEventStream() } catch { /* ignore */ }
+    recordFreshAgentObservabilityEvent({
+      kind: 'fresh_agent_sidecar',
+      provider: 'opencode',
+      phase: 'discarded',
+      generation: this.generation,
+      pid: running.child.pid ?? undefined,
+      baseUrl: running.baseUrl,
+      reason,
+    })
     this.emitLostForAllSessions()
     this.log.warn({ reason }, 'discarding opencode serve sidecar')
     void killOwnedProcesses(running.child, running.ownershipId, this.log)
@@ -224,6 +267,16 @@ export class OpencodeServeManager {
           this.running = undefined
           this.startPromise = undefined
           try { running.stopEventStream() } catch { /* ignore */ }
+          recordFreshAgentObservabilityEvent({
+            kind: 'fresh_agent_sidecar',
+            provider: 'opencode',
+            phase: 'exited',
+            generation: this.generation,
+            pid: child.pid ?? undefined,
+            baseUrl: running.baseUrl,
+            code,
+            signal,
+          })
           void killOwnedProcesses(running.child, running.ownershipId, this.log)
           this.emitLostForAllSessions()
         }
@@ -250,6 +303,15 @@ export class OpencodeServeManager {
         stopEventStream,
       }
       this.running = running
+      this.generation += 1
+      recordFreshAgentObservabilityEvent({
+        kind: 'fresh_agent_sidecar',
+        provider: 'opencode',
+        phase: 'started',
+        generation: this.generation,
+        pid: child.pid ?? undefined,
+        baseUrl,
+      })
       return running
     } catch (err) {
       if (child) this.stopChild(child)
@@ -434,7 +496,10 @@ export class OpencodeServeManager {
   subscribe(sessionId: string, listener: (event: ParsedServeEvent) => void): () => void {
     const emitter = this.emitterFor(sessionId)
     emitter.on('event', listener)
-    return () => emitter.off('event', listener)
+    return () => {
+      emitter.off('event', listener)
+      this.releaseEmitterIfIdle(sessionId, emitter)
+    }
   }
 
   onceIdle(sessionId: string, timeoutMs: number, route: ServeRoute = {}): Promise<void> {
@@ -451,6 +516,7 @@ export class OpencodeServeManager {
         clearInterval(pollTimer)
         emitter.off('event', handler)
         emitter.off('lost', onLost)
+        this.releaseEmitterIfIdle(sessionId, emitter)
       }
       const finish = () => {
         if (settled) return

--- a/server/fresh-agent/incident-router.ts
+++ b/server/fresh-agent/incident-router.ts
@@ -1,0 +1,35 @@
+import { Router } from 'express'
+
+/**
+ * Read-only incident-state inspection endpoint (kata zrrj).
+ *
+ * Mirrors server/debug-router.ts: structural deps, a single GET '/', and a
+ * versioned envelope. Every value it serves comes from the deps' own read-only
+ * inspection functions, which report identity ONLY as hashForLogs() hashes —
+ * never raw session ids, prompts, assistant text, or OpenCode payloads.
+ */
+export interface IncidentRouterDeps {
+  runtimeManager: { inspectState: () => unknown }
+  opencode: { inspectSessions: () => unknown; describeSidecar: () => unknown }
+}
+
+export function createFreshAgentIncidentRouter(deps: IncidentRouterDeps): Router {
+  const { runtimeManager, opencode } = deps
+  const router = Router()
+
+  router.get('/', (_req, res) => {
+    res.json({
+      version: 1,
+      time: new Date().toISOString(),
+      runtime: runtimeManager.inspectState(),
+      opencode: {
+        sessions: opencode.inspectSessions(),
+        // Explicit null (instead of dropping the key) when no sidecar is running,
+        // so incident readers can distinguish "not running" from "field missing".
+        sidecar: opencode.describeSidecar() ?? null,
+      },
+    })
+  })
+
+  return router
+}

--- a/server/fresh-agent/log-hash.ts
+++ b/server/fresh-agent/log-hash.ts
@@ -1,0 +1,17 @@
+import { createHash } from 'node:crypto'
+
+const HASH_LENGTH = 12
+
+/**
+ * Content-free identity for logs and incident inspection: a short, stable
+ * sha256 prefix of the raw value (session id, cwd, message id, ...).
+ *
+ * Leaf module on purpose (node:crypto only): callers that must stay
+ * logger-free — e.g. the runtime manager's read-only inspectState() — can hash
+ * identity without pulling the observability sink (and its logger dependency)
+ * into their module graph. observability.ts re-exports this so existing
+ * importers are unaffected.
+ */
+export function hashForLogs(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, HASH_LENGTH)
+}

--- a/server/fresh-agent/observability.ts
+++ b/server/fresh-agent/observability.ts
@@ -1,12 +1,11 @@
-import { createHash } from 'node:crypto'
 import type { Request, Response, NextFunction } from 'express'
 import { freshAgentObservabilityLogger } from '../logger.js'
+import { hashForLogs } from './log-hash.js'
 
-const HASH_LENGTH = 12
-
-export function hashForLogs(value: string): string {
-  return createHash('sha256').update(value).digest('hex').slice(0, HASH_LENGTH)
-}
+// Re-exported so existing `import { hashForLogs } from './observability.js'`
+// call sites keep working; the implementation lives in the logger-free leaf
+// module log-hash.ts (see its doc comment).
+export { hashForLogs }
 
 export type FreshAgentObservabilityEvent =
   | {

--- a/server/fresh-agent/observability.ts
+++ b/server/fresh-agent/observability.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import type { Request, Response, NextFunction } from 'express'
-import { logger } from '../logger.js'
+import { freshAgentObservabilityLogger } from '../logger.js'
 
 const HASH_LENGTH = 12
 
@@ -30,6 +30,7 @@ export type FreshAgentObservabilityEvent =
     lastTurnIdHash?: string
     revision?: number
     cwdHash?: string
+    trigger?: string
   }
   | {
     kind: 'fresh_agent_snapshot_rate_limited'
@@ -39,11 +40,96 @@ export type FreshAgentObservabilityEvent =
     httpStatus: 429
     route: string
     cwdHash?: string
+    retryAfterSeconds?: number
+    trigger?: string
+  }
+  | {
+    kind: 'fresh_agent_send'
+    sessionType: string
+    provider: string
+    sessionIdHash: string
+    cwdHash?: string
+    requestId?: string
+    outcome: 'accepted' | 'failed'
+    errorCode?: string
+    durationMs?: number
+  }
+  | {
+    kind: 'fresh_agent_interrupt'
+    sessionType: string
+    provider: string
+    sessionIdHash: string
+    cwdHash?: string
+    outcome: 'ok' | 'failed'
+    errorCode?: string
+  }
+  | {
+    kind: 'fresh_agent_attach'
+    sessionType: string
+    provider: string
+    sessionIdHash: string
+    cwdHash?: string
+    outcome: 'ok' | 'failed'
+    errorCode?: string
+    recovered?: boolean
+  }
+  | {
+    kind: 'fresh_agent_materialized'
+    sessionType: string
+    provider: string
+    previousSessionIdHash: string
+    sessionIdHash: string
+    cwdHash?: string
+  }
+  | {
+    kind: 'fresh_agent_monitor'
+    provider: 'opencode'
+    sessionIdHash: string
+    cwdHash?: string
+    phase: 'armed' | 'resolved_idle' | 'timeout' | 'sidecar_lost' | 'duplicate_suppressed'
+    sidecarGeneration?: number
+  }
+  | {
+    kind: 'fresh_agent_sidecar'
+    provider: 'opencode'
+    phase: 'started' | 'exited' | 'discarded'
+    generation: number
+    pid?: number
+    baseUrl?: string
+    reason?: string
+    code?: number | null
+    signal?: string | null
+  }
+  | {
+    kind: 'fresh_agent_snapshot_failed'
+    sessionType: string
+    provider: string
+    threadIdHash?: string
+    httpStatus: number
+    code?: string
+    durationMs?: number
+    trigger?: string
+    cwdHash?: string
+  }
+  | {
+    kind: 'fresh_agent_turn_recovery'
+    provider: 'opencode'
+    sessionIdHash: string
+    cwdHash?: string
+    action:
+      | 'continuation_injected'
+      | 'suppressed_user_stop'
+      | 'suppressed_user_followup'
+      | 'suppressed_already_recovered'
+      | 'suppressed_low_confidence'
+      | 'suppressed_no_route'
+    reason: string
+    messageIdHash?: string
   }
 
-type FreshAgentObservabilitySink = Pick<typeof logger, 'info' | 'warn'>
+type FreshAgentObservabilitySink = Pick<typeof freshAgentObservabilityLogger, 'info' | 'warn'>
 
-const defaultSink: FreshAgentObservabilitySink = logger
+const defaultSink: FreshAgentObservabilitySink = freshAgentObservabilityLogger
 let sink: FreshAgentObservabilitySink = defaultSink
 
 export function __setFreshAgentObservabilitySinkForTest(next: FreshAgentObservabilitySink): void {
@@ -51,63 +137,53 @@ export function __setFreshAgentObservabilitySinkForTest(next: FreshAgentObservab
 }
 
 function buildPayload(event: FreshAgentObservabilityEvent): Record<string, unknown> {
-  const base = { event: event.kind, component: 'fresh-agent-observability' }
-  switch (event.kind) {
-    case 'fresh_agent_opencode_status_observed':
-      return {
-        ...base,
-        provider: event.provider,
-        sessionIdHash: event.sessionIdHash,
-        status: event.status,
-        source: event.source,
-        ...(event.opencodeEventKind ? { opencodeEventKind: event.opencodeEventKind } : {}),
-        ...(event.cwdHash ? { cwdHash: event.cwdHash } : {}),
-      }
-    case 'fresh_agent_snapshot_served':
-      return {
-        ...base,
-        sessionType: event.sessionType,
-        provider: event.provider,
-        threadIdHash: event.threadIdHash,
-        httpStatus: event.httpStatus,
-        durationMs: event.durationMs,
-        ...(event.payloadBytes !== undefined ? { payloadBytes: event.payloadBytes } : {}),
-        turnCount: event.turnCount,
-        ...(event.lastTurnIdHash ? { lastTurnIdHash: event.lastTurnIdHash } : {}),
-        ...(event.revision !== undefined ? { revision: event.revision } : {}),
-        ...(event.cwdHash ? { cwdHash: event.cwdHash } : {}),
-      }
-    case 'fresh_agent_snapshot_rate_limited':
-      return {
-        ...base,
-        sessionType: event.sessionType,
-        provider: event.provider,
-        ...(event.threadIdHash ? { threadIdHash: event.threadIdHash } : {}),
-        httpStatus: event.httpStatus,
-        route: event.route,
-        ...(event.cwdHash ? { cwdHash: event.cwdHash } : {}),
-      }
+  const { kind, ...fields } = event
+  const payload: Record<string, unknown> = { event: kind, component: 'fresh-agent-observability' }
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) payload[key] = value
   }
+  return payload
+}
+
+const WARN_KINDS = new Set<FreshAgentObservabilityEvent['kind']>([
+  'fresh_agent_snapshot_rate_limited',
+  'fresh_agent_snapshot_failed',
+])
+
+function isWarnEvent(event: FreshAgentObservabilityEvent): boolean {
+  if (WARN_KINDS.has(event.kind)) return true
+  if (event.kind === 'fresh_agent_sidecar') return event.phase !== 'started'
+  if (event.kind === 'fresh_agent_monitor') return event.phase === 'timeout' || event.phase === 'sidecar_lost'
+  return false
 }
 
 export function recordFreshAgentObservabilityEvent(event: FreshAgentObservabilityEvent): void {
   const payload = buildPayload(event)
-  if (event.kind === 'fresh_agent_snapshot_rate_limited') {
+  if (isWarnEvent(event)) {
     sink.warn(payload, event.kind)
   } else {
     sink.info(payload, event.kind)
   }
 }
 
-const SNAPSHOT_PATH_PATTERN = /^\/([^/]+)\/([^/]+)\/([^/]+)$/
+// Matches all three thread routes relative to the mount point:
+//   /:sessionType/:provider/:threadId
+//   /:sessionType/:provider/:threadId/turns
+//   /:sessionType/:provider/:threadId/turns/:turnId
+const SNAPSHOT_PATH_PATTERN = /^\/([^/]+)\/([^/]+)\/([^/]+)(?:\/turns(?:\/[^/]+)?)?$/
+
+const MAX_TRIGGER_LENGTH = 32
 
 export function createFreshAgentSnapshotRateLimitMiddleware() {
   return (req: Request, res: Response, next: NextFunction) => {
     const match = SNAPSHOT_PATH_PATTERN.exec(req.path)
     if (match) {
       const [, sessionType, provider, threadId] = match
+      const trigger =
+        typeof req.query.trigger === 'string' ? req.query.trigger.slice(0, MAX_TRIGGER_LENGTH) : undefined
       res.on('finish', () => {
         if (res.statusCode === 429) {
+          const retryAfterSeconds = Number(res.getHeader('Retry-After')) || undefined
           recordFreshAgentObservabilityEvent({
             kind: 'fresh_agent_snapshot_rate_limited',
             sessionType,
@@ -115,6 +191,8 @@ export function createFreshAgentSnapshotRateLimitMiddleware() {
             threadIdHash: hashForLogs(threadId),
             httpStatus: 429,
             route: `/fresh-agent/threads/${sessionType}/${provider}/:threadId`,
+            ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
+            ...(trigger ? { trigger } : {}),
           })
         }
       })

--- a/server/fresh-agent/recovery-store.ts
+++ b/server/fresh-agent/recovery-store.ts
@@ -1,0 +1,164 @@
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { logger } from '../logger.js'
+
+export type RecoveryStoreData = {
+  version: 1
+  /** sessionId -> ms timestamp of the user's explicit stop. */
+  interrupts: Record<string, number>
+  /** sessionId -> messageId -> ms timestamp of the injected continuation. */
+  recoveries: Record<string, Record<string, number>>
+}
+
+/** Keep the file small: at most this many interrupts, and this many recoveries per session. */
+const MAX_ENTRIES = 100
+
+function emptyData(): RecoveryStoreData {
+  return { version: 1, interrupts: {}, recoveries: {} }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isRecoveryStoreData(value: unknown): value is RecoveryStoreData {
+  return (
+    isPlainObject(value) &&
+    value.version === 1 &&
+    isPlainObject(value.interrupts) &&
+    isPlainObject(value.recoveries)
+  )
+}
+
+/** Drop the oldest entries (by timestamp, insertion order on ties) until the record fits the cap. */
+function pruneOldest(record: Record<string, number>, max: number): void {
+  const excess = Object.keys(record).length - max
+  if (excess <= 0) return
+  const oldestFirst = Object.entries(record).sort((a, b) => a[1] - b[1])
+  for (const [key] of oldestFirst.slice(0, excess)) {
+    delete record[key]
+  }
+}
+
+/**
+ * Durable store for fresh-agent restart recovery decisions:
+ * - `interrupts`: explicit user stop intent per session ("never auto-recover after explicit stop").
+ * - `recoveries`: at-most-one-recovery-per-(session, message) ledger.
+ *
+ * Persists to `~/.freshell/fresh-agent-recovery.json` via atomic temp-file + rename writes.
+ * Holds only session/message ids and timestamps — never prompt or assistant text.
+ */
+export class FreshAgentRecoveryStore {
+  private readonly filePath: string
+  private cache: RecoveryStoreData | null = null
+  /** Serializes load-mutate-write cycles so concurrent mutators cannot interleave. */
+  private queue: Promise<unknown> = Promise.resolve()
+
+  constructor(options?: { filePath?: string }) {
+    this.filePath = options?.filePath ?? path.join(os.homedir(), '.freshell', 'fresh-agent-recovery.json')
+  }
+
+  async recordInterrupt(sessionId: string): Promise<void> {
+    await this.enqueue(async () => {
+      const data = await this.load()
+      data.interrupts[sessionId] = Date.now()
+      pruneOldest(data.interrupts, MAX_ENTRIES)
+      await this.save(data)
+    })
+  }
+
+  async clearInterrupt(sessionId: string): Promise<void> {
+    await this.enqueue(async () => {
+      const data = await this.load()
+      if (!Object.hasOwn(data.interrupts, sessionId)) return
+      delete data.interrupts[sessionId]
+      await this.save(data)
+    })
+  }
+
+  async hasInterrupt(sessionId: string): Promise<boolean> {
+    return this.enqueue(async () => {
+      const data = await this.load()
+      return Object.hasOwn(data.interrupts, sessionId)
+    })
+  }
+
+  async recordRecovery(sessionId: string, messageId: string): Promise<void> {
+    await this.enqueue(async () => {
+      const data = await this.load()
+      const forSession = (data.recoveries[sessionId] ??= {})
+      forSession[messageId] = Date.now()
+      pruneOldest(forSession, MAX_ENTRIES)
+      await this.save(data)
+    })
+  }
+
+  async hasRecovery(sessionId: string, messageId: string): Promise<boolean> {
+    return this.enqueue(async () => {
+      const data = await this.load()
+      const forSession = data.recoveries[sessionId]
+      return forSession !== undefined && Object.hasOwn(forSession, messageId)
+    })
+  }
+
+  private enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    const result = this.queue.then(fn)
+    // Keep the chain alive even if this operation rejects.
+    this.queue = result.catch(() => undefined)
+    return result
+  }
+
+  private async load(): Promise<RecoveryStoreData> {
+    if (this.cache) return this.cache
+    try {
+      const raw = await readFile(this.filePath, 'utf8')
+      const parsed: unknown = JSON.parse(raw)
+      if (isRecoveryStoreData(parsed)) {
+        this.cache = parsed
+        return this.cache
+      }
+      logger.warn(
+        { event: 'fresh_agent_recovery_store_invalid', filePath: this.filePath },
+        'Fresh-agent recovery store file has unexpected shape; starting empty',
+      )
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        logger.warn(
+          { err, event: 'fresh_agent_recovery_store_read_error', filePath: this.filePath },
+          'Failed to read fresh-agent recovery store; starting empty',
+        )
+      }
+    }
+    this.cache = emptyData()
+    return this.cache
+  }
+
+  private async save(data: RecoveryStoreData): Promise<void> {
+    await mkdir(path.dirname(this.filePath), { recursive: true })
+    const tmpPath = `${this.filePath}.tmp-${process.pid}-${Date.now()}`
+    await writeFile(tmpPath, JSON.stringify(data, null, 2), 'utf8')
+    try {
+      await rename(tmpPath, this.filePath)
+    } finally {
+      await rm(tmpPath, { force: true })
+    }
+    this.cache = data
+  }
+}
+
+let singleton: FreshAgentRecoveryStore | null = null
+
+/** Lazy process-wide singleton backed by the default `~/.freshell` path. */
+export function getFreshAgentRecoveryStore(): FreshAgentRecoveryStore {
+  if (!singleton) singleton = new FreshAgentRecoveryStore()
+  return singleton
+}
+
+/**
+ * Test hook: with a `filePath`, pins the singleton to a store backed by that file;
+ * without one, clears the singleton so the next get() lazily recreates the default.
+ */
+export function resetFreshAgentRecoveryStoreForTests(filePath?: string): void {
+  singleton = filePath ? new FreshAgentRecoveryStore({ filePath }) : null
+}

--- a/server/fresh-agent/router.ts
+++ b/server/fresh-agent/router.ts
@@ -96,7 +96,40 @@ export function createFreshAgentRouter(deps: {
     }
   }
 
-  function sendFreshAgentError(res: any, error: unknown, options?: { sessionId?: string }) {
+  type SnapshotFailureContext = {
+    sessionType: string
+    provider: string
+    threadId: string
+    startedAt: number
+    trigger?: string
+    cwd?: string
+  }
+
+  function sendFreshAgentError(
+    res: any,
+    error: unknown,
+    options?: { sessionId?: string; snapshot?: SnapshotFailureContext },
+  ) {
+    const result = writeFreshAgentError(res, error, options)
+    const snapshot = options?.snapshot
+    if (snapshot) {
+      const code = (error as { code?: unknown } | null | undefined)?.code
+      recordFreshAgentObservabilityEvent({
+        kind: 'fresh_agent_snapshot_failed',
+        sessionType: snapshot.sessionType,
+        provider: snapshot.provider,
+        threadIdHash: hashForLogs(snapshot.threadId),
+        httpStatus: res.statusCode,
+        ...(typeof code === 'string' && code.length > 0 ? { code } : {}),
+        durationMs: Date.now() - snapshot.startedAt,
+        ...(snapshot.trigger ? { trigger: snapshot.trigger } : {}),
+        ...(snapshot.cwd ? { cwdHash: hashForLogs(snapshot.cwd) } : {}),
+      })
+    }
+    return result
+  }
+
+  function writeFreshAgentError(res: any, error: unknown, options?: { sessionId?: string }) {
     if (error instanceof ClaudeFreshAgentStaleHistoryRevisionError) {
       return res.status(409).json({
         error: 'Stale restore revision',
@@ -172,10 +205,12 @@ export function createFreshAgentRouter(deps: {
       priority: ReadModelPrioritySchema.optional(),
       revision: z.coerce.number().int().nonnegative().optional(),
       cwd: z.string().trim().min(1).optional(),
+      trigger: z.string().max(32).optional(),
     }).safeParse({
       priority: typeof req.query.priority === 'string' ? req.query.priority : undefined,
       revision: typeof req.query.revision === 'string' ? req.query.revision : undefined,
       cwd: typeof req.query.cwd === 'string' ? req.query.cwd : undefined,
+      trigger: typeof req.query.trigger === 'string' ? req.query.trigger : undefined,
     })
 
     if (!params.success || !query.success) {
@@ -221,10 +256,21 @@ export function createFreshAgentRouter(deps: {
         ...(latestTurnId ? { lastTurnIdHash: hashForLogs(latestTurnId) } : {}),
         ...(revision !== undefined ? { revision } : {}),
         ...(query.data.cwd ? { cwdHash: hashForLogs(query.data.cwd) } : {}),
+        ...(query.data.trigger ? { trigger: query.data.trigger } : {}),
       })
     } catch (error) {
       if (signal.aborted || isReadModelAbortError(error)) return
-      return sendFreshAgentError(res, error, { sessionId: params.data.threadId })
+      return sendFreshAgentError(res, error, {
+        sessionId: params.data.threadId,
+        snapshot: {
+          sessionType: params.data.sessionType,
+          provider: params.data.provider,
+          threadId: params.data.threadId,
+          startedAt: snapshotStart,
+          ...(query.data.trigger ? { trigger: query.data.trigger } : {}),
+          ...(query.data.cwd ? { cwd: query.data.cwd } : {}),
+        },
+      })
     }
   })
 

--- a/server/fresh-agent/runtime-adapter.ts
+++ b/server/fresh-agent/runtime-adapter.ts
@@ -60,6 +60,10 @@ export interface FreshAgentRuntimeAdapter {
   resume?(input: FreshAgentCreateRequest): Promise<{ sessionId: string; sessionRef?: { provider: string; sessionId: string } }>
   attach?(locator: FreshAgentSessionLocator): Promise<{ sessionId: string; sessionRef?: { provider: string; sessionId: string } }> | { sessionId: string; sessionRef?: { provider: string; sessionId: string } }
   subscribe?(sessionId: string, listener: (message: unknown) => void): Promise<() => void> | (() => void)
+  /** Monotonic identity of the adapter state backing a session's event emitter.
+   * Consumers compare generations across calls to detect state recreation (a new
+   * emitter) and rebind subscriptions. Undefined when the session is unknown. */
+  sessionStateGeneration?(sessionId: string): number | undefined
   send?(sessionId: string, input: { requestId?: string; text: string; images?: FreshAgentInputImage[]; settings?: FreshAgentCreateRequest }): Promise<FreshAgentSendResult> | FreshAgentSendResult
   interrupt?(sessionId: string): Promise<void> | void
   compact?(sessionId: string, input?: { instructions?: string }): Promise<void> | void

--- a/server/fresh-agent/runtime-manager.ts
+++ b/server/fresh-agent/runtime-manager.ts
@@ -12,6 +12,7 @@ import {
   FreshAgentTurnPageSchema,
   type FreshAgentRequestId,
 } from '../../shared/fresh-agent-contract.js'
+import { hashForLogs } from './log-hash.js'
 import type { FreshAgentProviderRegistry } from './provider-registry.js'
 import type {
   FreshAgentCreateRequest,
@@ -128,6 +129,40 @@ export class FreshAgentRuntimeManager {
       runtimeProvider: registration.runtimeProvider,
       sessionRef: created.sessionRef,
     }
+  }
+
+  /**
+   * Read-only incident inspection (kata zrrj): a content-free summary of every
+   * tracked session plus the count of in-flight freshopencode recovery attaches.
+   * Identity is reported ONLY as hashForLogs() hashes — including inside `key`,
+   * which is rebuilt with the hashed session id so the raw id never leaves the
+   * process. Pure map walk; mutates nothing.
+   */
+  inspectState(): {
+    sessions: Array<{
+      key: string
+      sessionType: string
+      provider: string
+      sessionIdHash: string
+      cwdHash?: string
+      providerOwned?: boolean
+    }>
+    pendingRecoveries: number
+  } {
+    const sessions = [...this.sessions.entries()].map(([key, record]) => {
+      const prefix = `${record.sessionType}:${record.runtimeProvider}:`
+      const sessionId = key.startsWith(prefix) ? key.slice(prefix.length) : key
+      const sessionIdHash = hashForLogs(sessionId)
+      return {
+        key: `${record.sessionType}:${record.runtimeProvider}:${sessionIdHash}`,
+        sessionType: record.sessionType,
+        provider: record.runtimeProvider,
+        sessionIdHash,
+        ...(record.freshOpenCodeRouteCwd ? { cwdHash: hashForLogs(record.freshOpenCodeRouteCwd) } : {}),
+        ...(record.freshOpenCodeProviderOwnedNoRoute ? { providerOwned: true } : {}),
+      }
+    })
+    return { sessions, pendingRecoveries: this.freshOpencodeRecoveries.size }
   }
 
   async attach(input: FreshAgentSessionLocator): Promise<FreshAgentCreateResult> {

--- a/server/fresh-agent/runtime-manager.ts
+++ b/server/fresh-agent/runtime-manager.ts
@@ -212,6 +212,15 @@ export class FreshAgentRuntimeManager {
     return await record.adapter.subscribe(locator.sessionId, listener)
   }
 
+  /** Synchronous passthrough to the adapter's state-generation lookup (when
+   * implemented). Lets subscribers detect adapter-state recreation and rebind. */
+  sessionStateGeneration(locator: FreshAgentSessionLocator): number | undefined {
+    const record = this.sessions.get(this.key(locator))
+    const adapter = record?.adapter
+      ?? this.options.registry.resolveBySessionType(locator.sessionType)?.adapter
+    return adapter?.sessionStateGeneration?.(locator.sessionId)
+  }
+
   async send(
     locator: FreshAgentSessionLocator,
     input: { requestId?: string; text: string; images?: FreshAgentInputImage[]; settings?: FreshAgentCreateRequest },

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,7 @@ import os from 'os'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import cookieParser from 'cookie-parser'
-import rateLimit from 'express-rate-limit'
+import { createApiRateLimiter } from './rate-limit.js'
 import chokidar from 'chokidar'
 import { logger, resolveRuntimeLogLevel, setLogLevel } from './logger.js'
 import { requestLogger } from './request-logger.js'
@@ -201,15 +201,7 @@ async function main() {
   app.use('/api/fresh-agent/threads', createFreshAgentSnapshotRateLimitMiddleware())
 
   // Basic rate limiting for /api
-  app.use(
-    '/api',
-    rateLimit({
-      windowMs: 60_000,
-      max: 300,
-      standardHeaders: true,
-      legacyHeaders: false,
-    }),
-  )
+  app.use('/api', createApiRateLimiter())
 
   app.use(cookieParser())
   app.use('/api', httpAuthMiddleware)

--- a/server/index.ts
+++ b/server/index.ts
@@ -72,6 +72,7 @@ import { createSettingsRouter } from './settings-router.js'
 import { createPerfRouter } from './perf-router.js'
 import { createAiRouter } from './ai-router.js'
 import { createDebugRouter } from './debug-router.js'
+import { createFreshAgentIncidentRouter } from './fresh-agent/incident-router.js'
 import { LayoutStore } from './agent-api/layout-store.js'
 import { createAgentApiRouter } from './agent-api/router.js'
 import { ExtensionManager } from './extension-manager.js'
@@ -784,6 +785,19 @@ async function main() {
     codingCliIndexer,
     tabsRegistryStore,
     registry,
+  }))
+
+  // --- API: fresh-agent incident inspection (kata zrrj) ---
+  // Read-only, content-free (hashed identity only). Mounted after httpAuthMiddleware
+  // so it stays token-protected, and it shares the global /api rate limit
+  // (createApiRateLimiter, 300/60s) like every other API route — acceptable because
+  // this endpoint is polled manually by a human during incidents.
+  app.use('/api/debug/fresh-agent', createFreshAgentIncidentRouter({
+    runtimeManager: freshAgentRuntimeManager,
+    opencode: {
+      inspectSessions: () => opencodeFreshAgentAdapter.inspectSessions(),
+      describeSidecar: () => opencodeServeManager.describeSidecar(),
+    },
   }))
 
   // --- API: server-info ---

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -17,6 +17,10 @@ const DEFAULT_SESSION_LIFECYCLE_LOG_FILE = 'session-lifecycle'
 const DEFAULT_SESSION_LIFECYCLE_LOG_SUFFIX = '.jsonl'
 const DEFAULT_SESSION_LIFECYCLE_LOG_SIZE: SizeString = '10M'
 const DEFAULT_SESSION_LIFECYCLE_LOG_MAX_FILES = 10
+const DEFAULT_FRESH_AGENT_LOG_FILE = 'fresh-agent'
+const DEFAULT_FRESH_AGENT_LOG_SUFFIX = '.jsonl'
+const DEFAULT_FRESH_AGENT_LOG_SIZE: SizeString = '10M'
+const DEFAULT_FRESH_AGENT_LOG_MAX_FILES = 10
 export const DEFAULT_NON_DEBUG_LOG_LEVEL: LevelWithSilent = 'warn'
 const DEFAULT_CONSOLE_LOG_LEVEL: LevelWithSilent = 'error'
 const SOURCE_ENTRY_MATCHERS = [/(^|\/)server\/index\.ts$/i, /(^|\/)server\/index\.js$/i]
@@ -122,6 +126,25 @@ export function resolveSessionLifecycleLogPath(
   )
 }
 
+export function resolveFreshAgentObservabilityLogPath(
+  envVars: NodeJS.ProcessEnv = process.env,
+  homeDir: string = getFreshellHomeDir(envVars),
+  argv: string[] = process.argv,
+): string | null {
+  const explicitPath = envVars.LOG_FRESH_AGENT_PATH?.trim()
+  if (explicitPath) return path.resolve(explicitPath)
+  if (isTestRuntime(envVars)) return null
+
+  const logDirOverride = envVars.FRESHELL_LOG_DIR?.trim()
+  const logDir = logDirOverride ? path.resolve(logDirOverride) : path.join(homeDir, '.freshell', 'logs')
+  const mode = resolveDebugLogMode(envVars, argv)
+  const instance = resolveDebugInstanceTag(envVars)
+  return path.join(
+    logDir,
+    `${DEFAULT_FRESH_AGENT_LOG_FILE}.${mode}.${instance}${DEFAULT_FRESH_AGENT_LOG_SUFFIX}`,
+  )
+}
+
 function normalizeLogMode(value: string | undefined): LogMode | undefined {
   const normalized = value?.trim().toLowerCase()
   if (normalized === 'development' || normalized === 'dev') return 'development'
@@ -207,12 +230,28 @@ export function createDebugFileStream(filePath: string, options: DebugFileStream
   return createStream(path.basename(filePath), { path: dir, size, maxFiles })
 }
 
+type DedicatedFileLoggerOptions = {
+  filePath: string
+  level?: LevelWithSilent
+  size?: SizeString
+  maxFiles?: number
+}
+
+export function createDedicatedFileLogger(options: DedicatedFileLoggerOptions) {
+  const stream = createDebugFileStream(options.filePath, {
+    size: options.size,
+    maxFiles: options.maxFiles,
+  })
+  return pino(createPinoOptions({ level: options.level ?? 'info' }), stream)
+}
+
 export function createSessionLifecycleLogger(filePath: string) {
-  const stream = createDebugFileStream(filePath, {
+  return createDedicatedFileLogger({
+    filePath,
+    level: 'info',
     size: DEFAULT_SESSION_LIFECYCLE_LOG_SIZE,
     maxFiles: DEFAULT_SESSION_LIFECYCLE_LOG_MAX_FILES,
   })
-  return pino(createPinoOptions({ level: 'info' }), stream)
 }
 
 export function resolveRuntimeLogLevel(debugLoggingEnabled: boolean): LevelWithSilent {
@@ -315,6 +354,21 @@ const sessionLifecycleLogPath = resolveSessionLifecycleLogPath()
 export const sessionLifecycleLogger = sessionLifecycleLogPath
   ? createSessionLifecycleLogger(sessionLifecycleLogPath)
   : logger.child({ component: 'session-lifecycle-disabled' })
+
+// Always-on fresh-agent observability logger. Pinned at level 'info' so its
+// rows stay visible in production, where the main logger sits at 'warn' with
+// the Debug toggle off. In test runtimes (no resolved path) it must be truly
+// silent, so the fallback is a dedicated silent pino instance rather than a
+// child of the main logger.
+const freshAgentObservabilityLogPath = resolveFreshAgentObservabilityLogPath()
+export const freshAgentObservabilityLogger = freshAgentObservabilityLogPath
+  ? createDedicatedFileLogger({
+      filePath: freshAgentObservabilityLogPath,
+      level: 'info',
+      size: DEFAULT_FRESH_AGENT_LOG_SIZE,
+      maxFiles: DEFAULT_FRESH_AGENT_LOG_MAX_FILES,
+    })
+  : pino(createPinoOptions({ level: 'silent' }))
 
 export function setLogLevel(nextLevel: LevelWithSilent): void {
   logger.level = nextLevel

--- a/server/rate-limit.ts
+++ b/server/rate-limit.ts
@@ -1,0 +1,26 @@
+import rateLimit from 'express-rate-limit'
+import type { Request, Response } from 'express'
+
+export const API_RATE_LIMIT_WINDOW_MS = 60_000
+export const API_RATE_LIMIT_MAX = 300
+
+/**
+ * Global /api rate limiter. Budget is intentionally identical to the previous
+ * inline configuration (300 req / 60 s / IP) — do NOT raise it here; the fix
+ * for snapshot storms is client-side scheduling + backoff, not a bigger budget.
+ * This factory only adds a JSON 429 body (with retryAfterSeconds) and testability.
+ */
+export function createApiRateLimiter(options: { windowMs?: number; max?: number } = {}) {
+  const windowMs = options.windowMs ?? API_RATE_LIMIT_WINDOW_MS
+  return rateLimit({
+    windowMs,
+    max: options.max ?? API_RATE_LIMIT_MAX,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (_req: Request, res: Response) => {
+      const retryAfterHeader = res.getHeader('Retry-After')
+      const retryAfterSeconds = Number(retryAfterHeader) || Math.ceil(windowMs / 1000)
+      res.status(429).json({ error: 'Too many requests', code: 'RATE_LIMITED', retryAfterSeconds })
+    },
+  })
+}

--- a/server/terminal-stream/broker.ts
+++ b/server/terminal-stream/broker.ts
@@ -39,6 +39,7 @@ import {
   TERMINAL_BACKGROUND_BUFFERED_PAUSE_BYTES,
   TERMINAL_BACKGROUND_RETRY_FLUSH_MS,
   TERMINAL_STREAM_BATCH_MAX_BYTES,
+  TERMINAL_STREAM_FOREGROUND_PAUSE_BUFFERED_BYTES,
   TERMINAL_STREAM_RETRY_FLUSH_MS,
   TERMINAL_WS_CATASTROPHIC_BUFFERED_BYTES,
   TERMINAL_WS_CATASTROPHIC_STALL_MS,
@@ -856,12 +857,15 @@ export class TerminalStreamBroker {
       return
     }
 
+    // Every attachment pauses at its buffered-amount threshold: background at
+    // 512 KiB, foreground at 1 MiB — below WsHandler's 2 MiB drop+close(4008)
+    // kill line, so terminal output self-throttles before lifecycle messages
+    // (freshAgent.*, session updates) start dying on the shared socket. (zrrj)
     const wsBuffered = readWebSocketBufferedAmount(ws)
-    if (
-      attachment.priority === 'background'
-      && typeof wsBuffered === 'number'
-      && wsBuffered > TERMINAL_BACKGROUND_BUFFERED_PAUSE_BYTES
-    ) {
+    const pauseBufferedBytes = attachment.priority === 'background'
+      ? TERMINAL_BACKGROUND_BUFFERED_PAUSE_BYTES
+      : TERMINAL_STREAM_FOREGROUND_PAUSE_BUFFERED_BYTES
+    if (typeof wsBuffered === 'number' && wsBuffered > pauseBufferedBytes) {
       if (this.hasPendingAttachmentOutput(attachment)) {
         this.scheduleFlush(terminalId, attachment, TERMINAL_BACKGROUND_RETRY_FLUSH_MS)
       }

--- a/server/terminal-stream/constants.ts
+++ b/server/terminal-stream/constants.ts
@@ -29,3 +29,11 @@ export const TERMINAL_BACKGROUND_RETRY_FLUSH_MS = Math.max(
   1,
   Number(process.env.TERMINAL_BACKGROUND_RETRY_FLUSH_MS || 100),
 )
+
+/**
+ * Foreground attachments pause flushing when the socket has this much
+ * unflushed data. MUST stay below WsHandler's maxWsBufferedAmount (2 MiB)
+ * kill line: terminal output must self-throttle before lifecycle messages
+ * (freshAgent.*, session updates) start being dropped with a 4008 close. (zrrj)
+ */
+export const TERMINAL_STREAM_FOREGROUND_PAUSE_BUFFERED_BYTES = 1 * 1024 * 1024

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -119,6 +119,7 @@ import {
   normalizeFreshAgentProviderEvent,
 } from './fresh-agent/sdk-events.js'
 import { FreshAgentLostSessionError } from './fresh-agent/runtime-manager.js'
+import { hashForLogs, recordFreshAgentObservabilityEvent } from './fresh-agent/observability.js'
 
 type WsHandlerConfig = {
   maxConnections: number
@@ -1309,6 +1310,27 @@ export class WsHandler {
     }
   }
 
+  // Identity convention for structured observability rows (zrrj): never log raw
+  // session ids or cwd paths — only provider + sessionIdHash + cwdHash.
+  private freshAgentIdentityFields(locator: FreshAgentLocator): {
+    sessionType: string
+    provider: string
+    sessionIdHash: string
+    cwdHash?: string
+  } {
+    return {
+      sessionType: locator.sessionType,
+      provider: locator.provider,
+      sessionIdHash: hashForLogs(locator.sessionId),
+      ...(locator.cwd ? { cwdHash: hashForLogs(locator.cwd) } : {}),
+    }
+  }
+
+  private freshAgentErrorCode(error: unknown): string {
+    const code = (error as { code?: unknown } | null | undefined)?.code
+    return typeof code === 'string' && code.length > 0 ? code : 'INTERNAL_ERROR'
+  }
+
   private freshAgentEventMessage(locator: FreshAgentLocator, event: unknown) {
     return {
       type: 'freshAgent.event',
@@ -1436,6 +1458,16 @@ export class WsHandler {
       next.sessionId,
       sessionRef,
     )
+    // Single choke point for materialization: every freshAgent.session.materialized
+    // frame the WS layer sends flows through here (zrrj).
+    recordFreshAgentObservabilityEvent({
+      kind: 'fresh_agent_materialized',
+      sessionType: locator.sessionType,
+      provider: locator.provider,
+      previousSessionIdHash: hashForLogs(next.previousSessionId ?? locator.sessionId),
+      sessionIdHash: hashForLogs(next.sessionId),
+      ...(locator.cwd ? { cwdHash: hashForLogs(locator.cwd) } : {}),
+    })
     return materializedLocator
   }
 
@@ -3516,7 +3548,18 @@ export class WsHandler {
         state.pendingFreshAgentAttachByKey.set(authorizationKey, pendingEntry)
         try {
           await attachPromise
+          recordFreshAgentObservabilityEvent({
+            kind: 'fresh_agent_attach',
+            ...this.freshAgentIdentityFields(locator),
+            outcome: 'ok',
+          })
         } catch (error) {
+          recordFreshAgentObservabilityEvent({
+            kind: 'fresh_agent_attach',
+            ...this.freshAgentIdentityFields(locator),
+            outcome: 'failed',
+            errorCode: this.freshAgentErrorCode(error),
+          })
           if (this.clientStates.get(ws) !== state) return
           log.warn({
             err: error instanceof Error ? error : new Error(String(error)),
@@ -3540,12 +3583,20 @@ export class WsHandler {
         }
         const locator = this.freshAgentLocatorFromMessage(m)
         if (!await this.waitForFreshAgentAuthorization(ws, state, locator, m.requestId)) return
+        const startedAt = Date.now()
         try {
           const result = await manager.send(locator, {
             requestId: m.requestId,
             text: m.text,
             images: m.images,
             settings: m.settings,
+          })
+          recordFreshAgentObservabilityEvent({
+            kind: 'fresh_agent_send',
+            ...this.freshAgentIdentityFields(locator),
+            ...(m.requestId ? { requestId: m.requestId } : {}),
+            outcome: 'accepted',
+            durationMs: Date.now() - startedAt,
           })
           let acceptedLocator = locator
           if (result?.sessionId && result.sessionId !== m.sessionId) {
@@ -3575,6 +3626,14 @@ export class WsHandler {
             })
           }
         } catch (error) {
+          recordFreshAgentObservabilityEvent({
+            kind: 'fresh_agent_send',
+            ...this.freshAgentIdentityFields(locator),
+            ...(m.requestId ? { requestId: m.requestId } : {}),
+            outcome: 'failed',
+            errorCode: this.freshAgentErrorCode(error),
+            durationMs: Date.now() - startedAt,
+          })
           if (error instanceof FreshAgentLostSessionError) {
             this.sendError(ws, { code: 'FRESH_AGENT_LOST_SESSION', message: errorMessage(error), requestId: m.requestId })
             return
@@ -3594,7 +3653,18 @@ export class WsHandler {
         if (!this.requireFreshAgentAuthorization(ws, state, locator)) return
         try {
           await manager.interrupt(locator)
+          recordFreshAgentObservabilityEvent({
+            kind: 'fresh_agent_interrupt',
+            ...this.freshAgentIdentityFields(locator),
+            outcome: 'ok',
+          })
         } catch (error) {
+          recordFreshAgentObservabilityEvent({
+            kind: 'fresh_agent_interrupt',
+            ...this.freshAgentIdentityFields(locator),
+            outcome: 'failed',
+            errorCode: this.freshAgentErrorCode(error),
+          })
           this.sendError(ws, { code: 'INTERNAL_ERROR', message: errorMessage(error) })
         }
         return

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -118,6 +118,7 @@ import {
   makeFreshAgentProviderErrorEvent,
   normalizeFreshAgentProviderEvent,
 } from './fresh-agent/sdk-events.js'
+import { FreshAgentLostSessionError } from './fresh-agent/runtime-manager.js'
 
 type WsHandlerConfig = {
   maxConnections: number
@@ -3574,6 +3575,10 @@ export class WsHandler {
             })
           }
         } catch (error) {
+          if (error instanceof FreshAgentLostSessionError) {
+            this.sendError(ws, { code: 'FRESH_AGENT_LOST_SESSION', message: errorMessage(error), requestId: m.requestId })
+            return
+          }
           this.sendError(ws, { code: 'INTERNAL_ERROR', message: errorMessage(error), requestId: m.requestId })
         }
         return

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -138,6 +138,9 @@ type FreshAgentRuntimeManagerLike = {
   create: (input: any) => Promise<any>
   attach: (input: any) => any
   subscribe?: (locator: any, listener: (message: unknown) => void) => Promise<() => void> | (() => void)
+  /** Optional synchronous adapter-state generation lookup; when present, a changed
+   * generation means the state's emitter was recreated and subscriptions must rebind. */
+  sessionStateGeneration?: (locator: any) => number | undefined
   send?: (locator: any, input: any) => Promise<FreshAgentSendResult> | FreshAgentSendResult
   interrupt?: (locator: any) => Promise<void> | void
   compact?: (locator: any, input?: { instructions?: string }) => Promise<void> | void
@@ -176,6 +179,8 @@ type FreshAgentSubscriptionEntry = {
   locator: FreshAgentLocator
   off?: () => void
   pending?: Promise<void>
+  /** Adapter-state generation observed when the subscription bound (managers that expose it). */
+  stateGeneration?: number
 }
 
 type FreshAgentAuthorizationEntry = FreshAgentLocator
@@ -1507,7 +1512,16 @@ export class WsHandler {
       if (this.hasFreshAgentRoute(locator)) {
         existing.locator = { ...locator }
       }
-      return
+      // Generation-aware rebind (zrrj): when the manager exposes adapter-state
+      // generations and the current generation differs from the one we bound to,
+      // the adapter state (and its emitter) was recreated — our listener is
+      // orphaned on the dead emitter. Cancel the stale subscription and fall
+      // through to rebind. Managers without generations keep the no-op behavior.
+      const currentGeneration = manager.sessionStateGeneration?.(locator)
+      if (typeof currentGeneration !== 'number' || currentGeneration === existing.stateGeneration) {
+        return
+      }
+      this.cancelFreshAgentSubscription(state, existing.locator)
     }
 
     const entry: FreshAgentSubscriptionEntry = { active: true, locator: { ...locator } }
@@ -1541,16 +1555,24 @@ export class WsHandler {
               this.logFreshAgentSubscriptionOffError(locator, error)
             }
           }
-          state.freshAgentSubscriptions.delete(key)
+          // A rebind may have replaced this key with a fresh entry; only remove our own.
+          if (state.freshAgentSubscriptions.get(key) === entry) {
+            state.freshAgentSubscriptions.delete(key)
+          }
           return
         }
+        // Record the adapter-state generation the subscription actually bound to
+        // (read after subscribe so recovery-triggered state recreation is captured).
+        entry.stateGeneration = manager.sessionStateGeneration?.(locator)
         if (off) {
           entry.off = off
         }
       })
       .catch((error) => {
         entry.pending = undefined
-        state.freshAgentSubscriptions.delete(key)
+        if (state.freshAgentSubscriptions.get(key) === entry) {
+          state.freshAgentSubscriptions.delete(key)
+        }
         if (entry.active) {
           this.sendFreshAgentSubscriptionError(ws, locator, error)
         }

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -33,6 +33,7 @@ export const ErrorCode = z.enum([
   'UNAUTHORIZED',
   'PROTOCOL_MISMATCH',
   'SESSION_RESERVED',
+  'FRESH_AGENT_LOST_SESSION',
 ])
 
 export type ErrorCode = z.infer<typeof ErrorCode>

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -67,6 +67,11 @@ const BUSY_STATES = new Set(['running', 'compacting'])
 // server's create.failed carries no retry-after field by design).
 export const FRESH_AGENT_RESERVE_RETRY_WINDOW_MS = 30_000
 export const FRESH_AGENT_RESERVE_RETRY_FLOOR_MS = 1_000
+// Task 16 (zrrj): bounded re-poll when an idle snapshot is missing the
+// just-sent turn (server emitted idle before the durable transcript caught
+// up). Exported so tests assert the cap against the real constant.
+export const IDLE_INCOMPLETE_MAX_RETRIES = 5
+const IDLE_INCOMPLETE_RETRY_DELAY_MS = 1_000
 const SNAPSHOT_INVALIDATING_FRESH_AGENT_EVENTS = new Set([
   'freshAgent.session.changed',
   'freshAgent.session.snapshot',
@@ -636,6 +641,11 @@ export function FreshAgentView({
   const [rateLimitedUntil, setRateLimitedUntil] = useState<number | null>(null)
   void rateLimitedUntil
   const rateLimitRetryTimerRef = useRef<number | null>(null)
+  // Task 16: idle-incomplete re-poll budget and pending retry timer (deduped:
+  // never a second timer while one counts down; cleared on unmount). The
+  // local echo is the loop's marker -- see applySnapshot.
+  const idleIncompleteRetryCountRef = useRef(0)
+  const idleIncompleteRetryTimerRef = useRef<number | null>(null)
   const [queuedMessages, setQueuedMessages] = useState<string[]>([])
   // Transient, self-clearing banner for action feedback (rewind, shell errors).
   const [notice, setNotice] = useState<string | null>(null)
@@ -837,6 +847,14 @@ export function FreshAgentView({
     if (rateLimitRetryTimerRef.current !== null) {
       window.clearTimeout(rateLimitRetryTimerRef.current)
       rateLimitRetryTimerRef.current = null
+    }
+  }, [])
+
+  // Task 16: never leak a pending idle-incomplete retry timer past unmount.
+  useEffect(() => () => {
+    if (idleIncompleteRetryTimerRef.current !== null) {
+      window.clearTimeout(idleIncompleteRetryTimerRef.current)
+      idleIncompleteRetryTimerRef.current = null
     }
   }, [])
 
@@ -1735,11 +1753,39 @@ export function FreshAgentView({
             previousTurns: previousSnapshot?.turns,
           })
         : false
+      // Task 16: 'accepted but not landed' -- the raw input predicate of the
+      // stale-echo clear, INDEPENDENT of the retry-exhaustion gate below.
+      const echoStillPending = echo
+        ? !landedEcho && shouldClearStaleLocalEcho(displaySnapshot, echo, echoPendingMetadata)
+        : false
+      // The echo is the idle-incomplete re-poll loop's marker: it may only be
+      // cleared as STALE once the bounded retry budget is exhausted. A landed
+      // echo still clears immediately.
       const staleEcho = echo
-        ? snapshotAccepted && shouldClearStaleLocalEcho(displaySnapshot, echo, echoPendingMetadata)
+        ? snapshotAccepted
+          && idleIncompleteRetryCountRef.current >= IDLE_INCOMPLETE_MAX_RETRIES
+          && shouldClearStaleLocalEcho(displaySnapshot, echo, echoPendingMetadata)
         : false
       if (echo) {
         if (landedEcho || staleEcho) setLocalEcho(null)
+      }
+      // Task 16 (zrrj): an idle snapshot that does not yet contain the
+      // just-sent turn means the durable transcript is lagging -- schedule a
+      // bounded re-poll instead of permanently going quiet.
+      if (
+        displaySnapshot.status === 'idle'
+        && echoStillPending
+        && idleIncompleteRetryCountRef.current < IDLE_INCOMPLETE_MAX_RETRIES
+      ) {
+        idleIncompleteRetryCountRef.current += 1
+        if (idleIncompleteRetryTimerRef.current === null) { // dedupe: one pending timer max
+          idleIncompleteRetryTimerRef.current = window.setTimeout(() => {
+            idleIncompleteRetryTimerRef.current = null
+            requestSnapshotRefresh('idle-incomplete')
+          }, IDLE_INCOMPLETE_RETRY_DELAY_MS)
+        }
+      } else if (!echoStillPending) {
+        idleIncompleteRetryCountRef.current = 0
       }
       const fresh = paneContentRef.current
       const nextStatus = (resolved.status as FreshAgentPaneContent['status']) ?? fresh.status
@@ -2081,6 +2127,8 @@ export function FreshAgentView({
     const current = paneContentRef.current
     if (!current.sessionId) return
     const requestId = nanoid()
+    // Task 16: a new send starts a fresh idle-incomplete re-poll budget.
+    idleIncompleteRetryCountRef.current = 0
     const routeCwd = getFreshOpenCodeRouteCwd(current, { sessionCwd: freshOpenCodeRouteCwdRef.current })
     // Retain the exact outgoing text as the resend payload (Task 10): the
     // lost-session retry resends from this metadata, never from the echo.

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -1659,11 +1659,20 @@ export function FreshAgentView({
       const wouldRegressStatus = sessionStatus
         ? isStatusRegression(currentSessionStatus, sessionStatus)
         : false
+      const opencodeStatusFromLiveState =
+        (next as { extensions?: { opencode?: { statusFromLiveState?: unknown } } })
+          .extensions?.opencode?.statusFromLiveState === true
+      const canAdoptSnapshotStatus =
+        (provider === 'codex' && requestSessionType === 'freshcodex')
+        || (provider === 'opencode' && requestSessionType === 'freshopencode'
+          // busy (running) may always be adopted; idle (busy-CLEARING) only when
+          // live-reconciled -- otherwise the restore-window idle default (untracked
+          // or mid-reconcile adapter state) would clear a genuinely running turn.
+          && (snapshotIsBusy || opencodeStatusFromLiveState))
       if (
         sessionStatus
         && nextSessionId
-        && provider === 'codex'
-        && requestSessionType === 'freshcodex'
+        && canAdoptSnapshotStatus
         && !wouldRegressStatus
         && (
           snapshotIsBusy

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -1916,6 +1916,7 @@ export function FreshAgentView({
       // isStaleSnapshotRequest() when the outcome is applied, not by aborting.
       getFreshAgentThreadSnapshot(requestSessionType, provider, sessionId, {
         ...(requestCwd ? { cwd: requestCwd } : {}),
+        trigger,
       }),
     ).then((outcome) => {
       if (isStaleSnapshotRequest()) return

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -22,6 +22,7 @@ import { dismissTabGreen } from '@/store/turnCompletionAttention'
 import { registerFreshAgentCreate } from '@/lib/fresh-agent-ws'
 import { getFreshOpenCodeRouteCwd } from '@/lib/fresh-opencode-route'
 import { getRebindQueue } from '@/lib/rebind-queue'
+import { getSnapshotScheduler, makeSnapshotKey, type SnapshotTrigger } from '@/lib/fresh-agent-snapshot-scheduler'
 import {
   normalizeFreshAgentEffort,
   normalizeFreshAgentModel,
@@ -66,7 +67,6 @@ const BUSY_STATES = new Set(['running', 'compacting'])
 // server's create.failed carries no retry-after field by design).
 export const FRESH_AGENT_RESERVE_RETRY_WINDOW_MS = 30_000
 export const FRESH_AGENT_RESERVE_RETRY_FLOOR_MS = 1_000
-const SNAPSHOT_REFRESH_COALESCE_MS = 50
 const SNAPSHOT_INVALIDATING_FRESH_AGENT_EVENTS = new Set([
   'freshAgent.session.changed',
   'freshAgent.session.snapshot',
@@ -625,8 +625,13 @@ export function FreshAgentView({
   }, [])
   const [loadError, setLoadError] = useState<string | null>(null)
   const [snapshotRefreshNonce, setSnapshotRefreshNonce] = useState(0)
-  const snapshotRefreshTimerRef = useRef<number | null>(null)
-  const snapshotRefreshFollowUpRef = useRef(false)
+  const snapshotRefreshTriggerRef = useRef<SnapshotTrigger>('identity')
+  // Non-null while the snapshot key is rate-limited (429/backoff): the last
+  // good snapshot stays visible and a single retry is armed at expiry.
+  // Task 17 also consumes this for the snapshot `trigger` query param.
+  const [rateLimitedUntil, setRateLimitedUntil] = useState<number | null>(null)
+  void rateLimitedUntil
+  const rateLimitRetryTimerRef = useRef<number | null>(null)
   const [queuedMessages, setQueuedMessages] = useState<string[]>([])
   // Transient, self-clearing banner for action feedback (rewind, shell errors).
   const [notice, setNotice] = useState<string | null>(null)
@@ -812,27 +817,19 @@ export function FreshAgentView({
     }
   }, [releasePendingRebind])
 
-  const scheduleSnapshotRefresh = useCallback((options?: { followUpIfPending?: boolean }) => {
-    if (snapshotRefreshTimerRef.current !== null) {
-      if (options?.followUpIfPending) snapshotRefreshFollowUpRef.current = true
-      return
-    }
-    const fireRefresh = () => {
-      snapshotRefreshTimerRef.current = null
-      setSnapshotRefreshNonce((value) => value + 1)
-      if (!snapshotRefreshFollowUpRef.current) return
-      snapshotRefreshFollowUpRef.current = false
-      snapshotRefreshTimerRef.current = window.setTimeout(fireRefresh, SNAPSHOT_REFRESH_COALESCE_MS)
-    }
-    snapshotRefreshTimerRef.current = window.setTimeout(fireRefresh, SNAPSHOT_REFRESH_COALESCE_MS)
+  // Single trigger-tagged refresh path: every refresh site tags WHY it wants
+  // a snapshot, and the fetch effect hands that trigger to the shared per-key
+  // scheduler (debounce/coalesce now live there, not in this component).
+  const requestSnapshotRefresh = useCallback((trigger: SnapshotTrigger) => {
+    snapshotRefreshTriggerRef.current = trigger
+    setSnapshotRefreshNonce((value) => value + 1)
   }, [])
 
   useEffect(() => () => {
-    if (snapshotRefreshTimerRef.current !== null) {
-      window.clearTimeout(snapshotRefreshTimerRef.current)
-      snapshotRefreshTimerRef.current = null
+    if (rateLimitRetryTimerRef.current !== null) {
+      window.clearTimeout(rateLimitRetryTimerRef.current)
+      rateLimitRetryTimerRef.current = null
     }
-    snapshotRefreshFollowUpRef.current = false
   }, [])
 
   const recordPendingSendMetadata = useCallback((requestId: string, patch: PendingSendMetadata) => {
@@ -1062,7 +1059,7 @@ export function FreshAgentView({
     if (current.sessionId) {
       const cwd = getFreshOpenCodeRouteCwd(current, { sessionCwd: freshOpenCodeRouteCwdRef.current })
       sendFreshAgentMessage(buildFreshAgentAttachMessage(current, cwd))
-      setSnapshotRefreshNonce((value) => value + 1)
+      requestSnapshotRefresh('manual')
     } else if (current.status === 'creating' || current.status === 'starting') {
       createSentRef.current = true
       registerFreshAgentCreate(dispatch, current.createRequestId, {
@@ -1076,7 +1073,7 @@ export function FreshAgentView({
     }
 
     dispatch(consumePaneRefreshRequest({ tabId, paneId, requestId: refreshRequest.requestId }))
-  }, [buildCreateMessage, commitSnapshot, dispatch, paneId, refreshRequest, sendFreshAgentMessage, tabId])
+  }, [buildCreateMessage, commitSnapshot, dispatch, paneId, refreshRequest, requestSnapshotRefresh, sendFreshAgentMessage, tabId])
 
   const triggerRecovery = useCallback(() => {
     if (restoreTimeoutRef.current !== null) {
@@ -1375,18 +1372,18 @@ export function FreshAgentView({
         pendingRevealRefreshRef.current = true
       } else {
         sendAttach()
-        scheduleSnapshotRefresh()
+        requestSnapshotRefresh('reconnect')
       }
     })
-  }, [paneId, paneContent.sessionId, scheduleSnapshotRefresh, sendFreshAgentMessage, ws])
+  }, [paneId, paneContent.sessionId, requestSnapshotRefresh, sendFreshAgentMessage, ws])
 
   // F8: consume the deferred snapshot refresh on reveal.
   useEffect(() => {
     if (hidden) return
     if (!pendingRevealRefreshRef.current) return
     pendingRevealRefreshRef.current = false
-    scheduleSnapshotRefresh()
-  }, [hidden, scheduleSnapshotRefresh])
+    requestSnapshotRefresh('reveal')
+  }, [hidden, requestSnapshotRefresh])
 
   // reconcileNotice is a one-shot: visible for 5s, then consumed from the
   // pane content (a chat pane has no xterm write-notice channel; a timed
@@ -1492,7 +1489,7 @@ export function FreshAgentView({
           sessionRef,
         })
         migratePendingAutoTitle(current.sessionId, message.sessionId, message.provider)
-        setSnapshotRefreshNonce((value) => value + 1)
+        requestSnapshotRefresh('materialized')
         dispatch(updatePaneContent({
           tabId,
           paneId,
@@ -1539,15 +1536,13 @@ export function FreshAgentView({
         } else {
           recordPendingSendMetadata(message.requestId, { legacyAccepted: true })
         }
-        scheduleSnapshotRefresh({ followUpIfPending: true })
+        requestSnapshotRefresh('send-accepted')
       }
       if (
         isSnapshotInvalidatingFreshAgentEvent(message)
         && locatorMatchesPane(message, paneContentRef.current, freshOpenCodeRouteCwdRef.current)
       ) {
-        scheduleSnapshotRefresh({
-          followUpIfPending: readMessageEventType(message) === 'freshAgent.turn.complete',
-        })
+        requestSnapshotRefresh('event')
       }
       if (
         message.type === 'freshAgent.forked'
@@ -1588,7 +1583,7 @@ export function FreshAgentView({
       }
     })
     return unsubscribe
-  }, [agentSession?.cwd, clearReserveRedrive, commitSnapshot, dispatch, migratePendingAutoTitle, paneContent, paneContent.createRequestId, paneId, recordPendingSendMetadata, redriveAfterSessionReserved, releasePendingRebind, scheduleSnapshotRefresh, sendFreshAgentMessage, setLocalEcho, tabId, ws])
+  }, [agentSession?.cwd, clearReserveRedrive, commitSnapshot, dispatch, migratePendingAutoTitle, paneContent, paneContent.createRequestId, paneId, recordPendingSendMetadata, redriveAfterSessionReserved, releasePendingRebind, requestSnapshotRefresh, sendFreshAgentMessage, setLocalEcho, tabId, ws])
 
   useEffect(() => {
     if (!snapshotThreadId) return
@@ -1598,7 +1593,6 @@ export function FreshAgentView({
     // provider is lost -- fetching against a dead thread id is a guaranteed
     // 404 and triggerRecovery (below) is what should react to `.lost`.
     if ((paneContent.provider === 'claude' || paneContent.provider === 'codex') && agentSession?.lost) return
-    const controller = new AbortController()
     setLoadError(null)
     const sessionId = snapshotThreadId
     const provider = paneContent.provider
@@ -1610,154 +1604,187 @@ export function FreshAgentView({
       || paneContentRef.current.sessionType !== requestSessionType
       || snapshotThreadIdRef.current !== sessionId
     )
-    const requestCwd = paneContentRef.current.initialCwd
+    // A1: resolve the cwd ONCE (route cwd falls through initialCwd -> session
+    // cwd) and use the SAME value for both the scheduler key and the request,
+    // so sibling panes whose raw initialCwd diverges ('' vs '/w') still share
+    // one key -- keying on raw initialCwd would let the N-pane fan-out survive.
+    const requestCwd = freshOpenCodeRouteCwdRef.current ?? paneContentRef.current.initialCwd
     const requestAgentSessionStatusVersion = agentSessionStatusVersionRef.current
-    void getFreshAgentThreadSnapshot(requestSessionType, provider, sessionId, {
-      signal: controller.signal,
-      ...(requestCwd ? { cwd: requestCwd } : {}),
-    })
-      .then((next) => {
-        if (isStaleSnapshotRequest()) return
-        const snapshotIdentity = currentAutoTitleIdentityRef.current
-        const resolved = next as FreshAgentSnapshot
-        const resolvedHasUserTurns = freshAgentSnapshotHasUserTurn(resolved)
-        if (!resolvedHasUserTurns && !autoTitleSentRef.current) {
-          autoTitleFreshBoundaryRef.current = true
-        }
-        if (resolvedHasUserTurns) {
-          autoTitleFreshBoundaryRef.current = false
-          autoTitleSentRef.current = true
-        }
-        const previousSnapshot = snapshotRef.current
-        const displaySnapshot = mergeSnapshotForDisplay(previousSnapshot, resolved)
-        const snapshotAccepted = displaySnapshot !== previousSnapshot
-        commitSnapshot(displaySnapshot)
-        setSnapshotAutoTitleIdentity(snapshotIdentity)
-        const echo = localEchoRef.current
-        const echoPendingMetadata = echo ? pendingSendMetadataRef.current.get(echo.requestId) : undefined
-        const landedEcho = echo
-          ? localEchoLanded(displaySnapshot.turns, echo, echoPendingMetadata, {
-              allowTextMatch: snapshotAccepted,
-              previousTurns: previousSnapshot?.turns,
-            })
-          : false
-        const staleEcho = echo
-          ? snapshotAccepted && shouldClearStaleLocalEcho(displaySnapshot, echo, echoPendingMetadata)
-          : false
-        if (echo) {
-          if (landedEcho || staleEcho) setLocalEcho(null)
-        }
+    const applySnapshot = (next: FreshAgentSnapshot) => {
+      const snapshotIdentity = currentAutoTitleIdentityRef.current
+      const resolved = next as FreshAgentSnapshot
+      const resolvedHasUserTurns = freshAgentSnapshotHasUserTurn(resolved)
+      if (!resolvedHasUserTurns && !autoTitleSentRef.current) {
+        autoTitleFreshBoundaryRef.current = true
+      }
+      if (resolvedHasUserTurns) {
+        autoTitleFreshBoundaryRef.current = false
+        autoTitleSentRef.current = true
+      }
+      const previousSnapshot = snapshotRef.current
+      const displaySnapshot = mergeSnapshotForDisplay(previousSnapshot, resolved)
+      const snapshotAccepted = displaySnapshot !== previousSnapshot
+      commitSnapshot(displaySnapshot)
+      setSnapshotAutoTitleIdentity(snapshotIdentity)
+      const echo = localEchoRef.current
+      const echoPendingMetadata = echo ? pendingSendMetadataRef.current.get(echo.requestId) : undefined
+      const landedEcho = echo
+        ? localEchoLanded(displaySnapshot.turns, echo, echoPendingMetadata, {
+            allowTextMatch: snapshotAccepted,
+            previousTurns: previousSnapshot?.turns,
+          })
+        : false
+      const staleEcho = echo
+        ? snapshotAccepted && shouldClearStaleLocalEcho(displaySnapshot, echo, echoPendingMetadata)
+        : false
+      if (echo) {
+        if (landedEcho || staleEcho) setLocalEcho(null)
+      }
+      const fresh = paneContentRef.current
+      const nextStatus = (resolved.status as FreshAgentPaneContent['status']) ?? fresh.status
+      const snapshotSessionRef = provider === 'opencode' && resolved.sessionId && resolved.sessionId !== sessionId
+        ? { provider, sessionId: resolved.sessionId }
+        : undefined
+      const nextSessionId = snapshotSessionRef?.sessionId ?? fresh.sessionId
+      const nextSessionRef = snapshotSessionRef ?? fresh.sessionRef
+      const nextResumeSessionId = snapshotSessionRef?.sessionId ?? fresh.resumeSessionId ?? sessionId
+      if (snapshotSessionRef) {
+        migratePendingAutoTitle(fresh.sessionId, snapshotSessionRef.sessionId, provider)
+      }
+      const hasBlockingLocalEchoForSession = hasUnresolvedLocalEchoForSessionRef.current
+      const sessionStatus = nextStatus === 'create-failed' ? null : nextStatus
+      const snapshotIsBusy = sessionStatus === 'running' || sessionStatus === 'compacting'
+      const statusChangedSinceRequest = agentSessionStatusVersionRef.current !== requestAgentSessionStatusVersion
+      const currentSessionStatus = agentSessionStatusRef.current ?? fresh.status
+      const wouldRegressStatus = sessionStatus
+        ? isStatusRegression(currentSessionStatus, sessionStatus)
+        : false
+      if (
+        sessionStatus
+        && nextSessionId
+        && provider === 'codex'
+        && requestSessionType === 'freshcodex'
+        && !wouldRegressStatus
+        && (
+          snapshotIsBusy
+          || (!hasBlockingLocalEchoForSession && !statusChangedSinceRequest)
+        )
+      ) {
+        dispatch(setSessionStatus({
+          sessionId: nextSessionId,
+          sessionType: requestSessionType,
+          provider,
+          status: sessionStatus,
+        }))
+      }
+      if (
+        nextStatus === fresh.status
+        && nextSessionId === fresh.sessionId
+        && nextResumeSessionId === fresh.resumeSessionId
+        && nextSessionRef?.provider === fresh.sessionRef?.provider
+        && nextSessionRef?.sessionId === fresh.sessionRef?.sessionId
+      ) {
+        return
+      }
+      dispatch(updatePaneContent({
+        tabId,
+        paneId,
+        content: {
+          ...fresh,
+          sessionId: nextSessionId,
+          sessionRef: nextSessionRef,
+          status: nextStatus,
+          resumeSessionId: nextResumeSessionId,
+          pendingLocalEcho: landedEcho || staleEcho ? undefined : fresh.pendingLocalEcho,
+        },
+      }))
+    }
+    const handleSnapshotError = (error: unknown) => {
+      // AbortError swallow kept as harmless dead armor: scheduler-path
+      // fetches carry no signal (A2), so this can no longer fire.
+      if (error instanceof Error && error.name === 'AbortError') return
+      if (isStaleSnapshotRequest()) return
+      if (paneContent.provider === 'claude' && claudeSession && isRestoring) {
+        // While a restore is in flight the snapshot legitimately 404s.
+        // Outside of restore, swallowing here left dead Claude sessions as
+        // silent blank panes (live-test finding) — let the error surface.
+        setLoadError(null)
+        return
+      }
+      if (paneContent.provider === 'codex' && isUnmaterializedCodexThreadError(error)) {
         const fresh = paneContentRef.current
-        const nextStatus = (resolved.status as FreshAgentPaneContent['status']) ?? fresh.status
-        const snapshotSessionRef = provider === 'opencode' && resolved.sessionId && resolved.sessionId !== sessionId
-          ? { provider, sessionId: resolved.sessionId }
-          : undefined
-        const nextSessionId = snapshotSessionRef?.sessionId ?? fresh.sessionId
-        const nextSessionRef = snapshotSessionRef ?? fresh.sessionRef
-        const nextResumeSessionId = snapshotSessionRef?.sessionId ?? fresh.resumeSessionId ?? sessionId
-        if (snapshotSessionRef) {
-          migratePendingAutoTitle(fresh.sessionId, snapshotSessionRef.sessionId, provider)
-        }
-        const hasBlockingLocalEchoForSession = hasUnresolvedLocalEchoForSessionRef.current
-        const sessionStatus = nextStatus === 'create-failed' ? null : nextStatus
-        const snapshotIsBusy = sessionStatus === 'running' || sessionStatus === 'compacting'
-        const statusChangedSinceRequest = agentSessionStatusVersionRef.current !== requestAgentSessionStatusVersion
-        const currentSessionStatus = agentSessionStatusRef.current ?? fresh.status
-        const wouldRegressStatus = sessionStatus
-          ? isStatusRegression(currentSessionStatus, sessionStatus)
-          : false
-        if (
-          sessionStatus
-          && nextSessionId
-          && provider === 'codex'
-          && requestSessionType === 'freshcodex'
-          && !wouldRegressStatus
-          && (
-            snapshotIsBusy
-            || (!hasBlockingLocalEchoForSession && !statusChangedSinceRequest)
-          )
-        ) {
-          dispatch(setSessionStatus({
-            sessionId: nextSessionId,
-            sessionType: requestSessionType,
-            provider,
-            status: sessionStatus,
-          }))
-        }
-        if (
-          nextStatus === fresh.status
-          && nextSessionId === fresh.sessionId
-          && nextResumeSessionId === fresh.resumeSessionId
-          && nextSessionRef?.provider === fresh.sessionRef?.provider
-          && nextSessionRef?.sessionId === fresh.sessionRef?.sessionId
-        ) {
-          return
-        }
+        setLoadError(null)
+        commitSnapshot(null)
         dispatch(updatePaneContent({
           tabId,
           paneId,
           content: {
             ...fresh,
-            sessionId: nextSessionId,
-            sessionRef: nextSessionRef,
-            status: nextStatus,
-            resumeSessionId: nextResumeSessionId,
-            pendingLocalEcho: landedEcho || staleEcho ? undefined : fresh.pendingLocalEcho,
+            sessionId: undefined,
+            sessionRef: undefined,
+            createRequestId: nanoid(),
+            status: 'idle',
+            createError: undefined,
+            restoreError: buildRestoreError('durable_artifact_missing'),
           },
         }))
-      })
-      .catch((error: unknown) => {
-        if (error instanceof Error && error.name === 'AbortError') return
-        if (isStaleSnapshotRequest()) return
-        if (paneContent.provider === 'claude' && claudeSession && isRestoring) {
-          // While a restore is in flight the snapshot legitimately 404s.
-          // Outside of restore, swallowing here left dead Claude sessions as
-          // silent blank panes (live-test finding) — let the error surface.
-          setLoadError(null)
-          return
+        return
+      }
+      if (paneContent.provider === 'opencode' && isLostFreshOpencodeThreadError(error)) {
+        const fresh = paneContentRef.current
+        setLoadError(null)
+        commitSnapshot(null)
+        dispatch(updatePaneContent({
+          tabId,
+          paneId,
+          content: {
+            ...fresh,
+            sessionId: undefined,
+            sessionRef: undefined,
+            resumeSessionId: undefined,
+            createRequestId: nanoid(),
+            status: 'idle',
+            createError: undefined,
+            restoreError: buildRestoreError('durable_artifact_missing'),
+          },
+        }))
+        return
+      }
+      setLoadError(error instanceof Error ? error.message : 'Failed to load session')
+    }
+    const key = makeSnapshotKey({ sessionType: requestSessionType, provider, threadId: sessionId, cwd: requestCwd })
+    const trigger = snapshotRefreshTriggerRef.current
+    void getSnapshotScheduler().schedule(key, trigger, () =>
+      // NO signal: the run may execute on behalf of other panes sharing the
+      // key, or after this effect cleaned up (A2). Staleness is handled by
+      // isStaleSnapshotRequest() when the outcome is applied, not by aborting.
+      getFreshAgentThreadSnapshot(requestSessionType, provider, sessionId, {
+        ...(requestCwd ? { cwd: requestCwd } : {}),
+      }),
+    ).then((outcome) => {
+      if (isStaleSnapshotRequest()) return
+      if (outcome.status === 'ok') {
+        applySnapshot(outcome.value as FreshAgentSnapshot)
+        return
+      }
+      if (outcome.status === 'rate-limited' || outcome.status === 'backoff') {
+        // Keep the last good snapshot visible; no error banner. Re-arm one
+        // retry at expiry (dedupe: never arm a second timer alongside one
+        // already counting down).
+        setRateLimitedUntil(outcome.retryAtMs)
+        if (rateLimitRetryTimerRef.current === null) {
+          const delay = Math.max(0, outcome.retryAtMs - Date.now())
+          rateLimitRetryTimerRef.current = window.setTimeout(() => {
+            rateLimitRetryTimerRef.current = null
+            setRateLimitedUntil(null)
+            requestSnapshotRefresh('manual')
+          }, delay + 50)
         }
-        if (paneContent.provider === 'codex' && isUnmaterializedCodexThreadError(error)) {
-          const fresh = paneContentRef.current
-          setLoadError(null)
-          commitSnapshot(null)
-          dispatch(updatePaneContent({
-            tabId,
-            paneId,
-            content: {
-              ...fresh,
-              sessionId: undefined,
-              sessionRef: undefined,
-              createRequestId: nanoid(),
-              status: 'idle',
-              createError: undefined,
-              restoreError: buildRestoreError('durable_artifact_missing'),
-            },
-          }))
-          return
-        }
-        if (paneContent.provider === 'opencode' && isLostFreshOpencodeThreadError(error)) {
-          const fresh = paneContentRef.current
-          setLoadError(null)
-          commitSnapshot(null)
-          dispatch(updatePaneContent({
-            tabId,
-            paneId,
-            content: {
-              ...fresh,
-              sessionId: undefined,
-              sessionRef: undefined,
-              resumeSessionId: undefined,
-              createRequestId: nanoid(),
-              status: 'idle',
-              createError: undefined,
-              restoreError: buildRestoreError('durable_artifact_missing'),
-            },
-          }))
-          return
-        }
-        setLoadError(error instanceof Error ? error.message : 'Failed to load session')
-      })
-    return () => controller.abort()
+        return
+      }
+      if (outcome.status === 'coalesced') return
+      handleSnapshotError(outcome.error)
+    })
     // Depend only on what identifies *which* snapshot to load. This effect
     // dispatches updatePaneContent to persist its own resolved resumeSessionId/
     // status; listing the whole paneContent object (or those output fields) made
@@ -1776,6 +1803,7 @@ export function FreshAgentView({
     paneId,
     commitSnapshot,
     migratePendingAutoTitle,
+    requestSnapshotRefresh,
     setLocalEcho,
     snapshotThreadId,
     snapshotRefreshNonce,
@@ -1927,10 +1955,10 @@ export function FreshAgentView({
     if (hidden || !paneContent.sessionId) return
     if (!isBusy && !EARLY_STATES.has(effectiveStatus)) return
     const timer = window.setInterval(() => {
-      setSnapshotRefreshNonce((value) => value + 1)
+      requestSnapshotRefresh('poll')
     }, 3000)
     return () => window.clearInterval(timer)
-  }, [effectiveStatus, hidden, isBusy, paneContent.sessionId])
+  }, [effectiveStatus, hidden, isBusy, paneContent.sessionId, requestSnapshotRefresh])
 
   useEffect(() => {
     if (!notice) return

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -105,6 +105,10 @@ type PendingSendMetadata = {
   submittedTurnId?: string
   legacyAccepted?: boolean
   metadataUpdateStarted?: boolean
+  /** The exact text of the freshAgent.send frame -- retained as the resend
+   * payload for the lost-session retry (Task 10). Never read back from the
+   * local echo. */
+  text?: string
 }
 
 function localEchoLanded(
@@ -642,6 +646,10 @@ export function FreshAgentView({
   const localEchoRef = useRef<LocalEcho | null>(null)
   localEchoRef.current = localEcho
   const pendingSendMetadataRef = useRef<Map<string, PendingSendMetadata>>(new Map())
+  // Task 10: requestIds whose FRESH_AGENT_LOST_SESSION failure already fired a
+  // retry, plus the retry requestIds themselves -- a retry is never retried,
+  // so a resend can happen at most once per failed request (loop-proof).
+  const lostSessionRetryRef = useRef<Set<string>>(new Set())
   const descriptor = resolveFreshAgentType(paneContent.sessionType)
   // Capability-gated commands (e.g. /fork) only appear once the snapshot
   // confirms the provider supports the action.
@@ -862,6 +870,45 @@ export function FreshAgentView({
         }
       })
   }, [])
+
+  /** Builds and sends the freshAgent.send frame. Shared by the composer
+   * submit path (sendUserText) and the lost-session retry (Task 10) so the
+   * retry frame carries exactly the same fields, plus the route cwd. */
+  const sendFreshAgentSendFrame = useCallback((requestId: string, text: string, cwd?: string) => {
+    const current = paneContentRef.current
+    if (!current.sessionId) return
+    sendFreshAgentMessage({
+      type: 'freshAgent.send',
+      requestId,
+      sessionId: current.sessionId,
+      sessionType: current.sessionType,
+      provider: current.provider,
+      ...(cwd ? { cwd } : {}),
+      text,
+      settings: {
+        ...(current.initialCwd ? { cwd: current.initialCwd } : {}),
+        ...(resolveEffectiveFreshAgentModel(current, providerDefaults) ? { model: resolveEffectiveFreshAgentModel(current, providerDefaults) } : {}),
+        ...(getEffectiveFreshAgentPermissionMode(current) ? { permissionMode: getEffectiveFreshAgentPermissionMode(current) } : {}),
+        ...(current.sandbox ? { sandbox: current.sandbox } : {}),
+        ...(getEffectiveFreshAgentEffort(current, providerDefaults) ? { effort: getEffectiveFreshAgentEffort(current, providerDefaults) } : {}),
+      },
+    })
+  }, [providerDefaults, sendFreshAgentMessage])
+
+  /** Task 10: re-issue a failed send under a fresh requestId with the
+   * retained text + route cwd. The retry gets its own pending-metadata entry
+   * (same text) so a second failure cleans up through the normal fall-through
+   * path, and the visible local echo is re-stamped to the retry's requestId
+   * so the retry's eventual acceptance or failure correlates with what is on
+   * screen. */
+  const resendPendingMessage = useCallback((retryRequestId: string, text: string, cwd: string) => {
+    recordPendingSendMetadata(retryRequestId, { text })
+    sendFreshAgentSendFrame(retryRequestId, text, cwd)
+    const echo = localEchoRef.current
+    if (echo && echo.text === text) {
+      setLocalEcho({ ...echo, requestId: retryRequestId })
+    }
+  }, [recordPendingSendMetadata, sendFreshAgentSendFrame, setLocalEcho])
 
   const migratePendingAutoTitle = useCallback((
     previousSessionId: string | undefined,
@@ -1538,6 +1585,60 @@ export function FreshAgentView({
         }
         requestSnapshotRefresh('send-accepted')
       }
+      if (message.type === 'error') {
+        // Task 10: owned send failures. `requestId` is the only correlation
+        // handle on an error frame, and freshAgent.send is the only
+        // fresh-agent path that threads it: frames whose requestId matches a
+        // pendingSendMetadataRef entry are this pane's send failures. Frames
+        // with no matching requestId are not ours -- leave them alone.
+        const failedRequestId = typeof message.requestId === 'string' ? message.requestId : undefined
+        if (!failedRequestId || !pendingSendMetadataRef.current.has(failedRequestId)) return
+        const current = paneContentRef.current
+        if (
+          message.code === 'FRESH_AGENT_LOST_SESSION'
+          && current.sessionType === 'freshopencode'
+          && !lostSessionRetryRef.current.has(failedRequestId)
+        ) {
+          const pendingMeta = pendingSendMetadataRef.current.get(failedRequestId)
+          const cwd = freshOpenCodeRouteCwdRef.current
+          const sessionId = current.sessionId
+          // The ses_ guard keeps genuinely-invalid placeholder/non-durable
+          // lost-session errors on the normal cleanup path below.
+          if (pendingMeta?.text && cwd && sessionId && sessionId.startsWith('ses_')) {
+            // Re-attach with the route cwd (the incident's no-cwd locator),
+            // then resend the retained text exactly once. The original
+            // request is consumed here; the retry itself is never retried.
+            lostSessionRetryRef.current.add(failedRequestId)
+            pendingSendMetadataRef.current.delete(failedRequestId)
+            sendFreshAgentMessage({
+              type: 'freshAgent.attach',
+              sessionId,
+              sessionType: 'freshopencode',
+              provider: 'opencode',
+              cwd,
+            })
+            const retryRequestId = nanoid()
+            lostSessionRetryRef.current.add(retryRequestId)
+            resendPendingMessage(retryRequestId, pendingMeta.text, cwd)
+            // Do NOT fall through: the echo stays visible while the retry is
+            // in flight.
+            return
+          }
+        }
+        // Cleanup fall-through: every owned send failure that did not take
+        // the retry path (including a retried request failing again) releases
+        // the three leaks a failed send otherwise leaves behind -- the
+        // pending-metadata entry, the stale local echo (dual-write), and the
+        // optimistic `running` status.
+        pendingSendMetadataRef.current.delete(failedRequestId)
+        if (localEchoRef.current?.requestId === failedRequestId) {
+          setLocalEcho(null)
+        }
+        if (current.provider === 'opencode' && current.status === 'running') {
+          dispatch(mergePaneContent({ tabId, paneId, updates: { status: 'idle' } }))
+        }
+        return
+      }
       if (
         isSnapshotInvalidatingFreshAgentEvent(message)
         && locatorMatchesPane(message, paneContentRef.current, freshOpenCodeRouteCwdRef.current)
@@ -1583,7 +1684,7 @@ export function FreshAgentView({
       }
     })
     return unsubscribe
-  }, [agentSession?.cwd, clearReserveRedrive, commitSnapshot, dispatch, migratePendingAutoTitle, paneContent, paneContent.createRequestId, paneId, recordPendingSendMetadata, redriveAfterSessionReserved, releasePendingRebind, requestSnapshotRefresh, sendFreshAgentMessage, setLocalEcho, tabId, ws])
+  }, [agentSession?.cwd, clearReserveRedrive, commitSnapshot, dispatch, migratePendingAutoTitle, paneContent, paneContent.createRequestId, paneId, recordPendingSendMetadata, redriveAfterSessionReserved, releasePendingRebind, requestSnapshotRefresh, resendPendingMessage, sendFreshAgentMessage, setLocalEcho, tabId, ws])
 
   useEffect(() => {
     if (!snapshotThreadId) return
@@ -1981,7 +2082,9 @@ export function FreshAgentView({
     if (!current.sessionId) return
     const requestId = nanoid()
     const routeCwd = getFreshOpenCodeRouteCwd(current, { sessionCwd: freshOpenCodeRouteCwdRef.current })
-    recordPendingSendMetadata(requestId, {})
+    // Retain the exact outgoing text as the resend payload (Task 10): the
+    // lost-session retry resends from this metadata, never from the echo.
+    recordPendingSendMetadata(requestId, { text })
     // Checkpoint the working tree before the agent acts on this message, so
     // "rewind code to here" on this turn restores the pre-turn state. Fire and
     // forget: a failed snapshot must never block the send.
@@ -2018,22 +2121,7 @@ export function FreshAgentView({
       }))
     }
     const nextLocalEcho: LocalEcho = { text, requestId }
-    sendFreshAgentMessage({
-      type: 'freshAgent.send',
-      requestId,
-      sessionId: current.sessionId,
-      sessionType: current.sessionType,
-      provider: current.provider,
-      ...(routeCwd ? { cwd: routeCwd } : {}),
-      text,
-      settings: {
-        ...(current.initialCwd ? { cwd: current.initialCwd } : {}),
-        ...(resolveEffectiveFreshAgentModel(current, providerDefaults) ? { model: resolveEffectiveFreshAgentModel(current, providerDefaults) } : {}),
-        ...(getEffectiveFreshAgentPermissionMode(current) ? { permissionMode: getEffectiveFreshAgentPermissionMode(current) } : {}),
-        ...(current.sandbox ? { sandbox: current.sandbox } : {}),
-        ...(getEffectiveFreshAgentEffort(current, providerDefaults) ? { effort: getEffectiveFreshAgentEffort(current, providerDefaults) } : {}),
-      },
-    })
+    sendFreshAgentSendFrame(requestId, text, routeCwd)
     setLocalEchoState(nextLocalEcho)
     dispatch(mergePaneContent({
       tabId,
@@ -2043,7 +2131,7 @@ export function FreshAgentView({
         pendingLocalEcho: nextLocalEcho,
       },
     }))
-  }, [dispatch, paneId, providerDefaults, recordPendingSendMetadata, sendFreshAgentMessage, snapshotConfirmsNoUserTurns, tabId])
+  }, [dispatch, paneId, recordPendingSendMetadata, sendFreshAgentSendFrame, snapshotConfirmsNoUserTurns, tabId])
 
   // Flush queued messages when the turn ends. One flush per status change is
   // enough: all queued entries are delivered in order for the next turn.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -419,7 +419,7 @@ export async function getFreshAgentThreadSnapshot(
   sessionType: string,
   provider: string,
   threadId: string,
-  query: { revision?: number; cwd?: string; signal?: AbortSignal } = {},
+  query: { revision?: number; cwd?: string; trigger?: string; signal?: AbortSignal } = {},
   options: ApiRequestOptions = {},
 ): Promise<any> {
   const signal = query.signal ?? options.signal
@@ -427,6 +427,7 @@ export async function getFreshAgentThreadSnapshot(
     `/api/fresh-agent/threads/${encodeURIComponent(sessionType)}/${encodeURIComponent(provider)}/${encodeURIComponent(threadId)}${buildQueryString([
       ['revision', query.revision],
       ['cwd', query.cwd],
+      ['trigger', query.trigger],
     ])}`,
     { ...options, signal },
   )

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -41,12 +41,14 @@ import {
 export class ApiError extends Error {
   readonly status: number
   readonly details?: unknown
+  readonly retryAfterMs?: number
 
-  constructor(status: number, message: string, details?: unknown) {
+  constructor(status: number, message: string, details?: unknown, retryAfterMs?: number) {
     super(message)
     this.name = 'ApiError'
     this.status = status
     this.details = details
+    this.retryAfterMs = retryAfterMs
   }
 
   // `Error.prototype.message` is non-enumerable, so a bare `JSON.stringify` of an
@@ -120,6 +122,16 @@ export function isApiUnauthorizedError(error: unknown): error is ApiError {
 // Vite dev proxy) couldn't service the request right now. During a restart these
 // are expected and transient — unlike a 500 (app bug) or 4xx (client error).
 const TRANSIENT_HTTP_STATUSES = new Set([502, 503, 504])
+
+/** Parse a Retry-After header (delta-seconds or HTTP-date) into milliseconds. */
+export function parseRetryAfterMs(value: string | null | undefined, nowMs = Date.now()): number | undefined {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  if (/^\d+$/.test(trimmed)) return Number(trimmed) * 1000
+  const dateMs = Date.parse(trimmed)
+  if (!Number.isFinite(dateMs)) return undefined
+  return Math.max(0, dateMs - nowMs)
+}
 
 function isAbortError(error: unknown): boolean {
   if (typeof DOMException !== 'undefined' && error instanceof DOMException) {
@@ -247,7 +259,10 @@ async function request<T = any>(path: string, options: RequestInit = {}): Promis
   }
 
   if (!res.ok) {
-    throw new ApiError(res.status, getApiErrorMessage(data, res.statusText), data)
+    const retryAfterMs = res.status === 429
+      ? parseRetryAfterMs(typeof res.headers?.get === 'function' ? res.headers.get('retry-after') : undefined)
+      : undefined
+    throw new ApiError(res.status, getApiErrorMessage(data, res.statusText), data, retryAfterMs)
   }
 
   return data as T

--- a/src/lib/fresh-agent-snapshot-scheduler.ts
+++ b/src/lib/fresh-agent-snapshot-scheduler.ts
@@ -153,6 +153,28 @@ export class FreshAgentSnapshotScheduler {
       s.trailingRequested = false
     }
   }
+
+  /**
+   * Test-only teardown: cancel pending debounced runs and drop all key state.
+   * The singleton outlives component unmount BY DESIGN (run-closure contract),
+   * so without this a debounce timer armed near the end of one test fires its
+   * stale run into the next test (consuming that test's mock queues). Queued
+   * resolvers are resolved as coalesced so no caller promise is left pending.
+   */
+  disposeForTests(): void {
+    for (const s of this.keys.values()) {
+      if (s.debounceTimer !== null) {
+        clearTimeout(s.debounceTimer)
+        s.debounceTimer = null
+      }
+      s.trailingRequested = false
+      s.pendingRun = null
+      const resolvers = s.pendingResolvers
+      s.pendingResolvers = []
+      for (const resolve of resolvers) resolve({ status: 'coalesced' })
+    }
+    this.keys.clear()
+  }
 }
 
 let singleton: FreshAgentSnapshotScheduler | null = null
@@ -163,5 +185,6 @@ export function getSnapshotScheduler(): FreshAgentSnapshotScheduler {
 }
 
 export function resetSnapshotSchedulerForTests(): void {
+  singleton?.disposeForTests()
   singleton = null
 }

--- a/src/lib/fresh-agent-snapshot-scheduler.ts
+++ b/src/lib/fresh-agent-snapshot-scheduler.ts
@@ -1,0 +1,167 @@
+/**
+ * FreshAgentSnapshotScheduler -- per-snapshot-key scheduler for fresh-agent
+ * snapshot GETs: single-flight, trailing coalesce, class-based debounce, and
+ * 429 backoff (Retry-After or exponential). Module singleton, precedent:
+ * getRebindQueue()/resetRebindQueueForTests() in src/lib/rebind-queue.ts.
+ *
+ * Run-closure contract: the scheduler may execute a `run` closure long after
+ * the caller's React effect cleaned up (debounce/trailing), and one caller's
+ * closure runs on behalf of ALL sharers of the key. Callers must NOT bind
+ * caller-scoped AbortControllers/signals into `run` -- an owner abort
+ * mid-flight (or a debounced run firing an already-aborted signal) would
+ * resolve { status: 'error', AbortError } to every sharer, silently dropping
+ * the refresh for panes that are still alive. Pass no signal; staleness is
+ * handled by result-application guards, not cancellation.
+ */
+
+import { ApiError } from '@/lib/api'
+
+export type SnapshotTrigger =
+  | 'identity' | 'event' | 'send-accepted' | 'materialized'
+  | 'manual' | 'poll' | 'reconnect' | 'reveal' | 'idle-incomplete'
+
+export type SnapshotOutcome<T> =
+  | { status: 'ok'; value: T }
+  | { status: 'rate-limited'; retryAtMs: number }
+  | { status: 'backoff'; retryAtMs: number }
+  | { status: 'coalesced' }
+  | { status: 'error'; error: unknown }
+
+export const SNAPSHOT_DEBOUNCE_MS = 250
+const BACKOFF_BASE_MS = 1_000
+const BACKOFF_MAX_MS = 30_000
+
+const DEBOUNCED_TRIGGERS: ReadonlySet<SnapshotTrigger> = new Set(['event', 'send-accepted', 'reveal', 'reconnect'])
+
+export function makeSnapshotKey(input: {
+  sessionType: string; provider: string; threadId: string; cwd?: string
+}): string {
+  return `${input.sessionType}:${input.provider}:${input.threadId}:${input.cwd ?? ''}`
+}
+
+type Resolver<T> = (outcome: SnapshotOutcome<T>) => void
+
+type KeyState = {
+  inFlight: boolean
+  debounceTimer: ReturnType<typeof setTimeout> | null
+  /** Callers waiting on the pending (debounced or trailing) run. */
+  pendingResolvers: Resolver<any>[]
+  /** Latest run fn wins for the pending run. */
+  pendingRun: (() => Promise<any>) | null
+  trailingRequested: boolean
+  backoffUntil: number | null
+  consecutive429: number
+}
+
+export class FreshAgentSnapshotScheduler {
+  private readonly keys = new Map<string, KeyState>()
+
+  private state(key: string): KeyState {
+    let s = this.keys.get(key)
+    if (!s) {
+      s = {
+        inFlight: false, debounceTimer: null, pendingResolvers: [],
+        pendingRun: null, trailingRequested: false, backoffUntil: null, consecutive429: 0,
+      }
+      this.keys.set(key, s)
+    }
+    return s
+  }
+
+  getBackoffUntil(key: string): number | null {
+    const s = this.keys.get(key)
+    if (!s?.backoffUntil) return null
+    if (s.backoffUntil <= Date.now()) return null
+    return s.backoffUntil
+  }
+
+  schedule<T>(key: string, trigger: SnapshotTrigger, run: () => Promise<T>): Promise<SnapshotOutcome<T>> {
+    const s = this.state(key)
+    const retryAt = this.getBackoffUntil(key)
+    if (retryAt !== null) {
+      return Promise.resolve({ status: 'backoff', retryAtMs: retryAt })
+    }
+    return new Promise<SnapshotOutcome<T>>((resolve) => {
+      s.pendingResolvers.push(resolve as Resolver<any>)
+      s.pendingRun = run
+      if (s.inFlight) {
+        s.trailingRequested = true
+        return
+      }
+      const delay = DEBOUNCED_TRIGGERS.has(trigger) ? SNAPSHOT_DEBOUNCE_MS : 0
+      if (s.debounceTimer !== null) {
+        if (delay === 0) {
+          clearTimeout(s.debounceTimer)
+          s.debounceTimer = null
+          void this.execute(key)
+        }
+        return // burst absorbed into the pending timer
+      }
+      if (delay === 0) {
+        void this.execute(key)
+      } else {
+        s.debounceTimer = setTimeout(() => {
+          s.debounceTimer = null
+          void this.execute(key)
+        }, delay)
+      }
+    })
+  }
+
+  private async execute(key: string): Promise<void> {
+    const s = this.state(key)
+    const run = s.pendingRun
+    const resolvers = s.pendingResolvers
+    s.pendingRun = null
+    s.pendingResolvers = []
+    if (!run) return
+    s.inFlight = true
+    let outcome: SnapshotOutcome<any>
+    try {
+      const value = await run()
+      s.consecutive429 = 0
+      s.backoffUntil = null
+      outcome = { status: 'ok', value }
+    } catch (error: unknown) {
+      if (error instanceof ApiError && error.status === 429) {
+        s.consecutive429 += 1
+        const fallback = Math.min(BACKOFF_MAX_MS, BACKOFF_BASE_MS * 2 ** (s.consecutive429 - 1))
+        const retryAtMs = Date.now() + (error.retryAfterMs ?? fallback)
+        s.backoffUntil = retryAtMs
+        outcome = { status: 'rate-limited', retryAtMs }
+        // A 429 supersedes any trailing request: cancel it AND resolve the
+        // mid-flight cohort queued behind this run with the same rate-limited
+        // outcome -- their promises must never be left pending.
+        s.trailingRequested = false
+        const trailing = s.pendingResolvers
+        s.pendingResolvers = []
+        s.pendingRun = null
+        for (const resolve of trailing) resolve(outcome)
+      } else {
+        outcome = { status: 'error', error }
+      }
+    }
+    s.inFlight = false
+    for (const resolve of resolvers) resolve(outcome)
+    if (s.trailingRequested && s.pendingRun) {
+      s.trailingRequested = false
+      s.debounceTimer = setTimeout(() => {
+        s.debounceTimer = null
+        void this.execute(key)
+      }, SNAPSHOT_DEBOUNCE_MS)
+    } else {
+      s.trailingRequested = false
+    }
+  }
+}
+
+let singleton: FreshAgentSnapshotScheduler | null = null
+
+export function getSnapshotScheduler(): FreshAgentSnapshotScheduler {
+  if (!singleton) singleton = new FreshAgentSnapshotScheduler()
+  return singleton
+}
+
+export function resetSnapshotSchedulerForTests(): void {
+  singleton = null
+}

--- a/test/helpers/ws-backpressure.ts
+++ b/test/helpers/ws-backpressure.ts
@@ -1,0 +1,85 @@
+import { EventEmitter } from 'events'
+import WebSocket from 'ws'
+import { vi } from 'vitest'
+
+/** Mock WebSocket that extends EventEmitter (like real ws WebSockets). */
+export type MockWs = EventEmitter & {
+  bufferedAmount: number
+  readyState: number
+  send: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+  connectionId?: string
+  sessionUpdateGeneration?: number
+}
+
+/** Create a mock WebSocket with settable bufferedAmount and spied send/close. */
+export function createMockWs(overrides: Record<string, unknown> = {}): MockWs {
+  const ws = new EventEmitter() as MockWs
+  ws.bufferedAmount = 0
+  ws.readyState = WebSocket.OPEN
+  ws.send = vi.fn()
+  ws.close = vi.fn()
+  Object.assign(ws, overrides)
+  return ws
+}
+
+type MockedLogFn = { mock: { calls: unknown[][] } }
+
+export type MockedStructuredLogger = Record<'debug' | 'info' | 'warn' | 'error', MockedLogFn>
+
+/** Filter a mocked logger's structured payloads down to a single event name. */
+export function structuredLogsFrom(
+  logger: MockedStructuredLogger,
+  level: 'debug' | 'info' | 'warn' | 'error',
+  event: string,
+): Record<string, unknown>[] {
+  return logger[level].mock.calls
+    .map(([payload]) => payload)
+    .filter((payload): payload is Record<string, unknown> => (
+      !!payload
+      && typeof payload === 'object'
+      && (payload as { event?: unknown }).event === event
+    ))
+}
+
+/**
+ * Minimal registry double for TerminalStreamBroker tests: emits
+ * 'terminal.output.raw' and satisfies the attach/get/replay-budget surface
+ * the broker consumes.
+ */
+export class FakeBrokerRegistry extends EventEmitter {
+  private records = new Map<string, { terminalId: string; mode: string; buffer: { snapshot: () => string } }>()
+  private replayRingMaxChars: number | undefined
+
+  createTerminal(terminalId: string, mode = 'shell') {
+    this.records.set(terminalId, {
+      terminalId,
+      mode,
+      buffer: { snapshot: () => '' },
+    })
+  }
+
+  attach(terminalId: string) {
+    return this.records.get(terminalId) ?? null
+  }
+
+  resize(_terminalId: string, _cols: number, _rows: number) {
+    return true
+  }
+
+  detach(_terminalId: string) {
+    return true
+  }
+
+  setReplayRingMaxBytes(next: number | undefined) {
+    this.replayRingMaxChars = next
+  }
+
+  getReplayRingMaxChars() {
+    return this.replayRingMaxChars
+  }
+
+  get(terminalId: string) {
+    return this.records.get(terminalId)
+  }
+}

--- a/test/integration/server/codex-session-flow.test.ts
+++ b/test/integration/server/codex-session-flow.test.ts
@@ -30,8 +30,12 @@ vi.mock('../../../server/logger', () => {
     fatal: vi.fn(),
     child: vi.fn(),
   }
+  const freshAgentObservabilityLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+  }
   logger.child.mockReturnValue(logger)
-  return { logger, sessionLifecycleLogger: logger }
+  return { logger, sessionLifecycleLogger: logger, freshAgentObservabilityLogger }
 })
 
 process.env.AUTH_TOKEN = 'test-token'

--- a/test/server/agent-api-fresh-agent.test.ts
+++ b/test/server/agent-api-fresh-agent.test.ts
@@ -174,6 +174,24 @@ describe('agent-api fresh-agent: send-keys', () => {
     expect(attach).toHaveBeenCalledWith({ sessionId: 'ses_real_1', sessionType: 'freshopencode', provider: 'opencode' })
     expect(send).toHaveBeenCalledTimes(2)
   })
+
+  it('detects the lost session by its code, not its name (wrapped/subclassed errors still retry)', async () => {
+    // FreshAgentLostSessionError guarantees code = 'FRESH_AGENT_LOST_SESSION'; a subclass or
+    // wrapper may carry a different name but must still trigger the attach-and-retry path.
+    const wrapped = Object.assign(new Error('not tracked'), { code: 'FRESH_AGENT_LOST_SESSION' })
+    wrapped.name = 'WrappedLostSessionError'
+    const send = vi.fn().mockRejectedValueOnce(wrapped).mockResolvedValueOnce({ sessionId: 'ses_real_1' })
+    const attach = vi.fn(async () => ({ sessionId: 'ses_real_1' }))
+    const { app } = makeApp({ freshAgentRuntimeManager: {
+      create: vi.fn(async () => ({ sessionId: 'ses_real_1', sessionType: 'freshopencode', runtimeProvider: 'opencode' })),
+      send, attach,       getSnapshot: vi.fn(async () => ({ status: 'idle', turns: [] })),
+    } })
+    const created = await request(app).post('/api/tabs').send({ agent: 'opencode' })
+    const res = await request(app).post(`/api/panes/${created.body.data.paneId}/send-keys`).send({ data: 'hi' })
+    expect(res.status).toBe(200)
+    expect(attach).toHaveBeenCalledWith({ sessionId: 'ses_real_1', sessionType: 'freshopencode', provider: 'opencode' })
+    expect(send).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('agent-api fresh-agent: capture', () => {

--- a/test/server/ws-coding-cli-events.test.ts
+++ b/test/server/ws-coding-cli-events.test.ts
@@ -34,8 +34,12 @@ vi.mock('../../server/logger', () => {
     fatal: vi.fn(),
     child: vi.fn(),
   }
+  const freshAgentObservabilityLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+  }
   logger.child.mockReturnValue(logger)
-  return { logger, sessionLifecycleLogger: logger }
+  return { logger, sessionLifecycleLogger: logger, freshAgentObservabilityLogger }
 })
 
 vi.mock('../../server/config-store', () => ({

--- a/test/server/ws-protocol.test.ts
+++ b/test/server/ws-protocol.test.ts
@@ -104,6 +104,10 @@ const mockLogger = vi.hoisted(() => {
 vi.mock('../../server/logger', () => ({
   logger: mockLogger,
   sessionLifecycleLogger: mockLogger,
+  freshAgentObservabilityLogger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
   withLogContext: vi.fn((_ctx: any, fn: () => unknown) => fn()),
 }))
 

--- a/test/server/ws-terminal-create-session-repair.test.ts
+++ b/test/server/ws-terminal-create-session-repair.test.ts
@@ -20,6 +20,10 @@ const loggerMock = vi.hoisted(() => ({
   error: vi.fn(),
   child: vi.fn(),
 }))
+const freshAgentObservabilityLoggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+}))
 const DEFAULT_CONFIG_SNAPSHOT = vi.hoisted(() => ({
   version: 1,
   settings: {},
@@ -32,6 +36,7 @@ loggerMock.child.mockReturnValue(loggerMock)
 vi.mock('../../server/logger', () => ({
   logger: loggerMock,
   sessionLifecycleLogger: loggerMock,
+  freshAgentObservabilityLogger: freshAgentObservabilityLoggerMock,
 }))
 
 vi.mock('../../server/config-store', () => ({

--- a/test/unit/client/components/fresh-agent/FreshAgentView.hidden-rebind.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.hidden-rebind.test.tsx
@@ -8,6 +8,7 @@ import freshAgentReducer from '@/store/freshAgentSlice'
 import tabsReducer from '@/store/tabsSlice'
 import { FreshAgentView } from '@/components/fresh-agent/FreshAgentView'
 import { getRebindQueue, resetRebindQueueForTests } from '@/lib/rebind-queue'
+import { resetSnapshotSchedulerForTests } from '@/lib/fresh-agent-snapshot-scheduler'
 import type { FreshAgentPaneContent } from '@/store/paneTypes'
 
 // Claude snapshot hydration is keyed by Claude's durable UUID
@@ -145,6 +146,7 @@ describe('FreshAgentView hidden-pane rebind (F8)', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     resetRebindQueueForTests()
+    resetSnapshotSchedulerForTests()
     wsMock.send.mockClear()
     wsMock.onReconnect.mockClear()
     wsMock.onMessage.mockClear()
@@ -224,13 +226,17 @@ describe('FreshAgentView hidden-pane rebind (F8)', () => {
     // the reconnect edge.
     const paneContent = { ...basePaneContent, sessionId: SESS_4, status: 'idle' as const }
     const { rerender } = renderView({ paneContent, hidden: true })
-    act(() => { vi.advanceTimersByTime(500) })
+    // Async timer advance: the snapshot scheduler is single-flight per key, so
+    // the mount identity fetch must fully settle (promise continuations AND
+    // debounce timers) or the reveal refresh would fold into a trailing run
+    // that a sync advance can never fire.
+    await act(async () => { await vi.advanceTimersByTimeAsync(500) })
     const callsBeforeReconnect = apiMock.getFreshAgentThreadSnapshot.mock.calls.length
     fireReconnect()
-    act(() => { vi.advanceTimersByTime(500) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(500) })
     expect(apiMock.getFreshAgentThreadSnapshot.mock.calls.length).toBe(callsBeforeReconnect)
     rerenderView(rerender, { paneContent, hidden: false })
-    act(() => { vi.advanceTimersByTime(500) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(500) })
     expect(apiMock.getFreshAgentThreadSnapshot.mock.calls.length).toBeGreaterThan(callsBeforeReconnect)
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -1656,6 +1656,173 @@ describe('FreshAgentView', () => {
     expect(screen.getByText('Do not disappear on reload')).toBeInTheDocument()
   })
 
+  it('re-attaches with the route cwd and resends once when a send fails with FRESH_AGENT_LOST_SESSION', async () => {
+    const store = createStore()
+    let onMessage: ((message: Record<string, unknown>) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler: (message: Record<string, unknown>) => void) => {
+      onMessage = handler
+      return () => {}
+    })
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValue({
+      status: 'idle',
+      summary: 'empty',
+      capabilities: { send: true, interrupt: true, fork: true },
+      turns: [],
+    })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-lost-session',
+        sessionId: 'ses_9',
+        status: 'idle',
+        initialCwd: '/w',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'hello again' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const sendFrame = sentFreshAgentMessages('freshAgent.send').at(-1)
+    expect(sendFrame).toBeTruthy()
+    expect(sendFrame?.text).toBe('hello again')
+    await waitFor(() => {
+      expect(getFreshAgentPaneContent(store)).toMatchObject({ status: 'running' })
+    })
+    wsMock.send.mockClear()
+
+    // Act: server rejects with the lost-session code for that request
+    expect(onMessage).toBeTypeOf('function')
+    act(() => {
+      onMessage?.({
+        type: 'error',
+        code: 'FRESH_AGENT_LOST_SESSION',
+        requestId: sendFrame?.requestId,
+        message: 'not tracked',
+        timestamp: Date.now(),
+      })
+    })
+
+    // Assert: exactly one attach (with cwd) then one resend of the same text
+    await waitFor(() => {
+      const attaches = sentFreshAgentMessages('freshAgent.attach')
+      expect(attaches.some((m) => m.sessionId === 'ses_9' && m.cwd === '/w')).toBe(true)
+      expect(sentFreshAgentMessages('freshAgent.send').filter((m) => m.text === 'hello again')).toHaveLength(1)
+    })
+    // The echo stays visible while the retry is in flight
+    expect(screen.getByText('hello again')).toBeInTheDocument()
+
+    // Second failure for the retried request must NOT loop...
+    const retried = sentFreshAgentMessages('freshAgent.send').at(-1)
+    expect(retried?.requestId).toEqual(expect.any(String))
+    expect(retried?.requestId).not.toBe(sendFrame?.requestId)
+    wsMock.send.mockClear()
+    act(() => {
+      onMessage?.({
+        type: 'error',
+        code: 'FRESH_AGENT_LOST_SESSION',
+        requestId: retried?.requestId,
+        message: 'still not tracked',
+        timestamp: Date.now(),
+      })
+    })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100))
+    })
+    expect(sentFreshAgentMessages('freshAgent.send')).toHaveLength(0)
+    expect(sentFreshAgentMessages('freshAgent.attach')).toHaveLength(0)
+
+    // ...and the cleanup fall-through must fire for the final failure:
+    await waitFor(() => {
+      expect(screen.queryByText('hello again')).not.toBeInTheDocument() // stale local echo cleared
+    })
+    expect(getFreshAgentPaneContent(store).pendingLocalEcho).toBeUndefined() // Redux copy cleared too (dual-write)
+    expect(getFreshAgentPaneContent(store).status).not.toBe('running') // optimistic busy released
+  })
+
+  it('keeps placeholder-session lost-session failures on the normal cleanup path without a retry', async () => {
+    const store = createStore()
+    let onMessage: ((message: Record<string, unknown>) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler: (message: Record<string, unknown>) => void) => {
+      onMessage = handler
+      return () => {}
+    })
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValue({
+      status: 'idle',
+      summary: 'empty',
+      capabilities: { send: true, interrupt: true, fork: true },
+      turns: [],
+    })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-placeholder-lost',
+        sessionId: 'freshopencode-req-placeholder-lost',
+        status: 'idle',
+        initialCwd: '/w',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'hello placeholder' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    const sendFrame = sentFreshAgentMessages('freshAgent.send').at(-1)
+    expect(sendFrame?.text).toBe('hello placeholder')
+    await waitFor(() => {
+      expect(getFreshAgentPaneContent(store)).toMatchObject({ status: 'running' })
+    })
+    wsMock.send.mockClear()
+
+    expect(onMessage).toBeTypeOf('function')
+    act(() => {
+      onMessage?.({
+        type: 'error',
+        code: 'FRESH_AGENT_LOST_SESSION',
+        requestId: sendFrame?.requestId,
+        message: 'not tracked',
+        timestamp: Date.now(),
+      })
+    })
+
+    // No retry for a placeholder (non-ses_) session: cleanup path only.
+    await waitFor(() => {
+      expect(screen.queryByText('hello placeholder')).not.toBeInTheDocument()
+    })
+    expect(sentFreshAgentMessages('freshAgent.attach')).toHaveLength(0)
+    expect(sentFreshAgentMessages('freshAgent.send')).toHaveLength(0)
+    expect(getFreshAgentPaneContent(store).pendingLocalEcho).toBeUndefined()
+    expect(getFreshAgentPaneContent(store).status).not.toBe('running')
+  })
+
   it('does not transmit stale Freshopencode permissionMode on create or send', async () => {
     const creatingStore = createStore()
     creatingStore.dispatch(initLayout({

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -2781,6 +2781,119 @@ describe('FreshAgentView', () => {
     expect(store.getState().freshAgent.sessions[`freshcodex:codex:${sessionId}`]?.status).toBe('running')
   })
 
+  it('clears stale opencode busy state from a live-reconciled idle HTTP snapshot', async () => {
+    const store = createStore()
+    const sessionId = 'ses_1'
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValueOnce({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: sessionId,
+      sessionId,
+      status: 'idle',
+      revision: 210,
+      latestTurnId: null,
+      capabilities: { send: true, interrupt: true, fork: true },
+      tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 },
+      turns: [],
+      pendingApprovals: [],
+      pendingQuestions: [],
+      extensions: { opencode: { statusFromLiveState: true } },
+    })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        sessionId,
+        sessionRef: { provider: 'opencode', sessionId },
+        resumeSessionId: sessionId,
+        createRequestId: 'req-freshopencode-stale-running',
+        status: 'running',
+        initialCwd: '/home/dan/code/freshell',
+      },
+    }))
+    store.dispatch(setSessionStatus({
+      sessionId,
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      status: 'running',
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(store.getState().freshAgent.sessions[`freshopencode:opencode:${sessionId}`]?.status).toBe('idle')
+    })
+    expect(getFreshAgentPaneContent(store).status).toBe('idle')
+    expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledWith(
+      'freshopencode',
+      'opencode',
+      sessionId,
+      expect.objectContaining({ cwd: '/home/dan/code/freshell' }),
+    )
+  })
+
+  it('does NOT clear opencode busy state from an idle snapshot that is not live-reconciled', async () => {
+    const store = createStore()
+    const sessionId = 'ses_1'
+    // Restore-window default idle: untracked (adapter liveState?.status ?? 'idle')
+    // or mid-reconcile -- the snapshot carries no statusFromLiveState marker.
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValueOnce({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: sessionId,
+      sessionId,
+      status: 'idle',
+      revision: 211,
+      latestTurnId: null,
+      capabilities: { send: true, interrupt: true, fork: true },
+      tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 },
+      turns: [],
+      pendingApprovals: [],
+      pendingQuestions: [],
+    })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        sessionId,
+        sessionRef: { provider: 'opencode', sessionId },
+        resumeSessionId: sessionId,
+        createRequestId: 'req-freshopencode-not-live-reconciled',
+        status: 'running',
+        initialCwd: '/home/dan/code/freshell',
+      },
+    }))
+    store.dispatch(setSessionStatus({
+      sessionId,
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      status: 'running',
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    // The pane content still adopts the snapshot status (pre-existing behavior);
+    // waiting on it proves the snapshot was fully applied before we assert.
+    await waitFor(() => {
+      expect(getFreshAgentPaneContent(store).status).toBe('idle')
+    })
+    expect(store.getState().freshAgent.sessions[`freshopencode:opencode:${sessionId}`]?.status).toBe('running')
+  })
+
   it('preserves loaded transcript history when a submit refresh returns only the in-flight turn', async () => {
     const store = createStore()
     let onMessage: ((message: Record<string, unknown>) => void) | undefined

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -12,6 +12,8 @@ import { initLayout, requestPaneRefresh, setActivePane, updatePaneContent, updat
 import { useAppSelector } from '@/store/hooks'
 import { updateTab } from '@/store/tabsSlice'
 import { handleFreshAgentMessage } from '@/lib/fresh-agent-ws'
+import { ApiError } from '@/lib/api'
+import { resetSnapshotSchedulerForTests } from '@/lib/fresh-agent-snapshot-scheduler'
 import type { PaneNode } from '@/store/paneTypes'
 
 const CLAUDE_THREAD_ID = '550e8400-e29b-41d4-a716-446655440000'
@@ -182,6 +184,7 @@ function freshopencodeSnapshot(text: string, revision: number) {
 }
 
 beforeEach(() => {
+  resetSnapshotSchedulerForTests()
   wsMock.send.mockReset()
   wsMock.onMessage.mockReset()
   wsMock.onReconnect.mockReset()
@@ -4155,7 +4158,7 @@ describe('FreshAgentView', () => {
     })
   })
 
-  it('performs a follow-up freshopencode refresh when final send acceptance lands during an earlier invalidation debounce', async () => {
+  it('coalesces a final send acceptance landing during an earlier invalidation debounce into one shared refresh', async () => {
     const store = createStore()
     let wsHandler: ((message: any) => void) | undefined
     wsMock.onMessage.mockImplementation((handler) => {
@@ -4170,23 +4173,6 @@ describe('FreshAgentView', () => {
         status: 'idle',
         capabilities: { send: true, interrupt: true, fork: true },
         turns: [],
-      })
-      .mockResolvedValueOnce({
-        sessionType: 'freshopencode',
-        provider: 'opencode',
-        threadId: 'ses_final_race',
-        revision: 2,
-        status: 'idle',
-        capabilities: { send: true, interrupt: true, fork: true },
-        turns: [
-          {
-            id: 'turn-final-user',
-            turnId: 'turn-final-user',
-            role: 'user',
-            summary: 'Race final prompt',
-            items: [{ id: 'item-final-user', kind: 'text', text: 'Race final prompt' }],
-          },
-        ],
       })
       .mockResolvedValueOnce({
         sessionType: 'freshopencode',
@@ -4269,7 +4255,9 @@ describe('FreshAgentView', () => {
     await waitFor(() => {
       expect(screen.getByText('Final answer after durable history catches up')).toBeInTheDocument()
     })
-    expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(3)
+    // The invalidation debounce and the send acceptance coalesce into ONE
+    // shared scheduler run (initial fetch + one refresh), not a follow-up chain.
+    expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(2)
   })
 
   it('clears stale local echo after an idle recovered snapshot without the submitted turn', async () => {
@@ -5650,5 +5638,158 @@ describe('FreshAgentView transcript font size', () => {
       await waitFor(() => expect(document.activeElement).toBe(root))
       expect(focusSpy).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe('snapshot scheduler integration (zrrj)', () => {
+  const SCHED_SESSION_ID = 'ses_late_change'
+
+  function schedulerPaneContent(createRequestId: string) {
+    return {
+      kind: 'fresh-agent',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      createRequestId,
+      sessionId: SCHED_SESSION_ID,
+      sessionRef: { provider: 'opencode', sessionId: SCHED_SESSION_ID },
+      resumeSessionId: SCHED_SESSION_ID,
+      status: 'idle',
+    } as const
+  }
+
+  /**
+   * Capture EVERY ws.onMessage subscription and broadcast to all of them,
+   * like the real ws client does. Last-handler capture (the older pattern)
+   * only reaches one pane, which would hide the N-pane fan-out this task
+   * collapses.
+   */
+  function captureWsBroadcast() {
+    const handlers: Array<(message: unknown) => void> = []
+    wsMock.onMessage.mockImplementation((handler) => {
+      handlers.push(handler)
+      return () => {}
+    })
+    return (message: unknown) => {
+      act(() => {
+        for (const handler of [...handlers]) handler(message)
+      })
+    }
+  }
+
+  function sessionChanged() {
+    return {
+      type: 'freshAgent.event',
+      sessionId: SCHED_SESSION_ID,
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      event: {
+        type: 'freshAgent.session.changed',
+        sessionId: SCHED_SESSION_ID,
+        reason: 'opencode-message',
+      },
+    }
+  }
+
+  /** Real-timer sleep wrapped in act so late state updates never warn. */
+  const flushMs = (ms: number) => act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms))
+  })
+
+  it('coalesces a burst of freshopencode session.changed events across sibling panes into one snapshot GET', async () => {
+    const store = createStore()
+    const broadcast = captureWsBroadcast()
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(freshopencodeSnapshot('done', 10))
+
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: schedulerPaneContent('req-sched-a') }))
+    store.dispatch(initLayout({ tabId: 'tab-2', paneId: 'pane-2', content: schedulerPaneContent('req-sched-b') }))
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+        <StoreBackedFreshAgentView tabId="tab-2" paneId="pane-2" />
+      </Provider>,
+    )
+    // Let the identity fetches (immediate + trailing coalesce for the sibling)
+    // fully settle before measuring the burst.
+    await waitFor(() => expect(screen.getAllByText('done').length).toBeGreaterThan(0))
+    await flushMs(400)
+    apiMock.getFreshAgentThreadSnapshot.mockClear()
+
+    for (let i = 0; i < 10; i += 1) {
+      broadcast(sessionChanged())
+    }
+
+    // Exactly one trailing GET shared by both panes, not one per event/pane.
+    await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1))
+    await flushMs(400)
+    expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the last good snapshot visible and stops fetching during 429 backoff', async () => {
+    const store = createStore()
+    const broadcast = captureWsBroadcast()
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValueOnce(freshopencodeSnapshot('hello world', 10))
+
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: schedulerPaneContent('req-sched-429') }))
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+    await screen.findByText('hello world')
+    apiMock.getFreshAgentThreadSnapshot.mockRejectedValue(new ApiError(429, 'Too many requests', undefined, 60_000))
+
+    broadcast(sessionChanged())
+    await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(2))
+    await flushMs(50)
+    // Last good transcript stays visible; no load-error banner.
+    expect(screen.getByText('hello world')).toBeInTheDocument()
+    expect(screen.queryByText(/Too many requests/)).not.toBeInTheDocument()
+
+    // Further invalidations during backoff are suppressed without network.
+    broadcast(sessionChanged())
+    await flushMs(400)
+    expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(2)
+    expect(screen.getByText('hello world')).toBeInTheDocument()
+  })
+
+  it('does not refetch when another session sends (send.accepted for a foreign request)', async () => {
+    const store = createStore()
+    const broadcast = captureWsBroadcast()
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(freshopencodeSnapshot('done', 10))
+
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: schedulerPaneContent('req-sched-foreign') }))
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+    await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1))
+    apiMock.getFreshAgentThreadSnapshot.mockClear()
+
+    broadcast({
+      type: 'freshAgent.send.accepted',
+      requestId: 'someone-elses-request',
+      sessionId: SCHED_SESSION_ID,
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+    })
+    await flushMs(400)
+    expect(apiMock.getFreshAgentThreadSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('scheduler-path fetches carry no abort signal (shared runs must survive one pane unmounting)', async () => {
+    const store = createStore()
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(freshopencodeSnapshot('done', 10))
+
+    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: schedulerPaneContent('req-sched-signal') }))
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+    await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1))
+    // 4th positional arg is the query/options bag ({ revision?, cwd?, signal? }).
+    const options = apiMock.getFreshAgentThreadSnapshot.mock.calls[0][3]
+    expect(options?.signal).toBeUndefined()
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -6,7 +6,7 @@ import panesReducer from '@/store/panesSlice'
 import settingsReducer, { previewServerSettingsPatch, updateSettingsLocal } from '@/store/settingsSlice'
 import freshAgentReducer, { sessionInit, setSessionStatus, markSessionLost } from '@/store/freshAgentSlice'
 import tabsReducer from '@/store/tabsSlice'
-import { FreshAgentView } from '@/components/fresh-agent/FreshAgentView'
+import { FreshAgentView, IDLE_INCOMPLETE_MAX_RETRIES } from '@/components/fresh-agent/FreshAgentView'
 import { FreshAgentSettingsButton } from '@/components/fresh-agent/FreshAgentSettingsButton'
 import { initLayout, requestPaneRefresh, setActivePane, updatePaneContent, updatePaneTitle } from '@/store/panesSlice'
 import { useAppSelector } from '@/store/hooks'
@@ -4557,23 +4557,28 @@ describe('FreshAgentView', () => {
         capabilities: { send: true, interrupt: true, fork: true },
         turns: [],
       })
-      .mockResolvedValueOnce({
-        sessionType: 'freshopencode',
-        provider: 'opencode',
-        threadId: 'ses_stale_echo',
-        status: 'idle',
-        summary: 'recovered',
-        capabilities: { send: true, interrupt: true, fork: true },
-        turns: [
-          {
-            id: 'turn-existing-assistant',
-            turnId: 'turn-existing-assistant',
-            role: 'assistant',
-            summary: 'Recovered idle snapshot',
-            items: [{ id: 'item-existing-assistant', kind: 'text', text: 'Recovered idle snapshot' }],
-          },
-        ],
-      })
+    // Task 16: every subsequent fetch returns a FRESH recovered snapshot that
+    // still lacks the submitted turn — acceptance is by object identity, so a
+    // shared instance would skip the stale-echo path for the wrong reason.
+    let recoveredRevision = 2
+    apiMock.getFreshAgentThreadSnapshot.mockImplementation(async () => ({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'ses_stale_echo',
+      status: 'idle',
+      summary: 'recovered',
+      revision: recoveredRevision++,
+      capabilities: { send: true, interrupt: true, fork: true },
+      turns: [
+        {
+          id: 'turn-existing-assistant',
+          turnId: 'turn-existing-assistant',
+          role: 'assistant',
+          summary: 'Recovered idle snapshot',
+          items: [{ id: 'item-existing-assistant', kind: 'text', text: 'Recovered idle snapshot' }],
+        },
+      ],
+    }))
     store.dispatch(initLayout({
       tabId: 'tab-1',
       paneId: 'pane-1',
@@ -4633,9 +4638,92 @@ describe('FreshAgentView', () => {
     await waitFor(() => {
       expect(screen.getByText('Recovered idle snapshot')).toBeInTheDocument()
     })
-    expect(screen.queryByText('Orphan prompt')).not.toBeInTheDocument()
+    // Task 16 contract change: the echo is the idle-incomplete re-poll loop's
+    // marker, so the FIRST incomplete idle snapshot must NOT clear it...
+    expect(screen.getByText('Orphan prompt')).toBeInTheDocument()
+    // ...but once the bounded retry budget is exhausted, the stale echo
+    // clears exactly as before (real timers: 5 retries x 1s + settle).
+    await waitFor(() => {
+      expect(screen.queryByText('Orphan prompt')).not.toBeInTheDocument()
+    }, { timeout: 15_000 })
     expect(getFreshAgentPaneContent(store).pendingLocalEcho).toBeUndefined()
-  })
+  }, 25_000)
+
+  it('keeps re-polling (bounded) when an idle snapshot is missing the just-sent turn', async () => {
+    const store = createStore()
+    let wsHandler: ((message: any) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler) => {
+      wsHandler = handler
+      return () => {}
+    })
+    // HARNESS TRAP (fresh-eyes i3): return a FRESH snapshot object per fetch.
+    // Acceptance is by OBJECT IDENTITY (`snapshotAccepted = displaySnapshot
+    // !== previousSnapshot`; mergeSnapshotForDisplay does no content
+    // comparison). A shared mockResolvedValue(...) instance makes
+    // snapshotAccepted false, skips the stale-echo clear for the wrong
+    // reason, and lets a broken loop pass vacuously.
+    let rev = 1
+    apiMock.getFreshAgentThreadSnapshot.mockImplementation(
+      async () => freshopencodeSnapshot('unrelated earlier turn', rev++),
+    )
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-idle-incomplete',
+        sessionId: 'ses_late_change',
+        sessionRef: { provider: 'opencode', sessionId: 'ses_late_change' },
+        resumeSessionId: 'ses_late_change',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: 'question?' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    const send = sentFreshAgentMessages('freshAgent.send').at(-1)
+    const requestId = String(send?.requestId)
+    act(() => {
+      wsHandler?.({
+        type: 'freshAgent.send.accepted',
+        requestId,
+        sessionId: 'ses_late_change',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+      })
+    })
+
+    const calls = () => apiMock.getFreshAgentThreadSnapshot.mock.calls.length
+    const before = calls()
+    // SUSTAINED loop — a single extra fetch must NOT satisfy this test:
+    await waitFor(() => expect(calls()).toBeGreaterThanOrEqual(before + 2), { timeout: 8_000 })
+    // ...and it runs to the cap...
+    await waitFor(
+      () => expect(calls()).toBeGreaterThanOrEqual(before + IDLE_INCOMPLETE_MAX_RETRIES),
+      { timeout: 10_000 },
+    )
+    // ...then the exhaustion pass clears the echo (the loop's marker)...
+    await waitFor(() => {
+      expect(screen.queryByText('question?')).not.toBeInTheDocument()
+    }, { timeout: 8_000 })
+    // ...and STOPS (bounded — no unbounded polling):
+    const atCap = calls()
+    await new Promise((r) => setTimeout(r, 1_500))
+    expect(calls()).toBe(atCap)
+  }, 25_000) // real timers (this suite uses none fake); 5 retries x 1s + settle needs a raised test timeout
 
   it('clears local echo as soon as a fresh snapshot contains the submitted text', async () => {
     const store = createStore()

--- a/test/unit/client/lib/api.test.ts
+++ b/test/unit/client/lib/api.test.ts
@@ -50,6 +50,17 @@ function mockJsonResponse(status: number, value: unknown) {
   }
 }
 
+function mockResponseWithHeaders(status: number, value: unknown, headers: Record<string, string>) {
+  const headerMap = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]))
+  mockFetch.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'Too Many Requests',
+    text: async () => JSON.stringify(value),
+    headers: { get: (name: string) => headerMap.get(name.toLowerCase()) ?? null },
+  })
+}
+
 function successCapabilityResponse(
   sessionType: string,
   runtimeProvider: 'claude' | 'codex' | 'opencode',
@@ -865,5 +876,27 @@ describe('api error mapping', () => {
       status: 400,
       message: 'name required',
     })
+  })
+
+  it('carries retryAfterMs from a 429 Retry-After seconds header', async () => {
+    mockResponseWithHeaders(429, { error: 'Too many requests' }, { 'retry-after': '17' })
+    await expect(api.get('/api/fresh-agent/threads/freshopencode/opencode/ses_1')).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: 17_000,
+    })
+  })
+
+  it('leaves retryAfterMs undefined when the header is absent', async () => {
+    mockResponseWithHeaders(429, { error: 'Too many requests' }, {})
+    await expect(api.get('/api/x')).rejects.toMatchObject({ status: 429, retryAfterMs: undefined })
+  })
+
+  it('parses an HTTP-date Retry-After into a forward delta', async () => {
+    const future = new Date(Date.now() + 30_000).toUTCString()
+    mockResponseWithHeaders(429, { error: 'Too many requests' }, { 'retry-after': future })
+    const err = await api.get('/api/x').catch((e) => e)
+    expect(err.status).toBe(429)
+    expect(err.retryAfterMs).toBeGreaterThan(20_000)
+    expect(err.retryAfterMs).toBeLessThanOrEqual(31_000)
   })
 })

--- a/test/unit/client/lib/api.test.ts
+++ b/test/unit/client/lib/api.test.ts
@@ -286,6 +286,17 @@ describe('visible-first read-model helpers', () => {
     )
   })
 
+  it('appends the snapshot trigger to the fresh-agent snapshot query when provided', async () => {
+    mockFetch.mockResolvedValueOnce(mockJson(codexContractSnapshot))
+
+    await getFreshAgentThreadSnapshot('freshcodex', 'codex', 'thread-1', { revision: 7, trigger: 'poll' })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/fresh-agent/threads/freshcodex/codex/thread-1?revision=7&trigger=poll',
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    )
+  })
+
   it('rejects thread-turn requests that omit the pinned restore revision', async () => {
     await expect(getFreshAgentThreadTurns('session-1', { priority: 'visible' }, { signal: new AbortController().signal }))
       .rejects

--- a/test/unit/client/lib/fresh-agent-snapshot-scheduler.test.ts
+++ b/test/unit/client/lib/fresh-agent-snapshot-scheduler.test.ts
@@ -121,4 +121,15 @@ describe('FreshAgentSnapshotScheduler', () => {
     expect(out).toEqual({ status: 'error', error: boom })
     expect(scheduler.getBackoffUntil(KEY)).toBeNull()
   })
+
+  it('reset cancels pending debounced runs so a stale run cannot fire into the next test', async () => {
+    const scheduler = getSnapshotScheduler()
+    const run = vi.fn(async () => 'snap')
+    const pending = scheduler.schedule(KEY, 'event', run) // debounced 250ms
+    resetSnapshotSchedulerForTests()
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(run).not.toHaveBeenCalled()
+    // The caller's promise must still settle, never hang.
+    await expect(pending).resolves.toEqual({ status: 'coalesced' })
+  })
 })

--- a/test/unit/client/lib/fresh-agent-snapshot-scheduler.test.ts
+++ b/test/unit/client/lib/fresh-agent-snapshot-scheduler.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { ApiError } from '@/lib/api'
+import {
+  makeSnapshotKey,
+  getSnapshotScheduler,
+  resetSnapshotSchedulerForTests,
+} from '@/lib/fresh-agent-snapshot-scheduler'
+
+const KEY = makeSnapshotKey({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_1', cwd: '/w' })
+
+describe('FreshAgentSnapshotScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetSnapshotSchedulerForTests()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('builds the key from the exact request tuple', () => {
+    expect(KEY).toBe('freshopencode:opencode:ses_1:/w')
+    expect(makeSnapshotKey({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_1' }))
+      .toBe('freshopencode:opencode:ses_1:')
+  })
+
+  it('coalesces an event burst into a single run shared by all callers', async () => {
+    const scheduler = getSnapshotScheduler()
+    const run = vi.fn(async () => 'snap')
+    const p1 = scheduler.schedule(KEY, 'event', run)
+    const p2 = scheduler.schedule(KEY, 'event', run)
+    const p3 = scheduler.schedule(KEY, 'event', run)
+    await vi.advanceTimersByTimeAsync(250)
+    const [o1, o2, o3] = await Promise.all([p1, p2, p3])
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(o1).toEqual({ status: 'ok', value: 'snap' })
+    expect(o2).toEqual({ status: 'ok', value: 'snap' })
+    expect(o3).toEqual({ status: 'ok', value: 'snap' })
+  })
+
+  it('runs manual triggers immediately and holds a single trailing run while in flight', async () => {
+    const scheduler = getSnapshotScheduler()
+    let release!: () => void
+    const gate = new Promise<void>((r) => { release = r })
+    const run = vi.fn(async () => { await gate; return 'v' })
+    const first = scheduler.schedule(KEY, 'manual', run)
+    // three arrivals while in flight -> exactly one trailing run
+    const t1 = scheduler.schedule(KEY, 'event', run)
+    const t2 = scheduler.schedule(KEY, 'event', run)
+    release()
+    await first
+    await vi.advanceTimersByTimeAsync(250)
+    await Promise.all([t1, t2])
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('keys are independent', async () => {
+    const scheduler = getSnapshotScheduler()
+    const runA = vi.fn(async () => 'a')
+    const runB = vi.fn(async () => 'b')
+    const otherKey = makeSnapshotKey({ sessionType: 'freshopencode', provider: 'opencode', threadId: 'ses_2', cwd: '/w' })
+    const pa = scheduler.schedule(KEY, 'manual', runA)
+    const pb = scheduler.schedule(otherKey, 'manual', runB)
+    await Promise.all([pa, pb])
+    expect(runA).toHaveBeenCalledTimes(1)
+    expect(runB).toHaveBeenCalledTimes(1)
+  })
+
+  it('honors Retry-After on 429 and suppresses further runs until expiry', async () => {
+    const scheduler = getSnapshotScheduler()
+    const run = vi.fn(async () => { throw new ApiError(429, 'Too many requests', undefined, 5_000) })
+    const first = await scheduler.schedule(KEY, 'manual', run)
+    expect(first.status).toBe('rate-limited')
+    expect(run).toHaveBeenCalledTimes(1)
+
+    const during = await scheduler.schedule(KEY, 'poll', run)
+    expect(during.status).toBe('backoff')
+    expect(run).toHaveBeenCalledTimes(1)          // NO network call during backoff
+    expect(scheduler.getBackoffUntil(KEY)).toBeGreaterThan(Date.now())
+
+    await vi.advanceTimersByTimeAsync(5_001)
+    const ok = vi.fn(async () => 'fresh')
+    const after = await scheduler.schedule(KEY, 'poll', ok)
+    expect(after).toEqual({ status: 'ok', value: 'fresh' })
+    expect(scheduler.getBackoffUntil(KEY)).toBeNull()
+  })
+
+  it('resolves mid-flight sharers with rate-limited on a 429 instead of stranding their promises', async () => {
+    const scheduler = getSnapshotScheduler()
+    let reject!: (e: unknown) => void
+    const gated = new Promise<never>((_, r) => { reject = r })
+    const run = vi.fn(() => gated)
+    const first = scheduler.schedule(KEY, 'manual', run)
+    const midFlight = scheduler.schedule(KEY, 'event', run)   // arrives while in flight -> queued for the trailing run
+    reject(new ApiError(429, 'Too many requests', undefined, 5_000))
+    const [o1, o2] = await Promise.all([first, midFlight])    // BOTH must settle
+    expect(o1.status).toBe('rate-limited')
+    expect(o2.status).toBe('rate-limited')
+    expect(run).toHaveBeenCalledTimes(1)                      // the trailing run is cancelled: no second network call
+  })
+
+  it('falls back to exponential backoff when Retry-After is absent and doubles per consecutive 429', async () => {
+    const scheduler = getSnapshotScheduler()
+    const run429 = vi.fn(async () => { throw new ApiError(429, 'Too many requests') })
+    const o1 = await scheduler.schedule(KEY, 'manual', run429)
+    expect(o1.status).toBe('rate-limited')
+    if (o1.status !== 'rate-limited') throw new Error('unreachable')
+    const firstDelta = o1.retryAtMs - Date.now()
+    expect(firstDelta).toBeGreaterThan(0)
+    expect(firstDelta).toBeLessThanOrEqual(1_000)
+
+    await vi.advanceTimersByTimeAsync(1_001)
+    const o2 = await scheduler.schedule(KEY, 'manual', run429)
+    if (o2.status !== 'rate-limited') throw new Error(`expected rate-limited, got ${o2.status}`)
+    expect(o2.retryAtMs - Date.now()).toBeGreaterThan(1_000)   // doubled
+  })
+
+  it('resolves non-429 failures as error outcomes without backoff', async () => {
+    const scheduler = getSnapshotScheduler()
+    const boom = new Error('network down')
+    const out = await scheduler.schedule(KEY, 'manual', async () => { throw boom })
+    expect(out).toEqual({ status: 'error', error: boom })
+    expect(scheduler.getBackoffUntil(KEY)).toBeNull()
+  })
+})

--- a/test/unit/server/fresh-agent/incident-router.test.ts
+++ b/test/unit/server/fresh-agent/incident-router.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+
+import { createFreshAgentIncidentRouter } from '../../../../server/fresh-agent/incident-router.js'
+
+describe('fresh-agent incident router (zrrj)', () => {
+  it('returns hashed, content-free incident state', async () => {
+    const app = express()
+    app.use('/api/debug/fresh-agent', createFreshAgentIncidentRouter({
+      runtimeManager: { inspectState: () => ({ sessions: [{ key: 'k', sessionType: 'freshopencode', provider: 'opencode', sessionIdHash: 'abc123', cwdHash: 'def456' }], pendingRecoveries: 0 }) },
+      opencode: {
+        inspectSessions: () => [{ sessionIdHash: 'abc123', status: 'running', hasRealSession: true, monitorArmed: true }],
+        describeSidecar: () => ({ generation: 2, pid: 4242, baseUrl: 'http://127.0.0.1:1234' }),
+      },
+    }))
+    const res = await request(app).get('/api/debug/fresh-agent').expect(200)
+    expect(res.body).toMatchObject({ version: 1, opencode: { sidecar: { generation: 2 } } })
+    expect(typeof res.body.time).toBe('string')
+    // Deps are passed through verbatim under the versioned envelope.
+    expect(res.body.runtime).toEqual({
+      sessions: [{ key: 'k', sessionType: 'freshopencode', provider: 'opencode', sessionIdHash: 'abc123', cwdHash: 'def456' }],
+      pendingRecoveries: 0,
+    })
+    expect(res.body.opencode.sessions).toEqual([
+      { sessionIdHash: 'abc123', status: 'running', hasRealSession: true, monitorArmed: true },
+    ])
+    expect(res.body.opencode.sidecar).toEqual({ generation: 2, pid: 4242, baseUrl: 'http://127.0.0.1:1234' })
+  })
+
+  it('reports sidecar: null when no sidecar is running', async () => {
+    const app = express()
+    app.use('/api/debug/fresh-agent', createFreshAgentIncidentRouter({
+      runtimeManager: { inspectState: () => ({ sessions: [], pendingRecoveries: 0 }) },
+      opencode: {
+        inspectSessions: () => [],
+        describeSidecar: () => undefined,
+      },
+    }))
+    const res = await request(app).get('/api/debug/fresh-agent').expect(200)
+    expect(res.body.opencode.sidecar).toBeNull()
+    expect(res.body.opencode.sessions).toEqual([])
+  })
+})

--- a/test/unit/server/fresh-agent/observability.test.ts
+++ b/test/unit/server/fresh-agent/observability.test.ts
@@ -12,11 +12,16 @@ const mockState = vi.hoisted(() => {
     debug: vi.fn(),
     child: vi.fn(),
   }
-  return { logger }
+  const freshAgentObservabilityLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+  }
+  return { logger, freshAgentObservabilityLogger }
 })
 
 vi.mock('../../../../server/logger.js', () => ({
   logger: mockState.logger,
+  freshAgentObservabilityLogger: mockState.freshAgentObservabilityLogger,
 }))
 
 import {
@@ -217,14 +222,208 @@ describe('createFreshAgentSnapshotRateLimitMiddleware', () => {
     expect(warnSpy).not.toHaveBeenCalled()
   })
 
-  it('does not log for paths that do not match the snapshot pattern', async () => {
+  it('does not log for paths that do not match the snapshot/turns pattern', async () => {
     const app = makeApp(createFreshAgentSnapshotRateLimitMiddleware())
-    // 4 segments (turns route) should not match the 3-segment snapshot pattern.
+    // A 4th segment that is not "turns" is outside the thread route family.
     // The mock rate-limiter still sends 429, but the observability middleware
-    // should not log because the path doesn't match the snapshot pattern.
-    await request(app).get('/freshopencode/opencode/ses_real_1/turns?rate-limited=1').expect(429)
+    // should not log because the path doesn't match the pattern.
+    await request(app).get('/freshopencode/opencode/ses_real_1/other?rate-limited=1').expect(429)
+    // Too many segments after /turns/:turnId is also outside the pattern.
+    await request(app).get('/freshopencode/opencode/ses_real_1/turns/turn_1/extra?rate-limited=1').expect(429)
 
     expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('records 429s on the /turns and /turns/:turnId routes with retryAfterSeconds', async () => {
+    const app = express()
+    app.use('/fresh-agent/threads', createFreshAgentSnapshotRateLimitMiddleware())
+    app.get('*', (_req, res) => {
+      res.setHeader('Retry-After', '42')
+      res.status(429).end()
+    })
+    await request(app).get('/fresh-agent/threads/freshopencode/opencode/ses_abc/turns').expect(429)
+    await request(app).get('/fresh-agent/threads/freshopencode/opencode/ses_abc/turns/turn_1').expect(429)
+
+    expect(warnSpy).toHaveBeenCalledTimes(2)
+    const first = warnSpy.mock.calls[0][0]
+    expect(first).toMatchObject({
+      event: 'fresh_agent_snapshot_rate_limited',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      httpStatus: 429,
+      retryAfterSeconds: 42,
+    })
+    expect(first.threadIdHash).toBe(hashForLogs('ses_abc'))
+    const second = warnSpy.mock.calls[1][0]
+    expect(second).toMatchObject({
+      event: 'fresh_agent_snapshot_rate_limited',
+      retryAfterSeconds: 42,
+    })
+    expect(second.threadIdHash).toBe(hashForLogs('ses_abc'))
+    expect(JSON.stringify(first)).not.toContain('ses_abc')
+  })
+
+  it('includes a bounded trigger from the query string on rate-limited snapshot rows', async () => {
+    const app = makeApp(createFreshAgentSnapshotRateLimitMiddleware())
+    await request(app)
+      .get('/freshopencode/opencode/ses_real_1?rate-limited=1&trigger=ws-connect')
+      .expect(429)
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const [payload] = warnSpy.mock.calls[0]
+    expect(payload.trigger).toBe('ws-connect')
+  })
+})
+
+describe('default observability sink', () => {
+  it('routes info events through the dedicated fresh-agent logger by default', async () => {
+    // Re-import a fresh copy of the module so the sink override from other
+    // tests is gone and the module-level default sink is exercised.
+    vi.resetModules()
+    mockState.freshAgentObservabilityLogger.info.mockClear()
+    mockState.freshAgentObservabilityLogger.warn.mockClear()
+    mockState.logger.info.mockClear()
+    mockState.logger.warn.mockClear()
+
+    const fresh = await import('../../../../server/fresh-agent/observability.js')
+    fresh.recordFreshAgentObservabilityEvent({
+      kind: 'fresh_agent_snapshot_served',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadIdHash: fresh.hashForLogs('ses_default_sink'),
+      httpStatus: 200,
+      durationMs: 5,
+      turnCount: 1,
+    })
+
+    expect(mockState.freshAgentObservabilityLogger.info).toHaveBeenCalledTimes(1)
+    const [payload, msg] = mockState.freshAgentObservabilityLogger.info.mock.calls[0]
+    expect(payload.event).toBe('fresh_agent_snapshot_served')
+    expect(msg).toBe('fresh_agent_snapshot_served')
+    // The main logger (level warn in production) must NOT be the sink.
+    expect(mockState.logger.info).not.toHaveBeenCalled()
+
+    fresh.recordFreshAgentObservabilityEvent({
+      kind: 'fresh_agent_snapshot_rate_limited',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      httpStatus: 429,
+      route: '/fresh-agent/threads/freshopencode/opencode/:threadId',
+    })
+    expect(mockState.freshAgentObservabilityLogger.warn).toHaveBeenCalledTimes(1)
+    expect(mockState.logger.warn).not.toHaveBeenCalled()
+  })
+})
+
+describe('expanded event kinds and severity rule', () => {
+  let infoSpy: ReturnType<typeof vi.fn>
+  let warnSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    infoSpy = vi.fn()
+    warnSpy = vi.fn()
+    __setFreshAgentObservabilitySinkForTest({ info: infoSpy, warn: warnSpy })
+  })
+
+  it('accepts the new event kinds with warn severity for incident kinds', () => {
+    recordFreshAgentObservabilityEvent({
+      kind: 'fresh_agent_monitor',
+      provider: 'opencode',
+      sessionIdHash: hashForLogs('ses_x'),
+      phase: 'sidecar_lost',
+      sidecarGeneration: 3,
+    })
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'fresh_agent_monitor', phase: 'sidecar_lost', sidecarGeneration: 3 }),
+      'fresh_agent_monitor',
+    )
+
+    recordFreshAgentObservabilityEvent({
+      kind: 'fresh_agent_send',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      sessionIdHash: hashForLogs('ses_x'),
+      outcome: 'accepted',
+    })
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'fresh_agent_send', outcome: 'accepted' }),
+      'fresh_agent_send',
+    )
+  })
+
+  it('applies the severity rule across every new kind', () => {
+    const sessionIdHash = hashForLogs('ses_x')
+    const warnEvents = [
+      { kind: 'fresh_agent_sidecar', provider: 'opencode', phase: 'exited', generation: 1, code: 1, signal: null },
+      { kind: 'fresh_agent_sidecar', provider: 'opencode', phase: 'discarded', generation: 1, reason: 'stale' },
+      { kind: 'fresh_agent_monitor', provider: 'opencode', sessionIdHash, phase: 'timeout' },
+      { kind: 'fresh_agent_monitor', provider: 'opencode', sessionIdHash, phase: 'sidecar_lost' },
+      {
+        kind: 'fresh_agent_snapshot_failed',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        threadIdHash: sessionIdHash,
+        httpStatus: 502,
+        code: 'SIDEcar_DOWN'.toUpperCase(),
+        durationMs: 12,
+      },
+    ] as const
+    const infoEvents = [
+      { kind: 'fresh_agent_sidecar', provider: 'opencode', phase: 'started', generation: 2, pid: 123 },
+      { kind: 'fresh_agent_monitor', provider: 'opencode', sessionIdHash, phase: 'armed' },
+      { kind: 'fresh_agent_monitor', provider: 'opencode', sessionIdHash, phase: 'resolved_idle' },
+      { kind: 'fresh_agent_monitor', provider: 'opencode', sessionIdHash, phase: 'duplicate_suppressed' },
+      {
+        kind: 'fresh_agent_interrupt',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        sessionIdHash,
+        outcome: 'ok',
+      },
+      {
+        kind: 'fresh_agent_attach',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        sessionIdHash,
+        outcome: 'ok',
+        recovered: true,
+      },
+      {
+        kind: 'fresh_agent_materialized',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        previousSessionIdHash: hashForLogs('pending_1'),
+        sessionIdHash,
+      },
+      {
+        kind: 'fresh_agent_turn_recovery',
+        provider: 'opencode',
+        sessionIdHash,
+        action: 'continuation_injected',
+        reason: 'interrupted_turn_detected',
+        messageIdHash: hashForLogs('msg_9'),
+      },
+    ] as const
+
+    for (const event of warnEvents) {
+      recordFreshAgentObservabilityEvent(event)
+    }
+    for (const event of infoEvents) {
+      recordFreshAgentObservabilityEvent(event)
+    }
+
+    expect(warnSpy).toHaveBeenCalledTimes(warnEvents.length)
+    expect(infoSpy).toHaveBeenCalledTimes(infoEvents.length)
+    for (const [payload, msg] of [...warnSpy.mock.calls, ...infoSpy.mock.calls]) {
+      expect(payload.component).toBe('fresh-agent-observability')
+      expect(payload.event).toBe(msg)
+      // No raw identifiers or content in any row.
+      const serialized = JSON.stringify(payload)
+      expect(serialized).not.toContain('ses_x')
+      expect(serialized).not.toContain('msg_9')
+      expect(serialized).not.toContain('pending_1')
+      expect(serialized).not.toContain('undefined')
+    }
   })
 })
 

--- a/test/unit/server/fresh-agent/opencode-interrupted-turn.test.ts
+++ b/test/unit/server/fresh-agent/opencode-interrupted-turn.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import {
+  detectInterruptedTurn,
+  INTERRUPTED_TURN_STABILITY_MS,
+} from '../../../../server/fresh-agent/adapters/opencode/interrupted-turn.js'
+
+const NOW = 1_000_000_000
+const OLD = NOW - INTERRUPTED_TURN_STABILITY_MS - 1
+
+function assistant(info: Record<string, any>, parts: Record<string, any>[] = []) {
+  return { info: { id: 'm2', role: 'assistant', time: { created: OLD, updated: OLD }, ...info }, parts }
+}
+// realistic: user messages never carry time.completed (verified, V2)
+const user = { info: { id: 'm1', role: 'user', time: { created: OLD - 10 } }, parts: [] }
+
+describe('detectInterruptedTurn', () => {
+  it('flags missing completion + running tool part as interrupted', () => {
+    const verdict = detectInterruptedTurn(
+      [user, assistant({}, [{ type: 'tool', state: { status: 'running' } }])],
+      { nowMs: NOW },
+    )
+    expect(verdict).toEqual({ interrupted: true, messageId: 'm2', evidence: ['missing_completion', 'running_tool_part'] })
+  })
+
+  it('flags an explicit MessageAbortedError alone', () => {
+    // realistic: aborted turns DO carry time.completed (all 203 live MessageAbortedError rows)
+    const verdict = detectInterruptedTurn(
+      [user, assistant({ time: { created: OLD, completed: OLD + 1 }, error: { name: 'MessageAbortedError' } })],
+      { nowMs: NOW },
+    )
+    expect(verdict.interrupted).toBe(true)
+    if (verdict.interrupted) expect(verdict.evidence).toContain('aborted_error')
+  })
+
+  it('does not flag missing completion alone (insufficient evidence)', () => {
+    const verdict = detectInterruptedTurn([user, assistant({})], { nowMs: NOW })
+    expect(verdict).toEqual({ interrupted: false, reason: 'insufficient_evidence' })
+  })
+
+  it('respects the stability window for a still-writing row', () => {
+    const fresh = {
+      info: { id: 'm2', role: 'assistant', time: { created: NOW - 1_000 } },
+      parts: [{ type: 'tool', state: { status: 'running' } }],
+    }
+    expect(detectInterruptedTurn([user, fresh], { nowMs: NOW })).toEqual({
+      interrupted: false,
+      reason: 'within_stability_window',
+    })
+  })
+
+  it('never flags when the user already typed a follow-up', () => {
+    const trailingUser = { info: { id: 'm3', role: 'user', time: { created: OLD + 5 } }, parts: [] }
+    const verdict = detectInterruptedTurn(
+      [user, assistant({}, [{ type: 'tool', state: { status: 'running' } }]), trailingUser],
+      { nowMs: NOW },
+    )
+    expect(verdict).toEqual({ interrupted: false, reason: 'last_message_not_assistant' })
+  })
+
+  it('counts missing step-finish and zero output tokens as corroborating evidence', () => {
+    const verdict = detectInterruptedTurn(
+      [user, assistant({ tokens: { input: 50, output: 0 } }, [{ type: 'step-start' }])],
+      { nowMs: NOW },
+    )
+    expect(verdict.interrupted).toBe(true)
+    if (verdict.interrupted) {
+      expect(verdict.evidence).toEqual(
+        expect.arrayContaining(['missing_completion', 'zero_output_tokens', 'missing_step_finish']),
+      )
+    }
+  })
+
+  it('does not flag a cleanly completed turn', () => {
+    const done = assistant(
+      { time: { created: OLD, completed: OLD + 2 }, tokens: { input: 10, output: 40 } },
+      [{ type: 'step-start' }, { type: 'step-finish' }],
+    )
+    expect(detectInterruptedTurn([user, done], { nowMs: NOW }).interrupted).toBe(false)
+  })
+
+  it('returns empty_transcript for no messages', () => {
+    expect(detectInterruptedTurn([], { nowMs: NOW })).toEqual({ interrupted: false, reason: 'empty_transcript' })
+  })
+
+  it('detects aborted_error via the defensive info.error.data.name fallback', () => {
+    const verdict = detectInterruptedTurn(
+      [user, assistant({ time: { created: OLD, completed: OLD + 1 }, error: { data: { name: 'MessageAbortedError' } } })],
+      { nowMs: NOW },
+    )
+    expect(verdict.interrupted).toBe(true)
+    if (verdict.interrupted) expect(verdict.evidence).toContain('aborted_error')
+  })
+
+  it('does not count zero output tokens without any other evidence beside it', () => {
+    // completed turn, tool-only, 0 output tokens — legitimate, must not flag
+    const toolOnly = assistant(
+      { time: { created: OLD, completed: OLD + 2 }, tokens: { input: 30, output: 0 } },
+      [{ type: 'step-start' }, { type: 'step-finish' }, { type: 'tool', state: { status: 'completed' } }],
+    )
+    expect(detectInterruptedTurn([user, toolOnly], { nowMs: NOW })).toEqual({
+      interrupted: false,
+      reason: 'insufficient_evidence',
+    })
+  })
+
+  it('uses info.time.updated for the stability window when newer than created', () => {
+    const stillWriting = {
+      info: { id: 'm2', role: 'assistant', time: { created: OLD - 60_000, updated: NOW - 1_000 } },
+      parts: [{ type: 'tool', state: { status: 'running' } }],
+    }
+    expect(detectInterruptedTurn([user, stillWriting], { nowMs: NOW })).toEqual({
+      interrupted: false,
+      reason: 'within_stability_window',
+    })
+  })
+
+  it('honors a custom stabilityMs override', () => {
+    const recent = {
+      info: { id: 'm2', role: 'assistant', time: { created: NOW - 1_000 } },
+      parts: [{ type: 'tool', state: { status: 'running' } }],
+    }
+    const verdict = detectInterruptedTurn([user, recent], { nowMs: NOW, stabilityMs: 500 })
+    expect(verdict).toEqual({ interrupted: true, messageId: 'm2', evidence: ['missing_completion', 'running_tool_part'] })
+  })
+})

--- a/test/unit/server/fresh-agent/opencode-normalize.test.ts
+++ b/test/unit/server/fresh-agent/opencode-normalize.test.ts
@@ -443,3 +443,116 @@ describe('OpenCode fresh-agent normalization', () => {
     expect(FreshAgentTurnPageSchema.parse(fallback).nextCursor).toBe('fallback-cursor')
   })
 })
+
+describe('turn evidence extraction (zrrj)', () => {
+  it('surfaces missing completion time, abort error, and running tool parts', () => {
+    const snapshot = normalizeOpencodeSnapshot({
+      sessionType: 'freshopencode',
+      threadId: 'ses_1',
+      status: 'idle',
+      exported: {
+        info: { id: 'ses_1', time: { updated: 10 } },
+        messages: [
+          // realistic: user messages never carry time.completed (verified, V2)
+          { info: { id: 'm1', role: 'user', time: { created: 1 } }, parts: [] },
+          {
+            info: {
+              id: 'm2', role: 'assistant', time: { created: 2, completed: 3 }, // clean prior turn
+              tokens: { input: 10, output: 40 }, cost: 0.01,
+            },
+            parts: [{ type: 'step-start' }, { type: 'step-finish' }],
+          },
+          {
+            info: {
+              id: 'm3', role: 'assistant', time: { created: 4 }, // NO completed
+              error: { name: 'MessageAbortedError', message: 'aborted' },
+              tokens: { input: 100, output: 0 }, cost: 0,
+            },
+            parts: [
+              { type: 'tool', state: { status: 'running' } },
+              { type: 'step-start' },
+            ],
+          },
+        ],
+      },
+    })
+    // The client hard-validates snapshots against the shared contract; an
+    // evidence-bearing snapshot must still parse.
+    FreshAgentSnapshotSchema.parse(snapshot)
+    const evidence = (snapshot.extensions as any).opencode.turnEvidence
+    expect(evidence).toHaveLength(3)
+    expect(evidence[2]).toMatchObject({
+      turnId: 'm3', role: 'assistant',
+      timeCreated: 4,
+      error: { name: 'MessageAbortedError', message: 'aborted' },
+      tokens: { input: 100, output: 0 },
+      cost: 0,
+      runningToolPartCount: 1, stepStartCount: 1, stepFinishCount: 0,
+    })
+    // absent => unfinished: the property must be truly absent, not undefined-valued
+    expect(evidence[2]).not.toHaveProperty('timeCompleted')
+    expect(evidence[1]).toMatchObject({
+      turnId: 'm2', role: 'assistant', timeCreated: 2, timeCompleted: 3, cost: 0.01,
+      tokens: { input: 10, output: 40 },
+      runningToolPartCount: 0, stepStartCount: 1, stepFinishCount: 1,
+    })
+    expect(evidence[1].error).toBeUndefined()
+    expect(evidence[0]).toMatchObject({
+      turnId: 'm1', role: 'user', timeCreated: 1,
+      runningToolPartCount: 0, stepStartCount: 0, stepFinishCount: 0,
+    })
+    expect(evidence[0]).not.toHaveProperty('timeCompleted')
+  })
+
+  it('tolerates alternate error shapes and absent fields without crashing', () => {
+    const snapshot = normalizeOpencodeSnapshot({
+      sessionType: 'freshopencode',
+      threadId: 'ses_err_shapes',
+      exported: {
+        messages: [
+          { info: { id: 'm1', role: 'assistant', error: { data: { message: 'nested boom' } } }, parts: [] },
+          { info: { id: 'm2', role: 'assistant', error: 'plain boom' }, parts: [] },
+          { info: { id: 'm3', role: 'assistant' } }, // no parts array, no optional fields
+        ],
+      },
+    })
+    const evidence = (snapshot.extensions as any).opencode.turnEvidence
+    expect(evidence).toHaveLength(3)
+    expect(evidence[0].error).toEqual({ message: 'nested boom' })
+    expect(evidence[1].error).toEqual({ message: 'plain boom' })
+    expect(evidence[2]).toEqual({
+      turnId: 'm3',
+      role: 'assistant',
+      runningToolPartCount: 0,
+      stepStartCount: 0,
+      stepFinishCount: 0,
+    })
+  })
+
+  it('never leaks message text into evidence', () => {
+    const snapshot = normalizeOpencodeSnapshot({
+      sessionType: 'freshopencode',
+      threadId: 'ses_secret',
+      exported: {
+        info: { id: 'ses_secret', time: { updated: 5 } },
+        messages: [
+          {
+            info: { id: 'm1', role: 'assistant', time: { created: 1 } },
+            parts: [
+              { id: 'p1', type: 'text', text: 'the secret assistant text' },
+              {
+                id: 'p2',
+                type: 'tool',
+                tool: 'bash',
+                state: { status: 'running', input: { command: 'echo the secret assistant text' }, output: 'the secret assistant text' },
+              },
+            ],
+          },
+        ],
+      },
+    })
+    const json = JSON.stringify((snapshot.extensions as any).opencode.turnEvidence)
+    expect(json).not.toContain('the secret assistant text')
+    expect((snapshot.extensions as any).opencode.turnEvidence[0]).toMatchObject({ turnId: 'm1', runningToolPartCount: 1 })
+  })
+})

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -107,6 +107,11 @@ function makeAdapter(manager: FakeManager, overrides: Partial<Parameters<typeof 
     // Every test adapter gets an isolated recovery store by default so no test can
     // read or write the real user-level recovery file.
     recoveryStore: makeTempRecoveryStore(),
+    // Transcript-settle polls (zrrj Task 15): default the injected sleep to a no-op so
+    // tests using the never-settling default listMessages fixture exhaust the poll
+    // budget in pure microtasks instead of ~1.5 s of real timers. The PRODUCTION
+    // default stays the real setTimeout sleep; explicit per-test overrides still win.
+    settleSleep: async () => {},
     ...overrides,
   })
 }
@@ -1340,6 +1345,95 @@ describe('restore reconciliation emits and monitors (zrrj)', () => {
     const completions = events.filter((e) => e?.type === 'sdk.turn.complete')
     expect(idles).toHaveLength(1)
     expect(completions).toHaveLength(1)
+  })
+})
+
+describe('idle freshness (zrrj)', () => {
+  it('withholds idle and turn-complete until the final assistant message is queryable', async () => {
+    const now = Date.now()
+    const manager = makeFakeManager()
+    const idle = createDeferred<void>()
+    manager.onceIdle = vi.fn(() => idle.promise)
+    // First two polls: transcript still missing the final answer; third poll: it appears.
+    const unfinished = {
+      // user messages never carry time.completed (verified live, V2)
+      messages: [{ info: { id: 'm1', role: 'user', time: { created: now } }, parts: [] }],
+      nextCursor: null,
+    }
+    const finished = {
+      messages: [
+        ...unfinished.messages,
+        { info: { id: 'm2', role: 'assistant', time: { created: now, completed: now } }, parts: [] },
+      ],
+      nextCursor: null,
+    }
+    const events: any[] = []
+    // Each poll records whether idle had (wrongly) already been emitted before it ran.
+    const idleAlreadyEmittedAtPoll: boolean[] = []
+    manager.listMessages.mockImplementation(async () => {
+      idleAlreadyEmittedAtPoll.push(events.some((e) => e?.type === 'sdk.session.snapshot' && e.status === 'idle'))
+      return (idleAlreadyEmittedAtPoll.length >= 3 ? finished : unfinished) as any
+    })
+    const adapter = makeAdapter(manager, { settleSleep: async () => {} }) // injected no-op sleep
+    await adapter.create({ requestId: 'fresh-1', sessionType: 'freshopencode', provider: 'opencode' })
+    adapter.subscribe?.('freshopencode-fresh-1', (e) => events.push(e))
+    const sendPromise = adapter.send!('freshopencode-fresh-1', { text: 'q' })
+    idle.resolve()
+    await sendPromise
+    expect(manager.listMessages).toHaveBeenCalledTimes(3)
+    expect(idleAlreadyEmittedAtPoll).toEqual([false, false, false]) // idle withheld through every poll
+    const idleIndex = events.findIndex((e) => e?.type === 'sdk.session.snapshot' && e.status === 'idle')
+    const completeIndex = events.findIndex((e) => e?.type === 'sdk.turn.complete')
+    expect(idleIndex).toBeGreaterThanOrEqual(0)
+    expect(completeIndex).toBeGreaterThan(idleIndex - 1) // both emitted, after settling
+  })
+
+  it('gives up after the poll budget but still emits idle (never strands the pane busy)', async () => {
+    loggerMocks.logger.warn.mockClear()
+    const manager = makeFakeManager()
+    const idle = createDeferred<void>()
+    manager.onceIdle = vi.fn(() => idle.promise)
+    // Default listMessages fixture ({ messages: [] }) never settles.
+    const adapter = makeAdapter(manager, { settleSleep: async () => {} })
+    await adapter.create({ requestId: 'fresh-2', sessionType: 'freshopencode', provider: 'opencode' })
+    const events: any[] = []
+    adapter.subscribe?.('freshopencode-fresh-2', (e) => events.push(e))
+    const sendPromise = adapter.send!('freshopencode-fresh-2', { text: 'q' })
+    idle.resolve()
+    await sendPromise
+    expect(manager.listMessages.mock.calls.length).toBeGreaterThanOrEqual(2) // bounded polling actually happened
+    expect(manager.listMessages.mock.calls.length).toBeLessThanOrEqual(11) // 1 + max 10 polls
+    expect(events.some((e) => e?.type === 'sdk.session.snapshot' && e.status === 'idle')).toBe(true)
+    // Exhaustion degrades to the pre-task behavior (idle + chime) rather than stranding the turn.
+    expect(events.some((e) => e?.type === 'sdk.turn.complete')).toBe(true)
+    const warnCall = loggerMocks.logger.warn.mock.calls.find((call) => call[1] === 'transcript did not settle after idle')
+    expect(warnCall).toBeDefined()
+    expect(JSON.stringify(warnCall![0])).not.toContain('ses_real_1') // hashed identity only
+  })
+
+  it('monitor-resolve path proves the transcript (any completed assistant message) before emitting idle', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus = vi.fn(async () => ({ type: 'busy' }))
+    const idle = createDeferred<void>()
+    manager.onceIdle = vi.fn(() => idle.promise)
+    const events: any[] = []
+    const idleAlreadyEmittedAtPoll: boolean[] = []
+    manager.listMessages.mockImplementation(async () => {
+      idleAlreadyEmittedAtPoll.push(events.some((e) => e?.type === 'sdk.session.snapshot' && e.status === 'idle'))
+      // First poll: not yet queryable; second poll: an OLD completed assistant message —
+      // the monitor path passes sentAtMs = 0, so ANY completed assistant message settles.
+      return (idleAlreadyEmittedAtPoll.length >= 2
+        ? { messages: [{ info: { id: 'a1', role: 'assistant', time: { created: 1, completed: 2 } }, parts: [] }], nextCursor: null }
+        : { messages: [], nextCursor: null }) as any
+    })
+    const adapter = makeAdapter(manager)
+    await adapter.attach!({ sessionId: 'ses_live', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    adapter.subscribe?.('ses_live', (ev) => events.push(ev))
+    idle.resolve()
+    await vi.waitFor(() => expect(events.some((e) => e?.type === 'sdk.session.snapshot' && e.status === 'idle')).toBe(true))
+    expect(manager.listMessages).toHaveBeenCalledTimes(2)
+    expect(idleAlreadyEmittedAtPoll).toEqual([false, false]) // idle withheld until the transcript proved queryable
+    expect(events.some((e) => e?.type === 'sdk.turn.complete')).toBe(true)
   })
 })
 

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -29,6 +29,7 @@ vi.mock('../../../../server/fresh-agent/observability.js', async (importOriginal
 vi.mock('../../../../server/logger.js', () => ({ logger: loggerMocks.logger, freshAgentObservabilityLogger: loggerMocks.freshAgentObservabilityLogger }))
 
 import { createOpencodeFreshAgentAdapter } from '../../../../server/fresh-agent/adapters/opencode/adapter.js'
+import { OpencodeServeLostError } from '../../../../server/fresh-agent/adapters/opencode/serve-manager.js'
 import { FRESHOPENCODE_DEFAULT_MODEL } from '../../../../shared/fresh-agent-models.js'
 
 type FakeManager = ReturnType<typeof makeFakeManager>
@@ -155,7 +156,9 @@ describe('OpenCode serve adapter: create + send', () => {
     })
     expect(attached).toEqual({ sessionId: 'ses_real_1', sessionRef: { provider: 'opencode', sessionId: 'ses_real_1' } })
     expect(manager.subscribe).toHaveBeenCalledTimes(1)
-    expect(manager.subscribe).toHaveBeenCalledWith('ses_real_1', expect.any(Function))
+    // Third arg is the sidecar-loss handler (zrrj): serve stream binding registers
+    // an onLost listener alongside the event listener.
+    expect(manager.subscribe).toHaveBeenCalledWith('ses_real_1', expect.any(Function), expect.any(Function))
 
     // The in-flight send still completes with the correct result once idle resolves.
     idle.resolve()
@@ -588,6 +591,8 @@ describe('OpenCode serve adapter: create + send', () => {
   it('marks recovered durable sessions running only when OpenCode status is busy or retry', async () => {
     const manager = makeFakeManager()
     manager.getSessionStatus = vi.fn(async () => ({ type: 'busy' }))
+    // Keep the restore idle-recovery monitor (zrrj) pending so the session stays running.
+    manager.onceIdle = vi.fn(() => new Promise<void>(() => {}))
     const adapter = makeAdapter(manager)
 
     await adapter.attach?.({
@@ -613,6 +618,8 @@ describe('OpenCode serve adapter: create + send', () => {
     manager.getSessionStatus = vi.fn()
       .mockResolvedValueOnce({ type: 'busy' })
       .mockResolvedValueOnce({ nope: 'bad' })
+    // Keep the restore idle-recovery monitor (zrrj) pending so the first attach stays running.
+    manager.onceIdle = vi.fn(() => new Promise<void>(() => {}))
     const adapter = makeAdapter(manager)
 
     await adapter.attach?.({
@@ -732,6 +739,8 @@ describe('OpenCode serve adapter: create + send', () => {
   it('marks resumed durable sessions running when OpenCode reports retry', async () => {
     const manager = makeFakeManager()
     manager.getSessionStatus = vi.fn(async () => ({ type: 'retry' }))
+    // Keep the restore idle-recovery monitor (zrrj) pending so the session stays running.
+    manager.onceIdle = vi.fn(() => new Promise<void>(() => {}))
     const adapter = makeAdapter(manager)
 
     await adapter.resume?.({
@@ -1182,5 +1191,134 @@ describe('OpenCode serve adapter: status observability', () => {
     expect(running).toBeDefined()
     expect(running!.cwdHash).toBeDefined()
     expect(running!.cwdHash).not.toBe('/repo/work')
+  })
+})
+
+describe('restore reconciliation emits and monitors (zrrj)', () => {
+  it('emits a running session snapshot when attach reconciles a busy durable session', async () => {
+    // Ordering matters: attach registers the state via remember() BEFORE reconcile awaits
+    // getSessionStatus, so park the status read on a deferred, start attach, subscribe once
+    // the state is registered, THEN release the status read. The running emission must
+    // happen inside reconcile, DURING attach — an implementation that arms a monitor but
+    // never emits must FAIL here.
+    const manager = makeFakeManager()
+    const status = createDeferred<{ type: string } | undefined>()
+    manager.getSessionStatus = vi.fn(() => status.promise)
+    const adapter = makeAdapter(manager)
+    const events: any[] = []
+    const attaching = adapter.attach!({ sessionId: 'ses_live', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    await new Promise((r) => setImmediate(r)) // remember() has run; status read still parked
+    adapter.subscribe?.('ses_live', (ev) => events.push(ev))
+    status.resolve({ type: 'busy' })
+    await attaching
+    expect(events.some((e) => e.type === 'sdk.session.snapshot' && e.status === 'running')).toBe(true)
+  })
+
+  it('arms exactly one idle-recovery monitor per durable session and chimes on resolve', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus = vi.fn(async () => ({ type: 'busy' }))
+    const idle = createDeferred<void>()
+    manager.onceIdle = vi.fn(() => idle.promise)
+    const adapter = makeAdapter(manager)
+    const events: any[] = []
+    await adapter.attach!({ sessionId: 'ses_live', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    await adapter.attach!({ sessionId: 'ses_live', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }) // second restore path
+    expect(manager.onceIdle).toHaveBeenCalledTimes(1) // exactly ONE monitor
+    adapter.subscribe?.('ses_live', (ev) => events.push(ev))
+    idle.resolve()
+    await new Promise((r) => setImmediate(r))
+    expect(events.some((e) => e.type === 'sdk.session.snapshot' && e.status === 'idle')).toBe(true)
+    expect(events.some((e) => e.type === 'sdk.turn.complete' && typeof e.at === 'number')).toBe(true)
+  })
+
+  it('emits idle + a structured interruption signal when the monitor rejects with sidecar loss', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus = vi.fn(async () => ({ type: 'busy' }))
+    const idle = createDeferred<void>()
+    manager.onceIdle = vi.fn(() => idle.promise)
+    const adapter = makeAdapter(manager)
+    const events: any[] = []
+    await adapter.attach!({ sessionId: 'ses_live', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    adapter.subscribe?.('ses_live', (ev) => events.push(ev))
+    idle.reject(new OpencodeServeLostError('ses_live'))
+    await new Promise((r) => setImmediate(r))
+    expect(events.some((e) => e.type === 'sdk.session.snapshot' && e.status === 'idle')).toBe(true)
+    expect(events.some((e) => e.type === 'sdk.error' && /interrupted/i.test(e.message))).toBe(true)
+    expect(events.some((e) => e.type === 'sdk.turn.complete')).toBe(false) // no chime on interruption
+  })
+
+  it('emits idle + a structured interruption signal when the monitor times out', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus = vi.fn(async () => ({ type: 'busy' }))
+    const idle = createDeferred<void>()
+    manager.onceIdle = vi.fn(() => idle.promise)
+    const adapter = makeAdapter(manager)
+    const events: any[] = []
+    await adapter.attach!({ sessionId: 'ses_live', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    adapter.subscribe?.('ses_live', (ev) => events.push(ev))
+    idle.reject(new Error('Timed out after 600000ms waiting for OpenCode session ses_live to go idle.'))
+    await new Promise((r) => setImmediate(r))
+    expect(events.some((e) => e.type === 'sdk.session.snapshot' && e.status === 'idle')).toBe(true)
+    expect(events.some((e) => e.type === 'sdk.error' && /interrupted/i.test(e.message))).toBe(true)
+    expect(events.some((e) => e.type === 'sdk.turn.complete')).toBe(false)
+  })
+
+  it('does not arm a monitor when reconcile finds the session idle/absent', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus = vi.fn(async () => undefined) // absent == idle
+    const adapter = makeAdapter(manager)
+    await adapter.attach!({ sessionId: 'ses_calm', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    expect(manager.onceIdle).not.toHaveBeenCalled()
+  })
+
+  it('disarms a cold monitor when a new user send starts (no double idle/chime)', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus = vi.fn(async () => ({ type: 'busy' }))
+    const monitorIdle = createDeferred<void>()
+    manager.onceIdle = vi.fn()
+      .mockReturnValueOnce(monitorIdle.promise) // the cold monitor's waiter
+      .mockResolvedValue(undefined) // the send path's own waiter
+    const adapter = makeAdapter(manager)
+    await adapter.attach!({ sessionId: 'ses_live', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    expect(manager.onceIdle).toHaveBeenCalledTimes(1)
+    const events: any[] = []
+    adapter.subscribe?.('ses_live', (ev) => events.push(ev))
+
+    await adapter.send?.('ses_live', { text: 'next turn' })
+    // The cancelled monitor resolving later must not add a second idle/chime for this turn.
+    monitorIdle.resolve()
+    await new Promise((r) => setImmediate(r))
+
+    const idles = events.filter((e) => e.type === 'sdk.session.snapshot' && e.status === 'idle')
+    const completions = events.filter((e) => e.type === 'sdk.turn.complete')
+    expect(idles).toHaveLength(1)
+    expect(completions).toHaveLength(1)
+  })
+
+  it('does not arm a monitor when an attach reconciles busy during an in-flight send (no double idle/chime)', async () => {
+    const sendIdle = createDeferred<void>()
+    const manager = makeFakeManager()
+    manager.getSessionStatus = vi.fn(async () => ({ type: 'busy' }))
+    manager.onceIdle = vi.fn(() => sendIdle.promise)
+    const adapter = makeAdapter(manager)
+    await adapter.create({ requestId: 'req-mid', sessionType: 'freshopencode', provider: 'opencode', cwd: '/repo' })
+    const events: any[] = []
+    adapter.subscribe?.('freshopencode-req-mid', (e) => events.push(e))
+
+    const sendPromise = adapter.send?.('freshopencode-req-mid', { text: 'go' })
+    await vi.waitFor(() => expect(manager.promptAsync).toHaveBeenCalled())
+
+    // A pane refresh/reveal attach arrives while the send path's own onceIdle owns the turn.
+    await adapter.attach!({ sessionId: 'ses_real_1', sessionType: 'freshopencode', provider: 'opencode', cwd: '/repo' })
+    expect(manager.onceIdle).toHaveBeenCalledTimes(1) // only the send path's waiter
+
+    sendIdle.resolve()
+    await sendPromise
+    await new Promise((r) => setImmediate(r))
+
+    const idles = events.filter((e) => e?.type === 'sdk.session.snapshot' && e.status === 'idle')
+    const completions = events.filter((e) => e?.type === 'sdk.turn.complete')
+    expect(idles).toHaveLength(1)
+    expect(completions).toHaveLength(1)
   })
 })

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -13,8 +13,12 @@ const loggerMocks = vi.hoisted(() => {
     debug: vi.fn(),
     error: vi.fn(),
   }
+  const freshAgentObservabilityLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+  }
   logger.child.mockReturnValue(logger)
-  return { logger }
+  return { logger, freshAgentObservabilityLogger }
 })
 
 vi.mock('../../../../server/fresh-agent/observability.js', async (importOriginal) => {
@@ -22,7 +26,7 @@ vi.mock('../../../../server/fresh-agent/observability.js', async (importOriginal
   return { ...actual, recordFreshAgentObservabilityEvent: observabilityMocks.recordFreshAgentObservabilityEvent }
 })
 
-vi.mock('../../../../server/logger.js', () => ({ logger: loggerMocks.logger }))
+vi.mock('../../../../server/logger.js', () => ({ logger: loggerMocks.logger, freshAgentObservabilityLogger: loggerMocks.freshAgentObservabilityLogger }))
 
 import { createOpencodeFreshAgentAdapter } from '../../../../server/fresh-agent/adapters/opencode/adapter.js'
 import { FRESHOPENCODE_DEFAULT_MODEL } from '../../../../shared/fresh-agent-models.js'

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -1321,6 +1321,30 @@ describe('restore reconciliation emits and monitors (zrrj)', () => {
     expect(completions).toHaveLength(1)
   })
 
+  it('disarms a cold monitor when a compact starts (no double idle/chime)', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus = vi.fn(async () => ({ type: 'busy' }))
+    const monitorIdle = createDeferred<void>()
+    manager.onceIdle = vi.fn()
+      .mockReturnValueOnce(monitorIdle.promise) // the cold monitor's waiter
+      .mockResolvedValue(undefined) // the compact path's own waiter
+    const adapter = makeAdapter(manager)
+    await adapter.attach!({ sessionId: 'ses_live', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    expect(manager.onceIdle).toHaveBeenCalledTimes(1)
+    const events: any[] = []
+    adapter.subscribe?.('ses_live', (ev) => events.push(ev))
+
+    await adapter.compact?.('ses_live')
+    // The cancelled monitor resolving later must not add a second idle/chime for this turn.
+    monitorIdle.resolve()
+    await new Promise((r) => setImmediate(r))
+
+    const idles = events.filter((e) => e.type === 'sdk.session.snapshot' && e.status === 'idle')
+    const completions = events.filter((e) => e.type === 'sdk.turn.complete')
+    expect(idles).toHaveLength(1)
+    expect(completions).toHaveLength(1)
+  })
+
   it('does not arm a monitor when an attach reconciles busy during an in-flight send (no double idle/chime)', async () => {
     const sendIdle = createDeferred<void>()
     const manager = makeFakeManager()

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -1322,3 +1322,86 @@ describe('restore reconciliation emits and monitors (zrrj)', () => {
     expect(completions).toHaveLength(1)
   })
 })
+
+describe('statusFromLiveState (zrrj, Task 4 gate)', () => {
+  it('is false/absent for an untracked session snapshot (idle default)', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+
+    // getSnapshot for a ses_ id with no adapter state: status falls back to the
+    // placeholder-default 'idle', which must NOT license a client busy-clear.
+    const snapshot: any = await adapter.getSnapshot?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'ses_untracked',
+      cwd: '/repo/safe',
+    })
+
+    expect(snapshot.status).toBe('idle')
+    expect(snapshot.extensions.opencode.statusFromLiveState).not.toBe(true)
+    expect(snapshot.extensions.opencode.statusFromLiveState).toBe(false)
+  })
+
+  it('is true only after the initial reconcile completed', async () => {
+    // Reconcile resolves (absent from the status map => confirmed idle) -> true.
+    const manager = makeFakeManager()
+    manager.getSessionStatus = vi.fn(async () => undefined)
+    const adapter = makeAdapter(manager)
+    await adapter.attach?.({
+      sessionId: 'ses_reconciled',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      cwd: '/repo/safe',
+    })
+    const snapshot: any = await adapter.getSnapshot?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'ses_reconciled',
+      cwd: '/repo/safe',
+    })
+    expect(snapshot.status).toBe('idle')
+    expect(snapshot.extensions.opencode.statusFromLiveState).toBe(true)
+
+    // Error-swallow path: getSessionStatus rejecting must leave the flag false —
+    // a failed read never licenses a busy-clear.
+    const failingManager = makeFakeManager()
+    failingManager.getSessionStatus = vi.fn(async () => { throw new Error('status failed') })
+    const failingAdapter = makeAdapter(failingManager)
+    await failingAdapter.attach?.({
+      sessionId: 'ses_reconcile_failed',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      cwd: '/repo/safe',
+    })
+    const failedSnapshot: any = await failingAdapter.getSnapshot?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'ses_reconcile_failed',
+      cwd: '/repo/safe',
+    })
+    expect(failedSnapshot.status).toBe('idle')
+    expect(failedSnapshot.extensions.opencode.statusFromLiveState).toBe(false)
+  })
+
+  it('is true when the reconcile resolves busy (running branch)', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus = vi.fn(async () => ({ type: 'busy' }))
+    // Keep the restore idle-recovery monitor pending so the session stays running.
+    manager.onceIdle = vi.fn(() => new Promise<void>(() => {}))
+    const adapter = makeAdapter(manager)
+    await adapter.attach?.({
+      sessionId: 'ses_busy_flag',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      cwd: '/repo/safe',
+    })
+    const snapshot: any = await adapter.getSnapshot?.({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      threadId: 'ses_busy_flag',
+      cwd: '/repo/safe',
+    })
+    expect(snapshot.status).toBe('running')
+    expect(snapshot.extensions.opencode.statusFromLiveState).toBe(true)
+  })
+})

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../../../server/logger.js', () => ({ logger: loggerMocks.logger, fre
 
 import { createOpencodeFreshAgentAdapter } from '../../../../server/fresh-agent/adapters/opencode/adapter.js'
 import { OpencodeServeLostError } from '../../../../server/fresh-agent/adapters/opencode/serve-manager.js'
+import { hashForLogs } from '../../../../server/fresh-agent/observability.js'
 import { FreshAgentRecoveryStore } from '../../../../server/fresh-agent/recovery-store.js'
 import { FRESHOPENCODE_DEFAULT_MODEL } from '../../../../shared/fresh-agent-models.js'
 
@@ -1674,5 +1675,74 @@ describe('interrupted-turn recovery (zrrj)', () => {
     expect(await store.hasInterrupt('ses_int')).toBe(true)
     await adapter.send!('ses_int', { text: 'user follow-up' })
     expect(await store.hasInterrupt('ses_int')).toBe(false)
+  })
+})
+
+describe('inspectSessions: read-only incident summary (zrrj)', () => {
+  it('reports a hashed, content-free summary for a running session with an armed monitor', async () => {
+    const manager = makeFakeManager()
+    manager.getSessionStatus = vi.fn(async () => ({ type: 'busy' }))
+    // Keep the restore idle-recovery monitor pending so it stays armed.
+    manager.onceIdle = vi.fn(() => new Promise<void>(() => {}))
+    const adapter = makeAdapter(manager)
+    await adapter.attach!({ sessionId: 'ses_live', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+
+    const result = adapter.inspectSessions()
+
+    expect(result).toEqual([{
+      sessionIdHash: hashForLogs('ses_live'),
+      status: 'running',
+      hasRealSession: true,
+      cwdHash: hashForLogs('/w'),
+      monitorArmed: true,
+    }])
+    // Content-free: neither the raw ses_ id nor the raw cwd may appear anywhere.
+    const json = JSON.stringify(result)
+    expect(json).not.toContain('ses_')
+    expect(json).not.toContain('/w')
+  })
+
+  it('dedupes placeholder/real aliases and reports turn flags after a completed send', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+    await adapter.create({ requestId: 'req-inspect', sessionType: 'freshopencode', provider: 'opencode', cwd: '/repo' })
+    await adapter.send!('freshopencode-req-inspect', { text: 'secret user prompt' })
+
+    const result = adapter.inspectSessions()
+
+    // The state is remembered under BOTH the placeholder and the real ses_ id —
+    // the summary must report the underlying state exactly once.
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      sessionIdHash: hashForLogs('ses_real_1'),
+      status: 'idle',
+      hasRealSession: true,
+      monitorArmed: false,
+      turnAborted: false,
+      turnErrored: false,
+    })
+    expect(typeof result[0].lastTurnCompleteAt).toBe('number')
+    // No message text and no raw identity leaks into the summary.
+    const json = JSON.stringify(result)
+    expect(json).not.toContain('secret user prompt')
+    expect(json).not.toContain('ses_')
+    expect(json).not.toContain('/repo')
+  })
+
+  it('reports an unmaterialized placeholder with hasRealSession false', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+    await adapter.create({ requestId: 'req-cold', sessionType: 'freshopencode', provider: 'opencode', cwd: '/repo' })
+
+    const result = adapter.inspectSessions()
+
+    expect(result).toEqual([{
+      sessionIdHash: hashForLogs('freshopencode-req-cold'),
+      status: 'idle',
+      hasRealSession: false,
+      cwdHash: hashForLogs('/repo'),
+      monitorArmed: false,
+    }])
+    expect(JSON.stringify(result)).not.toContain('freshopencode-req-cold')
   })
 })

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -1469,7 +1469,34 @@ describe('interrupted-turn recovery (zrrj)', () => {
     expect(turnRecoveryAudits().some((e) => e.action === 'suppressed_already_recovered')).toBe(true)
   })
 
+  it('injects exactly one continuation when two restores race on the same session (no double-inject)', async () => {
+    // Multi-pane restore after a restart: two attaches of the same session land
+    // near-simultaneously. Without serializing the recovery passes, both hasRecovery
+    // reads resolve false before either recordRecovery lands (the store queues
+    // operations individually, with no atomic check-and-set) and BOTH inject —
+    // violating "at most ONE recovery per (session, message) ever".
+    observabilityMocks.recordFreshAgentObservabilityEvent.mockClear()
+    const store = makeTempRecoveryStore()
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue(undefined) // idle
+    manager.listMessages.mockResolvedValue(interruptedTranscript as any)
+    const adapter = makeAdapter(manager, { recoveryStore: store })
+
+    // Two schedule calls on the same state while the first pass is still in flight
+    // (its recovery-store reads are fs-async, so it cannot have finished yet).
+    await adapter.attach!({ sessionId: 'ses_int', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    await adapter.attach!({ sessionId: 'ses_int', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    await flushRecovery()
+
+    expect(manager.promptAsync).toHaveBeenCalledTimes(1)
+    const injected = turnRecoveryAudits().filter((e) => e.action === 'continuation_injected')
+    expect(injected).toHaveLength(1)
+    expect(turnRecoveryAudits().some((e) => e.action === 'suppressed_already_recovered')).toBe(true)
+    expect(await store.hasRecovery('ses_int', 'm2')).toBe(true)
+  })
+
   it('never recovers after an explicit user interrupt, across adapter instances', async () => {
+    observabilityMocks.recordFreshAgentObservabilityEvent.mockClear()
     const store = makeTempRecoveryStore()
     const manager = makeFakeManager()
     manager.getSessionStatus.mockResolvedValue(undefined)
@@ -1480,14 +1507,30 @@ describe('interrupted-turn recovery (zrrj)', () => {
     await adapter1.interrupt!('ses_int') // user stop
     expect(await store.hasInterrupt('ses_int')).toBe(true)
 
-    // Simulated restart: fresh adapter + manager sharing the durable store.
+    // Simulated restart: fresh adapter + manager sharing the durable store. The
+    // transcript now ends on a DIFFERENT interrupted assistant message (m9) — a
+    // fresh (session, message) pair with no ledger entry — so ledger suppression
+    // cannot mask the user-stop gate: only hasInterrupt can suppress this one.
     const manager2 = makeFakeManager()
     manager2.getSessionStatus.mockResolvedValue(undefined)
-    manager2.listMessages.mockResolvedValue(interruptedTranscript as any)
+    manager2.listMessages.mockResolvedValue({
+      messages: [
+        ...interruptedTranscript.messages,
+        { info: { id: 'm8', role: 'user', time: { created: OLD + 5 } }, parts: [] },
+        { info: { id: 'm9', role: 'assistant', time: { created: OLD + 10 } }, parts: [{ type: 'tool', state: { status: 'running' } }] },
+      ],
+      nextCursor: null,
+    } as any)
     const adapter2 = makeAdapter(manager2, { recoveryStore: store })
+    observabilityMocks.recordFreshAgentObservabilityEvent.mockClear()
     await adapter2.attach!({ sessionId: 'ses_int', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
     await flushRecovery()
     expect(manager2.promptAsync).not.toHaveBeenCalled()
+    // The suppression must come from the user-stop gate itself, not the ledger.
+    expect(turnRecoveryAudits().some((e) => e.action === 'suppressed_user_stop')).toBe(true)
+    expect(turnRecoveryAudits().some((e) => e.action === 'continuation_injected')).toBe(false)
+    // The gate fires before any ledger write: the fresh turn stays unburned.
+    expect(await store.hasRecovery('ses_int', 'm9')).toBe(false)
   })
 
   it('does not burn the recovery ledger on a no-cwd attach (route check precedes record)', async () => {

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from 'node:events'
+import { mkdtempSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 const observabilityMocks = vi.hoisted(() => ({
@@ -30,6 +33,7 @@ vi.mock('../../../../server/logger.js', () => ({ logger: loggerMocks.logger, fre
 
 import { createOpencodeFreshAgentAdapter } from '../../../../server/fresh-agent/adapters/opencode/adapter.js'
 import { OpencodeServeLostError } from '../../../../server/fresh-agent/adapters/opencode/serve-manager.js'
+import { FreshAgentRecoveryStore } from '../../../../server/fresh-agent/recovery-store.js'
 import { FRESHOPENCODE_DEFAULT_MODEL } from '../../../../shared/fresh-agent-models.js'
 
 type FakeManager = ReturnType<typeof makeFakeManager>
@@ -82,11 +86,27 @@ function makeFakeManager() {
   }
 }
 
+/** Isolated recovery store on a fresh temp file — tests must never touch ~/.freshell. */
+function makeTempRecoveryStore() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'freshell-recovery-test-'))
+  return new FreshAgentRecoveryStore({ filePath: path.join(dir, 'r.json') })
+}
+
+/** Drain the fire-and-forget recovery chain (recovery-store fs I/O + send queue). */
+async function flushRecovery() {
+  for (let i = 0; i < 25; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+}
+
 function makeAdapter(manager: FakeManager, overrides: Partial<Parameters<typeof createOpencodeFreshAgentAdapter>[0]> = {}) {
   return createOpencodeFreshAgentAdapter({
     serveManager: manager as any,
     validateCwd: async () => undefined,
     canonicalizePath: async (value: string) => value,
+    // Every test adapter gets an isolated recovery store by default so no test can
+    // read or write the real user-level recovery file.
+    recoveryStore: makeTempRecoveryStore(),
     ...overrides,
   })
 }
@@ -1403,5 +1423,119 @@ describe('statusFromLiveState (zrrj, Task 4 gate)', () => {
     })
     expect(snapshot.status).toBe('running')
     expect(snapshot.extensions.opencode.statusFromLiveState).toBe(true)
+  })
+})
+
+describe('interrupted-turn recovery (zrrj)', () => {
+  const OLD = Date.now() - 60_000
+  const interruptedTranscript = {
+    messages: [
+      // realistic: user messages never carry time.completed (verified, V2)
+      { info: { id: 'm1', role: 'user', time: { created: OLD - 10 } }, parts: [] },
+      { info: { id: 'm2', role: 'assistant', time: { created: OLD } }, parts: [{ type: 'tool', state: { status: 'running' } }] },
+    ],
+    nextCursor: null,
+  }
+
+  function turnRecoveryAudits(): Array<Record<string, unknown>> {
+    return observabilityMocks.recordFreshAgentObservabilityEvent.mock.calls
+      .map(([event]) => event as Record<string, unknown>)
+      .filter((event) => event.kind === 'fresh_agent_turn_recovery')
+  }
+
+  it('injects exactly one continuation for an interrupted turn on attach', async () => {
+    observabilityMocks.recordFreshAgentObservabilityEvent.mockClear()
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue(undefined) // idle
+    manager.listMessages.mockResolvedValue(interruptedTranscript as any)
+    const adapter = makeAdapter(manager, { recoveryStore: makeTempRecoveryStore() })
+    await adapter.attach!({ sessionId: 'ses_int', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    await flushRecovery()
+    expect(manager.promptAsync).toHaveBeenCalledTimes(1)
+    const body = (manager.promptAsync.mock.calls[0] as any[])[1]
+    expect(body.parts[0].text).toMatch(/interrupted/i)
+
+    // Auditable: exactly one continuation_injected row, hashed identity only.
+    const injected = turnRecoveryAudits().filter((e) => e.action === 'continuation_injected')
+    expect(injected).toHaveLength(1)
+    expect(JSON.stringify(injected[0])).not.toContain('ses_int')
+    expect(JSON.stringify(injected[0])).not.toContain('/w')
+
+    // Second attach (same store): ledger suppresses.
+    manager.promptAsync.mockClear()
+    await adapter.attach!({ sessionId: 'ses_int', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    await flushRecovery()
+    expect(manager.promptAsync).not.toHaveBeenCalled()
+    expect(turnRecoveryAudits().some((e) => e.action === 'suppressed_already_recovered')).toBe(true)
+  })
+
+  it('never recovers after an explicit user interrupt, across adapter instances', async () => {
+    const store = makeTempRecoveryStore()
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue(undefined)
+    manager.listMessages.mockResolvedValue(interruptedTranscript as any)
+    const adapter1 = makeAdapter(manager, { recoveryStore: store })
+    await adapter1.attach!({ sessionId: 'ses_int', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    await flushRecovery()
+    await adapter1.interrupt!('ses_int') // user stop
+    expect(await store.hasInterrupt('ses_int')).toBe(true)
+
+    // Simulated restart: fresh adapter + manager sharing the durable store.
+    const manager2 = makeFakeManager()
+    manager2.getSessionStatus.mockResolvedValue(undefined)
+    manager2.listMessages.mockResolvedValue(interruptedTranscript as any)
+    const adapter2 = makeAdapter(manager2, { recoveryStore: store })
+    await adapter2.attach!({ sessionId: 'ses_int', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    await flushRecovery()
+    expect(manager2.promptAsync).not.toHaveBeenCalled()
+  })
+
+  it('does not burn the recovery ledger on a no-cwd attach (route check precedes record)', async () => {
+    observabilityMocks.recordFreshAgentObservabilityEvent.mockClear()
+    const store = makeTempRecoveryStore()
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue(undefined)
+    manager.listMessages.mockResolvedValue(interruptedTranscript as any)
+    const adapter = makeAdapter(manager, { recoveryStore: store })
+    await adapter.attach!({ sessionId: 'ses_int', sessionType: 'freshopencode', provider: 'opencode' }) // NO cwd — the incident shape
+    await flushRecovery()
+    expect(manager.promptAsync).not.toHaveBeenCalled() // no injection possible
+    expect(turnRecoveryAudits().some((e) => e.action === 'suppressed_no_route')).toBe(true)
+    expect(await store.hasRecovery('ses_int', 'm2')).toBe(false) // ledger NOT burned
+
+    // A later cwd-bearing attach can still recover the turn.
+    await adapter.attach!({ sessionId: 'ses_int', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    await flushRecovery()
+    expect(manager.promptAsync).toHaveBeenCalledTimes(1)
+    expect(await store.hasRecovery('ses_int', 'm2')).toBe(true)
+  })
+
+  it('does not recover when the user already sent a follow-up', async () => {
+    observabilityMocks.recordFreshAgentObservabilityEvent.mockClear()
+    const manager = makeFakeManager()
+    manager.getSessionStatus.mockResolvedValue(undefined)
+    manager.listMessages.mockResolvedValue({
+      messages: [
+        ...interruptedTranscript.messages,
+        { info: { id: 'm3', role: 'user', time: { created: OLD + 5 } }, parts: [] },
+      ],
+      nextCursor: null,
+    } as any)
+    const adapter = makeAdapter(manager, { recoveryStore: makeTempRecoveryStore() })
+    await adapter.attach!({ sessionId: 'ses_int', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    await flushRecovery()
+    expect(manager.promptAsync).not.toHaveBeenCalled()
+    expect(turnRecoveryAudits().some((e) => e.action === 'suppressed_user_followup')).toBe(true)
+  })
+
+  it('a normal user send clears recorded interrupt intent', async () => {
+    const store = makeTempRecoveryStore()
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager, { recoveryStore: store })
+    await adapter.attach!({ sessionId: 'ses_int', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' })
+    await adapter.interrupt!('ses_int')
+    expect(await store.hasInterrupt('ses_int')).toBe(true)
+    await adapter.send!('ses_int', { text: 'user follow-up' })
+    expect(await store.hasInterrupt('ses_int')).toBe(false)
   })
 })

--- a/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
@@ -4,6 +4,8 @@ import { ReadableStream } from 'node:stream/web'
 import { describe, expect, it, vi } from 'vitest'
 import { parseServeEvent as parseEvt } from '../../../../server/fresh-agent/adapters/opencode/serve-events.js'
 import { OpencodeServeManager, OpencodeServeLostError } from '../../../../server/fresh-agent/adapters/opencode/serve-manager.js'
+import { __setFreshAgentObservabilitySinkForTest } from '../../../../server/fresh-agent/observability.js'
+import { freshAgentObservabilityLogger } from '../../../../server/logger.js'
 
 function fakeChild() {
   const child = new EventEmitter() as any
@@ -893,7 +895,7 @@ describe('OpencodeServeManager fan-out', () => {
     expect(seen.map((e) => e.kind)).toEqual(['session.idle'])
   })
 
-  it('cleans up the event stream and session emitters when the child exits unexpectedly', async () => {
+  it('cleans up the event stream but retains subscribed session emitters when the child exits unexpectedly', async () => {
     const child = fakeChild()
     const stopStream = vi.fn()
     const spawnFn = vi.fn(() => child)
@@ -913,7 +915,9 @@ describe('OpencodeServeManager fan-out', () => {
     child.emit('close', 1)
     expect(stopStream).toHaveBeenCalled()
     expect(child.kill).toHaveBeenCalled()
-    expect((manager as any).sessionEmitters.size).toBe(0)
+    // Survive-replacement (zrrj): the emitter stays in the map so the live
+    // subscription keeps receiving events from a replacement sidecar.
+    expect((manager as any).sessionEmitters.has('ses_child')).toBe(true)
     expect((manager as any).running).toBeUndefined()
   })
 
@@ -958,7 +962,7 @@ describe('OpencodeServeManager fan-out', () => {
     expect(seen.map((e) => e.kind)).toEqual(['session.idle'])
   })
 
-  it('request timeout emits lost event and cleans up session emitters', async () => {
+  it('request timeout emits lost event and retains subscribed session emitters for replacement', async () => {
     let messageSignal: AbortSignal | undefined
     const fetchFn = vi.fn(async (url: string, init: any) => {
       if (url.endsWith('/global/health')) return jsonResponse({ healthy: true })
@@ -984,7 +988,9 @@ describe('OpencodeServeManager fan-out', () => {
     expect(child.kill).toHaveBeenCalled()
     expect(lostHandler).toHaveBeenCalledTimes(1)
     expect(lostHandler.mock.calls[0][0]).toBeInstanceOf(OpencodeServeLostError)
-    expect((manager as any).sessionEmitters.has('ses_project')).toBe(false)
+    // Survive-replacement (zrrj): the subscription is still attached, so the
+    // emitter must remain for the replacement sidecar to dispatch into.
+    expect((manager as any).sessionEmitters.has('ses_project')).toBe(true)
   })
 
   it('request timeout rejects pending onceIdle with OpencodeServeLostError', async () => {
@@ -1008,6 +1014,94 @@ describe('OpencodeServeManager fan-out', () => {
 
     await expect(idle).rejects.toThrow(/opencode serve sidecar was lost/)
     expect((manager as any).sessionEmitters.has('ses_project')).toBe(false)
+  })
+})
+
+describe('sidecar replacement resilience (zrrj)', () => {
+  // fakeChild.kill() queues the 'close' emit on a microtask; flush it so the
+  // manager's close handler runs (discarding the dead sidecar) before we act.
+  const flushClose = () => new Promise((r) => setTimeout(r, 0))
+
+  it('keeps session subscriptions alive across sidecar replacement', async () => {
+    const { manager, child } = makeManager()
+    const seen: unknown[] = []
+    manager.subscribe('ses_1', (ev) => seen.push(ev))
+    await manager.ensureStarted()
+    // Kill the sidecar -> replacement on next call, then dispatch an event as
+    // the REPLACEMENT sidecar would.
+    child.kill()
+    await flushClose()
+    await manager.ensureStarted()
+    ;(manager as any).dispatchEvent({ kind: 'session.idle', sessionId: 'ses_1', properties: {}, raw: {} })
+    expect(seen).toHaveLength(1)
+  })
+
+  it('still emits lost to onceIdle waiters when the sidecar dies', async () => {
+    const { manager, child } = makeManager()
+    await manager.ensureStarted()
+    const idle = manager.onceIdle('ses_1', 5_000)
+    child.kill()
+    await expect(idle).rejects.toBeInstanceOf(OpencodeServeLostError)
+  })
+
+  it("emits 'lost' carrying the generation of the dead sidecar", async () => {
+    const { manager, child } = makeManager()
+    await manager.ensureStarted()
+    const lostHandler = vi.fn()
+    ;(manager as any).emitterFor('ses_1').on('lost', lostHandler)
+    child.kill()
+    await flushClose()
+    expect(lostHandler).toHaveBeenCalledTimes(1)
+    expect(lostHandler).toHaveBeenCalledWith(expect.any(OpencodeServeLostError), { generation: 1 })
+  })
+
+  it('increments generation per start and exposes pid/baseUrl via describeSidecar', async () => {
+    const { manager, child } = makeManager()
+    expect(manager.currentGeneration()).toBe(0)
+    expect(manager.describeSidecar()).toBeUndefined()
+    await manager.ensureStarted()
+    expect(manager.currentGeneration()).toBe(1)
+    const desc = manager.describeSidecar()
+    expect(desc).toMatchObject({
+      generation: 1,
+      pid: 4242,
+      baseUrl: expect.stringContaining('http://127.0.0.1:'),
+      ownershipId: expect.any(String),
+    })
+    child.kill()
+    await flushClose()
+    expect(manager.describeSidecar()).toBeUndefined()
+    await manager.ensureStarted()
+    expect(manager.currentGeneration()).toBe(2)
+    expect(manager.describeSidecar()).toMatchObject({ generation: 2 })
+  })
+
+  it('records fresh_agent_sidecar observability rows for started, exited, and discarded phases', async () => {
+    const infoSpy = vi.fn()
+    const warnSpy = vi.fn()
+    __setFreshAgentObservabilitySinkForTest({ info: infoSpy, warn: warnSpy })
+    try {
+      const { manager, child } = makeManager()
+      await manager.ensureStarted()
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'fresh_agent_sidecar', phase: 'started', generation: 1, pid: 4242, baseUrl: 'http://127.0.0.1:47999' }),
+        'fresh_agent_sidecar',
+      )
+      child.kill()
+      await new Promise((r) => setTimeout(r, 0))
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'fresh_agent_sidecar', phase: 'exited', generation: 1 }),
+        'fresh_agent_sidecar',
+      )
+      await manager.ensureStarted()
+      ;(manager as any).discardRunning('request_timeout')
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'fresh_agent_sidecar', phase: 'discarded', generation: 2, reason: 'request_timeout' }),
+        'fresh_agent_sidecar',
+      )
+    } finally {
+      __setFreshAgentObservabilitySinkForTest(freshAgentObservabilityLogger)
+    }
   })
 })
 

--- a/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-manager.test.ts
@@ -679,6 +679,25 @@ describe('OpencodeServeManager fan-out', () => {
     await expect(manager.onceIdle('ses_a', 30)).rejects.toThrow(/idle/i)
   })
 
+  it('onceIdle with assumeActive resolves from status-map absence without prior observed activity (zrrj)', async () => {
+    // Arm-time activity seed (A4): the caller (adapter idle-recovery monitor) just OBSERVED
+    // the session busy via the status map, so its own observation counts as the first
+    // activity mark. A turn that completed in the read->arm gap must resolve in a couple of
+    // idle polls, NOT hang to the timeout and emit a false "interrupted".
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith('/global/health')) return jsonResponse({ healthy: true })
+      if (url.endsWith('/session/status')) return jsonResponse({}) // idle/absent throughout
+      return jsonResponse({})
+    })
+    const { manager } = makeManager({
+      fetchFn: fetchFn as any,
+      idlePollMs: 5,
+    })
+    await manager.ensureStarted()
+
+    await expect(manager.onceIdle('ses_done', 5_000, undefined, { assumeActive: true })).resolves.toBeUndefined()
+  })
+
   it('onceIdle ignores late message.updated events when the status map stays absent', async () => {
     let push!: (e: any) => void
     const fetchFn = vi.fn(async (url: string) => {

--- a/test/unit/server/fresh-agent/recovery-store.test.ts
+++ b/test/unit/server/fresh-agent/recovery-store.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import {
+  FreshAgentRecoveryStore,
+  getFreshAgentRecoveryStore,
+  resetFreshAgentRecoveryStoreForTests,
+} from '../../../../server/fresh-agent/recovery-store.js'
+
+describe('FreshAgentRecoveryStore', () => {
+  let filePath: string
+  beforeEach(async () => {
+    filePath = path.join(await mkdtemp(path.join(tmpdir(), 'recovery-')), 'recovery.json')
+  })
+
+  it('persists interrupt intent across store instances (simulated restart)', async () => {
+    const store = new FreshAgentRecoveryStore({ filePath })
+    await store.recordInterrupt('ses_1')
+    const reborn = new FreshAgentRecoveryStore({ filePath })
+    expect(await reborn.hasInterrupt('ses_1')).toBe(true)
+    await reborn.clearInterrupt('ses_1')
+    expect(await new FreshAgentRecoveryStore({ filePath }).hasInterrupt('ses_1')).toBe(false)
+  })
+
+  it('records at most one recovery per (session, message) and persists it', async () => {
+    const store = new FreshAgentRecoveryStore({ filePath })
+    expect(await store.hasRecovery('ses_1', 'm2')).toBe(false)
+    await store.recordRecovery('ses_1', 'm2')
+    expect(await store.hasRecovery('ses_1', 'm2')).toBe(true)
+    expect(await new FreshAgentRecoveryStore({ filePath }).hasRecovery('ses_1', 'm2')).toBe(true)
+  })
+
+  it('starts empty on a corrupt file instead of throwing', async () => {
+    await writeFile(filePath, '{not json', 'utf8')
+    const store = new FreshAgentRecoveryStore({ filePath })
+    expect(await store.hasInterrupt('ses_1')).toBe(false)
+    await store.recordInterrupt('ses_1') // and can still write
+    expect(JSON.parse(await readFile(filePath, 'utf8')).version).toBe(1)
+  })
+
+  it('starts empty when the file is missing', async () => {
+    const store = new FreshAgentRecoveryStore({ filePath })
+    expect(await store.hasInterrupt('ses_1')).toBe(false)
+    expect(await store.hasRecovery('ses_1', 'm1')).toBe(false)
+  })
+
+  it('caps interrupts at the 100 most recent entries (drops oldest on insert)', async () => {
+    const store = new FreshAgentRecoveryStore({ filePath })
+    for (let i = 0; i < 101; i++) {
+      await store.recordInterrupt(`ses_${i}`)
+    }
+    const persisted = JSON.parse(await readFile(filePath, 'utf8'))
+    expect(Object.keys(persisted.interrupts)).toHaveLength(100)
+    expect(persisted.interrupts.ses_0).toBeUndefined()
+    expect(persisted.interrupts.ses_100).toBeTypeOf('number')
+    expect(await store.hasInterrupt('ses_0')).toBe(false)
+    expect(await store.hasInterrupt('ses_100')).toBe(true)
+  })
+
+  it('caps per-session recoveries at the 100 most recent entries (drops oldest on insert)', async () => {
+    const store = new FreshAgentRecoveryStore({ filePath })
+    for (let i = 0; i < 101; i++) {
+      await store.recordRecovery('ses_1', `m_${i}`)
+    }
+    await store.recordRecovery('ses_2', 'm_only')
+    const persisted = JSON.parse(await readFile(filePath, 'utf8'))
+    expect(Object.keys(persisted.recoveries.ses_1)).toHaveLength(100)
+    expect(persisted.recoveries.ses_1.m_0).toBeUndefined()
+    expect(persisted.recoveries.ses_1.m_100).toBeTypeOf('number')
+    // Other sessions are untouched by ses_1's cap.
+    expect(await store.hasRecovery('ses_2', 'm_only')).toBe(true)
+    expect(await store.hasRecovery('ses_1', 'm_0')).toBe(false)
+    expect(await store.hasRecovery('ses_1', 'm_100')).toBe(true)
+  })
+
+  it('does not lose updates from interleaved concurrent mutators', async () => {
+    const store = new FreshAgentRecoveryStore({ filePath })
+    await Promise.all([
+      ...Array.from({ length: 10 }, (_, i) => store.recordInterrupt(`ses_${i}`)),
+      ...Array.from({ length: 10 }, (_, i) => store.recordRecovery('ses_x', `m_${i}`)),
+    ])
+    const reborn = new FreshAgentRecoveryStore({ filePath })
+    for (let i = 0; i < 10; i++) {
+      expect(await reborn.hasInterrupt(`ses_${i}`)).toBe(true)
+      expect(await reborn.hasRecovery('ses_x', `m_${i}`)).toBe(true)
+    }
+  })
+
+  it('clearInterrupt persists removal and is a no-op for unknown sessions', async () => {
+    const store = new FreshAgentRecoveryStore({ filePath })
+    await store.clearInterrupt('never_recorded') // must not throw
+    await store.recordInterrupt('ses_1')
+    await store.clearInterrupt('ses_1')
+    expect(await store.hasInterrupt('ses_1')).toBe(false)
+    expect(await new FreshAgentRecoveryStore({ filePath }).hasInterrupt('ses_1')).toBe(false)
+  })
+
+  describe('singleton', () => {
+    beforeEach(() => {
+      resetFreshAgentRecoveryStoreForTests()
+    })
+
+    it('getFreshAgentRecoveryStore returns the same lazy instance', () => {
+      const a = getFreshAgentRecoveryStore()
+      const b = getFreshAgentRecoveryStore()
+      expect(a).toBeInstanceOf(FreshAgentRecoveryStore)
+      expect(b).toBe(a)
+    })
+
+    it('resetFreshAgentRecoveryStoreForTests(filePath) pins the singleton to a test file', async () => {
+      resetFreshAgentRecoveryStoreForTests(filePath)
+      const store = getFreshAgentRecoveryStore()
+      await store.recordInterrupt('ses_1')
+      expect(JSON.parse(await readFile(filePath, 'utf8')).interrupts.ses_1).toBeTypeOf('number')
+      resetFreshAgentRecoveryStoreForTests()
+      expect(getFreshAgentRecoveryStore()).not.toBe(store)
+    })
+  })
+})

--- a/test/unit/server/fresh-agent/router.test.ts
+++ b/test/unit/server/fresh-agent/router.test.ts
@@ -14,7 +14,11 @@ vi.mock('../../../../server/fresh-agent/observability.js', async (importOriginal
 import { createCodexFreshAgentAdapter } from '../../../../server/fresh-agent/adapters/codex/adapter.js'
 import { FreshAgentProviderRegistry } from '../../../../server/fresh-agent/provider-registry.js'
 import { createFreshAgentRouter } from '../../../../server/fresh-agent/router.js'
-import { FreshAgentRuntimeManager, FreshAgentStaleThreadRevisionError } from '../../../../server/fresh-agent/runtime-manager.js'
+import {
+  FreshAgentLostSessionError,
+  FreshAgentRuntimeManager,
+  FreshAgentStaleThreadRevisionError,
+} from '../../../../server/fresh-agent/runtime-manager.js'
 
 function makeCodexThread(id: string, turns: unknown[] = []) {
   return {
@@ -332,5 +336,55 @@ describe('fresh-agent router: snapshot served observability', () => {
     expect(events).toHaveLength(1)
     expect(events[0].cwdHash).toBeDefined()
     expect(JSON.stringify(events[0])).not.toContain('/repo/work')
+  })
+
+  it('threads the trigger query param into fresh_agent_snapshot_served', async () => {
+    observabilityMocks.recordFreshAgentObservabilityEvent.mockClear()
+    const manager = {
+      getSnapshot: vi.fn().mockResolvedValue({
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        threadId: 'ses_1',
+        revision: 1,
+        status: 'idle',
+        turns: [],
+      }),
+    } as unknown as FreshAgentRuntimeManager
+
+    const app = express()
+    app.use('/api', createFreshAgentRouter({ runtimeManager: manager }))
+
+    await request(app).get('/api/fresh-agent/threads/freshopencode/opencode/ses_1?trigger=poll').expect(200)
+
+    expect(observabilityMocks.recordFreshAgentObservabilityEvent).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'fresh_agent_snapshot_served', trigger: 'poll',
+    }))
+  })
+
+  it('emits fresh_agent_snapshot_failed with the mapped status on errors', async () => {
+    observabilityMocks.recordFreshAgentObservabilityEvent.mockClear()
+    const manager = {
+      getSnapshot: vi.fn().mockRejectedValue(new FreshAgentLostSessionError('gone')),
+    } as unknown as FreshAgentRuntimeManager
+
+    const app = express()
+    app.use('/api', createFreshAgentRouter({ runtimeManager: manager }))
+
+    await request(app).get('/api/fresh-agent/threads/freshopencode/opencode/ses_gone?trigger=event').expect(404)
+
+    expect(observabilityMocks.recordFreshAgentObservabilityEvent).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'fresh_agent_snapshot_failed',
+      httpStatus: 404,
+      trigger: 'event',
+      code: 'FRESH_AGENT_LOST_SESSION',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      durationMs: expect.any(Number),
+    }))
+    const failed = observabilityMocks.recordFreshAgentObservabilityEvent.mock.calls
+      .map(([event]) => event as Record<string, unknown>)
+      .find((event) => event.kind === 'fresh_agent_snapshot_failed')
+    expect(failed).toBeDefined()
+    expect(JSON.stringify(failed)).not.toContain('ses_gone')
   })
 })

--- a/test/unit/server/fresh-agent/runtime-manager.test.ts
+++ b/test/unit/server/fresh-agent/runtime-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { FreshAgentRuntimeManager } from '../../../../server/fresh-agent/runtime-manager.js'
 import { createFreshAgentProviderRegistry } from '../../../../server/fresh-agent/provider-registry.js'
+import { hashForLogs } from '../../../../server/fresh-agent/observability.js'
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void
@@ -885,5 +886,70 @@ describe('FreshAgentRuntimeManager', () => {
       threadId: 'codex-session-1',
     })).rejects.toThrow('uses codex, not claude')
     expect(codexAdapter.getSnapshot).not.toHaveBeenCalled()
+  })
+
+  describe('inspectState: read-only incident summary (zrrj)', () => {
+    it('reports hashed, content-free tracked sessions and pending recovery count', async () => {
+      const opencodeAdapter = {
+        create: vi.fn().mockResolvedValue({ sessionId: 'ses_real_1' }),
+      }
+      const registry = createFreshAgentProviderRegistry([
+        {
+          sessionType: 'freshopencode',
+          runtimeProvider: 'opencode',
+          adapter: opencodeAdapter as any,
+        },
+      ])
+      const manager = new FreshAgentRuntimeManager({ registry })
+      await manager.create({
+        requestId: 'req-1',
+        sessionType: 'freshopencode',
+        cwd: '/w',
+      })
+
+      const state = manager.inspectState()
+
+      expect(state).toEqual({
+        sessions: [{
+          key: `freshopencode:opencode:${hashForLogs('ses_real_1')}`,
+          sessionType: 'freshopencode',
+          provider: 'opencode',
+          sessionIdHash: hashForLogs('ses_real_1'),
+          cwdHash: hashForLogs('/w'),
+        }],
+        pendingRecoveries: 0,
+      })
+      // Content-free: neither the raw ses_ id nor the raw cwd may appear anywhere,
+      // including inside the session key.
+      const json = JSON.stringify(state)
+      expect(json).not.toContain('ses_')
+      expect(json).not.toContain('/w')
+    })
+
+    it('flags provider-owned no-route durable sessions as providerOwned', async () => {
+      const opencodeAdapter = {
+        create: vi.fn().mockResolvedValue({ sessionId: 'ses_real_2' }),
+      }
+      const registry = createFreshAgentProviderRegistry([
+        {
+          sessionType: 'freshopencode',
+          runtimeProvider: 'opencode',
+          adapter: opencodeAdapter as any,
+        },
+      ])
+      const manager = new FreshAgentRuntimeManager({ registry })
+      await manager.create({
+        requestId: 'req-2',
+        sessionType: 'freshopencode',
+      })
+
+      const state = manager.inspectState()
+
+      expect(state.sessions).toEqual([expect.objectContaining({
+        sessionIdHash: hashForLogs('ses_real_2'),
+        providerOwned: true,
+      })])
+      expect(state.sessions[0]).not.toHaveProperty('cwdHash')
+    })
   })
 })

--- a/test/unit/server/rate-limit.test.ts
+++ b/test/unit/server/rate-limit.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import {
+  createApiRateLimiter,
+  API_RATE_LIMIT_WINDOW_MS,
+  API_RATE_LIMIT_MAX,
+} from '../../../server/rate-limit.js'
+
+function makeApp(limiter = createApiRateLimiter({ windowMs: 60_000, max: 2 })) {
+  const app = express()
+  app.use('/api', limiter)
+  app.get('/api/ping', (_req, res) => {
+    res.json({ ok: true })
+  })
+  return app
+}
+
+describe('createApiRateLimiter', () => {
+  it('defaults to the production budget of 300 per 60s', async () => {
+    // Guard against accidental weakening: the constants must be the production budget...
+    expect(API_RATE_LIMIT_WINDOW_MS).toBe(60_000)
+    expect(API_RATE_LIMIT_MAX).toBe(300)
+    // ...and the factory must actually USE them as its defaults. express-rate-limit
+    // v7 does not expose options on the middleware, so verify behaviorally: a
+    // default limiter must allow request 300 and reject request 301 within one
+    // window. A weakened default (higher max / shorter window) fails this test.
+    const app = makeApp(createApiRateLimiter())
+    const agent = request(app)
+    for (let i = 0; i < API_RATE_LIMIT_MAX; i++) {
+      await agent.get('/api/ping').expect(200)
+    }
+    await agent.get('/api/ping').expect(429)
+  })
+
+  it('returns a JSON 429 with code RATE_LIMITED and retryAfterSeconds, plus Retry-After header', async () => {
+    const app = makeApp()
+    await request(app).get('/api/ping').expect(200)
+    await request(app).get('/api/ping').expect(200)
+    const res = await request(app).get('/api/ping').expect(429)
+    expect(res.headers['retry-after']).toMatch(/^\d+$/)
+    expect(res.body).toMatchObject({ error: 'Too many requests', code: 'RATE_LIMITED' })
+    expect(res.body.retryAfterSeconds).toBe(Number(res.headers['retry-after']))
+    expect(res.type).toMatch(/json/)
+  })
+})

--- a/test/unit/server/ws-handler-backpressure.test.ts
+++ b/test/unit/server/ws-handler-backpressure.test.ts
@@ -1,6 +1,5 @@
 // @vitest-environment node
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
-import { EventEmitter } from 'events'
 import http from 'http'
 import WebSocket from 'ws'
 import { WsHandler } from '../../../server/ws-handler'
@@ -11,6 +10,7 @@ import {
   TERMINAL_STREAM_ATTACH_REQUEST_ID_RESERVE_VALUE,
 } from '../../../server/terminal-stream/serialized-budget'
 import { MAX_REALTIME_MESSAGE_BYTES } from '../../../shared/read-models.js'
+import { createMockWs, FakeBrokerRegistry, structuredLogsFrom } from '../../helpers/ws-backpressure'
 
 const loggerMocks = vi.hoisted(() => {
   const logger = {
@@ -39,70 +39,10 @@ vi.mock('node-pty', () => ({
 
 const TEST_AUTH_TOKEN = 'testtoken-testtoken'
 
-/** Create a mock WebSocket that extends EventEmitter (like real ws WebSockets) */
-function createMockWs(overrides: Record<string, unknown> = {}) {
-  const ws = new EventEmitter() as EventEmitter & {
-    bufferedAmount: number
-    readyState: number
-    send: ReturnType<typeof vi.fn>
-    close: ReturnType<typeof vi.fn>
-    connectionId?: string
-    sessionUpdateGeneration?: number
-  }
-  ws.bufferedAmount = 0
-  ws.readyState = WebSocket.OPEN
-  ws.send = vi.fn()
-  ws.close = vi.fn()
-  Object.assign(ws, overrides)
-  return ws
-}
-
-function structuredLogs(level: 'debug' | 'info' | 'warn' | 'error', event: string) {
-  return loggerMocks.logger[level].mock.calls
-    .map(([payload]) => payload)
-    .filter((payload): payload is Record<string, unknown> => (
-      !!payload
-      && typeof payload === 'object'
-      && (payload as { event?: unknown }).event === event
-    ))
-}
-
-class FakeBrokerRegistry extends EventEmitter {
-  private records = new Map<string, { terminalId: string; mode: string; buffer: { snapshot: () => string } }>()
-  private replayRingMaxChars: number | undefined
-
-  createTerminal(terminalId: string, mode = 'shell') {
-    this.records.set(terminalId, {
-      terminalId,
-      mode,
-      buffer: { snapshot: () => '' },
-    })
-  }
-
-  attach(terminalId: string) {
-    return this.records.get(terminalId) ?? null
-  }
-
-  resize(_terminalId: string, _cols: number, _rows: number) {
-    return true
-  }
-
-  detach(_terminalId: string) {
-    return true
-  }
-
-  setReplayRingMaxBytes(next: number | undefined) {
-    this.replayRingMaxChars = next
-  }
-
-  getReplayRingMaxChars() {
-    return this.replayRingMaxChars
-  }
-
-  get(terminalId: string) {
-    return this.records.get(terminalId)
-  }
-}
+// createMockWs and FakeBrokerRegistry are shared with
+// ws-handler-fresh-agent-backpressure.test.ts via test/helpers/ws-backpressure.ts.
+const structuredLogs = (level: 'debug' | 'info' | 'warn' | 'error', event: string) =>
+  structuredLogsFrom(loggerMocks.logger, level, event)
 
 let originalAuthToken: string | undefined
 let originalTerminalClientQueueMaxBytes: string | undefined

--- a/test/unit/server/ws-handler-fresh-agent-backpressure.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent-backpressure.test.ts
@@ -1,0 +1,309 @@
+// @vitest-environment node
+// Terminal-stream <-> freshAgent backpressure coupling (kata zrrj, Tasks 19+20).
+//
+// Terminal output and freshAgent lifecycle events share one WebSocket with
+// asymmetric backpressure policy: WsHandler.send drops the message AND closes
+// the socket with 4008 when bufferedAmount > 2 MiB, while the broker's live
+// output path historically wrote with no foreground buffered-amount gate (its
+// own kill line is the 16 MiB/10 s catastrophic path). Task 20 adds a 1 MiB
+// foreground pause in the broker so terminal traffic alone can never inflate
+// bufferedAmount past the handler's kill line.
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import http from 'http'
+import WebSocket from 'ws'
+import { WsHandler } from '../../../server/ws-handler'
+import { TerminalRegistry } from '../../../server/terminal-registry'
+import { TerminalStreamBroker } from '../../../server/terminal-stream/broker'
+import {
+  createMockWs,
+  FakeBrokerRegistry,
+  structuredLogsFrom,
+  type MockWs,
+} from '../../helpers/ws-backpressure'
+
+const loggerMocks = vi.hoisted(() => {
+  const logger = {
+    child: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+  logger.child.mockReturnValue(logger)
+  return { logger }
+})
+
+vi.mock('../../../server/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/logger')>()
+  return {
+    ...actual,
+    logger: loggerMocks.logger,
+    sessionLifecycleLogger: loggerMocks.logger,
+    freshAgentObservabilityLogger: loggerMocks.logger,
+  }
+})
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(),
+}))
+
+const TEST_AUTH_TOKEN = 'testtoken-testtoken'
+const KILL_LINE_BYTES = 2 * 1024 * 1024
+
+const structuredLogs = (level: 'debug' | 'info' | 'warn' | 'error', event: string) =>
+  structuredLogsFrom(loggerMocks.logger, level, event)
+
+function sentPayloads(ws: MockWs): Record<string, unknown>[] {
+  return ws.send.mock.calls
+    .map(([raw]) => (typeof raw === 'string' ? JSON.parse(raw) : raw))
+    .filter((payload): payload is Record<string, unknown> => !!payload && typeof payload === 'object')
+}
+
+function sentTypes(ws: MockWs): unknown[] {
+  return sentPayloads(ws).map((payload) => payload.type)
+}
+
+function terminalOutputFrames(ws: MockWs): Record<string, unknown>[] {
+  return sentPayloads(ws).filter((payload) => payload.type === 'terminal.output')
+}
+
+async function flushMicrotasks(times = 6): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await Promise.resolve()
+  }
+}
+
+type CapturingRuntimeManager = {
+  manager: { subscribe: ReturnType<typeof vi.fn> }
+  listeners: Map<string, (event: unknown) => void>
+  off: ReturnType<typeof vi.fn>
+}
+
+function createCapturingRuntimeManager(): CapturingRuntimeManager {
+  const listeners = new Map<string, (event: unknown) => void>()
+  const off = vi.fn()
+  const manager = {
+    subscribe: vi.fn().mockImplementation(async (locator: unknown, listener: (event: unknown) => void) => {
+      listeners.set(JSON.stringify(locator), listener)
+      return off
+    }),
+  }
+  return { manager, listeners, off }
+}
+
+/** Just the ClientState fields the freshAgent subscription path touches. */
+function freshAgentClientStateStub() {
+  return {
+    freshAgentSubscriptions: new Map(),
+    freshAgentAuthorizations: new Map(),
+    pendingFreshAgentAttachByKey: new Map(),
+  }
+}
+
+const LOCATOR = { sessionId: 'ses_1', sessionType: 'freshclaude', provider: 'claude' }
+
+describe('terminal output vs freshAgent lifecycle on one socket (zrrj)', () => {
+  let originalAuthToken: string | undefined
+  let server: http.Server | undefined
+  let terminalRegistry: TerminalRegistry | undefined
+  let handler: WsHandler | undefined
+  let broker: TerminalStreamBroker | undefined
+
+  beforeEach(() => {
+    originalAuthToken = process.env.AUTH_TOKEN
+    process.env.AUTH_TOKEN = TEST_AUTH_TOKEN
+    loggerMocks.logger.debug.mockClear()
+    loggerMocks.logger.info.mockClear()
+    loggerMocks.logger.warn.mockClear()
+    loggerMocks.logger.error.mockClear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(async () => {
+    broker?.close()
+    broker = undefined
+    handler?.close()
+    handler = undefined
+    terminalRegistry?.shutdown()
+    terminalRegistry = undefined
+    if (server?.listening) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()))
+    }
+    server = undefined
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    if (originalAuthToken === undefined) {
+      delete process.env.AUTH_TOKEN
+    } else {
+      process.env.AUTH_TOKEN = originalAuthToken
+    }
+  })
+
+  async function createHandlerWithFreshAgentSubscription(ws: MockWs) {
+    const { manager, listeners, off } = createCapturingRuntimeManager()
+    server = http.createServer()
+    await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', () => resolve()))
+    terminalRegistry = new TerminalRegistry()
+    handler = new WsHandler(server, terminalRegistry, { freshAgentRuntimeManager: manager } as never)
+
+    const state = freshAgentClientStateStub()
+    ;(handler as any).ensureFreshAgentSubscription(ws, state, LOCATOR)
+    await flushMicrotasks()
+    const fireEvent = listeners.get(JSON.stringify(LOCATOR))
+    expect(fireEvent).toBeTypeOf('function')
+    return { state, off, fireEvent: fireEvent! }
+  }
+
+  it('delivers freshAgent.turn.complete while flooding terminal output (broker self-throttles below the kill line)', async () => {
+    // DESIRED behavior (RED until Task 20): the buffered pressure is PRODUCED
+    // BY THE BROKER (the thing Task 20 gates) - never seeded statically,
+    // because WsHandler.send keeps its 4008 close after the fix.
+    const ws = createMockWs()
+    // Accumulate-bytes idiom: the socket never drains.
+    ws.send.mockImplementation((frame: string) => {
+      ws.bufferedAmount += Buffer.byteLength(frame, 'utf8')
+    })
+
+    const { fireEvent } = await createHandlerWithFreshAgentSubscription(ws)
+
+    // Foreground attachment on an EMPTY terminal (no replay cursor - the
+    // replay path is already paced at 576 KiB and would make this vacuous).
+    const brokerRegistry = new FakeBrokerRegistry()
+    broker = new TerminalStreamBroker(brokerRegistry as any, vi.fn())
+    brokerRegistry.createTerminal('term-flood')
+    const attached = await broker.attach(
+      ws as any,
+      'term-flood',
+      'viewport_hydrate',
+      80,
+      24,
+      0,
+      'flood-attach',
+      undefined,
+      'foreground',
+    )
+    expect(attached).toBe('attached')
+
+    // Flood > 4 MiB of live output.
+    const chunk = 'x'.repeat(8 * 1024)
+    for (let i = 0; i < 640; i += 1) {
+      brokerRegistry.emit('terminal.output.raw', { terminalId: 'term-flood', data: chunk, at: Date.now() })
+    }
+    for (let i = 0; i < 900; i += 1) {
+      vi.runOnlyPendingTimers()
+    }
+
+    // RED today: broker live sends bypass any foreground buffered gate
+    // (safeSendPrepared passes no options), so bufferedAmount inflates to the
+    // full ~5 MiB flood - past the handler's 2 MiB kill line.
+    // GREEN after Task 20: the broker pauses at 1 MiB, so bufferedAmount stays
+    // below the kill line and lifecycle frames survive.
+    expect(ws.bufferedAmount).toBeLessThan(KILL_LINE_BYTES)
+
+    fireEvent({ type: 'freshAgent.turn.complete', sessionId: 'ses_1', at: Date.now() })
+    expect(sentTypes(ws)).toContain('freshAgent.event')
+    expect(ws.close).not.toHaveBeenCalledWith(4008, expect.anything())
+  })
+
+  it('EVIDENCE: retention_lost is log-only and emits zero WS frames in the current build', async () => {
+    const brokerRegistry = new FakeBrokerRegistry()
+    brokerRegistry.setReplayRingMaxBytes(1024)
+    broker = new TerminalStreamBroker(brokerRegistry as any, vi.fn())
+    brokerRegistry.createTerminal('term-retention')
+
+    const ws = createMockWs()
+    const attached = await broker.attach(ws as any, 'term-retention', 'viewport_hydrate', 80, 24, 0, 'retention-attach')
+    expect(attached).toBe('attached')
+
+    // Flood terminal.output.raw past the 1024-byte ring. Retention loss is
+    // handled synchronously inside the append path; no timers run here, so any
+    // WS frame observed below could only have come from retention itself.
+    const sendCallsBefore = ws.send.mock.calls.length
+    for (let i = 0; i < 8; i += 1) {
+      brokerRegistry.emit('terminal.output.raw', { terminalId: 'term-retention', data: 'y'.repeat(512), at: Date.now() })
+    }
+
+    const retentionLogs = structuredLogs('warn', 'terminal.replay.retention')
+    expect(retentionLogs.length).toBeGreaterThanOrEqual(1)
+    expect(retentionLogs[0]).toMatchObject({
+      terminalId: 'term-retention',
+      reason: 'retention_lost',
+    })
+    // Log-only: zero send-count delta from retention itself...
+    expect(ws.send.mock.calls.length - sendCallsBefore).toBe(0)
+
+    // ...and even after the queued output flushes normally, retention never
+    // produced a terminal.stream.changed frame (the pre-ff8589bb amplifier).
+    for (let i = 0; i < 50; i += 1) {
+      vi.runOnlyPendingTimers()
+    }
+    expect(sentTypes(ws)).not.toContain('terminal.stream.changed')
+    expect(ws.close).not.toHaveBeenCalled()
+  })
+
+  it('pauses a foreground live flush at 3 MiB bufferedAmount and retries on the 100 ms background-style timer', async () => {
+    // Task 20's flipped test 3. RED today: the broker flushes to a foreground
+    // attachment with NO bufferedAmount gate, so the frame is sent straight
+    // into a 3 MiB-deep socket. GREEN after Task 20: the flush pauses below
+    // the handler kill line and retries via the 100 ms background-pause
+    // mechanic (TERMINAL_BACKGROUND_RETRY_FLUSH_MS), NOT the generic 50 ms
+    // TERMINAL_STREAM_RETRY_FLUSH_MS.
+    const brokerRegistry = new FakeBrokerRegistry()
+    broker = new TerminalStreamBroker(brokerRegistry as any, vi.fn())
+    brokerRegistry.createTerminal('term-fg-pause')
+
+    const ws = createMockWs({ bufferedAmount: 3 * 1024 * 1024 })
+    const attached = await broker.attach(ws as any, 'term-fg-pause', 'viewport_hydrate', 80, 24, 0, 'fg-pause-attach', undefined, 'foreground')
+    expect(attached).toBe('attached')
+
+    brokerRegistry.emit('terminal.output.raw', { terminalId: 'term-fg-pause', data: 'fg-paused-output;', at: Date.now() })
+    // Run the immediate (0 ms) flush: it must pause, not send.
+    vi.runOnlyPendingTimers()
+    expect(terminalOutputFrames(ws)).toHaveLength(0)
+    expect(ws.close).not.toHaveBeenCalled()
+
+    // Drain the socket right away: any retry timer shorter than 100 ms would
+    // now flush early. 99 ms in, nothing may have been sent.
+    ws.bufferedAmount = 0
+    vi.advanceTimersByTime(99)
+    expect(terminalOutputFrames(ws)).toHaveLength(0)
+
+    // At exactly 100 ms the paused flush retries and delivers the output.
+    vi.advanceTimersByTime(1)
+    const outputs = terminalOutputFrames(ws)
+    expect(outputs.length).toBeGreaterThanOrEqual(1)
+    expect(outputs.map((payload) => String(payload.data)).join('')).toContain('fg-paused-output;')
+    expect(ws.close).not.toHaveBeenCalled()
+  })
+
+  it('EVIDENCE: after a 4008 backpressure close, freshAgent events are dropped with no replay', async () => {
+    const ws = createMockWs({ bufferedAmount: 3 * 1024 * 1024 })
+    // Real sockets leave OPEN once close() is initiated.
+    ws.close.mockImplementation(() => {
+      ws.readyState = WebSocket.CLOSED
+    })
+
+    const { state, off, fireEvent } = await createHandlerWithFreshAgentSubscription(ws)
+
+    // A freshAgent lifecycle event into a socket already past the 2 MiB kill
+    // line: WsHandler.send drops the frame AND closes the socket with 4008.
+    fireEvent({ type: 'freshAgent.turn.complete', sessionId: 'ses_1', at: Date.now() })
+    expect(ws.close).toHaveBeenCalledWith(4008, 'Backpressure')
+    expect(ws.send).not.toHaveBeenCalled()
+
+    // The connection-close path cancels every freshAgent subscription
+    // (WsHandler.onClose -> cancelAllFreshAgentSubscriptions) - nothing is
+    // queued or retained for the dead socket.
+    ;(handler as any).cancelAllFreshAgentSubscriptions(state)
+    expect(off).toHaveBeenCalledTimes(1)
+    expect(state.freshAgentSubscriptions.size).toBe(0)
+
+    // Later events are dropped outright: no backlog, no replay, no reconnect
+    // redelivery for this socket.
+    fireEvent({ type: 'freshAgent.turn.complete', sessionId: 'ses_1', at: Date.now() + 1 })
+    await flushMicrotasks()
+    expect(ws.send).not.toHaveBeenCalled()
+    expect(ws.close).toHaveBeenCalledTimes(1)
+    expect(sentTypes(ws)).not.toContain('freshAgent.event')
+  })
+})

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -9,6 +9,16 @@ vi.mock('../../../server/config-store.js', () => ({
   },
 }))
 
+const observabilityMocks = vi.hoisted(() => ({
+  recordFreshAgentObservabilityEvent: vi.fn(),
+}))
+
+vi.mock('../../../server/fresh-agent/observability.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/fresh-agent/observability.js')>()
+  return { ...actual, recordFreshAgentObservabilityEvent: observabilityMocks.recordFreshAgentObservabilityEvent }
+})
+
+import { hashForLogs } from '../../../server/fresh-agent/observability.js'
 import { WsHandler } from '../../../server/ws-handler.js'
 import { TerminalRegistry } from '../../../server/terminal-registry.js'
 import { FreshAgentLostSessionError } from '../../../server/fresh-agent/runtime-manager.js'
@@ -38,6 +48,7 @@ describe('WsHandler fresh-agent routing', () => {
     originalAuthToken = process.env.AUTH_TOKEN
     process.env.AUTH_TOKEN = TEST_AUTH_TOKEN
     vi.mocked(configStore.snapshot).mockResolvedValue(makeUserConfig(true))
+    observabilityMocks.recordFreshAgentObservabilityEvent.mockClear()
   })
 
   async function createServer(options: Record<string, unknown> = {}) {
@@ -1245,6 +1256,184 @@ describe('WsHandler fresh-agent routing', () => {
       })
       expect(runtimeManager.attach).not.toHaveBeenCalled()   // no server-side retry: cwd-bearing recovery already ran inside manager.send
       expect(runtimeManager.send).toHaveBeenCalledTimes(1)   // no blind retry loop
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('emits identity-hashed send and interrupt rows (zrrj)', async () => {
+    const observabilitySpy = observabilityMocks.recordFreshAgentObservabilityEvent
+    const runtimeManager = {
+      create: vi.fn().mockResolvedValue({ sessionId: 'ses_9', sessionType: 'freshopencode', runtimeProvider: 'opencode' }),
+      subscribe: vi.fn().mockReturnValue(() => undefined),
+      send: vi.fn().mockResolvedValue({ submittedTurnId: 'display-user-1' }),
+      interrupt: vi.fn().mockResolvedValue(undefined),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+    try {
+      const ws = await connectAndAuth(server)
+      ws.send(JSON.stringify({ type: 'freshAgent.create', requestId: 'req-1', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+      await vi.waitFor(() => expect(runtimeManager.create).toHaveBeenCalled())
+
+      ws.send(JSON.stringify({
+        type: 'freshAgent.send', requestId: 'r1', sessionId: 'ses_9',
+        sessionType: 'freshopencode', provider: 'opencode', cwd: '/w', text: 'hello',
+      }))
+      await vi.waitFor(() => expect(runtimeManager.send).toHaveBeenCalled())
+      ws.send(JSON.stringify({
+        type: 'freshAgent.interrupt', sessionId: 'ses_9',
+        sessionType: 'freshopencode', provider: 'opencode', cwd: '/w',
+      }))
+
+      await vi.waitFor(() => {
+        expect(observabilitySpy).toHaveBeenCalledWith(expect.objectContaining({
+          kind: 'fresh_agent_send', sessionType: 'freshopencode', provider: 'opencode',
+          sessionIdHash: hashForLogs('ses_9'), cwdHash: hashForLogs('/w'),
+          requestId: 'r1', outcome: 'accepted', durationMs: expect.any(Number),
+        }))
+        expect(observabilitySpy).toHaveBeenCalledWith(expect.objectContaining({
+          kind: 'fresh_agent_interrupt', outcome: 'ok', sessionIdHash: hashForLogs('ses_9'),
+          sessionType: 'freshopencode', provider: 'opencode',
+        }))
+      })
+      // No raw ids or prompt text anywhere in the payloads:
+      for (const [payload] of observabilitySpy.mock.calls) {
+        expect(JSON.stringify(payload)).not.toContain('ses_9')
+        expect(JSON.stringify(payload)).not.toContain('hello')
+      }
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('emits a failed send row carrying the lost-session error code (zrrj)', async () => {
+    const observabilitySpy = observabilityMocks.recordFreshAgentObservabilityEvent
+    const runtimeManager = {
+      create: vi.fn().mockResolvedValue({ sessionId: 'ses_9', sessionType: 'freshopencode', runtimeProvider: 'opencode' }),
+      subscribe: vi.fn().mockReturnValue(() => undefined),
+      send: vi.fn().mockRejectedValue(new FreshAgentLostSessionError('Fresh-agent session freshopencode/opencode/ses_9 is not tracked')),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+    try {
+      const ws = await connectAndAuth(server)
+      ws.send(JSON.stringify({ type: 'freshAgent.create', requestId: 'req-1', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+      await vi.waitFor(() => expect(runtimeManager.create).toHaveBeenCalled())
+
+      ws.send(JSON.stringify({
+        type: 'freshAgent.send', requestId: 'r1', sessionId: 'ses_9',
+        sessionType: 'freshopencode', provider: 'opencode', cwd: '/w', text: 'hello',
+      }))
+
+      await vi.waitFor(() => {
+        expect(observabilitySpy).toHaveBeenCalledWith(expect.objectContaining({
+          kind: 'fresh_agent_send', outcome: 'failed', errorCode: 'FRESH_AGENT_LOST_SESSION',
+          sessionIdHash: hashForLogs('ses_9'), requestId: 'r1', durationMs: expect.any(Number),
+        }))
+      })
+      for (const [payload] of observabilitySpy.mock.calls) {
+        expect(JSON.stringify(payload)).not.toContain('ses_9')
+        expect(JSON.stringify(payload)).not.toContain('hello')
+      }
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('emits a fresh_agent_attach row on successful attach (zrrj)', async () => {
+    const observabilitySpy = observabilityMocks.recordFreshAgentObservabilityEvent
+    const runtimeManager = {
+      attach: vi.fn().mockResolvedValue({ sessionId: 'ses_att', sessionType: 'freshclaude', runtimeProvider: 'claude' }),
+      subscribe: vi.fn().mockResolvedValue(() => undefined),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+    try {
+      const ws = await connectAndAuth(server)
+      ws.send(JSON.stringify({
+        type: 'freshAgent.attach', sessionId: 'ses_att',
+        sessionType: 'freshclaude', provider: 'claude', cwd: '/repo/w',
+      }))
+      await vi.waitFor(() => {
+        expect(observabilitySpy).toHaveBeenCalledWith(expect.objectContaining({
+          kind: 'fresh_agent_attach', outcome: 'ok', sessionType: 'freshclaude', provider: 'claude',
+          sessionIdHash: hashForLogs('ses_att'), cwdHash: hashForLogs('/repo/w'),
+        }))
+      })
+      for (const [payload] of observabilitySpy.mock.calls) {
+        expect(JSON.stringify(payload)).not.toContain('ses_att')
+        expect(JSON.stringify(payload)).not.toContain('/repo/w')
+      }
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('emits a failed fresh_agent_attach row when the manager attach rejects (zrrj)', async () => {
+    const observabilitySpy = observabilityMocks.recordFreshAgentObservabilityEvent
+    const runtimeManager = {
+      attach: vi.fn().mockRejectedValue(new Error('sidecar unreachable')),
+      subscribe: vi.fn().mockResolvedValue(() => undefined),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+    try {
+      const ws = await connectAndAuth(server)
+      ws.send(JSON.stringify({
+        type: 'freshAgent.attach', sessionId: 'ses_att_fail',
+        sessionType: 'freshopencode', provider: 'opencode', cwd: '/repo/w',
+      }))
+      await vi.waitFor(() => {
+        expect(observabilitySpy).toHaveBeenCalledWith(expect.objectContaining({
+          kind: 'fresh_agent_attach', outcome: 'failed', errorCode: 'INTERNAL_ERROR',
+          sessionIdHash: hashForLogs('ses_att_fail'),
+        }))
+      })
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('emits a fresh_agent_materialized row at the materialization choke point (zrrj)', async () => {
+    const observabilitySpy = observabilityMocks.recordFreshAgentObservabilityEvent
+    const runtimeManager = {
+      create: vi.fn().mockResolvedValue({ sessionId: 'freshopencode-req-mat', sessionType: 'freshopencode', runtimeProvider: 'opencode' }),
+      subscribe: vi.fn().mockReturnValue(() => undefined),
+      send: vi.fn().mockResolvedValue({
+        sessionId: 'ses_mat_1',
+        sessionRef: { provider: 'opencode', sessionId: 'ses_mat_1' },
+      }),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+    try {
+      const ws = await connectAndAuth(server)
+      ws.send(JSON.stringify({ type: 'freshAgent.create', requestId: 'req-mat', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+      await vi.waitFor(() => expect(runtimeManager.create).toHaveBeenCalled())
+
+      ws.send(JSON.stringify({
+        type: 'freshAgent.send', requestId: 'r-mat', sessionId: 'freshopencode-req-mat',
+        sessionType: 'freshopencode', provider: 'opencode', cwd: '/w', text: 'hello',
+      }))
+
+      await vi.waitFor(() => {
+        expect(observabilitySpy).toHaveBeenCalledWith(expect.objectContaining({
+          kind: 'fresh_agent_materialized', sessionType: 'freshopencode', provider: 'opencode',
+          previousSessionIdHash: hashForLogs('freshopencode-req-mat'),
+          sessionIdHash: hashForLogs('ses_mat_1'),
+          cwdHash: hashForLogs('/w'),
+        }))
+      })
+      for (const [payload] of observabilitySpy.mock.calls) {
+        expect(JSON.stringify(payload)).not.toContain('ses_mat_1')
+        expect(JSON.stringify(payload)).not.toContain('hello')
+      }
     } finally {
       handler.close()
       registry.shutdown()

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -1143,4 +1143,42 @@ describe('WsHandler fresh-agent routing', () => {
       await new Promise<void>((resolve) => server.close(() => resolve()))
     }
   })
+
+  it('rebinds the freshAgent subscription when the adapter state generation changes (zrrj)', async () => {
+    let stateGeneration = 1
+    const listeners: Array<(ev: unknown) => void> = []
+    const off = vi.fn()
+    const runtimeManager = {
+      attach: vi.fn().mockResolvedValue({ sessionId: 'ses_9', sessionType: 'freshopencode', runtimeProvider: 'opencode' }),
+      subscribe: vi.fn((_locator: unknown, listener: (ev: unknown) => void) => {
+        listeners.push(listener)
+        return off
+      }),
+      sessionStateGeneration: vi.fn(() => stateGeneration),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+    try {
+      const ws = await connectAndAuth(server)
+      const seenMessages: any[] = []
+      ws.on('message', (data) => { seenMessages.push(JSON.parse(data.toString())) })
+
+      // First attach subscribes. No ack frame exists for attach — wait on the stub call.
+      ws.send(JSON.stringify({ type: 'freshAgent.attach', sessionId: 'ses_9', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+      await vi.waitFor(() => expect(runtimeManager.subscribe).toHaveBeenCalledTimes(1))
+
+      // Simulate adapter-state recreation: new generation, new emitter (a NEW listener registration is required)
+      stateGeneration = 2
+      ws.send(JSON.stringify({ type: 'freshAgent.attach', sessionId: 'ses_9', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+      await vi.waitFor(() => expect(runtimeManager.subscribe).toHaveBeenCalledTimes(2))
+      expect(off).toHaveBeenCalledTimes(1) // the stale subscription was cancelled before rebinding
+
+      // Events dispatched through the NEW listener reach the client as freshAgent.event frames
+      listeners.at(-1)!({ type: 'sdk.session.snapshot', sessionId: 'ses_9', status: 'running' })
+      await vi.waitFor(() => expect(seenMessages.some((m) => m.type === 'freshAgent.event')).toBe(true))
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
 })

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../../server/config-store.js', () => ({
 
 import { WsHandler } from '../../../server/ws-handler.js'
 import { TerminalRegistry } from '../../../server/terminal-registry.js'
+import { FreshAgentLostSessionError } from '../../../server/fresh-agent/runtime-manager.js'
 import { configStore } from '../../../server/config-store.js'
 import { createDefaultServerSettings } from '../../../shared/settings.js'
 import { WS_PROTOCOL_VERSION } from '../../../shared/ws-protocol.js'
@@ -1175,6 +1176,75 @@ describe('WsHandler fresh-agent routing', () => {
       // Events dispatched through the NEW listener reach the client as freshAgent.event frames
       listeners.at(-1)!({ type: 'sdk.session.snapshot', sessionId: 'ses_9', status: 'running' })
       await vi.waitFor(() => expect(seenMessages.some((m) => m.type === 'freshAgent.event')).toBe(true))
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('propagates FRESH_AGENT_LOST_SESSION (with requestId) when the manager reports lost-session', async () => {
+    const runtimeManager = {
+      create: vi.fn().mockResolvedValue({ sessionId: 'ses_9', sessionType: 'freshopencode', runtimeProvider: 'opencode' }),
+      subscribe: vi.fn().mockReturnValue(() => undefined),
+      send: vi.fn().mockRejectedValue(new FreshAgentLostSessionError('Fresh-agent session freshopencode/opencode/ses_9 is not tracked')),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+    try {
+      const ws = await connectAndAuth(server)
+      const seenMessages: any[] = []
+      ws.on('message', (data) => { seenMessages.push(JSON.parse(data.toString())) })
+
+      // Authorize ses_9 via create (the file's canonical idiom) — NOT via attach.
+      ws.send(JSON.stringify({ type: 'freshAgent.create', requestId: 'req-1', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+      await vi.waitFor(() => expect(runtimeManager.create).toHaveBeenCalled())
+
+      ws.send(JSON.stringify({
+        type: 'freshAgent.send', requestId: 'r1', sessionId: 'ses_9',
+        sessionType: 'freshopencode', provider: 'opencode', cwd: '/w', text: 'hello',
+      }))
+      await vi.waitFor(() => {
+        const err = seenMessages.find((m) => m.type === 'error' && m.requestId === 'r1')
+        expect(err).toBeTruthy()
+        expect(err.code).toBe('FRESH_AGENT_LOST_SESSION')
+      })
+      expect(runtimeManager.send).toHaveBeenCalledTimes(1)
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('does not attach-retry inside the handler even for a cwd-bearing durable locator (client owns recovery)', async () => {
+    const runtimeManager = {
+      create: vi.fn().mockResolvedValue({ sessionId: 'ses_9', sessionType: 'freshopencode', runtimeProvider: 'opencode' }),
+      subscribe: vi.fn().mockReturnValue(() => undefined),
+      send: vi.fn().mockRejectedValue(new FreshAgentLostSessionError('Fresh-agent session freshopencode/opencode/ses_9 is not tracked')),
+      attach: vi.fn(),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+    try {
+      const ws = await connectAndAuth(server)
+      const seenMessages: any[] = []
+      ws.on('message', (data) => { seenMessages.push(JSON.parse(data.toString())) })
+
+      // Authorization comes from create — the client never sends freshAgent.attach in this test,
+      // so the attach spy is a pure detector for a server-side attach-retry.
+      ws.send(JSON.stringify({ type: 'freshAgent.create', requestId: 'req-1', sessionType: 'freshopencode', provider: 'opencode', cwd: '/w' }))
+      await vi.waitFor(() => expect(runtimeManager.create).toHaveBeenCalled())
+
+      ws.send(JSON.stringify({
+        type: 'freshAgent.send', requestId: 'r1', sessionId: 'ses_9',
+        sessionType: 'freshopencode', provider: 'opencode', cwd: '/w', text: 'hello',
+      }))
+      await vi.waitFor(() => {
+        const err = seenMessages.find((m) => m.type === 'error' && m.requestId === 'r1')
+        expect(err).toBeTruthy()
+        expect(err.code).toBe('FRESH_AGENT_LOST_SESSION')
+      })
+      expect(runtimeManager.attach).not.toHaveBeenCalled()   // no server-side retry: cwd-bearing recovery already ran inside manager.send
+      expect(runtimeManager.send).toHaveBeenCalledTimes(1)   // no blind retry loop
     } finally {
       handler.close()
       registry.shutdown()


### PR DESCRIPTION
## Summary

Fixes kata issue zrrj (P0) — the canonical FreshOpenCode restart/snapshot-storm/interrupted-turn incident kata (supersedes atv6, n5hd, 7r0x, fzvs, xfwe, zz85, ckk7).

## Accomplishments

21 tasks implemented TDD-style across client and server:

**Client snapshot scheduler:** per snapshot-key scheduling (one in-flight per key, trailing coalesce), all refresh triggers routed through it, debounced transcript-change bursts, 429 Retry-After backoff with last-good-snapshot kept visible, send.accepted refreshes filtered to the owning pane, successful idle HTTP snapshot clears stale busy state, bounded client re-polling.

**Server restore/status reconciliation:** durable resume/attach reconciles live OpenCode status before assuming idle; exactly one monitored idle-recovery per durable session key; structured interruption/recovery signals on sidecar loss; serve subscriptions survive sidecar replacement via sidecar generation identity; materialized ses_... sends resend-once for lost sessions.

**Interrupted-turn recovery:** evidence-based detection from transcript/tool state (missing finish times, MessageAbortedError, running tool parts, etc.), durable recovery ledger with loop prevention, at most one Freshell-owned continuation, never after explicit user stop or user follow-up.

**Idle freshness:** missing-final-answer race fixed with a proven freshness contract.

**Observability:** always-on low-volume structured logs with session/provider identity, snapshot metadata, rate-limit metadata, sidecar generation binding, and a read-only incident debug endpoint.

**Terminal-stream backpressure:** pauses below the WebSocket kill threshold.

Full test suite green on the branch pre-rebase (client 4,251 / server 4,627 / electron 350; typecheck and lint clean).

## Honesty Notes

**1. Plan Review:** The implementation PLAN never received a clean independent review pass — it hit the 3-round review cap with blockers found and fixed each round, and the final plan revision was not re-reviewed. The compensating evidence is the clean independent review of the finished code (PASSED first round, zero blocking issues).

**2. Deployment Gap:** The live self-hosted deployment runs the Rust server, so the Node server-side fixes do not reach it until Rust parity (recorded as a fast-follow). The client-side fixes (the cause of the actual request-storm outage) apply to the live deployment immediately.

## Test Results

- Client: 4253 passed, 3 skipped
- Server: 4629 passed, 4 skipped
- Electron: 350 passed
- Total: 9232 tests in coordinated run post-rebase verification

Closes #zrrj