### PR TITLE
feat(ejh6): reject the legacy resumeSessionId wire field on every create-class door (both servers)

### DIFF
--- a/crates/freshell-freshagent/src/claude.rs
+++ b/crates/freshell-freshagent/src/claude.rs
@@ -1806,15 +1806,19 @@ fn request_id_string(request_id: &freshell_protocol::StringOrNumber) -> String {
 /// `codex.rs`/`opencode_ws.rs` (both document the duplication) -- but unlike those two this
 /// one cannot hardcode the session type: provider `claude` covers BOTH `freshclaude` and
 /// `kilroy`, so the envelope's sessionType comes from the attach message.
-/// The durable claude id an attach carries: `resumeSessionId` first, then
-/// `sessionRef.sessionId` -- both written by the FROZEN client
-/// (`FreshAgentView.tsx:303-313`). Only canonical UUIDs qualify
-/// (`shared/session-contract.ts:34`) -- a nanoid here would just miss the store.
+/// The durable claude id an attach carries: `sessionRef.sessionId` first,
+/// then the legacy `resumeSessionId` fallback — flipped from legacy-first
+/// (kata ejh6 section 4b hygiene). After the wire-level reject on
+/// `freshAgent.attach`, the legacy field is dead for external input; the
+/// fallback remains only for internal/test constructions. Only canonical
+/// UUIDs qualify (`shared/session-contract.ts:34`) — a nanoid here would
+/// just miss the store.
 fn attach_durable_id(msg: &FreshAgentAttach) -> Option<String> {
     let candidate = msg
-        .resume_session_id
-        .clone()
-        .or_else(|| msg.session_ref.as_ref().map(|r| r.session_id.clone()))?;
+        .session_ref
+        .as_ref()
+        .map(|r| r.session_id.clone())
+        .or_else(|| msg.resume_session_id.clone())?;
     is_canonical_claude_uuid(&candidate).then_some(candidate)
 }
 

--- a/crates/freshell-freshagent/src/claude.rs
+++ b/crates/freshell-freshagent/src/claude.rs
@@ -2238,6 +2238,36 @@ pub(crate) mod tests {
         msg
     }
 
+    /// Delta review round-2 pin (kata ejh6 section 4b): `attach_durable_id` reads
+    /// sessionRef-first after the Task-7 flip. A legacy-first ordering (pre-flip)
+    /// returns the legacy id in the dual-carrier case — this test fails there.
+    #[test]
+    fn attach_durable_id_prefers_session_ref_over_legacy() {
+        const REF_ID: &str = "11111111-2222-4333-8444-555555555555";
+        const LEGACY_ID: &str = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+        // (i) both carriers set with different canonical UUIDs → sessionRef wins
+        let mut both = attach_msg("s");
+        both.session_ref = Some(freshell_protocol::SessionLocator {
+            provider: "claude".to_string(),
+            session_id: REF_ID.to_string(),
+        });
+        both.resume_session_id = Some(LEGACY_ID.to_string());
+        assert_eq!(attach_durable_id(&both), Some(REF_ID.to_string()));
+
+        // (ii) sessionRef only → its id
+        let ref_only = attach_msg_with_resume("s", REF_ID);
+        assert_eq!(attach_durable_id(&ref_only), Some(REF_ID.to_string()));
+
+        // (iii) legacy only → its id (internal/test-compat lane)
+        let mut legacy_only = attach_msg("s");
+        legacy_only.resume_session_id = Some(LEGACY_ID.to_string());
+        assert_eq!(attach_durable_id(&legacy_only), Some(LEGACY_ID.to_string()));
+
+        // (iv) neither → None
+        assert_eq!(attach_durable_id(&attach_msg("s")), None);
+    }
+
     fn write_fake_transcript(home: &std::path::Path, durable: &str) {
         let dir = home.join("projects").join("-t");
         std::fs::create_dir_all(&dir).unwrap();

--- a/crates/freshell-freshagent/src/claude.rs
+++ b/crates/freshell-freshagent/src/claude.rs
@@ -2227,7 +2227,10 @@ pub(crate) mod tests {
 
     fn attach_msg_with_resume(session_id: &str, durable: &str) -> FreshAgentAttach {
         let mut msg = attach_msg(session_id);
-        msg.resume_session_id = Some(durable.to_string());
+        msg.session_ref = Some(freshell_protocol::SessionLocator {
+            provider: "claude".to_string(),
+            session_id: durable.to_string(),
+        });
         msg
     }
 

--- a/crates/freshell-freshagent/src/codex.rs
+++ b/crates/freshell-freshagent/src/codex.rs
@@ -7026,14 +7026,15 @@ pub(crate) mod tests {
 
     // -- freshAgent.create resume (CODEX-FIRST triage Finding 1) --
 
-    /// FINDING 1 (CODEX-FIRST triage): `freshAgent.create` carrying `resumeSessionId` must
-    /// RESUME the existing thread (mirroring the reference's resume-first create path,
-    /// `runtime-manager.ts:103-112` -> `adapter.ts:843-869`), never mint a brand-new one.
-    /// The fake app-server's `thread/start` is configured to return an OBVIOUSLY WRONG id
-    /// (`thread-should-never-be-minted`) so a passing assertion on the requested resume id
-    /// proves `thread/resume` was used, not `thread/start`.
+    /// FINDING 1 (CODEX-FIRST triage): `freshAgent.create` carrying a provider-matched
+    /// `sessionRef` must RESUME the existing thread (mirroring the reference's
+    /// resume-first create path, `runtime-manager.ts:103-112` -> `adapter.ts:843-869`),
+    /// never mint a brand-new one. The fake app-server's `thread/start` is configured to
+    /// return an OBVIOUSLY WRONG id (`thread-should-never-be-minted`) so a passing
+    /// assertion on the requested resume id proves `thread/resume` was used, not
+    /// `thread/start`.
     #[tokio::test]
-    async fn handle_create_with_resume_session_id_resumes_the_same_thread() {
+    async fn handle_create_with_session_ref_resumes_the_same_thread() {
         let _guard = ENV_LOCK.lock().await;
         configure_fake_codex_cmd(r#"{"threadStartThreadId":"thread-should-never-be-minted"}"#);
         let (st, mut rx) = state_with_bus();
@@ -7044,8 +7045,11 @@ pub(crate) mod tests {
             provider: Some(freshell_protocol::AgentProvider::Codex),
             cwd: None,
             legacy_restore_context: None,
-            resume_session_id: Some("thread-existing-durable".to_string()),
-            session_ref: None,
+            resume_session_id: None,
+            session_ref: Some(freshell_protocol::SessionLocator {
+                provider: "codex".to_string(),
+                session_id: "thread-existing-durable".to_string(),
+            }),
             model: None,
             model_selection: None,
             permission_mode: None,
@@ -7089,7 +7093,7 @@ pub(crate) mod tests {
     /// Node parity (`runtime-manager.ts:106-108`): a `freshAgent.create` whose
     /// ONLY identity is a provider-matched `sessionRef` must resume the thread
     /// exactly like the legacy `resumeSessionId` carrier. Same wrong-mint
-    /// canary as the legacy-carrier test above: `thread/start` is pinned to an
+    /// canary as the sessionRef resume test above: `thread/start` is pinned to an
     /// obviously wrong id, so a passing sessionId assertion proves
     /// `thread/resume` was used.
     #[tokio::test]
@@ -7148,7 +7152,7 @@ pub(crate) mod tests {
         );
     }
 
-    /// FINDING 1 (CODEX-FIRST triage): when the caller-supplied `resumeSessionId` is
+    /// FINDING 1 (CODEX-FIRST triage): when the caller-supplied resume id is
     /// genuinely gone (`thread/resume` reports "not found"), the legacy reference has NO
     /// mint-new fallback inside `freshAgent.create`'s resume branch -- `runtime-manager.ts:
     /// 103-112` propagates the adapter's `resume()` failure unwrapped, and
@@ -7178,8 +7182,11 @@ pub(crate) mod tests {
             provider: Some(freshell_protocol::AgentProvider::Codex),
             cwd: None,
             legacy_restore_context: None,
-            resume_session_id: Some("thread-truly-gone".to_string()),
-            session_ref: None,
+            resume_session_id: None,
+            session_ref: Some(freshell_protocol::SessionLocator {
+                provider: "codex".to_string(),
+                session_id: "thread-truly-gone".to_string(),
+            }),
             model: None,
             model_selection: None,
             permission_mode: None,
@@ -7237,8 +7244,11 @@ pub(crate) mod tests {
             provider: Some(freshell_protocol::AgentProvider::Codex),
             cwd: None,
             legacy_restore_context: None,
-            resume_session_id: Some("thread-A-requested".to_string()),
-            session_ref: None,
+            resume_session_id: None,
+            session_ref: Some(freshell_protocol::SessionLocator {
+                provider: "codex".to_string(),
+                session_id: "thread-A-requested".to_string(),
+            }),
             model: None,
             model_selection: None,
             permission_mode: None,

--- a/crates/freshell-freshagent/src/lib.rs
+++ b/crates/freshell-freshagent/src/lib.rs
@@ -135,7 +135,7 @@ use freshell_opencode::{
 };
 use freshell_protocol::{
     FreshAgentEvent, FreshAgentSessionMaterialized, ServerMessage, SessionLocator, SessionsChanged,
-    UiCommand,
+    UiCommand, LEGACY_RESUME_IDENTITY_REFUSAL,
 };
 
 /// The opencode fresh-agent `sessionType` (`AGENT_SESSION_TYPES.opencode`, `router.ts:541`).
@@ -1624,6 +1624,17 @@ async fn create_tab(
 ) -> Response {
     if !authorized(&headers, &state.auth_token) {
         return fail_json(StatusCode::UNAUTHORIZED, "unauthorized".to_string());
+    }
+    // ejh6 (finding 3): door-top presence check. Reject whenever the body
+    // CONTAINS the key resumeSessionId with ANY JSON value (string, empty,
+    // null, number, object) — BEFORE any agent/browser/editor/terminal
+    // branch, including the `terminal_tabs::create_terminal_or_content_tab`
+    // delegation (this is the only REST entry to that function).
+    if body.get("resumeSessionId").is_some() {
+        return fail_json(
+            StatusCode::BAD_REQUEST,
+            LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
+        );
     }
     let agent = body.get("agent").and_then(Value::as_str).unwrap_or("");
     // Slice 1 (docs/plans/2026-07-18-agent-api-mcp-parity-spec.md \u00a72.1): `agent`

--- a/crates/freshell-freshagent/src/opencode_ws.rs
+++ b/crates/freshell-freshagent/src/opencode_ws.rs
@@ -3033,10 +3033,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_with_resume_session_id_rebinds_the_durable_session() {
+    async fn create_with_session_ref_rebinds_the_durable_session() {
         // V2/A4: the frozen client's ONLY post-reload resume vehicle is
-        // freshAgent.create{resumeSessionId: ses_*} -- donor shape: codex's
-        // handle_create_with_resume_session_id_resumes_the_same_thread.
+        // freshAgent.create{sessionRef: {provider: "opencode", sessionId: ses_*}}
+        // -- donor shape: codex's
+        // handle_create_with_session_ref_resumes_the_same_thread.
         let (state, mut rx) = state_with_durable_serve_session().await;
         let fake = std::sync::Arc::new(crate::identity_sink::FakeIdentitySink::default());
         fake.seed(
@@ -3053,7 +3054,10 @@ mod tests {
         state.set_identity_sink(fake);
 
         let mut create = create_msg("req-resume-oc");
-        create.resume_session_id = Some(DURABLE_ID.to_string());
+        create.session_ref = Some(freshell_protocol::SessionLocator {
+            provider: "opencode".to_string(),
+            session_id: DURABLE_ID.to_string(),
+        });
         state.handle_create(create).await;
 
         let sessions = state.sessions.lock().await;

--- a/crates/freshell-freshagent/src/pane_ops.rs
+++ b/crates/freshell-freshagent/src/pane_ops.rs
@@ -39,7 +39,7 @@ use axum::response::Response;
 use axum::{Json, Router};
 use serde_json::{json, Value};
 
-use freshell_protocol::{ServerMessage, UiCommand};
+use freshell_protocol::{ServerMessage, UiCommand, LEGACY_RESUME_IDENTITY_REFUSAL};
 
 use crate::layout_store::RenameOutcome;
 use crate::target_resolver::{resolve_target, ResolvedTarget};
@@ -149,6 +149,15 @@ pub(crate) async fn split_pane(
 ) -> Response {
     if !authorized(&headers, &state.auth_token) {
         return fail_json(StatusCode::UNAUTHORIZED, "unauthorized".to_string());
+    }
+    // ejh6 (finding 3): door-top presence check BEFORE `resolve_pane_target`
+    // and `layout.split_pane` so a rejection returns 400 with NO layout
+    // mutation.
+    if body.get("resumeSessionId").is_some() {
+        return fail_json(
+            StatusCode::BAD_REQUEST,
+            LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
+        );
     }
 
     let pane_id = match resolve_pane_target(&state, &raw_pane_id) {
@@ -704,6 +713,13 @@ pub(crate) async fn respawn_pane(
 ) -> Response {
     if !authorized(&headers, &state.auth_token) {
         return fail_json(StatusCode::UNAUTHORIZED, "unauthorized".to_string());
+    }
+    // ejh6 (finding 3): door-top presence check BEFORE `spawn_terminal_pane`.
+    if body.get("resumeSessionId").is_some() {
+        return fail_json(
+            StatusCode::BAD_REQUEST,
+            LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
+        );
     }
 
     let Some(tab_id) = state

--- a/crates/freshell-freshagent/src/pane_ops_tests.rs
+++ b/crates/freshell-freshagent/src/pane_ops_tests.rs
@@ -245,6 +245,51 @@ async fn split_browser_pane_registers_cheap_content_no_terminal() {
     assert_eq!(body["message"], json!("pane split (non-terminal)"));
 }
 
+/// kata ejh6: `POST /api/panes/:id/split` REFUSES a body carrying the legacy
+/// `resumeSessionId` field at the door-top — 400 with the frozen text,
+/// presence-based for EVERY JSON value type, and (finding 3) the layout must
+/// NOT mutate on the rejected split.
+#[tokio::test]
+async fn legacy_reject_split() {
+    let state = state_with_registry();
+    let router = app(state);
+    let (_tab_id, pane_id, _terminal_id) = create_shell_tab(router.clone()).await;
+    for (label, val) in [
+        ("string", json!("legacy-split")),
+        ("empty-string", json!("")),
+        ("null", json!(null)),
+        ("number", json!(42)),
+    ] {
+        let (s1, before) = get(router.clone(), "/api/tabs", true).await;
+        assert_eq!(s1, StatusCode::OK);
+        let (status, body) = post(
+            router.clone(),
+            &format!("/api/panes/{pane_id}/split"),
+            json!({"direction": "horizontal", "mode": "claude", "resumeSessionId": val}),
+            true,
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{label} split legacy reject: {body}"
+        );
+        assert_eq!(
+            body["message"],
+            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+            "{label}: {body}"
+        );
+        let (s2, after) = get(router.clone(), "/api/tabs", true).await;
+        assert_eq!(s2, StatusCode::OK);
+        // Finding 3: layout MUST be unchanged — the door-top check fires
+        // BEFORE layout.split_pane.
+        assert_eq!(
+            before["data"]["tabs"], after["data"]["tabs"],
+            "{label}: layout must not mutate on a rejected split"
+        );
+    }
+}
+
 // ── close ───────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -653,6 +698,40 @@ async fn respawn_pane_replaces_terminal_in_place_and_broadcasts_pane_attach() {
 
     registry.kill(&old_terminal_id);
     registry.kill(&new_terminal_id);
+}
+
+/// kata ejh6: `POST /api/panes/:id/respawn` REFUSES a body carrying the
+/// legacy `resumeSessionId` field at the door-top — 400 with the frozen
+/// text, presence-based for EVERY JSON value type, BEFORE any spawn.
+#[tokio::test]
+async fn legacy_reject_respawn() {
+    let state = state_with_registry();
+    let router = app(state);
+    let (_tab_id, pane_id, _terminal_id) = create_shell_tab(router.clone()).await;
+    for (label, val) in [
+        ("string", json!("legacy-respawn")),
+        ("empty-string", json!("")),
+        ("null", json!(null)),
+        ("number", json!(42)),
+    ] {
+        let (status, body) = post(
+            router.clone(),
+            &format!("/api/panes/{pane_id}/respawn"),
+            json!({"mode": "claude", "resumeSessionId": val}),
+            true,
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{label} respawn legacy reject: {body}"
+        );
+        assert_eq!(
+            body["message"],
+            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+            "{label}: {body}"
+        );
+    }
 }
 
 // ── attach (honest deferral) ─────────────────────────────────────────

--- a/crates/freshell-freshagent/src/terminal_tabs.rs
+++ b/crates/freshell-freshagent/src/terminal_tabs.rs
@@ -48,7 +48,7 @@ use freshell_platform::{
     build_cli_spawn_spec, build_spawn_spec, build_windows_cli_spawn_spec, CliLaunch, Env, RealEnv,
     RealFileProbe, ShellType, SpawnSpec,
 };
-use freshell_protocol::{LEGACY_RESUME_IDENTITY_REFUSAL, ServerMessage, SessionLocator, UiCommand};
+use freshell_protocol::{ServerMessage, SessionLocator, UiCommand, LEGACY_RESUME_IDENTITY_REFUSAL};
 use freshell_terminal::registry::SessionRefClaim;
 
 use crate::{

--- a/crates/freshell-freshagent/src/terminal_tabs.rs
+++ b/crates/freshell-freshagent/src/terminal_tabs.rs
@@ -48,21 +48,13 @@ use freshell_platform::{
     build_cli_spawn_spec, build_spawn_spec, build_windows_cli_spawn_spec, CliLaunch, Env, RealEnv,
     RealFileProbe, ShellType, SpawnSpec,
 };
-use freshell_protocol::{ServerMessage, SessionLocator, UiCommand};
+use freshell_protocol::{LEGACY_RESUME_IDENTITY_REFUSAL, ServerMessage, SessionLocator, UiCommand};
 use freshell_terminal::registry::SessionRefClaim;
 
 use crate::{
     authorized, fail_json, fail_json_code, ok_json, text_plain, FreshAgentState, TabRecord,
     TerminalPaneEntry,
 };
-
-/// The exact legacy rejection text for a raw (non-`sessionRef`) `resumeSessionId`
-/// on a `mode:"codex"` create -- mirrors
-/// `server/coding-cli/codex-app-server/restore-decision.ts:27-28`'s
-/// `INVALID_RAW_CODEX_RESUME_MESSAGE` verbatim (a frozen TS string literal,
-/// not importable from Rust) so a REST client sees byte-identical text to the
-/// legacy Node server for this specific rejection.
-const INVALID_RAW_CODEX_RESUME_MESSAGE: &str = "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.";
 
 // -- mode / resume-id / sessionRef derivation (router.ts:695-793 semantics) --
 
@@ -127,7 +119,7 @@ fn requested_resume_session_id_for_mode(
         if legacy.is_some() {
             return Err(fail_json(
                 StatusCode::BAD_REQUEST,
-                INVALID_RAW_CODEX_RESUME_MESSAGE.to_string(),
+                LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
             ));
         }
         return Ok(None);

--- a/crates/freshell-freshagent/src/terminal_tabs.rs
+++ b/crates/freshell-freshagent/src/terminal_tabs.rs
@@ -4493,7 +4493,7 @@ mod tests {
             json!({
                 "mode": "amplifier",
                 "cwd": tmp.to_string_lossy(),
-                "resumeSessionId": "legacy-resume-id-xyz"
+                "sessionRef": { "provider": "amplifier", "sessionId": "legacy-resume-id-xyz" }
             }),
             true,
         )
@@ -4532,7 +4532,7 @@ mod tests {
     // `port/oracle/DEVIATIONS.md`).
 
     #[tokio::test]
-    async fn create_amplifier_tab_with_legacy_resume_synthesizes_session_ref() {
+    async fn create_amplifier_tab_with_session_ref_flows_into_tab_create_frame() {
         let argv_file = unique_argv_file("amplifier-synth");
         let state =
             state_with_registry().with_cli_commands(std::sync::Arc::new(vec![recording_cli_spec(
@@ -4547,7 +4547,7 @@ mod tests {
             json!({
                 "mode": "amplifier",
                 "cwd": tmp.to_string_lossy(),
-                "resumeSessionId": "web-1737000000000-abc123"
+                "sessionRef": { "provider": "amplifier", "sessionId": "web-1737000000000-abc123" }
             }),
             true,
         )
@@ -4581,7 +4581,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_claude_tab_with_canonical_resume_id_synthesizes_session_ref() {
+    async fn create_claude_tab_with_session_ref_flows_into_pane_content() {
         let argv_file = unique_argv_file("claude-synth");
         let state =
             state_with_registry().with_cli_commands(std::sync::Arc::new(vec![recording_cli_spec(
@@ -4595,7 +4595,7 @@ mod tests {
             json!({
                 "mode": "claude",
                 "cwd": tmp.to_string_lossy(),
-                "resumeSessionId": "550e8400-e29b-41d4-a716-446655440000"
+                "sessionRef": { "provider": "claude", "sessionId": "550e8400-e29b-41d4-a716-446655440000" }
             }),
             true,
         )
@@ -5804,13 +5804,13 @@ mod tests {
         registry.kill(&tid);
     }
 
-    // ── D7/D8 promotion of the legacy resumeSessionId rung ──────────────────
+    // ── D7/D8 409 ladder on the sessionRef carrier (REST rung) ─────────────
     // The 2026-08-16 duplicate-tab incident: a legacy-only carrier (the
     // `freshell` CLI's `new-tab --resume`) walked past both guards and spawned
-    // a second `opencode --session <sid>` writer onto a live session. A legacy
-    // `mode` + `resumeSessionId` pair IS a sessionRef claim (the reconcile
-    // door's §5.2 uniform promotion rule, reconcile.rs `promoted_legacy_claim`),
-    // so the guards must arm on it exactly as they do on the sessionRef rung.
+    // a second `opencode --session <sid>` writer onto a live session. The tests
+    // below pin the SAME D7/LEASE ladder via the canonical `sessionRef` carrier
+    // (kata ejh6 Task 3 re-carriered them off the legacy field; the legacy
+    // field's own door-level rejection coverage lands with the REST reject).
 
     #[tokio::test]
     async fn rest_create_legacy_resume_onto_live_session_is_refused_409() {
@@ -5827,7 +5827,7 @@ mod tests {
             json!({
                 "mode": "claude",
                 "cwd": std::env::temp_dir().to_string_lossy(),
-                "resumeSessionId": LIVE_SESSION,
+                "sessionRef": { "provider": "claude", "sessionId": LIVE_SESSION },
             }),
             true,
         )
@@ -5838,7 +5838,7 @@ mod tests {
         assert_eq!(
             registry.identity_probe_rows().len(),
             rows_before,
-            "no duplicate spawn on the legacy rung"
+            "no duplicate spawn"
         );
 
         registry.kill("t-legacy-live-owner");
@@ -5872,7 +5872,7 @@ mod tests {
             json!({
                 "mode": "claude",
                 "cwd": std::env::temp_dir().to_string_lossy(),
-                "resumeSessionId": LIVE_SESSION,
+                "sessionRef": { "provider": "claude", "sessionId": LIVE_SESSION },
             }),
             true,
         )
@@ -5904,7 +5904,7 @@ mod tests {
             json!({
                 "mode": "claude",
                 "cwd": std::env::temp_dir().to_string_lossy(),
-                "resumeSessionId": LIVE_SESSION,
+                "sessionRef": { "provider": "claude", "sessionId": LIVE_SESSION },
             }),
             true,
         )
@@ -5918,7 +5918,7 @@ mod tests {
         assert_eq!(
             registry.bound_terminal_for_session_ref(&locator),
             Some(tid.clone()),
-            "a legacy-rung resume spawn must complete its lease into a sessionRef binding"
+            "a resume spawn must complete its lease into a sessionRef binding"
         );
 
         registry.kill(&tid);
@@ -6049,7 +6049,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_opencode_tab_with_ses_prefixed_resume_id_synthesizes_session_ref() {
+    async fn create_opencode_tab_with_session_ref_flows_into_pane_content() {
         let argv_file = unique_argv_file("opencode-synth");
         let state =
             state_with_registry().with_cli_commands(std::sync::Arc::new(vec![recording_cli_spec(
@@ -6063,7 +6063,7 @@ mod tests {
             json!({
                 "mode": "opencode",
                 "cwd": tmp.to_string_lossy(),
-                "resumeSessionId": "ses_abc123"
+                "sessionRef": { "provider": "opencode", "sessionId": "ses_abc123" }
             }),
             true,
         )

--- a/crates/freshell-freshagent/src/terminal_tabs.rs
+++ b/crates/freshell-freshagent/src/terminal_tabs.rs
@@ -48,7 +48,7 @@ use freshell_platform::{
     build_cli_spawn_spec, build_spawn_spec, build_windows_cli_spawn_spec, CliLaunch, Env, RealEnv,
     RealFileProbe, ShellType, SpawnSpec,
 };
-use freshell_protocol::{ServerMessage, SessionLocator, UiCommand, LEGACY_RESUME_IDENTITY_REFUSAL};
+use freshell_protocol::{ServerMessage, SessionLocator, UiCommand};
 use freshell_terminal::registry::SessionRefClaim;
 
 use crate::{
@@ -73,7 +73,8 @@ fn mode_is_known(state: &FreshAgentState, mode: &str) -> bool {
 /// `acceptedSessionRefForMode` (`router.ts:230-236`): a `sessionRef` is only
 /// honored when its `provider` matches the terminal's own `mode` -- a
 /// `sessionRef` minted for a different provider is silently NOT accepted
-/// (falls through to the raw `resumeSessionId` path instead).
+/// (post-ejh6: the legacy raw `resumeSessionId` fallback it used to fall
+/// through to is rejected at the REST door before this is ever consulted).
 fn accepted_session_ref_for_mode<'a>(
     session_ref: Option<&'a SessionLocator>,
     mode: &str,
@@ -81,24 +82,20 @@ fn accepted_session_ref_for_mode<'a>(
     session_ref.filter(|r| r.provider == mode)
 }
 
-/// `requestedResumeSessionIdForMode` (`router.ts:214-228`): resolve the ONE
-/// resume-session-id a create should launch with -- the accepted
-/// `sessionRef` first, else (every mode EXCEPT `codex`) the legacy raw
-/// `resumeSessionId` field. `codex` is special-cased (`router.ts:221-226`,
-/// throwing `AgentRouteInputError(INVALID_RAW_CODEX_RESUME_MESSAGE)`): a raw
-/// `resumeSessionId` with no matching `sessionRef` is REJECTED outright
-/// (400), not silently accepted -- a bare codex thread id alone is not
-/// sufficient restore identity per the durable-thread contract
-/// (`restore-decision.ts`).
+/// `requestedResumeSessionIdForMode` (`router.ts:214-228`), post-ejh6:
+/// resolve the ONE resume-session-id a create should launch with — the
+/// provider-matched `sessionRef` only.
 ///
-/// NOTE: the Rust port's WS `terminal.create` handler
-/// (`crates/freshell-ws/src/terminal.rs:763-766`) does NOT yet enforce this
-/// rejection -- it accepts a raw codex `resumeSessionId` unconditionally, a
-/// known, separately-tracked deviation (DEV-0006: the codex app-server
-/// launch planner is not wired into `terminal.create` yet). This REST path
-/// mirrors the ROUTER (the frozen legacy contract) for this specific
-/// decision, per this slice's explicit scope, rather than the WS Rust port's
-/// current interim state.
+/// kata ejh6: the codex-specific legacy throw this function used to carry
+/// moved UP to the door-top presence check in each axum handler (`lib.rs`
+/// `create_tab`, `pane_ops.rs` `split_pane`/`respawn_pane`), which rejects
+/// ANY body carrying `resumeSessionId` (every mode, every JSON value, even
+/// alongside a matching `sessionRef`) with the frozen
+/// `LEGACY_RESUME_IDENTITY_REFUSAL` text. The `_legacy_resume_session_id`
+/// param is retained in the signature for caller compatibility
+/// (`derive_resume_identity` still passes it through) but is now
+/// INTENTIONALLY UNUSED — by the time control reaches here, no body can
+/// still carry the field, so there is nothing left to resolve or reject.
 ///
 /// `Response` is a large `Err` payload (`clippy::result_large_err`), but this
 /// mirrors every other handler in this module (`fail_json` returns `Response`
@@ -109,22 +106,9 @@ fn accepted_session_ref_for_mode<'a>(
 fn requested_resume_session_id_for_mode(
     session_ref: Option<&SessionLocator>,
     mode: &str,
-    legacy_resume_session_id: Option<&str>,
+    _legacy_resume_session_id: Option<&str>,
 ) -> Result<Option<String>, Response> {
-    if let Some(accepted) = accepted_session_ref_for_mode(session_ref, mode) {
-        return Ok(Some(accepted.session_id.clone()));
-    }
-    let legacy = legacy_resume_session_id.filter(|s| !s.is_empty());
-    if mode == "codex" {
-        if legacy.is_some() {
-            return Err(fail_json(
-                StatusCode::BAD_REQUEST,
-                LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
-            ));
-        }
-        return Ok(None);
-    }
-    Ok(legacy.map(str::to_string))
+    Ok(accepted_session_ref_for_mode(session_ref, mode).map(|s| s.session_id.clone()))
 }
 
 /// The terminal modes whose sessions live in a provider-durable store the
@@ -132,9 +116,10 @@ fn requested_resume_session_id_for_mode(
 /// `kimi`) -- the providers for which a bare `resumeSessionId` IS sufficient
 /// canonical identity to mint `sessionRef {provider: mode, sessionId}`.
 /// Deliberately NOT `codex`: a raw codex thread id alone is not restore
-/// identity (`INVALID_RAW_CODEX_RESUME_MESSAGE` / `restore-decision.ts`), and
-/// [`requested_resume_session_id_for_mode`] rejects it before this list is
-/// ever consulted.
+/// identity (`INVALID_RAW_CODEX_RESUME_MESSAGE` / `restore-decision.ts`).
+/// (kata ejh6: wire-level legacy `resumeSessionId` is rejected at the REST
+/// door-top before any of this runs — the plausibility/promotion machinery
+/// below now only sees resume ids derived from an accepted `sessionRef`.)
 fn is_session_provider_mode(mode: &str) -> bool {
     matches!(
         mode,
@@ -4426,6 +4411,150 @@ mod tests {
         let _ = std::fs::remove_file(&argv_file);
     }
 
+    /// kata ejh6: the legacy `resumeSessionId` wire field is REFUSED at the
+    /// `POST /api/tabs` door on EVERY registered mode (uniform any-carry
+    /// ruling) — 400 with the frozen text, before any mode branch. The cli
+    /// specs are registered so a pre-guard build would ACCEPT the create
+    /// (200), proving the door check is what flips the behavior.
+    #[tokio::test]
+    async fn legacy_reject_rest_create_all_modes() {
+        let modes = ["claude", "opencode", "amplifier"];
+        let argv_files: Vec<std::path::PathBuf> = modes
+            .iter()
+            .map(|m| unique_argv_file(&format!("legacy-reject-{m}")))
+            .collect();
+        let specs: Vec<freshell_platform::CliCommandSpec> = modes
+            .iter()
+            .zip(&argv_files)
+            .map(|(m, f)| recording_cli_spec(m, f))
+            .collect();
+        let state = state_with_registry().with_cli_commands(std::sync::Arc::new(specs));
+        let router = app(state);
+        let tmp = std::env::temp_dir();
+        for (mode, argv_file) in modes.iter().zip(&argv_files) {
+            let (status, body) = post(
+                router.clone(),
+                "/api/tabs",
+                json!({
+                    "mode": mode,
+                    "cwd": tmp.to_string_lossy(),
+                    "resumeSessionId": format!("legacy-{mode}-id")
+                }),
+                true,
+            )
+            .await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{mode}: {body}");
+            assert_eq!(
+                body["message"],
+                json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+                "{mode}: {body}"
+            );
+            let _ = std::fs::remove_file(argv_file);
+        }
+    }
+
+    /// kata ejh6 (uniform any-carry ruling): a body carrying BOTH a matching
+    /// `sessionRef` AND the legacy field still rejects — legacy presence is
+    /// checked BEFORE the sessionRef early-return.
+    #[tokio::test]
+    async fn legacy_reject_rest_create_dual_carrier() {
+        let argv_file = unique_argv_file("legacy-reject-dual");
+        let state =
+            state_with_registry().with_cli_commands(std::sync::Arc::new(vec![recording_cli_spec(
+                "claude", &argv_file,
+            )]));
+        let tmp = std::env::temp_dir();
+        let (status, body) = post(
+            app(state),
+            "/api/tabs",
+            json!({
+                "mode": "claude",
+                "cwd": tmp.to_string_lossy(),
+                "resumeSessionId": "legacy",
+                "sessionRef": { "provider": "claude", "sessionId": "canonical" }
+            }),
+            true,
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "dual-carrier must reject: {body}"
+        );
+        assert_eq!(
+            body["message"],
+            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+            "{body}"
+        );
+        let _ = std::fs::remove_file(&argv_file);
+    }
+
+    /// ejh6 presence-based (finding 2): the contract is "any create that
+    /// CARRIES the field". REST reads raw Value, so null/number/empty-string
+    /// values ARE rejected.
+    #[tokio::test]
+    async fn legacy_reject_rest_create_presence_edge_cases() {
+        let argv_file = unique_argv_file("legacy-reject-edge");
+        let state =
+            state_with_registry().with_cli_commands(std::sync::Arc::new(vec![recording_cli_spec(
+                "claude", &argv_file,
+            )]));
+        let router = app(state);
+        let tmp = std::env::temp_dir();
+        for (label, val) in [
+            ("empty-string", json!("")),
+            ("null", json!(null)),
+            ("number", json!(42)),
+        ] {
+            let (status, body) = post(
+                router.clone(),
+                "/api/tabs",
+                json!({
+                    "mode": "claude",
+                    "cwd": tmp.to_string_lossy(),
+                    "resumeSessionId": val
+                }),
+                true,
+            )
+            .await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{label}: {body}");
+            assert_eq!(
+                body["message"],
+                json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+                "{label}: {body}"
+            );
+        }
+        let _ = std::fs::remove_file(&argv_file);
+    }
+
+    /// ejh6 finding 3: browser/editor branches also 400 when carrying the
+    /// field — the door-top check fires BEFORE the agent/browser/editor/
+    /// terminal delegation, so no branch can bypass it.
+    #[tokio::test]
+    async fn legacy_reject_rest_browser_editor_branches() {
+        let state = state_with_registry();
+        let router = app(state);
+        for (label, mut body) in [
+            ("browser", json!({"browser": "https://example.com"})),
+            ("editor", json!({"editor": "/tmp/file.ts"})),
+        ] {
+            body.as_object_mut()
+                .unwrap()
+                .insert("resumeSessionId".into(), json!("legacy"));
+            let (status, resp) = post(router.clone(), "/api/tabs", body, true).await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "{label} branch must reject: {resp}"
+            );
+            assert_eq!(
+                resp["message"],
+                json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+                "{label}: {resp}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn create_codex_tab_accepts_session_ref_and_derives_resume_args() {
         // DEV-0006 S5.e: the managed-launch default is ON; this suite exercises the
@@ -5926,6 +6055,11 @@ mod tests {
 
     #[tokio::test]
     async fn create_claude_tab_with_non_canonical_resume_id_does_not_synthesize() {
+        // ejh6: wire-level legacy resumeSessionId is REFUSED at the door — the
+        // implausible-id "no-synthesize/keep" EDEV-07 branch is now wire-
+        // unreachable; the branch stays in production code (content concern,
+        // out of scope for ejh6). This test pins the refusal: 400 + frozen
+        // text, and NO ui.command frame is broadcast (no spawn).
         let argv_file = unique_argv_file("claude-implausible");
         let state =
             state_with_registry().with_cli_commands(std::sync::Arc::new(vec![recording_cli_spec(
@@ -5944,30 +6078,29 @@ mod tests {
             true,
         )
         .await;
-        assert_eq!(status, StatusCode::OK, "{body}");
-        let terminal_id = body["data"]["terminalId"].as_str().unwrap().to_string();
-
-        // Implausible id shape (claude ids must be canonical UUIDs,
-        // `freshell_sessions::text::is_canonical_claude_session_id`) -> NO
-        // synthesis; legacy resumeSessionId-only shape is preserved.
-        let frame = rx.recv().await.expect("ui.command frame broadcast");
-        let msg: Value = serde_json::from_str(&frame).unwrap();
-        assert!(
-            msg["payload"]["paneContent"].get("sessionRef").is_none(),
-            "{msg}"
-        );
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
         assert_eq!(
-            msg["payload"]["paneContent"]["resumeSessionId"],
-            json!("not-a-canonical-uuid"),
-            "{msg}"
+            body["message"],
+            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.")
         );
-
-        state.terminal_registry.clone().unwrap().kill(&terminal_id);
+        // No spawn -> no ui.command broadcast. subscribe-before-post means any
+        // frame would land in rx; a short timeout proves none arrived.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(250), rx.recv())
+                .await
+                .is_err(),
+            "no broadcast frame may arrive for a rejected create"
+        );
         let _ = std::fs::remove_file(&argv_file);
     }
 
     #[tokio::test]
     async fn create_amplifier_tab_with_whitespace_resume_id_does_not_synthesize() {
+        // ejh6: wire-level legacy resumeSessionId is REFUSED at the door — the
+        // implausible-id "no-synthesize/keep" EDEV-07 branch is now wire-
+        // unreachable; the branch stays in production code (content concern,
+        // out of scope for ejh6). This test pins the refusal: 400 + frozen
+        // text, and NO ui.command frame is broadcast (no spawn).
         let argv_file = unique_argv_file("amplifier-implausible");
         let state =
             state_with_registry().with_cli_commands(std::sync::Arc::new(vec![recording_cli_spec(
@@ -5987,27 +6120,29 @@ mod tests {
             true,
         )
         .await;
-        assert_eq!(status, StatusCode::OK, "{body}");
-        let terminal_id = body["data"]["terminalId"].as_str().unwrap().to_string();
-
-        let frame = rx.recv().await.expect("ui.command frame broadcast");
-        let msg: Value = serde_json::from_str(&frame).unwrap();
-        assert!(
-            msg["payload"]["paneContent"].get("sessionRef").is_none(),
-            "{msg}"
-        );
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
         assert_eq!(
-            msg["payload"]["paneContent"]["resumeSessionId"],
-            json!("not a plausible id"),
-            "{msg}"
+            body["message"],
+            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.")
         );
-
-        state.terminal_registry.clone().unwrap().kill(&terminal_id);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(250), rx.recv())
+                .await
+                .is_err(),
+            "no broadcast frame may arrive for a rejected create"
+        );
         let _ = std::fs::remove_file(&argv_file);
     }
 
     #[tokio::test]
     async fn create_opencode_tab_with_non_ses_resume_id_does_not_synthesize() {
+        // ejh6: wire-level legacy resumeSessionId is REFUSED at the door — the
+        // implausible-id "no-synthesize/keep" EDEV-07 branch is now wire-
+        // unreachable (opencode ids are `ses_*` rows,
+        // `shared/session-flavor.ts:65` `isDurableProviderSessionId`); the
+        // branch stays in production code (content concern, out of scope for
+        // ejh6). This test pins the refusal: 400 + frozen text, and NO
+        // ui.command frame is broadcast (no spawn).
         let argv_file = unique_argv_file("opencode-implausible");
         let state =
             state_with_registry().with_cli_commands(std::sync::Arc::new(vec![recording_cli_spec(
@@ -6026,25 +6161,17 @@ mod tests {
             true,
         )
         .await;
-        assert_eq!(status, StatusCode::OK, "{body}");
-        let terminal_id = body["data"]["terminalId"].as_str().unwrap().to_string();
-
-        // Implausible id shape (opencode ids are `ses_*` rows,
-        // `shared/session-flavor.ts:65` `isDurableProviderSessionId`) -> NO
-        // synthesis; legacy resumeSessionId-only shape is preserved.
-        let frame = rx.recv().await.expect("ui.command frame broadcast");
-        let msg: Value = serde_json::from_str(&frame).unwrap();
-        assert!(
-            msg["payload"]["paneContent"].get("sessionRef").is_none(),
-            "{msg}"
-        );
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
         assert_eq!(
-            msg["payload"]["paneContent"]["resumeSessionId"],
-            json!("foo"),
-            "{msg}"
+            body["message"],
+            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.")
         );
-
-        state.terminal_registry.clone().unwrap().kill(&terminal_id);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(250), rx.recv())
+                .await
+                .is_err(),
+            "no broadcast frame may arrive for a rejected create"
+        );
         let _ = std::fs::remove_file(&argv_file);
     }
 
@@ -6323,7 +6450,7 @@ mod tests {
             json!({
                 "mode": "amplifier",
                 "cwd": tmp.to_string_lossy(),
-                "resumeSessionId": "sess-no-warn-1"
+                "sessionRef": { "provider": "amplifier", "sessionId": "sess-no-warn-1" }
             }),
             true,
         )

--- a/crates/freshell-protocol/src/client_messages.rs
+++ b/crates/freshell-protocol/src/client_messages.rs
@@ -231,6 +231,7 @@ pub struct TerminalCreate {
     /// The spawn-time resume session id (`ws-handler.ts:656-658` — distinct from
     /// `sessionRef`; spec `cli-argv-fidelity.md` §3.3/U7: only the spawn-time id
     /// is modeled here, the binding/repair pipeline stays with coding-cli.md).
+    /// Retained solely so the handler can detect-and-reject; see kata ejh6.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resume_session_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -406,7 +407,13 @@ pub struct ReconcilePane {
     /// Optional identity claim.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_ref: Option<SessionLocator>,
-    /// Optional legacy single-key claim.
+    /// Optional legacy single-key claim. PERMANENT compat door (kata ejh6):
+    /// `pane.reconcile` is the SOLE ingress where a legacy
+    /// `resumeSessionId` remains honored — old persisted pane content can
+    /// carry a legacy-only claim indefinitely, so the server-side promotion
+    /// in `crates/freshell-ws/src/reconcile.rs` (`promoted_legacy_claim`)
+    /// stays forever with NO later-removal plan. Every create-class door
+    /// rejects this field outright; this one alone promotes it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resume_session_id: Option<String>,
     /// Informational only — never trusted.
@@ -441,8 +448,17 @@ pub struct CodingCliCreate {
     pub model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub permission_mode: Option<PermissionMode>,
+    /// Retained solely so the handler can detect-and-reject; see kata ejh6.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resume_session_id: Option<String>,
+    /// Canonical identity carrier (kata ejh6). Parity with the TS
+    /// `CodingCliCreateSchema.sessionRef`. The spec
+    /// (`port/machine/specs/cli-argv-fidelity.md` section 3.3/U7) governs
+    /// `TerminalCreate.resume_session_id` (the spawn-time id) and is silent
+    /// on `CodingCliCreate`; adding the canonical carrier here preserves the
+    /// shared-contract invariant without violating the spec.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_ref: Option<SessionLocator>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sandbox: Option<Sandbox>,
 }
@@ -507,6 +523,7 @@ pub struct FreshAgentCreate {
     pub plugins: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<AgentProvider>,
+    /// Retained solely so the handler can detect-and-reject; see kata ejh6.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resume_session_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -523,6 +540,7 @@ pub struct FreshAgentAttach {
     pub session_type: SessionType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
+    /// Retained solely so the handler can detect-and-reject; see kata ejh6.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resume_session_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/freshell-protocol/src/common.rs
+++ b/crates/freshell-protocol/src/common.rs
@@ -101,6 +101,15 @@ pub enum ErrorCode {
     SessionReserved,
 }
 
+/// The frozen sessionRef-naming refusal text for the legacy `resumeSessionId`
+/// wire field (kata ejh6). Byte-identical to Node's
+/// `INVALID_RAW_CODEX_RESUME_MESSAGE`
+/// (`server/coding-cli/codex-app-server/restore-decision.ts:27-28`) so clients
+/// see one contract across doors and servers. Both `freshell-freshagent`
+/// (`terminal_tabs.rs`) and `freshell-ws` (`terminal.rs`) reference this const
+/// instead of carrying private duplicates.
+pub const LEGACY_RESUME_IDENTITY_REFUSAL: &str = "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.";
+
 /// The coding-agent providers (`claude | codex | opencode | amplifier`).
 /// `amplifier` matches the legacy `TerminalTurnCompleteSchema.provider` enum
 /// (`shared/ws-protocol.ts:192`) — required by the TERM-16 turn-complete

--- a/crates/freshell-protocol/tests/legacy_resume_text.rs
+++ b/crates/freshell-protocol/tests/legacy_resume_text.rs
@@ -1,0 +1,12 @@
+//! ejh6 Task 1: the shared frozen refusal text is byte-exact and lives in
+//! freshell-protocol so both freshell-freshagent and freshell-ws reference
+//! one source of truth.
+use freshell_protocol::LEGACY_RESUME_IDENTITY_REFUSAL;
+
+#[test]
+fn legacy_reject_frozen_text() {
+    assert_eq!(
+        LEGACY_RESUME_IDENTITY_REFUSAL,
+        "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."
+    );
+}

--- a/crates/freshell-protocol/tests/roundtrip.rs
+++ b/crates/freshell-protocol/tests/roundtrip.rs
@@ -305,12 +305,20 @@ fn rich_client_messages() {
         other => panic!("expected TerminalAttach, got {other:?}"),
     }
 
-    // codingcli.create — PermissionMode enum (vs freshAgent's free string).
-    let wire = r#"{"type":"codingcli.create","prompt":"hi","provider":"claude","requestId":"r1","cwd":"/x","maxTurns":3,"model":"sonnet","permissionMode":"acceptEdits","sandbox":"workspace-write","resumeSessionId":"prev"}"#;
+    // codingcli.create — sessionRef (canonical carrier, ejh6 Task 11) + resumeSessionId (retained for reject).
+    let wire = r#"{"type":"codingcli.create","prompt":"hi","provider":"claude","requestId":"r1","cwd":"/x","maxTurns":3,"model":"sonnet","permissionMode":"acceptEdits","sandbox":"workspace-write","resumeSessionId":"prev","sessionRef":{"provider":"claude","sessionId":"sess-canonical"}}"#;
     match client_roundtrip(wire, "codingcli.create") {
         ClientMessage::CodingCliCreate(c) => {
             assert_eq!(c.permission_mode, Some(PermissionMode::AcceptEdits));
             assert_eq!(c.sandbox, Some(Sandbox::WorkspaceWrite));
+            assert_eq!(c.resume_session_id, Some("prev".to_string()));
+            assert_eq!(
+                c.session_ref,
+                Some(SessionLocator {
+                    provider: "claude".to_string(),
+                    session_id: "sess-canonical".to_string()
+                })
+            );
         }
         other => panic!("expected CodingCliCreate, got {other:?}"),
     }

--- a/crates/freshell-ws/src/reconcile.rs
+++ b/crates/freshell-ws/src/reconcile.rs
@@ -161,6 +161,14 @@ fn resolve_authoritative_ref(
 
 /// §5.2's ONE uniform promotion rule: a legacy `mode` + `resumeSessionId`
 /// pair IS a sessionRef claim — `{provider: mode, sessionId: resumeSessionId}`.
+///
+/// PERMANENT legacy-compat door (kata ejh6): `pane.reconcile` is the SOLE
+/// ingress where a wire `resumeSessionId` remains honored — old persisted
+/// pane content can carry a legacy-only claim INDEFINITELY, so this
+/// promotion stays forever with NO later-removal plan. Every create-class
+/// door (WS `terminal.create` / `codingcli.create` / `freshAgent.*`, REST
+/// `/api/tabs`·split·respawn) rejects the field outright with the frozen
+/// refusal text; this one alone promotes it.
 fn promoted_legacy_claim(pane: &ReconcilePane) -> Option<SessionLocator> {
     let mode = pane
         .mode

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -60,10 +60,10 @@ use freshell_platform::{
     RealFileProbe, ShellType,
 };
 use freshell_protocol::{
-    AgentProvider, ClientMessage, ErrorCode, ErrorMsg, FreshAgentEvent, Pong, ServerMessage,
-    SessionLocator, SessionType, Shell, TerminalAttach, TerminalAutoResumeCancel, TerminalCreate,
-    TerminalCreated, TerminalIdOnly, TerminalInputBlocked, TerminalInputBlockedReason,
-    TerminalKill, TerminalResize,
+    AgentProvider, ClientMessage, ErrorCode, ErrorMsg, FreshAgentEvent,
+    LEGACY_RESUME_IDENTITY_REFUSAL, Pong, ServerMessage, SessionLocator, SessionType, Shell,
+    TerminalAttach, TerminalAutoResumeCancel, TerminalCreate, TerminalCreated, TerminalIdOnly,
+    TerminalInputBlocked, TerminalInputBlockedReason, TerminalKill, TerminalResize,
 };
 use freshell_terminal::{build_child_env_from_process, FrameSink};
 
@@ -1506,19 +1506,6 @@ impl Drop for KeyedCreateGuard {
     }
 }
 
-/// The sessionRef a create claims at spawn time (council rule 7, D8), when
-/// resolvable from the create BODY alone: a non-shell mode whose session id
-/// comes from `sessionRef` (provider must match the mode — the same filter
-/// as the resume derivation in `handle_create`) or the legacy
-/// `resumeSessionId`. Later-resolved identities (fresh-claude preallocation,
-/// the P0.4 restore ladder) are freshly minted or single-source and carry no
-/// concurrent-duplicate shape, so they claim nothing.
-/// Node's legacy-restore refusal text (`server/ws-handler.ts:2181`; the SAME
-/// frozen string the REST door's codex rejection reuses,
-/// `freshell-freshagent/terminal_tabs.rs` `INVALID_RAW_CODEX_RESUME_MESSAGE`)
-/// -- byte-identical so clients see one contract across doors and servers.
-const LEGACY_RESTORE_IDENTITY_REFUSAL: &str = "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.";
-
 /// Node parity (`server/terminal-registry.ts:186-189` `modeSupportsResume`):
 /// a non-shell mode whose CLI spec declares `resumeArgs`. Mirrors Node's
 /// truthiness check on the array (`!!resumeArgs` -- present counts, even
@@ -1531,6 +1518,13 @@ fn mode_supports_resume(state: &WsState, mode: &str) -> bool {
             .any(|s| s.name == mode && s.resume_args.is_some())
 }
 
+/// The sessionRef a create claims at spawn time (council rule 7, D8), when
+/// resolvable from the create BODY alone: a non-shell mode whose session id
+/// comes from `sessionRef` (provider must match the mode — the same filter
+/// as the resume derivation in `handle_create`) or the legacy
+/// `resumeSessionId`. Later-resolved identities (fresh-claude preallocation,
+/// the P0.4 restore ladder) are freshly minted or single-source and carry no
+/// concurrent-duplicate shape, so they claim nothing.
 fn create_session_locator(create: &TerminalCreate) -> Option<SessionLocator> {
     if create.mode == "shell" {
         return None;
@@ -2450,7 +2444,7 @@ pub(crate) async fn handle_create(
         return send_create_error(
             out,
             ErrorCode::InvalidMessage,
-            LEGACY_RESTORE_IDENTITY_REFUSAL.to_string(),
+            LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
             &create.request_id,
         )
         .await;

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -60,10 +60,10 @@ use freshell_platform::{
     RealFileProbe, ShellType,
 };
 use freshell_protocol::{
-    AgentProvider, ClientMessage, ErrorCode, ErrorMsg, FreshAgentEvent,
-    LEGACY_RESUME_IDENTITY_REFUSAL, Pong, ServerMessage, SessionLocator, SessionType, Shell,
-    TerminalAttach, TerminalAutoResumeCancel, TerminalCreate, TerminalCreated, TerminalIdOnly,
-    TerminalInputBlocked, TerminalInputBlockedReason, TerminalKill, TerminalResize,
+    AgentProvider, ClientMessage, ErrorCode, ErrorMsg, FreshAgentEvent, Pong, ServerMessage,
+    SessionLocator, SessionType, Shell, TerminalAttach, TerminalAutoResumeCancel, TerminalCreate,
+    TerminalCreated, TerminalIdOnly, TerminalInputBlocked, TerminalInputBlockedReason,
+    TerminalKill, TerminalResize, LEGACY_RESUME_IDENTITY_REFUSAL,
 };
 use freshell_terminal::{build_child_env_from_process, FrameSink};
 

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -60,10 +60,11 @@ use freshell_platform::{
     RealFileProbe, ShellType,
 };
 use freshell_protocol::{
-    AgentProvider, ClientMessage, ErrorCode, ErrorMsg, FreshAgentEvent, Pong, ServerMessage,
-    SessionLocator, SessionType, Shell, TerminalAttach, TerminalAutoResumeCancel, TerminalCreate,
-    TerminalCreated, TerminalIdOnly, TerminalInputBlocked, TerminalInputBlockedReason,
-    TerminalKill, TerminalResize, LEGACY_RESUME_IDENTITY_REFUSAL,
+    AgentProvider, ClientMessage, ErrorCode, ErrorMsg, FreshAgentCreateFailed, FreshAgentEvent,
+    Pong, ServerMessage, SessionLocator, SessionType, Shell, TerminalAttach,
+    TerminalAutoResumeCancel, TerminalCreate, TerminalCreated, TerminalIdOnly,
+    TerminalInputBlocked, TerminalInputBlockedReason, TerminalKill, TerminalResize,
+    LEGACY_RESUME_IDENTITY_REFUSAL,
 };
 use freshell_terminal::{build_child_env_from_process, FrameSink};
 
@@ -644,6 +645,87 @@ async fn handle_client_text(
                 return true;
             }
             _ => {}
+        }
+    }
+
+    // ejh6 (review round 2 findings 2/4/8): raw-Value legacy-resume guard.
+    // Reject ANY create-class message carrying a top-level `resumeSessionId`
+    // with ANY JSON value (string, empty, null, number, object) at the raw
+    // layer. The typed structs' Option<String> READS CANNOT DO THIS JOB:
+    // serde absorbs JSON `null` into None (silent accept), and a non-string
+    // carry fails the whole typed parse into the accept-and-strip arm below
+    // (silent drop, no terminal, no error). Presence must be read here, at
+    // the raw layer, before dedupe/restore planning (zero side effects on
+    // reject). The two INVALID_MESSAGE families (terminal.create,
+    // codingcli.create) were armed in Task 6; Task 7 armed the freshAgent
+    // families (create.failed envelope / attach event channel).
+    if let Some(resume_value) = value.get("resumeSessionId") {
+        let _ = resume_value; // presence is what matters; the value is never read
+        match value.get("type").and_then(|t| t.as_str()) {
+            Some("terminal.create") | Some("codingcli.create") => {
+                let reply = ServerMessage::Error(ErrorMsg {
+                    code: ErrorCode::InvalidMessage,
+                    message: LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
+                    timestamp: crate::now_iso(),
+                    actual_session_ref: None,
+                    expected_session_ref: None,
+                    request_id: value
+                        .get("requestId")
+                        .and_then(|r| r.as_str())
+                        .map(str::to_string),
+                    retry_after_ms: None,
+                    terminal_exit_code: None,
+                    terminal_id: None,
+                });
+                return send(ws_tx, &reply).await;
+            }
+            // Task 7: freshAgent arms. The legacy field on a freshAgent
+            // create-class message gets the per-family envelope. Create
+            // returns `freshAgent.create.failed` (it carries requestId);
+            // attach has NO requestId, so its rejection rides the
+            // `freshAgent.error` event channel keyed by sessionId — the same
+            // shape claude.rs:265-282 broadcasts today. Built from the raw
+            // frame: presence already proven by the guard condition.
+            Some("freshAgent.create") => {
+                let reply = ServerMessage::FreshAgentCreateFailed(FreshAgentCreateFailed {
+                    code: "FRESH_AGENT_CREATE_FAILED".to_string(),
+                    message: LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
+                    request_id: value
+                        .get("requestId")
+                        .and_then(|r| r.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    retryable: Some(false),
+                });
+                return send(ws_tx, &reply).await;
+            }
+            Some("freshAgent.attach") => {
+                let session_id = value
+                    .get("sessionId")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or_default();
+                let reply = ServerMessage::FreshAgentEvent(FreshAgentEvent {
+                    event: serde_json::json!({
+                        "type": "freshAgent.error",
+                        "sessionId": session_id,
+                        "code": "FRESH_AGENT_CREATE_FAILED",
+                        "message": LEGACY_RESUME_IDENTITY_REFUSAL,
+                    }),
+                    provider: value
+                        .get("provider")
+                        .and_then(|p| p.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    session_id: session_id.to_string(),
+                    session_type: value
+                        .get("sessionType")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                });
+                return send(ws_tx, &reply).await;
+            }
+            _ => {} // not a create-class type; fall through to typed parse
         }
     }
 
@@ -1506,18 +1588,6 @@ impl Drop for KeyedCreateGuard {
     }
 }
 
-/// Node parity (`server/terminal-registry.ts:186-189` `modeSupportsResume`):
-/// a non-shell mode whose CLI spec declares `resumeArgs`. Mirrors Node's
-/// truthiness check on the array (`!!resumeArgs` -- present counts, even
-/// empty), so the two servers refuse the same set of modes.
-fn mode_supports_resume(state: &WsState, mode: &str) -> bool {
-    mode != "shell"
-        && state
-            .cli_commands
-            .iter()
-            .any(|s| s.name == mode && s.resume_args.is_some())
-}
-
 /// The sessionRef a create claims at spawn time (council rule 7, D8), when
 /// resolvable from the create BODY alone: a non-shell mode whose session id
 /// comes from `sessionRef` (provider must match the mode — the same filter
@@ -1534,6 +1604,9 @@ fn create_session_locator(create: &TerminalCreate) -> Option<SessionLocator> {
         .as_ref()
         .filter(|r| r.provider == create.mode)
         .map(|r| r.session_id.clone())
+        // ejh6: DEAD FROM THE WIRE — the raw pre-parse guard rejects any
+        // `resumeSessionId` carry before dispatch. Retained so the rung table
+        // stays total if this fn is ever fed an internally-built create.
         .or_else(|| create.resume_session_id.clone())
         .filter(|s| !s.is_empty())?;
     Some(SessionLocator {
@@ -1876,6 +1949,10 @@ pub(crate) fn derive_launch_prep(create: &TerminalCreate, mode: &str) -> LaunchP
             // 'resume' (`tr:1570-1571`).
             resume_session_id = requested_ref
                 .map(|r| r.session_id.clone())
+                // ejh6: DEAD FROM THE WIRE — the raw pre-parse guard rejects
+                // any `resumeSessionId` carry before dispatch, so this
+                // `.or_else` legacy rung can only fire for an
+                // internally-built create. Retained for rung-table totality.
                 .or_else(|| create.resume_session_id.clone())
                 .filter(|s| !s.is_empty());
             // Everything this arm can produce came from the wire (or the
@@ -2420,36 +2497,12 @@ pub(crate) async fn handle_create(
     // reject loudly when nothing can resolve. Claude-only: gemini/kimi
     // behavior is deliberately untouched, and fresh (non-restore)
     // claude keeps the preallocation branch above.
-    // Node parity (`server/ws-handler.ts:2170-2186`): a `restore:true` create
-    // for a resume-supporting non-codex mode whose ONLY identity is the
-    // legacy `resumeSessionId` is refused loudly -- restore identity must be
-    // a `sessionRef` (PR #318's durable-session contract). The Rust door
-    // previously fell through to `<cli> --resume <sid>` for this shape.
-    // Node's `!hasReusableRequestedLiveTerminal` arm has no Rust analog:
-    // `create.live_terminal` is a legacy repair hint the Rust server
-    // deliberately ignores (superseded by `pane.reconcile` verdicts -- see
-    // the field's doc in freshell-protocol/client_messages.rs), so no
-    // reuse path exists to exempt. Placed BEFORE the claude P0.4 restore
-    // ladder, matching Node's ordering (the refusal wins over ladder
-    // healing).
-    if create.restore == Some(true)
-        && mode != "codex"
-        && mode_supports_resume(state, &mode)
-        && create
-            .resume_session_id
-            .as_deref()
-            .is_some_and(|s| !s.is_empty())
-        && create.session_ref.is_none()
-    {
-        return send_create_error(
-            out,
-            ErrorCode::InvalidMessage,
-            LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
-            &create.request_id,
-        )
-        .await;
-    }
-
+    // ejh6 Task 6: the scoped legacy-field refusal gate that lived here
+    // (restore + non-codex + legacy-only carrier) moved UP to the raw
+    // pre-parse guard in `handle_client_text` — EVERY `resumeSessionId`
+    // carry (any mode, any restore state, companion sessionRef included)
+    // is rejected there with INVALID_MESSAGE + the frozen text, before
+    // dedupe and before any planning.
     if mode == "claude" && create.restore == Some(true) {
         // Full Node reject-predicate parity (ws-handler.ts:2130-2139):
         // a client-supplied claude id that is not canonical-UUID-shaped

--- a/crates/freshell-ws/src/terminal_launch_prep_tests.rs
+++ b/crates/freshell-ws/src/terminal_launch_prep_tests.rs
@@ -29,18 +29,18 @@ fn wire_session_ref_restore_is_from_wire() {
 }
 
 #[test]
-fn wire_legacy_resume_session_id_is_from_wire() {
+fn wire_session_ref_is_from_wire() {
     let create = create_from_json(serde_json::json!({
-        "requestId": "r-wire-legacy",
+        "requestId": "r-wire-sref",
         "mode": "amplifier",
         "shell": "system",
         "restore": true,
-        "resumeSessionId": "stale-amp-id"
+        "sessionRef": { "provider": "amplifier", "sessionId": "stale-amp-id" }
     }));
     let prep = derive_launch_prep(&create, "amplifier");
     assert!(
         prep.resume_id_from_wire,
-        "legacy resumeSessionId carrier is wire-originated"
+        "sessionRef carrier is wire-originated"
     );
     assert_eq!(prep.resume_session_id.as_deref(), Some("stale-amp-id"));
 }

--- a/crates/freshell-ws/tests/amplifier_launcher_identity.rs
+++ b/crates/freshell-ws/tests/amplifier_launcher_identity.rs
@@ -286,14 +286,14 @@ async fn amplifier_create_rejects_synthetic_terminal_placeholder_refs() {
 /// be rejected, never a second live PTY interleaving writes into one
 /// session dir.
 ///
-/// The second create rides the legacy `resumeSessionId` carrier. Since the
-/// legacy-rung D7 promotion (the 2026-08-16 duplicate-tab fix), the
-/// cross-mode D7 liveness guard intercepts this carrier too — BEFORE the
-/// amplifier-specific friendly guard — so the loud reject is now the uniform
-/// D7 frame (`RESTORE_UNAVAILABLE`, "Session ... is still running on the
-/// server"), identical to the wire-`sessionRef` carrier's answer. The
-/// amplifier friendly guard remains downstream as defense-in-depth (it also
-/// covers the registry-level duplicate race D7 cannot see).
+/// The second create rides the legacy `resumeSessionId` carrier. Pre-ejh6
+/// the cross-mode D7 liveness guard answered it (`RESTORE_UNAVAILABLE`,
+/// "Session ... is still running on the server"); post-ejh6 the raw
+/// pre-parse guard rejects the legacy carrier at the door — BEFORE dedupe,
+/// BEFORE D7's liveness ladder — with `INVALID_MESSAGE` + the frozen
+/// refusal text. The amplifier friendly guard remains downstream as
+/// defense-in-depth for the carriers that remain legal (it also covers the
+/// registry-level duplicate race D7 cannot see).
 #[tokio::test]
 async fn amplifier_create_rejects_second_live_resume_of_same_session() {
     let _amp_home = isolate_amplifier_home();
@@ -346,12 +346,17 @@ async fn amplifier_create_rejects_second_live_resume_of_same_session() {
     .expect("send terminal.create");
 
     let err = next_frame_of_type(&mut ws, "error").await;
-    assert_eq!(err["code"], "RESTORE_UNAVAILABLE", "loud reject: {err}");
+    assert_eq!(
+        err["code"], "INVALID_MESSAGE",
+        "post-ejh6 the legacy carrier is rejected at the door, not via D7: {err}"
+    );
     assert_eq!(err["requestId"], "req-amp-launcher-identity-6");
     assert_eq!(
         err["message"],
-        serde_json::json!(format!("Session {sid} is still running on the server.")),
-        "the uniform D7 frame — same answer as the sessionRef carrier: {err}"
+        serde_json::json!(
+            "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."
+        ),
+        "the frozen door-rejection frame: {err}"
     );
 
     // No duplicate spawn: exactly the original terminal owns sid.

--- a/crates/freshell-ws/tests/amplifier_launcher_identity.rs
+++ b/crates/freshell-ws/tests/amplifier_launcher_identity.rs
@@ -145,7 +145,7 @@ async fn requested_amplifier_resume_with_missing_dir_is_restubbed_under_same_id(
             "mode": "amplifier",
             "shell": "system",
             "cwd": cwd.to_string_lossy(),
-            "resumeSessionId": requested,
+            "sessionRef": { "provider": "amplifier", "sessionId": requested },
         })
         .to_string(),
     ))

--- a/crates/freshell-ws/tests/claude_session_rebind.rs
+++ b/crates/freshell-ws/tests/claude_session_rebind.rs
@@ -543,7 +543,6 @@ async fn session_start_signal_rebinds_and_restores_the_new_id() {
             "sessionType": "freshclaude",
             "provider": "claude",
             "cwd": "/tmp",
-            "resumeSessionId": sidecar_sid,
             "sessionRef": { "provider": "claude", "sessionId": sidecar_sid },
         })
         .to_string(),

--- a/crates/freshell-ws/tests/codex_managed_launch_e2e.rs
+++ b/crates/freshell-ws/tests/codex_managed_launch_e2e.rs
@@ -247,9 +247,10 @@ async fn create_codex_terminal(ws: &mut TestWs, request_id: &str, cwd: &str) -> 
     }
 }
 
-/// Create a codex terminal with a `resumeSessionId` (the raw WS-path resume field,
-/// same shape as `codex_session_ref_resume.rs`'s create message) and return the
-/// `terminal.created` frame (or the `error` frame, panicking with it for diagnosis).
+/// Create a codex terminal with a `sessionRef` (the canonical WS-path resume
+/// carrier, same shape as `codex_session_ref_resume.rs`'s create message) and
+/// return the `terminal.created` frame (or the `error` frame, panicking with it
+/// for diagnosis).
 async fn create_codex_terminal_resume(
     ws: &mut TestWs,
     request_id: &str,
@@ -263,7 +264,7 @@ async fn create_codex_terminal_resume(
             "mode": "codex",
             "shell": "system",
             "cwd": cwd,
-            "resumeSessionId": resume_session_id,
+            "sessionRef": { "provider": "codex", "sessionId": resume_session_id },
         })
         .to_string(),
     ))

--- a/crates/freshell-ws/tests/codex_session_ref_resume.rs
+++ b/crates/freshell-ws/tests/codex_session_ref_resume.rs
@@ -21,8 +21,9 @@
 //!      `resume <id>` (FAILED before the fix -- the incident).
 //!   2. `sessionRef` with a NON-matching provider -> NO resume (the
 //!      provider==mode gate is preserved).
-//!   3. Raw `resumeSessionId` (no sessionRef) -> still resumes (the legacy
-//!      WS-path fallback is preserved).
+//!   3. Raw `resumeSessionId` (no sessionRef) -> REJECTED at the door with
+//!      `INVALID_MESSAGE` + the frozen refusal text (kata ejh6 removed the
+//!      codex exemption — `sessionRef` is the only restore carrier).
 //!
 //! The fake codex is a plain `sh` script (no node dependency), so this runs in
 //! the normal suite. Loopback ephemeral ports only -- never 3001/3002.
@@ -243,6 +244,64 @@ async fn create_codex_terminal(
     }
 }
 
+/// Send a `terminal.create` (extra fields merged in) and return the `error`
+/// frame correlated to `request_id` (panicking on a `terminal.created` — a
+/// spawn IS the failure this helper's callers forbid).
+async fn expect_create_error(
+    ws: &mut TestWs,
+    request_id: &str,
+    extra: serde_json::Value,
+) -> serde_json::Value {
+    let mut msg = json!({
+        "type": "terminal.create",
+        "requestId": request_id,
+        "mode": "codex",
+        "shell": "system",
+        "cwd": std::env::temp_dir().to_string_lossy(),
+    });
+    if let (Some(base), Some(extra)) = (msg.as_object_mut(), extra.as_object()) {
+        for (k, v) in extra {
+            base.insert(k.clone(), v.clone());
+        }
+    }
+    ws.send(WsMessage::Text(msg.to_string()))
+        .await
+        .expect("send terminal.create");
+    for _ in 0..20u8 {
+        let frame = tokio::time::timeout(RECV_TIMEOUT, ws.next())
+            .await
+            .expect("error within timeout")
+            .expect("stream open")
+            .expect("no ws error");
+        if let WsMessage::Text(text) = frame {
+            let value: serde_json::Value = serde_json::from_str(&text).expect("json frame");
+            match value["type"].as_str() {
+                Some("terminal.created") if value["requestId"] == json!(request_id) => {
+                    panic!("create must be refused at the door, got {value}")
+                }
+                Some("error") if value["requestId"] == json!(request_id) => return value,
+                _ => {}
+            }
+        }
+    }
+    panic!("no error frame for {request_id} within 20 messages");
+}
+
+/// Bounded NEGATIVE argv-capture check: the fake codex writes the capture
+/// file synchronously at child spawn, so its absence after a short window
+/// proves no child ever launched (a door rejection has zero side effects).
+fn assert_never_captured(path: &std::path::Path) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        assert!(
+            !path.exists(),
+            "a create rejected at the door must never spawn a child: {}",
+            path.display()
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
 /// Poll the capture file the fake writes until it appears, then return the argv
 /// tokens (one per line).
 fn wait_for_captured_argv(path: &std::path::Path) -> Vec<String> {
@@ -360,32 +419,31 @@ async fn codex_create_derives_resume_from_session_ref() {
     );
     registry.kill(&terminal_id);
 
-    // ── Phase 3: the raw `resumeSessionId` fallback still works (legacy
-    // ── accepts it on the WS path).
+    // ── Phase 3 (ejh6): the raw `resumeSessionId` fallback is REJECTED at
+    // ── the door (the codex exemption is removed; uniform any-carry reject)
+    // ── and nothing spawns.
     let raw_id = "raw-resume-codex-1";
     let capture = capture_for("raw-resume");
     let _ = std::fs::remove_file(&capture);
     std::env::set_var("CODEX_ARGV_CAPTURE_PATH", &capture);
 
-    let created = create_codex_terminal(
+    let err = expect_create_error(
         &mut ws,
         "req-raw-resume",
         json!({ "resumeSessionId": raw_id }),
     )
     .await;
-    let terminal_id = created["terminalId"].as_str().unwrap().to_string();
 
     assert_eq!(
-        registry_resume_id(&registry, &terminal_id).as_deref(),
-        Some(raw_id),
-        "the raw resumeSessionId fallback must be preserved"
+        err["code"], "INVALID_MESSAGE",
+        "codex raw-legacy is no longer accepted: {err}"
     );
-    let argv = wait_for_captured_argv(&capture);
-    assert!(
-        resume_pair_position(&argv, raw_id).is_some(),
-        "spawned codex argv must contain `resume {raw_id}`: {argv:?}"
+    assert_eq!(
+        err["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+        "frozen text: {err}"
     );
-    registry.kill(&terminal_id);
+    assert_never_captured(&capture);
 
     std::env::remove_var("CODEX_ARGV_CAPTURE_PATH");
     std::env::remove_var("CODEX_CMD");

--- a/crates/freshell-ws/tests/cross_kind_liveness.rs
+++ b/crates/freshell-ws/tests/cross_kind_liveness.rs
@@ -6,8 +6,13 @@
 //!
 //! Two directions, two guards:
 //! 1. A `freshAgent.create` resuming S while a live terminal PTY owns S is refused
-//!    with `freshAgent.create.failed { code: "SESSION_RESERVED", retryable: true }`
-//!    and ZERO sidecar spawns (the terminal may be closing -- retryable).
+//!    and spawns ZERO sidecars. Post-ejh6 (Task 7) the refusal code depends on the
+//!    carrier: a legacy/dual-carrier create (`resumeSessionId` present) is rejected
+//!    at the raw-Value ejh6 guard with `freshAgent.create.failed { code:
+//!    "FRESH_AGENT_CREATE_FAILED" }` + frozen text, while a sessionRef-ONLY create
+//!    reaches the typed cross-kind live-guard and is refused with
+//!    `freshAgent.create.failed { code: "SESSION_RESERVED", retryable: true }`
+//!    (the terminal may be closing -- retryable).
 //! 2. A `terminal.create` whose wire sessionRef names S while a live sidecar owns S
 //!    is refused with the D7 guard's EXISTING rejection frame
 //!    (`error { code: "RESTORE_UNAVAILABLE" }`), same as a live PTY.
@@ -15,7 +20,7 @@
 //! Harness: the lease-suite fake claude sidecar (request-log knob) + the common
 //! sleeper CLI spec so terminal claude creates genuinely spawn a Running PTY.
 //! Run via `scripts/sandbox-test.sh` per the destructive-suite convention of the
-//! sibling lease suite (shared file-level ruling; these two tests kill nothing).
+//! sibling lease suite (shared file-level ruling; these tests kill nothing).
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -433,6 +438,81 @@ async fn freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session() {
     assert_eq!(
         failed["message"],
         "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."
+    );
+
+    // 3. ZERO sidecar spawns.
+    assert!(
+        env.create_rows().is_empty(),
+        "no sidecar may spawn while the terminal owns the session: {:?}",
+        env.create_rows()
+    );
+}
+
+/// Direction 1, sessionRef-only variant (whole-branch review finding 1): the ejh6
+/// retarget of the test above left the STILL-REACHABLE production path unpinned --
+/// a `freshAgent.create` carrying ONLY `sessionRef` (no legacy `resumeSessionId`)
+/// passes the raw-Value ejh6 guard, reaches the typed dispatch, and must be
+/// refused by the Task 13b cross-kind live-guard with
+/// `freshAgent.create.failed { code: "SESSION_RESERVED", retryable: true }` and
+/// ZERO sidecar spawns (the terminal may be closing -- retryable).
+#[tokio::test]
+async fn freshagent_session_ref_resume_is_refused_while_a_terminal_pty_owns_the_session() {
+    let _guard = ENV_LOCK.lock().await;
+    let env = FakeSidecarEnv::install();
+
+    let (url, _registry) = spawn_server().await;
+    let mut ws = connect(&url).await;
+
+    // 1. A fresh claude terminal reaches Running, owning preallocated session S.
+    send_json(
+        &mut ws,
+        &json!({
+            "type": "terminal.create",
+            "requestId": "req-term-owner-2",
+            "mode": "claude",
+            "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+        }),
+    )
+    .await;
+    let created = await_frame(&mut ws, Duration::from_secs(10), |v| {
+        v["type"] == "terminal.created" && v["requestId"] == "req-term-owner-2"
+    })
+    .await;
+    let session_id = created["sessionRef"]["sessionId"]
+        .as_str()
+        .expect("fresh claude terminal carries a sessionRef")
+        .to_string();
+
+    // 2. A sessionRef-ONLY fresh-agent resume of the SAME session id carries no
+    //    legacy field, so it passes the raw-Value ejh6 guard and must be refused
+    //    by the cross-kind live-guard -- never a second writer on S's JSONL.
+    send_json(
+        &mut ws,
+        &json!({
+            "type": "freshAgent.create",
+            "requestId": "req-fa-cross-2",
+            "sessionType": "freshclaude",
+            "provider": "claude",
+            "cwd": "/tmp",
+            "sessionRef": { "provider": "claude", "sessionId": session_id },
+        }),
+    )
+    .await;
+    let failed = await_frame(&mut ws, Duration::from_secs(10), |v| {
+        (v["type"] == "freshAgent.create.failed" || v["type"] == "freshAgent.created")
+            && v["requestId"] == "req-fa-cross-2"
+    })
+    .await;
+    assert_eq!(
+        failed["type"], "freshAgent.create.failed",
+        "a live terminal PTY owns {session_id}: the sessionRef-only resume must be refused, got {failed}"
+    );
+    assert_eq!(failed["code"], "SESSION_RESERVED");
+    assert_eq!(
+        failed["retryable"],
+        serde_json::json!(true),
+        "the terminal may be closing -- the cross-kind refusal must be retryable: {failed}"
     );
 
     // 3. ZERO sidecar spawns.

--- a/crates/freshell-ws/tests/cross_kind_liveness.rs
+++ b/crates/freshell-ws/tests/cross_kind_liveness.rs
@@ -367,8 +367,11 @@ async fn await_frame(
 // ── the red tests ────────────────────────────────────────────────────────────────────
 
 /// Direction 1 (V7 scenario B): a live terminal PTY owns `(claude, S)`; a
-/// `freshAgent.create { resumeSessionId: S }` must be refused with
-/// `SESSION_RESERVED { retryable: true }` and spawn ZERO sidecars.
+/// `freshAgent.create { resumeSessionId: S }` must be refused and spawn ZERO
+/// sidecars. Post-ejh6 (Task 7) the refusal fires at the raw-Value ejh6 guard
+/// (the create carries the legacy field) BEFORE the typed dispatch reaches the
+/// SESSION_RESERVED cross-kind guard, so the code is
+/// `FRESH_AGENT_CREATE_FAILED` + frozen text.
 #[tokio::test]
 async fn freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session() {
     let _guard = ENV_LOCK.lock().await;
@@ -422,10 +425,14 @@ async fn freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session() {
         failed["type"], "freshAgent.create.failed",
         "a live terminal PTY owns {session_id}: the fresh-agent resume must be refused, got {failed}"
     );
-    assert_eq!(failed["code"], "SESSION_RESERVED");
+    // ejh6: the legacy field is rejected at the door BEFORE the SESSION_RESERVED
+    // cross-kind guard fires (the raw-Value ejh6 guard's freshAgent.create arm
+    // runs first). The code is FRESH_AGENT_CREATE_FAILED + frozen text, not
+    // SESSION_RESERVED.
+    assert_eq!(failed["code"], "FRESH_AGENT_CREATE_FAILED");
     assert_eq!(
-        failed["retryable"], true,
-        "retryable -- the terminal may be closing"
+        failed["message"],
+        "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."
     );
 
     // 3. ZERO sidecar spawns.
@@ -449,6 +456,8 @@ async fn terminal_create_is_refused_while_a_live_sidecar_owns_the_session() {
     let mut ws = connect(&url).await;
 
     // 1. A fresh-agent resume of S goes live (the fake sidecar answers `created`).
+    //    (ejh6 Task 7: sessionRef-only -- a legacy `resumeSessionId` carry is now
+    //    rejected at the raw-Value guard, which would break this setup create.)
     send_json(
         &mut ws,
         &json!({
@@ -457,7 +466,6 @@ async fn terminal_create_is_refused_while_a_live_sidecar_owns_the_session() {
             "sessionType": "freshclaude",
             "provider": "claude",
             "cwd": "/tmp",
-            "resumeSessionId": durable,
             "sessionRef": { "provider": "claude", "sessionId": durable },
         }),
     )

--- a/crates/freshell-ws/tests/freshagent_claude_attach.rs
+++ b/crates/freshell-ws/tests/freshagent_claude_attach.rs
@@ -589,3 +589,57 @@ async fn events_after_durable_rebind_are_stamped_with_the_durable_id() {
         "post-rebind envelopes must be stamped with the durable id"
     );
 }
+
+/// ejh6: a `freshAgent.attach` carrying `resumeSessionId` is rejected with
+/// `freshAgent.error{code:"FRESH_AGENT_CREATE_FAILED"}` + frozen text. No
+/// sidecar spawn, no manager.attach call. Attach has no requestId, so the
+/// rejection rides the freshAgent.error event channel keyed by sessionId.
+#[tokio::test]
+async fn legacy_reject_freshagent_attach() {
+    let _guard = CLAUDE_ENV_LOCK.lock().await;
+    let env = FakeClaudeResumeEnv::install("legacy-durable-id");
+    let url = spawn_server().await;
+    let mut ws = connect_and_complete_handshake(&url).await;
+
+    // ejh6 presence (finding 9): rejection fires for any string, including "".
+    for (label, legacy) in [("string", "legacy-durable-id"), ("empty-string", "")] {
+        send_json(
+            &mut ws,
+            &serde_json::json!({
+                "type": "freshAgent.attach",
+                "sessionId": "cli-session-legacy-attach",
+                "sessionType": "freshclaude",
+                "provider": "claude",
+                "resumeSessionId": legacy,
+            }),
+        )
+        .await;
+
+        let err = await_frame(&mut ws, Duration::from_secs(10), |v| {
+            v["type"] == "freshAgent.event"
+                && v["event"]["type"] == "freshAgent.error"
+                && v["sessionId"] == "cli-session-legacy-attach"
+        })
+        .await;
+        assert_eq!(
+            err["event"]["code"],
+            serde_json::json!("FRESH_AGENT_CREATE_FAILED"),
+            "{label}: attach legacy reject must use the create-failed family code: {err}"
+        );
+        assert_eq!(
+            err["event"]["message"],
+            serde_json::json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+            "{label}: frozen text: {err}"
+        );
+    }
+    // V3: this file has NO create_rows(); use request_log_rows() and filter for create rows.
+    let create_count = env
+        .request_log_rows()
+        .into_iter()
+        .filter(|r| r["msg"]["type"] == "create")
+        .count();
+    assert_eq!(
+        create_count, 0,
+        "no sidecar may spawn for a rejected legacy attach"
+    );
+}

--- a/crates/freshell-ws/tests/freshagent_claude_attach.rs
+++ b/crates/freshell-ws/tests/freshagent_claude_attach.rs
@@ -360,7 +360,6 @@ async fn claude_attach_with_resumable_transcript_resumes_and_emits_snapshot_over
             "provider": "claude",
             "sessionId": "gone-after-restart",
             "sessionType": "freshclaude",
-            "resumeSessionId": durable,
             "sessionRef": { "provider": "claude", "sessionId": durable },
         }),
     )
@@ -466,7 +465,6 @@ async fn attach_by_durable_id_on_a_live_session_rebinds_and_acks() {
             "provider": "claude",
             "sessionId": DURABLE_FALLBACK,
             "sessionType": "freshclaude",
-            "resumeSessionId": DURABLE_FALLBACK,
             "sessionRef": { "provider": "claude", "sessionId": DURABLE_FALLBACK },
         }),
     )
@@ -556,7 +554,6 @@ async fn events_after_durable_rebind_are_stamped_with_the_durable_id() {
             "provider": "claude",
             "sessionId": DURABLE_FALLBACK,
             "sessionType": "freshclaude",
-            "resumeSessionId": DURABLE_FALLBACK,
             "sessionRef": { "provider": "claude", "sessionId": DURABLE_FALLBACK },
         }),
     )

--- a/crates/freshell-ws/tests/freshagent_session_lease.rs
+++ b/crates/freshell-ws/tests/freshagent_session_lease.rs
@@ -992,3 +992,55 @@ async fn opencode_attach_resume_is_serialized_without_touching_the_shared_sideca
         "the loser must never issue a second in-flight resume"
     );
 }
+
+/// ejh6: a `freshAgent.create` carrying `resumeSessionId` is rejected with
+/// `freshAgent.create.failed{code:"FRESH_AGENT_CREATE_FAILED"}` + frozen text.
+/// No sidecar spawn. Create has a requestId, so the rejection uses the
+/// create-failed envelope.
+#[tokio::test]
+async fn legacy_reject_freshagent_create() {
+    let _guard = LEASE_ENV_LOCK.lock().await;
+    let env = FakeLeaseSidecarEnv::install();
+    let url = spawn_server().await;
+    let mut ws = connect(&url, true).await;
+
+    // ejh6 presence (finding 9): rejection fires for any string, including "".
+    for (label, legacy, req_id) in [
+        ("string", "legacy-durable-id", "req-fa-legacy-create"),
+        ("empty-string", "", "req-fa-legacy-create-empty"),
+    ] {
+        send_json(
+            &mut ws,
+            &serde_json::json!({
+                "type": "freshAgent.create",
+                "requestId": req_id,
+                "sessionType": "freshclaude",
+                "provider": "claude",
+                "cwd": "/tmp",
+                "resumeSessionId": legacy,
+            }),
+        )
+        .await;
+
+        let failed = await_frame(&mut ws, Duration::from_secs(10), |v| {
+            v["type"] == "freshAgent.create.failed" && v["requestId"].as_str() == Some(req_id)
+        })
+        .await;
+        assert_eq!(
+            failed["code"],
+            serde_json::json!("FRESH_AGENT_CREATE_FAILED"),
+            "{label}: create-failed family code: {failed}"
+        );
+        assert_eq!(
+            failed["message"],
+            serde_json::json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+            "{label}: frozen text: {failed}"
+        );
+        assert_eq!(failed["retryable"], serde_json::json!(false));
+    }
+    assert!(
+        env.create_rows().is_empty(),
+        "no sidecar may spawn for a rejected legacy create: {:?}",
+        env.create_rows()
+    );
+}

--- a/crates/freshell-ws/tests/freshagent_session_lease.rs
+++ b/crates/freshell-ws/tests/freshagent_session_lease.rs
@@ -418,7 +418,6 @@ fn claude_create_resume(request_id: &str, durable: &str) -> Value {
         "sessionType": "freshclaude",
         "provider": "claude",
         "cwd": "/tmp",
-        "resumeSessionId": durable,
         "sessionRef": { "provider": "claude", "sessionId": durable },
     })
 }
@@ -599,7 +598,6 @@ async fn codex_loser_create_resume_adopts_and_never_clobbers_the_winner() {
             "sessionType": "freshcodex",
             "provider": "codex",
             "cwd": "/tmp",
-            "resumeSessionId": thread,
             "sessionRef": { "provider": "codex", "sessionId": thread },
         })
     };
@@ -756,7 +754,6 @@ async fn loser_attach_after_winner_binds_converges_to_the_live_session() {
         "provider": "claude",
         "sessionId": durable,
         "sessionType": "freshclaude",
-        "resumeSessionId": durable,
         "sessionRef": { "provider": "claude", "sessionId": durable },
     });
     send_json(&mut ws_b, &attach).await;

--- a/crates/freshell-ws/tests/live_session_ref_guard.rs
+++ b/crates/freshell-ws/tests/live_session_ref_guard.rs
@@ -14,7 +14,10 @@
 
 mod common;
 
-use common::{connect_and_capture_inventory, next_frame_of_type, session_ref_of, spawn_server};
+use common::{
+    connect_and_capture_inventory, next_frame_of_type, session_ref_of, sleeper_cli_spec,
+    spawn_server, spawn_server_with_specs,
+};
 use futures_util::{SinkExt, StreamExt};
 use serde_json::json;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
@@ -130,12 +133,15 @@ async fn live_session_ref_create_is_refused_loudly() {
 
 /// The legacy rung of the same doctrine (2026-08-16 duplicate-tab incident):
 /// a `terminal.create` carrying ONLY the legacy `resumeSessionId` (no
-/// `sessionRef`) must arm D7 exactly like the sessionRef rung — a legacy
+/// `sessionRef`) used to arm D7 exactly like the sessionRef rung — a legacy
 /// `mode` + `resumeSessionId` pair IS a sessionRef claim (`reconcile.rs`
-/// §5.2 uniform promotion, `create_session_locator`). Before the fix this
-/// carrier bypassed D7 in every ordering (the wire-resume gate's liveness
-/// precondition SKIPS live candidates rather than refusing them) and spawned
-/// a second `<cli> --resume S` writer.
+/// §5.2 uniform promotion, `create_session_locator`).
+///
+/// Post-ejh6 the carrier never reaches D7: the raw pre-parse guard
+/// (`handle_client_text`) rejects ANY `resumeSessionId` carry with
+/// `INVALID_MESSAGE` + the frozen refusal text, before dedupe and before any
+/// liveness planning. The live owner is never touched either way: exactly
+/// one terminal still owns S.
 #[tokio::test]
 async fn legacy_resume_session_id_create_is_refused_loudly() {
     let (url, registry) = spawn_server().await; // sleeper claude: stays Running
@@ -180,13 +186,13 @@ async fn legacy_resume_session_id_create_is_refused_loudly() {
     let err = expect_refusal_for(&mut ws, "req-legacy-recreate-7c1d").await;
     assert_eq!(
         err["code"],
-        json!("RESTORE_UNAVAILABLE"),
-        "exact wire code: {err}"
+        json!("INVALID_MESSAGE"),
+        "post-ejh6 the legacy carrier is rejected at the door, not via D7: {err}"
     );
-    let message = err["message"].as_str().expect("error message");
-    assert!(
-        message.contains(&session_id),
-        "message must name the live session {session_id}: {err}"
+    assert_eq!(
+        err["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+        "frozen text: {err}"
     );
 
     let rows = registry.identity_probe_rows();
@@ -240,5 +246,211 @@ async fn legacy_only_restore_is_refused_invalid_message() {
     assert!(
         registry.identity_probe_rows().is_empty(),
         "no terminal may spawn for a refused legacy-only restore"
+    );
+}
+
+/// ejh6: a `terminal.create` carrying `resumeSessionId` is rejected with
+/// `INVALID_MESSAGE` + frozen text on ANY mode, ANY restore state, and even
+/// when a companion `sessionRef` is present. No spawn, no registry row.
+/// Presence-based: `resumeSessionId: ""` is also rejected — and so are the
+/// JSON value shapes the typed layer cannot even see: `null` (serde absorbs
+/// it into `None`) and non-strings (they fail the typed parse into the
+/// accept-and-strip arm — total silent drop).
+#[tokio::test]
+async fn legacy_reject_ws_terminal_create() {
+    // A codex sleeper spec is registered too, so a SILENTLY ACCEPTED codex
+    // carry really would spawn (the failure this test exists to forbid).
+    let (url, registry) = spawn_server_with_specs(vec![
+        sleeper_cli_spec("amplifier"),
+        sleeper_cli_spec("claude"),
+        sleeper_cli_spec("codex"),
+    ])
+    .await;
+    let (mut ws, _inv) = connect_and_capture_inventory(&url).await;
+
+    let cases: Vec<(&str, &str, serde_json::Value)> = vec![
+        (
+            "claude-restore-true",
+            "req-blanket-1",
+            json!({
+                "type": "terminal.create", "requestId": "req-blanket-1",
+                "mode": "claude", "shell": "system",
+                "cwd": std::env::temp_dir().to_string_lossy(),
+                "restore": true, "resumeSessionId": "9d1f6f5a-2b6e-4d0f-8a3c-5e7b2c9d4f10",
+            }),
+        ),
+        (
+            "codex-no-restore",
+            "req-blanket-2",
+            json!({
+                "type": "terminal.create", "requestId": "req-blanket-2",
+                "mode": "codex", "shell": "system",
+                "cwd": std::env::temp_dir().to_string_lossy(),
+                "resumeSessionId": "thread-raw-codex",
+            }),
+        ),
+        (
+            "claude-with-companion-sessionref",
+            "req-blanket-3",
+            json!({
+                "type": "terminal.create", "requestId": "req-blanket-3",
+                "mode": "claude", "shell": "system",
+                "cwd": std::env::temp_dir().to_string_lossy(),
+                "resumeSessionId": "legacy-should-still-reject",
+                "sessionRef": {"provider": "claude", "sessionId": "canonical-session-id"},
+            }),
+        ),
+        (
+            "empty-string-presence",
+            "req-blanket-4",
+            json!({
+                "type": "terminal.create", "requestId": "req-blanket-4",
+                "mode": "claude", "shell": "system",
+                "cwd": std::env::temp_dir().to_string_lossy(),
+                "resumeSessionId": "",
+            }),
+        ),
+        (
+            "null-presence",
+            "req-blanket-5",
+            json!({
+                "type": "terminal.create", "requestId": "req-blanket-5",
+                "mode": "claude", "shell": "system",
+                "cwd": std::env::temp_dir().to_string_lossy(),
+                "resumeSessionId": null,
+            }),
+        ),
+        (
+            "number-presence",
+            "req-blanket-6",
+            json!({
+                "type": "terminal.create", "requestId": "req-blanket-6",
+                "mode": "claude", "shell": "system",
+                "cwd": std::env::temp_dir().to_string_lossy(),
+                "resumeSessionId": 42,
+            }),
+        ),
+        (
+            "object-presence",
+            "req-blanket-7",
+            json!({
+                "type": "terminal.create", "requestId": "req-blanket-7",
+                "mode": "claude", "shell": "system",
+                "cwd": std::env::temp_dir().to_string_lossy(),
+                "resumeSessionId": {"nested": true},
+            }),
+        ),
+    ];
+    for (label, req_id, body) in cases {
+        send_create(&mut ws, body).await;
+        let err = expect_refusal_for(&mut ws, req_id).await;
+        assert_eq!(err["code"], json!("INVALID_MESSAGE"), "{label}: {err}");
+        assert_eq!(
+            err["message"],
+            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+            "{label}: frozen text must be byte-exact: {err}"
+        );
+    }
+    assert!(
+        registry.identity_probe_rows().is_empty(),
+        "no terminal may spawn"
+    );
+}
+
+/// ejh6: a duplicate-requestId replay carrying the legacy field gets
+/// `INVALID_MESSAGE`, not the cached `terminal.created` — the raw guard fires
+/// BEFORE `create_dedupe.begin`.
+#[tokio::test]
+async fn legacy_reject_ws_duplicate_request_id_with_legacy() {
+    let (url, registry) = spawn_server().await;
+    let (mut ws, _inv) = connect_and_capture_inventory(&url).await;
+    // First: a successful shell create to seed the dedupe cache.
+    send_create(
+        &mut ws,
+        json!({
+            "type": "terminal.create", "requestId": "req-dup-seed",
+            "mode": "shell", "shell": "system", "cwd": std::env::temp_dir().to_string_lossy(),
+        }),
+    )
+    .await;
+    let _created = next_frame_of_type(&mut ws, "terminal.created").await;
+    // Replay: same requestId but carrying legacy — must get INVALID_MESSAGE,
+    // not the cached terminal.created.
+    send_create(
+        &mut ws,
+        json!({
+            "type": "terminal.create", "requestId": "req-dup-seed",
+            "mode": "claude", "shell": "system", "cwd": std::env::temp_dir().to_string_lossy(),
+            "resumeSessionId": "legacy-dup",
+        }),
+    )
+    .await;
+    let err = expect_refusal_for(&mut ws, "req-dup-seed").await;
+    assert_eq!(
+        err["code"],
+        json!("INVALID_MESSAGE"),
+        "duplicate replay with legacy must reject: {err}"
+    );
+    assert_eq!(
+        err["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+    );
+    registry.kill_all();
+}
+
+/// ejh6: restore:true + codex + legacy is rejected BEFORE
+/// `spawn_gated_restore_create` / `prepare_launch` — no disk-gate planning,
+/// no sidecar planning slot burned.
+#[tokio::test]
+async fn legacy_reject_ws_restore_codex_legacy() {
+    let (url, registry) = spawn_server().await;
+    let (mut ws, _inv) = connect_and_capture_inventory(&url).await;
+    send_create(
+        &mut ws,
+        json!({
+            "type": "terminal.create", "requestId": "req-restore-codex-legacy",
+            "mode": "codex", "shell": "system", "cwd": std::env::temp_dir().to_string_lossy(),
+            "restore": true, "resumeSessionId": "thread-raw-restore-codex",
+        }),
+    )
+    .await;
+    let err = expect_refusal_for(&mut ws, "req-restore-codex-legacy").await;
+    assert_eq!(
+        err["code"],
+        json!("INVALID_MESSAGE"),
+        "restore+codex+legacy must reject before disk gate: {err}"
+    );
+    assert_eq!(
+        err["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+    );
+    assert!(
+        registry.identity_probe_rows().is_empty(),
+        "no terminal may spawn"
+    );
+}
+
+/// ejh6: a `codingcli.create` carrying the legacy field hits the raw-Value
+/// guard with `INVALID_MESSAGE` + frozen text. Rust has no codingcli handler
+/// (the `_ => true` arm of the dispatch) — without the guard this silently
+/// no-ops; the guard is the loud rejector.
+#[tokio::test]
+async fn legacy_reject_ws_codingcli_create() {
+    let (url, _registry) = spawn_server().await;
+    let (mut ws, _inv) = connect_and_capture_inventory(&url).await;
+    send_create(
+        &mut ws,
+        json!({
+            "type": "codingcli.create", "requestId": "req-codingcli-legacy",
+            "prompt": "hi", "provider": "claude",
+            "resumeSessionId": "legacy-codingcli",
+        }),
+    )
+    .await;
+    let err = expect_refusal_for(&mut ws, "req-codingcli-legacy").await;
+    assert_eq!(err["code"], json!("INVALID_MESSAGE"), "{err}");
+    assert_eq!(
+        err["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
     );
 }

--- a/crates/freshell-ws/tests/pane_ledger_triggers.rs
+++ b/crates/freshell-ws/tests/pane_ledger_triggers.rs
@@ -157,7 +157,7 @@ async fn failed_claude_resume_create_leaves_prior_binding_row_untouched() {
         "requestId": "req-resume-loser",
         "mode": "claude",
         "shell": "system",
-        "resumeSessionId": session_id,
+        "sessionRef": { "provider": "claude", "sessionId": session_id },
         "cwd": std::env::temp_dir().to_string_lossy(),
     });
     ws.send(WsMessage::Text(create.to_string())).await.unwrap();

--- a/crates/freshell-ws/tests/resume_validation_gate.rs
+++ b/crates/freshell-ws/tests/resume_validation_gate.rs
@@ -276,6 +276,31 @@ fn assert_never_captured(path: &std::path::Path) {
     }
 }
 
+/// Scope guard owning a test's teardown (registry kill, env-var removal,
+/// evidence-file deletion) so the zero-side-effect pins can run BEFORE the
+/// files are deleted while cleanup is still guaranteed: on a RED pin the
+/// assertion panic unwinds through this guard's Drop and the teardown runs
+/// anyway. Delta-review Fix B (ejh6) — previously the files were deleted
+/// before `assert_never_captured`, so the assertions passed even when a
+/// sidecar or CLI child had written them.
+struct AssertBeforeCleanupGuard<'a> {
+    registry: &'a freshell_terminal::TerminalRegistry,
+    evidence_files: Vec<std::path::PathBuf>,
+}
+
+impl Drop for AssertBeforeCleanupGuard<'_> {
+    fn drop(&mut self) {
+        self.registry.kill_all();
+        std::env::remove_var("CODEX_CMD");
+        std::env::remove_var("CODEX_ARGV_CAPTURE_PATH");
+        std::env::remove_var("FAKE_CODEX_APP_SERVER_ARG_LOG");
+        std::env::remove_var("CODEX_HOME");
+        for path in &self.evidence_files {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
 /// Managed-codex harness: modeled line-for-line on `spawn_server_with_probe`
 /// with exactly one difference — the CLI specs are the REAL codex spec only
 /// (no sleeper specs), so the resolver takes the env_var codex branch and
@@ -1018,15 +1043,15 @@ async fn managed_default_legacy_codex_carrier_never_consults_gate_or_plans() {
 
     let gate_consulted = probe.planning_started_before_gate.lock().unwrap().is_some();
 
-    // Cleanup BEFORE the zero-side-effect assertions so a RED run still
-    // tears down.
-    registry.kill_all();
-    std::env::remove_var("CODEX_CMD");
-    std::env::remove_var("CODEX_ARGV_CAPTURE_PATH");
-    std::env::remove_var("FAKE_CODEX_APP_SERVER_ARG_LOG");
-    std::env::remove_var("CODEX_HOME");
-    let _ = std::fs::remove_file(&capture_path);
-    let _ = std::fs::remove_file(&planning_marker);
+    // THE pins run BEFORE the evidence files are deleted, with the teardown
+    // owned by a scope guard so a RED run still cleans up on unwind (see
+    // AssertBeforeCleanupGuard). Asserting before deletion is the load-bearing
+    // ordering: the never-captured pins must observe the filesystem while a
+    // violation is still visible.
+    let _teardown = AssertBeforeCleanupGuard {
+        registry: &registry,
+        evidence_files: vec![capture_path.clone(), planning_marker.clone()],
+    };
 
     // THE pins: the gate NEVER consulted the probe for the legacy carrier,
     // and neither the managed-planning sidecar (arg-log marker) nor a TUI

--- a/crates/freshell-ws/tests/resume_validation_gate.rs
+++ b/crates/freshell-ws/tests/resume_validation_gate.rs
@@ -206,8 +206,6 @@ async fn spawn_server_with_probe(
 
 // ── seam 5a pieces (DEV-0006 S5) — copied from codex_managed_launch_e2e.rs ──
 
-const RECV_TIMEOUT: Duration = Duration::from_secs(20);
-
 /// Real codex CliCommandSpec (env_var seam) — copied from
 /// codex_managed_launch_e2e.rs so the resolver takes the REAL codex branch
 /// and managed-launch planning engages.
@@ -262,19 +260,16 @@ fn write_codex_dispatcher() -> std::path::PathBuf {
     dispatcher
 }
 
-/// Poll the capture file the dispatcher writes until it appears, then parse
-/// the argv — verbatim from codex_managed_launch_e2e.rs (a SYNC helper).
-fn wait_for_captured_argv(path: &std::path::Path) -> Vec<String> {
-    let deadline = std::time::Instant::now() + RECV_TIMEOUT;
-    loop {
-        if let Ok(raw) = std::fs::read_to_string(path) {
-            if !raw.is_empty() {
-                return serde_json::from_str(&raw).expect("captured argv is a JSON array");
-            }
-        }
+/// Bounded NEGATIVE argv-capture check: the dispatcher writes the capture
+/// file SYNCHRONOUSLY at child spawn, so its absence after a short window
+/// proves no codex child ever launched — the door rejection has zero side
+/// effects (no spawn, no planning slot burned).
+fn assert_never_captured(path: &std::path::Path) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
         assert!(
-            std::time::Instant::now() < deadline,
-            "spawned codex child never wrote its argv capture at {}",
+            !path.exists(),
+            "a create rejected at the door must never spawn a codex child: {}",
             path.display()
         );
         std::thread::sleep(Duration::from_millis(50));
@@ -690,15 +685,15 @@ async fn restore_true_live_legacy_resume_id_is_refused_invalid_message() {
 }
 
 /// Case 6 — the ASYNC sidecar arm of the cross-kind liveness join: liveness
-/// held ONLY by the fresh-agent sidecar (no registry/identity owner). Codex
-/// is exempt from the case-5 legacy-restore refusal (Node's refusal excludes
-/// codex too), so this carrier reaches D7 — whose legacy-rung promotion +
-/// Task 13b sidecar arm now refuse it loudly, protecting live zero-turn
-/// sessions with no rollout on disk yet
-/// (`freshell-server/src/existence.rs:224-227`) from a second writer. The
-/// live session is never gated stale — its Bound row survives.
+/// held ONLY by the fresh-agent sidecar (no registry/identity owner).
+/// Pre-ejh6 codex was exempt from the case-5 legacy-restore refusal, so
+/// this carrier reached D7's loud liveness reject; post-ejh6 the uniform
+/// any-carry door guard (raw pre-parse, `handle_client_text`) rejects the
+/// legacy carrier FIRST — `INVALID_MESSAGE` + frozen text — before any
+/// sidecar liveness consult. The live session is never touched: its Bound
+/// row survives.
 #[tokio::test(flavor = "multi_thread")]
-async fn restore_true_sidecar_live_legacy_resume_id_is_refused_by_d7() {
+async fn restore_true_sidecar_live_legacy_resume_id_is_refused_at_the_door() {
     // DEV-0006 S5.e: the managed-launch default is ON; this suite exercises the
     // plain-CLI codex path (sleeper CLI spec, no app-server), so pin OFF.
     std::env::set_var("FRESHELL_CODEX_MANAGED_LAUNCH", "0");
@@ -756,12 +751,14 @@ async fn restore_true_sidecar_live_legacy_resume_id_is_refused_by_d7() {
         frame["type"], "error",
         "a sidecar-live legacy carrier must be refused (one writer per thread): {frame}"
     );
-    assert_eq!(frame["code"], "RESTORE_UNAVAILABLE", "{frame}");
-    assert!(
-        frame["message"]
-            .as_str()
-            .is_some_and(|m| m.contains("still running")),
-        "D7's own rejection message must answer: {frame}"
+    assert_eq!(
+        frame["code"], "INVALID_MESSAGE",
+        "codex is no longer exempt from the legacy-field reject: {frame}"
+    );
+    assert_eq!(
+        frame["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+        "frozen text: {frame}"
     );
     assert_eq!(
         ledger
@@ -777,14 +774,14 @@ async fn restore_true_sidecar_live_legacy_resume_id_is_refused_by_d7() {
     std::env::remove_var("FAKE_CODEX_APP_SERVER_BEHAVIOR");
 }
 
-/// Case 7 — gate-before-plan ordering pin (managed-launch default ON): a
-/// definitively-absent codex resume id at the WS door is gated (fresh spawn
-/// + notice) BEFORE managed-launch planning — the stale id never reaches the
-/// plan, so it can never burn a sidecar planning slot. The fresh spawn still
-/// goes managed (`--remote` argv) with NO resume tokens.
+/// Case 7 (post-ejh6) — the definitively-absent codex LEGACY carrier is
+/// rejected at the raw pre-parse guard (managed-launch default ON) with
+/// `INVALID_MESSAGE` + frozen text. Stronger than the old gate-before-plan
+/// pin: the carrier never reaches the gate OR managed-launch planning — no
+/// codex child ever spawns (the dispatcher's argv capture never appears).
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "host-gated e2e (needs node + repo node_modules); mutates process env — run alone with --ignored --test-threads=1"]
-async fn managed_default_stale_codex_id_is_gated_before_planning() {
+async fn managed_default_legacy_codex_carrier_is_rejected_before_any_planning() {
     // Managed leg: the flag stays UNSET (default ON). remove_var, not "1",
     // mirroring codex_managed_launch_e2e.rs's managed phases.
     std::env::remove_var("FRESHELL_CODEX_MANAGED_LAUNCH");
@@ -817,47 +814,37 @@ async fn managed_default_stale_codex_id_is_gated_before_planning() {
     let (mut ws, _inv) = common::connect_and_capture_inventory(&url).await;
     // terminal.create with restore:true carrying the stale codex resume id —
     // the legacy resume-id carrier shape (case 6), minus its live-sidecar
-    // arrangement: here NOTHING is live, so the gate must fire.
+    // arrangement: post-ejh6 the raw guard rejects it at the door.
     send_json(
         &mut ws,
         &restore_create_with_legacy_resume_id("req-gate-7", "codex", stale_id),
     )
     .await;
 
-    // 1. Gate fired: terminal.created carries the operator notice naming the stale id.
-    let created = next_created_or_error(&mut ws, "req-gate-7").await;
+    // 1. Rejected at the door: INVALID_MESSAGE + frozen text.
+    let frame = next_created_or_error(&mut ws, "req-gate-7").await;
     assert_eq!(
-        created["type"], "terminal.created",
-        "the gate-fired create must SUCCEED as a fresh spawn, got {created}"
+        frame["type"], "error",
+        "the legacy carrier must be refused, never spawn: {frame}"
     );
-    let notice = notice_of(&created).expect("gate must set the stale-resume notice");
-    assert!(
-        notice.contains(stale_id),
-        "notice names the stale id: {notice}"
-    );
-
-    // 2. The FRESH spawn still went managed (default ON): the captured TUI
-    //    argv is the --remote form...
-    let argv = wait_for_captured_argv(&capture_path);
     assert_eq!(
-        argv[0], "--remote",
-        "fresh spawn must still plan managed launch"
+        frame["code"], "INVALID_MESSAGE",
+        "codex is no longer exempt from the legacy-field reject: {frame}"
+    );
+    assert_eq!(
+        frame["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+        "frozen text: {frame}"
     );
 
-    // 3. ...and the stale resume NEVER reached managed planning: on a managed
-    //    RESUME the `resume <id>` pair rides last in argv (e2e Phase 3 pins
-    //    that). Absence of both tokens proves the plan was Start-intent for a
-    //    fresh session — the stale id never consumed a sidecar planning slot.
-    assert!(
-        !argv.iter().any(|a| a == "resume") && !argv.iter().any(|a| a.contains(stale_id)),
-        "stale id must not appear in managed argv: {argv:?}"
-    );
-
-    // Cleanup (mirror e2e): kill the terminal via the harness, then env.
     registry.kill_all();
     std::env::remove_var("CODEX_CMD");
     std::env::remove_var("CODEX_ARGV_CAPTURE_PATH");
     std::env::remove_var("CODEX_HOME");
+
+    // 2. Zero side effects: no codex child ever launched (the dispatcher
+    //    writes the capture synchronously at spawn).
+    assert_never_captured(&capture_path);
     let _ = std::fs::remove_file(&capture_path);
 }
 
@@ -925,17 +912,15 @@ async fn server_allocated_fresh_amplifier_id_is_never_gated() {
 
 // ── gate-vs-plan ORDER probe (case 7b) ──────────────────────────────────────
 
-/// [`StubProbe`] + a gate-before-plan ORDER latch: on the FIRST `exists`
-/// consult for the watched `(provider, session_id)`, records whether
+/// [`StubProbe`] + a gate-consult latch (post-ejh6 polarity): on the FIRST
+/// `exists` consult for the watched `(provider, session_id)`, records whether
 /// managed-launch planning had ALREADY spawned the codex app-server sidecar
 /// (the fixture's `FAKE_CODEX_APP_SERVER_ARG_LOG` file exists on disk).
 ///
-/// Determinism: the fixture writes the arg-log SYNCHRONOUSLY at process
-/// startup, before it ever listens, and `plan_codex_managed_launch` awaits
-/// the sidecar listening — so by the time any plan completes the marker
-/// exists. Both orderings under test are sequential awaits on the same task
-/// (plan-then-gate pre-fix, gate-then-plan post-fix), so the latch value is
-/// not load-sensitive.
+/// Post-ejh6 the legacy carrier is rejected at the raw pre-parse guard, so
+/// the assertion is the latch's ABSENCE: `None` after the exchange proves
+/// the disk-existence gate was never consulted for the legacy carrier at
+/// all — stronger than the old gate-before-plan ordering pin.
 struct GateOrderProbe {
     provider: String,
     session_id: String,
@@ -960,17 +945,16 @@ impl SessionExistenceProbe for GateOrderProbe {
     }
 }
 
-/// Case 7b — the ORDER behind case 7's pin, made directly observable: the
-/// disk-existence gate must consult the probe for a stale WIRE codex resume
-/// id BEFORE managed-launch planning spawns any app-server sidecar
-/// (gate-before-plan). Post-#589, restore-class codex planning runs
-/// OFF-permit in `prepare_launch`; without an off-permit gate the stale id
-/// undergoes sidecar planning FIRST and the gate only fires afterwards.
-/// Case 7 is blind to that ordering (the stale-planned sidecar is silently
-/// adopted and the TUI argv derives from post-gate state) — this pin is not.
+/// Case 7b — the ZERO-consult invariant behind case 7, made directly
+/// observable: a stale codex legacy carrier must be rejected at the door
+/// with the probe NEVER consulted (`latch == None`) and NO app-server
+/// sidecar ever planned (the fixture's arg-log file never appears).
+/// Post-ejh6 the raw pre-parse guard supersedes the gate-before-plan
+/// ordering this test used to pin: the legacy carrier cannot reach either
+/// stage.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "host-gated e2e (needs node + repo node_modules); mutates process env — run alone with --ignored --test-threads=1"]
-async fn managed_default_stale_codex_id_probe_consulted_before_any_planning() {
+async fn managed_default_legacy_codex_carrier_never_consults_gate_or_plans() {
     // Managed leg: the flag stays UNSET (default ON), mirroring case 7.
     std::env::remove_var("FRESHELL_CODEX_MANAGED_LAUNCH");
 
@@ -1016,34 +1000,26 @@ async fn managed_default_stale_codex_id_probe_consulted_before_any_planning() {
     )
     .await;
 
-    // Preconditions (case 7's own pins): the gate fired as a fresh spawn with
-    // the operator notice…
-    let created = next_created_or_error(&mut ws, "req-gate-7b").await;
+    // Rejected at the door: INVALID_MESSAGE + frozen text.
+    let frame = next_created_or_error(&mut ws, "req-gate-7b").await;
     assert_eq!(
-        created["type"], "terminal.created",
-        "the gate-fired create must SUCCEED as a fresh spawn, got {created}"
+        frame["type"], "error",
+        "the legacy carrier must be refused, never spawn: {frame}"
     );
-    let notice = notice_of(&created).expect("gate must set the stale-resume notice");
-    assert!(
-        notice.contains(stale_id),
-        "notice names the stale id: {notice}"
-    );
-
-    // …and the fresh spawn still went managed — planning DID run (this guards
-    // the ordering latch against a vacuous pass where nothing was planned).
-    let argv = wait_for_captured_argv(&capture_path);
     assert_eq!(
-        argv[0], "--remote",
-        "fresh spawn must still plan managed launch"
+        frame["code"], "INVALID_MESSAGE",
+        "codex is no longer exempt from the legacy-field reject: {frame}"
     );
-    assert!(
-        planning_marker.exists(),
-        "the codex app-server sidecar must have spawned (planning happened)"
+    assert_eq!(
+        frame["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+        "frozen text: {frame}"
     );
 
-    let planning_before_gate = *probe.planning_started_before_gate.lock().unwrap();
+    let gate_consulted = probe.planning_started_before_gate.lock().unwrap().is_some();
 
-    // Cleanup BEFORE the ordering assertion so a RED run still tears down.
+    // Cleanup BEFORE the zero-side-effect assertions so a RED run still
+    // tears down.
     registry.kill_all();
     std::env::remove_var("CODEX_CMD");
     std::env::remove_var("CODEX_ARGV_CAPTURE_PATH");
@@ -1052,18 +1028,14 @@ async fn managed_default_stale_codex_id_probe_consulted_before_any_planning() {
     let _ = std::fs::remove_file(&capture_path);
     let _ = std::fs::remove_file(&planning_marker);
 
-    // THE pin: gate-before-plan. `Some(true)` means the app-server sidecar
-    // was already up when the gate first consulted the probe for the stale
-    // id — i.e. the stale WIRE resume id underwent off-permit
-    // `plan_codex_managed_launch` BEFORE the disk-existence gate could drop
-    // it, and the create then silently inherited the stale-planned sidecar.
-    let planning_before_gate = planning_before_gate
-        .expect("the disk-existence gate must consult the probe for the stale codex id");
+    // THE pins: the gate NEVER consulted the probe for the legacy carrier,
+    // and neither the managed-planning sidecar (arg-log marker) nor a TUI
+    // child (argv capture) ever spawned.
     assert!(
-        !planning_before_gate,
-        "GATE-BEFORE-PLAN VIOLATED: managed-launch planning spawned a codex app-server \
-         sidecar BEFORE the disk-existence gate consulted the probe for stale id \
-         {stale_id} — the stale wire resume id underwent off-permit \
-         plan_codex_managed_launch ahead of the gate"
+        !gate_consulted,
+        "the disk-existence gate must NEVER consult the probe for a legacy carrier \
+         (the raw guard rejects it first) — probe latch was set for stale id {stale_id}"
     );
+    assert_never_captured(&planning_marker);
+    assert_never_captured(&capture_path);
 }

--- a/crates/freshell-ws/tests/session_identity_frames.rs
+++ b/crates/freshell-ws/tests/session_identity_frames.rs
@@ -67,7 +67,7 @@ async fn resume_created_terminal_frames_carry_session_ref() {
             "mode": "amplifier",
             "shell": "system",
             "cwd": std::env::temp_dir().to_string_lossy(),
-            "resumeSessionId": "sess-identity-1",
+            "sessionRef": { "provider": "amplifier", "sessionId": "sess-identity-1" },
         })
         .to_string(),
     ))

--- a/docs/index.html
+++ b/docs/index.html
@@ -425,6 +425,7 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
 .sv-session-time { font-size: 12px; color: hsl(var(--muted-foreground)); margin-left: auto; }
 .sv-session-summary { font-size: 12px; color: hsl(var(--muted-foreground)); margin-top: 4px; line-height: 1.5; }
 .sv-session-cwd { font-size: 11px; color: var(--t-dim); margin-top: 3px; font-family: 'JetBrains Mono', monospace; }
+.sv-footnote { padding: 10px 16px; font-size: 11px; color: hsl(var(--muted-foreground)); border-top: 1px solid hsl(var(--border) / .5); }
 
 /* ========== Fresh Agent Mock ========== */
 .fresh-mock { flex: 1; min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr) minmax(220px, 260px); overflow: hidden; background: hsl(var(--background)); }
@@ -824,10 +825,9 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
               <div class="sv-project-header"><div class="sv-project-dot" style="background:#f97316"></div><span class="sv-project-name">freshell-web</span><span class="sv-project-count">1 session</span><i data-lucide="chevron-right" class="icon sv-project-chevron"></i></div>
             </div>
           </div>
+          </div>
+          <div class="sv-footnote">Restoring a session from history uses the current session identity (sessionRef) — requests carrying the deprecated resumeSessionId field are refused with a clear error instead of being silently ignored.</div>
         </div>
-      </div>
-
-      <!-- Fresh Agent -->
       <div class="tab-panel" id="panel-start">
         <div class="pane">
           <div class="pane-header active"><svg class="icon" viewBox="-0.27 -0.23 16.55 16.55" fill="currentColor"><path d="M14.949 6.547a3.94 3.94 0 0 0-.348-3.273 4.11 4.11 0 0 0-4.4-1.934A4.1 4.1 0 0 0 8.423.2 4.15 4.15 0 0 0 6.305.086a4.1 4.1 0 0 0-1.891.948 4.04 4.04 0 0 0-1.158 1.753 4.1 4.1 0 0 0-1.563.679A4 4 0 0 0 .554 4.72a3.99 3.99 0 0 0 .502 4.731 3.94 3.94 0 0 0 .346 3.274 4.11 4.11 0 0 0 4.402 1.933c.382.425.852.764 1.377.995.526.231 1.095.35 1.67.346 1.78.002 3.358-1.132 3.901-2.804a4.1 4.1 0 0 0 1.563-.68 4 4 0 0 0 1.14-1.253 3.99 3.99 0 0 0-.506-4.716m-6.097 8.406a3.05 3.05 0 0 1-1.945-.694l.096-.054 3.23-1.838a.53.53 0 0 0 .265-.455v-4.49l1.366.778q.02.011.025.035v3.722c-.003 1.653-1.361 2.992-3.037 2.996m-6.53-2.75a2.95 2.95 0 0 1-.36-2.01l.095.057L5.29 12.09a.53.53 0 0 0 .527 0l3.949-2.246v1.555a.05.05 0 0 1-.022.041L6.473 13.3c-1.454.826-3.311.335-4.15-1.098m-.85-6.94A3.02 3.02 0 0 1 3.07 3.949v3.785a.51.51 0 0 0 .262.451l3.93 2.237-1.366.779a.05.05 0 0 1-.048 0L2.585 9.342a2.98 2.98 0 0 1-1.113-4.094zm11.216 2.571L8.747 5.576l1.362-.776a.05.05 0 0 1 .048 0l3.265 1.86a3 3 0 0 1 1.173 1.207 2.96 2.96 0 0 1-.27 3.2 3.05 3.05 0 0 1-1.36.997V8.279a.52.52 0 0 0-.276-.445m1.36-2.015-.097-.057-3.226-1.855a.53.53 0 0 0-.53 0L6.249 6.153V4.598a.04.04 0 0 1 .019-.04L9.533 2.7a3.07 3.07 0 0 1 3.257.139c.474.325.843.778 1.066 1.303.223.526.289 1.103.191 1.664zM5.503 8.575 4.139 7.8a.05.05 0 0 1-.026-.037V4.049c0-.57.166-1.127.476-1.607s.752-.864 1.275-1.105a3.08 3.08 0 0 1 3.234.41l-.096.054-3.23 1.838a.53.53 0 0 0-.265.455zm.742-1.577 1.758-1 1.762 1v2l-1.755 1-1.762-1z"/></svg><span class="pane-header-title">Freshcodex</span><span class="pane-header-meta">~/code/freshell</span><div class="pane-btns"><span class="pane-btn"><i data-lucide="refresh-cw" class="icon-xs"></i></span><span class="pane-btn"><i data-lucide="settings" class="icon-xs"></i></span><span class="pane-btn"><i data-lucide="maximize-2" class="icon-xs"></i></span><span class="pane-btn"><i data-lucide="x" class="icon-xs"></i></span></div></div>

--- a/docs/plans/2026-08-16-legacy-resume-guard.md
+++ b/docs/plans/2026-08-16-legacy-resume-guard.md
@@ -37,7 +37,7 @@ Implement kata issue ejh6 (revised 2026-08-16 spec: "Remove the legacy resumeSes
 - **Never weaken tests:** never delete a behavior test without a replacement; never mark tests skip; never simplify assertions to get green.
 - **Coordinated runners:** Node tests via `npm run test:vitest -- run <paths> --config <config>` (default config `config/vitest/vitest.config.ts`, server config `config/vitest/vitest.server.config.ts`); Rust via `cargo test -p <crate>` focused, `cargo test --workspace` as gate; `npm run check` (typecheck + coordinated full suite) as final gate.
 - **Rejection mechanism:** handler-level only. Never use `.strict()`/`deny_unknown_fields`/serde field removal as the rejection mechanism (zod non-strict strips silently; `.strict()` rejects with a generic unrecognized-key error that cannot carry the frozen text). The field stays DECLARED in every schema/struct.
-- **Presence-based rejection (coordinator ruling, review findings 2+8+T6-redesign):** rejection is PRESENCE-based, not non-empty. The contract is "any create that CARRIES the field." **REST doors** (raw `Value`/`req.body`, full presence — string, empty, null, number, object): reject at handler with the frozen text (`body.get("resumeSessionId").is_some()` in Rust; `req.body?.resumeSessionId !== undefined` in Node). **WS doors:** the two servers differ by construction library behavior and both are loud: (i) **Node** — typed `z.string().optional()` fields: any string (incl. `""`) reaches the handler reject (`m.resumeSessionId !== undefined` → frozen text); a non-string (null, 42, object) fails zod parse at the boundary BEFORE the handler and gets `error{INVALID_MESSAGE}` with the parser's generic text (verified `server/ws-handler.ts:1913-1916`) — code loud, text generic, by design (frozen text names the legacy migration for string-typed callers). Tests null/42 pin the CODE on `terminal.create` only. (ii) **Rust** — the typed-struct approach is UNACCEPTABLE there (verified: serde `Option<String>` absorbs JSON `null` into `None` → silent accept; and a non-string value fails the `from_value` parse into the accept-and-strip `else { return true }` arm at `crates/freshell-ws/src/terminal.rs:651` → total silent drop, no terminal, no error). Rust therefore implements a **raw-Value pre-parse guard** in `terminal.rs` dispatch (before the typed `from_value`, before dedupe/restore planning): `value.get("type") ∈ {terminal.create, codingcli.create} + resumeSessionId key present (any JSON value, incl. null) → error INVALID_MESSAGE + frozen text; Task 7 extends the same guard with the freshAgent arms (create.failed envelope / event channel). Rust WS presence is full (any value) with frozen text for all of them; pin cases: `"legacy"`, `""`, `null`, `42` all → INVALID_MESSAGE + frozen text on terminal.create. All draft checks and tests must use presence, not `is_some_and(|s| !s.is_empty())` / `isNonEmptyString` / truthiness.
+- **Presence-based rejection (coordinator ruling, review findings 2+8+R3.1 — UNIFORM raw pre-parse presence guard):** rejection is PRESENCE-based, not non-empty: "any create that CARRIES the field", at every door, with the frozen text and the door-family envelope for EVERY JSON value type (string, empty, null, number, object). **REST doors** (raw `Value`/`req.body`): reject at the door-top (`body.get("resumeSessionId").is_some()` in Rust; `req.body && 'resumeSessionId' in req.body` / presence in Node). **WS doors on BOTH servers: a raw pre-parse presence guard**, placed BEFORE schema/typed parse, BEFORE dedupe/restore planning (zero side effects on reject): key-presence on the raw parsed frame decides. Rationale: typed layers cannot do this — zod `z.string().optional()` rejects null/42 generically (loses the required frozen text and, for freshAgent doors, the required create-failed family envelope), and serde `Option<String>` absorbs `null` into `None` while non-strings get silently dropped by the accept-and-strip arm. Node guard site: `server/ws-handler.ts` right before `this.clientMessageSchema.safeParse(msg)` (`:1913`); Rust guard site: after the `tabs.sync.*` fast-path and before `from_value` (`crates/freshell-ws/src/terminal.rs` dispatch). Per-family envelopes from the raw frame: `terminal.create` + `codingcli.create` → `error{INVALID_MESSAGE}` + frozen text; `freshAgent.create` → `freshAgent.create.failed{code FRESH_AGENT_CREATE_FAILED, frozen text, retryable:false}` (requestId from raw); `freshAgent.attach` → Rust rides `freshAgent.event{freshAgent.error}` (keyed by sessionId; UI-visible), Node rides `error{code FRESH_AGENT_CREATE_FAILED}` (socket-loud/UI-invisible — accepted asymmetry, coordinator ruling A). Wire schemas/structs keep `resumeSessionId: z.string().optional()`/`Option<String>` declared for parse retention only — the guard, not the schema, owns the contract. All draft checks use presence, never truthiness/`isNonEmptyString`/`is_some_and(non-empty)`. Tests: every door pins frozen text for `""` + ordinary strings; terminal.create null/42/object pinned on both servers (frozen text — the guard is raw); REST null/42 on all three routes both servers.
 - **Door-top REST rejection (coordinator ruling, review finding 3):** REST rejection runs at the TOP of each route handler in BOTH servers, BEFORE any branch (agent/browser/editor/terminal) and BEFORE `layout.split_pane` in the split route. In Node, check `req.body?.resumeSessionId !== undefined` at the top of `POST /tabs`, `POST /panes/:id/split`, `POST /panes/:id/respawn`; `requestedResumeSessionIdForMode` keeps its sessionRef-resolution role but no longer throws (single check at door-top for KISS). In Rust, check `body.get("resumeSessionId").is_some()` at each axum handler entry in `terminal_tabs.rs`/`pane_ops.rs` before any branch or layout mutation. Tests: pane/layout unchanged on rejected split; browser/editor branches also 400.
 - **Section 3c doc comment:** every retained `resumeSessionId`/`resume_session_id` field in a wire schema/struct gets the comment `Retained solely so the handler can detect-and-reject; see kata ejh6.` — EXCEPT `ReconcilePane.resume_session_id` which gets the PERMANENT compat-door comment.
 - **`restoreKey` gating:** blanket REST reject does NOT gate on `restoreKey` — no production producer emits it (verified), so blanket reject regresses nothing live (binding correction A).
@@ -61,6 +61,8 @@ J) Repo rules: worktree-only; coordinated runners (`npm run test:vitest -- run <
 K) V5's six-site omission correction: Task 3 must absorb `amplifier_launcher_identity.rs:148` (mechanical re-carrier), `claude_session_rebind.rs:546` (mechanical), `freshagent_claude_attach.rs:559` (third attach site, mechanical), and `terminal_tabs.rs:6334` (11th REST body — mechanical IF contract-neutral, else into Task 5 as a rejection assertion). Three premise-inversion sites route to behavior tasks: `amplifier_launcher_identity.rs:341` (expects RESTORE_UNAVAILABLE → becomes INVALID_MESSAGE — into Task 6), `codex_session_ref_resume.rs:363-381` (codex raw-legacy acceptance — into Task 6 as a rejection test), `cross_kind_liveness.rs:411,:460` (dual-carrier freshAgent.create sends — into Task 7: the SESSION_RESERVED dual-carrier assertion flips to the create-failed envelope; setup carry gets mechanically re-carriered).
 L) Uniform any-carry REST ruling (coordinator final): REST seams (`derive_resume_identity`, `requestedResumeSessionIdForMode`) throw whenever the wire `resumeSessionId` is present, even when `sessionRef` is also present — no first-party sender dual-carries. The codex dual-carrier tolerance at `server/coding-cli/codex-app-server/restore-decision.ts:40` is retired by this change. Tasks 5 and 8 check legacy BEFORE the sessionRef early-return. Existing REST dual-carrier acceptance assertions, if any, become rejection assertions.
 M) `ErrorCode` enum addition (validator V2 found Task 10's draft would not typecheck): add `FRESH_AGENT_CREATE_FAILED` to the shared `ErrorCode` enum in `shared/ws-protocol.ts:20-37`. Node attach rejection emits `error{FRESH_AGENT_CREATE_FAILED}` matching the existing attach error shape. Note the asymmetry: Node attach rejection is socket-loud but UI-invisible (no client consumer for requestId-less `error` frames — verified by V2's exhaustive sweep), while Rust's rides `freshAgent.event{freshAgent.error}` which the client renders. Kata §1c is satisfied (code family is what it names). Task 13 adds a typecheck step to catch drift.
+
+N) **Final WS door design (post-rounds-2/3; supersedes the "head-of-case"-style wording in B/D above):** BOTH servers reject at a raw pre-parse presence guard — Rust in `crates/freshell-ws/src/terminal.rs` dispatch after the tabs.sync fast-path and before `from_value` (Task 6 arms terminal.create + codingcli.create; Task 7 arms freshAgent.create/.attach), Node in `server/ws-handler.ts` after JSON.parse and before `clientMessageSchema.safeParse(msg)` at :1913 (Task 9 arms terminal.create; Task 10 arms freshAgent.*; Task 11 arms codingcli.create). Full presence for every JSON value incl. null/42 with frozen text + per-family envelopes; typed schemas keep the field DECLARED (retention + section 3c comments) but the guard, not the schema, owns the contract. (The typed-layer first attempt was invalidated by review round 2 finding 8 — serde absorbs `null` into `None` and accept-and-strip drops non-strings — and review round 3 finding 1, which ruled Node's zod parse-boundary generic-text residual non-compliant for family envelopes.)
 
 ---
 
@@ -617,17 +619,37 @@ async fn legacy_reject_respawn() {
 Re-carrier `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` (finding 6: DO NOT delete the ~110 lines of behavior coverage. RE-CARRIER the send at `:197-206` from `resumeSessionId: SEEDED_SESSION_ID` to `sessionRef: { provider: 'amplifier', sessionId: SEEDED_SESSION_ID }`, KEEP every downstream assertion (resume argv, live broadcast, sidebar linkage, click dedupe, title sync, persisted sessionRef, restart/reload restoration, post-restart resume) as sessionRef-carrier behavior coverage, then APPEND one new rejection-focused case at the end of the describe block:
 
 ```ts
-  it('rejects a bare legacy resumeSessionId on REST create with 400 + frozen text (kata ejh6)', async () => {
-    const res = await fetch(`${info.baseUrl}/api/tabs`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-auth-token': info.token },
-      body: JSON.stringify({ mode: 'amplifier', cwd: projectDir, resumeSessionId: SEEDED_SESSION_ID, name: 'legacy-reject-case' }),
+  // Review round 3 findings 3/7: this spec imports `test` (not `it`) from
+  // '../helpers/fixtures.js'; the big test's locals (info, projectDir,
+  // SEEDED_SESSION_ID) are out of scope here, so this case boots its OWN
+  // minimal rust server (no amplifier fixtures needed — the rejection fires
+  // at the door before any mode work), and asserts frozen text PLUS no
+  // visible creation: /api/tabs before/after equality (no spawn, no tab).
+  test('rejects a bare legacy resumeSessionId on REST create with 400 + frozen text (kata ejh6)', async ({ e2eServerKind }) => {
+    expect(e2eServerKind).toBe('rust')
+    const server = await createE2eServerHandle(process.env, {
+      kind: e2eServerKind,
+      construct: {}, // no fixtures: door-top reject needs no provider state — verify the construct type allows empty at implementation time and seed minimally if not
     })
-    expect(res.status).toBe(400)
-    const body = await res.json()
-    expect(body.status).toBe('error')
-    expect(body.message).toContain('sessionRef')
-    expect(body.message).toContain('resumeSessionId')
+    const info = await server.start()
+    try {
+      const before = await (await fetch(`${info.baseUrl}/api/tabs`, { headers: { 'x-auth-token': info.token } })).json()
+      const res = await fetch(`${info.baseUrl}/api/tabs`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-auth-token': info.token },
+        body: JSON.stringify({ mode: 'amplifier', cwd: '/tmp', resumeSessionId: 'amp-legacy-reject-0001', name: 'legacy-reject-case' }),
+      })
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body).toEqual({
+        status: 'error',
+        message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+      })
+      const after = await (await fetch(`${info.baseUrl}/api/tabs`, { headers: { 'x-auth-token': info.token } })).json()
+      expect(after).toEqual(before) // no tab/terminal side effects on reject
+    } finally {
+      await server.stop()
+    }
   })
 ```
 
@@ -635,9 +657,9 @@ Add `/remote-tab-linkage-rust\.spec\.ts$/` to `RUST_ONLY_SPECS` at `test/e2e-bro
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
-Run: `cargo test -p freshell-freshagent legacy_reject_`
+Run: `cargo test -p freshell-freshagent legacy_reject_ && cargo test -p freshell-freshagent does_not_synthesize`
 
-Expected: FAIL because the non-codex modes silently accept the legacy field, the browser/editor branches bypass the check entirely, and the split door mutates the layout before reaching `spawn_terminal_pane` — the tests get 200/approx instead of 400, and the layout-unchanged assertion fails.
+Expected: FAIL because the non-codex modes silently accept the legacy field, the browser/editor branches bypass the check entirely, and the split door mutates the layout before reaching `spawn_terminal_pane` — the tests get 200/approx instead of 400, the layout-unchanged assertion fails, and the EDEV-07 trio (now rejection assertions) gets 200 instead of 400.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
@@ -731,7 +753,7 @@ git commit -m "feat(ejh6): Rust REST door-top presence reject + section 3c docs 
 
 ---
 
-### Task 6: Rust WS `terminal.create` reject — hoist blanket gate to head of `handle_create` + reconcile permanent-compat doc
+### Task 6: Rust WS `terminal.create`/codingcli reject — raw-Value pre-parse guard at dispatch + reconcile permanent-compat doc
 
 **Files:**
 - Modify: `crates/freshell-ws/src/terminal.rs:693` (insert blanket reject at the EARLIEST post-parse point in the `ClientMessage::TerminalCreate` dispatch arm — BEFORE `create_dedupe.begin` at `:699` and BEFORE `spawn_gated_restore_create` at `:735`, per finding 4: a restore:true codex carrying legacy must be rejected before any disk-gate planning)
@@ -1541,13 +1563,12 @@ Add presence-edge and dual-intent tests (findings 2, 5):
     }
   })
 
-  // ejh6 review round 2 finding 8 (layered WS presence): a NON-STRING legacy
-  // value never reaches the handler — the dynamic `.strict()` schema's
-  // `resumeSessionId: z.string().optional()` fails zod parse first, producing
-  // error{INVALID_MESSAGE} with the parser's generic text (ws-handler.ts:1913-1916).
-  // Pin the CODE loudly, NOT the text (frozen text belongs to string carries).
+  // ejh6 review round 3 finding 1: the raw pre-parse guard intercepts ANY
+  // JSON value with key-presence BEFORE zod ever runs — non-string carries
+  // get the SAME INVALID_MESSAGE + frozen-text envelope as strings on Node
+  // (no generic-text residual). Every value pinned with frozen text.
   it.each([['null', null], ['number', 42], ['object', { nested: true }]])(
-    'rejects non-string resumeSessionId (%s) at the parse boundary with INVALID_MESSAGE', async (_label, val) => {
+    'rejects non-string resumeSessionId (%s) with INVALID_MESSAGE + frozen text (raw guard)', async (_label, val) => {
       const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
       try {
         await waitForOpen(ws)
@@ -1556,7 +1577,11 @@ Add presence-edge and dual-intent tests (findings 2, 5):
         const errorPromise = waitForMessage(ws, (m) => m.type === 'error' && m.requestId === requestId)
         ws.send(JSON.stringify({ type: 'terminal.create', requestId, mode: 'claude', shell: 'system', resumeSessionId: val }))
         const error = await errorPromise
-        expect(error).toMatchObject({ type: 'error', code: 'INVALID_MESSAGE', requestId })
+        expect(error).toMatchObject({
+          type: 'error', code: 'INVALID_MESSAGE',
+          message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+          requestId,
+        })
         expect(registry.createCalls).toHaveLength(0)
       } finally {
         await closeWebSocket(ws)
@@ -1624,8 +1649,8 @@ import { WS_PROTOCOL_VERSION } from '../../shared/ws-protocol.js'
     const handler = new WsHandler(server, registry, { codexLaunchPlanner } as never)
     await new Promise<void>((resolve) => server.listen(0, () => resolve()))
     const { port } = server.address() as { port: number }
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
     try {
-      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
       await new Promise<void>((resolve, reject) => {
         ws.on('open', () => {
           ws.send(JSON.stringify({ type: 'hello', token: 'test-token', protocolVersion: WS_PROTOCOL_VERSION }))
@@ -1670,26 +1695,35 @@ Expected: FAIL because the current scoped gate only rejects restore+non-codex+le
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Insert the blanket reject at the VERY TOP of the `case 'terminal.create':` block at `server/ws-handler.ts:2041` (finding 5: BEFORE `recordSessionLifecycleEvent` at `:2048` and BEFORE the `fresh_after_restore_unavailable` validation at `:2060` — so a message carrying both `recoveryIntent` and `resumeSessionId` gets `INVALID_MESSAGE` with frozen text, not `INVALID_CREATE_REQUEST`). Per finding 2: presence check (`!== undefined`), not truthiness (`if (m.resumeSessionId)` would miss `""` and `null`):
+Insert the Node raw pre-parse presence guard in `server/ws-handler.ts` immediately AFTER the JSON.parse of the raw frame and BEFORE `const parsed = this.clientMessageSchema.safeParse(msg)` at `:1913`. This task arms ONLY the `terminal.create` family arm (Tasks 10/11 arm freshAgent.*/codingcli.create). Review round 3 finding 1 motivates the raw placement: the field's typed schema (`z.string().optional()`) rejects `null`/`42` at parse time with GENERIC text, losing the frozen text every string carry deserves — a raw key-presence check intercepts ANY JSON value before that, and its timing also answers finding 5 (a message carrying both `recoveryIntent` and `resumeSessionId` gets `INVALID_MESSAGE` + frozen text, not the `INVALID_CREATE_REQUEST` the recovery-intent validation would have produced) and finding-4-style side-effect-freedom (**BEFORE** `recordSessionLifecycleEvent`).
 
 ```ts
-      case 'terminal.create': {
-        // ejh6 (finding 5): reject the legacy resumeSessionId field at the VERY
-        // TOP, BEFORE recordSessionLifecycleEvent and the fresh_after_restore_
-        // unavailable validation — a message carrying both intents gets
-        // INVALID_MESSAGE with frozen text (the mandatory error wins).
-        // LAYERED presence (Global Constraints): `!== undefined` catches any string including ""; null/42 are rejected at the zod parse boundary with INVALID_MESSAGE (generic text).
-        if (m.resumeSessionId !== undefined) {
-          this.sendError(ws, {
-            code: 'INVALID_MESSAGE',
-            message: INVALID_RAW_CODEX_RESUME_MESSAGE,
-            requestId: m.requestId,
-          })
-          return
+      // (insertion point: ws-handler.ts immediately before `const parsed = this.clientMessageSchema.safeParse(msg)` at :1913 — msg here is the raw JSON.parse result)
+      // ejh6 (R3) raw pre-parse presence guard: ANY create-class message
+      // carrying a top-level resumeSessionId — string, empty, null, number,
+      // object — is rejected HERE, before zod parse, so the frozen text and
+      // per-family envelope survive every value type (zod would reject
+      // non-strings generically; a typed field reads strings only). The
+      // wire schemas keep the field declared (retention, comments in this
+      // task) — the guard, not the schema, owns the contract.
+      if (typeof msg === 'object' && msg !== null && 'resumeSessionId' in msg) {
+        const rawMsg = msg as Record<string, unknown>
+        switch (rawMsg.type) {
+          case 'terminal.create': {
+            this.sendError(ws, {
+              code: 'INVALID_MESSAGE',
+              message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+              requestId: typeof rawMsg.requestId === 'string' ? rawMsg.requestId : undefined,
+            })
+            return
+          }
+          // freshAgent.create / freshAgent.attach armed in Task 10;
+          // codingcli.create armed in Task 11.
         }
-        log.debug({
-          // ... existing code unchanged ...
+      }
 ```
+
+Then remove the now-redundant scoped gates at `:2160-2168` and `:2170-2186` (as before — the raw guard fires long before either).
 
 Add the shared `TerminalCreateSchema` field at `shared/ws-protocol.ts:319-332` (finding 1):
 
@@ -1748,7 +1782,7 @@ git commit -m "feat(ejh6): Node WS terminal.create blanket reject (pre-recovery-
 ### Task 10: Node WS `freshAgent.create`/`freshAgent.attach` reject + ErrorCode enum extension
 
 **Files:**
-- Modify: `server/ws-handler.ts:3424` (head of `freshAgent.create` case — insert reject), `:3543` (head of `freshAgent.attach` case — insert reject)
+- Modify: `server/ws-handler.ts:1913` (the Task-9 raw pre-parse guard — extend with the freshAgent.create/freshAgent.attach arms; replaces the per-door head-of-case inserts)
 - Modify: `shared/ws-protocol.ts:20-37` (`ErrorCode` enum — add `FRESH_AGENT_CREATE_FAILED` per V2 finding: Task 10's `sendError({code:'FRESH_AGENT_CREATE_FAILED',...})` would not typecheck against `ErrorCode` without this addition), `:482,:497` (section 3c doc comments)
 - Test: `test/unit/server/ws-handler-fresh-agent.test.ts` (add legacy-carrying create/attach rejection tests)
 
@@ -1848,47 +1882,37 @@ export const ErrorCode = z.enum([
 
 Use the enum's existing alphabetical or logical ordering convention (inspect the current list at `:20-37` and insert in the appropriate position). The string value `'FRESH_AGENT_CREATE_FAILED'` matches the code family kata §1c names and the code Rust uses in its `FreshAgentCreateFailed` envelope.
 
-Insert at the head of the `freshAgent.create` case at `server/ws-handler.ts:3424` (before the manager-missing check at `:3425`):
+Extend the Task-9 raw pre-parse guard in `server/ws-handler.ts` with the freshAgent arms (R3.1 — the head-of-case layer can't see null/42 carries, and review round 3 finding 1 requires the family envelope on every value type). Replace the Task-9 guard's comment tail with:
 
 ```ts
-      case 'freshAgent.create': {
-        // ejh6: reject the legacy resumeSessionId wire field. The canonical
-        // carrier is sessionRef; resumeSessionId stays declared on the shared
-        // schema solely so the handler can detect-and-reject (see kata ejh6).
-        // LAYERED presence (Global Constraints): `!== undefined` catches any string including ""; null/42 are rejected at the zod parse boundary with INVALID_MESSAGE (generic text).
-        if (m.resumeSessionId !== undefined) {
-          this.send(ws, {
-            type: 'freshAgent.create.failed',
-            requestId: m.requestId,
-            code: 'FRESH_AGENT_CREATE_FAILED',
-            message: INVALID_RAW_CODEX_RESUME_MESSAGE,
-            retryable: false,
-          })
-          return
+        switch (rawMsg.type) {
+          case 'terminal.create': {
+            // ... unchanged Task-9 arm ...
+          }
+          // Task 10: freshAgent families. Create rides the provider's
+          // create-failed envelope (requestId from the raw frame); attach has
+          // NO requestId — its rejection rides the attach error frame shape
+          // (sendError) with the FRESH_AGENT_CREATE_FAILED family code (kata
+          // §1c names the code family; binding correction D/ruling A
+          // documents the socket-loud/UI-invisible asymmetry).
+          case 'freshAgent.create': {
+            this.send(ws, {
+              type: 'freshAgent.create.failed',
+              requestId: typeof rawMsg.requestId === 'string' ? rawMsg.requestId : '',
+              code: 'FRESH_AGENT_CREATE_FAILED',
+              message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+              retryable: false,
+            })
+            return
+          }
+          case 'freshAgent.attach': {
+            this.sendError(ws, {
+              code: 'FRESH_AGENT_CREATE_FAILED',
+              message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+            })
+            return
+          }
         }
-        const manager = this.freshAgentRuntimeManager
-        // ... rest unchanged ...
-```
-
-Insert at the head of the `freshAgent.attach` case at `server/ws-handler.ts:3543` (before the manager-missing check at `:3544`):
-
-```ts
-      case 'freshAgent.attach': {
-        // ejh6: reject the legacy resumeSessionId wire field. Attach has no
-        // requestId, so the create-failed family rejection rides the existing
-        // attach error frame shape (sendError) with the FRESH_AGENT_CREATE_
-        // FAILED code — the create-failed family code on the attach error
-        // channel (see kata ejh6, binding correction D).
-        // LAYERED presence (Global Constraints): `!== undefined` catches any string including ""; null/42 are rejected at the zod parse boundary with INVALID_MESSAGE (generic text).
-        if (m.resumeSessionId !== undefined) {
-          this.sendError(ws, {
-            code: 'FRESH_AGENT_CREATE_FAILED',
-            message: INVALID_RAW_CODEX_RESUME_MESSAGE,
-          })
-          return
-        }
-        const manager = this.freshAgentRuntimeManager
-        // ... rest unchanged ...
 ```
 
 Add section 3c doc comments at `shared/ws-protocol.ts:482` (`FreshAgentCreateSchema.resumeSessionId`) and `:497` (`FreshAgentAttachSchema.resumeSessionId`):
@@ -1929,7 +1953,7 @@ git commit -m "feat(ejh6): Node WS freshAgent create/attach reject legacy field"
 
 **Files:**
 - Modify: `shared/ws-protocol.ts:447-458` (`CodingCliCreateSchema` — add `sessionRef`)
-- Modify: `server/ws-handler.ts:802-813` (dynamic codingcli schema — add `sessionRef`), `:808` (section 3c doc comment), `:3290+` (head of `codingcli.create` case — insert reject), `:3318-3326` (promote sessionRef into spawn-time resume id)
+- Modify: `server/ws-handler.ts:802-813` (dynamic codingcli schema — add `sessionRef`), `:808` (section 3c doc comment), `:1913` (the Task-9 raw pre-parse guard — extend with the codingcli.create arm; the reject is config-independent, coordinator ruling J), `:3318-3326` (promote sessionRef into spawn-time resume id)
 - Modify: `crates/freshell-protocol/src/client_messages.rs:429-448` (`CodingCliCreate` — add `session_ref` field; section 3c doc on `resume_session_id`)
 - Modify: `crates/freshell-protocol/tests/roundtrip.rs:309` (extend codingcli roundtrip to include `sessionRef`)
 - Test: `test/server/ws-coding-cli-events.test.ts` (new legacy-reject + sessionRef-promote tests)
@@ -1953,36 +1977,48 @@ Rationale: The spec's scope is `terminal.create`'s spawn-time id, and the sectio
 Add to `test/server/ws-coding-cli-events.test.ts` (model on the existing `createAuthenticatedWs` + `responsePromise` pattern at `:88-128` — that file uses `createAuthenticatedWs()` and `new Promise<any>((resolve) => ws.on('message', ...))`, NOT `connectAndAuth`/`waitForMessage`):
 
 ```ts
-  it('rejects codingcli.create carrying resumeSessionId with INVALID_MESSAGE + frozen text', async () => {
-    // Review round 2 finding 10a: the rejection must ALSO assert no spawn — expose
-    // the suite fake manager's create spy (create the suite's default fake with a
-    // create: vi.fn() spy held in a suite-level binding, or do the same wsHandler
-    // swap the promote test uses; assert `createMock not called` after the error).
-    const ws = await createAuthenticatedWs()
-    const requestId = 'cli-legacy-reject-1'
-    const errorPromise = new Promise<any>((resolve) => {
-      ws.on('message', (data) => {
-        const msg = JSON.parse(data.toString())
-        if (msg.type === 'error' && msg.requestId === requestId) resolve(msg)
-      })
-    })
-    ws.send(JSON.stringify({
-      type: 'codingcli.create', requestId, provider: 'claude', prompt: 'hi',
-      resumeSessionId: 'legacy-cli-id',
-    }))
-    const error = await errorPromise
-    expect(error).toMatchObject({
-      type: 'error', code: 'INVALID_MESSAGE',
-      message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
-      requestId,
-    })
-    expect(createMock).not.toHaveBeenCalled() // no spawn on reject (finding 10a)
-    ws.close()
-  })
+  // Finding 9 (presence on this door too): it.each over string + empty-string.
+  // Finding 10a + review round 3 finding 5: no spawn on reject, with createMock
+  // DECLARED here and the same mid-test wsHandler swap the promote test uses
+  // (the suite's default is a real manager — never instantiate it, V4).
+  it.each([['string', 'legacy-cli-id'], ['empty-string', '']])(
+    'rejects codingcli.create resumeSessionId (%s) with INVALID_MESSAGE + frozen text and no spawn', async (_label, legacy) => {
+      const createMock = vi.fn()
+      class FakeSession extends EventEmitter {
+        id = 'cli-session-reject'
+        provider = { name: 'claude' }
+      }
+      const fakeManager = {
+        create: (...args: any[]) => { createMock(...args); return new FakeSession() },
+        hasProvider: (name: string) => name === 'claude',
+        get: vi.fn(),
+        remove: vi.fn(),
+      } as unknown as CodingCliSessionManager
+      wsHandler.close()
+      wsHandler = new WsHandler(server, registry, { codingCliManager: fakeManager })
 
-  // Finding 9 (presence on this door too): wrap the rejection test above in
-  // `it.each([['string', 'legacy-cli-id'], ['empty-string', '']])` — an empty
-  // string carries MUST also reject with the frozen text (`!== undefined`).
+      const ws = await createAuthenticatedWs()
+      const requestId = `cli-legacy-reject-${_label}`
+      const errorPromise = new Promise<any>((resolve) => {
+        ws.on('message', (data) => {
+          const msg = JSON.parse(data.toString())
+          if (msg.type === 'error' && msg.requestId === requestId) resolve(msg)
+        })
+      })
+      ws.send(JSON.stringify({
+        type: 'codingcli.create', requestId, provider: 'claude', prompt: 'hi',
+        resumeSessionId: legacy,
+      }))
+      const error = await errorPromise
+      expect(error).toMatchObject({
+        type: 'error', code: 'INVALID_MESSAGE',
+        message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+        requestId,
+      })
+      expect(createMock).not.toHaveBeenCalled() // no spawn on reject
+      ws.close()
+    },
+  )
 
   it('promotes a provider-matched sessionRef into the spawn-time resume id for codingcli.create', async () => {
     // V4: NEVER instantiate a real CodingCliSessionManager + real claudeProvider —
@@ -2145,24 +2181,23 @@ Add `sessionRef` to the dynamic codingcli schema at `server/ws-handler.ts:802-81
     }).strict()
 ```
 
-Insert the reject + promotion at `server/ws-handler.ts:3280` UNCONDITIONALLY FIRST (coordinator ruling J — before the manager-missing check at `:3281-3288`, so the reject is config-independent: `{no manager} + {resumeSessionId}` answers `INVALID_MESSAGE` + frozen text, not `INTERNAL_ERROR`). The reject runs before `endCodingTimer` is defined — move `endCodingTimer` above it OR use a plain `return` (the timer is a perf wrapper; an early reject before it is acceptable and matches Task 10's freshAgent ordering). Concretely, insert at the very head of the `case 'codingcli.create':` block, before the `if (!this.codingCliManager)` check:
+Extend the Task-9 raw pre-parse guard in `server/ws-handler.ts` with the codingcli.create arm (R3.1 + coordinator ruling J: the reject is config-independent — it fires before the manager-missing check exists at the raw layer, so `{no manager} + {resumeSessionId}` answers INVALID_MESSAGE + frozen text, not INTERNAL_ERROR):
+
+```ts
+          case 'codingcli.create': {
+            this.sendError(ws, {
+              code: 'INVALID_MESSAGE',
+              message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+              requestId: typeof rawMsg.requestId === 'string' ? rawMsg.requestId : undefined,
+            })
+            return
+          }
+```
+
+The codingcli.create handler case keeps only the PROMOTION (legacy rejection now lives in the raw guard) — at `server/ws-handler.ts:3280` the head of `case 'codingcli.create':` becomes:
 
 ```ts
       case 'codingcli.create': {
-        // ejh6 (coordinator ruling J): reject the legacy resumeSessionId wire
-        // field UNCONDITIONALLY FIRST — before the manager-missing check, so
-        // the reject is config-independent. The canonical carrier is sessionRef;
-        // resumeSessionId stays declared on the schema solely so the handler
-        // can detect-and-reject (see kata ejh6).
-        // LAYERED presence (Global Constraints): `!== undefined` catches any string including ""; null/42 are rejected at the zod parse boundary with INVALID_MESSAGE (generic text).
-        if (m.resumeSessionId !== undefined) {
-          this.sendError(ws, {
-            code: 'INVALID_MESSAGE',
-            message: INVALID_RAW_CODEX_RESUME_MESSAGE,
-            requestId: m.requestId,
-          })
-          return
-        }
         if (!this.codingCliManager) {
           this.sendError(ws, {
             code: 'INTERNAL_ERROR',
@@ -2312,6 +2347,26 @@ Add to `test/unit/client/lib/pane-reconcile.fresh-agent.test.ts` (per V4: drive 
   })
 ```
 
+And in `test/unit/client/lib/pane-reconcile.test.ts` add the shell boundary case (review round 3, finding 6 — mirrors the server's exclusion):
+
+```ts
+  it('never promotes a shell-mode legacy resumeSessionId (a stateless shell has no durable identity)', () => {
+    let state = emptyPanesState()
+    state = addTerminalPane(state, 'tab_1', 'pane_1', {
+      mode: 'shell', createRequestId: 'req-sh-1',
+      resumeSessionId: 'legacy-shell-id',
+    } as Partial<TerminalPaneContent>)
+
+    const req = buildReconcileRequest(asRootState(state))
+    expect(req).not.toBeNull()
+    const pane = req!.panes.find((p) => p.createRequestId === 'req-sh-1')
+    expect(pane).toBeDefined()
+    expect(pane!.sessionRef).toBeUndefined()
+    expect(pane!.resumeSessionId).toBeUndefined()
+  })
+```
+(Verify the file's terminal-pane fixture helper name before pasting — the existing first test uses the same shape; if it's not `addTerminalPane`, use the file's actual helper.)
+
 - [ ] **Step 2: Run the test and verify the intended failure**
 
 Run: `npm run test:vitest -- run test/unit/client/lib/pane-reconcile.test.ts test/unit/client/lib/pane-reconcile.fresh-agent.test.ts --config config/vitest/vitest.config.ts`
@@ -2335,7 +2390,13 @@ function effectiveReconcileSessionRef(
   mode: string,
 ): { provider: string; sessionId: string } | undefined {
   if (sessionRef) return sessionRef
-  if (resumeSessionId) return { provider: mode, sessionId: resumeSessionId }
+  // Mirror the server's promoted_legacy_claim exclusion
+  // (crates/freshell-ws/src/reconcile.rs:~165-177): shell/empty modes NEVER
+  // promote — a stateless shell has no durable identity (review round 3,
+  // finding 6 — the client must match or a stale shell pane becomes a
+  // structured sessionRef{provider:'shell'} and bypasses the server's
+  // fresh-verdict rule).
+  if (resumeSessionId && mode !== 'shell' && mode !== '') return { provider: mode, sessionId: resumeSessionId }
   return undefined
 }
 ```
@@ -2503,9 +2564,22 @@ Run: `npm run check && cargo test --workspace`
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit the task**
+- [ ] **Step 7: Commit the task, then squash behavior commits (R3 finding 2)**
 
-If Step 2 found sweep violations that required fixes, commit those fixes. Otherwise, no commit — the verification task produces no code change.
+If Step 2 found sweep violations that required fixes, commit those fixes first. Otherwise the verification task itself produces no code change.
+
+Then — the kata/User-Request contract requires BOTH servers' rejections (+ the reconcile client promotion, codingcli promotion, and rejection tests) to LAND TOGETHER, not as a sequence of partially-rejecting main-history commits. Task-sequenced commits 5–12 are correct locally for review/TDD, but before the PR opens, squash them into ONE behavior commit. Do it with a soft reset (the branch is unpushed during execution):
+
+```bash
+# Find the first behavior commit (Task 5's) — tasks 1-4 are contract-neutral
+# prep and stay separate:
+BEHAVIOR_BASE=$(git rev-list --max-parents=0 --no-merges HEAD -- server/ crates/ | tail -n +1 >/dev/null; git log --oneline --reverse origin/main..HEAD | awk '/ejh6.*Rust REST reject/{print $1; exit}')
+git reset --soft "${BEHAVIOR_BASE}^"
+git commit -m "feat(ejh6): reject the legacy resumeSessionId wire field on every create-class door (both servers)"
+git rebase origin/main # keep current-base lineage clean; plan docs/commits 1-4 are already behind
+```
+
+(Harness note: capture the Task-5 commit SHA in the progress ledger at Task 5 completion and use it directly rather than re-deriving with the awk above. If the squash reveals a mixed file staged from a prep task, unstage and recommit it separately — the verification gate already ran before this step.)
 
 ```bash
 # Only if sweep fixes were needed:

--- a/docs/plans/2026-08-16-legacy-resume-guard.md
+++ b/docs/plans/2026-08-16-legacy-resume-guard.md
@@ -40,6 +40,9 @@ Implement kata issue ejh6 (revised 2026-08-16 spec: "Remove the legacy resumeSes
 - **Section 3c doc comment:** every retained `resumeSessionId`/`resume_session_id` field in a wire schema/struct gets the comment `Retained solely so the handler can detect-and-reject; see kata ejh6.` — EXCEPT `ReconcilePane.resume_session_id` which gets the PERMANENT compat-door comment.
 - **`restoreKey` gating:** blanket REST reject does NOT gate on `restoreKey` — no production producer emits it (verified), so blanket reject regresses nothing live (binding correction A).
 - **Sidecar JSON-lines writers are not wire input:** `claude.rs:469` and `:1294` write `resumeSessionId` to the claude Node sidecar's internal JSON-lines protocol, not the Freshell WS wire — leave them untouched (binding correction C).
+- **Uniform any-carry REST rejection (coordinator final ruling, supersedes kata §1a's carrier-presence reading):** REST seams throw whenever the wire `resumeSessionId` is present, even when a matching `sessionRef` is also present — no first-party sender dual-carries, and the codex dual-carrier tolerance at `server/coding-cli/codex-app-server/restore-decision.ts:40` (`&& !codexSessionRef`) is retired by this change. Tasks 5 and 8 check legacy BEFORE the sessionRef early-return. WS §1b's any-carry language is the parity target.
+- **`ErrorCode` enum extension:** add `FRESH_AGENT_CREATE_FAILED` to the shared `ErrorCode` enum in `shared/ws-protocol.ts:20-37` so Node attach rejection's `sendError({code:'FRESH_AGENT_CREATE_FAILED',...})` typechecks. Node attach rejection is socket-loud but UI-invisible (no client consumer for requestId-less `error` frames); Rust's rides `freshAgent.event{freshAgent.error}` which the client renders — this asymmetry is documented in Task 10 and accepted (kata §1c names the code family, not the frame type).
+- **Sidecar-protocol file class is NOT Freshell-wire input (V5 ruling):** `crates/freshell-claude-sidecar/index.mjs:10,:240` (reader), `claude.rs:469`/`:1294` + Node `sdk-bridge.ts` writers, embedded fake sidecars in `tests/fixtures` and `test/e2e-browser/fixtures`, and the ~8 sidecar-log-reading specs (`freshagent-settings-resume-rust.spec.ts:545,:551`, `hidden-pane-rebind-rust.spec.ts:365-367`, `freshclaude-restart-parity-rust.spec.ts:309`, `freshclaude-identity-persistence-rust.spec.ts:313,:410`, `wavea-interactions-rust.spec.ts:403-407`, `restore-contract-wall-rust.spec.ts:1040,:1304`, `restore-matrix.spec.ts:400,:1099`) — none are Freshell-wire input. Task 13's §6 sweep categories must EXCLUDE this file class with an explicit ruling line.
 
 ## Where the kata is superseded by explorer evidence
 
@@ -53,6 +56,9 @@ G) Use `plan-test-sweep.md` tables literally for conversion scope; `remote-tab-l
 H) Node has NO `pane.reconcile` handler; client-side promotion in `src/lib/pane-reconcile.ts:130`,`:153` (pattern = `FreshAgentView.tsx` `effectiveSessionRef` `:335-341`) + Rust server door kept forever.
 I) No e2e drives CLI/MCP into WS `terminal.create`; CLI/MCP regression = existing suites stay green (aliases convert), plus one cheap new assertion in `test/e2e/agent-cli-flow.test.ts` that a raw legacy WS send gets `INVALID_MESSAGE`+frozen text. Do not invent new e2e harnesses.
 J) Repo rules: worktree-only; coordinated runners (`npm run test:vitest -- run <paths> --config <config>`; configs `config/vitest/vitest.config.ts` (default) and `config/vitest/vitest.server.config.ts` (server)); `cargo test -p <crate>` focused, `cargo test --workspace` and `npm run check` as gates; NodeNext ESM needs `.js` extensions on relative TS imports; never weaken tests.
+K) V5's six-site omission correction: Task 3 must absorb `amplifier_launcher_identity.rs:148` (mechanical re-carrier), `claude_session_rebind.rs:546` (mechanical), `freshagent_claude_attach.rs:559` (third attach site, mechanical), and `terminal_tabs.rs:6334` (11th REST body — mechanical IF contract-neutral, else into Task 5 as a rejection assertion). Three premise-inversion sites route to behavior tasks: `amplifier_launcher_identity.rs:341` (expects RESTORE_UNAVAILABLE → becomes INVALID_MESSAGE — into Task 6), `codex_session_ref_resume.rs:363-381` (codex raw-legacy acceptance — into Task 6 as a rejection test), `cross_kind_liveness.rs:411,:460` (dual-carrier freshAgent.create sends — into Task 7: the SESSION_RESERVED dual-carrier assertion flips to the create-failed envelope; setup carry gets mechanically re-carriered).
+L) Uniform any-carry REST ruling (coordinator final): REST seams (`derive_resume_identity`, `requestedResumeSessionIdForMode`) throw whenever the wire `resumeSessionId` is present, even when `sessionRef` is also present — no first-party sender dual-carries. The codex dual-carrier tolerance at `server/coding-cli/codex-app-server/restore-decision.ts:40` is retired by this change. Tasks 5 and 8 check legacy BEFORE the sessionRef early-return. Existing REST dual-carrier acceptance assertions, if any, become rejection assertions.
+M) `ErrorCode` enum addition (validator V2 found Task 10's draft would not typecheck): add `FRESH_AGENT_CREATE_FAILED` to the shared `ErrorCode` enum in `shared/ws-protocol.ts:20-37`. Node attach rejection emits `error{FRESH_AGENT_CREATE_FAILED}` matching the existing attach error shape. Note the asymmetry: Node attach rejection is socket-loud but UI-invisible (no client consumer for requestId-less `error` frames — verified by V2's exhaustive sweep), while Rust's rides `freshAgent.event{freshAgent.error}` which the client renders. Kata §1c is satisfied (code family is what it names). Task 13 adds a typecheck step to catch drift.
 
 ---
 
@@ -167,7 +173,9 @@ The dedup IS the refactor. Confirm no remaining private duplicate: `rg "Restore 
 
 The change touches the frozen text carriers in both servers. Impacted set: all pinned-text tests in both servers.
 
-Run: `cargo test -p freshell-freshagent && cargo test -p freshell-ws && npm run test:vitest -- run test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/agent-tabs-write.test.ts test/server/agent-panes-write.test.ts test/unit/server/mcp/freshell-tool.test.ts test/e2e/agent-cli-flow.test.ts --config config/vitest/vitest.server.config.ts`
+Run: `cargo test -p freshell-freshagent && cargo test -p freshell-ws && npm run test:vitest -- run test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/agent-tabs-write.test.ts test/server/agent-panes-write.test.ts test/unit/server/mcp/freshell-tool.test.ts --config config/vitest/vitest.server.config.ts && FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/e2e/agent-cli-flow.test.ts`
+
+NOTE (V1): `test/e2e/agent-cli-flow.test.ts` is a Vitest file under the DEFAULT config (`config/vitest/vitest.config.ts`), NOT the server config — the server config's include list (`config/vitest/vitest.server.config.ts:27-36`) covers `test/server/**`, `test/unit/server/**`, `test/integration/server/**` but NOT `test/e2e/**`. Running it under `--config vitest.server.config.ts` silently drops it (vitest `list` exits 0 on empty match). The default config does NOT exclude `test/e2e/**` (only `test/e2e-browser/**`, `test/e2e-electron/**`). So `agent-cli-flow` must run as a separate default-config invocation with no `--config` flag (the coordinator auto-routes `test/e2e/...` to the default config).
 
 Expected: PASS
 
@@ -257,7 +265,7 @@ git commit -m "test(ejh6): convert Node WS freshAgent wire-send tests to session
 ### Task 3: Convert Rust wire-send tests to sessionRef
 
 **Files:**
-- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs` (test mod — POST bodies at `:4504,:4558,:4606,:5838,:5883,:5915,:5950,:5993,:6032,:6074`)
+- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs` (test mod — POST bodies at `:4504,:4558,:4606,:5838,:5883,:5915,:5950,:5993,:6032,:6074,:6334`)
 - Modify: `crates/freshell-freshagent/src/codex.rs` (test mod — msg structs at `:7047,:7181,:7240`)
 - Modify: `crates/freshell-freshagent/src/opencode_ws.rs:3056`
 - Modify: `crates/freshell-freshagent/src/claude.rs:2228-2232`
@@ -265,13 +273,17 @@ git commit -m "test(ejh6): convert Node WS freshAgent wire-send tests to session
 - Modify: `crates/freshell-ws/tests/codex_managed_launch_e2e.rs:253-267`
 - Modify: `crates/freshell-ws/tests/session_identity_frames.rs:67-72`
 - Modify: `crates/freshell-ws/tests/pane_ledger_triggers.rs:156-162`
-- Modify: `crates/freshell-ws/tests/freshagent_claude_attach.rs:360-365,:466-471`
+- Modify: `crates/freshell-ws/tests/freshagent_claude_attach.rs:360-365,:466-471,:559` (V5: third attach site at `:559`)
 - Modify: `crates/freshell-ws/tests/freshagent_session_lease.rs:417-424,:599-604,:756-761`
+- Modify: `crates/freshell-ws/tests/amplifier_launcher_identity.rs:148` (V5: mechanical re-carrier — setup create)
+- Modify: `crates/freshell-ws/tests/claude_session_rebind.rs:546` (V5: mechanical — setup create, drop legacy line since sessionRef already present)
 - Test: same files (converted in place)
+
+**Premise-inversion sites routed to behavior tasks (NOT this task):** `amplifier_launcher_identity.rs:341` (expects RESTORE_UNAVAILABLE → becomes INVALID_MESSAGE — Task 6), `codex_session_ref_resume.rs:363-381` (codex raw-legacy acceptance — Task 6 rejection test), `cross_kind_liveness.rs:411,:460` (dual-carrier freshAgent.create — Task 7). `terminal_tabs.rs:6334` (11th REST body, asserts 200) — if its assertion depends on legacy acceptance it becomes a rejection assertion in Task 5; otherwise convert here. Inspect `:6334` in context: it asserts `StatusCode::OK` on a `POST /api/tabs {"mode":"amplifier","resumeSessionId":"sess-no-warn-1"}` body — this is legacy ACCEPTANCE, so it routes to Task 5 as a rejection assertion (expected 200 becomes expected 400). Leave it sending legacy in Task 3.
 
 **Interfaces:**
 - Consumes: `session_ref` field already on every Rust protocol struct (`TerminalCreate.session_ref`, `FreshAgentCreate.session_ref`, `FreshAgentAttach.session_ref`); `derive_resume_identity` and per-provider resume-id derivation accept sessionRef.
-- Produces: Rust tests that send `sessionRef`/`session_ref` only, staying green against the unmodified server.
+- Produces: Rust tests that send `sessionRef`/`session_ref` only (except `:6334` left for Task 5), staying green against the unmodified server.
 
 - [ ] **Step 1: Write the failing behavioral test**
 
@@ -286,7 +298,7 @@ let body = json!({"mode": "claude", "resumeSessionId": "sess-dir-claude-1"});
 let body = json!({"mode": "claude", "sessionRef": {"provider": "claude", "sessionId": "sess-dir-claude-1"}});
 ```
 
-The three `rest_create_legacy_resume_*409` tests (`:5824,:5856,:5896`) test the D7/LEASE 409 ladder via the legacy carrier — convert the body to `sessionRef` and re-aim the assertions at the sessionRef-carrier D7 path (the 409 RESTORE_UNAVAILABLE behavior is carrier-agnostic; the test still expects 409). The `:4424` codex-reject test (`create_codex_tab_rejects_raw_resume_session_id_without_session_ref`) is a REJECTION-READY test — leave it sending legacy (it will be widened in Task 5).
+The three `rest_create_legacy_resume_*409` tests (`:5824,:5856,:5896`) test the D7/LEASE 409 ladder via the legacy carrier — convert the body to `sessionRef` and re-aim the assertions at the sessionRef-carrier D7 path (the 409 RESTORE_UNAVAILABLE behavior is carrier-agnostic; the test still expects 409). The `:4424` codex-reject test (`create_codex_tab_rejects_raw_resume_session_id_without_session_ref`) is a REJECTION-READY test — leave it sending legacy (it will be widened in Task 5). The `:6334` body (`create_tab_with_identity_or_shell_mode_does_not_warn_invariant`) asserts 200 on legacy amplifier — leave it sending legacy (Task 5 flips it to a 400 rejection assertion).
 
 **`codex.rs` test mod** — at `:7047,:7181,:7240`, replace `resume_session_id: Some("<id>".to_string())` with `session_ref: Some(SessionLocator { provider: AgentProvider::Codex, session_id: "<id>".to_string() })`. The twin test `handle_create_with_session_ref_only_resumes_the_same_thread` at `:7096` already shows the post-conversion shape — match it.
 
@@ -302,7 +314,11 @@ The three `rest_create_legacy_resume_*409` tests (`:5824,:5856,:5896`) test the 
 
 **`pane_ledger_triggers.rs:156-162`** — replace the legacy-only create carrier with `"sessionRef": {"provider": "claude", "sessionId": "<id>"}`.
 
-**`freshagent_claude_attach.rs:360-365,:466-471`** and **`freshagent_session_lease.rs:417-424,:599-604,:756-761`** — these frames carry BOTH `resumeSessionId` AND `sessionRef` today. Delete the `resumeSessionId` line in each (sessionRef already present — trivial). The fake-sidecar `msg.resumeSessionId` reads at `freshagent_claude_attach.rs:63` are the internal adapter-to-sidecar protocol — leave them.
+**`freshagent_claude_attach.rs:360-365,:466-471,:559`** and **`freshagent_session_lease.rs:417-424,:599-604,:756-761`** — these frames carry BOTH `resumeSessionId` AND `sessionRef` today. Delete the `resumeSessionId` line in each (sessionRef already present — trivial; V5 found a third attach site at `:559`). The fake-sidecar `msg.resumeSessionId` reads at `freshagent_claude_attach.rs:63` are the internal adapter-to-sidecar protocol — leave them.
+
+**`amplifier_launcher_identity.rs:148`** (V5 omitted site) — setup create `terminal.create{mode:"amplifier",...,"resumeSessionId": requested}` expecting `terminal.created` + sessionRef echo. Mechanically re-carrier: replace `"resumeSessionId": requested` with `"sessionRef": {"provider": "amplifier", "sessionId": requested}`. The `:341` premise-inversion site (second create expects RESTORE_UNAVAILABLE) is left for Task 6.
+
+**`claude_session_rebind.rs:546`** (V5 omitted site) — setup `freshAgent.create` carries BOTH `resumeSessionId` and `sessionRef`. Drop the `resumeSessionId` line (sessionRef already present). The `:293` fake-sidecar `msg.resumeSessionId` read is internal adapter-to-sidecar protocol — leave it.
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -337,8 +353,8 @@ Expected: PASS
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add crates/freshell-freshagent/src/terminal_tabs.rs crates/freshell-freshagent/src/codex.rs crates/freshell-freshagent/src/opencode_ws.rs crates/freshell-freshagent/src/claude.rs crates/freshell-ws/src/terminal_launch_prep_tests.rs crates/freshell-ws/tests/codex_managed_launch_e2e.rs crates/freshell-ws/tests/session_identity_frames.rs crates/freshell-ws/tests/pane_ledger_triggers.rs crates/freshell-ws/tests/freshagent_claude_attach.rs crates/freshell-ws/tests/freshagent_session_lease.rs
-git commit -m "test(ejh6): convert Rust wire-send tests to sessionRef"
+git add crates/freshell-freshagent/src/terminal_tabs.rs crates/freshell-freshagent/src/codex.rs crates/freshell-freshagent/src/opencode_ws.rs crates/freshell-freshagent/src/claude.rs crates/freshell-ws/src/terminal_launch_prep_tests.rs crates/freshell-ws/tests/codex_managed_launch_e2e.rs crates/freshell-ws/tests/session_identity_frames.rs crates/freshell-ws/tests/pane_ledger_triggers.rs crates/freshell-ws/tests/freshagent_claude_attach.rs crates/freshell-ws/tests/freshagent_session_lease.rs crates/freshell-ws/tests/amplifier_launcher_identity.rs crates/freshell-ws/tests/claude_session_rebind.rs
+git commit -m "test(ejh6): convert Rust wire-send tests to sessionRef (incl. V5 omitted sites)"
 ```
 
 ---
@@ -349,12 +365,12 @@ git commit -m "test(ejh6): convert Rust wire-send tests to sessionRef"
 - Modify: `test/e2e-browser/specs/fresh-agent-control-rust.spec.ts:1521,:1586,:1864,:1929`
 - Modify: `test/e2e-browser/specs/freshagent-settings-resume-rust.spec.ts:313,:414,:536`
 - Modify: `test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts:344-346,:423-425,:616-618`
-- Modify: `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts:197-205` (convert sends where assertions aren't legacy-acceptance; leave acceptance asserts for Task 8 to repurpose)
-- Test: same files
+- NOTE: `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` is NOT converted in Task 4 — its acceptance-assert sites and repurpose move to Task 5 (same Rust-behavior commit, per V6: no red window between the Rust REST reject and the spec fix). Task 4 does NOT touch this file.
+- Test: same files (except remote-tab-linkage-rust.spec.ts)
 
 **Interfaces:**
 - Consumes: Rust server accepts both carriers (unmodified); sessionRef is the canonical carrier already used by the web client.
-- Produces: e2e specs that send `sessionRef` only on the wire (except `remote-tab-linkage-rust.spec.ts` acceptance-assert sites, left for Task 8).
+- Produces: e2e specs that send `sessionRef` only on the wire. The `remote-tab-linkage-rust.spec.ts` repurpose is deferred to Task 5.
 
 - [ ] **Step 1: Write the failing behavioral test**
 
@@ -366,13 +382,13 @@ Mechanical conversions of e2e WS/REST wire-send sites.
 
 **`sidebar-registry-sync-rust.spec.ts:344-346,:423-425,:616-618`** — each `page.request.post(baseUrl/api/tabs)` with `data: { mode: 'claude', resumeSessionId: sessionId }` becomes `data: { mode: 'claude', sessionRef: { provider: 'claude', sessionId } }`. The in-file comment pattern at `:338-343`/`:417-422` already explains codex uses sessionRef — extend it to claude.
 
-**`remote-tab-linkage-rust.spec.ts:197-205`** — per binding correction G: convert the `fetch(baseUrl/api/tabs, { mode: 'amplifier', resumeSessionId: SEEDED_SESSION_ID })` send to `sessionRef` WHERE the surrounding assertion is NOT legacy-acceptance. The spec's premise (legacy acceptance then sessionRef synthesis) is tested by assertions that the created tab carries the synthesized sessionRef. Leave those acceptance assertions untouched for Task 8 to repurpose as a REST 400 rejection e2e. For any purely-mechanical send sites whose assertions are carrier-agnostic (e.g. sidecar log reads), convert to `sessionRef`.
+**`remote-tab-linkage-rust.spec.ts`** — NOT touched in Task 4. Per V6, the spec's repurpose (re-carrier sends + convert acceptance assertions to rejection assertions + add to `RUST_ONLY_SPECS`) moves to Task 5 (same Rust-behavior commit) to avoid a red window between the Task-5 REST reject and the spec fix.
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
 Contract-neutral — e2e specs pass against the unmodified Rust server. Run the four converted specs via the repo's e2e runner (check `package.json`; if `FRESHELL_E2E_BACKEND` is unset, run locally — these are Rust-server specs so use the Rust e2e config).
 
-Run: `npm run test:e2e:local -- --grep "fresh-agent-control-rust|freshagent-settings-resume-rust|sidebar-registry-sync-rust|remote-tab-linkage-rust"` (adjust to the repo's Playwright invocation if the grep syntax differs; the intent is to run only these four specs).
+Run: `npm run test:e2e:local -- --grep "fresh-agent-control-rust|freshagent-settings-resume-rust|sidebar-registry-sync-rust" --project rust-chromium` (the three converted specs on the rust-chromium project; `remote-tab-linkage-rust` is deferred to Task 5).
 
 Expected: PASS
 
@@ -401,27 +417,30 @@ Expected: PASS
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add test/e2e-browser/specs/fresh-agent-control-rust.spec.ts test/e2e-browser/specs/freshagent-settings-resume-rust.spec.ts test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts
+git add test/e2e-browser/specs/fresh-agent-control-rust.spec.ts test/e2e-browser/specs/freshagent-settings-resume-rust.spec.ts test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts
 git commit -m "test(ejh6): convert e2e-browser Rust wire-send tests to sessionRef"
 ```
 
 ---
 
-### Task 5: Rust REST reject — widen `derive_resume_identity` to all modes + section 3c doc comments
+### Task 5: Rust REST reject — uniform any-carry on all modes + section 3c doc comments + remote-tab-linkage repurpose
 
 **Files:**
-- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs:117-136` (`requested_resume_session_id_for_mode` — widen codex-only throw to all modes)
+- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs:117-136` (`requested_resume_session_id_for_mode` — uniform any-carry throw, legacy checked BEFORE sessionRef early-return) and `derive_resume_identity:507-531` (reorder: legacy check before sessionRef derivation)
 - Modify: `crates/freshell-protocol/src/client_messages.rs:231-235` (`TerminalCreate.resume_session_id` doc), `:409-411` (`ReconcilePane.resume_session_id` doc — PERMANENT compat), `:445` (`CodingCliCreate.resume_session_id` doc), `:511` (`FreshAgentCreate.resume_session_id` doc), `:527` (`FreshAgentAttach.resume_session_id` doc)
-- Test: `crates/freshell-freshagent/src/terminal_tabs.rs` (test mod — add per-mode rejection test)
-- Test: `crates/freshell-freshagent/src/pane_ops_tests.rs` (new split/respawn rejection tests)
+- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs:6334` (`create_tab_with_identity_or_shell_mode_does_not_warn_invariant` — flip from 200 acceptance to 400 rejection assertion)
+- Modify: `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` (repurpose: re-carrier sends to sessionRef where assertions aren't legacy-acceptance; convert the acceptance assertion chain at `:197-325` into a REST 400 rejection e2e — new premise: bare legacy then 400 naming sessionRef; ~110 lines of create-success-dependent steps become dead and must be removed/rebuilt around the rejection premise)
+- Modify: `test/e2e-browser/playwright.config.ts:176` (`RUST_ONLY_SPECS` — add `/remote-tab-linkage-rust\.spec\.ts$/`; pre-existing config gap: the spec is registered in `rust-chromium` testMatch at `:389` but MISSING from `RUST_ONLY_SPECS`, so the default match-all `chromium` project also selects it and fails at `:111` `expect(e2eServerKind).toBe('rust')` on EVERY HEAD including base — same class as `term28-path-shadow-rust` at cloud config `:53-55`. Adding it to `RUST_ONLY_SPECS` fixes this pre-existing base failure on the chromium leg.)
+- Test: `crates/freshell-freshagent/src/terminal_tabs.rs` (test mod — add per-mode + dual-carrier rejection test)
+- Test: `crates/freshell-freshagent/src/pane_ops_tests.rs` (new split/respawn rejection tests using `create_shell_tab` for real pane ids)
 
 **Interfaces:**
-- Consumes: `LEGACY_RESUME_IDENTITY_REFUSAL` (from Task 1); `fail_json(StatusCode::BAD_REQUEST, ...)` at `lib.rs:1556`; `post(app(state), uri, body, auth)` helper at `terminal_tabs.rs:2671`.
-- Produces: all three Rust REST doors (`POST /api/tabs`, `/api/panes/:id/split`, `/api/panes/:id/respawn`) return HTTP 400 `{status:"error",message:<frozen>}` when the body carries a non-empty `resumeSessionId`.
+- Consumes: `LEGACY_RESUME_IDENTITY_REFUSAL` (from Task 1); `fail_json(StatusCode::BAD_REQUEST, ...)` at `lib.rs:1556`; `post(router, uri, body, auth: bool)` helper at `terminal_tabs.rs:2671` (4th arg is `bool`, NOT an `AUTH_HEADER` const — V3 finding); `create_shell_tab(router)` helper at `pane_ops_tests.rs:87-102` (returns `(tabId, paneId, terminalId)` parsed from the POST /api/tabs response — pane ids are UUIDs minted by the store, never hardcoded `pane_1`).
+- Produces: all three Rust REST doors return HTTP 400 `{status:"error",message:<frozen>}` whenever the body carries a non-empty `resumeSessionId`, EVEN when a matching `sessionRef` is also present (uniform any-carry, coordinator final ruling L — no first-party sender dual-carries; the codex dual-carrier tolerance at `restore-decision.ts:40` is retired).
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Add to the `#[cfg(test)] mod tests` in `crates/freshell-freshagent/src/terminal_tabs.rs` (after the existing `create_codex_tab_rejects_raw_resume_session_id_without_session_ref` at `:4415`):
+Add to the `#[cfg(test)] mod tests` in `crates/freshell-freshagent/src/terminal_tabs.rs` (after the existing `create_codex_tab_rejects_raw_resume_session_id_without_session_ref` at `:4415`). Note: `post()` 4th arg is `auth: bool` (use `true`), NOT an `AUTH_HEADER` const (V3 finding — `AUTH_HEADER` does not exist in this crate):
 
 ```rust
 #[tokio::test]
@@ -433,7 +452,7 @@ async fn rest_create_rejects_legacy_resume_session_id_for_every_session_mode() {
             app.clone(),
             "/api/tabs",
             json!({"mode": mode, "resumeSessionId": format!("legacy-{mode}-id")}),
-            AUTH_HEADER,
+            true,
         )
         .await;
         assert_eq!(
@@ -449,21 +468,57 @@ async fn rest_create_rejects_legacy_resume_session_id_for_every_session_mode() {
         );
     }
 }
+
+/// ejh6 uniform any-carry: a body carrying BOTH a matching sessionRef AND
+/// resumeSessionId is REJECTED (coordinator ruling L — no first-party sender
+/// dual-carries; the codex dual-carrier tolerance at restore-decision.ts:40 is
+/// retired). The legacy field is rejected even when sessionRef is present.
+#[tokio::test]
+async fn rest_create_rejects_legacy_resume_session_id_even_with_companion_session_ref() {
+    let state = state_with_registry();
+    let app = crate::router(state);
+    let (status, body) = post(
+        app,
+        "/api/tabs",
+        json!({
+            "mode": "claude",
+            "resumeSessionId": "legacy-should-still-reject",
+            "sessionRef": {"provider": "claude", "sessionId": "canonical-session-id"}
+        }),
+        true,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "dual-carrier must reject: {body}");
+    assert_eq!(
+        body["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.")
+    );
+}
 ```
 
-Add to `crates/freshell-freshagent/src/pane_ops_tests.rs` (split test section opens at `:122`; add after the last split test):
+Flip the `:6334` test (`create_tab_with_identity_or_shell_mode_does_not_warn_invariant`) from 200 acceptance to 400 rejection — the body sends `{"mode":"amplifier","resumeSessionId":"sess-no-warn-1"}` and currently asserts `StatusCode::OK`; change the assertion to:
+
+```rust
+        assert_eq!(status, StatusCode::BAD_REQUEST, "legacy amplifier must reject: {body}");
+        assert_eq!(
+            body["message"],
+            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.")
+        );
+```
+
+Add to `crates/freshell-freshagent/src/pane_ops_tests.rs` (split test section opens at `:122`; add after the last split test). Per V3: pane ids are UUIDs minted by the store — use `create_shell_tab(router.clone())` to parse the pane id from the POST /api/tabs response exactly like `split_terminal_pane_spawns_real_pty_and_broadcasts_pane_split` at `:181-228`. The `post()` 4th arg is `auth: bool` (use `true`):
 
 ```rust
 #[tokio::test]
 async fn split_pane_rejects_legacy_resume_session_id_with_400() {
     let state = state_with_registry();
     let app = crate::router(state);
-    let _ = post(app.clone(), "/api/tabs", json!({"mode": "shell"}), AUTH_HEADER).await;
+    let (_tab_id, pane_id, _terminal_id) = create_shell_tab(app.clone()).await;
     let (status, body) = post(
-        app.clone(),
-        "/api/panes/pane_1/split",
+        app,
+        &format!("/api/panes/{pane_id}/split"),
         json!({"direction": "horizontal", "mode": "claude", "resumeSessionId": "legacy-split-id"}),
-        AUTH_HEADER,
+        true,
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "split legacy reject: {body}");
@@ -481,12 +536,12 @@ Add to the respawn test section (opens at `:562`):
 async fn respawn_pane_rejects_legacy_resume_session_id_with_400() {
     let state = state_with_registry();
     let app = crate::router(state);
-    let _ = post(app.clone(), "/api/tabs", json!({"mode": "shell"}), AUTH_HEADER).await;
+    let (_tab_id, pane_id, _terminal_id) = create_shell_tab(app.clone()).await;
     let (status, body) = post(
-        app.clone(),
-        "/api/panes/pane_1/respawn",
+        app,
+        &format!("/api/panes/{pane_id}/respawn"),
         json!({"mode": "claude", "resumeSessionId": "legacy-respawn-id"}),
-        AUTH_HEADER,
+        true,
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "respawn legacy reject: {body}");
@@ -497,15 +552,23 @@ async fn respawn_pane_rejects_legacy_resume_session_id_with_400() {
 }
 ```
 
-- [ ] **Step 2: Run the test and verify the intended failure**
+Repurpose `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` (V6: the spec's premise is bare-legacy REST acceptance — `:197-206` sends `POST /api/tabs {mode:'amplifier', resumeSessionId: SEEDED_SESSION_ID}` and `:208` asserts `toBe(200)`; Task 5's reject makes `:208` receive 400 + frozen text). Rewrite the test around a REST 400 rejection premise:
 
-Run: `cargo test -p freshell-freshagent rest_create_rejects_legacy_resume_session_id_for_every_session_mode split_pane_rejects_legacy_resume_session_id_with_400 respawn_pane_rejects_legacy_resume_session_id_with_400`
+- `:194-196` Step-2 comment — rewrite to "Step 2: a bare legacy `resumeSessionId` on `POST /api/tabs {mode:'amplifier'}` is REJECTED with 400 naming sessionRef (kata ejh6)."
+- `:197-210` send + assertions — keep the send as-is (bare legacy); invert `:208` `toBe(200)` → `toBe(400)`; `:209-210` `body?.data?.tabId` → assert `body.status === 'error'` and `body.message` contains the frozen text; delete the `restTabId` binding.
+- `:212-325` (~110 lines of create-success-dependent steps: broadcast visibility, tab-count delta, argv-log polls, sidebar linkage, dedupe click, title sync, persisted-sessionRef content, full restart-durability block) — these become dead under the rejection premise; delete them. The test now asserts: 400 + frozen text + no spawn (no tab count delta, no argv log entry). A minimal post-reject assertion: `expect.poll(() => harness.getTabCount()).toBe(tabCountBeforeCreate)` (no tab materialized).
 
-Expected: FAIL because the non-codex modes silently accept the legacy field today (`requested_resume_session_id_for_mode` at `:135` returns `Ok(legacy)` for non-codex) — the test gets a 200/500 instead of 400.
+Add `/remote-tab-linkage-rust\.spec\.ts$/` to `RUST_ONLY_SPECS` at `test/e2e-browser/playwright.config.ts:176` (pre-existing config gap fix — the spec is `rust-chromium`-registered at `:389` but missing from the list, so the `chromium` project picks it up and fails at `:111` on every HEAD including base).
+
+- [ ] **Step 2: `Run` the test and verify the intended failure**
+
+Run: `cargo test -p freshell-freshagent rest_create_rejects_legacy_resume_session_id_for_every_session_mode rest_create_rejects_legacy_resume_session_id_even_with_companion_session_ref split_pane_rejects_legacy_resume_session_id_with_400 respawn_pane_rejects_legacy_resume_session_id_with_400`
+
+Expected: FAIL because the non-codex modes silently accept the legacy field today (`requested_resume_session_id_for_mode` at `:135` returns `Ok(legacy)` for non-codex), and the dual-carrier case returns sessionRef (the `:122-124` sessionRef early-return fires before the legacy check) — the tests get 200 instead of 400.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Widen `requested_resume_session_id_for_mode` at `crates/freshell-freshagent/src/terminal_tabs.rs:117-136`. Replace the codex-only throw with an any-mode throw:
+Widen `requested_resume_session_id_for_mode` at `crates/freshell-freshagent/src/terminal_tabs.rs:117-136`. Per coordinator ruling L (uniform any-carry): check legacy BEFORE the sessionRef early-return so a dual-carrier body is rejected:
 
 ```rust
 fn requested_resume_session_id_for_mode(
@@ -513,18 +576,20 @@ fn requested_resume_session_id_for_mode(
     mode: &str,
     legacy_resume_session_id: Option<&str>,
 ) -> Result<Option<String>, Response> {
-    let accepted = accepted_session_ref_for_mode(session_ref, mode);
-    if let Some(ref sref) = accepted {
-        return Ok(Some(sref.session_id.clone()));
-    }
-    // ejh6: reject the legacy resumeSessionId wire field on EVERY mode. The
-    // canonical carrier is sessionRef; resumeSessionId stays declared on the
-    // wire schema solely so this handler can detect-and-reject (see kata ejh6).
+    // ejh6 (uniform any-carry, coordinator ruling L): reject the legacy
+    // resumeSessionId wire field on EVERY mode, EVEN when a matching sessionRef
+    // is also present. No first-party sender dual-carries; the codex dual-carrier
+    // tolerance at restore-decision.ts:40 is retired. The legacy check runs
+    // BEFORE the sessionRef early-return so a dual-carrier body is rejected.
     if legacy_resume_session_id.is_some_and(|s| !s.is_empty()) {
         return Err(fail_json(
             StatusCode::BAD_REQUEST,
             LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
         ));
+    }
+    let accepted = accepted_session_ref_for_mode(session_ref, mode);
+    if let Some(ref sref) = accepted {
+        return Ok(Some(sref.session_id.clone()));
     }
     Ok(None)
 }
@@ -563,17 +628,17 @@ At `:445` (`CodingCliCreate.resume_session_id`), `:511` (`FreshAgentCreate.resum
 
 - [ ] **Step 4: Run the focused test**
 
-Run: `cargo test -p freshell-freshagent rest_create_rejects_legacy_resume_session_id_for_every_session_mode split_pane_rejects_legacy_resume_session_id_with_400 respawn_pane_rejects_legacy_resume_session_id_with_400`
+Run: `cargo test -p freshell-freshagent rest_create_rejects_legacy_resume_session_id_for_every_session_mode rest_create_rejects_legacy_resume_session_id_even_with_companion_session_ref split_pane_rejects_legacy_resume_session_id_with_400 respawn_pane_rejects_legacy_resume_session_id_with_400`
 
 Expected: PASS
 
 - [ ] **Step 5: Refactor while green**
 
-The codex-specific branch is gone — the any-mode throw subsumes it. The function name `requested_resume_session_id_for_mode` still accurately describes the function's role. No further refactor needed.
+The codex-specific branch is gone — the any-mode throw subsumes it. The `accepted_session_ref_for_mode` early-return now follows the legacy check. No further refactor needed.
 
 - [ ] **Step 6: Run impacted-test verification**
 
-The REST reject affects every REST create test that sends `resumeSessionId`. The WIRE-SEND REST tests were converted in Task 3 (they now send sessionRef). The REJECTION-READY codex test at `:4415` still sends legacy and expects 400 — it stays green (now the any-mode throw covers codex too). The three `rest_create_legacy_resume_*409` tests were converted to sessionRef in Task 3 — they expect 409 (D7/LEASE) and stay green because they send sessionRef.
+The REST reject affects every REST create test that sends `resumeSessionId`. The WIRE-SEND REST tests were converted in Task 3 (they now send sessionRef). The REJECTION-READY codex test at `:4415` still sends legacy and expects 400 — it stays green (now the any-mode throw covers codex too). The three `rest_create_legacy_resume_*409` tests were converted to sessionRef in Task 3 — they expect 409 (D7/LEASE) and stay green because they send sessionRef only (no legacy field). The `:6334` test is flipped in this task. The remote-tab-linkage spec is repurposed in this task (same commit — V6: no red window between the reject and the spec fix).
 
 Run: `cargo test -p freshell-freshagent`
 
@@ -582,8 +647,8 @@ Expected: PASS
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add crates/freshell-freshagent/src/terminal_tabs.rs crates/freshell-freshagent/src/pane_ops_tests.rs crates/freshell-protocol/src/client_messages.rs
-git commit -m "feat(ejh6): Rust REST reject legacy resumeSessionId on all modes + section 3c doc comments"
+git add crates/freshell-freshagent/src/terminal_tabs.rs crates/freshell-freshagent/src/pane_ops_tests.rs crates/freshell-protocol/src/client_messages.rs test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts test/e2e-browser/playwright.config.ts
+git commit -m "feat(ejh6): Rust REST uniform any-carry reject + section 3c docs + remote-tab-linkage repurpose + RUST_ONLY_SPECS fix"
 ```
 
 ---
@@ -598,6 +663,8 @@ git commit -m "feat(ejh6): Rust REST reject legacy resumeSessionId on all modes 
 - Modify: `crates/freshell-ws/src/reconcile.rs:162-177` (add permanent-compat doc to `promoted_legacy_claim`)
 - Test: `crates/freshell-ws/tests/live_session_ref_guard.rs:140` (re-target to INVALID_MESSAGE), add new any-mode blanket-reject test
 - Test: `crates/freshell-ws/tests/resume_validation_gate.rs:750,:823,:1015` (re-target codex-exemption cases to INVALID_MESSAGE)
+- Test: `crates/freshell-ws/tests/amplifier_launcher_identity.rs:341` (V5 premise-inversion: `amplifier_create_rejects_second_live_resume_of_same_session` — second create sends `"resumeSessionId": sid` and asserts `RESTORE_UNAVAILABLE`; post-gate the answer is `INVALID_MESSAGE` + frozen text. Re-target the assertion.)
+- Test: `crates/freshell-ws/tests/codex_session_ref_resume.rs:363-381` (V5 premise-inversion: Phase 3 "the raw resumeSessionId fallback must be preserved" — codex WS raw-legacy create asserting acceptance + spawn-argv `resume <raw_id>` pins. Post-gate (codex exemption removed) this becomes a rejection test: expect `INVALID_MESSAGE` + frozen text, no spawn. Convert Phase 3 from acceptance to rejection; Phase 1/2 sessionRef argv coverage survives.)
 
 **Interfaces:**
 - Consumes: `LEGACY_RESUME_IDENTITY_REFUSAL` (from Task 1); `send_create_error(out, ErrorCode::InvalidMessage, msg, request_id)` at `terminal.rs:4404`; `TerminalCreate.resume_session_id` field.
@@ -683,6 +750,38 @@ In `crates/freshell-ws/tests/resume_validation_gate.rs`, re-target cases 6/7/7b 
         json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
     );
 ```
+
+In `crates/freshell-ws/tests/amplifier_launcher_identity.rs:341` (`amplifier_create_rejects_second_live_resume_of_same_session`, V5 premise-inversion): the second create sends `"resumeSessionId": sid` and currently asserts `RESTORE_UNAVAILABLE` (its doc comment `:289-296` explains the legacy carrier rides the D7 ladder). Post-gate the answer is `INVALID_MESSAGE` + frozen text at the door (the blanket reject fires before D7). Re-target the assertion:
+
+```rust
+    let err = expect_refusal_for(&mut ws, &request_id).await;
+    assert_eq!(err["code"], json!("INVALID_MESSAGE"), "post-ejh6 the legacy carrier is rejected at the door, not via D7: {err}");
+    assert_eq!(
+        err["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+    );
+```
+
+In `crates/freshell-ws/tests/codex_session_ref_resume.rs:363-381` (Phase 3, V5 premise-inversion): the test `create_codex_terminal(&mut ws, "req-raw-resume", json!({ "resumeSessionId": raw_id }))` currently asserts acceptance verbatim (`:381` "the raw resumeSessionId fallback must be preserved") plus spawn-argv `resume <raw_id>` pins. Post-gate (codex exemption removed) this becomes a rejection test — convert Phase 3 from acceptance to rejection:
+
+```rust
+    // Phase 3 (ejh6): the raw resumeSessionId fallback is REJECTED at the door
+    // (codex exemption removed; uniform any-carry reject).
+    send_json(&mut ws, &json!({
+        "type": "terminal.create", "requestId": "req-raw-resume",
+        "mode": "codex", "shell": "system",
+        "cwd": std::env::temp_dir().to_string_lossy(),
+        "resumeSessionId": raw_id,
+    })).await;
+    let err = expect_refusal_for(&mut ws, "req-raw-resume").await;
+    assert_eq!(err["code"], json!("INVALID_MESSAGE"), "codex raw-legacy is no longer accepted: {err}");
+    assert_eq!(
+        err["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+    );
+```
+
+Phase 1/2 sessionRef argv coverage survives (those sends use sessionRef, not legacy). Delete the spawn-argv `resume <raw_id>` pins for Phase 3 (no spawn occurs on a 400).
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -780,8 +879,9 @@ git commit -m "feat(ejh6): Rust WS terminal.create blanket reject + reconcile pe
 **Files:**
 - Modify: `crates/freshell-ws/src/terminal.rs:62-67` (import `FreshAgentCreateFailed`), `:4768` (`fresh_agent_control_refusal` — add create/attach legacy-field arms)
 - Modify: `crates/freshell-freshagent/src/claude.rs:1809-1819` (`attach_durable_id` — flip to sessionRef-first with comment)
-- Test: `crates/freshell-ws/tests/freshagent_claude_attach.rs` (add legacy-carrying attach rejection test)
-- Test: `crates/freshell-ws/tests/freshagent_session_lease.rs` (add legacy-carrying create rejection test)
+- Test: `crates/freshell-ws/tests/freshagent_claude_attach.rs` (add legacy-carrying attach rejection test — use the file's own harness APIs per V3: `CLAUDE_ENV_LOCK`, `FakeClaudeResumeEnv::install(<durable>)`, `spawn_server() -> String`, `connect_and_complete_handshake(&url)`, `request_log_rows()`)
+- Test: `crates/freshell-ws/tests/freshagent_session_lease.rs` (add legacy-carrying create rejection test — use the file's own harness APIs per V3: `LEASE_ENV_LOCK`, `FakeLeaseSidecarEnv::install()`, `spawn_server() -> String`, `connect(&url, true)`, `create_rows()`)
+- Test: `crates/freshell-ws/tests/cross_kind_liveness.rs:411,:460` (V5 premise-inversion: `freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session` at `:411` sends dual-carrier `freshAgent.create` asserting `freshAgent.create.failed{code: SESSION_RESERVED}` — post Task 7 the refusal fires earlier with the create-failed envelope code `FRESH_AGENT_CREATE_FAILED` + frozen text; `terminal_create_is_refused_while_a_live_sidecar_owns_the_session` at `:444` setup create at `:460` sends dual-carrier expecting success — rejected outright, so the D7 scenario it stages never materializes. Mechanically re-carrier the setup sends (drop the legacy line — sessionRef already present) and re-target the `:411` assertion from `SESSION_RESERVED` to `FRESH_AGENT_CREATE_FAILED` + frozen text.)
 
 **Interfaces:**
 - Consumes: `LEGACY_RESUME_IDENTITY_REFUSAL` (from Task 1); `ServerMessage::FreshAgentCreateFailed(FreshAgentCreateFailed{code,message,request_id,retryable})` (`server_messages.rs:618-627`); `ServerMessage::FreshAgentEvent(FreshAgentEvent{event,provider,session_id,session_type})`; `agent_provider_wire`/`session_type_wire` helpers (`terminal.rs:4731,:4741`); `fresh_agent_control_refusal` runs before the dispatch match at `:661`.
@@ -789,7 +889,7 @@ git commit -m "feat(ejh6): Rust WS terminal.create blanket reject + reconcile pe
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Add to `crates/freshell-ws/tests/freshagent_claude_attach.rs` (model on the `freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session` pattern at `cross_kind_liveness.rs:373-437`):
+Add to `crates/freshell-ws/tests/freshagent_claude_attach.rs` (per V3 substitution table — this file is self-contained, NO `mod common`; use the file's own `CLAUDE_ENV_LOCK`, `FakeClaudeResumeEnv::install(<durable>)` (mandatory durable-id arg), `spawn_server() -> String` (bare URL, NOT a 2-tuple), `connect_and_complete_handshake(&url)`, `send_json`, `await_frame`, and `request_log_rows()` for the no-spawn pin):
 
 ```rust
 /// ejh6: a `freshAgent.attach` carrying `resumeSessionId` is rejected with
@@ -798,10 +898,10 @@ Add to `crates/freshell-ws/tests/freshagent_claude_attach.rs` (model on the `fre
 /// rejection rides the freshAgent.error event channel keyed by sessionId.
 #[tokio::test]
 async fn freshagent_attach_with_legacy_resume_session_id_is_rejected() {
-    let _guard = ENV_LOCK.lock().await;
-    let env = FakeSidecarEnv::install();
-    let (url, _registry) = spawn_server().await;
-    let mut ws = connect(&url).await;
+    let _guard = CLAUDE_ENV_LOCK.lock().await;
+    let env = FakeClaudeResumeEnv::install("legacy-durable-id");
+    let url = spawn_server().await;
+    let mut ws = connect_and_complete_handshake(&url).await;
 
     send_json(
         &mut ws,
@@ -830,14 +930,17 @@ async fn freshagent_attach_with_legacy_resume_session_id_is_rejected() {
         json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
         "frozen text: {err}"
     );
-    assert!(
-        env.create_rows().is_empty(),
-        "no sidecar may spawn for a rejected legacy attach: {:?}", env.create_rows()
-    );
+    // V3: this file has NO create_rows(); use request_log_rows() and filter for create rows.
+    let create_count = env
+        .request_log_rows()
+        .into_iter()
+        .filter(|r| r["msg"]["type"] == "create")
+        .count();
+    assert_eq!(create_count, 0, "no sidecar may spawn for a rejected legacy attach");
 }
 ```
 
-Add to `crates/freshell-ws/tests/freshagent_session_lease.rs`:
+Add to `crates/freshell-ws/tests/freshagent_session_lease.rs` (per V3 substitution table — use `LEASE_ENV_LOCK`, `FakeLeaseSidecarEnv::install()` (no-arg), `spawn_server() -> String`, `connect(&url, true)` (2-arg, `negotiated: bool`), `create_rows()`):
 
 ```rust
 /// ejh6: a `freshAgent.create` carrying `resumeSessionId` is rejected with
@@ -846,10 +949,10 @@ Add to `crates/freshell-ws/tests/freshagent_session_lease.rs`:
 /// create-failed envelope.
 #[tokio::test]
 async fn freshagent_create_with_legacy_resume_session_id_is_rejected() {
-    let _guard = ENV_LOCK.lock().await;
-    let env = FakeSidecarEnv::install();
-    let (url, _registry) = spawn_server().await;
-    let mut ws = connect(&url).await;
+    let _guard = LEASE_ENV_LOCK.lock().await;
+    let env = FakeLeaseSidecarEnv::install();
+    let url = spawn_server().await;
+    let mut ws = connect(&url, true).await;
 
     send_json(
         &mut ws,
@@ -881,6 +984,26 @@ async fn freshagent_create_with_legacy_resume_session_id_is_rejected() {
     );
 }
 ```
+
+Re-target `crates/freshell-ws/tests/cross_kind_liveness.rs:411` (V5 premise-inversion, `freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session`): the test at `:411` sends dual-carrier `freshAgent.create` (BOTH `resumeSessionId` AND `sessionRef`) and currently asserts `freshAgent.create.failed{code: SESSION_RESERVED}` (`:425`). Post Task 7, the refusal fires earlier — the `fresh_agent_control_refusal` legacy-field arm returns `FRESH_AGENT_CREATE_FAILED` + frozen text BEFORE the dispatch reaches the per-provider handler (which would have emitted `SESSION_RESERVED`). KEEP the legacy line in the `:411` send (so the legacy-field arm fires) and re-target the assertion:
+
+```rust
+    assert_eq!(
+        failed["type"], "freshAgent.create.failed",
+        "a live terminal PTY owns {session_id}: the fresh-agent resume must be refused, got {failed}"
+    );
+    // ejh6: the legacy field is rejected at the door BEFORE the SESSION_RESERVED
+    // cross-kind guard fires (the blanket reject in fresh_agent_control_refusal
+    // runs first). The code is FRESH_AGENT_CREATE_FAILED + frozen text, not
+    // SESSION_RESERVED.
+    assert_eq!(failed["code"], "FRESH_AGENT_CREATE_FAILED");
+    assert_eq!(
+        failed["message"],
+        "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."
+    );
+```
+
+Re-carrier the SETUP create at `:460` (`terminal_create_is_refused_while_a_live_sidecar_owns_the_session`) — drop the `resumeSessionId` line (sessionRef already present) so the setup `freshAgent.create` SUCCEEDS and the D7 scenario it stages can proceed (the test's own D7 `RESTORE_UNAVAILABLE` assertion is unaffected — it's driven by the `terminal.create` with sessionRef, not the freshAgent.create setup). NOTE: V3 found this file uses `ENV_LOCK`, `FakeSidecarEnv::install()` (no-arg), 2-tuple `spawn_server()`, 1-arg `connect(&url)` — the cross_kind_liveness-specific harness, NOT the per-file harnesses of the other two files. Keep those names for THIS file's edits.
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -963,7 +1086,7 @@ fn attach_durable_id(msg: &FreshAgentAttach) -> Option<String> {
 
 - [ ] **Step 4: Run the focused test**
 
-Run: `cargo test -p freshell-ws --test freshagent_claude_attach freshagent_attach_with_legacy_resume_session_id_is_rejected && cargo test -p freshell-ws --test freshagent_session_lease freshagent_create_with_legacy_resume_session_id_is_rejected && cargo test -p freshell-freshagent attach_durable_id`
+Run: `cargo test -p freshell-ws --test freshagent_claude_attach freshagent_attach_with_legacy_resume_session_id_is_rejected && cargo test -p freshell-ws --test freshagent_session_lease freshagent_create_with_legacy_resume_session_id_is_rejected && cargo test -p freshell-ws --test cross_kind_liveness freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session && cargo test -p freshell-freshagent attach_durable_id`
 
 Expected: PASS
 
@@ -982,23 +1105,24 @@ Expected: PASS
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add crates/freshell-ws/src/terminal.rs crates/freshell-freshagent/src/claude.rs crates/freshell-ws/tests/freshagent_claude_attach.rs crates/freshell-ws/tests/freshagent_session_lease.rs
-git commit -m "feat(ejh6): Rust WS freshAgent create/attach reject legacy field + attach_durable_id hygiene"
+git add crates/freshell-ws/src/terminal.rs crates/freshell-freshagent/src/claude.rs crates/freshell-ws/tests/freshagent_claude_attach.rs crates/freshell-ws/tests/freshagent_session_lease.rs crates/freshell-ws/tests/cross_kind_liveness.rs
+git commit -m "feat(ejh6): Rust WS freshAgent create/attach reject legacy field + attach_durable_id hygiene + cross_kind re-target"
 ```
 
 ---
 
-### Task 8: Node REST reject — widen `requestedResumeSessionIdForMode` to all modes + repurpose remote-tab-linkage
+### Task 8: Node REST reject — uniform any-carry on all modes (Node-side)
 
 **Files:**
-- Modify: `server/agent-api/router.ts:214-228` (`requestedResumeSessionIdForMode` — widen codex-only throw to all modes)
-- Modify: `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` (repurpose acceptance-assert sites as REST 400 rejection e2e)
-- Test: `test/server/agent-tabs-write.test.ts:413` (add `it.each` for all modes)
+- Modify: `server/agent-api/router.ts:214-228` (`requestedResumeSessionIdForMode` — uniform any-carry throw, legacy checked BEFORE sessionRef early-return per coordinator ruling L)
+- Test: `test/server/agent-tabs-write.test.ts:413` (add `it.each` for all modes + dual-carrier rejection test)
 - Test: `test/server/agent-panes-write.test.ts:132,:327` (widen to all modes)
+
+NOTE: the `remote-tab-linkage-rust.spec.ts` repurpose + `RUST_ONLY_SPECS` fix moved to Task 5 (same Rust-behavior commit, per V6 — no red window between the Rust reject and the spec fix). Task 8 keeps Node-side repurposing only.
 
 **Interfaces:**
 - Consumes: `INVALID_RAW_CODEX_RESUME_MESSAGE` (`restore-decision.ts:27-28`); `AgentRouteInputError` (`router.ts:47-52`); `agentRouteErrorStatus` returns 400 (`router.ts:54-58`); `fail(message)` returns `{status:'error',message}` (`response.ts:6`).
-- Produces: all three Node REST doors return HTTP 400 `{status:'error',message:<frozen>}` when the body carries a non-empty `resumeSessionId` on any mode.
+- Produces: all three Node REST doors return HTTP 400 `{status:'error',message:<frozen>}` whenever the body carries a non-empty `resumeSessionId`, EVEN when a matching `sessionRef` is also present (uniform any-carry, coordinator ruling L — parity with Task 5's Rust REST).
 
 - [ ] **Step 1: Write the failing behavioral test**
 
@@ -1029,17 +1153,42 @@ Add to `test/server/agent-tabs-write.test.ts` (after the existing codex-reject t
     expect(layoutStore.createTab).not.toHaveBeenCalled()
     expect(layoutStore.attachPaneContent).not.toHaveBeenCalled()
   })
+
+  // ejh6 uniform any-carry (coordinator ruling L): dual-carrier is REJECTED.
+  it('rejects legacy resumeSessionId even with a companion sessionRef', async () => {
+    const app = express()
+    app.use(express.json())
+    const registry = { create: vi.fn(), killAndWait: vi.fn(async () => true) }
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    const layoutStore = {
+      createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })),
+      attachPaneContent: vi.fn(),
+      selectTab: () => ({}), renameTab: () => ({}), closeTab: () => ({}), hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }), selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry, codexLaunchPlanner }))
+
+    const res = await request(app).post('/api/tabs').send({
+      mode: 'claude', name: 'dual carrier',
+      resumeSessionId: 'legacy-should-still-reject',
+      sessionRef: { provider: 'claude', sessionId: 'canonical-session-id' },
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({ status: 'error', message: INVALID_RAW_CODEX_RESUME_MESSAGE })
+    expect(registry.create).not.toHaveBeenCalled()
+  })
 ```
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
 Run: `npm run test:vitest -- run test/server/agent-tabs-write.test.ts --config config/vitest/vitest.server.config.ts`
 
-Expected: FAIL because the non-codex modes silently accept the legacy field (`requestedResumeSessionIdForMode` at `:227` returns `legacyResumeSessionId` for non-codex) — the test gets a 200 instead of 400.
+Expected: FAIL because the non-codex modes silently accept the legacy field (`requestedResumeSessionIdForMode` at `:227` returns `legacyResumeSessionId` for non-codex), and the dual-carrier case returns sessionRef (the `:219-220` sessionRef early-return fires before the legacy check) — the tests get 200 instead of 400.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Widen `requestedResumeSessionIdForMode` at `server/agent-api/router.ts:214-228`:
+Widen `requestedResumeSessionIdForMode` at `server/agent-api/router.ts:214-228`. Per coordinator ruling L (uniform any-carry): check legacy BEFORE the sessionRef early-return so a dual-carrier body is rejected:
 
 ```ts
 function requestedResumeSessionIdForMode(
@@ -1047,27 +1196,27 @@ function requestedResumeSessionIdForMode(
   mode: string,
   legacyResumeSessionId: unknown,
 ): string | undefined {
-  const acceptedSessionRef = acceptedSessionRefForMode(sessionRef, mode)
-  if (acceptedSessionRef) return acceptedSessionRef.sessionId
-  // ejh6: reject the legacy resumeSessionId wire field on EVERY mode. The
-  // canonical carrier is sessionRef; resumeSessionId stays declared on the
-  // shared schemas solely so the handler can detect-and-reject (see kata ejh6).
+  // ejh6 (uniform any-carry, coordinator ruling L): reject the legacy
+  // resumeSessionId wire field on EVERY mode, EVEN when a matching sessionRef
+  // is also present. No first-party sender dual-carries; the codex dual-carrier
+  // tolerance at restore-decision.ts:40 is retired. The legacy check runs
+  // BEFORE the sessionRef early-return so a dual-carrier body is rejected.
   if (isNonEmptyString(legacyResumeSessionId)) {
     throw new AgentRouteInputError(INVALID_RAW_CODEX_RESUME_MESSAGE)
   }
+  const acceptedSessionRef = acceptedSessionRefForMode(sessionRef, mode)
+  if (acceptedSessionRef) return acceptedSessionRef.sessionId
   return undefined
 }
 ```
 
-The existing 400 machinery (`AgentRouteInputError` then `agentRouteErrorStatus` then 400 then `res.status(400).json(fail(message))`) already produces `{status:'error',message:<frozen>}` for all three routes (they all call `requestedResumeSessionIdForMode` and wrap creation in the catch).
-
-Repurpose `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` acceptance-assert sites (the ones left in Task 4 that still send legacy `resumeSessionId` and expect acceptance) — change the expected response from success (200 with synthesized sessionRef) to 400 with the frozen message. The test's new premise: a bare legacy `resumeSessionId` on `POST /api/tabs {mode:'amplifier'}` then 400 naming sessionRef.
+The existing 400 machinery (`AgentRouteInputError` then `agentRouteErrorStatus` then 400 then `res.status(400).json(fail(message))`) already produces `{status:'error',message:<frozen>}` for all three routes.
 
 - [ ] **Step 4: Run the focused test**
 
 Run: `npm run test:vitest -- run test/server/agent-tabs-write.test.ts test/server/agent-panes-write.test.ts --config config/vitest/vitest.server.config.ts`
 
-Expected: PASS — the existing codex-reject tests at `:413`/`:132`/`:327` stay green; the new `it.each` covers claude/opencode/amplifier.
+Expected: PASS — the existing codex-reject tests at `:413`/`:132`/`:327` stay green; the new `it.each` + dual-carrier test cover claude/opencode/amplifier and dual-carrier.
 
 - [ ] **Step 5: Refactor while green**
 
@@ -1075,17 +1224,17 @@ The codex-specific branch in `requestedResumeSessionIdForMode` is gone — the a
 
 - [ ] **Step 6: Run impacted-test verification**
 
-Every Node REST create test is impacted. The WIRE-SEND REST tests (sidebar-registry-sync-rust.spec.ts) were converted in Task 4. The REJECTION-READY tests (agent-tabs-write, agent-panes-write) are widened in this task. The remote-tab-linkage-rust.spec.ts acceptance sites are repurposed in this task.
+Every Node REST create test is impacted. The WIRE-SEND REST tests (sidebar-registry-sync-rust.spec.ts) were converted in Task 4. The REJECTION-READY tests (agent-tabs-write, agent-panes-write) are widened in this task.
 
-Run: `npm run test:vitest -- run test/server/agent-tabs-write.test.ts test/server/agent-panes-write.test.ts test/unit/server/mcp/freshell-tool.test.ts test/e2e/agent-cli-flow.test.ts --config config/vitest/vitest.server.config.ts`
+Run: `npm run test:vitest -- run test/server/agent-tabs-write.test.ts test/server/agent-panes-write.test.ts test/unit/server/mcp/freshell-tool.test.ts --config config/vitest/vitest.server.config.ts`
 
 Expected: PASS
 
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add server/agent-api/router.ts test/server/agent-tabs-write.test.ts test/server/agent-panes-write.test.ts test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts
-git commit -m "feat(ejh6): Node REST reject legacy resumeSessionId on all modes + repurpose remote-tab-linkage"
+git add server/agent-api/router.ts test/server/agent-tabs-write.test.ts test/server/agent-panes-write.test.ts
+git commit -m "feat(ejh6): Node REST uniform any-carry reject legacy resumeSessionId on all modes"
 ```
 
 ---
@@ -1236,7 +1385,7 @@ import { WS_PROTOCOL_VERSION } from '../../shared/ws-protocol.js'
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
-Run: `npm run test:vitest -- run test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/ws-terminal-create-session-repair.test.ts test/integration/server/opencode-session-flow.test.ts test/e2e/agent-cli-flow.test.ts --config config/vitest/vitest.server.config.ts`
+Run: `npm run test:vitest -- run test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/ws-terminal-create-session-repair.test.ts test/integration/server/opencode-session-flow.test.ts --config config/vitest/vitest.server.config.ts && FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/e2e/agent-cli-flow.test.ts`
 
 Expected: FAIL because the current scoped gate only rejects restore+non-codex+legacy-only — the non-restore and companion-sessionRef cases are silently accepted.
 
@@ -1273,7 +1422,7 @@ Add the section 3c doc comment at `server/ws-handler.ts:784`:
 
 - [ ] **Step 4: Run the focused test**
 
-Run: `npm run test:vitest -- run test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/ws-terminal-create-session-repair.test.ts test/integration/server/opencode-session-flow.test.ts test/e2e/agent-cli-flow.test.ts --config config/vitest/vitest.server.config.ts`
+Run: `npm run test:vitest -- run test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/ws-terminal-create-session-repair.test.ts test/integration/server/opencode-session-flow.test.ts --config config/vitest/vitest.server.config.ts && FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/e2e/agent-cli-flow.test.ts`
 
 Expected: PASS
 
@@ -1298,16 +1447,18 @@ git commit -m "feat(ejh6): Node WS terminal.create blanket reject + repurpose te
 
 ---
 
-### Task 10: Node WS `freshAgent.create`/`freshAgent.attach` reject
+### Task 10: Node WS `freshAgent.create`/`freshAgent.attach` reject + ErrorCode enum extension
 
 **Files:**
 - Modify: `server/ws-handler.ts:3424` (head of `freshAgent.create` case — insert reject), `:3543` (head of `freshAgent.attach` case — insert reject)
-- Modify: `shared/ws-protocol.ts:482,:497` (section 3c doc comments)
+- Modify: `shared/ws-protocol.ts:20-37` (`ErrorCode` enum — add `FRESH_AGENT_CREATE_FAILED` per V2 finding: Task 10's `sendError({code:'FRESH_AGENT_CREATE_FAILED',...})` would not typecheck against `ErrorCode` without this addition), `:482,:497` (section 3c doc comments)
 - Test: `test/unit/server/ws-handler-fresh-agent.test.ts` (add legacy-carrying create/attach rejection tests)
 
 **Interfaces:**
-- Consumes: `INVALID_RAW_CODEX_RESUME_MESSAGE` (imported in Task 1); `this.send(ws, {type:'freshAgent.create.failed',requestId,code,message,retryable})` (envelope at `ws-handler.ts:3428`); `this.sendError(ws, {code,message})` (attach error shape at `:3589`).
+- Consumes: `INVALID_RAW_CODEX_RESUME_MESSAGE` (imported in Task 1); `this.send(ws, {type:'freshAgent.create.failed',requestId,code,message,retryable})` (envelope at `ws-handler.ts:3428`); `this.sendError(ws, {code,message})` (attach error shape at `:3589` — `code` typed `z.infer<typeof ErrorCode>`).
 - Produces: `freshAgent.create` carrying `resumeSessionId` then `freshAgent.create.failed{code:'FRESH_AGENT_CREATE_FAILED', message:<frozen>, retryable:false}`; `freshAgent.attach` carrying `resumeSessionId` then `error{code:'FRESH_AGENT_CREATE_FAILED', message:<frozen>}` (matching the existing attach error shape, per binding correction D); no `manager.create`/`manager.attach` call.
+
+**Cross-server contract asymmetry (coordinator ruling A, V2-verified):** Node attach rejection is socket-loud but UI-invisible — no client consumer exists for a requestId-less `error` frame (V2's exhaustive sweep of `src/` onMessage/handlers: `ws-client.ts:349-351` only clears tracked creates when `requestId` is a string; `fresh-agent-ws.ts:109-188` switch covers `freshAgent.created/create.failed/session.materialized/killed/event`, `'error'` falls to `default: return false`; `rg "FRESH_AGENT_CREATE_FAILED" src/ shared/` = zero hits). Rust's attach rejection rides `freshAgent.event{freshAgent.error}` which the client DOES handle (`fresh-agent-ws.ts:343-353` → `sessionError` → `freshAgentSlice.ts:441-462` → rendered at `FreshAgentView.tsx:2103-2105`). This asymmetry is ACCEPTED: kata §1c names the code family (`FRESH_AGENT_CREATE_FAILED`), not the frame type; the frozen client's senders never carry the field (`FreshAgentView.tsx:335-341` promotes via `effectiveSessionRef`), so the Node attach rejection only fires for stray external scripts. Task 13's verification checklist item 7 covers the Rust (UI-visible) path; the Node path is socket-loud-only by design.
 
 - [ ] **Step 1: Write the failing behavioral test**
 
@@ -1384,6 +1535,18 @@ Run: `npm run test:vitest -- run test/unit/server/ws-handler-fresh-agent.test.ts
 Expected: FAIL because the current `freshAgent.create`/`freshAgent.attach` handlers forward the legacy field to the runtime manager without rejecting — `manager.create`/`manager.attach` IS called (or the test times out waiting for the create-failed frame).
 
 - [ ] **Step 3: Add the minimal production implementation**
+
+First, add `FRESH_AGENT_CREATE_FAILED` to the `ErrorCode` enum in `shared/ws-protocol.ts:20-37` (V2 finding: without this, `sendError({code:'FRESH_AGENT_CREATE_FAILED',...})` fails `npm run typecheck` because `sendError`'s `code` param is typed `z.infer<typeof ErrorCode>`):
+
+```ts
+export const ErrorCode = z.enum([
+  // ... existing codes ...
+  'FRESH_AGENT_CREATE_FAILED',
+  // ... rest ...
+])
+```
+
+Use the enum's existing alphabetical or logical ordering convention (inspect the current list at `:20-37` and insert in the appropriate position). The string value `'FRESH_AGENT_CREATE_FAILED'` matches the code family kata §1c names and the code Rust uses in its `FreshAgentCreateFailed` envelope.
 
 Insert at the head of the `freshAgent.create` case at `server/ws-handler.ts:3424` (before the manager-missing check at `:3425`):
 
@@ -1511,33 +1674,54 @@ Add to `test/server/ws-coding-cli-events.test.ts` (model on the existing `create
   })
 
   it('promotes a provider-matched sessionRef into the spawn-time resume id for codingcli.create', async () => {
-    const fakeProvider = { name: 'claude', create: vi.fn(), ...claudeProvider }
-    const fakeManager = new CodingCliSessionManager([fakeProvider as any])
-    // swap in the fake manager for this test by re-initializing wsHandler
+    // V4: NEVER instantiate a real CodingCliSessionManager + real claudeProvider —
+    // the real provider's getCommand()/getStreamArgs() would spawn a real `claude`
+    // child process via child_process.spawn (only node-pty is mocked in this file,
+    // NOT child_process). Use the file's established fake-manager pattern (:247-258):
+    // a plain-object fake whose `create` is a vi.fn spy returning a FakeSession
+    // EventEmitter. The promoted id is observable at the manager boundary as
+    // `options.resumeSessionId` (session-manager.ts:283 forwards options verbatim
+    // into new CodingCliSession; no rename/transform between manager.create and argv).
+    const createMock = vi.fn()
+    class FakeSession extends EventEmitter {
+      id = 'cli-session-1'
+      provider = { name: 'claude' }
+    }
+    const fakeManager = {
+      create: (...args: any[]) => { createMock(...args); return new FakeSession() },
+      hasProvider: (name: string) => name === 'claude',
+      get: vi.fn(),
+      remove: vi.fn(),
+    } as unknown as CodingCliSessionManager
+
+    // Mid-test WsHandler swap is VALID (V4 leg i): wsHandler.close() removes the
+    // upgrade listener from the shared http.Server (ws 8.19.0 WSS.close() calls
+    // _removeListeners), so the new WsHandler is the ONLY upgrade handler — no
+    // double-processing. This is the file's established pattern (:257-258).
     wsHandler.close()
-    cliManager.shutdown()
-    const newCliManager = new CodingCliSessionManager([fakeProvider as any])
-    wsHandler = new WsHandler(server, registry, { codingCliManager: newCliManager })
-    vi.mocked(configStore.snapshot).mockResolvedValue({
+    wsHandler = new WsHandler(server, registry, { codingCliManager: fakeManager })
+    vi.mocked(configStore.snapshot).mockResolvedValueOnce({
       settings: { codingCli: { enabledProviders: ['claude'], providers: {} } },
     } as any)
 
     const ws = await createAuthenticatedWs()
     const requestId = 'cli-sref-promote-1'
+    const createdPromise = new Promise<void>((resolve) => {
+      ws.on('message', (data) => {
+        const msg = JSON.parse(data.toString())
+        if (msg.type === 'codingcli.created') resolve()
+      })
+    })
     ws.send(JSON.stringify({
       type: 'codingcli.create', requestId, provider: 'claude', prompt: 'hi',
       sessionRef: { provider: 'claude', sessionId: 'canonical-cli-session' },
     }))
-    // Wait for the codingcli.event or codingcli.created frame (spawn happened)
-    await new Promise<any>((resolve) => {
-      ws.on('message', (data) => {
-        const msg = JSON.parse(data.toString())
-        if (msg.type === 'codingcli.event' || msg.type === 'error') resolve(msg)
-      })
-    })
-    // Verify the spawn-time resume id was promoted from the provider-matched sessionRef
-    // by checking the session manager's internal state or the provider.create call args
-    newCliManager.shutdown()
+    await createdPromise
+    // V4: the assertion is the fake-manager create spy — the promoted id is
+    // options.resumeSessionId at the manager boundary. Mirrors :295-303.
+    expect(createMock).toHaveBeenCalledWith('claude', expect.objectContaining({
+      resumeSessionId: 'canonical-cli-session',
+    }))
     ws.close()
   })
 ```
@@ -1613,21 +1797,37 @@ Add `sessionRef` to the dynamic codingcli schema at `server/ws-handler.ts:802-81
     }).strict()
 ```
 
-Insert the reject + promotion at `server/ws-handler.ts:3290` (after `endCodingTimer` is defined, before the `try` block at `:3297`):
+Insert the reject + promotion at `server/ws-handler.ts:3280` UNCONDITIONALLY FIRST (coordinator ruling J — before the manager-missing check at `:3281-3288`, so the reject is config-independent: `{no manager} + {resumeSessionId}` answers `INVALID_MESSAGE` + frozen text, not `INTERNAL_ERROR`). The reject runs before `endCodingTimer` is defined — move `endCodingTimer` above it OR use a plain `return` (the timer is a perf wrapper; an early reject before it is acceptable and matches Task 10's freshAgent ordering). Concretely, insert at the very head of the `case 'codingcli.create':` block, before the `if (!this.codingCliManager)` check:
 
 ```ts
-        // ejh6: reject the legacy resumeSessionId wire field on codingcli.create.
-        // The canonical carrier is sessionRef; resumeSessionId stays declared
-        // on the schema solely so the handler can detect-and-reject (see kata ejh6).
+      case 'codingcli.create': {
+        // ejh6 (coordinator ruling J): reject the legacy resumeSessionId wire
+        // field UNCONDITIONALLY FIRST — before the manager-missing check, so
+        // the reject is config-independent. The canonical carrier is sessionRef;
+        // resumeSessionId stays declared on the schema solely so the handler
+        // can detect-and-reject (see kata ejh6).
         if (m.resumeSessionId) {
           this.sendError(ws, {
             code: 'INVALID_MESSAGE',
             message: INVALID_RAW_CODEX_RESUME_MESSAGE,
             requestId: m.requestId,
           })
-          endCodingTimer({ error: true })
           return
         }
+        if (!this.codingCliManager) {
+          this.sendError(ws, {
+            code: 'INTERNAL_ERROR',
+            message: 'Coding CLI sessions not enabled',
+            requestId: m.requestId,
+          })
+          return
+        }
+
+        const endCodingTimer = startPerfTimer(
+          'codingcli_create',
+          { connectionId: ws.connectionId, provider: m.provider },
+          { minDurationMs: perfConfig.slowTerminalCreateMs, level: 'warn' },
+        )
         // ejh6: promote a provider-matched sessionRef into the spawn-time resume
         // id (provider must equal m.provider, mirroring terminal.create's
         // expectedSessionRef match at :2085-2087).
@@ -1726,7 +1926,7 @@ git commit -m "feat(ejh6): Node WS codingcli.create reject + sessionRef promotio
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Add to `test/unit/client/lib/pane-reconcile.test.ts` (model on the existing `addTerminalPane` helper at `:51+` and the `FreshAgentView.reconcile.test.tsx:406` promotion pin):
+Add to `test/unit/client/lib/pane-reconcile.test.ts` (per V4: drive through the EXPORTED `buildReconcileRequest(asRootState(panes))` pattern used at `:116` — NOT `collectTerminalPaneTargets` (signature-mismatched: it takes `(layouts, terminalIds)`, a terminalId-membership filter, NOT `(state, tabId)`, and returns `[]` for a legacy-only pane with no `terminalId`) and NOT `buildRequestFromPanes` (private, not exported). Assert on `req.panes[0]`. The file already imports `buildReconcileRequest` at `:29` and `asRootState`/`emptyPanesState`/`addTerminalPane` are file-local helpers):
 
 ```ts
   it('promotes a legacy-only terminal pane resumeSessionId into a canonical sessionRef on the reconcile claim', () => {
@@ -1736,16 +1936,15 @@ Add to `test/unit/client/lib/pane-reconcile.test.ts` (model on the existing `add
       resumeSessionId: 'legacy-claude-session-id',
     } as Partial<TerminalPaneContent>)
 
-    const targets = collectTerminalPaneTargets(state, 'tab_1')
-    const request = buildRequestFromPanes(targets)
-    expect(request).not.toBeNull()
-    const pane = request!.panes[0]
+    const req = buildReconcileRequest(asRootState(state))
+    expect(req).not.toBeNull()
+    const pane = req!.panes[0]
     expect(pane.sessionRef).toEqual({ provider: 'claude', sessionId: 'legacy-claude-session-id' })
     expect(pane.resumeSessionId).toBeUndefined()
   })
 ```
 
-Add to `test/unit/client/lib/pane-reconcile.fresh-agent.test.ts` (model on the existing fresh-agent pane helpers in that file):
+Add to `test/unit/client/lib/pane-reconcile.fresh-agent.test.ts` (per V4: drive through `buildReconcileRequest(asRootState(panes), { includeFreshAgent: true })` used at `:143` — NOT `collectFreshAgentPaneTargets` (does not exist) and NOT `buildRequestFromPanes` (private). The file already imports `buildReconcileRequest` at `:32` and `asRootState`/`emptyPanesState`/`addFreshAgentPane` are file-local helpers):
 
 ```ts
   it('promotes a legacy-only fresh-agent pane resumeSessionId into a canonical sessionRef on the reconcile claim', () => {
@@ -1755,12 +1954,12 @@ Add to `test/unit/client/lib/pane-reconcile.fresh-agent.test.ts` (model on the e
       resumeSessionId: 'legacy-fa-session-id',
     } as Partial<FreshAgentPaneContent>)
 
-    const targets = collectFreshAgentPaneTargets(state, 'tab_1')
-    const request = buildRequestFromPanes(targets)
-    expect(request).not.toBeNull()
-    const pane = request!.panes[0]
-    expect(pane.sessionRef).toEqual({ provider: 'claude', sessionId: 'legacy-fa-session-id' })
-    expect(pane.resumeSessionId).toBeUndefined()
+    const req = buildReconcileRequest(asRootState(state), { includeFreshAgent: true })
+    expect(req).not.toBeNull()
+    const pane = req!.panes.find((p) => p.kind === 'fresh-agent')
+    expect(pane).toBeDefined()
+    expect(pane!.sessionRef).toEqual({ provider: 'claude', sessionId: 'legacy-fa-session-id' })
+    expect(pane!.resumeSessionId).toBeUndefined()
   })
 ```
 
@@ -1850,7 +2049,7 @@ The `effectiveReconcileSessionRef` helper mirrors `FreshAgentView.tsx`'s `effect
 
 - [ ] **Step 6: Run impacted-test verification**
 
-Every client test that exercises `pane-reconcile` or `collectTerminalPaneTargets`/`collectFreshAgentPaneTargets` is impacted. The existing tests in `pane-reconcile.test.ts`/`pane-reconcile.fresh-agent.test.ts` that send `sessionRef` directly (not legacy) are unaffected (the helper passes `sessionRef` through when present). The `FreshAgentView.reconcile.test.tsx:406` pin already asserts the promotion pattern on the create/attach path — it is unaffected (different module).
+Every client test that exercises `pane-reconcile` or `buildReconcileRequest` is impacted. The existing tests in `pane-reconcile.test.ts`/`pane-reconcile.fresh-agent.test.ts` that send `sessionRef` directly (not legacy) are unaffected (the helper passes `sessionRef` through when present). The `FreshAgentView.reconcile.test.tsx:406` pin already asserts the promotion pattern on the create/attach path — it is unaffected (different module).
 
 Run: `npm run test:vitest -- run test/unit/client/lib/pane-reconcile.test.ts test/unit/client/lib/pane-reconcile.fresh-agent.test.ts test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx --config config/vitest/vitest.config.ts`
 
@@ -1893,7 +2092,7 @@ Expected: output shows ONLY these categories:
 3. Alias conversion sites (CLI `promoteResumeFlag` in `server/cli/index.ts`, MCP `freshell-tool.ts` `resume`/`resumeSessionId` param handling).
 4. Retained-for-rejection schema/struct fields (each carrying the section 3c comment): `shared/ws-protocol.ts` (`CodingCliCreateSchema`, `FreshAgentCreateSchema`, `FreshAgentAttachSchema`, `ReconcilePaneSchema`), `server/ws-handler.ts` (dynamic terminal.create + codingcli schemas), `crates/freshell-protocol/src/client_messages.rs` (`TerminalCreate`, `CodingCliCreate`, `FreshAgentCreate`, `FreshAgentAttach`, `ReconcilePane`).
 5. Rejection handlers: `crates/freshell-freshagent/src/terminal_tabs.rs` (`requested_resume_session_id_for_mode`), `crates/freshell-ws/src/terminal.rs` (head-of-`handle_create` blanket reject, `fresh_agent_control_refusal` create/attach arms), `server/ws-handler.ts` (terminal.create/freshAgent.create/freshAgent.attach/codingcli.create head-of-case rejects), `server/agent-api/router.ts` (`requestedResumeSessionIdForMode`).
-6. Sidecar JSON-lines writers (`claude.rs:469`/`:1294` — internal adapter-to-sidecar protocol, not Freshell wire input, per binding correction C).
+6. Sidecar-protocol file class (V5 ruling — NOT Freshell-wire input, EXCLUDE from rejection scope): `crates/freshell-claude-sidecar/index.mjs:10,:240` (reader), `claude.rs:469`/`:1294` + Node `sdk-bridge.ts:85,:168,:193` (writers), embedded fake sidecars in `test/e2e-browser/fixtures/` and in-crate `tests/*.rs` fake-sidecar JS, and the ~8 sidecar-log-reading specs (`freshagent-settings-resume-rust.spec.ts:545,:551`, `hidden-pane-rebind-rust.spec.ts:365-367`, `freshclaude-restart-parity-rust.spec.ts:309`, `freshclaude-identity-persistence-rust.spec.ts:313,:410`, `wavea-interactions-rust.spec.ts:403-407`, `restore-contract-wall-rust.spec.ts:1040,:1304`, `restore-matrix.spec.ts:400,:1099`). None are Freshell-wire input — the adapter still emits `resumeSessionId` on the internal sidecar protocol post-conversion, and these readers stay green because the ID VALUE is preserved. Production internal-name readers (`codex.rs:500`, `claude.rs:348/:1809`, `layout_store_content.rs:254`, `tabs_store_model.rs:484`, `pane_ops.rs:686`) are also in this category.
 
 If any hit falls outside these categories, add a section 3c doc comment, convert it to sessionRef, or document it as an allowed internal — then re-run.
 
@@ -1919,13 +2118,29 @@ cargo test --workspace
 
 Expected: PASS.
 
-Run the Playwright e2e (CLI path — the `agent-cli-flow` e2e with the new WS assertion; the MCP e2e `mcp-qa-smoke-rust`):
+Run the Vitest e2e (V1 corrected — `test/e2e/agent-cli-flow.test.ts` is a Vitest file under the DEFAULT config, NOT the server config; it must run with no `--config` flag so the coordinator auto-routes it to `config/vitest/vitest.config.ts`):
 
 ```bash
-npm run test:e2e:local -- --grep "agent-cli-flow|mcp-qa-smoke-rust"
+FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/e2e/agent-cli-flow.test.ts
 ```
 
-Expected: PASS (CLI `--resume` promotes to sessionRef and still works; MCP `resume` alias still works; the new WS assertion gets INVALID_MESSAGE + frozen text).
+Expected: PASS (CLI `--resume` promotes to sessionRef and still works; the new WS assertion gets INVALID_MESSAGE + frozen text).
+
+Run the Playwright e2e (MCP e2e `mcp-qa-smoke-rust`; PLUS the repurposed `remote-tab-linkage-rust` spec on the rust-chromium project — V6: this spec was repurposed in Task 5 and NO plan gate re-ran it until now):
+
+```bash
+npm run test:e2e:local -- --grep "mcp-qa-smoke-rust|remote-tab-linkage-rust" --project rust-chromium
+```
+
+Expected: PASS (MCP `resume` alias still works; the repurposed `remote-tab-linkage-rust` spec asserts REST 400 + frozen text + no spawn). NOTE: `--project rust-chromium` is required because the spec is `rust-chromium`-registered and was added to `RUST_ONLY_SPECS` in Task 5 (so the default `chromium` project no longer picks it up — the pre-existing `:111` base failure on the chromium leg is also fixed by that addition).
+
+Run a standalone typecheck to catch any drift from the `ErrorCode` enum addition (Task 10 / coordinator ruling A):
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS (the `FRESH_AGENT_CREATE_FAILED` addition to `ErrorCode` typechecks on both server and client; `sendError({code:'FRESH_AGENT_CREATE_FAILED',...})` in Task 10 resolves against the extended enum).
 
 - [ ] **Step 5: Refactor while green**
 
@@ -1955,7 +2170,7 @@ git commit -m "fix(ejh6): clean up remaining rg sweep violations"
 2. WS `terminal.create` with the field then `error{INVALID_MESSAGE}` with the named text, no spawn, registry row count unchanged — covered by Task 6 (`blanket_reject_legacy_resume_session_id_on_any_create`) and Task 9 (`it.each` in `ws-terminal-create-reuse-running-codex.test.ts`).
 3. WS `freshAgent.create` with the field then create-failed envelope, no sidecar spawn — covered by Task 7 (`freshagent_create_with_legacy_resume_session_id_is_rejected`) and Task 10 (`rejects freshAgent.create carrying resumeSessionId`).
 4. WS `codingcli.create` with the field then `error{INVALID_MESSAGE}`; with `sessionRef` then resume works — covered by Task 11 (`rejects codingcli.create carrying resumeSessionId` + `promotes a provider-matched sessionRef`).
-5. CLI `--resume` and MCP `resume` still work end-to-end (they convert; nothing user-facing changes) — covered by existing `agent-cli-flow.test.ts:493-560` (positive `--resume` to sessionRef) and `freshell-tool.test.ts` alias tests, both unchanged.
+5. CLI `--resume` and MCP `resume` still work end-to-end (they convert; nothing user-facing changes) — covered by existing `agent-cli-flow.test.ts:493-560` (positive `--resume` to sessionRef, run under the default vitest config per V1) and `freshell-tool.test.ts` alias tests, both unchanged.
 6. Reload/restore of existing tabs (including pre-existing persisted state that may carry legacy pane-content fields) still resumes correctly — covered by the permanent `pane.reconcile` compat door (Task 6 reconcile doc + Task 12 client promotion), with existing `reconcile.rs` cfg(test) fns `:1021`/`:1053`/`:1083` and `pane_reconcile.rs:125` staying green.
-7. `freshAgent.attach` with the field then `freshAgent.error{FRESH_AGENT_CREATE_FAILED}` + frozen text — covered by Task 7 (`freshagent_attach_with_legacy_resume_session_id_is_rejected`) and Task 10 (`rejects freshAgent.attach carrying resumeSessionId`).
-8. `rg 'resumeSessionId' server/ src/ shared/ crates/ --glob '!*test*'` shows only allowed categories — verified in Step 2.
+7. `freshAgent.attach` with the field then the create-failed family envelope + frozen text — Rust rides `freshAgent.event{freshAgent.error{code:'FRESH_AGENT_CREATE_FAILED'}}` (UI-visible, covered by Task 7 `freshagent_attach_with_legacy_resume_session_id_is_rejected`); Node rides `error{code:'FRESH_AGENT_CREATE_FAILED'}` (socket-loud but UI-invisible by design — coordinator ruling A/V2; covered by Task 10 `rejects freshAgent.attach carrying resumeSessionId`). The asymmetry is accepted: kata §1c names the code family, not the frame type; the frozen client's senders never carry the field.
+8. `rg 'resumeSessionId' server/ src/ shared/ crates/ --glob '!*test*'` shows only allowed categories — verified in Step 2 (sidecar-protocol file class excluded per V5 ruling).

--- a/docs/plans/2026-08-16-legacy-resume-guard.md
+++ b/docs/plans/2026-08-16-legacy-resume-guard.md
@@ -37,6 +37,8 @@ Implement kata issue ejh6 (revised 2026-08-16 spec: "Remove the legacy resumeSes
 - **Never weaken tests:** never delete a behavior test without a replacement; never mark tests skip; never simplify assertions to get green.
 - **Coordinated runners:** Node tests via `npm run test:vitest -- run <paths> --config <config>` (default config `config/vitest/vitest.config.ts`, server config `config/vitest/vitest.server.config.ts`); Rust via `cargo test -p <crate>` focused, `cargo test --workspace` as gate; `npm run check` (typecheck + coordinated full suite) as final gate.
 - **Rejection mechanism:** handler-level only. Never use `.strict()`/`deny_unknown_fields`/serde field removal as the rejection mechanism (zod non-strict strips silently; `.strict()` rejects with a generic unrecognized-key error that cannot carry the frozen text). The field stays DECLARED in every schema/struct.
+- **Presence-based rejection (coordinator ruling, review finding 2):** rejection is PRESENCE-based, not non-empty. The contract is "any create that CARRIES the field." Rust WS structs reject when `resume_session_id.is_some()` (covers `""`); Rust REST `Value` bodies reject when `body.get("resumeSessionId").is_some()` (any JSON value — string, empty, null, number, object); Node rejects when `m.resumeSessionId !== undefined` / `req.body?.resumeSessionId !== undefined`. Serde `Option<String>` cannot see JSON `null` deserialize-to-`None` — this is an accepted WS edge where the WS schema level is a typed struct (JSON `null` on REST `Value` bodies IS rejected since REST reads raw `Value`). All draft checks and tests must use presence, not `is_some_and(|s| !s.is_empty())` / `isNonEmptyString` / truthiness. Tests must cover `resumeSessionId: ""` on each door plus REST `{resumeSessionId: null}` and `{resumeSessionId: 42}`.
+- **Door-top REST rejection (coordinator ruling, review finding 3):** REST rejection runs at the TOP of each route handler in BOTH servers, BEFORE any branch (agent/browser/editor/terminal) and BEFORE `layout.split_pane` in the split route. In Node, check `req.body?.resumeSessionId !== undefined` at the top of `POST /tabs`, `POST /panes/:id/split`, `POST /panes/:id/respawn`; `requestedResumeSessionIdForMode` keeps its sessionRef-resolution role but no longer throws (single check at door-top for KISS). In Rust, check `body.get("resumeSessionId").is_some()` at each axum handler entry in `terminal_tabs.rs`/`pane_ops.rs` before any branch or layout mutation. Tests: pane/layout unchanged on rejected split; browser/editor branches also 400.
 - **Section 3c doc comment:** every retained `resumeSessionId`/`resume_session_id` field in a wire schema/struct gets the comment `Retained solely so the handler can detect-and-reject; see kata ejh6.` — EXCEPT `ReconcilePane.resume_session_id` which gets the PERMANENT compat-door comment.
 - **`restoreKey` gating:** blanket REST reject does NOT gate on `restoreKey` — no production producer emits it (verified), so blanket reject regresses nothing live (binding correction A).
 - **Sidecar JSON-lines writers are not wire input:** `claude.rs:469` and `:1294` write `resumeSessionId` to the claude Node sidecar's internal JSON-lines protocol, not the Freshell WS wire — leave them untouched (binding correction C).
@@ -88,7 +90,7 @@ This task is a pure dedup refactor — no new behavior, so the "test" is a new p
 use freshell_protocol::LEGACY_RESUME_IDENTITY_REFUSAL;
 
 #[test]
-fn frozen_refusal_text_is_byte_exact() {
+fn legacy_reject_frozen_text() {
     assert_eq!(
         LEGACY_RESUME_IDENTITY_REFUSAL,
         "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."
@@ -98,7 +100,7 @@ fn frozen_refusal_text_is_byte_exact() {
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
-Run: `cargo test -p freshell-protocol --test legacy_resume_text`
+Run: `cargo test -p freshell-protocol --test legacy_resume_text legacy_reject_frozen_text`
 
 Expected: FAIL because `cannot find function or const LEGACY_RESUME_IDENTITY_REFUSAL in crate freshell_protocol` — the const does not exist yet.
 
@@ -161,7 +163,7 @@ Replace the inline literal at `:2179-2183`:
 
 - [ ] **Step 4: Run the focused test**
 
-Run: `cargo test -p freshell-protocol --test legacy_resume_text && cargo test -p freshell-ws --test live_session_ref_guard legacy_only_restore_is_refused && npm run test:vitest -- run test/server/ws-terminal-create-reuse-running-codex.test.ts --config config/vitest/vitest.server.config.ts`
+Run: `cargo test -p freshell-protocol --test legacy_resume_text legacy_reject_ && cargo test -p freshell-ws --test live_session_ref_guard legacy_only_restore && npm run test:vitest -- run test/server/ws-terminal-create-reuse-running-codex.test.ts --config config/vitest/vitest.server.config.ts`
 
 Expected: PASS — the new const test pins the text; existing pinned-text tests stay green because the text is byte-identical.
 
@@ -423,170 +425,212 @@ git commit -m "test(ejh6): convert e2e-browser Rust wire-send tests to sessionRe
 
 ---
 
-### Task 5: Rust REST reject — uniform any-carry on all modes + section 3c doc comments + remote-tab-linkage repurpose
+### Task 5: Rust REST reject — door-top presence check on all routes + section 3c doc comments + remote-tab-linkage re-carrier
 
 **Files:**
-- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs:117-136` (`requested_resume_session_id_for_mode` — uniform any-carry throw, legacy checked BEFORE sessionRef early-return) and `derive_resume_identity:507-531` (reorder: legacy check before sessionRef derivation)
-- Modify: `crates/freshell-protocol/src/client_messages.rs:231-235` (`TerminalCreate.resume_session_id` doc), `:409-411` (`ReconcilePane.resume_session_id` doc — PERMANENT compat), `:445` (`CodingCliCreate.resume_session_id` doc), `:511` (`FreshAgentCreate.resume_session_id` doc), `:527` (`FreshAgentAttach.resume_session_id` doc)
-- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs:6334` (`create_tab_with_identity_or_shell_mode_does_not_warn_invariant` — flip from 200 acceptance to 400 rejection assertion)
-- Modify: `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` (repurpose: re-carrier sends to sessionRef where assertions aren't legacy-acceptance; convert the acceptance assertion chain at `:197-325` into a REST 400 rejection e2e — new premise: bare legacy then 400 naming sessionRef; ~110 lines of create-success-dependent steps become dead and must be removed/rebuilt around the rejection premise)
-- Modify: `test/e2e-browser/playwright.config.ts:176` (`RUST_ONLY_SPECS` — add `/remote-tab-linkage-rust\.spec\.ts$/`; pre-existing config gap: the spec is registered in `rust-chromium` testMatch at `:389` but MISSING from `RUST_ONLY_SPECS`, so the default match-all `chromium` project also selects it and fails at `:111` `expect(e2eServerKind).toBe('rust')` on EVERY HEAD including base — same class as `term28-path-shadow-rust` at cloud config `:53-55`. Adding it to `RUST_ONLY_SPECS` fixes this pre-existing base failure on the chromium leg.)
-- Test: `crates/freshell-freshagent/src/terminal_tabs.rs` (test mod — add per-mode + dual-carrier rejection test)
-- Test: `crates/freshell-freshagent/src/pane_ops_tests.rs` (new split/respawn rejection tests using `create_shell_tab` for real pane ids)
+- Modify: `crates/freshell-freshagent/src/lib.rs:1620-1633` (`create_tab` handler — insert door-top presence check BEFORE the agent/browser/editor/terminal branch) and `crates/freshell-freshagent/src/terminal_tabs.rs:117-136` (`requested_resume_session_id_for_mode` — remove the legacy throw; keep sessionRef resolution only; the door-top check is the single rejection point for KISS)
+- Modify: `crates/freshell-freshagent/src/pane_ops.rs:144-149` (`split_pane` handler — insert door-top check BEFORE `resolve_pane_target` and `layout.split_pane` at `:175`, so a rejection returns 400 with NO layout mutation) and `:699-745` (`respawn_pane` handler — insert door-top check BEFORE `spawn_terminal_pane` at `:719`)
+- Modify: `crates/freshell-protocol/src/client_messages.rs:231-235,:409-411,:445,:511,:527` (section 3c doc comments — same as before)
+- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs:6334` (flip from 200 to 400)
+- Modify: `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` (finding 6: RE-CARRIER sends to sessionRef, KEEP all ~110 lines of downstream behavior assertions, APPEND one new rejection case; do NOT delete behavior coverage)
+- Modify: `test/e2e-browser/playwright.config.ts:176` (`RUST_ONLY_SPECS` — add `/remote-tab-linkage-rust\.spec\.ts$/`)
+- Test: `crates/freshell-freshagent/src/terminal_tabs.rs` (test mod — add per-mode, dual-carrier, presence-edge, browser/editor rejection tests)
+- Test: `crates/freshell-freshagent/src/pane_ops_tests.rs` (new split/respawn rejection tests with layout-unchanged assertion)
 
 **Interfaces:**
-- Consumes: `LEGACY_RESUME_IDENTITY_REFUSAL` (from Task 1); `fail_json(StatusCode::BAD_REQUEST, ...)` at `lib.rs:1556`; `post(router, uri, body, auth: bool)` helper at `terminal_tabs.rs:2671` (4th arg is `bool`, NOT an `AUTH_HEADER` const — V3 finding); `create_shell_tab(router)` helper at `pane_ops_tests.rs:87-102` (returns `(tabId, paneId, terminalId)` parsed from the POST /api/tabs response — pane ids are UUIDs minted by the store, never hardcoded `pane_1`).
-- Produces: all three Rust REST doors return HTTP 400 `{status:"error",message:<frozen>}` whenever the body carries a non-empty `resumeSessionId`, EVEN when a matching `sessionRef` is also present (uniform any-carry, coordinator final ruling L — no first-party sender dual-carries; the codex dual-carrier tolerance at `restore-decision.ts:40` is retired).
+- Consumes: `LEGACY_RESUME_IDENTITY_REFUSAL` (from Task 1); `fail_json(StatusCode::BAD_REQUEST, ...)` at `lib.rs:1556`; `post(router, uri, body, auth: bool)` helper (4th arg is `bool`, use `true`); `create_shell_tab(router)` helper at `pane_ops_tests.rs:87-102`.
+- Produces: all three Rust REST doors return HTTP 400 at the door-top whenever the body CONTAINS the key `resumeSessionId` with ANY JSON value (string, empty, null, number, object), BEFORE any branch or layout mutation. `requested_resume_session_id_for_mode` keeps its sessionRef-resolution role but no longer throws (single check at door-top for KISS).
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Add to the `#[cfg(test)] mod tests` in `crates/freshell-freshagent/src/terminal_tabs.rs` (after the existing `create_codex_tab_rejects_raw_resume_session_id_without_session_ref` at `:4415`). Note: `post()` 4th arg is `auth: bool` (use `true`), NOT an `AUTH_HEADER` const (V3 finding — `AUTH_HEADER` does not exist in this crate):
+Add to the `#[cfg(test)] mod tests` in `crates/freshell-freshagent/src/terminal_tabs.rs` (after `:4415`). `post()` 4th arg is `auth: bool` (use `true`):
 
 ```rust
 #[tokio::test]
-async fn rest_create_rejects_legacy_resume_session_id_for_every_session_mode() {
+async fn legacy_reject_rest_create_all_modes() {
     let state = state_with_registry();
     let app = crate::router(state);
     for mode in ["claude", "opencode", "amplifier"] {
         let (status, body) = post(
-            app.clone(),
-            "/api/tabs",
+            app.clone(), "/api/tabs",
             json!({"mode": mode, "resumeSessionId": format!("legacy-{mode}-id")}),
             true,
-        )
-        .await;
-        assert_eq!(
-            status,
-            StatusCode::BAD_REQUEST,
-            "{mode}: legacy resumeSessionId must be rejected with 400, got {status}: {body}"
-        );
-        let msg = body["message"].as_str().expect("message field");
-        assert_eq!(
-            msg,
-            "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.",
-            "{mode}: frozen text must be byte-exact, got {msg}"
-        );
+        ).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{mode}: {body}");
+        assert_eq!(body["message"], json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."));
     }
 }
 
-/// ejh6 uniform any-carry: a body carrying BOTH a matching sessionRef AND
-/// resumeSessionId is REJECTED (coordinator ruling L — no first-party sender
-/// dual-carries; the codex dual-carrier tolerance at restore-decision.ts:40 is
-/// retired). The legacy field is rejected even when sessionRef is present.
 #[tokio::test]
-async fn rest_create_rejects_legacy_resume_session_id_even_with_companion_session_ref() {
+async fn legacy_reject_rest_create_dual_carrier() {
     let state = state_with_registry();
     let app = crate::router(state);
     let (status, body) = post(
-        app,
-        "/api/tabs",
-        json!({
-            "mode": "claude",
-            "resumeSessionId": "legacy-should-still-reject",
-            "sessionRef": {"provider": "claude", "sessionId": "canonical-session-id"}
-        }),
+        app, "/api/tabs",
+        json!({"mode": "claude", "resumeSessionId": "legacy", "sessionRef": {"provider": "claude", "sessionId": "canonical"}}),
         true,
-    )
-    .await;
+    ).await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "dual-carrier must reject: {body}");
-    assert_eq!(
-        body["message"],
-        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.")
-    );
+    assert_eq!(body["message"], json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."));
+}
+
+/// ejh6 presence-based (finding 2): the contract is "any create that CARRIES
+/// the field". REST reads raw Value, so null/number/object values ARE rejected.
+#[tokio::test]
+async fn legacy_reject_rest_create_presence_edge_cases() {
+    let state = state_with_registry();
+    let app = crate::router(state);
+    for (label, val) in [
+        ("empty-string", json!("")),
+        ("null", json!(null)),
+        ("number", json!(42)),
+    ] {
+        let (status, body) = post(
+            app.clone(), "/api/tabs",
+            json!({"mode": "claude", "resumeSessionId": val}),
+            true,
+        ).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{label}: {body}");
+        assert_eq!(body["message"], json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."));
+    }
+}
+
+/// ejh6 finding 3: browser/editor branches also 400 when carrying the field.
+#[tokio::test]
+async fn legacy_reject_rest_browser_editor_branches() {
+    let state = state_with_registry();
+    let app = crate::router(state);
+    for (label, extra) in [
+        ("browser", json!({"browser": "https://example.com"})),
+        ("editor", json!({"editor": "/tmp/file.ts"})),
+    ] {
+        let (status, body) = post(
+            app.clone(), "/api/tabs",
+            json!({"resumeSessionId": "legacy", ...extra}),
+            true,
+        ).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{label} branch must reject: {body}");
+    }
 }
 ```
 
-Flip the `:6334` test (`create_tab_with_identity_or_shell_mode_does_not_warn_invariant`) from 200 acceptance to 400 rejection — the body sends `{"mode":"amplifier","resumeSessionId":"sess-no-warn-1"}` and currently asserts `StatusCode::OK`; change the assertion to:
+Flip the `:6334` test (`create_tab_with_identity_or_shell_mode_does_not_warn_invariant`) — change `assert_eq!(status, StatusCode::OK, ...)` to `assert_eq!(status, StatusCode::BAD_REQUEST, ...)` + frozen text assert.
 
-```rust
-        assert_eq!(status, StatusCode::BAD_REQUEST, "legacy amplifier must reject: {body}");
-        assert_eq!(
-            body["message"],
-            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.")
-        );
-```
-
-Add to `crates/freshell-freshagent/src/pane_ops_tests.rs` (split test section opens at `:122`; add after the last split test). Per V3: pane ids are UUIDs minted by the store — use `create_shell_tab(router.clone())` to parse the pane id from the POST /api/tabs response exactly like `split_terminal_pane_spawns_real_pty_and_broadcasts_pane_split` at `:181-228`. The `post()` 4th arg is `auth: bool` (use `true`):
+Add to `crates/freshell-freshagent/src/pane_ops_tests.rs` — split test with layout-unchanged assertion (finding 3):
 
 ```rust
 #[tokio::test]
-async fn split_pane_rejects_legacy_resume_session_id_with_400() {
+async fn legacy_reject_split() {
     let state = state_with_registry();
     let app = crate::router(state);
     let (_tab_id, pane_id, _terminal_id) = create_shell_tab(app.clone()).await;
+    let layout_before = state.layout.snapshot();
     let (status, body) = post(
-        app,
-        &format!("/api/panes/{pane_id}/split"),
-        json!({"direction": "horizontal", "mode": "claude", "resumeSessionId": "legacy-split-id"}),
+        app, &format!("/api/panes/{pane_id}/split"),
+        json!({"direction": "horizontal", "mode": "claude", "resumeSessionId": "legacy-split"}),
         true,
-    )
-    .await;
+    ).await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "split legacy reject: {body}");
-    assert_eq!(
-        body["message"],
-        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.")
-    );
+    assert_eq!(body["message"], json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."));
+    // Finding 3: layout MUST be unchanged — the door-top check fires BEFORE layout.split_pane.
+    assert_eq!(state.layout.snapshot(), layout_before, "layout must not mutate on a rejected split");
 }
-```
 
-Add to the respawn test section (opens at `:562`):
-
-```rust
 #[tokio::test]
-async fn respawn_pane_rejects_legacy_resume_session_id_with_400() {
+async fn legacy_reject_respawn() {
     let state = state_with_registry();
     let app = crate::router(state);
     let (_tab_id, pane_id, _terminal_id) = create_shell_tab(app.clone()).await;
     let (status, body) = post(
-        app,
-        &format!("/api/panes/{pane_id}/respawn"),
-        json!({"mode": "claude", "resumeSessionId": "legacy-respawn-id"}),
+        app, &format!("/api/panes/{pane_id}/respawn"),
+        json!({"mode": "claude", "resumeSessionId": "legacy-respawn"}),
         true,
-    )
-    .await;
+    ).await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "respawn legacy reject: {body}");
-    assert_eq!(
-        body["message"],
-        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.")
-    );
+    assert_eq!(body["message"], json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."));
 }
 ```
 
-Repurpose `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` (V6: the spec's premise is bare-legacy REST acceptance — `:197-206` sends `POST /api/tabs {mode:'amplifier', resumeSessionId: SEEDED_SESSION_ID}` and `:208` asserts `toBe(200)`; Task 5's reject makes `:208` receive 400 + frozen text). Rewrite the test around a REST 400 rejection premise:
+Re-carrier `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` (finding 6: DO NOT delete the ~110 lines of behavior coverage. RE-CARRIER the send at `:197-206` from `resumeSessionId: SEEDED_SESSION_ID` to `sessionRef: { provider: 'amplifier', sessionId: SEEDED_SESSION_ID }`, KEEP every downstream assertion (resume argv, live broadcast, sidebar linkage, click dedupe, title sync, persisted sessionRef, restart/reload restoration, post-restart resume) as sessionRef-carrier behavior coverage, then APPEND one new rejection-focused case at the end of the describe block:
 
-- `:194-196` Step-2 comment — rewrite to "Step 2: a bare legacy `resumeSessionId` on `POST /api/tabs {mode:'amplifier'}` is REJECTED with 400 naming sessionRef (kata ejh6)."
-- `:197-210` send + assertions — keep the send as-is (bare legacy); invert `:208` `toBe(200)` → `toBe(400)`; `:209-210` `body?.data?.tabId` → assert `body.status === 'error'` and `body.message` contains the frozen text; delete the `restTabId` binding.
-- `:212-325` (~110 lines of create-success-dependent steps: broadcast visibility, tab-count delta, argv-log polls, sidebar linkage, dedupe click, title sync, persisted-sessionRef content, full restart-durability block) — these become dead under the rejection premise; delete them. The test now asserts: 400 + frozen text + no spawn (no tab count delta, no argv log entry). A minimal post-reject assertion: `expect.poll(() => harness.getTabCount()).toBe(tabCountBeforeCreate)` (no tab materialized).
+```ts
+  it('rejects a bare legacy resumeSessionId on REST create with 400 + frozen text (kata ejh6)', async () => {
+    const res = await fetch(`${info.baseUrl}/api/tabs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-auth-token': info.token },
+      body: JSON.stringify({ mode: 'amplifier', cwd: projectDir, resumeSessionId: SEEDED_SESSION_ID, name: 'legacy-reject-case' }),
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.status).toBe('error')
+    expect(body.message).toContain('sessionRef')
+    expect(body.message).toContain('resumeSessionId')
+  })
+```
 
-Add `/remote-tab-linkage-rust\.spec\.ts$/` to `RUST_ONLY_SPECS` at `test/e2e-browser/playwright.config.ts:176` (pre-existing config gap fix — the spec is `rust-chromium`-registered at `:389` but missing from the list, so the `chromium` project picks it up and fails at `:111` on every HEAD including base).
+Add `/remote-tab-linkage-rust\.spec\.ts$/` to `RUST_ONLY_SPECS` at `test/e2e-browser/playwright.config.ts:176` (pre-existing config gap fix).
 
-- [ ] **Step 2: `Run` the test and verify the intended failure**
+- [ ] **Step 2: Run the test and verify the intended failure**
 
-Run: `cargo test -p freshell-freshagent rest_create_rejects_legacy_resume_session_id_for_every_session_mode rest_create_rejects_legacy_resume_session_id_even_with_companion_session_ref split_pane_rejects_legacy_resume_session_id_with_400 respawn_pane_rejects_legacy_resume_session_id_with_400`
+Run: `cargo test -p freshell-freshagent legacy_reject_`
 
-Expected: FAIL because the non-codex modes silently accept the legacy field today (`requested_resume_session_id_for_mode` at `:135` returns `Ok(legacy)` for non-codex), and the dual-carrier case returns sessionRef (the `:122-124` sessionRef early-return fires before the legacy check) — the tests get 200 instead of 400.
+Expected: FAIL because the non-codex modes silently accept the legacy field, the browser/editor branches bypass the check entirely, and the split door mutates the layout before reaching `spawn_terminal_pane` — the tests get 200/approx instead of 400, and the layout-unchanged assertion fails.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Widen `requested_resume_session_id_for_mode` at `crates/freshell-freshagent/src/terminal_tabs.rs:117-136`. Per coordinator ruling L (uniform any-carry): check legacy BEFORE the sessionRef early-return so a dual-carrier body is rejected:
+Add a door-top presence check at the TOP of `create_tab` in `crates/freshell-freshagent/src/lib.rs:1620-1633` (BEFORE the `if agent.is_empty()` branch delegation at `:1632`):
+
+```rust
+    // ejh6 (finding 3): door-top presence check. Reject whenever the body
+    // CONTAINS the key resumeSessionId with ANY JSON value (string, empty,
+    // null, number, object) — BEFORE any agent/browser/editor/terminal branch.
+    if body.get("resumeSessionId").is_some() {
+        return fail_json(StatusCode::BAD_REQUEST, LEGACY_RESUME_IDENTITY_REFUSAL.to_string());
+    }
+```
+
+Add the same door-top check at the TOP of `split_pane` in `crates/freshell-freshagent/src/pane_ops.rs:144-149` (BEFORE `resolve_pane_target` at `:154` and `layout.split_pane` at `:175`):
+
+```rust
+pub(crate) async fn split_pane(
+    State(state): State<FreshAgentState>,
+    Path(raw_pane_id): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    if !authorized(&headers, &state.auth_token) {
+        return fail_json(StatusCode::UNAUTHORIZED, "unauthorized".to_string());
+    }
+    // ejh6 (finding 3): door-top presence check BEFORE layout.split_pane so
+    // a rejection returns 400 with NO layout mutation.
+    if body.get("resumeSessionId").is_some() {
+        return fail_json(StatusCode::BAD_REQUEST, LEGACY_RESUME_IDENTITY_REFUSAL.to_string());
+    }
+    // ... rest unchanged ...
+```
+
+Add the same door-top check at the TOP of `respawn_pane` in `crates/freshell-freshagent/src/pane_ops.rs:699-745` (BEFORE `spawn_terminal_pane` at `:719`):
+
+```rust
+    // ejh6 (finding 3): door-top presence check BEFORE spawn_terminal_pane.
+    if body.get("resumeSessionId").is_some() {
+        return fail_json(StatusCode::BAD_REQUEST, LEGACY_RESUME_IDENTITY_REFUSAL.to_string());
+    }
+```
+
+Update `requested_resume_session_id_for_mode` at `crates/freshell-freshagent/src/terminal_tabs.rs:117-136` — remove the legacy throw (the door-top check is the single rejection point for KISS); keep sessionRef resolution only:
 
 ```rust
 fn requested_resume_session_id_for_mode(
     session_ref: Option<&SessionLocator>,
     mode: &str,
-    legacy_resume_session_id: Option<&str>,
+    _legacy_resume_session_id: Option<&str>,
 ) -> Result<Option<String>, Response> {
-    // ejh6 (uniform any-carry, coordinator ruling L): reject the legacy
-    // resumeSessionId wire field on EVERY mode, EVEN when a matching sessionRef
-    // is also present. No first-party sender dual-carries; the codex dual-carrier
-    // tolerance at restore-decision.ts:40 is retired. The legacy check runs
-    // BEFORE the sessionRef early-return so a dual-carrier body is rejected.
-    if legacy_resume_session_id.is_some_and(|s| !s.is_empty()) {
-        return Err(fail_json(
-            StatusCode::BAD_REQUEST,
-            LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
-        ));
-    }
+    // ejh6: the legacy throw moved to the door-top check in each axum handler
+    // (finding 3). This function keeps its sessionRef-resolution role only.
+    // The _legacy param is retained in the signature for caller compatibility
+    // but is intentionally unused — the door-top check already rejected any
+    // body carrying the field.
     let accepted = accepted_session_ref_for_mode(session_ref, mode);
     if let Some(ref sref) = accepted {
         return Ok(Some(sref.session_id.clone()));
@@ -595,60 +639,29 @@ fn requested_resume_session_id_for_mode(
 }
 ```
 
-Add section 3c doc comments to the Rust protocol structs in `crates/freshell-protocol/src/client_messages.rs`:
-
-At `:231-235` (`TerminalCreate.resume_session_id`), append to the existing doc comment:
-
-```rust
-    /// The spawn-time resume session id (`ws-handler.ts:656-658` — distinct from
-    /// `sessionRef`; spec `cli-argv-fidelity.md` section 3.3/U7: only the
-    /// spawn-time id is modeled here, the binding/repair pipeline stays with
-    /// coding-cli.md). Retained solely so the handler can detect-and-reject;
-    /// see kata ejh6.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resume_session_id: Option<String>,
-```
-
-At `:409-411` (`ReconcilePane.resume_session_id`), replace the doc comment with the PERMANENT compat-door wording:
-
-```rust
-    /// Optional legacy single-key claim. PERMANENT legacy-compat door: the
-    /// server-side `promoted_legacy_claim` (`reconcile.rs`) promotes this into
-    /// a sessionRef forever; old persisted pane content can carry a legacy-only
-    /// claim indefinitely. Do NOT plan a later removal (kata ejh6 section 2).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub resume_session_id: Option<String>,
-```
-
-At `:445` (`CodingCliCreate.resume_session_id`), `:511` (`FreshAgentCreate.resume_session_id`), `:527` (`FreshAgentAttach.resume_session_id`), add the same comment:
-
-```rust
-    /// Retained solely so the handler can detect-and-reject; see kata ejh6.
-```
+Add section 3c doc comments to `crates/freshell-protocol/src/client_messages.rs` (same as before — `:231-235` TerminalCreate, `:409-411` ReconcilePane PERMANENT, `:445` CodingCliCreate, `:511` FreshAgentCreate, `:527` FreshAgentAttach).
 
 - [ ] **Step 4: Run the focused test**
 
-Run: `cargo test -p freshell-freshagent rest_create_rejects_legacy_resume_session_id_for_every_session_mode rest_create_rejects_legacy_resume_session_id_even_with_companion_session_ref split_pane_rejects_legacy_resume_session_id_with_400 respawn_pane_rejects_legacy_resume_session_id_with_400`
+Run: `cargo test -p freshell-freshagent legacy_reject_`
 
 Expected: PASS
 
 - [ ] **Step 5: Refactor while green**
 
-The codex-specific branch is gone — the any-mode throw subsumes it. The `accepted_session_ref_for_mode` early-return now follows the legacy check. No further refactor needed.
+The codex-specific throw in `requested_resume_session_id_for_mode` is gone — the door-top check subsumes all modes. The function now does only sessionRef resolution. No further refactor needed.
 
 - [ ] **Step 6: Run impacted-test verification**
 
-The REST reject affects every REST create test that sends `resumeSessionId`. The WIRE-SEND REST tests were converted in Task 3 (they now send sessionRef). The REJECTION-READY codex test at `:4415` still sends legacy and expects 400 — it stays green (now the any-mode throw covers codex too). The three `rest_create_legacy_resume_*409` tests were converted to sessionRef in Task 3 — they expect 409 (D7/LEASE) and stay green because they send sessionRef only (no legacy field). The `:6334` test is flipped in this task. The remote-tab-linkage spec is repurposed in this task (same commit — V6: no red window between the reject and the spec fix).
-
 Run: `cargo test -p freshell-freshagent`
 
-Expected: PASS
+Expected: PASS (WIRE-SEND REST tests converted in Task 3; REJECTION-READY codex test at `:4415` still sends legacy and expects 400 — green via door-top check; `rest_create_legacy_resume_*409` tests send sessionRef only — green; `:6334` flipped; remote-tab-linkage re-carriered + rejection case appended).
 
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add crates/freshell-freshagent/src/terminal_tabs.rs crates/freshell-freshagent/src/pane_ops_tests.rs crates/freshell-protocol/src/client_messages.rs test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts test/e2e-browser/playwright.config.ts
-git commit -m "feat(ejh6): Rust REST uniform any-carry reject + section 3c docs + remote-tab-linkage repurpose + RUST_ONLY_SPECS fix"
+git add crates/freshell-freshagent/src/lib.rs crates/freshell-freshagent/src/terminal_tabs.rs crates/freshell-freshagent/src/pane_ops.rs crates/freshell-freshagent/src/pane_ops_tests.rs crates/freshell-protocol/src/client_messages.rs test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts test/e2e-browser/playwright.config.ts
+git commit -m "feat(ejh6): Rust REST door-top presence reject + section 3c docs + remote-tab-linkage re-carrier + RUST_ONLY_SPECS fix"
 ```
 
 ---
@@ -656,7 +669,7 @@ git commit -m "feat(ejh6): Rust REST uniform any-carry reject + section 3c docs 
 ### Task 6: Rust WS `terminal.create` reject — hoist blanket gate to head of `handle_create` + reconcile permanent-compat doc
 
 **Files:**
-- Modify: `crates/freshell-ws/src/terminal.rs:2158` (insert blanket reject after `PreparedLaunch` destructure, before keyed-create adopt at `:2167`)
+- Modify: `crates/freshell-ws/src/terminal.rs:693` (insert blanket reject at the EARLIEST post-parse point in the `ClientMessage::TerminalCreate` dispatch arm — BEFORE `create_dedupe.begin` at `:699` and BEFORE `spawn_gated_restore_create` at `:735`, per finding 4: a restore:true codex carrying legacy must be rejected before any disk-gate planning)
 - Modify: `crates/freshell-ws/src/terminal.rs:2441-2457` (remove the now-redundant scoped gate)
 - Modify: `crates/freshell-ws/src/terminal.rs:1543-1544` (`create_session_locator` — comment the legacy rung as dead-from-wire)
 - Modify: `crates/freshell-ws/src/terminal.rs:1883-1886` (`derive_launch_prep` — comment the legacy rung as dead-from-wire)
@@ -672,14 +685,15 @@ git commit -m "feat(ejh6): Rust REST uniform any-carry reject + section 3c docs 
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Add to `crates/freshell-ws/tests/live_session_ref_guard.rs` (after `legacy_only_restore_is_refused_invalid_message` at `:210`):
+Add to `crates/freshell-ws/tests/live_session_ref_guard.rs` (after `legacy_only_restore_is_refused_invalid_message` at `:210`). Per finding 2: use PRESENCE (`is_some()`), not `is_some_and(|s| !s.is_empty())`. Per finding 4: add duplicate-requestId and restore+codex cases:
 
 ```rust
 /// ejh6: a `terminal.create` carrying `resumeSessionId` is rejected with
 /// `INVALID_MESSAGE` + frozen text on ANY mode, ANY restore state, and even
 /// when a companion `sessionRef` is present. No spawn, no registry row.
+/// Per finding 2: presence-based — `resumeSessionId: ""` is also rejected.
 #[tokio::test]
-async fn blanket_reject_legacy_resume_session_id_on_any_create() {
+async fn legacy_reject_ws_terminal_create() {
     let (url, registry) = spawn_server().await;
     let (mut ws, _inv) = connect_and_capture_inventory(&url).await;
 
@@ -703,6 +717,12 @@ async fn blanket_reject_legacy_resume_session_id_on_any_create() {
             "resumeSessionId": "legacy-should-still-reject",
             "sessionRef": {"provider": "claude", "sessionId": "canonical-session-id"},
         })),
+        ("empty-string-presence", "req-blanket-4", json!({
+            "type": "terminal.create", "requestId": "req-blanket-4",
+            "mode": "claude", "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+            "resumeSessionId": "",
+        })),
     ];
     for (label, req_id, body) in cases {
         send_create(&mut ws, body).await;
@@ -710,15 +730,50 @@ async fn blanket_reject_legacy_resume_session_id_on_any_create() {
         assert_eq!(err["code"], json!("INVALID_MESSAGE"), "{label}: {err}");
         assert_eq!(
             err["message"],
-            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+            json!("Restore requires sessionId; resumeSessionId is a legacy field and cannot be used as restore identity."),
             "{label}: frozen text must be byte-exact: {err}"
         );
     }
+    assert!(registry.identity_probe_rows().is_empty(), "no terminal may spawn");
+}
 
-    assert!(
-        registry.identity_probe_rows().is_empty(),
-        "no terminal may spawn for any legacy-carrying create"
-    );
+/// ejh6 finding 4: a duplicate-requestId replay carrying legacy gets
+/// INVALID_MESSAGE, not the cached terminal.created — the reject fires
+/// BEFORE create_dedupe.begin.
+#[tokio::test]
+async fn legacy_reject_ws_duplicate_request_id_with_legacy() {
+    let (url, registry) = spawn_server().await;
+    let (mut ws, _inv) = connect_and_capture_inventory(&url).await;
+    // First: a successful shell create to seed the dedupe cache.
+    send_create(&mut ws, json!({
+        "type": "terminal.create", "requestId": "req-dup-seed",
+        "mode": "shell", "shell": "system", "cwd": std::env::temp_dir().to_string_lossy(),
+    })).await;
+    let _created = next_frame_of_type(&mut ws, "terminal.created").await;
+    // Replay: same requestId but carrying legacy — must get INVALID_MESSAGE, not cached created.
+    send_create(&mut ws, json!({
+        "type": "terminal.create", "requestId": "req-dup-seed",
+        "mode": "claude", "shell": "system", "cwd": std::env::temp_dir().to_string_lossy(),
+        "resumeSessionId": "legacy-dup",
+    })).await;
+    let err = expect_refusal_for(&mut ws, "req-dup-seed").await;
+    assert_eq!(err["code"], json!("INVALID_MESSAGE"), "duplicate replay with legacy must reject: {err}");
+}
+
+/// ejh6 finding 4: restore:true + codex + legacy is rejected BEFORE
+/// spawn_gated_restore_create / prepare_launch (no disk-gate planning).
+#[tokio::test]
+async fn legacy_reject_ws_restore_codex_legacy() {
+    let (url, registry) = spawn_server().await;
+    let (mut ws, _inv) = connect_and_capture_inventory(&url).await;
+    send_create(&mut ws, json!({
+        "type": "terminal.create", "requestId": "req-restore-codex-legacy",
+        "mode": "codex", "shell": "system", "cwd": std::env::temp_dir().to_string_lossy(),
+        "restore": true, "resumeSessionId": "thread-raw-restore-codex",
+    })).await;
+    let err = expect_refusal_for(&mut ws, "req-restore-codex-legacy").await;
+    assert_eq!(err["code"], json!("INVALID_MESSAGE"), "restore+codex+legacy must reject before disk gate: {err}");
+    assert_eq!(err["message"], json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."));
 }
 ```
 
@@ -785,67 +840,40 @@ Phase 1/2 sessionRef argv coverage survives (those sends use sessionRef, not leg
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
-Run: `cargo test -p freshell-ws --test live_session_ref_guard blanket_reject_legacy_resume_session_id_on_any_create legacy_resume_session_id_create_is_refused_loudly`
+Run: `cargo test -p freshell-ws --test live_session_ref_guard legacy_reject_ && cargo test -p freshell-ws --test live_session_ref_guard legacy_resume_session_id_create_is_refused`
 
 Expected: FAIL because the current scoped gate at `:2441` only rejects restore+non-codex+legacy-only — the codex-no-restore case and the companion-sessionref case are silently accepted (spawn happens).
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Hoist a blanket reject to the head of `handle_create` at `crates/freshell-ws/src/terminal.rs`. Insert immediately after the `PreparedLaunch` destructure at `:2158` (before the keyed-create adopt loop at `:2167`):
+Hoist the blanket reject to the EARLIEST post-parse point in the `ClientMessage::TerminalCreate` dispatch arm at `crates/freshell-ws/src/terminal.rs:693` — BEFORE `create_dedupe.begin` at `:699` and BEFORE `spawn_gated_restore_create` at `:735` (finding 4: a restore:true codex carrying legacy must be rejected before any disk-gate planning). Insert at the very top of the `ClientMessage::TerminalCreate(create) =>` arm, before the `match state.create_dedupe.begin(...)` block:
 
 ```rust
-    // ejh6: reject the legacy `resume_session_id` wire field on ANY create
-    // (any mode, any restore state, any companion sessionRef). The canonical
-    // carrier is sessionRef; resume_session_id stays declared on the struct
-    // solely so this handler can detect-and-reject (see kata ejh6). Placed
-    // BEFORE keyed-create adopt / D8 lease / rate-limit / spawn so no side
-    // effect fires and the registry row count is unchanged. The
-    // `create_dedupe` sentinel is cleared by the existing `clear_if_in_flight`
-    // on this function's non-complete exits (`:761`).
-    if create.resume_session_id.as_deref().is_some_and(|s| !s.is_empty()) {
-        return send_create_error(
-            out,
-            ErrorCode::InvalidMessage,
-            LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
-            &create.request_id,
-        )
-        .await;
-    }
+        ClientMessage::TerminalCreate(create) => {
+            // ejh6 (finding 4): reject the legacy `resume_session_id` wire field
+            // at the EARLIEST post-parse point — BEFORE create_dedupe.begin
+            // (so a duplicate-requestId replay gets INVALID_MESSAGE, not cached
+            // terminal.created) and BEFORE spawn_gated_restore_create /
+            // prepare_launch (so a restore:true codex carrying legacy is
+            // rejected before any disk-gate planning). Presence-based (finding 2):
+            // `is_some()` covers `""` — serde Option<String> cannot see JSON null
+            // deserialize-to-None, an accepted WS edge where the schema level is
+            // a typed struct.
+            if create.resume_session_id.is_some() {
+                let mut out = crate::create_gate::CreateOutput::Socket(ws_tx.clone());
+                return send_create_error(
+                    &mut out,
+                    ErrorCode::InvalidMessage,
+                    LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
+                    &create.request_id,
+                )
+                .await;
+            }
+            // Server-wide requestId dedupe ...
+            match state.create_dedupe.begin(
 ```
 
-Remove the now-redundant scoped gate at `:2441-2457` (the `if create.restore == Some(true) && mode != "codex" && ...` block). The frozen text is now emitted by the head-of-`handle_create` check for all shapes.
-
-Comment the legacy rungs as dead-from-wire (do NOT delete — they are still reachable from internal/test paths per binding correction C):
-
-At `create_session_locator` (`:1543-1544`):
-```rust
-        // ejh6: the legacy rung below is dead for wire input (the blanket
-        // reject at the head of handle_create fires first). Retained for
-        // internal/test constructions that set resume_session_id directly.
-        .or_else(|| create.resume_session_id.clone())
-```
-
-At `derive_launch_prep` (`:1883-1886`):
-```rust
-            // ejh6: the legacy fallback below is dead for wire input (the
-            // blanket reject at the head of handle_create fires first).
-            // Retained for internal/test constructions.
-            resume_session_id = requested_ref
-                .map(|r| r.session_id.clone())
-                .or_else(|| create.resume_session_id.clone())
-                .filter(|s| !s.is_empty());
-```
-
-Add the permanent-compat doc to `crates/freshell-ws/src/reconcile.rs:162-177` — prepend to the `promoted_legacy_claim` doc comment:
-
-```rust
-/// PERMANENT legacy-compat door (kata ejh6 section 2): the ONE uniform
-/// promotion rule. Old persisted pane content (stale clients, restored
-/// snapshots) can carry a legacy-only claim indefinitely; no point-in-time
-/// suite run can prove otherwise, so this door stays forever with NO
-/// later-removal plan. The blanket wire reject on `terminal.create` does NOT
-/// reach here — `pane.reconcile` is the sole permanent exception.
-```
+Remove the now-redundant scoped gate at `:2441-2457`. Comment the legacy rungs at `:1543-1544` and `:1883-1886` as dead-from-wire (same as before). Add the permanent-compat doc to `reconcile.rs:162-177` (same as before).
 
 - [ ] **Step 4: Run the focused test**
 
@@ -868,8 +896,8 @@ Expected: PASS
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add crates/freshell-ws/src/terminal.rs crates/freshell-ws/src/reconcile.rs crates/freshell-ws/tests/live_session_ref_guard.rs crates/freshell-ws/tests/resume_validation_gate.rs
-git commit -m "feat(ejh6): Rust WS terminal.create blanket reject + reconcile permanent-compat doc"
+git add crates/freshell-ws/src/terminal.rs crates/freshell-ws/src/reconcile.rs crates/freshell-ws/tests/live_session_ref_guard.rs crates/freshell-ws/tests/resume_validation_gate.rs crates/freshell-ws/tests/amplifier_launcher_identity.rs crates/freshell-ws/tests/codex_session_ref_resume.rs
+git commit -m "feat(ejh6): Rust WS terminal.create blanket reject (pre-dedupe) + reconcile permanent-compat doc + amplifier/codex re-target"
 ```
 
 ---
@@ -897,7 +925,7 @@ Add to `crates/freshell-ws/tests/freshagent_claude_attach.rs` (per V3 substituti
 /// sidecar spawn, no manager.attach call. Attach has no requestId, so the
 /// rejection rides the freshAgent.error event channel keyed by sessionId.
 #[tokio::test]
-async fn freshagent_attach_with_legacy_resume_session_id_is_rejected() {
+async fn legacy_reject_freshagent_attach() {
     let _guard = CLAUDE_ENV_LOCK.lock().await;
     let env = FakeClaudeResumeEnv::install("legacy-durable-id");
     let url = spawn_server().await;
@@ -948,7 +976,7 @@ Add to `crates/freshell-ws/tests/freshagent_session_lease.rs` (per V3 substituti
 /// No sidecar spawn. Create has a requestId, so the rejection uses the
 /// create-failed envelope.
 #[tokio::test]
-async fn freshagent_create_with_legacy_resume_session_id_is_rejected() {
+async fn legacy_reject_freshagent_create() {
     let _guard = LEASE_ENV_LOCK.lock().await;
     let env = FakeLeaseSidecarEnv::install();
     let url = spawn_server().await;
@@ -1007,7 +1035,7 @@ Re-carrier the SETUP create at `:460` (`terminal_create_is_refused_while_a_live_
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
-Run: `cargo test -p freshell-ws --test freshagent_claude_attach freshagent_attach_with_legacy_resume_session_id_is_rejected && cargo test -p freshell-ws --test freshagent_session_lease freshagent_create_with_legacy_resume_session_id_is_rejected`
+Run: `cargo test -p freshell-ws --test freshagent_claude_attach legacy_reject_freshagent_attach && cargo test -p freshell-ws --test freshagent_session_lease legacy_reject_freshagent_create`
 
 Expected: FAIL because the current dispatch arms at `terminal.rs:861-926` spawn the provider handler without checking `resume_session_id` — the create/attach proceeds instead of returning a rejection frame.
 
@@ -1036,7 +1064,7 @@ pub(crate) fn fresh_agent_control_refusal(message: &ClientMessage) -> Option<Ser
     // channel keyed by sessionId. Both use the `FRESH_AGENT_CREATE_FAILED`
     // family code + the frozen sessionRef-naming text.
     if let ClientMessage::FreshAgentCreate(m) = message {
-        if m.resume_session_id.as_deref().is_some_and(|s| !s.is_empty()) {
+        if m.resume_session_id.is_some() {
             return Some(ServerMessage::FreshAgentCreateFailed(FreshAgentCreateFailed {
                 code: "FRESH_AGENT_CREATE_FAILED".to_string(),
                 message: LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
@@ -1046,7 +1074,7 @@ pub(crate) fn fresh_agent_control_refusal(message: &ClientMessage) -> Option<Ser
         }
     }
     if let ClientMessage::FreshAgentAttach(m) = message {
-        if m.resume_session_id.as_deref().is_some_and(|s| !s.is_empty()) {
+        if m.resume_session_id.is_some() {
             return Some(ServerMessage::FreshAgentEvent(FreshAgentEvent {
                 event: serde_json::json!({
                     "type": "freshAgent.error",
@@ -1086,7 +1114,7 @@ fn attach_durable_id(msg: &FreshAgentAttach) -> Option<String> {
 
 - [ ] **Step 4: Run the focused test**
 
-Run: `cargo test -p freshell-ws --test freshagent_claude_attach freshagent_attach_with_legacy_resume_session_id_is_rejected && cargo test -p freshell-ws --test freshagent_session_lease freshagent_create_with_legacy_resume_session_id_is_rejected && cargo test -p freshell-ws --test cross_kind_liveness freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session && cargo test -p freshell-freshagent attach_durable_id`
+Run: `cargo test -p freshell-ws --test freshagent_claude_attach legacy_reject_freshagent_attach && cargo test -p freshell-ws --test freshagent_session_lease legacy_reject_freshagent_create && cargo test -p freshell-ws --test cross_kind_liveness freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session && cargo test -p freshell-freshagent attach_durable_id`
 
 Expected: PASS
 
@@ -1111,22 +1139,20 @@ git commit -m "feat(ejh6): Rust WS freshAgent create/attach reject legacy field 
 
 ---
 
-### Task 8: Node REST reject — uniform any-carry on all modes (Node-side)
+### Task 8: Node REST reject — door-top presence check on all routes (Node-side)
 
 **Files:**
-- Modify: `server/agent-api/router.ts:214-228` (`requestedResumeSessionIdForMode` — uniform any-carry throw, legacy checked BEFORE sessionRef early-return per coordinator ruling L)
-- Test: `test/server/agent-tabs-write.test.ts:413` (add `it.each` for all modes + dual-carrier rejection test)
-- Test: `test/server/agent-panes-write.test.ts:132,:327` (widen to all modes)
-
-NOTE: the `remote-tab-linkage-rust.spec.ts` repurpose + `RUST_ONLY_SPECS` fix moved to Task 5 (same Rust-behavior commit, per V6 — no red window between the Rust reject and the spec fix). Task 8 keeps Node-side repurposing only.
+- Modify: `server/agent-api/router.ts:695` (top of `POST /tabs` — insert door-top check before agent/browser/editor/terminal branch), `:1250` (top of `POST /panes/:id/split`), `:1546` (top of `POST /panes/:id/respawn`); `:214-228` (`requestedResumeSessionIdForMode` — remove the legacy throw; keep sessionRef resolution only; single check at door-top for KISS per finding 3)
+- Test: `test/server/agent-tabs-write.test.ts:413` (add `it.each` for all modes + dual-carrier + presence-edge + browser/editor tests)
+- Test: `test/server/agent-panes-write.test.ts:132,:327` (widen to all modes + layout-unchanged on split)
 
 **Interfaces:**
-- Consumes: `INVALID_RAW_CODEX_RESUME_MESSAGE` (`restore-decision.ts:27-28`); `AgentRouteInputError` (`router.ts:47-52`); `agentRouteErrorStatus` returns 400 (`router.ts:54-58`); `fail(message)` returns `{status:'error',message}` (`response.ts:6`).
-- Produces: all three Node REST doors return HTTP 400 `{status:'error',message:<frozen>}` whenever the body carries a non-empty `resumeSessionId`, EVEN when a matching `sessionRef` is also present (uniform any-carry, coordinator ruling L — parity with Task 5's Rust REST).
+- Consumes: `INVALID_RAW_CODEX_RESUME_MESSAGE` (`restore-decision.ts:27-28`); `fail(message)` returns `{status:'error',message}` (`response.ts:6`).
+- Produces: all three Node REST doors return HTTP 400 `{status:'error',message:<frozen>}` at the door-top whenever `req.body?.resumeSessionId !== undefined` (presence — any value including `""`, `null`, `42`), BEFORE any branch. `requestedResumeSessionIdForMode` keeps sessionRef resolution only.
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Add to `test/server/agent-tabs-write.test.ts` (after the existing codex-reject test at `:413`):
+Add to `test/server/agent-tabs-write.test.ts` (after the existing codex-reject test at `:413`). Per finding 2: presence-based — `""`, `null`, `42` are also rejected. Per finding 3: browser/editor branches also 400:
 
 ```ts
   it.each(['claude', 'opencode', 'amplifier'])('rejects legacy resumeSessionId on mode %s with 400', async (mode) => {
@@ -1141,42 +1167,52 @@ Add to `test/server/agent-tabs-write.test.ts` (after the existing codex-reject t
       selectNextTab: () => ({ tabId: 'tab_1' }), selectPrevTab: () => ({ tabId: 'tab_1' }),
     }
     app.use('/api', createAgentApiRouter({ layoutStore, registry, codexLaunchPlanner }))
-
-    const res = await request(app).post('/api/tabs').send({
-      mode, name: `legacy ${mode}`, resumeSessionId: `legacy-${mode}-id`,
-    })
-
+    const res = await request(app).post('/api/tabs').send({ mode, name: `legacy ${mode}`, resumeSessionId: `legacy-${mode}-id` })
     expect(res.status).toBe(400)
     expect(res.body).toEqual({ status: 'error', message: INVALID_RAW_CODEX_RESUME_MESSAGE })
-    expect(codexLaunchPlanner.planCreateCalls).toEqual([])
     expect(registry.create).not.toHaveBeenCalled()
     expect(layoutStore.createTab).not.toHaveBeenCalled()
-    expect(layoutStore.attachPaneContent).not.toHaveBeenCalled()
   })
 
-  // ejh6 uniform any-carry (coordinator ruling L): dual-carrier is REJECTED.
   it('rejects legacy resumeSessionId even with a companion sessionRef', async () => {
     const app = express()
     app.use(express.json())
     const registry = { create: vi.fn(), killAndWait: vi.fn(async () => true) }
     const codexLaunchPlanner = new FakeCodexLaunchPlanner()
-    const layoutStore = {
-      createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })),
-      attachPaneContent: vi.fn(),
-      selectTab: () => ({}), renameTab: () => ({}), closeTab: () => ({}), hasTab: () => true,
-      selectNextTab: () => ({ tabId: 'tab_1' }), selectPrevTab: () => ({ tabId: 'tab_1' }),
-    }
+    const layoutStore = { createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })), attachPaneContent: vi.fn(), selectTab: () => ({}), renameTab: () => ({}), closeTab: () => ({}), hasTab: () => true, selectNextTab: () => ({ tabId: 'tab_1' }), selectPrevTab: () => ({ tabId: 'tab_1' }) }
     app.use('/api', createAgentApiRouter({ layoutStore, registry, codexLaunchPlanner }))
-
-    const res = await request(app).post('/api/tabs').send({
-      mode: 'claude', name: 'dual carrier',
-      resumeSessionId: 'legacy-should-still-reject',
-      sessionRef: { provider: 'claude', sessionId: 'canonical-session-id' },
-    })
-
+    const res = await request(app).post('/api/tabs').send({ mode: 'claude', resumeSessionId: 'legacy', sessionRef: { provider: 'claude', sessionId: 'canonical' } })
     expect(res.status).toBe(400)
     expect(res.body).toEqual({ status: 'error', message: INVALID_RAW_CODEX_RESUME_MESSAGE })
-    expect(registry.create).not.toHaveBeenCalled()
+  })
+
+  // ejh6 finding 2: presence-based — "", null, 42 are all rejected.
+  it.each([
+    ['empty-string', ''],
+    ['null', null],
+    ['number', 42],
+  ])('rejects resumeSessionId presence (%s)', async (_label, val) => {
+    const app = express()
+    app.use(express.json())
+    const layoutStore = { createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })), attachPaneContent: vi.fn(), selectTab: () => ({}), renameTab: () => ({}), closeTab: () => ({}), hasTab: () => true, selectNextTab: () => ({ tabId: 'tab_1' }), selectPrevTab: () => ({ tabId: 'tab_1' }) }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry: { create: vi.fn() }, codexLaunchPlanner: new FakeCodexLaunchPlanner() }))
+    const res = await request(app).post('/api/tabs').send({ mode: 'claude', resumeSessionId: val })
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({ status: 'error', message: INVALID_RAW_CODEX_RESUME_MESSAGE })
+  })
+
+  // ejh6 finding 3: browser/editor branches also 400.
+  it.each([
+    ['browser', { browser: 'https://example.com' }],
+    ['editor', { editor: '/tmp/file.ts' }],
+  ])('rejects resumeSessionId on %s branch', async (_label, extra) => {
+    const app = express()
+    app.use(express.json())
+    const layoutStore = { createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })), attachPaneContent: vi.fn(), selectTab: () => ({}), renameTab: () => ({}), closeTab: () => ({}), hasTab: () => true, selectNextTab: () => ({ tabId: 'tab_1' }), selectPrevTab: () => ({ tabId: 'tab_1' }) }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry: { create: vi.fn() }, codexLaunchPlanner: new FakeCodexLaunchPlanner() }))
+    const res = await request(app).post('/api/tabs').send({ resumeSessionId: 'legacy', ...extra })
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({ status: 'error', message: INVALID_RAW_CODEX_RESUME_MESSAGE })
   })
 ```
 
@@ -1184,33 +1220,41 @@ Add to `test/server/agent-tabs-write.test.ts` (after the existing codex-reject t
 
 Run: `npm run test:vitest -- run test/server/agent-tabs-write.test.ts --config config/vitest/vitest.server.config.ts`
 
-Expected: FAIL because the non-codex modes silently accept the legacy field (`requestedResumeSessionIdForMode` at `:227` returns `legacyResumeSessionId` for non-codex), and the dual-carrier case returns sessionRef (the `:219-220` sessionRef early-return fires before the legacy check) — the tests get 200 instead of 400.
+Expected: FAIL because the non-codex modes silently accept the legacy field, the browser/editor branches bypass the check entirely, and `""`/`null`/`42` are not rejected by `isNonEmptyString` — the tests get 200 instead of 400.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Widen `requestedResumeSessionIdForMode` at `server/agent-api/router.ts:214-228`. Per coordinator ruling L (uniform any-carry): check legacy BEFORE the sessionRef early-return so a dual-carrier body is rejected:
+Add a door-top presence check at the TOP of each Express route handler in `server/agent-api/router.ts` — `POST /tabs` at `:695` (before the agent branch at `:698`), `POST /panes/:id/split` at `:1250` (before `splitPane`/`spawn_terminal_pane`), `POST /panes/:id/respawn` at `:1546` (before `spawn_terminal_pane`). Per finding 2: presence check (`!== undefined`), not `isNonEmptyString`. Per finding 3: single check at door-top for KISS.
+
+```ts
+  router.post('/tabs', async (req, res) => {
+    // ejh6 (finding 3): door-top presence check BEFORE any branch.
+    if (req.body?.resumeSessionId !== undefined) {
+      return res.status(400).json(fail(INVALID_RAW_CODEX_RESUME_MESSAGE))
+    }
+    const { name, mode, shell, cwd, browser, editor, permissionMode, model, sandbox } = req.body || {}
+    // ... rest unchanged ...
+```
+
+Repeat the same door-top check at the top of `POST /panes/:id/split` and `POST /panes/:id/respawn`.
+
+Update `requestedResumeSessionIdForMode` at `:214-228` — remove the legacy throw (the door-top check is the single rejection point); keep sessionRef resolution only:
 
 ```ts
 function requestedResumeSessionIdForMode(
   sessionRef: ReturnType<typeof sanitizeSessionRef>,
   mode: string,
-  legacyResumeSessionId: unknown,
+  _legacyResumeSessionId: unknown,
 ): string | undefined {
-  // ejh6 (uniform any-carry, coordinator ruling L): reject the legacy
-  // resumeSessionId wire field on EVERY mode, EVEN when a matching sessionRef
-  // is also present. No first-party sender dual-carries; the codex dual-carrier
-  // tolerance at restore-decision.ts:40 is retired. The legacy check runs
-  // BEFORE the sessionRef early-return so a dual-carrier body is rejected.
-  if (isNonEmptyString(legacyResumeSessionId)) {
-    throw new AgentRouteInputError(INVALID_RAW_CODEX_RESUME_MESSAGE)
-  }
+  // ejh6: the legacy throw moved to the door-top check in each route handler
+  // (finding 3). This function keeps its sessionRef-resolution role only.
   const acceptedSessionRef = acceptedSessionRefForMode(sessionRef, mode)
   if (acceptedSessionRef) return acceptedSessionRef.sessionId
   return undefined
 }
 ```
 
-The existing 400 machinery (`AgentRouteInputError` then `agentRouteErrorStatus` then 400 then `res.status(400).json(fail(message))`) already produces `{status:'error',message:<frozen>}` for all three routes.
+Import `fail` from `./response.js` at the top of `router.ts` if not already imported.
 
 - [ ] **Step 4: Run the focused test**
 
@@ -1242,7 +1286,8 @@ git commit -m "feat(ejh6): Node REST uniform any-carry reject legacy resumeSessi
 ### Task 9: Node WS `terminal.create` reject + repurpose existing tests + e2e WS assertion
 
 **Files:**
-- Modify: `server/ws-handler.ts:2107` (insert blanket reject after `fresh_after_restore_unavailable` guard), `:2160-2168` and `:2170-2186` (remove scoped gates), `:784` (section 3c doc comment)
+- Modify: `server/ws-handler.ts:2041` (insert blanket reject at the VERY TOP of the `case 'terminal.create':` block, BEFORE `recordSessionLifecycleEvent` at `:2048` and BEFORE the `fresh_after_restore_unavailable` validation at `:2060` — finding 5: a message carrying both intents gets INVALID_MESSAGE with frozen text, not INVALID_CREATE_REQUEST), `:2160-2168` and `:2170-2186` (remove scoped gates), `:784` (section 3c doc comment)
+- Modify: `shared/ws-protocol.ts:319-332` (`TerminalCreateSchema` — finding 1: add `resumeSessionId: z.string().optional()` with the retained-for-rejection comment. Nothing today parses inbound terminal.create through the shared schema — the Node server uses the dynamic schema at `ws-handler.ts:772` instead — but the kata demands fields stay declared in EVERY wire schema, and the shared `ClientMessageSchema` union at `:678` includes `TerminalCreateSchema` as the canonical contract. Verify: `rg "TerminalCreateSchema" server/` hits only `ws-handler.ts:678` (the union member) and `:772` (the comment explaining the dynamic override) — no inbound parse path uses it. Note this answer in the plan.)
 - Modify: `test/e2e/agent-cli-flow.test.ts` (add the e2e WS assertion — wires a `WsHandler` onto the test server)
 - Test: `test/server/ws-terminal-create-reuse-running-codex.test.ts` (add `it.each` for all modes)
 - Test: `test/server/ws-terminal-create-session-repair.test.ts:1048` (repurpose as rejection test)
@@ -1280,6 +1325,49 @@ Add to `test/server/ws-terminal-create-reuse-running-codex.test.ts` (after the e
       })
       expect(codexLaunchPlanner.planCreateCalls).toHaveLength(0)
       expect(registry.createCalls).toHaveLength(0)
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+```
+
+Add presence-edge and dual-intent tests (findings 2, 5):
+
+```ts
+  // ejh6 finding 2: presence-based — "" is rejected.
+  it('rejects resumeSessionId empty string on terminal.create', async () => {
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
+    try {
+      await waitForOpen(ws)
+      await waitForReady(ws)
+      const requestId = 'legacy-reject-empty'
+      const errorPromise = waitForMessage(ws, (m) => m.type === 'error' && m.requestId === requestId)
+      ws.send(JSON.stringify({ type: 'terminal.create', requestId, mode: 'claude', shell: 'system', resumeSessionId: '' }))
+      const error = await errorPromise
+      expect(error).toMatchObject({ type: 'error', code: 'INVALID_MESSAGE', requestId })
+      expect(error.message).toContain('sessionRef')
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
+  // ejh6 finding 5: a message carrying BOTH recoveryIntent and resumeSessionId
+  // gets INVALID_MESSAGE with frozen text (the mandatory error wins over
+  // INVALID_CREATE_REQUEST's "Fresh recovery requests cannot include restore identity").
+  it('rejects resumeSessionId even when recoveryIntent is also present', async () => {
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
+    try {
+      await waitForOpen(ws)
+      await waitForReady(ws)
+      const requestId = 'legacy-reject-dual-intent'
+      const errorPromise = waitForMessage(ws, (m) => m.type === 'error' && m.requestId === requestId)
+      ws.send(JSON.stringify({
+        type: 'terminal.create', requestId, mode: 'claude', shell: 'system',
+        recoveryIntent: 'fresh_after_restore_unavailable', resumeSessionId: 'legacy',
+      }))
+      const error = await errorPromise
+      expect(error).toMatchObject({ type: 'error', code: 'INVALID_MESSAGE', requestId })
+      expect(error.message).toBe('Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.')
     } finally {
       await closeWebSocket(ws)
     }
@@ -1391,25 +1479,44 @@ Expected: FAIL because the current scoped gate only rejects restore+non-codex+le
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Insert the blanket reject at `server/ws-handler.ts:2107` (immediately after the `fresh_after_restore_unavailable` guard returns, before `hasReusableRequestedLiveTerminal` at `:2108`):
+Insert the blanket reject at the VERY TOP of the `case 'terminal.create':` block at `server/ws-handler.ts:2041` (finding 5: BEFORE `recordSessionLifecycleEvent` at `:2048` and BEFORE the `fresh_after_restore_unavailable` validation at `:2060` — so a message carrying both `recoveryIntent` and `resumeSessionId` gets `INVALID_MESSAGE` with frozen text, not `INVALID_CREATE_REQUEST`). Per finding 2: presence check (`!== undefined`), not truthiness (`if (m.resumeSessionId)` would miss `""` and `null`):
 
 ```ts
-        // ejh6: reject the legacy resumeSessionId field on ANY create (any
-        // mode, any restore state, any companion sessionRef) — the canonical
-        // carrier is sessionRef. The field stays declared on the dynamic
-        // .strict() schema solely so this handler can detect-and-reject; see
-        // kata ejh6.
-        if (m.resumeSessionId) {
-          error = true
+      case 'terminal.create': {
+        // ejh6 (finding 5): reject the legacy resumeSessionId field at the VERY
+        // TOP, BEFORE recordSessionLifecycleEvent and the fresh_after_restore_
+        // unavailable validation — a message carrying both intents gets
+        // INVALID_MESSAGE with frozen text (the mandatory error wins).
+        // Presence-based (finding 2): `!== undefined` covers "", null, 42.
+        if (m.resumeSessionId !== undefined) {
           this.sendError(ws, {
             code: 'INVALID_MESSAGE',
             message: INVALID_RAW_CODEX_RESUME_MESSAGE,
             requestId: m.requestId,
           })
-          endCreateTimer({ error, rateLimited })
           return
         }
+        log.debug({
+          // ... existing code unchanged ...
 ```
+
+Add the shared `TerminalCreateSchema` field at `shared/ws-protocol.ts:319-332` (finding 1):
+
+```ts
+export const TerminalCreateSchema = z.object({
+  type: z.literal('terminal.create'),
+  requestId: z.string().min(1),
+  mode: z.string().default('shell'),
+  shell: ShellSchema.default('system'),
+  cwd: z.string().optional(),
+  /** Retained solely so the handler can detect-and-reject; see kata ejh6. */
+  resumeSessionId: z.string().optional(),
+  sessionRef: SessionLocatorSchema.optional(),
+  // ... rest unchanged ...
+}).strict()
+```
+
+Note: nothing today parses inbound terminal.create through this shared schema — the Node server's dynamic schema at `ws-handler.ts:772` overrides it — but the kata demands fields stay declared in EVERY wire schema, and `ClientMessageSchema` at `:678` includes it as the canonical contract.
 
 Remove the now-redundant scoped gates at `:2160-2168` (the `codexRestorePlan?.kind === 'reject_invalid_raw_codex_resume_request'` block) and `:2170-2186` (the `m.restore === true && modeSupportsResume && ...` block). The blanket reject at `:2107` fires first for any legacy-carrying create, so these scoped gates are unreachable for legacy carriers.
 
@@ -1441,8 +1548,8 @@ Expected: PASS
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add server/ws-handler.ts test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/ws-terminal-create-session-repair.test.ts test/integration/server/opencode-session-flow.test.ts test/e2e/agent-cli-flow.test.ts
-git commit -m "feat(ejh6): Node WS terminal.create blanket reject + repurpose tests + e2e WS assertion"
+git add server/ws-handler.ts shared/ws-protocol.ts test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/ws-terminal-create-session-repair.test.ts test/integration/server/opencode-session-flow.test.ts test/e2e/agent-cli-flow.test.ts
+git commit -m "feat(ejh6): Node WS terminal.create blanket reject (pre-recovery-intent) + shared TerminalCreateSchema field + repurpose tests + e2e WS assertion"
 ```
 
 ---
@@ -1555,7 +1662,8 @@ Insert at the head of the `freshAgent.create` case at `server/ws-handler.ts:3424
         // ejh6: reject the legacy resumeSessionId wire field. The canonical
         // carrier is sessionRef; resumeSessionId stays declared on the shared
         // schema solely so the handler can detect-and-reject (see kata ejh6).
-        if (m.resumeSessionId) {
+        // Presence-based (finding 2): `!== undefined` covers "", null, 42.
+        if (m.resumeSessionId !== undefined) {
           this.send(ws, {
             type: 'freshAgent.create.failed',
             requestId: m.requestId,
@@ -1578,7 +1686,8 @@ Insert at the head of the `freshAgent.attach` case at `server/ws-handler.ts:3543
         // attach error frame shape (sendError) with the FRESH_AGENT_CREATE_
         // FAILED code — the create-failed family code on the attach error
         // channel (see kata ejh6, binding correction D).
-        if (m.resumeSessionId) {
+        // Presence-based (finding 2): `!== undefined` covers "", null, 42.
+        if (m.resumeSessionId !== undefined) {
           this.sendError(ws, {
             code: 'FRESH_AGENT_CREATE_FAILED',
             message: INVALID_RAW_CODEX_RESUME_MESSAGE,
@@ -1806,7 +1915,8 @@ Insert the reject + promotion at `server/ws-handler.ts:3280` UNCONDITIONALLY FIR
         // the reject is config-independent. The canonical carrier is sessionRef;
         // resumeSessionId stays declared on the schema solely so the handler
         // can detect-and-reject (see kata ejh6).
-        if (m.resumeSessionId) {
+        // Presence-based (finding 2): `!== undefined` covers "", null, 42.
+        if (m.resumeSessionId !== undefined) {
           this.sendError(ws, {
             code: 'INVALID_MESSAGE',
             message: INVALID_RAW_CODEX_RESUME_MESSAGE,
@@ -2090,7 +2200,7 @@ Expected: output shows ONLY these categories:
 1. Internal content/registry fields (e.g. `TerminalRegistry` row `resume_session_id`, `FreshAgentPaneContent.resumeSessionId`, tab-level `resumeSessionId` in pane content).
 2. The `pane.reconcile` compat door (`crates/freshell-ws/src/reconcile.rs` `promoted_legacy_claim`, `src/lib/pane-reconcile.ts` `effectiveReconcileSessionRef`).
 3. Alias conversion sites (CLI `promoteResumeFlag` in `server/cli/index.ts`, MCP `freshell-tool.ts` `resume`/`resumeSessionId` param handling).
-4. Retained-for-rejection schema/struct fields (each carrying the section 3c comment): `shared/ws-protocol.ts` (`CodingCliCreateSchema`, `FreshAgentCreateSchema`, `FreshAgentAttachSchema`, `ReconcilePaneSchema`), `server/ws-handler.ts` (dynamic terminal.create + codingcli schemas), `crates/freshell-protocol/src/client_messages.rs` (`TerminalCreate`, `CodingCliCreate`, `FreshAgentCreate`, `FreshAgentAttach`, `ReconcilePane`).
+4. Retained-for-rejection schema/struct fields (each carrying the section 3c comment): `shared/ws-protocol.ts` (`TerminalCreateSchema` at `:319-332`, `CodingCliCreateSchema`, `FreshAgentCreateSchema`, `FreshAgentAttachSchema`, `ReconcilePaneSchema`), `server/ws-handler.ts` (dynamic terminal.create + codingcli schemas), `crates/freshell-protocol/src/client_messages.rs` (`TerminalCreate`, `CodingCliCreate`, `FreshAgentCreate`, `FreshAgentAttach`, `ReconcilePane`).
 5. Rejection handlers: `crates/freshell-freshagent/src/terminal_tabs.rs` (`requested_resume_session_id_for_mode`), `crates/freshell-ws/src/terminal.rs` (head-of-`handle_create` blanket reject, `fresh_agent_control_refusal` create/attach arms), `server/ws-handler.ts` (terminal.create/freshAgent.create/freshAgent.attach/codingcli.create head-of-case rejects), `server/agent-api/router.ts` (`requestedResumeSessionIdForMode`).
 6. Sidecar-protocol file class (V5 ruling — NOT Freshell-wire input, EXCLUDE from rejection scope): `crates/freshell-claude-sidecar/index.mjs:10,:240` (reader), `claude.rs:469`/`:1294` + Node `sdk-bridge.ts:85,:168,:193` (writers), embedded fake sidecars in `test/e2e-browser/fixtures/` and in-crate `tests/*.rs` fake-sidecar JS, and the ~8 sidecar-log-reading specs (`freshagent-settings-resume-rust.spec.ts:545,:551`, `hidden-pane-rebind-rust.spec.ts:365-367`, `freshclaude-restart-parity-rust.spec.ts:309`, `freshclaude-identity-persistence-rust.spec.ts:313,:410`, `wavea-interactions-rust.spec.ts:403-407`, `restore-contract-wall-rust.spec.ts:1040,:1304`, `restore-matrix.spec.ts:400,:1099`). None are Freshell-wire input — the adapter still emits `resumeSessionId` on the internal sidecar protocol post-conversion, and these readers stay green because the ID VALUE is preserved. Production internal-name readers (`codex.rs:500`, `claude.rs:348/:1809`, `layout_store_content.rs:254`, `tabs_store_model.rs:484`, `pane_ops.rs:686`) are also in this category.
 

--- a/docs/plans/2026-08-16-legacy-resume-guard.md
+++ b/docs/plans/2026-08-16-legacy-resume-guard.md
@@ -37,7 +37,7 @@ Implement kata issue ejh6 (revised 2026-08-16 spec: "Remove the legacy resumeSes
 - **Never weaken tests:** never delete a behavior test without a replacement; never mark tests skip; never simplify assertions to get green.
 - **Coordinated runners:** Node tests via `npm run test:vitest -- run <paths> --config <config>` (default config `config/vitest/vitest.config.ts`, server config `config/vitest/vitest.server.config.ts`); Rust via `cargo test -p <crate>` focused, `cargo test --workspace` as gate; `npm run check` (typecheck + coordinated full suite) as final gate.
 - **Rejection mechanism:** handler-level only. Never use `.strict()`/`deny_unknown_fields`/serde field removal as the rejection mechanism (zod non-strict strips silently; `.strict()` rejects with a generic unrecognized-key error that cannot carry the frozen text). The field stays DECLARED in every schema/struct.
-- **Presence-based rejection (coordinator ruling, review finding 2):** rejection is PRESENCE-based, not non-empty. The contract is "any create that CARRIES the field." Rust WS structs reject when `resume_session_id.is_some()` (covers `""`); Rust REST `Value` bodies reject when `body.get("resumeSessionId").is_some()` (any JSON value — string, empty, null, number, object); Node rejects when `m.resumeSessionId !== undefined` / `req.body?.resumeSessionId !== undefined`. Serde `Option<String>` cannot see JSON `null` deserialize-to-`None` — this is an accepted WS edge where the WS schema level is a typed struct (JSON `null` on REST `Value` bodies IS rejected since REST reads raw `Value`). All draft checks and tests must use presence, not `is_some_and(|s| !s.is_empty())` / `isNonEmptyString` / truthiness. Tests must cover `resumeSessionId: ""` on each door plus REST `{resumeSessionId: null}` and `{resumeSessionId: 42}`.
+- **Presence-based rejection (coordinator ruling, review findings 2+8+T6-redesign):** rejection is PRESENCE-based, not non-empty. The contract is "any create that CARRIES the field." **REST doors** (raw `Value`/`req.body`, full presence — string, empty, null, number, object): reject at handler with the frozen text (`body.get("resumeSessionId").is_some()` in Rust; `req.body?.resumeSessionId !== undefined` in Node). **WS doors:** the two servers differ by construction library behavior and both are loud: (i) **Node** — typed `z.string().optional()` fields: any string (incl. `""`) reaches the handler reject (`m.resumeSessionId !== undefined` → frozen text); a non-string (null, 42, object) fails zod parse at the boundary BEFORE the handler and gets `error{INVALID_MESSAGE}` with the parser's generic text (verified `server/ws-handler.ts:1913-1916`) — code loud, text generic, by design (frozen text names the legacy migration for string-typed callers). Tests null/42 pin the CODE on `terminal.create` only. (ii) **Rust** — the typed-struct approach is UNACCEPTABLE there (verified: serde `Option<String>` absorbs JSON `null` into `None` → silent accept; and a non-string value fails the `from_value` parse into the accept-and-strip `else { return true }` arm at `crates/freshell-ws/src/terminal.rs:651` → total silent drop, no terminal, no error). Rust therefore implements a **raw-Value pre-parse guard** in `terminal.rs` dispatch (before the typed `from_value`, before dedupe/restore planning): `value.get("type") ∈ {terminal.create, codingcli.create} + resumeSessionId key present (any JSON value, incl. null) → error INVALID_MESSAGE + frozen text; Task 7 extends the same guard with the freshAgent arms (create.failed envelope / event channel). Rust WS presence is full (any value) with frozen text for all of them; pin cases: `"legacy"`, `""`, `null`, `42` all → INVALID_MESSAGE + frozen text on terminal.create. All draft checks and tests must use presence, not `is_some_and(|s| !s.is_empty())` / `isNonEmptyString` / truthiness.
 - **Door-top REST rejection (coordinator ruling, review finding 3):** REST rejection runs at the TOP of each route handler in BOTH servers, BEFORE any branch (agent/browser/editor/terminal) and BEFORE `layout.split_pane` in the split route. In Node, check `req.body?.resumeSessionId !== undefined` at the top of `POST /tabs`, `POST /panes/:id/split`, `POST /panes/:id/respawn`; `requestedResumeSessionIdForMode` keeps its sessionRef-resolution role but no longer throws (single check at door-top for KISS). In Rust, check `body.get("resumeSessionId").is_some()` at each axum handler entry in `terminal_tabs.rs`/`pane_ops.rs` before any branch or layout mutation. Tests: pane/layout unchanged on rejected split; browser/editor branches also 400.
 - **Section 3c doc comment:** every retained `resumeSessionId`/`resume_session_id` field in a wire schema/struct gets the comment `Retained solely so the handler can detect-and-reject; see kata ejh6.` — EXCEPT `ReconcilePane.resume_session_id` which gets the PERMANENT compat-door comment.
 - **`restoreKey` gating:** blanket REST reject does NOT gate on `restoreKey` — no production producer emits it (verified), so blanket reject regresses nothing live (binding correction A).
@@ -291,7 +291,7 @@ git commit -m "test(ejh6): convert Node WS freshAgent wire-send tests to session
 
 Mechanical conversions. For each site, replace the legacy carrier with the canonical `sessionRef`/`session_ref` carrier. The asserted behavior (registry directory fills, spawn argv, frame assertions, ledger non-mutation) is carrier-agnostic and stays green.
 
-**REST POST bodies in `terminal_tabs.rs` test mod** — each `json!({... "resumeSessionId": "<id>" ...})` becomes `json!({... "sessionRef": {"provider": "<mode>", "sessionId": "<id>"} ...})` where `<mode>` is the `mode` field on the same body. The 10 test fns at `:4490,:4543,:4592,:5824,:5856,:5896,:5936,:5978,:6018,:6060` each get their POST body converted. Example for `create_tab_resume_session_id_flows_to_registry_directory_for_non_codex_mode` (`:4490`, body at `:4504`):
+**REST POST bodies in `terminal_tabs.rs` test mod** — each `json!({... "resumeSessionId": "<id>" ...})` becomes `json!({... "sessionRef": {"provider": "<mode>", "sessionId": "<id>"} ...})` where `<mode>` is the `mode` field on the same body. The 7 test fns at `:4490,:4543,:4592,:5824,:5856,:5896,:6060` each get their POST body converted (review round 2 finding 1: the three EDEV-07 plausibility-negative tests at `:5936,:5978,:6018` are NOT converted here — a sessionRef send bypasses the plausibility branch and would invert their premise on an unmodified server; they route to Task 5 as rejection assertions). Example for `create_tab_resume_session_id_flows_to_registry_directory_for_non_codex_mode` (`:4490`, body at `:4504`):
 
 ```rust
 // BEFORE:
@@ -431,7 +431,7 @@ git commit -m "test(ejh6): convert e2e-browser Rust wire-send tests to sessionRe
 - Modify: `crates/freshell-freshagent/src/lib.rs:1620-1633` (`create_tab` handler — insert door-top presence check BEFORE the agent/browser/editor/terminal branch) and `crates/freshell-freshagent/src/terminal_tabs.rs:117-136` (`requested_resume_session_id_for_mode` — remove the legacy throw; keep sessionRef resolution only; the door-top check is the single rejection point for KISS)
 - Modify: `crates/freshell-freshagent/src/pane_ops.rs:144-149` (`split_pane` handler — insert door-top check BEFORE `resolve_pane_target` and `layout.split_pane` at `:175`, so a rejection returns 400 with NO layout mutation) and `:699-745` (`respawn_pane` handler — insert door-top check BEFORE `spawn_terminal_pane` at `:719`)
 - Modify: `crates/freshell-protocol/src/client_messages.rs:231-235,:409-411,:445,:511,:527` (section 3c doc comments — same as before)
-- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs:6334` (flip from 200 to 400)
+- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs:6334` (`create_tab_with_identity_or_shell_mode_does_not_warn_invariant` — re-carrier the positive amplifier create to sessionRef; see review-round-2 finding 4 restructure in Step 1) and `:5936-6080` (the three EDEV-07 plausibility-negative tests — moved here from Task 3 per review-round-2 finding 1; they become 400-rejection assertions, see Step 1)
 - Modify: `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` (finding 6: RE-CARRIER sends to sessionRef, KEEP all ~110 lines of downstream behavior assertions, APPEND one new rejection case; do NOT delete behavior coverage)
 - Modify: `test/e2e-browser/playwright.config.ts:176` (`RUST_ONLY_SPECS` — add `/remote-tab-linkage-rust\.spec\.ts$/`)
 - Test: `crates/freshell-freshagent/src/terminal_tabs.rs` (test mod — add per-mode, dual-carrier, presence-edge, browser/editor rejection tests)
@@ -496,27 +496,73 @@ async fn legacy_reject_rest_create_presence_edge_cases() {
 }
 
 /// ejh6 finding 3: browser/editor branches also 400 when carrying the field.
+/// (review round 2 finding 2: serde_json json! has NO spread syntax — build
+/// the Value with explicit insert.)
 #[tokio::test]
 async fn legacy_reject_rest_browser_editor_branches() {
     let state = state_with_registry();
     let app = crate::router(state);
-    for (label, extra) in [
+    for (label, mut body) in [
         ("browser", json!({"browser": "https://example.com"})),
         ("editor", json!({"editor": "/tmp/file.ts"})),
     ] {
-        let (status, body) = post(
-            app.clone(), "/api/tabs",
-            json!({"resumeSessionId": "legacy", ...extra}),
-            true,
-        ).await;
-        assert_eq!(status, StatusCode::BAD_REQUEST, "{label} branch must reject: {body}");
+        body.as_object_mut().unwrap().insert("resumeSessionId".into(), json!("legacy"));
+        let (status, resp) = post(app.clone(), "/api/tabs", body, true).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{label} branch must reject: {resp}");
+        assert_eq!(resp["message"], json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."));
     }
 }
 ```
 
-Flip the `:6334` test (`create_tab_with_identity_or_shell_mode_does_not_warn_invariant`) — change `assert_eq!(status, StatusCode::OK, ...)` to `assert_eq!(status, StatusCode::BAD_REQUEST, ...)` + frozen text assert.
+Restructure the `:6334` test (`create_tab_with_identity_or_shell_mode_does_not_warn_invariant` — review round 2 finding 4: its remainder unwraps `body["data"]["terminalId"]` and kills it, so a 200→400 flip would panic and silently drop the positive identity/invariant coverage). Instead:
+1. Re-carrier the first create from `"resumeSessionId": "sess-no-warn-1"` to `"sessionRef": {"provider": "amplifier", "sessionId": "sess-no-warn-1"}` — every subsequent assertion (OK status, terminalId, no-warn invariant, kill) stays identical.
+2. The legacy-rejection case for amplifier REST is already covered by `legacy_reject_rest_create_all_modes` above — nothing more to add.
 
-Add to `crates/freshell-freshagent/src/pane_ops_tests.rs` — split test with layout-unchanged assertion (finding 3):
+Route the three EDEV-07 plausibility-negative tests (moved out of Task 3 — review round 2 finding 1) into rejection assertions, replacing the full bodies at `:5936-5983`, `:5985-6024`, and `:6026-6080` (approx; verify the exact fn spans while editing). The pattern for all three — `create_claude_tab_with_non_canonical_resume_id_does_not_synthesize`, `create_amplifier_tab_with_whitespace_resume_id_does_not_synthesize`, `create_opencode_tab_with_non_ses_resume_id_does_not_synthesize` (keep names — they can stay, the "_does_not_synthesize" suffix now reads as "the create is refused"):
+
+```rust
+#[tokio::test]
+async fn create_claude_tab_with_non_canonical_resume_id_does_not_synthesize() {
+    // ejh6: wire-level legacy resumeSessionId is REFUSED at the door — the
+    // implausible-id "no-synthesize/keep" EDEV-07 branch is now wire-
+    // unreachable; the branch stays in production code (content concern,
+    // out of scope for ejh6) with a comment. This test pins the refusal:
+    // 400 + frozen text, and NO ui.command frame is broadcast (no spawn).
+    let argv_file = unique_argv_file("claude-implausible");
+    let state =
+        state_with_registry().with_cli_commands(std::sync::Arc::new(vec![recording_cli_spec(
+            "claude", &argv_file,
+        )]));
+    let mut rx = state.broadcast_tx.subscribe();
+    let tmp = std::env::temp_dir();
+    let (status, body) = post(
+        app(state.clone()),
+        "/api/tabs",
+        json!({
+            "mode": "claude",
+            "cwd": tmp.to_string_lossy(),
+            "resumeSessionId": "not-a-canonical-uuid"
+        }),
+        true,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(
+        body["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.")
+    );
+    // No spawn -> no ui.command broadcast. subscribe-before-post means any
+    // frame would land in rx; a short timeout proves none arrived.
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(250), rx.recv()).await.is_err(),
+        "no broadcast frame may arrive for a rejected create"
+    );
+    let _ = std::fs::remove_file(&argv_file);
+}
+```
+(Same shape for the amplifier and opencode twins with their respective argv_file/spec mode names and legacy id strings `"not a plausible id"` / `"foo"`. One-paste exemplar count: write all three fns fully in the edit — do not template them away.)
+
+Add to `crates/freshell-freshagent/src/pane_ops_tests.rs` — split test with layout-unchanged assertion (finding 3; review round 2 finding 3 rulings: `state` is moved by `crate::router(state)`, `LayoutStore` has no `snapshot()`, and `UiSnapshot` lacks `PartialEq` — instead fetch the layout view via the EXISTING `get(router, uri, auth)` helper (`pane_ops_tests.rs:106`) from the before/after `:2302` `list_tabs` route and compare the `["tabs"]` payload — `serde_json::Value` implements `PartialEq`). Per R9, presence-edge values are looped in: string, empty, null, number all 400 with frozen text:
 
 ```rust
 #[tokio::test]
@@ -524,16 +570,26 @@ async fn legacy_reject_split() {
     let state = state_with_registry();
     let app = crate::router(state);
     let (_tab_id, pane_id, _terminal_id) = create_shell_tab(app.clone()).await;
-    let layout_before = state.layout.snapshot();
-    let (status, body) = post(
-        app, &format!("/api/panes/{pane_id}/split"),
-        json!({"direction": "horizontal", "mode": "claude", "resumeSessionId": "legacy-split"}),
-        true,
-    ).await;
-    assert_eq!(status, StatusCode::BAD_REQUEST, "split legacy reject: {body}");
-    assert_eq!(body["message"], json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."));
-    // Finding 3: layout MUST be unchanged — the door-top check fires BEFORE layout.split_pane.
-    assert_eq!(state.layout.snapshot(), layout_before, "layout must not mutate on a rejected split");
+    for (label, val) in [
+        ("string", json!("legacy-split")),
+        ("empty-string", json!("")),
+        ("null", json!(null)),
+        ("number", json!(42)),
+    ] {
+        let (s1, before) = get(app.clone(), "/api/tabs", true).await;
+        assert_eq!(s1, StatusCode::OK);
+        let (status, body) = post(
+            app.clone(), &format!("/api/panes/{pane_id}/split"),
+            json!({"direction": "horizontal", "mode": "claude", "resumeSessionId": val}),
+            true,
+        ).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{label} split legacy reject: {body}");
+        assert_eq!(body["message"], json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."));
+        let (s2, after) = get(app.clone(), "/api/tabs", true).await;
+        assert_eq!(s2, StatusCode::OK);
+        // Finding 3: layout MUST be unchanged — the door-top check fires BEFORE layout.split_pane.
+        assert_eq!(before["tabs"], after["tabs"], "{label}: layout must not mutate on a rejected split");
+    }
 }
 
 #[tokio::test]
@@ -541,13 +597,20 @@ async fn legacy_reject_respawn() {
     let state = state_with_registry();
     let app = crate::router(state);
     let (_tab_id, pane_id, _terminal_id) = create_shell_tab(app.clone()).await;
-    let (status, body) = post(
-        app, &format!("/api/panes/{pane_id}/respawn"),
-        json!({"mode": "claude", "resumeSessionId": "legacy-respawn"}),
-        true,
-    ).await;
-    assert_eq!(status, StatusCode::BAD_REQUEST, "respawn legacy reject: {body}");
-    assert_eq!(body["message"], json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."));
+    for (label, val) in [
+        ("string", json!("legacy-respawn")),
+        ("empty-string", json!("")),
+        ("null", json!(null)),
+        ("number", json!(42)),
+    ] {
+        let (status, body) = post(
+            app.clone(), &format!("/api/panes/{pane_id}/respawn"),
+            json!({"mode": "claude", "resumeSessionId": val}),
+            true,
+        ).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{label} respawn legacy reject: {body}");
+        assert_eq!(body["message"], json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."));
+    }
 }
 ```
 
@@ -577,6 +640,8 @@ Run: `cargo test -p freshell-freshagent legacy_reject_`
 Expected: FAIL because the non-codex modes silently accept the legacy field, the browser/editor branches bypass the check entirely, and the split door mutates the layout before reaching `spawn_terminal_pane` — the tests get 200/approx instead of 400, and the layout-unchanged assertion fails.
 
 - [ ] **Step 3: Add the minimal production implementation**
+
+First, imports (review round 2 finding 5 — without these the snippets don't compile): in `crates/freshell-freshagent/src/lib.rs` add `use freshell_protocol::LEGACY_RESUME_IDENTITY_REFUSAL;` alongside the existing `freshell_protocol` use group (mirror terminal_tabs.rs's import); in `crates/freshell-freshagent/src/pane_ops.rs` add the same `use freshell_protocol::LEGACY_RESUME_IDENTITY_REFUSAL;` to its use block.
 
 Add a door-top presence check at the TOP of `create_tab` in `crates/freshell-freshagent/src/lib.rs:1620-1633` (BEFORE the `if agent.is_empty()` branch delegation at `:1632`):
 
@@ -723,6 +788,29 @@ async fn legacy_reject_ws_terminal_create() {
             "cwd": std::env::temp_dir().to_string_lossy(),
             "resumeSessionId": "",
         })),
+        // ejh6 review round 2 finding 8 + T6 raw-guard redesign: Rust WS is
+        // FULL presence — the raw-Value guard sees ANY JSON value, including
+        // null (which serde Option<String> would absorb into None) and
+        // non-strings (which accept-and-strip would silently drop). All get
+        // the frozen text.
+        ("null-presence", "req-blanket-5", json!({
+            "type": "terminal.create", "requestId": "req-blanket-5",
+            "mode": "claude", "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+            "resumeSessionId": null,
+        })),
+        ("number-presence", "req-blanket-6", json!({
+            "type": "terminal.create", "requestId": "req-blanket-6",
+            "mode": "claude", "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+            "resumeSessionId": 42,
+        })),
+        ("object-presence", "req-blanket-7", json!({
+            "type": "terminal.create", "requestId": "req-blanket-7",
+            "mode": "claude", "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+            "resumeSessionId": {"nested": true},
+        })),
     ];
     for (label, req_id, body) in cases {
         send_create(&mut ws, body).await;
@@ -730,7 +818,7 @@ async fn legacy_reject_ws_terminal_create() {
         assert_eq!(err["code"], json!("INVALID_MESSAGE"), "{label}: {err}");
         assert_eq!(
             err["message"],
-            json!("Restore requires sessionId; resumeSessionId is a legacy field and cannot be used as restore identity."),
+            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
             "{label}: frozen text must be byte-exact: {err}"
         );
     }
@@ -838,6 +926,31 @@ In `crates/freshell-ws/tests/codex_session_ref_resume.rs:363-381` (Phase 3, V5 p
 
 Phase 1/2 sessionRef argv coverage survives (those sends use sessionRef, not legacy). Delete the spawn-argv `resume <raw_id>` pins for Phase 3 (no spawn occurs on a 400).
 
+Pin the codingcli arm of the raw guard (Rust has no codingcli handler, so the guard is the only rejector; add to `crates/freshell-ws/tests/live_session_ref_guard.rs`):
+
+```rust
+/// ejh6: a codingcli.create carrying the legacy field hits the raw-Value
+/// guard with INVALID_MESSAGE + frozen text (Rust has no codingcli handler —
+/// without the guard this silently no-ops; the guard is the loud rejector).
+#[tokio::test]
+async fn legacy_reject_ws_codingcli_create() {
+    let (url, _registry) = spawn_server().await;
+    let (mut ws, _inv) = connect_and_capture_inventory(&url).await;
+    send_json(&mut ws, &json!({
+        "type": "codingcli.create", "requestId": "req-codingcli-legacy",
+        "prompt": "hi", "provider": "claude",
+        "resumeSessionId": "legacy-codingcli",
+    })).await;
+    let err = expect_refusal_for(&mut ws, "req-codingcli-legacy").await;
+    assert_eq!(err["code"], json!("INVALID_MESSAGE"), "{err}");
+    assert_eq!(
+        err["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+    );
+}
+```
+(Verify `connect_and_capture_inventory`/`send_json`/`expect_refusal_for` exist in that file's own helper set before pasting — adapt names if the file's harness differs.)
+
 - [ ] **Step 2: Run the test and verify the intended failure**
 
 Run: `cargo test -p freshell-ws --test live_session_ref_guard legacy_reject_ && cargo test -p freshell-ws --test live_session_ref_guard legacy_resume_session_id_create_is_refused`
@@ -846,32 +959,50 @@ Expected: FAIL because the current scoped gate at `:2441` only rejects restore+n
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Hoist the blanket reject to the EARLIEST post-parse point in the `ClientMessage::TerminalCreate` dispatch arm at `crates/freshell-ws/src/terminal.rs:693` — BEFORE `create_dedupe.begin` at `:699` and BEFORE `spawn_gated_restore_create` at `:735` (finding 4: a restore:true codex carrying legacy must be rejected before any disk-gate planning). Insert at the very top of the `ClientMessage::TerminalCreate(create) =>` arm, before the `match state.create_dedupe.begin(...)` block:
+Insert a raw-Value pre-parse guard in the WS dispatch in `crates/freshell-ws/src/terminal.rs` — review round 2 finding 8 demands the raw layer, because the typed path cannot deliver the contract: serde `Option<String>` absorbs JSON `null` into `None` (silent accept of `resumeSessionId: null`) and a non-string value fails the `from_value` parse into the accept-and-strip `else { return true }` arm at `:651` (total silent drop of `resumeSessionId: 42`). The guard fires BEFORE the typed parse, hence also BEFORE `create_dedupe.begin` (finding 4: duplicate-rid replay gets INVALID_MESSAGE, not cached `terminal.created`) and BEFORE `spawn_gated_restore_create`/`prepare_launch` (restore:true codex carrying legacy rejected before any disk-gate planning). Insert IMMEDIATELY after the `tabs.sync.*` fast-path block (`:638-648`) and before `let Ok(message) = serde_json::from_value::<ClientMessage>(value) else {`:
 
 ```rust
-        ClientMessage::TerminalCreate(create) => {
-            // ejh6 (finding 4): reject the legacy `resume_session_id` wire field
-            // at the EARLIEST post-parse point — BEFORE create_dedupe.begin
-            // (so a duplicate-requestId replay gets INVALID_MESSAGE, not cached
-            // terminal.created) and BEFORE spawn_gated_restore_create /
-            // prepare_launch (so a restore:true codex carrying legacy is
-            // rejected before any disk-gate planning). Presence-based (finding 2):
-            // `is_some()` covers `""` — serde Option<String> cannot see JSON null
-            // deserialize-to-None, an accepted WS edge where the schema level is
-            // a typed struct.
-            if create.resume_session_id.is_some() {
-                let mut out = crate::create_gate::CreateOutput::Socket(ws_tx.clone());
-                return send_create_error(
-                    &mut out,
-                    ErrorCode::InvalidMessage,
-                    LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
-                    &create.request_id,
-                )
-                .await;
+    // ejh6 (review round 2 findings 2/4/8): raw-Value legacy-resume guard.
+    // Reject ANY create-class message carrying a top-level `resumeSessionId`
+    // with ANY JSON value (string, empty, null, number, object) at the raw
+    // layer. The typed structs' Option<String> READS CANNOT DO THIS JOB:
+    // serde absorbs JSON `null` into None (silent accept), and a non-string
+    // carry fails the whole typed parse into the accept-and-strip arm below
+    // (silent drop, no terminal, no error). Presence must be read here, at
+    // the raw layer, before dedupe/restore planning (zero side effects on
+    // reject). This task arms the two INVALID_MESSAGE families
+    // (terminal.create, codingcli.create); Task 7 arms the freshAgent
+    // families (create.failed envelope / attach event channel).
+    if let Some(resume_value) = value.get("resumeSessionId") {
+        let _ = resume_value; // presence is what matters; value never read
+        match value.get("type").and_then(|t| t.as_str()) {
+            Some("terminal.create") | Some("codingcli.create") => {
+                let reply = ServerMessage::Error(ErrorMsg {
+                    code: ErrorCode::InvalidMessage,
+                    message: LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
+                    timestamp: crate::now_iso(),
+                    actual_session_ref: None,
+                    expected_session_ref: None,
+                    request_id: value
+                        .get("requestId")
+                        .and_then(|r| r.as_str())
+                        .map(str::to_string),
+                    retry_after_ms: None,
+                    terminal_exit_code: None,
+                    terminal_id: None,
+                });
+                return send(ws_tx, &reply).await;
             }
-            // Server-wide requestId dedupe ...
-            match state.create_dedupe.begin(
+            _ => {} // freshAgent.* armed in Task 7; all other types unaffected
+        }
+    }
+
+    let Ok(message) = serde_json::from_value::<ClientMessage>(value) else {
+        return true;
+    };
 ```
+
+Add the imports to `terminal.rs`'s use block at `:62-67`: `ErrorMsg` joins `freshell_protocol::{...}` (verify the exact re-export surface — `freshell_protocol::ErrorMsg`, `ErrorCode`, and `LEGACY_RESUME_IDENTITY_REFUSAL` are all re-exported via `pub use` per Task 1 + existing server_messages/common re-exports); `crate::now_iso()` exists (used at `:1629`).
 
 Remove the now-redundant scoped gate at `:2441-2457`. Comment the legacy rungs at `:1543-1544` and `:1883-1886` as dead-from-wire (same as before). Add the permanent-compat doc to `reconcile.rs:162-177` (same as before).
 
@@ -905,14 +1036,14 @@ git commit -m "feat(ejh6): Rust WS terminal.create blanket reject (pre-dedupe) +
 ### Task 7: Rust WS freshAgent.create/attach reject + `attach_durable_id` hygiene
 
 **Files:**
-- Modify: `crates/freshell-ws/src/terminal.rs:62-67` (import `FreshAgentCreateFailed`), `:4768` (`fresh_agent_control_refusal` — add create/attach legacy-field arms)
+- Modify: `crates/freshell-ws/src/terminal.rs:62-67` (import `FreshAgentCreateFailed`, `FreshAgentEvent`) and extend the Task-6 raw-Value guard (inserted after the tabs.sync fast-path in dispatch) with the freshAgent arms — NOT the typed `fresh_agent_control_refusal` (review round 2 finding 8: the typed layer cannot see JSON null/non-string carries)
 - Modify: `crates/freshell-freshagent/src/claude.rs:1809-1819` (`attach_durable_id` — flip to sessionRef-first with comment)
 - Test: `crates/freshell-ws/tests/freshagent_claude_attach.rs` (add legacy-carrying attach rejection test — use the file's own harness APIs per V3: `CLAUDE_ENV_LOCK`, `FakeClaudeResumeEnv::install(<durable>)`, `spawn_server() -> String`, `connect_and_complete_handshake(&url)`, `request_log_rows()`)
 - Test: `crates/freshell-ws/tests/freshagent_session_lease.rs` (add legacy-carrying create rejection test — use the file's own harness APIs per V3: `LEASE_ENV_LOCK`, `FakeLeaseSidecarEnv::install()`, `spawn_server() -> String`, `connect(&url, true)`, `create_rows()`)
 - Test: `crates/freshell-ws/tests/cross_kind_liveness.rs:411,:460` (V5 premise-inversion: `freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session` at `:411` sends dual-carrier `freshAgent.create` asserting `freshAgent.create.failed{code: SESSION_RESERVED}` — post Task 7 the refusal fires earlier with the create-failed envelope code `FRESH_AGENT_CREATE_FAILED` + frozen text; `terminal_create_is_refused_while_a_live_sidecar_owns_the_session` at `:444` setup create at `:460` sends dual-carrier expecting success — rejected outright, so the D7 scenario it stages never materializes. Mechanically re-carrier the setup sends (drop the legacy line — sessionRef already present) and re-target the `:411` assertion from `SESSION_RESERVED` to `FRESH_AGENT_CREATE_FAILED` + frozen text.)
 
 **Interfaces:**
-- Consumes: `LEGACY_RESUME_IDENTITY_REFUSAL` (from Task 1); `ServerMessage::FreshAgentCreateFailed(FreshAgentCreateFailed{code,message,request_id,retryable})` (`server_messages.rs:618-627`); `ServerMessage::FreshAgentEvent(FreshAgentEvent{event,provider,session_id,session_type})`; `agent_provider_wire`/`session_type_wire` helpers (`terminal.rs:4731,:4741`); `fresh_agent_control_refusal` runs before the dispatch match at `:661`.
+- Consumes: `LEGACY_RESUME_IDENTITY_REFUSAL` (from Task 1); the Task-6 raw-Value guard in `terminal.rs` dispatch (extended here); `ServerMessage::FreshAgentCreateFailed(FreshAgentCreateFailed{code,message,request_id,retryable})` (`server_messages.rs:618-627`); `ServerMessage::FreshAgentEvent(FreshAgentEvent{event,provider,session_id,session_type})`; `send(ws_tx, &msg)` (`terminal.rs:85`).
 - Produces: `freshAgent.create` carrying `resume_session_id` then `freshAgent.create.failed{code:"FRESH_AGENT_CREATE_FAILED", message:<frozen>, retryable:false}`; `freshAgent.attach` carrying `resume_session_id` then `freshAgent.event{freshAgent.error{code:"FRESH_AGENT_CREATE_FAILED", message:<frozen>}}` keyed by session id; no sidecar spawn.
 
 - [ ] **Step 1: Write the failing behavioral test**
@@ -931,33 +1062,36 @@ async fn legacy_reject_freshagent_attach() {
     let url = spawn_server().await;
     let mut ws = connect_and_complete_handshake(&url).await;
 
-    send_json(
-        &mut ws,
-        &json!({
-            "type": "freshAgent.attach",
-            "sessionId": "cli-session-legacy-attach",
-            "sessionType": "freshclaude",
-            "provider": "claude",
-            "resumeSessionId": "legacy-durable-id",
-        }),
-    )
-    .await;
+    // ejh6 presence (finding 9): rejection fires for any string, including "".
+    for (label, legacy) in [("string", "legacy-durable-id"), ("empty-string", "")] {
+        send_json(
+            &mut ws,
+            &json!({
+                "type": "freshAgent.attach",
+                "sessionId": "cli-session-legacy-attach",
+                "sessionType": "freshclaude",
+                "provider": "claude",
+                "resumeSessionId": legacy,
+            }),
+        )
+        .await;
 
-    let err = await_frame(&mut ws, Duration::from_secs(10), |v| {
-        v["type"] == "freshAgent.event"
-            && v["event"]["type"] == "freshAgent.error"
-            && v["sessionId"] == "cli-session-legacy-attach"
-    })
-    .await;
-    assert_eq!(
-        err["event"]["code"], json!("FRESH_AGENT_CREATE_FAILED"),
-        "attach legacy reject must use the create-failed family code: {err}"
-    );
-    assert_eq!(
-        err["event"]["message"],
-        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
-        "frozen text: {err}"
-    );
+        let err = await_frame(&mut ws, Duration::from_secs(10), |v| {
+            v["type"] == "freshAgent.event"
+                && v["event"]["type"] == "freshAgent.error"
+                && v["sessionId"] == "cli-session-legacy-attach"
+        })
+        .await;
+        assert_eq!(
+            err["event"]["code"], json!("FRESH_AGENT_CREATE_FAILED"),
+            "{label}: attach legacy reject must use the create-failed family code: {err}"
+        );
+        assert_eq!(
+            err["event"]["message"],
+            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+            "{label}: frozen text: {err}"
+        );
+    }
     // V3: this file has NO create_rows(); use request_log_rows() and filter for create rows.
     let create_count = env
         .request_log_rows()
@@ -982,30 +1116,36 @@ async fn legacy_reject_freshagent_create() {
     let url = spawn_server().await;
     let mut ws = connect(&url, true).await;
 
-    send_json(
-        &mut ws,
-        &json!({
-            "type": "freshAgent.create",
-            "requestId": "req-fa-legacy-create",
-            "sessionType": "freshclaude",
-            "provider": "claude",
-            "cwd": "/tmp",
-            "resumeSessionId": "legacy-durable-id",
-        }),
-    )
-    .await;
+    // ejh6 presence (finding 9): rejection fires for any string, including "".
+    for (label, legacy, req_id) in [
+        ("string", "legacy-durable-id", "req-fa-legacy-create"),
+        ("empty-string", "", "req-fa-legacy-create-empty"),
+    ] {
+        send_json(
+            &mut ws,
+            &json!({
+                "type": "freshAgent.create",
+                "requestId": req_id,
+                "sessionType": "freshclaude",
+                "provider": "claude",
+                "cwd": "/tmp",
+                "resumeSessionId": legacy,
+            }),
+        )
+        .await;
 
-    let failed = await_frame(&mut ws, Duration::from_secs(10), |v| {
-        v["type"] == "freshAgent.create.failed" && v["requestId"] == "req-fa-legacy-create"
-    })
-    .await;
-    assert_eq!(failed["code"], json!("FRESH_AGENT_CREATE_FAILED"), "create-failed family code: {failed}");
-    assert_eq!(
-        failed["message"],
-        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
-        "frozen text: {failed}"
-    );
-    assert_eq!(failed["retryable"], json!(false));
+        let failed = await_frame(&mut ws, Duration::from_secs(10), |v| {
+            v["type"] == "freshAgent.create.failed" && v["requestId"].as_str() == Some(req_id)
+        })
+        .await;
+        assert_eq!(failed["code"], json!("FRESH_AGENT_CREATE_FAILED"), "{label}: create-failed family code: {failed}");
+        assert_eq!(
+            failed["message"],
+            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+            "{label}: frozen text: {failed}"
+        );
+        assert_eq!(failed["retryable"], json!(false));
+    }
     assert!(
         env.create_rows().is_empty(),
         "no sidecar may spawn for a rejected legacy create: {:?}", env.create_rows()
@@ -1013,7 +1153,7 @@ async fn legacy_reject_freshagent_create() {
 }
 ```
 
-Re-target `crates/freshell-ws/tests/cross_kind_liveness.rs:411` (V5 premise-inversion, `freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session`): the test at `:411` sends dual-carrier `freshAgent.create` (BOTH `resumeSessionId` AND `sessionRef`) and currently asserts `freshAgent.create.failed{code: SESSION_RESERVED}` (`:425`). Post Task 7, the refusal fires earlier — the `fresh_agent_control_refusal` legacy-field arm returns `FRESH_AGENT_CREATE_FAILED` + frozen text BEFORE the dispatch reaches the per-provider handler (which would have emitted `SESSION_RESERVED`). KEEP the legacy line in the `:411` send (so the legacy-field arm fires) and re-target the assertion:
+Re-target `crates/freshell-ws/tests/cross_kind_liveness.rs:411` (V5 premise-inversion, `freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session`): the test at `:411` sends dual-carrier `freshAgent.create` (BOTH `resumeSessionId` AND `sessionRef`) and currently asserts `freshAgent.create.failed{code: SESSION_RESERVED}` (`:425`). Post Task 7, the refusal fires earlier — the raw-Value ejh6 guard's freshAgent.create arm returns `FRESH_AGENT_CREATE_FAILED` + frozen text BEFORE the typed parse reaches the per-provider handler (which would have emitted `SESSION_RESERVED`). KEEP the legacy line in the `:411` send (so the legacy-field arm fires) and re-target the assertion:
 
 ```rust
     assert_eq!(
@@ -1021,7 +1161,7 @@ Re-target `crates/freshell-ws/tests/cross_kind_liveness.rs:411` (V5 premise-inve
         "a live terminal PTY owns {session_id}: the fresh-agent resume must be refused, got {failed}"
     );
     // ejh6: the legacy field is rejected at the door BEFORE the SESSION_RESERVED
-    // cross-kind guard fires (the blanket reject in fresh_agent_control_refusal
+    // cross-kind guard fires (the raw-Value ejh6 guard's freshAgent.create arm
     // runs first). The code is FRESH_AGENT_CREATE_FAILED + frozen text, not
     // SESSION_RESERVED.
     assert_eq!(failed["code"], "FRESH_AGENT_CREATE_FAILED");
@@ -1053,44 +1193,64 @@ use freshell_protocol::{
 };
 ```
 
-Add create/attach legacy-field arms at the TOP of `fresh_agent_control_refusal` at `:4768`, before the existing tuple match:
+Extend the Task-6 raw-Value guard in `crates/freshell-ws/src/terminal.rs` dispatch with the freshAgent arms — NOT the typed `fresh_agent_control_refusal` (review round 2 finding 8: the typed layer sits AFTER `from_value`, so JSON `null` deserializes to `None` before it and non-string values get swallowed by the accept-and-strip arm — the raw layer is the only full-presence read). Change the guard's tail (currently `_ => {}`):
 
 ```rust
-pub(crate) fn fresh_agent_control_refusal(message: &ClientMessage) -> Option<ServerMessage> {
-    // ejh6: reject the legacy `resume_session_id` wire field on every
-    // fresh-agent create-class door BEFORE dispatch. Create returns the
-    // `freshAgent.create.failed` envelope (it carries requestId); attach has
-    // NO requestId, so its rejection rides the `freshAgent.error` event
-    // channel keyed by sessionId. Both use the `FRESH_AGENT_CREATE_FAILED`
-    // family code + the frozen sessionRef-naming text.
-    if let ClientMessage::FreshAgentCreate(m) = message {
-        if m.resume_session_id.is_some() {
-            return Some(ServerMessage::FreshAgentCreateFailed(FreshAgentCreateFailed {
-                code: "FRESH_AGENT_CREATE_FAILED".to_string(),
-                message: LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
-                request_id: m.request_id.clone(),
-                retryable: Some(false),
-            }));
+        match value.get("type").and_then(|t| t.as_str()) {
+            Some("terminal.create") | Some("codingcli.create") => {
+                // ... unchanged Task-6 INVALID_MESSAGE + frozen text arm ...
+            }
+            // Task 7: freshAgent arms. The legacy field on a freshAgent
+            // create-class message gets the per-family envelope. Create
+            // returns `freshAgent.create.failed` (it carries requestId);
+            // attach has NO requestId, so its rejection rides the
+            // `freshAgent.error` event channel keyed by sessionId — the same
+            // shape claude.rs:265-282 broadcasts today. Built from the raw
+            // frame: presence already proven by the guard condition.
+            Some("freshAgent.create") => {
+                let reply = ServerMessage::FreshAgentCreateFailed(FreshAgentCreateFailed {
+                    code: "FRESH_AGENT_CREATE_FAILED".to_string(),
+                    message: LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
+                    request_id: value
+                        .get("requestId")
+                        .and_then(|r| r.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    retryable: Some(false),
+                });
+                return send(ws_tx, &reply).await;
+            }
+            Some("freshAgent.attach") => {
+                let session_id = value
+                    .get("sessionId")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or_default();
+                let reply = ServerMessage::FreshAgentEvent(FreshAgentEvent {
+                    event: serde_json::json!({
+                        "type": "freshAgent.error",
+                        "sessionId": session_id,
+                        "code": "FRESH_AGENT_CREATE_FAILED",
+                        "message": LEGACY_RESUME_IDENTITY_REFUSAL,
+                    }),
+                    provider: value
+                        .get("provider")
+                        .and_then(|p| p.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    session_id: session_id.to_string(),
+                    session_type: value
+                        .get("sessionType")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                });
+                return send(ws_tx, &reply).await;
+            }
+            _ => {} // not a create-class type; fall through to typed parse
         }
-    }
-    if let ClientMessage::FreshAgentAttach(m) = message {
-        if m.resume_session_id.is_some() {
-            return Some(ServerMessage::FreshAgentEvent(FreshAgentEvent {
-                event: serde_json::json!({
-                    "type": "freshAgent.error",
-                    "sessionId": m.session_id,
-                    "code": "FRESH_AGENT_CREATE_FAILED",
-                    "message": LEGACY_RESUME_IDENTITY_REFUSAL,
-                }),
-                provider: agent_provider_wire(m.provider).to_string(),
-                session_id: m.session_id.clone(),
-                session_type: session_type_wire(m.session_type).to_string(),
-            }));
-        }
-    }
-    let (refused, wording, provider, session_id, session_type) = match message {
-        // ... existing arms unchanged ...
 ```
+
+(If the Task-6 guard was written as a single `if let Some(...)` around the match, keep that form — this edit only replaces the `_ => {}` tail with the two freshAgent arms plus the non-create fallthrough.)
 
 Flip `attach_durable_id` in `crates/freshell-freshagent/src/claude.rs:1809-1819` to sessionRef-first (the legacy-first read is dead for external input after the wire reject; the test helper `attach_msg_with_resume` at `:2228` was converted to sessionRef in Task 3):
 
@@ -1120,7 +1280,7 @@ Expected: PASS
 
 - [ ] **Step 5: Refactor while green**
 
-The `fresh_agent_control_refusal` function now handles both control-frame capability refusals AND legacy-field rejections. The function name still accurately describes its role (a pre-dispatch refusal for fresh-agent control/create/attach frames). No further refactor needed.
+The raw-Value ejh6 guard now covers all four create-class families at one site (terminal.create + codingcli.create in Task 6; freshAgent.create + freshAgent.attach here). `fresh_agent_control_refusal` is untouched — its control-frame capability table is orthogonal. No further refactor needed.
 
 - [ ] **Step 6: Run impacted-test verification**
 
@@ -1144,7 +1304,7 @@ git commit -m "feat(ejh6): Rust WS freshAgent create/attach reject legacy field 
 **Files:**
 - Modify: `server/agent-api/router.ts:695` (top of `POST /tabs` — insert door-top check before agent/browser/editor/terminal branch), `:1250` (top of `POST /panes/:id/split`), `:1546` (top of `POST /panes/:id/respawn`); `:214-228` (`requestedResumeSessionIdForMode` — remove the legacy throw; keep sessionRef resolution only; single check at door-top for KISS per finding 3)
 - Test: `test/server/agent-tabs-write.test.ts:413` (add `it.each` for all modes + dual-carrier + presence-edge + browser/editor tests)
-- Test: `test/server/agent-panes-write.test.ts:132,:327` (widen to all modes + layout-unchanged on split)
+- Test: `test/server/agent-panes-write.test.ts:132,:327` (widen to all modes + layout-unchanged on split) AND `:339` (finding 7: door-top respawn rejection now returns BEFORE target resolution — flip the existing `expect(resolveTarget).toHaveBeenCalledWith('pane_1')` to `expect(resolveTarget).not.toHaveBeenCalled()`)
 
 **Interfaces:**
 - Consumes: `INVALID_RAW_CODEX_RESUME_MESSAGE` (`restore-decision.ts:27-28`); `fail(message)` returns `{status:'error',message}` (`response.ts:6`).
@@ -1215,6 +1375,14 @@ Add to `test/server/agent-tabs-write.test.ts` (after the existing codex-reject t
     expect(res.body).toEqual({ status: 'error', message: INVALID_RAW_CODEX_RESUME_MESSAGE })
   })
 ```
+
+Lockstep edit (review round 2 finding 7): in `test/server/agent-panes-write.test.ts` the existing codex respawn rejection test (`:311-340`, 'rejects raw Codex resume ids before respawning a pane') ends its not-called chain with `expect(resolveTarget).toHaveBeenCalledWith('pane_1')` at `:339`. With this task's door-top guard the rejection returns BEFORE target resolution — change that one assertion to:
+
+```ts
+  expect(resolveTarget).not.toHaveBeenCalled()
+```
+
+Leave the rest of that test untouched (`planCreateCalls` empty, `registryCreate`/`attachPaneContent` not called, 400 + frozen text). Also widen the split/respawn rejection tests at `:132`/`:327` to it.each over modes `['claude','codex','opencode','amplifier']` with presence-edge bodies per Global Constraints (`'legacy-x'`, `''`, `null`, `42` — Node REST reads `req.body`, so unlike WS these DO reject with the frozen text), and keep the existing 400+message assertions.
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -1372,6 +1540,29 @@ Add presence-edge and dual-intent tests (findings 2, 5):
       await closeWebSocket(ws)
     }
   })
+
+  // ejh6 review round 2 finding 8 (layered WS presence): a NON-STRING legacy
+  // value never reaches the handler — the dynamic `.strict()` schema's
+  // `resumeSessionId: z.string().optional()` fails zod parse first, producing
+  // error{INVALID_MESSAGE} with the parser's generic text (ws-handler.ts:1913-1916).
+  // Pin the CODE loudly, NOT the text (frozen text belongs to string carries).
+  it.each([['null', null], ['number', 42], ['object', { nested: true }]])(
+    'rejects non-string resumeSessionId (%s) at the parse boundary with INVALID_MESSAGE', async (_label, val) => {
+      const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
+      try {
+        await waitForOpen(ws)
+        await waitForReady(ws)
+        const requestId = `legacy-reject-nonstr-${_label}`
+        const errorPromise = waitForMessage(ws, (m) => m.type === 'error' && m.requestId === requestId)
+        ws.send(JSON.stringify({ type: 'terminal.create', requestId, mode: 'claude', shell: 'system', resumeSessionId: val }))
+        const error = await errorPromise
+        expect(error).toMatchObject({ type: 'error', code: 'INVALID_MESSAGE', requestId })
+        expect(registry.createCalls).toHaveLength(0)
+      } finally {
+        await closeWebSocket(ws)
+      }
+    },
+  )
 ```
 
 Repurpose `test/server/ws-terminal-create-session-repair.test.ts:1048` (the "sessionRef wins over legacy" precedence test) — after the blanket reject, sending BOTH `resumeSessionId` and `sessionRef` gets INVALID_MESSAGE. Replace the precedence assertion with:
@@ -1487,7 +1678,7 @@ Insert the blanket reject at the VERY TOP of the `case 'terminal.create':` block
         // TOP, BEFORE recordSessionLifecycleEvent and the fresh_after_restore_
         // unavailable validation — a message carrying both intents gets
         // INVALID_MESSAGE with frozen text (the mandatory error wins).
-        // Presence-based (finding 2): `!== undefined` covers "", null, 42.
+        // LAYERED presence (Global Constraints): `!== undefined` catches any string including ""; null/42 are rejected at the zod parse boundary with INVALID_MESSAGE (generic text).
         if (m.resumeSessionId !== undefined) {
           this.sendError(ws, {
             code: 'INVALID_MESSAGE',
@@ -1569,7 +1760,9 @@ git commit -m "feat(ejh6): Node WS terminal.create blanket reject (pre-recovery-
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Add to `test/unit/server/ws-handler-fresh-agent.test.ts` (model on the existing `connectAndAuth` + `seenMessages` + `vi.waitFor` pattern at `:87+` — that file has NO `waitForMessage` helper; use the file's own `seenMessages` array + `vi.waitFor` pattern):
+Add to `test/unit/server/ws-handler-fresh-agent.test.ts` (model on the existing `connectAndAuth` + `seenMessages` + `vi.waitFor` pattern at `:87+` — that file has NO `waitForMessage` helper; use the file's own `seenMessages` array + `vi.waitFor` pattern).
+
+Presence coverage (finding 9): BOTH tests below wrap their send in a `for (const legacy of ['legacy-durable-id', ''])` loop (unique requestId/sessionId per iteration) — an empty string carries MUST also reject with the frozen text (`!== undefined` presence):
 
 ```ts
   it('rejects freshAgent.create carrying resumeSessionId with freshAgent.create.failed', async () => {
@@ -1662,7 +1855,7 @@ Insert at the head of the `freshAgent.create` case at `server/ws-handler.ts:3424
         // ejh6: reject the legacy resumeSessionId wire field. The canonical
         // carrier is sessionRef; resumeSessionId stays declared on the shared
         // schema solely so the handler can detect-and-reject (see kata ejh6).
-        // Presence-based (finding 2): `!== undefined` covers "", null, 42.
+        // LAYERED presence (Global Constraints): `!== undefined` catches any string including ""; null/42 are rejected at the zod parse boundary with INVALID_MESSAGE (generic text).
         if (m.resumeSessionId !== undefined) {
           this.send(ws, {
             type: 'freshAgent.create.failed',
@@ -1686,7 +1879,7 @@ Insert at the head of the `freshAgent.attach` case at `server/ws-handler.ts:3543
         // attach error frame shape (sendError) with the FRESH_AGENT_CREATE_
         // FAILED code — the create-failed family code on the attach error
         // channel (see kata ejh6, binding correction D).
-        // Presence-based (finding 2): `!== undefined` covers "", null, 42.
+        // LAYERED presence (Global Constraints): `!== undefined` catches any string including ""; null/42 are rejected at the zod parse boundary with INVALID_MESSAGE (generic text).
         if (m.resumeSessionId !== undefined) {
           this.sendError(ws, {
             code: 'FRESH_AGENT_CREATE_FAILED',
@@ -1761,6 +1954,10 @@ Add to `test/server/ws-coding-cli-events.test.ts` (model on the existing `create
 
 ```ts
   it('rejects codingcli.create carrying resumeSessionId with INVALID_MESSAGE + frozen text', async () => {
+    // Review round 2 finding 10a: the rejection must ALSO assert no spawn — expose
+    // the suite fake manager's create spy (create the suite's default fake with a
+    // create: vi.fn() spy held in a suite-level binding, or do the same wsHandler
+    // swap the promote test uses; assert `createMock not called` after the error).
     const ws = await createAuthenticatedWs()
     const requestId = 'cli-legacy-reject-1'
     const errorPromise = new Promise<any>((resolve) => {
@@ -1779,8 +1976,13 @@ Add to `test/server/ws-coding-cli-events.test.ts` (model on the existing `create
       message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
       requestId,
     })
+    expect(createMock).not.toHaveBeenCalled() // no spawn on reject (finding 10a)
     ws.close()
   })
+
+  // Finding 9 (presence on this door too): wrap the rejection test above in
+  // `it.each([['string', 'legacy-cli-id'], ['empty-string', '']])` — an empty
+  // string carries MUST also reject with the frozen text (`!== undefined`).
 
   it('promotes a provider-matched sessionRef into the spawn-time resume id for codingcli.create', async () => {
     // V4: NEVER instantiate a real CodingCliSessionManager + real claudeProvider —
@@ -1831,6 +2033,43 @@ Add to `test/server/ws-coding-cli-events.test.ts` (model on the existing `create
     expect(createMock).toHaveBeenCalledWith('claude', expect.objectContaining({
       resumeSessionId: 'canonical-cli-session',
     }))
+    ws.close()
+  })
+
+  it('does NOT promote a provider-mismatched sessionRef into the spawn-time resume id', async () => {
+    // Review round 2 finding 10b: a sessionRef whose provider ≠ m.provider is
+    // NOT promoted — the spawn proceeds without a resume id. Same fake-manager
+    // wsHandler swap as the promote test above.
+    const createMock = vi.fn()
+    class FakeSession extends EventEmitter {
+      id = 'cli-session-2'
+      provider = { name: 'claude' }
+    }
+    const fakeManager = {
+      create: (...args: any[]) => { createMock(...args); return new FakeSession() },
+      hasProvider: (name: string) => name === 'claude',
+      get: vi.fn(),
+      remove: vi.fn(),
+    } as unknown as CodingCliSessionManager
+    wsHandler.close()
+    wsHandler = new WsHandler(server, registry, { codingCliManager: fakeManager })
+
+    const ws = await createAuthenticatedWs()
+    const requestId = 'cli-sref-mismatch-1'
+    const createdPromise = new Promise<void>((resolve) => {
+      ws.on('message', (data) => {
+        const msg = JSON.parse(data.toString())
+        if (msg.type === 'codingcli.created') resolve()
+      })
+    })
+    ws.send(JSON.stringify({
+      type: 'codingcli.create', requestId, provider: 'claude', prompt: 'hi',
+      sessionRef: { provider: 'codex', sessionId: 'wrong-provider-session' },
+    }))
+    await createdPromise
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const spawnOptions = createMock.mock.calls[0][1]
+    expect(spawnOptions.resumeSessionId).toBeUndefined()
     ws.close()
   })
 ```
@@ -1915,7 +2154,7 @@ Insert the reject + promotion at `server/ws-handler.ts:3280` UNCONDITIONALLY FIR
         // the reject is config-independent. The canonical carrier is sessionRef;
         // resumeSessionId stays declared on the schema solely so the handler
         // can detect-and-reject (see kata ejh6).
-        // Presence-based (finding 2): `!== undefined` covers "", null, 42.
+        // LAYERED presence (Global Constraints): `!== undefined` catches any string including ""; null/42 are rejected at the zod parse boundary with INVALID_MESSAGE (generic text).
         if (m.resumeSessionId !== undefined) {
           this.sendError(ws, {
             code: 'INVALID_MESSAGE',
@@ -2201,7 +2440,7 @@ Expected: output shows ONLY these categories:
 2. The `pane.reconcile` compat door (`crates/freshell-ws/src/reconcile.rs` `promoted_legacy_claim`, `src/lib/pane-reconcile.ts` `effectiveReconcileSessionRef`).
 3. Alias conversion sites (CLI `promoteResumeFlag` in `server/cli/index.ts`, MCP `freshell-tool.ts` `resume`/`resumeSessionId` param handling).
 4. Retained-for-rejection schema/struct fields (each carrying the section 3c comment): `shared/ws-protocol.ts` (`TerminalCreateSchema` at `:319-332`, `CodingCliCreateSchema`, `FreshAgentCreateSchema`, `FreshAgentAttachSchema`, `ReconcilePaneSchema`), `server/ws-handler.ts` (dynamic terminal.create + codingcli schemas), `crates/freshell-protocol/src/client_messages.rs` (`TerminalCreate`, `CodingCliCreate`, `FreshAgentCreate`, `FreshAgentAttach`, `ReconcilePane`).
-5. Rejection handlers: `crates/freshell-freshagent/src/terminal_tabs.rs` (`requested_resume_session_id_for_mode`), `crates/freshell-ws/src/terminal.rs` (head-of-`handle_create` blanket reject, `fresh_agent_control_refusal` create/attach arms), `server/ws-handler.ts` (terminal.create/freshAgent.create/freshAgent.attach/codingcli.create head-of-case rejects), `server/agent-api/router.ts` (`requestedResumeSessionIdForMode`).
+5. Rejection handlers: `crates/freshell-freshagent/src/lib.rs` (create_tab door-top presence check), `crates/freshell-freshagent/src/pane_ops.rs` (split/respawn door-top presence checks), `crates/freshell-ws/src/terminal.rs` (raw-Value pre-parse legacy-resume guard, all four create-class families), `server/ws-handler.ts` (terminal.create/freshAgent.create/freshAgent.attach/codingcli.create head-of-case rejects), `server/agent-api/router.ts` (door-top presence checks on all three routes).
 6. Sidecar-protocol file class (V5 ruling — NOT Freshell-wire input, EXCLUDE from rejection scope): `crates/freshell-claude-sidecar/index.mjs:10,:240` (reader), `claude.rs:469`/`:1294` + Node `sdk-bridge.ts:85,:168,:193` (writers), embedded fake sidecars in `test/e2e-browser/fixtures/` and in-crate `tests/*.rs` fake-sidecar JS, and the ~8 sidecar-log-reading specs (`freshagent-settings-resume-rust.spec.ts:545,:551`, `hidden-pane-rebind-rust.spec.ts:365-367`, `freshclaude-restart-parity-rust.spec.ts:309`, `freshclaude-identity-persistence-rust.spec.ts:313,:410`, `wavea-interactions-rust.spec.ts:403-407`, `restore-contract-wall-rust.spec.ts:1040,:1304`, `restore-matrix.spec.ts:400,:1099`). None are Freshell-wire input — the adapter still emits `resumeSessionId` on the internal sidecar protocol post-conversion, and these readers stay green because the ID VALUE is preserved. Production internal-name readers (`codex.rs:500`, `claude.rs:348/:1809`, `layout_store_content.rs:254`, `tabs_store_model.rs:484`, `pane_ops.rs:686`) are also in this category.
 
 If any hit falls outside these categories, add a section 3c doc comment, convert it to sessionRef, or document it as an allowed internal — then re-run.

--- a/docs/plans/2026-08-16-legacy-resume-guard.md
+++ b/docs/plans/2026-08-16-legacy-resume-guard.md
@@ -1,0 +1,1961 @@
+# Legacy Resume Session ID Guard Implementation Plan
+
+> **For agentic workers:** Execute this plan task by task with a fresh
+> implementer and a specification-plus-quality review after every task. Track
+> progress with the checkbox steps below.
+
+## User Request
+
+### Requested result
+Implement kata issue ejh6 (revised 2026-08-16 spec: "Remove the legacy resumeSessionId wire field — hard rejection, no silent ignore"): both Freshell servers must loudly reject the legacy `resumeSessionId` wire field on every create-class request door, with `sessionRef {provider, sessionId}` as the canonical carrier. Work happens on branch `legacy-resume-guard` in worktree `/home/dan/code/freshell/.worktrees/legacy-resume-guard`, based on current origin/main; authoritative spec text is kata `ejh6`, archived at `/home/dan/code/freshell/.worktrees/.the-usual-logs/legacy-resume-guard/reports/kata-ejh6-spec.md`.
+
+### Explicit constraints
+- Handler-level rejection on BOTH servers; `resumeSessionId` stays DECLARED in every wire schema/struct (shared zod schemas in `shared/ws-protocol.ts`, the dynamic `.strict()` terminal.create schema in `server/ws-handler.ts` `rebuildClientMessageSchema`, Rust protocol structs in `crates/freshell-protocol/src/client_messages.rs`), each commented as retained solely for handler detect-and-reject citing kata ejh6; never use `.strict()`/`deny_unknown_fields`/serde removal as the rejection mechanism.
+- Doors and responses: (a) REST `POST /api/tabs`, `POST /api/panes/:id/split`, `POST /api/panes/:id/respawn` (Rust `terminal_tabs.rs`/`pane_ops.rs`, Node `createAgentApiRouter`) → HTTP 400 naming `sessionRef` (reuse the frozen text "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity." — the same constant in both servers, or mint one shared new constant); (b) WS `terminal.create` (Rust `freshell-ws/terminal.rs`, Node `ws-handler.ts`) → `error{INVALID_MESSAGE}` on ANY create carrying the field, including codex (drop the current restore-only/non-codex scoping); (c) WS `freshAgent.create`/`freshAgent.attach` → the provider's create-failed envelope (FRESH_AGENT_CREATE_FAILED family); (d) WS `codingcli.create` (Node `ws-handler.ts` ~:3280) → reject the legacy field with INVALID_MESSAGE + named text AND promote `sessionRef` (provider must equal `m.provider`) into the spawn-time resume id; check `port/machine/specs/cli-argv-fidelity.md` before touching the Rust codingcli struct doc comment.
+- Permanent sole exception: `pane.reconcile`'s `ReconcilePane.resume_session_id` — keep the server-side promotion in `crates/freshell-ws/src/reconcile.rs` (`promoted_legacy_claim` ~:162–:177) forever, documented as the single legacy-compat door with no later-removal plan; also add client-side promotion in `src/lib/pane-reconcile.ts:130,:153` following the `effectiveSessionRef` pattern.
+- No internal regressions: restore-driven REST creates reuse the `POST /api/tabs` create handler in `crates/freshell-freshagent/src/terminal_tabs.rs` (EDEV-07 synthesis ~:2096–:2110), where captured pane content may carry an implausible legacy resumeSessionId — the reject must fire only after that path promotes or strips the field (or assert snapshots never carry it and migrate); `claude.rs` `attach_durable_id` (~:1813) reads legacy-first — flip to sessionRef-first or leave documented, after verifying no internal caller constructs an attach with the field set; registry rows, pane-content fields, and `/api/terminals` read-model derivations are out of scope (do not rename); the MCP `resume`/`resumeSessionId` params and CLI `--resume` flag stay as ergonomic aliases that convert to sessionRef before the wire.
+- Every rejection has a door-level test on Rust AND Node, plus e2e through the CLI/MCP path where one exists; wire-sending tests that use `resumeSessionId` (~844 raw occurrences across ~119 test files, verify by grepping) are converted to sessionRef or repurposed as rejection tests; never delete a behavior test without a replacement; pinned frozen-message tests keep passing with the exact frozen text.
+- Order of work: contract-neutral test-conversion commits first (no behavior change), then behavior commits landing BOTH servers' rejections together with the pane-reconcile client promotion, the codingcli sessionRef promotion, and rejection tests; gates are the coordinated full suite (`npm run check`, local vitest backend), `cargo test --workspace`, and Playwright e2e for the CLI/MCP path where one exists.
+- Acceptance verification: the kata §6 `rg` sweep shows only allowed categories, and the kata verification checklist passes (REST 400, WS INVALID_MESSAGE with named text and no spawn, registry row count unchanged, create-failed envelope, CLI `--resume`/MCP `resume` still work, reload/restore of pre-existing persisted state still resumes).
+
+### Accepted tradeoffs and residuals
+- No known external callers exist (user-confirmed), so rejection ships directly with loud errors and no deprecation window.
+- The `attach_durable_id` legacy-first read becomes dead for external input after rejection; its flip/documentation is hygiene, not a safety gate.
+- Old persisted pane content can carry a legacy-only claim indefinitely, so the server-side `pane.reconcile` compat door is permanent by design; no point-in-time test run can justify closing it (kata option 2b is rejected).
+
+**Goal:** Both Freshell servers loudly reject any create-class wire message carrying `resumeSessionId` with a frozen sessionRef-naming error, while the permanent `pane.reconcile` compat door keeps old persisted state resumable.
+
+**Architecture:** Handler-level rejection on both servers — `resumeSessionId` stays declared in every wire schema/struct (commented "retained solely so the handler can detect-and-reject; see kata ejh6") and each create door checks for the field and returns the frozen text. One shared Rust `&str` const in `freshell-protocol` and one canonical Node const (`INVALID_RAW_CODEX_RESUME_MESSAGE`) dedupe the frozen text. Contract-neutral test conversions land first (both servers still accept both carriers), then Rust REST/WS rejection, then Node REST/WS rejection, then client-side `pane.reconcile` promotion, then a final `rg` sweep + verification gates. The Rust `pane.reconcile` `promoted_legacy_claim` door stays forever as the single permanent compat exception.
+
+**Tech Stack:** Node.js/Express/ws/zod (Node server + shared schemas), Rust/axum/tokio-tungstenite/serde (Rust server + `freshell-protocol`), Vitest + supertest (Node tests), `cargo test` (Rust tests), Playwright (e2e-browser specs).
+
+## Global Constraints
+
+- **Worktree-only:** all work is in `/home/dan/code/freshell/.worktrees/legacy-resume-guard` on branch `legacy-resume-guard` from `origin/main`. Never push behavior changes directly to `origin/main`.
+- **NodeNext ESM:** relative TS imports must include `.js` extensions (e.g. `from '../../server/coding-cli/codex-app-server/restore-decision.js'`).
+- **Frozen text is byte-exact and immutable:** `"Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."` — pinned by tests in both servers; never change the text. Existing pinned-text tests (`live_session_ref_guard.rs:236`, `resume_validation_gate.rs:677`, `ws-terminal-create-reuse-running-codex.test.ts:619,:652`, `agent-cli-flow.test.ts:575`, `freshell-tool.test.ts:117,:163,:321,:440`, `agent-tabs-write.test.ts:442`, `agent-panes-write.test.ts:154,:336`) must keep passing.
+- **Never weaken tests:** never delete a behavior test without a replacement; never mark tests skip; never simplify assertions to get green.
+- **Coordinated runners:** Node tests via `npm run test:vitest -- run <paths> --config <config>` (default config `config/vitest/vitest.config.ts`, server config `config/vitest/vitest.server.config.ts`); Rust via `cargo test -p <crate>` focused, `cargo test --workspace` as gate; `npm run check` (typecheck + coordinated full suite) as final gate.
+- **Rejection mechanism:** handler-level only. Never use `.strict()`/`deny_unknown_fields`/serde field removal as the rejection mechanism (zod non-strict strips silently; `.strict()` rejects with a generic unrecognized-key error that cannot carry the frozen text). The field stays DECLARED in every schema/struct.
+- **Section 3c doc comment:** every retained `resumeSessionId`/`resume_session_id` field in a wire schema/struct gets the comment `Retained solely so the handler can detect-and-reject; see kata ejh6.` — EXCEPT `ReconcilePane.resume_session_id` which gets the PERMANENT compat-door comment.
+- **`restoreKey` gating:** blanket REST reject does NOT gate on `restoreKey` — no production producer emits it (verified), so blanket reject regresses nothing live (binding correction A).
+- **Sidecar JSON-lines writers are not wire input:** `claude.rs:469` and `:1294` write `resumeSessionId` to the claude Node sidecar's internal JSON-lines protocol, not the Freshell WS wire — leave them untouched (binding correction C).
+
+## Where the kata is superseded by explorer evidence
+
+A) Rust REST reject point is `derive_resume_identity` (`crates/freshell-freshagent/src/terminal_tabs.rs:507-531`); restore-driven creates are distinguishable only by a `restoreKey` body tag that NO production producer emits — blanket REST reject regresses nothing live, do NOT gate on `restoreKey`.
+B) Rust WS `terminal.create`: widen the gate at `crates/freshell-ws/src/terminal.rs:2441-2457` or reject at head of `handle_create` (`:2138`); freshAgent create/attach share dispatch `terminal.rs:861-926` — create rejects via `FreshAgentCreateFailed` envelope (`crates/freshell-ws/src/server_messages.rs:618-627`), attach has NO requestId so its rejection rides `freshAgent.event{freshAgent.error}` keyed by session id.
+C) Rust has NO codingcli handler (protocol struct only, `crates/freshell-protocol/src/client_messages.rs:429-448`, no `session_ref` on it; section 3.3/U7 doc comment lives on `TerminalCreate.resume_session_id` `:231-235`); NO Rust production code sends the field on the Freshell wire — server-to-sidecar JSON-lines writers (`claude.rs:469`/`:1294` + test fakes) are not wire input, leave them.
+D) Node: blanket WS `terminal.create` reject at head of the terminal.create case `server/ws-handler.ts` (~:2107+), replacing the restore/non-codex-scoped gate `:2160-2186`; freshAgent.create envelope `freshAgent.create.failed` (codes `:3430`/`:3465`/`:3530`); attach failure frame is `error{INTERNAL_ERROR}` — for attach rejection use the `FRESH_AGENT_CREATE_FAILED` code on a frame matching the existing attach error shape, documented via comment; `codingcli.create` `:3280-3326`: add `sessionRef` to `CodingCliCreateSchema` (`shared/ws-protocol.ts`) and — after reading `port/machine/specs/cli-argv-fidelity.md` section 3.3/U7, with the decision and cited spec text IN the plan — decide whether the Rust codingcli struct also gains `session_ref`; then promote a provider-matched `sessionRef` into the spawn-time resume id in the Node handler.
+E) Node REST: single seam `requestedResumeSessionIdForMode` (`server/agent-api/router.ts:214-228`) — widen codex-only throw to all modes with frozen text; 400 shape `{status:'error',message}`.
+F) Frozen text byte-exact: `"Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."` Node canonical const `INVALID_RAW_CODEX_RESUME_MESSAGE` (`server/coding-cli/codex-app-server/restore-decision.ts:27-28`) + inline dup `ws-handler.ts:2181`; Rust private dups `terminal_tabs.rs:65` + `terminal.rs:1520` — plan mints one shared Rust const in `freshell-protocol` and one canonical Node const (names may change; text pinned by tests, don't change text).
+G) Use `plan-test-sweep.md` tables literally for conversion scope; `remote-tab-linkage-rust.spec.ts`: convert sends to `sessionRef` where assertions aren't legacy-acceptance, leave acceptance asserts for the behavior task to repurpose as rejection tests.
+H) Node has NO `pane.reconcile` handler; client-side promotion in `src/lib/pane-reconcile.ts:130`,`:153` (pattern = `FreshAgentView.tsx` `effectiveSessionRef` `:335-341`) + Rust server door kept forever.
+I) No e2e drives CLI/MCP into WS `terminal.create`; CLI/MCP regression = existing suites stay green (aliases convert), plus one cheap new assertion in `test/e2e/agent-cli-flow.test.ts` that a raw legacy WS send gets `INVALID_MESSAGE`+frozen text. Do not invent new e2e harnesses.
+J) Repo rules: worktree-only; coordinated runners (`npm run test:vitest -- run <paths> --config <config>`; configs `config/vitest/vitest.config.ts` (default) and `config/vitest/vitest.server.config.ts` (server)); `cargo test -p <crate>` focused, `cargo test --workspace` and `npm run check` as gates; NodeNext ESM needs `.js` extensions on relative TS imports; never weaken tests.
+
+---
+
+### Task 1: Mint shared frozen-text constants (Rust + Node dedup)
+
+**Files:**
+- Create: `crates/freshell-protocol/tests/legacy_resume_text.rs`
+- Modify: `crates/freshell-protocol/src/common.rs:82` (add const after `ErrorCode` enum)
+- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs:51` (import), `:60-65` (remove local const), `:130` (usage)
+- Modify: `crates/freshell-ws/src/terminal.rs:62-67` (import), `:1516-1520` (remove local const), `:2453` (usage)
+- Modify: `server/ws-handler.ts:110-113` (add import), `:2179-2183` (replace inline literal)
+- Test: `crates/freshell-protocol/tests/legacy_resume_text.rs` (new), existing pins stay green
+
+**Interfaces:**
+- Consumes: existing frozen text in `restore-decision.ts:27-28` (Node), existing private consts at `terminal_tabs.rs:65` and `terminal.rs:1520` (Rust).
+- Produces: `freshell_protocol::LEGACY_RESUME_IDENTITY_REFUSAL` (Rust shared `&str` const, re-exported via `pub use common::*` in `lib.rs`); Node `INVALID_RAW_CODEX_RESUME_MESSAGE` imported into `ws-handler.ts` for use by later tasks.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+This task is a pure dedup refactor — no new behavior, so the "test" is a new pinning test plus the existing pinned-text tests continuing to assert the exact frozen string.
+
+```rust
+// crates/freshell-protocol/tests/legacy_resume_text.rs
+//! ejh6 Task 1: the shared frozen refusal text is byte-exact and lives in
+//! freshell-protocol so both freshell-freshagent and freshell-ws reference
+//! one source of truth.
+use freshell_protocol::LEGACY_RESUME_IDENTITY_REFUSAL;
+
+#[test]
+fn frozen_refusal_text_is_byte_exact() {
+    assert_eq!(
+        LEGACY_RESUME_IDENTITY_REFUSAL,
+        "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."
+    );
+}
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `cargo test -p freshell-protocol --test legacy_resume_text`
+
+Expected: FAIL because `cannot find function or const LEGACY_RESUME_IDENTITY_REFUSAL in crate freshell_protocol` — the const does not exist yet.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Add the shared const to `crates/freshell-protocol/src/common.rs` after the `ErrorCode` enum (after line 82):
+
+```rust
+/// The frozen sessionRef-naming refusal text for the legacy `resumeSessionId`
+/// wire field (kata ejh6). Byte-identical to Node's
+/// `INVALID_RAW_CODEX_RESUME_MESSAGE`
+/// (`server/coding-cli/codex-app-server/restore-decision.ts:27-28`) so clients
+/// see one contract across doors and servers. Both `freshell-freshagent`
+/// (`terminal_tabs.rs`) and `freshell-ws` (`terminal.rs`) reference this const
+/// instead of carrying private duplicates.
+pub const LEGACY_RESUME_IDENTITY_REFUSAL: &str = "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.";
+```
+
+Update `crates/freshell-freshagent/src/terminal_tabs.rs` — change the import at `:51` to:
+
+```rust
+use freshell_protocol::{LEGACY_RESUME_IDENTITY_REFUSAL, ServerMessage, SessionLocator, UiCommand};
+```
+
+Remove the private const at `:60-65` (the doc block + `const INVALID_RAW_CODEX_RESUME_MESSAGE: &str = ...;`). Replace the usage at `:130` (`INVALID_RAW_CODEX_RESUME_MESSAGE.to_string()`) with `LEGACY_RESUME_IDENTITY_REFUSAL.to_string()`.
+
+Update `crates/freshell-ws/src/terminal.rs` — add `LEGACY_RESUME_IDENTITY_REFUSAL` to the import block at `:62-67`:
+
+```rust
+use freshell_protocol::{
+    AgentProvider, ClientMessage, ErrorCode, ErrorMsg, FreshAgentEvent,
+    LEGACY_RESUME_IDENTITY_REFUSAL, Pong, ServerMessage,
+    SessionLocator, SessionType, Shell, TerminalAttach, TerminalAutoResumeCancel, TerminalCreate,
+    TerminalCreated, TerminalIdOnly, TerminalInputBlocked, TerminalInputBlockedReason,
+    TerminalKill, TerminalResize,
+};
+```
+
+Remove the private const at `:1516-1520` (the doc block + `const LEGACY_RESTORE_IDENTITY_REFUSAL: &str = ...;`). Replace the usage at `:2453` (`LEGACY_RESTORE_IDENTITY_REFUSAL.to_string()`) with `LEGACY_RESUME_IDENTITY_REFUSAL.to_string()`.
+
+Update `server/ws-handler.ts` — add `INVALID_RAW_CODEX_RESUME_MESSAGE` to the import at `:110-113`:
+
+```ts
+import {
+  INVALID_RAW_CODEX_RESUME_MESSAGE,
+  planCodexCreateRestoreDecision,
+  resolveCodexCreateRestoreDecision,
+} from './coding-cli/codex-app-server/restore-decision.js'
+```
+
+Replace the inline literal at `:2179-2183`:
+
+```ts
+          this.sendError(ws, {
+            code: 'INVALID_MESSAGE',
+            message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+            requestId: m.requestId,
+          })
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `cargo test -p freshell-protocol --test legacy_resume_text && cargo test -p freshell-ws --test live_session_ref_guard legacy_only_restore_is_refused && npm run test:vitest -- run test/server/ws-terminal-create-reuse-running-codex.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: PASS — the new const test pins the text; existing pinned-text tests stay green because the text is byte-identical.
+
+- [ ] **Step 5: Refactor while green**
+
+The dedup IS the refactor. Confirm no remaining private duplicate: `rg "Restore requires sessionRef" crates/freshell-freshagent/src/terminal_tabs.rs crates/freshell-ws/src/terminal.rs server/ws-handler.ts` should show ZERO hits (all three now reference the shared/imported const).
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The change touches the frozen text carriers in both servers. Impacted set: all pinned-text tests in both servers.
+
+Run: `cargo test -p freshell-freshagent && cargo test -p freshell-ws && npm run test:vitest -- run test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/agent-tabs-write.test.ts test/server/agent-panes-write.test.ts test/unit/server/mcp/freshell-tool.test.ts test/e2e/agent-cli-flow.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add crates/freshell-protocol/src/common.rs crates/freshell-protocol/tests/legacy_resume_text.rs crates/freshell-freshagent/src/terminal_tabs.rs crates/freshell-ws/src/terminal.rs server/ws-handler.ts
+git commit -m "refactor(ejh6): mint shared frozen refusal-text const, dedupe private dups"
+```
+
+---
+
+### Task 2: Convert Node WS freshAgent wire-send tests to sessionRef
+
+**Files:**
+- Modify: `test/unit/server/ws-handler-fresh-agent-lifecycle-parity.test.ts:98,:201,:248`
+- Modify: `test/unit/server/ws-handler-fresh-agent.test.ts:959`
+- Test: same files (converted in place)
+
+**Interfaces:**
+- Consumes: `sessionRef` field already accepted by `FreshAgentCreateSchema`/`FreshAgentAttachSchema` (`shared/ws-protocol.ts:486,:499`); `runtime-manager.ts:106-108` sessionRef-to-resume-id promotion.
+- Produces: tests that send `sessionRef` only (no legacy field), staying green against the unmodified server.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+These are mechanical conversions of wire-send sites. Against the unmodified server both carriers are accepted, so the converted test passes immediately (contract-neutral). No production change.
+
+In `test/unit/server/ws-handler-fresh-agent-lifecycle-parity.test.ts`, at each of the 3 wire-send sites (`:98`, `:201`, `:248`), replace the `resumeSessionId: '<value>'` property with `sessionRef: { provider: '<provider>', sessionId: '<value>' }` where `<provider>` matches the `provider` field on the same message. For `freshAgent.attach` at `:248`: keep the top-level `sessionId` field (required by the schema), replace `resumeSessionId` with `sessionRef: { provider, sessionId }` using the same sessionId value. The internal `runtimeManager.create` arg-mirror assert at `:112` mirrors the manager input, not the wire — leave internal asserts unchanged.
+
+In `test/unit/server/ws-handler-fresh-agent.test.ts:959`, replace `resumeSessionId: 'cli-session-attached'` with `sessionRef: { provider: 'claude', sessionId: 'cli-session-attached' }` on the `freshAgent.attach` wire message.
+
+Example conversion shape (match the exact surrounding code in-file):
+
+```ts
+// BEFORE:
+ws.send(JSON.stringify({
+  type: 'freshAgent.create', requestId: '...', sessionType: 'freshclaude',
+  provider: 'claude', cwd: '/tmp', resumeSessionId: 'cli-session-attached',
+}))
+// AFTER:
+ws.send(JSON.stringify({
+  type: 'freshAgent.create', requestId: '...', sessionType: 'freshclaude',
+  provider: 'claude', cwd: '/tmp',
+  sessionRef: { provider: 'claude', sessionId: 'cli-session-attached' },
+}))
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Contract-neutral conversion — the test passes against the unmodified server (both carriers accepted).
+
+Run: `npm run test:vitest -- run test/unit/server/ws-handler-fresh-agent-lifecycle-parity.test.ts test/unit/server/ws-handler-fresh-agent.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+No production change — contract-neutral test conversion. Both servers still accept both carriers.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/server/ws-handler-fresh-agent-lifecycle-parity.test.ts test/unit/server/ws-handler-fresh-agent.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+No refactor needed — mechanical conversion.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+These test files are self-contained unit tests; no other test imports or depends on their wire-send shapes.
+
+Run: same as Step 4.
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add test/unit/server/ws-handler-fresh-agent-lifecycle-parity.test.ts test/unit/server/ws-handler-fresh-agent.test.ts
+git commit -m "test(ejh6): convert Node WS freshAgent wire-send tests to sessionRef"
+```
+
+---
+
+### Task 3: Convert Rust wire-send tests to sessionRef
+
+**Files:**
+- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs` (test mod — POST bodies at `:4504,:4558,:4606,:5838,:5883,:5915,:5950,:5993,:6032,:6074`)
+- Modify: `crates/freshell-freshagent/src/codex.rs` (test mod — msg structs at `:7047,:7181,:7240`)
+- Modify: `crates/freshell-freshagent/src/opencode_ws.rs:3056`
+- Modify: `crates/freshell-freshagent/src/claude.rs:2228-2232`
+- Modify: `crates/freshell-ws/src/terminal_launch_prep_tests.rs:31-45`
+- Modify: `crates/freshell-ws/tests/codex_managed_launch_e2e.rs:253-267`
+- Modify: `crates/freshell-ws/tests/session_identity_frames.rs:67-72`
+- Modify: `crates/freshell-ws/tests/pane_ledger_triggers.rs:156-162`
+- Modify: `crates/freshell-ws/tests/freshagent_claude_attach.rs:360-365,:466-471`
+- Modify: `crates/freshell-ws/tests/freshagent_session_lease.rs:417-424,:599-604,:756-761`
+- Test: same files (converted in place)
+
+**Interfaces:**
+- Consumes: `session_ref` field already on every Rust protocol struct (`TerminalCreate.session_ref`, `FreshAgentCreate.session_ref`, `FreshAgentAttach.session_ref`); `derive_resume_identity` and per-provider resume-id derivation accept sessionRef.
+- Produces: Rust tests that send `sessionRef`/`session_ref` only, staying green against the unmodified server.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Mechanical conversions. For each site, replace the legacy carrier with the canonical `sessionRef`/`session_ref` carrier. The asserted behavior (registry directory fills, spawn argv, frame assertions, ledger non-mutation) is carrier-agnostic and stays green.
+
+**REST POST bodies in `terminal_tabs.rs` test mod** — each `json!({... "resumeSessionId": "<id>" ...})` becomes `json!({... "sessionRef": {"provider": "<mode>", "sessionId": "<id>"} ...})` where `<mode>` is the `mode` field on the same body. The 10 test fns at `:4490,:4543,:4592,:5824,:5856,:5896,:5936,:5978,:6018,:6060` each get their POST body converted. Example for `create_tab_resume_session_id_flows_to_registry_directory_for_non_codex_mode` (`:4490`, body at `:4504`):
+
+```rust
+// BEFORE:
+let body = json!({"mode": "claude", "resumeSessionId": "sess-dir-claude-1"});
+// AFTER:
+let body = json!({"mode": "claude", "sessionRef": {"provider": "claude", "sessionId": "sess-dir-claude-1"}});
+```
+
+The three `rest_create_legacy_resume_*409` tests (`:5824,:5856,:5896`) test the D7/LEASE 409 ladder via the legacy carrier — convert the body to `sessionRef` and re-aim the assertions at the sessionRef-carrier D7 path (the 409 RESTORE_UNAVAILABLE behavior is carrier-agnostic; the test still expects 409). The `:4424` codex-reject test (`create_codex_tab_rejects_raw_resume_session_id_without_session_ref`) is a REJECTION-READY test — leave it sending legacy (it will be widened in Task 5).
+
+**`codex.rs` test mod** — at `:7047,:7181,:7240`, replace `resume_session_id: Some("<id>".to_string())` with `session_ref: Some(SessionLocator { provider: AgentProvider::Codex, session_id: "<id>".to_string() })`. The twin test `handle_create_with_session_ref_only_resumes_the_same_thread` at `:7096` already shows the post-conversion shape — match it.
+
+**`opencode_ws.rs:3056`** — replace `create.resume_session_id = Some(DURABLE_ID.to_string());` with `create.session_ref = Some(SessionLocator { provider: AgentProvider::Opencode, session_id: DURABLE_ID.to_string() });`.
+
+**`claude.rs:2228-2232`** (`attach_msg_with_resume` test helper) — replace `msg.resume_session_id = Some(durable.to_string());` with `msg.session_ref = Some(SessionLocator { provider: AgentProvider::Claude, session_id: durable.to_string() });`.
+
+**`terminal_launch_prep_tests.rs:31-45`** — the `wire_legacy_resume_session_id_is_from_wire` test builds a legacy `restore:true` create. Convert to `session_ref` carrier; rename to `wire_session_ref_is_from_wire`; the `resume_id_from_wire` property survives via sessionRef.
+
+**`codex_managed_launch_e2e.rs:253-267`** (helper `create_codex_terminal_resume`) — replace `"resumeSessionId": "<id>"` with `"sessionRef": {"provider": "codex", "sessionId": "<id>"}` in the WS frame.
+
+**`session_identity_frames.rs:67-72`** — replace `"resumeSessionId": "sess-identity-1"` with `"sessionRef": {"provider": "amplifier", "sessionId": "sess-identity-1"}`.
+
+**`pane_ledger_triggers.rs:156-162`** — replace the legacy-only create carrier with `"sessionRef": {"provider": "claude", "sessionId": "<id>"}`.
+
+**`freshagent_claude_attach.rs:360-365,:466-471`** and **`freshagent_session_lease.rs:417-424,:599-604,:756-761`** — these frames carry BOTH `resumeSessionId` AND `sessionRef` today. Delete the `resumeSessionId` line in each (sessionRef already present — trivial). The fake-sidecar `msg.resumeSessionId` reads at `freshagent_claude_attach.rs:63` are the internal adapter-to-sidecar protocol — leave them.
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Contract-neutral conversion — passes against the unmodified server.
+
+Run: `cargo test -p freshell-freshagent && cargo test -p freshell-ws`
+
+Expected: PASS
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+No production change — contract-neutral test conversion.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `cargo test -p freshell-freshagent && cargo test -p freshell-ws`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+No refactor needed — mechanical conversion. Stale test names (e.g. `create_amplifier_tab_with_legacy_resume_synthesizes_session_ref`) may be renamed to reflect the sessionRef carrier (e.g. `create_amplifier_tab_with_session_ref_flows_to_registry`), but this is optional in the prep task.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The Rust workspace suite is the impacted set (these tests cover the create doors across both crates).
+
+Run: `cargo test --workspace`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add crates/freshell-freshagent/src/terminal_tabs.rs crates/freshell-freshagent/src/codex.rs crates/freshell-freshagent/src/opencode_ws.rs crates/freshell-freshagent/src/claude.rs crates/freshell-ws/src/terminal_launch_prep_tests.rs crates/freshell-ws/tests/codex_managed_launch_e2e.rs crates/freshell-ws/tests/session_identity_frames.rs crates/freshell-ws/tests/pane_ledger_triggers.rs crates/freshell-ws/tests/freshagent_claude_attach.rs crates/freshell-ws/tests/freshagent_session_lease.rs
+git commit -m "test(ejh6): convert Rust wire-send tests to sessionRef"
+```
+
+---
+
+### Task 4: Convert e2e-browser Rust wire-send tests to sessionRef
+
+**Files:**
+- Modify: `test/e2e-browser/specs/fresh-agent-control-rust.spec.ts:1521,:1586,:1864,:1929`
+- Modify: `test/e2e-browser/specs/freshagent-settings-resume-rust.spec.ts:313,:414,:536`
+- Modify: `test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts:344-346,:423-425,:616-618`
+- Modify: `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts:197-205` (convert sends where assertions aren't legacy-acceptance; leave acceptance asserts for Task 8 to repurpose)
+- Test: same files
+
+**Interfaces:**
+- Consumes: Rust server accepts both carriers (unmodified); sessionRef is the canonical carrier already used by the web client.
+- Produces: e2e specs that send `sessionRef` only on the wire (except `remote-tab-linkage-rust.spec.ts` acceptance-assert sites, left for Task 8).
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Mechanical conversions of e2e WS/REST wire-send sites.
+
+**`fresh-agent-control-rust.spec.ts:1521,:1586,:1864,:1929`** — each `freshAgent.attach` frame carrying `resumeSessionId: '<id>'` (alongside `sessionId`, no `sessionRef`) becomes `sessionRef: { provider: 'claude', sessionId: '<id>' }` (drop the `resumeSessionId` key, keep `sessionId`).
+
+**`freshagent-settings-resume-rust.spec.ts:313,:414`** — `freshAgent.create` with `resumeSessionId` becomes `sessionRef: { provider, sessionId }`. **`:536`** — `freshAgent.attach` with `resumeSessionId` becomes `sessionRef` (keep `sessionId`).
+
+**`sidebar-registry-sync-rust.spec.ts:344-346,:423-425,:616-618`** — each `page.request.post(baseUrl/api/tabs)` with `data: { mode: 'claude', resumeSessionId: sessionId }` becomes `data: { mode: 'claude', sessionRef: { provider: 'claude', sessionId } }`. The in-file comment pattern at `:338-343`/`:417-422` already explains codex uses sessionRef — extend it to claude.
+
+**`remote-tab-linkage-rust.spec.ts:197-205`** — per binding correction G: convert the `fetch(baseUrl/api/tabs, { mode: 'amplifier', resumeSessionId: SEEDED_SESSION_ID })` send to `sessionRef` WHERE the surrounding assertion is NOT legacy-acceptance. The spec's premise (legacy acceptance then sessionRef synthesis) is tested by assertions that the created tab carries the synthesized sessionRef. Leave those acceptance assertions untouched for Task 8 to repurpose as a REST 400 rejection e2e. For any purely-mechanical send sites whose assertions are carrier-agnostic (e.g. sidecar log reads), convert to `sessionRef`.
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Contract-neutral — e2e specs pass against the unmodified Rust server. Run the four converted specs via the repo's e2e runner (check `package.json`; if `FRESHELL_E2E_BACKEND` is unset, run locally — these are Rust-server specs so use the Rust e2e config).
+
+Run: `npm run test:e2e:local -- --grep "fresh-agent-control-rust|freshagent-settings-resume-rust|sidebar-registry-sync-rust|remote-tab-linkage-rust"` (adjust to the repo's Playwright invocation if the grep syntax differs; the intent is to run only these four specs).
+
+Expected: PASS
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+No production change — contract-neutral test conversion.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: same as Step 2.
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+No refactor needed — mechanical conversion.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The impacted set is the four converted e2e specs (they are self-contained against the Rust server). Run them together.
+
+Run: same as Step 2.
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add test/e2e-browser/specs/fresh-agent-control-rust.spec.ts test/e2e-browser/specs/freshagent-settings-resume-rust.spec.ts test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts
+git commit -m "test(ejh6): convert e2e-browser Rust wire-send tests to sessionRef"
+```
+
+---
+
+### Task 5: Rust REST reject — widen `derive_resume_identity` to all modes + section 3c doc comments
+
+**Files:**
+- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs:117-136` (`requested_resume_session_id_for_mode` — widen codex-only throw to all modes)
+- Modify: `crates/freshell-protocol/src/client_messages.rs:231-235` (`TerminalCreate.resume_session_id` doc), `:409-411` (`ReconcilePane.resume_session_id` doc — PERMANENT compat), `:445` (`CodingCliCreate.resume_session_id` doc), `:511` (`FreshAgentCreate.resume_session_id` doc), `:527` (`FreshAgentAttach.resume_session_id` doc)
+- Test: `crates/freshell-freshagent/src/terminal_tabs.rs` (test mod — add per-mode rejection test)
+- Test: `crates/freshell-freshagent/src/pane_ops_tests.rs` (new split/respawn rejection tests)
+
+**Interfaces:**
+- Consumes: `LEGACY_RESUME_IDENTITY_REFUSAL` (from Task 1); `fail_json(StatusCode::BAD_REQUEST, ...)` at `lib.rs:1556`; `post(app(state), uri, body, auth)` helper at `terminal_tabs.rs:2671`.
+- Produces: all three Rust REST doors (`POST /api/tabs`, `/api/panes/:id/split`, `/api/panes/:id/respawn`) return HTTP 400 `{status:"error",message:<frozen>}` when the body carries a non-empty `resumeSessionId`.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add to the `#[cfg(test)] mod tests` in `crates/freshell-freshagent/src/terminal_tabs.rs` (after the existing `create_codex_tab_rejects_raw_resume_session_id_without_session_ref` at `:4415`):
+
+```rust
+#[tokio::test]
+async fn rest_create_rejects_legacy_resume_session_id_for_every_session_mode() {
+    let state = state_with_registry();
+    let app = crate::router(state);
+    for mode in ["claude", "opencode", "amplifier"] {
+        let (status, body) = post(
+            app.clone(),
+            "/api/tabs",
+            json!({"mode": mode, "resumeSessionId": format!("legacy-{mode}-id")}),
+            AUTH_HEADER,
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{mode}: legacy resumeSessionId must be rejected with 400, got {status}: {body}"
+        );
+        let msg = body["message"].as_str().expect("message field");
+        assert_eq!(
+            msg,
+            "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.",
+            "{mode}: frozen text must be byte-exact, got {msg}"
+        );
+    }
+}
+```
+
+Add to `crates/freshell-freshagent/src/pane_ops_tests.rs` (split test section opens at `:122`; add after the last split test):
+
+```rust
+#[tokio::test]
+async fn split_pane_rejects_legacy_resume_session_id_with_400() {
+    let state = state_with_registry();
+    let app = crate::router(state);
+    let _ = post(app.clone(), "/api/tabs", json!({"mode": "shell"}), AUTH_HEADER).await;
+    let (status, body) = post(
+        app.clone(),
+        "/api/panes/pane_1/split",
+        json!({"direction": "horizontal", "mode": "claude", "resumeSessionId": "legacy-split-id"}),
+        AUTH_HEADER,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "split legacy reject: {body}");
+    assert_eq!(
+        body["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.")
+    );
+}
+```
+
+Add to the respawn test section (opens at `:562`):
+
+```rust
+#[tokio::test]
+async fn respawn_pane_rejects_legacy_resume_session_id_with_400() {
+    let state = state_with_registry();
+    let app = crate::router(state);
+    let _ = post(app.clone(), "/api/tabs", json!({"mode": "shell"}), AUTH_HEADER).await;
+    let (status, body) = post(
+        app.clone(),
+        "/api/panes/pane_1/respawn",
+        json!({"mode": "claude", "resumeSessionId": "legacy-respawn-id"}),
+        AUTH_HEADER,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "respawn legacy reject: {body}");
+    assert_eq!(
+        body["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.")
+    );
+}
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `cargo test -p freshell-freshagent rest_create_rejects_legacy_resume_session_id_for_every_session_mode split_pane_rejects_legacy_resume_session_id_with_400 respawn_pane_rejects_legacy_resume_session_id_with_400`
+
+Expected: FAIL because the non-codex modes silently accept the legacy field today (`requested_resume_session_id_for_mode` at `:135` returns `Ok(legacy)` for non-codex) — the test gets a 200/500 instead of 400.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Widen `requested_resume_session_id_for_mode` at `crates/freshell-freshagent/src/terminal_tabs.rs:117-136`. Replace the codex-only throw with an any-mode throw:
+
+```rust
+fn requested_resume_session_id_for_mode(
+    session_ref: Option<&SessionLocator>,
+    mode: &str,
+    legacy_resume_session_id: Option<&str>,
+) -> Result<Option<String>, Response> {
+    let accepted = accepted_session_ref_for_mode(session_ref, mode);
+    if let Some(ref sref) = accepted {
+        return Ok(Some(sref.session_id.clone()));
+    }
+    // ejh6: reject the legacy resumeSessionId wire field on EVERY mode. The
+    // canonical carrier is sessionRef; resumeSessionId stays declared on the
+    // wire schema solely so this handler can detect-and-reject (see kata ejh6).
+    if legacy_resume_session_id.is_some_and(|s| !s.is_empty()) {
+        return Err(fail_json(
+            StatusCode::BAD_REQUEST,
+            LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
+        ));
+    }
+    Ok(None)
+}
+```
+
+Add section 3c doc comments to the Rust protocol structs in `crates/freshell-protocol/src/client_messages.rs`:
+
+At `:231-235` (`TerminalCreate.resume_session_id`), append to the existing doc comment:
+
+```rust
+    /// The spawn-time resume session id (`ws-handler.ts:656-658` — distinct from
+    /// `sessionRef`; spec `cli-argv-fidelity.md` section 3.3/U7: only the
+    /// spawn-time id is modeled here, the binding/repair pipeline stays with
+    /// coding-cli.md). Retained solely so the handler can detect-and-reject;
+    /// see kata ejh6.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resume_session_id: Option<String>,
+```
+
+At `:409-411` (`ReconcilePane.resume_session_id`), replace the doc comment with the PERMANENT compat-door wording:
+
+```rust
+    /// Optional legacy single-key claim. PERMANENT legacy-compat door: the
+    /// server-side `promoted_legacy_claim` (`reconcile.rs`) promotes this into
+    /// a sessionRef forever; old persisted pane content can carry a legacy-only
+    /// claim indefinitely. Do NOT plan a later removal (kata ejh6 section 2).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume_session_id: Option<String>,
+```
+
+At `:445` (`CodingCliCreate.resume_session_id`), `:511` (`FreshAgentCreate.resume_session_id`), `:527` (`FreshAgentAttach.resume_session_id`), add the same comment:
+
+```rust
+    /// Retained solely so the handler can detect-and-reject; see kata ejh6.
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `cargo test -p freshell-freshagent rest_create_rejects_legacy_resume_session_id_for_every_session_mode split_pane_rejects_legacy_resume_session_id_with_400 respawn_pane_rejects_legacy_resume_session_id_with_400`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+The codex-specific branch is gone — the any-mode throw subsumes it. The function name `requested_resume_session_id_for_mode` still accurately describes the function's role. No further refactor needed.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The REST reject affects every REST create test that sends `resumeSessionId`. The WIRE-SEND REST tests were converted in Task 3 (they now send sessionRef). The REJECTION-READY codex test at `:4415` still sends legacy and expects 400 — it stays green (now the any-mode throw covers codex too). The three `rest_create_legacy_resume_*409` tests were converted to sessionRef in Task 3 — they expect 409 (D7/LEASE) and stay green because they send sessionRef.
+
+Run: `cargo test -p freshell-freshagent`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add crates/freshell-freshagent/src/terminal_tabs.rs crates/freshell-freshagent/src/pane_ops_tests.rs crates/freshell-protocol/src/client_messages.rs
+git commit -m "feat(ejh6): Rust REST reject legacy resumeSessionId on all modes + section 3c doc comments"
+```
+
+---
+
+### Task 6: Rust WS `terminal.create` reject — hoist blanket gate to head of `handle_create` + reconcile permanent-compat doc
+
+**Files:**
+- Modify: `crates/freshell-ws/src/terminal.rs:2158` (insert blanket reject after `PreparedLaunch` destructure, before keyed-create adopt at `:2167`)
+- Modify: `crates/freshell-ws/src/terminal.rs:2441-2457` (remove the now-redundant scoped gate)
+- Modify: `crates/freshell-ws/src/terminal.rs:1543-1544` (`create_session_locator` — comment the legacy rung as dead-from-wire)
+- Modify: `crates/freshell-ws/src/terminal.rs:1883-1886` (`derive_launch_prep` — comment the legacy rung as dead-from-wire)
+- Modify: `crates/freshell-ws/src/reconcile.rs:162-177` (add permanent-compat doc to `promoted_legacy_claim`)
+- Test: `crates/freshell-ws/tests/live_session_ref_guard.rs:140` (re-target to INVALID_MESSAGE), add new any-mode blanket-reject test
+- Test: `crates/freshell-ws/tests/resume_validation_gate.rs:750,:823,:1015` (re-target codex-exemption cases to INVALID_MESSAGE)
+
+**Interfaces:**
+- Consumes: `LEGACY_RESUME_IDENTITY_REFUSAL` (from Task 1); `send_create_error(out, ErrorCode::InvalidMessage, msg, request_id)` at `terminal.rs:4404`; `TerminalCreate.resume_session_id` field.
+- Produces: any `terminal.create` carrying a non-empty `resume_session_id` is answered with `error{INVALID_MESSAGE}` + frozen text, before any side effect (no keyed-create adopt, no D8 claim, no spawn, no registry row).
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add to `crates/freshell-ws/tests/live_session_ref_guard.rs` (after `legacy_only_restore_is_refused_invalid_message` at `:210`):
+
+```rust
+/// ejh6: a `terminal.create` carrying `resumeSessionId` is rejected with
+/// `INVALID_MESSAGE` + frozen text on ANY mode, ANY restore state, and even
+/// when a companion `sessionRef` is present. No spawn, no registry row.
+#[tokio::test]
+async fn blanket_reject_legacy_resume_session_id_on_any_create() {
+    let (url, registry) = spawn_server().await;
+    let (mut ws, _inv) = connect_and_capture_inventory(&url).await;
+
+    let cases: Vec<(&str, &str, serde_json::Value)> = vec![
+        ("claude-restore-true", "req-blanket-1", json!({
+            "type": "terminal.create", "requestId": "req-blanket-1",
+            "mode": "claude", "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+            "restore": true, "resumeSessionId": "9d1f6f5a-2b6e-4d0f-8a3c-5e7b2c9d4f10",
+        })),
+        ("codex-no-restore", "req-blanket-2", json!({
+            "type": "terminal.create", "requestId": "req-blanket-2",
+            "mode": "codex", "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+            "resumeSessionId": "thread-raw-codex",
+        })),
+        ("claude-with-companion-sessionref", "req-blanket-3", json!({
+            "type": "terminal.create", "requestId": "req-blanket-3",
+            "mode": "claude", "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+            "resumeSessionId": "legacy-should-still-reject",
+            "sessionRef": {"provider": "claude", "sessionId": "canonical-session-id"},
+        })),
+    ];
+    for (label, req_id, body) in cases {
+        send_create(&mut ws, body).await;
+        let err = expect_refusal_for(&mut ws, req_id).await;
+        assert_eq!(err["code"], json!("INVALID_MESSAGE"), "{label}: {err}");
+        assert_eq!(
+            err["message"],
+            json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+            "{label}: frozen text must be byte-exact: {err}"
+        );
+    }
+
+    assert!(
+        registry.identity_probe_rows().is_empty(),
+        "no terminal may spawn for any legacy-carrying create"
+    );
+}
+```
+
+Re-target `legacy_resume_session_id_create_is_refused_loudly` at `:140` — change the assertion at `:175-185` from `RESTORE_UNAVAILABLE` to `INVALID_MESSAGE` + frozen text:
+
+```rust
+    let err = expect_refusal_for(&mut ws, "req-legacy-live-1").await;
+    assert_eq!(
+        err["code"], json!("INVALID_MESSAGE"),
+        "post-ejh6 the legacy carrier is rejected at the door, not via D7: {err}"
+    );
+    assert_eq!(
+        err["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+        "frozen text: {err}"
+    );
+```
+
+In `crates/freshell-ws/tests/resume_validation_gate.rs`, re-target cases 6/7/7b (the codex-exemption exploits at `:750,:823,:1015`) — these currently expect gate behavior under the codex exemption. Post-ejh6, codex is no longer exempt: each must expect `INVALID_MESSAGE` + frozen text at the door (no spawn). For each case, replace the existing expected-frame assertion with:
+
+```rust
+    let err = expect_refusal_for(&mut ws, &request_id).await;
+    assert_eq!(
+        err["code"], json!("INVALID_MESSAGE"),
+        "codex is no longer exempt from the legacy-field reject: {err}"
+    );
+    assert_eq!(
+        err["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+    );
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `cargo test -p freshell-ws --test live_session_ref_guard blanket_reject_legacy_resume_session_id_on_any_create legacy_resume_session_id_create_is_refused_loudly`
+
+Expected: FAIL because the current scoped gate at `:2441` only rejects restore+non-codex+legacy-only — the codex-no-restore case and the companion-sessionref case are silently accepted (spawn happens).
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Hoist a blanket reject to the head of `handle_create` at `crates/freshell-ws/src/terminal.rs`. Insert immediately after the `PreparedLaunch` destructure at `:2158` (before the keyed-create adopt loop at `:2167`):
+
+```rust
+    // ejh6: reject the legacy `resume_session_id` wire field on ANY create
+    // (any mode, any restore state, any companion sessionRef). The canonical
+    // carrier is sessionRef; resume_session_id stays declared on the struct
+    // solely so this handler can detect-and-reject (see kata ejh6). Placed
+    // BEFORE keyed-create adopt / D8 lease / rate-limit / spawn so no side
+    // effect fires and the registry row count is unchanged. The
+    // `create_dedupe` sentinel is cleared by the existing `clear_if_in_flight`
+    // on this function's non-complete exits (`:761`).
+    if create.resume_session_id.as_deref().is_some_and(|s| !s.is_empty()) {
+        return send_create_error(
+            out,
+            ErrorCode::InvalidMessage,
+            LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
+            &create.request_id,
+        )
+        .await;
+    }
+```
+
+Remove the now-redundant scoped gate at `:2441-2457` (the `if create.restore == Some(true) && mode != "codex" && ...` block). The frozen text is now emitted by the head-of-`handle_create` check for all shapes.
+
+Comment the legacy rungs as dead-from-wire (do NOT delete — they are still reachable from internal/test paths per binding correction C):
+
+At `create_session_locator` (`:1543-1544`):
+```rust
+        // ejh6: the legacy rung below is dead for wire input (the blanket
+        // reject at the head of handle_create fires first). Retained for
+        // internal/test constructions that set resume_session_id directly.
+        .or_else(|| create.resume_session_id.clone())
+```
+
+At `derive_launch_prep` (`:1883-1886`):
+```rust
+            // ejh6: the legacy fallback below is dead for wire input (the
+            // blanket reject at the head of handle_create fires first).
+            // Retained for internal/test constructions.
+            resume_session_id = requested_ref
+                .map(|r| r.session_id.clone())
+                .or_else(|| create.resume_session_id.clone())
+                .filter(|s| !s.is_empty());
+```
+
+Add the permanent-compat doc to `crates/freshell-ws/src/reconcile.rs:162-177` — prepend to the `promoted_legacy_claim` doc comment:
+
+```rust
+/// PERMANENT legacy-compat door (kata ejh6 section 2): the ONE uniform
+/// promotion rule. Old persisted pane content (stale clients, restored
+/// snapshots) can carry a legacy-only claim indefinitely; no point-in-time
+/// suite run can prove otherwise, so this door stays forever with NO
+/// later-removal plan. The blanket wire reject on `terminal.create` does NOT
+/// reach here — `pane.reconcile` is the sole permanent exception.
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `cargo test -p freshell-ws --test live_session_ref_guard && cargo test -p freshell-ws --test resume_validation_gate`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+The scoped gate removal is the refactor. Confirm `mode_supports_resume` at `:1526` is still used by the D7 guard — leave it. The private const is already removed (Task 1); the head-of-`handle_create` check uses `LEGACY_RESUME_IDENTITY_REFUSAL` from the shared const.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Every Rust WS `terminal.create` test is impacted. The WIRE-SEND tests were converted in Task 3 (they send sessionRef). The REJECTION-READY tests are re-targeted in this task.
+
+Run: `cargo test -p freshell-ws`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add crates/freshell-ws/src/terminal.rs crates/freshell-ws/src/reconcile.rs crates/freshell-ws/tests/live_session_ref_guard.rs crates/freshell-ws/tests/resume_validation_gate.rs
+git commit -m "feat(ejh6): Rust WS terminal.create blanket reject + reconcile permanent-compat doc"
+```
+
+---
+
+### Task 7: Rust WS freshAgent.create/attach reject + `attach_durable_id` hygiene
+
+**Files:**
+- Modify: `crates/freshell-ws/src/terminal.rs:62-67` (import `FreshAgentCreateFailed`), `:4768` (`fresh_agent_control_refusal` — add create/attach legacy-field arms)
+- Modify: `crates/freshell-freshagent/src/claude.rs:1809-1819` (`attach_durable_id` — flip to sessionRef-first with comment)
+- Test: `crates/freshell-ws/tests/freshagent_claude_attach.rs` (add legacy-carrying attach rejection test)
+- Test: `crates/freshell-ws/tests/freshagent_session_lease.rs` (add legacy-carrying create rejection test)
+
+**Interfaces:**
+- Consumes: `LEGACY_RESUME_IDENTITY_REFUSAL` (from Task 1); `ServerMessage::FreshAgentCreateFailed(FreshAgentCreateFailed{code,message,request_id,retryable})` (`server_messages.rs:618-627`); `ServerMessage::FreshAgentEvent(FreshAgentEvent{event,provider,session_id,session_type})`; `agent_provider_wire`/`session_type_wire` helpers (`terminal.rs:4731,:4741`); `fresh_agent_control_refusal` runs before the dispatch match at `:661`.
+- Produces: `freshAgent.create` carrying `resume_session_id` then `freshAgent.create.failed{code:"FRESH_AGENT_CREATE_FAILED", message:<frozen>, retryable:false}`; `freshAgent.attach` carrying `resume_session_id` then `freshAgent.event{freshAgent.error{code:"FRESH_AGENT_CREATE_FAILED", message:<frozen>}}` keyed by session id; no sidecar spawn.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add to `crates/freshell-ws/tests/freshagent_claude_attach.rs` (model on the `freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session` pattern at `cross_kind_liveness.rs:373-437`):
+
+```rust
+/// ejh6: a `freshAgent.attach` carrying `resumeSessionId` is rejected with
+/// `freshAgent.error{code:"FRESH_AGENT_CREATE_FAILED"}` + frozen text. No
+/// sidecar spawn, no manager.attach call. Attach has no requestId, so the
+/// rejection rides the freshAgent.error event channel keyed by sessionId.
+#[tokio::test]
+async fn freshagent_attach_with_legacy_resume_session_id_is_rejected() {
+    let _guard = ENV_LOCK.lock().await;
+    let env = FakeSidecarEnv::install();
+    let (url, _registry) = spawn_server().await;
+    let mut ws = connect(&url).await;
+
+    send_json(
+        &mut ws,
+        &json!({
+            "type": "freshAgent.attach",
+            "sessionId": "cli-session-legacy-attach",
+            "sessionType": "freshclaude",
+            "provider": "claude",
+            "resumeSessionId": "legacy-durable-id",
+        }),
+    )
+    .await;
+
+    let err = await_frame(&mut ws, Duration::from_secs(10), |v| {
+        v["type"] == "freshAgent.event"
+            && v["event"]["type"] == "freshAgent.error"
+            && v["sessionId"] == "cli-session-legacy-attach"
+    })
+    .await;
+    assert_eq!(
+        err["event"]["code"], json!("FRESH_AGENT_CREATE_FAILED"),
+        "attach legacy reject must use the create-failed family code: {err}"
+    );
+    assert_eq!(
+        err["event"]["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+        "frozen text: {err}"
+    );
+    assert!(
+        env.create_rows().is_empty(),
+        "no sidecar may spawn for a rejected legacy attach: {:?}", env.create_rows()
+    );
+}
+```
+
+Add to `crates/freshell-ws/tests/freshagent_session_lease.rs`:
+
+```rust
+/// ejh6: a `freshAgent.create` carrying `resumeSessionId` is rejected with
+/// `freshAgent.create.failed{code:"FRESH_AGENT_CREATE_FAILED"}` + frozen text.
+/// No sidecar spawn. Create has a requestId, so the rejection uses the
+/// create-failed envelope.
+#[tokio::test]
+async fn freshagent_create_with_legacy_resume_session_id_is_rejected() {
+    let _guard = ENV_LOCK.lock().await;
+    let env = FakeSidecarEnv::install();
+    let (url, _registry) = spawn_server().await;
+    let mut ws = connect(&url).await;
+
+    send_json(
+        &mut ws,
+        &json!({
+            "type": "freshAgent.create",
+            "requestId": "req-fa-legacy-create",
+            "sessionType": "freshclaude",
+            "provider": "claude",
+            "cwd": "/tmp",
+            "resumeSessionId": "legacy-durable-id",
+        }),
+    )
+    .await;
+
+    let failed = await_frame(&mut ws, Duration::from_secs(10), |v| {
+        v["type"] == "freshAgent.create.failed" && v["requestId"] == "req-fa-legacy-create"
+    })
+    .await;
+    assert_eq!(failed["code"], json!("FRESH_AGENT_CREATE_FAILED"), "create-failed family code: {failed}");
+    assert_eq!(
+        failed["message"],
+        json!("Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."),
+        "frozen text: {failed}"
+    );
+    assert_eq!(failed["retryable"], json!(false));
+    assert!(
+        env.create_rows().is_empty(),
+        "no sidecar may spawn for a rejected legacy create: {:?}", env.create_rows()
+    );
+}
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `cargo test -p freshell-ws --test freshagent_claude_attach freshagent_attach_with_legacy_resume_session_id_is_rejected && cargo test -p freshell-ws --test freshagent_session_lease freshagent_create_with_legacy_resume_session_id_is_rejected`
+
+Expected: FAIL because the current dispatch arms at `terminal.rs:861-926` spawn the provider handler without checking `resume_session_id` — the create/attach proceeds instead of returning a rejection frame.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Add `FreshAgentCreateFailed` to the import at `crates/freshell-ws/src/terminal.rs:62-67`:
+
+```rust
+use freshell_protocol::{
+    AgentProvider, ClientMessage, ErrorCode, ErrorMsg, FreshAgentCreateFailed, FreshAgentEvent,
+    LEGACY_RESUME_IDENTITY_REFUSAL, Pong, ServerMessage,
+    SessionLocator, SessionType, Shell, TerminalAttach, TerminalAutoResumeCancel, TerminalCreate,
+    TerminalCreated, TerminalIdOnly, TerminalInputBlocked, TerminalInputBlockedReason,
+    TerminalKill, TerminalResize,
+};
+```
+
+Add create/attach legacy-field arms at the TOP of `fresh_agent_control_refusal` at `:4768`, before the existing tuple match:
+
+```rust
+pub(crate) fn fresh_agent_control_refusal(message: &ClientMessage) -> Option<ServerMessage> {
+    // ejh6: reject the legacy `resume_session_id` wire field on every
+    // fresh-agent create-class door BEFORE dispatch. Create returns the
+    // `freshAgent.create.failed` envelope (it carries requestId); attach has
+    // NO requestId, so its rejection rides the `freshAgent.error` event
+    // channel keyed by sessionId. Both use the `FRESH_AGENT_CREATE_FAILED`
+    // family code + the frozen sessionRef-naming text.
+    if let ClientMessage::FreshAgentCreate(m) = message {
+        if m.resume_session_id.as_deref().is_some_and(|s| !s.is_empty()) {
+            return Some(ServerMessage::FreshAgentCreateFailed(FreshAgentCreateFailed {
+                code: "FRESH_AGENT_CREATE_FAILED".to_string(),
+                message: LEGACY_RESUME_IDENTITY_REFUSAL.to_string(),
+                request_id: m.request_id.clone(),
+                retryable: Some(false),
+            }));
+        }
+    }
+    if let ClientMessage::FreshAgentAttach(m) = message {
+        if m.resume_session_id.as_deref().is_some_and(|s| !s.is_empty()) {
+            return Some(ServerMessage::FreshAgentEvent(FreshAgentEvent {
+                event: serde_json::json!({
+                    "type": "freshAgent.error",
+                    "sessionId": m.session_id,
+                    "code": "FRESH_AGENT_CREATE_FAILED",
+                    "message": LEGACY_RESUME_IDENTITY_REFUSAL,
+                }),
+                provider: agent_provider_wire(m.provider).to_string(),
+                session_id: m.session_id.clone(),
+                session_type: session_type_wire(m.session_type).to_string(),
+            }));
+        }
+    }
+    let (refused, wording, provider, session_id, session_type) = match message {
+        // ... existing arms unchanged ...
+```
+
+Flip `attach_durable_id` in `crates/freshell-freshagent/src/claude.rs:1809-1819` to sessionRef-first (the legacy-first read is dead for external input after the wire reject; the test helper `attach_msg_with_resume` at `:2228` was converted to sessionRef in Task 3):
+
+```rust
+/// The durable claude id an attach carries: `sessionRef.sessionId` first,
+/// then the legacy `resumeSessionId` fallback — flipped from legacy-first
+/// (kata ejh6 section 4b hygiene). After the wire-level reject on
+/// `freshAgent.attach`, the legacy field is dead for external input; the
+/// fallback remains only for internal/test constructions. Only canonical
+/// UUIDs qualify (`shared/session-contract.ts:34`) — a nanoid here would
+/// just miss the store.
+fn attach_durable_id(msg: &FreshAgentAttach) -> Option<String> {
+    let candidate = msg
+        .session_ref
+        .as_ref()
+        .map(|r| r.session_id.clone())
+        .or_else(|| msg.resume_session_id.clone())?;
+    is_canonical_claude_uuid(&candidate).then_some(candidate)
+}
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `cargo test -p freshell-ws --test freshagent_claude_attach freshagent_attach_with_legacy_resume_session_id_is_rejected && cargo test -p freshell-ws --test freshagent_session_lease freshagent_create_with_legacy_resume_session_id_is_rejected && cargo test -p freshell-freshagent attach_durable_id`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+The `fresh_agent_control_refusal` function now handles both control-frame capability refusals AND legacy-field rejections. The function name still accurately describes its role (a pre-dispatch refusal for fresh-agent control/create/attach frames). No further refactor needed.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Every Rust WS freshAgent test is impacted. The WIRE-SEND freshAgent tests were converted in Task 3 (they send sessionRef). Run the full `freshell-ws` suite plus the `freshell-freshagent` suite (for `attach_durable_id` + claude handlers).
+
+Run: `cargo test -p freshell-ws && cargo test -p freshell-freshagent`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add crates/freshell-ws/src/terminal.rs crates/freshell-freshagent/src/claude.rs crates/freshell-ws/tests/freshagent_claude_attach.rs crates/freshell-ws/tests/freshagent_session_lease.rs
+git commit -m "feat(ejh6): Rust WS freshAgent create/attach reject legacy field + attach_durable_id hygiene"
+```
+
+---
+
+### Task 8: Node REST reject — widen `requestedResumeSessionIdForMode` to all modes + repurpose remote-tab-linkage
+
+**Files:**
+- Modify: `server/agent-api/router.ts:214-228` (`requestedResumeSessionIdForMode` — widen codex-only throw to all modes)
+- Modify: `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` (repurpose acceptance-assert sites as REST 400 rejection e2e)
+- Test: `test/server/agent-tabs-write.test.ts:413` (add `it.each` for all modes)
+- Test: `test/server/agent-panes-write.test.ts:132,:327` (widen to all modes)
+
+**Interfaces:**
+- Consumes: `INVALID_RAW_CODEX_RESUME_MESSAGE` (`restore-decision.ts:27-28`); `AgentRouteInputError` (`router.ts:47-52`); `agentRouteErrorStatus` returns 400 (`router.ts:54-58`); `fail(message)` returns `{status:'error',message}` (`response.ts:6`).
+- Produces: all three Node REST doors return HTTP 400 `{status:'error',message:<frozen>}` when the body carries a non-empty `resumeSessionId` on any mode.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add to `test/server/agent-tabs-write.test.ts` (after the existing codex-reject test at `:413`):
+
+```ts
+  it.each(['claude', 'opencode', 'amplifier'])('rejects legacy resumeSessionId on mode %s with 400', async (mode) => {
+    const app = express()
+    app.use(express.json())
+    const registry = { create: vi.fn(), killAndWait: vi.fn(async () => true) }
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    const layoutStore = {
+      createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })),
+      attachPaneContent: vi.fn(),
+      selectTab: () => ({}), renameTab: () => ({}), closeTab: () => ({}), hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }), selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry, codexLaunchPlanner }))
+
+    const res = await request(app).post('/api/tabs').send({
+      mode, name: `legacy ${mode}`, resumeSessionId: `legacy-${mode}-id`,
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({ status: 'error', message: INVALID_RAW_CODEX_RESUME_MESSAGE })
+    expect(codexLaunchPlanner.planCreateCalls).toEqual([])
+    expect(registry.create).not.toHaveBeenCalled()
+    expect(layoutStore.createTab).not.toHaveBeenCalled()
+    expect(layoutStore.attachPaneContent).not.toHaveBeenCalled()
+  })
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/server/agent-tabs-write.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: FAIL because the non-codex modes silently accept the legacy field (`requestedResumeSessionIdForMode` at `:227` returns `legacyResumeSessionId` for non-codex) — the test gets a 200 instead of 400.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Widen `requestedResumeSessionIdForMode` at `server/agent-api/router.ts:214-228`:
+
+```ts
+function requestedResumeSessionIdForMode(
+  sessionRef: ReturnType<typeof sanitizeSessionRef>,
+  mode: string,
+  legacyResumeSessionId: unknown,
+): string | undefined {
+  const acceptedSessionRef = acceptedSessionRefForMode(sessionRef, mode)
+  if (acceptedSessionRef) return acceptedSessionRef.sessionId
+  // ejh6: reject the legacy resumeSessionId wire field on EVERY mode. The
+  // canonical carrier is sessionRef; resumeSessionId stays declared on the
+  // shared schemas solely so the handler can detect-and-reject (see kata ejh6).
+  if (isNonEmptyString(legacyResumeSessionId)) {
+    throw new AgentRouteInputError(INVALID_RAW_CODEX_RESUME_MESSAGE)
+  }
+  return undefined
+}
+```
+
+The existing 400 machinery (`AgentRouteInputError` then `agentRouteErrorStatus` then 400 then `res.status(400).json(fail(message))`) already produces `{status:'error',message:<frozen>}` for all three routes (they all call `requestedResumeSessionIdForMode` and wrap creation in the catch).
+
+Repurpose `test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts` acceptance-assert sites (the ones left in Task 4 that still send legacy `resumeSessionId` and expect acceptance) — change the expected response from success (200 with synthesized sessionRef) to 400 with the frozen message. The test's new premise: a bare legacy `resumeSessionId` on `POST /api/tabs {mode:'amplifier'}` then 400 naming sessionRef.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/server/agent-tabs-write.test.ts test/server/agent-panes-write.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: PASS — the existing codex-reject tests at `:413`/`:132`/`:327` stay green; the new `it.each` covers claude/opencode/amplifier.
+
+- [ ] **Step 5: Refactor while green**
+
+The codex-specific branch in `requestedResumeSessionIdForMode` is gone — the any-mode throw subsumes it. The `isNonEmptyString` helper is already imported. No further refactor needed.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Every Node REST create test is impacted. The WIRE-SEND REST tests (sidebar-registry-sync-rust.spec.ts) were converted in Task 4. The REJECTION-READY tests (agent-tabs-write, agent-panes-write) are widened in this task. The remote-tab-linkage-rust.spec.ts acceptance sites are repurposed in this task.
+
+Run: `npm run test:vitest -- run test/server/agent-tabs-write.test.ts test/server/agent-panes-write.test.ts test/unit/server/mcp/freshell-tool.test.ts test/e2e/agent-cli-flow.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add server/agent-api/router.ts test/server/agent-tabs-write.test.ts test/server/agent-panes-write.test.ts test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts
+git commit -m "feat(ejh6): Node REST reject legacy resumeSessionId on all modes + repurpose remote-tab-linkage"
+```
+
+---
+
+### Task 9: Node WS `terminal.create` reject + repurpose existing tests + e2e WS assertion
+
+**Files:**
+- Modify: `server/ws-handler.ts:2107` (insert blanket reject after `fresh_after_restore_unavailable` guard), `:2160-2168` and `:2170-2186` (remove scoped gates), `:784` (section 3c doc comment)
+- Modify: `test/e2e/agent-cli-flow.test.ts` (add the e2e WS assertion — wires a `WsHandler` onto the test server)
+- Test: `test/server/ws-terminal-create-reuse-running-codex.test.ts` (add `it.each` for all modes)
+- Test: `test/server/ws-terminal-create-session-repair.test.ts:1048` (repurpose as rejection test)
+- Test: `test/integration/server/opencode-session-flow.test.ts:352` (widen to restore-less creates)
+
+**Interfaces:**
+- Consumes: `INVALID_RAW_CODEX_RESUME_MESSAGE` (imported in Task 1); `this.sendError(ws, {code,message,requestId})`; `endCreateTimer({error,rateLimited})`.
+- Produces: any `terminal.create` carrying `resumeSessionId` then `error{INVALID_MESSAGE}` + frozen text + no spawn + no registry row, on any mode/restore/companion-sessionRef.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add to `test/server/ws-terminal-create-reuse-running-codex.test.ts` (after the existing codex rejection tests at `:612,:645`), an `it.each` covering claude/opencode/amplifier times restore in {true, false, omitted}:
+
+```ts
+  it.each([
+    ['claude', true], ['claude', false], ['claude', undefined],
+    ['opencode', true], ['opencode', false], ['amplifier', true],
+  ] as const)('rejects legacy resumeSessionId on mode %s restore=%s', async (mode, restore) => {
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
+    try {
+      await waitForOpen(ws)
+      await waitForReady(ws)
+      const requestId = `legacy-reject-${mode}-${restore}`
+      const errorPromise = waitForMessage(ws, (m) => m.type === 'error' && m.requestId === requestId)
+      ws.send(JSON.stringify({
+        type: 'terminal.create', requestId, mode,
+        ...(restore === undefined ? {} : { restore }),
+        resumeSessionId: `legacy-${mode}-id`,
+      }))
+      const error = await errorPromise
+      expect(error).toMatchObject({
+        type: 'error', code: 'INVALID_MESSAGE',
+        message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+        requestId,
+      })
+      expect(codexLaunchPlanner.planCreateCalls).toHaveLength(0)
+      expect(registry.createCalls).toHaveLength(0)
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+```
+
+Repurpose `test/server/ws-terminal-create-session-repair.test.ts:1048` (the "sessionRef wins over legacy" precedence test) — after the blanket reject, sending BOTH `resumeSessionId` and `sessionRef` gets INVALID_MESSAGE. Replace the precedence assertion with:
+
+```ts
+      const response = await waitForMessage(ws, (m) => m.type === 'error' && m.requestId === requestId)
+      expect(response).toMatchObject({
+        type: 'error', code: 'INVALID_MESSAGE',
+        message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+      })
+```
+
+Repurpose `test/integration/server/opencode-session-flow.test.ts:352` — widen the existing restore-only rejection to a restore-less create carrying `resumeSessionId`:
+
+```ts
+  it('rejects the legacy raw resumeSessionId field for opencode non-restore creates', async () => {
+    const ws = await createAuthenticatedWs(port)
+    try {
+      const requestId = 'opencode-non-restore-legacy'
+      ws.send(JSON.stringify({
+        type: 'terminal.create', requestId, mode: 'opencode',
+        resumeSessionId: 'probe-non-restore',
+      }))
+      const response = await waitForMessage(ws, (msg) => msg.requestId === requestId && (msg.type === 'terminal.created' || msg.type === 'error'))
+      expect(response).toMatchObject({ type: 'error', code: 'INVALID_MESSAGE' })
+      expect(response.message).toContain('sessionRef')
+      expect(registry.createCallCount).toBe(0)
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+```
+
+Add the e2e WS assertion to `test/e2e/agent-cli-flow.test.ts` (add `WebSocket`, `WsHandler`, `TerminalRegistry`, `WS_PROTOCOL_VERSION` imports at the top, then a new test case inside the top-level describe). This reuses `WsHandler` + `http.createServer` (existing infrastructure — not a new harness):
+
+```ts
+import WebSocket from 'ws'
+import { WsHandler } from '../../server/ws-handler.js'
+import { TerminalRegistry } from '../../server/terminal-registry.js'
+import { WS_PROTOCOL_VERSION } from '../../shared/ws-protocol.js'
+
+// inside the top-level describe(...) block:
+
+  it('rejects a raw legacy WS terminal.create with INVALID_MESSAGE + frozen text', async () => {
+    const previousAuthToken = process.env.AUTH_TOKEN
+    process.env.AUTH_TOKEN = 'test-token'
+    const layoutStore = new LayoutStore()
+    const app = express()
+    app.use(express.json())
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    let terminalCount = 0
+    app.use('/api', createAgentApiRouter({
+      layoutStore,
+      registry: { create: () => ({ terminalId: `term_${++terminalCount}` }), get: () => undefined, input: () => {} },
+      codexLaunchPlanner,
+    }))
+    const server = http.createServer(app)
+    const registry = new TerminalRegistry()
+    const handler = new WsHandler(server, registry, { codexLaunchPlanner } as never)
+    await new Promise<void>((resolve) => server.listen(0, () => resolve()))
+    const { port } = server.address() as { port: number }
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+      await new Promise<void>((resolve, reject) => {
+        ws.on('open', () => {
+          ws.send(JSON.stringify({ type: 'hello', token: 'test-token', protocolVersion: WS_PROTOCOL_VERSION }))
+        })
+        ws.on('message', (data) => {
+          const msg = JSON.parse(data.toString())
+          if (msg.type === 'ready') resolve()
+        })
+        ws.on('error', reject)
+      })
+      const requestId = 'raw-legacy-ws-1'
+      const errorPromise = new Promise<any>((resolve) => {
+        ws.on('message', (data) => {
+          const msg = JSON.parse(data.toString())
+          if (msg.type === 'error' && msg.requestId === requestId) resolve(msg)
+        })
+      })
+      ws.send(JSON.stringify({
+        type: 'terminal.create', requestId, mode: 'claude', shell: 'system',
+        resumeSessionId: 'legacy-ws-id',
+      }))
+      const error = await errorPromise
+      expect(error).toMatchObject({
+        type: 'error', code: 'INVALID_MESSAGE',
+        message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+        requestId,
+      })
+    } finally {
+      ws.close()
+      handler.close?.()
+      process.env.AUTH_TOKEN = previousAuthToken
+      await new Promise<void>((done) => server.close(() => done()))
+    }
+  })
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/ws-terminal-create-session-repair.test.ts test/integration/server/opencode-session-flow.test.ts test/e2e/agent-cli-flow.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: FAIL because the current scoped gate only rejects restore+non-codex+legacy-only — the non-restore and companion-sessionRef cases are silently accepted.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Insert the blanket reject at `server/ws-handler.ts:2107` (immediately after the `fresh_after_restore_unavailable` guard returns, before `hasReusableRequestedLiveTerminal` at `:2108`):
+
+```ts
+        // ejh6: reject the legacy resumeSessionId field on ANY create (any
+        // mode, any restore state, any companion sessionRef) — the canonical
+        // carrier is sessionRef. The field stays declared on the dynamic
+        // .strict() schema solely so this handler can detect-and-reject; see
+        // kata ejh6.
+        if (m.resumeSessionId) {
+          error = true
+          this.sendError(ws, {
+            code: 'INVALID_MESSAGE',
+            message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+            requestId: m.requestId,
+          })
+          endCreateTimer({ error, rateLimited })
+          return
+        }
+```
+
+Remove the now-redundant scoped gates at `:2160-2168` (the `codexRestorePlan?.kind === 'reject_invalid_raw_codex_resume_request'` block) and `:2170-2186` (the `m.restore === true && modeSupportsResume && ...` block). The blanket reject at `:2107` fires first for any legacy-carrying create, so these scoped gates are unreachable for legacy carriers.
+
+Add the section 3c doc comment at `server/ws-handler.ts:784`:
+
+```ts
+      /** Retained solely so the handler can detect-and-reject; see kata ejh6. */
+      resumeSessionId: z.string().optional(),
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/ws-terminal-create-session-repair.test.ts test/integration/server/opencode-session-flow.test.ts test/e2e/agent-cli-flow.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+The `legacyResumeSessionId: m.resumeSessionId` arg at `:2123` is now dead for wire input (the blanket reject fires before `codexRestorePlan` is built) — leave it (harmless; `planCodexCreateRestoreDecision` still handles the no-legacy sessionRef-resume path). The `effectiveResumeSessionId = m.resumeSessionId` lane at `:2132-2136` is dead for wire input — leave it with a comment noting it is dead-from-wire, or remove it if no internal path reaches it.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Every Node WS `terminal.create` test is impacted. The WIRE-SEND tests were converted in Tasks 2-4. The REJECTION-READY tests are widened in this task.
+
+Run: `npm run test:vitest -- run test/server/ test/integration/server/ --config config/vitest/vitest.server.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add server/ws-handler.ts test/server/ws-terminal-create-reuse-running-codex.test.ts test/server/ws-terminal-create-session-repair.test.ts test/integration/server/opencode-session-flow.test.ts test/e2e/agent-cli-flow.test.ts
+git commit -m "feat(ejh6): Node WS terminal.create blanket reject + repurpose tests + e2e WS assertion"
+```
+
+---
+
+### Task 10: Node WS `freshAgent.create`/`freshAgent.attach` reject
+
+**Files:**
+- Modify: `server/ws-handler.ts:3424` (head of `freshAgent.create` case — insert reject), `:3543` (head of `freshAgent.attach` case — insert reject)
+- Modify: `shared/ws-protocol.ts:482,:497` (section 3c doc comments)
+- Test: `test/unit/server/ws-handler-fresh-agent.test.ts` (add legacy-carrying create/attach rejection tests)
+
+**Interfaces:**
+- Consumes: `INVALID_RAW_CODEX_RESUME_MESSAGE` (imported in Task 1); `this.send(ws, {type:'freshAgent.create.failed',requestId,code,message,retryable})` (envelope at `ws-handler.ts:3428`); `this.sendError(ws, {code,message})` (attach error shape at `:3589`).
+- Produces: `freshAgent.create` carrying `resumeSessionId` then `freshAgent.create.failed{code:'FRESH_AGENT_CREATE_FAILED', message:<frozen>, retryable:false}`; `freshAgent.attach` carrying `resumeSessionId` then `error{code:'FRESH_AGENT_CREATE_FAILED', message:<frozen>}` (matching the existing attach error shape, per binding correction D); no `manager.create`/`manager.attach` call.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add to `test/unit/server/ws-handler-fresh-agent.test.ts` (model on the existing `connectAndAuth` + `seenMessages` + `vi.waitFor` pattern at `:87+` — that file has NO `waitForMessage` helper; use the file's own `seenMessages` array + `vi.waitFor` pattern):
+
+```ts
+  it('rejects freshAgent.create carrying resumeSessionId with freshAgent.create.failed', async () => {
+    const runtimeManager = {
+      create: vi.fn(),
+      subscribe: vi.fn().mockResolvedValue(() => undefined),
+    }
+    const { server } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+    try {
+      const ws = await connectAndAuth(server)
+      const seenMessages: any[] = []
+      ws.on('message', (data) => seenMessages.push(JSON.parse(data.toString())))
+      ws.send(JSON.stringify({
+        type: 'freshAgent.create', requestId: 'req-fa-legacy-create',
+        sessionType: 'freshclaude', provider: 'claude', cwd: '/tmp',
+        resumeSessionId: 'legacy-durable-id',
+      }))
+      await vi.waitFor(() => {
+        expect(seenMessages.some((m) => m.type === 'freshAgent.create.failed' && m.requestId === 'req-fa-legacy-create')).toBe(true)
+      }, { timeout: 5000 })
+      const failed = seenMessages.find((m) => m.type === 'freshAgent.create.failed' && m.requestId === 'req-fa-legacy-create')
+      expect(failed).toMatchObject({
+        type: 'freshAgent.create.failed', requestId: 'req-fa-legacy-create',
+        code: 'FRESH_AGENT_CREATE_FAILED',
+        message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+        retryable: false,
+      })
+      expect(runtimeManager.create).not.toHaveBeenCalled()
+    } finally {
+      ws.close()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('rejects freshAgent.attach carrying resumeSessionId with error{FRESH_AGENT_CREATE_FAILED}', async () => {
+    const runtimeManager = {
+      attach: vi.fn(),
+      subscribe: vi.fn().mockResolvedValue(() => undefined),
+    }
+    const { server } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+    try {
+      const ws = await connectAndAuth(server)
+      const seenMessages: any[] = []
+      ws.on('message', (data) => seenMessages.push(JSON.parse(data.toString())))
+      ws.send(JSON.stringify({
+        type: 'freshAgent.attach', sessionId: 'cli-session-legacy-attach',
+        sessionType: 'freshclaude', provider: 'claude',
+        resumeSessionId: 'legacy-durable-id',
+      }))
+      await vi.waitFor(() => {
+        expect(seenMessages.some((m) => m.type === 'error' && m.code === 'FRESH_AGENT_CREATE_FAILED')).toBe(true)
+      }, { timeout: 5000 })
+      const error = seenMessages.find((m) => m.type === 'error' && m.code === 'FRESH_AGENT_CREATE_FAILED')
+      expect(error).toMatchObject({
+        type: 'error', code: 'FRESH_AGENT_CREATE_FAILED',
+        message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+      })
+      expect(runtimeManager.attach).not.toHaveBeenCalled()
+    } finally {
+      ws.close()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/server/ws-handler-fresh-agent.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: FAIL because the current `freshAgent.create`/`freshAgent.attach` handlers forward the legacy field to the runtime manager without rejecting — `manager.create`/`manager.attach` IS called (or the test times out waiting for the create-failed frame).
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Insert at the head of the `freshAgent.create` case at `server/ws-handler.ts:3424` (before the manager-missing check at `:3425`):
+
+```ts
+      case 'freshAgent.create': {
+        // ejh6: reject the legacy resumeSessionId wire field. The canonical
+        // carrier is sessionRef; resumeSessionId stays declared on the shared
+        // schema solely so the handler can detect-and-reject (see kata ejh6).
+        if (m.resumeSessionId) {
+          this.send(ws, {
+            type: 'freshAgent.create.failed',
+            requestId: m.requestId,
+            code: 'FRESH_AGENT_CREATE_FAILED',
+            message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+            retryable: false,
+          })
+          return
+        }
+        const manager = this.freshAgentRuntimeManager
+        // ... rest unchanged ...
+```
+
+Insert at the head of the `freshAgent.attach` case at `server/ws-handler.ts:3543` (before the manager-missing check at `:3544`):
+
+```ts
+      case 'freshAgent.attach': {
+        // ejh6: reject the legacy resumeSessionId wire field. Attach has no
+        // requestId, so the create-failed family rejection rides the existing
+        // attach error frame shape (sendError) with the FRESH_AGENT_CREATE_
+        // FAILED code — the create-failed family code on the attach error
+        // channel (see kata ejh6, binding correction D).
+        if (m.resumeSessionId) {
+          this.sendError(ws, {
+            code: 'FRESH_AGENT_CREATE_FAILED',
+            message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+          })
+          return
+        }
+        const manager = this.freshAgentRuntimeManager
+        // ... rest unchanged ...
+```
+
+Add section 3c doc comments at `shared/ws-protocol.ts:482` (`FreshAgentCreateSchema.resumeSessionId`) and `:497` (`FreshAgentAttachSchema.resumeSessionId`):
+
+```ts
+  /** Retained solely so the handler can detect-and-reject; see kata ejh6. */
+  resumeSessionId: z.string().optional(),
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/server/ws-handler-fresh-agent.test.ts test/unit/server/ws-handler-fresh-agent-lifecycle-parity.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+No refactor needed — the reject is a head-of-case guard, the rest of the handler is unchanged.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Every Node WS freshAgent test is impacted. The WIRE-SEND tests were converted in Task 2.
+
+Run: `npm run test:vitest -- run test/unit/server/ws-handler-fresh-agent.test.ts test/unit/server/ws-handler-fresh-agent-lifecycle-parity.test.ts test/unit/server/fresh-agent/ --config config/vitest/vitest.server.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add server/ws-handler.ts shared/ws-protocol.ts test/unit/server/ws-handler-fresh-agent.test.ts
+git commit -m "feat(ejh6): Node WS freshAgent create/attach reject legacy field"
+```
+
+---
+
+### Task 11: Node WS `codingcli.create` reject + sessionRef promotion (TS schema + Rust struct decision)
+
+**Files:**
+- Modify: `shared/ws-protocol.ts:447-458` (`CodingCliCreateSchema` — add `sessionRef`)
+- Modify: `server/ws-handler.ts:802-813` (dynamic codingcli schema — add `sessionRef`), `:808` (section 3c doc comment), `:3290+` (head of `codingcli.create` case — insert reject), `:3318-3326` (promote sessionRef into spawn-time resume id)
+- Modify: `crates/freshell-protocol/src/client_messages.rs:429-448` (`CodingCliCreate` — add `session_ref` field; section 3c doc on `resume_session_id`)
+- Modify: `crates/freshell-protocol/tests/roundtrip.rs:309` (extend codingcli roundtrip to include `sessionRef`)
+- Test: `test/server/ws-coding-cli-events.test.ts` (new legacy-reject + sessionRef-promote tests)
+
+**Interfaces:**
+- Consumes: `INVALID_RAW_CODEX_RESUME_MESSAGE` (imported in Task 1); `SessionLocatorSchema` (`shared/ws-protocol.ts:49`); `SessionLocator` (`crates/freshell-protocol/src/client_messages.rs`).
+- Produces: `codingcli.create` carrying `resumeSessionId` then `error{INVALID_MESSAGE}` + frozen text + no `codingCliManager.create`; `codingcli.create` carrying `sessionRef {provider === m.provider}` then spawn-time resume id promoted from `sessionRef.sessionId`.
+
+**Decision on whether the Rust `CodingCliCreate` struct gains `session_ref` (binding correction D, citing `port/machine/specs/cli-argv-fidelity.md` section 3.3/U7):**
+
+**YES — add `session_ref: Option<SessionLocator>` to the Rust `CodingCliCreate` struct.**
+
+Cited spec text from `port/machine/specs/cli-argv-fidelity.md`:
+- Section 3.3 (`:516-519`): *"Parse the additional create-time inputs: `resume_session_id` is **missing** from `freshell_protocol::TerminalCreate` (`crates/freshell-protocol/src/client_messages.rs:179-200` has `session_ref` but not `resumeSessionId`; the reference schema has both, `ws-handler.ts:656-658`). Add `resume_session_id: Option<String>`."* — This item governs `TerminalCreate` specifically (the `terminal.create` door), NOT `CodingCliCreate`.
+- U7 (`:829-834`): *"`resumeSessionId` vs `session_ref` on the Rust wire. The Rust `TerminalCreate` lacks `resumeSessionId` (`client_messages.rs:179-200`). ... This spec only requires the **spawn-time** id (section 2 resume args); the full binding/repair pipeline remains covered by `specs/coding-cli.md`."* — U7 scopes the spec's requirement to `TerminalCreate`'s spawn-time id. It does NOT mention `CodingCliCreate` and does NOT forbid adding the canonical carrier (`sessionRef`) to it.
+
+Rationale: The spec's scope is `terminal.create`'s spawn-time id, and the section 3.3 item added `resume_session_id` to `TerminalCreate` (which now gets the section 3c retained-for-rejection comment). The spec is silent on `CodingCliCreate`. Since the TS `CodingCliCreateSchema` is being widened contract-additively with `sessionRef` (kata section 1d requirement), and `freshell-protocol` is the shared language-neutral contract (`port/AGENTS.md`: *"shared/ws-protocol.ts is the immutable contract. Extract to a language-neutral schema; generate Rust types from it. Both sides and the oracle share that single source of truth."*), keeping the Rust `CodingCliCreate` in parity preserves that invariant. Adding `session_ref` keeps the roundtrip test meaningful and means a future Rust `codingcli.create` handler would have the canonical carrier available without a second protocol change. The `resume_session_id` field on `CodingCliCreate` gets the section 3c "retained solely so the handler can detect-and-reject" comment.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add to `test/server/ws-coding-cli-events.test.ts` (model on the existing `createAuthenticatedWs` + `responsePromise` pattern at `:88-128` — that file uses `createAuthenticatedWs()` and `new Promise<any>((resolve) => ws.on('message', ...))`, NOT `connectAndAuth`/`waitForMessage`):
+
+```ts
+  it('rejects codingcli.create carrying resumeSessionId with INVALID_MESSAGE + frozen text', async () => {
+    const ws = await createAuthenticatedWs()
+    const requestId = 'cli-legacy-reject-1'
+    const errorPromise = new Promise<any>((resolve) => {
+      ws.on('message', (data) => {
+        const msg = JSON.parse(data.toString())
+        if (msg.type === 'error' && msg.requestId === requestId) resolve(msg)
+      })
+    })
+    ws.send(JSON.stringify({
+      type: 'codingcli.create', requestId, provider: 'claude', prompt: 'hi',
+      resumeSessionId: 'legacy-cli-id',
+    }))
+    const error = await errorPromise
+    expect(error).toMatchObject({
+      type: 'error', code: 'INVALID_MESSAGE',
+      message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+      requestId,
+    })
+    ws.close()
+  })
+
+  it('promotes a provider-matched sessionRef into the spawn-time resume id for codingcli.create', async () => {
+    const fakeProvider = { name: 'claude', create: vi.fn(), ...claudeProvider }
+    const fakeManager = new CodingCliSessionManager([fakeProvider as any])
+    // swap in the fake manager for this test by re-initializing wsHandler
+    wsHandler.close()
+    cliManager.shutdown()
+    const newCliManager = new CodingCliSessionManager([fakeProvider as any])
+    wsHandler = new WsHandler(server, registry, { codingCliManager: newCliManager })
+    vi.mocked(configStore.snapshot).mockResolvedValue({
+      settings: { codingCli: { enabledProviders: ['claude'], providers: {} } },
+    } as any)
+
+    const ws = await createAuthenticatedWs()
+    const requestId = 'cli-sref-promote-1'
+    ws.send(JSON.stringify({
+      type: 'codingcli.create', requestId, provider: 'claude', prompt: 'hi',
+      sessionRef: { provider: 'claude', sessionId: 'canonical-cli-session' },
+    }))
+    // Wait for the codingcli.event or codingcli.created frame (spawn happened)
+    await new Promise<any>((resolve) => {
+      ws.on('message', (data) => {
+        const msg = JSON.parse(data.toString())
+        if (msg.type === 'codingcli.event' || msg.type === 'error') resolve(msg)
+      })
+    })
+    // Verify the spawn-time resume id was promoted from the provider-matched sessionRef
+    // by checking the session manager's internal state or the provider.create call args
+    newCliManager.shutdown()
+    ws.close()
+  })
+```
+
+Add to `crates/freshell-protocol/tests/roundtrip.rs` (extend the codingcli roundtrip at `:309` to include `sessionRef`):
+
+```rust
+    // codingcli.create — sessionRef (canonical carrier, ejh6 Task 11) + resumeSessionId (retained for reject).
+    let wire = r#"{"type":"codingcli.create","prompt":"hi","provider":"claude","requestId":"r1","cwd":"/x","maxTurns":3,"model":"sonnet","permissionMode":"acceptEdits","sandbox":"workspace-write","resumeSessionId":"prev","sessionRef":{"provider":"claude","sessionId":"sess-canonical"}}"#;
+    match client_roundtrip(wire, "codingcli.create") {
+        ClientMessage::CodingCliCreate(c) => {
+            assert_eq!(c.permission_mode, Some(PermissionMode::AcceptEdits));
+            assert_eq!(c.sandbox, Some(Sandbox::WorkspaceWrite));
+            assert_eq!(c.resume_session_id, Some("prev".to_string()));
+            assert_eq!(
+                c.session_ref,
+                Some(SessionLocator { provider: "claude".to_string(), session_id: "sess-canonical".to_string() })
+            );
+        }
+        other => panic!("expected CodingCliCreate, got {other:?}"),
+    }
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/server/ws-coding-cli-events.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: FAIL because (a) the handler does not reject `resumeSessionId`; (b) the `sessionRef` field is not on the schema yet (the sessionRef-promote test may fail at parse or the manager is called with `resumeSessionId: undefined`).
+
+Run: `cargo test -p freshell-protocol --test roundtrip`
+
+Expected: FAIL because `CodingCliCreate` has no `session_ref` field — `c.session_ref` does not compile.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Add `sessionRef` to `shared/ws-protocol.ts:447-458` (`CodingCliCreateSchema`):
+
+```ts
+export const CodingCliCreateSchema = z.object({
+  type: z.literal('codingcli.create'),
+  requestId: z.string().min(1),
+  provider: CodingCliProviderSchema,
+  prompt: z.string().min(1),
+  cwd: z.string().optional(),
+  /** Retained solely so the handler can detect-and-reject; see kata ejh6. */
+  resumeSessionId: z.string().optional(),
+  /** Canonical identity carrier (kata ejh6). */
+  sessionRef: SessionLocatorSchema.optional(),
+  model: z.string().optional(),
+  maxTurns: z.number().int().positive().optional(),
+  permissionMode: z.enum(['default', 'plan', 'acceptEdits', 'bypassPermissions']).optional(),
+  sandbox: z.enum(['read-only', 'workspace-write', 'danger-full-access']).optional(),
+})
+```
+
+Add `sessionRef` to the dynamic codingcli schema at `server/ws-handler.ts:802-813`:
+
+```ts
+    const dynamicCodingCliCreateSchema = z.object({
+      type: z.literal('codingcli.create'),
+      requestId: z.string().min(1),
+      provider: dynamicProviderSchema,
+      prompt: z.string().min(1),
+      cwd: z.string().optional(),
+      /** Retained solely so the handler can detect-and-reject; see kata ejh6. */
+      resumeSessionId: z.string().optional(),
+      /** Canonical identity carrier (kata ejh6). */
+      sessionRef: SessionLocatorSchema.optional(),
+      model: z.string().optional(),
+      maxTurns: z.number().int().positive().optional(),
+      permissionMode: z.enum(['default', 'plan', 'acceptEdits', 'bypassPermissions']).optional(),
+      sandbox: z.enum(['read-only', 'workspace-write', 'danger-full-access']).optional(),
+    }).strict()
+```
+
+Insert the reject + promotion at `server/ws-handler.ts:3290` (after `endCodingTimer` is defined, before the `try` block at `:3297`):
+
+```ts
+        // ejh6: reject the legacy resumeSessionId wire field on codingcli.create.
+        // The canonical carrier is sessionRef; resumeSessionId stays declared
+        // on the schema solely so the handler can detect-and-reject (see kata ejh6).
+        if (m.resumeSessionId) {
+          this.sendError(ws, {
+            code: 'INVALID_MESSAGE',
+            message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+            requestId: m.requestId,
+          })
+          endCodingTimer({ error: true })
+          return
+        }
+        // ejh6: promote a provider-matched sessionRef into the spawn-time resume
+        // id (provider must equal m.provider, mirroring terminal.create's
+        // expectedSessionRef match at :2085-2087).
+        const codingResumeSessionId = m.sessionRef && m.sessionRef.provider === m.provider
+          ? m.sessionRef.sessionId
+          : undefined
+```
+
+Then at `:3318-3326`, replace `resumeSessionId: m.resumeSessionId` with `resumeSessionId: codingResumeSessionId`:
+
+```ts
+          const session = this.codingCliManager.create(m.provider, {
+            prompt: m.prompt,
+            cwd: m.cwd,
+            resumeSessionId: codingResumeSessionId,
+            model: m.model ?? providerDefaults.model,
+            maxTurns: m.maxTurns ?? providerDefaults.maxTurns,
+            permissionMode: m.permissionMode ?? providerDefaults.permissionMode,
+            sandbox: m.sandbox ?? providerDefaults.sandbox,
+          })
+```
+
+Add `session_ref` to the Rust `CodingCliCreate` struct at `crates/freshell-protocol/src/client_messages.rs:429-448`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodingCliCreate {
+    pub prompt: String,
+    /// Free-form provider string (`CodingCliProvider`).
+    pub provider: String,
+    pub request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_turns: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permission_mode: Option<PermissionMode>,
+    /// Retained solely so the handler can detect-and-reject; see kata ejh6.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resume_session_id: Option<String>,
+    /// Canonical identity carrier (kata ejh6). Parity with the TS
+    /// `CodingCliCreateSchema.sessionRef`. The spec
+    /// (`port/machine/specs/cli-argv-fidelity.md` section 3.3/U7) governs
+    /// `TerminalCreate.resume_session_id` (the spawn-time id) and is silent
+    /// on `CodingCliCreate`; adding the canonical carrier here preserves the
+    /// shared-contract invariant without violating the spec.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_ref: Option<SessionLocator>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<Sandbox>,
+}
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `cargo test -p freshell-protocol --test roundtrip && npm run test:vitest -- run test/server/ws-coding-cli-events.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+No refactor needed — the schema widening is additive, the reject is a head-of-case guard, and the promotion replaces one expression.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The codingcli schema change affects the dynamic schema union (every inbound WS message parses through it). The `resumeSessionId` field is retained so existing tests that send it still parse. Run the full server suite + protocol roundtrip.
+
+Run: `cargo test -p freshell-protocol && npm run test:vitest -- run test/server/ws-coding-cli-events.test.ts test/server/ws-protocol.test.ts --config config/vitest/vitest.server.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add shared/ws-protocol.ts server/ws-handler.ts crates/freshell-protocol/src/client_messages.rs crates/freshell-protocol/tests/roundtrip.rs test/server/ws-coding-cli-events.test.ts
+git commit -m "feat(ejh6): Node WS codingcli.create reject + sessionRef promotion + Rust struct parity"
+```
+
+---
+
+### Task 12: Client-side `pane.reconcile` promotion + `ReconcilePaneSchema` permanent-compat doc
+
+**Files:**
+- Modify: `src/lib/pane-reconcile.ts:119-133` (`toReconcilePane` — promote legacy `resumeSessionId` into `sessionRef`)
+- Modify: `src/lib/pane-reconcile.ts:140-156` (`toFreshAgentReconcilePane` — same promotion)
+- Modify: `shared/ws-protocol.ts:611-612` (`ReconcilePaneSchema.resumeSessionId` — PERMANENT compat-door doc)
+- Test: `test/unit/client/lib/pane-reconcile.test.ts` (new terminal promotion test)
+- Test: `test/unit/client/lib/pane-reconcile.fresh-agent.test.ts` (new fresh-agent promotion test)
+
+**Interfaces:**
+- Consumes: `effectiveSessionRef` pattern from `src/components/fresh-agent/FreshAgentView.tsx:335-341`; `TerminalPaneContent`/`FreshAgentPaneContent` (with `sessionRef` and `resumeSessionId` fields); `ReconcilePaneSchema` (`shared/ws-protocol.ts:596-615`).
+- Produces: both `toReconcilePane` and `toFreshAgentReconcilePane` promote a legacy-only `resumeSessionId` into a canonical `sessionRef {provider, sessionId}` (the permanent compat door), mirroring the server-side `promoted_legacy_claim`.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add to `test/unit/client/lib/pane-reconcile.test.ts` (model on the existing `addTerminalPane` helper at `:51+` and the `FreshAgentView.reconcile.test.tsx:406` promotion pin):
+
+```ts
+  it('promotes a legacy-only terminal pane resumeSessionId into a canonical sessionRef on the reconcile claim', () => {
+    let state = emptyPanesState()
+    state = addTerminalPane(state, 'tab_1', 'pane_1', {
+      mode: 'claude', createRequestId: 'req-1',
+      resumeSessionId: 'legacy-claude-session-id',
+    } as Partial<TerminalPaneContent>)
+
+    const targets = collectTerminalPaneTargets(state, 'tab_1')
+    const request = buildRequestFromPanes(targets)
+    expect(request).not.toBeNull()
+    const pane = request!.panes[0]
+    expect(pane.sessionRef).toEqual({ provider: 'claude', sessionId: 'legacy-claude-session-id' })
+    expect(pane.resumeSessionId).toBeUndefined()
+  })
+```
+
+Add to `test/unit/client/lib/pane-reconcile.fresh-agent.test.ts` (model on the existing fresh-agent pane helpers in that file):
+
+```ts
+  it('promotes a legacy-only fresh-agent pane resumeSessionId into a canonical sessionRef on the reconcile claim', () => {
+    let state = emptyPanesState()
+    state = addFreshAgentPane(state, 'tab_1', 'pane_1', {
+      provider: 'claude', createRequestId: 'req-fa-1',
+      resumeSessionId: 'legacy-fa-session-id',
+    } as Partial<FreshAgentPaneContent>)
+
+    const targets = collectFreshAgentPaneTargets(state, 'tab_1')
+    const request = buildRequestFromPanes(targets)
+    expect(request).not.toBeNull()
+    const pane = request!.panes[0]
+    expect(pane.sessionRef).toEqual({ provider: 'claude', sessionId: 'legacy-fa-session-id' })
+    expect(pane.resumeSessionId).toBeUndefined()
+  })
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/pane-reconcile.test.ts test/unit/client/lib/pane-reconcile.fresh-agent.test.ts --config config/vitest/vitest.config.ts`
+
+Expected: FAIL because the current `toReconcilePane`/`toFreshAgentReconcilePane` forward `resumeSessionId` as-is (the `:130`/`:153` spreads) and do NOT promote it into `sessionRef` — `pane.sessionRef` is undefined and `pane.resumeSessionId` is `'legacy-claude-session-id'`.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Apply the `effectiveSessionRef` pattern at both sites in `src/lib/pane-reconcile.ts`. Add a local helper mirroring `FreshAgentView.tsx:335-341`:
+
+```ts
+/// The ONE durable-identity claim a reconcile pane carries: the canonical
+/// sessionRef, with a legacy-only pane's `resumeSessionId` promoted into it
+/// ({provider, sessionId} — the same promotion rule the server's
+/// `promoted_legacy_claim` in `reconcile.rs` applies). The legacy wire field
+/// is NOT sent; the server-side reconcile door is the permanent compat
+/// exception (kata ejh6 section 2).
+function effectiveReconcileSessionRef(
+  sessionRef: { provider: string; sessionId: string } | undefined,
+  resumeSessionId: string | undefined,
+  mode: string,
+): { provider: string; sessionId: string } | undefined {
+  if (sessionRef) return sessionRef
+  if (resumeSessionId) return { provider: mode, sessionId: resumeSessionId }
+  return undefined
+}
+```
+
+Update `toReconcilePane` at `:119-133` — replace the two spreads (`sessionRef` and `resumeSessionId`) with one promoted `sessionRef`:
+
+```ts
+function toReconcilePane(tabId: string, paneId: string, content: TerminalPaneContent): ReconcilePane | null {
+  if (!content.createRequestId) return null
+  const sessionRef = effectiveReconcileSessionRef(content.sessionRef, content.resumeSessionId, content.mode)
+  return {
+    paneKey: paneKeyFor(tabId, paneId),
+    kind: 'terminal',
+    mode: content.mode,
+    createRequestId: content.createRequestId,
+    ...(content.terminalId ? { terminalId: content.terminalId } : {}),
+    ...(content.serverInstanceId ? { serverInstanceId: content.serverInstanceId } : {}),
+    ...(sessionRef ? { sessionRef } : {}),
+    ...(content.status ? { status: content.status } : {}),
+  }
+}
+```
+
+Update `toFreshAgentReconcilePane` at `:140-156` — same pattern (the "mode" for fresh-agent is `content.provider`):
+
+```ts
+function toFreshAgentReconcilePane(
+  tabId: string, paneId: string, content: FreshAgentPaneContent,
+): ReconcilePane | null {
+  if (!content.createRequestId) return null
+  const sessionRef = effectiveReconcileSessionRef(content.sessionRef, content.resumeSessionId, content.provider)
+  return {
+    paneKey: paneKeyFor(tabId, paneId),
+    kind: 'fresh-agent',
+    mode: content.provider,
+    createRequestId: content.createRequestId,
+    ...(sessionRef ? { sessionRef } : {}),
+    ...(content.status ? { status: content.status } : {}),
+  }
+}
+```
+
+Add the PERMANENT compat-door doc at `shared/ws-protocol.ts:611-612` (`ReconcilePaneSchema.resumeSessionId`):
+
+```ts
+  /** PERMANENT legacy-compat door: the server promotes this into a sessionRef
+   *  forever (kata ejh6 section 2). Do NOT plan a later removal. */
+  resumeSessionId: z.string().optional(),
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/pane-reconcile.test.ts test/unit/client/lib/pane-reconcile.fresh-agent.test.ts --config config/vitest/vitest.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+The `effectiveReconcileSessionRef` helper mirrors `FreshAgentView.tsx`'s `effectiveSessionRef`. If the codebase already exports a shared helper, use it instead — but grep confirms no shared helper exists today (`effectiveSessionRef` is local to `FreshAgentView.tsx`). Keep the local helper in `pane-reconcile.ts` (it has a distinct doc context: reconcile vs. create/attach).
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Every client test that exercises `pane-reconcile` or `collectTerminalPaneTargets`/`collectFreshAgentPaneTargets` is impacted. The existing tests in `pane-reconcile.test.ts`/`pane-reconcile.fresh-agent.test.ts` that send `sessionRef` directly (not legacy) are unaffected (the helper passes `sessionRef` through when present). The `FreshAgentView.reconcile.test.tsx:406` pin already asserts the promotion pattern on the create/attach path — it is unaffected (different module).
+
+Run: `npm run test:vitest -- run test/unit/client/lib/pane-reconcile.test.ts test/unit/client/lib/pane-reconcile.fresh-agent.test.ts test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx --config config/vitest/vitest.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/lib/pane-reconcile.ts shared/ws-protocol.ts test/unit/client/lib/pane-reconcile.test.ts test/unit/client/lib/pane-reconcile.fresh-agent.test.ts
+git commit -m "feat(ejh6): client pane.reconcile promotion + ReconcilePaneSchema permanent-compat doc"
+```
+
+---
+
+### Task 13: Final verification — kata section 6 `rg` sweep + verification checklist + gates
+
+**Files:**
+- No production changes (verification-only task).
+- Test: all suites (coordinated full suite + Rust workspace + Playwright e2e).
+
+**Interfaces:**
+- Consumes: all prior tasks (1-12) complete and committed.
+- Produces: verified green gates and a clean `rg` sweep showing only allowed categories.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+No new test — this task runs the kata section 6 `rg` sweep and the verification checklist. The "failure" is any `rg` hit outside the allowed categories or any failing gate.
+
+- [ ] **Step 2: Run the sweep and verify the expected state**
+
+Run the kata section 6 `rg` sweep:
+
+```bash
+rg 'resumeSessionId' server/ src/ shared/ crates/ --glob '!*test*'
+```
+
+Expected: output shows ONLY these categories:
+1. Internal content/registry fields (e.g. `TerminalRegistry` row `resume_session_id`, `FreshAgentPaneContent.resumeSessionId`, tab-level `resumeSessionId` in pane content).
+2. The `pane.reconcile` compat door (`crates/freshell-ws/src/reconcile.rs` `promoted_legacy_claim`, `src/lib/pane-reconcile.ts` `effectiveReconcileSessionRef`).
+3. Alias conversion sites (CLI `promoteResumeFlag` in `server/cli/index.ts`, MCP `freshell-tool.ts` `resume`/`resumeSessionId` param handling).
+4. Retained-for-rejection schema/struct fields (each carrying the section 3c comment): `shared/ws-protocol.ts` (`CodingCliCreateSchema`, `FreshAgentCreateSchema`, `FreshAgentAttachSchema`, `ReconcilePaneSchema`), `server/ws-handler.ts` (dynamic terminal.create + codingcli schemas), `crates/freshell-protocol/src/client_messages.rs` (`TerminalCreate`, `CodingCliCreate`, `FreshAgentCreate`, `FreshAgentAttach`, `ReconcilePane`).
+5. Rejection handlers: `crates/freshell-freshagent/src/terminal_tabs.rs` (`requested_resume_session_id_for_mode`), `crates/freshell-ws/src/terminal.rs` (head-of-`handle_create` blanket reject, `fresh_agent_control_refusal` create/attach arms), `server/ws-handler.ts` (terminal.create/freshAgent.create/freshAgent.attach/codingcli.create head-of-case rejects), `server/agent-api/router.ts` (`requestedResumeSessionIdForMode`).
+6. Sidecar JSON-lines writers (`claude.rs:469`/`:1294` — internal adapter-to-sidecar protocol, not Freshell wire input, per binding correction C).
+
+If any hit falls outside these categories, add a section 3c doc comment, convert it to sessionRef, or document it as an allowed internal — then re-run.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+No production change — fix any sweep violations found in Step 2 by adjusting the relevant task's output (e.g. adding a missing section 3c comment, converting a missed wire-send test).
+
+- [ ] **Step 4: Run the verification checklist gates**
+
+Run the coordinated full suite (typecheck + Node tests):
+
+```bash
+npm run check
+```
+
+Expected: PASS (typecheck clean + coordinated default + server vitest suites green).
+
+Run the Rust workspace suite:
+
+```bash
+cargo test --workspace
+```
+
+Expected: PASS.
+
+Run the Playwright e2e (CLI path — the `agent-cli-flow` e2e with the new WS assertion; the MCP e2e `mcp-qa-smoke-rust`):
+
+```bash
+npm run test:e2e:local -- --grep "agent-cli-flow|mcp-qa-smoke-rust"
+```
+
+Expected: PASS (CLI `--resume` promotes to sessionRef and still works; MCP `resume` alias still works; the new WS assertion gets INVALID_MESSAGE + frozen text).
+
+- [ ] **Step 5: Refactor while green**
+
+No refactor — verification-only.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The full coordinated suite IS the impacted set (this is the final gate).
+
+Run: `npm run check && cargo test --workspace`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the task**
+
+If Step 2 found sweep violations that required fixes, commit those fixes. Otherwise, no commit — the verification task produces no code change.
+
+```bash
+# Only if sweep fixes were needed:
+git add <fixed files>
+git commit -m "fix(ejh6): clean up remaining rg sweep violations"
+```
+
+**Verification checklist (kata section 6) — confirm each against the green gates:**
+
+1. `curl -X POST /api/tabs -d '{"mode":"claude","resumeSessionId":"<uuid>"}'` then 400 with the frozen message — covered by Task 5 (`rest_create_rejects_legacy_resume_session_id_for_every_session_mode`) and Task 8 (`it.each` in `agent-tabs-write.test.ts`).
+2. WS `terminal.create` with the field then `error{INVALID_MESSAGE}` with the named text, no spawn, registry row count unchanged — covered by Task 6 (`blanket_reject_legacy_resume_session_id_on_any_create`) and Task 9 (`it.each` in `ws-terminal-create-reuse-running-codex.test.ts`).
+3. WS `freshAgent.create` with the field then create-failed envelope, no sidecar spawn — covered by Task 7 (`freshagent_create_with_legacy_resume_session_id_is_rejected`) and Task 10 (`rejects freshAgent.create carrying resumeSessionId`).
+4. WS `codingcli.create` with the field then `error{INVALID_MESSAGE}`; with `sessionRef` then resume works — covered by Task 11 (`rejects codingcli.create carrying resumeSessionId` + `promotes a provider-matched sessionRef`).
+5. CLI `--resume` and MCP `resume` still work end-to-end (they convert; nothing user-facing changes) — covered by existing `agent-cli-flow.test.ts:493-560` (positive `--resume` to sessionRef) and `freshell-tool.test.ts` alias tests, both unchanged.
+6. Reload/restore of existing tabs (including pre-existing persisted state that may carry legacy pane-content fields) still resumes correctly — covered by the permanent `pane.reconcile` compat door (Task 6 reconcile doc + Task 12 client promotion), with existing `reconcile.rs` cfg(test) fns `:1021`/`:1053`/`:1083` and `pane_reconcile.rs:125` staying green.
+7. `freshAgent.attach` with the field then `freshAgent.error{FRESH_AGENT_CREATE_FAILED}` + frozen text — covered by Task 7 (`freshagent_attach_with_legacy_resume_session_id_is_rejected`) and Task 10 (`rejects freshAgent.attach carrying resumeSessionId`).
+8. `rg 'resumeSessionId' server/ src/ shared/ crates/ --glob '!*test*'` shows only allowed categories — verified in Step 2.

--- a/docs/plans/2026-08-16-legacy-resume-guard.md
+++ b/docs/plans/2026-08-16-legacy-resume-guard.md
@@ -1294,11 +1294,13 @@ fn attach_durable_id(msg: &FreshAgentAttach) -> Option<String> {
 }
 ```
 
+Add the ordering pin alongside the flip, in claude.rs's `#[cfg(test)]` mod: a direct-call unit test named `attach_durable_id_prefers_session_ref_over_legacy` covering (i) both carriers set with DIFFERENT canonical UUIDs → returns the sessionRef's id, (ii) sessionRef-only → its id, (iii) legacy-only → its id (test-compat lane), (iv) neither → None. Use canonical-UUID shapes (e.g. `11111111-2222-4333-8444-555555555555` / `aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee`) — the helper's `is_canonical_claude_uuid` gate rejects anything else. Red evidence: against the pre-flip legacy-first ordering, case (i) returns the legacy id and fails.
+
 - [ ] **Step 4: Run the focused test**
 
-Run: `cargo test -p freshell-ws --test freshagent_claude_attach legacy_reject_freshagent_attach && cargo test -p freshell-ws --test freshagent_session_lease legacy_reject_freshagent_create && cargo test -p freshell-ws --test cross_kind_liveness freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session && cargo test -p freshell-freshagent attach_durable_id`
+Run: `cargo test -p freshell-ws --test freshagent_claude_attach legacy_reject_freshagent_attach && cargo test -p freshell-ws --test freshagent_session_lease legacy_reject_freshagent_create && cargo test -p freshell-ws --test cross_kind_liveness freshagent_resume_is_refused_while_a_terminal_pty_owns_the_session && cargo test -p freshell-freshagent attach_durable_id && cargo test -p freshell-freshagent attach_untracked_without_any_durable_id_still_emits_lost_frame && cargo test -p freshell-freshagent concurrent_attaches_for_the_same_durable_id_spawn_at_most_one_sidecar && cargo test -p freshell-freshagent attach_with_durable_id_already_indexed_rebinds_and_acks`
 
-Expected: PASS
+Expected: PASS. The `attach_durable_id` filter selects the Step-3 ordering pin (`attach_durable_id_prefers_session_ref_over_legacy`) — bare helper-name filters match zero pre-existing tests, so the three durable-id attach tests are invoked by their real names to exercise the changed sessionRef-first selection through the handler.
 
 - [ ] **Step 5: Refactor while green**
 
@@ -2571,15 +2573,21 @@ If Step 2 found sweep violations that required fixes, commit those fixes first. 
 Then — the kata/User-Request contract requires BOTH servers' rejections (+ the reconcile client promotion, codingcli promotion, and rejection tests) to LAND TOGETHER, not as a sequence of partially-rejecting main-history commits. Task-sequenced commits 5–12 are correct locally for review/TDD, but before the PR opens, squash them into ONE behavior commit. Do it with a soft reset (the branch is unpushed during execution):
 
 ```bash
-# Find the first behavior commit (Task 5's) — tasks 1-4 are contract-neutral
-# prep and stay separate:
-BEHAVIOR_BASE=$(git rev-list --max-parents=0 --no-merges HEAD -- server/ crates/ | tail -n +1 >/dev/null; git log --oneline --reverse origin/main..HEAD | awk '/ejh6.*Rust REST reject/{print $1; exit}')
-git reset --soft "${BEHAVIOR_BASE}^"
+# The behavior base is the Task-5 commit. Take its SHA from the progress
+# ledger entry recorded at Task 5 completion ("Task 5: complete — impl
+# <task5-sha> ...") — do NOT grep commit subjects for it. Tasks 1-4 are
+# contract-neutral prep and stay separate.
+TASK5_SHA=<task5-sha-from-ledger>
+# Verify BEFORE resetting: this range must list exactly the behavior-task
+# commits (Tasks 5-12) — the oldest entry carries Task 5's subject ("feat(ejh6):
+# Rust REST door-top presence reject ...") and no prep-task commit appears:
+git log --format='%H %s' "${TASK5_SHA}^..HEAD"
+git reset --soft "${TASK5_SHA}^"
 git commit -m "feat(ejh6): reject the legacy resumeSessionId wire field on every create-class door (both servers)"
 git rebase origin/main # keep current-base lineage clean; plan docs/commits 1-4 are already behind
 ```
 
-(Harness note: capture the Task-5 commit SHA in the progress ledger at Task 5 completion and use it directly rather than re-deriving with the awk above. If the squash reveals a mixed file staged from a prep task, unstage and recommit it separately — the verification gate already ran before this step.)
+(Harness note: the Task-5 commit SHA captured in the progress ledger at Task 5 completion is the single source of truth; use it directly rather than re-deriving the base from commit subjects — subject patterns drift and a pattern that matches nothing yields an empty base and a `git reset --soft "^"` abort. If the squash reveals a mixed file staged from a prep task, unstage and recommit it separately — the verification gate already ran before this step.)
 
 ```bash
 # Only if sweep fixes were needed:

--- a/port/contract/ws-protocol.schema.json
+++ b/port/contract/ws-protocol.schema.json
@@ -830,6 +830,9 @@
             "restore": {
               "type": "boolean"
             },
+            "resumeSessionId": {
+              "type": "string"
+            },
             "sessionRef": {
               "additionalProperties": false,
               "properties": {
@@ -1406,6 +1409,24 @@
                 "danger-full-access"
               ],
               "type": "string"
+            },
+            "sessionRef": {
+              "additionalProperties": false,
+              "properties": {
+                "provider": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sessionId": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "provider",
+                "sessionId"
+              ],
+              "type": "object"
             },
             "type": {
               "const": "codingcli.create",
@@ -2287,6 +2308,24 @@
           ],
           "type": "string"
         },
+        "sessionRef": {
+          "additionalProperties": false,
+          "properties": {
+            "provider": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "sessionId": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "provider",
+            "sessionId"
+          ],
+          "type": "object"
+        },
         "type": {
           "const": "codingcli.create",
           "type": "string"
@@ -2464,7 +2503,8 @@
         "UNAUTHORIZED",
         "PROTOCOL_MISMATCH",
         "SESSION_RESERVED",
-        "FRESH_AGENT_LOST_SESSION"
+        "FRESH_AGENT_LOST_SESSION",
+        "FRESH_AGENT_CREATE_FAILED"
       ],
       "type": "string"
     },
@@ -4610,6 +4650,9 @@
         },
         "restore": {
           "type": "boolean"
+        },
+        "resumeSessionId": {
+          "type": "string"
         },
         "sessionRef": {
           "additionalProperties": false,

--- a/port/contract/ws-server-messages.schema.json
+++ b/port/contract/ws-server-messages.schema.json
@@ -570,7 +570,8 @@
             "UNAUTHORIZED",
             "PROTOCOL_MISMATCH",
             "SESSION_RESERVED",
-            "FRESH_AGENT_LOST_SESSION"
+            "FRESH_AGENT_LOST_SESSION",
+            "FRESH_AGENT_CREATE_FAILED"
           ],
           "type": "string"
         },

--- a/server/agent-api/router.ts
+++ b/server/agent-api/router.ts
@@ -214,17 +214,13 @@ type ResolvedSpawnProviderSettings = Awaited<ReturnType<typeof resolveSpawnProvi
 function requestedResumeSessionIdForMode(
   sessionRef: ReturnType<typeof sanitizeSessionRef>,
   mode: string,
-  legacyResumeSessionId: unknown,
+  _legacyResumeSessionId: unknown,
 ): string | undefined {
+  // ejh6 (finding 3): the legacy-field throw moved to a door-top presence check
+  // in each create route handler; this function keeps sessionRef resolution only.
   const acceptedSessionRef = acceptedSessionRefForMode(sessionRef, mode)
   if (acceptedSessionRef) return acceptedSessionRef.sessionId
-  if (mode === 'codex') {
-    if (isNonEmptyString(legacyResumeSessionId)) {
-      throw new AgentRouteInputError(INVALID_RAW_CODEX_RESUME_MESSAGE)
-    }
-    return undefined
-  }
-  return typeof legacyResumeSessionId === 'string' ? legacyResumeSessionId : undefined
+  return undefined
 }
 
 function acceptedSessionRefForMode(
@@ -233,10 +229,6 @@ function acceptedSessionRefForMode(
 ): ReturnType<typeof sanitizeSessionRef> {
   if (!sessionRef || sessionRef.provider !== mode) return undefined
   return sessionRef
-}
-
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0
 }
 
 function normalizeTerminalInputPayload(payload: Record<string, unknown>): string {
@@ -693,6 +685,10 @@ export function createAgentApiRouter({
   }
 
   router.post('/tabs', async (req, res) => {
+    // ejh6 (finding 3): door-top presence check BEFORE any branch (agent/browser/editor/terminal).
+    if (req.body?.resumeSessionId !== undefined) {
+      return res.status(400).json(fail(INVALID_RAW_CODEX_RESUME_MESSAGE))
+    }
     const { name, mode, shell, cwd, browser, editor, resumeSessionId, permissionMode, model, sandbox } = req.body || {}
     const requestedSessionRef = sanitizeSessionRef(req.body?.sessionRef)
     if (typeof req.body?.agent === 'string') {
@@ -1248,6 +1244,10 @@ export function createAgentApiRouter({
   })
 
   router.post('/panes/:id/split', async (req, res) => {
+    // ejh6 (finding 3): door-top presence check BEFORE any branch or layout mutation.
+    if (req.body?.resumeSessionId !== undefined) {
+      return res.status(400).json(fail(INVALID_RAW_CODEX_RESUME_MESSAGE))
+    }
     let launch: ResolvedSpawnProviderSettings | undefined
     let createdTerminalId: string | undefined
     try {
@@ -1544,6 +1544,10 @@ export function createAgentApiRouter({
   })
 
   router.post('/panes/:id/respawn', async (req, res) => {
+    // ejh6 (finding 3): door-top presence check BEFORE target resolution or spawn.
+    if (req.body?.resumeSessionId !== undefined) {
+      return res.status(400).json(fail(INVALID_RAW_CODEX_RESUME_MESSAGE))
+    }
     let launch: ResolvedSpawnProviderSettings | undefined
     let createdTerminalId: string | undefined
     try {

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -1922,7 +1922,13 @@ export class WsHandler {
       // non-strings generically; a typed field reads strings only). The
       // wire schemas keep the field declared (retention, comments in this
       // task) — the guard, not the schema, owns the contract.
-      if (typeof msg === 'object' && msg !== null && 'resumeSessionId' in msg) {
+      //
+      // The guard is gated on authentication (delta-review minor): pre-hello
+      // frames must fall through to the `!state.authenticated` gate below so
+      // they receive NOT_AUTHENTICATED + close(4001) — the required pre-auth
+      // envelope — not the legacy-field reject (which would also leak door
+      // behavior to unauthenticated senders).
+      if (state.authenticated && typeof msg === 'object' && msg !== null && 'resumeSessionId' in msg) {
         const rawMsg = msg as Record<string, unknown>
         switch (rawMsg.type) {
           case 'terminal.create': {

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -782,6 +782,7 @@ export class WsHandler {
       }),
       shell: ShellSchema.default('system'),
       cwd: z.string().optional(),
+      /** Retained solely so the handler can detect-and-reject; see kata ejh6. */
       resumeSessionId: z.string().optional(),
       sessionRef: SessionLocatorSchema.optional(),
       codexDurability: CodexDurabilityRefSchema.optional(),
@@ -806,7 +807,10 @@ export class WsHandler {
       provider: dynamicProviderSchema,
       prompt: z.string().min(1),
       cwd: z.string().optional(),
+      /** Retained solely so the handler can detect-and-reject; see kata ejh6. */
       resumeSessionId: z.string().optional(),
+      /** Canonical identity carrier (kata ejh6). */
+      sessionRef: SessionLocatorSchema.optional(),
       model: z.string().optional(),
       maxTurns: z.number().int().positive().optional(),
       permissionMode: z.enum(['default', 'plan', 'acceptEdits', 'bypassPermissions']).optional(),
@@ -1911,6 +1915,62 @@ export class WsHandler {
         return
       }
 
+      // ejh6 (R3) raw pre-parse presence guard: ANY create-class message
+      // carrying a top-level resumeSessionId — string, empty, null, number,
+      // object — is rejected HERE, before zod parse, so the frozen text and
+      // per-family envelope survive every value type (zod would reject
+      // non-strings generically; a typed field reads strings only). The
+      // wire schemas keep the field declared (retention, comments in this
+      // task) — the guard, not the schema, owns the contract.
+      if (typeof msg === 'object' && msg !== null && 'resumeSessionId' in msg) {
+        const rawMsg = msg as Record<string, unknown>
+        switch (rawMsg.type) {
+          case 'terminal.create': {
+            this.sendError(ws, {
+              code: 'INVALID_MESSAGE',
+              message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+              requestId: typeof rawMsg.requestId === 'string' ? rawMsg.requestId : undefined,
+            })
+            return
+          }
+          // Task 10: freshAgent families. Create rides the provider's
+          // create-failed envelope (requestId from the raw frame); attach has
+          // NO requestId — its rejection rides the attach error frame shape
+          // (sendError) with the FRESH_AGENT_CREATE_FAILED family code (kata
+          // §1c names the code family; binding correction D/ruling A
+          // documents the socket-loud/UI-invisible asymmetry).
+          case 'freshAgent.create': {
+            this.send(ws, {
+              type: 'freshAgent.create.failed',
+              requestId: typeof rawMsg.requestId === 'string' ? rawMsg.requestId : '',
+              code: 'FRESH_AGENT_CREATE_FAILED',
+              message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+              retryable: false,
+            })
+            return
+          }
+          case 'freshAgent.attach': {
+            this.sendError(ws, {
+              code: 'FRESH_AGENT_CREATE_FAILED',
+              message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+            })
+            return
+          }
+          // Task 11: codingcli.create → INVALID_MESSAGE + frozen text. The
+          // reject is config-independent (coordinator ruling J) — it fires here
+          // at the raw layer, before the manager-missing INTERNAL_ERROR branch
+          // exists, so {no manager} + {resumeSessionId} answers INVALID_MESSAGE.
+          case 'codingcli.create': {
+            this.sendError(ws, {
+              code: 'INVALID_MESSAGE',
+              message: INVALID_RAW_CODEX_RESUME_MESSAGE,
+              requestId: typeof rawMsg.requestId === 'string' ? rawMsg.requestId : undefined,
+            })
+            return
+          }
+        }
+      }
+
       const parsed = this.clientMessageSchema.safeParse(msg)
       if (!parsed.success) {
         this.sendError(ws, { code: 'INVALID_MESSAGE', message: parsed.error.message, requestId: msg?.requestId })
@@ -2131,6 +2191,8 @@ export class WsHandler {
         if (codexRestorePlan?.kind === 'durable_session_ref_resume') {
           effectiveResumeSessionId = codexRestorePlan.sessionId
         } else if (m.mode !== 'codex') {
+          // ejh6: the `m.resumeSessionId` fallback is dead for wire input —
+          // the raw pre-parse guard rejects any carry before this point.
           effectiveResumeSessionId = requestedSessionRef && requestedSessionRef.provider === m.mode
             ? requestedSessionRef.sessionId
             : m.resumeSessionId
@@ -2158,33 +2220,10 @@ export class WsHandler {
         } else if (effectiveResumeSessionId && m.mode === 'claude') {
           sessionBindingReason = 'resume'
         }
-        if (codexRestorePlan?.kind === 'reject_invalid_raw_codex_resume_request') {
-          error = true
-          this.sendError(ws, {
-            code: codexRestorePlan.code,
-            message: codexRestorePlan.message,
-            requestId: m.requestId,
-          })
-          endCreateTimer({ error, rateLimited })
-          return
-        }
-        if (
-          m.restore === true
-          && modeSupportsResume(m.mode as TerminalMode)
-          && !hasReusableRequestedLiveTerminal
-          && m.mode !== 'codex'
-          && m.resumeSessionId
-          && !requestedSessionRef
-        ) {
-          error = true
-          this.sendError(ws, {
-            code: 'INVALID_MESSAGE',
-            message: INVALID_RAW_CODEX_RESUME_MESSAGE,
-            requestId: m.requestId,
-          })
-          endCreateTimer({ error, rateLimited })
-          return
-        }
+        // ejh6: the scoped legacy-resumeSessionId gates formerly here
+        // (codex-planner reject + restore-scoped non-codex reject) are
+        // subsumed by the raw pre-parse presence guard in onMessage, which
+        // rejects ANY terminal.create carrying resumeSessionId before parse.
         if (
           m.restore === true
           && modeSupportsResume(m.mode as TerminalMode)
@@ -3293,6 +3332,13 @@ export class WsHandler {
           { connectionId: ws.connectionId, provider: m.provider },
           { minDurationMs: perfConfig.slowTerminalCreateMs, level: 'warn' },
         )
+        // ejh6: promote a provider-matched sessionRef into the spawn-time resume
+        // id (provider must equal m.provider, mirroring terminal.create's
+        // sessionRef match). The raw pre-parse guard above rejects any
+        // resumeSessionId carry, so sessionRef is the only wired carrier here.
+        const codingResumeSessionId = m.sessionRef && m.sessionRef.provider === m.provider
+          ? m.sessionRef.sessionId
+          : undefined
         let sessionId: string | undefined
         let error = false
         try {
@@ -3319,7 +3365,7 @@ export class WsHandler {
           const session = this.codingCliManager.create(m.provider, {
             prompt: m.prompt,
             cwd: m.cwd,
-            resumeSessionId: m.resumeSessionId,
+            resumeSessionId: codingResumeSessionId,
             model: m.model ?? providerDefaults.model,
             maxTurns: m.maxTurns ?? providerDefaults.maxTurns,
             permissionMode: m.permissionMode ?? providerDefaults.permissionMode,

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -108,6 +108,7 @@ import {
 import { UiLayoutSyncSchema } from './agent-api/layout-schema.js'
 import type { LayoutStore } from './agent-api/layout-store.js'
 import {
+  INVALID_RAW_CODEX_RESUME_MESSAGE,
   planCodexCreateRestoreDecision,
   resolveCodexCreateRestoreDecision,
 } from './coding-cli/codex-app-server/restore-decision.js'
@@ -2178,7 +2179,7 @@ export class WsHandler {
           error = true
           this.sendError(ws, {
             code: 'INVALID_MESSAGE',
-            message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+            message: INVALID_RAW_CODEX_RESUME_MESSAGE,
             requestId: m.requestId,
           })
           endCreateTimer({ error, rateLimited })

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -34,6 +34,7 @@ export const ErrorCode = z.enum([
   'PROTOCOL_MISMATCH',
   'SESSION_RESERVED',
   'FRESH_AGENT_LOST_SESSION',
+  'FRESH_AGENT_CREATE_FAILED',
 ])
 
 export type ErrorCode = z.infer<typeof ErrorCode>
@@ -322,6 +323,8 @@ export const TerminalCreateSchema = z.object({
   mode: z.string().default('shell'),
   shell: ShellSchema.default('system'),
   cwd: z.string().optional(),
+  /** Retained solely so the handler can detect-and-reject; see kata ejh6. */
+  resumeSessionId: z.string().optional(),
   sessionRef: SessionLocatorSchema.optional(),
   codexDurability: CodexDurabilityRefSchema.optional(),
   liveTerminal: LiveTerminalHandleSchema.optional(),
@@ -450,7 +453,10 @@ export const CodingCliCreateSchema = z.object({
   provider: CodingCliProviderSchema,
   prompt: z.string().min(1),
   cwd: z.string().optional(),
+  /** Retained solely so the handler can detect-and-reject; see kata ejh6. */
   resumeSessionId: z.string().optional(),
+  /** Canonical identity carrier (kata ejh6). */
+  sessionRef: SessionLocatorSchema.optional(),
   model: z.string().optional(),
   maxTurns: z.number().int().positive().optional(),
   permissionMode: z.enum(['default', 'plan', 'acceptEdits', 'bypassPermissions']).optional(),
@@ -479,6 +485,7 @@ export const FreshAgentCreateSchema = z.object({
     createdAt: z.number().finite().optional(),
     updatedAt: z.number().finite().optional(),
   }).optional(),
+  /** Retained solely so the handler can detect-and-reject; see kata ejh6. */
   resumeSessionId: z.string().optional(),
   model: z.string().optional(),
   permissionMode: z.string().optional(),
@@ -494,6 +501,7 @@ export const FreshAgentAttachSchema = z.object({
   sessionId: z.string().min(1),
   sessionType: z.enum(['freshclaude', 'freshcodex', 'kilroy', 'freshopencode']),
   provider: z.enum(['claude', 'codex', 'opencode']),
+  /** Retained solely so the handler can detect-and-reject; see kata ejh6. */
   resumeSessionId: z.string().optional(),
   cwd: z.string().optional(),
   sessionRef: SessionLocatorSchema.optional(),
@@ -608,7 +616,8 @@ export const ReconcilePaneSchema = z.object({
   serverInstanceId: z.string().min(1).optional(),
   /** Optional identity claim. */
   sessionRef: ReconcileSessionRefSchema.optional(),
-  /** Optional legacy single-key claim. */
+  /** PERMANENT legacy-compat door: the server promotes this into a sessionRef
+   *  forever (kata ejh6 section 2). Do NOT plan a later removal. */
   resumeSessionId: z.string().optional(),
   /** Informational only — never trusted. */
   status: z.string().optional(),

--- a/src/lib/pane-reconcile.ts
+++ b/src/lib/pane-reconcile.ts
@@ -116,9 +116,32 @@ export function collectTerminalPaneTargets(
   return targets
 }
 
+/// The ONE durable-identity claim a reconcile pane carries: the canonical
+/// sessionRef, with a legacy-only pane's `resumeSessionId` promoted into it
+/// ({provider, sessionId} — the same promotion rule the server's
+/// `promoted_legacy_claim` in `reconcile.rs` applies). The legacy wire field
+/// is NOT sent; the server-side reconcile door is the permanent compat
+/// exception (kata ejh6 section 2).
+function effectiveReconcileSessionRef(
+  sessionRef: { provider: string; sessionId: string } | undefined,
+  resumeSessionId: string | undefined,
+  mode: string,
+): { provider: string; sessionId: string } | undefined {
+  if (sessionRef) return sessionRef
+  // Mirror the server's promoted_legacy_claim exclusion
+  // (crates/freshell-ws/src/reconcile.rs:~165-177): shell/empty modes NEVER
+  // promote — a stateless shell has no durable identity (review round 3,
+  // finding 6 — the client must match or a stale shell pane becomes a
+  // structured sessionRef{provider:'shell'} and bypasses the server's
+  // fresh-verdict rule).
+  if (resumeSessionId && mode !== 'shell' && mode !== '') return { provider: mode, sessionId: resumeSessionId }
+  return undefined
+}
+
 function toReconcilePane(tabId: string, paneId: string, content: TerminalPaneContent): ReconcilePane | null {
   // Panes without a createRequestId cannot be reconciled — skip.
   if (!content.createRequestId) return null
+  const sessionRef = effectiveReconcileSessionRef(content.sessionRef, content.resumeSessionId, content.mode)
   return {
     paneKey: paneKeyFor(tabId, paneId),
     kind: 'terminal',
@@ -126,8 +149,7 @@ function toReconcilePane(tabId: string, paneId: string, content: TerminalPaneCon
     createRequestId: content.createRequestId,
     ...(content.terminalId ? { terminalId: content.terminalId } : {}),
     ...(content.serverInstanceId ? { serverInstanceId: content.serverInstanceId } : {}),
-    ...(content.sessionRef ? { sessionRef: content.sessionRef } : {}),
-    ...(content.resumeSessionId ? { resumeSessionId: content.resumeSessionId } : {}),
+    ...(sessionRef ? { sessionRef } : {}),
     ...(content.status ? { status: content.status } : {}),
   }
 }
@@ -144,13 +166,13 @@ function toFreshAgentReconcilePane(
 ): ReconcilePane | null {
   // Panes without a createRequestId cannot be reconciled — skip.
   if (!content.createRequestId) return null
+  const sessionRef = effectiveReconcileSessionRef(content.sessionRef, content.resumeSessionId, content.provider)
   return {
     paneKey: paneKeyFor(tabId, paneId),
     kind: 'fresh-agent',
     mode: content.provider,
     createRequestId: content.createRequestId,
-    ...(content.sessionRef ? { sessionRef: content.sessionRef } : {}),
-    ...(content.resumeSessionId ? { resumeSessionId: content.resumeSessionId } : {}),
+    ...(sessionRef ? { sessionRef } : {}),
     ...(content.status ? { status: content.status } : {}),
   }
 }

--- a/test/e2e-browser/playwright.config.ts
+++ b/test/e2e-browser/playwright.config.ts
@@ -285,6 +285,10 @@ export const RUST_ONLY_SPECS = [
   // owns its RustServer (isolated HOME, ephemeral port); the DELETE route
   // exists only on the Rust server.
   /session-delete-rust\.spec\.ts$/,
+  // Remote tab linkage (STATE-SYNC FIX 1 / EDEV-07) — boots its own
+  // RustServers, hard e2eServerKind==='rust' assertion per test; the legacy
+  // tree has no amplifier provider registered at all (pre-existing gap fix).
+  /remote-tab-linkage-rust\.spec\.ts$/,
 ]
 
 export default defineConfig({

--- a/test/e2e-browser/specs/fresh-agent-control-rust.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent-control-rust.spec.ts
@@ -1518,7 +1518,6 @@ test.describe('fresh-agent control surfaces — codex lane (rust)', () => {
         sessionId: 'thread-new-1',
         sessionType: 'freshcodex',
         cwd: lane.projectDir,
-        resumeSessionId: 'thread-new-1',
         sessionRef: { provider: 'codex', sessionId: 'thread-new-1' },
       })
       // No thread/resume for the source existed before this attach (create rode
@@ -1583,7 +1582,6 @@ test.describe('fresh-agent control surfaces — codex lane (rust)', () => {
         sessionId: 'thread-new-1',
         sessionType: 'freshcodex',
         cwd: lane.projectDir,
-        resumeSessionId: 'thread-new-1',
         sessionRef: { provider: 'codex', sessionId: 'thread-new-1' },
       })
       await expect
@@ -1861,7 +1859,6 @@ test.describe('fresh-agent control surfaces — opencode lane (rust)', () => {
         sessionId: parentId,
         sessionType: 'freshopencode',
         cwd: lane.projectDir,
-        resumeSessionId: parentId,
         sessionRef: { provider: 'opencode', sessionId: parentId },
       })
       const forkRowIndex = readOpencodeAudit(lane.auditLogPath)
@@ -1926,7 +1923,6 @@ test.describe('fresh-agent control surfaces — opencode lane (rust)', () => {
         sessionId: parentId,
         sessionType: 'freshopencode',
         cwd: lane.projectDir,
-        resumeSessionId: parentId,
         sessionRef: { provider: 'opencode', sessionId: parentId },
       })
       await expect

--- a/test/e2e-browser/specs/freshagent-settings-resume-rust.spec.ts
+++ b/test/e2e-browser/specs/freshagent-settings-resume-rust.spec.ts
@@ -310,7 +310,7 @@ test.describe('fresh-agent settings survive restart (rust)', () => {
         requestId: 'req-codex-settings-resume',
         sessionType: 'freshcodex',
         provider: 'codex',
-        resumeSessionId: threadId,
+        sessionRef: { provider: 'codex', sessionId: threadId },
       })
       await ws.waitFor(
         (f) => f.type === 'freshAgent.created' && f.requestId === 'req-codex-settings-resume',
@@ -411,7 +411,7 @@ test.describe('fresh-agent settings survive restart (rust)', () => {
         requestId: 'req-opencode-settings-resume',
         sessionType: 'freshopencode',
         provider: 'opencode',
-        resumeSessionId: sesId,
+        sessionRef: { provider: 'opencode', sessionId: sesId },
       })
       const created = await ws.waitFor(
         (f) => f.type === 'freshAgent.created' && f.requestId === 'req-opencode-settings-resume',
@@ -533,7 +533,6 @@ test.describe('fresh-agent settings survive restart (rust)', () => {
         provider: 'claude',
         sessionId: durable,
         sessionType: 'freshclaude',
-        resumeSessionId: durable,
         sessionRef: { provider: 'claude', sessionId: durable },
       })
 

--- a/test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts
+++ b/test/e2e-browser/specs/remote-tab-linkage-rust.spec.ts
@@ -12,11 +12,14 @@ import { TestHarness } from '../helpers/test-harness.js'
  * must be fully LINKED, not a grey orphan.
  *
  * This is the user's exact 2026-07-19 incident chain
- * (`docs/plans/2026-07-19-state-sync-cartography.md` Part 1), replayed and
- * now expected GREEN because the rust server synthesizes the canonical
+ * (`docs/plans/2026-07-19-state-sync-cartography.md` Part 1), replayed
+ * (kata ejh6: with the canonical `sessionRef {provider, sessionId}` carrier —
+ * the legacy bare `resumeSessionId` wire field is now rejected at the REST
+ * door, see the rejection case at the end of this describe) and expected
+ * GREEN because the rust server stamps the canonical
  * `sessionRef {provider: mode, sessionId}` onto the `ui.command{tab.create}`
  * payload (`crates/freshell-freshagent/src/terminal_tabs.rs`,
- * `spawn_terminal_pane`) instead of forwarding the legacy bare
+ * `spawn_terminal_pane`) instead of the legacy bare
  * `resumeSessionId` the frozen client's matchers are blind to for every
  * mode but `claude` (`src/lib/session-utils.ts:135-139`):
  *
@@ -191,8 +194,14 @@ test.describe('Remote tab linkage (Rust only)', () => {
         const tabCountBeforeCreate = await harness.getTabCount()
 
         // ------------------------------------------------------------------
-        // Step 2: the incident's exact trigger -- REST create with a bare
-        // legacy `resumeSessionId` (no sessionRef in the request).
+        // Step 2: the incident's trigger, re-carriered -- REST create with the
+        // canonical `sessionRef {provider, sessionId}` (kata ejh6: the legacy
+        // bare `resumeSessionId` wire field is now REJECTED at the door; see
+        // the rejection case at the end of this describe block). Every
+        // downstream assertion below (resume argv, live broadcast, sidebar
+        // linkage, click dedupe, title sync, persisted sessionRef,
+        // restart/reload restoration, post-restart resume) is unchanged
+        // sessionRef-carrier behavior coverage.
         // ------------------------------------------------------------------
         const res = await fetch(`${info.baseUrl}/api/tabs`, {
           method: 'POST',
@@ -200,7 +209,7 @@ test.describe('Remote tab linkage (Rust only)', () => {
           body: JSON.stringify({
             mode: 'amplifier',
             cwd: projectDir,
-            resumeSessionId: SEEDED_SESSION_ID,
+            sessionRef: { provider: 'amplifier', sessionId: SEEDED_SESSION_ID },
             name: TAB_NAME,
           }),
         })
@@ -328,6 +337,39 @@ test.describe('Remote tab linkage (Rust only)', () => {
       }
     } finally {
       await fs.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  // kata ejh6: the legacy `resumeSessionId` wire field is REJECTED at the
+  // `POST /api/tabs` door — 400 with the exact frozen text, and no visible
+  // creation (`/api/tabs` before/after equality proves no spawn, no tab).
+  // This case boots its OWN minimal rust server (no amplifier fixtures
+  // needed — the rejection fires at the door before any mode work), unlike
+  // the big linkage test above whose locals are out of scope here.
+  test('rejects a bare legacy resumeSessionId on REST create with 400 + frozen text (kata ejh6)', async ({ e2eServerKind }) => {
+    expect(e2eServerKind).toBe('rust')
+    const server = await createE2eServerHandle(process.env, {
+      kind: e2eServerKind,
+      construct: {}, // no fixtures: door-top reject needs no provider state
+    })
+    const info = await server.start()
+    try {
+      const before = await (await fetch(`${info.baseUrl}/api/tabs`, { headers: { 'x-auth-token': info.token } })).json()
+      const res = await fetch(`${info.baseUrl}/api/tabs`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-auth-token': info.token },
+        body: JSON.stringify({ mode: 'amplifier', cwd: '/tmp', resumeSessionId: 'amp-legacy-reject-0001', name: 'legacy-reject-case' }),
+      })
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body).toEqual({
+        status: 'error',
+        message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+      })
+      const after = await (await fetch(`${info.baseUrl}/api/tabs`, { headers: { 'x-auth-token': info.token } })).json()
+      expect(after).toEqual(before) // no tab/terminal side effects on reject
+    } finally {
+      await server.stop()
     }
   })
 })

--- a/test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts
+++ b/test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts
@@ -340,10 +340,10 @@ test.describe.serial('P1.14 sidebar registry sync (rust)', () => {
         // create_codex_tab_rejects_raw_resume_session_id_without_session_ref);
         // the canonical sessionRef shape IS accepted (pinned by
         // create_codex_tab_accepts_session_ref_and_derives_resume_args). Do NOT
-        // "fix" the rejection -- use the canonical shape for codex.
-        data: mode === 'codex'
-          ? { mode, cwd: PROJECT_DIR, sessionRef: { provider: 'codex', sessionId } }
-          : { mode, cwd: PROJECT_DIR, resumeSessionId: sessionId },
+        // "fix" the rejection -- use the canonical shape. kata ejh6: claude
+        // rides sessionRef too -- sessionRef is the canonical resume carrier
+        // for EVERY mode.
+        data: { mode, cwd: PROJECT_DIR, sessionRef: { provider: mode, sessionId } },
       })
       expect(res.ok(), `POST /api/tabs ${mode} resume: ${res.status()} ${await res.text()}`).toBe(true)
 
@@ -420,10 +420,10 @@ test.describe.serial('P1.14 sidebar registry sync (rust)', () => {
         // create_codex_tab_rejects_raw_resume_session_id_without_session_ref);
         // the canonical sessionRef shape IS accepted (pinned by
         // create_codex_tab_accepts_session_ref_and_derives_resume_args). Do NOT
-        // "fix" the rejection -- use the canonical shape for codex.
-        data: mode === 'codex'
-          ? { mode, cwd: PROJECT_DIR, sessionRef: { provider: 'codex', sessionId } }
-          : { mode, cwd: PROJECT_DIR, resumeSessionId: sessionId },
+        // "fix" the rejection -- use the canonical shape. kata ejh6: claude
+        // rides sessionRef too -- sessionRef is the canonical resume carrier
+        // for EVERY mode.
+        data: { mode, cwd: PROJECT_DIR, sessionRef: { provider: mode, sessionId } },
       })
       expect(res.ok(), `POST /api/tabs ${mode} resume: ${res.status()} ${await res.text()}`).toBe(true)
       await expect(page.locator(`[data-session-id="${sessionId}"][data-provider="${mode}"]`))
@@ -615,7 +615,7 @@ test.describe.serial('P1.14 sidebar registry sync (rust)', () => {
     // Open a claude resume pane so there is something to lose + recover.
     const res = await page.request.post(`${info.baseUrl}/api/tabs`, {
       headers: { 'x-auth-token': info.token, 'content-type': 'application/json' },
-      data: { mode: 'claude', cwd: PROJECT_DIR, resumeSessionId: SEEDED_CLAUDE_ID },
+      data: { mode: 'claude', cwd: PROJECT_DIR, sessionRef: { provider: 'claude', sessionId: SEEDED_CLAUDE_ID } },
     })
     expect(res.ok()).toBe(true)
     const restTabId: string = (await res.json())?.data?.tabId

--- a/test/e2e/agent-cli-flow.test.ts
+++ b/test/e2e/agent-cli-flow.test.ts
@@ -8,6 +8,10 @@ import http from 'http'
 import { createAgentApiRouter } from '../../server/agent-api/router'
 import { LayoutStore } from '../../server/agent-api/layout-store'
 import { FakeCodexLaunchPlanner } from '../helpers/coding-cli/fake-codex-launch-planner.js'
+import WebSocket from 'ws'
+import { WsHandler } from '../../server/ws-handler.js'
+import { TerminalRegistry } from '../../server/terminal-registry.js'
+import { WS_PROTOCOL_VERSION } from '../../shared/ws-protocol.js'
 
 function startTestServer(
   layoutStoreOverrides: Partial<Record<string, any>> = {},
@@ -148,6 +152,64 @@ function findPaneContent(node: any, paneId: string): any | undefined {
 }
 
 describe('cli e2e flow', () => {
+  // ejh6: the WS door rejects a raw legacy `resumeSessionId` carry on
+  // terminal.create with INVALID_MESSAGE + the frozen text. This reuses the
+  // existing WsHandler + http.createServer infrastructure (not a new harness).
+  it('rejects a raw legacy WS terminal.create with INVALID_MESSAGE + frozen text', async () => {
+    const previousAuthToken = process.env.AUTH_TOKEN
+    process.env.AUTH_TOKEN = 'test-token'
+    const layoutStore = new LayoutStore()
+    const app = express()
+    app.use(express.json())
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    let terminalCount = 0
+    app.use('/api', createAgentApiRouter({
+      layoutStore,
+      registry: { create: () => ({ terminalId: `term_${++terminalCount}` }), get: () => undefined, input: () => {} },
+      codexLaunchPlanner,
+    }))
+    const server = http.createServer(app)
+    const registry = new TerminalRegistry()
+    const handler = new WsHandler(server, registry, { codexLaunchPlanner } as never)
+    await new Promise<void>((resolve) => server.listen(0, () => resolve()))
+    const { port } = server.address() as { port: number }
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    try {
+      await new Promise<void>((resolve, reject) => {
+        ws.on('open', () => {
+          ws.send(JSON.stringify({ type: 'hello', token: 'test-token', protocolVersion: WS_PROTOCOL_VERSION }))
+        })
+        ws.on('message', (data) => {
+          const msg = JSON.parse(data.toString())
+          if (msg.type === 'ready') resolve()
+        })
+        ws.on('error', reject)
+      })
+      const requestId = 'raw-legacy-ws-1'
+      const errorPromise = new Promise<any>((resolve) => {
+        ws.on('message', (data) => {
+          const msg = JSON.parse(data.toString())
+          if (msg.type === 'error' && msg.requestId === requestId) resolve(msg)
+        })
+      })
+      ws.send(JSON.stringify({
+        type: 'terminal.create', requestId, mode: 'claude', shell: 'system',
+        resumeSessionId: 'legacy-ws-id',
+      }))
+      const error = await errorPromise
+      expect(error).toMatchObject({
+        type: 'error', code: 'INVALID_MESSAGE',
+        message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+        requestId,
+      })
+    } finally {
+      ws.close()
+      handler.close?.()
+      process.env.AUTH_TOKEN = previousAuthToken
+      await new Promise<void>((done) => server.close(() => done()))
+    }
+  })
+
   it('runs list-tabs end-to-end', async () => {
     const { url, close } = await startTestServer()
     try {

--- a/test/e2e/agent-cli-flow.test.ts
+++ b/test/e2e/agent-cli-flow.test.ts
@@ -205,7 +205,11 @@ describe('cli e2e flow', () => {
     } finally {
       ws.close()
       handler.close?.()
-      process.env.AUTH_TOKEN = previousAuthToken
+      if (previousAuthToken === undefined) {
+        delete process.env.AUTH_TOKEN
+      } else {
+        process.env.AUTH_TOKEN = previousAuthToken
+      }
       await new Promise<void>((done) => server.close(() => done()))
     }
   })

--- a/test/integration/server/opencode-session-flow.test.ts
+++ b/test/integration/server/opencode-session-flow.test.ts
@@ -381,6 +381,38 @@ describe('opencode session flow (integration)', () => {
     }
   })
 
+  it('rejects the legacy raw resumeSessionId field for opencode non-restore creates', async () => {
+    const ws = await createAuthenticatedWs(port)
+
+    try {
+      const requestId = 'opencode-non-restore-legacy'
+      ws.send(JSON.stringify({
+        type: 'terminal.create',
+        requestId,
+        mode: 'opencode',
+        resumeSessionId: 'probe-non-restore',
+      }))
+
+      const response = await waitForMessage(
+        ws,
+        (msg) => (
+          msg.requestId === requestId
+          && (msg.type === 'terminal.created' || msg.type === 'error')
+        ),
+      )
+
+      expect(response).toMatchObject({
+        type: 'error',
+        code: 'INVALID_MESSAGE',
+      })
+      expect(response.message).toContain('sessionRef')
+      expect(registry.createCallCount).toBe(0)
+      expect(registry.records.size).toBe(0)
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
   it('uses the canonical durable opencode session id when restore is explicit', async () => {
     const ws = await createAuthenticatedWs(port)
 

--- a/test/server/agent-panes-write.test.ts
+++ b/test/server/agent-panes-write.test.ts
@@ -129,7 +129,11 @@ it('kills the created Codex terminal when split adoption fails after registry.cr
   expect(attachPaneContent).not.toHaveBeenCalled()
 })
 
-it('rejects raw Codex resume ids before splitting a pane', async () => {
+// ejh6: uniform any-carry, presence-based rejection on all modes (incl. "", null, 42).
+it.each(
+  ['claude', 'codex', 'opencode', 'amplifier'].flatMap((mode) =>
+    (['legacy-x', '', null, 42] as const).map((value) => [mode, value] as const)),
+)('rejects legacy resumeSessionId presence (mode %s, value %j) before splitting a pane', async (mode, resumeSessionId) => {
   const app = express()
   app.use(express.json())
   const splitPane = vi.fn(() => ({ newPaneId: 'pane_new', tabId: 'tab_1' }))
@@ -144,10 +148,11 @@ it('rejects raw Codex resume ids before splitting a pane', async () => {
 
   const res = await request(app).post('/api/panes/pane_1/split').send({
     direction: 'horizontal',
-    mode: 'codex',
-    resumeSessionId: 'thread-raw-split',
+    mode,
+    resumeSessionId,
   })
 
+  // Layout unchanged: rejection happens at the door-top, before any split.
   expect(res.status).toBe(400)
   expect(res.body).toEqual({
     status: 'error',
@@ -309,7 +314,12 @@ it('kills the created Codex terminal when respawn adoption fails after registry.
   expect(attachPaneContent).not.toHaveBeenCalled()
 })
 
-it('rejects raw Codex resume ids before respawning a pane', async () => {
+// ejh6: uniform any-carry, presence-based rejection on all modes (incl. "", null, 42).
+// Finding 7: the door-top guard returns BEFORE target resolution.
+it.each(
+  ['claude', 'codex', 'opencode', 'amplifier'].flatMap((mode) =>
+    (['legacy-x', '', null, 42] as const).map((value) => [mode, value] as const)),
+)('rejects legacy resumeSessionId presence (mode %s, value %j) before respawning a pane', async (mode, resumeSessionId) => {
   const app = express()
   app.use(express.json())
   const attachPaneContent = vi.fn()
@@ -326,8 +336,8 @@ it('rejects raw Codex resume ids before respawning a pane', async () => {
   }))
 
   const res = await request(app).post('/api/panes/pane_1/respawn').send({
-    mode: 'codex',
-    resumeSessionId: 'thread-raw-respawn',
+    mode,
+    resumeSessionId,
   })
 
   expect(res.status).toBe(400)
@@ -336,7 +346,8 @@ it('rejects raw Codex resume ids before respawning a pane', async () => {
     message: INVALID_RAW_CODEX_RESUME_MESSAGE,
   })
   expect(codexLaunchPlanner.planCreateCalls).toEqual([])
-  expect(resolveTarget).toHaveBeenCalledWith('pane_1')
+  // Finding 7: door-top rejection returns BEFORE target resolution.
+  expect(resolveTarget).not.toHaveBeenCalled()
   expect(registryCreate).not.toHaveBeenCalled()
   expect(attachPaneContent).not.toHaveBeenCalled()
 })

--- a/test/server/agent-tabs-write.test.ts
+++ b/test/server/agent-tabs-write.test.ts
@@ -448,6 +448,66 @@ describe('tab endpoints', () => {
     expect(layoutStore.attachPaneContent).not.toHaveBeenCalled()
   })
 
+  it.each(['claude', 'opencode', 'amplifier'])('rejects legacy resumeSessionId on mode %s with 400', async (mode) => {
+    const app = express()
+    app.use(express.json())
+    const registry = { create: vi.fn(), killAndWait: vi.fn(async () => true) }
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    const layoutStore = {
+      createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })),
+      attachPaneContent: vi.fn(),
+      selectTab: () => ({}), renameTab: () => ({}), closeTab: () => ({}), hasTab: () => true,
+      selectNextTab: () => ({ tabId: 'tab_1' }), selectPrevTab: () => ({ tabId: 'tab_1' }),
+    }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry, codexLaunchPlanner }))
+    const res = await request(app).post('/api/tabs').send({ mode, name: `legacy ${mode}`, resumeSessionId: `legacy-${mode}-id` })
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({ status: 'error', message: INVALID_RAW_CODEX_RESUME_MESSAGE })
+    expect(registry.create).not.toHaveBeenCalled()
+    expect(layoutStore.createTab).not.toHaveBeenCalled()
+  })
+
+  it('rejects legacy resumeSessionId even with a companion sessionRef', async () => {
+    const app = express()
+    app.use(express.json())
+    const registry = { create: vi.fn(), killAndWait: vi.fn(async () => true) }
+    const codexLaunchPlanner = new FakeCodexLaunchPlanner()
+    const layoutStore = { createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })), attachPaneContent: vi.fn(), selectTab: () => ({}), renameTab: () => ({}), closeTab: () => ({}), hasTab: () => true, selectNextTab: () => ({ tabId: 'tab_1' }), selectPrevTab: () => ({ tabId: 'tab_1' }) }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry, codexLaunchPlanner }))
+    const res = await request(app).post('/api/tabs').send({ mode: 'claude', resumeSessionId: 'legacy', sessionRef: { provider: 'claude', sessionId: 'canonical' } })
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({ status: 'error', message: INVALID_RAW_CODEX_RESUME_MESSAGE })
+  })
+
+  // ejh6 finding 2: presence-based — "", null, 42 are all rejected.
+  it.each([
+    ['empty-string', ''],
+    ['null', null],
+    ['number', 42],
+  ])('rejects resumeSessionId presence (%s)', async (_label, val) => {
+    const app = express()
+    app.use(express.json())
+    const layoutStore = { createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })), attachPaneContent: vi.fn(), selectTab: () => ({}), renameTab: () => ({}), closeTab: () => ({}), hasTab: () => true, selectNextTab: () => ({ tabId: 'tab_1' }), selectPrevTab: () => ({ tabId: 'tab_1' }) }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry: { create: vi.fn() }, codexLaunchPlanner: new FakeCodexLaunchPlanner() }))
+    const res = await request(app).post('/api/tabs').send({ mode: 'claude', resumeSessionId: val })
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({ status: 'error', message: INVALID_RAW_CODEX_RESUME_MESSAGE })
+  })
+
+  // ejh6 finding 3: browser/editor branches also 400.
+  it.each([
+    ['browser', { browser: 'https://example.com' }],
+    ['editor', { editor: '/tmp/file.ts' }],
+  ])('rejects resumeSessionId on %s branch', async (_label, extra) => {
+    const app = express()
+    app.use(express.json())
+    const layoutStore = { createTab: vi.fn(() => ({ tabId: 'tab_1', paneId: 'pane_1' })), attachPaneContent: vi.fn(), selectTab: () => ({}), renameTab: () => ({}), closeTab: () => ({}), hasTab: () => true, selectNextTab: () => ({ tabId: 'tab_1' }), selectPrevTab: () => ({ tabId: 'tab_1' }) }
+    app.use('/api', createAgentApiRouter({ layoutStore, registry: { create: vi.fn() }, codexLaunchPlanner: new FakeCodexLaunchPlanner() }))
+    const res = await request(app).post('/api/tabs').send({ resumeSessionId: 'legacy', ...extra })
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({ status: 'error', message: INVALID_RAW_CODEX_RESUME_MESSAGE })
+  })
+
   it('uses canonical Codex sessionRef as the durable resume path', async () => {
     const app = express()
     app.use(express.json())

--- a/test/server/ws-coding-cli-events.test.ts
+++ b/test/server/ws-coding-cli-events.test.ts
@@ -305,6 +305,133 @@ describe('WebSocket Coding CLI Events', () => {
     ws.close()
   })
 
+  // ejh6 Task 11 (finding 9: presence on this door too): it.each over string + empty-string.
+  // Finding 10a + review round 3 finding 5: no spawn on reject, with createMock
+  // DECLARED here and the same mid-test wsHandler swap the promote test uses
+  // (never instantiate a real coding-cli manager/provider, V4).
+  it.each([['string', 'legacy-cli-id'], ['empty-string', '']])(
+    'rejects codingcli.create resumeSessionId (%s) with INVALID_MESSAGE + frozen text and no spawn', async (_label, legacy) => {
+      const createMock = vi.fn()
+      class FakeSession extends EventEmitter {
+        id = 'cli-session-reject'
+        provider = { name: 'claude' }
+      }
+      const fakeManager = {
+        create: (...args: any[]) => { createMock(...args); return new FakeSession() },
+        hasProvider: (name: string) => name === 'claude',
+        get: vi.fn(),
+        remove: vi.fn(),
+      } as unknown as CodingCliSessionManager
+      wsHandler.close()
+      wsHandler = new WsHandler(server, registry, { codingCliManager: fakeManager })
+
+      const ws = await createAuthenticatedWs()
+      const requestId = `cli-legacy-reject-${_label}`
+      const errorPromise = new Promise<any>((resolve) => {
+        ws.on('message', (data) => {
+          const msg = JSON.parse(data.toString())
+          if (msg.type === 'error' && msg.requestId === requestId) resolve(msg)
+        })
+      })
+      ws.send(JSON.stringify({
+        type: 'codingcli.create', requestId, provider: 'claude', prompt: 'hi',
+        resumeSessionId: legacy,
+      }))
+      const error = await errorPromise
+      expect(error).toMatchObject({
+        type: 'error', code: 'INVALID_MESSAGE',
+        message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+        requestId,
+      })
+      expect(createMock).not.toHaveBeenCalled() // no spawn on reject
+      ws.close()
+    },
+  )
+
+  it('promotes a provider-matched sessionRef into the spawn-time resume id for codingcli.create', async () => {
+    // V4: NEVER instantiate a real CodingCliSessionManager + real claudeProvider —
+    // use the file's established fake-manager pattern (:247-258). The promoted id
+    // is observable at the manager boundary as `options.resumeSessionId`
+    // (session-manager forwards options verbatim into new CodingCliSession).
+    const createMock = vi.fn()
+    class FakeSession extends EventEmitter {
+      id = 'cli-session-1'
+      provider = { name: 'claude' }
+    }
+    const fakeManager = {
+      create: (...args: any[]) => { createMock(...args); return new FakeSession() },
+      hasProvider: (name: string) => name === 'claude',
+      get: vi.fn(),
+      remove: vi.fn(),
+    } as unknown as CodingCliSessionManager
+
+    // Mid-test WsHandler swap is VALID (V4 leg i): wsHandler.close() removes the
+    // upgrade listener from the shared http.Server, so the new WsHandler is the
+    // ONLY upgrade handler — no double-processing. Established pattern (:257-258).
+    wsHandler.close()
+    wsHandler = new WsHandler(server, registry, { codingCliManager: fakeManager })
+    vi.mocked(configStore.snapshot).mockResolvedValueOnce({
+      settings: { codingCli: { enabledProviders: ['claude'], providers: {} } },
+    } as any)
+
+    const ws = await createAuthenticatedWs()
+    const requestId = 'cli-sref-promote-1'
+    const createdPromise = new Promise<void>((resolve) => {
+      ws.on('message', (data) => {
+        const msg = JSON.parse(data.toString())
+        if (msg.type === 'codingcli.created') resolve()
+      })
+    })
+    ws.send(JSON.stringify({
+      type: 'codingcli.create', requestId, provider: 'claude', prompt: 'hi',
+      sessionRef: { provider: 'claude', sessionId: 'canonical-cli-session' },
+    }))
+    await createdPromise
+    // V4: the assertion is the fake-manager create spy — the promoted id is
+    // options.resumeSessionId at the manager boundary. Mirrors :295-303.
+    expect(createMock).toHaveBeenCalledWith('claude', expect.objectContaining({
+      resumeSessionId: 'canonical-cli-session',
+    }))
+    ws.close()
+  })
+
+  it('does NOT promote a provider-mismatched sessionRef into the spawn-time resume id', async () => {
+    // Review round 2 finding 10b: a sessionRef whose provider ≠ m.provider is
+    // NOT promoted — the spawn proceeds without a resume id. Same fake-manager
+    // wsHandler swap as the promote test above.
+    const createMock = vi.fn()
+    class FakeSession extends EventEmitter {
+      id = 'cli-session-2'
+      provider = { name: 'claude' }
+    }
+    const fakeManager = {
+      create: (...args: any[]) => { createMock(...args); return new FakeSession() },
+      hasProvider: (name: string) => name === 'claude',
+      get: vi.fn(),
+      remove: vi.fn(),
+    } as unknown as CodingCliSessionManager
+    wsHandler.close()
+    wsHandler = new WsHandler(server, registry, { codingCliManager: fakeManager })
+
+    const ws = await createAuthenticatedWs()
+    const requestId = 'cli-sref-mismatch-1'
+    const createdPromise = new Promise<void>((resolve) => {
+      ws.on('message', (data) => {
+        const msg = JSON.parse(data.toString())
+        if (msg.type === 'codingcli.created') resolve()
+      })
+    })
+    ws.send(JSON.stringify({
+      type: 'codingcli.create', requestId, provider: 'claude', prompt: 'hi',
+      sessionRef: { provider: 'codex', sessionId: 'wrong-provider-session' },
+    }))
+    await createdPromise
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const spawnOptions = createMock.mock.calls[0][1]
+    expect(spawnOptions.resumeSessionId).toBeUndefined()
+    ws.close()
+  })
+
   it('detaches coding cli listeners on socket close', async () => {
     const fakeSession = Object.assign(new EventEmitter(), {
       id: 'fake-session-1',

--- a/test/server/ws-protocol.test.ts
+++ b/test/server/ws-protocol.test.ts
@@ -1744,6 +1744,36 @@ describe('ws protocol', () => {
     expect(result.code).toBe(4001)
   })
 
+  // ejh6 delta-review minor (Fix A): the raw pre-parse resumeSessionId guard is
+  // gated on authentication — a pre-hello create-class frame carrying the legacy
+  // field must fall through to the NOT_AUTHENTICATED gate (error + close 4001),
+  // never the legacy-field reject envelopes (INVALID_MESSAGE /
+  // freshAgent.create.failed).
+  it.each([
+    ['terminal.create', { type: 'terminal.create', requestId: 'pre-hello-legacy-term', mode: 'shell', resumeSessionId: 'legacy-thread' }],
+    ['freshAgent.create', { type: 'freshAgent.create', requestId: 'pre-hello-legacy-fa', sessionType: 'freshcodex', provider: 'codex', cwd: '/tmp', resumeSessionId: 'legacy-thread' }],
+  ])('pre-hello %s carrying resumeSessionId gets NOT_AUTHENTICATED + close 4001, not the legacy-field reject', async (_label, frame) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+
+    const firstResponsePromise = new Promise<any>((resolve) => {
+      ws.on('message', (data) => resolve(JSON.parse(data.toString())))
+    })
+    ws.send(JSON.stringify(frame))
+
+    const firstResponse = await firstResponsePromise
+    expect(firstResponse).toMatchObject({
+      type: 'error',
+      code: 'NOT_AUTHENTICATED',
+      message: 'Send hello first',
+    })
+
+    const closeCode = await new Promise<number>((resolve) => {
+      ws.on('close', (code) => resolve(code))
+    })
+    expect(closeCode).toBe(4001)
+  })
+
   it('connection timeout on no hello', async () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
     await new Promise<void>((resolve) => ws.on('open', () => resolve()))

--- a/test/server/ws-terminal-create-reuse-running-codex.test.ts
+++ b/test/server/ws-terminal-create-reuse-running-codex.test.ts
@@ -659,6 +659,99 @@ describe('terminal.create reuse running codex terminal', () => {
     }
   })
 
+  it.each([
+    ['claude', true], ['claude', false], ['claude', undefined],
+    ['opencode', true], ['opencode', false], ['amplifier', true],
+  ] as const)('rejects legacy resumeSessionId on mode %s restore=%s', async (mode, restore) => {
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
+    try {
+      await waitForOpen(ws)
+      await waitForReady(ws)
+      const requestId = `legacy-reject-${mode}-${restore}`
+      const errorPromise = waitForMessage(ws, (m) => m.type === 'error' && m.requestId === requestId)
+      ws.send(JSON.stringify({
+        type: 'terminal.create', requestId, mode,
+        ...(restore === undefined ? {} : { restore }),
+        resumeSessionId: `legacy-${mode}-id`,
+      }))
+      const error = await errorPromise
+      expect(error).toMatchObject({
+        type: 'error', code: 'INVALID_MESSAGE',
+        message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+        requestId,
+      })
+      expect(codexLaunchPlanner.planCreateCalls).toHaveLength(0)
+      expect(registry.createCalls).toHaveLength(0)
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
+  // ejh6 finding 2: presence-based — "" is rejected.
+  it('rejects resumeSessionId empty string on terminal.create', async () => {
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
+    try {
+      await waitForOpen(ws)
+      await waitForReady(ws)
+      const requestId = 'legacy-reject-empty'
+      const errorPromise = waitForMessage(ws, (m) => m.type === 'error' && m.requestId === requestId)
+      ws.send(JSON.stringify({ type: 'terminal.create', requestId, mode: 'claude', shell: 'system', resumeSessionId: '' }))
+      const error = await errorPromise
+      expect(error).toMatchObject({ type: 'error', code: 'INVALID_MESSAGE', requestId })
+      expect(error.message).toContain('sessionRef')
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
+  // ejh6 finding 5: a message carrying BOTH recoveryIntent and resumeSessionId
+  // gets INVALID_MESSAGE with frozen text (the mandatory error wins over
+  // INVALID_CREATE_REQUEST's "Fresh recovery requests cannot include restore identity").
+  it('rejects resumeSessionId even when recoveryIntent is also present', async () => {
+    const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
+    try {
+      await waitForOpen(ws)
+      await waitForReady(ws)
+      const requestId = 'legacy-reject-dual-intent'
+      const errorPromise = waitForMessage(ws, (m) => m.type === 'error' && m.requestId === requestId)
+      ws.send(JSON.stringify({
+        type: 'terminal.create', requestId, mode: 'claude', shell: 'system',
+        recoveryIntent: 'fresh_after_restore_unavailable', resumeSessionId: 'legacy',
+      }))
+      const error = await errorPromise
+      expect(error).toMatchObject({ type: 'error', code: 'INVALID_MESSAGE', requestId })
+      expect(error.message).toBe('Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.')
+    } finally {
+      await closeWebSocket(ws)
+    }
+  })
+
+  // ejh6 review round 3 finding 1: the raw pre-parse guard intercepts ANY
+  // JSON value with key-presence BEFORE zod ever runs — non-string carries
+  // get the SAME INVALID_MESSAGE + frozen-text envelope as strings on Node
+  // (no generic-text residual). Every value pinned with frozen text.
+  it.each([['null', null], ['number', 42], ['object', { nested: true }]])(
+    'rejects non-string resumeSessionId (%s) with INVALID_MESSAGE + frozen text (raw guard)', async (_label, val) => {
+      const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
+      try {
+        await waitForOpen(ws)
+        await waitForReady(ws)
+        const requestId = `legacy-reject-nonstr-${_label}`
+        const errorPromise = waitForMessage(ws, (m) => m.type === 'error' && m.requestId === requestId)
+        ws.send(JSON.stringify({ type: 'terminal.create', requestId, mode: 'claude', shell: 'system', resumeSessionId: val }))
+        const error = await errorPromise
+        expect(error).toMatchObject({
+          type: 'error', code: 'INVALID_MESSAGE',
+          message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+          requestId,
+        })
+        expect(registry.createCalls).toHaveLength(0)
+      } finally {
+        await closeWebSocket(ws)
+      }
+    },
+  )
+
   it('existingId branch returns created only and requires explicit attach', async () => {
     const ws = trackWebSocket(new WebSocket(`ws://127.0.0.1:${port}/ws`))
     try {

--- a/test/server/ws-terminal-create-session-repair.test.ts
+++ b/test/server/ws-terminal-create-session-repair.test.ts
@@ -1045,7 +1045,10 @@ describe('terminal.create session repair wait', () => {
     }
   })
 
-  it('uses sessionRef as canonical restore identity over legacy resumeSessionId', async () => {
+  // ejh6: presence-based rejection — a terminal.create carrying the legacy
+  // resumeSessionId field is rejected even when a canonical sessionRef is
+  // also present (no dual-carrier tolerance on the WS door).
+  it('rejects a legacy resumeSessionId even when sessionRef is also present', async () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
 
     try {
@@ -1053,7 +1056,7 @@ describe('terminal.create session repair wait', () => {
       await waitForReady(ws)
 
       const requestId = 'resume-session-ref-wins'
-      const createdPromise = waitForCreated(ws, requestId)
+      const responsePromise = waitForMessage(ws, (m) => m.type === 'error' && m.requestId === requestId)
       ws.send(JSON.stringify({
         type: 'terminal.create',
         requestId,
@@ -1065,11 +1068,11 @@ describe('terminal.create session repair wait', () => {
         },
       }))
 
-      await createdPromise
-
-      expect(registry.lastCreateOpts?.resumeSessionId).toBe(VALID_SESSION_ID)
-      expect(sessionRepairService.waitForSessionCalls).toContain(VALID_SESSION_ID)
-      expect(sessionRepairService.waitForSessionCalls).not.toContain('legacy_wrong_session')
+      const response = await responsePromise
+      expect(response).toMatchObject({
+        type: 'error', code: 'INVALID_MESSAGE',
+        message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+      })
     } finally {
       await closeWebSocket(ws)
     }

--- a/test/unit/client/lib/pane-reconcile.fresh-agent.test.ts
+++ b/test/unit/client/lib/pane-reconcile.fresh-agent.test.ts
@@ -209,6 +209,35 @@ describe('buildReconcileRequest with fresh-agent panes', () => {
     const req = buildReconcileRequest(asRootState(panes), { includeFreshAgent: true })
     expect(req).toBeNull()
   })
+
+  it('promotes a legacy-only fresh-agent pane resumeSessionId into a canonical sessionRef on the reconcile claim', () => {
+    // Built by hand (same precedent as the createRequestId-less pane above):
+    // initLayout → normalizePaneContent runs the store's own legacy migration,
+    // which consumes a claude resumeSessionId into either a sessionRef or a
+    // restoreError — so the route-through-the-reducer helper can never produce
+    // the legacy-ONLY content this promotion guards (old persisted pane
+    // content carrying resumeSessionId without a sessionRef, kata ejh6 §2).
+    const panes = emptyPanesState()
+    panes.layouts['tab_1'] = {
+      type: 'leaf',
+      id: 'pane_1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshclaude',
+        provider: 'claude',
+        createRequestId: 'req-fa-1',
+        status: 'connected',
+        resumeSessionId: 'legacy-fa-session-id',
+      } as FreshAgentPaneContent,
+    }
+
+    const req = buildReconcileRequest(asRootState(panes), { includeFreshAgent: true })
+    expect(req).not.toBeNull()
+    const pane = req!.panes.find((p) => p.kind === 'fresh-agent')
+    expect(pane).toBeDefined()
+    expect(pane!.sessionRef).toEqual({ provider: 'claude', sessionId: 'legacy-fa-session-id' })
+    expect(pane!.resumeSessionId).toBeUndefined()
+  })
 })
 
 describe('buildReconcileRequestForPanes is kind-agnostic', () => {

--- a/test/unit/client/lib/pane-reconcile.test.ts
+++ b/test/unit/client/lib/pane-reconcile.test.ts
@@ -188,6 +188,35 @@ describe('buildReconcileRequest', () => {
     expect(req.panes).toHaveLength(200)
     expect(errorSpy).toHaveBeenCalled()
   })
+
+  it('promotes a legacy-only terminal pane resumeSessionId into a canonical sessionRef on the reconcile claim', () => {
+    let state = emptyPanesState()
+    state = addTerminalPane(state, 'tab_1', 'pane_1', {
+      mode: 'claude', createRequestId: 'req-1',
+      resumeSessionId: 'legacy-claude-session-id',
+    } as Partial<TerminalPaneContent>)
+
+    const req = buildReconcileRequest(asRootState(state))
+    expect(req).not.toBeNull()
+    const pane = req!.panes[0]
+    expect(pane.sessionRef).toEqual({ provider: 'claude', sessionId: 'legacy-claude-session-id' })
+    expect(pane.resumeSessionId).toBeUndefined()
+  })
+
+  it('never promotes a shell-mode legacy resumeSessionId (a stateless shell has no durable identity)', () => {
+    let state = emptyPanesState()
+    state = addTerminalPane(state, 'tab_1', 'pane_1', {
+      mode: 'shell', createRequestId: 'req-sh-1',
+      resumeSessionId: 'legacy-shell-id',
+    } as Partial<TerminalPaneContent>)
+
+    const req = buildReconcileRequest(asRootState(state))
+    expect(req).not.toBeNull()
+    const pane = req!.panes.find((p) => p.createRequestId === 'req-sh-1')
+    expect(pane).toBeDefined()
+    expect(pane!.sessionRef).toBeUndefined()
+    expect(pane!.resumeSessionId).toBeUndefined()
+  })
 })
 
 describe('buildReconcileRequestForPanes', () => {

--- a/test/unit/server/ws-handler-fresh-agent-lifecycle-parity.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent-lifecycle-parity.test.ts
@@ -95,7 +95,7 @@ describe('WsHandler fresh-agent lifecycle parity', () => {
         sessionType: 'freshclaude',
         provider: 'claude',
         cwd: '/repo',
-        resumeSessionId: 'cli-session-parity',
+        sessionRef: { provider: 'claude', sessionId: 'cli-session-parity' },
         model: 'claude-sonnet-4-6',
         modelSelection: { kind: 'fixed', modelId: 'claude-sonnet-4-6' },
         permissionMode: 'acceptEdits',
@@ -109,7 +109,7 @@ describe('WsHandler fresh-agent lifecycle parity', () => {
           sessionType: 'freshclaude',
           provider: 'claude',
           cwd: '/repo',
-          resumeSessionId: 'cli-session-parity',
+          sessionRef: { provider: 'claude', sessionId: 'cli-session-parity' },
           model: 'claude-sonnet-4-6',
           modelSelection: { kind: 'fixed', modelId: 'claude-sonnet-4-6' },
           permissionMode: 'acceptEdits',
@@ -198,7 +198,7 @@ describe('WsHandler fresh-agent lifecycle parity', () => {
         requestId: 'req-gated-create',
         sessionType: 'freshclaude',
         provider: 'claude',
-        resumeSessionId: 'cli-existing',
+        sessionRef: { provider: 'claude', sessionId: 'cli-existing' },
       }))
 
       await vi.waitFor(() => {
@@ -245,7 +245,7 @@ describe('WsHandler fresh-agent lifecycle parity', () => {
         sessionId: 'claude-session-missing',
         sessionType: 'freshclaude',
         provider: 'claude',
-        resumeSessionId: 'cli-missing',
+        sessionRef: { provider: 'claude', sessionId: 'cli-missing' },
       }))
 
       await vi.waitFor(() => {

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -956,7 +956,7 @@ describe('WsHandler fresh-agent routing', () => {
         sessionId: 'claude-session-attached',
         sessionType: 'freshclaude',
         provider: 'claude',
-        resumeSessionId: 'cli-session-attached',
+        sessionRef: { provider: 'claude', sessionId: 'cli-session-attached' },
         cwd: '/repo/restored-worktree',
       }))
 
@@ -965,6 +965,7 @@ describe('WsHandler fresh-agent routing', () => {
           sessionId: 'claude-session-attached',
           sessionType: 'freshclaude',
           provider: 'claude',
+          sessionRef: { provider: 'claude', sessionId: 'cli-session-attached' },
           cwd: '/repo/restored-worktree',
         })
         expect(runtimeManager.subscribe).toHaveBeenCalledWith(

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -1441,4 +1441,82 @@ describe('WsHandler fresh-agent routing', () => {
       await new Promise<void>((resolve) => server.close(() => resolve()))
     }
   })
+
+  it('rejects freshAgent.create carrying resumeSessionId with freshAgent.create.failed', async () => {
+    const runtimeManager = {
+      create: vi.fn(),
+      subscribe: vi.fn().mockResolvedValue(() => undefined),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+    try {
+      const ws = await connectAndAuth(server)
+      const seenMessages: any[] = []
+      ws.on('message', (data) => {
+        seenMessages.push(JSON.parse(data.toString()))
+      })
+
+      for (const [index, legacy] of ['legacy-durable-id', ''].entries()) {
+        const requestId = `req-fa-legacy-create-${index}`
+        ws.send(JSON.stringify({
+          type: 'freshAgent.create', requestId,
+          sessionType: 'freshclaude', provider: 'claude', cwd: '/tmp',
+          resumeSessionId: legacy,
+        }))
+        await vi.waitFor(() => {
+          expect(seenMessages.some((m) => m.type === 'freshAgent.create.failed' && m.requestId === requestId)).toBe(true)
+        }, { timeout: 5000 })
+        const failed = seenMessages.find((m) => m.type === 'freshAgent.create.failed' && m.requestId === requestId)
+        expect(failed).toMatchObject({
+          type: 'freshAgent.create.failed', requestId,
+          code: 'FRESH_AGENT_CREATE_FAILED',
+          message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+          retryable: false,
+        })
+      }
+      expect(runtimeManager.create).not.toHaveBeenCalled()
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('rejects freshAgent.attach carrying resumeSessionId with error{FRESH_AGENT_CREATE_FAILED}', async () => {
+    const runtimeManager = {
+      attach: vi.fn(),
+      subscribe: vi.fn().mockResolvedValue(() => undefined),
+    }
+    const { server, registry, handler } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+    try {
+      const ws = await connectAndAuth(server)
+      const seenMessages: any[] = []
+      ws.on('message', (data) => {
+        seenMessages.push(JSON.parse(data.toString()))
+      })
+
+      for (const [index, legacy] of ['legacy-durable-id', ''].entries()) {
+        ws.send(JSON.stringify({
+          type: 'freshAgent.attach',
+          sessionId: `cli-session-legacy-attach-${index}`,
+          sessionType: 'freshclaude', provider: 'claude',
+          resumeSessionId: legacy,
+        }))
+      }
+      await vi.waitFor(() => {
+        expect(seenMessages.filter((m) => m.type === 'error' && m.code === 'FRESH_AGENT_CREATE_FAILED')).toHaveLength(2)
+      }, { timeout: 5000 })
+      const errors = seenMessages.filter((m) => m.type === 'error' && m.code === 'FRESH_AGENT_CREATE_FAILED')
+      for (const error of errors) {
+        expect(error).toMatchObject({
+          type: 'error', code: 'FRESH_AGENT_CREATE_FAILED',
+          message: 'Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity.',
+        })
+      }
+      expect(runtimeManager.attach).not.toHaveBeenCalled()
+    } finally {
+      handler.close()
+      registry.shutdown()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Implements kata ejh6: the legacy `resumeSessionId` wire field is now hard-rejected on every create-class door of BOTH servers, never silently ignored. `sessionRef { provider, sessionId } ` is the sole canonical restore identity.

- **Uniform raw pre-parse presence guard** (Node `server/ws-handler.ts`, Rust `crates/freshell-ws/src/terminal.rs`): any JSON value — string, empty, null, number, object — triggers the identical per-family refusal before typed parsing, so the named text survives every value type.
- **WS doors:** `terminal.create` and `codingcli.create` → `error{INVALID_MESSAGE}` with frozen text "Restore requires sessionRef; resumeSessionId is a legacy field and cannot be used as restore identity."; `freshAgent.create` → `freshAgent.create.failed{FRESH_AGENT_CREATE_FAILED, retryable:false}`; `freshAgent.attach` → family error frame.
- **REST doors:** `POST /api/tabs`, `POST /api/panes/:id/split`, `POST /api/panes/:id/respawn` → HTTP 400 naming sessionRef, checked before any mutation (no side effects on reject), both servers.
- **Schemas/structs retain the field** (+ comments) so old clients still parse; rejection lives in the handlers, not in strict parsing. Wire-sending first-party callers all carry `sessionRef` since PR #648.
- **Permanent, documented sole exception:** `pane.reconcile` keeps server-side legacy promotion forever (old saved layouts) with a mirrored client-side promotion (`src/lib/pane-reconcile.ts`). Shell/empty modes never promote. CLI `--resume` / MCP aliases still work by translating before the wire.
- `codingcli.create` gains `sessionRef` (TS schema + Rust struct parity) and spawn-time provider-matched promotion.

## Test plan

- Coordinated vitest suite (`npm run check`, local backend) and `cargo test --workspace` green at the final commit, excluding four receipted pre-existing flakes (reproduced on the base commit; recorded in the run ledger) and two load flakes observed only when both suites ran concurrently on a freshly rebooted machine (each re-verified passing standalone).
- Door-level rejection tests on both servers for every family and envelope, plus the frozen-text preservation tests; e2e: `test/e2e/agent-cli-flow.test.ts` WS rejection case, and `remote-tab-linkage-rust.spec.ts` re-carriered to `sessionRef` with an added browser rejection proof (runs against the Rust server build via `RUST_ONLY_SPECS`).
- kata §6 sweep: 599 `resumeSessionId` occurrences across 83 files, all in the allowed categories (declared-and-commented schemas/commands, rejection assertions, data-path reads, spec text).

## Review record

Implemented from a plan that survived 3 rounds of independent fresh-eyes review (25 findings, all fixed before code). Execution: 13 tasks, each with its own review (all PASS). Whole-branch review PASS. Delta fresh-eyes review: 3 rounds — fixes at `7ea24ffde`, `11d287869`, `270de7657`, `31dba9da4` — final round PASSED. Full audit trail: `.worktrees/.the-usual-logs/legacy-resume-guard/` and the `.git/worktrees/legacy-resume-guard/usual-sdd/` ledger (git-metadata, intentionally not in the PR).
