### PR TITLE
fix(session-identity): promote the legacy resumeSessionId rung into D7/D8 and convert every first-party sender to sessionRef

### DIFF
--- a/crates/freshell-freshagent/src/claude.rs
+++ b/crates/freshell-freshagent/src/claude.rs
@@ -344,7 +344,23 @@ impl FreshClaudeState {
         // Task 12 (D8 for fresh agents): a create-with-resume claims the per-sessionRef
         // lease BEFORE any spawn -- exactly one in-flight resume (and one live writer)
         // per durable transcript. ALWAYS ON (never capability-gated).
-        let resume_sid = msg.resume_session_id.clone().filter(|s| !s.is_empty());
+        //
+        // The resume id comes from the legacy `resumeSessionId` first, else the
+        // provider-matched `sessionRef` (Node parity: `runtime-manager.ts:106-108`
+        // promotes the sessionRef into the adapter's resume input the same way) --
+        // the canonical carrier must work standalone so the client can drop the
+        // legacy duplicate.
+        let resume_sid = msg
+            .resume_session_id
+            .clone()
+            .filter(|s| !s.is_empty())
+            .or_else(|| {
+                msg.session_ref
+                    .as_ref()
+                    .filter(|r| r.provider == PROVIDER)
+                    .map(|r| r.session_id.clone())
+                    .filter(|s| !s.is_empty())
+            });
         let mut lease_guard: Option<crate::FreshSessionLeaseGuard> = None;
         if let Some(sid) = resume_sid.as_deref() {
             // Task 13b (cross-kind liveness): a live terminal PTY owning `(claude, sid)`
@@ -450,7 +466,7 @@ impl FreshClaudeState {
             "model": msg.model,
             "permissionMode": msg.permission_mode,
             "effort": msg.effort,
-            "resumeSessionId": msg.resume_session_id,
+            "resumeSessionId": resume_sid,
         });
         if let Err(err) = write_line(&mut stdin, &create_req).await {
             let _ = child.start_kill();
@@ -2856,6 +2872,40 @@ rl.on('line', (line) => {
         })
         .await
         .unwrap_or_else(|_| panic!("freshAgent.created for {request_id} resolves within budget"))
+    }
+
+    /// Node parity (`runtime-manager.ts:106-108`): a `freshAgent.create` whose
+    /// ONLY identity is a provider-matched `sessionRef` must resume exactly
+    /// like the legacy `resumeSessionId` carrier — the canonical field cannot
+    /// be a second-class citizen while the client migrates off the legacy
+    /// duplicate. The fake sidecar echoes the create request's
+    /// `resumeSessionId` back as the durable id, so the created frame's
+    /// sessionId proves the promotion reached the sidecar.
+    #[tokio::test]
+    async fn handle_create_with_session_ref_only_resumes_like_legacy() {
+        let _guard = CLAUDE_ENV_LOCK.lock().await;
+        let env = FakeClaudeSidecarEnv::install();
+        let (st, mut rx) = state_with_bus();
+        let durable = "66666666-6666-4666-8666-666666666666";
+        let mut msg = dedup_create_msg("req-sref-only-1");
+        msg.session_ref = Some(freshell_protocol::SessionLocator {
+            provider: "claude".to_string(),
+            session_id: durable.to_string(),
+        });
+
+        st.handle_create(msg).await;
+        let frame = await_claude_created(&mut rx, "req-sref-only-1").await;
+
+        assert_eq!(
+            frame["type"], "freshAgent.created",
+            "sessionRef-only create must succeed: {frame}"
+        );
+        let log = std::fs::read_to_string(env.spawn_log_path()).unwrap();
+        assert!(
+            log.contains(durable),
+            "sidecar create must carry the sessionRef-derived resumeSessionId: {log}"
+        );
+        drop(env);
     }
 
     /// THE regression this task fixes: a duplicate `freshAgent.create` sharing a

--- a/crates/freshell-freshagent/src/codex.rs
+++ b/crates/freshell-freshagent/src/codex.rs
@@ -497,10 +497,27 @@ impl FreshCodexState {
             FreshAgentCreateOutcome::Proceed(guard) => guard,
         };
 
+        // The resume thread id: the legacy `resumeSessionId` first, else the
+        // provider-matched `sessionRef` (Node parity: `runtime-manager.ts:106-108`
+        // promotes the sessionRef into the adapter's resume input the same way) --
+        // the canonical carrier must work standalone so the client can drop the
+        // legacy duplicate.
+        let requested_resume_session_id = msg
+            .resume_session_id
+            .clone()
+            .filter(|s| !s.is_empty())
+            .or_else(|| {
+                msg.session_ref
+                    .as_ref()
+                    .filter(|r| r.provider == PROVIDER)
+                    .map(|r| r.session_id.clone())
+                    .filter(|s| !s.is_empty())
+            });
+
         // P1.13 (Task 5, R1): for a resume-create the client's explicit params win and
         // the ledger record fills the gaps -- merged BEFORE normalization, so a missing
         // model recovers the recorded one instead of being rewritten to the default.
-        let rec = match msg.resume_session_id.as_deref() {
+        let rec = match requested_resume_session_id.as_deref() {
             Some(resume_id) => self
                 .identity_sink()
                 .and_then(|s| s.load_settings("codex", resume_id))
@@ -532,7 +549,7 @@ impl FreshCodexState {
         // `resumeSessionId` set, `FreshAgentView.tsx`'s `triggerRecovery`) silently produced
         // an EMPTY new conversation under a brand-new id -- connected, no error, just quiet
         // data loss.
-        if let Some(resume_session_id) = msg.resume_session_id.clone() {
+        if let Some(resume_session_id) = requested_resume_session_id.clone() {
             // Task 13b (cross-kind liveness): a live terminal PTY owning
             // `(codex, thread)` is the one writer on that rollout -- refuse the resume
             // with the retryable loser answer; NO lease claim, NO spawn.
@@ -7059,6 +7076,68 @@ pub(crate) mod tests {
             frame["sessionId"], "thread-existing-durable",
             "create-with-resume must preserve the CALLER's thread id, never mint a new one \
              (thread/start would have returned thread-should-never-be-minted): {frame}"
+        );
+        assert!(
+            st.sessions
+                .lock()
+                .await
+                .contains_key("thread-existing-durable"),
+            "the resumed thread must be registered under its ORIGINAL id"
+        );
+    }
+
+    /// Node parity (`runtime-manager.ts:106-108`): a `freshAgent.create` whose
+    /// ONLY identity is a provider-matched `sessionRef` must resume the thread
+    /// exactly like the legacy `resumeSessionId` carrier. Same wrong-mint
+    /// canary as the legacy-carrier test above: `thread/start` is pinned to an
+    /// obviously wrong id, so a passing sessionId assertion proves
+    /// `thread/resume` was used.
+    #[tokio::test]
+    async fn handle_create_with_session_ref_only_resumes_the_same_thread() {
+        let _guard = ENV_LOCK.lock().await;
+        configure_fake_codex_cmd(r#"{"threadStartThreadId":"thread-should-never-be-minted"}"#);
+        let (st, mut rx) = state_with_bus();
+
+        st.handle_create(FreshAgentCreate {
+            request_id: "req-sref-resume-1".to_string(),
+            session_type: freshell_protocol::SessionType::Freshcodex,
+            provider: Some(freshell_protocol::AgentProvider::Codex),
+            cwd: None,
+            legacy_restore_context: None,
+            resume_session_id: None,
+            session_ref: Some(freshell_protocol::SessionLocator {
+                provider: "codex".to_string(),
+                session_id: "thread-existing-durable".to_string(),
+            }),
+            model: None,
+            model_selection: None,
+            permission_mode: None,
+            sandbox: None,
+            effort: None,
+            plugins: None,
+        })
+        .await;
+
+        let frame: Value = tokio::time::timeout(std::time::Duration::from_secs(15), async {
+            loop {
+                let frame: Value = serde_json::from_str(&rx.recv().await.unwrap()).unwrap();
+                if frame["type"] == "freshAgent.created"
+                    || frame["type"] == "freshAgent.create.failed"
+                {
+                    return frame;
+                }
+            }
+        })
+        .await
+        .expect("the fake app-server responds within the budget");
+
+        assert_eq!(
+            frame["type"], "freshAgent.created",
+            "resuming via sessionRef must succeed: {frame}"
+        );
+        assert_eq!(
+            frame["sessionId"], "thread-existing-durable",
+            "sessionRef-only create must resume the CALLER's thread id, never mint a new one: {frame}"
         );
         assert!(
             st.sessions

--- a/crates/freshell-freshagent/src/terminal_tabs.rs
+++ b/crates/freshell-freshagent/src/terminal_tabs.rs
@@ -1198,18 +1198,47 @@ pub(crate) async fn spawn_terminal_pane(
     // Placement: before any side effect (no PTY, no MCP write, no port alloc,
     // no codex plan), so refusal needs zero rollback. This is the single choke
     // point for POST /api/tabs, /api/panes/:id/split, and /api/panes/:id/respawn
-    // (every spawn_terminal_pane caller). Scoped to the sessionRef rung exactly
-    // like WS (`accepted_session_ref` already implies provider == mode); the
-    // legacy bare-resumeSessionId rung keeps its existing behavior. No
-    // self-exemption for respawn: the old terminal is deliberately never
-    // killed ("detach, don't kill"), so resuming its live session in a second
-    // PTY would be exactly the two-writers corruption this guard forbids.
-    let mut session_ref_lease: Option<RestSessionRefLease> = None;
-    if let Some(live_sid) = accepted_session_ref
+    // (every spawn_terminal_pane caller). No self-exemption for respawn: the
+    // old terminal is deliberately never killed ("detach, don't kill"), so
+    // resuming its live session in a second PTY would be exactly the
+    // two-writers corruption this guard forbids.
+    //
+    // The guard arms on ONE effective session locator: the accepted wire
+    // `sessionRef` first, else the PROMOTED legacy `resumeSessionId` rung --
+    // `{provider: mode, sessionId}` per the reconcile door's §5.2 uniform
+    // promotion rule (reconcile.rs `promoted_legacy_claim`). The legacy rung
+    // was previously unguarded, which let a legacy-only carrier (the
+    // `freshell` CLI's `--resume`) spawn a second live writer onto an owned
+    // session (2026-08-16 duplicate-tab incident). Promotion is gated on the
+    // SAME predicate the EDEV-07 pane_content synthesis uses
+    // ([`is_session_provider_mode`] + [`plausible_resume_session_id`]), and
+    // on the resume id still being the CALLER's wire value -- a gate-healed
+    // or freshly-minted id (claude prealloc, amplifier launcher identity)
+    // never came from the wire and claims nothing, exactly like the WS door.
+    let wire_legacy_resume_id = body
+        .get("resumeSessionId")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty());
+    let guard_locator: Option<SessionLocator> = accepted_session_ref
         .as_ref()
-        .map(|r| r.session_id.as_str())
-        .filter(|sid| !sid.is_empty() && resume_session_id.as_deref() == Some(*sid))
-    {
+        .filter(|r| {
+            !r.session_id.is_empty() && resume_session_id.as_deref() == Some(r.session_id.as_str())
+        })
+        .cloned()
+        .or_else(|| {
+            resume_session_id
+                .as_deref()
+                .filter(|sid| wire_legacy_resume_id == Some(*sid))
+                .filter(|sid| {
+                    is_session_provider_mode(&mode) && plausible_resume_session_id(&mode, sid)
+                })
+                .map(|sid| SessionLocator {
+                    provider: mode.clone(),
+                    session_id: sid.to_string(),
+                })
+        });
+    let mut session_ref_lease: Option<RestSessionRefLease> = None;
+    if let Some(live_sid) = guard_locator.as_ref().map(|r| r.session_id.as_str()) {
         if registry
             .live_session_owner(state.session_identity.as_deref(), &mode, live_sid)
             .is_some()
@@ -1237,10 +1266,9 @@ pub(crate) async fn spawn_terminal_pane(
         // is the already-minted create_request_id; holder_conn is a fresh
         // registry connection id (collision-free with WS conn cleanup -- REST
         // leases rely on RAII drop + the lease TTL, not conn-death cleanup).
-        let locator = SessionLocator {
-            provider: mode.clone(),
-            session_id: live_sid.to_string(),
-        };
+        let locator = guard_locator
+            .clone()
+            .expect("guard_locator is Some inside this branch");
         match registry.claim_session_ref(
             &locator,
             &create_request_id,
@@ -5779,6 +5807,126 @@ mod tests {
             registry.bound_terminal_for_session_ref(&locator),
             Some(tid.clone()),
             "REST resume spawn must complete its lease into a sessionRef binding"
+        );
+
+        registry.kill(&tid);
+    }
+
+    // ── D7/D8 promotion of the legacy resumeSessionId rung ──────────────────
+    // The 2026-08-16 duplicate-tab incident: a legacy-only carrier (the
+    // `freshell` CLI's `new-tab --resume`) walked past both guards and spawned
+    // a second `opencode --session <sid>` writer onto a live session. A legacy
+    // `mode` + `resumeSessionId` pair IS a sessionRef claim (the reconcile
+    // door's §5.2 uniform promotion rule, reconcile.rs `promoted_legacy_claim`),
+    // so the guards must arm on it exactly as they do on the sessionRef rung.
+
+    #[tokio::test]
+    async fn rest_create_legacy_resume_onto_live_session_is_refused_409() {
+        let argv_file = unique_argv_file("d7-rest-legacy-live-refusal");
+        let state = state_with_registry()
+            .with_cli_commands(Arc::new(vec![recording_cli_spec("claude", &argv_file)]));
+        let registry = state.terminal_registry.clone().unwrap();
+        forge_live_owner(&registry, "t-legacy-live-owner");
+        let rows_before = registry.identity_probe_rows().len();
+
+        let (status, body) = post(
+            app(state),
+            "/api/tabs",
+            json!({
+                "mode": "claude",
+                "cwd": std::env::temp_dir().to_string_lossy(),
+                "resumeSessionId": LIVE_SESSION,
+            }),
+            true,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT, "{body}");
+        assert_eq!(body["code"], json!("RESTORE_UNAVAILABLE"), "{body}");
+        assert_eq!(
+            registry.identity_probe_rows().len(),
+            rows_before,
+            "no duplicate spawn on the legacy rung"
+        );
+
+        registry.kill("t-legacy-live-owner");
+    }
+
+    #[tokio::test]
+    async fn rest_create_legacy_resume_while_lease_held_is_refused_409() {
+        let argv_file = unique_argv_file("d8-legacy-lease-held-refusal");
+        let state = state_with_registry()
+            .with_cli_commands(Arc::new(vec![recording_cli_spec("claude", &argv_file)]));
+        let registry = state.terminal_registry.clone().unwrap();
+        let router = app(state);
+
+        let locator = SessionLocator {
+            provider: "claude".into(),
+            session_id: LIVE_SESSION.into(),
+        };
+        assert!(matches!(
+            registry.claim_session_ref(
+                &locator,
+                "foreign-holder",
+                registry.new_connection_id(),
+                test_now_ms()
+            ),
+            SessionRefClaim::Acquired
+        ));
+
+        let (status, body) = post(
+            router,
+            "/api/tabs",
+            json!({
+                "mode": "claude",
+                "cwd": std::env::temp_dir().to_string_lossy(),
+                "resumeSessionId": LIVE_SESSION,
+            }),
+            true,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT, "{body}");
+        assert_eq!(body["code"], json!("RESTORE_UNAVAILABLE"), "{body}");
+
+        registry.fail_session_ref_claim(&locator, "foreign-holder");
+    }
+
+    #[tokio::test]
+    async fn rest_create_legacy_resume_completes_claim_into_binding() {
+        let argv_file = unique_argv_file("d8-legacy-lease-completion");
+        let state = state_with_registry()
+            .with_cli_commands(Arc::new(vec![recording_cli_spec("claude", &argv_file)]));
+        let registry = state.terminal_registry.clone().unwrap();
+        let router = app(state);
+
+        let locator = SessionLocator {
+            provider: "claude".into(),
+            session_id: LIVE_SESSION.into(),
+        };
+        assert_eq!(registry.bound_terminal_for_session_ref(&locator), None);
+
+        let (status, body) = post(
+            router,
+            "/api/tabs",
+            json!({
+                "mode": "claude",
+                "cwd": std::env::temp_dir().to_string_lossy(),
+                "resumeSessionId": LIVE_SESSION,
+            }),
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let tid = body["data"]["terminalId"]
+            .as_str()
+            .expect("terminalId")
+            .to_string();
+
+        assert_eq!(
+            registry.bound_terminal_for_session_ref(&locator),
+            Some(tid.clone()),
+            "a legacy-rung resume spawn must complete its lease into a sessionRef binding"
         );
 
         registry.kill(&tid);

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -1513,6 +1513,24 @@ impl Drop for KeyedCreateGuard {
 /// `resumeSessionId`. Later-resolved identities (fresh-claude preallocation,
 /// the P0.4 restore ladder) are freshly minted or single-source and carry no
 /// concurrent-duplicate shape, so they claim nothing.
+/// Node's legacy-restore refusal text (`server/ws-handler.ts:2181`; the SAME
+/// frozen string the REST door's codex rejection reuses,
+/// `freshell-freshagent/terminal_tabs.rs` `INVALID_RAW_CODEX_RESUME_MESSAGE`)
+/// -- byte-identical so clients see one contract across doors and servers.
+const LEGACY_RESTORE_IDENTITY_REFUSAL: &str = "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.";
+
+/// Node parity (`server/terminal-registry.ts:186-189` `modeSupportsResume`):
+/// a non-shell mode whose CLI spec declares `resumeArgs`. Mirrors Node's
+/// truthiness check on the array (`!!resumeArgs` -- present counts, even
+/// empty), so the two servers refuse the same set of modes.
+fn mode_supports_resume(state: &WsState, mode: &str) -> bool {
+    mode != "shell"
+        && state
+            .cli_commands
+            .iter()
+            .any(|s| s.name == mode && s.resume_args.is_some())
+}
+
 fn create_session_locator(create: &TerminalCreate) -> Option<SessionLocator> {
     if create.mode == "shell" {
         return None;
@@ -2408,6 +2426,36 @@ pub(crate) async fn handle_create(
     // reject loudly when nothing can resolve. Claude-only: gemini/kimi
     // behavior is deliberately untouched, and fresh (non-restore)
     // claude keeps the preallocation branch above.
+    // Node parity (`server/ws-handler.ts:2170-2186`): a `restore:true` create
+    // for a resume-supporting non-codex mode whose ONLY identity is the
+    // legacy `resumeSessionId` is refused loudly -- restore identity must be
+    // a `sessionRef` (PR #318's durable-session contract). The Rust door
+    // previously fell through to `<cli> --resume <sid>` for this shape.
+    // Node's `!hasReusableRequestedLiveTerminal` arm has no Rust analog:
+    // `create.live_terminal` is a legacy repair hint the Rust server
+    // deliberately ignores (superseded by `pane.reconcile` verdicts -- see
+    // the field's doc in freshell-protocol/client_messages.rs), so no
+    // reuse path exists to exempt. Placed BEFORE the claude P0.4 restore
+    // ladder, matching Node's ordering (the refusal wins over ladder
+    // healing).
+    if create.restore == Some(true)
+        && mode != "codex"
+        && mode_supports_resume(state, &mode)
+        && create
+            .resume_session_id
+            .as_deref()
+            .is_some_and(|s| !s.is_empty())
+        && create.session_ref.is_none()
+    {
+        return send_create_error(
+            out,
+            ErrorCode::InvalidMessage,
+            LEGACY_RESTORE_IDENTITY_REFUSAL.to_string(),
+            &create.request_id,
+        )
+        .await;
+    }
+
     if mode == "claude" && create.restore == Some(true) {
         // Full Node reject-predicate parity (ws-handler.ts:2130-2139):
         // a client-supplied claude id that is not canonical-UUID-shaped
@@ -2439,27 +2487,33 @@ pub(crate) async fn handle_create(
         }
     }
 
-    // D7 liveness guard on the DIRECT wire-sessionRef rung (recover-my-panes
-    // Task 2b, defense-in-depth). Every other live-guard lives inside the
+    // D7 liveness guard on the wire-identity rungs (recover-my-panes Task 2b,
+    // defense-in-depth). Every other live-guard lives inside the
     // createRequestId-keyed ladder (`resolve_claude_restore_session_id`), which
-    // the direct rung above bypasses entirely -- and the D5 recovery path
+    // the direct rungs above bypass entirely -- and the D5 recovery path
     // re-mints the createRequestId, so a session that goes live between the
     // inventory fetch and the user's accept would otherwise silently spawn a
     // SECOND `<cli> --resume S` while the original live PTY owns S (the
     // one-JSONL-writer doctrine: "silently wrong"). Mirrors the ladder's A13
     // row-matching -- the identity-registry owner check plus the REST-shaped
     // live-registry-row scan -- but MODE-GENERIC: codex/opencode/amplifier had
-    // no live-guard on ANY path, so this closes their gap too. Applies only
-    // when the resume id was derived from the wire `sessionRef` (the
-    // resumeSessionId fallback and ladder-resolved ids keep their existing
-    // guards).
-    if let Some(live_sid) = create
-        .session_ref
-        .as_ref()
-        .filter(|r| r.provider == mode)
-        .map(|r| r.session_id.as_str())
-        .filter(|sid| !sid.is_empty() && resume_session_id.as_deref() == Some(*sid))
-    {
+    // no live-guard on ANY path, so this closes their gap too.
+    //
+    // The guard arms on [`create_session_locator`] -- the SAME wire-identity
+    // derivation the D8 lease claims on: the accepted `sessionRef` first,
+    // else the PROMOTED legacy `resumeSessionId` rung (`{provider: mode,
+    // sessionId}`, the reconcile door's §5.2 uniform promotion rule). The
+    // legacy rung was previously unguarded here -- the wire-resume gate's
+    // liveness precondition SKIPS live candidates rather than refusing them,
+    // so a legacy-only carrier double-spawned onto a live session (the
+    // 2026-08-16 duplicate-tab incident, REST twin in
+    // freshell-freshagent/terminal_tabs.rs). The `resume_session_id`
+    // equality filter keeps later-resolved identities (fresh-claude/amplifier
+    // mints, gate-healed ids, ladder-resolved ids) outside the guard -- they
+    // are freshly minted or single-source and keep their existing guards.
+    let d7_locator = create_session_locator(&create)
+        .filter(|loc| resume_session_id.as_deref() == Some(loc.session_id.as_str()));
+    if let Some(live_sid) = d7_locator.as_ref().map(|loc| loc.session_id.as_str()) {
         // #540 (ks38): the identity-owner + Running-row join is now the shared
         // `TerminalRegistry::live_session_owner` helper (the same join the REST
         // resume paths consult), replacing the former inline two-arm check.

--- a/crates/freshell-ws/tests/amplifier_launcher_identity.rs
+++ b/crates/freshell-ws/tests/amplifier_launcher_identity.rs
@@ -286,14 +286,14 @@ async fn amplifier_create_rejects_synthetic_terminal_placeholder_refs() {
 /// be rejected, never a second live PTY interleaving writes into one
 /// session dir.
 ///
-/// The second create rides the legacy `resumeSessionId` carrier: the
-/// wire-`sessionRef` carrier is already intercepted by the cross-mode D7
-/// liveness guard (PR #540, "Session ... is still running on the server"),
-/// which this amplifier-specific guard composes AFTER — sequentially, never
-/// instead of. The message is asserted EXACTLY because the pre-Task-9 path
-/// already rejected via the wrapped registry error ("Could not restore ...:
-/// duplicate live resume: ..."), which contains the same substring — only
-/// the friendly guard produces this exact frame.
+/// The second create rides the legacy `resumeSessionId` carrier. Since the
+/// legacy-rung D7 promotion (the 2026-08-16 duplicate-tab fix), the
+/// cross-mode D7 liveness guard intercepts this carrier too — BEFORE the
+/// amplifier-specific friendly guard — so the loud reject is now the uniform
+/// D7 frame (`RESTORE_UNAVAILABLE`, "Session ... is still running on the
+/// server"), identical to the wire-`sessionRef` carrier's answer. The
+/// amplifier friendly guard remains downstream as defense-in-depth (it also
+/// covers the registry-level duplicate race D7 cannot see).
 #[tokio::test]
 async fn amplifier_create_rejects_second_live_resume_of_same_session() {
     let _amp_home = isolate_amplifier_home();
@@ -346,14 +346,12 @@ async fn amplifier_create_rejects_second_live_resume_of_same_session() {
     .expect("send terminal.create");
 
     let err = next_frame_of_type(&mut ws, "error").await;
-    assert_eq!(err["code"], "PTY_SPAWN_FAILED", "loud reject: {err}");
+    assert_eq!(err["code"], "RESTORE_UNAVAILABLE", "loud reject: {err}");
     assert_eq!(err["requestId"], "req-amp-launcher-identity-6");
     assert_eq!(
         err["message"],
-        serde_json::json!(format!(
-            "Amplifier session {sid} is already open in a live terminal."
-        )),
-        "the friendly guard frame, not the wrapped registry error: {err}"
+        serde_json::json!(format!("Session {sid} is still running on the server.")),
+        "the uniform D7 frame — same answer as the sessionRef carrier: {err}"
     );
 
     // No duplicate spawn: exactly the original terminal owns sid.

--- a/crates/freshell-ws/tests/live_session_ref_guard.rs
+++ b/crates/freshell-ws/tests/live_session_ref_guard.rs
@@ -127,3 +127,118 @@ async fn live_session_ref_create_is_refused_loudly() {
 
     registry.kill(&tid1);
 }
+
+/// The legacy rung of the same doctrine (2026-08-16 duplicate-tab incident):
+/// a `terminal.create` carrying ONLY the legacy `resumeSessionId` (no
+/// `sessionRef`) must arm D7 exactly like the sessionRef rung — a legacy
+/// `mode` + `resumeSessionId` pair IS a sessionRef claim (`reconcile.rs`
+/// §5.2 uniform promotion, `create_session_locator`). Before the fix this
+/// carrier bypassed D7 in every ordering (the wire-resume gate's liveness
+/// precondition SKIPS live candidates rather than refusing them) and spawned
+/// a second `<cli> --resume S` writer.
+#[tokio::test]
+async fn legacy_resume_session_id_create_is_refused_loudly() {
+    let (url, registry) = spawn_server().await; // sleeper claude: stays Running
+    let (mut ws, _inv) = connect_and_capture_inventory(&url).await;
+
+    send_create(
+        &mut ws,
+        json!({
+            "type": "terminal.create",
+            "requestId": "req-legacy-live-owner-1",
+            "mode": "claude",
+            "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+        }),
+    )
+    .await;
+    let created = next_frame_of_type(&mut ws, "terminal.created").await;
+    let tid1 = created["terminalId"]
+        .as_str()
+        .expect("terminalId")
+        .to_string();
+    let session_id = session_ref_of(&created).expect("fresh claude carries sessionRef")
+        ["sessionId"]
+        .as_str()
+        .expect("sessionId")
+        .to_string();
+
+    // The CLI-shaped legacy carrier: identity ONLY in resumeSessionId.
+    send_create(
+        &mut ws,
+        json!({
+            "type": "terminal.create",
+            "requestId": "req-legacy-recreate-7c1d",
+            "mode": "claude",
+            "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+            "resumeSessionId": session_id,
+        }),
+    )
+    .await;
+
+    let err = expect_refusal_for(&mut ws, "req-legacy-recreate-7c1d").await;
+    assert_eq!(
+        err["code"],
+        json!("RESTORE_UNAVAILABLE"),
+        "exact wire code: {err}"
+    );
+    let message = err["message"].as_str().expect("error message");
+    assert!(
+        message.contains(&session_id),
+        "message must name the live session {session_id}: {err}"
+    );
+
+    let rows = registry.identity_probe_rows();
+    assert_eq!(
+        rows.len(),
+        1,
+        "only the original live terminal may exist: {rows:?}"
+    );
+    assert_eq!(rows[0].terminal_id, tid1);
+
+    registry.kill(&tid1);
+}
+
+/// Node parity (`server/ws-handler.ts:2170-2186`): a `restore:true` create
+/// for a resume-supporting non-codex mode whose ONLY identity is the legacy
+/// `resumeSessionId` is refused with `INVALID_MESSAGE` and the frozen
+/// refusal text — restore identity must be a `sessionRef`. The Rust door
+/// previously spawned `<cli> --resume <sid>` for this shape (deviation from
+/// the Node contract).
+#[tokio::test]
+async fn legacy_only_restore_is_refused_invalid_message() {
+    let (url, registry) = spawn_server().await;
+    let (mut ws, _inv) = connect_and_capture_inventory(&url).await;
+
+    send_create(
+        &mut ws,
+        json!({
+            "type": "terminal.create",
+            "requestId": "req-legacy-restore-31ab",
+            "mode": "claude",
+            "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+            "restore": true,
+            "resumeSessionId": "9d1f6f5a-2b6e-4d0f-8a3c-5e7b2c9d4f10",
+        }),
+    )
+    .await;
+
+    let err = expect_refusal_for(&mut ws, "req-legacy-restore-31ab").await;
+    assert_eq!(
+        err["code"],
+        json!("INVALID_MESSAGE"),
+        "exact wire code: {err}"
+    );
+    assert_eq!(
+        err["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+        "frozen Node refusal text: {err}"
+    );
+
+    assert!(
+        registry.identity_probe_rows().is_empty(),
+        "no terminal may spawn for a refused legacy-only restore"
+    );
+}

--- a/crates/freshell-ws/tests/resume_validation_gate.rs
+++ b/crates/freshell-ws/tests/resume_validation_gate.rs
@@ -637,11 +637,15 @@ async fn restore_true_live_absent_sessionref_hits_d7_not_the_gate() {
     registry.kill_all();
 }
 
-/// Case 5 — the REGISTRY arm of the in-gate liveness precondition: a legacy
-/// `resumeSessionId`-only carrier bypasses D7 in every ordering, so the gate
-/// itself must refuse to fire on a LIVE session. Resume proceeds unchanged.
+/// Case 5 — the legacy `resumeSessionId`-only restore carrier is now REFUSED
+/// up front (Node parity, `server/ws-handler.ts:2170-2186`): restore identity
+/// must be a `sessionRef`. The refusal fires before D7 and before the gate,
+/// so the live session is never touched — its Bound row survives and no
+/// second writer spawns. (Pre-fix this carrier bypassed D7 entirely and the
+/// in-gate liveness precondition was its only protection; that precondition
+/// remains in `gate_wire_resume` as the D7→gate race-window backstop.)
 #[tokio::test(flavor = "multi_thread")]
-async fn restore_true_live_absent_legacy_resume_id_fails_open() {
+async fn restore_true_live_legacy_resume_id_is_refused_invalid_message() {
     let probe = StubProbe::answering("amplifier", "live-amp-legacy", SessionExistence::Absent);
     let (url, registry, ledger, state) = spawn_server_with_probe(probe, false).await;
     seed_bound_row(&ledger, "amplifier", "live-amp-legacy");
@@ -664,12 +668,14 @@ async fn restore_true_live_absent_legacy_resume_id_fails_open() {
     let frame = next_created_or_error(&mut ws, "req-gate-5").await;
 
     assert_eq!(
-        frame["type"], "terminal.created",
-        "the legacy carrier must proceed (fail open on liveness): {frame}"
+        frame["type"], "error",
+        "a legacy-only restore must be refused loudly, never spawn: {frame}"
     );
-    assert!(
-        notice_of(&frame).is_none(),
-        "a LIVE session must never gate: {frame}"
+    assert_eq!(frame["code"], "INVALID_MESSAGE", "{frame}");
+    assert_eq!(
+        frame["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+        "frozen Node refusal text: {frame}"
     );
     assert_eq!(
         ledger
@@ -683,13 +689,16 @@ async fn restore_true_live_absent_legacy_resume_id_fails_open() {
     registry.kill_all();
 }
 
-/// Case 6 — the ASYNC sidecar arm of the in-gate liveness join: liveness held
-/// ONLY by the fresh-agent sidecar (no registry/identity owner). This is the
-/// arm protecting live zero-turn sessions with no rollout on disk yet
-/// (`freshell-server/src/existence.rs:224-227`) — it must not be silently
-/// dropped while cases 4–5 still pass.
+/// Case 6 — the ASYNC sidecar arm of the cross-kind liveness join: liveness
+/// held ONLY by the fresh-agent sidecar (no registry/identity owner). Codex
+/// is exempt from the case-5 legacy-restore refusal (Node's refusal excludes
+/// codex too), so this carrier reaches D7 — whose legacy-rung promotion +
+/// Task 13b sidecar arm now refuse it loudly, protecting live zero-turn
+/// sessions with no rollout on disk yet
+/// (`freshell-server/src/existence.rs:224-227`) from a second writer. The
+/// live session is never gated stale — its Bound row survives.
 #[tokio::test(flavor = "multi_thread")]
-async fn restore_true_sidecar_live_absent_legacy_resume_id_fails_open() {
+async fn restore_true_sidecar_live_legacy_resume_id_is_refused_by_d7() {
     // DEV-0006 S5.e: the managed-launch default is ON; this suite exercises the
     // plain-CLI codex path (sleeper CLI spec, no app-server), so pin OFF.
     std::env::set_var("FRESHELL_CODEX_MANAGED_LAUNCH", "0");
@@ -744,12 +753,15 @@ async fn restore_true_sidecar_live_absent_legacy_resume_id_fails_open() {
     let frame = next_created_or_error(&mut ws, "req-gate-6").await;
 
     assert_eq!(
-        frame["type"], "terminal.created",
-        "sidecar-live legacy carrier must proceed (fail open): {frame}"
+        frame["type"], "error",
+        "a sidecar-live legacy carrier must be refused (one writer per thread): {frame}"
     );
+    assert_eq!(frame["code"], "RESTORE_UNAVAILABLE", "{frame}");
     assert!(
-        notice_of(&frame).is_none(),
-        "a sidecar-LIVE session must never gate: {frame}"
+        frame["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("still running")),
+        "D7's own rejection message must answer: {frame}"
     );
     assert_eq!(
         ledger

--- a/server/cli/index.ts
+++ b/server/cli/index.ts
@@ -146,6 +146,28 @@ function resolveSessionRefFlag(mode: unknown, raw: unknown): { rejected: boolean
   return { rejected: false, sessionRef: { provider, sessionId } }
 }
 
+// `--resume <sid>` is promoted to the canonical `sessionRef {provider: mode,
+// sessionId}` before it hits the wire — exactly like the MCP freshell tool
+// (server/mcp/freshell-tool.ts new-tab) — so the CLI never sends the legacy
+// `resumeSessionId` field. An explicit `--session-ref` wins; codex is
+// rejected earlier by rejectRawCodexResume. Without a mode there is no
+// provider to promote with, so the flag combination is refused loudly rather
+// than silently dropping the resume identity.
+function promoteResumeFlag(
+  mode: unknown,
+  resumeSessionId: string | undefined,
+  explicit: CliSessionRef | undefined,
+): { rejected: boolean; sessionRef?: CliSessionRef } {
+  if (explicit) return { rejected: false, sessionRef: explicit }
+  if (!resumeSessionId) return { rejected: false }
+  if (typeof mode !== 'string' || mode.length === 0) {
+    writeError('--resume requires --mode (or use --session-ref provider:sessionId).')
+    process.exitCode = 1
+    return { rejected: true }
+  }
+  return { rejected: false, sessionRef: { provider: mode, sessionId: resumeSessionId } }
+}
+
 async function fetchTabs(client: ReturnType<typeof createHttpClient>): Promise<{ tabs: TabSummary[]; activeTabId?: string | null }> {
   const res = await client.get('/api/tabs')
   const data = unwrap(res)
@@ -355,6 +377,8 @@ async function main() {
       const prompt = getFlag(flags, 'prompt') as string | undefined
       if (rejectRawCodexResume(mode, resumeSessionId)) return
       if (sessionRefResult.rejected) return
+      const promoted = promoteResumeFlag(mode, resumeSessionId, sessionRefResult.sessionRef)
+      if (promoted.rejected) return
 
       const res = await client.post('/api/tabs', {
         name,
@@ -363,8 +387,7 @@ async function main() {
         cwd,
         browser,
         editor,
-        resumeSessionId,
-        ...(sessionRefResult.sessionRef ? { sessionRef: sessionRefResult.sessionRef } : {}),
+        ...(promoted.sessionRef ? { sessionRef: promoted.sessionRef } : {}),
       })
       const data = unwrap(res)
       if (prompt && data?.paneId) {
@@ -464,6 +487,8 @@ async function main() {
       const sessionRefResult = resolveSessionRefFlag(mode, getFlag(flags, 'session-ref'))
       if (rejectRawCodexResume(mode, resumeSessionId)) return
       if (sessionRefResult.rejected) return
+      const promoted = promoteResumeFlag(mode, resumeSessionId, sessionRefResult.sessionRef)
+      if (promoted.rejected) return
 
       const resolved = await resolvePaneTarget(client, target)
       if (!resolved.pane?.id) {
@@ -479,8 +504,7 @@ async function main() {
         mode,
         shell,
         cwd,
-        resumeSessionId,
-        ...(sessionRefResult.sessionRef ? { sessionRef: sessionRefResult.sessionRef } : {}),
+        ...(promoted.sessionRef ? { sessionRef: promoted.sessionRef } : {}),
       })
       writeJson(res)
       return
@@ -601,6 +625,8 @@ async function main() {
       const sessionRefResult = resolveSessionRefFlag(mode, getFlag(flags, 'session-ref'))
       if (rejectRawCodexResume(mode, resumeSessionId)) return
       if (sessionRefResult.rejected) return
+      const promoted = promoteResumeFlag(mode, resumeSessionId, sessionRefResult.sessionRef)
+      if (promoted.rejected) return
       const resolved = await resolvePaneTarget(client, target)
       if (!resolved.pane?.id) {
         writeError(resolved.message || 'pane not found')
@@ -611,8 +637,7 @@ async function main() {
         mode,
         shell,
         cwd,
-        resumeSessionId,
-        ...(sessionRefResult.sessionRef ? { sessionRef: sessionRefResult.sessionRef } : {}),
+        ...(promoted.sessionRef ? { sessionRef: promoted.sessionRef } : {}),
       })
       writeJson(res)
       return

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -323,14 +323,29 @@ function persistDurableFreshAgentFlavor(message: {
   })
 }
 
+/// The ONE durable-identity claim an outgoing create/attach carries: the
+/// canonical sessionRef, with a legacy-only pane's `resumeSessionId` promoted
+/// into it ({provider, sessionId} — the same §5.2 promotion rule the server's
+/// reconcile door applies). The legacy wire field itself is no longer sent;
+/// every server door resolves its resume input from sessionRef
+/// (claude.rs/codex.rs/opencode_ws.rs create paths, claude.rs
+/// attach_durable_id, Node runtime-manager.ts:106-108).
+function effectiveSessionRef(content: FreshAgentPaneContent) {
+  if (content.sessionRef) return content.sessionRef
+  if (content.resumeSessionId) {
+    return { provider: content.provider, sessionId: content.resumeSessionId }
+  }
+  return undefined
+}
+
 function buildFreshAgentAttachMessage(content: FreshAgentPaneContent, cwd?: string) {
+  const sessionRef = effectiveSessionRef(content)
   return {
     type: 'freshAgent.attach',
     sessionId: content.sessionId,
     sessionType: content.sessionType,
     provider: content.provider,
-    ...(content.resumeSessionId ? { resumeSessionId: content.resumeSessionId } : {}),
-    ...(content.sessionRef ? { sessionRef: content.sessionRef } : {}),
+    ...(sessionRef ? { sessionRef } : {}),
     ...(cwd ? { cwd } : {}),
   } as const
 }
@@ -1025,9 +1040,7 @@ export function FreshAgentView({
       provider: content.provider,
       cwd: content.initialCwd,
       ...(legacyRestoreContext ? { legacyRestoreContext } : {}),
-      resumeSessionId: content.resumeSessionId
-        ?? (content.sessionRef?.provider === content.provider ? content.sessionRef.sessionId : undefined),
-      sessionRef: content.sessionRef,
+      sessionRef: effectiveSessionRef(content),
       modelSelection: content.modelSelection,
       model: resolveEffectiveFreshAgentModel(content, providerDefaults),
       ...(getEffectiveFreshAgentPermissionMode(content) ? { permissionMode: getEffectiveFreshAgentPermissionMode(content) } : {}),

--- a/test/e2e/agent-cli-flow.test.ts
+++ b/test/e2e/agent-cli-flow.test.ts
@@ -492,6 +492,68 @@ describe('cli e2e flow', () => {
     }
   })
 
+  it('promotes --resume into a canonical sessionRef for non-codex modes', async () => {
+    // The CLI is the last legacy-only carrier (the 2026-08-16 duplicate-tab
+    // incident): it must convert `--resume <sid>` into the canonical
+    // `sessionRef {provider: mode, sessionId}` before it hits the wire —
+    // exactly like the MCP freshell tool — instead of sending the legacy
+    // `resumeSessionId` field.
+    const server = await startTestServerWithRealLayoutStore()
+    try {
+      const created = await runCliJson<{ data: { tabId: string; paneId: string } }>(server.url, [
+        'new-tab',
+        '--mode',
+        'claude',
+        '--resume',
+        '11111111-1111-4111-8111-111111111111',
+      ])
+      const tabId = created.data.tabId
+      const firstPaneId = created.data.paneId
+
+      await waitForExpect(() => {
+        const snapshot = (server.layoutStore as any).snapshot
+        expect(findPaneContent(snapshot.layouts[tabId], firstPaneId)).toEqual(expect.objectContaining({
+          mode: 'claude',
+          sessionRef: { provider: 'claude', sessionId: '11111111-1111-4111-8111-111111111111' },
+        }))
+      })
+
+      const split = await runCliJson<{ data: { paneId: string } }>(server.url, [
+        'split-pane',
+        '-t',
+        firstPaneId,
+        '--mode',
+        'claude',
+        '--resume',
+        '22222222-2222-4222-8222-222222222222',
+      ])
+
+      await runCliJson<{ data: { terminalId: string } }>(server.url, [
+        'respawn-pane',
+        '-t',
+        firstPaneId,
+        '--mode',
+        'claude',
+        '--resume',
+        '33333333-3333-4333-8333-333333333333',
+      ])
+
+      await waitForExpect(() => {
+        const snapshot = (server.layoutStore as any).snapshot
+        expect(findPaneContent(snapshot.layouts[tabId], firstPaneId)).toEqual(expect.objectContaining({
+          mode: 'claude',
+          sessionRef: { provider: 'claude', sessionId: '33333333-3333-4333-8333-333333333333' },
+        }))
+        expect(findPaneContent(snapshot.layouts[tabId], split.data.paneId)).toEqual(expect.objectContaining({
+          mode: 'claude',
+          sessionRef: { provider: 'claude', sessionId: '22222222-2222-4222-8222-222222222222' },
+        }))
+      })
+    } finally {
+      await server.close()
+    }
+  })
+
   it('rejects raw Codex resume ids in new-tab, split-pane, and respawn-pane', async () => {
     const server = await startTestServerWithRealLayoutStore()
     try {

--- a/test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx
@@ -254,7 +254,10 @@ describe('FreshAgentView reconcile fold drive (Task 9)', () => {
     expect(creates).toHaveLength(2) // the fold re-fired the create effect
     const last = creates[creates.length - 1]
     expect(last.requestId).toBe('req-1')
-    expect(last.resumeSessionId).toBe(DURABLE)
+    // Canonical carrier only: the server promotes sessionRef into its resume
+    // input on every door (claude.rs/codex.rs/opencode_ws.rs create paths,
+    // Node runtime-manager.ts:106-108) — the legacy duplicate is gone.
+    expect(last.resumeSessionId).toBeUndefined()
     expect(last.sessionRef).toEqual({ provider: 'claude', sessionId: DURABLE })
   })
 
@@ -268,9 +271,10 @@ describe('FreshAgentView reconcile fold drive (Task 9)', () => {
     expect(sentOfType('freshAgent.create')).toHaveLength(0)
     const attach = sentOfType('freshAgent.attach').find((m) => m.sessionId === DURABLE)!
     expect(attach).toBeTruthy()
-    // claude's attach_durable_id reads ONLY resumeSessionId/sessionRef (claude.rs:866-872):
-    // the durable MUST ride those fields or a resumable session answers lost_session_frame.
-    expect(attach.resumeSessionId).toBe(DURABLE)
+    // claude's attach_durable_id reads resumeSessionId THEN sessionRef
+    // (claude.rs `attach_durable_id`): the durable rides the canonical
+    // sessionRef only — the legacy duplicate is no longer sent.
+    expect(attach.resumeSessionId).toBeUndefined()
     expect(attach.sessionRef).toEqual({ provider: 'claude', sessionId: DURABLE })
   })
 
@@ -395,7 +399,27 @@ describe('FreshAgentView .lost capability gate (Task 10)', () => {
     await flush()
     const creates = sentOfType('freshAgent.create')
     expect(creates.length).toBeGreaterThan(0)
-    expect(creates[creates.length - 1].resumeSessionId).toBe(DURABLE)
+    expect(creates[creates.length - 1].sessionRef).toEqual({ provider: 'claude', sessionId: DURABLE })
+    expect(creates[creates.length - 1].resumeSessionId).toBeUndefined()
+  })
+
+  it('legacy-only pane content promotes resumeSessionId into the create sessionRef client-side', async () => {
+    // A pane whose only persisted identity is the legacy content field (no
+    // sessionRef) must still reach the server with canonical identity: the
+    // builders promote {provider: content.provider, sessionId} instead of
+    // sending the legacy wire field.
+    renderFreshAgentPane({
+      sessionId: undefined,
+      status: 'creating',
+      createRequestId: 'req-1',
+      resumeSessionId: DURABLE,
+      sessionRef: undefined,
+    })
+    await flush()
+    const creates = sentOfType('freshAgent.create')
+    expect(creates).toHaveLength(1)
+    expect(creates[0].sessionRef).toEqual({ provider: 'claude', sessionId: DURABLE })
+    expect(creates[0].resumeSessionId).toBeUndefined()
   })
 
   it('an attach verdict for the SAME durable-as-sessionId clears the lost flag (no reconcile loop)', async () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -1308,7 +1308,7 @@ describe('FreshAgentView', () => {
         sessionType: 'freshopencode',
         provider: 'opencode',
         cwd: '/home/dan/code',
-        resumeSessionId: 'freshopencode--gP4qyCL7bwp8-xbw9G7b',
+        sessionRef: { provider: 'opencode', sessionId: 'freshopencode--gP4qyCL7bwp8-xbw9G7b' },
         legacyRestoreContext: {
           title: 'Identifying skills from GitHub repos',
           createdAt: 1_781_291_230_743,
@@ -1404,7 +1404,6 @@ describe('FreshAgentView', () => {
         sessionId: 'ses_attach_route',
         sessionType: 'freshopencode',
         provider: 'opencode',
-        resumeSessionId: 'ses_attach_route',
         sessionRef: { provider: 'opencode', sessionId: 'ses_attach_route' },
         cwd: '/repo/route-aware',
       })
@@ -1422,7 +1421,6 @@ describe('FreshAgentView', () => {
         sessionId: 'ses_attach_route',
         sessionType: 'freshopencode',
         provider: 'opencode',
-        resumeSessionId: 'ses_attach_route',
         sessionRef: { provider: 'opencode', sessionId: 'ses_attach_route' },
         cwd: '/repo/route-aware',
       })
@@ -4106,7 +4104,6 @@ describe('FreshAgentView', () => {
         sessionId: 'thread-refresh',
         sessionType: 'freshcodex',
         provider: 'codex',
-        resumeSessionId: 'thread-refresh',
         sessionRef: { provider: 'codex', sessionId: 'thread-refresh' },
       })
     })
@@ -5413,7 +5410,7 @@ describe('FreshAgentView', () => {
         type: 'freshAgent.create',
         sessionType: 'freshclaude',
         provider: 'claude',
-        resumeSessionId: durableSessionId,
+        sessionRef: { provider: 'claude', sessionId: durableSessionId },
         effort: 'high',
       }))
     })
@@ -5492,7 +5489,6 @@ describe('FreshAgentView', () => {
     expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
       type: 'freshAgent.create',
       requestId: 'req-sessionref-only',
-      resumeSessionId: 'codex-thread-recover',
       sessionRef: { provider: 'codex', sessionId: 'codex-thread-recover' },
     }))
     expect(apiMock.getFreshAgentThreadSnapshot).not.toHaveBeenCalled()
@@ -5562,7 +5558,7 @@ describe('FreshAgentView', () => {
         expect(wsMock.send).toHaveBeenCalledWith(expect.objectContaining({
           type: 'freshAgent.create',
           requestId: leaf.content.createRequestId,
-          resumeSessionId: 'codex-thread-disabled',
+          sessionRef: { provider: 'codex', sessionId: 'codex-thread-disabled' },
         }))
       }
     })


### PR DESCRIPTION
## Summary

Closes the guard hole behind the 2026-08-16 duplicate-tab incident: a create carrying only the legacy `resumeSessionId` wire field bypassed the D7 live-session guard and D8 sessionRef lease entirely, allowing a second live writer onto a running session.

**Step 1 — guard promotion at both create doors:**
- Rust REST (`terminal_tabs.rs`): the D7/D8 guard block now derives a locator from a wire-carried legacy `resumeSessionId` (plausible-id-gated, wire-equality-filtered so gate-healed/minted ids are excluded) and refuses/leases exactly like the sessionRef rung.
- Rust WS (`terminal.rs`): D7 now derives from `create_session_locator` — the same §5.2 promotion D8 already used — so legacy carriers hit the same 409/`RESTORE_UNAVAILABLE` refusal.
- Ported Node's legacy-restore refusal to Rust WS: `restore:true` + legacy-only identity on a resume-supporting non-codex mode → `INVALID_MESSAGE` with the frozen Node text.

**Step 2 — first-party senders converted to sessionRef-only:**
- `freshell` CLI: `--resume` now promotes client-side to a canonical `sessionRef` (`promoteResumeFlag`); `--resume` without `--mode` errors loudly instead of silently misbehaving.
- Web client: fresh-agent create/attach messages send `sessionRef` only (`effectiveSessionRef`); the legacy duplicate field is gone from the wire.
- Rust claude/codex fresh-agent adapters gained the `session_ref` fallback for resume input (opencode + Node already had it), so removing the client duplicate loses nothing.

**Step 3 — pane.reconcile legacy rung left unchanged** (load-bearing, already promoted server-side).

**Step 4** (hard wire-level rejection of the legacy field) is specced in kata `ejh6` for a follow-up agent.

## Test plan
- New red→green coverage at every door: REST legacy-resume refusal/lease/claim tests, WS `legacy_resume_session_id_create_is_refused_loudly` + `legacy_only_restore_is_refused_invalid_message`, adapter sessionRef-fallback tests (claude + codex), CLI promotion e2e, client wire-shape pins converted to sessionRef.
- Two pre-existing suites re-pinned to the new (stronger) contract with original protections retained: `amplifier_launcher_identity`, `resume_validation_gate` cases 5/6.
- Full verification: `cargo test --workspace` green (117 binaries), `npm run check` green (typecheck + coordinated full suite), clippy + eslint clean on touched files.
- Fresh-eyes independent review: no blockers; exhaustive guard-bypass hunt found no escape path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZjEiy5UqmMUefXS7HKvZc