### PR TITLE
fix(e2e): durable session identity across reconnect, not bridge-domain sessionId

### DIFF
--- a/test/e2e-browser/specs/reconnect-revive-rust.spec.ts
+++ b/test/e2e-browser/specs/reconnect-revive-rust.spec.ts
@@ -397,6 +397,22 @@ async function fixtureReplyCount(page: Page): Promise<number> {
     .count()
 }
 
+/** RRDBG: summarize the fake claude sidecar request log (create/send/timing). */
+async function rrdbgSidecarLog(requestLogPath: string): Promise<string> {
+  const raw = await fs.readFile(requestLogPath, 'utf8').catch(() => '')
+  const lines = raw.trim().split('\n').filter(Boolean)
+  const entries = lines.map((line) => {
+    try {
+      const e = JSON.parse(line) as { msg?: { type?: string; sessionId?: string; resumeSessionId?: string } }
+      const m = e.msg ?? {}
+      return `${m.type ?? '?'} sessionId=${m.sessionId ?? '-'} resume=${m.resumeSessionId ?? '-'}`
+    } catch {
+      return '<unparseable>'
+    }
+  })
+  return `RRDBG sidecar-log lines=${lines.length} :: ${entries.join(' | ')}`
+}
+
 /** Count `send` entries in the fake claude sidecar's request log. */
 async function sidecarSendCount(requestLogPath: string): Promise<number> {
   const raw = await fs.readFile(requestLogPath, 'utf8').catch(() => '')
@@ -756,7 +772,14 @@ test.describe('reconnect revive (rust)', () => {
       const contentAfterReconnect = findFreshAgentLeaf(
         await harness.getPaneLayout(freshTabId),
       )!.content!
-      expect(contentAfterReconnect.sessionId).toBe(sessionIdBefore)
+      try {
+        expect(contentAfterReconnect.sessionId).toBe(sessionIdBefore)
+      } catch (e) {
+        process.stdout.write(`RRDBG sessionIdBefore=${sessionIdBefore}\n`)
+        process.stdout.write(`RRDBG sessionIdAfter(full content)=${JSON.stringify(contentAfterReconnect)}\n`)
+        process.stdout.write(`${await rrdbgSidecarLog(requestLogPath)}\n`)
+        throw e
+      }
 
       // Discriminating round trip (see this file's FIXTURE LIMITATION note):
       // (a) the pane renders strictly MORE replies than survived the drop...

--- a/test/e2e-browser/specs/reconnect-revive-rust.spec.ts
+++ b/test/e2e-browser/specs/reconnect-revive-rust.spec.ts
@@ -397,22 +397,6 @@ async function fixtureReplyCount(page: Page): Promise<number> {
     .count()
 }
 
-/** RRDBG: summarize the fake claude sidecar request log (create/send/timing). */
-async function rrdbgSidecarLog(requestLogPath: string): Promise<string> {
-  const raw = await fs.readFile(requestLogPath, 'utf8').catch(() => '')
-  const lines = raw.trim().split('\n').filter(Boolean)
-  const entries = lines.map((line) => {
-    try {
-      const e = JSON.parse(line) as { msg?: { type?: string; sessionId?: string; resumeSessionId?: string } }
-      const m = e.msg ?? {}
-      return `${m.type ?? '?'} sessionId=${m.sessionId ?? '-'} resume=${m.resumeSessionId ?? '-'}`
-    } catch {
-      return '<unparseable>'
-    }
-  })
-  return `RRDBG sidecar-log lines=${lines.length} :: ${entries.join(' | ')}`
-}
-
 /** Count `send` entries in the fake claude sidecar's request log. */
 async function sidecarSendCount(requestLogPath: string): Promise<number> {
   const raw = await fs.readFile(requestLogPath, 'utf8').catch(() => '')
@@ -761,8 +745,6 @@ test.describe('reconnect revive (rust)', () => {
       const contentBeforeDrop = findFreshAgentLeaf(
         await harness.getPaneLayout(freshTabId),
       )!.content!
-      const sessionIdBefore: string = contentBeforeDrop.sessionId
-      process.stdout.write(`RRDBG contentBeforeDrop=${JSON.stringify(contentBeforeDrop)}\n`)
 
       // Bare socket drop; the server-side sidecar session stays live.
       await harness.forceDisconnect()
@@ -770,15 +752,21 @@ test.describe('reconnect revive (rust)', () => {
       await waitReady(page)
 
       // Same session identity after reconnect -- an in-place reattach, never
-      // a re-created session.
+      // a re-created session. Assert the DURABLE identity: the pane content's
+      // bridge-domain `sessionId` may re-key to the durable id during
+      // reconnect reconcile (legitimate cosmetics; ordering-dependent), while
+      // the durable id domain (`resumeSessionId` / `sessionRef.sessionId`) is
+      // the user-meaningful invariant that a reconnect must preserve.
       const contentAfterReconnect = findFreshAgentLeaf(
         await harness.getPaneLayout(freshTabId),
       )!.content!
-      // RRDBG: investigate cloud-only sessionId re-keying -- log instead of
-      // asserting so the discriminating round trip still classifies the flip.
-      process.stdout.write(`RRDBG sessionIdBefore=${sessionIdBefore}\n`)
-      process.stdout.write(`RRDBG sessionIdAfter(full content)=${JSON.stringify(contentAfterReconnect)}\n`)
-      process.stdout.write(`RRDBG flip=${contentAfterReconnect.sessionId !== sessionIdBefore}\n`)
+      expect(contentBeforeDrop.sessionRef?.sessionId).toBeTruthy()
+      expect(contentAfterReconnect.sessionRef?.sessionId).toBe(
+        contentBeforeDrop.sessionRef?.sessionId,
+      )
+      expect(contentAfterReconnect.resumeSessionId).toBe(
+        contentBeforeDrop.resumeSessionId,
+      )
 
       // Discriminating round trip (see this file's FIXTURE LIMITATION note):
       // (a) the pane renders strictly MORE replies than survived the drop...
@@ -794,9 +782,6 @@ test.describe('reconnect revive (rust)', () => {
       // ...and no dead-end text ever surfaces in the pane chrome.
       await expect(page.getByText(noDeadEndText)).toHaveCount(0)
     } finally {
-      process.stdout.write(`${await rrdbgSidecarLog(requestLogPath)}\n`)
-      const finalLeaf = findFreshAgentLeaf(await harness.getPaneLayout(freshTabId).catch(() => null))
-      process.stdout.write(`RRDBG finalLeaf=${JSON.stringify(finalLeaf?.content ?? null)}\n`)
       await server.stop().catch(() => {})
       await fs.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
     }

--- a/test/e2e-browser/specs/reconnect-revive-rust.spec.ts
+++ b/test/e2e-browser/specs/reconnect-revive-rust.spec.ts
@@ -758,9 +758,11 @@ test.describe('reconnect revive (rust)', () => {
       const sendsBeforeDrop = await sidecarSendCount(requestLogPath)
       expect(sendsBeforeDrop).toBe(1)
 
-      const sessionIdBefore: string = findFreshAgentLeaf(
+      const contentBeforeDrop = findFreshAgentLeaf(
         await harness.getPaneLayout(freshTabId),
-      )!.content!.sessionId
+      )!.content!
+      const sessionIdBefore: string = contentBeforeDrop.sessionId
+      process.stdout.write(`RRDBG contentBeforeDrop=${JSON.stringify(contentBeforeDrop)}\n`)
 
       // Bare socket drop; the server-side sidecar session stays live.
       await harness.forceDisconnect()
@@ -772,14 +774,11 @@ test.describe('reconnect revive (rust)', () => {
       const contentAfterReconnect = findFreshAgentLeaf(
         await harness.getPaneLayout(freshTabId),
       )!.content!
-      try {
-        expect(contentAfterReconnect.sessionId).toBe(sessionIdBefore)
-      } catch (e) {
-        process.stdout.write(`RRDBG sessionIdBefore=${sessionIdBefore}\n`)
-        process.stdout.write(`RRDBG sessionIdAfter(full content)=${JSON.stringify(contentAfterReconnect)}\n`)
-        process.stdout.write(`${await rrdbgSidecarLog(requestLogPath)}\n`)
-        throw e
-      }
+      // RRDBG: investigate cloud-only sessionId re-keying -- log instead of
+      // asserting so the discriminating round trip still classifies the flip.
+      process.stdout.write(`RRDBG sessionIdBefore=${sessionIdBefore}\n`)
+      process.stdout.write(`RRDBG sessionIdAfter(full content)=${JSON.stringify(contentAfterReconnect)}\n`)
+      process.stdout.write(`RRDBG flip=${contentAfterReconnect.sessionId !== sessionIdBefore}\n`)
 
       // Discriminating round trip (see this file's FIXTURE LIMITATION note):
       // (a) the pane renders strictly MORE replies than survived the drop...
@@ -795,6 +794,9 @@ test.describe('reconnect revive (rust)', () => {
       // ...and no dead-end text ever surfaces in the pane chrome.
       await expect(page.getByText(noDeadEndText)).toHaveCount(0)
     } finally {
+      process.stdout.write(`${await rrdbgSidecarLog(requestLogPath)}\n`)
+      const finalLeaf = findFreshAgentLeaf(await harness.getPaneLayout(freshTabId).catch(() => null))
+      process.stdout.write(`RRDBG finalLeaf=${JSON.stringify(finalLeaf?.content ?? null)}\n`)
       await server.stop().catch(() => {})
       await fs.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
     }


### PR DESCRIPTION
## Problem

After #677, the cloud e2e lane fails deterministically on one reconnect-revive test (`fresh-agent pane reattaches and round-trips after a bare socket drop`): post-reconnect, the pane content's `sessionId` reads as the durable transcript UUID instead of the pre-drop `fc-e2e-*` bridge id. The same test passes every time locally.

## Root cause (evidence, not guesswork)

Instrumented reproduction on the cloud lane (3 attempts, identical results):

- The fake claude sidecar's request log shows **one `create` + two `send`s** with the SAME bridge id before and after the drop — no new conversation is ever created.
- The pane content's **durable identity is unchanged across the drop**: `resumeSessionId`, `sessionRef.sessionId`, and even `createRequestId` are byte-identical pre/post.
- Only the bridge-domain `content.sessionId` field re-keys to the durable id during reconnect reconcile. Locally the assertion raced ahead of the re-key; in cloud the re-key lands first. Ordering-dependent test artifact, not a product fault.

## Fix

Assert the user-meaningful invariant — `sessionRef.sessionId` and `resumeSessionId` unchanged across a bare socket drop — with a comment documenting that the bridge-domain `sessionId` may legitimately re-key during reconnect reconcile. The discriminating round trip (fixture reply count + sidecar send count) stays strict and remains the real proof the same conversation survived.

## Verified

- Local: fixed spec passes.
- Cloud lane (Cloud Run Jobs, merged-main image): reconnect-revive spec **6/6 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)