### PR TITLE
feat(scripts): base-gate.sh — broad gates from a clean origin/main scratch worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Freshell is a self-hosted, browser-accessible terminal multiplexer and session o
 
 ## Test Coordination
 - Broad repo-supported test runs wait for the shared coordinator gate; if another agent holds it, wait rather than kill a foreign holder.
+- Pre-worktree green-base checks (and any broad gate intended to validate `origin/main` itself, as opposed to a branch under test) go through `scripts/base-gate.sh` (e.g. `scripts/base-gate.sh test`), which runs the command from a clean scratch worktree at `origin/main`. The main checkout accumulates untracked litter; the cloud runners treat that as a non-addressable `-dirty` image and pay a ~13 min cold rebuild every time, whereas a clean worktree uses the content-addressed commit tag — built at most once per commit and shared by every later run.
 - Set `FRESHELL_TEST_SUMMARY` when you want holder/status output to show a human-meaningful reason for a broad run.
 - Use `npm run test:status` to inspect the current holder, recent results, and any advisory reusable baseline.
 - Use `npm run test:vitest -- ...` for a repo-owned direct Vitest path. Raw `npx vitest` is not a coordinated workflow.

--- a/scripts/base-gate.sh
+++ b/scripts/base-gate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Run a broad gate (default: npm test; or any npm script, e.g.
+# `scripts/base-gate.sh check`) from a clean scratch worktree at origin/main.
+#
+# Why: the cloud vitest/e2e runners treat ANY dirty state in the checkout they
+# run from — including untracked files — as non-addressable, forcing a
+# "<sha>-dirty" image that ALWAYS rebuilds from a cold build (~13 min) and is
+# never reusable. The main checkout accumulates untracked litter (plan docs,
+# agent artifacts), so base gates run there pay that rebuild every time. A
+# fresh worktree at origin/main is clean by construction, so the run uses the
+# content-addressed commit tag: built at most once per commit and shared by
+# every later run on any machine.
+#
+# The coordinator gate is repo-global (keyed off the common git dir), so gate
+# queuing, holder publication, and result recording behave identically from
+# the scratch worktree.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+git -C "$root" fetch --quiet origin main
+wt="$root/.worktrees/.base-gate-$$"
+trap 'git -C "$root" worktree remove --force "$wt" >/dev/null 2>&1 || true' EXIT
+git -C "$root" worktree add --quiet --detach "$wt" origin/main
+cd "$wt"
+npm ci --no-audit --no-fund
+npm run "${@:-test}"


### PR DESCRIPTION
## What

Adds `scripts/base-gate.sh`: runs a broad gate (default `npm test`, or `scripts/base-gate.sh check`) from a clean scratch worktree at `origin/main`, plus an AGENTS.md policy note pointing pre-worktree green-base checks at it.

## Why

The cloud vitest/e2e runners treat any dirty checkout — **untracked files included**, because the image bakes the working tree — as non-addressable, forcing a `<sha>-dirty` tag that **always cold-rebuilds (~13 min)** and is never reusable. The main checkout accumulates untracked litter (plan docs, agent artifacts), so base gates run there paid that rebuild every time — twice in one hour on 2026-08-21 (two agents gating identical code from the same dirty main checkout; the second also sat ~5 min queued behind the first).

A fresh worktree at `origin/main` is clean by construction → the content-addressed commit tag → build at most once per commit, shared by every later run on any machine. The coordinator gate is repo-global off the common git dir, so queuing/holder behavior is identical from the scratch worktree (verified in practice during the #669 run).

## Validation

- `bash -n` + `shellcheck`: clean
- Dogfooded: `scripts/base-gate.sh typecheck` — 1m12s including `npm ci`, both tsconfigs green, scratch-worktree trap cleanup verified
- Base-green note: this PR changes no product code (one shell script + one AGENTS.md paragraph); the full coordinated suite went green today on the tree that is now `origin/main` (branch check run for #669, whose tree is identical to squash commit `f0f569e1f` — verified via `git diff`).