### PR TITLE
fix(cloud-test-builds): include mode-preamble fixtures the coordinated suite reads

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,7 +29,18 @@ docs/development/
 installers/
 electron/
 examples/
-port/
+# port/ stays excluded (7.4M oracle corpus belongs to the config-excluded
+# vitest.port.config.ts suites), EXCEPT the tiny 80K fixture dir the
+# coordinated suite's mode-preamble-fixtures test reads. ignore-file syntax
+# note (identical for .dockerignore): to re-include a path under an excluded
+# directory, fence each level with `dir/*` exclusions and `!dir` re-includes
+# — `port/` alone cannot be selectively re-included beneath.
+port/*
+!port/oracle/
+port/oracle/*
+!port/oracle/baselines/
+port/oracle/baselines/*
+!port/oracle/baselines/mode-preamble/
 assets/
 
 # Editor / IDE

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -30,7 +30,18 @@ docs/development/
 installers/
 electron/
 examples/
-port/
+# port/ stays excluded (7.4M oracle corpus belongs to the config-excluded
+# vitest.port.config.ts suites), EXCEPT the tiny 80K fixture dir the
+# coordinated suite's mode-preamble-fixtures test reads. gitignore-syntax
+# note (identical for .gcloudignore): to re-include a path under an excluded
+# directory, fence each level with `dir/*` exclusions and `!dir` re-includes
+# — `port/` alone cannot be selectively re-included beneath.
+port/*
+!port/oracle/
+port/oracle/*
+!port/oracle/baselines/
+port/oracle/baselines/*
+!port/oracle/baselines/mode-preamble/
 assets/
 
 # Editor / IDE


### PR DESCRIPTION
## Summary

The first verified cloud-vitest run (after the image-tag pin) surfaced one real failing test in the cloud image: `test/unit/server/terminal-stream/mode-preamble-fixtures.test.ts` — ENOENT on `port/oracle/baselines/mode-preamble/`, excluded from the image by the wholesale `port/` rule in `.gcloudignore` *and* `.dockerignore`. port/ is 8.1M of oracle corpus that belongs to the config-excluded `vitest.port.config.ts` suites — but this one 80K fixture dir is read by a coordinated-suite test and must ship.

Fence the `port/` exclusion level-by-level (`port/*` + per-level `!` re-includes — gitignore/.gcloudignore/.dockerignore syntax cannot re-include beneath a directory exclusion) so exactly `port/oracle/baselines/mode-preamble/` ships and everything else stays out.

## Test plan

- gitignore-semantics simulation of both ignore files: `port/oracle/baselines/mode-preamble/*` included, all other port paths (t2, machine, etc.) still excluded.
- `gcloud meta list-files-for-upload` on the real tree: upload set contains exactly the 17 mode-preamble fixture files + the pre-existing `!AGENTS.md` carve-out.
- Full cloud vitest run on this branch's pinned image tag (`7e211b7d68d1`): every shard/config passes except one timing-flake on a contended shard (`FreshAgentView` 429-backoff), proven flaky via run-1 pass + solo cloud re-run (727ms), recorded in the local flake journal.
