### PR TITLE
Fix gray-and-dead panes after WebSocket reconnect (4-layer reconnect revive)

### DIFF
--- a/crates/freshell-freshagent/src/claude.rs
+++ b/crates/freshell-freshagent/src/claude.rs
@@ -211,6 +211,19 @@ struct ClaudeSession {
     broadcast_id: Arc<std::sync::Mutex<String>>,
     /// The folded pending approval/question set (Task 2) — see [`ClaudePending`].
     pending: Arc<std::sync::Mutex<ClaudePending>>,
+    /// Last status the sidecar announced for this session (the stdout consumer's
+    /// `sdk.status` fold). Read by the attach-ack sites so a reconnect ack tells the
+    /// truth instead of the hardcoded "idle" that used to wedge stale-busy/stale-idle
+    /// panes. Starts "idle" — a fresh/just-resumed session has announced nothing else.
+    last_status: Arc<std::sync::Mutex<String>>,
+}
+
+impl ClaudeSession {
+    /// The last status the sidecar announced for this session (the stdout consumer's
+    /// `sdk.status` fold) — the truth the attach acks speak.
+    fn current_status(&self) -> String {
+        self.last_status.lock().expect("last status lock").clone()
+    }
 }
 
 impl FreshClaudeState {
@@ -501,6 +514,8 @@ impl FreshClaudeState {
         // binding row at `sdk.session.init`.
         let broadcast_id = Arc::new(std::sync::Mutex::new(created.clone()));
         let pending = Arc::new(std::sync::Mutex::new(ClaudePending::default()));
+        // Fresh session: nothing announced yet; the consumer's sdk.status fold owns it.
+        let last_status = Arc::new(std::sync::Mutex::new("idle".to_string()));
         let consumer = self.spawn_consumer(
             reader,
             created.clone(),
@@ -509,6 +524,7 @@ impl FreshClaudeState {
             Some(settings),
             Arc::clone(&broadcast_id),
             Arc::clone(&pending),
+            Arc::clone(&last_status),
         );
 
         // V5 interleaving 2 (Task 12): on the create-resume path, insert
@@ -533,6 +549,7 @@ impl FreshClaudeState {
                 cli_session_id: resume_sid.clone(),
                 broadcast_id,
                 pending,
+                last_status,
             },
         );
 
@@ -1033,9 +1050,9 @@ impl FreshClaudeState {
     /// |---|---|
     /// | tracked under `msg.session_id` | no-op -- NO frame (wire-shape parity, unchanged). Safe against dead sidecars ONLY because the consumer-exit eviction removes dead entries (ledger A9) |
     /// | untracked, no canonical durable id on the message | `lost_session_frame` (`INVALID_SESSION_ID`) -- unchanged fallback (also covers the verified A2 edge: a pane that never learned its UUID pre-kill attaches bare; lost -> client re-create is the designed, non-destructive outcome) |
-    /// | untracked, durable id already in `cli_index`, aliased session LIVE | REBIND + ACK (Task 10b): flip the live session's envelope stamp to the durable id and answer with the idle `freshAgent.session.snapshot` stamped with the durable -- the attaching client must observe success, never silence. The map is never re-keyed (alias, don't move) |
+    /// | untracked, durable id already in `cli_index`, aliased session LIVE | REBIND + ACK (Task 10b): flip the live session's envelope stamp to the durable id and answer with the `freshAgent.session.snapshot` stamped with the durable and the session's TRACKED status (the consumer's sdk.status fold, never a hardcoded idle) -- the attaching client must observe success, never silence. The map is never re-keyed (alias, don't move) |
     /// | untracked, durable id in `cli_index` but aliased session GONE (stale row, eviction in flight) | fall through to the resume path below (the session is dead; resuming converges the client) |
-    /// | untracked, transcript EXISTS (in ANY candidate root) | spawn sidecar and resume with the session's ORIGINAL cwd from `transcript_cwd` (ledger A15: the CLI's resume lookup is cwd-slug-scoped); if that cwd no longer exists, resume by the transcript's `.jsonl` PATH (verified cli.js escape hatch that bypasses slug scoping) with the attach cwd. Register under the CLIENT's `msg.session_id`, emit idle `freshAgent.session.snapshot` whose `timelineSessionId` is the durable UUID -- NEVER a nanoid (the frozen client persists it unvalidated, ledger A14/N3) |
+    /// | untracked, transcript EXISTS (in ANY candidate root) | spawn sidecar and resume with the session's ORIGINAL cwd from `transcript_cwd` (ledger A15: the CLI's resume lookup is cwd-slug-scoped); if that cwd no longer exists, resume by the transcript's `.jsonl` PATH (verified cli.js escape hatch that bypasses slug scoping) with the attach cwd. Register under the CLIENT's `msg.session_id`, emit a `freshAgent.session.snapshot` whose `timelineSessionId` is the durable UUID -- NEVER a nanoid (the frozen client persists it unvalidated, ledger A14/N3) -- carrying the session's tracked status ("idle" for a fresh resume, by construction) |
     /// | untracked, transcript ABSENT in EVERY candidate root | `lost_session_frame` -- positive denial: the store is the authority (honest even under the 30-day GC, ledger A4) |
     /// | untracked, spawn/pipe/created failure (incl. no store root resolvable) | top-level `error` `CLAUDE_ATTACH_RESUME_FAILED` -- NEVER the lost frame |
     pub async fn handle_attach(&self, msg: FreshAgentAttach) {
@@ -1178,7 +1195,9 @@ impl FreshClaudeState {
 
     /// Task 10b's REBIND + ACK: if `durable` is in `cli_index` and its aliased session
     /// is LIVE, flip the session's envelope stamp to the durable id and broadcast the
-    /// idle snapshot ack (stamped with the durable). Returns `false` when the index has
+    /// snapshot ack (stamped with the durable) announcing the session's REAL tracked
+    /// status — never a hardcoded "idle" (which flipped panes idle mid-turn and left
+    /// dead-window completions stale-busy forever). Returns `false` when the index has
     /// no row or the row is stale (aliased session gone). The sessions map is never
     /// re-keyed (alias, don't move -- in-flight consumers hold the placeholder key;
     /// sends and kills resolve through `cli_index`).
@@ -1186,25 +1205,28 @@ impl FreshClaudeState {
         let Some(map_key) = self.cli_index.lock().await.get(durable).cloned() else {
             return false;
         };
-        let rebound = {
+        let rebound_status = {
             let guard = self.sessions.lock().await;
             match guard.get(&map_key) {
                 Some(session) => {
+                    // Alias, don't move: flip only the envelope stamp. The status the
+                    // ack speaks is the consumer's sdk.status fold — truth at ack time.
                     *session.broadcast_id.lock().expect("broadcast id lock") = durable.to_string();
-                    true
+                    Some(session.current_status())
                 }
-                None => false,
+                None => None,
             }
         };
-        if rebound {
-            self.broadcast(&status_snapshot_frame(
-                durable,
-                durable,
-                "idle",
-                session_type,
-            ));
-        }
-        rebound
+        let Some(status) = rebound_status else {
+            return false;
+        };
+        self.broadcast(&status_snapshot_frame(
+            durable,
+            durable,
+            &status,
+            session_type,
+        ));
+        true
     }
 
     /// The not-tracked resume (codex `ensure_session_resumable` analog, file-store
@@ -1319,6 +1341,9 @@ impl FreshClaudeState {
         // records nothing (no laundered blank row under the new id, V7/A10).
         let broadcast_id = Arc::new(std::sync::Mutex::new(msg.session_id.clone()));
         let pending = Arc::new(std::sync::Mutex::new(ClaudePending::default()));
+        // Freshly resumed session: the tracked status starts "idle" (truthful — no
+        // turn can be in flight before the client sends).
+        let last_status = Arc::new(std::sync::Mutex::new("idle".to_string()));
         let consumer = self.spawn_consumer(
             reader,
             msg.session_id.clone(),
@@ -1327,6 +1352,7 @@ impl FreshClaudeState {
             recovered,
             Arc::clone(&broadcast_id),
             Arc::clone(&pending),
+            Arc::clone(&last_status),
         );
         self.sessions.lock().await.insert(
             msg.session_id.clone(),
@@ -1339,6 +1365,7 @@ impl FreshClaudeState {
                 cli_session_id: Some(durable.to_string()),
                 broadcast_id,
                 pending,
+                last_status: Arc::clone(&last_status),
             },
         );
         self.cli_index
@@ -1367,10 +1394,13 @@ impl FreshClaudeState {
             }
         }
 
+        // Read the tracked status (identical to the hardcoded "idle" it replaces for
+        // a fresh resume — truthful by construction) rather than repeating a literal.
+        let last_announced = last_status.lock().expect("last status lock").clone();
         self.broadcast(&status_snapshot_frame(
             &msg.session_id,
             durable,
-            "idle",
+            &last_announced,
             &session_type,
         ));
         Ok(())
@@ -1410,6 +1440,9 @@ impl FreshClaudeState {
     /// `pending` (Task 2): the shared pending approval/question handle the consumer
     /// folds `sdk.permission.*`/`sdk.question.*` lines into BEFORE the normalize/
     /// broadcast step (so a respond racing the event never sees stale membership).
+    /// `last_status`: the shared last-announced-status handle the attach acks read;
+    /// the consumer folds every `sdk.status` line into it BEFORE the broadcast step
+    /// (so an ack racing a status event never understates the tracked status).
     #[allow(clippy::too_many_arguments)] // Session-scoped wiring handed to the detached consumer; four call sites.
     fn spawn_consumer(
         &self,
@@ -1420,6 +1453,7 @@ impl FreshClaudeState {
         settings: Option<crate::identity_sink::FreshAgentSettings>,
         broadcast_id: Arc<std::sync::Mutex<String>>,
         pending: Arc<std::sync::Mutex<ClaudePending>>,
+        last_status: Arc<std::sync::Mutex<String>>,
     ) -> tokio::task::JoinHandle<()> {
         let broadcast_tx = self.broadcast_tx.clone();
         let sessions = self.sessions.clone();
@@ -1439,6 +1473,14 @@ impl FreshClaudeState {
                 // normalize/broadcast step, so a respond racing the event never
                 // observes a stale membership check.
                 fold_pending_frame(&pending, &value);
+                // Fold the sidecar's announced status per session BEFORE the
+                // broadcast step: the attach-ack sites read this so a reconnect ack
+                // speaks the REAL last status instead of a hardcoded "idle".
+                if value.get("type").and_then(Value::as_str) == Some("sdk.status") {
+                    if let Some(status) = value.get("status").and_then(Value::as_str) {
+                        *last_status.lock().expect("last status lock") = status.to_string();
+                    }
+                }
                 // Restart-parity (plan §2.8 item 2): record the durable Claude UUID.
                 // The index insert is load-bearing; the session-field copy is
                 // best-effort (the map entry may not exist yet during create).
@@ -1831,9 +1873,10 @@ fn is_canonical_claude_uuid(s: &str) -> bool {
         })
 }
 
-/// The codex-shape idle status snapshot (`freshAgent.session.snapshot`) claude emits
-/// after a resume-on-attach: provider-agnostic client-side (`fresh-agent-ws.ts:196-206`),
-/// it un-wedges a BUSY pane and hands the durable UUID over via `timelineSessionId`.
+/// The codex-shape status snapshot (`freshAgent.session.snapshot`) claude emits as the
+/// attach ack (rebind + resume-on-attach arms): provider-agnostic client-side
+/// (`fresh-agent-ws.ts:196-206`), it settles the pane to the session's REAL tracked
+/// status and hands the durable UUID over via `timelineSessionId`.
 fn status_snapshot_frame(
     session_id: &str,
     timeline_session_id: &str,
@@ -2140,6 +2183,7 @@ pub(crate) mod tests {
                 cli_session_id: None,
                 broadcast_id: Arc::new(std::sync::Mutex::new(session_id.to_string())),
                 pending: Arc::new(std::sync::Mutex::new(ClaudePending::default())),
+                last_status: Arc::new(std::sync::Mutex::new("idle".to_string())),
             },
         );
     }
@@ -2443,6 +2487,98 @@ pub(crate) mod tests {
         );
     }
 
+    /// The rebind arm's ack must announce the session's REAL tracked status (the
+    /// stdout consumer's `sdk.status` fold), not a hardcoded `"idle"`: attaching to a
+    /// live session while a turn is running must not flip the pane to idle, and a
+    /// completion that landed in the reconnect dead window must be told truthfully by
+    /// the ack that rescues the pane. The arrangement drives a `running` status
+    /// through the REAL consumer fold (the fake sidecar's `__set_status__` hook), and
+    /// the fold is observed on the WIRE (the `freshAgent.status` broadcast) before the
+    /// attach, so the assertion races nothing.
+    #[tokio::test]
+    async fn attach_rebind_ack_stamps_the_tracked_live_status_not_hardcoded_idle() {
+        let _guard = CLAUDE_ENV_LOCK.lock().await;
+        let env = FakeClaudeSidecarEnv::install();
+        let (st, mut rx) = state_with_bus();
+
+        // A tracked live claude session (fake sidecar standing in for the Node one).
+        st.handle_create(dedup_create_msg("req-rebind-status")).await;
+        let created = await_claude_created(&mut rx, "req-rebind-status").await;
+        let session_id = created["sessionId"].as_str().unwrap().to_string();
+
+        // Alias a durable id at it (live: the consumer's sdk.session.init fold writes
+        // this row; here the test writes it directly).
+        let durable = "9c9c9c9c-9c9c-49c9-8c9c-9c9c9c9c9c9c";
+        st.cli_index
+            .lock()
+            .await
+            .insert(durable.to_string(), session_id.clone());
+
+        // Drive sdk.status { status: "running" } through the REAL stdout consumer fold,
+        // and wait until its broadcast is observable — the fold (which the ack reads)
+        // lands before that broadcast, so the attach below sees "running".
+        st.handle_send(send_msg(&session_id, "__set_status__:running"))
+            .await;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(15);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let raw = tokio::time::timeout(remaining, rx.recv())
+                .await
+                .expect(
+                    "the __set_status__:running sdk.status frame never reached the broadcast bus",
+                )
+                .expect("broadcast bus closed");
+            let frame: Value = serde_json::from_str(&raw).unwrap();
+            if frame["type"] == "freshAgent.event"
+                && frame["event"]["type"] == "freshAgent.status"
+                && frame["event"]["status"] == "running"
+            {
+                break;
+            }
+        }
+
+        // The reconnect rescue: attach addressing the durable id → the REBIND arm.
+        st.handle_attach(attach_msg_with_resume("late-attacher", durable))
+            .await;
+
+        let frame = await_frame_of_inner_type(&mut rx, "freshAgent.session.snapshot").await;
+        assert_eq!(frame["sessionId"], durable);
+        assert_eq!(
+            frame["event"]["status"], "running",
+            "the rebind ack must speak the session's tracked status, not a hardcoded idle: {frame}"
+        );
+        assert_eq!(frame["event"]["timelineSessionId"], durable);
+        drop(env);
+    }
+
+    /// Pins the DEFAULT: a freshly resumed session has folded no non-idle status, so
+    /// its resume-for-attach ack must still announce `"idle"`. Truth by construction
+    /// (the tracked status starts "idle"), not a hardcoded literal — a regression that
+    /// keeps the resume ack truthful must not be confused with the pre-fix literal.
+    #[tokio::test]
+    async fn attach_ack_stays_idle_for_a_freshly_resumed_session() {
+        let _guard = CLAUDE_ENV_LOCK.lock().await;
+        let env = FakeClaudeSidecarEnv::install();
+        let home = tempfile::tempdir().unwrap();
+        let durable = "abababab-abab-4bab-8bab-abababababab";
+        write_fake_transcript(home.path(), durable);
+        std::env::set_var("CLAUDE_CONFIG_DIR", home.path());
+
+        let (st, mut rx) = state_with_bus();
+        st.handle_attach(attach_msg_with_resume("client-fresh-resume", durable))
+            .await;
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+
+        let frame = await_frame_of_inner_type(&mut rx, "freshAgent.session.snapshot").await;
+        assert_eq!(frame["sessionId"], "client-fresh-resume");
+        assert_eq!(
+            frame["event"]["status"], "idle",
+            "a freshly resumed session's ack must announce idle (the tracked default): {frame}"
+        );
+        assert_eq!(frame["event"]["timelineSessionId"], durable);
+        drop(env);
+    }
+
     /// Ledger A15's failure case: the transcript's recorded cwd no longer exists on
     /// disk, so the resume request must carry the transcript's `.jsonl` PATH (the
     /// verified cli.js escape hatch bypassing slug scoping) instead of the bare UUID.
@@ -2697,10 +2833,11 @@ pub(crate) mod tests {
     /// `query.interrupt()` was actually invoked", mirroring the real sidecar's
     /// `handleInterrupt`); on `{"type":"shutdown"}` it exits. Task 2 arms: a magic send
     /// of `__raise_permission__` emits a canned `sdk.permission.request` (the canUseTool
-    /// stand-in — the fake parks nothing), and `permission.respond`/`question.respond`/
-    /// non-magic `send` frames append the full received line to
-    /// `FRESHELL_TEST_CLAUDE_RESPOND_LOG` (the assertion surface for the respond/compact
-    /// handlers' exact stdin frame shapes).
+    /// stand-in — the fake parks nothing), a magic send of `__set_status__:<status>`
+    /// emits a real `sdk.status` frame (the attach-ack status-arrangement hook), and
+    /// `permission.respond`/`question.respond`/non-magic `send` frames append the full
+    /// received line to `FRESHELL_TEST_CLAUDE_RESPOND_LOG` (the assertion surface for
+    /// the respond/compact handlers' exact stdin frame shapes).
     const FAKE_CLAUDE_SIDECAR_SOURCE: &str = r#"
 import fs from 'node:fs'
 import readline from 'node:readline'
@@ -2750,6 +2887,11 @@ rl.on('line', (line) => {
         blockedPath: null,
         decisionReason: null,
       }) + '\n')
+    } else if (msg.text.startsWith('__set_status__:')) {
+      // Reconnect-revive hook: emit a real sdk.status frame so a test can arrange a
+      // non-default tracked status through the REAL stdout consumer fold (the attach
+      // ack under test speaks it back).
+      process.stdout.write(JSON.stringify({ type: 'sdk.status', sessionId: msg.sessionId, status: msg.text.slice('__set_status__:'.length) }) + '\n')
     } else if (respondLog) {
       // Non-magic sends (e.g. `/compact …`) land in the respond log verbatim so
       // tests can assert the exact stdin frame shape the compact handler writes.
@@ -3219,6 +3361,7 @@ rl.on('line', (line) => {
                 cli_session_id: None,
                 broadcast_id: Arc::new(std::sync::Mutex::new(session_id.to_string())),
                 pending: Arc::new(std::sync::Mutex::new(pending)),
+                last_status: Arc::new(std::sync::Mutex::new("idle".to_string())),
             },
         );
     }
@@ -3654,6 +3797,7 @@ rl.on('line', (line) => {
             None,
             Arc::new(std::sync::Mutex::new("fold-session".to_string())),
             Arc::clone(&pending),
+            Arc::new(std::sync::Mutex::new("idle".to_string())),
         );
 
         // The replace-resend is the LAST scripted line: observing its input proves the

--- a/crates/freshell-freshagent/src/claude.rs
+++ b/crates/freshell-freshagent/src/claude.rs
@@ -211,15 +211,17 @@ struct ClaudeSession {
     broadcast_id: Arc<std::sync::Mutex<String>>,
     /// The folded pending approval/question set (Task 2) — see [`ClaudePending`].
     pending: Arc<std::sync::Mutex<ClaudePending>>,
-    /// Last status the sidecar announced for this session (the stdout consumer's
-    /// `sdk.status` fold). Read by the attach-ack sites so a reconnect ack tells the
-    /// truth instead of the hardcoded "idle" that used to wedge stale-busy/stale-idle
-    /// panes. Starts "idle" — a fresh/just-resumed session has announced nothing else.
+    /// The session's tracked status (the stdout consumer's fold: the reference
+    /// bridge's turn lifecycle — `running` on `sdk.assistant`, `idle` on every
+    /// `sdk.result` — plus the raw `sdk.status` wire values folded on top).
+    /// Read by the attach-ack sites so a reconnect ack tells the truth instead of
+    /// the hardcoded "idle" that used to wedge stale-busy/stale-idle panes.
+    /// Starts "idle" — a fresh/just-resumed session has announced nothing else.
     last_status: Arc<std::sync::Mutex<String>>,
 }
 
 impl ClaudeSession {
-    /// The last status the sidecar announced for this session (the stdout consumer's
+    /// The session's tracked status (the stdout consumer's turn-lifecycle +
     /// `sdk.status` fold) — the truth the attach acks speak.
     fn current_status(&self) -> String {
         self.last_status.lock().expect("last status lock").clone()
@@ -514,7 +516,7 @@ impl FreshClaudeState {
         // binding row at `sdk.session.init`.
         let broadcast_id = Arc::new(std::sync::Mutex::new(created.clone()));
         let pending = Arc::new(std::sync::Mutex::new(ClaudePending::default()));
-        // Fresh session: nothing announced yet; the consumer's sdk.status fold owns it.
+        // Fresh session: nothing announced yet; the consumer's status fold owns it.
         let last_status = Arc::new(std::sync::Mutex::new("idle".to_string()));
         let consumer = self.spawn_consumer(
             reader,
@@ -1050,7 +1052,7 @@ impl FreshClaudeState {
     /// |---|---|
     /// | tracked under `msg.session_id` | no-op -- NO frame (wire-shape parity, unchanged). Safe against dead sidecars ONLY because the consumer-exit eviction removes dead entries (ledger A9) |
     /// | untracked, no canonical durable id on the message | `lost_session_frame` (`INVALID_SESSION_ID`) -- unchanged fallback (also covers the verified A2 edge: a pane that never learned its UUID pre-kill attaches bare; lost -> client re-create is the designed, non-destructive outcome) |
-    /// | untracked, durable id already in `cli_index`, aliased session LIVE | REBIND + ACK (Task 10b): flip the live session's envelope stamp to the durable id and answer with the `freshAgent.session.snapshot` stamped with the durable and the session's TRACKED status (the consumer's sdk.status fold, never a hardcoded idle) -- the attaching client must observe success, never silence. The map is never re-keyed (alias, don't move) |
+    /// | untracked, durable id already in `cli_index`, aliased session LIVE | REBIND + ACK (Task 10b): flip the live session's envelope stamp to the durable id and answer with the `freshAgent.session.snapshot` stamped with the durable and the session's TRACKED status (the consumer's turn-lifecycle + sdk.status fold, never a hardcoded idle) -- the attaching client must observe success, never silence. The map is never re-keyed (alias, don't move) |
     /// | untracked, durable id in `cli_index` but aliased session GONE (stale row, eviction in flight) | fall through to the resume path below (the session is dead; resuming converges the client) |
     /// | untracked, transcript EXISTS (in ANY candidate root) | spawn sidecar and resume with the session's ORIGINAL cwd from `transcript_cwd` (ledger A15: the CLI's resume lookup is cwd-slug-scoped); if that cwd no longer exists, resume by the transcript's `.jsonl` PATH (verified cli.js escape hatch that bypasses slug scoping) with the attach cwd. Register under the CLIENT's `msg.session_id`, emit a `freshAgent.session.snapshot` whose `timelineSessionId` is the durable UUID -- NEVER a nanoid (the frozen client persists it unvalidated, ledger A14/N3) -- carrying the session's tracked status ("idle" for a fresh resume, by construction) |
     /// | untracked, transcript ABSENT in EVERY candidate root | `lost_session_frame` -- positive denial: the store is the authority (honest even under the 30-day GC, ledger A4) |
@@ -1210,7 +1212,9 @@ impl FreshClaudeState {
             match guard.get(&map_key) {
                 Some(session) => {
                     // Alias, don't move: flip only the envelope stamp. The status the
-                    // ack speaks is the consumer's sdk.status fold — truth at ack time.
+                    // ack speaks is the consumer's tracked-status fold — truth at
+                    // ack time (a completed turn settles it; a live compaction or
+                    // in-flight turn announces truthfully).
                     *session.broadcast_id.lock().expect("broadcast id lock") = durable.to_string();
                     Some(session.current_status())
                 }
@@ -1394,9 +1398,19 @@ impl FreshClaudeState {
             }
         }
 
-        // Read the tracked status (identical to the hardcoded "idle" it replaces for
-        // a fresh resume — truthful by construction) rather than repeating a literal.
-        let last_announced = last_status.lock().expect("last status lock").clone();
+        // Read the tracked status through the same `current_status()` helper the
+        // rebind arm uses (the session was registered above; the lease-revocation
+        // teardown already returned). Identical to the hardcoded "idle" it replaces
+        // for a fresh resume — truthful by construction. The None fallback covers a
+        // sidecar that died before this read (already EOF-evicted by its consumer):
+        // nothing was ever announced, so "idle" stays the truthful default.
+        let last_announced = self
+            .sessions
+            .lock()
+            .await
+            .get(&msg.session_id)
+            .map(ClaudeSession::current_status)
+            .unwrap_or_else(|| "idle".to_string());
         self.broadcast(&status_snapshot_frame(
             &msg.session_id,
             durable,
@@ -1440,9 +1454,13 @@ impl FreshClaudeState {
     /// `pending` (Task 2): the shared pending approval/question handle the consumer
     /// folds `sdk.permission.*`/`sdk.question.*` lines into BEFORE the normalize/
     /// broadcast step (so a respond racing the event never sees stale membership).
-    /// `last_status`: the shared last-announced-status handle the attach acks read;
-    /// the consumer folds every `sdk.status` line into it BEFORE the broadcast step
-    /// (so an ack racing a status event never understates the tracked status).
+    /// `last_status`: the shared tracked-status handle the attach acks read; the
+    /// consumer folds the turn lifecycle (`sdk.assistant` → "running", every
+    /// `sdk.result` → "idle" — the reference bridge's semantics) and the raw
+    /// `sdk.status` wire values on top into it BEFORE the broadcast step (so an
+    /// ack racing a status event never understates the tracked status). The
+    /// result-edge settle means a mid-turn "compacting" can never wedge the
+    /// tracker past the turn's completion.
     #[allow(clippy::too_many_arguments)] // Session-scoped wiring handed to the detached consumer; four call sites.
     fn spawn_consumer(
         &self,
@@ -1473,13 +1491,27 @@ impl FreshClaudeState {
                 // normalize/broadcast step, so a respond racing the event never
                 // observes a stale membership check.
                 fold_pending_frame(&pending, &value);
-                // Fold the sidecar's announced status per session BEFORE the
-                // broadcast step: the attach-ack sites read this so a reconnect ack
-                // speaks the REAL last status instead of a hardcoded "idle".
-                if value.get("type").and_then(Value::as_str) == Some("sdk.status") {
-                    if let Some(status) = value.get("status").and_then(Value::as_str) {
-                        *last_status.lock().expect("last status lock") = status.to_string();
+                // Fold the session's tracked status BEFORE the broadcast step, so an
+                // ack racing an event never understates it. Mirror the reference
+                // bridge's lifecycle (server/sdk-bridge.ts): sdk.assistant marks the
+                // turn "running" (:426), EVERY sdk.result settles it back to "idle"
+                // (:445) — so a mid-turn "compacting" can never wedge the tracker
+                // for the rest of the session's life — and the raw sdk.status wire
+                // value folds on top (:351-352 compacting announces truthfully
+                // mid-turn; the stream-end idle is a no-op after the last result).
+                match value.get("type").and_then(Value::as_str) {
+                    Some("sdk.assistant") => {
+                        *last_status.lock().expect("last status lock") = "running".to_string();
                     }
+                    Some("sdk.result") => {
+                        *last_status.lock().expect("last status lock") = "idle".to_string();
+                    }
+                    Some("sdk.status") => {
+                        if let Some(status) = value.get("status").and_then(Value::as_str) {
+                            *last_status.lock().expect("last status lock") = status.to_string();
+                        }
+                    }
+                    _ => {}
                 }
                 // Restart-parity (plan §2.8 item 2): record the durable Claude UUID.
                 // The index insert is load-bearing; the session-field copy is
@@ -2342,6 +2374,29 @@ pub(crate) mod tests {
         .unwrap_or_else(|_| panic!("freshAgent.event with inner type {inner_type} within budget"))
     }
 
+    /// Bounded drain until a `freshAgent.status` broadcast carrying `status` arrives.
+    /// The consumer folds the tracked status BEFORE it broadcasts the matching
+    /// wire frame, so observing this frame proves the fold the attach acks read
+    /// has landed — the arrangement races nothing.
+    async fn await_status_on_wire(
+        rx: &mut tokio::sync::broadcast::Receiver<String>,
+        status: &str,
+    ) {
+        tokio::time::timeout(std::time::Duration::from_secs(15), async {
+            loop {
+                let frame: Value = serde_json::from_str(&rx.recv().await.unwrap()).unwrap();
+                if frame["type"] == "freshAgent.event"
+                    && frame["event"]["type"] == "freshAgent.status"
+                    && frame["event"]["status"] == status
+                {
+                    return;
+                }
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("freshAgent.status{{status:{status}}} within budget"));
+    }
+
     /// Bounded drain until a TOP-LEVEL `error` ServerMessage arrives; returns its message.
     async fn await_top_level_error(rx: &mut tokio::sync::broadcast::Receiver<String>) -> String {
         tokio::time::timeout(std::time::Duration::from_secs(15), async {
@@ -2488,13 +2543,15 @@ pub(crate) mod tests {
     }
 
     /// The rebind arm's ack must announce the session's REAL tracked status (the
-    /// stdout consumer's `sdk.status` fold), not a hardcoded `"idle"`: attaching to a
-    /// live session while a turn is running must not flip the pane to idle, and a
-    /// completion that landed in the reconnect dead window must be told truthfully by
-    /// the ack that rescues the pane. The arrangement drives a `running` status
-    /// through the REAL consumer fold (the fake sidecar's `__set_status__` hook), and
-    /// the fold is observed on the WIRE (the `freshAgent.status` broadcast) before the
-    /// attach, so the assertion races nothing.
+    /// stdout consumer's status fold), not a hardcoded `"idle"`: attaching to a
+    /// live session mid-compaction must keep the pane truthfully busy instead of
+    /// flipping it to idle, and a completion that landed in the reconnect dead
+    /// window must be told truthfully by the ack that rescues the pane. The
+    /// arrangement drives a REAL wire value (`compacting` — one of the two
+    /// statuses the production sidecar actually announces, index.mjs:151-153)
+    /// through the REAL consumer fold (the fake sidecar's `__set_status__`
+    /// hook), and the fold is observed on the WIRE (the `freshAgent.status`
+    /// broadcast) before the attach, so the assertion races nothing.
     #[tokio::test]
     async fn attach_rebind_ack_stamps_the_tracked_live_status_not_hardcoded_idle() {
         let _guard = CLAUDE_ENV_LOCK.lock().await;
@@ -2514,28 +2571,12 @@ pub(crate) mod tests {
             .await
             .insert(durable.to_string(), session_id.clone());
 
-        // Drive sdk.status { status: "running" } through the REAL stdout consumer fold,
-        // and wait until its broadcast is observable — the fold (which the ack reads)
-        // lands before that broadcast, so the attach below sees "running".
-        st.handle_send(send_msg(&session_id, "__set_status__:running"))
+        // Drive sdk.status { status: "compacting" } through the REAL stdout consumer
+        // fold, and wait until its broadcast is observable — the fold (which the ack
+        // reads) lands before that broadcast, so the attach below sees "compacting".
+        st.handle_send(send_msg(&session_id, "__set_status__:compacting"))
             .await;
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(15);
-        loop {
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            let raw = tokio::time::timeout(remaining, rx.recv())
-                .await
-                .expect(
-                    "the __set_status__:running sdk.status frame never reached the broadcast bus",
-                )
-                .expect("broadcast bus closed");
-            let frame: Value = serde_json::from_str(&raw).unwrap();
-            if frame["type"] == "freshAgent.event"
-                && frame["event"]["type"] == "freshAgent.status"
-                && frame["event"]["status"] == "running"
-            {
-                break;
-            }
-        }
+        await_status_on_wire(&mut rx, "compacting").await;
 
         // The reconnect rescue: attach addressing the durable id → the REBIND arm.
         st.handle_attach(attach_msg_with_resume("late-attacher", durable))
@@ -2544,8 +2585,104 @@ pub(crate) mod tests {
         let frame = await_frame_of_inner_type(&mut rx, "freshAgent.session.snapshot").await;
         assert_eq!(frame["sessionId"], durable);
         assert_eq!(
-            frame["event"]["status"], "running",
+            frame["event"]["status"], "compacting",
             "the rebind ack must speak the session's tracked status, not a hardcoded idle: {frame}"
+        );
+        assert_eq!(frame["event"]["timelineSessionId"], durable);
+        drop(env);
+    }
+
+    /// A mid-turn `compacting` must NOT wedge the tracked status for the rest of
+    /// the session's life. The tracker's fold mirrors the reference bridge's
+    /// lifecycle (sdk-bridge.ts:445): EVERY `sdk.result` settles the status back
+    /// to `"idle"`, so once the compacted turn completes, the close-and-reopen
+    /// rescue ack announces `"idle"` — never a sticky `compacting` that leaves
+    /// the revived pane blue with user input queueing forever (the client's
+    /// flush gate runs only when `!isBusy`). Both transitions are driven through
+    /// the REAL consumer fold (fake-sidecar hooks) in the REAL value space, and
+    /// each fold is observed on the WIRE before the attach, so the assertion
+    /// races nothing.
+    #[tokio::test]
+    async fn attach_rebind_ack_settles_to_idle_once_the_compacted_turn_completes() {
+        let _guard = CLAUDE_ENV_LOCK.lock().await;
+        let env = FakeClaudeSidecarEnv::install();
+        let (st, mut rx) = state_with_bus();
+
+        // A tracked live claude session (fake sidecar standing in for the Node one).
+        st.handle_create(dedup_create_msg("req-settle-status")).await;
+        let created = await_claude_created(&mut rx, "req-settle-status").await;
+        let session_id = created["sessionId"].as_str().unwrap().to_string();
+
+        // Alias a durable id at it (as above: live the init fold writes this row).
+        let durable = "8b8b8b8b-8b8b-48b8-8b8b-8b8b8b8b8b8b";
+        st.cli_index
+            .lock()
+            .await
+            .insert(durable.to_string(), session_id.clone());
+
+        // The wedge repro: a turn compacts mid-flight → tracked status "compacting".
+        st.handle_send(send_msg(&session_id, "__set_status__:compacting"))
+            .await;
+        await_status_on_wire(&mut rx, "compacting").await;
+
+        // The compacted turn completes: sdk.result is the settle edge. Observing
+        // its broadcast proves the settle fold has landed.
+        st.handle_send(send_msg(&session_id, "__emit_result__")).await;
+        let _ = await_frame_of_inner_type(&mut rx, "freshAgent.result").await;
+
+        // The reconnect rescue AFTER the turn settled: the ack must speak "idle",
+        // never the pre-completion "compacting".
+        st.handle_attach(attach_msg_with_resume("late-attacher-settled", durable))
+            .await;
+
+        let frame = await_frame_of_inner_type(&mut rx, "freshAgent.session.snapshot").await;
+        assert_eq!(frame["sessionId"], durable);
+        assert_eq!(
+            frame["event"]["status"], "idle",
+            "a completed turn must settle the tracked status (no sticky compacting): {frame}"
+        );
+        assert_eq!(frame["event"]["timelineSessionId"], durable);
+        drop(env);
+    }
+
+    /// Attaching while a turn is genuinely in flight must ack `"running"` — the
+    /// reference bridge's per-turn lifecycle edge (sdk-bridge.ts:426 — the real
+    /// sidecar announces NO `sdk.status: running`, busy is derived from stream
+    /// deltas, so this arm is the only way the tracker ever speaks "running").
+    /// Drives a REAL `sdk.assistant` frame through the fold and observes its
+    /// broadcast before the attach, so the assertion races nothing.
+    #[tokio::test]
+    async fn attach_rebind_ack_speaks_running_while_a_turn_is_in_flight() {
+        let _guard = CLAUDE_ENV_LOCK.lock().await;
+        let env = FakeClaudeSidecarEnv::install();
+        let (st, mut rx) = state_with_bus();
+
+        // A tracked live claude session (fake sidecar standing in for the Node one).
+        st.handle_create(dedup_create_msg("req-running-status")).await;
+        let created = await_claude_created(&mut rx, "req-running-status").await;
+        let session_id = created["sessionId"].as_str().unwrap().to_string();
+
+        // Alias a durable id at it (as above: live the init fold writes this row).
+        let durable = "7a7a7a7a-7a7a-47a7-8a7a-7a7a7a7a7a7a";
+        st.cli_index
+            .lock()
+            .await
+            .insert(durable.to_string(), session_id.clone());
+
+        // A turn starts: sdk.assistant is the running edge. Observing its
+        // broadcast proves the running fold has landed.
+        st.handle_send(send_msg(&session_id, "__emit_assistant__")).await;
+        let _ = await_frame_of_inner_type(&mut rx, "freshAgent.assistant").await;
+
+        // The reconnect rescue mid-turn: the ack must speak "running".
+        st.handle_attach(attach_msg_with_resume("late-attacher-midturn", durable))
+            .await;
+
+        let frame = await_frame_of_inner_type(&mut rx, "freshAgent.session.snapshot").await;
+        assert_eq!(frame["sessionId"], durable);
+        assert_eq!(
+            frame["event"]["status"], "running",
+            "the rebind ack must speak \"running\" while a turn is in flight: {frame}"
         );
         assert_eq!(frame["event"]["timelineSessionId"], durable);
         drop(env);
@@ -2834,7 +2971,10 @@ pub(crate) mod tests {
     /// `handleInterrupt`); on `{"type":"shutdown"}` it exits. Task 2 arms: a magic send
     /// of `__raise_permission__` emits a canned `sdk.permission.request` (the canUseTool
     /// stand-in — the fake parks nothing), a magic send of `__set_status__:<status>`
-    /// emits a real `sdk.status` frame (the attach-ack status-arrangement hook), and
+    /// emits a real `sdk.status` frame (the attach-ack status-arrangement hook),
+    /// `__emit_assistant__` emits a real `sdk.assistant` frame (a turn's RUNNING edge)
+    /// and `__emit_result__` a real `sdk.result` frame (a completed turn's SETTLE edge
+    /// — the real sidecar emits it on every SDK result whatever the subtype), and
     /// `permission.respond`/`question.respond`/non-magic `send` frames append the full
     /// received line to `FRESHELL_TEST_CLAUDE_RESPOND_LOG` (the assertion surface for
     /// the respond/compact handlers' exact stdin frame shapes).
@@ -2892,6 +3032,14 @@ rl.on('line', (line) => {
       // non-default tracked status through the REAL stdout consumer fold (the attach
       // ack under test speaks it back).
       process.stdout.write(JSON.stringify({ type: 'sdk.status', sessionId: msg.sessionId, status: msg.text.slice('__set_status__:'.length) }) + '\n')
+    } else if (msg.text === '__emit_assistant__') {
+      // Reconnect-revive hook: emit a real sdk.assistant frame (the real wire shape —
+      // index.mjs:165) so a test can drive the tracker's turn-start ("running") fold.
+      process.stdout.write(JSON.stringify({ type: 'sdk.assistant', sessionId: msg.sessionId, content: [{ type: 'text', text: 'part' }], model: 'fake-model' }) + '\n')
+    } else if (msg.text === '__emit_result__') {
+      // Reconnect-revive hook: emit a real sdk.result frame (the real wire shape —
+      // index.mjs:177) so a test can drive the tracker's turn-complete settle fold.
+      process.stdout.write(JSON.stringify({ type: 'sdk.result', sessionId: msg.sessionId, result: 'success', durationMs: 1, costUsd: 0, usage: {} }) + '\n')
     } else if (respondLog) {
       // Non-magic sends (e.g. `/compact …`) land in the respond log verbatim so
       // tests can assert the exact stdin frame shape the compact handler writes.

--- a/crates/freshell-freshagent/src/claude.rs
+++ b/crates/freshell-freshagent/src/claude.rs
@@ -1431,6 +1431,7 @@ impl FreshClaudeState {
             retry_after_ms: None,
             terminal_exit_code: None,
             terminal_id: None,
+            live_terminal_id: None,
         }));
     }
 

--- a/crates/freshell-freshagent/src/claude.rs
+++ b/crates/freshell-freshagent/src/claude.rs
@@ -2379,10 +2379,7 @@ pub(crate) mod tests {
     /// The consumer folds the tracked status BEFORE it broadcasts the matching
     /// wire frame, so observing this frame proves the fold the attach acks read
     /// has landed — the arrangement races nothing.
-    async fn await_status_on_wire(
-        rx: &mut tokio::sync::broadcast::Receiver<String>,
-        status: &str,
-    ) {
+    async fn await_status_on_wire(rx: &mut tokio::sync::broadcast::Receiver<String>, status: &str) {
         tokio::time::timeout(std::time::Duration::from_secs(15), async {
             loop {
                 let frame: Value = serde_json::from_str(&rx.recv().await.unwrap()).unwrap();
@@ -2560,7 +2557,8 @@ pub(crate) mod tests {
         let (st, mut rx) = state_with_bus();
 
         // A tracked live claude session (fake sidecar standing in for the Node one).
-        st.handle_create(dedup_create_msg("req-rebind-status")).await;
+        st.handle_create(dedup_create_msg("req-rebind-status"))
+            .await;
         let created = await_claude_created(&mut rx, "req-rebind-status").await;
         let session_id = created["sessionId"].as_str().unwrap().to_string();
 
@@ -2610,7 +2608,8 @@ pub(crate) mod tests {
         let (st, mut rx) = state_with_bus();
 
         // A tracked live claude session (fake sidecar standing in for the Node one).
-        st.handle_create(dedup_create_msg("req-settle-status")).await;
+        st.handle_create(dedup_create_msg("req-settle-status"))
+            .await;
         let created = await_claude_created(&mut rx, "req-settle-status").await;
         let session_id = created["sessionId"].as_str().unwrap().to_string();
 
@@ -2628,7 +2627,8 @@ pub(crate) mod tests {
 
         // The compacted turn completes: sdk.result is the settle edge. Observing
         // its broadcast proves the settle fold has landed.
-        st.handle_send(send_msg(&session_id, "__emit_result__")).await;
+        st.handle_send(send_msg(&session_id, "__emit_result__"))
+            .await;
         let _ = await_frame_of_inner_type(&mut rx, "freshAgent.result").await;
 
         // The reconnect rescue AFTER the turn settled: the ack must speak "idle",
@@ -2659,7 +2659,8 @@ pub(crate) mod tests {
         let (st, mut rx) = state_with_bus();
 
         // A tracked live claude session (fake sidecar standing in for the Node one).
-        st.handle_create(dedup_create_msg("req-running-status")).await;
+        st.handle_create(dedup_create_msg("req-running-status"))
+            .await;
         let created = await_claude_created(&mut rx, "req-running-status").await;
         let session_id = created["sessionId"].as_str().unwrap().to_string();
 
@@ -2672,7 +2673,8 @@ pub(crate) mod tests {
 
         // A turn starts: sdk.assistant is the running edge. Observing its
         // broadcast proves the running fold has landed.
-        st.handle_send(send_msg(&session_id, "__emit_assistant__")).await;
+        st.handle_send(send_msg(&session_id, "__emit_assistant__"))
+            .await;
         let _ = await_frame_of_inner_type(&mut rx, "freshAgent.assistant").await;
 
         // The reconnect rescue mid-turn: the ack must speak "running".

--- a/crates/freshell-freshagent/src/codex.rs
+++ b/crates/freshell-freshagent/src/codex.rs
@@ -1200,6 +1200,7 @@ impl FreshCodexState {
             retry_after_ms: None,
             terminal_exit_code: None,
             terminal_id: None,
+            live_terminal_id: None,
         }));
     }
 

--- a/crates/freshell-freshagent/src/opencode_ws.rs
+++ b/crates/freshell-freshagent/src/opencode_ws.rs
@@ -715,18 +715,7 @@ impl FreshOpencodeState {
 
             // `freshAgent.session.materialized` (ws-handler.ts:3477-3484): placeholder ->
             // durable, emitted EXACTLY ONCE (a later send never re-enters this branch).
-            self.broadcast(&ServerMessage::FreshAgentSessionMaterialized(
-                FreshAgentSessionMaterialized {
-                    previous_session_id: session.placeholder_id.clone(),
-                    provider: PROVIDER.to_string(),
-                    session_id: durable_id.clone(),
-                    session_type: SESSION_TYPE.to_string(),
-                    session_ref: Some(SessionLocator {
-                        provider: PROVIDER.to_string(),
-                        session_id: durable_id.clone(),
-                    }),
-                },
-            ));
+            self.broadcast(&materialized_frame(&session.placeholder_id, &durable_id));
 
             // PR-3: `bindServeStream(state)` (adapter.ts:349) -- start the persistent
             // serve-SSE bridge ONCE, right after materialization. A later send never
@@ -1369,7 +1358,7 @@ impl FreshOpencodeState {
             },
         };
 
-        let (status_session_id, running) = {
+        let (status_session_id, running, real_session_id) = {
             let mut session = session_arc.lock().await;
 
             // Ensure the serve-SSE bridge is running (restart it if it died) -- only
@@ -1400,8 +1389,19 @@ impl FreshOpencodeState {
                 .as_ref()
                 .map(|t| !t.is_finished())
                 .unwrap_or(false);
-            (status_session_id, running)
+            (status_session_id, running, session.real_session_id.clone())
         };
+
+        // Attach addressed by the PLACEHOLDER id of an already-materialized session:
+        // the requesting pane cannot correlate frames stamped with the real ses_* id
+        // (locatorMatchesPane), so its snapshot fetch would 404 into a false
+        // restore-error. Re-key it first via the same wire event the send path uses
+        // (materialize-on-send) -- the client fold updates slice AND pane content.
+        if let Some(real_id) = real_session_id.as_ref() {
+            if real_id != &msg.session_id {
+                self.broadcast(&materialized_frame(&msg.session_id, real_id));
+            }
+        }
 
         let status = if running { "running" } else { "idle" };
         self.broadcast(&event_frame(
@@ -1752,6 +1752,23 @@ fn settle_turn_outcome(
         };
         fresh_agent.broadcast(&event_frame(real_id, turn_complete_event(real_id, at)));
     }
+}
+
+/// `freshAgent.session.materialized` (ws-handler.ts:3477-3484): placeholder -> durable
+/// re-key frame. Shared by the materialize-on-send path and the tracked attach arm
+/// (Task 5: re-key a placeholder-addressed pane BEFORE its real-id-stamped ack
+/// snapshot, so the pane can correlate the ack it is about to receive).
+fn materialized_frame(previous_session_id: &str, real_id: &str) -> ServerMessage {
+    ServerMessage::FreshAgentSessionMaterialized(FreshAgentSessionMaterialized {
+        previous_session_id: previous_session_id.to_string(),
+        provider: PROVIDER.to_string(),
+        session_id: real_id.to_string(),
+        session_type: SESSION_TYPE.to_string(),
+        session_ref: Some(SessionLocator {
+            provider: PROVIDER.to_string(),
+            session_id: real_id.to_string(),
+        }),
+    })
 }
 
 /// The `freshAgent.error{code:'INVALID_SESSION_ID'}` shape (`sdk-events.ts:37`) the client
@@ -2682,6 +2699,105 @@ mod tests {
             .await
             .unwrap_or_else(|_| panic!("no snapshot frame observed for {real_id}"));
         assert_eq!(snapshot["event"]["status"], "idle");
+    }
+
+    /// Task 5 (reconnect-revive): a pane restored from the persisted layout may still be
+    /// addressed by the PLACEHOLDER id of an already-materialized session (it missed the
+    /// original materialized frame while disconnected). Its tracked `freshAgent.attach`
+    /// must re-key it FIRST via `freshAgent.session.materialized` — otherwise the ack
+    /// snapshot (stamped with the real `ses_*` id per the `real ?? placeholder` rule)
+    /// fails `locatorMatchesPane` and the pane's next snapshot GET 404s into a false
+    /// `durable_artifact_missing` against a live session.
+    #[tokio::test]
+    async fn attach_placeholder_addressed_session_emits_materialized_first() {
+        let (st, mut rx) = state_with_status_poll_and_receiver(1).await;
+
+        st.handle_create(create_msg("req-attach-ph")).await;
+        let placeholder = "freshopencode-req-attach-ph";
+        st.handle_send(send_msg(placeholder, "hello")).await;
+        let real_id = {
+            let guard = st.sessions.lock().await;
+            let session_arc = guard.get(placeholder).cloned().expect("session exists");
+            let s = session_arc.lock().await;
+            s.real_session_id.clone().expect("materialized after send")
+        };
+
+        // Same settle-wait as `attach_known_materialized_session_emits_idle_snapshot`:
+        // the ack snapshot's `status` must not race the detached turn task.
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let done = {
+                    let guard = st.sessions.lock().await;
+                    let session_arc = guard.get(&real_id).cloned().expect("session exists");
+                    let s = session_arc.lock().await;
+                    s.turn_task
+                        .as_ref()
+                        .map(|t| t.is_finished())
+                        .unwrap_or(true)
+                };
+                if done {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the turn task finishes within the budget");
+
+        // Drain every pre-attach frame (created / materialized-on-send / status / turn
+        // frames) so what is collected below is exactly what THIS attach emits; the
+        // awaited `handle_attach` queues all of its frames before it returns.
+        while rx.try_recv().is_ok() {}
+
+        st.handle_attach(attach_msg(placeholder)).await;
+        let mut frames: Vec<serde_json::Value> = Vec::new();
+        while let Ok(raw) = rx.try_recv() {
+            frames.push(serde_json::from_str(&raw).unwrap());
+        }
+
+        let materialized_idx = frames
+            .iter()
+            .position(|f| f["type"] == "freshAgent.session.materialized")
+            .expect("a placeholder-addressed attach must emit the materialized re-key");
+        let materialized = &frames[materialized_idx];
+        assert_eq!(materialized["previousSessionId"], placeholder);
+        assert_eq!(materialized["sessionId"], real_id);
+        assert_eq!(materialized["provider"], "opencode");
+        assert_eq!(materialized["sessionType"], "freshopencode");
+        assert_eq!(materialized["sessionRef"]["sessionId"], real_id);
+        assert_eq!(materialized["sessionRef"]["provider"], "opencode");
+
+        let snapshot_idx = frames
+            .iter()
+            .position(|f| {
+                f["event"]["type"] == "freshAgent.session.snapshot" && f["sessionId"] == real_id
+            })
+            .expect("the ack snapshot is still emitted");
+        assert!(
+            materialized_idx < snapshot_idx,
+            "the re-key must precede the real-id-stamped snapshot: {frames:?}"
+        );
+
+        // Regression guard (identity already matches): an attach addressed by the
+        // REAL id must NOT re-emit the materialized frame — only the snapshot.
+        while rx.try_recv().is_ok() {}
+        st.handle_attach(attach_msg(&real_id)).await;
+        let mut saw_materialized = false;
+        let mut saw_snapshot = false;
+        while let Ok(raw) = rx.try_recv() {
+            let frame: serde_json::Value = serde_json::from_str(&raw).unwrap();
+            if frame["type"] == "freshAgent.session.materialized" {
+                saw_materialized = true;
+            }
+            if frame["event"]["type"] == "freshAgent.session.snapshot" {
+                saw_snapshot = true;
+            }
+        }
+        assert!(
+            !saw_materialized,
+            "an attach addressed by the real id must not spam the materialized frame"
+        );
+        assert!(saw_snapshot, "the real-id attach still answers with a snapshot");
     }
 
     #[tokio::test]

--- a/crates/freshell-freshagent/src/opencode_ws.rs
+++ b/crates/freshell-freshagent/src/opencode_ws.rs
@@ -1754,7 +1754,8 @@ fn settle_turn_outcome(
     }
 }
 
-/// `freshAgent.session.materialized` (ws-handler.ts:3477-3484): placeholder -> durable
+/// `freshAgent.session.materialized` (legacy reference: server/ws-handler.ts's
+/// emission of the same event; line numbers drift — cite by name): placeholder -> durable
 /// re-key frame. Shared by the materialize-on-send path and the tracked attach arm
 /// (Task 5: re-key a placeholder-addressed pane BEFORE its real-id-stamped ack
 /// snapshot, so the pane can correlate the ack it is about to receive).

--- a/crates/freshell-freshagent/src/opencode_ws.rs
+++ b/crates/freshell-freshagent/src/opencode_ws.rs
@@ -363,6 +363,7 @@ impl FreshOpencodeState {
             retry_after_ms: None,
             terminal_exit_code: None,
             terminal_id: None,
+            live_terminal_id: None,
         }));
     }
 

--- a/crates/freshell-freshagent/src/opencode_ws.rs
+++ b/crates/freshell-freshagent/src/opencode_ws.rs
@@ -2799,7 +2799,10 @@ mod tests {
             !saw_materialized,
             "an attach addressed by the real id must not spam the materialized frame"
         );
-        assert!(saw_snapshot, "the real-id attach still answers with a snapshot");
+        assert!(
+            saw_snapshot,
+            "the real-id attach still answers with a snapshot"
+        );
     }
 
     #[tokio::test]

--- a/crates/freshell-freshagent/src/terminal_tabs.rs
+++ b/crates/freshell-freshagent/src/terminal_tabs.rs
@@ -34,7 +34,8 @@ use std::collections::HashSet;
 
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
@@ -601,6 +602,26 @@ fn validate_rest_resume(
             }
         }
     }
+}
+
+/// The D7/D8 409 refusal envelope (reconnect-revive Task 7): the exact
+/// `fail_json_code` shape plus, when the refusal can name a still-running
+/// terminal, the additive `liveTerminalId` a caller reattaches to instead of
+/// dead-ending on the message. The envelope and its message text stay
+/// byte-identical to every other RESTORE_UNAVAILABLE refusal ("still running
+/// on the server." — client regexes and muscle memory depend on it); all
+/// novelty rides the additive field, and `live_terminal_id: None` keeps the
+/// body byte-identical to the pre-feature shape (frozen-client parity).
+fn fail_json_restore_unavailable(live_sid: &str, live_terminal_id: Option<&str>) -> Response {
+    let mut body = json!({
+        "status": "error",
+        "code": "RESTORE_UNAVAILABLE",
+        "message": format!("Session {live_sid} is still running on the server."),
+    });
+    if let Some(tid) = live_terminal_id {
+        body["liveTerminalId"] = json!(tid);
+    }
+    (StatusCode::CONFLICT, Json(body)).into_response()
 }
 
 /// The successful result of [`spawn_terminal_pane`]: the `paneContent` JSON + the
@@ -1216,9 +1237,11 @@ pub(crate) async fn spawn_terminal_pane(
         });
     let mut session_ref_lease: Option<RestSessionRefLease> = None;
     if let Some(live_sid) = guard_locator.as_ref().map(|r| r.session_id.as_str()) {
-        if registry
+        // Reconnect-revive Task 7: every refusal that CAN name a live terminal
+        // carries its id (`liveTerminalId`) so the caller can reattach instead
+        // of dead-ending. The envelope and message text stay byte-identical.
+        if let Some(owner_terminal_id) = registry
             .live_session_owner(state.session_identity.as_deref(), &mode, live_sid)
-            .is_some()
         {
             tracing::warn!(
                 target: "freshell_freshagent::terminal_tabs",
@@ -1227,10 +1250,9 @@ pub(crate) async fn spawn_terminal_pane(
                 pane_id = %pane_id,
                 "spawn_refused: a Running terminal already owns this session (D7 live-guard, REST rung)"
             );
-            return Err(fail_json_code(
-                StatusCode::CONFLICT,
-                "RESTORE_UNAVAILABLE",
-                format!("Session {live_sid} is still running on the server."),
+            return Err(fail_json_restore_unavailable(
+                live_sid,
+                Some(&owner_terminal_id),
             ));
         }
 
@@ -1259,14 +1281,25 @@ pub(crate) async fn spawn_terminal_pane(
                     create_request_id.clone(),
                 ));
             }
-            // Conservative v1 (Design Decision 6): every non-Acquired arm
-            // answers the same 409 envelope. Held = a claim is in flight;
-            // BoundElsewhere = a live winner exists (D7's own answer);
-            // ExpiredNeedsKill = crashed holder -- no kill-and-adopt logic on
-            // REST, the lease TTL is the backstop.
-            SessionRefClaim::Held { .. }
-            | SessionRefClaim::BoundElsewhere { .. }
-            | SessionRefClaim::ExpiredNeedsKill { .. } => {
+            // Conservative v1 (Design Decision 6): Held/ExpiredNeedsKill answer
+            // the nameless 409 envelope (a claim in flight / a crashed holder
+            // has no live terminal to name). BoundElsewhere = a live winner
+            // exists (D7's own answer): carry its terminal id too, so the
+            // claim-race refusal is equally attachable (fresh-eyes F5).
+            SessionRefClaim::BoundElsewhere { terminal_id } => {
+                tracing::warn!(
+                    target: "freshell_freshagent::terminal_tabs",
+                    mode = %mode,
+                    session_id = %live_sid,
+                    pane_id = %pane_id,
+                    "spawn_refused: sessionRef already bound to a live terminal (D8, REST rung)"
+                );
+                return Err(fail_json_restore_unavailable(
+                    live_sid,
+                    Some(&terminal_id),
+                ));
+            }
+            SessionRefClaim::Held { .. } | SessionRefClaim::ExpiredNeedsKill { .. } => {
                 tracing::warn!(
                     target: "freshell_freshagent::terminal_tabs",
                     mode = %mode,
@@ -1274,11 +1307,7 @@ pub(crate) async fn spawn_terminal_pane(
                     pane_id = %pane_id,
                     "spawn_refused: sessionRef lease unavailable (D8, REST rung)"
                 );
-                return Err(fail_json_code(
-                    StatusCode::CONFLICT,
-                    "RESTORE_UNAVAILABLE",
-                    format!("Session {live_sid} is still running on the server."),
-                ));
+                return Err(fail_json_restore_unavailable(live_sid, None));
             }
         }
     }
@@ -4831,6 +4860,15 @@ mod tests {
             msg.contains(LIVE_SESSION),
             "message must name the live session: {msg}"
         );
+        // Reconnect-revive Task 7: the refusal must NAME the live owner
+        // terminal so a caller (client reattach fold, CLI, MCP) can revive the
+        // still-running session instead of dead-ending. Additive field; the
+        // message text itself stays byte-identical.
+        assert_eq!(
+            body["liveTerminalId"],
+            json!("t-live-owner"),
+            "the 409 must carry the still-running owner's terminal id: {body}"
+        );
         // No duplicate spawn: only the forged owner exists.
         assert_eq!(
             registry.identity_probe_rows().len(),
@@ -4911,6 +4949,13 @@ mod tests {
 
         assert_eq!(status, StatusCode::CONFLICT, "{body}");
         assert_eq!(body["code"], json!("RESTORE_UNAVAILABLE"), "{body}");
+        // Reconnect-revive Task 7: the owner comes from the identity-store arm
+        // of the D7 join, but the refusal names it just the same.
+        assert_eq!(
+            body["liveTerminalId"],
+            json!("t-adopted"),
+            "the 409 must carry the identity-arm owner's terminal id: {body}"
+        );
 
         registry.kill("t-adopted");
     }
@@ -5971,6 +6016,63 @@ mod tests {
         );
 
         registry.kill("t-legacy-live-owner");
+    }
+
+    /// Reconnect-revive Task 7 (fresh-eyes F5): the D8 `BoundElsewhere` arm
+    /// (claim race: a completed lease binding already points at the winner,
+    /// so D7's live-row join legitimately sees nothing) must name the claim's
+    /// terminal id too, making the race refusal equally attachable.
+    #[tokio::test]
+    async fn rest_create_resume_handle_race_bound_elsewhere_409_names_the_live_terminal() {
+        let argv_file = unique_argv_file("d8-bound-elsewhere-live-terminal-id");
+        let state = state_with_registry()
+            .with_cli_commands(Arc::new(vec![recording_cli_spec("claude", &argv_file)]));
+        let registry = state.terminal_registry.clone().unwrap();
+        let rows_before = registry.identity_probe_rows().len();
+
+        let locator = SessionLocator {
+            provider: "claude".into(),
+            session_id: LIVE_SESSION.into(),
+        };
+        // A winner completed its lease into a sessionRef->terminal binding.
+        // The winner's registry ROW is not visible to this door (the
+        // claim-race window: bound but not yet directory-registered here), so
+        // D7's live-owner join passes and the refusal comes from the binding.
+        assert!(matches!(
+            registry.claim_session_ref(
+                &locator,
+                "winner-create",
+                registry.new_connection_id(),
+                test_now_ms()
+            ),
+            SessionRefClaim::Acquired
+        ));
+        assert!(registry.complete_session_ref_claim(&locator, "winner-create", "t-claim-winner"));
+
+        let (status, body) = post(
+            app(state),
+            "/api/tabs",
+            json!({
+                "mode": "claude",
+                "cwd": std::env::temp_dir().to_string_lossy(),
+                "sessionRef": { "provider": "claude", "sessionId": LIVE_SESSION },
+            }),
+            true,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT, "{body}");
+        assert_eq!(body["code"], json!("RESTORE_UNAVAILABLE"), "{body}");
+        assert_eq!(
+            body["liveTerminalId"],
+            json!("t-claim-winner"),
+            "the claim-race refusal names the bound winner's terminal id: {body}"
+        );
+        assert_eq!(
+            registry.identity_probe_rows().len(),
+            rows_before,
+            "no duplicate spawn"
+        );
     }
 
     #[tokio::test]

--- a/crates/freshell-freshagent/src/terminal_tabs.rs
+++ b/crates/freshell-freshagent/src/terminal_tabs.rs
@@ -1240,8 +1240,8 @@ pub(crate) async fn spawn_terminal_pane(
         // Reconnect-revive Task 7: every refusal that CAN name a live terminal
         // carries its id (`liveTerminalId`) so the caller can reattach instead
         // of dead-ending. The envelope and message text stay byte-identical.
-        if let Some(owner_terminal_id) = registry
-            .live_session_owner(state.session_identity.as_deref(), &mode, live_sid)
+        if let Some(owner_terminal_id) =
+            registry.live_session_owner(state.session_identity.as_deref(), &mode, live_sid)
         {
             tracing::warn!(
                 target: "freshell_freshagent::terminal_tabs",
@@ -1294,10 +1294,7 @@ pub(crate) async fn spawn_terminal_pane(
                     pane_id = %pane_id,
                     "spawn_refused: sessionRef already bound to a live terminal (D8, REST rung)"
                 );
-                return Err(fail_json_restore_unavailable(
-                    live_sid,
-                    Some(&terminal_id),
-                ));
+                return Err(fail_json_restore_unavailable(live_sid, Some(&terminal_id)));
             }
             SessionRefClaim::Held { .. } | SessionRefClaim::ExpiredNeedsKill { .. } => {
                 tracing::warn!(

--- a/crates/freshell-protocol/src/common.rs
+++ b/crates/freshell-protocol/src/common.rs
@@ -99,6 +99,12 @@ pub enum ErrorCode {
     /// connection. The loser retries after the frame's `retryAfterMs` hint —
     /// by then it either adopts the winner's terminal or wins the next claim.
     SessionReserved,
+    /// pane.reconcile.request arrived on a connection that did not negotiate
+    /// paneReconcileV1: terminal for that request (the client falls back to the
+    /// legacy inventory census). Never emitted to pre-reconcile clients — they
+    /// never send the request.
+    #[serde(rename = "RECONCILE_NOT_NEGOTIATED")]
+    ReconcileNotNegotiated,
 }
 
 /// The frozen sessionRef-naming refusal text for the legacy `resumeSessionId`

--- a/crates/freshell-protocol/src/server_messages.rs
+++ b/crates/freshell-protocol/src/server_messages.rs
@@ -537,6 +537,11 @@ pub struct ErrorMsg {
     pub terminal_exit_code: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub terminal_id: Option<String>,
+    /// D7 (`RESTORE_UNAVAILABLE` only): the live terminal that owns the refused
+    /// session, so the client can reattach instead of dead-ending. Additive and
+    /// omitted everywhere else.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub live_terminal_id: Option<String>,
 }
 
 // --- extension.* ------------------------------------------------------------

--- a/crates/freshell-ws/src/create_dedupe.rs
+++ b/crates/freshell-ws/src/create_dedupe.rs
@@ -139,6 +139,7 @@ fn waiter_error(request_id: &str) -> ServerMessage {
         retry_after_ms: None,
         terminal_exit_code: None,
         terminal_id: None,
+        live_terminal_id: None,
     })
 }
 

--- a/crates/freshell-ws/src/lib.rs
+++ b/crates/freshell-ws/src/lib.rs
@@ -852,6 +852,7 @@ async fn send_error(
         retry_after_ms: None,
         terminal_exit_code: None,
         terminal_id: None,
+        live_terminal_id: None,
     });
     match serde_json::to_string(&msg) {
         Ok(json) => socket.send(Message::Text(json.into())).await,

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -6775,8 +6775,9 @@ mod pane_reconcile_gate_tests {
     /// client — no mocked sink. The upgrade handler parks forever so the
     /// socket stays open for the whole assertion window; the listener task
     /// dies with the test runtime.
-    type TestClient =
-        tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+    type TestClient = tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >;
 
     async fn loopback_sink_and_client() -> (WsSink, TestClient) {
         let (sink_tx, sink_rx) = tokio::sync::oneshot::channel::<WsSink>();
@@ -6902,7 +6903,10 @@ mod pane_reconcile_gate_tests {
             &create_cancel_rx,
         )
         .await;
-        assert!(keep_open, "the refusal must answer, not tear the connection down");
+        assert!(
+            keep_open,
+            "the refusal must answer, not tear the connection down"
+        );
 
         // Health marker behind the request: one dispatch loop, strictly
         // ordered, so on the OLD accept-and-strip path the FIRST frame back

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -680,6 +680,7 @@ async fn handle_client_text(
                     retry_after_ms: None,
                     terminal_exit_code: None,
                     terminal_id: None,
+                    live_terminal_id: None,
                 });
                 return send(ws_tx, &reply).await;
             }
@@ -1255,6 +1256,7 @@ async fn handle_client_text(
                     retry_after_ms: None,
                     terminal_exit_code: None,
                     terminal_id: None,
+                    live_terminal_id: None,
                 }),
             )
             .await;
@@ -1732,6 +1734,7 @@ async fn send_session_reserved(
         retry_after_ms: Some(retry_after_ms),
         terminal_exit_code: None,
         terminal_id: None,
+        live_terminal_id: None,
     });
     out.send(&msg).await
 }
@@ -2596,10 +2599,13 @@ pub(crate) async fn handle_create(
         // #540 (ks38): the identity-owner + Running-row join is now the shared
         // `TerminalRegistry::live_session_owner` helper (the same join the REST
         // resume paths consult), replacing the former inline two-arm check.
-        let registry_row_live = state
+        // Reconnect-revive Task 7: keep the owner id — the refusal NAMES it
+        // (`liveTerminalId`) so the client's create-error fold can reattach
+        // the pane to the still-running session instead of dead-ending.
+        let owner = state
             .registry
-            .live_session_owner(Some(&state.identity), &mode, live_sid)
-            .is_some();
+            .live_session_owner(Some(&state.identity), &mode, live_sid);
+        let registry_row_live = owner.is_some();
         // Task 13b (cross-kind liveness): a live FRESH-AGENT sidecar owning
         // `(provider, S)` is just as much "the one writer on S's JSONL" as a live
         // PTY -- "Reopen as freshclaude"/"Reopen as Claude CLI" makes the same
@@ -2631,11 +2637,17 @@ pub(crate) async fn handle_create(
                     "create_refused: a Running terminal already owns this session (D7 live-guard)"
                 );
             }
-            return send_create_error(
+            // The refusal text stays byte-identical (frozen clients and user
+            // regexes depend on it); all novelty rides the additive
+            // `live_terminal_id` — Some on the terminal-owner arm, None on the
+            // cross-kind fresh-agent arm (no terminal id exists there, so the
+            // client-side revival arm stays inert by design).
+            return send_create_error_with_live_terminal(
                 out,
                 ErrorCode::RestoreUnavailable,
                 format!("Session {live_sid} is still running on the server."),
                 &create.request_id,
+                owner,
             )
             .await;
         }
@@ -4486,6 +4498,21 @@ pub(crate) async fn send_create_error(
     message: String,
     request_id: &str,
 ) -> bool {
+    send_create_error_with_live_terminal(out, code, message, request_id, None).await
+}
+
+/// `send_create_error` + the D7 live-owner hint (`live_terminal_id`): the
+/// terminal that still owns the refused session, so the client's create-error
+/// fold can reattach instead of dead-ending (reconnect-revive Task 7).
+/// Additive and omitted when None — every other error frame stays
+/// byte-identical on the wire (frozen-client parity).
+pub(crate) async fn send_create_error_with_live_terminal(
+    out: &mut crate::create_gate::CreateOutput<'_>,
+    code: ErrorCode,
+    message: String,
+    request_id: &str,
+    live_terminal_id: Option<String>,
+) -> bool {
     let msg = ServerMessage::Error(ErrorMsg {
         code,
         message,
@@ -4496,6 +4523,7 @@ pub(crate) async fn send_create_error(
         retry_after_ms: None,
         terminal_exit_code: None,
         terminal_id: None,
+        live_terminal_id,
     });
     out.send(&msg).await
 }
@@ -4686,6 +4714,7 @@ fn handle_attach(
         retry_after_ms: None,
         terminal_id: Some(attach.terminal_id),
         terminal_exit_code: None,
+        live_terminal_id: None,
     }))
 }
 
@@ -4758,6 +4787,7 @@ fn input_session_identity_mismatch_error(
         retry_after_ms: None,
         terminal_exit_code: None,
         terminal_id: Some(terminal_id.to_string()),
+        live_terminal_id: None,
     })
 }
 
@@ -4794,6 +4824,7 @@ fn invalid_dims_error(cols: i64, rows: i64) -> ServerMessage {
         retry_after_ms: None,
         terminal_exit_code: None,
         terminal_id: None,
+        live_terminal_id: None,
     })
 }
 
@@ -5028,6 +5059,7 @@ async fn handle_kill(kill: TerminalKill, ws_tx: &mut WsSink, state: &WsState) ->
         retry_after_ms: None,
         terminal_id: Some(kill.terminal_id),
         terminal_exit_code: None,
+        live_terminal_id: None,
     });
     send(ws_tx, &msg).await
 }

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -1231,14 +1231,33 @@ async fn handle_client_text(
         // not by request/response pairing.
         ClientMessage::PaneReconcileRequest(request) => {
             // Answered ONLY on a connection that negotiated the capability
-            // (§4.2's "may I send?" gate); anything else is accept-and-strip
-            // ignored, exactly like an unknown frame — the frozen client's
-            // byte-inertness does not depend on this, since it never sends
-            // the request at all (§3).
+            // (§4.2's "may I send?" gate). A request on a NON-negotiated
+            // connection gets an explicit terminal refusal carrying the
+            // reconcileId, so the client falls back to the legacy inventory
+            // census NOW instead of wedging every pane pending-verdict until
+            // the next reconnect (the reported gray-and-dead shape). The
+            // refusal can never reach pre-reconcile ("frozen") clients — they
+            // never send the request at all (§3).
             if pane_reconcile_v1 {
                 return handle_pane_reconcile(request, ws_tx, state, pane_reconcile_fresh_agent_v1)
                     .await;
             }
+            // Capability not negotiated on THIS connection: answer explicitly.
+            send(
+                ws_tx,
+                &ServerMessage::Error(ErrorMsg {
+                    code: ErrorCode::ReconcileNotNegotiated,
+                    message: "pane.reconcile was not negotiated on this connection; fall back to the inventory census.".to_string(),
+                    timestamp: crate::now_iso(),
+                    actual_session_ref: None,
+                    expected_session_ref: None,
+                    request_id: Some(request.reconcile_id.clone()),
+                    retry_after_ms: None,
+                    terminal_exit_code: None,
+                    terminal_id: None,
+                }),
+            )
+            .await;
             true
         }
         ClientMessage::Ping => {
@@ -6702,5 +6721,185 @@ mod connection_span_filter_tests {
                 Some("term-xyz")
             );
         }
+    }
+}
+
+/// Task 2 (reconnect-revive): the `pane.reconcile.request` capability gate.
+/// A request arriving on a connection that did NOT negotiate `paneReconcileV1`
+/// must get an explicit terminal refusal carrying the reconcileId (the client
+/// falls back to the legacy inventory census NOW) instead of being
+/// accept-and-strip ignored — the silence used to wedge every pane
+/// pending-verdict until the next reconnect (the reported gray-and-dead
+/// shape). Pre-reconcile ("frozen") clients never send the request, so the
+/// error code can never reach them (frozen-client wire parity).
+#[cfg(test)]
+mod pane_reconcile_gate_tests {
+    use super::*;
+
+    /// A REAL loopback websocket pair: a scratch axum app upgrades the client
+    /// connection and hands its write half (the production `WsSink` type) to
+    /// the test, so `handle_client_text` runs its real serialization + send
+    /// path and the frames are asserted off the wire by a real tungstenite
+    /// client — no mocked sink. The upgrade handler parks forever so the
+    /// socket stays open for the whole assertion window; the listener task
+    /// dies with the test runtime.
+    type TestClient =
+        tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+    async fn loopback_sink_and_client() -> (WsSink, TestClient) {
+        let (sink_tx, sink_rx) = tokio::sync::oneshot::channel::<WsSink>();
+        let sink_tx = std::sync::Arc::new(tokio::sync::Mutex::new(Some(sink_tx)));
+        let router = axum::Router::new().route(
+            "/ws",
+            axum::routing::any(move |upgrade: axum::extract::ws::WebSocketUpgrade| {
+                let sink_tx = std::sync::Arc::clone(&sink_tx);
+                async move {
+                    upgrade.on_upgrade(move |socket| async move {
+                        let (sink, _read) = socket.split();
+                        if let Some(tx) = sink_tx.lock().await.take() {
+                            let _ = tx.send(sink);
+                        }
+                        // Park: keep the upgraded socket (and with it the
+                        // handed-out write half) alive until the test's
+                        // runtime tears the connection down.
+                        std::future::pending::<()>().await;
+                    })
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral loopback port");
+        let addr = listener.local_addr().expect("loopback local addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, router).await;
+        });
+        let (client, _resp) = tokio_tungstenite::connect_async(format!("ws://{addr}/ws"))
+            .await
+            .expect("ws connect to scratch server");
+        let sink = sink_rx
+            .await
+            .expect("upgrade handler delivered the write half");
+        (sink, client)
+    }
+
+    async fn next_text_frame(client: &mut TestClient) -> serde_json::Value {
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(5), client.next())
+            .await
+            .expect("frame within timeout")
+            .expect("stream not ended")
+            .expect("no ws error");
+        match msg {
+            tokio_tungstenite::tungstenite::Message::Text(text) => {
+                serde_json::from_str(&text).expect("json frame")
+            }
+            other => panic!("expected a text frame, got {other:?}"),
+        }
+    }
+
+    fn state() -> WsState {
+        let auth_token = Arc::new("s3cr3t-token-abcdef".to_string());
+        let broadcast_tx = Arc::new(tokio::sync::broadcast::channel::<String>(16).0);
+        WsState {
+            pane_ledger: std::sync::Arc::new(crate::pane_ledger::PaneLedger::disabled()),
+            layout: Default::default(),
+            identity: crate::identity::TerminalIdentityRegistry::new(),
+            terminal_meta: Default::default(),
+            auth_token: Arc::clone(&auth_token),
+            server_instance_id: Arc::new("srv-1111".to_string()),
+            boot_id: Arc::new("boot-2222".to_string()),
+            settings: Arc::new(crate::test_settings()),
+            handshake_settings: Arc::new(tokio::sync::RwLock::new(crate::test_settings())),
+            broadcast_tx: Arc::clone(&broadcast_tx),
+            auto_resume_tx: tokio::sync::mpsc::unbounded_channel().0,
+            auto_resume_cancels: Default::default(),
+            fresh_codex: freshell_freshagent::FreshCodexState::new(
+                Arc::clone(&auth_token),
+                Arc::clone(&broadcast_tx),
+                serde_json::json!({ "freshAgent": { "enabled": false } }),
+            ),
+            fresh_claude: freshell_freshagent::FreshClaudeState::new(Arc::clone(&broadcast_tx)),
+            fresh_opencode: freshell_freshagent::FreshOpencodeState::new(
+                freshell_freshagent::FreshAgentState::new(auth_token, Arc::clone(&broadcast_tx)),
+            ),
+            registry: freshell_terminal::TerminalRegistry::new(),
+            shutdown: Arc::new(tokio::sync::Notify::new()),
+            tabs: crate::tabs::TabsRegistry::new(),
+            screenshots: crate::screenshot::ScreenshotBroker::new(broadcast_tx),
+            subagent_interest: Default::default(),
+            terminals_revision: Arc::new(std::sync::atomic::AtomicI64::new(0)),
+            sessions_revision: Arc::new(std::sync::atomic::AtomicI64::new(0)),
+            cli_commands: Arc::new(Vec::new()),
+            ping_interval_ms: 30_000,
+            hello_timeout_ms: 5_000,
+            allowed_origins: Arc::new(crate::origin::default_allowed_origins()),
+            ws_max_payload_bytes: 16 * 1024 * 1024,
+            term09: crate::backpressure::Term09Config::default(),
+            create_protect: crate::create_limit::CreateProtectConfig::default(),
+            spawn_gate: std::sync::Arc::new(crate::spawn_gate::SpawnGate::new(4, 64)),
+            shutdown_started: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            create_dedupe: std::sync::Arc::new(crate::create_dedupe::CreateDedupe::default()),
+            config_fallback: None,
+            opencode_locator: None,
+            codex_locator: None,
+            activity: None,
+            session_existence: std::sync::Arc::new(crate::existence::NoIndexProbe::default()),
+            reconcile_deferral_budget_ms: crate::reconcile::RECONCILE_DEFERRAL_BUDGET_MS_DEFAULT,
+            fresh_agent_respawn_counts: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn pane_reconcile_request_without_capability_gets_explicit_error() {
+        let (mut ws_tx, mut client) = loopback_sink_and_client().await;
+        let state = state();
+        let conn_sink: FrameSink = std::sync::Arc::new(|_| {});
+        let mut create_limiter = crate::create_limit::CreateRateLimiter::new(8, 60_000);
+        let (_cancel_tx, create_cancel_rx) = tokio::sync::watch::channel(false);
+
+        let keep_open = handle_client_text(
+            r#"{"type":"pane.reconcile.request","reconcileId":"r1","panes":[{"paneKey":"tab-1:pane-1","kind":"terminal","mode":"shell","createRequestId":"cr-1"}]}"#,
+            &mut ws_tx,
+            &state,
+            1,
+            &conn_sink,
+            false,
+            false, // pane_reconcile_v1: NOT negotiated on this connection
+            false,
+            &mut create_limiter,
+            &create_cancel_rx,
+        )
+        .await;
+        assert!(keep_open, "the refusal must answer, not tear the connection down");
+
+        // Health marker behind the request: one dispatch loop, strictly
+        // ordered, so on the OLD accept-and-strip path the FIRST frame back
+        // is this pong (silence pin), while the fixed path emits the refusal
+        // first and the connection stays healthy (pong second).
+        let pong_ok = handle_client_text(
+            r#"{"type":"ping"}"#,
+            &mut ws_tx,
+            &state,
+            1,
+            &conn_sink,
+            false,
+            false,
+            false,
+            &mut create_limiter,
+            &create_cancel_rx,
+        )
+        .await;
+        assert!(pong_ok);
+
+        let refusal = next_text_frame(&mut client).await;
+        assert_eq!(refusal["type"], "error");
+        assert_eq!(refusal["code"], "RECONCILE_NOT_NEGOTIATED");
+        assert_eq!(
+            refusal["requestId"], "r1",
+            "the refusal must carry the reconcileId so the client correlates it"
+        );
+
+        let pong = next_text_frame(&mut client).await;
+        assert_eq!(pong["type"], "pong");
     }
 }

--- a/crates/freshell-ws/tests/cross_kind_liveness.rs
+++ b/crates/freshell-ws/tests/cross_kind_liveness.rs
@@ -597,3 +597,82 @@ async fn terminal_create_is_refused_while_a_live_sidecar_owns_the_session() {
         "no terminal may own {durable} -- the sidecar is the one writer"
     );
 }
+
+/// Reconnect-revive Task 7 (cross-kind arm): when the D7 refusal fires
+/// because a live FRESH-AGENT sidecar owns the session, no terminal id exists
+/// to name -- the refusal must OMIT `liveTerminalId` entirely
+/// (`#[serde(skip_serializing_if)]`; the field is additive and absent keeps
+/// every other error frame byte-identical for frozen clients). The revival
+/// arm stays inert: this refusal still dead-ends by design.
+#[tokio::test]
+async fn d7_cross_kind_refusal_omits_live_terminal_id() {
+    let _guard = ENV_LOCK.lock().await;
+    let env = FakeSidecarEnv::install();
+
+    let durable = "abababab-cdcd-4dcd-8dcd-cdcdcdcdcdcd";
+    let (url, registry) = spawn_server().await;
+    let mut ws = connect(&url).await;
+
+    // 1. A fresh-agent resume of S goes live (the fake sidecar answers `created`).
+    send_json(
+        &mut ws,
+        &json!({
+            "type": "freshAgent.create",
+            "requestId": "req-fa-owner-d7",
+            "sessionType": "freshclaude",
+            "provider": "claude",
+            "cwd": "/tmp",
+            "sessionRef": { "provider": "claude", "sessionId": durable },
+        }),
+    )
+    .await;
+    await_frame(&mut ws, Duration::from_secs(10), |v| {
+        v["type"] == "freshAgent.created" && v["requestId"] == "req-fa-owner-d7"
+    })
+    .await;
+    assert_eq!(env.create_rows().len(), 1, "the sidecar owns S now");
+
+    // 2. The D7 cross-kind refusal: RESTORE_UNAVAILABLE, message names the
+    //    session, and NO liveTerminalId (no terminal owns the session).
+    send_json(
+        &mut ws,
+        &json!({
+            "type": "terminal.create",
+            "requestId": "req-term-cross-d7",
+            "mode": "claude",
+            "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+            "restore": true,
+            "sessionRef": { "provider": "claude", "sessionId": durable },
+        }),
+    )
+    .await;
+    let frame = await_frame(&mut ws, Duration::from_secs(10), |v| {
+        (v["type"] == "error" || v["type"] == "terminal.created")
+            && v["requestId"] == "req-term-cross-d7"
+    })
+    .await;
+    assert_eq!(
+        frame["type"], "error",
+        "a live sidecar owns {durable}: terminal.create must be refused, got {frame}"
+    );
+    assert_eq!(frame["code"], "RESTORE_UNAVAILABLE");
+    assert!(
+        frame["message"]
+            .as_str()
+            .is_some_and(|m| m.contains(durable)),
+        "message must name the live session: {frame}"
+    );
+    assert!(
+        frame.get("liveTerminalId").is_none(),
+        "the cross-kind arm has no terminal id to name and must omit the field: {frame}"
+    );
+
+    // 3. No PTY spawned `claude --resume S`.
+    assert!(
+        !registry.directory().into_iter().any(|entry| {
+            entry.mode == "claude" && entry.resume_session_id.as_deref() == Some(durable)
+        }),
+        "no terminal may own {durable} -- the sidecar is the one writer"
+    );
+}

--- a/crates/freshell-ws/tests/live_session_ref_guard.rs
+++ b/crates/freshell-ws/tests/live_session_ref_guard.rs
@@ -131,6 +131,71 @@ async fn live_session_ref_create_is_refused_loudly() {
     registry.kill(&tid1);
 }
 
+/// Reconnect-revive Task 7: the D7 refusal must NAME the live owner terminal
+/// (`liveTerminalId`) so the client's create-error fold can reattach the pane
+/// to it instead of dead-ending on "Session … is still running on the
+/// server." Additive and omitted when no live terminal is nameable: every
+/// other error frame stays byte-identical (frozen-client wire parity).
+#[tokio::test]
+async fn d7_refusal_names_the_live_owner_terminal() {
+    let (url, registry) = spawn_server().await; // sleeper claude: stays Running
+    let (mut ws, _inv) = connect_and_capture_inventory(&url).await;
+
+    // A fresh claude terminal reaches Running, owning preallocated session S.
+    send_create(
+        &mut ws,
+        json!({
+            "type": "terminal.create",
+            "requestId": "req-d7-owner-1",
+            "mode": "claude",
+            "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+        }),
+    )
+    .await;
+    let created = next_frame_of_type(&mut ws, "terminal.created").await;
+    let tid1 = created["terminalId"]
+        .as_str()
+        .expect("terminalId")
+        .to_string();
+    let session_id = session_ref_of(&created).expect("fresh claude carries sessionRef")
+        ["sessionId"]
+        .as_str()
+        .expect("sessionId")
+        .to_string();
+
+    // The close-and-reopen fallback shape: a restored create whose wire
+    // sessionRef points at the STILL-RUNNING session.
+    send_create(
+        &mut ws,
+        json!({
+            "type": "terminal.create",
+            "requestId": "req-d7-reopen-1",
+            "mode": "claude",
+            "shell": "system",
+            "cwd": std::env::temp_dir().to_string_lossy(),
+            "restore": true,
+            "sessionRef": { "provider": "claude", "sessionId": session_id },
+        }),
+    )
+    .await;
+
+    let err = expect_refusal_for(&mut ws, "req-d7-reopen-1").await;
+    assert_eq!(err["code"], json!("RESTORE_UNAVAILABLE"), "{err}");
+    assert_eq!(
+        err["message"],
+        json!(format!("Session {session_id} is still running on the server.")),
+        "refusal text stays byte-identical (regexes and muscle memory depend on it): {err}"
+    );
+    assert_eq!(
+        err["liveTerminalId"],
+        json!(tid1),
+        "the refusal must name the still-running owner so clients can reattach: {err}"
+    );
+
+    registry.kill(&tid1);
+}
+
 /// The legacy rung of the same doctrine (2026-08-16 duplicate-tab incident):
 /// a `terminal.create` carrying ONLY the legacy `resumeSessionId` (no
 /// `sessionRef`) used to arm D7 exactly like the sessionRef rung — a legacy

--- a/crates/freshell-ws/tests/live_session_ref_guard.rs
+++ b/crates/freshell-ws/tests/live_session_ref_guard.rs
@@ -184,7 +184,9 @@ async fn d7_refusal_names_the_live_owner_terminal() {
     assert_eq!(err["code"], json!("RESTORE_UNAVAILABLE"), "{err}");
     assert_eq!(
         err["message"],
-        json!(format!("Session {session_id} is still running on the server.")),
+        json!(format!(
+            "Session {session_id} is still running on the server."
+        )),
         "refusal text stays byte-identical (regexes and muscle memory depend on it): {err}"
     );
     assert_eq!(

--- a/crates/freshell-ws/tests/pane_reconcile.rs
+++ b/crates/freshell-ws/tests/pane_reconcile.rs
@@ -17,8 +17,12 @@
 //! * 9.1.10 single-flight create-dedupe — negotiated connection adopts the
 //!   existing live terminal for a key; a non-negotiating connection keeps the
 //!   legacy spawn path.
-//! * inertness — a non-negotiating connection's `pane.reconcile.request` is
-//!   accept-and-strip ignored.
+//! * gate refusal (reconnect-revive Task 2) — a non-negotiating connection's
+//!   `pane.reconcile.request` is answered with an explicit terminal
+//!   `error{RECONCILE_NOT_NEGOTIATED}` carrying the `reconcileId`, so the
+//!   client's bounded boot-result wait resolves instantly instead of wedging
+//!   every pane pending-verdict. Pre-reconcile ("frozen") clients never send
+//!   the request, so the code can never reach them (§3 inertness).
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -309,10 +313,10 @@ async fn hello_without_capability_gets_unchanged_ready_and_with_it_gets_advertis
     );
 }
 
-// --- inertness ------------------------------------------------------------------
+// --- gate refusal (reconnect-revive Task 2) ------------------------------------
 
 #[tokio::test]
-async fn non_negotiating_connection_gets_no_reconcile_response() {
+async fn non_negotiating_connection_gets_explicit_reconcile_refusal() {
     let server = spawn_server().await;
     let (mut ws, _ready) = connect(&server.url, false).await;
 
@@ -322,14 +326,20 @@ async fn non_negotiating_connection_gets_no_reconcile_response() {
     ))
     .await
     .expect("send request");
-    // A ping after the request: if the very next frame is the pong, the
-    // request was accept-and-strip ignored (nothing was sent for it).
+    // A ping after the request proves the refusal is terminal for the
+    // REQUEST, not the connection: the health marker is still answered.
     ws.send(WsMessage::Text(
         serde_json::json!({ "type": "ping" }).to_string(),
     ))
     .await
     .expect("send ping");
 
+    let refusal = next_frame_of_type(&mut ws, "error").await;
+    assert_eq!(refusal["code"], "RECONCILE_NOT_NEGOTIATED");
+    assert_eq!(
+        refusal["requestId"], "rec-inert",
+        "the refusal carries the reconcileId so the client correlates it and falls back instantly"
+    );
     let frame = next_frame_of_type(&mut ws, "pong").await;
     assert_eq!(frame["type"], "pong");
 }

--- a/docs/plans/2026-08-22-reconnect-revive.md
+++ b/docs/plans/2026-08-22-reconnect-revive.md
@@ -112,12 +112,25 @@ describe('WsClient liveness', () => {
     expect(MockWebSocket.instances.length).toBe(2)     // …and is ignored (generation guard)
   })
 
-  it('clears the outstanding probe on any inbound message (no close)', async () => {
+  it('clears the outstanding probe on any inbound message (no abandon while traffic flows)', async () => {
     const { socket } = await connectReady(new WsClient('ws://test/ws'))
-    await vi.advanceTimersByTimeAsync(30_000)
-    socket._message({ type: 'pong', timestamp: 'x' })
-    await vi.advanceTimersByTimeAsync(60_000)
-    expect(MockWebSocket.instances.length).toBe(1)     // socket never recycled
+    await vi.advanceTimersByTimeAsync(30_000)           // t=30: probe
+    socket._message({ type: 'pong', timestamp: 'x' })  // probe cleared; silence restarts from t=30
+    // Silence restarts at the last inbound frame, so feed periodic traffic:
+    // at each 10s tick silence stays < 30s and no further probe is needed.
+    for (let i = 0; i < 3; i++) {
+      await vi.advanceTimersByTimeAsync(20_000)
+      socket._message({ type: 'settings.updated', settings: {} })
+    }
+    expect(MockWebSocket.instances.length).toBe(1)     // never abandoned
+  })
+
+  it('re-probes on persistent silence and abandons when the repeat probe also goes unanswered', async () => {
+    const { socket } = await connectReady(new WsClient('ws://test/ws'))
+    await vi.advanceTimersByTimeAsync(30_000)           // t=30: probe #1
+    socket._message({ type: 'pong', timestamp: 'x' })  // t=30: cleared
+    await vi.advanceTimersByTimeAsync(40_000)           // t=60: probe #2; t=70: unanswered 10s → abandon
+    expect(MockWebSocket.instances.length).toBe(2)
   })
 
   it('poke() while ready and recently active sends an immediate probe', async () => {

--- a/docs/plans/2026-08-22-reconnect-revive.md
+++ b/docs/plans/2026-08-22-reconnect-revive.md
@@ -83,7 +83,8 @@ describe('WsClient liveness', () => {
 
   it('sends an app-level ping after 30s of inbound silence while ready', async () => {
     const { socket } = await connectReady(new WsClient('ws://test/ws'))
-    // Ready traffic itself was inbound activity; 30s of silence triggers the probe.
+    // Ready traffic itself was inbound activity. 10s ticks at t=10/20 skip
+    // (silence < 30s); the t=30 tick sees silence === 30s and probes.
     await vi.advanceTimersByTimeAsync(30_000)
     expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(true)
   })
@@ -101,6 +102,7 @@ describe('WsClient liveness', () => {
     await vi.advanceTimersByTimeAsync(30_000)          // probe sent
     expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(true)
     // The dead transport NEVER delivers onclose — that is the hazard under test.
+    // t=30 tick probes; the t=40 tick sees probe age 10s >= PONG_TIMEOUT_MS and abandons.
     await vi.advanceTimersByTimeAsync(10_000)
     expect(MockWebSocket.instances.length).toBe(2)     // fresh socket driven immediately
     const fresh = MockWebSocket.instances[1]
@@ -166,10 +168,12 @@ Expected: FAIL because `'ping'` frames are never sent, `client.poke is not a fun
 
 ```ts
 // Constants (top of file, next to CONNECTION_TIMEOUT_MS):
-// Liveness probe cadence matches both servers' 30s keepalive; the pong timeout
-// bounds "half-open" detection; the foreground recycle threshold is >2 server
-// keepalive windows — past it the server may already have reaped the peer.
-const LIVENESS_INTERVAL_MS = 30_000
+// 10s tick so a probe's 10s timeout is re-evaluated 10s after it was sent
+// (a 30s tick would delay abandonment to t=60 — fresh-eyes F1). Probe fires
+// once inbound silence reaches 30s (both servers' keepalive cadence); the
+// foreground abandon threshold is >2 server keepalive windows.
+const LIVENESS_TICK_MS = 10_000
+const PROBE_AFTER_SILENCE_MS = 30_000
 const PONG_TIMEOUT_MS = 10_000
 const FOREGROUND_RECYCLE_SILENCE_MS = 65_000
 
@@ -193,7 +197,7 @@ private socketGen = 0
 
 private startLivenessWatch(): void {
   this.clearLivenessWatch()
-  this.livenessTimer = window.setInterval(() => this.tickLiveness(), LIVENESS_INTERVAL_MS)
+  this.livenessTimer = window.setInterval(() => this.tickLiveness(), LIVENESS_TICK_MS)
 }
 
 private clearLivenessWatch(): void {
@@ -210,7 +214,7 @@ private tickLiveness(): void {
     }
     return
   }
-  if (now - this.lastInboundAt < LIVENESS_INTERVAL_MS) return
+  if (now - this.lastInboundAt < PROBE_AFTER_SILENCE_MS) return
   this.probeSentAt = now
   this.sendNow({ type: 'ping' })
 }
@@ -251,11 +255,21 @@ private abandonStaleSocket(reason: string): void {
 poke(): void {
   if (this.intentionalClose) return
   if (this._state === 'ready') {
+    if (this.probeSentAt !== null && Date.now() - this.probeSentAt >= PONG_TIMEOUT_MS) {
+      this.abandonStaleSocket('foreground poke: outstanding probe expired')
+      return
+    }
     if (Date.now() - this.lastInboundAt >= FOREGROUND_RECYCLE_SILENCE_MS) {
       this.abandonStaleSocket('foreground poke past keepalive windows')
       return
     }
-    this.tickLiveness()
+    // Foreground means "ask now": probe immediately, bypassing the 30s silence
+    // gate (fresh-eyes F1 — routing this through tickLiveness's guard could
+    // never fire the immediate probe the tests pin).
+    if (this.probeSentAt === null) {
+      this.probeSentAt = Date.now()
+      this.sendNow({ type: 'ping' })
+    }
     return
   }
   if (this.connectPromise) return
@@ -479,7 +493,7 @@ Expected: PASS
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add src/lib/pane-reconcile.ts src/App.tsx crates/freshell-protocol/src/server_messages.rs crates/freshell-ws/src/terminal.rs test/unit/client/components/App.reconcile-adoption.test.tsx
+git add src/lib/pane-reconcile.ts src/App.tsx crates/freshell-protocol/src/common.rs crates/freshell-ws/src/terminal.rs test/unit/client/components/App.reconcile-adoption.test.tsx
 git commit -m "fix(reconcile): bound the boot-result wait and answer non-negotiated requests explicitly"
 ```
 
@@ -580,7 +594,7 @@ Slice: `sessionSnapshotReceived` and `freshAgentSnapshotReceived` each clear `lo
 
 View fold: with a codex pane `lost=true`, no sessionId change possible (durable id already), delivering a fresh-agent `attach` verdict via the boot reconcile fold clears `lost` in the freshAgent slice and the next snapshot-fetch effect run issues the HTTP GET (spy on `fetch`).
 
-Reconnect re-drive: with the pane still `lost=true` and NO verdict (reconcile absent), flipping `connection.status` `'disconnected' → 'ready'` re-runs the `.lost` recovery effect (spy `reconcileLostPane`/`triggerRecovery`).
+Reconnect re-drive: with the pane still `lost=true` and NO verdict (reconcile absent), flipping `connection.status` `'disconnected' → 'ready'` re-runs the `.lost` recovery effect (spy `reconcileLostPane`/`triggerRecovery`). Negative case (fresh-eyes F4): flipping `'ready' → 'disconnected'` does NOT run recovery (no offline session-id clearing / create minting — recovery only acts on post-reconnect evidence).
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -607,7 +621,7 @@ dispatch(clearSessionLost({ sessionId: <verdict locator sessionId>, sessionType:
 
 (Locator fields come from the verdict's `sessionRef` / pane entry following the adjacent `applyFreshAgentReconcileAttach` payload shape; import `clearSessionLost` from the slice.)
 
-`FreshAgentView.tsx` — add a selector `const connectionStatus = useAppSelector((s) => s.connection.status)` and add `connectionStatus` to the `.lost` recovery effect's dep array (:2069-2077 region), with a short comment: a fresh reconnect re-drives recovery even when lost/sessionId are unchanged.
+`FreshAgentView.tsx` — add a selector `const connectionStatus = useAppSelector((s) => s.connection.status)`, add `connectionStatus` to the `.lost` recovery effect's dep array (:2069-2077 region), AND gate the effect body: `if (connectionStatus !== 'ready') return` immediately after the provider/lost guards (fresh-eyes F4: without the gate the dep also fires on ready→disconnected, and `triggerRecovery()` could clear the pane's session id / mint a create request while offline — before any post-reconnect evidence exists).
 
 - [ ] **Step 4: Run the focused test**
 
@@ -810,7 +824,7 @@ Load-bearing LB-1 (falsified; `reports/load-bearing-validator-LB-1.md`): on nego
 
 1. panesSlice: `applyReattachToLiveTerminal` writes terminalId/status, clears restoreError, and bumps reconcileEpoch; it is a no-op for an unknown paneKey.
 2. TerminalView revive fold: create-error `{code:'RESTORE_UNAVAILABLE', liveTerminalId:'t1', requestId}` → the pane's store state gains `terminalId:'t1'`/`status:'running'` via the new reducer, its bumped `reconcileEpoch` re-fires the lifecycle effect so a `terminal.attach` for `t1` leaves the client, and the pane shows a `Reconnected to the still-running session.` notice — never `[Restore failed]`; a SECOND RESTORE_UNAVAILABLE for the same createRequestId does NOT revive again (one-shot bound) and falls through to the existing error write.
-3. Rust WS: the D7 refusal frame carries `live_terminal_id: Some(<owner>)` when `registry_row_live` (owner known) and `None` on the fresh-agent cross-kind arm. Rust REST: the 409 body carries `liveTerminalId` when a terminal owns the session and omits it for the cross-kind arm.
+3. Rust WS: the D7 refusal frame carries `live_terminal_id: Some(<owner>)` when `registry_row_live` (owner known) and `None` on the fresh-agent cross-kind arm. Rust REST: the D7 409 body carries `liveTerminalId` when a terminal owns the session and omits it for the cross-kind arm; the D8 BoundElsewhere 409 carries `liveTerminalId` set to the claim's `terminal_id`.
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -830,7 +844,7 @@ Wire (`server_messages.rs`, next to `terminal_id`):
 pub live_terminal_id: Option<String>,
 ```
 
-Add `live_terminal_id: None` to every other `ErrorMsg` literal (`send_create_error` :4464-4482 etc.). WS guard: capture `let owner = state.registry.live_session_owner(...)` once, set `registry_row_live = owner.is_some()`, and emit `live_terminal_id: owner` on the refusal. REST guard: put `liveTerminalId` in the 409 JSON body from the same owner (omit for the cross-kind arm). `shared/ws-protocol.ts`: error schema gains `liveTerminalId: z.string().optional()`.
+Add `live_terminal_id: None` to every other `ErrorMsg` literal (`send_create_error` :4464-4482 etc.). WS guard: capture `let owner = state.registry.live_session_owner(...)` once, set `registry_row_live = owner.is_some()`, and emit `live_terminal_id: owner` on the refusal. REST guard: put `liveTerminalId` in the 409 JSON body from the same owner (omit for the cross-kind arm). ALSO the REST door's D8 arm: `SessionRefClaim::BoundElsewhere { terminal_id }` currently maps to a nameless 409 discarding the id (`terminal_tabs.rs:1267-1281`) — carry `liveTerminalId: terminal_id` there too, so the claim-race refusal is equally attachable (fresh-eyes F5). `shared/ws-protocol.ts`: error schema gains `liveTerminalId: z.string().optional()`.
 
 panesSlice (next to `applyReconcileAttach`):
 
@@ -971,18 +985,41 @@ test.describe('reconnect revive (rust)', () => {
     await expect(page.getByText(noDeadEndText)).toHaveCount(0)
   })
 
-  test('server-process freeze (dead-peer shape) converges after thaw', async ({ freshellPage, page, harness, terminal, testServer }) => {
-    test.slow() // ~45s freeze window: trips the 30s probe + 10s pong timeout
+  test('server-process freeze forces client-side abandonment before thaw', async ({ freshellPage, page, harness, terminal, testServer }) => {
+    test.slow() // freeze window must cover the 30s probe + 10s pong timeout
+    test.skip(process.platform === 'win32', 'SIGSTOP/SIGCONT are POSIX-only (freeze-spec gate)')
     await terminal.waitForTerminal()
     await terminal.waitForPrompt()
     await terminal.executeCommand('echo "rr-freeze"')
     await terminal.waitForOutput('rr-freeze')
-    // SIGSTOP the SERVER (kernel holds the client sockets open; no close frame
-    // reaches the client — the true phone-background shape). Precedent:
-    // terminal-background-freeze-catchup.spec.ts (+win32 gate).
-    process.kill(testServer.info.pid, 'SIGSTOP')
-    await new Promise((r) => setTimeout(r, 45_000)) // client probe+timeout fires inside this window
-    process.kill(testServer.info.pid, 'SIGCONT')
+
+    // Fresh-eyes F3 discrimination: a stalled socket that merely RESUMES after
+    // SIGCONT passes every old assertion (ready + input), so they cannot be the
+    // discriminator. The one thing only the Task 1 watchdog produces is a
+    // client-driven status transition while NO close frame exists. Start an
+    // in-page status sampler FIRST (the browser is not frozen — only the
+    // server is), then freeze the server, then require a non-'ready' sample
+    // BEFORE thaw.
+    await page.evaluate(() => {
+      ;(window as any).__rrStatuses = []
+      ;(window as any).__rrTimer = setInterval(() => {
+        ;(window as any).__rrStatuses.push(window.__FRESHELL_TEST_HARNESS__?.getState()?.connection?.status)
+      }, 1_000)
+    })
+    const pid = testServer.info.pid
+    try {
+      process.kill(pid, 'SIGSTOP')
+      // Base behavior: no inbound traffic ever forces a state change — the
+      // sampler never leaves 'ready' and this wait times out (true red-first).
+      // With Task 1: t=30s probe → no pong → t=40s abandon → status flips.
+      await page.waitForFunction(
+        () => (window as any).__rrStatuses?.some((s: string | undefined) => s !== undefined && s !== 'ready'),
+        { timeout: 50_000 },
+      )
+    } finally {
+      process.kill(pid, 'SIGCONT') // never leave the fixture server stopped
+      await page.evaluate(() => clearInterval((window as any).__rrTimer)).catch(() => {})
+    }
     await harness.waitForConnection()
     await waitReady(page)
     await terminal.executeCommand('echo "rr-thawed"')
@@ -1005,7 +1042,7 @@ test.describe('reconnect revive (rust)', () => {
 
 Run: `npx playwright test --config test/e2e-browser/playwright.config.ts --project=rust-chromium test/e2e-browser/specs/reconnect-revive-rust.spec.ts`
 
-Expected against base: the REST-door contract test FAILS on the missing `liveTerminalId` field; the freeze test fails without the Task 1 watchdog (pane never revives inside the window); sidebar-adoption pin and plain-drop tests may already pass (documented pins). Record a per-test base-status table in the task's execution notes. In plan order this task runs last; any test still red after Tasks 1-7 is the LB-2 completeness signal — stop and attribute it before proceeding.
+Expected against base: the REST-door contract test FAILS on the missing `liveTerminalId` field; the freeze test's during-freeze sampler times out (on base nothing flips the status while no close frame exists — true red-first per fresh-eyes F3); the sidebar-adoption pin may already pass on base (documented pin); the fresh-agent drop test fails against the Task 4/5 wedges when drawn from them (lost-suppressed snapshot / placeholder-stamped ack) or passes as a pin otherwise — attribute per the table below. Record a per-test base-status table in the task's execution notes. In plan order this task runs last; any test still red after Tasks 1-7 is the LB-2 completeness signal — stop and attribute it before proceeding.
 
 - [ ] **Step 3: Add the minimal production implementation**
 

--- a/docs/plans/2026-08-22-reconnect-revive.md
+++ b/docs/plans/2026-08-22-reconnect-revive.md
@@ -241,6 +241,11 @@ private abandonStaleSocket(reason: string): void {
   this.serverCapabilities = {}
   this.resetReconcileHold({ requeueHeld: true })
   this.clearLivenessWatch()
+  // Fresh-eyes F2-2: a normal close notifies disconnectHandlers (App flips
+  // Redux connection.status at App.tsx:766-773) — abandonment must too, or
+  // Redux sits at 'ready' forever and every status-keyed recovery (Task 4's
+  // disconnected→ready transition; the Task 8 freeze sampler) wedges.
+  this.disconnectHandlers.forEach((h) => h())
   log.warn(`abandoning stale socket: ${reason}`)
   this.connect().catch((err) => log.debug('reconnect after abandon failed', err))
 }
@@ -315,7 +320,7 @@ Keep constants exported only if a test import needs them; otherwise private. No 
 
 The timer/filter changes touch every ws-client behavior suite plus the offline-chip/App bootstrap path and the client activity-callback wiring.
 
-Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.test.ts test/unit/client/lib/ws-client.reconnect-noise.test.ts test/unit/client/lib/ws-client.reconcile.test.ts test/unit/client/lib/ws-client.liveness.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx test/unit/client/components/App.restart-signals.test.tsx test/e2e/turn-complete-notification-flow.test.tsx test/unit/client/activity-callbacks.test.ts`
+Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.test.ts test/unit/client/lib/ws-client.reconnect-noise.test.ts test/unit/client/lib/ws-client.reconcile.test.ts test/unit/client/lib/ws-client.liveness.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx test/unit/client/components/App.restart-signals.test.tsx test/e2e/turn-complete-notification-flow.test.tsx`
 
 Expected: PASS
 
@@ -562,7 +567,7 @@ Factor the three-line re-register into one local helper used by both the `termin
 
 Hidden rebind, visibility transitions, hydration queue consumers, attach policy:
 
-Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.hidden-rebind.test.tsx test/unit/client/components/TerminalView.visibility.test.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/lib/hydration-queue.test.ts test/unit/client/lib/terminal-attach-policy.test.ts test/e2e/terminal-create-attach-ordering.test.tsx`
+Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.hidden-rebind.test.tsx test/unit/client/components/TerminalView.visibility.test.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/lib/hydration-queue.rebind.test.ts test/unit/client/lib/terminal-attach-policy.test.ts test/e2e/terminal-create-attach-ordering.test.tsx`
 
 Expected: PASS
 
@@ -637,7 +642,7 @@ None — three one-line/one-call changes at the exact seams; any dedup would hid
 
 Fresh-agent slice contracts, reconcile folds, hidden rebind (its Test 2 pins `.lost` re-create), snapshot scheduler consumers:
 
-Run: `npm run test:vitest -- run test/unit/client/store/freshAgentSlice.test.ts test/unit/client/components/fresh-agent/FreshAgentView.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.hidden-rebind.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.waiting-edge.test.tsx test/unit/client/lib/fresh-agent-ws.test.ts test/unit/client/lib/pane-reconcile.test.ts`
+Run: `npm run test:vitest -- run test/unit/client/store/freshAgentSlice.test.ts test/unit/client/components/fresh-agent/FreshAgentView.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.hidden-rebind.test.tsx test/unit/client/lib/fresh-agent-ws.test.ts test/unit/client/lib/pane-reconcile.test.ts`
 
 Expected: PASS
 
@@ -790,7 +795,7 @@ If locking ceremony repeats, add `fn current_status(&self) -> String` on `Claude
 
 The claude provider suite and the differential captures that pin ack CONTENT for these arms:
 
-Run: `cargo test -p freshell-freshagent claude && npm run test:vitest -- run test/integration/port/oracle/t2-invariants.test.ts test/unit/client/lib/fresh-agent-ws.test.ts`
+Run: `cargo test -p freshell-freshagent claude && npm run test:vitest -- run test/unit/port/oracle/t2-invariants.test.ts test/unit/client/lib/fresh-agent-ws.test.ts`
 
 Expected: PASS (if the oracle pins a hardcoded-idle capture on an arm whose tracked status changed, update per the oracle refresh procedure and record it).
 
@@ -814,6 +819,7 @@ Load-bearing LB-1 (falsified; `reports/load-bearing-validator-LB-1.md`): on nego
 - Modify: `src/components/TerminalView.tsx` (create-error handler :4872-4901)
 - Test: `test/unit/client/store/panesSlice.reconnect.test.ts` (or the slice's existing test home — check before creating)
 - Test: `test/unit/client/components/TerminalView.lifecycle.test.tsx` (revive fold cases)
+- Test: `test/e2e/terminal-create-attach-ordering.test.tsx` (jsdom full-pipeline revival fold — see Step 1 item 2b)
 - Test: `crates/freshell-ws/src/terminal.rs` tests; `crates/freshell-freshagent/src/terminal_tabs.rs` tests
 
 **Interfaces:**
@@ -824,11 +830,12 @@ Load-bearing LB-1 (falsified; `reports/load-bearing-validator-LB-1.md`): on nego
 
 1. panesSlice: `applyReattachToLiveTerminal` writes terminalId/status, clears restoreError, and bumps reconcileEpoch; it is a no-op for an unknown paneKey.
 2. TerminalView revive fold: create-error `{code:'RESTORE_UNAVAILABLE', liveTerminalId:'t1', requestId}` → the pane's store state gains `terminalId:'t1'`/`status:'running'` via the new reducer, its bumped `reconcileEpoch` re-fires the lifecycle effect so a `terminal.attach` for `t1` leaves the client, and the pane shows a `Reconnected to the still-running session.` notice — never `[Restore failed]`; a SECOND RESTORE_UNAVAILABLE for the same createRequestId does NOT revive again (one-shot bound) and falls through to the existing error write.
-3. Rust WS: the D7 refusal frame carries `live_terminal_id: Some(<owner>)` when `registry_row_live` (owner known) and `None` on the fresh-agent cross-kind arm. Rust REST: the D7 409 body carries `liveTerminalId` when a terminal owns the session and omits it for the cross-kind arm; the D8 BoundElsewhere 409 carries `liveTerminalId` set to the claim's `terminal_id`.
+2b. Full-pipeline proof (fresh-eyes F2-4): a jsdom-e2e case in `test/e2e/terminal-create-attach-ordering.test.tsx`'s real-App harness — a mounted TerminalView pane whose create draws the enriched refusal frame from the (mock-transport) wire → observe the reducer fold, the fresh `terminal.attach` for the named id, and the notice. A Playwright browser test cannot reach this fold: on negotiated WS connections the adopt arms absorb the create (LB-1) and the cross-kind arm correctly refuses without an id — so this jsdom full-pipeline level is the highest tier that can exercise the revival, and it joins the browser-side REST contract test (Task 8) that proves the server emits the field.
+3. Rust WS: the D7 refusal frame carries `live_terminal_id: Some(<owner>)` when `registry_row_live` (owner known), and `None` on the fresh-agent cross-kind arm (no terminal id exists there — the refusal stands, the revival arm stays inert by design). Rust REST — note the REST door has NO cross-kind refusal at all (`rest_gate_skips_sidecar_live_candidate_create_proceeds_unchanged`, terminal_tabs.rs:5400-5443, pins cross-kind → 200 OK; do not add one — fresh-eyes F2-3): its two reachable refusals are D7-terminal-owner and D8-BoundElsewhere, and BOTH carry `liveTerminalId` (the latter from the claim's `terminal_id`).
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
-Run: `npm run test:vitest -- run test/unit/client/store/panesSlice.reconnect.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx` and `cargo test -p freshell-ws d7 && cargo test -p freshell-freshagent terminal_tabs`
+Run: `npm run test:vitest -- run test/unit/client/store/panesSlice.reconnect.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/e2e/terminal-create-attach-ordering.test.tsx` and `cargo test -p freshell-ws d7 && cargo test -p freshell-freshagent terminal_tabs`
 
 Expected: FAIL because the reducer/revive/payload do not exist yet (`applyReattachToLiveTerminal` undefined; refusal payload lacks the id), not harness noise.
 
@@ -844,7 +851,7 @@ Wire (`server_messages.rs`, next to `terminal_id`):
 pub live_terminal_id: Option<String>,
 ```
 
-Add `live_terminal_id: None` to every other `ErrorMsg` literal (`send_create_error` :4464-4482 etc.). WS guard: capture `let owner = state.registry.live_session_owner(...)` once, set `registry_row_live = owner.is_some()`, and emit `live_terminal_id: owner` on the refusal. REST guard: put `liveTerminalId` in the 409 JSON body from the same owner (omit for the cross-kind arm). ALSO the REST door's D8 arm: `SessionRefClaim::BoundElsewhere { terminal_id }` currently maps to a nameless 409 discarding the id (`terminal_tabs.rs:1267-1281`) — carry `liveTerminalId: terminal_id` there too, so the claim-race refusal is equally attachable (fresh-eyes F5). `shared/ws-protocol.ts`: error schema gains `liveTerminalId: z.string().optional()`.
+Add `live_terminal_id: None` to every other `ErrorMsg` literal (`send_create_error` :4464-4482 etc.). WS guard: capture `let owner = state.registry.live_session_owner(...)` once, set `registry_row_live = owner.is_some()`, and emit `live_terminal_id: owner` on the refusal. REST guard: put `liveTerminalId` in the D7 409 JSON body from the same owner. ALSO the REST door's D8 arm: `SessionRefClaim::BoundElsewhere { terminal_id }` currently maps to a nameless 409 discarding the id (`terminal_tabs.rs:1267-1281`) — carry `liveTerminalId: terminal_id` there too, so the claim-race refusal is equally attachable (fresh-eyes F5). `shared/ws-protocol.ts`: error schema gains `liveTerminalId: z.string().optional()`.
 
 panesSlice (next to `applyReconcileAttach`):
 
@@ -878,7 +885,7 @@ if (msg.code === 'RESTORE_UNAVAILABLE' && typeof msg.liveTerminalId === 'string'
 
 - [ ] **Step 4: Run the focused test**
 
-Run: `npm run test:vitest -- run test/unit/client/store/panesSlice.reconnect.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx && cargo test -p freshell-ws d7 && cargo test -p freshell-freshagent terminal_tabs && npm run typecheck`
+Run: `npm run test:vitest -- run test/unit/client/store/panesSlice.reconnect.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/e2e/terminal-create-attach-ordering.test.tsx && cargo test -p freshell-ws d7 && cargo test -p freshell-freshagent terminal_tabs && npm run typecheck`
 
 Expected: PASS
 
@@ -897,7 +904,7 @@ Expected: PASS
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add shared/ws-protocol.ts src/store/panesSlice.ts src/components/TerminalView.tsx crates/freshell-protocol/src/server_messages.rs crates/freshell-ws/src/terminal.rs crates/freshell-freshagent/src/terminal_tabs.rs test/unit/client/store/panesSlice.reconnect.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx
+git add shared/ws-protocol.ts src/store/panesSlice.ts src/components/TerminalView.tsx crates/freshell-protocol/src/server_messages.rs crates/freshell-ws/src/terminal.rs crates/freshell-freshagent/src/terminal_tabs.rs test/unit/client/store/panesSlice.reconnect.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/e2e/terminal-create-attach-ordering.test.tsx
 git commit -m "fix(reopen): D7 refusals name the live owner; the pane reattaches instead of dead-ending"
 ```
 

--- a/docs/plans/2026-08-22-reconnect-revive.md
+++ b/docs/plans/2026-08-22-reconnect-revive.md
@@ -1,0 +1,993 @@
+# Reconnect Revive — Fix the Gray-and-Dead Pane Implementation Plan
+
+> **For agentic workers:** Execute this plan task by task with a fresh
+> implementer and a specification-plus-quality review after every task. Track
+> progress with the checkbox steps below.
+
+## User Request
+
+### Requested result
+Fix Freshell's gray-and-dead pane reconnect bug: on WebSocket reconnect (for example a phone browser returning from background), an open pane pointing at a server-side terminal or agent session that is still running must reattach and repaint live content instead of staying gray/dead — and the close-and-reopen fallback for that pane must revive the still-running session instead of dead-ending on a "Session … is still running on the server." error.
+
+### Explicit constraints
+- Run this fix through the the-usual-beta skill workflow.
+- Reconnect-path only: the multi-view attach feature (#4, including the #2/#3 policy pieces) is deferred to a later run and must not be implemented here.
+- Follow repository rules: red-green-refactor TDD with unit and e2e coverage; fix the system over the symptom.
+- Never restart the production self-hosted server without the user's explicit "APPROVED".
+- Everything lands through a PR targeting `main`; do not create the PR without explicit user approval.
+
+### Accepted tradeoffs and residuals
+- Multi-view/multi-device attach and adopt/view policies (#4, #2, #3) are deferred; this run keeps single-viewer-per-connection semantics.
+- Reconnect-only scope: pre-existing rough edges that are not on the reconnect/reattach path stay as they are.
+
+**Goal:** After any transport drop with the server still up, every open pane of every kind repairs itself: the client detects a dead or half-open socket, reconnects, reattaches (or is routed by reconcile verdicts), and repaints; and a user who closes and reopens such a pane lands attached to the still-running session instead of on a refusal.
+
+**Architecture:** Fix the wedge at each of its four layers, keeping every existing recovery contract intact. (1) Transport liveness — an app-level ping watchdog plus foreground pokes so a half-open socket is recycled into the normal reconnect path. (2) Reconcile loss — a bounded client-side wait that falls back to the legacy inventory census, plus an explicit server error instead of accept-and-strip silence on non-negotiated connections. (3) Per-pane reattach gaps — hidden-pane hydration parity on reconnect, fresh-agent `lost` revocation on truth-bearing evidence, opencode placeholder re-keying on attach ack, and a truthful claude attach-ack status. (4) Close→reopen — route reopen to the live terminal, carry the live terminal id in the D7 refusal, and fold that refusal into an attach instead of a dead-end.
+
+**Tech Stack:** React 18 / Redux Toolkit / TypeScript client (jsdom Vitest), Rust workspace server crates (`freshell-ws`, `freshell-terminal`, `freshell-freshagent`, `freshell-protocol`; cargo tests), Playwright e2e (`test/e2e-browser`, `rust-chromium` project).
+
+## Global Constraints
+
+- Work only in the worktree `/home/dan/code/freshell/.worktrees/reconnect-revive` on branch `the-usual/reconnect-revive`. Never touch the main checkout's files.
+- TypeScript server/shared code is NodeNext/ESM: relative imports include the `.js` extension.
+- Never restart the production self-hosted server (Rust server, port 3001) without the user's explicit `APPROVED`. Do not create a PR without explicit user approval. Commits keep the existing repo identity (`Dan Shapiro <3732858+danshapiro@users.noreply.github.com>`); never modify git config.
+- Focused test commands (run from the worktree root): client unit `npm run test:vitest -- run <file>` (client config is the default); Rust `cargo test -p <crate> <test-name-filter>`; e2e single spec `npx playwright test --config test/e2e-browser/playwright.config.ts --project=rust-chromium <spec-file>`. Broad suites (`npm test`, `npm run check`) are gate-coordinated and only run at the stage-4 gate, not per task.
+- One-JSONL-writer doctrine is untouched: the D7 live-guard and D8 lease stay in force; revival rides `terminal.attach` / `freshAgent.attach` / reconcile `attach` verdicts to the live handle — never a create-with-resume against a live owner.
+- Attach generation and geometry authority discipline is untouched: reattach carries a fresh `attachRequestId`; only visible panes claim viewport geometry on the wire (hidden panes use `keepalive_delta`/background hydration per `src/lib/terminal-attach-policy.ts`).
+- Frozen-client wire parity: every new wire field is optional and omitted when absent (`#[serde(skip_serializing_if = "Option::is_none")]`); any new error code is emitted only on a code path that pre-reconcile clients never drive (they never send `pane.reconcile.request`).
+- Do not add attach ACKs for claude/codex tracked-live attach (wire-shape parity; ws-oracle differential captures pin the silence). Repaint authority for fresh-agent panes stays the client-initiated HTTP snapshot fetch, hardened by Task 4.
+- No `TBD`/placeholder steps, no test that only checks static copy, no behavioral outcome left covered only by a mock or stub. UI copy changes go through the a11y lint (`npm run lint`) — this run's only user-visible copy is inside the xterm notice buffer, which is not DOM-a11y scoped.
+- `docs/index.html` is not updated by this run: no new user-facing feature or major UI change (behavioral fixes only).
+
+## Root-Cause Map (from the four explorer reports)
+
+Evidence lives in `.worktrees/.the-usual-logs/reconnect-revive/reports/` (`plan-client-terminal-reconnect.md`, `plan-server-ws-attach.md`, `plan-fresh-agent-reconnect.md`, `plan-tests-priorart-graystate.md`). The wedge layers:
+
+1. **No transport liveness on the client.** Everything rides on the browser delivering `onclose`; a half-open socket (phone radio flap, NAT timeout, frozen tab) never starts `scheduleReconnect` (`src/lib/ws-client.ts:508-586` is onclose-only), and nothing re-asserts connectivity on foreground (no `visibilitychange`/`online`/`pageshow` poke reaches `getWsClient()`). While the socket is dead-but-open, keystrokes pour into `pendingMessages` and are filter-dropped on the eventual reconnect (`ws-client.ts:300-304`).
+2. **Reconcile-result loss is a silent wedge.** The boot `pane.reconcile.result` is unicast to the requesting socket with no client wall-clock bound (`src/App.tsx:916-918` documents the deliberate absence), and the server accept-and-strip ignores the request on non-negotiated connections (`crates/freshell-ws/src/terminal.rs:1232-1243`). A lost result leaves every pane pending-verdict = gray with zero chrome.
+3. **Per-pane reattach gaps.** Hidden terminal panes register with the hydration queue on reconnect WITHOUT enqueueing themselves when their parser checkpoint is unusable (`src/components/TerminalView.tsx:5207`, `queueIfStarted: canResumeFromParserAppliedSurface`), unlike the `terminal.created` path's three-step re-register (`TerminalView.tsx:4506-4508`). Fresh-agent codex panes wedge on `lost=true`: nothing on the reconnect path clears it (`sessionSnapshotReceived` does not; the boot-reconcile attach fold does not; the `.lost` recovery effect cannot re-fire without a dep change — `FreshAgentView.tsx:1726,2045-2077`). Opencode panes addressed by a placeholder id miss frames stamped with the materialized `ses_*` id (`opencode_ws.rs:1394-1397`). Claude attach acks hardcode `idle` (`claude.rs:1203,1373`), leaving stale-busy panes after a dead-window turn completion.
+4. **Close→reopen dead-ends.** Sidebar close is detach-only; reopen issues `terminal.create{sessionRef}` which meets the D7 live-guard → `error{RESTORE_UNAVAILABLE,"Session {sid} is still running on the server."}` (`crates/freshell-ws/src/terminal.rs:2615-2621`; REST twin `crates/freshell-freshagent/src/terminal_tabs.rs:1223-1235`) → a terminal `[Restore failed]` write (`TerminalView.tsx:4897-4901`).
+
+Existing reconnect machinery that MUST stay intact (regression surface): the per-connection revival trio (re-attach on `onReconnect` with generation-tagged `terminal.attach`; boot reconcile + verdict folds; legacy census fallback), the sender-level pre-verdict create hold (`RECONCILE_VERDICT_WAIT_MS`), RebindQueue flap safety for hidden fresh-agent panes, the ws-oracle parity pins, and PR #532 launch-retry semantics.
+
+---
+
+### Task 1: WS transport liveness — app-level ping watchdog + foreground reconnect poke
+
+The client recycles a silently-dead socket into the existing reconnect machinery instead of waiting forever for `onclose`. Server-side WS pings are invisible to JS, so liveness is proven by an app-level `{type:'ping'}`→`{type:'pong'}` round trip that both servers already implement (`crates/freshell-ws/src/terminal.rs` Ping dispatch; legacy `server/ws-handler.ts:1832-1835`; pinned by `test/e2e-browser/specs/ws-ping-pong-matrix.spec.ts`).
+
+**Files:**
+- Modify: `src/lib/ws-client.ts` (state block ~:120-150; `handleIncomingMessage` :231; `onopen` :454; `onmessage` :478; `onclose` :508; `disconnect` :644; add `tickLiveness`/`poke`/`clearLivenessWatch` methods)
+- Modify: `src/App.tsx` (bootstrap effect ~:1470-1487: register/cleanup `visibilitychange`/`online`/`pageshow` listeners)
+- Test: `test/unit/client/lib/ws-client.liveness.test.ts` (create)
+- Test: `test/unit/client/components/App.ws-bootstrap.test.tsx` (add one wiring case)
+
+**Interfaces:**
+- Consumes: existing `sendNow`, `clearReconnectTimer`, `connect()`, `log` (client-logger), both servers' `ping`→`pong` shape.
+- Produces: `WsClient.poke(): void` — re-asserts connectivity on foreground: while `ready`, probes or force-recycles a long-silent socket; while down, skips the throttled backoff wait and connects immediately. App's foreground listeners call it.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Create `test/unit/client/lib/ws-client.liveness.test.ts`, mirroring the `MockWebSocket` harness and `vi.useFakeTimers()` setup of `test/unit/client/lib/ws-client.test.ts` (its lines 1-60), with a `connectReady(client)` helper that constructs a client, captures the latest `MockWebSocket.instances` entry, calls `_open()`, delivers `{type:'ready', bootId, serverInstanceId, capabilities:{...}}` via `_message`, and returns the socket:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WsClient, resetWsClientForTests } from '../../../../src/lib/ws-client'
+// MockWebSocket class + connectReady helper copied from ws-client.test.ts's harness.
+
+describe('WsClient liveness', () => {
+  beforeEach(() => { /* identical harness setup: fake timers, WebSocket override, auth token */ })
+  afterEach(() => { resetWsClientForTests(); vi.clearAllTimers(); vi.useRealTimers() })
+
+  it('sends an app-level ping after 30s of inbound silence while ready', async () => {
+    const { socket } = await connectReady(new WsClient('ws://test/ws'))
+    // Ready traffic itself was inbound activity; 30s of silence triggers the probe.
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(true)
+  })
+
+  it('does not ping while inbound traffic keeps the socket fresh', async () => {
+    const { socket } = await connectReady(new WsClient('ws://test/ws'))
+    await vi.advanceTimersByTimeAsync(15_000)
+    socket._message({ type: 'settings.updated', settings: {} }) // any inbound frame
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(false)
+  })
+
+  it('closes a socket whose probe goes unanswered past the pong timeout, entering the reconnect path', async () => {
+    const { socket } = await connectReady(new WsClient('ws://test/ws'))
+    await vi.advanceTimersByTimeAsync(30_000)          // probe sent
+    expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(true)
+    await vi.advanceTimersByTimeAsync(10_000)          // no pong → stale
+    expect(MockWebSocket.instances.length).toBe(1)
+    await vi.advanceTimersByTimeAsync(5_000)           // reconnect backoff lands a NEW socket
+    expect(MockWebSocket.instances.length).toBe(2)
+  })
+
+  it('clears the outstanding probe on any inbound message (no close)', async () => {
+    const { socket } = await connectReady(new WsClient('ws://test/ws'))
+    await vi.advanceTimersByTimeAsync(30_000)
+    socket._message({ type: 'pong', timestamp: 'x' })
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(MockWebSocket.instances.length).toBe(1)     // socket never recycled
+  })
+
+  it('poke() while ready and recently active sends an immediate probe', async () => {
+    const { client, socket } = await connectReady(new WsClient('ws://test/ws'))
+    client.poke()
+    expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(true)
+  })
+
+  it('poke() after 65s+ of silence recycles immediately instead of waiting out the probe', async () => {
+    const { client, socket } = await connectReady(new WsClient('ws://test/ws'))
+    // Simulate a frozen tab: no timers ran (background clamp) but the wall
+    // clock jumped past the recycle threshold.
+    vi.setSystemTime(Date.now() + 65_000)
+    client.poke()
+    await vi.advanceTimersByTimeAsync(2_000)           // reconnect backoff lands
+    expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(false) // no probe wait
+    expect(MockWebSocket.instances.length).toBe(2)     // recycled into a fresh socket
+    vi.setSystemTime(Date.now() - 65_000)
+  })
+
+  it('poke() while disconnected skips the pending backoff wait and connects now', async () => {
+    const { client } = await connectReady(new WsClient('ws://test/ws'))
+    MockWebSocket.instances[0]._close(4002, 'boom')    // transient → scheduleReconnect armed (1s+)
+    client.poke()
+    expect(MockWebSocket.instances.length).toBe(2)     // connected without advancing timers
+  })
+
+  it('stops probing after disconnect()', async () => {
+    const { client, socket } = await connectReady(new WsClient('ws://test/ws'))
+    client.disconnect()
+    const sentCount = socket.sent.length
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(socket.sent.length).toBe(sentCount)
+  })
+})
+```
+
+(Redraft note: the 65s-silence case is exercised more directly by setting `vi.setSystemTime` forward past the recycle threshold with the liveness interval temporarily stopped — assert `poke()` closes the socket immediately with no preceding `ping` in `socket.sent`.)
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.liveness.test.ts`
+
+Expected: FAIL because `'ping'` frames are never sent, `client.poke is not a function`, and no recycle occurs — the missing behavior, not a setup accident.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+`src/lib/ws-client.ts`:
+
+```ts
+// Constants (top of file, next to CONNECTION_TIMEOUT_MS):
+// Liveness probe cadence matches both servers' 30s keepalive; the pong timeout
+// bounds "half-open" detection; the foreground recycle threshold is >2 server
+// keepalive windows — past it the server may already have reaped the peer.
+const LIVENESS_INTERVAL_MS = 30_000
+const PONG_TIMEOUT_MS = 10_000
+const FOREGROUND_RECYCLE_SILENCE_MS = 65_000
+
+// Class state:
+private lastInboundAt = 0
+private probeSentAt: number | null = null
+private livenessTimer: number | null = null
+```
+
+In `handleIncomingMessage` (top): `this.lastInboundAt = Date.now(); this.probeSentAt = null` — any parsed inbound frame is liveness evidence (a socket relaying traffic is not half-open).
+
+In `onopen`: `this.lastInboundAt = Date.now(); this.probeSentAt = null; this.startLivenessWatch()`.
+
+New methods:
+
+```ts
+private startLivenessWatch(): void {
+  this.clearLivenessWatch()
+  this.livenessTimer = window.setInterval(() => this.tickLiveness(), LIVENESS_INTERVAL_MS)
+}
+
+private clearLivenessWatch(): void {
+  if (this.livenessTimer !== null) { window.clearInterval(this.livenessTimer); this.livenessTimer = null }
+  this.probeSentAt = null
+}
+
+private tickLiveness(): void {
+  if (this._state !== 'ready' || !this.ws || this.ws.readyState !== WebSocket.OPEN) return
+  const now = Date.now()
+  if (this.probeSentAt !== null) {
+    if (now - this.probeSentAt >= PONG_TIMEOUT_MS) {
+      // Half-open socket: the peer (or the path) is dead but the browser never
+      // delivered onclose. Recycling enters the NORMAL onclose → scheduleReconnect
+      // path; every pane-recovery mechanism keys off that.
+      log.warn('liveness probe unanswered; recycling stale socket')
+      this.ws.close()
+    }
+    return
+  }
+  if (now - this.lastInboundAt < LIVENESS_INTERVAL_MS) return
+  this.probeSentAt = now
+  this.sendNow({ type: 'ping' })
+}
+
+/**
+ * Foreground poke: re-assert connectivity when the page becomes visible/online.
+ * - ready + recently active   → probe immediately (fast failure discovery).
+ * - ready + silent past two server keepalive windows → recycle: the peer may
+ *   already be reaped, and reconnect convergence is cheaper than the probe wait.
+ * - down with a (possibly background-clamped) backoff timer pending → connect now.
+ */
+poke(): void {
+  if (this.intentionalClose) return
+  if (this._state === 'ready') {
+    if (Date.now() - this.lastInboundAt >= FOREGROUND_RECYCLE_SILENCE_MS) {
+      log.info('foreground poke: silent past keepalive windows; recycling socket')
+      this.ws?.close()
+      return
+    }
+    this.tickLiveness()
+    return
+  }
+  if (this.connectPromise) return
+  if (this._state === 'connecting') return
+  this.clearReconnectTimer()
+  this.connect().catch((err) => log.debug('poke reconnect failed', err))
+}
+```
+
+Call `this.clearLivenessWatch()` in `onclose` (with the other clears) and in `disconnect()`.
+
+`src/App.tsx` bootstrap effect (next to the `cleanupPromise`/cleanup return, ~:1476-1487):
+
+```ts
+const ws = getWsClient()
+const pokeWs = () => ws.poke()
+const pokeWsWhenVisible = () => { if (document.visibilityState === 'visible') ws.poke() }
+window.addEventListener('online', pokeWs)
+window.addEventListener('pageshow', pokeWs)
+document.addEventListener('visibilitychange', pokeWsWhenVisible)
+// ... cleanup: remove the three listeners.
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.liveness.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx`
+
+Expected: PASS (add one poke-wiring case to the bootstrap suite: dispatch a `visibilitychange` event with the document visible and assert a spy on `WsClient.prototype.poke` fired).
+
+- [ ] **Step 5: Refactor while green**
+
+Keep constants exported only if a test import needs them; otherwise private. No further refactor — single-purpose methods.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The timer/filter changes touch every ws-client behavior suite plus the offline-chip/App bootstrap path and the client activity-callback wiring.
+
+Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.test.ts test/unit/client/lib/ws-client.reconnect-noise.test.ts test/unit/client/lib/ws-client.reconcile.test.ts test/unit/client/lib/ws-client.liveness.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx test/unit/client/components/App.restart-signals.test.tsx test/e2e/turn-complete-notification-flow.test.tsx test/unit/client/activity-callbacks.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/lib/ws-client.ts src/App.tsx test/unit/client/lib/ws-client.liveness.test.ts test/unit/client/components/App.ws-bootstrap.test.tsx
+git commit -m "fix(ws): recycle silently-dead sockets via app-level liveness probe + foreground poke"
+```
+
+### Task 2: Boot-reconcile bounded wait (client) + explicit refusal on non-negotiated connections (server)
+
+A lost `pane.reconcile.result` must no longer wedge panes pending-verdict forever. Client side: after sending the boot request, App arms a 10s wall-clock timer (server's single warming deferral is 2s — `crates/freshell-ws/src/terminal.rs:4412-4430`); on expiry with the request still pending it runs the same teardown the correlated-error path already runs (`fallBackToLegacyCensus`). Server side: a `pane.reconcile.request` arriving on a connection that did not negotiate `paneReconcileV1` gets an explicit terminal error carrying the reconcileId, so post-reconcile clients fall back instantly and pre-reconcile clients never send the request at all.
+
+**Files:**
+- Modify: `src/lib/pane-reconcile.ts` (export the new constant)
+- Modify: `src/App.tsx` (~:1034-1141 ready/reconcile handlers; disconnect handler ~:766-773)
+- Modify: `crates/freshell-protocol/src/server_messages.rs` (new `ErrorCode` variant, ~:enum ErrorCode)
+- Modify: `crates/freshell-ws/src/terminal.rs` (:1232-1243 PaneReconcileRequest dispatch arm)
+- Test: `test/unit/client/components/App.reconcile-adoption.test.tsx` (add cases)
+- Test: `crates/freshell-ws/src/terminal.rs` `#[cfg(test)]` module (add rust test)
+
+**Interfaces:**
+- Consumes: existing `fallBackToLegacyCensus`, `pendingReconcileRef`, `clearReconcileCreateHold`, `clearAllReconcilePendingPanes`; server `ErrorMsg` struct + `send(ws_tx, …)`.
+- Produces: `export const RECONCILE_RESULT_WAIT_MS = 10_000` (pane-reconcile.ts); wire error code `RECONCILE_NOT_NEGOTIATED` (string) on `error` frames carrying `requestId = <reconcileId>`.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Client — in `test/unit/client/components/App.reconcile-adoption.test.tsx` (existing harness drives ready frames + reconcile result frames; follow its conventions):
+
+```ts
+it('falls back to the legacy census when no reconcile result arrives within 10s', async () => {
+  // ... boot a ready frame with paneReconcileV1 acknowledged and one live-terminal-less pane;
+  await vi.advanceTimersByTimeAsync(10_000)
+  // assert: pane no longer reconcile-pending and the census cleared its dead handle:
+  const paneContent = /* select the pane */
+  expect(paneContent.pendingReconcile).toBeUndefined()
+  expect(paneContent.terminalId).toBeUndefined() // census wiped the stale handle
+  expect(paneContent.status).toBe('creating')    // census re-armed the create path
+})
+
+it('does NOT run the census when the result folds before the wait expires', async () => {
+  // ... fold a normal attach verdict at t=2s; advance past 10s; assert no census ran
+  // (pane keeps its verdict-written terminalId; clearDeadTerminals never fired).
+})
+
+it('cancels the result wait on disconnect (no offline census)', async () => {
+  // ... ready + pending request, then deliver the ws disconnect path;
+  await vi.advanceTimersByTimeAsync(15_000)
+  // assert: NO census ran while disconnected (pane content unchanged, no clearDeadTerminals fold)
+})
+```
+
+Server — in the `terminal.rs` test module (follow its existing `handle_client_text` harness conventions):
+
+```rust
+#[tokio::test]
+async fn pane_reconcile_request_without_capability_gets_explicit_error() {
+    // Arrange a connection state with pane_reconcile_v1 = false, feed a
+    // PaneReconcileRequest frame with reconcile_id "r1".
+    // Assert the captured outgoing frame is error{code:"RECONCILE_NOT_NEGOTIATED",
+    // request_id:"r1"} — previously the arm returned true with no frame.
+}
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/client/components/App.reconcile-adoption.test.tsx`
+
+Expected: FAIL because the pending pane never resolves without a result (new timeout behavior missing).
+
+Run: `cargo test -p freshell-ws pane_reconcile_request_without_capability_gets_explicit_error`
+
+Expected: FAIL because no error frame is emitted (accept-and-strip today), not a compile/setup accident (the new `ErrorCode` variant will not exist yet — add the variant first if the red run needs compilation; that edit alone does not change behavior).
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+`src/lib/pane-reconcile.ts` top: `export const RECONCILE_RESULT_WAIT_MS = 10_000 // > the server's single 2s warming deferral + round-trip margin`.
+
+`src/App.tsx`:
+
+```ts
+const reconcileResultTimerRef = useRef<number | null>(null)
+const clearReconcileResultWait = () => {
+  if (reconcileResultTimerRef.current !== null) {
+    window.clearTimeout(reconcileResultTimerRef.current)
+    reconcileResultTimerRef.current = null
+  }
+}
+```
+
+In the ready branch, immediately after `ws.send(req)`:
+
+```ts
+clearReconcileResultWait()
+reconcileResultTimerRef.current = window.setTimeout(() => {
+  reconcileResultTimerRef.current = null
+  if (!pendingReconcileRef.current) return
+  // The result is unicast to THIS socket; if it was lost with a dying socket,
+  // only ANOTHER ready would heal the wedge (gray panes, zero chrome). Bound
+  // the wait and degrade to the legacy census instead. This supersedes the
+  // earlier deliberate no-timeout decision: the wedge it permits is the
+  // reported gray-and-dead shape.
+  log.warn('[reconcile] result wait expired — falling back to legacy census')
+  pendingReconcileRef.current = null
+  dispatch(clearAllReconcilePendingPanes())
+  ws.clearReconcileCreateHold()
+  fallBackToLegacyCensus()
+}, RECONCILE_RESULT_WAIT_MS)
+```
+
+In the `pane.reconcile.result` branch: call `clearReconcileResultWait()` right where `pendingReconcileRef.current = null` runs (fold and malformed paths alike). In the correlated `error` branch: same. In App's disconnect handling (where connection status flips away): `clearReconcileResultWait(); pendingReconcileRef.current = null` — the next ready re-sends the request; never census from stale inventory while offline.
+
+`crates/freshell-protocol/src/server_messages.rs` — add to `ErrorCode`:
+
+```rust
+/// pane.reconcile.request arrived on a connection that did not negotiate
+/// paneReconcileV1: terminal for that request (the client falls back to the
+/// legacy inventory census). Never emitted to pre-reconcile clients — they
+/// never send the request.
+#[serde(rename = "RECONCILE_NOT_NEGOTIATED")]
+ReconcileNotNegotiated,
+```
+
+`crates/freshell-ws/src/terminal.rs` (:1232-1243 arm):
+
+```rust
+ClientMessage::PaneReconcileRequest(request) => {
+    if pane_reconcile_v1 {
+        return handle_pane_reconcile(request, ws_tx, state, pane_reconcile_fresh_agent_v1)
+            .await;
+    }
+    // Capability not negotiated on THIS connection: answer explicitly so the
+    // client falls back to the legacy census NOW instead of wedging every
+    // pane pending-verdict until the next reconnect.
+    send(
+        ws_tx,
+        &ServerMessage::Error(ErrorMsg {
+            code: ErrorCode::ReconcileNotNegotiated,
+            message: "pane.reconcile was not negotiated on this connection; fall back to the inventory census.".to_string(),
+            timestamp: crate::now_iso(),
+            actual_session_ref: None,
+            expected_session_ref: None,
+            request_id: Some(request.reconcile_id.clone()),
+            retry_after_ms: None,
+            terminal_exit_code: None,
+            terminal_id: None,
+        }),
+    )
+    .await;
+    true
+}
+```
+
+(`PaneReconcileRequest.reconcile_id` confirmed at `crates/freshell-protocol/src/client_messages.rs:447-453`; `send`/`ws_tx` usage mirrors the adjacent `Ping` arm.)
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/client/components/App.reconcile-adoption.test.tsx && cargo test -p freshell-ws pane_reconcile_request_without_capability_gets_explicit_error`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+None beyond the shared `clearReconcileResultWait` helper — the three teardown call sites stay inline (they read as one deliberate sequence).
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Reconcile adoption/waiting, census fallback, restart signals, and the verdict-wait pane gate are the collision surface; the ErrorCode enum grow touches the port-oracle enum pins.
+
+Run: `npm run test:vitest -- run test/unit/client/components/App.reconcile-adoption.test.tsx test/unit/client/components/App.restart-signals.test.tsx test/unit/client/components/TerminalView.verdict-wait.test.tsx test/e2e/terminal-restart-recovery.test.tsx test/unit/port/oracle/t2-invariants.test.ts test/unit/port/oracle/mutation-validation.test.ts && cargo test -p freshell-ws reconcile && cargo test -p freshell-protocol`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/lib/pane-reconcile.ts src/App.tsx crates/freshell-protocol/src/server_messages.rs crates/freshell-ws/src/terminal.rs test/unit/client/components/App.reconcile-adoption.test.tsx
+git commit -m "fix(reconcile): bound the boot-result wait and answer non-negotiated requests explicitly"
+```
+
+### Task 3: Hidden terminal panes pump their reconnect rehydration
+
+On reconnect, a hidden terminal pane whose parser checkpoint is unusable registers with the hydration queue with `queueIfStarted:false`, so with the queue already started it sits registered-but-never-pumped until reveal — a gray background tab that looks exactly like the bug. Mirror the proven three-step re-register of the `terminal.created`-while-hidden path (`TerminalView.tsx:4506-4508`).
+
+**Files:**
+- Modify: `src/components/TerminalView.tsx` (:5191-5208 `onReconnect` hidden branch)
+- Test: `test/unit/client/components/TerminalView.hidden-rebind.test.tsx` and/or `TerminalView.lifecycle.test.tsx` (add cases; the lifecycle :7942 region already covers reconnect-before-first-hidden-attach)
+
+**Interfaces:**
+- Consumes: `getHydrationQueue().onHydrationComplete`, `hydrationRegisteredRef`, `registerForBackgroundHydration({ queueIfStarted })`.
+- Produces: none new (behavioral parity).
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add to the hidden-rebind/lifecycle suite:
+
+```ts
+it('pumps the hydration queue for a hidden pane on reconnect even without a usable parser checkpoint', async () => {
+  // Arrange: hidden pane with a live terminalId; hydration queue already STARTED
+  // (active tab hydrated first); NO parser-applied checkpoint for the terminal,
+  // so getCheckpointDeltaReplayDecision(tid) is not ok.
+  simulateReconnect()
+  // Act: let the hydration pump run (the queue drives one pane at a time).
+  // Assert: a terminal.attach left the client for the hidden pane WITHOUT a
+  // reveal, intent 'viewport_hydrate' (checkpoint-missing branch), and the
+  // queue advanced past this pane (subsequent registered hidden pane also pumped).
+})
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.hidden-rebind.test.tsx`
+
+Expected: FAIL because no attach is sent for the hidden pane until reveal (today's `queueIfStarted:false` path), not a harness error.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+`TerminalView.tsx` :5191-5208 — in the `onReconnect` hidden branch, replace the bare register call with the same three-step preflight the `terminal.created` hidden branch uses:
+
+```ts
+// Same three-step re-register as the terminal.created hidden path
+// (~:4506): a stale active slot or a consumed registration guard
+// otherwise wedges this pane out of the post-reconnect pump entirely.
+getHydrationQueue().onHydrationComplete(paneIdRef.current)
+hydrationRegisteredRef.current = false
+// Always queueIfStarted: a hidden pane's reattach must not wait for reveal.
+// The deferred intent chosen above (transport_reconnect vs viewport_hydrate)
+// still governs WHAT the attach asks for; this only governs THAT it runs.
+registerForBackgroundHydration({ queueIfStarted: true })
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.hidden-rebind.test.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+Factor the three-line re-register into one local helper used by both the `terminal.created` hidden branch and the reconnect hidden branch if the reviewer prefers DRY over deliberate duplication; either is acceptable — state the choice in the commit.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Hidden rebind, visibility transitions, hydration queue consumers, attach policy:
+
+Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.hidden-rebind.test.tsx test/unit/client/components/TerminalView.visibility.test.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/lib/hydration-queue.test.ts test/unit/client/lib/terminal-attach-policy.test.ts test/e2e/terminal-create-attach-ordering.test.tsx`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/components/TerminalView.tsx test/unit/client/components/TerminalView.hidden-rebind.test.tsx test/unit/client/components/TerminalView.lifecycle.test.tsx
+git commit -m "fix(terminal): pump hidden-pane rehydration on reconnect instead of waiting for reveal"
+```
+
+### Task 4: Fresh-agent `lost` revokes on truth-bearing reconnect evidence
+
+A codex (or claude) fresh-agent pane whose session slice entry got `lost=true` (spurious `INVALID_SESSION_ID` from a transient attach-resume race during the dead window) wedges forever: the snapshot fetch is suppressed (`FreshAgentView.tsx:1726`) and no reconnect path clears the flag. Three moves, all on the reconnect path: (a) a truth-bearing server answer revokes `lost`, (b) the server-authoritative `Live → attach` verdict fold revokes it, (c) the `.lost` recovery effect re-fires on a fresh reconnect even when its other deps are unchanged.
+
+**Files:**
+- Modify: `src/store/freshAgentSlice.ts` (`sessionSnapshotReceived` :293-328; `freshAgentSnapshotReceived` :374-399)
+- Modify: `src/lib/pane-reconcile.ts` (fresh-agent attach-verdict fold, ~:300)
+- Modify: `src/components/fresh-agent/FreshAgentView.tsx` (`.lost` recovery effect deps :2045-2077)
+- Test: `test/unit/client/store/freshAgentSlice.test.ts` (add cases; create the file only if absent — check first)
+- Test: `test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx` (add cases)
+
+**Interfaces:**
+- Consumes: existing `clearSessionLost` reducer (`freshAgentSlice.ts:475-481`), `applyFreshAgentReconcileAttach` fold, `state.connection.status`.
+- Produces: none new.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Slice: `sessionSnapshotReceived` and `freshAgentSnapshotReceived` each clear `lost` on the addressed session (a snapshot answer is positive evidence the session exists — the 404 `FRESH_AGENT_LOST_SESSION` path never dispatches these).
+
+View fold: with a codex pane `lost=true`, no sessionId change possible (durable id already), delivering a fresh-agent `attach` verdict via the boot reconcile fold clears `lost` in the freshAgent slice and the next snapshot-fetch effect run issues the HTTP GET (spy on `fetch`).
+
+Reconnect re-drive: with the pane still `lost=true` and NO verdict (reconcile absent), flipping `connection.status` `'disconnected' → 'ready'` re-runs the `.lost` recovery effect (spy `reconcileLostPane`/`triggerRecovery`).
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/client/store/freshAgentSlice.test.ts test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx`
+
+Expected: FAIL because `lost` stays true through all three paths (today's behavior), not a harness mistake.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+`freshAgentSlice.ts` — in `sessionSnapshotReceived` after `resolveOrEnsureSession` succeeds, and in `freshAgentSnapshotReceived` after `ensureSession`:
+
+```ts
+// Truth-bearing frame: a snapshot answer proves the session exists — revoke a
+// stale `lost` flag from a transient dead-window race (reconnect unwedge).
+session.lost = false
+```
+
+`pane-reconcile.ts` — in the fresh-agent `attach` verdict fold, immediately after dispatching `applyFreshAgentReconcileAttach`:
+
+```ts
+// Server said Live: the verdict itself is positive existence evidence.
+dispatch(clearSessionLost({ sessionId: <verdict locator sessionId>, sessionType: <…>, provider: <…> }))
+```
+
+(Locator fields come from the verdict's `sessionRef` / pane entry following the adjacent `applyFreshAgentReconcileAttach` payload shape; import `clearSessionLost` from the slice.)
+
+`FreshAgentView.tsx` — add a selector `const connectionStatus = useAppSelector((s) => s.connection.status)` and add `connectionStatus` to the `.lost` recovery effect's dep array (:2069-2077 region), with a short comment: a fresh reconnect re-drives recovery even when lost/sessionId are unchanged.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/client/store/freshAgentSlice.test.ts test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+None — three one-line/one-call changes at the exact seams; any dedup would hide intent.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Fresh-agent slice contracts, reconcile folds, hidden rebind (its Test 2 pins `.lost` re-create), snapshot scheduler consumers:
+
+Run: `npm run test:vitest -- run test/unit/client/store/freshAgentSlice.test.ts test/unit/client/components/fresh-agent/FreshAgentView.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.hidden-rebind.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.waiting-edge.test.tsx test/unit/client/lib/fresh-agent-ws.test.ts test/unit/client/lib/pane-reconcile.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/store/freshAgentSlice.ts src/lib/pane-reconcile.ts src/components/fresh-agent/FreshAgentView.tsx test/unit/client/store/freshAgentSlice.test.ts test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx
+git commit -m "fix(fresh-agent): revoke stale session-lost flags on truth-bearing reconnect evidence"
+```
+
+### Task 5: Opencode placeholder-addressed attach ack re-keys the pane
+
+Opencode's tracked-attach ack is stamped with the materialized `ses_*` id (`opencode_ws.rs:1394-1397`). A pane still addressed by its placeholder id cannot correlate that ack (its `locatorMatchesPane` filter drops it), keeps the placeholder identity, and its next snapshot GET 404s into a false `durable_artifact_missing` against a live session. The server already has the `freshAgent.session.materialized` wire event and the client already folds it into BOTH the slice and pane content (`fresh-agent-ws.ts:154-176`, `materializeFreshAgentPaneSession`) — emit it on this path too.
+
+**Files:**
+- Modify: `crates/freshell-freshagent/src/opencode_ws.rs` (`handle_attach` tracked arm :1394-1410)
+- Test: `crates/freshell-freshagent/src/opencode_ws.rs` `#[cfg(test)]` (add rust test)
+- Test: `test/unit/client/lib/fresh-agent-ws.test.ts` (add a fold case)
+
+**Interfaces:**
+- Consumes: existing `FreshAgentSessionMaterialized` protocol struct and the send-path emitter shape at `opencode_ws.rs:716-730`.
+- Produces: on a tracked `freshAgent.attach` whose request `session_id` is a placeholder alias (differs from the session's real/materialized id), the server broadcasts `freshAgent.session.materialized{previousSessionId, sessionId: real, sessionType, provider, sessionRef}` immediately BEFORE the ack snapshot (stamped real id).
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Rust: attach a tracked session by its placeholder id → assert the broadcast sequence includes `freshAgent.session.materialized{previousSessionId: <placeholder>, sessionId: <ses_*>}` followed by `freshAgent.session.snapshot` stamped with `<ses_*>`; and that attaching by the real id emits NO materialized frame (regression guard against spam when identity already matches).
+
+Client (fresh-agent-ws.test.ts): feeding a `freshAgent.session.materialized` frame for a placeholder-keyed pane dispatches both the slice `materializeSession` and the pane-content sessionId re-key (this may already pass — keep as the fold pin proving Task 5 needs no client change).
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `cargo test -p freshell-freshagent attach_placeholder_addressed_session_emits_materialized_first`
+
+Expected: FAIL because no materialized frame is emitted on the attach ack arm today, not a compile accident.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+In `handle_attach`'s tracked arm, before the snapshot broadcast:
+
+```rust
+// Attach addressed by the PLACEHOLDER id of an already-materialized session:
+// the requesting pane cannot correlate frames stamped with the real ses_* id
+// (locatorMatchesPane), so its snapshot fetch would 404 into a false
+// restore-error. Re-key it first via the same wire event the send path uses
+// (:716-730) — the client fold updates slice AND pane content.
+if let Some(real_id) = session_real_id.as_ref() {        // existing real_session_id source
+    if real_id != &msg.session_id {
+        self.broadcast(&ServerMessage::FreshAgentSessionMaterialized(
+            FreshAgentSessionMaterialized {
+                previous_session_id: msg.session_id.clone(),
+                provider: PROVIDER.to_string(),
+                session_id: real_id.clone(),
+                session_type: SESSION_TYPE.to_string(),
+                session_ref: Some(SessionLocator {
+                    provider: PROVIDER.to_string(),
+                    session_id: real_id.clone(),
+                }),
+            },
+        ));
+    }
+}
+```
+
+(Use the variable the tracked arm already holds for the real/placeholder pair; the ack snapshot itself stays stamped per the existing `real_session_id ?? placeholder` rule.)
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `cargo test -p freshell-freshagent attach_placeholder` && `npm run test:vitest -- run test/unit/client/lib/fresh-agent-ws.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+If the send-path materialized construction and this one now duplicate, extract one `materialized_frame(previous, real) -> ServerMessage` helper in `opencode_ws.rs` and use both call sites.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The opencode attach/ack pins and the materialization-once pins:
+
+Run: `cargo test -p freshell-freshagent && npm run test:vitest -- run test/unit/client/lib/fresh-agent-ws.test.ts test/unit/client/components/fresh-agent/FreshAgentView.test.tsx test/unit/client/store/freshAgentSlice.test.ts && npm run test:vitest -- run test/integration/port/oracle/t2-opencode-equivalence-rust.test.ts`
+
+Expected: PASS (the oracle equivalence run checks the attach-ack capture families; the new frame appears only on placeholder-addressed tracked attach — if a frozen capture pins that path, update the oracle per its documented procedure and note it in the commit).
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add crates/freshell-freshagent/src/opencode_ws.rs test/unit/client/lib/fresh-agent-ws.test.ts
+git commit -m "fix(opencode): re-key placeholder-addressed panes on attach ack via the materialized event"
+```
+
+### Task 6: Claude attach ack carries the session's real status
+
+Both claude attach-ack emit sites broadcast a hardcoded `"idle"` snapshot (`claude.rs:1200-1205` rebind arm, `:1370-1375` resume-for-attach arm). Attaching while a turn is actually running flips the pane to idle (composer mode churn), and — because claude never adopts HTTP snapshot status — a turn that completed in the dead window can leave the pane stale-busy forever when the ack path is the rescuer. Track the last announced status per session and speak it truthfully.
+
+**Files:**
+- Modify: `crates/freshell-freshagent/src/claude.rs` (`ClaudeSession` struct :186-210; both ack sites :1200-1205,:1370-1375; `spawn_consumer` :1414+ status fold)
+- Test: `crates/freshell-freshagent/src/claude.rs` `#[cfg(test)]` (adjust/extend around the existing :2344/:2431 ack assertions)
+
+**Interfaces:**
+- Consumes: the stdout consumer's existing `sdk.status → freshAgent.status` translation (where `normalize_sdk_type`-renamed frames are folded per session).
+- Produces: `ClaudeSession.last_status: Arc<std::sync::Mutex<String>>` (default `"idle"`), written on every `sdk.status` fold and read by both attach-ack sites.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+```rust
+#[tokio::test]
+async fn attach_rebind_ack_stamps_the_tracked_live_status_not_hardcoded_idle() {
+    // Arrange a tracked live claude session; drive an sdk.status { status: "running" }
+    // through the consumer; then attach addressing the durable id (rebind arm).
+    // Assert the ack snapshot's event.status == "running" (not "idle").
+}
+
+#[tokio::test]
+async fn attach_ack_stays_idle_for_a_freshly_resumed_session() {
+    // No sdk.status ever folded → ack still "idle" (pins the default).
+}
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `cargo test -p freshell-freshagent attach_rebind_ack_stamps_the_tracked_live_status_not_hardcoded_idle`
+
+Expected: FAIL because the ack carries the hardcoded `"idle"` while the session status is `"running"`, not a harness mistake.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+```rust
+struct ClaudeSession {
+    // ...existing fields...
+    /// Last status the sidecar announced for this session (sdk.status fold).
+    /// Read by the attach-ack sites so a reconnect ack tells the truth instead
+    /// of the hardcoded "idle" that used to wedge stale-busy/stale-idle panes.
+    last_status: Arc<std::sync::Mutex<String>>,
+}
+```
+
+Initialize `"idle"` at every `ClaudeSession` construction site. In `spawn_consumer`'s event fold (where `sdk.status` frames are handled for broadcast): `*session.last_status.lock().expect("…") = status_value.clone()`. At both `status_snapshot_frame(..., "idle", ...)` call sites, substitute `session.last_status.lock().expect("…").as_str()` (or clone). Fresh resume (`resume_for_attach`) starts at `"idle"` — correct, and this arm's ack remains truthful by construction.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `cargo test -p freshell-freshagent attach_ack && cargo test -p freshell-freshagent status_snapshot`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+If locking ceremony repeats, add `fn current_status(&self) -> String` on `ClaudeSession`.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The claude provider suite and the differential captures that pin ack CONTENT for these arms:
+
+Run: `cargo test -p freshell-freshagent claude && npm run test:vitest -- run test/integration/port/oracle/t2-invariants.test.ts test/unit/client/lib/fresh-agent-ws.test.ts`
+
+Expected: PASS (if the oracle pins a hardcoded-idle capture on an arm whose tracked status changed, update per the oracle refresh procedure and record it).
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add crates/freshell-freshagent/src/claude.rs
+git commit -m "fix(claude): attach ack announces the session's real last status"
+```
+
+### Task 7: Close→reopen revives the still-running session (no more D7 dead-end)
+
+Close is detach-only, so the session's PTY often keeps running; reopening issues `terminal.create{sessionRef}` which the D7 live-guard correctly refuses — and the pane dead-ends at `[Restore failed]`. Disarm the trap three ways, keeping D7/D8 fully in force: (a) the reopen path routes to the live terminal when the client already knows one, (b) the refusal carries the live terminal's id on both lanes, (c) the client folds an id-carrying refusal into an attach instead of a dead-end.
+
+**Files:**
+- Modify: `src/store/terminalMetaSlice.ts` (new selector)
+- Modify: `src/store/tabsSlice.ts` (`openSessionTab` :569+, new-pane arm)
+- Modify: `crates/freshell-protocol/src/server_messages.rs` (`ErrorMsg` optional field)
+- Modify: `crates/freshell-ws/src/terminal.rs` (D7 guard ~:2580-2623: include `live_terminal_id`)
+- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs` (REST 409 :1223-1235: include `liveTerminalId` in the JSON body)
+- Modify: `src/components/TerminalView.tsx` (create-error handler :4872-4901)
+- Modify: `shared/ws-protocol.ts` (error-message schema gains optional `liveTerminalId`)
+- Test: `test/unit/client/store/terminalMetaSlice.test.ts` (add/extend)
+- Test: `test/unit/client/store/tabsSlice.test.ts` (reopen routing case)
+- Test: `test/unit/client/components/TerminalView.lifecycle.test.tsx` (revive fold cases)
+- Test: `crates/freshell-ws/src/terminal.rs` tests; `crates/freshell-freshagent/src/terminal_tabs.rs` tests
+
+**Interfaces:**
+- Consumes: `TerminalMetaRecord{terminalId, provider, sessionId}` + `connection.liveTerminalIds`; `live_session_owner(...) -> Option<String>` (terminal id of the owner) at both guard sites.
+- Produces: `selectLiveTerminalIdForSession(state, provider, sessionId): string | undefined`; wire `error.liveTerminalId?: string`; REST 409 body gains `liveTerminalId` only when a terminal owns the session.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+1. Selector: meta rows + live ids → the live owner id; dead id excluded; provider mismatch excluded.
+2. `openSessionTab` new-pane arm: with a live owner in state, the created pane content carries `terminalId: <owner>`, `status: 'running'`, and NO resume-create follows (spy on the WS send: no `terminal.create` for that pane).
+3. TerminalView revive fold: create-error `{code:'RESTORE_UNAVAILABLE', liveTerminalId:'t1', requestId}` → content gains `terminalId:'t1'`, `status:'running'`, a `terminal.attach` for `t1` is sent, and the pane shows a `Reconnected to the still-running session.` notice — never `[Restore failed]`; a SECOND RESTORE_UNAVAILABLE for the same createRequestId does not revive again (bound the loop) and falls through to the existing error write.
+4. Rust WS: the D7 refusal frame carries `live_terminal_id: Some(<owner>)`. Rust REST: the 409 body carries `liveTerminalId` when a terminal owns the session and omits it for the fresh-agent-cross-kind arm (no terminal id exists there).
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/client/store/terminalMetaSlice.test.ts test/unit/client/store/tabsSlice.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx` and `cargo test -p freshell-ws d7 && cargo test -p freshell-freshagent terminal_tabs`
+
+Expected: FAIL because no selector/revive/payload exists yet (`selectLiveTerminalIdForSession` undefined; refusal payload lacks the id), not harness noise.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Selector (`terminalMetaSlice.ts`):
+
+```ts
+export const selectLiveTerminalIdForSession = (
+  state: { terminalMeta: TerminalMetaState; connection: { liveTerminalIds: string[] | null } },
+  provider: string,
+  sessionId: string,
+): string | undefined => {
+  const live = state.connection.liveTerminalIds
+  if (!live) return undefined
+  for (const meta of Object.values(state.terminalMeta.byTerminalId)) {
+    if (meta.provider === provider && meta.sessionId === sessionId && live.includes(meta.terminalId)) {
+      return meta.terminalId
+    }
+  }
+  return undefined
+}
+```
+
+`openSessionTab` new-pane arm (`tabsSlice.ts`, in the branch that builds fresh resume content):
+
+```ts
+const liveTerminalId = selectLiveTerminalIdForSession(state, resolvedProvider, sessionId)
+// ... when minting the new terminal pane content:
+//   liveTerminalId ? { terminalId: liveTerminalId, status: 'running', sessionRef: {provider, sessionId}, createRequestId: <fresh id> }
+//   : <existing resume content>
+```
+
+(Attach needs no create: TerminalView's create-or-attach effect takes the attach branch when `terminalId` is set — same shape the reconcile-adopt fold writes.)
+
+Wire (`server_messages.rs`):
+
+```rust
+/// D7 (`RESTORE_UNAVAILABLE` only): the live terminal that owns the refused
+/// session, so the client can reattach instead of dead-ending. Additive and
+/// omitted everywhere else.
+#[serde(skip_serializing_if = "Option::is_none")]
+pub live_terminal_id: Option<String>,
+```
+
+Add it to every `ErrorMsg` literal (`send_create_error` at `terminal.rs:4464-4482` sets `live_terminal_id: None`); WS guard: capture `let owner = state.registry.live_session_owner(...)` and emit `live_terminal_id: owner.clone() when registry_row_live`; REST: put `liveTerminalId` in the 409 JSON body from the same owner; `shared/ws-protocol.ts`: error schema gains `liveTerminalId: z.string().optional()`.
+
+TerminalView fold (create-error handler, before the dead-end arms):
+
+```ts
+if (msg.code === 'RESTORE_UNAVAILABLE' && typeof (msg as { liveTerminalId?: unknown }).liveTerminalId === 'string') {
+  const liveId = (msg as { liveTerminalId: string }).liveTerminalId
+  // One revival per createRequestId: if the live handle died in the race, the
+  // follow-on create lands the existing [Restore failed] path — never loop.
+  if (reviveAttemptedRef.current !== reqId) {
+    reviveAttemptedRef.current = reqId
+    updateContent({ status: 'running', terminalId: liveId, streamId: undefined, restoreError: undefined })
+    writeLocalXtermNotice(term, `\r\nReconnected to the still-running session.\r\n`)
+    return
+  }
+}
+```
+
+(`reviveAttemptedRef: useRef<string | null>(null)`, reset when a new createRequestId is minted alongside the existing launch-attempt bookkeeping.)
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/client/store/terminalMetaSlice.test.ts test/unit/client/store/tabsSlice.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx && cargo test -p freshell-ws d7 && cargo test -p freshell-freshagent terminal_tabs && npm run typecheck`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+Keep the refusals' "still running on the server." message text byte-identical (client regexes and user muscle memory depend on it); all novelty rides the additive id field.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Create-error handling (incl. `fresh_after_restore_unavailable`), restore/launch ladders, REST doors, oracle/error-contract pins:
+
+Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/lib/terminal-restore.test.ts test/unit/client/store/tabsSlice.test.ts test/unit/client/store/terminalMetaSlice.test.ts test/unit/port/oracle/t2-invariants.test.ts && cargo test -p freshell-ws && cargo test -p freshell-freshagent && cargo test -p freshell-protocol`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/store/terminalMetaSlice.ts src/store/tabsSlice.ts shared/ws-protocol.ts src/components/TerminalView.tsx crates/freshell-protocol/src/server_messages.rs crates/freshell-ws/src/terminal.rs crates/freshell-freshagent/src/terminal_tabs.rs test/unit/client/store/terminalMetaSlice.test.ts test/unit/client/store/tabsSlice.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx
+git commit -m "fix(reopen): reattach to the still-running session instead of dead-ending on D7"
+```
+
+### Task 8: E2E acceptance — reconnect revives (Rust server)
+
+First-class browser proof of the user-visible acceptance shape on the production server stack, closing the named coverage gaps (rust-side plain socket drop; "stops being gray/dead" assertions; the close→reopen revival; sequential drops mid-reattach).
+
+**Files:**
+- Create: `test/e2e-browser/specs/reconnect-revive-rust.spec.ts`
+- Modify: `test/e2e-browser/playwright.config.ts` (register the spec in `RUST_ONLY_SPECS` :176 list AND the `rust-chromium` project `testMatch` — both, matching the convention of the neighboring entries) and confirm it is NOT in `CLOUD_SKIP_SPECS` (`playwright.cloud.config.ts`)
+- Test: (the spec IS the test)
+
+**Interfaces:**
+- Consumes: fixtures `freshellPage`, `harness` (`forceDisconnect()`, `waitForConnection()`, `getConnectionStatus()`), `terminal` (`waitForTerminal()`, `waitForPrompt()`, `executeCommand()`, `waitForOutput()`), `RustServer`; default `recoveryOfferHandling: 'auto-decline'` (fixtures.ts:94) — no override needed since the spec owns no panel assertions.
+- Produces: none.
+
+- [ ] **Step 1: Write the failing (or coverage-missing) behavioral test**
+
+```ts
+import { test, expect } from '../helpers/fixtures.js'
+
+const noDeadEndText = /still running on the server|\[Restore failed\]/
+
+test.describe('reconnect revive (rust)', () => {
+  test('terminal pane reattaches and repaints after a bare socket drop', async ({ page, harness, terminal }) => {
+    await terminal.waitForTerminal()
+    await terminal.waitForPrompt()
+    await terminal.executeCommand('echo "rr-marker-one"')
+    await terminal.waitForOutput('rr-marker-one')
+
+    await harness.forceDisconnect()
+    await harness.waitForConnection()
+    await page.waitForFunction(
+      () => window.__FRESHELL_TEST_HARNESS__?.getState()?.connection?.status === 'ready',
+      { timeout: 20_000 },
+    )
+
+    // Settled end state, not just "ready": backlog visible again, chips gone.
+    await terminal.waitForOutput('rr-marker-one', { timeout: 20_000 })
+    await expect(page.getByText('Offline: input will queue until reconnected.')).toHaveCount(0)
+    await expect(page.getByText('Recovering terminal output...')).toHaveCount(0)
+    await expect(page.getByText(noDeadEndText)).toHaveCount(0)
+
+    // Live, not a frozen repaint: the PTY still answers input AFTER reconnect.
+    await terminal.executeCommand('echo "rr-marker-two"')
+    await terminal.waitForOutput('rr-marker-two', { timeout: 10_000 })
+  })
+
+  test('close -> reopen revives the still-running session instead of the "still running" refusal', async ({ page, harness, terminal }) => {
+    await terminal.waitForTerminal()
+    await terminal.waitForPrompt()
+    await terminal.executeCommand('echo "rr-close-marker"')
+    await terminal.waitForOutput('rr-close-marker')
+    // Close the tab (detach-only), then reopen the same session from the
+    // sidebar session list (the exact user workaround that dead-ended).
+    // ... drive close via the tab's close button (aria-label per the a11y
+    // contract) and reopen via the session row; assert:
+    await expect(page.getByText(noDeadEndText)).toHaveCount(0)
+    await terminal.waitForOutput('rr-close-marker', { timeout: 20_000 })
+    await terminal.executeCommand('echo "rr-after-reopen"')
+    await terminal.waitForOutput('rr-after-reopen', { timeout: 10_000 })
+  })
+
+  test('two sequential drops mid-reattach converge to a live pane', async ({ page, harness, terminal }) => {
+    await terminal.waitForTerminal()
+    await terminal.waitForPrompt()
+    await terminal.executeCommand('echo "rr-double"')
+    await terminal.waitForOutput('rr-double')
+    await harness.forceDisconnect()
+    await harness.waitForConnection()
+    await harness.forceDisconnect() // drop again before reattach could settle
+    await harness.waitForConnection()
+    await page.waitForFunction(
+      () => window.__FRESHELL_TEST_HARNESS__?.getState()?.connection?.status === 'ready',
+      { timeout: 20_000 },
+    )
+    await terminal.executeCommand('echo "rr-double-after"')
+    await terminal.waitForOutput('rr-double-after', { timeout: 20_000 })
+    await expect(page.getByText(noDeadEndText)).toHaveCount(0)
+  })
+})
+```
+
+(The close/reopen test's exact sidebar driving idioms come from the session-directory specs; the assertions above are the contract. A flaky-looking first red run is acceptable evidence of the missing behavior; a selector error is not.)
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npx playwright test --config test/e2e-browser/playwright.config.ts --project=rust-chromium test/e2e-browser/specs/reconnect-revive-rust.spec.ts`
+
+Expected (before Tasks 1-7 land, or when run against base): the close→reopen test FAILS with the "still running on the server" text; sequential-drop may already pass with Tasks 1-3 landed. In plan order this task runs last, so record the residual failure evidence if any test still cannot go green.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Register the spec (`/reconnect-revive-rust\.spec\.ts$/`) in `RUST_ONLY_SPECS` and the `rust-chromium` `testMatch` list with a one-line comment (socket-drop revival, not restartAbrupt-shaped). Production code is Tasks 1-7; this task adds no other production change.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npx playwright test --config test/e2e-browser/playwright.config.ts --project=rust-chromium test/e2e-browser/specs/reconnect-revive-rust.spec.ts`
+
+Expected: PASS (3/3)
+
+- [ ] **Step 5: Refactor while green**
+
+Extract a tiny shared `expectNoDeadEnd(page)` local helper if the triple-reading gets noisy; keep assertions explicit.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The spec registration edits touch project gating; run the neighboring rust reconnect family plus the config's own consumers:
+
+Run: `npx playwright test --config test/e2e-browser/playwright.config.ts --project=rust-chromium test/e2e-browser/specs/reconnect-revive-rust.spec.ts test/e2e-browser/specs/hidden-pane-rebind-rust.spec.ts test/e2e-browser/specs/server-restart-recovery.spec.ts` and `npm run test:vitest -- run test/e2e/vitest.config consumers` (only if such a config test exists; otherwise omit)
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add test/e2e-browser/specs/reconnect-revive-rust.spec.ts test/e2e-browser/playwright.config.ts
+git commit -m "test(e2e): prove reconnect revives terminal panes on the rust server"
+```
+
+## Cross-Cutting Notes
+
+- **Deferred residue (out of scope by the User Request):** multi-view/multi-device attach and adopt/view policies (#4/#2/#3); server-side retention-overflow signaling (`replayResetReason`) beyond what existing replay-gap handling surfaces; broadcast-bus replay across the dead window (all recovery here is pull/re-ask based, per the existing architecture).
+- **Frozen clients:** pre-reconcile clients never send `pane.reconcile.request` and never receive the new error code; all additive wire fields are omitted when absent. Old client + new server converges via the census. New client + old server: the watchdog/poke never needs the server to know about it; the reconcile wait expires into the census; the D7 revival only fires when the server sends the id (absent → today's `[Restore failed]` path, unchanged).
+- **Perf/visible-first audits:** liveness pings fire only on ≥30s inbound silence and never before ready; no new pre-ready HTTP traffic is introduced.

--- a/docs/plans/2026-08-22-reconnect-revive.md
+++ b/docs/plans/2026-08-22-reconnect-revive.md
@@ -864,7 +864,7 @@ Wire (`server_messages.rs`, next to `terminal_id`):
 pub live_terminal_id: Option<String>,
 ```
 
-Add `live_terminal_id: None` to every other `ErrorMsg` literal (`send_create_error` :4464-4482 etc.). WS guard: capture `let owner = state.registry.live_session_owner(...)` once, set `registry_row_live = owner.is_some()`, and emit `live_terminal_id: owner` on the refusal. REST guard: put `liveTerminalId` in the D7 409 JSON body from the same owner. ALSO the REST door's D8 arm: `SessionRefClaim::BoundElsewhere { terminal_id }` currently maps to a nameless 409 discarding the id (`terminal_tabs.rs:1267-1281`) — carry `liveTerminalId: terminal_id` there too, so the claim-race refusal is equally attachable (fresh-eyes F5). `shared/ws-protocol.ts`: error schema gains `liveTerminalId: z.string().optional()`.
+Add `live_terminal_id: None` to EVERY other `ErrorMsg` literal — the complete site list (compile-checked): `crates/freshell-ws/src/terminal.rs` (incl. `send_create_error` :4464-4482), `crates/freshell-ws/src/create_dedupe.rs`, `crates/freshell-ws/src/lib.rs`, `crates/freshell-freshagent/src/claude.rs`, `crates/freshell-freshagent/src/codex.rs`, `crates/freshell-freshagent/src/opencode_ws.rs`. Omitting any fails compilation; the commit below stages every one of them. WS guard: capture `let owner = state.registry.live_session_owner(...)` once, set `registry_row_live = owner.is_some()`, and emit `live_terminal_id: owner` on the refusal. REST guard: put `liveTerminalId` in the D7 409 JSON body from the same owner. ALSO the REST door's D8 arm: `SessionRefClaim::BoundElsewhere { terminal_id }` currently maps to a nameless 409 discarding the id (`terminal_tabs.rs:1267-1281`) — carry `liveTerminalId: terminal_id` there too, so the claim-race refusal is equally attachable (fresh-eyes F5). `shared/ws-protocol.ts`: error schema gains `liveTerminalId: z.string().optional()`.
 
 panesSlice (next to `applyReconcileAttach`):
 
@@ -917,7 +917,7 @@ Expected: PASS
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add shared/ws-protocol.ts src/store/panesSlice.ts src/components/TerminalView.tsx crates/freshell-protocol/src/server_messages.rs crates/freshell-ws/src/terminal.rs crates/freshell-freshagent/src/terminal_tabs.rs test/unit/client/store/panesSlice.reconnect.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/e2e/terminal-create-attach-ordering.test.tsx
+git add shared/ws-protocol.ts src/store/panesSlice.ts src/components/TerminalView.tsx crates/freshell-protocol/src/server_messages.rs crates/freshell-ws/src/terminal.rs crates/freshell-ws/src/create_dedupe.rs crates/freshell-ws/src/lib.rs crates/freshell-freshagent/src/terminal_tabs.rs crates/freshell-freshagent/src/claude.rs crates/freshell-freshagent/src/codex.rs crates/freshell-freshagent/src/opencode_ws.rs test/unit/client/store/panesSlice.reconnect.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/e2e/terminal-create-attach-ordering.test.tsx
 git commit -m "fix(reopen): D7 refusals name the live owner; the pane reattaches instead of dead-ending"
 ```
 
@@ -940,8 +940,12 @@ First-class browser proof of the user-visible acceptance shape on the production
 import { test, expect } from '../helpers/fixtures.js'
 
 const noDeadEndText = /still running on the server|\[Restore failed\]/
+// Playwright signature: waitForFunction(pageFunction, arg, options) — the
+// options object must be the THIRD argument or the timeout is ignored
+// (fresh-eyes F3-4).
 const waitReady = (page: any) => page.waitForFunction(
   () => window.__FRESHELL_TEST_HARNESS__?.getState()?.connection?.status === 'ready',
+  undefined,
   { timeout: 20_000 },
 )
 
@@ -1034,6 +1038,7 @@ test.describe('reconnect revive (rust)', () => {
       // With Task 1: t=30s probe → no pong → t=40s abandon → status flips.
       await page.waitForFunction(
         () => (window as any).__rrStatuses?.some((s: string | undefined) => s !== undefined && s !== 'ready'),
+        undefined,
         { timeout: 50_000 },
       )
     } finally {
@@ -1047,22 +1052,39 @@ test.describe('reconnect revive (rust)', () => {
     await expect(page.getByText(noDeadEndText)).toHaveCount(0)
   })
 
-  test('fresh-agent pane transcript repaints after a bare socket drop', async ({ freshellPage, page, harness }) => {
+  test('fresh-agent pane reattaches and round-trips after a bare socket drop', async ({ freshellPage, page, harness }) => {
     // Donor: hidden-pane-rebind-rust.spec.ts + its fake-claude-sidecar fixture
-    // (FAKE_CLAUDE_SIDECAR_SOURCE + seeded transcript). Arrange a VISIBLE
-    // freshclaude pane with one completed turn; forceDisconnect(); reconnect;
-    // assert the prior turn renders (HTTP snapshot 'reconnect' fetch fired and
-    // committed) and the composer is enabled — the Task 4/5 wedge would leave
-    // it 'Read-only session' with an empty transcript.
+    // (FAKE_CLAUDE_SIDECAR_SOURCE + scripted sidecar protocol). Arrange a
+    // VISIBLE freshclaude pane with one completed turn. forceDisconnect().
+    // THEN, while the client is down, drive the fake sidecar to emit a
+    // server-side-only marker event (the fixture's scripted mechanism — e.g.
+    // its control hook / next scripted turn) so post-reconnect rendering of
+    // the marker CANNOT come from pre-drop local state. Reconnect; assert the
+    // marker turn renders (reattach + snapshot/event pulled fresh state).
+    // FINALLY send a new prompt from the pane's composer and assert the fake
+    // sidecar's scripted reply renders — a post-reconnect send/response round
+    // trip, which only a genuinely reattached WS session can produce
+    // (fresh-eyes F3-2: render-only assertions can pass on surviving local
+    // React/Redux state with a fully broken reattach).
   })
 })
 ```
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
-Run: `npx playwright test --config test/e2e-browser/playwright.config.ts --project=rust-chromium test/e2e-browser/specs/reconnect-revive-rust.spec.ts`
+Run (against BASE, order-independently — fresh-eyes F3-3: Task 8 executes last, so "red on base" evidence CANNOT come from the current worktree; use a scratch worktree pinned at base_ref `530f5f3530dd660209fae11a81fc028827cdeb2e`, the same pattern `scripts/base-gate.sh` uses):
 
-Expected against base: the REST-door contract test FAILS on the missing `liveTerminalId` field; the freeze test's during-freeze sampler times out (on base nothing flips the status while no close frame exists — true red-first per fresh-eyes F3); the sidebar-adoption pin may already pass on base (documented pin); the fresh-agent drop test fails against the Task 4/5 wedges when drawn from them (lost-suppressed snapshot / placeholder-stamped ack) or passes as a pin otherwise — attribute per the table below. Record a per-test base-status table in the task's execution notes. In plan order this task runs last; any test still red after Tasks 1-7 is the LB-2 completeness signal — stop and attribute it before proceeding.
+```bash
+git worktree add /tmp/rr-base 530f5f3530dd660209fae11a81fc028827cdeb2e
+cd /tmp/rr-base && npm ci --no-audit --no-fund
+# copy the NEW spec + its playwright.config registration into the base tree
+cp <worktree>/test/e2e-browser/specs/reconnect-revive-rust.spec.ts /tmp/rr-base/test/e2e-browser/specs/
+# apply the same RUST_ONLY_SPECS/testMatch registration edit in /tmp/rr-base's playwright.config.ts
+cd /tmp/rr-base && npx playwright test --config test/e2e-browser/playwright.config.ts --project=rust-chromium test/e2e-browser/specs/reconnect-revive-rust.spec.ts
+# remove the scratch worktree after capturing the table
+```
+
+Expected against base (record this per-test base-status table in the task's execution notes — it is the LB-2 evidence): the REST-door contract test FAILS on the missing `liveTerminalId` field; the freeze test's during-freeze sampler times out (on base nothing flips the status while no close frame exists — true red-first per fresh-eyes F3); the fresh-agent round-trip test FAILS against the Task 4/5 wedge (no fresh state can land while its reattach is suppressed) or passes as a documented pin if base already covers it (attribute per-test); the sidebar-adoption pin may already pass on base (documented pin). Any test still red after Tasks 1-7 is the LB-2 completeness signal — stop and attribute it before proceeding.
 
 - [ ] **Step 3: Add the minimal production implementation**
 

--- a/docs/plans/2026-08-22-reconnect-revive.md
+++ b/docs/plans/2026-08-22-reconnect-revive.md
@@ -22,7 +22,7 @@ Fix Freshell's gray-and-dead pane reconnect bug: on WebSocket reconnect (for exa
 
 **Goal:** After any transport drop with the server still up, every open pane of every kind repairs itself: the client detects a dead or half-open socket, reconnects, reattaches (or is routed by reconcile verdicts), and repaints; and a user who closes and reopens such a pane lands attached to the still-running session instead of on a refusal.
 
-**Architecture:** Fix the wedge at each of its four layers, keeping every existing recovery contract intact. (1) Transport liveness — an app-level ping watchdog plus foreground pokes so a half-open socket is recycled into the normal reconnect path. (2) Reconcile loss — a bounded client-side wait that falls back to the legacy inventory census, plus an explicit server error instead of accept-and-strip silence on non-negotiated connections. (3) Per-pane reattach gaps — hidden-pane hydration parity on reconnect, fresh-agent `lost` revocation on truth-bearing evidence, opencode placeholder re-keying on attach ack, and a truthful claude attach-ack status. (4) Close→reopen — route reopen to the live terminal, carry the live terminal id in the D7 refusal, and fold that refusal into an attach instead of a dead-end.
+**Architecture:** Fix the wedge at each of its four layers, keeping every existing recovery contract intact. (1) Transport liveness — an app-level ping watchdog plus foreground pokes, recycling a half-open socket by *abandoning* it (handlers detached, generation-guarded, fresh socket driven immediately) rather than relying on `onclose` delivery from a dead transport. (2) Reconcile loss — a bounded client-side wait that falls back to the legacy inventory census, plus an explicit server error instead of accept-and-strip silence on non-negotiated connections. (3) Per-pane reattach gaps — hidden-pane hydration parity on reconnect, fresh-agent `lost` revocation on truth-bearing evidence, opencode placeholder re-keying on attach ack, and a truthful claude attach-ack status. (4) Close→reopen — the negotiated WS door already adopts (LB-1); the residual refusal lanes (REST doors, non-negotiated windows) carry the live terminal id in the D7 refusal, and the client folds an id-carrying refusal into an epoch-bumping reattach reducer instead of a dead-end.
 
 **Tech Stack:** React 18 / Redux Toolkit / TypeScript client (jsdom Vitest), Rust workspace server crates (`freshell-ws`, `freshell-terminal`, `freshell-freshagent`, `freshell-protocol`; cargo tests), Playwright e2e (`test/e2e-browser`, `rust-chromium` project).
 
@@ -46,7 +46,7 @@ Evidence lives in `.worktrees/.the-usual-logs/reconnect-revive/reports/` (`plan-
 1. **No transport liveness on the client.** Everything rides on the browser delivering `onclose`; a half-open socket (phone radio flap, NAT timeout, frozen tab) never starts `scheduleReconnect` (`src/lib/ws-client.ts:508-586` is onclose-only), and nothing re-asserts connectivity on foreground (no `visibilitychange`/`online`/`pageshow` poke reaches `getWsClient()`). While the socket is dead-but-open, keystrokes pour into `pendingMessages` and are filter-dropped on the eventual reconnect (`ws-client.ts:300-304`).
 2. **Reconcile-result loss is a silent wedge.** The boot `pane.reconcile.result` is unicast to the requesting socket with no client wall-clock bound (`src/App.tsx:916-918` documents the deliberate absence), and the server accept-and-strip ignores the request on non-negotiated connections (`crates/freshell-ws/src/terminal.rs:1232-1243`). A lost result leaves every pane pending-verdict = gray with zero chrome.
 3. **Per-pane reattach gaps.** Hidden terminal panes register with the hydration queue on reconnect WITHOUT enqueueing themselves when their parser checkpoint is unusable (`src/components/TerminalView.tsx:5207`, `queueIfStarted: canResumeFromParserAppliedSurface`), unlike the `terminal.created` path's three-step re-register (`TerminalView.tsx:4506-4508`). Fresh-agent codex panes wedge on `lost=true`: nothing on the reconnect path clears it (`sessionSnapshotReceived` does not; the boot-reconcile attach fold does not; the `.lost` recovery effect cannot re-fire without a dep change — `FreshAgentView.tsx:1726,2045-2077`). Opencode panes addressed by a placeholder id miss frames stamped with the materialized `ses_*` id (`opencode_ws.rs:1394-1397`). Claude attach acks hardcode `idle` (`claude.rs:1203,1373`), leaving stale-busy panes after a dead-window turn completion.
-4. **Close→reopen dead-ends.** Sidebar close is detach-only; reopen issues `terminal.create{sessionRef}` which meets the D7 live-guard → `error{RESTORE_UNAVAILABLE,"Session {sid} is still running on the server."}` (`crates/freshell-ws/src/terminal.rs:2615-2621`; REST twin `crates/freshell-freshagent/src/terminal_tabs.rs:1223-1235`) → a terminal `[Restore failed]` write (`TerminalView.tsx:4897-4901`).
+4. **Close→reopen dead-ends — but only off the negotiated WS door.** Sidebar close is detach-only; reopen issues `terminal.create{sessionRef}`. Load-bearing check LB-1 (validator report `reports/load-bearing-validator-LB-1.md`) behaviorally proved that on a `paneReconcileV1`-negotiated WS connection this create is always ADOPTED into the existing terminal (keyed arm / D8 `BoundElsewhere`) and never reaches D7. The `RESTORE_UNAVAILABLE` refusal provably fires only on the REST spawn doors (`crates/freshell-freshagent/src/terminal_tabs.rs:1223-1235`, no adopt arm exists there), on non-negotiated WS connections (mid-deploy stale bundles), and on the fresh-agent cross-kind owner arm. Where it fires, the pane dead-ends at `[Restore failed]` (`TerminalView.tsx:4897-4901`).
 
 Existing reconnect machinery that MUST stay intact (regression surface): the per-connection revival trio (re-attach on `onReconnect` with generation-tagged `terminal.attach`; boot reconcile + verdict folds; legacy census fallback), the sender-level pre-verdict create hold (`RECONCILE_VERDICT_WAIT_MS`), RebindQueue flap safety for hidden fresh-agent panes, the ws-oracle parity pins, and PR #532 launch-retry semantics.
 
@@ -55,6 +55,8 @@ Existing reconnect machinery that MUST stay intact (regression surface): the per
 ### Task 1: WS transport liveness — app-level ping watchdog + foreground reconnect poke
 
 The client recycles a silently-dead socket into the existing reconnect machinery instead of waiting forever for `onclose`. Server-side WS pings are invisible to JS, so liveness is proven by an app-level `{type:'ping'}`→`{type:'pong'}` round trip that both servers already implement (`crates/freshell-ws/src/terminal.rs` Ping dispatch; legacy `server/ws-handler.ts:1832-1835`; pinned by `test/e2e-browser/specs/ws-ping-pong-matrix.spec.ts`).
+
+**Mechanism (load-bearing LB-3, validated):** all four `scheduleReconnect` sites live inside `onclose` (`ws-client.ts:534/557/567/584`), and a dead transport cannot be trusted to deliver `onclose` promptly (or at all) in response to `ws.close()` — the browser close handshake has no reply to expect from a dead peer. So the recycle MUST NOT depend on the old socket's events: it **abandons** the socket — detaches every handler, generation-guards so a late event from the old socket is a no-op (validator LB-3 proved `connect()`'s bare `this.ws` swap corrupts the new connection otherwise), forces connection-local state down, and drives `connect()` immediately.
 
 **Files:**
 - Modify: `src/lib/ws-client.ts` (state block ~:120-150; `handleIncomingMessage` :231; `onopen` :454; `onmessage` :478; `onclose` :508; `disconnect` :644; add `tickLiveness`/`poke`/`clearLivenessWatch` methods)
@@ -94,14 +96,18 @@ describe('WsClient liveness', () => {
     expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(false)
   })
 
-  it('closes a socket whose probe goes unanswered past the pong timeout, entering the reconnect path', async () => {
+  it('abandons a socket whose probe goes unanswered past the pong timeout — no reliance on its onclose', async () => {
     const { socket } = await connectReady(new WsClient('ws://test/ws'))
     await vi.advanceTimersByTimeAsync(30_000)          // probe sent
     expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(true)
-    await vi.advanceTimersByTimeAsync(10_000)          // no pong → stale
-    expect(MockWebSocket.instances.length).toBe(1)
-    await vi.advanceTimersByTimeAsync(5_000)           // reconnect backoff lands a NEW socket
-    expect(MockWebSocket.instances.length).toBe(2)
+    // The dead transport NEVER delivers onclose — that is the hazard under test.
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(MockWebSocket.instances.length).toBe(2)     // fresh socket driven immediately
+    const fresh = MockWebSocket.instances[1]
+    fresh._open(); fresh._message(READY_MSG)           // fresh socket completes handshake
+    socket._close(4002, 'late')                        // stale socket's LATE close arrives
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(MockWebSocket.instances.length).toBe(2)     // …and is ignored (generation guard)
   })
 
   it('clears the outstanding probe on any inbound message (no close)', async () => {
@@ -118,15 +124,14 @@ describe('WsClient liveness', () => {
     expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(true)
   })
 
-  it('poke() after 65s+ of silence recycles immediately instead of waiting out the probe', async () => {
+  it('poke() after 65s+ of silence abandons immediately instead of waiting out the probe', async () => {
     const { client, socket } = await connectReady(new WsClient('ws://test/ws'))
     // Simulate a frozen tab: no timers ran (background clamp) but the wall
-    // clock jumped past the recycle threshold.
+    // clock jumped past the keepalive window threshold.
     vi.setSystemTime(Date.now() + 65_000)
-    client.poke()
-    await vi.advanceTimersByTimeAsync(2_000)           // reconnect backoff lands
+    client.poke()                                      // no onclose delivery from the dead socket
     expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(false) // no probe wait
-    expect(MockWebSocket.instances.length).toBe(2)     // recycled into a fresh socket
+    expect(MockWebSocket.instances.length).toBe(2)     // abandoned into a fresh socket
     vi.setSystemTime(Date.now() - 65_000)
   })
 
@@ -147,7 +152,7 @@ describe('WsClient liveness', () => {
 })
 ```
 
-(Redraft note: the 65s-silence case is exercised more directly by setting `vi.setSystemTime` forward past the recycle threshold with the liveness interval temporarily stopped — assert `poke()` closes the socket immediately with no preceding `ping` in `socket.sent`.)
+(`READY_MSG` is a shared fixture object `{type:'ready', bootId:'b1', serverInstanceId:'s1', capabilities:{}}` declared beside `connectReady`; every abandon test uses it for the fresh socket's handshake.)
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
@@ -178,9 +183,14 @@ In `handleIncomingMessage` (top): `this.lastInboundAt = Date.now(); this.probeSe
 
 In `onopen`: `this.lastInboundAt = Date.now(); this.probeSentAt = null; this.startLivenessWatch()`.
 
-New methods:
+New state + methods (the abandon mechanism replaces any reliance on the old socket's own events — LB-3):
 
 ```ts
+// Bumped for every new WebSocket; each socket's handlers capture their
+// generation and no-op once superseded (a late event from an abandoned socket
+// must never touch the live connection's state).
+private socketGen = 0
+
 private startLivenessWatch(): void {
   this.clearLivenessWatch()
   this.livenessTimer = window.setInterval(() => this.tickLiveness(), LIVENESS_INTERVAL_MS)
@@ -196,11 +206,7 @@ private tickLiveness(): void {
   const now = Date.now()
   if (this.probeSentAt !== null) {
     if (now - this.probeSentAt >= PONG_TIMEOUT_MS) {
-      // Half-open socket: the peer (or the path) is dead but the browser never
-      // delivered onclose. Recycling enters the NORMAL onclose → scheduleReconnect
-      // path; every pane-recovery mechanism keys off that.
-      log.warn('liveness probe unanswered; recycling stale socket')
-      this.ws.close()
+      this.abandonStaleSocket('liveness probe unanswered')
     }
     return
   }
@@ -210,9 +216,35 @@ private tickLiveness(): void {
 }
 
 /**
+ * Half-open socket disposal. A dead transport cannot be trusted to deliver
+ * onclose promptly (or ever), so recycling never waits on the old socket's
+ * events: handlers detach, connection-local state is forced down, and a fresh
+ * connect is driven NOW. The generation guard makes the old socket's late
+ * events no-ops (LB-3: the bare this.ws swap in connect() would otherwise let
+ * the old onclose corrupt the new connection).
+ */
+private abandonStaleSocket(reason: string): void {
+  const old = this.ws
+  if (old) {
+    old.onopen = null
+    old.onmessage = null
+    old.onclose = null
+    old.onerror = null
+    try { old.close() } catch { /* best effort: resource hygiene only */ }
+  }
+  this.ws = null
+  this._state = 'disconnected'
+  this.serverCapabilities = {}
+  this.resetReconcileHold({ requeueHeld: true })
+  this.clearLivenessWatch()
+  log.warn(`abandoning stale socket: ${reason}`)
+  this.connect().catch((err) => log.debug('reconnect after abandon failed', err))
+}
+
+/**
  * Foreground poke: re-assert connectivity when the page becomes visible/online.
  * - ready + recently active   → probe immediately (fast failure discovery).
- * - ready + silent past two server keepalive windows → recycle: the peer may
+ * - ready + silent past two server keepalive windows → abandon: the peer may
  *   already be reaped, and reconnect convergence is cheaper than the probe wait.
  * - down with a (possibly background-clamped) backoff timer pending → connect now.
  */
@@ -220,8 +252,7 @@ poke(): void {
   if (this.intentionalClose) return
   if (this._state === 'ready') {
     if (Date.now() - this.lastInboundAt >= FOREGROUND_RECYCLE_SILENCE_MS) {
-      log.info('foreground poke: silent past keepalive windows; recycling socket')
-      this.ws?.close()
+      this.abandonStaleSocket('foreground poke past keepalive windows')
       return
     }
     this.tickLiveness()
@@ -234,7 +265,15 @@ poke(): void {
 }
 ```
 
-Call `this.clearLivenessWatch()` in `onclose` (with the other clears) and in `disconnect()`.
+Generation guard inside `connect()` — after `this.ws = new WebSocket(this.url)`:
+
+```ts
+const gen = ++this.socketGen
+const socket = this.ws
+// Each handler starts with: if (gen !== this.socketGen || this.ws !== socket) return
+```
+
+Apply that one-line guard at the top of the `onopen`, `onmessage`, `onclose`, and `onerror` handlers. Also bump `this.socketGen` in `disconnect()` so a torn-down socket's late events are inert. Call `this.clearLivenessWatch()` in `onclose` (with the other clears) and in `disconnect()`.
 
 `src/App.tsx` bootstrap effect (next to the `cleanupPromise`/cleanup return, ~:1476-1487):
 
@@ -280,7 +319,7 @@ A lost `pane.reconcile.result` must no longer wedge panes pending-verdict foreve
 **Files:**
 - Modify: `src/lib/pane-reconcile.ts` (export the new constant)
 - Modify: `src/App.tsx` (~:1034-1141 ready/reconcile handlers; disconnect handler ~:766-773)
-- Modify: `crates/freshell-protocol/src/server_messages.rs` (new `ErrorCode` variant, ~:enum ErrorCode)
+- Modify: `crates/freshell-protocol/src/common.rs` (new `ErrorCode` variant; the enum lives at common.rs:74)
 - Modify: `crates/freshell-ws/src/terminal.rs` (:1232-1243 PaneReconcileRequest dispatch arm)
 - Test: `test/unit/client/components/App.reconcile-adoption.test.tsx` (add cases)
 - Test: `crates/freshell-ws/src/terminal.rs` `#[cfg(test)]` module (add rust test)
@@ -376,7 +415,7 @@ reconcileResultTimerRef.current = window.setTimeout(() => {
 
 In the `pane.reconcile.result` branch: call `clearReconcileResultWait()` right where `pendingReconcileRef.current = null` runs (fold and malformed paths alike). In the correlated `error` branch: same. In App's disconnect handling (where connection status flips away): `clearReconcileResultWait(); pendingReconcileRef.current = null` — the next ready re-sends the request; never census from stale inventory while offline.
 
-`crates/freshell-protocol/src/server_messages.rs` — add to `ErrorCode`:
+`crates/freshell-protocol/src/common.rs` (:74) — add to `ErrorCode`:
 
 ```rust
 /// pane.reconcile.request arrived on a connection that did not negotiate
@@ -652,7 +691,7 @@ if let Some(real_id) = session_real_id.as_ref() {        // existing real_sessio
 
 - [ ] **Step 4: Run the focused test**
 
-Run: `cargo test -p freshell-freshagent attach_placeholder` && `npm run test:vitest -- run test/unit/client/lib/fresh-agent-ws.test.ts`
+Run: `cargo test -p freshell-freshagent attach_placeholder && npm run test:vitest -- run test/unit/client/lib/fresh-agent-ws.test.ts`
 
 Expected: PASS
 
@@ -664,9 +703,9 @@ If the send-path materialized construction and this one now duplicate, extract o
 
 The opencode attach/ack pins and the materialization-once pins:
 
-Run: `cargo test -p freshell-freshagent && npm run test:vitest -- run test/unit/client/lib/fresh-agent-ws.test.ts test/unit/client/components/fresh-agent/FreshAgentView.test.tsx test/unit/client/store/freshAgentSlice.test.ts && npm run test:vitest -- run test/integration/port/oracle/t2-opencode-equivalence-rust.test.ts`
+Run: `cargo test -p freshell-freshagent && npm run test:vitest -- run test/unit/client/lib/fresh-agent-ws.test.ts test/unit/client/components/fresh-agent/FreshAgentView.test.tsx test/unit/client/store/freshAgentSlice.test.ts test/unit/port/oracle/t2-opencode-equivalence-rust.test.ts`
 
-Expected: PASS (the oracle equivalence run checks the attach-ack capture families; the new frame appears only on placeholder-addressed tracked attach — if a frozen capture pins that path, update the oracle per its documented procedure and note it in the commit).
+Expected: PASS. LB-6 validation settled the pin surface: the only exactly-once pin (`opencode_ws.rs:2688`) covers the send path; no attach-arm test pins the emitted sequence for opencode; the differential oracle never drives an opencode attach addressed by a placeholder id and its baseline projection is duplicate-insensitive. **Constraint recorded by validation: this task must stay OPENCODE-arm-only** — codex's attach arm IS sequence-pinned by the wireshape differential and must not gain any new frame.
 
 - [ ] **Step 7: Commit the task**
 
@@ -748,73 +787,40 @@ git add crates/freshell-freshagent/src/claude.rs
 git commit -m "fix(claude): attach ack announces the session's real last status"
 ```
 
-### Task 7: Close→reopen revives the still-running session (no more D7 dead-end)
+### Task 7: Disarm the residual D7 refusal lanes (REST doors + non-negotiated windows)
 
-Close is detach-only, so the session's PTY often keeps running; reopening issues `terminal.create{sessionRef}` which the D7 live-guard correctly refuses — and the pane dead-ends at `[Restore failed]`. Disarm the trap three ways, keeping D7/D8 fully in force: (a) the reopen path routes to the live terminal when the client already knows one, (b) the refusal carries the live terminal's id on both lanes, (c) the client folds an id-carrying refusal into an attach instead of a dead-end.
+Load-bearing LB-1 (falsified; `reports/load-bearing-validator-LB-1.md`): on negotiated WS connections, close→reopen already ADOPTS via the keyed/D8 arms — the D7 guard only fires on the REST spawn doors (no adopt arm), on non-negotiated WS connections, and on the fresh-agent cross-kind owner arm. So no client routing change is made (it would duplicate the adopt arms' semantics behind a staler cache — dropped under the scope rule). What remains: (a) every refusal that CAN name a live terminal carries its id, and (b) the client's create-error fold reattaches via that id instead of dead-ending — and the reattach MUST go through an epoch-bumping reducer (LB-5: plain `updateContent` does not re-fire the lifecycle effect; deps exclude `terminalId`/`status` by design, TerminalView.tsx:5349-5392).
 
 **Files:**
-- Modify: `src/store/terminalMetaSlice.ts` (new selector)
-- Modify: `src/store/tabsSlice.ts` (`openSessionTab` :569+, new-pane arm)
-- Modify: `crates/freshell-protocol/src/server_messages.rs` (`ErrorMsg` optional field)
-- Modify: `crates/freshell-ws/src/terminal.rs` (D7 guard ~:2580-2623: include `live_terminal_id`)
-- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs` (REST 409 :1223-1235: include `liveTerminalId` in the JSON body)
-- Modify: `src/components/TerminalView.tsx` (create-error handler :4872-4901)
+- Modify: `crates/freshell-protocol/src/server_messages.rs` (`ErrorMsg` optional `live_terminal_id` field — next to `terminal_id`)
+- Modify: `crates/freshell-ws/src/terminal.rs` (D7 guard ~:2580-2623: include `live_terminal_id`; `send_create_error` :4464-4482 sets `live_terminal_id: None`)
+- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs` (REST 409 :1223-1235: include `liveTerminalId` in the JSON body when a terminal owns the session)
 - Modify: `shared/ws-protocol.ts` (error-message schema gains optional `liveTerminalId`)
-- Test: `test/unit/client/store/terminalMetaSlice.test.ts` (add/extend)
-- Test: `test/unit/client/store/tabsSlice.test.ts` (reopen routing case)
+- Modify: `src/store/panesSlice.ts` (new reducer next to `applyReconcileAttach` :1948-1985)
+- Modify: `src/components/TerminalView.tsx` (create-error handler :4872-4901)
+- Test: `test/unit/client/store/panesSlice.reconnect.test.ts` (or the slice's existing test home — check before creating)
 - Test: `test/unit/client/components/TerminalView.lifecycle.test.tsx` (revive fold cases)
 - Test: `crates/freshell-ws/src/terminal.rs` tests; `crates/freshell-freshagent/src/terminal_tabs.rs` tests
 
 **Interfaces:**
-- Consumes: `TerminalMetaRecord{terminalId, provider, sessionId}` + `connection.liveTerminalIds`; `live_session_owner(...) -> Option<String>` (terminal id of the owner) at both guard sites.
-- Produces: `selectLiveTerminalIdForSession(state, provider, sessionId): string | undefined`; wire `error.liveTerminalId?: string`; REST 409 body gains `liveTerminalId` only when a terminal owns the session.
+- Consumes: `live_session_owner(...) -> Option<String>` (owner terminal id) at both guard sites; zod error schema in `shared/ws-protocol.ts`.
+- Produces: wire `error.liveTerminalId?: string` (omitted when absent — frozen clients byte-identical); REST 409 body gains `liveTerminalId` only when a terminal owns the session; `applyReattachToLiveTerminal({ tabId, paneId, terminalId })` — panesSlice reducer that sets `terminalId`, `status:'running'`, clears `restoreError`, and bumps `reconcileEpoch` (mirroring `applyReconcileAttach`'s proven fold shape).
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-1. Selector: meta rows + live ids → the live owner id; dead id excluded; provider mismatch excluded.
-2. `openSessionTab` new-pane arm: with a live owner in state, the created pane content carries `terminalId: <owner>`, `status: 'running'`, and NO resume-create follows (spy on the WS send: no `terminal.create` for that pane).
-3. TerminalView revive fold: create-error `{code:'RESTORE_UNAVAILABLE', liveTerminalId:'t1', requestId}` → content gains `terminalId:'t1'`, `status:'running'`, a `terminal.attach` for `t1` is sent, and the pane shows a `Reconnected to the still-running session.` notice — never `[Restore failed]`; a SECOND RESTORE_UNAVAILABLE for the same createRequestId does not revive again (bound the loop) and falls through to the existing error write.
-4. Rust WS: the D7 refusal frame carries `live_terminal_id: Some(<owner>)`. Rust REST: the 409 body carries `liveTerminalId` when a terminal owns the session and omits it for the fresh-agent-cross-kind arm (no terminal id exists there).
+1. panesSlice: `applyReattachToLiveTerminal` writes terminalId/status, clears restoreError, and bumps reconcileEpoch; it is a no-op for an unknown paneKey.
+2. TerminalView revive fold: create-error `{code:'RESTORE_UNAVAILABLE', liveTerminalId:'t1', requestId}` → the pane's store state gains `terminalId:'t1'`/`status:'running'` via the new reducer, its bumped `reconcileEpoch` re-fires the lifecycle effect so a `terminal.attach` for `t1` leaves the client, and the pane shows a `Reconnected to the still-running session.` notice — never `[Restore failed]`; a SECOND RESTORE_UNAVAILABLE for the same createRequestId does NOT revive again (one-shot bound) and falls through to the existing error write.
+3. Rust WS: the D7 refusal frame carries `live_terminal_id: Some(<owner>)` when `registry_row_live` (owner known) and `None` on the fresh-agent cross-kind arm. Rust REST: the 409 body carries `liveTerminalId` when a terminal owns the session and omits it for the cross-kind arm.
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
-Run: `npm run test:vitest -- run test/unit/client/store/terminalMetaSlice.test.ts test/unit/client/store/tabsSlice.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx` and `cargo test -p freshell-ws d7 && cargo test -p freshell-freshagent terminal_tabs`
+Run: `npm run test:vitest -- run test/unit/client/store/panesSlice.reconnect.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx` and `cargo test -p freshell-ws d7 && cargo test -p freshell-freshagent terminal_tabs`
 
-Expected: FAIL because no selector/revive/payload exists yet (`selectLiveTerminalIdForSession` undefined; refusal payload lacks the id), not harness noise.
+Expected: FAIL because the reducer/revive/payload do not exist yet (`applyReattachToLiveTerminal` undefined; refusal payload lacks the id), not harness noise.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Selector (`terminalMetaSlice.ts`):
-
-```ts
-export const selectLiveTerminalIdForSession = (
-  state: { terminalMeta: TerminalMetaState; connection: { liveTerminalIds: string[] | null } },
-  provider: string,
-  sessionId: string,
-): string | undefined => {
-  const live = state.connection.liveTerminalIds
-  if (!live) return undefined
-  for (const meta of Object.values(state.terminalMeta.byTerminalId)) {
-    if (meta.provider === provider && meta.sessionId === sessionId && live.includes(meta.terminalId)) {
-      return meta.terminalId
-    }
-  }
-  return undefined
-}
-```
-
-`openSessionTab` new-pane arm (`tabsSlice.ts`, in the branch that builds fresh resume content):
-
-```ts
-const liveTerminalId = selectLiveTerminalIdForSession(state, resolvedProvider, sessionId)
-// ... when minting the new terminal pane content:
-//   liveTerminalId ? { terminalId: liveTerminalId, status: 'running', sessionRef: {provider, sessionId}, createRequestId: <fresh id> }
-//   : <existing resume content>
-```
-
-(Attach needs no create: TerminalView's create-or-attach effect takes the attach branch when `terminalId` is set — same shape the reconcile-adopt fold writes.)
-
-Wire (`server_messages.rs`):
+Wire (`server_messages.rs`, next to `terminal_id`):
 
 ```rust
 /// D7 (`RESTORE_UNAVAILABLE` only): the live terminal that owns the refused
@@ -824,18 +830,30 @@ Wire (`server_messages.rs`):
 pub live_terminal_id: Option<String>,
 ```
 
-Add it to every `ErrorMsg` literal (`send_create_error` at `terminal.rs:4464-4482` sets `live_terminal_id: None`); WS guard: capture `let owner = state.registry.live_session_owner(...)` and emit `live_terminal_id: owner.clone() when registry_row_live`; REST: put `liveTerminalId` in the 409 JSON body from the same owner; `shared/ws-protocol.ts`: error schema gains `liveTerminalId: z.string().optional()`.
+Add `live_terminal_id: None` to every other `ErrorMsg` literal (`send_create_error` :4464-4482 etc.). WS guard: capture `let owner = state.registry.live_session_owner(...)` once, set `registry_row_live = owner.is_some()`, and emit `live_terminal_id: owner` on the refusal. REST guard: put `liveTerminalId` in the 409 JSON body from the same owner (omit for the cross-kind arm). `shared/ws-protocol.ts`: error schema gains `liveTerminalId: z.string().optional()`.
+
+panesSlice (next to `applyReconcileAttach`):
+
+```ts
+/** Close→reopen revival: a D7 refusal named the live owner terminal — reattach
+ * the pane to it. The reconcileEpoch bump is the lifecycle effect's ONLY
+ * re-fire signal (createRequestId is preserved), mirroring applyReconcileAttach. */
+applyReattachToLiveTerminal(state, action: PayloadAction<{ tabId: string; paneId: string; terminalId: string }>) {
+  // ...same lookup/defensive shape as applyReconcileAttach: find the pane in
+  // layouts, bail when absent; set content.terminalId, content.status='running',
+  // content.restoreError=undefined, content.reconcileEpoch = (content.reconcileEpoch ?? 0) + 1
+},
+```
 
 TerminalView fold (create-error handler, before the dead-end arms):
 
 ```ts
-if (msg.code === 'RESTORE_UNAVAILABLE' && typeof (msg as { liveTerminalId?: unknown }).liveTerminalId === 'string') {
-  const liveId = (msg as { liveTerminalId: string }).liveTerminalId
+if (msg.code === 'RESTORE_UNAVAILABLE' && typeof msg.liveTerminalId === 'string') {
   // One revival per createRequestId: if the live handle died in the race, the
   // follow-on create lands the existing [Restore failed] path — never loop.
   if (reviveAttemptedRef.current !== reqId) {
     reviveAttemptedRef.current = reqId
-    updateContent({ status: 'running', terminalId: liveId, streamId: undefined, restoreError: undefined })
+    dispatch(applyReattachToLiveTerminal({ tabId, paneId: paneIdRef.current, terminalId: msg.liveTerminalId }))
     writeLocalXtermNotice(term, `\r\nReconnected to the still-running session.\r\n`)
     return
   }
@@ -846,40 +864,40 @@ if (msg.code === 'RESTORE_UNAVAILABLE' && typeof (msg as { liveTerminalId?: unkn
 
 - [ ] **Step 4: Run the focused test**
 
-Run: `npm run test:vitest -- run test/unit/client/store/terminalMetaSlice.test.ts test/unit/client/store/tabsSlice.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx && cargo test -p freshell-ws d7 && cargo test -p freshell-freshagent terminal_tabs && npm run typecheck`
+Run: `npm run test:vitest -- run test/unit/client/store/panesSlice.reconnect.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx && cargo test -p freshell-ws d7 && cargo test -p freshell-freshagent terminal_tabs && npm run typecheck`
 
 Expected: PASS
 
 - [ ] **Step 5: Refactor while green**
 
-Keep the refusals' "still running on the server." message text byte-identical (client regexes and user muscle memory depend on it); all novelty rides the additive id field.
+Keep the refusals' "still running on the server." message text byte-identical (client regexes and user muscle memory depend on it); all novelty rides the additive id field. If `applyReattachToLiveTerminal` and `applyReconcileAttach` share lookup/fold boilerplate, extract one private helper inside panesSlice rather than exporting a new utility.
 
 - [ ] **Step 6: Run impacted-test verification**
 
 Create-error handling (incl. `fresh_after_restore_unavailable`), restore/launch ladders, REST doors, oracle/error-contract pins:
 
-Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/lib/terminal-restore.test.ts test/unit/client/store/tabsSlice.test.ts test/unit/client/store/terminalMetaSlice.test.ts test/unit/port/oracle/t2-invariants.test.ts && cargo test -p freshell-ws && cargo test -p freshell-freshagent && cargo test -p freshell-protocol`
+Run: `npm run test:vitest -- run test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/lib/terminal-restore.test.ts test/unit/client/store/panesSlice.reconnect.test.ts test/unit/port/oracle/t2-invariants.test.ts && cargo test -p freshell-ws && cargo test -p freshell-freshagent && cargo test -p freshell-protocol`
 
 Expected: PASS
 
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add src/store/terminalMetaSlice.ts src/store/tabsSlice.ts shared/ws-protocol.ts src/components/TerminalView.tsx crates/freshell-protocol/src/server_messages.rs crates/freshell-ws/src/terminal.rs crates/freshell-freshagent/src/terminal_tabs.rs test/unit/client/store/terminalMetaSlice.test.ts test/unit/client/store/tabsSlice.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx
-git commit -m "fix(reopen): reattach to the still-running session instead of dead-ending on D7"
+git add shared/ws-protocol.ts src/store/panesSlice.ts src/components/TerminalView.tsx crates/freshell-protocol/src/server_messages.rs crates/freshell-ws/src/terminal.rs crates/freshell-freshagent/src/terminal_tabs.rs test/unit/client/store/panesSlice.reconnect.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx
+git commit -m "fix(reopen): D7 refusals name the live owner; the pane reattaches instead of dead-ending"
 ```
 
 ### Task 8: E2E acceptance — reconnect revives (Rust server)
 
-First-class browser proof of the user-visible acceptance shape on the production server stack, closing the named coverage gaps (rust-side plain socket drop; "stops being gray/dead" assertions; the close→reopen revival; sequential drops mid-reattach).
+First-class browser proof of the user-visible acceptance shape on the production server stack, closing the named coverage gaps (rust-side plain socket drop; "stops being gray/dead" assertions; the refusal-lane disarm; sequential drops mid-reattach; a fresh-agent in-place socket drop). Load-bearing adjustments folded in (LB-1/LB-4): negotiated close→reopen already adopts on base, so the red-first refusal coverage lives at the REST door; the foreground-recycle window is unit-covered only (real visibilitytransition is not drivable in headless Playwright); server-SIGSTOP is the e2e dead-peer shape.
 
 **Files:**
 - Create: `test/e2e-browser/specs/reconnect-revive-rust.spec.ts`
-- Modify: `test/e2e-browser/playwright.config.ts` (register the spec in `RUST_ONLY_SPECS` :176 list AND the `rust-chromium` project `testMatch` — both, matching the convention of the neighboring entries) and confirm it is NOT in `CLOUD_SKIP_SPECS` (`playwright.cloud.config.ts`)
+- Modify: `test/e2e-browser/playwright.config.ts` (register `/reconnect-revive-rust\.spec\.ts$/` in BOTH `RUST_ONLY_SPECS` :176 and the `rust-chromium` project `testMatch` list, matching the convention of the neighboring entries) and confirm it is NOT in `CLOUD_SKIP_SPECS` (`playwright.cloud.config.ts`)
 - Test: (the spec IS the test)
 
 **Interfaces:**
-- Consumes: fixtures `freshellPage`, `harness` (`forceDisconnect()`, `waitForConnection()`, `getConnectionStatus()`), `terminal` (`waitForTerminal()`, `waitForPrompt()`, `executeCommand()`, `waitForOutput()`), `RustServer`; default `recoveryOfferHandling: 'auto-decline'` (fixtures.ts:94) — no override needed since the spec owns no panel assertions.
+- Consumes: fixtures `freshellPage`, `harness` (`forceDisconnect()`, `waitForConnection()`, `getConnectionStatus()`), `terminal` (`waitForTerminal()`, `waitForPrompt()`, `executeCommand()`, `waitForOutput()`), `RustServer`; `TestServerInfo.pid` (`helpers/test-server.ts:23`) for the SIGSTOP test; default `recoveryOfferHandling: 'auto-decline'` (fixtures.ts:94) — no override needed since the spec owns no panel assertions; fake-claude-sidecar fixture idioms from `hidden-pane-rebind-rust.spec.ts` for the fresh-agent test.
 - Produces: none.
 
 - [ ] **Step 1: Write the failing (or coverage-missing) behavioral test**
@@ -888,9 +906,13 @@ First-class browser proof of the user-visible acceptance shape on the production
 import { test, expect } from '../helpers/fixtures.js'
 
 const noDeadEndText = /still running on the server|\[Restore failed\]/
+const waitReady = (page: any) => page.waitForFunction(
+  () => window.__FRESHELL_TEST_HARNESS__?.getState()?.connection?.status === 'ready',
+  { timeout: 20_000 },
+)
 
 test.describe('reconnect revive (rust)', () => {
-  test('terminal pane reattaches and repaints after a bare socket drop', async ({ page, harness, terminal }) => {
+  test('terminal pane reattaches and repaints after a bare socket drop', async ({ freshellPage, page, harness, terminal }) => {
     await terminal.waitForTerminal()
     await terminal.waitForPrompt()
     await terminal.executeCommand('echo "rr-marker-one"')
@@ -898,10 +920,7 @@ test.describe('reconnect revive (rust)', () => {
 
     await harness.forceDisconnect()
     await harness.waitForConnection()
-    await page.waitForFunction(
-      () => window.__FRESHELL_TEST_HARNESS__?.getState()?.connection?.status === 'ready',
-      { timeout: 20_000 },
-    )
+    await waitReady(page)
 
     // Settled end state, not just "ready": backlog visible again, chips gone.
     await terminal.waitForOutput('rr-marker-one', { timeout: 20_000 })
@@ -914,22 +933,30 @@ test.describe('reconnect revive (rust)', () => {
     await terminal.waitForOutput('rr-marker-two', { timeout: 10_000 })
   })
 
-  test('close -> reopen revives the still-running session instead of the "still running" refusal', async ({ page, harness, terminal }) => {
-    await terminal.waitForTerminal()
-    await terminal.waitForPrompt()
-    await terminal.executeCommand('echo "rr-close-marker"')
-    await terminal.waitForOutput('rr-close-marker')
-    // Close the tab (detach-only), then reopen the same session from the
-    // sidebar session list (the exact user workaround that dead-ended).
-    // ... drive close via the tab's close button (aria-label per the a11y
-    // contract) and reopen via the session row; assert:
-    await expect(page.getByText(noDeadEndText)).toHaveCount(0)
-    await terminal.waitForOutput('rr-close-marker', { timeout: 20_000 })
-    await terminal.executeCommand('echo "rr-after-reopen"')
-    await terminal.waitForOutput('rr-after-reopen', { timeout: 10_000 })
+  test('REST resume door names the live owner in its refusal (red-first contract)', async ({ freshellPage, page, harness, terminal }) => {
+    // Shell panes never reach D7 (create_session_locator → None for shell):
+    // use a provider-mode (claude) terminal pane, hermetically seeded with a
+    // known session id, per the opencode-terminal-restore / session-directory
+    // donor idioms. Close it (detach-only), then drive the REST door:
+    //   POST /api/tabs { mode:'claude', sessionRef:{provider:'claude', sessionId:<id>}, ... }
+    // via page.evaluate(fetch). Assert on base-vs-after behavior:
+    //   - status is STILL 409 (D7 stays in force — doctrine),
+    //   - body.code === 'RESTORE_UNAVAILABLE',
+    //   - body.liveTerminalId === the still-running terminal's id   ← red on base
+    //     (reopen in the same client adopts namelessly via WS; this field is
+    //     what lets any refused caller reattach).
   })
 
-  test('two sequential drops mid-reattach converge to a live pane', async ({ page, harness, terminal }) => {
+  test('sidebar close -> reopen of a live session converges (regression pin)', async ({ freshellPage, page, harness, terminal }) => {
+    // LB-1 proved the negotiated WS door adopts on base: this test is GREEN on
+    // base and after — it pins the adopt arm so the Task 7 refusal-lane work
+    // never regresses it. Provider-mode pane with a known session id; close tab
+    // (detach-only); reopen from the sidebar session row; assert no dead-end
+    // text and output continuity (marker + post-reopen input round-trip).
+    await expect(page.getByText(noDeadEndText)).toHaveCount(0)
+  })
+
+  test('two sequential drops mid-reattach converge to a live pane', async ({ freshellPage, page, harness, terminal }) => {
     await terminal.waitForTerminal()
     await terminal.waitForPrompt()
     await terminal.executeCommand('echo "rr-double"')
@@ -938,44 +965,67 @@ test.describe('reconnect revive (rust)', () => {
     await harness.waitForConnection()
     await harness.forceDisconnect() // drop again before reattach could settle
     await harness.waitForConnection()
-    await page.waitForFunction(
-      () => window.__FRESHELL_TEST_HARNESS__?.getState()?.connection?.status === 'ready',
-      { timeout: 20_000 },
-    )
+    await waitReady(page)
     await terminal.executeCommand('echo "rr-double-after"')
     await terminal.waitForOutput('rr-double-after', { timeout: 20_000 })
     await expect(page.getByText(noDeadEndText)).toHaveCount(0)
   })
+
+  test('server-process freeze (dead-peer shape) converges after thaw', async ({ freshellPage, page, harness, terminal, testServer }) => {
+    test.slow() // ~45s freeze window: trips the 30s probe + 10s pong timeout
+    await terminal.waitForTerminal()
+    await terminal.waitForPrompt()
+    await terminal.executeCommand('echo "rr-freeze"')
+    await terminal.waitForOutput('rr-freeze')
+    // SIGSTOP the SERVER (kernel holds the client sockets open; no close frame
+    // reaches the client — the true phone-background shape). Precedent:
+    // terminal-background-freeze-catchup.spec.ts (+win32 gate).
+    process.kill(testServer.info.pid, 'SIGSTOP')
+    await new Promise((r) => setTimeout(r, 45_000)) // client probe+timeout fires inside this window
+    process.kill(testServer.info.pid, 'SIGCONT')
+    await harness.waitForConnection()
+    await waitReady(page)
+    await terminal.executeCommand('echo "rr-thawed"')
+    await terminal.waitForOutput('rr-thawed', { timeout: 30_000 })
+    await expect(page.getByText(noDeadEndText)).toHaveCount(0)
+  })
+
+  test('fresh-agent pane transcript repaints after a bare socket drop', async ({ freshellPage, page, harness }) => {
+    // Donor: hidden-pane-rebind-rust.spec.ts + its fake-claude-sidecar fixture
+    // (FAKE_CLAUDE_SIDECAR_SOURCE + seeded transcript). Arrange a VISIBLE
+    // freshclaude pane with one completed turn; forceDisconnect(); reconnect;
+    // assert the prior turn renders (HTTP snapshot 'reconnect' fetch fired and
+    // committed) and the composer is enabled — the Task 4/5 wedge would leave
+    // it 'Read-only session' with an empty transcript.
+  })
 })
 ```
-
-(The close/reopen test's exact sidebar driving idioms come from the session-directory specs; the assertions above are the contract. A flaky-looking first red run is acceptable evidence of the missing behavior; a selector error is not.)
 
 - [ ] **Step 2: Run the test and verify the intended failure**
 
 Run: `npx playwright test --config test/e2e-browser/playwright.config.ts --project=rust-chromium test/e2e-browser/specs/reconnect-revive-rust.spec.ts`
 
-Expected (before Tasks 1-7 land, or when run against base): the close→reopen test FAILS with the "still running on the server" text; sequential-drop may already pass with Tasks 1-3 landed. In plan order this task runs last, so record the residual failure evidence if any test still cannot go green.
+Expected against base: the REST-door contract test FAILS on the missing `liveTerminalId` field; the freeze test fails without the Task 1 watchdog (pane never revives inside the window); sidebar-adoption pin and plain-drop tests may already pass (documented pins). Record a per-test base-status table in the task's execution notes. In plan order this task runs last; any test still red after Tasks 1-7 is the LB-2 completeness signal — stop and attribute it before proceeding.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Register the spec (`/reconnect-revive-rust\.spec\.ts$/`) in `RUST_ONLY_SPECS` and the `rust-chromium` `testMatch` list with a one-line comment (socket-drop revival, not restartAbrupt-shaped). Production code is Tasks 1-7; this task adds no other production change.
+Register the spec in `RUST_ONLY_SPECS` and the `rust-chromium` `testMatch` list with a one-line comment (socket-drop/freeze revival; drives RustServer + forceDisconnect + SIGSTOP). Production code is Tasks 1-7; this task adds no other production change.
 
 - [ ] **Step 4: Run the focused test**
 
 Run: `npx playwright test --config test/e2e-browser/playwright.config.ts --project=rust-chromium test/e2e-browser/specs/reconnect-revive-rust.spec.ts`
 
-Expected: PASS (3/3)
+Expected: PASS (6/6). Also run once on the CLOUD backend before the PR per repo rule: `bash scripts/e2e-cloud.sh run --project=rust-chromium reconnect-revive-rust` (or the documented shard filter form) — a spec sitting in CLOUD_SKIP_SPECS is not coverage.
 
 - [ ] **Step 5: Refactor while green**
 
-Extract a tiny shared `expectNoDeadEnd(page)` local helper if the triple-reading gets noisy; keep assertions explicit.
+Extract a tiny shared `expectLivePaneAfterReconnect(page, terminal)` helper if the four terminal tests' tails get noisy; keep assertions explicit. Do not parameterize the freeze window — flakiness hides there.
 
 - [ ] **Step 6: Run impacted-test verification**
 
-The spec registration edits touch project gating; run the neighboring rust reconnect family plus the config's own consumers:
+The spec registration edits touch project gating; run the neighboring rust reconnect family:
 
-Run: `npx playwright test --config test/e2e-browser/playwright.config.ts --project=rust-chromium test/e2e-browser/specs/reconnect-revive-rust.spec.ts test/e2e-browser/specs/hidden-pane-rebind-rust.spec.ts test/e2e-browser/specs/server-restart-recovery.spec.ts` and `npm run test:vitest -- run test/e2e/vitest.config consumers` (only if such a config test exists; otherwise omit)
+Run: `npx playwright test --config test/e2e-browser/playwright.config.ts --project=rust-chromium test/e2e-browser/specs/reconnect-revive-rust.spec.ts test/e2e-browser/specs/hidden-pane-rebind-rust.spec.ts test/e2e-browser/specs/server-restart-recovery.spec.ts`
 
 Expected: PASS
 
@@ -983,11 +1033,12 @@ Expected: PASS
 
 ```bash
 git add test/e2e-browser/specs/reconnect-revive-rust.spec.ts test/e2e-browser/playwright.config.ts
-git commit -m "test(e2e): prove reconnect revives terminal panes on the rust server"
+git commit -m "test(e2e): prove reconnect revives panes on the rust server (drop, freeze, close-reopen, fresh-agent)"
 ```
 
 ## Cross-Cutting Notes
 
+- **Load-bearing resolution record (stage 2):** ledger at `.worktrees/.the-usual-logs/reconnect-revive/load-bearing-ledger.md`; validator reports under `reports/load-bearing-validator-*.md`. LB-1 falsified (WS negotiated close→reopen already adopts — retargeted Task 7, dropped its client-routing arm under the scope rule). LB-3 confirmed → Task 1 uses abandon-and-reconnect with generation guards. LB-4 substantiated → dead-peer e2e shape is server-SIGSTOP; the 65s foreground recycle is unit-covered only (headless Playwright cannot drive real visibility transitions; recorded tradeoff). LB-5 confirmed → Task 7's revive goes through the epoch-bumping `applyReattachToLiveTerminal` reducer. LB-6 confirmed (opencode attach arm only; codex's attach arm stays untouched — it is sequence-pinned by the wireshape differential). LB-7 confirmed → the 30s liveness interval needs no suite guards. LB-2 (completeness) is deferred to Stage 4 by design: Task 8's per-test base-status table plus attribution rubric is its evidence vehicle.
 - **Deferred residue (out of scope by the User Request):** multi-view/multi-device attach and adopt/view policies (#4/#2/#3); server-side retention-overflow signaling (`replayResetReason`) beyond what existing replay-gap handling surfaces; broadcast-bus replay across the dead window (all recovery here is pull/re-ask based, per the existing architecture).
 - **Frozen clients:** pre-reconcile clients never send `pane.reconcile.request` and never receive the new error code; all additive wire fields are omitted when absent. Old client + new server converges via the census. New client + old server: the watchdog/poke never needs the server to know about it; the reconcile wait expires into the census; the D7 revival only fires when the server sends the id (absent → today's `[Restore failed]` path, unchanged).
 - **Perf/visible-first audits:** liveness pings fire only on ≥30s inbound silence and never before ready; no new pre-ready HTTP traffic is introduced.

--- a/port/contract/ws-protocol.schema.json
+++ b/port/contract/ws-protocol.schema.json
@@ -2524,7 +2524,8 @@
         "PROTOCOL_MISMATCH",
         "SESSION_RESERVED",
         "FRESH_AGENT_LOST_SESSION",
-        "FRESH_AGENT_CREATE_FAILED"
+        "FRESH_AGENT_CREATE_FAILED",
+        "RECONCILE_NOT_NEGOTIATED"
       ],
       "type": "string"
     },

--- a/port/contract/ws-server-messages.schema.json
+++ b/port/contract/ws-server-messages.schema.json
@@ -571,7 +571,8 @@
             "PROTOCOL_MISMATCH",
             "SESSION_RESERVED",
             "FRESH_AGENT_LOST_SESSION",
-            "FRESH_AGENT_CREATE_FAILED"
+            "FRESH_AGENT_CREATE_FAILED",
+            "RECONCILE_NOT_NEGOTIATED"
           ],
           "type": "string"
         },

--- a/port/contract/ws-server-messages.schema.json
+++ b/port/contract/ws-server-messages.schema.json
@@ -591,6 +591,9 @@
           ],
           "type": "object"
         },
+        "liveTerminalId": {
+          "type": "string"
+        },
         "message": {
           "type": "string"
         },

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -764,6 +764,8 @@ export type ErrorMessage = {
   actualSessionRef?: SessionLocator
   /** SESSION_RESERVED only: how long the loser should wait before re-sending its create. Additive; omitted everywhere else. */
   retryAfterMs?: number
+  /** RESTORE_UNAVAILABLE only (D7): the live terminal that owns the refused session, so the create-error fold can reattach instead of dead-ending. Additive; omitted everywhere else. */
+  liveTerminalId?: string
   timestamp: string
 }
 

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -35,6 +35,7 @@ export const ErrorCode = z.enum([
   'SESSION_RESERVED',
   'FRESH_AGENT_LOST_SESSION',
   'FRESH_AGENT_CREATE_FAILED',
+  'RECONCILE_NOT_NEGOTIATED',
 ])
 
 export type ErrorCode = z.infer<typeof ErrorCode>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/store/sessionsThunks'
 import { fetchTerminalDirectoryWindow } from '@/store/terminalDirectoryThunks'
 import { createTerminalInvalidationHandler } from '@/lib/terminal-invalidation-handler'
-import { buildReconcileRequest, collectTerminalPaneTargets, foldVerdicts, setFreshAgentReconcileActive } from '@/lib/pane-reconcile'
+import { buildReconcileRequest, collectTerminalPaneTargets, foldVerdicts, RECONCILE_RESULT_WAIT_MS, setFreshAgentReconcileActive } from '@/lib/pane-reconcile'
 import { PaneReconcileResultSchema, type PaneReconcileRequest } from '@shared/ws-protocol'
 import { getShareAction, ensureShareUrlToken, isRemoteAccessEnabledStatus } from '@/lib/share-utils'
 import { getWsClient } from '@/lib/ws-client'
@@ -267,6 +267,9 @@ export default function App() {
   // mint their own).
   const paneReconcileActiveRef = useRef(false)
   const pendingReconcileRef = useRef<PaneReconcileRequest | null>(null)
+  // Wall-clock timer for the bounded boot-reconcile result wait; see
+  // clearReconcileResultWait in the ws effect for the full contract.
+  const reconcileResultTimerRef = useRef<number | null>(null)
   const fullscreenTouchStartYRef = useRef<number | null>(null)
   const isLandscapeTerminalView = isMobile && isLandscape && view === 'terminal'
   const shareAccessUrl = networkStatus?.accessUrl
@@ -511,6 +514,19 @@ export default function App() {
     let lastReadyServerInstanceId: string | undefined
     let lastSessionsRevision = -1
     const versionInfoLoadedRef = { current: false }
+
+    // Bounded wait for the current boot's pane.reconcile.result: the result
+    // is unicast to THIS socket, so a result lost with a dying socket would
+    // otherwise wedge panes pending-verdict until the NEXT ready healed them
+    // (the reported gray-and-dead shape). Armed right after the request is
+    // sent; cancelled by the result, a correlated error, disconnect, or
+    // teardown.
+    const clearReconcileResultWait = () => {
+      if (reconcileResultTimerRef.current !== null) {
+        window.clearTimeout(reconcileResultTimerRef.current)
+        reconcileResultTimerRef.current = null
+      }
+    }
 
     async function bootstrap() {
       const performAuthFailureTeardown = () => {
@@ -765,6 +781,11 @@ export default function App() {
 
       stopWsDisconnectSync = wsWithOptionalDisconnect.onDisconnect?.(() => {
         if (cancelled) return
+        // Cancel any armed boot-result wait: never census from stale
+        // inventory while offline — the next ready re-sends the request and
+        // re-arms the wait.
+        clearReconcileResultWait()
+        pendingReconcileRef.current = null
         resetCodexActivityOverlay()
         resetClaudeActivityOverlay()
         resetAmplifierActivityOverlay()
@@ -907,15 +928,19 @@ export default function App() {
         }
       }
 
-      // Terminal failure of a reconcile App minted (cardinality violation or a
+      // Terminal failure of a reconcile App minted (cardinality violation, a
       // correlated server error frame like RECONCILE_TOO_LARGE /
-      // RECONCILE_UNAVAILABLE): deactivate reconcile for THIS inventory cycle
-      // (re-set true on the next ready) and run the legacy census once from
-      // the CACHED liveTerminalIds — on the real wire terminal.inventory
-      // ALWAYS precedes any reconcile result, so the cache is populated.
-      // Deliberately NO wall-clock timeout on the pending reconcile: it would
-      // false-trip on legitimate deferrals; the request is re-sent on every
-      // ready, so reconnect covers loss windows.
+      // RECONCILE_UNAVAILABLE / RECONCILE_NOT_NEGOTIATED, or expiry of the
+      // bounded boot-result wait): deactivate reconcile for THIS inventory
+      // cycle (re-set true on the next ready) and run the legacy census once
+      // from the CACHED liveTerminalIds — on the real wire
+      // terminal.inventory ALWAYS precedes any reconcile result, so the
+      // cache is populated. The pending reconcile carries a bounded
+      // wall-clock wait (RECONCILE_RESULT_WAIT_MS, well past the server's
+      // single 2s warming deferral) that routes here on expiry — the earlier
+      // deliberate no-timeout decision wedged panes pending-verdict forever
+      // when the result died with its socket (the reported gray-and-dead
+      // shape).
       const fallBackToLegacyCensus = () => {
         pendingReconcileRef.current = null
         paneReconcileActiveRef.current = false
@@ -1051,6 +1076,22 @@ export default function App() {
                 dispatch(setReconcilePendingPanes({ paneKeys: req.panes.map((p) => p.paneKey), startedAt: Date.now() }))
                 ws.setReconcilePendingCreates(req.panes.map((p) => p.createRequestId))
                 ws.send(req)
+                clearReconcileResultWait()
+                reconcileResultTimerRef.current = window.setTimeout(() => {
+                  reconcileResultTimerRef.current = null
+                  if (!pendingReconcileRef.current) return
+                  // The result is unicast to THIS socket; if it was lost with
+                  // a dying socket, only ANOTHER ready would heal the wedge
+                  // (gray panes, zero chrome). Bound the wait and degrade to
+                  // the legacy census instead. This supersedes the earlier
+                  // deliberate no-timeout decision: the wedge it permits is
+                  // the reported gray-and-dead shape.
+                  log.warn('[reconcile] result wait expired — falling back to legacy census')
+                  pendingReconcileRef.current = null
+                  dispatch(clearAllReconcilePendingPanes())
+                  ws.clearReconcileCreateHold()
+                  fallBackToLegacyCensus()
+                }, RECONCILE_RESULT_WAIT_MS)
               } else {
                 ws.clearReconcileCreateHold() // nothing to reconcile — release any held creates immediately
               }
@@ -1078,6 +1119,7 @@ export default function App() {
             return
           }
           pendingReconcileRef.current = null
+          clearReconcileResultWait()
           const parsed = PaneReconcileResultSchema.safeParse(msg)
           if (!parsed.success) {
             console.error('[reconcile] malformed result — falling back to legacy census', parsed.error.issues)
@@ -1134,6 +1176,7 @@ export default function App() {
             console.error('[reconcile] server error — falling back to legacy census', (msg as { code?: unknown }).code)
             // Terminal for this reconcile: no verdicts are coming — release
             // the pending panes and the sender hold before the census.
+            clearReconcileResultWait()
             dispatch(clearAllReconcilePendingPanes())
             ws.clearReconcileCreateHold()
             fallBackToLegacyCensus()
@@ -1493,6 +1536,7 @@ export default function App() {
       document.removeEventListener('visibilitychange', pokeWsWhenVisible)
       cancelled = true
       cleanedUp = true
+      clearReconcileResultWait()
       cleanup?.()
       stopTabRegistrySync?.()
       stopWsDisconnectSync?.()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1476,7 +1476,21 @@ export default function App() {
 
     const cleanupPromise = bootstrap()
 
+    // Foreground reconnect poke: mobile browsers freeze or silently kill the
+    // socket while backgrounded, so re-assert transport liveness whenever the
+    // page comes back to the front (visibilitychange/online/pageshow — the
+    // iOS bfcache restore only fires pageshow).
+    const ws = getWsClient()
+    const pokeWs = () => ws.poke()
+    const pokeWsWhenVisible = () => { if (document.visibilityState === 'visible') ws.poke() }
+    window.addEventListener('online', pokeWs)
+    window.addEventListener('pageshow', pokeWs)
+    document.addEventListener('visibilitychange', pokeWsWhenVisible)
+
     return () => {
+      window.removeEventListener('online', pokeWs)
+      window.removeEventListener('pageshow', pokeWs)
+      document.removeEventListener('visibilitychange', pokeWsWhenVisible)
       cancelled = true
       cleanedUp = true
       cleanup?.()

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -5210,9 +5210,9 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           getHydrationQueue().onHydrationComplete(paneIdRef.current)
           hydrationRegisteredRef.current = false
           // Always queueIfStarted: a hidden pane's reattach must not wait for
-          // reveal. The deferred intent chosen above (transport_reconnect vs
-          // viewport_hydrate) still governs WHAT the attach asks for; this
-          // only governs THAT it runs.
+          // reveal. The deferred intent chosen above governs the REVEAL path;
+          // when the pump grants this pane a slot it recomputes the checkpoint
+          // decision at grant time. This call only governs THAT the pump runs.
           registerForBackgroundHydration({ queueIfStarted: true })
           return
         }

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -5204,7 +5204,16 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
                 pendingSinceSeq: 0,
                 pendingReason: 'hidden_reveal',
               }
-          registerForBackgroundHydration({ queueIfStarted: canResumeFromParserAppliedSurface })
+          // Same three-step re-register as the terminal.created hidden path
+          // (~:4506): a stale active slot or a consumed registration guard
+          // otherwise wedges this pane out of the post-reconnect pump entirely.
+          getHydrationQueue().onHydrationComplete(paneIdRef.current)
+          hydrationRegisteredRef.current = false
+          // Always queueIfStarted: a hidden pane's reattach must not wait for
+          // reveal. The deferred intent chosen above (transport_reconnect vs
+          // viewport_hydrate) still governs WHAT the attach asks for; this
+          // only governs THAT it runs.
+          registerForBackgroundHydration({ queueIfStarted: true })
           return
         }
         attachTerminal(tid, 'transport_reconnect')

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -15,6 +15,7 @@ import { useAppDispatch, useAppSelector, useAppStore } from '@/store/hooks'
 import { updateTab, switchToNextTab, switchToPrevTab } from '@/store/tabsSlice'
 import {
   applyReconcileAttach,
+  applyReattachToLiveTerminal,
   clearPaneReconcileNotice,
   clearReconcilePendingPane,
   consumePaneRefreshRequest,
@@ -836,6 +837,12 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
     expectedGeometryAuthority: TerminalGeometryAuthority
   } | null>(null)
   const launchAttemptRef = useRef<LaunchAttemptState | null>(null)
+  // One-shot revival bound: a create refused with a D7 liveTerminalId folds
+  // ONE reattach per createRequestId; a second refusal falls through to the
+  // existing dead-end write — never loop on a handle that died mid-revival.
+  // Reset wherever a fresh createRequestId is minted (launch-attempt
+  // bookkeeping sites), so a new create round gets a new revival chance.
+  const reviveAttemptedRef = useRef<string | null>(null)
   const suppressNextMatchingResizeRef = useRef<{
     terminalId: string
     cols: number
@@ -3300,6 +3307,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       requestIdRef.current = pending.requestId
       terminalIdRef.current = undefined
       launchAttemptRef.current = null
+      reviveAttemptedRef.current = null
       clearQuarantineRepair()
       currentAttachRef.current = null
       deferredAttachStateRef.current = {
@@ -4820,6 +4828,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           addTerminalRestoreRequestId(newRequestId)
           requestIdRef.current = newRequestId
           launchAttemptRef.current = null
+          reviveAttemptedRef.current = null
           clearQuarantineRepair()
           currentAttachRef.current = null
           clearRateLimitRetry()
@@ -4870,6 +4879,31 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
         }
 
         if (msg.type === 'error' && msg.requestId === reqId) {
+          // D7-refusal revival (reconnect-revive Task 7): the create was
+          // refused because the session is STILL RUNNING under the named
+          // terminal — reattach the pane to it instead of dead-ending on
+          // "[Restore failed] Session … is still running on the server."
+          // The epoch-bumping reducer fold is the ONLY re-fire signal the
+          // lifecycle effect honors (deps exclude terminalId/status by
+          // design), so the reattach rides the same proven path as
+          // applyReconcileAttach. One revival per createRequestId: if the
+          // live handle died in the race, the follow-on refusal lands the
+          // existing dead-end write — never loop.
+          if (
+            msg.code === 'RESTORE_UNAVAILABLE'
+            && typeof reqId === 'string'
+            && typeof msg.liveTerminalId === 'string'
+            && reviveAttemptedRef.current !== reqId
+          ) {
+            reviveAttemptedRef.current = reqId
+            dispatch(applyReattachToLiveTerminal({
+              tabId,
+              paneId: paneIdRef.current,
+              terminalId: msg.liveTerminalId,
+            }))
+            writeLocalXtermNotice(term, `\r\nReconnected to the still-running session.\r\n`)
+            return
+          }
           if (msg.code === 'RATE_LIMITED') {
             const scheduled = scheduleCreateRetry(reqId, 'rate-limit')
             if (scheduled) {
@@ -5038,6 +5072,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
               writeLocalXtermNotice(term, '\r\n[Starting a new terminal because the previous live terminal is gone and no durable session identity was saved]\r\n')
               const newRequestId = nanoid()
               launchAttemptRef.current = null
+              reviveAttemptedRef.current = null
               clearQuarantineRepair()
               currentAttachRef.current = null
               clearRateLimitRetry()
@@ -5109,6 +5144,7 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             clearTerminalRestoreRequestId(requestIdRef.current)
             addTerminalRestoreRequestId(newRequestId)
             requestIdRef.current = newRequestId
+            reviveAttemptedRef.current = null
             clearQuarantineRepair()
             currentAttachRef.current = null
             clearTerminalCursor(currentTerminalId)

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -629,6 +629,11 @@ export function FreshAgentView({
   const refreshRequest = useAppSelector((state) => state.panes.refreshRequestsByPane?.[tabId]?.[paneId] ?? null)
   const activeTabId = useAppSelector((state) => state.tabs.activeTabId)
   const activePaneId = useAppSelector((state) => state.panes.activePane[tabId])
+  // Reconnect authority for the .lost recovery driver below: App flips
+  // connection.status away from 'ready' on every stale-socket abandon and back
+  // to 'ready' after handshake, so a dep flip re-runs the driver on a fresh
+  // reconnect even when every other dep is unchanged.
+  const connectionStatus = useAppSelector((s) => s.connection.status)
   const isActivePane = !hidden && activeTabId === tabId && activePaneId === paneId
   const [snapshot, setSnapshot] = useState<FreshAgentSnapshot | null>(null)
   const snapshotRef = useRef<FreshAgentSnapshot | null>(null)
@@ -2045,6 +2050,11 @@ export function FreshAgentView({
   useEffect(() => {
     if (paneContent.provider !== 'claude' && paneContent.provider !== 'codex') return
     if (!paneContent.sessionId || !agentSession?.lost) return
+    // fresh-eyes F4: the connectionStatus dep also fires on ready->disconnected.
+    // Recovery may only act on POST-reconnect evidence -- while offline,
+    // triggerRecovery() would clear the pane's session id / mint a create
+    // request with no server truth behind it.
+    if (connectionStatus !== 'ready') return
     const shouldDeferUntilVisibleRestore = Boolean(
       agentSession.latestTurnId !== undefined && agentSession.historyLoaded === true
     )
@@ -2070,6 +2080,7 @@ export function FreshAgentView({
     agentSession?.historyLoaded,
     agentSession?.latestTurnId,
     agentSession?.lost,
+    connectionStatus,
     paneContent.provider,
     paneContent.sessionId,
     reconcileLostPane,

--- a/src/lib/pane-reconcile.ts
+++ b/src/lib/pane-reconcile.ts
@@ -18,6 +18,7 @@ import type {
   PaneReconcileResultMessage,
   ReconcilePane,
 } from '@shared/ws-protocol'
+import type { FreshAgentRuntimeProvider } from '@shared/fresh-agent'
 import { buildRestoreError } from '@shared/session-contract'
 import type { AppDispatch, RootState } from '@/store/store'
 import type {
@@ -36,6 +37,7 @@ import {
   setPaneRestoreError,
   setReconcileWarming,
 } from '@/store/panesSlice'
+import { clearSessionLost } from '@/store/freshAgentSlice'
 import { derivePaneTitle } from '@/lib/derivePaneTitle'
 
 /** Protocol cap on request size (mirrors PaneReconcileRequestSchema). */
@@ -307,6 +309,13 @@ function foldFreshAgentVerdict(
         serverInstanceId: result.serverInstanceId,
         corrected: verdict.corrected,
         duplicate: verdict.duplicate ? true : undefined,
+      }))
+      // Server said Live: the verdict itself is positive existence evidence —
+      // revoke a stale `lost` flag left by a transient dead-window race, or the
+      // snapshot fetch stays suppressed and the .lost driver re-fires forever.
+      dispatch(clearSessionLost({
+        sessionId: verdict.sessionRef.sessionId,
+        provider: verdict.sessionRef.provider as FreshAgentRuntimeProvider,
       }))
       outcome.attached++
       return true

--- a/src/lib/pane-reconcile.ts
+++ b/src/lib/pane-reconcile.ts
@@ -41,6 +41,9 @@ import { derivePaneTitle } from '@/lib/derivePaneTitle'
 /** Protocol cap on request size (mirrors PaneReconcileRequestSchema). */
 const MAX_RECONCILE_PANES = 200
 
+/** Bounded wait for a boot `pane.reconcile.result`: > the server's single 2s warming deferral + round-trip margin. */
+export const RECONCILE_RESULT_WAIT_MS = 10_000
+
 export function paneKeyFor(tabId: string, paneId: string): string {
   return `${tabId}:${paneId}`
 }

--- a/src/lib/ws-client.ts
+++ b/src/lib/ws-client.ts
@@ -795,6 +795,12 @@ export class WsClient {
       // gate (fresh-eyes F1 — routing this through tickLiveness's guard could
       // never fire the immediate probe the tests pin).
       if (this.probeSentAt === null) {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+          // Ready state with a non-open socket: a dead-in-flight close that
+          // may never deliver onclose — abandon rather than throw into send().
+          this.abandonStaleSocket('foreground poke: socket not open')
+          return
+        }
         this.probeSentAt = Date.now()
         this.sendNow({ type: 'ping' })
       }

--- a/src/lib/ws-client.ts
+++ b/src/lib/ws-client.ts
@@ -71,6 +71,18 @@ type InFlightCreate = {
 
 const CONNECTION_TIMEOUT_MS = 10_000
 
+// App-level transport liveness. Server-side WS pings are invisible to JS, so
+// liveness is proven by an app-level {type:'ping'}→{type:'pong'} round trip
+// that both servers implement. 10s tick so a probe's 10s timeout is
+// re-evaluated 10s after it was sent (a 30s tick would delay abandonment to
+// t=60 — fresh-eyes F1). Probe fires once inbound silence reaches 30s (both
+// servers' keepalive cadence); the foreground abandon threshold is >2 server
+// keepalive windows.
+const LIVENESS_TICK_MS = 10_000
+const PROBE_AFTER_SILENCE_MS = 30_000
+const PONG_TIMEOUT_MS = 10_000
+const FOREGROUND_RECYCLE_SILENCE_MS = 65_000
+
 // Bounded pre-verdict create hold: when the server acks paneReconcileV1, pane
 // creates are held until their pane's reconcile verdict folds — or this
 // wall-clock bound elapses and every still-held create flushes (legacy-eager
@@ -147,6 +159,14 @@ export class WsClient {
   // Per-connection: {} until a ready with capabilities arrives on the CURRENT
   // socket; reset on disconnect so a downgraded server is honored.
   private serverCapabilities: NonNullable<ReadyCapabilities> = {}
+
+  // Bumped for every new WebSocket; each socket's handlers capture their
+  // generation and no-op once superseded (a late event from an abandoned socket
+  // must never touch the live connection's state).
+  private socketGen = 0
+  private lastInboundAt = 0
+  private probeSentAt: number | null = null
+  private livenessTimer: number | null = null
 
   constructor(private url: string) {}
 
@@ -229,6 +249,10 @@ export class WsClient {
   }
 
   private handleIncomingMessage(msg: ServerMessage): void {
+    // Any parsed inbound frame is liveness evidence (a socket relaying traffic
+    // is not half-open): resets the silence clock and clears an outstanding probe.
+    this.lastInboundAt = Date.now()
+    this.probeSentAt = null
     if (msg.type === 'ready') {
       this._serverInstanceId = typeof msg.serverInstanceId === 'string' && msg.serverInstanceId.trim()
         ? msg.serverInstanceId
@@ -450,9 +474,18 @@ export class WsClient {
       }, CONNECTION_TIMEOUT_MS)
 
       this.ws = new WebSocket(this.url)
+      // Generation guard: each socket's handlers capture their generation and
+      // no-op once superseded — a late event from an abandoned socket must
+      // never touch the live connection's state (LB-3).
+      const gen = ++this.socketGen
+      const socket = this.ws
 
       this.ws.onopen = () => {
+        if (gen !== this.socketGen || this.ws !== socket) return
         this._state = 'connected'
+        this.lastInboundAt = Date.now()
+        this.probeSentAt = null
+        this.startLivenessWatch()
         this.reconnectAttempts = 0
         this.fastReconnectMode = false
         this.slowRetryAnnounced = false
@@ -476,6 +509,7 @@ export class WsClient {
       }
 
       this.ws.onmessage = (event) => {
+        if (gen !== this.socketGen || this.ws !== socket) return
         let msg: ServerMessage
         try {
           msg = JSON.parse(event.data) as ServerMessage
@@ -506,7 +540,9 @@ export class WsClient {
       }
 
       this.ws.onclose = (event) => {
+        if (gen !== this.socketGen || this.ws !== socket) return
         this.clearReadyTimeout()
+        this.clearLivenessWatch()
         const wasReady = this._state === 'ready'
         const closedBeforeReady = !wasReady
         this._state = 'disconnected'
@@ -586,6 +622,7 @@ export class WsClient {
       }
 
       this.ws.onerror = () => {
+        if (gen !== this.socketGen || this.ws !== socket) return
         // onclose will fire with details; if still connecting, reject quickly.
         if (this._state === 'connecting') {
           finishReject(new Error('WebSocket error'))
@@ -645,6 +682,9 @@ export class WsClient {
     this.intentionalClose = true
     this.clearReconnectTimer()
     this.clearReadyTimeout()
+    this.clearLivenessWatch()
+    // Bump the generation so a torn-down socket's late events are inert.
+    this.socketGen += 1
     this.ws?.close()
     this.ws = null
     this._state = 'disconnected'
@@ -673,6 +713,97 @@ export class WsClient {
       window.clearTimeout(this.readyTimeout)
       this.readyTimeout = null
     }
+  }
+
+  private startLivenessWatch(): void {
+    this.clearLivenessWatch()
+    this.livenessTimer = window.setInterval(() => this.tickLiveness(), LIVENESS_TICK_MS)
+  }
+
+  private clearLivenessWatch(): void {
+    if (this.livenessTimer !== null) {
+      window.clearInterval(this.livenessTimer)
+      this.livenessTimer = null
+    }
+    this.probeSentAt = null
+  }
+
+  private tickLiveness(): void {
+    if (this._state !== 'ready' || !this.ws || this.ws.readyState !== WebSocket.OPEN) return
+    const now = Date.now()
+    if (this.probeSentAt !== null) {
+      if (now - this.probeSentAt >= PONG_TIMEOUT_MS) {
+        this.abandonStaleSocket('liveness probe unanswered')
+      }
+      return
+    }
+    if (now - this.lastInboundAt < PROBE_AFTER_SILENCE_MS) return
+    this.probeSentAt = now
+    this.sendNow({ type: 'ping' })
+  }
+
+  /**
+   * Half-open socket disposal. A dead transport cannot be trusted to deliver
+   * onclose promptly (or ever), so recycling never waits on the old socket's
+   * events: handlers detach, connection-local state is forced down, and a fresh
+   * connect is driven NOW. The generation guard makes the old socket's late
+   * events no-ops (LB-3: the bare this.ws swap in connect() would otherwise let
+   * the old onclose corrupt the new connection).
+   */
+  private abandonStaleSocket(reason: string): void {
+    const old = this.ws
+    if (old) {
+      old.onopen = null
+      old.onmessage = null
+      old.onclose = null
+      old.onerror = null
+      try { old.close() } catch { /* best effort: resource hygiene only */ }
+    }
+    this.ws = null
+    this._state = 'disconnected'
+    this.serverCapabilities = {}
+    this.resetReconcileHold({ requeueHeld: true })
+    this.clearLivenessWatch()
+    // A normal close notifies disconnectHandlers (App flips Redux
+    // connection.status at App.tsx's onDisconnect subscription) — abandonment
+    // must too, or Redux sits at 'ready' forever and every status-keyed
+    // recovery wedges.
+    this.disconnectHandlers.forEach((h) => h())
+    log.warn(`abandoning stale socket: ${reason}`)
+    this.connect().catch((err) => log.debug('reconnect after abandon failed', err))
+  }
+
+  /**
+   * Foreground poke: re-assert connectivity when the page becomes visible/online.
+   * - ready + recently active   → probe immediately (fast failure discovery).
+   * - ready + silent past two server keepalive windows → abandon: the peer may
+   *   already be reaped, and reconnect convergence is cheaper than the probe wait.
+   * - down with a (possibly background-clamped) backoff timer pending → connect now.
+   */
+  poke(): void {
+    if (this.intentionalClose) return
+    if (this._state === 'ready') {
+      if (this.probeSentAt !== null && Date.now() - this.probeSentAt >= PONG_TIMEOUT_MS) {
+        this.abandonStaleSocket('foreground poke: outstanding probe expired')
+        return
+      }
+      if (Date.now() - this.lastInboundAt >= FOREGROUND_RECYCLE_SILENCE_MS) {
+        this.abandonStaleSocket('foreground poke past keepalive windows')
+        return
+      }
+      // Foreground means "ask now": probe immediately, bypassing the 30s silence
+      // gate (fresh-eyes F1 — routing this through tickLiveness's guard could
+      // never fire the immediate probe the tests pin).
+      if (this.probeSentAt === null) {
+        this.probeSentAt = Date.now()
+        this.sendNow({ type: 'ping' })
+      }
+      return
+    }
+    if (this.connectPromise) return
+    if (this._state === 'connecting') return
+    this.clearReconnectTimer()
+    this.connect().catch((err) => log.debug('poke reconnect failed', err))
   }
 
   /**

--- a/src/store/freshAgentSlice.ts
+++ b/src/store/freshAgentSlice.ts
@@ -300,6 +300,10 @@ const freshAgentSlice = createSlice({
     }>) {
       const session = resolveOrEnsureSession(state, action.payload, action.payload.status)
       if (!session) return
+      // Truth-bearing frame: a snapshot answer proves the session exists —
+      // revoke a stale `lost` flag from a transient dead-window race
+      // (reconnect unwedge).
+      session.lost = false
       const shouldRestartHydration = Boolean(
         session.historyLoaded
           && action.payload.revision != null
@@ -378,6 +382,10 @@ const freshAgentSlice = createSlice({
         sessionType: snapshot.sessionType,
         provider: snapshot.provider,
       }, snapshot.status as FreshAgentSessionStatus)
+      // Truth-bearing frame: a snapshot answer proves the session exists —
+      // revoke a stale `lost` flag from a transient dead-window race
+      // (reconnect unwedge).
+      session.lost = false
       session.snapshot = snapshot
       writeSessionStatus(session, snapshot.status as FreshAgentSessionStatus)
       session.latestTurnId = snapshot.latestTurnId

--- a/src/store/freshAgentSlice.ts
+++ b/src/store/freshAgentSlice.ts
@@ -384,7 +384,8 @@ const freshAgentSlice = createSlice({
       }, snapshot.status as FreshAgentSessionStatus)
       // Truth-bearing frame: a snapshot answer proves the session exists —
       // revoke a stale `lost` flag from a transient dead-window race
-      // (reconnect unwedge).
+      // (reconnect unwedge). This reducer is currently production-dormant (no
+      // dispatch site); the line is armor for any future HTTP-snapshot fold.
       session.lost = false
       session.snapshot = snapshot
       writeSessionStatus(session, snapshot.status as FreshAgentSessionStatus)

--- a/src/store/panesSlice.ts
+++ b/src/store/panesSlice.ts
@@ -653,6 +653,22 @@ function findReconcileTerminalContent(
   return leaf.content
 }
 
+/**
+ * Shared live-handle fold (applyReconcileAttach / applyReattachToLiveTerminal):
+ * point an already-mounted pane at a live terminal and bump the volatile
+ * epoch — the lifecycle effect's ONLY re-fire signal on an unchanged
+ * createRequestId (TerminalView excludes terminalId/status from its deps by
+ * design; without the bump the fold stays invisible and the pane gray).
+ * Callers own lookup and any extra identity/bookkeeping writes.
+ */
+function foldLiveTerminalAttach(content: TerminalPaneContent, terminalId: string): void {
+  content.terminalId = terminalId
+  content.streamId = undefined
+  content.status = 'running'
+  content.restoreError = undefined
+  content.reconcileEpoch = (content.reconcileEpoch ?? 0) + 1
+}
+
 /** Fresh-agent + terminal finder for reconcile fold reducers. */
 function findReconcilePaneContent(
   state: PanesState,
@@ -1962,19 +1978,14 @@ export const panesSlice = createSlice({
       const content = findReconcileTerminalContent(state, tabId, paneId)
       if (!content) return
 
-      content.terminalId = terminalId
+      foldLiveTerminalAttach(content, terminalId)
       content.serverInstanceId = serverInstanceId
-      content.streamId = undefined
-      content.status = 'running'
-      content.restoreError = undefined
       const sessionRef = sanitizeSessionRef(action.payload.sessionRef)
       if (sessionRef) {
         content.sessionRef = sessionRef
         content.resumeSessionId = undefined
       }
       content.pendingReconcile = undefined
-      // A1 fix: same-createRequestId folds are only observable via the epoch bump.
-      content.reconcileEpoch = (content.reconcileEpoch ?? 0) + 1
       if (corrected) {
         content.reconcileNotice = RECONCILE_NOTICE_CORRECTED
       } else if (duplicate) {
@@ -1982,6 +1993,20 @@ export const panesSlice = createSlice({
       }
       clearRestoreFallbackAttemptForPane(state, tabId, paneId)
       clearReconcilePendingForPane(state, tabId, paneId)
+    },
+
+    /** Close→reopen revival: a D7 refusal named the live owner terminal — reattach
+     * the pane to it. The reconcileEpoch bump is the lifecycle effect's ONLY
+     * re-fire signal (createRequestId is preserved), mirroring applyReconcileAttach. */
+    applyReattachToLiveTerminal: (
+      state,
+      action: PayloadAction<{ tabId: string; paneId: string; terminalId: string }>
+    ) => {
+      const { tabId, paneId, terminalId } = action.payload
+      if (!terminalId) return
+      const content = findReconcileTerminalContent(state, tabId, paneId)
+      if (!content) return
+      foldLiveTerminalAttach(content, terminalId)
     },
 
     /**
@@ -2309,6 +2334,7 @@ export const {
   clearDeadTerminals,
   clearTerminalLiveHandles,
   applyReconcileAttach,
+  applyReattachToLiveTerminal,
   resetPaneForReconcileCreate,
   applyFreshAgentReconcileAttach,
   resetFreshAgentPaneForReconcileCreate,

--- a/test/e2e-browser/playwright.config.ts
+++ b/test/e2e-browser/playwright.config.ts
@@ -289,6 +289,9 @@ export const RUST_ONLY_SPECS = [
   // RustServers, hard e2eServerKind==='rust' assertion per test; the legacy
   // tree has no amplifier provider registered at all (pre-existing gap fix).
   /remote-tab-linkage-rust\.spec\.ts$/,
+  // Reconnect-revive acceptance: socket-drop/freeze revival; drives
+  // RustServer + forceDisconnect + SIGSTOP (docs/plans/2026-08-22-reconnect-revive.md).
+  /reconnect-revive-rust\.spec\.ts$/,
 ]
 
 export default defineConfig({
@@ -528,6 +531,9 @@ export default defineConfig({
         // SESSION-02/03 -- soft-delete route + unmatched-/api/* 404-JSON
         // contract wall (see RUST_ONLY_SPECS entry + the spec's doc comment).
         /session-delete-rust\.spec\.ts$/,
+        // Reconnect-revive acceptance: socket-drop/freeze revival; drives
+        // RustServer + forceDisconnect + SIGSTOP (see RUST_ONLY_SPECS entry).
+        /reconnect-revive-rust\.spec\.ts$/,
       ],
     },
     // CONTINUITY SMOKE (pre-deploy gate): REAL freshell-server binary + REAL

--- a/test/e2e-browser/specs/reconnect-revive-rust.spec.ts
+++ b/test/e2e-browser/specs/reconnect-revive-rust.spec.ts
@@ -1,0 +1,774 @@
+/**
+ * RECONNECT REVIVE (rust) -- first-class browser proof of the user-visible
+ * reconnect acceptance shape on the production server stack
+ * (docs/plans/2026-08-22-reconnect-revive.md, Task 8).
+ *
+ * Six lanes, one per named coverage gap:
+ *
+ *  1. terminal pane reattaches and repaints after a bare socket drop --
+ *     rust-side plain socket drop with "stops being gray/dead" assertions:
+ *     pre-drop backlog visible again, offline/recovering chips gone, and a
+ *     LIVE post-reconnect input round trip (not a frozen repaint).
+ *  2. REST resume door names the live owner in its refusal (red-first
+ *     contract): POST /api/tabs with a sessionRef naming a still-running
+ *     session stays a 409 (D7 stays in force) but now carries
+ *     `liveTerminalId` so any refused caller can reattach instead of
+ *     dead-ending on "Session ... is still running on the server."
+ *  3. sidebar close -> reopen of a live session converges (regression pin):
+ *     LB-1 proved the negotiated WS door / live-row direct attach already
+ *     adopts on base -- GREEN on base and after; pins the adopt arm so the
+ *     Task 7 refusal-lane work can never regress it.
+ *  4. two sequential drops mid-reattach converge to a live pane.
+ *  5. server-process freeze (SIGSTOP) forces client-side abandonment before
+ *     thaw -- the ONLY discriminating assertion is the client's own status
+ *     transition while NO close frame exists (fresh-eyes F3); after thaw,
+ *     a normal reconnect + input round trip proves recovery.
+ *  6. fresh-agent pane reattaches and round-trips after a bare socket drop.
+ *     FIXTURE LIMITATION (per Task 8 execution note): the fake claude
+ *     sidecar's real scripted affordances (create/send/interrupt/shutdown +
+ *     HOLD_TURN knobs) offer NO scriptable unsolicited post-creation
+ *     emission, so there is no "server-side-only marker while the client is
+ *     down" hook to use. The discriminator here is therefore the
+ *     post-reconnect composer round trip itself, made non-vacuous two ways:
+ *     (a) server-side the sidecar request log must gain a NEW send after
+ *     the reconnect (the prompt genuinely crossed the new connection), and
+ *     (b) client-side the pane must render a strictly GREATER count of the
+ *     fixture's fixed reply text than before the drop (the response
+ *     genuinely came back over the reattached subscription -- fresh-eyes
+ *     F3-2: render-only assertions can pass on surviving local state with a
+ *     fully broken reattach).
+ *
+ * Rust-only: registered in RUST_ONLY_SPECS + the rust-chromium testMatch
+ * (socket-drop/freeze revival; drives RustServer + forceDisconnect +
+ * SIGSTOP). Not in CLOUD_SKIP_SPECS -- no real provider binaries needed
+ * (every claude interaction uses the committed fakes via CLAUDE_CMD /
+ * FRESHELL_CLAUDE_SIDECAR env seams).
+ *
+ * Helpers are COPIED from the donor specs (hidden-pane-rebind-rust,
+ * reconcile-client-adoption-rust, restore-contract-wall-rust,
+ * opencode-restart-recovery, freshclaude-identity-persistence-rust), not
+ * imported, per this suite's per-spec-ownership convention.
+ */
+import { test, expect } from '../helpers/fixtures.js'
+import { RustServer } from '../helpers/rust-server.js'
+import type { TestServerInfo } from '../helpers/test-server.js'
+import { TestHarness } from '../helpers/test-harness.js'
+import { openPanePicker } from '../helpers/pane-picker.js'
+import type { Page } from '@playwright/test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// ESM project: derive __dirname -- same convention as every fixture-
+// referencing donor spec (e.g. restore-contract-wall-rust.spec.ts).
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const FAKE_CLAUDE_CLI_SOURCE = path.resolve(__dirname, '../fixtures/fake-claude-cli.mjs')
+const FAKE_CLAUDE_SIDECAR_SOURCE = path.resolve(__dirname, '../fixtures/fake-claude-sidecar.mjs')
+
+const noDeadEndText = /still running on the server|\[Restore failed\]/
+
+// Playwright signature: waitForFunction(pageFunction, arg, options) -- the
+// options object must be the THIRD argument or the timeout is ignored
+// (fresh-eyes F3-4).
+const waitReady = (page: Page) => page.waitForFunction(
+  () => (window as any).__FRESHELL_TEST_HARNESS__?.getState()?.connection?.status === 'ready',
+  undefined,
+  { timeout: 20_000 },
+)
+
+// ---------------------------------------------------------------------------
+// Shared helpers (per-spec copies -- see file doc comment)
+// ---------------------------------------------------------------------------
+
+/** Copy a fixture into <binDir>/<binName> and make it executable. */
+async function installFakeCli(source: string, binName: string, binDir: string): Promise<string> {
+  await fs.mkdir(binDir, { recursive: true })
+  const target = path.join(binDir, binName)
+  await fs.copyFile(source, target)
+  await fs.chmod(target, 0o755)
+  return target
+}
+
+/** Read a fake CLI's argv-log JSONL (empty array if not yet written). */
+async function readArgvLog(logPath: string): Promise<Array<{ argv: string[] }>> {
+  const raw = await fs.readFile(logPath, 'utf8').catch(() => '')
+  if (!raw) return []
+  return raw.trim().split('\n').filter(Boolean).map((line) => JSON.parse(line) as { argv: string[] })
+}
+
+/** Dismiss the initial pane-type picker by choosing the first visible shell. */
+async function selectShellIfPickerShowing(page: Page): Promise<void> {
+  const picker = page.getByRole('toolbar', { name: /pane type picker/i }).last()
+  if (!(await picker.isVisible().catch(() => false))) return
+  for (const name of ['Shell', 'WSL', 'CMD', 'PowerShell', 'Bash']) {
+    const option = picker.getByRole('button', { name: new RegExp(`^${name}$`, 'i') })
+    if (await option.isVisible().catch(() => false)) {
+      await option.click({ force: true })
+      return
+    }
+  }
+}
+
+/** Idempotent .freshell/config.json seed (setupHome re-runs on every boot). */
+function seedWallConfig(input: {
+  providers: string[]
+  freshAgent?: boolean
+}): (homeDir: string) => Promise<void> {
+  return async (homeDir: string) => {
+    const freshellDir = path.join(homeDir, '.freshell')
+    await fs.mkdir(freshellDir, { recursive: true })
+    await fs.writeFile(
+      path.join(freshellDir, 'config.json'),
+      JSON.stringify(
+        {
+          version: 1,
+          settings: {
+            codingCli: { enabledProviders: input.providers },
+            ...(input.freshAgent ? { freshAgent: { enabled: true } } : {}),
+          },
+        },
+        null,
+        2,
+      ),
+    )
+  }
+}
+
+/** Boot an owned RustServer, navigate, and wait for harness + WS. */
+async function bootWall(
+  page: Page,
+  options: {
+    env?: Record<string, string>
+    setupHome?: (homeDir: string) => Promise<void>
+  } = {},
+): Promise<{ server: RustServer; info: TestServerInfo; harness: TestHarness }> {
+  const server = new RustServer({ env: options.env, setupHome: options.setupHome })
+  const info = await server.start()
+  await page.goto(`${info.baseUrl}/?token=${info.token}&e2e=1`)
+  const harness = new TestHarness(page)
+  await harness.waitForHarness()
+  await harness.waitForConnection()
+  return { server, info, harness }
+}
+
+// --- layout tree walkers (donor: restore-contract-wall-rust.spec.ts) ---
+
+function collectLeaves(node: any): any[] {
+  if (!node) return []
+  if (node.type === 'leaf') return [node]
+  if (node.type === 'split') return (node.children ?? []).flatMap(collectLeaves)
+  return []
+}
+
+function findLeavesByMode(layout: any, mode: string): any[] {
+  return collectLeaves(layout).filter((leaf) => leaf?.content?.mode === mode)
+}
+
+function findFreshAgentLeaf(node: any): any {
+  if (!node) return null
+  if (node.type === 'leaf' && node.content?.kind === 'fresh-agent') return node
+  if (node.type === 'split') {
+    for (const child of node.children ?? []) {
+      const found = findFreshAgentLeaf(child)
+      if (found) return found
+    }
+  }
+  return null
+}
+
+// --- tab close (donor: opencode-restart-recovery.spec.ts:341-348) --
+// Plain tab close is DETACH-ONLY (TabBar.tsx: shift-click kills); the
+// server-side PTY keeps running -- exactly the close-and-reopen story this
+// spec covers.
+
+async function closeTab(page: Page, tabId: string): Promise<void> {
+  await page.locator(`[data-context="tab"][data-tab-id="${tabId}"]`).click()
+  await page.locator(`[data-context="tab"][data-tab-id="${tabId}"]`).getByRole('button', { name: /close/i }).click()
+  await page.waitForFunction((closedTabId) => {
+    const tabs = (window as any).__FRESHELL_TEST_HARNESS__?.getState()?.tabs?.tabs ?? []
+    return !tabs.some((tab: any) => tab.id === closedTabId)
+  }, tabId, { timeout: 10_000 })
+}
+
+// --- claude terminal pane via the picker (donor: restore-contract-wall
+// :631-719 and reconcile-client-adoption :352-405) -- the picker/WS path
+// pre-allocates --session-id at t=0 and binds the pane's session identity,
+// which is what the D7 live-guard join sees. ---
+
+async function openClaudePaneAndCapture(
+  page: Page,
+  harness: TestHarness,
+  tabId: string,
+  projectDir: string,
+  argLogPath: string,
+): Promise<{ paneId: string; terminalId: string; sessionId: string }> {
+  const beforeIds = new Set(
+    findLeavesByMode(await harness.getPaneLayout(tabId), 'claude').map((l) => l.id),
+  )
+  const picker = await openPanePicker(page)
+  await picker.getByRole('button', { name: /^Claude CLI$/i }).click({ force: true })
+  const dirInput = page.getByRole('combobox', { name: /Starting directory for Claude/i })
+  await expect(dirInput).toBeVisible({ timeout: 15_000 })
+  await dirInput.fill(projectDir)
+  await dirInput.press('Enter')
+
+  const leaf = await expect
+    .poll(async () => {
+      const layout = await harness.getPaneLayout(tabId)
+      const newLeaf = findLeavesByMode(layout, 'claude').find((l) => !beforeIds.has(l.id))
+      return newLeaf?.content?.terminalId ? newLeaf : null
+    }, { timeout: 20_000 })
+    .not.toBeNull()
+    .then(async () => {
+      const layout = await harness.getPaneLayout(tabId)
+      return findLeavesByMode(layout, 'claude').find((l) => !beforeIds.has(l.id))!
+    })
+  const terminalId: string = leaf.content.terminalId
+
+  const sessionId: string = await expect
+    .poll(async () => {
+      const entries = await readArgvLog(argLogPath)
+      const withId = entries.find((e) => e.argv.includes('--session-id'))
+      if (!withId) return null
+      return withId.argv[withId.argv.indexOf('--session-id') + 1] ?? null
+    }, { timeout: 20_000 })
+    .not.toBeNull()
+    .then(async () => {
+      const entries = await readArgvLog(argLogPath)
+      const withId = entries.find((e) => e.argv.includes('--session-id'))!
+      return withId.argv[withId.argv.indexOf('--session-id') + 1]!
+    })
+  expect(sessionId).toMatch(/^[0-9a-f-]{36}$/)
+
+  // Client persisted the identity on the pane (fold via terminal.created).
+  await expect
+    .poll(async () => {
+      const layout = await harness.getPaneLayout(tabId)
+      return collectLeaves(layout).find((l) => l.id === leaf.id)?.content?.sessionRef?.sessionId ?? null
+    }, { timeout: 20_000 })
+    .toBe(sessionId)
+
+  return { paneId: leaf.id, terminalId, sessionId }
+}
+
+/**
+ * Minimal claude transcript the session index treats as interactive and the
+ * sidebar renders: TWO user/assistant turns (a one-turn session is classified
+ * non-interactive and silently excluded from the sidebar's default query --
+ * restore-matrix.spec.ts's root-cause note) plus a summary line carrying the
+ * unique title. Shape donor: restore-matrix.spec.ts scenario 3.
+ */
+async function writeClaudeTranscript(input: {
+  homeDir: string
+  projectSlug: string
+  sessionId: string
+  cwd: string
+  title: string
+}): Promise<void> {
+  const { homeDir, projectSlug, sessionId, cwd, title } = input
+  const mk = (suffix: string, extra: Record<string, unknown>) =>
+    JSON.stringify({
+      parentUuid: `${sessionId}-${suffix}`,
+      cwd,
+      sessionId,
+      version: '2.1.23',
+      gitBranch: 'main',
+      ...extra,
+    })
+  const lines: string[] = [
+    JSON.stringify({
+      type: 'system',
+      subtype: 'init',
+      session_id: sessionId,
+      uuid: `${sessionId}-system`,
+      timestamp: '2026-08-22T08:00:00.000Z',
+      cwd,
+      git: { branch: 'main', dirty: false },
+    }),
+    mk('user-1', {
+      type: 'user',
+      message: { role: 'user', content: `${title} request 1` },
+      uuid: `${sessionId}-user-1`,
+      timestamp: '2026-08-22T08:00:01.000Z',
+    }),
+    mk('assistant-1', {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        model: 'claude-opus-4-6-20260301',
+        content: [{ type: 'text', text: `${title} reply 1` }],
+        usage: { input_tokens: 100, output_tokens: 40 },
+      },
+      uuid: `${sessionId}-assistant-1`,
+      timestamp: '2026-08-22T08:00:02.000Z',
+    }),
+    mk('user-2', {
+      type: 'user',
+      message: { role: 'user', content: `${title} request 2` },
+      uuid: `${sessionId}-user-2`,
+      timestamp: '2026-08-22T08:00:03.000Z',
+    }),
+    mk('assistant-2', {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        model: 'claude-opus-4-6-20260301',
+        content: [{ type: 'text', text: `${title} reply 2` }],
+        usage: { input_tokens: 100, output_tokens: 40 },
+      },
+      uuid: `${sessionId}-assistant-2`,
+      timestamp: '2026-08-22T08:00:04.000Z',
+    }),
+    JSON.stringify({
+      type: 'summary',
+      summary: title,
+      leafUuid: `${sessionId}-assistant-2`,
+    }),
+  ]
+  const projectDir = path.join(homeDir, '.claude', 'projects', projectSlug)
+  await fs.mkdir(projectDir, { recursive: true })
+  await fs.writeFile(path.join(projectDir, `${sessionId}.jsonl`), `${lines.join('\n')}\n`, 'utf8')
+}
+
+// --- freshclaude fresh-agent helper (fixture: fake-claude-sidecar.mjs via
+// the production env seam FRESHELL_CLAUDE_SIDECAR; donor: hidden-pane-rebind
+// :153-182 / freshclaude-identity-persistence :183-219) ---
+
+async function createFreshclaudePane(page: Page, cwd: string): Promise<void> {
+  // setAvailableClis is client-only AND gets overwritten by the app
+  // bootstrap + /api/platform fetch; callers reach this helper only after
+  // harness.waitForConnection(), so the dispatch lands AFTER those
+  // overwrites (donor ordering). Keep it that way.
+  await page.evaluate(() => {
+    ;(window as any).__FRESHELL_TEST_HARNESS__?.dispatch({
+      type: 'connection/setAvailableClis',
+      payload: { claude: true, codex: false },
+    })
+  })
+  const picker = await openPanePicker(page)
+  await picker.getByRole('button', { name: /^Freshclaude$/i }).click({ force: true })
+  // /api/files/candidate-dirs returns [] on a clean isolated HOME (no $HOME
+  // fallback), so TYPE the cwd and press Enter instead.
+  const directoryInput = page.getByLabel(/^Starting directory for Freshclaude$/i)
+  await expect(directoryInput).toBeVisible({ timeout: 15_000 })
+  await directoryInput.fill(cwd)
+  await directoryInput.press('Enter')
+  await expect(page.locator('[data-context="fresh-agent"]').last()).toBeVisible({
+    timeout: 15_000,
+  })
+}
+
+/** Send one chat turn in the last fresh-agent pane and wait for idle. */
+async function sendFreshAgentTurn(
+  page: Page,
+  harness: TestHarness,
+  tabId: string,
+  text: string,
+): Promise<void> {
+  const paneRoot = page.locator('[data-context="fresh-agent"]').last()
+  await expect
+    .poll(async () => findFreshAgentLeaf(await harness.getPaneLayout(tabId))?.content?.status, {
+      timeout: 20_000,
+    })
+    .toBe('idle')
+  const composer = paneRoot.getByRole('textbox', { name: 'Chat message input' })
+  await composer.fill(text)
+  await paneRoot.getByRole('button', { name: 'Send' }).click()
+  await expect
+    .poll(async () => findFreshAgentLeaf(await harness.getPaneLayout(tabId))?.content?.status, {
+      timeout: 30_000,
+    })
+    .toBe('idle')
+}
+
+/** Count rendered copies of the fixture's fixed assistant reply text inside
+ *  the LAST fresh-agent pane. Per-turn render count is >=1 per turn, so a
+ *  strictly-greater count after the second turn is proof the second reply
+ *  genuinely rendered (the fixture's reply text is constant, so a distinct-
+ *  text assertion is impossible -- count growth is the discriminator). */
+async function fixtureReplyCount(page: Page): Promise<number> {
+  return page
+    .locator('[data-context="fresh-agent"]')
+    .last()
+    .getByText('Fixture claude turn', { exact: false })
+    .count()
+}
+
+/** Count `send` entries in the fake claude sidecar's request log. */
+async function sidecarSendCount(requestLogPath: string): Promise<number> {
+  const raw = await fs.readFile(requestLogPath, 'utf8').catch(() => '')
+  if (!raw) return 0
+  return raw
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line) as { msg?: { type?: string } }
+      } catch {
+        return {}
+      }
+    })
+    .filter((e) => e.msg?.type === 'send').length
+}
+
+// ---------------------------------------------------------------------------
+// The tests
+// ---------------------------------------------------------------------------
+
+test.describe('reconnect revive (rust)', () => {
+  test.setTimeout(240_000)
+
+  test('terminal pane reattaches and repaints after a bare socket drop', async ({ freshellPage, page, harness, terminal, e2eServerKind }) => {
+    expect(e2eServerKind).toBe('rust')
+    await terminal.waitForTerminal()
+    await terminal.waitForPrompt()
+    await terminal.executeCommand('echo "rr-marker-one"')
+    await terminal.waitForOutput('rr-marker-one')
+
+    await harness.forceDisconnect()
+    await harness.waitForConnection()
+    await waitReady(page)
+
+    // Settled end state, not just "ready": backlog visible again, chips gone.
+    await terminal.waitForOutput('rr-marker-one', { timeout: 20_000 })
+    await expect(page.getByText('Offline: input will queue until reconnected.')).toHaveCount(0)
+    await expect(page.getByText('Recovering terminal output...')).toHaveCount(0)
+    await expect(page.getByText(noDeadEndText)).toHaveCount(0)
+    // Buffer-level dead-end proof (the xterm notice channel renders to the
+    // terminal surface, which getByText can miss under the WebGL renderer).
+    expect(await harness.getTerminalBuffer() ?? '').not.toMatch(noDeadEndText)
+
+    // Live, not a frozen repaint: the PTY still answers input AFTER reconnect.
+    await terminal.executeCommand('echo "rr-marker-two"')
+    await terminal.waitForOutput('rr-marker-two', { timeout: 10_000 })
+  })
+
+  test('REST resume door names the live owner in its refusal (red-first contract)', async ({ page, e2eServerKind }) => {
+    expect(e2eServerKind).toBe('rust')
+    const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-rr-rest-door-'))
+    const projectDir = path.join(sharedRoot, 'project')
+    await fs.mkdir(projectDir, { recursive: true })
+    const argLogPath = path.join(sharedRoot, 'claude-argv.jsonl')
+    const fakeClaudePath = await installFakeCli(FAKE_CLAUDE_CLI_SOURCE, 'claude', path.join(sharedRoot, 'bin'))
+    const { server, harness, info } = await bootWall(page, {
+      env: { CLAUDE_CMD: fakeClaudePath, FAKE_CLAUDE_ARGV_LOG: argLogPath },
+      setupHome: seedWallConfig({ providers: ['claude'] }),
+    })
+    try {
+      await selectShellIfPickerShowing(page)
+      const tabId = (await harness.getActiveTabId())!
+      // Wait for the boot pane to become a REAL terminal before opening the
+      // pane picker (boot-picker fade-out guard, wall spec :641-647).
+      await expect(page.locator('.xterm').first()).toBeVisible({ timeout: 30_000 })
+
+      // Provider-mode (claude) terminal pane, hermetically seeded with a KNOWN
+      // session id (picker pre-allocation; shell panes never reach D7 --
+      // create_session_locator -> None for shell).
+      const { terminalId, sessionId } = await openClaudePaneAndCapture(
+        page,
+        harness,
+        tabId,
+        projectDir,
+        argLogPath,
+      )
+
+      // Close the tab (detach-only -- a plain close never kills the PTY).
+      // NOTE: the app auto-creates a fresh boot tab when the last tab closes,
+      // so "the tab is gone" (closeTab's own wait) is the close evidence --
+      // never a tab-count of zero.
+      await closeTab(page, tabId)
+
+      // The session is STILL RUNNING server-side after the client-side close.
+      const terminals = await page.evaluate(
+        async ({ baseUrl, token }) => {
+          const res = await fetch(`${baseUrl}/api/terminals`, {
+            headers: { 'x-auth-token': token },
+          })
+          return res.ok ? ((await res.json()) as Array<{ terminalId: string; status: string }>) : []
+        },
+        { baseUrl: info.baseUrl, token: info.token },
+      )
+      const liveRow = terminals.find((t) => t.terminalId === terminalId)
+      expect(liveRow, `terminal ${terminalId} must still be server-side after detach-only close`).toBeTruthy()
+      expect(liveRow!.status).toBe('running')
+
+      // Drive the REST resume door exactly as the plan specifies:
+      // POST /api/tabs { mode:'claude', sessionRef {...} } via page.evaluate.
+      const refusal = await page.evaluate(
+        async ({ baseUrl, token, sessionId: sid, cwd }) => {
+          const res = await fetch(`${baseUrl}/api/tabs`, {
+            method: 'POST',
+            headers: { 'x-auth-token': token, 'content-type': 'application/json' },
+            body: JSON.stringify({
+              mode: 'claude',
+              cwd,
+              sessionRef: { provider: 'claude', sessionId: sid },
+            }),
+          })
+          return { status: res.status, body: (await res.json().catch(() => null)) as Record<string, unknown> | null }
+        },
+        { baseUrl: info.baseUrl, token: info.token, sessionId, cwd: projectDir },
+      )
+
+      // D7 stays in force: still a 409 with the byte-identical refusal text.
+      expect(refusal.status).toBe(409)
+      expect(refusal.body?.status).toBe('error')
+      expect(refusal.body?.code).toBe('RESTORE_UNAVAILABLE')
+      expect(String(refusal.body?.message ?? '')).toContain('is still running on the server.')
+      // RED on base: the refusal must NAME the still-running terminal so the
+      // refused caller can reattach instead of dead-ending. (Reopen in the
+      // same client adopts namelessly via WS; this field is what lets any
+      // refused caller reattach.)
+      expect(refusal.body?.liveTerminalId).toBe(terminalId)
+    } finally {
+      await server.stop().catch(() => {})
+      await fs.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  test('sidebar close -> reopen of a live session converges (regression pin)', async ({ page, e2eServerKind }) => {
+    expect(e2eServerKind).toBe('rust')
+    const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-rr-sidebar-'))
+    const projectDir = path.join(sharedRoot, 'project')
+    await fs.mkdir(projectDir, { recursive: true })
+    const argLogPath = path.join(sharedRoot, 'claude-argv.jsonl')
+    const fakeClaudePath = await installFakeCli(FAKE_CLAUDE_CLI_SOURCE, 'claude', path.join(sharedRoot, 'bin'))
+    const sessionTitle = `rr sidebar revive ${Date.now()}`
+    const { server, harness, info } = await bootWall(page, {
+      env: { CLAUDE_CMD: fakeClaudePath, FAKE_CLAUDE_ARGV_LOG: argLogPath },
+      setupHome: seedWallConfig({ providers: ['claude'] }),
+    })
+    try {
+      await selectShellIfPickerShowing(page)
+      const tabId = (await harness.getActiveTabId())!
+      await expect(page.locator('.xterm').first()).toBeVisible({ timeout: 30_000 })
+      const { terminalId, sessionId } = await openClaudePaneAndCapture(
+        page,
+        harness,
+        tabId,
+        projectDir,
+        argLogPath,
+      )
+      // Realism: a live claude session always has an on-disk transcript; the
+      // sidebar row (and the isRunning enrichment that merges live state into
+      // it) is indexed from that file.
+      await writeClaudeTranscript({
+        homeDir: info.homeDir,
+        projectSlug: 'rr-sidebar-proj',
+        sessionId,
+        cwd: projectDir,
+        title: sessionTitle,
+      })
+
+      // The sidebar row appears (server session watcher -> sessions.changed ->
+      // refetch) and -- because the terminal is still running -- the merged
+      // row reports it, which is what routes the click through the
+      // direct-attach arm of openSessionTab.
+      const sessionList = page.getByTestId('sidebar-session-list')
+      await expect(sessionList).toBeVisible({ timeout: 30_000 })
+      const sessionRow = sessionList
+        .locator(`[data-context="sidebar-session"][data-session-id="${sessionId}"]`)
+      await expect(sessionRow).toBeVisible({ timeout: 30_000 })
+      await expect(sessionRow).toHaveAttribute('data-is-running', 'true', { timeout: 30_000 })
+      await expect(sessionRow).toHaveAttribute('data-running-terminal-id', terminalId, { timeout: 30_000 })
+
+      // Close the tab (detach-only) and reopen from the sidebar session row.
+      // (The app auto-creates a fresh boot tab on last-close -- the close
+      // evidence is closeTab's own wait, not a zero tab count.)
+      await closeTab(page, tabId)
+
+      const argvCountBeforeReopen = (await readArgvLog(argLogPath)).length
+      await sessionRow.click()
+
+      // A new tab opens for the session and ADOPTS the still-running terminal:
+      // same terminalId on the pane, never a respawn.
+      const newTabId: string = await expect
+        .poll(async () => harness.getActiveTabId(), { timeout: 15_000 })
+        .not.toBeNull()
+        .then(async () => (await harness.getActiveTabId())!)
+      expect(newTabId).not.toBe(tabId)
+      await expect
+        .poll(async () => {
+          const layout = await harness.getPaneLayout(newTabId)
+          const leaf = findLeavesByMode(layout, 'claude')[0]
+          return leaf?.content?.terminalId ?? null
+        }, { timeout: 20_000 })
+        .toBe(terminalId)
+
+      // No respawn: the fake CLI's argv log gains NO new invocation after the
+      // click (adoption reattaches to the live PTY, never re-launches claude).
+      const argvAfterReopen = await readArgvLog(argLogPath)
+      expect(argvAfterReopen.length).toBe(argvCountBeforeReopen)
+
+      // Output continuity: the pane repaints the ORIGINAL spawn marker from
+      // the live terminal's scrollback...
+      await expect
+        .poll(async () => {
+          const buffer = await harness.getTerminalBuffer(terminalId)
+          return typeof buffer === 'string'
+            && buffer.replace(/\n/g, '').includes(`claude: session ${sessionId} started`)
+        }, { timeout: 20_000 })
+        .toBe(true)
+
+      // ...and the post-reopen input round trip is live: keystrokes reach the
+      // still-running PTY and echo back (canonical-mode line discipline under
+      // the fixture CLI, which never touches termios).
+      await page.locator(`[data-context="terminal"][data-tab-id="${newTabId}"] .xterm`).first().click()
+      await page.keyboard.type('rr-reopen-echo-live')
+      await expect
+        .poll(async () => {
+          const buffer = await harness.getTerminalBuffer(terminalId)
+          return typeof buffer === 'string' && buffer.replace(/\n/g, '').includes('rr-reopen-echo-live')
+        }, { timeout: 15_000 })
+        .toBe(true)
+
+      // No dead-end text anywhere -- not in DOM chrome, not in the xterm
+      // notice buffer (the pre-Task-7 failure mode was a terminal write of
+      // "[Restore failed] ... still running on the server.").
+      await expect(page.getByText(noDeadEndText)).toHaveCount(0)
+      expect((await harness.getTerminalBuffer(terminalId)) ?? '').not.toMatch(noDeadEndText)
+    } finally {
+      await server.stop().catch(() => {})
+      await fs.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  test('two sequential drops mid-reattach converge to a live pane', async ({ freshellPage, page, harness, terminal, e2eServerKind }) => {
+    expect(e2eServerKind).toBe('rust')
+    await terminal.waitForTerminal()
+    await terminal.waitForPrompt()
+    await terminal.executeCommand('echo "rr-double"')
+    await terminal.waitForOutput('rr-double')
+    await harness.forceDisconnect()
+    await harness.waitForConnection()
+    await harness.forceDisconnect() // drop again before reattach could settle
+    await harness.waitForConnection()
+    await waitReady(page)
+    await terminal.executeCommand('echo "rr-double-after"')
+    await terminal.waitForOutput('rr-double-after', { timeout: 20_000 })
+    await expect(page.getByText(noDeadEndText)).toHaveCount(0)
+    expect((await harness.getTerminalBuffer()) ?? '').not.toMatch(noDeadEndText)
+  })
+
+  test('server-process freeze forces client-side abandonment before thaw', async ({ freshellPage, page, harness, terminal, testServer, e2eServerKind }) => {
+    expect(e2eServerKind).toBe('rust')
+    test.slow() // freeze window must cover the 30s probe + 10s pong timeout
+    test.skip(process.platform === 'win32', 'SIGSTOP/SIGCONT are POSIX-only (freeze-spec gate)')
+    await terminal.waitForTerminal()
+    await terminal.waitForPrompt()
+    await terminal.executeCommand('echo "rr-freeze"')
+    await terminal.waitForOutput('rr-freeze')
+
+    // Fresh-eyes F3 discrimination: a stalled socket that merely RESUMES after
+    // SIGCONT passes every old assertion (ready + input), so they cannot be the
+    // discriminator. The one thing only the Task 1 watchdog produces is a
+    // client-driven status transition while NO close frame exists. Start an
+    // in-page status sampler FIRST (the browser is not frozen -- only the
+    // server is), then freeze the server, then require a non-'ready' sample
+    // BEFORE thaw.
+    await page.evaluate(() => {
+      ;(window as any).__rrStatuses = []
+      ;(window as any).__rrTimer = setInterval(() => {
+        ;(window as any).__rrStatuses.push((window as any).__FRESHELL_TEST_HARNESS__?.getState()?.connection?.status)
+      }, 1_000)
+    })
+    const pid = testServer.info.pid
+    try {
+      process.kill(pid, 'SIGSTOP')
+      // Base behavior: no inbound traffic ever forces a state change -- the
+      // sampler never leaves 'ready' and this wait times out (true red-first).
+      // With Task 1: t=30s probe -> no pong -> t=40s abandon -> status flips.
+      // NOTE (deviation from the plan's 50_000, hardened against flakiness,
+      // NOT against discrimination): the 10s liveness TICK is not phase-locked
+      // to the freeze, so the worst real timeline is probe fired ~t=40 +
+      // pong timeout 10s + sampler lag ~1s => the flip can appear at ~t=51s.
+      // 60s still discriminates perfectly: on base the sampler NEVER flips
+      // while frozen, so any finite budget reds there identically.
+      await page.waitForFunction(
+        () => (window as any).__rrStatuses?.some((s: string | undefined) => s !== undefined && s !== 'ready'),
+        undefined,
+        { timeout: 60_000 },
+      )
+    } finally {
+      process.kill(pid, 'SIGCONT') // never leave the fixture server stopped
+      await page.evaluate(() => clearInterval((window as any).__rrTimer)).catch(() => {})
+    }
+    await harness.waitForConnection(30_000)
+    await waitReady(page)
+    await terminal.executeCommand('echo "rr-thawed"')
+    await terminal.waitForOutput('rr-thawed', { timeout: 30_000 })
+    await expect(page.getByText(noDeadEndText)).toHaveCount(0)
+    expect((await harness.getTerminalBuffer()) ?? '').not.toMatch(noDeadEndText)
+  })
+
+  test('fresh-agent pane reattaches and round-trips after a bare socket drop', async ({ page, e2eServerKind }) => {
+    expect(e2eServerKind).toBe('rust')
+    const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-rr-freshclaude-'))
+    const projectDir = path.join(sharedRoot, 'project')
+    await fs.mkdir(projectDir, { recursive: true })
+    const requestLogPath = path.join(sharedRoot, 'claude-sidecar-requests.jsonl')
+    const { server, harness } = await bootWall(page, {
+      env: { FRESHELL_CLAUDE_SIDECAR: FAKE_CLAUDE_SIDECAR_SOURCE, FAKE_CLAUDE_SIDECAR_LOG: requestLogPath },
+      setupHome: seedWallConfig({ providers: ['claude'], freshAgent: true }),
+    })
+    try {
+      await selectShellIfPickerShowing(page)
+      // Boot-picker fade-out guard before opening the pane picker (donor).
+      await expect(page.locator('.xterm').first()).toBeVisible({ timeout: 30_000 })
+      const freshTabId = (await harness.getActiveTabId())!
+      await createFreshclaudePane(page, projectDir)
+      await expect
+        .poll(async () => {
+          const c = findFreshAgentLeaf(await harness.getPaneLayout(freshTabId))?.content
+          return c?.sessionId ? true : null
+        }, { timeout: 30_000 })
+        .not.toBeNull()
+
+      // One completed turn BEFORE the drop (the plain happy path).
+      await sendFreshAgentTurn(page, harness, freshTabId, 'rr fresh agent turn one')
+      const replyCountBeforeDrop: number = await expect
+        .poll(async () => fixtureReplyCount(page), { timeout: 30_000 })
+        .toBeGreaterThan(0)
+        .then(() => fixtureReplyCount(page))
+      const sendsBeforeDrop = await sidecarSendCount(requestLogPath)
+      expect(sendsBeforeDrop).toBe(1)
+
+      const sessionIdBefore: string = findFreshAgentLeaf(
+        await harness.getPaneLayout(freshTabId),
+      )!.content!.sessionId
+
+      // Bare socket drop; the server-side sidecar session stays live.
+      await harness.forceDisconnect()
+      await harness.waitForConnection()
+      await waitReady(page)
+
+      // Same session identity after reconnect -- an in-place reattach, never
+      // a re-created session.
+      const contentAfterReconnect = findFreshAgentLeaf(
+        await harness.getPaneLayout(freshTabId),
+      )!.content!
+      expect(contentAfterReconnect.sessionId).toBe(sessionIdBefore)
+
+      // Discriminating round trip (see this file's FIXTURE LIMITATION note):
+      // (a) the pane renders strictly MORE replies than survived the drop...
+      await sendFreshAgentTurn(page, harness, freshTabId, 'rr fresh agent turn two')
+      await expect
+        .poll(async () => fixtureReplyCount(page), { timeout: 30_000 })
+        .toBeGreaterThan(replyCountBeforeDrop)
+      // ...(b) and the sidecar request log proves the second send genuinely
+      // crossed the (new) server connection to the still-live sidecar.
+      await expect
+        .poll(async () => sidecarSendCount(requestLogPath), { timeout: 15_000 })
+        .toBe(2)
+      // ...and no dead-end text ever surfaces in the pane chrome.
+      await expect(page.getByText(noDeadEndText)).toHaveCount(0)
+    } finally {
+      await server.stop().catch(() => {})
+      await fs.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+})

--- a/test/e2e-browser/specs/reconnect-revive-rust.spec.ts
+++ b/test/e2e-browser/specs/reconnect-revive-rust.spec.ts
@@ -694,7 +694,12 @@ test.describe('reconnect revive (rust)', () => {
         { timeout: 60_000 },
       )
     } finally {
-      process.kill(pid, 'SIGCONT') // never leave the fixture server stopped
+      try {
+        process.kill(pid, 'SIGCONT') // never leave the fixture server stopped
+      } catch {
+        // Process already gone (fixture teardown raced us) — the primary
+        // error from the test body stays the reported failure.
+      }
       await page.evaluate(() => clearInterval((window as any).__rrTimer)).catch(() => {})
     }
     await harness.waitForConnection(30_000)

--- a/test/e2e/terminal-create-attach-ordering.test.tsx
+++ b/test/e2e/terminal-create-attach-ordering.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
-import { Provider } from 'react-redux'
+import { Provider, useSelector } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import tabsReducer from '@/store/tabsSlice'
 import panesReducer from '@/store/panesSlice'
@@ -188,6 +188,30 @@ function lastSent(type: string, terminalId?: string) {
     if (terminalId && msg?.terminalId !== terminalId) return false
     return true
   })
+}
+
+type TestRootState = ReturnType<ReturnType<typeof createStore>['getState']>
+
+// Store-connected variant of the harness's static-prop render: the D7-refusal
+// revival fold happens INSIDE the store (a reducer), so the mounted view must
+// follow store folds for its lifecycle effect to re-fire on the epoch bump
+// (the same re-render loop App delivers in production).
+function TerminalViewFromStore({ tabId, paneId }: { tabId: string; paneId: string }) {
+  const paneContent = useSelector((state: TestRootState) => {
+    const layout = state.panes.layouts[tabId]
+    if (!layout || layout.type !== 'leaf') return null
+    return layout.content
+  })
+  if (!paneContent || paneContent.kind !== 'terminal') return null
+  return <TerminalView tabId={tabId} paneId={paneId} paneContent={paneContent} hidden={false} />
+}
+
+function leafTerminalContent(store: ReturnType<typeof createStore>) {
+  const layout = store.getState().panes.layouts['tab-order']
+  if (!layout || layout.type !== 'leaf' || layout.content.kind !== 'terminal') {
+    throw new Error('expected a terminal leaf in the harness store')
+  }
+  return layout.content
 }
 
 describe('terminal create/attach ordering (e2e)', () => {
@@ -536,5 +560,69 @@ describe('terminal create/attach ordering (e2e)', () => {
     expect(writes).toContain('before-reconnect')
     expect(writes).not.toContain('stale-after-reconnect')
     expect(writes).toContain('fresh-after-reconnect')
+  })
+
+  // D7-refusal revival, full pipeline (reconnect-revive Task 7, plan item
+  // 2b): a mounted TerminalView pane whose create draws the enriched refusal
+  // frame from the (mock-transport) wire must fold the store reattach, send a
+  // FRESH terminal.attach for the named still-running id, and announce the
+  // reconnection — never a second create, never "[Restore failed]". A
+  // Playwright browser test cannot reach this fold (on negotiated WS
+  // connections the adopt arms absorb the create, so the refusal never
+  // surfaces), which makes this jsdom real-harness level the highest tier
+  // that can exercise the revival end to end.
+  it('revives the pane onto the still-running session named by the D7 refusal', async () => {
+    const store = createStore({ status: 'creating', requestId: 'req-order-revive' })
+
+    render(
+      <Provider store={store}>
+        <TerminalViewFromStore tabId="tab-order" paneId="pane-order" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(lastSent('terminal.create')).toMatchObject({
+        type: 'terminal.create',
+        requestId: 'req-order-revive',
+      })
+    })
+    expect(lastSent('terminal.attach')).toBeUndefined()
+
+    // The enriched refusal frame, delivered through the mock wire:
+    // RESTORE_UNAVAILABLE + the terminal id that still owns the session.
+    wsHarness.emit({
+      type: 'error',
+      code: 'RESTORE_UNAVAILABLE',
+      message: 'Session sess-order-live is still running on the server.',
+      requestId: 'req-order-revive',
+      liveTerminalId: 'term-order-live',
+    })
+
+    // 1. The reducer folded the store reattach (terminalId + running, no
+    //    restoreError, no re-minted createRequestId).
+    await waitFor(() => {
+      expect(leafTerminalContent(store).terminalId).toBe('term-order-live')
+    })
+    const folded = leafTerminalContent(store)
+    expect(folded.status).toBe('running')
+    expect(folded.restoreError).toBeUndefined()
+    expect(folded.createRequestId).toBe('req-order-revive')
+
+    // 2. A FRESH terminal.attach for the NAMED id leaves the client — and no
+    //    second terminal.create ever goes out (never a duplicate writer).
+    await waitFor(() => {
+      expect(lastSent('terminal.attach', 'term-order-live')).toMatchObject({
+        type: 'terminal.attach',
+        terminalId: 'term-order-live',
+        attachRequestId: expect.any(String),
+      })
+    })
+    expect(sentMessages().filter((msg) => msg?.type === 'terminal.create')).toHaveLength(1)
+
+    // 3. The pane announces the reconnection — never the dead-end write.
+    const writes = terminalInstances[0].write.mock.calls.map(([data]) => String(data)).join('')
+    expect(writes).toContain('Reconnected to the still-running session.')
+    expect(writes).not.toContain('[Restore failed]')
+    expect(writes).not.toContain('[Launch failed]')
   })
 })

--- a/test/unit/client/components/App.reconcile-adoption.test.tsx
+++ b/test/unit/client/components/App.reconcile-adoption.test.tsx
@@ -88,6 +88,7 @@ vi.mock('@/lib/terminal-restore', () => ({
 }))
 
 let messageHandler: ((msg: any) => void) | null = null
+let disconnectHandler: (() => void) | null = null
 
 vi.mock('@/lib/ws-client', () => ({
   getWsClient: () => ({
@@ -294,7 +295,7 @@ function readyFrame(options: { capabilities?: Record<string, unknown> } = {}) {
   }
 }
 
-async function bootAppWithReady(options: { capabilities?: Record<string, unknown> } = {}) {
+async function bootApp() {
   const store = createStore()
   render(
     <Provider store={store}>
@@ -304,6 +305,11 @@ async function bootAppWithReady(options: { capabilities?: Record<string, unknown
   await waitFor(() => {
     expect(messageHandler).toBeTypeOf('function')
   })
+  return store
+}
+
+async function bootAppWithReady(options: { capabilities?: Record<string, unknown> } = {}) {
+  const store = await bootApp()
   act(() => {
     messageHandler?.(readyFrame(options))
   })
@@ -371,6 +377,11 @@ function lastSent(type: string): any {
   return sentFrames.filter((f) => f.type === type).pop()
 }
 
+/** The seeded single terminal leaf's content (tab-1 is the bare leaf). */
+function terminalPaneContentOf(store: { getState: () => any }) {
+  return (store.getState().panes.layouts as any)['tab-1']?.content
+}
+
 describe('App pane.reconcile adoption', () => {
   beforeEach(() => {
     cleanup()
@@ -382,10 +393,14 @@ describe('App pane.reconcile adoption', () => {
     seededFreshAgentPane = null
     setFreshAgentReconcileActive(false)
     messageHandler = null
+    disconnectHandler = null
     wsMocks.isReady = false
     wsMocks.serverInstanceId = undefined
     wsMocks.onReconnect.mockReturnValue(() => {})
-    wsMocks.onDisconnect.mockReturnValue(() => {})
+    wsMocks.onDisconnect.mockImplementation((cb: () => void) => {
+      disconnectHandler = cb
+      return () => { disconnectHandler = null }
+    })
     wsMocks.onMessage.mockImplementation((cb: (msg: any) => void) => {
       messageHandler = cb
       return () => { messageHandler = null }
@@ -611,6 +626,89 @@ describe('App pane.reconcile adoption', () => {
     const lastClearOrder = wsMocks.clearReconcileCreateHold.mock.invocationCallOrder.at(-1)!
     for (const order of wsMocks.cancelCreate.mock.invocationCallOrder) {
       expect(order).toBeLessThan(lastClearOrder)
+    }
+  })
+
+  // --- bounded boot-result wait (reconnect-revive Task 2) -------------------
+  // A pane.reconcile.result is unicast to THIS socket; if it dies with a
+  // dying socket, without a bounded wait the pane wedges pending-verdict
+  // forever (gray-and-dead). Fake timers ARE enabled only around the ready
+  // delivery and afterward: bootApp's waitFor needs real timers.
+
+  it('falls back to the legacy census when no reconcile result arrives within 10s', async () => {
+    seedPersistedTerminalPane({ createRequestId: 'cr-1' })
+    const store = await bootApp()
+    vi.useFakeTimers()
+    try {
+      await simulateReconnectWithReady({ capabilities: { paneReconcileV1: true } })
+      // Real wire order: terminal.inventory ALWAYS precedes any reconcile
+      // result — the fallback census runs from this CACHED list.
+      await receiveInventory({ liveTerminalIds: [] })
+      expect(sentFrames.some((f) => f.type === 'pane.reconcile.request')).toBe(true)
+      expect(terminalPaneContentOf(store)?.terminalId).toBe('term-old')
+      expect(Object.keys((store.getState().panes as any).reconcilePendingPanes ?? {})).not.toHaveLength(0)
+      expect(dispatchedTypes).not.toContain(clearDeadTerminals.type)
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000) })
+
+      // The wait expired with the request still pending → the same teardown
+      // the correlated-error path runs: pending panes are released and the
+      // legacy census wipes the dead handle and re-arms the create path.
+      expect((store.getState().panes as any).reconcilePendingPanes ?? {}).toEqual({})
+      const paneContent = terminalPaneContentOf(store)
+      expect(paneContent?.pendingReconcile).toBeUndefined()
+      expect(paneContent?.terminalId).toBeUndefined() // census wiped the stale handle
+      expect(paneContent?.status).toBe('creating')    // census re-armed the create path
+      expect(dispatchedTypes).toContain(clearDeadTerminals.type)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does NOT run the census when the result folds before the wait expires', async () => {
+    seedPersistedTerminalPane({ createRequestId: 'cr-1' })
+    const store = await bootApp()
+    vi.useFakeTimers()
+    try {
+      await simulateReconnectWithReady({ capabilities: { paneReconcileV1: true } })
+      await receiveInventory({ liveTerminalIds: [] })
+      const req = lastSent('pane.reconcile.request')
+      // The server's single warming deferral is 2s — a fold at t=2s is a
+      // legitimate deferral, not a lost result; the timer must be disarmed.
+      await act(async () => { await vi.advanceTimersByTimeAsync(2_000) })
+      await receiveServerFrame(attachResultFor(req, 'term-live'))
+      await act(async () => { await vi.advanceTimersByTimeAsync(20_000) })
+
+      expect(dispatchedTypes).not.toContain(clearDeadTerminals.type)
+      const paneContent = terminalPaneContentOf(store)
+      expect(paneContent?.terminalId).toBe('term-live') // verdict-written handle kept
+      expect(paneContent?.status).toBe('running')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels the result wait on disconnect (no offline census)', async () => {
+    seedPersistedTerminalPane({ createRequestId: 'cr-1' })
+    const store = await bootApp()
+    vi.useFakeTimers()
+    try {
+      await simulateReconnectWithReady({ capabilities: { paneReconcileV1: true } })
+      await receiveInventory({ liveTerminalIds: [] })
+      expect(sentFrames.some((f) => f.type === 'pane.reconcile.request')).toBe(true)
+      expect(disconnectHandler).toBeTypeOf('function')
+      const before = { ...terminalPaneContentOf(store) }
+
+      act(() => { disconnectHandler?.() })
+      await act(async () => { await vi.advanceTimersByTimeAsync(15_000) })
+
+      // While disconnected there is no socket the result could still arrive
+      // on — the timer must not fire a census from stale inventory; the next
+      // ready re-sends the request instead.
+      expect(dispatchedTypes).not.toContain(clearDeadTerminals.type)
+      expect(terminalPaneContentOf(store)).toEqual(before)
+    } finally {
+      vi.useRealTimers()
     }
   })
 })

--- a/test/unit/client/components/App.ws-bootstrap.test.tsx
+++ b/test/unit/client/components/App.ws-bootstrap.test.tsx
@@ -89,6 +89,7 @@ const wsMocks = vi.hoisted(() => ({
   onReconnect: vi.fn().mockReturnValue(() => {}),
   onDisconnect: vi.fn().mockReturnValue(() => {}),
   setHelloExtensionProvider: vi.fn(),
+  poke: vi.fn(),
   isReady: false,
   serverInstanceId: undefined as string | undefined,
 }))
@@ -116,6 +117,7 @@ vi.mock('@/lib/ws-client', () => ({
     onReconnect: wsMocks.onReconnect,
     onDisconnect: wsMocks.onDisconnect,
     setHelloExtensionProvider: wsMocks.setHelloExtensionProvider,
+    poke: wsMocks.poke,
     cancelCreate: vi.fn(),
     setReconcilePendingCreates: vi.fn(),
     clearReconcileCreateHold: vi.fn(),
@@ -361,6 +363,33 @@ describe('App WS bootstrap recovery', () => {
     await waitFor(() => {
       expect(wsMocks.connect).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it('pokes the websocket from a foreground visibilitychange listener', async () => {
+    const store = createStore()
+    wsMocks.connect.mockResolvedValueOnce(undefined)
+    // jsdom reports 'prerender'; force the visible state the listener gates on.
+    const visibilitySpy = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+
+    try {
+      render(
+        <Provider store={store}>
+          <App />
+        </Provider>
+      )
+
+      await waitFor(() => {
+        expect(wsMocks.connect).toHaveBeenCalledTimes(1)
+      })
+
+      act(() => {
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+
+      expect(wsMocks.poke).toHaveBeenCalled()
+    } finally {
+      visibilitySpy.mockRestore()
+    }
   })
 
   it('loads shell-critical bootstrap through /api/bootstrap without falling back to legacy settings/platform reads', async () => {

--- a/test/unit/client/components/TerminalView.hidden-rebind.test.tsx
+++ b/test/unit/client/components/TerminalView.hidden-rebind.test.tsx
@@ -3,7 +3,7 @@ import { render, cleanup, act } from '@testing-library/react'
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
 import tabsReducer from '@/store/tabsSlice'
-import panesReducer from '@/store/panesSlice'
+import panesReducer, { updatePaneContent } from '@/store/panesSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import connectionReducer from '@/store/connectionSlice'
 import sessionActivityReducer from '@/store/sessionActivitySlice'
@@ -176,6 +176,7 @@ function renderTerminalView(opts: RenderOptions) {
   )
   const result = render(ui(opts))
   return {
+    store,
     rerender: (o: RenderOptions) => result.rerender(ui(o)),
   }
 }
@@ -268,5 +269,50 @@ describe('TerminalView hidden-pane rebind (F8)', () => {
     // The reveal effect requires mode === 'waiting_for_geometry' to attach;
     // a live pane only gets a layout fit.
     expect(sentFrames('terminal.attach').length).toBe(attachesBeforeReveal)
+  })
+
+  it('reconnect while hidden re-registers with queueIfStarted (the pump cannot wait for reveal)', () => {
+    const { store } = renderTerminalView({
+      paneContent: { ...baseTerminalContent, terminalId: 'term-3', status: 'running', createRequestId: 'req-3' },
+      hidden: true,
+    })
+    // Fold the live terminalId into the layout (mirrors the terminal.created
+    // fold) so the #534 attach gate admits it.
+    act(() => {
+      store.dispatch(updatePaneContent({
+        tabId: 'tab-1',
+        paneId: 'pane-1',
+        content: { ...baseTerminalContent, terminalId: 'term-3', status: 'running', createRequestId: 'req-3' },
+      }))
+    })
+    // The mount-time background-hydration registration consumed the guard;
+    // clear the mock log so the assertions below see only the reconnect's
+    // actions.
+    hydrationMocks.queue.register.mockClear()
+    hydrationMocks.queue.onHydrationComplete.mockClear()
+
+    const reconnect = wsMocks.onReconnect.mock.calls.at(-1)?.[0]
+    expect(reconnect).toBeTypeOf('function')
+    act(() => { reconnect() })
+
+    // THE FIX: same three-step dance as the terminal.created hidden path --
+    // release this pane's stale queue slot, then re-register with
+    // queueIfStarted, since a hidden pane's reattach must not wait for reveal.
+    expect(hydrationMocks.queue.onHydrationComplete).toHaveBeenCalledWith('pane-1')
+    expect(hydrationMocks.queue.register).toHaveBeenCalledWith(
+      expect.objectContaining({ paneId: 'pane-1', trigger: expect.any(Function) }),
+      expect.objectContaining({ queueIfStarted: true }),
+    )
+
+    // When the queue grants the slot, a full replay attach leaves the client
+    // even though the pane is still hidden (no usable checkpoint here).
+    wsMocks.send.mockClear()
+    act(() => { hydrationMocks.registered.at(-1)!.trigger() })
+    expect(sentFrames('terminal.attach').at(-1)).toMatchObject({
+      terminalId: 'term-3',
+      intent: 'keepalive_delta', // wire token for hidden viewport hydration
+      sinceSeq: 0,
+      priority: 'background',
+    })
   })
 })

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -7973,6 +7973,76 @@ describe('TerminalView lifecycle updates', () => {
       })
     })
 
+    it('pumps the hydration queue for a hidden pane on reconnect even without a usable parser checkpoint', async () => {
+      // The active tab hydrated first: the background pump is already started
+      // (onActiveTabReady is one-shot) before this hidden pane ever mounts.
+      act(() => {
+        getHydrationQueue().onActiveTabReady('tab-active-first', ['tab-active-first'])
+      })
+
+      const { terminalId } = await renderTerminalHarness({
+        status: 'running',
+        terminalId: 'term-hidden-reconnect-pump',
+        hidden: true,
+        ackInitialAttach: false,
+      })
+
+      // A hidden pane mounted post-startup registers WITHOUT queueIfStarted by
+      // design -- it waits for reveal. Nothing may attach while it stays hidden.
+      expect(wsMocks.send.mock.calls
+        .map(([msg]) => msg)
+        .filter((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === terminalId)).toHaveLength(0)
+
+      // No parser-applied checkpoint exists for this terminal in the harness,
+      // so the reconnect hidden branch takes the checkpoint-missing path --
+      // exactly the branch that registered with queueIfStarted:false and wedged
+      // behind the consumed registration guard.
+      act(() => {
+        reconnectHandler?.()
+      })
+
+      // The pane must be re-queued AND pumped with no reveal: a full replay
+      // attach leaves the client through the background hydration slot.
+      // (Hidden viewport hydration uses the keepalive_delta wire token per the
+      // attach policy's geometry swap; sinceSeq 0 = full replay.)
+      await waitFor(() => {
+        expect(wsMocks.send).toHaveBeenCalledWith(expect.objectContaining({
+          type: 'terminal.attach',
+          terminalId,
+          intent: 'keepalive_delta',
+          sinceSeq: 0,
+          priority: 'background',
+          attachRequestId: expect.any(String),
+        }))
+      })
+
+      // The queue stays one-at-a-time: a second hidden pane registered behind
+      // this one must hold until this pane's hydration completes -- proof the
+      // reconnect re-register took the pump slot and the queue then advanced
+      // past it.
+      const trailingTrigger = vi.fn()
+      act(() => {
+        getHydrationQueue().register(
+          { tabId: 'tab-trailing', paneId: 'pane-trailing', trigger: trailingTrigger },
+          { queueIfStarted: true },
+        )
+      })
+      expect(trailingTrigger).not.toHaveBeenCalled()
+
+      act(() => {
+        messageHandler!({
+          type: 'terminal.attach.ready',
+          terminalId,
+          headSeq: 0,
+          replayFromSeq: 1,
+          replayToSeq: 0,
+        })
+      })
+      await waitFor(() => {
+        expect(trailingTrigger).toHaveBeenCalledTimes(1)
+      })
+    })
+
     it('uses the highest rendered sequence in reconnect attach requests', async () => {
       const { terminalId, term } = await renderTerminalHarness({ status: 'running', terminalId: 'term-v2-reconnect' })
 

--- a/test/unit/client/components/TerminalView.lifecycle.test.tsx
+++ b/test/unit/client/components/TerminalView.lifecycle.test.tsx
@@ -3249,6 +3249,162 @@ describe('TerminalView lifecycle updates', () => {
     expect(createCallsAfter.length).toBe(createCallsBefore.length + 1)
   })
 
+  describe('D7-refusal revival (close→reopen reattach)', () => {
+    function setupRevivalPane() {
+      const tabId = 'tab-revive'
+      const paneId = 'pane-revive'
+
+      const paneContent: TerminalPaneContent = {
+        kind: 'terminal',
+        createRequestId: 'req-revive',
+        status: 'creating',
+        mode: 'shell',
+        shell: 'system',
+      }
+
+      const root: PaneNode = { type: 'leaf', id: paneId, content: paneContent }
+
+      const store = configureStore({
+        reducer: {
+          tabs: tabsReducer,
+          panes: panesReducer,
+          settings: settingsReducer,
+          connection: connectionReducer,
+        },
+        preloadedState: {
+          tabs: {
+            tabs: [{
+              id: tabId,
+              mode: 'shell',
+              status: 'creating',
+              title: 'Shell',
+              titleSetByUser: false,
+              createRequestId: 'req-revive',
+            }],
+            activeTabId: tabId,
+          },
+          panes: {
+            layouts: { [tabId]: root },
+            activePane: { [tabId]: paneId },
+            paneTitles: {},
+          },
+          settings: createSettingsState(),
+          connection: { status: 'connected', error: null },
+        },
+      })
+
+      render(
+        <Provider store={store}>
+          <TerminalViewFromStore tabId={tabId} paneId={paneId} />
+        </Provider>
+      )
+
+      return { store, tabId, paneId }
+    }
+
+    const d7Refusal = (requestId: string) => ({
+      type: 'error' as const,
+      code: 'RESTORE_UNAVAILABLE',
+      message: 'Session sess-live is still running on the server.',
+      requestId,
+      liveTerminalId: 't-live-owner',
+    })
+
+    it('reattaches the pane to the live owner the enriched refusal names — never the dead-end write', async () => {
+      const { store, tabId } = setupRevivalPane()
+
+      await waitFor(() => {
+        expect(messageHandler).not.toBeNull()
+        expect(
+          wsMocks.send.mock.calls.filter(([msg]) => msg?.type === 'terminal.create'),
+        ).toHaveLength(1)
+      })
+
+      // The D7 refusal lands carrying the STILL-RUNNING owner id (the
+      // close→reopen fallback shape: open pane, live server-side owner).
+      act(() => {
+        messageHandler!(d7Refusal('req-revive'))
+      })
+
+      // The revival fold: store state gains the live handle via the new
+      // reducer — never status:'error', and createRequestId stays put
+      // (council rule 2: never re-minted).
+      const revived = getLeafTerminalContent(store, tabId)
+      expect(revived.terminalId).toBe('t-live-owner')
+      expect(revived.status).toBe('running')
+      expect(revived.restoreError).toBeUndefined()
+      expect(revived.createRequestId).toBe('req-revive')
+
+      // The epoch bump re-fires the lifecycle effect, so a terminal.attach for
+      // the NAMED id leaves the client — and no second terminal.create is sent.
+      await waitFor(() => {
+        expect(
+          wsMocks.send.mock.calls
+            .map(([msg]) => msg)
+            .filter((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === 't-live-owner'),
+        ).toHaveLength(1)
+      })
+      expect(
+        wsMocks.send.mock.calls.map(([msg]) => msg).filter((msg) => msg?.type === 'terminal.create'),
+      ).toHaveLength(1)
+
+      // The pane announces the reconnection — never the dead-end write.
+      const term = terminalInstances[0]
+      expectTerminalWriteContaining(term, 'Reconnected to the still-running session.')
+      expect(terminalWriteStrings(term).some((entry) => entry.includes('[Restore failed]'))).toBe(false)
+      expect(terminalWriteStrings(term).some((entry) => entry.includes('[Launch failed]'))).toBe(false)
+    })
+
+    it('revives at most once per createRequestId — the second refusal lands the existing error write', async () => {
+      const { store, tabId } = setupRevivalPane()
+
+      await waitFor(() => {
+        expect(messageHandler).not.toBeNull()
+        expect(
+          wsMocks.send.mock.calls.filter(([msg]) => msg?.type === 'terminal.create'),
+        ).toHaveLength(1)
+      })
+
+      // First refusal revives the pane onto the live owner…
+      act(() => {
+        messageHandler!(d7Refusal('req-revive'))
+      })
+      await waitFor(() => {
+        expect(
+          wsMocks.send.mock.calls
+            .map(([msg]) => msg)
+            .filter((msg) => msg?.type === 'terminal.attach' && msg?.terminalId === 't-live-owner'),
+        ).toHaveLength(1)
+      })
+      const attachesAfterRevival = wsMocks.send.mock.calls.map(([msg]) => msg).filter(
+        (msg) => msg?.type === 'terminal.attach',
+      ).length
+
+      // …but if the live handle died in the race, the follow-on refusal for
+      // the same createRequestId must NOT loop the revival — it falls through
+      // to the existing dead-end error write.
+      act(() => {
+        messageHandler!(d7Refusal('req-revive'))
+      })
+
+      const fallen = getLeafTerminalContent(store, tabId)
+      expect(fallen.status).toBe('error')
+      expect(
+        wsMocks.send.mock.calls.map(([msg]) => msg).filter((msg) => msg?.type === 'terminal.attach'),
+      ).toHaveLength(attachesAfterRevival)
+      expect(
+        wsMocks.send.mock.calls.map(([msg]) => msg).filter((msg) => msg?.type === 'terminal.create'),
+      ).toHaveLength(1)
+
+      const term = terminalInstances[0]
+      expectTerminalWriteContaining(term, 'Reconnected to the still-running session.')
+      expectTerminalWriteContaining(term, 'Session sess-live is still running on the server.')
+      expect(
+        terminalWriteStrings(term).filter((entry) => entry.includes('Reconnected to the still-running session.')),
+      ).toHaveLength(1)
+    })
+  })
+
   it('does not reconnect after terminal.exit when INVALID_TERMINAL_ID is received', async () => {
     // This test verifies the fix for the runaway terminal creation loop:
     // 1. Terminal exits normally (e.g., Claude fails to resume)

--- a/test/unit/client/components/fresh-agent/FreshAgentView.hidden-rebind.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.hidden-rebind.test.tsx
@@ -6,6 +6,7 @@ import panesReducer, { initLayout } from '@/store/panesSlice'
 import settingsReducer from '@/store/settingsSlice'
 import freshAgentReducer from '@/store/freshAgentSlice'
 import tabsReducer from '@/store/tabsSlice'
+import connectionReducer from '@/store/connectionSlice'
 import { FreshAgentView } from '@/components/fresh-agent/FreshAgentView'
 import { getRebindQueue, resetRebindQueueForTests } from '@/lib/rebind-queue'
 import { resetSnapshotSchedulerForTests } from '@/lib/fresh-agent-snapshot-scheduler'
@@ -63,8 +64,17 @@ function createStore() {
       settings: settingsReducer,
       freshAgent: freshAgentReducer,
       tabs: tabsReducer,
+      // FreshAgentView reads connection.status to gate the .lost recovery
+      // driver; preload ready so tests keep the pre-gate behavior.
+      connection: connectionReducer,
     },
     preloadedState: {
+      connection: {
+        status: 'ready' as const,
+        platform: null,
+        availableClis: {},
+        featureFlags: {},
+      },
       panes: {
         layouts: {},
         activePane: {},

--- a/test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.reconcile.test.tsx
@@ -11,6 +11,7 @@ import panesReducer, {
 import settingsReducer from '@/store/settingsSlice'
 import freshAgentReducer, { markSessionLost, setSessionStatus } from '@/store/freshAgentSlice'
 import tabsReducer from '@/store/tabsSlice'
+import connectionReducer, { setStatus } from '@/store/connectionSlice'
 import {
   FreshAgentView,
   FRESH_AGENT_RESERVE_RETRY_FLOOR_MS,
@@ -19,7 +20,11 @@ import {
 import { handleFreshAgentMessage } from '@/lib/fresh-agent-ws'
 import { useAppSelector } from '@/store/hooks'
 import { resetRebindQueueForTests } from '@/lib/rebind-queue'
-import { setFreshAgentReconcileActive } from '@/lib/pane-reconcile'
+import {
+  buildReconcileRequestForPanes,
+  foldVerdicts,
+  setFreshAgentReconcileActive,
+} from '@/lib/pane-reconcile'
 import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
 import type { FreshAgentPaneContent } from '@/store/paneTypes'
 
@@ -89,8 +94,18 @@ function createStore() {
       settings: settingsReducer,
       freshAgent: freshAgentReducer,
       tabs: tabsReducer,
+      // The .lost recovery driver is gated on connection.status === 'ready';
+      // preload ready so existing tests keep their pre-gate behavior, and flip
+      // it deliberately in the reconnect-evidence cases.
+      connection: connectionReducer,
     },
     preloadedState: {
+      connection: {
+        status: 'ready' as const,
+        platform: null,
+        availableClis: {},
+        featureFlags: {},
+      },
       panes: {
         layouts: {},
         activePane: {},
@@ -183,6 +198,23 @@ function leafContent(state: ReturnType<typeof store.getState>): FreshAgentPaneCo
     throw new Error('Expected fresh-agent leaf content')
   }
   return layout.content
+}
+
+// markSessionLost no-ops when the session record does not exist, so seed
+// it first (setSessionStatus routes through resolveOrEnsureSession) -- the
+// exact shape fresh-agent-ws produces before dispatching markSessionLost.
+function markSessionLostInStore(sessionId = 'live-1') {
+  act(() => {
+    store.dispatch(setSessionStatus({ sessionId, sessionType: 'freshclaude', provider: 'claude', status: 'running' }))
+    store.dispatch(markSessionLost({ sessionId, sessionType: 'freshclaude', provider: 'claude' }))
+  })
+}
+
+function sessionInStore(state: ReturnType<typeof store.getState>, sessionId: string) {
+  const key = makeFreshAgentSessionKey({ sessionId, sessionType: 'freshclaude', provider: 'claude' })
+  const session = state.freshAgent.sessions[key]
+  if (!session) throw new Error(`Missing freshAgent session ${sessionId}`)
+  return session
 }
 
 // Shared harness setup for both describes (Task 9 fold drive, Task 10
@@ -340,23 +372,6 @@ describe('FreshAgentView reconcile fold drive (Task 9)', () => {
 // capability-gated fallback (council rule: NEVER deleted).
 describe('FreshAgentView .lost capability gate (Task 10)', () => {
   const ORIGINAL_CREATE_REQUEST_ID = baseContent.createRequestId
-
-  // markSessionLost no-ops when the session record does not exist, so seed
-  // it first (setSessionStatus routes through resolveOrEnsureSession) -- the
-  // exact shape fresh-agent-ws produces before dispatching markSessionLost.
-  function markSessionLostInStore(sessionId = 'live-1') {
-    act(() => {
-      store.dispatch(setSessionStatus({ sessionId, sessionType: 'freshclaude', provider: 'claude', status: 'running' }))
-      store.dispatch(markSessionLost({ sessionId, sessionType: 'freshclaude', provider: 'claude' }))
-    })
-  }
-
-  function sessionInStore(state: ReturnType<typeof store.getState>, sessionId: string) {
-    const key = makeFreshAgentSessionKey({ sessionId, sessionType: 'freshclaude', provider: 'claude' })
-    const session = state.freshAgent.sessions[key]
-    if (!session) throw new Error(`Missing freshAgent session ${sessionId}`)
-    return session
-  }
 
   it('.lost with fresh-agent reconcile active sends a single-pane reconcile instead of heuristic recovery', async () => {
     setFreshAgentReconcileActive(true)
@@ -540,5 +555,113 @@ describe('FreshAgentView SESSION_RESERVED re-drive (Task 14)', () => {
       await vi.advanceTimersByTimeAsync(FRESH_AGENT_RESERVE_RETRY_FLOOR_MS + 20)
     })
     expect(sentOfType('freshAgent.attach').length).toBeGreaterThan(attachesBefore) // re-driven
+  })
+})
+
+// reconnect-revive Task 4: a fresh-agent pane whose slice entry got lost=true
+// from a transient dead-window attach race must UNWEDGE on truth-bearing
+// reconnect evidence -- (a) the server-authoritative Live -> attach verdict
+// fold revokes the flag (re-arming the suppressed snapshot fetch), and (b) a
+// fresh reconnect re-runs the .lost recovery driver even when every other dep
+// is unchanged. fresh-eyes F4: recovery acts only on post-reconnect evidence
+// -- a ready -> disconnected flip must clear nothing and mint nothing.
+describe('FreshAgentView lost revocation on reconnect evidence (reconnect-revive Task 4)', () => {
+  const CODEX_THREAD = 'thread-live-1'
+  const codexLostLoc = { sessionId: CODEX_THREAD, sessionType: 'freshcodex' as const, provider: 'codex' as const }
+  const codexKey = makeFreshAgentSessionKey(codexLostLoc)
+
+  function setConnection(status: 'disconnected' | 'ready') {
+    act(() => { store.dispatch(setStatus(status)) })
+  }
+
+  it('a server-authoritative attach fold revokes lost and the next snapshot-fetch run issues the HTTP GET', async () => {
+    // Codex pane with its durable id already as sessionId (no sessionId change
+    // possible): lost=true suppresses the snapshot GET (a guaranteed 404
+    // against a thread the client believes dead), and only the BOOT reconcile
+    // fold (foldVerdicts -- NOT this view's own .lost fold) can revoke it.
+    setFreshAgentReconcileActive(true) // keep the .lost driver on the reconcile path (never resets pane content)
+    act(() => {
+      store.dispatch(setSessionStatus({ ...codexLostLoc, status: 'running' }))
+      store.dispatch(markSessionLost(codexLostLoc))
+    })
+    expect(store.getState().freshAgent.sessions[codexKey].lost).toBe(true)
+
+    renderFreshAgentPane({
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      sessionId: CODEX_THREAD,
+      sessionRef: { provider: 'codex', sessionId: CODEX_THREAD },
+      status: 'connected',
+    })
+    await flush()
+    expect(apiMock.getFreshAgentThreadSnapshot).not.toHaveBeenCalled() // suppressed while lost
+
+    const bootRequest = buildReconcileRequestForPanes(store.getState(), [{ tabId, paneId }])
+    if (!bootRequest) throw new Error('expected a single-pane boot reconcile request')
+    act(() => {
+      foldVerdicts(store.dispatch, bootRequest, {
+        type: 'pane.reconcile.result',
+        reconcileId: bootRequest.reconcileId,
+        bootId: 'b',
+        serverInstanceId: 's',
+        verdicts: [{
+          paneKey: bootRequest.panes[0].paneKey,
+          verdict: 'attach',
+          sessionRef: { provider: 'codex', sessionId: CODEX_THREAD },
+        }],
+      })
+    })
+    await flush()
+    // The verdict was positive existence evidence: lost revoked, so the very
+    // next snapshot-effect run issues the GET.
+    expect(store.getState().freshAgent.sessions[codexKey].lost).toBe(false)
+    expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalled()
+  })
+
+  it('a fresh reconnect re-runs the .lost recovery driver (disconnected -> ready), no verdict and unchanged deps', async () => {
+    setFreshAgentReconcileActive(true)
+    setConnection('disconnected')
+    renderFreshAgentPane({ sessionId: 'live-1', status: 'running', sessionRef: { provider: 'claude', sessionId: DURABLE } })
+    markSessionLostInStore()
+    await flush()
+    // Offline: the gate holds recovery -- nothing is sent, no session-id
+    // clearing / create minting before any post-reconnect evidence exists.
+    expect(sentOfType('pane.reconcile.request')).toHaveLength(0)
+    expect(leafContent(store.getState()).createRequestId).toBe(baseContent.createRequestId)
+    // Reconnect: the connection.status flip alone re-drives the driver.
+    setConnection('ready')
+    await flush()
+    const reqs = sentOfType('pane.reconcile.request')
+    expect(reqs).toHaveLength(1)
+    expect((reqs[0].panes as Array<{ kind: string }>)[0].kind).toBe('fresh-agent')
+    // A fresh disconnect/reconnect pair re-drives again (other deps unchanged).
+    setConnection('disconnected')
+    await flush()
+    expect(sentOfType('pane.reconcile.request')).toHaveLength(1) // offline gate again
+    setConnection('ready')
+    await flush()
+    expect(sentOfType('pane.reconcile.request')).toHaveLength(2)
+  })
+
+  it('lost while offline does NOT run triggerRecovery (no session-id clearing / create minting) -- fresh-eyes F4', async () => {
+    setFreshAgentReconcileActive(false)
+    // Realistic lost-thread env (same rationale as the Task 10 legacy test):
+    // the snapshot fetch against a dead thread 404s, and the default resolving
+    // mock would overwrite the recovery status with the snapshot's.
+    apiMock.getFreshAgentThreadSnapshot.mockRejectedValue(new Error('lost thread'))
+    setConnection('disconnected')
+    renderFreshAgentPane({ sessionId: 'live-1', status: 'running', sessionRef: { provider: 'claude', sessionId: DURABLE } })
+    markSessionLostInStore()
+    await flush()
+    // Ungated, this transition would already have cleared the pane's session
+    // id and minted a new create request -- purely on dead-window-era evidence.
+    expect(leafContent(store.getState()).createRequestId).toBe(baseContent.createRequestId)
+    expect(leafContent(store.getState()).sessionId).toBe('live-1')
+    expect(leafContent(store.getState()).status).toBe('running')
+    // Control: the pane was recoverable all along -- reconnect runs recovery.
+    setConnection('ready')
+    await flush()
+    expect(leafContent(store.getState()).createRequestId).not.toBe(baseContent.createRequestId)
+    expect(leafContent(store.getState()).status).toBe('creating')
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -6,6 +6,7 @@ import panesReducer from '@/store/panesSlice'
 import settingsReducer, { previewServerSettingsPatch, updateSettingsLocal } from '@/store/settingsSlice'
 import freshAgentReducer, { sessionInit, setSessionStatus, markSessionLost } from '@/store/freshAgentSlice'
 import tabsReducer from '@/store/tabsSlice'
+import connectionReducer from '@/store/connectionSlice'
 import { FreshAgentView, IDLE_INCOMPLETE_MAX_RETRIES } from '@/components/fresh-agent/FreshAgentView'
 import { FreshAgentSettingsButton } from '@/components/fresh-agent/FreshAgentSettingsButton'
 import { initLayout, requestPaneRefresh, setActivePane, updatePaneContent, updatePaneTitle } from '@/store/panesSlice'
@@ -63,8 +64,17 @@ function createStore(tabTitleSetByUser = false) {
       settings: settingsReducer,
       freshAgent: freshAgentReducer,
       tabs: tabsReducer,
+      // FreshAgentView reads connection.status to gate the .lost recovery
+      // driver; preload ready so tests keep the pre-gate behavior.
+      connection: connectionReducer,
     },
     preloadedState: {
+      connection: {
+        status: 'ready' as const,
+        platform: null,
+        availableClis: {},
+        featureFlags: {},
+      },
       panes: {
         layouts: {},
         activePane: {},

--- a/test/unit/client/lib/fresh-agent-ws.test.ts
+++ b/test/unit/client/lib/fresh-agent-ws.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { configureStore } from '@reduxjs/toolkit'
-import freshAgentReducer from '@/store/freshAgentSlice'
-import panesReducer, { initLayout, type PanesState } from '@/store/panesSlice'
+import freshAgentReducer, { materializeSession } from '@/store/freshAgentSlice'
+import panesReducer, { initLayout, materializeFreshAgentSession, type PanesState } from '@/store/panesSlice'
 import { handleFreshAgentMessage, registerFreshAgentCreate } from '@/lib/fresh-agent-ws'
 import { cancelCreate, _resetCancelledCreates } from '@/lib/create-cancellation'
 import { flushPersistedLayoutNow } from '@/store/persistControl'
@@ -296,6 +296,57 @@ describe('fresh-agent-ws', () => {
       sessionId: durableId,
       sessionKey: `freshopencode:opencode:${durableId}`,
     })
+    expect(actionTypes).toContain(flushPersistedLayoutNow.type)
+  })
+
+  it('folds an attach-path freshAgent.session.materialized into BOTH slice and pane re-keys for a placeholder-keyed pane (Task 5 reconnect pin)', () => {
+    // The pane exactly as a reconnect restores it: keyed by the PLACEHOLDER id, with
+    // NO create handshake anywhere in this connection (the original create happened
+    // pre-disconnect; only the persisted layout survives). The Task 5 server emit on
+    // the tracked attach arm must therefore need no client change — this fold pin
+    // proves the existing materialized fold already covers the attach path.
+    const actionTypes: string[] = []
+    const store = createFreshAgentPaneStore(actionTypes)
+    const placeholderId = 'freshopencode-req-reconnect'
+    const durableId = 'ses_reconnect_1'
+
+    store.dispatch(initLayout({
+      tabId: 'tab-reconnect',
+      paneId: 'pane-reconnect',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        sessionId: placeholderId,
+        createRequestId: 'req-reconnect',
+        status: 'running',
+        resumeSessionId: placeholderId,
+        sessionRef: { provider: 'opencode', sessionId: placeholderId },
+      },
+    }))
+
+    expect(handleFreshAgentMessage(store.dispatch, {
+      type: 'freshAgent.session.materialized',
+      previousSessionId: placeholderId,
+      sessionId: durableId,
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      sessionRef: { provider: 'opencode', sessionId: durableId },
+    })).toBe(true)
+
+    expect(actionTypes).toContain(materializeSession.type)
+    expect(actionTypes).toContain(materializeFreshAgentSession.type)
+
+    const layout = store.getState().panes.layouts['tab-reconnect']
+    if (layout.type !== 'leaf') throw new Error('expected leaf layout')
+    expect(layout.content).toMatchObject({
+      kind: 'fresh-agent',
+      sessionId: durableId,
+      resumeSessionId: durableId,
+      sessionRef: { provider: 'opencode', sessionId: durableId },
+    })
+    expect(store.getState().freshAgent.sessions[`freshopencode:opencode:${placeholderId}`]).toBeUndefined()
+    expect(store.getState().freshAgent.sessions[`freshopencode:opencode:${durableId}`]).toBeDefined()
     expect(actionTypes).toContain(flushPersistedLayoutNow.type)
   })
 

--- a/test/unit/client/lib/ws-client.liveness.test.ts
+++ b/test/unit/client/lib/ws-client.liveness.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WsClient, resetWsClientForTests } from '../../../../src/lib/ws-client'
+
+class MockWebSocket {
+  static OPEN = 1
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.OPEN
+  onopen: null | (() => void) = null
+  onmessage: null | ((ev: { data: string }) => void) = null
+  onclose: null | ((ev: { code: number; reason: string }) => void) = null
+  onerror: null | (() => void) = null
+  sent: string[] = []
+
+  constructor(_url: string) {
+    MockWebSocket.instances.push(this)
+  }
+
+  send(data: any) {
+    this.sent.push(String(data))
+  }
+
+  close() {
+    this.onclose?.({ code: 1000, reason: '' })
+  }
+
+  _open() {
+    this.onopen?.()
+  }
+
+  _message(obj: any) {
+    this.onmessage?.({ data: JSON.stringify(obj) })
+  }
+
+  _close(code: number, reason = '') {
+    this.onclose?.({ code, reason })
+  }
+}
+
+// Shared fresh-socket handshake fixture: every abandon test delivers this on
+// the replacement socket so the recycled connection reaches ready.
+const READY_MSG = { type: 'ready', bootId: 'b1', serverInstanceId: 's1', capabilities: {} }
+
+async function connectReady(client: WsClient): Promise<{ client: WsClient; socket: MockWebSocket }> {
+  const p = client.connect()
+  const socket = MockWebSocket.instances[MockWebSocket.instances.length - 1]
+  socket._open()
+  socket._message(READY_MSG)
+  await p
+  return { client, socket }
+}
+
+describe('WsClient liveness', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    MockWebSocket.instances = []
+    // @ts-expect-error - test override
+    globalThis.WebSocket = MockWebSocket
+    localStorage.setItem('freshell.auth-token', 't')
+
+    // Some Vitest environments provide a minimal window without timer fns.
+    // jsdom window timers are NOT auto-faked: re-point the interval fns too,
+    // or the liveness watch never ticks under fake-timer advances.
+    ;(window as any).setTimeout = globalThis.setTimeout
+    ;(window as any).clearTimeout = globalThis.clearTimeout
+    ;(window as any).setInterval = globalThis.setInterval
+    ;(window as any).clearInterval = globalThis.clearInterval
+  })
+
+  afterEach(() => {
+    resetWsClientForTests()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('sends an app-level ping after 30s of inbound silence while ready', async () => {
+    const { socket } = await connectReady(new WsClient('ws://test/ws'))
+    // Ready traffic itself was inbound activity. 10s ticks at t=10/20 skip
+    // (silence < 30s); the t=30 tick sees silence === 30s and probes.
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(true)
+  })
+
+  it('does not ping while inbound traffic keeps the socket fresh', async () => {
+    const { socket } = await connectReady(new WsClient('ws://test/ws'))
+    await vi.advanceTimersByTimeAsync(15_000)
+    socket._message({ type: 'settings.updated', settings: {} }) // any inbound frame
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(false)
+  })
+
+  it('abandons a socket whose probe goes unanswered past the pong timeout — no reliance on its onclose', async () => {
+    const { socket } = await connectReady(new WsClient('ws://test/ws'))
+    await vi.advanceTimersByTimeAsync(30_000)          // probe sent
+    expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(true)
+    // The dead transport NEVER delivers onclose — that is the hazard under test.
+    // t=30 tick probes; the t=40 tick sees probe age 10s >= PONG_TIMEOUT_MS and abandons.
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(MockWebSocket.instances.length).toBe(2)     // fresh socket driven immediately
+    const fresh = MockWebSocket.instances[1]
+    fresh._open(); fresh._message(READY_MSG)           // fresh socket completes handshake
+    socket._close(4002, 'late')                        // stale socket's LATE close arrives
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(MockWebSocket.instances.length).toBe(2)     // …and is ignored (generation guard)
+  })
+
+  it('clears the outstanding probe on any inbound message (no abandon while traffic flows)', async () => {
+    const { socket } = await connectReady(new WsClient('ws://test/ws'))
+    await vi.advanceTimersByTimeAsync(30_000)           // t=30: probe
+    socket._message({ type: 'pong', timestamp: 'x' })  // probe cleared; silence restarts from t=30
+    // Silence restarts at the last inbound frame, so feed periodic traffic:
+    // at each 10s tick silence stays < 30s and no further probe is needed.
+    for (let i = 0; i < 3; i++) {
+      await vi.advanceTimersByTimeAsync(20_000)
+      socket._message({ type: 'settings.updated', settings: {} })
+    }
+    expect(MockWebSocket.instances.length).toBe(1)     // never abandoned
+  })
+
+  it('re-probes on persistent silence and abandons when the repeat probe also goes unanswered', async () => {
+    const { socket } = await connectReady(new WsClient('ws://test/ws'))
+    await vi.advanceTimersByTimeAsync(30_000)           // t=30: probe #1
+    socket._message({ type: 'pong', timestamp: 'x' })  // t=30: cleared
+    await vi.advanceTimersByTimeAsync(40_000)           // t=60: probe #2; t=70: unanswered 10s → abandon
+    expect(MockWebSocket.instances.length).toBe(2)
+  })
+
+  it('poke() while ready and recently active sends an immediate probe', async () => {
+    const { client, socket } = await connectReady(new WsClient('ws://test/ws'))
+    client.poke()
+    expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(true)
+  })
+
+  it('poke() after 65s+ of silence abandons immediately instead of waiting out the probe', async () => {
+    const { client, socket } = await connectReady(new WsClient('ws://test/ws'))
+    // Simulate a frozen tab: no timers ran (background clamp) but the wall
+    // clock jumped past the keepalive window threshold.
+    vi.setSystemTime(Date.now() + 65_000)
+    client.poke()                                      // no onclose delivery from the dead socket
+    expect(socket.sent.some((s) => JSON.parse(s).type === 'ping')).toBe(false) // no probe wait
+    expect(MockWebSocket.instances.length).toBe(2)     // abandoned into a fresh socket
+    vi.setSystemTime(Date.now() - 65_000)
+  })
+
+  it('poke() while disconnected skips the pending backoff wait and connects now', async () => {
+    const { client } = await connectReady(new WsClient('ws://test/ws'))
+    MockWebSocket.instances[0]._close(4002, 'boom')    // transient → scheduleReconnect armed (1s+)
+    client.poke()
+    expect(MockWebSocket.instances.length).toBe(2)     // connected without advancing timers
+  })
+
+  it('stops probing after disconnect()', async () => {
+    const { client, socket } = await connectReady(new WsClient('ws://test/ws'))
+    client.disconnect()
+    const sentCount = socket.sent.length
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(socket.sent.length).toBe(sentCount)
+  })
+})

--- a/test/unit/client/store/freshAgentSlice.test.ts
+++ b/test/unit/client/store/freshAgentSlice.test.ts
@@ -152,3 +152,47 @@ describe('freshAgentSlice', () => {
     expect(reducer(undefined, lostGhost).sessions).toEqual({})
   })
 })
+
+describe('freshAgentSlice lost revocation on truth-bearing snapshot evidence', () => {
+  // reconnect-revive Task 4: a snapshot answer is positive existence evidence
+  // (the 404 FRESH_AGENT_LOST_SESSION path never dispatches these reducers), so
+  // it revokes a stale `lost` flag left by a transient dead-window attach race.
+  const loc = { sessionId: 'thread-snapshot-truth', sessionType: 'freshcodex' as const, provider: 'codex' as const }
+  const key = makeFreshAgentSessionKey(loc)
+
+  function lostState() {
+    // Seed a live session first (markSessionLost is a safe no-op on a missing
+    // record), then wedge it the way the dead-window attach race does.
+    let state = reducer(undefined, setSessionStatus({ ...loc, status: 'running' }))
+    state = reducer(state, markSessionLost(loc))
+    expect(state.sessions[key].lost).toBe(true)
+    return state
+  }
+
+  it('sessionSnapshotReceived revokes a stale lost flag on the addressed session', () => {
+    const state = reducer(lostState(), sessionSnapshotReceived({ ...loc, latestTurnId: null, status: 'idle' }))
+    expect(state.sessions[key].lost).toBe(false)
+  })
+
+  it('freshAgentSnapshotReceived revokes a stale lost flag on the addressed session', () => {
+    const state = reducer(lostState(), freshAgentSnapshotReceived({
+      snapshot: {
+        ...loc,
+        threadId: loc.sessionId,
+        revision: 3,
+        latestTurnId: null,
+        status: 'idle',
+        capabilities: { send: true, interrupt: true, approvals: false, questions: false, fork: true },
+        tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 },
+        pendingApprovals: [],
+        pendingQuestions: [],
+        worktrees: [],
+        diffs: [],
+        childThreads: [],
+        turns: [],
+        extensions: {},
+      },
+    }))
+    expect(state.sessions[key].lost).toBe(false)
+  })
+})

--- a/test/unit/client/store/panesSlice.reconnect.test.ts
+++ b/test/unit/client/store/panesSlice.reconnect.test.ts
@@ -1,0 +1,133 @@
+// Reconnect-path reducers for the D7-refusal revival fold (reconnect-revive
+// Task 7): a close→reopen create that the server refuses with a D7
+// `RESTORE_UNAVAILABLE` carrying the STILL-RUNNING owner terminal id must
+// reattach the pane to that id instead of dead-ending on
+// "Session … is still running on the server." — never a second live writer
+// (one-JSONL-writer doctrine), never a silent gray pane.
+//
+// Placement note: panesSlice.reconcile.test.ts is the slice's reconnect-ish
+// test home for the pane.reconcile VERDICT folds (`applyReconcileAttach` and
+// siblings). This reducer is NOT a reconcile verdict — it folds an enriched
+// create-ERROR frame — so it gets its own home named for the reconnect path,
+// mirroring that file's scaffolding.
+
+import { describe, it, expect } from 'vitest'
+
+import panesReducer, {
+  initLayout,
+  applyReattachToLiveTerminal,
+} from '../../../../src/store/panesSlice'
+import type { PanesState } from '../../../../src/store/panesSlice'
+import type { PaneNode, TerminalPaneContent } from '../../../../src/store/paneTypes'
+
+function emptyState(): PanesState {
+  return {
+    layouts: {},
+    activePane: {},
+    paneTitles: {},
+    paneTitleSetByUser: {},
+    renameRequestTabId: null,
+    renameRequestPaneId: null,
+    zoomedPane: {},
+    refreshRequestsByPane: {},
+    restoreFallbackAttemptsByPane: {},
+  }
+}
+
+function stateWithTerminalPane(overrides: Partial<TerminalPaneContent> = {}): PanesState {
+  return panesReducer(emptyState(), initLayout({
+    tabId: 'tab1',
+    paneId: 'p1',
+    content: {
+      kind: 'terminal',
+      mode: 'claude',
+      shell: 'system',
+      createRequestId: 'cr-keep',
+      ...overrides,
+    },
+  }))
+}
+
+function findTerminalLeaf(node: PaneNode, paneId: string): TerminalPaneContent | undefined {
+  if (node.type === 'leaf') {
+    if (node.id === paneId && node.content.kind === 'terminal') return node.content
+    return undefined
+  }
+  return findTerminalLeaf(node.children[0], paneId) ?? findTerminalLeaf(node.children[1], paneId)
+}
+
+function terminalContent(state: PanesState, tabId: string, paneId: string): TerminalPaneContent {
+  const root = state.layouts[tabId]
+  if (!root) throw new Error(`no layout for tab ${tabId}`)
+  const content = findTerminalLeaf(root, paneId)
+  if (!content) throw new Error(`no terminal pane ${paneId} in tab ${tabId}`)
+  return content
+}
+
+describe('applyReattachToLiveTerminal (D7-refusal revival fold)', () => {
+  it('writes terminalId/status, clears restoreError, and bumps reconcileEpoch — createRequestId untouched', () => {
+    const state = stateWithTerminalPane({
+      createRequestId: 'cr-keep',
+      terminalId: undefined,
+      status: 'creating',
+      restoreError: { code: 'RESTORE_UNAVAILABLE', reason: 'dead_live_handle' },
+    })
+    const next = panesReducer(
+      state,
+      applyReattachToLiveTerminal({ tabId: 'tab1', paneId: 'p1', terminalId: 't1-live-owner' }),
+    )
+    const c = terminalContent(next, 'tab1', 'p1')
+    expect(c.terminalId).toBe('t1-live-owner')
+    expect(c.status).toBe('running')
+    expect(c.restoreError).toBeUndefined()
+    expect(c.createRequestId).toBe('cr-keep') // council rule 2: never re-minted
+    // The epoch bump is the lifecycle effect's ONLY re-fire signal on an
+    // already-mounted pane (TerminalView deps exclude terminalId/status by
+    // design) — without it the fold stays gray/dead.
+    expect(c.reconcileEpoch).toBe(1)
+  })
+
+  it('bumps reconcileEpoch monotonically across successive folds', () => {
+    let s = stateWithTerminalPane({ createRequestId: 'cr-keep' })
+    s = panesReducer(s, applyReattachToLiveTerminal({ tabId: 'tab1', paneId: 'p1', terminalId: 't-live-1' }))
+    s = panesReducer(s, applyReattachToLiveTerminal({ tabId: 'tab1', paneId: 'p1', terminalId: 't-live-2' }))
+    const c = terminalContent(s, 'tab1', 'p1')
+    expect(c.terminalId).toBe('t-live-2')
+    expect(c.reconcileEpoch).toBe(2)
+  })
+
+  it('is a no-op for an unknown paneKey', () => {
+    const state = stateWithTerminalPane({ createRequestId: 'cr-keep', status: 'creating' })
+    const next = panesReducer(
+      state,
+      applyReattachToLiveTerminal({ tabId: 'tab-other', paneId: 'p-other', terminalId: 't-x' }),
+    )
+    expect(next.layouts).toEqual(state.layouts)
+    expect(terminalContent(next, 'tab1', 'p1').terminalId).toBeUndefined()
+    expect(terminalContent(next, 'tab1', 'p1').status).toBe('creating')
+  })
+
+  it('is a no-op when the refusal names no usable terminal id', () => {
+    const state = stateWithTerminalPane({ createRequestId: 'cr-keep', status: 'creating' })
+    const next = panesReducer(
+      state,
+      applyReattachToLiveTerminal({ tabId: 'tab1', paneId: 'p1', terminalId: '' }),
+    )
+    const c = terminalContent(next, 'tab1', 'p1')
+    expect(c.terminalId).toBeUndefined()
+    expect(c.status).toBe('creating')
+    expect(c.reconcileEpoch).toBeUndefined()
+  })
+
+  it('is a no-op when the pane id does not exist on the tab', () => {
+    const state = stateWithTerminalPane({ createRequestId: 'cr-keep', status: 'creating' })
+    const next = panesReducer(
+      state,
+      applyReattachToLiveTerminal({ tabId: 'tab1', paneId: 'p-other', terminalId: 't-x' }),
+    )
+    const c = terminalContent(next, 'tab1', 'p1')
+    expect(c.terminalId).toBeUndefined()
+    expect(c.status).toBe('creating')
+    expect(c.reconcileEpoch).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

When a device's WebSocket connection to Freshell dies quietly (most commonly a phone browser backgrounded), panes stay gray and dead until the user closes and reopens them — and that reopen path could dead-end with "Session … is still running on the server."

## Fix — four layers (plan-first, validated)

1. **Transport liveness** — an app-level ping watchdog (~30s) notices a silent-dead connection, plus instant reconciliation when the page regains visibility/focus. Stale sockets are abandoned with generation guards (dead handlers detached) and a fresh socket replaces them.
2. **Reconcile-loss** — the client waits a short bound for boot reconciliation before declaring panes lost; the server now explicitly refuses non-negotiated terminal-attach requests (the window where the client used to wait forever) with a structured error.
3. **Per-pane reattach gaps** — hidden (never-visited) tabs now rehydrate on reconnect like visible ones; fresh-agent panes (`claude`/`codex`/`opencode`) revoke a client-side \`lost\` mark when server-attestable state exists and drive materialized live ids back down so gray panes recover; the claude attach ack carries the realistic per-arm status (with status lifecycle folding so completed turns settle).
4. **Close→reopen disarm** — single-writer refusals (D7/D8, WS + REST) now name the live \`terminalId\`; the client folds it into an epoch-bumping reattach. Protocol contracts regenerated on all three surfaces (TS shared, Rust protocol, port/contract JSON schemas).

The e2e suite (\`test/e2e-browser/specs/reconnect-revive-rust.spec.ts\`) plays these shapes end-to-end on the real Rust server: socket drop/revive, frozen-server watchdog, close/reopen adopt (keyed + named), agent-pane drop/revive, no regression on clean reconnect.

## Notes

- Out of scope by design: multi-view attach machinery (#4/#2/#3 policies) — follow-up work.
- Pre-existing, unrelated: the mutation-oracle harness has a broken pristine-rebuild step (root-caused to \`1de2258d8\`, present on main); tracked as a follow-up, evidence recorded.
- Verified: full coordinated test suite green at this HEAD (local backend); both Rust + client + server suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)