### PR TITLE
fix(fresh-agent): portal the gear popover out of the clipped pane header

### DIFF
--- a/src/components/fresh-agent/FreshAgentSettingsButton.tsx
+++ b/src/components/fresh-agent/FreshAgentSettingsButton.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Settings } from 'lucide-react'
 import type { FreshAgentPaneContent } from '@/store/paneTypes'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
@@ -104,6 +105,7 @@ export function FreshAgentSettingsButton({
   const [open, setOpen] = useState(false)
   const buttonRef = useRef<HTMLButtonElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
+  const [popoverPos, setPopoverPos] = useState<{ top: number; right: number } | undefined>(undefined)
   const [probedCapabilities, setProbedCapabilities] = useState<FreshAgentModelCapabilitiesResponse | undefined>(undefined)
   const [modelDialogOpen, setModelDialogOpen] = useState(false)
 
@@ -232,16 +234,27 @@ export function FreshAgentSettingsButton({
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => {
           event.stopPropagation()
+          if (!open && buttonRef.current) {
+            // The popover is portaled to document.body to escape the pane
+            // header's overflow-hidden clip stripe; anchor it to the gear's
+            // viewport rect (same 4px gap the old in-header mt-1 produced).
+            const rect = buttonRef.current.getBoundingClientRect()
+            setPopoverPos({
+              top: rect.bottom + 4,
+              right: Math.max(8, window.innerWidth - rect.right),
+            })
+          }
           setOpen((value) => !value)
         }}
       >
         <Settings className="h-[18px] w-[18px] sm:h-3 sm:w-3" />
       </button>
 
-      {open ? (
+      {open && popoverPos ? createPortal(
         <div
           ref={popoverRef}
-          className="absolute right-0 top-full z-50 mt-1 w-[min(16rem,calc(100vw-1rem))] rounded-md border border-border bg-card p-3 text-xs text-foreground shadow-lg"
+          className="fixed z-50 w-[min(16rem,calc(100vw-1rem))] rounded-md border border-border bg-card p-3 text-xs text-foreground shadow-lg"
+          style={{ top: popoverPos.top, right: popoverPos.right }}
           role="dialog"
           aria-label="Agent settings"
         >
@@ -417,7 +430,8 @@ export function FreshAgentSettingsButton({
               </label>
             ) : null}
           </div>
-        </div>
+        </div>,
+        document.body,
       ) : null}
 
       {opensModelDialog ? (

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -50,13 +50,31 @@ async function openFreshAgentSettings(page: any, providerName: string) {
   }).last()
   await expect(pane).toBeVisible({ timeout: 10_000 })
 
-  const dialog = pane.getByRole('dialog', { name: 'Agent settings' })
+  // The popover is portaled to document.body (it must escape the pane header's
+  // overflow-hidden clip stripe), so scope the dialog to the page, not the pane.
+  const dialog = page.getByRole('dialog', { name: 'Agent settings' })
   if (!(await dialog.isVisible().catch(() => false))) {
     await pane.getByRole('button', { name: /^agent settings$/i }).click()
   }
 
   await expect(dialog).toBeVisible({ timeout: 10_000 })
+  await expectPopoverUnclipped(dialog)
   return dialog
+}
+
+/** A header-clipped popover keeps a non-zero bounding box (toBeVisible passes)
+ * but its interior receives no pointer hits below the header stripe. Pin the
+ * portal escape via a hit-test at the dialog's center. */
+async function expectPopoverUnclipped(dialog: any): Promise<void> {
+  const hitInside = await dialog.evaluate((el: HTMLElement) => {
+    const rect = el.getBoundingClientRect()
+    const probe = document.elementFromPoint(
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2,
+    )
+    return probe !== null && (probe === el || el.contains(probe))
+  })
+  expect(hitInside).toBe(true)
 }
 
 async function expectFreshAgentSubmitButtonContrasted(

--- a/test/e2e-browser/specs/freshopencode-model-picker.spec.ts
+++ b/test/e2e-browser/specs/freshopencode-model-picker.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 import { test, expect } from '../helpers/fixtures.js'
 import { openPanePicker } from '../helpers/pane-picker.js'
 import fsp from 'node:fs/promises'
@@ -213,13 +213,31 @@ async function openFreshAgentSettings(page: Page) {
   }).last()
   await expect(pane).toBeVisible({ timeout: 10_000 })
 
-  const dialog = pane.getByRole('dialog', { name: 'Agent settings' })
+  // The popover is portaled to document.body (it must escape the pane header's
+  // overflow-hidden clip stripe), so scope the dialog to the page, not the pane.
+  const dialog = page.getByRole('dialog', { name: 'Agent settings' })
   if (!(await dialog.isVisible().catch(() => false))) {
     await pane.getByRole('button', { name: /^agent settings$/i }).click()
   }
 
   await expect(dialog).toBeVisible({ timeout: 10_000 })
+  await expectPopoverUnclipped(dialog)
   return dialog
+}
+
+/** A header-clipped popover keeps a non-zero bounding box (toBeVisible passes)
+ * but its interior receives no pointer hits below the header stripe. Pin the
+ * portal escape via a hit-test at the dialog's center. */
+async function expectPopoverUnclipped(dialog: Locator): Promise<void> {
+  const hitInside = await dialog.evaluate((el) => {
+    const rect = el.getBoundingClientRect()
+    const probe = document.elementFromPoint(
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2,
+    )
+    return probe !== null && (probe === el || el.contains(probe))
+  })
+  expect(hitInside).toBe(true)
 }
 
 test.describe('Freshopencode model + thinking selector', () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentSettingsButton.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentSettingsButton.test.tsx
@@ -580,4 +580,28 @@ describe('FreshAgentSettingsButton', () => {
     // table's re-clamped 'high'
     expect(thinking).toHaveValue('beta')
   })
+
+  it('renders the open popover outside the overflow-hidden .pane-header stripe', () => {
+    const store = createStore()
+    seedPane(store, {
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      model: 'opencode-go/glm-5.2',
+    })
+
+    render(
+      <Provider store={store}>
+        <div className="pane-header">
+          <StoreBackedFreshAgentSettingsButton tabId="tab-1" paneId="pane-1" />
+        </div>
+      </Provider>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Agent settings' }))
+
+    const dialog = screen.getByRole('dialog', { name: 'Agent settings' })
+    // .pane-header is an overflow-hidden clip container (index.css); a popover
+    // rendered inline inside it is clipped to a sliver of the header stripe.
+    // The popover must escape the header (portal to document.body).
+    expect(dialog.closest('.pane-header')).toBeNull()
+  })
 })


### PR DESCRIPTION
## What

The fresh-agent gear icon's settings popover opened on click but was visually clipped to invisibility: `.pane-header` has `overflow: hidden` (added in PR #490's narrow-pane identity fix), and the popover was absolutely positioned inside that ~2rem-tall stripe. Affected every fresh-agent provider (freshclaude/kilroy/freshcodex/freshopencode); most visible on freshopencode, where the popover is the only entry to the model picker.

## Fix

Portal the popover to `document.body` (same pattern as the adjacent `FreshAgentModelDialog`), anchored to the gear's viewport rect with the previous 4px offset. Outside-click and Escape handling are unchanged (document-level listeners).

## Tests

- **Red → green unit**: the open popover must render outside the `.pane-header` clip stripe (jsdom `closest()`) — failed pre-fix, passes post-fix.
- **e2e**: both `openFreshAgentSettings` helpers re-scope the portaled dialog to the page and pin a center hit-test — a clipped popover keeps a non-zero bounding box, so `toBeVisible` alone could not catch this class of regression.
- Gates: typecheck, full-repo lint, local e2e 13/13 (both specs, fresh worktree build), cloud e2e 13/13 (configured backend), `npm run check` (coordinated full suite + electron leg) green on the branch.