### PR TITLE
cloud: convert GCP test lanes to gcloud-robot identity ladder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,14 @@ npm run test:cloud:build    # Build and push the Docker image to Artifact Regist
 
 **Note:** The electron suite always runs locally even in cloud mode (it needs a display and native modules not available in the container).
 
+**Identity:** cloud lanes never require an interactive `gcloud auth login`.
+They resolve a gcloud identity lazily, in this order: `--account=` flag >
+`FRESHELL_GCP_ACCOUNT` > `GCLOUD_IDENT` > gcloud-robot probe (needs
+`GCLOUD_ROBOT_HOME`, the installed gcloud-robot skill directory) > ambient
+gcloud (with a one-line stderr note). Provisioning, rotation, and revocation
+live in [docs/development/gcloud-robot.md](docs/development/gcloud-robot.md).
+`GCLOUD_ROBOT_REQUIRE=1` fails closed when no robot identity resolves.
+
 ### E2E Test Backend (Cloud Run Jobs)
 
 Playwright e2e tests can run locally or on Google Cloud Run Jobs. The `FRESHELL_E2E_BACKEND` environment variable controls the default:
@@ -182,6 +190,14 @@ npm run test:e2e:cloud      # Force cloud
 **If `FRESHELL_E2E_BACKEND` is not set, ask the user which way to set it** before running e2e tests. Explain that cloud is much faster (parallel shards, ~2-3 min vs ~28 min) but is a paid Google Cloud service (~$0.03/run); local is free but slower. Once the user chooses, set it permanently in their `~/.bashrc` (or equivalent) so agents don't need to ask again.
 
 **Before filing any PR, ensure the affected e2e specs actually pass on the configured `FRESHELL_E2E_BACKEND` backend** — a spec sitting in `CLOUD_SKIP_SPECS` (`test/e2e-browser/playwright.cloud.config.ts`) or a filter that matched no tests is not coverage.
+
+**Identity:** cloud lanes never require an interactive `gcloud auth login`.
+They resolve a gcloud identity lazily, in this order: `--account=` flag >
+`FRESHELL_GCP_ACCOUNT` > `GCLOUD_IDENT` > gcloud-robot probe (needs
+`GCLOUD_ROBOT_HOME`, the installed gcloud-robot skill directory) > ambient
+gcloud (with a one-line stderr note). Provisioning, rotation, and revocation
+live in [docs/development/gcloud-robot.md](docs/development/gcloud-robot.md).
+`GCLOUD_ROBOT_REQUIRE=1` fails closed when no robot identity resolves.
 
 ## Architecture
 

--- a/docker/cloud-run/cloudbuild.yaml
+++ b/docker/cloud-run/cloudbuild.yaml
@@ -31,4 +31,9 @@ steps:
 options:
   machineType: 'E2_HIGHCPU_32'
   diskSizeGb: 200
+  # Build logs land in Cloud Logging, readable with roles/logging.viewer —
+  # the legacy default GCS log bucket would need project-wide roles/viewer
+  # for the submitting identity (gcloud-robot conversion). Note: this mode
+  # does not stream logs during submit; read after with `gcloud builds log`.
+  logging: 'CLOUD_LOGGING_ONLY'
 timeout: '3600s'

--- a/docs/development/gcloud-robot.md
+++ b/docs/development/gcloud-robot.md
@@ -126,11 +126,23 @@ account (export it). All skill scripts are invoked via
    "probe passes, build 403s" failure):
 
    ```bash
-   # Staging bucket Cloud Build uploads source to (confirm the name; the
-   # default is <project>_cloudbuild):
-   BUCKET="$(gcloud storage buckets list --project=misc-puttering-project \
-       --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" --format='value(name)' | grep cloudbuild)"
-   for role in roles/storage.objectAdmin roles/storage.legacyBucketReader; do
+   # Staging bucket Cloud Build uploads source to (the default is
+   # <project>_cloudbuild). Discovery must be deterministic: exactly one
+   # *cloudbuild* bucket or the operator stops and picks by hand.
+   mapfile -t BUCKETS < <(gcloud storage buckets list --project=misc-puttering-project \
+     --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" --format='value(name)' | grep cloudbuild)
+   if [ "${#BUCKETS[@]}" -ne 1 ]; then
+     printf 'expected exactly one *cloudbuild* bucket, found %d:\n' "${#BUCKETS[@]}" >&2
+     printf '  %s\n' "${BUCKETS[@]}" >&2
+     exit 1
+   fi
+   BUCKET="${BUCKETS[0]}"
+   echo "scoping storage grants to staging bucket: $BUCKET"
+   # objectUser (object CRUD/list/multipart), NOT objectAdmin: the submitter
+   # only stages ordinary source objects, and objectAdmin would add object
+   # setIamPolicy/retention powers the bearer key must never hold. (This
+   # diverges from the gcloud-robot skill's example role on purpose.)
+   for role in roles/storage.objectUser roles/storage.legacyBucketReader; do
      gcloud storage buckets add-iam-policy-binding "gs://$BUCKET" \
        --member="serviceAccount:gcloud-robot@misc-puttering-project.iam.gserviceaccount.com" \
        --role="$role" \

--- a/docs/development/gcloud-robot.md
+++ b/docs/development/gcloud-robot.md
@@ -1,0 +1,296 @@
+# gcloud-robot identity for cloud test lanes
+
+Freshell's cloud test lanes (`scripts/e2e-cloud.sh`, `scripts/vitest-cloud.sh`
+— Cloud Run Jobs for Playwright e2e and Vitest suites, plus their shared
+Cloud Build / Artifact Registry image machinery) no longer depend on an
+interactive `gcloud auth login`. Interactive gcloud sessions ride OAuth
+refresh tokens that Google silently culls (roughly hourly under heavy agent
+use); the last observed casualty was a base-gate run dying mid-lane with
+`Reauthentication failed. cannot prompt during non-interactive execution`
+(2026-08-23, UTC). The replacement is the gcloud-robot pattern: one
+per-project robot service account minted from a local JSON key — no browser
+login, no refresh token, no hourly expiry.
+
+Project: `misc-puttering-project` (region `us-west1`, AR repo `freshell-e2e`).
+Robot: `gcloud-robot@misc-puttering-project.iam.gserviceaccount.com`.
+
+## Security, stated plainly
+
+A JSON key is bearer power with no MFA and — by default — no expiry. It is
+weaker than an expiring interactive session. Two things bound the risk:
+least-privilege per-project grants (below), and rotation plus instant
+revocation as first-class operations (below). The control that still holds
+when logs are blind is the standing rotation cadence — keep one, and enable
+the key-usage alerting in "Monitor".
+
+## Adoption states
+
+The repo is in exactly one of two states at any time:
+
+1. **wired but not yet provisioned** — the ladder and this runbook are
+   committed, but the robot SA/key do not exist yet. Expected behavior: lanes
+   run exactly as before under ambient gcloud, with one quiet stderr note
+   (`gcloud-robot: no probed identity; using ambient gcloud` / `skill not
+   found ... — using ambient gcloud`). In this state `verify-as-robot.sh`
+   failing at the key/token-mint rung is the CORRECT result, not a
+   regression — do not debug it, provision.
+2. **provisioned and verified** — provisioning below completed and the
+   verification ladder passed as the robot.
+
+## How lanes resolve identity (after conversion)
+
+Lazily, immediately before a cloud lane's first real gcloud call (`help` and
+`run --local` never resolve anything and need zero GCP tooling), in this
+fixed order:
+
+1. `--account=<email>` flag — call-site pin, always wins.
+2. `FRESHELL_GCP_ACCOUNT` env — repo pin, also always wins.
+3. `GCLOUD_IDENT` env — explicit bypass (CI, hermetic tests): used verbatim,
+   no probe, no network.
+4. gcloud-robot probe — `$GCLOUD_ROBOT_HOME/scripts/select-gcloud-identity.sh`
+   picks the first credentialed account passing the lane's live
+   `testIamPermissions` probe. The robot "just works" wherever its key is
+   activated; human accounts keep working untouched.
+5. Ambient gcloud (default when nothing above resolves), announced once on
+   stderr. Set `GCLOUD_ROBOT_REQUIRE=1` to fail closed with guidance instead
+   (hardening / CI).
+
+A resolved identity pins every `--account` the wrappers emit and exports
+`CLOUDSDK_CORE_ACCOUNT`/`CLOUDSDK_CORE_PROJECT` for any unpinned descendants.
+
+## Operator setup
+
+### Prerequisites
+
+- The `gcloud-robot` skill installed for your agent platform (whatever
+  directory holds its `scripts/` — the repo never records that path).
+- The Cloud Resource Manager API enabled on the project (the identity probe's
+  `testIamPermissions` call needs it; any project that has ever touched IAM
+  already has it — `gcloud services enable cloudresourcemanager.googleapis.com
+  --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"`
+  is the one-time, idempotent enable).
+- Point the lanes at it once, e.g. in `~/.bashrc`:
+
+  ```bash
+  export GCLOUD_ROBOT_HOME="<installed gcloud-robot skill directory>"
+  # Prefer the robot when several accounts pass the probe:
+  export GCLOUD_ROBOT_ACCOUNT="gcloud-robot@misc-puttering-project.iam.gserviceaccount.com"
+  ```
+
+### Provision (once per project, human-run — agents never run these)
+
+All commands pin `--account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"` to your operator
+account (export it). All skill scripts are invoked via
+`bash "$GCLOUD_ROBOT_HOME/scripts/<name>.sh"`.
+
+1. Bootstrap the robot (project-level roles):
+
+   ```bash
+   GCLOUD_ROBOT_PROJECT=misc-puttering-project \
+   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor run.developer logging.viewer serviceusage.serviceUsageConsumer" \
+   GCLOUD_ROBOT_ADMIN_ACCOUNT="$GCLOUD_ROBOT_ADMIN_ACCOUNT" \
+   bash "$GCLOUD_ROBOT_HOME/scripts/bootstrap-robot.sh" --name gcloud-robot --activate
+   ```
+
+   This creates the SA, binds the project roles, mints a JSON key under
+   `~/.local/share/gcloud-robot/` (mode 600, never inside
+   `~/.config/gcloud`), prints the key path, and activates it. Record the
+   key location for yourself as
+   `key-path: <printed at provisioning>` (until then this runbook says:
+   not yet minted — operator step).
+
+   Also ensure the Artifact Registry repository exists. The robot holds
+   `artifactregistry.writer` (push) but writer CANNOT create repositories,
+   and the wrappers' create-if-missing path is `|| true`-masked — a missing
+   repo would surface only as a push failure mid-run:
+
+   ```bash
+   gcloud artifacts repositories describe freshell-e2e \
+     --location=us-west1 --project=misc-puttering-project \
+     --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" || \
+   gcloud artifacts repositories create freshell-e2e \
+     --repository-format=docker --location=us-west1 --project=misc-puttering-project \
+     --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"
+
+   # Push/write power is granted on THIS repository only (repository-level
+   # binding), never project-wide — the bearer key must not gain write access
+   # to every current and future repo:
+   gcloud artifacts repositories add-iam-policy-binding freshell-e2e \
+     --location=us-west1 --project=misc-puttering-project \
+     --member="serviceAccount:gcloud-robot@misc-puttering-project.iam.gserviceaccount.com" \
+     --role=roles/artifactregistry.writer \
+     --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" --condition=None
+   ```
+
+2. Scoped grants (bootstrap does NOT do these; skipping them is the classic
+   "probe passes, build 403s" failure):
+
+   ```bash
+   # Staging bucket Cloud Build uploads source to (confirm the name; the
+   # default is <project>_cloudbuild):
+   BUCKET="$(gcloud storage buckets list --project=misc-puttering-project \
+       --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" --format='value(name)' | grep cloudbuild)"
+   for role in roles/storage.objectAdmin roles/storage.legacyBucketReader; do
+     gcloud storage buckets add-iam-policy-binding "gs://$BUCKET" \
+       --member="serviceAccount:gcloud-robot@misc-puttering-project.iam.gserviceaccount.com" \
+       --role="$role" \
+       --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" --condition=None
+   done
+
+   # actAs on the default build/run identities. Cloud Run jobs execute as the
+   # project default compute SA, so creating jobs requires actAs on it. Cloud
+   # Build's default execution identity is DISCOVERED, not assumed: on older
+   # projects it is the legacy <number>@cloudbuild.gserviceaccount.com
+   # (Google-owned, accepts NO bindings — skip it), on newer ones the compute
+   # default SA. (actAs beyond this is only needed when a build config pins
+   # serviceAccount: — docker/cloud-run/cloudbuild.yaml pins none.)
+   PROJECT_NUMBER=$(gcloud projects describe misc-puttering-project \
+     --format='value(projectNumber)' --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT")
+   BUILD_SA="$(gcloud builds get-default-service-account --project=misc-puttering-project \
+     --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" | grep -oE '[A-Za-z0-9._-]+@[A-Za-z0-9.-]+' | head -1)"
+   for sa in "${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" ${BUILD_SA:+"$BUILD_SA"}; do
+     case "$sa" in
+       *@cloudbuild.gserviceaccount.com) echo "skipping $sa (legacy Cloud Build SA accepts no IAM bindings)"; continue ;;
+     esac
+     gcloud iam service-accounts add-iam-policy-binding "$sa" \
+       --member="serviceAccount:gcloud-robot@misc-puttering-project.iam.gserviceaccount.com" \
+       --role=roles/iam.serviceAccountUser \
+       --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" --condition=None
+   done
+   ```
+
+3. Verify as the robot. Read-only probes retry through IAM propagation lag;
+   a failure that persists past the retries names the missing grant.
+
+   ```bash
+   # For a quick pre-flight use GCLOUD_ROBOT_RETRIES=2 GCLOUD_ROBOT_RETRY_SLEEP=2,
+   # then unset them for the real run.
+   GCLOUD_ROBOT_ACCOUNT=gcloud-robot@misc-puttering-project.iam.gserviceaccount.com \
+   GCLOUD_ROBOT_PROJECT=misc-puttering-project \
+   GCLOUD_ROBOT_PROBE_PERMISSION=cloudbuild.builds.create \
+   GCLOUD_ROBOT_KEY_FILE=<key path printed by bootstrap> \
+   bash "$GCLOUD_ROBOT_HOME/scripts/verify-as-robot.sh" \
+     --probe "gcloud artifacts repositories describe freshell-e2e --location=us-west1 --project=misc-puttering-project" \
+     --probe "gcloud artifacts docker images describe us-west1-docker.pkg.dev/misc-puttering-project/freshell-e2e/freshell-e2e:latest --project=misc-puttering-project" \
+     --probe "gcloud run jobs list --region=us-west1 --project=misc-puttering-project --limit=1" \
+     --probe "gcloud builds list --project=misc-puttering-project --limit=1"
+   ```
+
+   The wrappers read execution logs via `gcloud beta run jobs executions logs
+   read ... || true`, which masks a missing `roles/logging.viewer` quietly.
+   When an execution exists, list a real log read as an explicit probe too:
+   `--probe "gcloud beta run jobs executions logs read <execution-name> --project=misc-puttering-project --region=us-west1"`.
+
+   Read probes alone do NOT prove the lane: they skip the scoped bucket
+   grants, job create/delete, actAs, and the per-execution overrides the
+   vitest lane uses. Finish verification with ONE REAL LANE SMOKE as the
+   robot (~$0.02; small test file):
+
+   ```bash
+   GCLOUD_IDENT=gcloud-robot@misc-puttering-project.iam.gserviceaccount.com \
+     bash scripts/vitest-cloud.sh run --cloud --config=default --shards=1 \
+       test/unit/lib/pane-utils.test.ts
+   ```
+
+   Expected on success: `All tasks completed successfully.` A 403 names the
+   missing grant in its error message — add the smallest covering grant
+   (`bootstrap-robot.sh --no-key` updates roles without touching keys), then
+   re-verify and re-smoke. Only after the probes AND the smoke pass is the
+   repo "provisioned and verified".
+
+4. Done. `npm run test:cloud` / `npm run test:e2e:cloud` now select the robot
+   automatically wherever its key is activated; no `.env` or repo config
+   exists for this (`.env.example` is server-runtime config and deliberately
+   carries no cloud-lane knobs).
+
+### Rotate (standing cadence — suggest quarterly, and after any suspicion)
+
+1. Mint + activate a new key. Re-supply the CURRENT role list exactly —
+   `bootstrap-robot.sh` re-applies it verbatim and bindings are additive-only:
+
+   ```bash
+   GCLOUD_ROBOT_PROJECT=misc-puttering-project \
+   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor run.developer logging.viewer serviceusage.serviceUsageConsumer" \
+   GCLOUD_ROBOT_ADMIN_ACCOUNT="$GCLOUD_ROBOT_ADMIN_ACCOUNT" \
+   bash "$GCLOUD_ROBOT_HOME/scripts/bootstrap-robot.sh" --rekey --activate
+   ```
+
+2. Prove the real lane works as the robot (verify block above with the new
+   key path).
+3. Delete the OLD key id in IAM (list with `--managed-by=user`, pick the row
+   whose id matches the old key file's `private_key_id`):
+
+   ```bash
+   gcloud iam service-accounts keys list --managed-by=user \
+     --iam-account=gcloud-robot@misc-puttering-project.iam.gserviceaccount.com \
+     --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"
+   gcloud iam service-accounts keys delete <OLD_KEY_ID> \
+     --iam-account=gcloud-robot@misc-puttering-project.iam.gserviceaccount.com \
+     --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"
+   ```
+
+4. On any other host holding the old key copy, delete the file and run
+   `gcloud auth revoke gcloud-robot@misc-puttering-project.iam.gserviceaccount.com`
+   there (never on the host that just activated the new key).
+
+### Revoke (leak response)
+
+Delete the key in IAM (`keys delete`, above) — that instantly stops all NEW
+token minting from every copy of the key. Tokens already minted stay valid
+for up to an hour (Google-documented; key deletion does not invalidate issued
+credentials). For an immediate total cutoff:
+
+```bash
+gcloud iam service-accounts disable gcloud-robot@misc-puttering-project.iam.gserviceaccount.com \
+  --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"
+```
+
+(Disabling halts all use project-wide until re-enabled — that is the trade
+for immediacy.)
+
+### Monitor (safety net, with honest limits)
+
+- Key lifecycle events: `CreateServiceAccountKey` is a default-on Admin
+  Activity audit event. Create a log-based metric (fully-qualified method
+  name, scoped to the robot) and alert on it in your monitoring stack:
+
+  ```bash
+  gcloud logging metrics create robot-key-creations \
+    --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" \
+    --description="key creation events for the gcloud-robot SA" \
+    --log-filter='protoPayload.methodName="google.iam.admin.v1.CreateServiceAccountKey" AND resource.labels.email_id="gcloud-robot@misc-puttering-project.iam.gserviceaccount.com"'
+  ```
+
+- Key usage: `iam.googleapis.com/service_account/key/authn_events_count`
+  (per-`key_id`) is the best available signal — but it is sampled every 600s
+  and data lags up to ~3 hours, so it suits anomaly review and off-hours
+  alerting, not instant paging. Rotation remains the control that holds when
+  logs are blind.
+
+### Troubleshooting
+
+- Probe passes but `gcloud builds submit` 403s → the actAs grants (step 2).
+- Cloud Build dies resolving source/logs (`storage.buckets.get` 403) → the
+  bucket-scoped `roles/storage.legacyBucketReader` (step 2); object roles
+  alone never carry bucket metadata reads.
+- Push 403s or the run logs "Creating Artifact Registry repository" then
+  fails → step 1's repo-exists check was skipped: writer cannot create
+  repositories. Run the describe/create block from provisioning.
+- "Where did build logs go?" / "submit doesn't stream anymore" → by design:
+  `options.logging: CLOUD_LOGGING_ONLY` puts logs in Cloud Logging (the
+  robot's `logging.viewer` covers reads; no project-wide viewer grant), and
+  this mode does not stream during submit. Builds complete normally; read
+  logs with `gcloud builds log <build-id> --project=misc-puttering-project`.
+- A grant that definitely exists 403s for the first minutes → IAM
+  propagation lag; the verifier's retries (12 × 30s default) absorb it.
+- A lane prints the ambient-fallback note and then gcloud's
+  "Reauthentication failed" → the lane fell back to ambient gcloud: the
+  robot is not provisioned (or not activated) on this machine. Provision
+  (above) or re-login interactively; both work, the point is the robot
+  cannot be culled.
+
+### CI
+
+No GitHub Actions workflow touches GCP (verified by survey); keep it that
+way. If CI ever needs GCP, use Workload Identity Federation (keyless) —
+never a JSON key in CI.

--- a/docs/plans/2026-08-22-gcloud-robot-conversion.md
+++ b/docs/plans/2026-08-22-gcloud-robot-conversion.md
@@ -87,20 +87,32 @@ Exact project-wide constraints every task must honor:
 - **Role set (documented, human-applied)** for project
   `misc-puttering-project`, robot `gcloud-robot`: project-level
   `roles/cloudbuild.builds.editor`, `roles/artifactregistry.writer`,
-  `roles/run.developer`, `roles/run.jobsExecutor`, `roles/run.viewer`,
-  `roles/logging.viewer`; bucket-scoped `roles/storage.objectAdmin` +
-  `roles/storage.legacyBucketReader` on the Cloud Build staging bucket
-  (default `misc-puttering-project_cloudbuild`, operator confirms);
-  `roles/iam.serviceAccountUser` (actAs) on the project's default compute
-  service account (`<projectNumber>-compute@developer.gserviceaccount.com`),
-  plus — ONLY IF the project's Cloud Build default service account
-  (`gcloud builds get-default-service-account`) is an identity the project
-  controls — actAs on that identity too (the LEGACY Cloud Build SA
+  `roles/run.developer`, `roles/logging.viewer`; bucket-scoped
+  `roles/storage.objectAdmin` + `roles/storage.legacyBucketReader` on the
+  Cloud Build staging bucket (default `misc-puttering-project_cloudbuild`,
+  operator confirms); `roles/iam.serviceAccountUser` (actAs) on the project's
+  default compute service account
+  (`<projectNumber>-compute@developer.gserviceaccount.com`), plus — ONLY IF
+  the project's Cloud Build default service account (`gcloud builds
+  get-default-service-account`) is an identity the project controls — actAs
+  on that identity too (the LEGACY Cloud Build SA
   `<projectNumber>@cloudbuild.gserviceaccount.com` is Google-owned and
-  accepts no bindings, and `service-<projectNumber>@gcp-sa-cloudbuild.iam.gserviceaccount.com`
-  is the service AGENT, never a build-execution identity — grant nothing on
-  either). NO `roles/serviceusage.serviceUsageConsumer` (not justified by the
-  surface).
+  accepts no bindings, and
+  `service-<projectNumber>@gcp-sa-cloudbuild.iam.gserviceaccount.com` is the
+  service AGENT, never a build-execution identity — grant nothing on either).
+  NO `roles/serviceusage.serviceUsageConsumer` (not justified by the surface).
+  Role-set reasoning, verified against the official role permission lists
+  (review round-1 remediation): `roles/run.developer` subsumes
+  `run.invoker`/`run.jobsExecutor`/`run.viewer` for job lanes and is the
+  tightest built-in that also carries `run.jobs.runWithOverrides` — REQUIRED
+  because the vitest wrapper's `run jobs execute --tasks/--task-timeout/
+  --update-env-vars` supplies per-execution overrides. `run.jobsExecutor`,
+  `run.jobsExecutorWithOverrides`, `run.invoker`, and `run.viewer` are
+  deliberately NOT in the list (each is either too narrow or redundant under
+  developer). The wrapper's create-if-missing Artifact Registry path
+  (`artifacts repositories create`) is NOT granted
+  (`artifactregistry.repositories.create` would need repoAdmin): the operator
+  checklist ensures the repository exists instead.
 - **Files explicitly out of scope (untouched, with reason):**
   `scripts/run-standard-tests.ts` (it `execFileSync`s `vitest-cloud.sh` with
   inherited env; identity resolution lives inside the wrapper so the
@@ -139,8 +151,16 @@ Exact project-wide constraints every task must honor:
   Build default is either the legacy `PROJECT_NUMBER@cloudbuild.gserviceaccount.com`
   (Google-owned, accepts no bindings) or, on newer setups, the compute default
   SA; the runbook discovers it via `gcloud builds get-default-service-account`
-  rather than assuming. Plan content updated accordingly (role-set Global
-  Constraint, Task 3 runbook step 2).
+  rather than assuming. Plan content updated accordingly.
+- **A6** (raised by plan-review round 1; RESOLVED against the official Cloud
+  Run IAM role permission lists): the vitest lane's per-execution overrides
+  (`run jobs execute --tasks/--task-timeout/--update-env-vars`) require
+  `run.jobs.runWithOverrides`; `roles/run.developer` carries it and subsumes
+  `run.invoker`/`run.jobsExecutor`/`run.jobsExecutorWithOverrides`/
+  `run.viewer` for these lanes, so the role set is developer + logging.viewer
+  only (plus the build/AR roles). Also verified: `artifactregistry.writer`
+  cannot create repositories (`repositories.create` absent) — the operator
+  checklist ensures the AR repo exists instead of granting repoAdmin.
 
 These are properties of external contracts; the plan's tasks do not depend on
 any other unproven claim. If A1/A2 invalidate a probe permission, swap the
@@ -183,11 +203,13 @@ wrapper-level block arrives in Task 2.
   `GCLOUD_ROBOT_HOME`, `GCLOUD_ROBOT_REQUIRE`, `GCLOUD_ROBOT_PROJECT`,
   `GCLOUD_ROBOT_PROBE_PERMISSION`).
 - Produces: `resolve_gcp_identity` (verbatim skill block) and
-  `freshell_resolve_cloud_identity <probe-permission>` — bridges the caller's
+  `freshell_resolve_cloud_identity <probe-permission>` — returns 0 untouched
+  when the caller's `GCP_ACCOUNT` is already pinned (rung 1 never touches the
+  network or strict-mode failure paths); otherwise bridges the caller's
   `GCP_PROJECT` into `GCLOUD_ROBOT_PROJECT`, defaults
-  `GCLOUD_ROBOT_PROBE_PERMISSION` from `$1`, then applies a resolved
-  `GCLOUD_IDENT` into the caller's `GCP_ACCOUNT` pin var when it is empty.
-  Used by both wrappers in Task 2.
+  `GCLOUD_ROBOT_PROBE_PERMISSION` from `$1`, resolves, applies a resulting
+  `GCLOUD_IDENT` into `GCP_ACCOUNT`, and PROPAGATES the ladder's failure
+  status. Used by both wrappers in Task 2.
 
 - [ ] **Step 1: Write the failing behavioral test**
 
@@ -249,7 +271,7 @@ printf '%s\n' "${SELECTOR_ACCOUNT:-}"
 FAKE_SELECTOR
 chmod +x "$FAKE_HOME/scripts/select-gcloud-identity.sh"
 
-SELECTOR_MARKER="$TDIR/selector-ran"
+export SELECTOR_MARKER="$TDIR/selector-ran"
 LADDER_STDERR="$TDIR/stderr"
 
 # Reads one "key=value" outcome line out of a run_ladder transcript.
@@ -257,15 +279,28 @@ field() {
   grep "^$2=" <<< "$1" | head -1 | cut -d= -f2-
 }
 
-# Runs the identity ladder in a FRESH bash process with exactly the env the
-# caller exported. Stdout: rc/ident/account/pin outcome lines. Stderr from
-# the ladder lands in $LADDER_STDERR. Resets the selector markers per run.
-# Always returns 0: the ladder's own rc is reported as the rc= outcome line,
-# so a crash in the subshell shows up as missing lines, not a set -e abort.
+# Identity/ladder knobs scrubbed out of the harness environment before every
+# ladder/wrapper invocation — an operator machine may legitimately export any
+# of these (FRESHELL_GCP_ACCOUNT, GCLOUD_ROBOT_REQUIRE=1, a real
+# GCLOUD_ROBOT_HOME, ...), and any leak would silently change which rung a
+# check exercises. Every ladder/wrapper call below applies this list, then
+# layers only the knobs the check intends.
+SCRUB=(-u GCLOUD_IDENT -u GCLOUD_ROBOT_HOME -u GCLOUD_ROBOT_REQUIRE
+       -u GCLOUD_ROBOT_PROJECT -u GCLOUD_ROBOT_PROBE_PERMISSION
+       -u FRESHELL_GCP_ACCOUNT -u CLOUDSDK_CORE_ACCOUNT -u CLOUDSDK_CORE_PROJECT
+       -u SELECTOR_ACCOUNT -u SELECTOR_FAIL)
+
+# Runs the identity ladder in a FRESH bash process over the scrubbed env;
+# extra KEY=VALUE arguments are the check's intended knobs, forwarded to env.
+# Stdout: rc/ident/account/pin outcome lines. Stderr from the ladder lands in
+# $LADDER_STDERR. Resets the selector markers per run. Always returns 0: the
+# ladder's own rc is reported as the rc= outcome line, so a subshell crash
+# shows up as missing lines, not a set -e abort.
 run_ladder() {
-  # $1 = probe-permission argument handed to freshell_resolve_cloud_identity
+  local probe="$1"
+  shift
   rm -f "$LADDER_STDERR" "$SELECTOR_MARKER" "$SELECTOR_MARKER.env"
-  env bash -c '
+  env "${SCRUB[@]}" "$@" bash -c '
     set -u
     . "$1"
     GCP_PROJECT="misc-puttering-project"
@@ -275,21 +310,20 @@ run_ladder() {
     printf "ident=%s\n" "${GCLOUD_IDENT:-}"
     printf "account=%s\n" "${CLOUDSDK_CORE_ACCOUNT:-}"
     printf "pin=%s\n" "$GCP_ACCOUNT"
-  ' _ "$HELPER" "$1" 2>"$LADDER_STDERR" || true
+  ' _ "$HELPER" "$probe" 2>"$LADDER_STDERR" || true
 }
 
 # --- Check A: sourcing is silent and side-effect-free ---------------------
 # help/local lanes source the helper unconditionally, so the source itself
 # must never print, resolve, or require any env.
-SRC_OUT=$(env -u GCLOUD_IDENT -u GCLOUD_ROBOT_HOME bash -c \
+SRC_OUT=$(env "${SCRUB[@]}" bash -c \
   'set -u; . "$1" && declare -F resolve_gcp_identity >/dev/null && declare -F freshell_resolve_cloud_identity >/dev/null && echo sourced-ok' \
   _ "$HELPER" 2>&1 || true)
 check "sourcing the helper defines both functions with zero output" \
   bash -c '[ "$1" = "sourced-ok" ]' _ "$SRC_OUT"
 
 # --- Check B: rung 2 — explicit GCLOUD_IDENT bypass, no network -----------
-OUT=$(export GCLOUD_IDENT="fake-bypass@example.invalid" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER; \
-      run_ladder "run.jobs.run")
+OUT=$(run_ladder "run.jobs.run" GCLOUD_IDENT="fake-bypass@example.invalid" GCLOUD_ROBOT_HOME="$FAKE_HOME")
 check "rung-2 bypass: GCLOUD_IDENT flows to pin + exports, selector never runs, silent" \
   bash -c '
     [ "$1" = "0" ] && [ "$2" = "fake-bypass@example.invalid" ] &&
@@ -299,9 +333,7 @@ check "rung-2 bypass: GCLOUD_IDENT flows to pin + exports, selector never runs, 
       "$SELECTOR_MARKER" "$LADDER_STDERR"
 
 # --- Check C: rung 3 — probe selects an account, env contract forwarded ---
-OUT=$(unset GCLOUD_IDENT; \
-      export GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER SELECTOR_ACCOUNT="gcloud-robot@example.invalid"; \
-      run_ladder "run.jobs.run")
+OUT=$(run_ladder "run.jobs.run" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_ACCOUNT="gcloud-robot@example.invalid")
 check "rung-3 probe: selector account adopted, project+probe env forwarded, silent" \
   bash -c '
     [ "$1" = "0" ] && [ "$2" = "gcloud-robot@example.invalid" ] &&
@@ -312,9 +344,7 @@ check "rung-3 probe: selector account adopted, project+probe env forwarded, sile
       "$SELECTOR_MARKER" "$LADDER_STDERR"
 
 # --- Check D: probe finds nothing — quiet ambient note, exit 0 ------------
-OUT=$(unset GCLOUD_IDENT; \
-      export GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER SELECTOR_FAIL=1; \
-      run_ladder "run.jobs.run")
+OUT=$(run_ladder "run.jobs.run" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_FAIL=1)
 check "probe-empty: one ambient-fallback stderr note, no identity, exit 0" \
   bash -c '
     [ "$1" = "0" ] && [ -z "$2" ] && [ -z "$3" ] && [ -z "$4" ] &&
@@ -325,8 +355,7 @@ check "probe-empty: one ambient-fallback stderr note, no identity, exit 0" \
       "$LADDER_STDERR" "$SELECTOR_MARKER"
 
 # --- Check E: skill absent — single quiet ambient note, exit 0 ------------
-OUT=$(unset GCLOUD_IDENT GCLOUD_ROBOT_HOME; export SELECTOR_MARKER; \
-      run_ladder "run.jobs.run")
+OUT=$(run_ladder "run.jobs.run")
 check "skill-absent: exactly one ambient-fallback stderr note, exit 0" \
   bash -c '
     [ "$1" = "0" ] &&
@@ -336,17 +365,14 @@ check "skill-absent: exactly one ambient-fallback stderr note, exit 0" \
   ' _ "$(field "$OUT" rc)" "$LADDER_STDERR" "$SELECTOR_MARKER"
 
 # --- Check F: strict mode fails closed when the skill is absent -----------
-OUT=$(unset GCLOUD_IDENT GCLOUD_ROBOT_HOME; export GCLOUD_ROBOT_REQUIRE=1; \
-      run_ladder "run.jobs.run")
+OUT=$(run_ladder "run.jobs.run" GCLOUD_ROBOT_REQUIRE=1)
 check "GCLOUD_ROBOT_REQUIRE=1, skill absent: nonzero rc + strict-mode guidance" \
   bash -c '
     [ "$1" != "0" ] && grep -q "strict mode" "$2" && [ -z "$3" ]
   ' _ "$(field "$OUT" rc)" "$LADDER_STDERR" "$(field "$OUT" account)"
 
 # --- Check G: strict mode fails closed when the probe finds nothing -------
-OUT=$(unset GCLOUD_IDENT; \
-      export GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER SELECTOR_FAIL=1 GCLOUD_ROBOT_REQUIRE=1; \
-      run_ladder "run.jobs.run")
+OUT=$(run_ladder "run.jobs.run" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_FAIL=1 GCLOUD_ROBOT_REQUIRE=1)
 check "GCLOUD_ROBOT_REQUIRE=1, probe empty: nonzero rc + probe failure named" \
   bash -c '
     [ "$1" != "0" ] && grep -q "no identity passes the probe" "$2"
@@ -354,8 +380,7 @@ check "GCLOUD_ROBOT_REQUIRE=1, probe empty: nonzero rc + probe failure named" \
 
 # --- Check H: idempotent — a second resolve never re-runs the selector ----
 rm -f "$SELECTOR_MARKER"
-OUT=$(unset GCLOUD_IDENT; \
-      export GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER SELECTOR_ACCOUNT="once@example.invalid"; \
+OUT=$(env "${SCRUB[@]}" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_ACCOUNT="once@example.invalid" \
       bash -c '
         set -u
         . "$1"
@@ -371,24 +396,28 @@ check "two resolves in one process run the selector exactly once" \
   ' _ "$(field "$OUT" ident)" "$SELECTOR_MARKER"
 
 # --- Check I: operator-pinned GCLOUD_ROBOT_PROJECT survives the bridge ----
-OUT=$(unset GCLOUD_IDENT; \
-      export GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER SELECTOR_ACCOUNT="robot@example.invalid" \
-             GCLOUD_ROBOT_PROJECT="other-project" GCLOUD_ROBOT_PROBE_PERMISSION="custom.perm.check"; \
-      run_ladder "run.jobs.run")
+OUT=$(run_ladder "run.jobs.run" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_ACCOUNT="robot@example.invalid" \
+      GCLOUD_ROBOT_PROJECT="other-project" GCLOUD_ROBOT_PROBE_PERMISSION="custom.perm.check")
 check "operator overrides: project + probe pass through to the selector verbatim" \
   bash -c '
     grep -q "project=other-project probe=custom.perm.check" "$2.env" &&
     [ "$1" = "robot@example.invalid" ]
   ' _ "$(field "$OUT" ident)" "$SELECTOR_MARKER"
 
-# --- Check J: rung 1 — a pinned GCP_ACCOUNT is never overwritten ----------
-OUT=$(unset GCLOUD_ROBOT_HOME; \
-      export GCLOUD_IDENT="ident@example.invalid" FRESHELL_GCP_ACCOUNT="pinned@example.invalid"; \
-      run_ladder "run.jobs.run")
-check "explicit account pin wins over the ladder result (rung 1)" \
+# --- Check J: rung 1 — a pinned GCP_ACCOUNT short-circuits the ladder -----
+# A pin must win BEFORE any ladder work: no selector run (even with
+# GCLOUD_ROBOT_HOME + GCLOUD_IDENT present), no CLOUDSDK exports, no stderr,
+# and strict mode may not fail a pinned call. The ident transcript line still
+# echoes the inherited env value — it is simply never consulted.
+OUT=$(run_ladder "run.jobs.run" GCLOUD_IDENT="ident@example.invalid" \
+      FRESHELL_GCP_ACCOUNT="pinned@example.invalid" GCLOUD_ROBOT_HOME="$FAKE_HOME" \
+      GCLOUD_ROBOT_REQUIRE=1)
+check "explicit account pin wins BEFORE the ladder (no probe, no exports, silent)" \
   bash -c '
-    [ "$1" = "pinned@example.invalid" ] && [ "$2" = "ident@example.invalid" ] && [ ! -s "$3" ]
-  ' _ "$(field "$OUT" pin)" "$(field "$OUT" ident)" "$LADDER_STDERR"
+    [ "$1" = "0" ] && [ "$2" = "pinned@example.invalid" ] && [ -z "$3" ] &&
+    [ ! -e "$4" ] && [ ! -s "$5" ]
+  ' _ "$(field "$OUT" rc)" "$(field "$OUT" pin)" "$(field "$OUT" account)" \
+      "$SELECTOR_MARKER" "$LADDER_STDERR"
 
 # WRAPPER-LEVEL-CHECKS-ANCHOR (Task 2 appends here)
 
@@ -417,11 +446,12 @@ marker never appears.)
 - [ ] **Step 3: Add the minimal production implementation**
 
 Create `scripts/lib/gcp-identity.sh` with exactly this content. The drop-in
-block between the BEGIN/END markers is the skill's verbatim text — the
-implementation shown here was composed against
-`~/.claude/skills/gcloud-robot/SKILL.md` §"The identity ladder is fixed"; if
-any drift is suspected at execution time, re-copy the block from that source
-(diff them if uncertain) and keep the repo copy byte-identical:
+block between the BEGIN/END markers is the skill's verbatim text — composed
+against the "identity ladder" section of the operator's installed
+gcloud-robot skill's SKILL.md (located wherever the operator's platform
+keeps installed skills, or via `GCLOUD_ROBOT_HOME` once set — never recorded
+in-commit). If any drift is suspected at execution time, re-copy the block
+from that source and keep the repo copy byte-identical:
 
 ```bash
 #!/usr/bin/env bash
@@ -492,15 +522,23 @@ resolve_gcp_identity() {
 # Requires the caller to provide GCP_PROJECT and GCP_ACCOUNT (possibly
 # empty), matching both cloud wrappers' top-of-file defaults.
 freshell_resolve_cloud_identity() {
+  # rung 1: an existing pin (the wrapper's --account= flag or
+  # FRESHELL_GCP_ACCOUNT) wins outright — skip the ladder ENTIRELY: no
+  # selector, no network, no stderr note, and GCLOUD_ROBOT_REQUIRE=1 must not
+  # fail a deliberately pinned call.
+  if [ -n "${GCP_ACCOUNT:-}" ]; then return 0; fi
   export GCLOUD_ROBOT_PROJECT="${GCLOUD_ROBOT_PROJECT:-${GCP_PROJECT:?GCP_PROJECT must be set before identity resolution}}"
   export GCLOUD_ROBOT_PROBE_PERMISSION="${GCLOUD_ROBOT_PROBE_PERMISSION:-${1:?probe permission argument required}}"
-  resolve_gcp_identity
+  # Propagate the ladder's status: under GCLOUD_ROBOT_REQUIRE=1 a failed
+  # resolve must fail the lane (both wrappers run set -e; the ladder already
+  # printed its guidance).
+  if ! resolve_gcp_identity; then return 1; fi
   # Pinned-call adoption (gcloud-robot skill): a probed identity takes the
-  # pinned --account slot ONLY when nothing pinned one — an operator's
-  # --account= / FRESHELL_GCP_ACCOUNT (rung 1) always wins. With nothing
-  # resolved the pin stays empty and the wrappers omit --account entirely,
-  # letting ambient gcloud apply (the ladder already noted that on stderr).
-  GCP_ACCOUNT="${GCP_ACCOUNT:-${GCLOUD_IDENT:-}}"
+  # pinned --account slot (the pin was empty, per the rung-1 branch above).
+  # With nothing resolved the pin stays empty and the wrappers omit
+  # --account entirely, letting ambient gcloud apply (the ladder already
+  # noted that on stderr).
+  GCP_ACCOUNT="${GCLOUD_IDENT:-}"
 }
 ```
 
@@ -843,10 +881,17 @@ reset_green() {
   touch "$GREEN_LOG"
 }
 
-# Every --account token observed across a run equals the expected one, and at
-# least one pinned call exists (an empty log proves nothing).
+# Every gcloud invocation that COULD pin an account DID pin this exact one:
+# the accounts log must contain one token per logged gcloud call (the bare
+# `gcloud info` PATH-probe call takes no flags and is excluded), all equal to
+# the expected value, and non-empty — an omit/present mix or an empty log
+# both fail.
 accounts_all_equal() {
-  [ -s "$GREEN_LOG.accounts" ] && \
+  [ -s "$GREEN_LOG.accounts" ] || return 1
+  local calls tokens
+  calls=$(grep '^GCLOUD_ARGS:' "$GREEN_LOG" | grep -vc '^GCLOUD_ARGS: info ')
+  tokens=$(wc -l < "$GREEN_LOG.accounts")
+  [ "$calls" -gt 0 ] && [ "$calls" -eq "$tokens" ] && \
     [ "$(sort -u "$GREEN_LOG.accounts" | wc -l)" = "1" ] && \
     [ "$(sort -u "$GREEN_LOG.accounts" | head -1)" = "--account=$1" ]
 }
@@ -854,8 +899,8 @@ accounts_all_equal() {
 # --- W1: e2e rung 2 — GCLOUD_IDENT drives every pinned call ----------------
 reset_green
 W1_ERR="$TDIR/w1.err"
-W1_OUT=$(env PATH="$GTDIR:$PATH" \
-         GCLOUD_IDENT="$RUNG2_IDENT" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER="$SELECTOR_MARKER" \
+W1_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+         GCLOUD_IDENT="$RUNG2_IDENT" GCLOUD_ROBOT_HOME="$FAKE_HOME" \
          "$WRAPPER_E2E" run --cloud --shards=1 2>"$W1_ERR") && W1_RC=0 || W1_RC=$?
 check "W1 e2e rung-2: run succeeds with GCLOUD_IDENT pinned on every call, selector untouched, silent" \
   bash -c '
@@ -867,30 +912,34 @@ check "W1 e2e rung-2: every gcloud call pinned to the GCLOUD_IDENT value" \
 check "W1 e2e rung-2: selector never ran and no hardcoded human account appeared" \
   bash -c '[ ! -e "$1" ] && ! grep -q "dan@danshapiro" "$2"' _ "$SELECTOR_MARKER" "$GREEN_LOG"
 
-# --- W2: e2e rung 1 — --account= beats FRESHELL_GCP_ACCOUNT > GCLOUD_IDENT -
+# --- W2: e2e rung 1 — a flag pin wins BEFORE the ladder runs --------------
 reset_green
-W2_OUT=$(env PATH="$GTDIR:$PATH" \
-         GCLOUD_IDENT="$RUNG2_IDENT" FRESHELL_GCP_ACCOUNT="$ENV_ACCOUNT" \
+W2_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+         GCLOUD_IDENT="$RUNG2_IDENT" FRESHELL_GCP_ACCOUNT="$ENV_ACCOUNT" GCLOUD_ROBOT_HOME="$FAKE_HOME" \
          "$WRAPPER_E2E" run --cloud --shards=1 --account="$FLAG_ACCOUNT" 2>/dev/null) && W2_RC=0 || W2_RC=$?
 check "W2 e2e rung-1: --account= flag wins over env and ladder" \
   bash -c '[ "$1" = "0" ]' _ "$W2_RC"
 check "W2 e2e rung-1: every gcloud call pinned to the flag value" \
   accounts_all_equal "$FLAG_ACCOUNT"
+check "W2 e2e rung-1: the ladder never ran for a pinned call (no probe, even with HOME set)" \
+  bash -c '[ ! -e "$1" ]' _ "$SELECTOR_MARKER"
 
-# --- W3: e2e rung 1b — FRESHELL_GCP_ACCOUNT beats GCLOUD_IDENT -------------
+# --- W3: e2e rung 1b — FRESHELL_GCP_ACCOUNT wins BEFORE the ladder --------
 reset_green
-W3_OUT=$(env PATH="$GTDIR:$PATH" \
-         GCLOUD_IDENT="$RUNG2_IDENT" FRESHELL_GCP_ACCOUNT="$ENV_ACCOUNT" \
+W3_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+         GCLOUD_IDENT="$RUNG2_IDENT" FRESHELL_GCP_ACCOUNT="$ENV_ACCOUNT" GCLOUD_ROBOT_HOME="$FAKE_HOME" \
          "$WRAPPER_E2E" run --cloud --shards=1 2>/dev/null) && W3_RC=0 || W3_RC=$?
 check "W3 e2e env-pin: FRESHELL_GCP_ACCOUNT wins over the ladder" \
   bash -c '[ "$1" = "0" ]' _ "$W3_RC"
 check "W3 e2e env-pin: every gcloud call pinned to the env value" \
   accounts_all_equal "$ENV_ACCOUNT"
+check "W3 e2e env-pin: the ladder never ran for a pinned call" \
+  bash -c '[ ! -e "$1" ]' _ "$SELECTOR_MARKER"
 
 # --- W4: e2e rung 3 — the probe result takes the pinned slot ---------------
 reset_green
-W4_OUT=$(env -u GCLOUD_IDENT -u FRESHELL_GCP_ACCOUNT PATH="$GTDIR:$PATH" \
-         GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER="$SELECTOR_MARKER" SELECTOR_ACCOUNT="$RUNG3_ROBOT" \
+W4_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+         GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_ACCOUNT="$RUNG3_ROBOT" \
          "$WRAPPER_E2E" run --cloud --shards=1 2>/dev/null) && W4_RC=0 || W4_RC=$?
 check "W4 e2e rung-3: probed identity pins every call; selector ran once w/ lane probe" \
   bash -c '
@@ -904,7 +953,7 @@ check "W4 e2e rung-3: every gcloud call pinned to the probed robot" \
 # --- W5: e2e rung 4 — nothing resolves: --account omitted, one note ---------
 reset_green
 W5_ERR="$TDIR/w5.err"
-W5_OUT=$(env -u GCLOUD_IDENT -u GCLOUD_ROBOT_HOME -u FRESHELL_GCP_ACCOUNT \
+W5_OUT=$(env "${SCRUB[@]}" \
          PATH="$GTDIR:$PATH" "$WRAPPER_E2E" run --cloud --shards=1 2>"$W5_ERR") && W5_RC=0 || W5_RC=$?
 check "W5 e2e ambient: run succeeds, --account omitted everywhere, one ambient note" \
   bash -c '
@@ -917,8 +966,8 @@ check "W5 e2e ambient: run succeeds, --account omitted everywhere, one ambient n
 # --- W6: vitest parity — rung-2 pin and rung-4 omission -------------------
 reset_green
 W6A_ERR="$TDIR/w6a.err"
-W6A_OUT=$(env PATH="$GTDIR:$PATH" \
-          GCLOUD_IDENT="$RUNG2_IDENT" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER="$SELECTOR_MARKER" \
+W6A_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+          GCLOUD_IDENT="$RUNG2_IDENT" GCLOUD_ROBOT_HOME="$FAKE_HOME" \
           "$WRAPPER_VITEST" run --cloud --config=default --shards=2 2>"$W6A_ERR") && W6A_RC=0 || W6A_RC=$?
 check "W6a vitest rung-2: succeeds, every call pinned to GCLOUD_IDENT, selector untouched" \
   bash -c '
@@ -930,7 +979,7 @@ check "W6a vitest rung-2: every gcloud call pinned to the GCLOUD_IDENT value" \
 
 reset_green
 W6B_ERR="$TDIR/w6b.err"
-W6B_OUT=$(env -u GCLOUD_IDENT -u GCLOUD_ROBOT_HOME -u FRESHELL_GCP_ACCOUNT \
+W6B_OUT=$(env "${SCRUB[@]}" \
           PATH="$GTDIR:$PATH" "$WRAPPER_VITEST" run --cloud --config=default --shards=2 2>"$W6B_ERR") && W6B_RC=0 || W6B_RC=$?
 check "W6b vitest ambient: run succeeds, --account omitted everywhere, one ambient note" \
   bash -c '
@@ -944,12 +993,14 @@ check "W6b vitest ambient: run succeeds, --account omitted everywhere, one ambie
 # Each pins GCLOUD_IDENT, so running them under a marker-trap
 # GCLOUD_ROBOT_HOME whose selector would FAIL must leave the marker untouched
 # AND the suites green: no nested wrapper invocation may reach the probe.
+# The scrub keeps any harness-level ladder knobs from leaking in and
+# invalidating the pin experiment.
 for nested in scripts/test/cloud-build.test.sh \
               scripts/test/cloud-exec-id-parse.test.sh \
               scripts/test/cloud-vitest-wrapper.test.sh \
               scripts/test/cloud-run-wrapper.test.sh; do
   rm -f "$SELECTOR_MARKER"
-  env GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER="$SELECTOR_MARKER" SELECTOR_FAIL=1 \
+  env "${SCRUB[@]}" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_FAIL=1 \
     bash "$nested" >"$TDIR/nested.log" 2>&1 && NESTED_RC=0 || NESTED_RC=$?
   check "W7 trap-11: $nested green and probe-free under hostile GCLOUD_ROBOT_HOME" \
     bash -c '[ "$1" = "0" ] && [ ! -e "$2" ]' _ "$NESTED_RC" "$SELECTOR_MARKER"
@@ -975,8 +1026,8 @@ if [ -n "$CLEAN_PATH" ]; then
       lane="${wrapper_pair%%:*}"
       wrapper="${wrapper_pair#*:}"
       rm -f "$SELECTOR_MARKER"
-      HELP_OUT=$(env -u GCLOUD_IDENT -u FRESHELL_GCP_ACCOUNT PATH="$CLEAN_PATH" \
-        GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER="$SELECTOR_MARKER" \
+      HELP_OUT=$(env "${SCRUB[@]}" PATH="$CLEAN_PATH" \
+        GCLOUD_ROBOT_HOME="$FAKE_HOME" \
         "$wrapper" help 2>&1) && HELP_RC=0 || HELP_RC=$?
       check "W8 $lane help: exit 0, prints usage, no identity activity, silent" \
         bash -c '
@@ -989,8 +1040,8 @@ fi
 
 # --- W9: the vitest local lane never wakes the ladder ----------------------
 rm -f "$SELECTOR_MARKER"
-W9_OUT=$(env -u GCLOUD_IDENT -u FRESHELL_GCP_ACCOUNT \
-         GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER="$SELECTOR_MARKER" \
+W9_OUT=$(env "${SCRUB[@]}" \
+         GCLOUD_ROBOT_HOME="$FAKE_HOME" \
          "$WRAPPER_VITEST" run --local --config=default test/unit/lib/pane-utils.test.ts 2>&1) \
   && W9_RC=0 || W9_RC=$?
 check "W9 vitest --local: runs real local vitest, no selector, no ladder output" \
@@ -1025,13 +1076,28 @@ replacing the `# WRAPPER-LEVEL-CHECKS-ANCHOR (Task 2 appends here)` line.
 Run: `bash scripts/test/cloud-gcp-identity.test.sh`
 
 Expected: FAIL against the not-yet-wired wrappers, with exactly this failure
-profile: W1–W4 and W6a fail because `accounts_all_equal` sees an empty or
-absent accounts log (nothing pins `--account` from `GCLOUD_IDENT`/probe yet);
-W5 and W6b fail because the single `skill not found ... using ambient gcloud`
-stderr note does not exist yet; W10/W11 fail because help documents none of
-the knobs. W7 and W8/W9's silence assertions pass vacuously pre-wiring (no
-ladder exists to trigger the trap); W7's red proof comes in the step-3
-interim run below.
+profile (derived from the wrappers' pre-wiring behavior — they pin the
+hardcoded human account on every flagged call, so the accounts log is FULL
+of `dan@danshapiro.com`, never empty):
+
+- W1 fails its pin assertions (every call is pinned — to the hardcoded
+  human, not the `GCLOUD_IDENT` value; and the no-hardcoded-human grep
+  fires). Its run-success sub-check passes (the green stub run worked
+  before, too).
+- W4 fails (the marker-trap selector never runs pre-wiring — no ladder
+  exists; and the accounts mismatch).
+- W5 and W6b fail (accounts log is NOT absent — calls pin the human — and
+  the ambient-fallback note does not exist).
+- W6a fails (accounts mismatch, as W1).
+- W10/W11 fail (help documents none of the knobs and still names the
+  hardcoded default).
+- W2/W3 PASS pre-wiring and must stay green (flag/env already win — the
+  refactor preserves that; their new "the ladder never ran for a pinned
+  call" assertions pass vacuously pre-wiring and become live after wiring,
+  where they guard the rung-1 short-circuit).
+- W7 and W8/W9's silence assertions pass vacuously pre-wiring (no ladder
+  exists to trigger the trap); W7's red proof is the step-3 interim run
+  below.
 
 - [ ] **Step 3: Add the minimal production implementation — wrapper wiring only**
 
@@ -1104,58 +1170,38 @@ git commit -m "feat(cloud): wire gcloud-robot identity ladder into e2e/vitest cl
 ### Task 3: Operator runbook + AGENTS.md identity sections
 
 Deliverable: `docs/development/gcloud-robot.md` — the operator runbook
-(robot identity, provisioning checklist, verify-as-domain step, rotation,
-revocation, monitoring, both adoption states) — plus the mandatory AGENTS.md
-updates in the two cloud-backend sections.
+(robot identity, provisioning checklist, verification, rotation, revocation,
+monitoring, both adoption states) — plus the mandatory AGENTS.md updates in
+the two cloud-backend sections.
+
+TDD shape: this is a docs-only task and the repo's TDD rule explicitly
+exempts doc changes ("all changes but the most trivial (e.g. doc changes)").
+Round-1 plan review reinforced this: the originally-planned D1–D5 checks
+greped docs for expected phrases/links, which the repo's own test-quality
+bar rules out as behavioral protection, so they were REMOVED — Task 3
+carries no new suite content, and its verification is the review-through
+checklist plus the existing-suite regression sweep below. The identity
+suite's trailing `# DOC-CHECKS-ANCHOR (Task 3 appends here)` line from
+Task 2 is deleted by this task (nothing ever appended).
 
 **Files:**
 - Create: `docs/development/gcloud-robot.md`
 - Modify: `AGENTS.md` (one Identity paragraph appended to each of
   `### Vitest Test Backend (Cloud Run Jobs)` and `### E2E Test Backend
   (Cloud Run Jobs)`)
-- Modify: `scripts/test/cloud-gcp-identity.test.sh` (append the doc-wiring
-  checks at `DOC-CHECKS-ANCHOR`)
+- Modify: `scripts/test/cloud-gcp-identity.test.sh` (delete the now-dead
+  `# DOC-CHECKS-ANCHOR (Task 3 appends here)` line only)
 
 **Interfaces:**
 - Consumes: provisioning content from the gcloud-robot skill's
   `references/provisioning.md` (role choice, scoped-grant command shapes,
-  rotation/revocation/monitoring contracts).
+  rotation/revocation/monitoring contracts) and the corrected role set from
+  Global Constraints (verified during review remediation).
 - Produces: the runbook the wrappers' `--help` text and AGENTS.md point at.
 
-- [ ] **Step 1: Write the failing behavioral test**
+- [ ] **Step 1: Author the docs**
 
-Append to `scripts/test/cloud-gcp-identity.test.sh`, replacing the
-`# DOC-CHECKS-ANCHOR (Task 3 appends here)` line:
-
-```bash
-# --- D1-D5: doc wiring -----------------------------------------------------
-# Pins the wiring between code and docs (existence, the two-state contract
-# agents must not debug away, the discovery knob, and the AGENTS.md link) —
-# the same content-pin style cloud-build.test.sh uses for help surfaces. It
-# deliberately does not gate prose.
-RUNBOOK="$ROOT/docs/development/gcloud-robot.md"
-check "D1 operator runbook exists" test -f "$RUNBOOK"
-check "D2 runbook names the wired-not-provisioned adoption state" \
-  bash -c 'grep -q "wired but not yet provisioned" "$1"' _ "$RUNBOOK"
-check "D3 runbook names the provisioned-and-verified adoption state" \
-  bash -c 'grep -q "provisioned and verified" "$1"' _ "$RUNBOOK"
-check "D4 runbook documents the GCLOUD_ROBOT_HOME discovery knob" \
-  bash -c 'grep -q "GCLOUD_ROBOT_HOME" "$1"' _ "$RUNBOOK"
-check "D5 AGENTS.md links the runbook" \
-  bash -c 'grep -q "docs/development/gcloud-robot.md" "$1"' _ "$ROOT/AGENTS.md"
-```
-
-- [ ] **Step 2: Run the test and verify the intended failure**
-
-Run: `bash scripts/test/cloud-gcp-identity.test.sh`
-
-Expected: FAIL — D1 (`docs/development/gcloud-robot.md` missing), D2–D4
-(grep against a missing file), and D5 (AGENTS.md has no such link yet). All
-pre-existing checks stay green.
-
-- [ ] **Step 3: Add the minimal production implementation**
-
-**3a.** Create `docs/development/gcloud-robot.md` with exactly this content:
+**1a.** Create `docs/development/gcloud-robot.md` with exactly this content:
 
 ````markdown
 # gcloud-robot identity for cloud test lanes
@@ -1247,7 +1293,7 @@ account (export it). All skill scripts are invoked via
 
    ```bash
    GCLOUD_ROBOT_PROJECT=misc-puttering-project \
-   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor artifactregistry.writer run.developer run.jobsExecutor run.viewer logging.viewer" \
+   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor artifactregistry.writer run.developer logging.viewer" \
    GCLOUD_ROBOT_ADMIN_ACCOUNT="$GCLOUD_ROBOT_ADMIN_ACCOUNT" \
    bash "$GCLOUD_ROBOT_HOME/scripts/bootstrap-robot.sh" --name gcloud-robot --activate
    ```
@@ -1258,6 +1304,20 @@ account (export it). All skill scripts are invoked via
    key location for yourself as
    `key-path: <printed at provisioning>` (until then this runbook says:
    not yet minted — operator step).
+
+   Also ensure the Artifact Registry repository exists. The robot holds
+   `artifactregistry.writer` (push) but writer CANNOT create repositories,
+   and the wrappers' create-if-missing path is `|| true`-masked — a missing
+   repo would surface only as a push failure mid-run:
+
+   ```bash
+   gcloud artifacts repositories describe freshell-e2e \
+     --location=us-west1 --project=misc-puttering-project \
+     --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" || \
+   gcloud artifacts repositories create freshell-e2e \
+     --repository-format=docker --location=us-west1 --project=misc-puttering-project \
+     --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"
+   ```
 
 2. Scoped grants (bootstrap does NOT do these; skipping them is the classic
    "probe passes, build 403s" failure):
@@ -1318,6 +1378,23 @@ account (export it). All skill scripts are invoked via
    When an execution exists, list a real log read as an explicit probe too:
    `--probe "gcloud beta run jobs executions logs read <execution-name> --project=misc-puttering-project --region=us-west1"`.
 
+   Read probes alone do NOT prove the lane: they skip the scoped bucket
+   grants, job create/delete, actAs, and the per-execution overrides the
+   vitest lane uses. Finish verification with ONE REAL LANE SMOKE as the
+   robot (~$0.02; small test file):
+
+   ```bash
+   GCLOUD_IDENT=gcloud-robot@misc-puttering-project.iam.gserviceaccount.com \
+     bash scripts/vitest-cloud.sh run --cloud --config=default --shards=1 \
+       test/unit/lib/pane-utils.test.ts
+   ```
+
+   Expected on success: `All tasks completed successfully.` A 403 names the
+   missing grant in its error message — add the smallest covering grant
+   (`bootstrap-robot.sh --no-key` updates roles without touching keys), then
+   re-verify and re-smoke. Only after the probes AND the smoke pass is the
+   repo "provisioned and verified".
+
 4. Done. `npm run test:cloud` / `npm run test:e2e:cloud` now select the robot
    automatically wherever its key is activated; no `.env` or repo config
    exists for this (`.env.example` is server-runtime config and deliberately
@@ -1330,7 +1407,7 @@ account (export it). All skill scripts are invoked via
 
    ```bash
    GCLOUD_ROBOT_PROJECT=misc-puttering-project \
-   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor artifactregistry.writer run.developer run.jobsExecutor run.viewer logging.viewer" \
+   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor artifactregistry.writer run.developer logging.viewer" \
    GCLOUD_ROBOT_ADMIN_ACCOUNT="$GCLOUD_ROBOT_ADMIN_ACCOUNT" \
    bash "$GCLOUD_ROBOT_HOME/scripts/bootstrap-robot.sh" --rekey --activate
    ```
@@ -1393,6 +1470,9 @@ for immediacy.)
 - Cloud Build dies resolving source/logs (`storage.buckets.get` 403) → the
   bucket-scoped `roles/storage.legacyBucketReader` (step 2); object roles
   alone never carry bucket metadata reads.
+- Push 403s or the run logs "Creating Artifact Registry repository" then
+  fails → step 1's repo-exists check was skipped: writer cannot create
+  repositories. Run the describe/create block from provisioning.
 - A grant that definitely exists 403s for the first minutes → IAM
   propagation lag; the verifier's retries (12 × 30s default) absorb it.
 - A lane prints the ambient-fallback note and then gcloud's
@@ -1408,7 +1488,7 @@ way. If CI ever needs GCP, use Workload Identity Federation (keyless) —
 never a JSON key in CI.
 ````
 
-**3b.** Edit `AGENTS.md` — append this paragraph at the end of the
+**1b.** Edit `AGENTS.md` — append this paragraph at the end of the
 `### Vitest Test Backend (Cloud Run Jobs)` section (immediately after the
 "**Note:** The electron suite always runs locally even in cloud mode ..."
 paragraph, before the `### E2E Test Backend (Cloud Run Jobs)` heading):
@@ -1423,35 +1503,28 @@ live in [docs/development/gcloud-robot.md](docs/development/gcloud-robot.md).
 `GCLOUD_ROBOT_REQUIRE=1` fails closed when no robot identity resolves.
 ```
 
-**3c.** Edit `AGENTS.md` — append this paragraph at the end of the
+**1c.** Edit `AGENTS.md` — append this paragraph at the end of the
 `### E2E Test Backend (Cloud Run Jobs)` section (immediately after the
 "**Before filing any PR, ensure the affected e2e specs actually pass on the
 configured `FRESHELL_E2E_BACKEND` backend** ..." paragraph, before the
-`## Architecture` heading): the identical Identity paragraph from 3b
+`## Architecture` heading): the identical Identity paragraph from 1b
 (verbatim — both sections name the same contract).
 
-- [ ] **Step 4: Run the focused test**
+**1d.** Delete the `# DOC-CHECKS-ANCHOR (Task 3 appends here)` line from
+`scripts/test/cloud-gcp-identity.test.sh` (the doc checks were cut per the
+repo's test-quality bar; the anchor is dead).
 
-Run: `bash scripts/test/cloud-gcp-identity.test.sh`
+- [ ] **Step 2: Verify**
 
-Expected: PASS — D1–D5 (and everything else) green, footer
-`=== All checks passed ===`, exit 0.
+2a. Read-through of the rendered runbook for command accuracy against the
+skill references (provisioning.md shapes: scoped grants carry
+`--condition=None`, skill scripts invoked as `bash
+"$GCLOUD_ROBOT_HOME/scripts/<name>.sh"`, key outside `~/.config/gcloud`) and
+confirm the AGENTS.md links resolve to the new file's path.
 
-- [ ] **Step 5: Refactor while green**
-
-Docs-only task; no code refactor. Do a read-through of the rendered runbook
-for command accuracy against the skill references (provisioning.md shapes:
-scoped grants carry `--condition=None`, budget of `bash <path>` invocation,
-key outside `~/.config/gcloud`).
-
-- [ ] **Step 6: Run impacted-test verification**
-
-AGENTS.md is included in the cloud image by `.gcloudignore`'s `!AGENTS.md`
-exception and read by server-side tests; the runbook is new documentation.
-The impacted set is again the full cloud-suite loop (the doc checks live in
-the identity suite), plus a typecheck-free confirmation that AGENTS.md still
-parses as plumbing-neutral markdown (no tooling consumes it programmatically
-beyond inclusion):
+2b. Regression sweep — AGENTS.md ships inside the cloud image and the identity
+suite lost only a comment line, so the impacted set is the full cloud-suite
+loop:
 
 Run:
 ```bash
@@ -1466,7 +1539,7 @@ done
 
 Expected: PASS — every suite exits 0.
 
-- [ ] **Step 7: Commit the task**
+- [ ] **Step 3: Commit the task**
 
 ```bash
 git add docs/development/gcloud-robot.md AGENTS.md scripts/test/cloud-gcp-identity.test.sh
@@ -1490,8 +1563,8 @@ git commit -m "docs(cloud): add gcloud-robot operator runbook + AGENTS.md identi
 | help/local lanes need zero GCP tooling and stay silent | Task 2 W8/W9; pre-existing cloud-run-wrapper check 12 |
 | Trap-11: stubbed suites never reach the probe | Task 2 W7 (four nested suites under a hostile marker-trap home) |
 | Hardcoded-default removal documented in help | Task 2 W10/W11 |
-| Runbook + AGENTS.md wiring | Task 3 D1–D5 |
-| Provisioning/rotation/revocation correctness | Documented only — human-executed; skill-mandated exclusion (no agent runs GCP mutations) |
+| Runbook + AGENTS.md docs | Task 3 — docs-only task; repo TDD doc exemption applies; verified by read-through + suite regression sweep |
+| Provisioning/rotation/revocation correctness | Documented only — human-executed; skill-mandated exclusion (no agent runs GCP mutations); surface completeness hardened by verify probes + one real lane smoke |
 | Whole-repo regression | Workflow stage gate (coordinated suite), outside task scope |
 
 ## Risk notes
@@ -1509,6 +1582,5 @@ git commit -m "docs(cloud): add gcloud-robot operator runbook + AGENTS.md identi
   one note and run exactly as before (including, today, the culled-credential
   failure mode). That is the contract: adoption is non-breaking; provisioning
   is the fix.
-
 
 

--- a/docs/plans/2026-08-22-gcloud-robot-conversion.md
+++ b/docs/plans/2026-08-22-gcloud-robot-conversion.md
@@ -1583,4 +1583,3 @@ git commit -m "docs(cloud): add gcloud-robot operator runbook + AGENTS.md identi
   failure mode). That is the contract: adoption is non-breaking; provisioning
   is the fix.
 
-

--- a/docs/plans/2026-08-22-gcloud-robot-conversion.md
+++ b/docs/plans/2026-08-22-gcloud-robot-conversion.md
@@ -91,9 +91,14 @@ Exact project-wide constraints every task must honor:
   Cloud Build access requirements explicitly demand
   `serviceusage.services.use` to run `gcloud builds` commands — without it a
   robot passes the create-probe yet fails `builds submit`). SCOPED GRANTS
-  (checklist, not bootstrap): `roles/storage.objectAdmin` +
+  (checklist, not bootstrap): `roles/storage.objectUser` +
   `roles/storage.legacyBucketReader` on the Cloud Build staging bucket
-  (default `misc-puttering-project_cloudbuild`, operator confirms);
+  (default `misc-puttering-project_cloudbuild`, discovered deterministically
+  — exactly one match required). objectUser, NOT objectAdmin: the lane only
+  stages ordinary objects; objectAdmin would add object setIamPolicy/
+  retention powers the bearer key must never hold (delta-review remediation —
+  the runbook code listing in Task 3 is a frozen draft and was superseded by
+  the executed runbook);
   `roles/artifactregistry.writer` on the `freshell-e2e` REPOSITORY ONLY
   (repository-level binding — project-wide would give the bearer key write
   access to every current and future repo; and writer CANNOT create

--- a/docs/plans/2026-08-22-gcloud-robot-conversion.md
+++ b/docs/plans/2026-08-22-gcloud-robot-conversion.md
@@ -85,40 +85,45 @@ Exact project-wide constraints every task must honor:
   commit per task; no PR creation; no production-server restarts; no broad
   kill patterns.
 - **Role set (documented, human-applied)** for project
-  `misc-puttering-project`, robot `gcloud-robot`: project-level
-  `roles/cloudbuild.builds.editor`, `roles/artifactregistry.writer`,
-  `roles/run.developer`, `roles/logging.viewer`; bucket-scoped
-  `roles/storage.objectAdmin` + `roles/storage.legacyBucketReader` on the
-  Cloud Build staging bucket (default `misc-puttering-project_cloudbuild`,
-  operator confirms); `roles/iam.serviceAccountUser` (actAs) on the project's
-  default compute service account
-  (`<projectNumber>-compute@developer.gserviceaccount.com`), plus — ONLY IF
-  the project's Cloud Build default service account (`gcloud builds
-  get-default-service-account`) is an identity the project controls — actAs
-  on that identity too (the LEGACY Cloud Build SA
+  `misc-puttering-project`, robot `gcloud-robot`. PROJECT-LEVEL (bootstrap):
+  `roles/cloudbuild.builds.editor`, `roles/run.developer`,
+  `roles/logging.viewer`, `roles/serviceusage.serviceUsageConsumer` (Google's
+  Cloud Build access requirements explicitly demand
+  `serviceusage.services.use` to run `gcloud builds` commands — without it a
+  robot passes the create-probe yet fails `builds submit`). SCOPED GRANTS
+  (checklist, not bootstrap): `roles/storage.objectAdmin` +
+  `roles/storage.legacyBucketReader` on the Cloud Build staging bucket
+  (default `misc-puttering-project_cloudbuild`, operator confirms);
+  `roles/artifactregistry.writer` on the `freshell-e2e` REPOSITORY ONLY
+  (repository-level binding — project-wide would give the bearer key write
+  access to every current and future repo; and writer CANNOT create
+  repositories, so the operator ensures the repo exists first);
+  `roles/iam.serviceAccountUser` (actAs) on the project's default compute
+  service account (`<projectNumber>-compute@developer.gserviceaccount.com`),
+  plus — ONLY IF the project's Cloud Build default service account
+  (`gcloud builds get-default-service-account`) is an identity the project
+  controls — actAs on that identity too (the LEGACY Cloud Build SA
   `<projectNumber>@cloudbuild.gserviceaccount.com` is Google-owned and
   accepts no bindings, and
   `service-<projectNumber>@gcp-sa-cloudbuild.iam.gserviceaccount.com` is the
   service AGENT, never a build-execution identity — grant nothing on either).
-  NO `roles/serviceusage.serviceUsageConsumer` (not justified by the surface).
   Role-set reasoning, verified against the official role permission lists
-  (review round-1 remediation): `roles/run.developer` subsumes
+  (review rounds 1–3): `roles/run.developer` subsumes
   `run.invoker`/`run.jobsExecutor`/`run.viewer` for job lanes and is the
   tightest built-in that also carries `run.jobs.runWithOverrides` — REQUIRED
   because the vitest wrapper's `run jobs execute --tasks/--task-timeout/
   --update-env-vars` supplies per-execution overrides. `run.jobsExecutor`,
   `run.jobsExecutorWithOverrides`, `run.invoker`, and `run.viewer` are
   deliberately NOT in the list (each is either too narrow or redundant under
-  developer). The wrapper's create-if-missing Artifact Registry path
-  (`artifacts repositories create`) is NOT granted
-  (`artifactregistry.repositories.create` would need repoAdmin): the operator
-  checklist ensures the repository exists instead. Build-log access comes
-  from routing Cloud Build logs to Cloud Logging
-  (`options.logging: CLOUD_LOGGING_ONLY` in cloudbuild.yaml — Task 2 edit
-  E12), which `roles/logging.viewer` covers; the legacy default GCS
+  developer). Build-log access comes from routing Cloud Build logs to Cloud
+  Logging (`options.logging: CLOUD_LOGGING_ONLY` in cloudbuild.yaml — Task 2
+  edit E12), which `roles/logging.viewer` covers; the legacy default GCS
   log-bucket path is documented upstream as requiring project-wide
   `roles/viewer` for manual builds reading its logs and is deliberately not
-  granted.
+  granted. Tradeoff, honest: CLOUD_LOGGING_ONLY disables live log streaming
+  during `gcloud builds submit` (upstream LoggingMode reference); builds
+  complete normally and logs are read after the fact with
+  `gcloud builds log <id>` (covered by editor's builds.get + logging.viewer).
 - **Files explicitly out of scope (untouched, with reason):**
   `scripts/run-standard-tests.ts` (it `execFileSync`s `vitest-cloud.sh` with
   inherited env; identity resolution lives inside the wrapper so the
@@ -170,14 +175,26 @@ Exact project-wide constraints every task must honor:
   checklist ensures the AR repo exists instead of granting repoAdmin.
 - **A7** (raised by plan-review round 2; RESOLVED against the upstream docs
   the reviewer cited — Cloud Build troubleshooting + build-log storage
-  behavior): with `logging` unspecified, Cloud Build writes build logs to the
-  legacy default GCS bucket, and reading them as the submitting identity
-  requires project-wide `roles/viewer` — refused as too wide. Fix instead:
+  behavior, plus the LoggingMode API reference from round 3): with `logging`
+  unspecified, Cloud Build writes build logs to the legacy default GCS bucket,
+  and reading them as the submitting identity requires project-wide
+  `roles/viewer` — refused as too wide. Fix instead:
   `options.logging: CLOUD_LOGGING_ONLY` in
   `docker/cloud-run/cloudbuild.yaml` (Task 2 E12), which puts build logs in
   Cloud Logging where the already-granted `roles/logging.viewer` suffices.
-  Human workflows' `builds submit` log streaming is unchanged; the Console
-  log link target changes (native bucket viewer → Logs Explorer).
+  Honest tradeoff (review round 3): this mode does NOT allow live log
+  streaming during submit — builds complete normally; logs are read after
+  the fact with `gcloud builds log <build-id>`; the Console log link target
+  changes (native bucket viewer → Logs Explorer).
+- **A8** (raised by plan-review round 3; RESOLVED against cited upstream
+  docs): (i) `serviceusage.services.use` is REQUIRED for principals running
+  `gcloud builds` commands (Cloud Build access-requirements doc) →
+  `roles/serviceusage.serviceUsageConsumer` added to the project level (the
+  earlier decision to omit it was wrong); (ii) Artifact Registry repository-
+  level IAM bindings are supported and recommended (AR access-control doc) →
+  `roles/artifactregistry.writer` moved from project level to a binding on
+  the existing `freshell-e2e` repository in the checklist's scoped-grant
+  step.
 
 These are properties of external contracts; the plan's tasks do not depend on
 any other unproven claim. If A1/A2 invalidate a probe permission, swap the
@@ -876,10 +893,11 @@ options:
 (One edit, one wrapper-neutral file — no V-mirror.) Rationale: the default
 (legacy GCS log bucket) requires project-wide `roles/viewer` for the
 submitting identity to read/stream build logs; Cloud Logging needs only the
-already-granted `roles/logging.viewer`. This changes where build logs land
-for humans too (streamed `builds submit` output is identical; only the
-Console link target moves from the bucket viewer to Logs Explorer) — called
-out in the Risk notes.
+already-granted `roles/logging.viewer`. Honest tradeoff (upstream LoggingMode
+reference): CLOUD_LOGGING_ONLY does NOT allow live log streaming during
+`gcloud builds submit` — builds complete normally, and logs are read after
+the fact with `gcloud builds log <build-id>`; the Console link target moves
+from the bucket viewer to Logs Explorer. Called out in the Risk notes.
 
 **E11 / V11 — help + header text.** e2e-cloud.sh:29 header line and
 e2e-cloud.sh usage(); vitest-cloud.sh:28 header line and
@@ -952,7 +970,12 @@ GREEN_LOG="$TDIR/green-gcloud.log"
 cat > "$GTDIR/gcloud" <<'GREEN_FAKE'
 #!/usr/bin/env bash
 echo "GCLOUD_ARGS: $*" >> "${GREEN_LOG:?set GREEN_LOG}"
-grep -oP -- '--account=\S+' <<< "$*" >> "${GREEN_LOG}.accounts" 2>/dev/null || true
+# Shell redirection creates its target eagerly, so `grep ... >> FILE` would
+# materialize an EMPTY accounts file even when no --account token exists —
+# breaking every "--account was omitted" assertion. Capture, write only when
+# non-empty: an ABSENT accounts file therefore proves omission.
+ACCT_TOKENS="$(grep -oP -- '--account=\S+' <<< "$*" 2>/dev/null || true)"
+if [ -n "$ACCT_TOKENS" ]; then printf '%s\n' "$ACCT_TOKENS" >> "${GREEN_LOG}.accounts"; fi
 if [[ "$*" == *"info"* ]]; then echo "/nonexistent-sdk-root"; exit 0; fi
 if [[ "$*" == *"artifacts docker images describe"* ]]; then exit 1; fi
 if [[ "$*" == *"artifacts repositories describe"* ]]; then exit 0; fi
@@ -1123,6 +1146,10 @@ for nested in scripts/test/cloud-build.test.sh \
 done
 
 # --- W8: help works with no gcloud, no account, fake HOME — and silently ---
+# The silence assertion matches ONLY the ladder's runtime diagnostic prefixes
+# ("gcloud-robot: skill not found", "gcloud-robot: no probed identity") — the
+# help text itself legitimately documents the ladder by name (E11), so a bare
+# "gcloud-robot" match would forbid the docs and break the suite by design.
 CLEAN_PATH="$PATH"
 if GCLOUD_PATH_RESOLVED=$(command -v gcloud 2>/dev/null); then
   GCLOUD_DIRNAME="$(cd "$(dirname "$GCLOUD_PATH_RESOLVED")" && pwd)"
@@ -1153,7 +1180,7 @@ if [ -n "$CLEAN_PATH" ]; then
       check "W8 $lane help: exit 0, prints usage, no identity activity, silent" \
         bash -c '
           [ "$1" = "0" ] && grep -qi "usage" <<<"$2" &&
-          ! grep -q "gcloud-robot" <<<"$2" && [ ! -e "$3" ]
+          ! grep -qE "gcloud-robot: (skill not found|no probed identity)" <<<"$2" && [ ! -e "$3" ]
         ' _ "$HELP_RC" "$HELP_OUT" "$SELECTOR_MARKER"
     done
   fi
@@ -1169,7 +1196,7 @@ check "W9 vitest --local: runs real local vitest, no selector, no ladder output"
   bash -c '
     [ "$1" = "0" ] &&
     grep -qE "Test Files|passed" <<<"$2" &&
-    ! grep -q "gcloud-robot" <<<"$2" && [ ! -e "$3" ]
+    ! grep -qE "gcloud-robot: (skill not found|no probed identity)" <<<"$2" && [ ! -e "$3" ]
   ' _ "$W9_RC" "$W9_OUT" "$SELECTOR_MARKER"
 
 # --- W12: e2e standalone lanes (build / push / logs) run their OWN ladder ---
@@ -1528,7 +1555,7 @@ account (export it). All skill scripts are invoked via
 
    ```bash
    GCLOUD_ROBOT_PROJECT=misc-puttering-project \
-   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor artifactregistry.writer run.developer logging.viewer" \
+   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor run.developer logging.viewer serviceusage.serviceUsageConsumer" \
    GCLOUD_ROBOT_ADMIN_ACCOUNT="$GCLOUD_ROBOT_ADMIN_ACCOUNT" \
    bash "$GCLOUD_ROBOT_HOME/scripts/bootstrap-robot.sh" --name gcloud-robot --activate
    ```
@@ -1552,6 +1579,15 @@ account (export it). All skill scripts are invoked via
    gcloud artifacts repositories create freshell-e2e \
      --repository-format=docker --location=us-west1 --project=misc-puttering-project \
      --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"
+
+   # Push/write power is granted on THIS repository only (repository-level
+   # binding), never project-wide — the bearer key must not gain write access
+   # to every current and future repo:
+   gcloud artifacts repositories add-iam-policy-binding freshell-e2e \
+     --location=us-west1 --project=misc-puttering-project \
+     --member="serviceAccount:gcloud-robot@misc-puttering-project.iam.gserviceaccount.com" \
+     --role=roles/artifactregistry.writer \
+     --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" --condition=None
    ```
 
 2. Scoped grants (bootstrap does NOT do these; skipping them is the classic
@@ -1642,7 +1678,7 @@ account (export it). All skill scripts are invoked via
 
    ```bash
    GCLOUD_ROBOT_PROJECT=misc-puttering-project \
-   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor artifactregistry.writer run.developer logging.viewer" \
+   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor run.developer logging.viewer serviceusage.serviceUsageConsumer" \
    GCLOUD_ROBOT_ADMIN_ACCOUNT="$GCLOUD_ROBOT_ADMIN_ACCOUNT" \
    bash "$GCLOUD_ROBOT_HOME/scripts/bootstrap-robot.sh" --rekey --activate
    ```
@@ -1708,10 +1744,11 @@ for immediacy.)
 - Push 403s or the run logs "Creating Artifact Registry repository" then
   fails → step 1's repo-exists check was skipped: writer cannot create
   repositories. Run the describe/create block from provisioning.
-- "Where did build logs go?" → build logs now land in Cloud Logging by
-  design (`options.logging: CLOUD_LOGGING_ONLY`), so the
-  robot's `logging.viewer` covers them and no project-wide viewer grant is
-  needed. Streamed `builds submit` output is unchanged.
+- "Where did build logs go?" / "submit doesn't stream anymore" → by design:
+  `options.logging: CLOUD_LOGGING_ONLY` puts logs in Cloud Logging (the
+  robot's `logging.viewer` covers reads; no project-wide viewer grant), and
+  this mode does not stream during submit. Builds complete normally; read
+  logs with `gcloud builds log <build-id> --project=misc-puttering-project`.
 - A grant that definitely exists 403s for the first minutes → IAM
   propagation lag; the verifier's retries (12 × 30s default) absorb it.
 - A lane prints the ambient-fallback note and then gcloud's
@@ -1827,10 +1864,12 @@ git commit -m "docs(cloud): add gcloud-robot operator runbook + AGENTS.md identi
   is the fix.
 - **Build-log location changes for everyone.** `options.logging:
   CLOUD_LOGGING_ONLY` moves build logs from the legacy GCS bucket to Cloud
-  Logging for human lanes too. The streamed `gcloud builds submit` output is
-  unchanged; only the Console link target moves (bucket viewer → Logs
-  Explorer). The alternative (granting the robot project-wide
-  `roles/viewer`) was refused as over-broad.
+  Logging for human lanes too — and (per the LoggingMode API reference)
+  `gcloud builds submit` no longer streams logs live during the ~13-minute
+  cold build; output appears at completion, and logs are readable any time
+  via `gcloud builds log <id>` (covered by builds editor +
+  `roles/logging.viewer`). The alternative (project-wide `roles/viewer` for
+  the robot) was refused as over-broad.
 - **Standalone lanes gain flag parsing.** `push`/`logs` now parse
   `--account=`/`--project-id=`/`--region=`; unknown args keep their old
   behavior (push ignores them; logs passes them through to `logs read`).

--- a/docs/plans/2026-08-22-gcloud-robot-conversion.md
+++ b/docs/plans/2026-08-22-gcloud-robot-conversion.md
@@ -87,13 +87,20 @@ Exact project-wide constraints every task must honor:
 - **Role set (documented, human-applied)** for project
   `misc-puttering-project`, robot `gcloud-robot`: project-level
   `roles/cloudbuild.builds.editor`, `roles/artifactregistry.writer`,
-  `roles/run.developer`, `roles/run.invoker`, `roles/run.viewer`,
+  `roles/run.developer`, `roles/run.jobsExecutor`, `roles/run.viewer`,
   `roles/logging.viewer`; bucket-scoped `roles/storage.objectAdmin` +
   `roles/storage.legacyBucketReader` on the Cloud Build staging bucket
   (default `misc-puttering-project_cloudbuild`, operator confirms);
   `roles/iam.serviceAccountUser` (actAs) on the project's default compute
-  service account and default Cloud Build service account. NO
-  `roles/serviceusage.serviceUsageConsumer` (not justified by the surface).
+  service account (`<projectNumber>-compute@developer.gserviceaccount.com`),
+  plus — ONLY IF the project's Cloud Build default service account
+  (`gcloud builds get-default-service-account`) is an identity the project
+  controls — actAs on that identity too (the LEGACY Cloud Build SA
+  `<projectNumber>@cloudbuild.gserviceaccount.com` is Google-owned and
+  accepts no bindings, and `service-<projectNumber>@gcp-sa-cloudbuild.iam.gserviceaccount.com`
+  is the service AGENT, never a build-execution identity — grant nothing on
+  either). NO `roles/serviceusage.serviceUsageConsumer` (not justified by the
+  surface).
 - **Files explicitly out of scope (untouched, with reason):**
   `scripts/run-standard-tests.ts` (it `execFileSync`s `vitest-cloud.sh` with
   inherited env; identity resolution lives inside the wrapper so the
@@ -123,11 +130,17 @@ Exact project-wide constraints every task must honor:
   `GCLOUD_ROBOT_ROLES`, `GCLOUD_ROBOT_ADMIN_ACCOUNT`, `--name`, `--activate`
   (runbook command correctness). Validate by reading the operator-installed
   script's usage.
-- **A5** The default actAs identities for `misc-puttering-project` are the
-  default compute SA (`<projectNumber>-compute@developer.gserviceaccount.com`)
-  and default Cloud Build SA
-  (`service-<projectNumber>@gcp-sa-cloudbuild.iam.gserviceaccount.com`).
-  Validate against official docs documenting both default SA names.
+- **A5** RESOLVED (stage 2, validator reports
+  `reports/load-bearing-validator-a5.md`): the compute default SA form
+  `<projectNumber>-compute@developer.gserviceaccount.com` is CONFIRMED; the
+  claimed Cloud Build form `service-<projectNumber>@gcp-sa-cloudbuild.iam.gserviceaccount.com`
+  is FALSIFIED — that address is the Google-managed Cloud Build service
+  AGENT (builds never run as it; no IAM bindings possible). The real Cloud
+  Build default is either the legacy `PROJECT_NUMBER@cloudbuild.gserviceaccount.com`
+  (Google-owned, accepts no bindings) or, on newer setups, the compute default
+  SA; the runbook discovers it via `gcloud builds get-default-service-account`
+  rather than assuming. Plan content updated accordingly (role-set Global
+  Constraint, Task 3 runbook step 2).
 
 These are properties of external contracts; the plan's tasks do not depend on
 any other unproven claim. If A1/A2 invalidate a probe permission, swap the
@@ -1211,6 +1224,11 @@ A resolved identity pins every `--account` the wrappers emit and exports
 
 - The `gcloud-robot` skill installed for your agent platform (whatever
   directory holds its `scripts/` — the repo never records that path).
+- The Cloud Resource Manager API enabled on the project (the identity probe's
+  `testIamPermissions` call needs it; any project that has ever touched IAM
+  already has it — `gcloud services enable cloudresourcemanager.googleapis.com
+  --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"`
+  is the one-time, idempotent enable).
 - Point the lanes at it once, e.g. in `~/.bashrc`:
 
   ```bash
@@ -1229,7 +1247,7 @@ account (export it). All skill scripts are invoked via
 
    ```bash
    GCLOUD_ROBOT_PROJECT=misc-puttering-project \
-   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor artifactregistry.writer run.developer run.invoker run.viewer logging.viewer" \
+   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor artifactregistry.writer run.developer run.jobsExecutor run.viewer logging.viewer" \
    GCLOUD_ROBOT_ADMIN_ACCOUNT="$GCLOUD_ROBOT_ADMIN_ACCOUNT" \
    bash "$GCLOUD_ROBOT_HOME/scripts/bootstrap-robot.sh" --name gcloud-robot --activate
    ```
@@ -1256,12 +1274,21 @@ account (export it). All skill scripts are invoked via
        --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" --condition=None
    done
 
-   # actAs on the default build/run identities (jobs and Cloud Build run as
-   # these, and submitting identities must be allowed to act as them):
+   # actAs on the default build/run identities. Cloud Run jobs execute as the
+   # project default compute SA, so creating jobs requires actAs on it. Cloud
+   # Build's default execution identity is DISCOVERED, not assumed: on older
+   # projects it is the legacy <number>@cloudbuild.gserviceaccount.com
+   # (Google-owned, accepts NO bindings — skip it), on newer ones the compute
+   # default SA. (actAs beyond this is only needed when a build config pins
+   # serviceAccount: — docker/cloud-run/cloudbuild.yaml pins none.)
    PROJECT_NUMBER=$(gcloud projects describe misc-puttering-project \
      --format='value(projectNumber)' --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT")
-   for sa in "${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
-             "service-${PROJECT_NUMBER}@gcp-sa-cloudbuild.iam.gserviceaccount.com"; do
+   BUILD_SA="$(gcloud builds get-default-service-account --project=misc-puttering-project \
+     --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" | grep -oE '[A-Za-z0-9._-]+@[A-Za-z0-9.-]+' | head -1)"
+   for sa in "${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" ${BUILD_SA:+"$BUILD_SA"}; do
+     case "$sa" in
+       *@cloudbuild.gserviceaccount.com) echo "skipping $sa (legacy Cloud Build SA accepts no IAM bindings)"; continue ;;
+     esac
      gcloud iam service-accounts add-iam-policy-binding "$sa" \
        --member="serviceAccount:gcloud-robot@misc-puttering-project.iam.gserviceaccount.com" \
        --role=roles/iam.serviceAccountUser \
@@ -1303,7 +1330,7 @@ account (export it). All skill scripts are invoked via
 
    ```bash
    GCLOUD_ROBOT_PROJECT=misc-puttering-project \
-   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor artifactregistry.writer run.developer run.invoker run.viewer logging.viewer" \
+   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor artifactregistry.writer run.developer run.jobsExecutor run.viewer logging.viewer" \
    GCLOUD_ROBOT_ADMIN_ACCOUNT="$GCLOUD_ROBOT_ADMIN_ACCOUNT" \
    bash "$GCLOUD_ROBOT_HOME/scripts/bootstrap-robot.sh" --rekey --activate
    ```

--- a/docs/plans/2026-08-22-gcloud-robot-conversion.md
+++ b/docs/plans/2026-08-22-gcloud-robot-conversion.md
@@ -1,0 +1,1487 @@
+# gcloud-robot Conversion Implementation Plan
+
+> **For agentic workers:** Execute this plan task by task with a fresh
+> implementer and a specification-plus-quality review after every task. Track
+> progress with the checkbox steps below.
+
+## User Request
+
+### Requested result
+Convert the freshell repository's gcloud-based tooling (the Cloud Run Jobs
+test lanes and their shared image build/publish machinery) off interactive
+`gcloud auth login` onto the gcloud-robot per-project robot-service-account
+pattern, per the installed gcloud-robot skill.
+
+### Explicit constraints
+- Follow the gcloud-robot skill contract: survey first; least-privilege
+  per-project role set derived from the surveyed surface; the converting agent
+  writes but never runs GCP-mutating provisioning; no JSON keys in CI; never
+  vendor the skill's scripts into the repo; runtime discovery only via
+  `GCLOUD_ROBOT_HOME`; a zero-surface survey would produce zero adoption
+  artifacts.
+- Follow freshell repo rules (AGENTS.md): work in the dedicated worktree under
+  `.worktrees/` from a green-verified base; never commit behavior changes to
+  local or origin main outside the PR flow; do not create a PR without explicit
+  user approval; never restart the production server.
+
+### Accepted tradeoffs and residuals
+- "Wired but not yet provisioned" is the accepted end state of this run: a
+  human operator runs the documented provisioning checklist once per project
+  afterward.
+- A JSON key is bearer power with no MFA and no default expiry; the runbook
+  must say so honestly and recommend rotation cadence, instant revocation
+  steps, and key-usage alerting.
+
+**Goal:** Freshell's cloud test lanes (e2e, vitest, image build/push) select their gcloud identity through the gcloud-robot ladder — explicit pin, `GCLOUD_IDENT`, installed-skill probe via `GCLOUD_ROBOT_HOME`, then quiet ambient fallback — so culled interactive logins stop killing agent test runs, with human sign-ins continuing to work untouched.
+
+**Architecture:** One sourced helper (`scripts/lib/gcp-identity.sh`) carries the skill's `resolve_gcp_identity` drop-in block verbatim plus a thin bridge into the wrappers' pinned `--account` variable. Both cloud wrappers source it and resolve identity lazily, immediately before each cloud lane's first real gcloud call, so `help` and local lanes need zero GCP tooling. Hermeticity is preserved by explicit `GCLOUD_IDENT` pins in the four stubbed-gcloud suites and proven by a new identity-ladder suite that runs the real wrappers against stubbed gcloud. An operator runbook documents the one-time human provisioning and key operations; the repo never vendors the skill and no agent runs GCP-mutating commands.
+
+**Tech Stack:** Bash (wrappers + standalone test suites under `scripts/test/`), gcloud CLI, Google Cloud Build / Cloud Run Jobs / Artifact Registry, the operator-installed `gcloud-robot` skill (discovered at runtime via `GCLOUD_ROBOT_HOME`, never committed or referenced by path).
+
+## Global Constraints
+
+Exact project-wide constraints every task must honor:
+
+- **No GCP mutations by agents.** Provisioning, key, and IAM commands appear
+  only as documented operator checklists (runbook, future PR body). No agent
+  runs `bootstrap-robot.sh` or any IAM-mutating gcloud call.
+- **Never vendor the skill.** The repo gains the drop-in block (the single
+  permitted copy, kept byte-identical) but never the skill's scripts, and no
+  committed file references the skill's installed location or any
+  machine-local absolute path. Machine-local facts are recorded generically
+  (e.g. `key-path: not yet minted — operator step`).
+- **Discovery only via `GCLOUD_ROBOT_HOME`.** No other resolution mechanism.
+- **No JSON keys in CI.** `.github/workflows/` has zero GCP surface today and
+  stays that way; CI belongs to Workload Identity Federation (runbook note).
+- **The identity ladder is fixed** (in order): call-site/repo pin wins >
+  `GCLOUD_IDENT` bypass (no network) > skill probe via
+  `$GCLOUD_ROBOT_HOME/scripts/select-gcloud-identity.sh` > ambient fallback
+  with ONE quiet stderr note (default) or fail-closed-with-guidance when
+  `GCLOUD_ROBOT_REQUIRE=1`. The drop-in block is copied verbatim from the
+  skill; never hand-compose a variant. No apostrophes inside `${...:?...}`
+  messages (bash parses the interior as its own quoting context).
+- **Hardcoded human default removed.** `dan@danshapiro.com` stops being any
+  wrapper default. Identity precedence after conversion:
+  `--account=` flag > `FRESHELL_GCP_ACCOUNT` env > `GCLOUD_IDENT` (ladder
+  result) > unset (flag omitted; ambient gcloud applies, announced by the
+  ladder's one-line note; `GCLOUD_ROBOT_REQUIRE=1` fails with guidance
+  instead).
+- **Lazy resolution only.** `freshell_resolve_cloud_identity` is called
+  immediately before a cloud lane's first real gcloud call, never at script
+  top. `help` and `run --local` must work on machines with NO gcloud, NO
+  skill, and NO network, and must not emit any gcloud-robot output.
+- **Probe permissions** (lane representatives): run/logs lanes →
+  `run.jobs.run`; build/push lane → `cloudbuild.builds.create`. (Stage-2
+  load-bearing items A1/A2 below.)
+- **Hermetic suites stay hermetic (skill trap 11).** The four stubbed-gcloud
+  suites pin `GCLOUD_IDENT=suite-pinned-identity@example.invalid` at the top
+  so the rung-2 bypass fires and a stray `GCLOUD_ROBOT_HOME` can never push a
+  suite onto the real probe/network path.
+- **Shell safety.** Wrappers run under `set -euo pipefail`; all new expansions
+  use guarded forms (`${VAR:-...}`), and command substitutions that may print
+  nothing (e.g. `$(account_flag)`) must leave exit status 0.
+- **Repo rules (AGENTS.md)** apply throughout: work only in this worktree on
+  branch `the-usual/gcloud-robot-conversion`; conventional, focused, one
+  commit per task; no PR creation; no production-server restarts; no broad
+  kill patterns.
+- **Role set (documented, human-applied)** for project
+  `misc-puttering-project`, robot `gcloud-robot`: project-level
+  `roles/cloudbuild.builds.editor`, `roles/artifactregistry.writer`,
+  `roles/run.developer`, `roles/run.invoker`, `roles/run.viewer`,
+  `roles/logging.viewer`; bucket-scoped `roles/storage.objectAdmin` +
+  `roles/storage.legacyBucketReader` on the Cloud Build staging bucket
+  (default `misc-puttering-project_cloudbuild`, operator confirms);
+  `roles/iam.serviceAccountUser` (actAs) on the project's default compute
+  service account and default Cloud Build service account. NO
+  `roles/serviceusage.serviceUsageConsumer` (not justified by the surface).
+- **Files explicitly out of scope (untouched, with reason):**
+  `scripts/run-standard-tests.ts` (it `execFileSync`s `vitest-cloud.sh` with
+  inherited env; identity resolution lives inside the wrapper so the
+  coordinator and base-gate paths inherit it for free);
+  `docker/cloud-run/{Dockerfile,entrypoint.sh,cloudbuild.yaml}` (no gcloud
+  identity inside the container; jobs/builds run as default identities — the
+  actAs grant is documented in the runbook); `.gcloudignore` (no relation to
+  identity); `.github/workflows/*` (zero GCP surface; CI stays keyless);
+  `.env.example` (server-runtime configuration only — the cloud wrappers are
+  operator shell tooling, so their knobs are documented in `--help`,
+  AGENTS.md, and the runbook instead); historical `docs/plans/*` (historical
+  records).
+
+## Stage-2 load-bearing assumptions (validate before execution)
+
+- **A1** `run.jobs.run` is a real, project-testable IAM permission for Cloud
+  Run Jobs (usable in a `testIamPermissions` probe). Validate against the
+  official Cloud Run IAM permission reference.
+- **A2** `cloudbuild.builds.create` is a real, project-testable IAM permission
+  for Cloud Build. Validate against the official Cloud Build IAM reference.
+- **A3** `$GCLOUD_ROBOT_HOME/scripts/select-gcloud-identity.sh` reads
+  `GCLOUD_ROBOT_PROJECT` + `GCLOUD_ROBOT_PROBE_PERMISSION` from env and prints
+  a passing account on stdout or exits 1 with empty stdout (the contract the
+  new suite's fake selector models). Validate by reading the operator-installed
+  script's header/usage (machine-local; allowed read).
+- **A4** `bootstrap-robot.sh` consumes `GCLOUD_ROBOT_PROJECT`,
+  `GCLOUD_ROBOT_ROLES`, `GCLOUD_ROBOT_ADMIN_ACCOUNT`, `--name`, `--activate`
+  (runbook command correctness). Validate by reading the operator-installed
+  script's usage.
+- **A5** The default actAs identities for `misc-puttering-project` are the
+  default compute SA (`<projectNumber>-compute@developer.gserviceaccount.com`)
+  and default Cloud Build SA
+  (`service-<projectNumber>@gcp-sa-cloudbuild.iam.gserviceaccount.com`).
+  Validate against official docs documenting both default SA names.
+
+These are properties of external contracts; the plan's tasks do not depend on
+any other unproven claim. If A1/A2 invalidate a probe permission, swap the
+permission constant(s) — the task structure is unaffected.
+
+---
+
+## Workspace prep (once, before Task 1 step 2)
+
+The worktree has no dependencies installed. Run:
+
+```bash
+cd /home/dan/code/freshell/.worktrees/gcloud-robot-conversion
+npm ci --no-audit --no-fund
+```
+
+Expected: completes with exit 0 (`added N packages`). Needed because
+`cloud-run-wrapper.test.sh` invokes real local Playwright and
+`cloud-vitest-wrapper.test.sh` runs a real local vitest file; the
+identity-suite runs them in turn. Not a coordinator-gated broad run.
+
+---
+
+### Task 1: Shared identity-ladder helper + hermetic ladder suite
+
+Deliverable: `scripts/lib/gcp-identity.sh` — the single sourced home of the
+skill's verbatim `resolve_gcp_identity` drop-in block plus the repo's thin
+bridge — proven by the new suite `scripts/test/cloud-gcp-identity.test.sh`
+(helper-level rung coverage). No wrapper changes yet; the suite's
+wrapper-level block arrives in Task 2.
+
+**Files:**
+- Create: `scripts/lib/gcp-identity.sh` (sourced, mode 644 — no exec bit)
+- Create: `scripts/test/cloud-gcp-identity.test.sh` (mode matches the existing
+  suites: check `stat -c %a scripts/test/cloud-build.test.sh` and mirror it)
+- Test: `scripts/test/cloud-gcp-identity.test.sh` (the suite is its own test)
+
+**Interfaces:**
+- Consumes: the gcloud-robot skill's drop-in contract (`GCLOUD_IDENT`,
+  `GCLOUD_ROBOT_HOME`, `GCLOUD_ROBOT_REQUIRE`, `GCLOUD_ROBOT_PROJECT`,
+  `GCLOUD_ROBOT_PROBE_PERMISSION`).
+- Produces: `resolve_gcp_identity` (verbatim skill block) and
+  `freshell_resolve_cloud_identity <probe-permission>` — bridges the caller's
+  `GCP_PROJECT` into `GCLOUD_ROBOT_PROJECT`, defaults
+  `GCLOUD_ROBOT_PROBE_PERMISSION` from `$1`, then applies a resolved
+  `GCLOUD_IDENT` into the caller's `GCP_ACCOUNT` pin var when it is empty.
+  Used by both wrappers in Task 2.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Create `scripts/test/cloud-gcp-identity.test.sh` with exactly this content
+(task-1 state; Task 2 appends the wrapper-level block at the marked anchor):
+
+```bash
+#!/usr/bin/env bash
+# Test: cloud-gcp-identity — hermetic coverage for the gcloud-robot identity
+# ladder (scripts/lib/gcp-identity.sh) adopted by scripts/e2e-cloud.sh and
+# scripts/vitest-cloud.sh. Covers every ladder rung (rung-1 repo pin respect,
+# rung-2 GCLOUD_IDENT bypass, rung-3 probe via GCLOUD_ROBOT_HOME, rung-4
+# quiet ambient fallback and GCLOUD_ROBOT_REQUIRE=1 fail-closed), bridge/env
+# forwarding, operator overrides, and single-probe idempotency.
+#
+# ALWAYS hermetic: the probe branch drives an inert fake selector under a
+# fake GCLOUD_ROBOT_HOME and every wrapper run uses a stubbed gcloud — no
+# network, no real credentials, no real IAM answers (skill trap 11).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT"
+
+HELPER="$ROOT/scripts/lib/gcp-identity.sh"
+WRAPPER_E2E="$ROOT/scripts/e2e-cloud.sh"
+WRAPPER_VITEST="$ROOT/scripts/vitest-cloud.sh"
+
+FAILURES=0
+check() {
+  local desc="$1"
+  shift
+  if "$@"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "=== Cloud GCP identity ladder test ==="
+
+TDIR="$(mktemp -d /tmp/cloud-gcp-identity.XXXXXX)"
+trap 'rm -rf "$TDIR"' EXIT
+
+# Inert stand-in for the gcloud-robot selector: records every invocation
+# (proves the probe branch ran) plus the env contract it observed, then
+# prints the caller-chosen account or takes the zero-candidate exit-1 path
+# with empty stdout (its documented failure shape — see skill known-issues
+# trap 11). Touches nothing but $TDIR; real curl/gcloud never run.
+FAKE_HOME="$TDIR/robot-home"
+mkdir -p "$FAKE_HOME/scripts"
+cat > "$FAKE_HOME/scripts/select-gcloud-identity.sh" <<'FAKE_SELECTOR'
+#!/usr/bin/env bash
+echo ran >> "${SELECTOR_MARKER:?set SELECTOR_MARKER}"
+echo "project=${GCLOUD_ROBOT_PROJECT:-} probe=${GCLOUD_ROBOT_PROBE_PERMISSION:-}" >> "${SELECTOR_MARKER}.env"
+if [ "${SELECTOR_FAIL:-0}" = "1" ]; then exit 1; fi
+printf '%s\n' "${SELECTOR_ACCOUNT:-}"
+FAKE_SELECTOR
+chmod +x "$FAKE_HOME/scripts/select-gcloud-identity.sh"
+
+SELECTOR_MARKER="$TDIR/selector-ran"
+LADDER_STDERR="$TDIR/stderr"
+
+# Reads one "key=value" outcome line out of a run_ladder transcript.
+field() {
+  grep "^$2=" <<< "$1" | head -1 | cut -d= -f2-
+}
+
+# Runs the identity ladder in a FRESH bash process with exactly the env the
+# caller exported. Stdout: rc/ident/account/pin outcome lines. Stderr from
+# the ladder lands in $LADDER_STDERR. Resets the selector markers per run.
+# Always returns 0: the ladder's own rc is reported as the rc= outcome line,
+# so a crash in the subshell shows up as missing lines, not a set -e abort.
+run_ladder() {
+  # $1 = probe-permission argument handed to freshell_resolve_cloud_identity
+  rm -f "$LADDER_STDERR" "$SELECTOR_MARKER" "$SELECTOR_MARKER.env"
+  env bash -c '
+    set -u
+    . "$1"
+    GCP_PROJECT="misc-puttering-project"
+    GCP_ACCOUNT="${FRESHELL_GCP_ACCOUNT:-}"
+    if freshell_resolve_cloud_identity "$2"; then rc=0; else rc=$?; fi
+    printf "rc=%s\n" "$rc"
+    printf "ident=%s\n" "${GCLOUD_IDENT:-}"
+    printf "account=%s\n" "${CLOUDSDK_CORE_ACCOUNT:-}"
+    printf "pin=%s\n" "$GCP_ACCOUNT"
+  ' _ "$HELPER" "$1" 2>"$LADDER_STDERR" || true
+}
+
+# --- Check A: sourcing is silent and side-effect-free ---------------------
+# help/local lanes source the helper unconditionally, so the source itself
+# must never print, resolve, or require any env.
+SRC_OUT=$(env -u GCLOUD_IDENT -u GCLOUD_ROBOT_HOME bash -c \
+  'set -u; . "$1" && declare -F resolve_gcp_identity >/dev/null && declare -F freshell_resolve_cloud_identity >/dev/null && echo sourced-ok' \
+  _ "$HELPER" 2>&1 || true)
+check "sourcing the helper defines both functions with zero output" \
+  bash -c '[ "$1" = "sourced-ok" ]' _ "$SRC_OUT"
+
+# --- Check B: rung 2 — explicit GCLOUD_IDENT bypass, no network -----------
+OUT=$(export GCLOUD_IDENT="fake-bypass@example.invalid" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER; \
+      run_ladder "run.jobs.run")
+check "rung-2 bypass: GCLOUD_IDENT flows to pin + exports, selector never runs, silent" \
+  bash -c '
+    [ "$1" = "0" ] && [ "$2" = "fake-bypass@example.invalid" ] &&
+    [ "$3" = "fake-bypass@example.invalid" ] && [ "$4" = "fake-bypass@example.invalid" ] &&
+    [ ! -e "$5" ] && [ ! -s "$6" ]
+  ' _ "$(field "$OUT" rc)" "$(field "$OUT" ident)" "$(field "$OUT" account)" "$(field "$OUT" pin)" \
+      "$SELECTOR_MARKER" "$LADDER_STDERR"
+
+# --- Check C: rung 3 — probe selects an account, env contract forwarded ---
+OUT=$(unset GCLOUD_IDENT; \
+      export GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER SELECTOR_ACCOUNT="gcloud-robot@example.invalid"; \
+      run_ladder "run.jobs.run")
+check "rung-3 probe: selector account adopted, project+probe env forwarded, silent" \
+  bash -c '
+    [ "$1" = "0" ] && [ "$2" = "gcloud-robot@example.invalid" ] &&
+    [ "$3" = "gcloud-robot@example.invalid" ] && [ "$4" = "gcloud-robot@example.invalid" ] &&
+    grep -q "project=misc-puttering-project probe=run.jobs.run" "$5.env" &&
+    [ ! -s "$6" ]
+  ' _ "$(field "$OUT" rc)" "$(field "$OUT" ident)" "$(field "$OUT" account)" "$(field "$OUT" pin)" \
+      "$SELECTOR_MARKER" "$LADDER_STDERR"
+
+# --- Check D: probe finds nothing — quiet ambient note, exit 0 ------------
+OUT=$(unset GCLOUD_IDENT; \
+      export GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER SELECTOR_FAIL=1; \
+      run_ladder "run.jobs.run")
+check "probe-empty: one ambient-fallback stderr note, no identity, exit 0" \
+  bash -c '
+    [ "$1" = "0" ] && [ -z "$2" ] && [ -z "$3" ] && [ -z "$4" ] &&
+    [ "$(wc -l < "$5")" = "1" ] &&
+    grep -q "no probed identity; using ambient gcloud" "$5" &&
+    [ -e "$6" ]
+  ' _ "$(field "$OUT" rc)" "$(field "$OUT" ident)" "$(field "$OUT" account)" "$(field "$OUT" pin)" \
+      "$LADDER_STDERR" "$SELECTOR_MARKER"
+
+# --- Check E: skill absent — single quiet ambient note, exit 0 ------------
+OUT=$(unset GCLOUD_IDENT GCLOUD_ROBOT_HOME; export SELECTOR_MARKER; \
+      run_ladder "run.jobs.run")
+check "skill-absent: exactly one ambient-fallback stderr note, exit 0" \
+  bash -c '
+    [ "$1" = "0" ] &&
+    [ "$(wc -l < "$2")" = "1" ] &&
+    grep -q "skill not found .* using ambient gcloud" "$2" &&
+    [ ! -e "$3" ]
+  ' _ "$(field "$OUT" rc)" "$LADDER_STDERR" "$SELECTOR_MARKER"
+
+# --- Check F: strict mode fails closed when the skill is absent -----------
+OUT=$(unset GCLOUD_IDENT GCLOUD_ROBOT_HOME; export GCLOUD_ROBOT_REQUIRE=1; \
+      run_ladder "run.jobs.run")
+check "GCLOUD_ROBOT_REQUIRE=1, skill absent: nonzero rc + strict-mode guidance" \
+  bash -c '
+    [ "$1" != "0" ] && grep -q "strict mode" "$2" && [ -z "$3" ]
+  ' _ "$(field "$OUT" rc)" "$LADDER_STDERR" "$(field "$OUT" account)"
+
+# --- Check G: strict mode fails closed when the probe finds nothing -------
+OUT=$(unset GCLOUD_IDENT; \
+      export GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER SELECTOR_FAIL=1 GCLOUD_ROBOT_REQUIRE=1; \
+      run_ladder "run.jobs.run")
+check "GCLOUD_ROBOT_REQUIRE=1, probe empty: nonzero rc + probe failure named" \
+  bash -c '
+    [ "$1" != "0" ] && grep -q "no identity passes the probe" "$2"
+  ' _ "$(field "$OUT" rc)" "$LADDER_STDERR"
+
+# --- Check H: idempotent — a second resolve never re-runs the selector ----
+rm -f "$SELECTOR_MARKER"
+OUT=$(unset GCLOUD_IDENT; \
+      export GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER SELECTOR_ACCOUNT="once@example.invalid"; \
+      bash -c '
+        set -u
+        . "$1"
+        GCP_PROJECT="misc-puttering-project"
+        GCP_ACCOUNT=""
+        freshell_resolve_cloud_identity "run.jobs.run"
+        freshell_resolve_cloud_identity "cloudbuild.builds.create"
+        printf "ident=%s\n" "$GCLOUD_IDENT"
+      ' _ "$HELPER" 2>/dev/null || true)
+check "two resolves in one process run the selector exactly once" \
+  bash -c '
+    [ "$1" = "once@example.invalid" ] && [ "$(wc -l < "$2")" = "1" ]
+  ' _ "$(field "$OUT" ident)" "$SELECTOR_MARKER"
+
+# --- Check I: operator-pinned GCLOUD_ROBOT_PROJECT survives the bridge ----
+OUT=$(unset GCLOUD_IDENT; \
+      export GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER SELECTOR_ACCOUNT="robot@example.invalid" \
+             GCLOUD_ROBOT_PROJECT="other-project" GCLOUD_ROBOT_PROBE_PERMISSION="custom.perm.check"; \
+      run_ladder "run.jobs.run")
+check "operator overrides: project + probe pass through to the selector verbatim" \
+  bash -c '
+    grep -q "project=other-project probe=custom.perm.check" "$2.env" &&
+    [ "$1" = "robot@example.invalid" ]
+  ' _ "$(field "$OUT" ident)" "$SELECTOR_MARKER"
+
+# --- Check J: rung 1 — a pinned GCP_ACCOUNT is never overwritten ----------
+OUT=$(unset GCLOUD_ROBOT_HOME; \
+      export GCLOUD_IDENT="ident@example.invalid" FRESHELL_GCP_ACCOUNT="pinned@example.invalid"; \
+      run_ladder "run.jobs.run")
+check "explicit account pin wins over the ladder result (rung 1)" \
+  bash -c '
+    [ "$1" = "pinned@example.invalid" ] && [ "$2" = "ident@example.invalid" ] && [ ! -s "$3" ]
+  ' _ "$(field "$OUT" pin)" "$(field "$OUT" ident)" "$LADDER_STDERR"
+
+# WRAPPER-LEVEL-CHECKS-ANCHOR (Task 2 appends here)
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "=== All checks passed ==="
+  exit 0
+else
+  echo "=== $FAILURES check(s) failed ==="
+  exit 1
+fi
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `bash scripts/test/cloud-gcp-identity.test.sh`
+
+Expected: FAIL because `scripts/lib/gcp-identity.sh` does not exist — sourcing
+a missing file aborts each subshell, so Check A's `declare -F` never runs and
+every `run_ladder` transcript is empty (all `field` extractions come back
+empty). All ten checks report FAIL and the suite exits 1. (This is
+missing-behavior failure, not a syntax accident: the suite parses and runs to
+completion, and Check A fails non-vacuously — its expected `sourced-ok`
+marker never appears.)
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Create `scripts/lib/gcp-identity.sh` with exactly this content. The drop-in
+block between the BEGIN/END markers is the skill's verbatim text — the
+implementation shown here was composed against
+`~/.claude/skills/gcloud-robot/SKILL.md` §"The identity ladder is fixed"; if
+any drift is suspected at execution time, re-copy the block from that source
+(diff them if uncertain) and keep the repo copy byte-identical:
+
+```bash
+#!/usr/bin/env bash
+# gcp-identity.sh — shared gcloud identity ladder for Freshell's GCP lanes
+# (scripts/e2e-cloud.sh, scripts/vitest-cloud.sh).
+#
+# THIS FILE IS SOURCED, NOT EXECUTED. It only defines functions — no
+# top-level side effects, no output, no network — so every lane, including
+# `help` and local runs on machines with no gcloud and no skill installed,
+# may source it unconditionally.
+#
+# resolve_gcp_identity below is the gcloud-robot skill's drop-in block,
+# copied VERBATIM. Do not hand-edit it: the rung ordering and the
+# ambient-default / strict-opt-in behavior are load-bearing. The skill
+# itself is never vendored or referenced by path; this block is the single
+# permitted copy, and run-time discovery of the selector happens only via
+# GCLOUD_ROBOT_HOME.
+#
+# Ladder (fixed order):
+#   1. A call-site / repo pin (the wrapper's --account= or FRESHELL_GCP_ACCOUNT)
+#      is never overridden — the bridge below only fills an EMPTY pin var.
+#   2. GCLOUD_IDENT set: use verbatim, no probe, no network.
+#   3. Probe: $GCLOUD_ROBOT_HOME/scripts/select-gcloud-identity.sh picks a
+#      credentialed account that passes the lane's live permission probe.
+#   4. Ambient fallback (default): one quiet stderr note, gcloud runs exactly
+#      as before adoption. GCLOUD_ROBOT_REQUIRE=1 turns rung 4 into
+#      fail-closed-with-guidance (hardening/CI).
+
+# --- BEGIN verbatim drop-in block (gcloud-robot skill) --------------------
+resolve_gcp_identity() {
+  [ -n "${GCLOUD_IDENT_RESOLVED:-}" ] && return 0; GCLOUD_IDENT_RESOLVED=1
+  export GCLOUD_ROBOT_PROJECT="${GCLOUD_ROBOT_PROJECT:?set GCLOUD_ROBOT_PROJECT}"
+  export GCLOUD_ROBOT_PROBE_PERMISSION="${GCLOUD_ROBOT_PROBE_PERMISSION:?set GCLOUD_ROBOT_PROBE_PERMISSION (lane representative permission)}"
+  if [ -n "${GCLOUD_IDENT:-}" ]; then
+    :                                                          # rung 2: explicit bypass, no network
+  elif [ -n "${GCLOUD_ROBOT_HOME:-}" ] && [ -x "$GCLOUD_ROBOT_HOME/scripts/select-gcloud-identity.sh" ]; then
+    GCLOUD_IDENT="$(bash "$GCLOUD_ROBOT_HOME/scripts/select-gcloud-identity.sh" 2>/dev/null)" || GCLOUD_IDENT=""
+    if [ -z "$GCLOUD_IDENT" ] && [ -n "${GCLOUD_ROBOT_REQUIRE:-}" ]; then
+      echo "gcloud-robot: no identity passes the probe on $GCLOUD_ROBOT_PROJECT (strict mode)" >&2
+      return 1
+    fi
+    [ -z "$GCLOUD_IDENT" ] && echo "gcloud-robot: no probed identity; using ambient gcloud" >&2
+  elif [ -n "${GCLOUD_ROBOT_REQUIRE:-}" ]; then
+    echo "gcloud-robot: skill not found at ${GCLOUD_ROBOT_HOME:-<unset>}... (strict mode)" >&2
+    return 1                                                   # rung 4: fail closed (opt-in)
+  else
+    echo "gcloud-robot: skill not found at ${GCLOUD_ROBOT_HOME:-<unset>} — using ambient gcloud (set GCLOUD_ROBOT_HOME to get robot identity)" >&2
+  fi
+  if [ -n "${GCLOUD_IDENT:-}" ]; then
+    export CLOUDSDK_CORE_ACCOUNT="$GCLOUD_IDENT" CLOUDSDK_CORE_PROJECT="$GCLOUD_ROBOT_PROJECT"
+  fi
+}
+# --- END verbatim drop-in block --------------------------------------------
+# Nesting rule (from the skill): never write ${...:?...} messages with
+# apostrophes — bash parses the ${} interior as its own quoting context.
+
+# freshell_resolve_cloud_identity bridges a wrapper's settings into the
+# ladder and applies a probed identity to the wrapper's pinned account var.
+#
+#   $1 = this lane's representative probe permission (the permission that
+#        gates the lane's real work): "cloudbuild.builds.create" for the
+#        build/push lane, "run.jobs.run" for the run and logs lanes.
+#
+# Call it LAZILY — immediately before a cloud lane's first real gcloud call,
+# after flag parsing — so help/local lanes never touch GCP tooling. The
+# ladder's own guard makes repeat calls free (single probe per process).
+#
+# Requires the caller to provide GCP_PROJECT and GCP_ACCOUNT (possibly
+# empty), matching both cloud wrappers' top-of-file defaults.
+freshell_resolve_cloud_identity() {
+  export GCLOUD_ROBOT_PROJECT="${GCLOUD_ROBOT_PROJECT:-${GCP_PROJECT:?GCP_PROJECT must be set before identity resolution}}"
+  export GCLOUD_ROBOT_PROBE_PERMISSION="${GCLOUD_ROBOT_PROBE_PERMISSION:-${1:?probe permission argument required}}"
+  resolve_gcp_identity
+  # Pinned-call adoption (gcloud-robot skill): a probed identity takes the
+  # pinned --account slot ONLY when nothing pinned one — an operator's
+  # --account= / FRESHELL_GCP_ACCOUNT (rung 1) always wins. With nothing
+  # resolved the pin stays empty and the wrappers omit --account entirely,
+  # letting ambient gcloud apply (the ladder already noted that on stderr).
+  GCP_ACCOUNT="${GCP_ACCOUNT:-${GCLOUD_IDENT:-}}"
+}
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `bash scripts/test/cloud-gcp-identity.test.sh`
+
+Expected: PASS — all ten checks (A–J) print PASS and the footer prints
+`=== All checks passed ===` (exit 0).
+
+- [ ] **Step 5: Refactor while green**
+
+No refactor: the helper is the skill's verbatim block plus a deliberately
+minimal bridge, and the suite is new and self-contained (the `field()` +
+`run_ladder` helpers are the dedup point — checks carry no repeated command
+pipelines).
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The helper is new and sourced by nothing yet, so no existing behavior can be
+affected; the impacted set is the new suite plus the four existing cloud
+suites proving untouched base behavior:
+
+Run:
+```bash
+for t in scripts/test/cloud-gcp-identity.test.sh \
+         scripts/test/cloud-build.test.sh \
+         scripts/test/cloud-exec-id-parse.test.sh \
+         scripts/test/cloud-vitest-wrapper.test.sh \
+         scripts/test/cloud-run-wrapper.test.sh; do
+  bash "$t" || { echo "SUITE FAILED: $t"; exit 1; }
+done
+```
+
+Expected: PASS — every suite exits 0. (Runtime note: cloud-run-wrapper runs
+real local Playwright several times; allow a few minutes.)
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add scripts/lib/gcp-identity.sh scripts/test/cloud-gcp-identity.test.sh
+git commit -m "feat(cloud): add gcloud-robot identity ladder helper + hermetic ladder suite"
+```
+
+---
+
+### Task 2: Wire the identity ladder into both cloud wrappers
+
+Deliverable: `scripts/e2e-cloud.sh` and `scripts/vitest-cloud.sh` resolve
+their gcloud identity through the shared helper, lazily per cloud lane, with
+the hardcoded human default removed; the four pre-existing stubbed suites
+gain their trap-11 pins; the identity suite gains wrapper-level coverage for
+the whole precedence chain on the real wrappers. Both wrappers receive the
+same wiring — the helper is the single dedup point, so the edits are small
+and mirrored (every hunk is still spelled out per file below).
+
+**Files:**
+- Modify: `scripts/e2e-cloud.sh` (hunks E1–E11; anchors verified at base
+  530f5f35: default at line 45, source point after 56, helpers 94–114,
+  cmd_build 191, cmd_push 220, cmd_run 364/367, submit 208, token 231,
+  describe 392–393, cmd_logs 575, usage 136/140–142, header comment 29)
+- Modify: `scripts/vitest-cloud.sh` (hunks V1–V11; same shape: default 43,
+  source after 54, helpers 91–112, cmd_build 187, cmd_push 216, cmd_run
+  345/347, submit 204–205, token 226, describe 376, cmd_logs 544, usage
+  133/137–139, header comment 28)
+- Modify: `scripts/test/cloud-build.test.sh` (pin after line 7 `cd "$ROOT"`)
+- Modify: `scripts/test/cloud-exec-id-parse.test.sh` (pin after line 18)
+- Modify: `scripts/test/cloud-run-wrapper.test.sh` (pin after line 7)
+- Modify: `scripts/test/cloud-vitest-wrapper.test.sh` (pin after line 8)
+- Modify: `scripts/test/cloud-gcp-identity.test.sh` (append the wrapper-level
+  block at the `WRAPPER-LEVEL-CHECKS-ANCHOR`)
+
+**Interfaces:**
+- Consumes: `freshell_resolve_cloud_identity` and `resolve_gcp_identity` from
+  Task 1's `scripts/lib/gcp-identity.sh` (sourced via `$SCRIPT_DIR/lib/`).
+- Produces: wrapper-local `account_flag()`, the conditional `gcloud_flags()` /
+  `gcloud_artifacts_flags()`, and the no-human-default `GCP_ACCOUNT`
+  lifecycle (`--account=` > `FRESHELL_GCP_ACCOUNT` > ladder > omitted).
+
+#### Wrapper edit reference (apply E1–E11 to e2e-cloud.sh; V1–V11 mirror to vitest-cloud.sh)
+
+**E1 / V1 — remove the hardcoded default.** e2e-cloud.sh:45
+`GCP_ACCOUNT="${FRESHELL_GCP_ACCOUNT:-dan@danshapiro.com}"` /
+vitest-cloud.sh:43 (same line) become:
+
+```bash
+# No account is hardcoded. Precedence: --account= flag > FRESHELL_GCP_ACCOUNT
+# > gcloud-robot identity ladder (freshell_resolve_cloud_identity, resolved
+# lazily per cloud lane) > unset — calls then omit --account and ambient
+# gcloud applies, which the ladder announces once on stderr.
+GCP_ACCOUNT="${FRESHELL_GCP_ACCOUNT:-}"
+```
+
+**E2 / V2 — source the helper.** Immediately after the `SCRIPT_DIR`/`ROOT`
+lines (e2e-cloud.sh:55-56 / vitest-cloud.sh:53-54):
+
+```bash
+# Shared gcloud identity ladder (gcloud-robot). Sourcing only defines
+# functions — no side effects, no output — so help and local lanes stay
+# gcloud-free and silent.
+# shellcheck source=scripts/lib/gcp-identity.sh
+. "$SCRIPT_DIR/lib/gcp-identity.sh"
+```
+
+**E3 / V3 — conditional account in the two flag helpers, plus `account_flag()`.**
+e2e-cloud.sh:94-96 / vitest-cloud.sh:91-93 (`gcloud_flags`) and
+e2e-cloud.sh:112-114 / vitest-cloud.sh:110-112 (`gcloud_artifacts_flags`)
+become (region vs location kept as-is per helper), followed by the new
+`account_flag`:
+
+```bash
+gcloud_flags() {
+  # No identity may legitimately resolve (rung 4: ambient gcloud). An empty
+  # pin omits --account entirely rather than passing gcloud an empty value.
+  if [ -n "${GCP_ACCOUNT:-}" ]; then
+    echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --region=${GCP_REGION}"
+  else
+    echo "--project=${GCP_PROJECT} --region=${GCP_REGION}"
+  fi
+}
+```
+
+```bash
+# gcloud artifacts commands use --location, not --region
+gcloud_artifacts_flags() {
+  if [ -n "${GCP_ACCOUNT:-}" ]; then
+    echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --location=${GCP_REGION}"
+  else
+    echo "--project=${GCP_PROJECT} --location=${GCP_REGION}"
+  fi
+}
+
+# Prints a pinned --account flag, or NOTHING (not even an empty word) when no
+# identity resolved — for the gcloud calls that pin inline instead of via
+# gcloud_flags(). An empty expansion inside an unquoted $() yields no argv
+# word, which is exactly what "omit --account" needs; always exits 0.
+account_flag() {
+  if [ -n "${GCP_ACCOUNT:-}" ]; then
+    printf -- '--account=%s' "${GCP_ACCOUNT}"
+  fi
+}
+```
+
+**E4 / V4 — resolve in `cmd_build`.** Immediately before the
+`# Content-addressed tag` block comment (e2e-cloud.sh:191 /
+vitest-cloud.sh:187), after the flag-parse loop:
+
+```bash
+  # Identity ladder (build/push lane): resolve before the first gcloud call,
+  # never at script top — help and local-only paths must keep working with
+  # zero GCP tooling. Probe = the lane's gating permission.
+  freshell_resolve_cloud_identity "cloudbuild.builds.create"
+```
+
+**E5 / V5 — resolve in `cmd_push`.** As the first statement after the
+"Building"/"Pushing" banner (e2e-cloud.sh after :220 `echo "[e2e-cloud]
+Pushing to Artifact Registry..."` / vitest-cloud.sh after :216
+`echo "[vitest-cloud] Pushing to Artifact Registry..."`):
+
+```bash
+  # A standalone `push` reaches gcloud without passing through cmd_build;
+  # resolve idempotently (free when cmd_build already did).
+  freshell_resolve_cloud_identity "cloudbuild.builds.create"
+```
+
+**E6 / V6 — resolve in `cmd_run`'s cloud branch.** After the local branch
+closes (e2e-cloud.sh: the `fi` after the `exec npx playwright test` block at
+:364 / vitest-cloud.sh: the `fi` after `exit "$exit_code"` at :345) and before
+the `# Recompute the remote ref` comment:
+
+```bash
+  # Identity ladder (run lane): resolve before the image describe / build /
+  # job calls below. `run --local` never reaches here (it exec'd or exited
+  # above), so the local lane stays free of GCP tooling and of the ladder's
+  # stderr note.
+  freshell_resolve_cloud_identity "run.jobs.run"
+```
+
+**E7 / V7 — drop the inline pin on `builds submit`.**
+e2e-cloud.sh:206-211 / vitest-cloud.sh:202-207:
+
+```bash
+    gcloud builds submit \
+      --config "$ROOT/docker/cloud-run/cloudbuild.yaml" \
+      $(account_flag) \
+      --project="$GCP_PROJECT" \
+      --substitutions=_IMAGE="${remote_base}:${tag}" \
+      "$ROOT"
+```
+
+**E8 / V8 — drop the inline pin on `print-access-token`.**
+e2e-cloud.sh:231 / vitest-cloud.sh:226:
+
+```bash
+  gcloud auth print-access-token $(account_flag) | \
+    docker login -u oauth2accesstoken --password-stdin \
+      "https://${GCP_REGION}-docker.pkg.dev"
+```
+
+An omitted `--account` here lets gcloud resolve ambient credentials for token
+minting; a missing ambient account surfaces gcloud's own reauthentication
+error, which the ladder's stderr note has already contextualized.
+
+**E9 / V9 — drop the inline pin on the image-existence probe.**
+e2e-cloud.sh:392-393:
+
+```bash
+  elif ! gcloud artifacts docker images describe "$IMAGE_REMOTE" \
+      $(account_flag) --project="$GCP_PROJECT" &>/dev/null 2>&1; then
+```
+
+vitest-cloud.sh:376-377:
+
+```bash
+  if ! gcloud artifacts docker images describe "$IMAGE_REMOTE" \
+      $(account_flag) --project="$GCP_PROJECT" &>/dev/null 2>&1; then
+```
+
+(The `elif`/`if` difference is the wrappers' existing structure; keep it.)
+
+**E10 / V10 — resolve in `cmd_logs`.** First statement of `cmd_logs`
+(e2e-cloud.sh before :575 `local execution_id` / vitest-cloud.sh before
+:544):
+
+```bash
+  # logs is a cloud-only lane (executions list + logs read); resolve before
+  # the first gcloud call.
+  freshell_resolve_cloud_identity "run.jobs.run"
+```
+
+**E11 / V11 — help + header text.** e2e-cloud.sh:29 header line and
+e2e-cloud.sh usage(); vitest-cloud.sh:28 header line and
+vitest-cloud.sh usage(). Header comment `--account` line becomes:
+
+```
+#   --account=EMAIL   GCP account pin (highest precedence; default: none —
+#                     FRESHELL_GCP_ACCOUNT env, then the gcloud-robot identity
+#                     ladder, then ambient gcloud)
+```
+
+usage() `--account` line becomes:
+
+```
+  --account=EMAIL   GCP account pin (highest precedence; default: none)
+```
+
+and the usage() `Environment:` block gains the knob documentation (e2e
+version shown; vitest version identical except `FRESHELL_E2E_BACKEND` →
+`FRESHELL_VITEST_BACKEND` and `FRESHELL_GCP_JOB` → `FRESHELL_GCP_VITEST_JOB`):
+
+```
+Environment:
+  FRESHELL_E2E_BACKEND  "local" (default) or "cloud"
+  FRESHELL_GCP_JOB      Cloud Run job-name prefix (default: freshell-e2e)
+  FRESHELL_GCP_ACCOUNT  GCP account override pinned on every gcloud call (optional)
+
+Identity (cloud lanes only — details: docs/development/gcloud-robot.md):
+  Cloud subcommands resolve a gcloud identity lazily, in this order:
+  --account= > FRESHELL_GCP_ACCOUNT > GCLOUD_IDENT > gcloud-robot probe
+  (needs GCLOUD_ROBOT_HOME, the installed gcloud-robot skill directory)
+  > ambient gcloud (one quiet stderr note). GCLOUD_ROBOT_REQUIRE=1 fails
+  closed with guidance instead of the ambient fallback.
+```
+
+#### Trap-11 pins for the four pre-existing suites
+
+Insert immediately after each suite's `cd "$ROOT"` line
+(cloud-build.test.sh:7, cloud-run-wrapper.test.sh:7,
+cloud-vitest-wrapper.test.sh:8, cloud-exec-id-parse.test.sh:18), identical in
+all four:
+
+```bash
+# gcloud-robot hermeticity pin (skill trap 11): the wrappers now carry a live
+# identity ladder. Pinning GCLOUD_IDENT forces the ladder's rung-2 bypass, so
+# no wrapper invocation from this suite can reach the real probe/network —
+# even if the harness environment happens to export GCLOUD_ROBOT_HOME. The
+# value is deliberately fake; nothing in this suite depends on it.
+export GCLOUD_IDENT="suite-pinned-identity@example.invalid"
+```
+
+#### Identity-suite wrapper-level block (appended at `WRAPPER-LEVEL-CHECKS-ANCHOR`)
+
+```bash
+# ---------------------------------------------------------------------------
+# Wrapper-level: the ladder drives --account on REAL wrapper cloud runs
+# (stubbed gcloud/docker; green-run shape mirrors cloud-exec-id-parse.test.sh).
+# ---------------------------------------------------------------------------
+echo "--- Wrapper-level identity checks ---"
+
+GTDIR="$TDIR/gcloud-stub"
+mkdir -p "$GTDIR"
+GREEN_LOG="$TDIR/green-gcloud.log"
+
+# Green-run fake gcloud. images describe reports the image MISSING (exit 1)
+# so every run also crosses the build lane (builds submit stubbed); the job
+# lifecycle succeeds for any --shards value. Records every argv in $GREEN_LOG
+# and every --account token (one per line) in $GREEN_LOG.accounts — an ABSENT
+# accounts file is the proof that every call omitted --account.
+cat > "$GTDIR/gcloud" <<'GREEN_FAKE'
+#!/usr/bin/env bash
+echo "GCLOUD_ARGS: $*" >> "${GREEN_LOG:?set GREEN_LOG}"
+grep -oP -- '--account=\S+' <<< "$*" >> "${GREEN_LOG}.accounts" 2>/dev/null || true
+if [[ "$*" == *"info"* ]]; then echo "/nonexistent-sdk-root"; exit 0; fi
+if [[ "$*" == *"artifacts docker images describe"* ]]; then exit 1; fi
+if [[ "$*" == *"artifacts repositories describe"* ]]; then exit 0; fi
+if [[ "$*" == *"artifacts repositories create"* ]]; then exit 0; fi
+if [[ "$*" == *"builds submit"* ]]; then exit 0; fi
+if [[ "$*" == *"auth print-access-token"* ]]; then echo stub-token; exit 0; fi
+if [[ "$*" == *"run jobs execute"* ]]; then echo "Execution [green-exec-1] has successfully completed."; exit 0; fi
+if [[ "$*" == *"executions list"* ]]; then echo "green-exec-1"; exit 0; fi
+if [[ "$*" == *"executions describe"* ]]; then
+  if [[ "$*" == *"succeededCount"* ]]; then
+    N=$(grep -oP -- '--tasks=\K[0-9]+' "${GREEN_LOG}" | tail -1)
+    echo "${N:-1}"
+  else
+    echo "0"
+  fi
+  exit 0
+fi
+if [[ "$*" == *"logs read"* ]]; then echo "  1 passed (1.0s)"; exit 0; fi
+if [[ "$*" == *"run jobs"* ]]; then exit 0; fi
+exit 0
+GREEN_FAKE
+cat > "$GTDIR/docker" <<'GREEN_DOCKER'
+#!/usr/bin/env bash
+if [ ! -t 0 ]; then cat >/dev/null 2>&1 || true; fi
+exit 0
+GREEN_DOCKER
+chmod +x "$GTDIR/gcloud" "$GTDIR/docker"
+
+# Distinctive values per rung and pin source so the accounts log proves
+# WHICH token won, never just that some token appeared.
+RUNG2_IDENT="rung2-bypass@example.invalid"
+RUNG3_ROBOT="rung3-robot@example.invalid"
+FLAG_ACCOUNT="flag-wins@example.invalid"
+ENV_ACCOUNT="env-wins@example.invalid"
+
+reset_green() {
+  rm -f "$GREEN_LOG" "$GREEN_LOG.accounts" "$SELECTOR_MARKER" "$SELECTOR_MARKER.env"
+  touch "$GREEN_LOG"
+}
+
+# Every --account token observed across a run equals the expected one, and at
+# least one pinned call exists (an empty log proves nothing).
+accounts_all_equal() {
+  [ -s "$GREEN_LOG.accounts" ] && \
+    [ "$(sort -u "$GREEN_LOG.accounts" | wc -l)" = "1" ] && \
+    [ "$(sort -u "$GREEN_LOG.accounts" | head -1)" = "--account=$1" ]
+}
+
+# --- W1: e2e rung 2 — GCLOUD_IDENT drives every pinned call ----------------
+reset_green
+W1_ERR="$TDIR/w1.err"
+W1_OUT=$(env PATH="$GTDIR:$PATH" \
+         GCLOUD_IDENT="$RUNG2_IDENT" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER="$SELECTOR_MARKER" \
+         "$WRAPPER_E2E" run --cloud --shards=1 2>"$W1_ERR") && W1_RC=0 || W1_RC=$?
+check "W1 e2e rung-2: run succeeds with GCLOUD_IDENT pinned on every call, selector untouched, silent" \
+  bash -c '
+    [ "$1" = "0" ] && grep -q "All tasks completed successfully" <<<"$2" &&
+    [ ! -s "$3" ]
+  ' _ "$W1_RC" "$W1_OUT" "$W1_ERR"
+check "W1 e2e rung-2: every gcloud call pinned to the GCLOUD_IDENT value" \
+  accounts_all_equal "$RUNG2_IDENT"
+check "W1 e2e rung-2: selector never ran and no hardcoded human account appeared" \
+  bash -c '[ ! -e "$1" ] && ! grep -q "dan@danshapiro" "$2"' _ "$SELECTOR_MARKER" "$GREEN_LOG"
+
+# --- W2: e2e rung 1 — --account= beats FRESHELL_GCP_ACCOUNT > GCLOUD_IDENT -
+reset_green
+W2_OUT=$(env PATH="$GTDIR:$PATH" \
+         GCLOUD_IDENT="$RUNG2_IDENT" FRESHELL_GCP_ACCOUNT="$ENV_ACCOUNT" \
+         "$WRAPPER_E2E" run --cloud --shards=1 --account="$FLAG_ACCOUNT" 2>/dev/null) && W2_RC=0 || W2_RC=$?
+check "W2 e2e rung-1: --account= flag wins over env and ladder" \
+  bash -c '[ "$1" = "0" ]' _ "$W2_RC"
+check "W2 e2e rung-1: every gcloud call pinned to the flag value" \
+  accounts_all_equal "$FLAG_ACCOUNT"
+
+# --- W3: e2e rung 1b — FRESHELL_GCP_ACCOUNT beats GCLOUD_IDENT -------------
+reset_green
+W3_OUT=$(env PATH="$GTDIR:$PATH" \
+         GCLOUD_IDENT="$RUNG2_IDENT" FRESHELL_GCP_ACCOUNT="$ENV_ACCOUNT" \
+         "$WRAPPER_E2E" run --cloud --shards=1 2>/dev/null) && W3_RC=0 || W3_RC=$?
+check "W3 e2e env-pin: FRESHELL_GCP_ACCOUNT wins over the ladder" \
+  bash -c '[ "$1" = "0" ]' _ "$W3_RC"
+check "W3 e2e env-pin: every gcloud call pinned to the env value" \
+  accounts_all_equal "$ENV_ACCOUNT"
+
+# --- W4: e2e rung 3 — the probe result takes the pinned slot ---------------
+reset_green
+W4_OUT=$(env -u GCLOUD_IDENT -u FRESHELL_GCP_ACCOUNT PATH="$GTDIR:$PATH" \
+         GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER="$SELECTOR_MARKER" SELECTOR_ACCOUNT="$RUNG3_ROBOT" \
+         "$WRAPPER_E2E" run --cloud --shards=1 2>/dev/null) && W4_RC=0 || W4_RC=$?
+check "W4 e2e rung-3: probed identity pins every call; selector ran once w/ lane probe" \
+  bash -c '
+    [ "$1" = "0" ] &&
+    [ "$(wc -l < "$2")" = "1" ] &&
+    grep -q "project=misc-puttering-project probe=run.jobs.run" "$2.env"
+  ' _ "$W4_RC" "$SELECTOR_MARKER"
+check "W4 e2e rung-3: every gcloud call pinned to the probed robot" \
+  accounts_all_equal "$RUNG3_ROBOT"
+
+# --- W5: e2e rung 4 — nothing resolves: --account omitted, one note ---------
+reset_green
+W5_ERR="$TDIR/w5.err"
+W5_OUT=$(env -u GCLOUD_IDENT -u GCLOUD_ROBOT_HOME -u FRESHELL_GCP_ACCOUNT \
+         PATH="$GTDIR:$PATH" "$WRAPPER_E2E" run --cloud --shards=1 2>"$W5_ERR") && W5_RC=0 || W5_RC=$?
+check "W5 e2e ambient: run succeeds, --account omitted everywhere, one ambient note" \
+  bash -c '
+    [ "$1" = "0" ] && grep -q "All tasks completed successfully" <<<"$2" &&
+    [ ! -e "$3" ] &&
+    [ "$(wc -l < "$4")" = "1" ] &&
+    grep -q "skill not found .* using ambient gcloud" "$4"
+  ' _ "$W5_RC" "$W5_OUT" "$GREEN_LOG.accounts" "$W5_ERR"
+
+# --- W6: vitest parity — rung-2 pin and rung-4 omission -------------------
+reset_green
+W6A_ERR="$TDIR/w6a.err"
+W6A_OUT=$(env PATH="$GTDIR:$PATH" \
+          GCLOUD_IDENT="$RUNG2_IDENT" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER="$SELECTOR_MARKER" \
+          "$WRAPPER_VITEST" run --cloud --config=default --shards=2 2>"$W6A_ERR") && W6A_RC=0 || W6A_RC=$?
+check "W6a vitest rung-2: succeeds, every call pinned to GCLOUD_IDENT, selector untouched" \
+  bash -c '
+    [ "$1" = "0" ] && grep -q "All tasks completed successfully" <<<"$2" &&
+    [ ! -e "$3" ] && [ ! -s "$4" ]
+  ' _ "$W6A_RC" "$W6A_OUT" "$SELECTOR_MARKER" "$W6A_ERR"
+check "W6a vitest rung-2: every gcloud call pinned to the GCLOUD_IDENT value" \
+  accounts_all_equal "$RUNG2_IDENT"
+
+reset_green
+W6B_ERR="$TDIR/w6b.err"
+W6B_OUT=$(env -u GCLOUD_IDENT -u GCLOUD_ROBOT_HOME -u FRESHELL_GCP_ACCOUNT \
+          PATH="$GTDIR:$PATH" "$WRAPPER_VITEST" run --cloud --config=default --shards=2 2>"$W6B_ERR") && W6B_RC=0 || W6B_RC=$?
+check "W6b vitest ambient: run succeeds, --account omitted everywhere, one ambient note" \
+  bash -c '
+    [ "$1" = "0" ] && grep -q "All tasks completed successfully" <<<"$2" &&
+    [ ! -e "$3" ] &&
+    [ "$(wc -l < "$4")" = "1" ] &&
+    grep -q "skill not found .* using ambient gcloud" "$4"
+  ' _ "$W6B_RC" "$W6B_OUT" "$GREEN_LOG.accounts" "$W6B_ERR"
+
+# --- W7: the four pre-existing stubbed suites are probe-proof (trap 11) ----
+# Each pins GCLOUD_IDENT, so running them under a marker-trap
+# GCLOUD_ROBOT_HOME whose selector would FAIL must leave the marker untouched
+# AND the suites green: no nested wrapper invocation may reach the probe.
+for nested in scripts/test/cloud-build.test.sh \
+              scripts/test/cloud-exec-id-parse.test.sh \
+              scripts/test/cloud-vitest-wrapper.test.sh \
+              scripts/test/cloud-run-wrapper.test.sh; do
+  rm -f "$SELECTOR_MARKER"
+  env GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER="$SELECTOR_MARKER" SELECTOR_FAIL=1 \
+    bash "$nested" >"$TDIR/nested.log" 2>&1 && NESTED_RC=0 || NESTED_RC=$?
+  check "W7 trap-11: $nested green and probe-free under hostile GCLOUD_ROBOT_HOME" \
+    bash -c '[ "$1" = "0" ] && [ ! -e "$2" ]' _ "$NESTED_RC" "$SELECTOR_MARKER"
+done
+
+# --- W8: help works with no gcloud, no account, fake HOME — and silently ---
+CLEAN_PATH="$PATH"
+if GCLOUD_PATH_RESOLVED=$(command -v gcloud 2>/dev/null); then
+  GCLOUD_DIRNAME="$(cd "$(dirname "$GCLOUD_PATH_RESOLVED")" && pwd)"
+  CLEAN_PATH="$(echo "$PATH" | tr ':' '\n' | grep -vx "$GCLOUD_DIRNAME" | paste -sd:)"
+  if [ "$CLEAN_PATH" = "$PATH" ]; then
+    echo "FAIL: could not construct a gcloud-free PATH (gcloud dir not on PATH?)"
+    FAILURES=$((FAILURES + 1))
+    CLEAN_PATH=""
+  fi
+fi
+if [ -n "$CLEAN_PATH" ]; then
+  if env PATH="$CLEAN_PATH" command -v gcloud >/dev/null 2>&1; then
+    echo "FAIL: gcloud still resolvable on the filtered PATH"
+    FAILURES=$((FAILURES + 1))
+  else
+    for wrapper_pair in "E2E:$WRAPPER_E2E" "VITEST:$WRAPPER_VITEST"; do
+      lane="${wrapper_pair%%:*}"
+      wrapper="${wrapper_pair#*:}"
+      rm -f "$SELECTOR_MARKER"
+      HELP_OUT=$(env -u GCLOUD_IDENT -u FRESHELL_GCP_ACCOUNT PATH="$CLEAN_PATH" \
+        GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER="$SELECTOR_MARKER" \
+        "$wrapper" help 2>&1) && HELP_RC=0 || HELP_RC=$?
+      check "W8 $lane help: exit 0, prints usage, no identity activity, silent" \
+        bash -c '
+          [ "$1" = "0" ] && grep -qi "usage" <<<"$2" &&
+          ! grep -q "gcloud-robot" <<<"$2" && [ ! -e "$3" ]
+        ' _ "$HELP_RC" "$HELP_OUT" "$SELECTOR_MARKER"
+    done
+  fi
+fi
+
+# --- W9: the vitest local lane never wakes the ladder ----------------------
+rm -f "$SELECTOR_MARKER"
+W9_OUT=$(env -u GCLOUD_IDENT -u FRESHELL_GCP_ACCOUNT \
+         GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_MARKER="$SELECTOR_MARKER" \
+         "$WRAPPER_VITEST" run --local --config=default test/unit/lib/pane-utils.test.ts 2>&1) \
+  && W9_RC=0 || W9_RC=$?
+check "W9 vitest --local: runs real local vitest, no selector, no ladder output" \
+  bash -c '
+    [ "$1" = "0" ] &&
+    grep -qE "Test Files|passed" <<<"$2" &&
+    ! grep -q "gcloud-robot" <<<"$2" && [ ! -e "$3" ]
+  ' _ "$W9_RC" "$W9_OUT" "$SELECTOR_MARKER"
+
+# --- W10/W11: help documents every identity knob, no human default ---------
+E2E_HELP=$("$WRAPPER_E2E" help 2>&1)
+VITEST_HELP=$("$WRAPPER_VITEST" help 2>&1)
+for knob in GCLOUD_IDENT GCLOUD_ROBOT_HOME GCLOUD_ROBOT_REQUIRE FRESHELL_GCP_ACCOUNT; do
+  check "W10 e2e help mentions $knob" bash -c 'grep -q "$1" <<<"$2"' _ "$knob" "$E2E_HELP"
+  check "W11 vitest help mentions $knob" bash -c 'grep -q "$1" <<<"$2"' _ "$knob" "$VITEST_HELP"
+done
+check "W10 e2e help carries no hardcoded human account" \
+  bash -c '! grep -q "dan@danshapiro" <<<"$1"' _ "$E2E_HELP"
+check "W11 vitest help carries no hardcoded human account" \
+  bash -c '! grep -q "dan@danshapiro" <<<"$1"' _ "$VITEST_HELP"
+
+# DOC-CHECKS-ANCHOR (Task 3 appends here)
+```
+
+- [ ] **Step 1: Extend the failing behavioral test**
+
+Append the wrapper-level block above to `scripts/test/cloud-gcp-identity.test.sh`,
+replacing the `# WRAPPER-LEVEL-CHECKS-ANCHOR (Task 2 appends here)` line.
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `bash scripts/test/cloud-gcp-identity.test.sh`
+
+Expected: FAIL against the not-yet-wired wrappers, with exactly this failure
+profile: W1–W4 and W6a fail because `accounts_all_equal` sees an empty or
+absent accounts log (nothing pins `--account` from `GCLOUD_IDENT`/probe yet);
+W5 and W6b fail because the single `skill not found ... using ambient gcloud`
+stderr note does not exist yet; W10/W11 fail because help documents none of
+the knobs. W7 and W8/W9's silence assertions pass vacuously pre-wiring (no
+ladder exists to trigger the trap); W7's red proof comes in the step-3
+interim run below.
+
+- [ ] **Step 3: Add the minimal production implementation — wrapper wiring only**
+
+Apply hunks E1–E11 to `scripts/e2e-cloud.sh` and V1–V11 to
+`scripts/vitest-cloud.sh` per the edit reference above. Do NOT yet add the
+four trap-11 pins.
+
+Interim verification (the pins' red proof): run
+`bash scripts/test/cloud-gcp-identity.test.sh` and confirm W1–W6, W8–W11 are
+now GREEN while **W7 is RED with `$SELECTOR_MARKER` written** — the nested
+suites invoked the wired wrappers, the ladder reached rung 3, and the
+marker-trap selector ran: exactly the trap-11 network-reachability hazard,
+caught hermetically. Record the marker's existence, then proceed.
+
+- [ ] **Step 4: Add the trap-11 pins and re-run**
+
+Add the pin block to all four pre-existing suites (anchor: after each
+`cd "$ROOT"`). Run:
+
+Run: `bash scripts/test/cloud-gcp-identity.test.sh`
+
+Expected: PASS — every check (helper-level A–J, wrapper-level W1–W11) passes
+and the footer prints `=== All checks passed ===` (exit 0). Runtime note:
+W7's nested `cloud-run-wrapper.test.sh` runs real local Playwright several
+times; allow a few minutes for the full suite.
+
+- [ ] **Step 5: Refactor while green**
+
+None. The ladder itself is deduplicated through the shared helper by design;
+the remaining mirror-structure edits (flag helpers, `account_flag`, three
+one-line resolve calls per wrapper) match the wrappers' established parallel
+layout — collapsing them would diverge from the repo's existing structure
+without removing real duplication. No repo-configured shell lint covers these
+wrappers; do a visual consistency pass on the two diffs instead
+(`git diff scripts/e2e-cloud.sh scripts/vitest-cloud.sh`) and confirm the
+hunks mirror each other apart from names/line placement.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Both wrappers changed and all six suites exercise them; the impacted set is
+the full cloud-suite loop:
+
+Run:
+```bash
+for t in scripts/test/cloud-gcp-identity.test.sh \
+         scripts/test/cloud-build.test.sh \
+         scripts/test/cloud-exec-id-parse.test.sh \
+         scripts/test/cloud-vitest-wrapper.test.sh \
+         scripts/test/cloud-run-wrapper.test.sh; do
+  bash "$t" || { echo "SUITE FAILED: $t"; exit 1; }
+done
+```
+
+Expected: PASS — every suite exits 0. (No TypeScript sources changed, so the
+vitest/tsc lanes are structurally unaffected; their regression coverage
+arrives via the workflow's coordinated suite at the stage gate.)
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add scripts/e2e-cloud.sh scripts/vitest-cloud.sh \
+        scripts/test/cloud-build.test.sh scripts/test/cloud-exec-id-parse.test.sh \
+        scripts/test/cloud-run-wrapper.test.sh scripts/test/cloud-vitest-wrapper.test.sh \
+        scripts/test/cloud-gcp-identity.test.sh
+git commit -m "feat(cloud): wire gcloud-robot identity ladder into e2e/vitest cloud wrappers"
+```
+
+---
+
+### Task 3: Operator runbook + AGENTS.md identity sections
+
+Deliverable: `docs/development/gcloud-robot.md` — the operator runbook
+(robot identity, provisioning checklist, verify-as-domain step, rotation,
+revocation, monitoring, both adoption states) — plus the mandatory AGENTS.md
+updates in the two cloud-backend sections.
+
+**Files:**
+- Create: `docs/development/gcloud-robot.md`
+- Modify: `AGENTS.md` (one Identity paragraph appended to each of
+  `### Vitest Test Backend (Cloud Run Jobs)` and `### E2E Test Backend
+  (Cloud Run Jobs)`)
+- Modify: `scripts/test/cloud-gcp-identity.test.sh` (append the doc-wiring
+  checks at `DOC-CHECKS-ANCHOR`)
+
+**Interfaces:**
+- Consumes: provisioning content from the gcloud-robot skill's
+  `references/provisioning.md` (role choice, scoped-grant command shapes,
+  rotation/revocation/monitoring contracts).
+- Produces: the runbook the wrappers' `--help` text and AGENTS.md point at.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Append to `scripts/test/cloud-gcp-identity.test.sh`, replacing the
+`# DOC-CHECKS-ANCHOR (Task 3 appends here)` line:
+
+```bash
+# --- D1-D5: doc wiring -----------------------------------------------------
+# Pins the wiring between code and docs (existence, the two-state contract
+# agents must not debug away, the discovery knob, and the AGENTS.md link) —
+# the same content-pin style cloud-build.test.sh uses for help surfaces. It
+# deliberately does not gate prose.
+RUNBOOK="$ROOT/docs/development/gcloud-robot.md"
+check "D1 operator runbook exists" test -f "$RUNBOOK"
+check "D2 runbook names the wired-not-provisioned adoption state" \
+  bash -c 'grep -q "wired but not yet provisioned" "$1"' _ "$RUNBOOK"
+check "D3 runbook names the provisioned-and-verified adoption state" \
+  bash -c 'grep -q "provisioned and verified" "$1"' _ "$RUNBOOK"
+check "D4 runbook documents the GCLOUD_ROBOT_HOME discovery knob" \
+  bash -c 'grep -q "GCLOUD_ROBOT_HOME" "$1"' _ "$RUNBOOK"
+check "D5 AGENTS.md links the runbook" \
+  bash -c 'grep -q "docs/development/gcloud-robot.md" "$1"' _ "$ROOT/AGENTS.md"
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `bash scripts/test/cloud-gcp-identity.test.sh`
+
+Expected: FAIL — D1 (`docs/development/gcloud-robot.md` missing), D2–D4
+(grep against a missing file), and D5 (AGENTS.md has no such link yet). All
+pre-existing checks stay green.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+**3a.** Create `docs/development/gcloud-robot.md` with exactly this content:
+
+````markdown
+# gcloud-robot identity for cloud test lanes
+
+Freshell's cloud test lanes (`scripts/e2e-cloud.sh`, `scripts/vitest-cloud.sh`
+— Cloud Run Jobs for Playwright e2e and Vitest suites, plus their shared
+Cloud Build / Artifact Registry image machinery) no longer depend on an
+interactive `gcloud auth login`. Interactive gcloud sessions ride OAuth
+refresh tokens that Google silently culls (roughly hourly under heavy agent
+use); the last observed casualty was a base-gate run dying mid-lane with
+`Reauthentication failed. cannot prompt during non-interactive execution`
+(2026-08-23, UTC). The replacement is the gcloud-robot pattern: one
+per-project robot service account minted from a local JSON key — no browser
+login, no refresh token, no hourly expiry.
+
+Project: `misc-puttering-project` (region `us-west1`, AR repo `freshell-e2e`).
+Robot: `gcloud-robot@misc-puttering-project.iam.gserviceaccount.com`.
+
+## Security, stated plainly
+
+A JSON key is bearer power with no MFA and — by default — no expiry. It is
+weaker than an expiring interactive session. Two things bound the risk:
+least-privilege per-project grants (below), and rotation plus instant
+revocation as first-class operations (below). The control that still holds
+when logs are blind is the standing rotation cadence — keep one, and enable
+the key-usage alerting in "Monitor".
+
+## Adoption states
+
+The repo is in exactly one of two states at any time:
+
+1. **wired but not yet provisioned** — the ladder and this runbook are
+   committed, but the robot SA/key do not exist yet. Expected behavior: lanes
+   run exactly as before under ambient gcloud, with one quiet stderr note
+   (`gcloud-robot: no probed identity; using ambient gcloud` / `skill not
+   found ... — using ambient gcloud`). In this state `verify-as-robot.sh`
+   failing at the key/token-mint rung is the CORRECT result, not a
+   regression — do not debug it, provision.
+2. **provisioned and verified** — provisioning below completed and the
+   verification ladder passed as the robot.
+
+## How lanes resolve identity (after conversion)
+
+Lazily, immediately before a cloud lane's first real gcloud call (`help` and
+`run --local` never resolve anything and need zero GCP tooling), in this
+fixed order:
+
+1. `--account=<email>` flag — call-site pin, always wins.
+2. `FRESHELL_GCP_ACCOUNT` env — repo pin, also always wins.
+3. `GCLOUD_IDENT` env — explicit bypass (CI, hermetic tests): used verbatim,
+   no probe, no network.
+4. gcloud-robot probe — `$GCLOUD_ROBOT_HOME/scripts/select-gcloud-identity.sh`
+   picks the first credentialed account passing the lane's live
+   `testIamPermissions` probe. The robot "just works" wherever its key is
+   activated; human accounts keep working untouched.
+5. Ambient gcloud (default when nothing above resolves), announced once on
+   stderr. Set `GCLOUD_ROBOT_REQUIRE=1` to fail closed with guidance instead
+   (hardening / CI).
+
+A resolved identity pins every `--account` the wrappers emit and exports
+`CLOUDSDK_CORE_ACCOUNT`/`CLOUDSDK_CORE_PROJECT` for any unpinned descendants.
+
+## Operator setup
+
+### Prerequisites
+
+- The `gcloud-robot` skill installed for your agent platform (whatever
+  directory holds its `scripts/` — the repo never records that path).
+- Point the lanes at it once, e.g. in `~/.bashrc`:
+
+  ```bash
+  export GCLOUD_ROBOT_HOME="<installed gcloud-robot skill directory>"
+  # Prefer the robot when several accounts pass the probe:
+  export GCLOUD_ROBOT_ACCOUNT="gcloud-robot@misc-puttering-project.iam.gserviceaccount.com"
+  ```
+
+### Provision (once per project, human-run — agents never run these)
+
+All commands pin `--account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"` to your operator
+account (export it). All skill scripts are invoked via
+`bash "$GCLOUD_ROBOT_HOME/scripts/<name>.sh"`.
+
+1. Bootstrap the robot (project-level roles):
+
+   ```bash
+   GCLOUD_ROBOT_PROJECT=misc-puttering-project \
+   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor artifactregistry.writer run.developer run.invoker run.viewer logging.viewer" \
+   GCLOUD_ROBOT_ADMIN_ACCOUNT="$GCLOUD_ROBOT_ADMIN_ACCOUNT" \
+   bash "$GCLOUD_ROBOT_HOME/scripts/bootstrap-robot.sh" --name gcloud-robot --activate
+   ```
+
+   This creates the SA, binds the project roles, mints a JSON key under
+   `~/.local/share/gcloud-robot/` (mode 600, never inside
+   `~/.config/gcloud`), prints the key path, and activates it. Record the
+   key location for yourself as
+   `key-path: <printed at provisioning>` (until then this runbook says:
+   not yet minted — operator step).
+
+2. Scoped grants (bootstrap does NOT do these; skipping them is the classic
+   "probe passes, build 403s" failure):
+
+   ```bash
+   # Staging bucket Cloud Build uploads source to (confirm the name; the
+   # default is <project>_cloudbuild):
+   BUCKET="$(gcloud storage buckets list --project=misc-puttering-project \
+       --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" --format='value(name)' | grep cloudbuild)"
+   for role in roles/storage.objectAdmin roles/storage.legacyBucketReader; do
+     gcloud storage buckets add-iam-policy-binding "gs://$BUCKET" \
+       --member="serviceAccount:gcloud-robot@misc-puttering-project.iam.gserviceaccount.com" \
+       --role="$role" \
+       --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" --condition=None
+   done
+
+   # actAs on the default build/run identities (jobs and Cloud Build run as
+   # these, and submitting identities must be allowed to act as them):
+   PROJECT_NUMBER=$(gcloud projects describe misc-puttering-project \
+     --format='value(projectNumber)' --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT")
+   for sa in "${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+             "service-${PROJECT_NUMBER}@gcp-sa-cloudbuild.iam.gserviceaccount.com"; do
+     gcloud iam service-accounts add-iam-policy-binding "$sa" \
+       --member="serviceAccount:gcloud-robot@misc-puttering-project.iam.gserviceaccount.com" \
+       --role=roles/iam.serviceAccountUser \
+       --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" --condition=None
+   done
+   ```
+
+3. Verify as the robot. Read-only probes retry through IAM propagation lag;
+   a failure that persists past the retries names the missing grant.
+
+   ```bash
+   # For a quick pre-flight use GCLOUD_ROBOT_RETRIES=2 GCLOUD_ROBOT_RETRY_SLEEP=2,
+   # then unset them for the real run.
+   GCLOUD_ROBOT_ACCOUNT=gcloud-robot@misc-puttering-project.iam.gserviceaccount.com \
+   GCLOUD_ROBOT_PROJECT=misc-puttering-project \
+   GCLOUD_ROBOT_PROBE_PERMISSION=cloudbuild.builds.create \
+   GCLOUD_ROBOT_KEY_FILE=<key path printed by bootstrap> \
+   bash "$GCLOUD_ROBOT_HOME/scripts/verify-as-robot.sh" \
+     --probe "gcloud artifacts repositories describe freshell-e2e --location=us-west1 --project=misc-puttering-project" \
+     --probe "gcloud artifacts docker images describe us-west1-docker.pkg.dev/misc-puttering-project/freshell-e2e/freshell-e2e:latest --project=misc-puttering-project" \
+     --probe "gcloud run jobs list --region=us-west1 --project=misc-puttering-project --limit=1" \
+     --probe "gcloud builds list --project=misc-puttering-project --limit=1"
+   ```
+
+   The wrappers read execution logs via `gcloud beta run jobs executions logs
+   read ... || true`, which masks a missing `roles/logging.viewer` quietly.
+   When an execution exists, list a real log read as an explicit probe too:
+   `--probe "gcloud beta run jobs executions logs read <execution-name> --project=misc-puttering-project --region=us-west1"`.
+
+4. Done. `npm run test:cloud` / `npm run test:e2e:cloud` now select the robot
+   automatically wherever its key is activated; no `.env` or repo config
+   exists for this (`.env.example` is server-runtime config and deliberately
+   carries no cloud-lane knobs).
+
+### Rotate (standing cadence — suggest quarterly, and after any suspicion)
+
+1. Mint + activate a new key. Re-supply the CURRENT role list exactly —
+   `bootstrap-robot.sh` re-applies it verbatim and bindings are additive-only:
+
+   ```bash
+   GCLOUD_ROBOT_PROJECT=misc-puttering-project \
+   GCLOUD_ROBOT_ROLES="cloudbuild.builds.editor artifactregistry.writer run.developer run.invoker run.viewer logging.viewer" \
+   GCLOUD_ROBOT_ADMIN_ACCOUNT="$GCLOUD_ROBOT_ADMIN_ACCOUNT" \
+   bash "$GCLOUD_ROBOT_HOME/scripts/bootstrap-robot.sh" --rekey --activate
+   ```
+
+2. Prove the real lane works as the robot (verify block above with the new
+   key path).
+3. Delete the OLD key id in IAM (list with `--managed-by=user`, pick the row
+   whose id matches the old key file's `private_key_id`):
+
+   ```bash
+   gcloud iam service-accounts keys list --managed-by=user \
+     --iam-account=gcloud-robot@misc-puttering-project.iam.gserviceaccount.com \
+     --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"
+   gcloud iam service-accounts keys delete <OLD_KEY_ID> \
+     --iam-account=gcloud-robot@misc-puttering-project.iam.gserviceaccount.com \
+     --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"
+   ```
+
+4. On any other host holding the old key copy, delete the file and run
+   `gcloud auth revoke gcloud-robot@misc-puttering-project.iam.gserviceaccount.com`
+   there (never on the host that just activated the new key).
+
+### Revoke (leak response)
+
+Delete the key in IAM (`keys delete`, above) — that instantly stops all NEW
+token minting from every copy of the key. Tokens already minted stay valid
+for up to an hour (Google-documented; key deletion does not invalidate issued
+credentials). For an immediate total cutoff:
+
+```bash
+gcloud iam service-accounts disable gcloud-robot@misc-puttering-project.iam.gserviceaccount.com \
+  --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT"
+```
+
+(Disabling halts all use project-wide until re-enabled — that is the trade
+for immediacy.)
+
+### Monitor (safety net, with honest limits)
+
+- Key lifecycle events: `CreateServiceAccountKey` is a default-on Admin
+  Activity audit event. Create a log-based metric (fully-qualified method
+  name, scoped to the robot) and alert on it in your monitoring stack:
+
+  ```bash
+  gcloud logging metrics create robot-key-creations \
+    --project=misc-puttering-project --account="$GCLOUD_ROBOT_ADMIN_ACCOUNT" \
+    --description="key creation events for the gcloud-robot SA" \
+    --log-filter='protoPayload.methodName="google.iam.admin.v1.CreateServiceAccountKey" AND resource.labels.email_id="gcloud-robot@misc-puttering-project.iam.gserviceaccount.com"'
+  ```
+
+- Key usage: `iam.googleapis.com/service_account/key/authn_events_count`
+  (per-`key_id`) is the best available signal — but it is sampled every 600s
+  and data lags up to ~3 hours, so it suits anomaly review and off-hours
+  alerting, not instant paging. Rotation remains the control that holds when
+  logs are blind.
+
+### Troubleshooting
+
+- Probe passes but `gcloud builds submit` 403s → the actAs grants (step 2).
+- Cloud Build dies resolving source/logs (`storage.buckets.get` 403) → the
+  bucket-scoped `roles/storage.legacyBucketReader` (step 2); object roles
+  alone never carry bucket metadata reads.
+- A grant that definitely exists 403s for the first minutes → IAM
+  propagation lag; the verifier's retries (12 × 30s default) absorb it.
+- A lane prints the ambient-fallback note and then gcloud's
+  "Reauthentication failed" → the lane fell back to ambient gcloud: the
+  robot is not provisioned (or not activated) on this machine. Provision
+  (above) or re-login interactively; both work, the point is the robot
+  cannot be culled.
+
+### CI
+
+No GitHub Actions workflow touches GCP (verified by survey); keep it that
+way. If CI ever needs GCP, use Workload Identity Federation (keyless) —
+never a JSON key in CI.
+````
+
+**3b.** Edit `AGENTS.md` — append this paragraph at the end of the
+`### Vitest Test Backend (Cloud Run Jobs)` section (immediately after the
+"**Note:** The electron suite always runs locally even in cloud mode ..."
+paragraph, before the `### E2E Test Backend (Cloud Run Jobs)` heading):
+
+```markdown
+**Identity:** cloud lanes never require an interactive `gcloud auth login`.
+They resolve a gcloud identity lazily, in this order: `--account=` flag >
+`FRESHELL_GCP_ACCOUNT` > `GCLOUD_IDENT` > gcloud-robot probe (needs
+`GCLOUD_ROBOT_HOME`, the installed gcloud-robot skill directory) > ambient
+gcloud (with a one-line stderr note). Provisioning, rotation, and revocation
+live in [docs/development/gcloud-robot.md](docs/development/gcloud-robot.md).
+`GCLOUD_ROBOT_REQUIRE=1` fails closed when no robot identity resolves.
+```
+
+**3c.** Edit `AGENTS.md` — append this paragraph at the end of the
+`### E2E Test Backend (Cloud Run Jobs)` section (immediately after the
+"**Before filing any PR, ensure the affected e2e specs actually pass on the
+configured `FRESHELL_E2E_BACKEND` backend** ..." paragraph, before the
+`## Architecture` heading): the identical Identity paragraph from 3b
+(verbatim — both sections name the same contract).
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `bash scripts/test/cloud-gcp-identity.test.sh`
+
+Expected: PASS — D1–D5 (and everything else) green, footer
+`=== All checks passed ===`, exit 0.
+
+- [ ] **Step 5: Refactor while green**
+
+Docs-only task; no code refactor. Do a read-through of the rendered runbook
+for command accuracy against the skill references (provisioning.md shapes:
+scoped grants carry `--condition=None`, budget of `bash <path>` invocation,
+key outside `~/.config/gcloud`).
+
+- [ ] **Step 6: Run impacted-test verification**
+
+AGENTS.md is included in the cloud image by `.gcloudignore`'s `!AGENTS.md`
+exception and read by server-side tests; the runbook is new documentation.
+The impacted set is again the full cloud-suite loop (the doc checks live in
+the identity suite), plus a typecheck-free confirmation that AGENTS.md still
+parses as plumbing-neutral markdown (no tooling consumes it programmatically
+beyond inclusion):
+
+Run:
+```bash
+for t in scripts/test/cloud-gcp-identity.test.sh \
+         scripts/test/cloud-build.test.sh \
+         scripts/test/cloud-exec-id-parse.test.sh \
+         scripts/test/cloud-vitest-wrapper.test.sh \
+         scripts/test/cloud-run-wrapper.test.sh; do
+  bash "$t" || { echo "SUITE FAILED: $t"; exit 1; }
+done
+```
+
+Expected: PASS — every suite exits 0.
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add docs/development/gcloud-robot.md AGENTS.md scripts/test/cloud-gcp-identity.test.sh
+git commit -m "docs(cloud): add gcloud-robot operator runbook + AGENTS.md identity sections"
+```
+
+---
+
+## Verification matrix (behavior → where proven)
+
+| Behavior | Proof |
+| --- | --- |
+| Ladder rung 2 (GCLOUD_IDENT) bypasses probe, pins + exports identity | Task 1 check B; Task 2 W1/W6a on the real wrappers |
+| Ladder rung 3 probe selects robot; project+probe env forwarded to selector | Task 1 checks C and I; Task 2 W4 on the real wrapper (single selector run) |
+| Ladder rung 4 ambient fallback: exactly one stderr note, exit 0, no crash | Task 1 checks D/E; Task 2 W5/W6b on the real wrappers |
+| `GCLOUD_ROBOT_REQUIRE=1` fails closed with guidance (both failure shapes) | Task 1 checks F/G |
+| Idempotency (one probe per process, even across lanes) | Task 1 check H |
+| Rung-1 pins (`--account=`, `FRESHELL_GCP_ACCOUNT`) always win | Task 1 check J; Task 2 W2/W3 on the real wrapper |
+| No hardcoded human account anywhere in wrappers or help | Task 2 W1 grep; W10/W11 absence checks |
+| `--account` omitted (not empty-flagged) when nothing resolves | Task 2 W5/W6b (absent accounts log) |
+| help/local lanes need zero GCP tooling and stay silent | Task 2 W8/W9; pre-existing cloud-run-wrapper check 12 |
+| Trap-11: stubbed suites never reach the probe | Task 2 W7 (four nested suites under a hostile marker-trap home) |
+| Hardcoded-default removal documented in help | Task 2 W10/W11 |
+| Runbook + AGENTS.md wiring | Task 3 D1–D5 |
+| Provisioning/rotation/revocation correctness | Documented only — human-executed; skill-mandated exclusion (no agent runs GCP mutations) |
+| Whole-repo regression | Workflow stage gate (coordinated suite), outside task scope |
+
+## Risk notes
+
+- **Mirrored wrappers.** The two wrappers keep their established parallel
+  layout; the only shared code is the helper. A reviewer comparing the two
+  diffs should see identical structural edits with vitest/e2e name swaps and
+  the defaults that already differ (shards, timeout, job prefix).
+- **One-process-one-probe.** A `run --cloud` that falls through to
+  `cmd_build` resolves on the run probe (`run.jobs.run`) first and never
+  re-probes for the build leg — correct by design (robot holds the union of
+  roles); a misconfigured identity fails fast on the real gcloud error, which
+  the ambient note contextualizes.
+- **Ambient fallback keeps old behavior.** Lanes on skill-less machines print
+  one note and run exactly as before (including, today, the culled-credential
+  failure mode). That is the contract: adoption is non-breaking; provisioning
+  is the fix.
+
+
+

--- a/docs/plans/2026-08-22-gcloud-robot-conversion.md
+++ b/docs/plans/2026-08-22-gcloud-robot-conversion.md
@@ -112,19 +112,26 @@ Exact project-wide constraints every task must honor:
   developer). The wrapper's create-if-missing Artifact Registry path
   (`artifacts repositories create`) is NOT granted
   (`artifactregistry.repositories.create` would need repoAdmin): the operator
-  checklist ensures the repository exists instead.
+  checklist ensures the repository exists instead. Build-log access comes
+  from routing Cloud Build logs to Cloud Logging
+  (`options.logging: CLOUD_LOGGING_ONLY` in cloudbuild.yaml — Task 2 edit
+  E12), which `roles/logging.viewer` covers; the legacy default GCS
+  log-bucket path is documented upstream as requiring project-wide
+  `roles/viewer` for manual builds reading its logs and is deliberately not
+  granted.
 - **Files explicitly out of scope (untouched, with reason):**
   `scripts/run-standard-tests.ts` (it `execFileSync`s `vitest-cloud.sh` with
   inherited env; identity resolution lives inside the wrapper so the
   coordinator and base-gate paths inherit it for free);
-  `docker/cloud-run/{Dockerfile,entrypoint.sh,cloudbuild.yaml}` (no gcloud
-  identity inside the container; jobs/builds run as default identities — the
-  actAs grant is documented in the runbook); `.gcloudignore` (no relation to
-  identity); `.github/workflows/*` (zero GCP surface; CI stays keyless);
+  `docker/cloud-run/{Dockerfile,entrypoint.sh}` (no gcloud identity inside
+  the container; jobs/builds run as default identities — the actAs grant is
+  documented in the runbook); `.gcloudignore` (no relation to identity);
+  `.github/workflows/*` (zero GCP surface; CI stays keyless);
   `.env.example` (server-runtime configuration only — the cloud wrappers are
   operator shell tooling, so their knobs are documented in `--help`,
   AGENTS.md, and the runbook instead); historical `docs/plans/*` (historical
-  records).
+  records). (`docker/cloud-run/cloudbuild.yaml` IS touched — one
+  `options.logging` line, see Task 2 E12 and Global Constraints.)
 
 ## Stage-2 load-bearing assumptions (validate before execution)
 
@@ -161,6 +168,16 @@ Exact project-wide constraints every task must honor:
   only (plus the build/AR roles). Also verified: `artifactregistry.writer`
   cannot create repositories (`repositories.create` absent) — the operator
   checklist ensures the AR repo exists instead of granting repoAdmin.
+- **A7** (raised by plan-review round 2; RESOLVED against the upstream docs
+  the reviewer cited — Cloud Build troubleshooting + build-log storage
+  behavior): with `logging` unspecified, Cloud Build writes build logs to the
+  legacy default GCS bucket, and reading them as the submitting identity
+  requires project-wide `roles/viewer` — refused as too wide. Fix instead:
+  `options.logging: CLOUD_LOGGING_ONLY` in
+  `docker/cloud-run/cloudbuild.yaml` (Task 2 E12), which puts build logs in
+  Cloud Logging where the already-granted `roles/logging.viewer` suffices.
+  Human workflows' `builds submit` log streaming is unchanged; the Console
+  log link target changes (native bucket viewer → Logs Explorer).
 
 These are properties of external contracts; the plan's tasks do not depend on
 any other unproven claim. If A1/A2 invalidate a probe permission, swap the
@@ -610,15 +627,20 @@ and mirrored (every hunk is still spelled out per file below).
 - Modify: `scripts/test/cloud-vitest-wrapper.test.sh` (pin after line 8)
 - Modify: `scripts/test/cloud-gcp-identity.test.sh` (append the wrapper-level
   block at the `WRAPPER-LEVEL-CHECKS-ANCHOR`)
+- Modify: `docker/cloud-run/cloudbuild.yaml` (E12 — one `options.logging`
+  line)
 
 **Interfaces:**
 - Consumes: `freshell_resolve_cloud_identity` and `resolve_gcp_identity` from
   Task 1's `scripts/lib/gcp-identity.sh` (sourced via `$SCRIPT_DIR/lib/`).
 - Produces: wrapper-local `account_flag()`, the conditional `gcloud_flags()` /
-  `gcloud_artifacts_flags()`, and the no-human-default `GCP_ACCOUNT`
-  lifecycle (`--account=` > `FRESHELL_GCP_ACCOUNT` > ladder > omitted).
+  `gcloud_artifacts_flags()`, the no-human-default `GCP_ACCOUNT` lifecycle
+  (`--account=` > `FRESHELL_GCP_ACCOUNT` > ladder > omitted), and pin-flag
+  parsing on the standalone `build` (already had it), `push`, and `logs`
+  lanes so the precedence contract holds on every cloud subcommand — with
+  non-pin `logs` arguments still passed through to `logs read` verbatim.
 
-#### Wrapper edit reference (apply E1–E11 to e2e-cloud.sh; V1–V11 mirror to vitest-cloud.sh)
+#### Wrapper edit reference (apply E1–E11 to e2e-cloud.sh; V1–V11 mirror to vitest-cloud.sh; E12 touches only cloudbuild.yaml)
 
 **E1 / V1 — remove the hardcoded default.** e2e-cloud.sh:45
 `GCP_ACCOUNT="${FRESHELL_GCP_ACCOUNT:-dan@danshapiro.com}"` /
@@ -693,16 +715,47 @@ vitest-cloud.sh:187), after the flag-parse loop:
   freshell_resolve_cloud_identity "cloudbuild.builds.create"
 ```
 
-**E5 / V5 — resolve in `cmd_push`.** As the first statement after the
-"Building"/"Pushing" banner (e2e-cloud.sh after :220 `echo "[e2e-cloud]
-Pushing to Artifact Registry..."` / vitest-cloud.sh after :216
-`echo "[vitest-cloud] Pushing to Artifact Registry..."`):
+**E5 / V5 — flag parsing + resolve in `cmd_push`.** Today `cmd_push` parses
+NO arguments, so `push --account=EMAIL` would silently ignore the pin and
+violate rung-1 precedence. Give `cmd_push` (e2e-cloud.sh:219-248 /
+vitest-cloud.sh:215-243) its own parse loop first, then resolve. The whole
+function head becomes:
 
 ```bash
+cmd_push() {
+  echo "[WRAPPER-TAG] Pushing to Artifact Registry..."
+
+  # The standalone push lane honors the same pin flags as build/run;
+  # parse FIRST so an explicit --account= wins without touching the ladder.
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --account=*)
+        GCP_ACCOUNT="${1#*=}"
+        shift
+        ;;
+      --project-id=*)
+        GCP_PROJECT="${1#*=}"
+        shift
+        ;;
+      --region=*)
+        GCP_REGION="${1#*=}"
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
   # A standalone `push` reaches gcloud without passing through cmd_build;
   # resolve idempotently (free when cmd_build already did).
   freshell_resolve_cloud_identity "cloudbuild.builds.create"
 ```
+
+(`[WRAPPER-TAG]` = `e2e-cloud` / `vitest-cloud`; the function's remaining
+body is unchanged. Callers pass arguments the same way: `cmd_push` from
+`cmd_build --local-build` passes nothing today and the dispatch passes
+`"$@"`.)
 
 **E6 / V6 — resolve in `cmd_run`'s cloud branch.** After the local branch
 closes (e2e-cloud.sh: the `fi` after the `exec npx playwright test` block at
@@ -759,15 +812,74 @@ vitest-cloud.sh:376-377:
 
 (The `elif`/`if` difference is the wrappers' existing structure; keep it.)
 
-**E10 / V10 — resolve in `cmd_logs`.** First statement of `cmd_logs`
-(e2e-cloud.sh before :575 `local execution_id` / vitest-cloud.sh before
-:544):
+**E10 / V10 — flag parsing + resolve in `cmd_logs`.** Today `cmd_logs`
+(e2e-cloud.sh:569-586 / vitest-cloud.sh:539-551) parses no pin flags and
+forwards its whole `$@` to `logs read`, so `logs --account=EMAIL` would list
+executions as one identity and read them as another. Add a parse loop that
+peels the three pin flags and collects everything else for passthrough; the
+function head becomes:
 
 ```bash
-  # logs is a cloud-only lane (executions list + logs read); resolve before
-  # the first gcloud call.
+cmd_logs() {
+  # Parse the pin flags FIRST (same contract as build/run); the rest passes
+  # through to `logs read` verbatim, preserving the existing behavior.
+  local -a logs_passthrough=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --account=*)
+        GCP_ACCOUNT="${1#*=}"
+        shift
+        ;;
+      --project-id=*)
+        GCP_PROJECT="${1#*=}"
+        shift
+        ;;
+      --region=*)
+        GCP_REGION="${1#*=}"
+        shift
+        ;;
+      *)
+        logs_passthrough+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  # logs is a cloud-only lane (executions list + logs read); resolve after
+  # parsing so an explicit pin short-circuits the ladder.
   freshell_resolve_cloud_identity "run.jobs.run"
 ```
+
+and its final call passes the collected passthrough args instead of raw `$@`
+(e2e-cloud.sh:585 / vitest-cloud.sh:550):
+
+```bash
+  gcloud beta run jobs executions logs read $(gcloud_flags) "$execution_id" \
+    "${logs_passthrough[@]+"${logs_passthrough[@]}"}"
+```
+
+(The `"${arr[@]+...}"` form is the repo's `set -u`-safe empty-array idiom,
+mirroring vitest-cloud.sh's vt_args expansion.)
+
+**E12 — Cloud Build logs route to Cloud Logging.** In
+`docker/cloud-run/cloudbuild.yaml`, add one line under the top-level
+`options:` mapping (which already carries `machineType: E2_HIGHCPU_32` and
+`diskSizeGb: 200`):
+
+```yaml
+options:
+  machineType: E2_HIGHCPU_32
+  diskSizeGb: 200
+  logging: CLOUD_LOGGING_ONLY
+```
+
+(One edit, one wrapper-neutral file — no V-mirror.) Rationale: the default
+(legacy GCS log bucket) requires project-wide `roles/viewer` for the
+submitting identity to read/stream build logs; Cloud Logging needs only the
+already-granted `roles/logging.viewer`. This changes where build logs land
+for humans too (streamed `builds submit` output is identical; only the
+Console link target moves from the bucket viewer to Logs Explorer) — called
+out in the Risk notes.
 
 **E11 / V11 — help + header text.** e2e-cloud.sh:29 header line and
 e2e-cloud.sh usage(); vitest-cloud.sh:28 header line and
@@ -847,8 +959,12 @@ if [[ "$*" == *"artifacts repositories describe"* ]]; then exit 0; fi
 if [[ "$*" == *"artifacts repositories create"* ]]; then exit 0; fi
 if [[ "$*" == *"builds submit"* ]]; then exit 0; fi
 if [[ "$*" == *"auth print-access-token"* ]]; then echo stub-token; exit 0; fi
-if [[ "$*" == *"run jobs execute"* ]]; then echo "Execution [green-exec-1] has successfully completed."; exit 0; fi
+# Substring-match order matters: "run jobs executions list|logs read" CONTAINS
+# "run jobs execute" as a substring, so the specific execution subcommands are
+# matched BEFORE the bare execute branch. (Nested-suite fakes use the same
+# discipline.)
 if [[ "$*" == *"executions list"* ]]; then echo "green-exec-1"; exit 0; fi
+if [[ "$*" == *"logs read"* ]]; then echo "  1 passed (1.0s)"; exit 0; fi
 if [[ "$*" == *"executions describe"* ]]; then
   if [[ "$*" == *"succeededCount"* ]]; then
     N=$(grep -oP -- '--tasks=\K[0-9]+' "${GREEN_LOG}" | tail -1)
@@ -858,7 +974,7 @@ if [[ "$*" == *"executions describe"* ]]; then
   fi
   exit 0
 fi
-if [[ "$*" == *"logs read"* ]]; then echo "  1 passed (1.0s)"; exit 0; fi
+if [[ "$*" == *"run jobs execute"* ]]; then echo "Execution [green-exec-1] has successfully completed."; exit 0; fi
 if [[ "$*" == *"run jobs"* ]]; then exit 0; fi
 exit 0
 GREEN_FAKE
@@ -1018,7 +1134,12 @@ if GCLOUD_PATH_RESOLVED=$(command -v gcloud 2>/dev/null); then
   fi
 fi
 if [ -n "$CLEAN_PATH" ]; then
-  if env PATH="$CLEAN_PATH" command -v gcloud >/dev/null 2>&1; then
+  # NOTE: `command -v` is a shell builtin; it must run INSIDE a shell (`env
+  # PATH=... bash -c ...`) — `env PATH=... command -v gcloud` tries to exec
+  # a program named "command", returns 127 unconditionally, and would
+  # certify a non-clean PATH. (The same latent bug exists in
+  # cloud-run-wrapper.test.sh check 12 — pre-existing, out of scope here.)
+  if env PATH="$CLEAN_PATH" bash -c 'command -v gcloud >/dev/null 2>&1'; then
     echo "FAIL: gcloud still resolvable on the filtered PATH"
     FAILURES=$((FAILURES + 1))
   else
@@ -1050,6 +1171,106 @@ check "W9 vitest --local: runs real local vitest, no selector, no ladder output"
     grep -qE "Test Files|passed" <<<"$2" &&
     ! grep -q "gcloud-robot" <<<"$2" && [ ! -e "$3" ]
   ' _ "$W9_RC" "$W9_OUT" "$SELECTOR_MARKER"
+
+# --- W12: e2e standalone lanes (build / push / logs) run their OWN ladder ---
+# cmd_run populates GCP_ACCOUNT before delegating to cmd_build/cmd_push, so
+# run-based checks can NEVER catch a missing resolver or a missing pin-parse
+# loop on the standalone lanes. These exercise them directly.
+
+# W12a: standalone build — probe selects, with the BUILD-lane probe permission.
+reset_green
+W12A_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+  GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_ACCOUNT="$RUNG3_ROBOT" \
+  "$WRAPPER_E2E" build 2>/dev/null) && W12A_RC=0 || W12A_RC=$?
+check "W12a e2e standalone build: probe identity selected once, build-lane probe permission" \
+  bash -c '
+    [ "$1" = "0" ] &&
+    [ "$(wc -l < "$2")" = "1" ] &&
+    grep -q "project=misc-puttering-project probe=cloudbuild.builds.create" "$2.env"
+  ' _ "$W12A_RC" "$SELECTOR_MARKER"
+check "W12a e2e standalone build: every gcloud call pinned to the probed robot" \
+  accounts_all_equal "$RUNG3_ROBOT"
+
+# W12b: strict mode + absent skill must NOT fail an explicitly pinned
+# standalone build (rung-1 immunity — guards the short-circuit itself).
+reset_green
+W12B_ERR="$TDIR/w12b.err"
+W12B_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" GCLOUD_ROBOT_REQUIRE=1 \
+  "$WRAPPER_E2E" build --account="$FLAG_ACCOUNT" 2>"$W12B_ERR") && W12B_RC=0 || W12B_RC=$?
+check "W12b e2e standalone build: --account pin wins, strict mode cannot fail it, silent" \
+  bash -c '
+    [ "$1" = "0" ] && grep -q "Cloud Build complete" <<<"$2" &&
+    [ ! -e "$3" ] && [ ! -s "$4" ]
+  ' _ "$W12B_RC" "$W12B_OUT" "$SELECTOR_MARKER" "$W12B_ERR"
+check "W12b e2e standalone build: every gcloud call pinned to the flag value" \
+  accounts_all_equal "$FLAG_ACCOUNT"
+
+# W12c: standalone push — rung-2 pin must reach describe/print-access-token.
+reset_green
+W12C_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" GCLOUD_IDENT="$RUNG2_IDENT" \
+  "$WRAPPER_E2E" push 2>/dev/null) && W12C_RC=0 || W12C_RC=$?
+check "W12c e2e standalone push: succeeds under rung-2 pin" \
+  bash -c '[ "$1" = "0" ] && [ ! -e "$3" ]' _ "$W12C_RC" "$W12C_OUT" "$SELECTOR_MARKER"
+check "W12c e2e standalone push: every gcloud call pinned to the GCLOUD_IDENT value" \
+  accounts_all_equal "$RUNG2_IDENT"
+
+# W12d: standalone logs — rung-2 pin on BOTH calls, non-pin args passed through.
+reset_green
+W12D_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" GCLOUD_IDENT="$RUNG2_IDENT" \
+  "$WRAPPER_E2E" logs --limit=3 --freshness=1d 2>/dev/null) && W12D_RC=0 || W12D_RC=$?
+check "W12d e2e standalone logs: list+read share the pinned identity, pass-through args preserved" \
+  bash -c '
+    [ "$1" = "0" ] && [ ! -e "$4" ] &&
+    grep "logs read" "$2" | grep -q -- "--limit=3" &&
+    grep "logs read" "$2" | grep -q -- "--freshness=1d"
+  ' _ "$W12D_RC" "$GREEN_LOG" "$W12D_OUT" "$SELECTOR_MARKER"
+check "W12d e2e standalone logs: every gcloud call pinned to the GCLOUD_IDENT value" \
+  accounts_all_equal "$RUNG2_IDENT"
+
+# W12e: standalone logs — flag pin wins on the logs lane (rung 1 there too).
+reset_green
+W12E_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" GCLOUD_ROBOT_REQUIRE=1 \
+  "$WRAPPER_E2E" logs --account="$FLAG_ACCOUNT" 2>/dev/null) && W12E_RC=0 || W12E_RC=$?
+check "W12e e2e standalone logs: --account pin honored (rung 1), strict-mode immune" \
+  bash -c '[ "$1" = "0" ] && [ ! -e "$3" ]' _ "$W12E_RC" "$W12E_OUT" "$SELECTOR_MARKER"
+check "W12e e2e standalone logs: every gcloud call pinned to the flag value" \
+  accounts_all_equal "$FLAG_ACCOUNT"
+
+# --- W13: vitest standalone lanes (build / push / logs) — parity pins -------
+# W13a: standalone build via probe.
+reset_green
+W13A_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+  GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_ACCOUNT="$RUNG3_ROBOT" \
+  "$WRAPPER_VITEST" build 2>/dev/null) && W13A_RC=0 || W13A_RC=$?
+check "W13a vitest standalone build: probe identity selected once, build-lane probe permission" \
+  bash -c '
+    [ "$1" = "0" ] &&
+    [ "$(wc -l < "$2")" = "1" ] &&
+    grep -q "project=misc-puttering-project probe=cloudbuild.builds.create" "$2.env"
+  ' _ "$W13A_RC" "$SELECTOR_MARKER"
+check "W13a vitest standalone build: every gcloud call pinned to the probed robot" \
+  accounts_all_equal "$RUNG3_ROBOT"
+
+# W13b: standalone push under rung-2 pin.
+reset_green
+W13B_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" GCLOUD_IDENT="$RUNG2_IDENT" \
+  "$WRAPPER_VITEST" push 2>/dev/null) && W13B_RC=0 || W13B_RC=$?
+check "W13b vitest standalone push: succeeds, every gcloud call pinned to GCLOUD_IDENT" \
+  bash -c '[ "$1" = "0" ] && [ ! -e "$3" ]' _ "$W13B_RC" "$W13B_OUT" "$SELECTOR_MARKER"
+check "W13b vitest standalone push: every gcloud call pinned to the GCLOUD_IDENT value" \
+  accounts_all_equal "$RUNG2_IDENT"
+
+# W13c: standalone logs under rung-2 pin, pass-through preserved.
+reset_green
+W13C_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" GCLOUD_IDENT="$RUNG2_IDENT" \
+  "$WRAPPER_VITEST" logs --limit=2 2>/dev/null) && W13C_RC=0 || W13C_RC=$?
+check "W13c vitest standalone logs: pinned identity on both calls, pass-through preserved" \
+  bash -c '
+    [ "$1" = "0" ] && [ ! -e "$4" ] &&
+    grep "logs read" "$2" | grep -q -- "--limit=2"
+  ' _ "$W13C_RC" "$GREEN_LOG" "$W13C_OUT" "$SELECTOR_MARKER"
+check "W13c vitest standalone logs: every gcloud call pinned to the GCLOUD_IDENT value" \
+  accounts_all_equal "$RUNG2_IDENT"
 
 # --- W10/W11: help documents every identity knob, no human default ---------
 E2E_HELP=$("$WRAPPER_E2E" help 2>&1)
@@ -1095,18 +1316,30 @@ of `dan@danshapiro.com`, never empty):
   refactor preserves that; their new "the ladder never ran for a pinned
   call" assertions pass vacuously pre-wiring and become live after wiring,
   where they guard the rung-1 short-circuit).
+- W12a/W13a fail (no ladder pre-wiring: the marker never runs, so the
+  probe-permission assertion fails; and the accounts mismatch, dan@ versus
+  the probed robot).
+- W12c/W12d/W12e/W13b/W13c fail via accounts mismatch pre-wiring — the
+  standalone push/logs lanes parse NO pin flags today, so they pin the
+  hardcoded human no matter what GCLOUD_IDENT/--account says (this is the
+  round-2 Major: `push --account=EMAIL` ignored; `logs --account=EMAIL`
+  split-identity).
+- W12b PASSES pre-wiring (the current `cmd_build` already parses
+  `--account`); it is the rung-1 strict-mode immunity guard and becomes live
+  the moment wiring lands — without the short-circuit it fails (strict note
+  + nonzero exit).
 - W7 and W8/W9's silence assertions pass vacuously pre-wiring (no ladder
   exists to trigger the trap); W7's red proof is the step-3 interim run
   below.
 
 - [ ] **Step 3: Add the minimal production implementation — wrapper wiring only**
 
-Apply hunks E1–E11 to `scripts/e2e-cloud.sh` and V1–V11 to
-`scripts/vitest-cloud.sh` per the edit reference above. Do NOT yet add the
-four trap-11 pins.
+Apply hunks E1–E11 to `scripts/e2e-cloud.sh`, V1–V11 to
+`scripts/vitest-cloud.sh`, and E12 to `docker/cloud-run/cloudbuild.yaml` per
+the edit reference above. Do NOT yet add the four trap-11 pins.
 
 Interim verification (the pins' red proof): run
-`bash scripts/test/cloud-gcp-identity.test.sh` and confirm W1–W6, W8–W11 are
+`bash scripts/test/cloud-gcp-identity.test.sh` and confirm W1–W6 and W8–W13 are
 now GREEN while **W7 is RED with `$SELECTOR_MARKER` written** — the nested
 suites invoked the wired wrappers, the ladder reached rung 3, and the
 marker-trap selector ran: exactly the trap-11 network-reachability hazard,
@@ -1137,7 +1370,8 @@ hunks mirror each other apart from names/line placement.
 
 - [ ] **Step 6: Run impacted-test verification**
 
-Both wrappers changed and all six suites exercise them; the impacted set is
+Both wrappers changed and all five suites exercise them (the identity suite
+plus the four pre-existing cloud suites); the impacted set is
 the full cloud-suite loop:
 
 Run:
@@ -1161,8 +1395,9 @@ arrives via the workflow's coordinated suite at the stage gate.)
 git add scripts/e2e-cloud.sh scripts/vitest-cloud.sh \
         scripts/test/cloud-build.test.sh scripts/test/cloud-exec-id-parse.test.sh \
         scripts/test/cloud-run-wrapper.test.sh scripts/test/cloud-vitest-wrapper.test.sh \
-        scripts/test/cloud-gcp-identity.test.sh
-git commit -m "feat(cloud): wire gcloud-robot identity ladder into e2e/vitest cloud wrappers"
+        scripts/test/cloud-gcp-identity.test.sh \
+        docker/cloud-run/cloudbuild.yaml
+git commit -m "feat(cloud): wire gcloud-robot identity ladder into e2e/vitest cloud wrappers + route build logs to Cloud Logging"
 ```
 
 ---
@@ -1473,6 +1708,10 @@ for immediacy.)
 - Push 403s or the run logs "Creating Artifact Registry repository" then
   fails → step 1's repo-exists check was skipped: writer cannot create
   repositories. Run the describe/create block from provisioning.
+- "Where did build logs go?" → build logs now land in Cloud Logging by
+  design (`options.logging: CLOUD_LOGGING_ONLY`), so the
+  robot's `logging.viewer` covers them and no project-wide viewer grant is
+  needed. Streamed `builds submit` output is unchanged.
 - A grant that definitely exists 403s for the first minutes → IAM
   propagation lag; the verifier's retries (12 × 30s default) absorb it.
 - A lane prints the ambient-fallback note and then gcloud's
@@ -1563,6 +1802,10 @@ git commit -m "docs(cloud): add gcloud-robot operator runbook + AGENTS.md identi
 | help/local lanes need zero GCP tooling and stay silent | Task 2 W8/W9; pre-existing cloud-run-wrapper check 12 |
 | Trap-11: stubbed suites never reach the probe | Task 2 W7 (four nested suites under a hostile marker-trap home) |
 | Hardcoded-default removal documented in help | Task 2 W10/W11 |
+| Standalone build lane resolves with the BUILD probe permission | Task 2 W12a/W13a |
+| Standalone push/logs lanes honor pins + ladder (rung-1 and rung-2), logs passthrough preserved | Task 2 W12b–W12e, W13b/W13c |
+| Rung-1 short-circuit immunity to strict mode (pinned lanes never touch the ladder) | Task 1 check J; Task 2 W12b/W12e |
+| Build logs readable with least privilege | Task 2 E12 (`logging: CLOUD_LOGGING_ONLY`) — covered by `roles/logging.viewer`; end-to-end shape proven by the runbook's operator lane smoke |
 | Runbook + AGENTS.md docs | Task 3 — docs-only task; repo TDD doc exemption applies; verified by read-through + suite regression sweep |
 | Provisioning/rotation/revocation correctness | Documented only — human-executed; skill-mandated exclusion (no agent runs GCP mutations); surface completeness hardened by verify probes + one real lane smoke |
 | Whole-repo regression | Workflow stage gate (coordinated suite), outside task scope |
@@ -1582,3 +1825,12 @@ git commit -m "docs(cloud): add gcloud-robot operator runbook + AGENTS.md identi
   one note and run exactly as before (including, today, the culled-credential
   failure mode). That is the contract: adoption is non-breaking; provisioning
   is the fix.
+- **Build-log location changes for everyone.** `options.logging:
+  CLOUD_LOGGING_ONLY` moves build logs from the legacy GCS bucket to Cloud
+  Logging for human lanes too. The streamed `gcloud builds submit` output is
+  unchanged; only the Console link target moves (bucket viewer → Logs
+  Explorer). The alternative (granting the robot project-wide
+  `roles/viewer`) was refused as over-broad.
+- **Standalone lanes gain flag parsing.** `push`/`logs` now parse
+  `--account=`/`--project-id=`/`--region=`; unknown args keep their old
+  behavior (push ignores them; logs passes them through to `logs read`).

--- a/docs/plans/2026-08-22-gcloud-robot-conversion.md
+++ b/docs/plans/2026-08-22-gcloud-robot-conversion.md
@@ -1582,4 +1582,3 @@ git commit -m "docs(cloud): add gcloud-robot operator runbook + AGENTS.md identi
   one note and run exactly as before (including, today, the culled-credential
   failure mode). That is the contract: adoption is non-breaking; provisioning
   is the fix.
-

--- a/scripts/e2e-cloud.sh
+++ b/scripts/e2e-cloud.sh
@@ -26,7 +26,9 @@
 #   --timeout=DURATION Cloud Run task timeout (default: 60m)
 #   --grep=PATTERN    Pass --grep=PATTERN to Playwright
 #   --project=NAME    Pass --project=NAME to Playwright
-#   --account=EMAIL   GCP account (default: FRESHELL_GCP_ACCOUNT env or dan@danshapiro.com)
+#   --account=EMAIL   GCP account pin (highest precedence; default: none —
+#                     FRESHELL_GCP_ACCOUNT env, then the gcloud-robot identity
+#                     ladder, then ambient gcloud)
 #   --project-id=ID   GCP project (default: FRESHELL_GCP_PROJECT env or misc-puttering-project)
 #   --region=REGION   GCP region (default: FRESHELL_GCP_REGION env or us-west1)
 #
@@ -42,7 +44,11 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Defaults
 # ---------------------------------------------------------------------------
-GCP_ACCOUNT="${FRESHELL_GCP_ACCOUNT:-dan@danshapiro.com}"
+# No account is hardcoded. Precedence: --account= flag > FRESHELL_GCP_ACCOUNT
+# > gcloud-robot identity ladder (freshell_resolve_cloud_identity, resolved
+# lazily per cloud lane) > unset — calls then omit --account and ambient
+# gcloud applies, which the ladder announces once on stderr.
+GCP_ACCOUNT="${FRESHELL_GCP_ACCOUNT:-}"
 GCP_PROJECT="${FRESHELL_GCP_PROJECT:-misc-puttering-project}"
 GCP_REGION="${FRESHELL_GCP_REGION:-us-west1}"
 GCP_REPO="${FRESHELL_GCP_REPO:-freshell-e2e}"
@@ -54,6 +60,12 @@ IMAGE_REMOTE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${GCP_REPO}/${IMAGE_NA
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Shared gcloud identity ladder (gcloud-robot). Sourcing only defines
+# functions — no side effects, no output — so help and local lanes stay
+# gcloud-free and silent.
+# shellcheck source=scripts/lib/gcp-identity.sh
+. "$SCRIPT_DIR/lib/gcp-identity.sh"
 
 # Commit-addressed image tag (wrap-review r3): a cloud run must execute the
 # code at the CURRENT HEAD — with only a mutable :latest tag, `run` would
@@ -92,7 +104,13 @@ fi
 # Helpers
 # ---------------------------------------------------------------------------
 gcloud_flags() {
-  echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --region=${GCP_REGION}"
+  # No identity may legitimately resolve (rung 4: ambient gcloud). An empty
+  # pin omits --account entirely rather than passing gcloud an empty value.
+  if [ -n "${GCP_ACCOUNT:-}" ]; then
+    echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --region=${GCP_REGION}"
+  else
+    echo "--project=${GCP_PROJECT} --region=${GCP_REGION}"
+  fi
 }
 
 # Unique per-run job. `gcloud run jobs execute` snapshots the job's CURRENT
@@ -110,7 +128,21 @@ unique_job_name() {
 
 # gcloud artifacts commands use --location, not --region
 gcloud_artifacts_flags() {
-  echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --location=${GCP_REGION}"
+  if [ -n "${GCP_ACCOUNT:-}" ]; then
+    echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --location=${GCP_REGION}"
+  else
+    echo "--project=${GCP_PROJECT} --location=${GCP_REGION}"
+  fi
+}
+
+# Prints a pinned --account flag, or NOTHING (not even an empty word) when no
+# identity resolved — for the gcloud calls that pin inline instead of via
+# gcloud_flags(). An empty expansion inside an unquoted $() yields no argv
+# word, which is exactly what "omit --account" needs; always exits 0.
+account_flag() {
+  if [ -n "${GCP_ACCOUNT:-}" ]; then
+    printf -- '--account=%s' "${GCP_ACCOUNT}"
+  fi
 }
 
 usage() {
@@ -133,13 +165,21 @@ Flags:
   --timeout=DURATION Cloud Run task timeout (default: 60m)
   --grep=PATTERN    Pass --grep=PATTERN to Playwright
   --project=NAME    Pass --project=NAME to Playwright
-  --account=EMAIL   GCP account (default: dan@danshapiro.com)
+  --account=EMAIL   GCP account pin (highest precedence; default: none)
   --project-id=ID   GCP project (default: misc-puttering-project)
   --region=REGION   GCP region (default: us-west1)
 
 Environment:
   FRESHELL_E2E_BACKEND  "local" (default) or "cloud"
   FRESHELL_GCP_JOB      Cloud Run job-name prefix (default: freshell-e2e)
+  FRESHELL_GCP_ACCOUNT  GCP account override pinned on every gcloud call (optional)
+
+Identity (cloud lanes only — details: docs/development/gcloud-robot.md):
+  Cloud subcommands resolve a gcloud identity lazily, in this order:
+  --account= > FRESHELL_GCP_ACCOUNT > GCLOUD_IDENT > gcloud-robot probe
+  (needs GCLOUD_ROBOT_HOME, the installed gcloud-robot skill directory)
+  > ambient gcloud (one quiet stderr note). GCLOUD_ROBOT_REQUIRE=1 fails
+  closed with guidance instead of the ambient fallback.
 
 Cloud job lifecycle: each cloud run creates its OWN unique job
 (<prefix>-<commit>[-dirty]-<random>), executes it, and deletes it
@@ -188,6 +228,11 @@ cmd_build() {
     esac
   done
 
+  # Identity ladder (build/push lane): resolve before the first gcloud call,
+  # never at script top — help and local-only paths must keep working with
+  # zero GCP tooling. Probe = the lane's gating permission.
+  freshell_resolve_cloud_identity "cloudbuild.builds.create"
+
   # Content-addressed tag (see image_tag_for_head): the only tag `run` pins.
   local tag remote_base
   tag="$(image_tag_for_head)"
@@ -205,7 +250,7 @@ cmd_build() {
     echo "[e2e-cloud] Building Docker image via Cloud Build (tag: $tag)..."
     gcloud builds submit \
       --config "$ROOT/docker/cloud-run/cloudbuild.yaml" \
-      --account="$GCP_ACCOUNT" \
+      $(account_flag) \
       --project="$GCP_PROJECT" \
       --substitutions=_IMAGE="${remote_base}:${tag}" \
       "$ROOT"
@@ -219,6 +264,32 @@ cmd_build() {
 cmd_push() {
   echo "[e2e-cloud] Pushing to Artifact Registry..."
 
+  # The standalone push lane honors the same pin flags as build/run;
+  # parse FIRST so an explicit --account= wins without touching the ladder.
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --account=*)
+        GCP_ACCOUNT="${1#*=}"
+        shift
+        ;;
+      --project-id=*)
+        GCP_PROJECT="${1#*=}"
+        shift
+        ;;
+      --region=*)
+        GCP_REGION="${1#*=}"
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  # A standalone `push` reaches gcloud without passing through cmd_build;
+  # resolve idempotently (free when cmd_build already did).
+  freshell_resolve_cloud_identity "cloudbuild.builds.create"
+
   # Ensure the Artifact Registry repo exists
   if ! gcloud artifacts repositories describe $(gcloud_artifacts_flags) "$GCP_REPO" &>/dev/null; then
     echo "[e2e-cloud] Creating Artifact Registry repository: $GCP_REPO"
@@ -228,7 +299,7 @@ cmd_push() {
 
   # Authenticate Docker to Artifact Registry using an access token.
   # We can't rely on the docker-credential-gcloud helper being on PATH.
-  gcloud auth print-access-token --account="$GCP_ACCOUNT" | \
+  gcloud auth print-access-token $(account_flag) | \
     docker login -u oauth2accesstoken --password-stdin \
       "https://${GCP_REGION}-docker.pkg.dev"
 
@@ -363,6 +434,12 @@ cmd_run() {
       "${pw_args[@]}"
   fi
 
+  # Identity ladder (run lane): resolve before the image describe / build /
+  # job calls below. `run --local` never reaches here (it exec'd above),
+  # so the local lane stays free of GCP tooling and of the ladder's
+  # stderr note.
+  freshell_resolve_cloud_identity "run.jobs.run"
+
   # Recompute the remote ref with potentially overridden GCP settings —
   # COMMIT-ADDRESSED, never mutable :latest (see image_tag_for_head): the
   # job must run THIS HEAD's code or fail loudly, never pass on a stale
@@ -390,7 +467,7 @@ cmd_run() {
       cmd_build
     fi
   elif ! gcloud artifacts docker images describe "$IMAGE_REMOTE" \
-      --account="$GCP_ACCOUNT" --project="$GCP_PROJECT" &>/dev/null 2>&1; then
+      $(account_flag) --project="$GCP_PROJECT" &>/dev/null 2>&1; then
     # Clean tree: the HEAD tag genuinely addresses this image's content.
     echo "[e2e-cloud] No remote image for HEAD ($image_tag), building and pushing..."
     if $local_build_flag; then
@@ -572,6 +649,35 @@ cmd_logs() {
   # legacy lookup only helps for executions of the old shared job. Per-run
   # logs are printed in full during the run and remain queryable in Cloud
   # Logging by job/execution name afterwards.
+
+  # Parse the pin flags FIRST (same contract as build/run); the rest passes
+  # through to `logs read` verbatim, preserving the existing behavior.
+  local -a logs_passthrough=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --account=*)
+        GCP_ACCOUNT="${1#*=}"
+        shift
+        ;;
+      --project-id=*)
+        GCP_PROJECT="${1#*=}"
+        shift
+        ;;
+      --region=*)
+        GCP_REGION="${1#*=}"
+        shift
+        ;;
+      *)
+        logs_passthrough+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  # logs is a cloud-only lane (executions list + logs read); resolve after
+  # parsing so an explicit pin short-circuits the ladder.
+  freshell_resolve_cloud_identity "run.jobs.run"
+
   local execution_id
   execution_id=$(gcloud run jobs executions list $(gcloud_flags) \
     --job="$GCP_JOB" \
@@ -582,7 +688,8 @@ cmd_logs() {
     echo "[e2e-cloud] No executions found for job $GCP_JOB" >&2
     exit 1
   fi
-  gcloud beta run jobs executions logs read $(gcloud_flags) "$execution_id" "$@"
+  gcloud beta run jobs executions logs read $(gcloud_flags) "$execution_id" \
+    "${logs_passthrough[@]+"${logs_passthrough[@]}"}"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/gcp-identity.sh
+++ b/scripts/lib/gcp-identity.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# gcp-identity.sh — shared gcloud identity ladder for Freshell's GCP lanes
+# (scripts/e2e-cloud.sh, scripts/vitest-cloud.sh).
+#
+# THIS FILE IS SOURCED, NOT EXECUTED. It only defines functions — no
+# top-level side effects, no output, no network — so every lane, including
+# `help` and local runs on machines with no gcloud and no skill installed,
+# may source it unconditionally.
+#
+# resolve_gcp_identity below is the gcloud-robot skill's drop-in block,
+# copied VERBATIM. Do not hand-edit it: the rung ordering and the
+# ambient-default / strict-opt-in behavior are load-bearing. The skill
+# itself is never vendored or referenced by path; this block is the single
+# permitted copy, and run-time discovery of the selector happens only via
+# GCLOUD_ROBOT_HOME.
+#
+# Ladder (fixed order):
+#   1. A call-site / repo pin (the wrapper's --account= or FRESHELL_GCP_ACCOUNT)
+#      is never overridden — the bridge below only fills an EMPTY pin var.
+#   2. GCLOUD_IDENT set: use verbatim, no probe, no network.
+#   3. Probe: $GCLOUD_ROBOT_HOME/scripts/select-gcloud-identity.sh picks a
+#      credentialed account that passes the lane's live permission probe.
+#   4. Ambient fallback (default): one quiet stderr note, gcloud runs exactly
+#      as before adoption. GCLOUD_ROBOT_REQUIRE=1 turns rung 4 into
+#      fail-closed-with-guidance (hardening/CI).
+
+# --- BEGIN verbatim drop-in block (gcloud-robot skill) --------------------
+resolve_gcp_identity() {
+  [ -n "${GCLOUD_IDENT_RESOLVED:-}" ] && return 0; GCLOUD_IDENT_RESOLVED=1
+  export GCLOUD_ROBOT_PROJECT="${GCLOUD_ROBOT_PROJECT:?set GCLOUD_ROBOT_PROJECT}"
+  export GCLOUD_ROBOT_PROBE_PERMISSION="${GCLOUD_ROBOT_PROBE_PERMISSION:?set GCLOUD_ROBOT_PROBE_PERMISSION (lane representative permission)}"
+  if [ -n "${GCLOUD_IDENT:-}" ]; then
+    :                                                          # rung 2: explicit bypass, no network
+  elif [ -n "${GCLOUD_ROBOT_HOME:-}" ] && [ -x "$GCLOUD_ROBOT_HOME/scripts/select-gcloud-identity.sh" ]; then
+    GCLOUD_IDENT="$(bash "$GCLOUD_ROBOT_HOME/scripts/select-gcloud-identity.sh" 2>/dev/null)" || GCLOUD_IDENT=""
+    if [ -z "$GCLOUD_IDENT" ] && [ -n "${GCLOUD_ROBOT_REQUIRE:-}" ]; then
+      echo "gcloud-robot: no identity passes the probe on $GCLOUD_ROBOT_PROJECT (strict mode)" >&2
+      return 1
+    fi
+    [ -z "$GCLOUD_IDENT" ] && echo "gcloud-robot: no probed identity; using ambient gcloud" >&2
+  elif [ -n "${GCLOUD_ROBOT_REQUIRE:-}" ]; then
+    echo "gcloud-robot: skill not found at ${GCLOUD_ROBOT_HOME:-<unset>}... (strict mode)" >&2
+    return 1                                                   # rung 4: fail closed (opt-in)
+  else
+    echo "gcloud-robot: skill not found at ${GCLOUD_ROBOT_HOME:-<unset>} — using ambient gcloud (set GCLOUD_ROBOT_HOME to get robot identity)" >&2
+  fi
+  if [ -n "${GCLOUD_IDENT:-}" ]; then
+    export CLOUDSDK_CORE_ACCOUNT="$GCLOUD_IDENT" CLOUDSDK_CORE_PROJECT="$GCLOUD_ROBOT_PROJECT"
+  fi
+}
+# --- END verbatim drop-in block --------------------------------------------
+# Nesting rule (from the skill): never write ${...:?...} messages with
+# apostrophes — bash parses the ${} interior as its own quoting context.
+
+# freshell_resolve_cloud_identity bridges a wrapper's settings into the
+# ladder and applies a probed identity to the wrapper's pinned account var.
+#
+#   $1 = this lane's representative probe permission (the permission that
+#        gates the lane's real work): "cloudbuild.builds.create" for the
+#        build/push lane, "run.jobs.run" for the run and logs lanes.
+#
+# Call it LAZILY — immediately before a cloud lane's first real gcloud call,
+# after flag parsing — so help/local lanes never touch GCP tooling. The
+# ladder's own guard makes repeat calls free (single probe per process).
+#
+# Requires the caller to provide GCP_PROJECT and GCP_ACCOUNT (possibly
+# empty), matching both cloud wrappers' top-of-file defaults.
+freshell_resolve_cloud_identity() {
+  # rung 1: an existing pin (the wrapper's --account= flag or
+  # FRESHELL_GCP_ACCOUNT) wins outright — skip the ladder ENTIRELY: no
+  # selector, no network, no stderr note, and GCLOUD_ROBOT_REQUIRE=1 must not
+  # fail a deliberately pinned call.
+  if [ -n "${GCP_ACCOUNT:-}" ]; then return 0; fi
+  export GCLOUD_ROBOT_PROJECT="${GCLOUD_ROBOT_PROJECT:-${GCP_PROJECT:?GCP_PROJECT must be set before identity resolution}}"
+  export GCLOUD_ROBOT_PROBE_PERMISSION="${GCLOUD_ROBOT_PROBE_PERMISSION:-${1:?probe permission argument required}}"
+  # Propagate the ladder's status: under GCLOUD_ROBOT_REQUIRE=1 a failed
+  # resolve must fail the lane (both wrappers run set -e; the ladder already
+  # printed its guidance).
+  if ! resolve_gcp_identity; then return 1; fi
+  # Pinned-call adoption (gcloud-robot skill): a probed identity takes the
+  # pinned --account slot (the pin was empty, per the rung-1 branch above).
+  # With nothing resolved the pin stays empty and the wrappers omit
+  # --account entirely, letting ambient gcloud apply (the ladder already
+  # noted that on stderr).
+  GCP_ACCOUNT="${GCLOUD_IDENT:-}"
+}

--- a/scripts/test/cloud-build.test.sh
+++ b/scripts/test/cloud-build.test.sh
@@ -6,6 +6,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$ROOT"
 
+# gcloud-robot hermeticity pin (skill trap 11): the wrappers now carry a live
+# identity ladder. Pinning GCLOUD_IDENT forces the ladder's rung-2 bypass, so
+# no wrapper invocation from this suite can reach the real probe/network —
+# even if the harness environment happens to export GCLOUD_ROBOT_HOME. The
+# value is deliberately fake; nothing in this suite depends on it.
+export GCLOUD_IDENT="suite-pinned-identity@example.invalid"
+
 CLOUDBUILD="$ROOT/docker/cloud-run/cloudbuild.yaml"
 GCLOUDIGNORE="$ROOT/.gcloudignore"
 

--- a/scripts/test/cloud-exec-id-parse.test.sh
+++ b/scripts/test/cloud-exec-id-parse.test.sh
@@ -17,6 +17,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$ROOT"
 
+# gcloud-robot hermeticity pin (skill trap 11): the wrappers now carry a live
+# identity ladder. Pinning GCLOUD_IDENT forces the ladder's rung-2 bypass, so
+# no wrapper invocation from this suite can reach the real probe/network —
+# even if the harness environment happens to export GCLOUD_ROBOT_HOME. The
+# value is deliberately fake; nothing in this suite depends on it.
+export GCLOUD_IDENT="suite-pinned-identity@example.invalid"
+
 FAILURES=0
 check() {
   local desc="$1"

--- a/scripts/test/cloud-gcp-identity.test.sh
+++ b/scripts/test/cloud-gcp-identity.test.sh
@@ -200,7 +200,367 @@ check "explicit account pin wins BEFORE the ladder (no probe, no exports, silent
   ' _ "$(field "$OUT" rc)" "$(field "$OUT" pin)" "$(field "$OUT" account)" \
       "$SELECTOR_MARKER" "$LADDER_STDERR"
 
-# WRAPPER-LEVEL-CHECKS-ANCHOR (Task 2 appends here)
+# ---------------------------------------------------------------------------
+# Wrapper-level: the ladder drives --account on REAL wrapper cloud runs
+# (stubbed gcloud/docker; green-run shape mirrors cloud-exec-id-parse.test.sh).
+# ---------------------------------------------------------------------------
+echo "--- Wrapper-level identity checks ---"
+
+GTDIR="$TDIR/gcloud-stub"
+mkdir -p "$GTDIR"
+# Exported: the fake gcloud/docker run as wrapper CHILD processes and read it.
+export GREEN_LOG="$TDIR/green-gcloud.log"
+
+# Green-run fake gcloud. images describe reports the image MISSING (exit 1)
+# so every run also crosses the build lane (builds submit stubbed); the job
+# lifecycle succeeds for any --shards value. Records every argv in $GREEN_LOG
+# and every --account token (one per line) in $GREEN_LOG.accounts — an ABSENT
+# accounts file is the proof that every call omitted --account.
+cat > "$GTDIR/gcloud" <<'GREEN_FAKE'
+#!/usr/bin/env bash
+echo "GCLOUD_ARGS: $*" >> "${GREEN_LOG:?set GREEN_LOG}"
+# Shell redirection creates its target eagerly, so `grep ... >> FILE` would
+# materialize an EMPTY accounts file even when no --account token exists —
+# breaking every "--account was omitted" assertion. Capture, write only when
+# non-empty: an ABSENT accounts file therefore proves omission.
+ACCT_TOKENS="$(grep -oP -- '--account=\S+' <<< "$*" 2>/dev/null || true)"
+if [ -n "$ACCT_TOKENS" ]; then printf '%s\n' "$ACCT_TOKENS" >> "${GREEN_LOG}.accounts"; fi
+if [[ "$*" == *"info"* ]]; then echo "/nonexistent-sdk-root"; exit 0; fi
+if [[ "$*" == *"artifacts docker images describe"* ]]; then exit 1; fi
+if [[ "$*" == *"artifacts repositories describe"* ]]; then exit 0; fi
+if [[ "$*" == *"artifacts repositories create"* ]]; then exit 0; fi
+if [[ "$*" == *"builds submit"* ]]; then exit 0; fi
+if [[ "$*" == *"auth print-access-token"* ]]; then echo stub-token; exit 0; fi
+# Substring-match order matters: "run jobs executions list|logs read" CONTAINS
+# "run jobs execute" as a substring, so the specific execution subcommands are
+# matched BEFORE the bare execute branch. (Nested-suite fakes use the same
+# discipline.)
+if [[ "$*" == *"executions list"* ]]; then echo "green-exec-1"; exit 0; fi
+if [[ "$*" == *"logs read"* ]]; then echo "  1 passed (1.0s)"; exit 0; fi
+if [[ "$*" == *"executions describe"* ]]; then
+  if [[ "$*" == *"succeededCount"* ]]; then
+    N=$(grep -oP -- '--tasks=\K[0-9]+' "${GREEN_LOG}" | tail -1)
+    echo "${N:-1}"
+  else
+    echo "0"
+  fi
+  exit 0
+fi
+if [[ "$*" == *"run jobs execute"* ]]; then echo "Execution [green-exec-1] has successfully completed."; exit 0; fi
+if [[ "$*" == *"run jobs"* ]]; then exit 0; fi
+exit 0
+GREEN_FAKE
+cat > "$GTDIR/docker" <<'GREEN_DOCKER'
+#!/usr/bin/env bash
+if [ ! -t 0 ]; then cat >/dev/null 2>&1 || true; fi
+exit 0
+GREEN_DOCKER
+chmod +x "$GTDIR/gcloud" "$GTDIR/docker"
+
+# Distinctive values per rung and pin source so the accounts log proves
+# WHICH token won, never just that some token appeared.
+RUNG2_IDENT="rung2-bypass@example.invalid"
+RUNG3_ROBOT="rung3-robot@example.invalid"
+FLAG_ACCOUNT="flag-wins@example.invalid"
+ENV_ACCOUNT="env-wins@example.invalid"
+
+reset_green() {
+  rm -f "$GREEN_LOG" "$GREEN_LOG.accounts" "$SELECTOR_MARKER" "$SELECTOR_MARKER.env"
+  touch "$GREEN_LOG"
+}
+
+# Every gcloud invocation that COULD pin an account DID pin this exact one:
+# the accounts log must contain one token per logged gcloud call (the bare
+# `gcloud info` PATH-probe call takes no flags and is excluded), all equal to
+# the expected value, and non-empty — an omit/present mix or an empty log
+# both fail.
+accounts_all_equal() {
+  [ -s "$GREEN_LOG.accounts" ] || return 1
+  local calls tokens
+  calls=$(grep '^GCLOUD_ARGS:' "$GREEN_LOG" | grep -vc '^GCLOUD_ARGS: info ')
+  tokens=$(wc -l < "$GREEN_LOG.accounts")
+  [ "$calls" -gt 0 ] && [ "$calls" -eq "$tokens" ] && \
+    [ "$(sort -u "$GREEN_LOG.accounts" | wc -l)" = "1" ] && \
+    [ "$(sort -u "$GREEN_LOG.accounts" | head -1)" = "--account=$1" ]
+}
+
+# --- W1: e2e rung 2 — GCLOUD_IDENT drives every pinned call ----------------
+reset_green
+W1_ERR="$TDIR/w1.err"
+W1_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+         GCLOUD_IDENT="$RUNG2_IDENT" GCLOUD_ROBOT_HOME="$FAKE_HOME" \
+         "$WRAPPER_E2E" run --cloud --shards=1 2>"$W1_ERR") && W1_RC=0 || W1_RC=$?
+check "W1 e2e rung-2: run succeeds with GCLOUD_IDENT pinned on every call, selector untouched, silent" \
+  bash -c '
+    [ "$1" = "0" ] && grep -q "All tasks completed successfully" <<<"$2" &&
+    [ ! -s "$3" ]
+  ' _ "$W1_RC" "$W1_OUT" "$W1_ERR"
+check "W1 e2e rung-2: every gcloud call pinned to the GCLOUD_IDENT value" \
+  accounts_all_equal "$RUNG2_IDENT"
+check "W1 e2e rung-2: selector never ran and no hardcoded human account appeared" \
+  bash -c '[ ! -e "$1" ] && ! grep -q "dan@danshapiro" "$2"' _ "$SELECTOR_MARKER" "$GREEN_LOG"
+
+# --- W2: e2e rung 1 — a flag pin wins BEFORE the ladder runs --------------
+reset_green
+W2_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+         GCLOUD_IDENT="$RUNG2_IDENT" FRESHELL_GCP_ACCOUNT="$ENV_ACCOUNT" GCLOUD_ROBOT_HOME="$FAKE_HOME" \
+         "$WRAPPER_E2E" run --cloud --shards=1 --account="$FLAG_ACCOUNT" 2>/dev/null) && W2_RC=0 || W2_RC=$?
+check "W2 e2e rung-1: --account= flag wins over env and ladder" \
+  bash -c '[ "$1" = "0" ]' _ "$W2_RC"
+check "W2 e2e rung-1: every gcloud call pinned to the flag value" \
+  accounts_all_equal "$FLAG_ACCOUNT"
+check "W2 e2e rung-1: the ladder never ran for a pinned call (no probe, even with HOME set)" \
+  bash -c '[ ! -e "$1" ]' _ "$SELECTOR_MARKER"
+
+# --- W3: e2e rung 1b — FRESHELL_GCP_ACCOUNT wins BEFORE the ladder --------
+reset_green
+W3_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+         GCLOUD_IDENT="$RUNG2_IDENT" FRESHELL_GCP_ACCOUNT="$ENV_ACCOUNT" GCLOUD_ROBOT_HOME="$FAKE_HOME" \
+         "$WRAPPER_E2E" run --cloud --shards=1 2>/dev/null) && W3_RC=0 || W3_RC=$?
+check "W3 e2e env-pin: FRESHELL_GCP_ACCOUNT wins over the ladder" \
+  bash -c '[ "$1" = "0" ]' _ "$W3_RC"
+check "W3 e2e env-pin: every gcloud call pinned to the env value" \
+  accounts_all_equal "$ENV_ACCOUNT"
+check "W3 e2e env-pin: the ladder never ran for a pinned call" \
+  bash -c '[ ! -e "$1" ]' _ "$SELECTOR_MARKER"
+
+# --- W4: e2e rung 3 — the probe result takes the pinned slot ---------------
+reset_green
+W4_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+         GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_ACCOUNT="$RUNG3_ROBOT" \
+         "$WRAPPER_E2E" run --cloud --shards=1 2>/dev/null) && W4_RC=0 || W4_RC=$?
+check "W4 e2e rung-3: probed identity pins every call; selector ran once w/ lane probe" \
+  bash -c '
+    [ "$1" = "0" ] &&
+    [ "$(wc -l < "$2")" = "1" ] &&
+    grep -q "project=misc-puttering-project probe=run.jobs.run" "$2.env"
+  ' _ "$W4_RC" "$SELECTOR_MARKER"
+check "W4 e2e rung-3: every gcloud call pinned to the probed robot" \
+  accounts_all_equal "$RUNG3_ROBOT"
+
+# --- W5: e2e rung 4 — nothing resolves: --account omitted, one note ---------
+reset_green
+W5_ERR="$TDIR/w5.err"
+W5_OUT=$(env "${SCRUB[@]}" \
+         PATH="$GTDIR:$PATH" "$WRAPPER_E2E" run --cloud --shards=1 2>"$W5_ERR") && W5_RC=0 || W5_RC=$?
+check "W5 e2e ambient: run succeeds, --account omitted everywhere, one ambient note" \
+  bash -c '
+    [ "$1" = "0" ] && grep -q "All tasks completed successfully" <<<"$2" &&
+    [ ! -e "$3" ] &&
+    [ "$(wc -l < "$4")" = "1" ] &&
+    grep -q "skill not found .* using ambient gcloud" "$4"
+  ' _ "$W5_RC" "$W5_OUT" "$GREEN_LOG.accounts" "$W5_ERR"
+
+# --- W6: vitest parity — rung-2 pin and rung-4 omission -------------------
+reset_green
+W6A_ERR="$TDIR/w6a.err"
+W6A_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+          GCLOUD_IDENT="$RUNG2_IDENT" GCLOUD_ROBOT_HOME="$FAKE_HOME" \
+          "$WRAPPER_VITEST" run --cloud --config=default --shards=2 2>"$W6A_ERR") && W6A_RC=0 || W6A_RC=$?
+check "W6a vitest rung-2: succeeds, every call pinned to GCLOUD_IDENT, selector untouched" \
+  bash -c '
+    [ "$1" = "0" ] && grep -q "All tasks completed successfully" <<<"$2" &&
+    [ ! -e "$3" ] && [ ! -s "$4" ]
+  ' _ "$W6A_RC" "$W6A_OUT" "$SELECTOR_MARKER" "$W6A_ERR"
+check "W6a vitest rung-2: every gcloud call pinned to the GCLOUD_IDENT value" \
+  accounts_all_equal "$RUNG2_IDENT"
+
+reset_green
+W6B_ERR="$TDIR/w6b.err"
+W6B_OUT=$(env "${SCRUB[@]}" \
+          PATH="$GTDIR:$PATH" "$WRAPPER_VITEST" run --cloud --config=default --shards=2 2>"$W6B_ERR") && W6B_RC=0 || W6B_RC=$?
+check "W6b vitest ambient: run succeeds, --account omitted everywhere, one ambient note" \
+  bash -c '
+    [ "$1" = "0" ] && grep -q "All tasks completed successfully" <<<"$2" &&
+    [ ! -e "$3" ] &&
+    [ "$(wc -l < "$4")" = "1" ] &&
+    grep -q "skill not found .* using ambient gcloud" "$4"
+  ' _ "$W6B_RC" "$W6B_OUT" "$GREEN_LOG.accounts" "$W6B_ERR"
+
+# --- W7: the four pre-existing stubbed suites are probe-proof (trap 11) ----
+# Each pins GCLOUD_IDENT, so running them under a marker-trap
+# GCLOUD_ROBOT_HOME whose selector would FAIL must leave the marker untouched
+# AND the suites green: no nested wrapper invocation may reach the probe.
+# The scrub keeps any harness-level ladder knobs from leaking in and
+# invalidating the pin experiment.
+for nested in scripts/test/cloud-build.test.sh \
+              scripts/test/cloud-exec-id-parse.test.sh \
+              scripts/test/cloud-vitest-wrapper.test.sh \
+              scripts/test/cloud-run-wrapper.test.sh; do
+  rm -f "$SELECTOR_MARKER"
+  env "${SCRUB[@]}" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_FAIL=1 \
+    bash "$nested" >"$TDIR/nested.log" 2>&1 && NESTED_RC=0 || NESTED_RC=$?
+  check "W7 trap-11: $nested green and probe-free under hostile GCLOUD_ROBOT_HOME" \
+    bash -c '[ "$1" = "0" ] && [ ! -e "$2" ]' _ "$NESTED_RC" "$SELECTOR_MARKER"
+done
+
+# --- W8: help works with no gcloud, no account, fake HOME — and silently ---
+# The silence assertion matches ONLY the ladder's runtime diagnostic prefixes
+# ("gcloud-robot: skill not found", "gcloud-robot: no probed identity") — the
+# help text itself legitimately documents the ladder by name (E11), so a bare
+# "gcloud-robot" match would forbid the docs and break the suite by design.
+CLEAN_PATH="$PATH"
+if GCLOUD_PATH_RESOLVED=$(command -v gcloud 2>/dev/null); then
+  GCLOUD_DIRNAME="$(cd "$(dirname "$GCLOUD_PATH_RESOLVED")" && pwd)"
+  CLEAN_PATH="$(echo "$PATH" | tr ':' '\n' | grep -vx "$GCLOUD_DIRNAME" | paste -sd:)"
+  if [ "$CLEAN_PATH" = "$PATH" ]; then
+    echo "FAIL: could not construct a gcloud-free PATH (gcloud dir not on PATH?)"
+    FAILURES=$((FAILURES + 1))
+    CLEAN_PATH=""
+  fi
+fi
+if [ -n "$CLEAN_PATH" ]; then
+  # NOTE: `command -v` is a shell builtin; it must run INSIDE a shell (`env
+  # PATH=... bash -c ...`) — `env PATH=... command -v gcloud` tries to exec
+  # a program named "command", returns 127 unconditionally, and would
+  # certify a non-clean PATH. (The same latent bug exists in
+  # cloud-run-wrapper.test.sh check 12 — pre-existing, out of scope here.)
+  if env PATH="$CLEAN_PATH" bash -c 'command -v gcloud >/dev/null 2>&1'; then
+    echo "FAIL: gcloud still resolvable on the filtered PATH"
+    FAILURES=$((FAILURES + 1))
+  else
+    for wrapper_pair in "E2E:$WRAPPER_E2E" "VITEST:$WRAPPER_VITEST"; do
+      lane="${wrapper_pair%%:*}"
+      wrapper="${wrapper_pair#*:}"
+      rm -f "$SELECTOR_MARKER"
+      HELP_OUT=$(env "${SCRUB[@]}" PATH="$CLEAN_PATH" \
+        GCLOUD_ROBOT_HOME="$FAKE_HOME" \
+        "$wrapper" help 2>&1) && HELP_RC=0 || HELP_RC=$?
+      check "W8 $lane help: exit 0, prints usage, no identity activity, silent" \
+        bash -c '
+          [ "$1" = "0" ] && grep -qi "usage" <<<"$2" &&
+          ! grep -qE "gcloud-robot: (skill not found|no probed identity)" <<<"$2" && [ ! -e "$3" ]
+        ' _ "$HELP_RC" "$HELP_OUT" "$SELECTOR_MARKER"
+    done
+  fi
+fi
+
+# --- W9: the vitest local lane never wakes the ladder ----------------------
+rm -f "$SELECTOR_MARKER"
+W9_OUT=$(env "${SCRUB[@]}" \
+         GCLOUD_ROBOT_HOME="$FAKE_HOME" \
+         "$WRAPPER_VITEST" run --local --config=default test/unit/lib/pane-utils.test.ts 2>&1) \
+  && W9_RC=0 || W9_RC=$?
+check "W9 vitest --local: runs real local vitest, no selector, no ladder output" \
+  bash -c '
+    [ "$1" = "0" ] &&
+    grep -qE "Test Files|passed" <<<"$2" &&
+    ! grep -qE "gcloud-robot: (skill not found|no probed identity)" <<<"$2" && [ ! -e "$3" ]
+  ' _ "$W9_RC" "$W9_OUT" "$SELECTOR_MARKER"
+
+# --- W12: e2e standalone lanes (build / push / logs) run their OWN ladder ---
+# cmd_run populates GCP_ACCOUNT before delegating to cmd_build/cmd_push, so
+# run-based checks can NEVER catch a missing resolver or a missing pin-parse
+# loop on the standalone lanes. These exercise them directly.
+
+# W12a: standalone build — probe selects, with the BUILD-lane probe permission.
+reset_green
+W12A_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+  GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_ACCOUNT="$RUNG3_ROBOT" \
+  "$WRAPPER_E2E" build 2>/dev/null) && W12A_RC=0 || W12A_RC=$?
+check "W12a e2e standalone build: probe identity selected once, build-lane probe permission" \
+  bash -c '
+    [ "$1" = "0" ] &&
+    [ "$(wc -l < "$2")" = "1" ] &&
+    grep -q "project=misc-puttering-project probe=cloudbuild.builds.create" "$2.env"
+  ' _ "$W12A_RC" "$SELECTOR_MARKER"
+check "W12a e2e standalone build: every gcloud call pinned to the probed robot" \
+  accounts_all_equal "$RUNG3_ROBOT"
+
+# W12b: strict mode + absent skill must NOT fail an explicitly pinned
+# standalone build (rung-1 immunity — guards the short-circuit itself).
+reset_green
+W12B_ERR="$TDIR/w12b.err"
+W12B_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" GCLOUD_ROBOT_REQUIRE=1 \
+  "$WRAPPER_E2E" build --account="$FLAG_ACCOUNT" 2>"$W12B_ERR") && W12B_RC=0 || W12B_RC=$?
+check "W12b e2e standalone build: --account pin wins, strict mode cannot fail it, silent" \
+  bash -c '
+    [ "$1" = "0" ] && grep -q "Cloud Build complete" <<<"$2" &&
+    [ ! -e "$3" ] && [ ! -s "$4" ]
+  ' _ "$W12B_RC" "$W12B_OUT" "$SELECTOR_MARKER" "$W12B_ERR"
+check "W12b e2e standalone build: every gcloud call pinned to the flag value" \
+  accounts_all_equal "$FLAG_ACCOUNT"
+
+# W12c: standalone push — rung-2 pin must reach describe/print-access-token.
+reset_green
+W12C_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" GCLOUD_IDENT="$RUNG2_IDENT" \
+  "$WRAPPER_E2E" push 2>/dev/null) && W12C_RC=0 || W12C_RC=$?
+check "W12c e2e standalone push: succeeds under rung-2 pin" \
+  bash -c '[ "$1" = "0" ] && [ ! -e "$3" ]' _ "$W12C_RC" "$W12C_OUT" "$SELECTOR_MARKER"
+check "W12c e2e standalone push: every gcloud call pinned to the GCLOUD_IDENT value" \
+  accounts_all_equal "$RUNG2_IDENT"
+
+# W12d: standalone logs — rung-2 pin on BOTH calls, non-pin args passed through.
+reset_green
+W12D_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" GCLOUD_IDENT="$RUNG2_IDENT" \
+  "$WRAPPER_E2E" logs --limit=3 --freshness=1d 2>/dev/null) && W12D_RC=0 || W12D_RC=$?
+check "W12d e2e standalone logs: list+read share the pinned identity, pass-through args preserved" \
+  bash -c '
+    [ "$1" = "0" ] && [ ! -e "$4" ] &&
+    grep "logs read" "$2" | grep -q -- "--limit=3" &&
+    grep "logs read" "$2" | grep -q -- "--freshness=1d"
+  ' _ "$W12D_RC" "$GREEN_LOG" "$W12D_OUT" "$SELECTOR_MARKER"
+check "W12d e2e standalone logs: every gcloud call pinned to the GCLOUD_IDENT value" \
+  accounts_all_equal "$RUNG2_IDENT"
+
+# W12e: standalone logs — flag pin wins on the logs lane (rung 1 there too).
+reset_green
+W12E_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" GCLOUD_ROBOT_REQUIRE=1 \
+  "$WRAPPER_E2E" logs --account="$FLAG_ACCOUNT" 2>/dev/null) && W12E_RC=0 || W12E_RC=$?
+check "W12e e2e standalone logs: --account pin honored (rung 1), strict-mode immune" \
+  bash -c '[ "$1" = "0" ] && [ ! -e "$3" ]' _ "$W12E_RC" "$W12E_OUT" "$SELECTOR_MARKER"
+check "W12e e2e standalone logs: every gcloud call pinned to the flag value" \
+  accounts_all_equal "$FLAG_ACCOUNT"
+
+# --- W13: vitest standalone lanes (build / push / logs) — parity pins -------
+# W13a: standalone build via probe.
+reset_green
+W13A_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" \
+  GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_ACCOUNT="$RUNG3_ROBOT" \
+  "$WRAPPER_VITEST" build 2>/dev/null) && W13A_RC=0 || W13A_RC=$?
+check "W13a vitest standalone build: probe identity selected once, build-lane probe permission" \
+  bash -c '
+    [ "$1" = "0" ] &&
+    [ "$(wc -l < "$2")" = "1" ] &&
+    grep -q "project=misc-puttering-project probe=cloudbuild.builds.create" "$2.env"
+  ' _ "$W13A_RC" "$SELECTOR_MARKER"
+check "W13a vitest standalone build: every gcloud call pinned to the probed robot" \
+  accounts_all_equal "$RUNG3_ROBOT"
+
+# W13b: standalone push under rung-2 pin.
+reset_green
+W13B_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" GCLOUD_IDENT="$RUNG2_IDENT" \
+  "$WRAPPER_VITEST" push 2>/dev/null) && W13B_RC=0 || W13B_RC=$?
+check "W13b vitest standalone push: succeeds, every gcloud call pinned to GCLOUD_IDENT" \
+  bash -c '[ "$1" = "0" ] && [ ! -e "$3" ]' _ "$W13B_RC" "$W13B_OUT" "$SELECTOR_MARKER"
+check "W13b vitest standalone push: every gcloud call pinned to the GCLOUD_IDENT value" \
+  accounts_all_equal "$RUNG2_IDENT"
+
+# W13c: standalone logs under rung-2 pin, pass-through preserved.
+reset_green
+W13C_OUT=$(env "${SCRUB[@]}" PATH="$GTDIR:$PATH" GCLOUD_IDENT="$RUNG2_IDENT" \
+  "$WRAPPER_VITEST" logs --limit=2 2>/dev/null) && W13C_RC=0 || W13C_RC=$?
+check "W13c vitest standalone logs: pinned identity on both calls, pass-through preserved" \
+  bash -c '
+    [ "$1" = "0" ] && [ ! -e "$4" ] &&
+    grep "logs read" "$2" | grep -q -- "--limit=2"
+  ' _ "$W13C_RC" "$GREEN_LOG" "$W13C_OUT" "$SELECTOR_MARKER"
+check "W13c vitest standalone logs: every gcloud call pinned to the GCLOUD_IDENT value" \
+  accounts_all_equal "$RUNG2_IDENT"
+
+# --- W10/W11: help documents every identity knob, no human default ---------
+E2E_HELP=$("$WRAPPER_E2E" help 2>&1)
+VITEST_HELP=$("$WRAPPER_VITEST" help 2>&1)
+for knob in GCLOUD_IDENT GCLOUD_ROBOT_HOME GCLOUD_ROBOT_REQUIRE FRESHELL_GCP_ACCOUNT; do
+  check "W10 e2e help mentions $knob" bash -c 'grep -q "$1" <<<"$2"' _ "$knob" "$E2E_HELP"
+  check "W11 vitest help mentions $knob" bash -c 'grep -q "$1" <<<"$2"' _ "$knob" "$VITEST_HELP"
+done
+check "W10 e2e help carries no hardcoded human account" \
+  bash -c '! grep -q "dan@danshapiro" <<<"$1"' _ "$E2E_HELP"
+check "W11 vitest help carries no hardcoded human account" \
+  bash -c '! grep -q "dan@danshapiro" <<<"$1"' _ "$VITEST_HELP"
+
+# DOC-CHECKS-ANCHOR (Task 3 appends here)
 
 echo ""
 if [ "$FAILURES" -eq 0 ]; then

--- a/scripts/test/cloud-gcp-identity.test.sh
+++ b/scripts/test/cloud-gcp-identity.test.sh
@@ -559,9 +559,6 @@ check "W10 e2e help carries no hardcoded human account" \
   bash -c '! grep -q "dan@danshapiro" <<<"$1"' _ "$E2E_HELP"
 check "W11 vitest help carries no hardcoded human account" \
   bash -c '! grep -q "dan@danshapiro" <<<"$1"' _ "$VITEST_HELP"
-
-# DOC-CHECKS-ANCHOR (Task 3 appends here)
-
 echo ""
 if [ "$FAILURES" -eq 0 ]; then
   echo "=== All checks passed ==="

--- a/scripts/test/cloud-gcp-identity.test.sh
+++ b/scripts/test/cloud-gcp-identity.test.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Test: cloud-gcp-identity — hermetic coverage for the gcloud-robot identity
+# ladder (scripts/lib/gcp-identity.sh) adopted by scripts/e2e-cloud.sh and
+# scripts/vitest-cloud.sh. Covers every ladder rung (rung-1 repo pin respect,
+# rung-2 GCLOUD_IDENT bypass, rung-3 probe via GCLOUD_ROBOT_HOME, rung-4
+# quiet ambient fallback and GCLOUD_ROBOT_REQUIRE=1 fail-closed), bridge/env
+# forwarding, operator overrides, and single-probe idempotency.
+#
+# ALWAYS hermetic: the probe branch drives an inert fake selector under a
+# fake GCLOUD_ROBOT_HOME and every wrapper run uses a stubbed gcloud — no
+# network, no real credentials, no real IAM answers (skill trap 11).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT"
+
+HELPER="$ROOT/scripts/lib/gcp-identity.sh"
+WRAPPER_E2E="$ROOT/scripts/e2e-cloud.sh"
+WRAPPER_VITEST="$ROOT/scripts/vitest-cloud.sh"
+
+FAILURES=0
+check() {
+  local desc="$1"
+  shift
+  if "$@"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "=== Cloud GCP identity ladder test ==="
+
+TDIR="$(mktemp -d /tmp/cloud-gcp-identity.XXXXXX)"
+trap 'rm -rf "$TDIR"' EXIT
+
+# Inert stand-in for the gcloud-robot selector: records every invocation
+# (proves the probe branch ran) plus the env contract it observed, then
+# prints the caller-chosen account or takes the zero-candidate exit-1 path
+# with empty stdout (its documented failure shape — see skill known-issues
+# trap 11). Touches nothing but $TDIR; real curl/gcloud never run.
+FAKE_HOME="$TDIR/robot-home"
+mkdir -p "$FAKE_HOME/scripts"
+cat > "$FAKE_HOME/scripts/select-gcloud-identity.sh" <<'FAKE_SELECTOR'
+#!/usr/bin/env bash
+echo ran >> "${SELECTOR_MARKER:?set SELECTOR_MARKER}"
+echo "project=${GCLOUD_ROBOT_PROJECT:-} probe=${GCLOUD_ROBOT_PROBE_PERMISSION:-}" >> "${SELECTOR_MARKER}.env"
+if [ "${SELECTOR_FAIL:-0}" = "1" ]; then exit 1; fi
+printf '%s\n' "${SELECTOR_ACCOUNT:-}"
+FAKE_SELECTOR
+chmod +x "$FAKE_HOME/scripts/select-gcloud-identity.sh"
+
+export SELECTOR_MARKER="$TDIR/selector-ran"
+LADDER_STDERR="$TDIR/stderr"
+
+# Reads one "key=value" outcome line out of a run_ladder transcript.
+field() {
+  grep "^$2=" <<< "$1" | head -1 | cut -d= -f2-
+}
+
+# Identity/ladder knobs scrubbed out of the harness environment before every
+# ladder/wrapper invocation — an operator machine may legitimately export any
+# of these (FRESHELL_GCP_ACCOUNT, GCLOUD_ROBOT_REQUIRE=1, a real
+# GCLOUD_ROBOT_HOME, ...), and any leak would silently change which rung a
+# check exercises. Every ladder/wrapper call below applies this list, then
+# layers only the knobs the check intends.
+SCRUB=(-u GCLOUD_IDENT -u GCLOUD_ROBOT_HOME -u GCLOUD_ROBOT_REQUIRE
+       -u GCLOUD_ROBOT_PROJECT -u GCLOUD_ROBOT_PROBE_PERMISSION
+       -u FRESHELL_GCP_ACCOUNT -u CLOUDSDK_CORE_ACCOUNT -u CLOUDSDK_CORE_PROJECT
+       -u SELECTOR_ACCOUNT -u SELECTOR_FAIL)
+
+# Runs the identity ladder in a FRESH bash process over the scrubbed env;
+# extra KEY=VALUE arguments are the check's intended knobs, forwarded to env.
+# Stdout: rc/ident/account/pin outcome lines. Stderr from the ladder lands in
+# $LADDER_STDERR. Resets the selector markers per run. Always returns 0: the
+# ladder's own rc is reported as the rc= outcome line, so a subshell crash
+# shows up as missing lines, not a set -e abort.
+run_ladder() {
+  local probe="$1"
+  shift
+  rm -f "$LADDER_STDERR" "$SELECTOR_MARKER" "$SELECTOR_MARKER.env"
+  env "${SCRUB[@]}" "$@" bash -c '
+    set -u
+    . "$1"
+    GCP_PROJECT="misc-puttering-project"
+    GCP_ACCOUNT="${FRESHELL_GCP_ACCOUNT:-}"
+    if freshell_resolve_cloud_identity "$2"; then rc=0; else rc=$?; fi
+    printf "rc=%s\n" "$rc"
+    printf "ident=%s\n" "${GCLOUD_IDENT:-}"
+    printf "account=%s\n" "${CLOUDSDK_CORE_ACCOUNT:-}"
+    printf "pin=%s\n" "$GCP_ACCOUNT"
+  ' _ "$HELPER" "$probe" 2>"$LADDER_STDERR" || true
+}
+
+# --- Check A: sourcing is silent and side-effect-free ---------------------
+# help/local lanes source the helper unconditionally, so the source itself
+# must never print, resolve, or require any env.
+SRC_OUT=$(env "${SCRUB[@]}" bash -c \
+  'set -u; . "$1" && declare -F resolve_gcp_identity >/dev/null && declare -F freshell_resolve_cloud_identity >/dev/null && echo sourced-ok' \
+  _ "$HELPER" 2>&1 || true)
+check "sourcing the helper defines both functions with zero output" \
+  bash -c '[ "$1" = "sourced-ok" ]' _ "$SRC_OUT"
+
+# --- Check B: rung 2 — explicit GCLOUD_IDENT bypass, no network -----------
+OUT=$(run_ladder "run.jobs.run" GCLOUD_IDENT="fake-bypass@example.invalid" GCLOUD_ROBOT_HOME="$FAKE_HOME")
+check "rung-2 bypass: GCLOUD_IDENT flows to pin + exports, selector never runs, silent" \
+  bash -c '
+    [ "$1" = "0" ] && [ "$2" = "fake-bypass@example.invalid" ] &&
+    [ "$3" = "fake-bypass@example.invalid" ] && [ "$4" = "fake-bypass@example.invalid" ] &&
+    [ ! -e "$5" ] && [ ! -s "$6" ]
+  ' _ "$(field "$OUT" rc)" "$(field "$OUT" ident)" "$(field "$OUT" account)" "$(field "$OUT" pin)" \
+      "$SELECTOR_MARKER" "$LADDER_STDERR"
+
+# --- Check C: rung 3 — probe selects an account, env contract forwarded ---
+OUT=$(run_ladder "run.jobs.run" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_ACCOUNT="gcloud-robot@example.invalid")
+check "rung-3 probe: selector account adopted, project+probe env forwarded, silent" \
+  bash -c '
+    [ "$1" = "0" ] && [ "$2" = "gcloud-robot@example.invalid" ] &&
+    [ "$3" = "gcloud-robot@example.invalid" ] && [ "$4" = "gcloud-robot@example.invalid" ] &&
+    grep -q "project=misc-puttering-project probe=run.jobs.run" "$5.env" &&
+    [ ! -s "$6" ]
+  ' _ "$(field "$OUT" rc)" "$(field "$OUT" ident)" "$(field "$OUT" account)" "$(field "$OUT" pin)" \
+      "$SELECTOR_MARKER" "$LADDER_STDERR"
+
+# --- Check D: probe finds nothing — quiet ambient note, exit 0 ------------
+OUT=$(run_ladder "run.jobs.run" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_FAIL=1)
+check "probe-empty: one ambient-fallback stderr note, no identity, exit 0" \
+  bash -c '
+    [ "$1" = "0" ] && [ -z "$2" ] && [ -z "$3" ] && [ -z "$4" ] &&
+    [ "$(wc -l < "$5")" = "1" ] &&
+    grep -q "no probed identity; using ambient gcloud" "$5" &&
+    [ -e "$6" ]
+  ' _ "$(field "$OUT" rc)" "$(field "$OUT" ident)" "$(field "$OUT" account)" "$(field "$OUT" pin)" \
+      "$LADDER_STDERR" "$SELECTOR_MARKER"
+
+# --- Check E: skill absent — single quiet ambient note, exit 0 ------------
+OUT=$(run_ladder "run.jobs.run")
+check "skill-absent: exactly one ambient-fallback stderr note, exit 0" \
+  bash -c '
+    [ "$1" = "0" ] &&
+    [ "$(wc -l < "$2")" = "1" ] &&
+    grep -q "skill not found .* using ambient gcloud" "$2" &&
+    [ ! -e "$3" ]
+  ' _ "$(field "$OUT" rc)" "$LADDER_STDERR" "$SELECTOR_MARKER"
+
+# --- Check F: strict mode fails closed when the skill is absent -----------
+OUT=$(run_ladder "run.jobs.run" GCLOUD_ROBOT_REQUIRE=1)
+check "GCLOUD_ROBOT_REQUIRE=1, skill absent: nonzero rc + strict-mode guidance" \
+  bash -c '
+    [ "$1" != "0" ] && grep -q "strict mode" "$2" && [ -z "$3" ]
+  ' _ "$(field "$OUT" rc)" "$LADDER_STDERR" "$(field "$OUT" account)"
+
+# --- Check G: strict mode fails closed when the probe finds nothing -------
+OUT=$(run_ladder "run.jobs.run" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_FAIL=1 GCLOUD_ROBOT_REQUIRE=1)
+check "GCLOUD_ROBOT_REQUIRE=1, probe empty: nonzero rc + probe failure named" \
+  bash -c '
+    [ "$1" != "0" ] && grep -q "no identity passes the probe" "$2"
+  ' _ "$(field "$OUT" rc)" "$LADDER_STDERR"
+
+# --- Check H: idempotent — a second resolve never re-runs the selector ----
+rm -f "$SELECTOR_MARKER"
+OUT=$(env "${SCRUB[@]}" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_ACCOUNT="once@example.invalid" \
+      bash -c '
+        set -u
+        . "$1"
+        GCP_PROJECT="misc-puttering-project"
+        GCP_ACCOUNT=""
+        freshell_resolve_cloud_identity "run.jobs.run"
+        freshell_resolve_cloud_identity "cloudbuild.builds.create"
+        printf "ident=%s\n" "$GCLOUD_IDENT"
+      ' _ "$HELPER" 2>/dev/null || true)
+check "two resolves in one process run the selector exactly once" \
+  bash -c '
+    [ "$1" = "once@example.invalid" ] && [ "$(wc -l < "$2")" = "1" ]
+  ' _ "$(field "$OUT" ident)" "$SELECTOR_MARKER"
+
+# --- Check I: operator-pinned GCLOUD_ROBOT_PROJECT survives the bridge ----
+OUT=$(run_ladder "run.jobs.run" GCLOUD_ROBOT_HOME="$FAKE_HOME" SELECTOR_ACCOUNT="robot@example.invalid" \
+      GCLOUD_ROBOT_PROJECT="other-project" GCLOUD_ROBOT_PROBE_PERMISSION="custom.perm.check")
+check "operator overrides: project + probe pass through to the selector verbatim" \
+  bash -c '
+    grep -q "project=other-project probe=custom.perm.check" "$2.env" &&
+    [ "$1" = "robot@example.invalid" ]
+  ' _ "$(field "$OUT" ident)" "$SELECTOR_MARKER"
+
+# --- Check J: rung 1 — a pinned GCP_ACCOUNT short-circuits the ladder -----
+# A pin must win BEFORE any ladder work: no selector run (even with
+# GCLOUD_ROBOT_HOME + GCLOUD_IDENT present), no CLOUDSDK exports, no stderr,
+# and strict mode may not fail a pinned call. The ident transcript line still
+# echoes the inherited env value — it is simply never consulted.
+OUT=$(run_ladder "run.jobs.run" GCLOUD_IDENT="ident@example.invalid" \
+      FRESHELL_GCP_ACCOUNT="pinned@example.invalid" GCLOUD_ROBOT_HOME="$FAKE_HOME" \
+      GCLOUD_ROBOT_REQUIRE=1)
+check "explicit account pin wins BEFORE the ladder (no probe, no exports, silent)" \
+  bash -c '
+    [ "$1" = "0" ] && [ "$2" = "pinned@example.invalid" ] && [ -z "$3" ] &&
+    [ ! -e "$4" ] && [ ! -s "$5" ]
+  ' _ "$(field "$OUT" rc)" "$(field "$OUT" pin)" "$(field "$OUT" account)" \
+      "$SELECTOR_MARKER" "$LADDER_STDERR"
+
+# WRAPPER-LEVEL-CHECKS-ANCHOR (Task 2 appends here)
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "=== All checks passed ==="
+  exit 0
+else
+  echo "=== $FAILURES check(s) failed ==="
+  exit 1
+fi

--- a/scripts/test/cloud-run-wrapper.test.sh
+++ b/scripts/test/cloud-run-wrapper.test.sh
@@ -6,6 +6,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$ROOT"
 
+# gcloud-robot hermeticity pin (skill trap 11): the wrappers now carry a live
+# identity ladder. Pinning GCLOUD_IDENT forces the ladder's rung-2 bypass, so
+# no wrapper invocation from this suite can reach the real probe/network —
+# even if the harness environment happens to export GCLOUD_ROBOT_HOME. The
+# value is deliberately fake; nothing in this suite depends on it.
+export GCLOUD_IDENT="suite-pinned-identity@example.invalid"
+
 SCRIPT="$ROOT/scripts/e2e-cloud.sh"
 
 echo "=== Cloud Run Wrapper Script Test ==="

--- a/scripts/test/cloud-vitest-wrapper.test.sh
+++ b/scripts/test/cloud-vitest-wrapper.test.sh
@@ -7,6 +7,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$ROOT"
 
+# gcloud-robot hermeticity pin (skill trap 11): the wrappers now carry a live
+# identity ladder. Pinning GCLOUD_IDENT forces the ladder's rung-2 bypass, so
+# no wrapper invocation from this suite can reach the real probe/network —
+# even if the harness environment happens to export GCLOUD_ROBOT_HOME. The
+# value is deliberately fake; nothing in this suite depends on it.
+export GCLOUD_IDENT="suite-pinned-identity@example.invalid"
+
 SCRIPT="$ROOT/scripts/vitest-cloud.sh"
 
 FAILURES=0

--- a/scripts/vitest-cloud.sh
+++ b/scripts/vitest-cloud.sh
@@ -25,7 +25,9 @@
 #   --shards=N        Number of parallel Cloud Run tasks (default: 4)
 #   --timeout=DURATION Cloud Run task timeout (default: 30m)
 #   --config=default|server|all  Which vitest configs to run (default: all)
-#   --account=EMAIL   GCP account (default: FRESHELL_GCP_ACCOUNT env or dan@danshapiro.com)
+#   --account=EMAIL   GCP account pin (highest precedence; default: none —
+#                     FRESHELL_GCP_ACCOUNT env, then the gcloud-robot identity
+#                     ladder, then ambient gcloud)
 #   --project-id=ID   GCP project (default: FRESHELL_GCP_PROJECT env or misc-puttering-project)
 #   --region=REGION   GCP region (default: FRESHELL_GCP_REGION env or us-west1)
 #
@@ -40,7 +42,11 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Defaults
 # ---------------------------------------------------------------------------
-GCP_ACCOUNT="${FRESHELL_GCP_ACCOUNT:-dan@danshapiro.com}"
+# No account is hardcoded. Precedence: --account= flag > FRESHELL_GCP_ACCOUNT
+# > gcloud-robot identity ladder (freshell_resolve_cloud_identity, resolved
+# lazily per cloud lane) > unset — calls then omit --account and ambient
+# gcloud applies, which the ladder announces once on stderr.
+GCP_ACCOUNT="${FRESHELL_GCP_ACCOUNT:-}"
 GCP_PROJECT="${FRESHELL_GCP_PROJECT:-misc-puttering-project}"
 GCP_REGION="${FRESHELL_GCP_REGION:-us-west1}"
 GCP_REPO="${FRESHELL_GCP_REPO:-freshell-e2e}"
@@ -52,6 +58,12 @@ IMAGE_REMOTE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${GCP_REPO}/${IMAGE_NA
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Shared gcloud identity ladder (gcloud-robot). Sourcing only defines
+# functions — no side effects, no output — so help and local lanes stay
+# gcloud-free and silent.
+# shellcheck source=scripts/lib/gcp-identity.sh
+. "$SCRIPT_DIR/lib/gcp-identity.sh"
 
 # Commit-addressed image tag — mirrors scripts/e2e-cloud.sh (wrap-review r3):
 # a cloud run must execute the code at the CURRENT HEAD — with only a mutable
@@ -89,7 +101,13 @@ DEFAULT_CONFIGS="config/vitest/vitest.config.ts config/vitest/vitest.server.conf
 # Helpers
 # ---------------------------------------------------------------------------
 gcloud_flags() {
-  echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --region=${GCP_REGION}"
+  # No identity may legitimately resolve (rung 4: ambient gcloud). An empty
+  # pin omits --account entirely rather than passing gcloud an empty value.
+  if [ -n "${GCP_ACCOUNT:-}" ]; then
+    echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --region=${GCP_REGION}"
+  else
+    echo "--project=${GCP_PROJECT} --region=${GCP_REGION}"
+  fi
 }
 
 # Unique per-run job. `gcloud run jobs execute` snapshots the job's CURRENT
@@ -108,7 +126,21 @@ unique_job_name() {
 
 # gcloud artifacts commands use --location, not --region
 gcloud_artifacts_flags() {
-  echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --location=${GCP_REGION}"
+  if [ -n "${GCP_ACCOUNT:-}" ]; then
+    echo "--account=${GCP_ACCOUNT} --project=${GCP_PROJECT} --location=${GCP_REGION}"
+  else
+    echo "--project=${GCP_PROJECT} --location=${GCP_REGION}"
+  fi
+}
+
+# Prints a pinned --account flag, or NOTHING (not even an empty word) when no
+# identity resolved — for the gcloud calls that pin inline instead of via
+# gcloud_flags(). An empty expansion inside an unquoted $() yields no argv
+# word, which is exactly what "omit --account" needs; always exits 0.
+account_flag() {
+  if [ -n "${GCP_ACCOUNT:-}" ]; then
+    printf -- '--account=%s' "${GCP_ACCOUNT}"
+  fi
 }
 
 usage() {
@@ -130,13 +162,21 @@ Flags:
   --shards=N        Number of parallel Cloud Run tasks (default: 4)
   --timeout=DURATION Cloud Run task timeout (default: 30m)
   --config=default|server|all  Which vitest configs to run (default: all)
-  --account=EMAIL   GCP account (default: dan@danshapiro.com)
+  --account=EMAIL   GCP account pin (highest precedence; default: none)
   --project-id=ID   GCP project (default: misc-puttering-project)
   --region=REGION   GCP region (default: us-west1)
 
 Environment:
   FRESHELL_VITEST_BACKEND  "local" (default) or "cloud"
   FRESHELL_GCP_VITEST_JOB  Cloud Run job-name prefix (default: freshell-vitest)
+  FRESHELL_GCP_ACCOUNT  GCP account override pinned on every gcloud call (optional)
+
+Identity (cloud lanes only — details: docs/development/gcloud-robot.md):
+  Cloud subcommands resolve a gcloud identity lazily, in this order:
+  --account= > FRESHELL_GCP_ACCOUNT > GCLOUD_IDENT > gcloud-robot probe
+  (needs GCLOUD_ROBOT_HOME, the installed gcloud-robot skill directory)
+  > ambient gcloud (one quiet stderr note). GCLOUD_ROBOT_REQUIRE=1 fails
+  closed with guidance instead of the ambient fallback.
 
 Cloud job lifecycle: each cloud run creates its OWN unique job
 (<prefix>-<commit>[-dirty]-<random>), executes it, and deletes it
@@ -184,6 +224,11 @@ cmd_build() {
     esac
   done
 
+  # Identity ladder (build/push lane): resolve before the first gcloud call,
+  # never at script top — help and local-only paths must keep working with
+  # zero GCP tooling. Probe = the lane's gating permission.
+  freshell_resolve_cloud_identity "cloudbuild.builds.create"
+
   # Content-addressed tag (see image_tag_for_head): the only tag `run` pins.
   local tag remote_base
   tag="$(image_tag_for_head)"
@@ -201,7 +246,7 @@ cmd_build() {
     echo "[vitest-cloud] Building Docker image via Cloud Build (tag: $tag)..."
     gcloud builds submit \
       --config "$ROOT/docker/cloud-run/cloudbuild.yaml" \
-      --account="$GCP_ACCOUNT" \
+      $(account_flag) \
       --project="$GCP_PROJECT" \
       --substitutions=_IMAGE="${remote_base}:${tag}" \
       "$ROOT"
@@ -215,6 +260,32 @@ cmd_build() {
 cmd_push() {
   echo "[vitest-cloud] Pushing to Artifact Registry..."
 
+  # The standalone push lane honors the same pin flags as build/run;
+  # parse FIRST so an explicit --account= wins without touching the ladder.
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --account=*)
+        GCP_ACCOUNT="${1#*=}"
+        shift
+        ;;
+      --project-id=*)
+        GCP_PROJECT="${1#*=}"
+        shift
+        ;;
+      --region=*)
+        GCP_REGION="${1#*=}"
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  # A standalone `push` reaches gcloud without passing through cmd_build;
+  # resolve idempotently (free when cmd_build already did).
+  freshell_resolve_cloud_identity "cloudbuild.builds.create"
+
   # Ensure the Artifact Registry repo exists
   if ! gcloud artifacts repositories describe $(gcloud_artifacts_flags) "$GCP_REPO" &>/dev/null; then
     echo "[vitest-cloud] Creating Artifact Registry repository: $GCP_REPO"
@@ -223,7 +294,7 @@ cmd_push() {
   fi
 
   # Authenticate Docker to Artifact Registry using an access token.
-  gcloud auth print-access-token --account="$GCP_ACCOUNT" | \
+  gcloud auth print-access-token $(account_flag) | \
     docker login -u oauth2accesstoken --password-stdin \
       "https://${GCP_REGION}-docker.pkg.dev"
 
@@ -344,6 +415,12 @@ cmd_run() {
     exit "$exit_code"
   fi
 
+  # Identity ladder (run lane): resolve before the image describe / build /
+  # job calls below. `run --local` never reaches here (it exited above),
+  # so the local lane stays free of GCP tooling and of the ladder's
+  # stderr note.
+  freshell_resolve_cloud_identity "run.jobs.run"
+
   # Recompute the remote ref with potentially overridden GCP settings —
   # COMMIT-ADDRESSED, never mutable :latest (see image_tag_for_head; mirrors
   # scripts/e2e-cloud.sh): the job must run THIS HEAD's code or fail loudly,
@@ -374,7 +451,7 @@ cmd_run() {
 
   # Ensure image exists in remote registry
   if ! gcloud artifacts docker images describe "$IMAGE_REMOTE" \
-      --account="$GCP_ACCOUNT" --project="$GCP_PROJECT" &>/dev/null 2>&1; then
+      $(account_flag) --project="$GCP_PROJECT" &>/dev/null 2>&1; then
     echo "[vitest-cloud] Remote image not found, building and pushing..."
     cmd_build
   fi
@@ -541,13 +618,43 @@ cmd_logs() {
   # run ends — this legacy lookup only helps for executions of the old shared
   # job. Per-run logs are printed in full during the run and remain queryable
   # in Cloud Logging by job/execution name afterwards.
+
+  # Parse the pin flags FIRST (same contract as build/run); the rest passes
+  # through to `logs read` verbatim, preserving the existing behavior.
+  local -a logs_passthrough=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --account=*)
+        GCP_ACCOUNT="${1#*=}"
+        shift
+        ;;
+      --project-id=*)
+        GCP_PROJECT="${1#*=}"
+        shift
+        ;;
+      --region=*)
+        GCP_REGION="${1#*=}"
+        shift
+        ;;
+      *)
+        logs_passthrough+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  # logs is a cloud-only lane (executions list + logs read); resolve after
+  # parsing so an explicit pin short-circuits the ladder.
+  freshell_resolve_cloud_identity "run.jobs.run"
+
   local execution_id
   execution_id=$(gcloud run jobs executions list $(gcloud_flags) --job="$GCP_JOB" --sort-by="~metadata.creationTimestamp" --format="value(name)" --limit=1)
   if [ -z "$execution_id" ]; then
     echo "[vitest-cloud] No executions found for job $GCP_JOB"
     exit 1
   fi
-  gcloud beta run jobs executions logs read $(gcloud_flags) "$execution_id" "$@"
+  gcloud beta run jobs executions logs read $(gcloud_flags) "$execution_id" \
+    "${logs_passthrough[@]+"${logs_passthrough[@]}"}"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Converts the cloud test lanes (`scripts/e2e-cloud.sh`, `scripts/vitest-cloud.sh` and their shared Cloud Build / Artifact Registry machinery) off interactive `gcloud auth login` onto the gcloud-robot per-project robot-service-account pattern.

Interactive gcloud sessions ride OAuth refresh tokens that Google silently culls (roughly hourly under heavy agent use); observed live during this run: a base-gate cloud run died with `Reauthentication failed. cannot prompt during non-interactive execution` (2026-08-23).

## How

- `scripts/lib/gcp-identity.sh` — shared sourced helper carrying the skill's `resolve_gcp_identity` drop-in block verbatim + a thin bridge into each wrapper's pinned account var.
- Identity precedence (fixed ladder): `--account=` flag > `FRESHELL_GCP_ACCOUNT` > `GCLOUD_IDENT` > skill probe via `GCLOUD_ROBOT_HOME` > ambient gcloud with exactly one stderr note. `GCLOUD_ROBOT_REQUIRE=1` fails closed instead.
- Lazy resolution: identity resolves immediately before a cloud lane's first real gcloud call. `help` and `run --local` need zero GCP tooling and emit nothing. Pin short-circuit: a pinned call never touches the probe, even under strict mode.
- Hardcoded human account default removed from both wrappers; `--account` omitted (not empty-flagged) when nothing resolves.
- Standalone `push`/`logs` lanes gained the same `--account=`/`--project-id=`/`--region=` parsing (previously ignored; per-review finding).
- Build logs route to Cloud Logging (`options.logging: CLOUD_LOGGING_ONLY`) so `roles/logging.viewer` covers them — tradeoff: no live submit streaming (read after with `gcloud builds log <id>`).
- New hermetic suite `scripts/test/cloud-gcp-identity.test.sh` (58 checks: every ladder rung on the real wrappers incl. standalone lanes, strict mode, omission proofs, and four pre-existing stubbed suites proven probe-proof under a hostile fake `GCLOUD_ROBOT_HOME` — those suites also gained the trap-11 `GCLOUD_IDENT` pin).
- Operator runbook `docs/development/gcloud-robot.md` + AGENTS.md identity sections.

## Provisioning (human, once per project — NOT in this PR)

The repo is now "wired but not yet provisioned" (accepted state). The runbook has the checklist: project-level `cloudbuild.builds.editor`, `run.developer`, `logging.viewer`, `serviceusage.serviceUsageConsumer`; scoped: `storage.objectUser`+`storage.legacyBucketReader` on the staging bucket, `artifactregistry.writer` on the `freshell-e2e` repo, actAs on the default compute SA (+ discovered build default SA when project-controlled). Verify via verify-as-robot probes + one real lane smoke. No agent runs these (skill rule; only explicit user instruction overrides).

## Verification

- All three tasks executed red-green; identity suite 58/58, full cloud-suite loop green at every gate.
- Independent delta review: PASSED (zero findings) after one remediation round.
- Full coordinated suite on final HEAD: client/server/electron all exit 0 (local backends — machine ambient gcloud creds are currently culled; cloud lanes verified hermetically + runbook operator smoke).
- Plan review: 3 rounds at cap; all 20 findings cleared (log under review artifacts; delta review governs the final state).
