### PR TITLE
fix(server): stop injecting heuristic --model on opencode pane spawns (kata 7mtf)

### DIFF
--- a/crates/freshell-platform/src/cli_launch.rs
+++ b/crates/freshell-platform/src/cli_launch.rs
@@ -313,27 +313,6 @@ pub fn get_opencode_env_overrides(
     overrides
 }
 
-/// `resolveOpencodeLaunchModel` (`server/opencode-launch.ts:20-29`).
-pub fn resolve_opencode_launch_model(
-    explicit_model: Option<&str>,
-    parent: &dyn Env,
-    command_env: &BTreeMap<String, String>,
-) -> Option<String> {
-    if let Some(m) = explicit_model.filter(|m| !m.is_empty()) {
-        return Some(m.to_string());
-    }
-    if resolve_google_api_key(parent, command_env).is_some() {
-        return Some("google/gemini-3-pro-preview".to_string());
-    }
-    if merged_env_truthy(parent, command_env, "OPENAI_API_KEY").is_some() {
-        return Some("openai/gpt-5".to_string());
-    }
-    if merged_env_truthy(parent, command_env, "ANTHROPIC_API_KEY").is_some() {
-        return Some("anthropic/claude-sonnet-4-5".to_string());
-    }
-    None
-}
-
 /// A minimal `new URL(wsUrl)` stand-in for the codex `--remote` validation
 /// (`terminal-registry.ts:297-305`): returns `(protocol_with_colon, hostname)`
 /// or `None` when the parse would throw. Faithful for every live input (the
@@ -526,12 +505,15 @@ pub fn resolve_coding_cli_command(
         settings_args.push("--port".to_string());
         settings_args.push(port.to_string());
     }
-    let effective_model: Option<String> = if inputs.mode == "opencode" {
-        if inputs.resume_session_id.filter(|s| !s.is_empty()).is_some() {
-            None
-        } else {
-            resolve_opencode_launch_model(inputs.model, env, &command_env)
-        }
+    // Opencode resume never carries `--model`; a FRESH opencode spawn carries
+    // `--model` only for an explicit model (kata 7mtf: the removed env-key
+    // heuristic guessed a model from provider API keys, which outranked
+    // opencode's own MRU model state — `opencode-launch.ts` likewise no
+    // longer resolves one).
+    let effective_model: Option<String> = if inputs.mode == "opencode"
+        && inputs.resume_session_id.filter(|s| !s.is_empty()).is_some()
+    {
+        None
     } else {
         inputs.model.filter(|m| !m.is_empty()).map(str::to_string)
     };

--- a/crates/freshell-platform/src/cli_launch_goldens.rs
+++ b/crates/freshell-platform/src/cli_launch_goldens.rs
@@ -429,10 +429,12 @@ fn g_o1_opencode_fresh_explicit_model() {
     assert_eq!(launch.env.len(), 1);
 }
 
-/// G-O2 — opencode, fresh, no model, `GEMINI_API_KEY=k1` (env-key default
-/// model + GOOGLE_GENERATIVE_AI_API_KEY override).
+/// G-O2 — opencode, fresh, no model, `GEMINI_API_KEY=k1` — no `--model` is
+/// injected (kata 7mtf: the retired env-key heuristic guessed
+/// `google/gemini-3-pro-preview`, which outranked opencode's own MRU model);
+/// the `GOOGLE_GENERATIVE_AI_API_KEY` env aliasing still applies.
 #[test]
-fn g_o2_opencode_gemini_key_default_model_and_env_override() {
+fn g_o2_opencode_gemini_key_no_model_with_env_override() {
     let expected_tui_config = golden_rebind_tui_config();
     let mut inputs = opencode_inputs();
     inputs.opencode_rebind_tui_config = Some(expected_tui_config.clone());
@@ -447,8 +449,6 @@ fn g_o2_opencode_gemini_key_default_model_and_env_override() {
             "127.0.0.1".to_string(),
             "--port".to_string(),
             "51234".to_string(),
-            "--model".to_string(),
-            "google/gemini-3-pro-preview".to_string(),
         ]
     );
     assert_eq!(
@@ -465,47 +465,135 @@ fn g_o2_opencode_gemini_key_default_model_and_env_override() {
     );
 }
 
-/// Opencode env-key default fallbacks: OPENAI, ANTHROPIC, none. Every case
-/// also carries the rebind injection (the env-only key never affects argv).
+/// Kata 7mtf regression — the retired env-key heuristic: a FRESH opencode
+/// spawn with NO explicit model must emit no `--model` flag no matter which
+/// provider API keys are present. The heuristic sniffed
+/// Google/OpenAI/Anthropic keys in the merged `{ parent ∪ commandEnv }` view
+/// and injected `google/gemini-3-pro-preview` / `openai/gpt-5` /
+/// `anthropic/claude-sonnet-4-5`, which outranked opencode's own MRU model
+/// state in every spawned pane. Sweep: no keys, each single key, all keys at
+/// once (parent env), and every key delivered through the manifest's
+/// `base_env` (the commandEnv half of the merge — the heuristic read the
+/// merged view, so both halves of the sweep are load-bearing).
 #[test]
-fn opencode_env_key_model_fallbacks() {
-    let expected_tui_config = golden_rebind_tui_config();
-    let inputs_with_rebind = || {
-        let mut inputs = opencode_inputs();
-        inputs.opencode_rebind_tui_config = Some(expected_tui_config.clone());
-        inputs
+fn opencode_fresh_without_explicit_model_never_injects_env_key_model() {
+    const PROVIDER_KEYS: [&str; 5] = [
+        "GOOGLE_GENERATIVE_AI_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+    ];
+    /// The exact bytes the heuristic used to inject — pinned so the test
+    /// names the regression, not just "some flag".
+    const GUESSED_MODELS: [&str; 3] = [
+        "google/gemini-3-pro-preview",
+        "openai/gpt-5",
+        "anthropic/claude-sonnet-4-5",
+    ];
+    let endpoint_only_argv = s(&["--hostname", "127.0.0.1", "--port", "51234"]);
+    let assert_no_model = |launch: &CliLaunch, case: &str| {
+        assert_eq!(
+            launch.args, endpoint_only_argv,
+            "{case}: fresh opencode without an explicit model must emit endpoint-only argv",
+        );
+        assert!(
+            !launch.args.iter().any(|a| a == "--model"),
+            "{case}: no --model flag allowed"
+        );
+        for guessed in GUESSED_MODELS {
+            assert!(
+                !launch.args.iter().any(|a| a == guessed),
+                "{case}: heuristic model {guessed} must not appear"
+            );
+        }
     };
-    let l1 = resolve_coding_cli_command(
-        &specs(),
-        &inputs_with_rebind(),
-        &env_of(&[("OPENAI_API_KEY", "x")]),
-    )
-    .unwrap()
-    .unwrap();
-    assert!(l1.args.contains(&"openai/gpt-5".to_string()));
-    assert_eq!(
-        l1.env.get("OPENCODE_TUI_CONFIG").map(String::as_str),
-        Some(expected_tui_config.as_str())
-    );
-    let l2 = resolve_coding_cli_command(
-        &specs(),
-        &inputs_with_rebind(),
-        &env_of(&[("ANTHROPIC_API_KEY", "x")]),
-    )
-    .unwrap()
-    .unwrap();
-    assert!(l2.args.contains(&"anthropic/claude-sonnet-4-5".to_string()));
-    assert_eq!(
-        l2.env.get("OPENCODE_TUI_CONFIG").map(String::as_str),
-        Some(expected_tui_config.as_str())
-    );
-    let l3 = resolve_coding_cli_command(&specs(), &inputs_with_rebind(), &env_of(&[]))
+
+    let mut cases: Vec<(String, Vec<(&str, &str)>)> =
+        vec![("no provider keys".to_string(), Vec::new())];
+    for key in PROVIDER_KEYS {
+        cases.push((format!("only {key}"), vec![(key, "k")]));
+    }
+    cases.push((
+        "every provider key".to_string(),
+        PROVIDER_KEYS.map(|k| (k, "k")).to_vec(),
+    ));
+    for (case, pairs) in cases {
+        let launch = resolve_coding_cli_command(&specs(), &opencode_inputs(), &env_of(&pairs))
+            .unwrap()
+            .unwrap();
+        assert_no_model(&launch, &case);
+    }
+
+    // commandEnv half of the merged view: provider keys arriving via
+    // `spec.base_env` must likewise not produce a model.
+    for key in PROVIDER_KEYS {
+        let mut all_specs = specs();
+        all_specs
+            .iter_mut()
+            .find(|sp| sp.name == "opencode")
+            .unwrap()
+            .base_env
+            .insert(key.to_string(), "k".to_string());
+        let launch = resolve_coding_cli_command(&all_specs, &opencode_inputs(), &env_of(&[]))
+            .unwrap()
+            .unwrap();
+        assert_no_model(&launch, &format!("{key} via base_env"));
+    }
+}
+
+/// Kata 7mtf passthrough pin: an EXPLICIT model still emits `--model` even
+/// with every provider key in the env, and a RESUME emits no `--model` even
+/// with an explicit model requested (both pre-existing rules; they must
+/// survive the heuristic's removal).
+#[test]
+fn opencode_model_flag_only_from_explicit_model_on_fresh_launch() {
+    let all_keys: Vec<(&str, &str)> = [
+        "GOOGLE_GENERATIVE_AI_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+    ]
+    .map(|k| (k, "k"))
+    .to_vec();
+
+    // Explicit model + armed env → exact `--model` pair.
+    let mut fresh = opencode_inputs();
+    fresh.model = Some("umans-ai-coding-plan/umans-kimi-k2.7");
+    let launch = resolve_coding_cli_command(&specs(), &fresh, &env_of(&all_keys))
         .unwrap()
         .unwrap();
-    assert_eq!(l3.args, s(&["--hostname", "127.0.0.1", "--port", "51234"]));
     assert_eq!(
-        l3.env.get("OPENCODE_TUI_CONFIG").map(String::as_str),
-        Some(expected_tui_config.as_str())
+        launch.args,
+        s(&[
+            "--hostname",
+            "127.0.0.1",
+            "--port",
+            "51234",
+            "--model",
+            "umans-ai-coding-plan/umans-kimi-k2.7"
+        ]),
+        "explicit model must pass through unchanged with an armed env"
+    );
+
+    // Resume + armed env (no explicit model) → no model args at all.
+    let mut resume = opencode_inputs();
+    resume.resume_session_id = Some("ses_regress");
+    let launch = resolve_coding_cli_command(&specs(), &resume, &env_of(&all_keys))
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        launch.args,
+        s(&[
+            "--hostname",
+            "127.0.0.1",
+            "--port",
+            "51234",
+            "--session",
+            "ses_regress"
+        ]),
+        "resume must stay model-free with an armed env"
     );
 }
 

--- a/crates/freshell-platform/src/spawn.rs
+++ b/crates/freshell-platform/src/spawn.rs
@@ -69,10 +69,9 @@ pub enum WindowsExe {
 // ===========================================================================
 pub use crate::cli_launch::{
     claude_settings_json, get_opencode_env_overrides, resolve_cli_launch,
-    resolve_coding_cli_command, resolve_opencode_launch_model, CliCommandSpec, CliLaunch,
-    CliLaunchError, CliLaunchInputs, LaunchIntent, McpInjection, ProviderTarget,
-    CLAUDE_BELL_COMMAND_UNIX, CLAUDE_BELL_COMMAND_WINDOWS, CODEX_MANAGED_REMOTE_CONFIG_ARGS,
-    CODEX_TUI_NOTIFICATION_ARGS,
+    resolve_coding_cli_command, CliCommandSpec, CliLaunch, CliLaunchError, CliLaunchInputs,
+    LaunchIntent, McpInjection, ProviderTarget, CLAUDE_BELL_COMMAND_UNIX,
+    CLAUDE_BELL_COMMAND_WINDOWS, CODEX_MANAGED_REMOTE_CONFIG_ARGS, CODEX_TUI_NOTIFICATION_ARGS,
 };
 
 /// The resolved shell spawn specification (shell mode).

--- a/port/machine/specs/cli-argv-fidelity.md
+++ b/port/machine/specs/cli-argv-fidelity.md
@@ -301,11 +301,11 @@ Order: `[providerArgs..., settingsArgs..., resumeArgs...]`.
 4. **Model (`settingsArgs`)** — `['--model', <model>]` (`extensions/opencode/freshell.json:11`)
    with opencode-specific effective-model logic (`terminal-registry.ts:340-347`):
    - resuming (`resumeSessionId` truthy) → **no model arg ever**;
-   - fresh: `providerSettings.model` if set, else
-     `resolveOpencodeLaunchModel` (`opencode-launch.ts:20-29`) picks by env:
-     Google key → `'google/gemini-3-pro-preview'`; else `OPENAI_API_KEY` →
-     `'openai/gpt-5'`; else `ANTHROPIC_API_KEY` → `'anthropic/claude-sonnet-4-5'`;
-     else no arg.
+   - fresh: `providerSettings.model` if set, else **no arg**. Kata 7mtf
+     removed the old env-key heuristic (`resolveOpencodeLaunchModel`, which
+     guessed Google/OpenAI/Anthropic models from API keys); the injected flag
+     outranked opencode's own MRU model state, so a fresh spawn now leaves
+     model selection to opencode.
 5. **Sandbox / permission mode** — no `sandboxArgs`/`permissionModeArgs` in the
    opencode manifest → no args regardless of settings.
 6. **Resume (`resumeArgs`)** — iff `resumeSessionId`:
@@ -316,9 +316,9 @@ Order: `[providerArgs..., settingsArgs..., resumeArgs...]`.
 
 **Full opencode argv (unix, fresh, GEMINI_API_KEY set, no explicit model):**
 ```
-[ '--hostname', '127.0.0.1', '--port', '<port>',
-  '--model', 'google/gemini-3-pro-preview' ]
+[ '--hostname', '127.0.0.1', '--port', '<port>' ]
 ```
+(post-kata-7mtf: no heuristic `--model`; opencode's own MRU/default applies)
 plus env `GOOGLE_GENERATIVE_AI_API_KEY=<key>`, plus the `<cwd>/.opencode/opencode.json`
 side-effect. Note argv contains **no MCP flags** for opencode.
 
@@ -472,9 +472,11 @@ Extend the existing pure builders; keep IO (file writes, port allocation) out.
    - claude: `["--settings", <compact JSON per §2.1(1)>]` (`tr:216-238`) —
      build with `serde_json` compact serialization; the bell strings are `const`s
      with unit tests pinning the exact bytes.
-   Opencode model default: port `resolveOpencodeLaunchModel` + `getOpencodeEnvOverrides`
-   (`ol:1-29`) as pure functions over `&dyn Env` (the env source is
-   `parent ∪ commandEnv`, `tr:293,343`).
+   Opencode env aliasing: port `getOpencodeEnvOverrides` (`ol:1-19`) as a pure
+   function over `&dyn Env` (the env source is `parent ∪ commandEnv`,
+   `tr:293,343`). The `resolveOpencodeLaunchModel` env-key model heuristic was
+   removed by kata 7mtf — a fresh opencode spawn emits `--model` only for an
+   explicit `providerSettings.model`; a resume never does (§2.3 item 4).
 4. **`build_cli_spawn_spec` / `build_windows_cli_spawn_spec`
    (`spawn.rs:505-527,550-650`)**: no ordering changes needed — they already
    append `launch.args` verbatim and layer `launch.env`; they inherit fidelity

--- a/server/opencode-launch.ts
+++ b/server/opencode-launch.ts
@@ -1,8 +1,11 @@
 type EnvSource = Record<string, string | undefined>
 
-const OPENCODE_DEFAULT_GOOGLE_MODEL = 'google/gemini-3-pro-preview'
-const OPENCODE_DEFAULT_OPENAI_MODEL = 'openai/gpt-5'
-const OPENCODE_DEFAULT_ANTHROPIC_MODEL = 'anthropic/claude-sonnet-4-5'
+// Kata 7mtf: the env-key model heuristic (resolveOpencodeLaunchModel →
+// google/gemini-3-pro-preview / openai/gpt-5 / anthropic/claude-sonnet-4-5)
+// was removed: the injected --model outranked opencode's own MRU model state,
+// so every spawned pane ignored the user's remembered model. A fresh spawn
+// with no explicit model now emits no --model flag at all (see
+// resolveCodingCliCommand in terminal-registry.ts).
 
 function resolveGoogleApiKey(env: EnvSource): string | undefined {
   return env.GOOGLE_GENERATIVE_AI_API_KEY || env.GEMINI_API_KEY || env.GOOGLE_API_KEY
@@ -15,15 +18,4 @@ export function getOpencodeEnvOverrides(env: EnvSource): Record<string, string> 
     overrides.GOOGLE_GENERATIVE_AI_API_KEY = googleApiKey
   }
   return overrides
-}
-
-export function resolveOpencodeLaunchModel(
-  explicitModel: string | undefined,
-  env: EnvSource,
-): string | undefined {
-  if (explicitModel) return explicitModel
-  if (resolveGoogleApiKey(env)) return OPENCODE_DEFAULT_GOOGLE_MODEL
-  if (env.OPENAI_API_KEY) return OPENCODE_DEFAULT_OPENAI_MODEL
-  if (env.ANTHROPIC_API_KEY) return OPENCODE_DEFAULT_ANTHROPIC_MODEL
-  return undefined
 }

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -39,7 +39,7 @@ import type {
   TerminalSessionUnboundEvent,
   TerminalSubagentClassifiedEvent,
 } from './terminal-stream/registry-events.js'
-import { getOpencodeEnvOverrides, resolveOpencodeLaunchModel } from './opencode-launch.js'
+import { getOpencodeEnvOverrides } from './opencode-launch.js'
 import { generateMcpInjection, cleanupMcpConfig } from './mcp/config-writer.js'
 import { CODEX_MANAGED_REMOTE_CONFIG_ARGS } from './coding-cli/codex-managed-config.js'
 // Stage 1a (plan §6, panel m8): a codex resume pty is a process-GROUP registration (pgid == pid),
@@ -352,10 +352,11 @@ function resolveCodingCliCommand(
       String(endpoint.port),
     )
   }
-  const effectiveModel = mode === 'opencode'
-    ? (resumeSessionId
-        ? undefined
-        : resolveOpencodeLaunchModel(providerSettings?.model, { ...process.env, ...commandEnv }))
+  // Opencode resume never carries --model; a fresh opencode spawn carries
+  // --model only for an explicit model (kata 7mtf: the env-key heuristic was
+  // removed — it outranked opencode's own MRU model state in every pane).
+  const effectiveModel = mode === 'opencode' && resumeSessionId
+    ? undefined
     : providerSettings?.model
   if (effectiveModel && spec.modelArgs) {
     settingsArgs.push(...spec.modelArgs(effectiveModel))

--- a/test/unit/server/opencode-launch.test.ts
+++ b/test/unit/server/opencode-launch.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { getOpencodeEnvOverrides, resolveOpencodeLaunchModel } from '../../../server/opencode-launch'
+import { getOpencodeEnvOverrides } from '../../../server/opencode-launch'
 
+// Kata 7mtf: the env-key model heuristic (resolveOpencodeLaunchModel) was
+// removed — a fresh opencode pane with no explicit model gets NO --model flag
+// so opencode's own MRU/default model wins. Regression coverage for that
+// behavior lives at the argv level in test/unit/server/terminal-registry.test.ts
+// ('opencode launches never inject a heuristic model').
 describe('opencode launch helpers', () => {
   it('maps GEMINI_API_KEY to GOOGLE_GENERATIVE_AI_API_KEY', () => {
     expect(getOpencodeEnvOverrides({
@@ -15,30 +20,5 @@ describe('opencode launch helpers', () => {
       GOOGLE_GENERATIVE_AI_API_KEY: 'google-key',
       GEMINI_API_KEY: 'gemini-key',
     })).toEqual({})
-  })
-
-  it('defaults to the google model when Google credentials are available through GEMINI_API_KEY', () => {
-    expect(resolveOpencodeLaunchModel(undefined, {
-      GEMINI_API_KEY: 'gemini-key',
-    })).toBe('google/gemini-3-pro-preview')
-  })
-
-  it('falls back to the OpenAI model when Google credentials are missing', () => {
-    expect(resolveOpencodeLaunchModel(undefined, {
-      OPENAI_API_KEY: 'openai-key',
-    })).toBe('openai/gpt-5')
-  })
-
-  it('falls back to the Anthropic model when only Anthropic credentials are available', () => {
-    expect(resolveOpencodeLaunchModel(undefined, {
-      ANTHROPIC_API_KEY: 'anthropic-key',
-    })).toBe('anthropic/claude-sonnet-4-5')
-  })
-
-  it('preserves an explicitly configured model', () => {
-    expect(resolveOpencodeLaunchModel('openai/gpt-5-mini', {
-      GEMINI_API_KEY: 'gemini-key',
-      OPENAI_API_KEY: 'openai-key',
-    })).toBe('openai/gpt-5-mini')
   })
 })

--- a/test/unit/server/terminal-registry.test.ts
+++ b/test/unit/server/terminal-registry.test.ts
@@ -1128,7 +1128,7 @@ describe('buildSpawnSpec Unix paths', () => {
       expect(spec.args).not.toContain('google/gemini-3-pro-preview')
     })
 
-    it('defaults OpenCode to a usable Google model and alias env when only GEMINI_API_KEY is set', () => {
+    it('keeps the GOOGLE_GENERATIVE_AI_API_KEY alias but injects no model when only GEMINI_API_KEY is set (kata 7mtf)', () => {
       delete process.env.OPENCODE_CMD
       delete process.env.GOOGLE_GENERATIVE_AI_API_KEY
       delete process.env.GOOGLE_API_KEY
@@ -1140,9 +1140,94 @@ describe('buildSpawnSpec Unix paths', () => {
         opencodeServer: TEST_OPENCODE_SERVER,
       })
 
-      expect(spec.args).toContain('--model')
-      expect(spec.args).toContain('google/gemini-3-pro-preview')
+      expect(spec.args).not.toContain('--model')
+      expect(spec.args).not.toContain('google/gemini-3-pro-preview')
       expect(spec.env.GOOGLE_GENERATIVE_AI_API_KEY).toBe('gemini-key')
+    })
+
+    // Kata 7mtf: the retired resolveOpencodeLaunchModel heuristic sniffed
+    // provider API keys in { ...process.env, ...commandEnv } and injected a
+    // guessed --model (google/gemini-3-pro-preview / openai/gpt-5 /
+    // anthropic/claude-sonnet-4-5) into EVERY fresh opencode pane, which
+    // outranked opencode's own MRU model state. A fresh spawn without an
+    // explicit model must now emit no --model flag no matter which provider
+    // keys are armed; opencode decides the model itself.
+    describe('opencode launches never inject a heuristic model (kata 7mtf)', () => {
+      const ALL_PROVIDER_KEYS = [
+        'GOOGLE_GENERATIVE_AI_API_KEY',
+        'GEMINI_API_KEY',
+        'GOOGLE_API_KEY',
+        'OPENAI_API_KEY',
+        'ANTHROPIC_API_KEY',
+      ]
+      const GUESSED_MODELS = [
+        'google/gemini-3-pro-preview',
+        'openai/gpt-5',
+        'anthropic/claude-sonnet-4-5',
+      ]
+
+      beforeEach(() => {
+        delete process.env.OPENCODE_CMD
+        // Hermetic: process.env is restored from the REAL shell env after
+        // each test, and this host arms provider keys — clear them all.
+        for (const key of ALL_PROVIDER_KEYS) delete process.env[key]
+      })
+
+      for (const onlyKey of [...ALL_PROVIDER_KEYS, undefined]) {
+        it(`fresh spawn with ${onlyKey ? `only ${onlyKey}` : 'no provider keys'} emits no --model`, () => {
+          if (onlyKey) process.env[onlyKey] = 'key'
+
+          const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, {
+            opencodeServer: TEST_OPENCODE_SERVER,
+          })
+
+          expect(spec.args).not.toContain('--model')
+          for (const guessed of GUESSED_MODELS) expect(spec.args).not.toContain(guessed)
+          // The endpoint pair is always present — the spawn still resolves.
+          expect(spec.args).toContain('--hostname')
+          expect(spec.args).toContain('127.0.0.1')
+          expect(spec.args).toContain('--port')
+        })
+      }
+
+      it('fresh spawn with every provider key armed emits no --model', () => {
+        for (const key of ALL_PROVIDER_KEYS) process.env[key] = 'key'
+
+        const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, {
+          opencodeServer: TEST_OPENCODE_SERVER,
+        })
+
+        expect(spec.args).not.toContain('--model')
+        for (const guessed of GUESSED_MODELS) expect(spec.args).not.toContain(guessed)
+      })
+
+      it('fresh spawn with an explicit model passes it through even with every provider key armed', () => {
+        for (const key of ALL_PROVIDER_KEYS) process.env[key] = 'key'
+
+        const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', undefined, {
+          model: 'umans-ai-coding-plan/umans-kimi-k2.7',
+          opencodeServer: TEST_OPENCODE_SERVER,
+        })
+
+        expect(spec.args).toContain('--model')
+        expect(spec.args).toContain('umans-ai-coding-plan/umans-kimi-k2.7')
+        for (const guessed of GUESSED_MODELS) expect(spec.args).not.toContain(guessed)
+      })
+
+      it('resume spawn emits no --model even with an explicit model and every provider key armed', () => {
+        for (const key of ALL_PROVIDER_KEYS) process.env[key] = 'key'
+
+        const spec = buildSpawnSpec('opencode', '/Users/john/project', 'system', 'ses_existing', {
+          model: 'openai/gpt-5-mini',
+          opencodeServer: TEST_OPENCODE_SERVER,
+        })
+
+        expect(spec.args).toContain('--session')
+        expect(spec.args).toContain('ses_existing')
+        expect(spec.args).not.toContain('--model')
+        expect(spec.args).not.toContain('openai/gpt-5-mini')
+        for (const guessed of GUESSED_MODELS) expect(spec.args).not.toContain(guessed)
+      })
     })
 
     it('does not set OPENCODE_PERMISSION for OpenCode when permission mode is provided', () => {


### PR DESCRIPTION
## Problem

Every opencode pane spawned without an explicit `model=` still got a `--model` flag injected, guessed from provider API keys in the merged environment (Google key -> `google/gemini-3-pro-preview`, else `OPENAI_API_KEY` -> `openai/gpt-5`, else `ANTHROPIC_API_KEY` -> `anthropic/claude-sonnet-4-5`). Opencode resolves its startup model as `--model` flag > opencode.json > MRU state > provider default, so the injected flag permanently outranked opencode's remembered model — `--model openai/gpt-5` was observed on 6 concurrent live panes whose MRU pointed elsewhere.

## Change

- Removed the env-key heuristic from the Rust resolver (`crates/freshell-platform/src/cli_launch.rs`, re-export dropped from `spawn.rs`) and from the TS spec source (`server/opencode-launch.ts`, `resolveCodingCliCommand` in `server/terminal-registry.ts`).
- Fresh opencode spawn: `--model` only for an explicit per-pane model. Resume: never `--model` (unchanged).
- `getOpencodeEnvOverrides` (`GOOGLE_GENERATIVE_AI_API_KEY` aliasing) is untouched — it is unrelated to model selection.
- Spec doc `port/machine/specs/cli-argv-fidelity.md` updated (normative model rule, full-argv example, port note).

## Broad regression coverage (red-green verified: 2 Rust + 7 vitest failures pre-fix)

- **Rust goldens** (`cli_launch_goldens.rs`): `opencode_fresh_without_explicit_model_never_injects_env_key_model` sweeps no keys / each of the 5 provider keys alone / all at once / keys via manifest `base_env` (both halves of the merged env view), asserting exact endpoint-only argv and absence of all three heuristic model strings; `opencode_model_flag_only_from_explicit_model_on_fresh_launch` pins explicit-model passthrough and resume suppression under a fully armed env; G-O2 rewritten to endpoint-only argv with the alias env intact.
- **TS argv level** (`test/unit/server/terminal-registry.test.ts`): matching kata-7mtf block through `buildSpawnSpec` (the exact child argv), hermetic against real-shell provider keys; `opencode-launch.test.ts` now covers only the env aliasing.

## Verification

- Green-base check on `origin/main` (af93597) ran before branching: full suite success (cloud).
- `cargo test -p freshell-platform`: 218/218. `cargo test --workspace`: all green. `cargo fmt`/`clippy` clean. `tsc` typecheck (client+server) clean.
- Coordinated full suite recorded a **full-suite SUCCESS reusable baseline for this exact commit** (`c1c259c4b`, clean tree).
- Two earlier cloud runs showed a single unrelated flake: `logger.separation`'s 30s file-content gate under shard contention (passes isolated on the same image and locally; evidence logged on kata ep0f).

Closes kata freshell#7mtf.