### PR TITLE
fix(terminal): silence replay-triggered phantom xterm focus reports (kata 9gy8)

### DIFF
--- a/docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md
+++ b/docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md
@@ -27,9 +27,9 @@ Fix pre-existing kata `9gy8`: when saved terminal history is replayed to rebuild
 - Server protocol and code: NO changes (`shared/ws-protocol.ts`, `server/`, `crates/` untouched).
 - Do not weaken, skip, or silence assertions in existing tests to make this pass. No code change may avoid the e2e style already established in `test/e2e-browser/specs/multi-client.spec.ts` (ws frame tracer, keyboard-typed arm command, `page.waitForFunction` on harness accessors).
 - The gate must cover BOTH `ESC[I` (focused) and `ESC[O` (blurred) — background/hidden pane replays emit the blur variant.
-- The swallwed report must not reach ANY of: ws input, `recordPaneTabActivity`, `updateSessionActivity`, or the un-anchored input buffer. The gate must sit before all of them.
+- The swallowed report must not reach ANY of: ws input, `recordPaneTabActivity`, `updateSessionActivity`, or the un-anchored input buffer. The gate must sit before all of them.
 - Keep tracked mode state intact: `getTerminalModes().sendFocusMode === true` after replay (arm preserved, report silenced).
-- Commit `feat:`, `test:`, `docs:` conventional messages; verify CI will see clippy/contract/typecheck-client green (no Rust/TS/contract changes expected, but prove it).
+- Commit conventional messages (`feat:`, `fix:`, `test:`, `docs:`); verify CI will see clippy/contract/typecheck-client green (no Rust/TS/contract changes expected, but prove it).
 - Bypass-the-scope buffering: reports generated while an attach anchor is pending are buffered upstream; the gate must therefore reject the phantom BEFORE the un-anchored fast-path can buffer it (onData entry is that point).
 
 ---
@@ -41,7 +41,7 @@ Fix pre-existing kata `9gy8`: when saved terminal history is replayed to rebuild
 - Test: `test/unit/client/lib/terminal-output-side-effects.test.ts`
 
 **Interfaces:**
-- Consumes: `getTerminalOutputWriteScope(terminalInstanceId)` from `./terminal-output-write-scope.js` (returns `{ suppressExternalSideEffects: boolean, ... } | null`), breadth-first on the existing page-lifecycle mocks used in this suite (e.g. expose or simulate via `beginTerminalOutputWriteScope(...)`).
+- Consumes: `getTerminalOutputWriteScope(terminalInstanceId)` from `./terminal-output-write-scope.js` (returns `{ suppressExternalSideEffects: boolean, ... } | null`) — tests simulate scopes directly via `beginTerminalOutputWriteScope(...)`, as the existing suite does.
 - Produces: `export function isReplayPhantomFocusReport(data: string, terminalInstanceId: string | undefined): boolean` — true exactly when `data === '\u001b[I'` or `data === '\u001b[O'` AND `getTerminalOutputWriteScope(terminalInstanceId)?.suppressExternalSideEffects === true`. No logging inside the helper (caller logs).
 
 - [ ] **Step 1: Write the failing behavioral test**
@@ -127,7 +127,7 @@ git commit -m "feat(terminal): pure predicate for replay-phantom xterm focus rep
 - Modify: `src/lib/terminal-output-write-scope.ts`
 - Test: `test/unit/client/lib/terminal-output-write-scope.test.ts`
 
-**Rationale (load-bearing A3):** `activeScopes` is one slot per `terminalInstanceId`; a live direct-path write for the same instance can overwrite a mid-parse replay scope, letting that replay's phantom slip the gate. Upgrade the map to an identity-checked stack: `Map<string, TerminalOutputWriteContext[]>`; `beginTerminalOutputWriteScope` pushes; `complete()` removes exactly that context; `getTerminalOutputWriteScope` returns the TOP (last) entry.
+**Rationale (load-bearing A3):** `activeScopes` is one slot per `terminalInstanceId`; a scope completing out of order can clear the wrong entry (e.g. the synchronous-throw early-complete paths in terminal-write-queue.ts:153-159), letting a later phantom slip the gate. Upgrade the map to an identity-checked stack: `Map<string, TerminalOutputWriteContext[]>`; `beginTerminalOutputWriteScope` pushes; `complete()` removes exactly that context; `getTerminalOutputWriteScope` returns the TOP (last) entry. Known residual (accepted, not widened): if a live scope and a replay scope for the same instance are both open and the replay bytes parse LATE, the gate reads the live top and that one phantom slips — the serializing write queue prevents this on every replay-driven rebuild path; the residual is confined to the queue-null fallback edge.
 
 - [ ] Steps (TDD): RED test — begin replay-suppress scope, then begin a non-suppress scope for the same id, complete the inner, assert the outer suppress scope is again active (leak closed); also assert existing behavior (single begin/complete) green. Implement the stack; the existing write-scope test file gets the two new cases plus full-suite stays green.
 - [ ] Commit: `feat(terminal): per-instance write-scope stack (closes replay-scope overlap leak, kata 9gy8)`
@@ -159,7 +159,7 @@ Concrete code: implementer reuses the file's existing replay-write-driving helpe
 
 Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx --reporter=basic`
 
-Expected: FAIL — tests 1, 4-6 observe `\u001b[I`/`\u001b[O` in the outgoing send stream (no gate exists yet).
+Expected: FAIL — tests 1, 2, 5, 6 observe `\u001b[I`/`\u001b[O` reaching the outgoing send stream / activity path (no gate exists yet); test 4 (live pass-through) passes pre-fix, and test 3 (non-report bytes) is a pass-through pin that stays green both ways.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
@@ -172,11 +172,9 @@ In `src/components/TerminalView.tsx`, inside the `term.onData((data) => { ... })
         // contained the app's ?1004h arm byte. Nothing about user focus
         // changed; this is invented input. Swallow silently (no send, no
         // activity) — the mode state is untouched.
-        logClient({
-          event: 'replay_phantom_focus_report_silenced',
+        log.debug('replay phantom focus report silenced (kata 9gy8)', {
           paneId,
           tabId,
-          level: 'debug',
           direction: data === '[I' ? 'in' : 'out',
         })
         return
@@ -229,7 +227,7 @@ Add (either as a `test` in the spec's "mode replay-sync" area or a sibling spec;
 
 1. Create a shell tab.
 2. Type `printf '\u001b[?1004h\n'` + Enter (arm focus reporting).
-3. `page.waitForFunction(() => window.__FRESHELL_TEST_HARNESS__.getTerminalModes('<pane-id>')?.sendFocusMode === true)` — arm visible.
+3. `page.waitForFunction(() => window.__FRESHELL_TEST_HARNESS__.getTerminalModes('<terminal-id>')?.sendFocusMode === true)` — arm visible.
 4. Reload the page.
 5. After reload ready, re-arm verification: `waitForFunction(sendFocusMode === true)` again (replay restored the arm).
 6. Assert: no sent ws message observed post-reload whose payload contains `\u001b[I` or `\u001b[O` (use the existing tracer collection pattern / harness sent-messages accessor). Scope the assertion window tightly: start at reload-ready, end at the arm-visible wait plus a short settle (load-bearing A4 — a GENUINE live focus report after the window would be legitimate and must not flake the test; headless runs generate no physical focus events, so the window is deterministic).

--- a/docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md
+++ b/docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md
@@ -70,8 +70,8 @@ import {
   type TerminalOutputSource,
 } from './terminal-output-write-scope.js'
 
-const XTERM_FOCUS_IN = '[I'
-const XTERM_FOCUS_OUT = '[O'
+const XTERM_FOCUS_IN = '\u001b[I'
+const XTERM_FOCUS_OUT = '\u001b[O'
 
 /**
  * xterm fires ESC[I / ESC[O synchronously from its parser every time it
@@ -175,7 +175,7 @@ In `src/components/TerminalView.tsx`, inside the `term.onData((data) => { ... })
         log.debug('replay phantom focus report silenced (kata 9gy8)', {
           paneId,
           tabId,
-          direction: data === '[I' ? 'in' : 'out',
+          direction: data === '\u001b[I' ? 'in' : 'out',
         })
         return
       }

--- a/docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md
+++ b/docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md
@@ -1,0 +1,289 @@
+# Kata 9gy8 — replay focus-report silencing Implementation Plan
+
+> **For agentic workers:** Execute this plan task by task with a fresh
+> implementer and a specification-plus-quality review after every task. Track
+> progress with the checkbox steps below.
+
+## User Request
+
+### Requested result
+Fix pre-existing kata `9gy8`: when saved terminal history is replayed to rebuild a pane (page reload, pane refresh, reconnect attach, split-pane open, resize rebinding), xterm.js re-fires the app's "report focus" switch (?1004) whose instruction bytes are inside the replayed chunk and immediately tells the app "you just got focus" — an invented keypress (`ESC[I`, seen live in opencode) the app never asked for. Terminal apps must stop receiving these phantom focus keystrokes during any replay-driven rebuild of a leaf surface.
+
+### Explicit constraints
+- Work starts in a dedicated git worktree under `.worktrees/` on a branch based on current `origin/main`; all changes are merged only through an approved PR to `main`.
+- Server-side protocol stays exactly as-is; nothing already merged needs changing to support this fix.
+
+### Accepted tradeoffs and residuals
+- A genuine focus event that lands *during* an active replay write is also silenced (phantom and real reports are byte-identical; replay time, not bytes, is the only discriminator). This is bounded: the next genuine click/focus change re-reports focus and the app recovers.
+
+**Goal:** After any form of history replay (reload, refresh, reconnect, split, resize rebind), an app that previously armed xterm focus reporting (`?1004h`) must not receive invented `ESC[I`/`ESC[O` input bytes caused purely by the replay — while the arm itself stays intact (`getTerminalModes().sendFocusMode === true`) and live focus reports continue to flow.
+
+**Architecture:** xterm fires `ESC[I`/`ESC[O` synchronously from its parser whenever a `?1004h` arming byte is parsed — including when that byte arrives via history replay. Freshell already wraps every replay write in a write scope (`beginTerminalOutputWriteScope`) carrying `suppressExternalSideEffects: true`, held open until xterm's write callback, so both sync and deferred (WriteBuffer macrotask) parses are covered. The fix adds a narrow gate at the single place where all terminal input leaves the client — the `term.onData` handler — that swallows an exact focus-report payload (`ESC[I` or `ESC[O`) while the current write scope has `suppressExternalSideEffects === true`. The arm itself is unaffected (xterm still tracks the mode; harness must observe `sendFocusMode: true` after replay), live focus reports outside a replay scope pass through unchanged, and nothing else touches input.
+
+**Tech Stack:** TypeScript/React (client), xterm.js, Vitest (unit + server), Playwright (e2e).
+
+## Global Constraints
+
+- Server protocol and code: NO changes (`shared/ws-protocol.ts`, `server/`, `crates/` untouched).
+- Do not weaken, skip, or silence assertions in existing tests to make this pass. No code change may avoid the e2e style already established in `test/e2e-browser/specs/multi-client.spec.ts` (ws frame tracer, keyboard-typed arm command, `page.waitForFunction` on harness accessors).
+- The gate must cover BOTH `ESC[I` (focused) and `ESC[O` (blurred) — background/hidden pane replays emit the blur variant.
+- The swallwed report must not reach ANY of: ws input, `recordPaneTabActivity`, `updateSessionActivity`, or the un-anchored input buffer. The gate must sit before all of them.
+- Keep tracked mode state intact: `getTerminalModes().sendFocusMode === true` after replay (arm preserved, report silenced).
+- Commit `feat:`, `test:`, `docs:` conventional messages; verify CI will see clippy/contract/typecheck-client green (no Rust/TS/contract changes expected, but prove it).
+- Bypass-the-scope buffering: reports generated while an attach anchor is pending are buffered upstream; the gate must therefore reject the phantom BEFORE the un-anchored fast-path can buffer it (onData entry is that point).
+
+---
+
+### Task 1: Gate predicate in terminal-output-side-effects lib (pure)
+
+**Files:**
+- Modify: `src/lib/terminal-output-side-effects.ts`
+- Test: `test/unit/client/lib/terminal-output-side-effects.test.ts`
+
+**Interfaces:**
+- Consumes: `getTerminalOutputWriteScope(terminalInstanceId)` from `./terminal-output-write-scope.js` (returns `{ suppressExternalSideEffects: boolean, ... } | null`), breadth-first on the existing page-lifecycle mocks used in this suite (e.g. expose or simulate via `beginTerminalOutputWriteScope(...)`).
+- Produces: `export function isReplayPhantomFocusReport(data: string, terminalInstanceId: string | undefined): boolean` — true exactly when `data === '\u001b[I'` or `data === '\u001b[O'` AND `getTerminalOutputWriteScope(terminalInstanceId)?.suppressExternalSideEffects === true`. No logging inside the helper (caller logs).
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add a `describe('isReplayPhantomFocusReport')` block with these tests (exact assertions):
+
+1. Swallow: inside `beginTerminalOutputWriteScope({ terminalInstanceId: 't1', source: 'replay', attachRequestId: undefined, generation: 'g', suppressExternalSideEffects: true })`, `isReplayPhantomFocusReport('\u001b[I', 't1') === true` and `isReplayPhantomFocusReport('\u001b[O', 't1') === true`.
+2. Pass-through, live scope: with `suppressExternalSideEffects: false`, the predicate is `false` for both byte strings.
+3. Pass-through, no scope: outside any scope, predicate is `false`.
+4. Pass-through, non-report bytes: with a suppressing replay scope open, `isReplayPhantomFocusReport('a', 't1') === false` and `isReplayPhantomFocusReport('\u001b[?1004h', 't1') === false` (the arm bytes themselves are terminal input bytes going nowhere — but prove arbitrary data is untouched).
+5. Cross-instance isolation: open a suppressing scope for 't1', assert `isReplayPhantomFocusReport('\u001b[I', 't2') === false`.
+6. Scope completion releases: after `scope.complete()`, the predicate returns `false` for the same input on the same instance id.
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/lib/terminal-output-side-effects.test.ts --reporter=basic`
+
+Expected: FAIL — `isReplayPhantomFocusReport` is not exported (`ImportError`/`TypeError`), proving the tests exercise the new predicate rather than a stub.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+```ts
+import {
+  getTerminalOutputWriteScope,
+  type TerminalOutputSideEffect,
+  type TerminalOutputSource,
+} from './terminal-output-write-scope.js'
+
+const XTERM_FOCUS_IN = '[I'
+const XTERM_FOCUS_OUT = '[O'
+
+/**
+ * xterm fires ESC[I / ESC[O synchronously from its parser every time it
+ * parses a ?1004h arm byte — including when that byte arrives via history
+ * replay (kata 9gy8). Such a replay-triggered report is a phantom: nothing
+ * about user focus changed, and the app receives an invented keypress.
+ * The replay write scope (“suppressExternalSideEffects”) is held open until
+ * xterm's write callback, which covers both synchronous and deferred parses,
+ * so it is the correct discriminator; the exact-bytes check keeps all other
+ * input untouched.
+ */
+export function isReplayPhantomFocusReport(
+  data: string,
+  terminalInstanceId: string | undefined,
+): boolean {
+  if (data !== XTERM_FOCUS_IN && data !== XTERM_FOCUS_OUT) return false
+  return getTerminalOutputWriteScope(terminalInstanceId)?.suppressExternalSideEffects === true
+}
+```
+
+(Names of the two constants are the literals shown in red-box form above: `'\u001b[I'` and `'\u001b[O'`.)
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/lib/terminal-output-side-effects.test.ts --reporter=basic`
+
+Expected: PASS (all new tests green, existing suite green).
+
+- [ ] **Step 5: Refactor while green**
+
+None expected; helper is a pure predicate with two constants. If the existing suite has a naming pattern for ESC literals, follow it instead of introducing local constants.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The scope lib is self-contained; only the predicate consumer changes in Task 2. Run the two scope-related suites together to prove an unchanged baseline:
+
+Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/lib/terminal-output-side-effects.test.ts test/unit/client/lib/terminal-output-write-scope.test.ts --reporter=basic`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/lib/terminal-output-side-effects.ts test/unit/client/lib/terminal-output-side-effects.test.ts
+git commit -m "feat(terminal): pure predicate for replay-phantom xterm focus reports (kata 9gy8)"
+```
+
+---
+
+### Task 2: onData gate in TerminalView + lifecycle integration tests
+
+**Files:**
+- Modify: `src/components/TerminalView.tsx` (onData handler at the registerTerminalCaptureHandler/connect block, current line ~2294)
+- Test: `test/unit/client/components/TerminalView.lifecycle.test.tsx` (new `describe('replay phantom focus report silencing (kata 9gy8)')`)
+
+**Interfaces:**
+- Consumes: `isReplayPhantomFocusReport` from Task 1; existing `terminalInstanceIdRef.current`, `sendInput`, `dispatch(dismissTabGreen)`, `recordPaneTabActivity`, `updateSessionActivity`, `bufferPendingInput` — all already in scope at the onData handler.
+- Produces: gate behavior only; no new public API.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add a new describe block in the lifecycle suite following the file's existing pattern for replay writes (the `submitAcceptedOutput`-style path used by the modes-sync describe at ~:9659). Tests:
+
+1. **Phantom swallowed on replay, byte-exact.** Mount a pane, arm nothing, drive a replay-mode write through the harness/mock containing the literal byte `\u001b[?1004h` followed by normal text; have the mock xterm invoke its registered onData with `'\u001b[I'` while the write scope is still open (the mock lifecycle component pattern already supports this — reuse how existing tests drive onData; e.g. `term.onData.mock.calls[0][0]('\u001b[I')`). Assert: no `send` call whose payload contains `\u001b[I`, and the mock harness `getSentWsMessages/...` input area is empty of focus bytes.
+2. **Activity not disturbed.** Same setup: `recordPaneTabActivity`/session-activity side of the handler did NOT receive the phantom input (assert via the file's existing activity-observation pattern; if none exists, assert the dismissal path not fired for bare `\u001b[I` — it already is a non-engagement byte, the sub-assertion is a no-op regression net).
+3. **Ingestion not disturbed for non-report bytes:** same replay chunk carries `\u001b[?1004h` + plain bytes; assert non-focus input from onData during the same scope window is untouched (i.e. gate applied only at the bytes level, not at the write-batch level).
+4. **Live pass-through regression.** With NO open replay scope (simulate: normal live write), fire onData `'\u001b[I'` and assert it reaches `send` (input) with exactly `'\u001b[I'`. This pins "live focus reports keep flowing".
+5. **Blur variant.** Same as (1) with `'\u001b[O'`: no send, no activity.
+6. **Outside-scope wakeup during a LATER replay of same pane:** after the first replay completes a suppress-scope lifecycle, a second replay for the same pane must still swallow (proves no "first-time-only" state).
+
+Concrete code: implementer reuses the file's existing replay-write-driving helper (the same one used to push a `terminal.modes.sync` frame in the existing modes-sync describe); the ONLY new bytes are the acceptance chunk and the onData invocation.
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx --reporter=basic`
+
+Expected: FAIL — tests 1, 4-6 observe `\u001b[I`/`\u001b[O` in the outgoing send stream (no gate exists yet).
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+In `src/components/TerminalView.tsx`, inside the `term.onData((data) => { ... })` handler, make the FIRST statement:
+
+```ts
+    term.onData((data) => {
+      if (isReplayPhantomFocusReport(data, terminalInstanceIdRef.current)) {
+        // Kata 9gy8: xterm re-fired a focus report because a replay chunk
+        // contained the app's ?1004h arm byte. Nothing about user focus
+        // changed; this is invented input. Swallow silently (no send, no
+        // activity) — the mode state is untouched.
+        logClient({
+          event: 'replay_phantom_focus_report_silenced',
+          paneId,
+          tabId,
+          level: 'debug',
+          direction: data === '[I' ? 'in' : 'out',
+        })
+        return
+      }
+      sendInput(data)
+      // ...existing engagement/activity logic unchanged
+```
+
+Add the import: `import { isReplayPhantomFocusReport } from '@/lib/terminal-output-side-effects'` (check the module's export — the helper lives in terminal-output-side-effects.ts, which is also re-exported from terminal-output-write-scope.js; import from the canonical source file to avoid a cycle).
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx --reporter=basic`
+
+Expected: PASS (all describe-block tests green; full file stays green).
+
+- [ ] **Step 5: Refactor while green**
+
+Keep the gate body minimal; the helper already isolates the predicate. No further refactor.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Everything touching onData/sendInput/write queue path:
+
+Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/TerminalView.keyboard.test.tsx test/unit/client/components/terminal/terminal-write-queue.test.ts --reporter=basic`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx
+git commit -m "fix(terminal): swallow replay-triggered phantom xterm focus reports at onData (kata 9gy8)"
+```
+
+---
+
+### Task 3: e2e wire proof (multi-client spec)
+
+**Files:**
+- Modify: `test/e2e-browser/specs/multi-client.spec.ts`
+
+**Interfaces:**
+- Consumes: existing ws frame tracer (page.on('websocket')), the keyboard-typed arm pattern (`printf` bytes), `page.waitForFunction` on `window.__FRESHELL_TEST_HARNESS__` accessors (`getSentWsMessages`, `getTerminalModes`), the ws-terminal-modes-sync server's harness-provided FakeRegistry (no server change).
+- Produces: one new spec entry proving phantom-free reload.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+Add (either as a `test` in the spec's "mode replay-sync" area or a sibling spec; the existing tests at multi-client.spec.ts:605-821 are the template):
+
+1. Create a shell tab.
+2. Type `printf '\u001b[?1004h\n'` + Enter (arm focus reporting).
+3. `page.waitForFunction(() => window.__FRESHELL_TEST_HARNESS__.getTerminalModes('<pane-id>')?.sendFocusMode === true)` — arm visible.
+4. Reload the page.
+5. After reload ready, re-arm verification: `waitForFunction(sendFocusMode === true)` again (replay restored the arm).
+6. Assert: no sent ws message observed post-reload whose payload contains `\u001b[I` or `\u001b[O` (use the existing tracer collection pattern / harness sent-messages accessor).
+
+Title: `mode replay-sync: replay no longer injects phantom xterm focus reports (kata 9gy8)`.
+
+Red-state proof BEFORE the fix: this test's step 6 currently FAILS on any leg where the arm byte lands in the retained window with the pane focused (the failing assertion is a ghost input frame; if a leg happens to be green due to a pane-focus race, the unit tests in Task 2 are the deterministic red).
+
+- [ ] **Step 2: Run the e2e and verify behavior**
+
+Run: `npm run test:e2e:local -- test/e2e-browser/specs/multi-client.spec.ts -g "9gy8"`
+
+Expected: test runs on all three legs; pre-fix (or via assertion shape) shows phantom input; post-fix no phantom on any leg.
+
+- [ ] **Step 3: Refactor while green**
+
+Share the tracer-verify helper with the existing mode-sync tests if one exists; otherwise duplicate minimally.
+
+- [ ] **Step 4: Run stable-e2e verification**
+
+Run: `npm run test:e2e:local -- test/e2e-browser/specs/multi-client.spec.ts -g "mode replay-sync"`
+
+Expected: PASS all 6 prior tests plus the new one.
+
+- [ ] **Step 5: Commit the task**
+
+```bash
+git add test/e2e-browser/specs/multi-client.spec.ts
+git commit -m "test(e2e): wire proof that replay no longer injects phantom focus reports (kata 9gy8)"
+```
+
+---
+
+### Task 4: bookkeeping (plan-status + kata comment + contract update)
+
+**Files:**
+- Modify: `docs/plans/2026-08-17-terminal-mode-replay-sync.md` (status box only, noting 9gy8 as SILENCED/residual)
+- Modify: `test/e2e-browser/specs/multi-client.spec.ts` line ~731 comment (residual now fixed)
+
+- [ ] **Step 1: Update the plan-status box**
+
+In the mode-replay-sync plan, add to its Stage-6/update area: `kata 9gy8 = SILENCED` with a link to this plan's branch commit SHA.
+
+- [ ] **Step 2: Update the spec comment**
+
+At multi-client.spec.ts:731-733 (the comment that says the sync preamble never fires and the replay path retains the focus-report bug), update the residual note: sync still never emits `?1004`, and replay no longer injects phantom reports via kata 9gy8. Reference the new test title.
+
+- [ ] **Step 3: Kata comment**
+
+`kata comment 9gy8 "Fix implemented in worktree kata-9gy8-focus-silence / branch the-usual/kata-9gy8-focus-silence + PR review; tests pin no phantom input at unit + e2e levels. Close after merge."`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/plans/2026-08-17-terminal-mode-replay-sync.md test/e2e-browser/specs/multi-client.spec.ts
+git commit -m "docs: kata 9gy8 silenced; update spec residual comment"
+```
+
+---
+
+## Self-review checklist
+
+1. **Spec coverage:** phantom swallow on reload/refresh/reconnect all map to the same gate; both live and replay edges tested (Tasks 1-2); wire-level e2e proof (Task 3); tracked mode intact (Task 1 test 4 arm-bytes distinction; Task 3 waits).
+2. **No silent deferrals:** none — every behavior change is tested; no stubs, mocks, or fake providers in production code.
+3. **File/interface consistency:** exact paths specified; new predicate consumed from one place; existing helper (`getTerminalOutputWriteScope`, `beginTerminalOutputWriteScope`) signatures reused untouched.
+4. **Executable tests:** every test has an exact command and expected outcome; reds proven for unit (export missing → ImportError) and lifecycle (assert sees phantom before gate); e2e red is leg-dependent (unit tests are the deterministic red).
+5. **Placeholder scan:** none — no TBD/TODO; assertions are concrete strings and byte comparisons.
+6. **Operational completeness:** debug log at debug level (off by default, per AGENTS.md); no user-facing UI, so no docs/index.html change; no AGENTS.md contract change; CI gates (clippy for Rust — no Rust touched; typecheck-client must pass; contract inventory untouched — no new ws message types added; prisma-style lint: chan previously passing getContext-gated `logClient` import and relative-vs-alias imports follow the file's existing imports).

--- a/docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md
+++ b/docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md
@@ -44,7 +44,7 @@ Fix pre-existing kata `9gy8`: when saved terminal history is replayed to rebuild
 - Consumes: `getTerminalOutputWriteScope(terminalInstanceId)` from `./terminal-output-write-scope.js` (returns `{ suppressExternalSideEffects: boolean, ... } | null`) — tests simulate scopes directly via `beginTerminalOutputWriteScope(...)`, as the existing suite does.
 - Produces: `export function isReplayPhantomFocusReport(data: string, terminalInstanceId: string | undefined): boolean` — true exactly when `data === '\u001b[I'` or `data === '\u001b[O'` AND `getTerminalOutputWriteScope(terminalInstanceId)?.suppressExternalSideEffects === true`. No logging inside the helper (caller logs).
 
-- [ ] **Step 1: Write the failing behavioral test**
+- [x] **Step 1: Write the failing behavioral test**
 
 Add a `describe('isReplayPhantomFocusReport')` block with these tests (exact assertions):
 
@@ -55,13 +55,13 @@ Add a `describe('isReplayPhantomFocusReport')` block with these tests (exact ass
 5. Cross-instance isolation: open a suppressing scope for 't1', assert `isReplayPhantomFocusReport('\u001b[I', 't2') === false`.
 6. Scope completion releases: after `scope.complete()`, the predicate returns `false` for the same input on the same instance id.
 
-- [ ] **Step 2: Run the test and verify the intended failure**
+- [x] **Step 2: Run the test and verify the intended failure**
 
 Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/lib/terminal-output-side-effects.test.ts --reporter=basic`
 
 Expected: FAIL — `isReplayPhantomFocusReport` is not exported (`ImportError`/`TypeError`), proving the tests exercise the new predicate rather than a stub.
 
-- [ ] **Step 3: Add the minimal production implementation**
+- [x] **Step 3: Add the minimal production implementation**
 
 ```ts
 import {
@@ -94,17 +94,17 @@ export function isReplayPhantomFocusReport(
 
 (Names of the two constants are the literals shown in red-box form above: `'\u001b[I'` and `'\u001b[O'`.)
 
-- [ ] **Step 4: Run the focused test**
+- [x] **Step 4: Run the focused test**
 
 Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/lib/terminal-output-side-effects.test.ts --reporter=basic`
 
 Expected: PASS (all new tests green, existing suite green).
 
-- [ ] **Step 5: Refactor while green**
+- [x] **Step 5: Refactor while green**
 
 None expected; helper is a pure predicate with two constants. If the existing suite has a naming pattern for ESC literals, follow it instead of introducing local constants.
 
-- [ ] **Step 6: Run impacted-test verification**
+- [x] **Step 6: Run impacted-test verification**
 
 The scope lib is self-contained; only the predicate consumer changes in Task 2. Run the two scope-related suites together to prove an unchanged baseline:
 
@@ -112,7 +112,7 @@ Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit the task**
+- [x] **Step 7: Commit the task**
 
 ```bash
 git add src/lib/terminal-output-side-effects.ts test/unit/client/lib/terminal-output-side-effects.test.ts
@@ -129,8 +129,8 @@ git commit -m "feat(terminal): pure predicate for replay-phantom xterm focus rep
 
 **Rationale (load-bearing A3):** `activeScopes` is one slot per `terminalInstanceId`; a scope completing out of order can clear the wrong entry (e.g. the synchronous-throw early-complete paths in terminal-write-queue.ts:153-159), letting a later phantom slip the gate. Upgrade the map to an identity-checked stack: `Map<string, TerminalOutputWriteContext[]>`; `beginTerminalOutputWriteScope` pushes; `complete()` removes exactly that context; `getTerminalOutputWriteScope` returns the TOP (last) entry. Known residual (accepted, not widened): if a live scope and a replay scope for the same instance are both open and the replay bytes parse LATE, the gate reads the live top and that one phantom slips — the serializing write queue prevents this on every replay-driven rebuild path; the residual is confined to the queue-null fallback edge.
 
-- [ ] Steps (TDD): RED test — begin replay-suppress scope, then begin a non-suppress scope for the same id, complete the inner, assert the outer suppress scope is again active (leak closed); also assert existing behavior (single begin/complete) green. Implement the stack; the existing write-scope test file gets the two new cases plus full-suite stays green.
-- [ ] Commit: `feat(terminal): per-instance write-scope stack (closes replay-scope overlap leak, kata 9gy8)`
+- [x] Steps (TDD): RED test — begin replay-suppress scope, then begin a non-suppress scope for the same id, complete the inner, assert the outer suppress scope is again active (leak closed); also assert existing behavior (single begin/complete) green. Implement the stack; the existing write-scope test file gets the two new cases plus full-suite stays green.
+- [x] Commit: `feat(terminal): per-instance write-scope stack (closes replay-scope overlap leak, kata 9gy8)`
 
 ### Task 2: onData gate in TerminalView + lifecycle integration tests
 
@@ -142,7 +142,7 @@ git commit -m "feat(terminal): pure predicate for replay-phantom xterm focus rep
 - Consumes: `isReplayPhantomFocusReport` from Task 1; existing `terminalInstanceIdRef.current`, `sendInput`, `dispatch(dismissTabGreen)`, `recordPaneTabActivity`, `updateSessionActivity`, `bufferPendingInput` — all already in scope at the onData handler.
 - Produces: gate behavior only; no new public API.
 
-- [ ] **Step 1: Write the failing behavioral test**
+- [x] **Step 1: Write the failing behavioral test**
 
 Add a new describe block in the lifecycle suite following the file's existing pattern for replay writes (the `submitAcceptedOutput`-style path used by the modes-sync describe at ~:9659). Tests:
 
@@ -155,13 +155,13 @@ Add a new describe block in the lifecycle suite following the file's existing pa
 
 Concrete code: implementer reuses the file's existing replay-write-driving helper (the same one used to push a `terminal.modes.sync` frame in the existing modes-sync describe); the ONLY new bytes are the acceptance chunk and the onData invocation.
 
-- [ ] **Step 2: Run the test and verify the intended failure**
+- [x] **Step 2: Run the test and verify the intended failure**
 
 Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx --reporter=basic`
 
 Expected: FAIL — tests 1, 2, 5, 6 observe `\u001b[I`/`\u001b[O` reaching the outgoing send stream / activity path (no gate exists yet); test 4 (live pass-through) passes pre-fix, and test 3 (non-report bytes) is a pass-through pin that stays green both ways.
 
-- [ ] **Step 3: Add the minimal production implementation**
+- [x] **Step 3: Add the minimal production implementation**
 
 In `src/components/TerminalView.tsx`, inside the `term.onData((data) => { ... })` handler, make the FIRST statement:
 
@@ -185,17 +185,17 @@ In `src/components/TerminalView.tsx`, inside the `term.onData((data) => { ... })
 
 Add the import from the canonical source file: `import { isReplayPhantomFocusReport } from '@/lib/terminal-output-side-effects'` (write-scope.js does NOT re-export it today) and use the file's existing logger symbol (`log`, created via `createLogger` at ~:175) — `logClient` does not exist.
 
-- [ ] **Step 4: Run the focused test**
+- [x] **Step 4: Run the focused test**
 
 Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx --reporter=basic`
 
 Expected: PASS (all describe-block tests green; full file stays green).
 
-- [ ] **Step 5: Refactor while green**
+- [x] **Step 5: Refactor while green**
 
 Keep the gate body minimal; the helper already isolates the predicate. No further refactor.
 
-- [ ] **Step 6: Run impacted-test verification**
+- [x] **Step 6: Run impacted-test verification**
 
 Everything touching onData/sendInput/write queue path:
 
@@ -203,7 +203,7 @@ Run: `FRESHELL_VITEST_BACKEND=local npm run test:vitest -- run test/unit/client/
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit the task**
+- [x] **Step 7: Commit the task**
 
 ```bash
 git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -221,7 +221,7 @@ git commit -m "fix(terminal): swallow replay-triggered phantom xterm focus repor
 - Consumes: existing ws frame tracer (page.on('websocket')), the keyboard-typed arm pattern (`printf` bytes), `page.waitForFunction` on `window.__FRESHELL_TEST_HARNESS__` accessors (`getSentWsMessages`, `getTerminalModes`), the ws-terminal-modes-sync server's harness-provided FakeRegistry (no server change).
 - Produces: one new spec entry proving phantom-free reload.
 
-- [ ] **Step 1: Write the failing e2e test**
+- [x] **Step 1: Write the failing e2e test**
 
 Add (either as a `test` in the spec's "mode replay-sync" area or a sibling spec; the existing tests at multi-client.spec.ts:605-821 are the template):
 
@@ -236,23 +236,23 @@ Title: `mode replay-sync: replay no longer injects phantom xterm focus reports (
 
 Red-state proof BEFORE the fix: this test's step 6 currently FAILS on any leg where the arm byte lands in the retained window with the pane focused (the failing assertion is a ghost input frame; if a leg happens to be green due to a pane-focus race, the unit tests in Task 2 are the deterministic red).
 
-- [ ] **Step 2: Run the e2e and verify behavior**
+- [x] **Step 2: Run the e2e and verify behavior**
 
 Run: `npm run test:e2e:local -- test/e2e-browser/specs/multi-client.spec.ts -g "9gy8"`
 
 Expected: test runs on all three legs; pre-fix (or via assertion shape) shows phantom input; post-fix no phantom on any leg.
 
-- [ ] **Step 3: Refactor while green**
+- [x] **Step 3: Refactor while green**
 
 Share the tracer-verify helper with the existing mode-sync tests if one exists; otherwise duplicate minimally.
 
-- [ ] **Step 4: Run stable-e2e verification**
+- [x] **Step 4: Run stable-e2e verification**
 
 Run: `npm run test:e2e:local -- test/e2e-browser/specs/multi-client.spec.ts -g "mode replay-sync"`
 
 Expected: PASS all 6 prior tests plus the new one.
 
-- [ ] **Step 5: Commit the task**
+- [x] **Step 5: Commit the task**
 
 ```bash
 git add test/e2e-browser/specs/multi-client.spec.ts

--- a/docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md
+++ b/docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md
@@ -121,6 +121,17 @@ git commit -m "feat(terminal): pure predicate for replay-phantom xterm focus rep
 
 ---
 
+### Task 1.5: per-instance write-scope stack (closes same-instance overlap leak)
+
+**Files:**
+- Modify: `src/lib/terminal-output-write-scope.ts`
+- Test: `test/unit/client/lib/terminal-output-write-scope.test.ts`
+
+**Rationale (load-bearing A3):** `activeScopes` is one slot per `terminalInstanceId`; a live direct-path write for the same instance can overwrite a mid-parse replay scope, letting that replay's phantom slip the gate. Upgrade the map to an identity-checked stack: `Map<string, TerminalOutputWriteContext[]>`; `beginTerminalOutputWriteScope` pushes; `complete()` removes exactly that context; `getTerminalOutputWriteScope` returns the TOP (last) entry.
+
+- [ ] Steps (TDD): RED test — begin replay-suppress scope, then begin a non-suppress scope for the same id, complete the inner, assert the outer suppress scope is again active (leak closed); also assert existing behavior (single begin/complete) green. Implement the stack; the existing write-scope test file gets the two new cases plus full-suite stays green.
+- [ ] Commit: `feat(terminal): per-instance write-scope stack (closes replay-scope overlap leak, kata 9gy8)`
+
 ### Task 2: onData gate in TerminalView + lifecycle integration tests
 
 **Files:**
@@ -135,7 +146,7 @@ git commit -m "feat(terminal): pure predicate for replay-phantom xterm focus rep
 
 Add a new describe block in the lifecycle suite following the file's existing pattern for replay writes (the `submitAcceptedOutput`-style path used by the modes-sync describe at ~:9659). Tests:
 
-1. **Phantom swallowed on replay, byte-exact.** Mount a pane, arm nothing, drive a replay-mode write through the harness/mock containing the literal byte `\u001b[?1004h` followed by normal text; have the mock xterm invoke its registered onData with `'\u001b[I'` while the write scope is still open (the mock lifecycle component pattern already supports this — reuse how existing tests drive onData; e.g. `term.onData.mock.calls[0][0]('\u001b[I')`). Assert: no `send` call whose payload contains `\u001b[I`, and the mock harness `getSentWsMessages/...` input area is empty of focus bytes.
+1. **Phantom swallowed on replay, byte-exact.** Mount a pane, arm nothing, drive a replay-mode write through the harness/mock containing the literal byte `\u001b[?1004h` followed by normal text; fire the registered onData handler WHILE the write scope is open: use `term.write.mockImplementationOnce` (or the suite's existing queue-driving spy) so the mock calls the captured `term.onData.mock.calls[0][0]('\u001b[I')` from inside the `write()` implementation — i.e. before the scope's callback completes it (calling onData after write resolves is post-scope and would not exercise the gate). Assert: no `send` call whose payload contains `\u001b[I`, and the mock harness `getSentWsMessages/...` input area is empty of focus bytes.
 2. **Activity not disturbed.** Same setup: `recordPaneTabActivity`/session-activity side of the handler did NOT receive the phantom input (assert via the file's existing activity-observation pattern; if none exists, assert the dismissal path not fired for bare `\u001b[I` — it already is a non-engagement byte, the sub-assertion is a no-op regression net).
 3. **Ingestion not disturbed for non-report bytes:** same replay chunk carries `\u001b[?1004h` + plain bytes; assert non-focus input from onData during the same scope window is untouched (i.e. gate applied only at the bytes level, not at the write-batch level).
 4. **Live pass-through regression.** With NO open replay scope (simulate: normal live write), fire onData `'\u001b[I'` and assert it reaches `send` (input) with exactly `'\u001b[I'`. This pins "live focus reports keep flowing".
@@ -174,7 +185,7 @@ In `src/components/TerminalView.tsx`, inside the `term.onData((data) => { ... })
       // ...existing engagement/activity logic unchanged
 ```
 
-Add the import: `import { isReplayPhantomFocusReport } from '@/lib/terminal-output-side-effects'` (check the module's export — the helper lives in terminal-output-side-effects.ts, which is also re-exported from terminal-output-write-scope.js; import from the canonical source file to avoid a cycle).
+Add the import from the canonical source file: `import { isReplayPhantomFocusReport } from '@/lib/terminal-output-side-effects'` (write-scope.js does NOT re-export it today) and use the file's existing logger symbol (`log`, created via `createLogger` at ~:175) — `logClient` does not exist.
 
 - [ ] **Step 4: Run the focused test**
 
@@ -221,7 +232,7 @@ Add (either as a `test` in the spec's "mode replay-sync" area or a sibling spec;
 3. `page.waitForFunction(() => window.__FRESHELL_TEST_HARNESS__.getTerminalModes('<pane-id>')?.sendFocusMode === true)` — arm visible.
 4. Reload the page.
 5. After reload ready, re-arm verification: `waitForFunction(sendFocusMode === true)` again (replay restored the arm).
-6. Assert: no sent ws message observed post-reload whose payload contains `\u001b[I` or `\u001b[O` (use the existing tracer collection pattern / harness sent-messages accessor).
+6. Assert: no sent ws message observed post-reload whose payload contains `\u001b[I` or `\u001b[O` (use the existing tracer collection pattern / harness sent-messages accessor). Scope the assertion window tightly: start at reload-ready, end at the arm-visible wait plus a short settle (load-bearing A4 — a GENUINE live focus report after the window would be legitimate and must not flake the test; headless runs generate no physical focus events, so the window is deterministic).
 
 Title: `mode replay-sync: replay no longer injects phantom xterm focus reports (kata 9gy8)`.
 
@@ -268,7 +279,7 @@ At multi-client.spec.ts:731-733 (the comment that says the sync preamble never f
 
 - [ ] **Step 3: Kata comment**
 
-`kata comment 9gy8 "Fix implemented in worktree kata-9gy8-focus-silence / branch the-usual/kata-9gy8-focus-silence + PR review; tests pin no phantom input at unit + e2e levels. Close after merge."`
+`kata comment 9gy8 -m "Fix implemented in worktree kata-9gy8-focus-silence / branch the-usual/kata-9gy8-focus-silence + PR review; tests pin no phantom input at unit + e2e levels. Close after merge."`
 
 - [ ] **Step 4: Commit**
 
@@ -286,4 +297,4 @@ git commit -m "docs: kata 9gy8 silenced; update spec residual comment"
 3. **File/interface consistency:** exact paths specified; new predicate consumed from one place; existing helper (`getTerminalOutputWriteScope`, `beginTerminalOutputWriteScope`) signatures reused untouched.
 4. **Executable tests:** every test has an exact command and expected outcome; reds proven for unit (export missing → ImportError) and lifecycle (assert sees phantom before gate); e2e red is leg-dependent (unit tests are the deterministic red).
 5. **Placeholder scan:** none — no TBD/TODO; assertions are concrete strings and byte comparisons.
-6. **Operational completeness:** debug log at debug level (off by default, per AGENTS.md); no user-facing UI, so no docs/index.html change; no AGENTS.md contract change; CI gates (clippy for Rust — no Rust touched; typecheck-client must pass; contract inventory untouched — no new ws message types added; prisma-style lint: chan previously passing getContext-gated `logClient` import and relative-vs-alias imports follow the file's existing imports).
+6. **Operational completeness:** debug log at debug level (off by default, per AGENTS.md); no user-facing UI, so no docs/index.html change; no AGENTS.md contract change; CI gates (clippy for Rust — no Rust touched; typecheck-client must pass; contract inventory untouched — no new ws message types added; lint: the file's existing `log` (createLogger) import pattern is reused; relative-vs-alias imports follow the file's existing imports).

--- a/docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md
+++ b/docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md
@@ -267,19 +267,19 @@ git commit -m "test(e2e): wire proof that replay no longer injects phantom focus
 - Modify: `docs/plans/2026-08-17-terminal-mode-replay-sync.md` (status box only, noting 9gy8 as SILENCED/residual)
 - Modify: `test/e2e-browser/specs/multi-client.spec.ts` line ~731 comment (residual now fixed)
 
-- [ ] **Step 1: Update the plan-status box**
+- [x] **Step 1: Update the plan-status box**
 
 In the mode-replay-sync plan, add to its Stage-6/update area: `kata 9gy8 = SILENCED` with a link to this plan's branch commit SHA.
 
-- [ ] **Step 2: Update the spec comment**
+- [x] **Step 2: Update the spec comment**
 
 At multi-client.spec.ts:731-733 (the comment that says the sync preamble never fires and the replay path retains the focus-report bug), update the residual note: sync still never emits `?1004`, and replay no longer injects phantom reports via kata 9gy8. Reference the new test title.
 
-- [ ] **Step 3: Kata comment**
+- [x] **Step 3: Kata comment**
 
 `kata comment 9gy8 -m "Fix implemented in worktree kata-9gy8-focus-silence / branch the-usual/kata-9gy8-focus-silence + PR review; tests pin no phantom input at unit + e2e levels. Close after merge."`
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add docs/plans/2026-08-17-terminal-mode-replay-sync.md test/e2e-browser/specs/multi-client.spec.ts

--- a/docs/plans/2026-08-17-terminal-mode-replay-sync.md
+++ b/docs/plans/2026-08-17-terminal-mode-replay-sync.md
@@ -121,6 +121,9 @@ One shared JSON family `port/oracle/baselines/mode-preamble/*.json` (input: trac
   zero focus junk" shape was abandoned because xterm 6.0.0 re-fires a focus
   report on ANY arm — including the REPLAY of the original arming byte while
   it is still inside the retained window — a pre-existing leak (kata 9gy8)
+  — **RESOLVED (post-merge)**: replay-sourced focus reports are silenced at
+  the onData gate; branch the-usual/kata-9gy8-focus-silence,
+  docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md.
   that would make any junk-free window assertion conflate two distinct
   mechanisms. The sync-exclusion wire pin is the property this branch owns.
 - Marker-forcing rule coverage: renderer-recreate (settings change) → next attach has surfaceReset=true AND sinceSeq=0 (no delta-on-blank-surface).

--- a/docs/plans/2026-08-17-terminal-mode-replay-sync.md
+++ b/docs/plans/2026-08-17-terminal-mode-replay-sync.md
@@ -121,9 +121,10 @@ One shared JSON family `port/oracle/baselines/mode-preamble/*.json` (input: trac
   zero focus junk" shape was abandoned because xterm 6.0.0 re-fires a focus
   report on ANY arm — including the REPLAY of the original arming byte while
   it is still inside the retained window — a pre-existing leak (kata 9gy8)
-  — **RESOLVED (post-merge)**: replay-sourced focus reports are silenced at
-  the onData gate; branch the-usual/kata-9gy8-focus-silence,
-  docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md.
+  that would make any junk-free window assertion conflate two distinct
+  mechanisms. **RESOLVED (follow-up branch the-usual/kata-9gy8-focus-silence)**:
+  replay-sourced focus reports are silenced at the client onData gate;
+  see docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md.
   that would make any junk-free window assertion conflate two distinct
   mechanisms. The sync-exclusion wire pin is the property this branch owns.
 - Marker-forcing rule coverage: renderer-recreate (settings change) → next attach has surfaceReset=true AND sinceSeq=0 (no delta-on-blank-surface).

--- a/docs/plans/2026-08-17-terminal-mode-replay-sync.md
+++ b/docs/plans/2026-08-17-terminal-mode-replay-sync.md
@@ -124,9 +124,8 @@ One shared JSON family `port/oracle/baselines/mode-preamble/*.json` (input: trac
   that would make any junk-free window assertion conflate two distinct
   mechanisms. **RESOLVED (follow-up branch the-usual/kata-9gy8-focus-silence)**:
   replay-sourced focus reports are silenced at the client onData gate;
-  see docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md.
-  that would make any junk-free window assertion conflate two distinct
-  mechanisms. The sync-exclusion wire pin is the property this branch owns.
+  see docs/plans/2026-08-17-kata-9gy8-replay-focus-silence.md. The
+  sync-exclusion wire pin is the property this branch owns.
 - Marker-forcing rule coverage: renderer-recreate (settings change) → next attach has surfaceReset=true AND sinceSeq=0 (no delta-on-blank-surface).
 
 ### 6. Live verification (same shape as PR#649 Task 3)

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -131,6 +131,7 @@ import {
   shouldAllowTerminalOutputSideEffect,
   type TerminalOutputSource,
 } from '@/lib/terminal-output-write-scope'
+import { isReplayPhantomFocusReport } from '@/lib/terminal-output-side-effects'
 import {
   createTerminalStartupProbeState,
   extractTerminalStartupProbes,
@@ -2292,6 +2293,22 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     requestTerminalLayout({ fit: true, focus: true })
 
     term.onData((data) => {
+      if (isReplayPhantomFocusReport(data, terminalInstanceIdRef.current)) {
+        // Kata 9gy8: xterm re-fired a focus report because a replay chunk
+        // contained the app's ?1004h arm byte. Nothing about user focus
+        // changed; this is invented input. Swallow silently (no send, no
+        // activity) — the tracked mode state is untouched. The gate sits
+        // before EVERYTHING below (sendInput, engagement/activity recording)
+        // and before any "bind later" input buffering.
+        log.debug('replay phantom focus report silenced (kata 9gy8)', {
+          paneId,
+          tabId,
+          // data is known-exact here (the gate only matches the two focus
+          // report strings), so endsWith safely reads the direction.
+          direction: data.endsWith('[I') ? 'in' : 'out',
+        })
+        return
+      }
       sendInput(data)
       // Decision 1: a real keystroke (printable / Enter) dismisses this tab's green
       // in BOTH attentionDismiss modes. Bare arrows / synthetic sequences do not.

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -2293,7 +2293,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     requestTerminalLayout({ fit: true, focus: true })
 
     term.onData((data) => {
-      if (isReplayPhantomFocusReport(data, terminalInstanceIdRef.current)) {
+      if (isReplayPhantomFocusReport(data, terminalInstanceId)) {
         // Kata 9gy8: xterm re-fired a focus report because a replay chunk
         // contained the app's ?1004h arm byte. Nothing about user focus
         // changed; this is invented input. Swallow silently (no send, no

--- a/src/lib/terminal-output-side-effects.ts
+++ b/src/lib/terminal-output-side-effects.ts
@@ -94,8 +94,8 @@ export function shouldAllowTerminalOutputSideEffect(
   return false
 }
 
-const XTERM_FOCUS_IN = '[I'
-const XTERM_FOCUS_OUT = '[O'
+const XTERM_FOCUS_IN = '\u001b[I'
+const XTERM_FOCUS_OUT = '\u001b[O'
 
 /**
  * xterm fires ESC[I / ESC[O synchronously from its parser every time it

--- a/src/lib/terminal-output-side-effects.ts
+++ b/src/lib/terminal-output-side-effects.ts
@@ -93,3 +93,24 @@ export function shouldAllowTerminalOutputSideEffect(
 
   return false
 }
+
+const XTERM_FOCUS_IN = '[I'
+const XTERM_FOCUS_OUT = '[O'
+
+/**
+ * xterm fires ESC[I / ESC[O synchronously from its parser every time it
+ * parses a ?1004h arm byte — including when that byte arrives via history
+ * replay (kata 9gy8). Such a replay-triggered report is a phantom: nothing
+ * about user focus changed, and the app receives an invented keypress.
+ * The replay write scope (“suppressExternalSideEffects”) is held open until
+ * xterm's write callback, which covers both synchronous and deferred parses,
+ * so it is the correct discriminator; the exact-bytes check keeps all other
+ * input untouched.
+ */
+export function isReplayPhantomFocusReport(
+  data: string,
+  terminalInstanceId: string | undefined,
+): boolean {
+  if (data !== XTERM_FOCUS_IN && data !== XTERM_FOCUS_OUT) return false
+  return getTerminalOutputWriteScope(terminalInstanceId)?.suppressExternalSideEffects === true
+}

--- a/src/lib/terminal-output-write-scope.ts
+++ b/src/lib/terminal-output-write-scope.ts
@@ -22,25 +22,36 @@ export type TerminalOutputWriteContext = {
   suppressExternalSideEffects: boolean
 }
 
-const activeScopes = new Map<string, TerminalOutputWriteContext>()
+const activeScopes = new Map<string, TerminalOutputWriteContext[]>()
 
 export function getTerminalOutputWriteScope(
   terminalInstanceId: string | undefined,
 ): TerminalOutputWriteContext | null {
   if (!terminalInstanceId) return null
-  return activeScopes.get(terminalInstanceId) ?? null
+  const stack = activeScopes.get(terminalInstanceId)
+  if (!stack || stack.length === 0) return null
+  return stack[stack.length - 1]
 }
 
 export function beginTerminalOutputWriteScope(
   context: TerminalOutputWriteContext,
 ): { complete: () => void } {
-  activeScopes.set(context.terminalInstanceId, context)
+  let stack = activeScopes.get(context.terminalInstanceId)
+  if (!stack) {
+    stack = []
+    activeScopes.set(context.terminalInstanceId, stack)
+  }
+  stack.push(context)
   let completed = false
   return {
     complete: () => {
       if (completed) return
       completed = true
-      if (activeScopes.get(context.terminalInstanceId) === context) {
+      const index = stack.indexOf(context)
+      if (index !== -1) {
+        stack.splice(index, 1)
+      }
+      if (stack.length === 0) {
         activeScopes.delete(context.terminalInstanceId)
       }
     },

--- a/test/e2e-browser/specs/multi-client.spec.ts
+++ b/test/e2e-browser/specs/multi-client.spec.ts
@@ -820,6 +820,95 @@ test.describe('Multi-Client', () => {
     await context.close()
   })
 
+  test('mode replay-sync: replay no longer injects phantom xterm focus reports (kata 9gy8)', async ({ browser, serverInfo }) => {
+    // Kata 9gy8 wire proof. xterm 6.0.0 re-fires the app's ?1004 focus-report
+    // switch on EVERY ?1004h parse — including when the arming byte is inside
+    // a replayed history chunk (page reload here) — and _reportFocus
+    // immediately emits ESC[I (focused surface) / ESC[O (unfocused) as
+    // synthetic input. The client gate (TerminalView onData +
+    // isReplayPhantomFocusReport) must swallow that invented keypress while
+    // the replay write scope is open, so the shell/app never sees an
+    // un-requested focus keystroke. The arm itself must survive: the replayed
+    // arm byte still sets sendFocusMode on the fresh surface (asserted via
+    // the harness modes accessor) — the mode is re-armed, the report is not.
+    test.setTimeout(120_000)
+    const context = await newClientContext(browser)
+    const page = await context.newPage()
+    await page.setViewportSize({ width: 1400, height: 900 })
+    await page.goto(`${serverInfo.baseUrl}/?token=${serverInfo.token}&e2e=1`)
+    await waitForReady(page)
+    await ensureTerminalReady(page)
+
+    const terminalId = await getActiveTerminalId(page)
+    expect(terminalId).toBeTruthy()
+    await flushPersistedLayout(page, terminalId!)
+
+    // Arm focus reporting exactly like a terminal app would (keyboard-typed
+    // printf, matching the sibling mode-sync specs). The arm byte is now
+    // inside the retained replay window, so the reload below re-feeds it to
+    // a fresh xterm surface.
+    await executeCommand(page, `printf '\\x1b[?1004h'; echo __FOCUS_ARMED__`)
+    await waitForTerminalText(page, '__FOCUS_ARMED__', terminalId!)
+    await page.waitForFunction((id) => {
+      const modes = window.__FRESHELL_TEST_HARNESS__?.getTerminalModes?.(id)
+      return modes?.sendFocusMode === true
+    }, terminalId, { timeout: 15_000 })
+
+    // Reload: fresh xterm surface, rehydrated via surfaceReset attach + sync
+    // preamble + retained-window replay. The reload installs a fresh harness,
+    // so getSentWsMessages is a clean, window-scoped record of every
+    // client→server message since boot — that IS the assertion window: it
+    // starts at reload-ready by construction and ends just after the arm is
+    // re-observed, so a genuine live focus report (impossible in headless
+    // anyway) can never flake it.
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await waitForReady(page)
+
+    // The fresh surface must claim a full wipe+hydrate and re-present the
+    // marker — proof the retained window (containing the ?1004h byte) replayed.
+    await page.waitForFunction((id) => {
+      const sent = window.__FRESHELL_TEST_HARNESS__?.getSentWsMessages?.() ?? []
+      return sent.some((m: any) =>
+        m?.type === 'terminal.attach'
+        && m?.terminalId === id
+        && m?.surfaceReset === true
+        && m?.sinceSeq === 0)
+    }, terminalId, { timeout: 45_000 })
+    await waitForTerminalText(page, '__FOCUS_ARMED__', terminalId!, 45_000)
+
+    // Arm restored by the replay: xterm parsed ?1004h out of the replayed
+    // chunk. This is the meaning-proving half — without it, "no phantom
+    // input" would pass vacuously on a surface that never saw the arm byte.
+    // xterm sets decPrivateModes.sendFocus and fires _reportFocus in the SAME
+    // parse step, so by the time this wait resolves the phantom (pre-fix)
+    // has already been emitted and recorded.
+    await page.waitForFunction((id) => {
+      const modes = window.__FRESHELL_TEST_HARNESS__?.getTerminalModes?.(id)
+      return modes?.sendFocusMode === true
+    }, terminalId, { timeout: 45_000 })
+
+    // Short settle for any same-tick send-path drift, then close the window:
+    // no terminal.input this client sent since reload may contain ESC[I or
+    // ESC[O (checked against both directions — the fresh surface has no
+    // 'focus' class headlessly, so the phantom variant is the blur report,
+    // but the gate is byte-exact either way).
+    await page.waitForTimeout(500)
+    const phantomInputs: any[] = await page.evaluate((id) => {
+      const sent = window.__FRESHELL_TEST_HARNESS__?.getSentWsMessages?.() ?? []
+      return sent.filter((m: any) =>
+        m?.type === 'terminal.input'
+        && m?.terminalId === id
+        && typeof m?.data === 'string'
+        && (m.data.includes('[I') || m.data.includes('[O')))
+    }, terminalId)
+    expect(
+      phantomInputs,
+      `replay of the ?1004h arm byte must not inject a focus report into the app; got: ${JSON.stringify(phantomInputs)}`,
+    ).toHaveLength(0)
+
+    await context.close()
+  })
+
   test('client disconnect is handled gracefully', async ({ browser, serverInfo }) => {
     const context = await newClientContext(browser)
     const page1 = await context.newPage()

--- a/test/e2e-browser/specs/multi-client.spec.ts
+++ b/test/e2e-browser/specs/multi-client.spec.ts
@@ -731,7 +731,8 @@ test.describe('Multi-Client', () => {
     // into the app's stdin. The preamble therefore tracks but NEVER emits
     // ?1004. (Replaying the ORIGINAL arming byte from the retained window no
     // longer leaks either: kata 9gy8 silences the phantom report at onData;
-    // see the SILENCING test later in this spec.)
+    // pinned by "mode replay-sync: replay no longer injects phantom xterm
+    // focus reports (kata 9gy8)" later in this spec.)
     //
     // This pins the wire behavior DIRECTLY: arm both a representative mode
     // (?2004, included) and ?1004, reload (fresh surface → surfaceReset
@@ -860,8 +861,8 @@ test.describe('Multi-Client', () => {
     // so getSentWsMessages is a clean, window-scoped record of every
     // client→server message since boot — that IS the assertion window: it
     // starts at reload-ready by construction and ends just after the arm is
-    // re-observed, so a genuine live focus report (impossible in headless
-    // anyway) can never flake it.
+    // re-observed; a genuine live focus report cannot flake it here because
+    // no focus change occurs post-arm in this flow.
     await page.reload({ waitUntil: 'domcontentloaded' })
     await waitForReady(page)
 

--- a/test/e2e-browser/specs/multi-client.spec.ts
+++ b/test/e2e-browser/specs/multi-client.spec.ts
@@ -729,8 +729,9 @@ test.describe('Multi-Client', () => {
     // _reportFocus immediately emits ESC[I/ESC[O on a focused surface — so a
     // sync preamble replaying ?1004h would deterministically inject junk
     // into the app's stdin. The preamble therefore tracks but NEVER emits
-    // ?1004. (Replaying the ORIGINAL arming byte while it is still inside
-    // the retained window is a pre-existing leak, out of scope here.)
+    // ?1004. (Replaying the ORIGINAL arming byte from the retained window no
+    // longer leaks either: kata 9gy8 silences the phantom report at onData;
+    // see the SILENCING test later in this spec.)
     //
     // This pins the wire behavior DIRECTLY: arm both a representative mode
     // (?2004, included) and ?1004, reload (fresh surface → surfaceReset
@@ -890,8 +891,9 @@ test.describe('Multi-Client', () => {
     // Short settle for any same-tick send-path drift, then close the window:
     // no terminal.input this client sent since reload may contain ESC[I or
     // ESC[O (checked against both directions — the fresh surface has no
-    // 'focus' class headlessly, so the phantom variant is the blur report,
-    // but the gate is byte-exact either way).
+    // 'focus' class headlessly — which variant the phantom takes depends on
+    // xterm's focus class at arm-parse time; the gate is byte-exact either
+    // way, so assert against both).
     await page.waitForTimeout(500)
     const phantomInputs: any[] = await page.evaluate((id) => {
       const sent = window.__FRESHELL_TEST_HARNESS__?.getSentWsMessages?.() ?? []
@@ -899,7 +901,7 @@ test.describe('Multi-Client', () => {
         m?.type === 'terminal.input'
         && m?.terminalId === id
         && typeof m?.data === 'string'
-        && (m.data.includes('[I') || m.data.includes('[O')))
+        && (m.data.includes('\u001b[I') || m.data.includes('\u001b[O')))
     }, terminalId)
     expect(
       phantomInputs,

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -6,6 +6,8 @@ import tabsReducer, { setActiveTab } from '@/store/tabsSlice'
 import panesReducer, { removeLayout, requestPaneRefresh } from '@/store/panesSlice'
 import settingsReducer, { defaultSettings, updateSettingsLocal } from '@/store/settingsSlice'
 import connectionReducer, { setStatus as setConnectionStatus } from '@/store/connectionSlice'
+import sessionActivityReducer from '@/store/sessionActivitySlice'
+import tabRecencyReducer from '@/store/tabRecencySlice'
 import turnCompletionReducer from '@/store/turnCompletionSlice'
 import paneRuntimeActivityReducer from '@/store/paneRuntimeActivitySlice'
 import { persistMiddleware, resetPersistedLayoutCacheForTests, resetPersistFlushListenersForTests } from '@/store/persistMiddleware'
@@ -9961,4 +9963,315 @@ describe('terminal.modes.sync (surface-reset mode preamble)', () => {
     return terminalWriteStrings(term)
   }
   function storeSentCount(): number { return wsMocks.send.mock.calls.length }
+})
+
+describe('replay phantom focus report silencing (kata 9gy8)', () => {
+  let messageHandler: ((msg: any) => void) | null = null
+  let reconnectHandler: (() => void) | null = null
+
+  const TERMINAL_ID = 'term-9gy8-focus'
+  const TAB_ID = 'tab-9gy8-focus'
+  const PANE_ID = 'pane-9gy8-focus'
+
+  const FOCUS_IN = '\u001b[I'
+  const FOCUS_OUT = '\u001b[O'
+  const ARM_FOCUS_REPORTING = '\u001b[?1004h'
+
+  function setupPane() {
+    const paneContent: TerminalPaneContent = {
+      kind: 'terminal',
+      createRequestId: 'req-9gy8-focus',
+      status: 'running',
+      mode: 'shell',
+      shell: 'system',
+      terminalId: TERMINAL_ID,
+    }
+    const root: PaneNode = { type: 'leaf', id: PANE_ID, content: paneContent }
+    const store = configureStore({
+      reducer: {
+        tabs: tabsReducer,
+        panes: panesReducer,
+        settings: settingsReducer,
+        connection: connectionReducer,
+        turnCompletion: turnCompletionReducer,
+        tabRecency: tabRecencyReducer,
+        sessionActivity: sessionActivityReducer,
+      },
+      preloadedState: {
+        tabs: {
+          tabs: [{
+            id: TAB_ID,
+            mode: 'shell',
+            status: 'running',
+            title: 'Shell',
+            titleSetByUser: false,
+            terminalId: TERMINAL_ID,
+            createRequestId: 'req-9gy8-focus',
+          }],
+          activeTabId: TAB_ID,
+        },
+        panes: {
+          layouts: { [TAB_ID]: root },
+          activePane: { [TAB_ID]: PANE_ID },
+          paneTitles: {},
+        },
+        settings: createSettingsState(),
+        connection: { status: 'connected', error: null, serverInstanceId: 'srv-9gy8' },
+        turnCompletion: { seq: 0, lastAtByTerminalId: {}, pendingEvents: [], attentionByTab: {} },
+        tabRecency: { version: 1, paneLastInputAt: {} },
+        sessionActivity: { sessions: {} },
+      },
+    })
+    return { store, paneContent }
+  }
+
+  function sentAttaches() {
+    return wsMocks.send.mock.calls
+      .map(([m]) => m)
+      .filter((m) => m?.type === 'terminal.attach' && m.terminalId === TERMINAL_ID)
+  }
+
+  function sentInputs() {
+    return wsMocks.send.mock.calls
+      .map(([m]) => m)
+      .filter((m) => m?.type === 'terminal.input' && m.terminalId === TERMINAL_ID)
+  }
+
+  function sentFocusReports() {
+    return sentInputs().filter((m) => m?.data === FOCUS_IN || m?.data === FOCUS_OUT)
+  }
+
+  function inputActivityActionTypes(dispatchSpy: ReturnType<typeof vi.fn>): string[] {
+    return dispatchSpy.mock.calls
+      .map((call) => (call[0] as { type?: unknown } | undefined)?.type)
+      .filter((type): type is string => typeof type === 'string')
+      .filter((type) => type === 'tabRecency/recordPaneTabActivity' || type === 'sessionActivity/updateSessionActivity')
+  }
+
+  function getTerm() {
+    const term = terminalInstances[terminalInstances.length - 1]
+    expect(term, 'a mock xterm instance must exist').toBeTruthy()
+    return term
+  }
+
+  function getOnDataHandler(): (data: string) => void {
+    const handler = getTerm().onData.mock.calls.at(-1)?.[0]
+    expect(handler, 'xterm onData handler must be registered').toBeTruthy()
+    return handler
+  }
+
+  async function renderPane() {
+    const { store, paneContent } = setupPane()
+    // Activity-observation pattern (same as TerminalView.lastInputAt.test.tsx):
+    // a pass-through dispatch spy, installed BEFORE render so useAppDispatch
+    // captures it.
+    const originalDispatch = store.dispatch
+    const dispatchSpy = vi.fn((action) => originalDispatch(action))
+    store.dispatch = dispatchSpy as typeof store.dispatch
+    render(
+      <Provider store={store}>
+        <TerminalView tabId={TAB_ID} paneId={PANE_ID} paneContent={paneContent} />
+      </Provider>
+    )
+    await waitFor(() => {
+      expect(terminalInstances.length).toBeGreaterThan(0)
+      expect(messageHandler).not.toBeNull()
+      expect(reconnectHandler).not.toBeNull()
+    })
+    return { store, dispatchSpy }
+  }
+
+  async function beginAttachWithReplayWindow(replayToSeq: number) {
+    await waitFor(() => expect(sentAttaches().length).toBe(1))
+    act(() => {
+      messageHandler!({
+        type: 'terminal.attach.ready',
+        terminalId: TERMINAL_ID,
+        headSeq: replayToSeq,
+        replayFromSeq: 1,
+        replayToSeq,
+      })
+    })
+  }
+
+  // Drive a replay chunk whose write fires the registered xterm onData handler
+  // with `fireDuringWrite` WHILE the chunk's replay write scope is still open —
+  // the exact timing a real xterm produces when a replayed chunk contains the
+  // app's ?1004h arm byte (xterm's parser re-fires the report mid-parse, before
+  // the write callback runs and completes the scope). Firing onData after the
+  // write resolves would be post-scope and would NOT exercise the gate.
+  function writeReplayChunk(input: { seqStart: number; seqEnd: number; data: string; fireDuringWrite?: string }) {
+    const term = getTerm()
+    if (input.fireDuringWrite !== undefined) {
+      const onData = getOnDataHandler()
+      const payload = input.fireDuringWrite
+      term.write.mockImplementationOnce((_chunk: string, onWritten?: () => void) => {
+        onData(payload)
+        onWritten?.()
+      })
+    }
+    act(() => {
+      messageHandler!({
+        type: 'terminal.output',
+        terminalId: TERMINAL_ID,
+        seqStart: input.seqStart,
+        seqEnd: input.seqEnd,
+        data: input.data,
+      })
+    })
+  }
+
+  beforeEach(() => {
+    vi.useRealTimers()
+    clearLocalStorageForTest()
+    __resetTerminalCursorCacheForTests()
+    __resetLastSentViewportCacheForTests()
+    resetHydrationQueueForTests()
+    resetPersistedLayoutCacheForTests()
+    resetPersistFlushListenersForTests()
+    latestAttachRequestIdByTerminal.clear()
+    latestStreamIdByTerminal.clear()
+    wsMocks.isReady = true
+    wsMocks.send.mockClear()
+    wsMocks.send.mockImplementation((msg: any) => {
+      if (
+        msg?.type === 'terminal.attach'
+        && typeof msg.terminalId === 'string'
+        && typeof msg.attachRequestId === 'string'
+      ) {
+        latestAttachRequestIdByTerminal.set(msg.terminalId, msg.attachRequestId)
+      }
+    })
+    wsMocks.onMessage.mockImplementation((callback: (msg: any) => void) => {
+      messageHandler = (msg: any) => callback(withCurrentAttachRequestId(msg))
+      return () => { messageHandler = null }
+    })
+    wsMocks.onReconnect.mockImplementation((callback: () => void) => {
+      reconnectHandler = callback
+      return () => {
+        if (reconnectHandler === callback) reconnectHandler = null
+      }
+    })
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+    terminalInstances.length = 0
+    runtimeMocks.instances.length = 0
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+    installPerfAuditBridge(null)
+    restoreMocks.consumeTerminalRestoreRequestId.mockReset()
+    restoreMocks.consumeTerminalRestoreRequestId.mockReturnValue(false)
+    terminalThemeMocks.getTerminalTheme.mockReset()
+    terminalThemeMocks.getTerminalTheme.mockReturnValue({})
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    clearLocalStorageForTest()
+    __resetTerminalCursorCacheForTests()
+    resetHydrationQueueForTests()
+    latestAttachRequestIdByTerminal.clear()
+    latestStreamIdByTerminal.clear()
+    messageHandler = null
+    reconnectHandler = null
+    installPerfAuditBridge(null)
+  })
+
+  it('swallows a phantom focus-in report fired while the replay write scope is open (no ws input, no input activity)', async () => {
+    const { store, dispatchSpy } = await renderPane()
+    await beginAttachWithReplayWindow(1)
+
+    dispatchSpy.mockClear()
+    writeReplayChunk({
+      seqStart: 1,
+      seqEnd: 1,
+      data: `${ARM_FOCUS_REPORTING}armed prompt$ `,
+      fireDuringWrite: FOCUS_IN,
+    })
+
+    // The replay chunk itself renders — the arm byte's text companions are written.
+    expect(terminalWriteStrings(getTerm()).join('')).toContain('armed prompt$ ')
+    // But the phantom report the parse invented reaches neither the wire nor the
+    // input-activity ledgers.
+    expect(sentFocusReports()).toEqual([])
+    expect(inputActivityActionTypes(dispatchSpy)).toEqual([])
+    expect(store.getState().tabRecency.paneLastInputAt[PANE_ID]).toBeUndefined()
+  })
+
+  it('swallows the blur variant (focus-out report) during replay', async () => {
+    const { store, dispatchSpy } = await renderPane()
+    await beginAttachWithReplayWindow(1)
+
+    dispatchSpy.mockClear()
+    writeReplayChunk({
+      seqStart: 1,
+      seqEnd: 1,
+      data: `${ARM_FOCUS_REPORTING}armed prompt$ `,
+      fireDuringWrite: FOCUS_OUT,
+    })
+
+    expect(terminalWriteStrings(getTerm()).join('')).toContain('armed prompt$ ')
+    expect(sentFocusReports()).toEqual([])
+    expect(inputActivityActionTypes(dispatchSpy)).toEqual([])
+    expect(store.getState().tabRecency.paneLastInputAt[PANE_ID]).toBeUndefined()
+  })
+
+  it('leaves non-focus input untouched during the same replay scope window (bytes-level gate, not batch-level)', async () => {
+    const { dispatchSpy } = await renderPane()
+    await beginAttachWithReplayWindow(1)
+
+    dispatchSpy.mockClear()
+    writeReplayChunk({
+      seqStart: 1,
+      seqEnd: 1,
+      data: `${ARM_FOCUS_REPORTING}armed prompt$ `,
+      fireDuringWrite: 'x',
+    })
+
+    // A genuine keystroke landing mid-replay-write still goes to the wire…
+    expect(sentInputs().filter((m) => m?.data === 'x')).toHaveLength(1)
+    // …and the replay chunk itself is ingested normally.
+    expect(terminalWriteStrings(getTerm()).join('')).toContain('armed prompt$ ')
+  })
+
+  it('still forwards a live focus report when no replay scope is open', async () => {
+    await renderPane()
+    await waitFor(() => expect(sentAttaches().length).toBe(1))
+    act(() => {
+      messageHandler!({
+        type: 'terminal.attach.ready',
+        terminalId: TERMINAL_ID,
+        headSeq: 0,
+        replayFromSeq: 0,
+        replayToSeq: 0,
+      })
+    })
+
+    fireData(getTerm(), FOCUS_IN)
+
+    expect(sentFocusReports()).toHaveLength(1)
+  })
+
+  it('swallows the phantom on every replay of the same pane (no first-time-only state)', async () => {
+    const { store, dispatchSpy } = await renderPane()
+    await beginAttachWithReplayWindow(2)
+
+    dispatchSpy.mockClear()
+    for (const seq of [1, 2]) {
+      writeReplayChunk({
+        seqStart: seq,
+        seqEnd: seq,
+        data: `${ARM_FOCUS_REPORTING}replay line ${seq}\r\n`,
+        fireDuringWrite: FOCUS_IN,
+      })
+    }
+
+    expect(terminalWriteStrings(getTerm()).join('')).toContain('replay line 2')
+    expect(sentFocusReports()).toEqual([])
+    expect(inputActivityActionTypes(dispatchSpy)).toEqual([])
+    expect(store.getState().tabRecency.paneLastInputAt[PANE_ID]).toBeUndefined()
+  })
 })

--- a/test/unit/client/lib/terminal-output-side-effects.test.ts
+++ b/test/unit/client/lib/terminal-output-side-effects.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { registerTerminalRequestModeBypass } from '@/components/terminal/request-mode-bypass'
+import { isReplayPhantomFocusReport } from '@/lib/terminal-output-side-effects'
 import {
   beginTerminalOutputWriteScope,
   shouldAllowTerminalOutputSideEffect,
@@ -156,7 +157,90 @@ describe('terminal output side-effect policy', () => {
       suppressExternalSideEffects: false,
     })
     expect(privateHandler([2004])).toBe(true)
-    expect(sendInput).toHaveBeenCalledWith('\u001b[?2004;1$y')
+    expect(sendInput).toHaveBeenCalledWith('[?2004;1$y')
     liveScope.complete()
+  })
+})
+
+describe('isReplayPhantomFocusReport', () => {
+  it('swallows ESC[I and ESC[O while a suppressing replay write scope is open', () => {
+    const scope = beginTerminalOutputWriteScope({
+      terminalInstanceId: 't1',
+      source: 'replay',
+      attachRequestId: undefined,
+      generation: 'g',
+      suppressExternalSideEffects: true,
+    })
+    try {
+      expect(isReplayPhantomFocusReport('[I', 't1')).toBe(true)
+      expect(isReplayPhantomFocusReport('[O', 't1')).toBe(true)
+    } finally {
+      scope.complete()
+    }
+  })
+
+  it('passes focus reports through inside a live (non-suppressing) scope', () => {
+    const scope = beginTerminalOutputWriteScope({
+      terminalInstanceId: 't1',
+      source: 'live',
+      attachRequestId: undefined,
+      generation: 'g',
+      suppressExternalSideEffects: false,
+    })
+    try {
+      expect(isReplayPhantomFocusReport('[I', 't1')).toBe(false)
+      expect(isReplayPhantomFocusReport('[O', 't1')).toBe(false)
+    } finally {
+      scope.complete()
+    }
+  })
+
+  it('passes focus reports through when no write scope is open', () => {
+    expect(isReplayPhantomFocusReport('[I', 't1')).toBe(false)
+    expect(isReplayPhantomFocusReport('[O', 't1')).toBe(false)
+  })
+
+  it('leaves non-report bytes untouched even under a suppressing replay scope', () => {
+    const scope = beginTerminalOutputWriteScope({
+      terminalInstanceId: 't1',
+      source: 'replay',
+      attachRequestId: undefined,
+      generation: 'g',
+      suppressExternalSideEffects: true,
+    })
+    try {
+      expect(isReplayPhantomFocusReport('a', 't1')).toBe(false)
+      expect(isReplayPhantomFocusReport('[?1004h', 't1')).toBe(false)
+    } finally {
+      scope.complete()
+    }
+  })
+
+  it('does not swallow reports for a different terminal instance', () => {
+    const scope = beginTerminalOutputWriteScope({
+      terminalInstanceId: 't1',
+      source: 'replay',
+      attachRequestId: undefined,
+      generation: 'g',
+      suppressExternalSideEffects: true,
+    })
+    try {
+      expect(isReplayPhantomFocusReport('[I', 't2')).toBe(false)
+    } finally {
+      scope.complete()
+    }
+  })
+
+  it('releases the swallow once the scope completes', () => {
+    const scope = beginTerminalOutputWriteScope({
+      terminalInstanceId: 't1',
+      source: 'replay',
+      attachRequestId: undefined,
+      generation: 'g',
+      suppressExternalSideEffects: true,
+    })
+    expect(isReplayPhantomFocusReport('[I', 't1')).toBe(true)
+    scope.complete()
+    expect(isReplayPhantomFocusReport('[I', 't1')).toBe(false)
   })
 })

--- a/test/unit/client/lib/terminal-output-side-effects.test.ts
+++ b/test/unit/client/lib/terminal-output-side-effects.test.ts
@@ -157,7 +157,7 @@ describe('terminal output side-effect policy', () => {
       suppressExternalSideEffects: false,
     })
     expect(privateHandler([2004])).toBe(true)
-    expect(sendInput).toHaveBeenCalledWith('[?2004;1$y')
+    expect(sendInput).toHaveBeenCalledWith('\u001b[?2004;1$y')
     liveScope.complete()
   })
 })
@@ -172,8 +172,8 @@ describe('isReplayPhantomFocusReport', () => {
       suppressExternalSideEffects: true,
     })
     try {
-      expect(isReplayPhantomFocusReport('[I', 't1')).toBe(true)
-      expect(isReplayPhantomFocusReport('[O', 't1')).toBe(true)
+      expect(isReplayPhantomFocusReport('\u001b[I', 't1')).toBe(true)
+      expect(isReplayPhantomFocusReport('\u001b[O', 't1')).toBe(true)
     } finally {
       scope.complete()
     }
@@ -188,16 +188,16 @@ describe('isReplayPhantomFocusReport', () => {
       suppressExternalSideEffects: false,
     })
     try {
-      expect(isReplayPhantomFocusReport('[I', 't1')).toBe(false)
-      expect(isReplayPhantomFocusReport('[O', 't1')).toBe(false)
+      expect(isReplayPhantomFocusReport('\u001b[I', 't1')).toBe(false)
+      expect(isReplayPhantomFocusReport('\u001b[O', 't1')).toBe(false)
     } finally {
       scope.complete()
     }
   })
 
   it('passes focus reports through when no write scope is open', () => {
-    expect(isReplayPhantomFocusReport('[I', 't1')).toBe(false)
-    expect(isReplayPhantomFocusReport('[O', 't1')).toBe(false)
+    expect(isReplayPhantomFocusReport('\u001b[I', 't1')).toBe(false)
+    expect(isReplayPhantomFocusReport('\u001b[O', 't1')).toBe(false)
   })
 
   it('leaves non-report bytes untouched even under a suppressing replay scope', () => {
@@ -210,7 +210,7 @@ describe('isReplayPhantomFocusReport', () => {
     })
     try {
       expect(isReplayPhantomFocusReport('a', 't1')).toBe(false)
-      expect(isReplayPhantomFocusReport('[?1004h', 't1')).toBe(false)
+      expect(isReplayPhantomFocusReport('\u001b[?1004h', 't1')).toBe(false)
     } finally {
       scope.complete()
     }
@@ -225,7 +225,7 @@ describe('isReplayPhantomFocusReport', () => {
       suppressExternalSideEffects: true,
     })
     try {
-      expect(isReplayPhantomFocusReport('[I', 't2')).toBe(false)
+      expect(isReplayPhantomFocusReport('\u001b[I', 't2')).toBe(false)
     } finally {
       scope.complete()
     }
@@ -239,8 +239,8 @@ describe('isReplayPhantomFocusReport', () => {
       generation: 'g',
       suppressExternalSideEffects: true,
     })
-    expect(isReplayPhantomFocusReport('[I', 't1')).toBe(true)
+    expect(isReplayPhantomFocusReport('\u001b[I', 't1')).toBe(true)
     scope.complete()
-    expect(isReplayPhantomFocusReport('[I', 't1')).toBe(false)
+    expect(isReplayPhantomFocusReport('\u001b[I', 't1')).toBe(false)
   })
 })

--- a/test/unit/client/lib/terminal-output-side-effects.test.ts
+++ b/test/unit/client/lib/terminal-output-side-effects.test.ts
@@ -197,6 +197,7 @@ describe('isReplayPhantomFocusReport', () => {
 
   it('passes focus reports through when no write scope is open', () => {
     expect(isReplayPhantomFocusReport('\u001b[I', 't1')).toBe(false)
+    expect(isReplayPhantomFocusReport('\u001b[I', undefined)).toBe(false)
     expect(isReplayPhantomFocusReport('\u001b[O', 't1')).toBe(false)
   })
 

--- a/test/unit/client/lib/terminal-output-write-scope.test.ts
+++ b/test/unit/client/lib/terminal-output-write-scope.test.ts
@@ -50,6 +50,36 @@ describe('terminal output write scope', () => {
     expect(getTerminalOutputWriteScope('surface-1')).toBeNull()
   })
 
+  it('restores the outer replay-suppress scope when an overlapping inner scope completes out of order', () => {
+    const replayScope = beginTerminalOutputWriteScope({
+      terminalInstanceId: 'surface-1',
+      source: 'replay',
+      attachRequestId: 'attach-1',
+      generation: 'attach-1',
+      suppressExternalSideEffects: true,
+    })
+    const liveScope = beginTerminalOutputWriteScope({
+      terminalInstanceId: 'surface-1',
+      source: 'live',
+      attachRequestId: 'attach-2',
+      generation: 'attach-2',
+      suppressExternalSideEffects: false,
+    })
+
+    // The inner live scope completes first; the outer replay scope must still
+    // be the active scope for the instance (a single-slot map would have lost
+    // it when the inner scope began).
+    liveScope.complete()
+    expect(getTerminalOutputWriteScope('surface-1')).toMatchObject({
+      source: 'replay',
+      attachRequestId: 'attach-1',
+      suppressExternalSideEffects: true,
+    })
+
+    replayScope.complete()
+    expect(getTerminalOutputWriteScope('surface-1')).toBeNull()
+  })
+
   it('suppresses external side effects during replay writes', () => {
     expect(shouldAllowTerminalOutputSideEffect({
       terminalInstanceId: 'surface-1',


### PR DESCRIPTION
## Problem

When saved terminal history is replayed to rebuild a pane (page reload, pane refresh, reconnect attach, split-pane open, resize rebinding), xterm.js re-fires the app's "report focus" switch (`?1004h`) present in the replayed chunk and immediately tells the app "you just got focus" — an invented keypress (`ESC[I`/`ESC[O`, observed live in opencode) the app never asked for.

## Fix (client-only; server protocol untouched)

- `terminal-output-side-effects.ts`: pure predicate `isReplayPhantomFocusReport(data, terminalInstanceId)` — true only for the exact report bytes while the current write scope has `suppressExternalSideEffects: true`.
- `terminal-output-write-scope.ts`: single-slot scope map upgraded to a per-instance identity-checked stack, closing an out-of-order-completion leak the load-bearing stage found.
- `TerminalView.tsx`: the `term.onData` gate is the first statement — a swallowed report reaches none of ws input, activity ledgers, the un-anchored buffer, or green-dismiss.
- Mode state is untouched: the arm still lands (`sendFocusMode === true` after replay); only the phantom report is silenced.

## Tests

- Predicate suite: swallow/live/no-scope/non-report/cross-instance/undefined-instance/scope-release (11/11).
- Lifecycle integration: onData fired inside an open suppress scope via `write.mockImplementationOnce` (the only timing that exercises the gate); red proven pre-fix with phantom observed in the send stream (157/157 green post).
- E2E (`multi-client.spec.ts`, all 3 legs): keyboard-arm, reload, arm provably restored, zero `ESC[I`/`ESC[O` in post-reload input. Red-state pinned by predicate mutation (receipt recorded in run logs).
- Full gate `npm run check` green at HEAD (twice).

## Process

Ran the-usual: load-bearing validation (4 plan defects caught pre-implementation), plan fresh-eyes PASSED R1, per-task reviews PASS, delta fresh-eyes PASSED R1, all findings dispositioned. Kata `9gy8` will be closed on merge. Accepted residual (documented): a genuine focus event landing during an active replay write is also silenced; the next click re-reports focus.