### PR TITLE
feat(scripts): add launch-rust.sh — canonical Rust server launcher; document in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,31 @@ Freshell is a self-hosted, browser-accessible terminal multiplexer and session o
   - **NEVER run `node dist/server/index.js` directly** — use `npm start` which sets `NODE_ENV=production`; without it the server prints the Vite port (5173) in the startup URL even though Vite isn't running
 - Example stop: `kill "$(cat /tmp/freshell-3344.pid)" && rm -f /tmp/freshell-3344.pid`
 - Before stopping any process, verify it belongs to the worktree (`ps -fp <pid>` and confirm cwd/path includes `.worktrees/...`).
-- **The self-hosted Freshell server must never be restarted without explicit user approval (the word "APPROVED").** Building is fine; deploying (stop + start) is not. The user's current Freshell session depends on it, and an unapproved restart will disconnect them mid-operation.
+- **The self-hosted Freshell server must never be restarted without explicit user approval (the word "APPROVED").** Building is fine; deploying (stop + start) is not. The user's current Freshell session depends on it, and an unapproved restart will disconnect them mid-operation. As of July 2026 the live self-hosted server is the RUST server on port 3002 (see below), not the Node server.
+
+## Rust Server (Self-Hosted Production)
+
+The production self-hosted Freshell is the Rust server (`target/release/freshell-server`, workspace crate `freshell-server`), running on **port 3002** from the main checkout. The Node server (`npm start`) still exists but is not what the user runs day-to-day.
+
+**Canonical launcher: `scripts/launch-rust.sh`** — use this instead of hand-rolled build/launch commands:
+
+```bash
+scripts/launch-rust.sh                 # build client + Rust server, start on port 3002
+scripts/launch-rust.sh --port 3499     # any other port (e.g. testing from a worktree)
+scripts/launch-rust.sh --client-only   # rebuild dist/client ONLY (no restart needed)
+scripts/launch-rust.sh --skip-build    # start without rebuilding
+scripts/launch-rust.sh --restart       # stop the pid-file-verified instance, then start
+scripts/launch-rust.sh --stop          # stop the pid-file-verified instance
+```
+
+Key facts:
+
+- **Client is served from disk.** The Rust server serves `dist/client` from the filesystem (SPA + fallback routing), so `--client-only` + a browser hard-refresh deploys client-side changes **without a server restart** (and therefore without needing "APPROVED"). Server-side (Rust) changes DO require a restart.
+- **Restarting the live 3002 server still requires the user's explicit "APPROVED"** — `--restart`/`--stop` exist for approved deploys and for scratch instances on other ports, not as a license to bounce production.
+- The script is safe by construction: it only ever kills PIDs from its own pid file, after verifying the process is this repo's `freshell-server` binary (cwd + args match); if the port is held by anything else it refuses. Logs go to `~/.freshell/logs/rust-server-<port>.log`, pid to `~/.freshell/rust-server-<port>.pid`.
+- The server loads `.env` from its cwd (env vars win over the file) and refuses to start without `AUTH_TOKEN`. Note `.env`'s `PORT` may differ from the live port — the launcher passes `PORT` explicitly.
+- The startup log line includes the commit the binary was built from: `freshell-server listening on http://0.0.0.0:<port> (ws://...) [commit <sha>]`. Use it (or `~/.freshell/logs/rust-server-3002.log`) to check what the running server was built from when asking "are we running change X?".
+- Health check: `curl http://127.0.0.1:<port>/api/health` (unauthenticated, rate-limit exempt).
 
 ## Codex Agent in CMD Instructions (Codex agents only; only when running in CMD on windows; all other agents must ignore)
 - Prefer bash/WSL over PowerShell; Windows paths map like `D:\\...` -> `/mnt/d/...`.

--- a/scripts/launch-rust.sh
+++ b/scripts/launch-rust.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Launch the Rust freshell server: build client + server, start in background.
+#
+# This is the canonical launcher for the self-hosted PRODUCTION Rust server
+# (default port 3002). See AGENTS.md "Rust Server (Self-Hosted Production)".
+#
+# Usage:
+#   scripts/launch-rust.sh                 # build client + server, start on port 3002
+#   scripts/launch-rust.sh --port 3499     # any other port (e.g. testing a branch)
+#   scripts/launch-rust.sh --client-only   # rebuild dist/client ONLY (no restart --
+#                                          #   the server serves it from disk; just
+#                                          #   hard-refresh the browser)
+#   scripts/launch-rust.sh --skip-build    # start without rebuilding
+#   scripts/launch-rust.sh --restart       # stop the pid-file-verified instance on
+#                                          #   this port first, then start
+#   scripts/launch-rust.sh --stop          # stop the pid-file-verified instance
+#
+# SAFETY (per AGENTS.md):
+#   * Restarting the LIVE self-hosted server (port 3002) requires explicit user
+#     approval ("APPROVED"). This script will never kill a process it did not
+#     start: it only stops PIDs recorded in its own pid file, and only after
+#     verifying the process is this repo's freshell-server binary.
+#   * If the port is held by an unknown process, it refuses and tells you.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FRESHELL_HOME="${FRESHELL_HOME:-$HOME/.freshell}"
+
+PORT="${PORT:-3002}"
+CLIENT_ONLY=0
+SKIP_BUILD=0
+RESTART=0
+STOP_ONLY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port) PORT="$2"; shift 2 ;;
+    --port=*) PORT="${1#*=}"; shift ;;
+    --client-only) CLIENT_ONLY=1; shift ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    --restart) RESTART=1; shift ;;
+    --stop) STOP_ONLY=1; shift ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown argument: $1 (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+PID_FILE="$FRESHELL_HOME/rust-server-$PORT.pid"
+LOG_FILE="$FRESHELL_HOME/logs/rust-server-$PORT.log"
+BINARY="$REPO_ROOT/target/release/freshell-server"
+
+cd "$REPO_ROOT"
+
+# --- helpers -----------------------------------------------------------------
+
+# True iff $1 is a live PID that is THIS repo's rust server (never match a
+# foreign process -- see AGENTS.md Process Safety).
+is_our_server_pid() {
+  local pid="$1" cwd="" args=""
+  kill -0 "$pid" 2>/dev/null || return 1
+  cwd="$(readlink "/proc/$pid/cwd" 2>/dev/null || true)"
+  args="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+  [[ "$cwd" == "$REPO_ROOT" && "$args" == *"target/release/freshell-server"* ]]
+}
+
+port_in_use() {
+  ss -tln 2>/dev/null | awk '{print $4}' | grep -qE "[:.]$PORT\$"
+}
+
+stop_ours() {
+  if [[ ! -f "$PID_FILE" ]]; then
+    echo "No pid file at $PID_FILE -- nothing to stop." >&2
+    return 1
+  fi
+  local pid
+  pid="$(cat "$PID_FILE")"
+  if is_our_server_pid "$pid"; then
+    echo "Stopping freshell-server pid $pid (port $PORT)..."
+    kill "$pid"
+    for _ in $(seq 1 20); do
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 0.25
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      echo "Process $pid did not exit after SIGTERM; NOT escalating automatically." >&2
+      return 1
+    fi
+    rm -f "$PID_FILE"
+  else
+    echo "Pid file $PID_FILE is stale (pid $pid is not this repo's server); removing." >&2
+    rm -f "$PID_FILE"
+    return 1
+  fi
+}
+
+# --- stop mode ---------------------------------------------------------------
+
+if [[ "$STOP_ONLY" == 1 ]]; then
+  stop_ours
+  exit $?
+fi
+
+# --- build -------------------------------------------------------------------
+
+if [[ "$SKIP_BUILD" != 1 ]]; then
+  echo "Building client (typecheck + vite)..."
+  npm run typecheck:client
+  npm run build:client
+  if [[ "$CLIENT_ONLY" == 1 ]]; then
+    echo ""
+    echo "Client rebuilt at dist/client. The running server serves it from disk --"
+    echo "hard-refresh the browser to pick it up. No server restart needed."
+    exit 0
+  fi
+  echo "Building Rust server (cargo build --release -p freshell-server)..."
+  cargo build --release -p freshell-server
+fi
+
+[[ -x "$BINARY" ]] || { echo "Missing binary: $BINARY (build first)" >&2; exit 1; }
+
+# --- preflight ---------------------------------------------------------------
+
+# AUTH_TOKEN must be available (env or .env in repo root; the server loads .env
+# from its cwd and refuses to start without a token).
+AUTH_TOKEN_VALUE="${AUTH_TOKEN:-$(grep -m1 '^AUTH_TOKEN=' .env 2>/dev/null | cut -d= -f2- || true)}"
+if [[ -z "$AUTH_TOKEN_VALUE" ]]; then
+  echo "AUTH_TOKEN not set (env or $REPO_ROOT/.env). The server will refuse to start." >&2
+  exit 1
+fi
+
+# Existing instance on this port?
+if [[ -f "$PID_FILE" ]]; then
+  saved_pid="$(cat "$PID_FILE")"
+  if is_our_server_pid "$saved_pid"; then
+    if [[ "$RESTART" == 1 ]]; then
+      stop_ours
+    else
+      echo "freshell-server already running on port $PORT (pid $saved_pid)."
+      echo "  URL: http://localhost:$PORT/?token=$AUTH_TOKEN_VALUE"
+      echo "  Use --restart to stop and relaunch it. NOTE: restarting the live"
+      echo "  self-hosted server (port 3002) requires explicit user approval."
+      exit 0
+    fi
+  else
+    rm -f "$PID_FILE"
+  fi
+fi
+
+if port_in_use; then
+  echo "Port $PORT is in use by a process this script did not start. Refusing." >&2
+  echo "(Never kill foreign processes -- see AGENTS.md Process Safety.)" >&2
+  exit 1
+fi
+
+# --- launch ------------------------------------------------------------------
+
+mkdir -p "$(dirname "$LOG_FILE")"
+echo "Starting freshell-server on port $PORT..."
+PORT="$PORT" nohup "$BINARY" >> "$LOG_FILE" 2>&1 &
+SERVER_PID=$!
+echo "$SERVER_PID" > "$PID_FILE"
+
+# Health check: /api/health is unauthenticated and rate-limit exempt.
+for _ in $(seq 1 60); do
+  if curl -fsS --max-time 2 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1; then
+    echo ""
+    echo "freshell-server is ready! (pid $SERVER_PID, port $PORT)"
+    # The listening line includes the commit the binary was built from.
+    grep -m1 "freshell-server listening" "$LOG_FILE" | tail -1 || true
+    echo "  URL: http://localhost:$PORT/?token=$AUTH_TOKEN_VALUE"
+    echo "  Log: $LOG_FILE"
+    echo "  Pid: $PID_FILE"
+    exit 0
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "Server exited during startup. Last log lines:" >&2
+    tail -20 "$LOG_FILE" >&2 || true
+    rm -f "$PID_FILE"
+    exit 1
+  fi
+  sleep 0.5
+done
+
+echo "Server started (pid $SERVER_PID) but /api/health not ready within 30s. Check $LOG_FILE" >&2
+exit 1


### PR DESCRIPTION
## Summary

Adds `scripts/launch-rust.sh` — a canonical, safe launcher for the Rust production server. The script builds the client + Rust server, starts on a configurable port (default 3002), and manages pid files + logs. Includes the script plus AGENTS.md documentation of the production deployment model.

## What's New

### scripts/launch-rust.sh

A production-grade launcher that:
- Builds client (`npm run build:client`) and Rust server (`cargo build --release -p freshell-server`)
- Starts in the background on a configurable port (default 3002) with nohup
- Manages pid file and log under `~/.freshell/logs/` and `~/.freshell/` 
- Verifies readiness via `/api/health` (unauthenticated, rate-limit exempt)
- Prints the startup URL and the commit the binary was built from
- Supports safety flags: `--client-only`, `--skip-build`, `--restart`, `--stop`, `--port <N>`

**Safety by construction:**
- Only kills processes via a pid file (no broad kill patterns)
- Verifies ownership: process must have cwd + args matching this repo's `freshell-server` binary
- Refuses to start if the target port is held by anything else
- Non-root: no elevated privileges needed

### AGENTS.md: New "Rust Server (Self-Hosted Production)" Section

Documents:
- The production server is the Rust binary (`freshell-server` crate) on port 3002
- The client is served from disk (`dist/client`), allowing client-only deploys without restart
- `--client-only` flag enables hot-deploy of client changes without "APPROVED"
- Server changes DO require "APPROVED" (per the existing Process Safety rule)
- The script is the canonical launcher — no hand-rolled build/launch commands
- Full command reference: `--port`, `--client-only`, `--skip-build`, `--restart`, `--stop`
- Health check: `curl http://127.0.0.1:<port>/api/health`
- Startup log line includes commit SHA for verifying what's running

## Validation

- End-to-end tested on scratch port 3499:
  - Build succeeds (client + server)
  - Launch succeeds
  - Health check passes
  - `--stop` cleanly terminates the process

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
