### PR TITLE
feat(terminal): open image file links in a viewer pane instead of the editor

### DIFF
--- a/crates/freshell-server/src/files.rs
+++ b/crates/freshell-server/src/files.rs
@@ -115,6 +115,7 @@ pub fn router(state: FilesState) -> Router {
         .route("/api/files/candidate-dirs", get(candidate_dirs))
         .route("/api/files/validate-dir", post(validate_dir))
         .route("/api/files/read", get(read_file))
+        .route("/api/files/raw", get(raw_file))
         .route("/api/files/stat", get(stat_file))
         .route("/api/files/write", post(write_file))
         .route("/api/files/complete", get(complete))
@@ -244,6 +245,50 @@ async fn read_file(
                 }))
                 .into_response()
             }
+            Err(err) => internal_error(&err.to_string()),
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => not_found("File not found"),
+        Err(err) => internal_error(&err.to_string()),
+    }
+}
+
+/// `GET /api/files/raw?path=<p>` → raw bytes with the send-compatible
+/// Content-Type table (port of the Node `/api/files/raw` route in
+/// `server/files-router.ts`).
+///
+/// Unlike `/local-file` (deliberately unsandboxed for Browser-pane `file://`
+/// entries), this route resolves exactly like [`read_file`]: tilde
+/// expansion, flavor-aware normalization, and the live `allowedFilePaths`
+/// sandbox (403). Error shapes mirror `read_file` (`400"Cannot read
+/// directory"`, `404 "File not found"`); the byte lane reuses
+/// [`send_file_response`], so image extensions come back with their vendored
+/// `image/*` Content-Type — the pane viewer's render hook.
+async fn raw_file(
+    State(state): State<FilesState>,
+    headers: HeaderMap,
+    Query(q): Query<PathQuery>,
+) -> Response {
+    if !crate::boot::is_authed(&headers, &state.auth_token) {
+        return unauthorized();
+    }
+    let Some(path) = q.path.filter(|p| !p.is_empty()) else {
+        return bad_request("path query parameter required");
+    };
+    let resolved = resolve_user_path(&path);
+    let settings = state.settings.get().await;
+    if !is_path_allowed(
+        resolved.sandbox_target(),
+        settings.allowed_file_paths.as_deref(),
+    ) {
+        return forbidden();
+    }
+    // Node's toFilesystemPath fallthrough — see read_file.
+    let resolved = resolved.fs_path.unwrap_or(resolved.display);
+    match std::fs::metadata(&resolved) {
+        Ok(meta) if meta.is_dir() => bad_request("Cannot read directory"),
+        Ok(meta) => match std::fs::read(&resolved) {
+            Ok(bytes) => send_file_response(&resolved, &meta, bytes),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => not_found("File not found"),
             Err(err) => internal_error(&err.to_string()),
         },
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => not_found("File not found"),
@@ -2573,5 +2618,87 @@ mod tests {
         let resp = get(&spaced).await;
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(body_bytes(resp).await, b"space-name");
+    }
+
+    // ---- GET /api/files/raw (sandboxed raw-bytes lane — Node `/raw` parity port) ----
+
+    async fn raw_file_resp(state: &FilesState, headers: HeaderMap, path: Option<&str>) -> Response {
+        raw_file(
+            State(state.clone()),
+            headers,
+            Query(PathQuery {
+                path: path.map(str::to_string),
+            }),
+        )
+        .await
+        .into_response()
+    }
+
+    #[tokio::test]
+    async fn raw_file_serves_image_bytes_with_mime() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bytes: Vec<u8> = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF];
+        let png = tmp.path().join("img.png");
+        std::fs::write(&png, &bytes).unwrap();
+        let resp = raw_file_resp(&test_state(), auth_headers(), Some(&png.to_string_lossy())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "image/png"
+        );
+        assert_eq!(body_bytes(resp).await, bytes, "binary bytes unmangled");
+    }
+
+    #[tokio::test]
+    async fn raw_file_missing_path_param_is_400_missing_file_is_404_dir_is_400() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let resp = raw_file_resp(&test_state(), auth_headers(), None).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            body_json(resp).await["error"],
+            "path query parameter required"
+        );
+
+        let missing = tmp.path().join("nope.png");
+        let resp = raw_file_resp(
+            &test_state(),
+            auth_headers(),
+            Some(&missing.to_string_lossy()),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_eq!(body_json(resp).await["error"], "File not found");
+
+        let resp = raw_file_resp(
+            &test_state(),
+            auth_headers(),
+            Some(&tmp.path().to_string_lossy()),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(body_json(resp).await["error"], "Cannot read directory");
+    }
+
+    #[tokio::test]
+    async fn raw_file_enforces_allowed_file_paths_sandbox() {
+        // R3 parity: the sandbox reads the LIVE SettingsStore (a PATCH
+        // /api/settings takes effect immediately), exactly like read_file.
+        let tmp = tempfile::tempdir().unwrap();
+        let png = tmp.path().join("img.png");
+        std::fs::write(&png, b"x").unwrap();
+
+        let state = test_state();
+        // SettingsStore::patch(&Value) — the same partial-settings patch API
+        // PATCH /api/settings uses; {} would fail unwrap, so unwrap to pin a
+        // valid patch body.
+        state
+            .settings
+            .patch(&json!({ "allowedFilePaths": ["/definitely-not-the-tmp-parent"] }))
+            .await
+            .unwrap();
+        let resp = raw_file_resp(&state, auth_headers(), Some(&png.to_string_lossy())).await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(body_json(resp).await["error"], "Path not allowed");
     }
 }

--- a/server/files-router.ts
+++ b/server/files-router.ts
@@ -110,6 +110,46 @@ export function createFilesRouter(deps: FilesRouterDeps): Router {
     }
   })
 
+  /**
+   * Raw-bytes lane for binary assets (images) opened in viewer panes.
+   * Unlike /local-file this IS sandboxed and resolves exactly like /read
+   * (tilde expansion, flavor-aware normalization, allowedFilePaths → 403);
+   * sendFile supplies the extension-based Content-Type (image/png, ...).
+   */
+  router.get('/raw', validatePath, async (req, res) => {
+    const filePath = req.query.path as string
+    if (!filePath) {
+      return res.status(400).json({ error: 'path query parameter required' })
+    }
+
+    const resolved = await resolveUserFilesystemPath(filePath)
+
+    try {
+      const stat = await fsp.stat(resolved)
+      if (stat.isDirectory()) {
+        return res.status(400).json({ error: 'Cannot read directory' })
+      }
+    } catch (err: any) {
+      if (err.code === 'ENOENT') {
+        return res.status(404).json({ error: 'File not found' })
+      }
+      return res.status(500).json({ error: err.message })
+    }
+
+    await new Promise<void>((resolve) => {
+      res.sendFile(resolved, (error?: NodeJS.ErrnoException) => {
+        if (error && !res.headersSent) {
+          if (error.code === 'ENOENT') {
+            res.status(404).json({ error: 'File not found' })
+          } else {
+            res.status(500).json({ error: 'Failed to send file' })
+          }
+        }
+        resolve()
+      })
+    })
+  })
+
   router.get('/stat', validatePath, async (req, res) => {
     const filePath = req.query.path as string
     if (!filePath) {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -110,7 +110,7 @@ import {
 import { useMobile } from '@/hooks/useMobile'
 import { useKeyboardInset } from '@/hooks/useKeyboardInset'
 import { useEnsureExtensionsRegistry } from '@/hooks/useEnsureExtensionsRegistry'
-import { findLocalFilePaths } from '@/lib/path-utils'
+import { findLocalFilePaths, isImageFilePath } from '@/lib/path-utils'
 import { findUrls } from '@/lib/url-utils'
 import { openExternalUrl, shouldOpenLinkExternally } from '@/lib/open-url'
 import { setHoveredUrl, clearHoveredUrl } from '@/lib/terminal-hovered-url'
@@ -2200,6 +2200,14 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
             activate: (event: MouseEvent) => {
               if (event && event.button !== 0) return
               if (terminalInstanceIdRef.current !== linkProviderTerminalInstanceId) return
+              if (isImageFilePath(m.path)) {
+                queuePaneSplit({
+                  kind: 'browser',
+                  url: `/api/files/raw?path=${encodeURIComponent(m.path)}`,
+                  devToolsOpen: false,
+                })
+                return
+              }
               queuePaneSplit({
                 kind: 'editor',
                 filePath: m.path,

--- a/src/lib/derivePaneTitle.ts
+++ b/src/lib/derivePaneTitle.ts
@@ -27,6 +27,18 @@ export function derivePaneTitle(content: PaneContent, extensions?: ClientExtensi
 
   if (content.kind === 'browser') {
     if (!content.url) return 'Browser'
+    // Raw-file byte-lane URLs (image viewer panes, file:// iframe lane):
+    // title by the served file's basename instead of falling through to
+    // 'Browser' (these relative URLs have no hostname).
+    const rawMatch = content.url.match(/^\/(?:api\/files\/raw|local-file)\?path=([^&]+)/)
+    if (rawMatch) {
+      try {
+        const segment = basenameSegment(decodeURIComponent(rawMatch[1]))
+        return segment ?? 'Browser'
+      } catch {
+        return 'Browser'
+      }
+    }
     try {
       const url = new URL(content.url)
       return url.hostname || 'Browser'

--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -70,3 +70,28 @@ export function joinPath(root: string, relativePath: string): string {
       : relativePath
   return `${trimmedRoot}${separator}${trimmedRelative}`
 }
+
+/**
+ * Extensions the client routes to an image viewer. Deliberately aligned with
+ * the `image/*` entries of the Rust byte-lane MIME table
+ * (crates/freshell-server/src/files.rs `local_file_content_type`), which the
+ * production self-hosted server uses to label exactly these correctly. The
+ * Node `/api/files/raw` route labels via send's vendored mime table, which
+ * serves `.avif` as application/octet-stream (pre-existing `/local-file` lane
+ * behavior); the named requirement (`.png`) renders on both servers.
+ */
+const IMAGE_EXTENSIONS = new Set([
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'ico', 'bmp', 'avif', 'svg',
+])
+
+/**
+ * True when the final segment of a file path (absolute, tilde, relative, or
+ * Windows) ends in a known image extension, case-insensitively. Dotfiles
+ * like `/x/.png` have no extension and return false.
+ */
+export function isImageFilePath(filePath: string): boolean {
+  const segment = filePath.split(/[\\/]/).pop() ?? ''
+  const dot = segment.lastIndexOf('.')
+  if (dot <= 0) return false
+  return IMAGE_EXTENSIONS.has(segment.slice(dot + 1).toLowerCase())
+}

--- a/test/e2e/terminal-file-link-same-tab.test.tsx
+++ b/test/e2e/terminal-file-link-same-tab.test.tsx
@@ -82,6 +82,8 @@ vi.mock('@monaco-editor/react', () => {
   }
 })
 
+const mockTerminalText = vi.hoisted(() => ({ line: '/tmp/example.txt' }))
+
 const linkProvidersByPaneId = new Map<string, {
   provideLinks: (line: number, callback: (links: any[] | undefined) => void) => void
 }>()
@@ -96,7 +98,7 @@ vi.mock('@xterm/xterm', () => {
       active: {
         viewportY: 0,
         getLine: vi.fn(() => ({
-          translateToString: () => '/tmp/example.txt',
+          translateToString: () => mockTerminalText.line,
         })),
       },
     }
@@ -249,6 +251,7 @@ describe('terminal file links open Monaco on the clicked pane branch without nav
     wsMocks.onReconnect.mockClear()
     wsMocks.setHelloExtensionProvider.mockClear()
     linkProvidersByPaneId.clear()
+    mockTerminalText.line = '/tmp/example.txt'
     vi.stubGlobal('ResizeObserver', MockResizeObserver)
   })
 
@@ -322,5 +325,54 @@ describe('terminal file links open Monaco on the clicked pane branch without nav
     await waitFor(() => {
       expect(apiMocks.get).toHaveBeenCalledWith('/api/files/read?path=%2Ftmp%2Fexample.txt')
     })
+  })
+
+  it('routes image file links to a browser pane instead of the editor', async () => {
+    mockTerminalText.line = '/tmp/example.png'
+    const store = createStore()
+
+    render(
+      <Provider store={store}>
+        <TabContent tabId="tab-1" />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(linkProvidersByPaneId.has('pane-clicked')).toBe(true)
+    })
+
+    const clickedProvider = linkProvidersByPaneId.get('pane-clicked')!
+    let links: any[] | undefined
+    clickedProvider.provideLinks(1, (provided) => {
+      links = provided
+    })
+
+    expect(links).toHaveLength(1)
+    expect(links![0].text).toBe('/tmp/example.png')
+
+    links![0].activate()
+
+    await waitFor(() => {
+      const root = store.getState().panes.layouts['tab-1']
+      if (root.type !== 'split') throw new Error('expected root split layout')
+      const rightBranch = root.children[1]
+      if (rightBranch.type !== 'split') throw new Error('expected right branch split')
+      const clickedBranch = rightBranch.children[1]
+      if (clickedBranch.type !== 'split') throw new Error('expected clicked branch split')
+      expect(clickedBranch.children[1]).toMatchObject({
+        type: 'leaf',
+        content: {
+          kind: 'browser',
+          url: '/api/files/raw?path=%2Ftmp%2Fexample.png',
+        },
+      })
+    })
+
+    // The editor lane is NOT exercised for images: no read call, no Monaco.
+    const readCalls = apiMocks.get.mock.calls.filter((c) =>
+      String(c[0]).startsWith('/api/files/read'),
+    )
+    expect(readCalls).toHaveLength(0)
+    expect(screen.queryByTestId('monaco-mock')).not.toBeInTheDocument()
   })
 })

--- a/test/integration/server/files-api.test.ts
+++ b/test/integration/server/files-api.test.ts
@@ -99,6 +99,64 @@ describe('Files API Integration', () => {
     })
   })
 
+  describe('GET /api/files/raw', () => {
+    it('serves PNG bytes exactly with an image/png Content-Type', async () => {
+      const pngBytes = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff, 0x10,
+      ])
+      const pngPath = path.join(tempDir, 'pixel.png')
+      await fsp.writeFile(pngPath, pngBytes)
+
+      const res = await request(app)
+        .get('/api/files/raw')
+        .set('x-auth-token', TEST_AUTH_TOKEN)
+        .query({ path: pngPath })
+        .buffer(true)
+        .parse((r, cb) => {
+          const chunks: Buffer[] = []
+          r.on('data', (c: Buffer) => chunks.push(c))
+          r.on('end', () => cb(null, Buffer.concat(chunks)))
+        })
+
+      expect(res.status).toBe(200)
+      expect(res.headers['content-type']).toBe('image/png')
+      expect(res.body).toEqual(pngBytes)
+    })
+
+    it('returns 404 JSON for a missing file', async () => {
+      const res = await request(app)
+        .get('/api/files/raw')
+        .set('x-auth-token', TEST_AUTH_TOKEN)
+        .query({ path: path.join(tempDir, 'missing.png') })
+      expect(res.status).toBe(404)
+      expect(res.body).toEqual({ error: 'File not found' })
+    })
+
+    it('expands tilde paths like the read route', async () => {
+      const homeName = `freshell-raw-${process.pid}-${Date.now()}.png`
+      const homePath = path.join(os.homedir(), homeName)
+      const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+      await fsp.writeFile(homePath, bytes)
+      try {
+        const res = await request(app)
+          .get('/api/files/raw')
+          .set('x-auth-token', TEST_AUTH_TOKEN)
+          .query({ path: `~/${homeName}` })
+          .buffer(true)
+          .parse((r, cb) => {
+            const chunks: Buffer[] = []
+            r.on('data', (c: Buffer) => chunks.push(c))
+            r.on('end', () => cb(null, Buffer.concat(chunks)))
+          })
+        expect(res.status).toBe(200)
+        expect(res.headers['content-type']).toBe('image/png')
+        expect(res.body).toEqual(bytes)
+      } finally {
+        await fsp.rm(homePath, { force: true }).catch(() => {})
+      }
+    })
+  })
+
   describe('POST /api/files/write', () => {
     it('writes content to file', async () => {
       const filePath = path.join(tempDir, 'new-file.txt')

--- a/test/unit/client/lib/derivePaneTitle.test.ts
+++ b/test/unit/client/lib/derivePaneTitle.test.ts
@@ -18,6 +18,47 @@ describe('derivePaneTitle', () => {
     expect(derivePaneTitle(content)).toBe('Browser')
   })
 
+  it('titles raw-file viewer panes by the file basename', () => {
+    expect(
+      derivePaneTitle({
+        kind: 'browser',
+        browserInstanceId: 'b1',
+        url: '/api/files/raw?path=%2Ftmp%2Fshot.png',
+        devToolsOpen: false,
+      }),
+    ).toBe('shot.png')
+    expect(
+      derivePaneTitle({
+        kind: 'browser',
+        browserInstanceId: 'b2',
+        url: '/local-file?path=%2Fhome%2Fdan%2Flogo.svg',
+        devToolsOpen: false,
+      }),
+    ).toBe('logo.svg')
+  })
+
+  it('keeps hostname titles for ordinary web URLs', () => {
+    expect(
+      derivePaneTitle({
+        kind: 'browser',
+        browserInstanceId: 'b3',
+        url: 'https://example.com/docs',
+        devToolsOpen: false,
+      }),
+    ).toBe('example.com')
+  })
+
+  it('returns "Browser" for a raw-file URL with malformed percent escapes', () => {
+    expect(
+      derivePaneTitle({
+        kind: 'browser',
+        browserInstanceId: 'bx',
+        url: '/api/files/raw?path=%zz',
+        devToolsOpen: false,
+      }),
+    ).toBe('Browser')
+  })
+
   it('returns "Shell" for shell mode terminal', () => {
     const content: PaneContent = {
       kind: 'terminal',

--- a/test/unit/client/lib/path-utils.test.ts
+++ b/test/unit/client/lib/path-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { findLocalFilePaths } from '@/lib/path-utils'
+import { isImageFilePath, findLocalFilePaths } from '@/lib/path-utils'
 
 function extractPaths(line: string): string[] {
   return findLocalFilePaths(line).map((m) => m.path)
@@ -24,5 +24,25 @@ describe('findLocalFilePaths', () => {
   it('rejects root slash and single-segment absolute words without extension', () => {
     const line = 'ignore / and ignore /tmp but keep /tmp/data.json'
     expect(extractPaths(line)).toEqual(['/tmp/data.json'])
+  })
+})
+
+describe('isImageFilePath', () => {
+  it('detects common image extensions case-insensitively', () => {
+    expect(isImageFilePath('/tmp/shot.png')).toBe(true)
+    expect(isImageFilePath('~/Pictures/Photo.JPG')).toBe(true)
+    expect(isImageFilePath('/repo/assets/icon.SvG')).toBe(true)
+    expect(isImageFilePath('C:\\img\\logo.webp')).toBe(true)
+    expect(isImageFilePath('/x/a.avif')).toBe(true)
+    expect(isImageFilePath('/x/a.bmp')).toBe(true)
+    expect(isImageFilePath('/x/a.ico')).toBe(true)
+  })
+
+  it('rejects text-like, extensionless, and dotfile paths', () => {
+    expect(isImageFilePath('/tmp/example.txt')).toBe(false)
+    expect(isImageFilePath('/src/index.ts')).toBe(false)
+    expect(isImageFilePath('/x/Makefile')).toBe(false)
+    expect(isImageFilePath('/x/archive.png.bak')).toBe(false)
+    expect(isImageFilePath('/x/.png')).toBe(false)
   })
 })

--- a/test/unit/server/files-router.test.ts
+++ b/test/unit/server/files-router.test.ts
@@ -159,6 +159,42 @@ describe('files-router path validation', () => {
     })
   })
 
+  describe('GET /api/files/raw', () => {
+    it('requires a path query parameter', async () => {
+      const res = await request(app).get('/api/files/raw')
+      expect(res.status).toBe(400)
+      expect(res.body).toEqual({ error: 'path query parameter required' })
+    })
+
+    it('rejects paths outside allowedFilePaths with 403', async () => {
+      mockGetSettings.mockResolvedValue({ allowedFilePaths: ['/allowed-root'] })
+      const res = await request(app)
+        .get('/api/files/raw')
+        .query({ path: '/elsewhere/secret.png' })
+      expect(res.status).toBe(403)
+      expect(res.body).toEqual({ error: 'Path not allowed' })
+      expect(mockStat).not.toHaveBeenCalled()
+    })
+
+    it('returns 404 for a missing file', async () => {
+      mockStat.mockRejectedValue(Object.assign(new Error('nope'), { code: 'ENOENT' }))
+      const res = await request(app)
+        .get('/api/files/raw')
+        .query({ path: '/home/user/missing.png' })
+      expect(res.status).toBe(404)
+      expect(res.body).toEqual({ error: 'File not found' })
+    })
+
+    it('returns 400 for a directory', async () => {
+      mockStat.mockResolvedValue({ isDirectory: () => true })
+      const res = await request(app)
+        .get('/api/files/raw')
+        .query({ path: '/home/user/dir' })
+      expect(res.status).toBe(400)
+      expect(res.body).toEqual({ error: 'Cannot read directory' })
+    })
+  })
+
   describe('POST /api/files/write', () => {
     it('allows writing when allowedFilePaths is undefined', async () => {
       mockGetSettings.mockResolvedValue({ allowedFilePaths: undefined })


### PR DESCRIPTION
Landing for kata freshell#3pjv (Darkforge job 3pjv).

Clicking a link to a `.png` (or other image) file in a terminal now opens it in a same-origin browser-pane viewer served by a new sandboxed `GET /api/files/raw` endpoint (Node + Rust parity), instead of dumping binary content into the editor. Text/code links still open in the editor unchanged.

Squashed landing commit for the 4-task TDD implementation; full plan is appended in the commit message under `## Plan`. QA gate at this commit: fully clean (client 5762 tests, server 5347, electron 432, cargo fmt/clippy lanes — all green).