### PR TITLE
fix(cloud-run): unique per-run jobs create/execute/delete; e2e wrapper fails closed

### DIFF
--- a/scripts/e2e-cloud.sh
+++ b/scripts/e2e-cloud.sh
@@ -95,6 +95,19 @@ gcloud_flags() {
   echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --region=${GCP_REGION}"
 }
 
+# Unique per-run job. `gcloud run jobs execute` snapshots the job's CURRENT
+# template, so sharing one job across runs lets a concurrent run's job update
+# swap the image/config of an in-flight run, and forces "find my execution"
+# to fall back to "the latest execution of the shared job" — which may be
+# another run's results. Every run therefore creates its own job
+# (<prefix>-<imagetag>-<random6>), executes it, and deletes it on every exit
+# path (success, failure, SIGINT/SIGTERM). FRESHELL_GCP_JOB is the prefix.
+unique_job_name() {
+  local rand
+  rand=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 6)
+  printf '%s-%s-%s' "$GCP_JOB" "$(image_tag_for_head)" "$rand"
+}
+
 # gcloud artifacts commands use --location, not --region
 gcloud_artifacts_flags() {
   echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --location=${GCP_REGION}"
@@ -126,6 +139,14 @@ Flags:
 
 Environment:
   FRESHELL_E2E_BACKEND  "local" (default) or "cloud"
+  FRESHELL_GCP_JOB      Cloud Run job-name prefix (default: freshell-e2e)
+
+Cloud job lifecycle: each cloud run creates its OWN unique job
+(<prefix>-<commit>[-dirty]-<random>), executes it, and deletes it
+afterwards — never a shared job — so concurrent runs cannot overwrite each
+other's image/config or read each other's results. The 'logs' subcommand
+reads the legacy shared job only; per-run logs are printed in full during
+the run and remain in Cloud Logging afterwards.
 
 Examples:
   scripts/e2e-cloud.sh run --local --project=chromium test/e2e-browser/specs/auth.spec.ts
@@ -385,7 +406,7 @@ cmd_run() {
   echo "[e2e-cloud]   Timeout: $timeout"
   echo "[e2e-cloud]   Args:    ${pw_args[*]}"
 
-  # Build a YAML env-vars file for the Cloud Run Job.
+  # Build a YAML env-vars file for this run's Cloud Run Job.
   # We use --env-vars-file (YAML) instead of --set-env-vars because
   # --set-env-vars splits on spaces, breaking PLAYWRIGHT_ARGS.
   # PLAYWRIGHT_ARGS is NEWLINE-delimited (one arg per line, YAML literal
@@ -394,65 +415,88 @@ cmd_run() {
   # re-split on spaces by the entrypoint and quotes could corrupt the YAML.
   # Note: CLOUD_RUN_TASK_COUNT and CLOUD_RUN_TASK_INDEX are reserved env vars
   # set automatically by Cloud Run when --tasks > 1 — do NOT set them here.
-  local env_file
-  env_file=$(mktemp /tmp/e2e-env-vars.XXXXXX.yaml)
+  RUN_ENV_FILE=$(mktemp /tmp/e2e-env-vars.XXXXXX.yaml)
   if [ "${#pw_args[@]}" -gt 0 ]; then
     {
       echo "PLAYWRIGHT_ARGS: |-"
       printf '  %s\n' "${pw_args[@]}"
-    } > "$env_file"
+    } > "$RUN_ENV_FILE"
   else
-    echo 'PLAYWRIGHT_ARGS: ""' > "$env_file"
+    echo 'PLAYWRIGHT_ARGS: ""' > "$RUN_ENV_FILE"
   fi
 
-  # Create or update the Cloud Run Job (create fails if it already exists,
-  # fall back to update).
-  gcloud run jobs create $(gcloud_flags) "$GCP_JOB" \
+  # Create THIS run's own unique job (see unique_job_name). Create-only: a
+  # name collision would mean the job is not unique to this run, so fail
+  # rather than fall back to mutating a shared job. The job carries all
+  # per-run state (image, tasks, timeout, arg env file) — safe to store on
+  # the job precisely because no other run ever touches it. Delete the job
+  # (and temp env file) on EVERY exit path: success, failure, Ctrl-C/TERM.
+  RUN_JOB_NAME="$(unique_job_name)"
+  if ! [[ "$RUN_JOB_NAME" =~ ^[a-z][a-z0-9-]{0,48}$ ]]; then
+    echo "[e2e-cloud] ERROR: invalid job name '$RUN_JOB_NAME' (check FRESHELL_GCP_JOB prefix)" >&2
+    rm -f "$RUN_ENV_FILE"
+    exit 1
+  fi
+  echo "[e2e-cloud]   Job:     $RUN_JOB_NAME"
+  cleanup_run_job() {
+    if [ -n "${RUN_JOB_NAME:-}" ]; then
+      gcloud run jobs delete $(gcloud_flags) "$RUN_JOB_NAME" --quiet >/dev/null 2>&1 || true
+    fi
+    if [ -n "${RUN_ENV_FILE:-}" ]; then
+      rm -f "$RUN_ENV_FILE"
+    fi
+  }
+  trap cleanup_run_job EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  gcloud run jobs create $(gcloud_flags) "$RUN_JOB_NAME" \
     --image="$IMAGE_REMOTE" \
     --tasks="$shards" \
     --task-timeout="$timeout" \
     --max-retries=0 \
-    --env-vars-file="$env_file" \
-    --memory=2Gi \
-    --cpu=2 \
-    2>/dev/null || \
-  gcloud run jobs update $(gcloud_flags) "$GCP_JOB" \
-    --image="$IMAGE_REMOTE" \
-    --tasks="$shards" \
-    --task-timeout="$timeout" \
-    --max-retries=0 \
-    --env-vars-file="$env_file" \
+    --env-vars-file="$RUN_ENV_FILE" \
     --memory=2Gi \
     --cpu=2
 
-  rm -f "$env_file"
-
-  # Execute the job and wait for completion.
-  # Capture the execution ID from the execute output to avoid a race with
-  # concurrent agents updating/executing the same shared job.
+  # Execute this run's job and wait for completion, capturing the exit
+  # status: an execute failure (quota, permissions, template error) MAY NOT
+  # masquerade as a test outcome.
   echo "[e2e-cloud] Executing Cloud Run Job..."
   local execute_output
-  execute_output=$(gcloud run jobs execute $(gcloud_flags) "$GCP_JOB" --wait 2>&1) || true
+  local execute_exit=0
+  local execution_id=""
+  execute_output=$(gcloud run jobs execute $(gcloud_flags) "$RUN_JOB_NAME" --wait 2>&1) || execute_exit=$?
   echo "$execute_output"
 
   # Extract the execution ID from the execute output. gcloud prints
   # `Execution [NAME] has successfully completed.` — brackets are literal and,
   # on color-capable captures, the name is wrapped in ANSI SGR codes — so strip
-  # escapes and allow the bracket form. (A bare `Execution \K[^ ]+` captured the
-  # bracket+escapes; downstream describe/logs then addressed a nonexistent
+  # escapes and allow the bracket form. (A bare `Execution \K[^ ]+` captured
+  # the bracket+escapes; downstream describe/logs then addressed a nonexistent
   # execution and the `|| echo 0` masking below reported succeeded=0 forever.)
   execution_id=$(echo "$execute_output" \
     | sed -E 's/\x1b\[[0-9;]*m//g' \
     | grep -oP 'Execution \[?\K[A-Za-z0-9][A-Za-z0-9-]*' \
     | head -1 || true)
   if [ -z "$execution_id" ]; then
-    # Fallback: query the latest execution (may race with concurrent agents)
-    echo "[e2e-cloud] WARNING: could not capture execution ID, falling back to latest"
+    # Fallback: list executions of THIS run's own job only — attribution-safe
+    # because no other run ever creates executions under it.
+    echo "[e2e-cloud] WARNING: could not capture execution ID, falling back to listing this run's job"
     execution_id=$(gcloud run jobs executions list $(gcloud_flags) \
-      --job="$GCP_JOB" \
+      --job="$RUN_JOB_NAME" \
       --sort-by="~metadata.creationTimestamp" \
       --format="value(name)" \
-      --limit=1)
+      --limit=1 || true)
+  fi
+
+  if [ "$execute_exit" -ne 0 ]; then
+    echo "[e2e-cloud] Cloud Run Job execution failed (exit code $execute_exit)."
+    if [ -n "$execution_id" ]; then
+      echo "[e2e-cloud] Fetching logs..."
+      gcloud beta run jobs executions logs read $(gcloud_flags) "$execution_id" 2>/dev/null || true
+    fi
+    exit 1
   fi
 
   # Fetch logs (requires beta track for logs read).
@@ -473,17 +517,31 @@ cmd_run() {
   echo "[e2e-cloud] Per-shard summary:"
   echo "$log_output" | grep -E '(\[e2e-entrypoint\] Shard [0-9]+/[0-9]+ assignment|^\s+[0-9]+ (passed|failed))' || true
 
-  # Check execution status
+  # Check execution status — transient describe errors right after
+  # `execute --wait` are a real flake class, so retry briefly; a PERMANENT
+  # query failure must fail the run, never read as succeeded=0/failed=0.
+  query_count() {
+    local field="$1" val attempt
+    for attempt in 1 2 3 4 5; do
+      if val=$(gcloud run jobs executions describe $(gcloud_flags) "$execution_id" \
+        --format="value($field)" 2>/dev/null); then
+        echo "${val:-0}"
+        return 0
+      fi
+      sleep 3
+    done
+    return 1
+  }
   local succeeded
   local failed
-  succeeded=$(gcloud run jobs executions describe $(gcloud_flags) "$execution_id" \
-    --format="value(status.succeededCount)" 2>/dev/null || echo "0")
-  failed=$(gcloud run jobs executions describe $(gcloud_flags) "$execution_id" \
-    --format="value(status.failedCount)" 2>/dev/null || echo "0")
-
-  # Normalize empty/null to 0
-  succeeded="${succeeded:-0}"
-  failed="${failed:-0}"
+  if ! succeeded=$(query_count status.succeededCount); then
+    echo "[e2e-cloud] ERROR: failed to query execution status"
+    exit 1
+  fi
+  if ! failed=$(query_count status.failedCount); then
+    echo "[e2e-cloud] ERROR: failed to query execution status"
+    exit 1
+  fi
 
   echo ""
   echo "[e2e-cloud] Succeeded tasks: $succeeded"
@@ -494,6 +552,14 @@ cmd_run() {
     exit 1
   fi
 
+  # Zero failures is not success: require every requested task to have
+  # succeeded (a cancelled/preempted task yields succeeded=0, failed=0 — and
+  # ran zero tests).
+  if [ "$succeeded" != "$shards" ]; then
+    echo "[e2e-cloud] ERROR: expected $shards succeeded task(s), got $succeeded."
+    exit 1
+  fi
+
   echo "[e2e-cloud] All tasks completed successfully."
 }
 
@@ -501,8 +567,11 @@ cmd_run() {
 # Subcommand: logs
 # ---------------------------------------------------------------------------
 cmd_logs() {
-  # `logs read` takes an EXECUTION name, not the job name — resolve the
-  # latest execution exactly like cmd_run does before fetching its logs.
+  # `logs read` takes an EXECUTION name, not the job name. NOTE: cloud runs
+  # now use unique per-run jobs that are deleted when the run ends — this
+  # legacy lookup only helps for executions of the old shared job. Per-run
+  # logs are printed in full during the run and remain queryable in Cloud
+  # Logging by job/execution name afterwards.
   local execution_id
   execution_id=$(gcloud run jobs executions list $(gcloud_flags) \
     --job="$GCP_JOB" \

--- a/scripts/test/cloud-exec-id-parse.test.sh
+++ b/scripts/test/cloud-exec-id-parse.test.sh
@@ -46,7 +46,15 @@ if [[ "$*" == *"run jobs execute"* ]]; then
   exit 0
 fi
 if [[ "$*" == *"executions describe"* ]]; then
-  if [[ "$*" == *"succeededCount"* ]]; then echo "1"; else echo "0"; fi
+  if [[ "$*" == *"succeededCount"* ]]; then
+    # Report every requested shard as succeeded (vitest passes per-execution
+    # --tasks=N; e2e creates the job with --tasks=N). The wrappers require
+    # succeeded == shards, so the stub must satisfy that to stay green.
+    N=$(grep -oP -- '--tasks=\K[0-9]+' "$FAKE_LOG" | tail -1)
+    echo "${N:-1}"
+  else
+    echo "0"
+  fi
   exit 0
 fi
 if [[ "$*" == *"executions list"* ]]; then echo "test-exec-123"; exit 0; fi

--- a/scripts/test/cloud-run-wrapper.test.sh
+++ b/scripts/test/cloud-run-wrapper.test.sh
@@ -337,5 +337,182 @@ if ! echo "$SPLIT_OUTPUT" | grep -q "3 passed"; then
 fi
 echo "PASS: split-form value flags are normalized before dispatch"
 
+# ---------------------------------------------------------------------------
+# Check 15: per-run unique job lifecycle + result hardening (stubbed gcloud).
+#
+# The run must:
+#  (a) create its OWN unique job (<prefix>-<imagetag>-<random>), execute it,
+#      and delete it on every exit path — a shared job lets a concurrent run
+#      overwrite the image/config of an in-flight run (execute snapshots the
+#      job's CURRENT template) and forces the cross-run "latest execution"
+#      fallback;
+#  (b) fail nonzero when `gcloud run jobs execute` itself fails — never print
+#      the success footer;
+#  (c) propagate permanent status-query errors (transient ones retry);
+#  (d) require succeeded tasks == requested shards, not merely failed == 0;
+#  (e) scope any execution-id fallback listing to the run's own job;
+#  (f) still delete the run's job on SIGINT mid-execution.
+# ---------------------------------------------------------------------------
+STUB2_DIR="$(mktemp -d /tmp/e2e-cloud-stub2.XXXXXX)"
+export STUB2_CAPTURE="$STUB2_DIR/capture"
+mkdir -p "$STUB2_CAPTURE"
+cat > "$STUB2_DIR/gcloud" <<'STUB2'
+#!/usr/bin/env bash
+echo "$*" >> "$STUB2_CAPTURE/gcloud.args"
+case "$*" in
+  "info "*) echo "/nonexistent-sdk-root"; exit 0 ;;
+  *"artifacts repositories describe"*) exit 0 ;;
+  *"artifacts repositories create"*) exit 0 ;;
+  *"artifacts docker images describe"*) exit 0 ;;
+  *"auth print-access-token"*) echo stub-token; exit 0 ;;
+  *"builds submit"*) exit 0 ;;
+  *"run jobs create"*) exit 0 ;;
+  *"run jobs delete"*) exit 0 ;;
+  *"run jobs execute"*)
+    if [ -n "${STUB2_EXECUTE_SLEEP:-}" ]; then sleep "$STUB2_EXECUTE_SLEEP"; exit 0; fi
+    if [ -n "${STUB2_EXECUTE_RC:-}" ]; then echo "ERROR: STUB2_EXECUTE_RC=$STUB2_EXECUTE_RC"; exit "$STUB2_EXECUTE_RC"; fi
+    if [ -n "${STUB2_EXECUTE_NOEXECLINE:-}" ]; then echo "Creating execution..."; echo "OK."; exit 0; fi
+    echo "Execution [exec-stub-7] has successfully completed."
+    exit 0 ;;
+  *"executions list"*) echo "exec-stub-7"; exit 0 ;;
+  *"executions describe"*)
+    if [ -n "${STUB2_DESCRIBE_FAIL:-}" ]; then
+      DCOUNT_FILE="$STUB2_CAPTURE/desc.count"
+      C=$(cat "$DCOUNT_FILE" 2>/dev/null || echo 0); C=$((C+1)); echo "$C" > "$DCOUNT_FILE"
+      if [ "$STUB2_DESCRIBE_FAIL" = "always" ] || [ "$C" -le "$STUB2_DESCRIBE_FAIL" ]; then exit 1; fi
+    fi
+    case "$*" in
+      *failedCount*) echo "${STUB2_FAILED:-0}" ;;
+      *succeededCount*) echo "${STUB2_SUCCEEDED:-1}" ;;
+      *) echo "1" ;;
+    esac
+    exit 0 ;;
+  *"logs read"*) echo "  6 passed (4.2s)"; exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB2
+cat > "$STUB2_DIR/docker" <<'STUB2D'
+#!/usr/bin/env bash
+if [ ! -t 0 ]; then cat >/dev/null 2>&1 || true; fi
+exit 0
+STUB2D
+chmod +x "$STUB2_DIR/gcloud" "$STUB2_DIR/docker"
+
+stub2_reset() {
+  rm -f "$STUB2_CAPTURE/gcloud.args" "$STUB2_CAPTURE/desc.count"
+  touch "$STUB2_CAPTURE/gcloud.args"
+}
+
+# (a) unique job lifecycle on the happy path
+echo "Testing: cloud run creates/executes/deletes its own unique job"
+stub2_reset
+UNIQ_OUT=$(env PATH="$STUB2_DIR:$PATH" STUB2_SUCCEEDED=2 "$SCRIPT" run --cloud --shards=2 2>&1) || {
+  echo "FAIL: unique-job cloud run errored"; echo "$UNIQ_OUT" | tail -10; rm -rf "$STUB2_DIR"; exit 1
+}
+E2E_JOB1=$(grep -oP 'Job:\s+\K[a-z0-9-]+' <<< "$UNIQ_OUT" | head -1 || true)
+if [ -z "$E2E_JOB1" ]; then
+  echo "FAIL: run header does not report a Job name"; echo "$UNIQ_OUT" | tail -10; rm -rf "$STUB2_DIR"; exit 1
+fi
+if ! grep -qP '^freshell-e2e-[a-z0-9]{12}(-dirty)?-[a-z0-9]{6}$' <<< "$E2E_JOB1"; then
+  echo "FAIL: job name '$E2E_JOB1' is not unique per run"; rm -rf "$STUB2_DIR"; exit 1
+fi
+for verb in create execute; do
+  if ! grep "run jobs $verb" "$STUB2_CAPTURE/gcloud.args" | grep -q -- "$E2E_JOB1"; then
+    echo "FAIL: 'run jobs $verb' did not target the run's own job ($E2E_JOB1)"
+    cat "$STUB2_CAPTURE/gcloud.args"; rm -rf "$STUB2_DIR"; exit 1
+  fi
+done
+if ! grep "run jobs delete" "$STUB2_CAPTURE/gcloud.args" | grep -q -- "$E2E_JOB1 --quiet\|--quiet .*$E2E_JOB1\|$E2E_JOB1$"; then
+  echo "FAIL: run did not delete its own job"; cat "$STUB2_CAPTURE/gcloud.args"; rm -rf "$STUB2_DIR"; exit 1
+fi
+if grep -q "run jobs update" "$STUB2_CAPTURE/gcloud.args"; then
+  echo "FAIL: run still mutates a job with 'run jobs update' (shared-job hazard)"
+  rm -rf "$STUB2_DIR"; exit 1
+fi
+# The unique job carries its own config, so per-run state (--tasks, the
+# PLAYWRIGHT_ARGS env file) lives on the created job — verify it is passed.
+if ! grep "run jobs create" "$STUB2_CAPTURE/gcloud.args" | grep -q -- "--tasks=2"; then
+  echo "FAIL: --tasks not applied for this run"; rm -rf "$STUB2_DIR"; exit 1
+fi
+echo "PASS: unique job created/executed/deleted with its own config"
+
+# a second run must get a different job
+stub2_reset
+UNIQ2_OUT=$(env PATH="$STUB2_DIR:$PATH" "$SCRIPT" run --cloud --shards=1 2>&1 || true)
+E2E_JOB2=$(grep -oP 'Job:\s+\K[a-z0-9-]+' <<< "$UNIQ2_OUT" | head -1 || true)
+if [ -z "$E2E_JOB2" ] || [ "$E2E_JOB1" = "$E2E_JOB2" ]; then
+  echo "FAIL: two runs share a job name ('$E2E_JOB1' vs '$E2E_JOB2')"; rm -rf "$STUB2_DIR"; exit 1
+fi
+echo "PASS: second run gets a different job name"
+
+# (b) execute failure fails the run (and still deletes the job)
+echo "Testing: execute failure fails the run, no success footer, job deleted"
+stub2_reset
+EXECFAIL_OUT=$(env PATH="$STUB2_DIR:$PATH" STUB2_EXECUTE_RC=7 "$SCRIPT" run --cloud --shards=1 2>&1) && EXECFAIL_RC=0 || EXECFAIL_RC=$?
+if [ "$EXECFAIL_RC" -eq 0 ]; then
+  echo "FAIL: wrapper reported success when execute exited 7"; rm -rf "$STUB2_DIR"; exit 1
+fi
+if grep -q "All tasks completed successfully" <<< "$EXECFAIL_OUT"; then
+  echo "FAIL: success footer printed despite execute failure"; rm -rf "$STUB2_DIR"; exit 1
+fi
+if ! grep -q "run jobs delete" "$STUB2_CAPTURE/gcloud.args"; then
+  echo "FAIL: run-owned job not deleted after execute failure"; rm -rf "$STUB2_DIR"; exit 1
+fi
+echo "PASS: execute failure fails the run and still deletes the job"
+
+# (c) status queries: transient errors retry; permanent errors fail the run
+echo "Testing: transient describe errors retry, permanent ones fail"
+stub2_reset
+env PATH="$STUB2_DIR:$PATH" STUB2_DESCRIBE_FAIL=2 "$SCRIPT" run --cloud --shards=1 >/dev/null 2>&1 || {
+  echo "FAIL: transient describe errors (2x) were not retried to success"; rm -rf "$STUB2_DIR"; exit 1
+}
+stub2_reset
+env PATH="$STUB2_DIR:$PATH" STUB2_DESCRIBE_FAIL=always "$SCRIPT" run --cloud --shards=1 >/dev/null 2>&1 && {
+  echo "FAIL: permanent describe errors were masked as success"; rm -rf "$STUB2_DIR"; exit 1
+}
+echo "PASS: describe errors retry then fail closed"
+
+# (d) succeeded must equal shards, not merely failed == 0
+echo "Testing: succeeded < shards fails the run"
+stub2_reset
+SHORT_OUT=$(env PATH="$STUB2_DIR:$PATH" STUB2_SUCCEEDED=0 STUB2_FAILED=0 "$SCRIPT" run --cloud --shards=1 2>&1) && SHORT_RC=0 || SHORT_RC=$?
+if [ "$SHORT_RC" -eq 0 ]; then
+  echo "FAIL: succeeded=0/1 shards reported as success ('zero failed' is not success)"; rm -rf "$STUB2_DIR"; exit 1
+fi
+if grep -q "All tasks completed successfully" <<< "$SHORT_OUT"; then
+  echo "FAIL: success footer printed with succeeded < shards"; rm -rf "$STUB2_DIR"; exit 1
+fi
+echo "PASS: succeeded < shards fails closed"
+
+# (e) execution-id fallback listing stays scoped to the run's own job
+echo "Testing: id-parse fallback lists executions of the run's own job only"
+stub2_reset
+FALLBACK_OUT=$(env PATH="$STUB2_DIR:$PATH" STUB2_EXECUTE_NOEXECLINE=1 "$SCRIPT" run --cloud --shards=1 2>&1 || true)
+FALLBACK_JOB=$(grep -oP 'Job:\s+\K[a-z0-9-]+' <<< "$FALLBACK_OUT" | head -1 || true)
+if [ -z "$FALLBACK_JOB" ] || ! grep "executions list" "$STUB2_CAPTURE/gcloud.args" | grep -q -- "--job=$FALLBACK_JOB"; then
+  echo "FAIL: fallback listing not scoped to the run's own job ($FALLBACK_JOB)"
+  cat "$STUB2_CAPTURE/gcloud.args"; rm -rf "$STUB2_DIR"; exit 1
+fi
+echo "PASS: fallback listing scoped to the run's own job"
+
+# (f) SIGINT mid-execution still deletes the run's job
+echo "Testing: SIGINT mid-run still deletes the run's job"
+stub2_reset
+setsid env PATH="$STUB2_DIR:$PATH" STUB2_EXECUTE_SLEEP=60 "$SCRIPT" run --cloud --shards=1 >/dev/null 2>&1 &
+E2E_INT_PID=$!
+for _ in $(seq 1 100); do
+  grep -q 'run jobs execute' "$STUB2_CAPTURE/gcloud.args" 2>/dev/null && break
+  sleep 0.1
+done
+kill -INT -- -"$E2E_INT_PID" 2>/dev/null || kill -INT "$E2E_INT_PID" 2>/dev/null || true
+wait "$E2E_INT_PID" 2>/dev/null || true
+if ! grep -q "run jobs delete" "$STUB2_CAPTURE/gcloud.args"; then
+  echo "FAIL: run-owned job not deleted after SIGINT"; rm -rf "$STUB2_DIR"; exit 1
+fi
+echo "PASS: SIGINT mid-run still deletes the job"
+
+rm -rf "$STUB2_DIR"
+unset STUB2_CAPTURE
+
 echo ""
 echo "=== All checks passed ==="

--- a/scripts/test/cloud-vitest-wrapper.test.sh
+++ b/scripts/test/cloud-vitest-wrapper.test.sh
@@ -155,7 +155,10 @@ if [[ "$*" == *"executions describe"* ]]; then
   if [[ "$*" == *"succeededCount"* ]]; then
     CC=$(cat "${FAKE_GCLOUD_LOG}.desccount" 2>/dev/null || echo 0); CC=$((CC+1)); echo "$CC" > "${FAKE_GCLOUD_LOG}.desccount"
     if [ "$CC" -le 2 ]; then exit 1; fi
-    echo "1"   # one succeeded shard
+    # Report every requested shard as succeeded (the wrapper must require
+    # succeeded == shards, so the stub must satisfy that to stay green).
+    N=$(grep -oP -- '--tasks=\K[0-9]+' "$FAKE_GCLOUD_LOG" | tail -1)
+    echo "${N:-4}"
   else
     echo "0"   # zero failed shards
   fi
@@ -171,6 +174,178 @@ rm -f "${FAKE_GCLOUD_LOG}.desccount"
 rm -f "$FAKE_GCLOUD_LOG"; touch "$FAKE_GCLOUD_LOG"
 check "transient describe failures retried (2 failures, then success)" bash -c "bash '$SCRIPT' run --cloud --config=default >/dev/null 2>&1"
 check "describe was retried (>=3 describe calls logged)" bash -c "[ \$(grep -c 'executions describe' '$FAKE_GCLOUD_LOG') -ge 3 ]"
+
+# Check 11: each cloud run uses its OWN unique Cloud Run job. A shared job is
+# a concurrency hole: `gcloud run jobs execute` snapshots the job's CURRENT
+# template, so a concurrent run's job update can swap the image of an
+# in-flight run, and a later run's own settings race on the same resource.
+# The run must create one job named <prefix>-<imagerag>-<random>, execute it,
+# and delete it on every exit path.
+cat > "$FAKE_GCLOUD_DIR/gcloud" << 'FAKE3'
+#!/usr/bin/env bash
+echo "FAKE_GCLOUD: $@" >> "${FAKE_GCLOUD_LOG:-/dev/null}"
+if [[ "$*" == *"artifacts docker images describe"* ]] || [[ "$*" == *"artifacts repositories describe"* ]] || [[ "$*" == *"builds submit"* ]]; then exit 0; fi
+if [[ "$*" == *"auth print-access-token"* ]]; then echo "fake-token"; exit 0; fi
+if [[ "$*" == *"info"* ]]; then echo "/usr/lib/google-cloud-sdk"; exit 0; fi
+if [[ "$*" == *"logs read"* ]]; then echo "Test Files  1 passed (1)"; exit 0; fi
+if [[ "$*" == *"executions describe"* ]]; then
+  if [[ "$*" == *"succeededCount"* ]]; then
+    N=$(grep -oP -- '--tasks=\K[0-9]+' "$FAKE_GCLOUD_LOG" | tail -1)
+    echo "${N:-4}"
+  else
+    echo "0"
+  fi
+  exit 0
+fi
+if [[ "$*" == *"executions list"* ]]; then echo "test-execution-1"; exit 0; fi
+if [[ "$*" == *"run jobs execute"* ]]; then echo "Execution [test-execution-1] has successfully completed."; exit 0; fi
+if [[ "$*" == *"run jobs"* ]]; then exit 0; fi
+exit 0
+FAKE3
+chmod +x "$FAKE_GCLOUD_DIR/gcloud"
+
+rm -f "$FAKE_GCLOUD_LOG"; touch "$FAKE_GCLOUD_LOG"
+UNIQ_OUTPUT=$(bash "$SCRIPT" run --cloud --config=default 2>&1) || {
+  echo "FAIL: unique-job cloud run errored"
+  echo "$UNIQ_OUTPUT" | tail -5
+  FAILURES=$((FAILURES + 1))
+  UNIQ_OUTPUT=""
+}
+JOB1=$(grep -oP 'Job:\s+\K[a-z0-9-]+' <<< "$UNIQ_OUTPUT" | head -1 || true)
+check "run header reports its unique Job name" bash -c "[ -n '${JOB1:-}' ]"
+if [ -n "${JOB1:-}" ]; then
+  check "job name is unique per run (prefix-imagetag-random)" \
+    grep -qP '^freshell-vitest-[a-z0-9]{12}(-dirty)?-[a-z0-9]{6}$' <<< "$JOB1"
+  check "create/execute/delete all target the run's own job" bash -c "
+    grep -q 'run jobs create .* ${JOB1} ' '$FAKE_GCLOUD_LOG' &&
+    grep -q 'run jobs execute .* ${JOB1} --tasks=' '$FAKE_GCLOUD_LOG' &&
+    grep -q 'run jobs delete .* ${JOB1} --quiet' '$FAKE_GCLOUD_LOG'"
+  check "no job update happens (the job is single-owner)" \
+    bash -c "! grep -q 'run jobs update' '$FAKE_GCLOUD_LOG'"
+  rm -f "$FAKE_GCLOUD_LOG"; touch "$FAKE_GCLOUD_LOG"
+  UNIQ2_OUTPUT=$(bash "$SCRIPT" run --cloud --config=default 2>&1 || true)
+  JOB2=$(grep -oP 'Job:\s+\K[a-z0-9-]+' <<< "$UNIQ2_OUTPUT" | head -1 || true)
+  check "a second run gets a different job name" \
+    bash -c "[ -n '${JOB2:-}' ] && [ '${JOB1}' != '${JOB2:-}' ]"
+fi
+
+# Check 12: `gcloud run jobs execute` failing (quota, permissions, ...) must
+# fail the run — and the run-owned job must STILL be deleted.
+cat > "$FAKE_GCLOUD_DIR/gcloud" << 'FAKE4'
+#!/usr/bin/env bash
+echo "FAKE_GCLOUD: $@" >> "${FAKE_GCLOUD_LOG:-/dev/null}"
+if [[ "$*" == *"artifacts docker images describe"* ]] || [[ "$*" == *"artifacts repositories describe"* ]] || [[ "$*" == *"builds submit"* ]]; then exit 0; fi
+if [[ "$*" == *"auth print-access-token"* ]]; then echo "fake-token"; exit 0; fi
+if [[ "$*" == *"info"* ]]; then echo "/usr/lib/google-cloud-sdk"; exit 0; fi
+if [[ "$*" == *"logs read"* ]]; then exit 0; fi
+if [[ "$*" == *"executions describe"* ]]; then echo "0"; exit 0; fi
+if [[ "$*" == *"executions list"* ]]; then exit 0; fi
+if [[ "$*" == *"run jobs execute"* ]]; then echo "ERROR: (gcloud.run.jobs.execute) quota exceeded"; exit 7; fi
+if [[ "$*" == *"run jobs"* ]]; then exit 0; fi
+exit 0
+FAKE4
+chmod +x "$FAKE_GCLOUD_DIR/gcloud"
+rm -f "$FAKE_GCLOUD_LOG"; touch "$FAKE_GCLOUD_LOG"
+EXECFAIL_OUTPUT=$(bash "$SCRIPT" run --cloud --config=default 2>&1) && EXECFAIL_RC=0 || EXECFAIL_RC=$?
+check "execute failure exits nonzero" bash -c "[ $EXECFAIL_RC -ne 0 ]"
+if grep -q 'All tasks completed successfully' <<< "$EXECFAIL_OUTPUT"; then
+  echo "FAIL: execute failure prints no success footer"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "PASS: execute failure prints no success footer"
+fi
+EXECFAIL_JOB=$(grep -oP 'Job:\s+\K[a-z0-9-]+' <<< "$EXECFAIL_OUTPUT" | head -1 || true)
+check "failed run still deletes its own job" bash -c \
+  "[ -n '${EXECFAIL_JOB:-}' ] && grep -q 'run jobs delete .* ${EXECFAIL_JOB} --quiet' '$FAKE_GCLOUD_LOG'"
+
+# Check 13: "zero failed tasks" is not success — the number of succeeded
+# tasks must equal the requested shard count, else the run fails closed
+# (a cancelled/preempted task has succeeded=0, failed=0, and zero tests ran).
+cat > "$FAKE_GCLOUD_DIR/gcloud" << 'FAKE5'
+#!/usr/bin/env bash
+echo "FAKE_GCLOUD: $@" >> "${FAKE_GCLOUD_LOG:-/dev/null}"
+if [[ "$*" == *"artifacts docker images describe"* ]] || [[ "$*" == *"artifacts repositories describe"* ]] || [[ "$*" == *"builds submit"* ]]; then exit 0; fi
+if [[ "$*" == *"auth print-access-token"* ]]; then echo "fake-token"; exit 0; fi
+if [[ "$*" == *"info"* ]]; then echo "/usr/lib/google-cloud-sdk"; exit 0; fi
+if [[ "$*" == *"logs read"* ]]; then echo "Test Files  1 passed (1)"; exit 0; fi
+if [[ "$*" == *"executions describe"* ]]; then
+  if [[ "$*" == *"succeededCount"* ]]; then echo "1"; else echo "0"; fi
+  exit 0
+fi
+if [[ "$*" == *"executions list"* ]]; then echo "test-execution-1"; exit 0; fi
+if [[ "$*" == *"run jobs execute"* ]]; then echo "Execution [test-execution-1] has successfully completed."; exit 0; fi
+if [[ "$*" == *"run jobs"* ]]; then exit 0; fi
+exit 0
+FAKE5
+chmod +x "$FAKE_GCLOUD_DIR/gcloud"
+rm -f "$FAKE_GCLOUD_LOG"; touch "$FAKE_GCLOUD_LOG"
+SHORT_OUTPUT=$(bash "$SCRIPT" run --cloud --config=default --shards=4 2>&1) && SHORT_RC=0 || SHORT_RC=$?
+check "succeeded < shards exits nonzero (1 of 4)" bash -c "[ $SHORT_RC -ne 0 ]"
+if grep -q 'All tasks completed successfully' <<< "$SHORT_OUTPUT"; then
+  echo "FAIL: succeeded < shards prints no success footer"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "PASS: succeeded < shards prints no success footer"
+fi
+
+# Check 14: when the execution id can't be parsed from execute output, the
+# fallback listing MUST be scoped to this run's own job (--job=<unique>) —
+# never the shared job, where it could return another run's execution.
+cat > "$FAKE_GCLOUD_DIR/gcloud" << 'FAKE6'
+#!/usr/bin/env bash
+echo "FAKE_GCLOUD: $@" >> "${FAKE_GCLOUD_LOG:-/dev/null}"
+if [[ "$*" == *"artifacts docker images describe"* ]] || [[ "$*" == *"artifacts repositories describe"* ]] || [[ "$*" == *"builds submit"* ]]; then exit 0; fi
+if [[ "$*" == *"auth print-access-token"* ]]; then echo "fake-token"; exit 0; fi
+if [[ "$*" == *"info"* ]]; then echo "/usr/lib/google-cloud-sdk"; exit 0; fi
+if [[ "$*" == *"logs read"* ]]; then echo "Test Files  1 passed (1)"; exit 0; fi
+if [[ "$*" == *"executions describe"* ]]; then
+  if [[ "$*" == *"succeededCount"* ]]; then
+    N=$(grep -oP -- '--tasks=\K[0-9]+' "$FAKE_GCLOUD_LOG" | tail -1)
+    echo "${N:-4}"
+  else
+    echo "0"
+  fi
+  exit 0
+fi
+if [[ "$*" == *"executions list"* ]]; then echo "fallback-exec-9"; exit 0; fi
+if [[ "$*" == *"run jobs execute"* ]]; then echo "Creating execution..."; echo "OK."; exit 0; fi
+if [[ "$*" == *"run jobs"* ]]; then exit 0; fi
+exit 0
+FAKE6
+chmod +x "$FAKE_GCLOUD_DIR/gcloud"
+rm -f "$FAKE_GCLOUD_LOG"; touch "$FAKE_GCLOUD_LOG"
+FALLBACK_OUTPUT=$(bash "$SCRIPT" run --cloud --config=default 2>&1 || true)
+FALLBACK_JOB=$(grep -oP 'Job:\s+\K[a-z0-9-]+' <<< "$FALLBACK_OUTPUT" | head -1 || true)
+check "id-parse fallback lists executions of THIS run's job only" bash -c \
+  "[ -n '${FALLBACK_JOB:-}' ] && grep 'executions list' '$FAKE_GCLOUD_LOG' | grep -q -- '--job=${FALLBACK_JOB}'"
+
+# Check 15: Ctrl-C (SIGINT to the process group) mid-execution still deletes
+# the run's own job via the exit trap.
+cat > "$FAKE_GCLOUD_DIR/gcloud" << 'FAKE7'
+#!/usr/bin/env bash
+echo "FAKE_GCLOUD: $@" >> "${FAKE_GCLOUD_LOG:-/dev/null}"
+if [[ "$*" == *"artifacts docker images describe"* ]] || [[ "$*" == *"artifacts repositories describe"* ]] || [[ "$*" == *"builds submit"* ]]; then exit 0; fi
+if [[ "$*" == *"auth print-access-token"* ]]; then echo "fake-token"; exit 0; fi
+if [[ "$*" == *"info"* ]]; then echo "/usr/lib/google-cloud-sdk"; exit 0; fi
+if [[ "$*" == *"logs read"* ]]; then exit 0; fi
+if [[ "$*" == *"executions describe"* ]]; then echo "0"; exit 0; fi
+if [[ "$*" == *"executions list"* ]]; then exit 0; fi
+if [[ "$*" == *"run jobs execute"* ]]; then sleep 60; exit 0; fi
+if [[ "$*" == *"run jobs"* ]]; then exit 0; fi
+exit 0
+FAKE7
+chmod +x "$FAKE_GCLOUD_DIR/gcloud"
+rm -f "$FAKE_GCLOUD_LOG"; touch "$FAKE_GCLOUD_LOG"
+setsid bash "$SCRIPT" run --cloud --config=default >/dev/null 2>&1 &
+INT_PID=$!
+for _ in $(seq 1 100); do
+  grep -q 'run jobs execute' "$FAKE_GCLOUD_LOG" 2>/dev/null && break
+  sleep 0.1
+done
+kill -INT -- -"$INT_PID" 2>/dev/null || kill -INT "$INT_PID" 2>/dev/null || true
+wait "$INT_PID" 2>/dev/null || true
+check "SIGINT mid-run still deletes the run's own job" \
+  grep -q 'run jobs delete' "$FAKE_GCLOUD_LOG"
 
 # Cleanup
 rm -rf "$FAKE_GCLOUD_DIR"

--- a/scripts/vitest-cloud.sh
+++ b/scripts/vitest-cloud.sh
@@ -92,6 +92,20 @@ gcloud_flags() {
   echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --region=${GCP_REGION}"
 }
 
+# Unique per-run job. `gcloud run jobs execute` snapshots the job's CURRENT
+# template, so sharing one job across runs lets a concurrent run's job update
+# swap the image of an in-flight run, and forces "find my execution" to fall
+# back to "the latest execution of the shared job" — which may be another
+# run's results. Every run therefore creates its own job
+# (<prefix>-<imagetag>-<random6>), executes it, and deletes it on every exit
+# path (success, failure, SIGINT/SIGTERM). FRESHELL_GCP_VITEST_JOB is the
+# prefix.
+unique_job_name() {
+  local rand
+  rand=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 6)
+  printf '%s-%s-%s' "$GCP_JOB" "$(image_tag_for_head)" "$rand"
+}
+
 # gcloud artifacts commands use --location, not --region
 gcloud_artifacts_flags() {
   echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --location=${GCP_REGION}"
@@ -122,6 +136,14 @@ Flags:
 
 Environment:
   FRESHELL_VITEST_BACKEND  "local" (default) or "cloud"
+  FRESHELL_GCP_VITEST_JOB  Cloud Run job-name prefix (default: freshell-vitest)
+
+Cloud job lifecycle: each cloud run creates its OWN unique job
+(<prefix>-<commit>[-dirty]-<random>), executes it, and deletes it
+afterwards — never a shared job — so concurrent runs cannot overwrite each
+other's image or read each other's results. The 'logs' subcommand reads the
+legacy shared job only; per-run logs are printed in full during the run and
+remain in Cloud Logging afterwards.
 
 Examples:
   scripts/vitest-cloud.sh run --local test/unit/lib/pane-utils.test.ts
@@ -371,31 +393,41 @@ cmd_run() {
     vitest_args_json=$(printf '%s\n' "${vt_args[@]}" | jq -R . | jq -sc .)
   fi
 
-  # Ensure the job exists with the correct image (create fails if it already
-  # exists, fall back to update image only — NOT tasks/timeout/env, which are
-  # per-execution overrides passed to `execute` below to avoid racing with
-  # concurrent agents on the shared job).
-  gcloud run jobs create $(gcloud_flags) "$GCP_JOB" \
-    --image="$IMAGE_REMOTE" \
-    --max-retries=0 \
-    --memory=4Gi \
-    --cpu=4 \
-    2>/dev/null || \
-  gcloud run jobs update $(gcloud_flags) "$GCP_JOB" \
+  # Create THIS run's own unique job (see unique_job_name). Create-only: a
+  # name collision would mean the job is not unique to this run, so fail
+  # rather than fall back to mutating a shared job. Per-run overrides
+  # (tasks/timeout/env) are passed to `execute` below; the job only carries
+  # the image. Delete the job on EVERY exit path: success, failure,
+  # Ctrl-C/TERM.
+  RUN_JOB_NAME="$(unique_job_name)"
+  if ! [[ "$RUN_JOB_NAME" =~ ^[a-z][a-z0-9-]{0,48}$ ]]; then
+    echo "[vitest-cloud] ERROR: invalid job name '$RUN_JOB_NAME' (check FRESHELL_GCP_VITEST_JOB prefix)" >&2
+    exit 1
+  fi
+  echo "[vitest-cloud]   Job:     $RUN_JOB_NAME"
+  cleanup_run_job() {
+    if [ -n "${RUN_JOB_NAME:-}" ]; then
+      gcloud run jobs delete $(gcloud_flags) "$RUN_JOB_NAME" --quiet >/dev/null 2>&1 || true
+    fi
+  }
+  trap cleanup_run_job EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  gcloud run jobs create $(gcloud_flags) "$RUN_JOB_NAME" \
     --image="$IMAGE_REMOTE" \
     --max-retries=0 \
     --memory=4Gi \
     --cpu=4
 
-  # Execute the job with per-execution overrides (tasks, timeout, env-vars).
-  # This avoids mutating the shared job with per-run state, preventing races
-  # with concurrent agents. Capture the execution ID from the output.
+  # Execute the job with per-execution overrides (tasks, timeout, env-vars),
+  # and capture the execution ID from the output.
   echo "[vitest-cloud] Executing Cloud Run Job..."
   local execute_output
   local execute_exit=0
   # Use ^@^ delimiter for --update-env-vars to handle commas in JSON arrays.
   local env_overrides="^@^TEST_MODE=vitest@VITEST_CONFIGS=${configs}@VITEST_ARGS_JSON=${vitest_args_json}"
-  execute_output=$(gcloud run jobs execute $(gcloud_flags) "$GCP_JOB" \
+  execute_output=$(gcloud run jobs execute $(gcloud_flags) "$RUN_JOB_NAME" \
     --tasks="$shards" \
     --task-timeout="$timeout" \
     --update-env-vars="$env_overrides" \
@@ -414,20 +446,24 @@ cmd_run() {
     | grep -oP 'Execution \[?\K[A-Za-z0-9][A-Za-z0-9-]*' \
     | head -1 || true)
   if [ -z "$execution_id" ]; then
-    echo "[vitest-cloud] WARNING: could not capture execution ID, falling back to latest"
+    # Fallback: list executions of THIS run's own job only — attribution-safe
+    # because no other run ever creates executions under it.
+    echo "[vitest-cloud] WARNING: could not capture execution ID, falling back to listing this run's job"
     execution_id=$(gcloud run jobs executions list $(gcloud_flags) \
-      --job="$GCP_JOB" \
+      --job="$RUN_JOB_NAME" \
       --sort-by="~metadata.creationTimestamp" \
       --format="value(name)" \
-      --limit=1)
+      --limit=1 || true)
   fi
 
   # If execute itself failed, report and exit — don't mask with status queries.
   if [ "$execute_exit" -ne 0 ]; then
     echo "[vitest-cloud] Cloud Run Job execution failed (exit code $execute_exit)."
-    # Still fetch logs for debugging
-    echo "[vitest-cloud] Fetching logs..."
-    gcloud beta run jobs executions logs read $(gcloud_flags) "$execution_id" 2>/dev/null || true
+    # Still fetch logs for debugging when an execution was created at all.
+    if [ -n "${execution_id:-}" ]; then
+      echo "[vitest-cloud] Fetching logs..."
+      gcloud beta run jobs executions logs read $(gcloud_flags) "$execution_id" 2>/dev/null || true
+    fi
     exit 1
   fi
 
@@ -486,6 +522,14 @@ cmd_run() {
     exit 1
   fi
 
+  # Zero failures is not success: require every requested task to have
+  # succeeded (a cancelled/preempted task yields succeeded=0, failed=0 — and
+  # ran zero tests).
+  if [ "$succeeded" != "$shards" ]; then
+    echo "[vitest-cloud] ERROR: expected $shards succeeded task(s), got $succeeded."
+    exit 1
+  fi
+
   echo "[vitest-cloud] All tasks completed successfully."
 }
 
@@ -493,6 +537,10 @@ cmd_run() {
 # Subcommand: logs
 # ---------------------------------------------------------------------------
 cmd_logs() {
+  # NOTE: cloud runs now use unique per-run jobs that are deleted when the
+  # run ends — this legacy lookup only helps for executions of the old shared
+  # job. Per-run logs are printed in full during the run and remain queryable
+  # in Cloud Logging by job/execution name afterwards.
   local execution_id
   execution_id=$(gcloud run jobs executions list $(gcloud_flags) --job="$GCP_JOB" --sort-by="~metadata.creationTimestamp" --format="value(name)" --limit=1)
   if [ -z "$execution_id" ]; then


### PR DESCRIPTION
## Why

Concurrent cloud test runs raced on the shared `freshell-vitest` / `freshell-e2e` jobs: the slower update's image won, selections crossed between runs, results were read via "latest execution of the shared job" (often another run's), and the e2e wrapper could report green falsely (swallowed execute errors, status-query failures treated as "0 failed", and "no failed tasks" accepted as success even when shards never reported).

Found while chasing the kata-sbnj findings about concurrent-run cross-contamination.

## What (fail-closed, structurally)

- `unique_job_name()` = `<suite>-<commit>[-dirty]-<random6>`, validated against Cloud Run's name rules; rendered in the run header.
- Run lifecycle: **create** the per-run job → **execute** it → **delete** the job on every exit path (EXIT/INT/TERM traps); e2e's run-env-file cleanup folds into the same traps.
- Execute exit code checked and propagated everywhere (including quoted-config `eval` branch and `cmd_run_cloud`).
- e2e `query_count` retries briefly, then **fails**; success requires `succeeded == requested shards` (not merely `failed == 0`).
- Execution-id fallback is scoped to `--job=$RUN_JOB_NAME` so it can never pick another run's execution.
- `cmd_logs` / usage still support the legacy shared jobs for archaeology.
- Legacy `cloudbuild.yaml` run-jobs step annotated (not exercised by the wrappers; left intact).

## Tests (RED -> GREEN)

- `scripts/test/cloud-vitest-wrapper.test.sh` 11-15: name format, create/execute/delete all target the generated name, no job `update`, distinct names across runs, execute-failure still deletes, succeeded<shards fails, scoped fallback, SIGINT cleanup (cross-process-group via setsid).
- `scripts/test/cloud-run-wrapper.test.sh` 15: e2e parity battery with env-steerable STUB2 stub.
- `scripts/test/cloud-exec-id-parse.test.sh`: stub now derives `succeededCount` from `--tasks=` in the log (proved the PR#628 stub had a dead assertion gap).
- Fixed vacuous footer greps (`SUCCEEDED/FAILED` scope in `bash -c`).

## Real-cloud verification

- 3 concurrent runs: full vitest 4-shard, vitest 2-shard default-only, full e2e 4-shard — distinct jobs in `gcloud run jobs list`; vitest runs graded their own selections without cross-contamination; all per-run jobs deleted after exit.
- My e2e run correctly **failed closed**: surfaced the pre-existing red rust-server-fixture specs in cloud (`ensureRustServerBuilt` runs `cargo build` inside a 2-CPU/2-GiB task and gets killed). Control run on unmodified `main` reproduced 17/18 of the same permanent failures, confirming pre-existing redness. Follow-up branch will fix those specs to use the prebuilt binary (`FRESHELL_E2E_RUST_SERVER_BIN` / `resolveRustServerBin`).

Co-authored-by: Dan Shapiro <3732858+danshapiro@users.noreply.github.com>