### PR TITLE
fix(ui): bound recovery offer dialog to viewport with internal scroll

### DIFF
--- a/docs/plans/2026-08-19-recovery-offer-phone.md
+++ b/docs/plans/2026-08-19-recovery-offer-phone.md
@@ -35,7 +35,7 @@ equivalence.
 
 **Tech Stack:** React 18 + Tailwind (dialog containment; `overflow-y-auto`,
 `max-h-[80vh]` per DeadSessionPanel precedent), TS (testids unchanged), Rust
-axum server (`GET /api/recovery-inventory` — no changes), Playwright e2e under
+axum server (`GET /api/recovery/inventory` — no changes), Playwright e2e under
 `test/e2e-browser/` (rust-chromium project, serial single worker,
 `FRESHELL_E2E_BACKEND` unset ⇒ local runs only; never cloud without asking).
 
@@ -106,7 +106,8 @@ Load-bearing evidence (validated this run, receipt at
   scenario 4 plus a teardown-lag guard (`waitForRecoverable`) at every
   close→required-offer transition without restart (after scenario 1's
   ctxB.close(), scenario 2's ctxC.close(), scenario 3's ctxD.close(), and
-  scenario 4's populating-context close).
+  scenario 4's populating-context close; context-E's close is deliberately
+  unguarded because scenario 4's populating boot uses a conditional decline).
 - Modify: NONE on the server. The untouched `data-testid` attrs keep the
   pinned contract (R2 pins).
 
@@ -139,7 +140,9 @@ Load-bearing evidence (validated this run, receipt at
   offer) must be preserved/kept true at every later transition — otherwise the
   next scenario's required-offer assertion is compromised by teardown lag.
   Mechanically the plan adds an enforced probe-poll guard
-  (`waitForRecoverable` helper polling the inventory endpoint with
+  (`waitForRecoverable` helper polling
+  `GET /api/recovery/inventory?clientInstanceId=freshell-test-probe&bootAgoMs=0`
+  until `recoverable === true` with
   `x-auth-token` via a STANDALONE `request.newContext({ baseURL:
   info.baseUrl, extraHTTPHeaders: { 'x-auth-token': info.token } })` — note
   `TestServerInfo` exposes `baseUrl` (lowercase), while Playwright's option
@@ -147,9 +150,15 @@ Load-bearing evidence (validated this run, receipt at
   `page.request` on a doomed page/context (handle is invalidated by `close()`),
   NOT a navigated page (that would create a tracked tabs.sync client and
   entangle the bootstrap fetch) — disposed after success) wherever a later
-  step REQUIRES the offer to appear after a close (after scenario 1's
-  context-B close, scenario 2's context-C close, scenario 3's context-D close,
-  and scenario 4's populating-context close).
+  step REQUIRES the offer to appear after a close — in this spec that is
+  after scenario 1's context-B close (before scenario 2's offer-requiring
+  boot), after scenario 2's context-C close (before scenario 3's context-D
+  boot), after scenario 3's context-D close (before scenario 3's own
+  context-E boot), and after scenario 4's populating-context close (before
+  scenario 4's phone-viewport boot). Scenario 3's context-E close is
+  deliberately NOT guarded: scenario 4's populating context uses a conditional
+  decline (below) precisely so it is robust whether or not an offer is
+  pending.
 - **R3 (interactions completeness).** Every panel interaction (restore/decline
   buttons, focus trap, Escape dismiss, backdrop-click dismiss) keeps working on
   the phone viewport, preserving today's semantics (dismissal keeps the offer
@@ -161,7 +170,7 @@ Load-bearing evidence (validated this run, receipt at
 | # | Requirement | Invariant | Pinning tests |
 |---|-------------|-----------|---------------|
 | R1 | R1 (containment) | Dialog `max-h` + internal scroll + reachable buttons | Component structural test + e2e scenario 4 (390x844 bounding box + `scrollHeight > clientHeight` + decline actionability) |
-| R2a | R2 (restart-independence) | A probe/guard poll exists at every close→required-offer transition without restart | Recover spec scenario transitions 1→2, 2→3, within-3, and before-4 all guarded; attacker text filed below |
+| R2a | R2 (restart-independence) | A probe/guard poll exists at every close→required-offer transition without restart | Recover spec scenario transitions 1→2, 2→3, within-3 (D→E), and populating→phone all guarded (context-E close deliberately unguarded — scenario 4 uses a conditional decline); attacker text filed below |
 | R2b | R2 (unmodified spec coherence) | `RESTORE-01..04` assertions unchanged & passing on `recover-my-panes-rust.spec.ts` and the sidebar pair | The four specs keep running in the same serial order with unchanged assertions |
 | R3 | R3 (interactions) | Dismiss/Accept/Escape/backdrop/focus keep working on the phone viewport | e2e scenario 4 decline actionability + unchanged unit interaction suite (all existing tests + new structural test) |
 
@@ -198,7 +207,7 @@ blocks, and the focus trap keep their current behavior.)
 
 ### Server WS handlers + routes
 
-**Unchanged.** `POST/GET /api/recovery-inventory` response shape stays as-is;
+**Unchanged.** `GET /api/recovery/inventory` response shape stays as-is;
 `tabs.sync.push` handler untouched; no rate-limit/auth changes.
 
 ## E2E story tests (canonical user stories + request-explicit coverage)
@@ -212,13 +221,16 @@ the full dialog and the decline control is tappable`. **One serial e2e spec
 untouched and their close→required-offer transitions get the common
 `waitForRecoverable` guard.** The suite:
 
-- **Scenario 4 (R1 + R3 pins):** a populating context boots and FIRST declines
-  its own suite-order offer (same idiom as the spec's existing decline flow):
-  at this point scenarios 1–3 all left nothing connected, so the populating
-  context's boot fetches the inventory and shows the modal, which would
-  otherwise intercept the `header-action-*`/`New shell tab` clicks it needs.
-  Only after `recovery-decline` does it create 20 shell tabs using the UI
-  control `getByRole('button', { name: 'New shell tab' })` (idiom donor:
+- **Scenario 4 (R1 + R3 pins):** a populating context boots. In a full serial
+  run, scenarios 1–3 left persisted records, so this boot shows the offer
+  modal — which would intercept the header clicks it needs next — so it FIRST
+  performs a conditional decline: wait for `recovery-offer-panel` with a short
+  timeout (~3s); if visible, click `recovery-decline`; if not visible (the
+  case in isolated `-g "scenario 4"` runs against a fresh server/home where
+  nothing is persisted yet), proceed. The conditional keeps the scenario
+  correct both in the canonical full-spec run AND when filtered alone (the
+  mutation-red lane relies on this). Then it creates 20 shell tabs using the
+  UI control `getByRole('button', { name: 'New shell tab' })` (idiom donor:
   `automation-layout-rust.spec.ts:143`; tab-count progress observable via
   `harness.getTabCount()`), then waits for persistence with a records-count
   fs-poll (newest generation for that context's client has ≥ 20 records —
@@ -233,8 +245,9 @@ untouched and their close→required-offer transitions get the common
 
 ### Attacker texts filed by Completion Critic (load-bearing, DO NOT SKIP ANY)
 
-- Probe-poll guarantee for scenario 4's close→boot transition and the three
-  existing scenario transitions: 30s budget (poll 500ms) per transition —
+- Probe-poll guarantee for the four close→required-offer transitions
+  (after ctxB.close(), ctxC.close(), ctxD.close(), and scenario 4's
+  populating-context close): 30s budget (poll 500ms) per transition —
   totals ≤2min worst case; validated: 10x+ headroom versus the lived behavior
   (a few ms after teardown-completing closes). New-server (`info.token`)
   provisioning reuses `startRustServer` token; kept in `recover-offer.ts`
@@ -323,12 +336,18 @@ not by running against absent behavior.
 - [ ] **Step 2: Run the test and verify the intended failure (mutation red)**
 
 Run scenario 4 against mutated production to prove it detects the missing
-behavior (restore immediately after; the mutation is never committed):
+behavior (restore immediately after; the mutation is never committed).
+Scenario 4's conditional decline means a filtered `-g "scenario 4"` run
+against the fresh isolated server/home stays on-path (no stale offer blocks
+the population UI), so the failure lands exactly on the containment
+assertions:
 1. Containment off: temporarily remove `max-h-[80vh] flex flex-col` from the
    dialog and `overflow-y-auto flex-1 min-h-0` from the `<ul>` in
    RecoveryOfferPanel.tsx, then run
    `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts -g "scenario 4"`
-   Expected: FAIL — the containment/scroll assertions fail.
+   Expected: FAIL — inside scenario 4, the containment/scroll assertions fail
+   (bounding-box overflow / `scrollHeight > clientHeight` false), NOT at the
+   boot/decline phase.
    Restore the classes.
 The failure must be for the missing behavior only (assertion mismatches on
 bounding boxes / scroll metrics — never harness errors).

--- a/docs/plans/2026-08-19-recovery-offer-phone.md
+++ b/docs/plans/2026-08-19-recovery-offer-phone.md
@@ -107,7 +107,8 @@ Load-bearing evidence (validated this run, receipt at
   close→required-offer transition without restart (after scenario 1's
   ctxB.close(), scenario 2's ctxC.close(), scenario 3's ctxD.close(), and
   scenario 4's populating-context close; context-E's close is deliberately
-  unguarded because scenario 4's populating boot uses a conditional decline).
+  unguarded because scenario 4's populating boot branches on the boot
+  inventory response payload, never on visibility timing — see scenario 4).
 - Modify: NONE on the server. The untouched `data-testid` attrs keep the
   pinned contract (R2 pins).
 
@@ -170,7 +171,7 @@ Load-bearing evidence (validated this run, receipt at
 | # | Requirement | Invariant | Pinning tests |
 |---|-------------|-----------|---------------|
 | R1 | R1 (containment) | Dialog `max-h` + internal scroll + reachable buttons | Component structural test + e2e scenario 4 (390x844 bounding box + `scrollHeight > clientHeight` + decline actionability) |
-| R2a | R2 (restart-independence) | A probe/guard poll exists at every close→required-offer transition without restart | Recover spec scenario transitions 1→2, 2→3, within-3 (D→E), and populating→phone all guarded (context-E close deliberately unguarded — scenario 4 uses a conditional decline); attacker text filed below |
+| R2a | R2 (restart-independence) | A probe/guard poll exists at every close→required-offer transition without restart | Recover spec scenario transitions 1→2, 2→3, within-3 (D→E), and populating→phone all guarded (context-E close deliberately unguarded — scenario 4's populating boot branches on the inventory response payload with a 30s render-latency-matching panel wait, so no visibility race); attacker text filed below |
 | R2b | R2 (unmodified spec coherence) | `RESTORE-01..04` assertions unchanged & passing on `recover-my-panes-rust.spec.ts` and the sidebar pair | The four specs keep running in the same serial order with unchanged assertions |
 | R3 | R3 (interactions) | Dismiss/Accept/Escape/backdrop/focus keep working on the phone viewport | e2e scenario 4 decline actionability + unchanged unit interaction suite (all existing tests + new structural test) |
 
@@ -221,16 +222,26 @@ the full dialog and the decline control is tappable`. **One serial e2e spec
 untouched and their close→required-offer transitions get the common
 `waitForRecoverable` guard.** The suite:
 
-- **Scenario 4 (R1 + R3 pins):** a populating context boots. In a full serial
-  run, scenarios 1–3 left persisted records, so this boot shows the offer
-  modal — which would intercept the header clicks it needs next — so it FIRST
-  performs a conditional decline: wait for `recovery-offer-panel` with a short
-  timeout (~3s); if visible, click `recovery-decline`; if not visible (the
-  case in isolated `-g "scenario 4"` runs against a fresh server/home where
-  nothing is persisted yet), proceed. The conditional keeps the scenario
-  correct both in the canonical full-spec run AND when filtered alone (the
-  mutation-red lane relies on this). Then it creates 20 shell tabs using the
-  UI control `getByRole('button', { name: 'New shell tab' })` (idiom donor:
+- **Scenario 4 (R1 + R3 pins):** `test.setTimeout(240_000)` — the repo
+  Playwright default is 60s and every existing scenario raises it to 120s or
+  240s; this scenario's own budget (decline ≤30s + 20-tab creation + ≤30s
+  persistence poll + ≤30s guard + phone-boot assertions) can exceed 60s.
+  A populating context boots. Offer rendering is asynchronous — the existing
+  recovery helper documents observed delays exceeding 10s and therefore waits
+  30s for the panel — so a fixed short visibility timeout races a delayed
+  modal. Instead the populating page attaches a response listener for the boot
+  `GET /api/recovery/inventory` request BEFORE navigation
+  (`page.waitForResponse(r => r.url().includes('/api/recovery/inventory'))`),
+  then branches on the parsed payload: if `recoverable === true` (canonical
+  full serial run — scenarios 1–3 left persisted records), wait up to 30s for
+  `recovery-offer-panel` and click `recovery-decline` (the modal would
+  otherwise intercept the header clicks needed next; the full-latency wait
+  closes the race); if `recoverable === false` (isolated `-g "scenario 4"`
+  runs against a fresh server/home), skip declining and proceed — the
+  mutation-red lane relies on this determinism, and it is also why
+  context-E's close needs no guard: the branch is driven by the response
+  payload, never by visibility timing. Then it creates 20 shell tabs using
+  the UI control `getByRole('button', { name: 'New shell tab' })` (idiom donor:
   `automation-layout-rust.spec.ts:143`; tab-count progress observable via
   `harness.getTabCount()`), then waits for persistence with a records-count
   fs-poll (newest generation for that context's client has ≥ 20 records —
@@ -337,7 +348,8 @@ not by running against absent behavior.
 
 Run scenario 4 against mutated production to prove it detects the missing
 behavior (restore immediately after; the mutation is never committed).
-Scenario 4's conditional decline means a filtered `-g "scenario 4"` run
+Scenario 4's response-payload-driven populating boot means a filtered
+`-g "scenario 4"` run
 against the fresh isolated server/home stays on-path (no stale offer blocks
 the population UI), so the failure lands exactly on the containment
 assertions:

--- a/docs/plans/2026-08-19-recovery-offer-phone.md
+++ b/docs/plans/2026-08-19-recovery-offer-phone.md
@@ -1,0 +1,405 @@
+# Recovery Offer Phone Fixes Implementation Plan
+
+> **For agentic workers:** Execute this plan task by task with a fresh
+> implementer and a specification-plus-quality review after every task. Track
+> progress with the checkbox steps below.
+
+**Goal:** A brand-new device (e.g. a phone on first login) must never be
+interrupted by the "Restore N panes from server memory?" recovery dialog while
+other clients are still connected to the server — and when the dialog IS
+legitimately shown, it must fit phone-sized viewports with a scrollable pane
+list and always-reachable action buttons.
+
+**Architecture:** Two independent fixes. (1) Server-side (Rust): track which
+tab-registry clients are currently connected over the WebSocket
+(socket-truthful — stamped on `tabs.sync.push`, cleared on connection
+teardown); the `GET /api/recovery/inventory` handler returns the empty,
+non-recoverable inventory whenever any client OTHER than the requester is
+connected. Rationale: while other clients are live, nothing has been lost —
+the recovery offer exists for browser loss / server restart, not to interrupt
+fresh devices with other machines' layouts. (2) Client: restructure
+`RecoveryOfferPanel` to the repo's established tall-modal pattern
+(`DeadSessionPanel.tsx`:`max-h-[80vh] flex flex-col` + internal
+`overflow-y-auto flex-1 min-h-0` scroll region + footer outside the scroll
+region). E2E pins both fixes.
+
+**Tech Stack:** Rust (axum, tokio) crates `freshell-server` + `freshell-ws`;
+React 18 + TypeScript client; Vitest + RTL; cargo test; Playwright e2e
+(rust-chromium project).
+
+## Global Constraints
+
+- The production server is the Rust server; the inventory route exists ONLY
+  there (the Node/legacy server 404s it and the client already stays quiet on
+  fetch failure — do not touch the legacy server).
+- Do not change `tabs.sync.push`/`tabs.sync.query`/`tabs.sync.client.retire`
+  wire semantics, the sidebar status-ring behavior, or snapshot persistence
+  formats. The connected-client structure is process-local memory only.
+- All client-visible responses keep the existing JSON shape
+  (`{recoverable, contentId, device, otherDevices, ledgerOnly}`), consumed in
+  `src/lib/recovery/types.ts`.
+- Existing e2e semantics pinned and preserved: with NO other client connected,
+  offers appear exactly as today (`recover-my-panes-rust.spec.ts` scenarios
+  1–3, `sidebar-registry-sync-rust.spec.ts` case-d).
+- Server uses NodeNext/ESM for TS; relative imports must include `.js`.
+- Commits focused per task; user identity per repo git config (never override).
+
+## Requirements
+
+- **R1 — Outcome:** A fresh browser/device booting with empty storage receives
+  NO recovery offer while any OTHER client is connected (`recoverable:false`).
+  This covers content of every kind: foreign device unions AND `ledgerOnly`
+  rows (the incident response contained 19 panes + 301 ledgerOnly rows — the
+  whole offer is gated, not just the union part). The requester itself is
+  never treated as "other" even when it is already connected/stamped (a
+  pending-offer re-fetch from an already-connected browser must still work).
+- **R2 — Outcome (preserve):** When no other client is connected, offers
+  appear exactly as before: post-restart first boot, and sole-browser loss
+  without restart (D7 live-note flow). Existing e2e scenarios pass unchanged.
+- **R3 — Outcome:** When the offer IS shown, the dialog fits within a
+  390x844-class viewport: the pane list scrolls internally and the
+  `Not now`/`Restore` buttons are always visible and clickable; the body
+  scroll-lock behavior is unchanged.
+- **R4 — Constraint:** No changes to tab-registry sync semantics, ring
+  status, persistence formats, or the legacy Node server. No new settings.
+- **R5 — Evidence:** Rust unit/route tests for the gate and the connected-set
+  structure; client component tests asserting the scroll-region structure;
+  new e2e scenario proving R1 (connected ⇒ no offer, then after disconnect ⇒
+  offer) and a phone-viewport e2e proving R3; the three existing recovery
+  scenarios (R2) green; final full local verification (`npm test`,
+  `cargo test -p freshell-server`, focused e2e) green on the final HEAD.
+
+---
+
+### Task 1: Rust server — connected-client tracking + inventory gating
+
+**Requirements served:** R1, R2, R4, R5
+
+**Behavior:**
+- The server tracks which `clientInstanceId`s currently have a live WS
+  connection that has pushed tab-registry state: stamp `(connectionId →
+  clientInstanceId)` on each validated `tabs.sync.push` (the frame requires a
+  non-empty `clientInstanceId` today — reuse that validation point), and drop
+  the connection's stamps at WS teardown (the same teardown block that calls
+  `LayoutStore::remove_client`).
+- `GET /api/recovery/inventory`: after auth, BEFORE reading snapshots: if the
+  live set minus the request's `clientInstanceId` is non-empty, return 200 with
+  the canonical empty inventory (`{"recoverable":false,"contentId":"<digest of
+  no substance>","device":null,"otherDevices":[],"ledgerOnly":[]}` — built by
+  calling `build_inventory(vec![], vec![], HashSet::new())` so the contentId
+  semantics stay exactly one code path). When nobody else is connected,
+  behavior is byte-identical to today.
+- A client that reconnects is re-stamped by its next push (first push fires on
+  WS ready — seconds); a momentarily-disconnected desktop may briefly allow an
+  offer — acceptable ("decline is cheap", and dismissal dedupes by contentId),
+  recorded as a deliberate trade-off.
+- Document the resolved residual in `docs/plans/2026-07-26-recover-my-panes.md`
+  (the `:43` "second machine still connected … decline is cheap" paragraph):
+  replaced by the connectedness gate description.
+
+**Files:**
+- Create: `crates/freshell-ws/src/connected_clients.rs` — `#[derive(Clone, Default)]
+  pub struct ConnectedTabClients { inner: Arc<Mutex<HashMap<u64, HashSet<String>>>> }`
+  with `note_push(&self, conn_id: u64, client_instance_id: &str)`,
+  `remove_connection(&self, conn_id: u64)`, `live_client_ids(&self) -> HashSet<String>`.
+  Export from `crates/freshell-ws/src/lib.rs` (`pub mod connected_clients;`).
+- Modify: `crates/freshell-ws/src/lib.rs` (WsState field
+  `pub connected_clients: ConnectedTabClients` next to the other shared
+  handles ~:96-382), `crates/freshell-ws/src/terminal.rs` (`handle_tabs_push`
+  ~:5090-5107 — stamp after the clientInstanceId validation ~:5171-5173 using
+  the handler's connection id; teardown block ~:579-615 — call
+  `connected_clients.remove_connection(conn_id)` beside `remove_client`).
+- Modify: `crates/freshell-server/src/recovery_inventory.rs` —
+  `RecoveryInventoryState` gains `pub connected: ConnectedTabClients`;
+  `inventory_handler` gates after auth; update stale doc comment (registry now
+  constructed at `main.rs:389`, not `:249`).
+- Modify: `crates/freshell-server/src/main.rs` (~:1615-1625 merge) — pass the
+  shared `ConnectedTabClients` (constructed once where the other shared state
+  is built) into both the `WsState` construction (~:1011) and
+  `RecoveryInventoryState`.
+- Modify: `crates/freshell-server/src/recovery_inventory_tests.rs` — new tests
+  (see below); existing tests construct `test_state(...)` — extend the helper
+  to accept (or default to) an empty `ConnectedTabClients` so existing tests
+  keep passing unchanged in behavior.
+- Modify: `docs/plans/2026-07-26-recover-my-panes.md` — residual text update.
+
+**Interfaces:**
+- Consumes: WS push/teardown sites, `build_inventory(unions, bindings, live)`
+  (existing, unchanged), `is_authed`.
+- Produces: `ConnectedTabClients` (public, Clone); the gated handler. No
+  response-shape change; no new query params.
+
+**Test cases:**
+- `ConnectedTabClients`: note/remove round-trip; two connections for the same
+  client — removing one keeps the client live; removing the only connection
+  clears it; `live_client_ids` unions across connections.
+- Route: seeded foreign union + live set `{other-client}` + requester `me` →
+  200, `recoverable:false`, `device:null`, `otherDevices:[]`,
+  `ledgerOnly:[]` (seed a ledgerOnly-eligible binding row too, proving rows
+  are gated as well).
+- Route: same seed but live set `{me}` (only requester connected) →
+  `recoverable:true` with the union offered (matches today's response).
+- Route: same seed, empty live set → unchanged legacy behavior.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add to `recovery_inventory_tests.rs`: the three route tests above (extend
+`test_state` helper minimally) and the `ConnectedTabClients` unit tests in the
+new module (`#[cfg(test)]` in `connected_clients.rs`, matching crate
+conventions). The route tests must fail today because the gate does not exist
+(suppressed-case test gets `recoverable:true`).
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `cargo test -p freshell-server recovery_inventory` and
+`cargo test -p freshell-ws connected_clients`
+
+Expected: FAIL — the suppressed-case route test observes
+`recoverable:true` (no gate), and the unit tests fail to compile (no module);
+both failures are for the missing behavior only.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Create `connected_clients.rs`; add `pub mod connected_clients;` + WsState
+field; stamp in `handle_tabs_push` after the non-empty validation; clear in
+the teardown block; gate in `inventory_handler` (early return via
+`Json(build_inventory(vec![], vec![], HashSet::new()))`); wire through
+`main.rs` (one instance, cloned into `WsState` and `RecoveryInventoryState`);
+extend `RecoveryInventoryState`; fix the stale doc comment; update the
+plan-doc residual.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `cargo test -p freshell-server recovery_inventory` and
+`cargo test -p freshell-ws connected_clients`
+
+Expected: PASS (all new + existing tests in both filters).
+
+- [ ] **Step 5: Refactor while green**
+
+Verify the stamp/clear sit at exactly one call site each; no duplication;
+log nothing new (this path is hot — no per-push logging).
+
+- [ ] **Step 6: Run broader verification**
+
+Run: `cargo test -p freshell-server` and `cargo test -p freshell-ws`
+Expected: PASS
+Run: `cargo clippy -p freshell-server -p freshell-ws -- -D warnings`
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add crates/freshell-ws/src/connected_clients.rs crates/freshell-ws/src/lib.rs crates/freshell-ws/src/terminal.rs crates/freshell-server/src/recovery_inventory.rs crates/freshell-server/src/recovery_inventory_tests.rs crates/freshell-server/src/main.rs docs/plans/2026-07-26-recover-my-panes.md
+git commit -m "fix(server): suppress recovery inventory offers while other clients are connected"
+```
+
+### Task 2: Client — scrollable RecoveryOfferPanel dialog
+
+**Requirements served:** R3, R5
+
+**Behavior:**
+- The dialog never exceeds the viewport; the pane list is the only scrolling
+  region; header (title + device label), the live note, and the footer buttons
+  stay outside the scroll region; backdrop click, Escape, focus trap, body
+  scroll-lock, and all testids (`recovery-offer-panel`, `recovery-decline`,
+  `recovery-accept`, `recovery-live-note`) behave exactly as today.
+
+**Files:**
+- Modify: `src/components/RecoveryOfferPanel.tsx` — dialog div gains
+  `max-h-[80vh] flex flex-col`; the `<ul>` gains `overflow-y-auto flex-1
+  min-h-0` (keep its existing `mt-3 ... space-y-1` classes). Mirror the
+  `DeadSessionPanel.tsx` structure (:55/:62) exactly: title/`<p>` outside, one
+  scrolling `<ul>`, footer outside.
+- Test: `test/unit/client/components/RecoveryOfferPanel.test.tsx` — add
+  structural assertions (below).
+
+**Interfaces:**
+- Consumes/produces nothing new (pure presentational change).
+
+**Test cases:**
+- Inventory with many panes renders every `<li>` (no truncation), the `<ul>`
+  carries `overflow-y-auto flex-1 min-h-0`, the dialog (`role="dialog"`)
+  carries `max-h-[80vh] flex flex-col`.
+- `recovery-decline` and `recovery-accept` are NOT descendants of the
+  scrolling `<ul>` (reachable without scrolling within it).
+- Existing 10 tests in the file keep passing (scroll-lock, focus trap,
+  backdrop, Escape, accept/decline flows).
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add the structural test to `RecoveryOfferPanel.test.tsx` (pattern: render with
+a fabricated multi-pane inventory via the existing `api.get` mock approach in
+that file; query `screen.getByRole('dialog')` and its `<ul>`; assert classes
+and non-descendance of the buttons).
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/client/components/RecoveryOfferPanel.test.tsx`
+Expected: FAIL — the dialog lacks `max-h-[80vh]`/scroll classes today (no
+other failure reason).
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Apply the two class changes in `RecoveryOfferPanel.tsx`.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/client/components/RecoveryOfferPanel.test.tsx test/unit/client/components/RecoveryOfferPanel.persisted-boot.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+None expected beyond matching the DeadSessionPanel pattern verbatim; confirm
+no other modal regression via the same file's suite.
+
+- [ ] **Step 6: Run broader verification**
+
+Run: `npm run test:vitest -- run test/unit/client`
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/components/RecoveryOfferPanel.tsx test/unit/client/components/RecoveryOfferPanel.test.tsx
+git commit -m "fix(client): make recovery offer dialog fit small viewports with internal scroll"
+```
+
+### Task 3: E2E — pin suppression-while-connected and phone-viewport containment
+
+**Requirements served:** R1, R2, R3, R5
+
+**Behavior (both scenarios join the serial
+`test/e2e-browser/specs/recover-my-panes-rust.spec.ts`, owning the same
+RustServer, appended after scenario 3):**
+
+- **Scenario 4 (R1 pin):** context A boots, creates a tab containing a
+  UNIQUE needle record (use browser-pane URL `https://example.org` — never
+  used elsewhere in this file) and waits for a snapshot generation containing
+  it (`waitForSnapshotContaining`). A STAYS OPEN. Fresh context B boots with a
+  response listener capturing the `GET /api/recovery/inventory` response:
+  assert HTTP 200 AND `recoverable === false` AND the panel never appears
+  (`toHaveCount(0)` evaluated only after the captured response resolved —
+  bounded wait, no blind retry). Then close A; poll the endpoint with an
+  authed probe (`page.request.get` of
+  `/api/recovery/inventory?clientInstanceId=probe-s4&bootAgoMs=0`) until
+  `recoverable === true` (30s budget — teardown may lag the close); finally
+  boot fresh context C and REQUIRE the panel (reuse
+  `openFreshContextWithOffer`), decline it, close C. This proves suppression
+  was connectedness, not data loss, and R2's re-appearance.
+- **Scenario 5 (R3 pin):** a populating context creates 20 tabs (the pane
+  records may be plain picker tabs — pickers are snapshotted records per
+  SESSION-05 evidence) using the UI control
+  `getByRole('button', { name: 'New shell tab' })` (idiom donor:
+  `automation-layout-rust.spec.ts:143`; tab-count progress observable via
+  `harness.getTabCount()`), then wait for persistence with a records-count
+  fs-poll (newest generation for that context's client has ≥ 20 records —
+  read the JSON gen files like `waitForSnapshotContaining` does). Close the
+  context. Boot a fresh context with
+  `browser.newContext({ serviceWorkers: 'block', viewport: { width: 390, height: 844 } })`:
+  panel visible; dialog bounding box fits within 390x844; the `<ul>` has
+  `scrollHeight > clientHeight` (internal scrolling exists — with a footer
+  outside it, the buttons' bounding boxes lie inside the viewport); clicking
+  `recovery-decline` succeeds (Playwright actionability = real reachability,
+  this is the user-level phone proof).
+- No changes to the shared auto-decline watcher (it stays correct: offers in
+  other specs either still occur when nothing else is connected, or are
+  legitimately suppressed — the watcher is tolerant either way).
+- Verified-by-reading (load-bearing stage): no hard offer assertions exist
+  while another context is connected anywhere in the suite (recover scenarios
+  1–3 all close each context before the next boots;
+  `sidebar-registry-sync-rust` case-d closes its context before
+  restartAbrupt; all other consumers use tolerant declines). If Task 3's
+  implementer finds this changed, adapt per R2's precedence: existing
+  semantics win, report the conflict back instead of weakening assertions.
+
+**Files:**
+- Modify: `test/e2e-browser/specs/recover-my-panes-rust.spec.ts` (append
+  scenarios, reuse its helpers; add a records-count fs poll helper local to
+  the file).
+
+**Interfaces:**
+- Consumes: `openFreshContextWithOffer`, `waitForSnapshotContaining`,
+  `FRESH_CONTEXT_OPTIONS`, `connect`, `traceInventoryFailures` (same file).
+- Produces: scenario 4 + 5; nothing exported.
+
+**Test cases:**
+- Connected context open ⇒ `recoverable:false`, no panel (R1).
+- Same content after disconnect ⇒ `recoverable:true`, panel appears (R2).
+- 390x844 viewport with 20+ panes ⇒ dialog within viewport, list scrolls
+  internally, decline clickable (R3).
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Write scenarios 4 and 5 in full.
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run (from the worktree):
+`npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts -g "scenario 4"`
+Expected: FAIL — scenario 4's response assertion sees `recoverable:true`
+(gate absent), proving the test observes the missing behavior. Scenario 5's
+containment assertions likewise fail on the uncapped dialog.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+None — production changes landed in Tasks 1–2; if Task 3 runs first
+(task-order independent), scenarios are red until those land. Run after Tasks
+1 and 2.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts`
+Expected: PASS — all five scenarios (budget: up to 600s for the cold release
+build, scenarios ~2-4 min each).
+
+- [ ] **Step 5: Refactor while green**
+
+Keep helpers file-local; match the file's existing comment/donor-citation
+conventions.
+
+- [ ] **Step 6: Run broader verification**
+
+Run: `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts test/e2e-browser/specs/sidebar-remote-status-rings-rust.spec.ts`
+Expected: PASS (the other specs with recovery-offer entanglement).
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add test/e2e-browser/specs/recover-my-panes-rust.spec.ts
+git commit -m "test(e2e): pin recovery-offer suppression while connected and phone-viewport containment"
+```
+
+### Task 4: Final verification of the whole delta
+
+**Requirements served:** R5
+
+- [ ] Run, in the worktree on the FINAL committed HEAD, and record receipts
+  (command, commit, exit code, counts) in the execution ledger:
+  1. `npm run check` (typecheck + coordinated full vitest suite) — PASS
+  2. `cargo test -p freshell-server -p freshell-ws` — PASS
+  3. `cargo clippy -p freshell-server -p freshell-ws -- -D warnings` — PASS
+  4. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts` — PASS (5 scenarios)
+  5. `npm run lint` (a11y gate on changed client file) — PASS
+- [ ] Docs decisions recorded in the ledger: `docs/index.html` not updated
+  (internal recovery dialog, not part of the default-experience mock — repo
+  rule requires mock updates only for major user-facing changes);
+  `docs/plans/2026-07-26-recover-my-panes.md` residual updated in Task 1.
+  Commit only if the ledger lives in the worktree (it does not — receipts are
+  recorded in the run logs; no commit expected for this task unless code
+  changes are required).
+
+## Notes / deliberate trade-offs (recorded, not blocking)
+
+- A momentarily-disconnected OTHER client (mid-reconnect, pre-first-push) can
+  briefly allow an offer; dismissal is deduped by contentId. Residual of the
+  socket-truthful design chosen over time-based heuristics (time heuristics
+  were rejected: the durable registry survives restarts and its 30-min TTL
+  would suppress legitimate offers minutes after a crash).
+- ledgerOnly is gated together with unions (the incident's wall was mostly
+  301 stale ledger rows). The 30-day ledger-row pile and never-aging stale
+  device dirs are separate cleanup opportunities, recorded as out-of-scope
+  findings — not addressed here.
+- Cross-device offers (recover the laptop's layout from the desktop) cease to
+  exist as an interruption; that was the documented "over-offer" the user
+  rejected. Sidebar rings remain the cross-device awareness surface.

--- a/docs/plans/2026-08-19-recovery-offer-phone.md
+++ b/docs/plans/2026-08-19-recovery-offer-phone.md
@@ -66,8 +66,29 @@ React 18 + TypeScript client; Vitest + RTL; cargo test; Playwright e2e
   structure; client component tests asserting the scroll-region structure;
   new e2e scenario proving R1 (connected ⇒ no offer, then after disconnect ⇒
   offer) and a phone-viewport e2e proving R3; the three existing recovery
-  scenarios (R2) green; final full local verification (`npm test`,
-  `cargo test -p freshell-server`, focused e2e) green on the final HEAD.
+  scenarios (R2) green; final full local verification (`npm run check`,
+  `cargo test -p freshell-server -p freshell-ws`, `cargo fmt --all -- --check`,
+  `cargo clippy --workspace --all-targets -- -D warnings`, focused e2e)
+  green on the final HEAD.
+
+### Product decision (explicit, plan-review-driven)
+
+The gate suppresses the offer whenever any OTHER client is **currently
+connected**. Residual the gate deliberately cannot remove: a phone booting
+while ALL clients are disconnected (e.g. desktop asleep/offline) still
+receives an offer — now scrollable, phone-contained, and one-tap dismissible
+(dismissal dedupes by contentId), but present. Complete "never on a
+brand-new device" silence is impossible without a wipe-surviving device
+identity, and none exists: `deviceId` is a random id in localStorage that
+regenerates on the very storage wipe the recovery flow exists for, and
+`deviceLabel` is the SERVER host's name (identical for the phone and the
+desktop). Verified live data during planning: the incident offer contained
+19 pane rows + 301 ledgerOnly rows drawn substantially from months-old dead
+browser-profile device dirs. The chosen heuristic eliminates exactly that
+incident class (the user's desktop is connected essentially always) while
+preserving every documented recovery promise (post-restart, sole-browser
+loss). If the disconnected-desktop residual ever bites in practice, revisit
+with a settings opt-out — recorded as a follow-up, not built here.
 
 ---
 
@@ -99,40 +120,56 @@ React 18 + TypeScript client; Vitest + RTL; cargo test; Playwright e2e
 
 **Files:**
 - Create: `crates/freshell-ws/src/connected_clients.rs` — `#[derive(Clone, Default)]
-  pub struct ConnectedTabClients { inner: Arc<Mutex<HashMap<u64, HashSet<String>>>> }`
+  pub struct ConnectedTabClients { by_conn: Arc<Mutex<HashMap<u64, String>>> }`
   with `note_push(&self, conn_id: u64, client_instance_id: &str)`,
   `remove_connection(&self, conn_id: u64)`, `live_client_ids(&self) -> HashSet<String>`.
+  `note_push` REPLACES the connection's prior stamp — one connection pushes for
+  exactly one current client, and a single connection can legitimately rotate its
+  `clientInstanceId` (BroadcastChannel lease-collision rotation,
+  `src/store/tabRegistrySync.ts:412-431`: the same socket pushes the old ID then
+  the replacement). A per-connection HashSet would strand the old ID as a phantom
+  "other" client and wrongly suppress later offers.
   Export from `crates/freshell-ws/src/lib.rs` (`pub mod connected_clients;`).
-- Modify: `crates/freshell-ws/src/lib.rs` (WsState field
-  `pub connected_clients: ConnectedTabClients` next to the other shared
-  handles ~:96-382), `crates/freshell-ws/src/terminal.rs` (`handle_tabs_push`
-  ~:5090-5107 — stamp after the clientInstanceId validation ~:5171-5173 using
-  the handler's connection id; teardown block ~:579-615 — call
-  `connected_clients.remove_connection(conn_id)` beside `remove_client`).
+- Modify: `crates/freshell-ws/src/tabs.rs` — `TabsRegistry` owns the new
+  `ConnectedTabClients` field (delegating accessors `note_connected_push`,
+  `clear_connected_connection`, `connected_client_ids`). TabsRegistry is
+  constructed exactly once (`main.rs:564-591`) and is Clone-cheap (Arc inside).
+  Deliberately NO new `WsState` field: `WsState` struct literals exist in ~36
+  files (incl. `freshell-ws/tests/common/mod.rs` and integration suites), so a
+  new pub field would break compilation across the workspace.
+- Modify: `crates/freshell-ws/src/terminal.rs` — `handle_tabs_push`
+  (~:5090-5107) stamps `state.tabs.note_connected_push(conn_id, &client_instance_id)`
+  right after the existing non-empty validation (~:5171-5173); the WS teardown
+  block (~:579-615) calls `state.tabs.clear_connected_connection(conn_id)` at a
+  point BEFORE its first await (validated: teardown's only await is the bounded
+  ≤500ms/lease kill-confirm loop at :605; everything before :602 is sync).
 - Modify: `crates/freshell-server/src/recovery_inventory.rs` —
-  `RecoveryInventoryState` gains `pub connected: ConnectedTabClients`;
-  `inventory_handler` gates after auth; update stale doc comment (registry now
-  constructed at `main.rs:389`, not `:249`).
-- Modify: `crates/freshell-server/src/main.rs` (~:1615-1625 merge) — pass the
-  shared `ConnectedTabClients` (constructed once where the other shared state
-  is built) into both the `WsState` construction (~:1011) and
-  `RecoveryInventoryState`.
+  `RecoveryInventoryState` gains `pub tabs: freshell_ws::tabs::TabsRegistry`;
+  `inventory_handler` gates after auth (see Behavior); update stale doc comment
+  (registry constructed at `main.rs:389`, not `:249`).
+- Modify: `crates/freshell-server/src/main.rs` (~:1615-1625 merge) — pass
+  `tabs.clone()` (the existing shared registry) into `RecoveryInventoryState`.
+  No new construction site needed.
 - Modify: `crates/freshell-server/src/recovery_inventory_tests.rs` — new tests
-  (see below); existing tests construct `test_state(...)` — extend the helper
-  to accept (or default to) an empty `ConnectedTabClients` so existing tests
-  keep passing unchanged in behavior.
+  (see below); the `test_state` helper (~:372-436) is the single construction
+  site — extend it with an empty `TabsRegistry` so existing tests keep
+  identical behavior.
 - Modify: `docs/plans/2026-07-26-recover-my-panes.md` — residual text update.
 
 **Interfaces:**
-- Consumes: WS push/teardown sites, `build_inventory(unions, bindings, live)`
-  (existing, unchanged), `is_authed`.
-- Produces: `ConnectedTabClients` (public, Clone); the gated handler. No
-  response-shape change; no new query params.
+- Consumes: `state.tabs` in push/teardown sites, `build_inventory(unions,
+  bindings, live)` (existing, unchanged), `is_authed`.
+- Produces: `ConnectedTabClients` (public, Clone) and its three TabsRegistry
+  delegation methods; the gated handler. No response-shape change; no new query
+  params; no WsState surface change.
 
 **Test cases:**
-- `ConnectedTabClients`: note/remove round-trip; two connections for the same
-  client — removing one keeps the client live; removing the only connection
-  clears it; `live_client_ids` unions across connections.
+- `ConnectedTabClients` (unit, in the new module): note/remove round-trip; two
+  connections for the same client — removing one keeps the client live;
+  removing the only connection clears it; `live_client_ids` unions across
+  connections; **rotation**: the same connection first stamps `old` then `new`
+  ⇒ `live_client_ids` contains `new` and NOT `old` (the phantom-suppression
+  regression pin).
 - Route: seeded foreign union + live set `{other-client}` + requester `me` →
   200, `recoverable:false`, `device:null`, `otherDevices:[]`,
   `ledgerOnly:[]` (seed a ledgerOnly-eligible binding row too, proving rows
@@ -143,29 +180,34 @@ React 18 + TypeScript client; Vitest + RTL; cargo test; Playwright e2e
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Add to `recovery_inventory_tests.rs`: the three route tests above (extend
-`test_state` helper minimally) and the `ConnectedTabClients` unit tests in the
-new module (`#[cfg(test)]` in `connected_clients.rs`, matching crate
-conventions). The route tests must fail today because the gate does not exist
-(suppressed-case test gets `recoverable:true`).
+Add to `recovery_inventory_tests.rs`: the three route tests above (extend the
+`test_state` helper with an empty `TabsRegistry`). These compile against
+today's handler and the suppressed-case test FAILS behaviorally
+(`recoverable:true` observed). The `ConnectedTabClients` unit tests land WITH
+the implementation in Step 3 (their pre-implementation "red" would be
+compile-level only, which proves nothing; the rotation unit test is an
+anti-regression pin for the HashMap-replacement contract, motivated by the
+real rotation path `tabRegistrySync.ts:412-431`).
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
-Run: `cargo test -p freshell-server recovery_inventory` and
-`cargo test -p freshell-ws connected_clients`
+Run: `cargo test -p freshell-server recovery_inventory`
 
-Expected: FAIL — the suppressed-case route test observes
-`recoverable:true` (no gate), and the unit tests fail to compile (no module);
-both failures are for the missing behavior only.
+Expected: FAIL — only the suppressed-case route test fails, observing
+`recoverable:true` plus non-empty `device`/`ledgerOnly` (the missing gate),
+not a compile/setup error; the other two new tests pass.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Create `connected_clients.rs`; add `pub mod connected_clients;` + WsState
-field; stamp in `handle_tabs_push` after the non-empty validation; clear in
-the teardown block; gate in `inventory_handler` (early return via
-`Json(build_inventory(vec![], vec![], HashSet::new()))`); wire through
-`main.rs` (one instance, cloned into `WsState` and `RecoveryInventoryState`);
-extend `RecoveryInventoryState`; fix the stale doc comment; update the
+Create `connected_clients.rs` (module + unit tests incl. rotation); add
+`pub mod connected_clients;` to `lib.rs` (no WsState change); add the
+`ConnectedTabClients` field + three delegating accessors to `TabsRegistry`;
+stamp in `handle_tabs_push` after the non-empty validation; clear in the
+teardown block before its first await; gate in `inventory_handler` (after
+auth: `let mut others = state.tabs.connected_client_ids(); others.remove(&exclude);
+if !others.is_empty() { return Json(build_inventory(vec![], vec![],
+HashSet::new())).into_response() }`); extend `RecoveryInventoryState` + pass
+`tabs.clone()` at the `main.rs` merge; fix the stale doc comment; update the
 plan-doc residual.
 
 - [ ] **Step 4: Run the focused test**
@@ -190,7 +232,7 @@ Expected: PASS
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add crates/freshell-ws/src/connected_clients.rs crates/freshell-ws/src/lib.rs crates/freshell-ws/src/terminal.rs crates/freshell-server/src/recovery_inventory.rs crates/freshell-server/src/recovery_inventory_tests.rs crates/freshell-server/src/main.rs docs/plans/2026-07-26-recover-my-panes.md
+git add crates/freshell-ws/src/connected_clients.rs crates/freshell-ws/src/lib.rs crates/freshell-ws/src/tabs.rs crates/freshell-ws/src/terminal.rs crates/freshell-server/src/recovery_inventory.rs crates/freshell-server/src/recovery_inventory_tests.rs crates/freshell-server/src/main.rs docs/plans/2026-07-26-recover-my-panes.md
 git commit -m "fix(server): suppress recovery inventory offers while other clients are connected"
 ```
 
@@ -273,39 +315,50 @@ git commit -m "fix(client): make recovery offer dialog fit small viewports with 
 `test/e2e-browser/specs/recover-my-panes-rust.spec.ts`, owning the same
 RustServer, appended after scenario 3):**
 
-- **Scenario 4 (R1 pin):** context A boots, creates a tab containing a
-  UNIQUE needle record (use browser-pane URL `https://example.org` — never
-  used elsewhere in this file) and waits for a snapshot generation containing
-  it (`waitForSnapshotContaining`). A STAYS OPEN. Fresh context B boots with a
-  response listener capturing the `GET /api/recovery/inventory` response:
-  assert HTTP 200 AND `recoverable === false` AND the panel never appears
-  (`toHaveCount(0)` evaluated only after the captured response resolved —
-  bounded wait, no blind retry). Then close B AND close A (the suite's
-  no-overlapping-contexts invariant: the gate suppresses offers while ANY
-  other client is connected, so both must be gone); poll the endpoint with an
-  authed probe (`page.request.get` of
-  `/api/recovery/inventory?clientInstanceId=probe-s4&bootAgoMs=0`) until
-  `recoverable === true` (30s budget — teardown may lag the close); finally
-  boot fresh context C and REQUIRE the panel (reuse
-  `openFreshContextWithOffer`), decline it, close C. This proves suppression
-  was connectedness, not data loss, and R2's re-appearance.
-- **Teardown-lag guard (applies wherever a required offer follows a context
-  close with NO server restart):** after `ctxC.close()` (end of scenario 2)
-  before scenario 3's context-D boot, and after `ctxD.close()` before context
-  E's boot, and before scenario 5's phone boot, poll the probe endpoint until
-  `recoverable === true` (30s). Reuse one file-local helper
-  (e.g. `waitForRecoverable`). Restart-based transitions (scenario 1) need no
-  guard — restart clears the set. Scenarios 1–3 keep every existing assertion
-  byte-identical; the guard additions are wait-only.
-- **Scenario 5 (R3 pin):** a populating context creates 20 tabs (the pane
-  records may be plain picker tabs — pickers are snapshotted records per
-  SESSION-05 evidence) using the UI control
+- **Scenario 4 (R1 pin):** context A boots and FIRST declines the suite-order
+  offer it receives itself (at A's boot nobody else is connected, so an offer
+  appears and its overlay would intercept the picker controls — the established
+  idiom in this suite: scenario 3's context-D decline at
+  `recover-my-panes-rust.spec.ts:395-403`; a tolerant decline helper like
+  `declineRecoveryOfferIfShowing` from the sidebar suites is fine). A then
+  creates a tab containing a UNIQUE needle record (browser-pane URL
+  `https://example.org` — never used elsewhere in this file) and waits for a
+  snapshot generation containing it (`waitForSnapshotContaining`). A STAYS OPEN
+  (connected). Fresh context B boots with a response listener capturing the
+  `GET /api/recovery/inventory` response: assert HTTP 200 AND
+  `recoverable === false` AND the panel never appears (`toHaveCount(0)`
+  evaluated only after the captured response resolved — bounded wait, no blind
+  retry). Then close B AND close A (the suite's no-overlapping-contexts
+  invariant: the gate suppresses offers while ANY other client is connected,
+  so both must be gone). Probe-poll until `recoverable === true` (30s budget —
+  teardown may lag the close) using a STANDALONE request context:
+  `const probe = await request.newContext({ baseURL: info.baseUrl, extraHTTPHeaders: { 'x-auth-token': info.token } })`
+  then loop `probe.get('/api/recovery/inventory?clientInstanceId=probe-s4&bootAgoMs=0')`,
+  `await probe.dispose()` after. Do NOT use `page.request` (bound to a closed
+  context) and do NOT navigate a probe page to Freshell (that would create a
+  tracked client and self-suppress). Finally boot fresh context C and REQUIRE
+  the panel (reuse `openFreshContextWithOffer`), decline it, close C. This
+  proves suppression was connectedness, not data loss, and R2's
+  re-appearance.
+- **Teardown-lag guard (applies at EVERY context close followed by a
+  required-offer boot with NO intervening server restart):** after
+  `ctxB.close()` (scenario 1 → 2 transition), after `ctxC.close()` (2 → 3),
+  after `ctxD.close()` (scenario 3, D → E), after scenario 4's B+A closes, and
+  after scenario 5's populating-context close: probe-poll until
+  `recoverable === true` (30s) via one file-local helper `waitForRecoverable`
+  built on the standalone request context above. Restart-based transitions
+  (scenario 1's A→restart→B) need no guard — restart clears the set.
+  Scenarios 1–3 keep every existing assertion byte-identical; the guard
+  additions are wait-only.
+- **Scenario 5 (R3 pin):** a populating context boots and FIRST declines its
+  own suite-order offer (same idiom as scenario 4's A), then creates 20 shell
+  tabs using the UI control
   `getByRole('button', { name: 'New shell tab' })` (idiom donor:
   `automation-layout-rust.spec.ts:143`; tab-count progress observable via
-  `harness.getTabCount()`), then wait for persistence with a records-count
+  `harness.getTabCount()`), then waits for persistence with a records-count
   fs-poll (newest generation for that context's client has ≥ 20 records —
   read the JSON gen files like `waitForSnapshotContaining` does). Close the
-  context. Boot a fresh context with
+  context, run the `waitForRecoverable` guard, then boot a fresh context with
   `browser.newContext({ serviceWorkers: 'block', viewport: { width: 390, height: 844 } })`:
   panel visible; dialog bounding box fits within 390x844; the `<ul>` has
   `scrollHeight > clientHeight` (internal scrolling exists — with a footer
@@ -341,21 +394,35 @@ RustServer, appended after scenario 3):**
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Write scenarios 4 and 5 in full.
+Write scenarios 4 and 5 in full, plus the file-local `waitForRecoverable`
+probe helper and the scenario-5 records-count poll. This task runs AFTER Tasks
+1 and 2 (production behavior already landed), so the red evidence is produced
+by mutation, below — not by running against absent behavior.
 
-- [ ] **Step 2: Run the test and verify the intended failure**
+- [ ] **Step 2: Run the test and verify the intended failure (mutation red)**
 
-Run (from the worktree):
-`npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts -g "scenario 4"`
-Expected: FAIL — scenario 4's response assertion sees `recoverable:true`
-(gate absent), proving the test observes the missing behavior. Scenario 5's
-containment assertions likewise fail on the uncapped dialog.
+Run the two new scenarios against mutated production to prove they detect the
+missing behavior (restore immediately after each observed failure; the
+mutations are never committed):
+1. Gate off: comment out the early-return block in `inventory_handler`
+   (recovery_inventory.rs), then run
+   `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts -g "scenario 4"`
+   Expected: FAIL — the response assertion sees `recoverable:true`.
+   Restore the gate.
+2. Containment off: temporarily remove `max-h-[80vh] flex flex-col` from the
+   dialog and `overflow-y-auto flex-1 min-h-0` from the `<ul>` in
+   RecoveryOfferPanel.tsx, then run
+   `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts -g "scenario 5"`
+   Expected: FAIL — the containment/scroll assertions fail.
+   Restore the classes.
+Both failures must be for the missing behavior only (assertion mismatches on
+`recoverable` / bounding boxes / scroll metrics — never harness errors).
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-None — production changes landed in Tasks 1–2; if Task 3 runs first
-(task-order independent), scenarios are red until those land. Run after Tasks
-1 and 2.
+None — production changes landed in Tasks 1–2. This step is limited to
+restoring/confirming the un-mutated tree (`git status` clean of production
+changes).
 
 - [ ] **Step 4: Run the focused test**
 
@@ -388,9 +455,11 @@ git commit -m "test(e2e): pin recovery-offer suppression while connected and pho
   (command, commit, exit code, counts) in the execution ledger:
   1. `npm run check` (typecheck + coordinated full vitest suite) — PASS
   2. `cargo test -p freshell-server -p freshell-ws` — PASS
-  3. `cargo clippy -p freshell-server -p freshell-ws -- -D warnings` — PASS
-  4. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts` — PASS (5 scenarios)
-  5. `npm run lint` (a11y gate on changed client file) — PASS
+  3. `cargo clippy --workspace --all-targets -- -D warnings` — PASS (CI shape)
+  4. `cargo fmt --all -- --check` — PASS (CI shape)
+  5. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts` — PASS (5 scenarios)
+  6. `npm run lint` (a11y gate on changed client file) — PASS
+  7. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts` — PASS (other recovery-offer-entangled spec)
 - [ ] Docs decisions recorded in the ledger: `docs/index.html` not updated
   (internal recovery dialog, not part of the default-experience mock — repo
   rule requires mock updates only for major user-facing changes);

--- a/docs/plans/2026-08-19-recovery-offer-phone.md
+++ b/docs/plans/2026-08-19-recovery-offer-phone.md
@@ -17,7 +17,7 @@ their names or comments.
 other changes."_ The over-offer gate investigated in earlier revisions is OUT
 of scope: no server changes, no gating. The incident's annoyance was the
 unusable (screen-filling, unscrollable) dialog; once contained and scrollable,
-"Dismiss" is one tap away on any device.
+"Not now" (decline) is one tap away on any device.
 
 **Architecture:** One presentation-only change to the dialog (viewport cap +
 internal scroll region + buttons outside the scroll region), pinned by a
@@ -130,8 +130,8 @@ Load-bearing evidence (validated this run, receipt at
 ## Requirements Spec
 
 - **R1 (formerly R3 — containment).** On a phone-sized viewport the dialog fits
-  the viewport, its list scrolls internally, and every control (`Dismiss`,
-  `Add tabs…`, focus trap, Escape dismiss, backdrop-click dismiss) remains
+  the viewport, its list scrolls internally, and every control (`Not now`,
+  `Restore`, focus trap, Escape dismiss, backdrop-click dismiss) remains
   reachable and functional.
 - **R2 (regression gate + no-seam).** `RESTORE-01..05` assertions + both
   recovery-offer-entangled specs (`recover-my-panes-rust`, `sidebar-registry-sync-rust` +
@@ -173,7 +173,7 @@ Load-bearing evidence (validated this run, receipt at
 | R1 | R1 (containment) | Dialog `max-h` + internal scroll + reachable buttons | Component structural test + e2e scenario 4 (390x844 bounding box + `scrollHeight > clientHeight` + decline actionability) |
 | R2a | R2 (restart-independence) | A probe/guard poll exists at every close→required-offer transition without restart | Recover spec scenario transitions 1→2, 2→3, within-3 (D→E), and populating→phone all guarded (context-E close deliberately unguarded — scenario 4's populating boot branches on the inventory response payload with a 30s render-latency-matching panel wait, so no visibility race); attacker text filed below |
 | R2b | R2 (unmodified spec coherence) | `RESTORE-01..04` assertions unchanged & passing on `recover-my-panes-rust.spec.ts` and the sidebar pair | The four specs keep running in the same serial order with unchanged assertions |
-| R3 | R3 (interactions) | Dismiss/Accept/Escape/backdrop/focus keep working on the phone viewport | e2e scenario 4 decline actionability + unchanged unit interaction suite (all existing tests + new structural test) |
+| R3 | R3 (interactions) | Not now/Restore/Escape/backdrop/focus keep working on the phone viewport | e2e scenario 4 decline actionability + unchanged unit interaction suite (all existing tests + new structural test) |
 
 ## Design (execution checklist after this plan)
 
@@ -190,21 +190,34 @@ rescoped by user decision._
 
 ### Client UI
 
-```
+The existing markup is preserved exactly; only the two annotated class tokens
+are added (`+` marks the change):
+
+```jsx
 <div data-testid="recovery-offer-panel" role="dialog" aria-modal="true"
-     className="relative w-full max-w-md mx-4 rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-5 shadow-xl max-h-[80vh] flex flex-col">
-  <h3 ...> ...
-  <p ...> ...
-  <strong[data-testid="recovery-live-note"]>
-  <ul className="mt-3 max-h-40 overflow-y-auto flex-1 min-h-0 rounded border ...">...
-  <div className="mt-5 flex justify-end gap-2">
-    <button data-testid="recovery-decline" .../>
-    <button data-testid="recovery-accept" .../>
+     aria-labelledby={HEADING_ID}
+     className="bg-background border border-border rounded-lg shadow-lg w-full max-w-md mx-4 p-5
+                + max-h-[80vh] flex flex-col">
+  <h2 id={HEADING_ID} className="text-lg font-semibold">Restore {paneCount} ...</h2>
+  {device && <p className="mt-1 text-xs text-muted-foreground">{device.deviceLabel}</p>}
+  <ul className="mt-3 text-sm text-muted-foreground list-disc pl-5 space-y-1
+                 + overflow-y-auto flex-1 min-h-0">
+    {/* pane list items (per-tab panes, then ledger-only entries) */}
+  </ul>
+  {anyLive && <p data-testid="recovery-live-note" className="mt-3 text-xs text-muted-foreground">...</p>}
+  <div className="mt-4 flex justify-end gap-2">
+    <Button data-testid="recovery-decline" variant="ghost" size="sm">Not now</Button>
+    <Button data-testid="recovery-accept" variant="default" size="sm" ref={acceptRef}>Restore</Button>
+  </div>
+</div>
 ```
 
-(The boot harness and dismissal semantics are UNCHANGED: dismissal keeps the
-offer pending for a later boot. All testids, the two scroll-lock
-blocks, and the focus trap keep their current behavior.)
+(The wrapper portal/overlay, focus-trap `onKeyDown` on the dialog, scroll-lock
+effect, every existing class token, and both buttons' labels (`Not now` /
+`Restore`) stay byte-identical. The overlay already centers the dialog;
+`max-h-[80vh]` caps it at 80% of the viewport; the `<ul>` becomes the sole
+internal scroll region; the button row remains a sibling below the list, so
+both buttons are always within the dialog's bounded box.)
 
 ### Server WS handlers + routes
 

--- a/docs/plans/2026-08-19-recovery-offer-phone.md
+++ b/docs/plans/2026-08-19-recovery-offer-phone.md
@@ -1,366 +1,218 @@
-# Recovery Offer Phone Fixes Implementation Plan
+# Fix scrollable RecoveryOfferPanel on small screens — Implementation Plan
 
-> **For agentic workers:** Execute this plan task by task with a fresh
-> implementer and a specification-plus-quality review after every task. Track
-> progress with the checkbox steps below.
+> **For agentic workers:** REQUIRED SUB-SKILL: use the-usual-executing-plans to implement
+> this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> Before first dispatch, the dispatching agent seeds the progress ledger at
+> `<worktree-git-dir>/usual-sdd/progress.md`, then announces exactly:
+> `I'm using the-usual-executing-plans to implement this plan.`
 
-**Goal:** A brand-new device (e.g. a phone on first login) must never be
-interrupted by the "Restore N panes from server memory?" recovery dialog while
-other clients are still connected to the server — and when the dialog IS
-legitimately shown, it must fit phone-sized viewports with a scrollable pane
-list and always-reachable action buttons.
+**Goal:** Make the `RecoveryOfferPanel` (RESTORE-03 modal under
+`src/App.tsx:961-973`) usable on phone-sized viewports — it currently crops the
+decline button off-screen with `document.body.style.overflow='hidden'` making
+the backdrop unscrollable. Mark the tests for R2 (scenario stability / no
+regression to RESTORE-01..04 assertions) and R3 (every user interaction) in
+their names or comments.
 
-**Architecture:** Two independent fixes. (1) Server-side (Rust): track which
-tab-registry clients are currently connected over the WebSocket
-(socket-truthful — stamped on `tabs.sync.push`, cleared on connection
-teardown); the `GET /api/recovery/inventory` handler returns the empty,
-non-recoverable inventory whenever any client OTHER than the requester is
-connected. Rationale: while other clients are live, nothing has been lost —
-the recovery offer exists for browser loss / server restart, not to interrupt
-fresh devices with other machines' layouts. (2) Client: restructure
-`RecoveryOfferPanel` to the repo's established tall-modal pattern
-(`DeadSessionPanel.tsx`:`max-h-[80vh] flex flex-col` + internal
-`overflow-y-auto flex-1 min-h-0` scroll region + footer outside the scroll
-region). E2E pins both fixes.
+**Scope decision (user, 2026-08-20):** _"Let's just fix the popup and make no
+other changes."_ The over-offer gate investigated in earlier revisions is OUT
+of scope: no server changes, no gating. The incident's annoyance was the
+unusable (screen-filling, unscrollable) dialog; once contained and scrollable,
+"Dismiss" is one tap away on any device.
 
-**Tech Stack:** Rust (axum, tokio) crates `freshell-server` + `freshell-ws`;
-React 18 + TypeScript client; Vitest + RTL; cargo test; Playwright e2e
-(rust-chromium project).
+**Architecture:** One presentation-only change to the dialog (viewport cap +
+internal scroll region + buttons outside the scroll region), pinned by a
+structural unit test and validated at real browser level by a new e2e scenario
+(390x844 viewport, 20 records, decline actionability). No API/protocol/WS
+changes; the fetch stays unconditional.
 
-## Global Constraints
+**Verification gate (closes incident loop, validated in the load-bearing
+stage):** the phone incident shape is reproduced in e2e with a viewport-limited
+context and a 20-record inventory; "all controls reachable and clickable on a
+390x844 viewport" is checkable by Playwright actionability; the verification
+step asserts containment (dialog bounding box within the viewport) and
+internal scrolling (`scrollHeight > clientHeight`), not pixel-perfect visual
+equivalence.
 
-- The production server is the Rust server; the inventory route exists ONLY
-  there (the Node/legacy server 404s it and the client already stays quiet on
-  fetch failure — do not touch the legacy server).
-- Do not change `tabs.sync.push`/`tabs.sync.query`/`tabs.sync.client.retire`
-  wire semantics, the sidebar status-ring behavior, or snapshot persistence
-  formats. The connected-client structure is process-local memory only.
-- All client-visible responses keep the existing JSON shape
-  (`{recoverable, contentId, device, otherDevices, ledgerOnly}`), consumed in
-  `src/lib/recovery/types.ts`.
-- Existing e2e semantics pinned and preserved: with NO other client connected,
-  offers appear exactly as today (`recover-my-panes-rust.spec.ts` scenarios
-  1–3, `sidebar-registry-sync-rust.spec.ts` case-d).
-- Server uses NodeNext/ESM for TS; relative imports must include `.js`.
-- Commits focused per task; user identity per repo git config (never override).
+**Tech Stack:** React 18 + Tailwind (dialog containment; `overflow-y-auto`,
+`max-h-[80vh]` per DeadSessionPanel precedent), TS (testids unchanged), Rust
+axum server (`GET /api/recovery-inventory` — no changes), Playwright e2e under
+`test/e2e-browser/` (rust-chromium project, serial single worker,
+`FRESHELL_E2E_BACKEND` unset ⇒ local runs only; never cloud without asking).
 
-## Requirements
+## Core deliverables
 
-- **R1 — Outcome:** A fresh browser/device booting with empty storage receives
-  NO recovery offer while any OTHER client is connected (`recoverable:false`).
-  This covers content of every kind: foreign device unions AND `ledgerOnly`
-  rows (the incident response contained 19 panes + 301 ledgerOnly rows — the
-  whole offer is gated, not just the union part). The requester itself is
-  never treated as "other" even when it is already connected/stamped (a
-  pending-offer re-fetch from an already-connected browser must still work).
-- **R2 — Outcome (preserve):** When no other client is connected, offers
-  appear exactly as before: post-restart first boot, and sole-browser loss
-  without restart (D7 live-note flow). Existing e2e scenarios pass unchanged.
-- **R3 — Outcome:** When the offer IS shown, the dialog fits within a
-  390x844-class viewport: the pane list scrolls internally and the
-  `Not now`/`Restore` buttons are always visible and clickable; the body
-  scroll-lock behavior is unchanged.
-- **R4 — Constraint:** No changes to tab-registry sync semantics, ring
-  status, persistence formats, or the legacy Node server. No new settings.
-- **R5 — Evidence:** Rust unit/route tests for the gate and the connected-set
-  structure; client component tests asserting the scroll-region structure;
-  new e2e scenario proving R1 (connected ⇒ no offer, then after disconnect ⇒
-  offer) and a phone-viewport e2e proving R3; the three existing recovery
-  scenarios (R2) green; final full local verification (`npm run check`,
-  `cargo test -p freshell-server -p freshell-ws`, `cargo fmt --all -- --check`,
-  `cargo clippy --workspace --all-targets -- -D warnings`, focused e2e)
-  green on the final HEAD.
+1. Bounded, internally-scrollable `RecoveryOfferPanel` dialog
+   (Deliverable/Verification: the dialog never exceeds the viewport on
+   phone-sized screens; the records list scrolls internally; all controls
+   reachable and clickable on a 390x844 viewport).
+2. Mobile-viewport e2e pinning that containment plus the phone user story
+   (Deliverable/Verification: e2e scenario with 20 records asserting bounding
+   box, internal scroll, and decline actionability on 390x844).
+3. Guarded e2e sequencing (Deliverable/Verification: teardown-lag guards at
+   every close→required-offer transition so scenarios never coerce on stale
+   connected-state — the guard is generic `waitForRecoverable` polling, no new
+   test seam).
 
-### Product decision (explicit, plan-review-driven)
+## Context map
 
-The gate suppresses the offer whenever any OTHER client is **currently
-connected**. Residual the gate deliberately cannot remove: a phone booting
-while ALL clients are disconnected (e.g. desktop asleep/offline) still
-receives an offer — now scrollable, phone-contained, and one-tap dismissible
-(dismissal dedupes by contentId), but present. Complete "never on a
-brand-new device" silence is impossible without a wipe-surviving device
-identity, and none exists: `deviceId` is a random id in localStorage that
-regenerates on the very storage wipe the recovery flow exists for, and
-`deviceLabel` is the SERVER host's name (identical for the phone and the
-desktop). Verified live data during planning: the incident offer contained
-19 pane rows + 301 ledgerOnly rows drawn substantially from months-old dead
-browser-profile device dirs. The chosen heuristic eliminates exactly that
-incident class (the user's desktop is connected essentially always) while
-preserving every documented recovery promise (post-restart, sole-browser
-loss). If the disconnected-desktop residual ever bites in practice, revisit
-with a settings opt-out — recorded as a follow-up, not built here.
+RESTORE-01 (offer query at boot) flows: `App.tsx:874-895` boot harness →
+`src/lib/api.ts:36-40` `fetchRecoveryInventory` → Rust `inventory_handler`
+(`crates/freshell-server/src/recovery_inventory.rs:384-420`) → `RecoveryOfferPanel.suggestedPaneRecords`. RESTORE-03/04: panel + `WindowSuggester` +
+`applyRecoverySuggestion` (App.tsx:961-973). The e2e reality (recover spec
+`openFreshContextWithOffer` + RESTORE-05 test site := App.tsx:874-895) +
+`recheck` behavior at RESTORE-06 (re-offer withheld until next connect). Full
+evidence: `.worktrees/.the-usual-logs/recovery-offer-phone/reports/plan-rust-inventory.md`, `plan-client-panel.md`, `plan-test-coverage.md`.
 
----
+Load-bearing evidence (validated this run, receipt at
+`.worktrees/.the-usual-logs/recovery-offer-phone/load-bearing-receipt.md`):
 
-### Task 1: Rust server — connected-client tracking + inventory gating
+- **LB-1 (was proven, revised, re-proven):** the e2e offer flow works
+  cross-context: a declarer context pushes `tabs.sync.push` (storage/broadcast
+  seeds skipped under `serviceWorkers:'block'`), its server-persisted
+  generations persist tolerance-free, and after TOTAL client disconnect a
+  FRESH-context boot reliably shows the panel (~3s). Shutdown/flush staleness
+  risk: NONE for persisted generations (broad-followers md1-3 falsified;
+  `waitForRecoverable` probe-poll after populating-context close absorbs the
+  layout-save linger horizon).
+- **LB-2:** zero sites in `hoverboard`, `recheck`, or e2e-run-mode fixtures
+  change the offer assertions — adding a scenario to the recover spec
+  cannot coerce RESTORE-01..04 assertions (validators reviewed every source in
+  `test/e2e-browser/`).
+- **LB-3:** teardown is read-loop-driven; validators re-verified the plan-text
+  claim that the probe-only inventory request carries no WS socket; the
+  polling helper with `x-auth-token` (a stateless GET, so it does not affect
+  rate limiting on other clients) is honest — no new auth-kind or
+  rate-limit risk per `rate_limit.rs:99-149`.
 
-**Requirements served:** R1, R2, R4, R5
+## Files to Map
 
-**Behavior:**
-- The server tracks which `clientInstanceId`s currently have a live WS
-  connection that has pushed tab-registry state: stamp `(connectionId →
-  clientInstanceId)` on each validated `tabs.sync.push` (the frame requires a
-  non-empty `clientInstanceId` today — reuse that validation point), and drop
-  the connection's stamps at WS teardown (the same teardown block that calls
-  `LayoutStore::remove_client`).
-- `GET /api/recovery/inventory`: after auth, BEFORE reading snapshots: if the
-  live set minus the request's `clientInstanceId` is non-empty, return 200 with
-  the canonical empty inventory (`{"recoverable":false,"contentId":"<digest of
-  no substance>","device":null,"otherDevices":[],"ledgerOnly":[]}` — built by
-  calling `build_inventory(vec![], vec![], HashSet::new())` so the contentId
-  semantics stay exactly one code path). When nobody else is connected,
-  behavior is byte-identical to today.
-- A client that reconnects is re-stamped by its next push (first push fires on
-  WS ready — seconds); a momentarily-disconnected desktop may briefly allow an
-  offer — acceptable ("decline is cheap", and dismissal dedupes by contentId),
-  recorded as a deliberate trade-off.
-- Document the resolved residual in `docs/plans/2026-07-26-recover-my-panes.md`
-  (the `:43` "second machine still connected … decline is cheap" paragraph):
-  replaced by the connectedness gate description.
+- Create: NONE (all edits are to existing files; helpers stay file-local in the
+  spec).
+- Modify: `src/components/RecoveryOfferPanel.tsx` — dialog container gets
+  `max-h-[80vh] flex flex-col`; the "Live now elsewhere" `<ul>` becomes the
+  sole scroll region with `overflow-y-auto flex-1 min-h-0`; header + paragraph
+  + button row remain fixed neighbors with `shrink-0`; testids
+  `recovery-offer-panel`, `recovery-decline`, `recovery-accept`,
+  `recovery-live-note` unchanged.
+- Modify: `test/unit/client/components/RecoveryOfferPanel.test.tsx` — one new
+  structural test: dialog has `max-h-[80vh] flex flex-col`, the
+  `recovery-live-note` element has `overflow-y-auto`, and the buttons render
+  as dialog children OUTSIDE the scrollable element (`note.parentElement !==
+  dialog.parentElement`).
+- Modify: `test/e2e-browser/specs/recover-my-panes-rust.spec.ts` — new serial
+  scenario 4 plus a teardown-lag guard (`waitForRecoverable`) at every
+  close→required-offer transition without restart (after scenario 1's
+  ctxB.close(), scenario 2's ctxC.close(), scenario 3's ctxD.close(), and
+  scenario 4's populating-context close).
+- Modify: NONE on the server. The untouched `data-testid` attrs keep the
+  pinned contract (R2 pins).
 
-**Files:**
-- Create: `crates/freshell-ws/src/connected_clients.rs` — `#[derive(Clone, Default)]
-  pub struct ConnectedTabClients { by_conn: Arc<Mutex<HashMap<u64, String>>> }`
-  with `note_push(&self, conn_id: u64, client_instance_id: &str)`,
-  `remove_connection(&self, conn_id: u64)`, `live_client_ids(&self) -> HashSet<String>`.
-  `note_push` REPLACES the connection's prior stamp — one connection pushes for
-  exactly one current client, and a single connection can legitimately rotate its
-  `clientInstanceId` (BroadcastChannel lease-collision rotation,
-  `src/store/tabRegistrySync.ts:412-431`: the same socket pushes the old ID then
-  the replacement). A per-connection HashSet would strand the old ID as a phantom
-  "other" client and wrongly suppress later offers.
-  Export from `crates/freshell-ws/src/lib.rs` (`pub mod connected_clients;`).
-- Modify: `crates/freshell-ws/src/tabs.rs` — `TabsRegistry` owns the new
-  `ConnectedTabClients` field (delegating accessors `note_connected_push`,
-  `clear_connected_connection`, `connected_client_ids`). TabsRegistry is
-  constructed exactly once (`main.rs:564-591`) and is Clone-cheap (Arc inside).
-  Deliberately NO new `WsState` field: `WsState` struct literals exist in ~36
-  files (incl. `freshell-ws/tests/common/mod.rs` and integration suites), so a
-  new pub field would break compilation across the workspace.
-- Modify: `crates/freshell-ws/src/terminal.rs` — `handle_tabs_push`
-  (~:5090-5107) gains a leading `conn_id: u64` parameter supplied by its
-  dispatcher (`terminal.rs:645`, the site that owns the connection id);
-  inside, stamped as `state.tabs.note_connected_push(conn_id, &client_instance_id)`
-  AFTER `process_tabs_push` validation succeeds (SUCCESS-only stamping —
-  validation lives in `process_tabs_push`; `tabs_push_response` and
-  `process_tabs_push` signatures stay untouched, so their six unit-test call
-  sites keep compiling. Only `handle_tabs_push`'s caller set changes: the
-  dispatcher plus any direct test callers). The WS teardown block (~:579-615)
-  calls `state.tabs.clear_connected_connection(conn_id)` at a point BEFORE
-  its first await (validated: teardown's only await is the bounded
-  ≤500ms/lease kill-confirm loop at :605; everything before :602 is sync).
-- Modify: `crates/freshell-server/src/recovery_inventory.rs` —
-  `RecoveryInventoryState` gains `pub tabs: freshell_ws::tabs::TabsRegistry`;
-  `inventory_handler` gates after auth (see Behavior); update stale doc comment
-  (registry constructed at `main.rs:389`, not `:249`).
-- Modify: `crates/freshell-server/src/main.rs` (~:1615-1625 merge) — pass
-  `tabs.clone()` (the existing shared registry) into `RecoveryInventoryState`.
-  No new construction site needed.
-- Modify: `crates/freshell-server/src/recovery_inventory_tests.rs` — new tests
-  (see below); the `test_state` helper (~:372-436) is the single construction
-  site — extend it with an empty `TabsRegistry` so existing tests keep
-  identical behavior.
-- Modify: `docs/plans/2026-07-26-recover-my-panes.md` — residual text update.
+## Architecture decisions
 
-**Interfaces:**
-- Consumes: `state.tabs` in push/teardown sites, `build_inventory(unions,
-  bindings, live)` (existing, unchanged), `is_authed`.
-- Produces: `ConnectedTabClients` (public, Clone) and its three TabsRegistry
-  delegation methods; the gated handler. No response-shape change; no new query
-  params; no WsState surface change.
+- **Presentation-only containment.** This is the idiomatic React/Tailwind fix
+  (one-fallback before/after: the dialog is bespoke and has no Dialog-primitive
+  in this codebase; mirroring DeadSessionPanel's `max-h-[80vh] flex flex-col` +
+  `overflow-y-auto flex-1 min-h-0` list exactly is the measured, minimal,
+  single-risk-axis change; the footer-with-buttons stays OUTSIDE the scroll
+  region so controls never scroll away from a mobile user).
+- **No new test seam, no new in-scope key.** The e2e guards poll the public
+  API; no new in-scope helper id or auth knob is introduced; the spec keeps
+  `serviceWorkers:'block'` and no other spec changes land (R2 gate evidence).
+- **No new subsystem — the dialog's containment is the entire change.** No
+  interceptor/state machine; the boot harness and fetch behavior stay
+  byte-identical.
 
-**Test cases:**
-- `ConnectedTabClients` (unit, in the new module): note/remove round-trip; two
-  connections for the same client — removing one keeps the client live;
-  removing the only connection clears it; `live_client_ids` unions across
-  connections; **rotation**: the same connection first stamps `old` then `new`
-  ⇒ `live_client_ids` contains `new` and NOT `old` (the phantom-suppression
-  regression pin).
-- Route: seeded foreign union + live set `{other-client}` + requester `me` →
-  200, `recoverable:false`, `device:null`, `otherDevices:[]`,
-  `ledgerOnly:[]` (seed a ledgerOnly-eligible binding row too, proving rows
-  are gated as well).
-- Route: same seed but live set `{me}` (only requester connected) →
-  `recoverable:true` with the union offered (matches today's response).
-- Route: same seed, empty live set → unchanged legacy behavior.
+## Requirements Spec
 
-- [ ] **Step 1: Write the failing behavioral test**
+- **R1 (formerly R3 — containment).** On a phone-sized viewport the dialog fits
+  the viewport, its list scrolls internally, and every control (`Dismiss`,
+  `Add tabs…`, focus trap, Escape→recheck timer, backdrop click→recheck timer)
+  remains reachable and functional.
+- **R2 (regression gate + no-seam).** `RESTORE-01..05` assertions + both
+  recovery-offer-entangled specs (`recover-my-panes-rust`, `sidebar-registry-sync-rust` +
+  `sidebar-remote-status-rings-rust`) keep passing against ONE fixed run-mode
+  shape; no new in-scope keys/testids/WS/API seams. Test-hygiene guard as an
+  e2e observer rule: scenario 1's existing final guard (nobody-connected ⇒ no
+  offer) must be preserved/kept true at every later transition — otherwise the
+  next scenario's required-offer assertion is compromised by teardown lag.
+  Mechanically the plan adds an enforced probe-poll guard
+  (`waitForRecoverable` helper polling the inventory endpoint with
+  `x-auth-token` via a STANDALONE `request.newContext({ baseURL:
+  info.baseURL, extraHTTPHeaders: { 'x-auth-token': info.token } })` — NOT
+  `page.request` on a doomed page/context (handle is invalidated by `close()`),
+  NOT a navigated page (that would create a tracked tabs.sync client and
+  entangle the bootstrap fetch) — disposed after success) wherever a later
+  step REQUIRES the offer to appear after a close (after scenario 1's
+  context-B close, scenario 2's context-C close, scenario 3's context-D close,
+  and scenario 4's populating-context close).
+- **R3 (interactions completeness).** Every panel interaction (restore/decline
+  buttons, focus trap including outside buttons, Escape→recheck timer,
+  backdrop click) keeps working on the phone viewport. Satisfied by the e2e
+  decline actionability plus the unchanged unit tests; no changed interaction
+  semantics.
 
-1a. First, behavior-preserving plumbing (so the red in 1b is behavioral, not a
-compile failure): create `connected_clients.rs` (module + its unit tests incl.
-rotation — they pass immediately; rotation is the anti-regression pin for the
-HashMap-replacement contract, motivated by `tabRegistrySync.ts:412-431`), add
-`pub mod connected_clients;` to `lib.rs`, add the `tabs` field to
-`RecoveryInventoryState`, add the three delegating accessors to `TabsRegistry`,
-extend the `test_state` helper with an empty `TabsRegistry`, add the `conn_id`
-parameter to `handle_tabs_push` + dispatcher callsite, pass `tabs.clone()` into
-`RecoveryInventoryState` at the `main.rs` merge (~:1615-1625), and the teardown
-clear-call. Run `cargo test -p freshell-server recovery_inventory` and
-`cargo test -p freshell-ws connected_clients` — ALL pass (no behavior change).
+## Invariant risk table for pinning
 
-1b. Now write the three route tests above. They compile (all surfaces exist)
-and the suppressed-case test FAILS behaviorally (gate absent).
+| # | Requirement | Invariant | Pinning tests |
+|---|-------------|-----------|---------------|
+| R1 | R1 (containment) | Dialog `max-h` + internal scroll + reachable buttons | Component structural test + e2e scenario 4 (390x844 bounding box + `scrollHeight > clientHeight` + decline actionability) |
+| R2a | R2 (restart-independence) | A probe/guard poll exists at every close→required-offer transition without restart | Recover spec scenario transitions 1→2, 2→3, within-3, and before-4 all guarded; attacker text filed below |
+| R2b | R2 (unmodified spec coherence) | `RESTORE-01..04` assertions unchanged & passing on `recover-my-panes-rust.spec.ts` and the sidebar pair | The four specs keep running in the same serial order with unchanged assertions |
+| R3 | R3 (interactions) | Dismiss/Accept/Escape/backdrop/focus keep working on the phone viewport | e2e scenario 4 decline actionability + unchanged unit interaction suite (all existing tests + new structural test) |
 
-- [ ] **Step 2: Run the test and verify the intended failure**
+## Design (execution checklist after this plan)
 
-Run: `cargo test -p freshell-server recovery_inventory`
+_No server changes land; the gate investigation in earlier plan revisions is
+rescoped by user decision._
 
-Expected: FAIL — only the suppressed-case route test fails, observing
-`recoverable:true` plus non-empty `device`/`ledgerOnly` (the missing gate),
-not a compile/setup error; the other two new tests pass.
+- Modify: `src/components/RecoveryOfferPanel.tsx` — dialog container
+  (~`RecoveryOfferPanel.tsx:191`) gets `max-h-[80vh] flex flex-col`; the
+  records `<ul>` (~:220) gains `overflow-y-auto flex-1 min-h-0` (DeadSessionPanel
+  `:55`/`:62` idiom); header + paragraph + buttons keep `shrink-0` outside the
+  scroll region; testids and interaction handlers stay untouched (R3 pins).
 
-- [ ] **Step 3: Add the minimal production implementation**
+## Interfaces
 
-Add ONLY the gate in `inventory_handler` (after auth:
-`let mut others = state.tabs.connected_client_ids(); others.remove(&exclude);
-if !others.is_empty() { return Json(build_inventory(vec![], vec![],
-HashSet::new())).into_response() }`). Fix the stale doc comment; update the
-plan-doc residual.
+### Client UI
 
-- [ ] **Step 4: Run the focused test**
-
-Run: `cargo test -p freshell-server recovery_inventory` and
-`cargo test -p freshell-ws connected_clients`
-
-Expected: PASS (all new + existing tests in both filters).
-
-- [ ] **Step 5: Refactor while green**
-
-Verify the stamp/clear sit at exactly one call site each; no duplication;
-log nothing new (this path is hot — no per-push logging).
-
-- [ ] **Step 6: Run broader verification**
-
-Run: `cargo test -p freshell-server` and `cargo test -p freshell-ws`
-Expected: PASS
-Run: `cargo clippy -p freshell-server -p freshell-ws -- -D warnings`
-Expected: PASS
-
-- [ ] **Step 7: Commit the task**
-
-```bash
-git add crates/freshell-ws/src/connected_clients.rs crates/freshell-ws/src/lib.rs crates/freshell-ws/src/tabs.rs crates/freshell-ws/src/terminal.rs crates/freshell-server/src/recovery_inventory.rs crates/freshell-server/src/recovery_inventory_tests.rs crates/freshell-server/src/main.rs docs/plans/2026-07-26-recover-my-panes.md
-git commit -m "fix(server): suppress recovery inventory offers while other clients are connected"
+```
+<div data-testid="recovery-offer-panel" role="dialog" aria-modal="true"
+     className="relative w-full max-w-md mx-4 rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-5 shadow-xl max-h-[80vh] flex flex-col">
+  <h3 ...> ...
+  <p ...> ...
+  <strong[data-testid="recovery-live-note"]>
+  <ul className="mt-3 max-h-40 overflow-y-auto flex-1 min-h-0 rounded border ...">...
+  <div className="mt-5 flex justify-end gap-2">
+    <button data-testid="recovery-decline" .../>
+    <button data-testid="recovery-accept" .../>
 ```
 
-### Task 2: Client — scrollable RecoveryOfferPanel dialog
+(The boots and recheck loops are UNCHANGED. All testids, the two scroll-lock
+blocks, and the focus trap keep their current behavior.)
 
-**Requirements served:** R3, R5
+### Server WS handlers + routes
 
-**Behavior:**
-- The dialog never exceeds the viewport; the pane list is the only scrolling
-  region; header (title + device label), the live note, and the footer buttons
-  stay outside the scroll region; backdrop click, Escape, focus trap, body
-  scroll-lock, and all testids (`recovery-offer-panel`, `recovery-decline`,
-  `recovery-accept`, `recovery-live-note`) behave exactly as today.
+**Unchanged.** `POST/GET /api/recovery-inventory` response shape stays as-is;
+`tabs.sync.push` handler untouched; no rate-limit/auth changes.
 
-**Files:**
-- Modify: `src/components/RecoveryOfferPanel.tsx` — dialog div gains
-  `max-h-[80vh] flex flex-col`; the `<ul>` gains `overflow-y-auto flex-1
-  min-h-0` (keep its existing `mt-3 ... space-y-1` classes). Mirror the
-  `DeadSessionPanel.tsx` structure (:55/:62) exactly: title/`<p>` outside, one
-  scrolling `<ul>`, footer outside.
-- Test: `test/unit/client/components/RecoveryOfferPanel.test.tsx` — add
-  structural assertions (below).
+## E2E story tests (canonical user stories + request-explicit coverage)
 
-**Interfaces:**
-- Consumes/produces nothing new (pure presentational change).
+Sole canonical story stems straight from the incident: open Freshell on a
+phone with a large recorded layout ⇒ you can DISMISS the modal without
+scrolling tricks. Auth is owned by helpers; this plan's tests focus on the
+phone-boot story. Story test naming: `scenario 4: small-viewport boots offer
+the full dialog and the decline control is tappable`. **One serial e2e spec
+(`recover-my-panes-rust`) contains the new scenario; scenarios 1–3 are
+untouched and their close→required-offer transitions get the common
+`waitForRecoverable` guard.** The suite:
 
-**Test cases:**
-- Inventory with many panes renders every `<li>` (no truncation), the `<ul>`
-  carries `overflow-y-auto flex-1 min-h-0`, the dialog (`role="dialog"`)
-  carries `max-h-[80vh] flex flex-col`.
-- `recovery-decline` and `recovery-accept` are NOT descendants of the
-  scrolling `<ul>` (reachable without scrolling within it).
-- All existing tests in the file keep passing (scroll-lock, focus trap,
-  backdrop, Escape, accept/decline flows — do not cite a count; counts drift).
-
-- [ ] **Step 1: Write the failing behavioral test**
-
-Add the structural test to `RecoveryOfferPanel.test.tsx` (pattern: render with
-a fabricated multi-pane inventory via the existing `api.get` mock approach in
-that file; query `screen.getByRole('dialog')` and its `<ul>`; assert classes
-and non-descendance of the buttons).
-
-- [ ] **Step 2: Run the test and verify the intended failure**
-
-Run: `npm run test:vitest -- run test/unit/client/components/RecoveryOfferPanel.test.tsx`
-Expected: FAIL — the dialog lacks `max-h-[80vh]`/scroll classes today (no
-other failure reason).
-
-- [ ] **Step 3: Add the minimal production implementation**
-
-Apply the two class changes in `RecoveryOfferPanel.tsx`.
-
-- [ ] **Step 4: Run the focused test**
-
-Run: `npm run test:vitest -- run test/unit/client/components/RecoveryOfferPanel.test.tsx test/unit/client/components/RecoveryOfferPanel.persisted-boot.test.tsx`
-Expected: PASS
-
-- [ ] **Step 5: Refactor while green**
-
-None expected beyond matching the DeadSessionPanel pattern verbatim; confirm
-no other modal regression via the same file's suite.
-
-- [ ] **Step 6: Run broader verification**
-
-Run: `npm run test:vitest -- run test/unit/client`
-Expected: PASS
-
-- [ ] **Step 7: Commit the task**
-
-```bash
-git add src/components/RecoveryOfferPanel.tsx test/unit/client/components/RecoveryOfferPanel.test.tsx
-git commit -m "fix(client): make recovery offer dialog fit small viewports with internal scroll"
-```
-
-### Task 3: E2E — pin suppression-while-connected and phone-viewport containment
-
-**Requirements served:** R1, R2, R3, R5
-
-**Behavior (both scenarios join the serial
-`test/e2e-browser/specs/recover-my-panes-rust.spec.ts`, owning the same
-RustServer, appended after scenario 3):**
-
-- **Scenario 4 (R1 pin):** context A boots and FIRST declines the suite-order
-  offer it receives itself (at A's boot nobody else is connected, so an offer
-  appears and its overlay would intercept the picker controls — the established
-  idiom in this suite: scenario 3's context-D decline at
-  `recover-my-panes-rust.spec.ts:395-403`; a tolerant decline helper like
-  `declineRecoveryOfferIfShowing` from the sidebar suites is fine). A then
-  creates a tab containing a UNIQUE needle record (browser-pane URL
-  `https://example.org` — never used elsewhere in this file) and waits for a
-  snapshot generation containing it (`waitForSnapshotContaining`). A STAYS OPEN
-  (connected). Fresh context B boots with a response listener capturing the
-  `GET /api/recovery/inventory` response: assert HTTP 200 AND
-  `recoverable === false` AND the panel never appears (`toHaveCount(0)`
-  evaluated only after the captured response resolved — bounded wait, no blind
-  retry). Then close B AND close A (the suite's no-overlapping-contexts
-  invariant: the gate suppresses offers while ANY other client is connected,
-  so both must be gone). Probe-poll until `recoverable === true` (30s budget —
-  teardown may lag the close) using a STANDALONE request context:
-  `const probe = await request.newContext({ baseURL: info.baseUrl, extraHTTPHeaders: { 'x-auth-token': info.token } })`
-  then loop `probe.get('/api/recovery/inventory?clientInstanceId=probe-s4&bootAgoMs=0')`,
-  `await probe.dispose()` after. Do NOT use `page.request` (bound to a closed
-  context) and do NOT navigate a probe page to Freshell (that would create a
-  tracked client and self-suppress). Finally boot fresh context C and REQUIRE
-  the panel (reuse `openFreshContextWithOffer`), decline it, close C. This
-  proves suppression was connectedness, not data loss, and R2's
-  re-appearance.
-- **Teardown-lag guard (applies at EVERY context close followed by a
-  required-offer boot with NO intervening server restart):** after
-  `ctxB.close()` (scenario 1 → 2 transition), after `ctxC.close()` (2 → 3),
-  after `ctxD.close()` (scenario 3, D → E), after scenario 4's B+A closes, and
-  after scenario 5's populating-context close: probe-poll until
-  `recoverable === true` (30s) via one file-local helper `waitForRecoverable`
-  built on the standalone request context above. Restart-based transitions
-  (scenario 1's A→restart→B) need no guard — restart clears the set.
-  Scenarios 1–3 keep every existing assertion byte-identical; the guard
-  additions are wait-only.
-- **Scenario 5 (R3 pin):** a populating context boots and FIRST declines its
-  own suite-order offer (same idiom as scenario 4's A), then creates 20 shell
-  tabs using the UI control
-  `getByRole('button', { name: 'New shell tab' })` (idiom donor:
+- **Scenario 4 (R1 + R3 pins):** a populating context boots and FIRST declines
+  its own suite-order offer (same idiom as the spec's existing decline flow):
+  at this point scenarios 1–3 all left nothing connected, so the populating
+  context's boot fetches the inventory and shows the modal, which would
+  otherwise intercept the `header-action-*`/`New shell tab` clicks it needs.
+  Only after `recovery-decline` does it create 20 shell tabs using the UI
+  control `getByRole('button', { name: 'New shell tab' })` (idiom donor:
   `automation-layout-rust.spec.ts:143`; tab-count progress observable via
   `harness.getTabCount()`), then waits for persistence with a records-count
   fs-poll (newest generation for that context's client has ≥ 20 records —
@@ -372,69 +224,116 @@ RustServer, appended after scenario 3):**
   outside it, the buttons' bounding boxes lie inside the viewport); clicking
   `recovery-decline` succeeds (Playwright actionability = real reachability,
   this is the user-level phone proof).
-- No changes to the shared auto-decline watcher (it stays correct: offers in
-  other specs either still occur when nothing else is connected, or are
-  legitimately suppressed — the watcher is tolerant either way).
-- Verified-by-reading (load-bearing stage): no hard offer assertions exist
-  while another context is connected anywhere in the suite (recover scenarios
-  1–3 all close each context before the next boots;
-  `sidebar-registry-sync-rust` case-d closes its context before
-  restartAbrupt; all other consumers use tolerant declines). If Task 3's
-  implementer finds this changed, adapt per R2's precedence: existing
-  semantics win, report the conflict back instead of weakening assertions.
 
-**Files:**
-- Modify: `test/e2e-browser/specs/recover-my-panes-rust.spec.ts` (append
-  scenarios, reuse its helpers; add a records-count fs poll helper local to
-  the file).
+### Attacker texts filed by Completion Critic (load-bearing, DO NOT SKIP ANY)
 
-**Interfaces:**
-- Consumes: `openFreshContextWithOffer`, `waitForSnapshotContaining`,
-  `FRESH_CONTEXT_OPTIONS`, `connect`, `traceInventoryFailures` (same file).
-- Produces: scenario 4 + 5; nothing exported.
+- Probe-poll guarantee for scenario 4's close→boot transition and the three
+  existing scenario transitions: 30s budget (poll 500ms) per transition —
+  totals ≤2min worst case; validated: 10x+ headroom versus the lived behavior
+  (a few ms after teardown-completing closes). New-server (`info.token`)
+  provisioning reuses `startRustServer` token; kept in `recover-offer.ts`
+  helpers.
 
-**Test cases:**
-- Connected context open ⇒ `recoverable:false`, no panel (R1).
-- Same content after disconnect ⇒ `recoverable:true`, panel appears (R2).
-- 390x844 viewport with 20+ panes ⇒ dialog within viewport, list scrolls
-  internally, decline clickable (R3).
+## Tasks (executed strictly in order by the-usual-subagent-driven-development)
+
+### Task 1: Client — made the RecoveryOfferPanel scrollable and reachable
+
+**Requirements served:** R1, R3
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Write scenarios 4 and 5 in full, plus the file-local `waitForRecoverable`
-probe helper and the scenario-5 records-count poll. This task runs AFTER Tasks
-1 and 2 (production behavior already landed), so the red evidence is produced
-by mutation, below — not by running against absent behavior.
+Add to `test/unit/client/components/RecoveryOfferPanel.test.tsx` (the file
+already mocks `getRecoveryInventory`, `acceptRecoverySuggestion`, etc.):
 
-- [ ] **Step 2: Run the test and verify the intended failure (mutation red)**
+- Renders panel with N records ⇒ the `recovery-offer-panel` dialog has Tailwind
+  classes `max-h-[80vh]` and `flex flex-col`; the `recovery-live-note`'s sibling
+  `<ul>` has `overflow-y-auto`, `min-h-0`, `flex-1`; AND the two buttons are
+  NOT descendants of the scrollable `<ul>` (pointer: the buttons stay in the
+  dialog's flex column but outside the scroll region).
+  Test name/comment must reference **R1 (dialog containment)**.
+- Existing tests in the file keep passing (scroll-lock, focus trap, backdrop,
+  Escape, accept/decline flows — do not cite a count; counts drift).
 
-Run the two new scenarios against mutated production to prove they detect the
-missing behavior (restore immediately after each observed failure; the
-mutations are never committed):
-1. Gate off: comment out the early-return block in `inventory_handler`
-   (recovery_inventory.rs), then run
-   `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts -g "scenario 4"`
-   Expected: FAIL — the response assertion sees `recoverable:true`.
-   Restore the gate.
-2. Containment off: temporarily remove `max-h-[80vh] flex flex-col` from the
-   dialog and `overflow-y-auto flex-1 min-h-0` from the `<ul>` in
-   RecoveryOfferPanel.tsx, then run
-   `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts -g "scenario 5"`
-   Expected: FAIL — the containment/scroll assertions fail.
-   Restore the classes.
-Both failures must be for the missing behavior only (assertion mismatches on
-`recoverable` / bounding boxes / scroll metrics — never harness errors).
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/client/components/RecoveryOfferPanel.test.tsx`
+
+Expected: FAIL — the new structural test fails against the current
+`RecoveryOfferPanel` (no `max-h-[80vh]`, no `overflow-y-auto` on the `<ul>`,
+buttons remain reachable — they sit in the dialog but outside the scroll
+region — exactly the same user-level red the phone hit).
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-None — production changes landed in Tasks 1–2. This step is limited to
+`src/components/RecoveryOfferPanel.tsx`:
+- Add `max-h-[80vh] flex flex-col` to the dialog container (the
+  `p-5 shadow-xl` div).
+- Make the records `<ul>` the scroll region by adding `overflow-y-auto
+  flex-1 min-h-0`.
+- Leave header/paragraph/buttons in the non-scrolling flex column (no
+  `shrink-0` required-with-flex—DeadSessionPanel has none on its footer).
+- Do not alter the body scroll-lock blocks (`RecoveryOfferPanel.tsx:111-126`).
+
+(no worker notes on shared scroll behavior — `main` and `index.css` stay
+untouched.)
+
+- [ ] **Step 4: Re-run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/client/components/RecoveryOfferPanel.test.tsx`
+Expected: PASS (existing tests + the new structural test).
+
+- [ ] **Step 5: Refactor while green**
+
+Keep class lists grouped by section; a small comment on the `<ul>` noting it
+is the only scroll region (the R1 intent).
+
+- [ ] **Step 6: Run broader verification**
+
+1. `npm run test:vitest -- run test/unit/client/components/RecoveryOfferPanel.test.tsx test/unit/client/components/RecoveryOfferPanel.persisted-boot.test.tsx` — PASS
+2. `npm run test:vitest -- run test/unit/client` — PASS (coordinated wrapper,
+   default vitest config)
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/components/RecoveryOfferPanel.tsx test/unit/client/components/RecoveryOfferPanel.test.tsx
+git commit -m "fix(ui): bound recovery offer dialog to viewport with internal scroll"
+```
+
+### Task 2: Pin a phone-sized viewport e2e to containment, add the boot-sequence guards
+
+**Requirements served:** R1, R2, R3
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Write scenario 4 as specified, plus the file-local `waitForRecoverable` probe
+helper and the records-count poll. This task runs AFTER Task 1 (production
+behavior already landed), so the red evidence is produced by mutation, below —
+not by running against absent behavior.
+
+- [ ] **Step 2: Run the test and verify the intended failure (mutation red)**
+
+Run scenario 4 against mutated production to prove it detects the missing
+behavior (restore immediately after; the mutation is never committed):
+1. Containment off: temporarily remove `max-h-[80vh] flex flex-col` from the
+   dialog and `overflow-y-auto flex-1 min-h-0` from the `<ul>` in
+   RecoveryOfferPanel.tsx, then run
+   `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts -g "scenario 4"`
+   Expected: FAIL — the containment/scroll assertions fail.
+   Restore the classes.
+The failure must be for the missing behavior only (assertion mismatches on
+bounding boxes / scroll metrics — never harness errors).
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+None — production changes landed in Task 1. This step is limited to
 restoring/confirming the un-mutated tree (`git status` clean of production
 changes).
 
 - [ ] **Step 4: Run the focused test**
 
 Run: `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts`
-Expected: PASS — all five scenarios (budget: up to 600s for the cold release
+Expected: PASS — all four scenarios (budget: up to 600s for the cold release
 build, scenarios ~2-4 min each).
 
 - [ ] **Step 5: Refactor while green**
@@ -451,41 +350,87 @@ Expected: PASS (the other specs with recovery-offer entanglement).
 
 ```bash
 git add test/e2e-browser/specs/recover-my-panes-rust.spec.ts
-git commit -m "test(e2e): pin recovery-offer suppression while connected and phone-viewport containment"
+git commit -m "test(e2e): pin recovery-offer phone-viewport containment and add boot-sequence guards"
 ```
 
-### Task 4: Final verification of the whole delta
+**Task-order discipline:** Task 1 before Task 2 (e2e lands on the shipped
+containment); class literals as specified.
 
-**Requirements served:** R5
+### Task 3: Final verification of the whole delta
+
+**Requirements served:** every row in the Invariant Risk table
 
 - [ ] Run, in the worktree on the FINAL committed HEAD, and record receipts
   (command, commit, exit code, counts) in the execution ledger:
   1. `npm run check` (typecheck + coordinated full vitest suite) — PASS
-  2. `cargo test -p freshell-server -p freshell-ws` — PASS
-  3. `cargo clippy --workspace --all-targets -- -D warnings` — PASS (CI shape)
-  4. `cargo fmt --all -- --check` — PASS (CI shape)
-  5. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts` — PASS (5 scenarios)
-  6. `npm run lint` (a11y gate on changed client file) — PASS
-  7. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts` — PASS (other recovery-offer-entangled spec)
-- [ ] Docs decisions recorded in the ledger: `docs/index.html` not updated
-  (internal recovery dialog, not part of the default-experience mock — repo
-  rule requires mock updates only for major user-facing changes);
-  `docs/plans/2026-07-26-recover-my-panes.md` residual updated in Task 1.
-  Commit only if the ledger lives in the worktree (it does not — receipts are
-  recorded in the run logs; no commit expected for this task unless code
-  changes are required).
+  2. `npm run lint` (a11y gate on changed client file) — PASS
+  3. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts` — PASS (4 scenarios)
+  4. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts` — PASS (other recovery-offer-entangled spec)
+  5. `docs/index.html` assessment (AGENTS.md gate) — answer: not needed;
+     the dialog is transparent to the mock's shape; no new copy is added.
+- [ ] FreshEyes delta review (read-only, full delta): round-of-3 via
+  `.worktrees/.the-usual-logs/recovery-offer-phone/workflow/scripts/fresheyes/run-review.sh`
+  with `--executor-family other`, clean worktree (commit HEAD recorded),
+  `--log-dir` under `recovery-offer-phone/reports/`, scope text describing the
+  FULL DELTA (diff base→worktree HEAD, plan file path, original-request.md
+  path, plus tier=B diminished-authority note), run from the MAIN REPO cwd.
+  PASSED ⇒ skip the recap skill; on Major counting as firewall ⇒ do NOT treat
+  it as an out-of-scope finding (those capture ideas/follow-ups; real bugs
+  fix in place per protocol).
 
-## Notes / deliberate trade-offs (recorded, not blocking)
+## Unrelated-but-needs-confirmation
 
-- A momentarily-disconnected OTHER client (mid-reconnect, pre-first-push) can
-  briefly allow an offer; dismissal is deduped by contentId. Residual of the
-  socket-truthful design chosen over time-based heuristics (time heuristics
-  were rejected: the durable registry survives restarts and its 30-min TTL
-  would suppress legitimate offers minutes after a crash).
-- ledgerOnly is gated together with unions (the incident's wall was mostly
-  301 stale ledger rows). The 30-day ledger-row pile and never-aging stale
-  device dirs are separate cleanup opportunities, recorded as out-of-scope
-  findings — not addressed here.
-- Cross-device offers (recover the laptop's layout from the desktop) cease to
-  exist as an interruption; that was the documented "over-offer" the user
-  rejected. Sidebar rings remain the cross-device awareness surface.
+- `docs/index.html` (AGENTS.md docs gate — "update `docs/index.html` when
+  adding new user-facing features or significant UI changes"): Task 3 records
+  an explicit assessment. This change is a presentation-correction of an
+  existing modal without user-visible new features; the mock does not show the
+  recovery offer panel at all, and the docs list spec-compliant client features
+  unchanged — nothing user-facing is added. No new docs-page tests.
+
+## Testing approach (repo-consistent)
+
+- Unit/component level (Vitest + Testing Library): the
+  `RecoveryOfferPanel.test.tsx` structural case uses Testing Library idioms
+  (render with mocked inventory fetch, assert via `getByTestId()` attributes
+  and `className`, check `ParentElement` containment); not a new test seam,
+  not structural copy added by free text.
+- E2E (Playwright, `rust-chromium` serial profile): scenario 4 in
+  `recover-my-panes-rust.spec.ts` runs via `npm run test:e2e:local` against a
+  fresh server provisioned by `startRustServer`.
+- No supplementary cloud tests (per `FRESHELL_E2E_BACKEND` unset ⇒ local only).
+- Full flaky history exists in `.worktrees/.the-usual-logs/recovery-offer-phone/reports/plan-test-coverage.md`
+  (`task-1xdS9sGNDbWBoXB3IJszyTy` — the close-lag site flakes ONLY if the test
+  author's added probe step doesn't include the guard; attacker texts above
+  carry the transition guard).
+
+(batch evidence of some taps / pin/site-side facts omitted for brevity: the
+boot harness site is `App.tsx:874-895`; RESTORE-05's mock keeps current
+returns; any dead-time drift at open time is out-of-scope for the plan.)
+
+## Self-review evidence (mandatory before plan ends)
+
+1. **Spec coverage:** each Requirements Spec row maps to ≥1 test task —
+   verified: R1→Task 1 + scenario 4; R2→scenario guards + Task 3 rows 3-4;
+   R3→Task 1 focus-trap/Escape/backdrop tests + scenario 4.
+2. **Placeholder scan:** none — verified by rereading the finished plan end to
+   end; the reviewers upstack are expected to repeat this on the dispatch
+   lane.
+3. **Type/consistency:** every token in Interfaces matches the surrounding
+   repo state (class names, `data-testid` strings, ws kind strings, route
+   paths); cross-checked versus `src/lib/api.ts`, `src/store/tabRegistrySync.ts`,
+   `crates/freshell-ws/src/tabs.rs` snapshots. Also confirmed RESTORE-06's
+   `recheck` invariant remains untouched.
+4. **Cycle check:** tasks and steps topologically ordered.
+5. **Assumption audit:** no standard-library euphemisms; precise React idioms
+   (`getByTestId`, `BoundingBox`, `scrollHeight`); no duck-typed "framework"
+   abstractions appear.
+6. **Anchor specificity:** all file/line anchors present for sites; every
+   donor idiom cited is shown above with its outcome; task graph lists every
+   file each task touches.
+7. **Scope check:** the plan matches this SLICE only — the over-offer gate,
+   `bind` contexts, and HTTP-vs-WS unification are out-of-scope (recorded in
+   `.worktrees/.the-usual-logs/recovery-offer-phone/out-of-scope-findings.md`);
+   no invented bonus refactor.
+8. **Ambiguity fatal-scan:** a second implementer executing tomorrow would
+   produce the same shapes (class lists are spelled out, selectors quoted,
+   identifiers spelled, no "shapes" murk) and reach green.

--- a/docs/plans/2026-08-19-recovery-offer-phone.md
+++ b/docs/plans/2026-08-19-recovery-offer-phone.md
@@ -280,13 +280,23 @@ RustServer, appended after scenario 3):**
   response listener capturing the `GET /api/recovery/inventory` response:
   assert HTTP 200 AND `recoverable === false` AND the panel never appears
   (`toHaveCount(0)` evaluated only after the captured response resolved —
-  bounded wait, no blind retry). Then close A; poll the endpoint with an
+  bounded wait, no blind retry). Then close B AND close A (the suite's
+  no-overlapping-contexts invariant: the gate suppresses offers while ANY
+  other client is connected, so both must be gone); poll the endpoint with an
   authed probe (`page.request.get` of
   `/api/recovery/inventory?clientInstanceId=probe-s4&bootAgoMs=0`) until
   `recoverable === true` (30s budget — teardown may lag the close); finally
   boot fresh context C and REQUIRE the panel (reuse
   `openFreshContextWithOffer`), decline it, close C. This proves suppression
   was connectedness, not data loss, and R2's re-appearance.
+- **Teardown-lag guard (applies wherever a required offer follows a context
+  close with NO server restart):** after `ctxC.close()` (end of scenario 2)
+  before scenario 3's context-D boot, and after `ctxD.close()` before context
+  E's boot, and before scenario 5's phone boot, poll the probe endpoint until
+  `recoverable === true` (30s). Reuse one file-local helper
+  (e.g. `waitForRecoverable`). Restart-based transitions (scenario 1) need no
+  guard — restart clears the set. Scenarios 1–3 keep every existing assertion
+  byte-identical; the guard additions are wait-only.
 - **Scenario 5 (R3 pin):** a populating context creates 20 tabs (the pane
   records may be plain picker tabs — pickers are snapshotted records per
   SESSION-05 evidence) using the UI control

--- a/docs/plans/2026-08-19-recovery-offer-phone.md
+++ b/docs/plans/2026-08-19-recovery-offer-phone.md
@@ -22,7 +22,7 @@ unusable (screen-filling, unscrollable) dialog; once contained and scrollable,
 **Architecture:** One presentation-only change to the dialog (viewport cap +
 internal scroll region + buttons outside the scroll region), pinned by a
 structural unit test and validated at real browser level by a new e2e scenario
-(390x844 viewport, 20 records, decline actionability). No API/protocol/WS
+(390x844 viewport, 40 records, decline actionability). No API/protocol/WS
 changes; the fetch stays unconditional.
 
 **Verification gate (closes incident loop, validated in the load-bearing
@@ -46,7 +46,7 @@ axum server (`GET /api/recovery/inventory` — no changes), Playwright e2e under
    phone-sized screens; the records list scrolls internally; all controls
    reachable and clickable on a 390x844 viewport).
 2. Mobile-viewport e2e pinning that containment plus the phone user story
-   (Deliverable/Verification: e2e scenario with 20 records asserting bounding
+   (Deliverable/Verification: e2e scenario with 40 records asserting bounding
    box, internal scroll, and decline actionability on 390x844).
 3. Guarded e2e sequencing (Deliverable/Verification: teardown-lag guards at
    every close→required-offer transition so scenarios never coerce on stale
@@ -237,7 +237,7 @@ untouched and their close→required-offer transitions get the common
 
 - **Scenario 4 (R1 + R3 pins):** `test.setTimeout(240_000)` — the repo
   Playwright default is 60s and every existing scenario raises it to 120s or
-  240s; this scenario's own budget (decline ≤30s + 20-tab creation + ≤30s
+  240s; this scenario's own budget (decline ≤30s + 40-tab creation + ≤30s
   persistence poll + ≤30s guard + phone-boot assertions) can exceed 60s.
   A populating context boots. Offer rendering is asynchronous — the existing
   recovery helper documents observed delays exceeding 10s and therefore waits
@@ -253,12 +253,19 @@ untouched and their close→required-offer transitions get the common
   runs against a fresh server/home), skip declining and proceed — the
   mutation-red lane relies on this determinism, and it is also why
   context-E's close needs no guard: the branch is driven by the response
-  payload, never by visibility timing. Then it creates 20 shell tabs using
+  payload, never by visibility timing. Then it creates 40 shell tabs using
   the UI control `getByRole('button', { name: 'New shell tab' })` (idiom donor:
   `automation-layout-rust.spec.ts:143`; tab-count progress observable via
   `harness.getTabCount()`), then waits for persistence with a records-count
-  fs-poll (newest generation for that context's client has ≥ 20 records —
-  read the JSON gen files like `waitForSnapshotContaining` does). Close the
+  fs-poll (newest generation for that context's client has ≥ 40 records —
+  read the JSON gen files like `waitForSnapshotContaining` does).
+  (Execution-discovered, reviewer-verified deviation: the original 20 records
+  is non-discriminating at 390x844 — ~21 records render ≈500px of list content
+  while the capped dialog leaves a ≈525px list budget, so
+  `scrollHeight === clientHeight` in BOTH the un-fixed and fixed states and
+  the assertion cannot distinguish them. 40 records (~950px) reproduces the
+  overflow cleanly: mutation run failed containment with dialog top at
+  y = −141, exactly (844−1126)/2.) Close the
   context, run the `waitForRecoverable` guard, then boot a fresh context with
   `browser.newContext({ serviceWorkers: 'block', viewport: { width: 390, height: 844 } })`:
   panel visible; dialog bounding box fits within 390x844; the `<ul>` has
@@ -424,7 +431,7 @@ containment); class literals as specified.
   1. `npm run check` (typecheck + coordinated full vitest suite) — PASS
   2. `npm run lint` (a11y gate on changed client file) — PASS
   3. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts` — PASS (4 scenarios)
-  4. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts` — PASS (other recovery-offer-entangled spec)
+  4. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts` — receipt: recovery-entangled case-d PASS; cases a/b/c are blocked by a PRE-EXISTING codex managed-launch breakage (default flipped ON by `6a8733a3a`, 2026-07-30; the spec's `fake-codex-terminal.mjs` has no `app-server` support; confirmed pre-existing and disjoint from this delta by two independent reviews; recorded in out-of-scope-findings.md) — run it, record the exact outcome, and do NOT attempt to fix it here
   5. `npm run test:e2e:local -- --project=chromium test/e2e-browser/specs/sidebar-remote-status-rings-rust.spec.ts` — PASS (registered only under the `chromium` project lane)
   6. `docs/index.html` assessment (AGENTS.md gate) — answer: not needed;
      the dialog is transparent to the mock's shape; no new copy is added.

--- a/docs/plans/2026-08-19-recovery-offer-phone.md
+++ b/docs/plans/2026-08-19-recovery-offer-phone.md
@@ -138,10 +138,16 @@ with a settings opt-out — recorded as a follow-up, not built here.
   files (incl. `freshell-ws/tests/common/mod.rs` and integration suites), so a
   new pub field would break compilation across the workspace.
 - Modify: `crates/freshell-ws/src/terminal.rs` — `handle_tabs_push`
-  (~:5090-5107) stamps `state.tabs.note_connected_push(conn_id, &client_instance_id)`
-  right after the existing non-empty validation (~:5171-5173); the WS teardown
-  block (~:579-615) calls `state.tabs.clear_connected_connection(conn_id)` at a
-  point BEFORE its first await (validated: teardown's only await is the bounded
+  (~:5090-5107) gains a leading `conn_id: u64` parameter supplied by its
+  dispatcher (`terminal.rs:645`, the site that owns the connection id);
+  inside, stamped as `state.tabs.note_connected_push(conn_id, &client_instance_id)`
+  AFTER `process_tabs_push` validation succeeds (SUCCESS-only stamping —
+  validation lives in `process_tabs_push`; `tabs_push_response` and
+  `process_tabs_push` signatures stay untouched, so their six unit-test call
+  sites keep compiling. Only `handle_tabs_push`'s caller set changes: the
+  dispatcher plus any direct test callers). The WS teardown block (~:579-615)
+  calls `state.tabs.clear_connected_connection(conn_id)` at a point BEFORE
+  its first await (validated: teardown's only await is the bounded
   ≤500ms/lease kill-confirm loop at :605; everything before :602 is sync).
 - Modify: `crates/freshell-server/src/recovery_inventory.rs` —
   `RecoveryInventoryState` gains `pub tabs: freshell_ws::tabs::TabsRegistry`;
@@ -180,14 +186,20 @@ with a settings opt-out — recorded as a follow-up, not built here.
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Add to `recovery_inventory_tests.rs`: the three route tests above (extend the
-`test_state` helper with an empty `TabsRegistry`). These compile against
-today's handler and the suppressed-case test FAILS behaviorally
-(`recoverable:true` observed). The `ConnectedTabClients` unit tests land WITH
-the implementation in Step 3 (their pre-implementation "red" would be
-compile-level only, which proves nothing; the rotation unit test is an
-anti-regression pin for the HashMap-replacement contract, motivated by the
-real rotation path `tabRegistrySync.ts:412-431`).
+1a. First, behavior-preserving plumbing (so the red in 1b is behavioral, not a
+compile failure): create `connected_clients.rs` (module + its unit tests incl.
+rotation — they pass immediately; rotation is the anti-regression pin for the
+HashMap-replacement contract, motivated by `tabRegistrySync.ts:412-431`), add
+`pub mod connected_clients;` to `lib.rs`, add the `tabs` field to
+`RecoveryInventoryState`, add the three delegating accessors to `TabsRegistry`,
+extend the `test_state` helper with an empty `TabsRegistry`, add the `conn_id`
+parameter to `handle_tabs_push` + dispatcher callsite, pass `tabs.clone()` into
+`RecoveryInventoryState` at the `main.rs` merge (~:1615-1625), and the teardown
+clear-call. Run `cargo test -p freshell-server recovery_inventory` and
+`cargo test -p freshell-ws connected_clients` — ALL pass (no behavior change).
+
+1b. Now write the three route tests above. They compile (all surfaces exist)
+and the suppressed-case test FAILS behaviorally (gate absent).
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -199,15 +211,10 @@ not a compile/setup error; the other two new tests pass.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Create `connected_clients.rs` (module + unit tests incl. rotation); add
-`pub mod connected_clients;` to `lib.rs` (no WsState change); add the
-`ConnectedTabClients` field + three delegating accessors to `TabsRegistry`;
-stamp in `handle_tabs_push` after the non-empty validation; clear in the
-teardown block before its first await; gate in `inventory_handler` (after
-auth: `let mut others = state.tabs.connected_client_ids(); others.remove(&exclude);
+Add ONLY the gate in `inventory_handler` (after auth:
+`let mut others = state.tabs.connected_client_ids(); others.remove(&exclude);
 if !others.is_empty() { return Json(build_inventory(vec![], vec![],
-HashSet::new())).into_response() }`); extend `RecoveryInventoryState` + pass
-`tabs.clone()` at the `main.rs` merge; fix the stale doc comment; update the
+HashSet::new())).into_response() }`). Fix the stale doc comment; update the
 plan-doc residual.
 
 - [ ] **Step 4: Run the focused test**
@@ -265,8 +272,8 @@ git commit -m "fix(server): suppress recovery inventory offers while other clien
   carries `max-h-[80vh] flex flex-col`.
 - `recovery-decline` and `recovery-accept` are NOT descendants of the
   scrolling `<ul>` (reachable without scrolling within it).
-- Existing 10 tests in the file keep passing (scroll-lock, focus trap,
-  backdrop, Escape, accept/decline flows).
+- All existing tests in the file keep passing (scroll-lock, focus trap,
+  backdrop, Escape, accept/decline flows — do not cite a count; counts drift).
 
 - [ ] **Step 1: Write the failing behavioral test**
 

--- a/docs/plans/2026-08-19-recovery-offer-phone.md
+++ b/docs/plans/2026-08-19-recovery-offer-phone.md
@@ -55,12 +55,12 @@ axum server (`GET /api/recovery-inventory` — no changes), Playwright e2e under
 
 ## Context map
 
-RESTORE-01 (offer query at boot) flows: `App.tsx:874-895` boot harness →
-`src/lib/api.ts:36-40` `fetchRecoveryInventory` → Rust `inventory_handler`
-(`crates/freshell-server/src/recovery_inventory.rs:384-420`) → `RecoveryOfferPanel.suggestedPaneRecords`. RESTORE-03/04: panel + `WindowSuggester` +
-`applyRecoverySuggestion` (App.tsx:961-973). The e2e reality (recover spec
-`openFreshContextWithOffer` + RESTORE-05 test site := App.tsx:874-895) +
-`recheck` behavior at RESTORE-06 (re-offer withheld until next connect). Full
+RESTORE-01 (offer query at boot) flows: the panel self-fetches via
+`getRecoveryInventory` (`src/lib/api.ts`) → Rust `inventory_handler`
+(`crates/freshell-server/src/recovery_inventory.rs:384-420`); the panel is
+rendered by App at `App.tsx:1926`. RESTORE-03/04: panel + suggestion/apply
+flow (App.tsx). Dismissal semantics (RESTORE-06): closing via Escape/backdrop
+keeps the offer pending for a later boot rather than starting a timer. Full
 evidence: `.worktrees/.the-usual-logs/recovery-offer-phone/reports/plan-rust-inventory.md`, `plan-client-panel.md`, `plan-test-coverage.md`.
 
 Load-bearing evidence (validated this run, receipt at
@@ -95,10 +95,13 @@ Load-bearing evidence (validated this run, receipt at
   `recovery-offer-panel`, `recovery-decline`, `recovery-accept`,
   `recovery-live-note` unchanged.
 - Modify: `test/unit/client/components/RecoveryOfferPanel.test.tsx` — one new
-  structural test: dialog has `max-h-[80vh] flex flex-col`, the
-  `recovery-live-note` element has `overflow-y-auto`, and the buttons render
-  as dialog children OUTSIDE the scrollable element (`note.parentElement !==
-  dialog.parentElement`).
+  structural test: the dialog (selected via `getByTestId('recovery-offer-panel')`)
+  has the classes `max-h-[80vh]` and `flex flex-col`; the `<ul>` descendant of
+  the dialog has `overflow-y-auto`, `flex-1`, and `min-h-0`; AND neither
+  `recovery-decline` nor `recovery-accept` is a descendant of that `<ul>`
+  (assert via `ul.contains(declineButton)` / `ul.contains(acceptButton)` ===
+  false — the footer lives in the dialog's flex column but outside the scroll
+  region).
 - Modify: `test/e2e-browser/specs/recover-my-panes-rust.spec.ts` — new serial
   scenario 4 plus a teardown-lag guard (`waitForRecoverable`) at every
   close→required-offer transition without restart (after scenario 1's
@@ -126,8 +129,8 @@ Load-bearing evidence (validated this run, receipt at
 
 - **R1 (formerly R3 — containment).** On a phone-sized viewport the dialog fits
   the viewport, its list scrolls internally, and every control (`Dismiss`,
-  `Add tabs…`, focus trap, Escape→recheck timer, backdrop click→recheck timer)
-  remains reachable and functional.
+  `Add tabs…`, focus trap, Escape dismiss, backdrop-click dismiss) remains
+  reachable and functional.
 - **R2 (regression gate + no-seam).** `RESTORE-01..05` assertions + both
   recovery-offer-entangled specs (`recover-my-panes-rust`, `sidebar-registry-sync-rust` +
   `sidebar-remote-status-rings-rust`) keep passing against ONE fixed run-mode
@@ -138,7 +141,9 @@ Load-bearing evidence (validated this run, receipt at
   Mechanically the plan adds an enforced probe-poll guard
   (`waitForRecoverable` helper polling the inventory endpoint with
   `x-auth-token` via a STANDALONE `request.newContext({ baseURL:
-  info.baseURL, extraHTTPHeaders: { 'x-auth-token': info.token } })` — NOT
+  info.baseUrl, extraHTTPHeaders: { 'x-auth-token': info.token } })` — note
+  `TestServerInfo` exposes `baseUrl` (lowercase), while Playwright's option
+  key is `baseURL`; `request` is imported from `@playwright/test`. NOT
   `page.request` on a doomed page/context (handle is invalidated by `close()`),
   NOT a navigated page (that would create a tracked tabs.sync client and
   entangle the bootstrap fetch) — disposed after success) wherever a later
@@ -146,10 +151,10 @@ Load-bearing evidence (validated this run, receipt at
   context-B close, scenario 2's context-C close, scenario 3's context-D close,
   and scenario 4's populating-context close).
 - **R3 (interactions completeness).** Every panel interaction (restore/decline
-  buttons, focus trap including outside buttons, Escape→recheck timer,
-  backdrop click) keeps working on the phone viewport. Satisfied by the e2e
-  decline actionability plus the unchanged unit tests; no changed interaction
-  semantics.
+  buttons, focus trap, Escape dismiss, backdrop-click dismiss) keeps working on
+  the phone viewport, preserving today's semantics (dismissal keeps the offer
+  pending for a later boot). Satisfied by the e2e decline actionability plus
+  the unchanged unit tests; no changed interaction semantics.
 
 ## Invariant risk table for pinning
 
@@ -187,7 +192,8 @@ rescoped by user decision._
     <button data-testid="recovery-accept" .../>
 ```
 
-(The boots and recheck loops are UNCHANGED. All testids, the two scroll-lock
+(The boot harness and dismissal semantics are UNCHANGED: dismissal keeps the
+offer pending for a later boot. All testids, the two scroll-lock
 blocks, and the focus trap keep their current behavior.)
 
 ### Server WS handlers + routes
@@ -243,13 +249,16 @@ untouched and their close→required-offer transitions get the common
 - [ ] **Step 1: Write the failing behavioral test**
 
 Add to `test/unit/client/components/RecoveryOfferPanel.test.tsx` (the file
-already mocks `getRecoveryInventory`, `acceptRecoverySuggestion`, etc.):
+already mocks the recovery-inventory API):
 
 - Renders panel with N records ⇒ the `recovery-offer-panel` dialog has Tailwind
-  classes `max-h-[80vh]` and `flex flex-col`; the `recovery-live-note`'s sibling
-  `<ul>` has `overflow-y-auto`, `min-h-0`, `flex-1`; AND the two buttons are
-  NOT descendants of the scrollable `<ul>` (pointer: the buttons stay in the
-  dialog's flex column but outside the scroll region).
+  classes `max-h-[80vh]` and `flex flex-col`; a `<ul>` descendant of the
+  dialog (select via `dialog.querySelector('ul')` — no new testids) has
+  `overflow-y-auto`, `min-h-0`, `flex-1`; AND the two buttons are NOT
+  descendants of that `<ul>`
+  (`ul.contains(getByTestId('recovery-decline')) === false`, same for
+  `recovery-accept` — the buttons stay in the dialog's flex column but outside
+  the scroll region).
   Test name/comment must reference **R1 (dialog containment)**.
 - Existing tests in the file keep passing (scroll-lock, focus trap, backdrop,
   Escape, accept/decline flows — do not cite a count; counts drift).
@@ -419,7 +428,8 @@ returns; any dead-time drift at open time is out-of-scope for the plan.)
    repo state (class names, `data-testid` strings, ws kind strings, route
    paths); cross-checked versus `src/lib/api.ts`, `src/store/tabRegistrySync.ts`,
    `crates/freshell-ws/src/tabs.rs` snapshots. Also confirmed RESTORE-06's
-   `recheck` invariant remains untouched.
+   dismissal semantics (pending offer re-surfaces on a later boot) remain
+   untouched.
 4. **Cycle check:** tasks and steps topologically ordered.
 5. **Assumption audit:** no standard-library euphemisms; precise React idioms
    (`getByTestId`, `BoundingBox`, `scrollHeight`); no duck-typed "framework"

--- a/docs/plans/2026-08-19-recovery-offer-phone.md
+++ b/docs/plans/2026-08-19-recovery-offer-phone.md
@@ -396,8 +396,14 @@ conventions.
 
 - [ ] **Step 6: Run broader verification**
 
-Run: `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts test/e2e-browser/specs/sidebar-remote-status-rings-rust.spec.ts`
-Expected: PASS (the other specs with recovery-offer entanglement).
+Run BOTH of these (the rings spec is not matched by `rust-chromium`'s
+`testMatch` — it is registered only under the `chromium` project, whose
+`e2eServerKind` fixture defaults to `legacy`; explicit CLI file filters are
+applied AFTER project `testMatch` selection, so it must be invoked via its
+configured project):
+1. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts` — PASS
+2. `npm run test:e2e:local -- --project=chromium test/e2e-browser/specs/sidebar-remote-status-rings-rust.spec.ts` — PASS
+(the other specs with recovery-offer entanglement).
 
 - [ ] **Step 7: Commit the task**
 
@@ -419,7 +425,8 @@ containment); class literals as specified.
   2. `npm run lint` (a11y gate on changed client file) — PASS
   3. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/recover-my-panes-rust.spec.ts` — PASS (4 scenarios)
   4. `npm run test:e2e:local -- --project=rust-chromium test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts` — PASS (other recovery-offer-entangled spec)
-  5. `docs/index.html` assessment (AGENTS.md gate) — answer: not needed;
+  5. `npm run test:e2e:local -- --project=chromium test/e2e-browser/specs/sidebar-remote-status-rings-rust.spec.ts` — PASS (registered only under the `chromium` project lane)
+  6. `docs/index.html` assessment (AGENTS.md gate) — answer: not needed;
      the dialog is transparent to the mock's shape; no new copy is added.
 - [ ] FreshEyes delta review (read-only, full delta): round-of-3 via
   `.worktrees/.the-usual-logs/recovery-offer-phone/workflow/scripts/fresheyes/run-review.sh`

--- a/src/components/RecoveryOfferPanel.tsx
+++ b/src/components/RecoveryOfferPanel.tsx
@@ -188,7 +188,7 @@ export function RecoveryOfferPanel(): JSX.Element | null {
         aria-modal="true"
         aria-labelledby={HEADING_ID}
         data-testid="recovery-offer-panel"
-        className="bg-background border border-border rounded-lg shadow-lg w-full max-w-md mx-4 p-5"
+        className="bg-background border border-border rounded-lg shadow-lg w-full max-w-md mx-4 p-5 max-h-[80vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => {
           if (e.key !== 'Tab') return
@@ -217,7 +217,8 @@ export function RecoveryOfferPanel(): JSX.Element | null {
           Restore {paneCount} {paneCount === 1 ? 'pane' : 'panes'} from server memory?
         </h2>
         {device && <p className="mt-1 text-xs text-muted-foreground">{device.deviceLabel}</p>}
-        <ul className="mt-3 text-sm text-muted-foreground list-disc pl-5 space-y-1">
+        {/* Sole scroll region (R1): keeps heading, notes, and buttons out of the scrollable area. */}
+        <ul className="mt-3 text-sm text-muted-foreground list-disc pl-5 space-y-1 overflow-y-auto flex-1 min-h-0">
           {(device?.tabs ?? []).flatMap((tab) =>
             tab.panes.map((pane) => (
               <li key={`${tab.tabKey}:${pane.paneId}`}>

--- a/test/e2e-browser/specs/recover-my-panes-rust.spec.ts
+++ b/test/e2e-browser/specs/recover-my-panes-rust.spec.ts
@@ -17,6 +17,20 @@
  * fresh context's offer shows the live-session note, and accepting recreates
  * the pane WITHOUT `--resume` — the running session is left untouched.
  *
+ * Scenario 4 (phone containment, R1/R3): a populating context records a
+ * 40-shell-tab layout and is lost WITHOUT a server restart; a fresh
+ * 390x844-viewport context is then offered the layout — the dialog must fit
+ * the viewport (bounding box), the records list must scroll internally
+ * (`scrollHeight > clientHeight`), and the decline control must be tappable
+ * (Playwright actionability IS the user-level phone proof). The inventory
+ * must OVERFLOW the dialog's 80vh-capped list budget (~525px at 844px tall,
+ * ~24px/record) to exercise containment at all — 20 records measure ~500px
+ * and fit under the cap, making every scroll/bounding assertion vacuous
+ * (identical metrics with and without the containment classes). Every
+ * close→required-offer transition without a restart is preceded by the
+ * file-local `waitForRecoverable` probe-poll guard (R2a) so WS-teardown lag
+ * can never starve a later boot's required offer.
+ *
  * Fixture shapes (fake CLI, config seeding, shell-picker choreography) are
  * COPIED from pane-ledger-restart-rust.spec.ts per this suite's
  * per-spec-ownership convention.
@@ -31,7 +45,7 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as os from 'node:os'
 import { fileURLToPath } from 'node:url'
-import type { BrowserContext, Page } from '@playwright/test'
+import { request, type BrowserContext, type Page } from '@playwright/test'
 import { RustServer, ensureRustServerBuilt } from '../helpers/rust-server.js'
 import type { TestServerInfo } from '../helpers/test-server.js'
 import { TestHarness } from '../helpers/test-harness.js'
@@ -154,6 +168,48 @@ async function createBrowserPane(page: Page, url: string): Promise<void> {
   await iframe.waitFor({ state: 'attached', timeout: 10_000 })
 }
 
+/**
+ * Close→required-offer guard (teardown-lag pin): poll
+ * `GET /api/recovery/inventory` with a PROBE clientInstanceId until the last
+ * closed context's records resolve as recoverable, so a later boot that
+ * REQUIRES the offer can never race WS-teardown lag. Uses a STANDALONE
+ * APIRequestContext — NOT `page.request` (its handle dies with the page's
+ * browser context) and NOT a navigated page (a booted page would register as
+ * a tracked tabs.sync client and entangle the very inventory it polls); the
+ * probe is a plain auth'd GET that never opens a WS socket, so it leaves no
+ * connected-state of its own. Disposed after use.
+ */
+async function waitForRecoverable(
+  info: TestServerInfo,
+  { timeoutMs = 30_000 }: { timeoutMs?: number } = {},
+): Promise<void> {
+  const req = await request.newContext({
+    baseURL: info.baseUrl,
+    extraHTTPHeaders: { 'x-auth-token': info.token },
+  })
+  try {
+    const deadline = Date.now() + timeoutMs
+    let lastPayload: unknown
+    while (Date.now() < deadline) {
+      const res = await req
+        .get('/api/recovery/inventory?clientInstanceId=freshell-test-probe&bootAgoMs=0')
+        .catch(() => null)
+      if (res?.ok()) {
+        const body = (await res.json().catch(() => null)) as { recoverable?: unknown } | null
+        lastPayload = body
+        if (body?.recoverable === true) return
+      }
+      await new Promise((r) => setTimeout(r, 500))
+    }
+    throw new Error(
+      `waitForRecoverable: inventory never reported recoverable=true within ${timeoutMs}ms; `
+      + `last payload: ${JSON.stringify(lastPayload)}`,
+    )
+  } finally {
+    await req.dispose()
+  }
+}
+
 test.describe('recover-my-panes browser-loss recovery (rust only)', () => {
   // Scenarios share ONE owned server and build on each other's durable state
   // (snapshots, ledger rows, a still-running PTY) — strict ordering required.
@@ -188,6 +244,61 @@ test.describe('recover-my-panes browser-loss recovery (rust only)', () => {
       await new Promise((r) => setTimeout(r, 500))
     }
     throw new Error(`No tabs-snapshot generation contained [${needles.join(', ')}] within ${timeoutMs}ms`)
+  }
+
+  /**
+   * Wait until the NEWEST persisted tabs-snapshot generation FOR THE GIVEN
+   * CLIENT carries >= minRecords records — the scenario-4 size pin. Same
+   * fs-poll idiom as waitForSnapshotContaining (snapshot pushes fire on ready
+   * + every 5s, so the registry's JSON generation files lag the UI by
+   * seconds): read every generation file, keep only the given
+   * clientInstanceId's, rank newest by (snapshotRevision, capturedAt) — the
+   * server's own per-client monotonic ordering (tabs_persist.rs
+   * `generation_rank`) — and insist the newest generation has the full tab
+   * set on disk.
+   */
+  async function waitForNewestGenerationRecordCount(
+    clientInstanceId: string,
+    minRecords: number,
+    timeoutMs = 30_000,
+  ): Promise<void> {
+    const snapshotsDir = path.join(capturedHome, '.freshell', 'tabs-snapshots')
+    const deadline = Date.now() + timeoutMs
+    let lastObserved = 0
+    while (Date.now() < deadline) {
+      const devices = await fs.readdir(snapshotsDir).catch(() => [] as string[])
+      for (const device of devices) {
+        const deviceDir = path.join(snapshotsDir, device)
+        const files = (await fs.readdir(deviceDir).catch(() => [] as string[]))
+          .filter((f) => f.endsWith('.json'))
+        let newest: { revision: number; capturedAt: number; count: number } | null = null
+        for (const f of files) {
+          const raw = await fs.readFile(path.join(deviceDir, f), 'utf8').catch(() => '')
+          let doc: any = null
+          try {
+            doc = JSON.parse(raw)
+          } catch {
+            continue
+          }
+          if (doc?.clientInstanceId !== clientInstanceId) continue
+          const revision = Number(doc?.snapshotRevision ?? 0)
+          const capturedAt = Number(doc?.capturedAt ?? 0)
+          const count = Array.isArray(doc?.records) ? doc.records.length : 0
+          if (!newest || revision > newest.revision || (revision === newest.revision && capturedAt > newest.capturedAt)) {
+            newest = { revision, capturedAt, count }
+          }
+        }
+        if (newest) {
+          lastObserved = Math.max(lastObserved, newest.count)
+          if (newest.count >= minRecords) return
+        }
+      }
+      await new Promise((r) => setTimeout(r, 500))
+    }
+    throw new Error(
+      `No persisted generation for client ${clientInstanceId} reached ${minRecords} records `
+      + `within ${timeoutMs}ms (last observed: ${lastObserved})`,
+    )
   }
 
   test.beforeAll(async () => {
@@ -362,6 +473,9 @@ test.describe('recover-my-panes browser-loss recovery (rust only)', () => {
     await expect(pageB.getByTestId('recovery-offer-panel')).toHaveCount(0)
 
     await ctxB.close()
+    // Guard (R2a): scenario 2's ctxC boot REQUIRES the offer — wait until B's
+    // closed records resolve as recoverable so teardown lag cannot starve it.
+    await waitForRecoverable(info)
   })
 
   test('scenario 2: decline path — panel closes, no recovered tabs added', async ({ browser, e2eServerKind }) => {
@@ -386,6 +500,8 @@ test.describe('recover-my-panes browser-loss recovery (rust only)', () => {
     expect(await harnessC.getTabCount()).toBe(1)
 
     await ctxC.close()
+    // Guard (R2a): scenario 3's ctxD boot REQUIRES the offer.
+    await waitForRecoverable(info)
   })
 
   test('scenario 3: no-restart browser loss — live session recreates WITHOUT resume (D7)', async ({ browser, e2eServerKind }) => {
@@ -432,6 +548,8 @@ test.describe('recover-my-panes browser-loss recovery (rust only)', () => {
     // ---- Lose the browser WITHOUT restarting the server: the claude PTY
     // stays Running (registry-owned, not connection-owned). ----
     await ctxD.close()
+    // Guard (R2a): context E's boot below REQUIRES the offer for D's layout.
+    await waitForRecoverable(info)
 
     // ---- Context E: the offer appears (the new session changed the
     // recoverable substance — scenario 2's dismissal cannot suppress it, and
@@ -462,6 +580,112 @@ test.describe('recover-my-panes browser-loss recovery (rust only)', () => {
       'live session must be recreated WITHOUT --resume (left untouched, D7)',
     ).toBe(false)
 
+    // Deliberately UNGUARDED close (R2a): scenario 4's populating boot never
+    // branches on offer visibility timing — it captures the boot inventory
+    // response payload and declines only when the payload says recoverable,
+    // so it is correct whether or not E's teardown has settled.
     await ctxE.close()
+  })
+
+  test('scenario 4: small-viewport boots offer the full dialog and the decline control is tappable', async ({ browser, e2eServerKind }) => {
+    expect(e2eServerKind).toBe('rust')
+    test.setTimeout(240_000)
+
+    // ---- Populating context: record a 40-shell-tab layout ----
+    // 40 records overflow the dialog's 80vh-capped list budget on an 844px
+    // viewport (measured ~24px/record ⇒ ~950px of content vs a ~525px list
+    // budget); the plan's 20 records measure ~500px and fit UNDER the cap,
+    // which made scrollHeight === clientHeight with AND without the
+    // containment classes — a non-discriminating assertion.
+    // A boot offer MODALLY intercepts the "New shell tab" clicks below — the
+    // canonical full serial run has recoverable state from scenarios 1–3,
+    // while an isolated `-g "scenario 4"` run against a fresh server/home has
+    // none. Branch on the boot inventory RESPONSE PAYLOAD (captured BEFORE
+    // navigation), never on visibility timing: offer render latency of >10s
+    // has been observed, so a short visibility probe would race a delayed
+    // modal into a false "no offer" read.
+    const ctxP = await browser.newContext(FRESH_CONTEXT_OPTIONS)
+    const pageP = await ctxP.newPage()
+    traceInventoryFailures(pageP, 'scenario4-populating')
+    const inventoryResponsePromise = pageP.waitForResponse((r) => r.url().includes('/api/recovery/inventory'))
+    const harnessP = await connect(pageP, info)
+    const inventoryBody = (await (await inventoryResponsePromise).json().catch(() => null)) as { recoverable?: unknown } | null
+    if (inventoryBody?.recoverable === true) {
+      const bootPanel = pageP.getByTestId('recovery-offer-panel')
+      await expect(bootPanel).toBeVisible({ timeout: 30_000 })
+      await pageP.getByTestId('recovery-decline').click()
+      await expect(bootPanel).toHaveCount(0)
+    }
+
+    // 40 shell tabs via the tab strip (idiom donor: automation-layout-rust.spec.ts:143
+    // — TabBar.tsx:535 `addTab({mode:'shell'})`; multirow-tabs.spec.ts's
+    // click-loop + waitForTabCount same shape).
+    const newShellTab = pageP.getByRole('button', { name: 'New shell tab' })
+    for (let i = 0; i < 40; i++) {
+      await newShellTab.click()
+    }
+    await harnessP.waitForTabCount(41, 30_000) // 1 boot tab + 40 shell tabs
+
+    // The populating client's claimed tabs-registry clientInstanceId (the
+    // TAB_REGISTRY_CLIENT_INSTANCE_ID_STORAGE_KEY value,
+    // src/store/storage-keys.ts:17) selects its generations out of every
+    // device dir in the poll below.
+    const populatingClientId = await pageP.evaluate(() =>
+      window.sessionStorage.getItem('freshell.tabs.client-instance-id.v1'),
+    )
+    expect(populatingClientId, 'populating context claimed a tabs-registry clientInstanceId').toBeTruthy()
+
+    // The 40-tab layout must be IN DISK before the context dies: newest
+    // generation for this client carries >= 40 records (the boot picker tab
+    // may contribute a 41st).
+    await waitForNewestGenerationRecordCount(populatingClientId!, 40)
+
+    // ---- Lose the populating browser WITHOUT a server restart ----
+    await ctxP.close()
+    // Guard (R2a): the phone boot below REQUIRES the 40-tab offer.
+    await waitForRecoverable(info)
+
+    // ---- Phone-viewport context: the offer must contain itself + scroll ----
+    const ctxPhone = await browser.newContext({
+      serviceWorkers: 'block',
+      viewport: { width: 390, height: 844 },
+    })
+    const pagePhone = await ctxPhone.newPage()
+    traceInventoryFailures(pagePhone, 'scenario4-phone')
+    await connect(pagePhone, info)
+
+    const panel = pagePhone.getByTestId('recovery-offer-panel')
+    await expect(panel).toBeVisible({ timeout: 30_000 })
+
+    // R1 containment: the dialog's rendered box never escapes the 390x844
+    // viewport (the phone incident: the dialog filled the screen and cropped
+    // the decline button off-viewport).
+    const box = await panel.boundingBox()
+    expect(box, 'recovery dialog must have a layout box').not.toBeNull()
+    expect(box!.x).toBeGreaterThanOrEqual(0)
+    expect(box!.y).toBeGreaterThanOrEqual(0)
+    expect(box!.x + box!.width).toBeLessThanOrEqual(390)
+    expect(box!.y + box!.height).toBeLessThanOrEqual(844)
+
+    // R1 internal scroll: the records list is the sole scroll region
+    // (RecoveryOfferPanel's <ul>) and provably overflows its own box with a
+    // 40-record inventory.
+    const recordsList = panel.locator('ul').first()
+    const listMetrics = await recordsList.evaluate((el) => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }))
+    expect(
+      listMetrics.scrollHeight,
+      'records list must scroll internally with a 40-record inventory',
+    ).toBeGreaterThan(listMetrics.clientHeight)
+
+    // R1/R3 phone proof: Playwright's click does the full actionability sweep
+    // (attached, visible, stable, receives events) — "Not now" really is one
+    // tap away on the phone-sized screen.
+    await pagePhone.getByTestId('recovery-decline').click()
+    await expect(panel).toHaveCount(0)
+
+    await ctxPhone.close()
   })
 })

--- a/test/unit/client/components/RecoveryOfferPanel.test.tsx
+++ b/test/unit/client/components/RecoveryOfferPanel.test.tsx
@@ -215,6 +215,43 @@ describe('RecoveryOfferPanel', () => {
     expect(isDismissed('cid-1')).toBe(false)
   })
 
+  // R1 (dialog containment): the dialog must be viewport-bounded with the
+  // records list as the sole scroll region, so phone-sized viewports can reach
+  // the buttons (DeadSessionPanel.tsx:55,62 is the idiom donor).
+  it('bounds the dialog to the viewport and makes the records <ul> the sole scroll region (R1: dialog containment)', async () => {
+    const pane = INVENTORY.device!.tabs[0].panes[0]
+    const multiInventory: RecoveryInventory = {
+      ...INVENTORY,
+      device: {
+        ...INVENTORY.device!,
+        tabs: [
+          {
+            tabKey: 'k',
+            tabName: 'work',
+            panes: Array.from({ length: 12 }, (_, i) => ({ ...pane, paneId: `p${i}` })),
+          },
+        ],
+      },
+    }
+    vi.mocked(getRecoveryInventory).mockResolvedValue(multiInventory)
+    render(<Provider store={makeTestStore()}><RecoveryOfferPanel /></Provider>)
+
+    const dialog = await screen.findByTestId('recovery-offer-panel')
+    expect(dialog).toHaveClass('max-h-[80vh]')
+    expect(dialog).toHaveClass('flex')
+    expect(dialog).toHaveClass('flex-col')
+
+    const ul = dialog.querySelector('ul')
+    expect(ul).not.toBeNull()
+    expect(ul).toHaveClass('overflow-y-auto')
+    expect(ul).toHaveClass('flex-1')
+    expect(ul).toHaveClass('min-h-0')
+
+    // Buttons stay outside the scroll region so they remain visible/reachable
+    expect(ul!.contains(screen.getByTestId('recovery-decline'))).toBe(false)
+    expect(ul!.contains(screen.getByTestId('recovery-accept'))).toBe(false)
+  })
+
   it('shows the live note for live panes and recreates them without sessionRef (D7)', async () => {
     const liveInventory: RecoveryInventory = {
       ...INVENTORY,


### PR DESCRIPTION
## Summary

Fixes the phone incident: a boot on a small viewport showed the "Restore N panes from server memory?" dialog screen-full and unscrollable — the backdrop scroll-lock meant the user could not reach the buttons at all.

- `RecoveryOfferPanel` dialog capped at `max-h-[80vh]` with `flex flex-col`; the records list is the sole internal scroll region (`overflow-y-auto flex-1 min-h-0`) — mirrors the existing `DeadSessionPanel` idiom. Title, note, and both buttons stay visible; every interaction (Not now / Restore / Escape / backdrop) still works.
- No other changes: no gating or suppression logic (scope decision by product owner), no server/API/WS changes.

## Testing

- Unit: new structural test pins the containment classes and that the buttons sit outside the scroll region; full client suite green (5142 passed).
- E2E: new scenario 4 in `recover-my-panes-rust.spec.ts` — 390x844 viewport, 40 recorded panes, asserts dialog containment, `scrollHeight > clientHeight`, and decline actionability. Mutation-verified: with the classes removed the scenario fails at containment (dialog top renders 141px above the viewport). Full spec 4/4 green; rings spec 3/3 green.
- Independent reviews: 8-round plan FreshEyes loop, per-task reviews, whole-branch review, delta FreshEyes — all pass.
- One pre-existing, unrelated failure is unchanged: `sidebar-registry-sync-rust` case-c fails on a codex managed-launch fixture gap that predates this branch (recorded, not silenced).

🤖 Generated with [OpenCode](https://opencode.ai)