### PR TITLE
test(e2e): fix stale permission banner copy assertion on mobile viewport

### DIFF
--- a/test/e2e-browser/specs/mobile-viewport.spec.ts
+++ b/test/e2e-browser/specs/mobile-viewport.spec.ts
@@ -247,7 +247,7 @@ test.describe('Mobile Viewport', () => {
     // Verify the permission banner is visible on mobile
     const banner = page.getByRole('alert', { name: /permission request for bash/i })
     await expect(banner).toBeVisible({ timeout: 10_000 })
-    await expect(banner).toContainText('Permission requested: Bash')
+    await expect(banner).toContainText('echo mobile-permission-test')
 
     // Verify Allow and Deny buttons are visible and clickable on mobile
     const allowBtn = banner.getByRole('button', { name: /allow tool use/i })


### PR DESCRIPTION
## Summary

Fixes the pre-existing-on-`main` e2e failure `permission banner buttons are visible and functional on mobile` (`test/e2e-browser/specs/mobile-viewport.spec.ts:195`; originally reported under its old home `fresh-agent-mobile.spec.ts`). The test asserted the copy `Permission requested: Bash`, which belonged to the since-deleted legacy `claude-chat/PermissionBanner.tsx`. The current `FreshAgentApprovalCard` renders `role="alert"` (`Permission request for Bash`) plus the tool name and a command-preview `<pre>` — the design pinned by its unit tests and already asserted against by the desktop sibling spec (`fresh-agent.spec.ts:1228`).

Evidence from the recorded gate baseline (`test/e2e-browser/gate01-baseline.json`): the banner locator resolved correctly and the mismatch was copy-only, so this is spec/UI drift, not a component regression. The mobile assertion now expects the command preview `echo mobile-permission-test`, mirroring the desktop pattern; banner visibility, Allow/Deny button visibility, and the `freshAgent.approval.respond` WS round-trip assertions are unchanged.

## Verification

- Focused e2e red→green verified at execution time; full spec file 7/7, desktop sibling banner test 1/1, `FreshAgentApprovalCard` unit tests 7/7.
- Full QA gate on this exact commit: exit 0 (clean).

🤖 Darkforge job 15gk