### PR TITLE
feat(freshagent): serve composer attachment uploads on the Rust server with Node parity

### DIFF
--- a/crates/freshell-server/src/attachments.rs
+++ b/crates/freshell-server/src/attachments.rs
@@ -1,0 +1,604 @@
+//! `POST /api/fresh-agent/attachments` — a faithful port of the Node oracle
+//! route (`server/fresh-agent-extras-router.ts:10,15-22,268-287`) so the
+//! fresh-agent composer's paperclip upload
+//! (`src/components/fresh-agent/FreshAgentComposer.tsx:160-174`, which fetches
+//! `POST /api/fresh-agent/attachments?name=<raw>` with the raw `File` body)
+//! works on the Rust server leg.
+//!
+//! # Parity table (Node oracle → this port)
+//!
+//! | Node oracle behavior | This port |
+//! |---|---|
+//! | `ATTACHMENT_MAX_BYTES = 10*1024*1024` (router.ts:10), enforced by `raw({ type, limit })` | `ATTACHMENT_MAX_BYTES`; `DefaultBodyLimit::max(...)` scoped to this sub-router — `Bytes` extraction over the cap rejects 413 |
+//! | missing/empty/non-string `?name` → 400 `{"error":"name query parameter required"}` (repeated `name` is an array, not a string) | `Query<Vec<(String, String)>>` preserves repeated keys; missing/empty/repeated → the identical 400 |
+//! | body must be a non-empty `application/octet-stream` buffer (raw's `type-is` gate) → 400 `{"error":"attachment body must be a non-empty application/octet-stream"}` | content-type matched case-insensitively on the type token before `;`, AND body non-empty → the identical 400 |
+//! | stores under `<os.homedir()>/.freshell/attachments/` (router.ts:20-22) | the same boot-resolved `home` threaded to `checkpoints_state` (`main.rs`) — equals `os.homedir()` whenever `FRESHELL_HOME` is unset — joined with `.freshell/attachments` |
+//! | filename `<randomUUID().slice(0,8)>-<sanitizeFilename(name)>` | `<first 8 hex of uuid4-simple>-<sanitize_filename(name)>` (same first-8-hex rendering) |
+//! | 200 `{path, bytes}` — plain body, no envelope | identical |
+//! | `sanitizeFilename`: POSIX basename (`path.basename`), then every char outside `[a-zA-Z0-9._-]` → `_` per UTF-16 code unit (astral chars become TWO `_`), empty → `'attachment'` | `sanitize_filename` below |
+//!
+//! # Declared divergences
+//!
+//! 1. fs write failure → `500 {"error":"failed to save attachment"}` +
+//!    `tracing::warn!`. Node leaves the response hanging forever on an fs
+//!    rejection (the `await fsp.writeFile(...)` rejection is unhandled). A
+//!    visible 500 preserves the failure visibility this work item is about.
+//! 2. 413 body format: express emits an HTML error page, axum emits its
+//!    default rejection body. The STATUS is the contract; the client maps on
+//!    status and never parses the 413 body (`attachmentUploadErrorMessage` in
+//!    `FreshAgentComposer.tsx`).
+//! 3. At the (wrong content-type × over-cap) intersection Node yields 400
+//!    while this port yields 413: express's `raw({ type })` never buffers the
+//!    body on a type mismatch so the handler's 400 is reached, whereas `Bytes`
+//!    extraction rejects over-cap with 413 before the handler's content-type
+//!    check. Unreachable from the real composer, which always sends
+//!    `application/octet-stream`.
+//!
+//! # Auth ordering (reproduces Node's middleware-first behavior)
+//!
+//! Node wires `authenticateToken` as app middleware BEFORE this route's
+//! `raw({ limit })` body parser, so an UNAUTHENTICATED over-cap request is
+//! 401, never 413. Axum `.layer()` calls wrap in reverse application order,
+//! so `middleware::from_fn_with_state(state, require_auth)` — added AFTER
+//! `DefaultBodyLimit::max(...)` — is the OUTERMOST layer of this sub-router
+//! and runs before the body limit is consulted. The handler itself contains
+//! no auth code.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::body::Bytes;
+use axum::extract::{DefaultBodyLimit, Query, State};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde_json::json;
+
+use crate::boot::{is_authed, unauthorized};
+
+/// `ATTACHMENT_MAX_BYTES` (`fresh-agent-extras-router.ts:10`): 10 MiB upload
+/// cap, enforced here by `DefaultBodyLimit` + `Bytes` extraction rather than
+/// express's `raw({ limit })`.
+const ATTACHMENT_MAX_BYTES: usize = 10 * 1024 * 1024;
+
+/// Shared state for the `/api/fresh-agent/attachments` route.
+#[derive(Clone)]
+pub struct AttachmentsApiState {
+    /// Mirrors `CheckpointsApiState::auth_token` — consumed by the outermost
+    /// `require_auth` middleware, never by the handler.
+    pub auth_token: Arc<String>,
+    /// Boot-resolved home whose `.freshell/attachments/` holds saved uploads
+    /// (mirrors `os.homedir()` in Node's `attachmentsDir`,
+    /// `fresh-agent-extras-router.ts:20-22`; boot `home` equals `os.homedir()`
+    /// whenever `FRESHELL_HOME` is unset).
+    pub home: Arc<PathBuf>,
+}
+
+/// The `/api/fresh-agent/attachments` sub-router. `require_auth` is layered
+/// last precisely so it becomes the OUTERMOST layer (axum layers wrap in
+/// reverse order), preserving Node's auth-before-body-read ordering — see the
+/// module doc comment.
+pub fn router(state: AttachmentsApiState) -> Router {
+    Router::new()
+        .route("/api/fresh-agent/attachments", post(upload_attachment))
+        .layer(DefaultBodyLimit::max(ATTACHMENT_MAX_BYTES))
+        .layer(middleware::from_fn_with_state(state.clone(), require_auth))
+        .with_state(state)
+}
+
+/// Node middleware-first ordering, reproduced: this runs BEFORE the body
+/// limit, so an unauthenticated over-cap request is 401, not 413.
+async fn require_auth(
+    State(state): State<AttachmentsApiState>,
+    request: axum::extract::Request,
+    next: Next,
+) -> Response {
+    if !is_authed(request.headers(), &state.auth_token) {
+        return unauthorized();
+    }
+    next.run(request).await
+}
+
+/// `router.post('/attachments', ...)` handler (`fresh-agent-extras-router.ts:268-287`),
+/// minus auth (enforced by the outermost `require_auth` layer above). Named
+/// checks come before body checks, exactly like the oracle.
+async fn upload_attachment(
+    State(state): State<AttachmentsApiState>,
+    headers: HeaderMap,
+    Query(names): Query<Vec<(String, String)>>,
+    body: Bytes,
+) -> Response {
+    // Express `typeof req.query.name !== 'string'` parity: `Query<Vec<..>>`
+    // keeps repeated keys AND unrelated keys, so first filter to pairs whose
+    // key IS `name` (Node reads `req.query.name`; other keys are ignored),
+    // then require exactly one non-empty value — missing, empty (`?name=`),
+    // and repeated `name` keys all reject.
+    let names: Vec<&String> = names
+        .iter()
+        .filter(|(key, _)| key == "name")
+        .map(|(_, value)| value)
+        .collect();
+    let name = match names.as_slice() {
+        [value] if !value.is_empty() => (*value).clone(),
+        _ => return bad_request("name query parameter required"),
+    };
+
+    if !is_octet_stream(&headers) || body.is_empty() {
+        return bad_request("attachment body must be a non-empty application/octet-stream");
+    }
+
+    let dir = state.home.join(".freshell").join("attachments");
+    if let Err(error) = tokio::fs::create_dir_all(&dir).await {
+        tracing::warn!(%error, dir = %dir.display(), "failed to save attachment (mkdir)");
+        return save_failure();
+    }
+    let uuid8 = uuid::Uuid::new_v4().simple().to_string();
+    // `simple()` renders exactly 32 lowercase hex chars, so the first-8 slice
+    // mirrors Node's `randomUUID().slice(0, 8)` and can never run short.
+    let filename = format!("{}-{}", &uuid8[..8], sanitize_filename(&name));
+    let target = dir.join(filename);
+    if let Err(error) = tokio::fs::write(&target, &body).await {
+        tracing::warn!(%error, target = %target.display(), "failed to save attachment (write)");
+        return save_failure();
+    }
+
+    Json(json!({ "path": target.display().to_string(), "bytes": body.len() })).into_response()
+}
+
+/// `sanitizeFilename` (`fresh-agent-extras-router.ts:15-18`): POSIX basename
+/// semantics (strip trailing '/', take the segment after the LAST '/' — '\'
+/// is NOT a separator), then every char outside `[a-zA-Z0-9._-]` → '_' PER
+/// UTF-16 CODE UNIT (astral chars like emoji become TWO underscores; é becomes
+/// ONE), empty → 'attachment'.
+pub(crate) fn sanitize_filename(name: &str) -> String {
+    // Node's `path.posix.basename`: trailing slashes do not produce a segment,
+    // so an all-slashes input basenames to '' (→ 'attachment'), never '/'.
+    let base = name.trim_end_matches('/').rsplit('/').next().unwrap_or("");
+    let mut out = String::with_capacity(base.len());
+    for unit in base.encode_utf16() {
+        let kept = char::from_u32(u32::from(unit))
+            .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+        match kept {
+            Some(c) => out.push(c),
+            // Surrogate halves (and every other disallowed code unit) each
+            // become one '_', so an astral char yields two.
+            None => out.push('_'),
+        }
+    }
+    if out.is_empty() {
+        "attachment".to_string()
+    } else {
+        out
+    }
+}
+
+fn bad_request(message: &str) -> Response {
+    (StatusCode::BAD_REQUEST, Json(json!({ "error": message }))).into_response()
+}
+
+fn save_failure() -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({ "error": "failed to save attachment" })),
+    )
+        .into_response()
+}
+
+/// Node's `type-is` semantics behind `raw({ type })`: the content-type header
+/// (absent → false) matches when its type token — everything before the first
+/// `;`, trimmed — equals `application/octet-stream` case-insensitively.
+fn is_octet_stream(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            value
+                .split(';')
+                .next()
+                .unwrap_or_default()
+                .trim()
+                .eq_ignore_ascii_case("application/octet-stream")
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use tower::ServiceExt;
+
+    const OCTET_STREAM: &str = "application/octet-stream";
+    const NAME_MSG: &str = "name query parameter required";
+    const BODY_MSG: &str = "attachment body must be a non-empty application/octet-stream";
+
+    fn state(home: &Path) -> AttachmentsApiState {
+        AttachmentsApiState {
+            auth_token: Arc::new("tok".to_string()),
+            home: Arc::new(home.to_path_buf()),
+        }
+    }
+
+    fn post_upload(
+        query: &str,
+        token: Option<&str>,
+        content_type: Option<&str>,
+        body: Vec<u8>,
+    ) -> axum::http::Request<axum::body::Body> {
+        let mut builder = axum::http::Request::builder()
+            .method("POST")
+            .uri(format!("/api/fresh-agent/attachments{query}"));
+        if let Some(token) = token {
+            builder = builder.header("x-auth-token", token);
+        }
+        if let Some(content_type) = content_type {
+            builder = builder.header("content-type", content_type);
+        }
+        builder.body(axum::body::Body::from(body)).unwrap()
+    }
+
+    async fn body_json(resp: Response) -> serde_json::Value {
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    async fn assert_error(resp: Response, status: StatusCode, message: &str) {
+        assert_eq!(resp.status(), status);
+        let value = body_json(resp).await;
+        assert_eq!(value, json!({ "error": message }));
+    }
+
+    /// Node oracle: "saves a raw binary attachment and returns its path".
+    #[tokio::test]
+    async fn saves_a_raw_binary_attachment_and_returns_its_path() {
+        let home = tempfile::tempdir().unwrap();
+        let app = router(state(home.path()));
+        let resp = app
+            .oneshot(post_upload(
+                "?name=note.txt",
+                Some("tok"),
+                Some(OCTET_STREAM),
+                b"hello attachment".to_vec(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let value = body_json(resp).await;
+        assert_eq!(value["bytes"], json!(16));
+
+        let saved_path = PathBuf::from(value["path"].as_str().unwrap());
+        let attachments_dir = home.path().join(".freshell").join("attachments");
+        assert_eq!(saved_path.parent().unwrap(), attachments_dir.as_path());
+        let basename = saved_path.file_name().unwrap().to_str().unwrap();
+        assert!(
+            regex::Regex::new(r"^[0-9a-f]{8}-note\.txt$")
+                .unwrap()
+                .is_match(basename),
+            "unexpected saved basename: {basename}"
+        );
+        let disk = tokio::fs::read(&saved_path).await.unwrap();
+        assert_eq!(disk, b"hello attachment");
+    }
+
+    /// Node oracle: "sanitizes hostile filenames".
+    #[tokio::test]
+    async fn sanitizes_hostile_filenames_before_saving() {
+        let home = tempfile::tempdir().unwrap();
+        let app = router(state(home.path()));
+        let resp = app
+            .oneshot(post_upload(
+                "?name=../../etc/passwd",
+                Some("tok"),
+                Some(OCTET_STREAM),
+                b"x".to_vec(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let value = body_json(resp).await;
+
+        let saved_path = PathBuf::from(value["path"].as_str().unwrap());
+        let attachments_dir = home.path().join(".freshell").join("attachments");
+        assert_eq!(saved_path.parent().unwrap(), attachments_dir.as_path());
+        let basename = saved_path.file_name().unwrap().to_str().unwrap();
+        assert!(
+            !basename.contains(".."),
+            "basename must not retain traversal: {basename}"
+        );
+        assert!(
+            basename.ends_with("-passwd"),
+            "basename must keep the sanitized name: {basename}"
+        );
+        let disk = tokio::fs::read(&saved_path).await.unwrap();
+        assert_eq!(disk, b"x");
+    }
+
+    /// Node oracle: "rejects missing name and empty body", plus repeated-name
+    /// parity (`typeof name !== 'string'` when express yields an array).
+    #[tokio::test]
+    async fn rejects_missing_name_empty_name_and_empty_body() {
+        let home = tempfile::tempdir().unwrap();
+        let app = router(state(home.path()));
+
+        // No `name` at all (empty body alongside — name is checked first).
+        let resp = app
+            .clone()
+            .oneshot(post_upload("", Some("tok"), Some(OCTET_STREAM), Vec::new()))
+            .await
+            .unwrap();
+        assert_error(resp, StatusCode::BAD_REQUEST, NAME_MSG).await;
+
+        // `name=` — present but empty.
+        let resp = app
+            .clone()
+            .oneshot(post_upload(
+                "?name=",
+                Some("tok"),
+                Some(OCTET_STREAM),
+                b"data".to_vec(),
+            ))
+            .await
+            .unwrap();
+        assert_error(resp, StatusCode::BAD_REQUEST, NAME_MSG).await;
+
+        // Repeated `name` — express yields an array, not a string.
+        let resp = app
+            .clone()
+            .oneshot(post_upload(
+                "?name=a.txt&name=b.txt",
+                Some("tok"),
+                Some(OCTET_STREAM),
+                b"data".to_vec(),
+            ))
+            .await
+            .unwrap();
+        assert_error(resp, StatusCode::BAD_REQUEST, NAME_MSG).await;
+
+        // Valid name but an empty body.
+        let resp = app
+            .clone()
+            .oneshot(post_upload(
+                "?name=x.txt",
+                Some("tok"),
+                Some(OCTET_STREAM),
+                Vec::new(),
+            ))
+            .await
+            .unwrap();
+        assert_error(resp, StatusCode::BAD_REQUEST, BODY_MSG).await;
+    }
+
+    /// Node oracle: `req.query.name` is `undefined` for `?foo=bar`, so the
+    /// oracle 400s. The key must BE `name`; a single non-empty pair with a
+    /// different key is not a name.
+    #[tokio::test]
+    async fn rejects_a_single_query_pair_whose_key_is_not_name() {
+        let home = tempfile::tempdir().unwrap();
+        let app = router(state(home.path()));
+        let resp = app
+            .oneshot(post_upload(
+                "?foo=bar",
+                Some("tok"),
+                Some(OCTET_STREAM),
+                b"data".to_vec(),
+            ))
+            .await
+            .unwrap();
+        assert_error(resp, StatusCode::BAD_REQUEST, NAME_MSG).await;
+
+        let attachments_dir = home.path().join(".freshell").join("attachments");
+        assert!(
+            tokio::fs::metadata(&attachments_dir).await.is_err(),
+            "attachments dir must not be created for a nameless request"
+        );
+    }
+
+    /// Node oracle: `?name=a.txt&other=x` has `req.query.name === 'a.txt'`
+    /// (a string), so the oracle 200s with name `a.txt`; unrelated params
+    /// beside a valid `name` are ignored.
+    #[tokio::test]
+    async fn accepts_a_name_alongside_unrelated_query_params() {
+        let home = tempfile::tempdir().unwrap();
+        let app = router(state(home.path()));
+        let resp = app
+            .oneshot(post_upload(
+                "?name=a.txt&other=x",
+                Some("tok"),
+                Some(OCTET_STREAM),
+                b"data".to_vec(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let value = body_json(resp).await;
+
+        let saved_path = PathBuf::from(value["path"].as_str().unwrap());
+        let attachments_dir = home.path().join(".freshell").join("attachments");
+        assert_eq!(saved_path.parent().unwrap(), attachments_dir.as_path());
+        let basename = saved_path.file_name().unwrap().to_str().unwrap();
+        assert!(
+            regex::Regex::new(r"^[0-9a-f]{8}-a\.txt$")
+                .unwrap()
+                .is_match(basename),
+            "unexpected saved basename: {basename}"
+        );
+        let disk = tokio::fs::read(&saved_path).await.unwrap();
+        assert_eq!(disk, b"data");
+    }
+
+    /// Node oracle: express's `raw({ type })` parses the body only when the
+    /// content type matches, so both a WRONG and an ABSENT Content-Type leave
+    /// `req.body` unparsed and the oracle 400s with the body message.
+    #[tokio::test]
+    async fn rejects_a_non_empty_body_with_the_wrong_content_type() {
+        let home = tempfile::tempdir().unwrap();
+        let app = router(state(home.path()));
+
+        let resp = app
+            .clone()
+            .oneshot(post_upload(
+                "?name=note.txt",
+                Some("tok"),
+                Some("text/plain"),
+                b"data".to_vec(),
+            ))
+            .await
+            .unwrap();
+        assert_error(resp, StatusCode::BAD_REQUEST, BODY_MSG).await;
+
+        // No Content-Type header at all: `headers.get(..)` misses, so
+        // `is_octet_stream`'s `None` branch is false and the same 400 fires —
+        // matching the oracle's type-skip on a missing content type.
+        let resp = app
+            .clone()
+            .oneshot(post_upload(
+                "?name=note.txt",
+                Some("tok"),
+                None,
+                b"data".to_vec(),
+            ))
+            .await
+            .unwrap();
+        assert_error(resp, StatusCode::BAD_REQUEST, BODY_MSG).await;
+
+        // The type match is case-insensitive on the token before any `;`
+        // parameters (Node's `type-is` semantics behind `raw({ type })`).
+        let resp = app
+            .oneshot(post_upload(
+                "?name=note.txt",
+                Some("tok"),
+                Some("APPLICATION/OCTET-STREAM; charset=binary"),
+                b"data".to_vec(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    /// Parity from Node's `authenticateToken` middleware at the mount.
+    #[tokio::test]
+    async fn rejects_unauthenticated_requests() {
+        let home = tempfile::tempdir().unwrap();
+        let app = router(state(home.path()));
+        let resp = app
+            .oneshot(post_upload(
+                "?name=note.txt",
+                None,
+                Some(OCTET_STREAM),
+                b"data".to_vec(),
+            ))
+            .await
+            .unwrap();
+        assert_error(resp, StatusCode::UNAUTHORIZED, "Unauthorized").await;
+
+        let attachments_dir = home.path().join(".freshell").join("attachments");
+        assert!(
+            tokio::fs::metadata(&attachments_dir).await.is_err(),
+            "attachments dir must not be created for a rejected request"
+        );
+    }
+
+    /// LB-10: Node's middleware-first ordering — auth is checked before the
+    /// body is read, so this is 401. It would be 413 if auth lived inside the
+    /// handler (behind Bytes extraction).
+    #[tokio::test]
+    async fn unauthenticated_over_cap_is_401_not_413() {
+        let home = tempfile::tempdir().unwrap();
+        let app = router(state(home.path()));
+        let over_cap = vec![7u8; ATTACHMENT_MAX_BYTES + 1];
+        let resp = app
+            .oneshot(post_upload(
+                "?name=big.bin",
+                None,
+                Some(OCTET_STREAM),
+                over_cap,
+            ))
+            .await
+            .unwrap();
+        assert_error(resp, StatusCode::UNAUTHORIZED, "Unauthorized").await;
+    }
+
+    /// Parity from `ATTACHMENT_MAX_BYTES` + express `raw({ limit })`; status
+    /// is the contract (declared divergence: 413 body format).
+    #[tokio::test]
+    async fn allows_the_cap_and_rejects_one_byte_over() {
+        let home = tempfile::tempdir().unwrap();
+        let app = router(state(home.path()));
+
+        let at_cap = vec![7u8; ATTACHMENT_MAX_BYTES];
+        let resp = app
+            .clone()
+            .oneshot(post_upload(
+                "?name=big.bin",
+                Some("tok"),
+                Some(OCTET_STREAM),
+                at_cap,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let value = body_json(resp).await;
+        assert_eq!(value["bytes"], json!(ATTACHMENT_MAX_BYTES));
+
+        let over_cap = vec![7u8; ATTACHMENT_MAX_BYTES + 1];
+        let resp = app
+            .oneshot(post_upload(
+                "?name=big.bin",
+                Some("tok"),
+                Some(OCTET_STREAM),
+                over_cap,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    /// Declared divergence: Node hangs silently on an fs rejection; this port
+    /// answers a visible 500.
+    #[tokio::test]
+    async fn a_save_failure_is_a_visible_500_not_a_hang() {
+        let home = tempfile::tempdir().unwrap();
+        // Squat `.freshell` with a regular FILE so
+        // `create_dir_all(.freshell/attachments)` fails with NotADirectory.
+        tokio::fs::write(home.path().join(".freshell"), b"file, not a dir")
+            .await
+            .unwrap();
+        let app = router(state(home.path()));
+        let resp = app
+            .oneshot(post_upload(
+                "?name=note.txt",
+                Some("tok"),
+                Some(OCTET_STREAM),
+                b"data".to_vec(),
+            ))
+            .await
+            .unwrap();
+        assert_error(
+            resp,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to save attachment",
+        )
+        .await;
+    }
+
+    #[test]
+    fn sanitize_filename_ports_the_node_basename_plus_replace_semantics() {
+        let cases = [
+            ("note.txt", "note.txt"),
+            ("/a/b/c.png", "c.png"),
+            ("../../etc/passwd", "passwd"),
+            ("C:\\foo:bar.txt", "C__foo_bar.txt"),
+            ("a  b.txt", "a__b.txt"),
+            ("caf\u{e9}.png", "caf_.png"),
+            ("\u{1F600}.png", "__.png"),
+            ("///", "attachment"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(sanitize_filename(input), expected, "input: {input:?}");
+        }
+    }
+}

--- a/crates/freshell-server/src/main.rs
+++ b/crates/freshell-server/src/main.rs
@@ -18,6 +18,7 @@
 
 mod ai_router;
 mod ai_title;
+mod attachments;
 mod auto_title;
 mod auto_title_sweep;
 mod boot;
@@ -1623,6 +1624,17 @@ async fn main() -> ExitCode {
         home: Arc::new(home.clone().unwrap_or_else(|| PathBuf::from("."))),
     };
 
+    // `POST /api/fresh-agent/attachments` (`fresh-agent-extras-router.ts:260-287`):
+    // the paperclip upload route the fresh-agent composer POSTs raw file bytes
+    // to before every attachment-bearing send. `home` is the SAME boot-resolved
+    // value as checkpoints above (uploads live under
+    // `<home>/.freshell/attachments/`) -- a `None` home falls back to the
+    // cwd-relative `.` likewise.
+    let attachments_state = attachments::AttachmentsApiState {
+        auth_token: Arc::clone(&auth_token),
+        home: Arc::new(home.clone().unwrap_or_else(|| PathBuf::from("."))),
+    };
+
     // SAFE-02: the global authenticated API rate limiter (checklist:
     // `docs/plans/2026-07-14-rust-tauri-parity-completion-checklist.md:539`).
     // ONE process-wide token bucket, wired below as the outermost-but-one
@@ -1653,6 +1665,7 @@ async fn main() -> ExitCode {
         .merge(freshell_freshagent::snapshot::router(snapshot_state))
         .merge(session_metadata::router(session_metadata_state))
         .merge(checkpoints::router(checkpoints_state))
+        .merge(attachments::router(attachments_state))
         // R1/R2/R3/R4: the ONE `/api/settings` router (GET+PATCH+PUT), backed by
         // the live `settings_store` \u2014 replaces the old split between this boot
         // module's frozen GET and the freshcodex slice's disconnected PATCH.

--- a/src/components/fresh-agent/FreshAgentComposer.tsx
+++ b/src/components/fresh-agent/FreshAgentComposer.tsx
@@ -168,6 +168,24 @@ function isTextEntryElement(value: Element | null): boolean {
 }
 
 /**
+ * Maps a failed upload response to the attachment chip's error text. The
+ * server-oracle messages win (data.error / data.message), except two statuses
+ * get clearer client-side wording: 404 means the attachments route is absent
+ * on this server (e.g. a build without it), and 413 trips the 10 MB cap —
+ * express's error body there is an unparseable HTML page, so the size limit is
+ * spelled out here instead.
+ */
+export function attachmentUploadErrorMessage(
+  status: number,
+  data: { error?: string; message?: string } | null,
+  filename: string,
+): string {
+  if (status === 404) return 'Attachments are not supported by this server'
+  if (status === 413) return `"${filename}" exceeds the 10 MB attachment size limit`
+  return data?.error || data?.message || `upload failed (${status})`
+}
+
+/**
  * Raw binary upload. Deliberately NOT base64-in-JSON: the server's global
  * express.json caps JSON bodies at 1mb, so attachments ship as
  * application/octet-stream (which the JSON parser ignores) with the filename
@@ -183,8 +201,11 @@ async function uploadAttachment(file: globalThis.File): Promise<{ path: string; 
     headers,
   })
   if (!res.ok) {
-    const data = await res.json().catch(() => null) as { error?: string; message?: string } | null
-    throw new Error(data?.error || data?.message || `upload failed (${res.status})`)
+    const data = (await res.json().catch(() => null)) as {
+      error?: string
+      message?: string
+    } | null
+    throw new Error(attachmentUploadErrorMessage(res.status, data, file.name))
   }
   return res.json() as Promise<{ path: string; bytes: number }>
 }

--- a/test/e2e-browser/playwright.config.ts
+++ b/test/e2e-browser/playwright.config.ts
@@ -117,6 +117,7 @@ export const MATRIX_SPECS = [
   // checkpoint routes and the fresh-agent checkpoint UI are shared code
   // paths, not a Rust-only feature. See agent-checkpoint-rewind.spec.ts.
   /agent-checkpoint-rewind\.spec\.ts$/,
+  /agent-attachments\.spec\.ts$/, // AGENT-11 (slice): composer uploads land on the server; failures are visible
   // SESSION-05 -- project colors on History project headers: real color
   // gesture in one browser, broadcast-driven update in a second context,
   // reload/restart persistence, unrelated project unchanged. Legacy is a

--- a/test/e2e-browser/specs/agent-attachments.spec.ts
+++ b/test/e2e-browser/specs/agent-attachments.spec.ts
@@ -1,0 +1,301 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Buffer } from 'node:buffer'
+import { test, expect } from '../helpers/fixtures.js'
+import { createE2eServerHandle } from '../helpers/external-target.js'
+import { TestHarness } from '../helpers/test-harness.js'
+import { openPanePicker } from '../helpers/pane-picker.js'
+
+/**
+ * AGENT-11 (SLICE) -- composer attachment uploads land on the server, and
+ * upload failures are visible as composer error chips. This spec covers the
+ * composer paperclip upload flow end to end
+ * (`src/components/fresh-agent/FreshAgentComposer.tsx`'s hidden
+ * `<input type="file">` -> `POST /api/fresh-agent/attachments?name=...` with
+ * a raw octet-stream body): happy-path persistence under
+ * `<home>/.freshell/attachments` with a uuid-prefixed, sanitized filename,
+ * hostile-name traversal containment, and the oversized-file failure
+ * rendering a visible "exceeds the 10 MB attachment size limit" chip while
+ * storing nothing. This work covers a slice of AGENT-11 only -- it does NOT
+ * take any AGENT-11 golden-checklist checkbox.
+ *
+ * Server-failure mapping lives in the composer's
+ * `attachmentUploadErrorMessage` (maps on `res.status`, never the 413 body,
+ * whose express error page is HTML), so the oversized chip text is identical
+ * on both server legs -- legacy-chromium is a true parity control (the Node
+ * route at `server/fresh-agent-extras-router.ts` is the behavioral oracle),
+ * and the rust lane is RED until the Rust route
+ * (`crates/freshell-server/src/attachments.rs`) lands.
+ *
+ * Cloud legality (LB-12/LB-13): NO server.restart() leg anywhere (the
+ * property that got `agent-checkpoint-rewind.spec.ts` listed in
+ * `CLOUD_SKIP_SPECS`); the fake codex app-server is booted exclusively via
+ * the `CODEX_CMD` construct env seam (the same shape as the cloud-legal
+ * `agent-continuity-matrix.spec.ts`); each test carries its own 90s
+ * `test.setTimeout`, comfortably inside the 120s cloud per-test budget.
+ *
+ * Routed through the generalized E2eServerHandle seam (HARNESS-02) so the
+ * SAME spec exercises the legacy Node server and the owned Rust server via
+ * the `e2eServerKind` project option (see `playwright.config.ts`'s
+ * `MATRIX_SPECS`).
+ */
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const FAKE_CODEX_APP_SERVER_SOURCE = path.resolve(
+  __dirname,
+  '../../fixtures/coding-cli/codex-app-server/fake-app-server.mjs',
+)
+
+/**
+ * Re-exec wrapper around the shared fake Codex app-server fixture (see
+ * `restore-matrix.spec.ts`'s identically-purposed helper for the full
+ * rationale for a wrapper rather than a raw copy -- ESM bare-specifier
+ * resolution and permission bits). Duplicated here rather than imported so
+ * this spec stays self-contained, matching this test directory's existing
+ * convention of each spec owning its own fixture-install helper (e.g.
+ * `agent-continuity-matrix.spec.ts`'s `installFakeOpencode`).
+ */
+async function installFakeCodexAppServer(destDir: string): Promise<string> {
+  await fs.mkdir(destDir, { recursive: true })
+  const dest = path.join(destDir, 'fake-codex-app-server-wrapper.mjs')
+  const wrapper = `#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+const target = ${JSON.stringify(FAKE_CODEX_APP_SERVER_SOURCE)}
+const result = spawnSync(process.execPath, [target, ...process.argv.slice(2)], { stdio: 'inherit' })
+process.exit(result.status ?? 1)
+`
+  await fs.writeFile(dest, wrapper, 'utf8')
+  await fs.chmod(dest, 0o755)
+  return dest
+}
+
+/** Find the (first) fresh-agent leaf node within a possibly-split pane layout tree. */
+function findFreshAgentLeaf(node: any): any {
+  if (!node) return null
+  if (node.type === 'leaf' && node.content?.kind === 'fresh-agent') return node
+  if (node.type === 'split') {
+    for (const child of node.children ?? []) {
+      const found = findFreshAgentLeaf(child)
+      if (found) return found
+    }
+  }
+  return null
+}
+
+test.describe('Agent attachments (AGENT-11 slice)', () => {
+  test('attaching files through the composer stores them on the server under sanitized names', async ({ page, e2eServerKind }) => {
+    // Per-test budget extended for the two real upload round trips; still
+    // comfortably under the 120s cloud per-test cap (no restart leg here).
+    test.setTimeout(90_000)
+    const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-agent11-attach-'))
+    const projectCwd = path.join(sharedRoot, 'project')
+    try {
+      await fs.mkdir(projectCwd, { recursive: true })
+
+      const fakeCodexPath = await installFakeCodexAppServer(path.join(sharedRoot, 'bin'))
+      // The isolated HOME the harness forces on the server (`FRESHELL_HOME`/
+      // `HOME`) is where uploads must land; capture it from the same
+      // `setupHome` parameter the rewind spec receives.
+      let homeDir = ''
+      const server = await createE2eServerHandle(process.env, {
+        kind: e2eServerKind,
+        construct: {
+          env: { CODEX_CMD: fakeCodexPath },
+          setupHome: async (isolatedHome) => {
+            homeDir = isolatedHome
+            const freshellDir = path.join(isolatedHome, '.freshell')
+            await fs.mkdir(freshellDir, { recursive: true })
+            await fs.writeFile(path.join(freshellDir, 'config.json'), JSON.stringify({
+              version: 1,
+              settings: {
+                freshAgent: { enabled: true },
+                codingCli: {
+                  enabledProviders: ['codex'],
+                  providers: { codex: { model: 'gpt-5-codex', sandbox: 'workspace-write' } },
+                },
+              },
+            }, null, 2))
+          },
+        },
+      })
+      const info = await server.start()
+
+      try {
+        await page.goto(`${info.baseUrl}/?token=${info.token}&e2e=1`)
+        const harness = new TestHarness(page)
+        await harness.waitForHarness()
+        await harness.waitForConnection()
+
+        await page.evaluate(() => {
+          window.__FRESHELL_TEST_HARNESS__?.dispatch({
+            type: 'connection/setAvailableClis',
+            payload: { claude: false, codex: true },
+          })
+        })
+
+        // With no terminal/tab already open, picking a provider from the
+        // very first (whole-screen) pane picker asks for a starting
+        // directory FIRST (`src/components/panes/DirectoryPicker.tsx`) --
+        // this is the REAL UI path that gives the pane its cwd.
+        const picker = await openPanePicker(page)
+        await picker.getByRole('button', { name: /^Freshcodex$/i }).click({ force: true })
+        const directoryInput = page.getByRole('combobox', { name: 'Starting directory for Freshcodex' })
+        await expect(directoryInput).toBeVisible({ timeout: 10_000 })
+        await directoryInput.fill(projectCwd)
+        await directoryInput.press('Enter')
+
+        const paneRoot = page.locator('[data-context="fresh-agent"]').last()
+        await expect(paneRoot).toBeVisible({ timeout: 15_000 })
+
+        const tabId = await harness.getActiveTabId()
+        expect(tabId).toBeTruthy()
+
+        // Real sidecar round trip must settle before proceeding.
+        await expect.poll(async () => {
+          const layout = await harness.getPaneLayout(tabId!)
+          return findFreshAgentLeaf(layout)?.content?.status
+        }, { timeout: 20_000 }).toBe('idle')
+
+        const attachmentsDir = path.join(homeDir, '.freshell', 'attachments')
+        const fileInput = paneRoot.locator('input[type="file"]')
+        const list = paneRoot.getByRole('list', { name: 'Attachments' })
+
+        // Happy path: the upload lands on disk under a uuid-prefixed,
+        // sanitized name and the chip's title shows the server-returned
+        // path (the auto-retrying title assertion is the readiness gate, so
+        // the spinner probe above it can never race).
+        await fileInput.setInputFiles({
+          name: 'note.txt',
+          mimeType: 'text/plain',
+          buffer: Buffer.from('hello attachment'),
+        })
+        await expect.poll(async () => list.getByRole('listitem').count(), { timeout: 15_000 }).toBe(1)
+        await expect.poll(async () => paneRoot.getByLabel('uploading').count(), { timeout: 15_000 }).toBe(0)
+        await expect(list.getByRole('listitem').first())
+          .toHaveAttribute('title', /[0-9a-f]{8}-note\.txt$/, { timeout: 15_000 })
+        const savedName: string = await expect.poll(async () => {
+          const entries = await fs.readdir(attachmentsDir).catch(() => [] as string[])
+          return entries.find((entry) => /^[0-9a-f]{8}-note\.txt$/.test(entry)) ?? null
+        }, { timeout: 15_000 }).not.toBeNull().then(async () => {
+          const entries = await fs.readdir(attachmentsDir)
+          return entries.find((entry) => /^[0-9a-f]{8}-note\.txt$/.test(entry))!
+        })
+        await expect(fs.readFile(path.join(attachmentsDir, savedName), 'utf8'))
+          .resolves.toBe('hello attachment')
+
+        // Traversal attempt: the `.txt` suffix passes the client extension
+        // gate (LB-6); server-side sanitization is what's under test. The
+        // hostile name must be reduced to a plain basename inside the
+        // attachments directory itself.
+        await fileInput.setInputFiles({
+          name: '../../etc/secret.txt',
+          mimeType: 'application/octet-stream',
+          buffer: Buffer.from('x'),
+        })
+        await expect.poll(async () => (await fs.readdir(attachmentsDir)).length, { timeout: 15_000 }).toBe(2)
+        const entries = await fs.readdir(attachmentsDir)
+        const traversal = entries.find((entry) => entry.endsWith('-secret.txt'))
+        expect(traversal).toBeTruthy()
+        expect(traversal).not.toContain('..')
+        expect(path.dirname(path.join(attachmentsDir, traversal!))).toBe(attachmentsDir)
+      } finally {
+        await server.stop().catch(() => {})
+      }
+    } finally {
+      await fs.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  test('an oversized upload shows a visible error in the composer and stores nothing', async ({ page, e2eServerKind }) => {
+    test.setTimeout(90_000)
+    const sharedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'freshell-agent11-oversize-'))
+    const projectCwd = path.join(sharedRoot, 'project')
+    try {
+      await fs.mkdir(projectCwd, { recursive: true })
+
+      const fakeCodexPath = await installFakeCodexAppServer(path.join(sharedRoot, 'bin'))
+      let homeDir = ''
+      const server = await createE2eServerHandle(process.env, {
+        kind: e2eServerKind,
+        construct: {
+          env: { CODEX_CMD: fakeCodexPath },
+          setupHome: async (isolatedHome) => {
+            homeDir = isolatedHome
+            const freshellDir = path.join(isolatedHome, '.freshell')
+            await fs.mkdir(freshellDir, { recursive: true })
+            await fs.writeFile(path.join(freshellDir, 'config.json'), JSON.stringify({
+              version: 1,
+              settings: {
+                freshAgent: { enabled: true },
+                codingCli: {
+                  enabledProviders: ['codex'],
+                  providers: { codex: { model: 'gpt-5-codex', sandbox: 'workspace-write' } },
+                },
+              },
+            }, null, 2))
+          },
+        },
+      })
+      const info = await server.start()
+
+      try {
+        await page.goto(`${info.baseUrl}/?token=${info.token}&e2e=1`)
+        const harness = new TestHarness(page)
+        await harness.waitForHarness()
+        await harness.waitForConnection()
+
+        await page.evaluate(() => {
+          window.__FRESHELL_TEST_HARNESS__?.dispatch({
+            type: 'connection/setAvailableClis',
+            payload: { claude: false, codex: true },
+          })
+        })
+
+        const picker = await openPanePicker(page)
+        await picker.getByRole('button', { name: /^Freshcodex$/i }).click({ force: true })
+        const directoryInput = page.getByRole('combobox', { name: 'Starting directory for Freshcodex' })
+        await expect(directoryInput).toBeVisible({ timeout: 10_000 })
+        await directoryInput.fill(projectCwd)
+        await directoryInput.press('Enter')
+
+        const paneRoot = page.locator('[data-context="fresh-agent"]').last()
+        await expect(paneRoot).toBeVisible({ timeout: 15_000 })
+
+        const tabId = await harness.getActiveTabId()
+        expect(tabId).toBeTruthy()
+
+        await expect.poll(async () => {
+          const layout = await harness.getPaneLayout(tabId!)
+          return findFreshAgentLeaf(layout)?.content?.status
+        }, { timeout: 20_000 }).toBe('idle')
+
+        const attachmentsDir = path.join(homeDir, '.freshell', 'attachments')
+        const fileInput = paneRoot.locator('input[type="file"]')
+        const list = paneRoot.getByRole('list', { name: 'Attachments' })
+
+        // One byte over the server's 10 MB body cap. The composer maps the
+        // 413 on `res.status` (never the unparseable HTML error body), so
+        // the SAME chip text renders on both server legs -- this is the
+        // acceptance-grade "visible error chip for an upload failure", not
+        // a silent catch.
+        await fileInput.setInputFiles({
+          name: 'huge.txt',
+          mimeType: 'application/octet-stream',
+          buffer: Buffer.alloc(10 * 1024 * 1024 + 1, 7),
+        })
+        await expect(list.getByText(/exceeds the 10 MB attachment size limit/))
+          .toBeVisible({ timeout: 30_000 })
+        const entries = await fs.readdir(attachmentsDir).catch(() => [] as string[])
+        expect(entries.some((entry) => entry.includes('huge'))).toBe(false)
+      } finally {
+        await server.stop().catch(() => {})
+      }
+    } finally {
+      await fs.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+})

--- a/test/unit/client/components/fresh-agent/FreshAgentComposer.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentComposer.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRef } from 'react'
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
-import { FreshAgentComposer, type FreshAgentComposerHandle } from '@/components/fresh-agent/FreshAgentComposer'
+import userEvent from '@testing-library/user-event'
+import { attachmentUploadErrorMessage, FreshAgentComposer, type FreshAgentComposerHandle } from '@/components/fresh-agent/FreshAgentComposer'
 import type { FreshAgentSessionMenuRow, FreshAgentSlashCommand } from '@shared/fresh-agent-slash-commands'
 
 const apiGet = vi.fn()
@@ -444,6 +445,112 @@ describe('FreshAgentComposer', () => {
       expect(getInput()).not.toHaveAttribute('aria-expanded')
       expect(getInput()).not.toHaveAttribute('aria-controls')
       expect(getInput()).not.toHaveAttribute('aria-activedescendant')
+    })
+  })
+
+  describe('attachmentUploadErrorMessage', () => {
+    it.each<[number, { error?: string; message?: string } | null, string, string]>([
+      // 404 = route absent on this server (e.g. Rust build without attachments).
+      [404, { error: 'Not found' }, 'a.txt', 'Attachments are not supported by this server'],
+      // 413 trips the 10 MB cap; express's HTML error body is unparseable, so
+      // the limit is spelled out client-side.
+      [413, null, 'big.txt', '"big.txt" exceeds the 10 MB attachment size limit'],
+      // Anything else: the server's own error/message text wins.
+      [401, { error: 'Unauthorized' }, 'a.txt', 'Unauthorized'],
+      // message worded without error: the message branch is exercised.
+      [500, { message: 'server exploded' }, 'a.txt', 'server exploded'],
+      [500, null, 'a.txt', 'upload failed (500)'],
+    ])('status %i with %s maps to a clear chip message', (status, data, filename, expected) => {
+      expect(attachmentUploadErrorMessage(status, data, filename)).toBe(expected)
+    })
+  })
+
+  describe('attachments', () => {
+    const fetchMock = vi.fn()
+
+    beforeEach(() => {
+      fetchMock.mockReset()
+      vi.stubGlobal('fetch', fetchMock)
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('uploads an attachment, shows the stored path on the chip, and sends its path', async () => {
+      const user = userEvent.setup()
+      const onSend = vi.fn()
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ path: '/home/u/.freshell/attachments/abcd1234-note.txt', bytes: 16 }),
+      })
+      const { container } = render(<FreshAgentComposer commands={GROUPED_COMMANDS} onSend={onSend} />)
+
+      await user.upload(
+        container.querySelector('input[type="file"]') as HTMLInputElement,
+        new File(['hello attachment'], 'note.txt', { type: 'text/plain' }),
+      )
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/fresh-agent/attachments?name=note.txt',
+        expect.objectContaining({ method: 'POST' }),
+      )
+
+      const list = await screen.findByRole('list', { name: 'Attachments' })
+      const item = within(list).getByRole('listitem')
+      await waitFor(() => {
+        expect(item).toHaveAttribute('title', '/home/u/.freshell/attachments/abcd1234-note.txt')
+      })
+
+      await user.type(getInput(), 'look at this')
+      await user.click(screen.getByRole('button', { name: 'Send' }))
+      expect(onSend).toHaveBeenCalledWith('look at this', ['/home/u/.freshell/attachments/abcd1234-note.txt'])
+    })
+
+    it('shows a visible error chip when the server lacks the attachments route (404)', async () => {
+      const user = userEvent.setup()
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'Not found' }),
+      })
+      const { container } = render(<FreshAgentComposer commands={GROUPED_COMMANDS} onSend={vi.fn()} />)
+
+      await user.upload(
+        container.querySelector('input[type="file"]') as HTMLInputElement,
+        new File(['hello'], 'note.txt', { type: 'text/plain' }),
+      )
+
+      const list = await screen.findByRole('list', { name: 'Attachments' })
+      expect(
+        await within(list).findByText('— Attachments are not supported by this server'),
+      ).toBeInTheDocument()
+    })
+
+    it('shows a visible error chip for an unparsable 413 (express HTML error page)', async () => {
+      const user = userEvent.setup()
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 413,
+        json: async () => { throw new SyntaxError('Unexpected token < in JSON') },
+      })
+      const { container } = render(<FreshAgentComposer commands={GROUPED_COMMANDS} onSend={vi.fn()} />)
+
+      await user.upload(
+        container.querySelector('input[type="file"]') as HTMLInputElement,
+        new File(['x'.repeat(64)], 'huge.txt', { type: 'text/plain' }),
+      )
+
+      // Fetch WAS called: .txt passes the client-side extension gate, so the
+      // failure provenance is the server, not a pre-fetch client rejection.
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/fresh-agent/attachments?name=huge.txt',
+        expect.objectContaining({ method: 'POST' }),
+      )
+      const list = await screen.findByRole('list', { name: 'Attachments' })
+      expect(
+        await within(list).findByText(/exceeds the 10 MB attachment size limit/),
+      ).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
Darkforge job te1m landing. Adds POST /api/fresh-agent/attachments to the Rust server with exact Node-oracle parity (10 MiB cap, sanitize, 401-before-413 ordering, {path,bytes}), and maps composer upload failures to visible error chips. Coverage: 11 Rust route tests, 31 composer component tests, e2e matrix spec green on both server lanes locally and on the cloud backend, production-mode scratch smoke verified, full QA gate passed at this exact commit. This PR exists to run the two required checks (typecheck-client, clippy) on the landing SHA; landing itself is an ordinary push of the same commit per the factory owner contract.