### PR TITLE
fix(client): hidden panes never claim viewport geometry (attach-geometry stomp)

### DIFF
--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -307,7 +307,17 @@ Verify the pid file PID belongs to the worktree (`ps -fp $(cat /tmp/freshell-334
 
 - [x] **Step 3: Teardown + record**
 
-Verify ownership before stopping: `ps -fp "$(cat /tmp/freshell-3344.pid)"` and confirm the process's cwd/binary is inside the worktree; only then `kill "$(cat /tmp/freshell-3344.pid)" && rm -f /tmp/freshell-3344.pid`. Write `/home/dan/code/freshell/.worktrees/.the-usual-logs/attach-geometry-resume-panes/reports/live-verify.md` with the evidence list and the assertion outcomes.
+Verify ownership before stopping: `ps -fp "$(cat /tmp/freshell-3344.pid)"` and confirm the process's cwd/binary is inside the worktree. The recorded PID is the npm/concurrently wrapper — its children (Vite, server) survive a plain kill (observed live), so terminate the OWNED PROCESS GROUP and verify the ports are released before removing the pid file:
+
+```bash
+PGID=$(ps -o pgid= -p "$(cat /tmp/freshell-3344.pid)" | tr -d ' ')
+ps -o cmd= -g "$PGID"   # eyeball: all members must belong to this scratch instance/worktree
+kill -TERM -- "-$PGID"
+sleep 2; (command -v ss >/dev/null && ss -tlnp | grep -E ':(3344|5273)\b' && echo 'STILL BOUND — investigate before proceeding' || true)
+rm -f /tmp/freshell-3344.pid
+```
+
+Write `/home/dan/code/freshell/.worktrees/.the-usual-logs/attach-geometry-resume-panes/reports/live-verify.md` with the evidence list and the assertion outcomes.
 
 - [x] **Step 4: No commit**
 

--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -24,7 +24,7 @@ Fix the freshell root cause behind broken mouse scrolling and garbage rendering 
 
 **Goal:** A terminal pane's PTY size is always governed by the visible client; hidden/background-hydration attaches replay scrollback without ever resizing the PTY.
 
-**Architecture:** One invariant in the client attach path: a pane that is not visible (`hiddenRef.current === true`) must never claim viewport geometry. Enforced at the single choke point `attachTerminal` (`src/components/TerminalView.tsx` ~2698): when hidden, the attach runs as a **geometry-neutral full replay** — `effectiveIntent = 'keepalive_delta'`, `sinceSeq` forced to `0` — independent of the caller's requested intent. This avoids three verified collisions with the naive clamp: (1) the internal re-promotion of non-viewport intents to `viewport_hydrate` (~2743-2751) is bypassed for hidden attaches; (2) the warm-delta rejection ladders in the `terminal.attach.ready` handler (4108/4143) can only fire when `sinceSeq > 0`, so forcing `sinceSeq = 0` prevents a clamp→reject→reattach loop in multi-client scenarios where `attach.ready` stamps `geometryAuthority: 'multi_client_unknown'`; (3) the client-side viewport bookkeeping (`syncGeometryEpochForViewport` ~2728, `rememberSentViewport`/`lastSentViewportRef` ~2855-2856) is skipped for hidden attaches, so a later visible-pane `terminal.resize` is not suppressed by `matchesLastSentViewport` (~1643-1650). Servers never resize for `keepalive_delta` (`registry.rs` contract) and wire replay keys off `since_seq` only (validator A confirmed: intent never reaches replay selection), so hidden panes still warm up with the full stream. Reveal attaches of visible panes stay `viewport_hydrate`. Two validator-falsified adjacencies are fixed in the same task: (i) the reveal `fit+resize` path can be suppressed by `matchesLastSentViewport` when the reveal-fit dims equal the pre-hide recorded dims — the reveal effect therefore requests the resize with an explicit force flag that bypasses both suppression gates in `flushScheduledLayout`; (ii) the unrecoverable-replay-gap recreate predicate (`isUnrecoverableOpenCodeViewportHydrate` ~3964) keys on wire intent `viewport_hydrate` — broadened to also accept `'keepalive_delta'` with `sinceSeq === 0` so hidden restored opencode panes keep their recreate-on-replay-gap behavior.
+**Architecture (v3, after plan-review round 1):** One invariant in the client attach path: a pane that is not visible must never claim viewport geometry on the wire. Enforced at the single choke point `attachTerminal` (`src/components/TerminalView.tsx` ~2698) with a **wire-token-only swap**: when `intent === 'viewport_hydrate'` while `hiddenRef.current` is true, the sent frame carries `intent: 'keepalive_delta'` while ALL client-side bookkeeping retains viewport-hydrate semantics (sinceSeq 0, `resetParserAppliedSurface`, viewport clear, `currentAttachRef.intent`/`deferredAttachStateRef.pendingIntent` unchanged) — so the replay path, the replay-gap recreate predicate, the rejection ladders, and reveal planning are all byte-for-byte unaffected, and the server simply never resizes (`registry.rs`: `KeepaliveDelta => false`; attach replay keys off `since_seq` only — validator A/C/B confirmed). Alongside the swap, the hidden-clamped attach **invalidates the this-client suppression records** (`lastSentViewportRef.current = null; forgetSentViewport(tid)` — the helper already exists at src/components/TerminalView.tsx:507) so the next visible-pane fit+resize is never suppressed by dims the server never applied (validator D falsified "no-op is enough"; this restores reveal-time convergence without touching suppression semantics for any existing flow). No new flags, no predicate broadening, no force-resize path, and no changes to natural `keepalive_delta`/`transport_reconnect` attaches.
 
 **Tech Stack:** React 18 / TypeScript client (xterm.js), Vitest + Testing Library (`test/unit/client/components/`), Playwright e2e (`test/e2e-browser/`), Rust ws/terminal crates only for the evidence probe (no Rust change).
 
@@ -40,28 +40,31 @@ Fix the freshell root cause behind broken mouse scrolling and garbage rendering 
 
 ---
 
-### Task 1: Hide-gated attach intent (RED witness test + choke-point implementation)
+### Task 1: Hide-gated attach intent (wire-token clamp + suppression-record invalidation)
 
 **Files:**
-- Delete: `crates/freshell-ws/tests/zz_probe_attach_resume_geometry.rs` (pre-plan probe; evidence retained in run logs `reports/`; it asserts only current-server contract, which stays unchanged)
-- Modify: `src/components/TerminalView.tsx` (`attachTerminal` ~line 2698)
-- Test: `test/unit/client/components/TerminalView.lifecycle.test.tsx` (extend existing attach-intent suite)
+- Delete: `crates/freshell-ws/tests/zz_probe_attach_resume_geometry.rs` (pre-plan probe; evidence retained in run logs `reports/`; it asserts only the current-server contract, which stays unchanged)
+- Modify: `src/components/TerminalView.tsx` (`attachTerminal` ~line 2698; the only production change)
+- Test: `test/unit/client/components/TerminalView.lifecycle.test.tsx` (extend the hidden-pane attach-intent block; reuse `renderTerminalHarness`, `wsMocks`, `messageHandler`, `restoreMocks`, `getHydrationQueue().onActiveTabReady`, `reconnectHandler`, `TerminalView`/`TerminalViewFromStore` exactly as neighboring tests do)
 
 **Interfaces:**
-- Consumes: `attachTerminal(tid: string, intent: 'viewport_hydrate' | 'keepalive_delta' | 'transport_reconnect', opts?: AttachTerminalOptions): void` and `hiddenRef.current: boolean` (both already in `TerminalView.tsx`).
-- Produces: no new exported names; changes the wire frame's `intent` field for attaches sent while the pane is hidden.
+- Consumes: `attachTerminal(tid: string, intent: 'viewport_hydrate' | 'keepalive_delta' | 'transport_reconnect', opts?: AttachTerminalOptions): void`, `hiddenRef.current: boolean`, existing module-level helper `forgetSentViewport(tid)` (src/components/TerminalView.tsx:507), `lastSentViewportRef` (per-instance ref).
+- Produces: no new exported names; only wire-frame `intent` differs for hidden clamps.
 
-- [ ] **Step 1: Write the failing behavioral test**
+- [ ] **Step 1: Write the failing behavioral tests**
 
-Add to `test/unit/client/components/TerminalView.lifecycle.test.tsx`, in the existing describe block containing the hidden-pane hydration tests (the block around line 8685 that uses `renderTerminalHarness({ hidden: true, ... })` plus `getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])`). Reuse `renderTerminalHarness`, `wsMocks`, `messageHandler`, `TerminalViewFromStore`, `act`, `waitFor` exactly as those tests do. New tests:
+Add three tests to the hidden-pane attach-intent block of `test/unit/client/components/TerminalView.lifecycle.test.tsx`.
+
+T1 — wire pin (RED witness):
 
 ```ts
-it('hidden background hydration attach does not claim viewport geometry', async () => {
-  const { store, tabId, paneId, terminalId } = await renderTerminalHarness({
+it('a pane hidden at mount hydrates in background with a geometry-neutral keepalive attach', async () => {
+  const { terminalId, tabId } = await renderTerminalHarness({
     status: 'running',
-    terminalId: 'term-hidden-geo-clamp',
+    terminalId: 'term-hidden-mount-geo-neutral',
     hidden: true,
-    requestId: 'req-hidden-geo-clamp',
+    clearSends: false,
+    requestId: 'req-hidden-mount-geo-neutral',
   })
 
   wsMocks.send.mockClear()
@@ -73,57 +76,49 @@ it('hidden background hydration attach does not claim viewport geometry', async 
     const attach = wsMocks.send.mock.calls
       .map(([msg]) => msg)
       .find((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId)
-    expect(attach, 'a background hydration attach frame must be sent').toBeTruthy()
-    expect(attach.intent, 'hidden hydration must not claim viewport geometry').toBe('keepalive_delta')
+    expect(attach, 'background hydration must send an attach').toBeTruthy()
+    expect(attach.intent).toBe('keepalive_delta')
     expect(attach.priority).toBe('background')
-    expect(attach.cols).toBeGreaterThan(0) // frame schema unchanged
+    expect(attach.sinceSeq).toBe(0)
+    expect(attach.cols).toBeGreaterThan(0)
     expect(attach.rows).toBeGreaterThan(0)
-    expect(
-      wsMocks.send.mock.calls
-        .map(([msg]) => msg)
-        .some((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId && msg?.intent === 'viewport_hydrate'),
-    ).toBe(false)
   })
+  expect(
+    wsMocks.send.mock.calls
+      .map(([msg]) => msg)
+      .some((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId && msg?.intent === 'viewport_hydrate'),
+  ).toBe(false)
 })
+```
 
-it('reveal after hidden hydration heals geometry via a forced resize, not a new geometry-claiming attach', async () => {
-  // Validator-D scenario pinned: pane first VISIBLE at fitted dims V1 (its
-  // attach records V1 as last-sent viewport), then hidden (hydration attach
-  // is clamped and records nothing), then revealed — the reveal-fit dims are
-  // again V1, so without the force flag `matchesLastSentViewport` would
-  // suppress the resize and a foreign (server-side) geometry change would
-  // never heal.
+T2 — heal path (validator-D sequence; pre-fix the resize is suppressed, post-fix it is emitted):
+
+```ts
+it('reveal after a clamped hidden attach emits terminal.resize even when fitted dims equal the pre-hide dims', async () => {
   const { store, tabId, paneId, terminalId, rerender } = await renderTerminalHarness({
     status: 'running',
-    terminalId: 'term-hidden-then-visible',
-    hidden: false,
-    requestId: 'req-hidden-then-visible',
+    terminalId: 'term-hidden-heal-suppression',
+    clearSends: false,
+    requestId: 'req-hidden-heal-suppression',
   })
+  // visible attach above records the fitted dims (neighboring tests pin this)
 
-  await waitFor(() => {
-    expect(
-      wsMocks.send.mock.calls
-        .map(([msg]) => msg)
-        .some((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId && msg?.intent === 'viewport_hydrate'),
-    ).toBe(true)
-  })
-
+  const readPaneContent = () => {
+    const layout = store.getState().panes.layouts[tabId]
+    return layout && layout.type === 'leaf' && layout.content.kind === 'terminal' ? layout.content : null
+  }
   rerender(
     <Provider store={store}>
-      <TerminalViewFromStore tabId={tabId} paneId={paneId} hidden={true} />
+      <TerminalView tabId={tabId} paneId={paneId} paneContent={readPaneContent()!} hidden />
     </Provider>,
   )
-  act(() => {
-    getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])
-  })
-  await waitFor(() => {
-    expect(
-      wsMocks.send.mock.calls
-        .map(([msg]) => msg)
-        .some((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId && msg?.intent === 'keepalive_delta'),
-    ).toBe(true)
-  })
 
+  // Produce the hidden background-hydration attach. Today (pre-fix) its
+  // wire intent is viewport_hydrate (red witness). If the hydration queue
+  // alone does not trigger it for this mount shape, drive it exactly as the
+  // neighbor "background hydrates a trusted hidden reconnect" test does —
+  // act(() => reconnectHandler?.()) — and record which trigger was used in
+  // the task report.
   act(() => {
     getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])
   })
@@ -142,204 +137,190 @@ it('reveal after hidden hydration heals geometry via a forced resize, not a new 
     </Provider>,
   )
 
-  // Contract: reveal of a pane that attached while hidden does NOT send
-  // another attach (deferred mode is 'live', not 'waiting_for_geometry');
-  // the reveal effect emits terminal.resize with the real fitted dims EVEN
-  // THOUGH they equal the pre-hide recorded dims (the force flag bypasses
-  // the suppression gates).
   await waitFor(() => {
-    expect(
-      wsMocks.send.mock.calls
-        .map(([msg]) => msg)
-        .filter((msg) => msg?.type === 'terminal.attach'),
-    ).toHaveLength(0)
     expect(
       wsMocks.send.mock.calls
         .map(([msg]) => msg)
         .some((msg) => msg?.type === 'terminal.resize' && msg?.terminalId === terminalId),
     ).toBe(true)
   })
+  // No NEW attach on reveal (deferred mode is 'live'); the resize is the heal.
+  expect(
+    wsMocks.send.mock.calls
+      .map(([msg]) => msg)
+      .filter((msg) => msg?.type === 'terminal.attach'),
+  ).toHaveLength(0)
 })
 ```
 
-And one more test pinning the recreate-path predicate broaden (validator F):
+T3 — surface reset at clamped full replay (green-by-construction guard, protects finding-2's regression): mount hidden via T1's shape, capture the sent attach's `attachRequestId`, then drive `messageHandler!` with `terminal.attach.ready` `{ headSeq: 3, replayFromSeq: 1, replayToSeq: 3, attachRequestId }` plus `terminal.output` `{ seqStart: 1, seqEnd: 3, data: 'CLAMPED-REPLAY-MARKER' }`; assert the mocked terminal write stream contains `CLAMPED-REPLAY-MARKER` exactly once.
 
-```ts
-it('hidden restored OpenCode pane whose clamped hydration attach hits replay_window_exceeded still kills and recreates the terminal', async () => {
-  // Mirror the pre-existing replay-gap test (~8685) shape with the SAME
-  // opencode sessionRef fixtures, but the attach is the clamped hidden one:
-  // intent keepalive_delta, sinceSeq 0, priority background, then drive
-  // terminal.attach.ready + terminal.output.gap {reason:'replay_window_exceeded'}
-  // for the SAME attachRequestId and assert the existing terminate+respawn
-  // contract fires (terminal.kill WS frame AND the replacement create flow,
-  // exactly as that test asserts today). This test REPLACES the old test's
-  // viewport_hydrate predicate per Step 1's rule.
-})
-```
+Also update the pre-existing hidden replay-gap test "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output" (~line 8685): change ONLY its attach wait predicate from `intent === 'viewport_hydrate'` to `intent === 'keepalive_delta'` (the production recreate predicate is NOT changed — `currentAttachRef.intent` retains viewport bookkeeping; that is part of the production contract this redesign pins). Any other pre-existing assertion of a hidden wire `viewport_hydrate` gets the same single-word update under the old-contract rule; record every touched test in the task report. Visible-pane assertions (e.g. "recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output" and the reconnect-before-reveal test at ~4635) must stay untouched and green.
 
-(Adjust identifiers at the call edges only — e.g. if `renderTerminalHarness` returns differently named keys or needs `sessionRef`/`mode`, mirror the neighboring tests. The assertions are the contract.)
-
-Also update the pre-existing hidden-hydration replay-gap test (~line 8685, "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output"): its attach predicate filters on `intent === 'viewport_hydrate' && priority === 'background'`. That encoded the old contract; change ONLY the predicate's intent to `'keepalive_delta'` so it keeps testing the recreate-on-replay-gap behavior under the new intent. The kill/recreate behavior contract of that test is unchanged. Do not weaken its assertions. Any other pre-existing test that fails for asserting hidden-pane `viewport_hydrate` must be reviewed individually: update it only if its purpose is the same (hidden-path contract), record each touched test in the task report. The "hidden split create keeps viewport_hydrate intent when reconnect fires before reveal" test (~line 4635) must be verified by reading its rerender order first: it rerenders with `hidden={false}` after the reconnect tick, so its awaited attach is sent while visible and must stay `viewport_hydrate` — if it fails, that failure is real information about stale `hiddenRef` handling; stop and escalate to the coordinator rather than loosening it.
-
-- [ ] **Step 2: Run the test and verify the intended failure**
+- [ ] **Step 2: Run the tests and verify the intended failure**
 
 Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx`
 
-Expected: FAIL because the hidden background-hydration attach frame carries `intent: 'viewport_hydrate'` today (the new first test fails on the intent assertion; the pre-existing replay-gap test will also fail after its predicate update — both failures are intent-level). Failure must be assertion-level, not mount/setup breakage.
+Expected: FAIL for T1 (wire intent is `viewport_hydrate` pre-fix) and FAIL for T2 (resize suppressed: pre-hidden viewport_hydrate attach re-recorded identical dims). T3 and the reconnect-before-reveal test must already pass — if they fail, the harness setup is wrong; fix the setup, not the assertions. The replay-gap test fails pre-fix only after its predicate update; both failure modes are assertion-level, not setup errors.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-In `src/components/TerminalView.tsx`, inside `attachTerminal` (~line 2698), apply four coordinated edits, all gated on one boolean captured at entry. Do not touch the visible-pane paths.
+All changes live in `attachTerminal` in `src/components/TerminalView.tsx` (~2698).
+
+1. After the re-promotion block computes `effectiveIntent` (~2740-2751), compute the wire intent:
 
 ```ts
-// at the top of attachTerminal, right after existing early returns (~2717):
-const isHiddenAttach = hiddenRef.current
+// Geometry authority invariant (attach-geometry-resume-panes): a pane that
+// is not visible must never CLAIM viewport geometry on the wire — servers
+// resize the PTY unconditionally for viewport_hydrate regardless of who
+// else is attached, so a hidden hydrating tab stamps stale/never-fitted
+// dims over the visible pane's size. The swap is wire-token-only: all
+// bookkeeping keeps viewport_hydrate semantics (sinceSeq 0, surface reset,
+// currentAttachRef/deferredAttachState intents); keepalive_delta is
+// replay-identical (replay keys off since_seq) and never resizes.
+const hiddenViewportAttach = effectiveIntent === 'viewport_hydrate' && hiddenRef.current
+const wireIntent = hiddenViewportAttach ? 'keepalive_delta' : effectiveIntent
 ```
 
-1. **Intent + replay clamp.** Replace the initial `let effectiveIntent = intent` assignment (~2740) so that when `isHiddenAttach`, `effectiveIntent` becomes `'keepalive_delta'` and both re-promotion branches (~2743-2751) are skipped (guard them with `!isHiddenAttach`). Force full replay for hidden attaches: when `isHiddenAttach`, treat `explicitSinceSeq` as `undefined` and the checkpoint decision as not-ok for the `deltaSeq`/`sinceSeq` derivation (~2752-2753), yielding `sinceSeq === 0`. This is what prevents the warm-delta rejection ladders (which require `sinceSeq > 0`) and any clamp→reject→reattach loop. Do NOT force `clearViewportFirst` either way for hidden attaches; keep the caller's value (cosmetic on a hidden surface).
-2. **Skip geometry bookkeeping for hidden attaches.** Guard with `!isHiddenAttach`: the `syncGeometryEpochForViewport(tid, cols, rows)` call (~2728) and the `rememberSentViewport(tid, cols, rows)` + `lastSentViewportRef.current = ...` pair (~2855-2856). A hidden attach never resizes server-side, so its dims must not become the "last sent viewport" that future visible resizes are suppressed against. Compute `cols`/`rows` as today (they stay in the frame — the schema is unchanged; the server ignores them for keepalive).
-3. Keep `deferredAttachStateRef.current` (~2794) and `currentAttachRef.current` (~2801) recording `pendingIntent`/`intent` = the SENT intent (`effectiveIntent`), so the reveal plan and ready-handler see the true wire semantics.
-4. **Broaden the recreate predicate.** In the `terminal.output.gap` handler, broaden `isUnrecoverableOpenCodeViewportHydrate` (~3964) to additionally accept `currentAttachRef.current?.intent === 'keepalive_delta'` while keeping `sinceSeq === 0`, `mode === 'opencode'`, and `sessionRef.provider === 'opencode'` unchanged (validator F: the recreate path otherwise silently dies for hidden restored opencode panes under the new contract). Update the comment to say both intents identify a full-surface replay attach — visible (`viewport_hydrate`) or hidden-clamped (`keepalive_delta`, sinceSeq 0). Acceptable-leak check: a visible checkpoint-arm keepalive attach has sinceSeq > 0 and stays excluded; do not change that.
-5. Add a code comment on the clamp stating the invariant and why sinceSeq must be 0 and viewport bookkeeping skipped (this is the load-bearing summary of the run's evidence; reference that `resize_for_attach` resizes unconditionally for viewport_hydrate).
+2. Use `wireIntent` (not `effectiveIntent`) in the `ws.send(buildTerminalAttachMessage({ ... }))` call. Do NOT change `deferredAttachStateRef.current.pendingIntent`, `currentAttachRef.current.intent`, seq-state handling, or any clearing.
 
-- [ ] **Step 3b (same task, same commit): reveal resize bypass gate.** Validator D falsified "skip-recording is enough": when the reveal-fit dims equal the pre-hide recorded dims, `matchesLastSentViewport` (~1643-1650) suppresses the reveal resize and the server-side mismatch persists. Implement an explicit force path: extend `requestTerminalLayout`'s options with `forceResize?: boolean` (~1599-1611, also extend `pendingLayoutWorkRef` shape), have ONLY the reveal layout effect (~2973) call `requestTerminalLayout({ fit: true, resize: true, forceResize: true })`, and in `flushScheduledLayout` (~1613-1658) skip the `matchesSuppressedViewport` and `matchesLastSentViewport` gates when the force flag is set — still fit() first, still record via `rememberSentViewport`/`lastSentViewportRef` after a forced send, still respect `suppressNetworkEffects` and the `tid` guard.
+3. Immediately after the `rememberSentViewport(tid, cols, rows)` / `lastSentViewportRef.current = ...` pair (~2855-2856):
+
+```ts
+if (hiddenViewportAttach) {
+  // The server did not apply these dims; do not let them suppress the next
+  // visible-pane resize (reveal-time heal path).
+  forgetSentViewport(tid)
+  lastSentViewportRef.current = null
+}
+```
+
+No other edits. In particular: do not touch the re-promotion conditions, the rejection ladders, the gap predicate, the reveal effect, or requestTerminalLayout.
 
 - [ ] **Step 4: Run the focused test**
 
 Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx`
 
-Expected: PASS (both new tests; the whole file stays green).
+Expected: PASS (T1/T2 now green; T3 stays green; every pre-existing test in the file stays green after the allowed predicate updates).
 
 - [ ] **Step 5: Refactor while green**
 
-Review call-site text: with the choke point in place, the background-hydration effect's explicit `'viewport_hydrate'` argument remains accurate intent-from-caller vocabulary (the clamp site handles gating); add the same one-line comment pointer at the hydration effect call site (TerminalView.tsx ~2992) to keep the invariant discoverable. No other refactor; do not touch the reveal-plan policy file.
+Verify no duplication crept into the attach block; keep the invariant comment within ~8 lines. No other refactor.
 
 - [ ] **Step 6: Run impacted-test verification**
 
-Impacted set: all client tests that cover attach intents, hydration, reveal attach, geometry epochs, and resize suppression. Enumerate them (verify with `ls test/unit/client/lib/ test/unit/client/components/ | grep -iE "attach|hydration|lifecycle|view-utils|terminal"` and include every attach/hydration/terminal-view file plus the policy file).
+Enumerate impacted client files first: `grep -rl "viewport_hydrate\|keepalive_delta" test/unit/client/src test/unit/client 2>/dev/null | sort -u` (then keep only files that exist). Run:
 
-Run: `npm run test:vitest -- run <each enumerated file>` (one invocation with the full enumerated list).
+```bash
+npm run test:vitest -- run <each enumerated file>
+npm run typecheck
+npm run lint
+```
 
-Expected: PASS with zero failures; record the file list and counts in the task report. Any failure whose root cause is the intent change must either be an old-contract assertion (update per Step 1's rule) or a real behavior defect (stop, do not commit; escalate to the coordinator with evidence).
+Expected: all PASS. Record the enumerated file list and counts in the task report. Failures whose root cause is an old-contract hidden-viewport assertion may be updated per the Step 1 rule; anything else is a real defect — stop, do not commit, escalate.
 
 - [ ] **Step 7: Commit the task**
 
 ```bash
-rm crates/freshell-ws/tests/zz_probe_attach_resume_geometry.rs  # untracked probe — plain rm, evidence retained in run logs
+rm crates/freshell-ws/tests/zz_probe_attach_resume_geometry.rs
 git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx
-git commit -m "fix(client): hidden panes never claim viewport geometry on attach
+git commit -m "fix(client): hidden panes never claim viewport geometry on the wire
 
-A hidden pane's fitted dims are stale; viewport_hydrate hydration attaches
-from any client applied them as the PTY size unconditionally, stomping the
-visible pane's geometry (opencode TUI wrap-garbage on scroll, stale bands).
-Downgrade viewport_hydrate to keepalive_delta at the attachTerminal choke
-point while the pane is hidden; reveal attaches of visible panes are
-unchanged and keep healing geometry."
+A hidden/background-hydrating tab attached with viewport_hydrate and stale
+(or never-fitted) dims; servers resize the PTY unconditionally for that
+intent, stomping the visible pane's geometry (opencode TUI wrap-garbage on
+scroll, dead regions). Swap the wire intent to keepalive_delta for such
+attaches — replay-identical, resize-free — and invalidate this client's
+suppression records so reveal-time fit+resize actually reaches the server.
+Client-side bookkeeping keeps viewport_hydrate semantics, so the replay-gap
+recreate predicate and reveal planning are unchanged."
 ```
 
 ---
 
-### Task 2: Multi-client e2e regression — hidden hydration does not stomp the visible pane's PTY
+### Task 2: e2e regression — REST-created tab stays geometry-neutral until reveal
 
 **Files:**
-- Test: `test/e2e-browser/specs/multi-client.spec.ts` (EXTEND this file — validator E confirmed it is already in MATRIX_SPECS (playwright.config.ts:13-170), so the matrix runs it on both legacy-chromium and rust-chromium with no config change. A NEW spec file would need MATRIX_SPECS registration — do not create one).
-- Modify: `src/lib/test-harness.ts` ONLY if the e2e cannot otherwise read the real PTY size — precedent uses `getTerminalBuffer` + typed `stty size` markers, which needs no harness change; prefer that. No production client changes in this task.
+- Test: `test/e2e-browser/specs/multi-client.spec.ts` (EXTEND — already a MATRIX_SPECS member per playwright.config.ts, so both legacy-chromium and rust-chromium run it with no config change; do NOT create a new spec file).
+- No production changes in this task (Task 1 is the fix). No harness changes needed (validator E verified `getTerminalBuffer(terminalId?)` and matrix helpers suffice).
 
 **Interfaces:**
-- Consumes: Task 1's behavior; `window.__FRESHELL_TEST_HARNESS__` (`getTerminalBuffer(terminalId?) → string|null` per src/lib/test-harness.ts:113-119); from `specs/multi-client.spec.ts`: `newClientContext` (:10-14) for the second context, `waitForTabWithTerminalId` (:88-139, leaves the tab hidden on B), `waitForMarkedPtySize` (:154-165), whose marker regex expects `__LABEL__:<rows> <cols>`.
-- Produces: a new test inside `specs/multi-client.spec.ts` asserting that a second client's hidden hydration attach does not change the PTY size reported by the owning pane (kernel truth via `stty size` markers read from the pane's xterm buffer).
+- Consumes: existing helpers in `specs/multi-client.spec.ts`: `newClientContext` if a second context proves useful, `waitForTabWithTerminalId`, `waitForMarkedPtySize` (:154-165, marker shape `__LABEL__:<rows> <cols>`, so the typed probe must be `echo __AXIS__:$(stty size)`), the file's `test` import and server/token fixtures, plus the page-side `window.__FRESHELL_TEST_HARNESS__` (`getSentWsMessages`, `getTerminalBuffer`) and store dispatch helpers exactly as used elsewhere in that file.
+- Produces: one new test in that file pinning the hidden-hydration geometry-neutral contract end-to-end.
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Add the test in `test/e2e-browser/specs/multi-client.spec.ts`, reusing its existing helpers verbatim (no new fixtures). The test contract (adapt only call-edge details to the file's actual helper signatures):
+Add this test (adapt only call edges to the file's real helper signatures). Test flow:
 
-```ts
-test('hidden hydration attach on client B does not change client A pane PTY size', async (...) => {
-  // 1. Client A creates a shell pane and lets it fit; resize A's browser
-  //    viewport to a distinctive size per existing helpers; record the PTY
-  //    size on A by typing `echo __AXIS__:$(stty size)` and awaiting
-  //    waitForMarkedPtySize('__AXIS__', ...) on A's harness buffer.
-  // 2. Open client B on the same server; DO NOT select A's tab; wait for
-  //    B's background hydration of A's tab to fire (B's inventory contains
-  //    the tab — waitForTabWithTerminalId on B's context — then the attach
-  //    frame: observable via B's harness getSentWsMessages filtered to
-  //    terminal.attach for A's terminalId; its intent field is also the
-  //    secondary assertion: pre-fix 'viewport_hydrate', post-fix
-  //    'keepalive_delta').
-  // 3. Type `echo __AXIS2__:$(stty size)` on A and assert via
-  //    waitForMarkedPtySize that the PTY size is UNCHANGED from step 1.
-  //
-  // Pre-fix failure mode: B's hidden hydration sends viewport_hydrate with
-  // stale dims and the PTY flips (probe evidence in the run's reports/).
-  // Post-fix B attaches keepalive_delta (no resize).
-})
-```
+1. In the page, create a shell pane and note its fitted dims (existing helpers). Resize the browser viewport to a distinctive geometry if the file has such a helper; otherwise keep defaults — the marker reading supplies the ground truth.
+2. Create a SECOND tab via REST WITHOUT selecting it: use the harness/evaluate to POST `/api/tabs` with `{ mode: 'shell', name: 'geo-witness' }` against the same server and token. Capture its `terminalId`/`tabId` from the response.
+3. Wait until the hidden tab's background hydration attach is sent (poll `getSentWsMessages` for `terminal.attach` with that terminalId), then assert: its `intent === 'keepalive_delta'` and `priority === 'background'`, and that NO `terminal.attach` with `intent === 'viewport_hydrate'` for that terminalId was sent while hidden.
+4. Select the tab (dispatch select/active-tab action the way other specs do), wait for its visible attach (`viewport_hydrate`), then type `echo __AXIS__:$(stty size)\r` into the pane and `waitForMarkedPtySize('__AXIS__', ...)` — assert the reported rows/cols equal the pane's currently fitted xterm dims (available via harness), NOT the 80x24/120x30 spawn defaults; and that a `terminal.resize` for that terminalId was emitted on reveal.
+5. Assert the FIRST pane's PTY size is unchanged throughout (repeat its stty marker at the end).
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
-Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium` (validator E verified this passthrough reaches playwright via scripts/e2e-cloud.sh:340-342; if the selector differs, confirm with `npm run test:e2e:local -- --list` and use the resolved form, still both matrix projects)
+Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium`
 
-Expected: FAIL because client B's hidden hydration attach flips the PTY away from client A's size. If the setup itself errors (context/tokens/hydration), fix the setup — the RED must be the PTY-size assertion.
-
-Note for the implementer: if Task 1's fix lands first, this test arrives GREEN by construction; that is acceptable for Task 2 because its purpose is the durable regression pin. Record in the task report whether RED was observed (stash Task 1 HEAD~ to demonstrate RED if the reviewer wants evidence: `git stash`/checkout dance is NOT required in the default flow; documenting probe evidence from `reports/` suffices).
+Expected: FAIL at step 3's intent assertion (pre-fix wire intent is `viewport_hydrate` for the hidden tab). If setup errors occur, fix the setup only. If Task 1 landed first, this test is green-by-construction — record that honestly and cite the probe/wire-level evidence instead of mangling RED.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-None — Task 1's production change is the fix. This task adds only the e2e. If the e2e cannot be expressed without a tiny harness accessor, add exactly one method to `src/lib/test-harness.ts` (e.g. `getTerminalProps(terminalId)` returning xterm cols/rows) with an accompanying focused vitest addition in the harness's existing unit test file, and use it in the e2e instead of weakening the assertion.
+None (Task 1 covers production). If the REST-create-in-page flow turns out to exist already as a helper in another spec, reuse it; do not add new e2e infrastructure.
 
 - [ ] **Step 4: Run the focused test**
 
-Run: the same e2e command from Step 2.
+Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium`
 
-Expected: PASS.
+Expected: PASS on both projects.
 
 - [ ] **Step 5: Refactor while green**
 
-Deduplicate any new setup code with `multi-client.spec.ts` helpers (share them via that file's existing helper module if one exists; do not create a new shared module for a single caller).
+Inline share nothing new; reuse the file's helpers. If two or more duplicated setup lines remain, follow the file's local extraction patterns.
 
 - [ ] **Step 6: Run impacted-test verification**
 
-Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium` (do not opt into cloud).
+Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium`
 
-Expected: PASS for both.
+Expected: PASS (the whole file, both projects).
 
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add test/e2e-browser/ (changed/new spec + any harness/new helper files)
-git commit -m "test(e2e): pin that hidden hydration attaches cannot stomp the visible pane's PTY size"
+git add test/e2e-browser/specs/multi-client.spec.ts
+git commit -m "test(e2e): pin geometry-neutral hidden hydration attach + reveal heal for REST-created tabs"
 ```
 
 ---
 
-### Task 3: Geometry-convergence live verification against the live root-cause scenario (opencode TUI garbage)
+### Task 3: Live end-to-end verification on a scratch worktree instance
 
 **Files:**
-- No tracked file changes; verification entry only (playwright-driven or manual harness steps against a scratch local server instance on a unique port per AGENTS.md process-safety rules).
+- No tracked file changes. Evidence (screenshots + captured dims) is written to the run logs `reports/` only.
 
 **Interfaces:**
-- Consumes: Tasks 1-2. A throwaway freshell instance started from the worktree with `NODE_ENV=development PORT=3344 npm run dev` (PID-recorded, killed afterwards), a real `opencode` TUI pane, and the test Chrome harness.
+- Consumes: Tasks 1-2. Scratch dev instance from the worktree per repo process-safety rules: `NODE_ENV=development PORT=3344 npm run dev > /tmp/freshell-3344.log 2>&1 & echo $! > /tmp/freshell-3344.pid` from the worktree, teasing out the token, driving via a browser (the agent's browser automation).
 
-- [ ] **Step 1: Reproduce the production symptom pre-fix (sanity)**
+- [ ] **Step 1: Boot + witness setup**
 
-On the scratch instance WITHOUT the fix (e.g. `git stash` of Task 1-2 in a SECOND checkout is not allowed in-repo; instead verify at base in the worktree by... — implementer: if demonstrating pre/post deltas in one worktree is awkward, SKIP this step and rely on the recorded live evidence in the run logs: wiring two clients with different window sizes against one opencode pane was already shown to produce the wrapped garbage capture `/tmp/opencode/chrome-*.png` and the ws geometry stomp from the probe run). Restate the observed pre-fix facts in the task report instead of re-producing.
+Verify the pid file PID belongs to the worktree (`ps -fp $(cat /tmp/freshell-3344.pid)` and confirm the cwd/command path includes the worktree). Open the dev client URL with token in the browser at a fixed window size. Create TWO panes: (a) a shell pane; (b) an opencode-mode pane via the pane picker/REST. REST-create a third shell tab that is never selected (producing a hidden-hydration tab).
 
-- [ ] **Step 2: Post-fix convergence check**
+- [ ] **Step 2: Machine-checkable assertions**
 
-With the fix committed: start the scratch server from the worktree (unique port 3344; record `/tmp/freshell-3344.pid`), open two window-sized contexts, run a real `opencode` TUI pane in client A at a fitted size; let client B's background hydration attach; force scrolls in A; assert via the harness buffer that the render stays intact (no wrapped-footer cascades) and that `stty size` matches A's fitted dims. Then switch visibility: select the tab in B and assert its reveal-attach heal (fresh `stty size` matches B's fitted dims after one resize tick).
+(a) Shell pane: type `echo __AXIS__:$(stty size)` — marker must equal the pane's current fitted xterm dims. (b) Opencode pane: assert via buffer rows (harness) that the footer renders on ONE row and contains both `ctrl+p` and `commands` (no wrap cascade); scroll back a few pages with PgUp and assert rows stay coherent (no right-edge fragment cascade — compare before/after dumps for absence of the known garbage pattern `^ ▀+$` mid-row splits and lone `\d+%)` fragments). (c) Witness tab: assert from `getSentWsMessages` that its hidden attach was `keepalive_delta`. (d) Reveal the witness tab, assert visible attach `viewport_hydrate` and a `terminal.resize` followed; type the stty marker there and confirm it equals its fitted dims. Record all dims + one screenshot per assertion into `reports/live-verify-*.png|json`.
 
-- [ ] **Step 3: Tear down and record**
+- [ ] **Step 3: Teardown + record**
 
-Kill the scratch instance with `kill "$(cat /tmp/freshell-3344.pid)" && rm -f /tmp/freshell-3344.pid`; record observed sizes and screenshots under the run's `logs_dir/reports/`; write the task report with evidence paths.
+Verify ownership before stopping: `ps -fp "$(cat /tmp/freshell-3344.pid)"` and confirm the process's cwd/binary is inside the worktree; only then `kill "$(cat /tmp/freshell-3344.pid)" && rm -f /tmp/freshell-3344.pid`. Write `reports/live-verify.md` with the evidence list and the assertion outcomes.
 
 - [ ] **Step 4: No commit**
 
-This task produces no tracked artifacts (AGENTS.md forbids committing scratch logs; the durable record is the run logs).
+This task produces no tracked artifacts (the evidence lives in the run logs).
 
 ---
 
 ## Addon: plan scope check vs User Request
 
-- Primary fix targets the established mechanism and satisfies "never claim viewport geometry while hidden" via the single choke point -> constraint satisfied; Node/Rust parity untouched (no server diff).
-- Reveal-time convergence is explicitly pinned by Task 1's second test and Task 2's step 2 second half.
-- Residuals honored: no server hardening, no fresh-agent identity work, base failures recorded not fixed.
+- Primary fix targets the established mechanism and satisfies "never claim viewport geometry while hidden" via the single choke point — wire intent swap to keepalive_delta — server parity untouched (no server diff).
+- Reveal-time convergence is restored through suppression-record invalidation on clamped attaches, explicitly pinned by Task 1's T2 and Task 2's step 4; Task 3 verifies it live (including the opencode visual integrity a human would notice as "garbage").
+- Residuals honored: no server hardening, no fresh-agent identity work, base failures recorded not fixed. Known accepted transient (validator AC): a hidden clamped replay paints over the stale hidden surface until reveal; invisible to users, verified safe.

--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -169,7 +169,8 @@ Expected: PASS with zero failures; record the file list and counts in the task r
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx && git rm crates/freshell-ws/tests/zz_probe_attach_resume_geometry.rs
+rm crates/freshell-ws/tests/zz_probe_attach_resume_geometry.rs  # untracked probe — plain rm, evidence retained in run logs
+git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx
 git commit -m "fix(client): hidden panes never claim viewport geometry on attach
 
 A hidden pane's fitted dims are stale; viewport_hydrate hydration attaches

--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -37,6 +37,7 @@ Fix the freshell root cause behind broken mouse scrolling and garbage rendering 
 - Work strictly inside the worktree `/home/dan/code/freshell/.worktrees/attach-geometry-resume-panes` on branch `the-usual/attach-geometry-resume-panes`; commit focused changes with conventional messages; do not push, merge, or open PRs.
 - Follow existing code style in touched files; add no dependencies.
 - The probe file `crates/freshell-ws/tests/zz_probe_attach_resume_geometry.rs` is pre-plan evidence, not part of the implementation; Task 1 deletes it (its assertions are superseded by the plan's own tests).
+- Broad verification gate (round-3 finding 6): after all implementation tasks, the orchestrator's end-of-execution gate runs `npm run check` (typecheck + coordinated full suite) AND `cargo test --workspace --exclude freshell-tauri`. A failure counts as a ledger-recorded pre-existing failure only with a base_ref reproduction receipt (baseline ledger already carries the two known base failures' identifiers/receipts); otherwise it blocks execution completion.
 
 ---
 
@@ -144,7 +145,7 @@ it('reveal after a clamped hidden attach emits terminal.resize even when fitted 
 })
 ```
 
-T3 — surface reset at clamped full replay (green-by-construction guard, protects round-1 finding-2's regression): mount hidden via T1's shape and drive one attach generation fully (attach.ready + tagged output writing `PRIOR-SURFACE-MARKER`) so the terminal surface is non-empty; then force a SECOND hidden clamped attach (exactly as the first was produced — `onActiveTabReady` again), and drive its attach.ready `{ headSeq: 6, replayFromSeq: 3, replayToSeq: 6, attachRequestId: <second attach request id> }` plus `terminal.output` `{ seqStart: 3, seqEnd: 6, data: 'CLAMPED-REPLAY-MARKER', attachRequestId: <second attach request id> }`; assert the mocked terminal write stream contains `CLAMPED-REPLAY-MARKER` exactly once AND `PRIOR-SURFACE-MARKER` exactly once (never duplicated by the replay). Every stream frame carries its attachRequestId.
+T3 — surface reset at clamped full replay (protects round-1 finding-2 against a bookkeeping-degraded implementation; runs green-by-construction on the correct one): mount hidden via T1's shape and drive ONE full attach generation so the mocked surface is non-empty (`term.write` receives `PRIOR-SURFACE-MARKER` once); assert the mocked `term.clear` was called for that attach (clearViewportFirst viewport bookkeeping). Then force a SECOND hidden clamped attach (`onActiveTabReady` again) with its own `attachRequestId` on every frame: attach.ready `{ headSeq: 6, replayFromSeq: 3, replayToSeq: 6 }` and output `{ seqStart: 3, seqEnd: 6, data: 'CLAMPED-REPLAY-MARKER' }`. Assert: (a) the second attach ALSO invoked `term.clear` — proves client bookkeeping kept viewport-hydrate surface-reset semantics under the wire-keepalive token (this FAILS if someone downgrades internal bookkeeping to keepalive semantics, which skips the clear branch); (b) `PRIOR-SURFACE-MARKER` appears exactly once and `CLAMPED-REPLAY-MARKER` exactly once across all `term.write` mock calls.
 
 Also update the pre-existing hidden replay-gap test "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output" (~line 8685): change ONLY its attach wait predicate from `intent === 'viewport_hydrate'` to `intent === 'keepalive_delta'` (the production recreate predicate is NOT changed — `currentAttachRef.intent` retains viewport bookkeeping; that is part of the production contract this redesign pins). Any other pre-existing assertion of a hidden wire `viewport_hydrate` gets the same single-word update under the old-contract rule; record every touched test in the task report. Visible-pane assertions (e.g. "recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output" and the reconnect-before-reveal test at ~4635) must stay untouched and green.
 
@@ -158,47 +159,7 @@ Expected: FAIL for T1 (wire intent is `viewport_hydrate` pre-fix), FAIL for T2 (
 
 Changes live in two places in `src/components/TerminalView.tsx`.
 
-3a. **Close the visibility-race window** (round-2 finding 3). `hiddenRef` is currently synced only in a passive effect (~1191-1199). The same file already establishes the render-synchronous precedent at ~1213-1218 ("Sync during render (not in useEffect) so refs always have latest values"). Move the `hiddenRef.current = hidden` assignment into that render-synchronous block (i.e. assign during render); keep ONLY the extra side effects (`clearHoveredUrl`, dataset cleanup on hide) in the effect. No other ref handling changes. Regression-pin this with the new test below — call it T4:
-
-```ts
-it('hide-then-immediate-reconnect still sends a geometry-neutral (keepalive) attach', async () => {
-  // Pin the commit→effect window closed: with legacy passive-effect syncing,
-  // a reconnect dispatched in the commit-before-effects flush observed the
-  // stale visible value and emitted viewport_hydrate.
-  const { store, tabId, paneId, terminalId, rerender } = await renderTerminalHarness({
-    status: 'running',
-    terminalId: 'term-hide-reconnect-race',
-    clearSends: false,
-    requestId: 'req-hide-reconnect-race',
-  })
-  const readPaneContent = () => {
-    const layout = store.getState().panes.layouts[tabId]
-    return layout && layout.type === 'leaf' && layout.content.kind === 'terminal' ? layout.content : null
-  }
-  wsMocks.send.mockClear()
-  rerender(
-    <Provider store={store}>
-      <TerminalView tabId={tabId} paneId={paneId} paneContent={readPaneContent()!} hidden />
-    </Provider>,
-  )
-  act(() => {
-    reconnectHandler?.()
-  })
-  await waitFor(() => {
-    expect(
-      wsMocks.send.mock.calls
-        .map(([msg]) => msg)
-        .some((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId),
-    ).toBe(true)
-  })
-  expect(
-    wsMocks.send.mock.calls
-      .map(([msg]) => msg)
-      .every((msg) => msg?.type !== 'terminal.attach' || msg?.intent === 'keepalive_delta'),
-    'no attach may claim viewport geometry after the pane committed hidden',
-  ).toBe(true)
-})
-```
+3a. **Close the visibility-race window** (round-2 finding 3, round-3 finding 1). `hiddenRef` is currently synced only in a passive effect (~1191-1199). Move the assignment to a **commit-phase layout effect** (`useLayoutEffect`): a layout effect runs synchronously with the commit, before any passive effect and before any separately-scheduled external callback can observe stale visibility — unlike render-phase writes, it cannot leak visibility from an uncommitted/superseded render (round-3's catching of the earlier render-sync proposal). Net change: convert the existing sync to `useLayoutEffect(() => { hiddenRef.current = hidden; ...existing extra side effects unchanged... }, [hidden, paneId])` (imports already include the hooks; keep the effect's cleanup extras as-is). No new T4 race test: act-wrapped rerender flushes passive effects in the harness, so no unit test can witness the window (round-3 finding 2); the change is a defensive commit-phase sync validated by the whole lifecycle suite staying green, and the residual theoretical window is recorded as an accepted residual.
 
 3b. **The clamp in `attachTerminal`** (~2698):
 
@@ -273,35 +234,35 @@ recreate predicate and reveal planning are unchanged."
 
 ---
 
-### Task 2: e2e regression — REST-created witness tab stays geometry-neutral until reveal
+### Task 2: e2e regression — reload-restored background tab stays geometry-neutral until reveal
 
 **Files:**
 - Test: `test/e2e-browser/specs/multi-client.spec.ts` (EXTEND — already a MATRIX_SPECS member per playwright.config.ts, so both legacy-chromium and rust-chromium run it with no config change; do NOT create a new spec file).
 - No production changes in this task.
 
 **Interfaces:**
-- Consumes: existing helpers in `specs/multi-client.spec.ts`: `waitForTabWithTerminalId`, `waitForMarkedPtySize` (:154-165, marker shape `__LABEL__:<rows> <cols>` — probe text must be `echo __AXIS__:$(stty size)`), the file's `test` import/fixtures, plus page-side `window.__FRESHELL_TEST_HARNESS__` (`getSentWsMessages`, `getTerminalBuffer`, and store dispatch via the harness as other specs do).
+- Consumes: existing helpers in `specs/multi-client.spec.ts` (`waitForTabWithTerminalId`, `waitForMarkedPtySize` (:154-165 — marker shape `__LABEL__:<rows> <cols>`), the file's `test` import/fixtures), the reload/persist-restore flow precedent from `test/e2e-browser/specs/rest-tab-persistence.spec.ts` (reuse its restore helpers/patterns verbatim where applicable), plus page-side `window.__FRESHELL_TEST_HARNESS__` (`getSentWsMessages`, `getTerminalBuffer`) and store dispatch as used by other specs.
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Round-2 finding 4 established: a REST-created tab broadcast arrives ACTIVE (tabsSlice addTab selects it), so the witness flow must create AND then un-select. Test flow:
+Deterministic mount-hidden shape via reload restore (round-3 findings 4-5: the REST-create flow auto-selects and then never re-hydrates, so it could never demonstrate the hidden attach; the boot-time path is the production shape behind the 80x24 stale-dims fleet). Test flow:
 
-1. In the page, use the harness/store to create or use an initial shell pane (existing helpers); record a `stty size` marker `__PRE__:` and keep the emitted dims.
-2. REST-create the witness tab: `page.evaluate(fetch('/api/tabs', { POST, headers incl. x-auth-token, body: { mode: 'shell', name: 'geo-witness' } }))`; the broadcast makes it ACTIVE (visible) and it may attach visibly — that is expected and outside the assertion.
-3. Switch the client BACK to the original tab (dispatch/tap exactly as other specs switch tabs), so the witness tab becomes hidden; then wait until the witness terminal's hydration attach fires while hidden (poll `getSentWsMessages` for `terminal.attach` frames with the witness terminalId).
-4. Assert the CLAMPED attach: at least one `terminal.attach` for the witness terminalId with `intent === 'keepalive_delta'` arrives after it became hidden; and NO `terminal.attach` with `intent === 'viewport_hydrate'` for that terminalId was sent after the hidden transition. (Frames sent while it was briefly visible pre-switch are expected and excluded by the after-transition window in the log, e.g. by slicing `getSentWsMessages` at the switch dispatch.)
-5. Reveal the witness tab (switch to it). Do NOT expect a new attach. Assert: a `terminal.resize` frame for the witness terminalId is emitted after reveal; capture its cols/rows.
-6. Type `echo __AXIS__:$(stty size)\r` in the witness pane; `waitForMarkedPtySize('__AXIS__', ...)` and assert the reported `rows cols` EQUAL the resize frame's dims (the kernel truth matches what the client claimed — wipe-out of a hidden claim would show the stale dims instead).
+1. In a fresh page, create TWO shell tabs (existing helpers): T-A (leave active) and T-B. Close/navigate-away and reload the page in the SAME context so both tabs restore from persistence; after boot ONLY T-A is active/visible and T-B's pane mounts hidden.
+2. Poll `getSentWsMessages` for `terminal.attach` frames naming T-B's terminalId after boot. Assert: at least one such attach arrived with `intent === 'keepalive_delta'` and `priority === 'background'`, and NO attach with `intent === 'viewport_hydrate'` for T-B's terminalId was sent while it was hidden.
+3. Switch to T-B. Do NOT expect a new attach. Assert a `terminal.resize` frame for T-B's terminalId follows the reveal; capture its cols/rows.
+4. In T-B, type `echo __AXIS__:$(stty size)\r`; `waitForMarkedPtySize('__AXIS__', ...)` and assert the kernel-reported `rows cols` EQUAL the resize frame's dims (a hidden-clamp failure would leave kernel dims at the stale/never-fitted values instead).
+
+If the reload-restore helper flow in `rest-tab-persistence.spec.ts` cannot supply T-B's terminalId at boot, get it from the harness/store dispatch state in-page; never resurrect a REST-create-empty-window shape.
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
 Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium`
 
-Expected: FAIL at step 4's intent assertion (pre-fix, the hidden hydration attach for the witness terminal is `viewport_hydrate`). Setup errors → fix setup only. If Task 1 landed first the test is green-by-construction: record that and cite the unit-level RED instead.
+Expected: FAIL at step 2's intent assertion (pre-fix hidden hydration attaches viewport_hydrate). Setup errors → fix setup only. If Task 1 landed first, the test is green-by-construction; record that and cite the unit RED witnesses.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-None (Task 1 covers production). Additionally, in THIS spec file, the pre-existing reconnect test that accepts `transport_reconnect | viewport_hydrate` for its hidden/background branch (round-2 finding 5): update that branch's accepted wire intent to `keepalive_delta` and update its comment rationale (which documented keepalive as a cold-reconnect marker) to the new contract: hidden/background attaches are keepalive_delta BY POLICY (they never claim geometry); visible foreground attaches remain viewport_hydrate/transport_reconnect. Record the edit in the task report.
+None (Task 1 covers production). Additionally, update the pre-existing reconnect test in THIS spec file (round-2 finding 5): its hidden/background branch's accepted wire intent becomes `keepalive_delta` with an updated comment ("hidden/background attaches are keepalive_delta BY POLICY — they never claim geometry; visible foreground attaches remain viewport_hydrate/transport_reconnect"). Record the edit in the task report.
 
 - [ ] **Step 4: Run the focused test**
 
@@ -323,7 +284,7 @@ Expected: PASS (whole file, both projects).
 
 ```bash
 git add test/e2e-browser/specs/multi-client.spec.ts
-git commit -m "test(e2e): pin geometry-neutral hidden hydration attach and reveal resize heal for REST-created tabs"
+git commit -m "test(e2e): pin geometry-neutral boot-time background hydration and reveal resize heal for restored tabs"
 ```
 
 ---
@@ -338,15 +299,15 @@ git commit -m "test(e2e): pin geometry-neutral hidden hydration attach and revea
 
 - [ ] **Step 1: Boot + witness setup**
 
-Verify the pid file PID belongs to the worktree (`ps -fp $(cat /tmp/freshell-3344.pid)` and confirm the cwd/command path includes the worktree). Open the dev client URL with token in the browser at a fixed window size. Create TWO panes: (a) a shell pane; (b) an opencode-mode pane via the pane picker/REST. REST-create a third shell tab, then immediately switch the client back to the shell-pane tab (the broadcast auto-selects the new tab — switch-back makes it hidden; wait for its background hydration attach, ~1-2s).
+Verify the pid file PID belongs to the worktree (`ps -fp $(cat /tmp/freshell-3344.pid)` and confirm the cwd/command path includes the worktree). Open the dev client URL with token in the browser at a fixed window size. Create TWO panes: (a) a shell pane T-A (leave active); (b) an opencode-mode pane (T-OC) via the pane picker/REST; (c) a second shell tab T-B. Then RELOAD the page (same context): persisted tabs restore, T-A active/visible, T-B hidden — the boot-time mount-hidden hydration shape.
 
 - [ ] **Step 2: Machine-checkable assertions**
 
-(a) Shell pane: type `echo __AXIS__:$(stty size)` — marker must equal the pane's current fitted xterm dims. (b) Opencode pane: assert via buffer rows (harness) that the footer renders on ONE row and contains both `ctrl+p` and `commands` (no wrap cascade); scroll back a few pages with PgUp and assert rows stay coherent (no right-edge fragment cascade — compare before/after dumps for absence of the known garbage pattern `^ ▀+$` mid-row splits and lone `\d+%)` fragments). (c) Witness tab: assert from `getSentWsMessages` that its hidden attach was `keepalive_delta`. (d) Reveal the witness tab, assert a `terminal.resize` frame followed the reveal (a new attach is NOT expected once hydration completed), then type the stty marker and confirm its dims equal the emitted resize frame dims (not the 80x24 never-fitted defaults). Record all dims + one screenshot per assertion into `reports/live-verify-*.png|json`.
+(a) Shell pane: type `echo __AXIS__:$(stty size)` — marker must equal the pane's current fitted xterm dims. (b) Opencode pane: assert via buffer rows (harness) that the footer renders on ONE row and contains both `ctrl+p` and `commands` (no wrap cascade); scroll back a few pages with PgUp and assert rows stay coherent (no right-edge fragment cascade — compare before/after dumps for absence of the known garbage pattern `^ ▀+$` mid-row splits and lone `\d+%)` fragments). (c) Witness tab T-B: assert from `getSentWsMessages` that its boot hydration attach was `keepalive_delta` with `priority: 'background'` and no `viewport_hydrate` frames named T-B's terminalId while hidden. (d) Reveal T-B, assert a `terminal.resize` frame followed the reveal (a new attach is NOT expected once hydration completed), then type the stty marker and confirm its dims equal the emitted resize frame dims (not the 80x24 never-fitted defaults). (e) The opencode pane T-OC (visible): footer renders on ONE row containing both `ctrl+p` and `commands`; PgUp-scroll a few pages and confirm no right-edge wrap-cascade fragments (compare row dumps; absence of lone `\d+%)` cells and row-split footer). Record all dims + one screenshot per assertion into the run logs dir `/home/dan/code/freshell/.worktrees/.the-usual-logs/attach-geometry-resume-panes/reports/live-verify-*.png|json` (outside the tracked worktree — never commit these).
 
 - [ ] **Step 3: Teardown + record**
 
-Verify ownership before stopping: `ps -fp "$(cat /tmp/freshell-3344.pid)"` and confirm the process's cwd/binary is inside the worktree; only then `kill "$(cat /tmp/freshell-3344.pid)" && rm -f /tmp/freshell-3344.pid`. Write `reports/live-verify.md` with the evidence list and the assertion outcomes.
+Verify ownership before stopping: `ps -fp "$(cat /tmp/freshell-3344.pid)"` and confirm the process's cwd/binary is inside the worktree; only then `kill "$(cat /tmp/freshell-3344.pid)" && rm -f /tmp/freshell-3344.pid`. Write `/home/dan/code/freshell/.worktrees/.the-usual-logs/attach-geometry-resume-panes/reports/live-verify.md` with the evidence list and the assertion outcomes.
 
 - [ ] **Step 4: No commit**
 

--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -24,7 +24,7 @@ Fix the freshell root cause behind broken mouse scrolling and garbage rendering 
 
 **Goal:** A terminal pane's PTY size is always governed by the visible client; hidden/background-hydration attaches replay scrollback without ever resizing the PTY.
 
-**Architecture:** One invariant in the client attach path: when the pane is not visible (`hiddenRef.current`), an attach intent of `viewport_hydrate` is downgraded to `keepalive_delta` at the single choke point (`attachTerminal` in `TerminalView.tsx`). The server never resizes for `keepalive_delta` (existing `registry.rs` contract: `KeepaliveDelta => false`), and wire replay behavior is intent-independent (registry `attach()` receives only `since_seq`). Reveal attaches of visible panes stay `viewport_hydrate` and keep healing geometry.
+**Architecture:** One invariant in the client attach path: a pane that is not visible (`hiddenRef.current === true`) must never claim viewport geometry. Enforced at the single choke point `attachTerminal` (`src/components/TerminalView.tsx` ~2698): when hidden, the attach runs as a **geometry-neutral full replay** — `effectiveIntent = 'keepalive_delta'`, `sinceSeq` forced to `0` — independent of the caller's requested intent. This avoids three verified collisions with the naive clamp: (1) the internal re-promotion of non-viewport intents to `viewport_hydrate` (~2743-2751) is bypassed for hidden attaches; (2) the warm-delta rejection ladders in the `terminal.attach.ready` handler (4108/4143) can only fire when `sinceSeq > 0`, so forcing `sinceSeq = 0` prevents a clamp→reject→reattach loop in multi-client scenarios where `attach.ready` stamps `geometryAuthority: 'multi_client_unknown'`; (3) the client-side viewport bookkeeping (`syncGeometryEpochForViewport` ~2728, `rememberSentViewport`/`lastSentViewportRef` ~2855-2856) is skipped for hidden attaches, so a later visible-pane `terminal.resize` is not suppressed by `matchesLastSentViewport` (~1643-1650). Servers never resize for `keepalive_delta` (`registry.rs` contract) and wire replay keys off `since_seq` only, so hidden panes still warm up with the full stream. Reveal attaches of visible panes stay `viewport_hydrate`; the reveal effect's `fit+resize` must then heal geometry — because hidden attaches no longer poison the "last sent viewport" record, the reveal resize actually reaches the server.
 
 **Tech Stack:** React 18 / TypeScript client (xterm.js), Vitest + Testing Library (`test/unit/client/components/`), Playwright e2e (`test/e2e-browser/`), Rust ws/terminal crates only for the evidence probe (no Rust change).
 
@@ -86,7 +86,7 @@ it('hidden background hydration attach does not claim viewport geometry', async 
   })
 })
 
-it('reveal after hidden hydration still attaches viewport_hydrate so geometry heals', async () => {
+it('reveal after hidden hydration heals geometry via a resize, not a new geometry-claiming attach', async () => {
   const { store, tabId, paneId, terminalId, rerender } = await renderTerminalHarness({
     status: 'running',
     terminalId: 'term-hidden-then-visible',
@@ -112,18 +112,30 @@ it('reveal after hidden hydration still attaches viewport_hydrate so geometry he
     </Provider>,
   )
 
+  // Contract: reveal of a pane that attached while hidden does NOT send
+  // another geometry-claiming attach (deferred mode is 'live', not
+  // 'waiting_for_geometry'); the existing reveal layout effect sends a
+  // terminal.resize with the real fitted dims, and the hidden attach must
+  // not have poisoned the suppression record (so this resize is actually
+  // emitted).
   await waitFor(() => {
-    const attach = wsMocks.send.mock.calls
-      .map(([msg]) => msg)
-      .find((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId)
-    expect(attach?.intent).toBe('viewport_hydrate')
+    expect(
+      wsMocks.send.mock.calls
+        .map(([msg]) => msg)
+        .some((msg) => msg?.type === 'terminal.attach'),
+    ).toBe(false)
+    expect(
+      wsMocks.send.mock.calls
+        .map(([msg]) => msg)
+        .some((msg) => msg?.type === 'terminal.resize' && msg?.terminalId === terminalId),
+    ).toBe(true)
   })
 })
 ```
 
 (Adjust identifiers at the call edges only — e.g. if `renderTerminalHarness` returns differently named keys or needs `sessionRef`/`mode`, mirror the neighboring tests. The assertions are the contract.)
 
-Also update the pre-existing hidden-hydration replay-gap test (~line 8685, "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output"): its attach predicate filters on `intent === 'viewport_hydrate' && priority === 'background'`. That encoded the old contract; change ONLY the predicate's intent to `'keepalive_delta'` so it keeps testing the recreate-on-replay-gap behavior under the new intent. The kill/recreate behavior contract of that test is unchanged. Do not weaken its assertions. Any other pre-existing test that fails for asserting hidden-pane `viewport_hydrate` must be reviewed individually: update it only if its purpose is the same (hidden-path contract), record each touched test in the task report, and never update the "hidden split create keeps viewport_hydrate intent when reconnect fires before reveal" test's assertion intent if the attach it waits for is sent after the pane became visible — verify by reading its rerender order before deciding.
+Also update the pre-existing hidden-hydration replay-gap test (~line 8685, "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output"): its attach predicate filters on `intent === 'viewport_hydrate' && priority === 'background'`. That encoded the old contract; change ONLY the predicate's intent to `'keepalive_delta'` so it keeps testing the recreate-on-replay-gap behavior under the new intent. The kill/recreate behavior contract of that test is unchanged. Do not weaken its assertions. Any other pre-existing test that fails for asserting hidden-pane `viewport_hydrate` must be reviewed individually: update it only if its purpose is the same (hidden-path contract), record each touched test in the task report. The "hidden split create keeps viewport_hydrate intent when reconnect fires before reveal" test (~line 4635) must be verified by reading its rerender order first: it rerenders with `hidden={false}` after the reconnect tick, so its awaited attach is sent while visible and must stay `viewport_hydrate` — if it fails, that failure is real information about stale `hiddenRef` handling; stop and escalate to the coordinator rather than loosening it.
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -133,20 +145,19 @@ Expected: FAIL because the hidden background-hydration attach frame carries `int
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-In `src/components/TerminalView.tsx`, locate `const attachTerminal = useCallback((` (~line 2698). Inside it, before the WS frame is built, clamp the intent by visibility:
+In `src/components/TerminalView.tsx`, inside `attachTerminal` (~line 2698), apply four coordinated edits, all gated on one boolean captured at entry. Do not touch the visible-pane paths.
 
 ```ts
-  // Geometry authority invariant: only a pane visible on THIS client may
-  // claim viewport geometry. A hidden pane's dims are stale (never fitted
-  // past its last visibility), and every server treats viewport_hydrate as
-  // an unconditional PTY resize — so a hidden attach would stomp the
-  // visible pane's geometry on every background hydration. keepalive_delta
-  // is replay-identical on the wire (replay keys off sinceSeq, not intent)
-  // and never resizes server-side.
-  const effectiveIntent: AttachIntent =
-    intent === 'viewport_hydrate' && hiddenRef.current ? 'keepalive_delta' : intent
+// at the top of attachTerminal, right after existing early returns (~2717):
+const isHiddenAttach = hiddenRef.current
 ```
-Use `effectiveIntent` everywhere below in place of `intent` for the sent frame and for any bookkeeping keyed on the sent intent (e.g. the deferred-attach record's `pendingIntent`, attach tracking, epoch sync decisions). Do not change replay options, priorities, or clearViewportFirst — those are surface-management, not geometry claims.
+
+1. **Intent + replay clamp.** Replace the initial `let effectiveIntent = intent` assignment (~2740) so that when `isHiddenAttach`, `effectiveIntent` becomes `'keepalive_delta'` and both re-promotion branches (~2743-2751) are skipped (guard them with `!isHiddenAttach`). Force full replay for hidden attaches: when `isHiddenAttach`, treat `explicitSinceSeq` as `undefined` and the checkpoint decision as not-ok for the `deltaSeq`/`sinceSeq` derivation (~2752-2753), yielding `sinceSeq === 0`. This is what prevents the warm-delta rejection ladders (which require `sinceSeq > 0`) and any clamp→reject→reattach loop. Do NOT force `clearViewportFirst` either way for hidden attaches; keep the caller's value (cosmetic on a hidden surface).
+2. **Skip geometry bookkeeping for hidden attaches.** Guard with `!isHiddenAttach`: the `syncGeometryEpochForViewport(tid, cols, rows)` call (~2728) and the `rememberSentViewport(tid, cols, rows)` + `lastSentViewportRef.current = ...` pair (~2855-2856). A hidden attach never resizes server-side, so its dims must not become the "last sent viewport" that future visible resizes are suppressed against. Compute `cols`/`rows` as today (they stay in the frame — the schema is unchanged; the server ignores them for keepalive).
+3. Keep `deferredAttachStateRef.current` (~2794) and `currentAttachRef.current` (~2801) recording `pendingIntent`/`intent` = the SENT intent (`effectiveIntent`), so the reveal plan and ready-handler see the true wire semantics.
+4. Add a code comment on the clamp stating the invariant and why sinceSeq must be 0 and viewport bookkeeping skipped (this is the load-bearing summary of the run's evidence; reference that `resize_for_attach` resizes unconditionally for viewport_hydrate).
+
+- [ ] **Step 3b (same task, same commit): reveal-side resize must not be suppressible.** In `flushScheduledLayout` (~1613-1658), evaluate whether, after a hidden attach with clamped bookkeeping, the reveal-time `fit+resize` can be suppressed by `matchesLastSentViewport`. The expected answer post-fix is "no" (nothing recorded while hidden; the last visible record may still be stale-equal if the visible pane's fitted dims are unchanged while the server was resized by someone... — with the stomp gone, the only resizer is THIS pane's visible client; if its last-sent record still matches the fitted dims, the suppression is CORRECT except when another client resized the PTY underneath, which the server-side contract still permits — accepted residual per the User Request). If the focused tests prove suppression still bites in the intended-heal flow, amend the reveal call to bypass suppression explicitly (the smallest change that does that, e.g. a forced resize flag on the reveal layout request), and pin it with the second lifecycle test's assertion list (add: "a terminal.resize frame with the pane's fitted dims is sent on reveal even when a previous visible attach recorded the same dims after a foreign resize changed the server geometry"). Document the chosen answer in the task report.
 
 - [ ] **Step 4: Run the focused test**
 

--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -153,7 +153,7 @@ Also update the pre-existing hidden replay-gap test "recreates a hidden restored
 
 Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx`
 
-Expected: FAIL for T1 (wire intent is `viewport_hydrate` pre-fix), FAIL for T2 (reveal resize suppressed pre-fix because the hidden viewport_hydrate attach recorded identical dims), and FAIL for T4 (hide-then-reconnect race: stale hiddenRef leaks a `viewport_hydrate`). T3 and the reconnect-before-reveal test (~4635) must pass pre-fix — if they fail, the harness setup is wrong; fix the setup, not the assertions. The replay-gap test fails pre-fix only after its predicate update; all failure modes must be assertion-level, not setup errors.
+Expected: FAIL for T1 (wire intent is `viewport_hydrate` pre-fix) and FAIL for T2 (reveal resize suppressed pre-fix: the hidden viewport_hydrate attach records dims the reveal-fit matches exactly in this fixture). T3 and the reconnect-before-reveal test (~4635) must pass pre-fix — if they fail, the harness setup is wrong; fix the setup, not the assertions. The replay-gap test fails pre-fix only after its predicate update; all failure modes must be assertion-level, not setup errors.
 
 - [x] **Step 3: Add the minimal production implementation**
 

--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -52,7 +52,7 @@ Fix the freshell root cause behind broken mouse scrolling and garbage rendering 
 - Consumes: `attachTerminal(tid: string, intent: 'viewport_hydrate' | 'keepalive_delta' | 'transport_reconnect', opts?: AttachTerminalOptions): void`, `hiddenRef.current: boolean`, existing module-level helper `forgetSentViewport(tid)` (src/components/TerminalView.tsx:507), `lastSentViewportRef` (per-instance ref).
 - Produces: no new exported names; only wire-frame `intent` differs for hidden clamps.
 
-- [ ] **Step 1: Write the failing behavioral tests**
+- [x] **Step 1: Write the failing behavioral tests**
 
 Add three tests to the hidden-pane attach-intent block of `test/unit/client/components/TerminalView.lifecycle.test.tsx`.
 
@@ -149,13 +149,13 @@ T3 — surface reset at clamped full replay (protects round-1 finding-2 against 
 
 Also update the pre-existing hidden replay-gap test "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output" (~line 8685): change ONLY its attach wait predicate from `intent === 'viewport_hydrate'` to `intent === 'keepalive_delta'` (the production recreate predicate is NOT changed — `currentAttachRef.intent` retains viewport bookkeeping; that is part of the production contract this redesign pins). Any other pre-existing assertion of a hidden wire `viewport_hydrate` gets the same single-word update under the old-contract rule; record every touched test in the task report. Visible-pane assertions (e.g. "recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output" and the reconnect-before-reveal test at ~4635) must stay untouched and green.
 
-- [ ] **Step 2: Run the tests and verify the intended failure**
+- [x] **Step 2: Run the tests and verify the intended failure**
 
 Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx`
 
 Expected: FAIL for T1 (wire intent is `viewport_hydrate` pre-fix), FAIL for T2 (reveal resize suppressed pre-fix because the hidden viewport_hydrate attach recorded identical dims), and FAIL for T4 (hide-then-reconnect race: stale hiddenRef leaks a `viewport_hydrate`). T3 and the reconnect-before-reveal test (~4635) must pass pre-fix — if they fail, the harness setup is wrong; fix the setup, not the assertions. The replay-gap test fails pre-fix only after its predicate update; all failure modes must be assertion-level, not setup errors.
 
-- [ ] **Step 3: Add the minimal production implementation**
+- [x] **Step 3: Add the minimal production implementation**
 
 Changes live in two places in `src/components/TerminalView.tsx`.
 
@@ -193,17 +193,17 @@ if (hiddenViewportAttach) {
 
 No other edits. In particular: do not touch the re-promotion conditions, the rejection ladders, the gap predicate, the reveal effect, or requestTerminalLayout.
 
-- [ ] **Step 4: Run the focused test**
+- [x] **Step 4: Run the focused test**
 
 Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx`
 
 Expected: PASS (T1/T2 now green; T3 stays green; every pre-existing test in the file stays green after the allowed predicate updates).
 
-- [ ] **Step 5: Refactor while green**
+- [x] **Step 5: Refactor while green**
 
 Verify no duplication crept into the attach block; keep the invariant comment within ~8 lines. No other refactor.
 
-- [ ] **Step 6: Run impacted-test verification**
+- [x] **Step 6: Run impacted-test verification**
 
 Enumerate impacted client files first: `grep -rl "viewport_hydrate\|keepalive_delta" test/unit/client/src test/unit/client 2>/dev/null | sort -u` (then keep only files that exist). Run:
 
@@ -215,7 +215,7 @@ npm run lint
 
 Expected: all PASS. Record the enumerated file list and counts in the task report. Failures whose root cause is an old-contract hidden-viewport assertion may be updated per the Step 1 rule; anything else is a real defect — stop, do not commit, escalate.
 
-- [ ] **Step 7: Commit the task**
+- [x] **Step 7: Commit the task**
 
 ```bash
 rm crates/freshell-ws/tests/zz_probe_attach_resume_geometry.rs

--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -91,34 +91,25 @@ it('a pane hidden at mount hydrates in background with a geometry-neutral keepal
 })
 ```
 
-T2 — heal path (validator-D sequence; pre-fix the resize is suppressed, post-fix it is emitted):
+T2 — heal path (validator-D sequence; pre-fix the resize is suppressed, post-fix it is emitted). Mount-hidden-directly shape (proven by the file's existing hidden-mount tests — no visible→hidden flip, which produces no hidden attach):
 
 ```ts
-it('reveal after a clamped hidden attach emits terminal.resize even when fitted dims equal the pre-hide dims', async () => {
+it('reveal after a clamped hidden attach emits terminal.resize even when fitted dims are unchanged', async () => {
+  // Mounting hidden + hydration trigger produces, PRE-FIX, a wire
+  // viewport_hydrate attach whose dims are the never-fitted xterm defaults —
+  // the same numeric dims the reveal-fit will compute in jsdom (stable
+  // fixture) — so the reveal resize is swallowed by matchesLastSentViewport
+  // pre-fix. Post-fix the clamped attach invalidates the suppression record
+  // and the resize is emitted. This is the RED witness for the heal path.
   const { store, tabId, paneId, terminalId, rerender } = await renderTerminalHarness({
     status: 'running',
     terminalId: 'term-hidden-heal-suppression',
+    hidden: true,
     clearSends: false,
     requestId: 'req-hidden-heal-suppression',
   })
-  // visible attach above records the fitted dims (neighboring tests pin this)
 
-  const readPaneContent = () => {
-    const layout = store.getState().panes.layouts[tabId]
-    return layout && layout.type === 'leaf' && layout.content.kind === 'terminal' ? layout.content : null
-  }
-  rerender(
-    <Provider store={store}>
-      <TerminalView tabId={tabId} paneId={paneId} paneContent={readPaneContent()!} hidden />
-    </Provider>,
-  )
-
-  // Produce the hidden background-hydration attach. Today (pre-fix) its
-  // wire intent is viewport_hydrate (red witness). If the hydration queue
-  // alone does not trigger it for this mount shape, drive it exactly as the
-  // neighbor "background hydrates a trusted hidden reconnect" test does —
-  // act(() => reconnectHandler?.()) — and record which trigger was used in
-  // the task report.
+  wsMocks.send.mockClear()
   act(() => {
     getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])
   })
@@ -153,7 +144,7 @@ it('reveal after a clamped hidden attach emits terminal.resize even when fitted 
 })
 ```
 
-T3 — surface reset at clamped full replay (green-by-construction guard, protects finding-2's regression): mount hidden via T1's shape, capture the sent attach's `attachRequestId`, then drive `messageHandler!` with `terminal.attach.ready` `{ headSeq: 3, replayFromSeq: 1, replayToSeq: 3, attachRequestId }` plus `terminal.output` `{ seqStart: 1, seqEnd: 3, data: 'CLAMPED-REPLAY-MARKER' }`; assert the mocked terminal write stream contains `CLAMPED-REPLAY-MARKER` exactly once.
+T3 — surface reset at clamped full replay (green-by-construction guard, protects round-1 finding-2's regression): mount hidden via T1's shape and drive one attach generation fully (attach.ready + tagged output writing `PRIOR-SURFACE-MARKER`) so the terminal surface is non-empty; then force a SECOND hidden clamped attach (exactly as the first was produced — `onActiveTabReady` again), and drive its attach.ready `{ headSeq: 6, replayFromSeq: 3, replayToSeq: 6, attachRequestId: <second attach request id> }` plus `terminal.output` `{ seqStart: 3, seqEnd: 6, data: 'CLAMPED-REPLAY-MARKER', attachRequestId: <second attach request id> }`; assert the mocked terminal write stream contains `CLAMPED-REPLAY-MARKER` exactly once AND `PRIOR-SURFACE-MARKER` exactly once (never duplicated by the replay). Every stream frame carries its attachRequestId.
 
 Also update the pre-existing hidden replay-gap test "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output" (~line 8685): change ONLY its attach wait predicate from `intent === 'viewport_hydrate'` to `intent === 'keepalive_delta'` (the production recreate predicate is NOT changed — `currentAttachRef.intent` retains viewport bookkeeping; that is part of the production contract this redesign pins). Any other pre-existing assertion of a hidden wire `viewport_hydrate` gets the same single-word update under the old-contract rule; record every touched test in the task report. Visible-pane assertions (e.g. "recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output" and the reconnect-before-reveal test at ~4635) must stay untouched and green.
 
@@ -161,11 +152,55 @@ Also update the pre-existing hidden replay-gap test "recreates a hidden restored
 
 Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx`
 
-Expected: FAIL for T1 (wire intent is `viewport_hydrate` pre-fix) and FAIL for T2 (resize suppressed: pre-hidden viewport_hydrate attach re-recorded identical dims). T3 and the reconnect-before-reveal test must already pass — if they fail, the harness setup is wrong; fix the setup, not the assertions. The replay-gap test fails pre-fix only after its predicate update; both failure modes are assertion-level, not setup errors.
+Expected: FAIL for T1 (wire intent is `viewport_hydrate` pre-fix), FAIL for T2 (reveal resize suppressed pre-fix because the hidden viewport_hydrate attach recorded identical dims), and FAIL for T4 (hide-then-reconnect race: stale hiddenRef leaks a `viewport_hydrate`). T3 and the reconnect-before-reveal test (~4635) must pass pre-fix — if they fail, the harness setup is wrong; fix the setup, not the assertions. The replay-gap test fails pre-fix only after its predicate update; all failure modes must be assertion-level, not setup errors.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-All changes live in `attachTerminal` in `src/components/TerminalView.tsx` (~2698).
+Changes live in two places in `src/components/TerminalView.tsx`.
+
+3a. **Close the visibility-race window** (round-2 finding 3). `hiddenRef` is currently synced only in a passive effect (~1191-1199). The same file already establishes the render-synchronous precedent at ~1213-1218 ("Sync during render (not in useEffect) so refs always have latest values"). Move the `hiddenRef.current = hidden` assignment into that render-synchronous block (i.e. assign during render); keep ONLY the extra side effects (`clearHoveredUrl`, dataset cleanup on hide) in the effect. No other ref handling changes. Regression-pin this with the new test below — call it T4:
+
+```ts
+it('hide-then-immediate-reconnect still sends a geometry-neutral (keepalive) attach', async () => {
+  // Pin the commit→effect window closed: with legacy passive-effect syncing,
+  // a reconnect dispatched in the commit-before-effects flush observed the
+  // stale visible value and emitted viewport_hydrate.
+  const { store, tabId, paneId, terminalId, rerender } = await renderTerminalHarness({
+    status: 'running',
+    terminalId: 'term-hide-reconnect-race',
+    clearSends: false,
+    requestId: 'req-hide-reconnect-race',
+  })
+  const readPaneContent = () => {
+    const layout = store.getState().panes.layouts[tabId]
+    return layout && layout.type === 'leaf' && layout.content.kind === 'terminal' ? layout.content : null
+  }
+  wsMocks.send.mockClear()
+  rerender(
+    <Provider store={store}>
+      <TerminalView tabId={tabId} paneId={paneId} paneContent={readPaneContent()!} hidden />
+    </Provider>,
+  )
+  act(() => {
+    reconnectHandler?.()
+  })
+  await waitFor(() => {
+    expect(
+      wsMocks.send.mock.calls
+        .map(([msg]) => msg)
+        .some((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId),
+    ).toBe(true)
+  })
+  expect(
+    wsMocks.send.mock.calls
+      .map(([msg]) => msg)
+      .every((msg) => msg?.type !== 'terminal.attach' || msg?.intent === 'keepalive_delta'),
+    'no attach may claim viewport geometry after the pane committed hidden',
+  ).toBe(true)
+})
+```
+
+3b. **The clamp in `attachTerminal`** (~2698):
 
 1. After the re-promotion block computes `effectiveIntent` (~2740-2751), compute the wire intent:
 
@@ -238,57 +273,57 @@ recreate predicate and reveal planning are unchanged."
 
 ---
 
-### Task 2: e2e regression — REST-created tab stays geometry-neutral until reveal
+### Task 2: e2e regression — REST-created witness tab stays geometry-neutral until reveal
 
 **Files:**
 - Test: `test/e2e-browser/specs/multi-client.spec.ts` (EXTEND — already a MATRIX_SPECS member per playwright.config.ts, so both legacy-chromium and rust-chromium run it with no config change; do NOT create a new spec file).
-- No production changes in this task (Task 1 is the fix). No harness changes needed (validator E verified `getTerminalBuffer(terminalId?)` and matrix helpers suffice).
+- No production changes in this task.
 
 **Interfaces:**
-- Consumes: existing helpers in `specs/multi-client.spec.ts`: `newClientContext` if a second context proves useful, `waitForTabWithTerminalId`, `waitForMarkedPtySize` (:154-165, marker shape `__LABEL__:<rows> <cols>`, so the typed probe must be `echo __AXIS__:$(stty size)`), the file's `test` import and server/token fixtures, plus the page-side `window.__FRESHELL_TEST_HARNESS__` (`getSentWsMessages`, `getTerminalBuffer`) and store dispatch helpers exactly as used elsewhere in that file.
-- Produces: one new test in that file pinning the hidden-hydration geometry-neutral contract end-to-end.
+- Consumes: existing helpers in `specs/multi-client.spec.ts`: `waitForTabWithTerminalId`, `waitForMarkedPtySize` (:154-165, marker shape `__LABEL__:<rows> <cols>` — probe text must be `echo __AXIS__:$(stty size)`), the file's `test` import/fixtures, plus page-side `window.__FRESHELL_TEST_HARNESS__` (`getSentWsMessages`, `getTerminalBuffer`, and store dispatch via the harness as other specs do).
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Add this test (adapt only call edges to the file's real helper signatures). Test flow:
+Round-2 finding 4 established: a REST-created tab broadcast arrives ACTIVE (tabsSlice addTab selects it), so the witness flow must create AND then un-select. Test flow:
 
-1. In the page, create a shell pane and note its fitted dims (existing helpers). Resize the browser viewport to a distinctive geometry if the file has such a helper; otherwise keep defaults — the marker reading supplies the ground truth.
-2. Create a SECOND tab via REST WITHOUT selecting it: use the harness/evaluate to POST `/api/tabs` with `{ mode: 'shell', name: 'geo-witness' }` against the same server and token. Capture its `terminalId`/`tabId` from the response.
-3. Wait until the hidden tab's background hydration attach is sent (poll `getSentWsMessages` for `terminal.attach` with that terminalId), then assert: its `intent === 'keepalive_delta'` and `priority === 'background'`, and that NO `terminal.attach` with `intent === 'viewport_hydrate'` for that terminalId was sent while hidden.
-4. Select the tab (dispatch select/active-tab action the way other specs do), wait for its visible attach (`viewport_hydrate`), then type `echo __AXIS__:$(stty size)\r` into the pane and `waitForMarkedPtySize('__AXIS__', ...)` — assert the reported rows/cols equal the pane's currently fitted xterm dims (available via harness), NOT the 80x24/120x30 spawn defaults; and that a `terminal.resize` for that terminalId was emitted on reveal.
-5. Assert the FIRST pane's PTY size is unchanged throughout (repeat its stty marker at the end).
+1. In the page, use the harness/store to create or use an initial shell pane (existing helpers); record a `stty size` marker `__PRE__:` and keep the emitted dims.
+2. REST-create the witness tab: `page.evaluate(fetch('/api/tabs', { POST, headers incl. x-auth-token, body: { mode: 'shell', name: 'geo-witness' } }))`; the broadcast makes it ACTIVE (visible) and it may attach visibly — that is expected and outside the assertion.
+3. Switch the client BACK to the original tab (dispatch/tap exactly as other specs switch tabs), so the witness tab becomes hidden; then wait until the witness terminal's hydration attach fires while hidden (poll `getSentWsMessages` for `terminal.attach` frames with the witness terminalId).
+4. Assert the CLAMPED attach: at least one `terminal.attach` for the witness terminalId with `intent === 'keepalive_delta'` arrives after it became hidden; and NO `terminal.attach` with `intent === 'viewport_hydrate'` for that terminalId was sent after the hidden transition. (Frames sent while it was briefly visible pre-switch are expected and excluded by the after-transition window in the log, e.g. by slicing `getSentWsMessages` at the switch dispatch.)
+5. Reveal the witness tab (switch to it). Do NOT expect a new attach. Assert: a `terminal.resize` frame for the witness terminalId is emitted after reveal; capture its cols/rows.
+6. Type `echo __AXIS__:$(stty size)\r` in the witness pane; `waitForMarkedPtySize('__AXIS__', ...)` and assert the reported `rows cols` EQUAL the resize frame's dims (the kernel truth matches what the client claimed — wipe-out of a hidden claim would show the stale dims instead).
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
 Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium`
 
-Expected: FAIL at step 3's intent assertion (pre-fix wire intent is `viewport_hydrate` for the hidden tab). If setup errors occur, fix the setup only. If Task 1 landed first, this test is green-by-construction — record that honestly and cite the probe/wire-level evidence instead of mangling RED.
+Expected: FAIL at step 4's intent assertion (pre-fix, the hidden hydration attach for the witness terminal is `viewport_hydrate`). Setup errors → fix setup only. If Task 1 landed first the test is green-by-construction: record that and cite the unit-level RED instead.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-None (Task 1 covers production). If the REST-create-in-page flow turns out to exist already as a helper in another spec, reuse it; do not add new e2e infrastructure.
+None (Task 1 covers production). Additionally, in THIS spec file, the pre-existing reconnect test that accepts `transport_reconnect | viewport_hydrate` for its hidden/background branch (round-2 finding 5): update that branch's accepted wire intent to `keepalive_delta` and update its comment rationale (which documented keepalive as a cold-reconnect marker) to the new contract: hidden/background attaches are keepalive_delta BY POLICY (they never claim geometry); visible foreground attaches remain viewport_hydrate/transport_reconnect. Record the edit in the task report.
 
 - [ ] **Step 4: Run the focused test**
 
 Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium`
 
-Expected: PASS on both projects.
+Expected: PASS on both projects, including the updated pre-existing reconnect test.
 
 - [ ] **Step 5: Refactor while green**
 
-Inline share nothing new; reuse the file's helpers. If two or more duplicated setup lines remain, follow the file's local extraction patterns.
+Reuse the file's helper patterns; no new infrastructure.
 
 - [ ] **Step 6: Run impacted-test verification**
 
 Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium`
 
-Expected: PASS (the whole file, both projects).
+Expected: PASS (whole file, both projects).
 
 - [ ] **Step 7: Commit the task**
 
 ```bash
 git add test/e2e-browser/specs/multi-client.spec.ts
-git commit -m "test(e2e): pin geometry-neutral hidden hydration attach + reveal heal for REST-created tabs"
+git commit -m "test(e2e): pin geometry-neutral hidden hydration attach and reveal resize heal for REST-created tabs"
 ```
 
 ---
@@ -303,11 +338,11 @@ git commit -m "test(e2e): pin geometry-neutral hidden hydration attach + reveal 
 
 - [ ] **Step 1: Boot + witness setup**
 
-Verify the pid file PID belongs to the worktree (`ps -fp $(cat /tmp/freshell-3344.pid)` and confirm the cwd/command path includes the worktree). Open the dev client URL with token in the browser at a fixed window size. Create TWO panes: (a) a shell pane; (b) an opencode-mode pane via the pane picker/REST. REST-create a third shell tab that is never selected (producing a hidden-hydration tab).
+Verify the pid file PID belongs to the worktree (`ps -fp $(cat /tmp/freshell-3344.pid)` and confirm the cwd/command path includes the worktree). Open the dev client URL with token in the browser at a fixed window size. Create TWO panes: (a) a shell pane; (b) an opencode-mode pane via the pane picker/REST. REST-create a third shell tab, then immediately switch the client back to the shell-pane tab (the broadcast auto-selects the new tab — switch-back makes it hidden; wait for its background hydration attach, ~1-2s).
 
 - [ ] **Step 2: Machine-checkable assertions**
 
-(a) Shell pane: type `echo __AXIS__:$(stty size)` — marker must equal the pane's current fitted xterm dims. (b) Opencode pane: assert via buffer rows (harness) that the footer renders on ONE row and contains both `ctrl+p` and `commands` (no wrap cascade); scroll back a few pages with PgUp and assert rows stay coherent (no right-edge fragment cascade — compare before/after dumps for absence of the known garbage pattern `^ ▀+$` mid-row splits and lone `\d+%)` fragments). (c) Witness tab: assert from `getSentWsMessages` that its hidden attach was `keepalive_delta`. (d) Reveal the witness tab, assert visible attach `viewport_hydrate` and a `terminal.resize` followed; type the stty marker there and confirm it equals its fitted dims. Record all dims + one screenshot per assertion into `reports/live-verify-*.png|json`.
+(a) Shell pane: type `echo __AXIS__:$(stty size)` — marker must equal the pane's current fitted xterm dims. (b) Opencode pane: assert via buffer rows (harness) that the footer renders on ONE row and contains both `ctrl+p` and `commands` (no wrap cascade); scroll back a few pages with PgUp and assert rows stay coherent (no right-edge fragment cascade — compare before/after dumps for absence of the known garbage pattern `^ ▀+$` mid-row splits and lone `\d+%)` fragments). (c) Witness tab: assert from `getSentWsMessages` that its hidden attach was `keepalive_delta`. (d) Reveal the witness tab, assert a `terminal.resize` frame followed the reveal (a new attach is NOT expected once hydration completed), then type the stty marker and confirm its dims equal the emitted resize frame dims (not the 80x24 never-fitted defaults). Record all dims + one screenshot per assertion into `reports/live-verify-*.png|json`.
 
 - [ ] **Step 3: Teardown + record**
 

--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -122,10 +122,22 @@ it('reveal after a clamped hidden attach emits terminal.resize even when fitted 
     ).toBe(true)
   })
 
+  // AS-BUILT (checked): complete the hidden attach generation first
+  // (attach.ready drives deferredAttachStateRef to 'live'), then flip
+  // `hidden` on the SAME TerminalView component (do NOT swap component
+  // types — see as-built note below) and await the reveal effect's resize.
   wsMocks.send.mockClear()
+  act(() => {
+    messageHandler!({
+      type: 'terminal.attach.ready',
+      terminalId,
+      headSeq: 0, replayFromSeq: 1, replayToSeq: 0,
+      attachRequestId: <sent attach requestId>,
+    })
+  })
   rerender(
     <Provider store={store}>
-      <TerminalViewFromStore tabId={tabId} paneId={paneId} hidden={false} />
+      <TerminalView tabId={tabId} paneId={paneId} paneContent={readPaneContent()!} hidden={false} />
     </Provider>,
   )
 
@@ -145,7 +157,7 @@ it('reveal after a clamped hidden attach emits terminal.resize even when fitted 
 })
 ```
 
-T3 — surface reset at clamped full replay (protects round-1 finding-2 against a bookkeeping-degraded implementation; runs green-by-construction on the correct one): mount hidden via T1's shape and drive ONE full attach generation so the mocked surface is non-empty (`term.write` receives `PRIOR-SURFACE-MARKER` once); assert the mocked `term.clear` was called for that attach (clearViewportFirst viewport bookkeeping). Then force a SECOND hidden clamped attach (`onActiveTabReady` again) with its own `attachRequestId` on every frame: attach.ready `{ headSeq: 6, replayFromSeq: 3, replayToSeq: 6 }` and output `{ seqStart: 3, seqEnd: 6, data: 'CLAMPED-REPLAY-MARKER' }`. Assert: (a) the second attach ALSO invoked `term.clear` — proves client bookkeeping kept viewport-hydrate surface-reset semantics under the wire-keepalive token (this FAILS if someone downgrades internal bookkeeping to keepalive semantics, which skips the clear branch); (b) `PRIOR-SURFACE-MARKER` appears exactly once and `CLAMPED-REPLAY-MARKER` exactly once across all `term.write` mock calls.
+T3 — surface reset at clamped full replay (protects round-1 finding-2 against a bookkeeping-degraded implementation; runs green-by-construction on the correct one): mount hidden via T1's shape and drive ONE full attach generation so the mocked surface is non-empty (`term.write` receives `PRIOR-SURFACE-MARKER` once); assert the mocked `term.clear` was called for that attach (clearViewportFirst viewport bookkeeping). Then force a SECOND hidden clamped attach (the hydration queue is one-shot per pane — re-arm via `store.dispatch(requestPaneRefresh({ tabId, paneId }))`, the production hidden re-arm path) with its own `attachRequestId` on every frame: attach.ready `{ headSeq: 6, replayFromSeq: 3, replayToSeq: 6 }` and output `{ seqStart: 3, seqEnd: 6, data: 'CLAMPED-REPLAY-MARKER' }`. Assert: (a) the second attach ALSO invoked `term.clear` — proves client bookkeeping kept viewport-hydrate surface-reset semantics under the wire-keepalive token (this FAILS if someone downgrades internal bookkeeping to keepalive semantics, which skips the clear branch); (b) `PRIOR-SURFACE-MARKER` appears exactly once and `CLAMPED-REPLAY-MARKER` exactly once across all `term.write` mock calls.
 
 Also update the pre-existing hidden replay-gap test "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output" (~line 8685): change ONLY its attach wait predicate from `intent === 'viewport_hydrate'` to `intent === 'keepalive_delta'` (the production recreate predicate is NOT changed — `currentAttachRef.intent` retains viewport bookkeeping; that is part of the production contract this redesign pins). Any other pre-existing assertion of a hidden wire `viewport_hydrate` gets the same single-word update under the old-contract rule; record every touched test in the task report. Visible-pane assertions (e.g. "recreates a restored OpenCode pane when visible viewport hydration cannot replay startup output" and the reconnect-before-reveal test at ~4635) must stay untouched and green.
 
@@ -159,7 +171,7 @@ Expected: FAIL for T1 (wire intent is `viewport_hydrate` pre-fix) and FAIL for T
 
 Changes live in two places in `src/components/TerminalView.tsx`.
 
-3a. **Close the visibility-race window** (round-2 finding 3, round-3 finding 1). `hiddenRef` is currently synced only in a passive effect (~1191-1199). Move the assignment to a **commit-phase layout effect** (`useLayoutEffect`): a layout effect runs synchronously with the commit, before any passive effect and before any separately-scheduled external callback can observe stale visibility — unlike render-phase writes, it cannot leak visibility from an uncommitted/superseded render (round-3's catching of the earlier render-sync proposal). Net change: convert the existing sync to `useLayoutEffect(() => { hiddenRef.current = hidden; ...existing extra side effects unchanged... }, [hidden, paneId])` (imports already include the hooks; keep the effect's cleanup extras as-is). No new T4 race test: act-wrapped rerender flushes passive effects in the harness, so no unit test can witness the window (round-3 finding 2); the change is a defensive commit-phase sync validated by the whole lifecycle suite staying green, and the residual theoretical window is recorded as an accepted residual.
+3a. **Close the visibility-race window** (round-2 finding 3, round-3 finding 1). `hiddenRef` is currently synced only in a passive effect (~1191-1199). Move the assignment to a **commit-phase layout effect** (`useLayoutEffect`): a layout effect runs synchronously with the commit, before any passive effect and before any separately-scheduled external callback can observe stale visibility — unlike render-phase writes, it cannot leak visibility from an uncommitted/superseded render (round-3's catching of the earlier render-sync proposal). Net change: convert the existing sync to `useLayoutEffect(() => { hiddenRef.current = hidden; ...existing extra side effects unchanged... }, [hidden, paneId])` (the import was added — `useLayoutEffect` was NOT previously imported at base; this parenthetical corrects the earlier claim). No new T4 race test: act-wrapped rerender flushes passive effects in the harness, so no unit test can witness the window (round-3 finding 2); the change is a defensive commit-phase sync validated by the whole lifecycle suite staying green, and the residual theoretical window is recorded as an accepted residual.
 
 3b. **The clamp in `attachTerminal`** (~2698):
 
@@ -295,7 +307,7 @@ git commit -m "test(e2e): pin geometry-neutral boot-time background hydration an
 - No tracked file changes. Evidence (screenshots + captured dims) is written to the run logs `reports/` only.
 
 **Interfaces:**
-- Consumes: Tasks 1-2. Scratch dev instance from the worktree per repo process-safety rules: `NODE_ENV=development PORT=3344 npm run dev > /tmp/freshell-3344.log 2>&1 & echo $! > /tmp/freshell-3344.pid` from the worktree, teasing out the token, driving via a browser (the agent's browser automation).
+- Consumes: Tasks 1-2. Scratch dev instance from the worktree per repo process-safety rules (runbook mirrors the executed procedure): `NODE_ENV=development PORT=3344 VITE_PORT=5273 setsid npm run dev > /tmp/freshell-3344.log 2>&1 & echo $! > /tmp/freshell-3344.pid` from the worktree (setsid puts the wrapper and all concurrently children in one owned process group; VITE_PORT is pinned because stock 5173 may be occupied — the client dev origin is the Vite port, the Express API is 3344), teasing out the token from `.env`, driving via the browser automation the agent environment provides (Vite origin `http://localhost:5273/?token=...&e2e=1` proxies /api + /ws to 3344).
 
 - [x] **Step 1: Boot + witness setup**
 
@@ -313,7 +325,12 @@ Verify ownership before stopping: `ps -fp "$(cat /tmp/freshell-3344.pid)"` and c
 PGID=$(ps -o pgid= -p "$(cat /tmp/freshell-3344.pid)" | tr -d ' ')
 ps -o cmd= -g "$PGID"   # eyeball: all members must belong to this scratch instance/worktree
 kill -TERM -- "-$PGID"
-sleep 2; (command -v ss >/dev/null && ss -tlnp | grep -E ':(3344|5273)\b' && echo 'STILL BOUND — investigate before proceeding' || true)
+sleep 2
+if command -v ss >/dev/null && ss -tlnp | grep -qE ':(3344|5273)\b'; then
+  echo 'STILL BOUND — do NOT remove the pid file; list the holders and terminate only SCRATCH members' >&2
+  ss -tlnp | grep -E ':(3344|5273)\b' >&2
+  exit 1
+fi
 rm -f /tmp/freshell-3344.pid
 ```
 

--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -1,0 +1,285 @@
+# Attach Geometry Authority for Hidden Panes Implementation Plan
+
+> **For agentic workers:** Execute this plan task by task with a fresh
+> implementer and a specification-plus-quality review after every task. Track
+> progress with the checkbox steps below.
+
+## User Request
+
+### Requested result
+Fix the freshell root cause behind broken mouse scrolling and garbage rendering in opencode CLI panes: the PTY geometry of a terminal pane must track the pane that is actually being viewed, not any hidden/background client. Today any client whose pane is hidden can attach with `viewport_hydrate` and the server applies that geometry unconditionally, stomping the visible pane's PTY size; nothing converges back until the visible pane happens to emit a new resize. The visible symptoms are opencode TUI full-width frames wrapping into diagonal garbage on scroll-triggered repaints (PTY wider than the view) and dead/stale regions (PTY narrower).
+
+### Explicit constraints
+- Root cause mechanism is established and the fix must target it: client-side background/hidden hydration attaches (`src/components/TerminalView.tsx` background-hydration effect) send `viewport_hydrate` with stale-fitted dimensions; the server's `resize_for_attach` applies `viewport_hydrate` geometry unconditionally (`crates/freshell-terminal/src/registry.rs`); multi-client stomp confirmed by a live ws-level probe (`Some((120,30,1))` → client A hydrate `100x29` → `Some((100,29,1))` → client B hidden-shape hydrate `124x31` → `Some((124,31,2))` while A attached).
+- Preserve Node/Rust server parity: no server behavior change in the primary fix.
+- Panes that are not visible must never claim viewport geometry; enforce at one central client choke point (TerminalView's `attachTerminal`), not by patching individual call sites.
+- Reveal-time convergence must survive: when a hidden pane becomes visible, its reveal attach (`viewport_hydrate` with real fitted dims) plus the existing reveal layout effect (`fit+resize`) must keep healing geometry. No regression to reveal-attach planning (`src/lib/terminal-attach-policy.ts` behavior).
+- Red-green-refactor TDD; unit + e2e coverage; repo rules in AGENTS.md apply: worktree-branch only, focused commits, no merge/push/PR creation.
+
+### Accepted tradeoffs and residuals
+- The server keeps the permissive `viewport_hydrate` contract (Node parity is preserved). A future server-side "hydrate applies geometry only when no other socket is attached" hardening is an optional follow-up and is out of scope.
+- Pre-existing base failures are recorded in the baseline ledger and are not blocking: `network::tests::concurrent_configure_and_disable_serialize_to_a_consistent_end_state` (environment-dependent 500 vs 200, reproduces at base in isolation) and `test/unit/server/coding-cli/codex-app-server/remote-proxy.test.ts` full-suite load flakes (100ms ws timeouts; the file passes in isolation, 261/261).
+- The explorer-reported separate gap — fresh-agent panes never register canonical identity in the WS identity registry (their identity sink writes only the PaneLedger) — is out of scope for this fix.
+- The user's "scrolls a few lines then stops / doesn't scroll" variant is consistent with the same geometry mismatch (scrollbox shrinks to a few rows when PTY rows are smaller than the viewport); the shared-cause fix resolves it.
+
+**Goal:** A terminal pane's PTY size is always governed by the visible client; hidden/background-hydration attaches replay scrollback without ever resizing the PTY.
+
+**Architecture:** One invariant in the client attach path: when the pane is not visible (`hiddenRef.current`), an attach intent of `viewport_hydrate` is downgraded to `keepalive_delta` at the single choke point (`attachTerminal` in `TerminalView.tsx`). The server never resizes for `keepalive_delta` (existing `registry.rs` contract: `KeepaliveDelta => false`), and wire replay behavior is intent-independent (registry `attach()` receives only `since_seq`). Reveal attaches of visible panes stay `viewport_hydrate` and keep healing geometry.
+
+**Tech Stack:** React 18 / TypeScript client (xterm.js), Vitest + Testing Library (`test/unit/client/components/`), Playwright e2e (`test/e2e-browser/`), Rust ws/terminal crates only for the evidence probe (no Rust change).
+
+## Global Constraints
+
+- Server uses NodeNext/ESM; relative imports must include `.js` extensions. (No server change expected; applies to any touched TS.)
+- Never reduce test coverage, mark tests as skip, or simplify tests to pass.
+- Test runs must use repo-owned paths: `npm run test:vitest -- run <files>` for focused vitest; `cargo test -p <crate>` for Rust; `npm test` full coordinated suite only at the gate; Playwright e2e via `npm run test:e2e:local -- <spec>` (local backend; cloud requires user opt-in).
+- Vitest has a shared coordinator gate; broad runs wait for it (`npm run test:status`).
+- Work strictly inside the worktree `/home/dan/code/freshell/.worktrees/attach-geometry-resume-panes` on branch `the-usual/attach-geometry-resume-panes`; commit focused changes with conventional messages; do not push, merge, or open PRs.
+- Follow existing code style in touched files; add no dependencies.
+- The probe file `crates/freshell-ws/tests/zz_probe_attach_resume_geometry.rs` is pre-plan evidence, not part of the implementation; Task 1 deletes it (its assertions are superseded by the plan's own tests).
+
+---
+
+### Task 1: Hide-gated attach intent (RED witness test + choke-point implementation)
+
+**Files:**
+- Delete: `crates/freshell-ws/tests/zz_probe_attach_resume_geometry.rs` (pre-plan probe; evidence retained in run logs `reports/`; it asserts only current-server contract, which stays unchanged)
+- Modify: `src/components/TerminalView.tsx` (`attachTerminal` ~line 2698)
+- Test: `test/unit/client/components/TerminalView.lifecycle.test.tsx` (extend existing attach-intent suite)
+
+**Interfaces:**
+- Consumes: `attachTerminal(tid: string, intent: 'viewport_hydrate' | 'keepalive_delta' | 'transport_reconnect', opts?: AttachTerminalOptions): void` and `hiddenRef.current: boolean` (both already in `TerminalView.tsx`).
+- Produces: no new exported names; changes the wire frame's `intent` field for attaches sent while the pane is hidden.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add to `test/unit/client/components/TerminalView.lifecycle.test.tsx`, in the existing describe block containing the hidden-pane hydration tests (the block around line 8685 that uses `renderTerminalHarness({ hidden: true, ... })` plus `getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])`). Reuse `renderTerminalHarness`, `wsMocks`, `messageHandler`, `TerminalViewFromStore`, `act`, `waitFor` exactly as those tests do. New tests:
+
+```ts
+it('hidden background hydration attach does not claim viewport geometry', async () => {
+  const { store, tabId, paneId, terminalId } = await renderTerminalHarness({
+    status: 'running',
+    terminalId: 'term-hidden-geo-clamp',
+    hidden: true,
+    requestId: 'req-hidden-geo-clamp',
+  })
+
+  wsMocks.send.mockClear()
+  act(() => {
+    getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])
+  })
+
+  await waitFor(() => {
+    const attach = wsMocks.send.mock.calls
+      .map(([msg]) => msg)
+      .find((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId)
+    expect(attach, 'a background hydration attach frame must be sent').toBeTruthy()
+    expect(attach.intent, 'hidden hydration must not claim viewport geometry').toBe('keepalive_delta')
+    expect(attach.priority).toBe('background')
+    expect(attach.cols).toBeGreaterThan(0) // frame schema unchanged
+    expect(attach.rows).toBeGreaterThan(0)
+    expect(
+      wsMocks.send.mock.calls
+        .map(([msg]) => msg)
+        .some((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId && msg?.intent === 'viewport_hydrate'),
+    ).toBe(false)
+  })
+})
+
+it('reveal after hidden hydration still attaches viewport_hydrate so geometry heals', async () => {
+  const { store, tabId, paneId, terminalId, rerender } = await renderTerminalHarness({
+    status: 'running',
+    terminalId: 'term-hidden-then-visible',
+    hidden: true,
+    requestId: 'req-hidden-then-visible',
+  })
+
+  act(() => {
+    getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])
+  })
+  await waitFor(() => {
+    expect(
+      wsMocks.send.mock.calls
+        .map(([msg]) => msg)
+        .some((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId && msg?.intent === 'keepalive_delta'),
+    ).toBe(true)
+  })
+
+  wsMocks.send.mockClear()
+  rerender(
+    <Provider store={store}>
+      <TerminalViewFromStore tabId={tabId} paneId={paneId} hidden={false} />
+    </Provider>,
+  )
+
+  await waitFor(() => {
+    const attach = wsMocks.send.mock.calls
+      .map(([msg]) => msg)
+      .find((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId)
+    expect(attach?.intent).toBe('viewport_hydrate')
+  })
+})
+```
+
+(Adjust identifiers at the call edges only — e.g. if `renderTerminalHarness` returns differently named keys or needs `sessionRef`/`mode`, mirror the neighboring tests. The assertions are the contract.)
+
+Also update the pre-existing hidden-hydration replay-gap test (~line 8685, "recreates a hidden restored OpenCode pane when background viewport hydration cannot replay startup output"): its attach predicate filters on `intent === 'viewport_hydrate' && priority === 'background'`. That encoded the old contract; change ONLY the predicate's intent to `'keepalive_delta'` so it keeps testing the recreate-on-replay-gap behavior under the new intent. The kill/recreate behavior contract of that test is unchanged. Do not weaken its assertions. Any other pre-existing test that fails for asserting hidden-pane `viewport_hydrate` must be reviewed individually: update it only if its purpose is the same (hidden-path contract), record each touched test in the task report, and never update the "hidden split create keeps viewport_hydrate intent when reconnect fires before reveal" test's assertion intent if the attach it waits for is sent after the pane became visible — verify by reading its rerender order before deciding.
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx`
+
+Expected: FAIL because the hidden background-hydration attach frame carries `intent: 'viewport_hydrate'` today (the new first test fails on the intent assertion; the pre-existing replay-gap test will also fail after its predicate update — both failures are intent-level). Failure must be assertion-level, not mount/setup breakage.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+In `src/components/TerminalView.tsx`, locate `const attachTerminal = useCallback((` (~line 2698). Inside it, before the WS frame is built, clamp the intent by visibility:
+
+```ts
+  // Geometry authority invariant: only a pane visible on THIS client may
+  // claim viewport geometry. A hidden pane's dims are stale (never fitted
+  // past its last visibility), and every server treats viewport_hydrate as
+  // an unconditional PTY resize — so a hidden attach would stomp the
+  // visible pane's geometry on every background hydration. keepalive_delta
+  // is replay-identical on the wire (replay keys off sinceSeq, not intent)
+  // and never resizes server-side.
+  const effectiveIntent: AttachIntent =
+    intent === 'viewport_hydrate' && hiddenRef.current ? 'keepalive_delta' : intent
+```
+Use `effectiveIntent` everywhere below in place of `intent` for the sent frame and for any bookkeeping keyed on the sent intent (e.g. the deferred-attach record's `pendingIntent`, attach tracking, epoch sync decisions). Do not change replay options, priorities, or clearViewportFirst — those are surface-management, not geometry claims.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx`
+
+Expected: PASS (both new tests; the whole file stays green).
+
+- [ ] **Step 5: Refactor while green**
+
+Review call-site text: with the choke point in place, the background-hydration effect's explicit `'viewport_hydrate'` argument remains accurate intent-from-caller vocabulary (the clamp site handles gating); add the same one-line comment pointer at the hydration effect call site (TerminalView.tsx ~2992) to keep the invariant discoverable. No other refactor; do not touch the reveal-plan policy file.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Impacted set: all client tests that cover attach intents, hydration, reveal attach, geometry epochs, and resize suppression. Enumerate them (verify with `ls test/unit/client/lib/ test/unit/client/components/ | grep -iE "attach|hydration|lifecycle|view-utils|terminal"` and include every attach/hydration/terminal-view file plus the policy file).
+
+Run: `npm run test:vitest -- run <each enumerated file>` (one invocation with the full enumerated list).
+
+Expected: PASS with zero failures; record the file list and counts in the task report. Any failure whose root cause is the intent change must either be an old-contract assertion (update per Step 1's rule) or a real behavior defect (stop, do not commit; escalate to the coordinator with evidence).
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx && git rm crates/freshell-ws/tests/zz_probe_attach_resume_geometry.rs
+git commit -m "fix(client): hidden panes never claim viewport geometry on attach
+
+A hidden pane's fitted dims are stale; viewport_hydrate hydration attaches
+from any client applied them as the PTY size unconditionally, stomping the
+visible pane's geometry (opencode TUI wrap-garbage on scroll, stale bands).
+Downgrade viewport_hydrate to keepalive_delta at the attachTerminal choke
+point while the pane is hidden; reveal attaches of visible panes are
+unchanged and keep healing geometry."
+```
+
+---
+
+### Task 2: Multi-client e2e regression — hidden hydration does not stomp the visible pane's PTY
+
+**Files:**
+- Test: `test/e2e-browser/multi-client.spec.ts` (extend; precedent file for cross-client PTY geometry assertions) OR a new `test/e2e-browser/attach-geometry-authority.spec.ts` if the existing file's fixture doesn't fit — verify the fixture shapes first, reuse MATRIX_SPECS conventions so it runs on both legacy and rust server projects.
+- Modify: `src/lib/test-harness.ts` ONLY if the e2e cannot otherwise read the real PTY size — precedent uses `getTerminalBuffer` + typed `stty size` markers, which needs no harness change; prefer that. No production client changes in this task.
+
+**Interfaces:**
+- Consumes: Task 1's behavior; `window.__FRESHELL_TEST_HARNESS__` (`getTerminalBuffer`, `sendWsMessage`, store dispatch) as used by `multi-client.spec.ts`; Playwright matrix fixtures from `test/e2e-browser/` (follow `multi-client.spec.ts` exactly).
+- Produces: an e2e spec asserting that a second client's hidden hydration attach does not change the PTY size reported by the owning pane (kernel truth via `stty size` markers read from the pane's xterm buffer).
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Test shape (follow `multi-client.spec.ts`'s browser-context setup helpers verbatim — same two-context creation, token wiring, and terminal creation helpers; do not invent new fixtures):
+
+```ts
+test('hidden hydration attach on client B does not change client A pane PTY size', async ({ /* matrix fixtures */ }) => {
+  // 1. Client A creates a pane running a shell; fit to a distinctive size
+  //    (e.g. resize the browser viewport / pane container per the file's
+  //    existing helpers); record PTY size via typing
+  //    `echo __AXIS__$(stty size)__` and reading the harness buffer marker.
+  // 2. Ensure A's tab becomes hidden on client B: open the same session in a
+  //    second browser context (client B), DO NOT select A's tab, and let the
+  //    background hydration attach fire (the file's hydration wait helpers,
+  //    or wait for B's inventory to contain the tab then one rendered-frame
+  //    tick).
+  // 3. Assert via the `stty size` marker on A that the PTY size is unchanged.
+  //
+  // Pre-fix this fails: B's hidden hydration sends viewport_hydrate with
+  // stale dims and the PTY flips to them (probe evidence in the run's
+  // reports/). Post-fix B attaches keepalive_delta (no resize).
+})
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:e2e:local -- attach-geometry-authority` (or the exact spec-name selector; verify with `npm run test:e2e:local -- --list` first and use the resolved name)
+
+Expected: FAIL because client B's hidden hydration attach flips the PTY away from client A's size. If the setup itself errors (context/tokens/hydration), fix the setup — the RED must be the PTY-size assertion.
+
+Note for the implementer: if Task 1's fix lands first, this test arrives GREEN by construction; that is acceptable for Task 2 because its purpose is the durable regression pin. Record in the task report whether RED was observed (stash Task 1 HEAD~ to demonstrate RED if the reviewer wants evidence: `git stash`/checkout dance is NOT required in the default flow; documenting probe evidence from `reports/` suffices).
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+None — Task 1's production change is the fix. This task adds only the e2e. If the e2e cannot be expressed without a tiny harness accessor, add exactly one method to `src/lib/test-harness.ts` (e.g. `getTerminalProps(terminalId)` returning xterm cols/rows) with an accompanying focused vitest addition in the harness's existing unit test file, and use it in the e2e instead of weakening the assertion.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: the same e2e command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Refactor while green**
+
+Deduplicate any new setup code with `multi-client.spec.ts` helpers (share them via that file's existing helper module if one exists; do not create a new shared module for a single caller).
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Run: `npm run test:e2e:local -- multi-client attach-geometry-authority` (both matrix projects that are selected by default; do not opt into cloud).
+
+Expected: PASS for both.
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add test/e2e-browser/ (changed/new spec + any harness/new helper files)
+git commit -m "test(e2e): pin that hidden hydration attaches cannot stomp the visible pane's PTY size"
+```
+
+---
+
+### Task 3: Geometry-convergence live verification against the live root-cause scenario (opencode TUI garbage)
+
+**Files:**
+- No tracked file changes; verification entry only (playwright-driven or manual harness steps against a scratch local server instance on a unique port per AGENTS.md process-safety rules).
+
+**Interfaces:**
+- Consumes: Tasks 1-2. A throwaway freshell instance started from the worktree with `NODE_ENV=development PORT=3344 npm run dev` (PID-recorded, killed afterwards), a real `opencode` TUI pane, and the test Chrome harness.
+
+- [ ] **Step 1: Reproduce the production symptom pre-fix (sanity)**
+
+On the scratch instance WITHOUT the fix (e.g. `git stash` of Task 1-2 in a SECOND checkout is not allowed in-repo; instead verify at base in the worktree by... — implementer: if demonstrating pre/post deltas in one worktree is awkward, SKIP this step and rely on the recorded live evidence in the run logs: wiring two clients with different window sizes against one opencode pane was already shown to produce the wrapped garbage capture `/tmp/opencode/chrome-*.png` and the ws geometry stomp from the probe run). Restate the observed pre-fix facts in the task report instead of re-producing.
+
+- [ ] **Step 2: Post-fix convergence check**
+
+With the fix committed: start the scratch server from the worktree (unique port 3344; record `/tmp/freshell-3344.pid`), open two window-sized contexts, run a real `opencode` TUI pane in client A at a fitted size; let client B's background hydration attach; force scrolls in A; assert via the harness buffer that the render stays intact (no wrapped-footer cascades) and that `stty size` matches A's fitted dims. Then switch visibility: select the tab in B and assert its reveal-attach heal (fresh `stty size` matches B's fitted dims after one resize tick).
+
+- [ ] **Step 3: Tear down and record**
+
+Kill the scratch instance with `kill "$(cat /tmp/freshell-3344.pid)" && rm -f /tmp/freshell-3344.pid`; record observed sizes and screenshots under the run's `logs_dir/reports/`; write the task report with evidence paths.
+
+- [ ] **Step 4: No commit**
+
+This task produces no tracked artifacts (AGENTS.md forbids committing scratch logs; the durable record is the run logs).
+
+---
+
+## Addon: plan scope check vs User Request
+
+- Primary fix targets the established mechanism and satisfies "never claim viewport geometry while hidden" via the single choke point -> constraint satisfied; Node/Rust parity untouched (no server diff).
+- Reveal-time convergence is explicitly pinned by Task 1's second test and Task 2's step 2 second half.
+- Residuals honored: no server hardening, no fresh-agent identity work, base failures recorded not fixed.

--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -24,7 +24,7 @@ Fix the freshell root cause behind broken mouse scrolling and garbage rendering 
 
 **Goal:** A terminal pane's PTY size is always governed by the visible client; hidden/background-hydration attaches replay scrollback without ever resizing the PTY.
 
-**Architecture:** One invariant in the client attach path: a pane that is not visible (`hiddenRef.current === true`) must never claim viewport geometry. Enforced at the single choke point `attachTerminal` (`src/components/TerminalView.tsx` ~2698): when hidden, the attach runs as a **geometry-neutral full replay** — `effectiveIntent = 'keepalive_delta'`, `sinceSeq` forced to `0` — independent of the caller's requested intent. This avoids three verified collisions with the naive clamp: (1) the internal re-promotion of non-viewport intents to `viewport_hydrate` (~2743-2751) is bypassed for hidden attaches; (2) the warm-delta rejection ladders in the `terminal.attach.ready` handler (4108/4143) can only fire when `sinceSeq > 0`, so forcing `sinceSeq = 0` prevents a clamp→reject→reattach loop in multi-client scenarios where `attach.ready` stamps `geometryAuthority: 'multi_client_unknown'`; (3) the client-side viewport bookkeeping (`syncGeometryEpochForViewport` ~2728, `rememberSentViewport`/`lastSentViewportRef` ~2855-2856) is skipped for hidden attaches, so a later visible-pane `terminal.resize` is not suppressed by `matchesLastSentViewport` (~1643-1650). Servers never resize for `keepalive_delta` (`registry.rs` contract) and wire replay keys off `since_seq` only, so hidden panes still warm up with the full stream. Reveal attaches of visible panes stay `viewport_hydrate`; the reveal effect's `fit+resize` must then heal geometry — because hidden attaches no longer poison the "last sent viewport" record, the reveal resize actually reaches the server.
+**Architecture:** One invariant in the client attach path: a pane that is not visible (`hiddenRef.current === true`) must never claim viewport geometry. Enforced at the single choke point `attachTerminal` (`src/components/TerminalView.tsx` ~2698): when hidden, the attach runs as a **geometry-neutral full replay** — `effectiveIntent = 'keepalive_delta'`, `sinceSeq` forced to `0` — independent of the caller's requested intent. This avoids three verified collisions with the naive clamp: (1) the internal re-promotion of non-viewport intents to `viewport_hydrate` (~2743-2751) is bypassed for hidden attaches; (2) the warm-delta rejection ladders in the `terminal.attach.ready` handler (4108/4143) can only fire when `sinceSeq > 0`, so forcing `sinceSeq = 0` prevents a clamp→reject→reattach loop in multi-client scenarios where `attach.ready` stamps `geometryAuthority: 'multi_client_unknown'`; (3) the client-side viewport bookkeeping (`syncGeometryEpochForViewport` ~2728, `rememberSentViewport`/`lastSentViewportRef` ~2855-2856) is skipped for hidden attaches, so a later visible-pane `terminal.resize` is not suppressed by `matchesLastSentViewport` (~1643-1650). Servers never resize for `keepalive_delta` (`registry.rs` contract) and wire replay keys off `since_seq` only (validator A confirmed: intent never reaches replay selection), so hidden panes still warm up with the full stream. Reveal attaches of visible panes stay `viewport_hydrate`. Two validator-falsified adjacencies are fixed in the same task: (i) the reveal `fit+resize` path can be suppressed by `matchesLastSentViewport` when the reveal-fit dims equal the pre-hide recorded dims — the reveal effect therefore requests the resize with an explicit force flag that bypasses both suppression gates in `flushScheduledLayout`; (ii) the unrecoverable-replay-gap recreate predicate (`isUnrecoverableOpenCodeViewportHydrate` ~3964) keys on wire intent `viewport_hydrate` — broadened to also accept `'keepalive_delta'` with `sinceSeq === 0` so hidden restored opencode panes keep their recreate-on-replay-gap behavior.
 
 **Tech Stack:** React 18 / TypeScript client (xterm.js), Vitest + Testing Library (`test/unit/client/components/`), Playwright e2e (`test/e2e-browser/`), Rust ws/terminal crates only for the evidence probe (no Rust change).
 
@@ -86,12 +86,42 @@ it('hidden background hydration attach does not claim viewport geometry', async 
   })
 })
 
-it('reveal after hidden hydration heals geometry via a resize, not a new geometry-claiming attach', async () => {
+it('reveal after hidden hydration heals geometry via a forced resize, not a new geometry-claiming attach', async () => {
+  // Validator-D scenario pinned: pane first VISIBLE at fitted dims V1 (its
+  // attach records V1 as last-sent viewport), then hidden (hydration attach
+  // is clamped and records nothing), then revealed — the reveal-fit dims are
+  // again V1, so without the force flag `matchesLastSentViewport` would
+  // suppress the resize and a foreign (server-side) geometry change would
+  // never heal.
   const { store, tabId, paneId, terminalId, rerender } = await renderTerminalHarness({
     status: 'running',
     terminalId: 'term-hidden-then-visible',
-    hidden: true,
+    hidden: false,
     requestId: 'req-hidden-then-visible',
+  })
+
+  await waitFor(() => {
+    expect(
+      wsMocks.send.mock.calls
+        .map(([msg]) => msg)
+        .some((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId && msg?.intent === 'viewport_hydrate'),
+    ).toBe(true)
+  })
+
+  rerender(
+    <Provider store={store}>
+      <TerminalViewFromStore tabId={tabId} paneId={paneId} hidden={true} />
+    </Provider>,
+  )
+  act(() => {
+    getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])
+  })
+  await waitFor(() => {
+    expect(
+      wsMocks.send.mock.calls
+        .map(([msg]) => msg)
+        .some((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId && msg?.intent === 'keepalive_delta'),
+    ).toBe(true)
   })
 
   act(() => {
@@ -113,23 +143,37 @@ it('reveal after hidden hydration heals geometry via a resize, not a new geometr
   )
 
   // Contract: reveal of a pane that attached while hidden does NOT send
-  // another geometry-claiming attach (deferred mode is 'live', not
-  // 'waiting_for_geometry'); the existing reveal layout effect sends a
-  // terminal.resize with the real fitted dims, and the hidden attach must
-  // not have poisoned the suppression record (so this resize is actually
-  // emitted).
+  // another attach (deferred mode is 'live', not 'waiting_for_geometry');
+  // the reveal effect emits terminal.resize with the real fitted dims EVEN
+  // THOUGH they equal the pre-hide recorded dims (the force flag bypasses
+  // the suppression gates).
   await waitFor(() => {
     expect(
       wsMocks.send.mock.calls
         .map(([msg]) => msg)
-        .some((msg) => msg?.type === 'terminal.attach'),
-    ).toBe(false)
+        .filter((msg) => msg?.type === 'terminal.attach'),
+    ).toHaveLength(0)
     expect(
       wsMocks.send.mock.calls
         .map(([msg]) => msg)
         .some((msg) => msg?.type === 'terminal.resize' && msg?.terminalId === terminalId),
     ).toBe(true)
   })
+})
+```
+
+And one more test pinning the recreate-path predicate broaden (validator F):
+
+```ts
+it('hidden restored OpenCode pane whose clamped hydration attach hits replay_window_exceeded still kills and recreates the terminal', async () => {
+  // Mirror the pre-existing replay-gap test (~8685) shape with the SAME
+  // opencode sessionRef fixtures, but the attach is the clamped hidden one:
+  // intent keepalive_delta, sinceSeq 0, priority background, then drive
+  // terminal.attach.ready + terminal.output.gap {reason:'replay_window_exceeded'}
+  // for the SAME attachRequestId and assert the existing terminate+respawn
+  // contract fires (terminal.kill WS frame AND the replacement create flow,
+  // exactly as that test asserts today). This test REPLACES the old test's
+  // viewport_hydrate predicate per Step 1's rule.
 })
 ```
 
@@ -155,9 +199,10 @@ const isHiddenAttach = hiddenRef.current
 1. **Intent + replay clamp.** Replace the initial `let effectiveIntent = intent` assignment (~2740) so that when `isHiddenAttach`, `effectiveIntent` becomes `'keepalive_delta'` and both re-promotion branches (~2743-2751) are skipped (guard them with `!isHiddenAttach`). Force full replay for hidden attaches: when `isHiddenAttach`, treat `explicitSinceSeq` as `undefined` and the checkpoint decision as not-ok for the `deltaSeq`/`sinceSeq` derivation (~2752-2753), yielding `sinceSeq === 0`. This is what prevents the warm-delta rejection ladders (which require `sinceSeq > 0`) and any clamp→reject→reattach loop. Do NOT force `clearViewportFirst` either way for hidden attaches; keep the caller's value (cosmetic on a hidden surface).
 2. **Skip geometry bookkeeping for hidden attaches.** Guard with `!isHiddenAttach`: the `syncGeometryEpochForViewport(tid, cols, rows)` call (~2728) and the `rememberSentViewport(tid, cols, rows)` + `lastSentViewportRef.current = ...` pair (~2855-2856). A hidden attach never resizes server-side, so its dims must not become the "last sent viewport" that future visible resizes are suppressed against. Compute `cols`/`rows` as today (they stay in the frame — the schema is unchanged; the server ignores them for keepalive).
 3. Keep `deferredAttachStateRef.current` (~2794) and `currentAttachRef.current` (~2801) recording `pendingIntent`/`intent` = the SENT intent (`effectiveIntent`), so the reveal plan and ready-handler see the true wire semantics.
-4. Add a code comment on the clamp stating the invariant and why sinceSeq must be 0 and viewport bookkeeping skipped (this is the load-bearing summary of the run's evidence; reference that `resize_for_attach` resizes unconditionally for viewport_hydrate).
+4. **Broaden the recreate predicate.** In the `terminal.output.gap` handler, broaden `isUnrecoverableOpenCodeViewportHydrate` (~3964) to additionally accept `currentAttachRef.current?.intent === 'keepalive_delta'` while keeping `sinceSeq === 0`, `mode === 'opencode'`, and `sessionRef.provider === 'opencode'` unchanged (validator F: the recreate path otherwise silently dies for hidden restored opencode panes under the new contract). Update the comment to say both intents identify a full-surface replay attach — visible (`viewport_hydrate`) or hidden-clamped (`keepalive_delta`, sinceSeq 0). Acceptable-leak check: a visible checkpoint-arm keepalive attach has sinceSeq > 0 and stays excluded; do not change that.
+5. Add a code comment on the clamp stating the invariant and why sinceSeq must be 0 and viewport bookkeeping skipped (this is the load-bearing summary of the run's evidence; reference that `resize_for_attach` resizes unconditionally for viewport_hydrate).
 
-- [ ] **Step 3b (same task, same commit): reveal-side resize must not be suppressible.** In `flushScheduledLayout` (~1613-1658), evaluate whether, after a hidden attach with clamped bookkeeping, the reveal-time `fit+resize` can be suppressed by `matchesLastSentViewport`. The expected answer post-fix is "no" (nothing recorded while hidden; the last visible record may still be stale-equal if the visible pane's fitted dims are unchanged while the server was resized by someone... — with the stomp gone, the only resizer is THIS pane's visible client; if its last-sent record still matches the fitted dims, the suppression is CORRECT except when another client resized the PTY underneath, which the server-side contract still permits — accepted residual per the User Request). If the focused tests prove suppression still bites in the intended-heal flow, amend the reveal call to bypass suppression explicitly (the smallest change that does that, e.g. a forced resize flag on the reveal layout request), and pin it with the second lifecycle test's assertion list (add: "a terminal.resize frame with the pane's fitted dims is sent on reveal even when a previous visible attach recorded the same dims after a foreign resize changed the server geometry"). Document the chosen answer in the task report.
+- [ ] **Step 3b (same task, same commit): reveal resize bypass gate.** Validator D falsified "skip-recording is enough": when the reveal-fit dims equal the pre-hide recorded dims, `matchesLastSentViewport` (~1643-1650) suppresses the reveal resize and the server-side mismatch persists. Implement an explicit force path: extend `requestTerminalLayout`'s options with `forceResize?: boolean` (~1599-1611, also extend `pendingLayoutWorkRef` shape), have ONLY the reveal layout effect (~2973) call `requestTerminalLayout({ fit: true, resize: true, forceResize: true })`, and in `flushScheduledLayout` (~1613-1658) skip the `matchesSuppressedViewport` and `matchesLastSentViewport` gates when the force flag is set — still fit() first, still record via `rememberSentViewport`/`lastSentViewportRef` after a forced send, still respect `suppressNetworkEffects` and the `tid` guard.
 
 - [ ] **Step 4: Run the focused test**
 
@@ -197,39 +242,42 @@ unchanged and keep healing geometry."
 ### Task 2: Multi-client e2e regression — hidden hydration does not stomp the visible pane's PTY
 
 **Files:**
-- Test: `test/e2e-browser/multi-client.spec.ts` (extend; precedent file for cross-client PTY geometry assertions) OR a new `test/e2e-browser/attach-geometry-authority.spec.ts` if the existing file's fixture doesn't fit — verify the fixture shapes first, reuse MATRIX_SPECS conventions so it runs on both legacy and rust server projects.
+- Test: `test/e2e-browser/specs/multi-client.spec.ts` (EXTEND this file — validator E confirmed it is already in MATRIX_SPECS (playwright.config.ts:13-170), so the matrix runs it on both legacy-chromium and rust-chromium with no config change. A NEW spec file would need MATRIX_SPECS registration — do not create one).
 - Modify: `src/lib/test-harness.ts` ONLY if the e2e cannot otherwise read the real PTY size — precedent uses `getTerminalBuffer` + typed `stty size` markers, which needs no harness change; prefer that. No production client changes in this task.
 
 **Interfaces:**
-- Consumes: Task 1's behavior; `window.__FRESHELL_TEST_HARNESS__` (`getTerminalBuffer`, `sendWsMessage`, store dispatch) as used by `multi-client.spec.ts`; Playwright matrix fixtures from `test/e2e-browser/` (follow `multi-client.spec.ts` exactly).
-- Produces: an e2e spec asserting that a second client's hidden hydration attach does not change the PTY size reported by the owning pane (kernel truth via `stty size` markers read from the pane's xterm buffer).
+- Consumes: Task 1's behavior; `window.__FRESHELL_TEST_HARNESS__` (`getTerminalBuffer(terminalId?) → string|null` per src/lib/test-harness.ts:113-119); from `specs/multi-client.spec.ts`: `newClientContext` (:10-14) for the second context, `waitForTabWithTerminalId` (:88-139, leaves the tab hidden on B), `waitForMarkedPtySize` (:154-165), whose marker regex expects `__LABEL__:<rows> <cols>`.
+- Produces: a new test inside `specs/multi-client.spec.ts` asserting that a second client's hidden hydration attach does not change the PTY size reported by the owning pane (kernel truth via `stty size` markers read from the pane's xterm buffer).
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Test shape (follow `multi-client.spec.ts`'s browser-context setup helpers verbatim — same two-context creation, token wiring, and terminal creation helpers; do not invent new fixtures):
+Add the test in `test/e2e-browser/specs/multi-client.spec.ts`, reusing its existing helpers verbatim (no new fixtures). The test contract (adapt only call-edge details to the file's actual helper signatures):
 
 ```ts
-test('hidden hydration attach on client B does not change client A pane PTY size', async ({ /* matrix fixtures */ }) => {
-  // 1. Client A creates a pane running a shell; fit to a distinctive size
-  //    (e.g. resize the browser viewport / pane container per the file's
-  //    existing helpers); record PTY size via typing
-  //    `echo __AXIS__$(stty size)__` and reading the harness buffer marker.
-  // 2. Ensure A's tab becomes hidden on client B: open the same session in a
-  //    second browser context (client B), DO NOT select A's tab, and let the
-  //    background hydration attach fire (the file's hydration wait helpers,
-  //    or wait for B's inventory to contain the tab then one rendered-frame
-  //    tick).
-  // 3. Assert via the `stty size` marker on A that the PTY size is unchanged.
+test('hidden hydration attach on client B does not change client A pane PTY size', async (...) => {
+  // 1. Client A creates a shell pane and lets it fit; resize A's browser
+  //    viewport to a distinctive size per existing helpers; record the PTY
+  //    size on A by typing `echo __AXIS__:$(stty size)` and awaiting
+  //    waitForMarkedPtySize('__AXIS__', ...) on A's harness buffer.
+  // 2. Open client B on the same server; DO NOT select A's tab; wait for
+  //    B's background hydration of A's tab to fire (B's inventory contains
+  //    the tab — waitForTabWithTerminalId on B's context — then the attach
+  //    frame: observable via B's harness getSentWsMessages filtered to
+  //    terminal.attach for A's terminalId; its intent field is also the
+  //    secondary assertion: pre-fix 'viewport_hydrate', post-fix
+  //    'keepalive_delta').
+  // 3. Type `echo __AXIS2__:$(stty size)` on A and assert via
+  //    waitForMarkedPtySize that the PTY size is UNCHANGED from step 1.
   //
-  // Pre-fix this fails: B's hidden hydration sends viewport_hydrate with
-  // stale dims and the PTY flips to them (probe evidence in the run's
-  // reports/). Post-fix B attaches keepalive_delta (no resize).
+  // Pre-fix failure mode: B's hidden hydration sends viewport_hydrate with
+  // stale dims and the PTY flips (probe evidence in the run's reports/).
+  // Post-fix B attaches keepalive_delta (no resize).
 })
 ```
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
-Run: `npm run test:e2e:local -- attach-geometry-authority` (or the exact spec-name selector; verify with `npm run test:e2e:local -- --list` first and use the resolved name)
+Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium` (validator E verified this passthrough reaches playwright via scripts/e2e-cloud.sh:340-342; if the selector differs, confirm with `npm run test:e2e:local -- --list` and use the resolved form, still both matrix projects)
 
 Expected: FAIL because client B's hidden hydration attach flips the PTY away from client A's size. If the setup itself errors (context/tokens/hydration), fix the setup — the RED must be the PTY-size assertion.
 
@@ -251,7 +299,7 @@ Deduplicate any new setup code with `multi-client.spec.ts` helpers (share them v
 
 - [ ] **Step 6: Run impacted-test verification**
 
-Run: `npm run test:e2e:local -- multi-client attach-geometry-authority` (both matrix projects that are selected by default; do not opt into cloud).
+Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium` (do not opt into cloud).
 
 Expected: PASS for both.
 

--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -297,19 +297,19 @@ git commit -m "test(e2e): pin geometry-neutral boot-time background hydration an
 **Interfaces:**
 - Consumes: Tasks 1-2. Scratch dev instance from the worktree per repo process-safety rules: `NODE_ENV=development PORT=3344 npm run dev > /tmp/freshell-3344.log 2>&1 & echo $! > /tmp/freshell-3344.pid` from the worktree, teasing out the token, driving via a browser (the agent's browser automation).
 
-- [ ] **Step 1: Boot + witness setup**
+- [x] **Step 1: Boot + witness setup**
 
 Verify the pid file PID belongs to the worktree (`ps -fp $(cat /tmp/freshell-3344.pid)` and confirm the cwd/command path includes the worktree). Open the dev client URL with token in the browser at a fixed window size. Create TWO panes: (a) a shell pane T-A (leave active); (b) an opencode-mode pane (T-OC) via the pane picker/REST; (c) a second shell tab T-B. Then RELOAD the page (same context): persisted tabs restore, T-A active/visible, T-B hidden — the boot-time mount-hidden hydration shape.
 
-- [ ] **Step 2: Machine-checkable assertions**
+- [x] **Step 2: Machine-checkable assertions**
 
 (a) Shell pane: type `echo __AXIS__:$(stty size)` — marker must equal the pane's current fitted xterm dims. (b) Opencode pane: assert via buffer rows (harness) that the footer renders on ONE row and contains both `ctrl+p` and `commands` (no wrap cascade); scroll back a few pages with PgUp and assert rows stay coherent (no right-edge fragment cascade — compare before/after dumps for absence of the known garbage pattern `^ ▀+$` mid-row splits and lone `\d+%)` fragments). (c) Witness tab T-B: assert from `getSentWsMessages` that its boot hydration attach was `keepalive_delta` with `priority: 'background'` and no `viewport_hydrate` frames named T-B's terminalId while hidden. (d) Reveal T-B, assert a `terminal.resize` frame followed the reveal (a new attach is NOT expected once hydration completed), then type the stty marker and confirm its dims equal the emitted resize frame dims (not the 80x24 never-fitted defaults). (e) The opencode pane T-OC (visible): footer renders on ONE row containing both `ctrl+p` and `commands`; PgUp-scroll a few pages and confirm no right-edge wrap-cascade fragments (compare row dumps; absence of lone `\d+%)` cells and row-split footer). Record all dims + one screenshot per assertion into the run logs dir `/home/dan/code/freshell/.worktrees/.the-usual-logs/attach-geometry-resume-panes/reports/live-verify-*.png|json` (outside the tracked worktree — never commit these).
 
-- [ ] **Step 3: Teardown + record**
+- [x] **Step 3: Teardown + record**
 
 Verify ownership before stopping: `ps -fp "$(cat /tmp/freshell-3344.pid)"` and confirm the process's cwd/binary is inside the worktree; only then `kill "$(cat /tmp/freshell-3344.pid)" && rm -f /tmp/freshell-3344.pid`. Write `/home/dan/code/freshell/.worktrees/.the-usual-logs/attach-geometry-resume-panes/reports/live-verify.md` with the evidence list and the assertion outcomes.
 
-- [ ] **Step 4: No commit**
+- [x] **Step 4: No commit**
 
 This task produces no tracked artifacts (the evidence lives in the run logs).
 

--- a/docs/plans/2026-08-16-attach-geometry-resume-panes.md
+++ b/docs/plans/2026-08-16-attach-geometry-resume-panes.md
@@ -243,7 +243,7 @@ recreate predicate and reveal planning are unchanged."
 **Interfaces:**
 - Consumes: existing helpers in `specs/multi-client.spec.ts` (`waitForTabWithTerminalId`, `waitForMarkedPtySize` (:154-165 — marker shape `__LABEL__:<rows> <cols>`), the file's `test` import/fixtures), the reload/persist-restore flow precedent from `test/e2e-browser/specs/rest-tab-persistence.spec.ts` (reuse its restore helpers/patterns verbatim where applicable), plus page-side `window.__FRESHELL_TEST_HARNESS__` (`getSentWsMessages`, `getTerminalBuffer`) and store dispatch as used by other specs.
 
-- [ ] **Step 1: Write the failing behavioral test**
+- [x] **Step 1: Write the failing behavioral test**
 
 Deterministic mount-hidden shape via reload restore (round-3 findings 4-5: the REST-create flow auto-selects and then never re-hydrates, so it could never demonstrate the hidden attach; the boot-time path is the production shape behind the 80x24 stale-dims fleet). Test flow:
 
@@ -254,33 +254,33 @@ Deterministic mount-hidden shape via reload restore (round-3 findings 4-5: the R
 
 If the reload-restore helper flow in `rest-tab-persistence.spec.ts` cannot supply T-B's terminalId at boot, get it from the harness/store dispatch state in-page; never resurrect a REST-create-empty-window shape.
 
-- [ ] **Step 2: Run the test and verify the intended failure**
+- [x] **Step 2: Run the test and verify the intended failure**
 
 Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium`
 
 Expected: FAIL at step 2's intent assertion (pre-fix hidden hydration attaches viewport_hydrate). Setup errors → fix setup only. If Task 1 landed first, the test is green-by-construction; record that and cite the unit RED witnesses.
 
-- [ ] **Step 3: Add the minimal production implementation**
+- [x] **Step 3: Add the minimal production implementation**
 
 None (Task 1 covers production). Additionally, update the pre-existing reconnect test in THIS spec file (round-2 finding 5): its hidden/background branch's accepted wire intent becomes `keepalive_delta` with an updated comment ("hidden/background attaches are keepalive_delta BY POLICY — they never claim geometry; visible foreground attaches remain viewport_hydrate/transport_reconnect"). Record the edit in the task report.
 
-- [ ] **Step 4: Run the focused test**
+- [x] **Step 4: Run the focused test**
 
 Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium`
 
 Expected: PASS on both projects, including the updated pre-existing reconnect test.
 
-- [ ] **Step 5: Refactor while green**
+- [x] **Step 5: Refactor while green**
 
 Reuse the file's helper patterns; no new infrastructure.
 
-- [ ] **Step 6: Run impacted-test verification**
+- [x] **Step 6: Run impacted-test verification**
 
 Run: `npm run test:e2e:local -- specs/multi-client.spec.ts --project=legacy-chromium --project=rust-chromium`
 
 Expected: PASS (whole file, both projects).
 
-- [ ] **Step 7: Commit the task**
+- [x] **Step 7: Commit the task**
 
 ```bash
 git add test/e2e-browser/specs/multi-client.spec.ts

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -2,6 +2,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -1188,7 +1189,11 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     }
   }, [terminalContent?.terminalId])
 
-  useEffect(() => {
+  // Sync visibility at commit phase (layout effect, not passive effect): a
+  // passive effect would leave a window where a queued attach callback could
+  // read a stale hiddenRef; a layout effect runs synchronously with the
+  // commit, before any separately-scheduled external callback can observe it.
+  useLayoutEffect(() => {
     hiddenRef.current = hidden
     if (hidden) {
       clearHoveredUrl(paneId)
@@ -2749,6 +2754,16 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       clearViewportFirst = true
       fullHydrateFallbackReason = checkpointDecision.reason
     }
+    // Geometry authority invariant (attach-geometry-resume-panes): a pane that
+    // is not visible must never CLAIM viewport geometry on the wire — servers
+    // resize the PTY unconditionally for viewport_hydrate regardless of who
+    // else is attached, so a hidden hydrating tab stamps stale/never-fitted
+    // dims over the visible pane's size. The swap is wire-token-only: all
+    // bookkeeping keeps viewport_hydrate semantics (sinceSeq 0, surface reset,
+    // currentAttachRef/deferredAttachState intents); keepalive_delta is
+    // replay-identical (replay keys off since_seq) and never resizes.
+    const hiddenViewportAttach = effectiveIntent === 'viewport_hydrate' && hiddenRef.current
+    const wireIntent = hiddenViewportAttach ? 'keepalive_delta' : effectiveIntent
     const deltaSeq = Math.max(0, Math.floor(explicitSinceSeq ?? (checkpointDecision.ok ? checkpointDecision.sinceSeq : 0)))
     const sinceSeq = effectiveIntent === 'viewport_hydrate' ? 0 : deltaSeq
     const surfaceQuarantined = hasInFlightWrites
@@ -2844,7 +2859,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     ws.send(buildTerminalAttachMessage({
       content: contentRef.current,
       terminalId: tid,
-      intent: effectiveIntent,
+      intent: wireIntent,
       cols,
       rows,
       sinceSeq,
@@ -2854,6 +2869,12 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     }))
     rememberSentViewport(tid, cols, rows)
     lastSentViewportRef.current = { terminalId: tid, cols, rows }
+    if (hiddenViewportAttach) {
+      // The server did not apply these dims; do not let them suppress the next
+      // visible-pane resize (reveal-time heal path).
+      forgetSentViewport(tid)
+      lastSentViewportRef.current = null
+    }
     if (surfaceQuarantined) {
       scheduleQuarantineRepair(tid, attachRequestId)
     }

--- a/test/e2e-browser/specs/multi-client.spec.ts
+++ b/test/e2e-browser/specs/multi-client.spec.ts
@@ -510,14 +510,17 @@ test.describe('Multi-Client', () => {
 
     // Kernel cross-check: the PTY's actual winsize must equal the dims the
     // reveal resize claimed (a hidden-clamp failure would leave the kernel
-    // at stale/never-fitted dims instead). Give the server a beat to apply
-    // the resize before asking stty.
-    await page.waitForTimeout(300)
-    await tabBTerminal.locator('.xterm').first().click()
-    await page.keyboard.type('echo __AXIS__:$(stty size)')
-    await page.keyboard.press('Enter')
-    const kernelSize = await waitForMarkedPtySize(page, '__AXIS__', terminalBId)
-    expect(kernelSize).toBe(`${healResize.rows} ${healResize.cols}`)
+    // at stale/never-fitted dims instead). Poll rather than assume the
+    // server has applied the resize within a fixed settle: each attempt
+    // re-asks stty, and readMarkedPtySize takes the LAST __AXIS__ marker,
+    // so a retry always compares the freshest kernel echo.
+    await expect(async () => {
+      await tabBTerminal.locator('.xterm').first().click()
+      await page.keyboard.type('echo __AXIS__:$(stty size)')
+      await page.keyboard.press('Enter')
+      const kernelSize = await waitForMarkedPtySize(page, '__AXIS__', terminalBId)
+      expect(kernelSize).toBe(`${healResize.rows} ${healResize.cols}`)
+    }).toPass({ timeout: 15_000, intervals: [250, 500, 1_000] })
 
     await context.close()
   })

--- a/test/e2e-browser/specs/multi-client.spec.ts
+++ b/test/e2e-browser/specs/multi-client.spec.ts
@@ -85,6 +85,16 @@ async function getActiveTerminalId(page: Page): Promise<string | null> {
   })
 }
 
+async function waitForActiveTerminalId(page: Page, timeout = 20_000): Promise<string> {
+  let latest: string | null = null
+  await expect(async () => {
+    latest = await getActiveTerminalId(page)
+    expect(latest).toBeTruthy()
+  }).toPass({ timeout })
+  if (!latest) throw new Error('Expected the active tab to expose a terminalId')
+  return latest
+}
+
 async function waitForTabWithTerminalId(page: Page, expectedTerminalId: string, timeout = 20_000): Promise<string> {
   await page.waitForFunction((terminalId) => {
     const state = window.__FRESHELL_TEST_HARNESS__?.getState()
@@ -267,34 +277,49 @@ test.describe('Multi-Client', () => {
     // TerminalView takes when it reconnects while its own pane is already
     // considered foreground/live (terminal-attach-policy.ts). But whether the
     // client takes that path or the slower "hidden pane reveal" path
-    // (viewport_hydrate, background-hydration) depends on the client's
-    // internal foreground/hidden bookkeeping at the exact instant the reconnect
-    // fires -- timing-sensitive, client-side (frozen `src/`, can't be changed
-    // here), and NOT something a wait/serialize change in this spec can pin.
-    // Under real host load this repo's build+test contention reliably tips it
-    // into the viewport_hydrate path (reproduced deterministically here, not
+    // (background-hydration attach) depends on the client's internal
+    // foreground/hidden bookkeeping at the exact instant the reconnect
+    // fires -- timing-sensitive, client-side, and NOT something a
+    // wait/serialize change in this spec can pin. Under real host load this
+    // repo's build+test contention reliably tips it into the
+    // background-hydration path (reproduced deterministically here, not
     // occasionally); on a quiet host it can land on transport_reconnect
-    // instead -- hence the flake, not a too-short wait budget.
+    // instead -- hence the historical flake, not a too-short wait budget.
+    //
+    // WIRE-INTENT POLICY (attach-geometry-resume-panes): hidden/background
+    // attaches are keepalive_delta BY POLICY -- they never claim geometry;
+    // visible foreground attaches remain viewport_hydrate/transport_reconnect.
+    // Page2's pane is VISIBLE here, and the foreground reconnect legitimately
+    // lands on viewport_hydrate when TerminalView's re-promotion fires
+    // (in-flight writes or no usable delta checkpoint -> full replay);
+    // verified by wire capture on this test: page2's frames arrive as
+    // { intent: 'viewport_hydrate', priority: 'foreground', sinceSeq: 0 }.
+    // If the client's hidden bookkeeping instead routes the reconnect through
+    // the background-hydration queue, the hidden clamp makes the wire token
+    // keepalive_delta with priority background -- replay-identical but
+    // geometry-neutral. The accepted reconnect-shaped set is therefore
+    // { transport_reconnect, viewport_hydrate, keepalive_delta }; the policy
+    // regression (a HIDDEN pane's attach claiming geometry) is pinned exactly
+    // by the sibling reload-restore test further down this file, not by this
+    // visible-pane scenario.
     //
     // Verified by direct experiment: relaxing this assertion to accept EITHER
-    // intent and letting the rest of the test run confirms the PTY-size and
-    // shared-output checks below (the test's actual documented contract) pass
-    // either way. So the specific intent value is an internal implementation
-    // choice, not the behavior this test is meant to guard -- asserting the
-    // exact intent was over-constraining an implementation detail rather than
-    // the contract. What DOES matter, and is still asserted: page2 issued a
-    // BOUNDED 1..2 re-attaches for this terminal (not zero -- a silently
-    // dropped reconnect -- and not a runaway retry storm; the 2 covers the
-    // reconnect attach plus at most one designed pane.reconcile fold
-    // re-fire via the reconcileEpoch bump, detailed below), using a
-    // reconnect-shaped intent (not a cold 'keepalive_delta', which would
-    // mean it never recognized this as a reconnect at all).
+    // reconnect-shaped intent and letting the rest of the test run confirms
+    // the PTY-size and shared-output checks below (the test's actual
+    // documented contract) pass on either path. So the specific intent value
+    // within that set is an internal implementation choice, not the behavior
+    // this test is meant to guard. What DOES matter, and is still asserted:
+    // page2 issued a BOUNDED 1..2 re-attaches for this terminal (not zero --
+    // a silently dropped reconnect -- and not a runaway retry storm; the 2
+    // covers the reconnect attach plus at most one designed pane.reconcile
+    // fold re-fire via the reconcileEpoch bump, detailed below), using a
+    // reconnect-shaped intent from the accepted set above.
     await page2.waitForFunction((id) => {
       const sent = window.__FRESHELL_TEST_HARNESS__?.getSentWsMessages?.() ?? []
       return sent.some((msg: any) =>
         msg?.type === 'terminal.attach'
         && msg?.terminalId === id
-        && (msg?.intent === 'transport_reconnect' || msg?.intent === 'viewport_hydrate')
+        && (msg?.intent === 'transport_reconnect' || msg?.intent === 'viewport_hydrate' || msg?.intent === 'keepalive_delta')
       )
     }, terminalId!, { timeout: 20_000 })
 
@@ -303,7 +328,7 @@ test.describe('Multi-Client', () => {
       return sent.filter((msg: any) =>
         msg?.type === 'terminal.attach'
         && msg?.terminalId === id
-        && (msg?.intent === 'transport_reconnect' || msg?.intent === 'viewport_hydrate')
+        && (msg?.intent === 'transport_reconnect' || msg?.intent === 'viewport_hydrate' || msg?.intent === 'keepalive_delta')
       )
     }, terminalId!)
     // Under paneReconcileV1 (the adopted client) a reconnect has TWO
@@ -328,6 +353,171 @@ test.describe('Multi-Client', () => {
     await executeCommand(page1, 'echo "__AFTER_PAGE2_RECONNECT__"')
     await waitForTerminalText(page1, '__AFTER_PAGE2_RECONNECT__', terminalId!)
     await waitForTerminalText(page2, '__AFTER_PAGE2_RECONNECT__', terminalId!)
+
+    await context.close()
+  })
+
+  // ------------------------------------------------------------------
+  // Geometry authority regression (attach-geometry-resume-panes): a
+  // reload-restored tab that boots HIDDEN must never claim viewport geometry
+  // on the wire -- servers resize the PTY unconditionally for
+  // viewport_hydrate, so a hidden tab's stale/never-fitted dims would stomp
+  // the visible pane's geometry. The deterministic mount-hidden shape comes
+  // from persistence restore (the production boot-time path): a REST/UI
+  // create flow auto-selects the new tab so it is never hidden, only a
+  // reload restores a hidden-at-mount pane. Post-fix the boot-time
+  // background hydration attach is keepalive_delta + priority background
+  // (replay-only), and the reveal heals geometry with a terminal.resize
+  // whose dims the kernel then confirms via stty.
+  // ------------------------------------------------------------------
+  test('reload-restored background tab stays geometry-neutral until reveal heals it with a resize', async ({ browser, serverInfo }) => {
+    test.setTimeout(120_000)
+    const context = await newClientContext(browser)
+    const page = await context.newPage()
+
+    await page.goto(`${serverInfo.baseUrl}/?token=${serverInfo.token}&e2e=1`)
+    await waitForReady(page)
+    await ensureTerminalReady(page)
+
+    // T-A stays the active tab across the reload.
+    const tabAId = await page.evaluate(() =>
+      window.__FRESHELL_TEST_HARNESS__?.getState()?.tabs?.activeTabId ?? null
+    )
+    expect(tabAId).toBeTruthy()
+    const terminalAId = await waitForActiveTerminalId(page)
+
+    // T-B is created and driven once, then hidden behind T-A -- after the
+    // reload it is the pane that mounts hidden at boot.
+    await page.locator('[data-context="tab-add"]').click()
+    await page.waitForFunction((prevTabId) => {
+      const state = window.__FRESHELL_TEST_HARNESS__?.getState()
+      return state?.tabs?.tabs?.length === 2 && state?.tabs?.activeTabId !== prevTabId
+    }, tabAId, { timeout: 10_000 })
+    const tabBId = await page.evaluate(() =>
+      window.__FRESHELL_TEST_HARNESS__?.getState()?.tabs?.activeTabId ?? null
+    )
+    expect(tabBId).toBeTruthy()
+
+    // A fresh tab may show a PanePicker; select a shell for it. The picker
+    // and terminal are scoped to T-B -- T-A's terminal stays mounted (just
+    // hidden), so an unscoped `.xterm` could resolve to the wrong pane.
+    const tabBTerminal = page.locator(`[data-context="terminal"][data-tab-id="${tabBId}"]`)
+    const tabBPicker = page.locator(`[data-context="pane-picker"][data-tab-id="${tabBId}"]`)
+    await page.waitForTimeout(500)
+    const tabBXtermVisible = await tabBTerminal.locator('.xterm').first().isVisible().catch(() => false)
+    if (!tabBXtermVisible) {
+      for (const name of ['Shell', 'WSL', 'CMD', 'PowerShell', 'Bash']) {
+        try {
+          const button = tabBPicker.getByRole('button', { name: new RegExp(`^${name}$`, 'i') })
+          if (await button.isVisible().catch(() => false)) {
+            await button.click({ timeout: 5000 })
+            break
+          }
+        } catch {
+          continue
+        }
+      }
+    }
+    await tabBTerminal.locator('.xterm').first().waitFor({ state: 'visible', timeout: 30_000 })
+    const terminalBId = await waitForActiveTerminalId(page)
+    expect(terminalBId).not.toBe(terminalAId)
+
+    // Leave a marker in T-B's scrollback: after the reload this marker can
+    // only reappear in T-B's buffer once its boot-time background attach's
+    // replay has landed -- a deterministic hydration-complete gate (with
+    // hydration incomplete the reveal below could legitimately fire a reveal
+    // attach instead of the resize-only heal path).
+    await tabBTerminal.locator('.xterm').first().click()
+    await page.keyboard.type('echo __PRE_RELOAD_MARKER__')
+    await page.keyboard.press('Enter')
+    await waitForTerminalText(page, '__PRE_RELOAD_MARKER__', terminalBId)
+
+    await activateTab(page, tabAId!)
+    await flushPersistedLayout(page, terminalBId)
+
+    // Reload in the SAME context: both tabs restore from persistence; T-A is
+    // active/visible and T-B's pane mounts hidden.
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await waitForReady(page)
+    await waitForTabWithTerminalId(page, terminalBId)
+    const restored = await page.evaluate(() => {
+      const state = window.__FRESHELL_TEST_HARNESS__?.getState()
+      return {
+        activeTabId: state?.tabs?.activeTabId ?? null,
+        tabCount: state?.tabs?.tabs?.length ?? 0,
+      }
+    })
+    expect(restored.tabCount).toBe(2)
+    expect(restored.activeTabId).toBe(tabAId)
+
+    // The reload installed a fresh harness, so getSentWsMessages is a clean
+    // record of everything since boot. The hidden pane's background hydration
+    // attach must be geometry-neutral: keepalive_delta + background, and never
+    // viewport_hydrate while hidden.
+    await page.waitForFunction((id) => {
+      const sent = window.__FRESHELL_TEST_HARNESS__?.getSentWsMessages?.() ?? []
+      return sent.some((msg: any) =>
+        msg?.type === 'terminal.attach'
+        && msg?.terminalId === id
+        && msg?.intent === 'keepalive_delta'
+        && msg?.priority === 'background')
+    }, terminalBId, { timeout: 45_000 })
+    await waitForTerminalText(page, '__PRE_RELOAD_MARKER__', terminalBId, 45_000)
+
+    const hiddenAttaches: any[] = await page.evaluate((id) => {
+      const sent = window.__FRESHELL_TEST_HARNESS__?.getSentWsMessages?.() ?? []
+      return sent.filter((msg: any) => msg?.type === 'terminal.attach' && msg?.terminalId === id)
+    }, terminalBId)
+    expect(
+      hiddenAttaches.some((msg: any) => msg.intent === 'keepalive_delta' && msg.priority === 'background'),
+      'a hidden-at-boot attach must arrive as keepalive_delta with priority background',
+    ).toBe(true)
+    expect(
+      hiddenAttaches.every((msg: any) => msg.intent !== 'viewport_hydrate'),
+      `a hidden pane must never claim viewport geometry; got: ${JSON.stringify(hiddenAttaches)}`,
+    ).toBe(true)
+
+    // Reveal T-B. The pane is already live via the geometry-neutral
+    // hydration, so NO new attach may fire -- the heal is a terminal.resize
+    // that the suppression-record invalidation lets through even when the
+    // fitted dims match the dims the clamped attach reported.
+    await page.evaluate(() => {
+      window.__FRESHELL_TEST_HARNESS__?.clearSentWsMessages?.()
+    })
+    await activateTab(page, tabBId!)
+    await page.waitForFunction((id) => {
+      const sent = window.__FRESHELL_TEST_HARNESS__?.getSentWsMessages?.() ?? []
+      return sent.some((msg: any) => msg?.type === 'terminal.resize' && msg?.terminalId === id)
+    }, terminalBId, { timeout: 15_000 })
+    // Observation window for a (forbidden) surprise attach after the reveal.
+    await page.waitForTimeout(500)
+    const afterReveal: any[] = await page.evaluate((id) => {
+      const sent = window.__FRESHELL_TEST_HARNESS__?.getSentWsMessages?.() ?? []
+      return sent.filter((msg: any) =>
+        (msg?.type === 'terminal.attach' || msg?.type === 'terminal.resize')
+        && msg?.terminalId === id)
+    }, terminalBId)
+    const revealAttaches = afterReveal.filter((msg: any) => msg.type === 'terminal.attach')
+    expect(
+      revealAttaches,
+      `no new attach may fire on reveal (the pane is already live); got: ${JSON.stringify(revealAttaches)}`,
+    ).toHaveLength(0)
+    const revealResizes = afterReveal.filter((msg: any) => msg.type === 'terminal.resize')
+    expect(revealResizes.length).toBeGreaterThanOrEqual(1)
+    const healResize = revealResizes[revealResizes.length - 1]
+    expect(healResize.cols).toBeGreaterThan(0)
+    expect(healResize.rows).toBeGreaterThan(0)
+
+    // Kernel cross-check: the PTY's actual winsize must equal the dims the
+    // reveal resize claimed (a hidden-clamp failure would leave the kernel
+    // at stale/never-fitted dims instead). Give the server a beat to apply
+    // the resize before asking stty.
+    await page.waitForTimeout(300)
+    await tabBTerminal.locator('.xterm').first().click()
+    await page.keyboard.type('echo __AXIS__:$(stty size)')
+    await page.keyboard.press('Enter')
+    const kernelSize = await waitForMarkedPtySize(page, '__AXIS__', terminalBId)
+    expect(kernelSize).toBe(`${healResize.rows} ${healResize.cols}`)
 
     await context.close()
   })

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -8720,7 +8720,7 @@ describe('TerminalView lifecycle updates', () => {
           .find((msg) =>
             msg?.type === 'terminal.attach'
             && msg?.terminalId === terminalId
-            && msg?.intent === 'viewport_hydrate'
+            && msg?.intent === 'keepalive_delta'
             && msg?.priority === 'background'
           )
         expect(attach?.attachRequestId).toBeTruthy()
@@ -8791,6 +8791,222 @@ describe('TerminalView lifecycle updates', () => {
           restore: true,
         }))
       })
+    })
+
+    it('a pane hidden at mount hydrates in background with a geometry-neutral keepalive attach', async () => {
+      const { terminalId, tabId } = await renderTerminalHarness({
+        status: 'running',
+        terminalId: 'term-hidden-mount-geo-neutral',
+        hidden: true,
+        clearSends: false,
+        requestId: 'req-hidden-mount-geo-neutral',
+      })
+
+      wsMocks.send.mockClear()
+      act(() => {
+        getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])
+      })
+
+      await waitFor(() => {
+        const attach = wsMocks.send.mock.calls
+          .map(([msg]) => msg)
+          .find((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId)
+        expect(attach, 'background hydration must send an attach').toBeTruthy()
+        expect(attach.intent).toBe('keepalive_delta')
+        expect(attach.priority).toBe('background')
+        expect(attach.sinceSeq).toBe(0)
+        expect(attach.cols).toBeGreaterThan(0)
+        expect(attach.rows).toBeGreaterThan(0)
+      })
+      expect(
+        wsMocks.send.mock.calls
+          .map(([msg]) => msg)
+          .some((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId && msg?.intent === 'viewport_hydrate'),
+      ).toBe(false)
+    })
+
+    it('reveal after a clamped hidden attach emits terminal.resize even when fitted dims are unchanged', async () => {
+      // Mounting hidden + hydration trigger produces, PRE-FIX, a wire
+      // viewport_hydrate attach whose dims are the never-fitted xterm defaults —
+      // the same numeric dims the reveal-fit will compute in jsdom (stable
+      // fixture) — so the reveal resize is swallowed by matchesLastSentViewport
+      // pre-fix. Post-fix the clamped attach invalidates the suppression record
+      // and the resize is emitted. This is the RED witness for the heal path.
+      const { store, tabId, paneId, terminalId, rerender } = await renderTerminalHarness({
+        status: 'running',
+        terminalId: 'term-hidden-heal-suppression',
+        hidden: true,
+        clearSends: false,
+        requestId: 'req-hidden-heal-suppression',
+      })
+
+      wsMocks.send.mockClear()
+      act(() => {
+        getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])
+      })
+      let hydrationAttach: any
+      await waitFor(() => {
+        hydrationAttach = wsMocks.send.mock.calls
+          .map(([msg]) => msg)
+          .find((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId && msg?.intent === 'keepalive_delta')
+        expect(hydrationAttach, 'clamped background attach must be geometry-neutral').toBeTruthy()
+      })
+
+      // Complete the clamped hydration so the pane is live before the reveal;
+      // reveal must then heal via resize alone (no new attach generation).
+      act(() => {
+        messageHandler!({
+          type: 'terminal.attach.ready',
+          terminalId,
+          headSeq: 0,
+          replayFromSeq: 1,
+          replayToSeq: 0,
+          attachRequestId: hydrationAttach.attachRequestId,
+        })
+      })
+
+      wsMocks.send.mockClear()
+      // Flip visibility on the SAME mounted component: rerendering with
+      // TerminalViewFromStore would swap the component type at the same JSX
+      // position, remounting the pane and legitimately producing a fresh
+      // foreground hydrate attach instead of the heal resize this test pins.
+      const readPaneContent = () => {
+        const layout = store.getState().panes.layouts[tabId]
+        return layout && layout.type === 'leaf' && layout.content.kind === 'terminal' ? layout.content : null
+      }
+      rerender(
+        <Provider store={store}>
+          <TerminalView tabId={tabId} paneId={paneId} paneContent={readPaneContent()!} hidden={false} />
+        </Provider>,
+      )
+
+      await waitFor(() => {
+        expect(
+          wsMocks.send.mock.calls
+            .map(([msg]) => msg)
+            .some((msg) => msg?.type === 'terminal.resize' && msg?.terminalId === terminalId),
+        ).toBe(true)
+      })
+      // No NEW attach on reveal (deferred mode is 'live'); the resize is the heal.
+      expect(
+        wsMocks.send.mock.calls
+          .map(([msg]) => msg)
+          .filter((msg) => msg?.type === 'terminal.attach'),
+      ).toHaveLength(0)
+    })
+
+    it('clamped hidden attaches keep viewport_hydrate surface-reset bookkeeping across replay generations', async () => {
+      // Both hidden attach generations must reset the mocked surface
+      // (term.clear) and replay only their own seq window — proof that client
+      // bookkeeping kept viewport_hydrate semantics under the wire keepalive
+      // token. A bookkeeping-degraded implementation (deriving clear/replay
+      // from the wire intent) skips the clear branch and FAILS this test.
+      //
+      // The second generation is forced via a pane refresh — the production
+      // re-arm path for a hidden pane (runRefreshAttach ->
+      // registerForBackgroundHydration({ queueIfStarted: true })) — because
+      // the hydration queue's onActiveTabReady is one-shot per queue
+      // instance, so calling it again cannot pump a second attach. The
+      // surface checkpoint saved by generation 1's parser-applied replay is
+      // reset so generation 2 takes the same full-hydrate branch a fresh
+      // profile takes, matching the plan's clamped-full-replay shape.
+      const { store, tabId, paneId, terminalId, term } = await renderTerminalHarness({
+        status: 'running',
+        terminalId: 'term-hidden-clamped-replay',
+        hidden: true,
+        clearSends: false,
+        requestId: 'req-hidden-clamped-replay',
+      })
+
+      term.write.mockClear()
+      term.clear.mockClear()
+      wsMocks.send.mockClear()
+
+      act(() => {
+        getHydrationQueue().onActiveTabReady('tab-visible-neighbor', ['tab-visible-neighbor', tabId])
+      })
+
+      let firstAttach: any
+      await waitFor(() => {
+        firstAttach = wsMocks.send.mock.calls
+          .map(([msg]) => msg)
+          .find((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId)
+        expect(firstAttach?.attachRequestId, 'background hydration must send a first attach').toBeTruthy()
+      })
+
+      act(() => {
+        messageHandler!({
+          type: 'terminal.attach.ready',
+          terminalId,
+          headSeq: 2,
+          replayFromSeq: 1,
+          replayToSeq: 2,
+          attachRequestId: firstAttach.attachRequestId,
+        })
+        messageHandler!({
+          type: 'terminal.output',
+          terminalId,
+          seqStart: 1,
+          seqEnd: 2,
+          data: 'PRIOR-SURFACE-MARKER',
+          attachRequestId: firstAttach.attachRequestId,
+        })
+      })
+
+      await waitFor(() => {
+        expect(terminalWriteStrings(term).some((data) => data.includes('PRIOR-SURFACE-MARKER'))).toBe(true)
+      })
+      // First generation's clearViewportFirst viewport bookkeeping fired.
+      expect(term.clear).toHaveBeenCalledTimes(1)
+
+      // Drop the checkpoint generation 1 recorded so generation 2's delta
+      // decision is missing_checkpoint again (the same full-hydrate branch a
+      // fresh profile takes for this shape).
+      clearLocalStorageForTest()
+      __resetTerminalCursorCacheForTests()
+
+      wsMocks.send.mockClear()
+      act(() => {
+        store.dispatch(requestPaneRefresh({ tabId, paneId }))
+      })
+
+      let secondAttach: any
+      await waitFor(() => {
+        const attaches = wsMocks.send.mock.calls
+          .map(([msg]) => msg)
+          .filter((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId)
+        secondAttach = attaches.find((msg) => msg?.attachRequestId !== firstAttach.attachRequestId)
+        expect(secondAttach?.attachRequestId, 'refresh must force a second hidden attach generation').toBeTruthy()
+      })
+      expect(secondAttach.priority).toBe('background')
+      expect(secondAttach.sinceSeq).toBe(0)
+
+      act(() => {
+        messageHandler!({
+          type: 'terminal.attach.ready',
+          terminalId,
+          headSeq: 6,
+          replayFromSeq: 3,
+          replayToSeq: 6,
+          attachRequestId: secondAttach.attachRequestId,
+        })
+        messageHandler!({
+          type: 'terminal.output',
+          terminalId,
+          seqStart: 3,
+          seqEnd: 6,
+          data: 'CLAMPED-REPLAY-MARKER',
+          attachRequestId: secondAttach.attachRequestId,
+        })
+      })
+
+      // (a) BOTH generations cleared the surface — the second attach did not
+      // degrade into keepalive bookkeeping (which skips the clear branch).
+      expect(term.clear).toHaveBeenCalledTimes(2)
+      // (b) Each generation replayed only its own seq window, exactly once.
+      const writes = terminalWriteStrings(term)
+      expect(writes.filter((data) => data.includes('PRIOR-SURFACE-MARKER'))).toHaveLength(1)
+      expect(writes.filter((data) => data.includes('CLAMPED-REPLAY-MARKER'))).toHaveLength(1)
     })
 
     it('does not send terminal.resize when an already-live terminal is hidden and revealed with unchanged geometry', async () => {


### PR DESCRIPTION
## Problem

Hidden / background tabs (warm-up hydration on boot, disconnected-but-restored windows) attach to pane terminals with `viewport_hydrate` intent carrying stale or never-fitted dims (e.g. the 80×24 xterm default). Both servers resize the PTY unconditionally on `viewport_hydrate`, so a hidden pane silently stomps the visible pane's geometry — producing opencode TUI wrap-cascade garbage on scroll-triggered repaints, dead regions where mouse scroll does nothing, and similar symptoms in other TUIs. Nothing converges back until the visible pane happens to resize.

Root cause proven live: `ps -t` showed visible-pane PTY being stomped by a background client's attach (measured 100×29 → 124×31 with no user action); the opencode fleet showed nine processes parked at exactly 80×24 (never-fitted default).

## Fix (client-only, both servers untouched)

In `TerminalView`'s attach path (the single choke point):

- A pane that is **not visible** sends its attach with wire intent `keepalive_delta` — never resized server-side, replay-identical (`since_seq` preserved). All internal bookkeeping keeps viewport semantics.
- The hidden attach's dims are **no longer recorded as "last sent"** (`forgetSentViewport`), so the reveal-time resize is never suppressed as a no-op — reveal heals geometry.
- `hiddenRef` sync moved from passive effect to layout effect (closes a render-phase staleness window).

Plan, evidence, review receipts: `docs/plans/2026-08-16-attach-geometry-resume-panes.md` and the run ledger (`.the-usual-logs/attach-geometry-resume-panes/` locally; not committed).

## Verification

- Unit: `TerminalView.lifecycle.test.tsx` 145/145 (new RED→GREEN pins: hidden attach never emits a geometry claim; reveal resize not suppressed; suppression-record invalidation; recreate predicate behavior unchanged).
- E2E (`multi-client` spec, both matrix projects): reload-restored background tab boots geometry-neutral, no geometry claim while hidden, reveal emits resize; kernel `stty size` equals emitted frame dims.
- Live opencode verification on a real scratch instance: footer stays single-line, PgUp scroll clean, hidden witness boots geometry-neutral, reveal heals to local fitted size.
- Full-suite gate: `npm run check` green + `cargo test --workspace --exclude freshell-tauri` green except pre-existing, base-reproduced failures recorded with receipts (network concurrency test on WSL — kata jgpc; rust-leg reconnect attach-count load flake — kata created).

## Tradeoffs recorded in ledger

- Server contract (`viewport_hydrate` resizes unconditionally) intentionally unchanged; optional future hardening = "hydrate applies geometry only when no other socket is attached".
- Natural hidden `keepalive_delta` attaches still record suppression dims (pre-existing semantics; rare cross-client coincidence residual) — follow-up notes in ledger.
