### PR TITLE
test(e2e): freshclaude pin follow-ups from PR #562 council review (non-vacuity guard, leaf re-fetch)

### DIFF
--- a/test/e2e-browser/specs/freshclaude-identity-persistence-rust.spec.ts
+++ b/test/e2e-browser/specs/freshclaude-identity-persistence-rust.spec.ts
@@ -380,9 +380,24 @@ test.describe('Freshclaude identity persistence (P0.2)', () => {
       // create-firing code a settle window BEFORE snapshotting sent
       // messages, so this "never fires" assertion can't pass merely because
       // we checked too early for a delayed create to have gone out yet.
+      // FORWARD-LOOKING HAZARD (follow-up from the PR #562 council review):
+      // this settle window is a fixed 1s. If freshell-ws auto-resume
+      // supervision ever extends to fresh-agent drivers (today it only
+      // covers terminal panes), a respawn create arriving with a backoff
+      // longer than 1s would land AFTER this snapshot and be invisible to
+      // the assertion below -- silently defeating this hazard guard. Any PR
+      // extending auto-resume supervision to fresh-agent drivers must widen
+      // this window (or poll) accordingly.
       await page.waitForTimeout(1_000)
+      // Re-fetch the leaf AFTER the settle window: the `leaf` captured above
+      // (before the settle) only proves the initial dead_session
+      // adjudication fired -- it is a stale snapshot with respect to any
+      // create that might land during the settle window, so asserting on it
+      // here would not actually prove "never silent" (follow-up from the PR
+      // #562 council review).
+      const leafAfterSettle = findFreshAgentLeaf(await harness.getPaneLayout(tabIdAfter!))
       // NEVER silent: identity not swapped, no create fired for this pane.
-      expect(leaf?.content?.sessionRef?.sessionId).toBe(DURABLE_CLI_SESSION_ID)
+      expect(leafAfterSettle?.content?.sessionRef?.sessionId).toBe(DURABLE_CLI_SESSION_ID)
       const sent = await harness.getSentWsMessages()
       expect(sent.filter((m: any) => m?.type === 'freshAgent.create')).toEqual([])
     } finally {

--- a/test/e2e-browser/specs/restore-contract-wall-rust.spec.ts
+++ b/test/e2e-browser/specs/restore-contract-wall-rust.spec.ts
@@ -1275,7 +1275,19 @@ test.describe('Restore Contract Wall (P0.1)', () => {
       // Any freshAgent.create fired across the restart+reload window must
       // carry the ORIGINAL durable id -- never a bare (resume-less) create,
       // which the fixture would otherwise re-stamp with the same static
-      // default and mask a lost identity.
+      // default and mask a lost identity. Non-vacuity checked (follow-up
+      // from the PR #562 council review): unlike
+      // specs/freshclaude-identity-persistence-rust.spec.ts's test 1, which
+      // RELOADS BEFORE the SIGKILL restart and observes exactly one RESPAWN
+      // freshAgent.create, THIS leg's ordering -- SIGKILL restart THEN
+      // reload -- resolves via freshAgent.attach alone; verified empirically
+      // (message list: hello, terminal.attach x3, ..., freshAgent.attach --
+      // zero freshAgent.create). So no non-vacuity assertion is added here:
+      // one would assert a create that never happens on this ordering and
+      // permanently red this leg. The for-loop below stays as the safety
+      // net against any future regression that starts firing a bare
+      // (identity-losing) create on this path, without falsely claiming a
+      // create is expected today.
       const sentAfterRestartReload = await harness.getSentWsMessages()
       const restartCreates = sentAfterRestartReload.filter((m: any) => m?.type === 'freshAgent.create') as any[]
       for (const create of restartCreates) {


### PR DESCRIPTION
## Summary

Tracked post-merge follow-ups from the `freshclaude-identity-persistence` (PR #562) council review round.

### 1. `restore-contract-wall-rust.spec.ts` — freshclaude wall leg create audit

Investigated whether the restart+reload create audit needed a non-vacuity guard mirroring test 1 of `freshclaude-identity-persistence-rust.spec.ts` (which asserts `creates.length > 0`).

I added the `toBeGreaterThan(0)` assertion first and it **failed** — not a flake, a real finding: this leg's ordering (SIGKILL restart **then** reload) resolves entirely via `freshAgent.attach` — zero `freshAgent.create` messages on the wire. This differs from test 1's ordering (reload **then** restart), which does fire exactly one RESPAWN create. Since asserting `>0` here would be asserting something that doesn't happen on this path, I did not add the guard — instead the comment now documents the empirical difference between the two orderings, and the existing per-create identity check remains as a regression safety net (if this path ever starts firing a bare create, it still gets checked).

### 2. `freshclaude-identity-persistence-rust.spec.ts` — HAZARD GUARD leaf staleness

The leaf used for the "identity not swapped" assertion was captured **before** the 1s settle window, so the assertion was checking a stale snapshot rather than proving nothing changed during the window the settle exists to cover. Re-fetch the leaf **after** the settle timeout before asserting.

Also added a forward-looking comment: if freshell-ws auto-resume supervision is ever extended to fresh-agent drivers (today it's terminal-only), a respawn create with backoff >1s would land after this fixed settle window and silently defeat the zero-creates assertion — flagging it now so that future extension PR trips over the comment.

## Testing

```
npx playwright test --config test/e2e-browser/playwright.config.ts \
  freshclaude-identity-persistence-rust.spec.ts restore-contract-wall-rust.spec.ts \
  --project=rust-chromium
```
17/17 passed.

Pre-approved by repo owner for PR creation/merge as a council follow-up.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>