### PR TITLE
feat(resume-dialog): remove the always-visible agent picker and hint

### DIFF
--- a/src/components/ResumeSessionDialog.tsx
+++ b/src/components/ResumeSessionDialog.tsx
@@ -68,7 +68,6 @@ export function ResumeSessionDialog({ open, onClose, onNavigate }: ResumeSession
   const store = useStore<RootState>()
   const [input, setInput] = useState('')
   const [agent, setAgent] = useState<string>(providers[0])
-  const [agentTouched, setAgentTouched] = useState(false)
   const [anywayCwd, setAnywayCwd] = useState('~')
   const [phase, setPhase] = useState<Phase>({ kind: 'idle' })
   // Inline error for confirming a cwd-less match with a blank cwd field.
@@ -82,12 +81,14 @@ export function ResumeSessionDialog({ open, onClose, onNavigate }: ResumeSession
   // homeDir prefill never overwrites a USER-edited working directory.
   const cwdTouchedRef = useRef(false)
 
-  // Advisory hint pre-fills the picker; never overrides a manual choice.
+  // Advisory parse hint drives the internal agent guess. There is no visible
+  // picker (kata 1ffd): the guess surfaces only on the no-match escape hatch's
+  // "Resume anyway with {agent}" button, which is the disclosure point.
   useEffect(() => {
-    if (agentTouched || !input) return
+    if (!input) return
     const { hint } = parseResumeInput(input)
     if (hint && providers.includes(hint.provider)) setAgent(hint.provider)
-  }, [input, agentTouched])
+  }, [input])
 
   const finishResume = useCallback(
     (target: ResumeTarget, note: string) => {
@@ -344,30 +345,6 @@ export function ResumeSessionDialog({ open, onClose, onNavigate }: ResumeSession
             }, 0)
           }}
         />
-        <div className="flex items-center gap-2">
-          <label className="text-xs text-muted-foreground" htmlFor="resume-agent-picker">
-            Agent
-          </label>
-          <select
-            id="resume-agent-picker"
-            data-testid="resume-agent-picker"
-            value={agent}
-            onChange={(event) => {
-              setAgent(event.target.value)
-              setAgentTouched(true)
-            }}
-            className={controlClass}
-          >
-            {providers.map((provider) => (
-              <option key={provider} value={provider}>
-                {provider}
-              </option>
-            ))}
-          </select>
-        </div>
-        <p className="text-[10px] text-muted-foreground">
-          Unverified guess — the session store decides the agent.
-        </p>
         <button
           type="button"
           data-testid="resume-resolve-button"

--- a/test/unit/client/components/ResumeSessionDialog.test.tsx
+++ b/test/unit/client/components/ResumeSessionDialog.test.tsx
@@ -88,11 +88,11 @@ describe('ResumeSessionDialog', () => {
     expect(screen.getByTestId('resume-note').textContent).toContain('codex')
   })
 
-  it('evidence wins over the picker, with a note', async () => {
+  it('server evidence decides the agent even when the parse hint disagrees', async () => {
     apiPost.mockReturnValue(ok([match({ provider: 'opencode', sessionId: SES, sessionType: undefined })]))
     renderDialog()
-    fireEvent.change(screen.getByTestId('resume-agent-picker'), { target: { value: 'claude' } })
-    typeAndResolve(SES)
+    // "claude --resume" hints claude, but the session store says opencode.
+    typeAndResolve(`claude --resume ${SES}`)
     await waitFor(() => expect(resumeSessionInTab).toHaveBeenCalled())
     expect(resumeSessionInTab.mock.calls[0][2]).toMatchObject({ provider: 'opencode' })
     expect(screen.getByTestId('resume-note').textContent).toContain('opencode')
@@ -116,22 +116,37 @@ describe('ResumeSessionDialog', () => {
     })
   })
 
-  it('zero matches: inline error, input preserved, resume-anyway uses picker agent', async () => {
+  it('zero matches: inline error, input preserved, resume-anyway uses the parse-hint agent', async () => {
     apiPost.mockReturnValue(ok([]))
     renderDialog()
     typeAndResolve(V4)
     await screen.findByTestId('resume-error')
     expect((screen.getByTestId('resume-input') as HTMLTextAreaElement).value).toBe(V4)
-    // hint pre-filled the picker to claude (v4 shape); user switches to amplifier
-    fireEvent.change(screen.getByTestId('resume-agent-picker'), { target: { value: 'amplifier' } })
+    // The v4 id shape hints claude; the button discloses that guess before launch.
+    expect(screen.getByTestId('resume-anyway-button').textContent).toBe('Resume anyway with claude')
     expect((screen.getByTestId('resume-anyway-cwd') as HTMLInputElement).value).toBe('~')
     fireEvent.click(screen.getByTestId('resume-anyway-button'))
     expect(resumeSessionInTab).toHaveBeenCalledTimes(1)
     expect(resumeSessionInTab.mock.calls[0][2]).toMatchObject({
-      provider: 'amplifier',
+      provider: 'claude',
       sessionId: V4,
-      sessionType: 'amplifier',
+      sessionType: 'claude',
       cwd: undefined, // '~' means server default (home directory)
+    })
+  })
+
+  it('the command form steers the guess: "codex resume <id>" discloses codex on the escape hatch', async () => {
+    apiPost.mockReturnValue(ok([]))
+    renderDialog()
+    typeAndResolve('codex resume abc123def0')
+    await screen.findByTestId('resume-error')
+    expect(screen.getByTestId('resume-anyway-button').textContent).toBe('Resume anyway with codex')
+    fireEvent.click(screen.getByTestId('resume-anyway-button'))
+    expect(resumeSessionInTab).toHaveBeenCalledTimes(1)
+    expect(resumeSessionInTab.mock.calls[0][2]).toMatchObject({
+      provider: 'codex',
+      sessionId: 'abc123def0',
+      sessionType: 'codex',
     })
   })
 
@@ -174,12 +189,11 @@ describe('ResumeSessionDialog', () => {
     expect(resumeSessionInTab).not.toHaveBeenCalled()
   })
 
-  it('pre-fills the agent picker from the hint', async () => {
+  it('renders NO always-visible agent picker or unverified-guess hint (kata 1ffd removal)', () => {
     renderDialog()
-    fireEvent.change(screen.getByTestId('resume-input'), {
-      target: { value: `codex resume ${V7}` },
-    })
-    expect((screen.getByTestId('resume-agent-picker') as HTMLSelectElement).value).toBe('codex')
+    expect(screen.queryByTestId('resume-agent-picker')).toBeNull()
+    expect(screen.queryByLabelText(/agent/i)).toBeNull()
+    expect(screen.queryByText(/unverified guess/i)).toBeNull()
   })
 
   it('closes on Escape', () => {


### PR DESCRIPTION
## Summary
- UX simplification, user-directed (kata 1ffd): the Resume dialog's always-visible Agent dropdown and its "Unverified guess — the session store decides the agent." hint confused users — the picker was ignored whenever a match was found (the matched session's own provider wins, by design) and only took effect on the no-match "Resume anyway" path.
- Removed both the dropdown and the hint. The parse-derived guess still drives the no-match escape hatch, whose button text remains the sole (and sufficient) disclosure: "Resume anyway with <agent>". Pasting a command form (e.g. `claude resume <id>`) still steers the guess.
- Deleted dead `agentTouched` state.

## Test plan
- [x] RED-first removal test written before the change
- [x] Resume dialog suite: 25/25 passing
- [x] Sidebar suites: 160/160 passing
- [x] e2e resume-button: 3/3 on legacy-chromium AND rust-chromium (spec never referenced the picker — it proves agent correctness via spawned argv)
- [x] Typecheck clean
- [x] Lint parity with main

Generated with [Amplifier](https://github.com/microsoft/amplifier)