### PR TITLE
fix(freshagent): durable tracking for freshagent-lane codex sidecars across unclean restarts (wfah)

### DIFF
--- a/crates/freshell-codex/src/launch_lifecycle.rs
+++ b/crates/freshell-codex/src/launch_lifecycle.rs
@@ -1273,6 +1273,7 @@ impl CodexLaunchRuntime for SpawnedCodexAppServerRuntime {
                             created_at: now,
                             updated_at: now,
                             state: SidecarRecordState::Active,
+                            lane: None,
                         };
                         // Write failures are logged LOUDLY, never abort the
                         // launch (the pane-ledger write-failure policy).

--- a/crates/freshell-codex/src/lib.rs
+++ b/crates/freshell-codex/src/lib.rs
@@ -95,7 +95,7 @@ pub use sidecar_reconcile::{
 #[cfg(feature = "real-transport")]
 pub use sidecar_store::{
     proc_cmdline, proc_starttime, set_codex_sidecar_store, verify_sidecar_identity,
-    CodexSidecarRecord, CodexSidecarStore, IdentityVerdict, SidecarRecordState,
+    CodexSidecarRecord, CodexSidecarStore, IdentityVerdict, SidecarLane, SidecarRecordState,
     SIDECAR_RECORD_VERSION,
 };
 #[cfg(feature = "real-transport")]

--- a/crates/freshell-codex/src/sidecar_reconcile.rs
+++ b/crates/freshell-codex/src/sidecar_reconcile.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use crate::app_server::{BoxFuture, CodexAppServerClient};
 use crate::launch_lifecycle::{CodexLaunchRuntime, CodexRuntimeReady};
 use crate::sidecar_store::{
-    verify_sidecar_identity, CodexSidecarRecord, CodexSidecarStore, IdentityVerdict,
+    verify_sidecar_identity, CodexSidecarRecord, CodexSidecarStore, IdentityVerdict, SidecarLane,
     SidecarRecordState,
 };
 use crate::sidecar_sweep::kill_verified_sidecar_tree;
@@ -124,9 +124,11 @@ impl SidecarReconciler {
                 IdentityVerdict::Verified | IdentityVerdict::Unverifiable => {
                     // Verified with a session id is claimable via the index;
                     // Verified without one and Unverifiable are held for the
-                    // sweep only.
-                    let claimable =
-                        verdict == IdentityVerdict::Verified && record.session_id.is_some();
+                    // sweep only. freshagent-lane records are sweep-only:
+                    // they are never claimed by terminal-pane restores (wfah).
+                    let claimable = verdict == IdentityVerdict::Verified
+                        && record.session_id.is_some()
+                        && record.lane != Some(SidecarLane::FreshAgent);
                     if claimable {
                         by_session
                             .entry(record.session_id.clone().expect("claimable has a session"))

--- a/crates/freshell-codex/src/sidecar_reconcile_tests.rs
+++ b/crates/freshell-codex/src/sidecar_reconcile_tests.rs
@@ -29,7 +29,7 @@
 use std::sync::Arc;
 
 use super::*;
-use crate::sidecar_store::CodexSidecarRecord;
+use crate::sidecar_store::{proc_cmdline, proc_starttime, CodexSidecarRecord};
 use crate::sidecar_test_support::{
     record_for_child, spawn_own_fake_app_server, spawn_own_fake_app_server_with_behavior,
     spawn_own_sleep_child, store_in, NEVER_SIGNALLED_GRACE, SESSION,
@@ -339,6 +339,58 @@ async fn duplicate_claim_prefers_the_live_writer_over_newer_updated_at() {
         .kill()
         .await
         .expect("cleanup: kill this test's own fixture");
+}
+
+/// wfah: a `lane:"freshAgent"` row carrying valid live identity evidence and a
+/// session id must be HELD (sweep fate) but NEVER indexed/claimable —
+/// terminal-pane restores must not adopt fresh-agent-lane sidecars.
+#[tokio::test]
+async fn boot_reconcile_never_indexes_freshagent_lane_records_for_claim() {
+    let child = spawn_own_sleep_child();
+    let pid = child.0.id();
+    let dir = tempfile::tempdir().expect("temp store root");
+    let store = store_in(&dir);
+    // Hand-written row, exactly as a previous freshagent generation will have
+    // written it. serde ignores unknown fields — including today's missing
+    // `lane` — so RED sees the row as claimable terminal-pane state.
+    std::fs::write(
+        dir.path().join("codex-sidecar-freshagent-lane.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "recordVersion": 1,
+            "ownershipId": "codex-sidecar-freshagent-lane",
+            "pid": pid,
+            "starttime": proc_starttime(pid as i32).expect("live child starttime"),
+            "cmdline": proc_cmdline(pid as i32).expect("live child cmdline"),
+            "wsUrl": "ws://127.0.0.1:9",
+            "sessionId": "thread-from-freshagent",
+            "serverInstanceId": "srv-prev",
+            "createdAt": 1,
+            "updatedAt": 1,
+            "state": { "kind": "active" },
+            "lane": "freshAgent",
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let (reconciler, report) = SidecarReconciler::boot_reconcile(store);
+    assert_eq!(
+        report.pruned_dead + report.pruned_mismatch,
+        0,
+        "live evidence is not pruned"
+    );
+    assert_eq!(report.held, 1, "the freshagent row is held for the sweep");
+
+    let claimed = reconciler.claim_for_session("thread-from-freshagent").await;
+    assert!(
+        claimed.is_none(),
+        "freshagent-lane records are never claimable, got {claimed:?}"
+    );
+    assert_eq!(
+        reconciler.unclaimed_len(),
+        1,
+        "still held after the refused claim"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/freshell-codex/src/sidecar_store.rs
+++ b/crates/freshell-codex/src/sidecar_store.rs
@@ -63,6 +63,10 @@ pub struct CodexSidecarRecord {
     pub created_at: i64,
     pub updated_at: i64,
     pub state: SidecarRecordState,
+    /// Spawning lane. Absent (`None`) on all pre-existing rows; `None` means
+    /// terminal-pane for claim purposes and must keep meaning that.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lane: Option<SidecarLane>,
 }
 
 /// Lifecycle state of a recorded sidecar: `Active` (owned by a live server
@@ -73,6 +77,18 @@ pub struct CodexSidecarRecord {
 pub enum SidecarRecordState {
     Active,
     Retained { reason: String },
+}
+
+/// Which spawning lane owns a recorded sidecar. `None` decodes every row
+/// written before this field existed — all of them terminal-pane writes —
+/// and the claim path must treat `None`/`TerminalPane` identically forever.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SidecarLane {
+    /// `SpawnedCodexAppServerRuntime` (terminal-pane codex sessions).
+    TerminalPane,
+    /// `FreshCodexState::spawn_sidecar` (freshcodex fresh-agent panes).
+    FreshAgent,
 }
 
 /// The durable record store. `root: None` ⇒ DISABLED: every write/remove is
@@ -366,8 +382,10 @@ pub fn set_codex_sidecar_store(store: Arc<CodexSidecarStore>) {
 
 /// The installed process-wide store, if any. `None` (nothing installed) means
 /// callers fall back to [`CodexSidecarStore::disabled`] — behavior identical
-/// to the pre-store world.
-pub(crate) fn codex_sidecar_store() -> Option<Arc<CodexSidecarStore>> {
+/// to the pre-store world. Also read by the freshagent lane
+/// (freshell-freshagent), which writes `Some(SidecarLane::FreshAgent)`
+/// records at spawn.
+pub fn codex_sidecar_store() -> Option<Arc<CodexSidecarStore>> {
     GLOBAL_SIDECAR_STORE.read().unwrap().clone()
 }
 

--- a/crates/freshell-codex/src/sidecar_store_tests.rs
+++ b/crates/freshell-codex/src/sidecar_store_tests.rs
@@ -33,6 +33,7 @@ fn sample_record(ownership_id: &str) -> CodexSidecarRecord {
         created_at: 1_700_000_000_000,
         updated_at: 1_700_000_000_001,
         state: SidecarRecordState::Active,
+        lane: None,
     }
 }
 
@@ -72,6 +73,36 @@ fn record_roundtrips_through_disk() {
     let mut loaded = store.load_all();
     loaded.sort_by(|a, b| a.ownership_id.cmp(&b.ownership_id));
     assert_eq!(loaded, vec![active, retained]);
+}
+
+#[test]
+fn lane_field_roundtrips_and_legacy_rows_decode_with_lane_none() {
+    let legacy = serde_json::json!({
+        "recordVersion": 1,
+        "ownershipId": "codex-sidecar-legacy",
+        "pid": 424242,
+        "starttime": 123456789,
+        "cmdline": ["codex", "app-server", "--listen", "ws://127.0.0.1:9"],
+        "wsUrl": "ws://127.0.0.1:9",
+        "serverInstanceId": "srv-prev",
+        "createdAt": 1,
+        "updatedAt": 1,
+        "state": { "kind": "active" },
+    });
+    let record: CodexSidecarRecord = serde_json::from_value(legacy).expect("legacy row decodes");
+    assert_eq!(
+        record.lane, None,
+        "rows written before the lane field decode as terminal-pane"
+    );
+
+    let with_lane = CodexSidecarRecord {
+        lane: Some(SidecarLane::FreshAgent),
+        ..record
+    };
+    let json = serde_json::to_string(&with_lane).expect("serialize");
+    assert!(json.contains("\"lane\":\"freshAgent\""));
+    let back: CodexSidecarRecord = serde_json::from_str(&json).expect("roundtrip");
+    assert_eq!(back.lane, Some(SidecarLane::FreshAgent));
 }
 
 #[test]

--- a/crates/freshell-codex/src/sidecar_test_support.rs
+++ b/crates/freshell-codex/src/sidecar_test_support.rs
@@ -99,6 +99,7 @@ pub(crate) fn record_for_child(
         created_at: 1_700_000_000_000,
         updated_at: 1_700_000_000_001,
         state: SidecarRecordState::Active,
+        lane: None,
     }
 }
 

--- a/crates/freshell-codex/tests/launch_lifecycle.rs
+++ b/crates/freshell-codex/tests/launch_lifecycle.rs
@@ -1068,6 +1068,7 @@ async fn plan_retry_falls_back_to_fresh_spawn_after_reattach_failure() {
         created_at: 1_700_000_000_000,
         updated_at: 1_700_000_000_001,
         state: SidecarRecordState::Active,
+        lane: None,
     };
     store.write(&dead_record).expect("write survivor record");
     let (reconciler, report) = SidecarReconciler::boot_reconcile(store.clone());
@@ -1243,6 +1244,7 @@ async fn plan_retry_spawns_fresh_after_claimed_reattach_ensure_ready_fails() {
         created_at: 1_700_000_000_000,
         updated_at: 1_700_000_000_001,
         state: SidecarRecordState::Active,
+        lane: None,
     };
     store
         .write(&survivor_record)

--- a/crates/freshell-freshagent/src/codex.rs
+++ b/crates/freshell-freshagent/src/codex.rs
@@ -890,6 +890,7 @@ impl FreshCodexState {
                 let mut child = child;
                 let _ = child.start_kill();
                 reap_owned_codex_sidecars(&ownership_id);
+                crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
                 self.fail_create(&request_id, "CODEX_THREAD_START_FAILED", &err.to_string());
                 return;
             }
@@ -1011,6 +1012,7 @@ impl FreshCodexState {
                 let mut child = child;
                 let _ = child.start_kill();
                 reap_owned_codex_sidecars(&ownership_id);
+                crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
                 // Own tree torn down above -- releasing the lease is safe.
                 if let Some(mut g) = lease_guard.take() {
                     g.fail();
@@ -1031,6 +1033,7 @@ impl FreshCodexState {
             let mut child = child;
             let _ = child.start_kill();
             reap_owned_codex_sidecars(&ownership_id);
+            crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
             if let Some(mut g) = lease_guard.take() {
                 g.fail();
             }
@@ -1190,6 +1193,7 @@ impl FreshCodexState {
             let _ = child.start_kill();
             let _ = child.wait().await;
             reap_owned_codex_sidecars(&ownership_id);
+            crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
             // Own tree confirmed torn down -- releasing the lease is safe.
             if let Some(mut g) = lease_guard.take() {
                 g.fail();
@@ -3234,6 +3238,7 @@ impl FreshCodexState {
                 let mut dead_child = child;
                 let _ = dead_child.start_kill();
                 reap_owned_codex_sidecars(&ownership_id);
+                crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
                 // FIX (CODEX-FIRST triage Finding 2): remember this id as genuinely gone so
                 // a later attach/create against it fails fast instead of repeating this same
                 // spawn-resume-fail cycle.
@@ -3256,6 +3261,7 @@ impl FreshCodexState {
                 let mut child = child;
                 let _ = child.start_kill();
                 reap_owned_codex_sidecars(&ownership_id);
+                crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
                 // Own tree torn down above -- releasing the lease is safe.
                 if let Some(mut g) = lease_guard.take() {
                     g.fail();
@@ -3272,6 +3278,7 @@ impl FreshCodexState {
             let mut child = child;
             let _ = child.start_kill();
             reap_owned_codex_sidecars(&ownership_id);
+            crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
             tracing::error!(
                 requested = %session_id,
                 returned = %started.thread_id,
@@ -3448,6 +3455,7 @@ impl FreshCodexState {
                 let mut child = child;
                 let _ = child.start_kill();
                 reap_owned_codex_sidecars(&ownership_id);
+                crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
                 // Own tree torn down above -- releasing the lease is safe.
                 if let Some(mut g) = lease_guard.take() {
                     g.fail();
@@ -3642,6 +3650,14 @@ impl FreshCodexState {
         // Drain child stdio so verbose app-server/MCP logs can never fill the pipe and stall it.
         drain_child_io(&mut child);
 
+        // wfah: durable tracking BEFORE the handshake — the record must exist
+        // even while this sidecar's 45s startup budget is still running, or an
+        // unclean server death would leave the child untracked.
+        if let Some(pid) = child.id() {
+            crate::codex_sidecar_tracking::record_spawned_sidecar(&ownership_id, pid, &ws_url)
+                .await;
+        }
+
         let deadline = Instant::now() + SIDECAR_START_BUDGET;
 
         // Connect the WS as soon as the listener is up (the app-server binds it after startup).
@@ -3650,6 +3666,7 @@ impl FreshCodexState {
                 Ok(transport) => break Arc::new(transport),
                 Err(err) => {
                     if let Ok(Some(status)) = child.try_wait() {
+                        crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
                         return Err(format!(
                             "codex app-server exited before listening: {status}"
                         ));
@@ -3657,6 +3674,7 @@ impl FreshCodexState {
                     if Instant::now() >= deadline {
                         let _ = child.start_kill();
                         reap_owned_codex_sidecars(&ownership_id);
+                        crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
                         return Err(format!("codex app-server WS never came up: {err}"));
                     }
                     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -3677,6 +3695,7 @@ impl FreshCodexState {
                         client.close().await;
                         let _ = child.start_kill();
                         reap_owned_codex_sidecars(&ownership_id);
+                        crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
                         return Err(format!("codex app-server initialize failed: {err}"));
                     }
                     tokio::time::sleep(Duration::from_millis(150)).await;
@@ -4124,6 +4143,7 @@ impl FreshCodexState {
                 let mut child = child;
                 let _ = child.start_kill();
                 reap_owned_codex_sidecars(&ownership_id);
+                crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
                 // Own tree torn down above -- releasing the lease is safe.
                 if let Some(mut g) = lease_guard.take() {
                     g.fail();
@@ -4149,6 +4169,7 @@ impl FreshCodexState {
             let mut child = child;
             let _ = child.start_kill();
             reap_owned_codex_sidecars(&ownership_id);
+            crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
             tracing::error!(
                 requested = %thread_id,
                 returned = %started.thread_id,
@@ -5207,7 +5228,7 @@ fn build_codex_turn_json(raw_turn: &Value, ordinal: usize) -> Result<Vec<Value>,
 ///   the reference's "leave the runtime mapped for lazy restart" invariant.
 /// - A `freshAgent.kill` REQUESTS teardown via `kill_rx`: gracefully `start_kill` + reap, with
 ///   NO self-heal event (the caller broadcasts its own `freshAgent.killed`).
-fn spawn_exit_watcher(
+pub(crate) fn spawn_exit_watcher(
     mut child: tokio::process::Child,
     ownership_id: String,
     thread_id: String,
@@ -5216,6 +5237,9 @@ fn spawn_exit_watcher(
     exited: Arc<AtomicBool>,
     leases: Arc<crate::session_lease::FreshAgentSessionLeases>,
 ) -> tokio::task::JoinHandle<()> {
+    // wfah: the thread id is fixed by the time the watcher is constructed at
+    // every successful spawn site; enrich the durable record once, here.
+    crate::codex_sidecar_tracking::enrich_record_session_id(&ownership_id, &thread_id);
     tokio::spawn(async move {
         // `biased` + the REQUESTED-kill arm listed FIRST: a `freshAgent.kill` signals
         // `kill_tx` right before `start_kill()`s the child, so `child.wait()` can become
@@ -5230,12 +5254,14 @@ fn spawn_exit_watcher(
                 let _ = child.start_kill();
                 let _ = child.wait().await;
                 reap_owned_codex_sidecars(&ownership_id);
+                crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
                 // Task 12: the bound session is gone -- reopen its durable id.
                 leases.clear_binding(PROVIDER, &thread_id);
                 tracing::info!(provider = PROVIDER, session_id = %thread_id, "freshagent.sidecar.reaped");
             }
             _ = child.wait() => {
                 reap_owned_codex_sidecars(&ownership_id);
+                crate::codex_sidecar_tracking::scrub_sidecar_record(&ownership_id);
                 // Task 12: a crashed sidecar is no longer a live writer -- reopen the
                 // durable id (the entry stays mapped for PR-4 lazy respawn, which
                 // re-claims through the attach/send seams).
@@ -5494,6 +5520,7 @@ async fn shut_down_fork_child(
     let _ = child.start_kill();
     let _ = child.wait().await;
     reap_owned_codex_sidecars(ownership_id);
+    crate::codex_sidecar_tracking::scrub_sidecar_record(ownership_id);
 }
 
 /// Codex fork's `lastTurnId` normalization (fresh-eyes round-3 F6): the REST snapshot
@@ -13676,9 +13703,10 @@ pub(crate) mod tests {
         )
     }
 
-    const ISOLATED_CODEX_ENV_KEYS: [&str; 5] = [
+    const ISOLATED_CODEX_ENV_KEYS: [&str; 6] = [
         "CODEX_HOME",
         "CODEX_CMD",
+        "FRESHELL_HOME",
         "FAKE_CODEX_APP_SERVER_BEHAVIOR",
         "FAKE_CODEX_APP_SERVER_ARG_LOG",
         "FAKE_CODEX_APP_SERVER_ALLOW_DURABLE_WRITES",

--- a/crates/freshell-freshagent/src/codex_sidecar_tracking.rs
+++ b/crates/freshell-freshagent/src/codex_sidecar_tracking.rs
@@ -1,0 +1,164 @@
+//! Durable cross-restart tracking for freshagent-lane codex sidecars (kata wfah).
+//!
+//! Every freshcodex sidecar (`FreshCodexState::spawn_sidecar`) is recorded in
+//! the shared rust-codex-sidecars store the moment it is spawned, and scrubbed
+//! whenever the lane reaps it, so the NEXT server generation's boot reconcile +
+//! grace-delayed sweep (wired in `crates/freshell-server/src/main.rs`) always
+//! sees this lane's survivors. Nothing in this module ever signals a process:
+//! killing stays the sweep's job.
+
+use freshell_codex::durability::default_server_instance_id;
+use freshell_codex::sidecar_store::{
+    codex_sidecar_store, proc_cmdline, proc_starttime, CodexSidecarRecord, SidecarLane,
+    SidecarRecordState, SIDECAR_RECORD_VERSION,
+};
+
+const PROVIDER: &str = "freshcodex";
+
+/// Poll budget for `/proc/<pid>` evidence right after spawn: the fork/exec
+/// window (empty cmdline) closes in milliseconds.
+const EVIDENCE_POLL_BUDGET: std::time::Duration = std::time::Duration::from_millis(2000);
+const EVIDENCE_POLL_STEP: std::time::Duration = std::time::Duration::from_millis(20);
+
+fn now_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or(0)
+}
+
+/// Write a verified-identity `CodexSidecarRecord` for a just-spawned sidecar,
+/// BEFORE its WS handshake completes (a server death mid-handshake must still
+/// produce a tracked survivor). Never fails the spawn: no store, an unreadable
+/// identity, or an io error are all logged loudly and leave today's
+/// kill-on-drop-only posture in place for that child.
+pub(crate) async fn record_spawned_sidecar(ownership_id: &str, pid: u32, ws_url: &str) {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (ownership_id, pid, ws_url);
+        return; // /proc identity evidence is Linux-only
+    }
+
+    let Some(store) = codex_sidecar_store() else {
+        return;
+    };
+    if !store.is_enabled() {
+        return;
+    }
+    if pid == 0 {
+        tracing::warn!(
+            provider = PROVIDER,
+            ownership_id,
+            "freshagent.sidecar.track_skipped: no pid"
+        );
+        return;
+    }
+
+    let deadline = std::time::Instant::now() + EVIDENCE_POLL_BUDGET;
+    let evidence = loop {
+        match (proc_starttime(pid as i32), proc_cmdline(pid as i32)) {
+            (Some(st), Some(cl)) if !cl.is_empty() => break Some((st, cl)),
+            _ if std::time::Instant::now() >= deadline => break None,
+            _ => tokio::time::sleep(EVIDENCE_POLL_STEP).await,
+        }
+    };
+    let Some((starttime, cmdline)) = evidence else {
+        tracing::warn!(
+            provider = PROVIDER,
+            ownership_id,
+            pid,
+            "freshagent.sidecar.track_skipped: /proc identity evidence unavailable within budget"
+        );
+        return;
+    };
+
+    let now = now_millis();
+    let record = CodexSidecarRecord {
+        record_version: SIDECAR_RECORD_VERSION,
+        ownership_id: ownership_id.to_string(),
+        pid,
+        starttime,
+        cmdline,
+        ws_url: ws_url.to_string(),
+        session_id: None,
+        terminal_id: None,
+        server_instance_id: default_server_instance_id(),
+        created_at: now,
+        updated_at: now,
+        state: SidecarRecordState::Active,
+        lane: Some(SidecarLane::FreshAgent),
+    };
+    match store.write(&record) {
+        Ok(()) => {
+            tracing::info!(
+                provider = PROVIDER,
+                ownership_id,
+                pid,
+                "freshagent.sidecar.tracked"
+            )
+        }
+        Err(err) => tracing::warn!(
+            provider = PROVIDER,
+            ownership_id,
+            pid,
+            error = %err,
+            "freshagent.sidecar.track_write_failed"
+        ),
+    }
+}
+
+/// Remove a sidecar's record whenever the lane reaps it (requested kill, crash
+/// arm, graceful shutdown, spawn-failure arm). Synchronous: the store's
+/// lock-free + atomic single-writer remove matches the reconciler's internal
+/// `remove_pruned` calls made under the same async discipline.
+pub(crate) fn scrub_sidecar_record(ownership_id: &str) {
+    let Some(store) = codex_sidecar_store() else {
+        return;
+    };
+    match store.remove(ownership_id) {
+        Ok(()) => tracing::debug!(
+            provider = PROVIDER,
+            ownership_id,
+            "freshagent.sidecar.untracked"
+        ),
+        Err(err) => tracing::warn!(
+            provider = PROVIDER,
+            ownership_id,
+            error = %err,
+            "freshagent.sidecar.untrack_failed"
+        ),
+    }
+}
+
+/// Record which codex thread a tracked sidecar serves once the lane knows it
+/// (watcher construction: the thread id is fixed at every successful spawn).
+pub(crate) fn enrich_record_session_id(ownership_id: &str, thread_id: &str) {
+    let Some(store) = codex_sidecar_store() else {
+        return;
+    };
+    let Some(mut record) = store
+        .load_all()
+        .into_iter()
+        .find(|r| r.ownership_id == ownership_id)
+    else {
+        return; // never tracked (disabled store / skipped write) — fine
+    };
+    if record.session_id.as_deref() == Some(thread_id) {
+        return;
+    }
+    record.session_id = Some(thread_id.to_string());
+    record.updated_at = now_millis();
+    if let Err(err) = store.write(&record) {
+        tracing::warn!(
+            provider = PROVIDER,
+            ownership_id,
+            session_id = %thread_id,
+            error = %err,
+            "freshagent.sidecar.enrich_failed"
+        );
+    }
+}
+
+#[cfg(test)]
+#[path = "codex_sidecar_tracking_tests.rs"]
+mod codex_sidecar_tracking_tests;

--- a/crates/freshell-freshagent/src/codex_sidecar_tracking_tests.rs
+++ b/crates/freshell-freshagent/src/codex_sidecar_tracking_tests.rs
@@ -1,0 +1,561 @@
+//! Cross-restart tracking tests for freshagent-lane codex sidecars (wfah).
+//! Linux-only: identity evidence is /proc-based. Every test serializes on
+//! `crate::codex::tests::ENV_LOCK` because the store handle is process-global
+//! and the spawn tests mutate `CODEX_CMD` — this guarantees no codex.rs spawn
+//! test runs concurrently (they all take ENV_LOCK for the same keys).
+#![cfg(target_os = "linux")]
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use freshell_codex::sidecar_store::{
+    proc_cmdline, proc_starttime, set_codex_sidecar_store, verify_sidecar_identity,
+    CodexSidecarStore, IdentityVerdict, SidecarLane, SidecarRecordState,
+};
+use serde_json::{json, Value};
+
+use crate::codex::tests::ENV_LOCK;
+// `scrub_sidecar_record` and `enrich_record_session_id` are exercised indirectly
+// (through spawn_sidecar / spawn_exit_watcher) — importing either here would be
+// an unused-imports lint failure.
+use crate::codex_sidecar_tracking::record_spawned_sidecar;
+// Same path codex.rs uses (re-exported from client_messages).
+use crate::FreshCodexState; // re-exported: `pub use codex::FreshCodexState` in lib.rs
+use freshell_protocol::FreshAgentCreate;
+
+/// Installs a tempdir store as the process-global handle for this test and
+/// restores the "nothing installed" posture (a disabled store — the
+/// documented identical-to-pre-store fallback) on drop.
+struct TrackingStoreGuard {
+    _dir: tempfile::TempDir,
+    store: Arc<CodexSidecarStore>,
+}
+
+impl TrackingStoreGuard {
+    fn install() -> Self {
+        let dir = tempfile::tempdir().expect("temp sidecar store root");
+        let store = Arc::new(CodexSidecarStore::new(dir.path().to_path_buf()));
+        assert!(store.is_enabled(), "tempdir stores are always writable");
+        set_codex_sidecar_store(store.clone());
+        Self { _dir: dir, store }
+    }
+    fn records(&self) -> Vec<freshell_codex::sidecar_store::CodexSidecarRecord> {
+        self.store.load_all()
+    }
+}
+
+impl Drop for TrackingStoreGuard {
+    fn drop(&mut self) {
+        set_codex_sidecar_store(Arc::new(CodexSidecarStore::disabled()));
+    }
+}
+
+fn fake_codex_cmd() -> String {
+    format!(
+        "node {}/../../test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+fn spawn_sleep_child() -> tokio::process::Child {
+    let mut cmd = tokio::process::Command::new("sleep");
+    cmd.arg("300");
+    cmd.kill_on_drop(true);
+    cmd.spawn().expect("spawn sleep fixture")
+}
+
+fn tracking_state() -> (FreshCodexState, tokio::sync::broadcast::Receiver<String>) {
+    let (tx, rx) = tokio::sync::broadcast::channel::<String>(64);
+    let st = FreshCodexState::new(
+        Arc::new("tok".to_string()),
+        Arc::new(tx),
+        json!({ "freshAgent": { "enabled": false } }),
+    );
+    (st, rx)
+}
+
+async fn create_tracked_session(
+    st: &FreshCodexState,
+    rx: &mut tokio::sync::broadcast::Receiver<String>,
+    request_id: &str,
+) -> String {
+    create_tracked_session_with_resume(st, rx, request_id, None).await
+}
+
+async fn create_tracked_session_with_resume(
+    st: &FreshCodexState,
+    rx: &mut tokio::sync::broadcast::Receiver<String>,
+    request_id: &str,
+    resume_session_id: Option<&str>,
+) -> String {
+    st.handle_create(
+        FreshAgentCreate {
+            request_id: request_id.to_string(),
+            session_type: freshell_protocol::SessionType::Freshcodex,
+            provider: Some(freshell_protocol::AgentProvider::Codex),
+            cwd: None,
+            legacy_restore_context: None,
+            resume_session_id: resume_session_id.map(str::to_string),
+            session_ref: None,
+            model: None,
+            model_selection: None,
+            permission_mode: None,
+            sandbox: None,
+            effort: None,
+            plugins: None,
+            tab_id: None,
+        },
+        None,
+    )
+    .await;
+    let frame: Value = tokio::time::timeout(std::time::Duration::from_secs(20), async {
+        loop {
+            let frame: Value = serde_json::from_str(&rx.recv().await.expect("bus stays open"))
+                .expect("valid json");
+            if frame["type"] == "freshAgent.created" || frame["type"] == "freshAgent.create.failed"
+            {
+                return frame;
+            }
+        }
+    })
+    .await
+    .expect("fixture create responds within the budget");
+    assert_eq!(
+        frame["type"], "freshAgent.created",
+        "fixture create failed: {frame}"
+    );
+    frame["sessionId"].as_str().expect("sessionId").to_string()
+}
+
+#[tokio::test]
+async fn spawn_record_carries_verifiable_proc_identity_and_freshagent_lane() {
+    let _env = ENV_LOCK.lock().await;
+    let guard = TrackingStoreGuard::install();
+    let mut child = spawn_sleep_child();
+    let pid = child.id().expect("spawned pid");
+
+    record_spawned_sidecar("codex-sidecar-wfah-t2", pid, "ws://127.0.0.1:1").await;
+
+    let records = guard.records();
+    assert_eq!(records.len(), 1, "exactly one record written");
+    let record = &records[0];
+    assert_eq!(record.ownership_id, "codex-sidecar-wfah-t2");
+    assert_eq!(record.pid, pid);
+    assert_eq!(record.lane, Some(SidecarLane::FreshAgent));
+    assert_eq!(record.state, SidecarRecordState::Active);
+    assert_eq!(record.session_id, None, "thread id unknown at spawn time");
+    assert_eq!(record.ws_url, "ws://127.0.0.1:1");
+    assert_eq!(record.cmdline, proc_cmdline(pid as i32).unwrap());
+    assert_eq!(record.starttime, proc_starttime(pid as i32).unwrap());
+    assert_eq!(
+        verify_sidecar_identity(record),
+        IdentityVerdict::Verified,
+        "a record must identify the very process it was written for"
+    );
+    let _ = child.start_kill();
+}
+
+#[tokio::test]
+async fn record_is_skipped_cleanly_when_no_store_is_installed() {
+    let _env = ENV_LOCK.lock().await;
+    let guard = TrackingStoreGuard::install();
+    // Stage the disabled posture the same way production falls back to it.
+    drop(guard);
+    let mut child = spawn_sleep_child();
+    let pid = child.id().expect("spawned pid");
+    record_spawned_sidecar("codex-sidecar-wfah-disabled", pid, "ws://127.0.0.1:1").await;
+    // No panic, no record write possible; the disabled store swallows writes.
+    let _ = child.start_kill();
+}
+
+#[tokio::test]
+async fn create_writes_a_freshagent_laned_record_for_the_real_sidecar() {
+    let _env = ENV_LOCK.lock().await;
+    std::env::set_var("CODEX_CMD", fake_codex_cmd());
+    let guard = TrackingStoreGuard::install();
+    let (st, mut rx) = tracking_state();
+
+    let session_id = create_tracked_session(&st, &mut rx, "req-wfah-t2-create").await;
+    assert!(!session_id.is_empty());
+
+    let records = guard.records();
+    assert_eq!(
+        records.len(),
+        1,
+        "exactly the spawned sidecar is tracked: {records:?}"
+    );
+    let record = &records[0];
+    assert_eq!(record.lane, Some(SidecarLane::FreshAgent));
+    assert!(
+        std::path::Path::new(&format!("/proc/{}", record.pid)).exists(),
+        "recorded pid must be live right after create"
+    );
+    assert!(
+        record.cmdline.iter().any(|a| a.contains("fake-app-server")),
+        "recorded cmdline must identify the fixture sidecar, got {:?}",
+        record.cmdline
+    );
+    assert_eq!(verify_sidecar_identity(record), IdentityVerdict::Verified);
+
+    st.shutdown().await; // scrubs the record only once Task 3's wiring lands
+}
+
+#[tokio::test]
+async fn failed_spawn_leaves_no_record() {
+    let _env = ENV_LOCK.lock().await;
+    // The node child survives ~1.5s — far beyond any realistic evidence-poll
+    // latency, so the optimistic record write deterministically lands before
+    // the child exits — it never listens, then exits, so spawn_sidecar returns
+    // Err via the "exited before listening" arm with the record already
+    // written. (No inner spaces in the script: spawn_sidecar whitespace-splits
+    // CODEX_CMD, so the script must stay a single argv. The trailing `--`
+    // stops node's option parsing, so the `-c ...` app-server args
+    // spawn_sidecar appends cannot be misparsed as node flags — without it
+    // node dies in milliseconds on `either --check or --eval`.)
+    std::env::set_var("CODEX_CMD", "node -e setTimeout(()=>{},1500) --");
+    let guard = TrackingStoreGuard::install();
+    let (st, mut rx) = tracking_state();
+
+    st.handle_create(
+        FreshAgentCreate {
+            request_id: "req-wfah-t2-fail".to_string(),
+            session_type: freshell_protocol::SessionType::Freshcodex,
+            provider: Some(freshell_protocol::AgentProvider::Codex),
+            cwd: None,
+            legacy_restore_context: None,
+            resume_session_id: None,
+            session_ref: None,
+            model: None,
+            model_selection: None,
+            permission_mode: None,
+            sandbox: None,
+            effort: None,
+            plugins: None,
+            tab_id: None,
+        },
+        None,
+    )
+    .await;
+    let frame: Value = tokio::time::timeout(std::time::Duration::from_secs(15), async {
+        loop {
+            let frame: Value = serde_json::from_str(&rx.recv().await.expect("bus")).expect("json");
+            if frame["type"] == "freshAgent.created" || frame["type"] == "freshAgent.create.failed"
+            {
+                return frame;
+            }
+        }
+    })
+    .await
+    .expect("failure frame within the budget");
+    assert_eq!(
+        frame["type"], "freshAgent.create.failed",
+        "expected failure: {frame}"
+    );
+
+    assert!(
+        guard.records().is_empty(),
+        "a failed spawn must scrub the record it optimistically wrote"
+    );
+}
+
+// ── Task 3: scrub the record on EVERY reap path ─────────────────────────────
+// (The Task 4 tests live at the bottom of this file.)
+
+/// Build a tracked sleeper + exit watcher exactly as production does.
+async fn build_recorded_watch(
+    ownership_id: &str,
+) -> (
+    tokio::task::JoinHandle<()>,
+    tokio::sync::oneshot::Sender<()>,
+    u32,
+) {
+    let child = spawn_sleep_child();
+    let pid = child.id().expect("spawned pid");
+    record_spawned_sidecar(ownership_id, pid, "ws://127.0.0.1:1").await;
+    let (tx, _rx) = tokio::sync::broadcast::channel::<String>(8);
+    let (kill_tx, kill_rx) = tokio::sync::oneshot::channel();
+    let watcher = crate::codex::spawn_exit_watcher(
+        child,
+        ownership_id.to_string(),
+        "thread-wfah-t3".to_string(),
+        Arc::new(tx),
+        kill_rx,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(crate::session_lease::FreshAgentSessionLeases::new()),
+    );
+    (watcher, kill_tx, pid)
+}
+
+#[tokio::test]
+async fn requested_kill_arm_removes_the_record() {
+    let _env = ENV_LOCK.lock().await;
+    let guard = TrackingStoreGuard::install();
+    let (watcher, kill_tx, pid) = build_recorded_watch("codex-sidecar-wfah-t3-kill").await;
+    assert_eq!(guard.records().len(), 1, "recorded before the kill");
+
+    kill_tx.send(()).expect("kill channel open");
+    watcher.await.expect("watcher completes");
+
+    assert!(
+        guard.records().is_empty(),
+        "requested kill scrubs the record"
+    );
+    assert!(
+        !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+        "the child itself is really gone"
+    );
+}
+
+#[tokio::test]
+async fn unrequested_exit_arm_removes_the_record() {
+    let _env = ENV_LOCK.lock().await;
+    let guard = TrackingStoreGuard::install();
+    let mut child = spawn_sleep_child();
+    let pid = child.id().expect("spawned pid");
+    record_spawned_sidecar("codex-sidecar-wfah-t3-crash", pid, "ws://127.0.0.1:1").await;
+    assert_eq!(
+        guard.records().len(),
+        1,
+        "set-up must have written the record"
+    );
+    let (tx, _rx) = tokio::sync::broadcast::channel::<String>(8);
+    let (_kill_tx, kill_rx) = tokio::sync::oneshot::channel();
+    let exited = Arc::new(AtomicBool::new(false));
+    child.start_kill().expect("start_kill a live child"); // the "crash"
+
+    let watcher = crate::codex::spawn_exit_watcher(
+        child,
+        "codex-sidecar-wfah-t3-crash".to_string(),
+        "thread-wfah-t3".to_string(),
+        Arc::new(tx),
+        kill_rx,
+        exited.clone(),
+        Arc::new(crate::session_lease::FreshAgentSessionLeases::new()),
+    );
+    watcher.await.expect("watcher completes");
+
+    assert!(
+        guard.records().is_empty(),
+        "the crash arm scrubs the record"
+    );
+    assert!(
+        exited.load(Ordering::SeqCst),
+        "the crash arm flips the lazy-restart flag"
+    );
+}
+
+#[tokio::test]
+async fn handle_kill_leaves_no_record() {
+    let _env = ENV_LOCK.lock().await;
+    std::env::set_var("CODEX_CMD", fake_codex_cmd());
+    let guard = TrackingStoreGuard::install();
+    let (st, mut rx) = tracking_state();
+    let session_id = create_tracked_session(&st, &mut rx, "req-wfah-t3-kill").await;
+    assert_eq!(guard.records().len(), 1);
+
+    st.handle_kill(freshell_protocol::FreshAgentKill {
+        provider: freshell_protocol::AgentProvider::Codex,
+        session_id,
+        session_type: freshell_protocol::SessionType::Freshcodex,
+        cwd: None,
+    })
+    .await;
+
+    assert!(
+        guard.records().is_empty(),
+        "freshAgent.kill reaps through the watcher, which scrubs"
+    );
+}
+
+#[tokio::test]
+async fn shutdown_leaves_no_records() {
+    let _env = ENV_LOCK.lock().await;
+    std::env::set_var("CODEX_CMD", fake_codex_cmd());
+    let guard = TrackingStoreGuard::install();
+    let (st, mut rx) = tracking_state();
+    create_tracked_session(&st, &mut rx, "req-wfah-t3-shutdown-a").await;
+    // The fixture answers EVERY default `thread/start` with `thread-new-1`, so a
+    // second PLAIN create would hit finish_create's live-incumbent adopt path and
+    // tear its own sidecar down (correctly scrubbing it) — leaving ONE record and
+    // one sidecar, not the two this test needs. Resume-create pins a distinct
+    // thread id (the fixture echoes `params.threadId`), so session b genuinely
+    // owns a second live sidecar.
+    create_tracked_session_with_resume(
+        &st,
+        &mut rx,
+        "req-wfah-t3-shutdown-b",
+        Some("thread-wfah-t3-shutdown-b"),
+    )
+    .await;
+    assert_eq!(guard.records().len(), 2);
+
+    st.shutdown().await;
+
+    assert!(
+        guard.records().is_empty(),
+        "graceful shutdown reaps the lane's sidecars AND their records"
+    );
+}
+
+#[tokio::test]
+async fn create_bail_after_spawn_leaves_no_record() {
+    let _env = ENV_LOCK.lock().await;
+    // thread/start errors AFTER spawn_sidecar returned OK: the lane takes the
+    // pre-watcher bail arm, which kills the child directly. The freshly
+    // written record must not linger.
+    std::env::set_var(
+        "FAKE_CODEX_APP_SERVER_BEHAVIOR",
+        json!({
+            "overrides": {
+                "thread/start": { "error": { "code": -32000, "message": "forced wfah bail" } }
+            }
+        })
+        .to_string(),
+    );
+    std::env::set_var("CODEX_CMD", fake_codex_cmd());
+    let guard = TrackingStoreGuard::install();
+    let (st, mut rx) = tracking_state();
+
+    st.handle_create(
+        FreshAgentCreate {
+            request_id: "req-wfah-t3-bail".to_string(),
+            session_type: freshell_protocol::SessionType::Freshcodex,
+            provider: Some(freshell_protocol::AgentProvider::Codex),
+            cwd: None,
+            legacy_restore_context: None,
+            resume_session_id: None,
+            session_ref: None,
+            model: None,
+            model_selection: None,
+            permission_mode: None,
+            sandbox: None,
+            effort: None,
+            plugins: None,
+            tab_id: None,
+        },
+        None,
+    )
+    .await;
+    let frame: Value = tokio::time::timeout(std::time::Duration::from_secs(15), async {
+        loop {
+            let frame: Value = serde_json::from_str(&rx.recv().await.expect("bus")).expect("json");
+            if frame["type"] == "freshAgent.created" || frame["type"] == "freshAgent.create.failed"
+            {
+                return frame;
+            }
+        }
+    })
+    .await
+    .expect("failure frame within the budget");
+    assert_eq!(
+        frame["type"], "freshAgent.create.failed",
+        "expected the bail: {frame}"
+    );
+
+    assert!(
+        guard.records().is_empty(),
+        "a pre-watcher bail must scrub the record it wrote at spawn"
+    );
+}
+
+// ── Task 4: thread-id enrichment + cross-generation hold/never-claim ────────
+
+use freshell_codex::sidecar_reconcile::SidecarReconciler;
+use freshell_codex::sidecar_sweep::SweepOutcome;
+
+#[tokio::test]
+async fn create_enriches_the_record_with_the_served_thread_id() {
+    let _env = ENV_LOCK.lock().await;
+    std::env::set_var("CODEX_CMD", fake_codex_cmd());
+    let guard = TrackingStoreGuard::install();
+    let (st, mut rx) = tracking_state();
+
+    let session_id = create_tracked_session(&st, &mut rx, "req-wfah-t4-enrich").await;
+
+    // watcher construction performs the enrichment before the lane finishes
+    // create; poll defensively (<=3s) for the store write to land.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    loop {
+        let records = guard.records();
+        if records.len() == 1 && records[0].session_id.as_deref() == Some(session_id.as_str()) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "record not enriched: {records:?}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    st.shutdown().await;
+}
+
+#[tokio::test]
+async fn next_generation_holds_then_reaps_a_freshagent_survivor_never_claiming_it() {
+    let _env = ENV_LOCK.lock().await;
+    std::env::set_var("CODEX_CMD", fake_codex_cmd());
+    let guard = TrackingStoreGuard::install();
+    let (st, mut rx) = tracking_state();
+    let session_id = create_tracked_session(&st, &mut rx, "req-wfah-t4-gen").await;
+    let ownership_id = guard.records()[0].ownership_id.clone();
+    let pid = guard.records()[0].pid;
+    assert_eq!(
+        guard.records()[0].session_id.as_deref(),
+        Some(session_id.as_str()),
+        "the claim-refusal assertion is only meaningful on an enriched (indexed) record"
+    );
+
+    // SIMULATE THE GENERATION BOUNDARY against the shared disk state: the old
+    // process is gone (crashed), its records survive; the new generation's boot
+    // reconcile reloads them. (We reuse the same fixture process — its
+    // /proc evidence is unchanged, exactly like a real orphan.)
+    let (reconciler, report) = SidecarReconciler::boot_reconcile(guard.store.clone());
+    assert_eq!(
+        report.pruned_dead + report.pruned_mismatch,
+        0,
+        "the live orphan is not pruned"
+    );
+    assert!(report.held >= 1, "the orphan is held for the sweep");
+
+    // A terminal-pane restore of the very same codex thread must never adopt the
+    // freshagent-lane record.
+    let claimed = reconciler.claim_for_session(&session_id).await;
+    assert!(
+        claimed.is_none(),
+        "freshagent records are never claimable: {claimed:?}"
+    );
+
+    // The grace-delayed sweep (driven directly here) reaps the verified-idle
+    // orphan (the fake fixture reports no active thread), removing the record.
+    let outcomes = reconciler.sweep_unclaimed().await;
+    let outcome = outcomes
+        .iter()
+        .find(|(oid, _)| oid == &ownership_id)
+        .map(|(_, o)| o)
+        .expect("the orphan record is swept");
+    assert_eq!(
+        outcome,
+        &SweepOutcome::Reaped,
+        "verified-idle orphan is reaped, not retained"
+    );
+
+    // The reaped process is really gone and the books are clean.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    while std::path::Path::new(&format!("/proc/{pid}")).exists()
+        && std::time::Instant::now() < deadline
+    {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(
+        !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+        "the swept orphan stays dead"
+    );
+    assert!(
+        guard.records().is_empty(),
+        "no record remains after the sweep"
+    );
+
+    // Old-generation cleanup: its watcher crash arm fires on the sweep's kill;
+    // shutdown still completes safely with the mapping present.
+    st.shutdown().await;
+}

--- a/crates/freshell-freshagent/src/lib.rs
+++ b/crates/freshell-freshagent/src/lib.rs
@@ -39,6 +39,7 @@
 pub mod claude;
 pub(crate) mod claude_snapshot;
 pub mod codex;
+pub(crate) mod codex_sidecar_tracking;
 pub mod identity_sink;
 pub mod layout_store;
 pub mod layout_tree;

--- a/crates/freshell-server/tests/safe11_term22_shutdown_reaping.rs
+++ b/crates/freshell-server/tests/safe11_term22_shutdown_reaping.rs
@@ -26,11 +26,17 @@
 //! graceful shutdown ("killing sidecars at shutdown is NOT acceptable —
 //! surviving restarts is a feature"). This suite's coverage is untouched by
 //! that: its codex leg is a freshagent-lane sidecar (`freshAgent.create
-//! {sessionType:"freshcodex"}`) plus a shell PTY, both OUTSIDE the retention
-//! scope, so it doubles as the tripwire that retention did not leak into the
-//! freshagent lane or shell-PTY reaping. The retention behavior itself is
-//! pinned by `crates/freshell-codex/tests/launch_lifecycle.rs`'s Task 10
-//! section.
+//! {sessionType:"freshcodex"}`) plus a shell PTY. The freshagent lane
+//! remains OUTSIDE the *retention* scope — it still kills its sidecars at
+//! graceful shutdown, so this test doubles as the tripwire that retention
+//! did not leak into the freshagent lane or shell-PTY reaping — but it is
+//! now INSIDE *tracking* (kata wfah): the lane writes a durable
+//! `lane:"freshAgent"` record at spawn, and the next server generation's
+//! boot reconcile + grace-delayed sweep reaps a tracked orphan left behind
+//! by an unclean death (proven below by
+//! `sigkill_restart_reaps_tracked_freshagent_sidecar_via_store`). The
+//! retention behavior itself is pinned by
+//! `crates/freshell-codex/tests/launch_lifecycle.rs`'s Task 10 section.
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -449,5 +455,330 @@ async fn shutdown_reaps_terminal_and_codex_sidecar_within_5s() {
         still_alive.is_empty(),
         "orphaned descendant pids after a graceful shutdown: {still_alive:?} \
          (all recorded descendants: {descendants:?})"
+    );
+}
+
+/// Directory of durable sidecar records for a test server home.
+fn sidecar_store_records(home: &std::path::Path) -> Vec<serde_json::Value> {
+    let dir = home.join(".freshell/rust-codex-sidecars");
+    let mut out = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        for entry in rd.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.ends_with(".json") {
+                if let Ok(text) = std::fs::read_to_string(entry.path()) {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
+                        out.push(v);
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// The freshagent-lane fixture sidecar of a test server, if any: its cmdline
+/// contains the fake app-server script name.
+fn find_freshagent_sidecar_pid(server_pid: u32) -> Option<u32> {
+    descendant_pids(server_pid)
+        .into_iter()
+        .find(|&pid| pid_cmdline(pid).contains("fake-app-server"))
+}
+
+/// Bounded `wait()` for a just-signalled std `Child`: poll `try_wait` until
+/// the process exits or the budget expires, escalating to SIGKILL so the
+/// caller's stderr drain can never block forever (`read_to_string` waits for
+/// the pipe EOF, which only the process's exit produces). All waits are
+/// `tokio::time::sleep`, matching the async discipline of the rest of this
+/// file.
+async fn reaped_wait(child: &mut Child, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    loop {
+        if let Ok(Some(_)) = child.try_wait() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Panic-path cleanup for the cross-restart test's spawned pids.
+/// `std::process::Child` has no kill-on-drop, and the SIGKILL test
+/// deliberately leaves the fixture sidecar running across server1's death,
+/// so any assertion failure unwinding between a spawn and that spawn's own
+/// teardown arm would strand a live server and/or sidecar past test end.
+/// The guard SIGKILLs every registered pid on drop unless disarmed: panics
+/// kill the registered set; the success path (and every explicit-cleanup
+/// failure arm) disarms once its own teardown has run, so a later
+/// `panic!`/`assert!` never double-signals.
+struct KillOnPanic {
+    pids: Vec<u32>,
+    armed: bool,
+}
+
+impl KillOnPanic {
+    fn new(pids: Vec<u32>) -> Self {
+        Self { pids, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for KillOnPanic {
+    fn drop(&mut self) {
+        if self.armed {
+            for &pid in &self.pids {
+                let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+            }
+        }
+    }
+}
+
+/// wfah Task 5: the cross-restart proof. Generation 1 boots, spawns a
+/// freshcodex fresh-agent sidecar (a durable `lane:"freshAgent"` record names
+/// it), and is then `kill -9`'d — no graceful shutdown, no Drop, no record
+/// scrub, so the sidecar survives orphaned (that is precisely the bug class
+/// being fixed). Generation 2 boots on the SAME home; its boot reconcile
+/// holds the record and the grace-delayed sweep (`1000ms` via
+/// `FRESHELL_CODEX_SIDECAR_REAP_GRACE_MS`) verifies the survivor, finds no
+/// active thread on the fixture, reaps it, and removes the record. The test
+/// asserts the full chain: record exists -> SIGKILL -> orphan survives ->
+/// generation 2 -> orphan gone AND record scrubbed.
+///
+/// RED (pre-Tasks 1-4): the freshagent lane wrote no record, so the run
+/// fails at the "no tracked record for pid" assertion and generation 2's
+/// sweep has nothing to reap — the orphan survives.
+#[tokio::test]
+async fn sigkill_restart_reaps_tracked_freshagent_sidecar_via_store() {
+    let server_binary = discover_server_binary();
+    let home = tempfile::tempdir().expect("create temp home");
+    let port1 = allocate_ephemeral_port();
+    seed_fresh_agent_enabled(home.path());
+
+    // Generation 1: boot, create a freshcodex fresh-agent session.
+    let mut server1 = Command::new(&server_binary)
+        .env("PORT", port1.to_string())
+        .env("AUTH_TOKEN", AUTH_TOKEN)
+        .env("FRESHELL_HOME", home.path())
+        .env("HOME", home.path())
+        .env("CODEX_CMD", format!("node {}", fake_codex_app_server_cmd()))
+        .env_remove("FAKE_CODEX_APP_SERVER_BEHAVIOR")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn freshell-server #1");
+    // Panic guard: any panic between here and this test's own SIGKILL arm
+    // below (assertion failures, ws handshake errors, ...) would otherwise
+    // unwind past `server1`'s drop and leak a live server plus its fixture
+    // sidecar past test end. The sidecar pid is registered as soon as it is
+    // identified; server1 is de-registered right after this test reaps it,
+    // so a post-SIGKILL panic can never signal a recycled pid.
+    let mut panic_guard = KillOnPanic::new(vec![server1.id()]);
+    if !wait_for_health(port1, &mut server1, Duration::from_secs(15)).await {
+        // Kill (and reap) BEFORE draining stderr: `read_to_string` blocks
+        // until the pipe EOFs, which only happens once the process exits.
+        let _ = server1.kill();
+        let _ = server1.wait();
+        let stderr = drain_stderr(&mut server1);
+        // This arm already reaped everything it started.
+        panic_guard.disarm();
+        panic!("server #1 never became healthy; stderr:\n{stderr}");
+    }
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port1}/ws"))
+        .await
+        .expect("ws connect");
+    send_json(
+        &mut ws,
+        &serde_json::json!({
+            "type": "hello",
+                "protocolVersion": freshell_protocol::WS_PROTOCOL_VERSION,
+                "token": AUTH_TOKEN,
+        }),
+    )
+    .await;
+    wait_for_message_type(&mut ws, "ready", Duration::from_secs(5))
+        .await
+        .expect("ready handshake");
+    send_json(
+        &mut ws,
+        &serde_json::json!({
+            "type": "freshAgent.create",
+            "requestId": "rid-wfah-sigkill",
+            "sessionType": "freshcodex",
+            "provider": "codex",
+        }),
+    )
+    .await;
+    // Generous: `SIDECAR_START_BUDGET` is 45s server-side — mirror the
+    // graceful test's 50s frame budget.
+    match wait_for_any_message_type(
+        &mut ws,
+        &["freshAgent.created", "freshAgent.createFailed"],
+        Duration::from_secs(50),
+    )
+    .await
+    {
+        Some((got, _)) if got == "freshAgent.created" => {}
+        other => {
+            // Failure-path teardown mirrors the success path: SIGTERM lets
+            // the server gracefully reap any sidecar it already spawned
+            // before we panic, so no fixture tree leaks past test end.
+            let _ = unsafe { libc::kill(server1.id() as libc::pid_t, libc::SIGTERM) };
+            let _ = reaped_wait(&mut server1, Duration::from_secs(10)).await;
+            let log_tail =
+                std::fs::read_to_string(home.path().join(".freshell/logs/rust-server.jsonl"))
+                    .unwrap_or_default();
+            let stderr = drain_stderr(&mut server1);
+            // The SIGTERM + reaped_wait above already killed server1 and let
+            // it gracefully reap any sidecar it held.
+            panic_guard.disarm();
+            panic!(
+                "expected freshAgent.created, got {other:?}; server #1 stderr:\n{stderr}\nlog tail:\n{log_tail}"
+            );
+        }
+    }
+
+    // The sidecar exists, and a durable tracked record names it.
+    let server1_pid = server1.id();
+    let sidecar_pid = match find_freshagent_sidecar_pid(server1_pid) {
+        Some(pid) => pid,
+        None => {
+            // Explicit-cleanup arm: SIGTERM (whose graceful shutdown reaps
+            // any sidecar the server holds), not the guard's SIGKILL -- a
+            // guard kill of server1 alone could strand the very sidecar this
+            // arm failed to identify.
+            let _ = unsafe { libc::kill(server1_pid as libc::pid_t, libc::SIGTERM) };
+            let _ = reaped_wait(&mut server1, Duration::from_secs(10)).await;
+            let stderr = drain_stderr(&mut server1);
+            panic_guard.disarm();
+            panic!(
+                "expected a fixture sidecar among the server's descendants; \
+                 server #1 stderr:\n{stderr}"
+            );
+        }
+    };
+    panic_guard.pids.push(sidecar_pid);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let record = loop {
+        let found = sidecar_store_records(home.path())
+            .into_iter()
+            .find(|r| r["pid"].as_u64() == Some(sidecar_pid as u64));
+        if let Some(record) = found {
+            break record;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no tracked record for pid {sidecar_pid}"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    };
+    assert_eq!(
+        record["lane"].as_str(),
+        Some("freshAgent"),
+        "freshagent rows carry the lane marker: {record}"
+    );
+    assert_eq!(record["state"]["kind"].as_str(), Some("active"));
+    drop(ws);
+
+    // THE UNCLEAN DEATH: no graceful shutdown, no Drop, no record scrub.
+    let kill_rc = unsafe { libc::kill(server1_pid as libc::pid_t, libc::SIGKILL) };
+    assert_eq!(kill_rc, 0, "SIGKILL to the server must land");
+    // Blocking std wait: SIGKILL landed, so the zombie is reaped promptly.
+    let _ = server1.wait();
+    // server1 is now dead and reaped by the test's own hand: de-register it
+    // so a later panic can never SIGKILL a recycled pid. The deliberately
+    // orphaned sidecar stays registered until the teardown below completes.
+    panic_guard.pids.retain(|&p| p != server1_pid);
+    // The orphan survives (that is precisely the bug class being fixed).
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(
+        pid_alive(sidecar_pid),
+        "the sidecar must still be alive after the unclean death — \
+         otherwise there is nothing to reap"
+    );
+
+    // Generation 2 on the SAME home: boot reconcile + shortened grace sweep.
+    let port2 = allocate_ephemeral_port();
+    let mut server2 = Command::new(&server_binary)
+        .env("PORT", port2.to_string())
+        .env("AUTH_TOKEN", AUTH_TOKEN)
+        .env("FRESHELL_HOME", home.path())
+        .env("HOME", home.path())
+        .env("CODEX_CMD", format!("node {}", fake_codex_app_server_cmd()))
+        .env("FRESHELL_CODEX_SIDECAR_REAP_GRACE_MS", "1000")
+        .env_remove("FAKE_CODEX_APP_SERVER_BEHAVIOR")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn freshell-server #2");
+    if !wait_for_health(port2, &mut server2, Duration::from_secs(15)).await {
+        // Same kill-then-drain discipline as generation 1, plus the leak
+        // guard for the generation-1 orphan generation 2 was about to reap.
+        // The guard signal is gated on identity re-verification (never
+        // signal a pid the test did not spawn AND verify): without a
+        // healthy server2 no sweep ran, so the orphan should still be ours
+        // -- but the discipline is not conditional on expectation.
+        if pid_cmdline(sidecar_pid).contains("fake-app-server") {
+            let _ = unsafe { libc::kill(sidecar_pid as libc::pid_t, libc::SIGKILL) };
+        }
+        let _ = server2.kill();
+        let _ = server2.wait();
+        let stderr = drain_stderr(&mut server2);
+        // This arm killed server2 and the registered sidecar itself.
+        panic_guard.disarm();
+        panic!("server #2 never became healthy; stderr:\n{stderr}");
+    }
+
+    // Within the grace + probe budget, the orphan is reaped and its record removed.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut reaped = false;
+    while Instant::now() < deadline {
+        let gone = !pid_alive(sidecar_pid);
+        let scrubbed = !sidecar_store_records(home.path())
+            .iter()
+            .any(|r| r["pid"].as_u64() == Some(sidecar_pid as u64));
+        if gone && scrubbed {
+            reaped = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    // Leak guard + teardown: never leave the fixture running past the test.
+    // The guard SIGKILL is gated on identity re-verification
+    // (`pid_cmdline(...).contains("fake-app-server")`): if generation 2's
+    // sweep reaped the orphan and the row/pid checks raced an unrelated
+    // recycle of the pid, this must not signal a foreign process (never
+    // signal a pid the test did not spawn AND verify). A genuinely
+    // not-reaped orphan still matches its fixture cmdline and is killed.
+    if !reaped && pid_cmdline(sidecar_pid).contains("fake-app-server") {
+        let _ = unsafe { libc::kill(sidecar_pid as libc::pid_t, libc::SIGKILL) };
+    }
+    let _ = unsafe { libc::kill(server2.id() as libc::pid_t, libc::SIGTERM) };
+    let _ = reaped_wait(&mut server2, Duration::from_secs(10)).await;
+    // Drain ONLY after server2 has exited (see `reaped_wait`): the pipe EOFs
+    // exactly once the process and every inherited-writer child are gone.
+    let server2_stderr = drain_stderr(&mut server2);
+    let log_tail = std::fs::read_to_string(home.path().join(".freshell/logs/rust-server.jsonl"))
+        .unwrap_or_default();
+
+    // The test's own reaping/teardown is complete: on the success path the
+    // sweep already reaped the orphan, and on the failure path the leak
+    // guard above killed it. Disarm so a failing final assertion does not
+    // re-signal anything.
+    panic_guard.disarm();
+
+    assert!(
+        reaped,
+        "the next generation must reap the tracked orphan. sidecar_pid={sidecar_pid} alive={} server2 stderr:\n{server2_stderr}\nlog tail:\n{log_tail}",
+        pid_alive(sidecar_pid),
     );
 }

--- a/crates/freshell-ws/tests/codex_sidecar_reattach_e2e.rs
+++ b/crates/freshell-ws/tests/codex_sidecar_reattach_e2e.rs
@@ -719,6 +719,7 @@ fn restore_reattaches_tui_to_surviving_sidecar_preserving_in_flight_turn() {
                 created_at: 1_700_000_000_000,
                 updated_at: 1_700_000_000_001,
                 state: SidecarRecordState::Active,
+                lane: None,
             })
             .expect("write survivor record");
         let (reconciler, report) = SidecarReconciler::boot_reconcile(store.clone());


### PR DESCRIPTION
Fresh-agent (freshcodex-pane) codex app-server sidecars were tracked in memory only: kills ran at graceful shutdown, `kill_on_drop(true)` was the sole in-process backstop, and the 5s shutdown force-exit (`std::process::exit(1)`) skips every Drop. Any crash/kill -9/slow shutdown left untracked orphan sidecars no later server could attribute or reap (kata wfah; ynfn residue; orphan pid 44963 evidence).

This extends the existing rust-codex-sidecars durable machinery (store/reconcile/sweep in crates/freshell-codex) to the freshagent lane:

- Every `spawn_sidecar` records a verified-identity record (`lane: freshAgent`) in the durable store before the WS handshake; the record is enriched with the served thread id once known.
- Every reap path in the lane (both exit-watcher arms, all ten pre-watcher bail arms, three spawn-failure arms, `shut_down_fork_child`) scrubs the record; graceful-shutdown semantics are unchanged (kill + untrack — never retention).
- The boot reconciler never indexes freshagent-lane rows for claims: terminal-pane restores cannot adopt them (never-claim negative tests at both levels).
- Black-box proof: a SIGKILLed server's freshcodex sidecar survives as a tracked orphan; the next generation's sweep reaps it and removes the record.

Verification: 6-task TDD run with per-task reviews + whole-branch review (PASS/APPROVED); plan review PASSED, delta review PASSED (Darkforge Fresh Eyes); cargo test --workspace green; fmt + 3 clippy legs clean; darkforge qa gate accepted at the squash commit. Full evidence chain under the run's traces dir.

Docs/index/README untouched: internal reliability fix, no user-visible surface change.
