### PR TITLE
fix(server): 7 user-facing bug fixes from parallel bug-hunt (freshagent, terminal lifecycle, recovery, sessions)

### DIFF
--- a/crates/freshell-freshagent/src/claude.rs
+++ b/crates/freshell-freshagent/src/claude.rs
@@ -2862,7 +2862,7 @@ rl.on('line', (line) => {
                 assert_eq!(frame["provider"], "claude", "{frame}");
                 assert_eq!(frame["sessionType"], "freshclaude", "{frame}");
                 assert!(
-                    frame["event"]["message"].as_str().unwrap_or("").len() > 0,
+                    !frame["event"]["message"].as_str().unwrap_or("").is_empty(),
                     "user-facing message required: {frame}"
                 );
                 break;

--- a/crates/freshell-freshagent/src/claude.rs
+++ b/crates/freshell-freshagent/src/claude.rs
@@ -1217,6 +1217,29 @@ impl FreshClaudeState {
                 for durable in &removed_durables {
                     state.leases.clear_binding(PROVIDER, durable);
                 }
+                // Adapter-asymmetry fix (bug-hunt pbh-20260807): an UNREQUESTED sidecar
+                // death must never be TOTAL SILENCE. The codex sibling broadcasts its
+                // crash self-heal `exited` status (`codex.rs spawn_exit_watcher`) and
+                // opencode's turn task emits an unconditional `idle`
+                // (`opencode_ws.rs run_turn`); the reference bridge broadcasts an
+                // explicit idle for exactly this edge so the pane doesn't stay stuck
+                // blue (`server/sdk-bridge.ts:344-353`). Claude alone dropped the pane
+                // into a forever-"working" wedge. Broadcast the `freshAgent.error`
+                // shape the client folds into a visible banner AND a
+                // running/streaming->idle drop (`fresh-agent-ws.ts:333-342`,
+                // `freshAgentSlice.sessionError`). This branch is UNREQUESTED-death
+                // only: `handle_kill`/`shutdown`/attach-teardown all remove the map
+                // entry (and abort this consumer) first, so `evicted` is false there
+                // and stays silent -- and no completion chime is ever fabricated
+                // (ADR Decision 2.1 holds).
+                let stamp = broadcast_id.lock().expect("broadcast id lock").clone();
+                tracing::warn!(session_id = %stamp, "freshagent.claude.sidecar_death_detected");
+                state.emit_fresh_agent_error(
+                    &stamp,
+                    &session_type,
+                    "SIDECAR_EXITED",
+                    "Claude agent process exited unexpectedly - the in-flight turn was lost. Reopen the pane or create a new agent to continue.",
+                );
             }
         })
     }
@@ -2784,5 +2807,71 @@ rl.on('line', (line) => {
                 "a successful interrupt must not broadcast an error: {frame}"
             );
         }
+    }
+
+    /// Adapter-asymmetry fix (bug-hunt pbh-20260807): an UNREQUESTED sidecar death
+    /// (crash/OOM/kill -9, never `freshAgent.kill`) must broadcast a pane-unwedging
+    /// `freshAgent.error` after the consumer-exit eviction. The codex sibling broadcasts
+    /// its crash self-heal `exited` status (`codex.rs spawn_exit_watcher`) and opencode's
+    /// turn task emits an unconditional `idle` (`opencode_ws.rs run_turn`); claude was the
+    /// only provider whose death edge was TOTAL SILENCE, leaving the pane stuck
+    /// busy/"working" forever (the reference bridge broadcasts an explicit idle for
+    /// exactly this reason -- `server/sdk-bridge.ts:344-353`). The client folds this frame
+    /// into a visible banner AND drops the stuck running/streaming state
+    /// (`fresh-agent-ws.ts:333-342`, `freshAgentSlice.sessionError`).
+    #[tokio::test]
+    async fn unrequested_sidecar_death_broadcasts_a_pane_unwedging_error() {
+        let _guard = CLAUDE_ENV_LOCK.lock().await;
+        let _env = FakeClaudeSidecarEnv::install();
+        let (tx, mut rx) = tokio::sync::broadcast::channel::<String>(64);
+        let st = FreshClaudeState::new(Arc::new(tx));
+
+        st.handle_create(dedup_create_msg("req-claude-death-unwedge"))
+            .await;
+        let created = await_claude_created(&mut rx, "req-claude-death-unwedge").await;
+        assert_eq!(created["type"], "freshAgent.created", "sanity: {created}");
+        let session_id = created["sessionId"].as_str().unwrap().to_string();
+
+        // Simulate the crash: SIGKILL the sidecar child directly (NOT handle_kill, which
+        // removes the map entry first and must stay silent).
+        {
+            let mut guard = st.sessions.lock().await;
+            let session = guard.get_mut(&session_id).expect("live session in map");
+            let _ = session.child.start_kill();
+        }
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let raw = tokio::time::timeout(remaining, rx.recv())
+                .await
+                .expect(
+                    "no SIDECAR_EXITED freshAgent.error was broadcast after an unrequested \
+                     sidecar death -- the pane stays wedged busy forever",
+                )
+                .expect("broadcast bus closed");
+            let frame: Value = serde_json::from_str(&raw).unwrap();
+            if frame["type"] == "freshAgent.event"
+                && frame["event"]["type"] == "freshAgent.error"
+                && frame["event"]["code"] == "SIDECAR_EXITED"
+            {
+                // Stamped with the session's broadcast id so the frozen client routes it
+                // to the right pane (fresh-agent-ws.ts:190-201).
+                assert_eq!(frame["sessionId"], json!(session_id), "{frame}");
+                assert_eq!(frame["event"]["sessionId"], json!(session_id), "{frame}");
+                assert_eq!(frame["provider"], "claude", "{frame}");
+                assert_eq!(frame["sessionType"], "freshclaude", "{frame}");
+                assert!(
+                    frame["event"]["message"].as_str().unwrap_or("").len() > 0,
+                    "user-facing message required: {frame}"
+                );
+                break;
+            }
+        }
+        // The pre-existing consumer-exit eviction (ledger A9) still happened.
+        assert!(
+            !st.sessions.lock().await.contains_key(&session_id),
+            "dead session must still be evicted from the sessions map"
+        );
     }
 }

--- a/crates/freshell-server/src/recovery_inventory.rs
+++ b/crates/freshell-server/src/recovery_inventory.rs
@@ -466,6 +466,45 @@ fn live_session_keys(
     keys
 }
 
+/// Test-only seam: simulate a concurrent `persist_generation` retention
+/// prune landing BETWEEN the overview scan and the union read (each takes
+/// the persist lock separately, so a `tabs.sync.push` from any reconnecting
+/// client can delete a just-selected generation file in that window). Each
+/// seeded batch is one such interleaved prune; batches are matched to the
+/// store root so parallel tests on other tempdirs are unaffected. Production
+/// builds compile this to a no-op.
+#[cfg(test)]
+static INJECTED_PRUNE_BATCHES: std::sync::Mutex<Vec<Vec<std::path::PathBuf>>> =
+    std::sync::Mutex::new(Vec::new());
+
+fn injected_prune_between_reads(_dir: &std::path::Path) {
+    #[cfg(test)]
+    {
+        let mut batches = INJECTED_PRUNE_BATCHES.lock().unwrap();
+        if let Some(position) = batches
+            .iter()
+            .position(|batch| batch.first().is_some_and(|path| path.starts_with(_dir)))
+        {
+            for path in batches.remove(position) {
+                let _ = std::fs::remove_file(&path);
+            }
+        }
+    }
+}
+
+/// Bounded re-reads when a concurrent retention prune lands between the
+/// overview scan and the union read. The two reads each take the tabs-persist
+/// lock separately, so a `tabs.sync.push` — which every reconnecting client
+/// fires at exactly the moment a fresh window fetches the inventory — can
+/// delete a just-selected generation file in between (a client at its
+/// retention cap prunes its oldest retained generation on every push, and
+/// selection takes ALL retained generations of surviving clients). A fresh
+/// overview re-selects from what actually survives, so one re-read converges
+/// in the benign race; exhaustion means the store is churning or incoherent
+/// under the reader and MUST fail loud (500, `:373`), never a clean 200
+/// whose inventory silently omits the whole device.
+const UNION_READ_ATTEMPTS: usize = 3;
+
 fn read_foreign_unions(
     dir: &std::path::Path,
     exclude_client: &str,
@@ -478,26 +517,50 @@ fn read_foreign_unions(
     if !dir.is_dir() {
         return Ok(out);
     }
-    for device in list_snapshot_devices(dir)? {
-        let Some((_, generations)) = read_device_overview(dir, &device)? else {
-            continue;
-        };
-        // Task 1 helper: drops the requester's own generations, concurrent
-        // post-boot clients (A16), AND stale clients (A15).
-        let foreign =
-            select_foreign_recent_generation_ids(&generations, exclude_client, boot_cutoff);
-        if foreign.is_empty() {
-            continue;
+    'devices: for device in list_snapshot_devices(dir)? {
+        let mut last_missing: Vec<String> = Vec::new();
+        for _attempt in 0..UNION_READ_ATTEMPTS {
+            let Some((_, generations)) = read_device_overview(dir, &device)? else {
+                continue 'devices; // genuinely absent (e.g. evicted) — skip
+            };
+            // Task 1 helper: drops the requester's own generations, concurrent
+            // post-boot clients (A16), AND stale clients (A15).
+            let foreign =
+                select_foreign_recent_generation_ids(&generations, exclude_client, boot_cutoff);
+            if foreign.is_empty() {
+                continue 'devices;
+            }
+            injected_prune_between_reads(dir);
+            match read_generations_union_by_ids(dir, &device, &foreign)? {
+                ComponentsUnion::Found(union_doc) => {
+                    out.push(DeviceUnion {
+                        device_id: device,
+                        union_doc,
+                    });
+                    continue 'devices;
+                }
+                // A component pruned between the overview scan and the union
+                // read: re-run the WHOLE cycle so selection reflects what
+                // actually survives — never a silent whole-device drop.
+                ComponentsUnion::Missing(ids) => last_missing = ids,
+            }
         }
-        match read_generations_union_by_ids(dir, &device, &foreign)? {
-            ComponentsUnion::Found(union_doc) => out.push(DeviceUnion {
-                device_id: device,
-                union_doc,
-            }),
-            // A component pruned between the overview scan and the union read:
-            // zero surviving generations for this device — skip it.
-            ComponentsUnion::Missing(_) => continue,
-        }
+        tracing::error!(
+            target: "freshell_server::recovery_inventory",
+            device = %device,
+            missing = ?last_missing,
+            attempts = UNION_READ_ATTEMPTS,
+            "recovery_inventory_device_union_incoherent: selected generations kept \
+             disappearing between the overview scan and the union read; failing loud \
+             rather than silently omitting the device from the recovery offer"
+        );
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "recovery inventory union read incoherent for device {device}: \
+                 {last_missing:?} still missing after {UNION_READ_ATTEMPTS} attempts"
+            ),
+        ));
     }
     Ok(out)
 }

--- a/crates/freshell-server/src/recovery_inventory_tests.rs
+++ b/crates/freshell-server/src/recovery_inventory_tests.rs
@@ -647,6 +647,128 @@ async fn route_bootagoms_drops_concurrent_post_boot_clients() {
     assert!(tabs.iter().any(|t| t["tabKey"] == "k1"));
 }
 
+/// The generation-file path `write_snapshot` produced (alphanumeric ids need
+/// no escaping) — used to seed the interleaved-prune injection seam.
+fn snapshot_path(
+    dir: &std::path::Path,
+    device: &str,
+    client: &str,
+    captured_at: u64,
+    rev: u64,
+) -> std::path::PathBuf {
+    dir.join(device)
+        .join(format!("{client}-{captured_at:020}-r{rev:012}.json"))
+}
+
+fn open_tab_records(tab_key: &str, updated_at: u64) -> serde_json::Value {
+    json!([
+        {"tabKey": tab_key, "tabId": tab_key, "tabName": tab_key, "status": "open",
+         "revision": 1, "updatedAt": updated_at, "paneCount": 1,
+         "panes": [{"paneId": format!("p-{tab_key}"), "kind": "terminal", "payload": {"mode": "shell"}}]}
+    ])
+}
+
+fn now_ms_u64() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+/// The restart-recovery interleave: every reconnecting client re-pushes right
+/// when the fresh window fetches the inventory, and a push from a client at
+/// its retention cap PRUNES that client's oldest generation — which the
+/// overview scan just selected (selection takes ALL retained generations of
+/// surviving clients). The union read must not answer that benign prune by
+/// silently omitting the ENTIRE device from the recovery offer: a re-read
+/// converges on what actually survives and the device is still offered.
+#[tokio::test]
+async fn transient_prune_between_reads_never_silently_drops_a_device() {
+    let tmp = tempfile::tempdir().unwrap();
+    let now = now_ms_u64();
+    // The lost client retains two generations (both pre-request, both fresh).
+    write_snapshot(
+        tmp.path(),
+        "dev1",
+        "lost",
+        now - 240_000,
+        1,
+        open_tab_records("k-old", now - 240_000),
+    );
+    write_snapshot(
+        tmp.path(),
+        "dev1",
+        "lost",
+        now - 60_000,
+        2,
+        open_tab_records("k1", now - 60_000),
+    );
+    // One concurrent retention prune lands between the overview scan and the
+    // union read, deleting the oldest just-selected generation.
+    INJECTED_PRUNE_BATCHES
+        .lock()
+        .unwrap()
+        .push(vec![snapshot_path(tmp.path(), "dev1", "lost", now - 240_000, 1)]);
+    let router = router(test_state(Some(tmp.path().to_path_buf()), None));
+    let (code, body) = get(
+        router,
+        "/api/recovery/inventory?clientInstanceId=me",
+        Some("tok"),
+    )
+    .await;
+    assert_eq!(code, axum::http::StatusCode::OK);
+    assert_eq!(
+        body["recoverable"], true,
+        "a benign concurrent prune must not silently empty the recovery offer"
+    );
+    assert_eq!(body["device"]["deviceId"], "dev1");
+    let tabs = body["device"]["tabs"].as_array().unwrap();
+    assert!(
+        tabs.iter().any(|t| t["tabKey"] == "k1"),
+        "the device's surviving newest generation must still be offered"
+    );
+}
+
+/// Exhausted re-reads mean the store is churning or incoherent under the
+/// reader: answer LOUD (500 + error log), never a clean 200 whose inventory
+/// silently omits the device (`recovery_inventory.rs` fail-loud policy:
+/// "never a silent empty inventory").
+#[tokio::test]
+async fn persistent_union_incoherence_fails_loud_not_silent_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let now = now_ms_u64();
+    for (i, age) in [240_000u64, 180_000, 120_000, 60_000].iter().enumerate() {
+        write_snapshot(
+            tmp.path(),
+            "dev1",
+            "lost",
+            now - age,
+            (i + 1) as u64,
+            open_tab_records("k1", now - age),
+        );
+    }
+    // A prune lands between the two reads on EVERY attempt (each batch is
+    // consumed by one attempt), so the selected set never survives.
+    {
+        let mut batches = INJECTED_PRUNE_BATCHES.lock().unwrap();
+        batches.push(vec![snapshot_path(tmp.path(), "dev1", "lost", now - 240_000, 1)]);
+        batches.push(vec![snapshot_path(tmp.path(), "dev1", "lost", now - 180_000, 2)]);
+        batches.push(vec![snapshot_path(tmp.path(), "dev1", "lost", now - 120_000, 3)]);
+    }
+    let router = router(test_state(Some(tmp.path().to_path_buf()), None));
+    let (code, body) = get(
+        router,
+        "/api/recovery/inventory?clientInstanceId=me",
+        Some("tok"),
+    )
+    .await;
+    assert_eq!(
+        code,
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        "persistent union incoherence must fail loud, not 200 with the device silently missing; got body {body}"
+    );
+}
+
 #[test]
 fn concurrent_fresh_windows_generations_are_dropped() {
     // A16/D2: a client whose ENTIRE retained history postdates the requester's boot is a

--- a/crates/freshell-server/src/recovery_inventory_tests.rs
+++ b/crates/freshell-server/src/recovery_inventory_tests.rs
@@ -708,7 +708,13 @@ async fn transient_prune_between_reads_never_silently_drops_a_device() {
     INJECTED_PRUNE_BATCHES
         .lock()
         .unwrap()
-        .push(vec![snapshot_path(tmp.path(), "dev1", "lost", now - 240_000, 1)]);
+        .push(vec![snapshot_path(
+            tmp.path(),
+            "dev1",
+            "lost",
+            now - 240_000,
+            1,
+        )]);
     let router = router(test_state(Some(tmp.path().to_path_buf()), None));
     let (code, body) = get(
         router,
@@ -751,9 +757,27 @@ async fn persistent_union_incoherence_fails_loud_not_silent_empty() {
     // consumed by one attempt), so the selected set never survives.
     {
         let mut batches = INJECTED_PRUNE_BATCHES.lock().unwrap();
-        batches.push(vec![snapshot_path(tmp.path(), "dev1", "lost", now - 240_000, 1)]);
-        batches.push(vec![snapshot_path(tmp.path(), "dev1", "lost", now - 180_000, 2)]);
-        batches.push(vec![snapshot_path(tmp.path(), "dev1", "lost", now - 120_000, 3)]);
+        batches.push(vec![snapshot_path(
+            tmp.path(),
+            "dev1",
+            "lost",
+            now - 240_000,
+            1,
+        )]);
+        batches.push(vec![snapshot_path(
+            tmp.path(),
+            "dev1",
+            "lost",
+            now - 180_000,
+            2,
+        )]);
+        batches.push(vec![snapshot_path(
+            tmp.path(),
+            "dev1",
+            "lost",
+            now - 120_000,
+            3,
+        )]);
     }
     let router = router(test_state(Some(tmp.path().to_path_buf()), None));
     let (code, body) = get(

--- a/crates/freshell-sessions/src/amplifier.rs
+++ b/crates/freshell-sessions/src/amplifier.rs
@@ -160,10 +160,37 @@ fn walk_metadata_files(root: &Path, dir: &Path, out: &mut Vec<FileStat>) {
             let under_sessions = relative.components().any(|c| c.as_os_str() == "sessions");
             if under_sessions {
                 if let Some(stat) = stat_metadata_file(&path) {
-                    out.push(stat);
+                    out.push(fold_activity_mtime(stat));
                 }
             }
         }
+    }
+}
+
+/// Fold the activity sidecars' mtimes (`transcript.jsonl` / `events.jsonl`,
+/// STAT-only -- content never read here) into the discovered metadata.json
+/// [`FileStat`]'s `mtime_ms`, so `SessionIndex`'s incremental cache
+/// (`directory_index.rs`, keyed on the discovered `(mtime, size)`) re-parses
+/// this session when its ACTIVITY changes even though metadata.json itself
+/// did not. Node parity: the reference refreshes `activityMtimeMs` on EVERY
+/// scan -- cache hit included (`session-indexer.ts:922-942`) -- precisely so
+/// "a session that was active/resumed after its metadata timestamps still
+/// rises in the recency-sorted sidebar" (`session-indexer.ts:1014-1017`).
+/// Keying the cache on the raw metadata mtime alone froze `last_activity_at`
+/// (and the first-user-message preview) at first-parse values forever.
+/// `size` stays metadata.json's own size; the folded mtime alone is what
+/// invalidates the cache entry.
+fn fold_activity_mtime(stat: FileStat) -> FileStat {
+    let Some(dir) = stat.path.parent() else {
+        return stat;
+    };
+    let activity = max_defined(
+        file_mtime_ms(&dir.join("transcript.jsonl")),
+        file_mtime_ms(&dir.join("events.jsonl")),
+    );
+    FileStat {
+        mtime_ms: max_defined(Some(stat.mtime_ms), activity).unwrap_or(stat.mtime_ms),
+        ..stat
     }
 }
 
@@ -702,6 +729,71 @@ mod tests {
         let providers: Vec<&str> = snapshot.iter().map(|s| s.provider.as_str()).collect();
         assert!(providers.contains(&"amplifier"));
         assert!(providers.contains(&"claude"));
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    // -- sidecar activity must refresh THROUGH the incremental index cache --
+    //
+    // Node parity pin: the reference refreshes `activityMtimeMs` on EVERY
+    // scan, cache hit included (`session-indexer.ts:922-942`), precisely so
+    // "a session that was active/resumed after its metadata timestamps still
+    // rises in the recency-sorted sidebar" (`session-indexer.ts:1014-1017`).
+    // `scan()` (used by the mtime-fold test above) bypasses the cache, so it
+    // can't catch a regression here -- this test goes through SessionIndex's
+    // incremental sweep, where a session whose ONLY change is a sidecar
+    // write (metadata.json untouched) must still re-surface with fresh
+    // recency instead of being served from the stale cached entry forever.
+
+    #[tokio::test]
+    async fn session_index_refreshes_amplifier_recency_when_only_sidecar_changes() {
+        let home = unique_temp_dir("sidecar-recency");
+        let dir = write_session(
+            &home,
+            "proj",
+            "sess-active",
+            r#"{"session_id":"sess-active","working_dir":"/p","created":1000}"#,
+            None,
+        );
+
+        let index = SessionIndex::with_ttl_and_cache_path(
+            vec![Arc::new(AmplifierSource::new(home.clone())) as Arc<dyn SessionSource>],
+            std::time::Duration::from_millis(1),
+            None, // no persistence: isolated, deterministic
+        );
+        let first = index.snapshot().await;
+        assert_eq!(first.len(), 1);
+        assert_eq!(
+            first[0].last_activity_at, 1000,
+            "no sidecars yet: recency comes from metadata alone"
+        );
+
+        // New activity: events.jsonl appears (mtime = now); metadata.json is
+        // NOT touched -- exactly what an ongoing/resumed amplifier turn does.
+        // The sleep guarantees the sidecar's mtime lands in a LATER
+        // millisecond than metadata.json's (mtime_ms granularity), so the
+        // test exercises the cache-invalidation contract, not a same-ms race.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        std::fs::write(dir.join("events.jsonl"), "{\"event\":\"turn\"}\n").unwrap();
+
+        // TTL is 1ms, so every snapshot() triggers a refresh; with
+        // stale-while-revalidate the fresh value lands within a few polls.
+        // Without the sidecar-aware discovery this NEVER updates (the cached
+        // entry is reused as long as metadata.json's mtime/size is unchanged).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            let snap = index.snapshot().await;
+            let last = snap.first().map(|s| s.last_activity_at);
+            if last.is_some_and(|l| l > 1000) {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "sidecar activity (events.jsonl mtime) never refreshed \
+                 last_activity_at through the incremental index cache; \
+                 stuck at {last:?}"
+            );
+        }
         let _ = std::fs::remove_dir_all(&home);
     }
 

--- a/crates/freshell-sessions/src/opencode_locator.rs
+++ b/crates/freshell-sessions/src/opencode_locator.rs
@@ -304,6 +304,23 @@ impl OpencodeLocator {
         let mut located = Vec::new();
         let terminal_ids: Vec<String> = inner.armed.keys().cloned().collect();
 
+        // Contested-cwd census over CONTENDERS -- armed terminals with an
+        // in-flight (unresolved) evaluation window -- mirroring the codex
+        // locator's cross-tick census (codex_locator.rs). One new session
+        // row landing inside >=2 same-cwd windows is unattributable: without
+        // this census whichever terminal evaluates first silently claims a
+        // sibling pane's session (and the sibling could claim it too). A
+        // resolved (or never-armed) same-cwd pane is NOT a contender, so an
+        // idle sibling never starves a later solo Enter (the codex census's
+        // P2 rule). Computed BEFORE the per-terminal loop so a terminal
+        // resolving mid-loop still counts against its cwd-mates this tick.
+        let mut cwd_counts: HashMap<String, usize> = HashMap::new();
+        for a in inner.armed.values() {
+            if !a.resolved {
+                *cwd_counts.entry(a.cwd_normalized.clone()).or_insert(0) += 1;
+            }
+        }
+
         for terminal_id in terminal_ids {
             let Some(armed) = inner.armed.get(&terminal_id) else {
                 continue;
@@ -366,6 +383,19 @@ impl OpencodeLocator {
                     terminal_id = %terminal_id,
                     candidates = ?matches.iter().map(|r| r.session_id.clone()).collect::<Vec<_>>(),
                     "opencode_locator_ambiguous: multiple cwd-confirmed opencode session rows within the correlation window; refusing to bind"
+                );
+                continue;
+            }
+
+            if cwd_counts.get(&cwd_normalized).copied().unwrap_or(0) >= 2 {
+                // Contested cwd (see the census above): a sole candidate
+                // visible to >=2 same-cwd in-flight windows is
+                // unattributable — refuse (never guess). Refusal never
+                // disarms: a later solo Enter re-evaluates.
+                tracing::warn!(
+                    terminal_id = %terminal_id,
+                    session_id = %matches[0].session_id,
+                    "opencode_locator_contested_cwd: >=2 contenders (in-flight evaluation windows) share this cwd; refusing to bind"
                 );
                 continue;
             }
@@ -846,6 +876,75 @@ mod tests {
         let located = locator.tick(enter_at + OPENCODE_WINDOW_MS + 1);
         assert_eq!(located.len(), 1);
         assert_eq!(located[0].session_id, "ses_at_enter");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    // -- 16b. contested cwd: ONE new row inside TWO armed same-cwd
+    // terminals' windows must bind NEITHER (mirrors the codex locator's
+    // contested-cwd census, codex_locator.rs). Without the census, pane A
+    // silently claims pane B's session row AND pane B claims it too --
+    // the same session id bound to two different panes. --
+
+    #[test]
+    fn one_row_inside_two_same_cwd_windows_binds_neither_terminal() {
+        let home = unique_temp_dir("contested-cwd");
+        let db = open_seed_db(&home);
+        let locator = OpencodeLocator::new(home.clone());
+
+        assert!(locator.arm("t1", "opencode", true, None, Some("/proj"), 0));
+        assert!(locator.arm("t2", "opencode", true, None, Some("/proj"), 10));
+        assert!(locator.note_submit("t1", 100));
+        assert!(locator.note_submit("t2", 150));
+
+        // Pane t2's real session row -- created after BOTH arms, same cwd,
+        // so it is a candidate inside BOTH evaluation windows.
+        insert_session(&db, "ses_contested", "/proj", 200, None, None);
+
+        let located = locator.tick(150 + OPENCODE_WINDOW_MS + 1);
+        assert!(
+            located.is_empty(),
+            "a row claimable by >=2 same-cwd contenders is unattributable and \
+             must bind NOBODY, got: {located:?}"
+        );
+        assert_eq!(
+            locator.armed_count(),
+            2,
+            "contested refusal must not disarm (a later solo Enter re-evaluates)"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    // -- 16c. no starvation: an armed same-cwd sibling with NO in-flight
+    // evaluation window (its spawn-anchored evaluation already resolved
+    // empty) is NOT a contender -- a later solo Enter still binds. Mirrors
+    // the codex census's contender definition (in-flight windows only;
+    // codex_locator.rs P2 incident 2026-07-27). --
+
+    #[test]
+    fn solo_enter_still_binds_when_same_cwd_sibling_has_no_open_window() {
+        let home = unique_temp_dir("census-no-starvation");
+        let db = open_seed_db(&home);
+        let locator = OpencodeLocator::new(home.clone());
+
+        assert!(locator.arm("t1", "opencode", true, None, Some("/proj"), 0));
+        assert!(locator.arm("t2", "opencode", true, None, Some("/proj"), 10));
+        // Both spawn-anchored evaluations resolve EMPTY (no rows yet).
+        assert!(locator.tick(10 + OPENCODE_WINDOW_MS + 1).is_empty());
+        assert_eq!(locator.armed_count(), 2);
+
+        // Only t2 re-opens a window (solo Enter); its row appears inside it.
+        let enter_at = 10_000;
+        assert!(locator.note_submit("t2", enter_at));
+        insert_session(&db, "ses_solo", "/proj", enter_at + 50, None, None);
+
+        let located = locator.tick(enter_at + OPENCODE_WINDOW_MS + 1);
+        assert_eq!(
+            located.len(),
+            1,
+            "an idle armed sibling must not starve the solo contender"
+        );
+        assert_eq!(located[0].terminal_id, "t2");
+        assert_eq!(located[0].session_id, "ses_solo");
         let _ = std::fs::remove_dir_all(&home);
     }
 

--- a/crates/freshell-terminal/src/output_queue.rs
+++ b/crates/freshell-terminal/src/output_queue.rs
@@ -18,8 +18,15 @@
 //! `(terminalId, connection)` broker attachment; only replay/live terminal
 //! OUTPUT frames pass through it (`broker.ts` calls
 //! `attachment.queue.enqueue()` only for those -- `attach.ready`,
-//! `terminal.created`, `terminal.exit`, etc. are sent directly and are never
-//! subject to eviction).
+//! `terminal.created`, etc. are sent directly and are never subject to
+//! eviction). ONE deliberate Rust-port deviation: `terminal.exit` ALSO
+//! travels this queue (as a non-evictable, zero-weight sequenced frame via
+//! [`OutputQueue::push_sequenced`]) because the port's connection loop
+//! drains its direct channel ahead of this queue -- a directly-sent exit
+//! would deterministically overtake still-queued replay/final output on the
+//! wire, and the client's exit teardown then discards that output (blank
+//! exited pane on attach-to-an-exited-terminal; truncated tail on a busy
+//! live exit). See `freshell-ws::backpressure`'s `route`.
 //!
 //! The Rust port's connection loop (`freshell-ws::terminal::run`) instead
 //! multiplexes EVERY server-to-client message for a connection (all
@@ -85,7 +92,11 @@ pub fn output_frame_meta(msg: &ServerMessage) -> Option<OutputFrameMeta> {
 struct QueuedItem {
     msg: ServerMessage,
     bytes: usize,
-    meta: OutputFrameMeta,
+    /// `Some` for a measured, evictable output frame; `None` for a sequenced
+    /// control frame ([`OutputQueue::push_sequenced`]) that must keep its
+    /// FIFO position relative to output but is NEVER evicted and carries no
+    /// queued-byte weight.
+    meta: Option<OutputFrameMeta>,
 }
 
 /// A pending, not-yet-delivered gap. Kept per-stream (mirrors legacy's
@@ -140,9 +151,35 @@ impl OutputQueue {
     /// (mirrors `enqueue(frame, queuedBytes = frame.bytes)`). Evicts the
     /// oldest frames first if this push takes the queue over `max_bytes`.
     pub fn push(&mut self, msg: ServerMessage, bytes: usize, meta: OutputFrameMeta) {
-        self.items.push_back(QueuedItem { msg, bytes, meta });
+        self.items.push_back(QueuedItem {
+            msg,
+            bytes,
+            meta: Some(meta),
+        });
         self.total_bytes += bytes;
         self.evict_overflow();
+    }
+
+    /// Push a sequenced CONTROL frame (e.g. `terminal.exit`) that must be
+    /// delivered strictly AFTER every output frame already queued here, but
+    /// is never itself evicted and never counts toward the byte budget.
+    ///
+    /// Why: the producer side guarantees `terminal.exit` is emitted only
+    /// after the final `terminal.output` frame (`crate::pty`'s ExitHook
+    /// contract; the registry's attach enqueues ready -> replay -> exit). A
+    /// connection loop that sends direct frames ahead of this queue would
+    /// invert that order whenever output is still pending -- the client's
+    /// exit teardown then discards the queued replay (a blank exited pane).
+    /// Routing the exit through the SAME FIFO preserves the wire order.
+    /// Zero-byte weight keeps `evict_overflow`'s loop invariant airtight
+    /// (`total_bytes > max_bytes` always implies an evictable frame exists)
+    /// and keeps [`Self::pending_bytes`] an output-only backpressure proxy.
+    pub fn push_sequenced(&mut self, msg: ServerMessage) {
+        self.items.push_back(QueuedItem {
+            msg,
+            bytes: 0,
+            meta: None,
+        });
     }
 
     /// Bytes currently retained (NEVER exceeds `max_bytes` after `push`
@@ -190,12 +227,22 @@ impl OutputQueue {
 
     fn evict_overflow(&mut self) {
         while self.total_bytes > self.max_bytes {
-            let Some(dropped) = self.items.pop_front() else {
+            // Evict the OLDEST measured output frame; sequenced control
+            // frames (`push_sequenced`, meta `None`) keep their FIFO slot and
+            // are never dropped -- losing a queued `terminal.exit` would
+            // leave the client's pane running forever. They carry zero bytes,
+            // so `total_bytes > max_bytes` guarantees an evictable frame
+            // exists (the `else break` is unreachable-in-practice safety).
+            let Some(index) = self.items.iter().position(|item| item.meta.is_some()) else {
+                break;
+            };
+            let Some(dropped) = self.items.remove(index) else {
                 break;
             };
             self.total_bytes -= dropped.bytes;
             self.dropped_frames += 1;
-            self.extend_gap(dropped.meta);
+            let meta = dropped.meta.expect("evicted items carry output meta");
+            self.extend_gap(meta);
         }
     }
 
@@ -359,6 +406,68 @@ mod tests {
         // 10 pushes of 100 bytes each into a 150-byte cap: only the LAST
         // frame (seq 9) fits after eviction settles.
         assert_eq!(gap.to_seq, 8);
+    }
+
+    fn exit_msg(terminal_id: &str) -> ServerMessage {
+        ServerMessage::TerminalExit(freshell_protocol::TerminalExit {
+            exit_code: 0,
+            terminal_id: terminal_id.to_string(),
+        })
+    }
+
+    /// A sequenced control frame keeps its FIFO position: output pushed
+    /// before it drains before it, output pushed after drains after it.
+    #[test]
+    fn sequenced_frame_preserves_fifo_position_relative_to_output() {
+        let mut q = OutputQueue::new(1_000_000);
+        push_frame(&mut q, 1, 1, 100);
+        q.push_sequenced(exit_msg("term-1"));
+
+        let drained = q.drain_all();
+        assert_eq!(drained.len(), 2);
+        assert!(matches!(drained[0], ServerMessage::TerminalOutput(_)));
+        assert!(
+            matches!(drained[1], ServerMessage::TerminalExit(_)),
+            "exit stays strictly after the output it followed"
+        );
+    }
+
+    /// A sequenced control frame is NEVER evicted by an overflow (losing a
+    /// queued `terminal.exit` would leave the pane running forever), carries
+    /// no byte weight, and never appears in a gap range.
+    #[test]
+    fn sequenced_frame_survives_overflow_eviction_and_carries_no_weight() {
+        let mut q = OutputQueue::new(150); // room for ~1 output frame
+        push_frame(&mut q, 1, 1, 100);
+        q.push_sequenced(exit_msg("term-1"));
+        assert_eq!(q.pending_bytes(), 100, "sequenced frames weigh nothing");
+
+        // Another terminal floods the SAME connection queue past the cap:
+        // eviction must skip the sequenced frame and drop output only.
+        push_frame(&mut q, 2, 2, 100); // 200 > 150 -> evict oldest OUTPUT (seq 1)
+        assert!(q.pending_bytes() <= 150);
+
+        let drained = q.drain_all();
+        let ServerMessage::TerminalOutputGap(gap) = &drained[0] else {
+            panic!("expected the overflow gap first, got {:?}", drained[0]);
+        };
+        assert_eq!((gap.from_seq, gap.to_seq), (1, 1), "gap covers output only");
+        assert!(
+            drained
+                .iter()
+                .any(|m| matches!(m, ServerMessage::TerminalExit(_))),
+            "the sequenced exit must survive eviction: {drained:?}"
+        );
+        // And it still sits BEFORE the output that was pushed after it.
+        let exit_pos = drained
+            .iter()
+            .position(|m| matches!(m, ServerMessage::TerminalExit(_)))
+            .unwrap();
+        let out_pos = drained
+            .iter()
+            .position(|m| matches!(m, ServerMessage::TerminalOutput(_)))
+            .unwrap();
+        assert!(exit_pos < out_pos, "FIFO position preserved: {drained:?}");
     }
 
     /// Two different terminals/streams overflowing on the SAME connection's

--- a/crates/freshell-terminal/src/registry.rs
+++ b/crates/freshell-terminal/src/registry.rs
@@ -249,6 +249,21 @@ struct TerminalShared {
     create_request_id: Option<String>,
     /// Attached connections, keyed by connection id (multi-client fan-out, `§7.3`).
     subscribers: HashMap<u64, Subscriber>,
+    /// Whether the client EXPLICITLY released its last reference to this
+    /// terminal (`terminal.detach` emptying `subscribers`) — as opposed to
+    /// merely losing its socket (`remove_connection`: browser closed, laptop
+    /// asleep, network drop). The client's detach reconciler
+    /// (`src/store/terminalDetachMiddleware.ts`) sends `terminal.detach` only
+    /// when a terminal disappears from EVERY pane layout, so an explicit
+    /// detach means "orphaned — nobody wants this anymore" while a
+    /// connection drop means "detached but still wanted" (the tmux-style
+    /// background-session promise, §1.3). `enforce_idle_kills` reaps
+    /// released terminals at the configured threshold (legacy cleanup) but
+    /// grants un-released ones the 24h hard cap instead of silently
+    /// SIGKILLing a wanted background shell after ~15 idle minutes.
+    /// Starts `true` (a never-attached row keeps legacy fast-reap
+    /// eligibility); any successful attach flips it `false`.
+    released_by_client: bool,
 }
 
 impl TerminalShared {
@@ -849,8 +864,13 @@ impl TerminalRegistry {
         )
     }
 
-    /// ITEM-3: idle hard cap for agent modes (see [`Self::is_agent_mode`]).
-    const AGENT_IDLE_HARD_CAP_MS: i64 = 24 * 60 * 60 * 1000;
+    /// ITEM-3: idle hard cap for agent modes (see [`Self::is_agent_mode`])
+    /// AND for detached-but-wanted terminals of any mode (connection lost
+    /// without an explicit `terminal.detach` — see
+    /// `TerminalShared::released_by_client`). Keeps the sweep as a cleanup
+    /// backstop for wedged/leaked rows without silently SIGKILLing a
+    /// background session the user intends to come back to.
+    const IDLE_HARD_CAP_MS: i64 = 24 * 60 * 60 * 1000;
 
     /// `enforceIdleKills()` (`terminal-registry.ts:1406-1425`): auto-kill every
     /// DETACHED **running** terminal idle beyond the configured threshold.
@@ -862,7 +882,13 @@ impl TerminalRegistry {
     /// Agent-mode terminals (see [`Self::is_agent_mode`]) use a 24-hour
     /// hard cap instead of the configured threshold — PTY silence is not
     /// idleness for an agent mid-work, but the sweep stays their cleanup
-    /// backstop for wedged exit detection (ITEM-3, ledger A14). Returns the
+    /// backstop for wedged exit detection (ITEM-3, ledger A14). The same
+    /// hard cap protects detached-but-WANTED terminals of any mode — ones
+    /// whose client socket dropped without an explicit `terminal.detach`
+    /// (browser closed, laptop asleep): the configured threshold applies
+    /// only to genuinely-orphaned rows (`released_by_client`), so a
+    /// background shell the user intends to return to is never silently
+    /// killed after mere idle minutes (§1.3). Returns the
     /// killed terminal ids (empty when nothing was eligible), for callers that
     /// want to log/observe the sweep and for deterministic test assertions.
     ///
@@ -895,8 +921,22 @@ impl TerminalRegistry {
                     // otherwise a detached animated TUI (spinner / ticking
                     // counter) is exempt from this sweep forever.
                     let idle_ms = now.saturating_sub(s.last_meaningful_activity_at);
-                    if Self::is_agent_mode(&s.mode) && idle_ms < Self::AGENT_IDLE_HARD_CAP_MS {
-                        // ITEM-3: agent session within the hard cap — spare.
+                    // Two classes get the 24h hard cap instead of the
+                    // configured threshold:
+                    //  * ITEM-3: agent sessions (PTY silence is not idleness
+                    //    for an agent mid-work);
+                    //  * detached-but-WANTED terminals: the client never
+                    //    explicitly released this terminal (its socket merely
+                    //    dropped — browser closed, laptop asleep). The tmux
+                    //    promise (§1.3 "background session") forbids silently
+                    //    SIGKILLing it after mere idle minutes; the hard cap
+                    //    keeps the sweep as the wedge/leak cleanup backstop.
+                    // Only genuinely-orphaned rows (explicit `terminal.detach`
+                    // of the last reference, or never referenced at all) are
+                    // reaped at the configured threshold, as before.
+                    if (Self::is_agent_mode(&s.mode) || !s.released_by_client)
+                        && idle_ms < Self::IDLE_HARD_CAP_MS
+                    {
                         return None;
                     }
                     if idle_ms < idle_threshold_ms {
@@ -1020,6 +1060,7 @@ impl TerminalRegistry {
             resume_session_id: resume_session_id.map(str::to_string),
             create_request_id: create_request_id.map(str::to_string),
             subscribers: HashMap::new(),
+            released_by_client: true,
         }));
 
         // The reader thread invokes this for every framed terminal.output: append to
@@ -1194,6 +1235,11 @@ impl TerminalRegistry {
                 terminal_output_batch_v1,
             },
         );
+        // Somebody attached => this terminal is wanted. A later socket drop
+        // (remove_connection) must NOT re-mark it fast-reap eligible — only an
+        // explicit `terminal.detach` of the last reference does (see
+        // `released_by_client`'s field docs).
+        s.released_by_client = false;
 
         let ready = ServerMessage::TerminalAttachReady(TerminalAttachReady {
             head_seq,
@@ -1270,6 +1316,13 @@ impl TerminalRegistry {
                 // threshold of grace — its meaningful clock may have expired
                 // while a watcher was attached (attached => reaper-exempt).
                 s.last_meaningful_activity_at = s.last_meaningful_activity_at.max(now_ms());
+                // The client explicitly released its LAST reference (the
+                // detach reconciler only sends `terminal.detach` when a
+                // terminal is gone from every pane layout): this terminal is
+                // now genuinely orphaned and reap-eligible at the configured
+                // threshold. Contrast `remove_connection`, which never sets
+                // this — a dropped socket is not a released terminal.
+                s.released_by_client = true;
             }
         }
     }
@@ -1841,6 +1894,7 @@ impl TerminalRegistry {
             resume_session_id: opts.resume_session_id,
             create_request_id,
             subscribers: HashMap::new(),
+            released_by_client: true,
         }));
         {
             let mut inner = self.inner.lock().expect("registry lock");
@@ -4108,6 +4162,82 @@ mod tests {
         // T was freshly detached by the disconnect => spared one threshold.
         // U never had a subscriber => its stale countdown stands => reaped.
         assert_eq!(killed, vec!["U".to_string()]);
+        assert_eq!(reg.inventory().len(), 1);
+    }
+
+    #[test]
+    fn enforce_idle_kills_spares_disconnect_detached_terminal_past_threshold() {
+        // The background-session promise (§1.3, "what if tmux and Claude fell
+        // in love"): a user who closes the browser / sleeps the laptop with a
+        // quiet shell in a pane must find it ALIVE when they come back — the
+        // client never sent terminal.detach, so the terminal is detached but
+        // still wanted. Before the fix, 20 idle minutes past the default
+        // 15-minute autoKillIdleMinutes threshold silently SIGKILLed it
+        // (scrollback gone). Now only the 24h hard cap applies.
+        let reg = TerminalRegistry::new();
+        reg.insert_headless("T", "S");
+        let (sink, _seen) = collector();
+        assert!(
+            reg.attach("T", 1, sink, Some("a".into()), 0, false, None)
+                .found
+        );
+        reg.set_auto_kill_idle_minutes(15); // the shipped default
+        reg.remove_connection(1); // socket drop, NOT an explicit detach
+                                  // 20 minutes idle — past the old ~15-minute threshold, far under 24h.
+        reg.backdate_last_activity("T", now_ms() - 20 * 60_000);
+
+        let killed = reg.enforce_idle_kills();
+
+        assert!(
+            killed.is_empty(),
+            "a detached-but-wanted terminal (connection lost, never released) \
+             must survive past the configured idle threshold, got {killed:?}"
+        );
+        assert_eq!(reg.inventory().len(), 1);
+    }
+
+    #[test]
+    fn enforce_idle_kills_reaps_disconnect_detached_terminal_past_the_hard_cap() {
+        // Counterweight: the sweep stays the cleanup backstop for sessions
+        // whose client never comes back — same 24h hard cap agents get.
+        let reg = TerminalRegistry::new();
+        reg.insert_headless("T", "S");
+        let (sink, _seen) = collector();
+        assert!(
+            reg.attach("T", 1, sink, Some("a".into()), 0, false, None)
+                .found
+        );
+        reg.set_auto_kill_idle_minutes(15);
+        reg.remove_connection(1);
+        // 25 hours stale — past the 24-hour hard cap.
+        reg.backdate_last_activity("T", now_ms() - 25 * 60 * 60_000);
+
+        assert_eq!(reg.enforce_idle_kills(), vec!["T".to_string()]);
+    }
+
+    #[test]
+    fn reattach_after_explicit_detach_restores_disconnect_protection() {
+        // released_by_client must be a live flag, not a one-way latch:
+        // detach (orphaned) -> reattach (wanted again) -> socket drop must
+        // land back in the protected detached-but-wanted state.
+        let reg = TerminalRegistry::new();
+        reg.insert_headless("T", "S");
+        let (sink, _seen) = collector();
+        assert!(
+            reg.attach("T", 1, sink, Some("a".into()), 0, false, None)
+                .found
+        );
+        reg.detach("T", 1); // explicitly released — fast-reap eligible
+        let (sink2, _seen2) = collector();
+        assert!(
+            reg.attach("T", 2, sink2, Some("b".into()), 0, false, None)
+                .found
+        );
+        reg.set_auto_kill_idle_minutes(15);
+        reg.remove_connection(2); // wanted again, then socket drop
+        reg.backdate_last_activity("T", now_ms() - 20 * 60_000);
+
+        assert!(reg.enforce_idle_kills().is_empty());
         assert_eq!(reg.inventory().len(), 1);
     }
 

--- a/crates/freshell-ws/src/backpressure.rs
+++ b/crates/freshell-ws/src/backpressure.rs
@@ -117,9 +117,30 @@ impl ConnectionOutputQueue {
     /// handed straight back (`Some(msg)`) so the caller sends it directly and
     /// unconditionally -- mirrors legacy exactly: only replay/live output
     /// passes through `ClientOutputQueue`; every other frame family
-    /// (`attach.ready`, `terminal.created`, `terminal.exit`, ...) is sent
-    /// immediately and is never subject to eviction.
+    /// (`attach.ready`, `terminal.created`, ...) is sent immediately and is
+    /// never subject to eviction. ONE deliberate deviation: `terminal.exit`
+    /// also travels the queue (non-evictable, zero-weight) to preserve its
+    /// output-then-exit wire order -- see the comment inside.
     pub fn route(&self, msg: ServerMessage) -> Option<ServerMessage> {
+        // `terminal.exit` is the ONE non-output frame with a producer-side
+        // ordering guarantee AGAINST output: it is only ever emitted after
+        // the final `terminal.output` frame (`freshell_terminal::pty`'s
+        // ExitHook contract; the registry's attach enqueues ready -> replay
+        // -> exit). Sending it on the direct channel while output waits in
+        // this queue would invert that order on the wire -- the connection
+        // loop drains direct frames FIRST -- and the client's exit teardown
+        // then discards the still-queued replay/final output (blank exited
+        // pane on attach-to-exited; truncated tail on a busy live exit). It
+        // therefore travels the SAME FIFO, as a non-evictable, zero-weight
+        // sequenced frame (never dropped, never counted as backpressure).
+        if matches!(msg, ServerMessage::TerminalExit(_)) {
+            {
+                let mut queue = self.inner.lock().expect("output queue mutex poisoned");
+                queue.push_sequenced(msg);
+            }
+            self.notify.notify_one();
+            return None;
+        }
         let Some(meta) = output_frame_meta(&msg) else {
             // Not a queueable output frame -- hand it straight back so the
             // caller sends it directly and unconditionally.
@@ -233,6 +254,55 @@ mod tests {
         assert!(
             m.tick(200),
             "sustained overflow past the stall duration must fire"
+        );
+    }
+
+    /// The producer-side invariant "terminal.exit can never overtake the
+    /// final terminal.output frames" (freshell-terminal/src/pty.rs:47-55;
+    /// registry attach enqueues ready -> replay -> exit) must survive the
+    /// connection loop's dual-channel design: output frames travel this
+    /// bounded queue while direct frames travel `conn_rx`, and the loop
+    /// drains `conn_rx` FIRST (terminal.rs `output_queue.notified()` arm).
+    /// If `route` hands a `TerminalExit` straight back while output is
+    /// pending here, the exit deterministically overtakes the replay on the
+    /// wire and the client's exit teardown discards the still-queued
+    /// scrollback (blank exited pane -- DEFECT 5b resurfaced at the ws
+    /// layer). `terminal.exit` must therefore travel the SAME FIFO.
+    #[test]
+    fn terminal_exit_never_overtakes_queued_output() {
+        let q = ConnectionOutputQueue::new(1_000_000);
+        let output = ServerMessage::TerminalOutput(freshell_protocol::TerminalOutput {
+            data: "final error text".to_string(),
+            seq_start: 1,
+            seq_end: 1,
+            stream_id: "s".to_string(),
+            terminal_id: "t".to_string(),
+            attach_request_id: Some("req-1".to_string()),
+            source: None,
+        });
+        assert!(q.route(output).is_none(), "output frame is queued");
+
+        let exit = ServerMessage::TerminalExit(freshell_protocol::TerminalExit {
+            exit_code: 1,
+            terminal_id: "t".to_string(),
+        });
+        assert!(
+            q.route(exit).is_none(),
+            "terminal.exit must travel the same FIFO as queued output, \
+             else it overtakes the replay/final output on the wire"
+        );
+
+        let drained = q.drain_all();
+        assert_eq!(drained.len(), 2);
+        assert!(
+            matches!(drained[0], ServerMessage::TerminalOutput(_)),
+            "output first, got {:?}",
+            drained[0]
+        );
+        assert!(
+            matches!(drained[1], ServerMessage::TerminalExit(_)),
+            "exit strictly after the output it followed, got {:?}",
+            drained[1]
         );
     }
 

--- a/crates/freshell-ws/src/opencode_association.rs
+++ b/crates/freshell-ws/src/opencode_association.rs
@@ -131,6 +131,15 @@ pub(crate) async fn drain_and_associate(state: &WsState) {
             );
             continue;
         }
+        // Claim guards on the id being adopted (parity with the codex
+        // adoption tail's `codex_identity::codex_claim_refused` and the
+        // opencode SIGNAL lane's `target_session_guards_pass` — this
+        // locator lane previously had neither, so a sole cwd-matching
+        // candidate could silently rebind another pane's (or a fresh
+        // agent's) session onto this terminal).
+        if opencode_claim_refused(state, &located.terminal_id, &located.session_id).await {
+            continue;
+        }
 
         state.identity.upsert(
             &located.terminal_id,
@@ -256,6 +265,61 @@ async fn classify_resume_target_task(
             crate::terminal::broadcast_terminals_changed(&state);
         }
     }
+}
+
+/// Shared misbind guards for the locator adoption lane. `session_id` is the
+/// id being CLAIMED. Mirrors `codex_identity::codex_claim_refused` (the
+/// codex adoption tail's REQUIRED A4 misbind hardening) and the opencode
+/// signal lane's `target_session_guards_pass` semantics:
+/// - retired-INCLUSIVE bound-elsewhere (ledger A8): a session bound to
+///   ANOTHER terminal — live or retired — must never be re-adopted here.
+///   Reachable with two panes in one cwd: pane A's `ses_*` row lands inside
+///   pane B's Enter window before B's own row exists, so B's locator emits
+///   A's id as a clean sole candidate. Same-terminal re-adopt is an
+///   idempotent allow.
+/// - fresh-agent exclusion (the codex B2xB4 twin): the fresh-agent
+///   `opencode serve` inherits the server env and writes the SAME
+///   `<HOME>/.local/share/opencode/opencode.db` this locator row-diffs, so
+///   an agent chat materializing its session in the pane's cwd inside the
+///   window would misbind as a sole candidate. A session the server knows
+///   as a fresh-agent session — live in the fresh_opencode session map, or
+///   recorded by the durable kind:fresh-agent ledger row — must never bind
+///   to a terminal pane.
+async fn opencode_claim_refused(state: &WsState, terminal_id: &str, session_id: &str) -> bool {
+    if let Some(existing) = state
+        .identity
+        .find_by_session_including_retired("opencode", session_id)
+    {
+        if existing != terminal_id {
+            tracing::warn!(
+                terminal_id = %terminal_id,
+                session_id = %session_id,
+                "opencode_association_rejected: session_bound_elsewhere"
+            );
+            return true;
+        }
+    }
+    if state.fresh_opencode.has_live_session(session_id).await {
+        tracing::warn!(
+            terminal_id = %terminal_id,
+            session_id = %session_id,
+            "opencode_association_rejected: freshagent_live_session"
+        );
+        return true;
+    }
+    if state
+        .pane_ledger
+        .lookup_by_session("opencode", session_id)
+        .is_some_and(|r| r.row.pane_kind.as_deref() == Some("fresh-agent"))
+    {
+        tracing::warn!(
+            terminal_id = %terminal_id,
+            session_id = %session_id,
+            "opencode_association_rejected: freshagent_ledger_row"
+        );
+        return true;
+    }
+    false
 }
 
 /// Fan `terminal.session.associated` (the sessionRef the client's
@@ -963,6 +1027,217 @@ mod tests {
                 .is_none(),
             "no ledger binding may be written for the rejected candidate"
         );
+
+        state.registry.kill("t1");
+        let _ = std::fs::remove_dir_all(&home);
+        let _ = std::fs::remove_dir_all(&ledger_dir);
+    }
+
+    /// One-writer defense, locator lane (mirror of `codex_association.rs`'s
+    /// `located_session_bound_elsewhere_is_rejected`): a session already
+    /// bound to ANOTHER terminal (including a retired binding) must never be
+    /// re-adopted by the drain. Two live panes in one cwd are enough to
+    /// reach this in production: pane A's `ses_*` row lands inside pane B's
+    /// Enter window before B's own row exists, so B's locator emits A's id
+    /// as a clean sole candidate.
+    #[tokio::test]
+    async fn located_session_bound_elsewhere_is_rejected() {
+        const SID: &str = "ses_boundelsewhere0000000000";
+        let home = unique_temp_dir("bound-elsewhere");
+        let (state, _rx) = state_with_locator(home.clone());
+        let db = open_seed_db(&home);
+
+        // The victim's binding, RETIRED — exactly the state the exit path
+        // leaves behind (terminal.rs's exit hook calls identity.retire).
+        // Retired-INCLUSIVE is the point: a dead pane's identity must still
+        // repel adoption by another terminal.
+        state.identity.upsert(
+            "victim",
+            Some("opencode"),
+            Some(SID),
+            Some("/tmp"),
+            now_ms(),
+        );
+        assert!(state.identity.retire("victim"));
+
+        let spec = freshell_platform::build_spawn_spec(
+            freshell_platform::ShellType::System,
+            freshell_platform::detect::HostOs::Linux,
+            false,
+            Some("/tmp"),
+            &freshell_platform::RealEnv,
+            &freshell_platform::RealFileProbe,
+            &std::collections::BTreeMap::new(),
+            None,
+            None,
+        );
+        state
+            .registry
+            .create(
+                &spec,
+                &std::collections::BTreeMap::new(),
+                "t1".to_string(),
+                "stream-1".to_string(),
+                "opencode",
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("spawn a real shell for the test PTY");
+        state
+            .registry
+            .set_meta("t1", None, None, Some("opencode".to_string()), None);
+
+        maybe_arm(&state, "t1", "opencode", Some("/tmp"), None);
+        note_possible_submit(&state, "t1", "\r");
+
+        // The bound-elsewhere session's row appears inside t1's window with
+        // t1's own cwd — a fully resolvable sole candidate, or this test
+        // proves nothing.
+        insert_session(&db, SID, "/tmp", crate::terminal::now_ms(), None, None);
+
+        // Drive drains until the locator EMITS (tick disarms on emission —
+        // armed_count 0 is the positive proof the Located event reached the
+        // drain's guards, not that the locator never resolved).
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let mut emitted = false;
+        for _ in 0..40 {
+            drain_and_associate(&state).await;
+            if state.opencode_locator.as_ref().unwrap().armed_count() == 0 {
+                emitted = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(emitted, "the locator must emit a Located event");
+
+        // Guard refused: nothing adopted.
+        assert!(
+            state.identity.get("t1").is_none(),
+            "a session bound to another terminal must never be adopted"
+        );
+        let entry = state
+            .registry
+            .directory()
+            .into_iter()
+            .find(|e| e.terminal_id == "t1")
+            .unwrap();
+        assert!(entry.resume_session_id.is_none());
+        // The victim's binding is untouched.
+        assert_eq!(
+            state
+                .identity
+                .find_by_session_including_retired("opencode", SID)
+                .as_deref(),
+            Some("victim")
+        );
+
+        state.registry.kill("t1");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// Fresh-agent exclusion, locator lane (mirror of `codex_association.rs`'s
+    /// `located_freshagent_known_thread_is_rejected`): the fresh-agent
+    /// `opencode serve` inherits the server env and writes the SAME
+    /// `<HOME>/.local/share/opencode/opencode.db` the locator row-diffs, so
+    /// an agent chat materializing its `ses_*` row in the pane's cwd inside
+    /// the Enter window is a clean sole candidate. B4's kind:fresh-agent
+    /// ledger row is the exclusion signal: a freshagent-known session must
+    /// never bind to a terminal pane.
+    #[tokio::test]
+    async fn located_freshagent_known_session_is_rejected() {
+        const SID: &str = "ses_freshagentknown00000000";
+        let home = unique_temp_dir("freshagent-known");
+        let ledger_dir = unique_temp_dir("freshagent-known-ledger");
+        let (state, _rx) = state_with_locator_and_ledger(home.clone(), &ledger_dir);
+        let db = open_seed_db(&home);
+
+        // The fresh-agent session's ledger row, exactly what the identity
+        // sink persists at session materialization (durable before answer).
+        state
+            .pane_ledger
+            .record_fresh_agent_binding(&crate::pane_ledger::FreshAgentBindingWrite {
+                provider: "opencode",
+                session_id: SID,
+                mode: "freshopencode",
+                cwd: Some("/tmp"),
+                create_request_id: None,
+                model: Some("some-model"),
+                sandbox: None,
+                permission_mode: None,
+                effort: None,
+                supersedes: None,
+                now_ms: now_ms(),
+            })
+            .expect("seed fresh-agent ledger row");
+
+        let spec = freshell_platform::build_spawn_spec(
+            freshell_platform::ShellType::System,
+            freshell_platform::detect::HostOs::Linux,
+            false,
+            Some("/tmp"),
+            &freshell_platform::RealEnv,
+            &freshell_platform::RealFileProbe,
+            &std::collections::BTreeMap::new(),
+            None,
+            None,
+        );
+        state
+            .registry
+            .create(
+                &spec,
+                &std::collections::BTreeMap::new(),
+                "t1".to_string(),
+                "stream-1".to_string(),
+                "opencode",
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("spawn a real shell for the test PTY");
+        state
+            .registry
+            .set_meta("t1", None, None, Some("opencode".to_string()), None);
+
+        maybe_arm(&state, "t1", "opencode", Some("/tmp"), None);
+        note_possible_submit(&state, "t1", "\r");
+
+        // The fresh-agent serve's row appears in the shared DB with the
+        // pane's own cwd — the exact misbind shape.
+        insert_session(&db, SID, "/tmp", crate::terminal::now_ms(), None, None);
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let mut emitted = false;
+        for _ in 0..40 {
+            drain_and_associate(&state).await;
+            if state.opencode_locator.as_ref().unwrap().armed_count() == 0 {
+                emitted = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(emitted, "the locator must emit a Located event");
+
+        // Guard refused: the fresh-agent session never binds the terminal.
+        assert!(
+            state.identity.get("t1").is_none(),
+            "a fresh-agent session must never bind to a terminal pane"
+        );
+        let entry = state
+            .registry
+            .directory()
+            .into_iter()
+            .find(|e| e.terminal_id == "t1")
+            .unwrap();
+        assert!(entry.resume_session_id.is_none());
+        // The fresh-agent ledger row is untouched (still fresh-agent kind).
+        let hit = state
+            .pane_ledger
+            .lookup_by_session("opencode", SID)
+            .expect("fresh-agent row survives");
+        assert_eq!(hit.row.pane_kind.as_deref(), Some("fresh-agent"));
 
         state.registry.kill("t1");
         let _ = std::fs::remove_dir_all(&home);

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -59,10 +59,10 @@ use freshell_platform::{
     RealFileProbe, ShellType,
 };
 use freshell_protocol::{
-    ClientMessage, ErrorCode, ErrorMsg, Pong, ServerMessage, SessionLocator, Shell, TerminalAttach,
-    TerminalAutoResumeCancel, TerminalCreate, TerminalCreated, TerminalIdOnly,
-    TerminalInputBlocked, TerminalInputBlockedReason, TerminalKill, TerminalMetaRecord,
-    TerminalMetaUpdated, TerminalResize,
+    AgentProvider, ClientMessage, ErrorCode, ErrorMsg, FreshAgentEvent, Pong, ServerMessage,
+    SessionLocator, SessionType, Shell, TerminalAttach, TerminalAutoResumeCancel, TerminalCreate,
+    TerminalCreated, TerminalIdOnly, TerminalInputBlocked, TerminalInputBlockedReason,
+    TerminalKill, TerminalMetaRecord, TerminalMetaUpdated, TerminalResize,
 };
 use freshell_terminal::{build_child_env_from_process, FrameSink};
 
@@ -521,6 +521,14 @@ async fn handle_client_text(
     let Ok(message) = serde_json::from_value::<ClientMessage>(value) else {
         return true;
     };
+    // Silent-drop fix (bug-hunt pbh-20260807): the fresh-agent control frames
+    // this port has no runtime handler for (approval.respond / question.respond /
+    // fork / compact) used to fall into the dispatch's `_ => true` catch-all and
+    // vanish -- the pane hung waiting forever. Answer them BEFORE the typed
+    // dispatch; see `unhandled_fresh_agent_control_reply`.
+    if let Some(reply) = unhandled_fresh_agent_control_reply(&message) {
+        return send(ws_tx, &reply).await;
+    }
     match message {
         // SAFE-08: structured restore-diagnostic record, parity with
         // server/ws-handler.ts:1901-1915's `client_restore_unavailable`
@@ -946,8 +954,16 @@ async fn handle_client_text(
             )
             .await
         }
-        // Everything else (opencode fresh-agent, activity lists, other ui.*) is
-        // out of scope for this path; ignore.
+        // Deliberately inert remainder -- every arm here is unreachable from the
+        // frozen client's live surface: `hello` was already consumed by the
+        // pre-loop handshake (`evaluate_hello`); `ui.layout.sync` is not consumed
+        // anywhere in this port yet (documented deferral --
+        // freshell-freshagent/src/pane_ops.rs `resize_pane`); `codingcli.*` has
+        // no runtime here and the frozen client never sends it (zero senders in
+        // `src/`). The user-reachable fresh-agent control frames
+        // (approval.respond / question.respond / fork / compact) are answered
+        // BEFORE this match by `unhandled_fresh_agent_control_reply` -- they must
+        // never fall through to this silent arm again.
         _ => true,
     }
 }
@@ -4351,6 +4367,90 @@ fn unknown_terminal_input_blocked(terminal_id: &str) -> ServerMessage {
         reason: TerminalInputBlockedReason::UnknownTerminal,
         terminal_id: terminal_id.to_string(),
     })
+}
+
+/// `AgentProvider` -> its wire string (the enum serializes lowercase).
+fn agent_provider_wire(provider: AgentProvider) -> &'static str {
+    match provider {
+        AgentProvider::Claude => "claude",
+        AgentProvider::Codex => "codex",
+        AgentProvider::Opencode => "opencode",
+        AgentProvider::Amplifier => "amplifier",
+    }
+}
+
+/// `SessionType` -> its wire string (the enum serializes lowercase).
+fn session_type_wire(session_type: SessionType) -> &'static str {
+    match session_type {
+        SessionType::Freshclaude => "freshclaude",
+        SessionType::Freshcodex => "freshcodex",
+        SessionType::Kilroy => "kilroy",
+        SessionType::Freshopencode => "freshopencode",
+    }
+}
+
+/// Silent-drop fix (bug-hunt pbh-20260807): the four fresh-agent control frames
+/// the frozen client really sends -- `freshAgent.approval.respond` (Approve/Deny
+/// click, `FreshAgentView.tsx:2208/2339`), `freshAgent.question.respond`
+/// (`:2462`), `freshAgent.fork` (`:1080`) and `freshAgent.compact` (`:1100`) --
+/// previously fell into the typed dispatch's silent `_ => true` catch-all and
+/// vanished: no reply, no log, and the pane hung waiting forever. No runtime
+/// handler exists in this port yet (the claude sidecar's interactive
+/// permission/question response channel is explicitly out of scope --
+/// `crates/freshell-claude-sidecar/index.mjs:42-45` -- and the codex/opencode
+/// slices expose no approval/fork/compact RPC), so follow the kata-dtfn
+/// discipline (see [`unknown_terminal_input_blocked`]): never TOTAL SILENCE for
+/// a user action. Answer with the `freshAgent.error` event shape the client
+/// folds into a visible pane error (`fresh-agent-ws.ts:333-342` -- any code
+/// other than `INVALID_SESSION_ID` dispatches `sessionError`), so the click
+/// fails loudly instead of wedging the pane. Returns `None` for every message
+/// that has a real dispatch arm.
+pub(crate) fn unhandled_fresh_agent_control_reply(
+    message: &ClientMessage,
+) -> Option<ServerMessage> {
+    let (msg_type, provider, session_id, session_type) = match message {
+        ClientMessage::FreshAgentApprovalRespond(m) => (
+            "freshAgent.approval.respond",
+            m.provider,
+            m.session_id.as_str(),
+            m.session_type,
+        ),
+        ClientMessage::FreshAgentQuestionRespond(m) => (
+            "freshAgent.question.respond",
+            m.provider,
+            m.session_id.as_str(),
+            m.session_type,
+        ),
+        ClientMessage::FreshAgentFork(m) => (
+            "freshAgent.fork",
+            m.provider,
+            m.session_id.as_str(),
+            m.session_type,
+        ),
+        ClientMessage::FreshAgentCompact(m) => (
+            "freshAgent.compact",
+            m.provider,
+            m.session_id.as_str(),
+            m.session_type,
+        ),
+        _ => return None,
+    };
+    tracing::warn!(
+        message_type = msg_type,
+        session_id = %session_id,
+        "fresh-agent control frame has no handler in this port; answering freshAgent.error instead of dropping it"
+    );
+    Some(ServerMessage::FreshAgentEvent(FreshAgentEvent {
+        event: serde_json::json!({
+            "type": "freshAgent.error",
+            "sessionId": session_id,
+            "code": "UNSUPPORTED_MESSAGE",
+            "message": format!("{msg_type} is not supported by this server"),
+        }),
+        provider: agent_provider_wire(provider).to_string(),
+        session_id: session_id.to_string(),
+        session_type: session_type_wire(session_type).to_string(),
+    }))
 }
 
 /// `terminal.resize` — resize the shared PTY (`registry.resize`); no dedicated wire

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -160,10 +160,13 @@ pub async fn run(
     // TERM-09: live terminal OUTPUT frames (`TerminalOutput`/`TerminalOutputBatch`)
     // are intercepted by `output_queue` BEFORE reaching this channel -- a bounded,
     // drop-oldest queue (mirrors `ClientOutputQueue`) that keeps ONE slow reader
-    // from growing server memory without bound. Every other frame family
-    // (`attach.ready`, `terminal.created`, `terminal.exit`, ...) is unaffected,
-    // exactly matching legacy's scoping (see `freshell_terminal::output_queue`
-    // and `crate::backpressure` module docs for the full mapping).
+    // from growing server memory without bound. `terminal.exit` ALSO travels the
+    // queue (as a zero-weight, non-evictable sequenced frame) so it can never
+    // overtake queued output/replay and blank an exited pane -- see
+    // `ConnectionOutputQueue::route`. Other frame families (`attach.ready`,
+    // `terminal.created`, ...) go direct on this channel (see
+    // `freshell_terminal::output_queue` and `crate::backpressure` module docs
+    // for the full mapping).
     let (conn_tx, mut conn_rx) = mpsc::unbounded_channel::<ServerMessage>();
     let output_queue = Arc::new(crate::backpressure::ConnectionOutputQueue::new(
         state.term09.queue_max_bytes,

--- a/crates/freshell-ws/tests/freshagent_control_reply.rs
+++ b/crates/freshell-ws/tests/freshagent_control_reply.rs
@@ -1,0 +1,151 @@
+//! Silent-drop fix (bug-hunt pbh-20260807): the fresh-agent control frames the
+//! frozen client really sends -- `freshAgent.approval.respond` (Approve/Deny
+//! click), `freshAgent.question.respond` (question answer), `freshAgent.fork`
+//! and `freshAgent.compact` -- used to fall into the typed dispatch's silent
+//! `_ => true` catch-all (`terminal.rs`) and vanish: no reply, no log, and the
+//! pane hung waiting forever. They must now answer on the wire with the
+//! `freshAgent.error` event shape the client renders as a visible pane error
+//! (`fresh-agent-ws.ts:333-342`) instead of being dropped.
+//!
+//! These tests drive a REAL axum server + REAL tokio-tungstenite client (same
+//! harness as `unknown_terminal_reply.rs`, the kata-dtfn precedent). On the
+//! pre-fix dispatch every test here times out waiting for ANY reply frame.
+
+mod common;
+use common::*;
+
+use futures_util::SinkExt;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+async fn send_json(ws: &mut TestWs, value: serde_json::Value) {
+    ws.send(WsMessage::Text(value.to_string()))
+        .await
+        .expect("send control frame");
+}
+
+/// Assert the `freshAgent.event` reply wraps a visible (non-lost-session)
+/// `freshAgent.error` for `session_id`.
+fn assert_visible_error(frame: &serde_json::Value, session_id: &str, provider: &str) {
+    assert_eq!(frame["provider"], serde_json::json!(provider));
+    assert_eq!(frame["sessionId"], serde_json::json!(session_id));
+    assert_eq!(
+        frame["event"]["type"],
+        serde_json::json!("freshAgent.error")
+    );
+    assert_eq!(frame["event"]["sessionId"], serde_json::json!(session_id));
+    // Any code OTHER than INVALID_SESSION_ID renders as a visible pane error
+    // client-side (`sessionError`); INVALID_SESSION_ID would instead mark the
+    // session lost and trigger recovery, which this is not.
+    assert_eq!(
+        frame["event"]["code"],
+        serde_json::json!("UNSUPPORTED_MESSAGE")
+    );
+    assert!(
+        frame["event"]["message"]
+            .as_str()
+            .expect("error message is a string")
+            .contains("not supported"),
+        "the error must name the unsupported control frame: {frame}"
+    );
+}
+
+#[tokio::test]
+async fn approval_respond_answers_with_a_visible_fresh_agent_error() {
+    let (url, _registry) = spawn_server().await;
+    let (mut ws, _inventory) = connect_and_capture_inventory(&url).await;
+
+    // The exact frame shape FreshAgentView.tsx:2339 sends on an Approve click.
+    send_json(
+        &mut ws,
+        serde_json::json!({
+            "type": "freshAgent.approval.respond",
+            "provider": "claude",
+            "sessionId": "ses-approve-1",
+            "sessionType": "freshclaude",
+            "decision": { "approved": true, "scope": "once" },
+            "requestId": "perm-1",
+        }),
+    )
+    .await;
+
+    let frame = next_frame_of_type(&mut ws, "freshAgent.event").await;
+    assert_visible_error(&frame, "ses-approve-1", "claude");
+}
+
+#[tokio::test]
+async fn question_respond_answers_with_a_visible_fresh_agent_error() {
+    let (url, _registry) = spawn_server().await;
+    let (mut ws, _inventory) = connect_and_capture_inventory(&url).await;
+
+    // FreshAgentView.tsx:2462's answer frame (requestId may be a number).
+    send_json(
+        &mut ws,
+        serde_json::json!({
+            "type": "freshAgent.question.respond",
+            "provider": "claude",
+            "sessionId": "ses-question-1",
+            "sessionType": "freshclaude",
+            "answers": { "q1": "yes" },
+            "requestId": 42,
+        }),
+    )
+    .await;
+
+    let frame = next_frame_of_type(&mut ws, "freshAgent.event").await;
+    assert_visible_error(&frame, "ses-question-1", "claude");
+}
+
+#[tokio::test]
+async fn fork_answers_with_a_visible_fresh_agent_error() {
+    let (url, _registry) = spawn_server().await;
+    let (mut ws, _inventory) = connect_and_capture_inventory(&url).await;
+
+    // FreshAgentView.tsx:1080's fork frame.
+    send_json(
+        &mut ws,
+        serde_json::json!({
+            "type": "freshAgent.fork",
+            "provider": "codex",
+            "sessionId": "ses-fork-1",
+            "sessionType": "freshcodex",
+            "requestId": "fork-req-1",
+        }),
+    )
+    .await;
+
+    let frame = next_frame_of_type(&mut ws, "freshAgent.event").await;
+    assert_visible_error(&frame, "ses-fork-1", "codex");
+}
+
+#[tokio::test]
+async fn compact_answers_with_a_visible_fresh_agent_error() {
+    let (url, _registry) = spawn_server().await;
+    let (mut ws, _inventory) = connect_and_capture_inventory(&url).await;
+
+    // FreshAgentView.tsx:1100's compact frame.
+    send_json(
+        &mut ws,
+        serde_json::json!({
+            "type": "freshAgent.compact",
+            "provider": "claude",
+            "sessionId": "ses-compact-1",
+            "sessionType": "freshclaude",
+        }),
+    )
+    .await;
+
+    let frame = next_frame_of_type(&mut ws, "freshAgent.event").await;
+    assert_visible_error(&frame, "ses-compact-1", "claude");
+}
+
+#[tokio::test]
+async fn handled_control_frames_still_reach_their_dispatch_arms() {
+    // Guard: the interception must not swallow a HANDLED sibling -- `ping`
+    // (the simplest round-trip control frame) still answers `pong`.
+    let (url, _registry) = spawn_server().await;
+    let (mut ws, _inventory) = connect_and_capture_inventory(&url).await;
+
+    send_json(&mut ws, serde_json::json!({ "type": "ping" })).await;
+    let frame = next_frame_of_type(&mut ws, "pong").await;
+    assert!(frame["timestamp"].is_string(), "pong carries a timestamp");
+}

--- a/docs/pbh-20260807/ANALYSIS-2.md
+++ b/docs/pbh-20260807/ANALYSIS-2.md
@@ -1,0 +1,205 @@
+# ANALYSIS-2 — pbh-20260807 (post late-harvest)
+
+Analyst: fable. Supersedes any earlier analysis written before the deep workers delivered.
+
+**Reframe (ground truth from this run):** the original 1-hour budget was mis-sized, not the
+workers. Deep flat-rate map workers legitimately take ~5–5.6 h; hunts ~3+ h. The four deep maps
+and one hunt that "ran long" delivered the highest-density artifacts of the run. Everything
+below treats the late artifacts as first-class primary sources.
+
+Sources (all complete): mm-mass, mm-churn (mechanical, ~30–40 min); mp-promise-docs,
+mp-promise-ui (promise ledgers, ~4.8–5.3 h); mf-server, mf-ws (fan inventories, ~5.2–5.6 h);
+h-freshagent-ws (hunt, ~3.2 h). Deduped against FIX-LOG.md F1–F8 (F3 adjudicated already-fixed).
+
+Scope: Rust `crates/` + the claude sidecar `.mjs` inside crates/. Node `server/` out of scope
+(read only as parity oracle). Oracle: user-facing (blocked / wrong-silent / confusion /
+data-loss). Severity S1 data-loss > S2 blocked > S3 wrong-silent > S4 confusion > S5 annoyance;
+silent / irreversible / trunk-artery escalate one level (shown as `S3→S2` etc.).
+
+---
+
+## 1. New findings inventory (NOT already fixed), ranked by severity × confidence
+
+Confidence legend: **V** = worker-verified with file:line citations; **C** = candidate,
+needs confirmation (mechanism cited, user-path or enforcement not yet proven).
+
+### Tier 1 — fix/confirm first
+
+**N1 — freshclaude Stop/Interrupt is a silent no-op** — `S2→S1-band` (blocked, escalated: silent) — **V** — h-freshagent-ws F1
+- Symptom: user clicks Stop (or presses Esc, or long-press STOP on Stream Deck) mid-turn; the agent keeps running to completion, burning tokens, with zero feedback.
+- Mechanism: `FreshClaudeState::handle_interrupt` (freshell-freshagent/src/claude.rs:649-653) writes `{"type":"interrupt"}` to sidecar stdin, but the sidecar dispatch `switch(req.type)` (freshell-claude-sidecar/index.mjs:279-284) has cases only for create/send/shutdown — interrupt falls to `default` and is logged-and-dropped; `handleInterrupt` (index.mjs:257) is dead code. Rust side sends no confirmation frame by design, so nothing surfaces.
+- Fix shape: one-line `case 'interrupt': handleInterrupt(req); break`. Smallest fix in the inventory; do it first.
+
+**N2 — freshclaude permission modes ("Default (ask)" / "Plan mode: no edits until approved") may be silently non-enforced** — `S3→S2, potentially S1` — **C** (cross-artifact synthesis; confirm before fixing) — mp-promise-ui × mf-ws A1 mitigating-facts
+- Symptom: user selects "Default (ask)" or "Plan mode (read-only, *Research and propose; no edits until approved*)" (FreshAgentSettingsButton.tsx:52-324); agent edits files anyway, with no approval card — because there IS no approval channel in this port.
+- Mechanism: the claude sidecar **auto-allows every `canUseTool`** and only surfaces `sdk.turn.waiting` (index.mjs:219-227, cited by mf-ws); provider snapshots advertise `approvals:false, questions:false`. If plan-mode exit / edit-tool gating depends on `canUseTool` (rather than being fully SDK-internal), the hard "no edits until approved" promise is broken silently and irreversibly (files change). Confirm: does the SDK enforce `permissionMode=plan` independent of the auto-allow callback? If not, this is the worst live finding in the run.
+
+**N3 — WS layer serves a BOOT-FROZEN settings snapshot; reconnect silently reverts live settings** — `S3→S2` (wrong-silent, escalated: silent + trunk-artery) — **V** — mf-server F1
+- Symptom: (a) user edits provider model/permissionMode/sandbox or defaultCwd in Settings, dialog says saved, **new panes still launch with boot-time values** until restart; (b) any WS auto-reconnect pushes the boot-era `settings.updated` frame and the SPA wholesale-applies it (App.tsx:1151-1153) — the UI **silently reverts** the user's patched settings for the rest of the server lifetime.
+- Mechanism: `WsState.settings: Arc<ServerSettings>` frozen at boot (main.rs:200/769; lib.rs:99-100); terminal.create reads it (terminal.rs:1085-1099, :1151, :2022, :3139); PATCH fan-out live-pushes only 3 knobs (settings_store.rs:1630-1651). Legacy re-reads live per connect/create. Also frozen: `config_fallback` notice (main.rs:212) — mid-session config.json corruption never reaches clients.
+
+**N4 — SO_REUSEPORT on the boot listener removes the EADDRINUSE fail-fast → split-brain double-server** — `S3→S2` (wrong-silent, escalated: silent + near-undiagnosable) — **V** (mechanism; trigger requires a second instance) — mf-server F6
+- Symptom: accidentally start a second freshell-server on the same port (systemd + manual run, two terminals) → both bind successfully; kernel load-balances TCP flows across two processes with separate registries/settings; panes and terminals appear, vanish, and reappear per reconnect. Only signal: one PaneLedger ERROR log line.
+- Mechanism: every listener created SO_REUSEADDR+SO_REUSEPORT, default-on (net_bind.rs:31-35, :52-56; main.rs:920-921, :1404-1409). Legacy Node fails loudly EADDRINUSE.
+
+### Tier 2 — verified wrong-silent (S3)
+
+**N5 — Project color feature is dead end-to-end** — `S3` — **V** — mf-server F5
+- Symptom: user sets a project color (HistoryView / context menu) → accepted, nothing happens, forever `#6b7280`. No error (ContextMenuProvider.tsx:613-622 swallows).
+- Mechanism: `PUT /api/project-colors` has no route in crates/ (JSON-404 fallback), AND the Rust directory payload never carries `color` at all.
+
+**N6 — Overview "Generate summary with AI" button silently does nothing** — `S3` — **V** — mf-server F5
+- Symptom: Sparkles button shown ungated (OverviewView.tsx:424), click → unhandled rejection, button pulses, no summary, no error.
+- Mechanism: `POST /api/ai/terminals/{id}/summary` unported. (Context-menu variant is correctly `aiEnabled`-gated; the Overview path is not.)
+
+**N7 — One global 300-token rate bucket shared by the BrowserPane proxy and all `/api/*` (incl. unauthenticated)** — `S3` — **V** (mechanism) — mf-server F8
+- Symptom: open a dev server in a BrowserPane → hundreds of module requests stream through `/api/proxy/http/...`, draining the same bucket bootstrap/settings/terminals need → app-wide 429s mid-interaction. On a 0.0.0.0 bind, an unauthenticated LAN scanner can starve the real user (legacy was per-IP).
+
+**N8 — `availableClis`/platform payload computed once at boot** — `S3` — **V** — mf-server F2
+- Symptom: install claude/codex while freshell is running → PanePicker never shows it until server restart (legacy detects live per request).
+
+**N9 — Tabs registry is in-memory only despite a disk tabs-persist module** — `S3` — **C** — mm-mass Concern #10
+- Symptom: after a server restart, TabsView ("All your tabs across devices") loses tabs from devices not currently connected (e.g., your phone/closed laptop) until each device reconnects and re-pushes; the "pull tab from another device" promise fails silently post-restart.
+- Mechanism: tabs.rs is explicitly in-memory-only (tabs.rs:1-25) while tabs_persist.rs writes disk snapshots used by a *different* consumer (recovery inventory). Confirm the post-restart TabsView behavior; three "survival" modules have three different durabilities.
+
+**N10 — "Agent MCP server" settings toggle promises a capability the Rust port doesn't ship** — `S3` — **C** — mp-promise-docs (AdvancedSettings.tsx:66-77 × mcp_inject.rs:16-30)
+- Symptom: toggle says "Expose Freshell as an MCP tool to coding agents... create tabs, send keys, screenshots" (default ON; NetworkQuickAccess shows "Agent MCP server: On") — but `mcp_inject.rs:16-30` notes Rust ships **no MCP server binary yet**. README's headline "self-configuring workspace" (README.md:29) silently doesn't work on the Rust server. Confirm what mcp_inject actually injects and whether agents get any tools.
+
+### Tier 3 — verified confusion (S4)
+
+**N11 — /fork offered by codex/opencode capability snapshots, then refused UNSUPPORTED** — `S4` — **V** — mf-ws A1 (residual after F1; do not re-report the silent-drop itself)
+- Snapshots advertise `fork:true` (codex.rs:3091; freshagent lib.rs:1344) while dispatch answers `freshAgent.error{UNSUPPORTED_MESSAGE}`; opencode_ws.rs:25/32 even documents fork/compact as out-of-scope while its snapshot still advertises fork. Fix = stop advertising, or implement.
+
+**N12 — Disabled provider's sessions keep appearing in the History sidebar** — `S4` — **V** — mf-server F3
+- `session_directory` never filters by `codingCli.enabledProviders` (session_directory.rs:388-399) while `resolve` does (resolve.rs:645-662) — disable a provider, its sessions stay listed (and the 2 s sweep keeps broadcasting their churn) while resume hides them.
+
+**N13 — User-set `sessionType` tags never shown in History** — `S4` — **V** — mf-server F4
+- Metadata overlay applied by resolve but not by the directory; session_metadata.rs:114-119 admits the read-side join is "not ported yet."
+
+**N14 — FreshAgentCreate silently gated when `freshAgent.enabled=false`** — `S4` — **V** (low reachability) — mf-ws A2
+- No reply at all (terminal.rs:720) vs legacy's `FRESH_CLIENTS_DISABLED{retryable:true}`; pane sits "creating" until the 10 s client backstop. Siblings (Attach/Send/Interrupt/Kill) aren't gated at all — "disabled" only blocks create, inconsistently.
+
+**N15 — BrowserPane on remote deployments: port-forward unported, misleading error** — `S4` — **V** — mf-server F5
+- `POST/DELETE /api/proxy/forward*` deliberately unported (proxy.rs:33-35), reachable exactly on LAN/remote deployments; user sees `Failed to connect to localhost:PORT` when nothing was dialed.
+
+**N16 — Proxy percent-decodes the upstream path before re-interpolating** — `S4` — **V** (edge-case reachability) — mf-server F9
+- `%23` → `#` truncates the upstream path silently (Vite `/@fs/` with `C#Demo` 404s); `%2F` changes path semantics; failures mislabeled `502 Failed to connect`.
+
+**N17 — freshagent REST auth is header-only; every other router accepts header OR cookie** — `S4` — **V** (low reachability today) — mf-server F7
+- Any cookie-only browser-context consumer 401s on `/api/tabs`, `/api/panes/*`, `/api/fresh-agent/*` while succeeding everywhere else. Claims parity with a middleware that accepts both.
+
+### Tier 4 — noted (S5 / doc-gap / deliberate-but-flagged)
+
+- **N18** TerminalAutoResumeCancel unknown-id: silent no-op vs TerminalKill's loud INVALID_TERMINAL_ID (mf-ws A5; documented deliberate) — `S5`.
+- **N19** `FreshAgentCreate` with `provider:None` parses then vanishes in `_ => {}` (mf-ws A3) — no frozen-client exposure; protocol-hygiene item for the amplifier-arm cleanup.
+- **N20** HOME-less fallback splits three ways, incl. hidden CWD-relative `.freshell/` (mf-server F10) — rare corner, `S5`.
+- **N21** Doc gaps that manufacture surprise (mm-mass): idle auto-kill of *explicitly detached* shells at the configured threshold (post-F2 this is the intended residual, but README never warns "background session ≠ immortal"), auto-resume backoff/cycle-cap behavior, fail-open resume when the session store is unreadable. Cheap README fixes, real confusion reducers.
+- **A6/A7** (mf-ws) input/attach identity-guard fail-open/fail-closed asymmetry and note_possible_submit ordering: deliberate and commented; recorded as regression-fragile invariants for future test-pinning, not bugs.
+
+### Explicit dedupe notes
+- The approval/question/fork/compact **silent drop** is F1 (fixed → loud). h-freshagent-ws independently re-adjudicated it as designed post-fix behavior. Only the *advertised-capability mismatch* (N11) and the *enforcement consequence* of auto-allow (N2) are new.
+- mm-mass Concern #3/#1 (idle reaper vs background session) is F2 (fixed); only the doc-gap residual (N21) remains.
+- mm-mass Concern #7's fail-open resume, and provider resume-after-restart, are F3 territory (adjudicated already-fixed); only the "user never told why" doc gap survives (N21).
+
+---
+
+## 2. Coverage map
+
+### Real coverage (delivered artifacts)
+
+| Territory | Worker(s) | Depth |
+|---|---|---|
+| Whole-tree mechanical census (mass, churn, doc-tagging) | mm-mass, mm-churn | Full, shallow-by-design |
+| Stated promises (README/docs/settings) | mp-promise-docs | Full ledger |
+| Implied promises (all UI copy) | mp-promise-ui | Full ledger |
+| freshell-server routers / HTTP / auth / orchestration fans | mf-server | Deep (10 asymmetries + healthy-fan negative results) |
+| freshell-ws message dispatch fan (`handle_client_text` + siblings) | mf-ws | Deep (8 asymmetries, full layer map) |
+| freshAgent WS above-side (T6: create/send/interrupt/kill/control) | h-freshagent-ws | Hunted, 1 confirmed finding |
+
+### Dark ground (14 workers never delivered — target the next wave here)
+
+Map (7): **mf-freshagent** (the largest crate cluster: codex.rs 7.3k, terminal_tabs.rs 6.2k,
+claude.rs, opencode_ws.rs, session_lease — below-side of every fresh-agent op; would confirm N2),
+**mf-sessions** (directory_index 3.9k, locators, resolve — History/resume correctness backbone),
+**mf-terminal-activity** (registry.rs 5.3k — highest fix-density file in the tree — + activity.rs
+6.8k + freshell-activity), **mf-platform-tauri** (elevation, port_forward, platform network —
+half of the remote-access surface), **mf-protocol-seams** (client/server message parity; mf-ws
+already found dead members, more likely), **mr-wiring**, **mr-reload**.
+
+Hunt (7): **h-remote** (network.rs 4.2k + net_bind + managed_ports — mm-churn's **#1
+churn-vs-docs gap**, newest code, merged at tip, widest blast radius; would also adjudicate N4),
+**h-attention** (attention-bell cluster #614, the tip commit, third rework of the semantics —
+mm-churn's most-likely-live-regression call), **h-crashed-resume** (auto_resume.rs 2k — F8-adjacent
+but the breaker/settle machine itself is unexamined), **h-restart-recovery** (partially covered by
+F4's fix; the recovery-offer flow end-to-end is not), **h-reload**, **h-idle-reaper** (mostly
+retired by F2), **h-provider-resume** (retired by F3 adjudication).
+
+Coverage math: map 6/13 delivered (mechanical 2/2, deep 4/11), hunt 1/8. The delivered set skews
+heavily toward the WS/server *above-side*; the provider *below-side* (freshagent internals),
+the terminal registry, sessions indexing, and everything remote/attention is dark.
+
+---
+
+## 3. Corrected timing model — "size the box to the work"
+
+Ground truth (launch → artifact):
+
+| Class | Workers | Durations | Delivery |
+|---|---|---|---|
+| Mechanical census | mm-mass, mm-churn | 30 m, 37 m | 2/2 (100%) |
+| Deep flat-rate map (promise ledger / fan inventory) | mp-promise-ui, mf-server, mp-promise-docs, mf-ws | 4 h 47 m – 5 h 36 m | 4/11 (36%) |
+| Hunt | h-freshagent-ws | 3 h 13 m | 1/8 (12.5%) |
+
+All workers self-exited; none were killed. Reading: the completers are the ones that ignored the
+1-hour framing and did the actual work; the 14 non-deliverers most plausibly exited around a
+budget they couldn't fit, leaving **nothing** because artifact-writing was end-loaded. Two
+correction levers, in order of importance:
+
+1. **Budget honestly.** Mechanical ≈ 0.5–0.75 h. Deep flat-rate map ≈ **5–6 h** (harvest window
+   6–7 h). Hunt ≈ **3–4 h** (harvest window 4–5 h). Tell workers the real budget; a worker told
+   "1 hour" that needs five will either rush garbage or exit empty.
+2. **Write-as-you-go artifacts.** Require incremental section flushes so a worker that dies at
+   70% still leaves 70% of an artifact. This run's non-deliverers yielded exactly zero despite
+   burning (collectively) tens of worker-hours.
+
+**Properly-sized overnight run** (assume launch 22:00):
+- 22:00 — launch everything at once: mechanical + deep maps + hunts (hunts on known candidates
+  needn't wait for maps; a second hunt tranche can be re-targeted at T+1 h off the mechanical output).
+- 22:45 — check-in #1: harvest mechanical (expect 100%); re-target/launch tranche-2 hunts.
+- 02:00 (T+4 h) — check-in #2: harvest hunts (expect the first completions T+3–4 h).
+- 05:00 (T+7 h) — check-in #3: harvest deep maps (expect completions T+5–6.5 h); sweep partial
+  artifacts from anything silent; anything with no partial by T+7 h is dead.
+- Expected delivery with honest budgets + incremental writes: plan for **70–80%** on deep/hunt
+  classes (vs 36%/12.5% under the mis-sized box). To land N artifacts, launch ⌈1.4 × N⌉ workers.
+- Three human/analyst touch points total (T+45 m, T+4 h, T+7 h); analysis pass at T+7 h.
+
+The lesson is not "workers are too slow" — a 5.5-hour mf-server delivered 10 ranked, cited,
+partially legacy-adjudicated findings plus negative results. That is the correct unit cost for
+that artifact. The box was wrong.
+
+---
+
+## 4. Recommended next wave
+
+### Fix first (from this inventory, before or alongside the wave)
+1. **N1** interrupt-drop — one-line sidecar dispatch case + a red/green sidecar test. Trivial, S2, silent.
+2. **N2** permission-mode enforcement — *confirm first* (30-min hunt-lite: does SDK plan-mode hold under auto-allow `canUseTool`?). If broken: highest-severity live bug in the run.
+3. **N3** WS boot-frozen settings — re-read the live store at handshake + terminal.create (mirrors legacy); kills both the stale-launch and the silent-revert-on-reconnect.
+4. **N5 + N6** dead SPA routes — either port `PUT /api/project-colors` + `POST /api/ai/terminals/{id}/summary` or gate the UI affordances; today both fail silently.
+5. **N4** REUSEPORT — default off for the boot listener (keep for rebind), restoring fail-fast.
+
+### Worker wave (dark ground, priority order)
+
+| # | Territory | Class | Budget | Why now |
+|---|---|---|---|---|
+| 1 | h-remote: network.rs/net_bind/managed_ports/elevation + N4 adjudication | hunt | 3–4 h | #1 churn-vs-docs gap, newest code at tip, remote-access blast radius |
+| 2 | h-attention: #614 bell cluster (activity.rs, freshell-activity/idle.rs) | hunt | 3–4 h | tip commit, third semantic rework, perceptual/user-facing failure class |
+| 3 | mf-freshagent: provider adapters below-side + session_lease | deep map | 5–6 h | largest unmapped cluster; below-side of N1/N2/N11; feeds tranche-2 hunts |
+| 4 | h-crashed-resume: auto_resume.rs breaker/settle + respawn caps | hunt | 3–4 h | 2k-LoC state machine, only F8-adjacent edges examined |
+| 5 | mf-sessions: directory_index/locators/resolve | deep map | 5–6 h | History/resume backbone, thin docs, F5/F7 both lived here |
+| 6 | h-tabs-restart: confirm N9 (TabsView after restart) + N10 (MCP toggle) | hunt-lite | 1–2 h | two cheap confirmations that upgrade C→V or retire |
+| 7 | mf-terminal-activity: registry.rs + activity hub | deep map | 5–6 h | highest fix-density file; post-F2/F6 the residual invariants deserve a map |
+
+Launch 1–7 together at 22:00 with honest budgets and write-as-you-go mandates; expect ~5 of 7 to
+deliver; harvest per the §3 schedule. mf-protocol-seams / mr-wiring / mr-reload stay parked for
+wave 3 unless wave-2 maps point at them.

--- a/docs/pbh-20260807/DECISION-LOG.md
+++ b/docs/pbh-20260807/DECISION-LOG.md
@@ -1,0 +1,7 @@
+# Decision log — pbh-20260807
+- 02:15 Scope ratified: target = Rust crates/ only; Node server/ out of scope (reference only).
+- 02:15 Severity matrix ratified (user-facing): S1 data-loss > S2 blocked > S3 wrong-silent > S4 confusion > S5 annoyance. Modulators: silent / irreversible / trunk-artery escalate one level (cap S1). Priority = severity × confidence.
+- 02:15 Hunt wave 1 territories ratified: T1 reload/reconnect (above+below), T4 idle-reaper vs background-session, T3 provider resume, T5 attention truth, T6 freshAgent WS above-side, T7 remote access, T2 restart recovery, T8 crashed-agent resume.
+- NOTE: acting as ratifier on the async user's behalf per their pre-authorized autonomous run; all calls surfaced in the final report for review.
+- NOTE: agmsg not installed -> JSONL coordination-log equivalent used.
+- NOTE: mapping deep-workers hung (opencode Explore-Agent stalls on huge crate reads); hung PIDs left running (no-kill), worked around. Skill fix queued: time-box workers + tighter task shapes.

--- a/docs/pbh-20260807/RUN-NOTES.md
+++ b/docs/pbh-20260807/RUN-NOTES.md
@@ -1,0 +1,37 @@
+# Parallel bug-hunt run pbh-20260807 (started 2026-08-07 01:02)
+Target: Rust `crates/` only. Node `server/` OUT of scope (reference only).
+Coordination channel: agmsg not installed -> using append-only JSONL equivalent at /tmp/pbh-20260807/.
+Base: origin/main @ 90fc866db. Branch: pbh/20260807/integration.
+Live server on :3001 (pid 4157145) is NOT touched; scratch instances use unique high ports with recorded PIDs.
+
+## Mapping-wave postmortem (fable, synthesis lead — 2026-08-07 02:13)
+
+Artifacts landed: docs/pbh-20260807/map/{promise-ledger,fan-inventory,code-mass-heatmap,territories}.md.
+
+Worker coverage:
+- GOOD: Lens 3 (code-mass) — mm-mass.md + mm-churn.md (/tmp/pbh-20260807/map/) were excellent:
+  concrete LoC/churn numbers, doc-tagging, and two pre-found asymmetries (idle-reaper vs
+  background-session; tabs in-memory vs tabs-persist) that seeded the top territories.
+- HUNG (no artifact ever appeared; polled 01:55-02:13, dir quiet since 01:42): Lens 1 (promises)
+  and Lens 2 (fans) workers, plus the regional workers for freshell-freshagent, freshell-sessions,
+  the reconcile/resume/reconnect machinery, freshell-protocol, and the UI-implied-promises pass.
+  Synthesis covered all of these by targeted direct reads (module-doc headers + protocol enums +
+  dispatch match arms + 7 SPA components); depth is shallower than a dedicated worker pass —
+  treat the fan inventory's "declared-but-unmatched WS members" as high-value but unverified.
+- Never assigned/dark: freshell-tauri, extensions lifecycle, freshell-server long tail
+  (updater/proxy/checkpoints/screenshots) — flagged dark in territories.md.
+
+Skill improvements (concrete):
+1. TIME-BOX + CHECKPOINT workers: require a partial artifact write within ~15 min of start
+   (append-as-you-go to the shared map dir, not write-once-at-end). The two workers that
+   finished wrote once at the end; the five that hung left NOTHING — a mid-run checkpoint would
+   have salvaged most of their reading. "Commit early" already exists for hunters; extend it
+   explicitly to mappers.
+2. SIMPLER TASK SHAPES for mapping: "read one 54k-LoC crate deeply" is an open-ended read that
+   invites context exhaustion (the likely hang cause on freshell-ws/freshagent). Card should
+   prescribe the cheap high-yield moves first: module-doc headers only (head -40 per file),
+   protocol/enum listings, grep for dispatch sites — then depth ONLY on the top-3 files. Cap
+   the region at ~10-15 files per worker and split big crates by concern, not by crate.
+3. HEARTBEAT on the coordination channel: mappers must post claim + a 10-min heartbeat; the
+   orchestrator re-assigns a region after 2 missed beats instead of discovering the gap at
+   synthesis time (this run discovered 5 hung regions only when synthesis polled the artifact dir).

--- a/docs/pbh-20260807/RUN-REPORT.md
+++ b/docs/pbh-20260807/RUN-REPORT.md
@@ -5,7 +5,7 @@
 **Coordination:** agmsg not installed → append-only JSONL equivalent.
 **Skill exercised:** `~/code/skill-parallel-development` (parallel-bug-hunt), first live run.
 
-## Outcome — 4 user-facing bugs fixed, closed-loop, all independently reviewed PASS (+1 adjudicated already-fixed)
+## Outcome — 5 user-facing bugs fixed, closed-loop, all independently reviewed PASS (+1 adjudicated already-fixed)
 
 ### F1 — freshclaude approvals/answers silently dropped  [S2/S3 · LANDED 6c5f9ad86 · review PASS]
 The freshAgent WS dispatch (`crates/freshell-ws/src/terminal.rs`) routed `approval.respond`,
@@ -42,6 +42,13 @@ from transcript/events sidecars — so real turns/resumes (sidecar-only appends)
 session at first-parse and sinking it to the bottom of the recency-sorted history where the user can't find it.
 Fix folds the sidecars' mtimes (stat-only) into the discovered stat so a sidecar write invalidates the cache.
 RED→GREEN through the real incremental sweep. Review confirmed stat-only (no perf regression), other providers byte-identical.
+
+### F6 — terminal.exit overtakes queued output/replay, blank exited panes  [S3 · LANDED 108f1365b · review PASS]
+`TerminalExit` bypassed the per-connection output FIFO (direct channel) while output/replay were queued, and the
+drain loop sends direct frames before queued output — so attaching to an exited terminal delivered ready→exit→replay,
+and the client clears the pane binding on exit, dropping the replay. Result: blank exited pane / scrollback lost on
+reattach to an exited terminal. Fix routes exit through the same FIFO (zero-weight, non-evictable) so output→exit
+order holds unconditionally. RED→GREEN. Review confirmed no exit-loss, eviction/gap accounting intact, attach.ready ordering preserved.
 
 ### F3 — provider resume after restart  [AUDIT_WRONG — already fixed]
 Candidate: codex/opencode sessions unresumable after a server restart. Adjudication found this is **not a

--- a/docs/pbh-20260807/RUN-REPORT.md
+++ b/docs/pbh-20260807/RUN-REPORT.md
@@ -1,0 +1,76 @@
+# Parallel bug-hunt run pbh-20260807 — Run report
+
+**Goal:** a higher-quality freshell experience — find and fix bugs a real user would fall afoul of, in the RUST implementation (`crates/`). Node `server/` was out of scope (reference only).
+**Base:** origin/main @ 90fc866db. **Branch:** `pbh/20260807/integration` (worktree; no PR, no deploy — ready for review).
+**Coordination:** agmsg not installed → append-only JSONL equivalent.
+**Skill exercised:** `~/code/skill-parallel-development` (parallel-bug-hunt), first live run.
+
+## Outcome — 2 user-facing bugs fixed, closed-loop, both independently reviewed PASS
+
+### F1 — freshclaude approvals/answers silently dropped  [S2/S3 · LANDED 6c5f9ad86 · review PASS]
+The freshAgent WS dispatch (`crates/freshell-ws/src/terminal.rs`) routed `approval.respond`,
+`question.respond`, `fork`, and `compact` into a silent `_ => true` catch-all — no handler exists in
+the Rust port. A user clicking **Approve/Deny** on a tool permission, answering a question, or hitting
+fork/compact got **nothing**: the pane wedged, the agent hung waiting. Fix makes these fail LOUDLY with a
+visible pane error (`UNSUPPORTED_MESSAGE`) that un-wedges the pane, matching the codebase's own
+"never total silence for a user action" pattern. New real-transport test (4 frames) — RED verified by
+stashing the fix (all 4 time out), GREEN after. Independent review confirmed the pre-fix drop, the
+non-vacuous test, and judged "fail loudly" a legitimate satisfaction (the approval channel is genuinely
+out of scope in this port; faking success would be worse).
+
+### F2 — idle reaper silently kills detached background terminals  [S1 · LANDED 082206711 · review PASS]
+`TerminalRegistry::enforce_idle_kills` treated "detached" as `subscribers.is_empty()`, so a mere socket
+drop — **closing the browser tab, a network blip, or the laptop sleeping** — made a running background
+terminal reap-eligible and SIGKILLed it after 15 idle minutes (scrollback + session lost), while the UI
+slider (min=5) can't disable it. This directly violates the tmux-like "background sessions keep running"
+promise. Fix distinguishes an explicit release (user closed it from every pane) from a mere disconnect:
+disconnected-but-wanted terminals now live under the existing 24h hard cap; genuine orphans still reap at
+the configured threshold (no PTY leak). Three tests (RED→GREEN). Independent review confirmed no leak, the
+flag resets on re-attach (not a one-way latch), and every case is bounded at 24h.
+
+### F3 — provider resume after restart  [AUDIT_WRONG — already fixed]
+Candidate: codex/opencode sessions unresumable after a server restart. Adjudication found this is **not a
+bug** — all providers reconstruct from disk on the cold path, with regression tests already pinning the
+exact historical failure. No change made. The confirm-before-fix gate earned its keep.
+
+## What the map found (mapping wave)
+Artifacts in `map/`: promise-ledger, fan-inventory, code-mass-heatmap, territories. Top territories were
+reload/reconnect, restart-recovery, provider-resume, attention truth, freshAgent WS, remote access,
+terminal I/O. Severity (ratified, user-facing): S1 data-loss > S2 blocked > S3 wrong-silent > S4 confusion
+> S5 annoyance; modulators (silent/irreversible/trunk-artery) escalate one level.
+
+## Verification & safety
+- All fixes verified with `cargo test` on the changed crate (green); pre-existing environmental e2e
+  failures were confirmed baseline-identical (not regressions).
+- Builds were serialized (one at a time) to protect the box; peak load stayed manageable.
+- The live self-hosted server on :3001 was never touched; no server was started or restarted.
+
+## Post-mortem — what this run taught (feeds skill v2)
+
+1. **The flat-rate worker pool hung on deep, open-ended analysis.** Both the mapping and hunt
+   waves launched ~13 and ~8 Kimi-via-opencode workers on "map this whole crate" / "hunt this
+   territory" tasks. After 20+ minutes most had produced **zero output** — opencode's internal
+   "Explore Agent" sub-tasks stalled on large crates (freshell-ws is 54k LOC). The ONLY Kimi
+   workers that finished were the mechanical ones (grep/wc code-mass/churn). This **undercuts the
+   skill's core economic premise** that cheap flat-rate workers do the bulk of the deep hunting.
+2. **What worked was a labor split.** Reasoning/coding-tier delegates (one orchestrator-tier
+   model) reliably did the map synthesis, the confirm-and-fix, and the independent reviews. The
+   reliable division: **many flat-rate workers for bounded/mechanical census; a few
+   reasoning-tier agents for deep analysis, fixing, and review** (a small number, so still
+   affordable).
+3. **Route around hung workers; don't depend on them.** Monitoring log freshness caught the
+   hangs; per the no-kill rule the hung sessions were left running (they cost ~0 CPU) and their
+   territory was covered by direct reads. A worker silent for many minutes with no artifact is
+   hung — plan for it.
+4. **High-churn map candidates are often already fixed.** F3 (provider resume) was a real
+   historical bug already fixed with regression tests; attention (#614) and remote (#615) landed
+   days ago. The map correctly points at where pain *was*; confirm-before-fix (AUDIT_WRONG) is
+   what stops wasted or wrong changes.
+5. **Serial builds kept the box safe** — no repeat of the 32-concurrent-build load spikes.
+
+### Skill v2 changes queued
+- Add **task-shaping / worker-reliability**: give flat-rate workers TIGHT, bounded, single-file
+  or mechanical tasks; forbid sub-agent spawning; require incremental output ("write as you go").
+- Make explicit the **tier split**: flat-rate pool for census + narrow confirmation; a small
+  reasoning-tier set for deep hunt/fix/review.
+- Elevate **confirm-before-fix (AUDIT_WRONG)** and **route-around-hung-workers** to first-class.

--- a/docs/pbh-20260807/RUN-REPORT.md
+++ b/docs/pbh-20260807/RUN-REPORT.md
@@ -5,7 +5,7 @@
 **Coordination:** agmsg not installed → append-only JSONL equivalent.
 **Skill exercised:** `~/code/skill-parallel-development` (parallel-bug-hunt), first live run.
 
-## Outcome — 2 user-facing bugs fixed, closed-loop, both independently reviewed PASS
+## Outcome — 4 user-facing bugs fixed, closed-loop, all independently reviewed PASS (+1 adjudicated already-fixed)
 
 ### F1 — freshclaude approvals/answers silently dropped  [S2/S3 · LANDED 6c5f9ad86 · review PASS]
 The freshAgent WS dispatch (`crates/freshell-ws/src/terminal.rs`) routed `approval.respond`,
@@ -27,6 +27,21 @@ promise. Fix distinguishes an explicit release (user closed it from every pane) 
 disconnected-but-wanted terminals now live under the existing 24h hard cap; genuine orphans still reap at
 the configured threshold (no PTY leak). Three tests (RED→GREEN). Independent review confirmed no leak, the
 flag resets on re-attach (not a one-way latch), and every case is bounded at 24h.
+
+### F4 — recover-my-panes inventory silently omits a whole device  [S3 · LANDED 75f641d47 · review PASS]
+`GET /api/recovery/inventory` did two separately-locked store reads; a concurrent `tabs.sync.push` at the
+retention cap prunes a just-selected snapshot generation between them, and the `Missing => continue` arm
+dropped the WHOLE device — a clean 200 with `recoverable:false` for a workspace fully on disk. Correlated
+with restart (every window re-pushes exactly when the fresh window fetches inventory). Fix: bounded per-device
+re-read that re-selects from survivors; still-incoherent → loud 500, never a silent empty. Two RED→GREEN tests.
+Review confirmed it discriminates true emptiness (still 200) from churn (loud 500), retry is bounded, normal path unchanged.
+
+### F5 — amplifier sessions freeze in history (stale recency/preview, effectively invisible)  [S3/S4 · LANDED 73ad20d6c · review PASS]
+The session index re-parses only when metadata.json's (mtime,size) changes, but amplifier recency + preview come
+from transcript/events sidecars — so real turns/resumes (sidecar-only appends) never refreshed, freezing the
+session at first-parse and sinking it to the bottom of the recency-sorted history where the user can't find it.
+Fix folds the sidecars' mtimes (stat-only) into the discovered stat so a sidecar write invalidates the cache.
+RED→GREEN through the real incremental sweep. Review confirmed stat-only (no perf regression), other providers byte-identical.
 
 ### F3 — provider resume after restart  [AUDIT_WRONG — already fixed]
 Candidate: codex/opencode sessions unresumable after a server restart. Adjudication found this is **not a

--- a/docs/pbh-20260807/RUN-REPORT.md
+++ b/docs/pbh-20260807/RUN-REPORT.md
@@ -5,7 +5,7 @@
 **Coordination:** agmsg not installed → append-only JSONL equivalent.
 **Skill exercised:** `~/code/skill-parallel-development` (parallel-bug-hunt), first live run.
 
-## Outcome — 5 user-facing bugs fixed, closed-loop, all independently reviewed PASS (+1 adjudicated already-fixed)
+## Outcome — 6 user-facing bugs fixed, closed-loop, all independently reviewed PASS (+1 adjudicated already-fixed)
 
 ### F1 — freshclaude approvals/answers silently dropped  [S2/S3 · LANDED 6c5f9ad86 · review PASS]
 The freshAgent WS dispatch (`crates/freshell-ws/src/terminal.rs`) routed `approval.respond`,
@@ -49,6 +49,13 @@ drain loop sends direct frames before queued output — so attaching to an exite
 and the client clears the pane binding on exit, dropping the replay. Result: blank exited pane / scrollback lost on
 reattach to an exited terminal. Fix routes exit through the same FIFO (zero-weight, non-evictable) so output→exit
 order holds unconditionally. RED→GREEN. Review confirmed no exit-loss, eviction/gap accounting intact, attach.ready ordering preserved.
+
+### F7 — opencode pane can silently bind the WRONG session  [S3 · LANDED 5aeae9c10 · review PASS]
+The opencode locator/drain lacked the misbind guards codex already has: two same-cwd opencode panes (or a
+fresh-agent `opencode serve` sharing opencode.db) could bind a pane to another pane's or a fresh-agent's session —
+so a later resume opens someone else's conversation, silently. Fix mirrors codex one-for-one: a contested-cwd census
+(a sole candidate shared by >=2 same-cwd contenders binds nobody) + drain-side claim refusal (bound-elsewhere,
+fresh-agent), all warn-logged. RED→GREEN. Review confirmed no starvation, rightful owner never rejected, symmetric with codex.
 
 ### F3 — provider resume after restart  [AUDIT_WRONG — already fixed]
 Candidate: codex/opencode sessions unresumable after a server restart. Adjudication found this is **not a

--- a/docs/pbh-20260807/RUN-REPORT.md
+++ b/docs/pbh-20260807/RUN-REPORT.md
@@ -5,7 +5,7 @@
 **Coordination:** agmsg not installed → append-only JSONL equivalent.
 **Skill exercised:** `~/code/skill-parallel-development` (parallel-bug-hunt), first live run.
 
-## Outcome — 6 user-facing bugs fixed, closed-loop, all independently reviewed PASS (+1 adjudicated already-fixed)
+## Outcome — 7 user-facing bugs fixed, closed-loop, all independently reviewed PASS (+1 adjudicated already-fixed)
 
 ### F1 — freshclaude approvals/answers silently dropped  [S2/S3 · LANDED 6c5f9ad86 · review PASS]
 The freshAgent WS dispatch (`crates/freshell-ws/src/terminal.rs`) routed `approval.respond`,
@@ -56,6 +56,13 @@ fresh-agent `opencode serve` sharing opencode.db) could bind a pane to another p
 so a later resume opens someone else's conversation, silently. Fix mirrors codex one-for-one: a contested-cwd census
 (a sole candidate shared by >=2 same-cwd contenders binds nobody) + drain-side claim refusal (bound-elsewhere,
 fresh-agent), all warn-logged. RED→GREEN. Review confirmed no starvation, rightful owner never rejected, symmetric with codex.
+
+### F8 — freshclaude pane wedged "working" forever after sidecar crash  [S2/S3 · LANDED f401dd7d0 · review PASS]
+Member asymmetry: when the claude sidecar dies UNREQUESTED mid-turn (crash/OOM), the claude adapter evicted the
+session in total silence — pane stuck busy forever — while codex (exit watcher) and opencode (unconditional idle)
+both self-heal. Fix broadcasts exactly one freshAgent.error{SIDECAR_EXITED} in the unrequested-death branch only
+(structurally impossible on user kill/shutdown); client shows a banner and clears busy. No false completion chime.
+RED→GREEN (test SIGKILLs the child directly). Review confirmed exactly-once, correct stamping, ADR preserved.
 
 ### F3 — provider resume after restart  [AUDIT_WRONG — already fixed]
 Candidate: codex/opencode sessions unresumable after a server restart. Adjudication found this is **not a

--- a/docs/pbh-20260807/findings/FIX-LOG.md
+++ b/docs/pbh-20260807/findings/FIX-LOG.md
@@ -63,3 +63,17 @@
 - Test: session_index_refreshes_amplifier_recency_when_only_sidecar_changes (through the real incremental sweep) — RED (stuck at Some(1000)) -> GREEN.
 - Verify: cargo test -p freshell-sessions green (lib 176; parity/resolve/locators/liveness suites). Only amplifier.rs touched.
 - Review: PASS (independent) — confirmed the (mtime,size)-on-metadata-only gate froze sidecar-driven recency; fold is stat-only (no content read), test drives the REAL incremental sweep and fails pre-fix deterministically, other providers byte-identical, no churn.
+
+## F6 — terminal.exit overtakes queued output/replay, discarding scrollback  [CONFIRMED, LANDED 108f1365b]
+- Promise: what the terminal shows is what the program printed; scrollback survives detach/reattach; no lost/truncated output.
+- Observed: output frames go through the bounded ConnectionOutputQueue but TerminalExit went straight to conn_tx
+  (crates/freshell-ws/src/backpressure.rs route; drain arm terminal.rs:339-351 sends all direct frames before
+  queued output). Attaching to an EXITED terminal → wire order ready→exit→replay; client clears terminalId on
+  exit (TerminalView.tsx:4464-4527) so the replay is dropped → blank exited pane / scrollback lost on reattach.
+  Deterministic. Severity S3 (wrong-silent: lost output the program actually produced).
+- Fix: route TerminalExit through the same per-connection FIFO as output via new push_sequenced() (zero-weight,
+  non-evictable, keeps FIFO slot; overflow eviction skips sequenced frames). Preserves output→exit order
+  unconditionally; attach.ready-before-replay untouched. 2 files.
+- Tests: terminal_exit_never_overtakes_queued_output (RED→GREEN) + 2 output_queue mechanism tests.
+- Verify: cargo test -p freshell-terminal -p freshell-ws green (175/175, lib 422/422); auto_resume_e2e 2 failures baseline-identical (pre-existing).
+- Review: PASS (independent) — confirmed the deterministic ready→exit→replay inversion (direct exit vs queued output, drain sends direct first) and the blank-exited-pane consequence; fix preserves output→exit FIFO order, sequenced frame non-evictable/zero-weight/can't be lost, eviction+gap accounting intact, attach.ready ordering held; test fails pre-fix.

--- a/docs/pbh-20260807/findings/FIX-LOG.md
+++ b/docs/pbh-20260807/findings/FIX-LOG.md
@@ -1,0 +1,34 @@
+# Fix log — pbh-20260807
+
+## F1 — freshAgent WS control messages silently dropped  [CONFIRMED, LANDED 6c5f9ad86]
+- Promise: in freshclaude, Approve/Deny a tool, answer a question, fork/compact — it takes effect.
+- Observed: approval.respond / question.respond / fork / compact hit a silent `_ => true` catch-all in
+  crates/freshell-ws/src/terminal.rs (dispatch :524, catch-all :951); no handler anywhere in Rust →
+  click Approve → nothing happens, pane wedges. Severity S2/S3 (blocked + wrong-silent).
+- Fix: intercept the 4 frames, log warn, answer freshAgent.error{UNSUPPORTED_MESSAGE} → client renders a
+  visible pane error (fails loudly, not silently). Catch-all comment corrected.
+- Test: crates/freshell-ws/tests/freshagent_control_reply.rs (4 tests) — RED verified via git stash, GREEN after.
+- Verify: cargo test -p freshell-ws lib 421/421; e2e failures identical to untouched baseline (environmental).
+- Review: PASS (independent, cold, promise+repro only) — confirmed the pre-fix silent drop, test non-vacuous (4 frames time out pre-fix), no regressions, "fail loudly with visible pane error" judged a legitimate satisfaction since the approval channel is genuinely out of scope in this port.
+
+## F2 — idle reaper silently kills detached background terminals  [CONFIRMED, LANDED 082206711]
+- Promise: detached/background terminals keep running (tmux-like); "PTY keeps running and buffering".
+- Observed: TerminalRegistry::enforce_idle_kills (crates/freshell-terminal/src/registry.rs) treats "detached" as
+  subscribers.is_empty(), so a mere socket drop (browser closed / laptop asleep / network blip) = SIGKILL after
+  DEFAULT_AUTO_KILL_IDLE_MINUTES=15; UI slider min=5 so a user cannot disable it. Scrollback + running session lost.
+  Severity S1 (silent, irreversible data loss).
+- Fix: track released_by_client (explicit detach of last subscriber) vs mere disconnect; apply the existing 24h
+  hard cap to disconnected-but-wanted terminals; reap only genuinely-orphaned rows at the configured threshold.
+- Test: enforce_idle_kills_spares_disconnect_detached_terminal_past_threshold (+hard-cap +reattach) — RED then GREEN.
+- Verify: cargo test -p freshell-terminal green (173+2+1); ws/server pre-existing e2e failures unrelated (baseline-identical).
+- Review: PASS (independent) — confirmed pre-fix disconnect=reap-at-15min; fix correctly separates explicit-release from disconnect, bounds every case at 24h (no leak), flag resets on reattach (not a latch), tests non-vacuous.
+- Review: pending (independent).
+
+## F3 — provider resume after server restart (codex/opencode 404)  [AUDIT_WRONG — already fixed]
+- Candidate: codex/opencode sessions unresumable after restart (snapshot only in memory).
+- Adjudication: NOT a bug. All providers reconstruct from disk on the cold path — codex via sidecar
+  thread/resume (freshagent/src/codex.rs:1358, doc :1287-1294 records this exact bug as ALREADY fixed),
+  opencode via serve by-id (opencode_ws.rs:1024-1046), existence gate fails-open (resume_validation.rs).
+  Regression tests already pin it (codex_session_ref_resume.rs, opencode_switch_rebind.rs). No change made.
+- Lesson: several top-map candidates sit in freshly-hardened areas (#614 attention, #615 remote, auto-resume);
+  the map surfaced real historical pain that is already addressed. Confirm-before-fix earned its keep.

--- a/docs/pbh-20260807/findings/FIX-LOG.md
+++ b/docs/pbh-20260807/findings/FIX-LOG.md
@@ -77,3 +77,19 @@
 - Tests: terminal_exit_never_overtakes_queued_output (RED→GREEN) + 2 output_queue mechanism tests.
 - Verify: cargo test -p freshell-terminal -p freshell-ws green (175/175, lib 422/422); auto_resume_e2e 2 failures baseline-identical (pre-existing).
 - Review: PASS (independent) — confirmed the deterministic ready→exit→replay inversion (direct exit vs queued output, drain sends direct first) and the blank-exited-pane consequence; fix preserves output→exit FIFO order, sequenced frame non-evictable/zero-weight/can't be lost, eviction+gap accounting intact, attach.ready ordering held; test fails pre-fix.
+
+## F7 — opencode locator can silently bind a pane to the WRONG session  [CONFIRMED, LANDED 5aeae9c10]
+- Promise: resuming/attaching a coding session gives ME my session — never silently bound to another pane's or a fresh-agent's session.
+- Observed: opencode locator drain (crates/freshell-ws/src/opencode_association.rs:105-133) adopted a Located
+  candidate WITHOUT the claim guards codex pins as required misbind hardening (codex_identity.rs:128-179) and that
+  the opencode signal lane already has; and OpencodeLocator::resolve_windows (crates/freshell-sessions/src/opencode_locator.rs:284-366)
+  had no contested-cwd census. Two same-cwd opencode panes (or a fresh-agent opencode serve sharing opencode.db)
+  → one new session row visible to ≥2 windows binds to whichever pane evaluates first → wrong conversation resumes
+  later, silently. Severity S3 (wrong-silent, near-undiagnosable).
+- Fix: mirror codex's guards — contested-cwd census (a sole candidate shared by ≥2 same-cwd contenders binds nobody;
+  no starvation of a solo contender) + drain-side claim refusal (bound-elsewhere incl. retired, fresh-agent live
+  session, durable fresh-agent ledger row), all warn-logged not silent.
+- Tests: located_session_bound_elsewhere_is_rejected, located_freshagent_known_session_is_rejected,
+  one_row_inside_two_same_cwd_windows_binds_neither_terminal, solo_enter_still_binds_when_same_cwd_sibling_has_no_open_window — RED→GREEN.
+- Verify: freshell-sessions green (178 lib+integration); freshell-ws 424 lib green, integration failures baseline-identical (env-dependent e2e).
+- Review: PASS (independent) — confirmed opencode lacked codex's misbind guards; census + drain refusal mirror codex one-for-one (with the correct !resolved translation for opencode's spawn-window), tests fail pre-fix, no starvation of a solo contender, rightful owner never rejected, all refusals warn-logged.

--- a/docs/pbh-20260807/findings/FIX-LOG.md
+++ b/docs/pbh-20260807/findings/FIX-LOG.md
@@ -32,3 +32,19 @@
   Regression tests already pin it (codex_session_ref_resume.rs, opencode_switch_rebind.rs). No change made.
 - Lesson: several top-map candidates sit in freshly-hardened areas (#614 attention, #615 remote, auto-resume);
   the map surfaced real historical pain that is already addressed. Confirm-before-fix earned its keep.
+
+## F4 — recovery inventory silently omits a whole device  [CONFIRMED, LANDED 75f641d47]
+- Promise: after a server restart, the recover-my-panes offer shows everything that is on disk — never a
+  silent "nothing to recover" for a recoverable workspace.
+- Observed: GET /api/recovery/inventory does two separately-locked store reads
+  (recovery_inventory.rs:492-500); a concurrent tabs.sync.push at the retention cap prunes a just-selected
+  generation between them, and the ComponentsUnion::Missing arm dropped the WHOLE device: 200 OK,
+  recoverable:false, zero log. Correlated with restart (every window re-pushes exactly when the fresh
+  window fetches inventory). Severity S3 wrong-silent (contradicts the module's own "never a silent empty
+  inventory" policy at recovery_inventory.rs:373-375).
+- Fix: bounded per-device re-read (3 attempts; fresh overview re-selects what survives); still-incoherent
+  after retries -> tracing::error + 500 via the existing fail-loud arm. Test-only injection seam for the
+  interleaved prune (same idiom as INJECTED_DELETE_FAILURES); no-op in production.
+- Tests: transient_prune_between_reads_never_silently_drops_a_device (RED->GREEN);
+  persistent_union_incoherence_fails_loud_not_silent_empty (RED->GREEN).
+- Verify: cargo test -p freshell-server fully green (558 unit + integration binaries); fmt/clippy clean.

--- a/docs/pbh-20260807/findings/FIX-LOG.md
+++ b/docs/pbh-20260807/findings/FIX-LOG.md
@@ -107,3 +107,16 @@
 - Test: unrequested_sidecar_death_broadcasts_a_pane_unwedging_error (SIGKILL child directly, not via handle_kill) — RED->GREEN.
 - Verify: cargo test -p freshell-freshagent — 334 pass; the 24 failures are pre-existing terminal_tabs e2e, byte-identical to baseline. claude:: module 34/34 green.
 - Review: PASS (independent) — confirmed claude was the one silent provider on unrequested death (codex exit-watcher + opencode unconditional idle both self-heal); exactly-once frame structurally guaranteed (remove-before-signal on every requested path + identity guard), no false completion, envelope stamped to the pane's current durable id, test SIGKILLs the child directly and times out pre-fix.
+
+## Holistic fresh-eyes review of the full changeset (superpowers:code-reviewer, cold, 2 iterations)
+- Iteration 1: FAIL — 2 CI-gate blockers in the changeset's own new test code (cargo fmt violations in
+  recovery_inventory_tests.rs; clippy len_zero in a claude.rs test assertion) + 1 stale TERM-09 comment in
+  ws/terminal.rs still claiming terminal.exit bypasses the output queue (contradicted the F6 invariant).
+  All fixed + verified (fmt --all --check green, clippy --workspace --all-targets -D warnings green,
+  targeted tests green) in 4ee87cb03.
+- Iteration 2: PASS (APPROVED) — fresh cold session; reviewer independently re-ran fmt/clippy/targeted suites
+  (freshell-terminal 178, freshell-sessions 269, recovery_inventory 20, ws backpressure/association 16,
+  freshagent_control_reply 5, claude:: 34 — all green; terminal_tabs failures = pre-declared env baseline).
+  Zero blocking, zero important issues. Nice-to-haves noted for PR description: wire-string helpers could
+  derive from serde; one-device incoherence 500s the whole recovery inventory (documented fail-loud choice);
+  fold_activity_mtime adds 2 stats/session/sweep (matches Node cost profile).

--- a/docs/pbh-20260807/findings/FIX-LOG.md
+++ b/docs/pbh-20260807/findings/FIX-LOG.md
@@ -93,3 +93,17 @@
   one_row_inside_two_same_cwd_windows_binds_neither_terminal, solo_enter_still_binds_when_same_cwd_sibling_has_no_open_window — RED→GREEN.
 - Verify: freshell-sessions green (178 lib+integration); freshell-ws 424 lib green, integration failures baseline-identical (env-dependent e2e).
 - Review: PASS (independent) — confirmed opencode lacked codex's misbind guards; census + drain refusal mirror codex one-for-one (with the correct !resolved translation for opencode's spawn-window), tests fail pre-fix, no starvation of a solo contender, rightful owner never rejected, all refusals warn-logged.
+
+## F8 — freshclaude pane wedged "working" forever after unrequested sidecar death  [CONFIRMED, LANDED f401dd7d0]
+- Promise: freshclaude/freshcodex/freshopencode chat behaves consistently; one provider isn't silently broken where others work.
+- Observed: member asymmetry — when the claude/kilroy sidecar dies UNREQUESTED mid-turn (crash/OOM/SIGKILL), the
+  claude adapter's stdout consumer evicted the session in TOTAL SILENCE (crates/freshell-freshagent/src/claude.rs:1190-1220),
+  so the pane stays "working"/streaming forever. codex (codex.rs:3289-3311 exit watcher) and opencode
+  (opencode_ws.rs:721-723 unconditional idle) both self-heal; Node reference broadcasts idle on claude stream death too.
+  Severity S2/S3 (blocked + wrong-silent).
+- Fix: in the unrequested-death (evicted) branch only, broadcast one freshAgent.error{SIDECAR_EXITED} stamped with the
+  session broadcast_id; client folds it to a visible banner + running/streaming->idle. No false completion chime
+  (ADR 2.1 "death never yields false completion" preserved). Matches the sibling adapters. claude.rs only.
+- Test: unrequested_sidecar_death_broadcasts_a_pane_unwedging_error (SIGKILL child directly, not via handle_kill) — RED->GREEN.
+- Verify: cargo test -p freshell-freshagent — 334 pass; the 24 failures are pre-existing terminal_tabs e2e, byte-identical to baseline. claude:: module 34/34 green.
+- Review: PASS (independent) — confirmed claude was the one silent provider on unrequested death (codex exit-watcher + opencode unconditional idle both self-heal); exactly-once frame structurally guaranteed (remove-before-signal on every requested path + identity guard), no false completion, envelope stamped to the pane's current durable id, test SIGKILLs the child directly and times out pre-fix.

--- a/docs/pbh-20260807/findings/FIX-LOG.md
+++ b/docs/pbh-20260807/findings/FIX-LOG.md
@@ -48,3 +48,18 @@
 - Tests: transient_prune_between_reads_never_silently_drops_a_device (RED->GREEN);
   persistent_union_incoherence_fails_loud_not_silent_empty (RED->GREEN).
 - Verify: cargo test -p freshell-server fully green (558 unit + integration binaries); fmt/clippy clean.
+
+## F5 — amplifier sessions freeze with stale recency/preview (effectively invisible in history)  [CONFIRMED, LANDED 73ad20d6c]
+- Promise: every past coding-agent session shows up in my history with correct recency/preview; a real session is never silently buried.
+- Observed: SessionIndex re-parses only when the discovered FileStat (mtime,size) changes
+  (crates/freshell-sessions/src/directory_index.rs:1342-1357), but AmplifierSource discovery statted ONLY
+  metadata.json (amplifier.rs:149-168), while recency + first-message preview come from the transcript/events
+  sidecars (folded at parse, amplifier.rs:379-386). Real amplifier turns/resumes append to sidecars without
+  touching metadata.json -> once cached, last_activity_at + preview freeze forever -> the session sinks to the
+  bottom of recency-sorted history and never resurfaces. Parity break vs Node (refreshes activityMtimeMs every
+  scan). Severity S3/S4 (wrong-silent: session there but unfindable where the user looks).
+- Fix: fold_activity_mtime() folds the two sidecars' mtimes (stat-only) into the discovered FileStat.mtime_ms,
+  so a sidecar write invalidates the cache and refreshes recency+preview. Provider-local; one call-site.
+- Test: session_index_refreshes_amplifier_recency_when_only_sidecar_changes (through the real incremental sweep) — RED (stuck at Some(1000)) -> GREEN.
+- Verify: cargo test -p freshell-sessions green (lib 176; parity/resolve/locators/liveness suites). Only amplifier.rs touched.
+- Review: PASS (independent) — confirmed the (mtime,size)-on-metadata-only gate froze sidecar-driven recency; fold is stat-only (no content read), test drives the REAL incremental sweep and fails pre-fix deterministically, other providers byte-identical, no churn.

--- a/docs/pbh-20260807/map/code-mass-heatmap.md
+++ b/docs/pbh-20260807/map/code-mass-heatmap.md
@@ -1,0 +1,37 @@
+# Code-Mass Heatmap — pbh-20260807 (Lens 3, Rust `crates/` target)
+
+Concerns ranked by volume × churn, tagged documented/undocumented. Undocumented+heavy =
+IMPLICIT PROMISE (added to the ledger as P34-P41). Merged from worker artifacts
+`/tmp/pbh-20260807/map/mm-mass.md` + `mm-churn.md` (good coverage) with synthesis
+verification (`git log --name-only -400 -- crates/` re-count matched worker numbers).
+
+Crate LOC: freshell-ws 54.3k · freshell-server 36.4k · freshagent 27.4k · sessions 15.7k ·
+codex 12.8k · platform 11k · terminal 10.3k · activity 8.5k · tauri 5.7k · protocol 3.6k ·
+opencode 2.8k. Churn by crate (6 mo): ws 446 > server 316 > freshagent 188 > terminal 92 =
+sessions 92 > platform 76 > codex 48. Top-churn files: terminal.rs (119), main.rs (117),
+ws/lib.rs (68), registry.rs (48, highest fix-ratio 22/50), terminal_tabs.rs (45).
+
+| Rank | Concern | Mass (non-test LoC) | Churn | Docs | Implicit promise |
+|---|---|---|---|---|---|
+| 1 | Multi-client reconnect / detach-attach background PTY (registry.rs + ws/terminal.rs + identity/pane-ledger) | >14k | very high (119+48) | **UNDOC** (module docs only) | P34 "server re-attaches a reconnected socket to a running PTY" |
+| 2 | Fresh-agent drives + per-session lease (freshagent codex/claude/opencode_ws + session_lease) | >20k | high (188/crate) | PARTIAL (README provider table) | P37 "one session, one live resumed terminal" |
+| 3 | Activity / turn-completion / attention truth (ws/activity.rs 6.8k + freshell-activity 8.5k + lanes/signals) | >17k | high; **#614 at tip** | UNDOC at behavior level | P27 reconnect re-sync w/o double-count; truthful bells |
+| 4 | Session-directory index / resume resolve / existence (sessions 15.7k + server existence/resolve/session_directory) | >11k | med (12+ each) | PARTIAL; fail-open rule UNDOC | P40 "resume fails open"; sessions appear in history |
+| 5 | Remote-access networking (server network.rs 4.2k + net_bind + managed_ports + platform firewall/elevated/port_forward) | ~7k | **hottest last 7 days** (11+3+3), merged at tip | **UNDOC** (plans only) — #1 churn-vs-docs gap | P02/P20 "remote access works and can be safely toggled" |
+| 6 | Codex remote-proxy / sidecar continuity (freshell-codex 12.8k: remote_proxy*, durability, launch_lifecycle) | >6k | low-med (48) | UNDOC | P39 "codex turns never duplicate-run / auto-resume across restart" |
+| 7 | Auto-resume + respawn caps + **idle auto-kill** (auto_resume.rs 2k + respawn in terminal.rs + registry reaper) | >3k | med (12), reaper changed at tip (24h cap) | UNDOC — README silent on both | P24 bounded-loud auto-resume; **P36 anti-promise: detached idle terminal killed @15min** |
+| 8 | Reconcile verdict handshake (reconcile.rs 1.2k + reconcile_freshagent + codex_reconcile) | ~2k | med (9) | UNDOC (plans only) | P35 "pane view reconciled against server truth" |
+| 9 | Settings/config persistence (settings_store.rs 3.6k) | ~3.6k | med (14) | **DOC** — recently remediated (R2/R3/R4) | P19 holds; treat as regression-watch only |
+| 10 | Tabs-sync in-memory vs disk persistence (tabs.rs + tabs_persist* ~2.5k) | ~2.5k | low | UNDOC + **internally contradictory** | P41 "open tabs survive restart" — only partially true |
+| 11 | WS survival mechanics (ws/lib.rs 1.1k: hello timeout, ping, backpressure disconnect) | ~1.3k | high (68) | UNDOC (env knobs absent from README) | P38 "dead socket dropped quietly; session survives" |
+| 12 | Windows/WSL path + files handling (server files.rs, platform path.rs/detect.rs) | ~3k | rising (5 last wk, windows-path-files) | PARTIAL (README:57) | P15 Windows/WSL terminals just work |
+| 13 | Origin/auth policy (ws/origin.rs, SAFE-01..03, rate_limit) | ~1k | low-med | thin | P14 token auth works; P02 browser origins accepted |
+| 14 | Tauri desktop shell (freshell-tauri) | 5.7k | very low | UNDOC | desktop app parity — **dark, see territories** |
+| 15 | Extensions registry + extension server lifecycle (server/extensions.rs + extension.server.* frames) | ~2k | low | DOC (README:167-175) | P06 — **dark, no worker touched it** |
+
+## Undocumented + heavy = richest hunting ground (Lens 3 verdict)
+1. Reconnect/background-session cluster (#1) — biggest mass, biggest implicit promise (P34), plus the P36/P22 contradiction with the reaper (#7).
+2. Remote-access networking (#5) — newest, hottest, thinnest-documented; blast radius = user locked out of their own server.
+3. Attention truth (#3) — semantics rewritten at the tip commit (#614) over two earlier reworks; perceptual, user-facing by definition.
+4. Fresh-agent lease/drives (#2) — 20k LoC guarding "never two writers of one transcript"; only the happy surface is documented.
+5. Session index / resolve (#4) — bugs here = sessions silently missing from history or refusing to resume (P03, the headline README promise).

--- a/docs/pbh-20260807/map/fan-inventory.md
+++ b/docs/pbh-20260807/map/fan-inventory.md
@@ -1,0 +1,75 @@
+# Fan Inventory — pbh-20260807 (Lens 2, Rust `crates/` target)
+
+A fan = one side facing many supposedly-interchangeable members. For each: ABOVE (dispatcher),
+MEMBERS, BELOW (shared service), and ASYMMETRIES (the bug pheromone — a member handled
+differently from siblings). Adjacencies listed at the end are the REAL graph edges to test.
+Worker coverage for this lens hung; assembled by synthesis (fable) from direct reads.
+
+## F1 — WS ClientMessage dispatch (the trunk fan)
+- ABOVE: per-connection select loop, protocol v7 handshake, keepalive/backpressure (`freshell-ws/src/lib.rs`); the giant match in `freshell-ws/src/terminal.rs:530-940`.
+- MEMBERS: 30 wire types (`freshell-protocol/src/client_messages.rs:18-80`): `terminal.*` (create/attach/input/resize/detach/kill/autoResumeCancel/codex.candidate.persisted), `freshAgent.*` (create/attach/send/interrupt/compact/approval.respond/question.respond/kill/fork), `*.activity.list` ×4, `pane.reconcile.request`, `ui.layout.sync`, `ui.screenshot.result`, `codingcli.*` ×3, hello/ping/client.diagnostic.
+- BELOW: TerminalRegistry, FreshAgent state slices, activity hub, reconcile deps, broadcast bus.
+- ASYMMETRIES:
+  - **Declared-but-unmatched members**: the dispatch match shows NO arms for `freshAgent.approval.respond`, `freshAgent.question.respond`, `freshAgent.fork`, `freshAgent.compact`, `codingcli.*`, `ui.layout.sync` — a trailing `_` swallows them silently (terminal.rs:739 comment "`_` keeps swallowing"). If the SPA/deck sends approval.respond (promise P33/P13), it may no-op silently. TOP pheromone.
+  - Interactive `terminal.create` bypasses the spawn gate but is rate-limited; `restore:true` creates bypass the rate limiter but take the gate (spawn_gate.rs:30-47, PR #552) — two doors, opposite protections.
+  - `freshAgent.attach` routes codex/opencode to LIVE runtime slices but claude to a DISK adapter (survives restart; the others don't — snapshot.rs:28-37).
+
+## F2 — Provider fan (claude / codex / opencode / amplifier / gemini / kimi)
+One product promise ("agents work alike": P03, P09, P17, P30) over six members, each with a
+DIFFERENT mechanism per subsystem — a fan-of-fans:
+- Session locators (BELOW: pane identity binder + ledger): codex = rollout-file snapshot-diff, ENTER-anchored only (`freshell-sessions/src/codex_locator.rs`); opencode = SQLite row-diff, spawn+Enter window (`opencode_locator.rs`); amplifier = pre-created stub dirs, identity minted by launcher (`amplifier_stub.rs`); claude = pre-allocated session id at launch (claude_fresh_prealloc); gemini/kimi = none (never resumable). Managed-codex panes suppress the locator (codex_association.rs `should_arm_codex_locator`).
+- Activity trackers (ABOVE: activity hub → attention bells P09/P27): claude = Stop-hook BEL; codex = BEL + rollout task events; amplifier = events.jsonl inotify tailer (attach@Start vs @Eof asymmetry); opencode = serve SSE lane (`opencode_lane.rs`); **gemini/kimi = status-inert** (activity.rs:9-11) — no bells at all for two launchable providers.
+- Existence/resume validation (BELOW: `SessionExistenceProbe`): claude = transcript file across ORDERED candidate roots (CLAUDE_CONFIG_DIR > CLAUDE_HOME > ~/.claude — real CLI IGNORES CLAUDE_HOME, claude_snapshot.rs:24-29); codex = rollout path; opencode = DB by-id query; amplifier = dir presence. Fail-open rule for unknown (resume_gate.rs).
+- Fresh-agent drives (ABOVE: `freshAgent.*`): codex = app-server JSON-RPC sidecar; claude = Node sidecar over stdio (the ONE sanctioned Node piece); opencode = serve REST/SSE; amplifier = NOT a fresh agent. Completion edges are status-guarded differently per provider (turn.status vs subtype==='success' vs idle edge).
+- Search tiers: claude+codex file-searchable; **opencode+amplifier unsearchable** at userMessages/fullText tiers (search.rs:13-18) — P11 silently weaker for two providers.
+
+## F3 — Spawn doors (three ways to create a PTY)
+- ABOVE: WS `terminal.create` (interactive | restore), REST agent-API `/api/tabs` + `/panes/:id/split` + respawn (`freshell-freshagent/src/terminal_tabs.rs`, `pane_ops.rs`), auto-resume respawn (`freshell-ws/src/auto_resume.rs`).
+- MEMBERS: the doors. BELOW: ONE shared `TerminalRegistry.create` + spawn gate + create dedupe + rate limit + MCP injection + provider settings.
+- ASYMMETRIES:
+  - Auto-resume covers ONLY WS-created terminals; REST/freshagent-created agent panes are explicitly out (auto_resume.rs:12-18) — same crash, different outcome by door.
+  - REST door: terminal mode `shell` ONLY; claude/codex/gemini/kimi return a deliberate 400 (terminal_tabs.rs:15-20) — collides with P07 ("tab with four subagents").
+  - Gate/limit treatment differs per door (see F1). Dedupe (`create_dedupe.rs`) replays `terminal.created` only while the terminal is RUNNING; after exit the same requestId spawns a NEW terminal — correct-by-legacy but surprising at the reconnect edge.
+
+## F4 — Reconcile/existence verdict fan
+- ABOVE: `pane.reconcile.request` handler (one bounded 2s deferral on `index_warming`, reconcile.rs:22-27); SPA folds verdicts (ReconcileWarmingBanner, DeadSessionPanel).
+- MEMBERS: per-pane verdicts over pane kinds: terminal panes, fresh-agent panes (`reconcile_freshagent.rs`), codex-managed panes (`codex_reconcile.rs`).
+- BELOW: TerminalRegistry × identity registry × pane ledger (supersededBy chains) × disk session index (1s-TTL `directory_index.rs`).
+- ASYMMETRIES: three sibling reconcile modules with separate logic; MAX 200 panes → `RECONCILE_TOO_LARGE` (what does the SPA do?); the deferral runs ONCE — a >2s cold index answers warming and relies on the client to retry.
+
+## F5 — Server→client broadcast bus
+- ABOVE: every producer (registry fan-out, fresh-agent slices, activity hub, tabs sync, sessions.changed).
+- MEMBERS: ~58 server message types (`freshell-protocol/src/server_messages.rs`).
+- BELOW: per-connection mpsc → socket; backpressure = 16MB/10s stall → disconnect (`backpressure.rs`); restore-path Channel sink "a dead connection just drops the frames" (create_gate.rs).
+- ASYMMETRIES: some producers push pre-serialized frames (fresh-agent) vs typed messages; ordering guaranteed per-terminal via seq, but cross-subsystem frames (e.g. `terminal.created` vs `freshAgent.created` vs `sessions.changed`) have no ordering contract.
+
+## F6 — Three "tab/workspace survival" stores (interface-with-impls by accident)
+- ABOVE: SPA tabs UI + tabRegistrySync + RecoveryOfferPanel.
+- MEMBERS: (a) in-memory tabs registry — NO restart survival (`tabs.rs:17-27`); (b) disk tabs-persist snapshot generations (`tabs_persist.rs`) — exists but is NOT the live store; (c) pane ledger + recovery inventory — identity survival for terminals.
+- ASYMMETRY: same user concept ("my open tabs"), three durability stories. mm-mass #10 flags the contradiction (P41).
+
+## F7 — Pane-identity ledger (shared service, many writers/readers)
+- ABOVE (writers): WS create/identity stamping, codex/opencode association controllers, fresh-agent `identity_sink` (server implements over the ledger), codex crash-respawn supersession (`supersedes`).
+- BELOW (readers): reconcile rung 2b (supersededBy chain), recovery inventory, auto-resume identity, resume validation retire-row.
+- ASYMMETRIES: binding rows keyed by sessionRef vs pending markers keyed by terminalId, never joined (G1); write failures "never block but never silent" — is the surface actually user-visible? Quarantine-per-row corruption policy.
+
+## F8 — Remote-access networking (platform × operation matrix)
+- ABOVE: Settings UI / NetworkQuickAccess → REST network routes (`freshell-server/src/network.rs`, 4.2k, 11 commits in last week).
+- MEMBERS: platforms (Windows, WSL2, macOS, Linux) × operations (bind rebind `net_bind.rs`, firewall rules `freshell-platform/src/firewall.rs`, elevation `elevated.rs`, port forward `port_forward.rs`, managed ports, origins rebuild ALLOWED_ORIGINS).
+- BELOW: ElevationRunner, OS firewall CLIs.
+- ASYMMETRIES: WSL2 needs port-forward + firewall pair others don't; confirm-disable/confirm-firewall protocol is new; failure here can lock the user out of the server entirely (P02/P20). Newest code, thinnest docs (mm-churn #1 undocumented hotspot).
+
+## F9 — Activity/attention above-layer (deck + tabs consume one truth)
+- ABOVE: SPA attention indicators, Stream Deck status backgrounds/rings + waiting counts (P09/P13).
+- MEMBERS: per-provider busy/idle/turn-complete edges (see F2), `completionSeq` reconnect seeding, NEW `terminal.idle` edge.
+- BELOW: activity hub single-timer deadline scheduler (zero-polling).
+- ASYMMETRIES: #614 ("truth-source-verified bells") landed AT TIP over #602/#597 — freshest semantics change in the tree; amplifier attach@Start vs @Eof; codex abort reasons.
+
+## Real adjacencies (test these edges, not the full grid)
+- F1→F2: dispatch arms call provider slices (freshAgent.* per provider).
+- F3→F7: every spawn door must stamp identity/ledger the same way (claude_fresh_prealloc flag must match genuine-fresh path — resume_validation.rs:21-24).
+- F2→F4: locator bindings feed existence/reconcile verdicts; a misbind surfaces as a WRONG verdict later.
+- F4→F6: reconcile verdicts drive the SPA's recovery/dead-session flows against the three stores.
+- F1→F5: every reply crosses the bus; backpressure disconnect re-enters F1 (reconnect).
+- F9→F5: bells ride the bus; a dropped frame = a missed bell.
+- F3→F2: spawn-door launch prep (resume argv, MCP inject) is per-provider.

--- a/docs/pbh-20260807/map/promise-ledger.md
+++ b/docs/pbh-20260807/map/promise-ledger.md
@@ -1,0 +1,60 @@
+# Promise Ledger — pbh-20260807 (Rust `crates/` target)
+
+One line per promise, plain user language. STATED = docs/UI copy; IMPLIED = the UI/code
+lets you do it, so it must work; IMPLICIT = undocumented-but-heavy machinery users take
+for granted (Lens 3 escalations from mm-mass/mm-churn). Source pointers are worktree-relative.
+Human ratifies before hunt launch.
+
+## Stated (README / UI copy)
+
+- P01. You can organize work into tabs and panes — agents, shells, browsers, editors — as many tabs as you want. (README.md:23)
+- P02. You can run freshell on one machine and use it from your laptop/phone over VPN/Tailscale. (README.md:24)
+- P03. "Speak with the dead": you can resume ANY Claude, Codex, or OpenCode session from ANY device — even sessions not started in freshell. (README.md:25)
+- P04. Tabs auto-name from terminal content, drag-and-drop reorder, and show per-pane type icons. (README.md:26)
+- P05. Freshclaude is a rich chat alternative to the Claude CLI with full session persistence. (README.md:27)
+- P06. You can add pane types / CLI integrations / services via extensions and manage them from the Extensions page. (README.md:28,167-175)
+- P07. Self-configuring workspace: ask Claude/Codex to open a browser pane or create a tab with four subagents — the tmux-like API makes it work. (README.md:29)
+- P08. Every pane header shows live cwd, git branch, and context usage. (README.md:30)
+- P09. When a coding CLI finishes its turn you get an attention indicator (highlight/pulse/darken) that dismisses on click or typing. (README.md:31)
+- P10. Right-click a session → AI-generated (Gemini) title. (README.md:32)
+- P11. Sidebar search: instant local results, then deep server-side content search. (README.md:33)
+- P12. Works on phones/tablets (auto-collapsing sidebar). (README.md:34)
+- P13. Stream Deck: keys = tabs (repo icons + status), press to focus, long-press APPROVE/STOP agents, dials/touch strip on Deck+, auto-reconnect after unplug/replug and page reloads. (README.md:35,68-95)
+- P14. First run auto-generates an AUTH_TOKEN and prints the URL to connect. (README.md:51)
+- P15. On Windows, terminals default to WSL; `WINDOWS_SHELL` picks cmd/powershell instead. (README.md:57)
+- P16. All keyboard shortcuts in the table work (new/close/reopen tab, prev/next, move, copy/paste/search…). (README.md:97-115)
+- P17. Claude/Codex/OpenCode/Amplifier: session history + launch; Gemini/Kimi: launch only. (README.md:139-153)
+- P18. Existing OpenCode work is discovered from OpenCode's own DB and resumable with no manual import. (README.md:153)
+- P19. Providers/settings configurable in the Settings UI or `~/.freshell/config.json`, and they persist. (README.md:152; settings_store.rs)
+- P20. Remote access can be turned on/off from the sidebar/settings, with visible status and copyable URL. (src/components/NetworkQuickAccess.tsx; crates/freshell-server/src/network.rs)
+
+## Implied (UI affordances)
+
+- P21. After a page reload or a network blip, everything comes back: tabs, panes, running terminals, scrollback — nothing lost, nothing duplicated. (crates/freshell-terminal/src/registry.rs:1-27; freshell-ws/src/create_dedupe.rs; src/components/ReconcileWarmingBanner.tsx)
+- P22. Closing a pane/tab or disconnecting does NOT kill the process — it becomes a "background session" you can list, re-open, or kill. (crates/freshell-freshagent/src/pane_ops.rs:16-34; src/components/BackgroundSessions.tsx)
+- P23. After a freshell server restart, you're OFFERED recovery of your previous workspace (never silently dropped, never auto-restored wrong). (src/components/RecoveryOfferPanel.tsx; crates/freshell-server/src/recovery_inventory.rs; freshell-ws/src/pane_ledger.rs)
+- P24. A crashed coding agent restarts itself (bounded, loud, cancellable) and the banner tells you what happened. (crates/freshell-ws/src/auto_resume.rs:1-40; src/components/TerminalExitBanner.tsx)
+- P25. Retries/reconnects never double-spawn: the same create request or resume never yields two terminals or two writers of one session. (freshell-ws/src/create_dedupe.rs; freshell-freshagent/src/session_lease.rs:1-19)
+- P26. If a saved session is dead, you get ONE batched dialog and YOU decide per pane — nothing is auto-closed. (src/components/DeadSessionPanel.tsx)
+- P27. Busy/idle/needs-attention states are truthful — no false green, no missed bells, and they survive reconnects without double-counting. (freshell-ws/src/activity.rs:1-31; commit #614)
+- P28. On a cold boot, panes waiting on the session index show ONE "warming" banner with Retry — not dead panes. (src/components/ReconcileWarmingBanner.tsx; freshell-ws/src/reconcile.rs:20-27)
+- P29. Resuming a session whose transcript is gone falls back to a FRESH pane with a notice — never silently wedges, never resumes the wrong thing. (freshell-ws/src/resume_validation.rs; freshell-platform/src/resume_gate.rs)
+- P30. A terminal you start an agent in becomes resumable later — freshell figures out which session the CLI created and binds it to the pane. (freshell-ws/src/{codex,opencode}_association.rs; freshell-sessions/src/{codex,opencode}_locator.rs, amplifier_stub.rs)
+- P31. Tabs open on your OTHER devices show up in the Tabs view and disappear when that device closes them. (freshell-ws/src/tabs.rs:1-27)
+- P32. A freshclaude/freshcodex/freshopencode pane renders its transcript after reload — the pane always "shows something". (freshell-freshagent/src/snapshot.rs:9-16)
+- P33. Long-press APPROVE on the deck / the approval UI actually answers the agent's pending approval. (freshell-protocol client `freshAgent.approval.respond`; README.md:70)
+
+## Implicit (undocumented + heavy — Lens 3 escalations; see code-mass-heatmap.md)
+
+- P34. "The server re-attaches a reconnected socket to a running PTY" — 14k+ LoC, zero user docs. (mm-mass #1)
+- P35. "A reconnecting client's pane view is reconciled against server truth" (verdicts, supersession chains). (mm-mass #2)
+- P36. ANTI-PROMISE, contradicts P22: a detached idle terminal is auto-killed at 15 min (agent modes: 24 h hard cap) — nowhere documented. (freshell-terminal/src/registry.rs:381,853; mm-mass #3)
+- P37. "Only one terminal resumes a given session; losers get SESSION_RESERVED + retry hint." (session_lease.rs; terminal.rs:1305-1320)
+- P38. "Dead sockets are quietly dropped (ping 30s / hello 5s / 16MB backpressure) and the session survives." (freshell-ws/src/lib.rs, backpressure.rs; mm-mass #6)
+- P39. "Codex/claude sidecar death never fakes a completed turn; turns never duplicate-run across restart." (freshell-freshagent/src/claude.rs ADR 2.1; freshell-codex durability)
+- P40. "Resume fails OPEN: an unreadable session store still tries to resume rather than refuse" — user is never told this. (freshell-platform/src/resume_gate.rs; mm-mass #7)
+- P41. PARTIAL: "open tabs survive a server restart" — tabs registry is in-memory-only while a separate disk tabs-persist module exists. (freshell-ws/src/tabs.rs:17-27 vs tabs_persist.rs; mm-mass #10)
+
+## Ratification notes
+- P36 vs P22 is the ledger's sharpest internal contradiction — hunt it, then ratify which is the real promise.
+- P07's REST door currently 400s agent-mode terminal tabs by design deferral (freshell-freshagent/src/terminal_tabs.rs:15-20) — ratify whether P07 is a live promise for agent modes.

--- a/docs/pbh-20260807/map/territories.md
+++ b/docs/pbh-20260807/map/territories.md
@@ -1,0 +1,116 @@
+# Ranked Territories — pbh-20260807 (Rust `crates/` target)
+
+Rank = user-proximity × breadth-or-mass × asymmetry-smell. Each entry: which lenses lit it
+(L1 promises / L2 fans / L3 mass-churn), which promises flow through it, and the asymmetry
+that makes it smell. Scope rule for every hunter: **Node `server/` + `*.ts` server code is
+NOT territory and produces NO findings** (reference-only for ambiguous contracts).
+
+## Ranked list
+
+### T1 — Reload/reconnect trunk artery (L1+L2+L3) — P21, P25, P28, P34, P35, P38
+WS handshake → attach/replay → create-dedupe replay → reconcile verdicts, the path every user
+crosses every session. Asymmetries: dedupe replays only while terminal RUNNING; reconcile's
+ONE 2s deferral vs minutes-long cold index; restore-path frame sink silently drops on dead
+connection. Biggest mass (heatmap #1) + top churn files (terminal.rs 119, lib.rs 68).
+
+### T2 — Server-restart recovery & the three survival stores (L1+L3) — P23, P31, P41, P26
+Pane ledger + recovery inventory + RecoveryOfferPanel vs in-memory tabs registry vs disk
+tabs-persist. Asymmetry: one user concept ("my workspace comes back"), three different
+durability stories; tabs registry documented in-code as lossy while a disk module exists.
+Data-loss class if the recovery offer is wrong or missing.
+
+### T3 — Provider resume members: "speak with the dead" (L1+L2) — P03, P17, P18, P29, P37, P40
+Resume any claude/codex/opencode(/amplifier) session from history or pasted id, from any
+device. 4 members × 4 distinct mechanisms (file / rollout / sqlite / stub); fail-open gate;
+SESSION_RESERVED lease losers; ResumeSessionDialog's bounded warming retries. The README's
+headline promise.
+
+### T4 — Idle reaper vs background-session promise (L2+L3) — P22, P36 (contradiction), P24
+registry.rs idle auto-kill (15 min detached; agent modes 24h hard cap, changed AT TIP) vs
+"PTY KEEPS RUNNING — background session" + BackgroundSessions UI. Highest fix-density file
+(22/50). A detached shell silently dies at 15 min: wrong-silent/data-loss candidate #1.
+
+### T5 — Attention/busy-idle truth (L1+L2+L3) — P09, P27, P13 (deck reads it)
+Activity hub + per-provider trackers + completionSeq reconnect seeding; #614 rewrote bell
+semantics at the tip commit over #602/#597. Asymmetries: gemini/kimi status-inert; amplifier
+tailer attach@Start vs @Eof; BEL-in-escape-sequence parsing. False green / missed bell =
+perceptual, every user, every day.
+
+### T6 — freshAgent WS surface, above-side (L1+L2) — P05, P32, P33
+Dispatch arms exist for create/attach/send/interrupt/kill — but `approval.respond`,
+`question.respond`, `fork`, `compact` (and `codingcli.*`, `ui.layout.sync`) fall into the
+silent `_` arm. Plus snapshot asymmetry: claude reads disk (survives restart), codex/opencode
+ask live runtime (post-restart 404 → FRESH_AGENT_LOST_SESSION?). Freshclaude chat + deck
+approvals ride here.
+
+### T7 — Remote-access networking (L1+L3) — P02, P20, P14
+network.rs + net_bind + managed_ports + platform firewall/elevated/port_forward. Newest code
+in the tree, hottest churn (last 7 days), thinnest docs, merged at tip. Failure = user locked
+out of their own server, or firewall/elevation prompts misbehave. Platform×operation matrix
+asymmetries (WSL2 port-forward pair).
+
+### T8 — Crashed-agent auto-resume (L2+L3) — P24, P37, P39
+auto_resume.rs breaker (2 retries, cycle cap, healthy-lifetime reset) + respawn generation
+caps + TerminalExitBanner copy. Asymmetry: only WS-created terminals auto-resume; REST/agent-
+API-created agent panes crash dead silently. Codex crash-respawn supersession chains join here.
+
+### T9 — Session directory/history + search + resolve (L1+L3) — P03, P11, P17, P28
+directory_index incremental per-file cache (mtime/size; cached EXCLUSIONS), locators' parse
+rules, resume_resolve precedence ladder, warming states. Bug = session silently missing from
+history / unresumable / search silently weaker for opencode+amplifier (documented gap — does
+the UI say so?).
+
+### T10 — Terminal-pane session association (L2) — P30, P03
+codex snapshot-diff (Enter-anchored, first-submit re-snapshot ordering precondition) and
+opencode row-diff (cwd+window match) locators + association controllers. Misbind = pane
+resumes SOMEONE ELSE'S session later: wrong-silent, hard for a user to even diagnose.
+
+### T11 — Agent-API / self-configuring workspace (L1+L2) — P07, P22, P25
+REST /api/tabs, send-keys, capture, wait-for, split/close/select + MCP inject. Known
+asymmetries: terminal mode `shell` only (400 for agent modes — is P07 then false?); REST
+send_keys opencode continuity fix (AGENT-08) claimed fixed — verify; REST door takes spawn
+gate unlike interactive WS.
+
+### T12 — Freshclaude/fresh-agent members, below-side (L2) — P05, P39
+Per-provider drives: claude Node sidecar (death is completion-safe), codex app-server
+(interrupt RPC, durability), opencode serve (health-probe cold start, idle edge). Leases,
+kill-before-release, ExpiredNeedsKill "held closed forever" path — a wedged session key means
+the user can NEVER resume that session until restart.
+
+### T13 — Spawn doors above-side: create storms & protections (L2) — P21, P25, P01
+Spawn gate FIFO/queue-cap/timeout vs rate limiter vs dedupe, per door. A ~20-tab reload storm
+must drain in order; interactive create must stay instant; queue-full/timeout errors must be
+loud and recoverable in the UI.
+
+### T14 — Windows/WSL platform seams (L1+L3) — P15
+files.rs windows-path handling (fresh churn), platform detect/path/spawn, WSL_DISTRO,
+WINDOWS_SHELL fallbacks. Blocked/confusion class for the whole Windows user population.
+
+## Dark-territory note (no territory covers these — assign one dark agent or accept residual)
+- **freshell-tauri (5.7k)** — desktop shell: no worker artifact, no territory. README even says Stream Deck is NOT supported in the desktop app; what else diverges? DARK.
+- **Extensions lifecycle** (server/extensions.rs + extension.server.* frames; P06 stated in README) — DARK.
+- **freshell-server long tail**: updater.rs, proxy.rs, checkpoints.rs, screenshots.rs, repo_icon*, diag/logging, rate_limit.rs, instance_id.rs, shutdown_forensics.rs — DARK (low churn, but updater+proxy are user-reachable).
+- **freshell-api (1 file)** — trivial, accept residual.
+- **Emergent long-running whole-system issues** (memory growth, ledger growth, scrollback caps over days) — named residual, no single owner.
+
+## Proposed severity matrix (for human ratification)
+| Rank | Class | Definition (user-observable) | Examples here |
+|---|---|---|---|
+| S1 | **data-loss** | Work/session/transcript irrecoverably gone or overwritten | idle reaper kills detached shell w/ unsaved state; double-writer corrupts transcript; recovery offer discards panes |
+| S2 | **blocked** | User cannot proceed; no in-UI workaround | can't connect after remote-access toggle; resume permanently SESSION_RESERVED; pane wedged in 'creating' |
+| S3 | **wrong-silent** | Wrong result presented as truth, no signal | pane bound to someone else's session; false "completed" turn; stale tab list shown as live |
+| S4 | **confusion** | Misleading/undocumented state with a recovery path | dead pane with no explanation; bell that shouldn't have fired; ghost device tabs until restart |
+| S5 | **annoyance** | Friction, delay, cosmetic | extra warming retries; flicker; duplicate notifications |
+Modulators (escalate one level, cap S1): **silent**, **irreversible**, **trunk-artery** (hits every session). Priority = severity × confidence; report unique root causes only.
+
+## Recommended first hunt wave (8 territories; ~one agent each, T1 gets above+below pair)
+1. **T1** reload/reconnect artery (2 agents: above = dispatch/dedupe/replay; below = reconcile/registry agreement)
+2. **T4** idle reaper vs background sessions (the ledger's sharpest contradiction)
+3. **T3** provider resume members ("speak with the dead" — the headline promise)
+4. **T5** attention truth (tip-commit semantics, deck depends on it)
+5. **T6** freshAgent WS above-side (silently-swallowed members + post-restart snapshots)
+6. **T7** remote-access networking (newest + hottest + lockout blast radius)
+7. **T2** restart recovery / three survival stores
+8. **T8** crashed-agent auto-resume (incl. the REST-door exclusion)
+Plus: 1 dark-territory agent (tauri + extensions + server long tail) when pool allows.
+Held for wave 2: T9, T10, T11, T12, T13, T14.


### PR DESCRIPTION
## Summary
Seven user-facing bug fixes to the Rust server, found by a structured parallel bug-hunt (promise-ledger / fan-inventory / code-mass mapping over crates/, then hypothesis-driven confirm-and-fix). Every fix carries a RED→GREEN regression test, passed an independent blind per-fix review, and the whole branch passed a holistic fresh-eyes code review (2 iterations; round-1 CI-gate findings fixed in 4ee87cb03).

## Fixes
1. **freshclaude approvals/answers were silently dropped** (6c5f9ad86) — `freshAgent.approval.respond` / `question.respond` / `fork` / `compact` hit a silent WS catch-all with no handler; clicking Approve wedged the pane. Now answered with a visible `freshAgent.error{UNSUPPORTED_MESSAGE}` that un-wedges the pane. Note: approvals are NOT implemented in this port (the sidecar has no interactive permission channel); this makes the gap loud instead of silent.
2. **Idle reaper killed detached background terminals** (082206711) — a mere socket drop (tab close / laptop sleep / network blip) made a running terminal reap-eligible at 15 min idle: SIGKILL, scrollback lost. Now only an explicit last-pane detach reaps at the configured threshold; disconnected-but-wanted terminals live under the existing 24h hard cap. S1 data-loss fix.
3. **"Recover my panes" silently omitted a whole device** (75f641d47) — a restart-correlated race between two separately-locked store reads (concurrent tabs push pruning a just-selected snapshot generation) dropped the entire device: clean 200, `recoverable:false`. Now a bounded per-device re-read converges on the benign race; persistent incoherence fails loud (500 + error log), never a silent empty.
4. **Amplifier sessions froze in history** (73ad20d6c) — the index re-parses only when the discovered stat changes, but amplifier recency/preview derive from transcript/events sidecars that discovery never statted; active sessions sank out of sight. Sidecar mtimes are now folded into the discovered stat (stat-only, no content reads at discovery).
5. **terminal.exit overtook queued output/replay** (108f1365b) — exit bypassed the per-connection output FIFO, so attaching to an exited terminal delivered ready→exit→replay and the client dropped the replay: blank exited panes / lost scrollback. Exit now rides the same FIFO as a zero-weight, non-evictable sequenced frame; output→exit order holds unconditionally.
6. **opencode pane could silently bind the wrong session** (5aeae9c10) — the opencode locator/drain lacked codex's misbind guards; two same-cwd panes (or a fresh-agent `opencode serve` sharing opencode.db) could claim each other's session. Now mirrors codex one-for-one: contested-cwd census (ambiguous sole candidate binds nobody, no starvation of a solo contender) + drain-side claim refusal (bound-elsewhere incl. retired, fresh-agent), all warn-logged.
7. **freshclaude pane wedged "working" forever after sidecar crash** (f401dd7d0) — claude was the only provider whose unrequested sidecar death was silent (codex has an exit watcher; opencode emits unconditional idle). Now broadcasts exactly one `freshAgent.error{SIDECAR_EXITED}` in the unrequested-death branch only (structurally impossible on user kill/shutdown); no false completion chime.

Also on the branch: `docs/pbh-20260807/` — the campaign's observability record (run report, fix log with per-fix review verdicts, decision log, mapping artifacts, timing analysis).

## Verification
- Per-crate suites green: freshell-terminal 178, freshell-sessions 269, freshell-server (incl. recovery_inventory 20), freshell-ws lib + freshagent_control_reply 5, freshell-freshagent claude:: 34.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Pre-existing env-dependent failures (verified identical at base, NOT regressions): freshell-ws auto_resume_e2e (2), freshell-freshagent terminal_tabs e2e (24, missing `tsx` MCP dep locally), occasional restore_storm flake under full-suite load.

## Reviewer notes worth knowing (non-blocking, from the fresh-eyes review)
- Fix 3 widens the blast radius of a persistently-wedged single device store from "one device silently missing" to "recovery inventory returns 500" — deliberate fail-loud choice.
- The wire-string helpers in ws/terminal.rs hand-duplicate serde's lowercase encoding (exhaustive matches keep it compiler-checked; could derive from serde later).
- fold_activity_mtime adds 2 stat calls per amplifier session per sweep (matches the Node reference's cost profile).

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)