### PR TITLE
feat(codex): reattach Node-server codex pane restores to surviving sidecars

### DIFF
--- a/docs/debug-codex-app-server-leak.md
+++ b/docs/debug-codex-app-server-leak.md
@@ -272,6 +272,7 @@ Use red-green-refactor. Add process-level tests where process behavior is the re
 - wrapper identity read failure after spawn is the direct startup failure: force identity lookup to return null without also forcing initialize failure, then assert the owned process group is torn down before retry and startup does not proceed with empty wrapper identity metadata
 - inherited ownership id is visible on the fake native child
 - startup reaper ignores legacy records, does not signal current-process-group records, and blocks startup for any unreaped new-schema record that is not explicitly verified as handled
+- (2026-09-06, kata 4g2a) posture update: where a hold reconciler is installed (default boot path), verified-owned prior-generation survivors are HELD claimable for restore-time reattach instead of killed (design and rationale in the 4g2a landing commit message's `## Plan` section); the bullets below describe the pre-4g2a kill-at-boot posture for non-held/unproven records
 - startup reaper removes only verified stale new-schema groups
 - startup fails when the new-schema reaper returns unreaped active/skipped ownership records, including live `ownerServerPid` and current-process-group cases
 - startup fails when the new-schema reaper throws from ownership verification, process-group signaling, waiting, or metadata removal

--- a/server/coding-cli/codex-app-server/launch-planner.ts
+++ b/server/coding-cli/codex-app-server/launch-planner.ts
@@ -1,4 +1,9 @@
-import type { CodexAppServerRuntime } from './runtime.js'
+import {
+  getCodexSurvivorAttachErrorCode,
+  type CodexAppServerRuntime,
+  type CodexSurvivorAttachErrorCode,
+  type HeldCodexSidecarOwnership,
+} from './runtime.js'
 import type { CodexThreadLifecycleEvent, CodexThreadLifecycleLossEvent, CodexTurnEvent } from './client.js'
 import type {
   CodexThreadTurnReadParams,
@@ -7,6 +12,7 @@ import type {
   CodexThreadTurnsListResult,
 } from './protocol.js'
 import { waitForAllSettledOrThrow } from '../../shutdown-join.js'
+import { logger } from '../../logger.js'
 import {
   CodexRemoteProxy,
   type CodexApprovalRequestEvent,
@@ -25,10 +31,23 @@ type CodexRuntimeLike = Pick<
   | 'unwatchPath'
   | 'readThreadTurn'
   | 'listThreadTurns'
+  | 'attachToSurvivingSidecar'
 >
+
+/**
+ * Restore-time survivor claim seam (kata 4g2a), implemented by CodexSidecarReconciler in
+ * sidecar-reattach.ts. Declared structurally here: this module never imports the reconciler, so
+ * the only import edges stay launch-planner.ts → runtime.ts and sidecar-reattach.ts → runtime.ts.
+ */
+export type CodexSidecarClaimSource = {
+  claimForSession(sessionId: string): HeldCodexSidecarOwnership | null
+  dropClaim(ownershipId: string): void
+  settleFailedClaim(ownership: HeldCodexSidecarOwnership, code: CodexSurvivorAttachErrorCode): Promise<void>
+}
 
 export type CodexLaunchSidecar = {
   adopt(input: { terminalId: string; generation: number }): Promise<void>
+  noteSessionId?(sessionId: string): Promise<void>
   markCandidatePersisted?(): void
   pauseCandidateCapture?(reason: string): void
   resumeCandidateCapture?(reason: string): void
@@ -92,6 +111,7 @@ type CodexLaunchProxy = Pick<
 
 type CodexLaunchPlannerOptions = {
   proxyFactory?: (options: CodexLaunchProxyOptions) => CodexLaunchProxy
+  reconciler?: CodexSidecarClaimSource
 }
 
 function errorMessage(error: unknown): string {
@@ -114,6 +134,7 @@ export class CodexLaunchPlanner {
   private readonly failedSidecarShutdowns = new Set<CodexLaunchSidecar>()
   private readonly runtimeFactory: () => CodexRuntimeLike
   private readonly proxyFactory: (options: CodexLaunchProxyOptions) => CodexLaunchProxy
+  private readonly reconciler?: CodexSidecarClaimSource
   private shutdownStarted = false
   private shutdownPromise: Promise<void> | null = null
 
@@ -125,12 +146,18 @@ export class CodexLaunchPlanner {
       ? runtimeOrFactory
       : () => runtimeOrFactory
     this.proxyFactory = options.proxyFactory ?? ((proxyOptions) => new CodexRemoteProxy(proxyOptions))
+    this.reconciler = options.reconciler
   }
 
   async planCreate(input: PlanCreateInput): Promise<CodexLaunchPlan> {
     this.assertAcceptingPlans()
     await this.retryFailedSidecarShutdownsBeforePlan()
     this.assertAcceptingPlans()
+
+    if (input.resumeSessionId) {
+      const claimedPlan = await this.tryPlanSurvivorClaim(input)
+      if (claimedPlan) return claimedPlan
+    }
 
     const runtime = this.runtimeFactory()
     let proxy: CodexLaunchProxy | undefined
@@ -140,6 +167,11 @@ export class CodexLaunchPlanner {
     try {
       if (input.resumeSessionId) {
         const ready = await runtime.ensureReady(input.cwd)
+        await runtime.updateOwnershipMetadata({ sessionId: input.resumeSessionId }).catch((error) => {
+          // Stamp loss must never break a working resume; it only forfeits this
+          // sidecar as a future restore claim candidate.
+          logger.warn({ err: error }, 'Codex sidecar ownership session stamp failed; restore-claim for this sidecar is degraded')
+        })
         proxy = this.proxyFactory({
           upstreamWsUrl: ready.wsUrl,
           requireCandidatePersistence: false,
@@ -205,6 +237,88 @@ export class CodexLaunchPlanner {
     }
   }
 
+  /**
+   * Restore-time survivor claim seam (kata 4g2a da92 parity): a resume-keyed plan claims a
+   * verified prior-generation sidecar held by the boot reconciler before falling back to the
+   * spawn path. Returns null when no reconciler is installed or no claim can produce a plan, so
+   * the caller spawns fresh (Task 1 then stamps the resume session id onto the new record).
+   * Coded attach failures settle back through the reconciler and advance to the next candidate;
+   * uncoded errors (e.g. proxy start or planner shutdown raced the attach) run the same
+   * ownership-gated teardown contract as planCreate's catch and rethrow unchanged.
+   */
+  private async tryPlanSurvivorClaim(input: PlanCreateInput): Promise<CodexLaunchPlan | null> {
+    const sessionId = input.resumeSessionId
+    const reconciler = this.reconciler
+    if (!sessionId || !reconciler) return null
+
+    // One candidate at a time through claimForSession; an empty claim returns null so the caller
+    // falls through to the spawn path unchanged.
+    for (;;) {
+      const candidate = reconciler.claimForSession(sessionId)
+      if (!candidate) return null
+
+      const candidateRuntime = this.runtimeFactory()
+      let candidateProxy: CodexLaunchProxy | undefined
+      const candidateSidecar = this.createSidecar(candidateRuntime, () => candidateProxy)
+      try {
+        const attached = await candidateRuntime.attachToSurvivingSidecar(candidate, { sessionId })
+        candidateProxy = this.proxyFactory({
+          upstreamWsUrl: attached.wsUrl,
+          requireCandidatePersistence: false,
+        })
+        const proxyReady = await candidateProxy.start()
+        this.assertAcceptingPlans()
+        this.activeSidecars.add(candidateSidecar)
+        reconciler.dropClaim(candidate.metadata.ownershipId)
+        logger.info(
+          { ownershipId: candidate.metadata.ownershipId, sessionId, wsUrl: attached.wsUrl },
+          'Codex restore claimed a surviving sidecar',
+        )
+        return {
+          sessionId,
+          remote: {
+            wsUrl: proxyReady.wsUrl,
+          },
+          sidecar: candidateSidecar,
+        }
+      } catch (error) {
+        const code = getCodexSurvivorAttachErrorCode(error)
+        if (code) {
+          // Coded survivor failure: the candidate runtime is provably inert
+          // (attachToSurvivingSidecar throws before any retitle/ready-state mutation and closes
+          // its own client), so the sidecar never enters activeSidecars and needs no shutdown —
+          // settling the claim with the reconciler owns the survivor's fate.
+          await candidateProxy?.close()
+          await reconciler.settleFailedClaim(candidate, code)
+          logger.warn(
+            { err: error, ownershipId: candidate.metadata.ownershipId, sessionId, code },
+            'Codex survivor claim failed; trying the next candidate or falling back to a fresh spawn',
+          )
+          continue
+        }
+        // Uncoded failure (e.g. proxy start or planner shutdown raced the attach): the candidate
+        // is consumed-then-unowned. Drop the claim, run the existing catch path's ownership-gated
+        // teardown of whatever the runtime built/attached, and rethrow the original error so
+        // planCodexLaunchWithRetry's fresh-spawn semantics stay unchanged. The candidate enters
+        // activeSidecars BEFORE the teardown attempt (review F1): a failed shutdown lands in
+        // failedSidecarShutdowns, which retryFailedSidecarShutdownsBeforePlan only retries for
+        // sidecars that remain planner-owned — the spawn-path catch relies on the same ordering.
+        // A successful shutdown self-removes from both sets.
+        reconciler.dropClaim(candidate.metadata.ownershipId)
+        this.activeSidecars.add(candidateSidecar)
+        try {
+          await candidateSidecar.shutdown()
+        } catch (shutdownError) {
+          throw codexSidecarTeardownError(
+            `Codex launch sidecar teardown failed after planning error: ${errorMessage(shutdownError)}`,
+            shutdownError,
+          )
+        }
+        throw error
+      }
+    }
+  }
+
   private async retryFailedSidecarShutdownsBeforePlan(): Promise<void> {
     const failedSidecars = [...this.failedSidecarShutdowns]
       .filter((sidecar) => this.activeSidecars.has(sidecar))
@@ -244,6 +358,9 @@ export class CodexLaunchPlanner {
         assertAdoptable()
         this.activeSidecars.delete(sidecar)
         this.failedSidecarShutdowns.delete(sidecar)
+      },
+      noteSessionId: async (sessionId) => {
+        await runtime.updateOwnershipMetadata({ sessionId })
       },
       markCandidatePersisted: () => getProxy()?.markCandidatePersisted(),
       pauseCandidateCapture: (reason) => getProxy()?.pauseCandidateCapture(reason),

--- a/server/coding-cli/codex-app-server/runtime.ts
+++ b/server/coding-cli/codex-app-server/runtime.ts
@@ -58,6 +58,8 @@ export type CodexSidecarOwnershipMetadata = {
   createdAt: string
   updatedAt: string
   codexHome?: string
+  /** Codex thread id — the restore-time claim key (kata 4g2a); absent on pre-feature records. */
+  sessionId?: string
 }
 
 export type ReadyState = {
@@ -74,6 +76,12 @@ type ActiveOwnership = {
   metadataPath: string
   metadata: CodexSidecarOwnershipMetadata
 }
+
+/**
+ * A verified survivor sidecar record handed to `CodexAppServerRuntime.attachToSurvivingSidecar`
+ * by the boot reconciler (kata 4g2a): the record's directory/path plus its parsed metadata.
+ */
+export type HeldCodexSidecarOwnership = ActiveOwnership
 
 type SpawnProcess = typeof spawn
 type ChildProcessHandle = ReturnType<SpawnProcess>
@@ -164,6 +172,16 @@ class CodexAppServerStartupError extends Error {
   }
 }
 
+/**
+ * Structural sink for the boot reaper's owner-dead branch (kata 4g2a), implemented by
+ * CodexSidecarReconciler in sidecar-reattach.ts. Declared here with the LITERAL verdict union:
+ * this module never imports the reconciler (not even a type-only import of its named verdict), so
+ * the only import edge stays sidecar-reattach.ts → runtime.ts.
+ */
+export type CodexSidecarHoldSink = {
+  hold(ownership: HeldCodexSidecarOwnership): Promise<'held' | 'removed-unowned' | 'kept-unproven'>
+}
+
 export type ReapOrphanedSidecarsOptions = {
   metadataDir?: string
   serverInstanceId: string
@@ -180,6 +198,20 @@ export type ReapOrphanedSidecarsOptions = {
    * log). Passed by the hourly maintenance tick; boot passes always attempt every record.
    */
   respectRetryBackoff?: boolean
+  /**
+   * Boot-hold sink (kata 4g2a): with a sink present, each owner-dead record is offered to it
+   * instead of the teardown tail. Verified survivors are held claimable for restore; the sink
+   * settles every other verdict through the same conservative ownership-gated teardown.
+   */
+  holdReconciler?: CodexSidecarHoldSink
+  /**
+   * Ownership ids the reaper must skip, checked before the budget/teardown tail. The hourly
+   * sweep passes the reconciler's protection set here (held survivors before grace expiry;
+   * in-flight claims always). The function form is re-consulted PER RECORD, so a claim that
+   * lands mid-pass protects every record scanned after it — a static set would snapshot the
+   * protection at pass start and could reap a survivor claimed during the pass.
+   */
+  skipOwnershipIds?: ReadonlySet<string> | (() => ReadonlySet<string>)
   /** Clock seam for the teardown budget (tests only). */
   nowFn?: () => number
 }
@@ -188,6 +220,8 @@ export type ReapOrphanedSidecarsResult = {
   reapedOwnershipIds: string[]
   ignoredLegacyRecords: string[]
   skippedActiveOwnershipIds: string[]
+  /** Verified survivors held claimable by the hold sink this pass (kata 4g2a boot reconcile). */
+  heldOwnershipIds: string[]
   /** Records that hit an unexpected per-record error; retained in place and retried next pass. */
   failedOwnershipIds: string[]
   /** Record files that could not be read (permissions, torn write); retained in place. */
@@ -219,7 +253,8 @@ export type CodexReaperRetryState = {
 const DEFAULT_STARTUP_ATTEMPT_LIMIT = 2
 const DEFAULT_STARTUP_ATTEMPT_TIMEOUT_MS = 3_000
 const STARTUP_POLL_MS = 50
-const DEFAULT_TERMINATE_GRACE_MS = 1_000
+// Exported for the sidecar reattach reconciler's failed-claim settle path (kata 4g2a).
+export const DEFAULT_TERMINATE_GRACE_MS = 1_000
 const OWNERSHIP_SCHEMA_VERSION = 1
 const LAUNCH_DIAGNOSTIC_METADATA_RECORD_CAP = 100
 const LAUNCH_DIAGNOSTIC_METADATA_RECORD_MAX_BYTES = 16 * 1024
@@ -583,9 +618,11 @@ async function isProcessGroupGone(processGroupId: number): Promise<boolean> {
   return false
 }
 
-type OwnedProcessGroupStatus = 'gone' | 'self' | 'owned' | 'foreign' | 'indeterminate'
+// Exported for the sidecar reattach reconciler's hold classification (kata 4g2a).
+export type OwnedProcessGroupStatus = 'gone' | 'self' | 'owned' | 'foreign' | 'indeterminate'
 
-async function classifyOwnedProcessGroup(
+// Exported for the sidecar reattach reconciler's hold classification (kata 4g2a).
+export async function classifyOwnedProcessGroup(
   metadata: CodexSidecarOwnershipMetadata,
 ): Promise<OwnedProcessGroupStatus> {
   if (await isProcessGroupGone(metadata.processGroupId)) return 'gone'
@@ -731,8 +768,11 @@ async function waitForProcessGroupGone(processGroupId: number, timeoutMs: number
   return isProcessGroupGone(processGroupId)
 }
 
-async function teardownOwnedProcessGroup(
-  ownership: ActiveOwnership,
+// Exported for the sidecar reattach reconciler's hold/settle teardown (kata 4g2a). The parameter
+// is annotated with the exported HeldCodexSidecarOwnership alias (type-identical to the internal
+// ActiveOwnership) so declaration emit never needs the private name.
+export async function teardownOwnedProcessGroup(
+  ownership: HeldCodexSidecarOwnership,
   terminateGraceMs: number,
 ): Promise<boolean> {
   const confirmedGone = await teardownOwnedProcessGroupCore(ownership, terminateGraceMs)
@@ -836,6 +876,7 @@ function parseMetadataRecord(raw: string, metadataPath: string): ParsedMetadataR
     || !isWrapperIdentity(candidate.wrapperIdentity)
     || typeof candidate.createdAt !== 'string'
     || typeof candidate.updatedAt !== 'string'
+    || (candidate.sessionId !== undefined && typeof candidate.sessionId !== 'string')
   ) {
     return { kind: 'malformedNewSchema', ownershipId }
   }
@@ -1201,6 +1242,7 @@ export async function reapOrphanedCodexAppServerSidecars(
     reapedOwnershipIds: [],
     ignoredLegacyRecords: [],
     skippedActiveOwnershipIds: [],
+    heldOwnershipIds: [],
     failedOwnershipIds: [],
     unreadableRecords: [],
     quarantinedRecords: [],
@@ -1366,6 +1408,47 @@ export async function reapOrphanedCodexAppServerSidecars(
       }
 
       const ownership: ActiveOwnership = { metadataDir, metadataPath, metadata }
+      // 4g2a: the reconciler's protection set is honored BEFORE the budget/teardown tail — no
+      // signal, no retry bookkeeping for swept-over held or in-flight ids. The function form is
+      // resolved PER RECORD so a claim that lands mid-pass still protects every record scanned
+      // after it.
+      const skipOwnershipIds = typeof options.skipOwnershipIds === 'function'
+        ? options.skipOwnershipIds()
+        : options.skipOwnershipIds
+      if (skipOwnershipIds?.has(metadata.ownershipId)) {
+        result.skippedActiveOwnershipIds.push(metadata.ownershipId)
+        continue
+      }
+      // 4g2a boot reconcile: with a hold sink present, verified survivors are HELD claimable for
+      // restore instead of killed; every non-owned verdict settles through the same conservative
+      // teardown the un-sunk path uses (the sink owns that call).
+      if (options.holdReconciler) {
+        const verdict = await options.holdReconciler.hold(ownership)
+        if (verdict === 'held') {
+          result.heldOwnershipIds.push(metadata.ownershipId)
+          continue
+        }
+        if (verdict === 'removed-unowned') {
+          result.reapedOwnershipIds.push(metadata.ownershipId)
+          await fsp.unlink(reaperRetrySidecarPath(metadataPath)).catch(() => undefined)
+          continue
+        }
+        // kept-unproven: identical to today's teardown-refusal branch (in-place retry, never
+        // quarantine).
+        const state = await recordCodexReaperRetryAttempt(metadataPath)
+        logCodexReaperRetry(
+          {
+            ownershipId: metadata.ownershipId,
+            metadataPath,
+            wrapperPid: metadata.wrapperPid,
+            processGroupId: metadata.processGroupId,
+          },
+          state,
+          'sidecar group ownership could not be verified for a boot hold',
+        )
+        result.retriedOwnershipIds.push(metadata.ownershipId)
+        continue
+      }
       // M2: once the pass's teardown budget is exhausted, skip the signal-and-wait teardown for
       // the remaining records. They keep retry state (so they surface in the boot summary and the
       // hourly tick re-attempts them) and are marked deferred — never dropped.
@@ -1454,6 +1537,41 @@ function summarizeCodexStartupReaperResult(result: ReapOrphanedSidecarsResult): 
     },
     'Codex startup reaper completed with unresolved ownership records; continuing boot (fail-open)',
   )
+}
+
+/**
+ * Total wall-clock budget for the survivor reattach probes (kata 4g2a): `initialize` and
+ * `thread/loaded/list` share ONE deadline computed from this budget, so a wedged survivor
+ * fails fast back to the fresh-spawn fallback (the da92 lane's 3s bound).
+ */
+export const CODEX_REATTACH_PROBE_BUDGET_MS = 3_000
+
+export type CodexSurvivorAttachErrorCode =
+  | 'codex_survivor_identity'
+  | 'codex_survivor_unreachable'
+  | 'codex_survivor_not_writer'
+
+export function getCodexSurvivorAttachErrorCode(error: unknown): CodexSurvivorAttachErrorCode | null {
+  const code = (error as { code?: unknown } | null | undefined)?.code
+  return code === 'codex_survivor_identity' || code === 'codex_survivor_unreachable' || code === 'codex_survivor_not_writer' ? code : null
+}
+
+function codexSurvivorAttachError(code: CodexSurvivorAttachErrorCode, message: string, cause?: unknown): Error {
+  const error = new Error(message, cause !== undefined ? { cause } : undefined)
+  ;(error as Error & { code: CodexSurvivorAttachErrorCode }).code = code
+  return error
+}
+
+// Races one probe against the REMAINING share of the attach deadline: each probe call in
+// `attachToSurvivingSidecar` is handed `probeDeadlineMs - Date.now()`, never a fresh full
+// budget, so initialize + thread/loaded/list together stay inside one ~3s deadline.
+async function withProbeBudget<T>(label: string, promise: Promise<T>, budgetMs: number, totalBudgetMs: number = budgetMs): Promise<T> {
+  return await Promise.race([
+    promise,
+    sleep(budgetMs).then(() => {
+      throw codexSurvivorAttachError('codex_survivor_unreachable', `${label} did not finish within its remaining ${budgetMs}ms slice of the ${totalBudgetMs}ms reattach probe budget`)
+    }),
+  ])
 }
 
 export class CodexAppServerRuntime {
@@ -1549,6 +1667,109 @@ export class CodexAppServerRuntime {
     return this.ready
   }
 
+  /**
+   * Bind this FRESH runtime instance to an already-running sidecar that survived a previous
+   * server's unclean exit (kata 4g2a restore-reattach, the da92 claim semantics): re-verify the
+   * recorded process group, probe its listener and thread-writer claim inside ONE shared
+   * deadline, retitle its ownership record to this server, and adopt its live state. This path
+   * never spawns. On any coded failure the survivor is never signaled and its record is left
+   * unmodified — disposal/settling belongs to the reconciler.
+   */
+  async attachToSurvivingSidecar(
+    ownership: HeldCodexSidecarOwnership,
+    options: { sessionId: string; probeBudgetMs?: number },
+  ): Promise<ReadyState> {
+    if (this.shutdownRequested) {
+      throw new Error('Codex app-server sidecar is shutting down.')
+    }
+    if (this.ready || this.ensureReadyPromise) {
+      throw new Error('Codex app-server sidecar already has a starting or running sidecar; it cannot attach to a survivor.')
+    }
+    await this.assertNoBlockedOwnership('attach to a surviving Codex app-server sidecar')
+
+    const metadata = ownership.metadata
+    // Fresh claim-time identity re-verification: anything but `owned` refuses AND never signals
+    // (the recorded group may be reused/foreign, or evidence may be unreadable — all refuse).
+    const classification = await classifyOwnedProcessGroup(metadata)
+    if (classification !== 'owned') {
+      throw codexSurvivorAttachError('codex_survivor_identity',
+        `Codex survivor sidecar ${metadata.ownershipId} failed ownership re-verification at claim time (${classification}); refusing to signal it`)
+    }
+
+    const budgetMs = options.probeBudgetMs ?? CODEX_REATTACH_PROBE_BUDGET_MS
+    const probeDeadlineMs = Date.now() + budgetMs // one shared deadline across both probes
+    const client = new CodexAppServerClient(
+      { wsUrl: metadata.wsUrl },
+      this.requestTimeoutMs ? { requestTimeoutMs: this.requestTimeoutMs } : {},
+    )
+    this.bindClientEventFanout(client)
+    this.client = client
+    let initialized: CodexInitializeResult
+    try {
+      initialized = await withProbeBudget('survivor initialize', client.initialize(), probeDeadlineMs - Date.now(), budgetMs)
+      const loaded = await withProbeBudget('survivor thread/loaded/list', client.listLoadedThreads(), Math.max(0, probeDeadlineMs - Date.now()), budgetMs)
+      if (!loaded.includes(options.sessionId)) {
+        // Reachable but not the writer for this claim key: keep the survivor alive — it may be
+        // the writer of another key's thread.
+        throw codexSurvivorAttachError('codex_survivor_not_writer',
+          `Codex survivor sidecar ${metadata.ownershipId} is reachable but is not the writer of ${options.sessionId}`)
+      }
+    } catch (error) {
+      if (this.client === client) this.client = null
+      await client.close().catch(() => undefined)
+      if (getCodexSurvivorAttachErrorCode(error)) throw error
+      throw codexSurvivorAttachError('codex_survivor_unreachable',
+        `Codex survivor sidecar ${metadata.ownershipId} was not reachable at its recorded listener`, error)
+    }
+
+    const ownerServerIdentity = await this.processIdentityReader(process.pid)
+    if (!isCompleteWrapperIdentity(ownerServerIdentity)) {
+      if (this.client === client) this.client = null
+      await client.close().catch(() => undefined)
+      throw codexSurvivorAttachError('codex_survivor_unreachable',
+        `Codex survivor sidecar ${metadata.ownershipId} could not be retitled: owner identity unreadable`)
+    }
+
+    this.ownership = {
+      metadataDir: ownership.metadataDir,
+      metadataPath: ownership.metadataPath,
+      metadata: {
+        ...metadata,
+        ownerServerPid: process.pid,
+        ownerServerIdentity,
+        updatedAt: new Date().toISOString(),
+      },
+    }
+    try {
+      await this.writeOwnershipRecord(this.ownership)
+    } catch (error) {
+      // Fail-soft (da92's write_record_loudly parity): a persistence hiccup must not murder a
+      // working sidecar — log loudly once and continue with the in-memory ownership.
+      logger.warn(
+        { err: error, ownershipId: metadata.ownershipId, metadataPath: ownership.metadataPath },
+        'Codex survivor ownership retitle write failed; continuing with in-memory ownership (log-and-continue parity)',
+      )
+    }
+    // Same registration shape as startRuntime's: this server process now owns exit-time reaping
+    // of the survivor's process group, so the group must be tracked from here on.
+    registerCodexChild({
+      pid: metadata.wrapperPid,
+      pgid: metadata.processGroupId,
+      kind: 'app-server',
+      envMarker: { name: 'FRESHELL_CODEX_SIDECAR_ID', value: metadata.ownershipId },
+    })
+    this.ready = {
+      wsUrl: metadata.wsUrl,
+      processPid: metadata.wrapperPid,
+      codexHome: initialized.codexHome,
+      ownershipId: metadata.ownershipId,
+      processGroupId: metadata.processGroupId,
+      metadataPath: ownership.metadataPath,
+    }
+    this.statusValue = 'running'
+    return this.ready
+  }
+
   async startThread(
     params: Omit<CodexThreadStartParams, 'experimentalRawEvents' | 'persistExtendedHistory'>,
   ): Promise<{ threadId: string; wsUrl: string }> {
@@ -1614,6 +1835,7 @@ export class CodexAppServerRuntime {
     terminalId?: string | null
     generation?: number | null
     codexHome?: string
+    sessionId?: string
   }): Promise<void> {
     await this.assertNoBlockedOwnership('update Codex app-server ownership metadata')
     if (!this.ownership) {
@@ -1624,6 +1846,7 @@ export class CodexAppServerRuntime {
       ...(input.terminalId !== undefined ? { terminalId: input.terminalId } : {}),
       ...(input.generation !== undefined ? { generation: input.generation } : {}),
       ...(input.codexHome !== undefined ? { codexHome: input.codexHome } : {}),
+      ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
       updatedAt: new Date().toISOString(),
     }
     await atomicWriteJson(this.ownership.metadataPath, this.ownership.metadata)
@@ -1809,6 +2032,49 @@ export class CodexAppServerRuntime {
     }
   }
 
+  // The single client event fanout shared verbatim by `startRuntime` and
+  // `attachToSurvivingSidecar` (kata 4g2a): an attached survivor's client feeds the same
+  // lifecycle/turn/loss handlers as a spawned sidecar's, with identical disconnect semantics
+  // (ignored while shutting down; otherwise surfaced as 'app_server_client_disconnect').
+  private bindClientEventFanout(client: CodexAppServerClient): void {
+    client.onThreadLifecycleLoss((event) => {
+      for (const handler of this.lifecycleLossHandlers) {
+        handler(event)
+      }
+    })
+    client.onThreadStarted((thread) => {
+      for (const handler of this.threadStartedHandlers) {
+        handler(thread)
+      }
+    })
+    client.onThreadLifecycle((event) => {
+      for (const handler of this.threadLifecycleHandlers) {
+        handler(event)
+      }
+    })
+    client.onFsChanged((event) => {
+      for (const handler of this.fsChangedHandlers) {
+        handler(event)
+      }
+    })
+    client.onTurnStarted((event) => {
+      for (const handler of this.turnStartedHandlers) {
+        handler(event)
+      }
+    })
+    client.onTurnCompleted((event) => {
+      for (const handler of this.turnCompletedHandlers) {
+        handler(event)
+      }
+    })
+    client.onDisconnect((event) => {
+      if (this.shutdownRequested) return
+      for (const handler of this.exitHandlers) {
+        handler(event.error, 'app_server_client_disconnect')
+      }
+    })
+  }
+
   private async startRuntime(cwd: CodexAppServerLaunchCwd): Promise<ReadyState> {
     await assertProcOwnershipProofAvailable()
     await assertCodexAppServerLaunchCwdReachable(cwd)
@@ -1901,42 +2167,7 @@ export class CodexAppServerRuntime {
           { wsUrl },
           this.requestTimeoutMs ? { requestTimeoutMs: this.requestTimeoutMs } : {},
         )
-        client.onThreadLifecycleLoss((event) => {
-          for (const handler of this.lifecycleLossHandlers) {
-            handler(event)
-          }
-        })
-        client.onThreadStarted((thread) => {
-          for (const handler of this.threadStartedHandlers) {
-            handler(thread)
-          }
-        })
-        client.onThreadLifecycle((event) => {
-          for (const handler of this.threadLifecycleHandlers) {
-            handler(event)
-          }
-        })
-        client.onFsChanged((event) => {
-          for (const handler of this.fsChangedHandlers) {
-            handler(event)
-          }
-        })
-        client.onTurnStarted((event) => {
-          for (const handler of this.turnStartedHandlers) {
-            handler(event)
-          }
-        })
-        client.onTurnCompleted((event) => {
-          for (const handler of this.turnCompletedHandlers) {
-            handler(event)
-          }
-        })
-        client.onDisconnect((event) => {
-          if (this.shutdownRequested) return
-          for (const handler of this.exitHandlers) {
-            handler(event.error, 'app_server_client_disconnect')
-          }
-        })
+        this.bindClientEventFanout(client)
         this.client = client
 
         const initialized = await this.waitForInitialize(client, child, childErrorPromise)

--- a/server/coding-cli/codex-app-server/sidecar-reattach.ts
+++ b/server/coding-cli/codex-app-server/sidecar-reattach.ts
@@ -1,0 +1,225 @@
+import { logger } from '../../logger.js'
+import {
+  classifyOwnedProcessGroup,
+  DEFAULT_TERMINATE_GRACE_MS,
+  teardownOwnedProcessGroup,
+  type CodexSurvivorAttachErrorCode,
+  type HeldCodexSidecarOwnership,
+} from './runtime.js'
+
+// Restore-time sidecar reattach (kata 4g2a): the boot reaper's owner-dead branch offers verified
+// survivors to this reconciler instead of killing them, so a restored resume-keyed codex pane can
+// claim its surviving app-server sidecar. Unclaimed survivors are swept through the hourly
+// maintenance tick once the grace window expires; in-flight claims are never swept.
+//
+// Import direction: this module imports from runtime.ts — runtime.ts NEVER imports this module
+// (its CodexSidecarHoldSink is declared structurally with the literal verdict union).
+
+export const CODEX_SIDECAR_REAP_GRACE_DEFAULT_MS = 30 * 60 * 1000
+
+export type CodexSidecarReconcilerLogger = {
+  info: (fields: Record<string, unknown>, message: string) => void
+  warn: (fields: Record<string, unknown>, message: string) => void
+}
+
+// Parses FRESHELL_CODEX_SIDECAR_REAP_GRACE_MS: absent → default; '0' (or any non-negative safe
+// integer) honored literally; anything else → default plus a warn (a mistyped value must never
+// disable the safety net, and must never crash boot either). Digit strings too long for a safe
+// integer parse to Infinity (or lose precision), which would make hasExpired() permanently false
+// and silently disable the sweep — they fall back like any other invalid value.
+export function resolveCodexSidecarReapGraceMs(
+  raw: string | undefined,
+  log: { warn: (fields: Record<string, unknown>, message: string) => void } = logger,
+): number {
+  if (raw === undefined) return CODEX_SIDECAR_REAP_GRACE_DEFAULT_MS
+  const trimmed = raw.trim()
+  if (/^\d+$/.test(trimmed)) {
+    const parsed = Number(trimmed)
+    if (Number.isSafeInteger(parsed) && parsed >= 0) return parsed
+  }
+  log.warn({ raw }, 'Invalid FRESHELL_CODEX_SIDECAR_REAP_GRACE_MS; falling back to the default sidecar reap grace')
+  return CODEX_SIDECAR_REAP_GRACE_DEFAULT_MS
+}
+
+export type CodexSidecarHoldVerdict = 'held' | 'removed-unowned' | 'kept-unproven'
+
+function isClaimableSessionId(sessionId: unknown): sessionId is string {
+  return typeof sessionId === 'string' && sessionId.length > 0
+}
+
+export class CodexSidecarReconciler {
+  private readonly reapGraceMs: number
+  private readonly nowFn: () => number
+  private readonly log: CodexSidecarReconcilerLogger
+  private readonly bootedAtMs: number
+  /** Verified survivors the boot reaper held for restore claims, keyed by ownershipId. */
+  private readonly held = new Map<string, HeldCodexSidecarOwnership>()
+  /** Claim index: codex thread id → held ownershipIds, sorted newest-updatedAt-first. */
+  private readonly bySession = new Map<string, string[]>()
+  /** Claims handed to an attacher but not yet settled or dropped: never swept mid-attach. */
+  private readonly inFlightClaims = new Set<string>()
+
+  constructor(options: {
+    reapGraceMs?: number
+    nowFn?: () => number
+    log?: CodexSidecarReconcilerLogger
+  } = {}) {
+    this.reapGraceMs = options.reapGraceMs ?? CODEX_SIDECAR_REAP_GRACE_DEFAULT_MS
+    this.nowFn = options.nowFn ?? Date.now
+    this.log = options.log ?? logger.child({ component: 'codex-sidecar-reconciler' })
+    this.bootedAtMs = this.nowFn()
+  }
+
+  /**
+   * Boot-pass entry: a fresh ownership classification decides the record's fate. Verified-owned
+   * survivors are held claimable; anything else delegates to the same conservative
+   * teardownOwnedProcessGroup the reaper uses today (gone/foreign unlink without signaling;
+   * self/indeterminate refuse and keep the file).
+   */
+  async hold(ownership: HeldCodexSidecarOwnership): Promise<CodexSidecarHoldVerdict> {
+    const { metadata } = ownership
+    const status = await classifyOwnedProcessGroup(metadata)
+    if (status !== 'owned') {
+      const removed = await teardownOwnedProcessGroup(ownership, DEFAULT_TERMINATE_GRACE_MS)
+      return removed ? 'removed-unowned' : 'kept-unproven'
+    }
+
+    this.held.set(metadata.ownershipId, ownership)
+    const sessionId = metadata.sessionId
+    if (isClaimableSessionId(sessionId)) {
+      // Re-holding an already-indexed record must not append a duplicate: the held map dedupes by
+      // key, this array does not (a duplicate would offer the same record to a second claim).
+      const ids = this.bySession.get(sessionId) ?? []
+      if (!ids.includes(metadata.ownershipId)) ids.push(metadata.ownershipId)
+      // Newest-updatedAt-first so a restore claims the freshest record for its thread.
+      ids.sort((a, b) => {
+        const updatedAtA = this.held.get(a)?.metadata.updatedAt ?? ''
+        const updatedAtB = this.held.get(b)?.metadata.updatedAt ?? ''
+        if (updatedAtA === updatedAtB) return a.localeCompare(b)
+        return updatedAtA < updatedAtB ? 1 : -1
+      })
+      this.bySession.set(sessionId, ids)
+    }
+    this.log.info(
+      { ownershipId: metadata.ownershipId, sessionId: sessionId ?? null, wsUrl: metadata.wsUrl },
+      'Held a verified surviving Codex app-server sidecar for restore claims',
+    )
+    return 'held'
+  }
+
+  /**
+   * One-shot claim for a restore-class plan: pops the newest still-held entry for the session
+   * (stale index entries whose record left `held` are skipped and dropped) and marks it in-flight
+   * so the sweep can never reap it mid-attach.
+   */
+  claimForSession(sessionId: string): HeldCodexSidecarOwnership | null {
+    const ids = this.bySession.get(sessionId)
+    if (!ids) return null
+    while (ids.length > 0) {
+      const ownershipId = ids.shift()!
+      const ownership = this.held.get(ownershipId)
+      if (!ownership) continue
+      this.inFlightClaims.add(ownershipId)
+      if (ids.length === 0) this.bySession.delete(sessionId)
+      return ownership
+    }
+    this.bySession.delete(sessionId)
+    return null
+  }
+
+  /** Attach succeeded: the survivor now belongs to the new server, fully un-managed here. */
+  dropClaim(ownershipId: string): void {
+    this.held.delete(ownershipId)
+    this.inFlightClaims.delete(ownershipId)
+    // The claim was already consumed out of bySession at claimForSession time.
+  }
+
+  /**
+   * Attach failed with a coded survivor error (kata 4g2a da92 parity):
+   * - `not_writer`: the sidecar may write another thread — keep it alive and held (its claim is
+   *   consumed; it never re-enters this session index).
+   * - `identity`/`unreachable`: reap the verified-but-unusable survivor through the same
+   *   conservative ownership-gated teardown the reaper uses, then drop the claim. A teardown
+   *   refusal (self/indeterminate) keeps the file for the hourly reaper to retry from disk.
+   *
+   * Never throws (review F2): teardownOwnedProcessGroup contractually returns false on refusals
+   * but can still throw on internal errors. Propagating that throw would strand the candidate in
+   * inFlightClaims (permanently sweep-protected) and substitute the original attach error at the
+   * claim loop, so a thrown teardown is warn-logged and still ends with dropClaim bookkeeping.
+   */
+  async settleFailedClaim(
+    ownership: HeldCodexSidecarOwnership,
+    code: CodexSurvivorAttachErrorCode,
+  ): Promise<void> {
+    if (code === 'codex_survivor_not_writer') {
+      this.inFlightClaims.delete(ownership.metadata.ownershipId)
+      return
+    }
+    try {
+      const removed = await teardownOwnedProcessGroup(ownership, DEFAULT_TERMINATE_GRACE_MS)
+      if (!removed) {
+        this.log.warn(
+          { ownershipId: ownership.metadata.ownershipId, code, metadataPath: ownership.metadataPath },
+          'Failed-claim survivor teardown was refused; the hourly reaper will retry the record from disk',
+        )
+      }
+    } catch (error) {
+      this.log.warn(
+        { err: error, ownershipId: ownership.metadata.ownershipId, code, metadataPath: ownership.metadataPath },
+        'Failed-claim survivor teardown threw; dropping the claim and leaving the record for the hourly reaper',
+      )
+    }
+    this.dropClaim(ownership.metadata.ownershipId)
+  }
+
+  /**
+   * The sweeper's bookkeeping: drop ids another actor (the hourly reaper) removed from disk so a
+   * reaped id never lingers in any map (otherwise the sweep would stay "due" over ghosts).
+   */
+  forget(ownershipIds: string[]): void {
+    if (ownershipIds.length === 0) return
+    const dropped = new Set(ownershipIds)
+    for (const ownershipId of ownershipIds) {
+      this.held.delete(ownershipId)
+      this.inFlightClaims.delete(ownershipId)
+    }
+    for (const [sessionId, ids] of this.bySession) {
+      const kept = ids.filter((ownershipId) => !dropped.has(ownershipId))
+      if (kept.length === 0) this.bySession.delete(sessionId)
+      else if (kept.length !== ids.length) this.bySession.set(sessionId, kept)
+    }
+  }
+
+  hasExpired(nowMs?: number): boolean {
+    const now = nowMs ?? this.nowFn()
+    return now - this.bootedAtMs >= this.reapGraceMs
+  }
+
+  /**
+   * Ids the reaper must skip right now: before grace expiry every held id plus every in-flight
+   * claim; after expiry only in-flight claims (an in-flight attach must never be swept out from
+   * under the attacher).
+   */
+  sweepProtectionSet(nowMs?: number): Set<string> {
+    if (this.hasExpired(nowMs)) {
+      return new Set(this.inFlightClaims)
+    }
+    return new Set([...this.held.keys(), ...this.inFlightClaims])
+  }
+
+  snapshot(): {
+    held: number
+    claimableSessions: number
+    inFlightClaims: number
+    bootedAtIso: string
+    reapGraceMs: number
+  } {
+    return {
+      held: this.held.size,
+      claimableSessions: this.bySession.size,
+      inFlightClaims: this.inFlightClaims.size,
+      bootedAtIso: new Date(this.bootedAtMs).toISOString(),
+      reapGraceMs: this.reapGraceMs,
+    }
+  }
+}

--- a/server/coding-cli/codex-observability.ts
+++ b/server/coding-cli/codex-observability.ts
@@ -10,6 +10,7 @@ import {
   reapOrphanedCodexAppServerSidecars,
   rescanCodexReaperQuarantine,
 } from './codex-app-server/runtime.js'
+import type { CodexSidecarReconciler } from './codex-app-server/sidecar-reattach.js'
 
 // Stage 1c observability (plan §7.5): one structured `codex-log-db:` line at boot and then hourly,
 // plus the hourly retry of pending reaper records and the quarantine rescan trigger.
@@ -46,6 +47,12 @@ export type CodexReaperMaintenanceOptions = {
   metadataDir?: string
   terminateGraceMs?: number
   log?: CodexObservabilityLogger
+  /**
+   * Boot reconciler holding verified survivors (kata 4g2a): drives the grace-gated sweep — once
+   * its grace window expires with survivors still held, the tick re-runs the reaper with the
+   * reconciler's protection set, then forgets whatever was reaped.
+   */
+  reconciler?: CodexSidecarReconciler
 }
 
 export type CodexObservabilityOptions = CodexReaperMaintenanceOptions & {
@@ -221,14 +228,23 @@ export async function runCodexReaperMaintenanceTick(options: CodexReaperMaintena
   try {
     const { promotedRecords } = await rescanCodexReaperQuarantine(options.metadataDir)
     const due = await hasDueCodexReaperRetries(options.metadataDir)
-    if (promotedRecords.length === 0 && !due) return
-    await reapOrphanedCodexAppServerSidecars({
+    const reconciler = options.reconciler
+    // 4g2a sweep: an expired reconciler with survivors still held regains the reaper's full
+    // authority (kill + unlink) over anything unclaimed and not in flight.
+    const sweepDue = reconciler?.hasExpired() === true && reconciler.snapshot().held > 0
+    if (promotedRecords.length === 0 && !due && !sweepDue) return
+    const result = await reapOrphanedCodexAppServerSidecars({
       serverInstanceId: options.serverInstanceId,
       // m2: per-record backoff gating — only due records are re-attempted (and re-counted).
       respectRetryBackoff: true,
       ...(options.metadataDir !== undefined ? { metadataDir: options.metadataDir } : {}),
       ...(options.terminateGraceMs !== undefined ? { terminateGraceMs: options.terminateGraceMs } : {}),
+      // Function form: the reaper re-consults the protection set PER RECORD, so a claim that
+      // lands mid-pass is honored by every record scanned after it (review Minor 1).
+      ...(reconciler !== undefined ? { skipOwnershipIds: () => reconciler.sweepProtectionSet() } : {}),
     })
+    // Killed records must leave the held maps (else sweepDue stays true forever over ghost ids).
+    reconciler?.forget(result.reapedOwnershipIds)
   } catch (error) {
     try {
       log.warn({ err: error }, 'codex reaper hourly retry tick failed')

--- a/server/index.ts
+++ b/server/index.ts
@@ -103,6 +103,10 @@ import {
   CodexAppServerRuntime,
   runCodexStartupReaper,
 } from './coding-cli/codex-app-server/runtime.js'
+import {
+  CodexSidecarReconciler,
+  resolveCodexSidecarReapGraceMs,
+} from './coding-cli/codex-app-server/sidecar-reattach.js'
 import { CodexLaunchPlanner } from './coding-cli/codex-app-server/launch-planner.js'
 import { startCodexObservability } from './coding-cli/codex-observability.js'
 import { installCodexChildExitHandlers, snapshotCodexChildren } from './coding-cli/codex-child-registry.js'
@@ -283,16 +287,28 @@ async function main() {
   const opencodeActivity = createOpencodeActivityIntegration({ registry, opencodeProvider })
 
   const sessionRepairService = getSessionRepairService({ skipDiscovery: true })
+  // 4g2a: the boot reconciler holds verified prior-generation sidecars claimable for restore
+  // (planner wiring lands with it); the hourly observability tick sweeps whatever stays
+  // unclaimed once the grace window expires.
+  const codexSidecarReconciler = new CodexSidecarReconciler({
+    reapGraceMs: resolveCodexSidecarReapGraceMs(process.env.FRESHELL_CODEX_SIDECAR_REAP_GRACE_MS),
+  })
   try {
-    await runCodexStartupReaper({ serverInstanceId })
+    await runCodexStartupReaper({ serverInstanceId, holdReconciler: codexSidecarReconciler })
   } catch (err) {
     // I4: boot must never die in the reaper. Unresolved records are retried by the hourly
     // observability tick and on the next boot.
     log.warn({ err }, 'Codex startup reaper failed; continuing startup (fail-open)')
   }
+  // One structured boot line: survivors held claimable, claims in flight, and the grace window.
+  log.info(
+    { codexSidecarReconciler: codexSidecarReconciler.snapshot() },
+    'Codex sidecar reconciler state after the boot reaper pass',
+  )
   // Boot + hourly codex-log-db line (WAL size, holder count, quarantine count), hourly retry of
-  // pending reaper records, and the quarantine rescan trigger. Observation-only; unref()'d timer.
-  const codexObservability = startCodexObservability({ serverInstanceId })
+  // pending reaper records, the reconciler sweep, and the quarantine rescan trigger.
+  // Observation-only; unref()'d timer.
+  const codexObservability = startCodexObservability({ serverInstanceId, reconciler: codexSidecarReconciler })
   const freshAgentModelCapabilityRegistry = new FreshAgentModelCapabilityRegistry()
 
   let sdkBridge: SdkBridge
@@ -408,7 +424,7 @@ async function main() {
       },
     ]),
   })
-  const codexLaunchPlanner = new CodexLaunchPlanner(() => new CodexAppServerRuntime({ serverInstanceId }))
+  const codexLaunchPlanner = new CodexLaunchPlanner(() => new CodexAppServerRuntime({ serverInstanceId }), { reconciler: codexSidecarReconciler })
   // Host pressure service: constructed provider-less (sources need the handler, which
   // needs the service) and wired via setSources after wsHandler exists below.
   const hostStats = new HostStatsService()

--- a/server/terminal-registry.ts
+++ b/server/terminal-registry.ts
@@ -634,6 +634,7 @@ export type TerminalRecord = {
     | 'resumeCandidateCapture'
     | 'readThreadTurn'
     | 'listThreadTurns'
+    | 'noteSessionId'
   >
   codexSidecarLifecycleUnsubscribe?: () => void
   codexSidecarLifecyclePublished?: boolean
@@ -2050,6 +2051,15 @@ export class TerminalRegistry extends EventEmitter {
     }
   }
 
+  private async noteCodexSidecarSession(record: TerminalRecord, sessionId: string): Promise<void> {
+    if (!record.codexSidecar?.noteSessionId) return
+    try {
+      await record.codexSidecar.noteSessionId(sessionId)
+    } catch (error) {
+      logger.warn({ err: error, terminalId: record.terminalId, sessionId }, 'Failed to stamp Codex sidecar ownership record with session id; restore-claim for this sidecar is degraded')
+    }
+  }
+
   private armCodexRolloutWatch(record: TerminalRecord, candidate = this.getCodexRolloutWatchCandidate(record)): void {
     const sidecar = record.codexSidecar
     if (!candidate || !sidecar?.watchPath) return
@@ -2494,6 +2504,7 @@ export class TerminalRegistry extends EventEmitter {
     this.clearCodexForkHandoffPending(record)
     this.armCodexRolloutWatch(record, forkCandidate)
     record.codexSidecar?.markCandidatePersisted?.()
+    await this.noteCodexSidecarSession(record, forkCandidate.candidateThreadId)
     logger.info({
       terminalId: record.terminalId,
       oldSessionId: oldResumeSessionId,
@@ -2585,6 +2596,9 @@ export class TerminalRegistry extends EventEmitter {
     const storedDurability = this.codexDurabilityRecordToRef(stored)
     record.codexDurability = storedDurability
     record.codexSidecar?.markCandidatePersisted?.()
+    if (storedDurability.candidate) {
+      await this.noteCodexSidecarSession(record, storedDurability.candidate.candidateThreadId)
+    }
     this.clearCodexInputGate(record)
     this.armCodexRolloutWatch(record)
     logger.info({

--- a/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/launch-planner.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import { CodexLaunchPlanner } from '../../../../../server/coding-cli/codex-app-server/launch-planner.js'
+import type {
+  CodexSurvivorAttachErrorCode,
+  HeldCodexSidecarOwnership,
+} from '../../../../../server/coding-cli/codex-app-server/runtime.js'
 
 function deferred<T = void>() {
   let resolve!: (value: T | PromiseLike<T>) => void
@@ -17,6 +21,8 @@ class FakeRuntime {
   ensureReadyCwdCalls: Array<string | undefined> = []
   startThreadCalls = 0
   adopted: Array<{ terminalId: string; generation: number }> = []
+  updateOwnershipMetadataCalls: Array<{ terminalId?: string | null; generation?: number | null; sessionId?: string }> = []
+  attachCalls: Array<{ ownershipId: string; sessionId: string }> = []
   loadedThreadListCalls = 0
   adoptError?: Error
   ensureReadyBlocker?: Promise<void>
@@ -24,6 +30,7 @@ class FakeRuntime {
   startThreadBlocker?: Promise<void>
   shutdownBlocker?: Promise<void>
   shutdownError?: Error
+  attachError?: Error
 
   constructor(
     readonly wsUrl: string,
@@ -56,10 +63,24 @@ class FakeRuntime {
     }
   }
 
-  async updateOwnershipMetadata(input: { terminalId?: string | null; generation?: number | null }) {
+  async updateOwnershipMetadata(input: { terminalId?: string | null; generation?: number | null; sessionId?: string }) {
     if (this.adoptError) throw this.adoptError
+    this.updateOwnershipMetadataCalls.push(input)
     if (input.terminalId && typeof input.generation === 'number') {
       this.adopted.push({ terminalId: input.terminalId, generation: input.generation })
+    }
+  }
+
+  async attachToSurvivingSidecar(ownership: HeldCodexSidecarOwnership, options: { sessionId: string }) {
+    this.attachCalls.push({ ownershipId: ownership.metadata.ownershipId, sessionId: options.sessionId })
+    if (this.attachError) throw this.attachError
+    return {
+      wsUrl: this.wsUrl,
+      processPid: 100,
+      codexHome: `/tmp/${this.threadId}-codex-home`,
+      ownershipId: ownership.metadata.ownershipId,
+      processGroupId: 100,
+      metadataPath: ownership.metadataPath,
     }
   }
 
@@ -81,12 +102,66 @@ type FakeProxyOptions = {
   requireCandidatePersistence?: boolean
 }
 
+function survivorCandidate(ownershipId: string, sessionId: string, wsUrl: string): HeldCodexSidecarOwnership {
+  return {
+    metadataDir: '/tmp/codex-sidecars',
+    metadataPath: `/tmp/codex-sidecars/${ownershipId}.json`,
+    metadata: {
+      schemaVersion: 1,
+      ownershipId,
+      serverInstanceId: 'srv-previous-generation',
+      ownerServerPid: 999999,
+      terminalId: null,
+      generation: null,
+      wsUrl,
+      wrapperPid: 424242,
+      processGroupId: 424242,
+      wrapperIdentity: { commandLine: ['codex', 'app-server'], cwd: null, startTimeTicks: null },
+      createdAt: '2026-09-05T00:00:00.000Z',
+      updatedAt: '2026-09-05T00:00:00.000Z',
+      sessionId,
+    },
+  }
+}
+
+function survivorAttachError(code: CodexSurvivorAttachErrorCode, message: string): Error {
+  const error = new Error(message) as Error & { code: CodexSurvivorAttachErrorCode }
+  error.code = code
+  return error
+}
+
+// Structural CodexSidecarClaimSource double: one-shot scripted candidate queue per claim call.
+class FakeClaimSource {
+  claimCalls: string[] = []
+  dropCalls: string[] = []
+  settleCalls: Array<{ ownershipId: string; code: CodexSurvivorAttachErrorCode }> = []
+  private readonly queue: HeldCodexSidecarOwnership[]
+
+  constructor(candidates: HeldCodexSidecarOwnership[]) {
+    this.queue = [...candidates]
+  }
+
+  claimForSession(sessionId: string): HeldCodexSidecarOwnership | null {
+    this.claimCalls.push(sessionId)
+    return this.queue.shift() ?? null
+  }
+
+  dropClaim(ownershipId: string): void {
+    this.dropCalls.push(ownershipId)
+  }
+
+  async settleFailedClaim(ownership: HeldCodexSidecarOwnership, code: CodexSurvivorAttachErrorCode): Promise<void> {
+    this.settleCalls.push({ ownershipId: ownership.metadata.ownershipId, code })
+  }
+}
+
 class FakeProxy {
   private static nextPort = 54000
 
   closeCalls = 0
   closeBlocker?: Promise<void>
   closeError?: Error
+  startError?: Error
   readonly wsUrl: string
   readonly upstreamWsUrl: string
   readonly requireCandidatePersistence: boolean
@@ -100,6 +175,7 @@ class FakeProxy {
   }
 
   async start() {
+    if (this.startError) throw this.startError
     return { wsUrl: this.wsUrl }
   }
 
@@ -121,13 +197,18 @@ class FakeProxy {
 function createPlanner(
   runtimeOrFactory: ConstructorParameters<typeof CodexLaunchPlanner>[0],
   proxies: FakeProxy[] = [],
+  reconciler?: FakeClaimSource,
+  proxyStartErrors: ReadonlyArray<Error | undefined> = [],
 ) {
   return new CodexLaunchPlanner(runtimeOrFactory, {
     proxyFactory: (options: FakeProxyOptions) => {
       const proxy = new FakeProxy(options)
+      const startError = proxyStartErrors[proxies.length]
+      if (startError) proxy.startError = startError
       proxies.push(proxy)
       return proxy
     },
+    ...(reconciler ? { reconciler } : {}),
   })
 }
 
@@ -418,6 +499,25 @@ describe('CodexLaunchPlanner', () => {
     expect(runtime.ensureReadyCwdCalls).toEqual(['/repo/resume'])
   })
 
+  it('stamps the resume sessionId onto the sidecar ownership record for resume plans', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43042', 'thr-resume')
+    const planner = createPlanner(() => runtime as any)
+
+    const plan = await planner.planCreate({ resumeSessionId: 'thr-resume' })
+
+    expect(plan.sessionId).toBe('thr-resume')
+    expect(runtime.updateOwnershipMetadataCalls).toContainEqual({ sessionId: 'thr-resume' })
+  })
+
+  it('never stamps a sessionId onto the sidecar ownership record for fresh plans', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43043', 'thread-fresh')
+    const planner = createPlanner(() => runtime as any)
+
+    await planner.planCreate({ cwd: '/repo/fresh' })
+
+    expect(runtime.updateOwnershipMetadataCalls.filter((input) => input.sessionId !== undefined)).toEqual([])
+  })
+
   it('forwards candidate capture pause and resume through the sidecar', async () => {
     const runtime = new FakeRuntime('ws://127.0.0.1:43026', 'thread-pause')
     const proxies: FakeProxy[] = []
@@ -430,6 +530,184 @@ describe('CodexLaunchPlanner', () => {
 
     expect(proxies[0].pauseCandidateCapture).toHaveBeenCalledWith('startup_update_prompt')
     expect(proxies[0].resumeCandidateCapture).toHaveBeenCalledWith('startup_update_prompt_skipped')
+
+    await plan.sidecar.shutdown()
+  })
+})
+
+describe('CodexLaunchPlanner restore-time survivor claims', () => {
+  it('claims and attaches a surviving sidecar for a resume plan instead of spawning', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:32101', 'thread-survivor')
+    const candidate = survivorCandidate('ownership-survivor', 'thread-resume', 'ws://127.0.0.1:32101')
+    const reconciler = new FakeClaimSource([candidate])
+    const proxies: FakeProxy[] = []
+    const planner = createPlanner(() => runtime as any, proxies, reconciler)
+
+    const plan = await planner.planCreate({ resumeSessionId: 'thread-resume' })
+
+    expect(plan.sessionId).toBe('thread-resume')
+    expect(proxies).toHaveLength(1)
+    expect(plan.remote.wsUrl).toBe(proxies[0].wsUrl)
+    expect(proxies[0].requireCandidatePersistence).toBe(false)
+    expect(proxies[0].upstreamWsUrl).toBe('ws://127.0.0.1:32101')
+    // The survivor claim path never spawns: ensureReady is the spawn door.
+    expect(runtime.ensureReadyCalls).toBe(0)
+    expect(runtime.attachCalls).toEqual([{ ownershipId: 'ownership-survivor', sessionId: 'thread-resume' }])
+    expect(reconciler.claimCalls).toEqual(['thread-resume'])
+    expect(reconciler.dropCalls).toEqual(['ownership-survivor'])
+    expect(reconciler.settleCalls).toEqual([])
+
+    await plan.sidecar.shutdown()
+  })
+
+  it('falls through to the spawn path when no survivor is claimable for the resume session', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43050', 'thr-fallback')
+    const reconciler = new FakeClaimSource([])
+    const proxies: FakeProxy[] = []
+    const planner = createPlanner(() => runtime as any, proxies, reconciler)
+
+    const plan = await planner.planCreate({ resumeSessionId: 'thr-fallback' })
+
+    expect(plan.sessionId).toBe('thr-fallback')
+    expect(reconciler.claimCalls).toEqual(['thr-fallback'])
+    expect(reconciler.dropCalls).toEqual([])
+    expect(reconciler.settleCalls).toEqual([])
+    expect(runtime.ensureReadyCalls).toBe(1)
+    expect(runtime.attachCalls).toEqual([])
+    // Task 1 stamping survives on the fallback spawn path: the fresh record carries the resume
+    // session id so a later crash+restore can claim it.
+    expect(runtime.updateOwnershipMetadataCalls).toContainEqual({ sessionId: 'thr-fallback' })
+
+    await plan.sidecar.shutdown()
+  })
+
+  it('settles a coded survivor attach failure and claims the next candidate', async () => {
+    const firstRuntime = new FakeRuntime('ws://127.0.0.1:32111', 'thread-first')
+    firstRuntime.attachError = survivorAttachError('codex_survivor_not_writer', 'reachable but not the writer of thread-resume')
+    const secondRuntime = new FakeRuntime('ws://127.0.0.1:32112', 'thread-second')
+    const firstCandidate = survivorCandidate('ownership-first', 'thread-resume', 'ws://127.0.0.1:32111')
+    const secondCandidate = survivorCandidate('ownership-second', 'thread-resume', 'ws://127.0.0.1:32112')
+    const reconciler = new FakeClaimSource([firstCandidate, secondCandidate])
+    const runtimes = [firstRuntime, secondRuntime]
+    const proxies: FakeProxy[] = []
+    const planner = createPlanner(() => runtimes.shift()! as any, proxies, reconciler)
+
+    const plan = await planner.planCreate({ resumeSessionId: 'thread-resume' })
+
+    expect(plan.sessionId).toBe('thread-resume')
+    // Claims proceed one candidate at a time through claimForSession.
+    expect(reconciler.claimCalls).toEqual(['thread-resume', 'thread-resume'])
+    expect(reconciler.settleCalls).toEqual([{ ownershipId: 'ownership-first', code: 'codex_survivor_not_writer' }])
+    expect(reconciler.dropCalls).toEqual(['ownership-second'])
+    expect(firstRuntime.ensureReadyCalls).toBe(0)
+    expect(secondRuntime.ensureReadyCalls).toBe(0)
+    expect(firstRuntime.attachCalls).toEqual([{ ownershipId: 'ownership-first', sessionId: 'thread-resume' }])
+    expect(secondRuntime.attachCalls).toEqual([{ ownershipId: 'ownership-second', sessionId: 'thread-resume' }])
+    // The coded-failure candidate never built a proxy; only the attached survivor did.
+    expect(proxies).toHaveLength(1)
+    expect(proxies[0].upstreamWsUrl).toBe('ws://127.0.0.1:32112')
+    expect(proxies[0].requireCandidatePersistence).toBe(false)
+    expect(plan.sidecar).toBeDefined()
+
+    // activeSidecars membership pin: a coded-failure candidate's runtime is provably inert
+    // (attachToSurvivingSidecar throws before any retitle/ready-state mutation), so its sidecar
+    // must never enter activeSidecars — otherwise a later planner shutdown() would silently tear
+    // down a half-attached runtime. Only the second (attached) sidecar is planner-owned.
+    await planner.shutdown()
+    expect(firstRuntime.shutdownCalls).toBe(0)
+    expect(secondRuntime.shutdownCalls).toBe(1)
+  })
+
+  it('drops the claim and runs sidecar teardown when the attach throws an uncoded error', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:32121', 'thread-uncoded')
+    runtime.attachError = new Error('proxy start exploded')
+    const candidate = survivorCandidate('ownership-uncoded', 'thread-resume', 'ws://127.0.0.1:32121')
+    const reconciler = new FakeClaimSource([candidate])
+    const planner = createPlanner(() => runtime as any, [], reconciler)
+
+    await expect(planner.planCreate({ resumeSessionId: 'thread-resume' })).rejects.toThrow('proxy start exploded')
+
+    // Uncoded errors treat the candidate as consumed-then-unowned: the claim is dropped (never
+    // settled) and the sidecar goes through the existing ownership-gated teardown catch path.
+    // planCodexLaunchWithRetry owns the retry policy above planCreate; the rethrown original
+    // error keeps the wrapper's fresh-spawn failure semantics byte-identical
+    // (launch-retry.test.ts covers the wrapper level).
+    expect(reconciler.claimCalls).toEqual(['thread-resume'])
+    expect(reconciler.dropCalls).toEqual(['ownership-uncoded'])
+    expect(reconciler.settleCalls).toEqual([])
+    expect(runtime.shutdownCalls).toBe(1)
+  })
+
+  it('retries a failed uncoded-claim sidecar teardown on the next planCreate (review F1)', async () => {
+    const firstRuntime = new FakeRuntime('ws://127.0.0.1:32141', 'thread-claim-teardown')
+    const secondRuntime = new FakeRuntime('ws://127.0.0.1:32142', 'thread-after-retry')
+    const runtimes = [firstRuntime, secondRuntime]
+    firstRuntime.shutdownError = new Error('transient candidate teardown failure')
+    const candidate = survivorCandidate('ownership-claim-teardown', 'thread-resume', 'ws://127.0.0.1:32141')
+    const reconciler = new FakeClaimSource([candidate])
+    const proxies: FakeProxy[] = []
+    // The attach succeeds, then the FIRST proxy's start fails uncoded; the claim is dropped and
+    // the candidate sidecar's teardown runs — and that teardown itself fails.
+    const planner = createPlanner(
+      () => runtimes.shift()! as any,
+      proxies,
+      reconciler,
+      [new Error('proxy start exploded')],
+    )
+
+    const rejection = await planner.planCreate({ resumeSessionId: 'thread-resume' })
+      .catch((caught: unknown) => caught)
+
+    expect(rejection).toMatchObject({ codexSidecarTeardownFailed: true })
+    expect((rejection as Error).message).toContain('transient candidate teardown failure')
+    expect(reconciler.dropCalls).toEqual(['ownership-claim-teardown'])
+    expect(firstRuntime.attachCalls).toEqual([{ ownershipId: 'ownership-claim-teardown', sessionId: 'thread-resume' }])
+    expect(firstRuntime.shutdownCalls).toBe(1)
+
+    firstRuntime.shutdownError = undefined
+
+    // Review F1 parity with the spawn path: the candidate entered activeSidecars BEFORE its
+    // teardown attempt, so the failed shutdown sits in failedSidecarShutdowns AND is reachable by
+    // retryFailedSidecarShutdownsBeforePlan — the next planCreate retries (and now succeeds at)
+    // the teardown before falling through to a fresh spawn.
+    const plan = await planner.planCreate({ resumeSessionId: 'thread-resume' })
+
+    expect(firstRuntime.shutdownCalls).toBe(2)
+    expect(reconciler.claimCalls).toEqual(['thread-resume', 'thread-resume'])
+    expect(plan.sessionId).toBe('thread-resume')
+    expect(secondRuntime.ensureReadyCalls).toBe(1)
+
+    await plan.sidecar.shutdown()
+  })
+
+  it('never consults the reconciler for fresh plans even when one is installed', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43060', 'thread-fresh-only')
+    const candidate = survivorCandidate('ownership-unused', 'thread-x', 'ws://127.0.0.1:32131')
+    const reconciler = new FakeClaimSource([candidate])
+    const planner = createPlanner(() => runtime as any, [], reconciler)
+
+    const plan = await planner.planCreate({ cwd: '/repo/fresh-claim' })
+
+    expect(plan.sessionId).toBeUndefined()
+    expect(reconciler.claimCalls).toEqual([])
+    expect(reconciler.dropCalls).toEqual([])
+    expect(runtime.attachCalls).toEqual([])
+    expect(runtime.ensureReadyCalls).toBe(1)
+
+    await plan.sidecar.shutdown()
+  })
+
+  it('keeps byte-identical legacy behavior when no reconciler is installed', async () => {
+    const runtime = new FakeRuntime('ws://127.0.0.1:43061', 'thread-legacy')
+    const planner = createPlanner(() => runtime as any)
+
+    const plan = await planner.planCreate({ resumeSessionId: 'thread-legacy', cwd: '/repo/legacy' })
+
+    expect(plan.sessionId).toBe('thread-legacy')
+    expect(runtime.attachCalls).toEqual([])
+    expect(runtime.ensureReadyCalls).toBe(1)
+    expect(runtime.ensureReadyCwdCalls).toEqual(['/repo/legacy'])
+    expect(runtime.updateOwnershipMetadataCalls).toContainEqual({ sessionId: 'thread-legacy' })
 
     await plan.sidecar.shutdown()
   })

--- a/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/runtime.test.ts
@@ -15,7 +15,9 @@ import {
   reapOrphanedCodexAppServerSidecars,
   rescanCodexReaperQuarantine,
   runCodexStartupReaper,
+  type CodexSidecarHoldSink,
 } from '../../../../../server/coding-cli/codex-app-server/runtime.js'
+import { CodexSidecarReconciler } from '../../../../../server/coding-cli/codex-app-server/sidecar-reattach.js'
 import { allocateLocalhostPort, type LoopbackServerEndpoint } from '../../../../../server/local-port.js'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -799,6 +801,30 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
       terminalId: 'term-missing',
       generation: 1,
     })).rejects.toThrow(/no active owned codex app-server sidecar/i)
+  })
+
+  it('stamps the codex thread sessionId onto the ownership record', async () => {
+    const metadataDir = await makeTempDir()
+    const runtime = createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-runtime-test',
+      startupAttemptTimeoutMs: REAL_STARTUP_ATTEMPT_TIMEOUT_MS,
+    })
+
+    const ready = await runtime.ensureReady()
+    await runtime.updateOwnershipMetadata({ sessionId: 'thr-1' })
+
+    const record = JSON.parse(await fsp.readFile(ready.metadataPath, 'utf8'))
+    expect(record.sessionId).toBe('thr-1')
+    expect(record.schemaVersion).toBe(1)
+    expect(record.ownershipId).toBe(ready.ownershipId)
+    expect(record.serverInstanceId).toBe('srv-runtime-test')
+    expect(record.ownerServerPid).toBe(process.pid)
+    expect(record.terminalId).toBeNull()
+    expect(record.generation).toBeNull()
+    expect(record.wsUrl).toBe(ready.wsUrl)
+    expect(record.wrapperPid).toBe(ready.processPid)
+    expect(record.processGroupId).toBe(ready.processGroupId)
   })
 
   it('tears down the process group and fails startup when ownership metadata cannot be written', async () => {
@@ -2358,6 +2384,168 @@ describeWithLinuxProc('CodexAppServerRuntime', () => {
       threadId: '019d9859-5670-72b1-851f-794ad7fef112',
       wsUrl: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:\d+$/),
     })
+  })
+
+  describe('boot reaper hold/skip integration (kata 4g2a task 3)', () => {
+    it('holds a verified prior-generation survivor through the holdReconciler sink instead of killing it', async () => {
+      const metadataDir = await makeTempDir()
+      const runtime = createRuntime({
+        metadataDir,
+        serverInstanceId: 'srv-previous',
+      })
+      const ready = await runtime.ensureReady()
+      await runtime.updateOwnershipMetadata({ sessionId: 'thr-held-boot' })
+      await markOwnershipRecordStale(ready.metadataPath)
+      const reconciler = new CodexSidecarReconciler()
+
+      const result = await runCodexStartupReaper({
+        metadataDir,
+        serverInstanceId: 'srv-current',
+        terminateGraceMs: 1,
+        holdReconciler: reconciler,
+      })
+
+      // The dead-owner verified survivor is held claimable, not killed: group alive, record kept.
+      expect(result.heldOwnershipIds).toContain(ready.ownershipId)
+      expect(result.reapedOwnershipIds).not.toContain(ready.ownershipId)
+      expect(result.retriedOwnershipIds).not.toContain(ready.ownershipId)
+      expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+      await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
+
+      // The held record is claimable by its Task-1 session id — exactly once.
+      const claimed = reconciler.claimForSession('thr-held-boot')
+      expect(claimed?.metadata.ownershipId).toBe(ready.ownershipId)
+      expect(reconciler.claimForSession('thr-held-boot')).toBeNull()
+    }, 20_000)
+
+    it('skips skipOwnershipIds records before the budget/teardown tail on a no-sink pass, leaving the group alive', async () => {
+      const metadataDir = await makeTempDir()
+      const runtime = createRuntime({
+        metadataDir,
+        serverInstanceId: 'srv-previous',
+      })
+      const ready = await runtime.ensureReady()
+      await markOwnershipRecordStale(ready.metadataPath)
+
+      const result = await reapOrphanedCodexAppServerSidecars({
+        metadataDir,
+        serverInstanceId: 'srv-current',
+        terminateGraceMs: 1,
+        skipOwnershipIds: new Set([ready.ownershipId]),
+      })
+
+      // The skip set is honored BEFORE the teardown tail: no signal, no retry bookkeeping.
+      expect(result.skippedActiveOwnershipIds).toContain(ready.ownershipId)
+      expect(result.reapedOwnershipIds).not.toContain(ready.ownershipId)
+      expect(result.retriedOwnershipIds).not.toContain(ready.ownershipId)
+      expect(result.heldOwnershipIds).not.toContain(ready.ownershipId)
+      expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+      await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
+      await expect(fsp.stat(`${ready.metadataPath}.reaper.json`)).rejects.toMatchObject({ code: 'ENOENT' })
+    }, 20_000)
+
+    it('resolves a function skipOwnershipIds per record, honoring a protection that lands mid-pass', async () => {
+      const metadataDir = await makeTempDir()
+      // Bare dead-owner records with long-gone groups: teardown proves `gone` and unlinks without
+      // ever signaling, so the pass stays deterministic under suite CPU starvation (the
+      // neighboring live-fixture test pins the no-signal-to-a-live-group property).
+      const writeOrphanRecord = async (name: string, ownershipId: string) => {
+        const now = new Date().toISOString()
+        await fsp.writeFile(path.join(metadataDir, name), JSON.stringify({
+          schemaVersion: 1,
+          ownershipId,
+          serverInstanceId: 'srv-previous',
+          ownerServerPid: 999_999_999,
+          terminalId: null,
+          generation: null,
+          wsUrl: 'ws://127.0.0.1:1',
+          wrapperPid: 999_999_998,
+          processGroupId: 999_999_997,
+          wrapperIdentity: { commandLine: ['codex'], cwd: '/tmp', startTimeTicks: 1 },
+          createdAt: now,
+          updatedAt: now,
+        }), { mode: 0o600 })
+      }
+      await writeOrphanRecord('mid-pass-protected.json', 'mid-pass-protected')
+      await writeOrphanRecord('mid-pass-swept.json', 'mid-pass-swept')
+
+      // A protection that lands WHILE the pass is scanning: the first per-record consultation
+      // adds the id, and the record carrying it must be skipped regardless of scan order. A
+      // pass-start snapshot would consult this exactly once for the whole pass.
+      const liveProtections = new Set<string>()
+      const skipSpy = vi.fn((): ReadonlySet<string> => {
+        liveProtections.add('mid-pass-protected')
+        return liveProtections
+      })
+
+      const result = await reapOrphanedCodexAppServerSidecars({
+        metadataDir,
+        serverInstanceId: 'srv-current',
+        terminateGraceMs: 1,
+        skipOwnershipIds: skipSpy,
+      })
+
+      // Per-record resolution: consulted once per scanned record, never snapshotted at pass start.
+      expect(skipSpy).toHaveBeenCalledTimes(2)
+      expect(result.failedOwnershipIds).toEqual([])
+      expect(result.skippedActiveOwnershipIds).toEqual(['mid-pass-protected'])
+      expect(result.reapedOwnershipIds).toEqual(['mid-pass-swept'])
+      // The mid-pass protection fully shielded its record: kept on disk, no retry bookkeeping.
+      await expect(fsp.stat(path.join(metadataDir, 'mid-pass-protected.json'))).resolves.toBeDefined()
+      await expect(fsp.stat(path.join(metadataDir, 'mid-pass-protected.json.reaper.json'))).rejects.toMatchObject({ code: 'ENOENT' })
+      // The unprotected record went through the normal verified teardown.
+      await expect(fsp.stat(path.join(metadataDir, 'mid-pass-swept.json'))).rejects.toMatchObject({ code: 'ENOENT' })
+    }, 30_000)
+
+    it('routes hold-sink verdicts to held/reaped/retried buckets and unlinks the retry sidecar only on removed-unowned', async () => {
+      const metadataDir = await makeTempDir()
+      const runtimeHeld = createRuntime({ metadataDir, serverInstanceId: 'srv-previous' })
+      const runtimeRemoved = createRuntime({ metadataDir, serverInstanceId: 'srv-previous' })
+      const runtimeKept = createRuntime({ metadataDir, serverInstanceId: 'srv-previous' })
+      const readyHeld = await runtimeHeld.ensureReady()
+      const readyRemoved = await runtimeRemoved.ensureReady()
+      const readyKept = await runtimeKept.ensureReady()
+      await markOwnershipRecordStale(readyHeld.metadataPath)
+      await markOwnershipRecordStale(readyRemoved.metadataPath)
+      await markOwnershipRecordStale(readyKept.metadataPath)
+      // The removed-unowned branch must clear stale retry bookkeeping left from an earlier pass.
+      const staleRetryPath = `${readyRemoved.metadataPath}.reaper.json`
+      await fsp.writeFile(staleRetryPath, JSON.stringify({ firstSeen: new Date().toISOString(), attempts: 1 }), { mode: 0o600 })
+
+      const verdicts = new Map<string, 'held' | 'removed-unowned' | 'kept-unproven'>([
+        [readyHeld.ownershipId, 'held'],
+        [readyRemoved.ownershipId, 'removed-unowned'],
+        [readyKept.ownershipId, 'kept-unproven'],
+      ])
+      const sink: CodexSidecarHoldSink = {
+        // The stub never touches processes or files; the reaper itself must route/report/clean up.
+        hold: async (ownership) => verdicts.get(ownership.metadata.ownershipId) ?? 'kept-unproven',
+      }
+
+      const result = await reapOrphanedCodexAppServerSidecars({
+        metadataDir,
+        serverInstanceId: 'srv-current',
+        terminateGraceMs: 1,
+        holdReconciler: sink,
+      })
+
+      expect(result.heldOwnershipIds).toEqual([readyHeld.ownershipId])
+      expect(result.reapedOwnershipIds).toEqual([readyRemoved.ownershipId])
+      expect(result.retriedOwnershipIds).toEqual([readyKept.ownershipId])
+      expect(result.skippedActiveOwnershipIds).toEqual([])
+      expect(result.failedOwnershipIds).toEqual([])
+      // Verdict routing is the SINK's contract: the reaper only unlinks retry bookkeeping on
+      // removal — the record's own fate (already settled by the sink) is not re-touched.
+      await expect(fsp.stat(staleRetryPath)).rejects.toMatchObject({ code: 'ENOENT' })
+      await expect(fsp.stat(readyRemoved.metadataPath)).resolves.toBeDefined()
+      // kept-unproven retried in place: backoff sidecar recorded, record kept, group alive.
+      const retryState = JSON.parse(await fsp.readFile(`${readyKept.metadataPath}.reaper.json`, 'utf8'))
+      expect(retryState.attempts).toBe(1)
+      for (const ready of [readyHeld, readyRemoved, readyKept]) {
+        await expect(fsp.stat(ready.metadataPath)).resolves.toBeDefined()
+        expect(await isProcessGroupAlive(ready.processGroupId)).toBe(true)
+      }
+    }, 30_000)
   })
 })
 

--- a/test/unit/server/coding-cli/codex-app-server/sidecar-reattach.test.ts
+++ b/test/unit/server/coding-cli/codex-app-server/sidecar-reattach.test.ts
@@ -1,0 +1,1135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import http from 'node:http'
+import { spawn } from 'node:child_process'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  CODEX_REATTACH_PROBE_BUDGET_MS,
+  CodexAppServerRuntime,
+  getCodexSurvivorAttachErrorCode,
+  runCodexStartupReaper,
+  type CodexSidecarOwnershipMetadata,
+  type HeldCodexSidecarOwnership,
+  type ReadyState,
+} from '../../../../../server/coding-cli/codex-app-server/runtime.js'
+import { CodexAppServerClient } from '../../../../../server/coding-cli/codex-app-server/client.js'
+import { CodexLaunchPlanner } from '../../../../../server/coding-cli/codex-app-server/launch-planner.js'
+import { CodexRemoteProxy } from '../../../../../server/coding-cli/codex-app-server/remote-proxy.js'
+import {
+  CODEX_SIDECAR_REAP_GRACE_DEFAULT_MS,
+  CodexSidecarReconciler,
+  resolveCodexSidecarReapGraceMs,
+} from '../../../../../server/coding-cli/codex-app-server/sidecar-reattach.js'
+import type { LoopbackServerEndpoint } from '../../../../../server/local-port.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const FAKE_SERVER_PATH = path.resolve(__dirname, '../../../../fixtures/coding-cli/codex-app-server/fake-app-server.mjs')
+
+// Same load posture as runtime.test.ts: these tests spawn REAL fixture sidecars that must reach
+// `initialize` under fileParallelism CPU starvation, so the per-attempt budget stays generous.
+const REAL_STARTUP_ATTEMPT_TIMEOUT_MS = 5_000
+
+// Polling deadline for helpers that wait on real OS side effects (process exit).
+const WAIT_HELPER_TIMEOUT_MS = 15_000
+
+const runtimes = new Set<CodexAppServerRuntime>()
+const blockers = new Set<http.Server>()
+const tempDirs = new Set<string>()
+// TUI-role clients and remote proxies still tracked by the scenario tests. Both are idempotent
+// to close and safe to re-close after a mid-test failure, so they live in their own registries.
+const tuiClients = new Set<CodexAppServerClient>()
+const launchProxies = new Set<CodexRemoteProxy>()
+let fixtureCodexHome: string
+
+beforeEach(async () => {
+  fixtureCodexHome = path.join(await makeTempDir(), 'codex-home')
+})
+
+async function closeBlocker(server: http.Server): Promise<void> {
+  blockers.delete(server)
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+}
+
+afterEach(async () => {
+  await Promise.all([...tuiClients].map(async (client) => {
+    tuiClients.delete(client)
+    await client.close().catch(() => undefined)
+  }))
+  await Promise.all([...launchProxies].map(async (proxy) => {
+    launchProxies.delete(proxy)
+    await proxy.close().catch(() => undefined)
+  }))
+  await Promise.all([...runtimes].map(async (runtime) => {
+    runtimes.delete(runtime)
+    await runtime.shutdown()
+  }))
+  await Promise.all([...blockers].map((blocker) => closeBlocker(blocker)))
+  await Promise.all([...tempDirs].map(async (dir) => {
+    tempDirs.delete(dir)
+    await fsp.rm(dir, { recursive: true, force: true })
+  }))
+})
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-sidecar-reattach-'))
+  tempDirs.add(dir)
+  return dir
+}
+
+async function occupyLoopbackPort(): Promise<{ blocker: http.Server; endpoint: LoopbackServerEndpoint }> {
+  const blocker = http.createServer((_req, res) => {
+    res.statusCode = 404
+    res.end()
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    blocker.once('error', reject)
+    blocker.listen(0, '127.0.0.1', () => resolve())
+  })
+
+  blockers.add(blocker)
+  const address = blocker.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to occupy loopback port for test')
+  }
+
+  return {
+    blocker,
+    endpoint: {
+      hostname: '127.0.0.1',
+      port: address.port,
+    },
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = WAIT_HELPER_TIMEOUT_MS): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ESRCH') {
+        return
+      }
+      throw error
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+
+  throw new Error(`Timed out waiting for process ${pid} to exit`)
+}
+
+async function isProcessGroupAlive(processGroupId: number): Promise<boolean> {
+  try {
+    process.kill(-processGroupId, 0)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return false
+    throw error
+  }
+}
+
+async function readWrapperIdentityForTest(pid: number) {
+  const [cmdline, cwd, stat] = await Promise.all([
+    fsp.readFile(`/proc/${pid}/cmdline`).catch(() => Buffer.from('')),
+    fsp.readlink(`/proc/${pid}/cwd`).catch(() => null),
+    fsp.readFile(`/proc/${pid}/stat`, 'utf8'),
+  ])
+  const closeParen = stat.lastIndexOf(')')
+  const fields = stat.slice(closeParen + 2).trim().split(/\s+/)
+  const startTimeTicks = Number(fields[19])
+  return {
+    commandLine: cmdline.toString('utf8').split('\0').filter(Boolean),
+    cwd,
+    startTimeTicks: Number.isFinite(startTimeTicks) ? startTimeTicks : null,
+  }
+}
+
+async function getOwnProcessGroupId(): Promise<number> {
+  const stat = await fsp.readFile('/proc/self/stat', 'utf8')
+  const closeParen = stat.lastIndexOf(')')
+  const fields = stat.slice(closeParen + 2).trim().split(/\s+/)
+  return Number(fields[2])
+}
+
+function createRuntime(options: ConstructorParameters<typeof CodexAppServerRuntime>[0] = {}): CodexAppServerRuntime {
+  const runtime = new CodexAppServerRuntime({
+    command: process.execPath,
+    commandArgs: [FAKE_SERVER_PATH],
+    startupAttemptTimeoutMs: REAL_STARTUP_ATTEMPT_TIMEOUT_MS,
+    ...options,
+    env: {
+      CODEX_HOME: fixtureCodexHome,
+      FAKE_CODEX_APP_SERVER_ALLOW_DURABLE_WRITES: '1',
+      ...options.env,
+    },
+  })
+  runtimes.add(runtime)
+  return runtime
+}
+
+// Simulation of an unclean previous-server death that leaves a SURVIVOR sidecar: a real fixture
+// process group is spawned and its authentic ownership record (real wrapper identity plus the
+// Task-1 `sessionId` claim key) is rewritten so its owner fields name a dead pid from a previous
+// server generation whose last write was an hour ago. The spawning runtime is deliberately NEVER
+// shut down by the rig — afterEach teardown stands in for the dead server's missing cleanup.
+async function spawnSurvivingFixture(input: {
+  metadataDir: string
+  loadedThreadIds: string[]
+  claimKey: string
+  delayMethodsMs?: Record<string, number>
+  appendThreadOperationLogPath?: string
+}): Promise<{ ready: ReadyState; held: HeldCodexSidecarOwnership }> {
+  const owner = createRuntime({
+    metadataDir: input.metadataDir,
+    serverInstanceId: 'srv-previous',
+    env: {
+      FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+        loadedThreadIds: input.loadedThreadIds,
+        ...(input.delayMethodsMs ? { delayMethodsMs: input.delayMethodsMs } : {}),
+        ...(input.appendThreadOperationLogPath
+          ? { appendThreadOperationLogPath: input.appendThreadOperationLogPath }
+          : {}),
+      }),
+    },
+  })
+  const ready = await owner.ensureReady()
+  await owner.updateOwnershipMetadata({ sessionId: input.claimKey })
+
+  const staleUpdatedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+  const raw = await fsp.readFile(ready.metadataPath, 'utf8')
+  const stale = {
+    ...(JSON.parse(raw) as CodexSidecarOwnershipMetadata),
+    ownerServerPid: 999_999_999,
+    serverInstanceId: 'srv-previous',
+    updatedAt: staleUpdatedAt,
+  }
+  await fsp.writeFile(ready.metadataPath, `${JSON.stringify(stale, null, 2)}\n`, { mode: 0o600 })
+
+  // Held ownership as a boot reconciler would construct it: from the record read back off disk.
+  const metadata = JSON.parse(await fsp.readFile(ready.metadataPath, 'utf8')) as CodexSidecarOwnershipMetadata
+  return {
+    ready,
+    held: {
+      metadataDir: input.metadataDir,
+      metadataPath: ready.metadataPath,
+      metadata,
+    },
+  }
+}
+
+const describeWithLinuxProc = process.platform === 'linux' ? describe : describe.skip
+
+describeWithLinuxProc('CodexAppServerRuntime.attachToSurvivingSidecar', () => {
+  it('attaches a fresh runtime to a surviving sidecar, retitling its ownership record', async () => {
+    const metadataDir = await makeTempDir()
+    const { ready: survivorReady, held } = await spawnSurvivingFixture({
+      metadataDir,
+      loadedThreadIds: ['thr-1'],
+      claimKey: 'thr-1',
+    })
+    const attachRuntime = createRuntime({ metadataDir, serverInstanceId: 'srv-current' })
+
+    const ready = await attachRuntime.attachToSurvivingSidecar(held, { sessionId: 'thr-1' })
+
+    // The ReadyState names the SURVIVOR's still-running incarnation — no fresh spawn occurred.
+    expect(ready.wsUrl).toBe(survivorReady.wsUrl)
+    expect(ready.processPid).toBe(survivorReady.processPid)
+    expect(ready.processGroupId).toBe(survivorReady.processGroupId)
+    expect(ready.ownershipId).toBe(survivorReady.ownershipId)
+    expect(ready.metadataPath).toBe(survivorReady.metadataPath)
+    expect(ready.codexHome).toBe(survivorReady.codexHome)
+    expect(attachRuntime.status()).toBe('running')
+
+    // A later ensureReady returns the attached state instead of spawning a new sidecar.
+    const again = await attachRuntime.ensureReady()
+    expect(again.processPid).toBe(survivorReady.processPid)
+    expect(again.wsUrl).toBe(survivorReady.wsUrl)
+
+    // The record on disk was retitled to THIS server process with a fresh complete owner
+    // identity; the claim key and the survivor's own identity fields are preserved.
+    const retitled = JSON.parse(await fsp.readFile(survivorReady.metadataPath, 'utf8'))
+    expect(retitled.ownerServerPid).toBe(process.pid)
+    expect(retitled.ownerServerIdentity).toEqual(await readWrapperIdentityForTest(process.pid))
+    expect(Date.parse(retitled.updatedAt)).toBeGreaterThan(Date.parse(held.metadata.updatedAt))
+    expect(retitled.sessionId).toBe('thr-1')
+    expect(retitled.wrapperPid).toBe(survivorReady.processPid)
+    expect(retitled.processGroupId).toBe(survivorReady.processGroupId)
+    expect(retitled.wsUrl).toBe(survivorReady.wsUrl)
+    expect(retitled.ownershipId).toBe(survivorReady.ownershipId)
+
+    // The attaching runtime owns the survivor now: shutdown tears the group down (the
+    // conservative ownership-verified path) and unlinks the record.
+    await attachRuntime.shutdown()
+    await waitForProcessExit(survivorReady.processPid)
+    expect(await isProcessGroupAlive(survivorReady.processGroupId)).toBe(false)
+    await expect(fsp.stat(survivorReady.metadataPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('refuses attach when the survivor group is gone, without signaling an unrelated live group', async () => {
+    const metadataDir = await makeTempDir()
+
+    // A short-lived REAL fixture child: capture its authentic wrapper identity, then let it exit
+    // so the record's process group classifies as `gone`.
+    const child = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 50)'], {
+      detached: true,
+      stdio: 'ignore',
+    })
+    const deadPid = child.pid
+    if (!deadPid) throw new Error('fixture child did not expose a pid')
+    const deadWrapperIdentity = await readWrapperIdentityForTest(deadPid)
+    await new Promise<void>((resolve, reject) => {
+      child.once('exit', () => resolve())
+      child.once('error', reject)
+    })
+    await waitForProcessExit(deadPid)
+
+    const now = new Date().toISOString()
+    const metadataPath = path.join(metadataDir, 'gone-sidecar.json')
+    const metadata: CodexSidecarOwnershipMetadata = {
+      schemaVersion: 1,
+      ownershipId: 'gone-sidecar',
+      serverInstanceId: 'srv-previous',
+      ownerServerPid: 999_999_999,
+      terminalId: null,
+      generation: null,
+      wsUrl: 'ws://127.0.0.1:1',
+      wrapperPid: deadPid,
+      processGroupId: deadPid,
+      wrapperIdentity: deadWrapperIdentity,
+      createdAt: now,
+      updatedAt: now,
+      sessionId: 'thr-gone',
+    }
+    await fsp.writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, { mode: 0o600 })
+
+    // Safety control: a still-live fixture sidecar that shares nothing with the dead record.
+    const control = createRuntime({ metadataDir, serverInstanceId: 'srv-control' })
+    const controlReady = await control.ensureReady()
+
+    const attachRuntime = createRuntime({ metadataDir, serverInstanceId: 'srv-current' })
+    const error = await attachRuntime.attachToSurvivingSidecar(
+      { metadataDir, metadataPath, metadata },
+      { sessionId: 'thr-gone' },
+    ).catch((caught: unknown) => caught)
+
+    expect(getCodexSurvivorAttachErrorCode(error)).toBe('codex_survivor_identity')
+    // Disposal belongs to the reconciler's settler, not the runtime: the record stays on disk.
+    await expect(fsp.stat(metadataPath)).resolves.toBeDefined()
+    // Nothing was signaled: the unrelated live group is untouched.
+    expect(await isProcessGroupAlive(controlReady.processGroupId)).toBe(true)
+    expect(attachRuntime.status()).toBe('stopped')
+  })
+
+  it('fails unreachable when the recorded listener does not answer the probe, inside the shared deadline', async () => {
+    const metadataDir = await makeTempDir()
+    const { ready: survivorReady, held } = await spawnSurvivingFixture({
+      metadataDir,
+      loadedThreadIds: ['thr-1'],
+      claimKey: 'thr-1',
+    })
+    // TCP accepts but the codex protocol never answers: the probe cannot succeed.
+    const { endpoint } = await occupyLoopbackPort()
+    const rerouted: HeldCodexSidecarOwnership = {
+      ...held,
+      metadata: { ...held.metadata, wsUrl: `ws://${endpoint.hostname}:${endpoint.port}` },
+    }
+    const attachRuntime = createRuntime({ metadataDir, serverInstanceId: 'srv-current' })
+
+    const startedAt = Date.now()
+    const error = await attachRuntime.attachToSurvivingSidecar(rerouted, { sessionId: 'thr-1' })
+      .catch((caught: unknown) => caught)
+    const elapsedMs = Date.now() - startedAt
+
+    expect(getCodexSurvivorAttachErrorCode(error)).toBe('codex_survivor_unreachable')
+    // The whole attach stays inside the single shared probe deadline (never two stacked budgets).
+    expect(elapsedMs).toBeLessThan(CODEX_REATTACH_PROBE_BUDGET_MS * 1.5)
+    // The survivor is never signaled and its record is NOT retitled.
+    expect(await isProcessGroupAlive(survivorReady.processGroupId)).toBe(true)
+    const record = JSON.parse(await fsp.readFile(survivorReady.metadataPath, 'utf8'))
+    expect(record.ownerServerPid).toBe(999_999_999)
+    expect(record.updatedAt).toBe(held.metadata.updatedAt)
+    expect(attachRuntime.status()).toBe('stopped')
+  })
+
+  it('fails at ~the SINGLE shared deadline when both probes answer slowly, never ~two stacked budgets', async () => {
+    // M1 pin (runtime.ts withProbeBudget + `probeDeadlineMs - Date.now()` handoff): each probe
+    // races only the REMAINING slice of one shared deadline. With per-probe stacked budgets the
+    // attaches below would either take ~2x the budget or SUCCEED — both fail these assertions.
+    const delayCases: Array<Record<string, number>> = [
+      // initialize consumes ~2.5s of the 3s deadline; the list probe's ~0.5s remainder expires
+      // against a 2.5s fixture delay.
+      { initialize: 2_500, 'thread/loaded/list': 2_500 },
+      // Symmetric: the list WOULD answer (~3.5s) inside a fresh stacked second budget; the shared
+      // deadline must cut it off at ~3s because initialize alone ate nearly the whole budget.
+      { initialize: 2_500, 'thread/loaded/list': 1_000 },
+    ]
+
+    for (const delayMethodsMs of delayCases) {
+      const metadataDir = await makeTempDir()
+      const { ready: survivorReady, held } = await spawnSurvivingFixture({
+        metadataDir,
+        loadedThreadIds: ['thr-slow'],
+        claimKey: 'thr-slow',
+        delayMethodsMs,
+      })
+      const attachRuntime = createRuntime({ metadataDir, serverInstanceId: 'srv-current' })
+
+      const startedAt = Date.now()
+      const error = await attachRuntime.attachToSurvivingSidecar(held, { sessionId: 'thr-slow' })
+        .catch((caught: unknown) => caught)
+      const elapsedMs = Date.now() - startedAt
+
+      expect(getCodexSurvivorAttachErrorCode(error)).toBe('codex_survivor_unreachable')
+      // The deadline governed: the attach ran to ≈ CODEX_REATTACH_PROBE_BUDGET_MS total …
+      expect(elapsedMs).toBeGreaterThanOrEqual(CODEX_REATTACH_PROBE_BUDGET_MS * 0.9)
+      // … and did NOT take two stacked budgets (~6s) — same 1.5x real-clock tolerance as test 3.
+      expect(elapsedMs).toBeLessThan(CODEX_REATTACH_PROBE_BUDGET_MS * 1.5)
+      // N1: the timeout message names both the expired remaining slice and the CONFIGURED total.
+      expect((error as Error).message).toContain(`of the ${CODEX_REATTACH_PROBE_BUDGET_MS}ms reattach probe budget`)
+      // The survivor is never signaled even when its probes time out.
+      expect(await isProcessGroupAlive(survivorReady.processGroupId)).toBe(true)
+      expect(attachRuntime.status()).toBe('stopped')
+    }
+  })
+
+  it('keeps a reachable survivor that is not the thread writer, without retitling its record', async () => {
+    const metadataDir = await makeTempDir()
+    const { ready: survivorReady, held } = await spawnSurvivingFixture({
+      metadataDir,
+      loadedThreadIds: ['thr-other'],
+      claimKey: 'thr-other',
+    })
+    const attachRuntime = createRuntime({ metadataDir, serverInstanceId: 'srv-current' })
+
+    const error = await attachRuntime.attachToSurvivingSidecar(held, { sessionId: 'thr-live' })
+      .catch((caught: unknown) => caught)
+
+    expect(getCodexSurvivorAttachErrorCode(error)).toBe('codex_survivor_not_writer')
+    // The survivor is kept alive — it may be the writer of another key's thread.
+    expect(await isProcessGroupAlive(survivorReady.processGroupId)).toBe(true)
+    // Its record was NOT retitled: the stale dead-owner fields are unchanged on disk.
+    const record = JSON.parse(await fsp.readFile(survivorReady.metadataPath, 'utf8'))
+    expect(record.ownerServerPid).toBe(999_999_999)
+    expect(record.ownerServerIdentity).toEqual(held.metadata.ownerServerIdentity)
+    expect(record.updatedAt).toBe(held.metadata.updatedAt)
+    expect(attachRuntime.status()).toBe('stopped')
+  })
+})
+
+// --- Task 3: CodexSidecarReconciler (boot hold + grace-gated sweep) ---
+
+// Raw detached fixture children used as lightweight survivor process groups for the reconciler
+// unit tests. afterEach kills only what these tests spawned (pgid-targeted).
+const rawChildren = new Set<number>()
+
+async function spawnRawSurvivingChild(): Promise<{ pid: number; identity: CodexSidecarOwnershipMetadata['wrapperIdentity'] }> {
+  const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 30000)'], {
+    detached: true,
+    stdio: 'ignore',
+  })
+  child.unref()
+  const pid = child.pid
+  if (!pid) throw new Error('raw fixture child did not expose a pid')
+  rawChildren.add(pid)
+  const identity = await readWrapperIdentityForTest(pid)
+  return { pid, identity: identity as CodexSidecarOwnershipMetadata['wrapperIdentity'] }
+}
+
+async function spawnShortLivedChild(): Promise<{ pid: number; identity: CodexSidecarOwnershipMetadata['wrapperIdentity'] }> {
+  const child = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 50)'], {
+    detached: true,
+    stdio: 'ignore',
+  })
+  const pid = child.pid
+  if (!pid) throw new Error('short-lived fixture child did not expose a pid')
+  const identity = await readWrapperIdentityForTest(pid)
+  await new Promise<void>((resolve, reject) => {
+    child.once('exit', () => resolve())
+    child.once('error', reject)
+  })
+  await waitForProcessExit(pid)
+  return { pid, identity: identity as CodexSidecarOwnershipMetadata['wrapperIdentity'] }
+}
+
+afterEach(async () => {
+  await Promise.all([...rawChildren].map(async (pid) => {
+    rawChildren.delete(pid)
+    try {
+      process.kill(-pid, 'SIGKILL')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error
+    }
+    await waitForProcessExit(pid).catch(() => undefined)
+  }))
+})
+
+function buildHeldRecord(overrides: Record<string, unknown> = {}): CodexSidecarOwnershipMetadata {
+  const now = new Date().toISOString()
+  return {
+    schemaVersion: 1,
+    ownershipId: `held-${Math.random().toString(36).slice(2)}`,
+    serverInstanceId: 'srv-previous',
+    ownerServerPid: 999_999_999,
+    terminalId: null,
+    generation: null,
+    wsUrl: 'ws://127.0.0.1:1',
+    wrapperPid: 999_999_998,
+    processGroupId: 999_999_997,
+    wrapperIdentity: { commandLine: ['codex'], cwd: '/tmp', startTimeTicks: 1 },
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  } as CodexSidecarOwnershipMetadata
+}
+
+async function writeHeldRecord(
+  metadataDir: string,
+  metadata: CodexSidecarOwnershipMetadata,
+): Promise<HeldCodexSidecarOwnership> {
+  const metadataPath = path.join(metadataDir, `${metadata.ownershipId}.json`)
+  await fsp.writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, { mode: 0o600 })
+  return { metadataDir, metadataPath, metadata }
+}
+
+function createReconcilerLog() {
+  return { info: vi.fn(), warn: vi.fn() }
+}
+
+describeWithLinuxProc('CodexSidecarReconciler hold verdicts', () => {
+  it('holds a verified-owned survivor claimable by its session id, leaving the group and record in place', async () => {
+    const metadataDir = await makeTempDir()
+    const { pid, identity } = await spawnRawSurvivingChild()
+    const metadata = buildHeldRecord({
+      ownershipId: 'hold-owned',
+      wrapperPid: pid,
+      processGroupId: pid,
+      wrapperIdentity: identity,
+      sessionId: 'thr-owned',
+    })
+    const ownership = await writeHeldRecord(metadataDir, metadata)
+    const log = createReconcilerLog()
+    const reconciler = new CodexSidecarReconciler({ log })
+
+    const verdict = await reconciler.hold(ownership)
+
+    expect(verdict).toBe('held')
+    // The survivor is never signaled by the hold: the group stays alive and its record stays.
+    expect(await isProcessGroupAlive(pid)).toBe(true)
+    await expect(fsp.stat(ownership.metadataPath)).resolves.toBeDefined()
+    expect(reconciler.snapshot()).toMatchObject({ held: 1, claimableSessions: 1, inFlightClaims: 0 })
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({ ownershipId: 'hold-owned', sessionId: 'thr-owned', wsUrl: metadata.wsUrl }),
+      expect.any(String),
+    )
+    const claimed = reconciler.claimForSession('thr-owned')
+    expect(claimed?.metadata.ownershipId).toBe('hold-owned')
+  })
+
+  it('removes a record whose process group is gone without signaling, returning removed-unowned', async () => {
+    const metadataDir = await makeTempDir()
+    const { pid, identity } = await spawnShortLivedChild()
+    const metadata = buildHeldRecord({
+      ownershipId: 'hold-gone',
+      wrapperPid: pid,
+      processGroupId: pid,
+      wrapperIdentity: identity,
+      sessionId: 'thr-gone',
+    })
+    const ownership = await writeHeldRecord(metadataDir, metadata)
+    const reconciler = new CodexSidecarReconciler({ log: createReconcilerLog() })
+
+    const verdict = await reconciler.hold(ownership)
+
+    expect(verdict).toBe('removed-unowned')
+    await expect(fsp.stat(ownership.metadataPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    // Nothing was indexed: the record is gone from disk and from the reconciler's maps.
+    expect(reconciler.snapshot()).toMatchObject({ held: 0, claimableSessions: 0, inFlightClaims: 0 })
+    expect(reconciler.claimForSession('thr-gone')).toBeNull()
+  })
+
+  it('refuses a record pointing at the test process own group, keeping the file (kept-unproven)', async () => {
+    const metadataDir = await makeTempDir()
+    const selfGroupId = await getOwnProcessGroupId()
+    const metadata = buildHeldRecord({
+      ownershipId: 'hold-self',
+      wrapperPid: process.pid,
+      processGroupId: selfGroupId,
+      wrapperIdentity: await readWrapperIdentityForTest(process.pid),
+      sessionId: 'thr-self',
+    })
+    const ownership = await writeHeldRecord(metadataDir, metadata)
+    const reconciler = new CodexSidecarReconciler({ log: createReconcilerLog() })
+
+    const verdict = await reconciler.hold(ownership)
+
+    expect(verdict).toBe('kept-unproven')
+    // Refusal keeps the record on disk and indexes nothing.
+    await expect(fsp.stat(ownership.metadataPath)).resolves.toBeDefined()
+    expect(reconciler.snapshot()).toMatchObject({ held: 0, claimableSessions: 0, inFlightClaims: 0 })
+    expect(reconciler.claimForSession('thr-self')).toBeNull()
+  })
+
+  it('holds a record without a session id as held but not claimable', async () => {
+    const metadataDir = await makeTempDir()
+    const { pid, identity } = await spawnRawSurvivingChild()
+    const metadata = buildHeldRecord({
+      ownershipId: 'hold-no-session',
+      wrapperPid: pid,
+      processGroupId: pid,
+      wrapperIdentity: identity,
+    })
+    const ownership = await writeHeldRecord(metadataDir, metadata)
+    const reconciler = new CodexSidecarReconciler({ log: createReconcilerLog() })
+
+    const verdict = await reconciler.hold(ownership)
+
+    expect(verdict).toBe('held')
+    expect(reconciler.snapshot()).toMatchObject({ held: 1, claimableSessions: 0, inFlightClaims: 0 })
+    expect(reconciler.claimForSession('thr-anything')).toBeNull()
+  })
+
+  it('re-holding the same ownershipId keeps its session index single (review Nit 3)', async () => {
+    const metadataDir = await makeTempDir()
+    const { pid, identity } = await spawnRawSurvivingChild()
+    const ownership = await writeHeldRecord(metadataDir, buildHeldRecord({
+      ownershipId: 'hold-twice',
+      wrapperPid: pid,
+      processGroupId: pid,
+      wrapperIdentity: identity,
+      sessionId: 'thr-twice',
+    }))
+    const reconciler = new CodexSidecarReconciler({ log: createReconcilerLog() })
+    expect(await reconciler.hold(ownership)).toBe('held')
+    // The boot reaper offers each record exactly once, but a re-hold must never double-index.
+    expect(await reconciler.hold(ownership)).toBe('held')
+    expect(reconciler.snapshot()).toMatchObject({ held: 1, claimableSessions: 1, inFlightClaims: 0 })
+
+    // One claim consumes the single index entry; a duplicated entry would be claimed (and
+    // counted in-flight) a second time here.
+    expect(reconciler.claimForSession('thr-twice')?.metadata.ownershipId).toBe('hold-twice')
+    expect(reconciler.claimForSession('thr-twice')).toBeNull()
+    expect(reconciler.snapshot()).toMatchObject({ held: 1, claimableSessions: 0, inFlightClaims: 1 })
+  })
+})
+
+describeWithLinuxProc('CodexSidecarReconciler claims', () => {
+  it('claims a held survivor exactly once per session id, newest-updatedAt first', async () => {
+    const metadataDir = await makeTempDir()
+    const older = await spawnRawSurvivingChild()
+    const newer = await spawnRawSurvivingChild()
+    const olderOwnership = await writeHeldRecord(metadataDir, buildHeldRecord({
+      ownershipId: 'claim-older',
+      wrapperPid: older.pid,
+      processGroupId: older.pid,
+      wrapperIdentity: older.identity,
+      sessionId: 'thr-shared',
+      updatedAt: new Date(Date.now() - 60_000).toISOString(),
+    }))
+    const newerOwnership = await writeHeldRecord(metadataDir, buildHeldRecord({
+      ownershipId: 'claim-newer',
+      wrapperPid: newer.pid,
+      processGroupId: newer.pid,
+      wrapperIdentity: newer.identity,
+      sessionId: 'thr-shared',
+    }))
+    const reconciler = new CodexSidecarReconciler({ log: createReconcilerLog() })
+    expect(await reconciler.hold(olderOwnership)).toBe('held')
+    expect(await reconciler.hold(newerOwnership)).toBe('held')
+
+    const first = reconciler.claimForSession('thr-shared')
+    expect(first?.metadata.ownershipId).toBe('claim-newer')
+    expect(reconciler.snapshot()).toMatchObject({ held: 2, claimableSessions: 1, inFlightClaims: 1 })
+    const second = reconciler.claimForSession('thr-shared')
+    expect(second?.metadata.ownershipId).toBe('claim-older')
+    // Both claims are consumed and in flight: the session key has no claimable candidate left.
+    expect(reconciler.claimForSession('thr-shared')).toBeNull()
+    expect(reconciler.snapshot()).toMatchObject({ held: 2, claimableSessions: 0, inFlightClaims: 2 })
+  })
+})
+
+describeWithLinuxProc('CodexSidecarReconciler settleFailedClaim', () => {
+  it('settles a codex_survivor_unreachable failure by reaping the verified group and unlinked record', async () => {
+    const metadataDir = await makeTempDir()
+    const { pid, identity } = await spawnRawSurvivingChild()
+    const metadata = buildHeldRecord({
+      ownershipId: 'settle-unreachable',
+      wrapperPid: pid,
+      processGroupId: pid,
+      wrapperIdentity: identity,
+      sessionId: 'thr-unreachable',
+    })
+    const ownership = await writeHeldRecord(metadataDir, metadata)
+    const reconciler = new CodexSidecarReconciler({ log: createReconcilerLog() })
+    expect(await reconciler.hold(ownership)).toBe('held')
+    const claimed = reconciler.claimForSession('thr-unreachable')
+    expect(claimed).not.toBeNull()
+
+    await reconciler.settleFailedClaim(claimed!, 'codex_survivor_unreachable')
+
+    // The verified-but-unusable survivor is conservatively reaped and unlinked (da92 parity).
+    expect(await isProcessGroupAlive(pid)).toBe(false)
+    await expect(fsp.stat(ownership.metadataPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(reconciler.snapshot()).toMatchObject({ held: 0, claimableSessions: 0, inFlightClaims: 0 })
+  })
+
+  it('settles a codex_survivor_identity failure on a dead survivor by unlinking its record WITHOUT signaling', async () => {
+    const metadataDir = await makeTempDir()
+    const { pid, identity } = await spawnRawSurvivingChild()
+    const metadata = buildHeldRecord({
+      ownershipId: 'settle-identity-gone',
+      wrapperPid: pid,
+      processGroupId: pid,
+      wrapperIdentity: identity,
+      sessionId: 'thr-identity',
+    })
+    const ownership = await writeHeldRecord(metadataDir, metadata)
+    const log = createReconcilerLog()
+    const reconciler = new CodexSidecarReconciler({ log })
+    expect(await reconciler.hold(ownership)).toBe('held')
+    const claimed = reconciler.claimForSession('thr-identity')
+    expect(claimed).not.toBeNull()
+    // Pre-settle state: held + in-flight, file on disk — so the drain below is non-vacuous.
+    expect(reconciler.snapshot()).toMatchObject({ held: 1, claimableSessions: 0, inFlightClaims: 1 })
+    await expect(fsp.stat(ownership.metadataPath)).resolves.toBeDefined()
+
+    // The survivor dies between claim and settle. At settle time the record's process
+    // classification is NOT 'owned' (the group resolves 'gone') — the same record shape the
+    // runtime codes codex_survivor_identity on and pointedly leaves on disk (see "refuses attach
+    // when the survivor group is gone" above; disposal is the settler's job).
+    process.kill(-pid, 'SIGKILL')
+    await waitForProcessExit(pid)
+    rawChildren.delete(pid) // already dead and reaped; afterEach must never signal a reused pgid
+    expect(await isProcessGroupAlive(pid)).toBe(false)
+
+    // The conservative verdict pins NO signal delivery: a 'gone' group is unlinked without being
+    // signaled. Spy installed AFTER the rig's own SIGKILL so only the settle itself is observed.
+    const originalKill = process.kill
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((killPid: number, signal?: NodeJS.Signals | number) =>
+      originalKill(killPid, signal as any)) as typeof process.kill)
+    try {
+      await reconciler.settleFailedClaim(claimed!, 'codex_survivor_identity')
+    } finally {
+      killSpy.mockRestore()
+    }
+
+    // Not one real signal was aimed at the dead group (signal 0 liveness probes excluded).
+    expect(killSpy.mock.calls.filter(([killPid, signal]) => killPid === -pid && signal !== 0)).toEqual([])
+    // The dead record is unlinked from disk …
+    await expect(fsp.stat(ownership.metadataPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    // … through the silent-success 'gone' verdict: no refusal/throw warn fired.
+    expect(log.warn).not.toHaveBeenCalled()
+    // … and dropClaim bookkeeping ran: nothing held, claimable, in-flight, or sweep-protected.
+    expect(reconciler.claimForSession('thr-identity')).toBeNull()
+    expect(reconciler.snapshot()).toMatchObject({ held: 0, claimableSessions: 0, inFlightClaims: 0 })
+    expect(reconciler.sweepProtectionSet()).toEqual(new Set())
+  })
+
+  it('settles a codex_survivor_not_writer failure by keeping the survivor alive and held', async () => {
+    const metadataDir = await makeTempDir()
+    const { pid, identity } = await spawnRawSurvivingChild()
+    const metadata = buildHeldRecord({
+      ownershipId: 'settle-not-writer',
+      wrapperPid: pid,
+      processGroupId: pid,
+      wrapperIdentity: identity,
+      sessionId: 'thr-not-writer',
+    })
+    const ownership = await writeHeldRecord(metadataDir, metadata)
+    const reconciler = new CodexSidecarReconciler({ log: createReconcilerLog() })
+    expect(await reconciler.hold(ownership)).toBe('held')
+    const claimed = reconciler.claimForSession('thr-not-writer')
+    expect(claimed).not.toBeNull()
+
+    await reconciler.settleFailedClaim(claimed!, 'codex_survivor_not_writer')
+
+    // The sidecar may be the writer of another thread: it stays alive, held, and un-signaled …
+    expect(await isProcessGroupAlive(pid)).toBe(true)
+    await expect(fsp.stat(ownership.metadataPath)).resolves.toBeDefined()
+    expect(reconciler.snapshot()).toMatchObject({ held: 1, claimableSessions: 0, inFlightClaims: 0 })
+    // … but its claim was consumed: it never re-enters this session index.
+    expect(reconciler.claimForSession('thr-not-writer')).toBeNull()
+  })
+
+  it('never throws when the survivor teardown throws; the claim leaves held and in-flight (review F2)', async () => {
+    const metadataDir = await makeTempDir()
+    const { pid, identity } = await spawnRawSurvivingChild()
+    const metadata = buildHeldRecord({
+      ownershipId: 'settle-teardown-throws',
+      wrapperPid: pid,
+      processGroupId: pid,
+      wrapperIdentity: identity,
+      sessionId: 'thr-teardown-throws',
+    })
+    const ownership = await writeHeldRecord(metadataDir, metadata)
+    const log = createReconcilerLog()
+    const reconciler = new CodexSidecarReconciler({ log })
+    expect(await reconciler.hold(ownership)).toBe('held')
+    const claimed = reconciler.claimForSession('thr-teardown-throws')
+    expect(claimed).not.toBeNull()
+
+    // Force the ownership-gated teardown to throw through the same process.kill seam the reaper
+    // tests use ("isolates process-group signaling failures…"): a throwing settle must still
+    // resolve and finish its bookkeeping instead of stranding the candidate in-flight.
+    const originalKill = process.kill
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((killPid: number, signal?: NodeJS.Signals | number) => {
+      if (killPid === -pid && signal === 'SIGTERM') {
+        const error = new Error('simulated SIGTERM failure') as NodeJS.ErrnoException
+        error.code = 'EPERM'
+        throw error
+      }
+      return originalKill(killPid, signal as any)
+    }) as typeof process.kill)
+
+    try {
+      await expect(reconciler.settleFailedClaim(claimed!, 'codex_survivor_unreachable')).resolves.toBeUndefined()
+    } finally {
+      killSpy.mockRestore()
+    }
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ ownershipId: 'settle-teardown-throws', code: 'codex_survivor_unreachable' }),
+      expect.any(String),
+    )
+    // dropClaim-equivalent bookkeeping ran despite the throw: the id is neither held nor in-flight,
+    // so sweepProtectionSet can never protect a stranded claim. The record stays on disk (the
+    // throw happened AT the signal), where the hourly reaper retries it.
+    expect(reconciler.snapshot()).toMatchObject({ held: 0, claimableSessions: 0, inFlightClaims: 0 })
+    expect(reconciler.sweepProtectionSet()).toEqual(new Set())
+    expect(await isProcessGroupAlive(pid)).toBe(true)
+    await expect(fsp.stat(ownership.metadataPath)).resolves.toBeDefined()
+  })
+})
+
+describeWithLinuxProc('CodexSidecarReconciler sweep protection and grace', () => {
+  it('protects held ids plus in-flight claims before expiry and only in-flight claims after', async () => {
+    let now = 1_000_000
+    const metadataDir = await makeTempDir()
+    const claimed = await spawnRawSurvivingChild()
+    const idle = await spawnRawSurvivingChild()
+    const claimedOwnership = await writeHeldRecord(metadataDir, buildHeldRecord({
+      ownershipId: 'sweep-claimed',
+      wrapperPid: claimed.pid,
+      processGroupId: claimed.pid,
+      wrapperIdentity: claimed.identity,
+      sessionId: 'thr-sweep',
+    }))
+    const idleOwnership = await writeHeldRecord(metadataDir, buildHeldRecord({
+      ownershipId: 'sweep-idle',
+      wrapperPid: idle.pid,
+      processGroupId: idle.pid,
+      wrapperIdentity: idle.identity,
+    }))
+    const reconciler = new CodexSidecarReconciler({
+      reapGraceMs: 30_000,
+      nowFn: () => now,
+      log: createReconcilerLog(),
+    })
+    expect(await reconciler.hold(claimedOwnership)).toBe('held')
+    expect(await reconciler.hold(idleOwnership)).toBe('held')
+
+    expect(reconciler.hasExpired()).toBe(false)
+    expect(reconciler.claimForSession('thr-sweep')?.metadata.ownershipId).toBe('sweep-claimed')
+    // Before expiry the reaper must skip everything the reconciler knows about.
+    expect(reconciler.sweepProtectionSet()).toEqual(new Set(['sweep-claimed', 'sweep-idle']))
+
+    now += 30_000
+    expect(reconciler.hasExpired()).toBe(true)
+    // After expiry only the in-flight claim stays protected: an attacher must never be swept.
+    expect(reconciler.sweepProtectionSet()).toEqual(new Set(['sweep-claimed']))
+
+    reconciler.dropClaim('sweep-claimed')
+    expect(reconciler.sweepProtectionSet()).toEqual(new Set())
+    expect(reconciler.snapshot()).toMatchObject({ held: 1, claimableSessions: 0, inFlightClaims: 0 })
+  })
+
+  it('forget drops ids another actor removed from disk across every reconciler map', async () => {
+    const metadataDir = await makeTempDir()
+    const { pid, identity } = await spawnRawSurvivingChild()
+    const ownership = await writeHeldRecord(metadataDir, buildHeldRecord({
+      ownershipId: 'forget-me',
+      wrapperPid: pid,
+      processGroupId: pid,
+      wrapperIdentity: identity,
+      sessionId: 'thr-forget',
+    }))
+    let now = 2_000_000
+    const reconciler = new CodexSidecarReconciler({ nowFn: () => now, log: createReconcilerLog() })
+    expect(await reconciler.hold(ownership)).toBe('held')
+
+    reconciler.forget(['forget-me'])
+
+    expect(reconciler.snapshot()).toMatchObject({ held: 0, claimableSessions: 0, inFlightClaims: 0 })
+    expect(reconciler.claimForSession('thr-forget')).toBeNull()
+    expect(reconciler.sweepProtectionSet()).toEqual(new Set())
+    now += Number.MAX_SAFE_INTEGER
+    expect(reconciler.sweepProtectionSet()).toEqual(new Set())
+  })
+})
+
+describe('resolveCodexSidecarReapGraceMs', () => {
+  it('parses undefined to the default, honors 0, and warns into the default on garbage', () => {
+    expect(CODEX_SIDECAR_REAP_GRACE_DEFAULT_MS).toBe(30 * 60 * 1000)
+    const log = createReconcilerLog()
+
+    expect(resolveCodexSidecarReapGraceMs(undefined)).toBe(CODEX_SIDECAR_REAP_GRACE_DEFAULT_MS)
+    expect(resolveCodexSidecarReapGraceMs('0', log)).toBe(0)
+    expect(log.warn).not.toHaveBeenCalled()
+    expect(resolveCodexSidecarReapGraceMs('90000', log)).toBe(90_000)
+    expect(log.warn).not.toHaveBeenCalled()
+    expect(resolveCodexSidecarReapGraceMs('nonsense', log)).toBe(CODEX_SIDECAR_REAP_GRACE_DEFAULT_MS)
+    expect(log.warn).toHaveBeenCalledTimes(1)
+    expect(resolveCodexSidecarReapGraceMs('-5', log)).toBe(CODEX_SIDECAR_REAP_GRACE_DEFAULT_MS)
+    expect(log.warn).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back to the default with a warn on digit strings that overflow a safe integer (review Nit 2)', () => {
+    const log = createReconcilerLog()
+    // A 400-digit string parses to Infinity; without the safe-integer guard hasExpired() would be
+    // permanently false and the sweep would silently never run.
+    expect(resolveCodexSidecarReapGraceMs('9'.repeat(400), log)).toBe(CODEX_SIDECAR_REAP_GRACE_DEFAULT_MS)
+    expect(log.warn).toHaveBeenCalledTimes(1)
+    expect(log.warn).toHaveBeenCalledWith({ raw: '9'.repeat(400) }, expect.any(String))
+    // 2^53+1 in digits loses precision on parse (not a safe integer); MAX_SAFE_INTEGER itself is
+    // still honored literally.
+    expect(resolveCodexSidecarReapGraceMs('9007199254740993', log)).toBe(CODEX_SIDECAR_REAP_GRACE_DEFAULT_MS)
+    expect(log.warn).toHaveBeenCalledTimes(2)
+    expect(resolveCodexSidecarReapGraceMs(String(Number.MAX_SAFE_INTEGER), log)).toBe(Number.MAX_SAFE_INTEGER)
+    expect(log.warn).toHaveBeenCalledTimes(2)
+  })
+})
+
+// --- Task 5: three-scenario restore-reattach proof at the planner+runtime layer ---
+
+// A TUI-role client: what the codex TUI does against the plan's remote proxy (initialize, then
+// thread/resume). Tracked so a mid-test failure never leaks an open socket.
+function connectTuiClient(wsUrl: string): CodexAppServerClient {
+  const client = new CodexAppServerClient({ wsUrl })
+  tuiClients.add(client)
+  return client
+}
+
+// Planner proxyFactory that hands the REAL CodexRemoteProxy to the plan while keeping a handle
+// for afterEach cleanup (proxies listen on real loopback ports).
+function trackedProxyFactory(options: ConstructorParameters<typeof CodexRemoteProxy>[0]): CodexRemoteProxy {
+  const proxy = new CodexRemoteProxy(options)
+  launchProxies.add(proxy)
+  return proxy
+}
+
+type FixtureThreadOperation = {
+  method: string
+  threadId: string | null
+  listenUrl: string
+  at: string
+  params?: Record<string, unknown>
+}
+
+// The fixture appends one JSONL entry per served thread/* op, each stamped with the SERVING
+// sidecar's own --listen URL. An ENOENT log means the fixture received zero thread ops — that is
+// itself the readable "no resume ever landed here" signal (the negative-control run leans on it).
+async function readThreadOperationLog(logPath: string): Promise<FixtureThreadOperation[]> {
+  const raw = await fsp.readFile(logPath, 'utf8').catch((error: NodeJS.ErrnoException) => {
+    if (error.code === 'ENOENT') return ''
+    throw error
+  })
+  return raw
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as FixtureThreadOperation)
+}
+
+describeWithLinuxProc('restore-reattach scenarios at the planner+runtime layer (kata 4g2a, da92 parity)', () => {
+  it('scenario 1: a resume-keyed restore claims the surviving sidecar and the TUI resume is served by it', async () => {
+    const metadataDir = await makeTempDir()
+    const logsDir = await makeTempDir()
+    const spawnCwd = await makeTempDir()
+    const logA = path.join(logsDir, 'fixture-a-thread-ops.jsonl')
+    const freshArgLog = path.join(logsDir, 'fresh-spawn-argv.json')
+    const freshOpLog = path.join(logsDir, 'fresh-spawn-thread-ops.jsonl')
+
+    // Unclean-death stand-in: fixture A survives with an authentic record retitled to a dead
+    // owner from a previous server generation, carrying the thr-A claim key.
+    const { ready: survivorReady } = await spawnSurvivingFixture({
+      metadataDir,
+      loadedThreadIds: ['thr-A'],
+      claimKey: 'thr-A',
+      appendThreadOperationLogPath: logA,
+    })
+    const survivorStartTimeTicks = (await readWrapperIdentityForTest(survivorReady.processPid)).startTimeTicks
+
+    // Boot reconcile: A is HELD claimable (the pre-feature reaper would have killed it here).
+    const reconciler = new CodexSidecarReconciler({ log: createReconcilerLog() })
+    const boot = await runCodexStartupReaper({
+      serverInstanceId: 'srv-current',
+      metadataDir,
+      holdReconciler: reconciler,
+    })
+    expect(boot.heldOwnershipIds).toEqual([survivorReady.ownershipId])
+    expect(await isProcessGroupAlive(survivorReady.processGroupId)).toBe(true)
+    expect(reconciler.snapshot()).toMatchObject({ held: 1, claimableSessions: 1, inFlightClaims: 0 })
+
+    // Same wiring the server's restore path takes (serverInstanceId/current); the env below is
+    // only ever consumed if the claim silently fails and a fresh spawn runs instead.
+    const planner = new CodexLaunchPlanner(() => createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          loadedThreadIds: ['thr-A'],
+          appendThreadOperationLogPath: freshOpLog,
+        }),
+        FAKE_CODEX_APP_SERVER_ARG_LOG: freshArgLog,
+      },
+    }), {
+      reconciler,
+      proxyFactory: trackedProxyFactory,
+    })
+
+    const plan = await planner.planCreate({ cwd: spawnCwd, resumeSessionId: 'thr-A' })
+    expect(plan.sessionId).toBe('thr-A')
+
+    // Play the TUI through the plan's remote proxy.
+    const tui = connectTuiClient(plan.remote.wsUrl)
+    await tui.initialize()
+    const resume = await tui.resumeThread({ threadId: 'thr-A' })
+    expect(resume.threadId).toBe('thr-A')
+
+    // Decisive reattach evidence: A's op log records the resume, stamped with A's OWN listener —
+    // the request was served by the surviving sidecar, not by a fresh incarnation.
+    const opsA = await readThreadOperationLog(logA)
+    expect(opsA.filter((op) => op.method === 'thread/loaded/list').map((op) => op.listenUrl))
+      .toEqual([survivorReady.wsUrl])
+    const resumes = opsA.filter((op) => op.method === 'thread/resume')
+    expect(resumes).toHaveLength(1)
+    expect(resumes[0]).toMatchObject({ threadId: 'thr-A', listenUrl: survivorReady.wsUrl })
+
+    // No fresh spawn ever ran: the claim path minted a runtime but never spawned through it.
+    await expect(fsp.stat(freshArgLog)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(await readThreadOperationLog(freshOpLog)).toEqual([])
+
+    // A is alive in the SAME incarnation (identical /proc start time — pid-reuse is excluded).
+    process.kill(survivorReady.processPid, 0)
+    expect((await readWrapperIdentityForTest(survivorReady.processPid)).startTimeTicks)
+      .toBe(survivorStartTimeTicks)
+
+    // adopt() retitles the record to the new terminal identity of this server generation.
+    await plan.sidecar.adopt({ terminalId: 't-1', generation: 0 })
+    const retitled = JSON.parse(await fsp.readFile(survivorReady.metadataPath, 'utf8'))
+    expect(retitled.terminalId).toBe('t-1')
+    expect(retitled.generation).toBe(0)
+    expect(retitled.ownerServerPid).toBe(process.pid)
+
+    // The claim was one-shot: thr-A has nothing left to claim.
+    expect(reconciler.claimForSession('thr-A')).toBeNull()
+    expect(reconciler.snapshot()).toMatchObject({ held: 0, claimableSessions: 0, inFlightClaims: 0 })
+
+    await plan.sidecar.shutdown()
+  })
+
+  it('scenario 2: an empty survivor store falls back to a byte-compatible fresh spawn', async () => {
+    const metadataDir = await makeTempDir()
+    const logsDir = await makeTempDir()
+    const spawnCwd = await makeTempDir()
+    const logB = path.join(logsDir, 'fixture-b-thread-ops.jsonl')
+    const argLogB = path.join(logsDir, 'fixture-b-argv.json')
+
+    // Same wiring as scenario 1 but the store holds nothing: claimForSession returns null and the
+    // planner takes the pre-feature spawn path unchanged.
+    const reconciler = new CodexSidecarReconciler({ log: createReconcilerLog() })
+    const planner = new CodexLaunchPlanner(() => createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          loadedThreadIds: ['thr-B'],
+          appendThreadOperationLogPath: logB,
+        }),
+        FAKE_CODEX_APP_SERVER_ARG_LOG: argLogB,
+      },
+    }), {
+      reconciler,
+      proxyFactory: trackedProxyFactory,
+    })
+
+    const plan = await planner.planCreate({ cwd: spawnCwd, resumeSessionId: 'thr-B' })
+    expect(plan.sessionId).toBe('thr-B')
+
+    const tui = connectTuiClient(plan.remote.wsUrl)
+    await tui.initialize()
+    const resume = await tui.resumeThread({ threadId: 'thr-B' })
+    expect(resume.threadId).toBe('thr-B')
+
+    // A fresh ownership record materialized with the Task-1 session stamp, owned by THIS server.
+    const recordFiles = (await fsp.readdir(metadataDir)).filter((entry) => entry.endsWith('.json'))
+    expect(recordFiles).toHaveLength(1)
+    const record = JSON.parse(
+      await fsp.readFile(path.join(metadataDir, recordFiles[0]), 'utf8'),
+    ) as CodexSidecarOwnershipMetadata
+    expect(record.sessionId).toBe('thr-B')
+    expect(record.ownerServerPid).toBe(process.pid)
+
+    // The fresh spawn itself served the resume (its own listener, matching its record).
+    const opsB = await readThreadOperationLog(logB)
+    const resumes = opsB.filter((op) => op.method === 'thread/resume')
+    expect(resumes).toHaveLength(1)
+    expect(resumes[0]).toMatchObject({ threadId: 'thr-B', listenUrl: record.wsUrl })
+
+    // Spawn argv integrity: the managed remote config args and `app-server --listen` shape are
+    // byte-identical to the pre-feature spawn path.
+    const argLog = JSON.parse(await fsp.readFile(argLogB, 'utf8')) as { argv: string[] }
+    const listenIndex = argLog.argv.indexOf('--listen')
+    expect(argLog.argv).toContain('-c')
+    expect(argLog.argv).toContain('features.apps=false')
+    expect(argLog.argv).toContain('app-server')
+    expect(listenIndex).toBeGreaterThanOrEqual(0)
+    expect(argLog.argv[listenIndex + 1]).toBe(record.wsUrl)
+
+    await plan.sidecar.shutdown()
+  })
+
+  it('scenario 3: the active-writer -32600 collision stays confined to the fresh-spawn path', async () => {
+    const metadataDir = await makeTempDir()
+    const spawnCwd = await makeTempDir()
+
+    // Fixture C stands in for a SECOND sidecar that adopted the thread: its scripted override is
+    // the exact -32600 the real app-server returns when a thread already has an active writer.
+    // Together with scenario 1 this pins the da92 asymmetry: the SAME resume succeeds against a
+    // claimed survivor and is rejected only on the fresh path.
+    const reconciler = new CodexSidecarReconciler({ log: createReconcilerLog() })
+    const planner = new CodexLaunchPlanner(() => createRuntime({
+      metadataDir,
+      serverInstanceId: 'srv-current',
+      env: {
+        FAKE_CODEX_APP_SERVER_BEHAVIOR: JSON.stringify({
+          overrides: {
+            'thread/resume': {
+              error: { code: -32600, message: 'thread already has an active writer' },
+            },
+          },
+        }),
+      },
+    }), {
+      reconciler,
+      proxyFactory: trackedProxyFactory,
+    })
+
+    const plan = await planner.planCreate({ cwd: spawnCwd, resumeSessionId: 'thr-C' })
+    expect(plan.sessionId).toBe('thr-C')
+
+    const tui = connectTuiClient(plan.remote.wsUrl)
+    await tui.initialize()
+    const error = await tui.resumeThread({ threadId: 'thr-C' }).catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as { code?: unknown }).code).toBe(-32600)
+    expect((error as Error).message).toContain('thread already has an active writer')
+
+    await plan.sidecar.shutdown()
+  })
+})

--- a/test/unit/server/coding-cli/codex-observability.test.ts
+++ b/test/unit/server/coding-cli/codex-observability.test.ts
@@ -16,6 +16,9 @@ import {
   runCodexReaperMaintenanceTick,
   startCodexObservability,
 } from '../../../../server/coding-cli/codex-observability.js'
+import {
+  CodexSidecarReconciler,
+} from '../../../../server/coding-cli/codex-app-server/sidecar-reattach.js'
 
 const tempDirs = new Set<string>()
 
@@ -396,6 +399,231 @@ describeWithLinuxProc('codex-observability reaper maintenance tick', () => {
       log: createLogSpy(),
     })).resolves.toBeUndefined()
   })
+})
+
+// Task 3 sweep gating: the reconciler's held survivors drive whether the tick re-runs the reaper
+// (and which ids it must skip). Raw detached fixture children play the surviving sidecar groups.
+describeWithLinuxProc('codex-observability reaper maintenance tick reconciler sweep gating', () => {
+  const sweptChildren = new Set<number>()
+
+  afterEach(async () => {
+    await Promise.all([...sweptChildren].map(async (pid) => {
+      sweptChildren.delete(pid)
+      try {
+        process.kill(-pid, 'SIGKILL')
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error
+      }
+      await waitForProcessExit(pid).catch(() => undefined)
+    }))
+  })
+
+  async function waitForProcessExit(pid: number, timeoutMs = 15_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      try {
+        process.kill(pid, 0)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ESRCH') return
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+    throw new Error(`Timed out waiting for process ${pid} to exit`)
+  }
+
+  async function isProcessGroupAlive(processGroupId: number): Promise<boolean> {
+    try {
+      process.kill(-processGroupId, 0)
+      return true
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ESRCH') return false
+      throw error
+    }
+  }
+
+  function buildExpired(): CodexSidecarReconciler {
+    return new CodexSidecarReconciler({ reapGraceMs: 0 })
+  }
+
+  // A raw detached fixture child stands in for a surviving sidecar group: its pgid is its own pid
+  // and its authentic /proc identity slots straight into a dead-owner ownership record.
+  async function spawnSweepFixtureChild(): Promise<{ pid: number; identity: Record<string, unknown> }> {
+    const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 30000)'], {
+      detached: true,
+      stdio: 'ignore',
+    })
+    child.unref()
+    const pid = child.pid
+    if (!pid) throw new Error('sweep fixture child did not expose a pid')
+    sweptChildren.add(pid)
+    const [cmdline, cwd, stat] = await Promise.all([
+      fsp.readFile(`/proc/${pid}/cmdline`).catch(() => Buffer.from('')),
+      fsp.readlink(`/proc/${pid}/cwd`).catch(() => null),
+      fsp.readFile(`/proc/${pid}/stat`, 'utf8'),
+    ])
+    const closeParen = stat.lastIndexOf(')')
+    const fields = stat.slice(closeParen + 2).trim().split(/\s+/)
+    const startTimeTicks = Number(fields[19])
+    return {
+      pid,
+      identity: {
+        commandLine: cmdline.toString('utf8').split('\0').filter(Boolean),
+        cwd,
+        startTimeTicks: Number.isFinite(startTimeTicks) ? startTimeTicks : null,
+      },
+    }
+  }
+
+  it('sweeps unclaimed survivors once the grace window expires and forgets the reaped ids', async () => {
+    const metadataDir = await makeTempDir()
+    const { pid, identity } = await spawnSweepFixtureChild()
+    const recordPath = path.join(metadataDir, 'obs-swept.json')
+    await fsp.writeFile(recordPath, JSON.stringify(buildValidOwnershipRecord({
+      ownershipId: 'obs-swept',
+      wrapperPid: pid,
+      processGroupId: pid,
+      wrapperIdentity: identity,
+      sessionId: 'thr-swept',
+    })), { mode: 0o600 })
+    const reconciler = buildExpired()
+    const metadata = JSON.parse(await fsp.readFile(recordPath, 'utf8'))
+    await reconciler.hold({ metadataDir, metadataPath: recordPath, metadata })
+    expect(reconciler.snapshot()).toMatchObject({ held: 1, claimableSessions: 1, inFlightClaims: 0 })
+    expect(reconciler.hasExpired()).toBe(true)
+
+    await runCodexReaperMaintenanceTick({ serverInstanceId: 'srv-tick', metadataDir, terminateGraceMs: 1, reconciler })
+
+    // Expired and unclaimed: the reaper runs with the id OUTSIDE skipOwnershipIds — full teardown.
+    expect(await isProcessGroupAlive(pid)).toBe(false)
+    await expect(fsp.stat(recordPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    // forget(result.reapedOwnershipIds) pruned every map, claimable-session index included.
+    expect(reconciler.snapshot()).toMatchObject({ held: 0, claimableSessions: 0, inFlightClaims: 0 })
+    expect(reconciler.claimForSession('thr-swept')).toBeNull()
+  })
+
+  it('passes held ids into skipOwnershipIds while the grace window has not expired', async () => {
+    const metadataDir = await makeTempDir()
+    const protectedChild = await spawnSweepFixtureChild()
+    const protectedPath = path.join(metadataDir, 'obs-protected.json')
+    await fsp.writeFile(protectedPath, JSON.stringify(buildValidOwnershipRecord({
+      ownershipId: 'obs-protected',
+      wrapperPid: protectedChild.pid,
+      processGroupId: protectedChild.pid,
+      wrapperIdentity: protectedChild.identity,
+      sessionId: 'thr-protected',
+    })), { mode: 0o600 })
+    // Control: an unprotected dead-owner record in the same dir proves the tick DID run the
+    // reaper — the protected survivor's survival is the skip set, not a skipped tick.
+    const controlChild = await spawnSweepFixtureChild()
+    const controlPath = path.join(metadataDir, 'obs-control.json')
+    await fsp.writeFile(controlPath, JSON.stringify(buildValidOwnershipRecord({
+      ownershipId: 'obs-control',
+      wrapperPid: controlChild.pid,
+      processGroupId: controlChild.pid,
+      wrapperIdentity: controlChild.identity,
+    })), { mode: 0o600 })
+    const reconciler = new CodexSidecarReconciler() // default grace: far from expiring
+    const protectedMetadata = JSON.parse(await fsp.readFile(protectedPath, 'utf8'))
+    await reconciler.hold({ metadataDir, metadataPath: protectedPath, metadata: protectedMetadata })
+    expect(reconciler.hasExpired()).toBe(false)
+
+    await runCodexReaperMaintenanceTick({ serverInstanceId: 'srv-tick', metadataDir, terminateGraceMs: 1, reconciler })
+
+    // The reaper ran (the control record is reaped) but the held id was skipped.
+    expect(await isProcessGroupAlive(controlChild.pid)).toBe(false)
+    await expect(fsp.stat(controlPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(await isProcessGroupAlive(protectedChild.pid)).toBe(true)
+    await expect(fsp.stat(protectedPath)).resolves.toBeDefined()
+    // …and no retry bookkeeping was written for the skipped id (it was never attempted).
+    await expect(fsp.stat(`${protectedPath}.reaper.json`)).rejects.toMatchObject({ code: 'ENOENT' })
+    // The reconciler still holds the survivor claimable afterwards.
+    expect(reconciler.snapshot()).toMatchObject({ held: 1, claimableSessions: 1, inFlightClaims: 0 })
+    expect(reconciler.claimForSession('thr-protected')?.metadata.ownershipId).toBe('obs-protected')
+  }, 20_000)
+
+  it('skips the reaper entirely when no retries are due and the reconciler grace has not expired', async () => {
+    const metadataDir = await makeTempDir()
+    const { pid, identity } = await spawnSweepFixtureChild()
+    const recordPath = path.join(metadataDir, 'obs-live-owner.json')
+    await fsp.writeFile(recordPath, JSON.stringify(buildValidOwnershipRecord({
+      ownershipId: 'obs-live-owner-not-due',
+      ownerServerPid: process.pid, // owner alive: not due, so only sweepDue could fire this tick
+      wrapperPid: pid,
+      processGroupId: pid,
+      wrapperIdentity: identity,
+    })), { mode: 0o600 })
+    const reconciler = new CodexSidecarReconciler()
+    const metadata = JSON.parse(await fsp.readFile(recordPath, 'utf8'))
+    await reconciler.hold({ metadataDir, metadataPath: recordPath, metadata })
+    expect(reconciler.hasExpired()).toBe(false)
+
+    await runCodexReaperMaintenanceTick({ serverInstanceId: 'srv-tick', metadataDir, terminateGraceMs: 1, reconciler })
+
+    // The tick early-returned: the reaper never ran, so it never wrote retry bookkeeping for the
+    // alive-but-unproven owner record (a running reaper would have retried it in place).
+    await expect(fsp.stat(`${recordPath}.reaper.json`)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fsp.stat(recordPath)).resolves.toBeDefined()
+    expect(await isProcessGroupAlive(pid)).toBe(true)
+    expect(reconciler.snapshot()).toMatchObject({ held: 1, claimableSessions: 0, inFlightClaims: 0 })
+  })
+
+  it('hands the reaper a per-record skip-set function, so a claim landing mid-pass is honored (review Minor 1)', async () => {
+    const metadataDir = await makeTempDir()
+    // An EXPIRED reconciler holding two survivors; both records are scanned in one reaper pass.
+    const claimedChild = await spawnSweepFixtureChild()
+    const claimedPath = path.join(metadataDir, 'obs-late-claim.json')
+    await fsp.writeFile(claimedPath, JSON.stringify(buildValidOwnershipRecord({
+      ownershipId: 'obs-late-claim',
+      wrapperPid: claimedChild.pid,
+      processGroupId: claimedChild.pid,
+      wrapperIdentity: claimedChild.identity,
+      sessionId: 'thr-late-claim',
+    })), { mode: 0o600 })
+    const sweptChild = await spawnSweepFixtureChild()
+    const sweptPath = path.join(metadataDir, 'obs-mid-pass-swept.json')
+    await fsp.writeFile(sweptPath, JSON.stringify(buildValidOwnershipRecord({
+      ownershipId: 'obs-mid-pass-swept',
+      wrapperPid: sweptChild.pid,
+      processGroupId: sweptChild.pid,
+      wrapperIdentity: sweptChild.identity,
+    })), { mode: 0o600 })
+    const reconciler = buildExpired()
+    for (const recordPath of [claimedPath, sweptPath]) {
+      const metadata = JSON.parse(await fsp.readFile(recordPath, 'utf8'))
+      expect(await reconciler.hold({ metadataDir, metadataPath: recordPath, metadata })).toBe('held')
+    }
+    expect(reconciler.snapshot()).toMatchObject({ held: 2, claimableSessions: 1, inFlightClaims: 0 })
+
+    // The claim lands while the pass is already scanning: the first per-record consultation
+    // performs it, and every record checked afterwards sees the id in-flight. A pass-start
+    // snapshot would consult the set exactly once for the whole pass.
+    const original = reconciler.sweepProtectionSet.bind(reconciler)
+    let claimLanded = false
+    const spy = vi.spyOn(reconciler, 'sweepProtectionSet').mockImplementation(() => {
+      if (!claimLanded) {
+        claimLanded = true
+        expect(reconciler.claimForSession('thr-late-claim')?.metadata.ownershipId).toBe('obs-late-claim')
+      }
+      return original()
+    })
+
+    await runCodexReaperMaintenanceTick({ serverInstanceId: 'srv-tick', metadataDir, terminateGraceMs: 1, reconciler })
+
+    // Per-record re-query: more than one consultation for a two-record pass.
+    expect(claimLanded).toBe(true)
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(2)
+    // The claimed survivor was protected from every check after its claim landed: no signal, no
+    // retry bookkeeping, record kept.
+    expect(await isProcessGroupAlive(claimedChild.pid)).toBe(true)
+    await expect(fsp.stat(claimedPath)).resolves.toBeDefined()
+    await expect(fsp.stat(`${claimedPath}.reaper.json`)).rejects.toMatchObject({ code: 'ENOENT' })
+    // …while the unclaimed expired record was swept and then forgotten by the reconciler.
+    expect(await isProcessGroupAlive(sweptChild.pid)).toBe(false)
+    await expect(fsp.stat(sweptPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(reconciler.snapshot()).toMatchObject({ held: 1, claimableSessions: 0, inFlightClaims: 1 })
+    expect(reconciler.sweepProtectionSet()).toEqual(new Set(['obs-late-claim']))
+  }, 20_000)
 })
 
 describeWithLinuxProc('codex-observability lifecycle', () => {

--- a/test/unit/server/terminal-registry.codex-sidecar.test.ts
+++ b/test/unit/server/terminal-registry.codex-sidecar.test.ts
@@ -92,6 +92,7 @@ function createFakeSidecar(options: {
     adopt: vi.fn(options.adopt ?? (async () => undefined)),
     shutdown: vi.fn(options.shutdown ?? (async () => undefined)),
     markCandidatePersisted: vi.fn(),
+    noteSessionId: vi.fn(async (_sessionId: string) => undefined),
     pauseCandidateCapture: vi.fn(),
     resumeCandidateCapture: vi.fn(),
     watchPath: vi.fn(async (targetPath: string) => ({ path: targetPath })),
@@ -264,6 +265,45 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
 
       expect(registry.input(term.terminalId, 'hello\r')).toEqual({ status: 'written' })
       expect(mockPtyProcess.instances[0].write).toHaveBeenCalledWith('hello\r')
+    } finally {
+      await removeTempDir(durabilityDir)
+    }
+  })
+
+  it('stamps the captured candidate thread id onto the sidecar ownership record via noteSessionId', async () => {
+    const durabilityDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-durability-'))
+    try {
+      const registry = new TerminalRegistry(undefined, undefined, undefined, {
+        codexDurabilityStore: new CodexDurabilityStore({ dir: durabilityDir }),
+        serverInstanceId: 'srv-test',
+      })
+      const sidecar = createFakeSidecar()
+      const term = registry.create({
+        mode: 'codex',
+        envContext: { tabId: 'tab-1', paneId: 'pane-1' },
+        providerSettings: {
+          codexAppServer: {
+            wsUrl: 'ws://127.0.0.1:43123',
+            sidecar,
+          },
+        } as any,
+      })
+
+      sidecar.emitCandidate({
+        source: 'thread_started_notification',
+        thread: {
+          id: '019e2a0c-7cef-7281-94df-d0d05d7b9ac3',
+          path: '/home/user/.codex/sessions/2026/05/14/rollout.jsonl',
+          ephemeral: false,
+        },
+      })
+
+      await vi.waitFor(() => expect(sidecar.noteSessionId).toHaveBeenCalledTimes(1))
+      expect(sidecar.noteSessionId).toHaveBeenCalledWith('019e2a0c-7cef-7281-94df-d0d05d7b9ac3')
+      // The stamp lands with the persisted durability identity, not before it.
+      expect(registry.get(term.terminalId)!.codexDurability).toMatchObject({
+        candidate: { candidateThreadId: '019e2a0c-7cef-7281-94df-d0d05d7b9ac3' },
+      })
     } finally {
       await removeTempDir(durabilityDir)
     }
@@ -994,6 +1034,54 @@ describe('TerminalRegistry Codex sidecar ownership', () => {
         sessionRef: { provider: 'codex', sessionId: 'thread-child' },
       }))
       expect(unboundEvents).toEqual([])
+    } finally {
+      await removeTempDir(durabilityDir)
+    }
+  })
+
+  it('stamps the fork handoff candidate thread id onto the sidecar ownership record via noteSessionId', async () => {
+    const durabilityDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-codex-durability-'))
+    try {
+      const store = new CodexDurabilityStore({ dir: durabilityDir })
+      const registry = new TerminalRegistry(undefined, undefined, undefined, {
+        codexDurabilityStore: store,
+        serverInstanceId: 'srv-test',
+      })
+      const sidecar = createFakeSidecar()
+      const term = registry.create({
+        mode: 'codex',
+        resumeSessionId: 'thread-parent',
+        providerSettings: {
+          codexAppServer: {
+            wsUrl: 'ws://127.0.0.1:43123',
+            sidecar,
+          },
+        } as any,
+      })
+      await store.write({
+        schemaVersion: CODEX_DURABILITY_SCHEMA_VERSION,
+        state: 'durable',
+        durableThreadId: 'thread-parent',
+        terminalId: term.terminalId,
+        serverInstanceId: 'srv-test',
+        updatedAt: 100,
+      })
+
+      sidecar.emitCandidate({
+        source: 'thread_fork_response',
+        thread: {
+          id: 'thread-child',
+          path: path.join(durabilityDir, 'fork-child.jsonl'),
+          ephemeral: false,
+        },
+      })
+
+      await vi.waitFor(() => expect(sidecar.noteSessionId).toHaveBeenCalledTimes(1))
+      expect(sidecar.noteSessionId).toHaveBeenCalledWith('thread-child')
+      expect((registry.get(term.terminalId) as any).codexForkHandoff).toMatchObject({
+        state: 'fork_handoff_staged',
+        candidate: { candidateThreadId: 'thread-child' },
+      })
     } finally {
       await removeTempDir(durabilityDir)
     }


### PR DESCRIPTION
Darkforge job 4g2a landing commit (single squashed change with full plan in the commit message). On Node server restart after an unexpected exit, codex pane restores reattach to surviving prior-generation sidecars instead of spawning duplicates — parity with the Rust lane, implemented independently in TypeScript. Full repo QA gate (darkforge qa) accepted at this exact SHA; two independent review loops passed.