### PR TITLE
test(server): widen logger.separation file-content gate 5s → 30s for cloud shard contention

### DIFF
--- a/test/integration/server/logger.separation.test.ts
+++ b/test/integration/server/logger.separation.test.ts
@@ -18,7 +18,11 @@ const REPO_ROOT = path.resolve(__dirname, '../../..')
 const require = createRequire(import.meta.url)
 let TSX_CLI: string | undefined
 const DEFAULT_TEST_TIMEOUT_MS = 120_000
-const FILE_CONTENT_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 5_000
+// The wait only bounds file-content APPEARANCE (the assertions care about
+// which filename was chosen, never about how fast). A cold `tsx` start under
+// full-suite shard contention on a shared Cloud Run vCPU exceeded the old 5s
+// gate (observed 2026-08-18, execution freshell-vitest-l68jz); unify at 30s.
+const FILE_CONTENT_TIMEOUT_MS = 30_000
 const ANSI_ESCAPE_PATTERN = /\u001b\[[0-9;]*m/g
 const SOURCE_LOGGER_PROBE = [
   '(async () => {',


### PR DESCRIPTION
## What
The `logger.separation` integration test bounded the wait for the probe's debug-log line to 5s on non-Windows. Every assertion in the file is about *which* log filename a launch mode chooses — none are about startup speed. Under full-suite shard contention on a shared Cloud Run vCPU, a cold `tsx` start exceeded 5s and failed the run (execution freshell-vitest-l68jz, 2026-08-18), while the same file passed alone in cloud (15s, 4/4 shards) and locally (3s).

## Fix
Unify the file-content gate at the existing Windows value (30s) with a comment recording why. Passing runs are unaffected — the wait loop returns the moment the pattern appears; the constant only gates failures.

## Test plan
- File runs green locally (5/5, 16.8s) via `npm run test:vitest -- run test/integration/server/logger.separation.test.ts --config config/vitest/vitest.server.config.ts`.
- Final verification: full `npm run test:cloud` at the post-merge HEAD (the whole point of this repair chain).