### PR TITLE
fix(api): return 422 pane-kind validation for legacy fresh-agent pane capture

### DIFF
--- a/crates/freshell-freshagent/src/lib.rs
+++ b/crates/freshell-freshagent/src/lib.rs
@@ -2542,7 +2542,28 @@ async fn capture(
         .cloned()
     {
         Some(pane) => pane,
-        None => return fail_json(StatusCode::NOT_FOUND, "pane not found".to_string()),
+        None => {
+            // Layout-only panes (e.g. a legacy `agent-chat` pane normalized to
+            // `fresh-agent` by a remote client's layout sync): mirror the Node
+            // capture route's pane-kind gate (router.ts:955-959) — every
+            // non-terminal layout kind answers the 422 validation wording the
+            // `content_panes` branch in terminal_tabs.rs already emits, rather
+            // than falling through to an unhandled 500 (Node, pre-fix) or a
+            // misleading 404. Runtime-backed fresh-agent panes resolved above;
+            // layout-visible terminal kinds and unknown ids keep 404
+            // `pane not found`.
+            if let Some(snap) = state.layout.get_pane_snapshot(&pane_id) {
+                if let Some(kind) = snap.kind.as_deref().filter(|k| *k != "terminal") {
+                    return fail_json(
+                        StatusCode::UNPROCESSABLE_ENTITY,
+                        format!(
+                            "pane kind \"{kind}\" does not support capture-pane; use screenshot-pane"
+                        ),
+                    );
+                }
+            }
+            return fail_json(StatusCode::NOT_FOUND, "pane not found".to_string());
+        }
     };
     let Some(durable_id) = pane.durable_id else {
         // No turn yet → empty transcript (text/plain), matching a fresh pane.

--- a/crates/freshell-freshagent/src/terminal_tabs.rs
+++ b/crates/freshell-freshagent/src/terminal_tabs.rs
@@ -6659,4 +6659,53 @@ mod tests {
             .unwrap()
             .contains("use screenshot-pane"));
     }
+
+    #[tokio::test]
+    async fn capture_layout_synced_legacy_fresh_agent_pane_is_422() {
+        // Mirrors the e2e kata scenario
+        // (test/e2e-browser/specs/fresh-agent-centralization-smoke.spec.ts:402-424):
+        // a legacy `agent-chat` pane arrives through the layout sync path, is
+        // normalized to `fresh-agent` by the layout store's migration, and
+        // exists in NO runtime pane map.
+        let state = state_with_registry();
+        state.layout.update_from_ui(
+            &serde_json::from_value::<freshell_protocol::UiLayoutSync>(json!({
+                "tabs": [{ "id": "t1" }],
+                "activeTabId": "t1",
+                "layouts": {
+                    "t1": {
+                        "type": "leaf",
+                        "id": "pane-legacy-agent",
+                        "content": {
+                            "kind": "agent-chat",
+                            "provider": "claude",
+                            "resumeSessionId": "11111111-1111-4111-8111-111111111111"
+                        }
+                    }
+                },
+                "activePane": { "t1": "pane-legacy-agent" },
+                "timestamp": 1
+            }))
+            .expect("UiLayoutSync parses"),
+            "conn-1",
+        );
+        let router = app(state);
+
+        let (status, body) = get(router, "/api/panes/pane-legacy-agent/capture", true).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(
+            body["message"],
+            json!("pane kind \"fresh-agent\" does not support capture-pane; use screenshot-pane")
+        );
+    }
+
+    #[tokio::test]
+    async fn capture_unknown_pane_still_404s_pane_not_found() {
+        // Guard: no layout sync, no runtime maps — the pre-existing unknown-pane
+        // answer is unchanged by the layout consult.
+        let state = state_with_registry();
+        let (status, body) = get(app(state), "/api/panes/nope/capture", true).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["message"], json!("pane not found"));
+    }
 }

--- a/server/agent-api/router.ts
+++ b/server/agent-api/router.ts
@@ -38,6 +38,7 @@ import {
   FreshAgentStaleThreadRevisionError,
   FreshAgentUnsupportedCapabilityError,
 } from '../fresh-agent/runtime-manager.js'
+import { ClaudeFreshAgentHistoryResolutionError } from '../fresh-agent/history/claude/history-service.js'
 
 const truthy = (value: unknown) => value === true || value === 'true' || value === '1' || value === 'yes'
 const SYNCABLE_TERMINAL_MODES = new Set(['claude', 'codex', 'opencode', 'gemini', 'kimi'])
@@ -918,6 +919,15 @@ export function createAgentApiRouter({
         })
         return res.type('text/plain').send(renderFreshAgentTranscript(snapshot))
       } catch (err: any) {
+        // A RESTORE_NOT_FOUND resolution means no session by this id exists on
+        // this server (a legacy/foreign layout-sync pane): answer with the
+        // generic pane-kind validation gate wording instead of an unhandled
+        // 500. Every other failure keeps its documented status mapping.
+        if (err instanceof ClaudeFreshAgentHistoryResolutionError && err.code === 'RESTORE_NOT_FOUND') {
+          return res.status(422).json(
+            fail(`pane kind "${paneSnapshot.kind}" does not support capture-pane; use screenshot-pane`),
+          )
+        }
         return res.status(agentRouteErrorStatus(err)).json(fail(err?.message || 'fresh-agent capture failed'))
       }
     }

--- a/test/server/agent-capture-pane.test.ts
+++ b/test/server/agent-capture-pane.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import express from 'express'
 import request from 'supertest'
 import { createAgentApiRouter } from '../../server/agent-api/router'
+import { ClaudeFreshAgentHistoryResolutionError } from '../../server/fresh-agent/history/claude/history-service'
+import { FreshAgentRuntimeUnavailableError } from '../../server/fresh-agent/runtime-manager'
 
 const registry = {
   get: () => ({ buffer: { snapshot: () => 'a\n\x1b[31mred\x1b[0m\n' } }),
@@ -60,5 +62,92 @@ describe('GET /api/panes/:id/capture', () => {
       status: 'error',
       message: expect.stringContaining('does not support capture-pane'),
     })
+  })
+
+  it('returns 422 pane-kind validation for a legacy fresh-agent pane with no backing session', async () => {
+    const app = express()
+    app.use(express.json())
+    app.use('/api', createAgentApiRouter({
+      layoutStore: {
+        resolvePaneToTerminal: () => undefined,
+        getPaneSnapshot: () => ({
+          kind: 'fresh-agent',
+          paneContent: {
+            kind: 'fresh-agent',
+            sessionType: 'freshclaude',
+            provider: 'claude',
+            sessionId: '11111111-1111-4111-8111-111111111111',
+          },
+        }),
+      } as any,
+      registry,
+      freshAgentRuntimeManager: {
+        getSnapshot: async () => {
+          throw new ClaudeFreshAgentHistoryResolutionError('RESTORE_NOT_FOUND', 'Restore session not found')
+        },
+      } as any,
+    }))
+    const res = await request(app).get('/api/panes/pane-legacy-agent/capture')
+    expect(res.status).toBe(422)
+    expect(res.body).toEqual({
+      status: 'error',
+      message: 'pane kind "fresh-agent" does not support capture-pane; use screenshot-pane',
+    })
+  })
+
+  it('keeps the 500 mapping for fresh-agent history resolution failures other than RESTORE_NOT_FOUND', async () => {
+    const app = express()
+    app.use(express.json())
+    app.use('/api', createAgentApiRouter({
+      layoutStore: {
+        resolvePaneToTerminal: () => undefined,
+        getPaneSnapshot: () => ({
+          kind: 'fresh-agent',
+          paneContent: {
+            kind: 'fresh-agent',
+            sessionType: 'freshclaude',
+            provider: 'claude',
+            sessionId: '22222222-2222-4222-8222-222222222222',
+          },
+        }),
+      } as any,
+      registry,
+      freshAgentRuntimeManager: {
+        getSnapshot: async () => {
+          throw new ClaudeFreshAgentHistoryResolutionError('RESTORE_DIVERGED', 'history diverged')
+        },
+      } as any,
+    }))
+    const res = await request(app).get('/api/panes/pane-diverged-agent/capture')
+    expect(res.status).toBe(500)
+    expect(res.body).toMatchObject({ status: 'error', message: expect.stringContaining('history diverged') })
+  })
+
+  it('keeps the existing status mapping for other fresh-agent capture failures', async () => {
+    const app = express()
+    app.use(express.json())
+    app.use('/api', createAgentApiRouter({
+      layoutStore: {
+        resolvePaneToTerminal: () => undefined,
+        getPaneSnapshot: () => ({
+          kind: 'fresh-agent',
+          paneContent: {
+            kind: 'fresh-agent',
+            sessionType: 'freshopencode',
+            provider: 'opencode',
+            sessionId: 'ses_gone',
+          },
+        }),
+      } as any,
+      registry,
+      freshAgentRuntimeManager: {
+        getSnapshot: async () => {
+          throw new FreshAgentRuntimeUnavailableError('runtime down')
+        },
+      } as any,
+    }))
+    const res = await request(app).get('/api/panes/pane-live-agent/capture')
+    expect(res.status).toBe(503)
+    expect(res.body).toMatchObject({ status: 'error', message: expect.stringContaining('runtime down') })
   })
 })


### PR DESCRIPTION
GET /api/panes/:id/capture, for a pane whose normalized kind is fresh-agent but with no capturable backing session on this server (a legacy/remote layout-sync pane): the Node server answered an unhandled 500 and the Rust server a misleading 404. Both servers now return a disciplined 422 pane-kind validation error with the verbatim existing wording: pane kind "fresh-agent" does not support capture-pane; use screenshot-pane.

- Node (server/agent-api/router.ts): the capture route's fresh-agent catch maps only ClaudeFreshAgentHistoryResolutionError with code RESTORE_NOT_FOUND to the 422 gate; every other failure keeps its agentRouteErrorStatus mapping.
- Rust (crates/freshell-freshagent/src/lib.rs): the capture handler's panes-map miss arm consults the shared layout store before answering 404 and emits the same 422 wording for any layout-visible non-terminal kind; terminal kinds and unknown ids keep 404; runtime-backed fresh-agent panes keep 200 transcripts.
- Tests: Node pins 422 exact wording + RESTORE_DIVERGED-stays-500 discriminator + 503 mapping; Rust pins layout-synced 422 exact wording + unknown-pane 404. The pinned e2e expectation in fresh-agent-centralization-smoke.spec.ts passes end to end against the built Node server.

Darkforge job kqn1. Full QA gate receipt: exact-commit exit-0 on 48d9ab287 (npm run check + cargo fmt/clippy). Fresh Eyes: plan PASSED (r1), delta PASSED (r1), landing-candidate reviews PASSED (focused r1-r3); label: fresh context, same model. The full implementation plan is appended to the commit message under '## Plan'.