### PR TITLE
test(mcp-bridge): align list-panes assertions with pinned Node-exact row contract (kata rw3z)

### DIFF
--- a/test/e2e-browser/specs/mcp-bridge-rust.spec.ts
+++ b/test/e2e-browser/specs/mcp-bridge-rust.spec.ts
@@ -120,15 +120,31 @@ test.describe('MCP bridge -- Rust QA lever pin (Slice 2)', () => {
       expect(typeof capture).toBe('string')
       expect(capture).toContain(marker)
 
-      // -- list-panes: our pane is present, correctly cross-referenced to tab + terminal --
+      // -- list-panes: our pane is present in the bare listing, correctly
+      // cross-referenced to its terminal. The pinned row contract is the
+      // Node-exact `{id, index, kind?, terminalId?, title?}` — deliberately
+      // WITHOUT a per-row `tabId` (the df1->main sync merge adopted main's
+      // evolved Node-exact listPanes row contract; see
+      // docs/plans/df1-evidence/MAIN-SYNC-MERGE.md "Gate record"). The frozen
+      // MCP binary types the same five fields (`PaneSummary`,
+      // server/mcp/freshell-tool.ts) and never reads `tabId`. Tab membership
+      // is cross-referenced the way this surface actually offers it: the
+      // `?tabId=` filter, exercised via the MCP tool's `target` param below.
       const listPanes = await mcp.callFreshellAction('list-panes')
       expect(listPanes.status).toBe('ok')
-      const ourPane = (listPanes.data.panes as Array<{ id: string; tabId: string; terminalId: string }>).find(
-        (p) => p.id === paneId,
-      )
+      const ourPane = (
+        listPanes.data.panes as Array<{ id: string; index: number; kind?: string; terminalId?: string }>
+      ).find((p) => p.id === paneId)
       expect(ourPane).toBeTruthy()
-      expect(ourPane?.tabId).toBe(tabId)
       expect(ourPane?.terminalId).toBe(terminalId)
+      expect(ourPane?.kind).toBe('terminal')
+      expect(ourPane?.index).toBe(0)
+
+      // -- list-panes with the tab as target: the pane<->tab membership edge --
+      const tabPanes = await mcp.callFreshellAction('list-panes', { target: tabId })
+      expect(tabPanes.status).toBe('ok')
+      const tabPaneIds = (tabPanes.data.panes as Array<{ id: string }>).map((p) => p.id)
+      expect(tabPaneIds).toContain(paneId)
     } finally {
       await mcp.close()
       await server.stop()


### PR DESCRIPTION
## Summary

Fixes the deterministic rust-chromium e2e failure at `test/e2e-browser/specs/mcp-bridge-rust.spec.ts:130` (`expect(ourPane?.tabId).toBe(tabId)` → `ourPane?.tabId` is `undefined`). Reproduction showed the pane row IS present in the bare `GET /api/panes` listing — the failing datum was solely the per-row `tabId` field, which the merge-ratified Node-exact row contract (`{id, index, kind?, terminalId?, title?}`; `docs/plans/df1-evidence/MAIN-SYNC-MERGE.md` "Gate record") deliberately omits. No consumer (frozen MCP `PaneSummary` passthrough, CLI printer, sibling `mcp-qa-smoke-rust` matrix) reads a per-row `tabId`; pane→tab membership is cross-referenced via the `?tabId=` filter.

**Test-side alignment only; no product change.** The bare `list-panes` block now asserts presence plus `terminalId` cross-reference, `kind === "terminal"`, and `index === 0`; a new `list-panes { target: tabId }` call pins the pane↔tab membership edge the way the surface actually offers it. Frozen MCP binary, Rust server, and the real MCP-over-stdio wire are unchanged.

Answers the kata question: the product is not wrong; the test's assertion surface was wrong.

## Evidence

- RED/GREEN: RED reproduced exactly as diagnosed (line 130 `Received: undefined`, line 129 passing), GREEN `1 passed`; impacted-run with sibling spec recorded (`mcp-qa-smoke-rust` codex-mode failure on this host is pre-existing/environmental and causally independent — spec byte-identical to base).
- Full QA gate (`npm run check` + cargo fmt/clippy) green at this exact commit `6b8048af0` (exit 0).
- Independent reviews: plan review PASSED, task review approved, whole-branch review APPROVED, delta review PASSED, landing-bound review PASSED on this exact squash — zero blocking findings across all rounds.