### PR TITLE
docs(agents): cloud-backend fallback policy in Testing section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,8 @@ npm run serve               # Build and run production server
 **On WSL machines, "the desktop app" means the Windows app.** Always build, install, and launch the Windows Electron app (`npm run electron:build:win` + the NSIS installer) — never a Linux AppImage/deb under WSLg. The Windows build must run as a native Windows process (WSL cannot compile `node-pty` for win32); drive it from WSL by rsyncing to a Windows-local dir and running Windows npm via `cmd.exe` — see [docs/development/windows-electron-build.md](docs/development/windows-electron-build.md).
 
 ### Testing
+Backend fallback policy: never silently fall back from the configured cloud test backend to local — if the cloud path fails, fix it; a local-backend run may substitute only when the cloud path cannot be fixed AND the user explicitly approves.
+
 ```bash
 npm test                    # Coordinated full suite (default + server configs)
 npm run check               # Typecheck, then coordinated full suite


### PR DESCRIPTION
Adds the fallback-policy sentence that has been living as a never-committed local edit in the main checkout: when the configured cloud test backend fails, fix the cloud path rather than silently running locally; local substitution only when the cloud path cannot be fixed AND the user explicitly approves.

Docs-only. The sentence was verified byte-identical to the rescued local edit.