### PR TITLE
fix(fresh-agent): run + repair the model-selector e2e; autofocus search after catalog probe

### DIFF
--- a/src/components/fresh-agent/FreshAgentModelDialog.tsx
+++ b/src/components/fresh-agent/FreshAgentModelDialog.tsx
@@ -206,8 +206,8 @@ export function FreshAgentModelDialog({
     setRecentModels(recent)
   }, [open, capabilities, mruProvider, paneId, cwdKey, effectiveModelId])
 
-  // Focus management: autofocus the search box on open, restore on close;
-  // Escape cancels (capture phase, ahead of parent popovers/views).
+  // Focus management: Escape cancels (capture phase, ahead of parent
+  // popovers/views); previous focus is restored on close.
   useEffect(() => {
     if (!open) return
     previousFocusRef.current = document.activeElement as HTMLElement | null
@@ -218,15 +218,23 @@ export function FreshAgentModelDialog({
       }
     }
     document.addEventListener('keydown', handleKeyDown, { capture: true })
-    const focusTimer = window.setTimeout(() => {
-      searchRef.current?.focus()
-    }, 0)
     return () => {
       document.removeEventListener('keydown', handleKeyDown, { capture: true })
-      window.clearTimeout(focusTimer)
       previousFocusRef.current?.focus()
     }
   }, [open, onClose])
+
+  // Autofocus the search box once the catalog is PRESENT: the input is
+  // `disabled` while the freshopencode probe is in flight, and focus() on a
+  // disabled element is a silent no-op — a mount-time-only timer would lose
+  // the race and leave focus on whatever opened the dialog.
+  useEffect(() => {
+    if (!open || !capabilities) return
+    const focusTimer = window.setTimeout(() => {
+      searchRef.current?.focus()
+    }, 0)
+    return () => window.clearTimeout(focusTimer)
+  }, [open, capabilities])
 
   const { groups, hiddenCount } = useMemo(() => {
     if (!capabilities) return { groups: [] as FreshAgentModelSourceGroup[], hiddenCount: 0 }

--- a/test/e2e-browser/playwright.cloud.config.ts
+++ b/test/e2e-browser/playwright.cloud.config.ts
@@ -29,8 +29,9 @@ import baseConfig from './playwright.config.js'
 // rendering/timing that differs in cloud.
 const CLOUD_SKIP_SPECS = [
   // Requires opencode binary
+  // (freshopencode-model-picker.spec.ts is cloud-legal: every fetch is routed
+  // and the sidecar is suppressed via the test harness, so it needs no binary)
   'freshopencode-db-history.spec.ts',
-  'freshopencode-model-picker.spec.ts',
   'freshopencode-restart-recovery.spec.ts',
   'freshopencode-first-send-reload-repro.spec.ts',
   'opencode-restart-recovery.spec.ts',

--- a/test/e2e-browser/specs/freshopencode-model-picker.spec.ts
+++ b/test/e2e-browser/specs/freshopencode-model-picker.spec.ts
@@ -149,16 +149,23 @@ async function routeFileApis(page: Page, cwd: string): Promise<void> {
   })
 }
 
-/** Create a freshopencode pane through the picker (network effects suppressed)
- * and hand it an idle session id so the composer becomes usable. */
+/** Create a freshopencode pane through the picker and hand it an idle session
+ * id so the composer becomes usable. Sweeping caveat: the picker pane is
+ * REPLACED by the real fresh-agent pane with a NEW pane id on selection, so
+ * both the suppression flag and the idle-session handoff must target the
+ * post-creation active pane (state.panes.activePane[tabId]), never an id
+ * captured from the picker DOM (same pattern as fresh-agent.spec.ts).
+ */
 async function createFreshopencodePane(page: Page, cwd: string): Promise<void> {
+  // Suppress ALL fresh-agent network effects BEFORE the pane exists: creation
+  // fires its session-create effect immediately, and a per-pane flag set after
+  // the fact races it — livelocked as "Fresh clients are disabled" (server
+  // rejection of the unsuppressed request) followed by a stuck `ended` state.
+  await page.evaluate(() => {
+    window.__FRESHELL_TEST_HARNESS__?.setSuppressAllFreshAgentNetworkEffects(true)
+  })
   const picker = await openPanePicker(page)
   await expect(picker.getByRole('button', { name: /^Freshopencode$/i })).toBeVisible({ timeout: 10_000 })
-  const targetPaneId = await picker.getAttribute('data-pane-id')
-  expect(targetPaneId).toBeTruthy()
-  await page.evaluate((paneId) => {
-    window.__FRESHELL_TEST_HARNESS__?.setFreshAgentNetworkEffectsSuppressed(paneId, true)
-  }, targetPaneId!)
   await picker.getByRole('button', { name: /^Freshopencode$/i }).click({ force: true })
   const directoryInput = page.getByLabel(/^Starting directory for Freshopencode$/i)
   await expect(directoryInput).toBeVisible({ timeout: 15_000 })
@@ -166,28 +173,43 @@ async function createFreshopencodePane(page: Page, cwd: string): Promise<void> {
   await directoryInput.press('Enter')
   await expect(page.locator('[data-context="fresh-agent"]').last()).toBeVisible({ timeout: 15_000 })
 
-  await page.evaluate((paneId) => {
+  await page.evaluate(() => {
     const harness = window.__FRESHELL_TEST_HARNESS__
-    if (!harness || !paneId) return
-    const panes = harness.getState().panes
-    const tabId = Object.keys(panes.layouts).find((key) => JSON.stringify(panes.layouts[key]).includes(paneId))
+    if (!harness) return
+    const state = harness.getState()
+    const tabId = state.tabs.activeTabId as string | undefined
     if (!tabId) return
-    const layout = panes.layouts[tabId]
-    if (layout?.type !== 'leaf' || layout.content?.kind !== 'fresh-agent') return
+    // The tab may be a SPLIT (terminal + fresh pane), so the top layout node is
+    // a 'split' — walk the tree for the fresh-agent leaf rather than assuming
+    // the root is a leaf.
+    type LayoutNode = { id: string; type: string; content?: { kind?: string }; children?: LayoutNode[] }
+    const findFreshLeaf = (node: LayoutNode | undefined): LayoutNode | undefined => {
+      if (!node) return undefined
+      if (node.type === 'leaf' && node.content?.kind === 'fresh-agent') return node
+      for (const child of node.children ?? []) {
+        const found = findFreshLeaf(child)
+        if (found) return found
+      }
+      return undefined
+    }
+    const leaf = findFreshLeaf(state.panes.layouts[tabId] as LayoutNode | undefined)
+    if (!leaf) return
     harness.dispatch({
       type: 'panes/updatePaneContent',
       payload: {
         tabId,
-        paneId,
-        content: { ...layout.content, sessionId: 'ses_e2e', status: 'idle' },
+        paneId: leaf.id,
+        content: { ...leaf.content, sessionId: 'ses_e2e', status: 'idle' },
       },
     })
-  }, targetPaneId)
+  })
 }
 
 async function openFreshAgentSettings(page: Page) {
   const pane = page.getByRole('group').filter({
-    has: page.getByText('Freshopencode', { exact: true }),
+    // The pane banner badge renders the provider lowercase ("freshopencode");
+    // fresh-agent.spec.ts's identical helper filters on providerName.toLowerCase().
+    has: page.getByText('freshopencode', { exact: true }),
   }).last()
   await expect(pane).toBeVisible({ timeout: 10_000 })
 

--- a/test/unit/client/components/fresh-agent/FreshAgentModelDialog.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentModelDialog.test.tsx
@@ -194,6 +194,30 @@ describe('FreshAgentModelDialog (freshopencode)', () => {
     expect(getFreshAgentModelCapabilitiesSpy).not.toHaveBeenCalled()
   })
 
+  it('focuses the search box once the catalog probe resolves (it is disabled while probing)', async () => {
+    // Regression: the open-time focus timer fires while capabilities are still
+    // undefined for freshopencode, and focus() on a DISABLED input is a no-op —
+    // focus used to stay on whatever opened the dialog (e.g. the popover's
+    // Change… button) forever.
+    const store = createStore()
+    seedFreshopencodePane(store)
+
+    let resolveProbe: ((value: typeof catalogResponse) => void) | undefined
+    getFreshAgentModelCapabilitiesSpy.mockReturnValueOnce(
+      new Promise((resolve) => { resolveProbe = resolve }),
+    )
+
+    renderDialog(store, { open: true })
+
+    const search = await screen.findByRole('searchbox', { name: 'Filter models' })
+    expect(search).toBeDisabled()
+
+    resolveProbe!(catalogResponse)
+
+    await waitFor(() => expect(search).toBeEnabled())
+    await waitFor(() => expect(search).toHaveFocus())
+  })
+
   it('fetches the cwd-scoped catalog on open and lists provider groups with the current model marked', async () => {
     const store = createStore()
     seedFreshopencodePane(store)
@@ -202,7 +226,7 @@ describe('FreshAgentModelDialog (freshopencode)', () => {
 
     const dialog = await screen.findByRole('dialog', { name: 'Model and thinking level' })
     expect(getFreshAgentModelCapabilitiesSpy).toHaveBeenCalledWith('freshopencode', expect.objectContaining({ cwd: '/repo/project-a' }))
-    expect(screen.getByRole('searchbox', { name: 'Filter models' })).toHaveFocus()
+    await waitFor(() => expect(screen.getByRole('searchbox', { name: 'Filter models' })).toHaveFocus())
 
     const modelsList = screen.getByRole('listbox', { name: 'Models' })
     expect(modelsList).toHaveTextContent('OpenCode Go')


### PR DESCRIPTION
Three small fixes that together make the selector e2e suite actually execute and pass, in both local playwright and Cloud Run Jobs:

1. **Cloud skip list**: `freshopencode-model-picker.spec.ts` stayed in `CLOUD_SKIP_SPECS` ("requires opencode binary") after its rewrite, so it never ran — in cloud OR locally — and PR #650's selector work shipped e2e-untested. The spec is fully self-contained (routed fetches + harness network suppression), so it is now unskipped.

2. **Spec helper repairs** (never executed before): suppress ALL fresh-agent network effects before pane creation (a per-pane flag set after creation raced the session-create effect into a server-rejected create and a stuck 'ended' session); hand the fake idle session to the correct pane (the picker pane is replaced with a NEW pane id, and the tab is a split — walk the layout tree for the fresh-agent leaf); filter the settings pane group by lowercase `freshopencode`, matching the banner text and fresh-agent.spec.ts.

3. **Real product bug the suite exposed**: the shared dialog autofocused its search box via a mount-time timer, but the freshopencode catalog probe keeps the input disabled on open — focus() was a silent no-op and focus sat on the popover's Change… button forever. Focus now follows capability arrival. Red-green: a new unit test pauses the probe mid-flight; the previously-passing assertion now awaits focus.

Verified: 15/15 dialog unit tests; 4/4 spec tests locally AND in the cloud e2e job (freshell-e2e-x45rw, 16.3s).

🤖 Generated with [OpenCode](https://opencode.ai) (Kimi-K3)