### PR TITLE
test(e2e): pin FRESHELL_CODEX_MANAGED_LAUNCH=0 in plain-CLI fake-codex rust specs (kata cnwc)

### DIFF
--- a/test/e2e-browser/specs/codex-terminal-restore-rust.spec.ts
+++ b/test/e2e-browser/specs/codex-terminal-restore-rust.spec.ts
@@ -179,6 +179,15 @@ test.describe('Codex Terminal Restore (Rust only)', () => {
           env: {
             CODEX_CMD: fakeCodexPath,
             FAKE_CODEX_TERMINAL_ARGV_LOG: argLogPath,
+            // Codex managed-launch opt-out (kata cnwc): 6a8733a3a flipped
+            // FRESHELL_CODEX_MANAGED_LAUNCH's default ON (only exact "0"
+            // disables, launch_plan.rs), but fake-codex-terminal.mjs only
+            // speaks the plain-CLI contract (prompt + Enter-gated rollout) --
+            // under the managed app-server plan every codex create 500s
+            // ("creating Codex terminal: app-server error 500"). Same pin the
+            // flag-flip commit set in the Rust plain-CLI unit/integration
+            // suites (set_var(FRESHELL_CODEX_MANAGED_LAUNCH, "0")).
+            FRESHELL_CODEX_MANAGED_LAUNCH: '0',
           },
           // PanePicker only renders a CLI option when THREE conditions all
           // hold (`src/components/panes/PanePicker.tsx`'s `cliOptions`

--- a/test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts
+++ b/test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts
@@ -184,6 +184,15 @@ test.describe.serial('P1.14 sidebar registry sync (rust)', () => {
         CODEX_CMD: fakeCodex,
         FAKE_CLAUDE_ARGV_LOG: path.join(sharedRoot, 'claude-argv.jsonl'),
         FAKE_CODEX_TERMINAL_ARGV_LOG: path.join(sharedRoot, 'codex-argv.jsonl'),
+        // Codex managed-launch opt-out (kata cnwc): 6a8733a3a flipped
+        // FRESHELL_CODEX_MANAGED_LAUNCH's default ON (only exact "0" disables,
+        // launch_plan.rs), but fake-codex-terminal.mjs only speaks the
+        // plain-CLI contract (prompt + Enter-gated rollout) -- under the
+        // managed app-server plan every codex create 500s
+        // ("creating Codex terminal: app-server error 500"). Same pin the
+        // flag-flip commit set in the Rust plain-CLI unit/integration suites
+        // (set_var(FRESHELL_CODEX_MANAGED_LAUNCH, "0")).
+        FRESHELL_CODEX_MANAGED_LAUNCH: '0',
       },
       setupHome: async (homeDir: string) => {
         await fs.mkdir(PROJECT_DIR, { recursive: true })
@@ -612,12 +621,38 @@ test.describe.serial('P1.14 sidebar registry sync (rust)', () => {
     // context never sees (donor scenario 3 relies on the same isolation).
     await declineRecoveryOfferIfShowing(page)
 
+    // #540's D7 live-session guard (70c43c656) 409-rejects this test's resume
+    // create while case-a's respawned claude terminal still owns
+    // SEEDED_CLAUDE_ID -- kill the earlier serial cases' live owners first,
+    // VERBATIM case-a's #540 reconciliation above (WS terminal.kill through
+    // the harness socket, EVERY running terminal: a pre-adoption codex
+    // terminal hides its resume id from the REST directory JSON, yet the D7
+    // guard's row arm still sees it as the live owner). Latent since #540 --
+    // only reachable once case-a passes again, which the cnwc managed-launch
+    // pin restores.
+    const liveOwners = async (): Promise<string[]> => {
+      const res = await page.request.get(`${info.baseUrl}/api/terminals`, {
+        headers: { 'x-auth-token': info.token },
+      })
+      expect(res.ok()).toBe(true)
+      const items: Array<{ terminalId: string; status: string }> = await res.json()
+      return items.filter((i) => i.status === 'running').map((i) => i.terminalId)
+    }
+    for (const terminalId of await liveOwners()) {
+      await page.evaluate((tid) => {
+        (window as any).__FRESHELL_TEST_HARNESS__?.sendWsMessage({ type: 'terminal.kill', terminalId: tid })
+      }, terminalId)
+    }
+    await expect(async () => {
+      expect(await liveOwners()).toHaveLength(0)
+    }).toPass({ timeout: 15_000 })
+
     // Open a claude resume pane so there is something to lose + recover.
     const res = await page.request.post(`${info.baseUrl}/api/tabs`, {
       headers: { 'x-auth-token': info.token, 'content-type': 'application/json' },
       data: { mode: 'claude', cwd: PROJECT_DIR, sessionRef: { provider: 'claude', sessionId: SEEDED_CLAUDE_ID } },
     })
-    expect(res.ok()).toBe(true)
+    expect(res.ok(), `POST /api/tabs claude resume: ${res.status()} ${await res.text()}`).toBe(true)
     const restTabId: string = (await res.json())?.data?.tabId
     expect(restTabId).toBeTruthy()
     await expect(page.locator(`[data-session-id="${SEEDED_CLAUDE_ID}"][data-provider="claude"]`))


### PR DESCRIPTION
## What

Fixes kata **cnwc** (`e2e: sidebar-registry-sync-rust cases a/b/c fail on codex app-server 500`).

`6a8733a3a` ("feat(codex): move Fresh Codex to app-server auto session recovery", 2026-07-30) flipped the `FRESHELL_CODEX_MANAGED_LAUNCH` default ON, but `test/e2e-browser/fixtures/fake-codex-terminal.mjs` only speaks the plain-CLI contract (prompt + Enter-gated rollout) and no e2e spec pinned the flag off. Every codex create in these specs has since failed with `creating Codex terminal: app-server error 500` — browser e2e is not merge-gated, so nobody noticed.

## Changes

- **`sidebar-registry-sync-rust.spec.ts` + `codex-terminal-restore-rust.spec.ts`**: pin `FRESHELL_CODEX_MANAGED_LAUNCH: '0'` in each spec's owned-server env — the same `set_var(FRESHELL_CODEX_MANAGED_LAUNCH, "0")` pin the flag-flip commit used in the Rust plain-CLI unit/integration suites. The production default stays ON; only these e2e servers opt out.
- **`sidebar-registry-sync-rust.spec.ts` case-d**: reconcile with #540's D7 live-session guard (`70c43c656`). Its claude resume create is 409-rejected while case-a's respawned claude terminal owns the session (`RESTORE_UNAVAILABLE: Session ... is still running on the server`). Case-d now kills the earlier serial cases' live terminals first (VERBATIM case-a's `188b151d6` idiom) and its POST assertion is fail-loud with status/body. This path was latent-red since #540 — only reachable once case-a passes again, which the pin restores.

## Verification

- Red reproduced first: case-c fails at the REST create (`res.ok()` false); serial semantics skipped b/a/d.
- Local green: `sidebar-registry-sync-rust` 4/4, `codex-terminal-restore-rust` green (`scripts/e2e-cloud.sh run --local --project=rust-chromium`).
- `npm run check` (typecheck + coordinated full suite, local backend) green on this branch.
- Cloud-backend e2e gate: waived by repo owner for this test-infra-only change (gcloud creds on this box were expired); `codex-terminal-restore-rust` sits in `CLOUD_SKIP_SPECS` either way and remains local-only coverage.

## Follow-up

Filed kata **ng6t**: teach the fake codex CLIs the app-server managed-launch protocol (so these pins can be dropped) and audit the other codex-fixture e2e specs (`codex-terminal-bounce-rust`, `compound-restart-rust`, etc.) for the same silent breakage.