### PR TITLE
feat(opencode): deterministic attention bell — abort-aware, permission pauses, death bells, Rust tracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,9 +1447,11 @@ dependencies = [
  "freshell-protocol",
  "freshell-sessions",
  "freshell-terminal",
+ "futures",
  "futures-util",
  "libc",
  "notify",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1479,12 +1481,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1552,6 +1569,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",

--- a/crates/freshell-activity/src/idle.rs
+++ b/crates/freshell-activity/src/idle.rs
@@ -49,9 +49,45 @@
 //!    death bell — a MISSED bell (never a false ring); accepted.
 //! 5. A SENT approval request auto-resolved server-side slower than ~2s rings
 //!    once (decision 5); accepted.
-//! 6. Node opencode death bells: deliberately excluded (noisy busy proxy) —
-//!    follow-up. Rust opencode: no hub tracker exists — N/A.
+//! 6. Opencode death bells now ring on both servers, ownership-scoped:
+//!    candidate/ambiguous ownership never death-rings (the old noisy-busy-proxy
+//!    problem, now excluded by construction). Consequences kept deliberate:
+//!    first-turn deaths stay silent (candidate covers the whole first turn on
+//!    Node — even with a candidate-armed permission pause pending), and a Rust
+//!    pane whose bind producers all fail (locator ambiguity + plugin absence)
+//!    stays candidate indefinitely — candidate-armed pauses still ring there,
+//!    but completions and death bells wait for the bind.
 //! 7. Unmanaged/PTY-only codex has no approval signal — documented limitation.
+//! 8. Opencode: an SSE reconnect during a permission pause loses the pending
+//!    pause bell (the busy snapshot clears it; GET /permission resync is a
+//!    possible follow-up). Ambiguous ownership stays bell-free. Child sessions
+//!    unseen on-stream (reconnect gap, mid-turn attach) are recovered by the
+//!    lane's HTTP root resolver (GET /session/{id} exposes parentID); only
+//!    resolver FAILURE degrades to ambiguous (conservative silence), retried
+//!    on the next occurrence.
+//! 9. Opencode protocol drift: permission.v2.* / question.* event families
+//!    (schema-declared, unobserved on 1.18.11) are unhandled — the pause bell
+//!    goes deaf if a future server switches families. session.idle is already
+//!    deprecated upstream and a v1->v2 event/health migration is in progress;
+//!    the log-once version gate (Rust lane + Node tracker) converts silent
+//!    drift into a logged warning, and /session/status absence==idle is
+//!    version-derived behavior (1.18.x).
+//! 10. Opencode abort window W1: an abort landing between the prompt loop-top
+//!    and processor.create emits NO abort evidence at all before idle — a
+//!    ms-scale window where a completion bell can ring on a human abort
+//!    (window W2 is closed by the abort-marked message.updated fallback).
+//! 11. Pathological opencode TUI quits — worker dispose exceeding the 5s
+//!    hard-terminate cap, or a raw SIGTERM (no drain path) — can leave
+//!    engagement set at spontaneous exit, so a death bell can ring on those
+//!    rare human quits. Normal quit paths verified to abort+drain (all four
+//!    quit inputs dispose runners via the abort path before exit); the
+//!    wire-flush instant is unprovable from code but mitigated upstream by
+//!    graceful SSE stream termination.
+//! 12. The opencode 120s busy deadman is EVENT-SILENCE-keyed (deltas and
+//!    heartbeats do not refresh it): a single >120s silent tool call trips it
+//!    mid-turn. Ownership survives and the turn's completion still rings —
+//!    the cost is the dropped busy light plus lost post-deadman death
+//!    engagement (the removal itself stays silent).
 
 use std::collections::HashMap;
 

--- a/crates/freshell-activity/src/idle.rs
+++ b/crates/freshell-activity/src/idle.rs
@@ -73,21 +73,21 @@
 //!    drift into a logged warning, and /session/status absence==idle is
 //!    version-derived behavior (1.18.x).
 //! 10. Opencode abort window W1: an abort landing between the prompt loop-top
-//!    and processor.create emits NO abort evidence at all before idle — a
-//!    ms-scale window where a completion bell can ring on a human abort
-//!    (window W2 is closed by the abort-marked message.updated fallback).
+//!     and processor.create emits NO abort evidence at all before idle — a
+//!     ms-scale window where a completion bell can ring on a human abort
+//!     (window W2 is closed by the abort-marked message.updated fallback).
 //! 11. Pathological opencode TUI quits — worker dispose exceeding the 5s
-//!    hard-terminate cap, or a raw SIGTERM (no drain path) — can leave
-//!    engagement set at spontaneous exit, so a death bell can ring on those
-//!    rare human quits. Normal quit paths verified to abort+drain (all four
-//!    quit inputs dispose runners via the abort path before exit); the
-//!    wire-flush instant is unprovable from code but mitigated upstream by
-//!    graceful SSE stream termination.
+//!     hard-terminate cap, or a raw SIGTERM (no drain path) — can leave
+//!     engagement set at spontaneous exit, so a death bell can ring on those
+//!     rare human quits. Normal quit paths verified to abort+drain (all four
+//!     quit inputs dispose runners via the abort path before exit); the
+//!     wire-flush instant is unprovable from code but mitigated upstream by
+//!     graceful SSE stream termination.
 //! 12. The opencode 120s busy deadman is EVENT-SILENCE-keyed (deltas and
-//!    heartbeats do not refresh it): a single >120s silent tool call trips it
-//!    mid-turn. Ownership survives and the turn's completion still rings —
-//!    the cost is the dropped busy light plus lost post-deadman death
-//!    engagement (the removal itself stays silent).
+//!     heartbeats do not refresh it): a single >120s silent tool call trips it
+//!     mid-turn. Ownership survives and the turn's completion still rings —
+//!     the cost is the dropped busy light plus lost post-deadman death
+//!     engagement (the removal itself stays silent).
 
 use std::collections::HashMap;
 

--- a/crates/freshell-activity/src/lib.rs
+++ b/crates/freshell-activity/src/lib.rs
@@ -29,6 +29,7 @@ pub mod claude;
 pub mod codex;
 pub mod idle;
 pub mod ledger;
+pub mod opencode;
 pub mod signal;
 
 /// Effects a tracker interaction can produce, drained by the caller (the

--- a/crates/freshell-activity/src/opencode.rs
+++ b/crates/freshell-activity/src/opencode.rs
@@ -1,0 +1,1074 @@
+//! Pure OpenCode ownership tracker — Rust port of the Node reducer
+//! (`server/coding-cli/opencode-ownership-reducer.ts`, plus decisions D1–D6
+//! of `docs/plans/2026-08-03-opencode-attention-bell.md`).
+//!
+//! Policy: OpenCode terminal panes ring the attention bell exactly like
+//! codex — bells on real turn ends only. Failed turns ring like completed
+//! turns; human aborts clear busy silently (D1); ambiguous ownership stays
+//! conservatively silent; child sessions never gate the root's turn edges
+//! (D5); `retry` status is busy (D6). Protocol facts derive from opencode
+//! 1.18.11 (live spike /tmp/opencode-spike/).
+//!
+//! The tracker is a pure, timer-free, RESOLVER-FREE state machine (no IO,
+//! no tokio): the hub owns time and transport, and recovery of session ids
+//! never seen on-stream is the LANE's job — the HTTP root-resolver fallback
+//! (Task 9) emits synthetic [`OpencodeActivityTracker::note_session_created`]
+//! calls before the triggering event, so by the time an event reaches this
+//! tracker the child→root mapping either exists or the conservative
+//! ambiguity rules apply.
+//!
+//! `OpencodePhase::Busy` is the ONLY phase on the wire: not-busy == record
+//! absence. Record dedupe compares phase + session only (like codex
+//! `has_public_change`) — a deliberate, documented divergence from Node's
+//! timestamp-sensitive dedupe, so repeated busy events don't spam frames.
+
+use std::collections::{HashMap, HashSet};
+
+use freshell_protocol::{OpencodeActivityRecord, OpencodePhase};
+
+use crate::ledger::TurnCompletionLedger;
+use crate::TrackerEffect;
+
+/// Mirrors Node `OPENCODE_BUSY_DEADMAN_MS` (`opencode-activity-tracker.ts`).
+pub const OPENCODE_BUSY_DEADMAN_MS: i64 = 120_000;
+
+pub type OpencodeEffect = TrackerEffect<OpencodeActivityRecord>;
+
+/// Session status vocabulary from `/session/status` and the SSE
+/// `session.status` events. `Retry` is busy everywhere (D6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpencodeStatus {
+    Busy,
+    Retry,
+    Idle,
+}
+
+/// Per-terminal ownership machine (port of `OpencodeOwnershipState`).
+#[derive(Debug, Clone, PartialEq)]
+enum Ownership {
+    /// No turn in flight; `known_session_id` is the confirmed identity.
+    Quiet { known_session_id: Option<String> },
+    /// An unconfirmed session is busy (no binding yet). Its completion is
+    /// DEFERRED to `bind_session` (`AwaitingAssociation`).
+    Candidate {
+        session_id: String,
+        previous_known: Option<String>,
+        cycle: u64,
+        stream: u64,
+        turn_aborted: bool,
+    },
+    /// The confirmed session is busy. `turn_aborted` is the per-turn abort
+    /// gate (D1): a consumed abort clears busy silently.
+    KnownBusy {
+        session_id: String,
+        cycle: u64,
+        stream: u64,
+        turn_aborted: bool,
+    },
+    /// A candidate turn ended; the completion waits for identity proof.
+    AwaitingAssociation {
+        session_id: String,
+        previous_known: Option<String>,
+        completed_at: i64,
+        aborted: bool,
+    },
+    /// Multiple busy root sessions: conservative silence (residual D8(a)).
+    Ambiguous {
+        known_session_id: Option<String>,
+        blocked: Vec<String>,
+    },
+}
+
+/// Per-terminal state.
+#[derive(Debug)]
+struct TerminalOpencode {
+    terminal_id: String,
+    ownership: Ownership,
+    /// session id -> root session id (built from session.created parentID;
+    /// self-mapped roots). Retained for the session's lifetime (D5).
+    session_roots: HashMap<String, String>,
+    /// Pending permission ids (Task 7).
+    pending_permissions: HashSet<String>,
+    /// Present == busy on the wire (`OpencodePhase::Busy` is the only phase).
+    record: Option<OpencodeActivityRecord>,
+    last_observed_at: i64,
+}
+
+/// Upsert the busy record. Emits a `Changed` frame only when the public
+/// shape changed — phase + session only, like codex `has_public_change`
+/// (deliberate divergence from Node's timestamp-sensitive dedupe).
+fn set_busy_record(
+    state: &mut TerminalOpencode,
+    session_id: Option<String>,
+    at: i64,
+) -> Vec<OpencodeEffect> {
+    let next = OpencodeActivityRecord {
+        terminal_id: state.terminal_id.clone(),
+        phase: OpencodePhase::Busy,
+        updated_at: at,
+        session_id,
+    };
+    let changed = match &state.record {
+        Some(prev) => prev.session_id != next.session_id,
+        None => true,
+    };
+    state.record = Some(next.clone());
+    if changed {
+        vec![TrackerEffect::Changed {
+            upsert: vec![next],
+            remove: vec![],
+        }]
+    } else {
+        Vec::new()
+    }
+}
+
+/// Drop the busy record; `force` emits the remove frame even when no record
+/// was present (Task 7's mid-pause abort path).
+fn clear_record(state: &mut TerminalOpencode, force: bool) -> Vec<OpencodeEffect> {
+    if state.record.take().is_none() && !force {
+        return Vec::new();
+    }
+    vec![TrackerEffect::Changed {
+        upsert: vec![],
+        remove: vec![state.terminal_id.clone()],
+    }]
+}
+
+/// Walk `session_roots` to the root with a seen-set cycle guard; an unknown
+/// id resolves to itself (mirror of Node `resolveKnownRoot` + the callers'
+/// `?? sessionId` fallback).
+fn resolve_root<'a>(state: &'a TerminalOpencode, session_id: &'a str) -> &'a str {
+    let mut current = session_id;
+    let mut seen: HashSet<&str> = HashSet::new();
+    while seen.insert(current) {
+        match state.session_roots.get(current) {
+            Some(next) if next.as_str() != current => current = next,
+            _ => return current,
+        }
+    }
+    // Cycle: conservative fallback to the raw id.
+    session_id
+}
+
+fn unique_sorted(mut values: Vec<String>) -> Vec<String> {
+    values.sort();
+    values.dedup();
+    values
+}
+
+/// Ownership + turn-edge tracker for OpenCode terminal panes.
+#[derive(Debug)]
+pub struct OpencodeActivityTracker {
+    states: HashMap<String, TerminalOpencode>,
+    ledger: TurnCompletionLedger,
+    /// Busy-deadman window; [`OPENCODE_BUSY_DEADMAN_MS`] in production.
+    /// Test-scale hook, same shape as the codex tracker's.
+    busy_deadman_ms: i64,
+}
+
+impl Default for OpencodeActivityTracker {
+    fn default() -> Self {
+        Self {
+            states: HashMap::new(),
+            ledger: TurnCompletionLedger::default(),
+            busy_deadman_ms: OPENCODE_BUSY_DEADMAN_MS,
+        }
+    }
+}
+
+impl OpencodeActivityTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Test-scale hook: override the busy-deadman window.
+    pub fn set_busy_deadman_ms(&mut self, ms: i64) {
+        self.busy_deadman_ms = ms;
+    }
+
+    /// Busy records only — record absence IS the idle representation.
+    pub fn list(&self) -> Vec<OpencodeActivityRecord> {
+        self.states
+            .values()
+            .filter_map(|state| state.record.clone())
+            .collect()
+    }
+
+    pub fn list_latest_completions(&self) -> Vec<freshell_protocol::TurnCompletionSnapshot> {
+        self.ledger.list_latest_completions()
+    }
+
+    /// Create-or-reset the terminal's state (tracking starts at create).
+    pub fn track_terminal(
+        &mut self,
+        terminal_id: &str,
+        session_id: Option<&str>,
+        at: i64,
+    ) -> Vec<OpencodeEffect> {
+        if let Some(state) = self.states.get_mut(terminal_id) {
+            state.ownership = Ownership::Quiet {
+                known_session_id: session_id.map(str::to_string),
+            };
+            state.session_roots.clear();
+            state.pending_permissions.clear();
+            state.last_observed_at = at;
+            // A stale record from the previous incarnation is removed.
+            return clear_record(state, false);
+        }
+        self.states.insert(
+            terminal_id.to_string(),
+            TerminalOpencode {
+                terminal_id: terminal_id.to_string(),
+                ownership: Ownership::Quiet {
+                    known_session_id: session_id.map(str::to_string),
+                },
+                session_roots: HashMap::new(),
+                pending_permissions: HashSet::new(),
+                record: None,
+                last_observed_at: at,
+            },
+        );
+        Vec::new()
+    }
+
+    /// Association/rebind identity from the SQLite locator or the TUI rebind
+    /// plugin (Task 10 wires the producers).
+    pub fn bind_session(
+        &mut self,
+        terminal_id: &str,
+        session_id: &str,
+        at: i64,
+    ) -> Vec<OpencodeEffect> {
+        let Self { states, ledger, .. } = self;
+        let Some(state) = states.get_mut(terminal_id) else {
+            return Vec::new();
+        };
+        state
+            .session_roots
+            .insert(session_id.to_string(), session_id.to_string());
+        match state.ownership.clone() {
+            Ownership::AwaitingAssociation {
+                session_id: own,
+                completed_at,
+                aborted,
+                ..
+            } if own == session_id => {
+                state.ownership = Ownership::Quiet {
+                    known_session_id: Some(own.clone()),
+                };
+                if aborted {
+                    return Vec::new();
+                }
+                // DEFERRED completion (Node confirmOpencodeAssociation):
+                // stamped at the STORED turn-end instant, not the bind's.
+                let seq = ledger.record_turn_completion(&state.terminal_id, completed_at);
+                vec![TrackerEffect::TurnComplete {
+                    terminal_id: state.terminal_id.clone(),
+                    session_id: Some(own),
+                    at: completed_at,
+                    completion_seq: seq,
+                }]
+            }
+            Ownership::AwaitingAssociation { previous_known, .. } => {
+                // Reject analog: the ended turn belonged to someone else.
+                state.ownership = Ownership::Quiet {
+                    known_session_id: previous_known,
+                };
+                Vec::new()
+            }
+            Ownership::Ambiguous { blocked, .. } => {
+                // Adoption assist: the next snapshot resolves it.
+                state.ownership = Ownership::Ambiguous {
+                    known_session_id: Some(session_id.to_string()),
+                    blocked,
+                };
+                Vec::new()
+            }
+            Ownership::Quiet { .. } => {
+                state.ownership = Ownership::Quiet {
+                    known_session_id: Some(session_id.to_string()),
+                };
+                Vec::new()
+            }
+            Ownership::Candidate {
+                session_id: own,
+                cycle,
+                stream,
+                turn_aborted,
+                ..
+            } if own == session_id => {
+                // Identity proof arrived mid-turn: promote in place.
+                state.ownership = Ownership::KnownBusy {
+                    session_id: own.clone(),
+                    cycle,
+                    stream,
+                    turn_aborted,
+                };
+                set_busy_record(state, Some(own), at)
+            }
+            Ownership::Candidate {
+                session_id: own,
+                cycle,
+                stream,
+                turn_aborted,
+                ..
+            } => {
+                state.ownership = Ownership::Candidate {
+                    session_id: own,
+                    previous_known: Some(session_id.to_string()),
+                    cycle,
+                    stream,
+                    turn_aborted,
+                };
+                Vec::new()
+            }
+            // Identity already flowing.
+            Ownership::KnownBusy { .. } => Vec::new(),
+        }
+    }
+
+    /// `session.created`: fold the parentID chain into `session_roots`.
+    pub fn note_session_created(
+        &mut self,
+        terminal_id: &str,
+        session_id: &str,
+        parent_id: Option<&str>,
+        at: i64,
+    ) -> Vec<OpencodeEffect> {
+        let Some(state) = self.states.get_mut(terminal_id) else {
+            return Vec::new();
+        };
+        state.last_observed_at = at;
+        match parent_id {
+            Some(parent) => {
+                let root = resolve_root(state, parent).to_string();
+                state
+                    .session_roots
+                    .insert(parent.to_string(), root.clone());
+                state
+                    .session_roots
+                    .insert(session_id.to_string(), root.clone());
+                // Adoption assist (Node session.created analog): an unowned
+                // ambiguity adopts the root; the next snapshot resolves.
+                if let Ownership::Ambiguous {
+                    known_session_id: known @ None,
+                    ..
+                } = &mut state.ownership
+                {
+                    *known = Some(root);
+                }
+            }
+            None => {
+                state
+                    .session_roots
+                    .insert(session_id.to_string(), session_id.to_string());
+            }
+        }
+        Vec::new()
+    }
+
+    /// `session.status` SSE edge (busy | retry | idle).
+    pub fn note_status(
+        &mut self,
+        terminal_id: &str,
+        session_id: &str,
+        status: OpencodeStatus,
+        cycle: u64,
+        stream: u64,
+        at: i64,
+    ) -> Vec<OpencodeEffect> {
+        let Self { states, ledger, .. } = self;
+        let Some(state) = states.get_mut(terminal_id) else {
+            return Vec::new();
+        };
+        state.last_observed_at = at;
+        let root = resolve_root(state, session_id).to_string();
+        match status {
+            OpencodeStatus::Idle => {
+                if root != session_id {
+                    // Child idle is SUPPRESSED (D5): only the root's own
+                    // idle ends the root's turn.
+                    return Vec::new();
+                }
+                reduce_idle_edge(state, ledger, &root, cycle, stream, at)
+            }
+            // Child busy remaps to the root; retry is busy (D6).
+            OpencodeStatus::Busy | OpencodeStatus::Retry => {
+                reduce_busy_edge(state, &root, cycle, stream, at)
+            }
+        }
+    }
+
+    /// `session.idle` SSE edge (the deprecated twin of `session.status{idle}`).
+    pub fn note_session_idle(
+        &mut self,
+        terminal_id: &str,
+        session_id: &str,
+        cycle: u64,
+        stream: u64,
+        at: i64,
+    ) -> Vec<OpencodeEffect> {
+        // Same routing as a status idle edge; dedupe is structural (D2):
+        // the first edge lands the machine in Quiet, the twin no-ops.
+        self.note_status(terminal_id, session_id, OpencodeStatus::Idle, cycle, stream, at)
+    }
+
+    /// `/session/status` snapshot (absence == idle; a literal idle entry is
+    /// treated as absent).
+    pub fn note_snapshot(
+        &mut self,
+        terminal_id: &str,
+        statuses: &[(String, OpencodeStatus)],
+        cycle: u64,
+        stream: u64,
+        at: i64,
+    ) -> Vec<OpencodeEffect> {
+        let Self { states, ledger, .. } = self;
+        let Some(state) = states.get_mut(terminal_id) else {
+            return Vec::new();
+        };
+        state.last_observed_at = at;
+        let busy_roots = collapse_busy_roots(state, statuses);
+        reduce_snapshot(state, ledger, busy_roots, cycle, stream, at)
+    }
+
+    /// PTY exit: drop the whole state.
+    pub fn note_exit(&mut self, terminal_id: &str) -> Vec<OpencodeEffect> {
+        match self.states.remove(terminal_id) {
+            Some(state) if state.record.is_some() => vec![TrackerEffect::Changed {
+                upsert: vec![],
+                remove: vec![terminal_id.to_string()],
+            }],
+            _ => Vec::new(),
+        }
+    }
+
+    /// Busy-deadman sweep: silence past the window drops the record with NO
+    /// completion (deadman swallow is silent, residual D8(e)). Ownership
+    /// survives, so the turn's eventual idle edge still completes it.
+    pub fn expire(&mut self, at: i64) -> Vec<OpencodeEffect> {
+        let mut effects = Vec::new();
+        for state in self.states.values_mut() {
+            if state.record.is_some() && at - state.last_observed_at > self.busy_deadman_ms {
+                effects.extend(clear_record(state, false));
+            }
+        }
+        effects
+    }
+
+    /// Earliest future instant at which [`Self::expire`] could change state.
+    pub fn next_deadline(&self) -> Option<i64> {
+        self.states
+            .values()
+            .filter(|state| state.record.is_some())
+            .map(|state| state.last_observed_at + self.busy_deadman_ms)
+            .min()
+    }
+}
+
+/// Idle-edge reducer (`session.idle` or `session.status{idle}`), with
+/// cycle/stream guards exactly like Node `sameSessionStream`. `session_id`
+/// is already root-resolved.
+fn reduce_idle_edge(
+    state: &mut TerminalOpencode,
+    ledger: &mut TurnCompletionLedger,
+    session_id: &str,
+    cycle: u64,
+    stream: u64,
+    at: i64,
+) -> Vec<OpencodeEffect> {
+    match state.ownership.clone() {
+        Ownership::KnownBusy {
+            session_id: own,
+            cycle: c,
+            stream: st,
+            turn_aborted,
+        } if own == session_id && c == cycle && st == stream => {
+            state.ownership = Ownership::Quiet {
+                known_session_id: Some(own.clone()),
+            };
+            // D7 ordering: remove BEFORE TurnComplete.
+            let mut effects = clear_record(state, false);
+            if !turn_aborted {
+                let seq = ledger.record_turn_completion(&state.terminal_id, at);
+                effects.push(TrackerEffect::TurnComplete {
+                    terminal_id: state.terminal_id.clone(),
+                    session_id: Some(own),
+                    at,
+                    completion_seq: seq,
+                });
+            }
+            effects
+        }
+        Ownership::Candidate {
+            session_id: own,
+            previous_known,
+            cycle: c,
+            stream: st,
+            turn_aborted,
+        } if own == session_id && c == cycle && st == stream => {
+            // Completion deferred to `bind_session`.
+            state.ownership = Ownership::AwaitingAssociation {
+                session_id: own,
+                previous_known,
+                completed_at: at,
+                aborted: turn_aborted,
+            };
+            clear_record(state, false)
+        }
+        Ownership::Ambiguous {
+            known_session_id,
+            blocked,
+        } if blocked.iter().any(|b| b == session_id) => {
+            let blocked: Vec<String> = blocked.into_iter().filter(|b| b != session_id).collect();
+            if blocked.is_empty() {
+                state.ownership = Ownership::Quiet { known_session_id };
+                clear_record(state, false)
+            } else {
+                state.ownership = Ownership::Ambiguous {
+                    known_session_id,
+                    blocked,
+                };
+                set_busy_record(state, None, at)
+            }
+        }
+        // Quiet / AwaitingAssociation / guard misses: unchanged. Quiet's
+        // no-op IS the double-idle dedupe (D2).
+        _ => Vec::new(),
+    }
+}
+
+/// Busy-edge reducer (busy or retry — D6). `session_id` is already
+/// root-resolved.
+fn reduce_busy_edge(
+    state: &mut TerminalOpencode,
+    session_id: &str,
+    cycle: u64,
+    stream: u64,
+    at: i64,
+) -> Vec<OpencodeEffect> {
+    match state.ownership.clone() {
+        Ownership::Quiet { known_session_id } => {
+            if known_session_id.as_deref() == Some(session_id) {
+                state.ownership = Ownership::KnownBusy {
+                    session_id: session_id.to_string(),
+                    cycle,
+                    stream,
+                    turn_aborted: false,
+                };
+            } else {
+                state.ownership = Ownership::Candidate {
+                    session_id: session_id.to_string(),
+                    previous_known: known_session_id,
+                    cycle,
+                    stream,
+                    turn_aborted: false,
+                };
+            }
+            set_busy_record(state, Some(session_id.to_string()), at)
+        }
+        Ownership::Candidate {
+            session_id: own,
+            previous_known,
+            ..
+        } => {
+            if own == session_id {
+                // Refresh: a new busy begins a new turn — abort gate re-arms.
+                state.ownership = Ownership::Candidate {
+                    session_id: own.clone(),
+                    previous_known,
+                    cycle,
+                    stream,
+                    turn_aborted: false,
+                };
+                set_busy_record(state, Some(own), at)
+            } else {
+                state.ownership = Ownership::Ambiguous {
+                    known_session_id: previous_known,
+                    blocked: unique_sorted(vec![own, session_id.to_string()]),
+                };
+                set_busy_record(state, None, at)
+            }
+        }
+        Ownership::KnownBusy {
+            session_id: own, ..
+        } => {
+            if own == session_id {
+                state.ownership = Ownership::KnownBusy {
+                    session_id: own.clone(),
+                    cycle,
+                    stream,
+                    turn_aborted: false,
+                };
+                set_busy_record(state, Some(own), at)
+            } else {
+                state.ownership = Ownership::Ambiguous {
+                    known_session_id: Some(own.clone()),
+                    blocked: unique_sorted(vec![own, session_id.to_string()]),
+                };
+                set_busy_record(state, None, at)
+            }
+        }
+        Ownership::Ambiguous {
+            known_session_id,
+            mut blocked,
+        } => {
+            if !blocked.iter().any(|b| b == session_id) {
+                blocked.push(session_id.to_string());
+                blocked = unique_sorted(blocked);
+            }
+            state.ownership = Ownership::Ambiguous {
+                known_session_id,
+                blocked,
+            };
+            set_busy_record(state, None, at)
+        }
+        // Node drops busy while awaiting association.
+        Ownership::AwaitingAssociation { .. } => Vec::new(),
+    }
+}
+
+/// Collapse a snapshot's status list onto roots — busy child wins over idle
+/// root (mirror of Node `classifyKnownSnapshotStatuses`) — then keep the
+/// sorted unique busy|retry roots. A literal idle entry is treated as
+/// absent (absence == idle, derives from opencode 1.18.11).
+fn collapse_busy_roots(
+    state: &TerminalOpencode,
+    statuses: &[(String, OpencodeStatus)],
+) -> Vec<String> {
+    let mut collapsed: HashMap<String, OpencodeStatus> = HashMap::new();
+    for (session_id, status) in statuses {
+        let root = resolve_root(state, session_id).to_string();
+        match collapsed.get(&root) {
+            // Only a busy entry may overwrite a busy entry.
+            Some(existing)
+                if *existing != OpencodeStatus::Idle && *status == OpencodeStatus::Idle => {}
+            _ => {
+                collapsed.insert(root, *status);
+            }
+        }
+    }
+    let mut busy_roots: Vec<String> = collapsed
+        .into_iter()
+        .filter(|(_, status)| *status != OpencodeStatus::Idle)
+        .map(|(root, _)| root)
+        .collect();
+    busy_roots.sort();
+    busy_roots
+}
+
+/// Snapshot reducer (Node `reduceSnapshot` branch table). `busy_roots` is
+/// sorted unique.
+fn reduce_snapshot(
+    state: &mut TerminalOpencode,
+    ledger: &mut TurnCompletionLedger,
+    busy_roots: Vec<String>,
+    cycle: u64,
+    stream: u64,
+    at: i64,
+) -> Vec<OpencodeEffect> {
+    match state.ownership.clone() {
+        Ownership::Ambiguous {
+            known_session_id, ..
+        } => {
+            if busy_roots.is_empty() {
+                state.ownership = Ownership::Quiet { known_session_id };
+                return clear_record(state, false);
+            }
+            if busy_roots.len() == 1 {
+                if let Some(known) = &known_session_id {
+                    if *known == busy_roots[0] {
+                        let known = known.clone();
+                        state.ownership = Ownership::KnownBusy {
+                            session_id: known.clone(),
+                            cycle,
+                            stream,
+                            turn_aborted: false,
+                        };
+                        return set_busy_record(state, Some(known), at);
+                    }
+                } else {
+                    // Deliberately silent (Node reduceSnapshot:296-307).
+                    state.ownership = Ownership::Candidate {
+                        session_id: busy_roots[0].clone(),
+                        previous_known: None,
+                        cycle,
+                        stream,
+                        turn_aborted: false,
+                    };
+                    return Vec::new();
+                }
+            }
+            // Recompute the blocked set (recompute, not union).
+            state.ownership = Ownership::Ambiguous {
+                known_session_id,
+                blocked: busy_roots,
+            };
+            Vec::new()
+        }
+        Ownership::KnownBusy {
+            session_id: own,
+            turn_aborted,
+            ..
+        } => {
+            if busy_roots.is_empty() {
+                state.ownership = Ownership::Quiet {
+                    known_session_id: Some(own.clone()),
+                };
+                let mut effects = clear_record(state, false);
+                if !turn_aborted {
+                    let seq = ledger.record_turn_completion(&state.terminal_id, at);
+                    effects.push(TrackerEffect::TurnComplete {
+                        terminal_id: state.terminal_id.clone(),
+                        session_id: Some(own),
+                        at,
+                        completion_seq: seq,
+                    });
+                }
+                effects
+            } else if busy_roots.len() == 1 && busy_roots[0] == own {
+                state.ownership = Ownership::KnownBusy {
+                    session_id: own.clone(),
+                    cycle,
+                    stream,
+                    turn_aborted: false,
+                };
+                set_busy_record(state, Some(own), at)
+            } else {
+                let mut blocked = busy_roots;
+                blocked.push(own.clone());
+                state.ownership = Ownership::Ambiguous {
+                    known_session_id: Some(own),
+                    blocked: unique_sorted(blocked),
+                };
+                set_busy_record(state, None, at)
+            }
+        }
+        Ownership::Candidate {
+            session_id: own,
+            previous_known,
+            turn_aborted,
+            ..
+        } => {
+            if busy_roots.is_empty() {
+                state.ownership = Ownership::AwaitingAssociation {
+                    session_id: own,
+                    previous_known,
+                    completed_at: at,
+                    aborted: turn_aborted,
+                };
+                clear_record(state, false)
+            } else if busy_roots.len() == 1 && busy_roots[0] == own {
+                state.ownership = Ownership::Candidate {
+                    session_id: own.clone(),
+                    previous_known,
+                    cycle,
+                    stream,
+                    turn_aborted: false,
+                };
+                set_busy_record(state, Some(own), at)
+            } else {
+                let mut blocked = busy_roots;
+                blocked.push(own);
+                state.ownership = Ownership::Ambiguous {
+                    known_session_id: previous_known,
+                    blocked: unique_sorted(blocked),
+                };
+                set_busy_record(state, None, at)
+            }
+        }
+        Ownership::AwaitingAssociation { .. } => Vec::new(),
+        Ownership::Quiet { known_session_id } => {
+            if busy_roots.is_empty() {
+                return clear_record(state, false);
+            }
+            if let Some(known) = known_session_id {
+                if busy_roots.len() == 1 {
+                    if busy_roots[0] == known {
+                        state.ownership = Ownership::KnownBusy {
+                            session_id: known.clone(),
+                            cycle,
+                            stream,
+                            turn_aborted: false,
+                        };
+                        return set_busy_record(state, Some(known), at);
+                    }
+                    // Session switched during an SSE reconnect gap, visible
+                    // only in the snapshot (Node reduceSnapshot:406-417).
+                    let foreign = busy_roots[0].clone();
+                    state.ownership = Ownership::Candidate {
+                        session_id: foreign.clone(),
+                        previous_known: Some(known),
+                        cycle,
+                        stream,
+                        turn_aborted: false,
+                    };
+                    return set_busy_record(state, Some(foreign), at);
+                }
+                state.ownership = Ownership::Ambiguous {
+                    known_session_id: Some(known),
+                    blocked: busy_roots,
+                };
+                set_busy_record(state, None, at)
+            } else if busy_roots.len() == 1 {
+                let candidate = busy_roots[0].clone();
+                state.ownership = Ownership::Candidate {
+                    session_id: candidate.clone(),
+                    previous_known: None,
+                    cycle,
+                    stream,
+                    turn_aborted: false,
+                };
+                set_busy_record(state, Some(candidate), at)
+            } else {
+                state.ownership = Ownership::Ambiguous {
+                    known_session_id: None,
+                    blocked: busy_roots,
+                };
+                set_busy_record(state, None, at)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(session_id: Option<&str>, at: i64) -> OpencodeActivityRecord {
+        OpencodeActivityRecord {
+            terminal_id: "t1".to_string(),
+            phase: OpencodePhase::Busy,
+            updated_at: at,
+            session_id: session_id.map(str::to_string),
+        }
+    }
+
+    fn upsert(record: OpencodeActivityRecord) -> OpencodeEffect {
+        TrackerEffect::Changed {
+            upsert: vec![record],
+            remove: vec![],
+        }
+    }
+
+    fn remove() -> OpencodeEffect {
+        TrackerEffect::Changed {
+            upsert: vec![],
+            remove: vec!["t1".to_string()],
+        }
+    }
+
+    fn turn_complete(session_id: &str, at: i64, seq: i64) -> OpencodeEffect {
+        TrackerEffect::TurnComplete {
+            terminal_id: "t1".to_string(),
+            session_id: Some(session_id.to_string()),
+            at,
+            completion_seq: seq,
+        }
+    }
+
+    fn completions(effects: &[OpencodeEffect]) -> Vec<i64> {
+        effects
+            .iter()
+            .filter_map(|effect| match effect {
+                TrackerEffect::TurnComplete { completion_seq, .. } => Some(*completion_seq),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn completed_turn_emits_remove_then_turn_complete() {
+        let mut tracker = OpencodeActivityTracker::new();
+        assert!(tracker.track_terminal("t1", Some("ses-r"), 0).is_empty());
+        assert_eq!(
+            tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100),
+            vec![upsert(rec(Some("ses-r"), 100))]
+        );
+        // D7 ordering: the remove frame precedes the completion.
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-r", 1, 1, 200),
+            vec![remove(), turn_complete("ses-r", 200, 1)]
+        );
+    }
+
+    #[test]
+    fn double_session_idle_is_deduped() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        assert_eq!(
+            completions(&tracker.note_session_idle("t1", "ses-r", 1, 1, 200)),
+            vec![1]
+        );
+        // Structural dedupe (D2): the state is already Quiet — no effects.
+        assert!(tracker.note_session_idle("t1", "ses-r", 1, 1, 207).is_empty());
+    }
+
+    #[test]
+    fn session_status_idle_then_session_idle_yields_one_completion() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        let first = tracker.note_status("t1", "ses-r", OpencodeStatus::Idle, 1, 1, 200);
+        assert_eq!(
+            first,
+            vec![remove(), turn_complete("ses-r", 200, 1)],
+            "session.status{{idle}} completes the turn"
+        );
+        // The spike's 7ms twin: session.idle trails session.status{idle}.
+        assert!(tracker.note_session_idle("t1", "ses-r", 1, 1, 207).is_empty());
+        assert_eq!(tracker.list_latest_completions().len(), 1);
+    }
+
+    #[test]
+    fn retry_status_counts_as_busy() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        // D6: retry from quiet(known) enters KnownBusy and upserts the record.
+        assert_eq!(
+            tracker.note_status("t1", "ses-r", OpencodeStatus::Retry, 1, 1, 100),
+            vec![upsert(rec(Some("ses-r"), 100))]
+        );
+        // A real turn was armed: the matching idle completes it.
+        assert_eq!(
+            completions(&tracker.note_session_idle("t1", "ses-r", 1, 1, 200)),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn child_idle_is_suppressed_and_child_busy_remaps_to_root() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        assert!(tracker
+            .note_session_created("t1", "ses-c", Some("ses-r"), 110)
+            .is_empty());
+        // Child busy remaps to the root: session stays ses-r, so the public
+        // shape is unchanged (dedupe) but the stored record refreshes.
+        assert!(tracker
+            .note_status("t1", "ses-c", OpencodeStatus::Busy, 1, 1, 120)
+            .is_empty());
+        assert_eq!(tracker.list(), vec![rec(Some("ses-r"), 120)]);
+        // Child idle is SUPPRESSED (D5): no effects, the record survives.
+        assert!(tracker.note_session_idle("t1", "ses-c", 1, 1, 130).is_empty());
+        assert_eq!(tracker.list(), vec![rec(Some("ses-r"), 120)]);
+        // The parent's own idle ends the turn: exactly one completion.
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-r", 1, 1, 200),
+            vec![remove(), turn_complete("ses-r", 200, 1)]
+        );
+    }
+
+    #[test]
+    fn candidate_completion_defers_to_bind_session() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", None, 0);
+        assert_eq!(
+            tracker.note_status("t1", "ses-x", OpencodeStatus::Busy, 1, 1, 100),
+            vec![upsert(rec(Some("ses-x"), 100))]
+        );
+        // Candidate turn end: remove only, completion deferred.
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-x", 1, 1, 200),
+            vec![remove()]
+        );
+        // The bind mints the deferred completion at the STORED idle timestamp.
+        assert_eq!(
+            tracker.bind_session("t1", "ses-x", 500),
+            vec![turn_complete("ses-x", 200, 1)]
+        );
+    }
+
+    #[test]
+    fn ambiguous_is_conservative_no_completions() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", None, 0);
+        tracker.note_status("t1", "ses-a", OpencodeStatus::Busy, 1, 1, 100);
+        // A second busy session: ambiguous, the record demotes to session-less.
+        assert_eq!(
+            tracker.note_status("t1", "ses-b", OpencodeStatus::Busy, 1, 1, 110),
+            vec![upsert(rec(None, 110))]
+        );
+        // First idle drops ses-a from the blocked set; record stays (no
+        // public change: session already None).
+        assert!(tracker.note_session_idle("t1", "ses-a", 1, 1, 120).is_empty());
+        assert_eq!(tracker.list(), vec![rec(None, 120)]);
+        // Last idle empties the blocked set: record removed, still silent.
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-b", 1, 1, 130),
+            vec![remove()]
+        );
+        assert!(tracker.list_latest_completions().is_empty());
+    }
+
+    #[test]
+    fn snapshot_empty_completes_a_known_busy_turn() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        // Snapshot path B: an empty snapshot ends the known-busy turn.
+        assert_eq!(
+            tracker.note_snapshot("t1", &[], 1, 1, 200),
+            vec![remove(), turn_complete("ses-r", 200, 1)]
+        );
+    }
+
+    #[test]
+    fn snapshot_single_foreign_busy_from_quiet_known_enters_candidate() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        // Session switched during an SSE reconnect gap, visible only in the
+        // snapshot (Node reduceSnapshot:406-417): candidate, not silence.
+        let statuses = vec![("ses-x".to_string(), OpencodeStatus::Busy)];
+        assert_eq!(
+            tracker.note_snapshot("t1", &statuses, 1, 1, 100),
+            vec![upsert(rec(Some("ses-x"), 100))]
+        );
+        // Candidate defers: the matching idle is quiet…
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-x", 1, 1, 200),
+            vec![remove()]
+        );
+        // …and the bind mints the deferred completion.
+        assert_eq!(
+            tracker.bind_session("t1", "ses-x", 300),
+            vec![turn_complete("ses-x", 200, 1)]
+        );
+    }
+
+    #[test]
+    fn stale_cycle_idle_is_ignored() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        // Wrong cycle, then wrong stream: both leave KnownBusy intact.
+        assert!(tracker.note_session_idle("t1", "ses-r", 2, 1, 150).is_empty());
+        assert!(tracker.note_session_idle("t1", "ses-r", 1, 2, 160).is_empty());
+        assert_eq!(tracker.list(), vec![rec(Some("ses-r"), 100)]);
+        // The matching idle still completes the turn.
+        assert_eq!(
+            completions(&tracker.note_session_idle("t1", "ses-r", 1, 1, 200)),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn deadman_expiry_removes_silently() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.set_busy_deadman_ms(1000);
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 0);
+        assert_eq!(tracker.next_deadline(), Some(1000));
+        assert!(
+            tracker.expire(1000).is_empty(),
+            "not yet silent PAST the window"
+        );
+        // Silence past the window: record dropped, NO completion (D8(e)).
+        assert_eq!(tracker.expire(2000), vec![remove()]);
+        assert!(tracker.list_latest_completions().is_empty());
+        assert_eq!(tracker.next_deadline(), None);
+    }
+}

--- a/crates/freshell-activity/src/opencode.rs
+++ b/crates/freshell-activity/src/opencode.rs
@@ -260,6 +260,12 @@ impl OpencodeActivityTracker {
                 if aborted {
                     return Vec::new();
                 }
+                if !state.pending_permissions.is_empty() {
+                    // Mid-pause turn end: the pause was the episode's bell —
+                    // the deferred completion is swallowed (D3).
+                    state.pending_permissions.clear();
+                    return Vec::new();
+                }
                 // DEFERRED completion (Node confirmOpencodeAssociation):
                 // stamped at the STORED turn-end instant, not the bind's.
                 let seq = ledger.record_turn_completion(&state.terminal_id, completed_at);
@@ -343,9 +349,7 @@ impl OpencodeActivityTracker {
         match parent_id {
             Some(parent) => {
                 let root = resolve_root(state, parent).to_string();
-                state
-                    .session_roots
-                    .insert(parent.to_string(), root.clone());
+                state.session_roots.insert(parent.to_string(), root.clone());
                 state
                     .session_roots
                     .insert(session_id.to_string(), root.clone());
@@ -411,7 +415,14 @@ impl OpencodeActivityTracker {
     ) -> Vec<OpencodeEffect> {
         // Same routing as a status idle edge; dedupe is structural (D2):
         // the first edge lands the machine in Quiet, the twin no-ops.
-        self.note_status(terminal_id, session_id, OpencodeStatus::Idle, cycle, stream, at)
+        self.note_status(
+            terminal_id,
+            session_id,
+            OpencodeStatus::Idle,
+            cycle,
+            stream,
+            at,
+        )
     }
 
     /// `/session/status` snapshot (absence == idle; a literal idle entry is
@@ -433,7 +444,161 @@ impl OpencodeActivityTracker {
         reduce_snapshot(state, ledger, busy_roots, cycle, stream, at)
     }
 
-    /// PTY exit: drop the whole state.
+    /// `session.error` — and Task 9's abort-marked `message.updated`, which
+    /// the lane translates into this SAME SessionError-shaped call (abort
+    /// window W2, derives from opencode 1.18.11). Only `MessageAbortedError`
+    /// on the owned root's OWN turn (matching id+cycle+stream) arms the
+    /// per-turn abort gate (D1); every other name/state is a no-op — failed
+    /// turns ring like completed turns, and trailing errors on quiet states
+    /// change nothing. Child `session.error` is ignored: the raw sessionID
+    /// must equal the owned root, no root-remapping for aborts (D5). No
+    /// effects, ever.
+    pub fn note_error(
+        &mut self,
+        terminal_id: &str,
+        session_id: &str,
+        error_name: &str,
+        cycle: u64,
+        stream: u64,
+        at: i64,
+    ) -> Vec<OpencodeEffect> {
+        let Some(state) = self.states.get_mut(terminal_id) else {
+            return Vec::new();
+        };
+        state.last_observed_at = at;
+        if error_name != "MessageAbortedError" {
+            return Vec::new();
+        }
+        if resolve_root(state, session_id) != session_id {
+            return Vec::new();
+        }
+        match &mut state.ownership {
+            Ownership::KnownBusy {
+                session_id: own,
+                cycle: c,
+                stream: st,
+                turn_aborted,
+            }
+            | Ownership::Candidate {
+                session_id: own,
+                cycle: c,
+                stream: st,
+                turn_aborted,
+                ..
+            } if own.as_str() == session_id && *c == cycle && *st == stream => {
+                *turn_aborted = true;
+            }
+            _ => {}
+        }
+        Vec::new()
+    }
+
+    /// `permission.asked`: the turn pauses on a human. Children CAN ask —
+    /// the event is stamped with the CHILD session id while the parent turn
+    /// blocks on it (opencode 1.18.11, validation pass 2026-08-03) — so the
+    /// asker is root-resolved first. Arms when the resolved root is the
+    /// owned session under `KnownBusy` OR `Candidate` (candidate arming,
+    /// D3: the single busy unbound session on the pane's own per-pane
+    /// endpoint — first-turn asks must ring). Foreign/unresolvable ids and
+    /// Quiet/Ambiguous/AwaitingAssociation states are no-ops. Only a NEWLY
+    /// inserted permission id arms — a duplicate asked never re-arms.
+    /// Effect ORDER is load-bearing (D7): record removal FIRST (demote),
+    /// attention boundary SECOND.
+    pub fn note_permission_asked(
+        &mut self,
+        terminal_id: &str,
+        session_id: &str,
+        permission_id: &str,
+        at: i64,
+    ) -> Vec<OpencodeEffect> {
+        let Some(state) = self.states.get_mut(terminal_id) else {
+            return Vec::new();
+        };
+        state.last_observed_at = at;
+        let root = resolve_root(state, session_id).to_string();
+        let owned = match &state.ownership {
+            Ownership::KnownBusy {
+                session_id: own, ..
+            }
+            | Ownership::Candidate {
+                session_id: own, ..
+            } => *own == root,
+            _ => false,
+        };
+        if !owned {
+            return Vec::new();
+        }
+        let newly_inserted = state.pending_permissions.insert(permission_id.to_string());
+        if !newly_inserted {
+            return Vec::new();
+        }
+        let mut effects = clear_record(state, false);
+        effects.push(TrackerEffect::AttentionBoundary {
+            terminal_id: state.terminal_id.clone(),
+            at,
+        });
+        effects
+    }
+
+    /// `permission.replied`: the pause ends. Unknown ids are no-ops. When
+    /// the LAST pending id clears and the turn is still owned
+    /// (`KnownBusy`/`Candidate`), the busy record is restored immediately —
+    /// busy cancels the armed gate window via `note_phase(Busy)` in the
+    /// frame mapper.
+    pub fn note_permission_replied(
+        &mut self,
+        terminal_id: &str,
+        permission_id: &str,
+        at: i64,
+    ) -> Vec<OpencodeEffect> {
+        let Some(state) = self.states.get_mut(terminal_id) else {
+            return Vec::new();
+        };
+        state.last_observed_at = at;
+        if !state.pending_permissions.remove(permission_id) {
+            return Vec::new();
+        }
+        if !state.pending_permissions.is_empty() {
+            return Vec::new();
+        }
+        match state.ownership.clone() {
+            Ownership::KnownBusy { session_id, .. } | Ownership::Candidate { session_id, .. } => {
+                set_busy_record(state, Some(session_id), at)
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    /// Death-bell engagement extension (D4): a pane blocked on a permission
+    /// whose process dies spontaneously must ring. Read by the hub's Exit
+    /// arm BEFORE `note_exit` (audit-A17 ordering, same as codex).
+    pub fn has_pending_permissions(&self, terminal_id: &str) -> bool {
+        self.states
+            .get(terminal_id)
+            .map(|s| !s.pending_permissions.is_empty())
+            .unwrap_or(false)
+    }
+
+    /// Candidate/ambiguous ownership never death-rings (D4): unconfirmed
+    /// identity stays conservatively silent even with a candidate-armed
+    /// pause pending. `AwaitingAssociation` is the candidate pause's
+    /// continuation (the claim survives into it, D3), so it blocks too.
+    pub fn blocks_death_bell(&self, terminal_id: &str) -> bool {
+        self.states
+            .get(terminal_id)
+            .map(|s| {
+                matches!(
+                    s.ownership,
+                    Ownership::Candidate { .. }
+                        | Ownership::Ambiguous { .. }
+                        | Ownership::AwaitingAssociation { .. }
+                )
+            })
+            .unwrap_or(false)
+    }
+
+    /// PTY exit: drop the whole state (`pending_permissions` goes with it —
+    /// the hub reads [`Self::has_pending_permissions`] BEFORE calling this).
     pub fn note_exit(&mut self, terminal_id: &str) -> Vec<OpencodeEffect> {
         match self.states.remove(terminal_id) {
             Some(state) if state.record.is_some() => vec![TrackerEffect::Changed {
@@ -488,6 +653,20 @@ fn reduce_idle_edge(
             state.ownership = Ownership::Quiet {
                 known_session_id: Some(own.clone()),
             };
+            // Mid-pause turn end: the pause was the episode's bell — NEVER
+            // a second completion (D3). The record is already absent while
+            // paused, so the only frame question is the abort cancel.
+            if !state.pending_permissions.is_empty() {
+                state.pending_permissions.clear();
+                if turn_aborted {
+                    // Force-emit the remove: at the gate it cancels the
+                    // armed window (note_exit) — total silence.
+                    return clear_record(state, true);
+                }
+                // Leave the armed window to fire once, or stay silent if
+                // it already rang.
+                return Vec::new();
+            }
             // D7 ordering: remove BEFORE TurnComplete.
             let mut effects = clear_record(state, false);
             if !turn_aborted {
@@ -515,6 +694,14 @@ fn reduce_idle_edge(
                 completed_at: at,
                 aborted: turn_aborted,
             };
+            if turn_aborted && !state.pending_permissions.is_empty() {
+                // Aborted mid-pause: same total-silence contract as the
+                // KnownBusy arm — force-emit the cancel.
+                state.pending_permissions.clear();
+                return clear_record(state, true);
+            }
+            // A non-aborted pause claim SURVIVES into AwaitingAssociation
+            // so the DEFERRED completion is swallowed at bind_session (D3).
             clear_record(state, false)
         }
         Ownership::Ambiguous {
@@ -574,7 +761,9 @@ fn reduce_busy_edge(
             ..
         } => {
             if own == session_id {
-                // Refresh: a new busy begins a new turn — abort gate re-arms.
+                // Refresh: a new busy begins a new turn — abort gate
+                // re-arms; a pause resumes out-of-band (D3).
+                state.pending_permissions.clear();
                 state.ownership = Ownership::Candidate {
                     session_id: own.clone(),
                     previous_known,
@@ -595,6 +784,8 @@ fn reduce_busy_edge(
             session_id: own, ..
         } => {
             if own == session_id {
+                // Refresh: abort gate re-arms; a pause resumes out-of-band.
+                state.pending_permissions.clear();
                 state.ownership = Ownership::KnownBusy {
                     session_id: own.clone(),
                     cycle,
@@ -716,6 +907,16 @@ fn reduce_snapshot(
                 state.ownership = Ownership::Quiet {
                     known_session_id: Some(own.clone()),
                 };
+                // Mid-pause turn end: mirror of the idle-edge hardening —
+                // the pause was the episode's bell, NEVER a second
+                // completion (D3).
+                if !state.pending_permissions.is_empty() {
+                    state.pending_permissions.clear();
+                    if turn_aborted {
+                        return clear_record(state, true);
+                    }
+                    return Vec::new();
+                }
                 let mut effects = clear_record(state, false);
                 if !turn_aborted {
                     let seq = ledger.record_turn_completion(&state.terminal_id, at);
@@ -728,6 +929,8 @@ fn reduce_snapshot(
                 }
                 effects
             } else if busy_roots.len() == 1 && busy_roots[0] == own {
+                // Refresh: abort gate re-arms; a pause resumes out-of-band.
+                state.pending_permissions.clear();
                 state.ownership = Ownership::KnownBusy {
                     session_id: own.clone(),
                     cycle,
@@ -758,8 +961,18 @@ fn reduce_snapshot(
                     completed_at: at,
                     aborted: turn_aborted,
                 };
+                if turn_aborted && !state.pending_permissions.is_empty() {
+                    // Aborted mid-pause: force-emit the cancel (mirror of
+                    // the idle-edge hardening).
+                    state.pending_permissions.clear();
+                    return clear_record(state, true);
+                }
+                // A non-aborted pause claim survives into
+                // AwaitingAssociation (swallowed at bind_session, D3).
                 clear_record(state, false)
             } else if busy_roots.len() == 1 && busy_roots[0] == own {
+                // Refresh: abort gate re-arms; a pause resumes out-of-band.
+                state.pending_permissions.clear();
                 state.ownership = Ownership::Candidate {
                     session_id: own.clone(),
                     previous_known,
@@ -868,6 +1081,13 @@ mod tests {
         }
     }
 
+    fn boundary(at: i64) -> OpencodeEffect {
+        TrackerEffect::AttentionBoundary {
+            terminal_id: "t1".to_string(),
+            at,
+        }
+    }
+
     fn completions(effects: &[OpencodeEffect]) -> Vec<i64> {
         effects
             .iter()
@@ -903,7 +1123,9 @@ mod tests {
             vec![1]
         );
         // Structural dedupe (D2): the state is already Quiet — no effects.
-        assert!(tracker.note_session_idle("t1", "ses-r", 1, 1, 207).is_empty());
+        assert!(tracker
+            .note_session_idle("t1", "ses-r", 1, 1, 207)
+            .is_empty());
     }
 
     #[test]
@@ -918,7 +1140,9 @@ mod tests {
             "session.status{{idle}} completes the turn"
         );
         // The spike's 7ms twin: session.idle trails session.status{idle}.
-        assert!(tracker.note_session_idle("t1", "ses-r", 1, 1, 207).is_empty());
+        assert!(tracker
+            .note_session_idle("t1", "ses-r", 1, 1, 207)
+            .is_empty());
         assert_eq!(tracker.list_latest_completions().len(), 1);
     }
 
@@ -953,7 +1177,9 @@ mod tests {
             .is_empty());
         assert_eq!(tracker.list(), vec![rec(Some("ses-r"), 120)]);
         // Child idle is SUPPRESSED (D5): no effects, the record survives.
-        assert!(tracker.note_session_idle("t1", "ses-c", 1, 1, 130).is_empty());
+        assert!(tracker
+            .note_session_idle("t1", "ses-c", 1, 1, 130)
+            .is_empty());
         assert_eq!(tracker.list(), vec![rec(Some("ses-r"), 120)]);
         // The parent's own idle ends the turn: exactly one completion.
         assert_eq!(
@@ -994,7 +1220,9 @@ mod tests {
         );
         // First idle drops ses-a from the blocked set; record stays (no
         // public change: session already None).
-        assert!(tracker.note_session_idle("t1", "ses-a", 1, 1, 120).is_empty());
+        assert!(tracker
+            .note_session_idle("t1", "ses-a", 1, 1, 120)
+            .is_empty());
         assert_eq!(tracker.list(), vec![rec(None, 120)]);
         // Last idle empties the blocked set: record removed, still silent.
         assert_eq!(
@@ -1045,8 +1273,12 @@ mod tests {
         tracker.track_terminal("t1", Some("ses-r"), 0);
         tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
         // Wrong cycle, then wrong stream: both leave KnownBusy intact.
-        assert!(tracker.note_session_idle("t1", "ses-r", 2, 1, 150).is_empty());
-        assert!(tracker.note_session_idle("t1", "ses-r", 1, 2, 160).is_empty());
+        assert!(tracker
+            .note_session_idle("t1", "ses-r", 2, 1, 150)
+            .is_empty());
+        assert!(tracker
+            .note_session_idle("t1", "ses-r", 1, 2, 160)
+            .is_empty());
         assert_eq!(tracker.list(), vec![rec(Some("ses-r"), 100)]);
         // The matching idle still completes the turn.
         assert_eq!(
@@ -1070,5 +1302,314 @@ mod tests {
         assert_eq!(tracker.expire(2000), vec![remove()]);
         assert!(tracker.list_latest_completions().is_empty());
         assert_eq!(tracker.next_deadline(), None);
+    }
+
+    #[test]
+    fn abort_then_idle_clears_silently() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        // D1: the abort observation only arms the per-turn flag — no effects.
+        assert!(tracker
+            .note_error("t1", "ses-r", "MessageAbortedError", 1, 1, 150)
+            .is_empty());
+        // The idle clears busy silently: remove only, no TurnComplete.
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-r", 1, 1, 200),
+            vec![remove()]
+        );
+        assert!(tracker.list_latest_completions().is_empty());
+        // Second idle: structural dedupe (D2) — nothing.
+        assert!(tracker
+            .note_session_idle("t1", "ses-r", 1, 1, 207)
+            .is_empty());
+    }
+
+    #[test]
+    fn w2_abort_marker_gates_like_session_error() {
+        // The message.updated abort marker (abort window W2, opencode
+        // 1.18.11) reaches the tracker through the SAME note_error entry:
+        // Task 9's translate maps the marker to a SessionError-shaped call.
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        // The marker-sourced abort observation: no effects.
+        assert!(tracker
+            .note_error("t1", "ses-r", "MessageAbortedError", 1, 1, 160)
+            .is_empty());
+        // Idle: remove only, no TurnComplete.
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-r", 1, 1, 200),
+            vec![remove()]
+        );
+        assert!(tracker.list_latest_completions().is_empty());
+        // Second idle: nothing.
+        assert!(tracker
+            .note_session_idle("t1", "ses-r", 1, 1, 207)
+            .is_empty());
+    }
+
+    #[test]
+    fn failed_turn_rings_and_trailing_error_is_noop() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        // Any error name other than MessageAbortedError changes nothing:
+        // failed turns ring like completed turns (D1).
+        assert!(tracker
+            .note_error("t1", "ses-r", "UnknownError", 1, 1, 150)
+            .is_empty());
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-r", 1, 1, 200),
+            vec![remove(), turn_complete("ses-r", 200, 1)]
+        );
+        // Trailing error on the now-quiet state: no effects, no state change.
+        assert!(tracker
+            .note_error("t1", "ses-r", "MessageAbortedError", 1, 1, 210)
+            .is_empty());
+        assert!(tracker.list().is_empty());
+        // Ownership stayed Quiet{known}: the next turn completes normally
+        // (the trailing abort did not poison it).
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 300);
+        assert_eq!(
+            completions(&tracker.note_session_idle("t1", "ses-r", 1, 1, 400)),
+            vec![2]
+        );
+    }
+
+    #[test]
+    fn child_abort_does_not_gate_the_root() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        tracker.note_session_created("t1", "ses-c", Some("ses-r"), 110);
+        // Child session.error is ignored: the raw sessionID must equal the
+        // owned root (D5), and ses-c root-resolves to ses-r ≠ ses-c.
+        assert!(tracker
+            .note_error("t1", "ses-c", "MessageAbortedError", 1, 1, 150)
+            .is_empty());
+        // The parent's own idle still completes the turn.
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-r", 1, 1, 200),
+            vec![remove(), turn_complete("ses-r", 200, 1)]
+        );
+    }
+
+    #[test]
+    fn permission_asked_demotes_then_arms_once() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        // D3/D7 ordering (load-bearing): record removal FIRST, attention
+        // boundary SECOND.
+        assert_eq!(
+            tracker.note_permission_asked("t1", "ses-r", "perm-1", 150),
+            vec![remove(), boundary(150)]
+        );
+        // A duplicate asked never re-arms: one boundary per pause.
+        assert!(tracker
+            .note_permission_asked("t1", "ses-r", "perm-1", 160)
+            .is_empty());
+    }
+
+    #[test]
+    fn child_permission_asked_resolves_to_root_and_arms() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        tracker.note_session_created("t1", "ses-c", Some("ses-r"), 110);
+        // Children CAN ask (the event is stamped with the CHILD session id
+        // and the parent turn blocks on it): root-resolve, then arm (D3).
+        assert_eq!(
+            tracker.note_permission_asked("t1", "ses-c", "perm-1", 150),
+            vec![remove(), boundary(150)]
+        );
+        // A foreign, unregistered id resolves to itself and never matches.
+        assert!(tracker
+            .note_permission_asked("t1", "ses-z", "perm-2", 160)
+            .is_empty());
+    }
+
+    #[test]
+    fn candidate_pause_arms_and_deferred_completion_is_swallowed_at_bind() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", None, 0);
+        // Busy with no binding: Candidate ownership.
+        assert_eq!(
+            tracker.note_status("t1", "ses-x", OpencodeStatus::Busy, 1, 1, 100),
+            vec![upsert(rec(Some("ses-x"), 100))]
+        );
+        // Candidate arming (D3): the single busy unbound session on the
+        // pane's own per-pane endpoint — first-turn asks must ring.
+        assert_eq!(
+            tracker.note_permission_asked("t1", "ses-x", "perm-1", 150),
+            vec![remove(), boundary(150)]
+        );
+        // Idle edge: AwaitingAssociation with the pause claim intact (the
+        // record was already removed at the ask — no effects here).
+        assert!(tracker
+            .note_session_idle("t1", "ses-x", 1, 1, 200)
+            .is_empty());
+        assert!(tracker.has_pending_permissions("t1"));
+        // Bind: NO deferred TurnComplete — the pause was the episode's bell
+        // (mid-pause turn end, D3).
+        assert!(tracker.bind_session("t1", "ses-x", 300).is_empty());
+        assert!(!tracker.has_pending_permissions("t1"));
+        assert!(tracker.list_latest_completions().is_empty());
+        // State is Quiet{known: Some(ses-x)}: the next busy+idle turn
+        // completes normally (KnownBusy path, first ledger completion).
+        tracker.note_status("t1", "ses-x", OpencodeStatus::Busy, 2, 1, 400);
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-x", 2, 1, 500),
+            vec![remove(), turn_complete("ses-x", 500, 1)]
+        );
+    }
+
+    #[test]
+    fn permission_replied_resumes_busy() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        tracker.note_permission_asked("t1", "ses-r", "perm-1", 150);
+        // The reply empties the set: the busy record is restored
+        // immediately with the OWNED session (KnownBusy ownership).
+        assert_eq!(
+            tracker.note_permission_replied("t1", "perm-1", 180),
+            vec![upsert(rec(Some("ses-r"), 180))]
+        );
+        // An unknown id is a no-op.
+        assert!(tracker
+            .note_permission_replied("t1", "perm-9", 185)
+            .is_empty());
+
+        // Repeat under Candidate ownership (re-track with no binding; the
+        // re-track drops the restored record).
+        assert_eq!(tracker.track_terminal("t1", None, 300), vec![remove()]);
+        tracker.note_status("t1", "ses-x", OpencodeStatus::Busy, 2, 1, 310);
+        tracker.note_permission_asked("t1", "ses-x", "perm-2", 320);
+        assert_eq!(
+            tracker.note_permission_replied("t1", "perm-2", 330),
+            vec![upsert(rec(Some("ses-x"), 330))]
+        );
+    }
+
+    #[test]
+    fn abort_mid_pause_force_emits_the_cancel() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        tracker.note_permission_asked("t1", "ses-r", "perm-1", 150);
+        assert!(tracker
+            .note_error("t1", "ses-r", "MessageAbortedError", 1, 1, 160)
+            .is_empty());
+        // The remove frame is FORCE-emitted despite the absent record: the
+        // gate's note_exit cancels the armed window — total silence. No
+        // TurnComplete, no boundary.
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-r", 1, 1, 200),
+            vec![remove()]
+        );
+        assert!(tracker.list_latest_completions().is_empty());
+        assert!(!tracker.has_pending_permissions("t1"));
+
+        // Repeat from Candidate ownership: the aborted candidate parks in
+        // AwaitingAssociation{aborted} with the same force-emit.
+        assert!(tracker.track_terminal("t1", None, 300).is_empty());
+        tracker.note_status("t1", "ses-x", OpencodeStatus::Busy, 2, 1, 310);
+        tracker.note_permission_asked("t1", "ses-x", "perm-2", 320);
+        assert!(tracker
+            .note_error("t1", "ses-x", "MessageAbortedError", 2, 1, 330)
+            .is_empty());
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-x", 2, 1, 400),
+            vec![remove()]
+        );
+        assert!(!tracker.has_pending_permissions("t1"));
+        // The bind of the aborted awaiting turn mints nothing.
+        assert!(tracker.bind_session("t1", "ses-x", 500).is_empty());
+        assert!(tracker.list_latest_completions().is_empty());
+    }
+
+    #[test]
+    fn completion_mid_pause_mints_nothing() {
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        tracker.note_permission_asked("t1", "ses-r", "perm-1", 150);
+        // Mid-pause turn end (no error): the pause was the episode's bell —
+        // NO effects at all (no second completion, no frames; the armed
+        // window is left to fire once or stay silent if it already rang).
+        assert!(tracker
+            .note_session_idle("t1", "ses-r", 1, 1, 200)
+            .is_empty());
+        assert!(tracker.list_latest_completions().is_empty());
+        assert!(!tracker.has_pending_permissions("t1"));
+    }
+
+    #[test]
+    fn death_predicates() {
+        // Quiet and KnownBusy never block (the hub's own criteria — owned
+        // busy, armed grace, pending permissions — decide engagement).
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        assert!(!tracker.blocks_death_bell("t1"));
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        assert!(!tracker.blocks_death_bell("t1"));
+        // has_pending_permissions over the pause lifecycle: true during the
+        // pause, false after replied.
+        assert!(!tracker.has_pending_permissions("t1"));
+        tracker.note_permission_asked("t1", "ses-r", "perm-1", 150);
+        assert!(tracker.has_pending_permissions("t1"));
+        tracker.note_permission_replied("t1", "perm-1", 180);
+        assert!(!tracker.has_pending_permissions("t1"));
+
+        // Candidate blocks — INCLUDING with a candidate-armed pause pending
+        // (D4: candidate ownership never death-rings).
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", None, 0);
+        tracker.note_status("t1", "ses-x", OpencodeStatus::Busy, 1, 1, 100);
+        assert!(tracker.blocks_death_bell("t1"));
+        tracker.note_permission_asked("t1", "ses-x", "perm-1", 150);
+        assert!(tracker.has_pending_permissions("t1"));
+        assert!(tracker.blocks_death_bell("t1"));
+        // The pause claim survives into AwaitingAssociation — still
+        // candidate-armed, still blocked (D4).
+        tracker.note_session_idle("t1", "ses-x", 1, 1, 200);
+        assert!(tracker.has_pending_permissions("t1"));
+        assert!(tracker.blocks_death_bell("t1"));
+        // Exit drops the pending set with the state (the hub reads
+        // has_pending_permissions BEFORE note_exit — audit-A17 ordering).
+        tracker.note_exit("t1");
+        assert!(!tracker.has_pending_permissions("t1"));
+        assert!(!tracker.blocks_death_bell("t1"));
+
+        // Ambiguous blocks (D4).
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", None, 0);
+        tracker.note_status("t1", "ses-a", OpencodeStatus::Busy, 1, 1, 100);
+        tracker.note_status("t1", "ses-b", OpencodeStatus::Busy, 1, 1, 110);
+        assert!(tracker.blocks_death_bell("t1"));
+    }
+
+    #[test]
+    fn busy_snapshot_refresh_rearms_the_abort_gate() {
+        // Node parity pin (Task 6 review note): busy re-entry/refresh
+        // re-arms `turn_aborted: false`, so a stale abort flag never
+        // swallows the NEXT turn's completion.
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        assert!(tracker
+            .note_error("t1", "ses-r", "MessageAbortedError", 1, 1, 150)
+            .is_empty());
+        // Same-session busy snapshot refresh: same public shape (dedupe, no
+        // frame) but a NEW turn — the abort flag is cleared.
+        let statuses = vec![("ses-r".to_string(), OpencodeStatus::Busy)];
+        assert!(tracker.note_snapshot("t1", &statuses, 1, 2, 160).is_empty());
+        // The refreshed turn's idle completes normally.
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-r", 1, 2, 200),
+            vec![remove(), turn_complete("ses-r", 200, 1)]
+        );
     }
 }

--- a/crates/freshell-activity/src/opencode.rs
+++ b/crates/freshell-activity/src/opencode.rs
@@ -278,6 +278,11 @@ impl OpencodeActivityTracker {
             }
             Ownership::AwaitingAssociation { previous_known, .. } => {
                 // Reject analog: the ended turn belonged to someone else.
+                // A surviving candidate pause claim (D3) is STALE here —
+                // without its confirm-swallow it would swallow the next
+                // turn's completion and leak into the death-bell window
+                // (Quiet never blocks). Retire it.
+                state.pending_permissions.clear();
                 state.ownership = Ownership::Quiet {
                     known_session_id: previous_known,
                 };
@@ -710,6 +715,11 @@ fn reduce_idle_edge(
         } if blocked.iter().any(|b| b == session_id) => {
             let blocked: Vec<String> = blocked.into_iter().filter(|b| b != session_id).collect();
             if blocked.is_empty() {
+                // Draining into Quiet retires any pause claim that survived
+                // the KnownBusy/Candidate → Ambiguous demotion — stale in
+                // Quiet (would swallow the next turn's bell / spurious
+                // death-bell).
+                state.pending_permissions.clear();
                 state.ownership = Ownership::Quiet { known_session_id };
                 clear_record(state, false)
             } else {
@@ -864,6 +874,10 @@ fn reduce_snapshot(
             known_session_id, ..
         } => {
             if busy_roots.is_empty() {
+                // Same staleness as the idle-edge drain: a pause claim that
+                // survived the demotion into Ambiguous must not land in
+                // Quiet.
+                state.pending_permissions.clear();
                 state.ownership = Ownership::Quiet { known_session_id };
                 return clear_record(state, false);
             }
@@ -1610,6 +1624,102 @@ mod tests {
         assert_eq!(
             tracker.note_session_idle("t1", "ses-r", 1, 2, 200),
             vec![remove(), turn_complete("ses-r", 200, 1)]
+        );
+    }
+
+    #[test]
+    fn rejected_bind_clears_stale_pause_claim() {
+        // A candidate pause claim survives into AwaitingAssociation (D3,
+        // load-bearing for the confirm-swallow), but a REJECTED bind lands
+        // in Quiet where the claim is stale: it must not swallow the next
+        // turn's completion or leak into the death-bell predicate.
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        // Foreign busy: Candidate{ses-x, previous_known: ses-r}.
+        assert_eq!(
+            tracker.note_status("t1", "ses-x", OpencodeStatus::Busy, 1, 1, 100),
+            vec![upsert(rec(Some("ses-x"), 100))]
+        );
+        // Candidate arming, then idle: claim survives into AwaitingAssociation.
+        assert_eq!(
+            tracker.note_permission_asked("t1", "ses-x", "perm-1", 150),
+            vec![remove(), boundary(150)]
+        );
+        assert!(tracker
+            .note_session_idle("t1", "ses-x", 1, 1, 200)
+            .is_empty());
+        assert!(tracker.has_pending_permissions("t1"));
+        // REJECTED bind (different session id): Quiet{ses-r}, claim retired.
+        assert!(tracker.bind_session("t1", "ses-y", 300).is_empty());
+        assert!(!tracker.has_pending_permissions("t1"));
+        // The next same-known-session turn completes normally — no
+        // mid-pause swallow of a genuinely completed turn's bell.
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 2, 1, 400);
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-r", 2, 1, 500),
+            vec![remove(), turn_complete("ses-r", 500, 1)]
+        );
+    }
+
+    #[test]
+    fn ambiguous_drain_via_idle_clears_stale_pause_claim() {
+        // A pause claim survives the KnownBusy → Ambiguous demotion; the
+        // idle-edge drain into Quiet must retire it.
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        assert_eq!(
+            tracker.note_permission_asked("t1", "ses-r", "perm-1", 150),
+            vec![remove(), boundary(150)]
+        );
+        // Foreign busy mid-pause: Ambiguous{known: ses-r, blocked: [b, r]}.
+        assert_eq!(
+            tracker.note_status("t1", "ses-b", OpencodeStatus::Busy, 1, 1, 160),
+            vec![upsert(rec(None, 160))]
+        );
+        assert!(tracker.has_pending_permissions("t1"));
+        // Drain the blocked set one idle at a time.
+        assert!(tracker
+            .note_session_idle("t1", "ses-r", 1, 1, 170)
+            .is_empty());
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-b", 1, 1, 180),
+            vec![remove()]
+        );
+        // Quiet: the stale claim is gone.
+        assert!(!tracker.has_pending_permissions("t1"));
+        // The next turn's busy→idle cycle mints a completion normally.
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 2, 1, 300);
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-r", 2, 1, 400),
+            vec![remove(), turn_complete("ses-r", 400, 1)]
+        );
+    }
+
+    #[test]
+    fn ambiguous_drain_via_snapshot_clears_stale_pause_claim() {
+        // Same staleness, drained through the snapshot reducer's
+        // empty-busy-roots arm instead of the idle edge.
+        let mut tracker = OpencodeActivityTracker::new();
+        tracker.track_terminal("t1", Some("ses-r"), 0);
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 1, 1, 100);
+        assert_eq!(
+            tracker.note_permission_asked("t1", "ses-r", "perm-1", 150),
+            vec![remove(), boundary(150)]
+        );
+        assert_eq!(
+            tracker.note_status("t1", "ses-b", OpencodeStatus::Busy, 1, 1, 160),
+            vec![upsert(rec(None, 160))]
+        );
+        assert!(tracker.has_pending_permissions("t1"));
+        // Empty snapshot drains Ambiguous → Quiet.
+        assert_eq!(tracker.note_snapshot("t1", &[], 2, 1, 200), vec![remove()]);
+        assert!(!tracker.has_pending_permissions("t1"));
+        // The next turn's busy→idle cycle mints a completion normally.
+        tracker.note_status("t1", "ses-r", OpencodeStatus::Busy, 3, 1, 300);
+        assert_eq!(
+            tracker.note_session_idle("t1", "ses-r", 3, 1, 400),
+            vec![remove(), turn_complete("ses-r", 400, 1)]
         );
     }
 }

--- a/crates/freshell-server/src/main.rs
+++ b/crates/freshell-server/src/main.rs
@@ -512,6 +512,14 @@ async fn main() -> ExitCode {
             freshell_ws::locate_codex_rollout(&codex_sessions_root, session_id)
         }));
     }
+    // Task 10: the opencode SSE lane's production IO seams (reqwest impls;
+    // fakes in tests). Unset would leave OpencodeAttach retire-only.
+    activity_hub.set_opencode_lane_deps(std::sync::Arc::new(
+        freshell_ws::opencode_lane::OpencodeLaneDeps {
+            http: std::sync::Arc::new(freshell_ws::opencode_lane::ReqwestLaneHttp::new()),
+            events: std::sync::Arc::new(freshell_ws::opencode_lane::ReqwestLaneStream::new()),
+        },
+    ));
     // Resolved ONCE so the rate-limit knobs and the gate the handlers consult
     // are guaranteed to come from the same env snapshot.
     let create_protect = freshell_ws::create_limit::CreateProtectConfig::from_env();

--- a/crates/freshell-ws/Cargo.toml
+++ b/crates/freshell-ws/Cargo.toml
@@ -76,6 +76,15 @@ freshell-codex = { path = "../freshell-codex", features = ["real-transport"] }
 # `freshell-server` installs (`crates/freshell-server/src/logging.rs`) --
 # this crate only emits events, it never installs its own subscriber.
 tracing = "0.1"
+# Task 9 opencode SSE lane: the injected IO seams' object-safe async traits
+# (`futures::future::BoxFuture` in `opencode_lane`'s OpencodeLaneHttp /
+# OpencodeEventStream / ConnectedOpencodeStream). Lean facade: std (implies
+# alloc, where BoxFuture lives); no executor/io machinery needed.
+futures = { version = "0.3", default-features = false, features = ["std"] }
+# Task 9 opencode SSE lane production impls (ReqwestLaneHttp/ReqwestLaneStream):
+# loopback plain-HTTP only, same lean no-default-features shape as
+# freshell-opencode's real-transport dep (the workspace already resolves 0.13).
+reqwest = { version = "0.13", default-features = false }
 # tabs-sync snapshot generation ids (continuity trio): SHA-256 over the
 # canonical `records` serialization, truncated to 128 bits. Same version the
 # workspace already resolves via crates/freshell-terminal/Cargo.toml:36.

--- a/crates/freshell-ws/src/activity.rs
+++ b/crates/freshell-ws/src/activity.rs
@@ -900,7 +900,7 @@ impl ActivityHub {
                 // nothing ever removes. Race-free because Exit and
                 // OpencodeAttach are processed serially on the hub task.
                 if inner.modes.get(&terminal_id).map(String::as_str) != Some("opencode") {
-                    tracing::debug!(
+                    tracing::warn!(
                         terminal_id = %terminal_id,
                         "opencode lane attach skipped: terminal no longer tracked"
                     );

--- a/crates/freshell-ws/src/activity.rs
+++ b/crates/freshell-ws/src/activity.rs
@@ -450,11 +450,10 @@ impl ActivityHub {
     }
 
     /// Task 9: install the SSE lane's injected IO seams (reqwest impls in
-    /// production; fakes in tests). Option'd — hub tests that never attach
-    /// leave it unset, and `OpencodeAttach` then only retires old lanes.
-    /// dead_code: Task 10's boot wiring is the production caller.
-    #[allow(dead_code)]
-    pub(crate) fn set_opencode_lane_deps(&self, deps: Arc<crate::opencode_lane::OpencodeLaneDeps>) {
+    /// production, wired by `freshell-server` at boot — Task 10; fakes in
+    /// tests). Option'd — hub tests that never attach leave it unset, and
+    /// `OpencodeAttach` then only retires old lanes.
+    pub fn set_opencode_lane_deps(&self, deps: Arc<crate::opencode_lane::OpencodeLaneDeps>) {
         let mut inner = self.inner.lock().expect("activity hub lock");
         inner.opencode_lane_deps = Some(deps);
     }
@@ -4627,6 +4626,76 @@ mod tests {
         );
         hub.bind_opencode_session("t-oc", "ses-new");
         assert_no_attention_frames(&mut rx, 1_500).await;
+    }
+
+    /// Task 10 producer contract (D3 deferred completion): a restore-created
+    /// opencode terminal WITHOUT resume identity goes busy for `ses-x`
+    /// (unconfirmed CANDIDATE), then idle — the completion is DEFERRED
+    /// (awaitingAssociation), total silence. The identity bind arriving via
+    /// `bind_opencode_session` (the ingress Task 10's association sweep and
+    /// TUI rebind-signal producers drive) confirms ownership and releases it:
+    /// terminal.turn.complete{provider:"opencode"} then exactly ONE
+    /// terminal.idle{reason:"grace"}.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn resume_created_opencode_terminal_binds_identity_via_bind_ingress() {
+        let (hub, mut rx) = hub();
+        observer_send(
+            &hub,
+            ActivityEvent::Created {
+                terminal_id: "t-oc".into(),
+                mode: "opencode".into(),
+                resume_session_id: None,
+                at: 1_000,
+            },
+        );
+        hub.register_opencode_lane_for_tests("t-oc", 1);
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::Status {
+                session_id: "ses-x".into(),
+                status: OpencodeStatus::Busy,
+            },
+        );
+        let busy = next_frame_matching(&mut rx, "opencode.activity.updated", 1_500, |v| {
+            v["upsert"][0]["phase"] == "busy"
+        })
+        .await;
+        assert!(busy.is_some(), "candidate busy upsert");
+
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionIdle {
+                session_id: "ses-x".into(),
+            },
+        );
+        // Candidate turn end: the completion must DEFER, not ring.
+        assert_no_attention_frames(&mut rx, 1_500).await;
+
+        // Identity proof (the Task 10 producers): the deferred completion
+        // releases — turn.complete first, then one idle after the grace.
+        hub.bind_opencode_session("t-oc", "ses-x");
+        let complete = next_frame_of_type(&mut rx, "terminal.turn.complete", 1_500)
+            .await
+            .expect("the bind releases the deferred completion");
+        assert_eq!(complete["terminalId"], "t-oc");
+        assert_eq!(complete["provider"], "opencode");
+        let idle = next_frame_of_type(&mut rx, "terminal.idle", 3_500)
+            .await
+            .expect("one grace idle after the released completion");
+        assert_eq!(idle["terminalId"], "t-oc");
+        assert_eq!(idle["reason"], "grace");
+        assert!(
+            next_frame_of_type(&mut rx, "terminal.idle", 1_500)
+                .await
+                .is_none(),
+            "exactly one terminal.idle for the released completion"
+        );
     }
 
     /// D1 + D3: an abort landing mid-pause force-emits the cancel — the

--- a/crates/freshell-ws/src/activity.rs
+++ b/crates/freshell-ws/src/activity.rs
@@ -42,11 +42,13 @@ use freshell_activity::amplifier::{
 use freshell_activity::claude::ClaudeActivityTracker;
 use freshell_activity::codex::CodexActivityTracker;
 use freshell_activity::idle::{IdleGate, IdleGatePhase};
+use freshell_activity::opencode::{OpencodeActivityTracker, OpencodeStatus};
 use freshell_activity::TrackerEffect;
 use freshell_protocol::{
     AgentProvider, AmplifierActivityRecord, AmplifierActivityUpdated, ClaudeActivityRecord,
-    ClaudeActivityUpdated, CodexActivityRecord, CodexActivityUpdated, ServerMessage, TerminalIdle,
-    TerminalIdleReason, TerminalTurnComplete, TurnCompletionSnapshot,
+    ClaudeActivityUpdated, CodexActivityRecord, CodexActivityUpdated, OpencodeActivityRecord,
+    OpencodeActivityUpdated, ServerMessage, TerminalIdle, TerminalIdleReason, TerminalTurnComplete,
+    TurnCompletionSnapshot,
 };
 use freshell_terminal::ActivityEvent;
 
@@ -154,6 +156,64 @@ enum HubEvent {
         request_id: String,
         requested: bool,
     },
+    /// Task 8: bind an opencode terminal's adopted session identity
+    /// (hub-task emission, mirror of `CodexBind`; Task 10 wires the
+    /// producers).
+    OpencodeBind {
+        terminal_id: String,
+        session_id: String,
+    },
+    /// Task 8: one generation-stamped opencode SSE-lane event (Task 9's
+    /// lane is the producer; hub-level tests inject directly).
+    /// `generation` is the hub-issued attach generation the ingress guard
+    /// matches against `opencode_lanes`; `cycle`/`stream` guard intra-lane
+    /// reconnect staleness inside the tracker.
+    /// dead_code: until Task 9 lands, hub-level tests are the only producer.
+    #[allow(dead_code)]
+    OpencodeLane {
+        terminal_id: String,
+        generation: u64,
+        cycle: u64,
+        stream: u64,
+        event: OpencodeLaneEvent,
+    },
+}
+
+/// The opencode SSE lane's event vocabulary (Task 9 produces these from the
+/// per-pane sidecar's `/event` stream + `/session/status` snapshots; the hub
+/// routes them into the pure `OpencodeActivityTracker`).
+/// dead_code: until Task 9 lands, hub-level tests are the only producer.
+#[allow(dead_code)]
+pub(crate) enum OpencodeLaneEvent {
+    /// `/session/status` snapshot (absence == idle).
+    Snapshot {
+        statuses: Vec<(String, OpencodeStatus)>,
+    },
+    /// `session.created` — folds the parentID chain into the root map.
+    SessionCreated {
+        session_id: String,
+        parent_id: Option<String>,
+    },
+    /// `session.status` edge (busy | retry | idle).
+    Status {
+        session_id: String,
+        status: OpencodeStatus,
+    },
+    /// `session.idle` — the deprecated twin of `session.status{idle}`.
+    SessionIdle { session_id: String },
+    /// `session.error` (and Task 9's abort-marked `message.updated`,
+    /// translated into this same shape).
+    SessionError {
+        session_id: String,
+        error_name: String,
+    },
+    /// `permission.asked` — the turn pauses on a human.
+    PermissionAsked {
+        session_id: String,
+        permission_id: String,
+    },
+    /// `permission.replied` — the pause ends.
+    PermissionReplied { permission_id: String },
 }
 
 struct AmplifierLane {
@@ -194,6 +254,7 @@ struct HubInner {
     claude: ClaudeActivityTracker,
     codex: CodexActivityTracker,
     amplifier: AmplifierActivityTracker,
+    opencode: OpencodeActivityTracker,
     idle: IdleGate,
     /// terminal id → mode, for every tracked CLI terminal.
     modes: HashMap<String, String>,
@@ -202,6 +263,12 @@ struct HubInner {
     lane_retries: HashMap<String, LaneRetry>,
     codex_lanes: HashMap<String, CodexLane>,
     codex_rollout_locator: Option<CodexRolloutLocator>,
+    /// Task 8/9: terminal id → (hub-issued attach generation, lane task).
+    /// The `OpencodeLane` ingress guard drops any event whose stamped
+    /// generation doesn't match the CURRENT entry; Exit removes the entry
+    /// so post-exit stragglers fail the match too. Task 9's SSE lane
+    /// registry populates this for real; hub-level tests insert dummies.
+    opencode_lanes: HashMap<String, (u64, tokio::task::JoinHandle<()>)>,
 }
 
 /// Cloneable handle to the hub (stored on `WsState`).
@@ -322,6 +389,51 @@ impl ActivityHub {
             request_id: request_id.to_string(),
             requested,
         });
+    }
+
+    /// Task 8: bind an opencode terminal's session identity into the
+    /// activity tracker (SQLite locator / TUI rebind plugin — Task 10
+    /// wires the producers). Channel-deferred (mirror of
+    /// `bind_codex_session`) so all frame emission stays on the hub task.
+    pub fn bind_opencode_session(&self, terminal_id: &str, session_id: &str) {
+        let _ = self.tx.send(HubEvent::OpencodeBind {
+            terminal_id: terminal_id.to_string(),
+            session_id: session_id.to_string(),
+        });
+    }
+
+    /// Task 8: generation-stamped SSE-lane ingress (Task 9's lane is the
+    /// caller). Channel-deferred like every other producer — the
+    /// single-emitter frame-ordering invariant.
+    /// dead_code: until Task 9 lands, hub-level tests are the only caller.
+    #[allow(dead_code)]
+    pub(crate) fn note_opencode_lane_event(
+        &self,
+        terminal_id: &str,
+        generation: u64,
+        cycle: u64,
+        stream: u64,
+        event: OpencodeLaneEvent,
+    ) {
+        let _ = self.tx.send(HubEvent::OpencodeLane {
+            terminal_id: terminal_id.to_string(),
+            generation,
+            cycle,
+            stream,
+            event,
+        });
+    }
+
+    /// Hub-level episode tests register a dummy `opencode_lanes` entry so
+    /// their injected lane events pass the generation guard without
+    /// spawning a real SSE lane (Task 9 owns the real registry).
+    #[cfg(test)]
+    fn register_opencode_lane_for_tests(&self, terminal_id: &str, generation: u64) {
+        let mut inner = self.inner.lock().expect("activity hub lock");
+        inner.opencode_lanes.insert(
+            terminal_id.to_string(),
+            (generation, tokio::spawn(async {})),
+        );
     }
 
     /// Install the resume-time rollout locator (called once from
@@ -471,6 +583,15 @@ impl ActivityHub {
         (inner.codex.list(), inner.codex.list_latest_completions())
     }
 
+    /// `opencode.activity.list` state.
+    pub fn opencode_list(&self) -> (Vec<OpencodeActivityRecord>, Vec<TurnCompletionSnapshot>) {
+        let inner = self.inner.lock().expect("activity hub lock");
+        (
+            inner.opencode.list(),
+            inner.opencode.list_latest_completions(),
+        )
+    }
+
     /// `amplifier.activity.list` state.
     pub fn amplifier_list(&self) -> (Vec<AmplifierActivityRecord>, Vec<TurnCompletionSnapshot>) {
         let inner = self.inner.lock().expect("activity hub lock");
@@ -612,6 +733,85 @@ impl ActivityHub {
                 };
                 self.emit(frames);
             }
+            HubEvent::OpencodeBind {
+                terminal_id,
+                session_id,
+            } => {
+                let at = now_ms();
+                let frames = {
+                    let mut inner = self.inner.lock().expect("activity hub lock");
+                    let effects = inner.opencode.bind_session(&terminal_id, &session_id, at);
+                    opencode_frames(&mut inner.idle, effects)
+                };
+                self.emit(frames);
+            }
+            HubEvent::OpencodeLane {
+                terminal_id,
+                generation,
+                cycle,
+                stream,
+                event,
+            } => {
+                let at = now_ms();
+                let frames = {
+                    let mut inner = self.inner.lock().expect("activity hub lock");
+                    // Attach-generation guard (A6): tokio `abort()` is asynchronous and
+                    // never retracts already-enqueued mpsc messages — a replaced lane can
+                    // legally enqueue events AFTER its successor's attach. Drop anything
+                    // not stamped with the CURRENT lane generation (Exit removes the map
+                    // entry, so post-exit stragglers drop too). cycle/stream still guard
+                    // intra-lane reconnect staleness inside the tracker.
+                    if inner.opencode_lanes.get(&terminal_id).map(|(g, _)| *g) != Some(generation) {
+                        return;
+                    }
+                    let effects =
+                        match event {
+                            OpencodeLaneEvent::Snapshot { statuses } => inner
+                                .opencode
+                                .note_snapshot(&terminal_id, &statuses, cycle, stream, at),
+                            OpencodeLaneEvent::SessionCreated {
+                                session_id,
+                                parent_id,
+                            } => inner.opencode.note_session_created(
+                                &terminal_id,
+                                &session_id,
+                                parent_id.as_deref(),
+                                at,
+                            ),
+                            OpencodeLaneEvent::Status { session_id, status } => inner
+                                .opencode
+                                .note_status(&terminal_id, &session_id, status, cycle, stream, at),
+                            OpencodeLaneEvent::SessionIdle { session_id } => inner
+                                .opencode
+                                .note_session_idle(&terminal_id, &session_id, cycle, stream, at),
+                            OpencodeLaneEvent::SessionError {
+                                session_id,
+                                error_name,
+                            } => inner.opencode.note_error(
+                                &terminal_id,
+                                &session_id,
+                                &error_name,
+                                cycle,
+                                stream,
+                                at,
+                            ),
+                            OpencodeLaneEvent::PermissionAsked {
+                                session_id,
+                                permission_id,
+                            } => inner.opencode.note_permission_asked(
+                                &terminal_id,
+                                &session_id,
+                                &permission_id,
+                                at,
+                            ),
+                            OpencodeLaneEvent::PermissionReplied { permission_id } => inner
+                                .opencode
+                                .note_permission_replied(&terminal_id, &permission_id, at),
+                        };
+                    opencode_frames(&mut inner.idle, effects)
+                };
+                self.emit(frames);
+            }
         }
     }
 
@@ -655,6 +855,17 @@ impl ActivityHub {
                             );
                             let (mut f, _force) = amplifier_frames(&mut inner.idle, effects);
                             frames.append(&mut f);
+                        }
+                        // Task 8: opencode tracking starts at create; the
+                        // SSE lane attach itself is Task 9/10.
+                        "opencode" => {
+                            inner.modes.insert(terminal_id.clone(), mode.clone());
+                            let effects = inner.opencode.track_terminal(
+                                &terminal_id,
+                                resume_session_id.as_deref(),
+                                at,
+                            );
+                            frames.extend(opencode_frames(&mut inner.idle, effects));
                         }
                         // Gemini/Kimi and every other mode: status-inert.
                         _ => {}
@@ -743,6 +954,9 @@ impl ActivityHub {
                             let (frames, _force) = amplifier_frames(&mut inner.idle, effects);
                             frames
                         }
+                        // Task 8: SSE-driven — PTY bytes carry no protocol
+                        // signal for opencode, NO heuristic bells.
+                        "opencode" => Vec::new(),
                         _ => Vec::new(),
                     }
                 };
@@ -772,6 +986,9 @@ impl ActivityHub {
                             inner.amplifier.note_output(&terminal_id, at);
                             Vec::new()
                         }
+                        // Task 8: SSE-driven — PTY bytes carry no protocol
+                        // signal for opencode, NO heuristic bells.
+                        "opencode" => Vec::new(),
                         _ => Vec::new(),
                     }
                 };
@@ -789,9 +1006,17 @@ impl ActivityHub {
                     // Task 7: a pane blocked on an approval whose process dies must
                     // ring even after its 2s boundary already rang, so pending
                     // approvals count as engagement too.
+                    // D4: candidate/ambiguous opencode ownership never death-rings —
+                    // even when a candidate-armed permission pause is pending
+                    // (residual D8(i)). `blocks_death_bell` is false for terminals
+                    // the opencode tracker doesn't know, so claude/codex/amplifier
+                    // behavior is unchanged.
+                    let opencode_death_eligible = !inner.opencode.blocks_death_bell(&terminal_id);
                     let ring_death_bell = spontaneous
-                        && (inner.idle.is_engaged(&terminal_id)
-                            || inner.codex.has_pending_approvals(&terminal_id));
+                        && ((inner.idle.is_engaged(&terminal_id) && opencode_death_eligible)
+                            || inner.codex.has_pending_approvals(&terminal_id)
+                            || (inner.opencode.has_pending_permissions(&terminal_id)
+                                && opencode_death_eligible));
                     let mut frames = Vec::new();
                     if ring_death_bell {
                         // Spontaneous death while engaged: same frame, same reason —
@@ -817,6 +1042,13 @@ impl ActivityHub {
                         inner.lanes.remove(&terminal_id);
                         inner.lane_retries.remove(&terminal_id);
                         inner.codex_lanes.remove(&terminal_id);
+                        if let Some((_, lane_task)) = inner.opencode_lanes.remove(&terminal_id) {
+                            // Stop the SSE lane with its pane; the map removal
+                            // ALSO makes any already-enqueued stragglers fail
+                            // the generation guard (abort never retracts
+                            // enqueued events).
+                            lane_task.abort();
+                        }
                         let tracker_frames = match mode.as_str() {
                             "claude" => {
                                 let effects = inner.claude.note_exit(&terminal_id);
@@ -831,6 +1063,10 @@ impl ActivityHub {
                                 let effects = inner.amplifier.note_exit(&terminal_id);
                                 let (frames, _force) = amplifier_frames(&mut inner.idle, effects);
                                 frames
+                            }
+                            "opencode" => {
+                                let effects = inner.opencode.note_exit(&terminal_id);
+                                opencode_frames(&mut inner.idle, effects)
                             }
                             _ => Vec::new(),
                         };
@@ -1125,6 +1361,8 @@ impl ActivityHub {
             let amplifier = inner.amplifier.expire(now);
             let (mut f, force_reads) = amplifier_frames(&mut inner.idle, amplifier);
             frames.append(&mut f);
+            let opencode = inner.opencode.expire(now);
+            frames.extend(opencode_frames(&mut inner.idle, opencode));
             for emission in inner.idle.expire(now) {
                 frames.push(ServerMessage::TerminalIdle(TerminalIdle {
                     terminal_id: emission.terminal_id,
@@ -1219,6 +1457,7 @@ fn hub_next_deadline(inner: &HubInner) -> Option<i64> {
         inner.claude.next_deadline(),
         inner.codex.next_deadline(),
         inner.amplifier.next_deadline(),
+        inner.opencode.next_deadline(),
         inner.idle.next_deadline(),
         inner
             .lane_retries
@@ -1336,6 +1575,60 @@ fn codex_frames(
         }
     }
     (frames, force_reads)
+}
+
+/// Map opencode tracker effects onto wire frames + idle-gate interactions.
+/// No force-reads: the opencode lane is SSE-push, not file-tail.
+fn opencode_frames(
+    idle: &mut IdleGate,
+    effects: Vec<TrackerEffect<OpencodeActivityRecord>>,
+) -> Vec<ServerMessage> {
+    let mut frames = Vec::new();
+    for effect in effects {
+        match effect {
+            TrackerEffect::Changed { upsert, remove } => {
+                // remove -> note_exit clears gate state; the boundary that FOLLOWS
+                // in the same batch re-arms grace-only (D7 — the Node emitter's
+                // "activityRemove followed by turnComplete" contract). Busy is
+                // the ONLY opencode phase on the wire, so every upsert maps to
+                // IdleGatePhase::Busy.
+                note_changed_to_gate(
+                    idle,
+                    upsert
+                        .iter()
+                        .map(|r| (r.terminal_id.as_str(), IdleGatePhase::Busy)),
+                    &remove,
+                );
+                frames.push(ServerMessage::OpencodeActivityUpdated(
+                    OpencodeActivityUpdated { remove, upsert },
+                ));
+            }
+            TrackerEffect::TurnComplete {
+                terminal_id,
+                session_id,
+                at,
+                completion_seq,
+            } => {
+                idle.note_turn_boundary(&terminal_id, at);
+                frames.push(turn_complete_frame(
+                    AgentProvider::Opencode,
+                    terminal_id,
+                    session_id,
+                    at,
+                    completion_seq,
+                ));
+            }
+            TrackerEffect::AttentionBoundary { terminal_id, at } => {
+                // Arms the bell WITHOUT a frame — a permission pause is not a
+                // turn end. Effect order guarantees the record removal was
+                // processed first, so the boundary arms.
+                idle.note_turn_boundary(&terminal_id, at);
+            }
+            // The opencode tracker never emits force-reads (SSE lane, no tailer).
+            TrackerEffect::ForceRead { .. } => {}
+        }
+    }
+    frames
 }
 
 /// Amplifier effects additionally surface force-read requests (the lane
@@ -3826,5 +4119,769 @@ mod tests {
             .await
             .expect("death bell: pending approvals count as engagement");
         assert_eq!(second["terminalId"], "t1");
+    }
+
+    // ---- OpenCode lane (attention bell, Task 8) ----
+
+    /// Shared setup: an opencode terminal created with a resume identity
+    /// ("ses-root"), a dummy generation-1 lanes-map entry, and a gen-1 busy
+    /// edge for the known root — CONFIRMED busy (`KnownBusy`).
+    async fn busy_opencode_terminal(
+        hub: &ActivityHub,
+        rx: &mut tokio::sync::broadcast::Receiver<String>,
+    ) {
+        observer_send(
+            hub,
+            ActivityEvent::Created {
+                terminal_id: "t-oc".into(),
+                mode: "opencode".into(),
+                resume_session_id: Some("ses-root".into()),
+                at: 1_000,
+            },
+        );
+        hub.register_opencode_lane_for_tests("t-oc", 1); // dummy lanes-map entry: generation 1 passes ingress
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::Status {
+                session_id: "ses-root".into(),
+                status: OpencodeStatus::Busy,
+            },
+        );
+        let frame = next_frame_matching(rx, "opencode.activity.updated", 1_500, |v| {
+            v["upsert"][0]["phase"] == "busy"
+        })
+        .await;
+        assert!(frame.is_some(), "expected the busy upsert");
+    }
+
+    /// Assert that NOTHING attention-relevant (`terminal.turn.complete` or
+    /// `terminal.idle`) is broadcast within `timeout_ms`. Unlike two
+    /// sequential `next_frame_of_type(..).is_none()` waits, a single pass
+    /// cannot mask one frame type by consuming it while waiting for the
+    /// other.
+    async fn assert_no_attention_frames(
+        rx: &mut tokio::sync::broadcast::Receiver<String>,
+        timeout_ms: u64,
+    ) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return;
+            }
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Ok(frame)) => {
+                    let value: serde_json::Value =
+                        serde_json::from_str(&frame).expect("frame json");
+                    assert!(
+                        value["type"] != "terminal.turn.complete"
+                            && value["type"] != "terminal.idle",
+                        "expected attention silence, got {frame}"
+                    );
+                }
+                _ => return,
+            }
+        }
+    }
+
+    /// D7: the owned root's idle edge ends the turn — remove frame, then
+    /// terminal.turn.complete{provider:"opencode"}, then exactly ONE
+    /// terminal.idle{reason:"grace"} after the 2s grace. The deprecated
+    /// `session.idle` twin landing second mints nothing (structural dedupe,
+    /// D2: the first edge lands the machine in Quiet).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_completed_turn_rings_once_after_grace() {
+        let (hub, mut rx) = hub();
+        busy_opencode_terminal(&hub, &mut rx).await;
+
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionIdle {
+                session_id: "ses-root".into(),
+            },
+        );
+        let complete = next_frame_of_type(&mut rx, "terminal.turn.complete", 1_500)
+            .await
+            .expect("turn complete for the owned root's idle edge");
+        assert_eq!(complete["provider"], "opencode");
+        assert_eq!(complete["terminalId"], "t-oc");
+        assert_eq!(complete["sessionId"], "ses-root");
+
+        let idle = next_frame_of_type(&mut rx, "terminal.idle", 3_500)
+            .await
+            .expect("exactly one terminal.idle after the grace");
+        assert_eq!(idle["terminalId"], "t-oc");
+        assert_eq!(idle["reason"], "grace");
+
+        // The deprecated twin idle edge lands second: nothing further.
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionIdle {
+                session_id: "ses-root".into(),
+            },
+        );
+        assert_no_attention_frames(&mut rx, 1_500).await;
+    }
+
+    /// D1: a human abort (`MessageAbortedError` on the owned root's own
+    /// turn) clears busy silently — no completion, no bell, even after the
+    /// grace would have elapsed, and the double idle edge stays silent too.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_abort_stays_silent() {
+        let (hub, mut rx) = hub();
+        busy_opencode_terminal(&hub, &mut rx).await;
+
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionError {
+                session_id: "ses-root".into(),
+                error_name: "MessageAbortedError".into(),
+            },
+        );
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionIdle {
+                session_id: "ses-root".into(),
+            },
+        );
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionIdle {
+                session_id: "ses-root".into(),
+            },
+        );
+        // 3_500ms covers the 2s grace: a wrongly armed bell would have rung.
+        assert_no_attention_frames(&mut rx, 3_500).await;
+    }
+
+    /// D1: failed turns ring like completed turns — a non-abort error is a
+    /// no-op and the following idle edge completes the turn. A trailing
+    /// error on the quiet state mints nothing.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_failed_turn_rings() {
+        let (hub, mut rx) = hub();
+        busy_opencode_terminal(&hub, &mut rx).await;
+
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionError {
+                session_id: "ses-root".into(),
+                error_name: "UnknownError".into(),
+            },
+        );
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionIdle {
+                session_id: "ses-root".into(),
+            },
+        );
+        let complete = next_frame_of_type(&mut rx, "terminal.turn.complete", 1_500)
+            .await
+            .expect("a failed turn still completes");
+        assert_eq!(complete["provider"], "opencode");
+        assert_eq!(complete["terminalId"], "t-oc");
+
+        let idle = next_frame_of_type(&mut rx, "terminal.idle", 3_500)
+            .await
+            .expect("one terminal.idle for the failed turn");
+        assert_eq!(idle["terminalId"], "t-oc");
+        assert_eq!(idle["reason"], "grace");
+
+        // Trailing error after the idle edge: quiet state, nothing minted.
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionError {
+                session_id: "ses-root".into(),
+                error_name: "UnknownError".into(),
+            },
+        );
+        assert_no_attention_frames(&mut rx, 1_500).await;
+    }
+
+    /// D3: (a) an unanswered permission ask demotes the record and rings
+    /// exactly once after the grace; (b) an ask answered within the grace
+    /// restores busy and stays silent.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_permission_pause_rings_once_and_reply_within_grace_is_silent() {
+        // (a) unanswered ask: one bell after the grace, never a second.
+        let (hub_a, mut rx_a) = hub();
+        busy_opencode_terminal(&hub_a, &mut rx_a).await;
+        hub_a.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::PermissionAsked {
+                session_id: "ses-root".into(),
+                permission_id: "perm-1".into(),
+            },
+        );
+        let removed = next_frame_matching(&mut rx_a, "opencode.activity.updated", 1_500, |v| {
+            v["remove"][0] == "t-oc"
+        })
+        .await;
+        assert!(removed.is_some(), "the pause demotes the busy record (D7)");
+        let idle = next_frame_of_type(&mut rx_a, "terminal.idle", 3_500)
+            .await
+            .expect("the unanswered ask rings after the grace");
+        assert_eq!(idle["terminalId"], "t-oc");
+        assert_eq!(idle["reason"], "grace");
+        assert!(
+            next_frame_of_type(&mut rx_a, "terminal.idle", 1_500)
+                .await
+                .is_none(),
+            "exactly one bell per pause"
+        );
+
+        // (b) ask answered within the grace: busy restored, total silence.
+        let (hub_b, mut rx_b) = hub();
+        busy_opencode_terminal(&hub_b, &mut rx_b).await;
+        hub_b.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::PermissionAsked {
+                session_id: "ses-root".into(),
+                permission_id: "perm-1".into(),
+            },
+        );
+        hub_b.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::PermissionReplied {
+                permission_id: "perm-1".into(),
+            },
+        );
+        let resumed = next_frame_matching(&mut rx_b, "opencode.activity.updated", 1_500, |v| {
+            v["upsert"][0]["phase"] == "busy"
+        })
+        .await;
+        assert!(resumed.is_some(), "the reply restores the busy record");
+        assert!(
+            next_frame_of_type(&mut rx_b, "terminal.idle", 3_500)
+                .await
+                .is_none(),
+            "an ask answered within the grace must stay silent"
+        );
+    }
+
+    /// D3: children CAN ask — the permission event is stamped with the
+    /// CHILD session id while the parent turn blocks on it, so the asker
+    /// root-resolves onto the owned root and the pause rings.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_child_permission_asked_arms_via_root_resolution() {
+        let (hub, mut rx) = hub();
+        busy_opencode_terminal(&hub, &mut rx).await;
+
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionCreated {
+                session_id: "ses-child".into(),
+                parent_id: Some("ses-root".into()),
+            },
+        );
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::PermissionAsked {
+                session_id: "ses-child".into(),
+                permission_id: "perm-1".into(),
+            },
+        );
+        let idle = next_frame_of_type(&mut rx, "terminal.idle", 3_500)
+            .await
+            .expect("the child's ask root-resolves and pauses the root (D3)");
+        assert_eq!(idle["terminalId"], "t-oc");
+        assert_eq!(idle["reason"], "grace");
+        assert!(
+            next_frame_of_type(&mut rx, "terminal.idle", 1_500)
+                .await
+                .is_none(),
+            "exactly one bell for the child's ask"
+        );
+    }
+
+    /// D3 candidate arming: a first-turn ask (no resume identity, the busy
+    /// session is an unconfirmed CANDIDATE) still rings. The turn then ends
+    /// mid-pause and identity proof arrives — the DEFERRED completion is
+    /// swallowed (the pause was the episode's bell).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_first_turn_permission_pause_rings_under_candidate() {
+        let (hub, mut rx) = hub();
+        observer_send(
+            &hub,
+            ActivityEvent::Created {
+                terminal_id: "t-oc".into(),
+                mode: "opencode".into(),
+                resume_session_id: None,
+                at: 1_000,
+            },
+        );
+        hub.register_opencode_lane_for_tests("t-oc", 1);
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::Status {
+                session_id: "ses-new".into(),
+                status: OpencodeStatus::Busy,
+            },
+        );
+        let busy = next_frame_matching(&mut rx, "opencode.activity.updated", 1_500, |v| {
+            v["upsert"][0]["phase"] == "busy"
+        })
+        .await;
+        assert!(busy.is_some(), "candidate busy upsert");
+
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::PermissionAsked {
+                session_id: "ses-new".into(),
+                permission_id: "perm-1".into(),
+            },
+        );
+        let idle = next_frame_of_type(&mut rx, "terminal.idle", 3_500)
+            .await
+            .expect("candidate arming (D3): first-turn asks must ring");
+        assert_eq!(idle["terminalId"], "t-oc");
+
+        // Turn end mid-pause, then the identity proof: the deferred
+        // completion is swallowed — NO terminal.turn.complete.
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionIdle {
+                session_id: "ses-new".into(),
+            },
+        );
+        hub.bind_opencode_session("t-oc", "ses-new");
+        assert_no_attention_frames(&mut rx, 1_500).await;
+    }
+
+    /// D1 + D3: an abort landing mid-pause force-emits the cancel — the
+    /// armed pause window dies with it, total silence even after the grace.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_mid_pause_abort_is_fully_silent() {
+        let (hub, mut rx) = hub();
+        busy_opencode_terminal(&hub, &mut rx).await;
+
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::PermissionAsked {
+                session_id: "ses-root".into(),
+                permission_id: "perm-1".into(),
+            },
+        );
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionError {
+                session_id: "ses-root".into(),
+                error_name: "MessageAbortedError".into(),
+            },
+        );
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionIdle {
+                session_id: "ses-root".into(),
+            },
+        );
+        // 3_500ms covers the grace: the armed pause bell must be cancelled.
+        assert_no_attention_frames(&mut rx, 3_500).await;
+    }
+
+    /// D4: spontaneous death while KnownBusy rings IMMEDIATELY (no grace —
+    /// a dead process emits nothing further, so nothing could cancel it).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_spontaneous_death_while_busy_rings_immediately() {
+        let (hub, mut rx) = hub();
+        busy_opencode_terminal(&hub, &mut rx).await;
+
+        observer_send(
+            &hub,
+            ActivityEvent::Exit {
+                terminal_id: "t-oc".into(),
+                at: now_ms(),
+                spontaneous: true,
+            },
+        );
+        // Well inside the 2s grace window: proves the immediate path.
+        let idle = next_frame_of_type(&mut rx, "terminal.idle", 1_500)
+            .await
+            .expect("immediate death bell for a spontaneous exit while busy");
+        assert_eq!(idle["terminalId"], "t-oc");
+        assert_eq!(idle["reason"], "grace");
+        assert!(
+            next_frame_of_type(&mut rx, "terminal.idle", 1_500)
+                .await
+                .is_none(),
+            "exactly one terminal.idle for the death"
+        );
+    }
+
+    /// D4: candidate/ambiguous ownership never death-rings — even with a
+    /// candidate-armed pause pending (residual D8(i)); an idle quiet pane is
+    /// silent; a freshell-initiated kill (spontaneous=false) is silent even
+    /// mid-turn.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_death_while_candidate_or_idle_is_silent_and_freshell_kill_is_silent() {
+        // (a) candidate busy: unconfirmed identity stays silent.
+        let (hub_a, mut rx_a) = hub();
+        observer_send(
+            &hub_a,
+            ActivityEvent::Created {
+                terminal_id: "t-oc".into(),
+                mode: "opencode".into(),
+                resume_session_id: None,
+                at: 1_000,
+            },
+        );
+        hub_a.register_opencode_lane_for_tests("t-oc", 1);
+        hub_a.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::Status {
+                session_id: "ses-new".into(),
+                status: OpencodeStatus::Busy,
+            },
+        );
+        let busy = next_frame_matching(&mut rx_a, "opencode.activity.updated", 1_500, |v| {
+            v["upsert"][0]["phase"] == "busy"
+        })
+        .await;
+        assert!(busy.is_some(), "candidate busy upsert");
+        observer_send(
+            &hub_a,
+            ActivityEvent::Exit {
+                terminal_id: "t-oc".into(),
+                at: now_ms(),
+                spontaneous: true,
+            },
+        );
+        assert!(
+            next_frame_of_type(&mut rx_a, "terminal.idle", 1_500)
+                .await
+                .is_none(),
+            "a candidate death must stay silent (D4)"
+        );
+
+        // (b) candidate + candidate-armed pause pending: STILL silent
+        // (residual D8(i)); 3_500ms also proves the armed pause window died
+        // with the pane instead of ringing at the grace deadline.
+        let (hub_b, mut rx_b) = hub();
+        observer_send(
+            &hub_b,
+            ActivityEvent::Created {
+                terminal_id: "t-oc".into(),
+                mode: "opencode".into(),
+                resume_session_id: None,
+                at: 1_000,
+            },
+        );
+        hub_b.register_opencode_lane_for_tests("t-oc", 1);
+        hub_b.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::Status {
+                session_id: "ses-new".into(),
+                status: OpencodeStatus::Busy,
+            },
+        );
+        let busy = next_frame_matching(&mut rx_b, "opencode.activity.updated", 1_500, |v| {
+            v["upsert"][0]["phase"] == "busy"
+        })
+        .await;
+        assert!(busy.is_some(), "candidate busy upsert");
+        hub_b.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::PermissionAsked {
+                session_id: "ses-new".into(),
+                permission_id: "perm-1".into(),
+            },
+        );
+        observer_send(
+            &hub_b,
+            ActivityEvent::Exit {
+                terminal_id: "t-oc".into(),
+                at: now_ms(),
+                spontaneous: true,
+            },
+        );
+        assert!(
+            next_frame_of_type(&mut rx_b, "terminal.idle", 3_500)
+                .await
+                .is_none(),
+            "a candidate-armed pause must not death-ring (residual D8(i))"
+        );
+
+        // (c) quiet idle pane: a spontaneous exit is not an attention event.
+        let (hub_c, mut rx_c) = hub();
+        observer_send(
+            &hub_c,
+            ActivityEvent::Created {
+                terminal_id: "t-oc".into(),
+                mode: "opencode".into(),
+                resume_session_id: Some("ses-root".into()),
+                at: 1_000,
+            },
+        );
+        observer_send(
+            &hub_c,
+            ActivityEvent::Exit {
+                terminal_id: "t-oc".into(),
+                at: now_ms(),
+                spontaneous: true,
+            },
+        );
+        assert!(
+            next_frame_of_type(&mut rx_c, "terminal.idle", 1_500)
+                .await
+                .is_none(),
+            "a spontaneous exit while idle must stay silent"
+        );
+
+        // (d) freshell-initiated kill mid-turn: silent.
+        let (hub_d, mut rx_d) = hub();
+        busy_opencode_terminal(&hub_d, &mut rx_d).await;
+        observer_send(
+            &hub_d,
+            ActivityEvent::Exit {
+                terminal_id: "t-oc".into(),
+                at: now_ms(),
+                spontaneous: false,
+            },
+        );
+        assert!(
+            next_frame_of_type(&mut rx_d, "terminal.idle", 1_500)
+                .await
+                .is_none(),
+            "a requested exit must never ring the death bell"
+        );
+    }
+
+    /// D4: a pane blocked on a permission whose process dies spontaneously
+    /// rings immediately — pending permissions count as engagement.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_death_during_pause_rings() {
+        let (hub, mut rx) = hub();
+        busy_opencode_terminal(&hub, &mut rx).await;
+
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::PermissionAsked {
+                session_id: "ses-root".into(),
+                permission_id: "perm-1".into(),
+            },
+        );
+        observer_send(
+            &hub,
+            ActivityEvent::Exit {
+                terminal_id: "t-oc".into(),
+                at: now_ms(),
+                spontaneous: true,
+            },
+        );
+        let idle = next_frame_of_type(&mut rx, "terminal.idle", 1_500)
+            .await
+            .expect("death during a pending permission pause must ring (D4)");
+        assert_eq!(idle["terminalId"], "t-oc");
+        // Exactly one: the exit teardown also cancels the armed pause window.
+        assert!(
+            next_frame_of_type(&mut rx, "terminal.idle", 3_500)
+                .await
+                .is_none(),
+            "exactly one bell for the death"
+        );
+    }
+
+    /// D5: a child's idle mid-parent-turn is suppressed — the busy record
+    /// survives and only the parent's own idle edge ends the turn.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_child_idle_mid_parent_turn_does_not_ring() {
+        let (hub, mut rx) = hub();
+        busy_opencode_terminal(&hub, &mut rx).await;
+
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionCreated {
+                session_id: "ses-child".into(),
+                parent_id: Some("ses-root".into()),
+            },
+        );
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::Status {
+                session_id: "ses-child".into(),
+                status: OpencodeStatus::Busy,
+            },
+        );
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionIdle {
+                session_id: "ses-child".into(),
+            },
+        );
+        // 3_500ms covers the grace: a wrongly armed bell would have rung.
+        assert_no_attention_frames(&mut rx, 3_500).await;
+        // The busy record survives the child's idle.
+        let (records, _) = hub.opencode_list();
+        assert_eq!(records.len(), 1, "the parent's busy record must survive");
+        assert_eq!(records[0].terminal_id, "t-oc");
+
+        // The parent's own idle edge ends the turn: one completion, one bell.
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionIdle {
+                session_id: "ses-root".into(),
+            },
+        );
+        let complete = next_frame_of_type(&mut rx, "terminal.turn.complete", 1_500)
+            .await
+            .expect("the parent's own idle edge completes the turn");
+        assert_eq!(complete["provider"], "opencode");
+        assert_eq!(complete["terminalId"], "t-oc");
+        let idle = next_frame_of_type(&mut rx, "terminal.idle", 3_500)
+            .await
+            .expect("one bell for the parent's turn end");
+        assert_eq!(idle["terminalId"], "t-oc");
+        assert!(
+            next_frame_of_type(&mut rx, "terminal.idle", 1_500)
+                .await
+                .is_none(),
+            "exactly one bell"
+        );
+    }
+
+    /// A6: a respawn re-registers the lane under a NEW generation — events
+    /// still stamped with the replaced generation are dropped WHOLE at
+    /// ingress (tokio `abort()` never retracts already-enqueued events);
+    /// current-generation events flow normally.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn respawn_drops_stale_lane_events() {
+        let (hub, mut rx) = hub();
+        busy_opencode_terminal(&hub, &mut rx).await; // generation 1 registered + gen-1 busy accepted
+
+        // The respawn's attach REPLACES the map entry under generation 2.
+        hub.register_opencode_lane_for_tests("t-oc", 2);
+
+        // Stragglers from the replaced lane: a busy for a DIFFERENT session
+        // (would demote to Ambiguous + emit frames if processed) and the
+        // turn's idle edge (would mint turn.complete + the bell).
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::Status {
+                session_id: "ses-stale".into(),
+                status: OpencodeStatus::Busy,
+            },
+        );
+        hub.note_opencode_lane_event(
+            "t-oc",
+            1,
+            1,
+            1,
+            OpencodeLaneEvent::SessionIdle {
+                session_id: "ses-root".into(),
+            },
+        );
+        // NO upsert, NO terminal.turn.complete, NO terminal.idle — nothing
+        // at all may be broadcast (3_500ms covers the would-be grace bell).
+        let frame = tokio::time::timeout(std::time::Duration::from_millis(3_500), rx.recv()).await;
+        assert!(
+            frame.is_err(),
+            "stale-generation lane events must be dropped whole, got {frame:?}"
+        );
+
+        // A gen-2 snapshot flows normally: no busy roots -> the still-busy
+        // turn completes and rings.
+        hub.note_opencode_lane_event(
+            "t-oc",
+            2,
+            1,
+            1,
+            OpencodeLaneEvent::Snapshot { statuses: vec![] },
+        );
+        let complete = next_frame_of_type(&mut rx, "terminal.turn.complete", 1_500)
+            .await
+            .expect("current-generation events flow normally");
+        assert_eq!(complete["provider"], "opencode");
+        assert_eq!(complete["terminalId"], "t-oc");
+        let idle = next_frame_of_type(&mut rx, "terminal.idle", 3_500)
+            .await
+            .expect("the completed turn rings after the grace");
+        assert_eq!(idle["terminalId"], "t-oc");
     }
 }

--- a/crates/freshell-ws/src/activity.rs
+++ b/crates/freshell-ws/src/activity.rs
@@ -168,8 +168,6 @@ enum HubEvent {
     /// `generation` is the hub-issued attach generation the ingress guard
     /// matches against `opencode_lanes`; `cycle`/`stream` guard intra-lane
     /// reconnect staleness inside the tracker.
-    /// dead_code: until Task 9 lands, hub-level tests are the only producer.
-    #[allow(dead_code)]
     OpencodeLane {
         terminal_id: String,
         generation: u64,
@@ -177,13 +175,20 @@ enum HubEvent {
         stream: u64,
         event: OpencodeLaneEvent,
     },
+    /// Task 9: attach (or re-attach) a terminal's opencode SSE lane.
+    /// Channel-deferred so the hub task issues the attach generation and
+    /// swaps the lane registry entry serially with Exit (A6).
+    OpencodeAttach {
+        terminal_id: String,
+        base_url: String,
+    },
 }
 
-/// The opencode SSE lane's event vocabulary (Task 9 produces these from the
-/// per-pane sidecar's `/event` stream + `/session/status` snapshots; the hub
-/// routes them into the pure `OpencodeActivityTracker`).
-/// dead_code: until Task 9 lands, hub-level tests are the only producer.
-#[allow(dead_code)]
+/// The opencode SSE lane's event vocabulary ([`crate::opencode_lane`]
+/// produces these from the per-pane sidecar's `/event` stream +
+/// `/session/status` snapshots; the hub routes them into the pure
+/// `OpencodeActivityTracker`).
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum OpencodeLaneEvent {
     /// `/session/status` snapshot (absence == idle).
     Snapshot {
@@ -266,9 +271,22 @@ struct HubInner {
     /// Task 8/9: terminal id → (hub-issued attach generation, lane task).
     /// The `OpencodeLane` ingress guard drops any event whose stamped
     /// generation doesn't match the CURRENT entry; Exit removes the entry
-    /// so post-exit stragglers fail the match too. Task 9's SSE lane
-    /// registry populates this for real; hub-level tests insert dummies.
+    /// so post-exit stragglers fail the match too. The `OpencodeAttach`
+    /// arm populates this for real; hub-level tests insert dummies.
     opencode_lanes: HashMap<String, (u64, tokio::task::JoinHandle<()>)>,
+    /// Task 9: monotonic attach-generation counter — bumped on EVERY
+    /// `OpencodeAttach` (A6), so events from a replaced lane can never
+    /// impersonate its successor.
+    opencode_lane_next_generation: u64,
+    /// Task 9: the SSE lane's injected IO seams. `None` until installed
+    /// (Task 10 wires the reqwest impls at boot); attach without deps only
+    /// retires old lanes.
+    opencode_lane_deps: Option<Arc<crate::opencode_lane::OpencodeLaneDeps>>,
+    /// Test-only send-side recorder of `note_opencode_lane_event` calls:
+    /// (generation, cycle, stream, event), in call order. The stamps are
+    /// not wire-visible, so lane tests pin them here.
+    #[cfg(test)]
+    lane_ingress_log: Vec<(u64, u64, u64, OpencodeLaneEvent)>,
 }
 
 /// Cloneable handle to the hub (stored on `WsState`).
@@ -405,8 +423,6 @@ impl ActivityHub {
     /// Task 8: generation-stamped SSE-lane ingress (Task 9's lane is the
     /// caller). Channel-deferred like every other producer — the
     /// single-emitter frame-ordering invariant.
-    /// dead_code: until Task 9 lands, hub-level tests are the only caller.
-    #[allow(dead_code)]
     pub(crate) fn note_opencode_lane_event(
         &self,
         terminal_id: &str,
@@ -415,6 +431,15 @@ impl ActivityHub {
         stream: u64,
         event: OpencodeLaneEvent,
     ) {
+        // Test-only send-side recorder: generation/cycle/stream stamps are
+        // not wire-visible (frames carry neither), so lane tests pin them
+        // here — BEFORE the ingress guard, recording what the lane produced.
+        #[cfg(test)]
+        self.inner
+            .lock()
+            .expect("activity hub lock")
+            .lane_ingress_log
+            .push((generation, cycle, stream, event.clone()));
         let _ = self.tx.send(HubEvent::OpencodeLane {
             terminal_id: terminal_id.to_string(),
             generation,
@@ -424,11 +449,64 @@ impl ActivityHub {
         });
     }
 
-    /// Hub-level episode tests register a dummy `opencode_lanes` entry so
-    /// their injected lane events pass the generation guard without
-    /// spawning a real SSE lane (Task 9 owns the real registry).
+    /// Task 9: install the SSE lane's injected IO seams (reqwest impls in
+    /// production; fakes in tests). Option'd — hub tests that never attach
+    /// leave it unset, and `OpencodeAttach` then only retires old lanes.
+    /// dead_code: Task 10's boot wiring is the production caller.
+    #[allow(dead_code)]
+    pub(crate) fn set_opencode_lane_deps(&self, deps: Arc<crate::opencode_lane::OpencodeLaneDeps>) {
+        let mut inner = self.inner.lock().expect("activity hub lock");
+        inner.opencode_lane_deps = Some(deps);
+    }
+
+    /// Task 9: attach (or re-attach) the per-terminal opencode SSE lane.
+    /// Channel-deferred (mirror of `attach_codex_rollout`) so the hub task
+    /// issues the attach generation and swaps the registry entry serially
+    /// with Exit — the single-emitter frame-ordering invariant.
+    pub fn attach_opencode_serve(&self, terminal_id: &str, hostname: &str, port: u16) {
+        let _ = self.tx.send(HubEvent::OpencodeAttach {
+            terminal_id: terminal_id.to_string(),
+            base_url: format!("http://{hostname}:{port}"),
+        });
+    }
+
+    /// Test-only view of the send-side lane ingress recorder.
     #[cfg(test)]
-    fn register_opencode_lane_for_tests(&self, terminal_id: &str, generation: u64) {
+    pub(crate) fn lane_ingress_log(&self) -> Vec<(u64, u64, u64, OpencodeLaneEvent)> {
+        self.inner
+            .lock()
+            .expect("activity hub lock")
+            .lane_ingress_log
+            .clone()
+    }
+
+    /// Test-only view of the lane registry size.
+    #[cfg(test)]
+    pub(crate) fn opencode_lane_count(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("activity hub lock")
+            .opencode_lanes
+            .len()
+    }
+
+    /// Test-only view of a terminal's current attach generation.
+    #[cfg(test)]
+    pub(crate) fn opencode_lane_generation(&self, terminal_id: &str) -> Option<u64> {
+        self.inner
+            .lock()
+            .expect("activity hub lock")
+            .opencode_lanes
+            .get(terminal_id)
+            .map(|(generation, _)| *generation)
+    }
+
+    /// Hub-level episode tests register a dummy `opencode_lanes` entry so
+    /// their injected lane events pass the generation guard without going
+    /// through `OpencodeAttach`; `opencode_lane` tests use it to admit a
+    /// directly-spawned lane's stamped generation.
+    #[cfg(test)]
+    pub(crate) fn register_opencode_lane_for_tests(&self, terminal_id: &str, generation: u64) {
         let mut inner = self.inner.lock().expect("activity hub lock");
         inner.opencode_lanes.insert(
             terminal_id.to_string(),
@@ -811,6 +889,58 @@ impl ActivityHub {
                     opencode_frames(&mut inner.idle, effects)
                 };
                 self.emit(frames);
+            }
+            HubEvent::OpencodeAttach {
+                terminal_id,
+                base_url,
+            } => {
+                let mut inner = self.inner.lock().expect("activity hub lock");
+                // Deferred-attach guard (mirror of `attach_codex_lane`'s):
+                // an Exit processed before this attach already tore the
+                // terminal down — spawning now would leak a lane task
+                // nothing ever removes. Race-free because Exit and
+                // OpencodeAttach are processed serially on the hub task.
+                if inner.modes.get(&terminal_id).map(String::as_str) != Some("opencode") {
+                    tracing::debug!(
+                        terminal_id = %terminal_id,
+                        "opencode lane attach skipped: terminal no longer tracked"
+                    );
+                    return;
+                }
+                // A6: hub-issued monotonic generation, bumped on EVERY
+                // attach — events from a replaced lane can never impersonate
+                // the current one.
+                inner.opencode_lane_next_generation += 1;
+                let generation = inner.opencode_lane_next_generation;
+                match inner.opencode_lane_deps.clone() {
+                    Some(deps) => {
+                        let handle = crate::opencode_lane::spawn_opencode_lane(
+                            deps,
+                            self.clone(),
+                            terminal_id.clone(),
+                            base_url,
+                            generation,
+                        );
+                        // Replacement is the contract: a respawned pane
+                        // re-allocates a NEW port, so the old lane is
+                        // aborted, never shared. (Its already-enqueued
+                        // events fail the generation guard.)
+                        if let Some((_, old)) = inner
+                            .opencode_lanes
+                            .insert(terminal_id, (generation, handle))
+                        {
+                            old.abort();
+                        }
+                    }
+                    None => {
+                        // No deps installed (unit tests / pre-Task-10 boot):
+                        // still retire any existing lane so stragglers fail
+                        // the guard.
+                        if let Some((_, old)) = inner.opencode_lanes.remove(&terminal_id) {
+                            old.abort();
+                        }
+                    }
+                }
             }
         }
     }
@@ -4883,5 +5013,115 @@ mod tests {
             .await
             .expect("the completed turn rings after the grace");
         assert_eq!(idle["terminalId"], "t-oc");
+    }
+
+    /// Task 9: `OpencodeAttach` spawns the SSE lane under a hub-issued
+    /// generation, a re-attach REPLACES it (generation bumps, still exactly
+    /// one lane), and Exit tears the registry entry down (post-exit
+    /// stragglers fail the generation match).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_attach_replaces_the_lane_and_exit_tears_it_down() {
+        use crate::opencode_lane::{
+            ConnectedOpencodeStream, OpencodeEventStream, OpencodeLaneDeps, OpencodeLaneHttp,
+        };
+
+        /// A health endpoint that never answers: the spawned lane parks in
+        /// its health-wait, so the test observes pure registry bookkeeping.
+        struct PendingHttp;
+        impl OpencodeLaneHttp for PendingHttp {
+            fn get_json<'a>(
+                &'a self,
+                _url: &'a str,
+            ) -> futures::future::BoxFuture<'a, Result<(u16, serde_json::Value), String>>
+            {
+                Box::pin(async {
+                    std::future::pending::<()>().await;
+                    unreachable!()
+                })
+            }
+        }
+        struct NeverConnects;
+        impl OpencodeEventStream for NeverConnects {
+            fn connect<'a>(
+                &'a self,
+                _url: &'a str,
+            ) -> futures::future::BoxFuture<'a, Result<Box<dyn ConnectedOpencodeStream>, String>>
+            {
+                Box::pin(async {
+                    std::future::pending::<()>().await;
+                    unreachable!()
+                })
+            }
+        }
+
+        async fn wait_until(pred: impl Fn() -> bool, what: &str) {
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(2_000);
+            while !pred() {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "timed out waiting for: {what}"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        }
+
+        let (hub, _rx) = hub();
+        hub.set_opencode_lane_deps(Arc::new(OpencodeLaneDeps {
+            http: Arc::new(PendingHttp),
+            events: Arc::new(NeverConnects),
+        }));
+        observer_send(
+            &hub,
+            ActivityEvent::Created {
+                terminal_id: "t-oc".into(),
+                mode: "opencode".into(),
+                resume_session_id: None,
+                at: 1_000,
+            },
+        );
+
+        hub.attach_opencode_serve("t-oc", "127.0.0.1", 4096);
+        {
+            let hub = hub.clone();
+            wait_until(
+                move || hub.opencode_lane_generation("t-oc") == Some(1),
+                "first attach registers generation 1",
+            )
+            .await;
+        }
+        assert_eq!(hub.opencode_lane_count(), 1);
+
+        // Re-attach REPLACES the lane (respawn re-allocates a NEW port):
+        // generation bumps, still exactly one lane.
+        hub.attach_opencode_serve("t-oc", "127.0.0.1", 4097);
+        {
+            let hub = hub.clone();
+            wait_until(
+                move || hub.opencode_lane_generation("t-oc") == Some(2),
+                "second attach bumps to generation 2",
+            )
+            .await;
+        }
+        assert_eq!(hub.opencode_lane_count(), 1);
+
+        // Exit tears the lane down: the map removal also makes post-exit
+        // stragglers fail the generation match.
+        observer_send(
+            &hub,
+            ActivityEvent::Exit {
+                terminal_id: "t-oc".into(),
+                at: 2_000,
+                spontaneous: false,
+            },
+        );
+        {
+            let hub = hub.clone();
+            wait_until(
+                move || hub.opencode_lane_count() == 0,
+                "exit removes the lane entry",
+            )
+            .await;
+        }
+        assert_eq!(hub.opencode_lane_generation("t-oc"), None);
     }
 }

--- a/crates/freshell-ws/src/lib.rs
+++ b/crates/freshell-ws/src/lib.rs
@@ -35,6 +35,7 @@ pub mod existence;
 pub mod identity;
 pub mod invariants;
 pub mod opencode_association;
+pub(crate) mod opencode_lane;
 pub mod opencode_signal;
 pub mod origin;
 pub mod pane_identity_binder;

--- a/crates/freshell-ws/src/lib.rs
+++ b/crates/freshell-ws/src/lib.rs
@@ -35,7 +35,7 @@ pub mod existence;
 pub mod identity;
 pub mod invariants;
 pub mod opencode_association;
-pub(crate) mod opencode_lane;
+pub mod opencode_lane;
 pub mod opencode_signal;
 pub mod origin;
 pub mod pane_identity_binder;

--- a/crates/freshell-ws/src/opencode_association.rs
+++ b/crates/freshell-ws/src/opencode_association.rs
@@ -165,6 +165,13 @@ pub(crate) async fn drain_and_associate(state: &WsState) {
             &located.session_id,
             entry.cwd.clone(),
         );
+        // Task 10: feed the identity proof into the activity hub — the
+        // opencode tracker's deferred (awaitingAssociation) completions
+        // release on this bind (channel-deferred, safe off the sweep task;
+        // codex_identity.rs:221 precedent).
+        if let Some(hub) = &state.activity {
+            hub.bind_opencode_session(&located.terminal_id, &located.session_id);
+        }
     }
 }
 

--- a/crates/freshell-ws/src/opencode_lane.rs
+++ b/crates/freshell-ws/src/opencode_lane.rs
@@ -1,0 +1,1364 @@
+//! Task 9: the per-terminal opencode SSE lane — the transport-only event
+//! pump between one pane's embedded `opencode serve` (loopback HTTP+SSE) and
+//! the activity hub's generation-guarded ingress
+//! ([`ActivityHub::note_opencode_lane_event`]). Policy lives in the pure
+//! tracker (`freshell-activity/src/opencode.rs`); this lane only gates on
+//! health, subscribes, snapshots, translates, and reconnects.
+//!
+//! Cycle shape (Node `runMonitor:321-348` + `consumeEvents:411-471` parity —
+//! connect BEFORE snapshot, A5):
+//! 1. health-wait (bounded per cycle) + the log-once version drift gate;
+//! 2. two-phase connect: resolves only on the FIRST `server.connected`
+//!    frame, detected on the RAW decoded SSE event BEFORE
+//!    `parse_serve_event` (which swallows it); frames past the ack are
+//!    buffered by the returned handle, never dropped;
+//! 3. `/session/status` snapshot — loss-free ONLY because the subscription
+//!    already stands: every transition is either IN the snapshot or ON the
+//!    open stream (/event has no replay; derives from opencode 1.18.11);
+//! 4. flush the buffered frames in order, then pump live events, root-
+//!    resolving unknown session ids over HTTP before forwarding (A4);
+//! 5. backoff + reconnect with cycle/stream bumps.
+//!
+//! All IO is injected behind [`OpencodeLaneHttp`] / [`OpencodeEventStream`]
+//! so the lane is unit-testable with fakes; the reqwest production impls
+//! live at the bottom (wired at boot by Task 10).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use freshell_activity::opencode::OpencodeStatus;
+use freshell_opencode::{parse_serve_event, ParsedServeEvent};
+
+use crate::activity::{ActivityHub, OpencodeLaneEvent};
+
+pub(crate) const OPENCODE_HEALTH_POLL_MS: u64 = 200; // mirrors Node :18
+pub(crate) const OPENCODE_HEALTH_TIMEOUT_MS: u64 = 15_000; // per cycle, Node :20
+pub(crate) const OPENCODE_RECONNECT_BASE_MS: u64 = 250; // Node :21
+pub(crate) const OPENCODE_RECONNECT_MAX_MS: u64 = 5_000; // Node :22
+pub(crate) const OPENCODE_READ_STALL_MS: u64 = 30_000; // Node :24 (production stream impl)
+/// Version drift gate (log-once per lane): prefix match against the REQUIRED
+/// `version` field of GET /global/health (derives from opencode 1.18.11:
+/// { healthy, version } are both required; session.idle is already deprecated
+/// upstream and a v1->v2 event/health migration is in progress — D8(h)).
+pub(crate) const TESTED_OPENCODE_VERSION_RANGE: &str = "1.18.";
+
+/// `true` when `version` is inside the tested vocabulary range. Out-of-range
+/// versions log ONCE per lane and keep bells on (best-effort; D8(h)).
+pub(crate) fn version_in_tested_range(version: &str) -> bool {
+    version.starts_with(TESTED_OPENCODE_VERSION_RANGE)
+}
+
+/// Injected HTTP seam: one JSON GET (health poll, `/session/status`
+/// snapshot, `/session/{id}` root resolve). The production impl applies the
+/// 2s per-request timeout.
+pub(crate) trait OpencodeLaneHttp: Send + Sync {
+    fn get_json<'a>(
+        &'a self,
+        url: &'a str,
+    ) -> futures::future::BoxFuture<'a, Result<(u16, serde_json::Value), String>>;
+}
+
+/// Injected SSE seam.
+pub(crate) trait OpencodeEventStream: Send + Sync {
+    /// Two-phase connect (Node connect-then-snapshot parity, A5): resolves
+    /// once the subscription is CONFIRMED — on the FIRST `server.connected`
+    /// SSE frame, detected on the raw decoded event BEFORE `parse_serve_event`
+    /// (which swallows it). Frames arriving after the ack are BUFFERED by the
+    /// returned handle, never dropped.
+    fn connect<'a>(
+        &'a self,
+        url: &'a str,
+    ) -> futures::future::BoxFuture<'a, Result<Box<dyn ConnectedOpencodeStream>, String>>;
+}
+
+/// A connected, ack'd `/event` subscription.
+pub(crate) trait ConnectedOpencodeStream: Send {
+    /// Deliver the buffered frames in order, then live parsed events, by
+    /// sending each into `events_tx` until the stream ends (returns on
+    /// disconnect; the sender is dropped on return, which is what lets the
+    /// lane's pump loop drain to `None`). The seam is a CHANNEL rather than a
+    /// sync callback because per-event handling must AWAIT the lane-level
+    /// HTTP root resolver (`OpencodeLaneHttp::get_json` is async) before
+    /// forwarding to the hub — that async work lives in the lane's pump loop
+    /// (below), which owns `known_sessions` mutably. FIFO channel + one
+    /// sequential pump preserves per-stream event ordering.
+    fn drive(
+        self: Box<Self>,
+        events_tx: tokio::sync::mpsc::UnboundedSender<ParsedServeEvent>,
+    ) -> futures::future::BoxFuture<'static, Result<(), String>>;
+}
+
+/// The lane's injected IO seams. Installed on the hub once at boot
+/// (`ActivityHub::set_opencode_lane_deps`); fakes in tests.
+pub(crate) struct OpencodeLaneDeps {
+    pub http: Arc<dyn OpencodeLaneHttp>,
+    pub events: Arc<dyn OpencodeEventStream>,
+}
+
+/// Spawn the per-terminal lane task. `generation` is hub-issued at attach
+/// (A6) and stamped on EVERY `note_opencode_lane_event` call, so the hub's
+/// ingress guard can drop stragglers from replaced lanes whole.
+pub(crate) fn spawn_opencode_lane(
+    deps: Arc<OpencodeLaneDeps>,
+    hub: ActivityHub,
+    terminal_id: String,
+    base_url: String,
+    generation: u64,
+) -> tokio::task::JoinHandle<()> {
+    let lane = Lane {
+        deps,
+        hub,
+        terminal_id,
+        base_url,
+        generation,
+    };
+    tokio::spawn(lane.run())
+}
+
+/// Abort the inner drive task when the lane task itself is aborted/dropped —
+/// tokio never cancels children, so without this the drive task (and the
+/// response body it owns) would outlive the `opencode_lanes` teardown.
+struct AbortOnDrop(tokio::task::JoinHandle<Result<(), String>>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// The lane task's fixed identity; per-cycle state lives in `run`'s locals.
+struct Lane {
+    deps: Arc<OpencodeLaneDeps>,
+    hub: ActivityHub,
+    terminal_id: String,
+    base_url: String,
+    generation: u64,
+}
+
+impl Lane {
+    fn note(&self, cycle: u64, stream: u64, event: OpencodeLaneEvent) {
+        self.hub
+            .note_opencode_lane_event(&self.terminal_id, self.generation, cycle, stream, event);
+    }
+
+    async fn run(self) {
+        let mut cycle: u64 = 0;
+        let mut stream: u64 = 0;
+        let mut backoff = OPENCODE_RECONNECT_BASE_MS;
+        let mut warned_version = false;
+        // Lane-lifetime root-resolver memory (A4): ids already announced to
+        // the hub via SessionCreated (streamed or synthetic).
+        let mut known_sessions: HashSet<String> = HashSet::new();
+
+        loop {
+            cycle += 1;
+            let streamed_ok = 'cycle: {
+                // 1. health-wait (bounded per cycle) + log-once version gate.
+                if !self.wait_healthy(&mut warned_version).await {
+                    break 'cycle false;
+                }
+
+                // 2. two-phase connect (A5): resolves once SUBSCRIBED (the
+                //    first raw server.connected frame); frames decoded past
+                //    the ack are buffered inside `conn`, never dropped.
+                stream += 1;
+                let url = format!("{}/event", self.base_url);
+                let conn = match self.deps.events.connect(&url).await {
+                    Ok(conn) => conn,
+                    Err(error) => {
+                        tracing::debug!(
+                            terminal_id = %self.terminal_id,
+                            %error,
+                            "opencode lane connect failed; backing off"
+                        );
+                        break 'cycle false;
+                    }
+                };
+
+                // 3. snapshot AFTER the subscription ack: every transition is
+                //    either IN the snapshot or ON the already-open stream —
+                //    /event has no replay (derives from opencode 1.18.11).
+                let statuses = match self.fetch_snapshot().await {
+                    Ok(statuses) => statuses,
+                    Err(error) => {
+                        tracing::debug!(
+                            terminal_id = %self.terminal_id,
+                            %error,
+                            "opencode lane snapshot failed; backing off"
+                        );
+                        break 'cycle false;
+                    }
+                };
+                // Root-resolve unknown snapshot session ids FIRST, then note.
+                for (session_id, _) in &statuses {
+                    self.resolve_root(cycle, stream, session_id, &mut known_sessions)
+                        .await;
+                }
+                self.note(cycle, stream, OpencodeLaneEvent::Snapshot { statuses });
+
+                // 4. drive + pump (channel seam — per-event handling must
+                //    AWAIT the async root resolver, so a sync callback cannot
+                //    be the seam). Buffered frames flush IN ORDER, then live.
+                let (events_tx, mut events_rx) = tokio::sync::mpsc::unbounded_channel();
+                let mut drive_task = AbortOnDrop(tokio::spawn(conn.drive(events_tx)));
+                while let Some(parsed) = events_rx.recv().await {
+                    let Some(event) = translate_serve_event(&parsed) else {
+                        continue;
+                    };
+                    match &event {
+                        OpencodeLaneEvent::SessionCreated {
+                            session_id,
+                            parent_id,
+                        } => {
+                            known_sessions.insert(session_id.clone());
+                            if let Some(parent_id) = parent_id {
+                                known_sessions.insert(parent_id.clone());
+                            }
+                        }
+                        OpencodeLaneEvent::Status { session_id, .. }
+                        | OpencodeLaneEvent::SessionIdle { session_id }
+                        | OpencodeLaneEvent::SessionError { session_id, .. }
+                        | OpencodeLaneEvent::PermissionAsked { session_id, .. } => {
+                            self.resolve_root(cycle, stream, session_id, &mut known_sessions)
+                                .await;
+                        }
+                        // No session id to resolve.
+                        OpencodeLaneEvent::PermissionReplied { .. }
+                        | OpencodeLaneEvent::Snapshot { .. } => {}
+                    }
+                    self.note(cycle, stream, event);
+                }
+                // rx drains to None only after drive dropped the sender on
+                // disconnect — every buffered/live event was pumped, none
+                // lost. Ok(Ok(())) == clean stream end.
+                matches!((&mut drive_task.0).await, Ok(Ok(())))
+            };
+
+            if streamed_ok {
+                // A successful streamed cycle resets the backoff to base.
+                backoff = OPENCODE_RECONNECT_BASE_MS;
+            }
+            // 5. backoff between cycles (doubled after failures, capped).
+            tokio::time::sleep(Duration::from_millis(backoff)).await;
+            backoff = (backoff * 2).min(OPENCODE_RECONNECT_MAX_MS);
+        }
+    }
+
+    /// Step 1: poll GET {base}/global/health every
+    /// [`OPENCODE_HEALTH_POLL_MS`], up to [`OPENCODE_HEALTH_TIMEOUT_MS`]
+    /// this cycle — the outer timeout also bounds a wedged probe (the
+    /// DEV-0001 lesson: never let one stalled response defeat the deadline).
+    /// Healthy == HTTP 200. On a healthy response, run the log-once version
+    /// drift gate: bells stay ON either way (best-effort; D8(h)).
+    async fn wait_healthy(&self, warned_version: &mut bool) -> bool {
+        let url = format!("{}/global/health", self.base_url);
+        let poll = async {
+            loop {
+                if let Ok((200, body)) = self.deps.http.get_json(&url).await {
+                    // Read the REQUIRED `version` field (derives from
+                    // opencode 1.18.11: /global/health returns
+                    // { healthy, version }, both required).
+                    let version = body.get("version").and_then(|v| v.as_str()).unwrap_or("");
+                    if !version_in_tested_range(version) && !*warned_version {
+                        tracing::warn!(
+                            terminal_id = %self.terminal_id,
+                            "opencode {version} untested for attention-bell vocabulary (tested: 1.18.x); bells stay on"
+                        );
+                        *warned_version = true;
+                    }
+                    return true;
+                }
+                tokio::time::sleep(Duration::from_millis(OPENCODE_HEALTH_POLL_MS)).await;
+            }
+        };
+        tokio::time::timeout(Duration::from_millis(OPENCODE_HEALTH_TIMEOUT_MS), poll)
+            .await
+            .unwrap_or(false)
+    }
+
+    /// Step 3: GET {base}/session/status → object map. Entries whose
+    /// `status.type` is busy/retry map to Busy/Retry; a literal
+    /// `{"type":"idle"}` entry parses as Idle (defensive — the live server
+    /// DROPS idle sessions; absence == idle; opencode 1.18.11). Unknown
+    /// status vocabulary is skipped: the transport stays conservative.
+    async fn fetch_snapshot(&self) -> Result<Vec<(String, OpencodeStatus)>, String> {
+        let url = format!("{}/session/status", self.base_url);
+        let (status, body) = self.deps.http.get_json(&url).await?;
+        if status != 200 {
+            return Err(format!("GET /session/status returned {status}"));
+        }
+        let map = body
+            .as_object()
+            .ok_or_else(|| "GET /session/status: body is not an object".to_string())?;
+        let mut statuses = Vec::new();
+        for (session_id, entry) in map {
+            match entry.get("type").and_then(|t| t.as_str()) {
+                Some("busy") => statuses.push((session_id.clone(), OpencodeStatus::Busy)),
+                Some("retry") => statuses.push((session_id.clone(), OpencodeStatus::Retry)),
+                Some("idle") => statuses.push((session_id.clone(), OpencodeStatus::Idle)),
+                _ => {}
+            }
+        }
+        Ok(statuses)
+    }
+
+    /// Lane-level HTTP root resolver (A4 — the Node `resolveRootForEvent` /
+    /// `classifySnapshotStatuses` seam, ported to HTTP). A session id unseen
+    /// on-stream is resolved via GET {base}/session/{id} and announced to
+    /// the hub as synthetic `SessionCreated` events BEFORE the triggering
+    /// event — first walking the `parentID` chain while the parent is itself
+    /// unknown, then emitting deepest ancestor first, so every mapping lands
+    /// before its dependents. On resolve failure (non-200, timeout, shape
+    /// mismatch) nothing is emitted or remembered: the caller forwards the
+    /// triggering event anyway (the tracker's conservative-ambiguity
+    /// behavior stands) and the next unknown-id occurrence retries.
+    ///
+    /// Runs in the lane task itself — inside the step-4 pump for streamed
+    /// events, inline in step 3 for snapshot entries — so every
+    /// `deps.http.get_json` await happens where `&mut known_sessions` is
+    /// directly in scope, and the sequential pump preserves the
+    /// emit-before-trigger ordering.
+    // derives from opencode 1.18.11: GET /session/{id} exposes parentID; /event has no replay
+    async fn resolve_root(
+        &self,
+        cycle: u64,
+        stream: u64,
+        session_id: &str,
+        known_sessions: &mut HashSet<String>,
+    ) {
+        if known_sessions.contains(session_id) {
+            return;
+        }
+        // (id, parent) pairs, triggering id first.
+        let mut chain: Vec<(String, Option<String>)> = Vec::new();
+        let mut current = session_id.to_string();
+        loop {
+            let url = format!("{}/session/{current}", self.base_url);
+            let (status, body) = match self.deps.http.get_json(&url).await {
+                Ok(response) => response,
+                Err(error) => {
+                    tracing::debug!(
+                        terminal_id = %self.terminal_id,
+                        session_id = %current,
+                        %error,
+                        "opencode root resolve failed; forwarding unresolved"
+                    );
+                    return;
+                }
+            };
+            if status != 200 || !body.is_object() {
+                tracing::debug!(
+                    terminal_id = %self.terminal_id,
+                    session_id = %current,
+                    status,
+                    "opencode root resolve rejected; forwarding unresolved"
+                );
+                return;
+            }
+            let parent_id = body
+                .get("parentID")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            chain.push((current.clone(), parent_id.clone()));
+            match parent_id {
+                // Walk up only while the parent is unknown; the chain guard
+                // breaks a (malformed) parentID cycle.
+                Some(parent)
+                    if !known_sessions.contains(&parent)
+                        && !chain.iter().any(|(id, _)| id == &parent) =>
+                {
+                    current = parent;
+                }
+                _ => break,
+            }
+        }
+        // Deepest ancestor first: the root mapping lands before dependents.
+        for (id, parent_id) in chain.into_iter().rev() {
+            known_sessions.insert(id.clone());
+            if let Some(parent) = &parent_id {
+                known_sessions.insert(parent.clone());
+            }
+            self.note(
+                cycle,
+                stream,
+                OpencodeLaneEvent::SessionCreated {
+                    session_id: id,
+                    parent_id,
+                },
+            );
+        }
+    }
+}
+
+/// Translate one parsed serve event into the hub's lane vocabulary. Kinds
+/// and property paths are verbatim from the spike (vocabulary.md).
+pub(crate) fn translate_serve_event(event: &ParsedServeEvent) -> Option<OpencodeLaneEvent> {
+    let props = &event.properties;
+    match event.kind.as_str() {
+        "session.created" => {
+            let info = props.get("info")?.as_object()?;
+            let session_id = info.get("id")?.as_str()?.to_string();
+            let parent_id = info
+                .get("parentID")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            Some(OpencodeLaneEvent::SessionCreated {
+                session_id,
+                parent_id,
+            })
+        }
+        "session.status" => {
+            let session_id = props.get("sessionID")?.as_str()?.to_string();
+            let status = match props.get("status")?.get("type")?.as_str()? {
+                "idle" => OpencodeStatus::Idle,
+                // schema-declared, never observed live (opencode 1.18.11) — busy-equivalent
+                "retry" => OpencodeStatus::Retry,
+                _ => OpencodeStatus::Busy,
+            };
+            Some(OpencodeLaneEvent::Status { session_id, status })
+        }
+        "session.idle" => Some(OpencodeLaneEvent::SessionIdle {
+            session_id: props.get("sessionID")?.as_str()?.to_string(),
+        }),
+        "session.error" => Some(OpencodeLaneEvent::SessionError {
+            session_id: props.get("sessionID")?.as_str()?.to_string(),
+            error_name: props
+                .get("error")
+                .and_then(|e| e.get("name"))
+                .and_then(|n| n.as_str())
+                .unwrap_or("UnknownError")
+                .to_string(),
+        }),
+        "permission.asked" => Some(OpencodeLaneEvent::PermissionAsked {
+            session_id: props.get("sessionID")?.as_str()?.to_string(),
+            permission_id: props.get("id")?.as_str()?.to_string(),
+        }),
+        "permission.replied" => Some(OpencodeLaneEvent::PermissionReplied {
+            permission_id: props.get("requestID")?.as_str()?.to_string(),
+        }),
+        "message.updated" => {
+            // W2 abort marker (derives from opencode 1.18.11): an abort landing
+            // between assistant-message creation and LLM stream start emits NO
+            // session.error — only message.updated with info.error.name ===
+            // "MessageAbortedError", always BEFORE idle. Error-less
+            // message.updated is routine message churn -> None. Both abort
+            // signals feed the same SessionError lane event (D1).
+            let session_id = props.get("sessionID")?.as_str()?.to_string();
+            let error_name = props
+                .get("info")?
+                .get("error")?
+                .get("name")?
+                .as_str()?
+                .to_string();
+            Some(OpencodeLaneEvent::SessionError {
+                session_id,
+                error_name,
+            })
+        }
+        // message.part.*, message.removed, session.updated, session.diff,
+        // plugin.added, ... are activity-irrelevant.
+        _ => None,
+    }
+}
+
+// ── production impls (reqwest; wired at boot by Task 10) ────────────────────
+
+/// Production [`OpencodeLaneHttp`]: `GET url` with the 2s per-request timeout
+/// (the loopback serve's AbortController analog — DEV-0001), JSON body.
+/// dead_code: constructed by Task 10's boot wiring; the seam lands here.
+#[allow(dead_code)]
+pub(crate) struct ReqwestLaneHttp(reqwest::Client);
+
+#[allow(dead_code)]
+impl ReqwestLaneHttp {
+    pub(crate) fn new() -> Self {
+        // Loopback plain-HTTP only; a plain client never fails to build.
+        Self(
+            reqwest::Client::builder()
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+        )
+    }
+}
+
+impl OpencodeLaneHttp for ReqwestLaneHttp {
+    fn get_json<'a>(
+        &'a self,
+        url: &'a str,
+    ) -> futures::future::BoxFuture<'a, Result<(u16, serde_json::Value), String>> {
+        Box::pin(async move {
+            let response = self
+                .0
+                .get(url)
+                .timeout(Duration::from_secs(2))
+                .send()
+                .await
+                .map_err(|e| e.to_string())?;
+            let status = response.status().as_u16();
+            let bytes = response.bytes().await.map_err(|e| e.to_string())?;
+            let body = serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
+            Ok((status, body))
+        })
+    }
+}
+
+/// Production [`OpencodeEventStream`]: GET `{base}/event` with
+/// `accept: text/event-stream`, then a chunk loop with the
+/// [`OPENCODE_READ_STALL_MS`] per-chunk read-stall watchdog (heartbeats
+/// arrive every ~10s) and a byte pending-buffer for partial UTF-8 — the
+/// shape of `freshell_opencode::transport::consume_events:145-198`, WITHOUT
+/// its internal reconnect loop (the lane owns cycles).
+/// dead_code: constructed by Task 10's boot wiring; the seam lands here.
+#[allow(dead_code)]
+pub(crate) struct ReqwestLaneStream(reqwest::Client);
+
+#[allow(dead_code)]
+impl ReqwestLaneStream {
+    pub(crate) fn new() -> Self {
+        Self(
+            reqwest::Client::builder()
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+        )
+    }
+}
+
+impl OpencodeEventStream for ReqwestLaneStream {
+    fn connect<'a>(
+        &'a self,
+        url: &'a str,
+    ) -> futures::future::BoxFuture<'a, Result<Box<dyn ConnectedOpencodeStream>, String>> {
+        Box::pin(async move {
+            // Bound the request send like a stalled chunk read. The SSE GET
+            // carries NO reqwest per-request timeout — that would kill the
+            // long-lived stream body; the per-chunk watchdog covers reads.
+            let response = tokio::time::timeout(
+                Duration::from_millis(OPENCODE_READ_STALL_MS),
+                self.0.get(url).header("accept", "text/event-stream").send(),
+            )
+            .await
+            .map_err(|_| "opencode /event connect stalled".to_string())?
+            .map_err(|e| e.to_string())?;
+            if !response.status().is_success() {
+                return Err(format!("GET /event returned {}", response.status()));
+            }
+            let mut inner = RawSseStream {
+                response,
+                decoder: RawSseDecoder::default(),
+                pending: Vec::new(),
+            };
+            // Two-phase connect: read until the FIRST raw `server.connected`
+            // frame — the subscription ack `parse_serve_event` swallows —
+            // buffering any frames decoded past it, in order.
+            let mut buffered: Vec<ParsedServeEvent> = Vec::new();
+            loop {
+                let values = inner
+                    .next_raw_events()
+                    .await?
+                    .ok_or_else(|| "stream ended before the server.connected ack".to_string())?;
+                let mut acked = false;
+                for value in values {
+                    if !acked
+                        && value.get("type").and_then(|t| t.as_str()) == Some("server.connected")
+                    {
+                        // The ack itself is control-plane, never forwarded.
+                        acked = true;
+                        continue;
+                    }
+                    if acked {
+                        if let Some(parsed) = parse_serve_event(&value) {
+                            buffered.push(parsed);
+                        }
+                    }
+                    // Pre-ack non-ack frames cannot exist (server.connected
+                    // is the serve's first frame; opencode 1.18.11) — dropped
+                    // defensively rather than mis-ordered around the snapshot.
+                }
+                if acked {
+                    return Ok(Box::new(ReqwestConnectedStream { inner, buffered })
+                        as Box<dyn ConnectedOpencodeStream>);
+                }
+            }
+        })
+    }
+}
+
+/// The reqwest `/event` body + raw decode state (pre-`parse_serve_event`).
+struct RawSseStream {
+    response: reqwest::Response,
+    decoder: RawSseDecoder,
+    /// Partial trailing UTF-8 scalar held for the next chunk
+    /// (`TextDecoder{stream:true}` parity).
+    pending: Vec<u8>,
+}
+
+impl RawSseStream {
+    /// One watchdog-bounded chunk read, decoded to raw JSON event values.
+    /// `Ok(None)` = clean stream end; `Err` = read stall or transport error.
+    async fn next_raw_events(&mut self) -> Result<Option<Vec<serde_json::Value>>, String> {
+        let chunk = tokio::time::timeout(
+            Duration::from_millis(OPENCODE_READ_STALL_MS),
+            self.response.chunk(),
+        )
+        .await
+        .map_err(|_| "opencode /event read stalled".to_string())?
+        .map_err(|e| e.to_string())?;
+        let Some(bytes) = chunk else { return Ok(None) };
+        self.pending.extend_from_slice(&bytes);
+        // Decode the longest valid UTF-8 prefix, holding a partial trailing
+        // scalar for the next chunk.
+        let valid_up_to = match std::str::from_utf8(&self.pending) {
+            Ok(_) => self.pending.len(),
+            Err(e) => e.valid_up_to(),
+        };
+        if valid_up_to == 0 {
+            return Ok(Some(Vec::new()));
+        }
+        let text = String::from_utf8_lossy(&self.pending[..valid_up_to]).into_owned();
+        self.pending.drain(..valid_up_to);
+        Ok(Some(self.decoder.push_str(&text)))
+    }
+}
+
+/// SSE block decoder yielding RAW JSON values. Mirrors
+/// `freshell_opencode::SseDecoder` block-for-block (CRLF-normalized `\n\n`
+/// boundaries, `:` comments skipped, multi-line `data:` joined, malformed
+/// frames skipped) but stops BEFORE `parse_serve_event` — the two-phase
+/// connect must see `server.connected`, which parsing swallows.
+#[derive(Default)]
+struct RawSseDecoder {
+    buf: String,
+}
+
+impl RawSseDecoder {
+    fn push_str(&mut self, chunk: &str) -> Vec<serde_json::Value> {
+        self.buf.push_str(&chunk.replace("\r\n", "\n"));
+        let mut out = Vec::new();
+        while let Some(idx) = self.buf.find("\n\n") {
+            let block = self.buf[..idx].to_string();
+            self.buf.drain(..idx + 2);
+            if let Some(value) = decode_raw_sse_block(&block) {
+                out.push(value);
+            }
+        }
+        out
+    }
+}
+
+fn decode_raw_sse_block(block: &str) -> Option<serde_json::Value> {
+    let mut data_lines: Vec<String> = Vec::new();
+    for line in block.split('\n') {
+        let trimmed = line.strip_suffix('\r').unwrap_or(line);
+        if trimmed.is_empty() || trimmed.starts_with(':') {
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("data:") {
+            data_lines.push(rest.trim_start().to_string());
+        }
+    }
+    if data_lines.is_empty() {
+        return None;
+    }
+    serde_json::from_str(&data_lines.join("\n")).ok()
+}
+
+/// The ack'd production stream: buffered frames first, then live.
+struct ReqwestConnectedStream {
+    inner: RawSseStream,
+    /// Frames decoded past the subscription ack, awaiting the post-snapshot
+    /// flush.
+    buffered: Vec<ParsedServeEvent>,
+}
+
+impl ConnectedOpencodeStream for ReqwestConnectedStream {
+    fn drive(
+        mut self: Box<Self>,
+        events_tx: tokio::sync::mpsc::UnboundedSender<ParsedServeEvent>,
+    ) -> futures::future::BoxFuture<'static, Result<(), String>> {
+        Box::pin(async move {
+            // Buffered frames FIRST, in order — the loss-free flush that
+            // happens after the lane noted its snapshot.
+            for event in std::mem::take(&mut self.buffered) {
+                if events_tx.send(event).is_err() {
+                    return Ok(());
+                }
+            }
+            loop {
+                match self.inner.next_raw_events().await {
+                    Ok(Some(values)) => {
+                        for value in values {
+                            if let Some(parsed) = parse_serve_event(&value) {
+                                if events_tx.send(parsed).is_err() {
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                    // Clean stream end → the lane reconnects at base backoff.
+                    Ok(None) => return Ok(()),
+                    // Read stall / transport error → backed-off reconnect.
+                    Err(error) => return Err(error),
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use freshell_activity::opencode::OpencodeStatus;
+    use freshell_opencode::{parse_serve_event, ParsedServeEvent, SseDecoder};
+    use serde_json::json;
+
+    use super::*;
+    use crate::activity::{ActivityHub, OpencodeLaneEvent};
+
+    // ── injected fakes (modeled on freshell-opencode/tests/
+    //    serve_health_bounded.rs FakeHttp/FakeAllocator) ──────────────────
+
+    /// Shared call-order log across BOTH fakes so tests can assert
+    /// cross-seam ordering (connect vs the `/session/status` GET).
+    type CallLog = Arc<Mutex<Vec<String>>>;
+
+    type HttpResponder =
+        Box<dyn Fn(&str) -> Result<(u16, serde_json::Value), String> + Send + Sync>;
+
+    struct FakeLaneHttp {
+        log: CallLog,
+        respond: HttpResponder,
+    }
+
+    impl OpencodeLaneHttp for FakeLaneHttp {
+        fn get_json<'a>(
+            &'a self,
+            url: &'a str,
+        ) -> futures::future::BoxFuture<'a, Result<(u16, serde_json::Value), String>> {
+            Box::pin(async move {
+                self.log
+                    .lock()
+                    .expect("call log")
+                    .push(format!("GET {url}"));
+                (self.respond)(url)
+            })
+        }
+    }
+
+    /// One scripted connection: buffered frames (decoded past the
+    /// subscription ack, flushed by `drive` FIRST), then live frames.
+    /// `finish == true` → `drive` returns `Ok(())` after sending (clean
+    /// stream end → the lane reconnects); `false` → `drive` parks forever
+    /// (the cycle stays open, so every stamp stays at this cycle/stream).
+    struct StreamScript {
+        buffered: Vec<ParsedServeEvent>,
+        live: Vec<ParsedServeEvent>,
+        finish: bool,
+    }
+
+    struct FakeLaneStream {
+        log: CallLog,
+        scripts: Mutex<VecDeque<StreamScript>>,
+    }
+
+    impl OpencodeEventStream for FakeLaneStream {
+        fn connect<'a>(
+            &'a self,
+            url: &'a str,
+        ) -> futures::future::BoxFuture<'a, Result<Box<dyn ConnectedOpencodeStream>, String>>
+        {
+            Box::pin(async move {
+                self.log
+                    .lock()
+                    .expect("call log")
+                    .push(format!("CONNECT {url}"));
+                let script = self.scripts.lock().expect("scripts").pop_front();
+                match script {
+                    Some(script) => {
+                        Ok(Box::new(FakeConnected { script }) as Box<dyn ConnectedOpencodeStream>)
+                    }
+                    // Out of scripted cycles: park so the lane goes quiet
+                    // instead of looping through unscripted reconnects.
+                    None => {
+                        std::future::pending::<()>().await;
+                        unreachable!()
+                    }
+                }
+            })
+        }
+    }
+
+    struct FakeConnected {
+        script: StreamScript,
+    }
+
+    impl ConnectedOpencodeStream for FakeConnected {
+        fn drive(
+            self: Box<Self>,
+            events_tx: tokio::sync::mpsc::UnboundedSender<ParsedServeEvent>,
+        ) -> futures::future::BoxFuture<'static, Result<(), String>> {
+            Box::pin(async move {
+                for event in self.script.buffered {
+                    let _ = events_tx.send(event);
+                }
+                for event in self.script.live {
+                    let _ = events_tx.send(event);
+                }
+                if self.script.finish {
+                    Ok(())
+                } else {
+                    std::future::pending::<()>().await;
+                    unreachable!()
+                }
+            })
+        }
+    }
+
+    fn parsed(value: serde_json::Value) -> ParsedServeEvent {
+        parse_serve_event(&value).expect("parseable serve event")
+    }
+
+    fn hub() -> (ActivityHub, tokio::sync::broadcast::Receiver<String>) {
+        let (broadcast_tx, rx) = tokio::sync::broadcast::channel::<String>(256);
+        (ActivityHub::new(Arc::new(broadcast_tx), None), rx)
+    }
+
+    /// Poll the hub's test-only send-side lane-ingress log until it holds at
+    /// least `min_len` entries (or panic on timeout).
+    async fn wait_for_ingress(
+        hub: &ActivityHub,
+        min_len: usize,
+        timeout_ms: u64,
+    ) -> Vec<(u64, u64, u64, OpencodeLaneEvent)> {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+        loop {
+            let log = hub.lane_ingress_log();
+            if log.len() >= min_len {
+                return log;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "ingress log never reached {min_len} entries, got {log:?}"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    }
+
+    /// Wait for the first frame of `wanted` type that also satisfies `pred`
+    /// (same helper shape as activity.rs's tests).
+    async fn next_frame_matching(
+        rx: &mut tokio::sync::broadcast::Receiver<String>,
+        wanted: &str,
+        timeout_ms: u64,
+        pred: impl Fn(&serde_json::Value) -> bool,
+    ) -> Option<serde_json::Value> {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return None;
+            }
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Ok(frame)) => {
+                    let value: serde_json::Value = serde_json::from_str(&frame).ok()?;
+                    if value["type"] == wanted && pred(&value) {
+                        return Some(value);
+                    }
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    // ── the tests ────────────────────────────────────────────────────────
+
+    /// Verbatim spike vocabulary through the REAL decoder chain
+    /// (`SseDecoder` → `parse_serve_event` → `translate_serve_event`):
+    /// every attention-relevant kind maps to its lane event, and the
+    /// activity-irrelevant kinds map to `None`.
+    #[test]
+    fn translate_covers_the_attention_vocabulary() {
+        let frames = [
+            json!({"type":"session.status","properties":{"sessionID":"ses-1","status":{"type":"busy"}}}),
+            json!({"type":"session.status","properties":{"sessionID":"ses-1","status":{"type":"idle"}}}),
+            json!({"type":"session.status","properties":{"sessionID":"ses-1","status":{"type":"retry"}}}),
+            json!({"type":"session.idle","properties":{"sessionID":"ses-1"}}),
+            json!({"type":"session.error","properties":{"sessionID":"ses-1","error":{"name":"MessageAbortedError","data":{"message":"aborted"}}}}),
+            json!({"type":"session.error","properties":{"sessionID":"ses-1","error":{"data":{"message":"boom"}}}}),
+            json!({"type":"permission.asked","properties":{"sessionID":"ses-1","id":"perm-1"}}),
+            json!({"type":"permission.replied","properties":{"sessionID":"ses-1","requestID":"perm-1"}}),
+            json!({"type":"session.created","properties":{"info":{"id":"ses-child","parentID":"ses-root"}}}),
+            json!({"type":"session.created","properties":{"info":{"id":"ses-root"}}}),
+            // W2 abort marker: message.updated WITH info.error.name ===
+            // "MessageAbortedError" is the second abort signal (D1).
+            json!({"type":"message.updated","properties":{"sessionID":"ses-1","info":{"sessionID":"ses-1","error":{"name":"MessageAbortedError"}}}}),
+            // Error-less message.updated is routine message churn.
+            json!({"type":"message.updated","properties":{"sessionID":"ses-1","info":{"sessionID":"ses-1"}}}),
+            json!({"type":"message.part.delta","properties":{"part":{"sessionID":"ses-1"},"delta":"hi"}}),
+            json!({"type":"session.diff","properties":{"sessionID":"ses-1","diff":[]}}),
+        ];
+        let stream: String = frames.iter().map(|f| format!("data: {f}\n\n")).collect();
+        let mut decoder = SseDecoder::new();
+        let events = decoder.push_str(&stream);
+        assert_eq!(
+            events.len(),
+            frames.len(),
+            "every frame decodes: {events:?}"
+        );
+
+        let translated: Vec<Option<OpencodeLaneEvent>> =
+            events.iter().map(translate_serve_event).collect();
+        assert_eq!(
+            translated[0],
+            Some(OpencodeLaneEvent::Status {
+                session_id: "ses-1".into(),
+                status: OpencodeStatus::Busy
+            })
+        );
+        assert_eq!(
+            translated[1],
+            Some(OpencodeLaneEvent::Status {
+                session_id: "ses-1".into(),
+                status: OpencodeStatus::Idle
+            })
+        );
+        assert_eq!(
+            translated[2],
+            Some(OpencodeLaneEvent::Status {
+                session_id: "ses-1".into(),
+                status: OpencodeStatus::Retry
+            })
+        );
+        assert_eq!(
+            translated[3],
+            Some(OpencodeLaneEvent::SessionIdle {
+                session_id: "ses-1".into()
+            })
+        );
+        assert_eq!(
+            translated[4],
+            Some(OpencodeLaneEvent::SessionError {
+                session_id: "ses-1".into(),
+                error_name: "MessageAbortedError".into()
+            })
+        );
+        assert_eq!(
+            translated[5],
+            Some(OpencodeLaneEvent::SessionError {
+                session_id: "ses-1".into(),
+                error_name: "UnknownError".into()
+            }),
+            "a session.error without error.name falls back to UnknownError"
+        );
+        assert_eq!(
+            translated[6],
+            Some(OpencodeLaneEvent::PermissionAsked {
+                session_id: "ses-1".into(),
+                permission_id: "perm-1".into()
+            })
+        );
+        assert_eq!(
+            translated[7],
+            Some(OpencodeLaneEvent::PermissionReplied {
+                permission_id: "perm-1".into()
+            })
+        );
+        assert_eq!(
+            translated[8],
+            Some(OpencodeLaneEvent::SessionCreated {
+                session_id: "ses-child".into(),
+                parent_id: Some("ses-root".into())
+            })
+        );
+        assert_eq!(
+            translated[9],
+            Some(OpencodeLaneEvent::SessionCreated {
+                session_id: "ses-root".into(),
+                parent_id: None
+            })
+        );
+        assert_eq!(
+            translated[10],
+            Some(OpencodeLaneEvent::SessionError {
+                session_id: "ses-1".into(),
+                error_name: "MessageAbortedError".into()
+            }),
+            "the W2 abort marker feeds the same SessionError lane event (D1)"
+        );
+        assert_eq!(
+            translated[11], None,
+            "error-less message.updated is routine churn"
+        );
+        assert_eq!(
+            translated[12], None,
+            "message.part.delta is activity-irrelevant"
+        );
+        assert_eq!(translated[13], None, "session.diff is activity-irrelevant");
+    }
+
+    /// Pure prefix check against `TESTED_OPENCODE_VERSION_RANGE`: "1.18.11"
+    /// passes; "1.19.0" and "2.0.0" fail (the lane logs once and keeps
+    /// bells on).
+    #[test]
+    fn version_gate_matches_only_the_tested_range() {
+        assert!(version_in_tested_range("1.18.11"));
+        assert!(!version_in_tested_range("1.19.0"));
+        assert!(!version_in_tested_range("2.0.0"));
+    }
+
+    /// The cycle shape: health gate (two 500s, then healthy) → two-phase
+    /// connect → `/session/status` snapshot → buffered-frame flush. The
+    /// snapshot is noted BEFORE the buffered `session.idle`, connect
+    /// precedes the snapshot GET, and every ingress event is stamped
+    /// (generation 1, cycle 1, stream 1).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn lane_gates_on_health_then_snapshots_then_streams() {
+        let log: CallLog = Arc::new(Mutex::new(Vec::new()));
+        let health_calls = Arc::new(AtomicUsize::new(0));
+        let health_calls_resp = health_calls.clone();
+        let http = Arc::new(FakeLaneHttp {
+            log: log.clone(),
+            respond: Box::new(move |url| {
+                if url.ends_with("/global/health") {
+                    let n = health_calls_resp.fetch_add(1, Ordering::SeqCst) + 1;
+                    if n <= 2 {
+                        return Ok((500, json!({})));
+                    }
+                    return Ok((200, json!({ "healthy": true, "version": "1.18.11" })));
+                }
+                if url.ends_with("/session/status") {
+                    return Ok((200, json!({ "ses-r": { "type": "busy" } })));
+                }
+                // Root-resolver probes 404: the conservative forward-anyway
+                // path (retried on the next unknown-id occurrence).
+                Ok((404, json!({})))
+            }),
+        });
+        let stream = Arc::new(FakeLaneStream {
+            log: log.clone(),
+            scripts: Mutex::new(VecDeque::from([StreamScript {
+                buffered: vec![parsed(
+                    json!({"type":"session.idle","properties":{"sessionID":"ses-r"}}),
+                )],
+                live: vec![],
+                finish: false, // keep cycle 1 open: all stamps stay (1, 1)
+            }])),
+        });
+        let deps = Arc::new(OpencodeLaneDeps {
+            http,
+            events: stream,
+        });
+
+        let (hub, mut rx) = hub();
+        // A tracked opencode terminal resumed on the root identity, so the
+        // snapshot's busy edge and the idle edge flow end-to-end to the wire.
+        (hub.registry_observer())(freshell_terminal::ActivityEvent::Created {
+            terminal_id: "t-oc".into(),
+            mode: "opencode".into(),
+            resume_session_id: Some("ses-r".into()),
+            at: 1_000,
+        });
+        hub.register_opencode_lane_for_tests("t-oc", 1);
+        let lane = spawn_opencode_lane(deps, hub.clone(), "t-oc".into(), "http://fake".into(), 1);
+
+        // Ingress order + stamping: Snapshot BEFORE the buffered
+        // SessionIdle, all (generation 1, cycle 1, stream 1).
+        let ingress = wait_for_ingress(&hub, 2, 5_000).await;
+        assert_eq!(
+            ingress[0],
+            (
+                1,
+                1,
+                1,
+                OpencodeLaneEvent::Snapshot {
+                    statuses: vec![("ses-r".into(), OpencodeStatus::Busy)]
+                }
+            )
+        );
+        assert_eq!(
+            ingress[1],
+            (
+                1,
+                1,
+                1,
+                OpencodeLaneEvent::SessionIdle {
+                    session_id: "ses-r".into()
+                }
+            )
+        );
+
+        // Call order: three health probes gate the cycle, and connect
+        // precedes the snapshot GET (the two-phase, loss-free ordering).
+        let calls = log.lock().expect("call log").clone();
+        let connect_at = calls
+            .iter()
+            .position(|c| c == "CONNECT http://fake/event")
+            .expect("connect happened");
+        let snapshot_at = calls
+            .iter()
+            .position(|c| c == "GET http://fake/session/status")
+            .expect("snapshot GET happened");
+        assert!(
+            connect_at < snapshot_at,
+            "two-phase connect must precede the snapshot: {calls:?}"
+        );
+        assert_eq!(
+            calls[..connect_at]
+                .iter()
+                .filter(|c| *c == "GET http://fake/global/health")
+                .count(),
+            3,
+            "health gated the cycle (two 500s then healthy): {calls:?}"
+        );
+
+        // End-to-end wire evidence: the events passed the REAL generation
+        // guard — busy upsert from the snapshot, then the idle edge's
+        // turn.complete.
+        let busy = next_frame_matching(&mut rx, "opencode.activity.updated", 5_000, |v| {
+            v["upsert"][0]["phase"] == "busy"
+        })
+        .await
+        .expect("snapshot busy upsert on the wire");
+        assert_eq!(busy["upsert"][0]["terminalId"], "t-oc");
+        let complete = next_frame_matching(&mut rx, "terminal.turn.complete", 5_000, |_| true)
+            .await
+            .expect("the buffered idle edge completes the turn");
+        assert_eq!(complete["provider"], "opencode");
+        assert_eq!(complete["terminalId"], "t-oc");
+
+        lane.abort();
+    }
+
+    /// Every reconnect is a fresh cycle AND a fresh stream: two clean
+    /// streamed cycles note two snapshots stamped (cycle 1, stream 1) then
+    /// (cycle 2, stream 2), each after its own connect.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reconnect_bumps_stream_and_resnapshots() {
+        let log: CallLog = Arc::new(Mutex::new(Vec::new()));
+        let http = Arc::new(FakeLaneHttp {
+            log: log.clone(),
+            respond: Box::new(|url| {
+                if url.ends_with("/global/health") {
+                    return Ok((200, json!({ "healthy": true, "version": "1.18.11" })));
+                }
+                if url.ends_with("/session/status") {
+                    return Ok((200, json!({})));
+                }
+                Ok((404, json!({})))
+            }),
+        });
+        let clean_cycle = || StreamScript {
+            buffered: vec![],
+            live: vec![],
+            finish: true, // drive returns Ok(()) immediately → reconnect
+        };
+        let stream = Arc::new(FakeLaneStream {
+            log: log.clone(),
+            scripts: Mutex::new(VecDeque::from([clean_cycle(), clean_cycle()])),
+        });
+        let deps = Arc::new(OpencodeLaneDeps {
+            http,
+            events: stream,
+        });
+
+        let (hub, _rx) = hub();
+        hub.register_opencode_lane_for_tests("t-oc", 1);
+        let lane = spawn_opencode_lane(deps, hub.clone(), "t-oc".into(), "http://fake".into(), 1);
+
+        let ingress = wait_for_ingress(&hub, 2, 5_000).await;
+        assert_eq!(
+            ingress[0],
+            (1, 1, 1, OpencodeLaneEvent::Snapshot { statuses: vec![] })
+        );
+        assert_eq!(
+            ingress[1],
+            (1, 2, 2, OpencodeLaneEvent::Snapshot { statuses: vec![] }),
+            "the reconnect bumps BOTH cycle and stream"
+        );
+
+        // Each snapshot was noted after its own connect: the call order is
+        // health → connect → snapshot GET, twice.
+        let calls = log.lock().expect("call log").clone();
+        assert_eq!(
+            &calls[..6],
+            &[
+                "GET http://fake/global/health".to_string(),
+                "CONNECT http://fake/event".to_string(),
+                "GET http://fake/session/status".to_string(),
+                "GET http://fake/global/health".to_string(),
+                "CONNECT http://fake/event".to_string(),
+                "GET http://fake/session/status".to_string(),
+            ],
+            "full order: {calls:?}"
+        );
+
+        lane.abort();
+    }
+
+    /// D8(c): a streamed event for a session unseen on-stream triggers the
+    /// HTTP root resolver, which announces the parent chain (deepest
+    /// ancestor first) BEFORE the triggering event; resolver failure
+    /// forwards the event anyway (conservative ambiguity stands, retried on
+    /// the next occurrence).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unmapped_session_is_resolved_via_http_before_forwarding() {
+        // ── success: the parentID chain lands root-first, then the event ──
+        let log: CallLog = Arc::new(Mutex::new(Vec::new()));
+        let http = Arc::new(FakeLaneHttp {
+            log: log.clone(),
+            respond: Box::new(|url| {
+                if url.ends_with("/global/health") {
+                    return Ok((200, json!({ "healthy": true, "version": "1.18.11" })));
+                }
+                if url.ends_with("/session/status") {
+                    return Ok((200, json!({})));
+                }
+                if url.ends_with("/session/ses-child") {
+                    return Ok((200, json!({ "id": "ses-child", "parentID": "ses-root" })));
+                }
+                if url.ends_with("/session/ses-root") {
+                    return Ok((200, json!({ "id": "ses-root" })));
+                }
+                Ok((404, json!({})))
+            }),
+        });
+        let stream = Arc::new(FakeLaneStream {
+            log: log.clone(),
+            scripts: Mutex::new(VecDeque::from([StreamScript {
+                buffered: vec![],
+                live: vec![parsed(
+                    json!({"type":"session.status","properties":{"sessionID":"ses-child","status":{"type":"busy"}}}),
+                )],
+                finish: false,
+            }])),
+        });
+        let deps = Arc::new(OpencodeLaneDeps {
+            http,
+            events: stream,
+        });
+
+        let (hub_ok, _rx) = hub();
+        hub_ok.register_opencode_lane_for_tests("t-oc", 1);
+        let lane =
+            spawn_opencode_lane(deps, hub_ok.clone(), "t-oc".into(), "http://fake".into(), 1);
+
+        let ingress = wait_for_ingress(&hub_ok, 4, 5_000).await;
+        assert_eq!(
+            ingress[0].3,
+            OpencodeLaneEvent::Snapshot { statuses: vec![] }
+        );
+        assert_eq!(
+            ingress[1],
+            (
+                1,
+                1,
+                1,
+                OpencodeLaneEvent::SessionCreated {
+                    session_id: "ses-root".into(),
+                    parent_id: None
+                }
+            ),
+            "the deepest unknown ancestor is announced FIRST"
+        );
+        assert_eq!(
+            ingress[2],
+            (
+                1,
+                1,
+                1,
+                OpencodeLaneEvent::SessionCreated {
+                    session_id: "ses-child".into(),
+                    parent_id: Some("ses-root".into())
+                }
+            )
+        );
+        assert_eq!(
+            ingress[3],
+            (
+                1,
+                1,
+                1,
+                OpencodeLaneEvent::Status {
+                    session_id: "ses-child".into(),
+                    status: OpencodeStatus::Busy
+                }
+            ),
+            "the triggering event lands AFTER the synthetic chain"
+        );
+        lane.abort();
+
+        // ── failure: 404 on GET /session/{id} → the Status is forwarded
+        //    anyway, with NO synthetic SessionCreated ──
+        let log_fail: CallLog = Arc::new(Mutex::new(Vec::new()));
+        let http_fail = Arc::new(FakeLaneHttp {
+            log: log_fail.clone(),
+            respond: Box::new(|url| {
+                if url.ends_with("/global/health") {
+                    return Ok((200, json!({ "healthy": true, "version": "1.18.11" })));
+                }
+                if url.ends_with("/session/status") {
+                    return Ok((200, json!({})));
+                }
+                Ok((404, json!({})))
+            }),
+        });
+        let stream_fail = Arc::new(FakeLaneStream {
+            log: log_fail.clone(),
+            scripts: Mutex::new(VecDeque::from([StreamScript {
+                buffered: vec![],
+                live: vec![parsed(
+                    json!({"type":"session.status","properties":{"sessionID":"ses-child","status":{"type":"busy"}}}),
+                )],
+                finish: false,
+            }])),
+        });
+        let deps_fail = Arc::new(OpencodeLaneDeps {
+            http: http_fail,
+            events: stream_fail,
+        });
+
+        let (hub_fail, _rx_fail) = hub();
+        hub_fail.register_opencode_lane_for_tests("t-oc", 1);
+        let lane_fail = spawn_opencode_lane(
+            deps_fail,
+            hub_fail.clone(),
+            "t-oc".into(),
+            "http://fake".into(),
+            1,
+        );
+
+        let ingress = wait_for_ingress(&hub_fail, 2, 5_000).await;
+        assert_eq!(
+            ingress[1],
+            (
+                1,
+                1,
+                1,
+                OpencodeLaneEvent::Status {
+                    session_id: "ses-child".into(),
+                    status: OpencodeStatus::Busy
+                }
+            ),
+            "resolve failure still forwards the triggering event"
+        );
+        assert!(
+            !ingress
+                .iter()
+                .any(|(_, _, _, e)| matches!(e, OpencodeLaneEvent::SessionCreated { .. })),
+            "no synthetic SessionCreated on resolver failure: {ingress:?}"
+        );
+        // The resolver WAS attempted (and will retry on the next occurrence).
+        assert!(
+            log_fail
+                .lock()
+                .expect("call log")
+                .iter()
+                .any(|c| c == "GET http://fake/session/ses-child"),
+            "the resolver probe was attempted"
+        );
+        lane_fail.abort();
+    }
+}

--- a/crates/freshell-ws/src/opencode_lane.rs
+++ b/crates/freshell-ws/src/opencode_lane.rs
@@ -52,7 +52,7 @@ pub(crate) fn version_in_tested_range(version: &str) -> bool {
 /// Injected HTTP seam: one JSON GET (health poll, `/session/status`
 /// snapshot, `/session/{id}` root resolve). The production impl applies the
 /// 2s per-request timeout.
-pub(crate) trait OpencodeLaneHttp: Send + Sync {
+pub trait OpencodeLaneHttp: Send + Sync {
     fn get_json<'a>(
         &'a self,
         url: &'a str,
@@ -60,7 +60,7 @@ pub(crate) trait OpencodeLaneHttp: Send + Sync {
 }
 
 /// Injected SSE seam.
-pub(crate) trait OpencodeEventStream: Send + Sync {
+pub trait OpencodeEventStream: Send + Sync {
     /// Two-phase connect (Node connect-then-snapshot parity, A5): resolves
     /// once the subscription is CONFIRMED — on the FIRST `server.connected`
     /// SSE frame, detected on the raw decoded event BEFORE `parse_serve_event`
@@ -73,7 +73,7 @@ pub(crate) trait OpencodeEventStream: Send + Sync {
 }
 
 /// A connected, ack'd `/event` subscription.
-pub(crate) trait ConnectedOpencodeStream: Send {
+pub trait ConnectedOpencodeStream: Send {
     /// Deliver the buffered frames in order, then live parsed events, by
     /// sending each into `events_tx` until the stream ends (returns on
     /// disconnect; the sender is dropped on return, which is what lets the
@@ -91,7 +91,7 @@ pub(crate) trait ConnectedOpencodeStream: Send {
 
 /// The lane's injected IO seams. Installed on the hub once at boot
 /// (`ActivityHub::set_opencode_lane_deps`); fakes in tests.
-pub(crate) struct OpencodeLaneDeps {
+pub struct OpencodeLaneDeps {
     pub http: Arc<dyn OpencodeLaneHttp>,
     pub events: Arc<dyn OpencodeEventStream>,
 }
@@ -466,19 +466,23 @@ pub(crate) fn translate_serve_event(event: &ParsedServeEvent) -> Option<Opencode
 
 /// Production [`OpencodeLaneHttp`]: `GET url` with the 2s per-request timeout
 /// (the loopback serve's AbortController analog — DEV-0001), JSON body.
-/// dead_code: constructed by Task 10's boot wiring; the seam lands here.
-#[allow(dead_code)]
-pub(crate) struct ReqwestLaneHttp(reqwest::Client);
+/// Constructed by `freshell-server`'s boot wiring (Task 10).
+pub struct ReqwestLaneHttp(reqwest::Client);
 
-#[allow(dead_code)]
 impl ReqwestLaneHttp {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         // Loopback plain-HTTP only; a plain client never fails to build.
         Self(
             reqwest::Client::builder()
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new()),
         )
+    }
+}
+
+impl Default for ReqwestLaneHttp {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -509,18 +513,22 @@ impl OpencodeLaneHttp for ReqwestLaneHttp {
 /// arrive every ~10s) and a byte pending-buffer for partial UTF-8 — the
 /// shape of `freshell_opencode::transport::consume_events:145-198`, WITHOUT
 /// its internal reconnect loop (the lane owns cycles).
-/// dead_code: constructed by Task 10's boot wiring; the seam lands here.
-#[allow(dead_code)]
-pub(crate) struct ReqwestLaneStream(reqwest::Client);
+/// Constructed by `freshell-server`'s boot wiring (Task 10).
+pub struct ReqwestLaneStream(reqwest::Client);
 
-#[allow(dead_code)]
 impl ReqwestLaneStream {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self(
             reqwest::Client::builder()
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new()),
         )
+    }
+}
+
+impl Default for ReqwestLaneStream {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/freshell-ws/src/opencode_signal.rs
+++ b/crates/freshell-ws/src/opencode_signal.rs
@@ -426,6 +426,14 @@ async fn rebind_fanout(
         cwd.map(str::to_string),
         previous,
     );
+    // Task 10: feed the identity proof into the activity hub — the in-TUI
+    // session-switch (and first-bind) signal rebinds the tracker's owned
+    // root; deferred (awaitingAssociation) completions release on this bind
+    // (channel-deferred, safe off the sweep task; codex_identity.rs:221
+    // precedent).
+    if let Some(hub) = &state.activity {
+        hub.bind_opencode_session(&sig.terminal_id, &sig.session_id);
+    }
 }
 
 /// Outcome of applying one signal: `Acted` (rebind done), `Retain` (might

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -926,19 +926,21 @@ async fn handle_client_text(
             )
             .await
         }
-        // OpenCode terminal-mode live tracking is deferred (the legacy lane
-        // is SSE-driven off the shared `opencode serve` sidecar, which
-        // terminal panes on this server do not run). The list contract is
-        // still answered — legacy's `OpencodePhase` only has `busy`, so "no
-        // records" IS the correct idle-state response shape.
+        // Task 8 (opencode-attention-bell): the list is now hub-backed —
+        // live tracker state, same reconnect-seeding contract as the other
+        // three families (per-terminal `completionSeq` completions).
         ClientMessage::OpencodeActivityList(list) => {
+            let (terminals, latest) = match &state.activity {
+                Some(hub) => hub.opencode_list(),
+                None => (Vec::new(), Vec::new()),
+            };
             send(
                 ws_tx,
                 &ServerMessage::OpencodeActivityListResponse(
                     freshell_protocol::OpencodeActivityListResponse {
                         request_id: list.request_id.clone(),
-                        terminals: Vec::new(),
-                        latest_turn_completions: Some(Vec::new()),
+                        terminals,
+                        latest_turn_completions: Some(latest),
                     },
                 ),
             )

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -2805,6 +2805,14 @@ pub(crate) async fn handle_create(
         resume_session_id.clone(),
     );
 
+    // Task 10: attach the per-terminal opencode SSE lane (attention bell).
+    // The endpoint was allocated pre-launch and rode into argv; the hub's
+    // OpencodeAttach arm re-checks the tracked mode, so this only arms for
+    // opencode panes. Channel-deferred — safe off the dispatch path.
+    if let (Some(hub), Some(ep)) = (&state.activity, opencode_endpoint.as_ref()) {
+        hub.attach_opencode_serve(&terminal_id, &ep.hostname, ep.port);
+    }
+
     // Restore-across-restart fix (opencode): arm the opencode locator for a
     // FRESH (non-resuming) opencode pane. No-ops for every other mode/resume
     // case.
@@ -3497,6 +3505,14 @@ pub async fn respawn_agent_terminal(
         Some(mode.clone()),
         resume_session_id.clone(),
     );
+
+    // Task 10: attach the per-terminal opencode SSE lane (attention bell).
+    // The respawn re-allocated a fresh loopback port above;
+    // `attach_opencode_serve` replaces the old lane by contract (A6
+    // generation bump retires the predecessor whole).
+    if let (Some(hub), Some(ep)) = (&state.activity, opencode_endpoint.as_ref()) {
+        hub.attach_opencode_serve(&terminal_id, &ep.hostname, ep.port);
+    }
 
     // Arm the provider locators the way `handle_create` does for this mode
     // (both gate on a FRESH — non-resuming — pane, so they no-op for a

--- a/docs/plans/2026-08-03-opencode-attention-bell.md
+++ b/docs/plans/2026-08-03-opencode-attention-bell.md
@@ -774,10 +774,17 @@ describe('death-bell markers on spontaneous exit', () => {
     // untrackTerminal({ terminalId: 'term-1' }) after knownBusy
     // assert plain { upsert: [], remove: ['term-1'] } with no marker fields
   })
+  it('spontaneous exit of a terminal that was never tracked emits NOTHING', async () => {
+    // NO trackTerminal call for 'term-9'; tracker.untrackTerminal({ terminalId: 'term-9', spontaneous: true })
+    // assert the 'changed' collector saw NO event mentioning 'term-9'.
+    // The wiring feeds EVERY registry terminal.exit (bash/claude/codex panes
+    // included) through untrackTerminal; untracked terminals must stay as
+    // silent as today (removeRecord's existence guard).
+  })
 })
 ```
 
-Write the four tests in full per the comments.
+Write the five tests in full per the comments.
 
 - [ ] **Step 2: Write the failing emitter episode test**
 
@@ -802,7 +809,7 @@ Append to `test/unit/server/coding-cli/truly-idle-emitter.test.ts` (its `beforeE
 
 Run both files:
 `npm run test:vitest -- run test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/unit/server/coding-cli/truly-idle-emitter.test.ts --config config/vitest/vitest.server.config.ts`
-Expected: tracker tests FAIL (no marker fields; TypeScript may reject `spontaneous` on `untrackTerminal`); the emitter test may already PASS (the emitter is generic) — if it passes, note that in the commit message; it is a pin, not a change driver.
+Expected: the marker-asserting tracker tests (knownBusy, permission-pause) FAIL (no marker fields; TypeScript may reject `spontaneous` on `untrackTerminal`); the candidate/no-flag/never-tracked pins may already PASS (they pin existing silence); the emitter test may already PASS (the emitter is generic) — note any already-passing pins in the commit message; they are pins, not change drivers.
 
 - [ ] **Step 4: Implement**
 
@@ -833,8 +840,16 @@ export type OpencodeActivityChange = {
     // candidate/ambiguous ownership never death-rings (D4: that noise is why
     // opencode death bells were excluded before).
     const ownershipKind = monitor?.ownership.kind
+    // `monitor !== undefined` gates the whole path: the wiring subscribes to
+    // EVERY registry terminal.exit (non-opencode panes included), so a
+    // never-tracked terminal must fall through to the silent removeRecord
+    // branch exactly as today. A permission pause removes only the record,
+    // never the monitor, so paused panes keep their monitor and stay eligible.
     const deathBellEligible =
-      input.spontaneous === true && ownershipKind !== 'candidate' && ownershipKind !== 'ambiguous'
+      monitor !== undefined &&
+      input.spontaneous === true &&
+      ownershipKind !== 'candidate' &&
+      ownershipKind !== 'ambiguous'
     const approvalPending = this.hasPendingPermissions(input.terminalId)
     this.pendingPermissions.delete(input.terminalId)
     // ... existing teardown body unchanged (dispose monitor, abort controller,

--- a/docs/plans/2026-08-03-opencode-attention-bell.md
+++ b/docs/plans/2026-08-03-opencode-attention-bell.md
@@ -1127,6 +1127,7 @@ Root resolution: `fn resolve_root<'a>(state: &'a TerminalOpencode, session_id: &
 | `AwaitingAssociation` | any | unchanged | none |
 | `Quiet` | empty | unchanged | `clear_record(false)` |
 | `Quiet{known: Some(k)}` | contains k, single | `KnownBusy{k, ...}` | `set_busy_record(Some(k), at)` |
+| `Quiet{known: Some(k)}` | single s, s != k | `Candidate{s, previous_known: Some(k), ..., false}` | `set_busy_record(Some(s), at)` (Node `reduceSnapshot:406-417` — session switched during an SSE reconnect gap, visible only in the snapshot; mirrors the busy reducer's foreign-busy row) |
 | `Quiet{known: Some(k)}` | multiple | `Ambiguous{Some(k), busy_roots}` | `set_busy_record(None, at)` |
 | `Quiet{known: None}` | exactly one | `Candidate{s, None, ...}` | `set_busy_record(Some(s), at)` |
 | `Quiet{known: None}` | multiple | `Ambiguous{None, busy_roots}` | `set_busy_record(None, at)` |
@@ -1156,6 +1157,7 @@ Create the file with the types above stubbed (`todo!()` bodies are fine for RED)
 #[test] fn candidate_completion_defers_to_bind_session() { /* no resume id: busy(ses-x) -> idle -> no TurnComplete; bind_session("ses-x") -> TurnComplete with at == the idle timestamp */ }
 #[test] fn ambiguous_is_conservative_no_completions() { /* two different busy sessions -> ambiguous; all idles -> no TurnComplete ever; record ends removed */ }
 #[test] fn snapshot_empty_completes_a_known_busy_turn() { /* snapshot path B */ }
+#[test] fn snapshot_single_foreign_busy_from_quiet_known_enters_candidate() { /* track(Some("ses-r")) -> note_snapshot([("ses-x", Busy)]): assert Changed{upsert busy, session ses-x} (Quiet{known: Some(k)} + single foreign busy root -> Candidate{s, previous_known: Some(k)}, Node reduceSnapshot:406-417); then a matching idle for ses-x yields NO TurnComplete (candidate defers); bind_session("ses-x") -> TurnComplete (reconnect-gap session switch is not silently dropped) */ }
 #[test] fn stale_cycle_idle_is_ignored() { /* idle with wrong cycle/stream leaves KnownBusy intact */ }
 #[test] fn deadman_expiry_removes_silently() { /* set_busy_deadman_ms(1000); busy at t=0; expire(t=2000) -> Changed{remove}, no TurnComplete; next_deadline math */ }
 ```
@@ -1492,10 +1494,17 @@ pub(crate) trait OpencodeEventStream: Send + Sync {
         -> futures::future::BoxFuture<'a, Result<Box<dyn ConnectedOpencodeStream>, String>>;
 }
 pub(crate) trait ConnectedOpencodeStream: Send {
-    /// Deliver the buffered frames in order, then live parsed events until the
-    /// stream ends (returns on disconnect).
-    fn drive<'a>(self: Box<Self>, sink: &'a (dyn Fn(freshell_opencode::ParsedServeEvent) + Send + Sync))
-        -> futures::future::BoxFuture<'a, Result<(), String>>;
+    /// Deliver the buffered frames in order, then live parsed events, by
+    /// sending each into `events_tx` until the stream ends (returns on
+    /// disconnect; the sender is dropped on return, which is what lets the
+    /// lane's pump loop drain to `None`). The seam is a CHANNEL rather than a
+    /// sync callback because per-event handling must AWAIT the lane-level
+    /// HTTP root resolver (`OpencodeLaneHttp::get_json` is async) before
+    /// forwarding to the hub — that async work lives in the lane's pump loop
+    /// (below), which owns `known_sessions` mutably. FIFO channel + one
+    /// sequential pump preserves per-stream event ordering.
+    fn drive(self: Box<Self>, events_tx: tokio::sync::mpsc::UnboundedSender<freshell_opencode::ParsedServeEvent>)
+        -> futures::future::BoxFuture<'static, Result<(), String>>;
 }
 pub(crate) struct OpencodeLaneDeps { pub http: std::sync::Arc<dyn OpencodeLaneHttp>, pub events: std::sync::Arc<dyn OpencodeEventStream> }
 pub(crate) fn spawn_opencode_lane(deps: std::sync::Arc<OpencodeLaneDeps>, hub: crate::activity::ActivityHub, terminal_id: String, base_url: String, generation: u64) -> tokio::task::JoinHandle<()>;
@@ -1546,17 +1555,24 @@ loop {
     //    Subscription strictly precedes the snapshot, so every transition is
     //    either IN the snapshot or ON the already-open stream — /event has no
     //    replay (derives from opencode 1.18.11).
-    // 4. drive: conn.drive(&sink).await flushes the buffered frames IN ORDER,
-    //    then delivers live events, where sink = |parsed| { if let Some(ev) =
-    //        translate_serve_event(&parsed) { /* root-resolve unknown session
-    //        ids (resolver below), then */ hub.note_opencode_lane_event(
-    //        &terminal_id, generation, cycle, stream, ev); } };
-    //    On a successful streamed cycle (drive returned Ok), reset backoff to base.
+    // 4. drive + pump (channel seam — per-event handling must AWAIT the async
+    //    root resolver, so a sync callback cannot be the seam):
+    //      let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    //      let drive_task = tokio::spawn(conn.drive(tx)); // buffered frames IN ORDER, then live
+    //      while let Some(parsed) = rx.recv().await {
+    //          if let Some(ev) = translate_serve_event(&parsed) {
+    //              // root-resolve unknown session ids FIRST (resolver below —
+    //              // awaits deps.http HERE in the pump, where &mut known_sessions
+    //              // is in scope), then:
+    //              hub.note_opencode_lane_event(&terminal_id, generation, cycle, stream, ev);
+    //          }
+    //      } // rx drains to None only after drive dropped tx on disconnect — no events lost
+    //    On a successful streamed cycle (drive_task.await == Ok(Ok(()))), reset backoff to base.
     // 5. sleep(backoff); backoff = (backoff * 2).min(OPENCODE_RECONNECT_MAX_MS);
 }
 ```
 
-**Lane-level HTTP root resolver (A4 — the Node `resolveRootForEvent`/`classifySnapshotStatuses` seam, ported to HTTP):** the lane owns a lane-lifetime `known_sessions: std::collections::HashSet<String>`; `SessionCreated` events (streamed or synthetic) insert their session (and parent) ids. Before forwarding any `Status`/`SessionIdle`/`SessionError`/`PermissionAsked` event — or noting a snapshot entry — whose session id is NOT in the set, the lane fetches `GET {base}/session/{id}` via the existing `OpencodeLaneHttp` seam (short timeout — the production impl's 2s default) and emits a synthetic `SessionCreated { session_id, parent_id }` to the hub BEFORE the triggering event, first walking the `parentID` chain while the parent is itself unknown (deepest ancestor first, so every mapping lands before its dependents). On resolve failure (non-200, timeout, shape mismatch): forward the triggering event anyway — the tracker's conservative-ambiguity behavior stands, and the next unknown-id occurrence retries. Carry the comment: `// derives from opencode 1.18.11: GET /session/{id} exposes parentID; /event has no replay`.
+**Lane-level HTTP root resolver (A4 — the Node `resolveRootForEvent`/`classifySnapshotStatuses` seam, ported to HTTP):** the lane owns a lane-lifetime `known_sessions: std::collections::HashSet<String>`; `SessionCreated` events (streamed or synthetic) insert their session (and parent) ids. Before forwarding any `Status`/`SessionIdle`/`SessionError`/`PermissionAsked` event — or noting a snapshot entry — whose session id is NOT in the set, the lane fetches `GET {base}/session/{id}` via the existing `OpencodeLaneHttp` seam (short timeout — the production impl's 2s default) and emits a synthetic `SessionCreated { session_id, parent_id }` to the hub BEFORE the triggering event, first walking the `parentID` chain while the parent is itself unknown (deepest ancestor first, so every mapping lands before its dependents). On resolve failure (non-200, timeout, shape mismatch): forward the triggering event anyway — the tracker's conservative-ambiguity behavior stands, and the next unknown-id occurrence retries. The resolver runs in the lane task itself — for streamed events inside the step-4 pump loop (never inside `drive`, which only feeds the channel), and for snapshot entries inline in step 3 — so every `deps.http.get_json` await happens where `&mut known_sessions` is directly in scope, and the sequential pump preserves the emit-before-trigger ordering. Carry the comment: `// derives from opencode 1.18.11: GET /session/{id} exposes parentID; /event has no replay`.
 
 `translate_serve_event` (kinds and property paths are verbatim from the spike — `/tmp/opencode-spike/vocabulary.md`):
 
@@ -1616,7 +1632,7 @@ pub(crate) fn translate_serve_event(event: &freshell_opencode::ParsedServeEvent)
 
 (`ParsedServeEvent.properties` is a `serde_json::Map<String, Value>` — adjust accessor chaining to `props.get("x")` returning `Option<&Value>` accordingly. `parse_serve_event` swallows `server.connected`/`server.heartbeat` — which is exactly why the two-phase connect detects the subscription ack on the RAW decoded event before parsing; the per-cycle snapshot is loss-free only because it happens AFTER that ack (Node snapshot-on-`server.connected` parity, A5).)
 
-Production impls: `ReqwestLaneHttp::get_json` = `client.get(url).timeout(2s).send() -> (status, json)`; `ReqwestLaneStream::connect` = GET with `accept: text/event-stream`, then a chunk loop with a 30s per-chunk `tokio::time::timeout` (read-stall watchdog — heartbeats arrive every ~10s) and a `Vec<u8>` pending buffer for partial UTF-8 (copy the shape of `freshell_opencode::transport::consume_events:145-198`, WITHOUT its internal reconnect loop — the lane owns cycles), feeding `SseDecoder::push_str` until the FIRST decoded event whose raw JSON `type` is `"server.connected"`; resolve with a handle owning the response body, the decoder, and any frames already decoded past the ack. `ConnectedOpencodeStream::drive` = flush those buffered frames through `parse_serve_event` to the sink in order, then continue the same chunk loop live.
+Production impls: `ReqwestLaneHttp::get_json` = `client.get(url).timeout(2s).send() -> (status, json)`; `ReqwestLaneStream::connect` = GET with `accept: text/event-stream`, then a chunk loop with a 30s per-chunk `tokio::time::timeout` (read-stall watchdog — heartbeats arrive every ~10s) and a `Vec<u8>` pending buffer for partial UTF-8 (copy the shape of `freshell_opencode::transport::consume_events:145-198`, WITHOUT its internal reconnect loop — the lane owns cycles), feeding `SseDecoder::push_str` until the FIRST decoded event whose raw JSON `type` is `"server.connected"`; resolve with a handle owning the response body, the decoder, and any frames already decoded past the ack. `ConnectedOpencodeStream::drive` = flush those buffered frames through `parse_serve_event` into `events_tx` in order, then continue the same chunk loop live, sending each parsed event; return (dropping `events_tx`) on stream end, read-stall timeout, or transport error.
 
 `OpencodeAttach` handling in `handle_event`: bump `opencode_lane_next_generation` (monotonic, hub-issued — A6) and take the new value as this lane's generation; abort any existing lane for the terminal (`opencode_lanes.insert(terminal_id, (generation, handle))` returning the old entry → `.abort()` — respawn re-allocates a NEW port, so replacement is the contract); if deps are set, `spawn_opencode_lane(deps, hub, terminal_id, base_url, generation)` and store `(generation, handle)`. The ingress guard (Task 8) then drops any `OpencodeLane` event whose stamped generation doesn't match the current map entry. Exit arm (Task 8 site): `if let Some((_, handle)) = inner.opencode_lanes.remove(&terminal_id) { handle.abort(); }` — removal makes post-exit stragglers fail the generation match too.
 

--- a/docs/plans/2026-08-03-opencode-attention-bell.md
+++ b/docs/plans/2026-08-03-opencode-attention-bell.md
@@ -7,7 +7,7 @@
 
 **Goal:** Extend the codex attention-bell policy (PR #597) to OPENCODE terminal panes on both servers: policy-correct bells on the Node server (abort-silent, failed-rings, permission pauses, death bells) and a complete, from-scratch OpenCode activity lane on the Rust server (tracker + SSE lane + hub wiring) that lights up the client's existing dead code paths with zero client changes.
 
-**Architecture:** OpenCode terminal panes embed an HTTP+SSE server on a freshell-allocated loopback port. On Node we extend the existing SSE tracker (`opencode-activity-tracker.ts`) and pure ownership reducer with per-turn abort gates, a permission-pause lane, and spontaneous-exit death-bell markers — the already-wired `TrulyIdleEmitter` does the rest. On Rust we build a pure tracker in `crates/freshell-activity/src/opencode.rs` (port of the Node reducer semantics + the new gates), a per-terminal SSE lane in `freshell-ws` reusing `freshell-opencode`'s `SseDecoder`/`parse_serve_event`, and hub wiring (mode arms, `opencode_frames`, death-bell predicate, `opencode.activity.list`).
+**Architecture:** OpenCode terminal panes embed an HTTP+SSE server on a freshell-allocated loopback port. On Node we extend the existing SSE tracker (`opencode-activity-tracker.ts`) and pure ownership reducer with per-turn abort gates (session.error + the abort-marked `message.updated` fallback), a root-resolved permission-pause lane (armed under knownBusy AND candidate ownership), a log-once version drift gate, and spontaneous-exit death-bell markers — the already-wired `TrulyIdleEmitter` does the rest. On Rust we build a pure, resolver-free tracker in `crates/freshell-activity/src/opencode.rs` (port of the Node reducer semantics + the new gates), a per-terminal SSE lane in `freshell-ws` reusing `freshell-opencode`'s `SseDecoder`/`parse_serve_event` (two-phase connect that snapshots only after the `server.connected` subscription ack, a lane-level HTTP root resolver for sessions unseen on-stream, the same log-once version gate, and hub-issued attach-generation stamping), and hub wiring (mode arms, `opencode_frames`, generation-guarded lane ingress, death-bell predicate, `opencode.activity.list`).
 
 **Tech Stack:** TypeScript (Node server, zod, vitest), Rust (tokio, reqwest, serde), OpenCode 1.18.11 SSE protocol (empirically spiked — see `/tmp/opencode-spike/`).
 
@@ -17,7 +17,7 @@
 - **Zero wire-shape changes.** All opencode wire schemas already exist (`OpencodeActivityRecordSchema` at `shared/ws-protocol.ts:124-129` with `phase: z.literal('busy')`, `opencode.activity.updated` `:140-144`, `opencode.activity.list.response` `:133-138`, provider `'opencode'` in `TerminalTurnCompleteSchema` `:190-197`, provider-agnostic `TerminalIdleSchema` `:222-227`). `terminal.idle.reason` reuses `'grace'` for all new causes. Contract freeze (`npm run test:port`) must show zero drift.
 - **Zero client changes.** `src/lib/pane-activity.ts:207` and `src/lib/terminal-output-side-effects.ts:39` already include `'opencode'`; the client is built for this and currently dark on Rust.
 - **Fresh-agent `freshopencode` surface (`server/fresh-agent/adapters/opencode/`) is OUT OF SCOPE** — do not touch. Its `turnAborted`/`turnErrored` gating is reference-only.
-- **Protocol facts derive from OpenCode 1.18.11** (live spike, `/tmp/opencode-spike/`). Any NEW load-bearing protocol assumption must consult `/tmp/opencode-spike/openapi.json` and carry a "derives from opencode 1.18.11" comment.
+- **Protocol facts derive from OpenCode 1.18.11** (live spike, `/tmp/opencode-spike/`; ordering/attribution facts — abort error-before-idle, the W1/W2 abort windows, child permission attribution, parent-scoped fan-out aborts, `/event` no-replay, `GET /session/{id}` exposing `parentID` — additionally verified against the opencode v1.18.11 source, validation pass 2026-08-03). Any NEW load-bearing protocol assumption must consult `/tmp/opencode-spike/openapi.json` and carry a "derives from opencode 1.18.11" comment.
 - **Never** restart the self-hosted server (build ok, deploy not), touch the production server (port 3002), the user's live opencode processes (pts/9, pts/33, pts/37), or `~/.local/share/opencode`.
 - **No PR creation without explicit user approval.** Everything to main via PR eventually.
 - Git author must be `Dan Shapiro <3732858+danshapiro@users.noreply.github.com>` (never `dan@danshapiro.com`). Conventional commits.
@@ -30,33 +30,33 @@
 
 ## Design Decisions (shared by all tasks — read before implementing any task)
 
-**D1 — Abort gate lives in the ownership state machine, per-turn.** `session.error{name:'MessageAbortedError'}` on the owned session while busy sets a `turnAborted` flag on the `knownBusy`/`candidate` state. The NEXT idle edge consumes it: state clears busy silently (activityRemove, NO turnComplete). The flag clears when consumed or when a new busy begins. All other `session.error` names set nothing — the following idle edge completes normally (failed turns ring exactly like completed turns, via the existing turnComplete → grace → `terminal.idle` path). Trailing errors on quiet/idle state are structurally no-ops (the reducer only reads the flag from busy states).
+**D1 — Abort gate lives in the ownership state machine, per-turn.** Abort evidence is `session.error{name:'MessageAbortedError'}` OR a `message.updated` whose message-info error name is `MessageAbortedError` — both on the owned session while busy, and both feeding the SAME `error` observation (the reducer is unchanged; only the tracker/lane vocabulary widens). The second form covers abort window W2: an abort landing between assistant-message creation (processor.create) and LLM stream start emits NO `session.error`, only the abort-marked `message.updated`, always BEFORE idle (derives from opencode 1.18.11, source-verified — validation pass 2026-08-03). Ordering is guaranteed whenever abort evidence is emitted at all: error-before-idle is deterministic (single fiber, FIFO bus→SSE), so the only failure mode is a MISSING error, never a late one. Residual W1: an abort landing between the prompt loop-top and processor.create emits no abort evidence at all — a ms-scale window where the completion bell would ring on a human abort (documented residual, D8(g)). The `error` observation sets a `turnAborted` flag on the `knownBusy`/`candidate` state. The NEXT idle edge consumes it: state clears busy silently (activityRemove, NO turnComplete). The flag clears when consumed or when a new busy begins. All other error names set nothing — the following idle edge completes normally (failed turns ring exactly like completed turns, via the existing turnComplete → grace → `terminal.idle` path). Trailing errors on quiet/idle state are structurally no-ops (the reducer only reads the flag from busy states).
 
 **D2 — Double `session.idle` dedupe is structural.** The first idle observation transitions `knownBusy → quiet`; the second (and the preceding `session.status{idle}` twin, ~7–20ms apart per the spike) lands on `quiet` and produces no actions. Pinned by tests, not by timers.
 
-**D3 — Permission pause maps to record removal + attention boundary.** `permission.asked` for the OWNED busy session removes the public record (opencode's existing not-busy representation — `phase` stays `'busy'`-only on the wire, NO new phase value) and then emits an attention boundary (codex ordering: demote FIRST, boundary SECOND). Only a newly-inserted permission id arms (duplicate `permission.asked` never re-arms). `permission.replied` (or the session going busy again) restores the busy record immediately — busy re-entry cancels within grace. Mid-pause turn end retires the pause WITHOUT a second bell: a mid-pause completion/failure swallows the turnComplete (the pause bell — rung or still in grace — is THE bell for the episode); a mid-pause abort additionally force-emits the removal so the armed grace window is cancelled (human at keyboard → total silence).
+**D3 — Permission pause maps to record removal + attention boundary.** `permission.asked` arms the pause when its raw sessionID RESOLVES to the pane's owned session via the child→root map (multi-level parent-chain walk; mappings retained for the session's lifetime) — NOT raw equality: children CAN ask, their asks are stamped with the CHILD session id, and the parent turn blocks on them (verified against the opencode v1.18.11 source, validation pass 2026-08-03). Arming covers `knownBusy` AND `candidate` ownership (the single busy unbound session observed on the pane's own per-pane endpoint): a fresh pane is candidate for its ENTIRE first turn by construction on Node, and the most common attention scenario — a first-turn tool-permission ask — must ring. The pause removes the public record (opencode's existing not-busy representation — `phase` stays `'busy'`-only on the wire, NO new phase value) and then emits an attention boundary (codex ordering: demote FIRST, boundary SECOND). Only a newly-inserted permission id arms (duplicate `permission.asked` never re-arms). `permission.replied` (or the session going busy again) restores the busy record immediately — busy re-entry cancels within grace. Mid-pause turn end retires the pause WITHOUT a second bell: a mid-pause completion/failure swallows the turnComplete — INCLUDING the DEFERRED completion a candidate turn mints at association confirm (the pause claim survives into `awaitingAssociation` for exactly that purpose); the pause bell — rung or still in grace — is THE bell for the episode. A mid-pause abort additionally force-emits the removal so the armed grace window is cancelled (human at keyboard → total silence). Death-bell scope (D4) is UNCHANGED by candidate arming.
 
-**D4 — Death-bell engagement is ownership-scoped.** 'Engaged' = knownBusy on the owned root session OR an armed grace deadline OR a non-empty pending-permission set — NEVER `candidate`/`ambiguous` ownership (that noise is exactly why death bells were excluded before; tightening this is the fix). The registry's exit event (`spontaneous: !requestedClose`, computed at `server/terminal-registry.ts:1517`/`:1542` on Node; `ActivityEvent::Exit{spontaneous}` on Rust) is the authoritative discriminator. SSE-drop alone is NEVER a death signal (reconnect churn) — corroboration only. Death bells are immediate (`reason: 'grace'`, no grace window).
+**D4 — Death-bell engagement is ownership-scoped.** 'Engaged' = knownBusy on the owned root session OR an armed grace deadline OR a non-empty pending-permission set — NEVER `candidate`/`ambiguous` ownership, even when a candidate-armed permission pause is pending (first-turn deaths stay silent — documented residual, D8(i); that noise is exactly why death bells were excluded before; tightening this is the fix). The registry's exit event (`spontaneous: !requestedClose`, computed at `server/terminal-registry.ts:1517`/`:1542` on Node; `ActivityEvent::Exit{spontaneous}` on Rust) is the authoritative discriminator. SSE-drop alone is NEVER a death signal (reconnect churn) — corroboration only. Death bells are immediate (`reason: 'grace'`, no grace window).
 
-**D5 — Child sessions never gate the root.** `session.created.properties.info.parentID` builds the child→root map. Child BUSY remaps to the root (keeps the root busy — matches existing behavior and snapshot "busy beats idle" collapsing). Child IDLE is SUPPRESSED (today's Node code remaps child idle onto the root, which falsely completes the root's turn — the live trace shows the child idle landing 921ms before the parent's; this plan fixes that). Child `session.error` and child `permission.asked` are ignored (raw sessionID must equal the owned root).
+**D5 — Child sessions never gate the root's turn edges.** `session.created.properties.info.parentID` builds the child→root map. Child BUSY remaps to the root (keeps the root busy — matches existing behavior and snapshot "busy beats idle" collapsing). Child IDLE is SUPPRESSED (today's Node code remaps child idle onto the root, which falsely completes the root's turn — the live trace shows the child idle landing 921ms before the parent's; this plan fixes that). Child `session.error` is ignored (raw sessionID must equal the owned root): a fan-out abort always emits the parent-scoped abort error too, after the child's (verified against the opencode v1.18.11 source, validation pass 2026-08-03). Child `permission.asked` is NOT ignored — it root-resolves and arms the pause (D3): the parent turn blocks on the child's ask.
 
 **D6 — `retry` status is busy.** `session.status{type:'retry'}` was never observed live but is schema-declared; both servers parse it defensively as busy.
 
 **D7 — Rust gate mapping mirrors the Node emitter mechanism.** `opencode_frames` maps `Changed.remove` → `idle.note_exit` (exactly what the existing `note_changed_to_gate` at `activity.rs:1396-1407` does): the removal clears gate state, and the `TurnComplete`/`AttentionBoundary` that FOLLOWS in the same effect batch re-arms grace-only. This is the same "activityRemove followed by turnComplete" contract documented at `truly-idle-emitter.ts:78-79`. Effect ordering (remove before boundary) is therefore load-bearing everywhere.
 
-**D8 — Accepted residuals (documented in Task 11, kept truthful):** (a) ambiguous ownership → no bells, no death bells; (b) SSE reconnect during a permission pause loses the pending-pause bell (the busy snapshot clears it; `GET /permission` resync is a possible follow-up); (c) child sessions created during an SSE reconnect gap can look like separate roots → ambiguous → conservative silence; (d) `permission.v2.*` / `question.*` event families are schema-declared but unobserved on 1.18.11 — unhandled (bell goes deaf if a future server switches families); (e) busy deadman (120s) removal is silent.
+**D8 — Accepted residuals (documented in Task 11, kept truthful):** (a) ambiguous ownership → no bells, no death bells; (b) SSE reconnect during a permission pause loses the pending-pause bell (the busy snapshot clears it; `GET /permission` resync is a possible follow-up); (c) child sessions created during an SSE reconnect gap or before a mid-turn lane attach are recovered by the lane's HTTP root-resolver fallback (`GET /session/{id}` exposes `parentID` — derives from opencode 1.18.11; `/event` has no replay); only resolver FAILURE degrades to ambiguous → conservative silence, retried on the next occurrence; (d) `permission.v2.*` / `question.*` event families are schema-declared but unobserved on 1.18.11 — unhandled (bell goes deaf if a future server switches families); (e) the 120s busy deadman is EVENT-SILENCE-keyed — deltas/heartbeats do NOT refresh it, so a single >120s silent tool call trips it mid-turn; ownership survives and the turn's completion still rings — the cost is the dropped busy light plus lost post-deadman death engagement (the removal itself stays silent); (f) pathological TUI quits — worker dispose exceeding the 5s hard-terminate cap, or a raw SIGTERM (no drain path) — can leave engagement set at spontaneous exit → a death bell can ring on those rare human quits (normal quit paths verified to abort+drain: all four quit inputs dispose runners via the abort path before exit; the wire-flush instant is unprovable from code but mitigated upstream by graceful stream termination); (g) abort window W1 — an abort landing between the prompt loop-top and processor.create emits no abort evidence at all → ms-scale risk of a completion bell on an abort (W2 is closed by D1's `message.updated` fallback); (h) opencode protocol drift: `session.idle` is already deprecated upstream and a v1→v2 event/health migration is in progress — the log-once version gate (Rust lane + Node tracker) converts silent drift into a logged warning, and `/session/status` absence==idle is version-derived behavior (1.18.x); (i) first-turn deaths stay silent (D4 keeps candidate excluded, even mid-pause), and on Rust a no-producer bind tail (locator ambiguity + plugin absence) leaves the pane candidate indefinitely — candidate-armed pauses still ring there, but completions and death bells wait for the bind.
 
 **File structure** (created/modified across tasks):
 
 | File | Responsibility |
 |---|---|
 | `server/coding-cli/opencode-ownership-reducer.ts` (modify) | pure state machine: + error observation, per-turn abort flags |
-| `server/coding-cli/opencode-activity-tracker.ts` (modify) | SSE client: + session.error/permission.* vocabulary, child-idle suppression, permission pause lane, death-bell markers |
+| `server/coding-cli/opencode-activity-tracker.ts` (modify) | SSE client: + session.error/abort-marked message.updated/permission.* vocabulary, child-idle suppression, root-resolved permission pause lane (knownBusy + candidate), death-bell markers, log-once version gate |
 | `server/coding-cli/opencode-activity-wiring.ts` (modify) | + thread `spontaneous` from `terminal.exit` |
-| `crates/freshell-activity/src/opencode.rs` (create) | pure Rust tracker: ownership machine + gates + permission pause + death predicates |
+| `crates/freshell-activity/src/opencode.rs` (create) | pure Rust tracker (resolver-free — unknown-id recovery is lane-level): ownership machine + gates + permission pause + death predicates |
 | `crates/freshell-activity/src/lib.rs` (modify) | + `pub mod opencode;` |
-| `crates/freshell-ws/src/activity.rs` (modify) | hub: opencode mode arms, `opencode_frames`, death predicate, list, deadlines, lane registry |
-| `crates/freshell-ws/src/opencode_lane.rs` (create) | per-terminal SSE lane: health-wait → snapshot → stream → backoff, injected IO seams |
+| `crates/freshell-ws/src/activity.rs` (modify) | hub: opencode mode arms, `opencode_frames`, death predicate, list, deadlines, generation-guarded lane registry |
+| `crates/freshell-ws/src/opencode_lane.rs` (create) | per-terminal SSE lane: health-wait + version gate → two-phase connect (subscribe on `server.connected`) → snapshot → flush buffered → stream → backoff; HTTP root-resolver fallback; generation stamping; injected IO seams |
 | `crates/freshell-ws/src/terminal.rs` (modify) | thread allocated endpoint to hub (create + respawn); swap the `opencode.activity.list` stub |
 | `crates/freshell-ws/src/opencode_association.rs` + `opencode_signal.rs` consumers (modify) | notify hub of session binds (identity only — do not conflate) |
 | `crates/freshell-server/src/main.rs` (modify) | install production lane deps |
@@ -253,7 +253,7 @@ git commit -m "feat(opencode): per-turn abort gate in the ownership reducer"
 
 ---
 
-### Task 2: Node tracker — session.error vocabulary + child-idle suppression
+### Task 2: Node tracker — session.error/message.updated vocabulary + child-idle suppression + version gate
 
 **Files:**
 - Modify: `server/coding-cli/opencode-activity-tracker.ts`
@@ -261,7 +261,7 @@ git commit -m "feat(opencode): per-turn abort gate in the ownership reducer"
 
 **Interfaces:**
 - Consumes: Task 1's `error` observation; existing SSE plumbing (`KNOWN_OPENCODE_EVENT_TYPES` `:115-120`, `OpencodeEventSchema` `:104-109`, `handleOpencodeEvent` `:510-568`, `resolveRootForEvent` `:570-591`).
-- Produces: tracker recognizes `session.error`; child idle edges are suppressed (raw child id never completes the root); tracker events unchanged (`'changed'`, `'turn.complete'`, `'association.requested'`).
+- Produces: tracker recognizes `session.error` AND the abort-marked `message.updated` (W2 fallback, D1 — both forward the same `error` observation); child idle edges are suppressed (raw child id never completes the root); log-once version drift gate in the health path; tracker events unchanged (`'changed'`, `'turn.complete'`, `'association.requested'`).
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -322,15 +322,36 @@ describe('abort/error episodes (policy: PR #597 extended to opencode)', () => {
     // session.status { sessionID: 'ses-parent', status: { type: 'idle' } }
     // assert exactly one completion (the parent's turn still rings)
   })
+
+  it('W2 abort marker: message.updated carrying error MessageAbortedError then double idle is silent', async () => {
+    // snapshot: { 'ses-root': busy }; then (abort window W2 — derives from opencode 1.18.11:
+    // an abort landing between assistant-message creation and LLM stream start emits NO
+    // session.error, only the abort-marked message.updated, always BEFORE idle):
+    // message.updated { sessionID: 'ses-root', info: { id: 'msg-1', role: 'assistant', error: { name: 'MessageAbortedError', data: { message: 'Aborted' } } } }
+    // session.status  { sessionID: 'ses-root', status: { type: 'idle' } }
+    // session.idle    { sessionID: 'ses-root' }
+    // session.status idle + session.idle again (double edge)
+    // assert completions === [] and exactly one remove (same assertions as the session.error abort test)
+  })
+})
+
+describe('version drift gate (log-once)', () => {
+  it('warns once for untested opencode versions and bells stay on', async () => {
+    // fixture health returns { healthy: true, version: '9.9.9' }; vi.spyOn(console, 'warn')
+    // drive the monitor through TWO health polls (let the stream end once so a
+    // reconnect cycle re-polls health); assert exactly ONE warning naming '9.9.9'
+    // and the tested 1.18.x range; then busy -> idle still emits one completion
+    // (bells stay on — the gate only logs)
+  })
 })
 ```
 
-Write the four tests in full (the second through fourth follow the first's fixture pattern verbatim — copy it; the comments above are the exact event sequences to enqueue and the exact assertions to make).
+Write the six tests in full (the comment-annotated ones follow the first's fixture pattern verbatim — copy it; the comments above are the exact event sequences to enqueue and the exact assertions to make).
 
 - [ ] **Step 2: Run to verify failure**
 
 Run: `npm run test:vitest -- run test/unit/server/coding-cli/opencode-activity-tracker.test.ts --config config/vitest/vitest.server.config.ts`
-Expected: FAIL — `session.error` events are silently dropped today (abort test sees a completion; child-idle test sees a false root completion).
+Expected: FAIL — `session.error` (and abort-marked `message.updated`) events are silently dropped today (abort tests see a completion; child-idle test sees a false root completion); the version-gate test sees no warning.
 
 - [ ] **Step 3: Implement**
 
@@ -352,9 +373,27 @@ const SessionErrorEventSchema = z
   .passthrough()
 ```
 
-2. Add `SessionErrorEventSchema` to the `OpencodeEventSchema` discriminated union (`:104-109`) and `'session.error'` to `KNOWN_OPENCODE_EVENT_TYPES` (`:115-120`). (Both are required or `parseOpencodeEvent:187-189` drops it silently.)
+2. Add the W2 abort-marker schema next to it (property path verified against the spike traces and the opencode v1.18.11 source — `properties.sessionID` + `properties.info.error.name`):
 
-3. In `handleOpencodeEvent` (`:510-568`), before the generic status handling, add:
+```ts
+const MessageUpdatedEventSchema = z
+  .object({
+    type: z.literal('message.updated'),
+    properties: z
+      .object({
+        sessionID: z.string().min(1),
+        info: z
+          .object({ error: z.object({ name: z.string().min(1) }).passthrough().optional() })
+          .passthrough(),
+      })
+      .passthrough(),
+  })
+  .passthrough()
+```
+
+3. Add `SessionErrorEventSchema` and `MessageUpdatedEventSchema` to the `OpencodeEventSchema` discriminated union (`:104-109`) and `'session.error'` + `'message.updated'` to `KNOWN_OPENCODE_EVENT_TYPES` (`:115-120`). (Both are required or `parseOpencodeEvent:187-189` drops them silently.)
+
+4. In `handleOpencodeEvent` (`:510-568`), before the generic status handling, add:
 
 ```ts
     if (event.type === 'session.error') {
@@ -375,7 +414,35 @@ const SessionErrorEventSchema = z
     }
 ```
 
-4. Child-idle suppression — in the idle branch (`:539-549`), guard before observing:
+5. W2 abort-marker forwarding — immediately after the `session.error` branch, add (both feed the SAME `error` observation; the reducer is unchanged):
+
+```ts
+    if (event.type === 'message.updated') {
+      // W2 abort marker (derives from opencode 1.18.11): an abort landing
+      // between assistant-message creation and LLM stream start emits NO
+      // session.error — only message.updated with info.error.name ===
+      // 'MessageAbortedError', always BEFORE the idle edge. Error-less
+      // message.updated is routine message churn: no attention signal.
+      const errorName = event.properties.info.error?.name
+      if (errorName === undefined) return
+      const rawSessionId = event.properties.sessionID
+      const rootSessionId = await this.resolveRootForEvent(monitor, rawSessionId)
+      // Same raw-equality scoping as session.error: child or unresolved
+      // markers never gate the root's turn.
+      if (rootSessionId === undefined || rootSessionId !== rawSessionId) return
+      this.observe(monitor, {
+        kind: 'error',
+        cycleId,
+        streamId,
+        sessionId: rootSessionId,
+        errorName,
+        at: this.now(),
+      })
+      return
+    }
+```
+
+6. Child-idle suppression — in the idle branch (`:539-549`), guard before observing:
 
 ```ts
       // Child sessions go idle mid-parent-turn (live trace: child idle 921ms
@@ -389,15 +456,27 @@ const SessionErrorEventSchema = z
 
 Busy/retry remapping (`:551-567`) stays exactly as-is (child busy keeps the root busy — matches the snapshot path's "busy beats idle" collapsing at `classifyKnownSnapshotStatuses:829-842`).
 
+7. Version drift gate (log-once, per monitor) — in the health-poll success path (where `GET /global/health` parses `{ healthy: true }`), read the response's `version` field (REQUIRED in the 1.18.11 health schema) and add:
+
+```ts
+// derives from opencode 1.18.11: /global/health returns { healthy, version },
+// both required. session.idle is already deprecated upstream and a v1->v2
+// event/health migration is in progress — warn on untested versions, but keep
+// bells ON (best-effort; the gate converts silent drift into a logged warning).
+const TESTED_OPENCODE_VERSION_RANGE = '1.18.'
+```
+
+If `typeof version === 'string' && !version.startsWith(TESTED_OPENCODE_VERSION_RANGE)` and the monitor has not warned yet (`versionWarned` boolean on the monitor state, reset in `trackTerminal`), `console.warn(...)` once naming the observed version and the tested range, then set the flag. No behavior change otherwise.
+
 - [ ] **Step 4: Run to verify pass**
 
-Run: same as Step 2. Expected: PASS — all 24 pre-existing tests plus the 4 new ones. If a pre-existing test pinned the old child-idle remap behavior, rewrite it with a `// SEMANTIC CHANGE (opencode-attention-bell): child idle is suppressed, not remapped` comment. (The explorer sweep found NO existing test emitting a child idle, so none is expected to break.)
+Run: same as Step 2. Expected: PASS — all 24 pre-existing tests plus the 6 new ones. If a pre-existing test pinned the old child-idle remap behavior, rewrite it with a `// SEMANTIC CHANGE (opencode-attention-bell): child idle is suppressed, not remapped` comment. (The explorer sweep found NO existing test emitting a child idle, so none is expected to break.)
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add server/coding-cli/opencode-activity-tracker.ts test/unit/server/coding-cli/opencode-activity-tracker.test.ts
-git commit -m "feat(opencode): session.error vocabulary, abort-silent episodes, child-idle suppression"
+git commit -m "feat(opencode): abort vocabulary (session.error + message.updated marker), child-idle suppression, version gate"
 ```
 
 ---
@@ -409,7 +488,7 @@ git commit -m "feat(opencode): session.error vocabulary, abort-silent episodes, 
 - Test: `test/unit/server/coding-cli/opencode-activity-tracker.test.ts`
 
 **Interfaces:**
-- Consumes: Task 2's vocabulary plumbing; codex's approval-pause pattern (`codex-activity-tracker.ts:359-409`: demote via `'changed'` FIRST, `'attention.boundary'` SECOND, newly-inserted-id dedupe).
+- Consumes: Task 2's vocabulary plumbing; the existing root resolver `resolveRootForEvent` (`:570-591` — D3's child→root pause resolution reuses it); codex's approval-pause pattern (`codex-activity-tracker.ts:359-409`: demote via `'changed'` FIRST, `'attention.boundary'` SECOND, newly-inserted-id dedupe).
 - Produces (relied on by Task 4 and by the already-wired emitter):
   - Tracker emits `'attention.boundary'` → `{ terminalId: string; at: number }` (the `wireTrulyIdleEmitter` subscription at `truly-idle-emitter.ts:230` already forwards it — ZERO `server/index.ts` changes).
   - `removeRecord(terminalId: string, opts?: { forceEmit?: boolean }): void`
@@ -459,14 +538,36 @@ describe('permission pause semantics (codex approval-pause mirror)', () => {
     // assert: completions === [] (turnComplete swallowed), boundaries.length === 1,
     //         and NO second 'changed' remove was emitted (grace left to fire once)
   })
-  it('permission.asked for a child or foreign session is ignored', async () => {
-    // enqueue permission.asked with sessionID 'ses-child' (registered child) and 'ses-other'
-    // assert boundaries === [] beyond the owned-session case
+  it('child permission.asked root-resolves to the owned root and arms the pause', async () => {
+    // SEMANTIC CHANGE vs raw-equality scoping: children CAN ask — their asks
+    // carry the CHILD sessionID and the parent turn blocks on them (opencode
+    // v1.18.11 source, validation pass 2026-08-03).
+    // register the child: session.created { info: { id: 'ses-child', parentID: 'ses-root' } }
+    // enqueue permission.asked { id: 'per-c1', sessionID: 'ses-child' }
+    // assert: one demotion + one boundary for term-1 (same ordering assertion as the first test)
+  })
+  it('permission.asked for a foreign/unresolvable session is ignored', async () => {
+    // enqueue permission.asked with sessionID 'ses-other' (never registered, not the root)
+    // assert boundaries === [] and no demotion
+  })
+  it('candidate-armed pause: a first-turn ask on a fresh pane rings', async () => {
+    // fresh-pane fixture WITHOUT a resume session id (trackTerminal({ terminalId, endpoint }))
+    // busy for 'ses-new' -> candidate ownership (whole first turn by construction, D3)
+    // enqueue permission.asked { id: 'per-1', sessionID: 'ses-new' }
+    // assert: demotion + one boundary; then permission.replied restores the busy record
+  })
+  it('deferred completion after a candidate pause is swallowed at association confirm', async () => {
+    // candidate pause (previous test's shape, without the reply) -> idle edge (turn end mid-pause)
+    // -> the tracker requests association; confirm it via the tracker's
+    //    confirmSessionAssociation path ({ sessionId: 'ses-new' })
+    // assert: completions === [] (the deferred turnComplete minted at confirm is
+    //         swallowed — the pause bell, rung or still in grace, was THE bell),
+    //         boundaries.length === 1, and no force-emitted second remove
   })
 })
 ```
 
-Write all six tests in full following the comments (they are exact sequences/assertions, same fixture as Task 2).
+Write all nine tests in full following the comments (they are exact sequences/assertions, same fixture as Task 2).
 
 - [ ] **Step 2: Run to verify failure**
 
@@ -514,9 +615,24 @@ Clear the terminal's entry in `untrackTerminal` and in `trackTerminal`'s early-r
 ```ts
     if (event.type === 'permission.asked') {
       const ownership = monitor.ownership
-      // Owned root session only: candidate/ambiguous ownership is conservative
-      // (no bells), and a CHILD's permission must not pause the root.
-      if (ownership.kind !== 'knownBusy' || ownership.sessionId !== event.properties.sessionID) return
+      // Root-resolve the asker (D3): children CAN ask — the event is stamped
+      // with the CHILD session id and the parent turn blocks on it (opencode
+      // v1.18.11 source, validation pass 2026-08-03). Multi-level chain walk;
+      // mappings are retained for the session's lifetime.
+      const rootSessionId = await this.resolveRootForEvent(monitor, event.properties.sessionID)
+      if (rootSessionId === undefined) return
+      // Arm under knownBusy OR candidate ownership: a fresh pane is candidate
+      // for its ENTIRE first turn by construction (the bind lands only at the
+      // first idle edge), and the single busy unbound session on the pane's
+      // own per-pane endpoint is this pane's turn — first-turn tool-permission
+      // asks are the most common attention scenario and must ring (D3).
+      // Ambiguous/quiet stays conservative (no bells).
+      if (
+        (ownership.kind !== 'knownBusy' && ownership.kind !== 'candidate') ||
+        ownership.sessionId !== rootSessionId
+      ) {
+        return
+      }
       const pending = this.pendingPermissions.get(monitor.terminalId) ?? new Set<string>()
       const newlyInserted = !pending.has(event.properties.id)
       pending.add(event.properties.id)
@@ -536,7 +652,8 @@ Clear the terminal's entry in `untrackTerminal` and in `trackTerminal`'s early-r
       if (pending.size > 0) return
       this.pendingPermissions.delete(monitor.terminalId)
       const ownership = monitor.ownership
-      if (ownership.kind !== 'knownBusy') return
+      // Restore under candidate too — pause mechanics are identical (D3).
+      if (ownership.kind !== 'knownBusy' && ownership.kind !== 'candidate') return
       // Resume busy immediately (codex resume_busy_after_approval analog):
       // the reply proves a human is present; busy re-entry cancels the armed
       // grace window without waiting ~1s for the next session.status{busy}.
@@ -563,22 +680,35 @@ Clear the terminal's entry in `untrackTerminal` and in `trackTerminal`'s early-r
   }
 ```
 
-5. Mid-pause coordination in `applyActions` (`:615-652`). Refactor the existing `switch` body into a private `applyAction(terminalId, action)` and wrap:
+5. Mid-pause coordination in `applyActions` (`:615-652`). Refactor the existing `switch` body into a private `applyAction(terminalId, action)` and wrap (NOTE: applyActions runs AFTER the reducer transition, so `monitor.ownership` is the POST-observation state — that is what distinguishes a knownBusy turn end from a candidate one):
 
 ```ts
   private applyActions(terminalId: string, actions: OpencodeOwnershipAction[]): void {
+    const ownership = this.monitors.get(terminalId)?.ownership
     const pauseActive = this.hasPendingPermissions(terminalId)
     const idleEdge = actions.some((a) => a.kind === 'activityRemove')
-    if (pauseActive && idleEdge) {
+    const completionEdge = actions.some((a) => a.kind === 'turnComplete')
+    if (pauseActive && (idleEdge || completionEdge)) {
       // Mid-pause turn end: the pause is THE attention episode for this turn.
-      // Retire it and never mint a second bell (codex PR #597 mid-pause
-      // silent-claim hardening, mirrored).
-      this.pendingPermissions.delete(terminalId)
-      const hasCompletion = actions.some((a) => a.kind === 'turnComplete')
-      if (!hasCompletion) {
-        // Abort mid-pause: human at keyboard — force-emit the removal so the
-        // emitter cancels any still-armed grace window (the record itself was
-        // already removed at pause entry).
+      // Never mint a second bell (codex PR #597 mid-pause silent-claim
+      // hardening, mirrored). A completion WITHOUT an idle edge is the
+      // DEFERRED completion minted at confirmOpencodeAssociation
+      // (candidate-armed pauses, D3) — swallowed the same way.
+      const awaitingBind = ownership?.kind === 'awaitingAssociation'
+      const aborted = awaitingBind && ownership.aborted === true
+      if (awaitingBind && !aborted) {
+        // Candidate turn end mid-pause: KEEP the pause claim alive so the
+        // deferred completion minted at confirm is swallowed on its own pass
+        // through this branch. The armed grace window stays live — the pause
+        // bell (rung or still in grace) is the episode's bell.
+      } else {
+        this.pendingPermissions.delete(terminalId)
+      }
+      if ((!completionEdge && !awaitingBind) || aborted) {
+        // Abort mid-pause (knownBusy -> quiet, or aborted candidate ->
+        // awaitingAssociation{aborted}): human at keyboard — force-emit the
+        // removal so the emitter cancels any still-armed grace window (the
+        // record itself was already removed at pause entry).
         this.removeRecord(terminalId, { forceEmit: true })
       }
       for (const action of actions) {
@@ -636,7 +766,9 @@ describe('death-bell markers on spontaneous exit', () => {
   })
   it('spontaneous exit while candidate or ambiguous carries NO marker', async () => {
     // drive ownership to candidate (busy for an unknown session with no resume id);
-    // untrackTerminal spontaneous; assert the change has no spontaneousExitRemovals
+    // untrackTerminal spontaneous; assert the change has no spontaneousExitRemovals.
+    // Repeat WITH a candidate-armed permission.asked pending: still no marker —
+    // D4 keeps candidate excluded even mid-pause (residual D8(i)).
   })
   it('freshell-initiated untrack (no flag) behaves exactly as before', async () => {
     // untrackTerminal({ terminalId: 'term-1' }) after knownBusy
@@ -936,7 +1068,7 @@ fn clear_record(state: &mut TerminalOpencode, force: bool) -> Vec<OpencodeEffect
 }
 ```
 
-Root resolution: `fn resolve_root<'a>(state: &'a TerminalOpencode, session_id: &'a str) -> &'a str` — walk `session_roots` with a seen-set cycle guard; unknown id resolves to itself.
+Root resolution: `fn resolve_root<'a>(state: &'a TerminalOpencode, session_id: &'a str) -> &'a str` — walk `session_roots` with a seen-set cycle guard; unknown id resolves to itself. The pure tracker stays RESOLVER-FREE (no IO): recovery of ids never seen on-stream is the LANE's job — Task 9's HTTP root-resolver fallback emits synthetic `note_session_created` calls before the triggering event, so by the time an event reaches this tracker the mapping either exists or the conservative-ambiguity rules apply.
 
 `note_status`/`note_session_idle` routing: resolve the root; **child idle (root != raw) is suppressed (D5)**; child busy/retry remaps to the root; then dispatch to the idle/busy reducers below. Every `note_*` updates `last_observed_at = at`.
 
@@ -945,7 +1077,7 @@ Root resolution: `fn resolve_root<'a>(state: &'a TerminalOpencode, session_id: &
 | Ownership | Guard | Next state | Effects (in order) |
 |---|---|---|---|
 | `KnownBusy{session==s, cycle==c, stream==st, turn_aborted}` | id+cycle+stream match | `Quiet{known: Some(s)}` | `clear_record(false)`; then if `!turn_aborted`: `TurnComplete{terminal_id, session_id: Some(s), at, completion_seq: ledger.record_turn_completion(terminal_id, at)}` (Task 7 adds the mid-pause override here) |
-| `Candidate{...}` matching | same | `AwaitingAssociation{session_id, previous_known, completed_at: at, aborted: turn_aborted}` | `clear_record(false)` (completion deferred to `bind_session`) |
+| `Candidate{...}` matching | same | `AwaitingAssociation{session_id, previous_known, completed_at: at, aborted: turn_aborted}` | `clear_record(false)` (completion deferred to `bind_session`; Task 7: a candidate-armed pause claim survives into `AwaitingAssociation`) |
 | `Ambiguous{blocked}` | session in `blocked` | drop it; empty → `Quiet{known}` | empty → `clear_record(false)`; non-empty → `set_busy_record(None, at)` |
 | `Quiet` / `AwaitingAssociation` | — | unchanged | none (this IS the double-idle dedupe, D2) |
 
@@ -985,7 +1117,7 @@ Root resolution: `fn resolve_root<'a>(state: &'a TerminalOpencode, session_id: &
 | `Quiet{known: None}` | multiple | `Ambiguous{None, busy_roots}` | `set_busy_record(None, at)` |
 
 **`bind_session`** (association/rebind identity arriving from the SQLite locator or the TUI rebind plugin — Task 10 wires the producers):
-- `AwaitingAssociation{session_id == bound, aborted: false}` → `Quiet{known: Some(bound)}` + `TurnComplete{..., at: completed_at, completion_seq: ledger...}` (deferred completion, Node `confirmOpencodeAssociation:440-458` — note `at` is the STORED `completed_at`).
+- `AwaitingAssociation{session_id == bound, aborted: false}` → `Quiet{known: Some(bound)}` + `TurnComplete{..., at: completed_at, completion_seq: ledger...}` (deferred completion, Node `confirmOpencodeAssociation:440-458` — note `at` is the STORED `completed_at`; Task 7 adds the mid-pause swallow override here: a surviving candidate-armed pause claim swallows this deferred completion).
 - `AwaitingAssociation{session_id == bound, aborted: true}` → `Quiet{known: Some(bound)}`, no effects.
 - `AwaitingAssociation{different}` → `Quiet{known: previous_known}`, no effects (reject analog).
 - `Ambiguous` → update `known_session_id = Some(bound)` in place (Node's session.created adoption assist; the next snapshot resolves it).
@@ -1058,24 +1190,28 @@ impl OpencodeActivityTracker {
 ```
 
 **Semantics:**
-- `note_error`: only when `session_id` resolves to itself (raw == root — child errors ignored, D5) AND `error_name == "MessageAbortedError"` AND ownership is `KnownBusy`/`Candidate` with matching id+cycle+stream → set `turn_aborted = true`. No effects, ever. All other names/states: no-op (trailing-error rule).
-- `note_permission_asked`: ownership must be `KnownBusy` with `session_id == owned` (raw equality — child/foreign ignored). `let newly_inserted = state.pending_permissions.insert(permission_id.to_string());` — only newly-inserted arms. Effects in order: `clear_record(false)` (demote), then `TrackerEffect::AttentionBoundary { terminal_id, at }`.
-- `note_permission_replied`: remove the id (unknown id → no-op). When the set EMPTIES and ownership is `KnownBusy{session}` → `set_busy_record(Some(session), at)` (immediate resume; busy cancels the armed gate window via `note_phase(Busy)` in the frame mapper).
-- Mid-pause hardening — extend the idle-edge completion row (Task 6, both idle and snapshot-empty paths): before minting, check `let pause_was_active = !state.pending_permissions.is_empty(); state.pending_permissions.clear();` If `pause_was_active`: NEVER mint `TurnComplete` (the pause is the episode's bell); if `turn_aborted` → `clear_record(true)` (force-emit remove → `note_exit` at the gate cancels the armed window → total silence); else → no effects (leave the armed window to fire once, or stay silent if it already rang).
-- Busy re-entry (`KnownBusy` same-session refresh) clears `pending_permissions` (out-of-band resume).
+- `note_error`: only when `session_id` resolves to itself (raw == root — child errors ignored, D5) AND `error_name == "MessageAbortedError"` AND ownership is `KnownBusy`/`Candidate` with matching id+cycle+stream → set `turn_aborted = true`. No effects, ever. All other names/states: no-op (trailing-error rule). (The W2 abort marker — Task 9's `message.updated` translation — arrives through this same entry point as a `SessionError`-shaped call; nothing extra is needed here.)
+- `note_permission_asked`: root-resolve the asker via `resolve_root` (children CAN ask — the event is stamped with the CHILD session id and the parent turn blocks on it; multi-level chain walk, mappings retained for session lifetime — opencode v1.18.11 source, validation pass 2026-08-03). Arm when ownership is `KnownBusy` OR `Candidate` with `session_id == resolved root` (candidate arming, D3: the single busy unbound session on the pane's own per-pane endpoint; first-turn asks must ring). Foreign/unresolvable ids and `Quiet`/`Ambiguous`/`AwaitingAssociation` states: no-op. `let newly_inserted = state.pending_permissions.insert(permission_id.to_string());` — only newly-inserted arms. Effects in order: `clear_record(false)` (demote), then `TrackerEffect::AttentionBoundary { terminal_id, at }`.
+- `note_permission_replied`: remove the id (unknown id → no-op). When the set EMPTIES and ownership is `KnownBusy{session}` or `Candidate{session}` → `set_busy_record(Some(session), at)` (immediate resume; busy cancels the armed gate window via `note_phase(Busy)` in the frame mapper).
+- Mid-pause hardening — extend the idle-edge completion rows (Task 6, both idle and snapshot-empty paths). With `KnownBusy` ownership: `let pause_was_active = !state.pending_permissions.is_empty();` if `pause_was_active`: clear the set and NEVER mint `TurnComplete` (the pause is the episode's bell); if `turn_aborted` → `clear_record(true)` (force-emit remove → `note_exit` at the gate cancels the armed window → total silence); else → no effects (leave the armed window to fire once, or stay silent if it already rang). With `Candidate` ownership (→ `AwaitingAssociation`): if `turn_aborted` → clear the set + `clear_record(true)` (same total-silence contract); else KEEP `pending_permissions` intact — the pause claim survives into `AwaitingAssociation` so the DEFERRED completion is swallowed at `bind_session` (next bullet).
+- `bind_session` mid-pause swallow (extends Task 6's bind rows): on `AwaitingAssociation{session_id == bound, aborted: false}` with `!state.pending_permissions.is_empty()` → clear the set, transition to `Quiet{known: Some(bound)}`, and mint NO deferred `TurnComplete` (mid-pause turn end — the pause was the episode's bell, D3).
+- Busy re-entry (`KnownBusy`/`Candidate` same-session refresh) clears `pending_permissions` (out-of-band resume).
 - `note_exit` clears `pending_permissions` with the state (the hub reads `has_pending_permissions` BEFORE calling `note_exit` — same audit-A17 ordering as codex).
 
 - [ ] **Step 1: Write the failing tests**
 
 ```rust
 #[test] fn abort_then_idle_clears_silently() { /* busy -> note_error(MessageAbortedError) -> idle: Changed{remove} only, no TurnComplete; second idle: nothing */ }
+#[test] fn w2_abort_marker_gates_like_session_error() { /* the message.updated abort marker reaches the tracker through the SAME note_error entry (Task 9's translate maps it to SessionError — derives from opencode 1.18.11, abort window W2): busy -> note_error(MessageAbortedError) sourced from the marker -> idle: Changed{remove} only, no TurnComplete; second idle: nothing */ }
 #[test] fn failed_turn_rings_and_trailing_error_is_noop() { /* busy -> note_error(UnknownError) -> idle: TurnComplete present; note_error after idle: no effects, ownership stays Quiet */ }
 #[test] fn child_abort_does_not_gate_the_root() { /* child registered; note_error(child, MessageAborted); parent idle still completes */ }
 #[test] fn permission_asked_demotes_then_arms_once() { /* busy -> note_permission_asked: [Changed{remove}, AttentionBoundary] in that order; duplicate id: no effects */ }
-#[test] fn permission_replied_resumes_busy() { /* pause -> note_permission_replied: Changed{upsert busy with owned session} */ }
-#[test] fn abort_mid_pause_force_emits_the_cancel() { /* pause -> note_error(abort) -> idle: Changed{remove} EMITTED despite absent record, no TurnComplete, no boundary */ }
+#[test] fn child_permission_asked_resolves_to_root_and_arms() { /* child registered via note_session_created; note_permission_asked(child id) while the root is KnownBusy: [Changed{remove}, AttentionBoundary]; a foreign unregistered id: no effects */ }
+#[test] fn candidate_pause_arms_and_deferred_completion_is_swallowed_at_bind() { /* track with NO session id -> busy(ses-x) = Candidate -> note_permission_asked(ses-x): [Changed{remove}, AttentionBoundary] (candidate arming, D3); idle edge -> AwaitingAssociation with the pause claim intact; bind_session("ses-x"): NO deferred TurnComplete (swallowed), state Quiet{known: Some(ses-x)} */ }
+#[test] fn permission_replied_resumes_busy() { /* pause -> note_permission_replied: Changed{upsert busy with owned session}; repeat under Candidate ownership */ }
+#[test] fn abort_mid_pause_force_emits_the_cancel() { /* pause -> note_error(abort) -> idle: Changed{remove} EMITTED despite absent record, no TurnComplete, no boundary; repeat from Candidate ownership (aborted candidate -> AwaitingAssociation{aborted}, same force-emit) */ }
 #[test] fn completion_mid_pause_mints_nothing() { /* pause -> idle (no error): NO effects at all */ }
-#[test] fn death_predicates() { /* blocks_death_bell: false for KnownBusy/Quiet, true for Candidate and Ambiguous; has_pending_permissions true during pause, false after replied/exit */ }
+#[test] fn death_predicates() { /* blocks_death_bell: false for KnownBusy/Quiet, true for Candidate and Ambiguous — INCLUDING Candidate with a candidate-armed pause pending (D4); has_pending_permissions true during pause, false after replied/exit */ }
 ```
 
 Write each in full.
@@ -1118,12 +1254,14 @@ enum OpencodeLaneEvent {  // pub(crate); carried by HubEvent
 }
 // HubEvent variants:
 //   OpencodeBind { terminal_id: String, session_id: String },
-//   OpencodeLane { terminal_id: String, cycle: u64, stream: u64, event: OpencodeLaneEvent },
+//   OpencodeLane { terminal_id: String, generation: u64, cycle: u64, stream: u64, event: OpencodeLaneEvent },
 // ActivityHub ingress:
 pub fn bind_opencode_session(&self, terminal_id: &str, session_id: &str);
-pub(crate) fn note_opencode_lane_event(&self, terminal_id: &str, cycle: u64, stream: u64, event: OpencodeLaneEvent);
+pub(crate) fn note_opencode_lane_event(&self, terminal_id: &str, generation: u64, cycle: u64, stream: u64, event: OpencodeLaneEvent);
 pub fn opencode_list(&self) -> (Vec<freshell_protocol::OpencodeActivityRecord>, Vec<freshell_protocol::TurnCompletionSnapshot>);
 ```
+
+(`generation` is the hub-issued attach generation — Task 9's `opencode_lanes` registry issues it; ingress drops mismatches. Hub-level tests register a dummy entry via the `#[cfg(test)]` helper below so their injected events pass the guard.)
 
 - [ ] **Step 1: Write the failing episode tests**
 
@@ -1135,7 +1273,8 @@ async fn busy_opencode_terminal(hub: &ActivityHub, rx: &mut tokio::sync::broadca
         terminal_id: "t-oc".into(), mode: "opencode".into(),
         resume_session_id: Some("ses-root".into()), at: 1_000,
     });
-    hub.note_opencode_lane_event("t-oc", 1, 1, OpencodeLaneEvent::Status {
+    hub.register_opencode_lane_for_tests("t-oc", 1); // dummy lanes-map entry: generation 1 passes ingress
+    hub.note_opencode_lane_event("t-oc", 1, 1, 1, OpencodeLaneEvent::Status {
         session_id: "ses-root".into(), status: OpencodeStatus::Busy,
     });
     let frame = next_frame_matching(rx, "opencode.activity.updated", 1_500, |v| {
@@ -1145,6 +1284,8 @@ async fn busy_opencode_terminal(hub: &ActivityHub, rx: &mut tokio::sync::broadca
 }
 ```
 
+(Every episode test that injects lane events registers a test generation first and stamps it — `note_opencode_lane_event(terminal_id, generation, cycle, stream, event)`; `respawn_drops_stale_lane_events` registers generation 2 mid-test to prove the drop.)
+
 Tests (each asserts EXACTLY one `terminal.idle` or none — use `next_frame_of_type(...).await.is_none()` for silence, timeout 1_500ms; ring waits use 3_500ms to cover the 2s grace):
 
 ```rust
@@ -1152,11 +1293,14 @@ Tests (each asserts EXACTLY one `terminal.idle` or none — use `next_frame_of_t
 #[tokio::test(flavor = "multi_thread")] async fn opencode_abort_stays_silent() { /* busy -> SessionError{MessageAbortedError} -> SessionIdle x2 -> NO terminal.turn.complete, NO terminal.idle */ }
 #[tokio::test(flavor = "multi_thread")] async fn opencode_failed_turn_rings() { /* busy -> SessionError{UnknownError} -> SessionIdle -> turn.complete + one terminal.idle; trailing SessionError after idle mints nothing */ }
 #[tokio::test(flavor = "multi_thread")] async fn opencode_permission_pause_rings_once_and_reply_within_grace_is_silent() { /* two scenarios or two tests: (a) PermissionAsked -> one terminal.idle after grace; (b) PermissionAsked -> PermissionReplied quickly -> silence */ }
+#[tokio::test(flavor = "multi_thread")] async fn opencode_child_permission_asked_arms_via_root_resolution() { /* busy root -> SessionCreated{child,parent} -> PermissionAsked{ses-child} -> one terminal.idle after grace (the child's ask root-resolves and pauses the root, D3) */ }
+#[tokio::test(flavor = "multi_thread")] async fn opencode_first_turn_permission_pause_rings_under_candidate() { /* Created WITHOUT resume id -> busy for "ses-new" (candidate) -> PermissionAsked{ses-new} -> one terminal.idle after grace (candidate arming, D3); then SessionIdle + hub.bind_opencode_session("t-oc", "ses-new") -> NO terminal.turn.complete (the deferred completion is swallowed mid-pause) */ }
 #[tokio::test(flavor = "multi_thread")] async fn opencode_mid_pause_abort_is_fully_silent() { /* PermissionAsked -> SessionError{abort} + SessionIdle -> no bell even after grace elapses */ }
 #[tokio::test(flavor = "multi_thread")] async fn opencode_spontaneous_death_while_busy_rings_immediately() { /* busy -> Exit{spontaneous:true} -> terminal.idle arrives fast (no grace) */ }
-#[tokio::test(flavor = "multi_thread")] async fn opencode_death_while_candidate_or_idle_is_silent_and_freshell_kill_is_silent() { /* candidate: Created WITHOUT resume id + busy for unknown session -> Exit{spontaneous:true} -> silence; idle quiet -> Exit spontaneous -> silence; busy -> Exit{spontaneous:false} -> silence */ }
-#[tokio::test(flavor = "multi_thread")] async fn opencode_death_during_pause_rings() { /* PermissionAsked -> Exit{spontaneous:true} -> immediate terminal.idle */ }
+#[tokio::test(flavor = "multi_thread")] async fn opencode_death_while_candidate_or_idle_is_silent_and_freshell_kill_is_silent() { /* candidate: Created WITHOUT resume id + busy for unknown session -> Exit{spontaneous:true} -> silence; candidate + PermissionAsked (candidate-armed pause pending) -> Exit{spontaneous:true} -> STILL silence (D4, residual D8(i)); idle quiet -> Exit spontaneous -> silence; busy -> Exit{spontaneous:false} -> silence */ }
+#[tokio::test(flavor = "multi_thread")] async fn opencode_death_during_pause_rings() { /* knownBusy + PermissionAsked -> Exit{spontaneous:true} -> immediate terminal.idle */ }
 #[tokio::test(flavor = "multi_thread")] async fn opencode_child_idle_mid_parent_turn_does_not_ring() { /* SessionCreated{child,parent} -> child busy -> child SessionIdle -> silence + record survives; parent SessionIdle -> one bell */ }
+#[tokio::test(flavor = "multi_thread")] async fn respawn_drops_stale_lane_events() { /* register generation 1 + busy via gen-1 events; register generation 2 (the respawn's attach); inject gen-1 Status{busy} + gen-1 SessionIdle: NO upsert, NO terminal.turn.complete, NO terminal.idle (ingress drops stale generations, A6); then a gen-2 Snapshot/turn behaves normally */ }
 ```
 
 Write each in full following `busy_opencode_terminal` + the codex episode style.
@@ -1169,7 +1313,7 @@ Run: `cargo test -p freshell-ws opencode` — FAIL (compile: no variants/methods
 
 In `activity.rs`:
 1. `HubInner` (`:192-205`): add `opencode: OpencodeActivityTracker,` (one process-wide instance, like codex).
-2. `HubEvent` (`:104-157`): add `OpencodeBind` and `OpencodeLane` variants (shapes above); ingress methods `bind_opencode_session` / `note_opencode_lane_event` that only `self.tx.send(...)` (single-emitter invariant, `:334-339`).
+2. `HubEvent` (`:104-157`): add `OpencodeBind` and `OpencodeLane` variants (shapes above); ingress methods `bind_opencode_session` / `note_opencode_lane_event` that only `self.tx.send(...)` (single-emitter invariant, `:334-339`). Add a `#[cfg(test)] fn register_opencode_lane_for_tests(&self, terminal_id: &str, generation: u64)` that inserts `(generation, tokio::spawn(async {}))` into `opencode_lanes` (Task 9's registry) so hub-level episode tests pass the generation guard without spawning real lanes.
 3. `handle_event` (`:524-616`): add arms mirroring the codex proxy lane (`:558-614`):
 
 ```rust
@@ -1182,10 +1326,19 @@ HubEvent::OpencodeBind { terminal_id, session_id } => {
     };
     self.emit(frames);
 }
-HubEvent::OpencodeLane { terminal_id, cycle, stream, event } => {
+HubEvent::OpencodeLane { terminal_id, generation, cycle, stream, event } => {
     let at = now_ms();
     let frames = {
         let mut inner = self.inner.lock().expect("activity hub lock");
+        // Attach-generation guard (A6): tokio `abort()` is asynchronous and
+        // never retracts already-enqueued mpsc messages — a replaced lane can
+        // legally enqueue events AFTER its successor's attach. Drop anything
+        // not stamped with the CURRENT lane generation (Exit removes the map
+        // entry, so post-exit stragglers drop too). cycle/stream still guard
+        // intra-lane reconnect staleness inside the tracker.
+        if inner.opencode_lanes.get(&terminal_id).map(|(g, _)| *g) != Some(generation) {
+            return;
+        }
         let effects = match event {
             OpencodeLaneEvent::Snapshot { statuses } => inner.opencode.note_snapshot(&terminal_id, &statuses, cycle, stream, at),
             OpencodeLaneEvent::SessionCreated { session_id, parent_id } => inner.opencode.note_session_created(&terminal_id, &session_id, parent_id.as_deref(), at),
@@ -1208,10 +1361,13 @@ HubEvent::OpencodeLane { terminal_id, cycle, stream, event } => {
 5. Death-bell predicate (`:792-794`) — extend, reading BEFORE teardown (ordering is audit-A17-pinned):
 
 ```rust
+// D4: candidate/ambiguous ownership never death-rings — even when a
+// candidate-armed permission pause is pending (residual D8(i)).
+let opencode_death_eligible = !inner.opencode.blocks_death_bell(&terminal_id);
 let ring_death_bell = spontaneous
-    && ((inner.idle.is_engaged(&terminal_id) && !inner.opencode.blocks_death_bell(&terminal_id))
+    && ((inner.idle.is_engaged(&terminal_id) && opencode_death_eligible)
         || inner.codex.has_pending_approvals(&terminal_id)
-        || inner.opencode.has_pending_permissions(&terminal_id));
+        || (inner.opencode.has_pending_permissions(&terminal_id) && opencode_death_eligible));
 ```
 
 (`blocks_death_bell` is `false` for terminals the opencode tracker doesn't know, so claude/codex/amplifier behavior is unchanged — pin that with the existing tests staying green.)
@@ -1301,18 +1457,33 @@ pub(crate) const OPENCODE_HEALTH_TIMEOUT_MS: u64 = 15_000; // per cycle, Node :2
 pub(crate) const OPENCODE_RECONNECT_BASE_MS: u64 = 250;    // Node :21
 pub(crate) const OPENCODE_RECONNECT_MAX_MS: u64 = 5_000;   // Node :22
 pub(crate) const OPENCODE_READ_STALL_MS: u64 = 30_000;     // Node :24 (production stream impl)
+/// Version drift gate (log-once per lane): prefix match against the REQUIRED
+/// `version` field of GET /global/health (derives from opencode 1.18.11:
+/// { healthy, version } are both required; session.idle is already deprecated
+/// upstream and a v1->v2 event/health migration is in progress — D8(h)).
+pub(crate) const TESTED_OPENCODE_VERSION_RANGE: &str = "1.18.";
 
 pub(crate) trait OpencodeLaneHttp: Send + Sync {
     fn get_json<'a>(&'a self, url: &'a str)
         -> futures::future::BoxFuture<'a, Result<(u16, serde_json::Value), String>>;
 }
 pub(crate) trait OpencodeEventStream: Send + Sync {
-    /// Connect once and deliver parsed events until the stream ends (returns on disconnect).
-    fn run_once<'a>(&'a self, url: &'a str, sink: &'a (dyn Fn(freshell_opencode::ParsedServeEvent) + Send + Sync))
+    /// Two-phase connect (Node connect-then-snapshot parity, A5): resolves
+    /// once the subscription is CONFIRMED — on the FIRST `server.connected`
+    /// SSE frame, detected on the raw decoded event BEFORE `parse_serve_event`
+    /// (which swallows it). Frames arriving after the ack are BUFFERED by the
+    /// returned handle, never dropped.
+    fn connect<'a>(&'a self, url: &'a str)
+        -> futures::future::BoxFuture<'a, Result<Box<dyn ConnectedOpencodeStream>, String>>;
+}
+pub(crate) trait ConnectedOpencodeStream: Send {
+    /// Deliver the buffered frames in order, then live parsed events until the
+    /// stream ends (returns on disconnect).
+    fn drive<'a>(self: Box<Self>, sink: &'a (dyn Fn(freshell_opencode::ParsedServeEvent) + Send + Sync))
         -> futures::future::BoxFuture<'a, Result<(), String>>;
 }
 pub(crate) struct OpencodeLaneDeps { pub http: std::sync::Arc<dyn OpencodeLaneHttp>, pub events: std::sync::Arc<dyn OpencodeEventStream> }
-pub(crate) fn spawn_opencode_lane(deps: std::sync::Arc<OpencodeLaneDeps>, hub: crate::activity::ActivityHub, terminal_id: String, base_url: String) -> tokio::task::JoinHandle<()>;
+pub(crate) fn spawn_opencode_lane(deps: std::sync::Arc<OpencodeLaneDeps>, hub: crate::activity::ActivityHub, terminal_id: String, base_url: String, generation: u64) -> tokio::task::JoinHandle<()>;
 pub(crate) fn translate_serve_event(event: &freshell_opencode::ParsedServeEvent) -> Option<crate::activity::OpencodeLaneEvent>;
 // production impls:
 pub(crate) struct ReqwestLaneHttp(/* reqwest::Client */);
@@ -1321,32 +1492,56 @@ pub(crate) struct ReqwestLaneStream(/* reqwest::Client */);
 //   HubEvent::OpencodeAttach { terminal_id: String, base_url: String }
 //   pub fn attach_opencode_serve(&self, terminal_id: &str, hostname: &str, port: u16)  // base_url = format!("http://{hostname}:{port}")
 //   pub fn set_opencode_lane_deps(&self, deps: Arc<OpencodeLaneDeps>)                  // Option'd; tests leave it unset
-//   HubInner: opencode_lanes: HashMap<String, tokio::task::JoinHandle<()>>
+//   HubInner: opencode_lanes: HashMap<String, (u64 /* attach generation */, tokio::task::JoinHandle<()>)>,
+//             opencode_lane_next_generation: u64  // monotonic; bumped on EVERY OpencodeAttach (A6)
 ```
 
-**Lane loop semantics (Node `runMonitor:321-348` parity):**
+**Lane loop semantics (Node `runMonitor:321-348` + `consumeEvents:411-471` parity — connect BEFORE snapshot):**
 
 ```rust
-// inside spawn_opencode_lane's task:
+// inside spawn_opencode_lane's task (generation is hub-issued at attach and
+// stamped on EVERY note_opencode_lane_event call):
 let mut cycle: u64 = 0;
 let mut stream: u64 = 0;
 let mut backoff = OPENCODE_RECONNECT_BASE_MS;
+let mut warned_version = false;
 loop {
     cycle += 1;
     // 1. health-wait: poll GET {base}/global/health every 200ms, up to 15s this cycle.
     //    On timeout: fall through to backoff and start a new cycle.
-    // 2. snapshot: GET {base}/session/status -> object map; entries whose
+    //    Version drift gate (log-once per lane): on a healthy response, read the
+    //    REQUIRED `version` field (derives from opencode 1.18.11: /global/health
+    //    returns { healthy, version }, both required); if
+    //    !version.starts_with(TESTED_OPENCODE_VERSION_RANGE) && !warned_version,
+    //    tracing::warn! once ("opencode {version} untested for attention-bell
+    //    vocabulary (tested: 1.18.x); bells stay on") and set warned_version.
+    //    Bells stay ON either way (best-effort; D8(h)).
+    // 2. stream += 1; two-phase connect (A5): let conn = deps.events
+    //    .connect(&format!("{base}/event")).await — resolves "subscribed" on the
+    //    FIRST server.connected frame (detected on the raw decoded SSE event
+    //    BEFORE parse_serve_event, which swallows it); frames arriving after the
+    //    ack are buffered inside `conn`. On connect error: fall through to backoff.
+    // 3. snapshot: GET {base}/session/status -> object map; entries whose
     //    status.type is "busy"/"retry" -> OpencodeStatus::{Busy,Retry};
     //    a literal {"type":"idle"} entry parses as Idle (defensive — the live
     //    server DROPS idle sessions; absence == idle; opencode 1.18.11).
-    //    hub.note_opencode_lane_event(&terminal_id, cycle, stream + 1, OpencodeLaneEvent::Snapshot { statuses });
-    // 3. stream += 1; connect: deps.events.run_once(&format!("{base}/event"), &sink).await
-    //    where sink = |parsed| { if let Some(ev) = translate_serve_event(&parsed) {
-    //        hub.note_opencode_lane_event(&terminal_id, cycle, stream, ev); } };
-    //    On successful connect (run_once returned Ok after streaming), reset backoff to base.
-    // 4. sleep(backoff); backoff = (backoff * 2).min(OPENCODE_RECONNECT_MAX_MS);
+    //    Root-resolve unknown snapshot session ids FIRST (resolver below), then
+    //    hub.note_opencode_lane_event(&terminal_id, generation, cycle, stream,
+    //        OpencodeLaneEvent::Snapshot { statuses });
+    //    Subscription strictly precedes the snapshot, so every transition is
+    //    either IN the snapshot or ON the already-open stream — /event has no
+    //    replay (derives from opencode 1.18.11).
+    // 4. drive: conn.drive(&sink).await flushes the buffered frames IN ORDER,
+    //    then delivers live events, where sink = |parsed| { if let Some(ev) =
+    //        translate_serve_event(&parsed) { /* root-resolve unknown session
+    //        ids (resolver below), then */ hub.note_opencode_lane_event(
+    //        &terminal_id, generation, cycle, stream, ev); } };
+    //    On a successful streamed cycle (drive returned Ok), reset backoff to base.
+    // 5. sleep(backoff); backoff = (backoff * 2).min(OPENCODE_RECONNECT_MAX_MS);
 }
 ```
+
+**Lane-level HTTP root resolver (A4 — the Node `resolveRootForEvent`/`classifySnapshotStatuses` seam, ported to HTTP):** the lane owns a lane-lifetime `known_sessions: std::collections::HashSet<String>`; `SessionCreated` events (streamed or synthetic) insert their session (and parent) ids. Before forwarding any `Status`/`SessionIdle`/`SessionError`/`PermissionAsked` event — or noting a snapshot entry — whose session id is NOT in the set, the lane fetches `GET {base}/session/{id}` via the existing `OpencodeLaneHttp` seam (short timeout — the production impl's 2s default) and emits a synthetic `SessionCreated { session_id, parent_id }` to the hub BEFORE the triggering event, first walking the `parentID` chain while the parent is itself unknown (deepest ancestor first, so every mapping lands before its dependents). On resolve failure (non-200, timeout, shape mismatch): forward the triggering event anyway — the tracker's conservative-ambiguity behavior stands, and the next unknown-id occurrence retries. Carry the comment: `// derives from opencode 1.18.11: GET /session/{id} exposes parentID; /event has no replay`.
 
 `translate_serve_event` (kinds and property paths are verbatim from the spike — `/tmp/opencode-spike/vocabulary.md`):
 
@@ -1383,26 +1578,44 @@ pub(crate) fn translate_serve_event(event: &freshell_opencode::ParsedServeEvent)
         "permission.replied" => Some(OpencodeLaneEvent::PermissionReplied {
             permission_id: props.get("requestID")?.as_str()?.to_string(),
         }),
-        _ => None, // message.*, session.updated, session.diff, plugin.added, ... are activity-irrelevant
+        "message.updated" => {
+            // W2 abort marker (derives from opencode 1.18.11): an abort landing
+            // between assistant-message creation and LLM stream start emits NO
+            // session.error — only message.updated with info.error.name ===
+            // "MessageAbortedError", always BEFORE idle. Error-less
+            // message.updated is routine message churn -> None. Both abort
+            // signals feed the same SessionError lane event (D1).
+            let session_id = props.get("sessionID")?.as_str()?.to_string();
+            let error_name = props
+                .get("info")?
+                .get("error")?
+                .get("name")?
+                .as_str()?
+                .to_string();
+            Some(OpencodeLaneEvent::SessionError { session_id, error_name })
+        }
+        _ => None, // message.part.*, message.removed, session.updated, session.diff, plugin.added, ... are activity-irrelevant
     }
 }
 ```
 
-(`ParsedServeEvent.properties` is a `serde_json::Map<String, Value>` — adjust accessor chaining to `props.get("x")` returning `Option<&Value>` accordingly. `parse_serve_event` already swallows `server.connected`/`server.heartbeat` — the lane's explicit per-cycle snapshot replaces the Node "snapshot on server.connected" trigger.)
+(`ParsedServeEvent.properties` is a `serde_json::Map<String, Value>` — adjust accessor chaining to `props.get("x")` returning `Option<&Value>` accordingly. `parse_serve_event` swallows `server.connected`/`server.heartbeat` — which is exactly why the two-phase connect detects the subscription ack on the RAW decoded event before parsing; the per-cycle snapshot is loss-free only because it happens AFTER that ack (Node snapshot-on-`server.connected` parity, A5).)
 
-Production impls: `ReqwestLaneHttp::get_json` = `client.get(url).timeout(2s).send() -> (status, json)`; `ReqwestLaneStream::run_once` = GET with `accept: text/event-stream`, chunk loop with a 30s per-chunk `tokio::time::timeout` (read-stall watchdog — heartbeats arrive every ~10s), a `Vec<u8>` pending buffer for partial UTF-8 (copy the shape of `freshell_opencode::transport::consume_events:145-198`, WITHOUT its internal reconnect loop — the lane owns cycles), feeding `SseDecoder::push_str` and `parse_serve_event`.
+Production impls: `ReqwestLaneHttp::get_json` = `client.get(url).timeout(2s).send() -> (status, json)`; `ReqwestLaneStream::connect` = GET with `accept: text/event-stream`, then a chunk loop with a 30s per-chunk `tokio::time::timeout` (read-stall watchdog — heartbeats arrive every ~10s) and a `Vec<u8>` pending buffer for partial UTF-8 (copy the shape of `freshell_opencode::transport::consume_events:145-198`, WITHOUT its internal reconnect loop — the lane owns cycles), feeding `SseDecoder::push_str` until the FIRST decoded event whose raw JSON `type` is `"server.connected"`; resolve with a handle owning the response body, the decoder, and any frames already decoded past the ack. `ConnectedOpencodeStream::drive` = flush those buffered frames through `parse_serve_event` to the sink in order, then continue the same chunk loop live.
 
-`OpencodeAttach` handling in `handle_event`: abort any existing lane handle for the terminal (`opencode_lanes.insert` returning the old handle → `.abort()` — respawn re-allocates a NEW port, so replacement is the contract), then if deps are set, `spawn_opencode_lane(...)` and store the handle. Exit arm (Task 8 site): `if let Some(handle) = inner.opencode_lanes.remove(&terminal_id) { handle.abort(); }`.
+`OpencodeAttach` handling in `handle_event`: bump `opencode_lane_next_generation` (monotonic, hub-issued — A6) and take the new value as this lane's generation; abort any existing lane for the terminal (`opencode_lanes.insert(terminal_id, (generation, handle))` returning the old entry → `.abort()` — respawn re-allocates a NEW port, so replacement is the contract); if deps are set, `spawn_opencode_lane(deps, hub, terminal_id, base_url, generation)` and store `(generation, handle)`. The ingress guard (Task 8) then drops any `OpencodeLane` event whose stamped generation doesn't match the current map entry. Exit arm (Task 8 site): `if let Some((_, handle)) = inner.opencode_lanes.remove(&terminal_id) { handle.abort(); }` — removal makes post-exit stragglers fail the generation match too.
 
 - [ ] **Step 1: Write the failing lane tests** (in `opencode_lane.rs` `mod tests`, with fake impls of the two traits — model on `crates/freshell-opencode/tests/serve_health_bounded.rs`'s `FakeHttp`/`FakeAllocator` style):
 
 ```rust
-#[test] fn translate_covers_the_attention_vocabulary() { /* feed verbatim spike JSON (session.status busy/idle/retry, session.idle, session.error abort+unknown, permission.asked/replied, session.created child+root) through freshell_opencode::SseDecoder + parse_serve_event + translate_serve_event; assert each OpencodeLaneEvent; assert message.part.delta and session.diff translate to None */ }
-#[tokio::test(flavor = "multi_thread")] async fn lane_gates_on_health_then_snapshots_then_streams() { /* FakeHttp: health returns 500 twice then 200; /session/status returns {"ses-r":{"type":"busy"}}; FakeStream delivers one session.idle then Ok(()); a recording hub (real ActivityHub + broadcast rx) sees Snapshot before SessionIdle with cycle=1 */ }
-#[tokio::test(flavor = "multi_thread")] async fn reconnect_bumps_stream_and_resnapshots() { /* FakeStream returns Ok(()) immediately twice; assert two Snapshot events with cycle 1 and 2 */ }
+#[test] fn translate_covers_the_attention_vocabulary() { /* feed verbatim spike JSON (session.status busy/idle/retry, session.idle, session.error abort+unknown, permission.asked/replied, session.created child+root, message.updated WITH info.error MessageAbortedError -> SessionError, message.updated WITHOUT an error -> None) through freshell_opencode::SseDecoder + parse_serve_event + translate_serve_event; assert each OpencodeLaneEvent; assert message.part.delta and session.diff translate to None */ }
+#[test] fn version_gate_matches_only_the_tested_range() { /* pure prefix check against TESTED_OPENCODE_VERSION_RANGE: "1.18.11" passes; "1.19.0" and "2.0.0" fail (the lane logs once and keeps bells on) */ }
+#[tokio::test(flavor = "multi_thread")] async fn lane_gates_on_health_then_snapshots_then_streams() { /* FakeHttp: health returns 500 twice then 200 (version "1.18.11"); FakeStream::connect resolves "subscribed" with one BUFFERED session.idle frame; /session/status returns {"ses-r":{"type":"busy"}}; a recording hub (real ActivityHub + broadcast rx, test lane generation registered) plus FakeHttp's recorded call order assert: connect precedes the /session/status GET; Snapshot is noted BEFORE the buffered SessionIdle; all with generation=1, cycle=1, stream=1 */ }
+#[tokio::test(flavor = "multi_thread")] async fn reconnect_bumps_stream_and_resnapshots() { /* FakeStream: connect resolves + drive returns Ok(()) immediately, twice; assert two Snapshot events with (cycle 1, stream 1) then (cycle 2, stream 2), each noted after its own connect */ }
+#[tokio::test(flavor = "multi_thread")] async fn unmapped_session_is_resolved_via_http_before_forwarding() { /* FakeStream delivers Status{ses-child, busy} with ses-child NOT in known_sessions; FakeHttp serves GET /session/ses-child -> {"id":"ses-child","parentID":"ses-root"} and GET /session/ses-root -> {"id":"ses-root"}; assert the hub sees SessionCreated{ses-root, None} then SessionCreated{ses-child, Some(ses-root)} BEFORE Status{ses-child}; failure variant: 404 on GET /session/{id} -> Status forwarded anyway (conservative ambiguity stands, next occurrence retries) */ }
 ```
 
-Write in full. Also a hub-level test in `activity.rs`: `opencode_attach_replaces_the_lane_and_exit_tears_it_down` — set fake deps via `set_opencode_lane_deps`, `attach_opencode_serve` twice + `Exit`, assert the lanes map (expose a `#[cfg(test)] fn opencode_lane_count(&self) -> usize`).
+Write in full. Also a hub-level test in `activity.rs`: `opencode_attach_replaces_the_lane_and_exit_tears_it_down` — set fake deps via `set_opencode_lane_deps`, `attach_opencode_serve` twice + `Exit`, assert the lanes map (expose `#[cfg(test)] fn opencode_lane_count(&self) -> usize` and `#[cfg(test)] fn opencode_lane_generation(&self, terminal_id: &str) -> Option<u64>`, asserting the generation bumps on the second attach).
 
 - [ ] **Step 2: Run RED** — `cargo test -p freshell-ws opencode_lane` fails to compile.
 
@@ -1431,7 +1644,7 @@ git commit -m "feat(ws): per-terminal opencode SSE lane with injected IO seams"
 
 - [ ] **Step 1: Write the failing test**
 
-In `activity.rs` tests (hub-level, since terminal.rs's handlers need a full WS harness): `resume_created_opencode_terminal_binds_identity_via_bind_ingress` — `Created` with `resume_session_id: None`, busy for `ses-x` (candidate), idle (awaitingAssociation), then `hub.bind_opencode_session("t-oc", "ses-x")` → expect `terminal.turn.complete{provider:"opencode"}` then one `terminal.idle`. (This pins the deferred-completion bind lane the association producers will drive.) Write it in full following the Task 8 episode style.
+In `activity.rs` tests (hub-level, since terminal.rs's handlers need a full WS harness): `resume_created_opencode_terminal_binds_identity_via_bind_ingress` — `Created` with `resume_session_id: None`, busy for `ses-x` (candidate), idle (awaitingAssociation), then `hub.bind_opencode_session("t-oc", "ses-x")` → expect `terminal.turn.complete{provider:"opencode"}` then one `terminal.idle`. (This pins the deferred-completion bind lane the association producers will drive. Register a test lane generation first — `hub.register_opencode_lane_for_tests("t-oc", 1)` — and stamp the busy/idle lane events with `generation: 1`, as in Task 8's helper.) Write it in full following the Task 8 episode style.
 
 - [ ] **Step 2: Run RED if the bind arm is incomplete; otherwise this is a pin** — `cargo test -p freshell-ws opencode`.
 
@@ -1494,14 +1707,42 @@ git commit -m "feat(ws): thread opencode endpoint and identity binds into the ac
 ```
 //! 6. Opencode death bells now ring on both servers, ownership-scoped:
 //!    candidate/ambiguous ownership never death-rings (the old noisy-busy-proxy
-//!    problem, now excluded by construction).
+//!    problem, now excluded by construction). Consequences kept deliberate:
+//!    first-turn deaths stay silent (candidate covers the whole first turn on
+//!    Node — even with a candidate-armed permission pause pending), and a Rust
+//!    pane whose bind producers all fail (locator ambiguity + plugin absence)
+//!    stays candidate indefinitely — candidate-armed pauses still ring there,
+//!    but completions and death bells wait for the bind.
 //! 8. Opencode: an SSE reconnect during a permission pause loses the pending
 //!    pause bell (the busy snapshot clears it; GET /permission resync is a
 //!    possible follow-up). Ambiguous ownership stays bell-free. Child sessions
-//!    created inside a reconnect gap can force ambiguous (conservative silence).
-//! 9. Opencode permission.v2.* / question.* event families (schema-declared,
-//!    unobserved on 1.18.11) are unhandled — the pause bell goes deaf if a
-//!    future server switches families.
+//!    unseen on-stream (reconnect gap, mid-turn attach) are recovered by the
+//!    lane's HTTP root resolver (GET /session/{id} exposes parentID); only
+//!    resolver FAILURE degrades to ambiguous (conservative silence), retried
+//!    on the next occurrence.
+//! 9. Opencode protocol drift: permission.v2.* / question.* event families
+//!    (schema-declared, unobserved on 1.18.11) are unhandled — the pause bell
+//!    goes deaf if a future server switches families. session.idle is already
+//!    deprecated upstream and a v1->v2 event/health migration is in progress;
+//!    the log-once version gate (Rust lane + Node tracker) converts silent
+//!    drift into a logged warning, and /session/status absence==idle is
+//!    version-derived behavior (1.18.x).
+//! 10. Opencode abort window W1: an abort landing between the prompt loop-top
+//!    and processor.create emits NO abort evidence at all before idle — a
+//!    ms-scale window where a completion bell can ring on a human abort
+//!    (window W2 is closed by the abort-marked message.updated fallback).
+//! 11. Pathological opencode TUI quits — worker dispose exceeding the 5s
+//!    hard-terminate cap, or a raw SIGTERM (no drain path) — can leave
+//!    engagement set at spontaneous exit, so a death bell can ring on those
+//!    rare human quits. Normal quit paths verified to abort+drain (all four
+//!    quit inputs dispose runners via the abort path before exit); the
+//!    wire-flush instant is unprovable from code but mitigated upstream by
+//!    graceful SSE stream termination.
+//! 12. The opencode 120s busy deadman is EVENT-SILENCE-keyed (deltas and
+//!    heartbeats do not refresh it): a single >120s silent tool call trips it
+//!    mid-turn. Ownership survives and the turn's completion still rings —
+//!    the cost is the dropped busy light plus lost post-deadman death
+//!    engagement (the removal itself stays silent).
 ```
 
 (Keep existing entries 1–5 and 7 verbatim; renumber only if the file's style demands it.)
@@ -1574,19 +1815,23 @@ git add -A && git commit -m "chore(opencode): verification sweep fixes"   # only
 
 **1. Spec coverage** — each spec requirement → covering task:
 - Completed turn rings after 2s grace, busy re-entry cancels, double-idle dedupe → Node: already-live path + Tasks 1–2 pins; Rust: Tasks 6, 8.
-- Abort/Esc silent, per-turn flag → Tasks 1–2 (Node), 7–8 (Rust).
+- Abort/Esc silent, per-turn flag, W2 abort-marked `message.updated` fallback → Tasks 1–2 (Node), 7–9 (Rust); W1 no-evidence window documented as residual (D8(g), Task 11).
 - Failed turn rings, trailing error no-op → Tasks 1–2, 7–8.
-- Permission pause: boundary, replied/busy resume, mid-pause hardening, duplicate dedupe, busy-only wire record → Tasks 3 (Node), 7–8 (Rust).
-- Spontaneous death while engaged (knownBusy ∨ armed grace ∨ pending permissions; never candidate/ambiguous), freshell kills silent, exit-while-idle silent, SSE-drop non-signal → Tasks 4 (Node), 7–8 (Rust); D4/D8 documented in Task 11.
+- Permission pause: boundary, replied/busy resume, mid-pause hardening (incl. the deferred-completion swallow at association confirm/bind), duplicate dedupe, busy-only wire record, root-resolved CHILD asks, candidate arming (first-turn asks ring) → Tasks 3 (Node), 7–8 (Rust).
+- Spontaneous death while engaged (knownBusy ∨ armed grace ∨ pending permissions; never candidate/ambiguous — even with a candidate-armed pause pending), freshell kills silent, exit-while-idle silent, SSE-drop non-signal → Tasks 4 (Node), 7–8 (Rust); D4/D8 documented in Task 11.
 - Child-session scoping + live-trace pins → Tasks 2, 5 (Node), 6, 8 (Rust).
-- Ambiguous conservative + residuals truth-up (idle.rs entry 6) → Tasks 6–8, 11.
+- Reconnect-gap / mid-turn-attach child recovery: lane-level HTTP root resolver (`GET /session/{id}` → parentID, synthetic SessionCreated before the triggering event; pure tracker stays resolver-free) → Task 9 (`unmapped_session_is_resolved_via_http_before_forwarding`); D8(c) narrowed to resolver failure → Task 11.
+- Lane/stream loss-free ordering: two-phase connect (subscribe on `server.connected` → snapshot → flush buffered → drive) → Task 9 (`lane_gates_on_health_then_snapshots_then_streams` pins connect-before-snapshot and snapshot-before-buffered-event).
+- Respawn stale-event immunity: hub-issued attach generations, generation-guarded ingress, Exit removes the entry → Tasks 8–9 (`respawn_drops_stale_lane_events`); cycle/stream keep guarding intra-lane staleness.
+- Version drift gate (log-once, bells stay on, `TESTED_OPENCODE_VERSION_RANGE`) → Tasks 2 (Node tracker health path), 9 (Rust lane); drift residuals (D8(h)) → Task 11.
+- Ambiguous conservative + residuals truth-up (idle.rs entries 6/8–12) → Tasks 6–8, 11.
 - Rust parity: pure tracker in freshell-activity, SSE lane reusing freshell-opencode decoder, hub wiring (Created/Exit/IdleGate/death/updated/list/turn.complete), endpoint threading, reconnect+health constants mirrored, zero client changes → Tasks 6–10.
 - opencode.activity.list answered from the hub (codex-mirror routing) → Task 8.
 - resolveOpencodeSessionRoots wiring pin → Task 5.
 - Testing expectations (Rust pure + hub episode + lane fakes; Node mirrors with collectors-before-action; deliberate pinned-test rewrites with SEMANTIC CHANGE comments; contract freeze green; fmt/clippy; targeted suites) → Tasks 1–10 test steps + Task 12.
 
-**1b. No silent deferrals** — every requirement lands as production behavior with a test naming the observable outcome (frames on the broadcast channel / tracker events), not stubs: the Rust lane's injected IO seams are test seams, and Task 10 installs the reqwest production impls in `main.rs` (built by `cargo build -p freshell-server`); hub episode tests prove the end-to-end frame behavior the client consumes. No stub survives without its production replacement task. Known residuals (D8) are protocol-inherent limits documented as residuals, not deferred requirements — none of the 8 required behaviors is moved there. **No unresolved coverage gaps.**
+**1b. No silent deferrals** — every requirement lands as production behavior with a test naming the observable outcome (frames on the broadcast channel / tracker events), not stubs: the Rust lane's injected IO seams are test seams, and Task 10 installs the reqwest production impls in `main.rs` (built by `cargo build -p freshell-server`); hub episode tests prove the end-to-end frame behavior the client consumes. Every validation-pass fix ships as production code with a named test in the same task: W2 marker (Task 2 W2 test; Task 7 `w2_abort_marker_gates_like_session_error`; Task 9 translate coverage), candidate/child pause arming (Task 3 tests; Task 7 `child_permission_asked_resolves_to_root_and_arms` + `candidate_pause_arms_and_deferred_completion_is_swallowed_at_bind`; Task 8 episode tests), HTTP root resolver (Task 9 `unmapped_session_is_resolved_via_http_before_forwarding`), two-phase connect ordering (Task 9 order pins), generation guard (Task 8 `respawn_drops_stale_lane_events`), version gate (Task 2 warn-once test; Task 9 `version_gate_matches_only_the_tested_range`). No stub survives without its production replacement task. The only residualized items are those explicitly adjudicated by the validation pass (W1 window, first-turn death silence, pathological quits, Rust bind tails, drift facts, deadman characterization) — documented in D8/Task 11, not silently dropped. **No unresolved coverage gaps.**
 
-**2. Placeholder scan** — Tasks 2, 3, 5, 8, 9 use comment-annotated test skeletons that specify exact event sequences and assertions with a "write in full" instruction plus a complete worked example in the same task; no TBD/TODO/"handle edge cases" items remain.
+**2. Placeholder scan** — Tasks 2, 3, 5, 7, 8, 9 use comment-annotated test skeletons that specify exact event sequences and assertions with a "write in full" instruction plus a complete worked example in the same task; no TBD/TODO/"handle edge cases" items remain (re-verified after the validation-pass edits).
 
-**3. Type consistency** — checked: `OpencodeActivityChange` marker fields match `TrulyIdleActivityChange` (`spontaneousExitRemovals`/`approvalPendingRemovals`, `:34`/`:41`); `untrackTerminal({ terminalId, spontaneous? })` matches the wiring call; Rust `OpencodeStatus`/`OpencodeLaneEvent` names match between Tasks 6–9; `opencode_frames` signature matches `claude_frames`' single-return shape (no force-reads); `blocks_death_bell`/`has_pending_permissions` names consistent across Tasks 7–8; `attach_opencode_serve(terminal_id, hostname, port)` consistent between Tasks 9–10; reducer `error` observation field names identical in Tasks 1–2.
+**3. Type consistency** — checked: `OpencodeActivityChange` marker fields match `TrulyIdleActivityChange` (`spontaneousExitRemovals`/`approvalPendingRemovals`, `:34`/`:41`); `untrackTerminal({ terminalId, spontaneous? })` matches the wiring call; Rust `OpencodeStatus`/`OpencodeLaneEvent` names match between Tasks 6–9; `opencode_frames` signature matches `claude_frames`' single-return shape (no force-reads); `blocks_death_bell`/`has_pending_permissions` names consistent across Tasks 7–8; `attach_opencode_serve(terminal_id, hostname, port)` consistent between Tasks 9–10; reducer `error` observation field names identical in Tasks 1–2 (and fed by both `session.error` and `message.updated`); `note_opencode_lane_event(terminal_id, generation, cycle, stream, event)` and `HubEvent::OpencodeLane{terminal_id, generation, cycle, stream, event}` consistent across Tasks 8–10 (helper, episode tests, lane loop, ingress guard, bind-lane test); `spawn_opencode_lane(..., generation: u64)` matches the `OpencodeAttach` arm; `opencode_lanes: HashMap<String, (u64, JoinHandle<()>)>` + `opencode_lane_next_generation` consistent between Tasks 8–9; two-phase `OpencodeEventStream::connect`/`ConnectedOpencodeStream::drive` names consistent across the trait, `ReqwestLaneStream` description, and lane tests; Rust root resolution is `resolve_root` (pure tracker, Tasks 6–8) with the lane-level HTTP fallback in Task 9, while Node reuses the existing `resolveRootForEvent` (Tasks 2–3); `TESTED_OPENCODE_VERSION_RANGE` named identically in the Node tracker and the Rust lane.

--- a/docs/plans/2026-08-03-opencode-attention-bell.md
+++ b/docs/plans/2026-08-03-opencode-attention-bell.md
@@ -1,0 +1,1592 @@
+# OpenCode Attention Bell (Node + Rust Terminal Panes) Implementation Plan
+
+> **For agentic workers:** This plan is executed task-by-task by the
+> workflow's execute stage: a fresh implementer per task, with a spec +
+> quality review after each task. Steps use checkbox (`- [ ]`) syntax
+> for tracking.
+
+**Goal:** Extend the codex attention-bell policy (PR #597) to OPENCODE terminal panes on both servers: policy-correct bells on the Node server (abort-silent, failed-rings, permission pauses, death bells) and a complete, from-scratch OpenCode activity lane on the Rust server (tracker + SSE lane + hub wiring) that lights up the client's existing dead code paths with zero client changes.
+
+**Architecture:** OpenCode terminal panes embed an HTTP+SSE server on a freshell-allocated loopback port. On Node we extend the existing SSE tracker (`opencode-activity-tracker.ts`) and pure ownership reducer with per-turn abort gates, a permission-pause lane, and spontaneous-exit death-bell markers — the already-wired `TrulyIdleEmitter` does the rest. On Rust we build a pure tracker in `crates/freshell-activity/src/opencode.rs` (port of the Node reducer semantics + the new gates), a per-terminal SSE lane in `freshell-ws` reusing `freshell-opencode`'s `SseDecoder`/`parse_serve_event`, and hub wiring (mode arms, `opencode_frames`, death-bell predicate, `opencode.activity.list`).
+
+**Tech Stack:** TypeScript (Node server, zod, vitest), Rust (tokio, reqwest, serde), OpenCode 1.18.11 SSE protocol (empirically spiked — see `/tmp/opencode-spike/`).
+
+## Global Constraints
+
+- **Policy (user-adjudicated, same as codex):** one bell (`terminal.idle`) = "agent stopped making progress for any NON-HUMAN-REQUESTED cause". Ring: completed turns, FAILED turns, spontaneous death while engaged, permission pauses. Silent: Esc/interrupt/abort, freshell-initiated kills/shutdown, idle quits, queued-follow-up turn ends. NO heuristic bells — protocol events only.
+- **Zero wire-shape changes.** All opencode wire schemas already exist (`OpencodeActivityRecordSchema` at `shared/ws-protocol.ts:124-129` with `phase: z.literal('busy')`, `opencode.activity.updated` `:140-144`, `opencode.activity.list.response` `:133-138`, provider `'opencode'` in `TerminalTurnCompleteSchema` `:190-197`, provider-agnostic `TerminalIdleSchema` `:222-227`). `terminal.idle.reason` reuses `'grace'` for all new causes. Contract freeze (`npm run test:port`) must show zero drift.
+- **Zero client changes.** `src/lib/pane-activity.ts:207` and `src/lib/terminal-output-side-effects.ts:39` already include `'opencode'`; the client is built for this and currently dark on Rust.
+- **Fresh-agent `freshopencode` surface (`server/fresh-agent/adapters/opencode/`) is OUT OF SCOPE** — do not touch. Its `turnAborted`/`turnErrored` gating is reference-only.
+- **Protocol facts derive from OpenCode 1.18.11** (live spike, `/tmp/opencode-spike/`). Any NEW load-bearing protocol assumption must consult `/tmp/opencode-spike/openapi.json` and carry a "derives from opencode 1.18.11" comment.
+- **Never** restart the self-hosted server (build ok, deploy not), touch the production server (port 3002), the user's live opencode processes (pts/9, pts/33, pts/37), or `~/.local/share/opencode`.
+- **No PR creation without explicit user approval.** Everything to main via PR eventually.
+- Git author must be `Dan Shapiro <3732858+danshapiro@users.noreply.github.com>` (never `dan@danshapiro.com`). Conventional commits.
+- Broad test runs take the shared coordinator gate: set `FRESHELL_TEST_SUMMARY="<reason>"`. Targeted suites preferred. Node targeted runs use the repo-owned path: `npm run test:vitest -- run <file> --config config/vitest/vitest.server.config.ts` (never bare `npx vitest`).
+- NodeNext/ESM: relative imports in server code MUST carry `.js`.
+- Commit `.kata.toml` if modified (no modification expected).
+- Worktree: `/home/dan/code/freshell/.worktrees/opencode-attention-bell`, branch `feat/opencode-attention-bell`, based on `origin/main`.
+
+---
+
+## Design Decisions (shared by all tasks — read before implementing any task)
+
+**D1 — Abort gate lives in the ownership state machine, per-turn.** `session.error{name:'MessageAbortedError'}` on the owned session while busy sets a `turnAborted` flag on the `knownBusy`/`candidate` state. The NEXT idle edge consumes it: state clears busy silently (activityRemove, NO turnComplete). The flag clears when consumed or when a new busy begins. All other `session.error` names set nothing — the following idle edge completes normally (failed turns ring exactly like completed turns, via the existing turnComplete → grace → `terminal.idle` path). Trailing errors on quiet/idle state are structurally no-ops (the reducer only reads the flag from busy states).
+
+**D2 — Double `session.idle` dedupe is structural.** The first idle observation transitions `knownBusy → quiet`; the second (and the preceding `session.status{idle}` twin, ~7–20ms apart per the spike) lands on `quiet` and produces no actions. Pinned by tests, not by timers.
+
+**D3 — Permission pause maps to record removal + attention boundary.** `permission.asked` for the OWNED busy session removes the public record (opencode's existing not-busy representation — `phase` stays `'busy'`-only on the wire, NO new phase value) and then emits an attention boundary (codex ordering: demote FIRST, boundary SECOND). Only a newly-inserted permission id arms (duplicate `permission.asked` never re-arms). `permission.replied` (or the session going busy again) restores the busy record immediately — busy re-entry cancels within grace. Mid-pause turn end retires the pause WITHOUT a second bell: a mid-pause completion/failure swallows the turnComplete (the pause bell — rung or still in grace — is THE bell for the episode); a mid-pause abort additionally force-emits the removal so the armed grace window is cancelled (human at keyboard → total silence).
+
+**D4 — Death-bell engagement is ownership-scoped.** 'Engaged' = knownBusy on the owned root session OR an armed grace deadline OR a non-empty pending-permission set — NEVER `candidate`/`ambiguous` ownership (that noise is exactly why death bells were excluded before; tightening this is the fix). The registry's exit event (`spontaneous: !requestedClose`, computed at `server/terminal-registry.ts:1517`/`:1542` on Node; `ActivityEvent::Exit{spontaneous}` on Rust) is the authoritative discriminator. SSE-drop alone is NEVER a death signal (reconnect churn) — corroboration only. Death bells are immediate (`reason: 'grace'`, no grace window).
+
+**D5 — Child sessions never gate the root.** `session.created.properties.info.parentID` builds the child→root map. Child BUSY remaps to the root (keeps the root busy — matches existing behavior and snapshot "busy beats idle" collapsing). Child IDLE is SUPPRESSED (today's Node code remaps child idle onto the root, which falsely completes the root's turn — the live trace shows the child idle landing 921ms before the parent's; this plan fixes that). Child `session.error` and child `permission.asked` are ignored (raw sessionID must equal the owned root).
+
+**D6 — `retry` status is busy.** `session.status{type:'retry'}` was never observed live but is schema-declared; both servers parse it defensively as busy.
+
+**D7 — Rust gate mapping mirrors the Node emitter mechanism.** `opencode_frames` maps `Changed.remove` → `idle.note_exit` (exactly what the existing `note_changed_to_gate` at `activity.rs:1396-1407` does): the removal clears gate state, and the `TurnComplete`/`AttentionBoundary` that FOLLOWS in the same effect batch re-arms grace-only. This is the same "activityRemove followed by turnComplete" contract documented at `truly-idle-emitter.ts:78-79`. Effect ordering (remove before boundary) is therefore load-bearing everywhere.
+
+**D8 — Accepted residuals (documented in Task 11, kept truthful):** (a) ambiguous ownership → no bells, no death bells; (b) SSE reconnect during a permission pause loses the pending-pause bell (the busy snapshot clears it; `GET /permission` resync is a possible follow-up); (c) child sessions created during an SSE reconnect gap can look like separate roots → ambiguous → conservative silence; (d) `permission.v2.*` / `question.*` event families are schema-declared but unobserved on 1.18.11 — unhandled (bell goes deaf if a future server switches families); (e) busy deadman (120s) removal is silent.
+
+**File structure** (created/modified across tasks):
+
+| File | Responsibility |
+|---|---|
+| `server/coding-cli/opencode-ownership-reducer.ts` (modify) | pure state machine: + error observation, per-turn abort flags |
+| `server/coding-cli/opencode-activity-tracker.ts` (modify) | SSE client: + session.error/permission.* vocabulary, child-idle suppression, permission pause lane, death-bell markers |
+| `server/coding-cli/opencode-activity-wiring.ts` (modify) | + thread `spontaneous` from `terminal.exit` |
+| `crates/freshell-activity/src/opencode.rs` (create) | pure Rust tracker: ownership machine + gates + permission pause + death predicates |
+| `crates/freshell-activity/src/lib.rs` (modify) | + `pub mod opencode;` |
+| `crates/freshell-ws/src/activity.rs` (modify) | hub: opencode mode arms, `opencode_frames`, death predicate, list, deadlines, lane registry |
+| `crates/freshell-ws/src/opencode_lane.rs` (create) | per-terminal SSE lane: health-wait → snapshot → stream → backoff, injected IO seams |
+| `crates/freshell-ws/src/terminal.rs` (modify) | thread allocated endpoint to hub (create + respawn); swap the `opencode.activity.list` stub |
+| `crates/freshell-ws/src/opencode_association.rs` + `opencode_signal.rs` consumers (modify) | notify hub of session binds (identity only — do not conflate) |
+| `crates/freshell-server/src/main.rs` (modify) | install production lane deps |
+| `crates/freshell-activity/src/idle.rs` (modify) | residuals list truth-up |
+| `shared/ws-protocol.ts`, `server/coding-cli/truly-idle-emitter.ts` (modify) | doc-comment truth-up only (no schema changes) |
+
+---
+
+### Task 1: Node reducer — error observation + per-turn abort gates
+
+**Files:**
+- Modify: `server/coding-cli/opencode-ownership-reducer.ts`
+- Test: `test/unit/server/coding-cli/opencode-ownership-reducer.test.ts`
+
+**Interfaces:**
+- Consumes: existing `OpencodeOwnershipState` (5 kinds, `:24-57`), `OpencodeOwnershipAction` (`:59-81`), `sameSessionStream` guard (`:103-110`).
+- Produces (used by Task 2's tracker forwarding and Task 6's Rust port):
+  - New observation variant: `{ kind: 'error'; cycleId: number; streamId: number; sessionId: string; errorName: string; at: number }`
+  - `candidate` and `knownBusy` states gain `turnAborted?: boolean`; `awaitingAssociation` gains `aborted?: boolean`.
+  - Semantics: abort-then-idle → `[activityRemove]` only; error-then-idle (non-abort) → unchanged `[activityRemove, turnComplete]`; abort flag cleared by busy re-entry; `confirmOpencodeAssociation` mints nothing when `aborted`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/unit/server/coding-cli/opencode-ownership-reducer.test.ts` (follow the file's existing import/helper style — it imports `createOpencodeOwnershipState`, `reduceOpencodeOwnership`, `confirmOpencodeAssociation` from `'../../../../server/coding-cli/opencode-ownership-reducer.js'`):
+
+```ts
+describe('abort gate (session.error MessageAbortedError)', () => {
+  const stream = { cycleId: 1, streamId: 1 }
+
+  function busyKnown() {
+    // quiet(known) + busy sse -> knownBusy
+    const s0 = createOpencodeOwnershipState('ses-root')
+    return reduceOpencodeOwnership(s0, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'busy', at: 1000 }).state
+  }
+
+  it('abort then idle clears busy silently (no turnComplete)', () => {
+    const s1 = reduceOpencodeOwnership(busyKnown(), { kind: 'error', ...stream, sessionId: 'ses-root', errorName: 'MessageAbortedError', at: 1500 })
+    expect(s1.actions).toEqual([])
+    const s2 = reduceOpencodeOwnership(s1.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'idle', at: 1507 })
+    expect(s2.actions).toEqual([{ kind: 'activityRemove', at: 1507 }])
+    expect(s2.state).toEqual({ kind: 'quiet', knownSessionId: 'ses-root' })
+  })
+
+  it('second idle edge after abort is a no-op (double session.idle dedupe)', () => {
+    const s1 = reduceOpencodeOwnership(busyKnown(), { kind: 'error', ...stream, sessionId: 'ses-root', errorName: 'MessageAbortedError', at: 1500 })
+    const s2 = reduceOpencodeOwnership(s1.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'idle', at: 1507 })
+    const s3 = reduceOpencodeOwnership(s2.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'idle', at: 1527 })
+    expect(s3.actions).toEqual([])
+  })
+
+  it('non-abort error names do not suppress the completion (failed turns ring)', () => {
+    const s1 = reduceOpencodeOwnership(busyKnown(), { kind: 'error', ...stream, sessionId: 'ses-root', errorName: 'UnknownError', at: 1500 })
+    expect(s1.actions).toEqual([])
+    const s2 = reduceOpencodeOwnership(s1.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'idle', at: 1507 })
+    expect(s2.actions).toEqual([
+      { kind: 'activityRemove', at: 1507 },
+      { kind: 'turnComplete', sessionId: 'ses-root', at: 1507 },
+    ])
+  })
+
+  it('trailing error on quiet state is a no-op (never mint from idle)', () => {
+    const quiet = { kind: 'quiet' as const, knownSessionId: 'ses-root' }
+    const r = reduceOpencodeOwnership(quiet, { kind: 'error', ...stream, sessionId: 'ses-root', errorName: 'UnknownError', at: 2000 })
+    expect(r.state).toEqual(quiet)
+    expect(r.actions).toEqual([])
+  })
+
+  it('a new busy clears the abort flag (per-turn semantics)', () => {
+    const s1 = reduceOpencodeOwnership(busyKnown(), { kind: 'error', ...stream, sessionId: 'ses-root', errorName: 'MessageAbortedError', at: 1500 })
+    const s2 = reduceOpencodeOwnership(s1.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'busy', at: 1600 })
+    const s3 = reduceOpencodeOwnership(s2.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'idle', at: 1700 })
+    expect(s3.actions).toContainEqual({ kind: 'turnComplete', sessionId: 'ses-root', at: 1700 })
+  })
+
+  it('abort from a mismatched cycle/stream is ignored', () => {
+    const s1 = reduceOpencodeOwnership(busyKnown(), { kind: 'error', cycleId: 9, streamId: 9, sessionId: 'ses-root', errorName: 'MessageAbortedError', at: 1500 })
+    const s2 = reduceOpencodeOwnership(s1.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'idle', at: 1507 })
+    expect(s2.actions).toContainEqual({ kind: 'turnComplete', sessionId: 'ses-root', at: 1507 })
+  })
+
+  it('snapshot-empty after abort is silent too', () => {
+    const s1 = reduceOpencodeOwnership(busyKnown(), { kind: 'error', ...stream, sessionId: 'ses-root', errorName: 'MessageAbortedError', at: 1500 })
+    const s2 = reduceOpencodeOwnership(s1.state, { kind: 'snapshot', ...stream, statuses: {}, at: 1507 })
+    expect(s2.actions).toEqual([{ kind: 'activityRemove', at: 1507 }])
+  })
+
+  it('aborted candidate turn never mints a completion at association confirm', () => {
+    // quiet(no known) + busy -> candidate
+    const s0 = createOpencodeOwnershipState()
+    const c1 = reduceOpencodeOwnership(s0, { kind: 'sse', ...stream, sessionId: 'ses-x', status: 'busy', at: 1000 })
+    const c2 = reduceOpencodeOwnership(c1.state, { kind: 'error', ...stream, sessionId: 'ses-x', errorName: 'MessageAbortedError', at: 1100 })
+    const c3 = reduceOpencodeOwnership(c2.state, { kind: 'sse', ...stream, sessionId: 'ses-x', status: 'idle', at: 1200 })
+    expect(c3.state.kind).toBe('awaitingAssociation')
+    const confirmed = confirmOpencodeAssociation(c3.state, { sessionId: 'ses-x' })
+    expect(confirmed.actions).toEqual([])
+    expect(confirmed.state).toEqual({ kind: 'quiet', knownSessionId: 'ses-x' })
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd /home/dan/code/freshell/.worktrees/opencode-attention-bell && npm run test:vitest -- run test/unit/server/coding-cli/opencode-ownership-reducer.test.ts --config config/vitest/vitest.server.config.ts`
+Expected: FAIL — TypeScript errors on the `'error'` observation kind (not in the union) and/or completion assertions failing. Compile errors count as RED.
+
+- [ ] **Step 3: Implement the reducer changes**
+
+In `server/coding-cli/opencode-ownership-reducer.ts`:
+
+1. Extend the observation union (after the existing `sse` variant, ~`:15-22`):
+
+```ts
+  | {
+      kind: 'error'
+      cycleId: number
+      streamId: number
+      sessionId: string
+      /** OpenCode error class name, e.g. 'MessageAbortedError' (opencode 1.18.11). */
+      errorName: string
+      at: number
+    }
+```
+
+2. Add the per-turn flags to the state union: on `candidate` (~`:29-36`) and `knownBusy` (~`:37-43`) add `turnAborted?: boolean`; on `awaitingAssociation` (~`:44-51`) add `aborted?: boolean`.
+
+3. Add `reduceError` (near `reduceIdle`):
+
+```ts
+function reduceError(
+  state: OpencodeOwnershipState,
+  observation: Extract<OpencodeObservation, { kind: 'error' }>,
+): OpencodeOwnershipResult {
+  // Only a human abort gates the next idle edge. Every other error name
+  // (UnknownError, ProviderAuthError, ...) leaves the turn to complete
+  // normally: failed turns ring exactly like completed turns.
+  if (observation.errorName !== 'MessageAbortedError') return { state, actions: [] }
+  if (
+    (state.kind === 'knownBusy' || state.kind === 'candidate') &&
+    sameSessionStream(state, observation)
+  ) {
+    return { state: { ...state, turnAborted: true }, actions: [] }
+  }
+  // Trailing errors on quiet/awaitingAssociation/ambiguous never mint anything.
+  return { state, actions: [] }
+}
+```
+
+4. Dispatch it in `reduceOpencodeOwnership` (~`:427-438`):
+
+```ts
+export function reduceOpencodeOwnership(
+  state: OpencodeOwnershipState,
+  observation: OpencodeObservation,
+): OpencodeOwnershipResult {
+  if (observation.kind === 'snapshot') return reduceSnapshot(state, observation)
+  if (observation.kind === 'error') return reduceError(state, observation)
+  if (observation.status === 'idle') return reduceIdle(state, observation)
+  return reduceBusy(state, observation)
+}
+```
+
+5. In `reduceIdle`'s `knownBusy` branch (`:230-242`), gate the completion:
+
+```ts
+  if (state.kind === 'knownBusy') {
+    if (!sameSessionStream(state, observation)) return { state, actions: [] }
+    const actions: OpencodeOwnershipAction[] = [{ kind: 'activityRemove', at: observation.at }]
+    if (!state.turnAborted) {
+      actions.push({ kind: 'turnComplete', sessionId: state.sessionId, at: observation.at })
+    }
+    return { state: { kind: 'quiet', knownSessionId: state.sessionId }, actions }
+  }
+```
+
+6. In `reduceIdle`'s `candidate` branch (`:212-228`), carry the flag into `awaitingAssociation`: add `...(state.turnAborted ? { aborted: true } : {})` to the new state object.
+
+7. In `reduceSnapshot`'s `knownBusy` empty-busy branch (`:322-330`), apply the same gate as (5) (build `actions` conditionally on `state.turnAborted`). In `reduceSnapshot`'s `candidate` empty-busy branch (`:346-361`), carry `aborted` as in (6).
+
+8. In `reduceBusy`, every branch that keeps/refreshes a `candidate` or `knownBusy` state for the SAME session must clear the flag: include `turnAborted: undefined` (or omit via a rebuilt object) in the refreshed state so a new busy begins a clean turn.
+
+9. In `confirmOpencodeAssociation` (`:440-458`): when `state.aborted === true`, return `{ state: { kind: 'quiet', knownSessionId: state.sessionId }, actions: [] }` (bind identity, mint nothing).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: same command as Step 2. Expected: PASS (all new tests + all 15 pre-existing reducer tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/dan/code/freshell/.worktrees/opencode-attention-bell
+git add server/coding-cli/opencode-ownership-reducer.ts test/unit/server/coding-cli/opencode-ownership-reducer.test.ts
+git commit -m "feat(opencode): per-turn abort gate in the ownership reducer"
+```
+
+---
+
+### Task 2: Node tracker — session.error vocabulary + child-idle suppression
+
+**Files:**
+- Modify: `server/coding-cli/opencode-activity-tracker.ts`
+- Test: `test/unit/server/coding-cli/opencode-activity-tracker.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1's `error` observation; existing SSE plumbing (`KNOWN_OPENCODE_EVENT_TYPES` `:115-120`, `OpencodeEventSchema` `:104-109`, `handleOpencodeEvent` `:510-568`, `resolveRootForEvent` `:570-591`).
+- Produces: tracker recognizes `session.error`; child idle edges are suppressed (raw child id never completes the root); tracker events unchanged (`'changed'`, `'turn.complete'`, `'association.requested'`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/unit/server/coding-cli/opencode-activity-tracker.test.ts`, reusing the file's own helpers (`createJsonResponse`, `createSseResponse`, `createControlledSseResponse`, `TEST_ENDPOINT`, fake-timer `beforeEach`/`afterEach` — see `:12-74`). Attach ALL collectors BEFORE the action under test (a prior codex bug was masked by attach-after).
+
+```ts
+describe('abort/error episodes (policy: PR #597 extended to opencode)', () => {
+  it('Esc/abort stays silent: MessageAbortedError then double idle emits no completion', async () => {
+    const sse = createControlledSseResponse()
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) return createJsonResponse({ healthy: true })
+      if (url.endsWith('/session/status')) return createJsonResponse({ 'ses-root': { type: 'busy' } })
+      if (url.endsWith('/event')) return sse.response
+      throw new Error(`unexpected url ${url}`)
+    })
+    const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+    const completions: unknown[] = []
+    const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+    tracker.on('turn.complete', (e) => completions.push(e))
+    tracker.on('changed', (c) => changes.push(c))
+    tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+    await vi.advanceTimersByTimeAsync(0)
+    sse.enqueue({ type: 'server.connected', properties: {} })
+    await vi.advanceTimersByTimeAsync(0) // snapshot marks ses-root knownBusy
+    // live abort trace (events-B.log): error -> status idle -> session.idle -> status idle -> session.idle
+    sse.enqueue({ type: 'session.error', properties: { sessionID: 'ses-root', error: { name: 'MessageAbortedError', data: { message: 'Aborted' } } } })
+    sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
+    sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
+    sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
+    sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(completions).toEqual([])
+    expect(changes.filter((c) => c.remove.length > 0)).toHaveLength(1) // one demotion, no double-remove
+    tracker.dispose()
+  })
+
+  it('failed turn rings: UnknownError then idle emits exactly one completion; trailing error is a no-op', async () => {
+    // same fixture shape as above; sequence from events-B.log scenario C:
+    // busy -> error(UnknownError) -> status idle -> session.idle -> error(UnknownError, stack) AFTER idle
+    // assert completions.length === 1 after the whole sequence
+  })
+
+  it('child session.idle mid-parent-turn does not complete the root (live trace events-D.log)', async () => {
+    // snapshot: { 'ses-parent': busy }; then:
+    // session.created { sessionID: 'ses-child', info: { id: 'ses-child', parentID: 'ses-parent' } }
+    // session.status  { sessionID: 'ses-child', status: { type: 'busy' } }
+    // session.status  { sessionID: 'ses-child', status: { type: 'idle' } }
+    // session.idle    { sessionID: 'ses-child' }          <- 921ms before the parent, must be suppressed
+    // assert completions === [] and the busy record survives with sessionId 'ses-parent'
+    // then: session.status { sessionID: 'ses-parent', status: { type: 'idle' } }
+    // assert exactly one completion for 'ses-parent'
+  })
+
+  it('child session.error does not abort the root turn', async () => {
+    // snapshot: parent busy; session.created child(parentID=parent);
+    // session.error { sessionID: 'ses-child', error: { name: 'MessageAbortedError', ... } }
+    // session.status { sessionID: 'ses-parent', status: { type: 'idle' } }
+    // assert exactly one completion (the parent's turn still rings)
+  })
+})
+```
+
+Write the four tests in full (the second through fourth follow the first's fixture pattern verbatim — copy it; the comments above are the exact event sequences to enqueue and the exact assertions to make).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm run test:vitest -- run test/unit/server/coding-cli/opencode-activity-tracker.test.ts --config config/vitest/vitest.server.config.ts`
+Expected: FAIL — `session.error` events are silently dropped today (abort test sees a completion; child-idle test sees a false root completion).
+
+- [ ] **Step 3: Implement**
+
+In `server/coding-cli/opencode-activity-tracker.ts`:
+
+1. Add the schema (near the other event schemas, ~`:93`):
+
+```ts
+const SessionErrorEventSchema = z
+  .object({
+    type: z.literal('session.error'),
+    properties: z
+      .object({
+        sessionID: z.string().min(1),
+        error: z.object({ name: z.string().min(1) }).passthrough(),
+      })
+      .passthrough(),
+  })
+  .passthrough()
+```
+
+2. Add `SessionErrorEventSchema` to the `OpencodeEventSchema` discriminated union (`:104-109`) and `'session.error'` to `KNOWN_OPENCODE_EVENT_TYPES` (`:115-120`). (Both are required or `parseOpencodeEvent:187-189` drops it silently.)
+
+3. In `handleOpencodeEvent` (`:510-568`), before the generic status handling, add:
+
+```ts
+    if (event.type === 'session.error') {
+      const rawSessionId = event.properties.sessionID
+      const rootSessionId = await this.resolveRootForEvent(monitor, rawSessionId)
+      // Child or unresolved errors never gate the root's turn (a sub-agent
+      // abort must not silence the parent; conservative for unknown ids).
+      if (rootSessionId === undefined || rootSessionId !== rawSessionId) return
+      this.observe(monitor, {
+        kind: 'error',
+        cycleId,
+        streamId,
+        sessionId: rootSessionId,
+        errorName: event.properties.error.name,
+        at: this.now(),
+      })
+      return
+    }
+```
+
+4. Child-idle suppression — in the idle branch (`:539-549`), guard before observing:
+
+```ts
+      // Child sessions go idle mid-parent-turn (live trace: child idle 921ms
+      // before the parent, events-D.log). Remapping a CHILD idle onto the
+      // root falsely completes the root's turn — suppress it. The root's own
+      // idle (raw id == resolved root) passes through unchanged.
+      if (observedSessionId !== undefined && observedSessionId !== event.properties.sessionID) {
+        return
+      }
+```
+
+Busy/retry remapping (`:551-567`) stays exactly as-is (child busy keeps the root busy — matches the snapshot path's "busy beats idle" collapsing at `classifyKnownSnapshotStatuses:829-842`).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: same as Step 2. Expected: PASS — all 24 pre-existing tests plus the 4 new ones. If a pre-existing test pinned the old child-idle remap behavior, rewrite it with a `// SEMANTIC CHANGE (opencode-attention-bell): child idle is suppressed, not remapped` comment. (The explorer sweep found NO existing test emitting a child idle, so none is expected to break.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/coding-cli/opencode-activity-tracker.ts test/unit/server/coding-cli/opencode-activity-tracker.test.ts
+git commit -m "feat(opencode): session.error vocabulary, abort-silent episodes, child-idle suppression"
+```
+
+---
+
+### Task 3: Node tracker — permission pause lane
+
+**Files:**
+- Modify: `server/coding-cli/opencode-activity-tracker.ts`
+- Test: `test/unit/server/coding-cli/opencode-activity-tracker.test.ts`
+
+**Interfaces:**
+- Consumes: Task 2's vocabulary plumbing; codex's approval-pause pattern (`codex-activity-tracker.ts:359-409`: demote via `'changed'` FIRST, `'attention.boundary'` SECOND, newly-inserted-id dedupe).
+- Produces (relied on by Task 4 and by the already-wired emitter):
+  - Tracker emits `'attention.boundary'` → `{ terminalId: string; at: number }` (the `wireTrulyIdleEmitter` subscription at `truly-idle-emitter.ts:230` already forwards it — ZERO `server/index.ts` changes).
+  - `removeRecord(terminalId: string, opts?: { forceEmit?: boolean }): void`
+  - Private `pendingPermissions: Map<string, Set<string>>`; `hasPendingPermissions(terminalId: string): boolean` (private helper, read by Task 4).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the tracker test file, using the Task 2 fixture pattern and a codex-style multi-stream collector (attach BEFORE acting):
+
+```ts
+function collectOpencode(tracker: OpencodeActivityTracker) {
+  const collected = {
+    changes: [] as Array<{ upsert: unknown[]; remove: string[] }>,
+    boundaries: [] as Array<{ terminalId: string; at: number }>,
+    completions: [] as unknown[],
+  }
+  tracker.on('changed', (c) => collected.changes.push(c))
+  tracker.on('attention.boundary', (e) => collected.boundaries.push(e))
+  tracker.on('turn.complete', (e) => collected.completions.push(e))
+  return collected
+}
+
+describe('permission pause semantics (codex approval-pause mirror)', () => {
+  it('permission.asked on the owned busy session demotes then arms the boundary once', async () => {
+    // fixture: snapshot { 'ses-root': busy } -> knownBusy, record present
+    // enqueue: { type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-root', permission: 'bash', patterns: ['sleep 60'], metadata: {}, always: [] } }
+    // assert: exactly one 'changed' with remove ['term-1'] (demotion),
+    //         exactly one boundary { terminalId: 'term-1' },
+    //         and the change was emitted BEFORE the boundary
+    //         (record the arrival order in a combined log array).
+  })
+  it('duplicate permission.asked ids never re-arm', async () => {
+    // enqueue the same permission.asked twice; assert boundaries.length === 1
+  })
+  it('permission.replied resumes busy immediately (cancels within grace)', async () => {
+    // after the pause, enqueue { type: 'permission.replied', properties: { sessionID: 'ses-root', requestID: 'per-1', reply: 'once' } }
+    // assert a busy upsert with sessionId 'ses-root' is emitted
+  })
+  it('abort mid-pause force-emits the removal and mints nothing', async () => {
+    // pause active -> enqueue session.error MessageAbortedError + double idle
+    // assert: completions === [], boundaries.length === 1 (no re-arm),
+    //         and a SECOND 'changed' remove for term-1 was emitted (the force-emit
+    //         that cancels the armed grace window at the emitter)
+  })
+  it('failure mid-pause retires the pause without a second bell', async () => {
+    // pause active -> enqueue session.error UnknownError + idle edges
+    // assert: completions === [] (turnComplete swallowed), boundaries.length === 1,
+    //         and NO second 'changed' remove was emitted (grace left to fire once)
+  })
+  it('permission.asked for a child or foreign session is ignored', async () => {
+    // enqueue permission.asked with sessionID 'ses-child' (registered child) and 'ses-other'
+    // assert boundaries === [] beyond the owned-session case
+  })
+})
+```
+
+Write all six tests in full following the comments (they are exact sequences/assertions, same fixture as Task 2).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm run test:vitest -- run test/unit/server/coding-cli/opencode-activity-tracker.test.ts --config config/vitest/vitest.server.config.ts`
+Expected: FAIL — `permission.*` events are dropped (no boundaries emitted).
+
+- [ ] **Step 3: Implement**
+
+In `server/coding-cli/opencode-activity-tracker.ts`:
+
+1. Schemas + vocabulary:
+
+```ts
+const PermissionAskedEventSchema = z
+  .object({
+    type: z.literal('permission.asked'),
+    properties: z.object({ id: z.string().min(1), sessionID: z.string().min(1) }).passthrough(),
+  })
+  .passthrough()
+
+const PermissionRepliedEventSchema = z
+  .object({
+    type: z.literal('permission.replied'),
+    properties: z.object({ sessionID: z.string().min(1), requestID: z.string().min(1) }).passthrough(),
+  })
+  .passthrough()
+```
+
+Add both to `OpencodeEventSchema` and `'permission.asked'`/`'permission.replied'` to `KNOWN_OPENCODE_EVENT_TYPES`.
+
+2. Tracker field + helper:
+
+```ts
+  private readonly pendingPermissions = new Map<string, Set<string>>()
+
+  private hasPendingPermissions(terminalId: string): boolean {
+    return (this.pendingPermissions.get(terminalId)?.size ?? 0) > 0
+  }
+```
+
+Clear the terminal's entry in `untrackTerminal` and in `trackTerminal`'s early-return reset block.
+
+3. In `handleOpencodeEvent`, before the status handling:
+
+```ts
+    if (event.type === 'permission.asked') {
+      const ownership = monitor.ownership
+      // Owned root session only: candidate/ambiguous ownership is conservative
+      // (no bells), and a CHILD's permission must not pause the root.
+      if (ownership.kind !== 'knownBusy' || ownership.sessionId !== event.properties.sessionID) return
+      const pending = this.pendingPermissions.get(monitor.terminalId) ?? new Set<string>()
+      const newlyInserted = !pending.has(event.properties.id)
+      pending.add(event.properties.id)
+      this.pendingPermissions.set(monitor.terminalId, pending)
+      if (!newlyInserted) return // duplicate asked never re-arms
+      const at = this.now()
+      // Demote FIRST (record removal is opencode's not-busy on the wire),
+      // boundary SECOND — the gate must see not-busy before it arms
+      // (codex ordering, codex-activity-tracker.ts:377-382).
+      this.removeRecord(monitor.terminalId)
+      this.emit('attention.boundary', { terminalId: monitor.terminalId, at })
+      return
+    }
+    if (event.type === 'permission.replied') {
+      const pending = this.pendingPermissions.get(monitor.terminalId)
+      if (!pending?.delete(event.properties.requestID)) return
+      if (pending.size > 0) return
+      this.pendingPermissions.delete(monitor.terminalId)
+      const ownership = monitor.ownership
+      if (ownership.kind !== 'knownBusy') return
+      // Resume busy immediately (codex resume_busy_after_approval analog):
+      // the reply proves a human is present; busy re-entry cancels the armed
+      // grace window without waiting ~1s for the next session.status{busy}.
+      this.upsertRecord({
+        terminalId: monitor.terminalId,
+        sessionId: ownership.sessionId,
+        phase: 'busy',
+        updatedAt: this.now(),
+        lastObservedAt: this.now(),
+      })
+      return
+    }
+```
+
+(Match `upsertRecord`'s actual record shape at `:704-724` — it requires `lastObservedAt`.)
+
+4. `removeRecord` force flag (`:726-732`):
+
+```ts
+  private removeRecord(terminalId: string, opts?: { forceEmit?: boolean }): void {
+    const existed = this.records.delete(terminalId)
+    if (!existed && !opts?.forceEmit) return
+    this.emit('changed', { upsert: [], remove: [terminalId] } satisfies OpencodeActivityChange)
+  }
+```
+
+5. Mid-pause coordination in `applyActions` (`:615-652`). Refactor the existing `switch` body into a private `applyAction(terminalId, action)` and wrap:
+
+```ts
+  private applyActions(terminalId: string, actions: OpencodeOwnershipAction[]): void {
+    const pauseActive = this.hasPendingPermissions(terminalId)
+    const idleEdge = actions.some((a) => a.kind === 'activityRemove')
+    if (pauseActive && idleEdge) {
+      // Mid-pause turn end: the pause is THE attention episode for this turn.
+      // Retire it and never mint a second bell (codex PR #597 mid-pause
+      // silent-claim hardening, mirrored).
+      this.pendingPermissions.delete(terminalId)
+      const hasCompletion = actions.some((a) => a.kind === 'turnComplete')
+      if (!hasCompletion) {
+        // Abort mid-pause: human at keyboard — force-emit the removal so the
+        // emitter cancels any still-armed grace window (the record itself was
+        // already removed at pause entry).
+        this.removeRecord(terminalId, { forceEmit: true })
+      }
+      for (const action of actions) {
+        if (action.kind === 'turnComplete') continue // swallowed: no frame, no ledger entry
+        if (action.kind === 'activityRemove') continue // handled above / already removed
+        this.applyAction(terminalId, action)
+      }
+      return
+    }
+    if (pauseActive && actions.some((a) => a.kind === 'activityUpsert')) {
+      this.pendingPermissions.delete(terminalId) // busy resumed out-of-band: pause over
+    }
+    for (const action of actions) this.applyAction(terminalId, action)
+  }
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: same command. Expected: PASS (all tracker tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/coding-cli/opencode-activity-tracker.ts test/unit/server/coding-cli/opencode-activity-tracker.test.ts
+git commit -m "feat(opencode): permission-pause attention boundary with mid-pause hardening"
+```
+
+---
+
+### Task 4: Node death bells — spontaneous-exit discriminator
+
+**Files:**
+- Modify: `server/coding-cli/opencode-activity-tracker.ts`, `server/coding-cli/opencode-activity-wiring.ts`
+- Test: `test/unit/server/coding-cli/opencode-activity-tracker.test.ts`, `test/unit/server/coding-cli/opencode-activity-wiring.test.ts`, `test/unit/server/coding-cli/truly-idle-emitter.test.ts`
+
+**Interfaces:**
+- Consumes: registry exit discriminator (`terminal-registry.ts:1542` emits `spontaneous: !requestedClose`; `kill()` emits `spontaneous: false` at `:4129`); emitter ring condition (`truly-idle-emitter.ts:132`: `spontaneous.has(id) && (engaged || approvalPending.has(id))` where `engaged = (busy && !pending) || graceTimer !== undefined`).
+- Produces:
+  - `OpencodeActivityChange` gains `spontaneousExitRemovals?: string[]` and `approvalPendingRemovals?: string[]` (internal-only; `ws-handler.broadcastOpencodeActivityUpdated:3872-3885` re-validates through the non-strict zod schema, so the extra fields never reach the wire).
+  - `untrackTerminal(input: { terminalId: string; spontaneous?: boolean }): void` — internal callers (`trackTerminal:283`, `dispose:317`) stay flag-less.
+
+- [ ] **Step 1: Write the failing tracker tests**
+
+Append to the tracker test file (Task 2 fixture; collector arrays typed `Array<{ upsert: unknown[]; remove: string[]; spontaneousExitRemovals?: string[]; approvalPendingRemovals?: string[] }>`):
+
+```ts
+describe('death-bell markers on spontaneous exit', () => {
+  it('spontaneous exit while knownBusy marks the removal', async () => {
+    // knownBusy via snapshot; then tracker.untrackTerminal({ terminalId: 'term-1', spontaneous: true })
+    // assert last change === { upsert: [], remove: ['term-1'], spontaneousExitRemovals: ['term-1'] }
+  })
+  it('spontaneous exit during a permission pause marks approvalPendingRemovals and emits despite the absent record', async () => {
+    // knownBusy -> permission.asked (record removed) -> untrackTerminal spontaneous
+    // assert change === { upsert: [], remove: ['term-1'], spontaneousExitRemovals: ['term-1'], approvalPendingRemovals: ['term-1'] }
+  })
+  it('spontaneous exit while candidate or ambiguous carries NO marker', async () => {
+    // drive ownership to candidate (busy for an unknown session with no resume id);
+    // untrackTerminal spontaneous; assert the change has no spontaneousExitRemovals
+  })
+  it('freshell-initiated untrack (no flag) behaves exactly as before', async () => {
+    // untrackTerminal({ terminalId: 'term-1' }) after knownBusy
+    // assert plain { upsert: [], remove: ['term-1'] } with no marker fields
+  })
+})
+```
+
+Write the four tests in full per the comments.
+
+- [ ] **Step 2: Write the failing emitter episode test**
+
+Append to `test/unit/server/coding-cli/truly-idle-emitter.test.ts` (its `beforeEach` uses fake timers + `emitter.on('idle', ...)` collectors — follow `:14-25`):
+
+```ts
+  it('opencode death while grace is armed rings immediately (post-turn window)', () => {
+    // opencode shape: turn end = remove followed by turnComplete, then death
+    emitter.noteActivityChanged({ upsert: [{ terminalId: 't1', phase: 'busy' }] })
+    emitter.noteActivityChanged({ remove: ['t1'] })
+    emitter.noteTurnComplete({ terminalId: 't1', at: Date.now() }) // arms grace
+    emitter.noteActivityChanged({ remove: ['t1'], spontaneousExitRemovals: ['t1'] })
+    expect(events).toEqual([{ terminalId: 't1', at: Date.now(), reason: 'grace' }])
+    vi.advanceTimersByTime(TERMINAL_IDLE_GRACE_MS + 1)
+    expect(events).toHaveLength(1) // the armed window was cancelled by the removal — no double ring
+  })
+```
+
+(The busy/approval-pending death cases are already covered generically at `:126-179` and `:329-351`; this pins the opencode-specific remove-then-boundary shape.)
+
+- [ ] **Step 3: Run to verify failure**
+
+Run both files:
+`npm run test:vitest -- run test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/unit/server/coding-cli/truly-idle-emitter.test.ts --config config/vitest/vitest.server.config.ts`
+Expected: tracker tests FAIL (no marker fields; TypeScript may reject `spontaneous` on `untrackTerminal`); the emitter test may already PASS (the emitter is generic) — if it passes, note that in the commit message; it is a pin, not a change driver.
+
+- [ ] **Step 4: Implement**
+
+1. `OpencodeActivityChange` (`opencode-activity-tracker.ts:37-40`):
+
+```ts
+export type OpencodeActivityChange = {
+  upsert: OpencodeActivityRecord[]
+  remove: string[]
+  /**
+   * Terminals whose PTY exit was NOT freshell-initiated (registry
+   * `spontaneous: !requestedClose`). Internal-only: the ws-handler's zod
+   * re-validation strips it from the wire. Death-bell input for the
+   * truly-idle emitter.
+   */
+  spontaneousExitRemovals?: string[]
+  /** Terminals with a pending permission pause at exit time (rings even though the record is absent). */
+  approvalPendingRemovals?: string[]
+}
+```
+
+2. `untrackTerminal` (`:296-313`) — read engagement BEFORE teardown (audit-A17 ordering, same as Rust `activity.rs:787-819`):
+
+```ts
+  untrackTerminal(input: { terminalId: string; spontaneous?: boolean }): void {
+    const monitor = this.monitors.get(input.terminalId)
+    // Engagement inputs are captured BEFORE teardown destroys them.
+    // candidate/ambiguous ownership never death-rings (D4: that noise is why
+    // opencode death bells were excluded before).
+    const ownershipKind = monitor?.ownership.kind
+    const deathBellEligible =
+      input.spontaneous === true && ownershipKind !== 'candidate' && ownershipKind !== 'ambiguous'
+    const approvalPending = this.hasPendingPermissions(input.terminalId)
+    this.pendingPermissions.delete(input.terminalId)
+    // ... existing teardown body unchanged (dispose monitor, abort controller,
+    //     clear reconnect timer, delete childSessionIds/sessionRootsByTerminal) ...
+    if (deathBellEligible) {
+      // Emit UNCONDITIONALLY: the record is usually already gone (turn ended
+      // or pause demoted), and the emitter needs the marked removal to reach
+      // its armed-grace / approval-pending checks.
+      this.records.delete(input.terminalId)
+      this.emit('changed', {
+        upsert: [],
+        remove: [input.terminalId],
+        spontaneousExitRemovals: [input.terminalId],
+        ...(approvalPending ? { approvalPendingRemovals: [input.terminalId] } : {}),
+      } satisfies OpencodeActivityChange)
+    } else {
+      this.removeRecord(input.terminalId)
+    }
+  }
+```
+
+3. Wiring (`opencode-activity-wiring.ts:86-89`):
+
+```ts
+  const onExit = (event: { terminalId?: string; spontaneous?: boolean }) => {
+    if (!event.terminalId) return
+    tracker.untrackTerminal({ terminalId: event.terminalId, spontaneous: event.spontaneous === true })
+  }
+```
+
+Add a wiring test in `opencode-activity-wiring.test.ts` (reuse `makeRegistry:29-38`): emit `registry.emit('terminal.exit', { terminalId, spontaneous: true })` and assert the tracker's `'changed'` payload carries `spontaneousExitRemovals` (spy via a collector on the returned `tracker`).
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: the Step 3 command plus `npm run test:vitest -- run test/unit/server/coding-cli/opencode-activity-wiring.test.ts --config config/vitest/vitest.server.config.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/coding-cli/opencode-activity-tracker.ts server/coding-cli/opencode-activity-wiring.ts test/unit/server/coding-cli/
+git commit -m "feat(opencode): death bells on spontaneous exit, ownership-scoped engagement"
+```
+
+---
+
+### Task 5: Node pins — full live-trace child episode + resolver wiring regression pin
+
+**Files:**
+- Test: `test/unit/server/coding-cli/opencode-activity-tracker.test.ts`
+- Create test: `test/unit/server/coding-cli/opencode-activity-integration.test.ts`
+
+**Interfaces:**
+- Consumes: `createOpencodeActivityIntegration` (`server/coding-cli/opencode-activity-integration.ts:16-22`), `OpencodeRootResolution` (`providers/opencode.ts:32-37`).
+- Produces: regression pins only — no production code changes.
+
+- [ ] **Step 1: Write the full live-trace child episode test (events-D.log, exact ordering)**
+
+Append to the tracker test file — this is the codex sub-agent false-green analog, pinned end-to-end:
+
+```ts
+  it('full events-D.log episode: child busy/idle mid-parent-turn yields exactly one parent completion and no early removal', async () => {
+    // fixture as in Task 2; snapshot { 'ses-parent': { type: 'busy' } }
+    // enqueue, in live order (server-derived timings in comments):
+    // 21:30:34.304 session.created child (info.parentID = 'ses-parent')
+    // 21:30:34.344 session.status child busy
+    // 21:30:36.089 session.status child idle
+    // 21:30:36.089 session.idle child            <- must NOT remove the record or complete
+    // 21:30:37.010 session.status parent idle    <- the real edge
+    // 21:30:37.010 session.idle parent           <- deduped
+    // assertions:
+    //   completions === [ one entry with sessionId 'ses-parent' ]
+    //   changes: no remove before the parent idle; exactly one remove total
+  })
+```
+
+Write it in full.
+
+- [ ] **Step 2: Write the resolver wiring pin test**
+
+Create `test/unit/server/coding-cli/opencode-activity-integration.test.ts`:
+
+```ts
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createOpencodeActivityIntegration } from '../../../../server/coding-cli/opencode-activity-integration.js'
+
+function makeRegistry() {
+  const registry = new EventEmitter() as any
+  registry.list = vi.fn(() => [])
+  registry.get = vi.fn(() => undefined)
+  registry.bindSession = vi.fn(() => ({ ok: true }))
+  registry.rebindSession = vi.fn(() => ({ ok: true }))
+  return registry
+}
+
+describe('opencode activity integration (resolver regression pin, docs/plans/2026-05-09-fix-opencode-ambiguous-ownership.md)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('injects the provider resolver — construction survives production mode (no identity-resolver fallback)', () => {
+    // Outside tests the tracker constructor THROWS unless a real resolver is
+    // injected (opencode-activity-tracker.ts:242-246). If index-style wiring
+    // ever loses the provider resolver again, this pin goes red.
+    vi.stubEnv('NODE_ENV', 'production')
+    const resolveOpencodeSessionRoots = vi.fn(async (ids: readonly string[]) => ({
+      rootsBySessionId: new Map(ids.map((id) => [id, id])),
+      unresolvedSessionIds: new Set<string>(),
+    }))
+    const integration = createOpencodeActivityIntegration({
+      registry: makeRegistry(),
+      opencodeProvider: { resolveOpencodeSessionRoots },
+    })
+    expect(integration.tracker).toBeDefined()
+    integration.dispose()
+  })
+})
+```
+
+- [ ] **Step 3: Run to verify (RED where applicable)**
+
+Run: `npm run test:vitest -- run test/unit/server/coding-cli/opencode-activity-tracker.test.ts test/unit/server/coding-cli/opencode-activity-integration.test.ts --config config/vitest/vitest.server.config.ts`
+Expected: the child episode test PASSES (Task 2 implemented suppression — this is a pin); the integration test PASSES (pin). If either FAILS, there is a real bug — fix it before proceeding (do not weaken the pin).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/unit/server/coding-cli/
+git commit -m "test(opencode): pin live-trace child episode and production resolver wiring"
+```
+
+---
+
+### Task 6: Rust tracker core — `crates/freshell-activity/src/opencode.rs`
+
+**Files:**
+- Create: `crates/freshell-activity/src/opencode.rs`
+- Modify: `crates/freshell-activity/src/lib.rs` (add `pub mod opencode;` to the module list at `:27-32`)
+
+**Interfaces:**
+- Consumes: `TrackerEffect<R>` (`lib.rs:39-56`), `TurnCompletionLedger` (`ledger.rs`), `freshell_protocol::{OpencodeActivityRecord, OpencodePhase}` (`common.rs:376-384`, `:328-332` — `Busy` is the ONLY phase; not-busy == record absence), `TurnCompletionSnapshot`.
+- Produces (used by Tasks 7–10):
+
+```rust
+pub const OPENCODE_BUSY_DEADMAN_MS: i64 = 120_000; // mirrors Node OPENCODE_BUSY_DEADMAN_MS
+
+pub type OpencodeEffect = TrackerEffect<OpencodeActivityRecord>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpencodeStatus { Busy, Retry, Idle } // retry is busy everywhere (D6)
+
+pub struct OpencodeActivityTracker { /* states: HashMap<String, TerminalOpencode>, ledger, busy_deadman_ms */ }
+
+impl OpencodeActivityTracker {
+    pub fn new() -> Self;
+    pub fn set_busy_deadman_ms(&mut self, ms: i64);
+    pub fn list(&self) -> Vec<OpencodeActivityRecord>;
+    pub fn list_latest_completions(&self) -> Vec<freshell_protocol::TurnCompletionSnapshot>;
+    pub fn track_terminal(&mut self, terminal_id: &str, session_id: Option<&str>, at: i64) -> Vec<OpencodeEffect>;
+    pub fn bind_session(&mut self, terminal_id: &str, session_id: &str, at: i64) -> Vec<OpencodeEffect>;
+    pub fn note_session_created(&mut self, terminal_id: &str, session_id: &str, parent_id: Option<&str>, at: i64) -> Vec<OpencodeEffect>;
+    pub fn note_status(&mut self, terminal_id: &str, session_id: &str, status: OpencodeStatus, cycle: u64, stream: u64, at: i64) -> Vec<OpencodeEffect>;
+    pub fn note_session_idle(&mut self, terminal_id: &str, session_id: &str, cycle: u64, stream: u64, at: i64) -> Vec<OpencodeEffect>;
+    pub fn note_snapshot(&mut self, terminal_id: &str, statuses: &[(String, OpencodeStatus)], cycle: u64, stream: u64, at: i64) -> Vec<OpencodeEffect>;
+    pub fn note_exit(&mut self, terminal_id: &str) -> Vec<OpencodeEffect>;
+    pub fn expire(&mut self, at: i64) -> Vec<OpencodeEffect>;
+    pub fn next_deadline(&self) -> Option<i64>;
+}
+```
+
+**Semantics to port (this is the Node reducer, `opencode-ownership-reducer.ts`, plus D1–D6; the branch tables below are normative):**
+
+Ownership enum (private):
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+enum Ownership {
+    Quiet { known_session_id: Option<String> },
+    Candidate { session_id: String, previous_known: Option<String>, cycle: u64, stream: u64, turn_aborted: bool },
+    KnownBusy { session_id: String, cycle: u64, stream: u64, turn_aborted: bool },
+    AwaitingAssociation { session_id: String, previous_known: Option<String>, completed_at: i64, aborted: bool },
+    Ambiguous { known_session_id: Option<String>, blocked: Vec<String> },
+}
+```
+
+Per-terminal state (private):
+
+```rust
+#[derive(Debug)]
+struct TerminalOpencode {
+    terminal_id: String,
+    ownership: Ownership,
+    /// session id -> root session id (built from session.created parentID; self-mapped roots).
+    session_roots: std::collections::HashMap<String, String>,
+    /// pending permission ids (Task 7).
+    pending_permissions: std::collections::HashSet<String>,
+    /// present == busy on the wire (OpencodePhase::Busy is the only phase).
+    record: Option<OpencodeActivityRecord>,
+    last_observed_at: i64,
+}
+```
+
+Record helpers (compare like codex `has_public_change:180-185` — phase + session only, so repeated busy events don't spam frames; a deliberate, documented divergence from Node's timestamp-sensitive dedupe):
+
+```rust
+fn set_busy_record(state: &mut TerminalOpencode, session_id: Option<String>, at: i64) -> Vec<OpencodeEffect> {
+    let next = OpencodeActivityRecord {
+        terminal_id: state.terminal_id.clone(),
+        phase: freshell_protocol::OpencodePhase::Busy,
+        updated_at: at,
+        session_id,
+    };
+    let changed = match &state.record {
+        Some(prev) => prev.session_id != next.session_id,
+        None => true,
+    };
+    state.record = Some(next.clone());
+    if changed {
+        vec![TrackerEffect::Changed { upsert: vec![next], remove: vec![] }]
+    } else {
+        Vec::new()
+    }
+}
+
+fn clear_record(state: &mut TerminalOpencode, force: bool) -> Vec<OpencodeEffect> {
+    if state.record.take().is_none() && !force {
+        return Vec::new();
+    }
+    vec![TrackerEffect::Changed { upsert: vec![], remove: vec![state.terminal_id.clone()] }]
+}
+```
+
+Root resolution: `fn resolve_root<'a>(state: &'a TerminalOpencode, session_id: &'a str) -> &'a str` — walk `session_roots` with a seen-set cycle guard; unknown id resolves to itself.
+
+`note_status`/`note_session_idle` routing: resolve the root; **child idle (root != raw) is suppressed (D5)**; child busy/retry remaps to the root; then dispatch to the idle/busy reducers below. Every `note_*` updates `last_observed_at = at`.
+
+**Idle-edge reducer** (`session.idle` or `session.status{idle}`), with cycle/stream guards exactly like Node `sameSessionStream`:
+
+| Ownership | Guard | Next state | Effects (in order) |
+|---|---|---|---|
+| `KnownBusy{session==s, cycle==c, stream==st, turn_aborted}` | id+cycle+stream match | `Quiet{known: Some(s)}` | `clear_record(false)`; then if `!turn_aborted`: `TurnComplete{terminal_id, session_id: Some(s), at, completion_seq: ledger.record_turn_completion(terminal_id, at)}` (Task 7 adds the mid-pause override here) |
+| `Candidate{...}` matching | same | `AwaitingAssociation{session_id, previous_known, completed_at: at, aborted: turn_aborted}` | `clear_record(false)` (completion deferred to `bind_session`) |
+| `Ambiguous{blocked}` | session in `blocked` | drop it; empty → `Quiet{known}` | empty → `clear_record(false)`; non-empty → `set_busy_record(None, at)` |
+| `Quiet` / `AwaitingAssociation` | — | unchanged | none (this IS the double-idle dedupe, D2) |
+
+**Busy reducer** (busy or retry):
+
+| Ownership | Next state | Effects |
+|---|---|---|
+| `Quiet{known: Some(k)}`, s == k | `KnownBusy{k, cycle, stream, turn_aborted: false}` | `set_busy_record(Some(k), at)` |
+| `Quiet{known: Some(k)}`, s != k | `Candidate{s, previous_known: Some(k), ..., false}` | `set_busy_record(Some(s), at)` |
+| `Quiet{known: None}` | `Candidate{s, None, ..., false}` | `set_busy_record(Some(s), at)` |
+| `Candidate` same s | refresh cycle/stream, `turn_aborted: false` | `set_busy_record(Some(s), at)` |
+| `Candidate` different s | `Ambiguous{known: previous_known, blocked: sorted unique [old, s]}` | `set_busy_record(None, at)` |
+| `KnownBusy` same s | refresh cycle/stream, `turn_aborted: false` (Task 7: also clears `pending_permissions` — busy resume) | `set_busy_record(Some(s), at)` |
+| `KnownBusy` different s | `Ambiguous{known: Some(own), blocked: [own, s]}` | `set_busy_record(None, at)` |
+| `Ambiguous` | add s to `blocked` if new | `set_busy_record(None, at)` |
+| `AwaitingAssociation` | unchanged | none (Node `:205` drops it) |
+
+**Snapshot reducer** (`note_snapshot`): collapse the status list onto roots (busy child wins over idle root, mirroring `classifyKnownSnapshotStatuses:829-842`), producing sorted unique `busy_roots: Vec<String>` (busy|retry only — absence == idle per the spike, and a literal `{type:"idle"}` entry is parsed and treated as absent). Then the Node `reduceSnapshot` branch table:
+
+| Ownership | busy_roots | Next state | Effects |
+|---|---|---|---|
+| `Ambiguous` | empty | `Quiet{known}` | `clear_record(false)` |
+| `Ambiguous` | single == known | `KnownBusy{known, cycle, stream, false}` | `set_busy_record(Some(known), at)` |
+| `Ambiguous{known: None}` | single | `Candidate{s, None, ..., false}` | none (deliberately silent, Node `:296-307`) |
+| `Ambiguous` | otherwise | recompute `blocked` (recompute, not union) | none |
+| `KnownBusy` | empty | `Quiet{known: Some(own)}` | `clear_record(false)` + completion gated on `turn_aborted` (same as the idle-edge row) |
+| `KnownBusy` | single == own | refresh cycle/stream | `set_busy_record(Some(own), at)` |
+| `KnownBusy` | otherwise | `Ambiguous{Some(own), [own ∪ busy_roots]}` | `set_busy_record(None, at)` |
+| `Candidate` | empty | `AwaitingAssociation{..., completed_at: at, aborted: turn_aborted}` | `clear_record(false)` |
+| `Candidate` | single == own | refresh | `set_busy_record(Some(own), at)` |
+| `Candidate` | otherwise | `Ambiguous` | `set_busy_record(None, at)` |
+| `AwaitingAssociation` | any | unchanged | none |
+| `Quiet` | empty | unchanged | `clear_record(false)` |
+| `Quiet{known: Some(k)}` | contains k, single | `KnownBusy{k, ...}` | `set_busy_record(Some(k), at)` |
+| `Quiet{known: Some(k)}` | multiple | `Ambiguous{Some(k), busy_roots}` | `set_busy_record(None, at)` |
+| `Quiet{known: None}` | exactly one | `Candidate{s, None, ...}` | `set_busy_record(Some(s), at)` |
+| `Quiet{known: None}` | multiple | `Ambiguous{None, busy_roots}` | `set_busy_record(None, at)` |
+
+**`bind_session`** (association/rebind identity arriving from the SQLite locator or the TUI rebind plugin — Task 10 wires the producers):
+- `AwaitingAssociation{session_id == bound, aborted: false}` → `Quiet{known: Some(bound)}` + `TurnComplete{..., at: completed_at, completion_seq: ledger...}` (deferred completion, Node `confirmOpencodeAssociation:440-458` — note `at` is the STORED `completed_at`).
+- `AwaitingAssociation{session_id == bound, aborted: true}` → `Quiet{known: Some(bound)}`, no effects.
+- `AwaitingAssociation{different}` → `Quiet{known: previous_known}`, no effects (reject analog).
+- `Ambiguous` → update `known_session_id = Some(bound)` in place (Node's session.created adoption assist; the next snapshot resolves it).
+- `Quiet`/`Candidate`/`KnownBusy` → set/replace the known id: `Quiet` → `Quiet{known: Some(bound)}`; `Candidate{session==bound}` → `KnownBusy` (preserve cycle/stream/turn_aborted) + `set_busy_record(Some(bound), at)`; `Candidate{different}` → keep candidate, set `previous_known = Some(bound)`; `KnownBusy` → keep (identity already flowing).
+- Also self-map `session_roots.insert(bound.clone(), bound.clone())`.
+
+**`note_session_created`**: if `parent_id` is `Some(p)`: `let root = resolve_root(state, p).to_string()`; insert `p → root` (self-map if unknown) and `session_id → root`. If ownership is `Ambiguous{known: None, ..}` → set `known_session_id = Some(root)` (Node `:520-529` analog; the next snapshot/status resolves). If `parent_id` is `None`: self-map `session_id → session_id`. No effects.
+
+**`track_terminal`**: create-or-reset the state: `ownership = Quiet{known: session_id.map(...)}`, clear maps/sets, `last_observed_at = at`; if a stale record existed → `clear_record(false)` effect. **`note_exit`**: remove the whole state; if a record was present → `Changed{remove}` effect. **`expire(at)`**: any state with `record.is_some() && at - last_observed_at > busy_deadman_ms` → drop the record (`clear_record(false)`, NO completion — deadman swallow is silent, residual (e)). **`next_deadline`**: min over record-holding states of `last_observed_at + busy_deadman_ms`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create the file with the types above stubbed (`todo!()` bodies are fine for RED) and an in-file `#[cfg(test)] mod tests` (codex style: helpers `fn completions(effects: &[OpencodeEffect]) -> Vec<...>` etc.). Tests to write (all pure, no tokio):
+
+```rust
+#[test] fn completed_turn_emits_remove_then_turn_complete() { /* track(Some("ses-r")) -> note_status busy -> note_session_idle; assert effects order: Changed{upsert busy}, then on idle: Changed{remove} BEFORE TurnComplete (D7 ordering) */ }
+#[test] fn double_session_idle_is_deduped() { /* second note_session_idle returns no effects */ }
+#[test] fn session_status_idle_then_session_idle_yields_one_completion() { /* the spike's 7ms twin */ }
+#[test] fn retry_status_counts_as_busy() { /* note_status Retry from quiet(known) -> KnownBusy record upsert */ }
+#[test] fn child_idle_is_suppressed_and_child_busy_remaps_to_root() { /* note_session_created(child, parent) -> child busy refreshes root record (session_id stays root) -> child idle: NO effects, record survives -> parent idle: one completion */ }
+#[test] fn candidate_completion_defers_to_bind_session() { /* no resume id: busy(ses-x) -> idle -> no TurnComplete; bind_session("ses-x") -> TurnComplete with at == the idle timestamp */ }
+#[test] fn ambiguous_is_conservative_no_completions() { /* two different busy sessions -> ambiguous; all idles -> no TurnComplete ever; record ends removed */ }
+#[test] fn snapshot_empty_completes_a_known_busy_turn() { /* snapshot path B */ }
+#[test] fn stale_cycle_idle_is_ignored() { /* idle with wrong cycle/stream leaves KnownBusy intact */ }
+#[test] fn deadman_expiry_removes_silently() { /* set_busy_deadman_ms(1000); busy at t=0; expire(t=2000) -> Changed{remove}, no TurnComplete; next_deadline math */ }
+```
+
+Write each in full (they are direct method-call sequences with `assert_eq!` on effect vectors).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /home/dan/code/freshell/.worktrees/opencode-attention-bell && cargo test -p freshell-activity opencode`
+Expected: FAIL (todo! panics / compile errors count as RED).
+
+- [ ] **Step 3: Implement the tracker per the tables above**
+
+Write the full implementation. Keep it a pure, timer-free state machine (no IO, no tokio) — the hub owns time and transport. Doc-comment the module header with the policy line and "protocol facts derive from opencode 1.18.11 (live spike /tmp/opencode-spike/)".
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p freshell-activity opencode` — PASS. Then `cargo test -p freshell-activity` — all existing tracker tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/freshell-activity/src/opencode.rs crates/freshell-activity/src/lib.rs
+git commit -m "feat(activity): pure opencode ownership tracker (Node reducer port)"
+```
+
+---
+
+### Task 7: Rust tracker gates — abort, error, permission pause, death predicates
+
+**Files:**
+- Modify: `crates/freshell-activity/src/opencode.rs`
+
+**Interfaces:**
+- Consumes: Task 6's tracker; codex approval-lane semantics (`codex.rs:762-843`) as the pattern.
+- Produces (used by Tasks 8–9):
+
+```rust
+impl OpencodeActivityTracker {
+    pub fn note_error(&mut self, terminal_id: &str, session_id: &str, error_name: &str, cycle: u64, stream: u64, at: i64) -> Vec<OpencodeEffect>;
+    pub fn note_permission_asked(&mut self, terminal_id: &str, session_id: &str, permission_id: &str, at: i64) -> Vec<OpencodeEffect>;
+    pub fn note_permission_replied(&mut self, terminal_id: &str, permission_id: &str, at: i64) -> Vec<OpencodeEffect>;
+    pub fn has_pending_permissions(&self, terminal_id: &str) -> bool;
+    /// candidate/ambiguous ownership never death-rings (D4).
+    pub fn blocks_death_bell(&self, terminal_id: &str) -> bool;
+}
+```
+
+**Semantics:**
+- `note_error`: only when `session_id` resolves to itself (raw == root — child errors ignored, D5) AND `error_name == "MessageAbortedError"` AND ownership is `KnownBusy`/`Candidate` with matching id+cycle+stream → set `turn_aborted = true`. No effects, ever. All other names/states: no-op (trailing-error rule).
+- `note_permission_asked`: ownership must be `KnownBusy` with `session_id == owned` (raw equality — child/foreign ignored). `let newly_inserted = state.pending_permissions.insert(permission_id.to_string());` — only newly-inserted arms. Effects in order: `clear_record(false)` (demote), then `TrackerEffect::AttentionBoundary { terminal_id, at }`.
+- `note_permission_replied`: remove the id (unknown id → no-op). When the set EMPTIES and ownership is `KnownBusy{session}` → `set_busy_record(Some(session), at)` (immediate resume; busy cancels the armed gate window via `note_phase(Busy)` in the frame mapper).
+- Mid-pause hardening — extend the idle-edge completion row (Task 6, both idle and snapshot-empty paths): before minting, check `let pause_was_active = !state.pending_permissions.is_empty(); state.pending_permissions.clear();` If `pause_was_active`: NEVER mint `TurnComplete` (the pause is the episode's bell); if `turn_aborted` → `clear_record(true)` (force-emit remove → `note_exit` at the gate cancels the armed window → total silence); else → no effects (leave the armed window to fire once, or stay silent if it already rang).
+- Busy re-entry (`KnownBusy` same-session refresh) clears `pending_permissions` (out-of-band resume).
+- `note_exit` clears `pending_permissions` with the state (the hub reads `has_pending_permissions` BEFORE calling `note_exit` — same audit-A17 ordering as codex).
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test] fn abort_then_idle_clears_silently() { /* busy -> note_error(MessageAbortedError) -> idle: Changed{remove} only, no TurnComplete; second idle: nothing */ }
+#[test] fn failed_turn_rings_and_trailing_error_is_noop() { /* busy -> note_error(UnknownError) -> idle: TurnComplete present; note_error after idle: no effects, ownership stays Quiet */ }
+#[test] fn child_abort_does_not_gate_the_root() { /* child registered; note_error(child, MessageAborted); parent idle still completes */ }
+#[test] fn permission_asked_demotes_then_arms_once() { /* busy -> note_permission_asked: [Changed{remove}, AttentionBoundary] in that order; duplicate id: no effects */ }
+#[test] fn permission_replied_resumes_busy() { /* pause -> note_permission_replied: Changed{upsert busy with owned session} */ }
+#[test] fn abort_mid_pause_force_emits_the_cancel() { /* pause -> note_error(abort) -> idle: Changed{remove} EMITTED despite absent record, no TurnComplete, no boundary */ }
+#[test] fn completion_mid_pause_mints_nothing() { /* pause -> idle (no error): NO effects at all */ }
+#[test] fn death_predicates() { /* blocks_death_bell: false for KnownBusy/Quiet, true for Candidate and Ambiguous; has_pending_permissions true during pause, false after replied/exit */ }
+```
+
+Write each in full.
+
+- [ ] **Step 2: Run RED**
+
+Run: `cargo test -p freshell-activity opencode` — FAIL.
+
+- [ ] **Step 3: Implement per the semantics above. Step 4: Run GREEN** (`cargo test -p freshell-activity`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/freshell-activity/src/opencode.rs
+git commit -m "feat(activity): opencode abort/permission gates and death-bell predicates"
+```
+
+---
+
+### Task 8: Rust hub wiring — mode arms, frames, death bell, activity.list
+
+**Files:**
+- Modify: `crates/freshell-ws/src/activity.rs`
+- Modify: `crates/freshell-ws/src/terminal.rs` (`:929-946` stub only)
+
+**Interfaces:**
+- Consumes: Tasks 6–7 tracker; `IdleGate` (`idle.rs`); `note_changed_to_gate` (`activity.rs:1396-1407`), `turn_complete_frame` (`:1409-1423`), `codex_frames` as the template (`:1286-1339`); protocol types `OpencodeActivityUpdated`/`OpencodeActivityListResponse` (`server_messages.rs:449-463`), `AgentProvider::Opencode`.
+- Produces (used by Tasks 9–10):
+
+```rust
+// activity.rs
+enum OpencodeLaneEvent {  // pub(crate); carried by HubEvent
+    Snapshot { statuses: Vec<(String, freshell_activity::opencode::OpencodeStatus)> },
+    SessionCreated { session_id: String, parent_id: Option<String> },
+    Status { session_id: String, status: freshell_activity::opencode::OpencodeStatus },
+    SessionIdle { session_id: String },
+    SessionError { session_id: String, error_name: String },
+    PermissionAsked { session_id: String, permission_id: String },
+    PermissionReplied { permission_id: String },
+}
+// HubEvent variants:
+//   OpencodeBind { terminal_id: String, session_id: String },
+//   OpencodeLane { terminal_id: String, cycle: u64, stream: u64, event: OpencodeLaneEvent },
+// ActivityHub ingress:
+pub fn bind_opencode_session(&self, terminal_id: &str, session_id: &str);
+pub(crate) fn note_opencode_lane_event(&self, terminal_id: &str, cycle: u64, stream: u64, event: OpencodeLaneEvent);
+pub fn opencode_list(&self) -> (Vec<freshell_protocol::OpencodeActivityRecord>, Vec<freshell_protocol::TurnCompletionSnapshot>);
+```
+
+- [ ] **Step 1: Write the failing episode tests**
+
+Append to `activity.rs`'s `mod tests` (helpers: `hub()` `:1430`, `observer_send` `:1436`, `next_frame_matching` `:1444`, `next_frame_of_type` `:1468`; all `#[tokio::test(flavor = "multi_thread")]`; model on the codex episodes at `:1713-1841` and `:3560-3804`). Add a local helper:
+
+```rust
+async fn busy_opencode_terminal(hub: &ActivityHub, rx: &mut tokio::sync::broadcast::Receiver<String>) {
+    observer_send(hub, ActivityEvent::Created {
+        terminal_id: "t-oc".into(), mode: "opencode".into(),
+        resume_session_id: Some("ses-root".into()), at: 1_000,
+    });
+    hub.note_opencode_lane_event("t-oc", 1, 1, OpencodeLaneEvent::Status {
+        session_id: "ses-root".into(), status: OpencodeStatus::Busy,
+    });
+    let frame = next_frame_matching(rx, "opencode.activity.updated", 1_500, |v| {
+        v["upsert"][0]["phase"] == "busy"
+    }).await;
+    assert!(frame.is_some(), "expected the busy upsert");
+}
+```
+
+Tests (each asserts EXACTLY one `terminal.idle` or none — use `next_frame_of_type(...).await.is_none()` for silence, timeout 1_500ms; ring waits use 3_500ms to cover the 2s grace):
+
+```rust
+#[tokio::test(flavor = "multi_thread")] async fn opencode_completed_turn_rings_once_after_grace() { /* busy -> SessionIdle -> expect terminal.turn.complete{provider:"opencode"} then ONE terminal.idle{reason:"grace"}; a second SessionIdle mints nothing further */ }
+#[tokio::test(flavor = "multi_thread")] async fn opencode_abort_stays_silent() { /* busy -> SessionError{MessageAbortedError} -> SessionIdle x2 -> NO terminal.turn.complete, NO terminal.idle */ }
+#[tokio::test(flavor = "multi_thread")] async fn opencode_failed_turn_rings() { /* busy -> SessionError{UnknownError} -> SessionIdle -> turn.complete + one terminal.idle; trailing SessionError after idle mints nothing */ }
+#[tokio::test(flavor = "multi_thread")] async fn opencode_permission_pause_rings_once_and_reply_within_grace_is_silent() { /* two scenarios or two tests: (a) PermissionAsked -> one terminal.idle after grace; (b) PermissionAsked -> PermissionReplied quickly -> silence */ }
+#[tokio::test(flavor = "multi_thread")] async fn opencode_mid_pause_abort_is_fully_silent() { /* PermissionAsked -> SessionError{abort} + SessionIdle -> no bell even after grace elapses */ }
+#[tokio::test(flavor = "multi_thread")] async fn opencode_spontaneous_death_while_busy_rings_immediately() { /* busy -> Exit{spontaneous:true} -> terminal.idle arrives fast (no grace) */ }
+#[tokio::test(flavor = "multi_thread")] async fn opencode_death_while_candidate_or_idle_is_silent_and_freshell_kill_is_silent() { /* candidate: Created WITHOUT resume id + busy for unknown session -> Exit{spontaneous:true} -> silence; idle quiet -> Exit spontaneous -> silence; busy -> Exit{spontaneous:false} -> silence */ }
+#[tokio::test(flavor = "multi_thread")] async fn opencode_death_during_pause_rings() { /* PermissionAsked -> Exit{spontaneous:true} -> immediate terminal.idle */ }
+#[tokio::test(flavor = "multi_thread")] async fn opencode_child_idle_mid_parent_turn_does_not_ring() { /* SessionCreated{child,parent} -> child busy -> child SessionIdle -> silence + record survives; parent SessionIdle -> one bell */ }
+```
+
+Write each in full following `busy_opencode_terminal` + the codex episode style.
+
+- [ ] **Step 2: Run RED**
+
+Run: `cargo test -p freshell-ws opencode` — FAIL (compile: no variants/methods).
+
+- [ ] **Step 3: Implement**
+
+In `activity.rs`:
+1. `HubInner` (`:192-205`): add `opencode: OpencodeActivityTracker,` (one process-wide instance, like codex).
+2. `HubEvent` (`:104-157`): add `OpencodeBind` and `OpencodeLane` variants (shapes above); ingress methods `bind_opencode_session` / `note_opencode_lane_event` that only `self.tx.send(...)` (single-emitter invariant, `:334-339`).
+3. `handle_event` (`:524-616`): add arms mirroring the codex proxy lane (`:558-614`):
+
+```rust
+HubEvent::OpencodeBind { terminal_id, session_id } => {
+    let at = now_ms();
+    let frames = {
+        let mut inner = self.inner.lock().expect("activity hub lock");
+        let effects = inner.opencode.bind_session(&terminal_id, &session_id, at);
+        opencode_frames(&mut inner.idle, effects)
+    };
+    self.emit(frames);
+}
+HubEvent::OpencodeLane { terminal_id, cycle, stream, event } => {
+    let at = now_ms();
+    let frames = {
+        let mut inner = self.inner.lock().expect("activity hub lock");
+        let effects = match event {
+            OpencodeLaneEvent::Snapshot { statuses } => inner.opencode.note_snapshot(&terminal_id, &statuses, cycle, stream, at),
+            OpencodeLaneEvent::SessionCreated { session_id, parent_id } => inner.opencode.note_session_created(&terminal_id, &session_id, parent_id.as_deref(), at),
+            OpencodeLaneEvent::Status { session_id, status } => inner.opencode.note_status(&terminal_id, &session_id, status, cycle, stream, at),
+            OpencodeLaneEvent::SessionIdle { session_id } => inner.opencode.note_session_idle(&terminal_id, &session_id, cycle, stream, at),
+            OpencodeLaneEvent::SessionError { session_id, error_name } => inner.opencode.note_error(&terminal_id, &session_id, &error_name, cycle, stream, at),
+            OpencodeLaneEvent::PermissionAsked { session_id, permission_id } => inner.opencode.note_permission_asked(&terminal_id, &session_id, &permission_id, at),
+            OpencodeLaneEvent::PermissionReplied { permission_id } => inner.opencode.note_permission_replied(&terminal_id, &permission_id, at),
+        };
+        opencode_frames(&mut inner.idle, effects)
+    };
+    self.emit(frames);
+}
+```
+
+4. Mode dispatch — add `"opencode"` arms:
+   - Created (`:629-661`): `inner.modes.insert(terminal_id.clone(), mode.clone()); let effects = inner.opencode.track_terminal(&terminal_id, resume_session_id.as_deref(), at); opencode_frames(&mut inner.idle, effects)` (lane attach itself is Task 9/10).
+   - Input (`:731-747`) and Output (`:761-776`): `"opencode" => Vec::new()` (SSE-driven; PTY bytes carry no protocol signal — NO heuristic bells).
+   - Exit tracker arm (`:820-836`): `"opencode" => opencode_frames(&mut inner.idle, inner.opencode.note_exit(&terminal_id))`.
+5. Death-bell predicate (`:792-794`) — extend, reading BEFORE teardown (ordering is audit-A17-pinned):
+
+```rust
+let ring_death_bell = spontaneous
+    && ((inner.idle.is_engaged(&terminal_id) && !inner.opencode.blocks_death_bell(&terminal_id))
+        || inner.codex.has_pending_approvals(&terminal_id)
+        || inner.opencode.has_pending_permissions(&terminal_id));
+```
+
+(`blocks_death_bell` is `false` for terminals the opencode tracker doesn't know, so claude/codex/amplifier behavior is unchanged — pin that with the existing tests staying green.)
+6. Frame mapper, next to `codex_frames` (`:1286`):
+
+```rust
+fn opencode_frames(idle: &mut IdleGate, effects: Vec<TrackerEffect<freshell_protocol::OpencodeActivityRecord>>) -> Vec<ServerMessage> {
+    let mut frames = Vec::new();
+    for effect in effects {
+        match effect {
+            TrackerEffect::Changed { upsert, remove } => {
+                // remove -> note_exit clears gate state; the boundary that FOLLOWS
+                // in the same batch re-arms grace-only (D7 — the Node emitter's
+                // "activityRemove followed by turnComplete" contract).
+                note_changed_to_gate(
+                    idle,
+                    upsert.iter().map(|r| (r.terminal_id.as_str(), IdleGatePhase::Busy)),
+                    &remove,
+                );
+                frames.push(ServerMessage::OpencodeActivityUpdated(
+                    freshell_protocol::OpencodeActivityUpdated { remove, upsert },
+                ));
+            }
+            TrackerEffect::TurnComplete { terminal_id, session_id, at, completion_seq } => {
+                idle.note_turn_boundary(&terminal_id, at);
+                frames.push(turn_complete_frame(AgentProvider::Opencode, terminal_id, session_id, at, completion_seq));
+            }
+            TrackerEffect::AttentionBoundary { terminal_id, at } => {
+                idle.note_turn_boundary(&terminal_id, at); // arms the bell; no frame
+            }
+            TrackerEffect::ForceRead { .. } => {}
+        }
+    }
+    frames
+}
+```
+
+7. `hub_next_deadline` (`:1217-1232`): add `inner.opencode.next_deadline()`. `expire_due` (`:1115-1183`): add `let frames = opencode_frames(&mut inner.idle, inner.opencode.expire(now));` alongside the other trackers.
+8. `opencode_list` next to `codex_list` (`:469`): `let inner = ...; (inner.opencode.list(), inner.opencode.list_latest_completions())`.
+
+In `terminal.rs` (`:929-946`): replace the hardcoded empty stub with the hub call, matching the codex sibling at `:895-907`:
+
+```rust
+ClientMessage::OpencodeActivityList(list) => {
+    let (terminals, latest) = match &state.activity {
+        Some(hub) => hub.opencode_list(),
+        None => (Vec::new(), Vec::new()),
+    };
+    send(ws_tx, &ServerMessage::OpencodeActivityListResponse(
+        freshell_protocol::OpencodeActivityListResponse {
+            request_id: list.request_id.clone(),
+            terminals,
+            latest_turn_completions: Some(latest),
+        })).await
+}
+```
+
+Search `crates/freshell-ws/` for tests pinning the empty-stub response (`grep -n "OpencodeActivityList" crates/freshell-ws/src/`); if one pins emptiness, rewrite it against the hub with a `// SEMANTIC CHANGE (opencode-attention-bell): list is now hub-backed` comment. `gemini_and_kimi_are_status_inert` (`:1994`) covers only gemini/kimi and stays untouched.
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `cargo test -p freshell-ws` and `cargo test -p freshell-activity`. Expected: PASS (all pre-existing codex/claude/amplifier episodes green — the death predicate extension must not disturb them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/freshell-ws/src/activity.rs crates/freshell-ws/src/terminal.rs
+git commit -m "feat(ws): opencode hub lane — mode arms, frames, death bell, activity.list"
+```
+
+---
+
+### Task 9: Rust SSE lane — per-terminal event pump with injected IO
+
+**Files:**
+- Create: `crates/freshell-ws/src/opencode_lane.rs`
+- Modify: `crates/freshell-ws/src/lib.rs` (add `mod opencode_lane;`), `crates/freshell-ws/src/activity.rs` (lane registry + `OpencodeAttach` HubEvent + deps setter), `crates/freshell-ws/Cargo.toml` (add `reqwest` + `futures` workspace deps if not already present)
+
+**Interfaces:**
+- Consumes: `freshell_opencode::{SseDecoder, ParsedServeEvent, parse_serve_event}` (events.rs — NOT feature-gated), Task 8's `note_opencode_lane_event` ingress + `OpencodeLaneEvent`.
+- Produces:
+
+```rust
+// opencode_lane.rs
+pub(crate) const OPENCODE_HEALTH_POLL_MS: u64 = 200;      // mirrors Node :18
+pub(crate) const OPENCODE_HEALTH_TIMEOUT_MS: u64 = 15_000; // per cycle, Node :20
+pub(crate) const OPENCODE_RECONNECT_BASE_MS: u64 = 250;    // Node :21
+pub(crate) const OPENCODE_RECONNECT_MAX_MS: u64 = 5_000;   // Node :22
+pub(crate) const OPENCODE_READ_STALL_MS: u64 = 30_000;     // Node :24 (production stream impl)
+
+pub(crate) trait OpencodeLaneHttp: Send + Sync {
+    fn get_json<'a>(&'a self, url: &'a str)
+        -> futures::future::BoxFuture<'a, Result<(u16, serde_json::Value), String>>;
+}
+pub(crate) trait OpencodeEventStream: Send + Sync {
+    /// Connect once and deliver parsed events until the stream ends (returns on disconnect).
+    fn run_once<'a>(&'a self, url: &'a str, sink: &'a (dyn Fn(freshell_opencode::ParsedServeEvent) + Send + Sync))
+        -> futures::future::BoxFuture<'a, Result<(), String>>;
+}
+pub(crate) struct OpencodeLaneDeps { pub http: std::sync::Arc<dyn OpencodeLaneHttp>, pub events: std::sync::Arc<dyn OpencodeEventStream> }
+pub(crate) fn spawn_opencode_lane(deps: std::sync::Arc<OpencodeLaneDeps>, hub: crate::activity::ActivityHub, terminal_id: String, base_url: String) -> tokio::task::JoinHandle<()>;
+pub(crate) fn translate_serve_event(event: &freshell_opencode::ParsedServeEvent) -> Option<crate::activity::OpencodeLaneEvent>;
+// production impls:
+pub(crate) struct ReqwestLaneHttp(/* reqwest::Client */);
+pub(crate) struct ReqwestLaneStream(/* reqwest::Client */);
+// activity.rs additions:
+//   HubEvent::OpencodeAttach { terminal_id: String, base_url: String }
+//   pub fn attach_opencode_serve(&self, terminal_id: &str, hostname: &str, port: u16)  // base_url = format!("http://{hostname}:{port}")
+//   pub fn set_opencode_lane_deps(&self, deps: Arc<OpencodeLaneDeps>)                  // Option'd; tests leave it unset
+//   HubInner: opencode_lanes: HashMap<String, tokio::task::JoinHandle<()>>
+```
+
+**Lane loop semantics (Node `runMonitor:321-348` parity):**
+
+```rust
+// inside spawn_opencode_lane's task:
+let mut cycle: u64 = 0;
+let mut stream: u64 = 0;
+let mut backoff = OPENCODE_RECONNECT_BASE_MS;
+loop {
+    cycle += 1;
+    // 1. health-wait: poll GET {base}/global/health every 200ms, up to 15s this cycle.
+    //    On timeout: fall through to backoff and start a new cycle.
+    // 2. snapshot: GET {base}/session/status -> object map; entries whose
+    //    status.type is "busy"/"retry" -> OpencodeStatus::{Busy,Retry};
+    //    a literal {"type":"idle"} entry parses as Idle (defensive — the live
+    //    server DROPS idle sessions; absence == idle; opencode 1.18.11).
+    //    hub.note_opencode_lane_event(&terminal_id, cycle, stream + 1, OpencodeLaneEvent::Snapshot { statuses });
+    // 3. stream += 1; connect: deps.events.run_once(&format!("{base}/event"), &sink).await
+    //    where sink = |parsed| { if let Some(ev) = translate_serve_event(&parsed) {
+    //        hub.note_opencode_lane_event(&terminal_id, cycle, stream, ev); } };
+    //    On successful connect (run_once returned Ok after streaming), reset backoff to base.
+    // 4. sleep(backoff); backoff = (backoff * 2).min(OPENCODE_RECONNECT_MAX_MS);
+}
+```
+
+`translate_serve_event` (kinds and property paths are verbatim from the spike — `/tmp/opencode-spike/vocabulary.md`):
+
+```rust
+pub(crate) fn translate_serve_event(event: &freshell_opencode::ParsedServeEvent) -> Option<OpencodeLaneEvent> {
+    let props = &event.properties;
+    match event.kind.as_str() {
+        "session.created" => {
+            let info = props.get("info")?.as_object()?;
+            let session_id = info.get("id")?.as_str()?.to_string();
+            let parent_id = info.get("parentID").and_then(|v| v.as_str()).map(str::to_string);
+            Some(OpencodeLaneEvent::SessionCreated { session_id, parent_id })
+        }
+        "session.status" => {
+            let session_id = props.get("sessionID")?.as_str()?.to_string();
+            let status = match props.get("status")?.get("type")?.as_str()? {
+                "idle" => OpencodeStatus::Idle,
+                "retry" => OpencodeStatus::Retry, // schema-declared, never observed live (opencode 1.18.11) — busy-equivalent
+                _ => OpencodeStatus::Busy,
+            };
+            Some(OpencodeLaneEvent::Status { session_id, status })
+        }
+        "session.idle" => Some(OpencodeLaneEvent::SessionIdle {
+            session_id: props.get("sessionID")?.as_str()?.to_string(),
+        }),
+        "session.error" => Some(OpencodeLaneEvent::SessionError {
+            session_id: props.get("sessionID")?.as_str()?.to_string(),
+            error_name: props.get("error").and_then(|e| e.get("name")).and_then(|n| n.as_str()).unwrap_or("UnknownError").to_string(),
+        }),
+        "permission.asked" => Some(OpencodeLaneEvent::PermissionAsked {
+            session_id: props.get("sessionID")?.as_str()?.to_string(),
+            permission_id: props.get("id")?.as_str()?.to_string(),
+        }),
+        "permission.replied" => Some(OpencodeLaneEvent::PermissionReplied {
+            permission_id: props.get("requestID")?.as_str()?.to_string(),
+        }),
+        _ => None, // message.*, session.updated, session.diff, plugin.added, ... are activity-irrelevant
+    }
+}
+```
+
+(`ParsedServeEvent.properties` is a `serde_json::Map<String, Value>` — adjust accessor chaining to `props.get("x")` returning `Option<&Value>` accordingly. `parse_serve_event` already swallows `server.connected`/`server.heartbeat` — the lane's explicit per-cycle snapshot replaces the Node "snapshot on server.connected" trigger.)
+
+Production impls: `ReqwestLaneHttp::get_json` = `client.get(url).timeout(2s).send() -> (status, json)`; `ReqwestLaneStream::run_once` = GET with `accept: text/event-stream`, chunk loop with a 30s per-chunk `tokio::time::timeout` (read-stall watchdog — heartbeats arrive every ~10s), a `Vec<u8>` pending buffer for partial UTF-8 (copy the shape of `freshell_opencode::transport::consume_events:145-198`, WITHOUT its internal reconnect loop — the lane owns cycles), feeding `SseDecoder::push_str` and `parse_serve_event`.
+
+`OpencodeAttach` handling in `handle_event`: abort any existing lane handle for the terminal (`opencode_lanes.insert` returning the old handle → `.abort()` — respawn re-allocates a NEW port, so replacement is the contract), then if deps are set, `spawn_opencode_lane(...)` and store the handle. Exit arm (Task 8 site): `if let Some(handle) = inner.opencode_lanes.remove(&terminal_id) { handle.abort(); }`.
+
+- [ ] **Step 1: Write the failing lane tests** (in `opencode_lane.rs` `mod tests`, with fake impls of the two traits — model on `crates/freshell-opencode/tests/serve_health_bounded.rs`'s `FakeHttp`/`FakeAllocator` style):
+
+```rust
+#[test] fn translate_covers_the_attention_vocabulary() { /* feed verbatim spike JSON (session.status busy/idle/retry, session.idle, session.error abort+unknown, permission.asked/replied, session.created child+root) through freshell_opencode::SseDecoder + parse_serve_event + translate_serve_event; assert each OpencodeLaneEvent; assert message.part.delta and session.diff translate to None */ }
+#[tokio::test(flavor = "multi_thread")] async fn lane_gates_on_health_then_snapshots_then_streams() { /* FakeHttp: health returns 500 twice then 200; /session/status returns {"ses-r":{"type":"busy"}}; FakeStream delivers one session.idle then Ok(()); a recording hub (real ActivityHub + broadcast rx) sees Snapshot before SessionIdle with cycle=1 */ }
+#[tokio::test(flavor = "multi_thread")] async fn reconnect_bumps_stream_and_resnapshots() { /* FakeStream returns Ok(()) immediately twice; assert two Snapshot events with cycle 1 and 2 */ }
+```
+
+Write in full. Also a hub-level test in `activity.rs`: `opencode_attach_replaces_the_lane_and_exit_tears_it_down` — set fake deps via `set_opencode_lane_deps`, `attach_opencode_serve` twice + `Exit`, assert the lanes map (expose a `#[cfg(test)] fn opencode_lane_count(&self) -> usize`).
+
+- [ ] **Step 2: Run RED** — `cargo test -p freshell-ws opencode_lane` fails to compile.
+
+- [ ] **Step 3: Implement per the semantics above. Step 4: Run GREEN** — `cargo test -p freshell-ws`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/freshell-ws/src/opencode_lane.rs crates/freshell-ws/src/lib.rs crates/freshell-ws/src/activity.rs crates/freshell-ws/Cargo.toml Cargo.lock
+git commit -m "feat(ws): per-terminal opencode SSE lane with injected IO seams"
+```
+
+---
+
+### Task 10: Rust threading — endpoint to hub, identity binds, production deps
+
+**Files:**
+- Modify: `crates/freshell-ws/src/terminal.rs` (create `:2380-2505` region, respawn `:3214-3283` region)
+- Modify: `crates/freshell-ws/src/opencode_association.rs` (`drain_and_associate`, `:86+`)
+- Modify: the `OpencodeSignal` rebind consumer (find it: `grep -rn "OpencodeDrainOutcome\|rebinds" crates/freshell-ws/src/ --include="*.rs"` — one drain call site applies rebind signals to the registry)
+- Modify: `crates/freshell-server/src/main.rs` (hub construction block, `:495-513`)
+
+**Interfaces:**
+- Consumes: `opencode_endpoint` locals (`terminal.rs:2384`, `:3216`), `hub.attach_opencode_serve` / `hub.bind_opencode_session` / `hub.set_opencode_lane_deps` (Tasks 8–9).
+- Produces: a live production path — create/respawn attaches the lane; association/rebind feeds identity; main.rs installs `ReqwestLaneHttp`/`ReqwestLaneStream`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `activity.rs` tests (hub-level, since terminal.rs's handlers need a full WS harness): `resume_created_opencode_terminal_binds_identity_via_bind_ingress` — `Created` with `resume_session_id: None`, busy for `ses-x` (candidate), idle (awaitingAssociation), then `hub.bind_opencode_session("t-oc", "ses-x")` → expect `terminal.turn.complete{provider:"opencode"}` then one `terminal.idle`. (This pins the deferred-completion bind lane the association producers will drive.) Write it in full following the Task 8 episode style.
+
+- [ ] **Step 2: Run RED if the bind arm is incomplete; otherwise this is a pin** — `cargo test -p freshell-ws opencode`.
+
+- [ ] **Step 3: Implement the threading**
+
+1. `terminal.rs` create path: immediately after the launch resolves and the terminal is successfully registered (after the `CliLaunchInputs` consumption at `:2499-2505`, at the point where `handle_create` has a definitive terminal id and the spawn succeeded — co-locate with the existing `opencode_association::maybe_arm(...)` call at `:2809`):
+
+```rust
+if let (Some(hub), Some(ep)) = (&state.activity, opencode_endpoint.as_ref()) {
+    hub.attach_opencode_serve(&terminal_id, &ep.hostname, ep.port);
+}
+```
+
+2. Respawn path: same two lines co-located with the respawn's `maybe_arm` at `:3502` (the respawn re-allocated a fresh port at `:3216-3224`; `attach_opencode_serve` replaces the old lane by contract).
+3. `opencode_association.rs` `drain_and_associate`: at the point a rebind/bind succeeds against the registry (where it broadcasts `terminal.session.associated`), add:
+
+```rust
+if let Some(hub) = &state.activity {
+    hub.bind_opencode_session(&terminal_id, &session_id);
+}
+```
+
+4. Same one-liner at the `OpencodeSignal` rebind consumer (the in-TUI session-switch path).
+5. `main.rs`, next to `set_codex_rollout_locator` (`:511-513`):
+
+```rust
+activity_hub.set_opencode_lane_deps(std::sync::Arc::new(freshell_ws::opencode_lane::OpencodeLaneDeps {
+    http: std::sync::Arc::new(freshell_ws::opencode_lane::ReqwestLaneHttp::new()),
+    events: std::sync::Arc::new(freshell_ws::opencode_lane::ReqwestLaneStream::new()),
+}));
+```
+
+(Adjust visibility: `opencode_lane` module + deps/impl types need `pub` reachability from `freshell-server`; widen from `pub(crate)` where required.)
+
+- [ ] **Step 4: Run GREEN + build**
+
+Run: `cargo test -p freshell-ws && cargo build -p freshell-server`
+Expected: PASS + clean build. Do NOT deploy/restart anything.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/freshell-ws/src/terminal.rs crates/freshell-ws/src/opencode_association.rs crates/freshell-ws/src/opencode_lane.rs crates/freshell-ws/src/activity.rs crates/freshell-server/src/main.rs
+git commit -m "feat(ws): thread opencode endpoint and identity binds into the activity hub"
+```
+
+(If the signal-consumer edit touched a different file, add it too.)
+
+---
+
+### Task 11: Docs + residuals truth-up
+
+**Files:**
+- Modify: `crates/freshell-activity/src/idle.rs` (residuals block `:35-54`)
+- Modify: `shared/ws-protocol.ts` (doc comment `:199-221` ONLY — no schema tokens)
+- Modify: `server/coding-cli/truly-idle-emitter.ts` (doc comments `:78-79` context and the `:222-227` "codex-only" note)
+
+- [ ] **Step 1: Rewrite `idle.rs` Accepted Residual 6** (currently: `6. Node opencode death bells: deliberately excluded (noisy busy proxy) — follow-up. Rust opencode: no hub tracker exists — N/A.`) to reflect reality, and append the new opencode residuals (D8):
+
+```
+//! 6. Opencode death bells now ring on both servers, ownership-scoped:
+//!    candidate/ambiguous ownership never death-rings (the old noisy-busy-proxy
+//!    problem, now excluded by construction).
+//! 8. Opencode: an SSE reconnect during a permission pause loses the pending
+//!    pause bell (the busy snapshot clears it; GET /permission resync is a
+//!    possible follow-up). Ambiguous ownership stays bell-free. Child sessions
+//!    created inside a reconnect gap can force ambiguous (conservative silence).
+//! 9. Opencode permission.v2.* / question.* event families (schema-declared,
+//!    unobserved on 1.18.11) are unhandled — the pause bell goes deaf if a
+//!    future server switches families.
+```
+
+(Keep existing entries 1–5 and 7 verbatim; renumber only if the file's style demands it.)
+
+- [ ] **Step 2: Update the `terminal.idle` normative doc comment** at `shared/ws-protocol.ts:199-221`: the approval-pause bullet currently says "(managed codex only)" — change to "(managed codex; opencode permission pauses)". Update `truly-idle-emitter.ts:222-227`'s `onAttentionBoundary` comment ("codex-only, no-op for others") to name codex + opencode. Comment-only edits.
+
+- [ ] **Step 3: Verify zero wire drift**
+
+Run: `npm run test:vitest -- run test/unit/port/ws-contract-freeze.test.ts --config config/vitest/vitest.server.config.ts`
+Expected: PASS with NO regenerated JSON (comments don't feed the contract). If it fails, the edit touched schema tokens — revert and re-apply as pure comments.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/freshell-activity/src/idle.rs shared/ws-protocol.ts server/coding-cli/truly-idle-emitter.ts
+git commit -m "docs(idle): truth-up accepted residuals and attention-bell contract notes for opencode"
+```
+
+---
+
+### Task 12: Verification sweep
+
+**Files:** none (verification only; fix-forward commits if anything is red).
+
+- [ ] **Step 1: Rust gates**
+
+```bash
+cd /home/dan/code/freshell/.worktrees/opencode-attention-bell
+cargo fmt --all -- --check
+cargo clippy -p freshell-activity -p freshell-ws -p freshell-opencode -- -D warnings
+cargo test -p freshell-activity -p freshell-ws -p freshell-opencode
+```
+
+Expected: all clean/green. Fix and amend/commit as needed (`fix(...)`/`test(...)` commits).
+
+- [ ] **Step 2: Node targeted suites**
+
+```bash
+npm run test:vitest -- run test/unit/server/coding-cli/ test/unit/port/ws-contract-freeze.test.ts --config config/vitest/vitest.server.config.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Full gate (coordinator-gated)**
+
+```bash
+FRESHELL_TEST_SUMMARY="opencode attention bell: full check before review" npm run check
+```
+
+Expected: PASS (typecheck + coordinated full suite). Never kill a foreign coordinator holder; wait or retry.
+
+- [ ] **Step 4: Hygiene**
+
+```bash
+git status --short   # expect clean; .kata.toml untouched
+git log --oneline origin/main..HEAD
+```
+
+Confirm: no wire-contract JSON churn in the diff (`git diff origin/main --stat -- port/contract/` is empty), no changes under `server/fresh-agent/adapters/opencode/`, no PR opened. Commit any stragglers.
+
+- [ ] **Step 5: Final commit (if any hygiene fixes)**
+
+```bash
+git add -A && git commit -m "chore(opencode): verification sweep fixes"   # only if needed
+```
+
+---
+
+## Self-Review Record
+
+**1. Spec coverage** — each spec requirement → covering task:
+- Completed turn rings after 2s grace, busy re-entry cancels, double-idle dedupe → Node: already-live path + Tasks 1–2 pins; Rust: Tasks 6, 8.
+- Abort/Esc silent, per-turn flag → Tasks 1–2 (Node), 7–8 (Rust).
+- Failed turn rings, trailing error no-op → Tasks 1–2, 7–8.
+- Permission pause: boundary, replied/busy resume, mid-pause hardening, duplicate dedupe, busy-only wire record → Tasks 3 (Node), 7–8 (Rust).
+- Spontaneous death while engaged (knownBusy ∨ armed grace ∨ pending permissions; never candidate/ambiguous), freshell kills silent, exit-while-idle silent, SSE-drop non-signal → Tasks 4 (Node), 7–8 (Rust); D4/D8 documented in Task 11.
+- Child-session scoping + live-trace pins → Tasks 2, 5 (Node), 6, 8 (Rust).
+- Ambiguous conservative + residuals truth-up (idle.rs entry 6) → Tasks 6–8, 11.
+- Rust parity: pure tracker in freshell-activity, SSE lane reusing freshell-opencode decoder, hub wiring (Created/Exit/IdleGate/death/updated/list/turn.complete), endpoint threading, reconnect+health constants mirrored, zero client changes → Tasks 6–10.
+- opencode.activity.list answered from the hub (codex-mirror routing) → Task 8.
+- resolveOpencodeSessionRoots wiring pin → Task 5.
+- Testing expectations (Rust pure + hub episode + lane fakes; Node mirrors with collectors-before-action; deliberate pinned-test rewrites with SEMANTIC CHANGE comments; contract freeze green; fmt/clippy; targeted suites) → Tasks 1–10 test steps + Task 12.
+
+**1b. No silent deferrals** — every requirement lands as production behavior with a test naming the observable outcome (frames on the broadcast channel / tracker events), not stubs: the Rust lane's injected IO seams are test seams, and Task 10 installs the reqwest production impls in `main.rs` (built by `cargo build -p freshell-server`); hub episode tests prove the end-to-end frame behavior the client consumes. No stub survives without its production replacement task. Known residuals (D8) are protocol-inherent limits documented as residuals, not deferred requirements — none of the 8 required behaviors is moved there. **No unresolved coverage gaps.**
+
+**2. Placeholder scan** — Tasks 2, 3, 5, 8, 9 use comment-annotated test skeletons that specify exact event sequences and assertions with a "write in full" instruction plus a complete worked example in the same task; no TBD/TODO/"handle edge cases" items remain.
+
+**3. Type consistency** — checked: `OpencodeActivityChange` marker fields match `TrulyIdleActivityChange` (`spontaneousExitRemovals`/`approvalPendingRemovals`, `:34`/`:41`); `untrackTerminal({ terminalId, spontaneous? })` matches the wiring call; Rust `OpencodeStatus`/`OpencodeLaneEvent` names match between Tasks 6–9; `opencode_frames` signature matches `claude_frames`' single-return shape (no force-reads); `blocks_death_bell`/`has_pending_permissions` names consistent across Tasks 7–8; `attach_opencode_serve(terminal_id, hostname, port)` consistent between Tasks 9–10; reducer `error` observation field names identical in Tasks 1–2.

--- a/docs/plans/2026-08-03-opencode-attention-bell.md
+++ b/docs/plans/2026-08-03-opencode-attention-bell.md
@@ -182,7 +182,7 @@ In `server/coding-cli/opencode-ownership-reducer.ts`:
 
 2. Add the per-turn flags to the state union: on `candidate` (~`:29-36`) and `knownBusy` (~`:37-43`) add `turnAborted?: boolean`; on `awaitingAssociation` (~`:44-51`) add `aborted?: boolean`.
 
-3. Add `reduceError` (near `reduceIdle`):
+3. Widen `sameSessionStream`'s observation parameter (~`:103-110`) from `Extract<OpencodeObservation, { kind: 'sse' }>` to `Extract<OpencodeObservation, { kind: 'sse' | 'error' }>` — the guard only reads `sessionId`/`cycleId`/`streamId`, which both variants carry. Without this widening, `reduceError` below is a TS2345 type error at `npm run check` (Task 12 Step 3) even though esbuild-transpiled vitest runs stay green. Then add `reduceError` (near `reduceIdle`):
 
 ```ts
 function reduceError(
@@ -1751,7 +1751,7 @@ git commit -m "feat(ws): thread opencode endpoint and identity binds into the ac
 
 - [ ] **Step 3: Verify zero wire drift**
 
-Run: `npm run test:vitest -- run test/unit/port/ws-contract-freeze.test.ts --config config/vitest/vitest.server.config.ts`
+Run: `npm run test:port` (the freeze test lives at `test/unit/port/ws-contract-freeze.test.ts`, matched ONLY by `config/vitest/vitest.port.config.ts` — the server config does not include `test/unit/port/`, so never run it under `vitest.server.config.ts`).
 Expected: PASS with NO regenerated JSON (comments don't feed the contract). If it fails, the edit touched schema tokens — revert and re-apply as pure comments.
 
 - [ ] **Step 4: Commit**
@@ -1781,10 +1781,11 @@ Expected: all clean/green. Fix and amend/commit as needed (`fix(...)`/`test(...)
 - [ ] **Step 2: Node targeted suites**
 
 ```bash
-npm run test:vitest -- run test/unit/server/coding-cli/ test/unit/port/ws-contract-freeze.test.ts --config config/vitest/vitest.server.config.ts
+npm run test:vitest -- run test/unit/server/coding-cli/ --config config/vitest/vitest.server.config.ts
+npm run test:port
 ```
 
-Expected: PASS.
+Expected: BOTH commands PASS. (Two separate runs on purpose: the contract-freeze test is only matched by the port config — folding it into the server-config invocation silently skips it.)
 
 - [ ] **Step 3: Full gate (coordinator-gated)**
 

--- a/server/coding-cli/opencode-activity-tracker.ts
+++ b/server/coding-cli/opencode-activity-tracker.ts
@@ -380,7 +380,8 @@ export class OpencodeActivityTracker extends EventEmitter {
       monitor !== undefined &&
       input.spontaneous === true &&
       ownershipKind !== 'candidate' &&
-      ownershipKind !== 'ambiguous'
+      ownershipKind !== 'ambiguous' &&
+      ownershipKind !== 'awaitingAssociation'
     const approvalPending = this.hasPendingPermissions(input.terminalId)
     if (monitor) {
       monitor.disposed = true
@@ -482,7 +483,8 @@ export class OpencodeActivityTracker extends EventEmitter {
     }
     if (typeof version !== 'string' || version.startsWith(TESTED_OPENCODE_VERSION_RANGE)) return
     monitor.versionWarned = true
-    console.warn(
+    this.log.warn(
+      { terminalId: monitor.terminalId, endpoint: monitor.endpoint, version },
       `OpenCode version ${version} has not been tested with the freshell activity tracker `
       + `(tested: ${TESTED_OPENCODE_VERSION_RANGE}x); keeping attention bells on best-effort.`,
     )
@@ -825,6 +827,8 @@ export class OpencodeActivityTracker extends EventEmitter {
     if (!monitor || monitor.disposed) return
     const result = rejectOpencodeAssociation(monitor.ownership, { sessionId: input.sessionId })
     monitor.ownership = result.state
+    // Clear any pending permissions so the stale pause claim cannot leak into the death-bell window
+    this.pendingPermissions.delete(input.terminalId)
     this.applyActions(monitor.terminalId, result.actions)
   }
 

--- a/server/coding-cli/opencode-activity-tracker.ts
+++ b/server/coding-cli/opencode-activity-tracker.ts
@@ -825,10 +825,17 @@ export class OpencodeActivityTracker extends EventEmitter {
   rejectSessionAssociation(input: { terminalId: string; sessionId: string }): void {
     const monitor = this.monitors.get(input.terminalId)
     if (!monitor || monitor.disposed) return
+    // Gate the pending-permission clear on actual rejection: only clear if the
+    // rejection matched the current ownership state (awaitingAssociation + matching sessionId).
+    // Rust parity: rejectOpencodeAssociation only modifies state if matched; we only
+    // clear pendingPermissions inside that matched arm to avoid stale-claim leaks.
+    const preRejectOwnership = monitor.ownership
     const result = rejectOpencodeAssociation(monitor.ownership, { sessionId: input.sessionId })
     monitor.ownership = result.state
-    // Clear any pending permissions so the stale pause claim cannot leak into the death-bell window
-    this.pendingPermissions.delete(input.terminalId)
+    // Clear pending permissions only if ownership actually changed (rejection matched)
+    if (preRejectOwnership.kind === 'awaitingAssociation' && preRejectOwnership.sessionId === input.sessionId) {
+      this.pendingPermissions.delete(input.terminalId)
+    }
     this.applyActions(monitor.terminalId, result.actions)
   }
 

--- a/server/coding-cli/opencode-activity-tracker.ts
+++ b/server/coding-cli/opencode-activity-tracker.ts
@@ -101,11 +101,39 @@ const SessionCreatedEventSchema = z.object({
   }).passthrough(),
 }).passthrough()
 
+const SessionErrorEventSchema = z
+  .object({
+    type: z.literal('session.error'),
+    properties: z
+      .object({
+        sessionID: z.string().min(1),
+        error: z.object({ name: z.string().min(1) }).passthrough(),
+      })
+      .passthrough(),
+  })
+  .passthrough()
+
+const MessageUpdatedEventSchema = z
+  .object({
+    type: z.literal('message.updated'),
+    properties: z
+      .object({
+        sessionID: z.string().min(1),
+        info: z
+          .object({ error: z.object({ name: z.string().min(1) }).passthrough().optional() })
+          .passthrough(),
+      })
+      .passthrough(),
+  })
+  .passthrough()
+
 const OpencodeEventSchema = z.discriminatedUnion('type', [
   ServerConnectedEventSchema,
   SessionStatusEventSchema,
   SessionIdleEventSchema,
   SessionCreatedEventSchema,
+  SessionErrorEventSchema,
+  MessageUpdatedEventSchema,
 ])
 
 const OpencodeEventTypeSchema = z.object({
@@ -117,7 +145,15 @@ const KNOWN_OPENCODE_EVENT_TYPES = new Set<z.infer<typeof OpencodeEventSchema>['
   'session.status',
   'session.idle',
   'session.created',
+  'session.error',
+  'message.updated',
 ])
+
+// derives from opencode 1.18.11: /global/health returns { healthy, version },
+// both required. session.idle is already deprecated upstream and a v1->v2
+// event/health migration is in progress — warn on untested versions, but keep
+// bells ON (best-effort; the gate converts silent drift into a logged warning).
+const TESTED_OPENCODE_VERSION_RANGE = '1.18.'
 
 type FetchLike = typeof fetch
 
@@ -134,6 +170,7 @@ type MonitorState = {
   reconnectTimer?: ReturnType<typeof setTimeout>
   reconnectResolve?: () => void
   ownership: OpencodeOwnershipState
+  versionWarned?: boolean
   lastSnapshot?: {
     cycleId: number
     streamId: number
@@ -275,6 +312,7 @@ export class OpencodeActivityTracker extends EventEmitter {
       && !existing.disposed
     ) {
       existing.ownership = createOpencodeOwnershipState(input.sessionId)
+      existing.versionWarned = false
       this.childSessionIds.delete(input.terminalId)
       this.sessionRootsByTerminal.delete(input.terminalId)
       return
@@ -355,6 +393,7 @@ export class OpencodeActivityTracker extends EventEmitter {
           signal,
         })
         if (response.ok) {
+          await this.warnOnVersionDrift(monitor, response)
           return
         }
       } catch (error) {
@@ -367,6 +406,23 @@ export class OpencodeActivityTracker extends EventEmitter {
       }
       await this.sleep(signal, OPENCODE_HEALTH_POLL_MS)
     }
+  }
+
+  private async warnOnVersionDrift(monitor: MonitorState, response: Response): Promise<void> {
+    if (monitor.versionWarned) return
+    let version: unknown
+    try {
+      const body = (await response.json()) as { version?: unknown } | null
+      version = body?.version
+    } catch {
+      return
+    }
+    if (typeof version !== 'string' || version.startsWith(TESTED_OPENCODE_VERSION_RANGE)) return
+    monitor.versionWarned = true
+    console.warn(
+      `OpenCode version ${version} has not been tested with the freshell activity tracker `
+      + `(tested: ${TESTED_OPENCODE_VERSION_RANGE}x); keeping attention bells on best-effort.`,
+    )
   }
 
   private async refreshSnapshot(
@@ -531,12 +587,60 @@ export class OpencodeActivityTracker extends EventEmitter {
       return
     }
 
+    if (event.type === 'session.error') {
+      const rawSessionId = event.properties.sessionID
+      const rootSessionId = await this.resolveRootForEvent(monitor, rawSessionId)
+      // Child or unresolved errors never gate the root's turn (a sub-agent
+      // abort must not silence the parent; conservative for unknown ids).
+      if (rootSessionId === undefined || rootSessionId !== rawSessionId) return
+      this.observe(monitor, {
+        kind: 'error',
+        cycleId,
+        streamId,
+        sessionId: rootSessionId,
+        errorName: event.properties.error.name,
+        at: this.now(),
+      })
+      return
+    }
+
+    if (event.type === 'message.updated') {
+      // W2 abort marker (derives from opencode 1.18.11): an abort landing
+      // between assistant-message creation and LLM stream start emits NO
+      // session.error — only message.updated with info.error.name ===
+      // 'MessageAbortedError', always BEFORE the idle edge. Error-less
+      // message.updated is routine message churn: no attention signal.
+      const errorName = event.properties.info.error?.name
+      if (errorName === undefined) return
+      const rawSessionId = event.properties.sessionID
+      const rootSessionId = await this.resolveRootForEvent(monitor, rawSessionId)
+      // Same raw-equality scoping as session.error: child or unresolved
+      // markers never gate the root's turn.
+      if (rootSessionId === undefined || rootSessionId !== rawSessionId) return
+      this.observe(monitor, {
+        kind: 'error',
+        cycleId,
+        streamId,
+        sessionId: rootSessionId,
+        errorName,
+        at: this.now(),
+      })
+      return
+    }
+
     const observedSessionId = await this.resolveRootForEvent(monitor, event.properties.sessionID)
     const observedStatus = event.type === 'session.idle'
       ? 'idle'
       : event.properties.status.type
 
     if (observedStatus === 'idle') {
+      // Child sessions go idle mid-parent-turn (live trace: child idle 921ms
+      // before the parent, events-D.log). Remapping a CHILD idle onto the
+      // root falsely completes the root's turn — suppress it. The root's own
+      // idle (raw id == resolved root) passes through unchanged.
+      if (observedSessionId !== undefined && observedSessionId !== event.properties.sessionID) {
+        return
+      }
       this.observe(monitor, {
         kind: 'sse',
         cycleId,

--- a/server/coding-cli/opencode-activity-tracker.ts
+++ b/server/coding-cli/opencode-activity-tracker.ts
@@ -37,6 +37,15 @@ export type OpencodeActivityRecord = {
 export type OpencodeActivityChange = {
   upsert: OpencodeActivityRecord[]
   remove: string[]
+  /**
+   * Terminals whose PTY exit was NOT freshell-initiated (registry
+   * `spontaneous: !requestedClose`). Internal-only: the ws-handler's zod
+   * re-validation strips it from the wire. Death-bell input for the
+   * truly-idle emitter.
+   */
+  spontaneousExitRemovals?: string[]
+  /** Terminals with a pending permission pause at exit time (rings even though the record is absent). */
+  approvalPendingRemovals?: string[]
 }
 
 export type OpencodeAssociationRequestedEvent = {
@@ -356,8 +365,23 @@ export class OpencodeActivityTracker extends EventEmitter {
     void this.runMonitor(monitor)
   }
 
-  untrackTerminal(input: { terminalId: string }): void {
+  untrackTerminal(input: { terminalId: string; spontaneous?: boolean }): void {
     const monitor = this.monitors.get(input.terminalId)
+    // Engagement inputs are captured BEFORE teardown destroys them.
+    // candidate/ambiguous ownership never death-rings (D4: that noise is why
+    // opencode death bells were excluded before).
+    const ownershipKind = monitor?.ownership.kind
+    // `monitor !== undefined` gates the whole path: the wiring subscribes to
+    // EVERY registry terminal.exit (non-opencode panes included), so a
+    // never-tracked terminal must fall through to the silent removeRecord
+    // branch exactly as today. A permission pause removes only the record,
+    // never the monitor, so paused panes keep their monitor and stay eligible.
+    const deathBellEligible =
+      monitor !== undefined &&
+      input.spontaneous === true &&
+      ownershipKind !== 'candidate' &&
+      ownershipKind !== 'ambiguous'
+    const approvalPending = this.hasPendingPermissions(input.terminalId)
     if (monitor) {
       monitor.disposed = true
       monitor.lastSnapshot = undefined
@@ -373,7 +397,20 @@ export class OpencodeActivityTracker extends EventEmitter {
     this.childSessionIds.delete(input.terminalId)
     this.sessionRootsByTerminal.delete(input.terminalId)
     this.pendingPermissions.delete(input.terminalId)
-    this.removeRecord(input.terminalId)
+    if (deathBellEligible) {
+      // Emit UNCONDITIONALLY: the record is usually already gone (turn ended
+      // or pause demoted), and the emitter needs the marked removal to reach
+      // its armed-grace / approval-pending checks.
+      this.records.delete(input.terminalId)
+      this.emit('changed', {
+        upsert: [],
+        remove: [input.terminalId],
+        spontaneousExitRemovals: [input.terminalId],
+        ...(approvalPending ? { approvalPendingRemovals: [input.terminalId] } : {}),
+      } satisfies OpencodeActivityChange)
+    } else {
+      this.removeRecord(input.terminalId)
+    }
   }
 
   dispose(): void {

--- a/server/coding-cli/opencode-activity-tracker.ts
+++ b/server/coding-cli/opencode-activity-tracker.ts
@@ -127,6 +127,24 @@ const MessageUpdatedEventSchema = z
   })
   .passthrough()
 
+// derives from opencode 1.18.11: permission.asked carries a unique permission
+// id (echoed back as requestID on permission.replied) and the ASKING session's
+// id -- a child session asks under its OWN sessionID while the parent turn
+// blocks on the answer.
+const PermissionAskedEventSchema = z
+  .object({
+    type: z.literal('permission.asked'),
+    properties: z.object({ id: z.string().min(1), sessionID: z.string().min(1) }).passthrough(),
+  })
+  .passthrough()
+
+const PermissionRepliedEventSchema = z
+  .object({
+    type: z.literal('permission.replied'),
+    properties: z.object({ sessionID: z.string().min(1), requestID: z.string().min(1) }).passthrough(),
+  })
+  .passthrough()
+
 const OpencodeEventSchema = z.discriminatedUnion('type', [
   ServerConnectedEventSchema,
   SessionStatusEventSchema,
@@ -134,6 +152,8 @@ const OpencodeEventSchema = z.discriminatedUnion('type', [
   SessionCreatedEventSchema,
   SessionErrorEventSchema,
   MessageUpdatedEventSchema,
+  PermissionAskedEventSchema,
+  PermissionRepliedEventSchema,
 ])
 
 const OpencodeEventTypeSchema = z.object({
@@ -147,6 +167,8 @@ const KNOWN_OPENCODE_EVENT_TYPES = new Set<z.infer<typeof OpencodeEventSchema>['
   'session.created',
   'session.error',
   'message.updated',
+  'permission.asked',
+  'permission.replied',
 ])
 
 // derives from opencode 1.18.11: /global/health returns { healthy, version },
@@ -246,6 +268,8 @@ export class OpencodeActivityTracker extends EventEmitter {
   private readonly monitors = new Map<string, MonitorState>()
   private readonly childSessionIds = new Map<string, Set<string>>()
   private readonly sessionRootsByTerminal = new Map<string, Map<string, string>>()
+  // Pending permission-request ids per terminal (codex pendingApprovals mirror).
+  private readonly pendingPermissions = new Map<string, Set<string>>()
   private readonly fetchImpl: FetchLike
   private readonly log: TrackerLogger
   private readonly now: () => number
@@ -315,6 +339,7 @@ export class OpencodeActivityTracker extends EventEmitter {
       existing.versionWarned = false
       this.childSessionIds.delete(input.terminalId)
       this.sessionRootsByTerminal.delete(input.terminalId)
+      this.pendingPermissions.delete(input.terminalId)
       return
     }
 
@@ -347,6 +372,7 @@ export class OpencodeActivityTracker extends EventEmitter {
     }
     this.childSessionIds.delete(input.terminalId)
     this.sessionRootsByTerminal.delete(input.terminalId)
+    this.pendingPermissions.delete(input.terminalId)
     this.removeRecord(input.terminalId)
   }
 
@@ -628,6 +654,61 @@ export class OpencodeActivityTracker extends EventEmitter {
       return
     }
 
+    if (event.type === 'permission.asked') {
+      const ownership = monitor.ownership
+      // Root-resolve the asker (D3): children CAN ask -- the event is stamped
+      // with the CHILD session id and the parent turn blocks on it (opencode
+      // v1.18.11 source, validation pass 2026-08-03). Multi-level chain walk;
+      // mappings are retained for the session's lifetime.
+      const rootSessionId = await this.resolveRootForEvent(monitor, event.properties.sessionID)
+      if (rootSessionId === undefined) return
+      // Arm under knownBusy OR candidate ownership: a fresh pane is candidate
+      // for its ENTIRE first turn by construction (the bind lands only at the
+      // first idle edge), and the single busy unbound session on the pane's
+      // own per-pane endpoint is this pane's turn -- first-turn tool-permission
+      // asks are the most common attention scenario and must ring (D3).
+      // Ambiguous/quiet stays conservative (no bells).
+      if (
+        (ownership.kind !== 'knownBusy' && ownership.kind !== 'candidate') ||
+        ownership.sessionId !== rootSessionId
+      ) {
+        return
+      }
+      const pending = this.pendingPermissions.get(monitor.terminalId) ?? new Set<string>()
+      const newlyInserted = !pending.has(event.properties.id)
+      pending.add(event.properties.id)
+      this.pendingPermissions.set(monitor.terminalId, pending)
+      if (!newlyInserted) return // duplicate asked never re-arms
+      const at = this.now()
+      // Demote FIRST (record removal is opencode's not-busy on the wire),
+      // boundary SECOND -- the gate must see not-busy before it arms
+      // (codex ordering, codex-activity-tracker.ts:377-382).
+      this.removeRecord(monitor.terminalId)
+      this.emit('attention.boundary', { terminalId: monitor.terminalId, at })
+      return
+    }
+
+    if (event.type === 'permission.replied') {
+      const pending = this.pendingPermissions.get(monitor.terminalId)
+      if (!pending?.delete(event.properties.requestID)) return
+      if (pending.size > 0) return
+      this.pendingPermissions.delete(monitor.terminalId)
+      const ownership = monitor.ownership
+      // Restore under candidate too -- pause mechanics are identical (D3).
+      if (ownership.kind !== 'knownBusy' && ownership.kind !== 'candidate') return
+      // Resume busy immediately (codex resume_busy_after_approval analog):
+      // the reply proves a human is present; busy re-entry cancels the armed
+      // grace window without waiting ~1s for the next session.status{busy}.
+      this.upsertRecord({
+        terminalId: monitor.terminalId,
+        sessionId: ownership.sessionId,
+        phase: 'busy',
+        updatedAt: this.now(),
+        lastObservedAt: this.now(),
+      })
+      return
+    }
+
     const observedSessionId = await this.resolveRootForEvent(monitor, event.properties.sessionID)
     const observedStatus = event.type === 'session.idle'
       ? 'idle'
@@ -716,42 +797,88 @@ export class OpencodeActivityTracker extends EventEmitter {
     this.applyActions(monitor.terminalId, result.actions)
   }
 
+  private hasPendingPermissions(terminalId: string): boolean {
+    return (this.pendingPermissions.get(terminalId)?.size ?? 0) > 0
+  }
+
+  // NOTE: applyActions runs AFTER the reducer transition, so the ownership it
+  // reads is the POST-observation state -- that is what distinguishes a
+  // knownBusy turn end (now quiet) from a candidate one (now awaitingAssociation).
   private applyActions(terminalId: string, actions: OpencodeOwnershipAction[]): void {
-    for (const action of actions) {
-      if (action.kind === 'activityUpsert') {
-        this.upsertRecord({
-          terminalId,
-          ...(action.sessionId ? { sessionId: action.sessionId } : {}),
-          phase: 'busy',
-          updatedAt: action.at,
-        })
-        continue
+    const ownership = this.monitors.get(terminalId)?.ownership
+    const pauseActive = this.hasPendingPermissions(terminalId)
+    const idleEdge = actions.some((a) => a.kind === 'activityRemove')
+    const completionEdge = actions.some((a) => a.kind === 'turnComplete')
+    if (pauseActive && (idleEdge || completionEdge)) {
+      // Mid-pause turn end: the pause is THE attention episode for this turn.
+      // Never mint a second bell (codex PR #597 mid-pause silent-claim
+      // hardening, mirrored). A completion WITHOUT an idle edge is the
+      // DEFERRED completion minted at confirmOpencodeAssociation
+      // (candidate-armed pauses, D3) -- swallowed the same way.
+      const awaitingBind = ownership?.kind === 'awaitingAssociation'
+      const aborted = awaitingBind && ownership.aborted === true
+      if (awaitingBind && !aborted) {
+        // Candidate turn end mid-pause: KEEP the pause claim alive so the
+        // deferred completion minted at confirm is swallowed on its own pass
+        // through this branch. The armed grace window stays live -- the pause
+        // bell (rung or still in grace) is the episode's bell.
+      } else {
+        this.pendingPermissions.delete(terminalId)
       }
-      if (action.kind === 'activityRemove') {
-        this.removeRecord(terminalId)
-        continue
+      if ((!completionEdge && !awaitingBind) || aborted) {
+        // Abort mid-pause (knownBusy -> quiet, or aborted candidate ->
+        // awaitingAssociation{aborted}): human at keyboard -- force-emit the
+        // removal so the emitter cancels any still-armed grace window (the
+        // record itself was already removed at pause entry).
+        this.removeRecord(terminalId, { forceEmit: true })
       }
-      if (action.kind === 'requestAssociation') {
-        this.emit('association.requested', {
-          terminalId,
-          sessionId: action.sessionId,
-        } satisfies OpencodeAssociationRequestedEvent)
-        continue
+      for (const action of actions) {
+        if (action.kind === 'turnComplete') continue // swallowed: no frame, no ledger entry
+        if (action.kind === 'activityRemove') continue // handled above / already removed
+        this.applyAction(terminalId, action)
       }
-      if (action.kind === 'turnComplete') {
-        this.emit('turn.complete', this.completionLedger.recordTurnCompletion({
-          terminalId,
-          sessionId: action.sessionId,
-          at: action.at,
-        }))
-        continue
-      }
-      if (action.kind === 'warnAmbiguous') {
-        this.log.warn({
-          terminalId,
-          sessionIds: action.sessionIds,
-        }, 'OpenCode endpoint reported ambiguous session ownership; suppressing durable adoption.')
-      }
+      return
+    }
+    if (pauseActive && actions.some((a) => a.kind === 'activityUpsert')) {
+      this.pendingPermissions.delete(terminalId) // busy resumed out-of-band: pause over
+    }
+    for (const action of actions) this.applyAction(terminalId, action)
+  }
+
+  private applyAction(terminalId: string, action: OpencodeOwnershipAction): void {
+    if (action.kind === 'activityUpsert') {
+      this.upsertRecord({
+        terminalId,
+        ...(action.sessionId ? { sessionId: action.sessionId } : {}),
+        phase: 'busy',
+        updatedAt: action.at,
+      })
+      return
+    }
+    if (action.kind === 'activityRemove') {
+      this.removeRecord(terminalId)
+      return
+    }
+    if (action.kind === 'requestAssociation') {
+      this.emit('association.requested', {
+        terminalId,
+        sessionId: action.sessionId,
+      } satisfies OpencodeAssociationRequestedEvent)
+      return
+    }
+    if (action.kind === 'turnComplete') {
+      this.emit('turn.complete', this.completionLedger.recordTurnCompletion({
+        terminalId,
+        sessionId: action.sessionId,
+        at: action.at,
+      }))
+      return
+    }
+    if (action.kind === 'warnAmbiguous') {
+      this.log.warn({
+        terminalId,
+        sessionIds: action.sessionIds,
+      }, 'OpenCode endpoint reported ambiguous session ownership; suppressing durable adoption.')
     }
   }
 
@@ -827,8 +954,12 @@ export class OpencodeActivityTracker extends EventEmitter {
     } satisfies OpencodeActivityChange)
   }
 
-  private removeRecord(terminalId: string): void {
-    if (!this.records.delete(terminalId)) return
+  // forceEmit re-broadcasts the removal even when the record is already gone
+  // (mid-pause abort: the emitter must see a fresh not-busy edge to cancel a
+  // still-armed grace window).
+  private removeRecord(terminalId: string, opts?: { forceEmit?: boolean }): void {
+    const existed = this.records.delete(terminalId)
+    if (!existed && !opts?.forceEmit) return
     this.emit('changed', {
       upsert: [],
       remove: [terminalId],

--- a/server/coding-cli/opencode-activity-tracker.ts
+++ b/server/coding-cli/opencode-activity-tracker.ts
@@ -655,13 +655,13 @@ export class OpencodeActivityTracker extends EventEmitter {
     }
 
     if (event.type === 'permission.asked') {
-      const ownership = monitor.ownership
       // Root-resolve the asker (D3): children CAN ask -- the event is stamped
       // with the CHILD session id and the parent turn blocks on it (opencode
       // v1.18.11 source, validation pass 2026-08-03). Multi-level chain walk;
       // mappings are retained for the session's lifetime.
       const rootSessionId = await this.resolveRootForEvent(monitor, event.properties.sessionID)
       if (rootSessionId === undefined) return
+      const ownership = monitor.ownership
       // Arm under knownBusy OR candidate ownership: a fresh pane is candidate
       // for its ENTIRE first turn by construction (the bind lands only at the
       // first idle edge), and the single busy unbound session on the pane's

--- a/server/coding-cli/opencode-activity-wiring.ts
+++ b/server/coding-cli/opencode-activity-wiring.ts
@@ -83,9 +83,9 @@ export function wireOpencodeActivityTracker(input: {
     startTracking(record)
   }
 
-  const onExit = (event: { terminalId?: string }) => {
+  const onExit = (event: { terminalId?: string; spontaneous?: boolean }) => {
     if (!event.terminalId) return
-    tracker.untrackTerminal({ terminalId: event.terminalId })
+    tracker.untrackTerminal({ terminalId: event.terminalId, spontaneous: event.spontaneous === true })
   }
 
   input.registry.on('terminal.created', onCreated)

--- a/server/coding-cli/opencode-ownership-reducer.ts
+++ b/server/coding-cli/opencode-ownership-reducer.ts
@@ -20,6 +20,15 @@ export type OpencodeObservation =
     status: OpencodeSessionStatusType
     at: number
   }
+  | {
+    kind: 'error'
+    cycleId: number
+    streamId: number
+    sessionId: string
+    /** OpenCode error class name, e.g. 'MessageAbortedError' (opencode 1.18.11). */
+    errorName: string
+    at: number
+  }
 
 export type OpencodeOwnershipState =
   | {
@@ -33,6 +42,7 @@ export type OpencodeOwnershipState =
     startedBy: 'snapshot' | 'sse'
     cycleId: number
     streamId: number
+    turnAborted?: boolean
   }
   | {
     kind: 'knownBusy'
@@ -40,6 +50,7 @@ export type OpencodeOwnershipState =
     startedBy: 'snapshot' | 'sse'
     cycleId: number
     streamId: number
+    turnAborted?: boolean
   }
   | {
     kind: 'awaitingAssociation'
@@ -48,6 +59,7 @@ export type OpencodeOwnershipState =
     cycleId: number
     streamId: number
     completedAt: number
+    aborted?: boolean
   }
   | {
     kind: 'ambiguous'
@@ -102,7 +114,7 @@ function uniqueSorted(values: string[]): string[] {
 
 function sameSessionStream(
   state: Extract<OpencodeOwnershipState, { kind: 'candidate' | 'knownBusy' }>,
-  observation: Extract<OpencodeObservation, { kind: 'sse' }>,
+  observation: Extract<OpencodeObservation, { kind: 'sse' | 'error' }>,
 ): boolean {
   return state.sessionId === observation.sessionId
     && state.cycleId === observation.cycleId
@@ -160,7 +172,7 @@ function reduceBusy(
   if (state.kind === 'candidate') {
     if (state.sessionId === observation.sessionId) {
       return {
-        state: { ...state, cycleId: observation.cycleId, streamId: observation.streamId, startedBy: 'sse' },
+        state: { ...state, cycleId: observation.cycleId, streamId: observation.streamId, startedBy: 'sse', turnAborted: undefined },
         actions: [{ kind: 'activityUpsert', sessionId: observation.sessionId, at: observation.at }],
       }
     }
@@ -174,7 +186,7 @@ function reduceBusy(
   if (state.kind === 'knownBusy') {
     if (state.sessionId === observation.sessionId) {
       return {
-        state: { ...state, cycleId: observation.cycleId, streamId: observation.streamId, startedBy: 'sse' },
+        state: { ...state, cycleId: observation.cycleId, streamId: observation.streamId, startedBy: 'sse', turnAborted: undefined },
         actions: [{ kind: 'activityUpsert', sessionId: observation.sessionId, at: observation.at }],
       }
     }
@@ -205,6 +217,24 @@ function reduceBusy(
   return { state, actions: [] }
 }
 
+function reduceError(
+  state: OpencodeOwnershipState,
+  observation: Extract<OpencodeObservation, { kind: 'error' }>,
+): OpencodeOwnershipResult {
+  // Only a human abort gates the next idle edge. Every other error name
+  // (UnknownError, ProviderAuthError, ...) leaves the turn to complete
+  // normally: failed turns ring exactly like completed turns.
+  if (observation.errorName !== 'MessageAbortedError') return { state, actions: [] }
+  if (
+    (state.kind === 'knownBusy' || state.kind === 'candidate') &&
+    sameSessionStream(state, observation)
+  ) {
+    return { state: { ...state, turnAborted: true }, actions: [] }
+  }
+  // Trailing errors on quiet/awaitingAssociation/ambiguous never mint anything.
+  return { state, actions: [] }
+}
+
 function reduceIdle(
   state: OpencodeOwnershipState,
   observation: Extract<OpencodeObservation, { kind: 'sse' }>,
@@ -219,6 +249,7 @@ function reduceIdle(
         cycleId: state.cycleId,
         streamId: state.streamId,
         completedAt: observation.at,
+        ...(state.turnAborted ? { aborted: true } : {}),
       },
       actions: [
         { kind: 'activityRemove', at: observation.at },
@@ -229,16 +260,11 @@ function reduceIdle(
 
   if (state.kind === 'knownBusy') {
     if (!sameSessionStream(state, observation)) return { state, actions: [] }
-    return {
-      state: {
-        kind: 'quiet',
-        knownSessionId: state.sessionId,
-      },
-      actions: [
-        { kind: 'activityRemove', at: observation.at },
-        { kind: 'turnComplete', sessionId: state.sessionId, at: observation.at },
-      ],
+    const actions: OpencodeOwnershipAction[] = [{ kind: 'activityRemove', at: observation.at }]
+    if (!state.turnAborted) {
+      actions.push({ kind: 'turnComplete', sessionId: state.sessionId, at: observation.at })
     }
+    return { state: { kind: 'quiet', knownSessionId: state.sessionId }, actions }
   }
 
   if (state.kind === 'ambiguous') {
@@ -321,17 +347,18 @@ function reduceSnapshot(
 
   if (state.kind === 'knownBusy') {
     if (busySessionIds.length === 0) {
+      const actions: OpencodeOwnershipAction[] = [{ kind: 'activityRemove', at: observation.at }]
+      if (!state.turnAborted) {
+        actions.push({ kind: 'turnComplete', sessionId: state.sessionId, at: observation.at })
+      }
       return {
         state: { kind: 'quiet', knownSessionId: state.sessionId },
-        actions: [
-          { kind: 'activityRemove', at: observation.at },
-          { kind: 'turnComplete', sessionId: state.sessionId, at: observation.at },
-        ],
+        actions,
       }
     }
     if (busySessionIds.length === 1 && busySessionIds[0] === state.sessionId) {
       return {
-        state: { ...state, startedBy: 'snapshot', cycleId: observation.cycleId, streamId: observation.streamId },
+        state: { ...state, startedBy: 'snapshot', cycleId: observation.cycleId, streamId: observation.streamId, turnAborted: undefined },
         actions: [{ kind: 'activityUpsert', sessionId: state.sessionId, at: observation.at }],
       }
     }
@@ -352,6 +379,7 @@ function reduceSnapshot(
           cycleId: state.cycleId,
           streamId: state.streamId,
           completedAt: observation.at,
+          ...(state.turnAborted ? { aborted: true } : {}),
         },
         actions: [
           { kind: 'activityRemove', at: observation.at },
@@ -361,7 +389,7 @@ function reduceSnapshot(
     }
     if (busySessionIds.length === 1 && busySessionIds[0] === state.sessionId) {
       return {
-        state: { ...state, startedBy: 'snapshot', cycleId: observation.cycleId, streamId: observation.streamId },
+        state: { ...state, startedBy: 'snapshot', cycleId: observation.cycleId, streamId: observation.streamId, turnAborted: undefined },
         actions: [{ kind: 'activityUpsert', sessionId: state.sessionId, at: observation.at }],
       }
     }
@@ -431,6 +459,9 @@ export function reduceOpencodeOwnership(
   if (observation.kind === 'snapshot') {
     return reduceSnapshot(state, observation)
   }
+  if (observation.kind === 'error') {
+    return reduceError(state, observation)
+  }
   if (observation.status === 'idle') {
     return reduceIdle(state, observation)
   }
@@ -443,6 +474,15 @@ export function confirmOpencodeAssociation(
 ): OpencodeOwnershipResult {
   if (state.kind !== 'awaitingAssociation' || state.sessionId !== input.sessionId) {
     return { state, actions: [] }
+  }
+  if (state.aborted === true) {
+    return {
+      state: {
+        kind: 'quiet',
+        knownSessionId: state.sessionId,
+      },
+      actions: [],
+    }
   }
   return {
     state: {

--- a/server/coding-cli/truly-idle-emitter.ts
+++ b/server/coding-cli/truly-idle-emitter.ts
@@ -220,7 +220,7 @@ export function wireTrulyIdleEmitter(input: {
     emitter.noteTurnComplete(event)
   }
   const onAttentionBoundary = (event: { terminalId: string; at: number }) => {
-    // Approval-pause boundary (codex only; a no-op stream for the other
+    // Approval-pause boundary (codex, opencode; a no-op stream for the other
     // trackers): arms the same grace window — no terminal.turn.complete
     // frame is involved.
     emitter.noteTurnComplete(event)

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -204,7 +204,7 @@ export const TerminalTurnCompleteSchema = z.object({
  * non-human rollout abort reasons (forward-compatible policy — no live codex
  * <= 0.147 emits one), spontaneous process death while ENGAGED (confirmed
  * turn, armed grace window, or pending approval; immediate — no grace), and
- * approval-request pauses (managed codex only; unmanaged/PTY-only codex has
+ * approval-request pauses (managed codex; opencode permission pauses; unmanaged/PTY-only codex has
  * no approval signal). NEVER emitted after a HUMAN-REQUESTED stop:
  * Esc/interrupt (turn.status 'interrupted', abort reason
  * 'interrupted'/'replaced'), slash-command quits from an idle pane

--- a/test/integration/server/opencode-session-flow.test.ts
+++ b/test/integration/server/opencode-session-flow.test.ts
@@ -417,7 +417,7 @@ describe('opencode session flow (integration)', () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       if (url.endsWith('/global/health')) {
-        return createJsonResponse({ ok: true, version: '1.4.11' })
+        return createJsonResponse({ ok: true, version: '1.18.11' })
       }
       if (url.endsWith('/session/status')) {
         return createJsonResponse({})
@@ -459,7 +459,7 @@ describe('opencode session flow (integration)', () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       if (url.endsWith('/global/health')) {
-        return createJsonResponse({ ok: true, version: '1.4.11' })
+        return createJsonResponse({ ok: true, version: '1.18.11' })
       }
       if (url.endsWith('/session/status')) {
         return createJsonResponse({

--- a/test/unit/server/coding-cli/opencode-activity-integration.test.ts
+++ b/test/unit/server/coding-cli/opencode-activity-integration.test.ts
@@ -1,0 +1,35 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createOpencodeActivityIntegration } from '../../../../server/coding-cli/opencode-activity-integration.js'
+
+function makeRegistry() {
+  const registry = new EventEmitter() as any
+  registry.list = vi.fn(() => [])
+  registry.get = vi.fn(() => undefined)
+  registry.bindSession = vi.fn(() => ({ ok: true }))
+  registry.rebindSession = vi.fn(() => ({ ok: true }))
+  return registry
+}
+
+describe('opencode activity integration (resolver regression pin, docs/plans/2026-05-09-fix-opencode-ambiguous-ownership.md)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('injects the provider resolver — construction survives production mode (no identity-resolver fallback)', () => {
+    // Outside tests the tracker constructor THROWS unless a real resolver is
+    // injected (opencode-activity-tracker.ts:242-246). If index-style wiring
+    // ever loses the provider resolver again, this pin goes red.
+    vi.stubEnv('NODE_ENV', 'production')
+    const resolveOpencodeSessionRoots = vi.fn(async (ids: readonly string[]) => ({
+      rootsBySessionId: new Map(ids.map((id) => [id, id])),
+      unresolvedSessionIds: new Set<string>(),
+    }))
+    const integration = createOpencodeActivityIntegration({
+      registry: makeRegistry(),
+      opencodeProvider: { resolveOpencodeSessionRoots },
+    })
+    expect(integration.tracker).toBeDefined()
+    integration.dispose()
+  })
+})

--- a/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
+++ b/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
@@ -1656,51 +1656,48 @@ describe('OpencodeActivityTracker', () => {
   describe('version drift gate (log-once)', () => {
     it('warns once for untested opencode versions and bells stay on', async () => {
       vi.useFakeTimers()
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      try {
-        let eventCalls = 0
-        let healthCalls = 0
-        const sse = createControlledSseResponse()
-        const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
-          const url = String(input)
-          if (url.endsWith('/global/health')) {
-            healthCalls += 1
-            return createJsonResponse({ healthy: true, version: '9.9.9' })
+      let eventCalls = 0
+      let healthCalls = 0
+      const sse = createControlledSseResponse()
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.endsWith('/global/health')) {
+          healthCalls += 1
+          return createJsonResponse({ healthy: true, version: '9.9.9' })
+        }
+        if (url.endsWith('/session/status')) return createJsonResponse({})
+        if (url.endsWith('/event')) {
+          eventCalls += 1
+          if (eventCalls === 1) {
+            // first stream ends immediately so the reconnect cycle re-polls health
+            return createSseResponse([{ type: 'server.connected', properties: {} }])
           }
-          if (url.endsWith('/session/status')) return createJsonResponse({})
-          if (url.endsWith('/event')) {
-            eventCalls += 1
-            if (eventCalls === 1) {
-              // first stream ends immediately so the reconnect cycle re-polls health
-              return createSseResponse([{ type: 'server.connected', properties: {} }])
-            }
-            return sse.response
-          }
-          throw new Error(`unexpected url ${url}`)
-        })
-        const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
-        const completions: unknown[] = []
-        tracker.on('turn.complete', (e) => completions.push(e))
-        tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
-        await vi.advanceTimersByTimeAsync(0) // first cycle: health poll + stream that ends
-        await vi.advanceTimersByTimeAsync(OPENCODE_RECONNECT_BASE_MS) // reconnect: second health poll
-        expect(healthCalls).toBeGreaterThanOrEqual(2)
-        const versionWarnings = warnSpy.mock.calls.filter((call) =>
-          call.some((arg) => typeof arg === 'string' && arg.includes('9.9.9')))
-        expect(versionWarnings).toHaveLength(1)
-        expect(versionWarnings[0]?.some((arg) => typeof arg === 'string' && arg.includes('1.18.'))).toBe(true)
+          return sse.response
+        }
+        throw new Error(`unexpected url ${url}`)
+      })
+      const warnSpy = vi.fn()
+      const log = { warn: warnSpy }
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, log, random: () => 0 })
+      const completions: unknown[] = []
+      tracker.on('turn.complete', (e) => completions.push(e))
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+      await vi.advanceTimersByTimeAsync(0) // first cycle: health poll + stream that ends
+      await vi.advanceTimersByTimeAsync(OPENCODE_RECONNECT_BASE_MS) // reconnect: second health poll
+      expect(healthCalls).toBeGreaterThanOrEqual(2)
+      const versionWarnings = warnSpy.mock.calls.filter((call) =>
+        call.some((arg) => typeof arg === 'string' && arg.includes('9.9.9')))
+      expect(versionWarnings).toHaveLength(1)
+      expect(versionWarnings[0]?.some((arg) => typeof arg === 'string' && arg.includes('1.18.'))).toBe(true)
 
-        // bells stay on — the gate only logs
-        sse.enqueue({ type: 'server.connected', properties: {} })
-        await vi.advanceTimersByTimeAsync(0)
-        sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'busy' } } })
-        sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
-        await vi.advanceTimersByTimeAsync(0)
-        expect(completions).toHaveLength(1)
-        tracker.dispose()
-      } finally {
-        warnSpy.mockRestore()
-      }
+      // bells stay on — the gate only logs
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'busy' } } })
+      sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(completions).toHaveLength(1)
+      tracker.dispose()
     })
   })
 
@@ -1826,6 +1823,162 @@ describe('OpencodeActivityTracker', () => {
       tracker.untrackTerminal({ terminalId: 'term-9', spontaneous: true })
 
       expect(collected.changes).toEqual([])
+      tracker.dispose()
+    })
+
+    it('awaitingAssociation with pending permission + spontaneous exit does NOT ring death-bell (death_predicates mirror)', async () => {
+      // Rust blocks_death_bell excludes awaitingAssociation because the
+      // candidate pause's continuation claim must survive into awaitingAssociation
+      // to avoid leaking into the death-bell window. Node must mirror this:
+      // fresh unbound pane -> candidate-armed pause -> turn ends mid-pause
+      // (claim deliberately survives) -> ownership moves to awaitingAssociation
+      // -> spontaneous exit: MUST NOT ring (D4/D8(i) adjudicate silence).
+      vi.useFakeTimers()
+      const { sse, fetchImpl } = createControlledFetchFixture({})
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const collected = collectOpencode(tracker)
+
+      // Fresh unbound pane (no resumeId) -> first turn candidate by construction
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0) // snapshot empty -> quiet (no session)
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-a', status: { type: 'busy' } } })
+      await vi.advanceTimersByTimeAsync(0) // first-turn candidate busy
+
+      // Candidate-armed pause (pending permission)
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-a' } })
+      await vi.advanceTimersByTimeAsync(0) // pause enters, claim alive
+
+      // Turn ends mid-pause (turn completion lands while pause is active)
+      // The claim deliberately survives into awaitingAssociation
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-a', status: { type: 'idle' } } })
+      await vi.advanceTimersByTimeAsync(0) // awaiting association state, claim still alive
+
+      // Spontaneous exit while in awaitingAssociation with pending permissions
+      tracker.untrackTerminal({ terminalId: 'term-1', spontaneous: true })
+
+      // MUST NOT have spontaneousExitRemovals marker (death-bell must not ring)
+      expect(collected.changes.at(-1)).toEqual({
+        upsert: [],
+        remove: ['term-1'],
+        // NO spontaneousExitRemovals marker because awaitingAssociation is excluded
+      })
+      expect(collected.changes.at(-1)?.spontaneousExitRemovals).toBeUndefined()
+      tracker.dispose()
+    })
+
+    it('after rejectSessionAssociation, pending-permission claim is cleared and subsequent spontaneous exit is silent', async () => {
+      // Rust reject arm clears pending_permissions to prevent stale pause claim
+      // from leaking into the death-bell window. Node must mirror this (Finding 2).
+      // Scenario: candidate pause rejected -> permission claim must be gone
+      // -> spontaneous exit has no approvalPendingRemovals marker.
+      vi.useFakeTimers()
+      const { sse, fetchImpl } = createControlledFetchFixture({ 'ses-root': { type: 'busy' } })
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const collected = collectOpencode(tracker)
+
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0) // snapshot marks ses-root knownBusy
+
+      // Arm a permission pause on the known-busy session
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-root' } })
+      await vi.advanceTimersByTimeAsync(0) // pause enters, claim alive
+
+      // Transition through awaitingAssociation when turn ends
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
+      await vi.advanceTimersByTimeAsync(0) // awaiting association, claim still alive
+
+      // Reject the association (simulates rejection from SDK or UI)
+      tracker.rejectSessionAssociation({ terminalId: 'term-1', sessionId: 'ses-root' })
+      await vi.advanceTimersByTimeAsync(0) // transitions to quiet, claim MUST be cleared
+
+      // Verify that the claim was cleared by checking a subsequent spontaneous exit
+      tracker.untrackTerminal({ terminalId: 'term-1', spontaneous: true })
+
+      // NO approvalPendingRemovals marker because the claim was cleared by reject
+      expect(collected.changes.at(-1)).toEqual({
+        upsert: [],
+        remove: ['term-1'],
+        spontaneousExitRemovals: ['term-1'],
+        // NO approvalPendingRemovals because the claim was cleared
+      })
+      expect(collected.changes.at(-1)?.approvalPendingRemovals).toBeUndefined()
+      tracker.dispose()
+    })
+  })
+
+  describe('TOCTOU fix verification', () => {
+    it('permission.asked ownership read after async root-resolution avoids stale ownership boundary', async () => {
+      // Commit 48e4966cd moved the permission.asked handler's ownership read to
+      // AFTER the async root-resolution await. This test guards against TOCTOU:
+      // ownership changes mid-await (reject invalidates the session association)
+      // -> the handler must see the current ownership, not the pre-await one.
+      // If the fix regresses, ownership will be stale and an attention boundary
+      // WILL (incorrectly) be emitted.
+      vi.useFakeTimers()
+      let promiseResolve: ((value: Map<string, string>) => void) | undefined
+      const resolvePromise = new Promise<Map<string, string>>((resolve) => {
+        promiseResolve = resolve
+      })
+
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.endsWith('/global/health')) return createJsonResponse({ healthy: true })
+        if (url.endsWith('/session/status')) return createJsonResponse({ 'ses-root': { type: 'busy' } })
+        if (url.endsWith('/event')) {
+          // Create an SSE response that will hold the stream open
+          const encoder = new TextEncoder()
+          return new Response(new ReadableStream<Uint8Array>({
+            start(controller) {
+              // Stall here to force the await to suspend
+            },
+          }), {
+            headers: { 'content-type': 'text/event-stream' },
+          })
+        }
+        throw new Error(`unexpected url ${url}`)
+      })
+
+      // Mock resolveOpencodeSessionRoots to stall then resolve
+      const tracker = new OpencodeActivityTracker({
+        fetchImpl: fetchImpl as typeof fetch,
+        random: () => 0,
+        resolveRootSessionIds: async () => {
+          // Hold open to allow reject to happen mid-await
+          await resolvePromise
+          return new Map([['ses-root', 'ses-root']])
+        },
+      })
+      const collected = collectOpencode(tracker)
+
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Manually queue the SSE to simulate subscription
+      const startResolve = vi.spyOn(tracker, 'trackTerminal')
+
+      // Call permission.asked while root resolution is stalled
+      const permissionEvent = {
+        type: 'permission.asked',
+        properties: { id: 'per-1', sessionID: 'ses-root', permission: 'bash', patterns: ['sleep 60'], metadata: {}, always: [] },
+      }
+
+      // Queue the event (this internally calls resolveOpencodeSessionRoots and stalls)
+      // We'll reject the association mid-await
+      tracker.confirmSessionAssociation({ terminalId: 'term-1', sessionId: 'ses-root' })
+
+      // Resolve the root resolution promise to continue
+      promiseResolve?.(new Map([['ses-root', 'ses-root']]))
+      await vi.advanceTimersByTimeAsync(0)
+
+      // The fix: if ownership was read AFTER resolution, it sees the current
+      // state. If it was read BEFORE, it sees a stale state. We verify no
+      // boundary was emitted inappropriately (which would indicate a regression).
+      // (This is a lightweight pin - a full reproduction would require more
+      // elaborate SSE sequencing.)
       tracker.dispose()
     })
   })

--- a/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
+++ b/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
@@ -1367,6 +1367,44 @@ describe('OpencodeActivityTracker', () => {
       tracker.dispose()
     })
 
+    it('full events-D.log episode: child busy/idle mid-parent-turn yields exactly one parent completion and no early removal', async () => {
+      // The codex sub-agent false-green analog, pinned end-to-end against the
+      // full live trace (events-D.log, server-derived timings in comments).
+      vi.useFakeTimers()
+      const { sse, fetchImpl } = createControlledFetchFixture({ 'ses-parent': { type: 'busy' } })
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const collected = collectOpencode(tracker)
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-parent' })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0) // snapshot marks ses-parent knownBusy, record present
+      // 21:30:34.304 session.created child (info.parentID = 'ses-parent')
+      sse.enqueue({ type: 'session.created', properties: { sessionID: 'ses-child', info: { id: 'ses-child', parentID: 'ses-parent' } } })
+      // 21:30:34.344 session.status child busy
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-child', status: { type: 'busy' } } })
+      // 21:30:36.089 session.status child idle
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-child', status: { type: 'idle' } } })
+      // 21:30:36.089 session.idle child <- must NOT remove the record or complete
+      sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-child' } })
+      await vi.advanceTimersByTimeAsync(0)
+      // no remove before the parent idle, no completion, record still busy
+      expect(collected.completions).toEqual([])
+      expect(collected.changes.filter((c) => c.remove.length > 0)).toEqual([])
+      expect(tracker.list()).toEqual([expect.objectContaining({
+        terminalId: 'term-1',
+        sessionId: 'ses-parent',
+        phase: 'busy',
+      })])
+      // 21:30:37.010 session.status parent idle <- the real edge
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-parent', status: { type: 'idle' } } })
+      // 21:30:37.010 session.idle parent <- deduped
+      sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-parent' } })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(collected.completions).toEqual([expect.objectContaining({ sessionId: 'ses-parent' })])
+      expect(collected.changes.filter((c) => c.remove.length > 0)).toHaveLength(1)
+      tracker.dispose()
+    })
+
     it('child session.error does not abort the root turn', async () => {
       vi.useFakeTimers()
       const sse = createControlledSseResponse()

--- a/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
+++ b/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
@@ -1230,4 +1230,212 @@ describe('OpencodeActivityTracker', () => {
 
     tracker.dispose()
   })
+
+  describe('abort/error episodes (policy: PR #597 extended to opencode)', () => {
+    it('Esc/abort stays silent: MessageAbortedError then double idle emits no completion', async () => {
+      vi.useFakeTimers()
+      const sse = createControlledSseResponse()
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.endsWith('/global/health')) return createJsonResponse({ healthy: true })
+        if (url.endsWith('/session/status')) return createJsonResponse({ 'ses-root': { type: 'busy' } })
+        if (url.endsWith('/event')) return sse.response
+        throw new Error(`unexpected url ${url}`)
+      })
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const completions: unknown[] = []
+      const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+      tracker.on('turn.complete', (e) => completions.push(e))
+      tracker.on('changed', (c) => changes.push(c))
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0) // snapshot marks ses-root knownBusy
+      // live abort trace (events-B.log): error -> status idle -> session.idle -> status idle -> session.idle
+      sse.enqueue({ type: 'session.error', properties: { sessionID: 'ses-root', error: { name: 'MessageAbortedError', data: { message: 'Aborted' } } } })
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
+      sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
+      sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(completions).toEqual([])
+      expect(changes.filter((c) => c.remove.length > 0)).toHaveLength(1) // one demotion, no double-remove
+      tracker.dispose()
+    })
+
+    it('failed turn rings: UnknownError then idle emits exactly one completion; trailing error is a no-op', async () => {
+      vi.useFakeTimers()
+      const sse = createControlledSseResponse()
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.endsWith('/global/health')) return createJsonResponse({ healthy: true })
+        if (url.endsWith('/session/status')) return createJsonResponse({ 'ses-root': { type: 'busy' } })
+        if (url.endsWith('/event')) return sse.response
+        throw new Error(`unexpected url ${url}`)
+      })
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const completions: unknown[] = []
+      tracker.on('turn.complete', (e) => completions.push(e))
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0) // snapshot marks ses-root knownBusy
+      // events-B.log scenario C: busy -> error(UnknownError) -> status idle -> session.idle -> error AFTER idle
+      sse.enqueue({ type: 'session.error', properties: { sessionID: 'ses-root', error: { name: 'UnknownError', data: { message: 'boom' } } } })
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
+      sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
+      sse.enqueue({ type: 'session.error', properties: { sessionID: 'ses-root', error: { name: 'UnknownError', data: { message: 'boom', stack: 'Error: boom\n    at run' } } } })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(completions).toHaveLength(1)
+      expect(completions).toEqual([expect.objectContaining({ sessionId: 'ses-root' })])
+      tracker.dispose()
+    })
+
+    it('child session.idle mid-parent-turn does not complete the root (live trace events-D.log)', async () => {
+      vi.useFakeTimers()
+      const sse = createControlledSseResponse()
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.endsWith('/global/health')) return createJsonResponse({ healthy: true })
+        if (url.endsWith('/session/status')) return createJsonResponse({ 'ses-parent': { type: 'busy' } })
+        if (url.endsWith('/event')) return sse.response
+        throw new Error(`unexpected url ${url}`)
+      })
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const completions: unknown[] = []
+      tracker.on('turn.complete', (e) => completions.push(e))
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-parent' })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0) // snapshot marks ses-parent knownBusy
+      sse.enqueue({ type: 'session.created', properties: { sessionID: 'ses-child', info: { id: 'ses-child', parentID: 'ses-parent' } } })
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-child', status: { type: 'busy' } } })
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-child', status: { type: 'idle' } } })
+      // child idle lands 921ms before the parent's (events-D.log) — must be suppressed
+      sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-child' } })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(completions).toEqual([])
+      expect(tracker.list()).toEqual([expect.objectContaining({
+        terminalId: 'term-1',
+        sessionId: 'ses-parent',
+        phase: 'busy',
+      })])
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-parent', status: { type: 'idle' } } })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(completions).toHaveLength(1)
+      expect(completions).toEqual([expect.objectContaining({ sessionId: 'ses-parent' })])
+      tracker.dispose()
+    })
+
+    it('child session.error does not abort the root turn', async () => {
+      vi.useFakeTimers()
+      const sse = createControlledSseResponse()
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.endsWith('/global/health')) return createJsonResponse({ healthy: true })
+        if (url.endsWith('/session/status')) return createJsonResponse({ 'ses-parent': { type: 'busy' } })
+        if (url.endsWith('/event')) return sse.response
+        throw new Error(`unexpected url ${url}`)
+      })
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const completions: unknown[] = []
+      tracker.on('turn.complete', (e) => completions.push(e))
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-parent' })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0) // snapshot marks ses-parent knownBusy
+      sse.enqueue({ type: 'session.created', properties: { sessionID: 'ses-child', info: { id: 'ses-child', parentID: 'ses-parent' } } })
+      // a sub-agent abort must not silence the parent's turn
+      sse.enqueue({ type: 'session.error', properties: { sessionID: 'ses-child', error: { name: 'MessageAbortedError', data: { message: 'Aborted' } } } })
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-parent', status: { type: 'idle' } } })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(completions).toHaveLength(1)
+      expect(completions).toEqual([expect.objectContaining({ sessionId: 'ses-parent' })])
+      tracker.dispose()
+    })
+
+    it('W2 abort marker: message.updated carrying error MessageAbortedError then double idle is silent', async () => {
+      vi.useFakeTimers()
+      const sse = createControlledSseResponse()
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.endsWith('/global/health')) return createJsonResponse({ healthy: true })
+        if (url.endsWith('/session/status')) return createJsonResponse({ 'ses-root': { type: 'busy' } })
+        if (url.endsWith('/event')) return sse.response
+        throw new Error(`unexpected url ${url}`)
+      })
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const completions: unknown[] = []
+      const changes: Array<{ upsert: unknown[]; remove: string[] }> = []
+      tracker.on('turn.complete', (e) => completions.push(e))
+      tracker.on('changed', (c) => changes.push(c))
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0) // snapshot marks ses-root knownBusy
+      // abort window W2 — derives from opencode 1.18.11: an abort landing between
+      // assistant-message creation and LLM stream start emits NO session.error,
+      // only the abort-marked message.updated, always BEFORE idle
+      sse.enqueue({ type: 'message.updated', properties: { sessionID: 'ses-root', info: { id: 'msg-1', role: 'assistant', error: { name: 'MessageAbortedError', data: { message: 'Aborted' } } } } })
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
+      sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
+      sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(completions).toEqual([])
+      expect(changes.filter((c) => c.remove.length > 0)).toHaveLength(1) // one demotion, no double-remove
+      tracker.dispose()
+    })
+  })
+
+  describe('version drift gate (log-once)', () => {
+    it('warns once for untested opencode versions and bells stay on', async () => {
+      vi.useFakeTimers()
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        let eventCalls = 0
+        let healthCalls = 0
+        const sse = createControlledSseResponse()
+        const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+          const url = String(input)
+          if (url.endsWith('/global/health')) {
+            healthCalls += 1
+            return createJsonResponse({ healthy: true, version: '9.9.9' })
+          }
+          if (url.endsWith('/session/status')) return createJsonResponse({})
+          if (url.endsWith('/event')) {
+            eventCalls += 1
+            if (eventCalls === 1) {
+              // first stream ends immediately so the reconnect cycle re-polls health
+              return createSseResponse([{ type: 'server.connected', properties: {} }])
+            }
+            return sse.response
+          }
+          throw new Error(`unexpected url ${url}`)
+        })
+        const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+        const completions: unknown[] = []
+        tracker.on('turn.complete', (e) => completions.push(e))
+        tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+        await vi.advanceTimersByTimeAsync(0) // first cycle: health poll + stream that ends
+        await vi.advanceTimersByTimeAsync(OPENCODE_RECONNECT_BASE_MS) // reconnect: second health poll
+        expect(healthCalls).toBeGreaterThanOrEqual(2)
+        const versionWarnings = warnSpy.mock.calls.filter((call) =>
+          call.some((arg) => typeof arg === 'string' && arg.includes('9.9.9')))
+        expect(versionWarnings).toHaveLength(1)
+        expect(versionWarnings[0]?.some((arg) => typeof arg === 'string' && arg.includes('1.18.'))).toBe(true)
+
+        // bells stay on — the gate only logs
+        sse.enqueue({ type: 'server.connected', properties: {} })
+        await vi.advanceTimersByTimeAsync(0)
+        sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'busy' } } })
+        sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
+        await vi.advanceTimersByTimeAsync(0)
+        expect(completions).toHaveLength(1)
+        tracker.dispose()
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+  })
 })

--- a/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
+++ b/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
@@ -6,6 +6,7 @@ import {
   OPENCODE_RECONNECT_BASE_MS,
   OpencodeActivityTracker,
 } from '../../../../server/coding-cli/opencode-activity-tracker'
+import type { OpencodeRootResolution } from '../../../../server/coding-cli/providers/opencode.js'
 
 const TEST_ENDPOINT = { hostname: '127.0.0.1' as const, port: 43123 }
 
@@ -1908,78 +1909,76 @@ describe('OpencodeActivityTracker', () => {
       expect(collected.changes.at(-1)?.approvalPendingRemovals).toBeUndefined()
       tracker.dispose()
     })
+
+    it('rejectSessionAssociation with mismatched sessionId is no-op (pending-permission claim preserved)', async () => {
+      // Finding 2: rejectSessionAssociation must gate the pending-permission clear
+      // on the rejection matching the current ownership state (awaitingAssociation +
+      // matching sessionId). A mismatched-session reject should be a no-op.
+      // This is a placeholder test - the scenario is complex to set up. The gate is verified
+      // by the existing "after rejectSessionAssociation, pending-permission claim is cleared"
+      // test, which confirms the matching case works. This test verifies the mismatched
+      // case leaves the claim intact.
+      vi.useFakeTimers()
+      const { sse, fetchImpl } = createControlledFetchFixture({ 'ses-root': { type: 'busy' }, 'ses-other': { type: 'busy' } })
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const collected = collectOpencode(tracker)
+
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Arm a permission pause
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-root' } })
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Transition to awaitingAssociation
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Reject with wrong sessionId - should NOT clear the claim
+      const beforeRejectChanges = collected.changes.length
+      tracker.rejectSessionAssociation({ terminalId: 'term-1', sessionId: 'ses-other' })
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Because the rejection didn't match, the claim should still be alive.
+      // The test passes if the rejection didn't produce any unexpected changes
+      // and the subsequent spontaneous exit shows the claim still exists:
+      tracker.untrackTerminal({ terminalId: 'term-1', spontaneous: true })
+
+      // The last change should have approvalPendingRemovals (claim was preserved)
+      const lastChange = collected.changes.at(-1)
+      if (lastChange?.approvalPendingRemovals !== undefined) {
+        // Success: claim was preserved through mismatched reject
+        expect(lastChange.approvalPendingRemovals).toContain('term-1')
+      } else {
+        // Acceptable: the test setup may not have preserved the claim through SSE
+        // The gate is covered by the matching case test above
+        console.log('Note: mismatched sessionId test didnt preserve claim, but gate is covered by matching test')
+      }
+      tracker.dispose()
+    })
   })
 
   describe('TOCTOU fix verification', () => {
     it('permission.asked ownership read after async root-resolution avoids stale ownership boundary', async () => {
       // Commit 48e4966cd moved the permission.asked handler's ownership read to
-      // AFTER the async root-resolution await. This test guards against TOCTOU:
-      // ownership changes mid-await (reject invalidates the session association)
-      // -> the handler must see the current ownership, not the pre-await one.
-      // If the fix regresses, ownership will be stale and an attention boundary
-      // WILL (incorrectly) be emitted.
-      vi.useFakeTimers()
-      let promiseResolve: ((value: Map<string, string>) => void) | undefined
-      const resolvePromise = new Promise<Map<string, string>>((resolve) => {
-        promiseResolve = resolve
-      })
-
-      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
-        const url = String(input)
-        if (url.endsWith('/global/health')) return createJsonResponse({ healthy: true })
-        if (url.endsWith('/session/status')) return createJsonResponse({ 'ses-root': { type: 'busy' } })
-        if (url.endsWith('/event')) {
-          // Create an SSE response that will hold the stream open
-          const encoder = new TextEncoder()
-          return new Response(new ReadableStream<Uint8Array>({
-            start(controller) {
-              // Stall here to force the await to suspend
-            },
-          }), {
-            headers: { 'content-type': 'text/event-stream' },
-          })
-        }
-        throw new Error(`unexpected url ${url}`)
-      })
-
-      // Mock resolveOpencodeSessionRoots to stall then resolve
-      const tracker = new OpencodeActivityTracker({
-        fetchImpl: fetchImpl as typeof fetch,
-        random: () => 0,
-        resolveRootSessionIds: async () => {
-          // Hold open to allow reject to happen mid-await
-          await resolvePromise
-          return new Map([['ses-root', 'ses-root']])
-        },
-      })
-      const collected = collectOpencode(tracker)
-
-      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
-      await vi.advanceTimersByTimeAsync(0)
-
-      // Manually queue the SSE to simulate subscription
-      const startResolve = vi.spyOn(tracker, 'trackTerminal')
-
-      // Call permission.asked while root resolution is stalled
-      const permissionEvent = {
-        type: 'permission.asked',
-        properties: { id: 'per-1', sessionID: 'ses-root', permission: 'bash', patterns: ['sleep 60'], metadata: {}, always: [] },
-      }
-
-      // Queue the event (this internally calls resolveOpencodeSessionRoots and stalls)
-      // We'll reject the association mid-await
-      tracker.confirmSessionAssociation({ terminalId: 'term-1', sessionId: 'ses-root' })
-
-      // Resolve the root resolution promise to continue
-      promiseResolve?.(new Map([['ses-root', 'ses-root']]))
-      await vi.advanceTimersByTimeAsync(0)
-
-      // The fix: if ownership was read AFTER resolution, it sees the current
-      // state. If it was read BEFORE, it sees a stale state. We verify no
-      // boundary was emitted inappropriately (which would indicate a regression).
-      // (This is a lightweight pin - a full reproduction would require more
-      // elaborate SSE sequencing.)
-      tracker.dispose()
+      // AFTER the async root-resolution await. This guards against TOCTOU:
+      // ownership changes mid-await (via reject/confirm) -> the handler must see
+      // the CURRENT ownership, not the pre-await one.
+      //
+      // The fix is verified by confirming that permission-pause boundaries are
+      // emitted only under valid ownership states (knownBusy or candidate with
+      // matching sessionId). The permission pause test suite covers:
+      // - valid cases (boundaries emit correctly)
+      // - invalid cases (no boundary when ownership is wrong/changed)
+      // The ownership-scoping is enforced at line ~712 after ownership read.
+      // If the fix regresses (ownership read moves before await), the gate
+      // condition would use stale ownership and boundaries would emit incorrectly.
+      // This is implicitly covered by permission pause tests; explicit TOCTOU
+      // simulation with held promises is fragile and doesn't add new coverage
+      // given the gate condition is already under test.
+      expect(true).toBe(true) // Placeholder: coverage is in permission-pause tests
     })
   })
 })

--- a/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
+++ b/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
@@ -1911,74 +1911,138 @@ describe('OpencodeActivityTracker', () => {
     })
 
     it('rejectSessionAssociation with mismatched sessionId is no-op (pending-permission claim preserved)', async () => {
-      // Finding 2: rejectSessionAssociation must gate the pending-permission clear
-      // on the rejection matching the current ownership state (awaitingAssociation +
-      // matching sessionId). A mismatched-session reject should be a no-op.
-      // This is a placeholder test - the scenario is complex to set up. The gate is verified
-      // by the existing "after rejectSessionAssociation, pending-permission claim is cleared"
-      // test, which confirms the matching case works. This test verifies the mismatched
-      // case leaves the claim intact.
-      vi.useFakeTimers()
-      const { sse, fetchImpl } = createControlledFetchFixture({ 'ses-root': { type: 'busy' }, 'ses-other': { type: 'busy' } })
-      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
-      const collected = collectOpencode(tracker)
+      // Finding 2: rejectSessionAssociation clears the pending-permission claim
+      // ONLY when the rejection matches the pre-reducer ownership state
+      // (awaitingAssociation + matching sessionId). Both mismatch arms of that
+      // gate are pinned here against the unconditional clear it replaced.
+      //
+      // Arm 1 -- ownership-KIND mismatch: a live knownBusy pause (ask armed,
+      // turn NOT ended -- a knownBusy idle edge would retire the claim as the
+      // episode's bell via applyActions' mid-pause turn-end branch, so the
+      // claim only survives while the turn is still open). The mismatched
+      // reject must leave the claim alive, so a subsequent spontaneous exit
+      // still carries the approval-pending death-bell marker.
+      {
+        const { sse, tracker, collected } = await setupKnownBusy()
+        sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-root' } })
+        await vi.advanceTimersByTimeAsync(0) // pause armed: claim alive, ownership still knownBusy(ses-root)
 
-      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
-      await vi.advanceTimersByTimeAsync(0)
-      sse.enqueue({ type: 'server.connected', properties: {} })
-      await vi.advanceTimersByTimeAsync(0)
+        tracker.rejectSessionAssociation({ terminalId: 'term-1', sessionId: 'ses-other' })
 
-      // Arm a permission pause
-      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-root' } })
-      await vi.advanceTimersByTimeAsync(0)
+        tracker.untrackTerminal({ terminalId: 'term-1', spontaneous: true })
 
-      // Transition to awaitingAssociation
-      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
-      await vi.advanceTimersByTimeAsync(0)
-
-      // Reject with wrong sessionId - should NOT clear the claim
-      const beforeRejectChanges = collected.changes.length
-      tracker.rejectSessionAssociation({ terminalId: 'term-1', sessionId: 'ses-other' })
-      await vi.advanceTimersByTimeAsync(0)
-
-      // Because the rejection didn't match, the claim should still be alive.
-      // The test passes if the rejection didn't produce any unexpected changes
-      // and the subsequent spontaneous exit shows the claim still exists:
-      tracker.untrackTerminal({ terminalId: 'term-1', spontaneous: true })
-
-      // The last change should have approvalPendingRemovals (claim was preserved)
-      const lastChange = collected.changes.at(-1)
-      if (lastChange?.approvalPendingRemovals !== undefined) {
-        // Success: claim was preserved through mismatched reject
-        expect(lastChange.approvalPendingRemovals).toContain('term-1')
-      } else {
-        // Acceptable: the test setup may not have preserved the claim through SSE
-        // The gate is covered by the matching case test above
-        console.log('Note: mismatched sessionId test didnt preserve claim, but gate is covered by matching test')
+        expect(collected.changes.at(-1)).toEqual({
+          upsert: [],
+          remove: ['term-1'],
+          spontaneousExitRemovals: ['term-1'],
+          approvalPendingRemovals: ['term-1'],
+        })
       }
-      tracker.dispose()
+      // Arm 2 -- SESSION-ID mismatch with matching kind: a candidate pause
+      // whose claim deliberately survives the idle edge into
+      // awaitingAssociation(ses-a). Rejecting a DIFFERENT sessionId must not
+      // clear the claim. Survival is observable because the deferred
+      // completion minted at the matching confirm is swallowed while the
+      // claim is alive (the pause bell was THE bell); had the mismatched
+      // reject cleared the claim, confirm would emit turn.complete.
+      {
+        const { sse, fetchImpl } = createControlledFetchFixture({})
+        const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+        const collected = collectOpencode(tracker)
+        tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT })
+        await vi.advanceTimersByTimeAsync(0)
+        sse.enqueue({ type: 'server.connected', properties: {} })
+        await vi.advanceTimersByTimeAsync(0)
+        sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-a', status: { type: 'busy' } } })
+        await vi.advanceTimersByTimeAsync(0) // first-turn candidate busy
+        sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-a' } })
+        await vi.advanceTimersByTimeAsync(0) // candidate-armed pause, claim alive
+        sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-a', status: { type: 'idle' } } })
+        await vi.advanceTimersByTimeAsync(0) // awaitingAssociation(ses-a), claim survives (D8(i))
+
+        tracker.rejectSessionAssociation({ terminalId: 'term-1', sessionId: 'ses-other' })
+        tracker.confirmSessionAssociation({ terminalId: 'term-1', sessionId: 'ses-a' })
+
+        // Claim survived the mismatched reject: the deferred completion is swallowed.
+        expect(collected.completions).toEqual([])
+        expect(collected.boundaries).toHaveLength(1) // the pause bell stays the episode's only bell
+        tracker.dispose()
+      }
     })
   })
 
   describe('TOCTOU fix verification', () => {
-    it('permission.asked ownership read after async root-resolution avoids stale ownership boundary', async () => {
-      // Commit 48e4966cd moved the permission.asked handler's ownership read to
-      // AFTER the async root-resolution await. This guards against TOCTOU:
-      // ownership changes mid-await (via reject/confirm) -> the handler must see
-      // the CURRENT ownership, not the pre-await one.
-      //
-      // The fix is verified by confirming that permission-pause boundaries are
-      // emitted only under valid ownership states (knownBusy or candidate with
-      // matching sessionId). The permission pause test suite covers:
-      // - valid cases (boundaries emit correctly)
-      // - invalid cases (no boundary when ownership is wrong/changed)
-      // The ownership-scoping is enforced at line ~712 after ownership read.
-      // If the fix regresses (ownership read moves before await), the gate
-      // condition would use stale ownership and boundaries would emit incorrectly.
-      // This is implicitly covered by permission pause tests; explicit TOCTOU
-      // simulation with held promises is fragile and doesn't add new coverage
-      // given the gate condition is already under test.
-      expect(true).toBe(true) // Placeholder: coverage is in permission-pause tests
+    it('permission.asked reads ownership AFTER root resolution: mid-await invalidation stays silent', async () => {
+      // Commit 48e4966cd moved the permission.asked handler's ownership read
+      // to AFTER the async root-resolution await. Pin the ordering: ownership
+      // invalidated while the resolver is in flight must gate the pause (no
+      // boundary, no claim). With the pre-fix ordering (read before await)
+      // the handler arms from the STALE knownBusy snapshot and rings.
+      vi.useFakeTimers()
+      const { sse, fetchImpl } = createControlledFetchFixture({ 'ses-root': { type: 'busy' } })
+      const resolverCalls: string[][] = []
+      let releaseChildResolution: ((resolution: OpencodeRootResolution) => void) | undefined
+      const resolveOpencodeSessionRoots = async (
+        sessionIds: readonly string[],
+      ): Promise<OpencodeRootResolution> => {
+        resolverCalls.push([...sessionIds])
+        if (sessionIds.includes('ses-child')) {
+          // Hold the child lookup open: this suspension is the TOCTOU window.
+          return await new Promise<OpencodeRootResolution>((resolve) => {
+            releaseChildResolution = resolve
+          })
+        }
+        // Snapshot lookups (ses-root) resolve immediately as identity roots.
+        return {
+          rootsBySessionId: new Map(sessionIds.map((sessionId) => [sessionId, sessionId])),
+          unresolvedSessionIds: new Set<string>(),
+        }
+      }
+      const tracker = new OpencodeActivityTracker({
+        fetchImpl: fetchImpl as typeof fetch,
+        random: () => 0,
+        resolveOpencodeSessionRoots,
+      })
+      const collected = collectOpencode(tracker)
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0) // snapshot marks ses-root knownBusy, record present
+
+      // A child ask that needs root resolution: the handler suspends on the
+      // held resolver promise ('ses-child' is not in the child->root map).
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-child' } })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(resolverCalls).toContainEqual(['ses-child']) // suspended inside the TOCTOU window
+      expect(collected.boundaries).toEqual([]) // nothing armed while suspended
+
+      // Invalidate ownership mid-await: re-tracking the same endpoint resets
+      // ownership to quiet synchronously. (reject/confirmSessionAssociation
+      // only act on awaitingAssociation, so they CANNOT invalidate knownBusy;
+      // re-track is the public synchronous transition out of it.)
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+
+      // Release the held resolution, mapping the child onto the now-stale root.
+      if (!releaseChildResolution) throw new Error('resolver was never suspended on ses-child')
+      releaseChildResolution({
+        rootsBySessionId: new Map([['ses-child', 'ses-root']]),
+        unresolvedSessionIds: new Set<string>(),
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Post-await ownership is quiet: the gate must stay silent -- no
+      // boundary and no pause demotion (the busy record is left in place).
+      expect(collected.boundaries).toEqual([])
+      expect(collected.changes.filter((c) => c.remove.length > 0)).toEqual([])
+
+      // And no pause claim was armed: the spontaneous exit carries the plain
+      // death-bell marker with NO approval-pending marker.
+      tracker.untrackTerminal({ terminalId: 'term-1', spontaneous: true })
+      expect(collected.changes.at(-1)).toEqual({
+        upsert: [],
+        remove: ['term-1'],
+        spontaneousExitRemovals: ['term-1'],
+      })
     })
   })
 })

--- a/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
+++ b/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
@@ -67,6 +67,41 @@ function createControlledSseResponse() {
   }
 }
 
+function createControlledFetchFixture(snapshot: Record<string, unknown>) {
+  const sse = createControlledSseResponse()
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.endsWith('/global/health')) return createJsonResponse({ healthy: true })
+    if (url.endsWith('/session/status')) return createJsonResponse(snapshot)
+    if (url.endsWith('/event')) return sse.response
+    throw new Error(`unexpected url ${url}`)
+  })
+  return { sse, fetchImpl }
+}
+
+function collectOpencode(tracker: OpencodeActivityTracker) {
+  const collected = {
+    changes: [] as Array<{ upsert: unknown[]; remove: string[] }>,
+    boundaries: [] as Array<{ terminalId: string; at: number }>,
+    completions: [] as unknown[],
+    // combined arrival-order log across streams (demote-before-boundary checks)
+    order: [] as string[],
+  }
+  tracker.on('changed', (c) => {
+    collected.changes.push(c)
+    collected.order.push(c.remove.length > 0 ? 'changed:remove' : 'changed:upsert')
+  })
+  tracker.on('attention.boundary', (e) => {
+    collected.boundaries.push(e)
+    collected.order.push('boundary')
+  })
+  tracker.on('turn.complete', (e) => {
+    collected.completions.push(e)
+    collected.order.push('completion')
+  })
+  return collected
+}
+
 describe('OpencodeActivityTracker', () => {
   afterEach(() => {
     vi.useRealTimers()
@@ -1384,6 +1419,193 @@ describe('OpencodeActivityTracker', () => {
       await vi.advanceTimersByTimeAsync(0)
       expect(completions).toEqual([])
       expect(changes.filter((c) => c.remove.length > 0)).toHaveLength(1) // one demotion, no double-remove
+      tracker.dispose()
+    })
+  })
+
+  describe('permission pause semantics (codex approval-pause mirror)', () => {
+    async function setupKnownBusyPause() {
+      vi.useFakeTimers()
+      const { sse, fetchImpl } = createControlledFetchFixture({ 'ses-root': { type: 'busy' } })
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const collected = collectOpencode(tracker)
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0) // snapshot marks ses-root knownBusy, record present
+      return { sse, tracker, collected }
+    }
+
+    it('permission.asked on the owned busy session demotes then arms the boundary once', async () => {
+      const { sse, tracker, collected } = await setupKnownBusyPause()
+      sse.enqueue({
+        type: 'permission.asked',
+        properties: { id: 'per-1', sessionID: 'ses-root', permission: 'bash', patterns: ['sleep 60'], metadata: {}, always: [] },
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(collected.changes.filter((c) => c.remove.length > 0)).toEqual([
+        { upsert: [], remove: ['term-1'] },
+      ])
+      expect(collected.boundaries).toEqual([{ terminalId: 'term-1', at: expect.any(Number) }])
+      // demote FIRST, boundary SECOND (codex ordering): the gate must see
+      // not-busy before it arms
+      expect(collected.order.indexOf('changed:remove')).toBeGreaterThanOrEqual(0)
+      expect(collected.order.indexOf('changed:remove')).toBeLessThan(collected.order.indexOf('boundary'))
+      tracker.dispose()
+    })
+
+    it('duplicate permission.asked ids never re-arm', async () => {
+      const { sse, tracker, collected } = await setupKnownBusyPause()
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-root' } })
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-root' } })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(collected.boundaries).toHaveLength(1)
+      tracker.dispose()
+    })
+
+    it('permission.replied resumes busy immediately (cancels within grace)', async () => {
+      const { sse, tracker, collected } = await setupKnownBusyPause()
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-root' } })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'permission.replied', properties: { sessionID: 'ses-root', requestID: 'per-1', reply: 'once' } })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(collected.changes.at(-1)).toEqual({
+        upsert: [expect.objectContaining({ terminalId: 'term-1', sessionId: 'ses-root', phase: 'busy' })],
+        remove: [],
+      })
+      tracker.dispose()
+    })
+
+    it('abort mid-pause force-emits the removal and mints nothing', async () => {
+      const { sse, tracker, collected } = await setupKnownBusyPause()
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-root' } })
+      await vi.advanceTimersByTimeAsync(0)
+      // live abort trace (events-B.log): error -> status idle -> session.idle -> status idle -> session.idle
+      sse.enqueue({ type: 'session.error', properties: { sessionID: 'ses-root', error: { name: 'MessageAbortedError', data: { message: 'Aborted' } } } })
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
+      sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
+      sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(collected.completions).toEqual([])
+      expect(collected.boundaries).toHaveLength(1) // no re-arm
+      // the force-emit that cancels the armed grace window at the emitter:
+      // a SECOND remove for term-1 even though the record was already gone
+      expect(collected.changes.filter((c) => c.remove.length > 0)).toEqual([
+        { upsert: [], remove: ['term-1'] },
+        { upsert: [], remove: ['term-1'] },
+      ])
+      tracker.dispose()
+    })
+
+    it('failure mid-pause retires the pause without a second bell', async () => {
+      const { sse, tracker, collected } = await setupKnownBusyPause()
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-root' } })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'session.error', properties: { sessionID: 'ses-root', error: { name: 'UnknownError', data: { message: 'boom' } } } })
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-root', status: { type: 'idle' } } })
+      sse.enqueue({ type: 'session.idle', properties: { sessionID: 'ses-root' } })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(collected.completions).toEqual([]) // turnComplete swallowed: the pause bell was THE bell
+      expect(collected.boundaries).toHaveLength(1)
+      // NO second remove: the armed grace window is left to fire once
+      expect(collected.changes.filter((c) => c.remove.length > 0)).toHaveLength(1)
+      tracker.dispose()
+    })
+
+    it('child permission.asked root-resolves to the owned root and arms the pause', async () => {
+      // SEMANTIC CHANGE vs raw-equality scoping: children CAN ask -- their asks
+      // carry the CHILD sessionID and the parent turn blocks on them (opencode
+      // v1.18.11 source, validation pass 2026-08-03).
+      const { sse, tracker, collected } = await setupKnownBusyPause()
+      sse.enqueue({ type: 'session.created', properties: { sessionID: 'ses-child', info: { id: 'ses-child', parentID: 'ses-root' } } })
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-c1', sessionID: 'ses-child' } })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(collected.changes.filter((c) => c.remove.length > 0)).toEqual([
+        { upsert: [], remove: ['term-1'] },
+      ])
+      expect(collected.boundaries).toEqual([{ terminalId: 'term-1', at: expect.any(Number) }])
+      expect(collected.order.indexOf('changed:remove')).toBeGreaterThanOrEqual(0)
+      expect(collected.order.indexOf('changed:remove')).toBeLessThan(collected.order.indexOf('boundary'))
+      tracker.dispose()
+    })
+
+    it('permission.asked for a foreign/unresolvable session is ignored', async () => {
+      const { sse, tracker, collected } = await setupKnownBusyPause()
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-x', sessionID: 'ses-other' } })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(collected.boundaries).toEqual([])
+      expect(collected.changes.filter((c) => c.remove.length > 0)).toEqual([]) // no demotion
+      tracker.dispose()
+    })
+
+    it('candidate-armed pause: a first-turn ask on a fresh pane rings', async () => {
+      vi.useFakeTimers()
+      const { sse, fetchImpl } = createControlledFetchFixture({})
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const collected = collectOpencode(tracker)
+      // fresh-pane fixture WITHOUT a resume session id
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0)
+      // busy for ses-new -> candidate ownership (whole first turn by construction, D3)
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-new', status: { type: 'busy' } } })
+      await vi.advanceTimersByTimeAsync(0)
+
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-new' } })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(collected.changes.filter((c) => c.remove.length > 0)).toEqual([
+        { upsert: [], remove: ['term-1'] },
+      ])
+      expect(collected.boundaries).toEqual([{ terminalId: 'term-1', at: expect.any(Number) }])
+      expect(collected.order.indexOf('changed:remove')).toBeGreaterThanOrEqual(0)
+      expect(collected.order.indexOf('changed:remove')).toBeLessThan(collected.order.indexOf('boundary'))
+
+      sse.enqueue({ type: 'permission.replied', properties: { sessionID: 'ses-new', requestID: 'per-1', reply: 'once' } })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(collected.changes.at(-1)).toEqual({
+        upsert: [expect.objectContaining({ terminalId: 'term-1', sessionId: 'ses-new', phase: 'busy' })],
+        remove: [],
+      })
+      tracker.dispose()
+    })
+
+    it('deferred completion after a candidate pause is swallowed at association confirm', async () => {
+      vi.useFakeTimers()
+      const { sse, fetchImpl } = createControlledFetchFixture({})
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const collected = collectOpencode(tracker)
+      tracker.on('association.requested', (payload) => tracker.confirmSessionAssociation(payload))
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-new', status: { type: 'busy' } } })
+      await vi.advanceTimersByTimeAsync(0)
+      // candidate pause (no reply)
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-new' } })
+      await vi.advanceTimersByTimeAsync(0)
+      // idle edge (turn end mid-pause) -> tracker requests association,
+      // handler above confirms it via confirmSessionAssociation
+      sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-new', status: { type: 'idle' } } })
+      await vi.advanceTimersByTimeAsync(0)
+
+      // the deferred turnComplete minted at confirm is swallowed -- the pause
+      // bell, rung or still in grace, was THE bell for this episode
+      expect(collected.completions).toEqual([])
+      expect(collected.boundaries).toHaveLength(1)
+      // no force-emitted second remove: the grace window is left to fire once
+      expect(collected.changes.filter((c) => c.remove.length > 0)).toHaveLength(1)
       tracker.dispose()
     })
   })

--- a/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
+++ b/test/unit/server/coding-cli/opencode-activity-tracker.test.ts
@@ -81,7 +81,12 @@ function createControlledFetchFixture(snapshot: Record<string, unknown>) {
 
 function collectOpencode(tracker: OpencodeActivityTracker) {
   const collected = {
-    changes: [] as Array<{ upsert: unknown[]; remove: string[] }>,
+    changes: [] as Array<{
+      upsert: unknown[]
+      remove: string[]
+      spontaneousExitRemovals?: string[]
+      approvalPendingRemovals?: string[]
+    }>,
     boundaries: [] as Array<{ terminalId: string; at: number }>,
     completions: [] as unknown[],
     // combined arrival-order log across streams (demote-before-boundary checks)
@@ -1658,6 +1663,132 @@ describe('OpencodeActivityTracker', () => {
       } finally {
         warnSpy.mockRestore()
       }
+    })
+  })
+
+  describe('death-bell markers on spontaneous exit', () => {
+    async function setupKnownBusy() {
+      vi.useFakeTimers()
+      const { sse, fetchImpl } = createControlledFetchFixture({ 'ses-root': { type: 'busy' } })
+      const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+      const collected = collectOpencode(tracker)
+      tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT, sessionId: 'ses-root' })
+      await vi.advanceTimersByTimeAsync(0)
+      sse.enqueue({ type: 'server.connected', properties: {} })
+      await vi.advanceTimersByTimeAsync(0) // snapshot marks ses-root knownBusy, record present
+      return { sse, tracker, collected }
+    }
+
+    it('spontaneous exit while knownBusy marks the removal', async () => {
+      const { tracker, collected } = await setupKnownBusy()
+
+      tracker.untrackTerminal({ terminalId: 'term-1', spontaneous: true })
+
+      expect(collected.changes.at(-1)).toEqual({
+        upsert: [],
+        remove: ['term-1'],
+        spontaneousExitRemovals: ['term-1'],
+      })
+    })
+
+    it('spontaneous exit during a permission pause marks approvalPendingRemovals and emits despite the absent record', async () => {
+      const { sse, tracker, collected } = await setupKnownBusy()
+      sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-root' } })
+      await vi.advanceTimersByTimeAsync(0) // pause entry already removed the record
+
+      tracker.untrackTerminal({ terminalId: 'term-1', spontaneous: true })
+
+      expect(collected.changes.at(-1)).toEqual({
+        upsert: [],
+        remove: ['term-1'],
+        spontaneousExitRemovals: ['term-1'],
+        approvalPendingRemovals: ['term-1'],
+      })
+    })
+
+    it('spontaneous exit while candidate or ambiguous carries NO marker', async () => {
+      vi.useFakeTimers()
+      // candidate: busy for an unknown session on a pane with no resume id --
+      // candidate for the ENTIRE first turn by construction (D4: candidate
+      // noise is why opencode death bells were excluded before).
+      {
+        const { sse, fetchImpl } = createControlledFetchFixture({})
+        const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+        const collected = collectOpencode(tracker)
+        tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT })
+        await vi.advanceTimersByTimeAsync(0)
+        sse.enqueue({ type: 'server.connected', properties: {} })
+        await vi.advanceTimersByTimeAsync(0)
+        sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-new', status: { type: 'busy' } } })
+        await vi.advanceTimersByTimeAsync(0)
+
+        tracker.untrackTerminal({ terminalId: 'term-1', spontaneous: true })
+
+        // plain removal of the candidate busy record -- no marker fields
+        expect(collected.changes.at(-1)).toEqual({ upsert: [], remove: ['term-1'] })
+        expect(collected.changes.some((c) => c.spontaneousExitRemovals !== undefined)).toBe(false)
+      }
+      // candidate WITH an armed permission pause: still no marker -- D4 keeps
+      // candidate excluded even mid-pause (residual D8(i)).
+      {
+        const { sse, fetchImpl } = createControlledFetchFixture({})
+        const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, random: () => 0 })
+        const collected = collectOpencode(tracker)
+        tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT })
+        await vi.advanceTimersByTimeAsync(0)
+        sse.enqueue({ type: 'server.connected', properties: {} })
+        await vi.advanceTimersByTimeAsync(0)
+        sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-new', status: { type: 'busy' } } })
+        sse.enqueue({ type: 'permission.asked', properties: { id: 'per-1', sessionID: 'ses-new' } })
+        await vi.advanceTimersByTimeAsync(0)
+
+        tracker.untrackTerminal({ terminalId: 'term-1', spontaneous: true })
+
+        expect(collected.changes.some((c) => c.spontaneousExitRemovals !== undefined)).toBe(false)
+        expect(collected.changes.some((c) => c.approvalPendingRemovals !== undefined)).toBe(false)
+      }
+      // ambiguous: two busy sessions with no resume id
+      {
+        const { sse, fetchImpl } = createControlledFetchFixture({})
+        const log = { warn: vi.fn() }
+        const tracker = new OpencodeActivityTracker({ fetchImpl: fetchImpl as typeof fetch, log, random: () => 0 })
+        const collected = collectOpencode(tracker)
+        tracker.trackTerminal({ terminalId: 'term-1', endpoint: TEST_ENDPOINT })
+        await vi.advanceTimersByTimeAsync(0)
+        sse.enqueue({ type: 'server.connected', properties: {} })
+        await vi.advanceTimersByTimeAsync(0)
+        sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-a', status: { type: 'busy' } } })
+        sse.enqueue({ type: 'session.status', properties: { sessionID: 'ses-b', status: { type: 'busy' } } })
+        await vi.advanceTimersByTimeAsync(0)
+
+        tracker.untrackTerminal({ terminalId: 'term-1', spontaneous: true })
+
+        expect(collected.changes.at(-1)).toEqual({ upsert: [], remove: ['term-1'] })
+        expect(collected.changes.some((c) => c.spontaneousExitRemovals !== undefined)).toBe(false)
+      }
+    })
+
+    it('freshell-initiated untrack (no flag) behaves exactly as before', async () => {
+      const { tracker, collected } = await setupKnownBusy()
+
+      tracker.untrackTerminal({ terminalId: 'term-1' })
+
+      expect(collected.changes.at(-1)).toEqual({ upsert: [], remove: ['term-1'] })
+      expect(collected.changes.some((c) => c.spontaneousExitRemovals !== undefined)).toBe(false)
+      expect(collected.changes.some((c) => c.approvalPendingRemovals !== undefined)).toBe(false)
+    })
+
+    it('spontaneous exit of a terminal that was never tracked emits NOTHING', async () => {
+      // The wiring feeds EVERY registry terminal.exit (bash/claude/codex panes
+      // included) through untrackTerminal; untracked terminals must stay as
+      // silent as today (removeRecord's existence guard).
+      const tracker = new OpencodeActivityTracker({ random: () => 0 })
+      const collected = collectOpencode(tracker)
+
+      tracker.untrackTerminal({ terminalId: 'term-9', spontaneous: true })
+
+      expect(collected.changes).toEqual([])
+      tracker.dispose()
     })
   })
 })

--- a/test/unit/server/coding-cli/opencode-activity-wiring.test.ts
+++ b/test/unit/server/coding-cli/opencode-activity-wiring.test.ts
@@ -138,10 +138,14 @@ describe('wireOpencodeActivityTracker', () => {
       if (url.endsWith('/event')) {
         return createSseResponse([
           { type: 'server.connected', properties: {} },
+          // SEMANTIC CHANGE (opencode-attention-bell): child idle is suppressed,
+          // not remapped — only the ROOT's own idle completes the turn now, so
+          // the completion edge here is ses-root-1's idle (the snapshot already
+          // resolved ses-child-1 to that root).
           {
             type: 'session.idle',
             properties: {
-              sessionID: 'ses-child-1',
+              sessionID: 'ses-root-1',
             },
           },
         ])

--- a/test/unit/server/coding-cli/opencode-activity-wiring.test.ts
+++ b/test/unit/server/coding-cli/opencode-activity-wiring.test.ts
@@ -180,4 +180,53 @@ describe('wireOpencodeActivityTracker', () => {
       wired.dispose()
     }
   })
+
+  it('threads the registry spontaneous-exit discriminator through untrackTerminal', async () => {
+    vi.useFakeTimers()
+    const terminal = {
+      terminalId: 'term-opencode-1',
+      mode: 'opencode',
+      status: 'running',
+      resumeSessionId: 'ses-root',
+      opencodeServer: { hostname: '127.0.0.1', port: 32123 },
+    }
+    const registry = makeRegistry(terminal, { includeInList: true })
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/global/health')) return createJsonResponse({ healthy: true })
+      if (url.endsWith('/session/status')) {
+        return createJsonResponse({ 'ses-root': { type: 'busy' } })
+      }
+      if (url.endsWith('/event')) {
+        return createSseResponse([{ type: 'server.connected', properties: {} }])
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+    const wired = wireOpencodeActivityTracker({
+      registry,
+      fetchImpl: fetchImpl as typeof fetch,
+      random: () => 0,
+    })
+    const changes: Array<{
+      upsert: unknown[]
+      remove: string[]
+      spontaneousExitRemovals?: string[]
+      approvalPendingRemovals?: string[]
+    }> = []
+    wired.tracker.on('changed', (change) => changes.push(change))
+
+    try {
+      await vi.advanceTimersByTimeAsync(0) // health + SSE connect + snapshot: ses-root knownBusy
+
+      registry.emit('terminal.exit', { terminalId: 'term-opencode-1', spontaneous: true })
+
+      expect(changes.at(-1)).toEqual({
+        upsert: [],
+        remove: ['term-opencode-1'],
+        spontaneousExitRemovals: ['term-opencode-1'],
+      })
+    } finally {
+      wired.dispose()
+    }
+  })
 })

--- a/test/unit/server/coding-cli/opencode-ownership-reducer.test.ts
+++ b/test/unit/server/coding-cli/opencode-ownership-reducer.test.ts
@@ -655,3 +655,76 @@ describe('opencode ownership reducer', () => {
     ])
   })
 })
+
+describe('abort gate (session.error MessageAbortedError)', () => {
+  const stream = { cycleId: 1, streamId: 1 }
+
+  function busyKnown() {
+    // quiet(known) + busy sse -> knownBusy
+    const s0 = createOpencodeOwnershipState('ses-root')
+    return reduceOpencodeOwnership(s0, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'busy', at: 1000 }).state
+  }
+
+  it('abort then idle clears busy silently (no turnComplete)', () => {
+    const s1 = reduceOpencodeOwnership(busyKnown(), { kind: 'error', ...stream, sessionId: 'ses-root', errorName: 'MessageAbortedError', at: 1500 })
+    expect(s1.actions).toEqual([])
+    const s2 = reduceOpencodeOwnership(s1.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'idle', at: 1507 })
+    expect(s2.actions).toEqual([{ kind: 'activityRemove', at: 1507 }])
+    expect(s2.state).toEqual({ kind: 'quiet', knownSessionId: 'ses-root' })
+  })
+
+  it('second idle edge after abort is a no-op (double session.idle dedupe)', () => {
+    const s1 = reduceOpencodeOwnership(busyKnown(), { kind: 'error', ...stream, sessionId: 'ses-root', errorName: 'MessageAbortedError', at: 1500 })
+    const s2 = reduceOpencodeOwnership(s1.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'idle', at: 1507 })
+    const s3 = reduceOpencodeOwnership(s2.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'idle', at: 1527 })
+    expect(s3.actions).toEqual([])
+  })
+
+  it('non-abort error names do not suppress the completion (failed turns ring)', () => {
+    const s1 = reduceOpencodeOwnership(busyKnown(), { kind: 'error', ...stream, sessionId: 'ses-root', errorName: 'UnknownError', at: 1500 })
+    expect(s1.actions).toEqual([])
+    const s2 = reduceOpencodeOwnership(s1.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'idle', at: 1507 })
+    expect(s2.actions).toEqual([
+      { kind: 'activityRemove', at: 1507 },
+      { kind: 'turnComplete', sessionId: 'ses-root', at: 1507 },
+    ])
+  })
+
+  it('trailing error on quiet state is a no-op (never mint from idle)', () => {
+    const quiet = { kind: 'quiet' as const, knownSessionId: 'ses-root' }
+    const r = reduceOpencodeOwnership(quiet, { kind: 'error', ...stream, sessionId: 'ses-root', errorName: 'UnknownError', at: 2000 })
+    expect(r.state).toEqual(quiet)
+    expect(r.actions).toEqual([])
+  })
+
+  it('a new busy clears the abort flag (per-turn semantics)', () => {
+    const s1 = reduceOpencodeOwnership(busyKnown(), { kind: 'error', ...stream, sessionId: 'ses-root', errorName: 'MessageAbortedError', at: 1500 })
+    const s2 = reduceOpencodeOwnership(s1.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'busy', at: 1600 })
+    const s3 = reduceOpencodeOwnership(s2.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'idle', at: 1700 })
+    expect(s3.actions).toContainEqual({ kind: 'turnComplete', sessionId: 'ses-root', at: 1700 })
+  })
+
+  it('abort from a mismatched cycle/stream is ignored', () => {
+    const s1 = reduceOpencodeOwnership(busyKnown(), { kind: 'error', cycleId: 9, streamId: 9, sessionId: 'ses-root', errorName: 'MessageAbortedError', at: 1500 })
+    const s2 = reduceOpencodeOwnership(s1.state, { kind: 'sse', ...stream, sessionId: 'ses-root', status: 'idle', at: 1507 })
+    expect(s2.actions).toContainEqual({ kind: 'turnComplete', sessionId: 'ses-root', at: 1507 })
+  })
+
+  it('snapshot-empty after abort is silent too', () => {
+    const s1 = reduceOpencodeOwnership(busyKnown(), { kind: 'error', ...stream, sessionId: 'ses-root', errorName: 'MessageAbortedError', at: 1500 })
+    const s2 = reduceOpencodeOwnership(s1.state, { kind: 'snapshot', ...stream, statuses: {}, at: 1507 })
+    expect(s2.actions).toEqual([{ kind: 'activityRemove', at: 1507 }])
+  })
+
+  it('aborted candidate turn never mints a completion at association confirm', () => {
+    // quiet(no known) + busy -> candidate
+    const s0 = createOpencodeOwnershipState()
+    const c1 = reduceOpencodeOwnership(s0, { kind: 'sse', ...stream, sessionId: 'ses-x', status: 'busy', at: 1000 })
+    const c2 = reduceOpencodeOwnership(c1.state, { kind: 'error', ...stream, sessionId: 'ses-x', errorName: 'MessageAbortedError', at: 1100 })
+    const c3 = reduceOpencodeOwnership(c2.state, { kind: 'sse', ...stream, sessionId: 'ses-x', status: 'idle', at: 1200 })
+    expect(c3.state.kind).toBe('awaitingAssociation')
+    const confirmed = confirmOpencodeAssociation(c3.state, { sessionId: 'ses-x' })
+    expect(confirmed.actions).toEqual([])
+    expect(confirmed.state).toEqual({ kind: 'quiet', knownSessionId: 'ses-x' })
+  })
+})

--- a/test/unit/server/coding-cli/truly-idle-emitter.test.ts
+++ b/test/unit/server/coding-cli/truly-idle-emitter.test.ts
@@ -182,6 +182,17 @@ describe('TrulyIdleEmitter', () => {
     expect(events[0]).toMatchObject({ terminalId: 't1', reason: 'grace' })
   })
 
+  it('opencode death while grace is armed rings immediately (post-turn window)', () => {
+    // opencode shape: turn end = remove followed by turnComplete, then death
+    emitter.noteActivityChanged({ upsert: [{ terminalId: 't1', phase: 'busy' }] })
+    emitter.noteActivityChanged({ remove: ['t1'] })
+    emitter.noteTurnComplete({ terminalId: 't1', at: Date.now() }) // arms grace
+    emitter.noteActivityChanged({ remove: ['t1'], spontaneousExitRemovals: ['t1'] })
+    expect(events).toEqual([{ terminalId: 't1', at: Date.now(), reason: 'grace' }])
+    vi.advanceTimersByTime(TERMINAL_IDLE_GRACE_MS + 1)
+    expect(events).toHaveLength(1) // the armed window was cancelled by the removal — no double ring
+  })
+
   it('never emits on a deadman/signal-loss idle flip (phase idle without a turn boundary)', () => {
     emitter.noteActivityChanged({ upsert: [{ terminalId: 't1', phase: 'busy' }], remove: [] })
     emitter.noteActivityChanged({ upsert: [{ terminalId: 't1', phase: 'idle' }], remove: [] })


### PR DESCRIPTION
## Problem

OpenCode terminal panes had the weakest attention story of the four CLIs:

- **Node server:** every busy→idle edge rang the bell — pressing Esc rang identically to a real completion; `session.error` and `permission.*` events were silently dropped; death bells were structurally impossible (deliberately excluded as a "noisy busy proxy").
- **Rust server (production):** a total dead zone — no opencode tracker existed at all. Because the client lists opencode as server-authoritative (disabling its own BEL fallback), opencode panes on Rust **never turned green and never rang**.

## Grounding

Design validated by a live protocol spike against real OpenCode 1.18.11 (`opencode serve` + the TUI-embedded server): abort emits `session.error{MessageAbortedError}` before the idle edge (which double-fires — dedupe needed); failed turns emit distinguishable `session.error`; child sub-sessions emit their own idle edges on the parent's stream (false-green analog of the codex sub-agent bug, confirmed live); `permission.asked`/`permission.replied` are the only stream signals for permission pauses; SSE-drop is immediate on kill -9. Spike logs preserved and pinned as test fixtures.

## What this PR does

Applies the attention-bell policy (PR #597): **one bell = stopped for any non-human cause; silent for human-requested stops.**

**Node server:**
- Per-turn abort gate: Esc/abort (`MessageAbortedError`, plus message-marker fallback for the timing windows that miss it) suppresses the bell; failed turns ring; trailing errors on idle sessions are no-ops; double `session.idle` deduped
- Permission-pause lane: rings once after grace, resolves back to busy, mid-pause completion can't double-ring, duplicate asks don't re-arm — and bells arm even before first-turn session binding is confirmed
- Death bells: spontaneous-exit discriminator plumbed through; engagement tightened to owned/knownBusy (fixing the noisy-proxy exclusion properly); freshell-initiated kills and exits-while-idle stay silent
- Child sub-sessions can't complete/abort/ring the root (pinned against the live trace); production resolver wiring pinned by regression test

**Rust server (new — closes the dead zone):**
- Pure tracker `freshell-activity/src/opencode.rs` with the same gates; per-terminal SSE lane reusing `freshell-opencode` transport with connect-first/buffer/snapshot ordering (cannot lose a turn end), generation stamps against stale-listener phantom bells, and HTTP fallback to rebuild parent/child mapping after reconnect
- Hub wiring: mode arms, `opencode.activity.updated`/`opencode.activity.list`, `terminal.turn.complete{provider:'opencode'}`, IdleGate integration, immediate death bell while engaged
- Node/Rust death-bell behavioral parity verified by review + pins

**Robustness:** log-once version-drift warning when opencode reports a version newer than the tested range — protocol drift becomes visible instead of silently inverting bells.

## Contract

Zero wire-shape changes, zero client changes — the client's existing opencode code paths (schemas shipped long ago) simply light up. `idle.rs` Accepted Residuals list trued up.

## Validation

- 4 full-suite gates green across execution (cargo workspace tests + coordinated `npm run check` incl. contract freeze)
- Independent delta review: passed round 1, zero blocking; whole-branch review "Ready to merge: Yes" after real findings were fixed (incl. a Node/Rust death-bell mismatch and a vacuous test caught and rewritten)
- All new tests red→green verified; live-trace episode tests pin exact event ordering from the spike

Generated with Amplifier

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>