### PR TITLE
fix(sessions): restore session delete on the rust server (soft delete + visible failures)

### DIFF
--- a/crates/freshell-server/src/sessions.rs
+++ b/crates/freshell-server/src/sessions.rs
@@ -1,6 +1,7 @@
 //! `/api/sessions/:sessionId` — session rename/archive/delete overrides and
 //! AI/first-message title generation. Faithful port of the write half of
-//! `server/sessions-router.ts` (`PATCH` :122-165, `POST generate-title` :167-210),
+//! `server/sessions-router.ts` (`PATCH` :122-165, `DELETE` :243-251,
+//! `POST generate-title` :167-210),
 //! backed by `SettingsStore::patch_session_override`. The REVERSE terminal-cascade
 //! rename (`cascadeSessionRenameToTerminal`, `rename-cascade.ts:39-50`) IS
 //! implemented in `patch_session` below: a rename of a session currently running
@@ -77,10 +78,13 @@ pub struct SessionsState {
     pub index: Option<Arc<freshell_sessions::directory_index::SessionIndex>>,
 }
 
-/// The sessions sub-router (`PATCH /api/sessions/:id` + `POST .../generate-title`).
+/// The sessions sub-router (`PATCH`/`DELETE /api/sessions/:id` + `POST .../generate-title`).
 pub fn router(state: SessionsState) -> Router {
     Router::new()
-        .route("/api/sessions/{session_id}", patch(patch_session))
+        .route(
+            "/api/sessions/{session_id}",
+            patch(patch_session).delete(delete_session),
+        )
         .route(
             "/api/sessions/{session_id}/generate-title",
             post(generate_title),
@@ -219,6 +223,32 @@ async fn patch_session(
     }
 
     Json(Value::Object(out)).into_response()
+}
+
+/// `DELETE /api/sessions/:sessionId` — the Node soft delete
+/// (`sessions-router.ts:243-251`): a single-key `{deleted:true}` override
+/// patch (`configStore.deleteSession` → `patch_session_override`; existing
+/// title/summary overrides survive), then a direct `sessions.changed`
+/// broadcast (the route's counterpart to the Node route's
+/// `codingCliIndexer.refresh()` — the directory sweep is blind to
+/// override-only changes, GAP-1). Always `{ok:true}` — no 404 for unknown
+/// ids, matching the Node route exactly.
+async fn delete_session(
+    State(state): State<SessionsState>,
+    AxumPath(raw_id): AxumPath<String>,
+    Query(q): Query<std::collections::HashMap<String, String>>,
+    headers: HeaderMap,
+) -> Response {
+    if !is_authed(&headers, &state.auth_token) {
+        return unauthorized();
+    }
+    let key = composite_key(&raw_id, &provider_of(&q));
+    state
+        .settings
+        .patch_session_override(&key, &[("deleted", Some(Value::Bool(true)))])
+        .await;
+    broadcast_sessions_changed_from(&state);
+    Json(json!({ "ok": true })).into_response()
 }
 
 /// The one `sessions.changed` emit site (revision bump + frame send), factored

--- a/crates/freshell-server/src/sessions_tests.rs
+++ b/crates/freshell-server/src/sessions_tests.rs
@@ -600,6 +600,298 @@ async fn patch_override_is_visible_through_session_directory_overlay() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+// ── DELETE /api/sessions/:sessionId (soft delete, sessions-router.ts:243-251) ──
+
+/// Node parity: `router.delete('/sessions/:sessionId')` requires the same
+/// token gate as PATCH — an unauthenticated DELETE never reaches the store.
+#[tokio::test]
+async fn delete_requires_auth() {
+    let dir = std::env::temp_dir().join(format!("frs-sess-router-{}", uuid_like()));
+    std::fs::create_dir_all(dir.join(".freshell")).unwrap();
+    let app = super::router(state(&dir));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/sessions/abc123?provider=claude")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The core soft-delete write: a single-key `{deleted:true}` override patch
+/// (`configStore.deleteSession`) lands on disk under the composite key, the
+/// response is exactly `{"ok":true}`, and no provider `.jsonl` is touched.
+#[tokio::test]
+async fn delete_persists_soft_delete_override_and_returns_ok() {
+    let dir = std::env::temp_dir().join(format!("frs-sess-router-{}", uuid_like()));
+    std::fs::create_dir_all(dir.join(".freshell")).unwrap();
+    let app = super::router(state(&dir));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/sessions/del-me?provider=claude")
+                .header("x-auth-token", "tok")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v, serde_json::json!({ "ok": true }));
+    let cfg: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(dir.join(".freshell").join("config.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        cfg["sessionOverrides"]["claude:del-me"]["deleted"],
+        serde_json::json!(true)
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Node parity: the route NEVER 404s — an unknown id just writes a harmless
+/// tombstone override and still answers `{"ok":true}`.
+#[tokio::test]
+async fn delete_unknown_session_returns_ok_tombstone() {
+    let dir = std::env::temp_dir().join(format!("frs-sess-router-{}", uuid_like()));
+    std::fs::create_dir_all(dir.join(".freshell")).unwrap();
+    let app = super::router(state(&dir));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/sessions/no-such-session?provider=claude")
+                .header("x-auth-token", "tok")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v, serde_json::json!({ "ok": true }));
+    let cfg: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(dir.join(".freshell").join("config.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        cfg["sessionOverrides"]["claude:no-such-session"]["deleted"],
+        serde_json::json!(true)
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Key shaping: axum percent-decodes the path param BEFORE we see it, so an
+/// already-composite `codex%3Axyz` passes through verbatim, while a BARE id
+/// gets the `?provider=` prefix — same ladder as `composite_key` for PATCH.
+#[tokio::test]
+async fn delete_decodes_composite_key_and_prefixes_bare_ids() {
+    let dir = std::env::temp_dir().join(format!("frs-sess-router-{}", uuid_like()));
+    std::fs::create_dir_all(dir.join(".freshell")).unwrap();
+    let app = super::router(state(&dir));
+    for uri in [
+        "/api/sessions/codex%3Axyz",
+        "/api/sessions/plain-id?provider=codex",
+    ] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(uri)
+                    .header("x-auth-token", "tok")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "DELETE {uri}");
+    }
+    let cfg: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(dir.join(".freshell").join("config.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        cfg["sessionOverrides"]["codex:xyz"]["deleted"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        cfg["sessionOverrides"]["codex:plain-id"]["deleted"],
+        serde_json::json!(true)
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// GAP-1 twin of the archive test: a delete is an override-only,
+/// sidebar-visible change the directory sweep is blind to, so the route must
+/// broadcast `sessions.changed` directly — and successive deletes must bump
+/// the SHARED counter (monotonic, not reset per request).
+#[tokio::test]
+async fn delete_broadcasts_sessions_changed_and_revision_is_monotonic() {
+    let dir = std::env::temp_dir().join(format!("frs-sess-router-{}", uuid_like()));
+    std::fs::create_dir_all(dir.join(".freshell")).unwrap();
+    let st = state(&dir);
+    let mut broadcast_rx = st.broadcast_tx.subscribe();
+    let app = super::router(st.clone());
+
+    for uri in [
+        "/api/sessions/abc123?provider=claude",
+        "/api/sessions/def456?provider=claude",
+    ] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(uri)
+                    .header("x-auth-token", "tok")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "DELETE {uri}");
+    }
+
+    let first_frame = broadcast_rx
+        .try_recv()
+        .expect("sessions.changed broadcast fired for the first delete");
+    let first_frame: serde_json::Value = serde_json::from_str(&first_frame).unwrap();
+    assert_eq!(first_frame["type"], serde_json::json!("sessions.changed"));
+    let first_revision = first_frame["revision"].as_i64().unwrap();
+    let second_frame = broadcast_rx
+        .try_recv()
+        .expect("sessions.changed broadcast fired for the second delete");
+    let second_frame: serde_json::Value = serde_json::from_str(&second_frame).unwrap();
+    let second_revision = second_frame["revision"].as_i64().unwrap();
+    assert!(
+        second_revision > first_revision,
+        "revision must strictly increase across successive deletes"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Round-trip through the READ model: a session visible in the directory
+/// disappears after a DELETE through THIS router because the overlay
+/// (`apply_session_overrides`, session_directory.rs) filters `deleted:true`
+/// rows — and the underlying index/jsonl are untouched.
+#[tokio::test]
+async fn deleted_session_disappears_from_session_directory_overlay() {
+    let home = std::env::temp_dir().join(format!("frs-sess-router-{}", uuid_like()));
+    let project = home.join(".claude").join("projects").join("-tmp-proj");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(home.join(".freshell")).unwrap();
+    // Same discovery-safe shape as the overlay donor above: `cwd`-bearing,
+    // two user messages (survives the default `isNonInteractive` filter).
+    let content = [
+        r#"{"cwd":"/tmp/proj","sessionId":"healthy-session-id","type":"user","message":{"role":"user","content":"first prompt"},"timestamp":"2025-01-30T10:00:00.000Z"}"#,
+        r#"{"cwd":"/tmp/proj","sessionId":"healthy-session-id","type":"assistant","message":{"role":"assistant","content":"ack"},"timestamp":"2025-01-30T10:00:01.000Z"}"#,
+        r#"{"cwd":"/tmp/proj","sessionId":"healthy-session-id","type":"user","message":{"role":"user","content":"second prompt"},"timestamp":"2025-01-30T10:00:02.000Z"}"#,
+    ]
+    .join("\n");
+    std::fs::write(project.join("healthy-session-id.jsonl"), content).unwrap();
+
+    let settings = crate::settings_store::SettingsStore::load(Some(&home), vec!["claude".into()]);
+    let auth_token: std::sync::Arc<String> = std::sync::Arc::new("tok".into());
+    let (tx, _rx) = tokio::sync::broadcast::channel::<String>(16);
+    let sessions_app = super::router(super::SessionsState {
+        auth_token: std::sync::Arc::clone(&auth_token),
+        settings: settings.clone(),
+        identity: freshell_ws::identity::TerminalIdentityRegistry::new(),
+        registry: freshell_terminal::TerminalRegistry::new(),
+        broadcast_tx: std::sync::Arc::new(tx),
+        terminals_revision: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0)),
+        sessions_revision: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0)),
+        ai_key: crate::ai_title::AiKeyCell::init(None, None),
+        gemini: std::sync::Arc::new(FakeGemini(Err("unused in default test state".into()))),
+        index: None,
+    });
+    let session_index =
+        std::sync::Arc::new(freshell_sessions::directory_index::SessionIndex::new(vec![
+            std::sync::Arc::new(freshell_sessions::directory_index::ClaudeSource::new(
+                crate::session_directory::claude_home(&home),
+            )) as std::sync::Arc<dyn freshell_sessions::directory_index::SessionSource>,
+        ]));
+    let dir_app =
+        crate::session_directory::router(crate::session_directory::SessionDirectoryState {
+            auth_token: std::sync::Arc::clone(&auth_token),
+            settings,
+            session_index: Some(session_index),
+            identity: freshell_ws::identity::TerminalIdentityRegistry::new(),
+            metadata: crate::session_metadata::SessionMetadataStore::new(home.join(".freshell")),
+        });
+
+    // Present BEFORE the delete.
+    let before_resp = dir_app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/session-directory?priority=visible")
+                .header("x-auth-token", "tok")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(before_resp.status(), StatusCode::OK);
+    let before = body_json(before_resp).await;
+    let items = before["items"].as_array().unwrap();
+    assert!(
+        items
+            .iter()
+            .any(|i| i["sessionId"] == serde_json::json!("healthy-session-id")),
+        "seeded session must be visible before DELETE"
+    );
+
+    // Soft-delete through the sessions router.
+    let del_resp = sessions_app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/sessions/healthy-session-id?provider=claude")
+                .header("x-auth-token", "tok")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(del_resp.status(), StatusCode::OK);
+
+    // Gone AFTER the delete — and the source .jsonl is still on disk, since
+    // a soft delete only writes the override.
+    let after_resp = dir_app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/session-directory?priority=visible")
+                .header("x-auth-token", "tok")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(after_resp.status(), StatusCode::OK);
+    let after = body_json(after_resp).await;
+    let items = after["items"].as_array().unwrap();
+    assert!(
+        items
+            .iter()
+            .all(|i| i["sessionId"] != serde_json::json!("healthy-session-id")),
+        "deleted session must be filtered from the directory, got {items:?}"
+    );
+    assert!(project.join("healthy-session-id.jsonl").exists());
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// Same 4-line fake as `auto_title_sweep`'s test transport: the wired-in
 /// result IS the Gemini reply. NO live Gemini calls in tests, ever.
 struct FakeGemini(Result<String, String>);

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -48,6 +48,7 @@ export default function HistoryView({ onOpenSession }: { onOpenSession?: () => v
   const [filter, setFilter] = useState('')
   const [loading, setLoading] = useState(false)
   const [mobileSessionSheet, setMobileSessionSheet] = useState<MobileSessionSheetState | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
 
   useEffect(() => {
     if (historyWindow || topLevelSessionCount > 0) return
@@ -117,7 +118,16 @@ export default function HistoryView({ onOpenSession }: { onOpenSession?: () => v
   async function deleteSession(provider: CodingCliProviderName | undefined, sessionId: string) {
     // Use composite key format: provider:sessionId
     const compositeKey = `${provider || 'claude'}:${sessionId}`
-    await api.delete(`/api/sessions/${encodeURIComponent(compositeKey)}`)
+    try {
+      await api.delete(`/api/sessions/${encodeURIComponent(compositeKey)}`)
+    } catch (err) {
+      // SESSION-03: a failed delete must not LOOK like a success — surface it
+      // inline instead of an unhandled rejection while the row stays put.
+      const message = err instanceof Error ? err.message : 'Delete failed'
+      setDeleteError(`Failed to delete session: ${message}`)
+      return
+    }
+    setDeleteError(null)
     // The depth-preserving silent refresh no longer removes vanished sessions —
     // propagate the delete explicitly and immediately.
     dispatch(removeSessionFromProjects({ provider, sessionId }))
@@ -185,6 +195,15 @@ export default function HistoryView({ onOpenSession }: { onOpenSession?: () => v
           />
         </div>
       </div>
+
+      {deleteError ? (
+        <div
+          role="alert"
+          className="border-b border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive md:px-6"
+        >
+          {deleteError}
+        </div>
+      ) : null}
 
       {/* Content */}
       <div className="flex-1 overflow-y-auto">

--- a/src/components/context-menu/ContextMenuProvider.tsx
+++ b/src/components/context-menu/ContextMenuProvider.tsx
@@ -119,6 +119,10 @@ type ConfirmState = {
   body: React.ReactNode
   confirmLabel: string
   onConfirm: () => void
+  /** Set when a confirm attempt fails (e.g. the delete request rejected):
+   * ConfirmModal announces it via role="alert" and the dialog stays open
+   * instead of silently closing with the row intact. */
+  error?: string
 }
 
 type ContextMenuProviderProps = {
@@ -566,19 +570,24 @@ export function ContextMenuProvider({
         </div>
       ),
       onConfirm: async () => {
+        const compositeKey = `${provider || info.session.provider || 'claude'}:${sessionId}`
         try {
-          const compositeKey = `${provider || info.session.provider || 'claude'}:${sessionId}`
           await api.delete(`/api/sessions/${encodeURIComponent(compositeKey)}`)
-          // The depth-preserving silent refresh (see refreshVisibleSessionWindowSilently)
-          // no longer removes vanished sessions — propagate the delete
-          // explicitly and immediately.
-          dispatch(removeSessionFromProjects({ provider: provider || info.session.provider, sessionId }))
-          await dispatch(refreshActiveSessionWindow() as any)
-        } catch {
-          // ignore
-        } finally {
-          setConfirmState(null)
+        } catch (err) {
+          // SESSION-03: a failed delete must not LOOK like a success — keep
+          // the dialog open and announce the failure instead of swallowing it.
+          const message = err instanceof Error ? err.message : 'Delete failed'
+          setConfirmState((prev) =>
+            prev ? { ...prev, error: `Failed to delete session: ${message}` } : prev,
+          )
+          return
         }
+        setConfirmState(null)
+        // The depth-preserving silent refresh (see refreshVisibleSessionWindowSilently)
+        // no longer removes vanished sessions — propagate the delete
+        // explicitly and immediately.
+        dispatch(removeSessionFromProjects({ provider: provider || info.session.provider, sessionId }))
+        await dispatch(refreshActiveSessionWindow() as any)
       },
     })
   }, [dispatch, getSessionInfo, menuState?.target])
@@ -1459,6 +1468,7 @@ export function ContextMenuProvider({
         title={confirmState?.title || ''}
         body={confirmState?.body || null}
         confirmLabel={confirmState?.confirmLabel || 'Confirm'}
+        error={confirmState?.error}
         onConfirm={() => confirmState?.onConfirm()}
         onCancel={() => setConfirmState(null)}
       />

--- a/src/components/ui/confirm-modal.tsx
+++ b/src/components/ui/confirm-modal.tsx
@@ -9,6 +9,9 @@ type ConfirmModalProps = {
   body: React.ReactNode
   confirmLabel: string
   confirmVariant?: ButtonVariant
+  /** Failure text from a previous confirm attempt (e.g. a delete the server
+   * rejected) — announced via role="alert" while the dialog stays open. */
+  error?: string
   onConfirm: () => void
   onCancel: () => void
 }
@@ -32,6 +35,7 @@ export function ConfirmModal({
   body,
   confirmLabel,
   confirmVariant = 'destructive',
+  error,
   onConfirm,
   onCancel,
 }: ConfirmModalProps) {
@@ -117,6 +121,11 @@ export function ConfirmModal({
       >
         <h2 className="text-lg font-semibold">{title}</h2>
         <div className="mt-3 text-sm text-muted-foreground">{body}</div>
+        {error ? (
+          <p role="alert" className="mt-3 text-sm text-destructive">
+            {error}
+          </p>
+        ) : null}
         <div className="mt-4 flex justify-end gap-2">
           <Button variant="ghost" size="sm" onClick={onCancel}>
             Cancel

--- a/test/e2e-browser/playwright.config.ts
+++ b/test/e2e-browser/playwright.config.ts
@@ -277,6 +277,10 @@ export const RUST_ONLY_SPECS = [
   // layout into), so they only ever run under the rust-chromium project.
   /automation-layout-rust\.spec\.ts$/,
   /git-badges-rust\.spec\.ts$/,
+  // SESSION-02/03 soft delete + unmatched-/api/* 404-JSON contract wall:
+  // owns its RustServer (isolated HOME, ephemeral port); the DELETE route
+  // exists only on the Rust server.
+  /session-delete-rust\.spec\.ts$/,
 ]
 
 export default defineConfig({
@@ -510,6 +514,9 @@ export default defineConfig({
         // persistence, Tasks 17-18). Covers git badge parity for
         // REST-created terminals via FreshAgentState post-create seeding.
         /git-badges-rust\.spec\.ts$/,
+        // SESSION-02/03 -- soft-delete route + unmatched-/api/* 404-JSON
+        // contract wall (see RUST_ONLY_SPECS entry + the spec's doc comment).
+        /session-delete-rust\.spec\.ts$/,
       ],
     },
     // CONTINUITY SMOKE (pre-deploy gate): REAL freshell-server binary + REAL

--- a/test/e2e-browser/specs/session-delete-rust.spec.ts
+++ b/test/e2e-browser/specs/session-delete-rust.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * SESSION-02/03 rust-server contract wall, at the REAL binary boundary.
+ *
+ *  leg 1: DELETE /api/sessions/:id is a soft delete — the session drops out
+ *         of the session-directory read model, the override tombstone lands
+ *         in ~/.freshell/config.json, and the provider .jsonl is untouched.
+ *  leg 2: an unmatched /api/* path answers 404 JSON (never 200 SPA HTML),
+ *         and an unauthenticated DELETE answers 401 — the "silent success"
+ *         failure class cannot re-emerge at the server boundary.
+ *
+ * Owns a RustServer directly (ephemeral loopback port — NEVER 3001/3002),
+ * in RUST_ONLY_SPECS because the DELETE route exists only on the Rust server
+ * (under the legacy server the delete leg exercises a different write path).
+ */
+import { test, expect } from '@playwright/test'
+import { promises as fs } from 'node:fs'
+import * as path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { RustServer, ensureRustServerBuilt, type TestServerInfo } from '../helpers/rust-server.js'
+
+const SESSION_ID = randomUUID()
+const SESSION_KEY = `claude:${SESSION_ID}`
+const PROJECT_DIR = '/tmp/session-delete-e2e-proj'
+
+// Flat Claude transcript shape — the exact shape sessions_tests.rs's overlay
+// round-trip proves end-to-end through ClaudeSource + the directory route.
+// NOTE: the `system/init + uuid/parentUuid` nested shape used by some older
+// specs is NOT indexed by the current Rust ClaudeSource (verified empirically
+// while authoring this spec: a nested seed never appeared in
+// /api/session-directory on either the pre- or post-fix binary; the flat
+// shape appeared on the first poll of both).
+function buildSessionJsonl(sessionId: string, cwd: string): string {
+  return [
+    JSON.stringify({ cwd, sessionId, type: 'user', message: { role: 'user', content: 'session-delete e2e seed' }, timestamp: '2025-01-30T10:00:00.000Z' }),
+    JSON.stringify({ cwd, sessionId, type: 'assistant', message: { role: 'assistant', content: 'ack' }, timestamp: '2025-01-30T10:00:01.000Z' }),
+    JSON.stringify({ cwd, sessionId, type: 'user', message: { role: 'user', content: 'second prompt' }, timestamp: '2025-01-30T10:00:02.000Z' }),
+  ].join('\n') + '\n'
+}
+
+function authed(info: TestServerInfo): Record<string, string> {
+  return { 'x-auth-token': info.token }
+}
+
+async function directorySessionIds(info: TestServerInfo): Promise<string[]> {
+  const resp = await fetch(`${info.baseUrl}/api/session-directory?priority=visible`, {
+    headers: authed(info),
+  })
+  if (!resp.ok) throw new Error(`session-directory answered ${resp.status}`)
+  const body = (await resp.json()) as { items?: Array<{ sessionId?: string }> }
+  return (body.items ?? []).map((i) => i.sessionId ?? '')
+}
+
+// NOT serial: the two legs are independent (leg 2 never mutates state), and
+// serial's skip-on-failure would hide leg 2's verdict when a red run (base
+// binary) fails leg 1 — the point of the red run is the full 405 picture.
+test.describe('session delete (rust server)', () => {
+  test.setTimeout(240_000)
+  let server: RustServer
+  let info: TestServerInfo
+
+  test.beforeAll(async () => {
+    // Same pattern as sidebar-registry-sync-rust.spec.ts:171-176: the first
+    // release build can take minutes, and the default 60s hook timeout would
+    // kill server.start() mid-build.
+    test.setTimeout(600_000)
+    // RustServer.boot resolves FRESHELL_E2E_RUST_SERVER_BIN fail-closed
+    // (rust-server.ts:455) — when a caller pins a binary (e.g. a base-binary
+    // red run), don't ALSO spend a head release build in this hook.
+    if (!process.env.FRESHELL_E2E_RUST_SERVER_BIN) ensureRustServerBuilt()
+    server = new RustServer({
+      setupHome: async (homeDir: string) => {
+        await fs.mkdir(PROJECT_DIR, { recursive: true })
+        const freshellDir = path.join(homeDir, '.freshell')
+        await fs.mkdir(freshellDir, { recursive: true })
+        await fs.writeFile(path.join(freshellDir, 'config.json'), JSON.stringify({
+          version: 1,
+          settings: { codingCli: { enabledProviders: ['claude'] } },
+        }, null, 2))
+        const slug = PROJECT_DIR.replace(/\//g, '-')
+        const projDir = path.join(homeDir, '.claude', 'projects', slug)
+        await fs.mkdir(projDir, { recursive: true })
+        await fs.writeFile(
+          path.join(projDir, `${SESSION_ID}.jsonl`),
+          buildSessionJsonl(SESSION_ID, PROJECT_DIR),
+        )
+      },
+    })
+    info = await server.start()
+  })
+
+  test.afterAll(async () => {
+    await server?.stop()
+    await fs.rm(PROJECT_DIR, { recursive: true, force: true })
+  })
+
+  test('soft delete hides the session, keeps the transcript, and persists the override', async () => {
+    // The isolated provider home is indexed on the server's sweep cadence —
+    // poll the directory until discovery, not a fixed sleep.
+    await expect.poll(() => directorySessionIds(info), { timeout: 60_000 }).toContain(SESSION_ID)
+
+    const seededJsonl = path.join(
+      info.homeDir,
+      '.claude', 'projects', PROJECT_DIR.replace(/\//g, '-'),
+      `${SESSION_ID}.jsonl`,
+    )
+
+    const del = await fetch(
+      `${info.baseUrl}/api/sessions/${encodeURIComponent(SESSION_KEY)}`,
+      { method: 'DELETE', headers: authed(info) },
+    )
+    expect(del.status).toBe(200)
+    expect(await del.json()).toEqual({ ok: true })
+
+    await expect.poll(() => directorySessionIds(info), { timeout: 60_000 }).not.toContain(SESSION_ID)
+
+    // Soft delete: the provider transcript is untouched, and the override is
+    // exactly the single-key {deleted:true} tombstone.
+    await expect(fs.access(seededJsonl)).resolves.toBeUndefined()
+    const cfg = JSON.parse(
+      await fs.readFile(path.join(info.homeDir, '.freshell', 'config.json'), 'utf8'),
+    )
+    expect(cfg.sessionOverrides?.[SESSION_KEY]?.deleted).toBe(true)
+  })
+
+  test('unmatched /api/* is 404 JSON (never SPA HTML 200), and unauthenticated DELETE is 401', async () => {
+    const miss = await fetch(`${info.baseUrl}/api/definitely-not-a-route`, {
+      headers: authed(info),
+    })
+    expect(miss.status).toBe(404)
+    expect(miss.headers.get('content-type') ?? '').toContain('application/json')
+
+    const unauth = await fetch(
+      `${info.baseUrl}/api/sessions/${encodeURIComponent(SESSION_KEY)}`,
+      { method: 'DELETE' },
+    )
+    expect(unauth.status).toBe(401)
+  })
+})

--- a/test/unit/client/components/ContextMenuProvider.test.tsx
+++ b/test/unit/client/components/ContextMenuProvider.test.tsx
@@ -1641,6 +1641,60 @@ describe('ContextMenuProvider', () => {
     })
   })
 
+  it('keeps the confirm dialog open with an error when the delete request fails', async () => {
+    const user = userEvent.setup()
+    const store = createStoreWithSession()
+    store.dispatch(commitSessionWindowVisibleRefresh({
+      surface: 'sidebar',
+      projects: store.getState().sessions.projects,
+      totalSessions: 1,
+      hasMore: false,
+      oldestLoadedTimestamp: 2000,
+      oldestLoadedSessionId: `claude:${VALID_SESSION_ID}`,
+    } as any))
+    apiMocks.delete.mockRejectedValueOnce(new Error('boom'))
+    render(
+      <Provider store={store}>
+        <ContextMenuProvider
+          view="terminal"
+          onViewChange={() => {}}
+          onToggleSidebar={() => {}}
+          sidebarCollapsed={false}
+        >
+          <div
+            data-context={ContextIds.SidebarSession}
+            data-session-id={VALID_SESSION_ID}
+            data-provider="claude"
+          >
+            Sidebar Session
+          </div>
+        </ContextMenuProvider>
+      </Provider>
+    )
+
+    await user.pointer({ target: screen.getByText('Sidebar Session'), keys: '[MouseRight]' })
+    await user.click(screen.getByRole('menuitem', { name: 'Delete' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    // SESSION-03: a failed delete must not LOOK like a success — the dialog
+    // stays open and announces the failure instead of silently closing with
+    // the row intact.
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to delete session: boom')
+    })
+    expect(screen.getByRole('dialog', { name: 'Delete session?' })).toBeInTheDocument()
+
+    // Nothing was removed from either the top-level projects or the window.
+    const sessions = store.getState().sessions
+    expect(
+      sessions.projects.flatMap((p: any) => p.sessions).some((s: any) => s.sessionId === VALID_SESSION_ID),
+    ).toBe(true)
+    expect(
+      (sessions.windows?.sidebar?.projects ?? []).flatMap((p: any) => p.sessions)
+        .some((s: any) => s.sessionId === VALID_SESSION_ID),
+    ).toBe(true)
+  })
+
   it('keeps built-in sidebar resume command available before extension registry hydration', async () => {
     const user = userEvent.setup()
     const store = createStoreWithSession()

--- a/test/unit/client/components/HistoryView.delete.test.tsx
+++ b/test/unit/client/components/HistoryView.delete.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import HistoryView from '@/components/HistoryView'
+import sessionsReducer from '@/store/sessionsSlice'
+import tabsReducer from '@/store/tabsSlice'
+import panesReducer from '@/store/panesSlice'
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn().mockResolvedValue([]),
+  put: vi.fn().mockResolvedValue({}),
+  patch: vi.fn().mockResolvedValue({}),
+  delete: vi.fn().mockResolvedValue({}),
+  fetchSidebarSessionsSnapshot: vi.fn().mockResolvedValue({
+    projects: [],
+    totalSessions: 0,
+    oldestIncludedTimestamp: 0,
+    oldestIncludedSessionId: '',
+    hasMore: false,
+  }),
+  searchSessions: vi.fn().mockResolvedValue({ results: [], hasMore: false }),
+}))
+
+// Same stub shape as HistoryView.mobile.test.tsx: spread the real module so
+// pure named exports (e.g. isApiUnauthorizedError, consulted by
+// fetchSessionWindow's rejection handler) stay live, and stub the thunk's
+// direct network entry points so no real fetch escapes.
+vi.mock('@/lib/api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api')>('@/lib/api')
+  return {
+    ...actual,
+    api: apiMocks,
+    fetchSidebarSessionsSnapshot: apiMocks.fetchSidebarSessionsSnapshot,
+    searchSessions: apiMocks.searchSessions,
+  }
+})
+
+function renderHistoryView() {
+  const projectPath = '/test/project'
+  const store = configureStore({
+    reducer: {
+      sessions: sessionsReducer,
+      tabs: tabsReducer,
+      panes: panesReducer,
+    },
+    middleware: (getDefault) =>
+      getDefault({
+        serializableCheck: {
+          ignoredPaths: ['sessions.expandedProjects'],
+        },
+      }),
+    preloadedState: {
+      sessions: {
+        projects: [
+          {
+            projectPath,
+            color: '#6b7280',
+            sessions: [
+              {
+                provider: 'claude',
+                sessionId: 'session-123',
+                projectPath,
+                lastActivityAt: Date.now(),
+                title: 'Test Session',
+                summary: 'summary',
+              },
+            ],
+          },
+        ],
+        expandedProjects: new Set([projectPath]),
+      },
+      tabs: { tabs: [], activeTabId: null },
+      panes: {
+        layouts: {},
+        activePane: {},
+        paneTitles: {},
+        paneTitleSetByUser: {},
+        renameRequestTabId: null,
+        renameRequestPaneId: null,
+        zoomedPane: {},
+        refreshRequestsByPane: {},
+      },
+    } as any,
+  })
+
+  render(
+    <Provider store={store}>
+      <HistoryView />
+    </Provider>
+  )
+  return store
+}
+
+describe('HistoryView session delete', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('deletes through the composite-key route and removes the session from store state', async () => {
+    const store = renderHistoryView()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete session' }))
+
+    await waitFor(() => {
+      expect(apiMocks.delete).toHaveBeenCalledWith(
+        `/api/sessions/${encodeURIComponent('claude:session-123')}`,
+      )
+    })
+    await waitFor(() => {
+      expect(
+        store.getState().sessions.projects
+          .flatMap((p: any) => p.sessions)
+          .some((s: any) => s.sessionId === 'session-123'),
+      ).toBe(false)
+    })
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('surfaces a failed delete inline and keeps the session (SESSION-03)', async () => {
+    apiMocks.delete.mockRejectedValueOnce(new Error('boom'))
+    const store = renderHistoryView()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete session' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to delete session: boom')
+    })
+    expect(
+      store.getState().sessions.projects
+        .flatMap((p: any) => p.sessions)
+        .some((s: any) => s.sessionId === 'session-123'),
+    ).toBe(true)
+  })
+})

--- a/test/unit/client/components/ui/confirm-modal.test.tsx
+++ b/test/unit/client/components/ui/confirm-modal.test.tsx
@@ -1,8 +1,15 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
 import { ConfirmModal } from '@/components/ui/confirm-modal'
 
 describe('ConfirmModal', () => {
+  // vitest runs this file with sequence.shuffle=true ("detect order-dependent
+  // tests"): each render portals into document.body, so tests must not leak
+  // their modal into a sibling test's queries.
+  afterEach(() => {
+    cleanup()
+  })
+
   it('defaults the confirm button to destructive styling', () => {
     render(
       <ConfirmModal
@@ -32,5 +39,38 @@ describe('ConfirmModal', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Continue' })).toHaveClass('bg-primary')
+  })
+
+  it('announces an operation failure with an alert role when error is provided', () => {
+    render(
+      <ConfirmModal
+        open
+        title="Delete session?"
+        body="This cannot be undone."
+        confirmLabel="Delete"
+        error="Failed to delete session: boom"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Failed to delete session: boom',
+    )
+  })
+
+  it('renders no alert region when no error is provided', () => {
+    render(
+      <ConfirmModal
+        open
+        title="Delete session?"
+        body="This cannot be undone."
+        confirmLabel="Delete"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 })

--- a/test/unit/client/lib/api.test.ts
+++ b/test/unit/client/lib/api.test.ts
@@ -910,4 +910,13 @@ describe('api error mapping', () => {
     expect(err.retryAfterMs).toBeGreaterThan(20_000)
     expect(err.retryAfterMs).toBeLessThanOrEqual(31_000)
   })
+
+  it('locks the delete contract the failure-surfacing UI relies on: a 404 JSON body rejects as an ApiError', async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(404, { error: 'Not found' }))
+
+    await expect(api.delete('/api/sessions/claude%3Amissing')).rejects.toMatchObject({
+      status: 404,
+      message: 'Not found',
+    })
+  })
 })


### PR DESCRIPTION
## Problem

Deleting a session (from the sidebar context menu or History view) silently failed against the Rust server: the `DELETE /api/sessions/:id` route was unimplemented, axum answered `405 Method Not Allowed`, and both client delete paths hid the failure — `ContextMenuProvider` swallowed the rejection with a bare `catch {}` (closing the dialog as if the delete succeeded), and `HistoryView` left the promise unhandled. Sessions appeared deleted but were untouched.

## Changes

Three commits:

1. **`fix(server)`** — `crates/freshell-server/src/sessions.rs`: implement `DELETE /api/sessions/:id` as an exact port of the Node route's soft delete (`server/sessions-router.ts:243-251`): never removes `.jsonl` transcript files; writes a composite-key tombstone (`claude:<id>` via `?provider=` prefix or percent-decoded passthrough) using a single-key `{deleted:true}` patch via `patch_session_override` (existing overrides merge); always `200 {"ok":true}`, never 404 even for unknown ids (Node parity); broadcasts `sessions.changed` directly since the periodic session-directory sweep is blind to override-only changes. Mounted as `patch(patch_session).delete(delete_session)` on the existing route itself. Six colocated tests in `sessions_tests.rs`: auth gate, tombstone persistence, unknown-id parity, `%3A`-decode/bare-id prefixing, broadcast revision monotonicity, and a `?mode=directory` overlay round trip proving the tombstone hides the seeded session at the read-model layer.

2. **`fix(client)`** — failure surfacing closes the silent-failure class in both delete paths:
   - `ConfirmModal` (used by the sidebar context menu) gains an optional `error` prop rendered as a non-focusable `<p role="alert">`; on delete rejection the dialog stays open with `Failed to delete session: <message>` and the session list is left untouched (`ContextMenuProvider`).
   - `HistoryView` catches failures into a destructive inline banner under the header (clears on next successful delete or unmount).
   - API-test lock that `api.delete` rejects 404 JSON bodies as a typed `ApiError` (prevents "404 treated as success" from returning).
   - Shuffle-safety fix in `confirm-modal.test.tsx` (`afterEach(cleanup)`) since the default vitest config runs `sequence.shuffle: true`.

3. **`test(e2e)`** — `test/e2e-browser/specs/session-delete-rust.spec.ts` (PW-RUST, fetch-level binary contract): leg 1 proves soft delete round-trips through the overlay (`?mode=directory`), the `config.json` tombstone, and `.jsonl` survival, proving 200-vs-Node parity rather than merely "some status"; leg 2 pins the unmatched-`/api/*` 404 JSON shape (pre-existing in `serve_client.rs`) and the unauthenticated DELETE 401. Registered in both `RUST_ONLY_SPECS` and the rust-chromium `testMatch`.
   - Includes a spec comment documenting the indexer constraint: the nested `system/init + uuid/parentUuid` transcript shape is not indexed by the current Rust `ClaudeSource`; the spec uses the parseable flat shape (verified against the real binary).

## Verification

- Rust: the 6 colocated tests were written against the stub (red: 405/401 mismatches), then green with the route; full crate suite passes (`727 passed` including existing tests; the only failure is a pre-existing environment-poisoned `repo_icon_git` test that fails identically at base — a stray `/tmp/.git` on the dev host, since removed). `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Client: 90/90 across the four touched test files; `tsc --noEmit` clean; `eslint` shows only pre-existing warnings (the one `:1380` useMemo warning verified present at base).
- Binary boundary red/green: the e2e spec fails against the pre-fix production binary exactly at `expect(del.status).toBe(200)` (405) and leg-2's 401 check, then passes against the worktree-built binary (2/2) without rebuilding, via the `FRESHELL_E2E_RUST_SERVER_BIN` fail-closed override.
- Coordinated gate: third `npm run check` fully green (default + server + electron suites). Attempts 1–2 each flaked on two *different*, unrelated under-load timing timeouts on the dev host; all four were isolated-rerun to green.
- Manual binary probe against the worktree server confirmed: DELETE 200 `{"ok":true}` + persisted tombstone + untouched jsonl, unauth DELETE 401, unmatched `/api` 404 JSON.
- Reviews: three independent clean fresh-eyes reviews (two adversarial in-session rounds plus a cross-family fresheyes review, all "No findings" / PASSED; static-only per skill design).
