### PR TITLE
fix(e2e): rust e2e suites honor prebuilt binary + dual-role codex fakes

### DIFF
--- a/test/e2e-browser/fixtures/codex-dual-role.ts
+++ b/test/e2e-browser/fixtures/codex-dual-role.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+export const FAKE_CODEX_APP_SERVER = path.resolve(
+  __dirname,
+  '../../fixtures/coding-cli/codex-app-server/fake-app-server.mjs',
+)
+
+/**
+ * Install a DUAL-ROLE `codex` binary into `binDir`: argv containing
+ * `app-server` routes to the shared fake app-server; everything else execs
+ * the given terminal fake (`terminalSource`, an .mjs path). Returns the shim
+ * path (to be set as CODEX_CMD).
+ *
+ * Required by the Rust server's codex terminal lane v2: the lane boots a
+ * `codex app-server` sidecar FIRST, spawned from the SAME CODEX_CMD. A
+ * terminal-only fake exits 0 instantly on that spawn (stdin is /dev/null),
+ * so every codex pane create fails PTY_SPAWN_FAILED ("codex app-server
+ * exited before listening: exit status: 0"). Any rust e2e spec that creates
+ * a codex TERMINAL pane must use this helper (or an equivalent shim — see
+ * restore-contract-wall-rust's installDualRoleCodex, which additionally
+ * overrides CODEX_HOME for rollout writes).
+ */
+export async function installDualRoleCodexCli(
+  binDir: string,
+  terminalSource: string,
+  terminalEnv?: Record<string, string>,
+): Promise<string> {
+  await fs.mkdir(binDir, { recursive: true })
+  const target = path.join(binDir, 'codex')
+  const terminalEnvExtra = JSON.stringify(terminalEnv ?? {})
+  const script = `#!/usr/bin/env node
+const { spawnSync } = require('node:child_process')
+const argv = process.argv.slice(2)
+if (argv.includes('app-server')) {
+  const result = spawnSync(process.execPath, [${JSON.stringify(FAKE_CODEX_APP_SERVER)}, ...argv], { stdio: 'inherit', env: process.env })
+  process.exit(result.status ?? 1)
+}
+const result = spawnSync(process.execPath, [${JSON.stringify(terminalSource)}, ...argv], { stdio: 'inherit', env: { ...process.env, ...${terminalEnvExtra} } })
+process.exit(result.status ?? 1)
+`
+  await fs.writeFile(target, script, 'utf8')
+  await fs.chmod(target, 0o755)
+  return target
+}

--- a/test/e2e-browser/fixtures/fake-codex-terminal.mjs
+++ b/test/e2e-browser/fixtures/fake-codex-terminal.mjs
@@ -18,6 +18,19 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
+import process from 'node:process'
+
+/**
+ * Managed-topology handshake — the Rust server runs codex terminals through a
+ * `codex app-server` sidecar proxy (argv carries `--remote ws://…`). The disk
+ * locator is deliberately SUPPRESSED for managed panes (D-03): identity binds
+ * from the proxy's candidate stream, i.e. from a `thread/started`
+ * notification riding this terminal's own proxied connection. A real codex
+ * TUI performs `initialize` → `thread/start` on that connection. So on the
+ * first Enter this fixture does the same handshake (best-effort, async, only
+ * when `--remote` is present), then writes the rollout with the APP-SERVER'S
+ * thread id, so the proxy-bound identity and the on-disk artifact agree.
+ */
 
 const argv = process.argv.slice(2)
 
@@ -59,6 +72,46 @@ if (resumeIndex !== -1) {
   const sessionId = argv[resumeIndex + 1] ?? ''
   process.stdout.write(`codex: resumed session ${sessionId}\r\n`)
 } else {
+  // Best-effort managed-topology handshake; resolves the app-server's thread
+  // id (or null when absent/unreachable). Never delays rollout materialization
+  // by more than a bounded budget: the pane contract is Enter-anchored.
+  async function startManagedThread() {
+    const remoteIdx = argv.indexOf('--remote')
+    if (remoteIdx === -1 || !argv[remoteIdx + 1]) return null
+    try {
+      const { WebSocket } = await import('ws')
+      const ws = new WebSocket(argv[remoteIdx + 1])
+      const rpc = (method, params) => new Promise((resolve, reject) => {
+        const id = `${method}-${Date.now()}`
+        const to = setTimeout(() => reject(new Error('rpc timeout')), 3000)
+        const onMsg = (data) => {
+          try {
+            const m = JSON.parse(data.toString())
+            if (m.id === id) {
+              clearTimeout(to)
+              ws.off('message', onMsg)
+              m.error ? reject(new Error(m.error.message || 'rpc error')) : resolve(m.result)
+            }
+          } catch { /* ignore stray frames */ }
+        }
+        ws.on('message', onMsg)
+        ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
+      })
+      await new Promise((resolve, reject) => {
+        ws.on('open', resolve)
+        ws.on('error', reject)
+        setTimeout(() => reject(new Error('connect timeout')), 3000)
+      })
+      await rpc('initialize', { clientInfo: { name: 'fake-codex-terminal', version: '1.0.0' } })
+      ws.send(JSON.stringify({ jsonrpc: '2.0', method: 'initialized' }))
+      const result = await rpc('thread/start', { cwd: process.cwd() })
+      ws.close()
+      return result?.thread?.id ?? null
+    } catch {
+      return null
+    }
+  }
+
   process.stdout.write('codex> \r\n')
   let wrote = false
   process.stdin.on('data', (chunk) => {
@@ -68,22 +121,25 @@ if (resumeIndex !== -1) {
     // create the rollout — only the first Enter does.
     if (!s.includes('\r') && !s.includes('\n')) return
     wrote = true
-    const threadId = crypto.randomUUID()
-    const finish = () => {
+    const finish = (maybeThreadId) => {
+      const threadId = maybeThreadId ?? crypto.randomUUID()
       writeRollout(threadId)
       process.stdout.write(`codex: session ${threadId} started\r\n`)
     }
     const gate = process.env.FAKE_CODEX_TERMINAL_ROLLOUT_GATE_PATH
-    if (gate) {
-      const poll = setInterval(() => {
-        if (fs.existsSync(gate)) {
-          clearInterval(poll)
-          finish()
-        }
-      }, 50)
-    } else {
-      finish()
-    }
+    startManagedThread().then((managedThreadId) => {
+      const finishWith = () => finish(managedThreadId)
+      if (gate) {
+        const poll = setInterval(() => {
+          if (fs.existsSync(gate)) {
+            clearInterval(poll)
+            finishWith()
+          }
+        }, 50)
+      } else {
+        finishWith()
+      }
+    })
   })
 }
 process.stdin.resume()

--- a/test/e2e-browser/helpers/codex-dual-role.test.ts
+++ b/test/e2e-browser/helpers/codex-dual-role.test.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { spawn, type ChildProcess } from 'node:child_process'
+import { describe, it, expect } from 'vitest'
+import { installDualRoleCodexCli } from '../fixtures/codex-dual-role'
+
+/**
+ * Behavioral pinning for the dual-role codex shim installed by e2e specs.
+ *
+ * The Rust server's codex terminal lane spawns TWO processes from the same
+ * CODEX_CMD: the TUI (plain argv) and a `codex app-server` sidecar FIRST.
+ * A terminal-only fake at CODEX_CMD exits 0 instantly on the sidecar spawn
+ * (stdin is /dev/null), and every codex pane create dies PTY_SPAWN_FAILED.
+ * The dual-role shim must therefore:
+ *   (a) run the given terminal fake for plain argv (stdi. in/out passthrough), and
+ *   (b) route argv containing `app-server` to the shared fake app-server,
+ *       which STAYS ALIVE listening (the sidecar contract).
+ */
+
+const TERMINAL_MARKER = 'DUAL_ROLE_TERMINAL_RAN'
+
+async function writeTerminalFake(binDir: string): Promise<string> {
+  const terminalSrc = path.join(binDir, 'terminal-src.mjs')
+  await fs.writeFile(terminalSrc, `console.log(${JSON.stringify(TERMINAL_MARKER)})\nprocess.exit(0)\n`, 'utf8')
+  return terminalSrc
+}
+
+function spawnShim(binPath: string, args: string[]): { child: ChildProcess; stdout: string[] } {
+  const stdout: string[] = []
+  const child = spawn(binPath, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+  child.stdout?.on('data', (d) => stdout.push(String(d)))
+  return { child, stdout }
+}
+
+async function waitExit(child: ChildProcess, timeoutMs: number): Promise<number | null> {
+  return await new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), timeoutMs)
+    child.on('exit', (code) => {
+      clearTimeout(timer)
+      resolve(code)
+    })
+  })
+}
+
+describe('codex-dual-role shim', () => {
+  it('runs the terminal fake for plain argv', async () => {
+    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dual-role-'))
+    const terminalSrc = await writeTerminalFake(binDir)
+    const bin = await installDualRoleCodexCli(binDir, terminalSrc)
+    expect(bin).toBe(path.join(binDir, 'codex'))
+
+    const { child, stdout } = spawnShim(bin, [])
+    const code = await waitExit(child, 10_000)
+    expect(code).not.toBeNull()
+    expect(code).toBe(0)
+    await waitUntil(2_000, () => stdout.join('').includes(TERMINAL_MARKER))
+  }, 30_000)
+
+  it('routes `app-server` argv to the fake app-server, which keeps listening (the sidecar contract)', async () => {
+    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dual-role-'))
+    const terminalSrc = await writeTerminalFake(binDir)
+    const bin = await installDualRoleCodexCli(binDir, terminalSrc)
+
+    const { child, stdout } = spawnShim(bin, ['-c', 'features.apps=false', 'app-server', '--listen', 'ws://127.0.0.1:0'])
+    // A listening sidecar survives its whole lifetime — it does NOT exit 0
+    // instantly the way a terminal-only fake does when stdin is /dev/null.
+    const earlyExit = await waitExit(child, 3_000)
+    expect(earlyExit).toBeNull()
+    // And it never confused itself for the terminal fake.
+    await new Promise((r) => setTimeout(r, 100))
+    expect(stdout.join('')).not.toContain(TERMINAL_MARKER)
+    child.kill('SIGTERM')
+    await waitExit(child, 10_000)
+  }, 30_000)
+
+  it('passes terminalEnv through to the terminal role only', async () => {
+    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dual-role-'))
+    const terminalSrc = path.join(binDir, 'terminal-src.mjs')
+    await fs.writeFile(
+      terminalSrc,
+      "console.log('env=' + process.env.DUAL_ROLE_TEST_ENV)\nprocess.exit(0)\n",
+      'utf8',
+    )
+    const bin = await installDualRoleCodexCli(binDir, terminalSrc, {
+      DUAL_ROLE_TEST_ENV: 'env-carry-1',
+    })
+    const { child, stdout } = spawnShim(bin, [])
+    const code = await waitExit(child, 10_000)
+    expect(code).toBe(0)
+    await waitUntil(2_000, () => stdout.join('').includes('env=env-carry-1'))
+  }, 30_000)
+
+  it('a terminal-only fake at CODEX_CMD exits 0 instantly under sidecar argv (the pathology this shim fixes)', async () => {
+    // Contrast test: documents the failure this helper prevents. If the
+    // shared app-server fake stops working, the previous test fails; if the
+    // dispatch breaks toward the terminal role, this one catches regression
+    // in the FIXture's transitive meaning.
+    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dual-role-'))
+    const terminalSrc = await writeTerminalFake(binDir)
+    const bin = await installDualRoleCodexCli(binDir, terminalSrc)
+
+    const { child, stdout } = spawnShim(bin, ['-c', 'features.apps=false', 'app-server', '--listen', 'ws://127.0.0.1:0'])
+    const code = await waitExit(child, 10_000)
+    child.kill('SIGTERM')
+    // Terminal fake must NOT have run.
+    expect(stdout.join('')).not.toContain(TERMINAL_MARKER)
+    expect(code).toBeNull()
+  }, 30_000)
+})
+
+async function waitUntil(timeoutMs: number, pred: () => boolean): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (pred()) return
+    await new Promise((r) => setTimeout(r, 50))
+  }
+  throw new Error('waitUntil timed out')
+}

--- a/test/e2e-browser/helpers/rust-server-bin.test.ts
+++ b/test/e2e-browser/helpers/rust-server-bin.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { resolveRustServerBin, rustServerBinSha256 } from './rust-server.js'
+import { ensureRustServerBuilt, resolveRustServerBin, rustServerBinSha256 } from './rust-server.js'
 
 describe('resolveRustServerBin (fail-closed override, :2015)', () => {
   const buildHead = () => '/BUILT/head/freshell-server' // sentinel: never used on the override paths
@@ -38,5 +38,37 @@ describe('resolveRustServerBin (fail-closed override, :2015)', () => {
   })
   it('falls back to the built HEAD binary when the override is UNSET', () => {
     expect(resolveRustServerBin({}, buildHead)).toEqual({ bin: '/BUILT/head/freshell-server', source: 'built' })
+  })
+})
+
+describe('ensureRustServerBuilt (FRESHELL_E2E_RUST_SERVER_BIN short-circuit)', () => {
+  // Cloud Run e2e tasks prebuild the binary into the image and select it via
+  // the env override; a workspace `cargo build` inside the 2-CPU / 2-GiB task
+  // gets SIGKILLed. These tests pin that the override path NEVER runs cargo:
+  // each passes a temp root with no Cargo workspace, so a stray cargo spawn
+  // fails the test with a cargo error instead of the expected result.
+  const scratchRoot = () => fs.mkdtempSync(path.join(os.tmpdir(), 'no-workspace-'))
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns the override binary without running cargo', () => {
+    const f = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ovr-')), 'server')
+    fs.writeFileSync(f, '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+    vi.stubEnv('FRESHELL_E2E_RUST_SERVER_BIN', f)
+    expect(ensureRustServerBuilt(scratchRoot())).toBe(f)
+  })
+
+  it('FAILS CLOSED on a missing override path (never falls back to cargo)', () => {
+    vi.stubEnv('FRESHELL_E2E_RUST_SERVER_BIN', '/no/such/binary')
+    expect(() => ensureRustServerBuilt(scratchRoot())).toThrow(/does not exist/)
+  })
+
+  it('FAILS CLOSED on a non-executable override', () => {
+    const f = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ovr-')), 'bin')
+    fs.writeFileSync(f, 'not exec', { mode: 0o644 })
+    vi.stubEnv('FRESHELL_E2E_RUST_SERVER_BIN', f)
+    expect(() => ensureRustServerBuilt(scratchRoot())).toThrow(/not executable/)
   })
 })

--- a/test/e2e-browser/helpers/rust-server.ts
+++ b/test/e2e-browser/helpers/rust-server.ts
@@ -78,8 +78,23 @@ let rustBuildDone = false
  * with `cargo build --release -p freshell-server` if missing (idempotent —
  * cargo itself no-ops on a clean, unchanged build).
  * Source of truth: `port/oracle/harness/external-server.ts`'s `ensureRustServerBuilt`.
+ *
+ * INTENTIONAL DIVERGENCE from that source: the Cloud Run e2e image prebuilds
+ * the binary, selects it via `FRESHELL_E2E_RUST_SERVER_BIN`, and runs specs in
+ * a 2-CPU / 2-GiB task where a workspace `cargo build` gets killed outright.
+ * When the override is set, this short-circuits through
+ * `resolveRustServerBin`'s FAIL-CLOSED validation (:2015) and returns the
+ * override — cargo NEVER runs on that path (a typo'd override must throw, not
+ * silently run a different binary). The oracle harness deliberately keeps the
+ * source behavior: it runs on dev/CI machines with cargo available and no
+ * prebuilt-image contract.
  */
 export function ensureRustServerBuilt(root: string = PROJECT_ROOT): string {
+  if (process.env.FRESHELL_E2E_RUST_SERVER_BIN?.trim()) {
+    return resolveRustServerBin(process.env, () => {
+      throw new Error('unreachable: FRESHELL_E2E_RUST_SERVER_BIN is set; buildHead must not run')
+    }).bin
+  }
   const bin = rustServerBinPath(root)
   if (rustBuildDone && fs.existsSync(bin)) return bin
 

--- a/test/e2e-browser/specs/codex-status-completeness-rust.spec.ts
+++ b/test/e2e-browser/specs/codex-status-completeness-rust.spec.ts
@@ -8,6 +8,7 @@ import { createE2eServerHandle } from '../helpers/external-target.js'
 import { RustServer } from '../helpers/rust-server.js'
 import { TestHarness } from '../helpers/test-harness.js'
 import { openPanePicker } from '../helpers/pane-picker.js'
+import { installDualRoleCodexCli } from '../fixtures/codex-dual-role'
 
 /**
  * Codex status completeness (Rust only) — wire-level proof that codex panes
@@ -44,30 +45,9 @@ async function installFakeCli(binDir: string, name: string, source: string): Pro
   return target
 }
 
-// Dual-role codex shim, donor shape: restore-contract-wall-rust.spec.ts's
-// installDualRoleCodex (terminal source parameterized). Required: the Rust
-// server's codex terminal lane boots a `codex app-server` sidecar FIRST with
-// the SAME CODEX_CMD; a terminal-only fake exits 0 on that spawn (stdin is
-// /dev/null) and every codex pane create fails PTY_SPAWN_FAILED
-// ("app-server exited before listening").
-async function installDualRoleCodexCli(binDir: string, terminalSource: string): Promise<string> {
-  await fs.mkdir(binDir, { recursive: true })
-  const target = path.join(binDir, 'codex')
-  const appServerSource = path.resolve(__dirname, '../../fixtures/coding-cli/codex-app-server/fake-app-server.mjs')
-  const script = `#!/usr/bin/env node
-const { spawnSync } = require('node:child_process')
-const argv = process.argv.slice(2)
-if (argv.includes('app-server')) {
-  const result = spawnSync(process.execPath, [${JSON.stringify(appServerSource)}, ...argv], { stdio: 'inherit', env: process.env })
-  process.exit(result.status ?? 1)
-}
-const result = spawnSync(process.execPath, [${JSON.stringify(terminalSource)}, ...argv], { stdio: 'inherit', env: process.env })
-process.exit(result.status ?? 1)
-`
-  await fs.writeFile(target, script, 'utf8')
-  await fs.chmod(target, 0o755)
-  return target
-}
+// Dual-role codex shim: shared helper (test/e2e-browser/fixtures/codex-dual-role.ts).
+// A terminal-only fake at CODEX_CMD dies instantly on the codex app-server
+// sidecar spawn and every codex create fails PTY_SPAWN_FAILED.
 
 /**
  * A raw, node-side WS capture client: performs the real hello handshake and

--- a/test/e2e-browser/specs/codex-status-completeness-rust.spec.ts
+++ b/test/e2e-browser/specs/codex-status-completeness-rust.spec.ts
@@ -34,11 +34,37 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 const FAKE_BEL_CLI = path.resolve(__dirname, '../fixtures/fake-bel-cli.mjs')
+const FAKE_CODEX_CLI = path.resolve(__dirname, '../fixtures/fake-codex-cli.mjs')
 
 async function installFakeCli(binDir: string, name: string, source: string): Promise<string> {
   await fs.mkdir(binDir, { recursive: true })
   const target = path.join(binDir, name)
   await fs.copyFile(source, target)
+  await fs.chmod(target, 0o755)
+  return target
+}
+
+// Dual-role codex shim, donor shape: restore-contract-wall-rust.spec.ts's
+// installDualRoleCodex (terminal source parameterized). Required: the Rust
+// server's codex terminal lane boots a `codex app-server` sidecar FIRST with
+// the SAME CODEX_CMD; a terminal-only fake exits 0 on that spawn (stdin is
+// /dev/null) and every codex pane create fails PTY_SPAWN_FAILED
+// ("app-server exited before listening").
+async function installDualRoleCodexCli(binDir: string, terminalSource: string): Promise<string> {
+  await fs.mkdir(binDir, { recursive: true })
+  const target = path.join(binDir, 'codex')
+  const appServerSource = path.resolve(__dirname, '../../fixtures/coding-cli/codex-app-server/fake-app-server.mjs')
+  const script = `#!/usr/bin/env node
+const { spawnSync } = require('node:child_process')
+const argv = process.argv.slice(2)
+if (argv.includes('app-server')) {
+  const result = spawnSync(process.execPath, [${JSON.stringify(appServerSource)}, ...argv], { stdio: 'inherit', env: process.env })
+  process.exit(result.status ?? 1)
+}
+const result = spawnSync(process.execPath, [${JSON.stringify(terminalSource)}, ...argv], { stdio: 'inherit', env: process.env })
+process.exit(result.status ?? 1)
+`
+  await fs.writeFile(target, script, 'utf8')
   await fs.chmod(target, 0o755)
   return target
 }
@@ -309,11 +335,9 @@ test.describe('Codex status completeness (Rust only)', () => {
   }) => {
     expect(e2eServerKind).toBe('rust')
     const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-restart-'))
-    const fakeCodex = await installFakeCli(
-      path.join(sharedRoot, 'bin'),
-      'codex',
-      path.resolve(__dirname, '../fixtures/fake-codex-cli.mjs'),
-    )
+    // Dual-role: the codex terminal lane boots a `codex app-server` sidecar
+    // first; a terminal-only fake dies on it (PTY_SPAWN_FAILED).
+    const fakeCodex = await installDualRoleCodexCli(path.join(sharedRoot, 'bin'), FAKE_CODEX_CLI)
     let rolloutPath = ''
     const server = new RustServer({
       env: { CODEX_CMD: fakeCodex },
@@ -415,7 +439,9 @@ test.describe('Codex status completeness (Rust only)', () => {
   }) => {
     expect(e2eServerKind).toBe('rust')
     const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-twin-'))
-    const fakeCodex = await installFakeCli(path.join(sharedRoot, 'bin'), 'codex', FAKE_BEL_CLI)
+    // Dual-role (see note at site one): the codex lane boots an app-server
+    // sidecar first; the BEL fake must cover only the terminal branch.
+    const fakeCodex = await installDualRoleCodexCli(path.join(sharedRoot, 'bin'), FAKE_BEL_CLI)
     const mkServer = () =>
       new RustServer({
         env: { CODEX_CMD: fakeCodex },

--- a/test/e2e-browser/specs/compound-restart-rust.spec.ts
+++ b/test/e2e-browser/specs/compound-restart-rust.spec.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { test, expect } from '../helpers/fixtures.js'
 import { RustServer } from '../helpers/rust-server.js'
 import { TestHarness } from '../helpers/test-harness.js'
+import { installDualRoleCodexCli } from '../fixtures/codex-dual-role'
 
 /**
  * COMPOUND-RESTART -- the two never-tested disruption modes called out by
@@ -52,11 +53,10 @@ const __dirname = path.dirname(__filename)
 const FAKE_CODEX_CLI_SOURCE = path.resolve(__dirname, '../fixtures/fake-codex-cli.mjs')
 
 async function installFakeCodexCli(binDir: string): Promise<string> {
-  await fs.mkdir(binDir, { recursive: true })
-  const target = path.join(binDir, 'codex')
-  await fs.copyFile(FAKE_CODEX_CLI_SOURCE, target)
-  await fs.chmod(target, 0o755)
-  return target
+  // Dual-role: the Rust codex terminal lane boots a `codex app-server`
+  // sidecar first from the same CODEX_CMD; a terminal-only fake exits 0 on
+  // that spawn and every codex create fails PTY_SPAWN_FAILED.
+  return installDualRoleCodexCli(binDir, FAKE_CODEX_CLI_SOURCE)
 }
 
 async function selectShellIfPickerShowing(page: import('@playwright/test').Page): Promise<void> {

--- a/test/e2e-browser/specs/deploy-tab-diff-rust.spec.ts
+++ b/test/e2e-browser/specs/deploy-tab-diff-rust.spec.ts
@@ -8,6 +8,7 @@ import fs from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { RustServer } from '../helpers/rust-server.js'
 import { TestHarness } from '../helpers/test-harness.js'
+import { installDualRoleCodexCli } from '../fixtures/codex-dual-role'
 
 /**
  * CONTINUITY TRIO deliverable 3 acceptance
@@ -42,11 +43,10 @@ const run = promisify(execFile)
 const SESSION_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
 
 async function installFakeCodexCli(binDir: string): Promise<string> {
-  await fs.mkdir(binDir, { recursive: true })
-  const target = path.join(binDir, 'codex')
-  await fs.copyFile(FAKE_CODEX_CLI_SOURCE, target)
-  await fs.chmod(target, 0o755)
-  return target
+  // Dual-role: the Rust codex terminal lane boots a `codex app-server`
+  // sidecar first from the same CODEX_CMD; a terminal-only fake exits 0 on
+  // that spawn and every codex create fails PTY_SPAWN_FAILED.
+  return installDualRoleCodexCli(binDir, FAKE_CODEX_CLI_SOURCE)
 }
 
 async function connect(page: import('@playwright/test').Page, info: any): Promise<TestHarness> {

--- a/test/e2e-browser/specs/idle-gate-semantics-rust.spec.ts
+++ b/test/e2e-browser/specs/idle-gate-semantics-rust.spec.ts
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'node:url'
 import { test, expect } from '../helpers/fixtures.js'
 import { RustServer } from '../helpers/rust-server.js'
 import { TestHarness } from '../helpers/test-harness.js'
+import { installDualRoleCodexCli } from '../fixtures/codex-dual-role'
 import { WsCapture, type WsFrame } from '../helpers/ws-capture.js'
 
 const FIXTURES_DIR = fileURLToPath(new URL('../fixtures', import.meta.url))
@@ -165,7 +166,9 @@ test.describe('idle-gate semantics (rust)', () => {
     expect(e2eServerKind).toBe('rust')
     const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-idlegate-codex-'))
     try {
-      const fakeCodex = await installFakeCli(path.join(sharedRoot, 'bin'), 'codex', FAKE_BEL_CLI)
+      // Dual-role: the Rust codex terminal lane boots a 'codex app-server'
+      // sidecar first; a terminal-only fake dies on it (PTY_SPAWN_FAILED).
+      const fakeCodex = await installDualRoleCodexCli(path.join(sharedRoot, 'bin'), FAKE_BEL_CLI)
       const server = new RustServer({
         env: { CODEX_CMD: fakeCodex },
         setupHome: seedProviders(['codex']),

--- a/test/e2e-browser/specs/pane-ledger-restart-rust.spec.ts
+++ b/test/e2e-browser/specs/pane-ledger-restart-rust.spec.ts
@@ -6,10 +6,11 @@
  * moments after creation loses nothing, and the restarted server's boot
  * scan preserves (never quarantines, never sweeps) the evidence.
  *
- * Wall 2 (`SIGKILL-inside-locator-window`): a pane killed mid
- * identity-establishment leaves a durable pending marker that SURVIVES the
- * restart boot scan — fresh-by-race stays distinguishable from
- * fresh-by-intent.
+ * Wall 2 (`SIGKILL-between-spawn-and-identity-resolution`): in the managed
+ * codex topology, identity resolves at the first managed handshake
+ * (`thread/started` from the proxy candidate). A pane killed BEFORE ever
+ * being submitted leaves a durable pending marker that SURVIVES the restart
+ * boot scan — fresh-by-race stays distinguishable from fresh-by-intent.
  *
  * Fixture shapes (fake CLIs, temp-home seeding, restart choreography)
  * mirror compound-restart-rust.spec.ts; helpers are copied, not imported,
@@ -22,6 +23,7 @@ import * as os from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { RustServer } from '../helpers/rust-server.js'
 import { TestHarness } from '../helpers/test-harness.js'
+import { installDualRoleCodexCli } from '../fixtures/codex-dual-role'
 import { openPanePicker } from '../helpers/pane-picker.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -106,6 +108,12 @@ async function within5s(check: () => Promise<boolean>, what: string): Promise<vo
   throw new Error(`5s durability wall breached: ${what}`)
 }
 
+// The walls below assert RAW ledger file state after SIGKILL; the harness
+// auto-decline watcher would answer the recovery offer first, and the
+// decline routes through terminal.kill, which deletes the pending marker
+// (crates/freshell-ws/src/terminal.rs). Keep decline manual here.
+test.use({ recoveryOfferHandling: 'manual' })
+
 test.describe('pane-identity ledger restart durability', () => {
   test.setTimeout(180_000)
 
@@ -116,7 +124,9 @@ test.describe('pane-identity ledger restart durability', () => {
     try {
       const argLog = path.join(sharedRoot, 'claude-argv.jsonl')
       const fakeClaude = await installFakeCli(path.join(sharedRoot, 'bin'), 'claude', 'fake-claude-cli.mjs')
-      const fakeCodex = await installFakeCli(path.join(sharedRoot, 'bin'), 'codex', 'fake-codex-cli.mjs')
+      // Dual-role: the Rust codex terminal lane boots a 'codex app-server'
+      // sidecar first; a terminal-only fake dies on it (PTY_SPAWN_FAILED).
+      const fakeCodex = await installDualRoleCodexCli(path.join(sharedRoot, 'bin'), path.resolve(__dirname, '../fixtures/fake-codex-cli.mjs'))
       const seed = seedConfig()
       const server = new RustServer({
         env: { CLAUDE_CMD: fakeClaude, CODEX_CMD: fakeCodex, FAKE_CLAUDE_ARGV_LOG: argLog },
@@ -254,23 +264,17 @@ test.describe('pane-identity ledger restart durability', () => {
     }
   })
 
-  test('SIGKILL inside the codex locator window leaves a durable fresh-by-race marker', async ({ page, e2eServerKind }) => {
+  test('SIGKILL between spawn and identity resolution leaves a durable fresh-by-race marker', async ({ page, e2eServerKind }) => {
     expect(e2eServerKind).toBe('rust')
     const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'pane-ledger-locator-'))
     let capturedHome = ''
     try {
-      const fakeCodex = await installFakeCli(path.join(sharedRoot, 'bin'), 'codex', 'fake-codex-terminal.mjs')
+      // Dual-role: the Rust codex terminal lane boots a 'codex app-server'
+      // sidecar first; a terminal-only fake dies on it (PTY_SPAWN_FAILED).
+      const fakeCodex = await installDualRoleCodexCli(path.join(sharedRoot, 'bin'), path.resolve(__dirname, '../fixtures/fake-codex-terminal.mjs'))
       const seed = seedConfig()
-      // ROLLOUT GATE (REQUIRED for this wall's premise): the fake codex
-      // WRITES a real rollout JSONL on its FIRST Enter unless
-      // FAKE_CODEX_TERMINAL_ROLLOUT_GATE_PATH is set and the gate file
-      // never exists (fake-codex-terminal.mjs:76-86). Point it at a
-      // path we NEVER create, so identity deterministically never resolves
-      // and the pending marker is the only evidence — no race against the
-      // SIGKILL.
-      const rolloutGate = path.join(sharedRoot, 'rollout-gate-never-created')
       const server = new RustServer({
-        env: { CODEX_CMD: fakeCodex, FAKE_CODEX_TERMINAL_ROLLOUT_GATE_PATH: rolloutGate },
+        env: { CODEX_CMD: fakeCodex },
         setupHome: async (homeDir: string) => {
           capturedHome = homeDir
           await seed(homeDir)
@@ -292,33 +296,31 @@ test.describe('pane-identity ledger restart durability', () => {
           'codex pending marker on disk',
         )
 
-        // The codex pending marker exists from SPAWN (codex is in
-        // MARKER_MODES), but the locator WINDOW is Enter-anchored: it only
-        // opens on the pane's first submit. Click the fresh pane's xterm
-        // (`.last()` — only the boot shell and this pane exist) and type +
-        // Enter so the SIGKILL below lands INSIDE an open window. A short
-        // settle lets the Enter complete the browser -> WS -> PTY hop
-        // before the kill.
-        await page.locator('.xterm').last().click()
-        await page.keyboard.type('hello codex')
-        await page.keyboard.press('Enter')
-        await page.waitForTimeout(500)
-
-        // SIGKILL INSIDE the locator window (the never-created gate means
-        // no rollout exists for the fake, so identity never resolves — the
-        // marker is the only evidence identity was in flight).
+        // Identity window semantics in the managed topology (codex terminal
+        // v2): the proxy candidate binds identity at the pane's FIRST managed
+        // handshake (`thread/started` after the first Enter). A pane that is
+        // spawned and NEVER submitted is exactly the fresh-by-race shape this
+        // wall protects: pending marker, zero bindings. SIGKILL here, without
+        // touching the pane, and the restarted boot scan must PRESERVE the
+        // marker (never sweep, never quarantine) and land NO binding row for
+        // it. (Bindings live under bindings/<provider>/<session>.json — the
+        // listFiles below is intentionally NOT recursive: a file at that path
+        // means the marker consumed correctly, which did not happen.)
         await server.restartAbrupt()
         await expect(async () => {
           const status = await page.evaluate(() => (window as any).__FRESHELL_TEST_HARNESS__?.getWsReadyState())
           expect(status).toBe('ready')
         }).toPass({ timeout: 60_000 })
 
-        // The restarted boot scan PRESERVED the marker (fresh-by-race
-        // distinguishable from fresh-by-intent) — and nothing bound it.
         const pending = (await listFiles(path.join(ledgerDir, 'pending'))).filter((f) => f.endsWith('.json'))
         expect(pending.length).toBeGreaterThan(0)
-        const bindings = await listFiles(path.join(ledgerDir, 'bindings'))
-        expect(bindings.filter((f) => f.endsWith('.json'))).toHaveLength(0)
+        // Bindings are nested as bindings/<provider>/<session-id>.json —
+        // check the FULL tree for any binding row (the penultimate shape of
+        // "identity resolved"), which must be empty here.
+        const bindingRows = (await fs.readdir(path.join(ledgerDir, 'bindings'), { recursive: true }).catch(() => []))
+          .map(String)
+          .filter((f) => f.endsWith('.json'))
+        expect(bindingRows).toHaveLength(0)
       } finally {
         await server.stop().catch(() => {})
       }

--- a/test/e2e-browser/specs/reconcile-client-adoption-rust.spec.ts
+++ b/test/e2e-browser/specs/reconcile-client-adoption-rust.spec.ts
@@ -20,6 +20,7 @@
 import { test, expect } from '../helpers/fixtures.js'
 import { RustServer, type TestServerInfo } from '../helpers/rust-server.js'
 import { TestHarness } from '../helpers/test-harness.js'
+import { installDualRoleCodexCli } from '../fixtures/codex-dual-role'
 import { openPanePicker } from '../helpers/pane-picker.js'
 import type { Page } from '@playwright/test'
 import fs from 'node:fs/promises'
@@ -549,11 +550,9 @@ test.describe('reconcile client adoption (rust server, real SPA)', () => {
     const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-adopt-dead-'))
     const projectDir = path.join(sharedRoot, 'project')
     await fs.mkdir(projectDir, { recursive: true })
-    const fakeCodexPath = await installFakeCli(
-      FAKE_CODEX_CLI_SOURCE,
-      'codex',
-      path.join(sharedRoot, 'bin'),
-    )
+    // Dual-role: the Rust codex terminal lane boots a 'codex app-server'
+    // sidecar first; a terminal-only fake dies on it (PTY_SPAWN_FAILED).
+    const fakeCodexPath = await installDualRoleCodexCli(path.join(sharedRoot, 'bin'), FAKE_CODEX_CLI_SOURCE)
     const { server, harness, info } = await bootAdoption(page, {
       env: { CODEX_CMD: fakeCodexPath },
       setupHome: seedCodexAdoptionHome(

--- a/test/e2e-browser/specs/restore-contract-wall-rust.spec.ts
+++ b/test/e2e-browser/specs/restore-contract-wall-rust.spec.ts
@@ -797,11 +797,10 @@ test.describe('Restore Contract Wall (P0.1)', () => {
     const projectDir = path.join(sharedRoot, 'project')
     await fs.mkdir(projectDir, { recursive: true })
     const argLogPath = path.join(sharedRoot, 'codex-argv.jsonl')
-    const fakeCodexPath = await installFakeCli(
-      FAKE_CODEX_CLI_SOURCE,
-      'codex',
-      path.join(sharedRoot, 'bin'),
-    )
+    // Dual-role: the Rust server's codex terminal lane boots a `codex
+    // app-server` sidecar FIRST (PTY_SPAWN_FAILED otherwise), so the fake
+    // must answer both app-server argv (fake app-server) and terminal argv.
+    const fakeCodexPath = await installDualRoleCodex(path.join(sharedRoot, 'bin'), argLogPath)
 
     const { server, harness } = await bootWall(page, {
       env: { CODEX_CMD: fakeCodexPath, FAKE_CODEX_ARGV_LOG: argLogPath },
@@ -2036,11 +2035,10 @@ test.describe('Restore Contract Wall (P0.1)', () => {
     const projectDir = path.join(sharedRoot, 'project')
     await fs.mkdir(projectDir, { recursive: true })
     const argLogPath = path.join(sharedRoot, 'codex-argv.jsonl')
-    const fakeCodexPath = await installFakeCli(
-      FAKE_CODEX_CLI_SOURCE,
-      'codex',
-      path.join(sharedRoot, 'bin'),
-    )
+    // Dual-role: the Rust server's codex terminal lane boots a `codex
+    // app-server` sidecar FIRST (PTY_SPAWN_FAILED otherwise), so the fake
+    // must answer both app-server argv (fake app-server) and terminal argv.
+    const fakeCodexPath = await installDualRoleCodex(path.join(sharedRoot, 'bin'), argLogPath)
     const { server, harness, info } = await bootWall(page, {
       env: { CODEX_CMD: fakeCodexPath, FAKE_CODEX_ARGV_LOG: argLogPath },
       setupHome: seedCodexHome(CODEX_SESSION_ID, SESSION_TITLE, projectDir),
@@ -2215,11 +2213,10 @@ test.describe('Restore Contract Wall (P0.1)', () => {
     const projectDir = path.join(sharedRoot, 'project')
     await fs.mkdir(projectDir, { recursive: true })
     const argLogPath = path.join(sharedRoot, 'codex-argv.jsonl')
-    const fakeCodexPath = await installFakeCli(
-      FAKE_CODEX_CLI_SOURCE,
-      'codex',
-      path.join(sharedRoot, 'bin'),
-    )
+    // Dual-role: the Rust server's codex terminal lane boots a `codex
+    // app-server` sidecar FIRST (PTY_SPAWN_FAILED otherwise), so the fake
+    // must answer both app-server argv (fake app-server) and terminal argv.
+    const fakeCodexPath = await installDualRoleCodex(path.join(sharedRoot, 'bin'), argLogPath)
     const { server, harness, info } = await bootWall(page, {
       env: { CODEX_CMD: fakeCodexPath, FAKE_CODEX_ARGV_LOG: argLogPath },
       setupHome: seedCodexHome(CODEX_SESSION_ID, SESSION_TITLE, projectDir),

--- a/test/e2e-browser/specs/restore-contract-wall-rust.spec.ts
+++ b/test/e2e-browser/specs/restore-contract-wall-rust.spec.ts
@@ -27,6 +27,7 @@ import { test, expect } from '../helpers/fixtures.js'
 import { RustServer, type TestServerInfo } from '../helpers/rust-server.js'
 import { TestHarness } from '../helpers/test-harness.js'
 import { openPanePicker } from '../helpers/pane-picker.js'
+import { installDualRoleCodexCli } from '../fixtures/codex-dual-role'
 import type { Page } from '@playwright/test'
 import fs from 'node:fs/promises'
 import os from 'node:os'
@@ -520,21 +521,7 @@ async function createBrowserPaneInPage(page: Page): Promise<void> {
 
 /** Single-executable `codex` shim: app-server argv -> fake app-server; else terminal fake. */
 async function installDualRoleCodex(binDir: string, argLogPath: string): Promise<string> {
-  await fs.mkdir(binDir, { recursive: true })
-  const target = path.join(binDir, 'codex')
-  const script = `#!/usr/bin/env node
-const { spawnSync } = require('node:child_process')
-const argv = process.argv.slice(2)
-if (argv.includes('app-server')) {
-  const result = spawnSync(process.execPath, [${JSON.stringify(FAKE_CODEX_APP_SERVER_SOURCE)}, ...argv], { stdio: 'inherit', env: process.env })
-  process.exit(result.status ?? 1)
-}
-const result = spawnSync(process.execPath, [${JSON.stringify(FAKE_CODEX_CLI_SOURCE)}, ...argv], { stdio: 'inherit', env: { ...process.env, FAKE_CODEX_ARGV_LOG: ${JSON.stringify(argLogPath)} } })
-process.exit(result.status ?? 1)
-`
-  await fs.writeFile(target, script, 'utf8')
-  await fs.chmod(target, 0o755)
-  return target
+  return installDualRoleCodexCli(binDir, FAKE_CODEX_CLI_SOURCE, { FAKE_CODEX_ARGV_LOG: argLogPath })
 }
 
 /** Single-executable `opencode` shim: `serve` argv -> fake sidecar; else terminal fake. */
@@ -2024,6 +2011,9 @@ test.describe('Restore Contract Wall (P0.1)', () => {
     e2eServerKind,
   }) => {
     expect(e2eServerKind).toBe('rust')
+    // Cloud (2-worker shard) wall-clock: SIGKILL + dual-client recovery + a
+    // stable-count settle on the arg log exceeds the describe-level 180s.
+    test.setTimeout(300_000)
     // P1.7 (D8, §4.3) LANDED -- pin flipped by the reconcile-client-adoption
     // lane: the server now runs a per-sessionRef single-flight lease on the
     // create path (losers get error{SESSION_RESERVED}) and reconcile verdicts

--- a/test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts
+++ b/test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts
@@ -23,6 +23,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 // below stays the sole authority over panel interactions. No opt-out needed.
 
 const SEEDED_CLAUDE_ID = randomUUID()
+// case-d gets its own seeded claude id: the serial suite already bound
+// SEEDED_CLAUDE_ID to a running resume terminal in case-b, and the Rust
+// server now rejects REST resume of a still-running session (409
+// RESTORE_UNAVAILABLE). A distinct, unbound id keeps case-d's premise valid.
+const SEEDED_CLAUDE_ID_D = randomUUID()
 const PROJECT_DIR = '/tmp/p114-sidebar-project'
 
 // Copied VERBATIM from pane-ledger-restart-rust.spec.ts:29 (per this
@@ -31,6 +36,35 @@ async function installFakeCli(binDir: string, name: string, source: string): Pro
   await fs.mkdir(binDir, { recursive: true })
   const target = path.join(binDir, name)
   await fs.copyFile(path.resolve(__dirname, '../fixtures', source), target)
+  await fs.chmod(target, 0o755)
+  return target
+}
+
+// Dual-role codex shim, donor shape: restore-contract-wall-rust.spec.ts's
+// installDualRoleCodex — terminal target swapped for THIS spec's rollout-writing
+// fake-codex-terminal.mjs (argv log env name adjusted to match). Required because
+// the Rust server's codex terminal lane boots a `codex app-server` sidecar FIRST
+// (spawned with the SAME CODEX_CMD): a terminal-only fake exits 0 there (stdin
+// is /dev/null), and every codex pane create fails with PTY_SPAWN_FAILED
+// ("app-server exited before listening"). One executable must answer both roles:
+// app-server argv -> the shared fake app-server fixture; otherwise the terminal
+// fake.
+async function installDualRoleCodex(binDir: string, argLogPath: string): Promise<string> {
+  await fs.mkdir(binDir, { recursive: true })
+  const target = path.join(binDir, 'codex')
+  const appServerSource = path.resolve(__dirname, '../../fixtures/coding-cli/codex-app-server/fake-app-server.mjs')
+  const terminalSource = path.resolve(__dirname, '../fixtures/fake-codex-terminal.mjs')
+  const script = `#!/usr/bin/env node
+const { spawnSync } = require('node:child_process')
+const argv = process.argv.slice(2)
+if (argv.includes('app-server')) {
+  const result = spawnSync(process.execPath, [${JSON.stringify(appServerSource)}, ...argv], { stdio: 'inherit', env: process.env })
+  process.exit(result.status ?? 1)
+}
+const result = spawnSync(process.execPath, [${JSON.stringify(terminalSource)}, ...argv], { stdio: 'inherit', env: { ...process.env, FAKE_CODEX_TERMINAL_ARGV_LOG: ${JSON.stringify(argLogPath)} } })
+process.exit(result.status ?? 1)
+`
+  await fs.writeFile(target, script, 'utf8')
   await fs.chmod(target, 0o755)
   return target
 }
@@ -177,7 +211,12 @@ test.describe.serial('P1.14 sidebar registry sync (rust)', () => {
     sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'p114-sidebar-'))
     const binDir = path.join(sharedRoot, 'bin')
     const fakeClaude = await installFakeCli(binDir, 'claude', 'fake-claude-cli.mjs')
-    const fakeCodex = await installFakeCli(binDir, 'codex', 'fake-codex-terminal.mjs')
+    // Dual-role: the codex terminal lane boots a `codex app-server` sidecar
+    // first; a terminal-only fake dies on it (PTY_SPAWN_FAILED).
+    const fakeCodex = await installDualRoleCodex(
+      binDir,
+      path.join(sharedRoot, 'codex-argv.jsonl'),
+    )
     server = new RustServer({
       env: {
         CLAUDE_CMD: fakeClaude,
@@ -210,6 +249,9 @@ test.describe.serial('P1.14 sidebar registry sync (rust)', () => {
         await fs.writeFile(
           path.join(projDir, `${SEEDED_CLAUDE_ID}.jsonl`),
           buildClaudeSessionJsonl(SEEDED_CLAUDE_ID, PROJECT_DIR, 'P114 seeded claude session'))
+        await fs.writeFile(
+          path.join(projDir, `${SEEDED_CLAUDE_ID_D}.jsonl`),
+          buildClaudeSessionJsonl(SEEDED_CLAUDE_ID_D, PROJECT_DIR, 'P114 case-d claude session'))
       },
     })
     info = await server.start()
@@ -650,25 +692,25 @@ test.describe.serial('P1.14 sidebar registry sync (rust)', () => {
     // Open a claude resume pane so there is something to lose + recover.
     const res = await page.request.post(`${info.baseUrl}/api/tabs`, {
       headers: { 'x-auth-token': info.token, 'content-type': 'application/json' },
-      data: { mode: 'claude', cwd: PROJECT_DIR, sessionRef: { provider: 'claude', sessionId: SEEDED_CLAUDE_ID } },
+      data: { mode: 'claude', cwd: PROJECT_DIR, sessionRef: { provider: 'claude', sessionId: SEEDED_CLAUDE_ID_D } },
     })
     expect(res.ok(), `POST /api/tabs claude resume: ${res.status()} ${await res.text()}`).toBe(true)
     const restTabId: string = (await res.json())?.data?.tabId
     expect(restTabId).toBeTruthy()
-    await expect(page.locator(`[data-session-id="${SEEDED_CLAUDE_ID}"][data-provider="claude"]`))
+    await expect(page.locator(`[data-session-id="${SEEDED_CLAUDE_ID_D}"][data-provider="claude"]`))
       .toHaveAttribute('data-has-tab', 'true', { timeout: 30_000 })
 
     // Disk-settle before the kill (donor: recover-my-panes-rust.spec.ts:275-287):
     // the ledger binding row for the session, then a snapshot generation whose
     // CONTENT includes THIS test's pane. Needle on restTabId too: earlier
-    // cases' generations already contain SEEDED_CLAUDE_ID, so the sessionId
+    // cases' generations already contain SEEDED_CLAUDE_ID_D, so the sessionId
     // alone would match a stale generation and the wait would be vacuous.
     await expect(async () => {
       const dir = path.join(info.homeDir, '.freshell', 'pane-ledger', 'bindings', 'claude')
       const rows = await fs.readdir(dir, { recursive: true }).catch(() => [] as string[])
-      expect(rows.map(String).some((f) => f.includes(SEEDED_CLAUDE_ID))).toBe(true)
+      expect(rows.map(String).some((f) => f.includes(SEEDED_CLAUDE_ID_D))).toBe(true)
     }).toPass({ timeout: 15_000 })
-    await waitForSnapshotContaining([SEEDED_CLAUDE_ID, restTabId])
+    await waitForSnapshotContaining([SEEDED_CLAUDE_ID_D, restTabId])
 
     // Lost client + abrupt server death. Closing the WHOLE context (donor
     // :290) is the validated lost-client simulation: the fresh context below
@@ -698,7 +740,7 @@ test.describe.serial('P1.14 sidebar registry sync (rust)', () => {
     await expect(page2.locator('.xterm').first()).toBeAttached({ timeout: 30_000 })
 
     // THE CONTRACT: the recovered session is green again, exactly once.
-    const row = page2.locator(`[data-session-id="${SEEDED_CLAUDE_ID}"][data-provider="claude"]`)
+    const row = page2.locator(`[data-session-id="${SEEDED_CLAUDE_ID_D}"][data-provider="claude"]`)
     await expect(row).toHaveAttribute('data-has-tab', 'true', { timeout: 45_000 })
     await expect(row).toHaveCount(1)
 

--- a/test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts
+++ b/test/e2e-browser/specs/sidebar-registry-sync-rust.spec.ts
@@ -15,6 +15,7 @@ import { randomUUID } from 'node:crypto'
 import { fileURLToPath } from 'node:url'
 import { RustServer, ensureRustServerBuilt, type TestServerInfo } from '../helpers/rust-server.js'
 import { TestHarness } from '../helpers/test-harness.js'
+import { installDualRoleCodexCli } from '../fixtures/codex-dual-role'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // NOTE (RESTORE-01): this spec imports `test` from '@playwright/test'
@@ -40,34 +41,11 @@ async function installFakeCli(binDir: string, name: string, source: string): Pro
   return target
 }
 
-// Dual-role codex shim, donor shape: restore-contract-wall-rust.spec.ts's
-// installDualRoleCodex — terminal target swapped for THIS spec's rollout-writing
-// fake-codex-terminal.mjs (argv log env name adjusted to match). Required because
-// the Rust server's codex terminal lane boots a `codex app-server` sidecar FIRST
-// (spawned with the SAME CODEX_CMD): a terminal-only fake exits 0 there (stdin
-// is /dev/null), and every codex pane create fails with PTY_SPAWN_FAILED
-// ("app-server exited before listening"). One executable must answer both roles:
-// app-server argv -> the shared fake app-server fixture; otherwise the terminal
-// fake.
-async function installDualRoleCodex(binDir: string, argLogPath: string): Promise<string> {
-  await fs.mkdir(binDir, { recursive: true })
-  const target = path.join(binDir, 'codex')
-  const appServerSource = path.resolve(__dirname, '../../fixtures/coding-cli/codex-app-server/fake-app-server.mjs')
-  const terminalSource = path.resolve(__dirname, '../fixtures/fake-codex-terminal.mjs')
-  const script = `#!/usr/bin/env node
-const { spawnSync } = require('node:child_process')
-const argv = process.argv.slice(2)
-if (argv.includes('app-server')) {
-  const result = spawnSync(process.execPath, [${JSON.stringify(appServerSource)}, ...argv], { stdio: 'inherit', env: process.env })
-  process.exit(result.status ?? 1)
-}
-const result = spawnSync(process.execPath, [${JSON.stringify(terminalSource)}, ...argv], { stdio: 'inherit', env: { ...process.env, FAKE_CODEX_TERMINAL_ARGV_LOG: ${JSON.stringify(argLogPath)} } })
-process.exit(result.status ?? 1)
-`
-  await fs.writeFile(target, script, 'utf8')
-  await fs.chmod(target, 0o755)
-  return target
-}
+// Dual-role codex shim: shared helper (test/e2e-browser/fixtures/codex-dual-role.ts),
+// terminal target = THIS spec's rollout-writing fake-codex-terminal.mjs, argv log
+// threaded via terminalEnv. A terminal-only fake at CODEX_CMD dies instantly on
+// the codex app-server sidecar spawn -> every codex create PTY_SPAWN_FAILED.
+const FAKE_CODEX_TERMINAL_SOURCE = path.resolve(__dirname, '../fixtures/fake-codex-terminal.mjs')
 
 // Copied VERBATIM from remote-tab-linkage-rust.spec.ts:60-74.
 async function selectShellIfPickerShowing(page: import('@playwright/test').Page): Promise<void> {
@@ -213,9 +191,10 @@ test.describe.serial('P1.14 sidebar registry sync (rust)', () => {
     const fakeClaude = await installFakeCli(binDir, 'claude', 'fake-claude-cli.mjs')
     // Dual-role: the codex terminal lane boots a `codex app-server` sidecar
     // first; a terminal-only fake dies on it (PTY_SPAWN_FAILED).
-    const fakeCodex = await installDualRoleCodex(
+    const fakeCodex = await installDualRoleCodexCli(
       binDir,
-      path.join(sharedRoot, 'codex-argv.jsonl'),
+      FAKE_CODEX_TERMINAL_SOURCE,
+      { FAKE_CODEX_TERMINAL_ARGV_LOG: path.join(sharedRoot, 'codex-argv.jsonl') },
     )
     server = new RustServer({
       env: {

--- a/test/e2e-browser/specs/terminal-activity-rust.spec.ts
+++ b/test/e2e-browser/specs/terminal-activity-rust.spec.ts
@@ -6,6 +6,7 @@ import WebSocket from 'ws'
 import { test, expect } from '../helpers/fixtures.js'
 import { createE2eServerHandle } from '../helpers/external-target.js'
 import { TestHarness } from '../helpers/test-harness.js'
+import { installDualRoleCodexCli } from '../fixtures/codex-dual-role'
 import { openPanePicker } from '../helpers/pane-picker.js'
 
 /**
@@ -311,7 +312,10 @@ test.describe('Terminal-mode CLI activity (Rust only)', () => {
     expect(e2eServerKind).toBe('rust')
 
     const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-activity-codex-'))
-    const fakeCodex = await installFakeCli(path.join(sharedRoot, 'bin'), 'codex', FAKE_BEL_CLI)
+    // Dual-role: the Rust codex terminal lane boots a `codex app-server`
+    // sidecar first from the same CODEX_CMD; a terminal-only fake exits 0 on
+    // that spawn and every codex create fails PTY_SPAWN_FAILED.
+    const fakeCodex = await installDualRoleCodexCli(path.join(sharedRoot, 'bin'), FAKE_BEL_CLI)
     const server = await createE2eServerHandle(process.env, {
       kind: e2eServerKind,
       construct: {

--- a/test/e2e-browser/specs/turn-complete-restart-resume-rust.spec.ts
+++ b/test/e2e-browser/specs/turn-complete-restart-resume-rust.spec.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { test, expect } from '../helpers/fixtures.js'
 import { RustServer } from '../helpers/rust-server.js'
 import { TestHarness } from '../helpers/test-harness.js'
+import { installDualRoleCodexCli } from '../fixtures/codex-dual-role'
 import { openPanePicker } from '../helpers/pane-picker.js'
 
 /**
@@ -97,7 +98,10 @@ test.describe('Turn-complete alert across abrupt restart (Rust only)', () => {
   test('a recovered CLI pane rings exactly once for its first post-restart turn', async ({ page, e2eServerKind }) => {
     expect(e2eServerKind).toBe('rust')
     const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-lane-c-chime-'))
-    const fakeCodex = await installFakeCli(path.join(sharedRoot, 'bin'), 'codex', FAKE_BEL_CLI)
+    // Dual-role: the Rust codex terminal lane boots a `codex app-server`
+    // sidecar first from the same CODEX_CMD; a terminal-only fake exits 0 on
+    // that spawn and every codex create fails PTY_SPAWN_FAILED.
+    const fakeCodex = await installDualRoleCodexCli(path.join(sharedRoot, 'bin'), FAKE_BEL_CLI)
     const server = new RustServer({
       env: { CODEX_CMD: fakeCodex },
       setupHome: async (homeDir) => {


### PR DESCRIPTION
## Why
The cloud vitest/e2e wrapper hardening (PR #666) unmasked a long-standing layer of permanently-red playwright specs on the rust track. Three independent root causes, all fixed here:

1. **`ensureRustServerBuilt` always ran `cargo build`** even when `FRESHELL_E2E_RUST_SERVER_BIN` pointed at a prebuilt binary. In the 2 GiB Cloud Run tasks this OOM-killed the build, and its in-container death starved co-located tests.
2. **Half the codex-bearing suites used terminal-only fakes at `CODEX_CMD`.** The managed codex terminal lane (v2) spawns a `codex app-server` sidecar from the SAME binary before the TUI; a terminal-only fake exits 0 instantly on that spawn (stdin is /dev/null), so every codex create failed `PTY_SPAWN_FAILED`. Unobservable while cloud e2e itself was broken.
3. **`sidebar-registry-sync` case-d's premise was invalidated** by the (correct, landed) D7 409-guard against resuming a still-running session.

## What changed
- `rust-server.ts` honors the prebuilt-binary override with fail-closed validation (never runs cargo when set). Unit-pinned (3 tests).
- New shared helper `test/e2e-browser/fixtures/codex-dual-role.ts` (`installDualRoleCodexCli`) with behavioral tests (terminal role for plain argv, app-server role stays listening under sidecar argv, env passthrough).
- `fake-codex-terminal.mjs` performs the real managed handshake (initialize -> thread/start on the --remote proxy) and writes its rollout with the app-server-returned thread id, so proxy-candidate identity binding works end-to-end in tests.
- 10 spec files converted to dual-role installs (restore-contract-wall, codex-status-completeness, sidebar-registry-sync, compound-restart, deploy-tab-diff, terminal-activity, turn-complete, idle-gate, pane-ledger, reconcile-client-adoption).
- `pane-ledger` wall-2 redesigned for the managed lane: identity resolves at the first managed handshake, so the durability wall now kills before any submit and asserts the pending marker survives the boot scan with zero binding rows.
- case-d gets its own seeded session id; two-clients-same-sessionRef gets a cloud-scale timeout (300s).
- E2e helper coverage runs under the e2e helpers vitest config (282 tests locally green).

## Evidence
- Full cloud e2e (4 shards): permanently-red failures went **18 -> 10**; every codex-cluster spec is green (`agent-crash-autoresume`, `restore-contract-wall` x3, `codex-status-completeness`, `sidebar-registry-sync` cases b/c/d, `compound-restart`, `deploy-tab-diff`, `terminal-activity`, `turn-complete`, `idle-gate`, `pane-ledger`, `reconcile-client-adoption`).
- Control experiment: an identical full-cloud run on unmodified `main` reproduced 17/18 of the original reds -> pre-existing, not branch regressions.
- Local runs of every touched spec green; `tsc` and eslint clean; helper suite 282/282.

## Remaining cloud reds (all pre-existing on main, verified via the control run; tracked for follow-up)
cfg01 config-drift signal, title-sync:217 first-char duplication (looks like a genuine client input race), restore-wall:2008 contention timeout, rest-spawn-gate, multi-client x2, mcp-bridge, terminal-lifecycle:152 resize flake.

## Notes on interplay with the managed-launch opt-out pins
PRs #669-#671 landed `FRESHELL_CODEX_MANAGED_LAUNCH: '0'` pins + a live-owner kill in `sidebar-registry-sync` while this branch was in flight, working around the same root cause. The rebase was text-clean; both mechanisms coexist benignly (my handshake only runs when `--remote` argv appears, which the pins suppress). Removing the pins to exercise the managed lane with these working fakes is a deliberate follow-up decision, not bundled here.