### PR TITLE
feat(fresh-agent): collapse adjacent tool activity into one accumulating strip line

### DIFF
--- a/docs/plans/2026-08-23-freshagent-activity-line.md
+++ b/docs/plans/2026-08-23-freshagent-activity-line.md
@@ -140,7 +140,7 @@ Do NOT commit. The failing e2e is staged with Task 2's commit once green.
 
 **Interfaces:**
 - Consumes: `FreshAgentTurn`, `FreshAgentTranscriptItem` from `@shared/fresh-agent-contract`; existing `buildActivity`, `isActivityLike`, `FreshAgentActivityStrip`, `FreshAgentTurnArticle`.
-- Produces: `buildTranscriptLayout(turns: FreshAgentTurn[]): { layouts: TurnLayout[]; lineEndIndex: Map<number, number> }` (module-scope pure function, not exported; `lineEndIndex` maps a line's origin-turn index → the index of the line's LAST contributing display turn), `selectLiveActivityBlockIdFromLayout(...)`; `FreshAgentTurnArticle` gains `blocks: RenderBlock[]` and `actionTurn: FreshAgentTurn` props and drops its internal `buildBlocks` call.
+- Produces: `buildTranscriptLayout(turns: FreshAgentTurn[]): { layouts: TurnLayout[]; lineEndIndex: Map<number, number>; tail: { blockId: string; turnIndex: number } | null }` (module-scope pure function, not exported; `lineEndIndex` maps a line's origin-turn index → the index of the line's LAST contributing display turn; `tail` names the last rendered block when it is an activity line), `rendersVisibly(...)`, `selectLiveActivityBlockIdFromLayout(...)`; `FreshAgentTurnArticle` gains `blocks: RenderBlock[]` and `actionTurn: FreshAgentTurn` props and drops its internal `buildBlocks` call.
 
 - [ ] **Step 1: Write the failing behavioral tests (new unit cases)**
 
@@ -306,6 +306,56 @@ describe('activity line collapse', () => {
     expect(merged).toBe(first)
     expect(merged).toHaveTextContent('5 tools used')
   })
+
+  it('keeps two same-turn lines distinct when a message splits them (tool → text → tool)', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[{
+          id: 'turn-mixed', role: 'assistant', summary: '',
+          items: [
+            { id: 'tool-a', kind: 'tool_use', toolUseId: 'ca', name: 'Read', input: { file_path: 'src/a.ts' } },
+            { id: 'item-note', kind: 'text', text: 'first pass done' },
+            { id: 'tool-b', kind: 'tool_use', toolUseId: 'cb', name: 'Read', input: { file_path: 'src/b.ts' } },
+          ],
+        }]}
+      />,
+    )
+    const strips = screen.getAllByRole('region', { name: 'Activity strip' })
+    expect(strips).toHaveLength(2)
+    expect(strips[0]).toHaveTextContent('1 tool used')
+    expect(strips[1]).toHaveTextContent('1 tool used')
+  })
+
+  it('an invisible (whitespace-only) text item does not split the line', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          toolTurn('turn-a', [['c1','src/a.ts']]),
+          { id: 'turn-empty-text', role: 'assistant', summary: '',
+            items: [{ id: 'item-empty', kind: 'text', text: '   ' }] },
+          toolTurn('turn-b', [['c2','src/b.ts']]),
+        ]}
+      />,
+    )
+    expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('2 tools used')
+  })
+
+  it('hands liveness to the merged line across an absorbed previous turn while the last turn streams empty', () => {
+    render(
+      <FreshAgentTranscript
+        isStreaming
+        turns={[
+          toolTurn('turn-a', [['c1','src/a.ts']]),
+          toolTurn('turn-b', [['c2','src/b.ts']]),
+          { id: 'turn-streaming', role: 'assistant', summary: '', items: [] },
+        ]}
+      />,
+    )
+    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    expect(screen.getAllByLabelText('running')).toHaveLength(1)
+    expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('Read')
+    expect(screen.queryByText('2 tools used')).not.toBeInTheDocument()
+  })
 })
 ```
 
@@ -326,12 +376,25 @@ In `src/components/fresh-agent/FreshAgentTranscript.tsx`:
 ```ts
 type TurnLayout = { blocks: RenderBlock[] }
 
+/** Mirrors FreshAgentItemCard's null-render path for text items: a text item
+ * that renders nothing must not close an open line (nothing visibly between). */
+function rendersVisibly(item: FreshAgentTranscriptItem): boolean {
+  if (item.kind === 'text') return stripSystemReminders(item.text).trim().length > 0
+  return true
+}
+
 /**
  * One OPEN activity line per transcript state: a next turn's leading
  * activity items append to the open line when the turn has the same role and
  * no message item has rendered between (a role change paints a header, so it
  * counts as "something between"). Lines are re-built from the concatenated
  * item list so buildActivity's tool_use/tool_result stitching stays intact.
+ *
+ * Line ids use a global per-layout sequence (`line:${n}`), NOT the origin turn
+ * index: one turn can own two lines (`tool → text → tool`), and identical keys
+ * would make React reuse state/DOM across what must stay two separate strips.
+ * The key is stable while a line extends (no new line opens mid-extension), so
+ * the strip keeps its DOM node — the "started in the right place" behavior.
  *
  * Zero-item turns (Rust codex `subAgentActivity` rows, opencode structural
  * messages) render real articles today, so they hard-close any open line —
@@ -340,24 +403,22 @@ type TurnLayout = { blocks: RenderBlock[] }
  * provider message id; stitching keys toolUseId, which is verified unique, so
  * stitching is unaffected — only React keys need this).
  */
-function buildTranscriptLayout(turns: FreshAgentTurn[]): { layouts: TurnLayout[]; lineEndIndex: Map<number, number> } {
+function buildTranscriptLayout(turns: FreshAgentTurn[]): {
+  layouts: TurnLayout[]
+  lineEndIndex: Map<number, number>
+  tail: { blockId: string; turnIndex: number } | null
+} {
   const layouts: TurnLayout[] = []
   let open: { originIndex: number; role: FreshAgentTurn['role']; items: FreshAgentTranscriptItem[] } | null = null
   const lineEndIndex = new Map<number, number>()
+  let lineSeq = 0
 
   const flushOpen = () => {
     if (!open) return
     const rows = buildActivity(open.items)
     if (rows.length > 0) {
-      layouts[open.originIndex].blocks.push({
-        kind: 'activity',
-        // Stable per origin turn: the line keeps its React identity (and DOM
-        // node, scroll state, expanded state) while later turns' items append
-        // into it — this is the "started in the right place, extended in
-        // place" behavior, not an after-the-fact regrouping remount.
-        id: `line:${open.originIndex}`,
-        rows,
-      })
+      const id = `line:${lineSeq++}`
+      layouts[open.originIndex].blocks.push({ kind: 'activity', id, rows })
     }
     open = null
   }
@@ -387,16 +448,28 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): { layouts: TurnLayout[]
         }
         continue
       }
+      if (!rendersVisibly(item)) continue
       flushOpen()
       layout.blocks.push({ kind: 'item', item })
     }
   }
   flushOpen()
-  return { layouts, lineEndIndex }
+
+  // tail = last rendered block overall when it is an activity line; null when
+  // the transcript visibly ends in a message.
+  let tail: { blockId: string; turnIndex: number } | null = null
+  for (let i = layouts.length - 1; i >= 0; i--) {
+    const blocks = layouts[i].blocks
+    if (blocks.length === 0) continue
+    const last = blocks[blocks.length - 1]
+    if (last.kind === 'activity') tail = { blockId: last.id, turnIndex: i }
+    break
+  }
+  return { layouts, lineEndIndex, tail }
 }
 ```
 
-Note: after a message flushes the open line, `open` is null, so later activity in the SAME turn opens a fresh line whose remaining activity items absorb normally — `text → tool_use → tool_result` stays ONE line, exactly matching today's in-turn `buildBlocks` batching.
+Note: after a message flushes the open line, `open` is null, so later activity in the SAME turn opens a fresh line whose remaining activity items absorb normally — `text → tool_use → tool_result` stays ONE line, exactly matching today's in-turn `buildBlocks` batching — while `tool → text → tool` yields two lines with distinct `line:N` identities.
 
 (b) Replace `selectLiveActivityBlockId` (:307–339) with a layout-driven version:
 
@@ -405,6 +478,7 @@ function selectLiveActivityBlockIdFromLayout(
   layouts: TurnLayout[],
   turns: FreshAgentTurn[],
   isStreaming: boolean,
+  tail: { blockId: string; turnIndex: number } | null,
 ): string | null {
   let latestActivityBlockId: string | null = null
   layouts.forEach((layout) => {
@@ -413,35 +487,39 @@ function selectLiveActivityBlockIdFromLayout(
     }
   })
 
+  const lastIndex = turns.length - 1
+  const lastTurn = turns[lastIndex]
+
   if (!isStreaming) {
     // Settled sessions mark only a trailing thinking strip as live. Mirror the
     // old last-turn rule; when the last turn was absorbed, its items live at
     // the tail of the latest line, so check that line instead.
-    const lastIndex = turns.length - 1
-    const lastBlocks = lastIndex >= 0 ? layouts[lastIndex].blocks : []
-    const candidate = lastBlocks.length > 0
-      ? lastBlocks[lastBlocks.length - 1]
-      : (turns[lastIndex]?.items.length ?? 0) > 0 && latestActivityBlockId
-        ? [...layouts.flatMap((l) => l.blocks)].at(-1)
+    const blocks = lastIndex >= 0 ? layouts[lastIndex].blocks : []
+    const lastBlock = blocks.length > 0 ? blocks[blocks.length - 1] : null
+    const candidateId = lastBlock?.kind === 'activity'
+      ? lastBlock.id
+      : (lastTurn?.items.length ?? 0) > 0 && tail && tail.turnIndex < lastIndex
+        ? tail.blockId
         : null
+    if (!candidateId) return null
+    const candidate = [...layouts.flatMap((l) => l.blocks)].find((b) => b.kind === 'activity' && b.id === candidateId)
     return candidate?.kind === 'activity' && candidate.rows.at(-1)?.type === 'thinking'
       ? candidate.id
       : null
   }
 
-  const lastTurn = turns[turns.length - 1]
   if (lastTurn && lastTurn.items.length > 0) return latestActivityBlockId
+  if (!lastTurn || !tail) return null
 
-  // Last display turn streams with zero visible items: hand liveness to an
-  // adjacent open line (same role, trailing activity) instead of injecting a
-  // second empty strip line below it.
-  const previousIndex = turns.length - 2
-  if (previousIndex >= 0 && lastTurn) {
-    const previousBlocks = layouts[previousIndex]?.blocks ?? []
-    const previousLast = previousBlocks[previousBlocks.length - 1]
-    if (previousLast?.kind === 'activity' && turns[previousIndex].role === lastTurn.role) {
-      return previousLast.id
-    }
+  // Last display turn streams with zero visible items: hand liveness to the
+  // trailing line when nothing rendered between them (intermediate turns were
+  // absorbed into that line; a zero-item or message intermediate is a real
+  // boundary) and roles match the whole way across.
+  const absorbedOnly = turns.slice(tail.turnIndex + 1, lastIndex)
+    .every((turn, offset) =>
+      turn.items.length > 0 && layouts[tail.turnIndex + 1 + offset].blocks.length === 0)
+  if (absorbedOnly && turns[tail.turnIndex].role === lastTurn.role) {
+    return tail.blockId
   }
   return null
 }
@@ -453,10 +531,10 @@ function selectLiveActivityBlockIdFromLayout(
 const displayTurns = useMemo(() => (
   filterTurnsForDisplay(coalesceSyntheticToolResultTurns(turns), displayOptions, isStreaming)
 ), [displayOptions, turns, isStreaming])
-const { layouts: turnLayouts, lineEndIndex } = useMemo(() => buildTranscriptLayout(displayTurns), [displayTurns])
+const { layouts: turnLayouts, lineEndIndex, tail } = useMemo(() => buildTranscriptLayout(displayTurns), [displayTurns])
 const liveActivityBlockId = useMemo(
-  () => selectLiveActivityBlockIdFromLayout(turnLayouts, displayTurns, isStreaming),
-  [turnLayouts, displayTurns, isStreaming],
+  () => selectLiveActivityBlockIdFromLayout(turnLayouts, displayTurns, isStreaming, tail),
+  [turnLayouts, displayTurns, isStreaming, tail],
 )
 ```
 
@@ -564,9 +642,9 @@ Expected: PASS (eslint-plugin-jsx-a11y clean — no new interactive DOM added).
 
 - [ ] **Step 3: Confirm no other render callers construct turn blocks differently**
 
-Run: `grep -rn "buildBlocks\|coalesceSyntheticToolResultTurns" src/ test/unit | grep -v FreshAgentTranscript.tsx`
+Run: `grep -rn "buildBlocks\|coalesceSyntheticToolResultTurns" src/ test/unit | grep -v FreshAgentTranscript.tsx || true`
 
-Expected: only the transcript test references; `FreshAgentView.tsx`/`FreshAgentMobile` consume `FreshAgentTranscript` as a component (no direct block construction).
+Expected: EMPTY output — the transcript test and component are the only references; `FreshAgentView.tsx`/`FreshAgentMobile` consume `FreshAgentTranscript` as a component (no direct block construction). (`|| true` required: empty matches exit 1.)
 
 - [ ] **Step 4: Record outcomes and commit (only if receipts/notes were written as part of the run log)**
 
@@ -587,5 +665,6 @@ git commit -m "docs: mark freshagent-activity-line tasks complete with verificat
 
 - **Zero-item turns are real** (Rust codex `subAgentActivity` rows emit `{role:"assistant", summary:"", items:[]}`; opencode structural messages likewise) and they render real article chrome today. The layout pass hard-closes any open line on a zero-item turn — two halves of a codex tool run split by a `subAgentActivity` marker therefore stay two strips. Residual, accepted: fixing THAT split needs a provider-level turn-shape decision, out of scope for this render-rule change.
 - **TS-claude item-id reuse across turns** (one provider message id spanning multiple JSONL lines yields duplicate `turn:<msg>:item:N` ids) is handled by display-only id dedupe in the absorb path; `toolUseId` stitching is verified unique (615MB × 813 real transcripts, zero repeats) and unaffected. Validator evidence (external run logs, by workflow design outside the tracked tree): `/home/dan/code/freshell/.worktrees/.the-usual-logs/freshagent-activity-line/reports/load-bearing-validator-c2.md` and `.../load-bearing-validator-n1.md`.
-- **Stable line identity:** each open line's React key is `line:<originTurnIndex>`, stable while later turns' items append — the strip keeps its DOM node (verified by an incremental rerender test asserting node identity), scroll position, and expanded state across extension; this is what distinguishes an extending open line from an after-the-fact regrouping remount.
+- **Stable line identity:** each open line's React key is a per-layout sequence `line:<n>` unique across all lines (one turn can own two), stable while the line extends — the strip keeps its DOM node (verified by an incremental rerender test asserting node identity), scroll position, and expanded state across extension; this is what distinguishes an extending open line from an after-the-fact regrouping remount.
+- **Invisible items are not boundaries:** text items that render nothing (whitespace/system-reminder-only after `stripSystemReminders`; `FreshAgentItemCard` returns null for them) neither close the open line nor emit item blocks, so the visual rule "if anything renders between them" is evaluated on what actually renders.
 - **Non-streaming liveness:** mirrors the old last-turn trailing-thinking rule, extended to cover a last turn that was absorbed (its items close the latest line, so the check reads that line's trailing row).

--- a/docs/plans/2026-08-23-freshagent-activity-line.md
+++ b/docs/plans/2026-08-23-freshagent-activity-line.md
@@ -403,7 +403,7 @@ function rendersVisibly(item: FreshAgentTranscriptItem): boolean {
  * provider message id; stitching keys toolUseId, which is verified unique, so
  * stitching is unaffected — only React keys need this).
  */
-function buildTranscriptLayout(turns: FreshAgentTurn[]): {
+function buildTranscriptLayout(turns: DisplayTurn[], paintedSummaryKeys: PaintedSummaryStore): {
   layouts: TurnLayout[]
   lineEndIndex: Map<number, number>
   tail: { blockId: string; turnIndex: number } | null
@@ -432,7 +432,18 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): {
     }
     for (const item of turn.items) {
       if (isActivityLike(item)) {
-        if (open && open.role === turn.role) {
+        // Cross-turn absorb is refused by either boundary guard: an authored
+        // summary (no echo among the turn's pre-filter items), or a summary
+        // this view already painted (prefix-matched per turnId). Intra-turn
+        // chaining into the turn's own line is always free.
+        if (
+          open
+          && open.role === turn.role
+          && (
+            open.originIndex === turnIndex
+            || (!paintedSummaryMatches(paintedSummaryKeys, turn) && !summaryIsAuthoredContent(turn))
+          )
+        ) {
           const taken = new Set(open.items.map((openItem) => openItem.id))
           let displayItem = item
           let counter = 2
@@ -448,7 +459,17 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): {
         }
         continue
       }
-      if (!rendersVisibly(item)) continue
+      if (!rendersVisibly(item)) {
+        // Invisible content only. Same-role turns merge freely (nothing renders
+        // between the lines). A different-role turn still paints its header, so
+        // it closes the open line and keeps its (invisible-bodied) block,
+        // matching the pre-change renderer's chrome.
+        if (open && turn.role !== open.role) {
+          flushOpen()
+          layout.blocks.push({ kind: 'item', item })
+        }
+        continue
+      }
       flushOpen()
       layout.blocks.push({ kind: 'item', item })
     }
@@ -510,6 +531,11 @@ function selectLiveActivityBlockIdFromLayout(
 
   if (lastTurn && lastTurn.items.length > 0) return latestActivityBlockId
   if (!lastTurn || !tail) return null
+  // A summary-only last turn renders its own article (summary markdown plus
+  // the injected live strip); handing liveness to the tail line would skip
+  // that article and hide the summary. A rendered summary is a message — it
+  // closes the line.
+  if (lastTurn.summary && lastTurn.summary.trim().length > 0) return null
 
   // Last display turn streams with zero visible items: hand liveness to the
   // trailing line when nothing rendered between them (intermediate turns were
@@ -529,14 +555,19 @@ function selectLiveActivityBlockIdFromLayout(
 
 ```ts
 const displayTurns = useMemo(() => (
-  filterTurnsForDisplay(coalesceSyntheticToolResultTurns(turns), displayOptions, isStreaming)
+  filterTurnsForDisplay(coalesceSyntheticToolResultTurns(turns), displayOptions, isStreaming, paintedSummaryKeysRef.current)
 ), [displayOptions, turns, isStreaming])
-const { layouts: turnLayouts, lineEndIndex, tail } = useMemo(() => buildTranscriptLayout(displayTurns), [displayTurns])
+const { layouts: turnLayouts, lineEndIndex, tail } = useMemo(
+  () => buildTranscriptLayout(displayTurns, paintedSummaryKeysRef.current),
+  [displayTurns],
+)
 const liveActivityBlockId = useMemo(
   () => selectLiveActivityBlockIdFromLayout(turnLayouts, displayTurns, isStreaming, tail),
   [turnLayouts, displayTurns, isStreaming, tail],
 )
 ```
+
+(Painted-summary tracking: an effect records, per turnId, each zero-item summary this view actually rendered; `filterTurnsForDisplay` keeps an invisible placeholder for a fully-filtered turn whose summary painted, and `buildTranscriptLayout`'s absorb guard refuses a painted follower. Prefix matching on the summary text lets a growing streaming summary inherit its boundary while duplicate turnIds with unrelatable summaries do not. A transcript that mounts already-settled never painted, so its hidden summaries do not block merging.)
 
 (d) In the render loop (:765–780), pass blocks in, skip fully-absorbed turns, and resolve the article's action turn to the line's LAST contributing turn so fork/rewind/context-menu affordances survive merging at line-end granularity:
 
@@ -585,7 +616,7 @@ Note the article still renders its fallback summary path only when `blocks.lengt
 1. `'keeps consecutive activity-only assistant turns separate while marking only the latest live'` (~:459) — replace expectation block: now ONE strip, one running indicator; click Toggle once; `src/one.ts`, `src/two.ts`, `src/three.ts` all visible; running indicator count stays 1. Rename to `'collapses consecutive activity-only assistant turns into one live strip'`.
 2. `'coalesces adjacent Claude tool-use/result exchanges without rendering synthetic You turns'` (:576) — after synthetic coalescing the two exchanges are adjacent same-role activity-only turns: change `strips` to length 1, expect `'2 tools used'`, headers still `['You', 'Freshclaude']`, still zero user-role strips.
 3. `'keeps adjacent activity-only display turns distinct and actionable'` (:892) — replace with the line-end-fork test from Step 1 (last case); the protection is preserved at line granularity: the single merged article's fork resolves to the line's last contributing turn (`display-activity-2`), delete the old two-article/two-strip assertions.
-4. `'does not show a second running indicator on an earlier turn when the streaming last turn has no displayable items'` (:1179) — new expected behavior: exactly 1 strip total (the injected empty strip is suppressed; the previous turn's line carries the live reel), one `running` indicator, and the settled text `'1 tool used'` is NOT shown while live.
+4. `'does not show a second running indicator on an earlier turn when the streaming last turn has no displayable items'` (:1179) — final behavior: when the last turn carries a painted summary, the visible-summary guard refuses the liveness handoff, so that turn renders its own article (summary + injected live strip) and the previous turn's settled line stays: exactly 2 strips with exactly 1 running indicator (the injected strip). An EMPTY-summary fixture collapses to 1 strip whose prior line goes live.
 
 - [x] **Step 4: Run the focused tests**
 

--- a/docs/plans/2026-08-23-freshagent-activity-line.md
+++ b/docs/plans/2026-08-23-freshagent-activity-line.md
@@ -59,15 +59,20 @@ test.describe('activity line collapse', () => {
     sessionId: string,
     turns: unknown[],
   ) {
-    // NOTE TO IMPLEMENTER: mirror the setup of the 'style setting persists' test:
+    // NOTE TO IMPLEMENTER: mirror the setup of the 'style setting persists per Fresh Agent pane type
+    // and applies serif rendering' test in this same file AND copy its fixture set ({ freshellPage,
+    // page, harness, terminal } — the repository fixtures perform navigation/harness setup only when
+    // freshellPage is requested; the helper below receives page + terminal, which is sufficient once
+    // the TEST CALLBACKS request freshellPage/harness):
     // 1. await terminal.waitForTerminal(); await enableClaudeAndCodex(page)
     // 2. open the pane picker, click Freshcodex, accept the first option
     // 3. page.route(`**/api/fresh-agent/threads/freshcodex/codex/${sessionId}*`) fulfilling a snapshot with
     //    { sessionType:'freshcodex', provider:'codex', threadId:sessionId, sessionId, revision:1,
     //      latestTurnId:<last turn id>, status:'idle', summary:'', capabilities:{...true}, settings:{...},
     //      tokenUsage:{...zeros}, pendingApprovals:[], pendingQuestions:[], worktrees:[], diffs:[], turns }
-    // 4. page.evaluate dispatching panes/updatePaneContent to point the new freshcodex leaf at sessionId
-    //    (copy the findFreshcodexLeaf walk + dispatch from the serif test, minus the style filter)
+    // 4. page.evaluate dispatching panes/updatePaneContent via window.__FRESHELL_TEST_HARNESS__ to point
+    //    the new freshcodex leaf at sessionId (copy the leaf-walk + dispatch from the serif test, minus
+    //    the style filter)
   }
 
   function toolTurn(turnId: string, calls: Array<[string, string]>) {
@@ -82,7 +87,7 @@ test.describe('activity line collapse', () => {
     }
   }
 
-  test('collapses adjacent same-role tool turns into one accumulating activity line (3 + 2 = 5)', async ({ page, terminal }) => {
+  test('collapses adjacent same-role tool turns into one accumulating activity line (3 + 2 = 5)', async ({ freshellPage: _freshellPage, page, harness, terminal }) => {
     await seedCollapsePane(page, terminal, 'collapse-thread', [
       { id: 'turn-user', turnId: 'turn-user', role: 'user', summary: 'read files',
         items: [{ id: 'item-user', kind: 'text', text: 'read these five files' }] },
@@ -100,7 +105,7 @@ test.describe('activity line collapse', () => {
     await expect(pane.getByText('src/e.ts')).toBeVisible()
   })
 
-  test('an intervening message keeps two tool lines separate', async ({ page, terminal }) => {
+  test('an intervening message keeps two tool lines separate', async ({ freshellPage: _freshellPage, page, harness, terminal }) => {
     await seedCollapsePane(page, terminal, 'split-thread', [
       toolTurn('turn-a', [['c1','src/a.ts']]),
       { id: 'turn-msg', turnId: 'turn-msg', role: 'assistant', summary: 'note',
@@ -284,6 +289,23 @@ describe('activity line collapse', () => {
     expect(screen.getByText('src/a.ts')).toBeInTheDocument()
     expect(screen.getByText('src/b.ts')).toBeInTheDocument()
   })
+
+  it('extends the open line in place as adjacent tool turns stream in (same DOM node, no regroup)', () => {
+    const userTurn = {
+      id: 'turn-user', role: 'user' as const, summary: 'req',
+      items: [{ id: 'item-user', kind: 'text' as const, text: 'read five files' }],
+    }
+    const turnA = toolTurn('turn-a', [['c1','src/a.ts'],['c2','src/b.ts'],['c3','src/c.ts']])
+    const { rerender } = render(<FreshAgentTranscript turns={[userTurn, turnA]} />)
+    const first = screen.getByRole('region', { name: 'Activity strip' })
+    expect(first).toHaveTextContent('3 tools used')
+
+    rerender(<FreshAgentTranscript turns={[userTurn, turnA, toolTurn('turn-b', [['c4','src/d.ts'],['c5','src/e.ts']])]} />)
+    const merged = screen.getByRole('region', { name: 'Activity strip' })
+    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    expect(merged).toBe(first)
+    expect(merged).toHaveTextContent('5 tools used')
+  })
 })
 ```
 
@@ -329,9 +351,11 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): { layouts: TurnLayout[]
     if (rows.length > 0) {
       layouts[open.originIndex].blocks.push({
         kind: 'activity',
-        // originIndex prefix keeps the join-collision-free guarantee with
-        // duplicated TS-claude item ids.
-        id: `line:${open.originIndex}:${open.items.map((item) => item.id).join(':')}`,
+        // Stable per origin turn: the line keeps its React identity (and DOM
+        // node, scroll state, expanded state) while later turns' items append
+        // into it — this is the "started in the right place, extended in
+        // place" behavior, not an after-the-fact regrouping remount.
+        id: `line:${open.originIndex}`,
         rows,
       })
     }
@@ -345,10 +369,9 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): { layouts: TurnLayout[]
       flushOpen()
       continue
     }
-    let messageSeenInTurn = false
     for (const item of turn.items) {
       if (isActivityLike(item)) {
-        if (open && open.role === turn.role && !messageSeenInTurn) {
+        if (open && open.role === turn.role) {
           const taken = new Set(open.items.map((openItem) => openItem.id))
           let displayItem = item
           let counter = 2
@@ -366,13 +389,14 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): { layouts: TurnLayout[]
       }
       flushOpen()
       layout.blocks.push({ kind: 'item', item })
-      messageSeenInTurn = true
     }
   }
   flushOpen()
   return { layouts, lineEndIndex }
 }
 ```
+
+Note: after a message flushes the open line, `open` is null, so later activity in the SAME turn opens a fresh line whose remaining activity items absorb normally — `text → tool_use → tool_result` stays ONE line, exactly matching today's in-turn `buildBlocks` batching.
 
 (b) Replace `selectLiveActivityBlockId` (:307–339) with a layout-driven version:
 
@@ -562,6 +586,6 @@ git commit -m "docs: mark freshagent-activity-line tasks complete with verificat
 ## Validated design notes (load-bearing stage, 2026-08-24)
 
 - **Zero-item turns are real** (Rust codex `subAgentActivity` rows emit `{role:"assistant", summary:"", items:[]}`; opencode structural messages likewise) and they render real article chrome today. The layout pass hard-closes any open line on a zero-item turn — two halves of a codex tool run split by a `subAgentActivity` marker therefore stay two strips. Residual, accepted: fixing THAT split needs a provider-level turn-shape decision, out of scope for this render-rule change.
-- **TS-claude item-id reuse across turns** (one provider message id spanning multiple JSONL lines yields duplicate `turn:<msg>:item:N` ids) is handled by display-only id dedupe in the absorb path; `toolUseId` stitching is verified unique (615MB × 813 real transcripts, zero repeats) and unaffected. Validators: `reports/load-bearing-validator-c2.md`, `reports/load-bearing-validator-n1.md`.
-- **Remount parity:** the merged line's React key changes whenever items append (key = joined display ids) — identical to today's in-turn streaming growth regime; expanded state surviving mid-stream appends is not a regression vector to preserve. Recorded residual.
+- **TS-claude item-id reuse across turns** (one provider message id spanning multiple JSONL lines yields duplicate `turn:<msg>:item:N` ids) is handled by display-only id dedupe in the absorb path; `toolUseId` stitching is verified unique (615MB × 813 real transcripts, zero repeats) and unaffected. Validator evidence (external run logs, by workflow design outside the tracked tree): `/home/dan/code/freshell/.worktrees/.the-usual-logs/freshagent-activity-line/reports/load-bearing-validator-c2.md` and `.../load-bearing-validator-n1.md`.
+- **Stable line identity:** each open line's React key is `line:<originTurnIndex>`, stable while later turns' items append — the strip keeps its DOM node (verified by an incremental rerender test asserting node identity), scroll position, and expanded state across extension; this is what distinguishes an extending open line from an after-the-fact regrouping remount.
 - **Non-streaming liveness:** mirrors the old last-turn trailing-thinking rule, extended to cover a last turn that was absorbed (its items close the latest line, so the check reads that line's trailing row).

--- a/docs/plans/2026-08-23-freshagent-activity-line.md
+++ b/docs/plans/2026-08-23-freshagent-activity-line.md
@@ -19,7 +19,7 @@ In fresh-agent transcripts, adjacent tool-activity lines with nothing rendered b
 
 **Goal:** Adjacent fresh-agent tool-activity strips with nothing between them render as one accumulating "N tools used" line (opened once, extended in place) instead of one strip per turn; any intervening message or role-change header keeps them separate.
 
-**Architecture:** Replace per-turn `buildBlocks` strip boundaries with a transcript-level single-pass layout in `FreshAgentTranscript.tsx`. The layout walks display turns once, keeping at most one OPEN activity line: a turn's leading activity items append to the open line when the turn has the same role as the line and no message item has rendered between; any message item or role change closes the line and later activity opens a new one. The line mounts once, in the article of the turn where its first item appears; turns fully absorbed into the line render no article. Per-turn articles, fork/rewind wiring, glom indexing, and live-strip liveness all keep working: `selectLiveActivityBlockId` is re-derived from the same layout, and the empty-streaming-turn injected strip is suppressed only when an adjacent open line already carries liveness.
+**Architecture:** Replace per-turn `buildBlocks` strip boundaries with a transcript-level single-pass layout in `FreshAgentTranscript.tsx`. The layout walks display turns once, keeping at most one OPEN activity line: a turn's leading activity items append to the open line when the turn has the same role as the line and no message item has rendered between; any message item or role change closes the line and later activity opens a new one. The line mounts once, in the article of the turn where its first item appears; turns fully absorbed into the line render no article. Fork/rewind/copy affordances are preserved at line granularity: a merged line's actions resolve to the line's LAST contributing turn (the most recent point the line covers), so the existing "fork from the latest activity turn" protection stays intact. `selectLiveActivityBlockId` is re-derived from the same layout, and the empty-streaming-turn injected strip is suppressed only when an adjacent open line already carries liveness.
 
 **Tech Stack:** React 18, TypeScript, Vitest + Testing Library (unit), Playwright e2e via the repo's configured backend (`test/e2e-browser`). No server or Rust changes — both servers feed the same REST snapshot shape into this one client component (verified by exploration).
 
@@ -53,10 +53,13 @@ Append a new `test.describe('activity line collapse', ...)` block at the end of 
 
 ```ts
 test.describe('activity line collapse', () => {
-  const STRIP = '.fresh-agent-activity-strip'
-
-  async function seedCollapsePane(page: Parameters<typeof openPanePicker>[0], sessionId: string, turns: unknown[]) {
-    await terminal... // NOTE TO IMPLEMENTER: mirror the setup of the 'style setting persists' test:
+  async function seedCollapsePane(
+    page: Parameters<typeof openPanePicker>[0],
+    terminal: { waitForTerminal: () => Promise<void> },
+    sessionId: string,
+    turns: unknown[],
+  ) {
+    // NOTE TO IMPLEMENTER: mirror the setup of the 'style setting persists' test:
     // 1. await terminal.waitForTerminal(); await enableClaudeAndCodex(page)
     // 2. open the pane picker, click Freshcodex, accept the first option
     // 3. page.route(`**/api/fresh-agent/threads/freshcodex/codex/${sessionId}*`) fulfilling a snapshot with
@@ -80,7 +83,7 @@ test.describe('activity line collapse', () => {
   }
 
   test('collapses adjacent same-role tool turns into one accumulating activity line (3 + 2 = 5)', async ({ page, terminal }) => {
-    await seedCollapsePane(page, 'collapse-thread', [
+    await seedCollapsePane(page, terminal, 'collapse-thread', [
       { id: 'turn-user', turnId: 'turn-user', role: 'user', summary: 'read files',
         items: [{ id: 'item-user', kind: 'text', text: 'read these five files' }] },
       toolTurn('turn-a', [['c1','src/a.ts'],['c2','src/b.ts'],['c3','src/c.ts']]),
@@ -88,16 +91,17 @@ test.describe('activity line collapse', () => {
     ])
     const pane = page.locator('[data-context="fresh-agent"]').last()
     await expect(pane).toBeVisible({ timeout: 10_000 })
-    await expect(pane.locator(STRIP)).toHaveCount(1)
-    await expect(pane.locator(STRIP).first()).toContainText('5 tools used')
+    const strips = pane.getByRole('region', { name: 'Activity strip' })
+    await expect(strips).toHaveCount(1)
+    await expect(strips.first()).toContainText('5 tools used')
     await pane.getByRole('button', { name: 'Toggle activity details' }).click()
-    await expect(pane.locator('.fresh-agent-tool-block')).toHaveCount(5)
-    await expect(pane.locator('.fresh-agent-tool-block').nth(0)).toContainText('src/a.ts')
-    await expect(pane.locator('.fresh-agent-tool-block').nth(4)).toContainText('src/e.ts')
+    await expect(pane.getByRole('button', { name: 'Read tool call' })).toHaveCount(5)
+    await expect(pane.getByText('src/a.ts')).toBeVisible()
+    await expect(pane.getByText('src/e.ts')).toBeVisible()
   })
 
   test('an intervening message keeps two tool lines separate', async ({ page, terminal }) => {
-    await seedCollapsePane(page, 'split-thread', [
+    await seedCollapsePane(page, terminal, 'split-thread', [
       toolTurn('turn-a', [['c1','src/a.ts']]),
       { id: 'turn-msg', turnId: 'turn-msg', role: 'assistant', summary: 'note',
         items: [{ id: 'item-msg', kind: 'text', text: 'First file read.' }] },
@@ -105,9 +109,10 @@ test.describe('activity line collapse', () => {
     ])
     const pane = page.locator('[data-context="fresh-agent"]').last()
     await expect(pane).toBeVisible({ timeout: 10_000 })
-    await expect(pane.locator(STRIP)).toHaveCount(2)
-    await expect(pane.locator(STRIP).nth(0)).toContainText('1 tool used')
-    await expect(pane.locator(STRIP).nth(1)).toContainText('1 tool used')
+    const strips = pane.getByRole('region', { name: 'Activity strip' })
+    await expect(strips).toHaveCount(2)
+    await expect(strips.nth(0)).toContainText('1 tool used')
+    await expect(strips.nth(1)).toContainText('1 tool used')
   })
 })
 ```
@@ -116,7 +121,7 @@ The helper prose comments marked `NOTE TO IMPLEMENTER` must be replaced with the
 
 - [ ] **Step 2: Run the tests and verify the intended failure**
 
-Run: `npm run test:e2e -- test/e2e-browser/specs/fresh-agent.spec.ts -g "activity line collapse"`
+Run: `npm run test:e2e -- test/e2e-browser/specs/fresh-agent.spec.ts --grep "activity line collapse"`
 
 Expected: FAIL because the first test currently finds 2 strips ("3 tools used" and "2 tools used") instead of one strip with "5 tools used". The second test (intervening message) may PASS already — that is fine and expected; it guards the boundary.
 
@@ -130,7 +135,7 @@ Do NOT commit. The failing e2e is staged with Task 2's commit once green.
 
 **Interfaces:**
 - Consumes: `FreshAgentTurn`, `FreshAgentTranscriptItem` from `@shared/fresh-agent-contract`; existing `buildActivity`, `isActivityLike`, `FreshAgentActivityStrip`, `FreshAgentTurnArticle`.
-- Produces: `buildTranscriptLayout(turns: FreshAgentTurn[]): TurnLayout[]` (module-scope pure function, not exported), `selectLiveActivityBlockIdFromLayout(...)`; `FreshAgentTurnArticle` gains a `blocks: RenderBlock[]` prop and drops its internal `buildBlocks` call.
+- Produces: `buildTranscriptLayout(turns: FreshAgentTurn[]): { layouts: TurnLayout[]; lineEndIndex: Map<number, number> }` (module-scope pure function, not exported; `lineEndIndex` maps a line's origin-turn index → the index of the line's LAST contributing display turn), `selectLiveActivityBlockIdFromLayout(...)`; `FreshAgentTurnArticle` gains `blocks: RenderBlock[]` and `actionTurn: FreshAgentTurn` props and drops its internal `buildBlocks` call.
 
 - [ ] **Step 1: Write the failing behavioral tests (new unit cases)**
 
@@ -226,7 +231,7 @@ describe('activity line collapse', () => {
     expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('6 tools used')
   })
 
-  it('fully absorbed turns render no article and fork targets the line origin', () => {
+  it('fully absorbed turns render no article and fork targets the line end', () => {
     const onFork = vi.fn()
     render(
       <FreshAgentTranscript
@@ -247,7 +252,7 @@ describe('activity line collapse', () => {
     expect(screen.getByText('Thinking')).toBeInTheDocument()
     const forkButtons = screen.getAllByRole('button', { name: 'Fork conversation from here' })
     fireEvent.click(forkButtons[0])
-    expect(onFork).toHaveBeenCalledWith('native-a')
+    expect(onFork).toHaveBeenCalledWith('native-b')
   })
 
   it('treats a zero-item turn as a boundary between tool lines', () => {
@@ -313,9 +318,10 @@ type TurnLayout = { blocks: RenderBlock[] }
  * provider message id; stitching keys toolUseId, which is verified unique, so
  * stitching is unaffected — only React keys need this).
  */
-function buildTranscriptLayout(turns: FreshAgentTurn[]): TurnLayout[] {
+function buildTranscriptLayout(turns: FreshAgentTurn[]): { layouts: TurnLayout[]; lineEndIndex: Map<number, number> } {
   const layouts: TurnLayout[] = []
   let open: { originIndex: number; role: FreshAgentTurn['role']; items: FreshAgentTranscriptItem[] } | null = null
+  const lineEndIndex = new Map<number, number>()
 
   const flushOpen = () => {
     if (!open) return
@@ -351,6 +357,7 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): TurnLayout[] {
             counter += 1
           }
           open.items.push(displayItem as FreshAgentTranscriptItem)
+          lineEndIndex.set(open.originIndex, turnIndex)
         } else {
           flushOpen()
           open = { originIndex: turnIndex, role: turn.role, items: [item] }
@@ -363,7 +370,7 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): TurnLayout[] {
     }
   }
   flushOpen()
-  return layouts
+  return { layouts, lineEndIndex }
 }
 ```
 
@@ -422,14 +429,14 @@ function selectLiveActivityBlockIdFromLayout(
 const displayTurns = useMemo(() => (
   filterTurnsForDisplay(coalesceSyntheticToolResultTurns(turns), displayOptions, isStreaming)
 ), [displayOptions, turns, isStreaming])
-const turnLayouts = useMemo(() => buildTranscriptLayout(displayTurns), [displayTurns])
+const { layouts: turnLayouts, lineEndIndex } = useMemo(() => buildTranscriptLayout(displayTurns), [displayTurns])
 const liveActivityBlockId = useMemo(
   () => selectLiveActivityBlockIdFromLayout(turnLayouts, displayTurns, isStreaming),
   [turnLayouts, displayTurns, isStreaming],
 )
 ```
 
-(d) In the render loop (:765–780), pass blocks in and skip fully-absorbed turns:
+(d) In the render loop (:765–780), pass blocks in, skip fully-absorbed turns, and resolve the article's action turn to the line's LAST contributing turn so fork/rewind/context-menu affordances survive merging at line-end granularity:
 
 ```tsx
 {displayTurns.map((turn, index) => {
@@ -438,10 +445,12 @@ const liveActivityBlockId = useMemo(
   const isLastStreaming = isStreaming && index === displayTurns.length - 1
   if (absorbed) return null
   if (isLastStreaming && blocksForTurn.length === 0 && turn.items.length === 0 && liveActivityBlockId !== null) return null
+  const actionTurn = displayTurns[lineEndIndex.get(index) ?? index]
   return (
     <FreshAgentTurnArticle
       key={`${getFreshAgentDisplayTurnKey(turn)}:${index}`}
       turn={turn}
+      actionTurn={actionTurn}
       blocks={blocksForTurn}
       actions={actions}
       agentLabel={agentLabel}
@@ -457,6 +466,8 @@ const liveActivityBlockId = useMemo(
 })}
 ```
 
+In `FreshAgentTurnArticle`, every action surface (`FreshAgentTurnActions`, the context menu handler, the long-press action sheet opener) uses the new `actionTurn` prop instead of `turn` for `onForkFromTurn`/`onRewindToTurn`/`buildTurnActionItems`/`onOpenActions` — so a merged line forks from the last point the line covers (`(none stated)` residual: mid-line fork targets between absorbed turns are removed, a required consequence of rendering one line).
+
 (e) In `FreshAgentTurnArticle`, accept `blocks` as a prop (remove its internal `buildBlocks` call and the now-unused `displayOptions` prop if it was only used for that), and change the injected-strip condition (:573) so it only fires when no open line took over liveness:
 
 ```tsx
@@ -471,7 +482,7 @@ Note the article still renders its fallback summary path only when `blocks.lengt
 
 1. `'keeps consecutive activity-only assistant turns separate while marking only the latest live'` (~:459) — replace expectation block: now ONE strip, one running indicator; click Toggle once; `src/one.ts`, `src/two.ts`, `src/three.ts` all visible; running indicator count stays 1. Rename to `'collapses consecutive activity-only assistant turns into one live strip'`.
 2. `'coalesces adjacent Claude tool-use/result exchanges without rendering synthetic You turns'` (:576) — after synthetic coalescing the two exchanges are adjacent same-role activity-only turns: change `strips` to length 1, expect `'2 tools used'`, headers still `['You', 'Freshclaude']`, still zero user-role strips.
-3. `'keeps adjacent activity-only display turns distinct and actionable'` (:892) — replace with the new absorb/fork-origin test from Step 1 (last case), delete the old two-article/two-strip assertions.
+3. `'keeps adjacent activity-only display turns distinct and actionable'` (:892) — replace with the line-end-fork test from Step 1 (last case); the protection is preserved at line granularity: the single merged article's fork resolves to the line's last contributing turn (`display-activity-2`), delete the old two-article/two-strip assertions.
 4. `'does not show a second running indicator on an earlier turn when the streaming last turn has no displayable items'` (:1179) — new expected behavior: exactly 1 strip total (the injected empty strip is suppressed; the previous turn's line carries the live reel), one `running` indicator, and the settled text `'1 tool used'` is NOT shown while live.
 
 - [ ] **Step 4: Run the focused tests**
@@ -479,7 +490,7 @@ Note the article still renders its fallback summary path only when `blocks.lengt
 Run: `npm run test:vitest -- run test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx`
 
 Expected: PASS (all new cases plus the rewritten legacy cases) then:
-Run: `npm run test:e2e -- test/e2e-browser/specs/fresh-agent.spec.ts -g "activity line collapse"`
+Run: `npm run test:e2e -- test/e2e-browser/specs/fresh-agent.spec.ts --grep "activity line collapse"`
 Expected: PASS (Task 1's failing test is now green).
 
 - [ ] **Step 5: Refactor while green**
@@ -544,7 +555,7 @@ git commit -m "docs: mark freshagent-activity-line tasks complete with verificat
 
 ## Risks / recorded decisions
 
-- **Fork/rewind granularity:** a turn fully absorbed into an open line is no longer a fork/rewind target (its article does not render); the line's origin turn is the target. Server fork constraints (composite `turnId`) are honored: we never synthesize composite `turnId`s; the origin turn's own `turnId` is passed through unchanged.
+- **Fork/rewind granularity:** a merged activity line exposes its fork/rewind/context-menu actions against the line's LAST contributing turn (the most recent point the line covers), so the existing protection "fork from the latest activity turn" holds verbatim. Mid-line fork targets between absorbed turns are removed — a required consequence of rendering one line. Server fork constraints (composite `turnId`) are honored: never synthesize composite `turnId`s; the last contributor's own `turnId` passes through unchanged.
 - **Streaming empty-turn suppression** only engages when the previous display turn has a trailing activity line of the same role; all other streaming-empty cases keep the current injected-strip behavior (jp70 hardening untouched).
 - **Role-change = boundary** matches the user's rule because a role change paints a visible header between strips; thinking/reasoning are line content, not boundaries.
 

--- a/docs/plans/2026-08-23-freshagent-activity-line.md
+++ b/docs/plans/2026-08-23-freshagent-activity-line.md
@@ -1,0 +1,493 @@
+# Fresh-Agent Transcript: Single Accumulating Activity Line Implementation Plan
+
+> **For agentic workers:** Execute this plan task by task with a fresh
+> implementer and a specification-plus-quality review after every task. Track
+> progress with the checkbox steps below.
+
+## User Request
+
+### Requested result
+In fresh-agent transcripts, adjacent tool-activity lines with nothing rendered between them (e.g. "3 tools used" followed by "2 tools used") appear as one line whose tool count accumulates (e.g. "5 tools used"); the single line keeps absorbing tool activity until a message appears, and only then does a new line start. If anything renders between two tool runs, they stay as separate lines.
+
+### Explicit constraints
+- Implement via the the-usual-beta workflow (dedicated worktree, committed plan, load-bearing validation, independent plan review, TDD execution, independent delta review, plain-language recap; PR only after explicit user approval).
+- Build the behavior as one open activity line that tool runs join as they stream (start in the right place), not as after-the-fact moving of tool items between turns.
+- If anything (message text, user message, role-change header) renders between tool runs, the runs must not collapse.
+
+### Accepted tradeoffs and residuals
+- (none stated)
+
+**Goal:** Adjacent fresh-agent tool-activity strips with nothing between them render as one accumulating "N tools used" line (opened once, extended in place) instead of one strip per turn; any intervening message or role-change header keeps them separate.
+
+**Architecture:** Replace per-turn `buildBlocks` strip boundaries with a transcript-level single-pass layout in `FreshAgentTranscript.tsx`. The layout walks display turns once, keeping at most one OPEN activity line: a turn's leading activity items append to the open line when the turn has the same role as the line and no message item has rendered between; any message item or role change closes the line and later activity opens a new one. The line mounts once, in the article of the turn where its first item appears; turns fully absorbed into the line render no article. Per-turn articles, fork/rewind wiring, glom indexing, and live-strip liveness all keep working: `selectLiveActivityBlockId` is re-derived from the same layout, and the empty-streaming-turn injected strip is suppressed only when an adjacent open line already carries liveness.
+
+**Tech Stack:** React 18, TypeScript, Vitest + Testing Library (unit), Playwright e2e via the repo's configured backend (`test/e2e-browser`). No server or Rust changes — both servers feed the same REST snapshot shape into this one client component (verified by exploration).
+
+## Global Constraints
+
+- Work only in the worktree `/home/dan/code/freshell/.worktrees/freshagent-activity-line` (branch `the-usual/freshagent-activity-line`, anchored at `6d5b5394ccfd00844579d8857180ff7fad4a2ef9`). Never touch the main checkout.
+- TDD red/green/refactor; never reduce coverage, skip tests, or loosen assertions to pass.
+- All vitest runs use the repo-owned path from the worktree: `npm run test:vitest -- run <paths>` (never raw `npx vitest`).
+- e2e runs use the configured `FRESHELL_E2E_BACKEND` (cloud by default here): `npm run test:e2e -- <spec>`.
+- Server code uses NodeNext/ESM with `.js` relative import extensions (not applicable to the client change here, but the constraint stands for any touched server file).
+- Commits are focused and conventional (`feat:`, `test:`, `docs:`). Never set git config/identity. Never amend, force-push, or create PRs.
+- Never synthesize composite `turnId`s: server fork paths parse format-sensitive ids (Rust codex strips a trailing `:row-N`, Rust opencode gates on `^msg`). Composite display `id`s joined with `:` are established precedent (`appendTurnItems` in the same file) and are fine for React keys only.
+- The `## User Request` block above is verbatim and must not be edited by remediation.
+- `docs/index.html` is a mock of major UX surfaces; this change is a rendering-rule refinement of an existing surface, so no mock update is required (recorded decision, not an oversight).
+- `test/browser_use/tool_coalesce.py` asserts a within-turn "N tools used" strip; strips still show that text after this change, so the script needs no edit (recorded decision).
+
+---
+
+### Task 1: Failing e2e coverage for adjacent-strip collapsing
+
+**Files:**
+- Test: `test/e2e-browser/specs/fresh-agent.spec.ts`
+
+**Interfaces:**
+- Consumes: existing harness pattern — `page.route('**/api/fresh-agent/threads/freshcodex/codex/<session>*', ...)` fulfilling the snapshot REST call; picker flow via `openPanePicker(page)`; `panes/updatePaneContent` dispatch to point the pane at the seeded session (see the 'style setting persists per Fresh Agent pane type and applies serif rendering' test in the same file for the exact flow).
+- Produces: two failing e2e tests proving the pre-fix behavior (later turned green by Task 2).
+
+- [ ] **Step 1: Write the failing behavioral tests**
+
+Append a new `test.describe('activity line collapse', ...)` block at the end of `test/e2e-browser/specs/fresh-agent.spec.ts`, reusing the same file's picker/*route* seeding pattern:
+
+```ts
+test.describe('activity line collapse', () => {
+  const STRIP = '.fresh-agent-activity-strip'
+
+  async function seedCollapsePane(page: Parameters<typeof openPanePicker>[0], sessionId: string, turns: unknown[]) {
+    await terminal... // NOTE TO IMPLEMENTER: mirror the setup of the 'style setting persists' test:
+    // 1. await terminal.waitForTerminal(); await enableClaudeAndCodex(page)
+    // 2. open the pane picker, click Freshcodex, accept the first option
+    // 3. page.route(`**/api/fresh-agent/threads/freshcodex/codex/${sessionId}*`) fulfilling a snapshot with
+    //    { sessionType:'freshcodex', provider:'codex', threadId:sessionId, sessionId, revision:1,
+    //      latestTurnId:<last turn id>, status:'idle', summary:'', capabilities:{...true}, settings:{...},
+    //      tokenUsage:{...zeros}, pendingApprovals:[], pendingQuestions:[], worktrees:[], diffs:[], turns }
+    // 4. page.evaluate dispatching panes/updatePaneContent to point the new freshcodex leaf at sessionId
+    //    (copy the findFreshcodexLeaf walk + dispatch from the serif test, minus the style filter)
+  }
+
+  function toolTurn(turnId: string, calls: Array<[string, string]>) {
+    // calls: [callId, filePath] pairs; produces an assistant turn whose items are
+    // tool_use(toolUseId=callId, name:'Read', input:{file_path}) followed by its tool_result(content:'ok').
+    return {
+      id: turnId, turnId, role: 'assistant', summary: '',
+      items: calls.flatMap(([callId, filePath]) => [
+        { id: `tool-${callId}`, kind: 'tool_use', toolUseId: callId, name: 'Read', input: { file_path: filePath } },
+        { id: `result-${callId}`, kind: 'tool_result', toolUseId: callId, content: 'ok', isError: false },
+      ]),
+    }
+  }
+
+  test('collapses adjacent same-role tool turns into one accumulating activity line (3 + 2 = 5)', async ({ page, terminal }) => {
+    await seedCollapsePane(page, 'collapse-thread', [
+      { id: 'turn-user', turnId: 'turn-user', role: 'user', summary: 'read files',
+        items: [{ id: 'item-user', kind: 'text', text: 'read these five files' }] },
+      toolTurn('turn-a', [['c1','src/a.ts'],['c2','src/b.ts'],['c3','src/c.ts']]),
+      toolTurn('turn-b', [['c4','src/d.ts'],['c5','src/e.ts']]),
+    ])
+    const pane = page.locator('[data-context="fresh-agent"]').last()
+    await expect(pane).toBeVisible({ timeout: 10_000 })
+    await expect(pane.locator(STRIP)).toHaveCount(1)
+    await expect(pane.locator(STRIP).first()).toContainText('5 tools used')
+    await pane.getByRole('button', { name: 'Toggle activity details' }).click()
+    await expect(pane.locator('.fresh-agent-tool-block')).toHaveCount(5)
+    await expect(pane.locator('.fresh-agent-tool-block').nth(0)).toContainText('src/a.ts')
+    await expect(pane.locator('.fresh-agent-tool-block').nth(4)).toContainText('src/e.ts')
+  })
+
+  test('an intervening message keeps two tool lines separate', async ({ page, terminal }) => {
+    await seedCollapsePane(page, 'split-thread', [
+      toolTurn('turn-a', [['c1','src/a.ts']]),
+      { id: 'turn-msg', turnId: 'turn-msg', role: 'assistant', summary: 'note',
+        items: [{ id: 'item-msg', kind: 'text', text: 'First file read.' }] },
+      toolTurn('turn-b', [['c2','src/b.ts']]),
+    ])
+    const pane = page.locator('[data-context="fresh-agent"]').last()
+    await expect(pane).toBeVisible({ timeout: 10_000 })
+    await expect(pane.locator(STRIP)).toHaveCount(2)
+    await expect(pane.locator(STRIP).nth(0)).toContainText('1 tool used')
+    await expect(pane.locator(STRIP).nth(1)).toContainText('1 tool used')
+  })
+})
+```
+
+The helper prose comments marked `NOTE TO IMPLEMENTER` must be replaced with the actual copied setup code from the serif test (lines ~233–374 of the same file at base).
+
+- [ ] **Step 2: Run the tests and verify the intended failure**
+
+Run: `npm run test:e2e -- test/e2e-browser/specs/fresh-agent.spec.ts -g "activity line collapse"`
+
+Expected: FAIL because the first test currently finds 2 strips ("3 tools used" and "2 tools used") instead of one strip with "5 tools used". The second test (intervening message) may PASS already — that is fine and expected; it guards the boundary.
+
+Do NOT commit. The failing e2e is staged with Task 2's commit once green.
+
+### Task 2: Transcript-level open activity line (layout pass + render wiring + unit suite)
+
+**Files:**
+- Modify: `src/components/fresh-agent/FreshAgentTranscript.tsx`
+- Test: `test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx`
+
+**Interfaces:**
+- Consumes: `FreshAgentTurn`, `FreshAgentTranscriptItem` from `@shared/fresh-agent-contract`; existing `buildActivity`, `isActivityLike`, `FreshAgentActivityStrip`, `FreshAgentTurnArticle`.
+- Produces: `buildTranscriptLayout(turns: FreshAgentTurn[]): TurnLayout[]` (module-scope pure function, not exported), `selectLiveActivityBlockIdFromLayout(...)`; `FreshAgentTurnArticle` gains a `blocks: RenderBlock[]` prop and drops its internal `buildBlocks` call.
+
+- [ ] **Step 1: Write the failing behavioral tests (new unit cases)**
+
+Add to `test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx` (a new `describe('activity line collapse', ...)`):
+
+```tsx
+describe('activity line collapse', () => {
+  const toolTurn = (turnId: string, calls: Array<[string, string]>): FreshAgentTurn => ({
+    id: turnId,
+    turnId,
+    role: 'assistant',
+    summary: '',
+    items: calls.flatMap(([callId, filePath]): FreshAgentTranscriptItem[] => [
+      { id: `tool-${callId}`, kind: 'tool_use', toolUseId: callId, name: 'Read', input: { file_path: filePath } },
+      { id: `result-${callId}`, kind: 'tool_result', toolUseId: callId, content: 'ok', isError: false },
+    ]),
+  })
+
+  it('collapses adjacent same-role tool-only turns into one accumulating strip line', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          { id: 'turn-user', role: 'user', summary: 'req',
+            items: [{ id: 'item-user', kind: 'text', text: 'read five files' }] },
+          toolTurn('turn-a', [['c1','src/a.ts'],['c2','src/b.ts'],['c3','src/c.ts']]),
+          toolTurn('turn-b', [['c4','src/d.ts'],['c5','src/e.ts']]),
+        ]}
+      />,
+    )
+    const strips = screen.getAllByRole('region', { name: 'Activity strip' })
+    expect(strips).toHaveLength(1)
+    expect(strips[0]).toHaveTextContent('5 tools used')
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle activity details' }))
+    expect(screen.getAllByText(/^src\/[a-e]\.ts$/)).toHaveLength(5)
+    expect(screen.getByText('src/e.ts')).toBeInTheDocument()
+  })
+
+  it('keeps tool lines separate when a message renders between them', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          toolTurn('turn-a', [['c1','src/a.ts']]),
+          { id: 'turn-msg', role: 'assistant', summary: 'note',
+            items: [{ id: 'item-msg', kind: 'text', text: 'First file read.' }] },
+          toolTurn('turn-b', [['c2','src/b.ts']]),
+        ]}
+      />,
+    )
+    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+  })
+
+  it('does not collapse tool lines across a role change', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          toolTurn('turn-a', [['c1','src/a.ts']]),
+          { ...toolTurn('turn-b', [['c2','src/b.ts']]), role: 'tool' },
+        ]}
+      />,
+    )
+    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+    // the role change renders a header between the lines
+    expect(screen.getByText('Tool')).toBeInTheDocument()
+  })
+
+  it('a trailing text card in the earlier turn keeps the lines separate', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          { id: 'turn-a', role: 'assistant', summary: 'work',
+            items: [
+              { id: 'tool-c1', kind: 'tool_use', toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } },
+              { id: 'item-msg', kind: 'text', text: 'done with a' },
+            ] },
+          toolTurn('turn-b', [['c2','src/b.ts']]),
+        ]}
+      />,
+    )
+    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+  })
+
+  it('merges a chain of three adjacent tool-only turns', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          toolTurn('turn-a', [['c1','src/a.ts'],['c2','src/b.ts']]),
+          toolTurn('turn-b', [['c3','src/c.ts'],['c4','src/d.ts']]),
+          toolTurn('turn-c', [['c5','src/e.ts'],['c6','src/f.ts']]),
+        ]}
+      />,
+    )
+    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('6 tools used')
+  })
+
+  it('fully absorbed turns render no article and fork targets the line origin', () => {
+    const onFork = vi.fn()
+    render(
+      <FreshAgentTranscript
+        canFork
+        onForkFromTurn={onFork}
+        turns={[
+          { id: 'turn-a', turnId: 'native-a', role: 'assistant', summary: '',
+            items: [{ id: 't1', kind: 'thinking', text: 'first thought' }] },
+          { id: 'turn-b', turnId: 'native-b', role: 'assistant', summary: '',
+            items: [{ id: 't2', kind: 'thinking', text: 'second thought' }] },
+        ]}
+      />,
+    )
+    expect(screen.getAllByRole('article', { name: 'Assistant transcript turn' })).toHaveLength(1)
+    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    // merged thinking-only line settles to 'thought'
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle activity details' }))
+    expect(screen.getByText('Thinking')).toBeInTheDocument()
+    const forkButtons = screen.getAllByRole('button', { name: 'Fork conversation from here' })
+    fireEvent.click(forkButtons[0])
+    expect(onFork).toHaveBeenCalledWith('native-a')
+  })
+})
+```
+
+(Note: thinking items require `showThinking` default true — the component default is `true`; these turns are activity-only thinking runs merging into one line, matching the "second thought" gh-of the old :892 test.)
+
+- [ ] **Step 2: Run the new tests and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx -t "activity line collapse"`
+
+Expected: FAIL — the collapse/merge/absorb cases currently render 2/2/2/1+2/more strips and articles because strip boundaries are per-turn (per-turn `buildBlocks` in `FreshAgentTurnArticle`, `FreshAgentTranscript.tsx:497`). The 'keeps separate' and 'trailing text' cases may pass already (they assert preserved boundaries).
+
+- [ ] **Step 3: Add the production implementation**
+
+In `src/components/fresh-agent/FreshAgentTranscript.tsx`:
+
+(a) After `buildBlocks` (:225), add the transcript-level layout pass:
+
+```ts
+type TurnLayout = { blocks: RenderBlock[] }
+
+/**
+ * One OPEN activity line per transcript state: a next turn's leading
+ * activity items append to the open line when the turn has the same role and
+ * no message item has rendered between (a role change paints a header, so it
+ * counts as "something between"). Lines are re-built from the concatenated
+ * item list so buildActivity's tool_use/tool_result stitching stays intact.
+ */
+function buildTranscriptLayout(turns: FreshAgentTurn[]): TurnLayout[] {
+  const layouts: TurnLayout[] = []
+  let open: { originIndex: number; role: FreshAgentTurn['role']; items: FreshAgentTranscriptItem[] } | null = null
+
+  const flushOpen = () => {
+    if (!open) return
+    const rows = buildActivity(open.items)
+    if (rows.length > 0) {
+      layouts[open.originIndex].blocks.push({
+        kind: 'activity',
+        id: open.items.map((item) => item.id).join(':'),
+        rows,
+      })
+    }
+    open = null
+  }
+
+  for (const [turnIndex, turn] of turns.entries()) {
+    const layout: TurnLayout = { blocks: [] }
+    layouts.push(layout)
+    let messageSeenInTurn = false
+    for (const item of turn.items) {
+      if (isActivityLike(item)) {
+        if (open && open.role === turn.role && !messageSeenInTurn) {
+          open.items.push(item)
+        } else {
+          flushOpen()
+          open = { originIndex: turnIndex, role: turn.role, items: [item] }
+        }
+        continue
+      }
+      flushOpen()
+      layout.blocks.push({ kind: 'item', item })
+      messageSeenInTurn = true
+    }
+  }
+  flushOpen()
+  return layouts
+}
+```
+
+(b) Replace `selectLiveActivityBlockId` (:307–339) with a layout-driven version:
+
+```ts
+function selectLiveActivityBlockIdFromLayout(
+  layouts: TurnLayout[],
+  turns: FreshAgentTurn[],
+  isStreaming: boolean,
+): string | null {
+  let latestActivityBlockId: string | null = null
+  let lastBlocksTurn = -1
+  layouts.forEach((layout, index) => {
+    if (layout.blocks.length > 0) lastBlocksTurn = index
+    for (const block of layout.blocks) {
+      if (block.kind === 'activity') latestActivityBlockId = block.id
+    }
+  })
+  const lastBlocks = lastBlocksTurn >= 0 ? layouts[lastBlocksTurn].blocks : []
+  const lastBlock = lastBlocks[lastBlocks.length - 1]
+  const trailingThinkingBlockId =
+    lastBlock?.kind === 'activity' && lastBlock.rows.at(-1)?.type === 'thinking'
+      ? lastBlock.id
+      : null
+
+  if (!isStreaming) return trailingThinkingBlockId
+
+  const lastTurn = turns[turns.length - 1]
+  if (lastTurn && lastTurn.items.length > 0) return latestActivityBlockId
+
+  // Last display turn streams with zero visible items: hand liveness to an
+  // adjacent open line (same role, trailing activity) instead of injecting a
+  // second empty strip line below it.
+  const previousIndex = turns.length - 2
+  if (previousIndex >= 0 && lastTurn) {
+    const previousBlocks = layouts[previousIndex]?.blocks ?? []
+    const previousLast = previousBlocks[previousBlocks.length - 1]
+    if (previousLast?.kind === 'activity' && turns[previousIndex].role === lastTurn.role) {
+      return previousLast.id
+    }
+  }
+  return null
+}
+```
+
+(c) In `FreshAgentTranscript` (:632), compute the layout and derive liveness from it:
+
+```ts
+const displayTurns = useMemo(() => (
+  filterTurnsForDisplay(coalesceSyntheticToolResultTurns(turns), displayOptions, isStreaming)
+), [displayOptions, turns, isStreaming])
+const turnLayouts = useMemo(() => buildTranscriptLayout(displayTurns), [displayTurns])
+const liveActivityBlockId = useMemo(
+  () => selectLiveActivityBlockIdFromLayout(turnLayouts, displayTurns, isStreaming),
+  [turnLayouts, displayTurns, isStreaming],
+)
+```
+
+(d) In the render loop (:765–780), pass blocks in and skip fully-absorbed turns:
+
+```tsx
+{displayTurns.map((turn, index) => {
+  const blocksForTurn = turnLayouts[index]?.blocks ?? []
+  const absorbed = turn.items.length > 0 && blocksForTurn.length === 0
+  const isLastStreaming = isStreaming && index === displayTurns.length - 1
+  if (absorbed) return null
+  if (isLastStreaming && blocksForTurn.length === 0 && turn.items.length === 0 && liveActivityBlockId !== null) return null
+  return (
+    <FreshAgentTurnArticle
+      key={`${getFreshAgentDisplayTurnKey(turn)}:${index}`}
+      turn={turn}
+      blocks={blocksForTurn}
+      actions={actions}
+      agentLabel={agentLabel}
+      showTimecodes={resolvedShowTimecodes}
+      showTools={showTools}
+      showHeader={index === 0 || displayTurns[index - 1]?.role !== turn.role}
+      continuation={index > 0 && displayTurns[index - 1]?.role === turn.role}
+      liveActivityBlockId={liveActivityBlockId}
+      isStreamingLastTurn={isLastStreaming}
+      index={index}
+    />
+  )
+})}
+```
+
+(e) In `FreshAgentTurnArticle`, accept `blocks` as a prop (remove its internal `buildBlocks` call and the now-unused `displayOptions` prop if it was only used for that), and change the injected-strip condition (:573) so it only fires when no open line took over liveness:
+
+```tsx
+{isStreamingLastTurn && blocks.length === 0 && liveActivityBlockId === null ? (
+  <FreshAgentActivityStrip rows={[]} live initialExpanded={showTools} />
+) : null}
+```
+
+Note the article still renders its fallback summary path only when `blocks.length === 0 && turn.items.length > 0` is IMPOSSIBLE by construction (parent returns null for that case), so the existing `:566–572` fallback continues to apply only to legacy empty-item turns.
+
+(f) Update the four existing tests that encode the old per-turn boundary:
+
+1. `'keeps consecutive activity-only assistant turns separate while marking only the latest live'` (~:459) — replace expectation block: now ONE strip, one running indicator; click Toggle once; `src/one.ts`, `src/two.ts`, `src/three.ts` all visible; running indicator count stays 1. Rename to `'collapses consecutive activity-only assistant turns into one live strip'`.
+2. `'coalesces adjacent Claude tool-use/result exchanges without rendering synthetic You turns'` (:576) — after synthetic coalescing the two exchanges are adjacent same-role activity-only turns: change `strips` to length 1, expect `'2 tools used'`, headers still `['You', 'Freshclaude']`, still zero user-role strips.
+3. `'keeps adjacent activity-only display turns distinct and actionable'` (:892) — replace with the new absorb/fork-origin test from Step 1 (last case), delete the old two-article/two-strip assertions.
+4. `'does not show a second running indicator on an earlier turn when the streaming last turn has no displayable items'` (:1179) — new expected behavior: exactly 1 strip total (the injected empty strip is suppressed; the previous turn's line carries the live reel), one `running` indicator, and the settled text `'1 tool used'` is NOT shown while live.
+
+- [ ] **Step 4: Run the focused tests**
+
+Run: `npm run test:vitest -- run test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx`
+
+Expected: PASS (all new cases plus the rewritten legacy cases) then:
+Run: `npm run test:e2e -- test/e2e-browser/specs/fresh-agent.spec.ts -g "activity line collapse"`
+Expected: PASS (Task 1's failing test is now green).
+
+- [ ] **Step 5: Refactor while green**
+
+Specific cleanups: remove the now-unused `buildBlocks` function IF nothing else uses it (check `selectLiveActivityBlockId`'s replacement consumed the last caller — delete dead code and any now-unused `options` plumbing in `FreshAgentTurnArticle`); dedupe the `messageSeenInTurn` + `flushOpen` sequence if it reads cleaner extracted; keep `buildTranscriptLayout` and the live-selection function adjacent and pure. No behavior change.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Impacted set: every spec rendering `FreshAgentTranscript` or its children (the article/strip DOM contract changed: absorbed turns no longer render articles; strip mounting position unchanged otherwise).
+
+Run: `npm run test:vitest -- run test/unit/client/components/fresh-agent/ test/unit/shared/fresh-agent-turns.test.ts`
+
+Expected: PASS — includes FreshAgentMobile.test.tsx, FreshAgentTurnActions.test.tsx, FreshAgentItemCard.test.tsx, FreshAgentSharedWidgets.test.tsx.
+
+Then the e2e surface that touches fresh-agent DOM: `npm run test:e2e -- test/e2e-browser/specs/fresh-agent.spec.ts test/e2e-browser/specs/fresh-agent-mobile.spec.ts test/e2e-browser/specs/fresh-agent-control-rust.spec.ts` (the last asserts `article[data-turn-index]` counts and fork hover — absorbed-turn skipping must not regress them; those fixtures have message content between tool runs, so no absorption occurs there).
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/components/fresh-agent/FreshAgentTranscript.tsx \
+        test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx \
+        test/e2e-browser/specs/fresh-agent.spec.ts
+git commit -m "feat(fresh-agent): collapse adjacent tool activity into one accumulating strip line"
+```
+
+### Task 3: Whole-surface verification + residual checks
+
+**Files:**
+- Modify: none expected.
+- Test: impacted breadth only.
+
+**Interfaces:**
+- Consumes: the Task 2 implementation.
+- Produces: verification receipts for the recap.
+
+- [ ] **Step 1: Reading-time sanity of the browser_use script**
+
+Verify by inspection (no edit expected) that `test/browser_use/tool_coalesce.py`'s goal ("consecutive tool uses in an assistant turn appear as ONE strip showing 'N tools used'") remains satisfied: within-turn grouping is unchanged, and the script's per-turn lookups still find one strip per message turn. Record the conclusion in the task receipt.
+
+- [ ] **Step 2: Typecheck + lint the touched surface**
+
+Run: `npx tsc --noEmit -p .` from the worktree and `npm run lint -- src/components/fresh-agent/FreshAgentTranscript.tsx test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx test/e2e-browser/specs/fresh-agent.spec.ts`
+
+Expected: PASS (eslint-plugin-jsx-a11y clean — no new interactive DOM added).
+
+- [ ] **Step 3: Confirm no other render callers construct turn blocks differently**
+
+Run: `grep -rn "buildBlocks\|coalesceSyntheticToolResultTurns" src/ test/unit | grep -v FreshAgentTranscript.tsx`
+
+Expected: only the transcript test references; `FreshAgentView.tsx`/`FreshAgentMobile` consume `FreshAgentTranscript` as a component (no direct block construction).
+
+- [ ] **Step 4: Record outcomes and commit (only if receipts/notes were written as part of the run log)**
+
+```bash
+git add docs/plans/2026-08-23-freshagent-activity-line.md
+git commit -m "docs: mark freshagent-activity-line tasks complete with verification receipts"
+```
+
+(The full-suite gate is NOT part of this plan — the the-usual-beta execution stage owns the single final full-suite run after review loops, per its contract.)
+
+## Risks / recorded decisions
+
+- **Fork/rewind granularity:** a turn fully absorbed into an open line is no longer a fork/rewind target (its article does not render); the line's origin turn is the target. Server fork constraints (composite `turnId`) are honored: we never synthesize composite `turnId`s; the origin turn's own `turnId` is passed through unchanged.
+- **Streaming empty-turn suppression** only engages when the previous display turn has a trailing activity line of the same role; all other streaming-empty cases keep the current injected-strip behavior (jp70 hardening untouched).
+- **Role-change = boundary** matches the user's rule because a role change paints a visible header between strips; thinking/reasoning are line content, not boundaries.

--- a/docs/plans/2026-08-23-freshagent-activity-line.md
+++ b/docs/plans/2026-08-23-freshagent-activity-line.md
@@ -249,6 +249,36 @@ describe('activity line collapse', () => {
     fireEvent.click(forkButtons[0])
     expect(onFork).toHaveBeenCalledWith('native-a')
   })
+
+  it('treats a zero-item turn as a boundary between tool lines', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          toolTurn('turn-a', [['c1','src/a.ts']]),
+          { id: 'turn-empty', turnId: 'turn-empty', role: 'assistant', summary: '', items: [] },
+          toolTurn('turn-b', [['c2','src/b.ts']]),
+        ]}
+      />,
+    )
+    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+  })
+
+  it('renders both tools when TS-claude duplicate item ids collide across merged turns', () => {
+    render(
+      <FreshAgentTranscript
+        turns={[
+          { id: 'turn-a', turnId: 'turn:msg-1', role: 'assistant', summary: '',
+            items: [{ id: 'turn:msg-1:item:0', kind: 'tool_use', toolUseId: 'toolu_1', name: 'Read', input: { file_path: 'src/a.ts' } }] },
+          { id: 'turn-b', turnId: 'turn:msg-1', role: 'assistant', summary: '',
+            items: [{ id: 'turn:msg-1:item:0', kind: 'tool_use', toolUseId: 'toolu_2', name: 'Read', input: { file_path: 'src/b.ts' } }] },
+        ]}
+      />,
+    )
+    expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('2 tools used')
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle activity details' }))
+    expect(screen.getByText('src/a.ts')).toBeInTheDocument()
+    expect(screen.getByText('src/b.ts')).toBeInTheDocument()
+  })
 })
 ```
 
@@ -264,7 +294,7 @@ Expected: FAIL — the collapse/merge/absorb cases currently render 2/2/2/1+2/mo
 
 In `src/components/fresh-agent/FreshAgentTranscript.tsx`:
 
-(a) After `buildBlocks` (:225), add the transcript-level layout pass:
+(a) After `buildBlocks` (:225), add the transcript-level layout pass. Two validator-driven hardening rules are baked in — see "Validated design notes" at the bottom:
 
 ```ts
 type TurnLayout = { blocks: RenderBlock[] }
@@ -275,6 +305,13 @@ type TurnLayout = { blocks: RenderBlock[] }
  * no message item has rendered between (a role change paints a header, so it
  * counts as "something between"). Lines are re-built from the concatenated
  * item list so buildActivity's tool_use/tool_result stitching stays intact.
+ *
+ * Zero-item turns (Rust codex `subAgentActivity` rows, opencode structural
+ * messages) render real articles today, so they hard-close any open line —
+ * they are "something between" by definition. Absorbed follower items get
+ * display-only id dedupe (TS claude reuses item ids across turns sharing one
+ * provider message id; stitching keys toolUseId, which is verified unique, so
+ * stitching is unaffected — only React keys need this).
  */
 function buildTranscriptLayout(turns: FreshAgentTurn[]): TurnLayout[] {
   const layouts: TurnLayout[] = []
@@ -286,7 +323,9 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): TurnLayout[] {
     if (rows.length > 0) {
       layouts[open.originIndex].blocks.push({
         kind: 'activity',
-        id: open.items.map((item) => item.id).join(':'),
+        // originIndex prefix keeps the join-collision-free guarantee with
+        // duplicated TS-claude item ids.
+        id: `line:${open.originIndex}:${open.items.map((item) => item.id).join(':')}`,
         rows,
       })
     }
@@ -296,11 +335,22 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): TurnLayout[] {
   for (const [turnIndex, turn] of turns.entries()) {
     const layout: TurnLayout = { blocks: [] }
     layouts.push(layout)
+    if (turn.items.length === 0) {
+      flushOpen()
+      continue
+    }
     let messageSeenInTurn = false
     for (const item of turn.items) {
       if (isActivityLike(item)) {
         if (open && open.role === turn.role && !messageSeenInTurn) {
-          open.items.push(item)
+          const taken = new Set(open.items.map((openItem) => openItem.id))
+          let displayItem = item
+          let counter = 2
+          while (taken.has(displayItem.id)) {
+            displayItem = { ...item, id: `${item.id}:d${counter}` }
+            counter += 1
+          }
+          open.items.push(displayItem as FreshAgentTranscriptItem)
         } else {
           flushOpen()
           open = { originIndex: turnIndex, role: turn.role, items: [item] }
@@ -326,21 +376,27 @@ function selectLiveActivityBlockIdFromLayout(
   isStreaming: boolean,
 ): string | null {
   let latestActivityBlockId: string | null = null
-  let lastBlocksTurn = -1
-  layouts.forEach((layout, index) => {
-    if (layout.blocks.length > 0) lastBlocksTurn = index
+  layouts.forEach((layout) => {
     for (const block of layout.blocks) {
       if (block.kind === 'activity') latestActivityBlockId = block.id
     }
   })
-  const lastBlocks = lastBlocksTurn >= 0 ? layouts[lastBlocksTurn].blocks : []
-  const lastBlock = lastBlocks[lastBlocks.length - 1]
-  const trailingThinkingBlockId =
-    lastBlock?.kind === 'activity' && lastBlock.rows.at(-1)?.type === 'thinking'
-      ? lastBlock.id
-      : null
 
-  if (!isStreaming) return trailingThinkingBlockId
+  if (!isStreaming) {
+    // Settled sessions mark only a trailing thinking strip as live. Mirror the
+    // old last-turn rule; when the last turn was absorbed, its items live at
+    // the tail of the latest line, so check that line instead.
+    const lastIndex = turns.length - 1
+    const lastBlocks = lastIndex >= 0 ? layouts[lastIndex].blocks : []
+    const candidate = lastBlocks.length > 0
+      ? lastBlocks[lastBlocks.length - 1]
+      : (turns[lastIndex]?.items.length ?? 0) > 0 && latestActivityBlockId
+        ? [...layouts.flatMap((l) => l.blocks)].at(-1)
+        : null
+    return candidate?.kind === 'activity' && candidate.rows.at(-1)?.type === 'thinking'
+      ? candidate.id
+      : null
+  }
 
   const lastTurn = turns[turns.length - 1]
   if (lastTurn && lastTurn.items.length > 0) return latestActivityBlockId
@@ -491,3 +547,10 @@ git commit -m "docs: mark freshagent-activity-line tasks complete with verificat
 - **Fork/rewind granularity:** a turn fully absorbed into an open line is no longer a fork/rewind target (its article does not render); the line's origin turn is the target. Server fork constraints (composite `turnId`) are honored: we never synthesize composite `turnId`s; the origin turn's own `turnId` is passed through unchanged.
 - **Streaming empty-turn suppression** only engages when the previous display turn has a trailing activity line of the same role; all other streaming-empty cases keep the current injected-strip behavior (jp70 hardening untouched).
 - **Role-change = boundary** matches the user's rule because a role change paints a visible header between strips; thinking/reasoning are line content, not boundaries.
+
+## Validated design notes (load-bearing stage, 2026-08-24)
+
+- **Zero-item turns are real** (Rust codex `subAgentActivity` rows emit `{role:"assistant", summary:"", items:[]}`; opencode structural messages likewise) and they render real article chrome today. The layout pass hard-closes any open line on a zero-item turn — two halves of a codex tool run split by a `subAgentActivity` marker therefore stay two strips. Residual, accepted: fixing THAT split needs a provider-level turn-shape decision, out of scope for this render-rule change.
+- **TS-claude item-id reuse across turns** (one provider message id spanning multiple JSONL lines yields duplicate `turn:<msg>:item:N` ids) is handled by display-only id dedupe in the absorb path; `toolUseId` stitching is verified unique (615MB × 813 real transcripts, zero repeats) and unaffected. Validators: `reports/load-bearing-validator-c2.md`, `reports/load-bearing-validator-n1.md`.
+- **Remount parity:** the merged line's React key changes whenever items append (key = joined display ids) — identical to today's in-turn streaming growth regime; expanded state surviving mid-stream appends is not a regression vector to preserve. Recorded residual.
+- **Non-streaming liveness:** mirrors the old last-turn trailing-thinking rule, extended to cover a last turn that was absorbed (its items close the latest line, so the check reads that line's trailing row).

--- a/docs/plans/2026-08-23-freshagent-activity-line.md
+++ b/docs/plans/2026-08-23-freshagent-activity-line.md
@@ -140,7 +140,7 @@ Do NOT commit. The failing e2e is staged with Task 2's commit once green.
 
 **Interfaces:**
 - Consumes: `FreshAgentTurn`, `FreshAgentTranscriptItem` from `@shared/fresh-agent-contract`; existing `buildActivity`, `isActivityLike`, `FreshAgentActivityStrip`, `FreshAgentTurnArticle`.
-- Produces: `buildTranscriptLayout(turns: FreshAgentTurn[]): { layouts: TurnLayout[]; lineEndIndex: Map<number, number>; tail: { blockId: string; turnIndex: number } | null }` (module-scope pure function, not exported; `lineEndIndex` maps a line's origin-turn index → the index of the line's LAST contributing display turn; `tail` names the last rendered block when it is an activity line), `rendersVisibly(...)`, `selectLiveActivityBlockIdFromLayout(...)`; `FreshAgentTurnArticle` gains `blocks: RenderBlock[]` and `actionTurn: FreshAgentTurn` props and drops its internal `buildBlocks` call.
+- Produces: `buildTranscriptLayout(turns: DisplayTurn[], paintedSummaryKeys: PaintedSummaryStore): { layouts: TurnLayout[]; lineEndIndex: Map<number, number>; tail: { blockId: string; turnIndex: number } | null }` (module-scope pure function, not exported; `lineEndIndex` maps a line's origin-turn index → the index of the line's LAST contributing display turn; `tail` names the last rendered block when it is an activity line), `rendersVisibly(...)`, `summaryIsAuthoredContent(...)`, `recordPaintedSummary(...)`/`paintedSummaryMatches(...)` (per-turnId prefix-matched painted-summary identity), `selectLiveActivityBlockIdFromLayout(...)`; `FreshAgentTurnArticle` gains `blocks: RenderBlock[]` and `actionTurn: FreshAgentTurn` props and drops its internal `buildBlocks` call.
 
 - [x] **Step 1: Write the failing behavioral tests (new unit cases)**
 

--- a/docs/plans/2026-08-23-freshagent-activity-line.md
+++ b/docs/plans/2026-08-23-freshagent-activity-line.md
@@ -47,7 +47,7 @@ In fresh-agent transcripts, adjacent tool-activity lines with nothing rendered b
 - Consumes: existing harness pattern — `page.route('**/api/fresh-agent/threads/freshcodex/codex/<session>*', ...)` fulfilling the snapshot REST call; picker flow via `openPanePicker(page)`; `panes/updatePaneContent` dispatch to point the pane at the seeded session (see the 'style setting persists per Fresh Agent pane type and applies serif rendering' test in the same file for the exact flow).
 - Produces: two failing e2e tests proving the pre-fix behavior (later turned green by Task 2).
 
-- [ ] **Step 1: Write the failing behavioral tests**
+- [x] **Step 1: Write the failing behavioral tests**
 
 Append a new `test.describe('activity line collapse', ...)` block at the end of `test/e2e-browser/specs/fresh-agent.spec.ts`, reusing the same file's picker/*route* seeding pattern:
 
@@ -124,7 +124,7 @@ test.describe('activity line collapse', () => {
 
 The helper prose comments marked `NOTE TO IMPLEMENTER` must be replaced with the actual copied setup code from the serif test (lines ~233–374 of the same file at base).
 
-- [ ] **Step 2: Run the tests and verify the intended failure**
+- [x] **Step 2: Run the tests and verify the intended failure**
 
 Run: `npm run test:e2e -- test/e2e-browser/specs/fresh-agent.spec.ts --grep "activity line collapse"`
 
@@ -142,7 +142,7 @@ Do NOT commit. The failing e2e is staged with Task 2's commit once green.
 - Consumes: `FreshAgentTurn`, `FreshAgentTranscriptItem` from `@shared/fresh-agent-contract`; existing `buildActivity`, `isActivityLike`, `FreshAgentActivityStrip`, `FreshAgentTurnArticle`.
 - Produces: `buildTranscriptLayout(turns: FreshAgentTurn[]): { layouts: TurnLayout[]; lineEndIndex: Map<number, number>; tail: { blockId: string; turnIndex: number } | null }` (module-scope pure function, not exported; `lineEndIndex` maps a line's origin-turn index → the index of the line's LAST contributing display turn; `tail` names the last rendered block when it is an activity line), `rendersVisibly(...)`, `selectLiveActivityBlockIdFromLayout(...)`; `FreshAgentTurnArticle` gains `blocks: RenderBlock[]` and `actionTurn: FreshAgentTurn` props and drops its internal `buildBlocks` call.
 
-- [ ] **Step 1: Write the failing behavioral tests (new unit cases)**
+- [x] **Step 1: Write the failing behavioral tests (new unit cases)**
 
 Add to `test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx` (a new `describe('activity line collapse', ...)`):
 
@@ -361,13 +361,13 @@ describe('activity line collapse', () => {
 
 (Note: thinking items require `showThinking` default true — the component default is `true`; these turns are activity-only thinking runs merging into one line, matching the "second thought" gh-of the old :892 test.)
 
-- [ ] **Step 2: Run the new tests and verify the intended failure**
+- [x] **Step 2: Run the new tests and verify the intended failure**
 
 Run: `npm run test:vitest -- run test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx -t "activity line collapse"`
 
 Expected: FAIL — the collapse/merge/absorb cases currently render 2/2/2/1+2/more strips and articles because strip boundaries are per-turn (per-turn `buildBlocks` in `FreshAgentTurnArticle`, `FreshAgentTranscript.tsx:497`). The 'keeps separate' and 'trailing text' cases may pass already (they assert preserved boundaries).
 
-- [ ] **Step 3: Add the production implementation**
+- [x] **Step 3: Add the production implementation**
 
 In `src/components/fresh-agent/FreshAgentTranscript.tsx`:
 
@@ -587,7 +587,7 @@ Note the article still renders its fallback summary path only when `blocks.lengt
 3. `'keeps adjacent activity-only display turns distinct and actionable'` (:892) — replace with the line-end-fork test from Step 1 (last case); the protection is preserved at line granularity: the single merged article's fork resolves to the line's last contributing turn (`display-activity-2`), delete the old two-article/two-strip assertions.
 4. `'does not show a second running indicator on an earlier turn when the streaming last turn has no displayable items'` (:1179) — new expected behavior: exactly 1 strip total (the injected empty strip is suppressed; the previous turn's line carries the live reel), one `running` indicator, and the settled text `'1 tool used'` is NOT shown while live.
 
-- [ ] **Step 4: Run the focused tests**
+- [x] **Step 4: Run the focused tests**
 
 Run: `npm run test:vitest -- run test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx`
 
@@ -595,11 +595,11 @@ Expected: PASS (all new cases plus the rewritten legacy cases) then:
 Run: `npm run test:e2e -- test/e2e-browser/specs/fresh-agent.spec.ts --grep "activity line collapse"`
 Expected: PASS (Task 1's failing test is now green).
 
-- [ ] **Step 5: Refactor while green**
+- [x] **Step 5: Refactor while green**
 
 Specific cleanups: remove the now-unused `buildBlocks` function IF nothing else uses it (check `selectLiveActivityBlockId`'s replacement consumed the last caller — delete dead code and any now-unused `options` plumbing in `FreshAgentTurnArticle`); dedupe the `messageSeenInTurn` + `flushOpen` sequence if it reads cleaner extracted; keep `buildTranscriptLayout` and the live-selection function adjacent and pure. No behavior change.
 
-- [ ] **Step 6: Run impacted-test verification**
+- [x] **Step 6: Run impacted-test verification**
 
 Impacted set: every spec rendering `FreshAgentTranscript` or its children (the article/strip DOM contract changed: absorbed turns no longer render articles; strip mounting position unchanged otherwise).
 
@@ -611,7 +611,7 @@ Then the e2e surface that touches fresh-agent DOM: `npm run test:e2e -- test/e2e
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit the task**
+- [x] **Step 7: Commit the task**
 
 ```bash
 git add src/components/fresh-agent/FreshAgentTranscript.tsx \
@@ -630,23 +630,23 @@ git commit -m "feat(fresh-agent): collapse adjacent tool activity into one accum
 - Consumes: the Task 2 implementation.
 - Produces: verification receipts for the recap.
 
-- [ ] **Step 1: Reading-time sanity of the browser_use script**
+- [x] **Step 1: Reading-time sanity of the browser_use script**
 
 Verify by inspection (no edit expected) that `test/browser_use/tool_coalesce.py`'s goal ("consecutive tool uses in an assistant turn appear as ONE strip showing 'N tools used'") remains satisfied: within-turn grouping is unchanged, and the script's per-turn lookups still find one strip per message turn. Record the conclusion in the task receipt.
 
-- [ ] **Step 2: Typecheck + lint the touched surface**
+- [x] **Step 2: Typecheck + lint the touched surface**
 
 Run: `npx tsc --noEmit -p .` from the worktree and `npm run lint -- src/components/fresh-agent/FreshAgentTranscript.tsx test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx test/e2e-browser/specs/fresh-agent.spec.ts`
 
 Expected: PASS (eslint-plugin-jsx-a11y clean — no new interactive DOM added).
 
-- [ ] **Step 3: Confirm no other render callers construct turn blocks differently**
+- [x] **Step 3: Confirm no other render callers construct turn blocks differently**
 
 Run: `grep -rn "buildBlocks\|coalesceSyntheticToolResultTurns" src/ test/unit | grep -v FreshAgentTranscript.tsx || true`
 
 Expected: EMPTY output — the transcript test and component are the only references; `FreshAgentView.tsx`/`FreshAgentMobile` consume `FreshAgentTranscript` as a component (no direct block construction). (`|| true` required: empty matches exit 1.)
 
-- [ ] **Step 4: Record outcomes and commit (only if receipts/notes were written as part of the run log)**
+- [x] **Step 4: Record outcomes and commit (only if receipts/notes were written as part of the run log)**
 
 ```bash
 git add docs/plans/2026-08-23-freshagent-activity-line.md

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -247,6 +247,11 @@ function itemEchoes(item: FreshAgentTranscriptItem): string[] {
   push(rec.query)
   push(rec.path)
   push(rec.tool)
+  // Codex image_generation summarizes as its result (normalize.ts); live
+  // claude summarizes a tool_result by its string content
+  // (summarizeFreshAgentItems) — both are plain echoes of the item.
+  push(rec.result)
+  push(rec.content)
   if (typeof rec.server === 'string' && typeof rec.tool === 'string') {
     push(`${rec.server}:${rec.tool}`)
   }
@@ -258,18 +263,50 @@ function itemEchoes(item: FreshAgentTranscriptItem): string[] {
   const kind = typeof rec.kind === 'string' ? rec.kind : ''
   push(SUMMARY_LABEL_BY_KIND[kind])
   if (kind === 'tool_result') {
+    // TS normalizer: 'Tool result'/'Tool error'; Rust claude snapshot:
+    // '[tool result]' (no error variant — claude_snapshot.rs).
     push(rec.isError === true ? 'Tool error' : 'Tool result')
+    push('[tool result]')
   }
   return echoes
 }
+
+/**
+ * A summary segment is an echo when it tiles completely from the turn's item
+ * echoes joined by single spaces — the live claude summarizer space-joins
+ * per-block summaries ('Read Read'), and codex truncates each block summary,
+ * so the final tile may be a prefix of an echo.
+ */
+function segmentMatchesEchoes(segment: string, echoes: string[]): boolean {
+  if (echoes.some((echo) => echo.includes(segment))) return true
+  const n = segment.length
+  const reachable: boolean[] = new Array(n + 1).fill(false)
+  reachable[0] = true
+  for (let i = 0; i < n; i++) {
+    if (!reachable[i]) continue
+    for (const echo of echoes) {
+      if (segment.startsWith(echo, i)) {
+        const end = i + echo.length
+        if (end === n) reachable[n] = true
+        else if (segment[end] === ' ') reachable[end + 1] = true
+      }
+      if (echo.length > n - i && echo.startsWith(segment.slice(i))) {
+        reachable[n] = true
+      }
+    }
+  }
+  return reachable[n]
+}
+
 function summaryIsAuthoredContent(turn: FreshAgentTurn): boolean {
   const summary = typeof turn.summary === 'string' ? turn.summary : ''
   // Synthetic tool-result coalescing joins summaries with blank lines; judge
   // each segment against the turn's items independently.
   const segments = summary.split(/\n+/).map((segment) => segment.trim()).filter(Boolean)
   if (segments.length === 0) return false
-  return turn.items.length === 0
-    || segments.some((segment) => !turn.items.some((item) => itemEchoes(item).some((echo) => echo.includes(segment))))
+  if (turn.items.length === 0) return true
+  const echoes = turn.items.flatMap((item) => itemEchoes(item))
+  return segments.some((segment) => !segmentMatchesEchoes(segment, echoes))
 }
 
 function buildTranscriptLayout(turns: FreshAgentTurn[]): {
@@ -384,23 +421,38 @@ function coalesceSyntheticToolResultTurns(turns: FreshAgentTurn[]): FreshAgentTu
   return coalesced
 }
 
+/**
+ * A turn whose items were all filtered out (e.g. hidden thinking with the
+ * default showThinking=false) still painted its summary while it was the
+ * streaming tail. That summary rendered between the surrounding tool runs,
+ * so once the turn is superseded it must leave a permanent, invisible
+ * boundary: dropping it outright would let the runs retro-collapse and the
+ * rendered summary vanish after the fact. The placeholder keeps the layout
+ * boundary (zero-item turns hard-close an open line) without rendering
+ * anything — the hidden thinking text stays hidden.
+ */
+type DisplayTurn = FreshAgentTurn & { filteredPlaceholder?: true }
+
 function filterTurnsForDisplay(
   turns: FreshAgentTurn[],
   options: TranscriptDisplayOptions,
   isStreaming: boolean,
-): FreshAgentTurn[] {
+): DisplayTurn[] {
   return turns
-    .map((turn, index) => {
+    .map((turn, index): DisplayTurn | null => {
       const items = turn.items.filter((item) => shouldDisplayTranscriptItem(item, options))
       if (turn.items.length > 0 && items.length === 0) {
         if (isStreaming && index === turns.length - 1) {
           return { ...turn, items: [] }
         }
+        if (isStreaming && typeof turn.summary === 'string' && turn.summary.trim().length > 0) {
+          return { ...turn, items: [], summary: '', filteredPlaceholder: true }
+        }
         return null
       }
       return items === turn.items ? turn : { ...turn, items }
     })
-    .filter((turn): turn is FreshAgentTurn => turn !== null)
+    .filter((turn): turn is DisplayTurn => turn !== null)
 }
 
 function normalizeActivityRows(rows: ActivityRow[], live: boolean): ActivityRow[] {
@@ -918,6 +970,9 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
           const absorbed = turn.items.length > 0 && blocksForTurn.length === 0
           const isLastStreaming = isStreaming && index === displayTurns.length - 1
           if (absorbed) return null
+          // Invisible boundary marker: painted its summary as the streaming
+          // tail, now superseded — it separates lines but renders nothing.
+          if (turn.filteredPlaceholder) return null
           if (isLastStreaming && blocksForTurn.length === 0 && turn.items.length === 0 && liveActivityBlockId !== null) return null
           // Fork/rewind/copy resolve to the article line's LAST contributing turn
           // (the most recent point the line covers), so the existing "fork from

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -191,37 +191,98 @@ type RenderBlock =
   | { kind: 'item'; item: FreshAgentTranscriptItem }
   | { kind: 'activity'; id: string; rows: ActivityRow[] }
 
-function buildBlocks(
-  items: FreshAgentTranscriptItem[],
-  options: TranscriptDisplayOptions,
-): RenderBlock[] {
-  const blocks: RenderBlock[] = []
-  let pending: FreshAgentTranscriptItem[] = []
-  const flush = () => {
-    if (pending.length === 0) return
-    const rows = buildActivity(pending)
+type TurnLayout = { blocks: RenderBlock[] }
+
+/** Mirrors FreshAgentItemCard's null-render path for text items: a text item
+ * that renders nothing must not close an open line (nothing visibly between). */
+function rendersVisibly(item: FreshAgentTranscriptItem): boolean {
+  if (item.kind === 'text') return stripSystemReminders(item.text).trim().length > 0
+  return true
+}
+
+/**
+ * One OPEN activity line per transcript state: a next turn's leading
+ * activity items append to the open line when the turn has the same role and
+ * no message item has rendered between (a role change paints a header, so it
+ * counts as "something between"). Lines are re-built from the concatenated
+ * item list so buildActivity's tool_use/tool_result stitching stays intact.
+ *
+ * Line ids use a global per-layout sequence (`line:${n}`), NOT the origin turn
+ * index: one turn can own two lines (`tool → text → tool`), and identical keys
+ * would make React reuse state/DOM across what must stay two separate strips.
+ * The key is stable while a line extends (no new line opens mid-extension), so
+ * the strip keeps its DOM node — the "started in the right place" behavior.
+ *
+ * Zero-item turns (Rust codex `subAgentActivity` rows, opencode structural
+ * messages) render real articles today, so they hard-close any open line —
+ * they are "something between" by definition. Absorbed follower items get
+ * display-only id dedupe (TS claude reuses item ids across turns sharing one
+ * provider message id; stitching keys toolUseId, which is verified unique, so
+ * stitching is unaffected — only React keys need this).
+ */
+function buildTranscriptLayout(turns: FreshAgentTurn[]): {
+  layouts: TurnLayout[]
+  lineEndIndex: Map<number, number>
+  tail: { blockId: string; turnIndex: number } | null
+} {
+  const layouts: TurnLayout[] = []
+  let open: { originIndex: number; role: FreshAgentTurn['role']; items: FreshAgentTranscriptItem[] } | null = null
+  const lineEndIndex = new Map<number, number>()
+  let lineSeq = 0
+
+  const flushOpen = () => {
+    if (!open) return
+    const rows = buildActivity(open.items)
     if (rows.length > 0) {
-      blocks.push({
-        kind: 'activity',
-        id: pending.map((item) => item.id).join(':'),
-        rows,
-      })
+      const id = `line:${lineSeq++}`
+      layouts[open.originIndex].blocks.push({ kind: 'activity', id, rows })
     }
-    pending = []
+    open = null
   }
-  for (const item of items) {
-    if (!shouldDisplayTranscriptItem(item, options)) {
+
+  for (const [turnIndex, turn] of turns.entries()) {
+    const layout: TurnLayout = { blocks: [] }
+    layouts.push(layout)
+    if (turn.items.length === 0) {
+      flushOpen()
       continue
     }
-    if (isActivityLike(item)) {
-      pending.push(item)
-      continue
+    for (const item of turn.items) {
+      if (isActivityLike(item)) {
+        if (open && open.role === turn.role) {
+          const taken = new Set(open.items.map((openItem) => openItem.id))
+          let displayItem = item
+          let counter = 2
+          while (taken.has(displayItem.id)) {
+            displayItem = { ...item, id: `${item.id}:d${counter}` }
+            counter += 1
+          }
+          open.items.push(displayItem as FreshAgentTranscriptItem)
+          lineEndIndex.set(open.originIndex, turnIndex)
+        } else {
+          flushOpen()
+          open = { originIndex: turnIndex, role: turn.role, items: [item] }
+        }
+        continue
+      }
+      if (!rendersVisibly(item)) continue
+      flushOpen()
+      layout.blocks.push({ kind: 'item', item })
     }
-    flush()
-    blocks.push({ kind: 'item', item })
   }
-  flush()
-  return blocks
+  flushOpen()
+
+  // tail = last rendered block overall when it is an activity line; null when
+  // the transcript visibly ends in a message.
+  let tail: { blockId: string; turnIndex: number } | null = null
+  for (let i = layouts.length - 1; i >= 0; i--) {
+    const blocks = layouts[i].blocks
+    if (blocks.length === 0) continue
+    const last = blocks[blocks.length - 1]
+    if (last.kind === 'activity') tail = { blockId: last.id, turnIndex: i }
+    break
+  }
+  return { layouts, lineEndIndex, tail }
 }
 
 function isSyntheticToolResultTurn(turn: FreshAgentTurn): boolean {
@@ -304,38 +365,54 @@ function normalizeActivityRows(rows: ActivityRow[], live: boolean): ActivityRow[
   return changed ? settledRows : rows
 }
 
-function selectLiveActivityBlockId(
+function selectLiveActivityBlockIdFromLayout(
+  layouts: TurnLayout[],
   turns: FreshAgentTurn[],
   isStreaming: boolean,
-  options: TranscriptDisplayOptions,
+  tail: { blockId: string; turnIndex: number } | null,
 ): string | null {
   let latestActivityBlockId: string | null = null
-  let latestTrailingThinkingBlockId: string | null = null
-
-  turns.forEach((turn, turnIndex) => {
-    const blocks = buildBlocks(turn.items, options)
-    for (const block of blocks) {
-      if (block.kind === 'activity') {
-        latestActivityBlockId = block.id
-      }
-    }
-
-    if (turnIndex === turns.length - 1) {
-      const lastBlock = blocks[blocks.length - 1]
-      if (lastBlock?.kind === 'activity' && lastBlock.rows.at(-1)?.type === 'thinking') {
-        latestTrailingThinkingBlockId = lastBlock.id
-      }
+  layouts.forEach((layout) => {
+    for (const block of layout.blocks) {
+      if (block.kind === 'activity') latestActivityBlockId = block.id
     }
   })
 
-  if (isStreaming) {
-    const lastTurn = turns[turns.length - 1]
-    if (lastTurn && !lastTurn.items.some((item) => shouldDisplayTranscriptItem(item, options))) {
-      return null
-    }
-    return latestActivityBlockId
+  const lastIndex = turns.length - 1
+  const lastTurn = turns[lastIndex]
+
+  if (!isStreaming) {
+    // Settled sessions mark only a trailing thinking strip as live. Mirror the
+    // old last-turn rule; when the last turn was absorbed, its items live at
+    // the tail of the latest line, so check that line instead.
+    const blocks = lastIndex >= 0 ? layouts[lastIndex].blocks : []
+    const lastBlock = blocks.length > 0 ? blocks[blocks.length - 1] : null
+    const candidateId = lastBlock?.kind === 'activity'
+      ? lastBlock.id
+      : (lastTurn?.items.length ?? 0) > 0 && tail && tail.turnIndex < lastIndex
+        ? tail.blockId
+        : null
+    if (!candidateId) return null
+    const candidate = [...layouts.flatMap((l) => l.blocks)].find((b) => b.kind === 'activity' && b.id === candidateId)
+    return candidate?.kind === 'activity' && candidate.rows.at(-1)?.type === 'thinking'
+      ? candidate.id
+      : null
   }
-  return latestTrailingThinkingBlockId
+
+  if (lastTurn && lastTurn.items.length > 0) return latestActivityBlockId
+  if (!lastTurn || !tail) return null
+
+  // Last display turn streams with zero visible items: hand liveness to the
+  // trailing line when nothing rendered between them (intermediate turns were
+  // absorbed into that line; a zero-item or message intermediate is a real
+  // boundary) and roles match the whole way across.
+  const absorbedOnly = turns.slice(tail.turnIndex + 1, lastIndex)
+    .every((turn, offset) =>
+      turn.items.length > 0 && layouts[tail.turnIndex + 1 + offset].blocks.length === 0)
+  if (absorbedOnly && turns[tail.turnIndex].role === lastTurn.role) {
+    return tail.blockId
+  }
+  return null
 }
 
 function FreshAgentThinkingRow({ text }: { text: string }) {
@@ -470,6 +547,8 @@ type TurnActionProps = {
 
 function FreshAgentTurnArticle({
   turn,
+  actionTurn,
+  blocks,
   actions,
   agentLabel,
   showTimecodes,
@@ -477,11 +556,14 @@ function FreshAgentTurnArticle({
   showHeader,
   continuation,
   liveActivityBlockId,
-  displayOptions,
   isStreamingLastTurn,
   index,
 }: {
   turn: FreshAgentTurn
+  /** Turn the action affordances target — the line's LAST contributing turn
+   * when this article's activity line absorbed later turns, else `turn`. */
+  actionTurn: FreshAgentTurn
+  blocks: RenderBlock[]
   actions: TurnActionProps
   agentLabel?: string
   showTimecodes: boolean
@@ -489,12 +571,10 @@ function FreshAgentTurnArticle({
   showHeader: boolean
   continuation: boolean
   liveActivityBlockId: string | null
-  displayOptions: TranscriptDisplayOptions
   isStreamingLastTurn: boolean
   index: number
 }) {
   const isUser = turn.role === 'user'
-  const blocks = buildBlocks(turn.items, displayOptions)
   const turnLabel = getTurnLabel(turn, agentLabel)
   const timecode = formatTurnTimecode(turn.timestamp)
   // Long-press opens the action sheet on touch devices (iOS fires no
@@ -502,9 +582,9 @@ function FreshAgentTurnArticle({
   // the second call is a no-op re-set of the same state).
   const longPress = useMemo(() => (
     actions.onOpenActions
-      ? buildLongPressHandlers<HTMLElement>(() => actions.onOpenActions?.(turn))
+      ? buildLongPressHandlers<HTMLElement>(() => actions.onOpenActions?.(actionTurn))
       : null
-  ), [actions, turn])
+  ), [actions, actionTurn])
   return (
     <article
       className={cn(
@@ -522,18 +602,18 @@ function FreshAgentTurnArticle({
         if (actions.onOpenActions) {
           event.preventDefault()
           event.stopPropagation()
-          actions.onOpenActions(turn)
+          actions.onOpenActions(actionTurn)
           return
         }
         if (!actions.onTurnContextMenu) return
         event.preventDefault()
         event.stopPropagation()
-        actions.onTurnContextMenu(event, turn)
+        actions.onTurnContextMenu(event, actionTurn)
       }}
       {...(longPress ?? {})}
     >
       <FreshAgentTurnActions
-        turn={turn}
+        turn={actionTurn}
         canFork={actions.canFork}
         onForkFromTurn={actions.onForkFromTurn}
         onRewindToTurn={actions.onRewindToTurn}
@@ -570,7 +650,7 @@ function FreshAgentTurnArticle({
           // showed literal backticks (live-test finding) — render markdown.
           <FreshAgentMarkdownBody text={turn.summary ?? ''} />
         )}
-        {isStreamingLastTurn && blocks.length === 0 ? (
+        {isStreamingLastTurn && blocks.length === 0 && liveActivityBlockId === null ? (
           <FreshAgentActivityStrip rows={[]} live initialExpanded={showTools} />
         ) : null}
       </div>
@@ -632,9 +712,10 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
   const displayTurns = useMemo(() => (
     filterTurnsForDisplay(coalesceSyntheticToolResultTurns(turns), displayOptions, isStreaming)
   ), [displayOptions, turns, isStreaming])
+  const { layouts: turnLayouts, lineEndIndex, tail } = useMemo(() => buildTranscriptLayout(displayTurns), [displayTurns])
   const liveActivityBlockId = useMemo(
-    () => selectLiveActivityBlockId(displayTurns, isStreaming, displayOptions),
-    [displayOptions, displayTurns, isStreaming],
+    () => selectLiveActivityBlockIdFromLayout(turnLayouts, displayTurns, isStreaming, tail),
+    [turnLayouts, displayTurns, isStreaming, tail],
   )
   const transcriptSignature = useMemo(() => (
     displayTurns.map((turn) => {
@@ -762,22 +843,34 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
           recomputeGlom()
         }}
       >
-        {displayTurns.map((turn, index) => (
-          <FreshAgentTurnArticle
-            key={`${getFreshAgentDisplayTurnKey(turn)}:${index}`}
-            turn={turn}
-            actions={actions}
-            agentLabel={agentLabel}
-            showTimecodes={resolvedShowTimecodes}
-            showTools={showTools}
-            showHeader={index === 0 || displayTurns[index - 1]?.role !== turn.role}
-            continuation={index > 0 && displayTurns[index - 1]?.role === turn.role}
-            liveActivityBlockId={liveActivityBlockId}
-            displayOptions={displayOptions}
-            isStreamingLastTurn={isStreaming && index === displayTurns.length - 1}
-            index={index}
-          />
-        ))}
+        {displayTurns.map((turn, index) => {
+          const blocksForTurn = turnLayouts[index]?.blocks ?? []
+          const absorbed = turn.items.length > 0 && blocksForTurn.length === 0
+          const isLastStreaming = isStreaming && index === displayTurns.length - 1
+          if (absorbed) return null
+          if (isLastStreaming && blocksForTurn.length === 0 && turn.items.length === 0 && liveActivityBlockId !== null) return null
+          // Fork/rewind/copy resolve to the article line's LAST contributing turn
+          // (the most recent point the line covers), so the existing "fork from
+          // the latest activity turn" protection survives merging.
+          const actionTurn = displayTurns[lineEndIndex.get(index) ?? index]
+          return (
+            <FreshAgentTurnArticle
+              key={`${getFreshAgentDisplayTurnKey(turn)}:${index}`}
+              turn={turn}
+              actionTurn={actionTurn}
+              blocks={blocksForTurn}
+              actions={actions}
+              agentLabel={agentLabel}
+              showTimecodes={resolvedShowTimecodes}
+              showTools={showTools}
+              showHeader={index === 0 || displayTurns[index - 1]?.role !== turn.role}
+              continuation={index > 0 && displayTurns[index - 1]?.role === turn.role}
+              liveActivityBlockId={liveActivityBlockId}
+              isStreamingLastTurn={isLastStreaming}
+              index={index}
+            />
+          )
+        })}
       </div>
       {glomTarget ? (
         <button

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -220,6 +220,58 @@ function rendersVisibly(item: FreshAgentTranscriptItem): boolean {
  * provider message id; stitching keys toolUseId, which is verified unique, so
  * stitching is unaffected — only React keys need this).
  */
+/*
+ * A non-empty turn summary is either an echo of one of the turn's own items
+ * (codex builds tool-row summaries from the first item — `summarize_codex_items`
+ * maps tool_use→name, command→command text, mcp_tool→"server:tool", etc.) or
+ * authored content with no item counterpart (e.g. claude keeps thinking text as
+ * the summary after a tool arrives, which the summary fallback paints while the
+ * turn is still empty). Only the authored kind is "something between" the tool
+ * runs: it can render, so the runs behind it are permanently separated — even
+ * later, when blocks exist and the base fallback no longer paints the summary.
+ * Echo summaries carry no extra rendering, so they never block a merge.
+ */
+const SUMMARY_LABEL_BY_KIND: Record<string, string> = {
+  file_change: 'File change',
+  context_compaction: 'Context compacted',
+}
+function itemEchoes(item: FreshAgentTranscriptItem): string[] {
+  const echoes: string[] = []
+  const push = (value: unknown) => {
+    if (typeof value === 'string' && value.trim().length > 0) echoes.push(value)
+  }
+  const rec = item as unknown as Record<string, unknown>
+  push(rec.text)
+  push(rec.name)
+  push(rec.command)
+  push(rec.query)
+  push(rec.path)
+  push(rec.tool)
+  if (typeof rec.server === 'string' && typeof rec.tool === 'string') {
+    push(`${rec.server}:${rec.tool}`)
+  }
+  if (typeof rec.event === 'string') push(`${rec.event} review mode`)
+  const joinStrings = (value: unknown) =>
+    Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string').join('\n') : ''
+  push(joinStrings(rec.summary))
+  push(joinStrings(rec.content))
+  const kind = typeof rec.kind === 'string' ? rec.kind : ''
+  push(SUMMARY_LABEL_BY_KIND[kind])
+  if (kind === 'tool_result') {
+    push(rec.isError === true ? 'Tool error' : 'Tool result')
+  }
+  return echoes
+}
+function summaryIsAuthoredContent(turn: FreshAgentTurn): boolean {
+  const summary = typeof turn.summary === 'string' ? turn.summary : ''
+  // Synthetic tool-result coalescing joins summaries with blank lines; judge
+  // each segment against the turn's items independently.
+  const segments = summary.split(/\n+/).map((segment) => segment.trim()).filter(Boolean)
+  if (segments.length === 0) return false
+  return turn.items.length === 0
+    || segments.some((segment) => !turn.items.some((item) => itemEchoes(item).some((echo) => echo.includes(segment))))
+}
+
 function buildTranscriptLayout(turns: FreshAgentTurn[]): {
   layouts: TurnLayout[]
   lineEndIndex: Map<number, number>
@@ -249,7 +301,10 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): {
     }
     for (const item of turn.items) {
       if (isActivityLike(item)) {
-        if (open && open.role === turn.role) {
+        // The authored-summary guard applies only to absorbing into a PREVIOUS
+        // turn's line. Once this turn has opened its own line, its later
+        // activity items chain into it normally.
+        if (open && open.role === turn.role && (open.originIndex === turnIndex || !summaryIsAuthoredContent(turn))) {
           const taken = new Set(open.items.map((openItem) => openItem.id))
           let displayItem = item
           let counter = 2

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -312,7 +312,7 @@ function summaryIsAuthoredContent(turn: DisplayTurn): boolean {
 
 function buildTranscriptLayout(
   turns: DisplayTurn[],
-  paintedSummaryKeys: ReadonlySet<string>,
+  paintedSummaryKeys: PaintedSummaryStore,
 ): {
   layouts: TurnLayout[]
   lineEndIndex: Map<number, number>
@@ -355,7 +355,7 @@ function buildTranscriptLayout(
           && open.role === turn.role
           && (
             open.originIndex === turnIndex
-            || (!paintedSummaryKeys.has(paintedSummaryKey(turn)) && !summaryIsAuthoredContent(turn))
+            || (!paintedSummaryMatches(paintedSummaryKeys, turn) && !summaryIsAuthoredContent(turn))
           )
         ) {
           const taken = new Set(open.items.map((openItem) => openItem.id))
@@ -465,20 +465,46 @@ type DisplayTurn = FreshAgentTurn & {
 }
 
 /**
- * Painted-summary identity. turnId alone is insufficient: validated claude
- * data permits multiple display turns sharing one turnId (one provider
- * message spanning JSONL rows), so the summary text scopes the key —
- * painting one occurrence must not mark a different occurrence as painted.
+ * Painted-summary identity: per-turnId list of summaries this view has
+ * rendered for that turn. Two failure shapes pull in opposite directions and
+ * this structure holds both:
+ * - Streaming summaries GROW (accumulated OpenCode reasoning parts, etc.):
+ *   'Considering' paints, then becomes 'Considering options'. Matching uses a
+ *   prefix relation, so the grown summary still inherits its painted
+ *   boundary (a painted boundary must be permanent across frames).
+ * - Validated claude data permits duplicate display turnIds across JSONL
+ *   rows: painting 'First thought' must not mark a different occurrence
+ *   whose summary 'Second thought' never painted (no prefix relation).
  */
-function paintedSummaryKey(turn: Pick<FreshAgentTurn, 'turnId' | 'id' | 'summary'>): string {
-  return `${getFreshAgentDisplayTurnKey(turn)}:${(turn.summary ?? '').trim()}`
+type PaintedSummaryStore = ReadonlyMap<string, readonly string[]>
+
+function recordPaintedSummary(
+  store: Map<string, string[]>,
+  turn: Pick<FreshAgentTurn, 'turnId' | 'id' | 'summary'>,
+): void {
+  const summary = (turn.summary ?? '').trim()
+  if (!summary) return
+  const key = getFreshAgentDisplayTurnKey(turn)
+  const list = store.get(key) ?? []
+  if (!list.includes(summary)) list.push(summary)
+  store.set(key, list)
+}
+
+function paintedSummaryMatches(
+  store: PaintedSummaryStore,
+  turn: Pick<FreshAgentTurn, 'turnId' | 'id' | 'summary'>,
+): boolean {
+  const summary = (turn.summary ?? '').trim()
+  if (!summary) return false
+  const painted = store.get(getFreshAgentDisplayTurnKey(turn))
+  return painted?.some((p) => p === summary || p.startsWith(summary) || summary.startsWith(p)) ?? false
 }
 
 function filterTurnsForDisplay(
   turns: FreshAgentTurn[],
   options: TranscriptDisplayOptions,
   isStreaming: boolean,
-  paintedSummaryKeys: ReadonlySet<string>,
+  paintedSummaryKeys: PaintedSummaryStore,
 ): DisplayTurn[] {
   return turns
     .map((turn, index): DisplayTurn | null => {
@@ -487,7 +513,7 @@ function filterTurnsForDisplay(
         if (isStreaming && index === turns.length - 1) {
           return { ...turn, items: [] }
         }
-        if (paintedSummaryKeys.has(paintedSummaryKey(turn))) {
+        if (paintedSummaryMatches(paintedSummaryKeys, turn)) {
           return { ...turn, items: [], summary: '', filteredPlaceholder: true }
         }
         return null
@@ -877,7 +903,7 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
   // Keys of summaries this mounted view has actually painted (see the
   // recording effect below). Feeds the placeholder boundary so it survives
   // the busy→idle isStreaming flip without blocking settled-history merges.
-  const paintedSummaryKeysRef = useRef<Set<string>>(new Set())
+  const paintedSummaryKeysRef = useRef<Map<string, string[]>>(new Map())
   const displayTurns = useMemo(() => (
     filterTurnsForDisplay(
       coalesceSyntheticToolResultTurns(turns),
@@ -904,7 +930,7 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
       if (typeof turn.summary !== 'string' || turn.summary.trim().length === 0) return
       const isLastStreaming = isStreaming && index === displayTurns.length - 1
       if (isLastStreaming && liveActivityBlockId !== null) return
-      painted.add(paintedSummaryKey(turn))
+      recordPaintedSummary(painted, turn)
     })
   }, [displayTurns, isStreaming, liveActivityBlockId])
   const transcriptSignature = useMemo(() => (

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -298,18 +298,22 @@ function segmentMatchesEchoes(segment: string, echoes: string[]): boolean {
   return reachable[n]
 }
 
-function summaryIsAuthoredContent(turn: FreshAgentTurn): boolean {
+function summaryIsAuthoredContent(turn: DisplayTurn): boolean {
   const summary = typeof turn.summary === 'string' ? turn.summary : ''
   // Synthetic tool-result coalescing joins summaries with blank lines; judge
   // each segment against the turn's items independently.
   const segments = summary.split(/\n+/).map((segment) => segment.trim()).filter(Boolean)
   if (segments.length === 0) return false
-  if (turn.items.length === 0) return true
-  const echoes = turn.items.flatMap((item) => itemEchoes(item))
+  const sourceItems = turn.echoItems ?? turn.items
+  if (sourceItems.length === 0) return true
+  const echoes = sourceItems.flatMap((item) => itemEchoes(item))
   return segments.some((segment) => !segmentMatchesEchoes(segment, echoes))
 }
 
-function buildTranscriptLayout(turns: FreshAgentTurn[]): {
+function buildTranscriptLayout(
+  turns: DisplayTurn[],
+  paintedSummaryKeys: ReadonlySet<string>,
+): {
   layouts: TurnLayout[]
   lineEndIndex: Map<number, number>
   tail: { blockId: string; turnIndex: number } | null
@@ -338,10 +342,22 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): {
     }
     for (const item of turn.items) {
       if (isActivityLike(item)) {
-        // The authored-summary guard applies only to absorbing into a PREVIOUS
-        // turn's line. Once this turn has opened its own line, its later
-        // activity items chain into it normally.
-        if (open && open.role === turn.role && (open.originIndex === turnIndex || !summaryIsAuthoredContent(turn))) {
+        // The boundary guards apply only to absorbing into a PREVIOUS turn's
+        // line. Once this turn has opened its own line, its later activity
+        // items chain into it normally. Two cross-turn boundaries: an
+        // authored summary (no echo among the turn's items), and a summary
+        // this view already PAINTED — the echo verdict is recomputed from
+        // current items each frame, so a painted summary that later gains an
+        // echoing item must still hold its boundary or the lines
+        // retro-collapse across content that rendered.
+        if (
+          open
+          && open.role === turn.role
+          && (
+            open.originIndex === turnIndex
+            || (!paintedSummaryKeys.has(paintedSummaryKey(turn)) && !summaryIsAuthoredContent(turn))
+          )
+        ) {
           const taken = new Set(open.items.map((openItem) => openItem.id))
           let displayItem = item
           let counter = 2
@@ -437,7 +453,26 @@ function coalesceSyntheticToolResultTurns(turns: FreshAgentTurn[]): FreshAgentTu
  * every later frame, while a transcript mounted already-settled — where the
  * hidden summary never rendered — still collapses freely.
  */
-type DisplayTurn = FreshAgentTurn & { filteredPlaceholder?: true }
+type DisplayTurn = FreshAgentTurn & {
+  filteredPlaceholder?: true
+  /** Pre-filter items, attached when display filtering dropped any. Echo
+   * classification judges the summary against everything the turn CONTAINS —
+   * hidden thinking is part of production summaries (live: space-joined with
+   * the tool name; Rust snapshot: the thinking text itself), and the summary
+   * never renders when an activity block does, so hidden items must still
+   * count as echoes or the common claude thinking→tool turn can never merge. */
+  echoItems?: FreshAgentTranscriptItem[]
+}
+
+/**
+ * Painted-summary identity. turnId alone is insufficient: validated claude
+ * data permits multiple display turns sharing one turnId (one provider
+ * message spanning JSONL rows), so the summary text scopes the key —
+ * painting one occurrence must not mark a different occurrence as painted.
+ */
+function paintedSummaryKey(turn: Pick<FreshAgentTurn, 'turnId' | 'id' | 'summary'>): string {
+  return `${getFreshAgentDisplayTurnKey(turn)}:${(turn.summary ?? '').trim()}`
+}
 
 function filterTurnsForDisplay(
   turns: FreshAgentTurn[],
@@ -452,12 +487,13 @@ function filterTurnsForDisplay(
         if (isStreaming && index === turns.length - 1) {
           return { ...turn, items: [] }
         }
-        if (paintedSummaryKeys.has(getFreshAgentDisplayTurnKey(turn))) {
+        if (paintedSummaryKeys.has(paintedSummaryKey(turn))) {
           return { ...turn, items: [], summary: '', filteredPlaceholder: true }
         }
         return null
       }
-      return items === turn.items ? turn : { ...turn, items }
+      if (items.length === turn.items.length) return turn
+      return { ...turn, items, echoItems: turn.items }
     })
     .filter((turn): turn is DisplayTurn => turn !== null)
 }
@@ -850,7 +886,10 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
       paintedSummaryKeysRef.current,
     )
   ), [displayOptions, turns, isStreaming])
-  const { layouts: turnLayouts, lineEndIndex, tail } = useMemo(() => buildTranscriptLayout(displayTurns), [displayTurns])
+  const { layouts: turnLayouts, lineEndIndex, tail } = useMemo(
+    () => buildTranscriptLayout(displayTurns, paintedSummaryKeysRef.current),
+    [displayTurns],
+  )
   const liveActivityBlockId = useMemo(
     () => selectLiveActivityBlockIdFromLayout(turnLayouts, displayTurns, isStreaming, tail),
     [turnLayouts, displayTurns, isStreaming, tail],
@@ -865,7 +904,7 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
       if (typeof turn.summary !== 'string' || turn.summary.trim().length === 0) return
       const isLastStreaming = isStreaming && index === displayTurns.length - 1
       if (isLastStreaming && liveActivityBlockId !== null) return
-      painted.add(getFreshAgentDisplayTurnKey(turn))
+      painted.add(paintedSummaryKey(turn))
     })
   }, [displayTurns, isStreaming, liveActivityBlockId])
   const transcriptSignature = useMemo(() => (

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -430,6 +430,12 @@ function coalesceSyntheticToolResultTurns(turns: FreshAgentTurn[]): FreshAgentTu
  * rendered summary vanish after the fact. The placeholder keeps the layout
  * boundary (zero-item turns hard-close an open line) without rendering
  * anything — the hidden thinking text stays hidden.
+ *
+ * Permanence is scoped to what THIS mounted view actually painted: the
+ * caller passes the keys of summaries rendered so far (recorded from the
+ * render loop), so the boundary survives the busy→idle isStreaming flip and
+ * every later frame, while a transcript mounted already-settled — where the
+ * hidden summary never rendered — still collapses freely.
  */
 type DisplayTurn = FreshAgentTurn & { filteredPlaceholder?: true }
 
@@ -437,6 +443,7 @@ function filterTurnsForDisplay(
   turns: FreshAgentTurn[],
   options: TranscriptDisplayOptions,
   isStreaming: boolean,
+  paintedSummaryKeys: ReadonlySet<string>,
 ): DisplayTurn[] {
   return turns
     .map((turn, index): DisplayTurn | null => {
@@ -445,7 +452,7 @@ function filterTurnsForDisplay(
         if (isStreaming && index === turns.length - 1) {
           return { ...turn, items: [] }
         }
-        if (isStreaming && typeof turn.summary === 'string' && turn.summary.trim().length > 0) {
+        if (paintedSummaryKeys.has(getFreshAgentDisplayTurnKey(turn))) {
           return { ...turn, items: [], summary: '', filteredPlaceholder: true }
         }
         return null
@@ -831,14 +838,36 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
   const displayOptions = useMemo<TranscriptDisplayOptions>(() => ({
     showThinking,
   }), [showThinking])
+  // Keys of summaries this mounted view has actually painted (see the
+  // recording effect below). Feeds the placeholder boundary so it survives
+  // the busy→idle isStreaming flip without blocking settled-history merges.
+  const paintedSummaryKeysRef = useRef<Set<string>>(new Set())
   const displayTurns = useMemo(() => (
-    filterTurnsForDisplay(coalesceSyntheticToolResultTurns(turns), displayOptions, isStreaming)
+    filterTurnsForDisplay(
+      coalesceSyntheticToolResultTurns(turns),
+      displayOptions,
+      isStreaming,
+      paintedSummaryKeysRef.current,
+    )
   ), [displayOptions, turns, isStreaming])
   const { layouts: turnLayouts, lineEndIndex, tail } = useMemo(() => buildTranscriptLayout(displayTurns), [displayTurns])
   const liveActivityBlockId = useMemo(
     () => selectLiveActivityBlockIdFromLayout(turnLayouts, displayTurns, isStreaming, tail),
     [turnLayouts, displayTurns, isStreaming, tail],
   )
+  // Record every zero-item summary that reached an article (mirrors the
+  // render loop's skip conditions) so a later frame can leave a placeholder
+  // boundary where the summary once painted.
+  useEffect(() => {
+    const painted = paintedSummaryKeysRef.current
+    displayTurns.forEach((turn, index) => {
+      if (turn.filteredPlaceholder || turn.items.length > 0) return
+      if (typeof turn.summary !== 'string' || turn.summary.trim().length === 0) return
+      const isLastStreaming = isStreaming && index === displayTurns.length - 1
+      if (isLastStreaming && liveActivityBlockId !== null) return
+      painted.add(getFreshAgentDisplayTurnKey(turn))
+    })
+  }, [displayTurns, isStreaming, liveActivityBlockId])
   const transcriptSignature = useMemo(() => (
     displayTurns.map((turn) => {
       const itemSignature = turn.items.map((item) => {

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -265,7 +265,17 @@ function buildTranscriptLayout(turns: FreshAgentTurn[]): {
         }
         continue
       }
-      if (!rendersVisibly(item)) continue
+      if (!rendersVisibly(item)) {
+        // Invisible content only. Same-role turns merge freely (nothing renders
+        // between the lines). A different-role turn still paints its header, so
+        // it closes the open line and keeps its (invisible-bodied) block,
+        // matching the pre-change renderer's chrome.
+        if (open && turn.role !== open.role) {
+          flushOpen()
+          layout.blocks.push({ kind: 'item', item })
+        }
+        continue
+      }
       flushOpen()
       layout.blocks.push({ kind: 'item', item })
     }
@@ -401,6 +411,11 @@ function selectLiveActivityBlockIdFromLayout(
 
   if (lastTurn && lastTurn.items.length > 0) return latestActivityBlockId
   if (!lastTurn || !tail) return null
+  // A summary-only last turn renders its own article (summary markdown plus
+  // the injected live strip); handing liveness to the tail line would skip
+  // that article and hide the summary. A rendered summary is a message — it
+  // closes the line.
+  if (lastTurn.summary && lastTurn.summary.trim().length > 0) return null
 
   // Last display turn streams with zero visible items: hand liveness to the
   // trailing line when nothing rendered between them (intermediate turns were

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -1002,3 +1002,146 @@ test.describe('Fresh Agent', () => {
     await expect(page.getByText(/feature\/fresh-agent/)).toBeVisible()
   })
 })
+
+test.describe('activity line collapse', () => {
+  async function seedCollapsePane(
+    page: Parameters<typeof openPanePicker>[0],
+    terminal: { waitForTerminal: () => Promise<void> },
+    sessionId: string,
+    turns: unknown[],
+  ) {
+    // Mirrors the setup of the 'style setting persists per Fresh Agent pane type
+    // and applies serif rendering' test above (freshcodex picker flow, routed
+    // snapshot, leaf-walk + panes/updatePaneContent dispatch), minus the style
+    // filter and style-specific seeded content.
+    await terminal.waitForTerminal()
+    await enableClaudeAndCodex(page)
+
+    const picker = await openPanePicker(page)
+    await suppressFreshAgentNetworkForActivePane(page)
+    await picker.getByRole('button', { name: /^Freshcodex$/i }).click({ force: true })
+    await page.getByRole('option').first().click()
+    // The picker selection lands in the panes store a beat before/after the
+    // fresh-agent pane mounts; wait for the pane before seeding its session.
+    await expect(page.locator('[data-context="fresh-agent"]').last()).toBeVisible({ timeout: 10_000 })
+
+    const lastTurnId = (turns[turns.length - 1] as { id?: string } | undefined)?.id ?? ''
+    await page.route(`**/api/fresh-agent/threads/freshcodex/codex/${sessionId}*`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          sessionType: 'freshcodex',
+          provider: 'codex',
+          threadId: sessionId,
+          sessionId,
+          revision: 1,
+          latestTurnId: lastTurnId,
+          status: 'idle',
+          summary: '',
+          capabilities: { send: true, interrupt: true, approvals: true, questions: true, fork: true },
+          settings: { model: 'gpt-5.4-flash', permissionMode: 'on-request', effort: 'high', plugins: [] },
+          tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 },
+          pendingApprovals: [],
+          pendingQuestions: [],
+          worktrees: [],
+          diffs: [],
+          turns,
+        }),
+      })
+    })
+    await expect.poll(async () => page.evaluate((sid) => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      const state = harness?.getState()
+      const findFreshcodexLeaf = (node: any): any => {
+        if (!node) return null
+        if (
+          node.type === 'leaf'
+          && node.content?.kind === 'fresh-agent'
+          && node.content.sessionType === 'freshcodex'
+        ) {
+          return node
+        }
+        if (node.type === 'split') {
+          return findFreshcodexLeaf(node.children?.[0]) ?? findFreshcodexLeaf(node.children?.[1])
+        }
+        return null
+      }
+      let tabId: string | null = null
+      let leaf: any = null
+      for (const [candidateTabId, layout] of Object.entries(state?.panes?.layouts ?? {})) {
+        const candidateLeaf = findFreshcodexLeaf(layout)
+        if (candidateLeaf) {
+          tabId = candidateTabId
+          leaf = candidateLeaf
+        }
+      }
+      if (!tabId || !leaf) return false
+      harness?.dispatch({
+        type: 'panes/updatePaneContent',
+        payload: {
+          tabId,
+          paneId: leaf.id,
+          content: {
+            ...leaf.content,
+            sessionId: sid,
+            sessionRef: { provider: 'codex', sessionId: sid },
+            resumeSessionId: sid,
+            status: 'idle',
+            settingsDismissed: true,
+          },
+        },
+      })
+      return true
+    }, sessionId), { timeout: 10_000 }).toBe(true)
+  }
+
+  function toolTurn(turnId: string, calls: Array<[string, string]>) {
+    // calls: [callId, filePath] pairs; produces an assistant turn whose items are
+    // tool_use(toolUseId=callId, name:'Read', input:{file_path}) followed by its
+    // tool_result(content:'ok').
+    return {
+      id: turnId,
+      turnId,
+      role: 'assistant',
+      summary: '',
+      items: calls.flatMap(([callId, filePath]) => [
+        { id: `tool-${callId}`, kind: 'tool_use', toolUseId: callId, name: 'Read', input: { file_path: filePath } },
+        { id: `result-${callId}`, kind: 'tool_result', toolUseId: callId, content: 'ok', isError: false },
+      ]),
+    }
+  }
+
+  test('collapses adjacent same-role tool turns into one accumulating activity line (3 + 2 = 5)', async ({ freshellPage: _freshellPage, page, harness: _harness, terminal }) => {
+    await seedCollapsePane(page, terminal, 'collapse-thread', [
+      { id: 'turn-user', turnId: 'turn-user', role: 'user', summary: 'read files',
+        items: [{ id: 'item-user', kind: 'text', text: 'read these five files' }] },
+      toolTurn('turn-a', [['c1', 'src/a.ts'], ['c2', 'src/b.ts'], ['c3', 'src/c.ts']]),
+      toolTurn('turn-b', [['c4', 'src/d.ts'], ['c5', 'src/e.ts']]),
+    ])
+    const pane = page.locator('[data-context="fresh-agent"]').last()
+    await expect(pane).toBeVisible({ timeout: 10_000 })
+    const strips = pane.getByRole('region', { name: 'Activity strip' })
+    await expect(strips).toHaveCount(1)
+    await expect(strips.first()).toContainText('5 tools used')
+    await pane.getByRole('button', { name: 'Toggle activity details' }).click()
+    await expect(pane.getByRole('button', { name: 'Read tool call' })).toHaveCount(5)
+    await expect(pane.getByText('src/a.ts')).toBeVisible()
+    await expect(pane.getByText('src/e.ts')).toBeVisible()
+  })
+
+  test('an intervening message keeps two tool lines separate', async ({ freshellPage: _freshellPage, page, harness: _harness, terminal }) => {
+    await seedCollapsePane(page, terminal, 'split-thread', [
+      toolTurn('turn-a', [['c1', 'src/a.ts']]),
+      { id: 'turn-msg', turnId: 'turn-msg', role: 'assistant', summary: 'note',
+        items: [{ id: 'item-msg', kind: 'text', text: 'First file read.' }] },
+      toolTurn('turn-b', [['c2', 'src/b.ts']]),
+    ])
+    const pane = page.locator('[data-context="fresh-agent"]').last()
+    await expect(pane).toBeVisible({ timeout: 10_000 })
+    const strips = pane.getByRole('region', { name: 'Activity strip' })
+    await expect(strips).toHaveCount(2)
+    await expect(strips.nth(0)).toContainText('1 tool used')
+    await expect(strips.nth(1)).toContainText('1 tool used')
+  })
+})

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -1112,7 +1112,7 @@ test.describe('activity line collapse', () => {
     }
   }
 
-  test('collapses adjacent same-role tool turns into one accumulating activity line (3 + 2 = 5)', async ({ freshellPage: _freshellPage, page, harness: _harness, terminal }) => {
+  test('collapses adjacent same-role tool turns into one accumulating activity line (3 + 2 = 5)', async ({ freshellPage: _freshellPage, page, harness, terminal }) => {
     await seedCollapsePane(page, terminal, 'collapse-thread', [
       { id: 'turn-user', turnId: 'turn-user', role: 'user', summary: 'read files',
         items: [{ id: 'item-user', kind: 'text', text: 'read these five files' }] },
@@ -1128,6 +1128,12 @@ test.describe('activity line collapse', () => {
     await expect(pane.getByRole('button', { name: 'Read tool call' })).toHaveCount(5)
     await expect(pane.getByText('src/a.ts')).toBeVisible()
     await expect(pane.getByText('src/e.ts')).toBeVisible()
+    // A merged line's fork affordance resolves to the line's LAST contributing turn.
+    const lineArticle = pane.locator('article[data-turn-index="1"]')
+    await lineArticle.hover()
+    await lineArticle.getByRole('button', { name: 'Fork conversation from here' }).click()
+    const forkFrame = ((await harness.getSentWsMessages()) as any[]).find((m) => m?.type === 'freshAgent.fork')
+    expect(forkFrame?.input?.atTurnId).toBe('turn-b')
   })
 
   test('an intervening message keeps two tool lines separate', async ({ freshellPage: _freshellPage, page, harness: _harness, terminal }) => {

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -1207,13 +1207,17 @@ describe('FreshAgentTranscript', () => {
         />,
       )
 
-      // The injected empty strip is suppressed: the previous turn's line
-      // carries the live reel, so exactly one strip shows one running
-      // indicator, and the settled '1 tool used' text is not shown while live.
+      // The final turn has a visible summary, so it closes the line and
+      // renders its own article (summary + injected live strip) instead of
+      // handing liveness to the earlier line — the earlier turn completed
+      // before the final turn started, so its line settles. Exactly one
+      // running indicator remains, on the live strip, and none on the
+      // earlier turn.
       expect(screen.getAllByLabelText('running')).toHaveLength(1)
       const strips = screen.getAllByRole('region', { name: 'Activity strip' })
-      expect(strips).toHaveLength(1)
-      expect(strips[0]).not.toHaveTextContent('1 tool used')
+      expect(strips).toHaveLength(2)
+      expect(strips[0]).toHaveTextContent('1 tool used')
+      expect(screen.getByText('thinking')).toBeInTheDocument()
     })
 
     it('drops a non-streaming turn when all items are filtered out', () => {
@@ -1699,6 +1703,39 @@ describe('FreshAgentTranscript', () => {
       expect(screen.getAllByLabelText('running')).toHaveLength(1)
       expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('Read')
       expect(screen.queryByText('2 tools used')).not.toBeInTheDocument()
+    })
+
+    it('keeps a summary-only streaming turn and its injected live strip visible after an activity line', () => {
+      render(
+        <FreshAgentTranscript
+          isStreaming
+          turns={[
+            { id: 'turn-a', turnId: 'turn-a', role: 'assistant', summary: '',
+              items: [{ id: 'tool-c1', kind: 'tool_use', toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } }] },
+            { id: 'turn-summary', turnId: 'turn-summary', role: 'assistant', summary: 'Wrapping up shortly', items: [] },
+          ]}
+        />,
+      )
+      expect(screen.getByText('Wrapping up shortly')).toBeInTheDocument()
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+      expect(screen.getAllByLabelText('running')).toHaveLength(1)
+    })
+
+    it('closes the line across a role change even when the message body is invisible', () => {
+      render(
+        <FreshAgentTranscript
+          turns={[
+            { id: 'turn-a', turnId: 'turn-a', role: 'assistant', summary: '',
+              items: [{ id: 'tool-c1', kind: 'tool_use', toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } }] },
+            { id: 'turn-user-invisible', turnId: 'turn-user-invisible', role: 'user', summary: '',
+              items: [{ id: 'item-invisible', kind: 'text', text: '   ' }] },
+            { id: 'turn-b', turnId: 'turn-b', role: 'assistant', summary: '',
+              items: [{ id: 'tool-c2', kind: 'tool_use', toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } }] },
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+      expect(screen.getByText('You')).toBeInTheDocument()
     })
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -1884,5 +1884,55 @@ describe('FreshAgentTranscript', () => {
       rerender(<FreshAgentTranscript isStreaming showThinking={false} turns={[turnA, thinkingTurn, turnB]} />)
       expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
     })
+
+    it('keeps the hidden-thinking boundary after the session goes idle (isStreaming flips false)', () => {
+      const turnA = {
+        id: 'turn-a', turnId: 'turn-a', role: 'assistant' as const, summary: '',
+        items: [{ id: 'tool-c1', kind: 'tool_use' as const, toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } }],
+      }
+      const thinkingTurn = {
+        id: 'turn-thinking', turnId: 'turn-thinking', role: 'assistant' as const,
+        summary: 'Considering options',
+        items: [{ id: 'think-1', kind: 'thinking' as const, text: 'Considering options' }],
+      }
+      const turnB = {
+        id: 'turn-b', turnId: 'turn-b', role: 'assistant' as const, summary: 'Read',
+        items: [{ id: 'tool-c2', kind: 'tool_use' as const, toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } }],
+      }
+      // The thinking turn's summary paints as the streaming tail...
+      const { rerender } = render(
+        <FreshAgentTranscript isStreaming showThinking={false} turns={[turnA, thinkingTurn]} />,
+      )
+      expect(screen.getByText('Considering options')).toBeInTheDocument()
+      // ...then the next tool arrives in a new turn: separated lines.
+      rerender(<FreshAgentTranscript isStreaming showThinking={false} turns={[turnA, thinkingTurn, turnB]} />)
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+      // The session completes (FreshAgentView passes isStreaming=isBusy). The
+      // summary rendered between the two tool runs in this view, so the runs
+      // must not retro-collapse now that streaming is over.
+      rerender(<FreshAgentTranscript isStreaming={false} showThinking={false} turns={[turnA, thinkingTurn, turnB]} />)
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+    })
+
+    it('collapses freely across hidden-thinking turns whose summary never painted (settled history)', () => {
+      // A transcript mounted already-settled never rendered the hidden thinking
+      // turn's summary, so nothing stood between the tool runs in this view.
+      render(
+        <FreshAgentTranscript
+          isStreaming={false}
+          showThinking={false}
+          turns={[
+            { id: 'turn-a', turnId: 'turn-a', role: 'assistant', summary: '',
+              items: [{ id: 'tool-c1', kind: 'tool_use', toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } }] },
+            { id: 'turn-thinking', turnId: 'turn-thinking', role: 'assistant',
+              summary: 'Considering options',
+              items: [{ id: 'think-1', kind: 'thinking', text: 'Considering options' }] },
+            { id: 'turn-b', turnId: 'turn-b', role: 'assistant', summary: 'Read',
+              items: [{ id: 'tool-c2', kind: 'tool_use', toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } }] },
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    })
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -1798,5 +1798,91 @@ describe('FreshAgentTranscript', () => {
       expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
       expect(screen.getByText('Read')).toBeInTheDocument()
     })
+
+    it('merges a follower whose coalesced summary carries the Rust claude [tool result] label', () => {
+      // The production Rust claude snapshot summarizer emits '[tool result]'
+      // (claude_snapshot.rs), not the TS normalizer's 'Tool result'. Synthetic
+      // result coalescing joins it to the tool echo with a blank line.
+      render(
+        <FreshAgentTranscript
+          isStreaming
+          turns={[
+            toolTurn('turn-a', [['c1', 'src/a.ts']]),
+            { id: 'turn-b', turnId: 'turn-b', role: 'assistant', summary: 'Read\n\n[tool result]',
+              items: [
+                { id: 'tool-c2', kind: 'tool_use', toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } },
+                { id: 'result-c2', kind: 'tool_result', toolUseId: 'c2', content: 'file body', isError: false },
+              ] },
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    })
+
+    it('merges a follower whose live summary space-joins several item echoes', () => {
+      // The live freshAgent.assistant path summarizes a turn by space-joining
+      // every content block (summarizeFreshAgentItems), so a two-Read batch is
+      // 'Read Read' — not contained in any single item echo, but fully composed
+      // of them.
+      render(
+        <FreshAgentTranscript
+          isStreaming
+          turns={[
+            toolTurn('turn-a', [['c1', 'src/a.ts']]),
+            { id: 'turn-b', turnId: 'turn-b', role: 'assistant', summary: 'Read Read',
+              items: [
+                { id: 'tool-c2', kind: 'tool_use', toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } },
+                { id: 'tool-c3', kind: 'tool_use', toolUseId: 'c3', name: 'Read', input: { file_path: 'src/c.ts' } },
+              ] },
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    })
+
+    it('merges a codex image-generation follower whose summary echoes its result', () => {
+      render(
+        <FreshAgentTranscript
+          isStreaming
+          turns={[
+            toolTurn('turn-a', [['c1', 'src/a.ts']]),
+            { id: 'turn-b', turnId: 'turn-b', role: 'assistant', summary: 'cat.png',
+              items: [
+                { id: 'img-1', kind: 'image_generation', status: 'complete', revisedPrompt: null, result: 'cat.png' },
+              ] },
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    })
+
+    it('pins the hidden-thinking cadence: a summary that rendered as a distinct turn permanently separates the surrounding tool runs', () => {
+      const turnA = {
+        id: 'turn-a', turnId: 'turn-a', role: 'assistant' as const, summary: '',
+        items: [{ id: 'tool-c1', kind: 'tool_use' as const, toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } }],
+      }
+      const thinkingTurn = {
+        id: 'turn-thinking', turnId: 'turn-thinking', role: 'assistant' as const,
+        summary: 'Considering options',
+        items: [{ id: 'think-1', kind: 'thinking' as const, text: 'Considering options' }],
+      }
+      // Frame 1 (showThinking=false, the production default): the thinking-only
+      // streaming tail keeps its summary rendered.
+      const { rerender } = render(
+        <FreshAgentTranscript isStreaming showThinking={false} turns={[turnA, thinkingTurn]} />,
+      )
+      expect(screen.getByText('Considering options')).toBeInTheDocument()
+
+      // Frame 2: the next tool arrives in a NEW turn. The thinking turn is no
+      // longer the streaming tail, so hidden thinking drops out of view — but
+      // its summary rendered between the two tool runs, so the runs stay
+      // permanently separated instead of retro-collapsing into one line.
+      const turnB = {
+        id: 'turn-b', turnId: 'turn-b', role: 'assistant' as const, summary: 'Read',
+        items: [{ id: 'tool-c2', kind: 'tool_use' as const, toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } }],
+      }
+      rerender(<FreshAgentTranscript isStreaming showThinking={false} turns={[turnA, thinkingTurn, turnB]} />)
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+    })
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { createRoot, type Root } from 'react-dom/client'
 import { flushSync } from 'react-dom'
 import { FreshAgentTranscript, type FreshAgentTranscriptHandle } from '@/components/fresh-agent/FreshAgentTranscript'
+import type { FreshAgentTranscriptItem, FreshAgentTurn } from '@shared/fresh-agent-contract'
 
 // Render markdown bodies synchronously. The real LazyMarkdown wraps MarkdownRenderer
 // in React.lazy + Suspense; mocking it to render MarkdownRenderer directly removes
@@ -456,7 +457,7 @@ describe('FreshAgentTranscript', () => {
     expect(strips[0]).toHaveTextContent('1 tool used')
   })
 
-  it('keeps consecutive activity-only assistant turns separate while marking only the latest live', () => {
+  it('collapses consecutive activity-only assistant turns into one live strip', () => {
     render(
       <FreshAgentTranscript
         isStreaming
@@ -507,14 +508,14 @@ describe('FreshAgentTranscript', () => {
       />,
     )
 
-    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(3)
+    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
     expect(screen.getAllByLabelText('running')).toHaveLength(1)
-    expect(screen.getByText('src/three.ts')).toBeInTheDocument()
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Toggle activity details' })[2])
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle activity details' }))
+    expect(screen.getByText('src/one.ts')).toBeInTheDocument()
+    expect(screen.getByText('src/two.ts')).toBeInTheDocument()
+    expect(screen.getByText('src/three.ts')).toBeInTheDocument()
     expect(screen.getAllByLabelText('running')).toHaveLength(1)
-    fireEvent.click(screen.getAllByRole('button', { name: 'Toggle activity details' })[0])
-    expect(screen.getAllByLabelText('complete').length).toBeGreaterThanOrEqual(1)
   })
 
   it('folds Claude user-role tool results into the assistant activity instead of attributing them to You', () => {
@@ -635,9 +636,11 @@ describe('FreshAgentTranscript', () => {
       .filter(Boolean)
     expect(visibleHeaders).toEqual(['You', 'Freshclaude'])
     expect(container.querySelectorAll('[data-turn-role="user"] .fresh-agent-activity-strip')).toHaveLength(0)
+    // The two exchanges are adjacent same-role activity-only turns after
+    // synthetic-result coalescing: one accumulating line, '2 tools used'.
     const strips = screen.getAllByRole('region', { name: 'Activity strip' })
-    expect(strips).toHaveLength(2)
-    expect(strips.every((strip) => strip.textContent?.includes('1 tool used'))).toBe(true)
+    expect(strips).toHaveLength(1)
+    expect(strips[0]).toHaveTextContent('2 tools used')
   })
 
   it('shows the speaker label once for consecutive turns from the same role', () => {
@@ -889,7 +892,7 @@ describe('FreshAgentTranscript', () => {
       .toHaveTextContent('1 tool used · 1 file changed')
   })
 
-  it('keeps adjacent activity-only display turns distinct and actionable', () => {
+  it('merges adjacent activity-only display turns into one line actionable from the line end', () => {
     const onFork = vi.fn()
     render(
       <FreshAgentTranscript
@@ -914,11 +917,13 @@ describe('FreshAgentTranscript', () => {
       />,
     )
 
-    expect(screen.getAllByRole('article', { name: 'Assistant transcript turn' })).toHaveLength(2)
-    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+    expect(screen.getAllByRole('article', { name: 'Assistant transcript turn' })).toHaveLength(1)
+    expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
 
+    // Fork protection is preserved at line granularity: the merged article's
+    // fork resolves to the line's last contributing turn.
     const forkButtons = screen.getAllByRole('button', { name: 'Fork conversation from here' })
-    fireEvent.click(forkButtons[1])
+    fireEvent.click(forkButtons[0])
     expect(onFork).toHaveBeenCalledWith('display-activity-2')
   })
 
@@ -1202,10 +1207,13 @@ describe('FreshAgentTranscript', () => {
         />,
       )
 
+      // The injected empty strip is suppressed: the previous turn's line
+      // carries the live reel, so exactly one strip shows one running
+      // indicator, and the settled '1 tool used' text is not shown while live.
       expect(screen.getAllByLabelText('running')).toHaveLength(1)
       const strips = screen.getAllByRole('region', { name: 'Activity strip' })
-      expect(strips).toHaveLength(2)
-      expect(strips[0]).toHaveTextContent('1 tool used')
+      expect(strips).toHaveLength(1)
+      expect(strips[0]).not.toHaveTextContent('1 tool used')
     })
 
     it('drops a non-streaming turn when all items are filtered out', () => {
@@ -1480,6 +1488,217 @@ describe('FreshAgentTranscript', () => {
       fireEvent.contextMenu(screen.getByRole('article', { name: 'Assistant transcript turn' }))
       const item = screen.getByRole('menuitem', { name: 'Rewind code to here' })
       expect(item).toBeDisabled()
+    })
+  })
+
+  describe('activity line collapse', () => {
+    const toolTurn = (turnId: string, calls: Array<[string, string]>): FreshAgentTurn => ({
+      id: turnId,
+      turnId,
+      role: 'assistant',
+      summary: '',
+      items: calls.flatMap(([callId, filePath]): FreshAgentTranscriptItem[] => [
+        { id: `tool-${callId}`, kind: 'tool_use', toolUseId: callId, name: 'Read', input: { file_path: filePath } },
+        { id: `result-${callId}`, kind: 'tool_result', toolUseId: callId, content: 'ok', isError: false },
+      ]),
+    })
+
+    it('collapses adjacent same-role tool-only turns into one accumulating strip line', () => {
+      render(
+        <FreshAgentTranscript
+          turns={[
+            { id: 'turn-user', turnId: 'turn-user', role: 'user', summary: 'req',
+              items: [{ id: 'item-user', kind: 'text', text: 'read five files' }] },
+            toolTurn('turn-a', [['c1','src/a.ts'],['c2','src/b.ts'],['c3','src/c.ts']]),
+            toolTurn('turn-b', [['c4','src/d.ts'],['c5','src/e.ts']]),
+          ]}
+        />,
+      )
+      const strips = screen.getAllByRole('region', { name: 'Activity strip' })
+      expect(strips).toHaveLength(1)
+      expect(strips[0]).toHaveTextContent('5 tools used')
+      fireEvent.click(screen.getByRole('button', { name: 'Toggle activity details' }))
+      expect(screen.getAllByText(/^src\/[a-e]\.ts$/)).toHaveLength(5)
+      expect(screen.getByText('src/e.ts')).toBeInTheDocument()
+    })
+
+    it('keeps tool lines separate when a message renders between them', () => {
+      render(
+        <FreshAgentTranscript
+          turns={[
+            toolTurn('turn-a', [['c1','src/a.ts']]),
+            { id: 'turn-msg', turnId: 'turn-msg', role: 'assistant', summary: 'note',
+              items: [{ id: 'item-msg', kind: 'text', text: 'First file read.' }] },
+            toolTurn('turn-b', [['c2','src/b.ts']]),
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+    })
+
+    it('does not collapse tool lines across a role change', () => {
+      render(
+        <FreshAgentTranscript
+          turns={[
+            toolTurn('turn-a', [['c1','src/a.ts']]),
+            { ...toolTurn('turn-b', [['c2','src/b.ts']]), role: 'tool' },
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+      // the role change renders a header between the lines
+      expect(screen.getByText('Tool')).toBeInTheDocument()
+    })
+
+    it('a trailing text card in the earlier turn keeps the lines separate', () => {
+      render(
+        <FreshAgentTranscript
+          turns={[
+            { id: 'turn-a', turnId: 'turn-a', role: 'assistant', summary: 'work',
+              items: [
+                { id: 'tool-c1', kind: 'tool_use', toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } },
+                { id: 'item-msg', kind: 'text', text: 'done with a' },
+              ] },
+            toolTurn('turn-b', [['c2','src/b.ts']]),
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+    })
+
+    it('merges a chain of three adjacent tool-only turns', () => {
+      render(
+        <FreshAgentTranscript
+          turns={[
+            toolTurn('turn-a', [['c1','src/a.ts'],['c2','src/b.ts']]),
+            toolTurn('turn-b', [['c3','src/c.ts'],['c4','src/d.ts']]),
+            toolTurn('turn-c', [['c5','src/e.ts'],['c6','src/f.ts']]),
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+      expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('6 tools used')
+    })
+
+    it('fully absorbed turns render no article and fork targets the line end', () => {
+      const onFork = vi.fn()
+      render(
+        <FreshAgentTranscript
+          canFork
+          onForkFromTurn={onFork}
+          turns={[
+            { id: 'turn-a', turnId: 'native-a', role: 'assistant', summary: '',
+              items: [{ id: 't1', kind: 'thinking', text: 'first thought' }] },
+            { id: 'turn-b', turnId: 'native-b', role: 'assistant', summary: '',
+              items: [{ id: 't2', kind: 'thinking', text: 'second thought' }] },
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('article', { name: 'Assistant transcript turn' })).toHaveLength(1)
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+      // merged thinking-only line settles to 'thought'
+      fireEvent.click(screen.getByRole('button', { name: 'Toggle activity details' }))
+      expect(screen.getByText('Thinking')).toBeInTheDocument()
+      const forkButtons = screen.getAllByRole('button', { name: 'Fork conversation from here' })
+      fireEvent.click(forkButtons[0])
+      expect(onFork).toHaveBeenCalledWith('native-b')
+    })
+
+    it('treats a zero-item turn as a boundary between tool lines', () => {
+      render(
+        <FreshAgentTranscript
+          turns={[
+            toolTurn('turn-a', [['c1','src/a.ts']]),
+            { id: 'turn-empty', turnId: 'turn-empty', role: 'assistant', summary: '', items: [] },
+            toolTurn('turn-b', [['c2','src/b.ts']]),
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+    })
+
+    it('renders both tools when TS-claude duplicate item ids collide across merged turns', () => {
+      render(
+        <FreshAgentTranscript
+          turns={[
+            { id: 'turn-a', turnId: 'turn:msg-1', role: 'assistant', summary: '',
+              items: [{ id: 'turn:msg-1:item:0', kind: 'tool_use', toolUseId: 'toolu_1', name: 'Read', input: { file_path: 'src/a.ts' } }] },
+            { id: 'turn-b', turnId: 'turn:msg-1', role: 'assistant', summary: '',
+              items: [{ id: 'turn:msg-1:item:0', kind: 'tool_use', toolUseId: 'toolu_2', name: 'Read', input: { file_path: 'src/b.ts' } }] },
+          ]}
+        />,
+      )
+      expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('2 tools used')
+      fireEvent.click(screen.getByRole('button', { name: 'Toggle activity details' }))
+      expect(screen.getByText('src/a.ts')).toBeInTheDocument()
+      expect(screen.getByText('src/b.ts')).toBeInTheDocument()
+    })
+
+    it('extends the open line in place as adjacent tool turns stream in (same DOM node, no regroup)', () => {
+      const userTurn = {
+        id: 'turn-user', turnId: 'turn-user', role: 'user' as const, summary: 'req',
+        items: [{ id: 'item-user', kind: 'text' as const, text: 'read five files' }],
+      }
+      const turnA = toolTurn('turn-a', [['c1','src/a.ts'],['c2','src/b.ts'],['c3','src/c.ts']])
+      const { rerender } = render(<FreshAgentTranscript turns={[userTurn, turnA]} />)
+      const first = screen.getByRole('region', { name: 'Activity strip' })
+      expect(first).toHaveTextContent('3 tools used')
+
+      rerender(<FreshAgentTranscript turns={[userTurn, turnA, toolTurn('turn-b', [['c4','src/d.ts'],['c5','src/e.ts']])]} />)
+      const merged = screen.getByRole('region', { name: 'Activity strip' })
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+      expect(merged).toBe(first)
+      expect(merged).toHaveTextContent('5 tools used')
+    })
+
+    it('keeps two same-turn lines distinct when a message splits them (tool → text → tool)', () => {
+      render(
+        <FreshAgentTranscript
+          turns={[{
+            id: 'turn-mixed', turnId: 'turn-mixed', role: 'assistant', summary: '',
+            items: [
+              { id: 'tool-a', kind: 'tool_use', toolUseId: 'ca', name: 'Read', input: { file_path: 'src/a.ts' } },
+              { id: 'item-note', kind: 'text', text: 'first pass done' },
+              { id: 'tool-b', kind: 'tool_use', toolUseId: 'cb', name: 'Read', input: { file_path: 'src/b.ts' } },
+            ],
+          }]}
+        />,
+      )
+      const strips = screen.getAllByRole('region', { name: 'Activity strip' })
+      expect(strips).toHaveLength(2)
+      expect(strips[0]).toHaveTextContent('1 tool used')
+      expect(strips[1]).toHaveTextContent('1 tool used')
+    })
+
+    it('an invisible (whitespace-only) text item does not split the line', () => {
+      render(
+        <FreshAgentTranscript
+          turns={[
+            toolTurn('turn-a', [['c1','src/a.ts']]),
+            { id: 'turn-empty-text', turnId: 'turn-empty-text', role: 'assistant', summary: '',
+              items: [{ id: 'item-empty', kind: 'text', text: '   ' }] },
+            toolTurn('turn-b', [['c2','src/b.ts']]),
+          ]}
+        />,
+      )
+      expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('2 tools used')
+    })
+
+    it('hands liveness to the merged line across an absorbed previous turn while the last turn streams empty', () => {
+      render(
+        <FreshAgentTranscript
+          isStreaming
+          turns={[
+            toolTurn('turn-a', [['c1','src/a.ts']]),
+            toolTurn('turn-b', [['c2','src/b.ts']]),
+            { id: 'turn-streaming', turnId: 'turn-streaming', role: 'assistant', summary: '', items: [] },
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+      expect(screen.getAllByLabelText('running')).toHaveLength(1)
+      expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('Read')
+      expect(screen.queryByText('2 tools used')).not.toBeInTheDocument()
     })
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -1934,5 +1934,109 @@ describe('FreshAgentTranscript', () => {
       )
       expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
     })
+
+    it('merges a mixed thinking-plus-tool turn whose hidden thinking is part of the summary (live claude shape)', () => {
+      // Production default showThinking=false: the thinking item is filtered
+      // out, and the summary ('Considering Read', space-joined by the live
+      // summarizer) never renders — the article renders its activity block.
+      // Echo classification must still see the hidden items, or the common
+      // claude thinking→tool turn can never merge.
+      render(
+        <FreshAgentTranscript
+          isStreaming
+          showThinking={false}
+          turns={[
+            toolTurn('turn-a', [['c1', 'src/a.ts']]),
+            { id: 'turn-b', turnId: 'turn-b', role: 'assistant', summary: 'Considering Read',
+              items: [
+                { id: 'think-1', kind: 'thinking', text: 'Considering' },
+                { id: 'tool-c2', kind: 'tool_use', toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } },
+              ] },
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    })
+
+    it('merges a mixed thinking-plus-tool turn whose summary is the hidden thinking text (Rust snapshot shape)', () => {
+      render(
+        <FreshAgentTranscript
+          isStreaming
+          showThinking={false}
+          turns={[
+            toolTurn('turn-a', [['c1', 'src/a.ts']]),
+            { id: 'turn-b', turnId: 'turn-b', role: 'assistant', summary: 'Considering',
+              items: [
+                { id: 'think-1', kind: 'thinking', text: 'Considering' },
+                { id: 'tool-c2', kind: 'tool_use', toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } },
+              ] },
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    })
+
+    it('keeps a painted summary boundary when the same turn later gains items that echo it', () => {
+      const turnA = {
+        id: 'turn-a', turnId: 'turn-a', role: 'assistant' as const, summary: '',
+        items: [{ id: 'tool-c1', kind: 'tool_use' as const, toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } }],
+      }
+      const turnBEmpty = {
+        id: 'turn-b', turnId: 'turn-b', role: 'assistant' as const,
+        summary: 'Wrapping up shortly', items: [],
+      }
+      // Frame 1: the summary-only streaming tail paints its summary.
+      const { rerender } = render(
+        <FreshAgentTranscript isStreaming showThinking turns={[turnA, turnBEmpty]} />,
+      )
+      expect(screen.getByText('Wrapping up shortly')).toBeInTheDocument()
+
+      // Frame 2: the same turn gains a thinking item echoing the summary plus
+      // a tool. The summary is now classifiable as an echo, but it RENDERED
+      // between the two tool runs, so the new activity keeps its own line.
+      const turnBWithItems = {
+        ...turnBEmpty,
+        items: [
+          { id: 'think-1', kind: 'thinking' as const, text: 'Wrapping up shortly' },
+          { id: 'tool-c2', kind: 'tool_use' as const, toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } },
+        ],
+      }
+      rerender(<FreshAgentTranscript isStreaming showThinking turns={[turnA, turnBWithItems]} />)
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+    })
+
+    it('does not let a painted summary mark a different turn that shares its turnId', () => {
+      const thinkingTurn = (summary: string, itemId: string) => ({
+        id: `turn-dup-${itemId}`, turnId: 'turn-dup', role: 'assistant' as const,
+        summary,
+        items: [{ id: itemId, kind: 'thinking' as const, text: summary }],
+      })
+      const turnA = {
+        id: 'turn-a', turnId: 'turn-a', role: 'assistant' as const, summary: '',
+        items: [{ id: 'tool-c1', kind: 'tool_use' as const, toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } }],
+      }
+      const turnB = {
+        id: 'turn-b', turnId: 'turn-b', role: 'assistant' as const, summary: 'Read',
+        items: [{ id: 'tool-c2', kind: 'tool_use' as const, toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } }],
+      }
+      // Frame 1: one display turn with turnId 'turn-dup' paints its summary.
+      const { rerender } = render(
+        <FreshAgentTranscript isStreaming showThinking={false} turns={[thinkingTurn('First thought', 'think-1')]} />,
+      )
+      expect(screen.getByText('First thought')).toBeInTheDocument()
+
+      // Frame 2: a DIFFERENT display turn reuses turnId 'turn-dup' with a
+      // different summary that never painted (validated claude data permits
+      // duplicate display keys across JSONL rows). It must not inherit the
+      // painted boundary — the tool runs still collapse.
+      rerender(
+        <FreshAgentTranscript
+          isStreaming={false}
+          showThinking={false}
+          turns={[turnA, thinkingTurn('Second thought', 'think-2'), turnB]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    })
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -2038,5 +2038,37 @@ describe('FreshAgentTranscript', () => {
       )
       expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
     })
+
+    it('keeps the painted boundary when a streaming summary grows after painting', () => {
+      const turnA = {
+        id: 'turn-a', turnId: 'turn-a', role: 'assistant' as const, summary: '',
+        items: [{ id: 'tool-c1', kind: 'tool_use' as const, toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } }],
+      }
+      // Frame 1: the streaming tail paints its summary 'Considering'.
+      const turnBEmpty = {
+        id: 'turn-b', turnId: 'turn-b', role: 'assistant' as const,
+        summary: 'Considering', items: [],
+      }
+      const { rerender } = render(
+        <FreshAgentTranscript isStreaming showThinking turns={[turnA, turnBEmpty]} />,
+      )
+      expect(screen.getByText('Considering')).toBeInTheDocument()
+
+      // Frame 2: the same turn's reasoning accumulated — the summary grew to
+      // 'Considering options' and the turn now carries items echoing it
+      // (repeatedly fetched OpenCode reasoning parts have this shape). The
+      // painted text rendered between the tool runs; the new activity must
+      // keep its own line even though the summary text mutated.
+      const turnBGrown = {
+        ...turnBEmpty,
+        summary: 'Considering options',
+        items: [
+          { id: 'think-1', kind: 'thinking' as const, text: 'Considering options' },
+          { id: 'tool-c2', kind: 'tool_use' as const, toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } },
+        ],
+      }
+      rerender(<FreshAgentTranscript isStreaming showThinking turns={[turnA, turnBGrown]} />)
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+    })
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -1737,5 +1737,33 @@ describe('FreshAgentTranscript', () => {
       expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
       expect(screen.getByText('You')).toBeInTheDocument()
     })
+
+    it('pins the streaming summary cadence: summary shows while the last turn is empty, then the arriving tool joins the line', () => {
+      const turnA = {
+        id: 'turn-a', turnId: 'turn-a', role: 'assistant' as const, summary: '',
+        items: [{ id: 'tool-c1', kind: 'tool_use' as const, toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } }],
+      }
+      const turnCEmpty = {
+        id: 'turn-c', turnId: 'turn-c', role: 'assistant' as const,
+        summary: 'Wrapping up shortly', items: [],
+      }
+      // Frame 1: summary-only streaming tail renders its summary plus the injected
+      // live strip (matches the pre-change summary-fallback behavior).
+      const { rerender } = render(<FreshAgentTranscript isStreaming turns={[turnA, turnCEmpty]} />)
+      expect(screen.getByText('Wrapping up shortly')).toBeInTheDocument()
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+
+      // Frame 2: the tool arrives in the same turn. Nothing renders between the
+      // two tool runs — the summary is hidden by the long-standing fallback rule
+      // (blocks suppress it) — so the tool joins the open line in place.
+      const turnCWithTool = {
+        ...turnCEmpty,
+        items: [{ id: 'tool-c2', kind: 'tool_use' as const, toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } }],
+      }
+      rerender(<FreshAgentTranscript isStreaming turns={[turnA, turnCWithTool]} />)
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+      expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('Read')
+      expect(screen.queryByText('Wrapping up shortly')).not.toBeInTheDocument()
+    })
   })
 })

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -903,14 +903,14 @@ describe('FreshAgentTranscript', () => {
             id: 'native-turn',
             turnId: 'display-activity-1',
             role: 'assistant',
-            summary: 'first activity',
+            summary: 'first thought',
             items: [{ id: 'think-1', kind: 'thinking', text: 'first thought' }],
           },
           {
             id: 'native-turn',
             turnId: 'display-activity-2',
             role: 'assistant',
-            summary: 'second activity',
+            summary: 'second thought',
             items: [{ id: 'think-2', kind: 'thinking', text: 'second thought' }],
           },
         ]}
@@ -1738,7 +1738,40 @@ describe('FreshAgentTranscript', () => {
       expect(screen.getByText('You')).toBeInTheDocument()
     })
 
-    it('pins the streaming summary cadence: summary shows while the last turn is empty, then the arriving tool joins the line', () => {
+    it('permanently separates tool runs when the follower turn carries a summary that is not an item echo', () => {
+      render(
+        <FreshAgentTranscript
+          isStreaming
+          turns={[
+            { id: 'turn-a', turnId: 'turn-a', role: 'assistant', summary: '',
+              items: [{ id: 'tool-c1', kind: 'tool_use', toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } }] },
+            { id: 'turn-c', turnId: 'turn-c', role: 'assistant', summary: 'Wrapping up shortly',
+              items: [{ id: 'tool-c2', kind: 'tool_use', toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } }] },
+          ]}
+        />,
+      )
+      // The summary is authored content (no item says "Wrapping up shortly"), so
+      // the tool run behind it can never join the previous line — even after the
+      // base fallback stops painting the summary once blocks exist.
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+    })
+
+    it('still merges a follower whose summary merely echoes one of its own items (codex tool preview)', () => {
+      render(
+        <FreshAgentTranscript
+          isStreaming
+          turns={[
+            { id: 'turn-a', turnId: 'turn-a', role: 'assistant', summary: '',
+              items: [{ id: 'tool-c1', kind: 'tool_use', toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } }] },
+            { id: 'turn-c', turnId: 'turn-c', role: 'assistant', summary: 'Read',
+              items: [{ id: 'tool-c2', kind: 'tool_use', toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } }] },
+          ]}
+        />,
+      )
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
+    })
+
+    it('pins the streaming summary cadence: an authored summary permanently keeps the following tool run on its own line', () => {
       const turnA = {
         id: 'turn-a', turnId: 'turn-a', role: 'assistant' as const, summary: '',
         items: [{ id: 'tool-c1', kind: 'tool_use' as const, toolUseId: 'c1', name: 'Read', input: { file_path: 'src/a.ts' } }],
@@ -1753,17 +1786,17 @@ describe('FreshAgentTranscript', () => {
       expect(screen.getByText('Wrapping up shortly')).toBeInTheDocument()
       expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
 
-      // Frame 2: the tool arrives in the same turn. Nothing renders between the
-      // two tool runs — the summary is hidden by the long-standing fallback rule
-      // (blocks suppress it) — so the tool joins the open line in place.
+      // Frame 2: the tool arrives in the same turn. The authored summary rendered
+      // between the two tool runs, so they are permanently separated — the base
+      // fallback still hides the summary once blocks exist, but the run keeps its
+      // own line and never retro-merges into the previous one.
       const turnCWithTool = {
         ...turnCEmpty,
         items: [{ id: 'tool-c2', kind: 'tool_use' as const, toolUseId: 'c2', name: 'Read', input: { file_path: 'src/b.ts' } }],
       }
       rerender(<FreshAgentTranscript isStreaming turns={[turnA, turnCWithTool]} />)
-      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(1)
-      expect(screen.getByRole('region', { name: 'Activity strip' })).toHaveTextContent('Read')
-      expect(screen.queryByText('Wrapping up shortly')).not.toBeInTheDocument()
+      expect(screen.getAllByRole('region', { name: 'Activity strip' })).toHaveLength(2)
+      expect(screen.getByText('Read')).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## What
In fresh-agent transcripts, adjacent tool-activity strips with nothing rendered between them ('3 tools used' followed by '2 tools used') now collapse into one accumulating line ('5 tools used') that keeps absorbing tool activity until a message appears; only then does a new line start. Anything rendered between two tool runs keeps them as separate lines.

## How
Transcript-level open-line layout pass in \`src/components/fresh-agent/FreshAgentTranscript.tsx\` (\`buildTranscriptLayout\`): one OPEN line per transcript state; follower turns' leading activity items absorb when same-role and no boundary intervenes; lines close on message items, role changes (the header renders), zero-item structural turns, and invisible-text turns in a different role. Lines are re-derived from concatenated item lists so \`buildActivity\` stitching stays intact; fork/rewind resolve to the line's last contributing turn; layout-driven liveness handoff handles the streaming-empty-last-turn case with a visible-summary bail.

Boundary permanence layers (reviewer-driven):
- A follower whose summary is **authored content** (no echo among the turn's PRE-FILTER items — hidden thinking is part of production summaries and the summary never renders when an activity block does) never absorbs.
- A summary this view **painted** is a permanent boundary — per-turnId prefix-matched painted identity (streaming summaries grow and inherit; duplicate claude turnIds with unrelatable text do not), enforced via an invisible placeholder when the turn later filters out entirely (survives busy→idle) and via an absorb refusal when the turn later gains echoing items.
- Echo matching covers all production summarizers (live claude space-joins, TS claude tool_result content, Rust claude '[tool result]', codex truncated tails incl. image_generation.result) via compositional tiling.

## Verification
- Unit: FreshAgentTranscript 79/79 incl. 17 collapse-focused contract tests (merged counts, message/user/role/invisible boundaries, zero-item close, authored-summary, painted permanence live+idle+growth, duplicate turnIds, streaming cadence, fork targeting, settled free-collapse).
- Cloud Playwright e2e (activity line collapse spec): 2 passed at runtime HEAD.
- Full coordinated suite at converged HEAD 27a1c6432: cloud vitest all shards green (client 1433+1306+1286+1168; server 1141+1629+1219+1133) + electron 350/350 local.
- the-usual loop: 2 focused episodes + 4 delta rounds converged with zero blocking issues; findings log: .worktrees/.the-usual-logs/freshagent-activity-line/
- Plan synchronized to shipped behavior (docs/plans/2026-08-23-freshagent-activity-line.md).

## Dispositioned non-blockers
- Article-wide actionTurn (fork/rewind target the line's last contributing turn; article-level actions predate this run) — out of scope, potential future line-granular chrome redesign.
- Per-append Set rebuild in absorb path — optional perf (lines are short).
- Painted permanence is per-mounted-view by design: a settled reload may merge lines that live streaming had separated (pinned by test).