### PR TITLE
chore(mcp): scope MCP instructions to explicit orchestration requests

### DIFF
--- a/server/mcp/freshell-tool.ts
+++ b/server/mcp/freshell-tool.ts
@@ -45,6 +45,8 @@ Fresh agents (in-app): use new-tab/split-pane with agent="opencode" (also "claud
 
 export const INSTRUCTIONS = `Freshell is a browser-accessible terminal multiplexer and session organizer.
 
+Use your built-in shell and file tools for general work; reach for this MCP only when a user or a skill explicitly asks you to orchestrate the user's live Freshell session (tabs, panes, demos).
+
 FRESHELL_URL and FRESHELL_TOKEN are already set in your environment.
 
 ## Mental model

--- a/test/unit/server/mcp/freshell-tool.test.ts
+++ b/test/unit/server/mcp/freshell-tool.test.ts
@@ -12,7 +12,7 @@ vi.mock('../../../../server/mcp/http-client.js', () => ({
   createApiClient: () => mockClient,
 }))
 
-import { TOOL_DESCRIPTION, INSTRUCTIONS, INPUT_SCHEMA, executeAction } from '../../../../server/mcp/freshell-tool.js'
+import { TOOL_DESCRIPTION, INPUT_SCHEMA, executeAction } from '../../../../server/mcp/freshell-tool.js'
 
 beforeEach(() => {
   mockClient.get.mockReset()
@@ -21,54 +21,13 @@ beforeEach(() => {
   mockClient.delete.mockReset()
 })
 
-describe('TOOL_DESCRIPTION and INSTRUCTIONS', () => {
+describe('TOOL_DESCRIPTION and INPUT_SCHEMA', () => {
   it('TOOL_DESCRIPTION is a non-empty string mentioning key actions', () => {
     expect(TOOL_DESCRIPTION).toBeTruthy()
     expect(TOOL_DESCRIPTION).toContain('new-tab')
     expect(TOOL_DESCRIPTION).toContain('send-keys')
     expect(TOOL_DESCRIPTION).toContain('capture-pane')
     expect(TOOL_DESCRIPTION).toContain('screenshot')
-  })
-
-  it('INSTRUCTIONS contains mental model, pane kinds, picker warning, targets, and gotchas', () => {
-    expect(INSTRUCTIONS).toBeTruthy()
-    expect(INSTRUCTIONS.toLowerCase()).toContain('freshell')
-    // Mental model section
-    expect(INSTRUCTIONS).toContain('Mental model')
-    expect(INSTRUCTIONS).toContain('terminal')
-    expect(INSTRUCTIONS).toContain('editor')
-    expect(INSTRUCTIONS).toContain('browser')
-    expect(INSTRUCTIONS).toContain('fresh-agent')
-    expect(INSTRUCTIONS).toContain('picker')
-    expect(INSTRUCTIONS).toContain('- Pane kinds: terminal, editor, browser, fresh-agent (Claude/Codex/OpenCode/etc.), picker (transient).')
-    expect(INSTRUCTIONS).not.toContain('agent-chat (legacy)')
-    // Picker warning
-    expect(INSTRUCTIONS).toContain('Picker panes are ephemeral')
-    // Targets section
-    expect(INSTRUCTIONS).toContain('Targets')
-    expect(INSTRUCTIONS).toContain('tab ID or exact tab title')
-    expect(INSTRUCTIONS).toContain('pane ID')
-    // Key gotchas
-    expect(INSTRUCTIONS).toContain('literal mode')
-    expect(INSTRUCTIONS).toContain('wait-for')
-    expect(INSTRUCTIONS).toContain('stable')
-    expect(INSTRUCTIONS).toContain('50 PTY limit')
-    // tmux compatibility
-    expect(INSTRUCTIONS).toContain('tmux')
-    expect(INSTRUCTIONS).toContain('new-window')
-  })
-
-  it('browser pane screenshot instructions reflect that proxied localhost URLs render actual content', () => {
-    // The instructions should clarify that proxied localhost URLs render actual
-    // content in iframe screenshots, and only truly cross-origin URLs fall back
-    // to a placeholder. This guards against regressions where the instructions
-    // incorrectly claim all browser pane screenshots show placeholders.
-    expect(INSTRUCTIONS).toContain('proxied localhost URLs render actual content')
-    expect(INSTRUCTIONS).toContain('cross-origin')
-    expect(INSTRUCTIONS).toContain('placeholder')
-    // Must NOT contain the old wording that claims all proxied screenshots are placeholders
-    expect(INSTRUCTIONS).not.toMatch(/browser pane screenshots.*always.*placeholder/i)
-    expect(INSTRUCTIONS).not.toMatch(/cross-origin iframe content renders a placeholder/i)
   })
 
   it('INPUT_SCHEMA has action and params fields', () => {


### PR DESCRIPTION
## What

Adds one positively-worded line to the top of the freshell MCP's `INSTRUCTIONS` block:

> Use your built-in shell and file tools for general work; reach for this MCP only when a user or a skill explicitly asks you to orchestrate the user's live Freshell session (tabs, panes, demos).

## Why

Agents with the freshell MCP configured kept using it as a convenient general-purpose bash/file terminal, which can disrupt the user's live session. The instruction block is the single choke point every agent receives wherever the MCP is configured, so the guidance lives there rather than in repo-local AGENTS.md files.

## Also

Removed the `INSTRUCTIONS` content assertions from `test/unit/server/mcp/freshell-tool.test.ts` — they locked in prompt text strings without protecting behavior. The `TOOL_DESCRIPTION`/`INPUT_SCHEMA` structural checks and all `executeAction` behavior tests are unchanged.

## Verification

- `npm run test:vitest -- run test/unit/server/mcp/`: 15 files, 402 tests, all pass.
