### PR TITLE
feat(rust): serve /api/fresh-agent/model-capabilities from the Rust server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,6 +1320,7 @@ dependencies = [
  "freshell-protocol",
  "freshell-sessions",
  "freshell-terminal",
+ "futures-util",
  "libc",
  "serde",
  "serde_json",
@@ -1337,6 +1338,7 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "reqwest",
+ "serde",
  "serde_json",
  "tokio",
  "uuid",

--- a/crates/freshell-freshagent/Cargo.toml
+++ b/crates/freshell-freshagent/Cargo.toml
@@ -67,6 +67,10 @@ serde_json = { workspace = true }
 # guarantees). `fancy-regex` is already resolved in the workspace lockfile (a transitive dep of
 # `jsonschema`), so this adds no new dependency to the build graph, only a direct one.
 fancy-regex = "0.18"
+# `future::Shared` backs the model-capabilities registry's in-flight single-flight
+# coalescing (`model-capability-registry.ts`'s `opencodeInFlightByKey` promise map
+# — one probe, many awaiters). Already resolved in the workspace lock.
+futures-util = "0.3"
 # The shared broadcast bus (String frames), the create/turn async orchestration, the codex
 # app-server sidecar spawn (`process`), and its stdio drain (`io-util`).
 tokio = { version = "1", features = ["rt", "macros", "sync", "time", "process", "io-util"] }

--- a/crates/freshell-freshagent/src/lib.rs
+++ b/crates/freshell-freshagent/src/lib.rs
@@ -42,6 +42,7 @@ pub mod codex;
 pub mod identity_sink;
 pub mod layout_store;
 pub mod layout_tree;
+pub mod model_capabilities;
 pub mod opencode_ws;
 pub mod pane_ops;
 mod pane_resize;
@@ -314,6 +315,14 @@ pub struct FreshAgentState {
     /// wired (the `rename_persistence` convention): creates proceed, only the
     /// meta seeding is skipped.
     pub(crate) terminal_created_hook: Option<TerminalCreatedHook>,
+    /// The `GET`/`POST /api/fresh-agent/model-capabilities/*` registry
+    /// ([`model_capabilities`]): cwd-keyed TTL cache + single-flight coalescing
+    /// over the transient opencode catalog probe, plus the static codex/claude
+    /// catalogs. Constructed with the REAL transport probe in
+    /// [`Self::new`] (there is no wiring ceremony — unlike the Option-until-
+    /// wired fields above, production construction is unconditional); tests
+    /// install a scripted probe via [`Self::with_model_capability_probe`].
+    pub(crate) model_capabilities: Arc<model_capabilities::ModelCapabilityRegistry>,
 }
 
 /// What [`terminal_tabs::spawn_terminal_pane`] hands the injected
@@ -407,7 +416,22 @@ impl FreshAgentState {
             rename_persistence: None,
             terminals_revision: None,
             terminal_created_hook: None,
+            model_capabilities: Arc::new(model_capabilities::ModelCapabilityRegistry::new(
+                Arc::new(model_capabilities::OpencodeCatalogProbe::default()),
+            )),
         }
+    }
+
+    /// Install a scripted model-catalog probe (tests) — the registry's
+    /// `opencodeCatalogProvider` injection seam
+    /// (`model-capability-registry.ts:196-202`). Rebuilds the registry around
+    /// the replacement probe; any prior cache entries are discarded with it.
+    pub fn with_model_capability_probe(
+        mut self,
+        probe: Arc<dyn model_capabilities::ModelCatalogProbe>,
+    ) -> Self {
+        self.model_capabilities = Arc::new(model_capabilities::ModelCapabilityRegistry::new(probe));
+        self
     }
 
     /// Wire the P1.13 identity-event sink (set-once; later calls are no-ops).
@@ -1483,6 +1507,7 @@ pub fn router(state: FreshAgentState) -> Router {
         .route("/api/panes/{id}/capture", get(capture))
         .route("/api/panes/{id}/wait-for", get(terminal_tabs::wait_for))
         .with_state(state.clone())
+        .merge(model_capabilities::router(state.clone()))
         .merge(pane_ops::router(state))
 }
 

--- a/crates/freshell-freshagent/src/model_capabilities.rs
+++ b/crates/freshell-freshagent/src/model_capabilities.rs
@@ -1,0 +1,499 @@
+//! # model_capabilities — `GET`/`POST /api/fresh-agent/model-capabilities/*`
+//!
+//! Port of the Node pair
+//! * `server/fresh-agent/model-capabilities-router.ts` (route shape, 400/200/503
+//!   statuses, cwd context resolution) and
+//! * `server/fresh-agent/model-capability-registry.ts` (per-cwd TTL cache with
+//!   in-flight single-flight coalescing, refresh bypass, static catalogs,
+//!   typed-error envelopes),
+//!
+//! sitting on the [`freshell_opencode::catalog`] probe for the `freshopencode`
+//! runtime. The response bodies conform to
+//! `shared/fresh-agent-model-capabilities.ts` (`ok:true` success at 200,
+//! `ok:false` `unavailable` + typed error at 503).
+//!
+//! ## Deviation (tracked)
+//!
+//! `freshclaude`/`kilroy`: Node probes the Claude Agent SDK's `supportedModels()`
+//! (`registry.probeCatalog`). There is no Claude SDK in the Rust workspace, so this
+//! module serves the shared static table for the claude providers as well (the
+//! same list `createStaticSuccess` would build for `freshcodex` with claude
+//! entries substituted). The endpoint stays uniformly functional; live claude
+//! probing lands with the two-column model-selector slice.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use futures_util::future::{FutureExt, Shared};
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
+
+use freshell_opencode::catalog::{
+    probe_enabled_model_catalog, CatalogConfig, CatalogDeps, ModelCapability,
+};
+use freshell_opencode::serve::BoxFuture;
+use freshell_opencode::transport::{LoopbackPortAllocator, ReqwestServeHttp, TokioProcessSpawner};
+
+use crate::{authorized, fail_json, FreshAgentState};
+
+/// `FRESH_AGENT_MODEL_CAPABILITY_CACHE_TTL_MS`
+/// (`shared/fresh-agent-model-capabilities.ts:3`).
+pub const MODEL_CAPABILITY_CACHE_TTL: Duration = Duration::from_millis(5 * 60 * 1000);
+
+// ── session types (FreshAgentModelCapabilitiesSessionTypeSchema) ───────────────
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionType {
+    FreshClaude,
+    FreshCodex,
+    Kilroy,
+    FreshOpencode,
+}
+
+impl SessionType {
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "freshclaude" => Some(Self::FreshClaude),
+            "freshcodex" => Some(Self::FreshCodex),
+            "kilroy" => Some(Self::Kilroy),
+            "freshopencode" => Some(Self::FreshOpencode),
+            _ => None,
+        }
+    }
+
+    fn wire(self) -> &'static str {
+        match self {
+            Self::FreshClaude => "freshclaude",
+            Self::FreshCodex => "freshcodex",
+            Self::Kilroy => "kilroy",
+            Self::FreshOpencode => "freshopencode",
+        }
+    }
+
+    /// `FreshAgentModelCapabilitiesRuntimeProviderSchema` (the descriptor's
+    /// `runtimeProvider`).
+    fn runtime_provider(self) -> &'static str {
+        match self {
+            Self::FreshCodex => "codex",
+            Self::FreshOpencode => "opencode",
+            Self::FreshClaude | Self::Kilroy => "claude",
+        }
+    }
+}
+
+// ── errors (FreshAgentModelCapabilityErrorSchema) ───────────────────────────────
+
+/// The typed catalog error carried in the `ok:false` envelope
+/// (`code`/`message`/`retryable`).
+#[derive(Clone, Debug, PartialEq)]
+pub struct CapabilityError {
+    pub code: String,
+    pub message: String,
+    pub retryable: bool,
+}
+
+// ── the probe seam (registry's opencodeCatalogProvider) ────────────────────────
+
+pub type CatalogOut = Result<Vec<ModelCapability>, CapabilityError>;
+
+/// Injected probe — the port seam for the reference's `opencodeCatalogProvider`
+/// dependency (`RegistryOptions.opencodeCatalogProvider`). Real impl spawns the
+/// transient catalog serve; tests record cwd and script responses.
+pub trait ModelCatalogProbe: Send + Sync {
+    fn probe<'a>(&'a self, cwd: Option<&'a str>) -> BoxFuture<'a, CatalogOut>;
+}
+
+/// Production probe over the real transport: transient `opencode serve --pure`.
+pub struct OpencodeCatalogProbe {
+    deps: CatalogDeps,
+    config: CatalogConfig,
+}
+
+impl OpencodeCatalogProbe {
+    pub fn new(deps: CatalogDeps, config: CatalogConfig) -> Self {
+        Self { deps, config }
+    }
+}
+
+impl Default for OpencodeCatalogProbe {
+    fn default() -> Self {
+        Self::new(
+            CatalogDeps {
+                spawner: Arc::new(TokioProcessSpawner),
+                http: Arc::new(ReqwestServeHttp::new()),
+                ports: Arc::new(LoopbackPortAllocator),
+            },
+            CatalogConfig::default(),
+        )
+    }
+}
+
+impl ModelCatalogProbe for OpencodeCatalogProbe {
+    fn probe<'a>(&'a self, cwd: Option<&'a str>) -> BoxFuture<'a, CatalogOut> {
+        Box::pin(async move {
+            probe_enabled_model_catalog(&self.deps, &self.config, cwd)
+                .await
+                .map_err(|e| CapabilityError {
+                    // `probeOpencodeCatalog` wraps every untyped probe failure
+                    // (model-capability-registry.ts:320-340).
+                    code: "CAPABILITY_PROBE_FAILED".to_string(),
+                    message: e.to_string(),
+                    retryable: true,
+                })
+        })
+    }
+}
+
+// ── registry (FreshAgentModelCapabilityRegistry) ───────────────────────────────
+
+#[derive(Clone)]
+struct CachedCatalog {
+    fetched_at_ms: u64,
+    models: Vec<ModelCapability>,
+}
+
+type SharedCatalogFuture = Shared<BoxFuture<'static, Result<CachedCatalog, CapabilityError>>>;
+
+#[derive(Default)]
+struct RegistryState {
+    cache: HashMap<String, CachedCatalog>,
+    inflight: HashMap<String, SharedCatalogFuture>,
+}
+
+/// cwd-keyed TTL cache + in-flight coalescing — `opencodeCacheByKey` /
+/// `opencodeInFlightByKey` (`model-capability-registry.ts:193-194`).
+pub struct ModelCapabilityRegistry {
+    probe: Arc<dyn ModelCatalogProbe>,
+    ttl: Duration,
+    now: Arc<dyn Fn() -> u64 + Send + Sync>,
+    state: Arc<Mutex<RegistryState>>,
+}
+
+fn system_now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+impl ModelCapabilityRegistry {
+    pub fn new(probe: Arc<dyn ModelCatalogProbe>) -> Self {
+        Self {
+            probe,
+            ttl: MODEL_CAPABILITY_CACHE_TTL,
+            now: Arc::new(system_now_ms),
+            state: Arc::new(Mutex::new(RegistryState::default())),
+        }
+    }
+
+    /// Test seam (`RegistryOptions{now, ttlMs}`): injected clock and TTL so cache
+    /// aging is deterministic.
+    pub fn with_clock(
+        probe: Arc<dyn ModelCatalogProbe>,
+        now: Arc<dyn Fn() -> u64 + Send + Sync>,
+        ttl: Duration,
+    ) -> Self {
+        Self {
+            probe,
+            ttl,
+            now,
+            state: Arc::new(Mutex::new(RegistryState::default())),
+        }
+    }
+
+    /// `getCapabilities` (`model-capability-registry.ts:211-234`): cache hit within
+    /// TTL → `cached`; otherwise single-flight refresh → `fresh`; probe failure →
+    /// the `unavailable` envelope at 503 (cache untouched). Non-opencode runtimes
+    /// serve the static catalog (`createStaticSuccess`, `:354-378`) — for claude
+    /// providers that is the documented deviation above.
+    pub async fn get(&self, session_type: SessionType, cwd: Option<String>) -> (StatusCode, Value) {
+        if session_type != SessionType::FreshOpencode {
+            return (
+                StatusCode::OK,
+                success_body(
+                    session_type,
+                    "fresh",
+                    (self.now)(),
+                    static_models(session_type),
+                ),
+            );
+        }
+        let key = cache_key(cwd.as_deref());
+        {
+            let state = self.state.lock().await;
+            if let Some(cached) = state.cache.get(&key) {
+                // `:270-271`: `now - fetchedAt <= ttlMs`.
+                let age_ms = (self.now)().saturating_sub(cached.fetched_at_ms);
+                if age_ms <= self.ttl.as_millis() as u64 {
+                    return (
+                        StatusCode::OK,
+                        success_body(
+                            session_type,
+                            "cached",
+                            cached.fetched_at_ms,
+                            cached.models.clone(),
+                        ),
+                    );
+                }
+            }
+        }
+        self.finish_opencode(session_type, key, cwd).await
+    }
+
+    /// `refreshCapabilities` (`:236-254`): skips the TTL check but shares any
+    /// in-flight probe; a failed refresh leaves the last successful cache entry
+    /// in place (`:223-266`, "keeps the last successful catalog").
+    pub async fn refresh(
+        &self,
+        session_type: SessionType,
+        cwd: Option<String>,
+    ) -> (StatusCode, Value) {
+        if session_type != SessionType::FreshOpencode {
+            return (
+                StatusCode::OK,
+                success_body(
+                    session_type,
+                    "fresh",
+                    (self.now)(),
+                    static_models(session_type),
+                ),
+            );
+        }
+        self.finish_opencode(session_type, cache_key(cwd.as_deref()), cwd)
+            .await
+    }
+
+    async fn finish_opencode(
+        &self,
+        session_type: SessionType,
+        key: String,
+        cwd: Option<String>,
+    ) -> (StatusCode, Value) {
+        match self.refreshed_catalog(key, cwd).await {
+            Ok(catalog) => (
+                StatusCode::OK,
+                success_body(session_type, "fresh", catalog.fetched_at_ms, catalog.models),
+            ),
+            Err(err) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                failure_body(session_type, &err),
+            ),
+        }
+    }
+
+    /// `refreshOpencodeCatalog` (`:295-318`): the single-flight. The shared
+    /// future removes itself from `inflight` and writes the cache on success —
+    /// the reference's `.then(cache.set).finally(inflight.delete)`.
+    async fn refreshed_catalog(
+        &self,
+        key: String,
+        cwd: Option<String>,
+    ) -> Result<CachedCatalog, CapabilityError> {
+        let shared = {
+            let mut state = self.state.lock().await;
+            match state.inflight.get(&key) {
+                Some(existing) => existing.clone(),
+                None => {
+                    let probe = self.probe.clone();
+                    let now = self.now.clone();
+                    let state_arc = self.state.clone();
+                    let key_for_cleanup = key.clone();
+                    // `:302-306`: only a non-blank cwd reaches the probe context.
+                    let cwd = cwd.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+                    let key_for_cache = key.clone();
+                    let future = async move {
+                        let out = probe
+                            .probe(cwd.as_deref())
+                            .await
+                            .map(|models| CachedCatalog {
+                                fetched_at_ms: now(),
+                                models,
+                            });
+                        let mut state = state_arc.lock().await;
+                        state.inflight.remove(&key_for_cleanup);
+                        if let Ok(catalog) = &out {
+                            state.cache.insert(key_for_cache, catalog.clone());
+                        }
+                        out
+                    };
+                    let shared: SharedCatalogFuture = future.boxed().shared();
+                    state.inflight.insert(key, shared.clone());
+                    shared
+                }
+            }
+        };
+        shared.await
+    }
+}
+
+/// `opencodeCacheKey` (`:256-261`).
+fn cache_key(cwd: Option<&str>) -> String {
+    let cwd = cwd.map(str::trim).filter(|s| !s.is_empty());
+    format!("opencode:{}", cwd.unwrap_or("<default>"))
+}
+
+/// `createStaticSuccess` (`:354-378`): the shared
+/// `FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE` tables
+/// (`shared/fresh-agent-models.ts:21-84`) as capability rows.
+fn static_models(session_type: SessionType) -> Vec<ModelCapability> {
+    type Row = (&'static str, &'static str, &'static [&'static str]);
+    let rows: &[Row] = match session_type {
+        SessionType::FreshCodex => &[
+            (
+                "gpt-5.5",
+                "GPT-5.5",
+                &["none", "minimal", "low", "medium", "high", "max"],
+            ),
+            (
+                "gpt-5.4-flash",
+                "GPT-5.4 Flash",
+                &["none", "minimal", "low", "medium", "high"],
+            ),
+            (
+                "gpt-5.3-codex-spark",
+                "GPT-5.3 Codex Spark",
+                &["none", "minimal", "low", "medium", "high", "max"],
+            ),
+        ],
+        // DEVIATION (module doc): Node probes the Claude SDK `supportedModels()`
+        // for the claude providers; the Rust port serves the shared static table.
+        SessionType::FreshClaude | SessionType::Kilroy => &[(
+            "claude-opus-4-6",
+            "Claude Opus 4.6",
+            &["low", "medium", "high"],
+        )],
+        SessionType::FreshOpencode => &[],
+    };
+    rows.iter()
+        .map(|(id, display_name, levels)| ModelCapability {
+            id: id.to_string(),
+            display_name: display_name.to_string(),
+            provider: session_type.runtime_provider(),
+            source: None,
+            // `:359-366`: effort support derives from the levels list, not the flag.
+            supports_effort: !levels.is_empty(),
+            supported_effort_levels: levels.iter().map(|s| s.to_string()).collect(),
+            supports_adaptive_thinking: !levels.is_empty(),
+        })
+        .collect()
+}
+
+/// `FreshAgentModelCapabilitiesSchema.extend({ok:true})` — the six keys, exactly.
+fn success_body(
+    session_type: SessionType,
+    status: &'static str,
+    fetched_at_ms: u64,
+    models: Vec<ModelCapability>,
+) -> Value {
+    json!({
+        "ok": true,
+        "sessionType": session_type.wire(),
+        "runtimeProvider": session_type.runtime_provider(),
+        "status": status,
+        "fetchedAt": fetched_at_ms,
+        "models": models,
+    })
+}
+
+/// `createFailure` (`model-capability-registry.ts:469-489`): no `fetchedAt` key
+/// (the zod schema leaves it optional and the reference omits it).
+fn failure_body(session_type: SessionType, err: &CapabilityError) -> Value {
+    json!({
+        "ok": false,
+        "sessionType": session_type.wire(),
+        "runtimeProvider": session_type.runtime_provider(),
+        "status": "unavailable",
+        "models": [],
+        "error": {
+            "code": err.code,
+            "message": err.message,
+            "retryable": err.retryable,
+        },
+    })
+}
+
+// ── HTTP surface (createFreshAgentModelCapabilitiesRouter) ─────────────────────
+
+/// The two routes. Merged into [`crate::router`] so `freshell-server`'s `main.rs`
+/// mounts this crate exactly once, unchanged.
+pub fn router(state: FreshAgentState) -> Router {
+    Router::new()
+        .route(
+            "/api/fresh-agent/model-capabilities/{session_type}",
+            get(get_capabilities),
+        )
+        .route(
+            "/api/fresh-agent/model-capabilities/{session_type}/refresh",
+            post(refresh_capabilities),
+        )
+        .with_state(state)
+}
+
+/// `GET /:sessionType` (`model-capabilities-router.ts:33-47`).
+async fn get_capabilities(
+    State(state): State<FreshAgentState>,
+    headers: HeaderMap,
+    Path(session_type): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    if !authorized(&headers, &state.auth_token) {
+        return fail_json(StatusCode::UNAUTHORIZED, "unauthorized".to_string());
+    }
+    let Some(st) = SessionType::parse(&session_type) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "Invalid sessionType" })),
+        )
+            .into_response();
+    };
+    let (status, body) = state
+        .model_capabilities
+        .get(st, resolve_context(st, &query))
+        .await;
+    (status, Json(body)).into_response()
+}
+
+/// `POST /:sessionType/refresh` (`model-capabilities-router.ts:49-63`).
+async fn refresh_capabilities(
+    State(state): State<FreshAgentState>,
+    headers: HeaderMap,
+    Path(session_type): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    if !authorized(&headers, &state.auth_token) {
+        return fail_json(StatusCode::UNAUTHORIZED, "unauthorized".to_string());
+    }
+    let Some(st) = SessionType::parse(&session_type) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "Invalid sessionType" })),
+        )
+            .into_response();
+    };
+    let (status, body) = state
+        .model_capabilities
+        .refresh(st, resolve_context(st, &query))
+        .await;
+    (status, Json(body)).into_response()
+}
+
+/// `resolveContext` (`model-capabilities-router.ts:19-26`): only freshopencode
+/// takes a `cwd` query param into the probe context.
+fn resolve_context(session_type: SessionType, query: &HashMap<String, String>) -> Option<String> {
+    if session_type != SessionType::FreshOpencode {
+        return None;
+    }
+    query.get("cwd").cloned()
+}
+
+#[cfg(test)]
+#[path = "model_capabilities_tests.rs"]
+mod tests;

--- a/crates/freshell-freshagent/src/model_capabilities_tests.rs
+++ b/crates/freshell-freshagent/src/model_capabilities_tests.rs
@@ -1,0 +1,510 @@
+//! Tests for `model_capabilities.rs` — ports of
+//! `test/unit/server/fresh-agent/model-capability-registry.test.ts` (registry
+//! semantics) plus route-level coverage of `model-capabilities-router.ts`
+//! (400/200/503, auth, cwd query plumbing).
+
+use super::*;
+use axum::body::Body;
+use axum::http::Request;
+use serde_json::json;
+use std::collections::VecDeque;
+use tokio::sync::Notify;
+use tower::util::ServiceExt;
+
+// ── fakes ─────────────────────────────────────────────────────────────────────
+
+/// Scripted probe: records every cwd it is asked about, replies FIFO, and can
+/// optionally gate responses on a `Notify` the test controls (single-flight).
+#[derive(Default)]
+struct RecordingProbe {
+    calls: Mutex<Vec<Option<String>>>,
+    responses: Mutex<VecDeque<CatalogOut>>,
+    gate: Option<Arc<Notify>>,
+}
+
+impl RecordingProbe {
+    fn new() -> Self {
+        Self::default()
+    }
+    fn gated() -> (Arc<Self>, Arc<Notify>) {
+        let gate = Arc::new(Notify::new());
+        (
+            Arc::new(Self {
+                gate: Some(gate.clone()),
+                ..Self::default()
+            }),
+            gate,
+        )
+    }
+    async fn push_ok(&self, models: Vec<ModelCapability>) {
+        self.responses.lock().await.push_back(Ok(models));
+    }
+    async fn push_err(&self, err: CapabilityError) {
+        self.responses.lock().await.push_back(Err(err));
+    }
+    async fn call_count(&self) -> usize {
+        self.calls.lock().await.len()
+    }
+    async fn calls(&self) -> Vec<Option<String>> {
+        self.calls.lock().await.clone()
+    }
+}
+
+impl ModelCatalogProbe for RecordingProbe {
+    fn probe<'a>(&'a self, cwd: Option<&'a str>) -> BoxFuture<'a, CatalogOut> {
+        Box::pin(async move {
+            self.calls.lock().await.push(cwd.map(|s| s.to_string()));
+            let next = self.responses.lock().await.pop_front().unwrap_or_else(|| {
+                Err(CapabilityError {
+                    code: "CAPABILITY_PROBE_FAILED".into(),
+                    message: "no scripted response".into(),
+                    retryable: true,
+                })
+            });
+            if let Some(gate) = &self.gate {
+                gate.notified().await;
+            }
+            next
+        })
+    }
+}
+
+fn cap(id: &str, display: &str, source_id: Option<&str>) -> ModelCapability {
+    ModelCapability {
+        id: id.to_string(),
+        display_name: display.to_string(),
+        provider: "opencode",
+        source: source_id.map(|s| freshell_opencode::catalog::ModelCapabilitySource {
+            id: s.to_string(),
+            display_name: s.to_string(),
+        }),
+        supports_effort: true,
+        supported_effort_levels: ["minimal", "low", "medium", "high", "max"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        supports_adaptive_thinking: true,
+    }
+}
+
+fn glm() -> Vec<ModelCapability> {
+    vec![cap("opencode-go/glm-5.2", "GLM 5.2", Some("opencode-go"))]
+}
+
+fn gemini() -> Vec<ModelCapability> {
+    vec![cap("google/gemini-3-pro", "Gemini 3 Pro", Some("google"))]
+}
+
+fn registry_with(
+    probe: Arc<RecordingProbe>,
+) -> (ModelCapabilityRegistry, Arc<std::sync::Mutex<u64>>) {
+    let now = Arc::new(std::sync::Mutex::new(1_000u64));
+    let now_clone = now.clone();
+    let registry = ModelCapabilityRegistry::with_clock(
+        probe,
+        Arc::new(move || *now_clone.lock().unwrap()),
+        Duration::from_millis(5_000),
+    );
+    (registry, now)
+}
+
+fn expected_model_json(m: &ModelCapability) -> Value {
+    serde_json::to_value(m).unwrap()
+}
+
+// ── registry semantics (model-capability-registry.test.ts ports) ──────────────
+
+/// Port of "caches OpenCode capabilities by cwd without probing Claude or live
+/// session sidecars" (`registry.test.ts:387-419`).
+#[tokio::test]
+async fn opencode_catalog_caches_by_cwd() {
+    let probe = Arc::new(RecordingProbe::new());
+    probe.push_ok(glm()).await;
+    probe.push_ok(gemini()).await;
+    let (registry, _now) = registry_with(probe.clone());
+
+    let (status_a, body_a) = registry
+        .get(SessionType::FreshOpencode, Some("/repo/a".into()))
+        .await;
+    assert_eq!(status_a, StatusCode::OK);
+    assert_eq!(body_a["status"], json!("fresh"));
+    assert_eq!(body_a["models"][0]["id"], json!("opencode-go/glm-5.2"));
+
+    let (_s, body_b) = registry
+        .get(SessionType::FreshOpencode, Some("/repo/b".into()))
+        .await;
+    assert_eq!(body_b["models"][0]["id"], json!("google/gemini-3-pro"));
+
+    // Repeat A within TTL → cached, no third probe.
+    let (_s, body_a2) = registry
+        .get(SessionType::FreshOpencode, Some("/repo/a".into()))
+        .await;
+    assert_eq!(body_a2["status"], json!("cached"));
+    assert_eq!(probe.call_count().await, 2);
+}
+
+/// Port of the TTL arm of "coalesces concurrent refreshes, reuses successful
+/// cache within ttl, and refreshes again after expiry" (`:133-185`).
+#[tokio::test]
+async fn cache_entry_expires_past_ttl_and_reprobes() {
+    let probe = Arc::new(RecordingProbe::new());
+    probe.push_ok(glm()).await;
+    probe.push_ok(gemini()).await;
+    let (registry, now) = registry_with(probe.clone());
+
+    let (_s, first) = registry.get(SessionType::FreshOpencode, None).await;
+    assert_eq!(first["status"], json!("fresh"));
+    let (_s, cached) = registry.get(SessionType::FreshOpencode, None).await;
+    assert_eq!(cached["status"], json!("cached"));
+    assert_eq!(cached["fetchedAt"], json!(1_000));
+    assert_eq!(probe.call_count().await, 1);
+
+    *now.lock().unwrap() += 5_001;
+    let (_s, reprobe) = registry.get(SessionType::FreshOpencode, None).await;
+    assert_eq!(reprobe["status"], json!("fresh"));
+    assert_eq!(reprobe["fetchedAt"], json!(6_001));
+    assert_eq!(reprobe["models"][0]["id"], json!("google/gemini-3-pro"));
+    assert_eq!(probe.call_count().await, 2);
+}
+
+/// Port of "keeps the last successful catalog after a failed refresh"
+/// (`:223-266`).
+#[tokio::test]
+async fn failed_refresh_keeps_last_successful_cache() {
+    let probe = Arc::new(RecordingProbe::new());
+    probe.push_ok(glm()).await;
+    let (registry, _now) = registry_with(probe.clone());
+
+    let (status, first) = registry
+        .get(SessionType::FreshOpencode, Some("/repo/a".into()))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(first["models"][0]["id"], json!("opencode-go/glm-5.2"));
+
+    probe
+        .push_err(CapabilityError {
+            code: "CAPABILITY_PROBE_FAILED".into(),
+            message: "probe failed".into(),
+            retryable: true,
+        })
+        .await;
+    let (status, refresh) = registry
+        .refresh(SessionType::FreshOpencode, Some("/repo/a".into()))
+        .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        refresh,
+        json!({
+            "ok": false,
+            "sessionType": "freshopencode",
+            "runtimeProvider": "opencode",
+            "status": "unavailable",
+            "models": [],
+            "error": {
+                "code": "CAPABILITY_PROBE_FAILED",
+                "message": "probe failed",
+                "retryable": true,
+            },
+        })
+    );
+
+    // The cache kept the last success; get() stays within TTL → cached.
+    let (status, after) = registry
+        .get(SessionType::FreshOpencode, Some("/repo/a".into()))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(after["status"], json!("cached"));
+    assert_eq!(after["models"][0]["id"], json!("opencode-go/glm-5.2"));
+}
+
+/// Port of the coalescing arm of `:133-185`: concurrent refreshes share ONE probe.
+#[tokio::test]
+async fn concurrent_refreshes_single_flight_one_probe() {
+    let (probe, gate) = RecordingProbe::gated();
+    probe.push_ok(glm()).await;
+    let (registry, _now) = registry_with(probe.clone());
+    let registry = Arc::new(registry);
+
+    let a = {
+        let registry = registry.clone();
+        tokio::spawn(async move { registry.refresh(SessionType::FreshOpencode, None).await })
+    };
+    let b = {
+        let registry = registry.clone();
+        tokio::spawn(async move { registry.refresh(SessionType::FreshOpencode, None).await })
+    };
+    // Let both tasks enter the gate.
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    gate.notify_waiters();
+    let ((status_a, body_a), (status_b, body_b)) = (a.await.unwrap(), b.await.unwrap());
+
+    assert_eq!(status_a, StatusCode::OK);
+    assert_eq!(status_b, StatusCode::OK);
+    assert_eq!(body_a["status"], json!("fresh"));
+    assert_eq!(body_b["status"], json!("fresh"));
+    assert_eq!(probe.call_count().await, 1, "one probe served both waiters");
+}
+
+/// Blank cwd is the default cache key and reaches the probe as `None`
+/// (`opencodeCacheKey`, `:256-261` + the `:302-306` trim).
+#[tokio::test]
+async fn blank_cwd_maps_to_default_cache_key() {
+    let probe = Arc::new(RecordingProbe::new());
+    probe.push_ok(glm()).await;
+    let (registry, _now) = registry_with(probe.clone());
+
+    let (_s, _) = registry
+        .get(SessionType::FreshOpencode, Some("   ".into()))
+        .await;
+    assert_eq!(probe.calls().await, vec![None]);
+}
+
+/// Port of "serves non-Claude fresh-agent catalogs without reusing the Claude
+/// probe cache" + the static-codec arm (`:187-221`), AND the documented claude
+/// static deviation (module doc).
+#[tokio::test]
+async fn non_opencode_session_types_serve_static_catalogs() {
+    let probe = Arc::new(RecordingProbe::new());
+    let (registry, _now) = registry_with(probe.clone());
+
+    let (status, codex) = registry.get(SessionType::FreshCodex, None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        codex,
+        json!({
+            "ok": true,
+            "sessionType": "freshcodex",
+            "runtimeProvider": "codex",
+            "status": "fresh",
+            "fetchedAt": 1_000,
+            "models": [
+                {
+                    "id": "gpt-5.5",
+                    "displayName": "GPT-5.5",
+                    "provider": "codex",
+                    "supportsEffort": true,
+                    "supportedEffortLevels": ["none", "minimal", "low", "medium", "high", "max"],
+                    "supportsAdaptiveThinking": true,
+                },
+                {
+                    "id": "gpt-5.4-flash",
+                    "displayName": "GPT-5.4 Flash",
+                    "provider": "codex",
+                    "supportsEffort": true,
+                    "supportedEffortLevels": ["none", "minimal", "low", "medium", "high"],
+                    "supportsAdaptiveThinking": true,
+                },
+                {
+                    "id": "gpt-5.3-codex-spark",
+                    "displayName": "GPT-5.3 Codex Spark",
+                    "provider": "codex",
+                    "supportsEffort": true,
+                    "supportedEffortLevels": ["none", "minimal", "low", "medium", "high", "max"],
+                    "supportsAdaptiveThinking": true,
+                },
+            ],
+        })
+    );
+
+    for (st, wire) in [
+        (SessionType::Kilroy, "kilroy"),
+        (SessionType::FreshClaude, "freshclaude"),
+    ] {
+        let (status, body) = registry.get(st, None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body,
+            json!({
+                "ok": true,
+                "sessionType": wire,
+                "runtimeProvider": "claude",
+                "status": "fresh",
+                "fetchedAt": 1_000,
+                "models": [
+                    {
+                        "id": "claude-opus-4-6",
+                        "displayName": "Claude Opus 4.6",
+                        "provider": "claude",
+                        "supportsEffort": true,
+                        "supportedEffortLevels": ["low", "medium", "high"],
+                        "supportsAdaptiveThinking": true,
+                    },
+                ],
+            })
+        );
+    }
+
+    assert_eq!(probe.call_count().await, 0, "static paths never probe");
+}
+
+// ── route level (model-capabilities-router.ts ports) ─────────────────────────
+
+fn app_with_probe(probe: Arc<RecordingProbe>) -> Router {
+    let (tx, _rx) = tokio::sync::broadcast::channel::<String>(64);
+    let state = FreshAgentState::new(Arc::new("tok".to_string()), Arc::new(tx))
+        .with_model_capability_probe(probe);
+    router(state)
+}
+
+async fn body_json(resp: Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+async fn get(app: Router, uri: &str, auth: bool) -> (StatusCode, Value) {
+    let mut builder = Request::builder().method("GET").uri(uri);
+    if auth {
+        builder = builder.header("x-auth-token", "tok");
+    }
+    let resp = app
+        .oneshot(builder.body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    (resp.status(), body_json(resp).await)
+}
+
+async fn post(app: Router, uri: &str, auth: bool) -> (StatusCode, Value) {
+    let mut builder = Request::builder().method("POST").uri(uri);
+    if auth {
+        builder = builder.header("x-auth-token", "tok");
+    }
+    let resp = app
+        .oneshot(builder.body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    (resp.status(), body_json(resp).await)
+}
+
+const CAP: &str = "/api/fresh-agent/model-capabilities";
+
+/// `model-capabilities-router.ts:34-37 + :50-53`.
+#[tokio::test]
+async fn invalid_session_type_is_400_for_get_and_refresh() {
+    let probe = Arc::new(RecordingProbe::new());
+    let app = app_with_probe(probe);
+
+    let (status, body) = get(app.clone(), &format!("{CAP}/nope"), true).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, json!({ "error": "Invalid sessionType" }));
+
+    let (status, body) = post(app, &format!("{CAP}/nope/refresh"), true).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, json!({ "error": "Invalid sessionType" }));
+}
+
+/// Missing auth token → the crate-wide 401 envelope (same convention as
+/// `list_tabs`/`capture`).
+#[tokio::test]
+async fn routes_require_auth() {
+    let probe = Arc::new(RecordingProbe::new());
+    let app = app_with_probe(probe);
+
+    let (status, body) = get(app.clone(), &format!("{CAP}/freshopencode"), false).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        body,
+        json!({ "status": "error", "message": "unauthorized" })
+    );
+
+    let (status, _) = post(app, &format!("{CAP}/freshopencode/refresh"), false).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+/// The happy path: a cwd-scoped GET probes once and returns the full strict
+/// envelope (`FreshAgentModelCapabilitiesResponseSchema`).
+#[tokio::test]
+async fn get_freshopencode_returns_full_envelope_and_forwards_cwd() {
+    let probe = Arc::new(RecordingProbe::new());
+    probe.push_ok(glm()).await;
+    let app = app_with_probe(probe.clone());
+
+    let (status, body) = get(app, &format!("{CAP}/freshopencode?cwd=/repo/a"), true).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ok"], json!(true));
+    assert_eq!(body["sessionType"], json!("freshopencode"));
+    assert_eq!(body["runtimeProvider"], json!("opencode"));
+    assert_eq!(body["status"], json!("fresh"));
+    assert!(
+        body["fetchedAt"].as_u64().expect("fetchedAt is an int") > 0,
+        "fetchedAt is a positive epoch-ms int"
+    );
+    assert_eq!(
+        body["models"][0],
+        expected_model_json(&cap("opencode-go/glm-5.2", "GLM 5.2", Some("opencode-go")))
+    );
+    // No extra keys (zod .strict() analog).
+    assert_eq!(
+        body.as_object().unwrap().keys().collect::<Vec<_>>().len(),
+        6,
+        "success envelope carries exactly ok/sessionType/runtimeProvider/status/fetchedAt/models"
+    );
+    assert_eq!(probe.calls().await, vec![Some("/repo/a".to_string())]);
+}
+
+/// Probe failure → 503 + the typed-error failure envelope.
+#[tokio::test]
+async fn probe_failure_maps_to_503_unavailable_envelope() {
+    let probe = Arc::new(RecordingProbe::new());
+    probe
+        .push_err(CapabilityError {
+            code: "CAPABILITY_PROBE_FAILED".into(),
+            message: "opencode serve did not become healthy within 20000ms".into(),
+            retryable: true,
+        })
+        .await;
+    let app = app_with_probe(probe);
+
+    let (status, body) = get(app, &format!("{CAP}/freshopencode"), true).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        body,
+        json!({
+            "ok": false,
+            "sessionType": "freshopencode",
+            "runtimeProvider": "opencode",
+            "status": "unavailable",
+            "models": [],
+            "error": {
+                "code": "CAPABILITY_PROBE_FAILED",
+                "message": "opencode serve did not become healthy within 20000ms",
+                "retryable": true,
+            },
+        })
+    );
+}
+
+/// Static providers work over HTTP too and never probe.
+#[tokio::test]
+async fn get_freshcodex_serves_static_catalog_over_http() {
+    let probe = Arc::new(RecordingProbe::new());
+    let app = app_with_probe(probe.clone());
+
+    let (status, body) = get(app, &format!("{CAP}/freshcodex?cwd=/ignored"), true).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["runtimeProvider"], json!("codex"));
+    assert_eq!(body["models"].as_array().unwrap().len(), 3);
+    assert_eq!(body["models"][0]["id"], json!("gpt-5.5"));
+    assert_eq!(probe.call_count().await, 0);
+}
+
+/// POST refresh re-probes even within the TTL window.
+#[tokio::test]
+async fn refresh_reprobes_and_reports_fresh() {
+    let probe = Arc::new(RecordingProbe::new());
+    probe.push_ok(glm()).await;
+    probe.push_ok(gemini()).await;
+    let app = app_with_probe(probe.clone());
+
+    let (_, first) = get(app.clone(), &format!("{CAP}/freshopencode"), true).await;
+    assert_eq!(first["status"], json!("fresh"));
+    let (_, cached) = get(app.clone(), &format!("{CAP}/freshopencode"), true).await;
+    assert_eq!(cached["status"], json!("cached"));
+
+    let (_, refreshed) = post(app, &format!("{CAP}/freshopencode/refresh"), true).await;
+    assert_eq!(refreshed["status"], json!("fresh"));
+    assert_eq!(refreshed["models"][0]["id"], json!("google/gemini-3-pro"));
+    assert_eq!(probe.call_count().await, 2);
+}

--- a/crates/freshell-opencode/Cargo.toml
+++ b/crates/freshell-opencode/Cargo.toml
@@ -35,6 +35,9 @@ real-transport = ["dep:reqwest", "dep:libc", "tokio/process", "tokio/io-util"]
 # Dynamic JSON parsing that mirrors the TS `Record<string, unknown>` event/property
 # model (JSON.parse parity, corruption-tolerant). preserve_order matches the object model.
 serde_json = { workspace = true }
+# `#[derive(Serialize)]` for the model-catalog capability wire shape
+# (`catalog.rs` — the exact `FreshAgentModelCapabilitySchema` camelCase keys).
+serde = { workspace = true }
 # Async runtime for the bounded health wait, the once-idle select loop, and the
 # broadcast fan-out. `time` = the per-probe timeout + retry sleep (DEV-0001);
 # `sync` = the per-session broadcast emitter + single-flight start mutex.
@@ -50,3 +53,10 @@ reqwest = { version = "0.13", default-features = false, features = ["stream"], o
 # FRESHELL_OPENCODE_SIDECAR_ID tag (killOwnedProcesses, serve-manager.ts:599-623). Only
 # needed by the real transport; libc is already in the workspace lock (transitive).
 libc = { version = "0.2", optional = true }
+
+[dev-dependencies]
+# `test-util` unlocks `#[tokio::test(start_paused = true)]` so the catalog probe's
+# bounded-health/deadline tests (catalog.rs) run deterministically on a paused clock —
+# the same discipline tests/serve_health_bounded.rs relies on with real sleeps; unlike
+# that integration test these in-file tests advance the mock clock instantly.
+tokio = { version = "1", features = ["test-util"] }

--- a/crates/freshell-opencode/src/catalog.rs
+++ b/crates/freshell-opencode/src/catalog.rs
@@ -1,0 +1,873 @@
+//! # catalog — the **transient** `opencode serve --pure` model-catalog probe
+//!
+//! Port of `server/fresh-agent/adapters/opencode/model-catalog.ts`
+//! (`createOpencodeModelCatalogProvider` + `normalizeOpencodeEnabledModelCatalog`),
+//! which backs `GET /api/fresh-agent/model-capabilities/freshopencode`.
+//!
+//! Unlike the long-lived session sidecar ([`crate::serve::OpencodeServeManager`]), the
+//! catalog probe spawns an **isolated, short-lived** serve per request — cwd-scoped so
+//! project-level `opencode.json` provider config is honored — fetches
+//! `/config/providers`, normalizes the enabled provider→model list into the shared
+//! `FreshAgentModelCapability` wire shape
+//! (`shared/fresh-agent-model-capabilities.ts`), and kills the child on every exit
+//! path (`ChildGuard`, the `finally { killChildGroup(child) }` analog).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Serialize;
+use serde_json::Value;
+use tokio::time::Instant;
+
+use crate::serve::{
+    is_healthy_response, PortAllocator, ProcessSpawner, ServeError, ServeHttp, ServeHttpRequest,
+    ServeProcess, SpawnRequest, OPENCODE_SIDECAR_OWNERSHIP_ENV,
+};
+
+/// `DEFAULT_HEALTH_TIMEOUT_MS` (`model-catalog.ts:8`).
+pub const CATALOG_HEALTH_TIMEOUT_MS: u64 = 20_000;
+/// The per-probe bound applied to each `/global/health` poll — the SAME DEV-0001
+/// discipline as the sidecar manager (the reference's catalog probe shares the
+/// un-bounded-health bug; we do NOT port it).
+pub const CATALOG_HEALTH_PROBE_TIMEOUT_MS: u64 = 2_000;
+/// `DEFAULT_HEALTH_POLL_INTERVAL_MS` (`model-catalog.ts:10`).
+pub const CATALOG_HEALTH_RETRY_INTERVAL_MS: u64 = 150;
+/// `DEFAULT_REQUEST_TIMEOUT_MS` (`model-catalog.ts:9`) — 5 s, distinct from the
+/// sidecar manager's 30 s request timeout.
+pub const CATALOG_REQUEST_TIMEOUT_MS: u64 = 5_000;
+/// `MAX_DISPLAY_NAME_LENGTH` (`model-catalog.ts:11`).
+const MAX_DISPLAY_NAME_LENGTH: usize = 120;
+
+/// The fixed thinking-level list the shared contract serves for opencode models
+/// today (`normalizeOpencodeEnabledModelCatalog`,
+/// `model-catalog.ts:334`): `[minimal, low, medium, high, max]`. NOTE: this is the
+/// known placeholder — per-model real levels (from the `/config/providers`
+/// `variants` map) are a follow-up slice that must land in Node and Rust together.
+pub const OPENCODE_PLACEHOLDER_EFFORT_LEVELS: [&str; 5] =
+    ["minimal", "low", "medium", "high", "max"];
+
+/// One capability row, serialized camelCase to match
+/// `FreshAgentModelCapabilitySchema` (`shared/fresh-agent-model-capabilities.ts`)
+/// byte-for-byte-key-for-key. `source` is omitted (not null) when absent, matching
+/// the zod `.strict()` schema where the key is optional.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ModelCapability {
+    pub id: String,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    pub provider: &'static str,
+    #[serde(rename = "source", skip_serializing_if = "Option::is_none")]
+    pub source: Option<ModelCapabilitySource>,
+    #[serde(rename = "supportsEffort")]
+    pub supports_effort: bool,
+    #[serde(rename = "supportedEffortLevels")]
+    pub supported_effort_levels: Vec<String>,
+    #[serde(rename = "supportsAdaptiveThinking")]
+    pub supports_adaptive_thinking: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ModelCapabilitySource {
+    pub id: String,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+}
+
+/// Injected IO for the probe — the same three seams [`crate::serve::ServeDeps`]
+/// uses, minus the SSE event source a catalog probe never opens.
+#[derive(Clone)]
+pub struct CatalogDeps {
+    pub spawner: Arc<dyn ProcessSpawner>,
+    pub http: Arc<dyn ServeHttp>,
+    pub ports: Arc<dyn PortAllocator>,
+}
+
+/// Timing/command knobs, defaulted to the reference values. `command` honors
+/// `OPENCODE_CMD` exactly like [`crate::serve::ServeConfig::default`] so the two
+/// opencode-spawning paths resolve the same binary.
+#[derive(Clone, Debug)]
+pub struct CatalogConfig {
+    pub command: String,
+    pub env: Vec<(String, String)>,
+    pub health_timeout: Duration,
+    pub health_probe_timeout: Duration,
+    pub health_retry_interval: Duration,
+    pub request_timeout: Duration,
+}
+
+impl Default for CatalogConfig {
+    fn default() -> Self {
+        Self {
+            command: std::env::var("OPENCODE_CMD")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "opencode".to_string()),
+            env: Vec::new(),
+            health_timeout: Duration::from_millis(CATALOG_HEALTH_TIMEOUT_MS),
+            health_probe_timeout: Duration::from_millis(CATALOG_HEALTH_PROBE_TIMEOUT_MS),
+            health_retry_interval: Duration::from_millis(CATALOG_HEALTH_RETRY_INTERVAL_MS),
+            request_timeout: Duration::from_millis(CATALOG_REQUEST_TIMEOUT_MS),
+        }
+    }
+}
+
+/// Spawn the transient probe serve, wait (bounded) for health, fetch
+/// `/config/providers`, normalize the enabled model list, and kill the child —
+/// `getCatalog` (`model-catalog.ts:165-202`) + normalize.
+///
+/// `cwd` (trimmed, non-empty) selects project-config resolution
+/// (`model-catalog.ts:168-170,178`).
+pub async fn probe_enabled_model_catalog(
+    deps: &CatalogDeps,
+    config: &CatalogConfig,
+    cwd: Option<&str>,
+) -> Result<Vec<ModelCapability>, ServeError> {
+    // `model-catalog.ts:168-170`: blank cwd means the default (process) cwd.
+    let cwd = cwd.map(str::trim).filter(|s| !s.is_empty());
+    let endpoint = deps.ports.allocate().map_err(ServeError::PortAllocation)?;
+    let base_url = format!("http://{}:{}", endpoint.hostname, endpoint.port);
+    let ownership_id = uuid::Uuid::new_v4().to_string();
+
+    let mut env = config.env.clone();
+    env.push((
+        OPENCODE_SIDECAR_OWNERSHIP_ENV.to_string(),
+        ownership_id.clone(),
+    ));
+    let process = deps
+        .spawner
+        .spawn(SpawnRequest {
+            command: config.command.clone(),
+            hostname: endpoint.hostname,
+            port: endpoint.port,
+            ownership_id,
+            env,
+            pure: true,
+            cwd: cwd.map(|s| s.to_string()),
+        })
+        .map_err(ServeError::Spawn)?;
+    // `finally { killChildGroup(child) }` (`model-catalog.ts:199-201`): the guard
+    // kills on EVERY exit path below — success, health failure, HTTP error, decode
+    // error.
+    let guard = ChildGuard(process);
+
+    wait_for_catalog_health(deps, config, &base_url, guard.process()).await?;
+
+    let url = format!("{base_url}/config/providers");
+    let req = ServeHttpRequest::get(url.clone()).with_timeout(config.request_timeout);
+    let res = match tokio::time::timeout(config.request_timeout, deps.http.request(req)).await {
+        Ok(result) => result.map_err(ServeError::Transport)?,
+        Err(_) => {
+            return Err(ServeError::RequestTimeout {
+                method: "GET".to_string(),
+                url,
+                timeout_ms: config.request_timeout.as_millis() as u64,
+            });
+        }
+    };
+    if !res.ok() {
+        // `model-catalog.ts:194-196`.
+        return Err(ServeError::Http {
+            method: "GET".to_string(),
+            url,
+            status: res.status,
+            body: String::from_utf8_lossy(&res.body).into_owned(),
+        });
+    }
+    let raw: Value =
+        serde_json::from_slice(&res.body).map_err(|e| ServeError::Decode(e.to_string()))?;
+    // `guard` drops here (end of scope), killing the probe child on the success
+    // path too — the reference's `finally`.
+    Ok(normalize_enabled_model_catalog(&raw))
+}
+
+/// `normalizeOpencodeEnabledModelCatalog` (`model-catalog.ts:308-340`): accept the
+/// providers payload as a record OR the 1.17.x array form (`readProvidersField`,
+/// `:245-260`), skip slash-containing provider ids (`:315`), sanitize display names
+/// (`cleanDisplayName`, `:233-240`), and NEVER copy credential-shaped model fields
+/// (api-key/options/headers/description) into the output.
+pub fn normalize_enabled_model_catalog(raw: &Value) -> Vec<ModelCapability> {
+    let mut models = Vec::new();
+    for (provider_key, raw_provider) in read_provider_entries(raw) {
+        let Some(provider) = raw_provider.as_object() else {
+            continue;
+        };
+        // `model-catalog.ts:314-316`: id → key fallback; slash ids skipped (they
+        // would collide with the `provider/model` id join).
+        let provider_id = read_non_empty_string(provider.get("id")).unwrap_or(provider_key);
+        if provider_id.is_empty() || provider_id.contains('/') {
+            continue;
+        }
+        let provider_display_name = {
+            let cleaned = clean_display_name(
+                &read_non_empty_string(provider.get("name")).unwrap_or_else(|| provider_id.clone()),
+            );
+            if cleaned.is_empty() {
+                provider_id.clone()
+            } else {
+                cleaned
+            }
+        };
+        let Some(raw_models) = provider.get("models").and_then(Value::as_object) else {
+            continue;
+        };
+        for (model_key, raw_model) in raw_models {
+            let Some(model) = raw_model.as_object() else {
+                continue;
+            };
+            let model_id =
+                read_non_empty_string(model.get("id")).unwrap_or_else(|| model_key.clone());
+            if model_id.is_empty() {
+                continue;
+            }
+            // `model-catalog.ts:322-327`: name → displayName → display_name → id.
+            let display = clean_display_name(
+                &read_non_empty_string(model.get("name"))
+                    .or_else(|| read_non_empty_string(model.get("displayName")))
+                    .or_else(|| read_non_empty_string(model.get("display_name")))
+                    .unwrap_or_else(|| model_id.clone()),
+            );
+            let display_name = if display.is_empty() {
+                model_id.clone()
+            } else {
+                display
+            };
+            models.push(ModelCapability {
+                id: format!("{provider_id}/{model_id}"),
+                display_name,
+                provider: "opencode",
+                source: Some(ModelCapabilitySource {
+                    id: provider_id.clone(),
+                    display_name: provider_display_name.clone(),
+                }),
+                supports_effort: true,
+                supported_effort_levels: OPENCODE_PLACEHOLDER_EFFORT_LEVELS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+                supports_adaptive_thinking: true,
+            });
+        }
+    }
+    // `compareBySourceThenNameThenId` (`model-catalog.ts:297-306`): localeCompare
+    // with `sensitivity: 'base'` — case-insensitive ordering, ties fall through.
+    models.sort_by(|a, b| {
+        let a_src = a.source.as_ref().map(|s| s.id.as_str()).unwrap_or("");
+        let b_src = b.source.as_ref().map(|s| s.id.as_str()).unwrap_or("");
+        ci_cmp(a_src, b_src)
+            .then_with(|| ci_cmp(&a.display_name, &b.display_name))
+            .then_with(|| ci_cmp(&a.id, &b.id))
+    });
+    models
+}
+
+/// `readNonEmptyString` (`model-catalog.ts:227-231`).
+fn read_non_empty_string(value: Option<&Value>) -> Option<String> {
+    let trimmed = value?.as_str()?.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// `cleanDisplayName` (`model-catalog.ts:233-240`): strip C0 control chars + DEL
+/// (`CONTROL_CHAR_PATTERN`), trim, cap at [`MAX_DISPLAY_NAME_LENGTH`].
+fn clean_display_name(value: &str) -> String {
+    let stripped: String = value
+        .chars()
+        .filter(|c| !matches!(*c, '\u{0}'..='\u{1F}' | '\u{7F}'))
+        .collect();
+    let trimmed = stripped.trim();
+    if trimmed.chars().count() > MAX_DISPLAY_NAME_LENGTH {
+        trimmed.chars().take(MAX_DISPLAY_NAME_LENGTH).collect()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Case-insensitive compare standing in for `localeCompare(_, 'base')`.
+fn ci_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    a.to_lowercase().cmp(&b.to_lowercase())
+}
+
+/// `readProvidersField`/`readProviderMap` (`model-catalog.ts:245-284`): the
+/// providers field arrives as a record (current) OR a 1.17.x array of Info
+/// objects; array entries key by their own `id`.
+fn read_provider_entries(raw: &Value) -> Vec<(String, Value)> {
+    let mut out = Vec::new();
+    match raw.get("providers") {
+        Some(Value::Object(map)) => {
+            for (key, value) in map {
+                out.push((key.clone(), value.clone()));
+            }
+        }
+        Some(Value::Array(items)) => {
+            for entry in items {
+                if entry.is_object() {
+                    if let Some(id) = read_non_empty_string(entry.get("id")) {
+                        out.push((id, entry.clone()));
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Kills the probe child exactly once on drop — the `finally` analog.
+struct ChildGuard(Box<dyn ServeProcess>);
+
+impl ChildGuard {
+    fn process(&self) -> &dyn ServeProcess {
+        self.0.as_ref()
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        self.0.kill();
+    }
+}
+
+/// Bounded health wait for the probe serve — the same DEV-0001 discipline as
+/// [`crate::serve::OpencodeServeManager::wait_for_health`] (each probe bounded by
+/// `health_probe_timeout`, `take_fatal_startup_error`/`exited` checked per poll,
+/// retry cadence, outer deadline → [`ServeError::NotHealthy`]). The reference's
+/// catalog wait (`model-catalog.ts:91-163`) additionally watches an abort signal;
+/// nothing upstream threads one in, so the port omits it.
+async fn wait_for_catalog_health(
+    deps: &CatalogDeps,
+    config: &CatalogConfig,
+    base_url: &str,
+    process: &dyn ServeProcess,
+) -> Result<(), ServeError> {
+    let deadline = Instant::now() + config.health_timeout;
+    loop {
+        if let Some(stderr) = process.take_fatal_startup_error() {
+            return Err(ServeError::StartupFailed(stderr));
+        }
+        if let Some(code) = process.exited() {
+            return Err(ServeError::ProcessExited { code });
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+
+        let probe_budget = config.health_probe_timeout.min(remaining);
+        let req =
+            ServeHttpRequest::get(format!("{base_url}/global/health")).with_timeout(probe_budget);
+        match tokio::time::timeout(probe_budget, deps.http.request(req)).await {
+            Ok(Ok(resp)) if resp.ok() && is_healthy_response(&resp.body) => return Ok(()),
+            _ => {}
+        }
+
+        let sleep_for = config
+            .health_retry_interval
+            .min(deadline.saturating_duration_since(Instant::now()));
+        if sleep_for.is_zero() {
+            break;
+        }
+        tokio::time::sleep(sleep_for).await;
+    }
+    Err(ServeError::NotHealthy {
+        timeout_ms: config.health_timeout.as_millis() as u64,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serve::{Endpoint, ServeHttpResponse};
+    use serde_json::json;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    // ── fakes (the serve.rs trait seams) ────────────────────────────────────────
+
+    #[derive(Default)]
+    struct FakeProcessState {
+        exited: Option<i32>,
+        fatal_stderr: Option<String>,
+        kill_calls: usize,
+    }
+
+    struct FakeProcess {
+        state: Arc<Mutex<FakeProcessState>>,
+    }
+
+    impl ServeProcess for FakeProcess {
+        fn exited(&self) -> Option<i32> {
+            self.state.lock().unwrap().exited
+        }
+        fn take_fatal_startup_error(&self) -> Option<String> {
+            self.state.lock().unwrap().fatal_stderr.take()
+        }
+        fn kill(&self) {
+            self.state.lock().unwrap().kill_calls += 1;
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeSpawner {
+        requests: Mutex<Vec<SpawnRequest>>,
+        process_state: Arc<Mutex<FakeProcessState>>,
+    }
+
+    impl FakeSpawner {
+        fn kill_calls(&self) -> usize {
+            self.process_state.lock().unwrap().kill_calls
+        }
+    }
+
+    impl ProcessSpawner for FakeSpawner {
+        fn spawn(&self, req: SpawnRequest) -> Result<Box<dyn ServeProcess>, String> {
+            self.requests.lock().unwrap().push(req);
+            Ok(Box::new(FakeProcess {
+                state: self.process_state.clone(),
+            }))
+        }
+    }
+
+    #[derive(Default)]
+    struct ScriptedHttpState {
+        health: VecDeque<Result<ServeHttpResponse, String>>,
+        providers: VecDeque<Result<ServeHttpResponse, String>>,
+        requests: Vec<String>,
+    }
+
+    #[derive(Default)]
+    struct ScriptedHttp {
+        state: Mutex<ScriptedHttpState>,
+    }
+
+    impl ScriptedHttp {
+        fn push_health(&self, r: Result<ServeHttpResponse, String>) {
+            self.state.lock().unwrap().health.push_back(r);
+        }
+        fn push_providers(&self, r: Result<ServeHttpResponse, String>) {
+            self.state.lock().unwrap().providers.push_back(r);
+        }
+        fn requests(&self) -> Vec<String> {
+            self.state.lock().unwrap().requests.clone()
+        }
+    }
+
+    impl ServeHttp for ScriptedHttp {
+        fn request<'a>(
+            &'a self,
+            req: ServeHttpRequest,
+        ) -> crate::serve::BoxFuture<'a, Result<ServeHttpResponse, String>> {
+            let url = req.url.clone();
+            let next = {
+                let mut state = self.state.lock().unwrap();
+                state.requests.push(url.clone());
+                if url.ends_with("/global/health") {
+                    state.health.pop_front()
+                } else if url.ends_with("/config/providers") {
+                    state.providers.pop_front()
+                } else {
+                    None
+                }
+            };
+            Box::pin(async move {
+                next.unwrap_or_else(|| Err(format!("no scripted response for {url}")))
+            })
+        }
+    }
+
+    struct FixedPorts;
+
+    impl PortAllocator for FixedPorts {
+        fn allocate(&self) -> Result<Endpoint, String> {
+            Ok(Endpoint {
+                hostname: "127.0.0.1".to_string(),
+                port: 48123,
+            })
+        }
+    }
+
+    fn js_status_ok(body: Value) -> Result<ServeHttpResponse, String> {
+        Ok(ServeHttpResponse::new(
+            200,
+            serde_json::to_vec(&body).unwrap(),
+        ))
+    }
+
+    fn test_deps(spawner: Arc<FakeSpawner>, http: Arc<ScriptedHttp>) -> CatalogDeps {
+        CatalogDeps {
+            spawner,
+            http,
+            ports: Arc::new(FixedPorts),
+        }
+    }
+
+    fn fast_config() -> CatalogConfig {
+        CatalogConfig {
+            command: "opencode".to_string(),
+            env: Vec::new(),
+            health_timeout: Duration::from_millis(5_000),
+            health_probe_timeout: Duration::from_millis(2_000),
+            health_retry_interval: Duration::from_millis(150),
+            request_timeout: Duration::from_millis(500),
+        }
+    }
+
+    // ── probe behavior (the spawn→health→fetch→kill lifecycle) ──────────────────
+
+    /// Port of `opencode-model-catalog.test.ts` "starts an isolated short-lived
+    /// serve process, fetches cwd-scoped /config/providers, and stops only that
+    /// child" (`:29-68`).
+    #[tokio::test(start_paused = true)]
+    async fn probe_spawns_pure_cwd_scoped_serve_fetches_config_providers_and_kills_child() {
+        let spawner = Arc::new(FakeSpawner::default());
+        let http = Arc::new(ScriptedHttp::default());
+        http.push_health(js_status_ok(json!({ "healthy": true })));
+        http.push_providers(js_status_ok(json!({
+            "providers": {
+                "opencode-go": {
+                    "id": "opencode-go",
+                    "name": "opencode-go",
+                    "models": { "glm-5.2": { "id": "glm-5.2", "name": "GLM 5.2" } },
+                },
+            },
+            "default": { "opencode-go": "glm-5.2" },
+        })));
+
+        let result = probe_enabled_model_catalog(
+            &test_deps(spawner.clone(), http.clone()),
+            &fast_config(),
+            Some("/repo/project-a"),
+        )
+        .await
+        .expect("happy-path probe succeeds");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "opencode-go/glm-5.2");
+        assert_eq!(result[0].display_name, "GLM 5.2");
+
+        let spawned = spawner.requests.lock().unwrap();
+        assert_eq!(spawned.len(), 1, "exactly one probe child spawned");
+        let req = &spawned[0];
+        assert_eq!(req.command, "opencode");
+        assert_eq!(req.hostname, "127.0.0.1");
+        assert_eq!(req.port, 48123);
+        assert!(req.pure, "the catalog probe must spawn with --pure");
+        assert_eq!(req.cwd.as_deref(), Some("/repo/project-a"));
+        assert!(
+            req.env
+                .iter()
+                .any(|(k, v)| k == OPENCODE_SIDECAR_OWNERSHIP_ENV && !v.is_empty()),
+            "the probe child carries the ownership tag so kill() can reap the group"
+        );
+        drop(spawned);
+
+        assert_eq!(
+            http.requests(),
+            vec![
+                "http://127.0.0.1:48123/global/health".to_string(),
+                "http://127.0.0.1:48123/config/providers".to_string(),
+            ]
+        );
+        assert_eq!(
+            spawner.kill_calls(),
+            1,
+            "the probe child is killed exactly once"
+        );
+    }
+
+    /// Port of "fast-fails when the serve child exits before becoming healthy"
+    /// (`:108-128`): an exit during startup short-circuits the health wait.
+    #[tokio::test(start_paused = true)]
+    async fn probe_fails_fast_when_child_exits_before_healthy() {
+        let spawner = Arc::new(FakeSpawner::default());
+        {
+            spawner.process_state.lock().unwrap().exited = Some(1);
+        }
+        let http = Arc::new(ScriptedHttp::default());
+        http.push_health(Ok(ServeHttpResponse::new(503, b"{}".to_vec())));
+
+        let err =
+            probe_enabled_model_catalog(&test_deps(spawner.clone(), http), &fast_config(), None)
+                .await
+                .expect_err("early exit fails the probe");
+        assert_eq!(err, ServeError::ProcessExited { code: 1 });
+        assert_eq!(spawner.kill_calls(), 1);
+    }
+
+    /// Port of "fast-fails when the serve child emits an error (e.g. ENOENT) before
+    /// becoming healthy" (`:130-150`): the fatal-stderr path (the reference greps
+    /// stderr; the port reads `take_fatal_startup_error`, same seam the sidecar uses).
+    #[tokio::test(start_paused = true)]
+    async fn probe_fails_fast_when_stderr_reports_serve_error() {
+        let spawner = Arc::new(FakeSpawner::default());
+        {
+            spawner.process_state.lock().unwrap().fatal_stderr =
+                Some("ServeError: EADDRINUSE port 48123".to_string());
+        }
+        let http = Arc::new(ScriptedHttp::default());
+        http.push_health(Ok(ServeHttpResponse::new(503, b"{}".to_vec())));
+
+        let err =
+            probe_enabled_model_catalog(&test_deps(spawner.clone(), http), &fast_config(), None)
+                .await
+                .expect_err("fatal stderr fails the probe");
+        assert!(
+            matches!(&err, ServeError::StartupFailed(msg) if msg.contains("EADDRINUSE")),
+            "fatal stderr surfaced via StartupFailed, got {err:?}"
+        );
+        assert_eq!(spawner.kill_calls(), 1);
+    }
+
+    /// A serve that never becomes healthy within the outer deadline fails as
+    /// `NotHealthy` — the DEV-0001 bounded-probe discipline, kept in the catalog
+    /// probe even though the Node reference's catalog wait shares the un-bounded bug.
+    #[tokio::test(start_paused = true)]
+    async fn probe_fails_not_healthy_at_the_outer_deadline() {
+        let spawner = Arc::new(FakeSpawner::default());
+        let http = Arc::new(ScriptedHttp::default());
+        // Health polls that always fail (transport-side, e.g. connection refused);
+        // under paused time the loop burns through the deadline instantly.
+        for _ in 0..256 {
+            http.push_health(Err("connection refused".to_string()));
+        }
+
+        let err =
+            probe_enabled_model_catalog(&test_deps(spawner.clone(), http), &fast_config(), None)
+                .await
+                .expect_err("wedged serve fails as NotHealthy");
+        assert_eq!(err, ServeError::NotHealthy { timeout_ms: 5_000 });
+        assert_eq!(spawner.kill_calls(), 1);
+    }
+
+    /// `model-catalog.ts:194-196`: a non-2xx `/config/providers` is a hard error.
+    #[tokio::test(start_paused = true)]
+    async fn probe_fails_when_config_providers_is_not_ok() {
+        let spawner = Arc::new(FakeSpawner::default());
+        let http = Arc::new(ScriptedHttp::default());
+        http.push_health(js_status_ok(json!({ "healthy": true })));
+        http.push_providers(Ok(ServeHttpResponse::new(500, b"boom".to_vec())));
+
+        let err =
+            probe_enabled_model_catalog(&test_deps(spawner.clone(), http), &fast_config(), None)
+                .await
+                .expect_err("non-2xx providers response fails the probe");
+        assert!(
+            matches!(&err, ServeError::Http { status: 500, .. }),
+            "providers 500 surfaces as Http{{status:500}}, got {err:?}"
+        );
+        assert_eq!(spawner.kill_calls(), 1);
+    }
+
+    /// Health polls retry at the configured cadence until a healthy response lands.
+    #[tokio::test(start_paused = true)]
+    async fn probe_retries_health_until_healthy() {
+        let spawner = Arc::new(FakeSpawner::default());
+        let http = Arc::new(ScriptedHttp::default());
+        http.push_health(Err("connection refused".to_string()));
+        http.push_health(Ok(ServeHttpResponse::new(503, b"{}".to_vec())));
+        http.push_health(js_status_ok(json!({ "healthy": true })));
+        http.push_providers(js_status_ok(json!({ "providers": {}, "default": {} })));
+
+        let result = probe_enabled_model_catalog(
+            &test_deps(spawner.clone(), http.clone()),
+            &fast_config(),
+            None,
+        )
+        .await
+        .expect("recovers once the serve comes up");
+        assert!(result.is_empty(), "empty providers → empty model list");
+        assert_eq!(
+            http.requests().len(),
+            4,
+            "three health polls then the providers fetch"
+        );
+    }
+
+    // ── normalization (pure function) ───────────────────────────────────────────
+
+    /// Port of "sanitizes enabled provider models and does not copy
+    /// credential-shaped fields or descriptions" (`:70-106`).
+    #[test]
+    fn normalize_sanitizes_models_and_never_leaks_credentials() {
+        let models = normalize_enabled_model_catalog(&json!({
+            "providers": {
+                "deepseek": {
+                    "id": "deepseek",
+                    "name": "deepseek",
+                    "apiKey": "must-not-leak",
+                    "models": {
+                        "deepseek-v4-pro": {
+                            "id": "deepseek-v4-pro",
+                            "name": "DeepSeek V4 Pro",
+                            "description": "must-not-leak-description",
+                            "options": { "apiKey": "must-not-leak" },
+                            "headers": { "authorization": "must-not-leak" },
+                        },
+                    },
+                },
+                "bad/source": {
+                    "id": "bad/source",
+                    "models": { "one": { "id": "one" } },
+                },
+            },
+        }));
+
+        assert_eq!(
+            models,
+            vec![ModelCapability {
+                id: "deepseek/deepseek-v4-pro".to_string(),
+                display_name: "DeepSeek V4 Pro".to_string(),
+                provider: "opencode",
+                source: Some(ModelCapabilitySource {
+                    id: "deepseek".to_string(),
+                    display_name: "deepseek".to_string(),
+                }),
+                supports_effort: true,
+                supported_effort_levels: OPENCODE_PLACEHOLDER_EFFORT_LEVELS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+                supports_adaptive_thinking: true,
+            }]
+        );
+        let rendered = serde_json::to_string(&models).unwrap();
+        assert!(
+            !rendered.contains("must-not-leak")
+                && !rendered.contains("authorization")
+                && !rendered.contains("apiKey")
+                && !rendered.contains("description"),
+            "credential-shaped fields never reach the serialized output: {rendered}"
+        );
+    }
+
+    /// Port of "normalizes array-format providers from opencode 1.17.x
+    /// /config/providers" (`:152-203`), incl. the source→displayName→id sort.
+    #[test]
+    fn normalize_accepts_the_1_17_array_provider_format_and_sorts() {
+        let models = normalize_enabled_model_catalog(&json!({
+            "providers": [
+                {
+                    "id": "deepseek",
+                    "name": "deepseek",
+                    "models": {
+                        "deepseek-v4-pro": { "id": "deepseek-v4-pro", "name": "DeepSeek V4 Pro" },
+                        "deepseek-v4-flash": { "id": "deepseek-v4-flash", "name": "DeepSeek V4 Flash" },
+                    },
+                },
+                {
+                    "id": "opencode-go",
+                    "name": "opencode-go",
+                    "models": { "glm-5.2": { "id": "glm-5.2", "name": "GLM 5.2" } },
+                },
+            ],
+            "default": { "opencode-go": "glm-5.2" },
+        }));
+
+        let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "deepseek/deepseek-v4-flash",
+                "deepseek/deepseek-v4-pro",
+                "opencode-go/glm-5.2"
+            ]
+        );
+        assert!(models.iter().all(|m| m.supports_effort
+            && m.supported_effort_levels
+                == OPENCODE_PLACEHOLDER_EFFORT_LEVELS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect::<Vec<_>>()
+            && m.supports_adaptive_thinking));
+    }
+
+    /// `model-catalog.ts:314,320`: empty/missing ids fall back to the MAP KEY; a
+    /// provider with a slash (or empty id AND key) is skipped; model entries that
+    /// are not objects are skipped.
+    #[test]
+    fn normalize_falls_back_to_map_keys_and_skips_malformed_entries() {
+        let models = normalize_enabled_model_catalog(&json!({
+            "providers": {
+                "keyprovider": {
+                    "models": {
+                        "keymodel": { "name": "Keyed Name" },
+                        "garbage": 42,
+                    },
+                },
+                "nested/slash": {
+                    "id": "nested/slash",
+                    "models": { "x": {} },
+                },
+            },
+        }));
+
+        assert_eq!(
+            models,
+            vec![ModelCapability {
+                id: "keyprovider/keymodel".to_string(),
+                display_name: "Keyed Name".to_string(),
+                provider: "opencode",
+                source: Some(ModelCapabilitySource {
+                    id: "keyprovider".to_string(),
+                    display_name: "keyprovider".to_string(),
+                }),
+                supports_effort: true,
+                supported_effort_levels: OPENCODE_PLACEHOLDER_EFFORT_LEVELS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+                supports_adaptive_thinking: true,
+            }]
+        );
+    }
+
+    /// `cleanDisplayName` (`:233-240`): control characters stripped, trimmed,
+    /// capped at 120 chars; display-name fallback chain
+    /// name → displayName → display_name → id (`:322-327`).
+    #[test]
+    fn normalize_cleans_display_names_and_follows_the_fallback_chain() {
+        let long = "x".repeat(300);
+        let provided = json!({
+            "providers": {
+                "p": {
+                    "id": "p",
+                    "name": "\u{7}Providers\u{1} Name\u{7f}",
+                    "models": {
+                        "a": { "id": "a", "name": "  Named With Spaces  " },
+                        "b": { "id": "b", "displayName": "Camel Display" },
+                        "c": { "id": "c", "display_name": "Snake Display" },
+                        "d": { "id": "d" },
+                        "e": { "id": "e", "name": long },
+                        "f": { "id": "f", "name": "\u{0}-\u{1f}" },
+                    },
+                },
+            },
+        });
+
+        let models = normalize_enabled_model_catalog(&provided);
+        let by_id: std::collections::HashMap<&str, &ModelCapability> =
+            models.iter().map(|m| (m.id.as_str(), m)).collect();
+
+        assert_eq!(by_id["p/a"].display_name, "Named With Spaces");
+        assert_eq!(by_id["p/b"].display_name, "Camel Display");
+        assert_eq!(by_id["p/c"].display_name, "Snake Display");
+        assert_eq!(by_id["p/d"].display_name, "d");
+        assert_eq!(by_id["p/e"].display_name.len(), MAX_DISPLAY_NAME_LENGTH);
+        assert_eq!(by_id["p/f"].display_name, "-");
+        assert_eq!(
+            by_id["p/a"].source.as_ref().unwrap().display_name,
+            "Providers Name"
+        );
+    }
+
+    /// A `null`/garbage providers field normalizes to an empty list, not a panic
+    /// (`readProvidersField`, `:245-260`).
+    #[test]
+    fn normalize_tolerates_missing_or_wrong_typed_providers_field() {
+        assert!(normalize_enabled_model_catalog(&json!({ "providers": null })).is_empty());
+        assert!(normalize_enabled_model_catalog(&json!({ "providers": "nope" })).is_empty());
+        assert!(normalize_enabled_model_catalog(&json!({})).is_empty());
+    }
+}

--- a/crates/freshell-opencode/src/lib.rs
+++ b/crates/freshell-opencode/src/lib.rs
@@ -33,6 +33,7 @@
 //! the unchanged outer deadline; a wedged serve fails as the bounded "did not become
 //! healthy" error instead of hanging. Pinned by `tests/serve_health_bounded.rs`.
 
+pub mod catalog;
 pub mod events;
 pub mod model;
 pub mod serve;

--- a/crates/freshell-opencode/src/serve.rs
+++ b/crates/freshell-opencode/src/serve.rs
@@ -160,6 +160,13 @@ pub struct SpawnRequest {
     pub ownership_id: String,
     /// The full child environment (base env + `FRESHELL_OPENCODE_SIDECAR_ID`).
     pub env: Vec<(String, String)>,
+    /// The catalog probe spawns `serve --pure` (`model-catalog.ts:173`); the
+    /// long-lived session sidecar must NOT (it defaults config off).
+    pub pure: bool,
+    /// The catalog probe's working directory (`model-catalog.ts:178`) so
+    /// project-level `opencode.json` provider config resolves; `None` for the
+    /// session sidecar (its cwd scoping rides the `?directory=` route param).
+    pub cwd: Option<String>,
 }
 
 /// A spawned serve sidecar handle. Readiness consults [`ServeProcess::exited`] and
@@ -431,6 +438,8 @@ impl OpencodeServeManager {
                 port: endpoint.port,
                 ownership_id,
                 env,
+                pure: false,
+                cwd: None,
             })
             .map_err(ServeError::Spawn)?;
 

--- a/crates/freshell-opencode/src/transport.rs
+++ b/crates/freshell-opencode/src/transport.rs
@@ -213,11 +213,17 @@ impl ProcessSpawner for TokioProcessSpawner {
     fn spawn(&self, req: SpawnRequest) -> Result<Box<dyn ServeProcess>, String> {
         use std::process::Stdio;
         let mut cmd = tokio::process::Command::new(&req.command);
-        cmd.arg("serve")
-            .arg("--hostname")
+        cmd.arg("serve");
+        if req.pure {
+            cmd.arg("--pure");
+        }
+        cmd.arg("--hostname")
             .arg(&req.hostname)
             .arg("--port")
             .arg(req.port.to_string());
+        if let Some(cwd) = &req.cwd {
+            cmd.current_dir(cwd);
+        }
         // Inherit the parent env, then layer the request env (incl. the ownership tag).
         for (key, value) in &req.env {
             cmd.env(key, value);


### PR DESCRIPTION
## What

Ports the Node model-capabilities surface (`server/fresh-agent/model-capabilities-router.ts` + `model-capability-registry.ts` + the opencode catalog probe) to the Rust server, so the freshopencode gear popover works on the production Rust server — where the endpoint previously 404'd and the popover rendered "Catalog unavailable".

- `freshell-opencode/src/catalog.rs`: the transient, cwd-scoped `opencode serve --pure` probe (bounded per-probe health polls — same DEV-0001 discipline as the sidecar manager — `/config/providers` fetch, ownership-tagged child killed on every path) plus the strict normalizer incl. the array/record provider shapes, display-name sanitization, and credential-field exclusion.
- `SpawnRequest` gains `pure`/`cwd`; the long-lived session sidecar keeps both unset.
- `freshell-freshagent/src/model_capabilities.rs`: `GET /api/fresh-agent/model-capabilities/{sessionType}` + `POST .../refresh` with cwd-keyed 5-min TTL cache, in-flight single-flight coalescing, refresh bypass, static codex/claude catalogs, and the strict `ok:true`-200 / `ok:false`-503 envelopes.
- TDD throughout: 11 new catalog tests + 12 new registry/route tests, ported from `test/unit/server/fresh-agent/{opencode-model-catalog,model-capability-registry}.test.ts`.

## Verified

- Full `cargo test --workspace` green; clippy + fmt clean.
- Live scratch-server probe against the real `opencode serve --pure`: 39 models across 8 providers, fresh→cached (~33 ms) → cwd-scoped re-probe; 400/401 envelopes unchanged.
- The live server on 3001 is **not** restarted by this PR; deploy is a separate step.

## Deviation (documented in module docs)

`freshclaude`/`kilroy`: Node probes the Claude Agent SDK's `supportedModels()`; the Rust workspace has no Claude SDK, so these serve the shared static table (the same list the client falls back to) instead of a live probe. The freshopencode catalog — the only consumer today — is unaffected. Live claude model probing lands with the follow-up selector slice.

🤖 Generated with [OpenCode](https://opencode.ai) (Kimi-K3)