### PR TITLE
fix(test): make build-id HEAD test run without checkout .git

### DIFF
--- a/test/server/build-id.test.ts
+++ b/test/server/build-id.test.ts
@@ -38,10 +38,25 @@ describe('server build id', () => {
   })
 
   it('computeBuildId returns the current git HEAD sha for the repository', () => {
-    const expected = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: REPO_ROOT })
-      .toString()
-      .trim()
-    expect(computeBuildId(REPO_ROOT)).toBe(expected)
+    // Build a fixture repo instead of probing this checkout: CI cloud images
+    // ship the source tree without .git/ (see .gcloudignore/.dockerignore),
+    // so asserting against REPO_ROOT's HEAD is impossible there. Only a git
+    // binary is required anywhere this suite runs.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'build-id-fixture-repo-'))
+    try {
+      execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir })
+      execFileSync(
+        'git',
+        ['-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-q', '--allow-empty', '-m', 'init'],
+        { cwd: dir },
+      )
+      const expected = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir })
+        .toString()
+        .trim()
+      expect(computeBuildId(dir)).toBe(expected)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   it('computeBuildId falls back to "unknown" outside a git repository', () => {


### PR DESCRIPTION
## Summary
- `test/server/build-id.test.ts`'s `computeBuildId` test asserted against the checkout's own HEAD via `git rev-parse HEAD`. On cloud vitest images `.git/` is excluded from the build context (`.gcloudignore`/".dockerignore"), so the test failed there deterministically — the only red in the full cloud suite at `6c541bec`.
- The test now builds a fixture git repo in a tmpdir and asserts `computeBuildId(dir)` against that repo's HEAD. Same coverage, works anywhere a git binary exists.

## Verification
- Focused local: `npm run test:vitest -- run test/server/build-id.test.ts --config config/vitest/vitest.server.config.ts` → 8/8 pass.
- Coordinated full suite, cloud backend, on this branch commit (`e49c2f66f`): all shards green, including `test/server/build-id.test.ts ✓ (8 tests)` on cloud.