### PR TITLE
fix(fresh-agent): define popover surface tokens so overlay menus render opaque

### DIFF
--- a/src/theme-variables.css
+++ b/src/theme-variables.css
@@ -4,6 +4,10 @@
   --foreground: 240 10% 10%;
   --card: 0 0% 98%;
   --card-foreground: 240 10% 10%;
+  /* Floating overlay surfaces (menus, popovers) — kept at card parity so all
+   * app menus share one look. */
+  --popover: 0 0% 98%;
+  --popover-foreground: 240 10% 10%;
   --muted: 240 5% 96%;
   --muted-foreground: 240 4% 46%;
   --accent: 240 5% 96%;
@@ -43,6 +47,9 @@
   --foreground: 0 0% 98%;
   --card: 240 6% 10%;
   --card-foreground: 0 0% 98%;
+  /* Floating overlay surfaces (menus, popovers) — card parity, see :root. */
+  --popover: 240 6% 10%;
+  --popover-foreground: 0 0% 98%;
   --muted: 240 4% 16%;
   --muted-foreground: 240 5% 65%;
   --accent: 240 4% 16%;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,8 @@ export default {
         border: 'hsl(var(--border))',
         card: 'hsl(var(--card))',
         'card-foreground': 'hsl(var(--card-foreground))',
+        popover: 'hsl(var(--popover))',
+        'popover-foreground': 'hsl(var(--popover-foreground))',
         muted: 'hsl(var(--muted))',
         'muted-foreground': 'hsl(var(--muted-foreground))',
         accent: 'hsl(var(--accent))',

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -604,6 +604,48 @@ test.describe('Fresh Agent', () => {
     expect(monoFont).not.toBe(defaultFont)
   })
 
+  test('turn context menu renders on an opaque popover surface', async ({ freshellPage: _freshellPage, page, terminal }) => {
+    await terminal.waitForTerminal()
+    const sessionId = '63333000-0000-4333-8333-000000000006'
+    await stubFreshclaudeThread(page, sessionId, [
+      {
+        id: 'turn-menu-user',
+        turnId: 'turn-menu-user',
+        role: 'user',
+        summary: 'Summarize the menu surface.',
+        items: [{ id: 'item-menu-user', kind: 'text', text: 'Summarize the menu surface.' }],
+      },
+    ])
+    await installFreshclaudeStripPane(page, sessionId)
+
+    const paneRoot = page.locator('[data-context="fresh-agent"]')
+    const turnText = paneRoot.getByText('Summarize the menu surface.', { exact: true })
+    await expect(turnText).toBeVisible({ timeout: 10_000 })
+    await turnText.click({ button: 'right' })
+
+    // Fine-pointer desktop: right-clicking a turn opens the floating turn menu.
+    const menu = page.getByRole('menu', { name: 'Turn context menu' })
+    await expect(menu).toBeVisible()
+
+    // Regression pin: bg-popover previously resolved to no rule at all (the
+    // popover tokens were missing from the tailwind config/theme variables),
+    // so the menu floated over the transcript with a transparent background.
+    const backgroundColor = await menu.evaluate((el) => getComputedStyle(el).backgroundColor)
+    expect(backgroundColor, 'turn context menu must not be transparent').not.toBe('rgba(0, 0, 0, 0)')
+    expect(backgroundColor).not.toBe('transparent')
+
+    // And it must be the popover surface token itself, not accidental inheritance.
+    const expectedSurface = await page.evaluate(() => {
+      const probe = document.createElement('div')
+      probe.style.backgroundColor = 'hsl(var(--popover))'
+      document.body.appendChild(probe)
+      const value = getComputedStyle(probe).backgroundColor
+      probe.remove()
+      return value
+    })
+    expect(backgroundColor).toBe(expectedSurface)
+  })
+
   test('pane picker hides fresh clients by default even when their CLIs are enabled', async ({ freshellPage, page, terminal }) => {
     await terminal.waitForTerminal()
     await page.evaluate(() => {

--- a/test/unit/client/theme/tailwind-theme-tokens.test.ts
+++ b/test/unit/client/theme/tailwind-theme-tokens.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import postcss from 'postcss'
+import tailwindcss from 'tailwindcss'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+// @ts-ignore — untyped ESM .js module; loaded so the test runs the REAL tailwind config
+import tailwindConfig from '../../../../tailwind.config.js'
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..')
+
+/**
+ * Run the real Tailwind compiler against the real config and content globs —
+ * the same generation the production build performs. A utility class used in
+ * src only ships to the browser when it resolves to a real color token here;
+ * otherwise the generated stylesheet silently contains no rule for it and the
+ * element renders with a transparent background (the fresh-agent turn
+ * context-menu bug).
+ */
+async function generateUtilitiesCss(): Promise<string> {
+  const content = (tailwindConfig.content as string[]).map((p: string) => path.resolve(projectRoot, p))
+  const result = await postcss([tailwindcss({ ...tailwindConfig, content })]).process('@tailwind utilities;', { from: undefined })
+  return result.css
+}
+
+/** Collect the custom properties defined by one theme block (:root / .dark). */
+function themeBlockVars(themeCss: postcss.Root, selector: string): Set<string> {
+  const vars = new Set<string>()
+  themeCss.walkRules(selector, (rule) => {
+    rule.walkDecls((decl) => {
+      if (decl.prop.startsWith('--')) vars.add(decl.prop)
+    })
+  })
+  return vars
+}
+
+describe('tailwind theme tokens', () => {
+  it('generates rules for the popover surface tokens used by fresh-agent overlays', async () => {
+    const css = await generateUtilitiesCss()
+    // Used by FreshAgentTurnActions (turn right-click menu + hover toolbar),
+    // FreshAgentActionSheet, and the FreshAgentComposer slash-command menu.
+    for (const utility of ['bg-popover', 'text-popover-foreground']) {
+      expect(css, `${utility} must generate a real rule`).toMatch(new RegExp(`\\.${utility}\\s*\\{`))
+    }
+  })
+
+  it('defines every CSS variable referenced by theme colors in both :root and .dark', () => {
+    const colors: Record<string, string> = tailwindConfig.theme?.extend?.colors ?? {}
+    const referenced = new Set<string>()
+    for (const value of Object.values(colors)) {
+      for (const match of String(value).matchAll(/var\((--[\w-]+)\)/g)) {
+        referenced.add(match[1])
+      }
+    }
+    expect(referenced.size).toBeGreaterThan(0)
+    const themeCss = postcss.parse(readFileSync(path.join(projectRoot, 'src/theme-variables.css'), 'utf8'))
+    const rootVars = themeBlockVars(themeCss, ':root')
+    const darkVars = themeBlockVars(themeCss, '.dark')
+    for (const varName of referenced) {
+      expect(rootVars.has(varName), `${varName} must be defined in :root`).toBe(true)
+      expect(darkVars.has(varName), `${varName} must be defined in .dark`).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

Right-click menus in fresh-agent panes rendered with a transparent background, making them hard to read over transcript text.

Root cause: `FreshAgentTurnActions` (turn context menu + hover toolbar), `FreshAgentActionSheet`, and the `FreshAgentComposer` slash-command menu style their surfaces with `bg-popover` / `text-popover-foreground`, but the popover tokens were never added to the Tailwind palette or to `theme-variables.css`. Tailwind generated no rule for those classes, so the surfaces had `background-color: rgba(0, 0, 0, 0)`. The app's other menus use `bg-card` (defined), so only fresh-agent surfaces were affected.

## Fix

Adds `popover` / `popover-foreground` tokens to `tailwind.config.js` and `--popover` / `--popover-foreground` to both `:root` (light) and `.dark` in `src/theme-variables.css`, at card parity (same values as `card`), matching the look of the proven global context menu.

## Tests

- **New unit test** `test/unit/client/theme/tailwind-theme-tokens.test.ts` runs the real Tailwind compiler over the real content globs and asserts the popover utilities generate rules, plus an invariant that every CSS var referenced by theme colors is defined in both `:root` and `.dark`. Verified red pre-fix, green post-fix.
- **New Playwright pin** in `test/e2e-browser/specs/fresh-agent.spec.ts` right-clicks a freshclaude turn and asserts the menu's computed background is the opaque popover surface. Verified red in a real browser pre-fix (computed `rgba(0, 0, 0, 0)`), green post-fix.
- Broad coordinated `npm test` (cloud vitest) green on this commit; affected e2e spec green on cloud (20 passed); typecheck + a11y gate clean.

Audited the rest of the codebase for other theme-token utilities missing from the palette — `popover` was the only one.