### PR TITLE
fix(ws): warn-log dead_session reconcile verdicts with claimed identity

### DIFF
--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -4459,6 +4459,25 @@ async fn handle_pane_reconcile(
             }
         };
     }
+    // A `dead_session` verdict parks the pane in the client's dead-sessions
+    // dialog awaiting user adjudication — the loud, user-facing end of the
+    // restore ladder. Log each one with the claimed identity so the
+    // adjudication is reconstructable from server logs alone (previously a
+    // dead verdict left no trace: derivation is pure, and the wire frame is
+    // only visible to the requesting client).
+    for v in &verdicts {
+        if matches!(v.verdict, freshell_protocol::ReconcileVerdict::DeadSession) {
+            tracing::warn!(
+                pane_key = %v.pane_key,
+                verdict = "dead_session",
+                reason = v.reason.as_deref(),
+                terminal_id = v.terminal_id.as_deref(),
+                provider = v.session_ref.as_ref().map(|s| s.provider.as_str()),
+                session_id = v.session_ref.as_ref().map(|s| s.session_id.as_str()),
+                "pane_reconcile.dead_session"
+            );
+        }
+    }
     let result = ServerMessage::PaneReconcileResult(freshell_protocol::PaneReconcileResult {
         reconcile_id: request.reconcile_id,
         boot_id: state.boot_id.as_ref().clone(),

--- a/crates/freshell-ws/tests/pane_reconcile_freshagent.rs
+++ b/crates/freshell-ws/tests/pane_reconcile_freshagent.rs
@@ -755,3 +755,150 @@ async fn old_thread_claim_after_crash_respawn_answers_the_new_terminus() {
     );
     assert_eq!(verdicts[0]["corrected"], true);
 }
+
+// ── dead_session verdict observability (WARN log at the result choke point) ──
+//
+// A `dead_session` verdict parks a pane in the client's dead-sessions dialog
+// — a loud, user-facing adjudication for which the server previously emitted
+// NO log line at all (reconstructing the "why" required ledger + on-disk
+// forensics). The verdict stream now logs once per dead verdict, with the
+// claimed identity fields, at the result-send choke point.
+
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::Layer;
+
+#[derive(Debug, Clone, Default)]
+struct CapturedEvent {
+    message: String,
+    /// The event's OWN fields only (all dead-session log fields are recorded
+    /// on the event; no span merge needed).
+    fields: std::collections::BTreeMap<String, String>,
+}
+
+#[derive(Default)]
+struct CapVisitor {
+    message: String,
+    fields: std::collections::BTreeMap<String, String>,
+}
+
+impl Visit for CapVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let rendered = format!("{value:?}");
+        if field.name() == "message" {
+            self.message = rendered;
+        } else {
+            self.fields.insert(field.name().to_string(), rendered);
+        }
+    }
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = value.to_string();
+        } else {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+    }
+}
+
+struct LogCapture {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl<S> Layer<S> for LogCapture
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = CapVisitor::default();
+        event.record(&mut visitor);
+        self.events
+            .lock()
+            .expect("capture lock")
+            .push(CapturedEvent {
+                message: visitor.message,
+                fields: visitor.fields,
+            });
+    }
+}
+
+/// Thread-local capture. `#[tokio::test]` is a current-thread runtime, so the
+/// in-process server's reconcile task (tokio::spawn'd by the accept loop) is
+/// polled on THIS thread and observes the guard — the
+/// `diag01_lifecycle_events.rs` convention.
+fn log_capture() -> (
+    Arc<Mutex<Vec<CapturedEvent>>>,
+    tracing::subscriber::DefaultGuard,
+) {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let layer = LogCapture {
+        events: Arc::clone(&events),
+    };
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let guard = tracing::subscriber::set_default(subscriber);
+    (events, guard)
+}
+
+#[tokio::test]
+async fn dead_session_verdict_is_warn_logged_with_claimed_identity() {
+    let (events, _guard) = log_capture();
+    let probe = std::sync::Arc::new(StubProbe::default());
+    // GoneObserved: ledger-observed before, Absent now.
+    probe
+        .answers
+        .lock()
+        .unwrap()
+        .insert(("codex".into(), "gone-1".into()), SessionExistence::Absent);
+    probe
+        .observed
+        .lock()
+        .unwrap()
+        .insert(("codex".into(), "gone-1".into()));
+    let server = spawn_server_with_probe(probe).await;
+    let (mut ws, _ready) = connect(&server.url, true, true).await;
+    let verdicts = reconcile_request(
+        &mut ws,
+        serde_json::json!([
+            { "paneKey": "deadpane", "kind": "fresh-agent",
+              "sessionRef": {"provider": "codex", "sessionId": "gone-1"} }
+        ]),
+    )
+    .await;
+    assert_eq!(verdicts[0]["verdict"], "dead_session");
+    assert_eq!(verdicts[0]["reason"], "session_not_on_disk");
+
+    let events = events.lock().expect("capture lock");
+    let hits: Vec<&CapturedEvent> = events
+        .iter()
+        .filter(|e| e.message.contains("pane_reconcile.dead_session"))
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "exactly one dead_session WARN per dead verdict; got {events:?}"
+    );
+    let fields = &hits[0].fields;
+    assert!(
+        fields
+            .get("pane_key")
+            .is_some_and(|v| v.contains("deadpane")),
+        "pane_key recorded: {fields:?}"
+    );
+    assert!(
+        fields.get("provider").is_some_and(|v| v.contains("codex")),
+        "provider recorded: {fields:?}"
+    );
+    assert!(
+        fields
+            .get("session_id")
+            .is_some_and(|v| v.contains("gone-1")),
+        "session_id recorded: {fields:?}"
+    );
+    assert!(
+        fields
+            .get("reason")
+            .is_some_and(|v| v.contains("session_not_on_disk")),
+        "reason recorded: {fields:?}"
+    );
+}

--- a/test/unit/vite-config.test.ts
+++ b/test/unit/vite-config.test.ts
@@ -22,16 +22,22 @@ const TEST_TIMEOUT_MS = 20_000
 
 describe('getNetworkHost', () => {
   const originalHost = process.env.HOST
+  const originalBindHost = process.env.FRESHELL_BIND_HOST
 
   beforeEach(() => {
     vi.restoreAllMocks()
     vi.resetModules()
     delete process.env.HOST
+    // FRESHELL_BIND_HOST is an explicit override honored by getNetworkHost;
+    // a developer shell that exports it would otherwise leak into every case.
+    delete process.env.FRESHELL_BIND_HOST
   })
 
   afterEach(() => {
     if (originalHost !== undefined) process.env.HOST = originalHost
     else delete process.env.HOST
+    if (originalBindHost !== undefined) process.env.FRESHELL_BIND_HOST = originalBindHost
+    else delete process.env.FRESHELL_BIND_HOST
   })
 
   it('returns 127.0.0.1 when config file does not exist', async () => {


### PR DESCRIPTION
## Why

A `dead_session` verdict parks a pane in the client's dead-sessions dialog — the loud, user-facing end of the restore ladder — but the Rust server logged **nothing** when issuing one. Diagnosing why a pane showed up dead (e.g. a zero-turn codex session that never got a rollout file) required reconstructing it from the pane ledger + on-disk rollout files.

## What

- `crates/freshell-ws/src/terminal.rs` — `handle_pane_reconcile` now emits one `pane_reconcile.dead_session` WARN per dead verdict at the result-send choke point, before `PaneReconcileResult` goes out. Fields: `pane_key`, `reason`, `terminal_id`, `provider`, `session_id`. Covers terminal and fresh-agent arms, and the single index_warming deferral re-derivation, for free.
- `crates/freshell-ws/tests/pane_reconcile_freshagent.rs` — raw-WS integration test: a GoneObserved fresh-agent claim through the in-process server asserts the dead verdict on the wire **and** the WARN event with its identity fields (capturing-layer idiom from `diag01_lifecycle_events.rs`).
- `test/unit/vite-config.test.ts` — scrub `FRESHELL_BIND_HOST` in `beforeEach`/`afterEach`. The explicit override is honored over config, so a shell exporting it leaked `0.0.0.0` into every fallback-expected case and turned the local base gate red-herring red.

## Verification

- New test: RED (no event) → GREEN
- `cargo test -p freshell-ws` — green except `auto_resume_e2e`'s 2 PTY-spawn timeouts, which fail identically on unmodified `origin/main` on this host (pre-existing, environmental)
- `cargo clippy -p freshell-ws --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test -p freshell-protocol -p freshell-terminal --locked` — green
- `npm run check` (typecheck + coordinated full suite) — green
- e2e `server-restart-recovery.spec.ts` — green (first run had one 120s timeout caused by a cold release `cargo build` inside the test; retry with warm cache passed)