### PR TITLE
fix(server): files.rs Node-parity fixes (qa-campaign port)

### DIFF
--- a/crates/freshell-server/src/files.rs
+++ b/crates/freshell-server/src/files.rs
@@ -560,6 +560,33 @@ fn trim_trailing_separators(input: &str) -> String {
     }
 }
 
+/// Lexical `path.resolve` segment collapse (`path-utils.ts:294`) for
+/// slash-absolute inputs: `.` dropped, `..` pops the last component (clamped
+/// at the filesystem root), redundant separators folded, trailing separators
+/// stripped. Non-absolute inputs are returned unchanged fail-closed: a
+/// relative or Windows-literal spelling can never prefix-match an absolute
+/// sandbox root, so collapsing here could only ever weaken the check.
+fn collapse_dot_segments(input: &str) -> String {
+    if !input.starts_with('/') {
+        return input.to_string();
+    }
+    let mut components: Vec<&str> = Vec::new();
+    for segment in input.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                components.pop();
+            }
+            _ => components.push(segment),
+        }
+    }
+    if components.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{}", components.join("/"))
+    }
+}
+
 /// A user path resolved for filesystem access: the flavor-preserving DISPLAY
 /// string (what goes back to the client in `resolvedPath` / suggestion paths)
 /// plus the native path used for actual filesystem operations.
@@ -1452,6 +1479,26 @@ mod tests {
         assert_eq!(trim_trailing_separators("/tmp/x/"), "/tmp/x");
         assert_eq!(trim_trailing_separators("/tmp/x///"), "/tmp/x");
         assert_eq!(trim_trailing_separators("/tmp/x"), "/tmp/x");
+    }
+
+    #[test]
+    fn collapse_dot_segments_mirrors_node_path_resolve() {
+        assert_eq!(
+            collapse_dot_segments("/home/user/projects/../../etc/passwd"),
+            "/home/etc/passwd" // two `..` pop `projects` and `user`
+        );
+        assert_eq!(
+            collapse_dot_segments("/home/user/projects//../../../etc/passwd"),
+            "/etc/passwd" // three `..` pop everything down to the root
+        );
+        assert_eq!(collapse_dot_segments("/a/./b/"), "/a/b");
+        assert_eq!(collapse_dot_segments("/a/b/../b/file.txt"), "/a/b/file.txt");
+        // `..` clamps at the filesystem root, like path.resolve.
+        assert_eq!(collapse_dot_segments("/../.."), "/");
+        assert_eq!(collapse_dot_segments("/"), "/");
+        // Non-absolute / literal fallback strings stay byte-exact (fail-closed).
+        assert_eq!(collapse_dot_segments("C:\\Users\\..\\x"), "C:\\Users\\..\\x");
+        assert_eq!(collapse_dot_segments("rel/../x"), "rel/../x");
     }
 
     #[test]

--- a/crates/freshell-server/src/files.rs
+++ b/crates/freshell-server/src/files.rs
@@ -25,7 +25,8 @@
 //!   original's empty-state response really is `{ directories: [] }`.
 //! * `POST /api/files/validate-dir` \u2014 mirrors `files-router.ts:232` +
 //!   `path-utils.ts#isReachableDirectory`: normalize the user path (`~` expansion,
-//!   trailing-separator trim), `stat` it, and report `{ valid, resolvedPath }`
+//!   trailing-separator trim, lexical `.`/`..` collapse — the `path.posix.resolve`
+//!   of path-utils.ts:69-70), `stat` it, and report `{ valid, resolvedPath }`
 //!   (`valid` iff it resolves to an existing directory).
 //!
 //! Both routes are gated by the shared auth token (via [`crate::boot::is_authed`],
@@ -524,15 +525,20 @@ fn add_unique_directory(
 /// Normalize a user-supplied directory path: sanitize the raw input first
 /// (`sanitizeUserPathInput` runs on EVERY flavor at the top of Node's
 /// `normalizeUserPath`, `path-utils.ts:55` → `:24-30`: trim whitespace, strip
-/// one pair of wrapping quotes, re-trim), then expand a leading `~`/`~/\u2026` to `$HOME`
-/// and trim trailing separators (mirrors `path-utils.ts#normalizeUserPath` for the
-/// POSIX host the oracle runs on \u2014 the `\\wsl$\u2026` Windows flavor is a later step,
-/// not exercised by the Linux-host e2e). Returns the path unchanged when it does
-/// not resolve.
+/// one pair of wrapping quotes, re-trim), then expand a leading `~`/`~/\u2026` to `$HOME`,
+/// trim trailing separators, and collapse `.`/`..` segments LEXICALLY
+/// — Node's `normalizeUserPath` runs `path.posix.resolve` on POSIX inputs
+/// (path-utils.ts:69-70), so `<tmp>/nope/../real` reaches the filesystem (and is
+/// displayed) as `<tmp>/real` even when the `nope` intermediate does not exist;
+/// a raw stat on the verbatim spelling would ENOENT on that intermediate first
+/// (mirrors `path-utils.ts#normalizeUserPath` for the
+/// POSIX host the oracle runs on \u2014 the `\\wsl$\u2026` Windows flavor is a later step, handled in
+/// [`resolve_user_path`]). Non-absolute inputs are returned unchanged when they
+/// do not resolve (the collapse is absolute-only, fail-closed).
 pub(crate) fn normalize_user_path(input: &str) -> String {
     let cleaned = sanitize_user_path_input(input);
     let expanded = expand_tilde(&cleaned);
-    trim_trailing_separators(&expanded)
+    collapse_dot_segments(&trim_trailing_separators(&expanded))
 }
 
 /// Expand a leading `~` (bare or `~/rest`) to the process `$HOME`. Other `~user`
@@ -1080,6 +1086,36 @@ mod tests {
         .into_response();
         let v = body_json(resp).await;
         assert_eq!(v["valid"], false);
+    }
+
+    /// Node's `normalizeUserPath` runs `path.posix.resolve` on POSIX inputs
+    /// (path-utils.ts:69-70), collapsing `.`/`..` segments LEXICALLY — so
+    /// `<tmp>/nope/../real` reaches the filesystem as `<tmp>/real` and
+    /// `validate-dir` reports it valid even though `nope` never exists
+    /// (files-router.ts:243). A port keeping the `..` segments verbatim would
+    /// ENOENT the raw stat on the missing `nope` intermediate and echo the
+    /// un-collapsed path; both the stat and the display string must use the
+    /// collapsed form.
+    // Intentional: env lock held across `.await` BY DESIGN (see above).
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn test_dotseg_collapse_display() {
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("real")).unwrap();
+        let spelled = format!("{}/nope/../real", tmp.path().to_string_lossy());
+        let collapsed = format!("{}/real", tmp.path().to_string_lossy());
+        let resp = validate_dir(
+            State(test_state()),
+            auth_headers(),
+            Json(json!({ "path": spelled })),
+        )
+        .await
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["valid"], true, "Node resolves `..` lexically before stat");
+        assert_eq!(v["resolvedPath"], collapsed);
     }
 
     // ---- complete (R-WIN3: suggestions rendered in the INPUT's flavor) ----

--- a/crates/freshell-server/src/files.rs
+++ b/crates/freshell-server/src/files.rs
@@ -525,7 +525,7 @@ fn add_unique_directory(
 /// Normalize a user-supplied directory path: sanitize the raw input first
 /// (`sanitizeUserPathInput` runs on EVERY flavor at the top of Node's
 /// `normalizeUserPath`, `path-utils.ts:55` → `:24-30`: trim whitespace, strip
-/// one pair of wrapping quotes, re-trim), then expand a leading `~`/`~/\u2026` to `$HOME`,
+/// one pair of wrapping quotes, re-trim), then expand a leading `~`/`~\\…`/`~/\u2026` to `$HOME`,
 /// trim trailing separators, and collapse `.`/`..` segments LEXICALLY
 /// — Node's `normalizeUserPath` runs `path.posix.resolve` on POSIX inputs
 /// (path-utils.ts:69-70), so `<tmp>/nope/../real` reaches the filesystem (and is
@@ -541,9 +541,13 @@ pub(crate) fn normalize_user_path(input: &str) -> String {
     collapse_dot_segments(&trim_trailing_separators(&expanded))
 }
 
-/// Expand a leading `~` (bare or `~/rest`) to the process `$HOME`. Other `~user`
-/// forms are left untouched (the DirectoryPicker only ever sends `~` or absolute
-/// paths).
+/// Expand a leading `~` (bare, `~/rest`, or `~\rest`) to the process `$HOME`.
+/// Node expands BOTH separator spellings (`path-utils.ts:61`:
+/// `startsWith('~/') || startsWith('~\\')`) — the backslash form is what
+/// Windows users type into the DirectoryPicker targeting a WSL host, and
+/// `~\rest` is `native` flavor (not Windows: `~` matches none of the
+/// drive/UNC/rooted prefixes), so it reaches this seam. Other `~user` forms
+/// are left untouched.
 fn expand_tilde(input: &str) -> String {
     if input == "~" {
         if let Some(home) = home_dir() {
@@ -551,9 +555,19 @@ fn expand_tilde(input: &str) -> String {
         }
         return input.to_string();
     }
-    if let Some(rest) = input.strip_prefix("~/") {
+    if let Some(rest) = input
+        .strip_prefix("~/")
+        .or_else(|| input.strip_prefix("~\\"))
+    {
         if let Some(home) = home_dir() {
-            return home.join(rest).to_string_lossy().into_owned();
+            // Node's posix path.join(home, rest) (path-utils.ts:62) CONCATENATES
+            // then lexically normalizes: a rest starting with `/` (mixed
+            // separators like `~\/x` or `~//x`) folds onto home as
+            // `$HOME/rest` — never replaces it, unlike `Path::join`'s
+            // absolute-argument semantics which would root the result at `/`.
+            // Inner backslashes stay literal (`~\a\b` -> `$HOME/a\b`), and
+            // `.`/`..` collapse exactly like join's normalize.
+            return collapse_dot_segments(&format!("{}/{rest}", home.to_string_lossy()));
         }
     }
     input.to_string()
@@ -983,6 +997,40 @@ mod tests {
         let r = resolve_user_path("~/proj");
         assert_eq!(r.display, "/home/tester/proj");
         assert_eq!(r.fs_path, Some("/home/tester/proj".to_string()));
+    }
+
+    /// FILE-03: `normalizeUserPath` expands BOTH `~/rest` AND `~\rest` to the
+    /// home directory (path-utils.ts:61: `startsWith('~/') ||
+    /// startsWith('~\\')`) — the backslash form is what Windows users type
+    /// into the DirectoryPicker targeting a WSL host. `expand_tilde`
+    /// previously handled only `~` and `~/`, so `~\proj` stayed a literal
+    /// name that no endpoint could address (cluster tilde_expand regression).
+    #[test]
+    fn test_tilde_expand_backslash_form_expands_to_home() {
+        let _guard = env_lock();
+        let _env = EnvGuard::set(&[("HOME", Some("/home/tester"))]);
+        let r = resolve_user_path("~\\proj");
+        assert_eq!(r.display, "/home/tester/proj");
+        assert_eq!(r.fs_path, Some("/home/tester/proj".to_string()));
+        // The helper agrees (the `~\` prefix joins exactly like `~/`), and
+        // the bare `~\` form lands on home itself (Node path.join(home, '')).
+        assert_eq!(expand_tilde("~\\proj"), "/home/tester/proj");
+        assert_eq!(normalize_user_path("~\\"), "/home/tester");
+        // Review pin (boundary separator forms): a `~<sep>` rest that itself
+        // starts with `/` FOLDS onto home — Node's posix path.join(home,
+        // rest) concatenates then normalizes (path-utils.ts:62), so these
+        // yield `$HOME/x`; `Path::join`'s absolute-argument replacement
+        // would instead root-anchor them at `/x` (the bounced defect).
+        assert_eq!(expand_tilde("~\\/x"), "/home/tester/x");
+        assert_eq!(expand_tilde("~//x"), "/home/tester/x");
+        let r = resolve_user_path("~\\/x");
+        assert_eq!(r.display, "/home/tester/x");
+        assert_eq!(r.fs_path, Some("/home/tester/x".to_string()));
+        // Inner backslashes are NOT separators on the posix host: they stay
+        // literal, exactly like Node's join (`~\a\b` -> `$HOME/a\b`).
+        assert_eq!(expand_tilde("~\\a\\b"), "/home/tester/a\\b");
+        // …and `.`/`..` in the rest collapse like join's normalize.
+        assert_eq!(expand_tilde("~/../x"), "/home/x");
     }
 
     // ---- validate_dir (R-WIN2: Windows input on WSL resolves via the mount) ----

--- a/crates/freshell-server/src/files.rs
+++ b/crates/freshell-server/src/files.rs
@@ -734,11 +734,14 @@ fn resolve_completion_input(prefix: &str, root: Option<&str>) -> String {
 }
 
 /// Port of `isAbsoluteUserPath` (`files-router.ts:38`) for the POSIX host: a `~`
-/// prefix or a POSIX/Windows absolute path.
+/// prefix or a POSIX/Windows absolute path. `path.win32.isAbsolute` is true for
+/// any leading backslash, so win32-rooted (`\rooted\x`) and UNC
+/// (`\\srv\share\dir`) forms count as absolute too.
 fn is_absolute_user_path(input: &str) -> bool {
     let cleaned = input.trim();
     cleaned.starts_with('~')
         || cleaned.starts_with('/')
+        || cleaned.starts_with('\\') // \\srv\share UNC or \rooted win32 forms
         || (cleaned.len() >= 3 && cleaned.as_bytes()[1] == b':') // C:\u2026 drive-absolute
 }
 
@@ -1603,6 +1606,28 @@ mod tests {
         assert!(is_absolute_user_path("C:\\Users"));
         assert!(!is_absolute_user_path("rel/path"));
         assert!(!is_absolute_user_path("a.txt"));
+    }
+
+    /// FILE-03 (network shares / prefix-confusion): the legacy
+    /// `isAbsoluteUserPath` (files-router.ts:38-42) uses
+    /// `path.win32.isAbsolute`, which is TRUE for UNC (`\\srv\share\dir`) and
+    /// rooted (`\rooted\x`) forms, so `resolveCompletionInput`
+    /// (files-router.ts:46) returns them unchanged instead of anchoring them
+    /// under the caller's `root`.
+    #[test]
+    fn test_unc_classification() {
+        assert!(is_absolute_user_path("\\\\srv\\share\\dir"));
+        assert!(is_absolute_user_path("\\rooted\\x"));
+        // Observable port behavior: rooted/UNC prefixes are returned unchanged,
+        // never joined under the completion root.
+        assert_eq!(
+            resolve_completion_input("\\\\srv\\share\\dir", Some("/root")),
+            "\\\\srv\\share\\dir"
+        );
+        assert_eq!(
+            resolve_completion_input("\\rooted\\x", Some("/root")),
+            "\\rooted\\x"
+        );
     }
 
     #[test]

--- a/crates/freshell-server/src/files.rs
+++ b/crates/freshell-server/src/files.rs
@@ -1627,7 +1627,10 @@ mod tests {
         assert_eq!(collapse_dot_segments("/../.."), "/");
         assert_eq!(collapse_dot_segments("/"), "/");
         // Non-absolute / literal fallback strings stay byte-exact (fail-closed).
-        assert_eq!(collapse_dot_segments("C:\\Users\\..\\x"), "C:\\Users\\..\\x");
+        assert_eq!(
+            collapse_dot_segments("C:\\Users\\..\\x"),
+            "C:\\Users\\..\\x"
+        );
         assert_eq!(collapse_dot_segments("rel/../x"), "rel/../x");
     }
 

--- a/crates/freshell-server/src/files.rs
+++ b/crates/freshell-server/src/files.rs
@@ -521,13 +521,17 @@ fn add_unique_directory(
     directories.push(trimmed.to_string());
 }
 
-/// Normalize a user-supplied directory path: expand a leading `~`/`~/\u2026` to `$HOME`
+/// Normalize a user-supplied directory path: sanitize the raw input first
+/// (`sanitizeUserPathInput` runs on EVERY flavor at the top of Node's
+/// `normalizeUserPath`, `path-utils.ts:55` → `:24-30`: trim whitespace, strip
+/// one pair of wrapping quotes, re-trim), then expand a leading `~`/`~/\u2026` to `$HOME`
 /// and trim trailing separators (mirrors `path-utils.ts#normalizeUserPath` for the
 /// POSIX host the oracle runs on \u2014 the `\\wsl$\u2026` Windows flavor is a later step,
 /// not exercised by the Linux-host e2e). Returns the path unchanged when it does
 /// not resolve.
 pub(crate) fn normalize_user_path(input: &str) -> String {
-    let expanded = expand_tilde(input);
+    let cleaned = sanitize_user_path_input(input);
+    let expanded = expand_tilde(&cleaned);
     trim_trailing_separators(&expanded)
 }
 
@@ -1547,6 +1551,34 @@ mod tests {
         assert_eq!(expand_tilde("~"), "/home/tester");
         assert_eq!(expand_tilde("~/proj"), "/home/tester/proj");
         assert_eq!(expand_tilde("/abs"), "/abs");
+    }
+
+    /// posix_not_sanitized regression: Node sanitizes EVERY flavor's input at
+    /// the top of `normalizeUserPath` (`path-utils.ts:55` →
+    /// `sanitizeUserPathInput` `:24-30`: trim whitespace, strip one pair of
+    /// wrapping quotes, re-trim). This port previously sanitized only
+    /// `resolve_user_path`'s Windows branch, so a space-padded or shell-quoted
+    /// POSIX path was stat'd/written verbatim.
+    #[test]
+    fn test_posix_input_trims_and_unquotes() {
+        let _guard = env_lock();
+        let _env = EnvGuard::set(&[("HOME", Some("/home/tester"))]);
+        // Leading/trailing whitespace padding is trimmed.
+        assert_eq!(normalize_user_path("/tmp/x "), "/tmp/x");
+        assert_eq!(normalize_user_path("  /tmp/x"), "/tmp/x");
+        // One pair of matching wrapping quotes (a shell-pasted path) is stripped.
+        assert_eq!(normalize_user_path("\"/tmp/x\""), "/tmp/x");
+        assert_eq!(normalize_user_path("'/tmp/x'"), "/tmp/x");
+        // The sanitize runs BEFORE tilde expansion (path-utils.ts:55 then
+        // `:58-63`), so a padded/quoted `~` still expands.
+        assert_eq!(normalize_user_path(" \"~/proj\" "), "/home/tester/proj");
+        // A quotes-only input sanitizes to empty, like Node's `''` return for a
+        // falsy `cleaned` (path-utils.ts:26,56).
+        assert_eq!(normalize_user_path("\"\""), "");
+        // The display/fs path every handler consumes carry the sanitized form.
+        let r = resolve_user_path(" \"/tmp/x\" ");
+        assert_eq!(r.display, "/tmp/x");
+        assert_eq!(r.fs_path, Some("/tmp/x".to_string()));
     }
 
     #[test]

--- a/crates/freshell-server/src/files.rs
+++ b/crates/freshell-server/src/files.rs
@@ -437,7 +437,13 @@ async fn complete(
 /// common "directory already there" case never takes that branch. This port
 /// therefore never pre-checks existence \u2014 it always attempts the create and
 /// reports `existed` purely from what `create_dir_all` tells it (i.e. never true
-/// on success), matching the original's observable behavior exactly.
+/// on success), matching the original's observable behavior exactly. Both of
+/// the original's 409 "Path exists but is not a directory" branches are mapped:
+/// EEXIST-on-a-non-directory (`files-router.ts:265-271`, the target itself is
+/// an existing file) and ENOTDIR (`files-router.ts:272-274`, an INTERMEDIATE
+/// component is a file, e.g. mkdir of `<existing-file>/sub` — the target does
+/// not exist, so this maps from `ErrorKind::NotADirectory`, never from an
+/// existence re-check).
 /// Windows-flavor inputs convert through the WSL mount before create_dir_all; inputs with no native address on this host are rejected with 400 instead of creating a literal backslash-named directory.
 async fn mkdir(
     State(state): State<FilesState>,
@@ -476,14 +482,19 @@ async fn mkdir(
         }
         Err(err) => match err.kind() {
             std::io::ErrorKind::PermissionDenied => forbidden_msg("Permission denied"),
+            // Node's ENOTDIR branch (`files-router.ts:272-274`): an INTERMEDIATE
+            // path component exists but is not a directory (e.g. mkdir of
+            // `<existing-file>/sub`) → 409. The target itself does NOT exist in
+            // this case, so it must be mapped from the error kind — re-checking
+            // the target's existence (the EEXIST branch below) can never catch
+            // it and would wrongly fall through to 500.
+            std::io::ErrorKind::NotADirectory => conflict_not_a_directory(),
             _ => {
-                // A path component that exists but is not a directory \u2192 409.
+                // Node's EEXIST-on-a-non-directory branch
+                // (`files-router.ts:265-271`): the TARGET itself exists but is
+                // not a directory → 409.
                 if Path::new(&fs_path).exists() {
-                    (
-                        StatusCode::CONFLICT,
-                        Json(json!({ "error": "Path exists but is not a directory" })),
-                    )
-                        .into_response()
+                    conflict_not_a_directory()
                 } else {
                     internal_error(&err.to_string())
                 }
@@ -753,6 +764,16 @@ pub(crate) fn forbidden() -> Response {
 /// `403 { "error": <msg> }` \u2014 the mkdir permission-deny shape.
 fn forbidden_msg(msg: &str) -> Response {
     (StatusCode::FORBIDDEN, Json(json!({ "error": msg }))).into_response()
+}
+
+/// `409 { "error": "Path exists but is not a directory" }` — the mkdir
+/// EEXIST-non-directory / ENOTDIR shape (`files-router.ts:270,273`).
+fn conflict_not_a_directory() -> Response {
+    (
+        StatusCode::CONFLICT,
+        Json(json!({ "error": "Path exists but is not a directory" })),
+    )
+        .into_response()
 }
 
 /// `404 { "error": <msg> }`.
@@ -1459,6 +1480,24 @@ mod tests {
         assert_eq!(v["existed"], false);
         assert_eq!(v["resolvedPath"], target);
         assert!(std::path::Path::new(&target).is_dir());
+    }
+
+    // Intentional: env lock held across `.await` BY DESIGN (see above).
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn test_mkdir_enotdir_is_409_not_500() {
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        // An INTERMEDIATE component that is a FILE: recursive mkdir fails
+        // ENOTDIR, which Node maps to 409 "Path exists but is not a directory"
+        // (`files-router.ts:272-274`) — never a 500.
+        std::fs::write(tmp.path().join("blocker"), b"x").unwrap();
+        let target = format!("{}/blocker/sub", tmp.path().to_string_lossy());
+        let resp = mkdir_resp(&target).await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"], "Path exists but is not a directory");
+        assert!(!std::path::Path::new(&target).exists());
     }
 
     #[test]


### PR DESCRIPTION
Ports 5 reviewed, tested Node-parity fixes for `crates/freshell-server/src/files.rs` from the qa-campaign branch (`qa-campaign-20260806`, 887 commits behind main — hand-ported, not cherry-picked) onto current main. Per-fix red-green TDD: each fix's origin tests were added first and watched FAIL on current main, then the implementation was ported until green.

| Origin | Fix | Red evidence (pre-fix) | Port commit |
|---|---|---|---|
| `3d50937a6` | mkdir across a file component: 500 -> 409 "Path exists but is not a directory" (Node's ENOTDIR branch, files-router.ts:272-274) | `test_mkdir_enotdir_is_409_not_500` got 500, expected 409 | `75d3a65a1` |
| `b9a885e4f` | POSIX inputs sanitized before normalize (trim + strip one wrapping quote pair), like Node's sanitizeUserPathInput on every flavor | `test_posix_input_trims_and_unquotes` returned the verbatim padded spelling | `b306f7164` |
| `0f024b1a3` | UNC (`\\srv\share\dir`) and rooted (`\rooted\x`) forms classified absolute (path.win32.isAbsolute), no longer anchored under the completion root | `test_unc_classification`: `is_absolute_user_path("\\\\srv\\share\\dir")` was false | `38cbf4115` |
| `e02f3d6a2` | `.`/`..` segments collapsed lexically in normalize_user_path (Node's path.posix.resolve at path-utils.ts:69-70); validate-dir on `dir/nope/../real` now validates | `test_dotseg_collapse_display`: valid:false, expected true | `71b085091` |
| `fdb316f3d` + `dd6d6b36b` | Windows-style `~\folder` expanded to $HOME incl. review pins (~\\/x, ~//x fold onto home; inner backslashes stay literal; `..` collapses) — combined final intent | `test_tilde_expand_backslash_form_expands_to_home`: `~\proj` stayed literal | `e4ad1bc68` |

The `collapse_dot_segments` helper both dot-segment fixes build on is ported from the same branch's FILE-06 commit `6f556d566` (helper + unit test only, not FILE-06's sandbox-comparison rework) in `c1b9de7d9`.

Not ported (deliberate): the .ico content-type fix (`e413b31f0`) and the weak-ETag fix (`714d6a3d4`) — they depend on the /local-file route being built in the separate fix/local-file-route lane and will ride with it.

Verification: `cargo fmt` clean, `cargo clippy -p freshell-server -- -D warnings` clean, `cargo test -p freshell-server` full crate suite green: 770 passed, 0 failed, 1 ignored (757 bin unit + 13 integration).