### PR TITLE
fix(context-menu): restore pane header targeting

### DIFF
--- a/src/components/context-menu/context-menu-utils.ts
+++ b/src/components/context-menu/context-menu-utils.ts
@@ -67,6 +67,10 @@ export function parseContextTarget(contextId: ContextId, data: ContextDataset): 
       return data.tabId && data.paneId
         ? { kind: 'pane', tabId: data.tabId, paneId: data.paneId }
         : null
+    case ContextIds.PaneHeader:
+      return data.tabId && data.paneId
+        ? { kind: 'pane', tabId: data.tabId, paneId: data.paneId }
+        : null
     case ContextIds.PaneDivider:
       return data.tabId && data.splitId
         ? { kind: 'pane-divider', tabId: data.tabId, splitId: data.splitId }

--- a/src/components/panes/PaneHeader.tsx
+++ b/src/components/panes/PaneHeader.tsx
@@ -126,6 +126,8 @@ export default function PaneHeader({
           : isActive ? 'bg-muted' : 'bg-muted/50 text-muted-foreground'
       )}
       data-context={ContextIds.PaneHeader}
+      data-tab-id={tabId}
+      data-pane-id={paneId}
       onDoubleClick={isRenaming ? undefined : onDoubleClick}
       role="banner"
       aria-label={`Pane: ${title}`}

--- a/test/unit/client/components/context-menu/context-menu-utils.test.ts
+++ b/test/unit/client/components/context-menu/context-menu-utils.test.ts
@@ -54,6 +54,35 @@ describe('parseContextTarget', () => {
     expect(result).toEqual({ kind: 'tab', tabId: 'tab-1' })
   })
 
+  it('parseContextTarget for PaneHeader returns the exact pane target', () => {
+    const result = parseContextTarget(ContextIds.PaneHeader, {
+      tabId: 'tab-header',
+      paneId: 'pane-header',
+    })
+
+    expect(result).toEqual({
+      kind: 'pane',
+      tabId: 'tab-header',
+      paneId: 'pane-header',
+    })
+  })
+
+  it('parseContextTarget for PaneHeader returns null when tabId is missing', () => {
+    const result = parseContextTarget(ContextIds.PaneHeader, {
+      paneId: 'pane-header',
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('parseContextTarget for PaneHeader returns null when paneId is missing', () => {
+    const result = parseContextTarget(ContextIds.PaneHeader, {
+      tabId: 'tab-header',
+    })
+
+    expect(result).toBeNull()
+  })
+
   it('parseContextTarget for FreshAgent preserves pane and session flavor identity', () => {
     const result = parseContextTarget(ContextIds.FreshAgent, {
       tabId: 'tab-1',

--- a/test/unit/client/components/panes/PaneHeader.test.tsx
+++ b/test/unit/client/components/panes/PaneHeader.test.tsx
@@ -137,6 +137,25 @@ describe('PaneHeader', () => {
       expect(screen.getByText('My Terminal')).toBeInTheDocument()
     })
 
+    it('renders its pane-header context marker and exact pane identity', () => {
+      render(
+        <PaneHeader
+          tabId="tab-header"
+          paneId="pane-header"
+          title="My Terminal"
+          status="running"
+          isActive={true}
+          onClose={vi.fn()}
+          content={makeTerminalContent()}
+        />
+      )
+
+      const header = screen.getByRole('banner', { name: 'Pane: My Terminal' })
+      expect(header).toHaveAttribute('data-context', 'pane-header')
+      expect(header).toHaveAttribute('data-tab-id', 'tab-header')
+      expect(header).toHaveAttribute('data-pane-id', 'pane-header')
+    })
+
     it('renders status indicator', () => {
       render(
         <PaneHeader


### PR DESCRIPTION
## Summary

- restore pane-specific context menus for right-click and primary-button context gestures on pane headers
- preserve `data-context="pane-header"`, add exact tab/pane identity, and resolve pane headers through the existing pane target
- add direct parser and rendered-attribute coverage, including safe handling of missing identity fields

## Root cause

The pane-header marker stopped context lookup at the header, but the parser did not recognize that marker and the header carried no tab or pane IDs. Parsing therefore returned no pane target and the provider fell back to the global application menu.

## Test plan

- [x] Reproduced on `main`: `pane-context-menu-stability` reported 2 failed and 4 passed
- [x] Focused fixed behavior: 84 passed
- [x] Related and new unit coverage: 149 passed
- [x] `npm run typecheck`: passed
- [x] `npm run lint`: passed with 0 errors (11 unrelated existing warnings)
- [x] `npm run test:e2e:a11y-gate:deny`: passed
- [x] Fresh `npm run check`: passed
  - client: 5,019 passed; 8 skipped
  - server: 4,924 passed; 29 skipped
  - electron: 350 passed
- [x] Earlier broad-run deadline flakes were rechecked: all three tests passed together and in three repeated focused runs before the fresh full pass

Generated with [Amplifier](https://github.com/microsoft/amplifier)
