### PR TITLE
docs(agents): WSL desktop builds target the Windows Electron app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ npm run serve               # Build and run production server
 # `npm run check` for safe verification, or build from a worktree.
 ```
 
-Windows desktop builds (`npm run electron:build:win`) must run on native Windows — see [docs/development/windows-electron-build.md](docs/development/windows-electron-build.md).
+**On WSL machines, "the desktop app" means the Windows app.** Always build, install, and launch the Windows Electron app (`npm run electron:build:win` + the NSIS installer) — never a Linux AppImage/deb under WSLg. The Windows build must run as a native Windows process (WSL cannot compile `node-pty` for win32); drive it from WSL by rsyncing to a Windows-local dir and running Windows npm via `cmd.exe` — see [docs/development/windows-electron-build.md](docs/development/windows-electron-build.md).
 
 ### Testing
 ```bash


### PR DESCRIPTION
## What changed
Doc-only, one-line edit to AGENTS.md: strengthens the Windows Electron build guidance in the Building section.

## Why
On WSL machines, "the desktop app" means the **Windows** app. The previous line only said Windows desktop builds must run on native Windows; the new guidance makes the intent unambiguous:
- Build/install/launch the Windows Electron app (`npm run electron:build:win` + NSIS installer) — never a Linux AppImage/deb under WSLg.
- WSL cannot compile `node-pty` for win32, so the build must run as a native Windows process.
- Drive it from WSL by rsyncing to a Windows-local dir and running Windows npm via `cmd.exe` (see docs/development/windows-electron-build.md).

## How to verify
Read the diff — single hunk in AGENTS.md, no code changes.

## Breaking changes
None (documentation only).