### PR TITLE
fix(terminal): yield background focus to inline editors; retry transient pane-not-found on rename (kata r49m)

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -152,6 +152,7 @@ import {
   type TerminalRuntime,
 } from '@/components/terminal/terminal-runtime'
 import { createLayoutScheduler } from '@/components/terminal/layout-scheduler'
+import { shouldYieldProgrammaticTerminalFocus } from '@/components/terminal/focus-policy'
 import {
   createTerminalWriteQueue,
   type TerminalWriteQueue,
@@ -1290,9 +1291,18 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
 
     requestAnimationFrame(() => {
       if (termRef.current !== term) return
+      // kata r49m: a stale activation frame must not steal focus from an
+      // inline editor (e.g. the pane-rename input); the diverted keystrokes
+      // would be consumed by xterm and lost.
+      if (shouldYieldProgrammaticTerminalFocus()) {
+        log.debug('programmatic terminal focus yielded to inline editor', { paneId, tabId, source: 'active-pane-effect' })
+        return
+      }
       term.focus()
     })
-  }, [isTerminal, shouldFocusActiveTerminal])
+    // paneId/tabId are mount-stable props; listed only so the debug-log
+    // payload above satisfies exhaustive-deps without new warnings.
+  }, [isTerminal, shouldFocusActiveTerminal, paneId, tabId])
 
   useEffect(() => {
     lastSessionActivityAtRef.current = 0
@@ -1733,9 +1743,16 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
       try { term.scrollToBottom() } catch { /* disposed */ }
     }
     if (shouldFocus) {
-      term.focus()
+      // kata r49m: same yield policy for the coalesced layout flush.
+      if (shouldYieldProgrammaticTerminalFocus()) {
+        log.debug('programmatic terminal focus yielded to inline editor', { paneId: paneIdRef.current, tabId, source: 'layout-flush' })
+      } else {
+        term.focus()
+      }
     }
-  }, [suppressNetworkEffects, syncGeometryEpochForViewport, ws])
+    // tabId is a mount-stable prop; listed only so the debug-log payload
+    // above satisfies exhaustive-deps without new warnings.
+  }, [suppressNetworkEffects, syncGeometryEpochForViewport, ws, tabId])
 
   const enqueueTerminalWrite = useCallback((data: string, onWritten?: () => void, options?: TerminalWriteQueueOptions): boolean => {
     if (!data) return false

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -17,6 +17,7 @@ import { isFreshAgentProviderName, getFreshAgentProviderConfig } from '@/lib/fre
 import { getFreshAgentLabel, normalizeFreshAgentEffort, normalizeFreshAgentModel, resolveFreshAgentPaneCreateEffort, resolveFreshAgentType } from '@/lib/fresh-agent-registry'
 import { clearDraft } from '@/lib/draft-store'
 import { getTerminalActions } from '@/lib/pane-action-registry'
+import { renamePaneWithMirrorRetry } from '@/lib/pane-rename'
 import { buildPaneRefreshTarget } from '@/lib/pane-utils'
 import { cn } from '@/lib/utils'
 import { withChunkErrorRecovery } from '@/lib/import-retry'
@@ -287,22 +288,26 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
       return
     }
     if (node.type !== 'leaf') return
-    api.patch(`/api/panes/${encodeURIComponent(paneId)}`, {
-      name: trimmed,
-    }).then((response: { data?: { paneId?: string; tabRenamed?: boolean }; message?: string } | null | undefined) => {
-      if (response?.data?.paneId !== paneId) {
-        throw new Error(response?.message || 'Failed to rename pane')
+    void (async () => {
+      try {
+        const result = await renamePaneWithMirrorRetry(paneId, trimmed, {
+          patch: (path, body) => api.patch(path, body),
+        })
+        if (!result.ok) {
+          setRenameError(result.message)
+          return
+        }
+        dispatch(applyPaneRename({ tabId, paneId, title: trimmed }))
+        setRenameError(null)
+        setRenamingPaneId(null)
+        setRenameValue('')
+      } catch (error: any) {
+        const message = typeof error?.message === 'string' && error.message
+          ? error.message
+          : 'Failed to rename pane'
+        setRenameError(message)
       }
-      dispatch(applyPaneRename({ tabId, paneId, title: trimmed }))
-      setRenameError(null)
-      setRenamingPaneId(null)
-      setRenameValue('')
-    }).catch((error: any) => {
-      const message = typeof error?.message === 'string' && error.message
-        ? error.message
-        : 'Failed to rename pane'
-      setRenameError(message)
-    })
+    })()
   }, [dispatch, tabId, renamingPaneId, renameValue, node])
 
   const handleRenameKeyDown = useCallback((e: React.KeyboardEvent) => {

--- a/src/components/terminal/focus-policy.ts
+++ b/src/components/terminal/focus-policy.ts
@@ -1,0 +1,48 @@
+/**
+ * TerminalView's background focus paths (the active-pane rAF effect and the
+ * coalesced layout flush) can fire long after they were requested — under a
+ * saturated main thread, exactly while the user has started inline editing
+ * elsewhere in the pane chrome (kata r49m: pane-header rename). Stealing
+ * focus mid-edit diverts the pending keystrokes into xterm's helper textarea,
+ * where they are consumed as PTY input and silently lost.
+ *
+ * The policy: programmatic terminal focus yields to any text-entry element
+ * outside xterm's own helper textarea. Non-text controls (buttons,
+ * checkboxes) do not yield, so click-to-activate typing UX is unchanged.
+ * User-driven refocus paths (search close, mobile toolbar) never consult this.
+ */
+const XTERM_HELPER_TEXTAREA_CLASS = 'xterm-helper-textarea'
+
+const NON_TEXT_INPUT_TYPES = new Set([
+  'button',
+  'checkbox',
+  'color',
+  'file',
+  'hidden',
+  'image',
+  'radio',
+  'range',
+  'reset',
+  'submit',
+])
+
+function isTextEntryControl(el: Element): boolean {
+  if (el instanceof HTMLTextAreaElement) return true
+  if (el instanceof HTMLInputElement) {
+    return !NON_TEXT_INPUT_TYPES.has((el.type || 'text').toLowerCase())
+  }
+  return false
+}
+
+export function shouldYieldProgrammaticTerminalFocus(doc: Document = document): boolean {
+  const el = doc.activeElement
+  if (!el || el === doc.body) return false
+  if (
+    el instanceof HTMLTextAreaElement &&
+    el.classList.contains(XTERM_HELPER_TEXTAREA_CLASS)
+  ) {
+    return false
+  }
+  if (isTextEntryControl(el)) return true
+  return el.closest('[contenteditable]:not([contenteditable="false"])') !== null
+}

--- a/src/lib/pane-rename.ts
+++ b/src/lib/pane-rename.ts
@@ -1,0 +1,55 @@
+/**
+ * Human pane renames PATCH /api/panes/:id. The server's layout mirror is
+ * client-pushed (ui.layout.sync, 200ms-1000ms+ debounce after a fresh
+ * resume), so a fast rename can hit the documented Node-parity no-op
+ * 200 {message:'pane not found'} even though the pane plainly exists
+ * (kata r49m companion race: the open editor was stranded with a stale
+ * error). Only that transient no-op is retried; it is the one response
+ * that provably means "mirror not landed yet" rather than a user error.
+ */
+import { createLogger } from '@/lib/client-logger'
+
+const log = createLogger('pane-rename')
+
+export type PaneRenameResponse =
+  | { data?: { paneId?: string; tabId?: string; tabRenamed?: boolean }; message?: string }
+  | null
+  | undefined
+
+export type PaneRenameResult =
+  | { ok: true; response: PaneRenameResponse }
+  | { ok: false; message: string }
+
+const MIRROR_NOT_FOUND_MESSAGE = 'pane not found'
+const DEFAULT_RETRY_DELAYS_MS: readonly number[] = [200, 400, 800]
+const GENERIC_FAILURE_MESSAGE = 'Failed to rename pane'
+
+export async function renamePaneWithMirrorRetry(
+  paneId: string,
+  name: string,
+  opts: {
+    patch: (path: string, body: unknown) => Promise<PaneRenameResponse>
+    sleep?: (ms: number) => Promise<void>
+    retryDelaysMs?: readonly number[]
+  },
+): Promise<PaneRenameResult> {
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
+  const retryDelaysMs = opts.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS
+  for (let attempt = 0; ; attempt++) {
+    const response = await opts.patch(`/api/panes/${encodeURIComponent(paneId)}`, { name })
+    if (response?.data?.paneId === paneId) {
+      return { ok: true, response }
+    }
+    const message =
+      typeof response?.message === 'string' && response.message ? response.message : GENERIC_FAILURE_MESSAGE
+    const retryable = message === MIRROR_NOT_FOUND_MESSAGE && attempt < retryDelaysMs.length
+    if (!retryable) return { ok: false, message }
+    const delayMs = retryDelaysMs[attempt]
+    log.debug('retrying pane rename after transient pane-not-found (layout mirror not landed yet)', {
+      paneId,
+      attempt: attempt + 1,
+      delayMs,
+    })
+    await sleep(delayMs)
+  }
+}

--- a/test/unit/client/components/TerminalView.focus-yield.test.tsx
+++ b/test/unit/client/components/TerminalView.focus-yield.test.tsx
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, render, cleanup } from '@testing-library/react'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import tabsReducer from '@/store/tabsSlice'
+import panesReducer, { setActivePane } from '@/store/panesSlice'
+import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
+import connectionReducer from '@/store/connectionSlice'
+import type { PaneNode, TerminalPaneContent } from '@/store/paneTypes'
+
+const wsMocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  connect: vi.fn().mockResolvedValue(undefined),
+  onMessage: vi.fn().mockReturnValue(() => {}),
+  onReconnect: vi.fn().mockReturnValue(() => {}),
+}))
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({
+    send: wsMocks.send,
+    connect: wsMocks.connect,
+    onMessage: wsMocks.onMessage,
+    onReconnect: wsMocks.onReconnect,
+  }),
+}))
+
+vi.mock('@/lib/terminal-themes', () => ({
+  getTerminalTheme: () => ({}),
+}))
+
+vi.mock('lucide-react', () => ({
+  Loader2: ({ className }: { className?: string }) => <svg data-testid="loader" className={className} />,
+}))
+
+// Capture the keyboard handler callback
+let capturedKeyHandler: ((event: KeyboardEvent) => boolean) | null = null
+let capturedOnData: ((data: string) => void) | null = null
+// Widened vs the keyboard-test copy so `focus` is observable (harness only).
+let capturedTerminal: { paste: ReturnType<typeof vi.fn>, focus: ReturnType<typeof vi.fn> } | null = null
+let capturedLinkProviders: Array<{
+  provideLinks: (line: number, callback: (links: any[] | undefined) => void) => void
+}> = []
+let capturedFilePathProvider: {
+  provideLinks: (line: number, callback: (links: any[] | undefined) => void) => void
+} | null = null
+
+vi.mock('@xterm/xterm', () => {
+  class MockTerminal {
+    options: Record<string, unknown> = {}
+    cols = 80
+    rows = 24
+    buffer = {
+      active: {
+        getLine: vi.fn(() => ({
+          translateToString: () => '/tmp/example.txt',
+        })),
+      },
+    }
+    open = vi.fn()
+    loadAddon = vi.fn()
+    registerLinkProvider = vi.fn((provider: any) => {
+      capturedLinkProviders.push(provider)
+      return { dispose: vi.fn() }
+    })
+    write = vi.fn()
+    writeln = vi.fn()
+    clear = vi.fn()
+    dispose = vi.fn()
+    onData = vi.fn((cb: (data: string) => void) => {
+      capturedOnData = cb
+    })
+    onTitleChange = vi.fn(() => ({ dispose: vi.fn() }))
+    selectAll = vi.fn()
+    reset = vi.fn()
+    paste = vi.fn((text: string) => {
+      capturedOnData?.(text)
+    })
+    attachCustomKeyEventHandler = vi.fn((handler: (event: KeyboardEvent) => boolean) => {
+      capturedKeyHandler = handler
+    })
+    attachCustomWheelEventHandler = vi.fn()
+    getSelection = vi.fn(() => 'selected text')
+    focus = vi.fn()
+
+    constructor() {
+      capturedTerminal = this
+    }
+  }
+
+  return { Terminal: MockTerminal }
+})
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit = vi.fn()
+  },
+}))
+
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
+
+// Mock clipboard
+const clipboardMocks = vi.hoisted(() => ({
+  readText: vi.fn().mockResolvedValue('pasted content'),
+  copyText: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/clipboard', () => ({
+  readText: clipboardMocks.readText,
+  copyText: clipboardMocks.copyText,
+}))
+
+import TerminalView from '@/components/TerminalView'
+
+class MockResizeObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+}
+
+function createTestStore(terminalId?: string) {
+  const tabId = 'tab-1'
+  const paneId = 'pane-1'
+
+  const paneContent: TerminalPaneContent = {
+    kind: 'terminal',
+    createRequestId: 'req-1',
+    status: 'running',
+    mode: 'shell',
+    shell: 'system',
+    terminalId,
+    initialCwd: '/tmp',
+  }
+
+  const root: PaneNode = { type: 'leaf', id: paneId, content: paneContent }
+
+  return {
+    store: configureStore({
+      reducer: {
+        tabs: tabsReducer,
+        panes: panesReducer,
+        settings: settingsReducer,
+        connection: connectionReducer,
+      },
+      preloadedState: {
+        tabs: {
+          tabs: [{
+            id: tabId,
+            mode: 'shell' as const,
+            status: 'running' as const,
+            title: 'Shell',
+            titleSetByUser: false,
+            createRequestId: 'req-1',
+            terminalId,
+          }],
+          activeTabId: tabId,
+        },
+        panes: {
+          layouts: { [tabId]: root },
+          activePane: { [tabId]: paneId },
+          paneTitles: {},
+        },
+        settings: { settings: defaultSettings, status: 'loaded' as const },
+        connection: { status: 'connected' as const, error: null },
+      },
+    }),
+    tabId,
+    paneId,
+    paneContent,
+  }
+}
+
+/** rAF is spied into a manual queue (TerminalView.visibility.test.tsx:186
+ * pattern) so the test, not the scheduler, decides when the deferred
+ * focus frame lands — that is exactly the cloud-latency window. */
+let rafSpyToRestore: ReturnType<typeof vi.spyOn> | null = null
+function captureRaf() {
+  const pending: FrameRequestCallback[] = []
+  const spy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    pending.push(cb)
+    return pending.length
+  })
+  rafSpyToRestore = spy
+  return { pending, spy }
+}
+function flushRaf(pending: FrameRequestCallback[]) {
+  while (pending.length > 0) pending.shift()?.(16)
+}
+
+function focusForeignInput(): HTMLInputElement {
+  const input = Object.assign(document.createElement('input'), { type: 'text' })
+  input.setAttribute('aria-label', 'Rename pane') // mirrors the pane rename editor
+  document.body.appendChild(input)
+  input.focus()
+  return input
+}
+
+function renderActiveTerminal(store: ReturnType<typeof createTestStore>['store'], paneContent: TerminalPaneContent) {
+  return render(
+    <Provider store={store}>
+      <TerminalView tabId="tab-1" paneId="pane-1" paneContent={paneContent} />
+    </Provider>,
+  )
+}
+
+describe('TerminalView background focus yield', () => {
+  beforeEach(() => {
+    capturedKeyHandler = null
+    capturedOnData = null
+    capturedTerminal = null
+    capturedLinkProviders = []
+    capturedFilePathProvider = null
+    wsMocks.send.mockClear()
+    clipboardMocks.readText.mockClear()
+    clipboardMocks.copyText.mockClear()
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+  })
+
+  afterEach(() => {
+    ;(document.activeElement as HTMLElement | null)?.blur?.()
+    // Remove foreign text-entry nodes the tests appended to document.body
+    // (RTL cleanup only removes containers it created).
+    document.querySelectorAll('input[aria-label="Rename pane"], textarea.xterm-helper-textarea').forEach((el) => el.remove())
+    cleanup()
+    vi.unstubAllGlobals()
+    // Restore ONLY the rAF spy: vi.restoreAllMocks() would also reset the
+    // hoisted vi.fn() mock implementations (ws-client, clipboard) and break
+    // other tests, which run in shuffled order (vitest sequence.shuffle).
+    rafSpyToRestore?.mockRestore()
+    rafSpyToRestore = null
+  })
+
+  it('CONTROL: focuses the terminal on activation when no editable element holds focus', async () => {
+    const { pending } = captureRaf()
+    const { store, paneContent } = createTestStore('term-1')
+    renderActiveTerminal(store, paneContent)
+    await act(async () => { flushRaf(pending) })
+    expect(capturedTerminal?.focus).toHaveBeenCalled()
+  })
+
+  it('does NOT steal focus from an inline editor when a stale activation frame lands (RED)', async () => {
+    focusForeignInput()
+    const { pending } = captureRaf()
+    const { store, paneContent } = createTestStore('term-1')
+    renderActiveTerminal(store, paneContent)
+    await act(async () => { flushRaf(pending) })
+    expect(capturedTerminal?.focus).not.toHaveBeenCalled()
+  })
+
+  it('does NOT steal focus from an inline editor when the mount layout-flush focus lands late (RED)', async () => {
+    // Same guard, second call site: the mount flush feeds
+    // requestTerminalLayout({ fit: true, focus: true }) through the rAF
+    // scheduler (TerminalView.tsx:2300). Covered by the same render+flush as
+    // above, asserted through the mount path only: no store interaction.
+    focusForeignInput()
+    const { pending } = captureRaf()
+    const { store, paneContent } = createTestStore('term-1')
+    renderActiveTerminal(store, paneContent)
+    await act(async () => { flushRaf(pending) })
+    expect(capturedTerminal?.focus).not.toHaveBeenCalled()
+    // Blurring the editor must restore normal focus behavior on the next frame.
+    ;(document.activeElement as HTMLElement | null)?.blur?.()
+    await act(async () => { flushRaf(pending) })
+    // A fresh activation effect re-run is out of scope here; the important
+    // half is that nothing threw and the terminal remains usable.
+  })
+
+  it('does NOT steal focus from an inline editor when the pane is re-activated (active-pane effect)', async () => {
+    // Isolate the active-pane rAF effect (TerminalView.tsx:1276): on mount the
+    // effect early-returns on the null termRef, so focus must come through
+    // once via the mount layout flush before the activation path is testable.
+    const { pending } = captureRaf()
+    const { store, paneContent } = createTestStore('term-1')
+    renderActiveTerminal(store, paneContent)
+    await act(async () => { flushRaf(pending) })
+    expect(capturedTerminal?.focus).toHaveBeenCalled() // mount flush (CONTROL proof)
+    capturedTerminal?.focus.mockClear()
+
+    // Focus a foreign inline editor AFTER all mount frames drained, so only
+    // the re-activation frame below can attempt the steal.
+    focusForeignInput()
+
+    // Re-trigger the activation effect: `shouldFocusActiveTerminal` must flip
+    // false -> true across two separate commits (a single batched render would
+    // leave the deps unchanged and never re-run the effect).
+    await act(async () => {
+      store.dispatch(setActivePane({ tabId: 'tab-1', paneId: 'pane-2' }))
+    })
+    await act(async () => {
+      store.dispatch(setActivePane({ tabId: 'tab-1', paneId: 'pane-1' }))
+    })
+    await act(async () => { flushRaf(pending) })
+    expect(capturedTerminal?.focus).not.toHaveBeenCalled()
+
+    // Control counterpart: with the editor blurred, the same deactivation /
+    // re-activation pair must focus the terminal again.
+    ;(document.activeElement as HTMLElement | null)?.blur?.()
+    await act(async () => {
+      store.dispatch(setActivePane({ tabId: 'tab-1', paneId: 'pane-2' }))
+    })
+    await act(async () => {
+      store.dispatch(setActivePane({ tabId: 'tab-1', paneId: 'pane-1' }))
+    })
+    await act(async () => { flushRaf(pending) })
+    expect(capturedTerminal?.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('still focuses when xterm\'s own helper textarea holds focus', async () => {
+    const helper = document.createElement('textarea')
+    helper.classList.add('xterm-helper-textarea')
+    document.body.appendChild(helper)
+    helper.focus()
+    const { pending } = captureRaf()
+    const { store, paneContent } = createTestStore('term-1')
+    renderActiveTerminal(store, paneContent)
+    await act(async () => { flushRaf(pending) })
+    expect(capturedTerminal?.focus).toHaveBeenCalled()
+  })
+})

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -894,6 +894,9 @@ describe('PaneContainer', () => {
       mockApiPatch.mockResolvedValueOnce({
         status: 'ok',
         message: 'pane not found',
+      }).mockResolvedValue({
+        status: 'ok',
+        message: 'pane not found',
       })
 
       const leafNode: PaneNode = {
@@ -922,10 +925,48 @@ describe('PaneContainer', () => {
       await waitFor(() => {
         expect(mockApiPatch).toHaveBeenCalledWith('/api/panes/pane-1', { name: 'Ops desk' })
       })
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('pane not found')
+      }, { timeout: 5_000 })
+      expect(mockApiPatch).toHaveBeenCalledTimes(4)
       expect(await screen.findByLabelText('Rename pane')).toHaveValue('Ops desk')
-      expect(screen.getByRole('alert')).toHaveTextContent('pane not found')
       expect(store.getState().panes.paneTitles['tab-1']?.['pane-1']).toBe('Shell')
       expect(store.getState().tabs.tabs[0].title).toBe('Tab 1')
+    })
+
+    it('retries the rename when the pane is not yet mirrored and commits once it lands', async () => {
+      mockApiPatch
+        .mockResolvedValueOnce({ status: 'ok', message: 'pane not found' })
+        .mockResolvedValueOnce({
+          status: 'ok',
+          data: { tabId: 'tab-1', paneId: 'pane-1', tabRenamed: true },
+          message: 'pane renamed',
+        })
+
+      const leafNode: PaneNode = {
+        type: 'leaf',
+        id: 'pane-1',
+        content: createTerminalContent({ terminalId: 'term-1' }),
+      }
+      const store = createStore({
+        layouts: { 'tab-1': leafNode },
+        activePane: { 'tab-1': 'pane-1' },
+        paneTitles: { 'tab-1': { 'pane-1': 'Shell' } },
+        renameRequestTabId: 'tab-1',
+        renameRequestPaneId: 'pane-1',
+      })
+      renderWithStore(<PaneContainer tabId="tab-1" node={leafNode} />, store)
+
+      const renameInput = await screen.findByLabelText('Rename pane')
+      fireEvent.change(renameInput, { target: { value: 'Ops desk' } })
+      fireEvent.blur(renameInput)
+
+      await waitFor(() => {
+        expect(store.getState().panes.paneTitles['tab-1']?.['pane-1']).toBe('Ops desk')
+      }, { timeout: 5_000 })
+      expect(mockApiPatch).toHaveBeenCalledTimes(2)
+      expect(mockApiPatch).toHaveBeenNthCalledWith(2, '/api/panes/pane-1', { name: 'Ops desk' })
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     })
 
     it('does not update local pane titles when the pane rename API rejects the request', async () => {

--- a/test/unit/client/components/terminal/focus-policy.test.ts
+++ b/test/unit/client/components/terminal/focus-policy.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, afterEach } from 'vitest'
+
+import { shouldYieldProgrammaticTerminalFocus } from '@/components/terminal/focus-policy'
+
+function appendFocused<T extends HTMLElement>(el: T): T {
+  document.body.appendChild(el)
+  el.focus()
+  return el
+}
+
+afterEach(() => {
+  ;(document.activeElement as HTMLElement | null)?.blur?.()
+  document.body.innerHTML = ''
+  expect(shouldYieldProgrammaticTerminalFocus()).toBe(false)
+})
+
+describe('shouldYieldProgrammaticTerminalFocus', () => {
+  it('does not yield when nothing (body) is focused', () => {
+    expect(document.activeElement).toBe(document.body)
+    expect(shouldYieldProgrammaticTerminalFocus()).toBe(false)
+  })
+
+  it('yields to a focused text input (the pane-rename editor case)', () => {
+    appendFocused(Object.assign(document.createElement('input'), { type: 'text' }))
+    expect(shouldYieldProgrammaticTerminalFocus()).toBe(true)
+  })
+
+  it('yields to a focused plain textarea', () => {
+    appendFocused(document.createElement('textarea'))
+    expect(shouldYieldProgrammaticTerminalFocus()).toBe(true)
+  })
+
+  it('yields to a focused contenteditable region', () => {
+    // tabIndex makes the div deterministically focusable in jsdom.
+    const el = Object.assign(document.createElement('div'), { tabIndex: 0 })
+    el.setAttribute('contenteditable', 'true')
+    appendFocused(el)
+    expect(shouldYieldProgrammaticTerminalFocus()).toBe(true)
+  })
+
+  it('does NOT yield to xterm\'s own helper textarea (the terminal itself has focus)', () => {
+    const helper = appendFocused(document.createElement('textarea'))
+    helper.classList.add('xterm-helper-textarea')
+    helper.focus()
+    expect(shouldYieldProgrammaticTerminalFocus()).toBe(false)
+  })
+
+  it('does NOT yield to non-text controls (buttons, checkboxes) so click-to-activate UX is preserved', () => {
+    appendFocused(Object.assign(document.createElement('button'), { textContent: 'Close' }))
+    expect(shouldYieldProgrammaticTerminalFocus()).toBe(false)
+
+    ;(document.activeElement as HTMLElement).blur()
+    appendFocused(Object.assign(document.createElement('input'), { type: 'checkbox' }))
+    expect(shouldYieldProgrammaticTerminalFocus()).toBe(false)
+  })
+})

--- a/test/unit/client/lib/pane-rename.test.ts
+++ b/test/unit/client/lib/pane-rename.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Repo-standard hoisted logger double: every test gets a no-op logger; only
+// the retry test asserts on the calls.
+const logSpies = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}))
+
+vi.mock('@/lib/client-logger', () => ({
+  createLogger: () => logSpies,
+}))
+
+import { renamePaneWithMirrorRetry } from '@/lib/pane-rename'
+
+const patchOk = () => Promise.resolve({ status: 'ok', data: { paneId: 'pane-1', tabId: 'tab-1' }, message: 'pane renamed' } as object) as never
+const patchNotFound = () => Promise.resolve({ status: 'ok', message: 'pane not found' } as object) as never
+
+describe('renamePaneWithMirrorRetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('succeeds on the first attempt without sleeping', async () => {
+    const patch = vi.fn().mockImplementation(patchOk)
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const result = await renamePaneWithMirrorRetry('pane-1', 'Ops desk', { patch, sleep })
+    expect(result).toEqual({ ok: true, response: expect.objectContaining({ message: 'pane renamed' }) })
+    expect(patch).toHaveBeenCalledTimes(1)
+    expect(patch).toHaveBeenCalledWith('/api/panes/pane-1', { name: 'Ops desk' })
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('retries the transient pane-not-found no-op until the mirror lands', async () => {
+    const patch = vi.fn().mockImplementationOnce(patchNotFound).mockImplementation(patchOk)
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const result = await renamePaneWithMirrorRetry('pane-1', 'Ops desk', { patch, sleep, retryDelaysMs: [5, 10, 20] })
+    expect(result.ok).toBe(true)
+    expect(patch).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledTimes(1)
+    expect(sleep).toHaveBeenCalledWith(5)
+    // Review M2: a retried attempt must be observable in the field. Exactly one
+    // debug event, emitted before/at the sleep, carrying the retry evidence.
+    expect(logSpies.debug).toHaveBeenCalledTimes(1)
+    expect(logSpies.debug).toHaveBeenCalledWith(
+      expect.stringContaining('pane-not-found'),
+      { paneId: 'pane-1', attempt: 1, delayMs: 5 },
+    )
+    expect(logSpies.debug.mock.invocationCallOrder[0])
+      .toBeLessThanOrEqual(sleep.mock.invocationCallOrder[0])
+  })
+
+  it('gives up after the retry budget with the last pane-not-found message', async () => {
+    const patch = vi.fn().mockImplementation(patchNotFound)
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const result = await renamePaneWithMirrorRetry('pane-1', 'Ops desk', { patch, sleep, retryDelaysMs: [5, 10, 20] })
+    expect(result).toEqual({ ok: false, message: 'pane not found' })
+    expect(patch).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not retry a non-retryable mismatch message', async () => {
+    const patch = vi.fn().mockResolvedValue({ status: 'ok', message: 'name too long' })
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const result = await renamePaneWithMirrorRetry('pane-1', 'Ops desk', { patch, sleep })
+    expect(result).toEqual({ ok: false, message: 'name too long' })
+    expect(patch).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the generic message when the response carries none', async () => {
+    const patch = vi.fn().mockResolvedValue(undefined)
+    const result = await renamePaneWithMirrorRetry('pane-1', 'Ops desk', { patch, sleep: vi.fn() })
+    expect(result).toEqual({ ok: false, message: 'Failed to rename pane' })
+  })
+
+  it('propagates patch rejections (caller surfaces them)', async () => {
+    const patch = vi.fn().mockRejectedValue(new Error('network down'))
+    await expect(renamePaneWithMirrorRetry('pane-1', 'Ops desk', { patch, sleep: vi.fn() })).rejects.toThrow('network down')
+  })
+})


### PR DESCRIPTION
Fixes the cloud e2e failure `title-sync-convergence.spec.ts:217` ("pane header rename converges the sidebar"): under Cloud Run latency, the terminal could grab keyboard focus mid-rename and the typed name vanished into the terminal (the pane header kept showing the old title; the reported "duplicated first character" was the provider-icon letter badge).

- `src/components/terminal/focus-policy.ts` + `TerminalView.tsx`: both background programmatic `term.focus()` paths yield whenever a text-entry element outside xterm's helper textarea holds focus; user-driven refocus paths untouched.
- `src/lib/pane-rename.ts` + `PaneContainer.tsx`: the documented transient 200 `pane not found` no-op during layout-mirror lag is retried on a bounded [200,400,800]ms backoff with per-retry debug logging.

Evidence: full QA gate green at exact squashed HEAD 2c78116747202396f0e3f0c925a4e48268091ef1 (darkforge qa receipt); title-sync-convergence 5/5 chromium + 5/5 rust-chromium, tab-management 11/11 chromium on the landing tree; independent Fresh Eyes review focused/3 PASSED (fresh context, same model).

Land as a merge commit (do NOT squash-merge) so the gated SHA stays intact in main history.