### PR TITLE
fix(cloud-wrappers): parse bracketed/ANSI execution ids from gcloud execute output

### DIFF
--- a/scripts/e2e-cloud.sh
+++ b/scripts/e2e-cloud.sh
@@ -435,12 +435,16 @@ cmd_run() {
   execute_output=$(gcloud run jobs execute $(gcloud_flags) "$GCP_JOB" --wait 2>&1) || true
   echo "$execute_output"
 
-  # Extract the execution ID from the execute output (format: "Execution NAME")
-  local execution_id
-  # (`|| true`: grep no-match must not kill set -eo pipefail before the
-  # fall-back latest-execution lookup; real gcloud prints "Execution NAME ...",
-  # stubs/minimal CLIs may print nothing.)
-  execution_id=$(echo "$execute_output" | grep -oP 'Execution \K[^ ]+' | head -1 || true)
+  # Extract the execution ID from the execute output. gcloud prints
+  # `Execution [NAME] has successfully completed.` — brackets are literal and,
+  # on color-capable captures, the name is wrapped in ANSI SGR codes — so strip
+  # escapes and allow the bracket form. (A bare `Execution \K[^ ]+` captured the
+  # bracket+escapes; downstream describe/logs then addressed a nonexistent
+  # execution and the `|| echo 0` masking below reported succeeded=0 forever.)
+  execution_id=$(echo "$execute_output" \
+    | sed -E 's/\x1b\[[0-9;]*m//g' \
+    | grep -oP 'Execution \[?\K[A-Za-z0-9][A-Za-z0-9-]*' \
+    | head -1 || true)
   if [ -z "$execution_id" ]; then
     # Fallback: query the latest execution (may race with concurrent agents)
     echo "[e2e-cloud] WARNING: could not capture execution ID, falling back to latest"

--- a/scripts/test/cloud-exec-id-parse.test.sh
+++ b/scripts/test/cloud-exec-id-parse.test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Test: cloud-exec-id-parse — regression for execution-ID capture from
+# `gcloud run jobs execute --wait` output.
+#
+# gcloud prints "Execution [NAME] has successfully completed." (brackets are
+# literal around the name, ANSI SGR codes around it on color-capable output).
+# Both wrappers previously parsed with `grep -oP 'Execution \K[^ ]+'`, which
+# captured the leading "[" (and ANSI escapes), making every downstream
+# describe/logs call address a nonexistent execution:
+#   - vitest-cloud.sh: status queries all failed → green run reported failed
+#     (observed live 2026-08-18, executions freshell-vitest-xzrwg/-ftrdv).
+#   - e2e-cloud.sh: `|| echo 0` masked the failure → wrapper always reported
+#     success with succeeded=0, masking real task failures.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT"
+
+FAILURES=0
+check() {
+  local desc="$1"
+  shift
+  if "$@"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "=== Cloud execution-ID parse regression test ==="
+
+FAKE_DIR=$(mktemp -d)
+trap 'rm -rf "$FAKE_DIR"' EXIT
+export FAKE_LOG="$FAKE_DIR/gcloud.log"
+touch "$FAKE_LOG"
+
+cat > "$FAKE_DIR/gcloud" << 'FAKE'
+#!/usr/bin/env bash
+echo "FAKE_GCLOUD: $@" >> "$FAKE_LOG"
+# Mimic current gcloud: "Execution [NAME] ..." with literal brackets and ANSI
+# SGR codes around the name (observed ngcloud output 2026-08-18).
+if [[ "$*" == *"run jobs execute"* ]]; then
+  printf 'Creating execution...\nExecution [\033[1mtest-exec-123\033[m] has successfully completed.\n'
+  exit 0
+fi
+if [[ "$*" == *"executions describe"* ]]; then
+  if [[ "$*" == *"succeededCount"* ]]; then echo "1"; else echo "0"; fi
+  exit 0
+fi
+if [[ "$*" == *"executions list"* ]]; then echo "test-exec-123"; exit 0; fi
+if [[ "$*" == *"logs read"* ]]; then echo "Test Files  1 passed (1)"; exit 0; fi
+if [[ "$*" == *"artifacts docker images describe"* ]] || [[ "$*" == *"artifacts repositories describe"* ]] || [[ "$*" == *"builds submit"* ]]; then exit 0; fi
+if [[ "$*" == *"auth print-access-token"* ]]; then echo "fake-token"; exit 0; fi
+if [[ "$*" == *"info"* ]]; then echo "/usr/lib/google-cloud-sdk"; exit 0; fi
+if [[ "$*" == *"run jobs"* ]]; then exit 0; fi  # create/update
+exit 0
+FAKE
+chmod +x "$FAKE_DIR/gcloud"
+export PATH="$FAKE_DIR:$PATH"
+
+# --- vitest wrapper ---
+rm -f "$FAKE_LOG"; touch "$FAKE_LOG"
+VITEST_OUT=$(bash "$ROOT/scripts/vitest-cloud.sh" run --cloud --config=default 2>&1) && VITEST_RC=0 || VITEST_RC=$?
+check "vitest wrapper exits 0 on green run" bash -c "[ $VITEST_RC -eq 0 ]"
+check "vitest wrapper prints success footer" grep -q "All tasks completed successfully" <<< "$VITEST_OUT"
+# Downstream queries must address the clean id (no bracket/ANSI garbage).
+check "vitest describe targets clean execution id" \
+  bash -c "grep -q 'executions describe .* test-exec-123 ' '$FAKE_LOG' && ! grep -q 'executions describe .*\[' '$FAKE_LOG'"
+
+# --- e2e wrapper ---
+rm -f "$FAKE_LOG"; touch "$FAKE_LOG"
+E2E_OUT=$(bash "$ROOT/scripts/e2e-cloud.sh" run --cloud --shards=1 2>&1) && E2E_RC=0 || E2E_RC=$?
+check "e2e wrapper exits 0 on green run" bash -c "[ $E2E_RC -eq 0 ]"
+check "e2e wrapper reports truthfully (succeeded=1)" grep -q "Succeeded tasks: 1" <<< "$E2E_OUT"
+check "e2e describe targets clean execution id" \
+  bash -c "grep -q 'executions describe .* test-exec-123 ' '$FAKE_LOG' && ! grep -q 'executions describe .*\[' '$FAKE_LOG'"
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "=== All checks passed ==="
+  exit 0
+else
+  echo "=== $FAILURES check(s) failed ==="
+  exit 1
+fi

--- a/scripts/vitest-cloud.sh
+++ b/scripts/vitest-cloud.sh
@@ -402,9 +402,17 @@ cmd_run() {
     --wait 2>&1) || execute_exit=$?
   echo "$execute_output"
 
-  # Extract the execution ID from the execute output (format: "Execution NAME")
+  # Extract the execution ID from the execute output. gcloud prints
+  # `Execution [NAME] has successfully completed.` — brackets are literal and,
+  # on color-capable captures, the name is wrapped in ANSI SGR codes — so strip
+  # escapes and allow the bracket form. (A bare `Execution \K[^ ]+` captures the
+  # bracket+escapes; every downstream describe/logs then addresses a nonexistent
+  # execution — observed live 2026-08-18 on executions -xzrwg and -ftrdv.)
   local execution_id
-  execution_id=$(echo "$execute_output" | grep -oP 'Execution \K[^ ]+' | head -1)
+  execution_id=$(echo "$execute_output" \
+    | sed -E 's/\x1b\[[0-9;]*m//g' \
+    | grep -oP 'Execution \[?\K[A-Za-z0-9][A-Za-z0-9-]*' \
+    | head -1 || true)
   if [ -z "$execution_id" ]; then
     echo "[vitest-cloud] WARNING: could not capture execution ID, falling back to latest"
     execution_id=$(gcloud run jobs executions list $(gcloud_flags) \


### PR DESCRIPTION
## What
`gcloud run jobs execute` prints `Execution [NAME] has successfully completed.` with **literal brackets** and ANSI SGR codes around the name. Both cloud wrappers parsed it with `grep -oP 'Execution \K[^ ]+'`, capturing the bracket (and escapes) — every downstream `executions describe`/`logs read` then addressed a nonexistent execution.

## Impact (observed live 2026-08-18)
- `vitest-cloud.sh`: status queries always failed → a fully green 4-shard run exited 1 (executions freshell-vitest-xzrwg, -ftrdv). The 5x retry added in #660 could not help a deterministic wrong address.
- `e2e-cloud.sh`: `|| echo 0` masked the failure → wrapper reported success with `succeeded=0` unconditionally, which would have hidden real task failures.

## Fix
Strip ANSI escapes and accept the bracketed form: `Execution \[?\K[A-Za-z0-9][A-Za-z0-9-]*`.

## Test plan
- New `scripts/test/cloud-exec-id-parse.test.sh`: fake gcloud emitting the real bracketed+ANSI format; asserts both wrappers exit 0, report truthfully, and target the clean id in downstream queries. Verified RED before the fix, GREEN after.
- Existing `cloud-vitest-wrapper.test.sh` + `cloud-vitest-entrypoint.test.sh` remain green.