### PR TITLE
docs(AGENTS): gate PRs on actually-running e2e green

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,8 @@ npm run test:e2e:cloud      # Force cloud
 
 **If `FRESHELL_E2E_BACKEND` is not set, ask the user which way to set it** before running e2e tests. Explain that cloud is much faster (parallel shards, ~2-3 min vs ~28 min) but is a paid Google Cloud service (~$0.03/run); local is free but slower. Once the user chooses, set it permanently in their `~/.bashrc` (or equivalent) so agents don't need to ask again.
 
+**Before filing any PR, ensure the affected e2e specs actually pass on the configured `FRESHELL_E2E_BACKEND` backend** — a spec sitting in `CLOUD_SKIP_SPECS` (`test/e2e-browser/playwright.cloud.config.ts`) or a filter that matched no tests is not coverage.
+
 ## Architecture
 
 ### Tech Stack


### PR DESCRIPTION
One line: before filing a PR, the affected e2e specs must pass on the configured `FRESHELL_E2E_BACKEND` backend — and specs hidden by `CLOUD_SKIP_SPECS` (or a filter matching nothing) do not count.

Motivation: the model-selector spec sat on the cloud skip list and merged in #650 untested; when finally executed it revealed a real autofocus bug (fixed separately).

🤖 Generated with [OpenCode](https://opencode.ai) (Kimi-K3)