### PR TITLE
fix(freshclaude): dispatch 'interrupt' frames so Stop aborts an in-flight turn

### DIFF
--- a/crates/freshell-claude-sidecar/index.mjs
+++ b/crates/freshell-claude-sidecar/index.mjs
@@ -279,6 +279,7 @@ rl.on('line', (line) => {
   switch (req?.type) {
     case 'create': handleCreate(req); break
     case 'send': handleSend(req); break
+    case 'interrupt': handleInterrupt(req); break
     case 'shutdown': shutdown(); process.exit(0); break
     default: logerr(`unknown request type: ${req?.type}`)
   }

--- a/crates/freshell-freshagent/tests/claude_sidecar_interrupt_dispatch.rs
+++ b/crates/freshell-freshagent/tests/claude_sidecar_interrupt_dispatch.rs
@@ -1,0 +1,157 @@
+//! Regression test for the freshclaude Stop/Interrupt silent no-op: the REAL
+//! sidecar (`crates/freshell-claude-sidecar/index.mjs`) defines `handleInterrupt`
+//! but its stdin dispatch switch historically only routed `create`/`send`/`shutdown`,
+//! so the `{"type":"interrupt",...}` frame the Rust adapter writes
+//! (`claude.rs::handle_interrupt`) fell into `default: logerr('unknown request
+//! type: ...')` and was dropped — the user's Stop click did nothing. The crate's
+//! unit tests all use a FAKE sidecar (embedded JS that handles `interrupt`),
+//! which is exactly how this real-sidecar gap slipped past them.
+//!
+//! This test spawns the REAL `index.mjs` source with `node` and drives its stdin
+//! directly. The `@anthropic-ai/claude-agent-sdk` dependency is vendored via
+//! `npm install` into the sidecar package's own node_modules and is NOT present
+//! in a plain checkout/CI, so the test copies the real `index.mjs` VERBATIM into
+//! a temp dir with a stub `node_modules/@anthropic-ai/claude-agent-sdk` that
+//! satisfies only the top-level `import { query }` (the interrupt-dispatch path
+//! under test never calls `query()`; the stub throws if it is called). Only
+//! module RESOLUTION is redirected — every dispatched line of JS is the real
+//! source, read at test time.
+//!
+//! Observable contract (fire-and-forget interrupt, per the comment above
+//! `handleInterrupt`): an interrupt for an unknown session emits an
+//! `sdk.error "session not found"` frame on stdout. Pre-fix behavior was a
+//! stderr `unknown request type: interrupt` log and NO stdout frame.
+//!
+//! Requires `node` on PATH — the same requirement the crate's existing
+//! fake-sidecar tests already impose.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// Stub SDK entry: satisfies `import { query } from '@anthropic-ai/claude-agent-sdk'`
+/// without the vendored dependency. The interrupt-dispatch path never calls it.
+const STUB_SDK_INDEX: &str = "export function query() {\n  throw new Error('test stub: query() must not be called by the interrupt-dispatch test')\n}\n";
+
+const STUB_SDK_PACKAGE_JSON: &str = r#"{
+  "name": "@anthropic-ai/claude-agent-sdk",
+  "version": "0.0.0-test-stub",
+  "type": "module",
+  "main": "index.mjs"
+}
+"#;
+
+fn real_sidecar_source() -> String {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../freshell-claude-sidecar/index.mjs"
+    );
+    std::fs::read_to_string(path).expect("read the real crates/freshell-claude-sidecar/index.mjs")
+}
+
+#[test]
+fn real_sidecar_dispatches_interrupt_frames_to_handle_interrupt() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(dir.path().join("index.mjs"), real_sidecar_source())
+        .expect("copy real index.mjs verbatim");
+    let sdk_dir = dir
+        .path()
+        .join("node_modules/@anthropic-ai/claude-agent-sdk");
+    std::fs::create_dir_all(&sdk_dir).expect("create stub sdk dir");
+    std::fs::write(sdk_dir.join("package.json"), STUB_SDK_PACKAGE_JSON).expect("stub package");
+    std::fs::write(sdk_dir.join("index.mjs"), STUB_SDK_INDEX).expect("stub entry");
+
+    let mut child = Command::new("node")
+        .arg(dir.path().join("index.mjs"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn node with the real sidecar source (node is required by this crate's tests)");
+
+    // Reader threads: forward each line with a tag so the main thread can poll
+    // with timeouts (the pre-fix failure mode is "no stdout frame ever arrives",
+    // which must fail the test, not hang it).
+    let (tx, rx) = mpsc::channel::<(&'static str, String)>();
+    let stdout = child.stdout.take().expect("piped stdout");
+    let stderr = child.stderr.take().expect("piped stderr");
+    let tx_out = tx.clone();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            if tx_out.send(("stdout", line)).is_err() {
+                break;
+            }
+        }
+    });
+    std::thread::spawn(move || {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            if tx.send(("stderr", line)).is_err() {
+                break;
+            }
+        }
+    });
+
+    // Gate on the sidecar's startup log so the interrupt frame is never written
+    // before the dispatch loop is armed.
+    let mut stderr_lines: Vec<String> = Vec::new();
+    let ready = loop {
+        match rx.recv_timeout(Duration::from_secs(30)) {
+            Ok(("stderr", line)) => {
+                let is_ready = line.contains("ready");
+                stderr_lines.push(line);
+                if is_ready {
+                    break true;
+                }
+            }
+            Ok((_, line)) => panic!("unexpected stdout frame before any request: {line}"),
+            Err(_) => break false,
+        }
+    };
+    assert!(
+        ready,
+        "sidecar never logged ready; stderr so far: {stderr_lines:?}"
+    );
+
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    stdin
+        .write_all(b"{\"type\":\"interrupt\",\"sessionId\":\"nope\"}\n")
+        .expect("write interrupt frame");
+    stdin.flush().expect("flush interrupt frame");
+
+    // Post-fix observable: handleInterrupt emits the session-not-found sdk.error
+    // frame on stdout. Pre-fix: the frame is dropped by the `default:` arm and
+    // stderr logs `unknown request type: interrupt` instead.
+    let mut error_frame: Option<serde_json::Value> = None;
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while error_frame.is_none() {
+        let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
+            break;
+        };
+        match rx.recv_timeout(remaining) {
+            Ok(("stdout", line)) => {
+                error_frame =
+                    Some(serde_json::from_str(&line).expect("sidecar stdout is newline-JSON"));
+            }
+            Ok((_, line)) => stderr_lines.push(line),
+            Err(_) => break,
+        }
+    }
+
+    child.kill().ok();
+    child.wait().ok();
+
+    assert!(
+        !stderr_lines
+            .iter()
+            .any(|l| l.contains("unknown request type: interrupt")),
+        "pre-fix behavior: the interrupt frame fell into the dispatch default arm and was \
+         dropped; stderr: {stderr_lines:?}"
+    );
+    let frame = error_frame.expect(
+        "no stdout frame arrived: the interrupt request was not dispatched to handleInterrupt",
+    );
+    assert_eq!(frame["type"], "sdk.error", "frame: {frame}");
+    assert_eq!(frame["sessionId"], "nope", "frame: {frame}");
+    assert_eq!(frame["message"], "session not found", "frame: {frame}");
+}


### PR DESCRIPTION
## Summary
The claude sidecar's stdin dispatch switch (`crates/freshell-claude-sidecar/index.mjs`) had cases for `create`/`send`/`shutdown` only — `interrupt` frames from the Rust adapter (`claude.rs handle_interrupt`) fell into `default: logerr('unknown request type')` and were **silently dropped**. User symptom: clicking **Stop** on a runaway freshclaude turn did nothing — no abort, no feedback, agent keeps burning.

**Fix:** one line — route `interrupt` to the already-defined `handleInterrupt` (fire-and-forget semantics preserved; no reply on success, matching the Rust side's no-broadcast expectation).

**Why tests missed it:** the crate's unit tests drive a FAKE embedded-JS sidecar that *does* handle `interrupt`, so the real dispatch table was never exercised.

**Test:** new integration test spawns the REAL `index.mjs` (read at test time — no copy to drift) with a stub SDK module (throws if called; the dispatch path never calls it), sends an interrupt frame, and asserts the post-fix observable (`sdk.error` "session not found" on stdout) and absence of the pre-fix one (stderr "unknown request type: interrupt"). Verified RED on the unmodified sidecar, GREEN after.

**Verification:** `cargo test -p freshell-freshagent` green except the documented pre-existing env-dependent terminal_tabs baseline (24, missing `tsx` MCP dep locally); `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean. Independent blind review: PASS.

This is finding **N1** from the pbh-20260807 bug-hunt (see `docs/pbh-20260807/ANALYSIS-2.md` on main).

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)