### PR TITLE
fix(server): implement /local-file route on rust server

### DIFF
--- a/crates/freshell-server/src/files.rs
+++ b/crates/freshell-server/src/files.rs
@@ -33,6 +33,25 @@
 //! and read-only against the retained client; no `server/` or `shared/` source is
 //! touched.
 //!
+//! FILE-01: this module also hosts `GET /local-file` (port of
+//! `server/local-file-router.ts:42-79`), the raw-byte lane the retained
+//! Browser pane uses for `file://` entries
+//! (`src/components/panes/BrowserPane.tsx:68-91` rewrites every `file://` URL
+//! to `/local-file?path=<p>` for iframe loading). Same auth gate as above
+//! (header-or-cookie, which is exactly what the original re-implements at
+//! `local-file-router.ts:45-56`), then `sendFile`-style byte serving with the
+//! original's stable error shapes: 400 `path query parameter required`,
+//! 404 `File not found`, 400 `Cannot serve directories`, 500
+//! `Failed to read file metadata` (stat errors) / `Failed to send file`
+//! (read errors). NOTE: unlike the `/api/files/*` handlers, the original
+//! applies NO `allowedFilePaths` sandbox to this route (`server/index.ts:190`
+//! mounts it bare), so none is applied here.
+//! FILE-02: `/local-file` preserves Windows drive and UNC file URLs —
+//! `file:///C:/…` and `file://server/share/…` arrive (exactly-once decoded
+//! from the query param) as `C:/…` and `//server/share/…`, and
+//! [`resolve_for_local_file`] keeps the drive / `\\server\share` device
+//! instead of losing it to cwd-anchoring or separator folding.
+//!
 //! R3 (security-relevant): `allowedFilePaths` sandbox enforcement reads the LIVE
 //! [`SettingsStore`] on every request (not a boot-time snapshot), so a
 //! `PATCH /api/settings` toggling the sandbox takes effect immediately \u2014 the
@@ -44,7 +63,7 @@ use std::sync::Arc;
 
 use axum::{
     extract::{Query, State},
-    http::{HeaderMap, StatusCode},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, post},
     Json, Router,
@@ -99,6 +118,9 @@ pub fn router(state: FilesState) -> Router {
         .route("/api/files/write", post(write_file))
         .route("/api/files/complete", get(complete))
         .route("/api/files/mkdir", post(mkdir))
+        // FILE-01: the Browser-pane `file://` byte lane (top-level mount,
+        // exactly like `server/index.ts:190`; NOT under /api/files).
+        .route("/local-file", get(local_file))
         .with_state(state)
 }
 
@@ -492,6 +514,54 @@ async fn mkdir(
     }
 }
 
+/// `GET /local-file?path=<p>` — raw `sendFile`-style bytes for the Browser
+/// pane's `file://` entries (`local-file-router.ts:42-79`).
+///
+/// Auth is the shared header-or-cookie gate ([`crate::boot::is_authed`]): the
+/// original re-implements `httpAuthMiddleware` inline here
+/// (`local-file-router.ts:45-56`) with the identical
+/// `headerToken || cookieToken` resolution and timing-safe compare, so the
+/// shared gate is byte-equivalent. Error shapes are stabilized exactly like
+/// the original: missing/empty `path` → 400 `path query parameter required`;
+/// a missing target → 404 `File not found`; a directory → 400
+/// `Cannot serve directories`; other stat failures → 500
+/// `Failed to read file metadata`; read failures after a successful stat
+/// (e.g. an unreadable file) → 500 `Failed to send file`.
+///
+/// The path runs through Node's `path.resolve` semantics only (lexical
+/// `.`/`..` collapse, relative inputs anchored at the server cwd — plus the
+/// FILE-02 drive/UNC device preservation for `C:/…` and `//server/share/…`
+/// inputs; see [`resolve_for_local_file`]): the original does NOT expand
+/// `~`, does NOT do WSL conversion, and does NOT apply any sandbox on this
+/// route — none are applied here either.
+async fn local_file(
+    State(state): State<FilesState>,
+    headers: HeaderMap,
+    Query(q): Query<PathQuery>,
+) -> Response {
+    if !crate::boot::is_authed(&headers, &state.auth_token) {
+        return unauthorized();
+    }
+    let Some(path) = q.path.filter(|p| !p.is_empty()) else {
+        return bad_request("path query parameter required");
+    };
+    let resolved = resolve_for_local_file(&path);
+    match std::fs::metadata(&resolved) {
+        Ok(meta) if meta.is_dir() => bad_request("Cannot serve directories"),
+        Ok(meta) => match std::fs::read(&resolved) {
+            Ok(bytes) => send_file_response(&resolved, &meta, bytes),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => not_found("File not found"),
+            // The original's sendFile callback maps EISDIR here to the 400 —
+            // unreachable in practice (the metadata is_dir pre-check above
+            // catches every stable directory; only a stat-then-becomes-dir
+            // race could reach it) — every other read failure is the 500.
+            Err(_) => internal_error("Failed to send file"),
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => not_found("File not found"),
+        Err(_) => internal_error("Failed to read file metadata"),
+    }
+}
+
 // \u2500\u2500 Helpers \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 
 /// `addUniqueDirectory` (`candidate-dirs.ts:11`): push a trimmed, non-empty,
@@ -698,6 +768,190 @@ fn is_absolute_user_path(input: &str) -> bool {
     cleaned.starts_with('~')
         || cleaned.starts_with('/')
         || (cleaned.len() >= 3 && cleaned.as_bytes()[1] == b':') // C:\u2026 drive-absolute
+}
+
+/// Lexical `path.resolve` segment collapse for slash-absolute inputs: `.`
+/// dropped, `..` pops the last component (clamped at the filesystem root),
+/// redundant separators folded, trailing separators stripped. Non-absolute
+/// inputs are returned unchanged (fail-closed: [`resolve_for_local_file`]
+/// cwd-anchors relative inputs BEFORE calling this, so everything it passes
+/// here is absolute). Used only by the `/local-file` lane — deliberately NOT
+/// wired into [`normalize_user_path`], whose existing callers' behavior is
+/// unchanged.
+fn collapse_dot_segments(input: &str) -> String {
+    if !input.starts_with('/') {
+        return input.to_string();
+    }
+    let mut components: Vec<&str> = Vec::new();
+    for segment in input.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                components.pop();
+            }
+            _ => components.push(segment),
+        }
+    }
+    if components.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{}", components.join("/"))
+    }
+}
+
+/// Node's `path.resolve(filePath)` (`local-file-router.ts:64`):
+///
+/// * FILE-02: drive-absolute (`C:\…` and the client's forward-slash spelling
+///   `C:/…`) and UNC (`\\server\share\…` and the client's forward-slash
+///   spelling `//server/share/…` — `BrowserPane.tsx:75-87` sends exactly
+///   these two forms) resolve through [`win32_resolve`], Node's
+///   `path.win32.resolve` — which is what `path.resolve` IS on the win32
+///   Tauri host this route serves `file://` bytes for. The drive is never
+///   mistaken for a cwd-relative name and the UNC host is never
+///   separator-folded into a `/server/share` POSIX cousin, so on a Windows
+///   host build the result addresses the file natively. On a POSIX host the
+///   resulting backslash literal has no native address and stats `NotFound`
+///   → the same 404 the original yields from its own cwd-anchored (`C:/…` →
+///   `<cwd>/C:/…`) / folded (`//server/share/…` → `/server/share/…`)
+///   spellings — with one deliberate fail-closed divergence: Node-on-POSIX
+///   folds a crafted `//etc/x` input to `/etc/x` and could serve it, while
+///   keeping the UNC device means such an input can never resolve to a
+///   same-named local path here.
+/// * an absolute POSIX input is normalized lexically (`.`/`..` collapsed,
+///   redundant separators folded, trailing separators stripped — exactly
+///   [`collapse_dot_segments`]);
+/// * a relative input is anchored at the process cwd first, like
+///   `path.resolve`.
+///
+/// Deliberately NOT [`resolve_user_path`]: the original performs no `~`
+/// expansion and no WSL conversion here, so a `~foo` input is simply a
+/// (usually nonexistent) cwd-relative name and 404s naturally; a drive/UNC
+/// target on a WSL host likewise stats the backslash literal and 404s
+/// (`local-file-router.ts` contains no `toFilesystemPath` call).
+fn resolve_for_local_file(input: &str) -> String {
+    if let Some(resolved) = win32_resolve(input) {
+        return resolved;
+    }
+    if input.starts_with('/') {
+        collapse_dot_segments(input)
+    } else {
+        match std::env::current_dir() {
+            Ok(cwd) => collapse_dot_segments(&format!("{}/{input}", cwd.to_string_lossy())),
+            // No cwd: path.resolve cannot normalize a relative input without
+            // one; hand the literal to fs, which fails the stat naturally.
+            Err(_) => input.to_string(),
+        }
+    }
+}
+
+/// The `sendFile` 200 (send@0.19.2 `SendStream.prototype.setHeader`/`type`):
+/// the bytes plus `Accept-Ranges: bytes`, `Cache-Control: public, max-age=0`,
+/// `Last-Modified` (mtime.toUTCString shape), the weak
+/// `W/"<size-hex>-<mtimeMs-hex>"` ETag, and a mime-db content-type — unknown
+/// extensions get NO Content-Type header at all (send's `if (!type) return`,
+/// deliberately matching the original rather than forcing octet-stream).
+/// Conditional-GET (304) / Range (206) revalidation from send is not ported:
+/// a full 200 re-fetch is always byte-correct.
+fn send_file_response(resolved: &str, meta: &std::fs::Metadata, bytes: Vec<u8>) -> Response {
+    // `Body` (not `Vec<u8>`): axum's Vec<u8> IntoResponse injects a default
+    // `application/octet-stream` Content-Type, which would break send's
+    // unknown-extension = NO Content-Type behavior (`if (!type) return`).
+    let mut response = (StatusCode::OK, axum::body::Body::from(bytes)).into_response();
+    let h = response.headers_mut();
+    if let Some(content_type) = local_file_content_type(resolved) {
+        h.insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
+    }
+    h.insert(header::ACCEPT_RANGES, HeaderValue::from_static("bytes"));
+    h.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("public, max-age=0"),
+    );
+    if let Ok(modified) = meta.modified() {
+        let ts = chrono::DateTime::<chrono::Utc>::from(modified);
+        // mtime.toUTCString(): RFC-7231 IMF-fixdate (`%a`/`%b` are chrono's
+        // fixed English abbreviations, locale-independent).
+        if let Ok(v) = HeaderValue::from_str(&ts.format("%a, %d %b %Y %H:%M:%S GMT").to_string()) {
+            h.insert(header::LAST_MODIFIED, v);
+        }
+        // etag@1.8.1 stattag: '"' + size.toString(16) + '-' +
+        // mtime.getTime().toString(16) + '"', prefixed `W/` — send@0.19.2
+        // calls `etag(stat)` with NO options (send/index.js:879), and etag
+        // defaults `weak` to `isstats(entity)` = true for a fs.Stats
+        // (etag/index.js:76-79, 91-93). (`weak: false` is only the default
+        // for string/Buffer entities.)
+        if let Ok(v) = HeaderValue::from_str(&format!(
+            "W/\"{:x}-{}\"",
+            meta.len(),
+            js_hex(ts.timestamp_millis())
+        )) {
+            h.insert(header::ETAG, v);
+        }
+    }
+    response
+}
+
+/// JS `Number#toString(16)`: sign-then-magnitude on negatives, unlike Rust's
+/// two's-complement `{:x}` (only reachable for pre-1970 mtimes).
+fn js_hex(n: i64) -> String {
+    if n < 0 {
+        format!("-{:x}", n.unsigned_abs())
+    } else {
+        format!("{n:x}")
+    }
+}
+
+/// send's `type()`: send@0.19.2 vendors mime@1.6.0 (not mime-types/mime-db
+/// 1.52), whose baked-in `types.json` snapshot — taken from mime-db ~1.40 —
+/// predates the `image/vnd.microsoft.icon` alias and maps `ico` to
+/// `image/x-icon` only. Extension lookup, lowercased, plus `charsets.lookup`
+/// (db charset else `text/*` → `UTF-8`, uppercase). Unknown → `None` (no
+/// header, see [`send_file_response`]). Table values verified against
+/// `mime.lookup`/`mime.charsets.lookup` on the vendored package. Note this
+/// track's values differ from [`crate::serve_client`]'s SPA table where the
+/// original differs (e.g. the SPA's text-type charsets are lowercase `utf-8`;
+/// send's `charsets.lookup` yields uppercase `UTF-8`).
+fn local_file_content_type(path: &str) -> Option<&'static str> {
+    let ext = Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    match ext.as_str() {
+        "html" | "htm" | "shtml" => Some("text/html; charset=UTF-8"),
+        "js" | "mjs" => Some("application/javascript; charset=UTF-8"),
+        "css" => Some("text/css; charset=UTF-8"),
+        "json" | "map" => Some("application/json; charset=UTF-8"),
+        "txt" | "text" | "conf" | "def" | "list" | "log" | "in" | "ini" => {
+            Some("text/plain; charset=UTF-8")
+        }
+        "md" | "markdown" => Some("text/markdown; charset=UTF-8"),
+        "csv" => Some("text/csv; charset=UTF-8"),
+        "yaml" | "yml" => Some("text/yaml; charset=UTF-8"),
+        "xml" => Some("application/xml"),
+        "svg" => Some("image/svg+xml"),
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        "ico" => Some("image/x-icon"),
+        "bmp" => Some("image/bmp"),
+        "avif" => Some("image/avif"),
+        "pdf" => Some("application/pdf"),
+        "wasm" => Some("application/wasm"),
+        "zip" => Some("application/zip"),
+        "gz" => Some("application/gzip"),
+        "bin" => Some("application/octet-stream"),
+        "woff" => Some("font/woff"),
+        "woff2" => Some("font/woff2"),
+        "ttf" => Some("font/ttf"),
+        "otf" => Some("font/otf"),
+        "mp4" => Some("video/mp4"),
+        "webm" => Some("video/webm"),
+        "mp3" => Some("audio/mpeg"),
+        "wav" => Some("audio/wave"),
+        "ogg" => Some("audio/ogg"),
+        _ => None,
+    }
 }
 
 /// `401 { "error": "Unauthorized" }` \u2014 byte-shape-equal to the original's reject.
@@ -1546,7 +1800,7 @@ mod tests {
 
     #[tokio::test]
     async fn candidate_dirs_empty_state_has_no_home_fallback() {
-        // R8: an empty candidate set stays `[]` \u2014 no `$HOME` fallback entry.
+        // R8: an empty candidate set stays `[]` — no `$HOME` fallback entry.
         let state = FilesState {
             auth_token: Arc::new("tok".to_string()),
             settings: SettingsStore::load(None, Vec::new()),
@@ -1560,5 +1814,563 @@ mod tests {
             .unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["directories"], json!([]));
+    }
+
+    // ---- FILE-01: GET /local-file (local-file-router.ts) ----
+
+    /// Body bytes of a response, exactly as sent.
+    async fn body_bytes(resp: Response) -> Vec<u8> {
+        axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec()
+    }
+
+    async fn local_file_resp(
+        state: &FilesState,
+        headers: HeaderMap,
+        path: Option<&str>,
+    ) -> Response {
+        local_file(
+            State(state.clone()),
+            headers,
+            Query(PathQuery {
+                path: path.map(str::to_string),
+            }),
+        )
+        .await
+        .into_response()
+    }
+
+    #[tokio::test]
+    async fn local_file_rejects_bad_and_missing_credentials() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("a.txt");
+        std::fs::write(&file, b"x").unwrap();
+        let path = file.to_string_lossy().into_owned();
+
+        // No credentials at all -> 401 { "error": "Unauthorized" }.
+        let resp = local_file_resp(&test_state(), HeaderMap::new(), Some(&path)).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"], "Unauthorized");
+
+        // A WRONG header is rejected even though the file exists.
+        let mut bad = HeaderMap::new();
+        bad.insert("x-auth-token", "nope".parse().unwrap());
+        let resp = local_file_resp(&test_state(), bad, Some(&path)).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // A wrong COOKIE is rejected likewise (both channels gate).
+        let mut bad_cookie = HeaderMap::new();
+        bad_cookie.insert("cookie", "freshell-auth=nope".parse().unwrap());
+        let resp = local_file_resp(&test_state(), bad_cookie, Some(&path)).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // Positive control: the good header serves.
+        let resp = local_file_resp(&test_state(), auth_headers(), Some(&path)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn local_file_requires_path_query_parameter() {
+        for missing in [None, Some("")] {
+            let resp = local_file_resp(&test_state(), auth_headers(), missing).await;
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "{missing:?}");
+            let v = body_json(resp).await;
+            assert_eq!(v["error"], "path query parameter required");
+        }
+    }
+
+    #[tokio::test]
+    async fn local_file_serves_html_utf8_bytes_with_send_headers() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Multi-byte UTF-8 content must round-trip unmangled.
+        let content = "<h1>héllo — 世界</h1>\n";
+        let file = tmp.path().join("page.html");
+        std::fs::write(&file, content.as_bytes()).unwrap();
+
+        let resp =
+            local_file_resp(&test_state(), auth_headers(), Some(&file.to_string_lossy())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/html; charset=UTF-8"
+        );
+        // send's setHeader: Accept-Ranges / Cache-Control / Last-Modified / ETag.
+        assert_eq!(resp.headers().get(header::ACCEPT_RANGES).unwrap(), "bytes");
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "public, max-age=0"
+        );
+        assert!(resp
+            .headers()
+            .get(header::LAST_MODIFIED)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .ends_with(" GMT"));
+        // etag stattag: 'W/"'<size hex>'-'<mtimeMs hex>'"' — WEAK (send
+        // passes a fs.Stats to etag@1.8.1 with no options, so `weak`
+        // defaults to true).
+        let etag = resp.headers().get(header::ETAG).unwrap().to_str().unwrap();
+        let len = content.len();
+        let expected_prefix = format!("W/\"{len:x}-");
+        assert!(etag.starts_with(&expected_prefix), "etag {etag}");
+        let ms_hex = etag[expected_prefix.len()..etag.len() - 1].to_string();
+        assert!(!ms_hex.is_empty() && ms_hex.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(body_bytes(resp).await, content.as_bytes());
+    }
+
+    /// send@0.19.2 calls `etag(stat)` with NO options (send/index.js:879);
+    /// etag@1.8.1 then defaults `weak` to `isstats(entity)` = true
+    /// (etag/index.js:76-79) and prefixes `W/` (etag/index.js:91-93). The
+    /// original /local-file therefore sends `ETag: W/"<size-hex>-<mtime-hex>"`
+    /// — the WEAK stattag, never the strong form (`weak` only defaults false
+    /// for string/Buffer entities; a fs.Stats is weak by default).
+    #[tokio::test]
+    async fn test_etag_shape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("a.txt");
+        std::fs::write(&file, b"etag-me").unwrap();
+        let resp =
+            local_file_resp(&test_state(), auth_headers(), Some(&file.to_string_lossy())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let etag = resp
+            .headers()
+            .get(header::ETAG)
+            .expect("sendFile always sets an ETag")
+            .to_str()
+            .unwrap();
+        let len = b"etag-me".len();
+        assert!(
+            etag.starts_with(&format!("W/\"{len:x}-")),
+            "original ETag is the WEAK stattag W/\"<size-hex>-<mtime-hex>\"; got {etag}"
+        );
+        assert!(etag.ends_with('"'));
+    }
+
+    #[tokio::test]
+    async fn local_file_serves_image_and_binary_bytes_exactly() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Invalid-UTF-8, non-ASCII binary content (a fake PNG magic + NULs).
+        let bytes: Vec<u8> = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF];
+
+        let png = tmp.path().join("img.png");
+        std::fs::write(&png, &bytes).unwrap();
+        let resp =
+            local_file_resp(&test_state(), auth_headers(), Some(&png.to_string_lossy())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "image/png"
+        );
+        assert_eq!(body_bytes(resp).await, bytes, "binary bytes unmangled");
+
+        // .bin is an explicit mime-db octet-stream entry.
+        let bin = tmp.path().join("blob.bin");
+        std::fs::write(&bin, &bytes).unwrap();
+        let resp =
+            local_file_resp(&test_state(), auth_headers(), Some(&bin.to_string_lossy())).await;
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/octet-stream"
+        );
+
+        // An extension mime-db does NOT know: send sets NO Content-Type at
+        // all (`if (!type) return`) — never a guessed default.
+        let weird = tmp.path().join("blob.xyzzy");
+        std::fs::write(&weird, &bytes).unwrap();
+        let resp = local_file_resp(
+            &test_state(),
+            auth_headers(),
+            Some(&weird.to_string_lossy()),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(resp.headers().get(header::CONTENT_TYPE).is_none());
+
+        // Extension case is folded (mime.lookup lowercases).
+        let upper = tmp.path().join("IMG2.PNG");
+        std::fs::write(&upper, &bytes).unwrap();
+        let resp = local_file_resp(
+            &test_state(),
+            auth_headers(),
+            Some(&upper.to_string_lossy()),
+        )
+        .await;
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "image/png"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_file_missing_is_404_directory_is_400() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("nope.txt");
+        let resp = local_file_resp(
+            &test_state(),
+            auth_headers(),
+            Some(&missing.to_string_lossy()),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"], "File not found");
+
+        // A directory — requested with AND without a trailing separator
+        // (path.resolve strips it before stat) — is the 400 shape.
+        for dir in [
+            tmp.path().to_string_lossy().into_owned(),
+            format!("{}/", tmp.path().to_string_lossy()),
+        ] {
+            let resp = local_file_resp(&test_state(), auth_headers(), Some(&dir)).await;
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "{dir}");
+            let v = body_json(resp).await;
+            assert_eq!(v["error"], "Cannot serve directories");
+        }
+    }
+
+    #[tokio::test]
+    async fn local_file_dotdot_collapses_lexically_like_path_resolve() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real.txt");
+        std::fs::write(&real, b"real").unwrap();
+        // path.resolve("<tmp>/nope/../real.txt") -> "<tmp>/real.txt"
+        // LEXICALLY, so the never-existing `nope` component must not matter
+        // (a kernel-resolved naive string would ENOENT here).
+        let spelled = format!("{}/nope/../real.txt", tmp.path().to_string_lossy());
+        let resp = local_file_resp(&test_state(), auth_headers(), Some(&spelled)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_bytes(resp).await, b"real");
+    }
+
+    #[test]
+    fn resolve_for_local_file_absolute_and_relative() {
+        assert_eq!(resolve_for_local_file("/a//b/./c/"), "/a/b/c");
+        assert_eq!(resolve_for_local_file("/a/../b"), "/b");
+        assert_eq!(resolve_for_local_file("/"), "/");
+        // Relative inputs anchor at the server cwd (path.resolve semantics).
+        let cwd = std::env::current_dir()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            resolve_for_local_file("x/../y.txt"),
+            collapse_dot_segments(&format!("{cwd}/x/../y.txt"))
+        );
+    }
+
+    #[test]
+    fn js_hex_matches_js_tostring16() {
+        assert_eq!(js_hex(0), "0");
+        assert_eq!(js_hex(500), "1f4");
+        // JS Number#toString(16) is sign-then-magnitude on negatives.
+        assert_eq!(js_hex(-500), "-1f4");
+    }
+
+    #[test]
+    fn local_file_content_type_matches_vendored_mime_db() {
+        let cases: &[(&str, Option<&str>)] = &[
+            ("a.html", Some("text/html; charset=UTF-8")),
+            ("a.txt", Some("text/plain; charset=UTF-8")),
+            ("a.md", Some("text/markdown; charset=UTF-8")),
+            ("a.json", Some("application/json; charset=UTF-8")),
+            ("a.png", Some("image/png")),
+            ("a.ico", Some("image/x-icon")),
+            ("a.xml", Some("application/xml")), // no charset in mime-db
+            ("a.bin", Some("application/octet-stream")),
+            ("a.woff2", Some("font/woff2")),
+            ("noext", None),
+            (".png", None), // dotfile: no extension, like path.extname
+        ];
+        for (path, expected) in cases {
+            assert_eq!(local_file_content_type(path), *expected, "{path}");
+        }
+    }
+
+    /// send@0.19.2's vendored mime@1.6.0 maps `.ico` to `image/x-icon`
+    /// (its baked-in types.json is a mime-db ~1.40 snapshot that predates the
+    /// `image/vnd.microsoft.icon` alias — `types.json` contains only
+    /// `image/x-icon` for `ico`), so the original /local-file sets
+    /// `Content-Type: image/x-icon` — not `image/vnd.microsoft.icon`.
+    #[test]
+    fn test_mime_content_type_ico_is_image_x_icon() {
+        assert_eq!(local_file_content_type("a.ico"), Some("image/x-icon"));
+        // send lowercases the extension before lookup (mime.lookup lowercases
+        // internally), so a `.ICO` spelling takes the same branch.
+        assert_eq!(local_file_content_type("A.ICO"), Some("image/x-icon"));
+    }
+
+    #[cfg(unix)]
+    fn running_as_root() -> bool {
+        // SAFETY: geteuid is always safe to call.
+        unsafe { libc::geteuid() == 0 }
+    }
+
+    // Permission fixtures are skipped under root, which bypasses mode bits
+    // (chmod 000 reads fine) and would invert the 500 expectation.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_file_unreadable_file_is_500_failed_to_send() {
+        use std::os::unix::fs::PermissionsExt;
+        if running_as_root() {
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("locked.txt");
+        std::fs::write(&file, b"secret").unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o000)).unwrap();
+        // stat SUCCEEDS on the mode-000 file, so this takes the sendFile
+        // read-error branch — 500 "Failed to send file".
+        let resp =
+            local_file_resp(&test_state(), auth_headers(), Some(&file.to_string_lossy())).await;
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"], "Failed to send file");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_file_unsearchable_parent_is_500_metadata_error() {
+        use std::os::unix::fs::PermissionsExt;
+        if running_as_root() {
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("locked-dir");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(sub.join("f.txt"), b"secret").unwrap();
+        std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o000)).unwrap();
+        // stat itself fails (EACCES on the parent) -> the stat-error branch.
+        let target = sub.join("f.txt");
+        let resp = local_file_resp(
+            &test_state(),
+            auth_headers(),
+            Some(&target.to_string_lossy()),
+        )
+        .await;
+        std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"], "Failed to read file metadata");
+    }
+
+    /// `encodeURIComponent` (BrowserPane.tsx:87): every byte outside the
+    /// unreserved set becomes %XX — INCLUDING `/` (unlike a path encoder).
+    fn encode_uri_component(input: &str) -> String {
+        let mut out = String::new();
+        for &b in input.as_bytes() {
+            let unreserved = b.is_ascii_alphanumeric()
+                || matches!(
+                    b,
+                    b'-' | b'_' | b'.' | b'!' | b'~' | b'*' | b'\'' | b'(' | b')'
+                );
+            if unreserved {
+                out.push(b as char);
+            } else {
+                out.push_str(&format!("%{b:02X}"));
+            }
+        }
+        out
+    }
+
+    /// Router-level: a Unicode filename arrives percent-encoded (as the
+    /// Browser pane sends it), decodes exactly once, and serves — authed by
+    /// the URL-decoded `freshell-auth` COOKIE alone (the iframe channel).
+    #[tokio::test]
+    async fn local_file_unicode_name_and_cookie_auth_through_router() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::util::ServiceExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("café ☕ 世界.txt");
+        std::fs::write(&file, "châu 🍜".as_bytes()).unwrap();
+        let encoded = encode_uri_component(&file.to_string_lossy());
+
+        // A token needing cookie percent-encoding (BrowserPane stores the
+        // cookie encodeURIComponent'ed); the gate decodes it before compare.
+        let state = FilesState {
+            auth_token: Arc::new("a b/c".to_string()),
+            ..test_state()
+        };
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/local-file?path={encoded}"))
+            .header("cookie", "freshell-auth=a%20b%2Fc")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router(state).oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/plain; charset=UTF-8"
+        );
+        assert_eq!(body_bytes(resp).await, "châu 🍜".as_bytes());
+    }
+
+    // ---- FILE-02: drive/UNC device preservation + exactly-once decode ----
+
+    #[test]
+    fn local_file_resolve_preserves_windows_drive() {
+        // The client's `file:///C:/…` conversion strips only the leading
+        // slash (`BrowserPane.tsx:75-80`) — the server must keep the drive
+        // instead of cwd-anchoring it as a relative name. On the win32 host
+        // `C:\…` is natively addressable; on POSIX it stats NotFound -> the
+        // same 404 the original yields.
+        assert_eq!(
+            resolve_for_local_file("C:/Users/dan/notes.txt"),
+            "C:\\Users\\dan\\notes.txt"
+        );
+        // Drive-letter case is preserved as typed (path.win32.resolve).
+        assert_eq!(resolve_for_local_file("c:/"), "c:\\");
+        // Backslash drive spellings keep the drive too…
+        assert_eq!(
+            resolve_for_local_file("D:\\proj\\sub\\..\\x.txt"),
+            "D:\\proj\\x.txt"
+        );
+        // …and dot segments collapse INSIDE the drive (never above its root).
+        assert_eq!(resolve_for_local_file("D:/../x.txt"), "D:\\x.txt");
+        // A drive-absolute input is never treated as cwd-relative.
+        let cwd = std::env::current_dir()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert!(!resolve_for_local_file("E:/data/f.bin").starts_with(&cwd));
+    }
+
+    #[test]
+    fn local_file_resolve_preserves_unc_host() {
+        // `BrowserPane.tsx:82-85` reattaches the URL hostname as a
+        // forward-slash `//server/share` prefix; the host must survive —
+        // folding `//srv/sh` to `/srv/sh` would address a same-named LOCAL
+        // path instead of the share.
+        assert_eq!(
+            resolve_for_local_file("//file-server/Projects/report FINAL.txt"),
+            "\\\\file-server\\Projects\\report FINAL.txt"
+        );
+        // Spaces and Unicode share/dir names survive (HARNESS-06 shape).
+        assert_eq!(
+            resolve_for_local_file("//srv/Archïve/café 世界.txt"),
+            "\\\\srv\\Archïve\\café 世界.txt"
+        );
+        // Backslash UNC spellings keep the device as well.
+        assert_eq!(
+            resolve_for_local_file("\\\\srv\\share\\x.txt"),
+            "\\\\srv\\share\\x.txt"
+        );
+        // A `..` hop is clamped at the share root — it cannot cross into a
+        // sibling share (path.win32.resolve semantics).
+        assert_eq!(
+            resolve_for_local_file("//srv/share/../x.txt"),
+            "\\\\srv\\share\\x.txt"
+        );
+        // Bare share root gets Node's trailing `\\server\share\` form.
+        assert_eq!(resolve_for_local_file("//srv/share"), "\\\\srv\\share\\");
+    }
+
+    #[test]
+    fn local_file_resolve_other_lanes_unchanged() {
+        // Single-slash absolutes still collapse lexically (never reclassified
+        // as UNC: a `//` prefix is a Windows UNC spelling, `/` alone is not).
+        assert_eq!(resolve_for_local_file("/a//b/../c/"), "/a/c");
+        // Relatives still anchor at the process cwd, and `~` is NOT expanded
+        // on this route (both Node `path.resolve` parity).
+        let cwd = std::env::current_dir()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            resolve_for_local_file("rel/x.txt"),
+            format!("{cwd}/rel/x.txt")
+        );
+        assert_eq!(resolve_for_local_file("~/x.txt"), format!("{cwd}/~/x.txt"));
+        // Drive-relative `C:foo` is cwd-dependent, so win32_resolve refuses it
+        // (like deterministic-core `resolve_user_path`) and it keeps the
+        // legacy cwd-anchored lane.
+        let resolved = resolve_for_local_file("C:foo");
+        assert!(resolved.ends_with("/C:foo"), "{resolved}");
+        // The documented fail-closed divergence: a crafted `//etc/x` input
+        // keeps its UNC device and can never fold onto the local `/etc/x`
+        // (Node-on-POSIX would fold and could serve it). The share root gets
+        // Node's trailing `\\server\share\` form (path.win32.resolve renders
+        // device roots with the separator, exactly like `C:\`).
+        assert_eq!(resolve_for_local_file("//etc/x"), "\\\\etc\\x\\");
+    }
+
+    #[tokio::test]
+    async fn local_file_unc_and_drive_targets_fail_with_bounded_error() {
+        // PW-TAURI-WIN's "remove the share" leg, server-side: an
+        // unreachable/unaddressable drive or share target must produce the
+        // original's bounded recoverable JSON error — never a hang, never a
+        // 500, never bytes from a same-named local cousin. (On this POSIX
+        // host the backslash literal has no native address; on a Windows
+        // host with the share removed the UNC stat fails the same way.)
+        for path in [
+            "//removed-share-server/public/x.txt",
+            "\\\\removed-share-server\\public\\x.txt",
+            "C:/definitely/not/here.bin",
+        ] {
+            let resp = local_file_resp(&test_state(), auth_headers(), Some(path)).await;
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND, "{path}");
+            let v = body_json(resp).await;
+            assert_eq!(v["error"], "File not found", "{path}");
+        }
+        // …and the auth gate still runs BEFORE any path handling for these
+        // forms (a drive/UNC probe without credentials is a 401, not a 404).
+        let resp = local_file_resp(
+            &test_state(),
+            HeaderMap::new(),
+            Some("//removed-share-server/public/x.txt"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// A double-decoding server would fetch the space-name neighbor when the
+    /// request names a literal `%20` file — pin exactly-once decode and
+    /// exact-target serving through the real HTTP layer.
+    #[tokio::test]
+    async fn local_file_decodes_path_exactly_once_and_never_serves_encoded_neighbor() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::util::ServiceExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        // Neighbor pair whose names differ ONLY by literal `%20` vs a space —
+        // the "similarly prefixed neighbor" must never be served for the
+        // other's URL.
+        let literal_pct = tmp.path().join("My%20Doc.txt");
+        let spaced = tmp.path().join("My Doc.txt");
+        std::fs::write(&literal_pct, b"literal-percent-name").unwrap();
+        std::fs::write(&spaced, b"space-name").unwrap();
+
+        let get = |file: &std::path::Path| {
+            let encoded = encode_uri_component(&file.to_string_lossy());
+            let state = test_state();
+            async move {
+                let req = Request::builder()
+                    .method("GET")
+                    .uri(format!("/local-file?path={encoded}"))
+                    .header("x-auth-token", "tok")
+                    .body(Body::empty())
+                    .unwrap();
+                router(state).oneshot(req).await.unwrap()
+            }
+        };
+
+        // `My%2520Doc.txt` decodes ONCE to `My%20Doc.txt` (the literal file);
+        // a second decode would land on `My Doc.txt` and serve its bytes.
+        let resp = get(&literal_pct).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_bytes(resp).await, b"literal-percent-name");
+
+        // And the plain `%20` form decodes once to the space-named neighbor.
+        let resp = get(&spaced).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_bytes(resp).await, b"space-name");
     }
 }

--- a/crates/freshell-server/src/files.rs
+++ b/crates/freshell-server/src/files.rs
@@ -835,35 +835,6 @@ fn is_absolute_user_path(input: &str) -> bool {
         || (cleaned.len() >= 3 && cleaned.as_bytes()[1] == b':') // C:\u2026 drive-absolute
 }
 
-/// Lexical `path.resolve` segment collapse for slash-absolute inputs: `.`
-/// dropped, `..` pops the last component (clamped at the filesystem root),
-/// redundant separators folded, trailing separators stripped. Non-absolute
-/// inputs are returned unchanged (fail-closed: [`resolve_for_local_file`]
-/// cwd-anchors relative inputs BEFORE calling this, so everything it passes
-/// here is absolute). Used only by the `/local-file` lane — deliberately NOT
-/// wired into [`normalize_user_path`], whose existing callers' behavior is
-/// unchanged.
-fn collapse_dot_segments(input: &str) -> String {
-    if !input.starts_with('/') {
-        return input.to_string();
-    }
-    let mut components: Vec<&str> = Vec::new();
-    for segment in input.split('/') {
-        match segment {
-            "" | "." => {}
-            ".." => {
-                components.pop();
-            }
-            _ => components.push(segment),
-        }
-    }
-    if components.is_empty() {
-        "/".to_string()
-    } else {
-        format!("/{}", components.join("/"))
-    }
-}
-
 /// Node's `path.resolve(filePath)` (`local-file-router.ts:64`):
 ///
 /// * FILE-02: drive-absolute (`C:\…` and the client's forward-slash spelling


### PR DESCRIPTION
## The gap

The retained Browser pane rewrites every `file://` URL to `GET /local-file?path=<p>` for iframe loading (`src/components/panes/BrowserPane.tsx:68-91`). The Node server serves this (`server/index.ts:190` + `server/local-file-router.ts`); the Rust server had no such route, so browser panes on `file://` URLs broke under the Rust server.

## What the route does

`GET /local-file?path=<p>` serves raw local-file bytes to authed browser iframes:

- Header-or-cookie auth via the shared `crate::boot::is_authed` gate (byte-equivalent to the original's inline `headerToken || cookieToken` re-implementation).
- `sendFile`-style responses: mime-table Content-Type (unknown extension = NO header, like send's `if (!type) return`), `Accept-Ranges: bytes`, `Cache-Control: public, max-age=0`, `Last-Modified`, weak stattag ETag (`W/"<size-hex>-<mtimeMs-hex>"`).
- Stable error shapes: 400 `path query parameter required` / `Cannot serve directories`, 404 `File not found`, 500 `Failed to read file metadata` / `Failed to send file`.
- Path resolution is Node `path.resolve` semantics only: lexical `..` collapse, cwd-anchored relatives, Windows drive (`C:/…`) and UNC (`//server/share/…`) device preservation — including the deliberate fail-closed divergence where a crafted `//etc/x` keeps its UNC device and can never fold onto local `/etc/x`. No `~` expansion, no WSL conversion, no `allowedFilePaths` sandbox (the original mounts the route bare).

## Implementation

Hand-port of the unlanded qa-campaign FILE-01/FILE-02 reference commits onto current main. One file: `crates/freshell-server/src/files.rs` (+814/−2) — handler, `resolve_for_local_file`/`collapse_dot_segments`/`send_file_response`/`js_hex`/`local_file_content_type` helpers, route registration, and tests. TDD: the 19 tests failed first (assertion-level red against stubs), then passed against the real implementation.

## Tests

- 19 new tests in `files.rs`: auth gate (missing/wrong header/cookie), missing/empty path param, UTF-8 + binary byte-exactness, send headers + ETag shape, mime table incl. vendored-mime `ico` → `image/x-icon` and unknown-extension no-Content-Type, 404/400/500 error shapes (incl. unix permission fixtures), lexical `..` collapse, drive/UNC preservation, bounded 404 for unreachable drive/UNC, auth-before-path-handling, exactly-once percent-decoding through the real router (never serves the encoded neighbor).
- Full crate suite: 770 passed, 0 failed, 1 ignored.
- `cargo fmt` clean; `cargo clippy -p freshell-server --all-targets -- -D warnings` clean.