### PR TITLE
perf(client): stable terminal surfaces — pane identity independent of split-tree ancestry

### DIFF
--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy, useRef, useCallback, useMemo, useState, useEffect } from 'react'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
-import { setActivePane, resizePanes, updatePaneContent, clearPaneRenameRequest, toggleZoom, requestPaneRefresh } from '@/store/panesSlice'
+import { setActivePane, updatePaneContent, clearPaneRenameRequest, toggleZoom, requestPaneRefresh } from '@/store/panesSlice'
 import { closePaneWithCleanup } from '@/store/tabsSlice'
 import type { PaneNode, PaneContent } from '@/store/paneTypes'
 import Pane from './Pane'
@@ -30,7 +30,7 @@ import {
   formatPaneRuntimeTooltip,
   type PaneRuntimeMeta,
 } from '@/lib/format-terminal-title-meta'
-import { snap1D, collectCollinearSnapTargets, convertThresholdToLocal } from '@/lib/pane-snap'
+import { usePaneSplitResize } from './usePaneSplitResize'
 import { nanoid } from 'nanoid'
 import { ContextIds } from '@/components/context-menu/context-menu-constants'
 import type { CodingCliProviderName } from '@/lib/coding-cli-types'
@@ -232,10 +232,6 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
     (s) => s.freshAgent?.pendingCreates ?? EMPTY_FRESH_AGENT_PENDING_CREATES
   )
 
-  // Drag state for snapping: track the original size and accumulated delta
-  const dragStartSizeRef = useRef<number>(0)
-  const accumulatedDeltaRef = useRef<number>(0)
-
   // Check if this is the only pane (root is a leaf)
   const rootNode = useAppSelector((s) => s.panes.layouts[tabId])
   const isOnlyPane = rootNode?.type === 'leaf'
@@ -361,63 +357,9 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
     dispatch(toggleZoom({ tabId, paneId }))
   }, [dispatch, tabId])
 
-  const handleResizeStart = useCallback(() => {
-    if (node.type !== 'split') return
-    dragStartSizeRef.current = node.sizes[0]
-    accumulatedDeltaRef.current = 0
-  }, [node])
-
-  const handleResize = useCallback((splitId: string, delta: number, direction: 'horizontal' | 'vertical', shiftHeld?: boolean) => {
-    if (!containerRef.current) return
-    if (node.type !== 'split' || node.id !== splitId) return
-
-    const container = containerRef.current
-    const totalSize = direction === 'horizontal' ? container.offsetWidth : container.offsetHeight
-    const percentDelta = (delta / totalSize) * 100
-
-    let newSize: number
-
-    if (dragStartSizeRef.current === 0) {
-      // Keyboard resize (no drag start): apply delta directly without snapping
-      newSize = node.sizes[0] + percentDelta
-    } else {
-      // Mouse/touch drag: accumulate delta and apply snapping
-      accumulatedDeltaRef.current += percentDelta
-      const rawNewSize = dragStartSizeRef.current + accumulatedDeltaRef.current
-
-      // Get root container dimensions for coordinate conversion
-      const rootContainer = containerRef.current.closest('[data-pane-root]') as HTMLElement | null
-      const rootW = rootContainer?.offsetWidth ?? container.offsetWidth
-      const rootH = rootContainer?.offsetHeight ?? container.offsetHeight
-
-      // Collect snap targets in local % space using absolute coordinate conversion
-      const collinearPositions = rootNode
-        ? collectCollinearSnapTargets(rootNode, direction, splitId, rootW, rootH)
-        : []
-
-      // Convert snap threshold from "% of smallest dimension" to local split %
-      const localThreshold = convertThresholdToLocal(snapThreshold, rootW, rootH, totalSize)
-
-      // Apply snapping
-      newSize = snap1D(
-        rawNewSize,
-        dragStartSizeRef.current,
-        collinearPositions,
-        localThreshold,
-        shiftHeld ?? false,
-      )
-    }
-
-    const clampedSize = Math.max(10, Math.min(90, newSize))
-    const newSize2 = 100 - clampedSize
-
-    dispatch(resizePanes({ tabId, splitId, sizes: [clampedSize, newSize2] }))
-  }, [dispatch, tabId, node, rootNode, snapThreshold])
-
-  const handleResizeEnd = useCallback(() => {
-    dragStartSizeRef.current = 0
-    accumulatedDeltaRef.current = 0
-  }, [])
+  const { handleResizeStart, handleResize, handleResizeEnd } = usePaneSplitResize({
+    tabId, node, rootNode, containerRef, snapThreshold,
+  })
 
   // Render a leaf pane
   if (node.type === 'leaf') {

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -493,7 +493,12 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
     )
   }
 
-  // Render a split
+  // Render a split: RECURSIVE COMPATIBILITY RENDERER. In production
+  // PaneLayout always renders StablePaneLayout, which only ever hands
+  // PaneContainer leaf nodes; this branch survives solely to serve the pane
+  // unit suite's split-shaped fixtures. Do not extend it for new behavior —
+  // new split-path behavior belongs in StablePaneLayout/StablePaneDivider
+  // (and its tests in StablePaneLayout.test.tsx).
   const [size1, size2] = node.sizes
 
   return (

--- a/src/components/panes/PaneGeometryTree.tsx
+++ b/src/components/panes/PaneGeometryTree.tsx
@@ -1,0 +1,41 @@
+import { useCallback } from 'react'
+import type { PaneNode } from '@/store/paneTypes'
+import { cn } from '@/lib/utils'
+
+export type RegisterPaneSlot = (key: string, element: HTMLDivElement | null) => void
+
+type GeometryProps = { node: PaneNode; registerSlot: RegisterPaneSlot }
+
+function PaneSlot({ paneId, registerSlot }: { paneId: string; registerSlot: RegisterPaneSlot }) {
+  const ref = useCallback((element: HTMLDivElement | null) => registerSlot(`pane:${paneId}`, element), [paneId, registerSlot])
+  return <div ref={ref} data-pane-geometry-slot={paneId} className="h-full w-full" />
+}
+
+function SplitGeometry({ node, registerSlot }: GeometryProps & { node: Extract<PaneNode, { type: 'split' }> }) {
+  const splitRef = useCallback((element: HTMLDivElement | null) => registerSlot(`split:${node.id}`, element), [node.id, registerSlot])
+  const dividerRef = useCallback((element: HTMLDivElement | null) => registerSlot(`divider:${node.id}`, element), [node.id, registerSlot])
+  const [size1, size2] = node.sizes
+  const axis = node.direction === 'horizontal' ? 'width' : 'height'
+  return (
+    <div ref={splitRef} data-pane-geometry-split={node.id} className={cn('flex h-full w-full', node.direction === 'horizontal' ? 'flex-row' : 'flex-col')}>
+      <div style={{ [axis]: `${size1}%` }} className="min-w-0 min-h-0">
+        <PaneGeometryTree node={node.children[0]} registerSlot={registerSlot} />
+      </div>
+      <div ref={dividerRef} data-pane-geometry-divider={node.id} className={cn('flex-shrink-0', node.direction === 'horizontal' ? 'w-3' : 'h-3')} />
+      <div style={{ [axis]: `${size2}%` }} className="min-w-0 min-h-0">
+        <PaneGeometryTree node={node.children[1]} registerSlot={registerSlot} />
+      </div>
+    </div>
+  )
+}
+
+/** A noninteractive, accessibility-hidden copy of the existing flex geometry.
+ * Its divider placeholders use the same w-3/h-3 sizing as PaneDivider; there
+ * is no competing pixel layout algorithm. Real controls live in visual order
+ * alongside the stable pane shells.
+ */
+export default function PaneGeometryTree(props: GeometryProps) {
+  return props.node.type === 'leaf'
+    ? <PaneSlot paneId={props.node.id} registerSlot={props.registerSlot} />
+    : <SplitGeometry {...props} node={props.node} />
+}

--- a/src/components/panes/PaneLayout.tsx
+++ b/src/components/panes/PaneLayout.tsx
@@ -1,16 +1,11 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { initLayout, addPane, splitPane } from '@/store/panesSlice'
-import type { PaneContentInput, PaneNode } from '@/store/paneTypes'
-import PaneContainer from './PaneContainer'
+import type { PaneContentInput } from '@/store/paneTypes'
+import StablePaneLayout from './StablePaneLayout'
+import { collectSurfaceLeaves, resolveSurfaceZoom } from '@/lib/pane-surface-layout'
 import FloatingActionButton from './FloatingActionButton'
 import IntersectionDragOverlay from './IntersectionDragOverlay'
-
-/** Find a leaf node by id in the pane tree. */
-function findLeaf(node: PaneNode, id: string): Extract<PaneNode, { type: 'leaf' }> | null {
-  if (node.type === 'leaf') return node.id === id ? node : null
-  return findLeaf(node.children[0], id) || findLeaf(node.children[1], id)
-}
 
 interface PaneLayoutProps {
   tabId: string
@@ -63,14 +58,13 @@ export default function PaneLayout({ tabId, defaultContent, hidden }: PaneLayout
     return <div className="h-full w-full" /> // Loading state
   }
 
-  // When zoomed, find the leaf and render only that pane
-  const zoomedLeaf = zoomedPaneId ? findLeaf(layout, zoomedPaneId) : null
-  const nodeToRender = zoomedLeaf ?? layout
+  // Invalid/stale zoom IDs use the normal layout, including its dividers.
+  const effectiveZoom = resolveSurfaceZoom(collectSurfaceLeaves(layout), zoomedPaneId)
 
   return (
     <div ref={containerRef} data-pane-root className="relative h-full w-full">
-      <PaneContainer tabId={tabId} node={nodeToRender} hidden={hidden} />
-      {!zoomedPaneId && (
+      <StablePaneLayout tabId={tabId} layout={layout} zoomedPaneId={effectiveZoom} hidden={hidden} />
+      {!effectiveZoom && (
         <IntersectionDragOverlay tabId={tabId} containerRef={containerRef} />
       )}
       <FloatingActionButton

--- a/src/components/panes/StablePaneLayout.tsx
+++ b/src/components/panes/StablePaneLayout.tsx
@@ -35,7 +35,7 @@ function InertRegion({ hidden, style, children, paneId }: {
       data-stable-pane-id={paneId}
       aria-hidden={hidden || undefined}
       className="absolute min-w-0 min-h-0"
-      style={{ ...style, visibility: hidden ? 'hidden' : undefined, pointerEvents: hidden ? 'none' : 'auto' }}
+      style={{ ...style, visibility: hidden ? 'hidden' : undefined, opacity: hidden ? 0 : undefined, pointerEvents: hidden ? 'none' : 'auto' }}
     >
       {children}
     </div>

--- a/src/components/panes/StablePaneLayout.tsx
+++ b/src/components/panes/StablePaneLayout.tsx
@@ -81,6 +81,15 @@ const readRect = (element: HTMLElement): SurfaceRect => {
  * zoom. The empty split tree retains the existing flex/divider geometry; the
  * measured leaf rectangles position the real pane shells in a sibling layer.
  * No portals, DOM reparenting, terminal serialization, or global cache.
+ *
+ * The `hidden` prop fans out to three distinct consumers under one flag:
+ * inactive-tab hiding (PaneLayout's own `hidden`), zoom-hidden siblings, and
+ * surfaces whose measurement is temporarily unavailable. TerminalView's
+ * hidden path routes to the background-hydration queue, which assumes
+ * tab-level semantics; a zoom-hidden pane in the ACTIVE tab may therefore be
+ * deprioritized by that queue. This is no worse than the previous behavior
+ * (zoom used to unmount the pane entirely), but the overload is explicit so
+ * later hydration work can split the two meanings.
  */
 export default function StablePaneLayout({ tabId, layout, zoomedPaneId, hidden = false }: Props) {
   const rootRef = useRef<HTMLDivElement>(null)
@@ -96,10 +105,30 @@ export default function StablePaneLayout({ tabId, layout, zoomedPaneId, hidden =
 
   const getSplitElement = useCallback((id: string) => slotsRef.current.get(`split:${id}`) ?? null, [])
 
+  // The measurement effect must NOT rerun on content-only leaf updates (new
+  // layout object, same pane/divider/sizes structure): tearing down and
+  // recreating the ResizeObserver for every output-driven content assignment
+  // would force synchronous layout reads during provider churn. The effect
+  // keys on the structural signature and reads the freshest items via ref.
+  const structure = useMemo(
+    () =>
+      items
+        .map((n) =>
+          n.type === 'leaf'
+            ? `pane:${n.id}`
+            : `divider:${n.id}:${n.direction}:${n.sizes[0]}:${n.sizes[1]}`,
+        )
+        .join('|'),
+    [items],
+  )
+  const itemsRef = useRef(items)
+  itemsRef.current = items
+
   useLayoutEffect(() => {
     const root = rootRef.current
     if (!root) return
     let disposed = false
+    const items = itemsRef.current
     const measure = () => {
       if (disposed) return
       // Read all geometry before setState can cause any writes. No per-token
@@ -134,7 +163,8 @@ export default function StablePaneLayout({ tabId, layout, zoomedPaneId, hidden =
       disposed = true
       observer.disconnect()
     }
-  }, [items, zoom])
+    // Structure (not content) or zoom changes re-arm the measurement pass.
+  }, [structure, zoom])
 
   return (
     <div ref={rootRef} data-stable-pane-layout className="relative h-full w-full min-w-0 min-h-0">

--- a/src/components/panes/StablePaneLayout.tsx
+++ b/src/components/panes/StablePaneLayout.tsx
@@ -1,0 +1,164 @@
+import { useCallback, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import { useAppSelector } from '@/store/hooks'
+import { ContextIds } from '@/components/context-menu/context-menu-constants'
+import PaneDivider from './PaneDivider'
+import { usePaneSplitResize } from './usePaneSplitResize'
+import type { PaneNode } from '@/store/paneTypes'
+import {
+  collectSurfaceOrder,
+  localSurfaceRect,
+  reconcileSurfaceMeasurements,
+  resolveSurfaceZoom,
+  type SurfaceMeasurements,
+  type SurfaceRect,
+} from '@/lib/pane-surface-layout'
+import PaneContainer from './PaneContainer'
+import PaneGeometryTree, { type RegisterPaneSlot } from './PaneGeometryTree'
+
+type Props = { tabId: string; layout: PaneNode; zoomedPaneId?: string; hidden?: boolean }
+
+function InertRegion({ hidden, style, children, paneId }: {
+  hidden: boolean
+  style?: CSSProperties
+  children: ReactNode
+  paneId?: string
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  useLayoutEffect(() => {
+    // React 18 does not type inert as a JSX prop. Setting the DOM property
+    // preserves native keyboard/a11y exclusion without a project-wide shim.
+    if (ref.current) ref.current.inert = hidden
+  }, [hidden])
+  return (
+    <div
+      ref={ref}
+      data-stable-pane-id={paneId}
+      aria-hidden={hidden || undefined}
+      className="absolute min-w-0 min-h-0"
+      style={{ ...style, visibility: hidden ? 'hidden' : undefined, pointerEvents: hidden ? 'none' : 'auto' }}
+    >
+      {children}
+    </div>
+  )
+}
+
+function StablePaneDivider({ tabId, node, root, getSplitElement }: {
+  tabId: string
+  node: Extract<PaneNode, { type: 'split' }>
+  root: PaneNode
+  getSplitElement: (id: string) => HTMLDivElement | null
+}) {
+  // Resolve the CURRENT geometry slot when an input event occurs. Reading
+  // a slot ref during render can capture the detached pre-restructure node.
+  const containerRef = useMemo(() => ({ get current() { return getSplitElement(node.id) } }), [getSplitElement, node.id])
+  const snapThreshold = useAppSelector((s) => s.settings?.settings?.panes?.snapThreshold ?? 2)
+  const { handleResizeStart, handleResize, handleResizeEnd } = usePaneSplitResize({
+    tabId, node, rootNode: root, containerRef, snapThreshold,
+  })
+  return (
+    <div className={`flex h-full w-full ${node.direction === 'vertical' ? 'flex-col' : 'flex-row'}`}>
+      <PaneDivider
+        direction={node.direction}
+        onResizeStart={handleResizeStart}
+        onResize={(delta, shiftHeld) => handleResize(node.id, delta, node.direction, shiftHeld)}
+        onResizeEnd={handleResizeEnd}
+        dataContext={ContextIds.PaneDivider}
+        dataTabId={tabId}
+        dataSplitId={node.id}
+      />
+    </div>
+  )
+}
+
+const readRect = (element: HTMLElement): SurfaceRect => {
+  const { left, top, width, height } = element.getBoundingClientRect()
+  return { left, top, width, height }
+}
+
+/** Pane identity is independent of split-tree ancestry.
+ *
+ * Keep every surviving pane under the SAME keyed parent, including during
+ * zoom. The empty split tree retains the existing flex/divider geometry; the
+ * measured leaf rectangles position the real pane shells in a sibling layer.
+ * No portals, DOM reparenting, terminal serialization, or global cache.
+ */
+export default function StablePaneLayout({ tabId, layout, zoomedPaneId, hidden = false }: Props) {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const slotsRef = useRef(new Map<string, HTMLDivElement>())
+  const items = useMemo(() => collectSurfaceOrder(layout), [layout])
+  const leaves = useMemo(() => items.filter((node) => node.type === 'leaf'), [items])
+  const zoom = resolveSurfaceZoom(leaves, zoomedPaneId)
+  const [measurements, setMeasurements] = useState<SurfaceMeasurements>(() => Object.create(null))
+  const registerSlot: RegisterPaneSlot = useCallback((key, element) => {
+    if (element) slotsRef.current.set(key, element)
+    else slotsRef.current.delete(key)
+  }, [])
+
+  const getSplitElement = useCallback((id: string) => slotsRef.current.get(`split:${id}`) ?? null, [])
+
+  useLayoutEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+    let disposed = false
+    const measure = () => {
+      if (disposed) return
+      // Read all geometry before setState can cause any writes. No per-token
+      // work: this runs on layout commits or actual element size changes.
+      const rootRect = readRect(root)
+      const computed = getComputedStyle(root)
+      // clientWidth/clientHeight round fractional CSS sizes. Use the computed
+      // borderless content box to avoid changing xterm's column threshold.
+      const width = Number.parseFloat(computed.width) || root.clientWidth
+      const height = Number.parseFloat(computed.height) || root.clientHeight
+      const measured = new Map<string, SurfaceRect>()
+      for (const item of items) {
+        const key = `${item.type === 'leaf' ? 'pane' : 'divider'}:${item.id}`
+        const slot = slotsRef.current.get(key)
+        const rect = slot ? localSurfaceRect(rootRect, readRect(slot), width, height) : undefined
+        if (rect) measured.set(key, rect)
+        else if (item.type === 'leaf' && item.id === zoom && width > 0 && height > 0 && rootRect.width > 0 && rootRect.height > 0) {
+          // A new zoomed pane can mount even when its normal split slot has
+          // collapsed; its actual visible region is the full layout root.
+          measured.set(key, { left: 0, top: 0, width, height })
+        }
+      }
+      setMeasurements((previous) => reconcileSurfaceMeasurements(previous, items.map((item) => `${item.type === 'leaf' ? 'pane' : 'divider'}:${item.id}`), measured))
+    }
+    // Establish correct geometry BEFORE mounting new terminal surfaces. An
+    // already-mounted pane remains mounted even while geometry is unavailable.
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(root)
+    for (const slot of slotsRef.current.values()) observer.observe(slot)
+    return () => {
+      disposed = true
+      observer.disconnect()
+    }
+  }, [items, zoom])
+
+  return (
+    <div ref={rootRef} data-stable-pane-layout className="relative h-full w-full min-w-0 min-h-0">
+      <div data-pane-geometry-tree aria-hidden="true" className="h-full w-full pointer-events-none" style={{ visibility: 'hidden' }}>
+        <PaneGeometryTree node={layout} registerSlot={registerSlot} />
+      </div>
+      <div data-pane-surface-layer className="absolute inset-0 pointer-events-none">
+        {items.map((node) => {
+          const key = `${node.type === 'leaf' ? 'pane' : 'divider'}:${node.id}`
+          const measurement = measurements[key]
+          if (!measurement) return null
+          const paneHidden = hidden || !measurement.measurable || (!!zoom && (node.type !== 'leaf' || zoom !== node.id))
+          const style: CSSProperties = node.type === 'leaf' && zoom === node.id
+            ? { left: 0, top: 0, width: '100%', height: '100%' }
+            : measurement.rect
+          return (
+            <InertRegion key={key} paneId={node.type === 'leaf' ? node.id : undefined} hidden={paneHidden} style={style}>
+              {node.type === 'leaf'
+                ? <PaneContainer tabId={tabId} node={node} hidden={paneHidden} />
+                : <StablePaneDivider tabId={tabId} node={node} root={layout} getSplitElement={getSplitElement} />}
+            </InertRegion>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/panes/usePaneSplitResize.ts
+++ b/src/components/panes/usePaneSplitResize.ts
@@ -1,0 +1,61 @@
+import { useCallback, useRef, type RefObject } from 'react'
+import { useAppDispatch } from '@/store/hooks'
+import { resizePanes } from '@/store/panesSlice'
+import type { PaneNode } from '@/store/paneTypes'
+import { snap1D, collectCollinearSnapTargets, convertThresholdToLocal } from '@/lib/pane-snap'
+
+/** Shared by the recursive compatibility renderer and the stable divider layer.
+ * Keep drag, Shift bypass, keyboard deltas, and snapping in one implementation.
+ */
+export function usePaneSplitResize({ tabId, node, rootNode, containerRef, snapThreshold }: {
+  tabId: string
+  node: PaneNode
+  rootNode?: PaneNode
+  containerRef: RefObject<HTMLDivElement | null>
+  snapThreshold: number
+}) {
+  const dispatch = useAppDispatch()
+  const dragStartSizeRef = useRef<number>(0)
+  const accumulatedDeltaRef = useRef<number>(0)
+
+  const handleResizeStart = useCallback(() => {
+    if (node.type !== 'split') return
+    dragStartSizeRef.current = node.sizes[0]
+    accumulatedDeltaRef.current = 0
+  }, [node])
+
+  const handleResize = useCallback((splitId: string, delta: number, direction: 'horizontal' | 'vertical', shiftHeld?: boolean) => {
+    if (!containerRef.current) return
+    if (node.type !== 'split' || node.id !== splitId) return
+
+    const container = containerRef.current
+    const totalSize = direction === 'horizontal' ? container.offsetWidth : container.offsetHeight
+    // A hidden/zero-sized container has no meaningful pixel-to-percent mapping.
+    if (totalSize <= 0 || !Number.isFinite(delta)) return
+    const percentDelta = (delta / totalSize) * 100
+    let newSize: number
+    if (dragStartSizeRef.current === 0) {
+      newSize = node.sizes[0] + percentDelta
+    } else {
+      accumulatedDeltaRef.current += percentDelta
+      const rawNewSize = dragStartSizeRef.current + accumulatedDeltaRef.current
+      const rootContainer = container.closest('[data-pane-root]') as HTMLElement | null
+      const rootW = rootContainer?.offsetWidth ?? container.offsetWidth
+      const rootH = rootContainer?.offsetHeight ?? container.offsetHeight
+      const collinearPositions = rootNode
+        ? collectCollinearSnapTargets(rootNode, direction, splitId, rootW, rootH)
+        : []
+      const localThreshold = convertThresholdToLocal(snapThreshold, rootW, rootH, totalSize)
+      newSize = snap1D(rawNewSize, dragStartSizeRef.current, collinearPositions, localThreshold, shiftHeld ?? false)
+    }
+    const clampedSize = Math.max(10, Math.min(90, newSize))
+    dispatch(resizePanes({ tabId, splitId, sizes: [clampedSize, 100 - clampedSize] }))
+  }, [dispatch, tabId, node, rootNode, containerRef, snapThreshold])
+
+  const handleResizeEnd = useCallback(() => {
+    dragStartSizeRef.current = 0
+    accumulatedDeltaRef.current = 0
+  }, [])
+
+  return { handleResizeStart, handleResize, handleResizeEnd }
+}

--- a/src/lib/pane-surface-layout.ts
+++ b/src/lib/pane-surface-layout.ts
@@ -93,12 +93,12 @@ function sameRect(a: SurfaceRect, b: SurfaceRect): boolean {
  */
 export function reconcileSurfaceMeasurements(
   previous: SurfaceMeasurements,
-  paneIds: readonly string[],
+  surfaceKeys: readonly string[],
   measured: ReadonlyMap<string, SurfaceRect>,
 ): SurfaceMeasurements {
   const next: Record<string, MeasuredSurface> = Object.create(null)
   let changed = false
-  for (const id of paneIds) {
+  for (const id of surfaceKeys) {
     const rect = measured.get(id)
     const old = Object.hasOwn(previous, id) ? previous[id] : undefined
     if (isUsableSurfaceRect(rect)) {

--- a/src/lib/pane-surface-layout.ts
+++ b/src/lib/pane-surface-layout.ts
@@ -1,0 +1,113 @@
+/** Geometry and identity helpers for the stable pane surface layer.
+ * Pure functions: no terminal state, network calls, or global pane cache.
+ */
+export type SurfaceRect = { left: number; top: number; width: number; height: number }
+export type MeasuredSurface = { rect: SurfaceRect; measurable: boolean }
+export type SurfaceMeasurements = Readonly<Record<string, MeasuredSurface>>
+
+type LayoutNode<T> =
+  | { type: 'leaf'; id: string; content: T }
+  | { type: 'split'; id: string; direction: 'horizontal' | 'vertical'; sizes: [number, number]; children: [LayoutNode<T>, LayoutNode<T>] }
+
+/** Retain the actual leaf objects, not new content snapshots. Keys are pane IDs. */
+export function collectSurfaceLeaves<T>(root: LayoutNode<T>): Array<Extract<LayoutNode<T>, { type: 'leaf' }>> {
+  const leaves: Array<Extract<LayoutNode<T>, { type: 'leaf' }>> = []
+  const pending = [root]
+  const seenNodes = new Set<LayoutNode<T>>()
+  const seenIds = new Set<string>()
+  while (pending.length) {
+    const node = pending.pop()!
+    if (seenNodes.has(node)) throw new Error('Pane layout contains a cycle or shared node')
+    seenNodes.add(node)
+    if (node.type === 'leaf') {
+      if (seenIds.has(node.id)) throw new Error(`Duplicate pane ID: ${node.id}`)
+      seenIds.add(node.id)
+      leaves.push(node)
+    } else {
+      if (node.children.length !== 2) throw new Error('A pane split must have two children')
+      pending.push(node.children[1], node.children[0])
+    }
+  }
+  return leaves
+}
+
+/** In-order pane/divider presentation matches the recursive layout's DOM
+ * reading and keyboard order while all stateful components share one parent.
+ */
+export function collectSurfaceOrder<T>(root: LayoutNode<T>): LayoutNode<T>[] {
+  collectSurfaceLeaves(root) // Validate before traversing malformed persistence.
+  const ordered: LayoutNode<T>[] = []
+  const pending: Array<{ node: LayoutNode<T>; emit: boolean }> = [{ node: root, emit: false }]
+  const splitIds = new Set<string>()
+  while (pending.length) {
+    const { node, emit } = pending.pop()!
+    if (node.type === 'leaf' || emit) {
+      ordered.push(node)
+    } else {
+      if (splitIds.has(node.id)) throw new Error(`Duplicate split ID: ${node.id}`)
+      splitIds.add(node.id)
+      pending.push({ node: node.children[1], emit: false }, { node, emit: true }, { node: node.children[0], emit: false })
+    }
+  }
+  return ordered
+}
+
+export function resolveSurfaceZoom(leaves: readonly { id: string }[], zoomedPaneId?: string): string | undefined {
+  return zoomedPaneId && leaves.some((leaf) => leaf.id === zoomedPaneId) ? zoomedPaneId : undefined
+}
+
+export function isUsableSurfaceRect(rect: SurfaceRect | undefined): rect is SurfaceRect {
+  return !!rect && Object.values(rect).every(Number.isFinite) && rect.width > 0 && rect.height > 0
+}
+
+/** Convert viewport coordinates into the borderless layout root's CSS pixels.
+ * The root deliberately has no border/padding. Axis-aligned CSS scaling is
+ * supported; rotation/skew is not a supported pane-root layout transform.
+ */
+export function localSurfaceRect(
+  root: SurfaceRect,
+  slot: SurfaceRect,
+  rootWidth: number,
+  rootHeight: number,
+): SurfaceRect | undefined {
+  if (!isUsableSurfaceRect(root) || !isUsableSurfaceRect(slot)
+    || !Number.isFinite(rootWidth) || !Number.isFinite(rootHeight)
+    || rootWidth <= 0 || rootHeight <= 0) return undefined
+  const sx = rootWidth / root.width
+  const sy = rootHeight / root.height
+  return {
+    left: (slot.left - root.left) * sx,
+    top: (slot.top - root.top) * sy,
+    width: slot.width * sx,
+    height: slot.height * sy,
+  }
+}
+
+function sameRect(a: SurfaceRect, b: SurfaceRect): boolean {
+  return a.left === b.left && a.top === b.top && a.width === b.width && a.height === b.height
+}
+
+/** Zero-sized/temporarily unavailable roots must not destroy mounted surfaces.
+ * Keep the last usable geometry but make it noninteractive. Closed panes are
+ * removed immediately. A never-measured pane mounts only when measurable.
+ */
+export function reconcileSurfaceMeasurements(
+  previous: SurfaceMeasurements,
+  paneIds: readonly string[],
+  measured: ReadonlyMap<string, SurfaceRect>,
+): SurfaceMeasurements {
+  const next: Record<string, MeasuredSurface> = Object.create(null)
+  let changed = false
+  for (const id of paneIds) {
+    const rect = measured.get(id)
+    const old = Object.hasOwn(previous, id) ? previous[id] : undefined
+    if (isUsableSurfaceRect(rect)) {
+      next[id] = old?.measurable && sameRect(old.rect, rect) ? old : { rect, measurable: true }
+    } else if (old) {
+      next[id] = old.measurable ? { rect: old.rect, measurable: false } : old
+    }
+    if (next[id] !== old) changed = true
+  }
+  if (Object.keys(previous).length !== Object.keys(next).length) changed = true
+  return changed ? next : previous
+}

--- a/test/e2e-browser/specs/stable-terminal-surfaces.spec.ts
+++ b/test/e2e-browser/specs/stable-terminal-surfaces.spec.ts
@@ -1,0 +1,99 @@
+import type { ElementHandle, Locator, Page } from '@playwright/test'
+import { test, expect } from '../helpers/fixtures.js'
+import type { TestHarness } from '../helpers/test-harness.js'
+
+// Client topology regression with real xterm and the configured isolated test
+// backend. It is not a benchmark of provider startup or an actual CLI transcript.
+// Run only against owned test instances, never a production/external target.
+function pane(page: Page, id: string): Locator {
+  return page.locator(`[data-pane-shell="true"][data-pane-id="${id}"]`)
+}
+async function sameSurface(original: ElementHandle, selector: string) {
+  await expect.poll(() => original.evaluate((node, query) => node.isConnected && document.querySelector(query) === node, selector)).toBe(true)
+}
+async function requireMessageCapture(page: Page) {
+  await page.evaluate(() => {
+    const harness=window.__FRESHELL_TEST_HARNESS__
+    if (!harness?.getSentWsMessages || !harness.clearSentWsMessages) throw new Error('Outbound message recording is required for this regression')
+  })
+}
+async function noReattach(harness: TestHarness, terminalId: string, requestId: string) {
+  const messages=await harness.getSentWsMessages() as Array<{type?: string;terminalId?: string;requestId?: string}>
+  expect(messages.filter(message =>
+    (['terminal.attach','terminal.detach','terminal.kill'].includes(message.type??'') && message.terminalId===terminalId)
+    || (message.type==='terminal.create' && message.requestId===requestId),
+  )).toEqual([])
+}
+async function splitPicker(page: Page, current: Locator) {
+  await current.locator('.xterm').click({button:'right'})
+  await page.getByRole('menuitem',{name:/split horizontally/i}).click()
+  await expect(page.locator('[data-context="pane-picker"]').last()).toBeVisible()
+}
+async function chooseShell(page: Page) {
+  const picker=page.locator('[data-context="pane-picker"]').last()
+  const button=picker.getByRole('button',{name:/^(Shell|WSL|CMD|PowerShell|Bash)$/i}).first()
+  await expect(button).toBeVisible();await button.click()
+}
+
+test.describe('Stable terminal surfaces',()=>{
+  test('split and sibling close preserve the original xterm DOM, output, and attachment',async({freshellPage,page,harness,terminal})=>{
+    void freshellPage
+    await terminal.waitForTerminal();await terminal.waitForPrompt();await requireMessageCapture(page)
+    const tabId=await harness.getActiveTabId();expect(tabId).toBeTruthy()
+    const layout=await harness.getPaneLayout(tabId!)
+    expect(layout.type).toBe('leaf')
+    const paneId=layout.id as string, terminalId=layout.content.terminalId as string, requestId=layout.content.createRequestId as string
+    expect(terminalId).toBeTruthy()
+    const selector=`[data-pane-shell="true"][data-pane-id="${paneId}"] .xterm`
+    const original=await page.locator(selector).elementHandle();expect(original).not.toBeNull()
+    await terminal.executeCommand('echo stable-surface-marker');await harness.waitForTerminalText('stable-surface-marker',{terminalId})
+    await harness.clearSentWsMessages()
+    await splitPicker(page,pane(page,paneId))
+    await sameSurface(original!,selector)
+    const pickerPane=page.locator('[data-pane-shell="true"]').filter({has:page.locator('[data-context="pane-picker"]')})
+    await pickerPane.getByRole('button',{name:'Close pane',exact:true}).click()
+    await expect.poll(async()=>(await harness.getPaneLayout(tabId!)).type).toBe('leaf')
+    await sameSurface(original!,selector)
+    await harness.waitForTerminalText('stable-surface-marker',{terminalId})
+    await noReattach(harness,terminalId,requestId)
+  })
+
+  test('zoom and unzoom preserve both real xterms while excluding hidden input and dividers',async({freshellPage,page,harness,terminal})=>{
+    void freshellPage
+    await terminal.waitForTerminal();await terminal.waitForPrompt();await requireMessageCapture(page)
+    const tabId=await harness.getActiveTabId();const initial=await harness.getPaneLayout(tabId!)
+    await splitPicker(page,pane(page,initial.id));await chooseShell(page)
+    await expect(page.locator('.xterm:visible')).toHaveCount(2)
+    const layout=await harness.getPaneLayout(tabId!)
+    const first=layout.children[0], second=layout.children[1]
+    await expect.poll(async()=>(await harness.getPaneLayout(tabId!)).children[1].content.terminalId).toBeTruthy()
+    // Re-read after the second create response has installed its terminal ID.
+    const settled=await harness.getPaneLayout(tabId!)
+    const secondId=settled.children[1].content.terminalId as string
+    await expect.poll(()=>harness.getTerminalBuffer(secondId)).not.toBeNull()
+    const firstSelector=`[data-pane-shell="true"][data-pane-id="${first.id}"] .xterm`
+    const secondSelector=`[data-pane-shell="true"][data-pane-id="${second.id}"] .xterm`
+    const firstElement=await page.locator(firstSelector).elementHandle()
+    const secondElement=await page.locator(secondSelector).elementHandle()
+    expect(firstElement).not.toBeNull();expect(secondElement).not.toBeNull()
+    // Positive traffic proves the second pane is anchored before clearing
+    // capture; merely registering an empty xterm buffer is not attach readiness.
+    await page.locator(secondSelector).click()
+    await page.keyboard.type('echo stable-second-marker')
+    await page.keyboard.press('Enter')
+    await harness.waitForTerminalText('stable-second-marker', { terminalId: secondId })
+    await harness.clearSentWsMessages()
+    for(let i=0;i<5;i++) {
+      await pane(page,first.id).getByRole('button',{name:'Maximize pane',exact:true}).click()
+      await expect(page.locator('.xterm:visible')).toHaveCount(1)
+      await expect(page.locator('[data-context="pane-divider"]:visible')).toHaveCount(0)
+      expect(await pane(page,second.id).evaluate(node=>(node.closest('[data-stable-pane-id]') as HTMLElement)?.inert)).toBe(true)
+      await sameSurface(firstElement!,firstSelector);await sameSurface(secondElement!,secondSelector)
+      await pane(page,first.id).getByRole('button',{name:'Restore pane',exact:true}).click()
+      await expect(page.locator('.xterm:visible')).toHaveCount(2)
+    }
+    await noReattach(harness,first.content.terminalId,first.content.createRequestId)
+    await noReattach(harness,secondId,second.content.createRequestId)
+    await sameSurface(firstElement!,firstSelector);await sameSurface(secondElement!,secondSelector)
+  })
+})

--- a/test/e2e-browser/specs/stable-terminal-surfaces.spec.ts
+++ b/test/e2e-browser/specs/stable-terminal-surfaces.spec.ts
@@ -18,7 +18,9 @@ async function requireMessageCapture(page: Page) {
   })
 }
 async function noReattach(harness: TestHarness, terminalId: string, requestId: string) {
-  const messages=await harness.getSentWsMessages() as Array<{type?: string;terminalId?: string;requestId?: string}>
+  const messages=await harness.getSentWsMessages() as Array<{type?: string
+  terminalId?: string
+  requestId?: string}>
   expect(messages.filter(message =>
     (['terminal.attach','terminal.detach','terminal.kill'].includes(message.type??'') && message.terminalId===terminalId)
     || (message.type==='terminal.create' && message.requestId===requestId),
@@ -32,21 +34,27 @@ async function splitPicker(page: Page, current: Locator) {
 async function chooseShell(page: Page) {
   const picker=page.locator('[data-context="pane-picker"]').last()
   const button=picker.getByRole('button',{name:/^(Shell|WSL|CMD|PowerShell|Bash)$/i}).first()
-  await expect(button).toBeVisible();await button.click()
+  await expect(button).toBeVisible()
+  await button.click()
 }
 
 test.describe('Stable terminal surfaces',()=>{
   test('split and sibling close preserve the original xterm DOM, output, and attachment',async({freshellPage,page,harness,terminal})=>{
     void freshellPage
-    await terminal.waitForTerminal();await terminal.waitForPrompt();await requireMessageCapture(page)
-    const tabId=await harness.getActiveTabId();expect(tabId).toBeTruthy()
+    await terminal.waitForTerminal()
+    await terminal.waitForPrompt()
+    await requireMessageCapture(page)
+    const tabId=await harness.getActiveTabId()
+    expect(tabId).toBeTruthy()
     const layout=await harness.getPaneLayout(tabId!)
     expect(layout.type).toBe('leaf')
     const paneId=layout.id as string, terminalId=layout.content.terminalId as string, requestId=layout.content.createRequestId as string
     expect(terminalId).toBeTruthy()
     const selector=`[data-pane-shell="true"][data-pane-id="${paneId}"] .xterm`
-    const original=await page.locator(selector).elementHandle();expect(original).not.toBeNull()
-    await terminal.executeCommand('echo stable-surface-marker');await harness.waitForTerminalText('stable-surface-marker',{terminalId})
+    const original=await page.locator(selector).elementHandle()
+    expect(original).not.toBeNull()
+    await terminal.executeCommand('echo stable-surface-marker')
+    await harness.waitForTerminalText('stable-surface-marker',{terminalId})
     await harness.clearSentWsMessages()
     await splitPicker(page,pane(page,paneId))
     await sameSurface(original!,selector)
@@ -60,9 +68,13 @@ test.describe('Stable terminal surfaces',()=>{
 
   test('zoom and unzoom preserve both real xterms while excluding hidden input and dividers',async({freshellPage,page,harness,terminal})=>{
     void freshellPage
-    await terminal.waitForTerminal();await terminal.waitForPrompt();await requireMessageCapture(page)
-    const tabId=await harness.getActiveTabId();const initial=await harness.getPaneLayout(tabId!)
-    await splitPicker(page,pane(page,initial.id));await chooseShell(page)
+    await terminal.waitForTerminal()
+    await terminal.waitForPrompt()
+    await requireMessageCapture(page)
+    const tabId=await harness.getActiveTabId()
+    const initial=await harness.getPaneLayout(tabId!)
+    await splitPicker(page,pane(page,initial.id))
+    await chooseShell(page)
     await expect(page.locator('.xterm:visible')).toHaveCount(2)
     const layout=await harness.getPaneLayout(tabId!)
     const first=layout.children[0], second=layout.children[1]
@@ -75,7 +87,8 @@ test.describe('Stable terminal surfaces',()=>{
     const secondSelector=`[data-pane-shell="true"][data-pane-id="${second.id}"] .xterm`
     const firstElement=await page.locator(firstSelector).elementHandle()
     const secondElement=await page.locator(secondSelector).elementHandle()
-    expect(firstElement).not.toBeNull();expect(secondElement).not.toBeNull()
+    expect(firstElement).not.toBeNull()
+    expect(secondElement).not.toBeNull()
     // Positive traffic proves the second pane is anchored before clearing
     // capture; merely registering an empty xterm buffer is not attach readiness.
     await page.locator(secondSelector).click()
@@ -88,12 +101,15 @@ test.describe('Stable terminal surfaces',()=>{
       await expect(page.locator('.xterm:visible')).toHaveCount(1)
       await expect(page.locator('[data-context="pane-divider"]:visible')).toHaveCount(0)
       expect(await pane(page,second.id).evaluate(node=>(node.closest('[data-stable-pane-id]') as HTMLElement)?.inert)).toBe(true)
-      await sameSurface(firstElement!,firstSelector);await sameSurface(secondElement!,secondSelector)
+      await sameSurface(firstElement!,firstSelector)
+      await sameSurface(secondElement!,secondSelector)
       await pane(page,first.id).getByRole('button',{name:'Restore pane',exact:true}).click()
       await expect(page.locator('.xterm:visible')).toHaveCount(2)
     }
     await noReattach(harness,first.content.terminalId,first.content.createRequestId)
     await noReattach(harness,secondId,second.content.createRequestId)
-    await sameSurface(firstElement!,firstSelector);await sameSurface(secondElement!,secondSelector)
+    await sameSurface(firstElement!,firstSelector)
+    await sameSurface(secondElement!,secondSelector)
   })
 })
+

--- a/test/e2e/pane-context-menu-stability.test.tsx
+++ b/test/e2e/pane-context-menu-stability.test.tsx
@@ -14,6 +14,7 @@ import PaneLayout from '@/components/panes/PaneLayout'
 import { ContextMenuProvider } from '@/components/context-menu/ContextMenuProvider'
 import { ContextIds } from '@/components/context-menu/context-menu-constants'
 import type { PaneNode } from '@/store/paneTypes'
+import { installPaneGeometry } from '../helpers/pane-geometry'
 
 const wsMocks = {
   send: vi.fn(),
@@ -237,6 +238,15 @@ async function settleMenu() {
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
   })
 }
+
+const paneGeometry: { current: ReturnType<typeof installPaneGeometry> | null } = { current: null }
+beforeEach(() => {
+  paneGeometry.current = installPaneGeometry()
+})
+afterEach(() => {
+  paneGeometry.current?.restore()
+  paneGeometry.current = null
+})
 
 describe('pane context menu stability (e2e)', () => {
   beforeEach(() => {

--- a/test/e2e/pane-header-runtime-meta-flow.test.tsx
+++ b/test/e2e/pane-header-runtime-meta-flow.test.tsx
@@ -25,6 +25,7 @@ import {
   resolveLocalSettings,
 } from '@shared/settings'
 import { makeFreshAgentSessionKey } from '@shared/fresh-agent'
+import { installPaneGeometry } from '../helpers/pane-geometry'
 
 const wsMocks = vi.hoisted(() => {
   const messageHandlers = new Set<(msg: any) => void>()
@@ -351,6 +352,15 @@ function createStore(options?: {
 beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn()
   HTMLElement.prototype.scrollIntoView = vi.fn()
+})
+
+const paneGeometry: { current: ReturnType<typeof installPaneGeometry> | null } = { current: null }
+beforeEach(() => {
+  paneGeometry.current = installPaneGeometry()
+})
+afterEach(() => {
+  paneGeometry.current?.restore()
+  paneGeometry.current = null
 })
 
 describe('pane header runtime metadata flow (e2e)', () => {

--- a/test/e2e/refresh-context-menu-flow.test.tsx
+++ b/test/e2e/refresh-context-menu-flow.test.tsx
@@ -186,51 +186,64 @@ describe('refresh context menu flow (e2e)', () => {
 
   it('Refresh tab exits zoom and refreshes all browser panes in the stored layout', async () => {
     vi.mocked(api.post).mockImplementation(() => new Promise(() => {}))
+    let reloadCount = 0
+    const contentWindowSpy = vi.spyOn(window.HTMLIFrameElement.prototype, 'contentWindow', 'get').mockImplementation(() => {
+      return {
+        location: {
+          reload: () => {
+            reloadCount += 1
+          },
+        },
+      } as any
+    })
 
-    const layout: PaneNode = {
-      type: 'split',
-      id: 'split-1',
-      direction: 'horizontal',
-      sizes: [50, 50],
-      children: [
-        createBrowserLeaf('pane-1', 'browser-1', 'http://127.0.0.1:3000'),
-        createBrowserLeaf('pane-2', 'browser-2', 'http://127.0.0.1:3001'),
-      ],
+    try {
+      const layout: PaneNode = {
+        type: 'split',
+        id: 'split-1',
+        direction: 'horizontal',
+        sizes: [50, 50],
+        children: [
+          createBrowserLeaf('pane-1', 'browser-1', 'http://127.0.0.1:3000'),
+          createBrowserLeaf('pane-2', 'browser-2', 'http://127.0.0.1:3001'),
+        ],
+      }
+      const store = createStore(layout, { zoomedPaneId: 'pane-1' })
+      const user = userEvent.setup()
+      const { container } = renderFlow(store)
+
+      // Only pane-1 (port 3000) uses TCP forwarding — it matches Freshell's
+      // own port so the HTTP proxy skips it; pane-2 uses the same-origin
+      // /api/proxy path and never posts. The forward promise never resolves,
+      // so pane-1 has no iframe and one in-flight forward.
+      await waitFor(() => {
+        expect(vi.mocked(api.post)).toHaveBeenCalledTimes(1)
+      })
+      vi.mocked(api.post).mockClear()
+
+      await user.pointer({ target: screen.getByText('Tab One'), keys: '[MouseRight]' })
+      await user.click(screen.getByRole('menuitem', { name: 'Refresh tab' }))
+
+      await waitFor(() => {
+        expect(store.getState().panes.zoomedPane['tab-1']).toBeUndefined()
+      })
+      await waitFor(() => {
+        expect(container.querySelectorAll('[data-context="pane"]')).toHaveLength(2)
+      })
+      // Zoom exit keeps BOTH panes mounted (the stable surface layer — the old
+      // recursive tree remounted the zoomed sibling). pane-1's refresh takes
+      // the recover path: still no iframe (forward never resolved), so it
+      // retries the forward exactly once. pane-2 reloads its iframe in place.
+      await waitFor(() => {
+        expect(vi.mocked(api.post)).toHaveBeenCalledTimes(1)
+      })
+      expect(reloadCount).toBe(1)
+      await waitFor(() => {
+        expect(store.getState().panes.refreshRequestsByPane['tab-1']).toBeUndefined()
+      })
+    } finally {
+      contentWindowSpy.mockRestore()
     }
-    const store = createStore(layout, { zoomedPaneId: 'pane-1' })
-    const user = userEvent.setup()
-    const { container } = renderFlow(store)
-
-    await waitFor(() => {
-      expect(vi.mocked(api.post)).toHaveBeenCalledTimes(1)
-    })
-    vi.mocked(api.post).mockClear()
-
-    // The now-mounted hidden pane is refreshed TOO (stable surfaces keep it
-    // alive; the old recursive layout only refreshed the zoomed pane). Its
-    // iframe reload hits jsdom's "Not implemented: navigation" console.error;
-    // that emission is the expected refresh happening, so allow it here.
-    ;(globalThis as any).__ALLOW_CONSOLE_ERROR__ = true
-    await user.pointer({ target: screen.getByText('Tab One'), keys: '[MouseRight]' })
-    await user.click(screen.getByRole('menuitem', { name: 'Refresh tab' }))
-
-    await waitFor(() => {
-      expect(store.getState().panes.zoomedPane['tab-1']).toBeUndefined()
-    })
-    await waitFor(() => {
-      expect(container.querySelectorAll('[data-context="pane"]')).toHaveLength(2)
-    })
-    // Only pane-1 (port 3000) uses TCP forwarding — it matches Freshell's own
-    // port so the HTTP proxy skips it. Pane-2 (port 3001) is proxied through
-    // /api/proxy/http/3001/ (same-origin) instead. The zoom exit used to
-    // REMOUNT pane-1's browser (destroying the iframe and re-forwarding the
-    // port — a second api.post); the stable surface layer keeps both panes
-    // mounted, so exactly the initial forward remains, and both panes consume
-    // their refresh requests in place (asserted via the store clear below).
-    expect(vi.mocked(api.post)).toHaveBeenCalledTimes(1)
-    await waitFor(() => {
-      expect(store.getState().panes.refreshRequestsByPane['tab-1']).toBeUndefined()
-    })
   })
 
   it('Refresh pane from the pane shell queues and consumes a matching browser refresh request', async () => {

--- a/test/e2e/refresh-context-menu-flow.test.tsx
+++ b/test/e2e/refresh-context-menu-flow.test.tsx
@@ -13,6 +13,7 @@ import PaneLayout from '@/components/panes/PaneLayout'
 import { ContextMenuProvider } from '@/components/context-menu/ContextMenuProvider'
 import { ContextIds } from '@/components/context-menu/context-menu-constants'
 import type { PaneNode } from '@/store/paneTypes'
+import { installPaneGeometry } from '../helpers/pane-geometry'
 
 const wsMocks = {
   send: vi.fn(),
@@ -160,6 +161,15 @@ function renderFlow(store: ReturnType<typeof createStore>) {
   )
 }
 
+const paneGeometry: { current: ReturnType<typeof installPaneGeometry> | null } = { current: null }
+beforeEach(() => {
+  paneGeometry.current = installPaneGeometry()
+})
+afterEach(() => {
+  paneGeometry.current?.restore()
+  paneGeometry.current = null
+})
+
 describe('refresh context menu flow (e2e)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -196,6 +206,11 @@ describe('refresh context menu flow (e2e)', () => {
     })
     vi.mocked(api.post).mockClear()
 
+    // The now-mounted hidden pane is refreshed TOO (stable surfaces keep it
+    // alive; the old recursive layout only refreshed the zoomed pane). Its
+    // iframe reload hits jsdom's "Not implemented: navigation" console.error;
+    // that emission is the expected refresh happening, so allow it here.
+    ;(globalThis as any).__ALLOW_CONSOLE_ERROR__ = true
     await user.pointer({ target: screen.getByText('Tab One'), keys: '[MouseRight]' })
     await user.click(screen.getByRole('menuitem', { name: 'Refresh tab' }))
 
@@ -207,11 +222,12 @@ describe('refresh context menu flow (e2e)', () => {
     })
     // Only pane-1 (port 3000) uses TCP forwarding — it matches Freshell's own
     // port so the HTTP proxy skips it. Pane-2 (port 3001) is proxied through
-    // /api/proxy/http/3001/ (same-origin) instead.  Each TCP-forwarded pane
-    // triggers one api.post for the initial render plus one for the refresh.
-    await waitFor(() => {
-      expect(vi.mocked(api.post)).toHaveBeenCalledTimes(2)
-    })
+    // /api/proxy/http/3001/ (same-origin) instead. The zoom exit used to
+    // REMOUNT pane-1's browser (destroying the iframe and re-forwarding the
+    // port — a second api.post); the stable surface layer keeps both panes
+    // mounted, so exactly the initial forward remains, and both panes consume
+    // their refresh requests in place (asserted via the store clear below).
+    expect(vi.mocked(api.post)).toHaveBeenCalledTimes(1)
     await waitFor(() => {
       expect(store.getState().panes.refreshRequestsByPane['tab-1']).toBeUndefined()
     })

--- a/test/e2e/terminal-file-link-same-tab.test.tsx
+++ b/test/e2e/terminal-file-link-same-tab.test.tsx
@@ -8,6 +8,7 @@ import panesReducer from '@/store/panesSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import connectionReducer from '@/store/connectionSlice'
 import type { PaneNode, TerminalPaneContent } from '@/store/paneTypes'
+import { installPaneGeometry } from '../helpers/pane-geometry'
 
 const wsMocks = vi.hoisted(() => ({
   send: vi.fn(),
@@ -229,6 +230,15 @@ function createStore() {
     },
   })
 }
+
+const paneGeometry: { current: ReturnType<typeof installPaneGeometry> | null } = { current: null }
+beforeEach(() => {
+  paneGeometry.current = installPaneGeometry()
+})
+afterEach(() => {
+  paneGeometry.current?.restore()
+  paneGeometry.current = null
+})
 
 describe('terminal file links open Monaco on the clicked pane branch without navigating tabs', () => {
   beforeEach(() => {

--- a/test/e2e/terminal-url-context-menu.test.tsx
+++ b/test/e2e/terminal-url-context-menu.test.tsx
@@ -14,6 +14,7 @@ import PaneLayout from '@/components/panes/PaneLayout'
 import { ContextMenuProvider } from '@/components/context-menu/ContextMenuProvider'
 import { ContextIds } from '@/components/context-menu/context-menu-constants'
 import type { PaneNode } from '@/store/paneTypes'
+import { installPaneGeometry } from '../helpers/pane-geometry'
 
 const wsMocks = {
   send: vi.fn(),
@@ -236,6 +237,15 @@ async function settleMenu() {
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
   })
 }
+
+const paneGeometry: { current: ReturnType<typeof installPaneGeometry> | null } = { current: null }
+beforeEach(() => {
+  paneGeometry.current = installPaneGeometry()
+})
+afterEach(() => {
+  paneGeometry.current?.restore()
+  paneGeometry.current = null
+})
 
 describe('terminal URL context menu items (e2e)', () => {
   beforeEach(() => {

--- a/test/e2e/terminal-url-link-click.test.tsx
+++ b/test/e2e/terminal-url-link-click.test.tsx
@@ -14,7 +14,6 @@ const wsMocks = vi.hoisted(() => ({
   send: vi.fn(),
   connect: vi.fn().mockResolvedValue(undefined),
   onMessage: vi.fn().mockReturnValue(() => {}),
-  DEBUG: true,
   onReconnect: vi.fn().mockReturnValue(() => {}),
   setHelloExtensionProvider: vi.fn(),
 }))

--- a/test/e2e/terminal-url-link-click.test.tsx
+++ b/test/e2e/terminal-url-link-click.test.tsx
@@ -8,11 +8,13 @@ import panesReducer from '@/store/panesSlice'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
 import connectionReducer from '@/store/connectionSlice'
 import type { PaneNode, TerminalPaneContent } from '@/store/paneTypes'
+import { installPaneGeometry } from '../helpers/pane-geometry'
 
 const wsMocks = vi.hoisted(() => ({
   send: vi.fn(),
   connect: vi.fn().mockResolvedValue(undefined),
   onMessage: vi.fn().mockReturnValue(() => {}),
+  DEBUG: true,
   onReconnect: vi.fn().mockReturnValue(() => {}),
   setHelloExtensionProvider: vi.fn(),
 }))
@@ -234,6 +236,15 @@ function createStore(opts?: { warnExternalLinks?: boolean }) {
     },
   })
 }
+
+const paneGeometry: { current: ReturnType<typeof installPaneGeometry> | null } = { current: null }
+beforeEach(() => {
+  paneGeometry.current = installPaneGeometry()
+})
+afterEach(() => {
+  paneGeometry.current?.restore()
+  paneGeometry.current = null
+})
 
 describe('terminal URL links open browser pane on the clicked pane branch without navigating tabs', () => {
   beforeEach(() => {

--- a/test/helpers/pane-geometry.ts
+++ b/test/helpers/pane-geometry.ts
@@ -1,0 +1,67 @@
+/**
+ * jsdom geometry harness for the stable pane surface layer.
+ *
+ * The production surface layer mounts a pane shell only after its geometry
+ * slot has a usable measurement (never at a made-up size, per the PR
+ * contract). jsdom reports 0×0 bounding rects and 0 client/offset sizes and
+ * has no ResizeObserver, so without this harness nothing under PaneLayout
+ * ever mounts. Tests get: every element returns a positive rect (identity
+ * layout: no scaling, no translation), clientWidth/offsetWidth report the
+ * same box, and ResizeObserver callbacks can be driven manually.
+ *
+ * Tests that need per-element geometry (e.g. distinct pane rectangles) should
+ * install their own finer harness like StablePaneLayout.test.tsx does; this
+ * one is deliberately uniform.
+ */
+import { vi } from 'vitest'
+import { act } from '@testing-library/react'
+
+export type InstalledPaneGeometry = {
+  /** Drive every connected observer's measure callback (real RO fires this). */
+  triggerResize: () => void
+  restore: () => void
+}
+
+type ObserverEntry = { callback: ResizeObserverCallback; disconnected: boolean }
+
+export function installPaneGeometry(box = { width: 1000, height: 600 }): InstalledPaneGeometry {
+  const observers: ObserverEntry[] = []
+  // Restore ONLY this harness's own spies: vi.restoreAllMocks() would also
+  // wipe plain vi.fn() mockReturnValue registrations belonging to the host
+  // suite's own fixtures (restored to undefined-returning), breaking later
+  // tests in the same file.
+  const spies = [
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+      const r = { left: 0, top: 0, width: box.width, height: box.height }
+      return { ...r, x: r.left, y: r.top, right: r.left + r.width, bottom: r.top + r.height, toJSON: () => r } as DOMRect
+    }),
+  ]
+  for (const [property, value] of [['clientWidth', box.width], ['offsetWidth', box.width], ['clientHeight', box.height], ['offsetHeight', box.height]] as const) {
+    spies.push(vi.spyOn(HTMLElement.prototype, property, 'get').mockReturnValue(value))
+  }
+  vi.stubGlobal('ResizeObserver', class {
+    entry: ObserverEntry
+    constructor(callback: ResizeObserverCallback) {
+      this.entry = { callback, disconnected: false }
+      observers.push(this.entry)
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {
+      this.entry.disconnected = true
+    }
+  })
+  return {
+    triggerResize: () => {
+      act(() => {
+        for (const observer of [...observers]) {
+          if (!observer.disconnected) observer.callback([], {} as ResizeObserver)
+        }
+      })
+    },
+    restore: () => {
+      for (const spy of spies) spy.mockRestore()
+      vi.unstubAllGlobals()
+    },
+  }
+}

--- a/test/helpers/pane-geometry.ts
+++ b/test/helpers/pane-geometry.ts
@@ -13,7 +13,7 @@
  * install their own finer harness like StablePaneLayout.test.tsx does; this
  * one is deliberately uniform.
  */
-import { vi } from 'vitest'
+import { vi, type MockInstance } from 'vitest'
 import { act } from '@testing-library/react'
 
 export type InstalledPaneGeometry = {
@@ -30,7 +30,7 @@ export function installPaneGeometry(box = { width: 1000, height: 600 }): Install
   // wipe plain vi.fn() mockReturnValue registrations belonging to the host
   // suite's own fixtures (restored to undefined-returning), breaking later
   // tests in the same file.
-  const spies = [
+  const spies: MockInstance[] = [
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
       const r = { left: 0, top: 0, width: box.width, height: box.height }
       return { ...r, x: r.left, y: r.top, right: r.left + r.width, bottom: r.top + r.height, toJSON: () => r } as DOMRect
@@ -39,6 +39,7 @@ export function installPaneGeometry(box = { width: 1000, height: 600 }): Install
   for (const [property, value] of [['clientWidth', box.width], ['offsetWidth', box.width], ['clientHeight', box.height], ['offsetHeight', box.height]] as const) {
     spies.push(vi.spyOn(HTMLElement.prototype, property, 'get').mockReturnValue(value))
   }
+  const originalResizeObserver = (globalThis as { ResizeObserver?: unknown }).ResizeObserver
   vi.stubGlobal('ResizeObserver', class {
     entry: ObserverEntry
     constructor(callback: ResizeObserverCallback) {
@@ -61,7 +62,13 @@ export function installPaneGeometry(box = { width: 1000, height: 600 }): Install
     },
     restore: () => {
       for (const spy of spies) spy.mockRestore()
-      vi.unstubAllGlobals()
+      // Undo exactly OUR global stub: vi.unstubAllGlobals() would also clear
+      // globals the host suite stubbed in beforeAll (or anywhere else).
+      if (originalResizeObserver === undefined) {
+        delete (globalThis as { ResizeObserver?: unknown }).ResizeObserver
+      } else {
+        ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = originalResizeObserver
+      }
     },
   }
 }

--- a/test/integration/client/editor-pane.test.tsx
+++ b/test/integration/client/editor-pane.test.tsx
@@ -8,6 +8,7 @@ import tabsReducer from '@/store/tabsSlice'
 import settingsReducer from '@/store/settingsSlice'
 import connectionReducer, { setStatus } from '@/store/connectionSlice'
 import PaneLayout from '@/components/panes/PaneLayout'
+import { installPaneGeometry } from '../../helpers/pane-geometry'
 
 // Mock Monaco to avoid loading issues in tests
 vi.mock('@monaco-editor/react', () => {
@@ -209,6 +210,15 @@ async function selectEditorFromPicker(user: ReturnType<typeof userEvent.setup>) 
 async function findEditorPathInput() {
   return screen.findByPlaceholderText(/enter file path/i, {}, { timeout: 3_000 })
 }
+
+const paneGeometry: { current: ReturnType<typeof installPaneGeometry> | null } = { current: null }
+beforeEach(() => {
+  paneGeometry.current = installPaneGeometry()
+})
+afterEach(() => {
+  paneGeometry.current?.restore()
+  paneGeometry.current = null
+})
 
 describe('Editor Pane Integration', () => {
   let store: ReturnType<typeof createTestStore>

--- a/test/unit/client/components/panes/PaneLayout.test.tsx
+++ b/test/unit/client/components/panes/PaneLayout.test.tsx
@@ -8,6 +8,7 @@ import tabsReducer from '@/store/tabsSlice'
 import settingsReducer from '@/store/settingsSlice'
 import type { PanesState } from '@/store/panesSlice'
 import type { PaneNode, PaneContent } from '@/store/paneTypes'
+import { installPaneGeometry } from '@test/helpers/pane-geometry'
 
 // Hoist mock functions so vi.mock can reference them
 const { mockSend, mockTerminalView } = vi.hoisted(() => ({
@@ -193,6 +194,10 @@ describe('PaneLayout', () => {
       y: 0,
       toJSON: () => {},
     }))
+    // jsdom reports 0-area geometry and has no ResizeObserver, so the stable
+    // surface layer would keep every pane unmounted. Install the shared
+    // harness (uniform positive rects + drivable observer).
+    installPaneGeometry()
   })
 
   afterEach(() => {

--- a/test/unit/client/components/panes/PaneLayout.test.tsx
+++ b/test/unit/client/components/panes/PaneLayout.test.tsx
@@ -203,6 +203,7 @@ describe('PaneLayout', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   describe('layout initialization', () => {
@@ -273,6 +274,34 @@ describe('PaneLayout', () => {
       const state = store.getState().panes
       // The active pane should be the same as the layout's pane id
       expect(state.activePane[tabId]).toBe(state.layouts[tabId].id)
+    })
+  })
+
+  describe('malformed persistence', () => {
+    it('fails loudly on duplicate pane ids instead of looping or ambiguity', () => {
+      const dup = {
+        type: 'split' as const,
+        id: 's',
+        direction: 'horizontal' as const,
+        sizes: [50, 50] as [number, number],
+        children: [
+          { type: 'leaf' as const, id: 'same', content: createTerminalContent() },
+          { type: 'leaf' as const, id: 'same', content: createTerminalContent() },
+        ],
+      }
+      // React logs the thrown render error through console.error on purpose;
+      // the suite's console guard must allow THIS expected failure.
+      ;(globalThis as any).__ALLOW_CONSOLE_ERROR__ = true
+      const store = createStore({
+        layouts: { 'tab-1': dup },
+        activePane: { 'tab-1': 'same' },
+      })
+      expect(() =>
+        renderWithStore(
+          <PaneLayout tabId="tab-1" defaultContent={createTerminalContent()} />,
+          store
+        )
+      ).toThrow(/Duplicate pane ID/)
     })
   })
 

--- a/test/unit/client/components/panes/StablePaneLayout.test.tsx
+++ b/test/unit/client/components/panes/StablePaneLayout.test.tsx
@@ -1,0 +1,182 @@
+import { StrictMode } from 'react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PaneNode } from '@/store/paneTypes'
+import StablePaneLayout from '@/components/panes/StablePaneLayout'
+
+// This suite runs the real stable layer, geometry tree, PaneDivider, and resize
+// hook. A lifecycle-counted pane stands in for xterm: browser acceptance must
+// additionally exercise the actual TerminalView and provider terminal streams.
+const observed = vi.hoisted(() => ({
+  mounts: new Map<string, number>(),
+  disposals: new Map<string, number>(),
+  dispatch: vi.fn(),
+}))
+vi.mock('@/store/hooks', () => ({
+  useAppDispatch: () => observed.dispatch,
+  useAppSelector: (select: (state: unknown) => unknown) => select({ settings: { settings: { panes: { snapThreshold: 0 } } } }),
+}))
+vi.mock('@/store/panesSlice', () => ({ resizePanes: (payload: unknown) => ({ type: 'panes/resizePanes', payload }) }))
+vi.mock('@/lib/utils', () => ({ cn: (...parts: unknown[]) => parts.filter(Boolean).join(' ') }))
+vi.mock('@/components/panes/PaneContainer', async () => {
+  const { useEffect } = await import('react')
+  return { default: ({ node, hidden }: { node: Extract<PaneNode, { type: 'leaf' }>; hidden?: boolean }) => {
+    useEffect(() => {
+      observed.mounts.set(node.id, (observed.mounts.get(node.id) ?? 0) + 1)
+      return () => { observed.disposals.set(node.id, (observed.disposals.get(node.id) ?? 0) + 1) }
+    }, [node.id])
+    return <div data-testid={`pane-${node.id}`} data-hidden={hidden ? 'true' : 'false'}>
+      <textarea aria-label={`Input ${node.id}`} defaultValue={`draft-${node.id}`} />
+      <span>{node.content.kind === 'terminal' ? node.content.terminalId : node.content.kind}</span>
+    </div>
+  } }
+})
+
+const leaf = (id: string): Extract<PaneNode, { type: 'leaf' }> => ({
+  type: 'leaf', id, content: { kind: 'terminal', mode: 'claude', status: 'running', createRequestId: `create-${id}`, terminalId: `terminal-${id}` },
+})
+const split = (id: string, a: PaneNode, b: PaneNode): PaneNode => ({ type: 'split', id, direction: 'horizontal', sizes: [50,50], children: [a,b] })
+type Rect = { left: number; top: number; width: number; height: number }
+const rect = (width=488, left=0, height=600, top=0): Rect => ({left,top,width,height})
+let rootRect = rect(1000)
+let rectangles: Map<string, Rect>
+let observers: Array<{ callback: ResizeObserverCallback; disconnected: boolean }>
+function box(element: HTMLElement): Rect {
+  if (!element.isConnected) return rect(0,0,0)
+  if (element.hasAttribute('data-stable-pane-layout') || element.hasAttribute('data-pane-root')) return rootRect
+  for (const [attr,prefix] of [['data-pane-geometry-slot','pane:'],['data-pane-geometry-divider','divider:'],['data-pane-geometry-split','split:']]) {
+    const id=element.getAttribute(attr)
+    if (id !== null) return rectangles.get(`${prefix}${id}`) ?? rect(0,0,0)
+  }
+  return rect(0,0,0)
+}
+function notifyResize() {
+  act(() => { for (const observer of [...observers]) if (!observer.disconnected) observer.callback([], {} as ResizeObserver) })
+}
+function surface(id: string) { return screen.getByTestId(`pane-${id}`).closest('[data-stable-pane-id]') as HTMLElement }
+
+beforeEach(() => {
+  observed.mounts.clear(); observed.disposals.clear(); observed.dispatch.mockClear()
+  rootRect=rect(1000); observers=[]
+  rectangles=new Map([
+    ['pane:a',rect()],['pane:b',rect(500,500)],['pane:c',rect(200,100)],
+    ['divider:s',rect(12,488)],['split:s',rect(1000)],
+    ['divider:outer',rect(12,200)],['split:outer',rect(1000)],
+  ])
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function(this: HTMLElement) {
+    const r=box(this);return { ...r, x:r.left,y:r.top,right:r.left+r.width,bottom:r.top+r.height,toJSON:()=>r } as DOMRect
+  })
+  for (const [property,axis] of [['clientWidth','width'],['offsetWidth','width'],['clientHeight','height'],['offsetHeight','height']] as const) {
+    vi.spyOn(HTMLElement.prototype,property,'get').mockImplementation(function(this: HTMLElement) { return box(this)[axis] })
+  }
+  vi.stubGlobal('ResizeObserver',class {
+    entry: typeof observers[number]
+    constructor(callback: ResizeObserverCallback) { this.entry={callback,disconnected:false};observers.push(this.entry) }
+    observe() {} unobserve() {} disconnect() { this.entry.disconnected=true }
+  })
+})
+afterEach(() => { cleanup();vi.restoreAllMocks();vi.unstubAllGlobals() })
+
+describe('stable pane ownership', () => {
+  it('keeps a pane and its draft when a leaf is wrapped in a split and collapsed again', () => {
+    const a=leaf('a');const {rerender}=render(<StablePaneLayout tabId="tab" layout={a} />)
+    const input=screen.getByLabelText('Input a');fireEvent.change(input,{target:{value:'unsent work'}})
+    const original=surface('a')
+    rerender(<StablePaneLayout tabId="tab" layout={split('s',a,leaf('b'))} />)
+    expect(surface('a')).toBe(original);expect(screen.getByLabelText('Input a')).toBe(input)
+    rerender(<StablePaneLayout tabId="tab" layout={a} />)
+    expect(observed.mounts.get('a')).toBe(1);expect(observed.disposals.get('a')??0).toBe(0)
+    expect((input as HTMLTextAreaElement).value).toBe('unsent work')
+    expect(observed.disposals.get('b')).toBe(1)
+  })
+  it('retains all surfaces through nested ancestry changes', () => {
+    const a=leaf('a'),b=leaf('b');const {rerender}=render(<StablePaneLayout tabId="tab" layout={split('s',a,b)} />)
+    const original=surface('a')
+    rerender(<StablePaneLayout tabId="tab" layout={split('outer',leaf('c'),split('s',a,b))} />)
+    expect(surface('a')).toBe(original);expect(observed.mounts.get('a')).toBe(1)
+  })
+  it('zoom hides and inerts siblings/dividers without unmounting them', () => {
+    const layout=split('s',leaf('a'),leaf('b'));const {rerender}=render(<StablePaneLayout tabId="tab" layout={layout} />)
+    const a=surface('a'), b=surface('b')
+    for(let i=0;i<20;i++) {
+      rerender(<StablePaneLayout tabId="tab" layout={layout} zoomedPaneId="a" />)
+      expect(surface('b')).toBe(b);expect(b.inert).toBe(true);expect(b.getAttribute('aria-hidden')).toBe('true')
+      expect(a.style.width).toBe('100%');expect(screen.getByRole('separator',{hidden:true}).closest('[aria-hidden="true"]')).not.toBeNull()
+      rerender(<StablePaneLayout tabId="tab" layout={layout} />)
+    }
+    expect(surface('a')).toBe(a);expect(b.inert).toBe(false);expect(observed.mounts.get('b')).toBe(1)
+    expect(observed.disposals.size).toBe(0)
+  })
+  it('stale zoom IDs leave both panes and the separator usable', () => {
+    render(<StablePaneLayout tabId="tab" layout={split('s',leaf('a'),leaf('b'))} zoomedPaneId="missing" />)
+    expect(surface('a').inert).toBe(false);expect(surface('b').inert).toBe(false)
+    expect(screen.getByRole('separator')).toBeTruthy()
+  })
+  it('keeps the normal pane-divider-pane keyboard and reading order', () => {
+    const {container}=render(<StablePaneLayout tabId="tab" layout={split('s',leaf('a'),leaf('b'))} />)
+    const order=[...container.querySelectorAll('[data-pane-surface-layer] textarea, [data-pane-surface-layer] [role="separator"]')]
+    expect(order.map(e=>e.getAttribute('aria-label'))).toEqual(['Input a','Pane divider (horizontal resize)','Input b'])
+    expect(container.querySelectorAll('[data-pane-geometry-tree] [tabindex]').length).toBe(0)
+  })
+  it('updates content in place without caching an obsolete terminal ID', () => {
+    const a=leaf('a');const {rerender}=render(<StablePaneLayout tabId="tab" layout={a} />)
+    const old=surface('a');const content={...a.content,terminalId:'replacement-terminal'}
+    rerender(<StablePaneLayout tabId="tab" layout={{...a,content}} />)
+    expect(surface('a')).toBe(old);expect(screen.getByText('replacement-terminal')).toBeTruthy()
+    expect(observed.mounts.get('a')).toBe(1)
+  })
+  it('keeps measured surfaces while geometry is unavailable, then restores their visibility', () => {
+    const {unmount}=render(<StablePaneLayout tabId="tab" layout={leaf('a')} />)
+    const a=surface('a');rootRect=rect(0,0,0);notifyResize()
+    expect(surface('a')).toBe(a);expect(a.inert).toBe(true)
+    rootRect=rect(1000);notifyResize();expect(a.inert).toBe(false)
+    unmount();expect(observed.disposals.get('a')).toBe(1)
+    expect(observers.every(o=>o.disconnected)).toBe(true)
+  })
+  it('does not construct a new surface at guessed zero-sized initial geometry', () => {
+    rootRect=rect(0,0,0);render(<StablePaneLayout tabId="tab" layout={leaf('a')} />)
+    expect(observed.mounts.size).toBe(0)
+    rootRect=rect(1000);notifyResize();expect(observed.mounts.get('a')).toBe(1)
+  })
+  it('hidden tab surfaces remain mounted and become usable again', () => {
+    const layout=leaf('a');const {rerender}=render(<StablePaneLayout tabId="tab" layout={layout} />)
+    const a=surface('a');rerender(<StablePaneLayout tabId="tab" layout={layout} hidden />)
+    expect(a.inert).toBe(true);rerender(<StablePaneLayout tabId="tab" layout={layout} />)
+    expect(surface('a')).toBe(a);expect(observed.mounts.get('a')).toBe(1)
+  })
+  it('does not introduce additional mounts after StrictMode initialization', () => {
+    const layout=split('s',leaf('a'),leaf('b'))
+    const {rerender}=render(<StrictMode><StablePaneLayout tabId="tab" layout={layout} /></StrictMode>)
+    const before=new Map(observed.mounts)
+    rerender(<StrictMode><StablePaneLayout tabId="tab" layout={layout} zoomedPaneId="a" /></StrictMode>)
+    rerender(<StrictMode><StablePaneLayout tabId="tab" layout={layout} /></StrictMode>)
+    expect(observed.mounts).toEqual(before)
+  })
+  it('keyboard resize still dispatches through the shared split resize hook', () => {
+    render(<StablePaneLayout tabId="tab" layout={split('s',leaf('a'),leaf('b'))} />)
+    fireEvent.keyDown(screen.getByRole('separator'),{key:'ArrowRight'})
+    expect(observed.dispatch).toHaveBeenCalledWith({type:'panes/resizePanes',payload:{tabId:'tab',splitId:'s',sizes:[51,49]}})
+  })
+  it('resolves the replacement geometry element after wrapping an existing split', () => {
+    const a=leaf('a'), b=leaf('b');const layout=split('s',a,b)
+    const {container,rerender}=render(<StablePaneLayout tabId="tab" layout={layout} />)
+    const oldGeometry=container.querySelector('[data-pane-geometry-split="s"]')
+    // The mocked rectangle remains exactly the same. The new layout commit
+    // replaces the geometry DOM but need not update measurement state.
+    rerender(<StablePaneLayout tabId="tab" layout={split('outer',leaf('c'),layout)} />)
+    const currentGeometry=container.querySelector('[data-pane-geometry-split="s"]')
+    expect(currentGeometry).not.toBe(oldGeometry)
+    // React may repurpose the old root element for the outer split instead
+    // of detaching it. Either way, it is no longer the correct split slot.
+    expect(oldGeometry?.getAttribute('data-pane-geometry-split')).not.toBe('s')
+    Object.defineProperty(oldGeometry!, 'offsetWidth', { configurable: true, value: 0 })
+    const divider=container.querySelector('[role="separator"][data-split-id="s"]')!
+    fireEvent.keyDown(divider,{key:'ArrowRight'})
+    expect(observed.dispatch).toHaveBeenCalledWith({type:'panes/resizePanes',payload:{tabId:'tab',splitId:'s',sizes:[51,49]}})
+  })
+  it('repeated no-op measurements do not recreate surfaces', () => {
+    render(<StablePaneLayout tabId="tab" layout={leaf('a')} />)
+    for(let i=0;i<50;i++) notifyResize()
+    expect(observed.mounts.get('a')).toBe(1);expect(observed.disposals.size).toBe(0)
+  })
+})

--- a/test/unit/client/components/panes/StablePaneLayout.test.tsx
+++ b/test/unit/client/components/panes/StablePaneLayout.test.tsx
@@ -17,7 +17,6 @@ vi.mock('@/store/hooks', () => ({
   useAppSelector: (select: (state: unknown) => unknown) => select({ settings: { settings: { panes: { snapThreshold: 0 } } } }),
 }))
 vi.mock('@/store/panesSlice', () => ({ resizePanes: (payload: unknown) => ({ type: 'panes/resizePanes', payload }) }))
-vi.mock('@/lib/utils', () => ({ cn: (...parts: unknown[]) => parts.filter(Boolean).join(' ') }))
 vi.mock('@/components/panes/PaneContainer', async () => {
   const { useEffect } = await import('react')
   return { default: ({ node, hidden }: { node: Extract<PaneNode, { type: 'leaf' }>; hidden?: boolean }) => {
@@ -178,5 +177,61 @@ describe('stable pane ownership', () => {
     render(<StablePaneLayout tabId="tab" layout={leaf('a')} />)
     for(let i=0;i<50;i++) notifyResize()
     expect(observed.mounts.get('a')).toBe(1);expect(observed.disposals.size).toBe(0)
+  })
+
+
+describe('stable divider resizing', () => {
+  it('a real mouse drag on the stable divider resizes through the shared hook', () => {
+    const layout = split('s', leaf('a'), leaf('b'))
+    render(<StablePaneLayout tabId="tab" layout={layout} />)
+    const divider = screen.getByRole('separator')
+
+    fireEvent.mouseDown(divider, { clientX: 500, clientY: 300 })
+    fireEvent.mouseMove(document, { clientX: 600, clientY: 300 })
+    fireEvent.mouseUp(document)
+
+    expect(observed.dispatch).toHaveBeenCalled()
+    const last = observed.dispatch.mock.calls.at(-1)![0]
+    expect(last.type).toBe('panes/resizePanes')
+    expect(last.payload.tabId).toBe('tab')
+    expect(last.payload.splitId).toBe('s')
+    // Split slot is 1000px wide in the geometry harness: +100px = +10% from 50.
+    expect(last.payload.sizes).toEqual([60, 40])
+  })
+
+  it('a keyboard nudge resizes without snapping machinery', () => {
+    const layout = split('s', leaf('a'), leaf('b'))
+    render(<StablePaneLayout tabId="tab" layout={layout} />)
+    const divider = screen.getByRole('separator')
+
+    fireEvent.keyDown(divider, { key: 'ArrowRight' })
+
+    expect(observed.dispatch).toHaveBeenCalled()
+    const last = observed.dispatch.mock.calls.at(-1)![0]
+    expect(last.type).toBe('panes/resizePanes')
+    expect(last.payload.sizes[0]).toBeGreaterThan(50)
+  })
+})
+
+})
+
+
+describe('stable divider resizing', () => {
+  it('refuses to resize from an unreadable or zero-area container', () => {
+    const layout = split('s', leaf('a'), leaf('b'))
+    render(<StablePaneLayout tabId="tab" layout={layout} />)
+    const divider = screen.getByRole('separator')
+
+    // A zero-sized container can never produce a valid pixel-to-percent
+    // mapping: the event is a no-op (previously this dispatched NaN sizes).
+    const zeroWidth = vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(0)
+    try {
+      fireEvent.mouseDown(divider, { clientX: 500, clientY: 300 })
+      fireEvent.mouseMove(document, { clientX: 600, clientY: 300 })
+      fireEvent.mouseUp(document)
+      expect(observed.dispatch).not.toHaveBeenCalled()
+    } finally {
+      zeroWidth.mockRestore()
+    }
   })
 })

--- a/test/unit/client/components/panes/StablePaneLayout.test.tsx
+++ b/test/unit/client/components/panes/StablePaneLayout.test.tsx
@@ -55,15 +55,19 @@ function notifyResize() {
 function surface(id: string) { return screen.getByTestId(`pane-${id}`).closest('[data-stable-pane-id]') as HTMLElement }
 
 beforeEach(() => {
-  observed.mounts.clear(); observed.disposals.clear(); observed.dispatch.mockClear()
-  rootRect=rect(1000); observers=[]
+  observed.mounts.clear()
+  observed.disposals.clear()
+  observed.dispatch.mockClear()
+  rootRect=rect(1000)
+  observers=[]
   rectangles=new Map([
     ['pane:a',rect()],['pane:b',rect(500,500)],['pane:c',rect(200,100)],
     ['divider:s',rect(12,488)],['split:s',rect(1000)],
     ['divider:outer',rect(12,200)],['split:outer',rect(1000)],
   ])
   vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function(this: HTMLElement) {
-    const r=box(this);return { ...r, x:r.left,y:r.top,right:r.left+r.width,bottom:r.top+r.height,toJSON:()=>r } as DOMRect
+    const r=box(this)
+    return { ...r, x:r.left,y:r.top,right:r.left+r.width,bottom:r.top+r.height,toJSON:()=>r } as DOMRect
   })
   for (const [property,axis] of [['clientWidth','width'],['offsetWidth','width'],['clientHeight','height'],['offsetHeight','height']] as const) {
     vi.spyOn(HTMLElement.prototype,property,'get').mockImplementation(function(this: HTMLElement) { return box(this)[axis] })
@@ -78,37 +82,50 @@ afterEach(() => { cleanup();vi.restoreAllMocks();vi.unstubAllGlobals() })
 
 describe('stable pane ownership', () => {
   it('keeps a pane and its draft when a leaf is wrapped in a split and collapsed again', () => {
-    const a=leaf('a');const {rerender}=render(<StablePaneLayout tabId="tab" layout={a} />)
-    const input=screen.getByLabelText('Input a');fireEvent.change(input,{target:{value:'unsent work'}})
+    const a=leaf('a')
+    const {rerender}=render(<StablePaneLayout tabId="tab" layout={a} />)
+    const input=screen.getByLabelText('Input a')
+    fireEvent.change(input,{target:{value:'unsent work'}})
     const original=surface('a')
     rerender(<StablePaneLayout tabId="tab" layout={split('s',a,leaf('b'))} />)
-    expect(surface('a')).toBe(original);expect(screen.getByLabelText('Input a')).toBe(input)
+    expect(surface('a')).toBe(original)
+    expect(screen.getByLabelText('Input a')).toBe(input)
     rerender(<StablePaneLayout tabId="tab" layout={a} />)
-    expect(observed.mounts.get('a')).toBe(1);expect(observed.disposals.get('a')??0).toBe(0)
+    expect(observed.mounts.get('a')).toBe(1)
+    expect(observed.disposals.get('a')??0).toBe(0)
     expect((input as HTMLTextAreaElement).value).toBe('unsent work')
     expect(observed.disposals.get('b')).toBe(1)
   })
   it('retains all surfaces through nested ancestry changes', () => {
-    const a=leaf('a'),b=leaf('b');const {rerender}=render(<StablePaneLayout tabId="tab" layout={split('s',a,b)} />)
+    const a=leaf('a'),b=leaf('b')
+    const {rerender}=render(<StablePaneLayout tabId="tab" layout={split('s',a,b)} />)
     const original=surface('a')
     rerender(<StablePaneLayout tabId="tab" layout={split('outer',leaf('c'),split('s',a,b))} />)
-    expect(surface('a')).toBe(original);expect(observed.mounts.get('a')).toBe(1)
+    expect(surface('a')).toBe(original)
+    expect(observed.mounts.get('a')).toBe(1)
   })
   it('zoom hides and inerts siblings/dividers without unmounting them', () => {
-    const layout=split('s',leaf('a'),leaf('b'));const {rerender}=render(<StablePaneLayout tabId="tab" layout={layout} />)
+    const layout=split('s',leaf('a'),leaf('b'))
+    const {rerender}=render(<StablePaneLayout tabId="tab" layout={layout} />)
     const a=surface('a'), b=surface('b')
     for(let i=0;i<20;i++) {
       rerender(<StablePaneLayout tabId="tab" layout={layout} zoomedPaneId="a" />)
-      expect(surface('b')).toBe(b);expect(b.inert).toBe(true);expect(b.getAttribute('aria-hidden')).toBe('true')
-      expect(a.style.width).toBe('100%');expect(screen.getByRole('separator',{hidden:true}).closest('[aria-hidden="true"]')).not.toBeNull()
+      expect(surface('b')).toBe(b)
+      expect(b.inert).toBe(true)
+      expect(b.getAttribute('aria-hidden')).toBe('true')
+      expect(a.style.width).toBe('100%')
+      expect(screen.getByRole('separator',{hidden:true}).closest('[aria-hidden="true"]')).not.toBeNull()
       rerender(<StablePaneLayout tabId="tab" layout={layout} />)
     }
-    expect(surface('a')).toBe(a);expect(b.inert).toBe(false);expect(observed.mounts.get('b')).toBe(1)
+    expect(surface('a')).toBe(a)
+    expect(b.inert).toBe(false)
+    expect(observed.mounts.get('b')).toBe(1)
     expect(observed.disposals.size).toBe(0)
   })
   it('stale zoom IDs leave both panes and the separator usable', () => {
     render(<StablePaneLayout tabId="tab" layout={split('s',leaf('a'),leaf('b'))} zoomedPaneId="missing" />)
-    expect(surface('a').inert).toBe(false);expect(surface('b').inert).toBe(false)
+    expect(surface('a').inert).toBe(false)
+    expect(surface('b').inert).toBe(false)
     expect(screen.getByRole('separator')).toBeTruthy()
   })
   it('keeps the normal pane-divider-pane keyboard and reading order', () => {
@@ -118,30 +135,46 @@ describe('stable pane ownership', () => {
     expect(container.querySelectorAll('[data-pane-geometry-tree] [tabindex]').length).toBe(0)
   })
   it('updates content in place without caching an obsolete terminal ID', () => {
-    const a=leaf('a');const {rerender}=render(<StablePaneLayout tabId="tab" layout={a} />)
-    const old=surface('a');const content={...a.content,terminalId:'replacement-terminal'}
+    const a=leaf('a')
+    const {rerender}=render(<StablePaneLayout tabId="tab" layout={a} />)
+    const old=surface('a')
+    const content={...a.content,terminalId:'replacement-terminal'}
     rerender(<StablePaneLayout tabId="tab" layout={{...a,content}} />)
-    expect(surface('a')).toBe(old);expect(screen.getByText('replacement-terminal')).toBeTruthy()
+    expect(surface('a')).toBe(old)
+    expect(screen.getByText('replacement-terminal')).toBeTruthy()
     expect(observed.mounts.get('a')).toBe(1)
   })
   it('keeps measured surfaces while geometry is unavailable, then restores their visibility', () => {
     const {unmount}=render(<StablePaneLayout tabId="tab" layout={leaf('a')} />)
-    const a=surface('a');rootRect=rect(0,0,0);notifyResize()
-    expect(surface('a')).toBe(a);expect(a.inert).toBe(true)
-    rootRect=rect(1000);notifyResize();expect(a.inert).toBe(false)
-    unmount();expect(observed.disposals.get('a')).toBe(1)
+    const a=surface('a')
+    rootRect=rect(0,0,0)
+    notifyResize()
+    expect(surface('a')).toBe(a)
+    expect(a.inert).toBe(true)
+    rootRect=rect(1000)
+    notifyResize()
+    expect(a.inert).toBe(false)
+    unmount()
+    expect(observed.disposals.get('a')).toBe(1)
     expect(observers.every(o=>o.disconnected)).toBe(true)
   })
   it('does not construct a new surface at guessed zero-sized initial geometry', () => {
-    rootRect=rect(0,0,0);render(<StablePaneLayout tabId="tab" layout={leaf('a')} />)
+    rootRect=rect(0,0,0)
+    render(<StablePaneLayout tabId="tab" layout={leaf('a')} />)
     expect(observed.mounts.size).toBe(0)
-    rootRect=rect(1000);notifyResize();expect(observed.mounts.get('a')).toBe(1)
+    rootRect=rect(1000)
+    notifyResize()
+    expect(observed.mounts.get('a')).toBe(1)
   })
   it('hidden tab surfaces remain mounted and become usable again', () => {
-    const layout=leaf('a');const {rerender}=render(<StablePaneLayout tabId="tab" layout={layout} />)
-    const a=surface('a');rerender(<StablePaneLayout tabId="tab" layout={layout} hidden />)
-    expect(a.inert).toBe(true);rerender(<StablePaneLayout tabId="tab" layout={layout} />)
-    expect(surface('a')).toBe(a);expect(observed.mounts.get('a')).toBe(1)
+    const layout=leaf('a')
+    const {rerender}=render(<StablePaneLayout tabId="tab" layout={layout} />)
+    const a=surface('a')
+    rerender(<StablePaneLayout tabId="tab" layout={layout} hidden />)
+    expect(a.inert).toBe(true)
+    rerender(<StablePaneLayout tabId="tab" layout={layout} />)
+    expect(surface('a')).toBe(a)
+    expect(observed.mounts.get('a')).toBe(1)
   })
   it('does not introduce additional mounts after StrictMode initialization', () => {
     const layout=split('s',leaf('a'),leaf('b'))
@@ -157,7 +190,8 @@ describe('stable pane ownership', () => {
     expect(observed.dispatch).toHaveBeenCalledWith({type:'panes/resizePanes',payload:{tabId:'tab',splitId:'s',sizes:[51,49]}})
   })
   it('resolves the replacement geometry element after wrapping an existing split', () => {
-    const a=leaf('a'), b=leaf('b');const layout=split('s',a,b)
+    const a=leaf('a'), b=leaf('b')
+    const layout=split('s',a,b)
     const {container,rerender}=render(<StablePaneLayout tabId="tab" layout={layout} />)
     const oldGeometry=container.querySelector('[data-pane-geometry-split="s"]')
     // The mocked rectangle remains exactly the same. The new layout commit
@@ -176,9 +210,12 @@ describe('stable pane ownership', () => {
   it('repeated no-op measurements do not recreate surfaces', () => {
     render(<StablePaneLayout tabId="tab" layout={leaf('a')} />)
     for(let i=0;i<50;i++) notifyResize()
-    expect(observed.mounts.get('a')).toBe(1);expect(observed.disposals.size).toBe(0)
+    expect(observed.mounts.get('a')).toBe(1)
+    expect(observed.disposals.size).toBe(0)
   })
 
+
+})
 
 describe('stable divider resizing', () => {
   it('a real mouse drag on the stable divider resizes through the shared hook', () => {
@@ -211,12 +248,7 @@ describe('stable divider resizing', () => {
     expect(last.type).toBe('panes/resizePanes')
     expect(last.payload.sizes[0]).toBeGreaterThan(50)
   })
-})
 
-})
-
-
-describe('stable divider resizing', () => {
   it('refuses to resize from an unreadable or zero-area container', () => {
     const layout = split('s', leaf('a'), leaf('b'))
     render(<StablePaneLayout tabId="tab" layout={layout} />)
@@ -235,3 +267,4 @@ describe('stable divider resizing', () => {
     }
   })
 })
+

--- a/test/unit/client/lib/pane-surface-layout.test.ts
+++ b/test/unit/client/lib/pane-surface-layout.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import {
+  collectSurfaceLeaves, collectSurfaceOrder, resolveSurfaceZoom,
+  localSurfaceRect, reconcileSurfaceMeasurements,
+  type SurfaceRect,
+} from '@/lib/pane-surface-layout'
+
+type Tree = { type: 'leaf'; id: string; content: { value: string } }
+  | { type: 'split'; id: string; direction: 'horizontal'; sizes: [number,number]; children: [Tree,Tree] }
+const leaf=(id: string): Tree=>({type:'leaf',id,content:{value:id}})
+const split=(id: string,a: Tree,b: Tree): Tree=>({type:'split',id,direction:'horizontal',sizes:[50,50],children:[a,b]})
+const rect: SurfaceRect={left:0,top:0,width:100,height:50}
+
+describe('pane surface layout',()=>{
+  it('retains exact leaf objects and content through topology changes',()=>{
+    const a=leaf('a'), b=leaf('b')
+    expect(collectSurfaceLeaves(split('s',a,b))[0]).toBe(a)
+    expect(collectSurfaceLeaves(split('o',leaf('c'),split('s',a,b)))[1]).toBe(a)
+  })
+  it('preserves the recursive pane-divider-pane presentation order',()=>{
+    expect(collectSurfaceOrder(split('s',leaf('a'),split('t',leaf('b'),leaf('c')))).map(n=>n.id)).toEqual(['a','s','b','t','c'])
+  })
+  it('rejects malformed persistence without looping or assigning ambiguous keys',()=>{
+    const a=leaf('a')
+    expect(()=>collectSurfaceLeaves(split('s',a,a))).toThrow(/shared node/)
+    expect(()=>collectSurfaceLeaves(split('s',a,leaf('a')))).toThrow(/Duplicate pane ID/)
+    expect(()=>collectSurfaceOrder(split('s',split('t',a,leaf('b')),split('t',leaf('c'),leaf('d'))))).toThrow(/Duplicate split ID/)
+  })
+  it('treats stale zoom as an ordinary full layout',()=>{
+    expect(resolveSurfaceZoom([{id:'a'},{id:'b'}],'gone')).toBeUndefined()
+    expect(resolveSurfaceZoom([{id:'a'},{id:'b'}],'b')).toBe('b')
+  })
+  it('normalizes translated and scaled viewport geometry into CSS pixels',()=>{
+    expect(localSurfaceRect({left:20,top:30,width:200,height:100},{left:120,top:30,width:100,height:100},100,50)).toEqual({left:50,top:0,width:50,height:50})
+    expect(localSurfaceRect(rect,rect,0,50)).toBeUndefined()
+  })
+  it('keeps an existing surface when measurement temporarily disappears',()=>{
+    const first=reconcileSurfaceMeasurements({},['a'],new Map([['a',rect]]))
+    const hidden=reconcileSurfaceMeasurements(first,['a'],new Map())
+    expect(hidden.a.rect).toBe(first.a.rect);expect(hidden.a.measurable).toBe(false)
+    expect(reconcileSurfaceMeasurements(hidden,['a'],new Map([['a',rect]])).a.measurable).toBe(true)
+  })
+  it('does not render-loop on unchanged measurements or leak closed entries',()=>{
+    const first=reconcileSurfaceMeasurements({},['a'],new Map([['a',rect]]))
+    expect(reconcileSurfaceMeasurements(first,['a'],new Map([['a',{...rect}]]))).toBe(first)
+    expect(Object.keys(reconcileSurfaceMeasurements(first,[],new Map()))).toEqual([])
+  })
+  it('never guesses an initial terminal size and handles arbitrary ID strings',()=>{
+    expect(Object.keys(reconcileSurfaceMeasurements({},['a'],new Map()))).toEqual([])
+    const next=reconcileSurfaceMeasurements({},['__proto__'],new Map([['__proto__',rect]]))
+    expect(Object.getPrototypeOf(next)).toBeNull();expect(next.__proto__.measurable).toBe(true)
+  })
+})

--- a/test/unit/client/lib/pane-surface-layout.test.ts
+++ b/test/unit/client/lib/pane-surface-layout.test.ts
@@ -37,7 +37,8 @@ describe('pane surface layout',()=>{
   it('keeps an existing surface when measurement temporarily disappears',()=>{
     const first=reconcileSurfaceMeasurements({},['a'],new Map([['a',rect]]))
     const hidden=reconcileSurfaceMeasurements(first,['a'],new Map())
-    expect(hidden.a.rect).toBe(first.a.rect);expect(hidden.a.measurable).toBe(false)
+    expect(hidden.a.rect).toBe(first.a.rect)
+    expect(hidden.a.measurable).toBe(false)
     expect(reconcileSurfaceMeasurements(hidden,['a'],new Map([['a',rect]])).a.measurable).toBe(true)
   })
   it('does not render-loop on unchanged measurements or leak closed entries',()=>{
@@ -48,6 +49,8 @@ describe('pane surface layout',()=>{
   it('never guesses an initial terminal size and handles arbitrary ID strings',()=>{
     expect(Object.keys(reconcileSurfaceMeasurements({},['a'],new Map()))).toEqual([])
     const next=reconcileSurfaceMeasurements({},['__proto__'],new Map([['__proto__',rect]]))
-    expect(Object.getPrototypeOf(next)).toBeNull();expect(next.__proto__.measurable).toBe(true)
+    expect(Object.getPrototypeOf(next)).toBeNull()
+    expect(next.__proto__.measurable).toBe(true)
   })
 })
+


### PR DESCRIPTION
# perf(client): stable terminal surfaces — pane identity independent of split-tree ancestry

## Problem

Any change to a pane's *position in the React tree* — splitting a leaf, closing a sibling, wrapping a subtree, zoom/unzoom — reconstructed the xterm surface and triggered a full historical replay, with resulting output churn (`terminal.attach` + replay traffic, DMA/GPU reset, scroll/selection loss) even though the underlying execution never changed. `TerminalView` correctly disposes xterm on unmount, so the fix is not hydration; it is never unmounting the surviving shell in the first place.

## Architecture

`PaneLayout` becomes a thin wrapper around a stable surface layer:

- **`PaneGeometryTree`** renders a geometry-only replica of the recursive flex tree (empty leaf slots, `w-3`/`h-3` divider placeholders matching `PaneDivider`) — always `visibility: hidden` + `aria-hidden`, so the browser's existing flex allocation (divider space, fractional sizes) remains the single source of truth.
- One **layout effect** measures leaf/divider slots via a single `ResizeObserver`; rects are converted to the root's borderless CSS pixels (computed style, so fractional widths survive; axis-aligned scaling supported; rotation/skew excluded).
- **`StablePaneLayout`** keeps every pane and divider mounted under one stable `pane:<id>` / `divider:<id>` keyed parent, absolutely positioned at measured rects. Content updates flow through the SAME leaf objects (no snapshot cache), so fresh-agent/browser/replace lifecycles work as before.
- **Zoom hides rather than unmounts**: hidden panes get `inert`, `aria-hidden`, `visibility: hidden`, `opacity: 0`, `pointer-events: none`. A stale zoom id falls back to the full layout. Temporarily unmeasurable surfaces (0-area root during layout flips) keep their last rect, inert, until measurement returns; never-measured surfaces never mount at a guessed 0×0.
- **Dividers** resolve the current split geometry element at event time, not at render (restructured nodes replace the geometry slot identity).
- **`usePaneSplitResize`** carries the (previously inlined in PaneContainer) drag/keyboard/snap behavior, consumed by `StablePaneDivider` in production and by PaneContainer's recursively-rendered compatibility branch — which exists only for the pane unit suite's split-shaped fixtures (all production paths now hand it leaves; the branch is documented as such, and production drag coverage lives in `StablePaneLayout.test.tsx`).

Bounded retention: closing a pane removes its key; surface state never survives a closed pane; there is no module-global terminal cache. Closed-pane resources release exactly once (pinned by mounted/disposed counters).

## Verification

- `npm run build:client`, `npm run typecheck`, and the coordinated `npm run check` all green.
- New unit suites: `pane-surface-layout.test.ts` (8 cases: identity, order, malformed-persistence guards, zoom resolution, rect normalization, no-op measurement reuse, closed-pane removal, proto-pollution key safety) and `StablePaneLayout.test.tsx` (16 mounted cases: split/collapse survival, nested restructuring, content-update delivery, zoom hidden/inert/a11y treatment, lost-geometry retention, never-mount-at-guessed-size, divider drag/keyboard on the stable path, zero-area no-op guard, disposal-exactly-once).
- Existing suites: all pane/divider/intersection/context-menu/focus/title/resize/hidden/attach/replay PaneContainer + PaneLayout tests pass (several needed jsdom geometry: the new shared `test/helpers/pane-geometry.ts` provides drivable ResizeObserver + positive rects, restoring only its own stubs).
- The refresh-tab flow test was corrected with the reviewer's precise pattern (contentWindow spy counting real reloads) instead of the initial global console-error bypass.
- e2e chromium: new `stable-terminal-surfaces.spec.ts` (real Rust server, real xterm, per-surface DOM identity across split→close, 5× zoom/unzoom, hidden-pane inert exclusion, zero extra create/attach/detach/kill frames) + full `pane-system.spec.ts` pass 12/12; **also green after the fresh-eyes round 2 edits**.
- Supplementary bundle checks: the `.mjs` pure-helper suite and all 4 mutation negative-controls reproduced here.

## Fresh-eyes review history

Two rounds (Claude). Round 1: the zoom-refresh test had been weakened through the global console-error bypass (rewritten honestly); PaneContainer's split renderer was undocumented dead-in-production surface (documented + production drag coverage added); fixture hygiene (DEBUG marker, cn mock, ResizeObserver unstubbing); plus the zero-area resize guard pinned. Round 2 **PASSED** with minors only.

Deliberate non-changes, disclosed (per the review pass):
- Fail-fast on duplicate pane IDs in a persisted layout (no reducer can produce them; recovery is closing the tab) — the old recursive renderer would have mis-rendered them silently.
- Keeping `PaneContainer`'s recursive split branch as the fixture-only compatibility renderer instead of migrating ~30 split-shaped tests wholesale (reviewer-listed either/or; chosen for contained diff).
- A zoom-hidden pane still uses the same `hidden` flag that TerminalView's background-hydration queue interprets as tab-level; documented at the prop seam (no regression vs unmount, but a real prior assumption).
