### PR TITLE
fix(pane-ledger): bounded EWOULDBLOCK-only lock retry + loud load_index I/O errors (kata s52d)

### DIFF
--- a/crates/freshell-ws/src/pane_ledger.rs
+++ b/crates/freshell-ws/src/pane_ledger.rs
@@ -96,7 +96,11 @@
 //!
 //! Corruption policy: fail loud PER-ROW, never per-store — an unparsable row
 //! is quarantined (renamed aside + logged), never silently dropped, and never
-//! causes healthy rows to be skipped.
+//! causes healthy rows to be skipped. H2: `load_index` logs a structured
+//! ERROR (`pane_ledger_load_index_dir_unreadable` /
+//! `pane_ledger_load_index_row_unreadable`) for any I/O failure; only
+//! parse/wrong-version rows stay silent for the boot scan to quarantine
+//! loudly.
 //!
 //! Write-failure policy: a ledger write failure never blocks the
 //! create/identity event, but it is never silent — see
@@ -108,7 +112,12 @@
 //! at 21ms@1k / 426ms@20k rows; TTL math yields 1.2k-12k rows). Files stay
 //! the durable source of truth; this process is the only writer
 //! (single-writer flock, [`PaneLedger::new_locked`]), so write-through
-//! invalidation is trivial. Reads never touch the fs and may run inline on
+//! invalidation is trivial. H1: the flock's *acquisition* tolerates the
+//! inheritance-mediated transient holder class — the fork→exec open-file-
+//! description handoff can leave `<root>/lock` momentarily held through a
+//! forked child's pre-exec window — via a bounded EWOULDBLOCK-only retry
+//! (see [`LOCK_RETRY_MAX_ATTEMPTS`]); a genuine second writer still
+//! degrades loudly. Reads never touch the fs and may run inline on
 //! async paths; WRITES fsync (~15ms p50 on this host) and must be wrapped in
 //! `spawn_blocking` at async call sites (the `terminal.rs:1369-1379`
 //! PTY-spawn precedent) — the sync API here stays call-site-agnostic.
@@ -126,6 +135,21 @@ pub use pane_ledger_scan::{BootScanReport, QuarantinedRow, PENDING_MARKER_ORPHAN
 /// Gates schema migration (spec §4.2): rows with a different version are
 /// quarantined loudly at boot, never silently reinterpreted.
 pub const LEDGER_VERSION: u32 = 1;
+
+/// H1: a *transient* holder window — the fork→exec open-file-description
+/// inheritance handoff (a forked child transiently carries a reference to
+/// the lock's OFD; std opens O_CLOEXEC, so the window ends AT exec, proven
+/// by validator PoC arm b2 / N6) — can leave `<root>/lock` momentarily held
+/// when `new_locked` runs; single-shot `LOCK_NB` then converted a µs-scale
+/// window (no-fork release measured ~13µs, PoC arm a) into a process-
+/// lifetime DISABLED ledger (deflake kata s52d). Acquisition retries ONLY
+/// on EWOULDBLOCK with a fixed budget: generous vs the measured window
+/// class, small at the one-shot boot call site, and loud-unchanged for a
+/// genuine persistent second writer (same ERROR, ~275ms later).
+#[cfg(unix)]
+const LOCK_RETRY_MAX_ATTEMPTS: u32 = 12;
+#[cfg(unix)]
+const LOCK_RETRY_DELAY_MS: u64 = 25;
 
 /// Bound rows not observed within this TTL are expired TO TOMBSTONES
 /// (`retired/gc_expired`), never deleted (spec §4.2 lifecycle).
@@ -1328,10 +1352,15 @@ impl PaneLedger {
 
     /// Production construction (V2.md single-writer guard): acquire an
     /// exclusive advisory `flock(2)` on `<root>/lock` (the `ConfigLock`
-    /// pattern, `settings_store.rs:385-417`). If another process holds it,
-    /// log a loud structured ERROR and come up DISABLED (no-op) — never two
-    /// writers on one store. Non-unix: no flock primitive is wired;
-    /// construct normally (ConfigLock's non-unix parity).
+    /// pattern, `settings_store.rs:385-417`). Acquisition retries
+    /// EWOULDBLOCK-only on a fixed budget (see `LOCK_RETRY_MAX_ATTEMPTS`)
+    /// so a transient holder window — the fork→exec open-file-description
+    /// inheritance handoff — cannot downgrade this process to a
+    /// lifetime-DISABLED ledger; a persistent second writer still degrades
+    /// loudly. If another process holds it past the budget, log a loud
+    /// structured ERROR and come up DISABLED (no-op) — never two writers
+    /// on one store. Non-unix: no flock primitive is wired; construct
+    /// normally (ConfigLock's non-unix parity).
     pub fn new_locked(root: Option<PathBuf>) -> Self {
         let Some(r) = root.clone() else {
             return Self::new(None);
@@ -1357,10 +1386,35 @@ impl PaneLedger {
 
     #[cfg(unix)]
     fn acquire_store_lock(root: &Path) -> std::io::Result<Option<std::fs::File>> {
+        let mut attempt = 0u32;
+        loop {
+            match Self::flock_once(root) {
+                Err(err) if err.raw_os_error() == Some(libc::EWOULDBLOCK) => {
+                    attempt += 1;
+                    if attempt >= LOCK_RETRY_MAX_ATTEMPTS {
+                        return Err(err);
+                    }
+                    // Sync sleep is deliberate: this is the one-shot boot-time
+                    // constructor path, never a hot path, and the wait only
+                    // happens while a (transient) holder is actually observed.
+                    std::thread::sleep(std::time::Duration::from_millis(LOCK_RETRY_DELAY_MS));
+                }
+                other => return other,
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn flock_once(root: &Path) -> std::io::Result<Option<std::fs::File>> {
         use std::os::unix::io::AsRawFd;
         std::fs::create_dir_all(root)?;
         // Content irrelevant (only existence + flock state matter);
         // truncate(false) avoids clippy's suspicious_open_options.
+        //
+        // O_CLOEXEC: `std::fs::File` opens close-on-exec by DEFAULT — KEEP it
+        // that way: flock state rides the open file description, so a lock fd
+        // carried across exec by a detached child would keep holding the flock
+        // after this process dies (sidecar_store.rs V6.md NA-3 precedent).
         let file = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
@@ -1518,37 +1572,83 @@ impl PaneLedger {
     }
 
     /// The ONE directory scan — construction-time only (V1.md).
+    ///
+    /// H2 loudness contract: I/O failures are never silent here. An unreadable
+    /// directory or row would otherwise present as a silently-EMPTY index —
+    /// the exact compounding mode behind "came up blind despite the lock being
+    /// acquirable and rows on disk". Parse/wrong-version skips stay silent BY
+    /// POLICY: the boot scan (`quarantine_unparsable`) is their loud path.
+    /// A row that vanishes between listing and read (Missing) is benign TOCTOU
+    /// residue and stays silent.
     fn load_index(root: &Path) -> LedgerIndex {
+        fn unreadable_dir(path: &std::path::Path, err: &std::io::Error) {
+            tracing::error!(
+                target: "freshell_ws::pane_ledger",
+                path = %path.display(),
+                error = %err,
+                "pane_ledger_load_index_dir_unreadable: rows under this directory are ABSENT from the in-memory index"
+            );
+        }
+        fn unreadable_row(path: &std::path::Path, err: &RowLoadError) {
+            tracing::error!(
+                target: "freshell_ws::pane_ledger",
+                path = %path.display(),
+                error = %err,
+                "pane_ledger_load_index_row_unreadable: this row is ABSENT from the in-memory index (boot-scan quarantine cannot repair an unreadable file)"
+            );
+        }
         let mut index = LedgerIndex::default();
-        if let Ok(providers) = std::fs::read_dir(Self::bindings_dir(root)) {
-            for provider in providers.flatten() {
-                let Ok(files) = std::fs::read_dir(provider.path()) else {
-                    continue;
-                };
-                for file in files.flatten() {
-                    let path = file.path();
-                    if path.extension().and_then(|e| e.to_str()) != Some("json") {
-                        continue; // *.tmp-* and *.quarantined-* residue
-                    }
-                    if let Ok(row) = load_row::<BindingRow>(&path) {
-                        if row.ledger_version == LEDGER_VERSION {
-                            index
-                                .bindings
-                                .insert((row.provider.clone(), row.session_id.clone()), row);
+        match std::fs::read_dir(Self::bindings_dir(root)) {
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {} // fresh root — normal
+            Err(err) => unreadable_dir(&Self::bindings_dir(root), &err),
+            Ok(providers) => {
+                for provider in providers.flatten() {
+                    match std::fs::read_dir(provider.path()) {
+                        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(err) => unreadable_dir(&provider.path(), &err),
+                        Ok(files) => {
+                            for file in files.flatten() {
+                                let path = file.path();
+                                if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                                    continue; // *.tmp-* and *.quarantined-* residue
+                                }
+                                match load_row::<BindingRow>(&path) {
+                                    Ok(row) => {
+                                        if row.ledger_version == LEDGER_VERSION {
+                                            index.bindings.insert(
+                                                (row.provider.clone(), row.session_id.clone()),
+                                                row,
+                                            );
+                                        }
+                                    }
+                                    Err(RowLoadError::Io(err)) => {
+                                        unreadable_row(&path, &RowLoadError::Io(err))
+                                    }
+                                    Err(RowLoadError::Missing) | Err(RowLoadError::Parse(_)) => {}
+                                }
+                            }
                         }
                     }
                 }
             }
         }
-        if let Ok(files) = std::fs::read_dir(Self::pending_dir(root)) {
-            for file in files.flatten() {
-                let path = file.path();
-                if path.extension().and_then(|e| e.to_str()) != Some("json") {
-                    continue;
-                }
-                if let Ok(marker) = load_row::<PendingMarker>(&path) {
-                    if marker.ledger_version == LEDGER_VERSION {
-                        index.pending.insert(marker.terminal_id.clone(), marker);
+        match std::fs::read_dir(Self::pending_dir(root)) {
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => unreadable_dir(&Self::pending_dir(root), &err),
+            Ok(files) => {
+                for file in files.flatten() {
+                    let path = file.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                        continue;
+                    }
+                    match load_row::<PendingMarker>(&path) {
+                        Ok(marker) => {
+                            if marker.ledger_version == LEDGER_VERSION {
+                                index.pending.insert(marker.terminal_id.clone(), marker);
+                            }
+                        }
+                        Err(RowLoadError::Io(err)) => unreadable_row(&path, &RowLoadError::Io(err)),
+                        Err(RowLoadError::Missing) | Err(RowLoadError::Parse(_)) => {}
                     }
                 }
             }

--- a/crates/freshell-ws/src/pane_ledger_tests.rs
+++ b/crates/freshell-ws/src/pane_ledger_tests.rs
@@ -20,6 +20,40 @@ fn temp_root(label: &str) -> PathBuf {
     dir
 }
 
+/// H1 diagnostic: on a lock-acquisition failure, `/proc/locks` names the
+/// live holder pid(s) for this lock file (self vs foreign is the only
+/// discrimination it can make: the pid column is the LOCKING tgid, so an
+/// inheritance-window transient reports THIS test process's own pid, never
+/// the forked child's). Match the hardened dev+ino token (format
+/// `%02x:%02x:%d`, evidence-locked by validator PoC arm c).
+#[cfg(unix)]
+fn lock_holder_report(lock_path: &Path) -> String {
+    use std::os::unix::fs::MetadataExt;
+    let Ok(meta) = std::fs::metadata(lock_path) else {
+        return "lock file itself unreadable".into();
+    };
+    let token = format!(
+        "{:02x}:{:02x}:{}",
+        libc::major(meta.dev()),
+        libc::minor(meta.dev()),
+        meta.ino()
+    );
+    match std::fs::read_to_string("/proc/locks") {
+        Ok(body) => {
+            let hits: Vec<&str> = body
+                .lines()
+                .filter(|l| l.split_whitespace().nth(5) == Some(token.as_str()))
+                .collect();
+            if hits.is_empty() {
+                format!("no /proc/locks row for {token}")
+            } else {
+                hits.join("\n")
+            }
+        }
+        Err(err) => format!("lock-holders unavailable: {err}"),
+    }
+}
+
 fn write(
     provider: &str,
     session_id: &str,
@@ -2156,7 +2190,7 @@ fn new_locked_degrades_to_disabled_when_another_holder_exists() {
     // constructor coming up blind -- and the errno that would name the
     // mechanism (EWOULDBLOCK: flock genuinely held, vs ENOSPC/EMFILE:
     // resource pressure, vs a silently-empty load_index) was dropped because
-    // this binary installs no tracing subscriber. Per C1's reasoning we do
+    // this binary installs no tracing subscriber. Per C1's reasoning we did
     // NOT retry-mask; instead every assertion below carries the on-disk and
     // errno evidence needed to diagnose the next occurrence on sight.
     //
@@ -2164,11 +2198,11 @@ fn new_locked_degrades_to_disabled_when_another_holder_exists() {
     // is errno=11 EWOULDBLOCK at the re-acquire after `drop(holder)`: the
     // dropped holder's flock can remain kernel-held for a tick, and
     // `new_locked` swallows the errno into a DISABLED ledger
-    // (pane_ledger.rs:247-255). The one-shot probe-2 acquire (which panicked
+    // (pane_ledger.rs:1374-1384). The one-shot probe-2 acquire (which panicked
     // on exactly that signature) and the third construction are therefore
     // REPLACED by one bounded wait whose RETRY UNIT is the third construction
     // itself, with a TWO-BRANCH diagnosis per failed construction keyed on
-    // `candidate.is_enabled()` (pane_ledger.rs:295 — false only when the
+    // `candidate.is_enabled()` (pane_ledger.rs:1447 — false only when the
     // candidate's own lock acquisition FAILED):
     //  - ENABLED but blind (the candidate holds the flock yet cannot see
     //    s1.json — load_index swallowed an I/O error, H2): panic
@@ -2195,6 +2229,12 @@ fn new_locked_degrades_to_disabled_when_another_holder_exists() {
     // The loser-construction property and the on-disk evidence probe stay
     // one-shot and untouched — the C1 no-retry-masking decision holds for
     // everything the wait does not cover.
+    // s52d addendum: production now absorbs this transient class — acquisition retries
+    // EWOULDBLOCK-only on a fixed budget (LOCK_RETRY_MAX_ATTEMPTS / LOCK_RETRY_DELAY_MS,
+    // pane_ledger.rs:150-152), so the DISABLED branch below first requires contention
+    // that outlives the production ~275ms budget; persistent failures still panic with
+    // full evidence (and the budget-expiry assert below now reports the /proc/locks
+    // holder pid for this lock file — the s52d holder-identity deliverable).
     let root = temp_root("lock");
     let holder = PaneLedger::new_locked(Some(root.clone()));
     holder
@@ -2264,7 +2304,7 @@ fn new_locked_degrades_to_disabled_when_another_holder_exists() {
                 "third new_locked came up ENABLED yet BLIND — the candidate \
                  itself holds the flock (lock WAS free/held by us) and \
                  s1.json is confirmed on disk by the on-disk probe above, so \
-                 load_index swallowed an I/O error (H2, pane_ledger.rs:314) \
+                 load_index swallowed an I/O error (H2, pane_ledger.rs:1583) \
                  — provisional-final, never retried"
             );
         }
@@ -2314,8 +2354,12 @@ fn new_locked_degrades_to_disabled_when_another_holder_exists() {
                     std::time::Instant::now() < deadline,
                     "flock still EWOULDBLOCK after the 10s bounded wait — the \
                      proven flake signature persisted past the wait; last \
-                     captured lock failure: {err_text} (fossils family: \
-                     pane-ledger-test-lock-*)"
+                     captured lock failure: {err_text}; holder report \
+                     (/proc/locks names the LOCKING tgid — an inheritance-\
+                     window transient reports THIS test process's own pid, a \
+                     foreign holder reports a foreign pid): {} (fossils \
+                     family: pane-ledger-test-lock-*)",
+                    lock_holder_report(&root.join("lock"))
                 );
                 std::thread::sleep(std::time::Duration::from_millis(25));
             }
@@ -2336,6 +2380,59 @@ fn new_locked_degrades_to_disabled_when_another_holder_exists() {
     // The loop above breaks only when the third construction sees the binding —
     // the old trailing `assert!(next.ever_bound(...))` is subsumed by the loop's
     // success criterion and is removed (it would have been unreachable).
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn acquire_retries_through_a_transient_holder_release() {
+    // H1 root-cause class: with LOCK_NB a single-shot acquire fails inside a
+    // transient holder window (e.g. a forked child still carrying a dup of
+    // the lock fd pre-exec). Production acquisition must ABSORB a window that
+    // releases well inside the retry budget: the holder is dropped 50ms after
+    // construction starts, far below the worst-case budget (~275ms).
+    // Margin math: 50ms dropper vs ~275ms budget tolerates ~225ms of
+    // scheduling overshoot (N4, proven structurally) — do NOT "tighten" the
+    // 50ms toward the budget; that would reintroduce flakiness.
+    let root = temp_root("lock-retry");
+    let holder = PaneLedger::new_locked(Some(root.clone()));
+    let rehome = root.clone();
+    let dropper = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        drop(holder);
+    });
+    let started = std::time::Instant::now();
+    let candidate = PaneLedger::new_locked(Some(rehome));
+    dropper.join().unwrap();
+    assert!(
+        candidate.is_enabled(),
+        "bounded retry must absorb a transient holder window; ledger came up DISABLED"
+    );
+    assert!(
+        started.elapsed() >= std::time::Duration::from_millis(50),
+        "acquisition must wait for the real holder release, not race past it"
+    );
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn persistent_contention_still_degrades_disabled_within_a_bounded_budget() {
+    // The single-writer contract is unchanged: a REAL second writer never
+    // acquires. The retry budget only bounds degradation latency (~0.3s),
+    // it never masks persistent contention.
+    let root = temp_root("lock-persist");
+    let _holder = PaneLedger::new_locked(Some(root.clone()));
+    let started = std::time::Instant::now();
+    let loser = PaneLedger::new_locked(Some(root.clone()));
+    assert!(
+        !loser.is_enabled(),
+        "a persistent holder must still degrade"
+    );
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(3),
+        "degradation is bounded by the fixed retry budget, never a spin"
+    );
     std::fs::remove_dir_all(&root).ok();
 }
 
@@ -7848,5 +7945,78 @@ fn reattach_never_moves_attribution_backwards() {
     assert_eq!(row.create_request_id.as_deref(), Some("req-new-mono"));
     assert_eq!(row.tab_key.as_deref(), Some("device-1:tab-5"));
     assert_eq!(row.last_attributed_at, Some(5_000));
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn load_index_dir_io_errors_are_loud_not_silently_empty() {
+    // H2 (kata s52d companion): an I/O failure while listing the store must
+    // NEVER surface as a silently-empty index. `bindings` forged as a
+    // REGULAR FILE makes read_dir deterministic-ENOTDIR on any uid (chmod
+    // tricks are root-skip-flaky); same for `pending`.
+    let root = temp_root("load-loud-dir");
+    std::fs::write(root.join("bindings"), b"not a dir").unwrap();
+    std::fs::write(root.join("pending"), b"not a dir").unwrap();
+    let (events, guard) = crate::invariants::capture::capture();
+    let ledger = PaneLedger::new(Some(root.clone()));
+    drop(guard);
+    let events = events.lock().unwrap();
+    let hits: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.target == "freshell_ws::pane_ledger"
+                && e.message.contains("pane_ledger_load_index_dir_unreadable")
+        })
+        .collect();
+    assert_eq!(
+        hits.len(),
+        2,
+        "one ERROR per unreadable top-level dir (bindings + pending); got: {events:?}"
+    );
+    assert!(hits.iter().all(|h| h.fields.contains_key("path")));
+    drop(events);
+    assert!(
+        !ledger.ever_bound("claude", "anything"),
+        "index correctly empty; loudness is the contract"
+    );
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn load_index_row_io_errors_are_loud_per_row() {
+    // Same H2 lane, per-ROW: an entry ending in .json that is a DIRECTORY
+    // makes the row read deterministic-EISDIR (uid-independent). Parse
+    // errors of REAL rows stay silent-by-contract here (boot-scan quarantine
+    // owns loudness) — this test must NOT flip that: only Io arms the event.
+    let root = temp_root("load-loud-row");
+    std::fs::create_dir_all(root.join("bindings").join("claude").join("ghost.json")).unwrap();
+    let (events, guard) = crate::invariants::capture::capture();
+    let ledger = PaneLedger::new(Some(root.clone()));
+    drop(guard);
+    let events = events.lock().unwrap();
+    let hits: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.target == "freshell_ws::pane_ledger"
+                && e.message.contains("pane_ledger_load_index_row_unreadable")
+        })
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "one ERROR for the unreadable row; got: {events:?}"
+    );
+    let want_path = format!(
+        "{}",
+        root.join("bindings")
+            .join("claude")
+            .join("ghost.json")
+            .display()
+    );
+    assert_eq!(hits[0].fields.get("path"), Some(&want_path));
+    drop(events);
+    assert!(ledger.list_bindings().is_empty());
     std::fs::remove_dir_all(&root).ok();
 }


### PR DESCRIPTION
## What

Fixes the deflake-caught flake in `pane_ledger::tests::new_locked_degrades_to_disabled_when_another_holder_exists` (errno 11 / EWOULDBLOCK probing the private lock path immediately after the holder dropped, ~1/10 runs under workspace load), and the companion silent-failure finding that `load_index()` swallowed I/O errors.

### H1 — bounded EWOULDBLOCK-only retry (product race)

The flake's mechanism class is a fork→exec open-file-description inheritance handoff (in-tree trigger: `git` spawns from `terminal_meta.rs:492` inside the same lib test binary under parallel libtest): a forked child transiently carries a reference to the lock's OFD, so `<root>/lock` stays momentarily held; single-shot `LOCK_NB` converted that microsecond window into a process-lifetime DISABLED ledger. A scratch PoC on-host proved the class (bare close→reopen releases in ~13µs; inherited OFD refs block fresh acquirers with EWOULDBLOCK; O_CLOEXEC bounds the window AT exec).

`acquire_store_lock` now retries **only** on EWOULDBLOCK with a fixed budget (12 attempts × 25ms ≈ 275ms, one-shot boot path). Non-EWOULDBLOCK errnos fail immediately; a genuine persistent second writer still degrades loudly, just ~275ms later. Single-writer guard unchanged.

Reconciled onto the DEFLAKE-2 test architecture merged on main (bounded construction retry classified by captured `pane_ledger_lock_unavailable` events); this PR keeps that architecture and adds the s52d deliverables on top: two tests pinning the production absorb/contention contract, and a `/proc/locks` holder-pid report (dev+inode `%02x:%02x:%d` match) in the deflake test's budget-expiry panic.

### H2 — loud `load_index` I/O errors

Unreadable bindings/pending directories or row files now emit structured `tracing::error!` events (`pane_ledger_load_index_dir_unreadable` / `pane_ledger_load_index_row_unreadable`, target `freshell_ws::pane_ledger`) instead of a silently-empty index. NotFound / parse / wrong-version silence preserved per the documented boot-scan-quarantine loudness policy. New capture-based tests pin exact event counts (2 / 1).

Upstream scope note: the rollback / kill-tombstone subtrees added on main after this kata retain upstream's silence policy (separate follow-up candidate).

## Verification

- Reproduced the flake live at the pre-fix base (506/507, errno 11); 20/20 repetitions of the pane_ledger suite under 8-thread load after the fix
- pane_ledger suite 153/153 post-merge; full `cargo test -p freshell-ws` green; `cargo test -p freshell-server` 902 green
- `cargo fmt --all --check` + strict clippy (workspace + both real-transport feature lanes) clean
- Full QA gate (`npm run check` + fmt + clippy) green at this exact commit
- Independent review: plan PASSED; complete delta PASSED twice (pre-reconcile branch and this squashed landing commit)
