### PR TITLE
fix(cloud-run): pin entrypoint mode via COPY --chmod=755

### DIFF
--- a/docker/cloud-run/Dockerfile
+++ b/docker/cloud-run/Dockerfile
@@ -126,9 +126,13 @@ COPY . .
 ENV FRESHELL_E2E_RUST_SERVER_BIN=/app/target/release/freshell-server
 
 # Copy the entrypoint script (after COPY . . so it's not overwritten by
-# a stale copy in the source tree).
-COPY docker/cloud-run/entrypoint.sh /usr/local/bin/e2e-entrypoint.sh
-RUN chmod +x /usr/local/bin/e2e-entrypoint.sh
+# a stale copy in the source tree). --chmod=755 is load-bearing: COPY preserves
+# the context file's mode, and a umask-0077 checkout bakes 0700 (no group/other
+# READ). `RUN chmod +x` only ORs execute bits (0700|0111 = 0711), and a script
+# must be READABLE to execute — under USER node (uid 1000) that produced
+# "bash: .../e2e-entrypoint.sh: Permission denied" at container start (the
+# runtime stage below). Mirrors docker/sandbox/Dockerfile's COPY --chmod=755.
+COPY --chmod=755 docker/cloud-run/entrypoint.sh /usr/local/bin/e2e-entrypoint.sh
 
 # Switch to non-root user for runtime (node:22-bookworm provides UID 1000).
 # This is required by server-side tests that verify permission errors

--- a/scripts/test/cloud-run-entrypoint-mode.test.sh
+++ b/scripts/test/cloud-run-entrypoint-mode.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Test: cloud-run entrypoint is usable by the non-root runtime user.
+#
+# BEHAVIORAL regression test for the "Permission denied at container start"
+# failure class. COPY preserves the build-context file's mode, and a
+# umask-0077 checkout bakes docker/cloud-run/entrypoint.sh = 0700 (no
+# group/other READ). A bare 'RUN chmod +x' only ORs execute bits
+# (0700|0111 = 0711), and a script must be READABLE to execute, so images
+# built from such checkouts crashed under USER node with:
+#   bash: /usr/local/bin/e2e-entrypoint.sh: Permission denied
+# The fix pins the mode in the COPY itself (COPY --chmod=755). This test
+# deterministically reproduces the bad source mode (chmod 0700 around the
+# build), builds the ACTUAL Dockerfile, and asserts:
+#   1. the runtime user (node, uid 1000) can read AND execute the entrypoint
+#   2. the container starts through its configured ENTRYPOINT (--dry-run
+#      completes, no Permission denied)
+# It fails against the pre-fix Dockerfile (COPY + 'RUN chmod +x') and passes
+# against the fixed one.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT"
+
+IMAGE_TAG="freshell-entrypoint-mode:test"
+EP="docker/cloud-run/entrypoint.sh"
+DOCKERFILE="docker/cloud-run/Dockerfile"
+IN_CONTAINER_EP="/usr/local/bin/e2e-entrypoint.sh"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "SKIP: docker not available"
+  exit 0
+fi
+
+FAILURES=0
+fail() {
+  echo "FAIL: $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+# --- Reproduce the bad source mode deterministically -----------------------
+# (a fresh git checkout under umask 0077 lands here anyway; forcing it makes
+# the test independent of the invoking shell's umask)
+ORIG_MODE="$(stat -c %a "$EP")"
+restore_mode() { chmod "$ORIG_MODE" "$EP"; }
+trap restore_mode EXIT
+chmod 700 "$EP"
+
+# --- Build the ACTUAL Dockerfile from the restricted context ---------------
+echo "Building $DOCKERFILE with a 0700-entrypoint source (this may take a while on a cold cache)..."
+if ! docker build -f "$DOCKERFILE" -t "$IMAGE_TAG" . >"$SCRIPT_DIR/.entrypoint-mode-build.log" 2>&1; then
+  fail "docker build failed (see $SCRIPT_DIR/.entrypoint-mode-build.log)"
+  tail -30 "$SCRIPT_DIR/.entrypoint-mode-build.log"
+  exit 1
+fi
+echo "PASS: docker build succeeded"
+restore_mode
+trap - EXIT
+
+# --- Check 1: entrypoint readable+executable by the runtime user -----------
+# Runs as the image's USER (node, uid 1000) — exactly the runtime identity.
+if docker run --rm --entrypoint /bin/sh "$IMAGE_TAG" \
+  -c "test -r $IN_CONTAINER_EP && test -x $IN_CONTAINER_EP" >/dev/null 2>&1; then
+  echo "PASS: entrypoint readable AND executable by the non-root runtime user"
+else
+  fail "entrypoint not readable+executable by the non-root runtime user (the 0711 'Permission denied' regression)"
+fi
+
+# --- Check 2: the container starts through its configured ENTRYPOINT -------
+set +e
+RUN_OUT="$(docker run --rm "$IMAGE_TAG" --dry-run 2>&1)"
+RUN_EXIT=$?
+set -e
+if [ "$RUN_EXIT" -eq 0 ] && ! echo "$RUN_OUT" | grep -qi "permission denied"; then
+  echo "PASS: container starts via its configured entrypoint (--dry-run, exit 0)"
+else
+  fail "container failed to start through its configured entrypoint (exit $RUN_EXIT)"
+  echo "$RUN_OUT" | tail -30
+fi
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "=== All checks passed ==="
+  exit 0
+else
+  echo "=== $FAILURES check(s) failed ==="
+  exit 1
+fi

--- a/scripts/test/cloud-run-entrypoint-mode.test.sh
+++ b/scripts/test/cloud-run-entrypoint-mode.test.sh
@@ -9,8 +9,9 @@
 # built from such checkouts crashed under USER node with:
 #   bash: /usr/local/bin/e2e-entrypoint.sh: Permission denied
 # The fix pins the mode in the COPY itself (COPY --chmod=755). This test
-# deterministically reproduces the bad source mode, builds the ACTUAL
-# Dockerfile, and asserts — against the exact image this build produced:
+# builds the ACTUAL Dockerfile from an ISOLATED copy of the working tree
+# with the entrypoint restricted to 0700 in that private copy, and asserts
+# — against the exact image this build produced:
 #   0. the image's configured runtime user is the non-root user (uid 1000)
 #   1. that user can read AND execute the entrypoint
 #   2. the container starts through its configured ENTRYPOINT (--dry-run
@@ -18,13 +19,13 @@
 # It fails against the pre-fix Dockerfile (COPY + 'RUN chmod +x') and passes
 # against the fixed one.
 #
-# Concurrency: the 0700 fixture mutates the shared source file's mode in
-# place, so the chmod→build→restore window is guarded by a per-worktree
-# lock (overlapping invocations would otherwise save/restore modes under
-# each other's builds). Every assertion runs against the built image's
-# IMMUTABLE id (captured via --iidfile), never the mutable tag — tags are
-# shared across worktrees, so a concurrent rebuild could otherwise swap the
-# image between this build and its assertions.
+# Isolation: the fixture never mutates the shared source tree — the context
+# is a disposable copy under mktemp, so there is nothing to restore on
+# success, failure, or cancellation, and concurrent invocations (same or
+# different worktrees) cannot interfere. Every assertion runs against the
+# built image's IMMUTABLE id (captured via --iidfile), never the mutable
+# tag — tags are shared across worktrees, so a concurrent rebuild could
+# otherwise swap the image between this build and its assertions.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -48,32 +49,48 @@ fail() {
 }
 
 WORK="$(mktemp -d)"
-trap 'rm -rf "$WORK"' EXIT
+CTX="$WORK/context"
 IIDFILE="$WORK/image-id"
-BUILD_LOG="$SCRIPT_DIR/.entrypoint-mode-build.log"
-# Per-worktree lock (same realpath -> same lock), outside the repo so it
-# never litters the tree.
-BUILD_LOCK="/tmp/freshell-entrypoint-mode-$(printf %s "$ROOT" | md5sum | cut -d' ' -f1).lock"
+BUILD_LOG="$WORK/build.log"
+trap 'rm -rf "$WORK"' EXIT
 
-# --- Reproduce the bad source mode deterministically, build, restore --------
-# A fresh git checkout under umask 0077 lands at 0700 anyway; forcing it
-# makes the test independent of the invoking shell's umask. The whole
-# chmod→build→restore window is one critical section under the worktree
-# lock, and the build's image id is captured for the assertions below.
-BUILD_STATUS=0
-(
-  flock 9
-  ORIG_MODE="$(stat -c %a "$EP")"
-  chmod 700 "$EP"
-  docker build -f "$DOCKERFILE" --iidfile "$IIDFILE" -t "$IMAGE_TAG" . \
-    >"$BUILD_LOG" 2>&1 || BUILD_STATUS=1
-  chmod "$ORIG_MODE" "$EP"
-  exit "$BUILD_STATUS"
-) 9>"$BUILD_LOCK" || {
-  fail "docker build failed (see $BUILD_LOG)"
+# --- Build the isolated context ---------------------------------------------
+# Full copy of the working tree; the builder still applies the tree's own
+# committed .dockerignore to this directory context, so the excludes here
+# only bound the copy cost. The fixture then restricts the entrypoint in
+# the PRIVATE copy and verifies the mode before building (a setup failure
+# must abort, never silently build the wrong fixture).
+echo "Preparing isolated 0700-entrypoint build context..."
+mkdir -p "$CTX"
+tar -cf - \
+  --exclude=./node_modules \
+  --exclude=./dist \
+  --exclude=./target \
+  --exclude=./.git \
+  --exclude=./.worktrees \
+  --exclude=./coverage \
+  --exclude=./test-results \
+  --exclude=./playwright-report \
+  --exclude=./.env \
+  --exclude=./.env.local \
+  . | tar -xf - -C "$CTX"
+
+chmod 700 "$CTX/$EP"
+FIXTURE_MODE="$(stat -c %a "$CTX/$EP")"
+if [ "$FIXTURE_MODE" != "700" ]; then
+  fail "fixture setup failed: context entrypoint mode is $FIXTURE_MODE, expected 700"
+  exit 1
+fi
+
+# --- Build the ACTUAL Dockerfile from the restricted context ----------------
+echo "Building $DOCKERFILE with a 0700-entrypoint context (this may take a while on a cold cache)..."
+if ! docker build -f "$CTX/$DOCKERFILE" --iidfile "$IIDFILE" -t "$IMAGE_TAG" "$CTX" \
+  >"$BUILD_LOG" 2>&1; then
+  cp "$BUILD_LOG" "$SCRIPT_DIR/.entrypoint-mode-build.log"
+  fail "docker build failed (see $SCRIPT_DIR/.entrypoint-mode-build.log)"
   tail -30 "$BUILD_LOG"
   exit 1
-}
+fi
 echo "PASS: docker build succeeded (mode-0700 entrypoint context)"
 
 if [ ! -s "$IIDFILE" ]; then

--- a/scripts/test/cloud-run-entrypoint-mode.test.sh
+++ b/scripts/test/cloud-run-entrypoint-mode.test.sh
@@ -9,13 +9,22 @@
 # built from such checkouts crashed under USER node with:
 #   bash: /usr/local/bin/e2e-entrypoint.sh: Permission denied
 # The fix pins the mode in the COPY itself (COPY --chmod=755). This test
-# deterministically reproduces the bad source mode (chmod 0700 around the
-# build), builds the ACTUAL Dockerfile, and asserts:
-#   1. the runtime user (node, uid 1000) can read AND execute the entrypoint
+# deterministically reproduces the bad source mode, builds the ACTUAL
+# Dockerfile, and asserts — against the exact image this build produced:
+#   0. the image's configured runtime user is the non-root user (uid 1000)
+#   1. that user can read AND execute the entrypoint
 #   2. the container starts through its configured ENTRYPOINT (--dry-run
 #      completes, no Permission denied)
 # It fails against the pre-fix Dockerfile (COPY + 'RUN chmod +x') and passes
 # against the fixed one.
+#
+# Concurrency: the 0700 fixture mutates the shared source file's mode in
+# place, so the chmod→build→restore window is guarded by a per-worktree
+# lock (overlapping invocations would otherwise save/restore modes under
+# each other's builds). Every assertion runs against the built image's
+# IMMUTABLE id (captured via --iidfile), never the mutable tag — tags are
+# shared across worktrees, so a concurrent rebuild could otherwise swap the
+# image between this build and its assertions.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -38,28 +47,55 @@ fail() {
   FAILURES=$((FAILURES + 1))
 }
 
-# --- Reproduce the bad source mode deterministically -----------------------
-# (a fresh git checkout under umask 0077 lands here anyway; forcing it makes
-# the test independent of the invoking shell's umask)
-ORIG_MODE="$(stat -c %a "$EP")"
-restore_mode() { chmod "$ORIG_MODE" "$EP"; }
-trap restore_mode EXIT
-chmod 700 "$EP"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+IIDFILE="$WORK/image-id"
+BUILD_LOG="$SCRIPT_DIR/.entrypoint-mode-build.log"
+# Per-worktree lock (same realpath -> same lock), outside the repo so it
+# never litters the tree.
+BUILD_LOCK="/tmp/freshell-entrypoint-mode-$(printf %s "$ROOT" | md5sum | cut -d' ' -f1).lock"
 
-# --- Build the ACTUAL Dockerfile from the restricted context ---------------
-echo "Building $DOCKERFILE with a 0700-entrypoint source (this may take a while on a cold cache)..."
-if ! docker build -f "$DOCKERFILE" -t "$IMAGE_TAG" . >"$SCRIPT_DIR/.entrypoint-mode-build.log" 2>&1; then
-  fail "docker build failed (see $SCRIPT_DIR/.entrypoint-mode-build.log)"
-  tail -30 "$SCRIPT_DIR/.entrypoint-mode-build.log"
+# --- Reproduce the bad source mode deterministically, build, restore --------
+# A fresh git checkout under umask 0077 lands at 0700 anyway; forcing it
+# makes the test independent of the invoking shell's umask. The whole
+# chmod→build→restore window is one critical section under the worktree
+# lock, and the build's image id is captured for the assertions below.
+BUILD_STATUS=0
+(
+  flock 9
+  ORIG_MODE="$(stat -c %a "$EP")"
+  chmod 700 "$EP"
+  docker build -f "$DOCKERFILE" --iidfile "$IIDFILE" -t "$IMAGE_TAG" . \
+    >"$BUILD_LOG" 2>&1 || BUILD_STATUS=1
+  chmod "$ORIG_MODE" "$EP"
+  exit "$BUILD_STATUS"
+) 9>"$BUILD_LOCK" || {
+  fail "docker build failed (see $BUILD_LOG)"
+  tail -30 "$BUILD_LOG"
+  exit 1
+}
+echo "PASS: docker build succeeded (mode-0700 entrypoint context)"
+
+if [ ! -s "$IIDFILE" ]; then
+  fail "docker build did not report an image id (--iidfile empty)"
   exit 1
 fi
-echo "PASS: docker build succeeded"
-restore_mode
-trap - EXIT
+IMAGE_ID="$(cat "$IIDFILE")"
 
-# --- Check 1: entrypoint readable+executable by the runtime user -----------
-# Runs as the image's USER (node, uid 1000) — exactly the runtime identity.
-if docker run --rm --entrypoint /bin/sh "$IMAGE_TAG" \
+# --- Check 0: the image's configured runtime user is the non-root user ------
+# No --user override: we assert the identity the image itself configures
+# (USER node -> uid 1000). If the image ever reverted to root, the
+# permission checks below would pass vacuously against a root-owned 0711
+# entrypoint — this check keeps them meaningful.
+RUN_UID="$(docker run --rm --entrypoint /bin/sh "$IMAGE_ID" -c 'id -u' 2>/dev/null || true)"
+if [ "$RUN_UID" = "1000" ]; then
+  echo "PASS: image's configured runtime user is non-root (uid 1000)"
+else
+  fail "image's configured runtime user is not the non-root user (got uid '${RUN_UID:-<run failed>}', expected 1000)"
+fi
+
+# --- Check 1: entrypoint readable+executable by that runtime user -----------
+if docker run --rm --entrypoint /bin/sh "$IMAGE_ID" \
   -c "test -r $IN_CONTAINER_EP && test -x $IN_CONTAINER_EP" >/dev/null 2>&1; then
   echo "PASS: entrypoint readable AND executable by the non-root runtime user"
 else
@@ -68,7 +104,7 @@ fi
 
 # --- Check 2: the container starts through its configured ENTRYPOINT -------
 set +e
-RUN_OUT="$(docker run --rm "$IMAGE_TAG" --dry-run 2>&1)"
+RUN_OUT="$(docker run --rm "$IMAGE_ID" --dry-run 2>&1)"
 RUN_EXIT=$?
 set -e
 if [ "$RUN_EXIT" -eq 0 ] && ! echo "$RUN_OUT" | grep -qi "permission denied"; then

--- a/scripts/test/cloud-vitest-entrypoint.test.sh
+++ b/scripts/test/cloud-vitest-entrypoint.test.sh
@@ -69,14 +69,18 @@ check "Dockerfile contains 'chown' for node ownership" grep -q 'chown.*node' "$D
 # Check 13: Dockerfile sets PLAYWRIGHT_BROWSERS_PATH before the existing install
 check "Dockerfile contains 'PLAYWRIGHT_BROWSERS_PATH'" grep -q 'PLAYWRIGHT_BROWSERS_PATH' "$DOCKERFILE"
 
-# Check 14: USER node comes AFTER RUN chmod (not before)
-# Extract line numbers
-CHMOD_LINE=$(grep -n 'RUN chmod' "$DOCKERFILE" | tail -1 | cut -d: -f1)
+# Check 14: the entrypoint COPY pins the mode explicitly (COPY --chmod=755),
+# and USER node comes AFTER that COPY (not before). COPY --chmod is
+# load-bearing: COPY preserves the context file's mode, and umask-0077
+# checkouts bake 0700 (no group/other READ) — `RUN chmod +x` only ORs
+# execute bits (0700|0111=0711), and a script must be READABLE to execute,
+# so the non-root runtime hit "Permission denied" at container start.
+ENTRYPOINT_COPY_LINE=$(grep -n 'COPY --chmod=755 docker/cloud-run/entrypoint.sh' "$DOCKERFILE" | tail -1 | cut -d: -f1)
 USER_LINE=$(grep -n 'USER node' "$DOCKERFILE" | tail -1 | cut -d: -f1)
-if [ -n "$CHMOD_LINE" ] && [ -n "$USER_LINE" ] && [ "$USER_LINE" -gt "$CHMOD_LINE" ]; then
-  echo "PASS: USER node (line $USER_LINE) is after RUN chmod (line $CHMOD_LINE)"
+if [ -n "$ENTRYPOINT_COPY_LINE" ] && [ -n "$USER_LINE" ] && [ "$USER_LINE" -gt "$ENTRYPOINT_COPY_LINE" ]; then
+  echo "PASS: USER node (line $USER_LINE) is after the --chmod=755 entrypoint COPY (line $ENTRYPOINT_COPY_LINE)"
 else
-  echo "FAIL: USER node (line ${USER_LINE:-N/A}) is not after RUN chmod (line ${CHMOD_LINE:-N/A})"
+  echo "FAIL: USER node (line ${USER_LINE:-N/A}) is not after the --chmod=755 entrypoint COPY (line ${ENTRYPOINT_COPY_LINE:-N/A}) — COPY must pin the entrypoint mode before switching to USER node"
   FAILURES=$((FAILURES + 1))
 fi
 

--- a/scripts/test/cloud-vitest-entrypoint.test.sh
+++ b/scripts/test/cloud-vitest-entrypoint.test.sh
@@ -69,20 +69,11 @@ check "Dockerfile contains 'chown' for node ownership" grep -q 'chown.*node' "$D
 # Check 13: Dockerfile sets PLAYWRIGHT_BROWSERS_PATH before the existing install
 check "Dockerfile contains 'PLAYWRIGHT_BROWSERS_PATH'" grep -q 'PLAYWRIGHT_BROWSERS_PATH' "$DOCKERFILE"
 
-# Check 14: the entrypoint COPY pins the mode explicitly (COPY --chmod=755),
-# and USER node comes AFTER that COPY (not before). COPY --chmod is
-# load-bearing: COPY preserves the context file's mode, and umask-0077
-# checkouts bake 0700 (no group/other READ) — `RUN chmod +x` only ORs
-# execute bits (0700|0111=0711), and a script must be READABLE to execute,
-# so the non-root runtime hit "Permission denied" at container start.
-ENTRYPOINT_COPY_LINE=$(grep -n 'COPY --chmod=755 docker/cloud-run/entrypoint.sh' "$DOCKERFILE" | tail -1 | cut -d: -f1)
-USER_LINE=$(grep -n 'USER node' "$DOCKERFILE" | tail -1 | cut -d: -f1)
-if [ -n "$ENTRYPOINT_COPY_LINE" ] && [ -n "$USER_LINE" ] && [ "$USER_LINE" -gt "$ENTRYPOINT_COPY_LINE" ]; then
-  echo "PASS: USER node (line $USER_LINE) is after the --chmod=755 entrypoint COPY (line $ENTRYPOINT_COPY_LINE)"
-else
-  echo "FAIL: USER node (line ${USER_LINE:-N/A}) is not after the --chmod=755 entrypoint COPY (line ${ENTRYPOINT_COPY_LINE:-N/A}) — COPY must pin the entrypoint mode before switching to USER node"
-  FAILURES=$((FAILURES + 1))
-fi
+# Check 14: moved to the behavioral suite — the entrypoint COPY mode pin is
+# verified by scripts/test/cloud-run-entrypoint-mode.test.sh, which builds
+# the actual Dockerfile from a 0700-entrypoint context and asserts the
+# non-root runtime user can read+execute the entrypoint (a text grep here
+# cannot fail when that behavior breaks).
 
 echo ""
 if [ "$FAILURES" -eq 0 ]; then


### PR DESCRIPTION
## Problem

Cloud Run Job containers for images built from fresh worktrees on umask-0077 machines fail at container start:

```
bash: /usr/local/bin/e2e-entrypoint.sh: Permission denied
```

This made every `base-gate.sh test` run at `origin/main` fail (the base has no green cloud-vitest baseline for the current commit), blocking all work that requires the shared test-coordinator gate.

## Root cause

- `COPY` preserves the build-context file's mode. A `git worktree add` checkout under `umask 0077` bakes `docker/cloud-run/entrypoint.sh` as `0700` (no group/other READ).
- `RUN chmod +x` only ORs execute bits: `0700 | 0111 = 0711` — still no group/other read.
- A script must be READABLE to execute; the container runs as `USER node` (uid 1000, added 2026-08-09), so every such image crashed at start. Before `USER node`, root could read the file, masking the bug.

## Fix

- `docker/cloud-run/Dockerfile`: pin the mode in the COPY itself (`COPY --chmod=755 docker/cloud-run/entrypoint.sh /usr/local/bin/e2e-entrypoint.sh`), mirroring `docker/sandbox/Dockerfile`'s existing idiom; drop the now-redundant `RUN chmod +x`.
- `scripts/test/cloud-run-entrypoint-mode.test.sh` (new): behavioral regression — builds the actual Dockerfile from an isolated disposable context whose entrypoint is 0700, then asserts (a) the image's configured runtime user is uid 1000, (b) that user can read+execute the entrypoint, (c) the container starts through its configured ENTRYPOINT (`--dry-run`, no Permission denied). Assertions pin the built image's immutable `--iidfile` id, not the shared mutable tag.
- `scripts/test/cloud-vitest-entrypoint.test.sh`: remove the text-grep check that pinned the old `RUN chmod` ordering (superseded by the behavioral test).

## Verification

- Red: with the pre-fix Dockerfile the new test reproduces the production failure exactly (`bash: /usr/local/bin/e2e-entrypoint.sh: Permission denied`, exit 126).
- Green: with the fix, all checks pass (uid 1000, readable+executable, `--dry-run` exits 0).
- Full coordinated suite on this branch (cloud vitest 4 shards + local electron): green; coordinator `full-suite=success`.
- Image rebuilt for the fix commit; in-image inspection shows entrypoint `-rwxr-xr-x` root-owned.
- Fresh Eyes independent review (GPT): PASSED after 3 fix iterations (behavioral test replaces grep; iidfile pinning; isolated context fixture).