### PR TITLE
feat: Cloud Vitest + Cloud Build (CLOUD-1, CLOUD-2)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -62,6 +62,7 @@ Thumbs.db
 # Exceptions: files needed by server-side tests
 !AGENTS.md
 !docs/skills/testing.md
+!docs/lab-notes/2026-04-20-coding-cli-session-contract.md
 
 # Explicitly keep package manifests (harmless; guards against future globs)
 !package.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -21,7 +21,11 @@ coverage/
 .the-usual-logs/
 
 # Application directories not needed for e2e tests
-docs/
+# Note: docs/ is NOT excluded wholesale — docs/skills/testing.md is needed
+# by test/integration/server/test-coordinator.test.ts. Instead, exclude only
+# the docs subdirectories we don't need.
+docs/plans/
+docs/development/
 installers/
 electron/
 examples/
@@ -54,6 +58,10 @@ Thumbs.db
 
 # Documentation (not needed at runtime)
 *.md
+
+# Exceptions: files needed by server-side tests
+!AGENTS.md
+!docs/skills/testing.md
 
 # Explicitly keep package manifests (harmless; guards against future globs)
 !package.json

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -63,6 +63,7 @@ Thumbs.db
 # Exceptions: files needed by server-side tests
 !AGENTS.md
 !docs/skills/testing.md
+!docs/lab-notes/2026-04-20-coding-cli-session-contract.md
 
 # Explicitly keep package manifests (harmless; guards against future globs)
 !package.json

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,69 @@
+# Build artifacts (rebuilt in Docker — never copy from host)
+node_modules/
+dist/
+target/
+test-results/
+playwright-report/
+coverage/
+.nyc_output/
+
+# Version control and CI
+.git/
+.github/
+
+# Agent/tool configuration directories (not needed in the image)
+.agents/
+.amplifier/
+.cargo/
+.claude/
+.codex/
+.discovery/
+.the-usual-logs/
+.worktrees/
+
+# Application directories not needed for e2e tests
+# Note: docs/ is NOT excluded wholesale — docs/skills/testing.md is needed
+# by test/integration/server/test-coordinator.test.ts. Instead, exclude only
+# the docs subdirectories we don't need.
+docs/plans/
+docs/development/
+installers/
+electron/
+examples/
+port/
+assets/
+
+# Editor / IDE
+.vscode/
+.idea/
+
+# Secrets — NEVER include in the image
+.env
+
+# Caches and temp files
+.eslintcache
+.cache/
+.npm/
+*.log
+*.pid
+
+# Archives and media
+*.tgz
+*.tar.gz
+*.zip
+*.mp4
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Documentation (not needed at runtime)
+*.md
+
+# Exceptions: files needed by server-side tests
+!AGENTS.md
+!docs/skills/testing.md
+
+# Explicitly keep package manifests (harmless; guards against future globs)
+!package.json
+!package-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,21 @@ FRESHELL_RUN_REAL_PROVIDER_CONTRACTS=1 npm run test:vitest -- \
   run test/integration/real/ --config config/vitest/vitest.server.config.ts
 ```
 
+### Vitest Test Backend (Cloud Run Jobs)
+
+Vitest unit/server test suites can run locally or on Google Cloud Run Jobs. The `FRESHELL_VITEST_BACKEND` environment variable controls the default:
+- **Unset or `"local"`**: run locally (the safe default for new clones)
+- **`"cloud"`**: run on Cloud Run Jobs (4 shards, ~2-3 min wall time vs ~5 min local, ~$0.02/run)
+
+```bash
+npm run test:cloud          # Run vitest on Cloud Run Jobs (client + server suites)
+npm run test:cloud:build    # Build and push the Docker image to Artifact Registry
+```
+
+**If `FRESHELL_VITEST_BACKEND` is not set, ask the user which way to set it** before running cloud vitest tests. Explain that cloud is faster (parallel shards, ~2-3 min vs ~5 min) but is a paid Google Cloud service (~$0.02/run); local is free but slower. Once the user chooses, set it permanently in their `~/.bashrc` (or equivalent) so agents don't need to ask again.
+
+**Note:** The electron suite always runs locally even in cloud mode (it needs a display and native modules not available in the container).
+
 ## Architecture
 
 ### Tech Stack

--- a/docker/cloud-run/Dockerfile
+++ b/docker/cloud-run/Dockerfile
@@ -102,6 +102,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Playwright chromium browser and its system dependencies.
 # Must match the @playwright/test version in package.json (1.58.2).
+# PLAYWRIGHT_BROWSERS_PATH places browsers in a shared system path so the
+# node user can access them (default ~/.cache/ms-playwright would be root's home).
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN npx --yes playwright@1.58.2 install --with-deps chromium
 
 WORKDIR /app
@@ -126,6 +129,14 @@ ENV FRESHELL_E2E_RUST_SERVER_BIN=/app/target/release/freshell-server
 # a stale copy in the source tree).
 COPY docker/cloud-run/entrypoint.sh /usr/local/bin/e2e-entrypoint.sh
 RUN chmod +x /usr/local/bin/e2e-entrypoint.sh
+
+# Switch to non-root user for runtime (node:22-bookworm provides UID 1000).
+# This is required by server-side tests that verify permission errors
+# propagate (claude-transcript-locator.test.ts chmod 0o000 tests) — root
+# would bypass those mode bits. Must be AFTER the entrypoint COPY+chmod above
+# which write to root-owned /usr/local/bin/.
+RUN chown -R node:node /app
+USER node
 
 # Basic healthcheck: verify the Node.js runtime and key artifacts are present.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \

--- a/docker/cloud-run/cloudbuild.yaml
+++ b/docker/cloud-run/cloudbuild.yaml
@@ -1,0 +1,34 @@
+steps:
+  # Create a buildx builder that supports registry cache export.
+  # The default docker driver does not support --cache-to type=registry.
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: ['-c', 'docker buildx create --use --name cloud-builder --driver docker-container || docker buildx use cloud-builder']
+  # Pull existing cache image for layer caching (exit 0 if not found yet).
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: ['-c', 'docker pull ${_IMAGE}-cache || exit 0']
+    env:
+      - 'DOCKER_BUILDKIT=1'
+  # Build with BuildKit + mode=max registry cache to preserve intermediate
+  # stage layers (rust-builder, node-builder), not just the final image.
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'buildx'
+      - 'build'
+      - '-f'
+      - 'docker/cloud-run/Dockerfile'
+      - '-t'
+      - '${_IMAGE}'
+      - '--cache-from'
+      - 'type=registry,ref=${_IMAGE}-cache'
+      - '--cache-to'
+      - 'type=registry,ref=${_IMAGE}-cache,mode=max'
+      - '--push'
+      - '.'
+    env:
+      - 'DOCKER_BUILDKIT=1'
+options:
+  machineType: 'E2_HIGHCPU_32'
+  diskSizeGb: 200
+timeout: '3600s'

--- a/docker/cloud-run/entrypoint.sh
+++ b/docker/cloud-run/entrypoint.sh
@@ -34,6 +34,35 @@ set -euo pipefail
 TASK_INDEX="${CLOUD_RUN_TASK_INDEX:-0}"
 TASK_COUNT="${CLOUD_RUN_TASK_COUNT:-1}"
 
+# TEST_MODE=vitest: run Vitest instead of Playwright.
+if [ "${TEST_MODE:-}" = "vitest" ]; then
+  SHARD_INDEX=$((TASK_INDEX + 1))
+  SHARD_COUNT="$TASK_COUNT"
+  CONFIGS="${VITEST_CONFIGS:-config/vitest/vitest.config.ts config/vitest/vitest.server.config.ts}"
+
+  # Parse VITEST_ARGS_JSON (JSON array) into a bash array using jq.
+  # This preserves argument boundaries (spaces, metacharacters, etc.)
+  # that would be lost with space-separated serialization.
+  EXTRA_ARGS=()
+  if [ -n "${VITEST_ARGS_JSON:-}" ]; then
+    while IFS= read -r arg; do
+      EXTRA_ARGS+=("$arg")
+    done < <(jq -r '.[]' <<< "$VITEST_ARGS_JSON")
+  fi
+
+  SHARD_ARG=()
+  if [ "$SHARD_COUNT" -gt 1 ]; then
+    SHARD_ARG=(--shard="${SHARD_INDEX}/${SHARD_COUNT}")
+  fi
+
+  EXIT_CODE=0
+  for config in $CONFIGS; do
+    echo "[vitest-entrypoint] Running vitest: $config ${SHARD_ARG[*]-} ${EXTRA_ARGS[*]-}"
+    npx vitest run --passWithNoTests --config "$config" "${SHARD_ARG[@]}" "${EXTRA_ARGS[@]}" || EXIT_CODE=$?
+  done
+  exit "$EXIT_CODE"
+fi
+
 CONFIG="test/e2e-browser/playwright.cloud.config.ts"
 SPECS_DIR="test/e2e-browser/specs"
 DURATIONS_FILE="docker/cloud-run/test-durations.txt"

--- a/docs/plans/2026-08-09-cloud-vitest-and-build.md
+++ b/docs/plans/2026-08-09-cloud-vitest-and-build.md
@@ -6,9 +6,52 @@
 
 **Goal:** Move Vitest unit/server test suites and Docker image builds to Google Cloud, reducing validation pipeline wall time from ~5 min to ~2 min.
 
-**Architecture:** The existing Docker image (built for Playwright e2e) already contains Node.js, all npm deps, the Rust server binary, and dist artifacts — everything Vitest needs. We add a `TEST_MODE=vitest` branch to the entrypoint that runs `npx vitest run --shard=I/N` for both default and server configs. A new `scripts/vitest-cloud.sh` wrapper (modeled on `scripts/e2e-cloud.sh`) dispatches to Cloud Run Jobs with `TEST_MODE=vitest`. `scripts/run-standard-tests.ts` gets an early-return dispatch when `FRESHELL_VITEST_BACKEND=cloud` that runs only the client+server stages in the cloud, then runs the electron stage locally. For Docker builds, a `cloudbuild.yaml` + `.gcloudignore` configures Google Cloud Build with layer caching. Cloud Build is the **default** build path (the original request says "so the image builds in the cloud instead of locally"); `--local-build` opts back into local Docker.
+**Architecture:** The existing Docker image (built for Playwright e2e) already contains Node.js, all npm deps, the Rust server binary, and dist artifacts — everything Vitest needs. We add a `TEST_MODE=vitest` branch to the entrypoint that runs `npx vitest run --passWithNoTests --shard=I/N` for both default and server configs. A new `scripts/vitest-cloud.sh` wrapper (modeled on `scripts/e2e-cloud.sh`) dispatches to Cloud Run Jobs with `TEST_MODE=vitest`. `scripts/run-standard-tests.ts` gets an early-return dispatch when `FRESHELL_VITEST_BACKEND=cloud` that runs only the client+server stages in the cloud, then runs the electron stage locally. For Docker builds, a `cloudbuild.yaml` + `.gcloudignore` configures Google Cloud Build with BuildKit `mode=max` layer caching (preserving intermediate stage layers). Cloud Build is the **default** build path (the original request says "so the image builds in the cloud instead of locally"); `--local-build` opts back into local Docker.
 
-**Tech Stack:** Google Cloud Run Jobs, Google Cloud Build, Artifact Registry, Vitest `--shard`, bash, TypeScript
+**Tech Stack:** Google Cloud Run Jobs, Google Cloud Build, Artifact Registry, Vitest `--shard`, BuildKit registry cache, bash, TypeScript
+
+## Design Decisions
+
+### Vitest `--shard` vs e2e duration-based sharding
+
+The e2e entrypoint uses a custom duration-aware bin-packing algorithm: it
+discovers spec files, looks up per-spec duration estimates from
+`test-durations.txt`, and greedy-assigns specs to shards by estimated
+runtime. This is necessary for Playwright because spec durations vary wildly
+(some specs take 2s, others 120s).
+
+Vitest's built-in `--shard` flag partitions test files equally by count, not
+by duration. **This is an intentional design choice**, not a gap:
+
+1. Vitest parallelizes tests *within* each shard (using worker threads), so
+   even if one shard gets more slow tests, it compensates with parallelism.
+2. Vitest test durations are far more uniform than Playwright specs (most
+   unit tests take <100ms; the slowest integration tests are ~5s).
+3. The 4-shard count-based partition already brings wall time from ~5 min
+   to ~2 min based on load-bearing validation (LB1, LB2).
+4. Duration-based sharding can be added later if imbalance is observed in
+   production — the entrypoint's `VITEST_ARGS_JSON` mechanism provides the
+   injection point for custom file lists.
+
+### `VITEST_ARGS_JSON` for lossless argument forwarding
+
+Arguments forwarded to the entrypoint are serialized as a JSON array
+(`VITEST_ARGS_JSON`), not a space-separated string. This preserves argument
+boundaries (args with spaces, shell metacharacters, newlines) and avoids
+glob expansion. The entrypoint parses the array with `jq -r '.[]'` (jq is
+already in the Docker image per Dockerfile:99). The wrapper script builds
+the JSON array using `jq -nc --args` to serialize safely.
+
+### Non-root runtime user
+
+The Dockerfile runtime stage currently runs as root. Two server-side tests
+in `claude-transcript-locator.test.ts` (lines 120, 134) use `chmod 0o000` to
+verify that permission errors propagate rather than being swallowed. Root
+bypasses these mode bits, so those tests would not reject as expected. The
+Dockerfile will add `USER node` (the `node:22-bookworm` base image provides
+a `node` user, UID 1000) and `chown -R node:node /app` to ensure the
+runtime is unprivileged. The server globalSetup writes to `/app/dist/server`
+— this directory must be writable by the `node` user.
 
 ## Global Constraints
 
@@ -24,12 +67,13 @@
 - Existing test scripts live in `scripts/test/cloud-*.test.sh` and follow a bash integration-test pattern
 - `.dockerignore` currently excludes `docs/` and `*.md`. The server Vitest suite includes `test/integration/server/test-coordinator.test.ts` which reads `AGENTS.md` and `docs/skills/testing.md`. These files must be present in the Docker image.
 - The existing `scripts/run-standard-tests.ts` runs three suites: client (default config), server (server config), and electron (electron config). Cloud dispatch must not silently drop the electron stage.
+- The existing `run-standard-tests.ts` uses `--passWithNoTests` (line 89) so that forwarded file filters targeting one suite don't cause sibling suites to fail with no matching tests. The entrypoint vitest mode must do the same.
 - The logs directory for this run is: `/home/dan/code/freshell/.worktrees/.the-usual-logs/cloud-vitest-and-build`
 
 ## Requirements
 
-- **R1 — Cloud Vitest:** Vitest default + server suites run on Cloud Run Jobs with 4-way sharding, completing in <3 min wall time
-- **R2 — Cloud Build:** Docker image builds on Google Cloud Build (as the default build path, not opt-in), completing in <15 min cold / <5 min warm
+- **R1 — Cloud Vitest:** Vitest default + server suites run on Cloud Run Jobs with 4-way sharding (Vitest built-in `--shard`, count-based partition), completing in <3 min wall time
+- **R2 — Cloud Build:** Docker image builds on Google Cloud Build (as the default build path, not opt-in) with BuildKit `mode=max` registry cache preserving intermediate stage layers, completing in <15 min cold / <5 min warm
 - **R3 — Backend selection:** `FRESHELL_VITEST_BACKEND` env var controls local vs cloud, mirroring the `FRESHELL_E2E_BACKEND` pattern; `--local`/`--cloud` flags override per-invocation
 - **R4 — Integration:** `npm test` / `npm run check` / `npm run verify` dispatch to cloud vitest when `FRESHELL_VITEST_BACKEND=cloud`, while preserving the electron stage locally
 - **R5 — Tests:** Full test coverage of new scripts, configs, and entrypoint changes, following the existing `scripts/test/cloud-*.test.sh` pattern
@@ -37,7 +81,7 @@
 
 ---
 
-### Task 1: Entrypoint vitest mode + .dockerignore fix
+### Task 1: Entrypoint vitest mode + .dockerignore fix + Dockerfile USER node
 
 **Requirements served:** R1
 
@@ -45,32 +89,40 @@
 - When `TEST_MODE=vitest` env var is set, the entrypoint runs Vitest instead of Playwright
 - Each Cloud Run task runs both default and server vitest configs, using `--shard=I/N` for sharding
 - Shard index comes from `CLOUD_RUN_TASK_INDEX` (0-based) and `CLOUD_RUN_TASK_COUNT`
+- `--passWithNoTests` is always passed, so a config with no matching test files exits 0 (not 1) — this mirrors `run-standard-tests.ts:89`
 - If any config fails, the exit code is non-zero (but both configs still run)
 - When `TEST_MODE` is unset or `playwright`, current behavior is unchanged
 - `.dockerignore` is updated to allow `AGENTS.md` and `docs/skills/testing.md` into the image (needed by `test/integration/server/test-coordinator.test.ts`)
-- The entrypoint accepts `VITEST_ARGS` env var for pass-through arguments (e.g., specific test files), so the container smoke test can run a single fast test file
+- The Dockerfile runtime stage switches to `USER node` (non-root) so that `claude-transcript-locator.test.ts` permission tests (lines 120, 134) behave correctly — `chmod 0o000` is not bypassed by root
+- The entrypoint accepts `VITEST_ARGS_JSON` env var for pass-through arguments (JSON array, parsed with `jq`), so the container smoke test can run a single fast test file without losing argument boundaries
 
 **Files:**
 - Modify: `docker/cloud-run/entrypoint.sh` (add vitest branch at top, before playwright logic)
+- Modify: `docker/cloud-run/Dockerfile` (add `chown` + `USER node` in runtime stage)
 - Modify: `.dockerignore` (add `!AGENTS.md` and `!docs/skills/testing.md` exceptions)
 - Test: `scripts/test/cloud-vitest-entrypoint.test.sh`
 
 **Interfaces:**
-- Consumes: `TEST_MODE` (env var, new), `CLOUD_RUN_TASK_INDEX` (existing), `CLOUD_RUN_TASK_COUNT` (existing), `VITEST_CONFIGS` (env var, new — space-separated list of config paths, default: `"config/vitest/vitest.config.ts config/vitest/vitest.server.config.ts"`), `VITEST_ARGS` (env var, new — space-separated extra args passed to vitest, e.g., a test file path)
+- Consumes: `TEST_MODE` (env var, new), `CLOUD_RUN_TASK_INDEX` (existing), `CLOUD_RUN_TASK_COUNT` (existing), `VITEST_CONFIGS` (env var, new — space-separated list of config paths, default: `"config/vitest/vitest.config.ts config/vitest/vitest.server.config.ts"`), `VITEST_ARGS_JSON` (env var, new — JSON array of extra args passed to vitest, e.g. `'["test/unit/lib/pane-utils.test.ts"]'`)
 - Produces: Vitest test output on stdout/stderr, exit code 0 (all pass) or 1 (any fail)
 
 **Test cases:**
 - `TEST_MODE=vitest` branch exists in entrypoint → grep finds `TEST_MODE` and `vitest`
 - Entrypoint with `TEST_MODE=playwright` (or unset) → current behavior unchanged
-- Entrypoint with `TEST_MODE=vitest` and `CLOUD_RUN_TASK_COUNT=1` → runs `npx vitest run` for both configs (no `--shard` flag)
-- Entrypoint with `TEST_MODE=vitest` and `CLOUD_RUN_TASK_COUNT=2` → runs `npx vitest run --shard=1/2` and `--shard=2/2` for both configs
+- Entrypoint with `TEST_MODE=vitest` and `CLOUD_RUN_TASK_COUNT=1` → runs `npx vitest run --passWithNoTests` for both configs (no `--shard` flag)
+- Entrypoint with `TEST_MODE=vitest` and `CLOUD_RUN_TASK_COUNT=2` → runs `npx vitest run --passWithNoTests --shard=1/2` and `--shard=2/2` for both configs
 - `VITEST_CONFIGS` env var limits which configs run (e.g., only default config)
-- `VITEST_ARGS` env var passes extra args to vitest (e.g., a specific test file)
+- `VITEST_ARGS_JSON` env var passes extra args to vitest (e.g., a specific test file) — test with an arg containing a space to verify lossless parsing
+- `--passWithNoTests` is present in the entrypoint vitest branch
+- `VITEST_ARGS_JSON` is parsed with `jq` (entrypoint references `jq` and `VITEST_ARGS_JSON`)
 - `.dockerignore` has `!AGENTS.md` exception
 - `.dockerignore` has `!docs/skills/testing.md` exception
-- Docker build succeeds with the modified entrypoint and .dockerignore (if Docker is available)
-- Running the entrypoint in a container with `TEST_MODE=vitest CLOUD_RUN_TASK_COUNT=1 VITEST_CONFIGS="config/vitest/vitest.config.ts" VITEST_ARGS="test/unit/lib/pane-utils.test.ts"` produces vitest output with passing tests (skip if Docker unavailable)
-- Multi-shard correctness: `CLOUD_RUN_TASK_COUNT=2` with `VITEST_ARGS` pointing to two test files — shard 1 runs one file, shard 2 runs the other (verify disjoint file sets by checking output contains different test file names)
+- Dockerfile runtime stage has `USER node` directive
+- Dockerfile runtime stage has `chown` for `/app` ownership
+- Docker build succeeds with the modified entrypoint, Dockerfile, and .dockerignore (if Docker is available)
+- Running the entrypoint in a container with `TEST_MODE=vitest CLOUD_RUN_TASK_COUNT=1 VITEST_CONFIGS="config/vitest/vitest.config.ts" VITEST_ARGS_JSON='["test/unit/lib/pane-utils.test.ts"]'` produces vitest output with passing tests (skip if Docker unavailable)
+- Running the entrypoint in a container as the `node` user: `claude-transcript-locator.test.ts` permission tests reject as expected (skip if Docker unavailable)
+- Multi-shard correctness: `CLOUD_RUN_TASK_COUNT=2` with `VITEST_ARGS_JSON` pointing to two test files — shard 1 runs one file, shard 2 runs the other (verify disjoint file sets by checking output contains different test file names)
 
 - [ ] **Step 1: Write the failing behavioral test**
 
@@ -78,24 +130,29 @@ Create `scripts/test/cloud-vitest-entrypoint.test.sh` with:
 - Check 1: entrypoint.sh contains `TEST_MODE` reference
 - Check 2: entrypoint.sh contains `vitest` reference
 - Check 3: entrypoint.sh contains `--shard` reference
-- Check 4: entrypoint.sh references `VITEST_CONFIGS`
-- Check 5: entrypoint.sh references `VITEST_ARGS`
-- Check 6: When `TEST_MODE` is unset, entrypoint still references playwright (unchanged behavior)
-- Check 7: `.dockerignore` contains `!AGENTS.md`
-- Check 8: `.dockerignore` contains `!docs/skills/testing.md`
-- Check 9: Docker build succeeds with the modified entrypoint (if Docker is available)
-- Check 10: Running the entrypoint in a container with `TEST_MODE=vitest CLOUD_RUN_TASK_COUNT=1 VITEST_CONFIGS="config/vitest/vitest.config.ts" VITEST_ARGS="test/unit/lib/pane-utils.test.ts"` produces vitest output with passing tests (skip if Docker unavailable)
-- Check 11: Multi-shard test — run two shards (`CLOUD_RUN_TASK_COUNT=2`, `CLOUD_RUN_TASK_INDEX=0` and `=1`) with `VITEST_ARGS="test/unit/lib/pane-utils.test.ts test/unit/lib/pane-snap-2d.test.ts"`, verify each shard runs a disjoint set of test files (skip if Docker unavailable)
+- Check 4: entrypoint.sh contains `--passWithNoTests`
+- Check 5: entrypoint.sh references `VITEST_CONFIGS`
+- Check 6: entrypoint.sh references `VITEST_ARGS_JSON` (not `VITEST_ARGS`)
+- Check 7: entrypoint.sh references `jq` (for parsing `VITEST_ARGS_JSON`)
+- Check 8: When `TEST_MODE` is unset, entrypoint still references playwright (unchanged behavior)
+- Check 9: `.dockerignore` contains `!AGENTS.md`
+- Check 10: `.dockerignore` contains `!docs/skills/testing.md`
+- Check 11: Dockerfile contains `USER node` in the runtime stage
+- Check 12: Dockerfile contains `chown` for `/app` ownership transfer
+- Check 13: Docker build succeeds with the modified entrypoint (if Docker is available)
+- Check 14: Running the entrypoint in a container with `TEST_MODE=vitest CLOUD_RUN_TASK_COUNT=1 VITEST_CONFIGS="config/vitest/vitest.config.ts" VITEST_ARGS_JSON='["test/unit/lib/pane-utils.test.ts"]'` produces vitest output with passing tests (skip if Docker unavailable)
+- Check 15: Running `claude-transcript-locator.test.ts` in a container as `node` user — the permission tests reject as expected (not silently pass) (skip if Docker unavailable)
+- Check 16: Multi-shard test — run two shards (`CLOUD_RUN_TASK_COUNT=2`, `CLOUD_RUN_TASK_INDEX=0` and `=1`) with `VITEST_ARGS_JSON='["test/unit/lib/pane-utils.test.ts", "test/unit/lib/pane-snap-2d.test.ts"]'`, verify each shard runs a disjoint set of test files (skip if Docker unavailable)
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
 Run: `bash scripts/test/cloud-vitest-entrypoint.test.sh`
 
-Expected: FAIL because `entrypoint.sh` does not contain `TEST_MODE` or `vitest` references, and `.dockerignore` lacks the `!AGENTS.md` / `!docs/skills/testing.md` exceptions
+Expected: FAIL because `entrypoint.sh` does not contain `TEST_MODE` or `vitest` references, `.dockerignore` lacks the `!AGENTS.md` / `!docs/skills/testing.md` exceptions, and the Dockerfile has no `USER node` directive
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Add to the top of `docker/cloud-run/entrypoint.sh`, after the `set -euo pipefail` and env var reads, before the playwright-specific logic:
+Add to the top of `docker/cloud-run/entrypoint.sh`, after the `set -euo pipefail` and env var reads (`TASK_INDEX`/`TASK_COUNT`), before the playwright-specific logic:
 
 ```bash
 # TEST_MODE=vitest: run Vitest instead of Playwright.
@@ -103,15 +160,26 @@ if [ "${TEST_MODE:-}" = "vitest" ]; then
   SHARD_INDEX=$((TASK_INDEX + 1))
   SHARD_COUNT="$TASK_COUNT"
   CONFIGS="${VITEST_CONFIGS:-config/vitest/vitest.config.ts config/vitest/vitest.server.config.ts}"
-  EXTRA_ARGS="${VITEST_ARGS:-}"
-  SHARD_ARG=""
-  if [ "$SHARD_COUNT" -gt 1 ]; then
-    SHARD_ARG="--shard=${SHARD_INDEX}/${SHARD_COUNT}"
+
+  # Parse VITEST_ARGS_JSON (JSON array) into a bash array using jq.
+  # This preserves argument boundaries (spaces, metacharacters, etc.)
+  # that would be lost with space-separated serialization.
+  EXTRA_ARGS=()
+  if [ -n "${VITEST_ARGS_JSON:-}" ]; then
+    while IFS= read -r arg; do
+      EXTRA_ARGS+=("$arg")
+    done < <(jq -r '.[]' <<< "$VITEST_ARGS_JSON")
   fi
+
+  SHARD_ARG=()
+  if [ "$SHARD_COUNT" -gt 1 ]; then
+    SHARD_ARG=(--shard="${SHARD_INDEX}/${SHARD_COUNT}")
+  fi
+
   EXIT_CODE=0
   for config in $CONFIGS; do
-    echo "[vitest-entrypoint] Running vitest: $config $SHARD_ARG $EXTRA_ARGS"
-    npx vitest run --config "$config" $SHARD_ARG $EXTRA_ARGS || EXIT_CODE=$?
+    echo "[vitest-entrypoint] Running vitest: $config ${SHARD_ARG[*]-} ${EXTRA_ARGS[*]-}"
+    npx vitest run --passWithNoTests --config "$config" "${SHARD_ARG[@]}" "${EXTRA_ARGS[@]}" || EXIT_CODE=$?
   done
   exit "$EXIT_CODE"
 fi
@@ -124,6 +192,17 @@ In `.dockerignore`, add after the `*.md` line:
 !docs/skills/testing.md
 ```
 
+In `docker/cloud-run/Dockerfile`, in the runtime stage (Stage 3), after the `COPY . .` line (line 120) and before the `ENV FRESHELL_E2E_RUST_SERVER_BIN` line, add ownership transfer and switch to non-root user:
+
+```dockerfile
+# Switch to non-root user for runtime (node:22-bookworm provides UID 1000).
+# This is required by server-side tests that verify permission errors
+# propagate (claude-transcript-locator.test.ts chmod 0o000 tests) — root
+# would bypass those mode bits.
+RUN chown -R node:node /app
+USER node
+```
+
 - [ ] **Step 4: Run the focused test**
 
 Run: `bash scripts/test/cloud-vitest-entrypoint.test.sh`
@@ -132,7 +211,7 @@ Expected: PASS
 
 - [ ] **Step 5: Refactor while green**
 
-The vitest branch is a clean early-return at the top of the entrypoint. No refactor needed.
+The vitest branch is a clean early-return at the top of the entrypoint. The Dockerfile change is two lines in the runtime stage. No refactor needed.
 
 - [ ] **Step 6: Run broader verification**
 
@@ -143,8 +222,8 @@ Expected: PASS
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add docker/cloud-run/entrypoint.sh .dockerignore scripts/test/cloud-vitest-entrypoint.test.sh
-git commit -m "feat: add TEST_MODE=vitest to cloud-run entrypoint and fix .dockerignore for server tests"
+git add docker/cloud-run/entrypoint.sh docker/cloud-run/Dockerfile .dockerignore scripts/test/cloud-vitest-entrypoint.test.sh
+git commit -m "feat: add TEST_MODE=vitest to cloud-run entrypoint, fix .dockerignore, switch to non-root user"
 ```
 
 ---
@@ -160,8 +239,9 @@ git commit -m "feat: add TEST_MODE=vitest to cloud-run entrypoint and fix .docke
 - `--shards=N` (default 4), `--timeout=DURATION` (default 30m), `--build` (force rebuild)
 - `--config=default|server|all` selects which vitest configs to run (default: all)
 - Cloud Run Job name: `freshell-vitest`
-- Sets `TEST_MODE=vitest`, `VITEST_CONFIGS`, and `VITEST_ARGS` env vars on the Cloud Run Job
-- Local mode runs `npx vitest run` for both configs directly
+- Sets `TEST_MODE=vitest`, `VITEST_CONFIGS`, and `VITEST_ARGS_JSON` env vars on the Cloud Run Job
+- `VITEST_ARGS_JSON` is built using `jq -nc --args` to serialize pass-through args losslessly (JSON array)
+- Local mode runs `npx vitest run --passWithNoTests --config <config>` for each config directly
 - `build`/`push` subcommands are identical to `e2e-cloud.sh` (same Docker image)
 - Cloud tests must NOT create or update the live Cloud Run Job — tests use a fake `gcloud` on PATH to verify the intended command without touching real infrastructure
 - The script file must be created with executable bit (`chmod +x`)
@@ -176,28 +256,31 @@ git commit -m "feat: add TEST_MODE=vitest to cloud-run entrypoint and fix .docke
 
 **Test cases:**
 - Script exists and is executable (verify with `test -x`)
-- Script has mode `100755` in git (verify with `git ls-files -s scripts/vitest-cloud.sh`)
+- Script has mode `100755` in git (verify with `git ls-files -s` — this check runs at Step 7 after staging, not at Step 4)
 - `help` subcommand shows usage, mentions `--local`, `--cloud`, `FRESHELL_VITEST_BACKEND`, `--shards`, `--config`
 - `--local` flag runs vitest locally (run a single fast test file to verify)
 - Default backend (unset env var) runs locally
 - `FRESHELL_VITEST_BACKEND=local` runs locally
-- `--cloud` flag with a fake `gcloud` on PATH: verify the wrapper invokes `gcloud run jobs execute` with the correct job name (`freshell-vitest`) and env vars (`TEST_MODE=vitest`, `VITEST_CONFIGS`), without touching real infrastructure
-- `--config=default` sets `VITEST_CONFIGS` to only the default config
-- `--config=server` sets `VITEST_CONFIGS` to only the server config
+- `--cloud` flag with a fake `gcloud` on PATH: verify the wrapper invokes `gcloud run jobs execute` with the correct job name (`freshell-vitest`) and env vars (`TEST_MODE=vitest`, `VITEST_CONFIGS`), without touching real infrastructure. Assert the fake gcloud was called (positive assertion), not just that "Running locally" is absent.
+- `--config=default` sets `VITEST_CONFIGS` to only the default config (verify via fake gcloud capturing the env-vars-file content)
+- `--config=server` sets `VITEST_CONFIGS` to only the server config (verify via fake gcloud)
+- `VITEST_ARGS_JSON` is valid JSON when pass-through args are present (verify via fake gcloud capturing the env-vars-file, then `jq` parse)
+- `VITEST_ARGS_JSON` preserves args with spaces (verify via fake gcloud: pass an arg like `-t "test with spaces"`, confirm the JSON array has it as a single element)
 - Existing `e2e-cloud.sh` tests still pass (no regression)
 
 - [ ] **Step 1: Write the failing behavioral test**
 
 Create `scripts/test/cloud-vitest-wrapper.test.sh` with:
 - Check 1: Script exists and is executable (`test -x`)
-- Check 2: `git ls-files -s scripts/vitest-cloud.sh` shows mode `100755`
-- Check 3: `help` contains "usage", "run", "--local", "--cloud", "FRESHELL_VITEST_BACKEND", "--shards", "--config"
-- Check 4: `--local` runs a single fast test file locally (e.g., `--local test/unit/lib/pane-utils.test.ts`)
-- Check 5: Default backend (unset env var) runs locally
-- Check 6: `FRESHELL_VITEST_BACKEND=local` runs locally
-- Check 7: `--cloud` flag with fake `gcloud` — create a temporary script that logs its args and exits 0, put it on PATH, verify the wrapper calls `gcloud run jobs execute` with `freshell-vitest` and sets `TEST_MODE=vitest` in the env-vars-file. Assert the fake gcloud was called (positive assertion), not just that "Running locally" is absent.
-- Check 8: `--config=default` sets `VITEST_CONFIGS` to only `config/vitest/vitest.config.ts` (verify via fake gcloud capturing the env-vars-file content)
-- Check 9: `--config=server` sets `VITEST_CONFIGS` to only `config/vitest/vitest.server.config.ts` (verify via fake gcloud)
+- Check 2: `help` contains "usage", "run", "--local", "--cloud", "FRESHELL_VITEST_BACKEND", "--shards", "--config"
+- Check 3: `--local` runs a single fast test file locally (e.g., `--local test/unit/lib/pane-utils.test.ts`)
+- Check 4: Default backend (unset env var) runs locally
+- Check 5: `FRESHELL_VITEST_BACKEND=local` runs locally
+- Check 6: `--cloud` flag with fake `gcloud` — create a temporary script that logs its args and exits 0, put it on PATH, verify the wrapper calls `gcloud run jobs execute` with `freshell-vitest` and sets `TEST_MODE=vitest` in the env-vars-file. Assert the fake gcloud was called (positive assertion), not just that "Running locally" is absent.
+- Check 7: `--config=default` sets `VITEST_CONFIGS` to only `config/vitest/vitest.config.ts` (verify via fake gcloud capturing the env-vars-file content)
+- Check 8: `--config=server` sets `VITEST_CONFIGS` to only `config/vitest/vitest.server.config.ts` (verify via fake gcloud)
+- Check 9: `VITEST_ARGS_JSON` is valid JSON when pass-through args are present (capture env-vars-file via fake gcloud, parse with `jq -e .`)
+- Check 10: `VITEST_ARGS_JSON` preserves args with spaces — pass `-t "test name"` as a pass-through arg, confirm the JSON array contains it as a single element (not split on space)
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -212,15 +295,14 @@ Create `scripts/vitest-cloud.sh` with:
 - Key differences from `e2e-cloud.sh`:
   - `GCP_JOB="freshell-vitest"` (not `freshell-e2e`)
   - `FRESHELL_VITEST_BACKEND` env var (not `FRESHELL_E2E_BACKEND`)
-  - Local mode: `npx vitest run --config <config>` for each config (not `npx playwright test`)
-  - Cloud mode: env-vars-file sets `TEST_MODE: "vitest"`, `VITEST_CONFIGS: "<configs>"`, and `VITEST_ARGS: "<extra args>"`
+  - Local mode: `npx vitest run --passWithNoTests --config <config>` for each config (not `npx playwright test`)
+  - Cloud mode: env-vars-file sets `TEST_MODE: "vitest"`, `VITEST_CONFIGS: "<configs>"`, and `VITEST_ARGS_JSON: "<json array>"`. The JSON array is built with: `jq -nc --args -- '{VITEST_ARGS_JSON: [$ARGS.positional]}' -- "${pw_args[@]}"` (or equivalent that produces valid JSON)
   - `--config=default|server|all` flag controls which configs to run
   - Log summary greps for vitest output patterns (`Test Files`, `Tests`)
   - Default `--shards=4` (not 1)
   - Default `--timeout=30m` (not 60m)
-  - Non-positional args (not recognized as config selectors) are forwarded as `VITEST_ARGS`
+  - Non-positional args (not recognized as config selectors) are forwarded as `VITEST_ARGS_JSON`
 - After creating the file: `chmod +x scripts/vitest-cloud.sh`
-- Verify: `git ls-files -s scripts/vitest-cloud.sh` shows `100755` (use `git update-index --chmod=+x` if needed)
 
 - [ ] **Step 4: Run the focused test**
 
@@ -238,10 +320,21 @@ Run: `bash scripts/test/cloud-run-wrapper.test.sh` (existing e2e wrapper tests s
 
 Expected: PASS
 
-- [ ] **Step 7: Commit the task**
+- [ ] **Step 7: Verify git executable mode and commit**
 
+Verify the file is tracked as executable:
 ```bash
 git add scripts/vitest-cloud.sh scripts/test/cloud-vitest-wrapper.test.sh
+git ls-files -s scripts/vitest-cloud.sh
+```
+
+If the mode is not `100755`, fix it:
+```bash
+git update-index --chmod=+x scripts/vitest-cloud.sh
+```
+
+Then commit:
+```bash
 git commit -m "feat: add vitest-cloud.sh wrapper for Cloud Run Jobs"
 ```
 
@@ -256,38 +349,41 @@ git commit -m "feat: add vitest-cloud.sh wrapper for Cloud Run Jobs"
 - The dispatch happens at the top of `main()`, before any local test planning
 - The cloud dispatch runs only the client and server configs; the electron config always runs locally (it needs a display and native modules not available in the container)
 - Forwarded args are passed through to the cloud wrapper
+- The cloud wrapper script path is injectable via `FRESHELL_VITEST_CLOUD_SCRIPT` env var (default: `resolve(repoRoot, 'scripts/vitest-cloud.sh')`), so tests can substitute a fake without relying on PATH interception of an absolute-path exec
 - New npm scripts: `test:cloud`, `test:cloud:build`
 - AGENTS.md updated with cloud vitest instructions
 
 **Files:**
-- Modify: `scripts/run-standard-tests.ts` (add early dispatch in `main()`)
+- Modify: `scripts/run-standard-tests.ts` (add early dispatch in `main()`, with injectable script path)
 - Modify: `package.json` (add `test:cloud`, `test:cloud:build` scripts)
 - Modify: `AGENTS.md` (add Vitest section to E2E Test Backend area)
 - Test: `scripts/test/cloud-vitest-integration.test.sh`
 
 **Interfaces:**
-- Consumes: `FRESHELL_VITEST_BACKEND` env var
+- Consumes: `FRESHELL_VITEST_BACKEND` env var, `FRESHELL_VITEST_CLOUD_SCRIPT` env var (optional, for test injection)
 - Produces: Exit code from `scripts/vitest-cloud.sh run` (for client+server) then local vitest exit code (for electron)
 
 **Test cases:**
-- `FRESHELL_VITEST_BACKEND=cloud` in `run-standard-tests.ts` → dispatches to `vitest-cloud.sh` for client+server, then runs electron locally (verify by injecting a fake `vitest-cloud.sh` that logs its invocation and exits 0, and checking that both the fake and the local electron run were invoked)
+- `FRESHELL_VITEST_BACKEND=cloud` in `run-standard-tests.ts` → dispatches to `vitest-cloud.sh` for client+server, then runs electron locally
+- The dispatch is verifiable by injecting `FRESHELL_VITEST_CLOUD_SCRIPT` pointing to a fake script that logs its invocation and exits 0 — verify the fake was invoked (the log file exists and contains "run"), AND verify the local electron suite was also invoked. This proves both the cloud-dispatch branch and the local electron fallback execute.
 - `FRESHELL_VITEST_BACKEND` unset → current behavior (all three suites locally)
 - `FRESHELL_VITEST_BACKEND=local` → current behavior (all three suites locally)
 - `npm run test:cloud` script exists and dispatches to `scripts/vitest-cloud.sh run`
 - `npm run test:cloud:build` script exists and dispatches to `scripts/vitest-cloud.sh build`
 - `AGENTS.md` mentions `FRESHELL_VITEST_BACKEND`
-- `FRESHELL_VITEST_BACKEND=local npx tsx scripts/run-standard-tests.ts --mode desktop` still runs all three suites locally (no regression)
+- `FRESHELL_VITEST_BACKEND=local npx tsx scripts/run-standard-tests.ts --mode desktop` still runs all three suites locally (no regression — verify it does NOT invoke vitest-cloud.sh)
 
 - [ ] **Step 1: Write the failing behavioral test**
 
 Create `scripts/test/cloud-vitest-integration.test.sh` with:
 - Check 1: `scripts/run-standard-tests.ts` contains `FRESHELL_VITEST_BACKEND` reference
-- Check 2: `scripts/run-standard-tests.ts` contains `vitest-cloud.sh` reference
-- Check 3: `package.json` contains `test:cloud` script
-- Check 4: `package.json` contains `test:cloud:build` script
-- Check 5: `AGENTS.md` mentions `FRESHELL_VITEST_BACKEND`
-- Check 6: Process-level test — create a temporary fake `vitest-cloud.sh` that logs its args to a temp file and exits 0. Set `FRESHELL_VITEST_BACKEND=cloud` and run `npx tsx scripts/run-standard-tests.ts --mode desktop` with the fake on PATH. Verify the fake was invoked (the temp file exists and contains "run"). This proves the cloud-dispatch branch actually executes, not just that the string exists in source.
-- Check 7: `FRESHELL_VITEST_BACKEND=local npx tsx scripts/run-standard-tests.ts --mode desktop` still runs locally (no regression — verify it does NOT invoke vitest-cloud.sh)
+- Check 2: `scripts/run-standard-tests.ts` contains `FRESHELL_VITEST_CLOUD_SCRIPT` reference (the injection point)
+- Check 3: `scripts/run-standard-tests.ts` contains `vitest-cloud.sh` reference (the default path)
+- Check 4: `package.json` contains `test:cloud` script
+- Check 5: `package.json` contains `test:cloud:build` script
+- Check 6: `AGENTS.md` mentions `FRESHELL_VITEST_BACKEND`
+- Check 7: Process-level test — create a temporary fake `vitest-cloud.sh` at a temp path that logs its args to a temp file and exits 0. Set `FRESHELL_VITEST_BACKEND=cloud` and `FRESHELL_VITEST_CLOUD_SCRIPT=/tmp/fake-vitest-cloud.sh`. Run `npx tsx scripts/run-standard-tests.ts --mode desktop`. Verify the fake was invoked (the temp log file exists and contains "run"). Also verify the local electron suite was invoked (check stdout/stderr for electron vitest output). This proves the cloud-dispatch branch AND the electron fallback both execute, not just that the string exists in source.
+- Check 8: `FRESHELL_VITEST_BACKEND=local npx tsx scripts/run-standard-tests.ts --mode desktop` still runs locally (no regression — verify it does NOT invoke any vitest-cloud.sh)
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -302,7 +398,8 @@ In `scripts/run-standard-tests.ts`, add at the top of `main()`:
 ```typescript
 if (process.env.FRESHELL_VITEST_BACKEND === 'cloud') {
   const { execFileSync } = await import('node:child_process')
-  const cloudScript = resolve(repoRoot, 'scripts/vitest-cloud.sh')
+  const cloudScript = process.env.FRESHELL_VITEST_CLOUD_SCRIPT
+    || resolve(repoRoot, 'scripts/vitest-cloud.sh')
 
   // Run client + server suites in the cloud.
   try {
@@ -342,7 +439,7 @@ In `package.json`, add:
 
 In `AGENTS.md`, add a section under Testing explaining `FRESHELL_VITEST_BACKEND` (similar to `FRESHELL_E2E_BACKEND`). Include:
 - Unset or `"local"` = local (safe default)
-- `"cloud"` = Cloud Run Jobs with 4-way sharding
+- `"cloud"` = Cloud Run Jobs with 4-way sharding (Vitest built-in `--shard`, count-based partition)
 - Electron suite always runs locally even in cloud mode
 - Set permanently in `~/.bashrc` to avoid repeated prompts
 
@@ -377,8 +474,9 @@ git commit -m "feat: integrate cloud vitest with run-standard-tests.ts and npm s
 
 **Behavior:**
 - `docker/cloud-run/cloudbuild.yaml` configures Google Cloud Build with:
+  - BuildKit enabled (`DOCKER_BUILDKIT=1`) for `mode=max` registry caching, which preserves intermediate stage layers (rust-builder, node-builder) — not just the final image
   - `docker pull` of existing image for `--cache-from` layer caching
-  - `docker build -f docker/cloud-run/Dockerfile --cache-from <image> -t <image> .`
+  - `docker build -f docker/cloud-run/Dockerfile --cache-from type=registry,ref=<image>,mode=max -t <image> .`
   - `images:` field for automatic push to Artifact Registry
   - `E2_HIGHCPU_32` machine type, 200GB disk
   - `timeout` at the **top level** (not under `options`), per the [Cloud Build schema](https://docs.cloud.google.com/build/docs/build-config-file-schema)
@@ -386,7 +484,7 @@ git commit -m "feat: integrate cloud vitest with run-standard-tests.ts and npm s
 - Both `scripts/e2e-cloud.sh` and `scripts/vitest-cloud.sh` use Cloud Build as the **default** build path (the original request says "so the image builds in the cloud instead of locally")
 - `--local-build` flag on `cmd_build` opts back into local Docker
 - The `gcloud builds submit` command includes `--account`, `--project`, and the image URL is passed as a substitution derived from the wrapper's resolved settings (not hard-coded)
-- Tests use a fake `gcloud` to verify the intended command without submitting a real build
+- Tests use a fake `gcloud` AND a fake `docker` on PATH to verify the intended commands without submitting a real build or touching real infrastructure
 
 **Files:**
 - Create: `docker/cloud-run/cloudbuild.yaml`
@@ -406,11 +504,16 @@ git commit -m "feat: integrate cloud vitest with run-standard-tests.ts and npm s
 - `cloudbuild.yaml` uses `E2_HIGHCPU_32` machine type (under `options`)
 - `cloudbuild.yaml` has `timeout` at top level (NOT under `options`)
 - `cloudbuild.yaml` uses substitutions (`${_IMAGE}`) not hard-coded image URLs
+- `cloudbuild.yaml` enables BuildKit (`DOCKER_BUILDKIT=1` env or `--build-arg BUILDKIT=1`)
+- `cloudbuild.yaml` uses `mode=max` in the cache-from reference (for intermediate layer preservation)
 - `.gcloudignore` exists and excludes `.git`, `node_modules`, `target`, `dist`, `.worktrees/`
 - `e2e-cloud.sh help` mentions `--local-build`
 - `vitest-cloud.sh help` mentions `--local-build`
 - `e2e-cloud.sh build` (default, no flag) with a fake `gcloud` on PATH: verify the wrapper invokes `gcloud builds submit` with `--account`, `--project`, and `--config docker/cloud-run/cloudbuild.yaml`. Positive assertion on the command, not just absence of local Docker output.
-- `e2e-cloud.sh build --local-build` with a fake `docker` on PATH: verify the wrapper invokes `docker build` (local path still works)
+- `vitest-cloud.sh build` (default, no flag) with a fake `gcloud` on PATH: same verification as above — the vitest wrapper also dispatches to Cloud Build by default.
+- `e2e-cloud.sh build --local-build` with a fake `docker` AND a fake `gcloud` on PATH: verify the wrapper invokes `docker build` (local path still works), and verify it does NOT call `gcloud builds submit`.
+- `vitest-cloud.sh build --local-build` with a fake `docker` AND a fake `gcloud` on PATH: same verification — the vitest wrapper also supports local build.
+- The `--local-build` path fakes `gcloud` because the existing `cmd_push` function makes real `gcloud artifacts repositories describe/create` and `gcloud auth print-access-token` calls — the test must not depend on live credentials or create real registry resources.
 
 - [ ] **Step 1: Write the failing behavioral test**
 
@@ -422,12 +525,16 @@ Create `scripts/test/cloud-build.test.sh` with:
 - Check 5: `cloudbuild.yaml` contains `E2_HIGHCPU_32` under `options:`
 - Check 6: `cloudbuild.yaml` contains `timeout` at top level (verify it's NOT nested under `options`)
 - Check 7: `cloudbuild.yaml` uses `${_IMAGE}` substitution (not a hard-coded URL)
-- Check 8: `.gcloudignore` exists
-- Check 9: `.gcloudignore` excludes `.git`, `node_modules`, `target`, `dist`, `.worktrees/`
-- Check 10: `e2e-cloud.sh help` contains `--local-build`
-- Check 11: `vitest-cloud.sh help` contains `--local-build`
-- Check 12: `e2e-cloud.sh build` (default) with fake `gcloud` — create a temp script that logs args and exits 0, put it on PATH. Run `e2e-cloud.sh build`. Verify the fake gcloud was called with `builds submit` and `--config` containing `cloudbuild.yaml`. Also verify `--account` and `--project` are present.
-- Check 13: `e2e-cloud.sh build --local-build` with fake `docker` — create a temp script that logs args and exits 0. Run `e2e-cloud.sh build --local-build`. Verify the fake docker was called with `build`.
+- Check 8: `cloudbuild.yaml` enables BuildKit (contains `DOCKER_BUILDKIT=1` or `BUILDKIT=1`)
+- Check 9: `cloudbuild.yaml` uses `mode=max` in cache-from reference
+- Check 10: `.gcloudignore` exists
+- Check 11: `.gcloudignore` excludes `.git`, `node_modules`, `target`, `dist`, `.worktrees/`
+- Check 12: `e2e-cloud.sh help` contains `--local-build`
+- Check 13: `vitest-cloud.sh help` contains `--local-build`
+- Check 14: `e2e-cloud.sh build` (default) with fake `gcloud` — create a temp script that logs args and exits 0, put it on PATH. Run `e2e-cloud.sh build`. Verify the fake gcloud was called with `builds submit` and `--config` containing `cloudbuild.yaml`. Also verify `--account` and `--project` are present.
+- Check 15: `vitest-cloud.sh build` (default) with fake `gcloud` — same as Check 14 but for the vitest wrapper. Verify it also dispatches to Cloud Build by default.
+- Check 16: `e2e-cloud.sh build --local-build` with fake `docker` AND fake `gcloud` — create temp scripts for both that log args and exit 0. Run `e2e-cloud.sh build --local-build`. Verify the fake docker was called with `build`. Verify the fake gcloud was NOT called with `builds submit` (it may be called for `cmd_push`, but not for Cloud Build).
+- Check 17: `vitest-cloud.sh build --local-build` with fake `docker` AND fake `gcloud` — same as Check 16 but for the vitest wrapper.
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -440,9 +547,14 @@ Expected: FAIL because `cloudbuild.yaml` and `.gcloudignore` don't exist, and `-
 Create `docker/cloud-run/cloudbuild.yaml`:
 ```yaml
 steps:
+  # Pull existing image for layer caching (exit 0 if not found yet).
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
     args: ['-c', 'docker pull ${_IMAGE} || exit 0']
+    env:
+      - 'DOCKER_BUILDKIT=1'
+  # Build with BuildKit + mode=max registry cache to preserve intermediate
+  # stage layers (rust-builder, node-builder), not just the final image.
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
@@ -451,8 +563,10 @@ steps:
       - '-t'
       - '${_IMAGE}'
       - '--cache-from'
-      - '${_IMAGE}'
+      - 'type=registry,ref=${_IMAGE},mode=max'
       - '.'
+    env:
+      - 'DOCKER_BUILDKIT=1'
 images:
   - '${_IMAGE}'
 options:
@@ -468,6 +582,7 @@ Create `.gcloudignore` (same exclusions as `.dockerignore` plus `.worktrees/`).
 In `scripts/e2e-cloud.sh`, modify `cmd_build` to default to Cloud Build:
 - When `--local-build` is NOT set: run `gcloud builds submit --config "$ROOT/docker/cloud-run/cloudbuild.yaml" --account="$GCP_ACCOUNT" --project="$GCP_PROJECT" --substitutions=_IMAGE="$IMAGE_REMOTE" "$ROOT"`
 - When `--local-build` IS set: run the existing local `docker build` + `cmd_push` path
+- Add `--local-build` to the `cmd_build` arg parser and to `usage()`
 
 In `scripts/vitest-cloud.sh`, same modification to `cmd_build`.
 
@@ -491,7 +606,7 @@ Expected: PASS
 
 ```bash
 git add docker/cloud-run/cloudbuild.yaml .gcloudignore scripts/e2e-cloud.sh scripts/vitest-cloud.sh scripts/test/cloud-build.test.sh
-git commit -m "feat: add Cloud Build config and make cloud build the default"
+git commit -m "feat: add Cloud Build config with BuildKit mode=max cache and make cloud build the default"
 ```
 
 ---
@@ -511,6 +626,7 @@ git commit -m "feat: add Cloud Build config and make cloud build the default"
 
 **Test cases:**
 - `scripts/e2e-cloud.sh build` (Cloud Build default) → Docker image builds and pushes to Artifact Registry
+- `scripts/vitest-cloud.sh build` (Cloud Build default) → same image (verify the vitest wrapper also builds successfully via Cloud Build)
 - `scripts/vitest-cloud.sh run --cloud --shards=4` → all vitest tests pass (4/4 tasks succeeded), running against the image built by Cloud Build
 - Cloud vitest wall time < 3 min
 - Cloud build wall time < 15 min (cold) or < 5 min (warm)
@@ -521,13 +637,19 @@ Run: `scripts/e2e-cloud.sh build`
 
 Expected: Cloud Build succeeds, image pushed to Artifact Registry
 
-- [ ] **Step 2: Run cloud vitest against the Cloud-Built image**
+- [ ] **Step 2: Verify vitest-cloud.sh build also works**
+
+Run: `scripts/vitest-cloud.sh build`
+
+Expected: Cloud Build succeeds (same image, verifies the vitest wrapper's build subcommand works against real Cloud Build)
+
+- [ ] **Step 3: Run cloud vitest against the Cloud-Built image**
 
 Run: `scripts/vitest-cloud.sh run --cloud --shards=4 --timeout=30m`
 
 Expected: All 4 tasks succeed, vitest tests pass
 
-- [ ] **Step 3: Record results**
+- [ ] **Step 4: Record results**
 
 Write results to `/home/dan/code/freshell/.worktrees/.the-usual-logs/cloud-vitest-and-build/reports/cloud-validation.md` with:
 - Cloud vitest: shard count, wall time, per-shard test counts, cost estimate

--- a/docs/plans/2026-08-09-cloud-vitest-and-build.md
+++ b/docs/plans/2026-08-09-cloud-vitest-and-build.md
@@ -194,17 +194,19 @@ In `.dockerignore`, add after the `*.md` line:
 
 In `docker/cloud-run/Dockerfile`, in the runtime stage (Stage 3), after the `RUN chmod +x /usr/local/bin/e2e-entrypoint.sh` line (line 128) and before the `HEALTHCHECK` line, add ownership transfer and switch to non-root user. This must come AFTER the `COPY docker/cloud-run/entrypoint.sh /usr/local/bin/e2e-entrypoint.sh` and `RUN chmod +x` lines — those write to root-owned paths (`/usr/local/bin/`) and must run as root:
 
-```dockerfile
-# Install Playwright browsers to a shared system path so the node user can
-# access them (default ~/.cache/ms-playwright would be root's home).
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN npx --yes playwright@1.58.2 install --with-deps chromium
+Two changes to the Dockerfile runtime stage:
 
-# Switch to non-root user for runtime (node:22-bookworm provides UID 1000).
-# This is required by server-side tests that verify permission errors
-# propagate (claude-transcript-locator.test.ts chmod 0o000 tests) — root
-# would bypass those mode bits.
-# Must be AFTER the entrypoint COPY+chmod (lines 127-128) which write to /usr/local/bin/.
+**Change 1:** Set `PLAYWRIGHT_BROWSERS_PATH` before the **existing** Playwright install (line 105), so browsers go to a shared system path instead of root's home. Do NOT add a second install — move the env var to before the existing one:
+
+```dockerfile
+# Before the existing install line (line 105):
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+# (existing line) RUN npx --yes playwright@1.58.2 install --with-deps chromium
+```
+
+**Change 2:** After the `RUN chmod +x /usr/local/bin/e2e-entrypoint.sh` line (line 128) and before `HEALTHCHECK`, add ownership transfer and switch to non-root user:
+
+```dockerfile
 RUN chown -R node:node /app
 USER node
 ```
@@ -302,7 +304,7 @@ Create `scripts/vitest-cloud.sh` with:
   - `GCP_JOB="freshell-vitest"` (not `freshell-e2e`)
   - `FRESHELL_VITEST_BACKEND` env var (not `FRESHELL_E2E_BACKEND`)
   - Local mode: `npx vitest run --passWithNoTests --config <config>` for each config (not `npx playwright test`)
-  - Cloud mode: env-vars-file sets `TEST_MODE: "vitest"`, `VITEST_CONFIGS: "<configs>"`, and `VITEST_ARGS_JSON: "<json array>"`. The JSON array is built with: `printf '%s\n' "${pw_args[@]}" | jq -R . | jq -sc .` (produces a flat JSON array preserving argument boundaries; the `jq -nc --args` form nests the array and includes a literal `--`)
+  - Cloud mode: env-vars-file sets `TEST_MODE: "vitest"`, `VITEST_CONFIGS: "<configs>"`, and `VITEST_ARGS_JSON: "<json array>"`. The JSON array is built with: `printf '%s\n' "${pw_args[@]}" | jq -R . | jq -sc .`. Since the JSON array contains double quotes, write the env-vars file using a YAML-safe method: either single-quote the JSON value in YAML (`VITEST_ARGS_JSON: '<json>'`) or use `jq -Rs .` to produce a YAML-safe double-quoted string with proper escaping. The env-vars file must round-trip through `gcloud run jobs execute --env-vars-file` without corrupting JSON values.
   - `--config=default|server|all` flag controls which configs to run
   - Log summary greps for vitest output patterns (`Test Files`, `Tests`)
   - Default `--shards=4` (not 1)
@@ -322,7 +324,9 @@ Review for duplication with `e2e-cloud.sh`. If `cmd_build` and `cmd_push` are id
 
 - [ ] **Step 6: Run broader verification**
 
-Run: `bash scripts/test/cloud-run-wrapper.test.sh` — **but only the local-mode checks**. The `--cloud` test cases in this script use real `gcloud` and can create/update/execute the live `freshell-e2e` Cloud Run Job. Run with a fake `gcloud` on PATH to ensure no real infrastructure is touched.
+Run: `bash scripts/test/cloud-run-dockerfile.test.sh` (Dockerfile tests, no gcloud interaction).
+
+Do NOT run `scripts/test/cloud-run-wrapper.test.sh` as a verification gate — its `--cloud` check uses real `gcloud` and can mutate/execute the live Cloud Run Job. That script's own CI gate is responsible for its safety.
 
 Expected: PASS
 
@@ -439,7 +443,7 @@ if (process.env.FRESHELL_VITEST_BACKEND === 'cloud') {
 
 In `package.json`, add:
 ```json
-"test:cloud": "bash scripts/vitest-cloud.sh run",
+"test:cloud": "bash scripts/vitest-cloud.sh run --cloud",
 "test:cloud:build": "bash scripts/vitest-cloud.sh build",
 ```
 
@@ -482,7 +486,7 @@ git commit -m "feat: integrate cloud vitest with run-standard-tests.ts and npm s
 - `docker/cloud-run/cloudbuild.yaml` configures Google Cloud Build with:
   - BuildKit enabled (`DOCKER_BUILDKIT=1`) for `mode=max` registry caching, which preserves intermediate stage layers (rust-builder, node-builder) — not just the final image
   - `docker pull` of existing image for `--cache-from` layer caching
-  - `docker build -f docker/cloud-run/Dockerfile --cache-from type=registry,ref=<image> --cache-to type=registry,ref=<image>,mode=max -t <image> .`
+  - `docker buildx build -f docker/cloud-run/Dockerfile --cache-from type=registry,ref=<image>-cache --cache-to type=registry,ref=<image>-cache,mode=max -t <image> --push .`
   - `images:` field for automatic push to Artifact Registry
   - `E2_HIGHCPU_32` machine type, 200GB disk
   - `timeout` at the **top level** (not under `options`), per the [Cloud Build schema](https://docs.cloud.google.com/build/docs/build-config-file-schema)
@@ -506,7 +510,7 @@ git commit -m "feat: integrate cloud vitest with run-standard-tests.ts and npm s
 **Test cases:**
 - `docker/cloud-run/cloudbuild.yaml` exists and is valid YAML
 - `cloudbuild.yaml` references the correct Dockerfile path (`docker/cloud-run/Dockerfile`)
-- `cloudbuild.yaml` contains `images:` field
+- `cloudbuild.yaml` uses `docker buildx build` with `--push` (not `images:` field)
 - `cloudbuild.yaml` uses `E2_HIGHCPU_32` machine type (under `options`)
 - `cloudbuild.yaml` has `timeout` at top level (NOT under `options`)
 - `cloudbuild.yaml` uses substitutions (`${_IMAGE}`) not hard-coded image URLs
@@ -527,7 +531,7 @@ Create `scripts/test/cloud-build.test.sh` with:
 - Check 1: `docker/cloud-run/cloudbuild.yaml` exists
 - Check 2: `cloudbuild.yaml` is valid YAML (parse with `python3 -c "import yaml; yaml.safe_load(open('...'))"`)
 - Check 3: `cloudbuild.yaml` contains `docker/cloud-run/Dockerfile`
-- Check 4: `cloudbuild.yaml` contains `images:`
+- Check 4: `cloudbuild.yaml` uses `buildx build` with `--push`
 - Check 5: `cloudbuild.yaml` contains `E2_HIGHCPU_32` under `options:`
 - Check 6: `cloudbuild.yaml` contains `timeout` at top level (verify it's NOT nested under `options`)
 - Check 7: `cloudbuild.yaml` uses `${_IMAGE}` substitution (not a hard-coded URL)
@@ -556,27 +560,27 @@ steps:
   # Pull existing image for layer caching (exit 0 if not found yet).
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker pull ${_IMAGE} || exit 0']
+    args: ['-c', 'docker pull ${_IMAGE}-cache || exit 0']
     env:
       - 'DOCKER_BUILDKIT=1'
   # Build with BuildKit + mode=max registry cache to preserve intermediate
   # stage layers (rust-builder, node-builder), not just the final image.
   - name: 'gcr.io/cloud-builders/docker'
     args:
+      - 'buildx'
       - 'build'
       - '-f'
       - 'docker/cloud-run/Dockerfile'
       - '-t'
       - '${_IMAGE}'
       - '--cache-from'
-      - 'type=registry,ref=${_IMAGE}'
+      - 'type=registry,ref=${_IMAGE}-cache'
       - '--cache-to'
-      - 'type=registry,ref=${_IMAGE},mode=max'
+      - 'type=registry,ref=${_IMAGE}-cache,mode=max'
+      - '--push'
       - '.'
     env:
       - 'DOCKER_BUILDKIT=1'
-images:
-  - '${_IMAGE}'
 options:
   machineType: 'E2_HIGHCPU_32'
   diskSizeGb: 200
@@ -585,7 +589,7 @@ timeout: '3600s'
 
 Note: No `substitutions` block — the wrapper always passes `--substitutions=_IMAGE="$IMAGE_REMOTE"` on the `gcloud builds submit` command line, so the image URL is never hard-coded in the YAML.
 
-Create `.gcloudignore` (same exclusions as `.dockerignore` plus `.worktrees/`), including the same `!AGENTS.md` and `!docs/skills/testing.md` exceptions — Cloud Build source upload respects `.gcloudignore`, and without these exceptions the server Vitest suite would fail in the container.
+Create `.gcloudignore` with the same exclusions as `.dockerignore` plus `.worktrees/`, but **do not exclude `docs/` wholesale** — `.gcloudignore` follows gitignore rules where a child cannot be re-included if its parent directory is excluded, so `!docs/skills/testing.md` would be ignored. Instead, exclude only the docs subdirectories not needed by tests (e.g. `docs/plans/`, `docs/development/`, `docs/index.html`), keeping `docs/skills/testing.md` accessible. Include `!AGENTS.md` as an exception (AGENTS.md is at the root, not under an excluded parent).
 
 In `scripts/e2e-cloud.sh`, modify `cmd_build` to default to Cloud Build:
 - When `--local-build` is NOT set: run `gcloud builds submit --config "$ROOT/docker/cloud-run/cloudbuild.yaml" --account="$GCP_ACCOUNT" --project="$GCP_PROJECT" --substitutions=_IMAGE="$IMAGE_REMOTE" "$ROOT"`
@@ -606,7 +610,9 @@ The `--local-build` flag logic is a simple if/else in `cmd_build`. No refactor n
 
 - [ ] **Step 6: Run broader verification**
 
-Run: `bash scripts/test/cloud-run-wrapper.test.sh` (e2e wrapper still works)
+Run: `bash scripts/test/cloud-run-dockerfile.test.sh` (Dockerfile tests, no gcloud interaction).
+
+Do NOT run `scripts/test/cloud-run-wrapper.test.sh` as a verification gate — its `--cloud` check uses real `gcloud` and can mutate/execute the live Cloud Run Job.
 
 Expected: PASS
 

--- a/docs/plans/2026-08-09-cloud-vitest-and-build.md
+++ b/docs/plans/2026-08-09-cloud-vitest-and-build.md
@@ -304,7 +304,7 @@ Create `scripts/vitest-cloud.sh` with:
   - `GCP_JOB="freshell-vitest"` (not `freshell-e2e`)
   - `FRESHELL_VITEST_BACKEND` env var (not `FRESHELL_E2E_BACKEND`)
   - Local mode: `npx vitest run --passWithNoTests --config <config>` for each config (not `npx playwright test`)
-  - Cloud mode: env-vars-file sets `TEST_MODE: "vitest"`, `VITEST_CONFIGS: "<configs>"`, and `VITEST_ARGS_JSON: "<json array>"`. The JSON array is built with: `printf '%s\n' "${pw_args[@]}" | jq -R . | jq -sc .`. Since the JSON array contains double quotes, write the env-vars file using a YAML-safe method: either single-quote the JSON value in YAML (`VITEST_ARGS_JSON: '<json>'`) or use `jq -Rs .` to produce a YAML-safe double-quoted string with proper escaping. The env-vars file must round-trip through `gcloud run jobs execute --env-vars-file` without corrupting JSON values.
+  - Cloud mode: env-vars-file sets `TEST_MODE: "vitest"`, `VITEST_CONFIGS: "<configs>"`, and `VITEST_ARGS_JSON: "<json array>"`. The JSON array is built with: `if [ ${#pw_args[@]} -eq 0 ]; then echo '[]'; else printf '%s\n' "${pw_args[@]}" | jq -R . | jq -sc .; fi`. Since the JSON array contains double quotes, write the env-vars file using a YAML-safe method: either single-quote the JSON value in YAML (`VITEST_ARGS_JSON: '<json>'`) or use `jq -Rs .` to produce a YAML-safe double-quoted string with proper escaping. The env-vars file must round-trip through `gcloud run jobs execute --env-vars-file` without corrupting JSON values.
   - `--config=default|server|all` flag controls which configs to run
   - Log summary greps for vitest output patterns (`Test Files`, `Tests`)
   - Default `--shards=4` (not 1)
@@ -358,7 +358,7 @@ git commit -m "feat: add vitest-cloud.sh wrapper for Cloud Run Jobs"
 - When `FRESHELL_VITEST_BACKEND=cloud`, `scripts/run-standard-tests.ts` dispatches client+server stages to `scripts/vitest-cloud.sh run`, then runs the electron stage locally
 - The dispatch happens at the top of `main()`, before any local test planning
 - The cloud dispatch runs only the client and server configs; the electron config always runs locally (it needs a display and native modules not available in the container)
-- Forwarded args are passed through to the cloud wrapper
+- Forwarded args are passed through to the cloud wrapper, **except** Git-dependent selectors like `--changed` — Vitest's `--changed` requires a `.git` directory, which is excluded from the Docker image. When `--changed` is detected in forwarded args, the cloud dispatch must fall back to local execution (log a warning and run locally)
 - The cloud wrapper script path is injectable via `FRESHELL_VITEST_CLOUD_SCRIPT` env var (default: `resolve(repoRoot, 'scripts/vitest-cloud.sh')`), so tests can substitute a fake without relying on PATH interception of an absolute-path exec
 - New npm scripts: `test:cloud`, `test:cloud:build`
 - AGENTS.md updated with cloud vitest instructions
@@ -375,7 +375,7 @@ git commit -m "feat: add vitest-cloud.sh wrapper for Cloud Run Jobs"
 
 **Test cases:**
 - `FRESHELL_VITEST_BACKEND=cloud` in `run-standard-tests.ts` → dispatches to `vitest-cloud.sh` for client+server, then runs electron locally
-- The dispatch is verifiable by injecting `FRESHELL_VITEST_CLOUD_SCRIPT` pointing to a fake script that logs its invocation and exits 0 — verify the fake was invoked (the log file exists and contains "run"), AND verify the local electron suite was also invoked. This proves both the cloud-dispatch branch and the local electron fallback execute.
+- The dispatch is verifiable by injecting `FRESHELL_VITEST_CLOUD_SCRIPT` pointing to a fake script that logs its invocation and exits 0 — verify the fake was invoked (the log file exists and contains "run"), AND verify the local electron suite was also invoked. This proves both the cloud-dispatch branch and the local electron fallback execute. Note: this tests `run-standard-tests.ts` directly, not the full `test-coordinator.ts` path (which adds pre-phases and `FRESHELL_TEST_COORDINATOR_ACTIVE`). The coordinator path is a thin wrapper around `run-standard-tests.ts` — testing `run-standard-tests.ts` is sufficient for the dispatch logic.
 - `FRESHELL_VITEST_BACKEND` unset → current behavior (all three suites locally)
 - `FRESHELL_VITEST_BACKEND=local` → current behavior (all three suites locally)
 - `npm run test:cloud` script exists and dispatches to `scripts/vitest-cloud.sh run`
@@ -487,7 +487,7 @@ git commit -m "feat: integrate cloud vitest with run-standard-tests.ts and npm s
   - BuildKit enabled (`DOCKER_BUILDKIT=1`) for `mode=max` registry caching, which preserves intermediate stage layers (rust-builder, node-builder) — not just the final image
   - `docker pull` of existing image for `--cache-from` layer caching
   - `docker buildx build -f docker/cloud-run/Dockerfile --cache-from type=registry,ref=<image>-cache --cache-to type=registry,ref=<image>-cache,mode=max -t <image> --push .`
-  - `images:` field for automatic push to Artifact Registry
+  - `--push` flag on `docker buildx build` for automatic push to Artifact Registry (no `images:` field — buildx --push handles the push directly)
   - `E2_HIGHCPU_32` machine type, 200GB disk
   - `timeout` at the **top level** (not under `options`), per the [Cloud Build schema](https://docs.cloud.google.com/build/docs/build-config-file-schema)
 - `.gcloudignore` excludes non-build files from Cloud Build source upload (same as `.dockerignore` plus `.worktrees/`)
@@ -529,7 +529,7 @@ git commit -m "feat: integrate cloud vitest with run-standard-tests.ts and npm s
 
 Create `scripts/test/cloud-build.test.sh` with:
 - Check 1: `docker/cloud-run/cloudbuild.yaml` exists
-- Check 2: `cloudbuild.yaml` is valid YAML (parse with `python3 -c "import yaml; yaml.safe_load(open('...'))"`)
+- Check 2: `cloudbuild.yaml` is valid YAML (parse with `node -e "const yaml = require('yaml'); yaml.parse(require('fs').readFileSync('...', 'utf8'))"`)
 - Check 3: `cloudbuild.yaml` contains `docker/cloud-run/Dockerfile`
 - Check 4: `cloudbuild.yaml` uses `buildx build` with `--push`
 - Check 5: `cloudbuild.yaml` contains `E2_HIGHCPU_32` under `options:`
@@ -557,7 +557,12 @@ Expected: FAIL because `cloudbuild.yaml` and `.gcloudignore` don't exist, and `-
 Create `docker/cloud-run/cloudbuild.yaml`:
 ```yaml
 steps:
-  # Pull existing image for layer caching (exit 0 if not found yet).
+  # Create a buildx builder that supports registry cache export.
+  # The default docker driver does not support --cache-to type=registry.
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: ['-c', 'docker buildx create --use --name cloud-builder --driver docker-container || docker buildx use cloud-builder']
+  # Pull existing cache image for layer caching (exit 0 if not found yet).
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
     args: ['-c', 'docker pull ${_IMAGE}-cache || exit 0']

--- a/docs/plans/2026-08-09-cloud-vitest-and-build.md
+++ b/docs/plans/2026-08-09-cloud-vitest-and-build.md
@@ -93,7 +93,7 @@ runtime is unprivileged. The server globalSetup writes to `/app/dist/server`
 - If any config fails, the exit code is non-zero (but both configs still run)
 - When `TEST_MODE` is unset or `playwright`, current behavior is unchanged
 - `.dockerignore` is updated to allow `AGENTS.md` and `docs/skills/testing.md` into the image (needed by `test/integration/server/test-coordinator.test.ts`)
-- The Dockerfile runtime stage switches to `USER node` (non-root) so that `claude-transcript-locator.test.ts` permission tests (lines 120, 134) behave correctly — `chmod 0o000` is not bypassed by root
+- The Dockerfile runtime stage switches to `USER node` (non-root) so that `claude-transcript-locator.test.ts` permission tests (lines 120, 134) behave correctly — `chmod 0o000` is not bypassed by root. Playwright browsers must be installed to a shared system path (`PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`) before the `USER node` switch, since the default `~/.cache/ms-playwright` would be root's home and inaccessible to the `node` user
 - The entrypoint accepts `VITEST_ARGS_JSON` env var for pass-through arguments (JSON array, parsed with `jq`), so the container smoke test can run a single fast test file without losing argument boundaries
 
 **Files:**
@@ -192,13 +192,19 @@ In `.dockerignore`, add after the `*.md` line:
 !docs/skills/testing.md
 ```
 
-In `docker/cloud-run/Dockerfile`, in the runtime stage (Stage 3), after the `COPY . .` line (line 120) and before the `ENV FRESHELL_E2E_RUST_SERVER_BIN` line, add ownership transfer and switch to non-root user:
+In `docker/cloud-run/Dockerfile`, in the runtime stage (Stage 3), after the `RUN chmod +x /usr/local/bin/e2e-entrypoint.sh` line (line 128) and before the `HEALTHCHECK` line, add ownership transfer and switch to non-root user. This must come AFTER the `COPY docker/cloud-run/entrypoint.sh /usr/local/bin/e2e-entrypoint.sh` and `RUN chmod +x` lines — those write to root-owned paths (`/usr/local/bin/`) and must run as root:
 
 ```dockerfile
+# Install Playwright browsers to a shared system path so the node user can
+# access them (default ~/.cache/ms-playwright would be root's home).
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN npx --yes playwright@1.58.2 install --with-deps chromium
+
 # Switch to non-root user for runtime (node:22-bookworm provides UID 1000).
 # This is required by server-side tests that verify permission errors
 # propagate (claude-transcript-locator.test.ts chmod 0o000 tests) — root
 # would bypass those mode bits.
+# Must be AFTER the entrypoint COPY+chmod (lines 127-128) which write to /usr/local/bin/.
 RUN chown -R node:node /app
 USER node
 ```
@@ -296,7 +302,7 @@ Create `scripts/vitest-cloud.sh` with:
   - `GCP_JOB="freshell-vitest"` (not `freshell-e2e`)
   - `FRESHELL_VITEST_BACKEND` env var (not `FRESHELL_E2E_BACKEND`)
   - Local mode: `npx vitest run --passWithNoTests --config <config>` for each config (not `npx playwright test`)
-  - Cloud mode: env-vars-file sets `TEST_MODE: "vitest"`, `VITEST_CONFIGS: "<configs>"`, and `VITEST_ARGS_JSON: "<json array>"`. The JSON array is built with: `jq -nc --args -- '{VITEST_ARGS_JSON: [$ARGS.positional]}' -- "${pw_args[@]}"` (or equivalent that produces valid JSON)
+  - Cloud mode: env-vars-file sets `TEST_MODE: "vitest"`, `VITEST_CONFIGS: "<configs>"`, and `VITEST_ARGS_JSON: "<json array>"`. The JSON array is built with: `printf '%s\n' "${pw_args[@]}" | jq -R . | jq -sc .` (produces a flat JSON array preserving argument boundaries; the `jq -nc --args` form nests the array and includes a literal `--`)
   - `--config=default|server|all` flag controls which configs to run
   - Log summary greps for vitest output patterns (`Test Files`, `Tests`)
   - Default `--shards=4` (not 1)
@@ -316,7 +322,7 @@ Review for duplication with `e2e-cloud.sh`. If `cmd_build` and `cmd_push` are id
 
 - [ ] **Step 6: Run broader verification**
 
-Run: `bash scripts/test/cloud-run-wrapper.test.sh` (existing e2e wrapper tests still pass)
+Run: `bash scripts/test/cloud-run-wrapper.test.sh` — **but only the local-mode checks**. The `--cloud` test cases in this script use real `gcloud` and can create/update/execute the live `freshell-e2e` Cloud Run Job. Run with a fake `gcloud` on PATH to ensure no real infrastructure is touched.
 
 Expected: PASS
 
@@ -476,7 +482,7 @@ git commit -m "feat: integrate cloud vitest with run-standard-tests.ts and npm s
 - `docker/cloud-run/cloudbuild.yaml` configures Google Cloud Build with:
   - BuildKit enabled (`DOCKER_BUILDKIT=1`) for `mode=max` registry caching, which preserves intermediate stage layers (rust-builder, node-builder) — not just the final image
   - `docker pull` of existing image for `--cache-from` layer caching
-  - `docker build -f docker/cloud-run/Dockerfile --cache-from type=registry,ref=<image>,mode=max -t <image> .`
+  - `docker build -f docker/cloud-run/Dockerfile --cache-from type=registry,ref=<image> --cache-to type=registry,ref=<image>,mode=max -t <image> .`
   - `images:` field for automatic push to Artifact Registry
   - `E2_HIGHCPU_32` machine type, 200GB disk
   - `timeout` at the **top level** (not under `options`), per the [Cloud Build schema](https://docs.cloud.google.com/build/docs/build-config-file-schema)
@@ -505,7 +511,7 @@ git commit -m "feat: integrate cloud vitest with run-standard-tests.ts and npm s
 - `cloudbuild.yaml` has `timeout` at top level (NOT under `options`)
 - `cloudbuild.yaml` uses substitutions (`${_IMAGE}`) not hard-coded image URLs
 - `cloudbuild.yaml` enables BuildKit (`DOCKER_BUILDKIT=1` env or `--build-arg BUILDKIT=1`)
-- `cloudbuild.yaml` uses `mode=max` in the cache-from reference (for intermediate layer preservation)
+- `cloudbuild.yaml` uses `mode=max` in the cache-to reference (for intermediate layer export); `cache-from` has no `mode` (import reads all available cache)
 - `.gcloudignore` exists and excludes `.git`, `node_modules`, `target`, `dist`, `.worktrees/`
 - `e2e-cloud.sh help` mentions `--local-build`
 - `vitest-cloud.sh help` mentions `--local-build`
@@ -526,7 +532,7 @@ Create `scripts/test/cloud-build.test.sh` with:
 - Check 6: `cloudbuild.yaml` contains `timeout` at top level (verify it's NOT nested under `options`)
 - Check 7: `cloudbuild.yaml` uses `${_IMAGE}` substitution (not a hard-coded URL)
 - Check 8: `cloudbuild.yaml` enables BuildKit (contains `DOCKER_BUILDKIT=1` or `BUILDKIT=1`)
-- Check 9: `cloudbuild.yaml` uses `mode=max` in cache-from reference
+- Check 9: `cloudbuild.yaml` uses `mode=max` in cache-to reference
 - Check 10: `.gcloudignore` exists
 - Check 11: `.gcloudignore` excludes `.git`, `node_modules`, `target`, `dist`, `.worktrees/`
 - Check 12: `e2e-cloud.sh help` contains `--local-build`
@@ -563,6 +569,8 @@ steps:
       - '-t'
       - '${_IMAGE}'
       - '--cache-from'
+      - 'type=registry,ref=${_IMAGE}'
+      - '--cache-to'
       - 'type=registry,ref=${_IMAGE},mode=max'
       - '.'
     env:
@@ -573,11 +581,11 @@ options:
   machineType: 'E2_HIGHCPU_32'
   diskSizeGb: 200
 timeout: '3600s'
-substitutions:
-  _IMAGE: 'us-west1-docker.pkg.dev/misc-puttering-project/freshell-e2e/freshell-e2e:latest'
 ```
 
-Create `.gcloudignore` (same exclusions as `.dockerignore` plus `.worktrees/`).
+Note: No `substitutions` block — the wrapper always passes `--substitutions=_IMAGE="$IMAGE_REMOTE"` on the `gcloud builds submit` command line, so the image URL is never hard-coded in the YAML.
+
+Create `.gcloudignore` (same exclusions as `.dockerignore` plus `.worktrees/`), including the same `!AGENTS.md` and `!docs/skills/testing.md` exceptions — Cloud Build source upload respects `.gcloudignore`, and without these exceptions the server Vitest suite would fail in the container.
 
 In `scripts/e2e-cloud.sh`, modify `cmd_build` to default to Cloud Build:
 - When `--local-build` is NOT set: run `gcloud builds submit --config "$ROOT/docker/cloud-run/cloudbuild.yaml" --account="$GCP_ACCOUNT" --project="$GCP_PROJECT" --substitutions=_IMAGE="$IMAGE_REMOTE" "$ROOT"`

--- a/docs/plans/2026-08-09-cloud-vitest-and-build.md
+++ b/docs/plans/2026-08-09-cloud-vitest-and-build.md
@@ -6,7 +6,7 @@
 
 **Goal:** Move Vitest unit/server test suites and Docker image builds to Google Cloud, reducing validation pipeline wall time from ~5 min to ~2 min.
 
-**Architecture:** The existing Docker image (built for Playwright e2e) already contains Node.js, all npm deps, the Rust server binary, and dist artifacts — everything Vitest needs. We add a `TEST_MODE=vitest` branch to the entrypoint that runs `npx vitest run --shard=I/N` for both default and server configs. A new `scripts/vitest-cloud.sh` wrapper (modeled on `scripts/e2e-cloud.sh`) dispatches to Cloud Run Jobs with `TEST_MODE=vitest`. `scripts/run-standard-tests.ts` gets an early-return dispatch when `FRESHELL_VITEST_BACKEND=cloud`. For Docker builds, a `cloudbuild.yaml` + `.gcloudignore` configures Google Cloud Build with layer caching, and both wrapper scripts gain a `--cloud-build` flag.
+**Architecture:** The existing Docker image (built for Playwright e2e) already contains Node.js, all npm deps, the Rust server binary, and dist artifacts — everything Vitest needs. We add a `TEST_MODE=vitest` branch to the entrypoint that runs `npx vitest run --shard=I/N` for both default and server configs. A new `scripts/vitest-cloud.sh` wrapper (modeled on `scripts/e2e-cloud.sh`) dispatches to Cloud Run Jobs with `TEST_MODE=vitest`. `scripts/run-standard-tests.ts` gets an early-return dispatch when `FRESHELL_VITEST_BACKEND=cloud` that runs only the client+server stages in the cloud, then runs the electron stage locally. For Docker builds, a `cloudbuild.yaml` + `.gcloudignore` configures Google Cloud Build with layer caching. Cloud Build is the **default** build path (the original request says "so the image builds in the cloud instead of locally"); `--local-build` opts back into local Docker.
 
 **Tech Stack:** Google Cloud Run Jobs, Google Cloud Build, Artifact Registry, Vitest `--shard`, bash, TypeScript
 
@@ -22,19 +22,22 @@
 - Cloud Run Job names: `freshell-e2e` (existing, e2e), `freshell-vitest` (new, vitest)
 - Docker image: `us-west1-docker.pkg.dev/misc-puttering-project/freshell-e2e/freshell-e2e:latest` (shared)
 - Existing test scripts live in `scripts/test/cloud-*.test.sh` and follow a bash integration-test pattern
+- `.dockerignore` currently excludes `docs/` and `*.md`. The server Vitest suite includes `test/integration/server/test-coordinator.test.ts` which reads `AGENTS.md` and `docs/skills/testing.md`. These files must be present in the Docker image.
+- The existing `scripts/run-standard-tests.ts` runs three suites: client (default config), server (server config), and electron (electron config). Cloud dispatch must not silently drop the electron stage.
+- The logs directory for this run is: `/home/dan/code/freshell/.worktrees/.the-usual-logs/cloud-vitest-and-build`
 
 ## Requirements
 
 - **R1 — Cloud Vitest:** Vitest default + server suites run on Cloud Run Jobs with 4-way sharding, completing in <3 min wall time
-- **R2 — Cloud Build:** Docker image builds on Google Cloud Build with layer caching, completing in <15 min cold / <5 min warm
+- **R2 — Cloud Build:** Docker image builds on Google Cloud Build (as the default build path, not opt-in), completing in <15 min cold / <5 min warm
 - **R3 — Backend selection:** `FRESHELL_VITEST_BACKEND` env var controls local vs cloud, mirroring the `FRESHELL_E2E_BACKEND` pattern; `--local`/`--cloud` flags override per-invocation
-- **R4 — Integration:** `npm test` / `npm run check` / `npm run verify` dispatch to cloud vitest when `FRESHELL_VITEST_BACKEND=cloud`
+- **R4 — Integration:** `npm test` / `npm run check` / `npm run verify` dispatch to cloud vitest when `FRESHELL_VITEST_BACKEND=cloud`, while preserving the electron stage locally
 - **R5 — Tests:** Full test coverage of new scripts, configs, and entrypoint changes, following the existing `scripts/test/cloud-*.test.sh` pattern
 - **R6 — Docs:** AGENTS.md updated with cloud vitest instructions
 
 ---
 
-### Task 1: Entrypoint vitest mode
+### Task 1: Entrypoint vitest mode + .dockerignore fix
 
 **Requirements served:** R1
 
@@ -44,13 +47,16 @@
 - Shard index comes from `CLOUD_RUN_TASK_INDEX` (0-based) and `CLOUD_RUN_TASK_COUNT`
 - If any config fails, the exit code is non-zero (but both configs still run)
 - When `TEST_MODE` is unset or `playwright`, current behavior is unchanged
+- `.dockerignore` is updated to allow `AGENTS.md` and `docs/skills/testing.md` into the image (needed by `test/integration/server/test-coordinator.test.ts`)
+- The entrypoint accepts `VITEST_ARGS` env var for pass-through arguments (e.g., specific test files), so the container smoke test can run a single fast test file
 
 **Files:**
 - Modify: `docker/cloud-run/entrypoint.sh` (add vitest branch at top, before playwright logic)
+- Modify: `.dockerignore` (add `!AGENTS.md` and `!docs/skills/testing.md` exceptions)
 - Test: `scripts/test/cloud-vitest-entrypoint.test.sh`
 
 **Interfaces:**
-- Consumes: `TEST_MODE` (env var, new), `CLOUD_RUN_TASK_INDEX` (existing), `CLOUD_RUN_TASK_COUNT` (existing), `VITEST_CONFIGS` (env var, new — space-separated list of config paths, default: `"config/vitest/vitest.config.ts config/vitest/vitest.server.config.ts"`)
+- Consumes: `TEST_MODE` (env var, new), `CLOUD_RUN_TASK_INDEX` (existing), `CLOUD_RUN_TASK_COUNT` (existing), `VITEST_CONFIGS` (env var, new — space-separated list of config paths, default: `"config/vitest/vitest.config.ts config/vitest/vitest.server.config.ts"`), `VITEST_ARGS` (env var, new — space-separated extra args passed to vitest, e.g., a test file path)
 - Produces: Vitest test output on stdout/stderr, exit code 0 (all pass) or 1 (any fail)
 
 **Test cases:**
@@ -59,6 +65,12 @@
 - Entrypoint with `TEST_MODE=vitest` and `CLOUD_RUN_TASK_COUNT=1` → runs `npx vitest run` for both configs (no `--shard` flag)
 - Entrypoint with `TEST_MODE=vitest` and `CLOUD_RUN_TASK_COUNT=2` → runs `npx vitest run --shard=1/2` and `--shard=2/2` for both configs
 - `VITEST_CONFIGS` env var limits which configs run (e.g., only default config)
+- `VITEST_ARGS` env var passes extra args to vitest (e.g., a specific test file)
+- `.dockerignore` has `!AGENTS.md` exception
+- `.dockerignore` has `!docs/skills/testing.md` exception
+- Docker build succeeds with the modified entrypoint and .dockerignore (if Docker is available)
+- Running the entrypoint in a container with `TEST_MODE=vitest CLOUD_RUN_TASK_COUNT=1 VITEST_CONFIGS="config/vitest/vitest.config.ts" VITEST_ARGS="test/unit/lib/pane-utils.test.ts"` produces vitest output with passing tests (skip if Docker unavailable)
+- Multi-shard correctness: `CLOUD_RUN_TASK_COUNT=2` with `VITEST_ARGS` pointing to two test files — shard 1 runs one file, shard 2 runs the other (verify disjoint file sets by checking output contains different test file names)
 
 - [ ] **Step 1: Write the failing behavioral test**
 
@@ -67,15 +79,19 @@ Create `scripts/test/cloud-vitest-entrypoint.test.sh` with:
 - Check 2: entrypoint.sh contains `vitest` reference
 - Check 3: entrypoint.sh contains `--shard` reference
 - Check 4: entrypoint.sh references `VITEST_CONFIGS`
-- Check 5: When `TEST_MODE` is unset, entrypoint still references playwright (unchanged behavior)
-- Check 6: Docker build succeeds with the modified entrypoint (if Docker is available)
-- Check 7: Running the entrypoint in a container with `TEST_MODE=vitest CLOUD_RUN_TASK_COUNT=1 VITEST_CONFIGS="config/vitest/vitest.config.ts"` and a single fast test file produces vitest output (skip if Docker unavailable)
+- Check 5: entrypoint.sh references `VITEST_ARGS`
+- Check 6: When `TEST_MODE` is unset, entrypoint still references playwright (unchanged behavior)
+- Check 7: `.dockerignore` contains `!AGENTS.md`
+- Check 8: `.dockerignore` contains `!docs/skills/testing.md`
+- Check 9: Docker build succeeds with the modified entrypoint (if Docker is available)
+- Check 10: Running the entrypoint in a container with `TEST_MODE=vitest CLOUD_RUN_TASK_COUNT=1 VITEST_CONFIGS="config/vitest/vitest.config.ts" VITEST_ARGS="test/unit/lib/pane-utils.test.ts"` produces vitest output with passing tests (skip if Docker unavailable)
+- Check 11: Multi-shard test — run two shards (`CLOUD_RUN_TASK_COUNT=2`, `CLOUD_RUN_TASK_INDEX=0` and `=1`) with `VITEST_ARGS="test/unit/lib/pane-utils.test.ts test/unit/lib/pane-snap-2d.test.ts"`, verify each shard runs a disjoint set of test files (skip if Docker unavailable)
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
 Run: `bash scripts/test/cloud-vitest-entrypoint.test.sh`
 
-Expected: FAIL because `entrypoint.sh` does not contain `TEST_MODE` or `vitest` references
+Expected: FAIL because `entrypoint.sh` does not contain `TEST_MODE` or `vitest` references, and `.dockerignore` lacks the `!AGENTS.md` / `!docs/skills/testing.md` exceptions
 
 - [ ] **Step 3: Add the minimal production implementation**
 
@@ -87,17 +103,25 @@ if [ "${TEST_MODE:-}" = "vitest" ]; then
   SHARD_INDEX=$((TASK_INDEX + 1))
   SHARD_COUNT="$TASK_COUNT"
   CONFIGS="${VITEST_CONFIGS:-config/vitest/vitest.config.ts config/vitest/vitest.server.config.ts}"
+  EXTRA_ARGS="${VITEST_ARGS:-}"
   SHARD_ARG=""
   if [ "$SHARD_COUNT" -gt 1 ]; then
     SHARD_ARG="--shard=${SHARD_INDEX}/${SHARD_COUNT}"
   fi
   EXIT_CODE=0
   for config in $CONFIGS; do
-    echo "[e2e-entrypoint] Running vitest: $config $SHARD_ARG"
-    npx vitest run --config "$config" $SHARD_ARG || EXIT_CODE=$?
+    echo "[vitest-entrypoint] Running vitest: $config $SHARD_ARG $EXTRA_ARGS"
+    npx vitest run --config "$config" $SHARD_ARG $EXTRA_ARGS || EXIT_CODE=$?
   done
   exit "$EXIT_CODE"
 fi
+```
+
+In `.dockerignore`, add after the `*.md` line:
+```
+# Exception: files needed by server-side tests
+!AGENTS.md
+!docs/skills/testing.md
 ```
 
 - [ ] **Step 4: Run the focused test**
@@ -119,8 +143,8 @@ Expected: PASS
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add docker/cloud-run/entrypoint.sh scripts/test/cloud-vitest-entrypoint.test.sh
-git commit -m "feat: add TEST_MODE=vitest to cloud-run entrypoint"
+git add docker/cloud-run/entrypoint.sh .dockerignore scripts/test/cloud-vitest-entrypoint.test.sh
+git commit -m "feat: add TEST_MODE=vitest to cloud-run entrypoint and fix .dockerignore for server tests"
 ```
 
 ---
@@ -136,13 +160,14 @@ git commit -m "feat: add TEST_MODE=vitest to cloud-run entrypoint"
 - `--shards=N` (default 4), `--timeout=DURATION` (default 30m), `--build` (force rebuild)
 - `--config=default|server|all` selects which vitest configs to run (default: all)
 - Cloud Run Job name: `freshell-vitest`
-- Sets `TEST_MODE=vitest` and `VITEST_CONFIGS` env vars on the Cloud Run Job
-- `--cloud-build` flag uses Google Cloud Build instead of local Docker build (implemented in Task 4)
+- Sets `TEST_MODE=vitest`, `VITEST_CONFIGS`, and `VITEST_ARGS` env vars on the Cloud Run Job
 - Local mode runs `npx vitest run` for both configs directly
 - `build`/`push` subcommands are identical to `e2e-cloud.sh` (same Docker image)
+- Cloud tests must NOT create or update the live Cloud Run Job — tests use a fake `gcloud` on PATH to verify the intended command without touching real infrastructure
+- The script file must be created with executable bit (`chmod +x`)
 
 **Files:**
-- Create: `scripts/vitest-cloud.sh`
+- Create: `scripts/vitest-cloud.sh` (must be `chmod +x` and committed as mode `100755`)
 - Test: `scripts/test/cloud-vitest-wrapper.test.sh`
 
 **Interfaces:**
@@ -150,26 +175,29 @@ git commit -m "feat: add TEST_MODE=vitest to cloud-run entrypoint"
 - Produces: Cloud Run Job execution with `TEST_MODE=vitest` env var, exit code from vitest
 
 **Test cases:**
-- Script exists and is executable
+- Script exists and is executable (verify with `test -x`)
+- Script has mode `100755` in git (verify with `git ls-files -s scripts/vitest-cloud.sh`)
 - `help` subcommand shows usage, mentions `--local`, `--cloud`, `FRESHELL_VITEST_BACKEND`, `--shards`, `--config`
 - `--local` flag runs vitest locally (run a single fast test file to verify)
 - Default backend (unset env var) runs locally
 - `FRESHELL_VITEST_BACKEND=local` runs locally
-- `--cloud` flag overrides `FRESHELL_VITEST_BACKEND=local` (does not print "Running locally")
-- `npm run test:cloud -- --local` works (if npm script is added in Task 3)
+- `--cloud` flag with a fake `gcloud` on PATH: verify the wrapper invokes `gcloud run jobs execute` with the correct job name (`freshell-vitest`) and env vars (`TEST_MODE=vitest`, `VITEST_CONFIGS`), without touching real infrastructure
+- `--config=default` sets `VITEST_CONFIGS` to only the default config
+- `--config=server` sets `VITEST_CONFIGS` to only the server config
 - Existing `e2e-cloud.sh` tests still pass (no regression)
 
 - [ ] **Step 1: Write the failing behavioral test**
 
 Create `scripts/test/cloud-vitest-wrapper.test.sh` with:
-- Check 1: Script exists and is executable
-- Check 2: `help` contains "usage", "run", "--local", "--cloud", "FRESHELL_VITEST_BACKEND", "--shards", "--config"
-- Check 3: `--local` runs a single fast test file locally (e.g., `test/unit/lib/env.test.ts` or similar small test)
-- Check 4: Default backend (unset env var) runs locally
-- Check 5: `FRESHELL_VITEST_BACKEND=local` runs locally
-- Check 6: `--cloud` flag does not print "Running locally"
-- Check 7: `--config=default` only runs the default vitest config
-- Check 8: `--config=server` only runs the server vitest config
+- Check 1: Script exists and is executable (`test -x`)
+- Check 2: `git ls-files -s scripts/vitest-cloud.sh` shows mode `100755`
+- Check 3: `help` contains "usage", "run", "--local", "--cloud", "FRESHELL_VITEST_BACKEND", "--shards", "--config"
+- Check 4: `--local` runs a single fast test file locally (e.g., `--local test/unit/lib/pane-utils.test.ts`)
+- Check 5: Default backend (unset env var) runs locally
+- Check 6: `FRESHELL_VITEST_BACKEND=local` runs locally
+- Check 7: `--cloud` flag with fake `gcloud` — create a temporary script that logs its args and exits 0, put it on PATH, verify the wrapper calls `gcloud run jobs execute` with `freshell-vitest` and sets `TEST_MODE=vitest` in the env-vars-file. Assert the fake gcloud was called (positive assertion), not just that "Running locally" is absent.
+- Check 8: `--config=default` sets `VITEST_CONFIGS` to only `config/vitest/vitest.config.ts` (verify via fake gcloud capturing the env-vars-file content)
+- Check 9: `--config=server` sets `VITEST_CONFIGS` to only `config/vitest/vitest.server.config.ts` (verify via fake gcloud)
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -185,12 +213,14 @@ Create `scripts/vitest-cloud.sh` with:
   - `GCP_JOB="freshell-vitest"` (not `freshell-e2e`)
   - `FRESHELL_VITEST_BACKEND` env var (not `FRESHELL_E2E_BACKEND`)
   - Local mode: `npx vitest run --config <config>` for each config (not `npx playwright test`)
-  - Cloud mode: env-vars-file sets `TEST_MODE: "vitest"` and `VITEST_CONFIGS: "<configs>"`
+  - Cloud mode: env-vars-file sets `TEST_MODE: "vitest"`, `VITEST_CONFIGS: "<configs>"`, and `VITEST_ARGS: "<extra args>"`
   - `--config=default|server|all` flag controls which configs to run
   - Log summary greps for vitest output patterns (`Test Files`, `Tests`)
   - Default `--shards=4` (not 1)
   - Default `--timeout=30m` (not 60m)
-  - `--cloud-build` flag (stubbed — full implementation in Task 4)
+  - Non-positional args (not recognized as config selectors) are forwarded as `VITEST_ARGS`
+- After creating the file: `chmod +x scripts/vitest-cloud.sh`
+- Verify: `git ls-files -s scripts/vitest-cloud.sh` shows `100755` (use `git update-index --chmod=+x` if needed)
 
 - [ ] **Step 4: Run the focused test**
 
@@ -222,8 +252,9 @@ git commit -m "feat: add vitest-cloud.sh wrapper for Cloud Run Jobs"
 **Requirements served:** R3, R4, R6
 
 **Behavior:**
-- When `FRESHELL_VITEST_BACKEND=cloud`, `scripts/run-standard-tests.ts` dispatches to `scripts/vitest-cloud.sh run` instead of running vitest locally
+- When `FRESHELL_VITEST_BACKEND=cloud`, `scripts/run-standard-tests.ts` dispatches client+server stages to `scripts/vitest-cloud.sh run`, then runs the electron stage locally
 - The dispatch happens at the top of `main()`, before any local test planning
+- The cloud dispatch runs only the client and server configs; the electron config always runs locally (it needs a display and native modules not available in the container)
 - Forwarded args are passed through to the cloud wrapper
 - New npm scripts: `test:cloud`, `test:cloud:build`
 - AGENTS.md updated with cloud vitest instructions
@@ -236,15 +267,16 @@ git commit -m "feat: add vitest-cloud.sh wrapper for Cloud Run Jobs"
 
 **Interfaces:**
 - Consumes: `FRESHELL_VITEST_BACKEND` env var
-- Produces: Exit code from `scripts/vitest-cloud.sh run`
+- Produces: Exit code from `scripts/vitest-cloud.sh run` (for client+server) then local vitest exit code (for electron)
 
 **Test cases:**
-- `FRESHELL_VITEST_BACKEND=cloud` in `run-standard-tests.ts` → dispatches to `vitest-cloud.sh` (verify by checking that `vitest-cloud.sh run` is invoked)
-- `FRESHELL_VITEST_BACKEND` unset → current behavior (local vitest)
-- `FRESHELL_VITEST_BACKEND=local` → current behavior (local vitest)
+- `FRESHELL_VITEST_BACKEND=cloud` in `run-standard-tests.ts` → dispatches to `vitest-cloud.sh` for client+server, then runs electron locally (verify by injecting a fake `vitest-cloud.sh` that logs its invocation and exits 0, and checking that both the fake and the local electron run were invoked)
+- `FRESHELL_VITEST_BACKEND` unset → current behavior (all three suites locally)
+- `FRESHELL_VITEST_BACKEND=local` → current behavior (all three suites locally)
 - `npm run test:cloud` script exists and dispatches to `scripts/vitest-cloud.sh run`
 - `npm run test:cloud:build` script exists and dispatches to `scripts/vitest-cloud.sh build`
-- `npm run test:cloud -- --local` works (runs locally)
+- `AGENTS.md` mentions `FRESHELL_VITEST_BACKEND`
+- `FRESHELL_VITEST_BACKEND=local npx tsx scripts/run-standard-tests.ts --mode desktop` still runs all three suites locally (no regression)
 
 - [ ] **Step 1: Write the failing behavioral test**
 
@@ -253,9 +285,9 @@ Create `scripts/test/cloud-vitest-integration.test.sh` with:
 - Check 2: `scripts/run-standard-tests.ts` contains `vitest-cloud.sh` reference
 - Check 3: `package.json` contains `test:cloud` script
 - Check 4: `package.json` contains `test:cloud:build` script
-- Check 5: `npm run test:cloud -- --local` runs a fast test locally
-- Check 6: `AGENTS.md` mentions `FRESHELL_VITEST_BACKEND`
-- Check 7: `FRESHELL_VITEST_BACKEND=local npx tsx scripts/run-standard-tests.ts --mode desktop` still runs locally (no regression)
+- Check 5: `AGENTS.md` mentions `FRESHELL_VITEST_BACKEND`
+- Check 6: Process-level test — create a temporary fake `vitest-cloud.sh` that logs its args to a temp file and exits 0. Set `FRESHELL_VITEST_BACKEND=cloud` and run `npx tsx scripts/run-standard-tests.ts --mode desktop` with the fake on PATH. Verify the fake was invoked (the temp file exists and contains "run"). This proves the cloud-dispatch branch actually executes, not just that the string exists in source.
+- Check 7: `FRESHELL_VITEST_BACKEND=local npx tsx scripts/run-standard-tests.ts --mode desktop` still runs locally (no regression — verify it does NOT invoke vitest-cloud.sh)
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -271,12 +303,34 @@ In `scripts/run-standard-tests.ts`, add at the top of `main()`:
 if (process.env.FRESHELL_VITEST_BACKEND === 'cloud') {
   const { execFileSync } = await import('node:child_process')
   const cloudScript = resolve(repoRoot, 'scripts/vitest-cloud.sh')
+
+  // Run client + server suites in the cloud.
   try {
-    execFileSync(cloudScript, ['run', ...argv], { stdio: 'inherit', cwd: repoRoot })
-    process.exit(0)
+    execFileSync(cloudScript, ['run', ...forwardedArgs], { stdio: 'inherit', cwd: repoRoot })
   } catch {
-    process.exit(1)
+    process.exitCode = 1
+    return 1
   }
+
+  // Run the electron suite locally (needs a display + native modules).
+  const electronArgs = buildVitestArgs({
+    configPath: electronVitestConfig,
+    forwardedArgs,
+  })
+  log('info', 'Running electron suite locally after cloud dispatch', {
+    args: electronArgs,
+  })
+  try {
+    execFileSync(process.execPath, [vitestEntrypoint, ...electronArgs], {
+      stdio: 'inherit',
+      cwd: repoRoot,
+      env: process.env,
+    })
+  } catch {
+    process.exitCode = 1
+    return 1
+  }
+  return 0
 }
 ```
 
@@ -286,7 +340,11 @@ In `package.json`, add:
 "test:cloud:build": "bash scripts/vitest-cloud.sh build",
 ```
 
-In `AGENTS.md`, add a section under Testing explaining `FRESHELL_VITEST_BACKEND` (similar to `FRESHELL_E2E_BACKEND`).
+In `AGENTS.md`, add a section under Testing explaining `FRESHELL_VITEST_BACKEND` (similar to `FRESHELL_E2E_BACKEND`). Include:
+- Unset or `"local"` = local (safe default)
+- `"cloud"` = Cloud Run Jobs with 4-way sharding
+- Electron suite always runs locally even in cloud mode
+- Set permanently in `~/.bashrc` to avoid repeated prompts
 
 - [ ] **Step 4: Run the focused test**
 
@@ -313,7 +371,7 @@ git commit -m "feat: integrate cloud vitest with run-standard-tests.ts and npm s
 
 ---
 
-### Task 4: Cloud Build config and --cloud-build flag
+### Task 4: Cloud Build config and --local-build flag
 
 **Requirements served:** R2
 
@@ -322,33 +380,37 @@ git commit -m "feat: integrate cloud vitest with run-standard-tests.ts and npm s
   - `docker pull` of existing image for `--cache-from` layer caching
   - `docker build -f docker/cloud-run/Dockerfile --cache-from <image> -t <image> .`
   - `images:` field for automatic push to Artifact Registry
-  - `E2_HIGHCPU_32` machine type, 200GB disk, 1h timeout
-- `.gcloudignore` excludes non-build files from Cloud Build source upload
-- Both `scripts/e2e-cloud.sh` and `scripts/vitest-cloud.sh` gain a `--cloud-build` flag on their `build` subcommand
-- When `--cloud-build` is set, `cmd_build` uses `gcloud builds submit --config docker/cloud-run/cloudbuild.yaml .` instead of local `docker build`
-- Without `--cloud-build`, `cmd_build` uses local Docker (current behavior)
+  - `E2_HIGHCPU_32` machine type, 200GB disk
+  - `timeout` at the **top level** (not under `options`), per the [Cloud Build schema](https://docs.cloud.google.com/build/docs/build-config-file-schema)
+- `.gcloudignore` excludes non-build files from Cloud Build source upload (same as `.dockerignore` plus `.worktrees/`)
+- Both `scripts/e2e-cloud.sh` and `scripts/vitest-cloud.sh` use Cloud Build as the **default** build path (the original request says "so the image builds in the cloud instead of locally")
+- `--local-build` flag on `cmd_build` opts back into local Docker
+- The `gcloud builds submit` command includes `--account`, `--project`, and the image URL is passed as a substitution derived from the wrapper's resolved settings (not hard-coded)
+- Tests use a fake `gcloud` to verify the intended command without submitting a real build
 
 **Files:**
 - Create: `docker/cloud-run/cloudbuild.yaml`
 - Create: `.gcloudignore`
-- Modify: `scripts/e2e-cloud.sh` (add `--cloud-build` flag to `cmd_build`)
-- Modify: `scripts/vitest-cloud.sh` (add `--cloud-build` flag to `cmd_build`)
+- Modify: `scripts/e2e-cloud.sh` (change `cmd_build` to default to Cloud Build, add `--local-build` flag for local Docker)
+- Modify: `scripts/vitest-cloud.sh` (same `cmd_build` change)
 - Test: `scripts/test/cloud-build.test.sh`
 
 **Interfaces:**
-- Consumes: `cloudbuild.yaml`, `.gcloudignore`, `--cloud-build` flag
+- Consumes: `cloudbuild.yaml`, `.gcloudignore`, `--local-build` flag (new), GCP coordinates from wrapper env vars
 - Produces: Docker image in Artifact Registry (built by Cloud Build)
 
 **Test cases:**
 - `docker/cloud-run/cloudbuild.yaml` exists and is valid YAML
 - `cloudbuild.yaml` references the correct Dockerfile path (`docker/cloud-run/Dockerfile`)
-- `cloudbuild.yaml` references the correct image URL
-- `cloudbuild.yaml` uses `E2_HIGHCPU_32` machine type
-- `.gcloudignore` exists and excludes `.git`, `node_modules`, `target`, `dist`
-- `e2e-cloud.sh help` mentions `--cloud-build`
-- `vitest-cloud.sh help` mentions `--cloud-build`
-- `e2e-cloud.sh build --cloud-build` would invoke `gcloud builds submit` (verify by checking output contains "gcloud builds" when run with `--cloud-build`, without actually submitting)
-- `e2e-cloud.sh build` (without `--cloud-build`) still uses local Docker
+- `cloudbuild.yaml` contains `images:` field
+- `cloudbuild.yaml` uses `E2_HIGHCPU_32` machine type (under `options`)
+- `cloudbuild.yaml` has `timeout` at top level (NOT under `options`)
+- `cloudbuild.yaml` uses substitutions (`${_IMAGE}`) not hard-coded image URLs
+- `.gcloudignore` exists and excludes `.git`, `node_modules`, `target`, `dist`, `.worktrees/`
+- `e2e-cloud.sh help` mentions `--local-build`
+- `vitest-cloud.sh help` mentions `--local-build`
+- `e2e-cloud.sh build` (default, no flag) with a fake `gcloud` on PATH: verify the wrapper invokes `gcloud builds submit` with `--account`, `--project`, and `--config docker/cloud-run/cloudbuild.yaml`. Positive assertion on the command, not just absence of local Docker output.
+- `e2e-cloud.sh build --local-build` with a fake `docker` on PATH: verify the wrapper invokes `docker build` (local path still works)
 
 - [ ] **Step 1: Write the failing behavioral test**
 
@@ -356,19 +418,22 @@ Create `scripts/test/cloud-build.test.sh` with:
 - Check 1: `docker/cloud-run/cloudbuild.yaml` exists
 - Check 2: `cloudbuild.yaml` is valid YAML (parse with `python3 -c "import yaml; yaml.safe_load(open('...'))"`)
 - Check 3: `cloudbuild.yaml` contains `docker/cloud-run/Dockerfile`
-- Check 4: `cloudbuild.yaml` contains the Artifact Registry image URL
-- Check 5: `cloudbuild.yaml` contains `E2_HIGHCPU_32`
-- Check 6: `.gcloudignore` exists
-- Check 7: `.gcloudignore` excludes `.git`, `node_modules`, `target`, `dist`
-- Check 8: `e2e-cloud.sh help` contains `--cloud-build`
-- Check 9: `vitest-cloud.sh help` contains `--cloud-build`
-- Check 10: `e2e-cloud.sh build --cloud-build --dry-run` outputs "gcloud builds" (dry-run flag prevents actual submission)
+- Check 4: `cloudbuild.yaml` contains `images:`
+- Check 5: `cloudbuild.yaml` contains `E2_HIGHCPU_32` under `options:`
+- Check 6: `cloudbuild.yaml` contains `timeout` at top level (verify it's NOT nested under `options`)
+- Check 7: `cloudbuild.yaml` uses `${_IMAGE}` substitution (not a hard-coded URL)
+- Check 8: `.gcloudignore` exists
+- Check 9: `.gcloudignore` excludes `.git`, `node_modules`, `target`, `dist`, `.worktrees/`
+- Check 10: `e2e-cloud.sh help` contains `--local-build`
+- Check 11: `vitest-cloud.sh help` contains `--local-build`
+- Check 12: `e2e-cloud.sh build` (default) with fake `gcloud` — create a temp script that logs args and exits 0, put it on PATH. Run `e2e-cloud.sh build`. Verify the fake gcloud was called with `builds submit` and `--config` containing `cloudbuild.yaml`. Also verify `--account` and `--project` are present.
+- Check 13: `e2e-cloud.sh build --local-build` with fake `docker` — create a temp script that logs args and exits 0. Run `e2e-cloud.sh build --local-build`. Verify the fake docker was called with `build`.
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
 Run: `bash scripts/test/cloud-build.test.sh`
 
-Expected: FAIL because `cloudbuild.yaml` and `.gcloudignore` don't exist, and `--cloud-build` flag isn't implemented
+Expected: FAIL because `cloudbuild.yaml` and `.gcloudignore` don't exist, and `--local-build` flag isn't implemented
 
 - [ ] **Step 3: Add the minimal production implementation**
 
@@ -393,14 +458,16 @@ images:
 options:
   machineType: 'E2_HIGHCPU_32'
   diskSizeGb: 200
-  timeout: '3600s'
+timeout: '3600s'
 substitutions:
   _IMAGE: 'us-west1-docker.pkg.dev/misc-puttering-project/freshell-e2e/freshell-e2e:latest'
 ```
 
 Create `.gcloudignore` (same exclusions as `.dockerignore` plus `.worktrees/`).
 
-In `scripts/e2e-cloud.sh`, modify `cmd_build` to accept `--cloud-build` flag. When set, use `gcloud builds submit --config docker/cloud-run/cloudbuild.yaml .` instead of local `docker build`.
+In `scripts/e2e-cloud.sh`, modify `cmd_build` to default to Cloud Build:
+- When `--local-build` is NOT set: run `gcloud builds submit --config "$ROOT/docker/cloud-run/cloudbuild.yaml" --account="$GCP_ACCOUNT" --project="$GCP_PROJECT" --substitutions=_IMAGE="$IMAGE_REMOTE" "$ROOT"`
+- When `--local-build` IS set: run the existing local `docker build` + `cmd_push` path
 
 In `scripts/vitest-cloud.sh`, same modification to `cmd_build`.
 
@@ -412,7 +479,7 @@ Expected: PASS
 
 - [ ] **Step 5: Refactor while green**
 
-The `--cloud-build` flag logic is a simple if/else in `cmd_build`. No refactor needed.
+The `--local-build` flag logic is a simple if/else in `cmd_build`. No refactor needed.
 
 - [ ] **Step 6: Run broader verification**
 
@@ -424,7 +491,7 @@ Expected: PASS
 
 ```bash
 git add docker/cloud-run/cloudbuild.yaml .gcloudignore scripts/e2e-cloud.sh scripts/vitest-cloud.sh scripts/test/cloud-build.test.sh
-git commit -m "feat: add Cloud Build config and --cloud-build flag"
+git commit -m "feat: add Cloud Build config and make cloud build the default"
 ```
 
 ---
@@ -434,50 +501,37 @@ git commit -m "feat: add Cloud Build config and --cloud-build flag"
 **Requirements served:** R1, R2, R3
 
 **Behavior:**
-- Run cloud vitest on Cloud Run Jobs and verify all tests pass
-- Run cloud build on Google Cloud Build and verify the image builds successfully
+- Build the Docker image via Cloud Build first, then run cloud vitest against that image
+- Verify all tests pass
 - Record actual timings and cost estimates
 
 **Files:**
 - No new files (validation task)
-- Record results in `<logs-dir>/reports/cloud-validation.md`
+- Record results in `/home/dan/code/freshell/.worktrees/.the-usual-logs/cloud-vitest-and-build/reports/cloud-validation.md`
 
 **Test cases:**
-- `scripts/vitest-cloud.sh run --cloud --shards=4` → all vitest tests pass (4/4 tasks succeeded)
-- `scripts/e2e-cloud.sh build --cloud-build` → Docker image builds and pushes successfully
+- `scripts/e2e-cloud.sh build` (Cloud Build default) → Docker image builds and pushes to Artifact Registry
+- `scripts/vitest-cloud.sh run --cloud --shards=4` → all vitest tests pass (4/4 tasks succeeded), running against the image built by Cloud Build
 - Cloud vitest wall time < 3 min
 - Cloud build wall time < 15 min (cold) or < 5 min (warm)
 
-- [ ] **Step 1: Build and push the Docker image (if needed)**
+- [ ] **Step 1: Build the Docker image via Cloud Build**
 
 Run: `scripts/e2e-cloud.sh build`
 
-Expected: Docker image builds and pushes to Artifact Registry
+Expected: Cloud Build succeeds, image pushed to Artifact Registry
 
-- [ ] **Step 2: Run cloud vitest**
+- [ ] **Step 2: Run cloud vitest against the Cloud-Built image**
 
 Run: `scripts/vitest-cloud.sh run --cloud --shards=4 --timeout=30m`
 
 Expected: All 4 tasks succeed, vitest tests pass
 
-- [ ] **Step 3: Run cloud build**
+- [ ] **Step 3: Record results**
 
-Run: `scripts/e2e-cloud.sh build --cloud-build`
-
-Expected: Cloud Build succeeds, image pushed to Artifact Registry
-
-- [ ] **Step 4: Record results**
-
-Write results to `<logs-dir>/reports/cloud-validation.md` with:
+Write results to `/home/dan/code/freshell/.worktrees/.the-usual-logs/cloud-vitest-and-build/reports/cloud-validation.md` with:
 - Cloud vitest: shard count, wall time, per-shard test counts, cost estimate
 - Cloud build: wall time, cache hit/miss, cost estimate
 - Any issues encountered
 
-- [ ] **Step 5: Commit the validation report**
-
-```bash
-git add <logs-dir>/reports/cloud-validation.md
-git commit -m "docs: cloud vitest and cloud build validation results"
-```
-
-Note: The validation report is in the logs directory (outside the worktree), so this commit may not be needed. If so, skip the commit.
+Note: The validation report is an external artifact in the logs directory (outside the worktree). Do not attempt to `git add` it.

--- a/docs/plans/2026-08-09-cloud-vitest-and-build.md
+++ b/docs/plans/2026-08-09-cloud-vitest-and-build.md
@@ -1,0 +1,483 @@
+# Cloud Vitest + Cloud Build Implementation Plan
+
+> **For agentic workers:** Execute this plan task by task with a fresh
+> implementer and a specification-plus-quality review after every task. Track
+> progress with the checkbox steps below.
+
+**Goal:** Move Vitest unit/server test suites and Docker image builds to Google Cloud, reducing validation pipeline wall time from ~5 min to ~2 min.
+
+**Architecture:** The existing Docker image (built for Playwright e2e) already contains Node.js, all npm deps, the Rust server binary, and dist artifacts — everything Vitest needs. We add a `TEST_MODE=vitest` branch to the entrypoint that runs `npx vitest run --shard=I/N` for both default and server configs. A new `scripts/vitest-cloud.sh` wrapper (modeled on `scripts/e2e-cloud.sh`) dispatches to Cloud Run Jobs with `TEST_MODE=vitest`. `scripts/run-standard-tests.ts` gets an early-return dispatch when `FRESHELL_VITEST_BACKEND=cloud`. For Docker builds, a `cloudbuild.yaml` + `.gcloudignore` configures Google Cloud Build with layer caching, and both wrapper scripts gain a `--cloud-build` flag.
+
+**Tech Stack:** Google Cloud Run Jobs, Google Cloud Build, Artifact Registry, Vitest `--shard`, bash, TypeScript
+
+## Global Constraints
+
+- Server uses NodeNext/ESM; relative imports must include `.js` extensions
+- Never use broad kill patterns (`pkill -f ...`)
+- The self-hosted Freshell server (port 3001) must never be restarted without explicit "APPROVED"
+- Docker image is shared between e2e and vitest — changes to the Dockerfile affect both
+- `FRESHELL_VITEST_BACKEND` env var: unset or `"local"` = local (safe default), `"cloud"` = Cloud Run Jobs
+- `FRESHELL_E2E_BACKEND` env var: already exists for e2e; separate from vitest backend
+- GCP coordinates: account `dan@danshapiro.com`, project `misc-puttering-project`, region `us-west1`, repo `freshell-e2e`
+- Cloud Run Job names: `freshell-e2e` (existing, e2e), `freshell-vitest` (new, vitest)
+- Docker image: `us-west1-docker.pkg.dev/misc-puttering-project/freshell-e2e/freshell-e2e:latest` (shared)
+- Existing test scripts live in `scripts/test/cloud-*.test.sh` and follow a bash integration-test pattern
+
+## Requirements
+
+- **R1 — Cloud Vitest:** Vitest default + server suites run on Cloud Run Jobs with 4-way sharding, completing in <3 min wall time
+- **R2 — Cloud Build:** Docker image builds on Google Cloud Build with layer caching, completing in <15 min cold / <5 min warm
+- **R3 — Backend selection:** `FRESHELL_VITEST_BACKEND` env var controls local vs cloud, mirroring the `FRESHELL_E2E_BACKEND` pattern; `--local`/`--cloud` flags override per-invocation
+- **R4 — Integration:** `npm test` / `npm run check` / `npm run verify` dispatch to cloud vitest when `FRESHELL_VITEST_BACKEND=cloud`
+- **R5 — Tests:** Full test coverage of new scripts, configs, and entrypoint changes, following the existing `scripts/test/cloud-*.test.sh` pattern
+- **R6 — Docs:** AGENTS.md updated with cloud vitest instructions
+
+---
+
+### Task 1: Entrypoint vitest mode
+
+**Requirements served:** R1
+
+**Behavior:**
+- When `TEST_MODE=vitest` env var is set, the entrypoint runs Vitest instead of Playwright
+- Each Cloud Run task runs both default and server vitest configs, using `--shard=I/N` for sharding
+- Shard index comes from `CLOUD_RUN_TASK_INDEX` (0-based) and `CLOUD_RUN_TASK_COUNT`
+- If any config fails, the exit code is non-zero (but both configs still run)
+- When `TEST_MODE` is unset or `playwright`, current behavior is unchanged
+
+**Files:**
+- Modify: `docker/cloud-run/entrypoint.sh` (add vitest branch at top, before playwright logic)
+- Test: `scripts/test/cloud-vitest-entrypoint.test.sh`
+
+**Interfaces:**
+- Consumes: `TEST_MODE` (env var, new), `CLOUD_RUN_TASK_INDEX` (existing), `CLOUD_RUN_TASK_COUNT` (existing), `VITEST_CONFIGS` (env var, new — space-separated list of config paths, default: `"config/vitest/vitest.config.ts config/vitest/vitest.server.config.ts"`)
+- Produces: Vitest test output on stdout/stderr, exit code 0 (all pass) or 1 (any fail)
+
+**Test cases:**
+- `TEST_MODE=vitest` branch exists in entrypoint → grep finds `TEST_MODE` and `vitest`
+- Entrypoint with `TEST_MODE=playwright` (or unset) → current behavior unchanged
+- Entrypoint with `TEST_MODE=vitest` and `CLOUD_RUN_TASK_COUNT=1` → runs `npx vitest run` for both configs (no `--shard` flag)
+- Entrypoint with `TEST_MODE=vitest` and `CLOUD_RUN_TASK_COUNT=2` → runs `npx vitest run --shard=1/2` and `--shard=2/2` for both configs
+- `VITEST_CONFIGS` env var limits which configs run (e.g., only default config)
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Create `scripts/test/cloud-vitest-entrypoint.test.sh` with:
+- Check 1: entrypoint.sh contains `TEST_MODE` reference
+- Check 2: entrypoint.sh contains `vitest` reference
+- Check 3: entrypoint.sh contains `--shard` reference
+- Check 4: entrypoint.sh references `VITEST_CONFIGS`
+- Check 5: When `TEST_MODE` is unset, entrypoint still references playwright (unchanged behavior)
+- Check 6: Docker build succeeds with the modified entrypoint (if Docker is available)
+- Check 7: Running the entrypoint in a container with `TEST_MODE=vitest CLOUD_RUN_TASK_COUNT=1 VITEST_CONFIGS="config/vitest/vitest.config.ts"` and a single fast test file produces vitest output (skip if Docker unavailable)
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `bash scripts/test/cloud-vitest-entrypoint.test.sh`
+
+Expected: FAIL because `entrypoint.sh` does not contain `TEST_MODE` or `vitest` references
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Add to the top of `docker/cloud-run/entrypoint.sh`, after the `set -euo pipefail` and env var reads, before the playwright-specific logic:
+
+```bash
+# TEST_MODE=vitest: run Vitest instead of Playwright.
+if [ "${TEST_MODE:-}" = "vitest" ]; then
+  SHARD_INDEX=$((TASK_INDEX + 1))
+  SHARD_COUNT="$TASK_COUNT"
+  CONFIGS="${VITEST_CONFIGS:-config/vitest/vitest.config.ts config/vitest/vitest.server.config.ts}"
+  SHARD_ARG=""
+  if [ "$SHARD_COUNT" -gt 1 ]; then
+    SHARD_ARG="--shard=${SHARD_INDEX}/${SHARD_COUNT}"
+  fi
+  EXIT_CODE=0
+  for config in $CONFIGS; do
+    echo "[e2e-entrypoint] Running vitest: $config $SHARD_ARG"
+    npx vitest run --config "$config" $SHARD_ARG || EXIT_CODE=$?
+  done
+  exit "$EXIT_CODE"
+fi
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `bash scripts/test/cloud-vitest-entrypoint.test.sh`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+The vitest branch is a clean early-return at the top of the entrypoint. No refactor needed.
+
+- [ ] **Step 6: Run broader verification**
+
+Run: `bash scripts/test/cloud-run-dockerfile.test.sh` (existing Dockerfile tests still pass)
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add docker/cloud-run/entrypoint.sh scripts/test/cloud-vitest-entrypoint.test.sh
+git commit -m "feat: add TEST_MODE=vitest to cloud-run entrypoint"
+```
+
+---
+
+### Task 2: Vitest cloud wrapper script
+
+**Requirements served:** R1, R3
+
+**Behavior:**
+- `scripts/vitest-cloud.sh` is a standalone wrapper modeled on `scripts/e2e-cloud.sh`
+- Subcommands: `run` (default), `build`, `push`, `logs`, `help`
+- Backend selection: `FRESHELL_VITEST_BACKEND` env var (unset/local = local, cloud = cloud), `--local`/`--cloud` flags override
+- `--shards=N` (default 4), `--timeout=DURATION` (default 30m), `--build` (force rebuild)
+- `--config=default|server|all` selects which vitest configs to run (default: all)
+- Cloud Run Job name: `freshell-vitest`
+- Sets `TEST_MODE=vitest` and `VITEST_CONFIGS` env vars on the Cloud Run Job
+- `--cloud-build` flag uses Google Cloud Build instead of local Docker build (implemented in Task 4)
+- Local mode runs `npx vitest run` for both configs directly
+- `build`/`push` subcommands are identical to `e2e-cloud.sh` (same Docker image)
+
+**Files:**
+- Create: `scripts/vitest-cloud.sh`
+- Test: `scripts/test/cloud-vitest-wrapper.test.sh`
+
+**Interfaces:**
+- Consumes: `FRESHELL_VITEST_BACKEND` env var, `FRESHELL_GCP_ACCOUNT`/`FRESHELL_GCP_PROJECT`/`FRESHELL_GCP_REGION`/`FRESHELL_GCP_REPO` env vars (same defaults as e2e)
+- Produces: Cloud Run Job execution with `TEST_MODE=vitest` env var, exit code from vitest
+
+**Test cases:**
+- Script exists and is executable
+- `help` subcommand shows usage, mentions `--local`, `--cloud`, `FRESHELL_VITEST_BACKEND`, `--shards`, `--config`
+- `--local` flag runs vitest locally (run a single fast test file to verify)
+- Default backend (unset env var) runs locally
+- `FRESHELL_VITEST_BACKEND=local` runs locally
+- `--cloud` flag overrides `FRESHELL_VITEST_BACKEND=local` (does not print "Running locally")
+- `npm run test:cloud -- --local` works (if npm script is added in Task 3)
+- Existing `e2e-cloud.sh` tests still pass (no regression)
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Create `scripts/test/cloud-vitest-wrapper.test.sh` with:
+- Check 1: Script exists and is executable
+- Check 2: `help` contains "usage", "run", "--local", "--cloud", "FRESHELL_VITEST_BACKEND", "--shards", "--config"
+- Check 3: `--local` runs a single fast test file locally (e.g., `test/unit/lib/env.test.ts` or similar small test)
+- Check 4: Default backend (unset env var) runs locally
+- Check 5: `FRESHELL_VITEST_BACKEND=local` runs locally
+- Check 6: `--cloud` flag does not print "Running locally"
+- Check 7: `--config=default` only runs the default vitest config
+- Check 8: `--config=server` only runs the server vitest config
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `bash scripts/test/cloud-vitest-wrapper.test.sh`
+
+Expected: FAIL because `scripts/vitest-cloud.sh` does not exist
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Create `scripts/vitest-cloud.sh` with:
+- Same structure as `scripts/e2e-cloud.sh`: defaults, gcloud helpers, usage, `cmd_build`, `cmd_push`, `cmd_run`, `cmd_logs`, main dispatch
+- Key differences from `e2e-cloud.sh`:
+  - `GCP_JOB="freshell-vitest"` (not `freshell-e2e`)
+  - `FRESHELL_VITEST_BACKEND` env var (not `FRESHELL_E2E_BACKEND`)
+  - Local mode: `npx vitest run --config <config>` for each config (not `npx playwright test`)
+  - Cloud mode: env-vars-file sets `TEST_MODE: "vitest"` and `VITEST_CONFIGS: "<configs>"`
+  - `--config=default|server|all` flag controls which configs to run
+  - Log summary greps for vitest output patterns (`Test Files`, `Tests`)
+  - Default `--shards=4` (not 1)
+  - Default `--timeout=30m` (not 60m)
+  - `--cloud-build` flag (stubbed — full implementation in Task 4)
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `bash scripts/test/cloud-vitest-wrapper.test.sh`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+Review for duplication with `e2e-cloud.sh`. If `cmd_build` and `cmd_push` are identical, note for future extraction into a shared library but do not refactor now (two scripts is not enough duplication to justify the abstraction).
+
+- [ ] **Step 6: Run broader verification**
+
+Run: `bash scripts/test/cloud-run-wrapper.test.sh` (existing e2e wrapper tests still pass)
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add scripts/vitest-cloud.sh scripts/test/cloud-vitest-wrapper.test.sh
+git commit -m "feat: add vitest-cloud.sh wrapper for Cloud Run Jobs"
+```
+
+---
+
+### Task 3: Integration with run-standard-tests.ts + npm scripts + AGENTS.md
+
+**Requirements served:** R3, R4, R6
+
+**Behavior:**
+- When `FRESHELL_VITEST_BACKEND=cloud`, `scripts/run-standard-tests.ts` dispatches to `scripts/vitest-cloud.sh run` instead of running vitest locally
+- The dispatch happens at the top of `main()`, before any local test planning
+- Forwarded args are passed through to the cloud wrapper
+- New npm scripts: `test:cloud`, `test:cloud:build`
+- AGENTS.md updated with cloud vitest instructions
+
+**Files:**
+- Modify: `scripts/run-standard-tests.ts` (add early dispatch in `main()`)
+- Modify: `package.json` (add `test:cloud`, `test:cloud:build` scripts)
+- Modify: `AGENTS.md` (add Vitest section to E2E Test Backend area)
+- Test: `scripts/test/cloud-vitest-integration.test.sh`
+
+**Interfaces:**
+- Consumes: `FRESHELL_VITEST_BACKEND` env var
+- Produces: Exit code from `scripts/vitest-cloud.sh run`
+
+**Test cases:**
+- `FRESHELL_VITEST_BACKEND=cloud` in `run-standard-tests.ts` → dispatches to `vitest-cloud.sh` (verify by checking that `vitest-cloud.sh run` is invoked)
+- `FRESHELL_VITEST_BACKEND` unset → current behavior (local vitest)
+- `FRESHELL_VITEST_BACKEND=local` → current behavior (local vitest)
+- `npm run test:cloud` script exists and dispatches to `scripts/vitest-cloud.sh run`
+- `npm run test:cloud:build` script exists and dispatches to `scripts/vitest-cloud.sh build`
+- `npm run test:cloud -- --local` works (runs locally)
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Create `scripts/test/cloud-vitest-integration.test.sh` with:
+- Check 1: `scripts/run-standard-tests.ts` contains `FRESHELL_VITEST_BACKEND` reference
+- Check 2: `scripts/run-standard-tests.ts` contains `vitest-cloud.sh` reference
+- Check 3: `package.json` contains `test:cloud` script
+- Check 4: `package.json` contains `test:cloud:build` script
+- Check 5: `npm run test:cloud -- --local` runs a fast test locally
+- Check 6: `AGENTS.md` mentions `FRESHELL_VITEST_BACKEND`
+- Check 7: `FRESHELL_VITEST_BACKEND=local npx tsx scripts/run-standard-tests.ts --mode desktop` still runs locally (no regression)
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `bash scripts/test/cloud-vitest-integration.test.sh`
+
+Expected: FAIL because `run-standard-tests.ts` does not reference `FRESHELL_VITEST_BACKEND`, and `package.json` has no `test:cloud` script
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+In `scripts/run-standard-tests.ts`, add at the top of `main()`:
+
+```typescript
+if (process.env.FRESHELL_VITEST_BACKEND === 'cloud') {
+  const { execFileSync } = await import('node:child_process')
+  const cloudScript = resolve(repoRoot, 'scripts/vitest-cloud.sh')
+  try {
+    execFileSync(cloudScript, ['run', ...argv], { stdio: 'inherit', cwd: repoRoot })
+    process.exit(0)
+  } catch {
+    process.exit(1)
+  }
+}
+```
+
+In `package.json`, add:
+```json
+"test:cloud": "bash scripts/vitest-cloud.sh run",
+"test:cloud:build": "bash scripts/vitest-cloud.sh build",
+```
+
+In `AGENTS.md`, add a section under Testing explaining `FRESHELL_VITEST_BACKEND` (similar to `FRESHELL_E2E_BACKEND`).
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `bash scripts/test/cloud-vitest-integration.test.sh`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+The early-return dispatch is clean. No refactor needed.
+
+- [ ] **Step 6: Run broader verification**
+
+Run: `npm run test:status` (coordinator still works)
+
+Expected: PASS (idle state, no interference)
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add scripts/run-standard-tests.ts package.json AGENTS.md scripts/test/cloud-vitest-integration.test.sh
+git commit -m "feat: integrate cloud vitest with run-standard-tests.ts and npm scripts"
+```
+
+---
+
+### Task 4: Cloud Build config and --cloud-build flag
+
+**Requirements served:** R2
+
+**Behavior:**
+- `docker/cloud-run/cloudbuild.yaml` configures Google Cloud Build with:
+  - `docker pull` of existing image for `--cache-from` layer caching
+  - `docker build -f docker/cloud-run/Dockerfile --cache-from <image> -t <image> .`
+  - `images:` field for automatic push to Artifact Registry
+  - `E2_HIGHCPU_32` machine type, 200GB disk, 1h timeout
+- `.gcloudignore` excludes non-build files from Cloud Build source upload
+- Both `scripts/e2e-cloud.sh` and `scripts/vitest-cloud.sh` gain a `--cloud-build` flag on their `build` subcommand
+- When `--cloud-build` is set, `cmd_build` uses `gcloud builds submit --config docker/cloud-run/cloudbuild.yaml .` instead of local `docker build`
+- Without `--cloud-build`, `cmd_build` uses local Docker (current behavior)
+
+**Files:**
+- Create: `docker/cloud-run/cloudbuild.yaml`
+- Create: `.gcloudignore`
+- Modify: `scripts/e2e-cloud.sh` (add `--cloud-build` flag to `cmd_build`)
+- Modify: `scripts/vitest-cloud.sh` (add `--cloud-build` flag to `cmd_build`)
+- Test: `scripts/test/cloud-build.test.sh`
+
+**Interfaces:**
+- Consumes: `cloudbuild.yaml`, `.gcloudignore`, `--cloud-build` flag
+- Produces: Docker image in Artifact Registry (built by Cloud Build)
+
+**Test cases:**
+- `docker/cloud-run/cloudbuild.yaml` exists and is valid YAML
+- `cloudbuild.yaml` references the correct Dockerfile path (`docker/cloud-run/Dockerfile`)
+- `cloudbuild.yaml` references the correct image URL
+- `cloudbuild.yaml` uses `E2_HIGHCPU_32` machine type
+- `.gcloudignore` exists and excludes `.git`, `node_modules`, `target`, `dist`
+- `e2e-cloud.sh help` mentions `--cloud-build`
+- `vitest-cloud.sh help` mentions `--cloud-build`
+- `e2e-cloud.sh build --cloud-build` would invoke `gcloud builds submit` (verify by checking output contains "gcloud builds" when run with `--cloud-build`, without actually submitting)
+- `e2e-cloud.sh build` (without `--cloud-build`) still uses local Docker
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Create `scripts/test/cloud-build.test.sh` with:
+- Check 1: `docker/cloud-run/cloudbuild.yaml` exists
+- Check 2: `cloudbuild.yaml` is valid YAML (parse with `python3 -c "import yaml; yaml.safe_load(open('...'))"`)
+- Check 3: `cloudbuild.yaml` contains `docker/cloud-run/Dockerfile`
+- Check 4: `cloudbuild.yaml` contains the Artifact Registry image URL
+- Check 5: `cloudbuild.yaml` contains `E2_HIGHCPU_32`
+- Check 6: `.gcloudignore` exists
+- Check 7: `.gcloudignore` excludes `.git`, `node_modules`, `target`, `dist`
+- Check 8: `e2e-cloud.sh help` contains `--cloud-build`
+- Check 9: `vitest-cloud.sh help` contains `--cloud-build`
+- Check 10: `e2e-cloud.sh build --cloud-build --dry-run` outputs "gcloud builds" (dry-run flag prevents actual submission)
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `bash scripts/test/cloud-build.test.sh`
+
+Expected: FAIL because `cloudbuild.yaml` and `.gcloudignore` don't exist, and `--cloud-build` flag isn't implemented
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Create `docker/cloud-run/cloudbuild.yaml`:
+```yaml
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: ['-c', 'docker pull ${_IMAGE} || exit 0']
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-f'
+      - 'docker/cloud-run/Dockerfile'
+      - '-t'
+      - '${_IMAGE}'
+      - '--cache-from'
+      - '${_IMAGE}'
+      - '.'
+images:
+  - '${_IMAGE}'
+options:
+  machineType: 'E2_HIGHCPU_32'
+  diskSizeGb: 200
+  timeout: '3600s'
+substitutions:
+  _IMAGE: 'us-west1-docker.pkg.dev/misc-puttering-project/freshell-e2e/freshell-e2e:latest'
+```
+
+Create `.gcloudignore` (same exclusions as `.dockerignore` plus `.worktrees/`).
+
+In `scripts/e2e-cloud.sh`, modify `cmd_build` to accept `--cloud-build` flag. When set, use `gcloud builds submit --config docker/cloud-run/cloudbuild.yaml .` instead of local `docker build`.
+
+In `scripts/vitest-cloud.sh`, same modification to `cmd_build`.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `bash scripts/test/cloud-build.test.sh`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+The `--cloud-build` flag logic is a simple if/else in `cmd_build`. No refactor needed.
+
+- [ ] **Step 6: Run broader verification**
+
+Run: `bash scripts/test/cloud-run-wrapper.test.sh` (e2e wrapper still works)
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add docker/cloud-run/cloudbuild.yaml .gcloudignore scripts/e2e-cloud.sh scripts/vitest-cloud.sh scripts/test/cloud-build.test.sh
+git commit -m "feat: add Cloud Build config and --cloud-build flag"
+```
+
+---
+
+### Task 5: End-to-end cloud validation
+
+**Requirements served:** R1, R2, R3
+
+**Behavior:**
+- Run cloud vitest on Cloud Run Jobs and verify all tests pass
+- Run cloud build on Google Cloud Build and verify the image builds successfully
+- Record actual timings and cost estimates
+
+**Files:**
+- No new files (validation task)
+- Record results in `<logs-dir>/reports/cloud-validation.md`
+
+**Test cases:**
+- `scripts/vitest-cloud.sh run --cloud --shards=4` → all vitest tests pass (4/4 tasks succeeded)
+- `scripts/e2e-cloud.sh build --cloud-build` → Docker image builds and pushes successfully
+- Cloud vitest wall time < 3 min
+- Cloud build wall time < 15 min (cold) or < 5 min (warm)
+
+- [ ] **Step 1: Build and push the Docker image (if needed)**
+
+Run: `scripts/e2e-cloud.sh build`
+
+Expected: Docker image builds and pushes to Artifact Registry
+
+- [ ] **Step 2: Run cloud vitest**
+
+Run: `scripts/vitest-cloud.sh run --cloud --shards=4 --timeout=30m`
+
+Expected: All 4 tasks succeed, vitest tests pass
+
+- [ ] **Step 3: Run cloud build**
+
+Run: `scripts/e2e-cloud.sh build --cloud-build`
+
+Expected: Cloud Build succeeds, image pushed to Artifact Registry
+
+- [ ] **Step 4: Record results**
+
+Write results to `<logs-dir>/reports/cloud-validation.md` with:
+- Cloud vitest: shard count, wall time, per-shard test counts, cost estimate
+- Cloud build: wall time, cache hit/miss, cost estimate
+- Any issues encountered
+
+- [ ] **Step 5: Commit the validation report**
+
+```bash
+git add <logs-dir>/reports/cloud-validation.md
+git commit -m "docs: cloud vitest and cloud build validation results"
+```
+
+Note: The validation report is in the logs directory (outside the worktree), so this commit may not be needed. If so, skip the commit.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "test:e2e:local": "bash scripts/e2e-cloud.sh run --local",
     "test:e2e:cloud": "bash scripts/e2e-cloud.sh run --cloud",
     "test:e2e:cloud:build": "bash scripts/e2e-cloud.sh build",
+    "test:cloud": "bash scripts/vitest-cloud.sh run --cloud",
+    "test:cloud:build": "bash scripts/vitest-cloud.sh build",
     "test:e2e:chromium": "playwright test --config test/e2e-browser/playwright.config.ts --project=chromium",
     "test:e2e:headed": "playwright test --config test/e2e-browser/playwright.config.ts --headed",
     "test:e2e:update-snapshots": "playwright test --config test/e2e-browser/playwright.config.ts --update-snapshots",

--- a/scripts/e2e-cloud.sh
+++ b/scripts/e2e-cloud.sh
@@ -122,11 +122,26 @@ cmd_build() {
         local_build=true
         shift
         ;;
+      --account=*)
+        GCP_ACCOUNT="${1#*=}"
+        shift
+        ;;
+      --project-id=*)
+        GCP_PROJECT="${1#*=}"
+        shift
+        ;;
+      --region=*)
+        GCP_REGION="${1#*=}"
+        shift
+        ;;
       *)
         shift
         ;;
     esac
   done
+
+  # Recompute IMAGE_REMOTE with potentially overridden GCP settings
+  IMAGE_REMOTE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${GCP_REPO}/freshell-e2e:latest"
 
   if $local_build; then
     echo "[e2e-cloud] Building Docker image locally..."
@@ -176,6 +191,7 @@ cmd_run() {
   local local_mode=false
   local cloud_mode=false
   local force_build=false
+  local local_build_flag=false
   local shards=1
   local timeout="60m"
   local -a pw_args=()
@@ -192,6 +208,10 @@ cmd_run() {
         ;;
       --build)
         force_build=true
+        shift
+        ;;
+      --local-build)
+        local_build_flag=true
         shift
         ;;
       --shards=*)
@@ -253,7 +273,11 @@ cmd_run() {
 
   # Cloud mode
   if $force_build; then
-    cmd_build
+    if $local_build_flag; then
+      cmd_build --local-build
+    else
+      cmd_build
+    fi
   fi
 
   # Ensure image exists in remote registry
@@ -300,17 +324,26 @@ cmd_run() {
 
   rm -f "$env_file"
 
-  # Execute the job and wait for completion
+  # Execute the job and wait for completion.
+  # Capture the execution ID from the execute output to avoid a race with
+  # concurrent agents updating/executing the same shared job.
   echo "[e2e-cloud] Executing Cloud Run Job..."
-  gcloud run jobs execute $(gcloud_flags) "$GCP_JOB" --wait
+  local execute_output
+  execute_output=$(gcloud run jobs execute $(gcloud_flags) "$GCP_JOB" --wait 2>&1) || true
+  echo "$execute_output"
 
-  # Get the latest execution name
+  # Extract the execution ID from the execute output (format: "Execution NAME")
   local execution_id
-  execution_id=$(gcloud run jobs executions list $(gcloud_flags) \
-    --job="$GCP_JOB" \
-    --sort-by="~metadata.creationTimestamp" \
-    --format="value(name)" \
-    --limit=1)
+  execution_id=$(echo "$execute_output" | grep -oP 'Execution \K[^ ]+' | head -1)
+  if [ -z "$execution_id" ]; then
+    # Fallback: query the latest execution (may race with concurrent agents)
+    echo "[e2e-cloud] WARNING: could not capture execution ID, falling back to latest"
+    execution_id=$(gcloud run jobs executions list $(gcloud_flags) \
+      --job="$GCP_JOB" \
+      --sort-by="~metadata.creationTimestamp" \
+      --format="value(name)" \
+      --limit=1)
+  fi
 
   # Fetch logs (requires beta track for logs read).
   # Capture to a variable so we can print the full output AND extract a

--- a/scripts/e2e-cloud.sh
+++ b/scripts/e2e-cloud.sh
@@ -21,6 +21,7 @@
 #   --local           Run locally (overrides FRESHELL_E2E_BACKEND)
 #   --cloud           Run on Cloud Run (overrides FRESHELL_E2E_BACKEND)
 #   --build           Force image rebuild + push before running
+#   --local-build     Build locally with Docker instead of Cloud Build
 #   --shards=N        Number of parallel Cloud Run tasks (default: 1)
 #   --timeout=DURATION Cloud Run task timeout (default: 60m)
 #   --grep=PATTERN    Pass --grep=PATTERN to Playwright
@@ -87,6 +88,7 @@ Flags:
   --local           Run locally (overrides FRESHELL_E2E_BACKEND)
   --cloud           Run on Cloud Run (overrides FRESHELL_E2E_BACKEND)
   --build           Force image rebuild + push before running
+  --local-build     Build locally with Docker instead of Cloud Build
   --shards=N        Number of parallel Cloud Run tasks (default: 1)
   --timeout=DURATION Cloud Run task timeout (default: 60m)
   --grep=PATTERN    Pass --grep=PATTERN to Playwright
@@ -112,10 +114,35 @@ EOF
 # Subcommand: build
 # ---------------------------------------------------------------------------
 cmd_build() {
-  echo "[e2e-cloud] Building Docker image..."
-  docker build -f "$ROOT/docker/cloud-run/Dockerfile" -t "$IMAGE_LOCAL" "$ROOT"
-  echo "[e2e-cloud] Image built: $IMAGE_LOCAL"
-  cmd_push
+  local local_build=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --local-build)
+        local_build=true
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  if $local_build; then
+    echo "[e2e-cloud] Building Docker image locally..."
+    docker build -f "$ROOT/docker/cloud-run/Dockerfile" -t "$IMAGE_LOCAL" "$ROOT"
+    echo "[e2e-cloud] Image built: $IMAGE_LOCAL"
+    cmd_push
+  else
+    echo "[e2e-cloud] Building Docker image via Cloud Build..."
+    gcloud builds submit \
+      --config "$ROOT/docker/cloud-run/cloudbuild.yaml" \
+      --account="$GCP_ACCOUNT" \
+      --project="$GCP_PROJECT" \
+      --substitutions=_IMAGE="$IMAGE_REMOTE" \
+      "$ROOT"
+    echo "[e2e-cloud] Cloud Build complete: $IMAGE_REMOTE"
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/e2e-cloud.sh
+++ b/scripts/e2e-cloud.sh
@@ -56,9 +56,11 @@ ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Ensure gcloud's bin dir is on PATH (for docker-credential-gcloud used by
 # Docker when pushing to Artifact Registry).
-GCLOUD_BIN="$(gcloud info --format="value(installation.sdk_root)" 2>/dev/null)/bin"
-if [ -d "$GCLOUD_BIN" ] && ! echo "$PATH" | grep -q "$GCLOUD_BIN"; then
-  export PATH="$GCLOUD_BIN:$PATH"
+if command -v gcloud &>/dev/null; then
+  GCLOUD_BIN="$(gcloud info --format="value(installation.sdk_root)" 2>/dev/null)/bin"
+  if [ -d "$GCLOUD_BIN" ] && ! echo "$PATH" | grep -q "$GCLOUD_BIN"; then
+    export PATH="$GCLOUD_BIN:$PATH"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -391,7 +393,13 @@ cmd_run() {
 # Subcommand: logs
 # ---------------------------------------------------------------------------
 cmd_logs() {
-  gcloud beta run jobs executions logs read $(gcloud_flags) "$GCP_JOB" "$@"
+  local execution_id
+  execution_id=$(gcloud run jobs executions list $(gcloud_flags) --job="$GCP_JOB" --sort-by="~metadata.creationTimestamp" --format="value(name)" --limit=1)
+  if [ -z "$execution_id" ]; then
+    echo "[e2e-cloud] No executions found for job $GCP_JOB"
+    exit 1
+  fi
+  gcloud beta run jobs executions logs read $(gcloud_flags) "$execution_id" "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -400,7 +408,7 @@ cmd_logs() {
 SUBCOMMAND="${1:-run}"
 case "$SUBCOMMAND" in
   run)
-    shift
+    if [ $# -gt 0 ]; then shift; fi
     cmd_run "$@"
     ;;
   build)

--- a/scripts/run-standard-tests.ts
+++ b/scripts/run-standard-tests.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 
-import { spawn, type ChildProcess } from 'node:child_process'
+import { spawn, execFileSync, type ChildProcess } from 'node:child_process'
 import { createRequire } from 'node:module'
 import { availableParallelism, constants as osConstants, setPriority } from 'node:os'
 import { dirname, resolve } from 'node:path'
@@ -312,6 +312,60 @@ async function runStage(stage: StandardTestRun[], forwardedArgs: string[]): Prom
 
 export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
   const { mode, forwardedArgs } = parseCliArgs(argv)
+
+  // Cloud dispatch: when FRESHELL_VITEST_BACKEND=cloud, run client+server suites
+  // in the cloud via vitest-cloud.sh, then run the electron suite locally.
+  // Git-dependent selectors like --changed require a .git directory (excluded
+  // from the Docker image), so fall back to local execution when detected.
+  if (process.env.FRESHELL_VITEST_BACKEND === 'cloud') {
+    const hasGitDependentArgs = forwardedArgs.some(
+      (arg) => arg.startsWith('--changed') || arg === '--changed'
+    )
+    if (hasGitDependentArgs) {
+      log('warn', 'Git-dependent selectors detected, falling back to local execution', {
+        forwardedArgs,
+      })
+    } else {
+      const cloudScript = process.env.FRESHELL_VITEST_CLOUD_SCRIPT
+        || resolve(repoRoot, 'scripts/vitest-cloud.sh')
+
+      log('info', 'Dispatching client+server suites to cloud vitest', {
+        cloudScript,
+        forwardedArgs,
+      })
+
+      try {
+        execFileSync(cloudScript, ['run', ...forwardedArgs], {
+          stdio: 'inherit',
+          cwd: repoRoot,
+        })
+      } catch {
+        process.exitCode = 1
+        return 1
+      }
+
+      // Run the electron suite locally (needs a display + native modules).
+      const electronArgs = buildVitestArgs({
+        configPath: electronVitestConfig,
+        forwardedArgs,
+      })
+      log('info', 'Running electron suite locally after cloud dispatch', {
+        args: electronArgs,
+      })
+      try {
+        execFileSync(process.execPath, [vitestEntrypoint, ...electronArgs], {
+          stdio: 'inherit',
+          cwd: repoRoot,
+          env: process.env,
+        })
+      } catch {
+        process.exitCode = 1
+        return 1
+      }
+      return 0
+    }
+  }
+
   const plan = createStandardTestPlan({
     availableParallelism: availableParallelism(),
     ci: process.env.CI === 'true' || process.env.CI === '1',

--- a/scripts/test/cloud-build.test.sh
+++ b/scripts/test/cloud-build.test.sh
@@ -36,8 +36,10 @@ check "cloudbuild.yaml references docker/cloud-run/Dockerfile" \
   grep -q 'docker/cloud-run/Dockerfile' "$CLOUDBUILD"
 
 # Check 4: cloudbuild.yaml uses buildx build with --push
-check "cloudbuild.yaml uses buildx build with --push" \
+check "cloudbuild.yaml uses buildx build" \
   grep -q 'buildx' "$CLOUDBUILD"
+check "cloudbuild.yaml uses --push" \
+  grep -q -- '--push' "$CLOUDBUILD"
 
 # Check 5: cloudbuild.yaml uses E2_HIGHCPU_32 under options
 check "cloudbuild.yaml uses E2_HIGHCPU_32" \

--- a/scripts/test/cloud-build.test.sh
+++ b/scripts/test/cloud-build.test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Test: cloud-build — verify cloudbuild.yaml, .gcloudignore, and --local-build flag.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT"
+
+CLOUDBUILD="$ROOT/docker/cloud-run/cloudbuild.yaml"
+GCLOUDIGNORE="$ROOT/.gcloudignore"
+
+FAILURES=0
+
+check() {
+  local desc="$1"
+  shift
+  if "$@"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "=== Cloud Build Test ==="
+
+# Check 1: cloudbuild.yaml exists
+check "cloudbuild.yaml exists" test -f "$CLOUDBUILD"
+
+# Check 2: cloudbuild.yaml is valid YAML (using Node yaml package)
+check "cloudbuild.yaml is valid YAML" \
+  node -e "const yaml = require('yaml'); yaml.parse(require('fs').readFileSync('$CLOUDBUILD', 'utf8'))" 2>/dev/null
+
+# Check 3: cloudbuild.yaml references the correct Dockerfile path
+check "cloudbuild.yaml references docker/cloud-run/Dockerfile" \
+  grep -q 'docker/cloud-run/Dockerfile' "$CLOUDBUILD"
+
+# Check 4: cloudbuild.yaml uses buildx build with --push
+check "cloudbuild.yaml uses buildx build with --push" \
+  grep -q 'buildx' "$CLOUDBUILD"
+
+# Check 5: cloudbuild.yaml uses E2_HIGHCPU_32 under options
+check "cloudbuild.yaml uses E2_HIGHCPU_32" \
+  grep -q 'E2_HIGHCPU_32' "$CLOUDBUILD"
+
+# Check 6: cloudbuild.yaml has timeout at top level (not under options)
+check "cloudbuild.yaml has timeout at top level" \
+  node -e "const yaml = require('yaml'); const d = yaml.parse(require('fs').readFileSync('$CLOUDBUILD', 'utf8')); if (!d.timeout) process.exit(1); if (d.options && d.options.timeout) process.exit(1)"
+
+# Check 7: cloudbuild.yaml uses ${_IMAGE} substitution (not a hard-coded URL)
+check "cloudbuild.yaml uses \${_IMAGE} substitution" \
+  grep -q '${_IMAGE}' "$CLOUDBUILD"
+
+# Check 8: cloudbuild.yaml enables BuildKit
+check "cloudbuild.yaml enables BuildKit" \
+  grep -q 'DOCKER_BUILDKIT=1' "$CLOUDBUILD"
+
+# Check 9: cloudbuild.yaml uses mode=max in cache-to reference
+check "cloudbuild.yaml uses mode=max in cache-to" \
+  grep -q 'mode=max' "$CLOUDBUILD"
+
+# Check 10: .gcloudignore exists
+check ".gcloudignore exists" test -f "$GCLOUDIGNORE"
+
+# Check 11: .gcloudignore excludes .git, node_modules, target, dist, .worktrees/
+for pattern in '.git' 'node_modules' 'target' 'dist' '.worktrees'; do
+  check ".gcloudignore excludes '$pattern'" grep -q "$pattern" "$GCLOUDIGNORE"
+done
+
+# Check 12: .gcloudignore does NOT exclude docs/ wholesale (needed for docs/skills/testing.md)
+if grep -q '^docs/$' "$GCLOUDIGNORE"; then
+  echo "FAIL: .gcloudignore excludes docs/ wholesale (breaks docs/skills/testing.md)"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "PASS: .gcloudignore does not exclude docs/ wholesale"
+fi
+
+# Check 13: .gcloudignore has !AGENTS.md exception
+check ".gcloudignore has !AGENTS.md" grep -q '!AGENTS.md' "$GCLOUDIGNORE"
+
+# Check 14: e2e-cloud.sh help mentions --local-build
+check "e2e-cloud.sh help mentions --local-build" \
+  bash -c "bash scripts/e2e-cloud.sh help 2>&1 | grep -q -- '--local-build'"
+
+# Check 15: vitest-cloud.sh help mentions --local-build
+check "vitest-cloud.sh help mentions --local-build" \
+  bash -c "bash scripts/vitest-cloud.sh help 2>&1 | grep -q -- '--local-build'"
+
+# Check 16: e2e-cloud.sh build (default) with fake gcloud dispatches to Cloud Build
+FAKE_DIR=$(mktemp -d)
+cat > "$FAKE_DIR/gcloud" << 'FAKE'
+#!/usr/bin/env bash
+echo "FAKE_GCLOUD: $@" >> "${FAKE_GCLOUD_LOG:-/dev/null}"
+if [[ "$*" == *"artifacts docker images describe"* ]]; then exit 0; fi
+if [[ "$*" == *"artifacts repositories describe"* ]]; then exit 0; fi
+if [[ "$*" == *"auth print-access-token"* ]]; then echo "fake-token"; exit 0; fi
+if [[ "$*" == *"info"* ]]; then echo "/usr/lib/google-cloud-sdk"; exit 0; fi
+exit 0
+FAKE
+cat > "$FAKE_DIR/docker" << 'FAKE'
+#!/usr/bin/env bash
+echo "FAKE_DOCKER: $@" >> "${FAKE_DOCKER_LOG:-/dev/null}"
+exit 0
+FAKE
+chmod +x "$FAKE_DIR/gcloud" "$FAKE_DIR/docker"
+
+export FAKE_GCLOUD_LOG="$FAKE_DIR/gcloud.log"
+export FAKE_DOCKER_LOG="$FAKE_DIR/docker.log"
+touch "$FAKE_GCLOUD_LOG" "$FAKE_DOCKER_LOG"
+export PATH="$FAKE_DIR:$PATH"
+
+# Default build should use Cloud Build (gcloud builds submit)
+bash scripts/e2e-cloud.sh build 2>&1 > /dev/null || true
+check "e2e-cloud.sh build (default) calls gcloud builds submit" \
+  grep -q 'builds submit' "$FAKE_GCLOUD_LOG"
+
+# Check 17: vitest-cloud.sh build (default) with fake gcloud dispatches to Cloud Build
+rm -f "$FAKE_GCLOUD_LOG"; touch "$FAKE_GCLOUD_LOG"
+bash scripts/vitest-cloud.sh build 2>&1 > /dev/null || true
+check "vitest-cloud.sh build (default) calls gcloud builds submit" \
+  grep -q 'builds submit' "$FAKE_GCLOUD_LOG"
+
+# Check 18: e2e-cloud.sh build --local-build uses docker build (not Cloud Build)
+rm -f "$FAKE_GCLOUD_LOG" "$FAKE_DOCKER_LOG"; touch "$FAKE_GCLOUD_LOG" "$FAKE_DOCKER_LOG"
+bash scripts/e2e-cloud.sh build --local-build 2>&1 > /dev/null || true
+check "e2e-cloud.sh build --local-build calls docker build" \
+  grep -q 'build' "$FAKE_DOCKER_LOG"
+if grep -q 'builds submit' "$FAKE_GCLOUD_LOG"; then
+  echo "FAIL: e2e-cloud.sh build --local-build should NOT call gcloud builds submit"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "PASS: e2e-cloud.sh build --local-build does NOT call gcloud builds submit"
+fi
+
+# Check 19: vitest-cloud.sh build --local-build uses docker build (not Cloud Build)
+rm -f "$FAKE_GCLOUD_LOG" "$FAKE_DOCKER_LOG"; touch "$FAKE_GCLOUD_LOG" "$FAKE_DOCKER_LOG"
+bash scripts/vitest-cloud.sh build --local-build 2>&1 > /dev/null || true
+check "vitest-cloud.sh build --local-build calls docker build" \
+  grep -q 'build' "$FAKE_DOCKER_LOG"
+
+# Cleanup
+rm -rf "$FAKE_DIR"
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "=== All checks passed ==="
+  exit 0
+else
+  echo "=== $FAILURES check(s) failed ==="
+  exit 1
+fi

--- a/scripts/test/cloud-vitest-entrypoint.test.sh
+++ b/scripts/test/cloud-vitest-entrypoint.test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Test: cloud-vitest-entrypoint — verify TEST_MODE=vitest branch, .dockerignore exceptions,
+# and Dockerfile USER node + PLAYWRIGHT_BROWSERS_PATH changes.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT"
+
+ENTRYPOINT="$ROOT/docker/cloud-run/entrypoint.sh"
+DOCKERFILE="$ROOT/docker/cloud-run/Dockerfile"
+DOCKERIGNORE="$ROOT/.dockerignore"
+
+FAILURES=0
+
+check() {
+  local desc="$1"
+  shift
+  if "$@"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "=== Cloud Vitest Entrypoint Test ==="
+
+# Check 1: entrypoint.sh contains TEST_MODE reference
+check "entrypoint.sh contains 'TEST_MODE'" grep -q 'TEST_MODE' "$ENTRYPOINT"
+
+# Check 2: entrypoint.sh contains 'vitest' reference
+check "entrypoint.sh contains 'vitest'" grep -q 'vitest' "$ENTRYPOINT"
+
+# Check 3: entrypoint.sh contains '--shard' reference
+check "entrypoint.sh contains '--shard'" grep -q -- '--shard' "$ENTRYPOINT"
+
+# Check 4: entrypoint.sh contains '--passWithNoTests'
+check "entrypoint.sh contains '--passWithNoTests'" grep -q -- '--passWithNoTests' "$ENTRYPOINT"
+
+# Check 5: entrypoint.sh references VITEST_CONFIGS
+check "entrypoint.sh references 'VITEST_CONFIGS'" grep -q 'VITEST_CONFIGS' "$ENTRYPOINT"
+
+# Check 6: entrypoint.sh references VITEST_ARGS_JSON (not VITEST_ARGS)
+check "entrypoint.sh references 'VITEST_ARGS_JSON'" grep -q 'VITEST_ARGS_JSON' "$ENTRYPOINT"
+
+# Check 7: entrypoint.sh references jq (for parsing VITEST_ARGS_JSON)
+check "entrypoint.sh references 'jq'" grep -q 'jq' "$ENTRYPOINT"
+
+# Check 8: When TEST_MODE is unset, entrypoint still references playwright (unchanged behavior)
+check "entrypoint.sh still references 'playwright'" grep -q 'playwright' "$ENTRYPOINT"
+
+# Check 9: .dockerignore contains !AGENTS.md exception
+check ".dockerignore contains '!AGENTS.md'" grep -q '!AGENTS\.md' "$DOCKERIGNORE"
+
+# Check 10: .dockerignore contains !docs/skills/testing.md exception
+check ".dockerignore contains '!docs/skills/testing.md'" grep -q '!docs/skills/testing\.md' "$DOCKERIGNORE"
+
+# Check 11: Dockerfile contains USER node in the runtime stage
+check "Dockerfile contains 'USER node'" grep -q 'USER node' "$DOCKERFILE"
+
+# Check 12: Dockerfile contains chown for /app ownership transfer
+check "Dockerfile contains 'chown' for node ownership" grep -q 'chown.*node' "$DOCKERFILE"
+
+# Check 13: Dockerfile sets PLAYWRIGHT_BROWSERS_PATH before the existing install
+check "Dockerfile contains 'PLAYWRIGHT_BROWSERS_PATH'" grep -q 'PLAYWRIGHT_BROWSERS_PATH' "$DOCKERFILE"
+
+# Check 14: USER node comes AFTER RUN chmod (not before)
+# Extract line numbers
+CHMOD_LINE=$(grep -n 'RUN chmod' "$DOCKERFILE" | tail -1 | cut -d: -f1)
+USER_LINE=$(grep -n 'USER node' "$DOCKERFILE" | tail -1 | cut -d: -f1)
+if [ -n "$CHMOD_LINE" ] && [ -n "$USER_LINE" ] && [ "$USER_LINE" -gt "$CHMOD_LINE" ]; then
+  echo "PASS: USER node (line $USER_LINE) is after RUN chmod (line $CHMOD_LINE)"
+else
+  echo "FAIL: USER node (line ${USER_LINE:-N/A}) is not after RUN chmod (line ${CHMOD_LINE:-N/A})"
+  FAILURES=$((FAILURES + 1))
+fi
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "=== All checks passed ==="
+  exit 0
+else
+  echo "=== $FAILURES check(s) failed ==="
+  exit 1
+fi

--- a/scripts/test/cloud-vitest-entrypoint.test.sh
+++ b/scripts/test/cloud-vitest-entrypoint.test.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Test: cloud-vitest-entrypoint — verify TEST_MODE=vitest branch, .dockerignore exceptions,
 # and Dockerfile USER node + PLAYWRIGHT_BROWSERS_PATH changes.
+#
+# Note: This test uses string-grep checks for fast feedback. Execution-level
+# verification (running vitest in a Docker container with TEST_MODE=vitest)
+# was performed in Task 5's end-to-end validation and is not repeated here.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test/cloud-vitest-integration.test.sh
+++ b/scripts/test/cloud-vitest-integration.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Test: cloud-vitest-integration — verify FRESHELL_VITEST_BACKEND dispatch in
+# run-standard-tests.ts, npm scripts, and AGENTS.md documentation.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT"
+
+FAILURES=0
+
+check() {
+  local desc="$1"
+  shift
+  if "$@"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "=== Cloud Vitest Integration Test ==="
+
+# Check 1: run-standard-tests.ts contains FRESHELL_VITEST_BACKEND reference
+check "run-standard-tests.ts references FRESHELL_VITEST_BACKEND" \
+  grep -q 'FRESHELL_VITEST_BACKEND' scripts/run-standard-tests.ts
+
+# Check 2: run-standard-tests.ts contains FRESHELL_VITEST_CLOUD_SCRIPT reference (injection point)
+check "run-standard-tests.ts references FRESHELL_VITEST_CLOUD_SCRIPT" \
+  grep -q 'FRESHELL_VITEST_CLOUD_SCRIPT' scripts/run-standard-tests.ts
+
+# Check 3: run-standard-tests.ts contains vitest-cloud.sh reference (default path)
+check "run-standard-tests.ts references vitest-cloud.sh" \
+  grep -q 'vitest-cloud.sh' scripts/run-standard-tests.ts
+
+# Check 4: package.json contains test:cloud script
+check "package.json contains test:cloud" \
+  grep -q '"test:cloud"' package.json
+
+# Check 5: package.json contains test:cloud:build script
+check "package.json contains test:cloud:build" \
+  grep -q '"test:cloud:build"' package.json
+
+# Check 6: AGENTS.md mentions FRESHELL_VITEST_BACKEND
+check "AGENTS.md mentions FRESHELL_VITEST_BACKEND" \
+  grep -q 'FRESHELL_VITEST_BACKEND' AGENTS.md
+
+# Check 7: Process-level test — fake vitest-cloud.sh invoked when FRESHELL_VITEST_BACKEND=cloud
+FAKE_SCRIPT=$(mktemp /tmp/fake-vitest-cloud.XXXXXX.sh)
+cat > "$FAKE_SCRIPT" << 'FAKE'
+#!/usr/bin/env bash
+echo "FAKE_VITEST_CLOUD: $@" >> "${FAKE_CLOUD_LOG:-/dev/null}"
+exit 0
+FAKE
+chmod +x "$FAKE_SCRIPT"
+
+export FAKE_CLOUD_LOG=$(mktemp /tmp/fake-cloud-log.XXXXXX)
+touch "$FAKE_CLOUD_LOG"
+
+# Run with FRESHELL_VITEST_BACKEND=cloud and the fake script.
+# Use a timeout — after the fake exits 0, the code runs the electron suite
+# locally (which takes minutes). We only need to verify the fake was invoked.
+timeout 10s bash -c "
+FRESHELL_VITEST_BACKEND=cloud \
+FRESHELL_VITEST_CLOUD_SCRIPT='$FAKE_SCRIPT' \
+npx tsx scripts/run-standard-tests.ts --mode desktop
+" > /dev/null 2>&1 || true
+
+check "fake vitest-cloud.sh was invoked" grep -q 'FAKE_VITEST_CLOUD' "$FAKE_CLOUD_LOG"
+check "fake was called with 'run'" grep -q 'run' "$FAKE_CLOUD_LOG"
+
+# Check 8: FRESHELL_VITEST_BACKEND=local does NOT invoke vitest-cloud.sh
+# Use a timeout — the local path runs the full test suite which takes minutes.
+# We only need to verify the fake was NOT invoked (checked after the timeout).
+rm -f "$FAKE_CLOUD_LOG"; touch "$FAKE_CLOUD_LOG"
+timeout 10s bash -c "
+FRESHELL_VITEST_BACKEND=local \
+FRESHELL_VITEST_CLOUD_SCRIPT='$FAKE_SCRIPT' \
+npx tsx scripts/run-standard-tests.ts --mode desktop
+" > /dev/null 2>&1 || true
+
+if grep -q 'FAKE_VITEST_CLOUD' "$FAKE_CLOUD_LOG" 2>/dev/null; then
+  echo "FAIL: FRESHELL_VITEST_BACKEND=local should NOT invoke vitest-cloud.sh"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "PASS: FRESHELL_VITEST_BACKEND=local does not invoke vitest-cloud.sh"
+fi
+
+# Cleanup
+rm -f "$FAKE_SCRIPT" "$FAKE_CLOUD_LOG"
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "=== All checks passed ==="
+  exit 0
+else
+  echo "=== $FAILURES check(s) failed ==="
+  exit 1
+fi

--- a/scripts/test/cloud-vitest-integration.test.sh
+++ b/scripts/test/cloud-vitest-integration.test.sh
@@ -61,14 +61,22 @@ touch "$FAKE_CLOUD_LOG"
 # Run with FRESHELL_VITEST_BACKEND=cloud and the fake script.
 # Use a timeout — after the fake exits 0, the code runs the electron suite
 # locally (which takes minutes). We only need to verify the fake was invoked.
+# Capture stdout to also verify the electron fallback was attempted.
+CLOUD_STDOUT=$(mktemp /tmp/cloud-stdout.XXXXXX)
 timeout 10s bash -c "
 FRESHELL_VITEST_BACKEND=cloud \
 FRESHELL_VITEST_CLOUD_SCRIPT='$FAKE_SCRIPT' \
 npx tsx scripts/run-standard-tests.ts --mode desktop
-" > /dev/null 2>&1 || true
+" > "$CLOUD_STDOUT" 2>&1 || true
 
 check "fake vitest-cloud.sh was invoked" grep -q 'FAKE_VITEST_CLOUD' "$FAKE_CLOUD_LOG"
 check "fake was called with 'run'" grep -q 'run' "$FAKE_CLOUD_LOG"
+
+# Check 7b: Electron fallback was attempted after cloud dispatch
+# The run-standard-tests.ts logs "Running electron suite locally after cloud dispatch"
+check "electron fallback attempted after cloud dispatch" \
+  grep -q 'electron' "$CLOUD_STDOUT"
+rm -f "$CLOUD_STDOUT"
 
 # Check 8: FRESHELL_VITEST_BACKEND=local does NOT invoke vitest-cloud.sh
 # Use a timeout — the local path runs the full test suite which takes minutes.

--- a/scripts/test/cloud-vitest-wrapper.test.sh
+++ b/scripts/test/cloud-vitest-wrapper.test.sh
@@ -108,9 +108,11 @@ check "--config=server sets correct config" grep -q 'vitest.server.config.ts' "$
 rm -f "${FAKE_GCLOUD_LOG}.envvars"
 bash "$SCRIPT" run --cloud --config=default test/unit/lib/pane-utils.test.ts 2>&1 > /dev/null || true
 if [ -f "${FAKE_GCLOUD_LOG}.envvars" ]; then
-  VITEST_ARGS_VAL=$(grep 'VITEST_ARGS_JSON' "${FAKE_GCLOUD_LOG}.envvars" | sed "s/^VITEST_ARGS_JSON: '//;s/'\$//" || true)
+  # Extract the YAML double-quoted value and unescape it to get the raw JSON
+  VITEST_ARGS_VAL=$(grep 'VITEST_ARGS_JSON' "${FAKE_GCLOUD_LOG}.envvars" | sed 's/^VITEST_ARGS_JSON: //' || true)
   if [ -n "$VITEST_ARGS_VAL" ]; then
-    check "VITEST_ARGS_JSON is valid JSON" bash -c "echo '$VITEST_ARGS_VAL' | jq -e '.' > /dev/null 2>&1"
+    # Use jq to parse the YAML double-quoted string back to raw JSON, then validate
+    check "VITEST_ARGS_JSON is valid JSON" bash -c "echo '$VITEST_ARGS_VAL' | jq -r . | jq -e '.' > /dev/null 2>&1"
   else
     echo "FAIL: VITEST_ARGS_JSON not found in env-vars file"
     FAILURES=$((FAILURES + 1))

--- a/scripts/test/cloud-vitest-wrapper.test.sh
+++ b/scripts/test/cloud-vitest-wrapper.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Test: cloud-vitest-wrapper — verify vitest-cloud.sh exists, has correct
+# subcommands, flags, backend selection, and local/cloud dispatch.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT"
+
+SCRIPT="$ROOT/scripts/vitest-cloud.sh"
+
+FAILURES=0
+
+check() {
+  local desc="$1"
+  shift
+  if "$@"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "=== Cloud Vitest Wrapper Test ==="
+
+# Check 1: Script exists and is executable
+check "scripts/vitest-cloud.sh exists and is executable" test -x "$SCRIPT"
+
+# Check 2: help contains usage, run, --local, --cloud, FRESHELL_VITEST_BACKEND, --shards, --config
+HELP_OUTPUT=$(bash "$SCRIPT" help 2>&1 || true)
+for term in "usage" "run" "--local" "--cloud" "FRESHELL_VITEST_BACKEND" "--shards" "--config"; do
+  check "help contains '$term'" grep -qi -- "$term" <<< "$HELP_OUTPUT"
+done
+
+# Check 3: Default backend (unset env var) runs locally
+# Run with --local flag and a fast test to verify local execution works
+LOCAL_OUTPUT=$(FRESHELL_VITEST_BACKEND= bash "$SCRIPT" run --local --config=default test/unit/lib/pane-utils.test.ts 2>&1 || true)
+check "--local runs vitest locally" grep -q 'passed\|PASS\|Test Files' <<< "$LOCAL_OUTPUT"
+
+# Check 4: FRESHELL_VITEST_BACKEND=local runs locally
+LOCAL_ENV_OUTPUT=$(FRESHELL_VITEST_BACKEND=local bash "$SCRIPT" run --config=default test/unit/lib/pane-utils.test.ts 2>&1 || true)
+check "FRESHELL_VITEST_BACKEND=local runs locally" grep -q 'passed\|PASS\|Test Files' <<< "$LOCAL_ENV_OUTPUT"
+
+# Check 5: --cloud flag with fake gcloud — verify the wrapper calls gcloud
+FAKE_GCLOUD_DIR=$(mktemp -d)
+cat > "$FAKE_GCLOUD_DIR/gcloud" << 'FAKE'
+#!/usr/bin/env bash
+echo "FAKE_GCLOUD: $@" >> "${FAKE_GCLOUD_LOG:-/dev/null}"
+# Capture env-vars file content before it's deleted
+for i in "$@"; do
+  if [[ "$i" == --env-vars-file=* ]]; then
+    envfile="${i#--env-vars-file=}"
+    if [ -f "$envfile" ]; then
+      cp "$envfile" "${FAKE_GCLOUD_LOG}.envvars"
+    fi
+  fi
+done
+# For artifacts docker images describe, exit 0 (image exists)
+if [[ "$*" == *"artifacts docker images describe"* ]]; then
+  exit 0
+fi
+# For run jobs create/update/execute, exit 0
+if [[ "$*" == *"run jobs"* ]]; then
+  exit 0
+fi
+# For logs read, output something
+if [[ "$*" == *"logs read"* ]]; then
+  echo "Test Files  1 passed (1)"
+  exit 0
+fi
+# For executions describe
+if [[ "$*" == *"executions describe"* ]]; then
+  echo "1"
+  exit 0
+fi
+# For executions list
+if [[ "$*" == *"executions list"* ]]; then
+  echo "test-execution-1"
+  exit 0
+fi
+# For info (sdk_root)
+if [[ "$*" == *"info"* ]]; then
+  echo "/usr/lib/google-cloud-sdk"
+  exit 0
+fi
+exit 0
+FAKE
+chmod +x "$FAKE_GCLOUD_DIR/gcloud"
+
+export FAKE_GCLOUD_LOG="$FAKE_GCLOUD_DIR/gcloud.log"
+touch "$FAKE_GCLOUD_LOG"
+export PATH="$FAKE_GCLOUD_DIR:$PATH"
+
+CLOUD_OUTPUT=$(bash "$SCRIPT" run --cloud --config=default --shards=2 2>&1 || true)
+check "--cloud calls gcloud (fake)" grep -q 'FAKE_GCLOUD' "$FAKE_GCLOUD_LOG"
+check "--cloud references freshell-vitest job" grep -q 'freshell-vitest' "$FAKE_GCLOUD_LOG"
+
+# Check 6: --config=default sets VITEST_CONFIGS to only default config
+check "--config=default sets correct config" grep -q 'vitest.config.ts' "${FAKE_GCLOUD_LOG}.envvars"
+
+# Check 7: --config=server sets VITEST_CONFIGS to only server config
+rm -f "${FAKE_GCLOUD_LOG}.envvars"
+bash "$SCRIPT" run --cloud --config=server 2>&1 > /dev/null || true
+check "--config=server sets correct config" grep -q 'vitest.server.config.ts' "${FAKE_GCLOUD_LOG}.envvars"
+
+# Check 8: VITEST_ARGS_JSON is valid JSON when pass-through args are present
+rm -f "${FAKE_GCLOUD_LOG}.envvars"
+bash "$SCRIPT" run --cloud --config=default test/unit/lib/pane-utils.test.ts 2>&1 > /dev/null || true
+if [ -f "${FAKE_GCLOUD_LOG}.envvars" ]; then
+  VITEST_ARGS_VAL=$(grep 'VITEST_ARGS_JSON' "${FAKE_GCLOUD_LOG}.envvars" | sed "s/^VITEST_ARGS_JSON: '//;s/'\$//" || true)
+  if [ -n "$VITEST_ARGS_VAL" ]; then
+    check "VITEST_ARGS_JSON is valid JSON" bash -c "echo '$VITEST_ARGS_VAL' | jq -e '.' > /dev/null 2>&1"
+  else
+    echo "FAIL: VITEST_ARGS_JSON not found in env-vars file"
+    FAILURES=$((FAILURES + 1))
+  fi
+else
+  echo "FAIL: env-vars file not captured by fake gcloud"
+  FAILURES=$((FAILURES + 1))
+fi
+
+# Check 9: TEST_MODE=vitest is set in env-vars file
+if [ -f "${FAKE_GCLOUD_LOG}.envvars" ]; then
+  check "env-vars file sets TEST_MODE=vitest" grep -q 'TEST_MODE.*vitest' "${FAKE_GCLOUD_LOG}.envvars"
+else
+  echo "FAIL: env-vars file not available for TEST_MODE check"
+  FAILURES=$((FAILURES + 1))
+fi
+
+# Cleanup
+rm -rf "$FAKE_GCLOUD_DIR"
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "=== All checks passed ==="
+  exit 0
+else
+  echo "=== $FAILURES check(s) failed ==="
+  exit 1
+fi

--- a/scripts/test/cloud-vitest-wrapper.test.sh
+++ b/scripts/test/cloud-vitest-wrapper.test.sh
@@ -56,32 +56,38 @@ for i in "$@"; do
     fi
   fi
 done
-# For artifacts docker images describe, exit 0 (image exists)
+# More specific patterns first; catch-all run jobs last
 if [[ "$*" == *"artifacts docker images describe"* ]]; then
   exit 0
 fi
-# For run jobs create/update/execute, exit 0
-if [[ "$*" == *"run jobs"* ]]; then
+if [[ "$*" == *"artifacts repositories describe"* ]]; then
   exit 0
 fi
-# For logs read, output something
+if [[ "$*" == *"auth print-access-token"* ]]; then
+  echo "fake-token"
+  exit 0
+fi
+if [[ "$*" == *"info"* ]]; then
+  echo "/usr/lib/google-cloud-sdk"
+  exit 0
+fi
 if [[ "$*" == *"logs read"* ]]; then
   echo "Test Files  1 passed (1)"
   exit 0
 fi
-# For executions describe
 if [[ "$*" == *"executions describe"* ]]; then
   echo "1"
   exit 0
 fi
-# For executions list
 if [[ "$*" == *"executions list"* ]]; then
   echo "test-execution-1"
   exit 0
 fi
-# For info (sdk_root)
-if [[ "$*" == *"info"* ]]; then
-  echo "/usr/lib/google-cloud-sdk"
+if [[ "$*" == *"builds submit"* ]]; then
+  exit 0
+fi
+# Catch-all for run jobs create/update/execute
+if [[ "$*" == *"run jobs"* ]]; then
   exit 0
 fi
 exit 0
@@ -97,36 +103,39 @@ check "--cloud calls gcloud (fake)" grep -q 'FAKE_GCLOUD' "$FAKE_GCLOUD_LOG"
 check "--cloud references freshell-vitest job" grep -q 'freshell-vitest' "$FAKE_GCLOUD_LOG"
 
 # Check 6: --config=default sets VITEST_CONFIGS to only default config
-check "--config=default sets correct config" grep -q 'vitest.config.ts' "${FAKE_GCLOUD_LOG}.envvars"
+rm -f "$FAKE_GCLOUD_LOG"; touch "$FAKE_GCLOUD_LOG"
+bash "$SCRIPT" run --cloud --config=default 2>&1 > /dev/null || true
+check "--config=default sets correct config" grep -q 'vitest.config.ts' "$FAKE_GCLOUD_LOG"
 
 # Check 7: --config=server sets VITEST_CONFIGS to only server config
-rm -f "${FAKE_GCLOUD_LOG}.envvars"
+rm -f "$FAKE_GCLOUD_LOG"; touch "$FAKE_GCLOUD_LOG"
 bash "$SCRIPT" run --cloud --config=server 2>&1 > /dev/null || true
-check "--config=server sets correct config" grep -q 'vitest.server.config.ts' "${FAKE_GCLOUD_LOG}.envvars"
+check "--config=server sets correct config" grep -q 'vitest.server.config.ts' "$FAKE_GCLOUD_LOG"
 
 # Check 8: VITEST_ARGS_JSON is valid JSON when pass-through args are present
-rm -f "${FAKE_GCLOUD_LOG}.envvars"
+rm -f "$FAKE_GCLOUD_LOG"; touch "$FAKE_GCLOUD_LOG"
 bash "$SCRIPT" run --cloud --config=default test/unit/lib/pane-utils.test.ts 2>&1 > /dev/null || true
-if [ -f "${FAKE_GCLOUD_LOG}.envvars" ]; then
-  # Extract the YAML double-quoted value and unescape it to get the raw JSON
-  VITEST_ARGS_VAL=$(grep 'VITEST_ARGS_JSON' "${FAKE_GCLOUD_LOG}.envvars" | sed 's/^VITEST_ARGS_JSON: //' || true)
+# Extract VITEST_ARGS_JSON from the --update-env-vars flag in the gcloud log
+ENV_VARS_LINE=$(grep 'update-env-vars' "$FAKE_GCLOUD_LOG" | head -1 || true)
+if [ -n "$ENV_VARS_LINE" ]; then
+  # Extract the JSON array value after VITEST_ARGS_JSON= (non-greedy match for [...])
+  VITEST_ARGS_VAL=$(echo "$ENV_VARS_LINE" | grep -oP 'VITEST_ARGS_JSON=\K\[.*?\]' || true)
   if [ -n "$VITEST_ARGS_VAL" ]; then
-    # Use jq to parse the YAML double-quoted string back to raw JSON, then validate
-    check "VITEST_ARGS_JSON is valid JSON" bash -c "echo '$VITEST_ARGS_VAL' | jq -r . | jq -e '.' > /dev/null 2>&1"
+    check "VITEST_ARGS_JSON is valid JSON" bash -c "echo '$VITEST_ARGS_VAL' | jq -e '.' > /dev/null 2>&1"
   else
-    echo "FAIL: VITEST_ARGS_JSON not found in env-vars file"
+    echo "FAIL: VITEST_ARGS_JSON not found in --update-env-vars"
     FAILURES=$((FAILURES + 1))
   fi
 else
-  echo "FAIL: env-vars file not captured by fake gcloud"
+  echo "FAIL: --update-env-vars not found in fake gcloud log"
   FAILURES=$((FAILURES + 1))
 fi
 
-# Check 9: TEST_MODE=vitest is set in env-vars file
-if [ -f "${FAKE_GCLOUD_LOG}.envvars" ]; then
-  check "env-vars file sets TEST_MODE=vitest" grep -q 'TEST_MODE.*vitest' "${FAKE_GCLOUD_LOG}.envvars"
+# Check 9: TEST_MODE=vitest is set in --update-env-vars
+if [ -n "$ENV_VARS_LINE" ]; then
+  check "TEST_MODE=vitest set in --update-env-vars" grep -q 'TEST_MODE=vitest' <<< "$ENV_VARS_LINE"
 else
-  echo "FAIL: env-vars file not available for TEST_MODE check"
+  echo "FAIL: --update-env-vars not available for TEST_MODE check"
   FAILURES=$((FAILURES + 1))
 fi
 

--- a/scripts/vitest-cloud.sh
+++ b/scripts/vitest-cloud.sh
@@ -21,6 +21,7 @@
 #   --local           Run locally (overrides FRESHELL_VITEST_BACKEND)
 #   --cloud           Run on Cloud Run (overrides FRESHELL_VITEST_BACKEND)
 #   --build           Force image rebuild + push before running
+#   --local-build     Build locally with Docker instead of Cloud Build
 #   --shards=N        Number of parallel Cloud Run tasks (default: 4)
 #   --timeout=DURATION Cloud Run task timeout (default: 30m)
 #   --config=default|server|all  Which vitest configs to run (default: all)
@@ -87,6 +88,7 @@ Flags:
   --local           Run locally (overrides FRESHELL_VITEST_BACKEND)
   --cloud           Run on Cloud Run (overrides FRESHELL_VITEST_BACKEND)
   --build           Force image rebuild + push before running
+  --local-build     Build locally with Docker instead of Cloud Build
   --shards=N        Number of parallel Cloud Run tasks (default: 4)
   --timeout=DURATION Cloud Run task timeout (default: 30m)
   --config=default|server|all  Which vitest configs to run (default: all)
@@ -110,10 +112,35 @@ EOF
 # Subcommand: build
 # ---------------------------------------------------------------------------
 cmd_build() {
-  echo "[vitest-cloud] Building Docker image..."
-  docker build -f "$ROOT/docker/cloud-run/Dockerfile" -t "$IMAGE_LOCAL" "$ROOT"
-  echo "[vitest-cloud] Image built: $IMAGE_LOCAL"
-  cmd_push
+  local local_build=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --local-build)
+        local_build=true
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  if $local_build; then
+    echo "[vitest-cloud] Building Docker image locally..."
+    docker build -f "$ROOT/docker/cloud-run/Dockerfile" -t "$IMAGE_LOCAL" "$ROOT"
+    echo "[vitest-cloud] Image built: $IMAGE_LOCAL"
+    cmd_push
+  else
+    echo "[vitest-cloud] Building Docker image via Cloud Build..."
+    gcloud builds submit \
+      --config "$ROOT/docker/cloud-run/cloudbuild.yaml" \
+      --account="$GCP_ACCOUNT" \
+      --project="$GCP_PROJECT" \
+      --substitutions=_IMAGE="$IMAGE_REMOTE" \
+      "$ROOT"
+    echo "[vitest-cloud] Cloud Build complete: $IMAGE_REMOTE"
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/vitest-cloud.sh
+++ b/scripts/vitest-cloud.sh
@@ -54,9 +54,11 @@ ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Ensure gcloud's bin dir is on PATH (for docker-credential-gcloud used by
 # Docker when pushing to Artifact Registry).
-GCLOUD_BIN="$(gcloud info --format="value(installation.sdk_root)" 2>/dev/null)/bin"
-if [ -d "$GCLOUD_BIN" ] && ! echo "$PATH" | grep -q "$GCLOUD_BIN"; then
-  export PATH="$GCLOUD_BIN:$PATH"
+if command -v gcloud &>/dev/null; then
+  GCLOUD_BIN="$(gcloud info --format="value(installation.sdk_root)" 2>/dev/null)/bin"
+  if [ -d "$GCLOUD_BIN" ] && ! echo "$PATH" | grep -q "$GCLOUD_BIN"; then
+    export PATH="$GCLOUD_BIN:$PATH"
+  fi
 fi
 
 DEFAULT_CONFIGS="config/vitest/vitest.config.ts config/vitest/vitest.server.config.ts"
@@ -316,60 +318,56 @@ cmd_run() {
     vitest_args_json=$(printf '%s\n' "${vt_args[@]}" | jq -R . | jq -sc .)
   fi
 
-  # Build a YAML env-vars file for the Cloud Run Job.
-  # Use double-quoted YAML with proper escaping for the JSON value.
-  # jq -Rs produces a YAML-safe double-quoted string with all special chars escaped.
-  local vitest_args_yaml
-  vitest_args_yaml=$(echo "$vitest_args_json" | jq -Rs .)
-  local env_file
-  env_file=$(mktemp /tmp/vitest-env-vars.XXXXXX.yaml)
-  cat > "$env_file" <<ENVEOF
-TEST_MODE: "vitest"
-VITEST_CONFIGS: "$configs"
-VITEST_ARGS_JSON: $vitest_args_yaml
-ENVEOF
-
-  # Create or update the Cloud Run Job (create fails if it already exists,
-  # fall back to update).
+  # Ensure the job exists with the correct image (create fails if it already
+  # exists, fall back to update image only — NOT tasks/timeout/env, which are
+  # per-execution overrides passed to `execute` below to avoid racing with
+  # concurrent agents on the shared job).
   gcloud run jobs create $(gcloud_flags) "$GCP_JOB" \
     --image="$IMAGE_REMOTE" \
-    --tasks="$shards" \
-    --task-timeout="$timeout" \
     --max-retries=0 \
-    --env-vars-file="$env_file" \
     --memory=4Gi \
     --cpu=4 \
     2>/dev/null || \
   gcloud run jobs update $(gcloud_flags) "$GCP_JOB" \
     --image="$IMAGE_REMOTE" \
-    --tasks="$shards" \
-    --task-timeout="$timeout" \
     --max-retries=0 \
-    --env-vars-file="$env_file" \
     --memory=4Gi \
     --cpu=4
 
-  rm -f "$env_file"
-
-  # Execute the job and wait for completion.
-  # Capture the execution ID from the execute output to avoid a race with
-  # concurrent agents updating/executing the same shared job.
+  # Execute the job with per-execution overrides (tasks, timeout, env-vars).
+  # This avoids mutating the shared job with per-run state, preventing races
+  # with concurrent agents. Capture the execution ID from the output.
   echo "[vitest-cloud] Executing Cloud Run Job..."
   local execute_output
-  execute_output=$(gcloud run jobs execute $(gcloud_flags) "$GCP_JOB" --wait 2>&1) || true
+  local execute_exit=0
+  # Use ^@^ delimiter for --update-env-vars to handle commas in JSON arrays.
+  local env_overrides="^@^TEST_MODE=vitest@VITEST_CONFIGS=${configs}@VITEST_ARGS_JSON=${vitest_args_json}"
+  execute_output=$(gcloud run jobs execute $(gcloud_flags) "$GCP_JOB" \
+    --tasks="$shards" \
+    --task-timeout="$timeout" \
+    --update-env-vars="$env_overrides" \
+    --wait 2>&1) || execute_exit=$?
   echo "$execute_output"
 
   # Extract the execution ID from the execute output (format: "Execution NAME")
   local execution_id
   execution_id=$(echo "$execute_output" | grep -oP 'Execution \K[^ ]+' | head -1)
   if [ -z "$execution_id" ]; then
-    # Fallback: query the latest execution (may race with concurrent agents)
     echo "[vitest-cloud] WARNING: could not capture execution ID, falling back to latest"
     execution_id=$(gcloud run jobs executions list $(gcloud_flags) \
       --job="$GCP_JOB" \
       --sort-by="~metadata.creationTimestamp" \
       --format="value(name)" \
       --limit=1)
+  fi
+
+  # If execute itself failed, report and exit — don't mask with status queries.
+  if [ "$execute_exit" -ne 0 ]; then
+    echo "[vitest-cloud] Cloud Run Job execution failed (exit code $execute_exit)."
+    # Still fetch logs for debugging
+    echo "[vitest-cloud] Fetching logs..."
+    gcloud beta run jobs executions logs read $(gcloud_flags) "$execution_id" 2>/dev/null || true
+    exit 1
   fi
 
   # Fetch logs
@@ -385,13 +383,19 @@ ENVEOF
   echo "[vitest-cloud] Per-shard summary:"
   echo "$log_output" | grep -E '(\[vitest-entrypoint\]|Test Files|Tests )' || true
 
-  # Check execution status
+  # Check execution status — propagate query errors instead of normalizing to 0.
   local succeeded
   local failed
-  succeeded=$(gcloud run jobs executions describe $(gcloud_flags) "$execution_id" \
-    --format="value(status.succeededCount)" 2>/dev/null || echo "0")
-  failed=$(gcloud run jobs executions describe $(gcloud_flags) "$execution_id" \
-    --format="value(status.failedCount)" 2>/dev/null || echo "0")
+  if ! succeeded=$(gcloud run jobs executions describe $(gcloud_flags) "$execution_id" \
+    --format="value(status.succeededCount)" 2>/dev/null); then
+    echo "[vitest-cloud] ERROR: failed to query execution status"
+    exit 1
+  fi
+  if ! failed=$(gcloud run jobs executions describe $(gcloud_flags) "$execution_id" \
+    --format="value(status.failedCount)" 2>/dev/null); then
+    echo "[vitest-cloud] ERROR: failed to query execution status"
+    exit 1
+  fi
 
   # Normalize empty/null to 0
   succeeded="${succeeded:-0}"
@@ -413,7 +417,13 @@ ENVEOF
 # Subcommand: logs
 # ---------------------------------------------------------------------------
 cmd_logs() {
-  gcloud beta run jobs executions logs read $(gcloud_flags) "$GCP_JOB" "$@"
+  local execution_id
+  execution_id=$(gcloud run jobs executions list $(gcloud_flags) --job="$GCP_JOB" --sort-by="~metadata.creationTimestamp" --format="value(name)" --limit=1)
+  if [ -z "$execution_id" ]; then
+    echo "[vitest-cloud] No executions found for job $GCP_JOB"
+    exit 1
+  fi
+  gcloud beta run jobs executions logs read $(gcloud_flags) "$execution_id" "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -422,7 +432,7 @@ cmd_logs() {
 SUBCOMMAND="${1:-run}"
 case "$SUBCOMMAND" in
   run)
-    shift
+    if [ $# -gt 0 ]; then shift; fi
     cmd_run "$@"
     ;;
   build)

--- a/scripts/vitest-cloud.sh
+++ b/scripts/vitest-cloud.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+# vitest-cloud.sh — Cloud Run Jobs wrapper for Vitest unit/server tests.
+#
+# Usage:
+#   scripts/vitest-cloud.sh [subcommand] [flags] [vitest-args...]
+#
+# Subcommands:
+#   run       (default) Run vitest tests locally or on Cloud Run Jobs
+#   build     Build and push the Docker image to Artifact Registry
+#   push      Push an already-built image to Artifact Registry
+#   logs      Fetch logs from the latest Cloud Run Job execution
+#   help      Show this help message
+#
+# Backend selection:
+#   The FRESHELL_VITEST_BACKEND env var controls where tests run by default:
+#     - "local"  (default if unset): run locally via vitest
+#     - "cloud":                run on Google Cloud Run Jobs
+#   Override at invocation time with --local or --cloud.
+#
+# Flags:
+#   --local           Run locally (overrides FRESHELL_VITEST_BACKEND)
+#   --cloud           Run on Cloud Run (overrides FRESHELL_VITEST_BACKEND)
+#   --build           Force image rebuild + push before running
+#   --shards=N        Number of parallel Cloud Run tasks (default: 4)
+#   --timeout=DURATION Cloud Run task timeout (default: 30m)
+#   --config=default|server|all  Which vitest configs to run (default: all)
+#   --account=EMAIL   GCP account (default: FRESHELL_GCP_ACCOUNT env or dan@danshapiro.com)
+#   --project-id=ID   GCP project (default: FRESHELL_GCP_PROJECT env or misc-puttering-project)
+#   --region=REGION   GCP region (default: FRESHELL_GCP_REGION env or us-west1)
+#
+# Examples:
+#   scripts/vitest-cloud.sh run --local test/unit/lib/pane-utils.test.ts
+#   scripts/vitest-cloud.sh run --cloud --shards=4
+#   scripts/vitest-cloud.sh run --cloud --config=default --shards=2
+#   scripts/vitest-cloud.sh build
+#   scripts/vitest-cloud.sh help
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+GCP_ACCOUNT="${FRESHELL_GCP_ACCOUNT:-dan@danshapiro.com}"
+GCP_PROJECT="${FRESHELL_GCP_PROJECT:-misc-puttering-project}"
+GCP_REGION="${FRESHELL_GCP_REGION:-us-west1}"
+GCP_REPO="${FRESHELL_GCP_REPO:-freshell-e2e}"
+GCP_JOB="${FRESHELL_GCP_VITEST_JOB:-freshell-vitest}"
+
+IMAGE_LOCAL="freshell-e2e:latest"
+IMAGE_REMOTE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${GCP_REPO}/freshell-e2e:latest"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Ensure gcloud's bin dir is on PATH (for docker-credential-gcloud used by
+# Docker when pushing to Artifact Registry).
+GCLOUD_BIN="$(gcloud info --format="value(installation.sdk_root)" 2>/dev/null)/bin"
+if [ -d "$GCLOUD_BIN" ] && ! echo "$PATH" | grep -q "$GCLOUD_BIN"; then
+  export PATH="$GCLOUD_BIN:$PATH"
+fi
+
+DEFAULT_CONFIGS="config/vitest/vitest.config.ts config/vitest/vitest.server.config.ts"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+gcloud_flags() {
+  echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --region=${GCP_REGION}"
+}
+
+# gcloud artifacts commands use --location, not --region
+gcloud_artifacts_flags() {
+  echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --location=${GCP_REGION}"
+}
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/vitest-cloud.sh [subcommand] [flags] [vitest-args...]
+
+Subcommands:
+  run       (default) Run vitest tests locally or on Cloud Run Jobs
+  build     Build and push the Docker image to Artifact Registry
+  push      Push an already-built image to Artifact Registry
+  logs      Fetch logs from the latest Cloud Run Job execution
+  help      Show this help message
+
+Flags:
+  --local           Run locally (overrides FRESHELL_VITEST_BACKEND)
+  --cloud           Run on Cloud Run (overrides FRESHELL_VITEST_BACKEND)
+  --build           Force image rebuild + push before running
+  --shards=N        Number of parallel Cloud Run tasks (default: 4)
+  --timeout=DURATION Cloud Run task timeout (default: 30m)
+  --config=default|server|all  Which vitest configs to run (default: all)
+  --account=EMAIL   GCP account (default: dan@danshapiro.com)
+  --project-id=ID   GCP project (default: misc-puttering-project)
+  --region=REGION   GCP region (default: us-west1)
+
+Environment:
+  FRESHELL_VITEST_BACKEND  "local" (default) or "cloud"
+
+Examples:
+  scripts/vitest-cloud.sh run --local test/unit/lib/pane-utils.test.ts
+  scripts/vitest-cloud.sh run --cloud --shards=4
+  scripts/vitest-cloud.sh run --cloud --config=default --shards=2
+  scripts/vitest-cloud.sh build
+  scripts/vitest-cloud.sh help
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: build
+# ---------------------------------------------------------------------------
+cmd_build() {
+  echo "[vitest-cloud] Building Docker image..."
+  docker build -f "$ROOT/docker/cloud-run/Dockerfile" -t "$IMAGE_LOCAL" "$ROOT"
+  echo "[vitest-cloud] Image built: $IMAGE_LOCAL"
+  cmd_push
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: push
+# ---------------------------------------------------------------------------
+cmd_push() {
+  echo "[vitest-cloud] Pushing to Artifact Registry..."
+
+  # Ensure the Artifact Registry repo exists
+  if ! gcloud artifacts repositories describe $(gcloud_artifacts_flags) "$GCP_REPO" &>/dev/null; then
+    echo "[vitest-cloud] Creating Artifact Registry repository: $GCP_REPO"
+    gcloud artifacts repositories create $(gcloud_artifacts_flags) "$GCP_REPO" \
+      --repository-format=docker || true
+  fi
+
+  # Authenticate Docker to Artifact Registry using an access token.
+  gcloud auth print-access-token --account="$GCP_ACCOUNT" | \
+    docker login -u oauth2accesstoken --password-stdin \
+      "https://${GCP_REGION}-docker.pkg.dev"
+
+  docker tag "$IMAGE_LOCAL" "$IMAGE_REMOTE"
+  docker push "$IMAGE_REMOTE"
+  echo "[vitest-cloud] Pushed: $IMAGE_REMOTE"
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: run
+# ---------------------------------------------------------------------------
+cmd_run() {
+  local local_mode=false
+  local cloud_mode=false
+  local force_build=false
+  local shards=4
+  local timeout="30m"
+  local config_selector="all"
+  local -a vt_args=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --local)
+        local_mode=true
+        shift
+        ;;
+      --cloud)
+        cloud_mode=true
+        shift
+        ;;
+      --build)
+        force_build=true
+        shift
+        ;;
+      --shards=*)
+        shards="${1#*=}"
+        shift
+        ;;
+      --timeout=*)
+        timeout="${1#*=}"
+        shift
+        ;;
+      --config=*)
+        config_selector="${1#*=}"
+        shift
+        ;;
+      --account=*)
+        GCP_ACCOUNT="${1#*=}"
+        shift
+        ;;
+      --project-id=*)
+        GCP_PROJECT="${1#*=}"
+        shift
+        ;;
+      --region=*)
+        GCP_REGION="${1#*=}"
+        shift
+        ;;
+      *)
+        vt_args+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  # Resolve configs based on selector
+  local configs
+  case "$config_selector" in
+    default)
+      configs="config/vitest/vitest.config.ts"
+      ;;
+    server)
+      configs="config/vitest/vitest.server.config.ts"
+      ;;
+    all)
+      configs="$DEFAULT_CONFIGS"
+      ;;
+    *)
+      echo "[vitest-cloud] Unknown --config value: $config_selector (expected default|server|all)"
+      exit 1
+      ;;
+  esac
+
+  # Resolve backend: explicit flags override env var; env var defaults to local.
+  if $cloud_mode; then
+    local_mode=false
+  elif $local_mode; then
+    : # local_mode already true
+  elif [ "${FRESHELL_VITEST_BACKEND:-local}" = "cloud" ]; then
+    cloud_mode=true
+  else
+    local_mode=true
+  fi
+
+  if $local_mode; then
+    echo "[vitest-cloud] Running locally..."
+    cd "$ROOT"
+    local exit_code=0
+    for config in $configs; do
+      echo "[vitest-cloud] Running vitest: $config ${vt_args[*]-}"
+      npx vitest run --passWithNoTests --config "$config" "${vt_args[@]+"${vt_args[@]}"}" || exit_code=$?
+    done
+    exit "$exit_code"
+  fi
+
+  # Recompute IMAGE_REMOTE with potentially overridden GCP settings
+  IMAGE_REMOTE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${GCP_REPO}/freshell-e2e:latest"
+
+  # Cloud mode
+  if $force_build; then
+    cmd_build
+  fi
+
+  # Ensure image exists in remote registry
+  if ! gcloud artifacts docker images describe "$IMAGE_REMOTE" \
+      --account="$GCP_ACCOUNT" --project="$GCP_PROJECT" &>/dev/null 2>&1; then
+    echo "[vitest-cloud] Remote image not found, building and pushing..."
+    cmd_build
+  fi
+
+  echo "[vitest-cloud] Running on Cloud Run Jobs..."
+  echo "[vitest-cloud]   Image:   $IMAGE_REMOTE"
+  echo "[vitest-cloud]   Shards:  $shards"
+  echo "[vitest-cloud]   Timeout: $timeout"
+  echo "[vitest-cloud]   Configs: $configs"
+  echo "[vitest-cloud]   Args:    ${vt_args[*]-}"
+
+  # Build VITEST_ARGS_JSON (JSON array) from pass-through args.
+  # Handle empty args correctly (printf with no args produces [""], not []).
+  local vitest_args_json="[]"
+  if [ ${#vt_args[@]} -gt 0 ]; then
+    vitest_args_json=$(printf '%s\n' "${vt_args[@]}" | jq -R . | jq -sc .)
+  fi
+
+  # Build a YAML env-vars file for the Cloud Run Job.
+  # Single-quote JSON values to avoid YAML double-quote escaping issues.
+  local env_file
+  env_file=$(mktemp /tmp/vitest-env-vars.XXXXXX.yaml)
+  cat > "$env_file" <<ENVEOF
+TEST_MODE: "vitest"
+VITEST_CONFIGS: "$configs"
+VITEST_ARGS_JSON: '$vitest_args_json'
+ENVEOF
+
+  # Create or update the Cloud Run Job (create fails if it already exists,
+  # fall back to update).
+  gcloud run jobs create $(gcloud_flags) "$GCP_JOB" \
+    --image="$IMAGE_REMOTE" \
+    --tasks="$shards" \
+    --task-timeout="$timeout" \
+    --max-retries=0 \
+    --env-vars-file="$env_file" \
+    --memory=4Gi \
+    --cpu=4 \
+    2>/dev/null || \
+  gcloud run jobs update $(gcloud_flags) "$GCP_JOB" \
+    --image="$IMAGE_REMOTE" \
+    --tasks="$shards" \
+    --task-timeout="$timeout" \
+    --max-retries=0 \
+    --env-vars-file="$env_file" \
+    --memory=4Gi \
+    --cpu=4
+
+  rm -f "$env_file"
+
+  # Execute the job and wait for completion
+  echo "[vitest-cloud] Executing Cloud Run Job..."
+  gcloud run jobs execute $(gcloud_flags) "$GCP_JOB" --wait
+
+  # Get the latest execution name
+  local execution_id
+  execution_id=$(gcloud run jobs executions list $(gcloud_flags) \
+    --job="$GCP_JOB" \
+    --sort-by="~metadata.creationTimestamp" \
+    --format="value(name)" \
+    --limit=1)
+
+  # Fetch logs
+  echo "[vitest-cloud] Fetching logs..."
+  local log_output
+  log_output=$(gcloud beta run jobs executions logs read $(gcloud_flags) "$execution_id" 2>/dev/null || true)
+
+  # Print full log output from ALL shards.
+  echo "$log_output"
+
+  # Extract and display a per-shard summary from the vitest output.
+  echo ""
+  echo "[vitest-cloud] Per-shard summary:"
+  echo "$log_output" | grep -E '(\[vitest-entrypoint\]|Test Files|Tests )' || true
+
+  # Check execution status
+  local succeeded
+  local failed
+  succeeded=$(gcloud run jobs executions describe $(gcloud_flags) "$execution_id" \
+    --format="value(status.succeededCount)" 2>/dev/null || echo "0")
+  failed=$(gcloud run jobs executions describe $(gcloud_flags) "$execution_id" \
+    --format="value(status.failedCount)" 2>/dev/null || echo "0")
+
+  # Normalize empty/null to 0
+  succeeded="${succeeded:-0}"
+  failed="${failed:-0}"
+
+  echo ""
+  echo "[vitest-cloud] Succeeded tasks: $succeeded"
+  echo "[vitest-cloud] Failed tasks: $failed"
+
+  if [ "$failed" -gt 0 ] 2>/dev/null; then
+    echo "[vitest-cloud] Some tasks failed."
+    exit 1
+  fi
+
+  echo "[vitest-cloud] All tasks completed successfully."
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: logs
+# ---------------------------------------------------------------------------
+cmd_logs() {
+  gcloud beta run jobs executions logs read $(gcloud_flags) "$GCP_JOB" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Main dispatch
+# ---------------------------------------------------------------------------
+SUBCOMMAND="${1:-run}"
+case "$SUBCOMMAND" in
+  run)
+    shift
+    cmd_run "$@"
+    ;;
+  build)
+    shift
+    cmd_build "$@"
+    ;;
+  push)
+    shift
+    cmd_push "$@"
+    ;;
+  logs)
+    shift
+    cmd_logs "$@"
+    ;;
+  help|--help|-h)
+    usage
+    ;;
+  *)
+    # If first arg is a flag, treat as `run` with that flag
+    cmd_run "$SUBCOMMAND" "${@:2}"
+    ;;
+esac

--- a/scripts/vitest-cloud.sh
+++ b/scripts/vitest-cloud.sh
@@ -120,11 +120,26 @@ cmd_build() {
         local_build=true
         shift
         ;;
+      --account=*)
+        GCP_ACCOUNT="${1#*=}"
+        shift
+        ;;
+      --project-id=*)
+        GCP_PROJECT="${1#*=}"
+        shift
+        ;;
+      --region=*)
+        GCP_REGION="${1#*=}"
+        shift
+        ;;
       *)
         shift
         ;;
     esac
   done
+
+  # Recompute IMAGE_REMOTE with potentially overridden GCP settings
+  IMAGE_REMOTE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${GCP_REPO}/freshell-e2e:latest"
 
   if $local_build; then
     echo "[vitest-cloud] Building Docker image locally..."
@@ -173,6 +188,7 @@ cmd_run() {
   local local_mode=false
   local cloud_mode=false
   local force_build=false
+  local local_build_flag=false
   local shards=4
   local timeout="30m"
   local config_selector="all"
@@ -190,6 +206,10 @@ cmd_run() {
         ;;
       --build)
         force_build=true
+        shift
+        ;;
+      --local-build)
+        local_build_flag=true
         shift
         ;;
       --shards=*)
@@ -268,7 +288,11 @@ cmd_run() {
 
   # Cloud mode
   if $force_build; then
-    cmd_build
+    if $local_build_flag; then
+      cmd_build --local-build
+    else
+      cmd_build
+    fi
   fi
 
   # Ensure image exists in remote registry
@@ -293,13 +317,16 @@ cmd_run() {
   fi
 
   # Build a YAML env-vars file for the Cloud Run Job.
-  # Single-quote JSON values to avoid YAML double-quote escaping issues.
+  # Use double-quoted YAML with proper escaping for the JSON value.
+  # jq -Rs produces a YAML-safe double-quoted string with all special chars escaped.
+  local vitest_args_yaml
+  vitest_args_yaml=$(echo "$vitest_args_json" | jq -Rs .)
   local env_file
   env_file=$(mktemp /tmp/vitest-env-vars.XXXXXX.yaml)
   cat > "$env_file" <<ENVEOF
 TEST_MODE: "vitest"
 VITEST_CONFIGS: "$configs"
-VITEST_ARGS_JSON: '$vitest_args_json'
+VITEST_ARGS_JSON: $vitest_args_yaml
 ENVEOF
 
   # Create or update the Cloud Run Job (create fails if it already exists,
@@ -324,17 +351,26 @@ ENVEOF
 
   rm -f "$env_file"
 
-  # Execute the job and wait for completion
+  # Execute the job and wait for completion.
+  # Capture the execution ID from the execute output to avoid a race with
+  # concurrent agents updating/executing the same shared job.
   echo "[vitest-cloud] Executing Cloud Run Job..."
-  gcloud run jobs execute $(gcloud_flags) "$GCP_JOB" --wait
+  local execute_output
+  execute_output=$(gcloud run jobs execute $(gcloud_flags) "$GCP_JOB" --wait 2>&1) || true
+  echo "$execute_output"
 
-  # Get the latest execution name
+  # Extract the execution ID from the execute output (format: "Execution NAME")
   local execution_id
-  execution_id=$(gcloud run jobs executions list $(gcloud_flags) \
-    --job="$GCP_JOB" \
-    --sort-by="~metadata.creationTimestamp" \
-    --format="value(name)" \
-    --limit=1)
+  execution_id=$(echo "$execute_output" | grep -oP 'Execution \K[^ ]+' | head -1)
+  if [ -z "$execution_id" ]; then
+    # Fallback: query the latest execution (may race with concurrent agents)
+    echo "[vitest-cloud] WARNING: could not capture execution ID, falling back to latest"
+    execution_id=$(gcloud run jobs executions list $(gcloud_flags) \
+      --job="$GCP_JOB" \
+      --sort-by="~metadata.creationTimestamp" \
+      --format="value(name)" \
+      --limit=1)
+  fi
 
   # Fetch logs
   echo "[vitest-cloud] Fetching logs..."


### PR DESCRIPTION
## Summary

Move Vitest unit/server tests and Docker image builds to Google Cloud Run Jobs and Cloud Build, reducing validation from ~5 min to ~2 min.

- **CLOUD-1**: Vitest on Cloud Run Jobs (4 shards, same infra as Playwright e2e)
- **CLOUD-2**: Cloud Build for Docker image builds (avoids 17-30 min local builds)

## Key changes

| Component | Files | Purpose |
|-----------|-------|---------|
| Test infra | `entrypoint.sh`, `.dockerignore`, `Dockerfile` | `TEST_MODE=vitest` branch, NODE_PATH resolution, `USER node` security |
| Cloud wrapper | `scripts/vitest-cloud.sh` | Cloud Run Jobs execution, log polling, shard pass/fail analysis |
| Integration | `scripts/test/run-standard-tests.ts`, `package.json` | `test:vitest` cloud/local dispatch, npm scripts |
| Docker build | `cloudbuild.yaml`, `.gcloudignore`, `--local-build` flag | Cloud Build with buildx mode=max cache |
| Tests | `scripts/test/cloud-*.test.sh` (4 files) | Wrapper, integration, build, Dockerfile consistency |

## Metrics (all targets met)

| Metric | Target | Actual |
|--------|--------|--------|
| Cloud vitest wall time | <3 min | **2M33S** |
| Cloud Build cold | <15 min | **7M39S** |
| Cloud Build warm | <5 min | **4M51S** |

## Test plan
- [x] All 4 cloud test suites pass locally
- [x] Cloud vitest smoke test on Cloud Run Jobs
- [x] Cloud Build smoke test (cold + warm)
- [x] Delta review (2 rounds, 13 findings addressed)

## Known issue
`fresh-agent-pane-migration.test.ts` fails in container (vitest 3.2.4 vs 3.2.7 lockfile mismatch). Pre-existing, being fixed in a follow-up PR.