### PR TITLE
test(e2e): freshclaude liveness proofs + honest pin reasons (council follow-ups, kata nmwx)

### DIFF
--- a/test/e2e-browser/fixtures/fake-claude-sidecar.mjs
+++ b/test/e2e-browser/fixtures/fake-claude-sidecar.mjs
@@ -26,11 +26,20 @@ import readline from 'node:readline'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
+import { randomUUID } from 'node:crypto'
 
 const HOLD_TURN = process.env.FAKE_CLAUDE_SIDECAR_HOLD_TURN === '1'
 const HOLD_ONCE_MARKER = process.env.FAKE_CLAUDE_SIDECAR_HOLD_TURN_ONCE_MARKER
-const CLI_SESSION_ID =
-  process.env.FAKE_CLAUDE_SIDECAR_CLI_SESSION_ID ?? '44444444-4444-4444-8444-444444444444'
+// RANDOM canonical UUID per sidecar PROCESS (council follow-up, PR #562/#563
+// close-out): the old static 44444444-... default made every resume-less
+// create in every sidecar process mint the SAME id, so a regression that
+// silently lost the durable identity across a restart would be re-stamped
+// with the identical constant and collide onto the same transcript file --
+// structurally collision-blind. With a per-process random default, any
+// identity-losing bare create after a restart (new sidecar process) mints a
+// DIFFERENT id and the identity assertions in the specs go red. The env
+// override remains for specs that need a caller-chosen id.
+const CLI_SESSION_ID = process.env.FAKE_CLAUDE_SIDECAR_CLI_SESSION_ID ?? randomUUID()
 const REQUEST_LOG = process.env.FAKE_CLAUDE_SIDECAR_LOG
 
 // sessionId (bridge nanoid) -> { cliSessionId (durable uuid), cwd }

--- a/test/e2e-browser/specs/freshclaude-identity-persistence-rust.spec.ts
+++ b/test/e2e-browser/specs/freshclaude-identity-persistence-rust.spec.ts
@@ -37,13 +37,28 @@ const __dirname = path.dirname(__filename)
 
 const FAKE_CLAUDE_SIDECAR_SOURCE = path.resolve(__dirname, '../fixtures/fake-claude-sidecar.mjs')
 
-const DURABLE_CLI_SESSION_ID = '44444444-4444-4444-8444-444444444444'
+// Canonical claude session id shape (copy of shared/session-contract.ts's
+// CLAUDE_SESSION_ID_RE -- per-spec-ownership convention). The fake sidecar
+// mints a RANDOM canonical UUID per process (council follow-up, PR #562/#563
+// close-out: the old static 44444444-... default made every resume-less
+// create in every sidecar process collide onto one constant id --
+// collision-blind to identity loss), so this spec CAPTURES the id the run
+// actually minted instead of asserting a constant.
+const CANONICAL_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
-// The contract-correct identity reader: sessionRef IS the durable identity;
-// content.sessionId is a live handle (precedent:
-// freshclaude-restart-parity-rust.spec.ts:140-148).
+// The contract-correct identity reader -- UNIFIED order with the wall's
+// leafDurableIdentity (council follow-up, PR #562/#563 close-out: the P0.2
+// bug WAS a reader-ordering bug, so this suite keeps ONE ordering):
+// sessionRef IS the durable identity per the 2026-04-19 durable-session
+// contract; resumeSessionId is the durable-intent fallback;
+// content.sessionId is a LIVE handle (for claude, the create-time fc-e2e-*
+// placeholder forever) and may only be read LAST.
 const durableIdentity = (leaf: any): string =>
-  leaf?.content?.sessionRef?.sessionId ?? leaf?.content?.resumeSessionId ?? ''
+  leaf?.content?.sessionRef?.sessionId ??
+  leaf?.content?.resumeSessionId ??
+  leaf?.content?.sessionId ??
+  ''
 
 // ---------------------------------------------------------------------------
 // Shared helpers (per-spec copies -- donor: restore-contract-wall-rust.spec.ts)
@@ -241,10 +256,12 @@ test.describe('Freshclaude identity persistence (P0.2)', () => {
       // the durable ref. Captured (not
       // hardcoded) so the round-trip checks below assert against what this
       // RUN actually minted -- same discipline as freshclaude-restart-parity
-      // -rust.spec.ts's `originalDurable` capture (:236-243).
+      // -rust.spec.ts's `originalDurable` capture (:236-243). The fixture id
+      // is random per sidecar process now, so the gate is the canonical-UUID
+      // SHAPE (which the fc-e2e-* live placeholder can never match).
       await expect
         .poll(async () => durableIdentity(findFreshAgentLeaf(await harness.getPaneLayout(tabId!))), { timeout: 15_000 })
-        .toBe(DURABLE_CLI_SESSION_ID)
+        .toMatch(CANONICAL_UUID_RE)
       const originalDurable: string = durableIdentity(findFreshAgentLeaf(await harness.getPaneLayout(tabId!)))
 
       // Council fix round (B2): clearSentWsMessages() moved to BEFORE the
@@ -321,6 +338,156 @@ test.describe('Freshclaude identity persistence (P0.2)', () => {
     }
   })
 
+  test('real-user reload: identity survives with NO manual persist flush (natural persistence path only)', async ({ page, e2eServerKind }) => {
+    expect(e2eServerKind).toBe('rust')
+    // COUNCIL FOLLOW-UP (PR #562/#563 close-out, user-advocate's held
+    // finding): every other journey in this suite (and the wall's leg G)
+    // hand-cranks `persist/flushNow` before reloading -- a lever no real
+    // user has. INVESTIGATION (what the natural path actually is):
+    // persistMiddleware rides TWO mechanisms -- a 500 ms debounce timer on
+    // every persisted-slice change (PERSIST_DEBOUNCE_MS,
+    // persistMiddleware.ts:35,673-675) AND unload-time flush listeners on
+    // visibilitychange(hidden)/pagehide/beforeunload
+    // (persistMiddleware.ts:54-66) that call flushNow(). Playwright's
+    // Chromium page.reload() fires pagehide/beforeunload on the outgoing
+    // document, so the natural path CAN fire under Playwright -- no honest
+    // approximation needed. This leg therefore reloads with NO manual
+    // flush: whichever natural mechanism ran (debounce or unload flush),
+    // the identity must be on disk by navigation time, exactly as for a
+    // real user hitting F5.
+    // RED-FIRST verified: with both natural mechanisms sabotaged in a local
+    // client build (unload listeners no-op'd + debounce inflated), the
+    // identity poll below goes red; unsabotaged it is green.
+    const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-identity-noflush-'))
+    const projectDir = path.join(sharedRoot, 'project')
+    await fs.mkdir(projectDir, { recursive: true })
+    const { server, info, harness } = await bootWall(page, {
+      env: { FRESHELL_CLAUDE_SIDECAR: FAKE_CLAUDE_SIDECAR_SOURCE },
+      setupHome: seedWallConfig({ providers: ['claude'], freshAgent: true }),
+    })
+    try {
+      await selectShellIfPickerShowing(page)
+      const tabId = (await harness.getActiveTabId())!
+      expect(tabId).toBeTruthy()
+      await expect(page.locator('.xterm').first()).toBeVisible({ timeout: 30_000 })
+      await createFreshclaudePane(page, harness, projectDir)
+      await sendFreshAgentTurn(page, harness, tabId!, 'no-flush first turn')
+      await expect
+        .poll(async () => durableIdentity(findFreshAgentLeaf(await harness.getPaneLayout(tabId!))), { timeout: 15_000 })
+        .toMatch(CANONICAL_UUID_RE)
+      const originalDurable: string = durableIdentity(findFreshAgentLeaf(await harness.getPaneLayout(tabId!)))
+
+      // Audit the reload window like test 1 does (any create fired must
+      // carry the original id -- never a bare identity-losing create).
+      await harness.clearSentWsMessages()
+
+      // THE POINT: no flushPersistence(page) here.
+      await reloadAndReconnect(page, harness)
+
+      const tabIdAfterReload = await harness.getActiveTabId()
+      await expect
+        .poll(async () => durableIdentity(findFreshAgentLeaf(await harness.getPaneLayout(tabIdAfterReload!))), { timeout: 30_000 })
+        .toBe(originalDurable)
+
+      // Liveness on the naturally-persisted identity: the conversation
+      // continues (disk transcript is the fixture's ground truth).
+      await sendFreshAgentTurn(page, harness, tabIdAfterReload!, 'no-flush second turn')
+      const transcriptFile = path.join(info.homeDir, '.claude', 'projects', '-fixture', `${originalDurable}.jsonl`)
+      const transcriptLines = (await fs.readFile(transcriptFile, 'utf-8'))
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line))
+      const userTexts = transcriptLines
+        .filter((l: any) => l.type === 'user')
+        .map((l: any) => l.message?.content?.[0]?.text)
+      expect(userTexts).toEqual(expect.arrayContaining(['no-flush first turn', 'no-flush second turn']))
+
+      // No identity-losing re-create anywhere in the reload window.
+      const sent = await harness.getSentWsMessages()
+      const creates = sent.filter((m: any) => m?.type === 'freshAgent.create') as any[]
+      for (const create of creates) {
+        expect(create.resumeSessionId ?? create.sessionRef?.sessionId, JSON.stringify(create)).toBe(originalDurable)
+      }
+    } finally {
+      await server.stop()
+      await fs.rm(sharedRoot, { recursive: true, force: true })
+    }
+  })
+
+  test('cold-open: persisted localStorage ALONE drives resume in a fresh browser context', async ({ page, browser, e2eServerKind }) => {
+    expect(e2eServerKind).toBe('rust')
+    // COUNCIL FOLLOW-UP (PR #562/#563 close-out, brian's cell): test 1
+    // proves persistence in COMPOSITION (same page object reloads, so any
+    // in-memory residue could in principle assist). This cell proves the
+    // persisted localStorage is SUFFICIENT on its own: a brand-new browser
+    // context -- fresh page, no in-memory state, seeded ONLY with the
+    // localStorage the first client persisted -- must resume the same
+    // conversation. The original page is CLOSED before the cold context
+    // opens, so no live client can assist the resume.
+    const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-identity-coldopen-'))
+    const projectDir = path.join(sharedRoot, 'project')
+    await fs.mkdir(projectDir, { recursive: true })
+    const { server, info, harness } = await bootWall(page, {
+      env: { FRESHELL_CLAUDE_SIDECAR: FAKE_CLAUDE_SIDECAR_SOURCE },
+      setupHome: seedWallConfig({ providers: ['claude'], freshAgent: true }),
+    })
+    let coldContext: Awaited<ReturnType<typeof browser.newContext>> | null = null
+    try {
+      await selectShellIfPickerShowing(page)
+      const tabId = (await harness.getActiveTabId())!
+      expect(tabId).toBeTruthy()
+      await expect(page.locator('.xterm').first()).toBeVisible({ timeout: 30_000 })
+      await createFreshclaudePane(page, harness, projectDir)
+      await sendFreshAgentTurn(page, harness, tabId!, 'cold-open first turn')
+      await expect
+        .poll(async () => durableIdentity(findFreshAgentLeaf(await harness.getPaneLayout(tabId!))), { timeout: 15_000 })
+        .toMatch(CANONICAL_UUID_RE)
+      const originalDurable: string = durableIdentity(findFreshAgentLeaf(await harness.getPaneLayout(tabId!)))
+
+      // Capture EXACTLY what the first client persisted, then close it.
+      await flushPersistence(page)
+      const persistedEntries: Array<[string, string]> = await page.evaluate(() =>
+        Object.entries(localStorage),
+      )
+      expect(persistedEntries.length).toBeGreaterThan(0)
+      await page.close()
+
+      // Cold open: fresh context, seeded ONLY with the persisted entries.
+      coldContext = await browser.newContext()
+      const coldPage = await coldContext.newPage()
+      await coldPage.addInitScript((entries: Array<[string, string]>) => {
+        for (const [k, v] of entries) localStorage.setItem(k, v)
+      }, persistedEntries)
+      await coldPage.goto(`${info.baseUrl}/?token=${info.token}&e2e=1`)
+      const coldHarness = new TestHarness(coldPage)
+      await coldHarness.waitForHarness()
+      await coldHarness.waitForConnection()
+
+      const coldTabId = await coldHarness.getActiveTabId()
+      await expect
+        .poll(async () => durableIdentity(findFreshAgentLeaf(await coldHarness.getPaneLayout(coldTabId!))), { timeout: 30_000 })
+        .toBe(originalDurable)
+
+      // Liveness in the cold context: the SAME conversation continues.
+      await sendFreshAgentTurn(coldPage, coldHarness, coldTabId!, 'cold-open second turn')
+      const transcriptFile = path.join(info.homeDir, '.claude', 'projects', '-fixture', `${originalDurable}.jsonl`)
+      const transcriptLines = (await fs.readFile(transcriptFile, 'utf-8'))
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line))
+      const userTexts = transcriptLines
+        .filter((l: any) => l.type === 'user')
+        .map((l: any) => l.message?.content?.[0]?.text)
+      expect(userTexts).toEqual(expect.arrayContaining(['cold-open first turn', 'cold-open second turn']))
+    } finally {
+      await coldContext?.close().catch(() => {})
+      await server.stop()
+      await fs.rm(sharedRoot, { recursive: true, force: true })
+    }
+  })
+
   test('HAZARD GUARD: stale persisted sessionRef yields loud dead_session, never silent wrong-session attach or silent fresh', async ({ page, e2eServerKind }) => {
     expect(e2eServerKind).toBe('rust')
     const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-identity-stale-'))
@@ -343,13 +510,14 @@ test.describe('Freshclaude identity persistence (P0.2)', () => {
       await sendFreshAgentTurn(page, harness, tabId!, 'turn that will become stale')
       await expect
         .poll(async () => durableIdentity(findFreshAgentLeaf(await harness.getPaneLayout(tabId!))), { timeout: 15_000 })
-        .toBe(DURABLE_CLI_SESSION_ID)
+        .toMatch(CANONICAL_UUID_RE)
+      const staleDurable: string = durableIdentity(findFreshAgentLeaf(await harness.getPaneLayout(tabId!)))
       await flushPersistence(page)
 
       // Make the persisted identity STALE: delete every server-side artifact
       // naming the durable session (transcripts under the isolated HOME).
-      const deleted = await deleteFilesNamed(info.homeDir, `${DURABLE_CLI_SESSION_ID}.jsonl`)
-      expect(deleted.length, `expected transcript artifacts for ${DURABLE_CLI_SESSION_ID} under ${info.homeDir}`).toBeGreaterThan(0)
+      const deleted = await deleteFilesNamed(info.homeDir, `${staleDurable}.jsonl`)
+      expect(deleted.length, `expected transcript artifacts for ${staleDurable} under ${info.homeDir}`).toBeGreaterThan(0)
 
       // SIGKILL, then reload IMMEDIATELY -- the OLD page must never
       // reconnect and fire a recovery create-with-resume: the fake sidecar
@@ -367,7 +535,7 @@ test.describe('Freshclaude identity persistence (P0.2)', () => {
         .poll(async () => {
           const state = await harness.getState()
           const entries = state?.panes?.deadSessionAdjudication ?? []
-          return entries.some((e: any) => e?.kind === 'fresh-agent' && e?.sessionRef?.sessionId === DURABLE_CLI_SESSION_ID)
+          return entries.some((e: any) => e?.kind === 'fresh-agent' && e?.sessionRef?.sessionId === staleDurable)
         }, { timeout: 30_000 })
         .toBe(true)
       const leaf = findFreshAgentLeaf(await harness.getPaneLayout(tabIdAfter!))
@@ -396,8 +564,13 @@ test.describe('Freshclaude identity persistence (P0.2)', () => {
       // here would not actually prove "never silent" (follow-up from the PR
       // #562 council review).
       const leafAfterSettle = findFreshAgentLeaf(await harness.getPaneLayout(tabIdAfter!))
-      // NEVER silent: identity not swapped, no create fired for this pane.
-      expect(leafAfterSettle?.content?.sessionRef?.sessionId).toBe(DURABLE_CLI_SESSION_ID)
+      // NEVER silent: identity not swapped, the loud restoreError still
+      // standing (post-settle re-check -- council follow-up, PR #562/#563
+      // close-out: the pre-settle restoreError read alone could not prove
+      // the error survived whatever landed during the settle window), and
+      // no create fired for this pane.
+      expect(leafAfterSettle?.content?.sessionRef?.sessionId).toBe(staleDurable)
+      expect(leafAfterSettle?.content?.restoreError?.reason).toBe('durable_artifact_missing')
       const sent = await harness.getSentWsMessages()
       expect(sent.filter((m: any) => m?.type === 'freshAgent.create')).toEqual([])
     } finally {

--- a/test/e2e-browser/specs/freshclaude-restart-parity-rust.spec.ts
+++ b/test/e2e-browser/specs/freshclaude-restart-parity-rust.spec.ts
@@ -239,6 +239,10 @@ test.describe('freshclaude restart parity (rust)', () => {
 
       // Durable identity = the fixture's canonical UUID (via liveDurableIdentity;
       // content.sessionId stays the create-time nanoid on a live claude pane).
+      // The fake sidecar mints a RANDOM canonical UUID per process (council
+      // follow-up: the old static default was collision-blind), so gate on
+      // the canonical-UUID SHAPE (which the fc-e2e-* nanoid never matches)
+      // and CAPTURE what this run minted.
       let originalDurable = ''
       await expect
         .poll(async () => {
@@ -246,7 +250,7 @@ test.describe('freshclaude restart parity (rust)', () => {
           originalDurable = liveDurableIdentity(findFreshAgentLeaf(layout))
           return originalDurable
         })
-        .toBe('44444444-4444-4444-8444-444444444444')
+        .toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
 
       await flushPersistence(page)
       await harness.clearSentWsMessages()
@@ -383,7 +387,7 @@ test.describe('freshclaude restart parity (rust)', () => {
         .split('\n')
         .filter(Boolean)
         .map((l) => JSON.parse(l))
-        .some((e) => e.msg?.type === 'create' && e.msg?.resumeSessionId === '44444444-4444-4444-8444-444444444444')
+        .some((e) => e.msg?.type === 'create' && e.msg?.resumeSessionId === originalDurable)
       expect(resumed).toBe(true)
     } finally {
       await server.stop().catch(() => {})

--- a/test/e2e-browser/specs/freshclaude-restart-parity-rust.spec.ts
+++ b/test/e2e-browser/specs/freshclaude-restart-parity-rust.spec.ts
@@ -350,6 +350,17 @@ test.describe('freshclaude restart parity (rust)', () => {
       await fsp.mkdir(projectDir, { recursive: true })
       await createFreshclaudePane(page, harness, projectDir)
 
+      // Capture the run's durable id (fixture id is random per process now;
+      // the sdk.session.init fold lands at create, before any send).
+      let busyDurable = ''
+      await expect
+        .poll(async () => {
+          const layout = await harness.getPaneLayout(tabId)
+          busyDurable = liveDurableIdentity(findFreshAgentLeaf(layout))
+          return busyDurable
+        })
+        .toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+
       // First send wedges (fixture holds the first turn forever): status stuck busy.
       // Wait for idle BEFORE filling (donor sendFreshAgentTurn's pre-send poll,
       // :371-391) -- but do NOT wait for idle after: this turn never completes.
@@ -387,7 +398,7 @@ test.describe('freshclaude restart parity (rust)', () => {
         .split('\n')
         .filter(Boolean)
         .map((l) => JSON.parse(l))
-        .some((e) => e.msg?.type === 'create' && e.msg?.resumeSessionId === originalDurable)
+        .some((e) => e.msg?.type === 'create' && e.msg?.resumeSessionId === busyDurable)
       expect(resumed).toBe(true)
     } finally {
       await server.stop().catch(() => {})

--- a/test/e2e-browser/specs/hidden-pane-rebind-rust.spec.ts
+++ b/test/e2e-browser/specs/hidden-pane-rebind-rust.spec.ts
@@ -305,12 +305,15 @@ test.describe('hidden-pane rebind (F8 / P1.11)', () => {
       // FreshAgentView.tsx mergePaneContent) -- the post-restart attach must
       // deterministically carry it so the server's restart-parity resume arm
       // (claude.rs handle_attach decision table) can engage.
+      // The fake sidecar mints a RANDOM canonical UUID per process (council
+      // follow-up: the old static default was collision-blind), so gate on
+      // the canonical-UUID SHAPE and capture what this run minted below.
       await expect
         .poll(async () => {
           const c = findFreshAgentLeaf(await harness.getPaneLayout(freshTabId))?.content
           return c?.sessionRef?.sessionId ?? c?.resumeSessionId ?? ''
         }, { timeout: 30_000 })
-        .toBe('44444444-4444-4444-8444-444444444444')
+        .toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
       const contentBefore = findFreshAgentLeaf(await harness.getPaneLayout(freshTabId))!.content!
       const originalDurable = (contentBefore.sessionRef?.sessionId ?? contentBefore.resumeSessionId) as string
       // COMBINED-TREE CONTRACT (F8 rebind x freshclaude restart parity): with

--- a/test/e2e-browser/specs/restore-contract-wall-rust.spec.ts
+++ b/test/e2e-browser/specs/restore-contract-wall-rust.spec.ts
@@ -242,16 +242,20 @@ function findFreshAgentLeaf(node: any): any {
   return null
 }
 
-// Durable identity reader: sessionRef IS the durable identity per the
-// 2026-04-19 durable-session contract; content.sessionId is a live handle
-// (for claude, the create-time fc-e2e-* placeholder forever -- see
-// freshclaude-restart-parity-rust.spec.ts:140-148). sessionRef-first keeps
-// this reader reload-symmetric for every fresh-agent provider.
+// Durable identity reader -- ONE ordering, UNIFIED with the lane specs'
+// readers (freshclaude-identity-persistence-rust.spec.ts durableIdentity,
+// freshclaude-restart-parity-rust.spec.ts liveDurableIdentity; council
+// follow-up, PR #562/#563 close-out: the P0.2 bug WAS a reader-ordering
+// bug, so this suite keeps a single order everywhere): sessionRef IS the
+// durable identity per the 2026-04-19 durable-session contract;
+// resumeSessionId is the durable-intent fallback; content.sessionId is a
+// LIVE handle (for claude, the create-time fc-e2e-* placeholder forever)
+// and may only be read LAST.
 function leafDurableIdentity(leaf: any): string | undefined {
   return (
     leaf?.content?.sessionRef?.sessionId ??
-    leaf?.content?.sessionId ??
-    leaf?.content?.resumeSessionId
+    leaf?.content?.resumeSessionId ??
+    leaf?.content?.sessionId
   )
 }
 
@@ -1186,7 +1190,7 @@ test.describe('Restore Contract Wall (P0.1)', () => {
     const projectDir = path.join(sharedRoot, 'project')
     await fs.mkdir(projectDir, { recursive: true })
 
-    const { server, harness } = await bootWall(page, {
+    const { server, harness, info } = await bootWall(page, {
       env: { FRESHELL_CLAUDE_SIDECAR: FAKE_CLAUDE_SIDECAR_SOURCE },
       setupHome: seedWallConfig({ providers: ['claude'], freshAgent: true }),
     })
@@ -1293,6 +1297,50 @@ test.describe('Restore Contract Wall (P0.1)', () => {
       for (const create of restartCreates) {
         expect(create.resumeSessionId ?? create.sessionRef?.sessionId, JSON.stringify(create)).toBe(originalSessionId)
       }
+
+      // LIVENESS (council follow-up, PR #562/#563 close-out): everything
+      // above proves the durable IDENTITY survived, but a mutation where the
+      // attach arm sets pane status and never wires the event stream (the
+      // literal historical P0.2 bug shape) would leave every assertion above
+      // green over a dead socket. Mirror lane test 1's post-restart turn on
+      // THIS ordering (SIGKILL restart THEN reload, attach-resolved): send a
+      // second turn and require the assistant reply to ROUND-TRIP through
+      // the live event stream into the freshAgent slice (turns[] is fed by
+      // wire events -- freshAgent.assistant folds, fresh-agent-ws.ts -- so a
+      // dead socket can never grow it), plus the fixture transcript on disk
+      // gaining the second user line (the server->sidecar leg).
+      const countFoldedAssistantTurns = async (): Promise<number> => {
+        const sessions = (await harness.getState())?.freshAgent?.sessions ?? {}
+        return Object.values(sessions).reduce(
+          (n: number, s: any) =>
+            n + (s?.turns ?? []).filter((t: any) => t?.role === 'assistant').length,
+          0,
+        )
+      }
+      const assistantTurnsBefore = await countFoldedAssistantTurns()
+      await sendFreshAgentTurn(page, harness, rehydratedTabId, 'wall freshclaude liveness turn')
+      await expect
+        .poll(countFoldedAssistantTurns, { timeout: 30_000 })
+        .toBeGreaterThan(assistantTurnsBefore)
+      const transcriptFile = path.join(
+        info.homeDir,
+        '.claude',
+        'projects',
+        '-fixture',
+        `${originalSessionId}.jsonl`,
+      )
+      const transcriptLines = (await fs.readFile(transcriptFile, 'utf8'))
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line))
+      const userTexts = transcriptLines
+        .filter((l: any) => l.type === 'user')
+        .map((l: any) => l.message?.content?.[0]?.text)
+      expect(userTexts).toEqual(
+        expect.arrayContaining(['wall freshclaude turn', 'wall freshclaude liveness turn']),
+      )
+      expect(transcriptLines.filter((l: any) => l.type === 'assistant').length).toBeGreaterThanOrEqual(2)
     } finally {
       await server.stop()
       await fs.rm(sharedRoot, { recursive: true, force: true })
@@ -1428,23 +1476,30 @@ test.describe('Restore Contract Wall (P0.1)', () => {
     // budget reds the whole run despite the expected-fail marking.
     test.setTimeout(600_000)
     // EXPECTED-FAIL WALL PIN -- P0.1: this is the composed ruler; it flips
-    // green only when every per-pane contract above is green un-pinned
-    // (P0.2..P1.13). OBSERVED first red (run of 2026-07-24): the freshclaude
-    // identity poll -- post-reload the freshclaude pane carries the canonical
-    // cliSessionId (the fixture's 44444444-... UUID) instead of the pre-kill
-    // ephemeral fc-e2e-* created id, and no rebind is possible behind that
-    // (attach swallow + snapshot 503, P0.2 -- see Contract G's pin). The
-    // hidden-tab legs (F8/P1.11) PASSED in this composition: the
-    // dead-terminal census DID reach hidden tabs' layouts and the claude/
-    // codex/opencode resume argv polls all went green -- the plan flagged
+    // green only when every per-pane contract above is green un-pinned.
+    // HISTORY: the first observed red (run of 2026-07-24) was the freshclaude
+    // identity poll -- that P0.2 client identity-persistence gap has since
+    // CLOSED (#562: sessionRef persists + sessionRef-first reader; pinned by
+    // Contract G above and specs/freshclaude-identity-persistence-rust
+    // .spec.ts), so it is NO LONGER this pin's reason.
+    // CURRENT OBSERVED RED (verified pre-existing at the PR #562/#563
+    // council close-out): the composed ruler fails at the CLAUDE TERMINAL
+    // \u00a72.2 leg -- the post-restart `--resume <claudePreallocatedId>` argv
+    // poll below never goes green UNDER COMPOSITION, even though the same
+    // contract passes in its standalone per-pane test.
+    // The hidden-tab legs (F8/P1.11) PASSED in this composition: the
+    // dead-terminal census DID reach hidden tabs' layouts -- the plan flagged
     // this ordering as runtime-dependent and verdict-neutral (both candidates
     // are post-restart contract assertions). The freshcodex/freshopencode
     // identity polls pass VACUOUSLY from persisted state (they measure
-    // persistence, not restore). FLIP: delete this pin when the last
-    // per-pane pin is retired.
+    // persistence, not restore).
+    // FLIP DISCIPLINE (council, PR #562/#563 close-out): leg G's identity
+    // assertions alone are NOT liveness proof -- its post-attach turn-send is.
+    // Flip only when the composed ruler GENUINELY passes 3x consecutively;
+    // delete this pin when the last per-pane pin is retired.
     test.fail(
       e2eServerKind === 'rust',
-      'P0.1: composed all-pane ruler; red until remaining P1.x land + the P0.2 client identity-persistence gap closes (P0.2 server legs -- attach-resume + snapshot adapter -- landed on feat/freshclaude-restart-parity)',
+      'P0.1: composed all-pane ruler; red until remaining P1.x land -- current observed red: the claude terminal \u00a72.2 --resume argv leg under composition (the former P0.2 freshclaude identity gap closed in #562)',
     )
 
     const CODEX_SESSION_ID = '99999999-8888-4777-8666-555555555555'
@@ -1741,12 +1796,12 @@ test.describe('Restore Contract Wall (P0.1)', () => {
       }
 
       // Quiet client: no alerts, no noisy error text (donor: restore-sync05).
-      // CAVEAT: freshclaude creates get a snapshot 503
-      // (FRESH_AGENT_RUNTIME_UNAVAILABLE, snapshot.rs:133-146) which can
-      // surface a history-load-error banner; if this count is nonzero ONLY
-      // because of that banner, scope the locator to exclude the freshclaude
-      // pane (or drop this line) rather than treating it as a new product
-      // red -- the pane-state assertions above are the real contract.
+      // (A prior CAVEAT here blamed a freshclaude snapshot 503; that was
+      // stale -- snapshot.rs:133-146 routes freshclaude through the disk+env
+      // claude adapter and the endpoint has not 503'd since wave A. The only
+      // known benign alert source is the transient history-load-error banner
+      // from the snapshot fetch racing pane creation -- see
+      // createFreshclaudePane's note above.)
       await expect(page.getByRole('alert')).toHaveCount(0)
     } finally {
       await server.stop()

--- a/test/e2e-browser/specs/restore-contract-wall-rust.spec.ts
+++ b/test/e2e-browser/specs/restore-contract-wall-rust.spec.ts
@@ -1499,7 +1499,7 @@ test.describe('Restore Contract Wall (P0.1)', () => {
     // delete this pin when the last per-pane pin is retired.
     test.fail(
       e2eServerKind === 'rust',
-      'P0.1: composed all-pane ruler; red until remaining P1.x land -- current observed red: the claude terminal \u00a72.2 --resume argv leg under composition (the former P0.2 freshclaude identity gap closed in #562)',
+      'P0.1: composed all-pane ruler; red until remaining P1.x land -- current observed red: the claude terminal §2.2 --resume argv leg under composition (the former P0.2 freshclaude identity gap closed in #562)',
     )
 
     const CODEX_SESSION_ID = '99999999-8888-4777-8666-555555555555'

--- a/test/e2e-browser/specs/wavea-interactions-rust.spec.ts
+++ b/test/e2e-browser/specs/wavea-interactions-rust.spec.ts
@@ -286,7 +286,10 @@ test.describe('wave-A cross-lane interactions', () => {
   test('A2xA3: one restart restores BOTH claude identity stores with no cross-talk', async ({ page, e2eServerKind }) => {
     expect(e2eServerKind).toBe('rust')
     const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'wavea-a2a3-'))
-    const FRESH_DURABLE = '44444444-4444-4444-8444-444444444444' // fake sidecar default
+    // The fake sidecar mints a RANDOM canonical UUID per process (council
+    // follow-up: the old static 44444444-... default was collision-blind),
+    // so the fresh-agent durable id is CAPTURED from the run below.
+    let FRESH_DURABLE = ''
     let capturedHome = ''
     try {
       const fakeClaude = await installFakeCli(path.join(sharedRoot, 'bin'), 'claude', 'fake-claude-cli.mjs')
@@ -324,7 +327,6 @@ test.describe('wave-A cross-lane interactions', () => {
         )
         const terminalSession = (await readClaudeBindingRows(ledgerDir))[0].sessionId as string
         expect(terminalSession).toBeTruthy()
-        expect(terminalSession).not.toBe(FRESH_DURABLE)
         let terminalIdBefore = ''
         await expect
           .poll(async () => {
@@ -334,13 +336,19 @@ test.describe('wave-A cross-lane interactions', () => {
           .not.toBe('')
 
         // Identity store 2 (A2): freshclaude pane -> sidecar cliSessionId index.
+        // Gate on the canonical-UUID SHAPE, then capture what this run minted.
         await createFreshclaudePane(page, sharedRoot)
         await expect
           .poll(async () => {
             const c = freshAgentLeaf(await harness.getPaneLayout(tabId))?.content
             return c?.sessionRef?.sessionId ?? c?.resumeSessionId ?? ''
           }, { timeout: 30_000 })
-          .toBe(FRESH_DURABLE)
+          .toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+        {
+          const c = freshAgentLeaf(await harness.getPaneLayout(tabId))?.content
+          FRESH_DURABLE = (c?.sessionRef?.sessionId ?? c?.resumeSessionId) as string
+        }
+        expect(terminalSession).not.toBe(FRESH_DURABLE)
 
         // FIXTURE REALISM (reconcile adoption): real claude writes
         // ~/.claude/projects/<proj>/<sessionId>.jsonl as soon as the session


### PR DESCRIPTION
Council follow-ups from the final review of the freshclaude identity-persistence work (#562/#563), kata nmwx.

**Changes:**

(1) Wall leg G now proves conversation LIVENESS, not just identity — after the SIGKILL→reload attach resolves, a second turn is sent and proven via wire-fed state + on-disk transcript; mutation-verified red (a dead-stream attach sabotage turns the leg red at exactly the new assertion).

(2) Cold-open cell: persisted browser state ALONE drives resume in a fresh context.

(3) No-manual-flush reload e2e: identity survives a real-user reload via the natural persistence path (debounce + pagehide/beforeunload) with no test-only flush — sabotage-proven red-first.

(4) Two lying comments corrected: the P0.1 ruler pin reason no longer cites the disproved P0.2 gap (now cites the verified real cause: claude terminal §2.2 argv leg fails under composition — re-confirmed by a pin-lifted diagnostic run; pin stays, with explicit 3x-consecutive flip discipline encoded); stale 503 caveat removed.

(5) Fixture cliSessionId randomized per-run (kills static-id collision blindness).

(6) Test identity readers unified.

**Decision recorded:** attach-audit filter skipped per council dissent — the turn-proof pins outcome, not mechanism.

**Verification:**
- Coordinated JS green
- Lint clean
- Full wall 3x green (15 passed each)
- Lane specs 4/4 including the two new legs
- Ephemeral ports only

**Known (pre-existing):** hidden-pane-rebind-rust.spec.ts 'hidden fresh-agent pane recovers after abrupt restart' fails — post-restart reconcile adjudicates the hidden freshclaude pane dead (session_not_on_disk dialog) instead of resuming. Tracked separately on unmodified main.