### PR TITLE
fix(e2e): register rust-only specs in RUST_ONLY_SPECS and rust-chromium testMatch

### DIFF
--- a/test/e2e-browser/playwright.cloud.config.ts
+++ b/test/e2e-browser/playwright.cloud.config.ts
@@ -50,8 +50,9 @@ const CLOUD_SKIP_SPECS = [
   'pane-activity-indicator.spec.ts',
   // Environment-sensitive: timing-sensitive localStorage persistence
   'rest-tab-persistence.spec.ts',
-  // Rust-only: asserts e2eServerKind === 'rust' but runs under chromium
-  // project (not in RUST_ONLY_SPECS — pre-existing config gap)
+  // Rust-only: asserts e2eServerKind === 'rust'; runs only under the
+  // rust-chromium project (registered in RUST_ONLY_SPECS). Skipped in cloud
+  // pending cloud validation of this rust-only lane.
   'term28-path-shadow-rust.spec.ts',
   // Server-build mismatch reload: the Cloud Run image builds WITHOUT git
   // metadata (.dockerignore drops .git), so the Rust bake and the Vite

--- a/test/e2e-browser/playwright.config.ts
+++ b/test/e2e-browser/playwright.config.ts
@@ -312,6 +312,48 @@ export const RUST_ONLY_SPECS = [
   // Reconnect-revive acceptance: socket-drop/freeze revival; drives
   // RustServer + forceDisconnect + SIGSTOP (docs/plans/2026-08-22-reconnect-revive.md).
   /reconnect-revive-rust\.spec\.ts$/,
+  // AMPLIFIER-RESTORE (docs/plans/2026-07-18-amplifier-restore-spec.md):
+  // KNOWN DIVERGENCE -- legacy predates upstream #514 and has NO amplifier
+  // provider registered; a genuinely rust-only feature (see the spec's doc
+  // comment and the rust-chromium testMatch entry).
+  /amplifier-restore-rust\.spec\.ts$/,
+  // Opencode terminal restore: KNOWN DIVERGENCE -- legacy has no opencode
+  // terminal<->session association (see the spec's doc comment).
+  /opencode-terminal-restore-rust\.spec\.ts$/,
+  // CODEX-BOUNCE (2026-07-22 incident regression): the resume-derivation bug
+  // was in the Rust WS create path; the legacy anchor was correct -- rust-only
+  // (see the rust-chromium testMatch entry and spec doc comment).
+  /codex-terminal-bounce-rust\.spec\.ts$/,
+  // MCP bridge pin: the unmodified legacy MCP stdio binary against an owned,
+  // ephemeral Rust server; rust-only (see the rust-chromium testMatch entry).
+  /mcp-bridge-rust\.spec\.ts$/,
+  // MCP QA smoke: the full mode-matrix payoff of the MCP QA lever; rust-only
+  // (see the rust-chromium testMatch entry + spec doc comment).
+  /mcp-qa-smoke-rust\.spec\.ts$/,
+  // TERM-28: Rust portable-pty PATH-only bare-command resolution fix; legacy
+  // node-pty is unaffected (see the rust-chromium testMatch entry).
+  /term28-path-shadow-rust\.spec\.ts$/,
+  // REST-TAB-PERSISTENCE (client tab-poisoning incident evidence): the
+  // `amplifier` mode trigger has no legacy provider -- the same KNOWN
+  // DIVERGENCE as amplifier-restore-rust above (see the rust-chromium
+  // testMatch entry).
+  /rest-tab-persistence\.spec\.ts$/,
+  // DIAG-03 -- rotation limits are a deliberate Rust-only hardening feature;
+  // the frozen legacy server has no equivalent (see the spec's doc comment).
+  /diag03-rotation-redaction-rust\.spec\.ts$/,
+  // RECONCILE-HANDSHAKE (PW-RUST, design §9.2): raw-WS synthetic-client proof
+  // of the reconciliation-on-connect handshake against the REAL Rust server.
+  // Was registered in NEITHER list (zero tests collected under rust-chromium;
+  // wrongly collected by the match-all chromium project).
+  /reconcile-handshake-rust\.spec\.ts$/,
+  // Remote status rings Task 5 e2e pin (docs/plans/2026-08-10-remote-status-rings.md):
+  // owns a RustServer (ephemeral port) + raw-WS second-device tabs.sync.push.
+  // Was registered in NEITHER list. See the spec's doc comment.
+  /sidebar-remote-status-rings-rust\.spec\.ts$/,
+  // Sidebar status-tier sort (sibling of sidebar-remote-status-rings-rust):
+  // against the REAL Rust server, same raw-WS second-device harness; landed
+  // upstream unregistered (silent false green) — registered here.
+  /sidebar-status-tier-sort-rust\.spec\.ts$/,
 ]
 
 export default defineConfig({
@@ -565,6 +607,16 @@ export default defineConfig({
         // Reconnect-revive acceptance: socket-drop/freeze revival; drives
         // RustServer + forceDisconnect + SIGSTOP (see RUST_ONLY_SPECS entry).
         /reconnect-revive-rust\.spec\.ts$/,
+        // Reconcile handshake (PW-RUST design §9.2): synthetic raw-WS client
+        // proof of the reconciliation-on-connect handshake against the REAL
+        // Rust server (see the RUST_ONLY_SPECS entry + spec doc comment).
+        /reconcile-handshake-rust\.spec\.ts$/,
+        // Remote status rings Task 5 e2e pin (see the RUST_ONLY_SPECS entry
+        // + spec doc comment; owns its RustServer on an ephemeral port).
+        /sidebar-remote-status-rings-rust\.spec\.ts$/,
+        // Sidebar status-tier sort e2e pin (see the RUST_ONLY_SPECS entry + the
+        // spec's doc comment; owns its RustServer on an ephemeral port).
+        /sidebar-status-tier-sort-rust\.spec\.ts$/,
       ],
     },
     // CONTINUITY SMOKE (pre-deploy gate): REAL freshell-server binary + REAL

--- a/test/unit/e2e-browser-spec-registration.test.ts
+++ b/test/unit/e2e-browser-spec-registration.test.ts
@@ -1,0 +1,73 @@
+// Pins the playwright.config.ts rust-only registration invariant: every
+// rust-only spec runs EXACTLY ONCE, under the `rust-chromium` project.
+// Default `chromium` is a match-all project (testIgnore: RUST_ONLY_SPECS);
+// a spec in rust-chromium `testMatch` but missing from RUST_ONLY_SPECS is
+// also collected by `chromium` and runs against the legacy Node server
+// (darkforge job 0q8k / GATE-01 evidence). A spec on disk but unregistered
+// collects ZERO tests under rust-chromium -- a silent false green.
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import baseConfig, {
+  MATRIX_SPECS,
+  RUST_ONLY_SPECS,
+} from '../../test/e2e-browser/playwright.config'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const specsDir = path.resolve(__dirname, '../../test/e2e-browser/specs')
+
+type Pattern = string | RegExp
+function toRegexes(patterns: Pattern | Pattern[] | undefined): RegExp[] {
+  const list = Array.isArray(patterns) ? patterns : patterns ? [patterns] : []
+  return list.map((p) => (p instanceof RegExp ? p : new RegExp(p)))
+}
+
+// rust-chromium `testMatch` entries that are ALSO allowed under the match-all
+// `chromium` project (intentional Node/Rust double coverage), each with the
+// reason this is NOT a RUST_ONLY_SPECS hole. Keyed by exact regex source.
+const INTENTIONAL_CHROMIUM_DOUBLE_COVERAGE: Record<string, string> = {
+  [/sidebar-opencode-rail\.spec\.ts$/.source]:
+    'Node parity is part of the fix (spec doc comment + testMatch comment).',
+  [/harness-01-rust-server\.spec\.ts$/.source]:
+    'Server-kind-agnostic owned-fixture self-test; config comment says it only needs to run once, under rust-chromium, but it also passes under chromium (harmless duplicate).',
+}
+
+const chromium = baseConfig.projects?.find((p) => p.name === 'chromium')
+const rust = baseConfig.projects?.find((p) => p.name === 'rust-chromium')
+
+describe('playwright e2e rust-only spec registration', () => {
+  it('chromium testIgnore is exactly the shared RUST_ONLY_SPECS array', () => {
+    expect(chromium?.testIgnore).toBe(RUST_ONLY_SPECS)
+  })
+
+  it('every on-disk *-rust.spec.ts is registered in BOTH rust-chromium testMatch and RUST_ONLY_SPECS', () => {
+    const onDisk = fs
+      .readdirSync(specsDir)
+      .filter((f) => f.endsWith('-rust.spec.ts'))
+    const rustMatch = toRegexes(rust?.testMatch as Pattern | Pattern[] | undefined)
+    const unregistered = onDisk.filter(
+      (f) =>
+        !rustMatch.some((re) => re.test(f)) ||
+        !RUST_ONLY_SPECS.some((re) => re.test(f)),
+    )
+    expect(unregistered).toEqual([])
+  })
+
+  it('every rust-chromium testMatch entry is in RUST_ONLY_SPECS or allowlisted for intentional chromium double coverage', () => {
+    const rustMatch = toRegexes(rust?.testMatch as Pattern | Pattern[] | undefined)
+    const ignoreSources = new Set(RUST_ONLY_SPECS.map((re) => re.source))
+    // MATRIX_SPECS are multi-server BY DESIGN (HARNESS-02): they run under
+    // legacy-chromium, rust-chromium, AND the match-all chromium project.
+    const matrixSources = new Set(MATRIX_SPECS.map((re) => re.source))
+    const violators = rustMatch
+      .map((re) => re.source)
+      .filter((source) => !matrixSources.has(source))
+      .filter(
+        (source) =>
+          !ignoreSources.has(source) &&
+          !(source in INTENTIONAL_CHROMIUM_DOUBLE_COVERAGE),
+      )
+    expect(violators).toEqual([])
+  })
+})


### PR DESCRIPTION
Rust-only Playwright specs listed in the rust-chromium testMatch but missing from RUST_ONLY_SPECS were also collected by the match-all chromium project and run against the legacy Node server, where they fail or diverge; several more were registered in neither list, so they collected zero tests under rust-chromium (a silent false green).

This lands the reconciled registration (both lists, per-entry justifying comments) plus a Vitest consistency suite that fails if the lists ever drift apart again. The two never-before-run specs (reconcile-handshake-rust, sidebar-remote-status-rings-rust) were proven green under --project=rust-chromium, and the invariant caught one newly-added upstream spec (sidebar-status-tier-sort-rust) during landing reconciliation, which this also registers.

Head commit is the exact QA-gated squash: 4d1bbd601d3c540a3138cfc28b4744db4ce1bcac.