### PR TITLE
feat(host-stats): bind pids to the real cgroup constraint; rename pane to System Status

### DIFF
--- a/crates/freshell-platform/src/host_stats_readers.rs
+++ b/crates/freshell-platform/src/host_stats_readers.rs
@@ -694,6 +694,73 @@ pub fn read_pids_limit(proc_root: &Path, cgroup_root: &Path) -> Option<u64> {
     read_number_file(&proc_root.join("sys").join("kernel").join("threads-max"))
 }
 
+/// A same-node cgroup pids reading: the constraint a fork would hit first
+/// (Node `PidsConstraint`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PidsConstraint {
+    pub current: u64,
+    pub max: u64,
+}
+
+/// The BINDING pids constraint (Node `readPidsConstraint`): walk THIS
+/// process's cgroup chain from the leaf toward the root and return the
+/// `{current, max}` pair of the node whose finite `pids.max` has the HIGHEST
+/// utilization (`current`/`max`) — the limit a fork would actually hit first.
+/// This is the WSL/systemd aggregate shape: the leaf is often 'max' while an
+/// ANCESTOR slice (e.g. `user-1000.slice`) carries the real TasksMax, which
+/// the leaf-only [`read_pids_limit`] never sees. A node qualifies only when
+/// BOTH `pids.max` (finite, >0 — matching [`read_pids_limit`]'s convention)
+/// and `pids.current` read, so the returned pair is always a consistent
+/// same-node reading. No qualified node -> `None` (callers fall back to the
+/// system-wide `read_pid_count`/`read_pids_limit` pair). Deepest node wins
+/// ties (deterministic).
+///
+/// The cgroup fs root has NO limit files by design; [`resolve_cgroup_leaf`]
+/// already yields `None` for a process sitting at the cgroup2 root.
+///
+/// NOTE (frozen contract): parameter order here is (proc_root, cgroup_root)
+/// — the opposite of [`read_cgroup_memory`]. Callers: read the signatures,
+/// do not assume.
+pub fn read_pids_constraint(proc_root: &Path, cgroup_root: &Path) -> Option<PidsConstraint> {
+    let leaf = resolve_cgroup_leaf(proc_root, "pids")?;
+    // Deepest-first chain; the fs-root segment is never read (no limit files).
+    let segments: Vec<&str> = match &leaf {
+        CgroupLeaf::V2(path) | CgroupLeaf::V1(path) => {
+            path.split('/').filter(|segment| !segment.is_empty()).collect()
+        }
+    };
+    let mut best: Option<PidsConstraint> = None;
+    let mut best_ratio = -1.0_f64;
+    for depth in (1..=segments.len()).rev() {
+        let node_path = segments[..depth].join("/");
+        let dir = match &leaf {
+            CgroupLeaf::V2(_) => cgroup_root.join(&node_path),
+            CgroupLeaf::V1(_) => cgroup_root.join("pids").join(&node_path),
+        };
+        let Some(max_text) = safe_read(&dir.join("pids.max")) else {
+            continue;
+        };
+        let Some(max) = parse_cgroup_limit(&max_text) else {
+            continue; // 'max'/garbage: unlimited, not binding
+        };
+        if max == 0 {
+            continue; // matches read_pids_limit's limit > 0 convention
+        }
+        let Some(current_text) = safe_read(&dir.join("pids.current")) else {
+            continue; // no readable same-node pair
+        };
+        let Ok(current) = current_text.trim().parse::<u64>() else {
+            continue;
+        };
+        let ratio = current as f64 / max as f64;
+        if ratio > best_ratio {
+            best_ratio = ratio;
+            best = Some(PidsConstraint { current, max });
+        }
+    }
+    best
+}
+
 /// `Max open files` SOFT limit from `/proc/self/limits` ('unlimited' ->
 /// `None`) (Node `readSelfLimitsFdsMax`).
 pub fn read_self_limits_fds_max(proc_root: &Path) -> Option<u64> {

--- a/crates/freshell-platform/src/host_stats_readers.rs
+++ b/crates/freshell-platform/src/host_stats_readers.rs
@@ -725,9 +725,10 @@ pub fn read_pids_constraint(proc_root: &Path, cgroup_root: &Path) -> Option<Pids
     let leaf = resolve_cgroup_leaf(proc_root, "pids")?;
     // Deepest-first chain; the fs-root segment is never read (no limit files).
     let segments: Vec<&str> = match &leaf {
-        CgroupLeaf::V2(path) | CgroupLeaf::V1(path) => {
-            path.split('/').filter(|segment| !segment.is_empty()).collect()
-        }
+        CgroupLeaf::V2(path) | CgroupLeaf::V1(path) => path
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .collect(),
     };
     let mut best: Option<PidsConstraint> = None;
     let mut best_ratio = -1.0_f64;

--- a/crates/freshell-server/src/host_stats.rs
+++ b/crates/freshell-server/src/host_stats.rs
@@ -664,8 +664,19 @@ impl CollectorCtx {
         let proc_root = &self.cfg.proc_root;
         let fds_used = readers::read_self_fd_count(proc_root);
         let fds_max = readers::read_self_limits_fds_max(proc_root);
-        let pids_used = readers::read_pid_count(proc_root);
-        let pids_max = readers::read_pids_limit(proc_root, &self.cfg.cgroup_root());
+        // The binding pids constraint (leaf->root chain, highest-utilization
+        // node) yields a coherent same-node pair. The legacy fallback
+        // (system-wide count paired with a leaf/threads-max limit) is
+        // incoherent when an ancestor slice carries the real TasksMax —
+        // the WSL/systemd aggregate shape that motivated the constraint walk.
+        let pids_constraint = readers::read_pids_constraint(proc_root, &self.cfg.cgroup_root());
+        let (pids_used, pids_max) = match pids_constraint {
+            Some(constraint) => (Some(constraint.current), Some(constraint.max)),
+            None => (
+                readers::read_pid_count(proc_root),
+                readers::read_pids_limit(proc_root, &self.cfg.cgroup_root()),
+            ),
+        };
         let time_wait = readers::read_tcp_state_counts(proc_root).map(|t| t.time_wait);
         let ephemeral_ports =
             readers::read_ephemeral_port_range(proc_root).map(|r| r.end - r.start + 1);
@@ -1642,6 +1653,184 @@ mod tests {
             readers::read_pids_limit(&pid_max_only, &cgroup_fixture()),
             None
         );
+    }
+
+    /// Write `<root>/<rel>` creating parent dirs; the pids-constraint tmp
+    /// overlays below build their trees with it (Node suite parity:
+    /// test/unit/server/host-stats/readers.test.ts beforeAll writeFile).
+    fn write_rel(root: &Path, rel: &str, content: &str) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn host_stats_pids_constraint_binds_leaf_pair_and_chain_walk() {
+        // Committed v2 tree: the leaf is the only constrained node.
+        assert_eq!(
+            readers::read_pids_constraint(&procmini_fixture(), &cgroup_fixture()),
+            Some(readers::PidsConstraint {
+                current: 42,
+                max: 10854
+            })
+        );
+        // Chain walk (WSL/systemd aggregate shape): leaf 'max', the real
+        // TasksMax lives on an ANCESTOR slice.
+        let tmp = tempfile::tempdir().unwrap();
+        let proc_root = tmp.path().join("proc");
+        let cgroup_root = tmp.path().join("cgroup");
+        write_rel(
+            &proc_root,
+            "self/cgroup",
+            "0::/user.slice/user-1000.slice/user@1000.service/app.slice/freshell.service\n",
+        );
+        write_rel(
+            &cgroup_root,
+            "user.slice/user-1000.slice/user@1000.service/app.slice/freshell.service/pids.max",
+            "max\n",
+        );
+        write_rel(&cgroup_root, "user.slice/user-1000.slice/pids.max", "678924\n");
+        write_rel(
+            &cgroup_root,
+            "user.slice/user-1000.slice/pids.current",
+            "16240\n",
+        );
+        assert_eq!(
+            readers::read_pids_constraint(&proc_root, &cgroup_root),
+            Some(readers::PidsConstraint {
+                current: 16240,
+                max: 678924
+            })
+        );
+        // A process at the cgroup2 root has no leaf -> None (no fs-root reads).
+        let tmp2 = tempfile::tempdir().unwrap();
+        write_rel(&tmp2.path().join("proc"), "self/cgroup", "0::/\n");
+        assert_eq!(
+            readers::read_pids_constraint(&tmp2.path().join("proc"), &cgroup_fixture()),
+            None
+        );
+        // No cgroup data at all -> None (never a panic).
+        assert_eq!(
+            readers::read_pids_constraint(&missing(), &cgroup_fixture()),
+            None
+        );
+    }
+
+    #[test]
+    fn host_stats_pids_constraint_binds_highest_utilization_node() {
+        // Leaf 90/100 (0.9) beats ancestor 500/1000 (0.5).
+        let tmp = tempfile::tempdir().unwrap();
+        let proc_root = tmp.path().join("proc");
+        let cgroup_root = tmp.path().join("cgroup");
+        write_rel(&proc_root, "self/cgroup", "0::/slices/a.service\n");
+        write_rel(&cgroup_root, "slices/a.service/pids.max", "100\n");
+        write_rel(&cgroup_root, "slices/a.service/pids.current", "90\n");
+        write_rel(&cgroup_root, "slices/pids.max", "1000\n");
+        write_rel(&cgroup_root, "slices/pids.current", "500\n");
+        assert_eq!(
+            readers::read_pids_constraint(&proc_root, &cgroup_root),
+            Some(readers::PidsConstraint { current: 90, max: 100 })
+        );
+
+        // Ancestor 600/1000 (0.6) beats leaf 400/1000 (0.4).
+        let tmp = tempfile::tempdir().unwrap();
+        let proc_root = tmp.path().join("proc");
+        let cgroup_root = tmp.path().join("cgroup");
+        write_rel(&proc_root, "self/cgroup", "0::/slices/b.service\n");
+        write_rel(&cgroup_root, "slices/b.service/pids.max", "1000\n");
+        write_rel(&cgroup_root, "slices/b.service/pids.current", "400\n");
+        write_rel(&cgroup_root, "slices/pids.max", "1000\n");
+        write_rel(&cgroup_root, "slices/pids.current", "600\n");
+        assert_eq!(
+            readers::read_pids_constraint(&proc_root, &cgroup_root),
+            Some(readers::PidsConstraint {
+                current: 600,
+                max: 1000
+            })
+        );
+
+        // No constrained node anywhere (leaf 'max', no ancestor files) -> None.
+        let tmp = tempfile::tempdir().unwrap();
+        let proc_root = tmp.path().join("proc");
+        let cgroup_root = tmp.path().join("cgroup");
+        write_rel(&proc_root, "self/cgroup", "0::/slices/c.service\n");
+        write_rel(&cgroup_root, "slices/c.service/pids.max", "max\n");
+        assert_eq!(
+            readers::read_pids_constraint(&proc_root, &cgroup_root),
+            None
+        );
+
+        // A finite pids.max without pids.current cannot form a same-node pair.
+        let tmp = tempfile::tempdir().unwrap();
+        let proc_root = tmp.path().join("proc");
+        let cgroup_root = tmp.path().join("cgroup");
+        write_rel(&proc_root, "self/cgroup", "0::/slices/d.service\n");
+        write_rel(&cgroup_root, "slices/d.service/pids.max", "max\n");
+        write_rel(&cgroup_root, "slices/pids.max", "500\n");
+        assert_eq!(
+            readers::read_pids_constraint(&proc_root, &cgroup_root),
+            None
+        );
+    }
+
+    #[test]
+    fn host_stats_pids_constraint_v1_chain() {
+        // v1 pids controller: leaf 50/777 (0.06) loses to ancestor 900/1000 (0.9).
+        let tmp = tempfile::tempdir().unwrap();
+        let proc_root = tmp.path().join("proc");
+        let cgroup_root = tmp.path().join("cgroup");
+        write_rel(&proc_root, "self/cgroup", "3:pids:/limited.slice/svc.service\n");
+        write_rel(&cgroup_root, "pids/limited.slice/svc.service/pids.max", "777\n");
+        write_rel(
+            &cgroup_root,
+            "pids/limited.slice/svc.service/pids.current",
+            "50\n",
+        );
+        write_rel(&cgroup_root, "pids/limited.slice/pids.max", "1000\n");
+        write_rel(&cgroup_root, "pids/limited.slice/pids.current", "900\n");
+        assert_eq!(
+            readers::read_pids_constraint(&proc_root, &cgroup_root),
+            Some(readers::PidsConstraint {
+                current: 900,
+                max: 1000
+            })
+        );
+    }
+
+    #[test]
+    fn host_stats_limits_section_prefers_binding_pids_pair() {
+        // Service wiring: a resolved constraint pair replaces the system-wide
+        // count + leaf limit in the limits section (the legacy pair is
+        // incoherent when an ancestor slice carries the real TasksMax).
+        let tmp = tempfile::tempdir().unwrap();
+        let proc_root = tmp.path().join("proc");
+        let sys_root = tmp.path().join("sys");
+        write_rel(
+            &proc_root,
+            "self/cgroup",
+            "0::/user.slice/user-1000.slice/user@1000.service/app.slice/freshell.service\n",
+        );
+        write_rel(
+            &sys_root,
+            "fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/freshell.service/pids.max",
+            "max\n",
+        );
+        write_rel(
+            &sys_root,
+            "fs/cgroup/user.slice/user-1000.slice/pids.max",
+            "678924\n",
+        );
+        write_rel(
+            &sys_root,
+            "fs/cgroup/user.slice/user-1000.slice/pids.current",
+            "16240\n",
+        );
+        let interest = HostStatsInterestRegistry::default();
+        let collector = test_collector(proc_root, sys_root, &interest);
+        let limits = collector.ctx.read_limits_section();
+        assert!(limits.available);
+        assert_eq!(limits.pids_used, Some(16240));
+        assert_eq!(limits.pids_max, Some(678924));
     }
 
     #[test]

--- a/crates/freshell-server/src/host_stats.rs
+++ b/crates/freshell-server/src/host_stats.rs
@@ -1689,7 +1689,11 @@ mod tests {
             "user.slice/user-1000.slice/user@1000.service/app.slice/freshell.service/pids.max",
             "max\n",
         );
-        write_rel(&cgroup_root, "user.slice/user-1000.slice/pids.max", "678924\n");
+        write_rel(
+            &cgroup_root,
+            "user.slice/user-1000.slice/pids.max",
+            "678924\n",
+        );
         write_rel(
             &cgroup_root,
             "user.slice/user-1000.slice/pids.current",
@@ -1729,7 +1733,10 @@ mod tests {
         write_rel(&cgroup_root, "slices/pids.current", "500\n");
         assert_eq!(
             readers::read_pids_constraint(&proc_root, &cgroup_root),
-            Some(readers::PidsConstraint { current: 90, max: 100 })
+            Some(readers::PidsConstraint {
+                current: 90,
+                max: 100
+            })
         );
 
         // Ancestor 600/1000 (0.6) beats leaf 400/1000 (0.4).
@@ -1779,8 +1786,16 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let proc_root = tmp.path().join("proc");
         let cgroup_root = tmp.path().join("cgroup");
-        write_rel(&proc_root, "self/cgroup", "3:pids:/limited.slice/svc.service\n");
-        write_rel(&cgroup_root, "pids/limited.slice/svc.service/pids.max", "777\n");
+        write_rel(
+            &proc_root,
+            "self/cgroup",
+            "3:pids:/limited.slice/svc.service\n",
+        );
+        write_rel(
+            &cgroup_root,
+            "pids/limited.slice/svc.service/pids.max",
+            "777\n",
+        );
         write_rel(
             &cgroup_root,
             "pids/limited.slice/svc.service/pids.current",

--- a/docs/index.html
+++ b/docs/index.html
@@ -756,7 +756,7 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
                 <div class="picker-row">
                 <button class="picker-option">
                   <i data-lucide="gauge" class="picker-lucide"></i>
-                  <span class="picker-label">Host Stats</span>
+                  <span class="picker-label">System Status</span>
                   <span class="picker-shortcut">H</span>
                 </button>
                 </div>

--- a/server/host-stats/readers.ts
+++ b/server/host-stats/readers.ts
@@ -452,6 +452,63 @@ export function readPidsLimit(procRoot: string = PROC_ROOT, cgroupRoot: string =
   }
 }
 
+/** A same-node cgroup pids reading: the constraint a fork would hit first. */
+export type PidsConstraint = { current: number; max: number }
+
+/**
+ * The BINDING pids constraint: walks THIS process's cgroup chain from the leaf
+ * toward the root and returns the {current, max} pair of the node whose finite
+ * pids.max has the HIGHEST utilization (current/max) — the limit a fork would
+ * actually hit first. This is the WSL/systemd aggregate shape: the leaf is
+ * often 'max' while an ANCESTOR slice (e.g. user-1000.slice) carries the real
+ * TasksMax, which the leaf-only readPidsLimit never sees. A node qualifies
+ * only when BOTH pids.max (finite, >0 — matching readPidsLimit's convention)
+ * and pids.current read, so the returned pair is always a consistent same-node
+ * reading. No qualified node -> null (callers fall back to the system-wide
+ * readPidCount/readPidsLimit pair). Deepest node wins ties (deterministic).
+ *
+ * The cgroup fs root has NO limit files by design; resolveCgroupLeaf already
+ * yields null for a process sitting at the cgroup2 root.
+ *
+ * NOTE (frozen contract): parameter order here is (procRoot, cgroupRoot) — the
+ * opposite of readCgroupMemory(cgroupRoot, procRoot). Callers: read the
+ * signatures, do not assume.
+ */
+export function readPidsConstraint(
+  procRoot: string = PROC_ROOT,
+  cgroupRoot: string = CGROUP_ROOT,
+): PidsConstraint | null {
+  try {
+    const leaf = resolveCgroupLeaf(procRoot, 'pids')
+    if (!leaf) return null
+    // Deepest-first chain; the fs-root segment is never read (no limit files).
+    const segments = leaf.path.split('/').filter((segment) => segment.length > 0)
+    let best: PidsConstraint | null = null
+    let bestRatio = -1
+    for (let depth = segments.length; depth >= 1; depth--) {
+      const nodePath = segments.slice(0, depth).join('/')
+      const dir =
+        leaf.version === 'v2' ? path.join(cgroupRoot, nodePath) : path.join(cgroupRoot, 'pids', nodePath)
+      const maxText = safeRead(path.join(dir, 'pids.max'))
+      if (maxText === null) continue
+      const max = parseCgroupLimit(maxText)
+      if (max === null || max <= 0) continue // 'max'/garbage: unlimited, not binding
+      const currentText = safeRead(path.join(dir, 'pids.current'))
+      if (currentText === null) continue // no readable same-node pair
+      const current = Number(currentText.trim())
+      if (!Number.isFinite(current) || current < 0) continue
+      const ratio = current / max
+      if (ratio > bestRatio) {
+        bestRatio = ratio
+        best = { current, max }
+      }
+    }
+    return best
+  } catch {
+    return null
+  }
+}
+
 /** 'Max open files' SOFT limit from '/proc/self/limits' ('unlimited' -> null). */
 export function readSelfLimitsFdsMax(procRoot: string = PROC_ROOT): number | null {
   const text = safeRead(path.join(procRoot, 'self', 'limits'))

--- a/server/host-stats/service.ts
+++ b/server/host-stats/service.ts
@@ -43,6 +43,7 @@ import {
   readMeminfo,
   readNetDev,
   readPidCount,
+  readPidsConstraint,
   readPidsLimit,
   readPsi,
   readSelfFdCount,
@@ -628,8 +629,14 @@ export class HostStatsService {
     const procRoot = this.procRoot ?? '/proc'
     const fdsUsed = readSelfFdCount(procRoot)
     const fdsMax = readSelfLimitsFdsMax(procRoot)
-    const pidsUsed = readPidCount(procRoot)
-    const pidsMax = readPidsLimit(procRoot, this.cgroupRoot)
+    // The binding pids constraint (leaf→root chain, highest-utilization node)
+    // yields a coherent same-node pair. The legacy fallback (system-wide
+    // count paired with a leaf/threads-max limit) is incoherent when an
+    // ancestor slice carries the real TasksMax — the WSL/systemd aggregate
+    // shape that motivated the constraint walk.
+    const pidsConstraint = readPidsConstraint(procRoot, this.cgroupRoot)
+    const pidsUsed = pidsConstraint ? pidsConstraint.current : readPidCount(procRoot)
+    const pidsMax = pidsConstraint ? pidsConstraint.max : readPidsLimit(procRoot, this.cgroupRoot)
     const tcp = readTcpStateCounts(procRoot)
     const ports = readEphemeralPortRange(procRoot)
     const timeWait = tcp ? tcp.timeWait : null

--- a/server/mcp/freshell-tool.ts
+++ b/server/mcp/freshell-tool.ts
@@ -455,7 +455,7 @@ Pane commands:
   resize-pane     Resize a pane. Params: target, x? (1-99), y? (1-99)
   swap-pane       Swap two panes. Params: target, with (other pane ID)
   respawn-pane    Restart a pane's terminal. Params: target, mode?, shell?, cwd?, resume?, sessionRef?
-  hostStats       Pass hostStats: true on new-tab or split-pane to create a Host Stats pane (CPU/RAM/load metrics) instead of a terminal -- no process is spawned.
+  hostStats       Pass hostStats: true on new-tab or split-pane to create a System Status pane (CPU/RAM/load metrics) instead of a terminal -- no process is spawned.
 
 Terminal I/O:
   send-keys       Send input to a pane. Params: target, keys, literal?, sessionRef?

--- a/src/components/context-menu/menu-defs.ts
+++ b/src/components/context-menu/menu-defs.ts
@@ -436,7 +436,14 @@ export function buildMenuItems(target: ContextTarget, ctx: MenuBuildContext): Me
       { type: 'item', id: 'split-right', label: 'Split right', onSelect: () => actions.splitPane(target.tabId, target.paneId, 'horizontal') },
       { type: 'item', id: 'split-down', label: 'Split down', onSelect: () => actions.splitPane(target.tabId, target.paneId, 'vertical') },
       { type: 'separator', id: 'pane-split-sep' },
-      { type: 'item', id: 'rename-pane', label: 'Rename pane', onSelect: () => actions.renamePane(target.tabId, target.paneId) },
+      {
+        type: 'item',
+        id: 'rename-pane',
+        label: 'Rename pane',
+        onSelect: () => actions.renamePane(target.tabId, target.paneId),
+        // The host-stats pane is always named by the app ('System Status').
+        disabled: paneContent?.kind === 'host-stats',
+      },
       { type: 'separator', id: 'pane-replace-sep' },
       { type: 'item', id: 'replace-pane', label: 'Replace pane', onSelect: () => actions.replacePane(target.tabId, target.paneId) },
     ]

--- a/src/components/panes/PaneContainer.tsx
+++ b/src/components/panes/PaneContainer.tsx
@@ -514,7 +514,9 @@ export default function PaneContainer({ tabId, node, hidden }: PaneContainerProp
         onRenameKeyDown={isRenaming ? handleRenameKeyDown : undefined}
         onSearch={node.content.kind === 'terminal' ? () => getTerminalActions(node.id)?.openSearch() : undefined}
         onRefresh={handleRefresh}
-        onDoubleClickTitle={() => startRename(node.id, paneTitle)}
+        onDoubleClickTitle={
+          node.content.kind === 'host-stats' ? undefined : () => startRename(node.id, paneTitle)
+        }
       >
         {renderContent(tabId, node.id, node.content, isOnlyPane, hidden)}
       </Pane>
@@ -865,7 +867,7 @@ function renderContent(
 
   if (content.kind === 'host-stats') {
     return (
-      <ErrorBoundary key={paneId} label="Host Stats">
+      <ErrorBoundary key={paneId} label="System Status">
         <HostStatsPane tabId={tabId} paneId={paneId} />
       </ErrorBoundary>
     )

--- a/src/components/panes/PanePicker.tsx
+++ b/src/components/panes/PanePicker.tsx
@@ -42,7 +42,7 @@ const nonShellOptions: PickerOption[] = [
 
 // Host pressure dashboard (plan-pane-types §3c): the server-derived flag
 // already encodes platform support; the platform clause is belt-and-braces.
-const hostStatsOption: PickerOption = { type: 'host-stats', label: 'Host Stats', icon: Gauge, shortcut: 'H' }
+const hostStatsOption: PickerOption = { type: 'host-stats', label: 'System Status', icon: Gauge, shortcut: 'H' }
 
 const EMPTY_AVAILABLE_CLIS: Record<string, boolean> = {}
 const EMPTY_FEATURE_FLAGS: Record<string, boolean> = {}

--- a/src/lib/derivePaneTitle.ts
+++ b/src/lib/derivePaneTitle.ts
@@ -52,7 +52,7 @@ export function derivePaneTitle(content: PaneContent, extensions?: ClientExtensi
   }
 
   if (content.kind === 'host-stats') {
-    return 'Host Stats'
+    return 'System Status'
   }
 
   // Terminal content — coding-agent (non-shell) terminals name by working directory

--- a/src/lib/deriveTabName.ts
+++ b/src/lib/deriveTabName.ts
@@ -115,7 +115,13 @@ export function deriveTabName(layout: PaneNode, extensions?: ClientExtensionEntr
     return segment || 'Shell'
   }
 
-  // Priority 5: Picker (when all panes are pickers)
+  // Priority 5: First host-stats pane (always named by the app)
+  const hostStats = contents.find((content) => content.kind === 'host-stats')
+  if (hostStats) {
+    return 'System Status'
+  }
+
+  // Priority 6: Picker (when all panes are pickers)
   const hasOnlyPickers = contents.every(isPicker)
   if (hasOnlyPickers && contents.length > 0) {
     return 'New Tab'

--- a/src/lib/pane-title.ts
+++ b/src/lib/pane-title.ts
@@ -12,6 +12,12 @@ export function matchesDerivedPaneTitle(
   extensions?: ClientExtensionEntry[],
 ): boolean {
   if (!storedTitle) return false
+  // The host-stats pane is always named by the app ('System Status'): every
+  // stored title — the legacy 'Host Stats' default, the canonical name, or a
+  // stale user override — resolves to the derived title. Renaming it is
+  // blocked at the UX entry points; this forces any title that already
+  // exists in persisted state.
+  if (content.kind === 'host-stats') return true
   if (storedTitle === derivePaneTitle(content, extensions)) return true
   // Only treat the legacy extension-blind label as equivalent when we also
   // have extension metadata that could have changed the canonical label.

--- a/src/lib/tab-registry-open.ts
+++ b/src/lib/tab-registry-open.ts
@@ -224,7 +224,7 @@ export function paneKindLabel(kind: RegistryPaneSnapshot['kind']): string {
   if (kind === 'editor') return 'Editor'
   if (kind === 'fresh-agent' || kind === 'claude-chat') return 'Agent'
   if (kind === 'extension') return 'Extension'
-  if (kind === 'host-stats') return 'Host Stats'
+  if (kind === 'host-stats') return 'System Status'
   return kind
 }
 

--- a/test/e2e-browser/playwright.config.ts
+++ b/test/e2e-browser/playwright.config.ts
@@ -171,7 +171,7 @@ export const MATRIX_SPECS = [
   // docs/development/rename-scope-contract.md); legacy remains the true
   // parity control. See title-sync-convergence.spec.ts.
   /title-sync-convergence\.spec\.ts$/,
-  // HOST-STATS (host-pressure-pane plan, Task 10) — Host Stats pane smoke:
+  // HOST-STATS (host-pressure-pane plan, Task 10) — System Status pane smoke:
   // picker create, verdict strip/CPU tile, refresh interaction (Collecting
   // state + age label), Disks fallback em-dash contract, tab-switch liveness,
   // reload restore. Assertions are backend-agnostic (the Rust lane renders

--- a/test/e2e-browser/specs/host-stats-pane.spec.ts
+++ b/test/e2e-browser/specs/host-stats-pane.spec.ts
@@ -6,7 +6,7 @@ import { openPanePicker } from '../helpers/pane-picker.js'
  * (docs/plans/2026-08-25-host-pressure-pane.md, Task 10 content block).
  *
  * Authored + standalone-committed in Task 7 with captured RED evidence: the
- * first test fails at the picker click because the 'Host Stats' picker option
+ * first test fails at the picker click because the 'System Status' picker option
  * does not exist until Task 7's GREEN phase lands (this is the only sequence
  * point where absence-RED is reachable). Task 10 registers this spec into
  * MATRIX_SPECS (test/e2e-browser/playwright.config.ts) and re-runs it GREEN
@@ -35,10 +35,10 @@ function findLeafByKind(node: PaneNodeLike | null, kind: string): PaneNodeLike |
   return null
 }
 
-test.describe('Host Stats pane', () => {
+test.describe('System Status pane', () => {
   async function openHostStatsPane(page: any) {
     await openPanePicker(page)
-    const option = page.getByRole('button', { name: /^Host Stats$/ })
+    const option = page.getByRole('button', { name: /^System Status$/ })
     await expect(option).toBeVisible({ timeout: 10_000 })
     await option.click()
     const section = page.getByRole('region', { name: 'Host stats' })
@@ -46,7 +46,7 @@ test.describe('Host Stats pane', () => {
     return section
   }
 
-  test('opens a Host Stats pane from the pane picker', async ({ freshellPage, page, harness }) => {
+  test('opens a System Status pane from the pane picker', async ({ freshellPage, page, harness }) => {
     await openHostStatsPane(page)
 
     const activeTabId = await harness.getActiveTabId()

--- a/test/unit/client/components/context-menu/menu-defs.test.ts
+++ b/test/unit/client/components/context-menu/menu-defs.test.ts
@@ -180,6 +180,33 @@ describe('buildMenuItems — pane context menu', () => {
     const separatorAfterSplit = items[splitDownIdx + 1]
     expect(separatorAfterSplit?.type).toBe('separator')
   })
+
+  it('rename pane is disabled for a host-stats pane (the pane is always named by the app)', () => {
+    const mockActions = createMockActions()
+    const mockContext = createMockContext(mockActions)
+    mockContext.paneLayouts = {
+      tab1: {
+        type: 'leaf',
+        id: 'pane1',
+        content: { kind: 'host-stats' },
+      },
+    }
+    const target: ContextTarget = { kind: 'pane', tabId: 'tab1', paneId: 'pane1' }
+    const items = buildMenuItems(target, mockContext)
+    const rename = items.find(i => i.type === 'item' && i.id === 'rename-pane')
+    expect(rename).toBeDefined()
+    if (rename?.type === 'item') expect(rename.disabled).toBe(true)
+  })
+
+  it('rename pane stays enabled for a terminal pane', () => {
+    const mockActions = createMockActions()
+    const mockContext = createMockContext(mockActions)
+    const target: ContextTarget = { kind: 'pane', tabId: 'tab1', paneId: 'pane1' }
+    const items = buildMenuItems(target, mockContext)
+    const rename = items.find(i => i.type === 'item' && i.id === 'rename-pane')
+    expect(rename).toBeDefined()
+    if (rename?.type === 'item') expect(rename.disabled).not.toBe(true)
+  })
 })
 
 describe('buildMenuItems — fresh-agent context', () => {

--- a/test/unit/client/components/panes/HostStatsPane.test.tsx
+++ b/test/unit/client/components/panes/HostStatsPane.test.tsx
@@ -328,8 +328,8 @@ describe('HostStatsPane', () => {
   })
 
   describe('(f) title + icon helpers', () => {
-    it('derivePaneTitle returns Host Stats for host-stats content', () => {
-      expect(derivePaneTitle({ kind: 'host-stats' })).toBe('Host Stats')
+    it('derivePaneTitle returns System Status for host-stats content', () => {
+      expect(derivePaneTitle({ kind: 'host-stats' })).toBe('System Status')
     })
 
     it('PaneIcon renders the Gauge icon for host-stats content', () => {

--- a/test/unit/client/components/panes/PaneContainer.createContent.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.createContent.test.tsx
@@ -562,7 +562,7 @@ describe('createContentForType with ext: prefix', () => {
       </Provider>,
     )
 
-    const hostStatsButton = document.querySelector('[aria-label="Host Stats"]') as HTMLElement
+    const hostStatsButton = document.querySelector('[aria-label="System Status"]') as HTMLElement
     expect(hostStatsButton).not.toBeNull()
     fireEvent.click(hostStatsButton)
     fireEvent.transitionEnd(getPickerContainer())
@@ -588,6 +588,6 @@ describe('createContentForType with ext: prefix', () => {
       </Provider>,
     )
 
-    expect(document.querySelector('[aria-label="Host Stats"]')).toBeNull()
+    expect(document.querySelector('[aria-label="System Status"]')).toBeNull()
   })
 })

--- a/test/unit/client/components/panes/PanePicker.test.tsx
+++ b/test/unit/client/components/panes/PanePicker.test.tsx
@@ -675,40 +675,40 @@ describe('PanePicker', () => {
     })
   })
 
-  // Host Stats option gating (mirrors 'platform-specific shell options'):
+  // System Status option gating (mirrors 'platform-specific shell options'):
   // gate = featureFlags.hostStatsAvailable === true && platform !== 'win32'.
   describe('host stats pane option', () => {
-    it('hides Host Stats when the hostStatsAvailable feature flag is absent', () => {
+    it('hides System Status when the hostStatsAvailable feature flag is absent', () => {
       renderPicker({ platform: 'linux' })
-      expect(screen.queryByRole('button', { name: 'Host Stats' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'System Status' })).not.toBeInTheDocument()
     })
 
-    it('hides Host Stats when hostStatsAvailable is false', () => {
+    it('hides System Status when hostStatsAvailable is false', () => {
       renderPicker({ platform: 'linux', featureFlags: { hostStatsAvailable: false } })
-      expect(screen.queryByRole('button', { name: 'Host Stats' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'System Status' })).not.toBeInTheDocument()
     })
 
-    it('hides Host Stats on win32 even when the flag is true', () => {
+    it('hides System Status on win32 even when the flag is true', () => {
       renderPicker({ platform: 'win32', featureFlags: { hostStatsAvailable: true } })
-      expect(screen.queryByRole('button', { name: 'Host Stats' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'System Status' })).not.toBeInTheDocument()
       // Sanity: the platform-specific windows shells still render in this state.
       expect(screen.getByText('PowerShell')).toBeInTheDocument()
     })
 
-    it('shows Host Stats with an accessible button name and Gauge icon when the flag is true on linux', () => {
+    it('shows System Status with an accessible button name and Gauge icon when the flag is true on linux', () => {
       renderPicker({ platform: 'linux', featureFlags: { hostStatsAvailable: true } })
-      expect(screen.getByRole('button', { name: 'Host Stats' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'System Status' })).toBeInTheDocument()
       expect(screen.getByTestId('gauge-icon')).toBeInTheDocument()
     })
 
-    it('calls onSelect with host-stats when Host Stats is clicked', () => {
+    it('calls onSelect with host-stats when System Status is clicked', () => {
       const { onSelect } = renderPicker({ platform: 'linux', featureFlags: { hostStatsAvailable: true } })
-      fireEvent.click(screen.getByRole('button', { name: 'Host Stats' }))
+      fireEvent.click(screen.getByRole('button', { name: 'System Status' }))
       completeFadeAnimation()
       expect(onSelect).toHaveBeenCalledWith('host-stats')
     })
 
-    it('uses the H shortcut for Host Stats', () => {
+    it('uses the H shortcut for System Status', () => {
       const { onSelect } = renderPicker({ platform: 'linux', featureFlags: { hostStatsAvailable: true } })
       fireEvent.keyDown(getContainer(), { key: 'h' })
       completeFadeAnimation()

--- a/test/unit/client/lib/deriveTabName.test.ts
+++ b/test/unit/client/lib/deriveTabName.test.ts
@@ -9,6 +9,16 @@ const mockExtensions: ClientExtensionEntry[] = [
 ]
 
 describe('deriveTabName', () => {
+  it('returns System Status for a host-stats pane', () => {
+    const layout: PaneNode = {
+      type: 'leaf',
+      id: 'pane-1',
+      content: { kind: 'host-stats' },
+    }
+
+    expect(deriveTabName(layout)).toBe('System Status')
+  })
+
   it('returns provider label for codex terminal', () => {
     const layout: PaneNode = {
       type: 'leaf',

--- a/test/unit/client/lib/pane-title.test.ts
+++ b/test/unit/client/lib/pane-title.test.ts
@@ -25,6 +25,8 @@ const opencodeContent: PaneContent = {
   createRequestId: 'req-1',
 }
 
+const hostStatsContent: PaneContent = { kind: 'host-stats' }
+
 describe('pane-title helpers', () => {
   it('matches extension-aware derived titles', () => {
     expect(matchesDerivedPaneTitle('OpenCode', opencodeContent, opencodeExtensions)).toBe(true)
@@ -44,5 +46,20 @@ describe('pane-title helpers', () => {
 
   it('preserves explicit runtime titles', () => {
     expect(getPaneDisplayTitle(opencodeContent, 'Release prep', opencodeExtensions)).toBe('Release prep')
+  })
+
+  it('treats every host-stats stored title as derived (legacy, canonical, or user-renamed)', () => {
+    // The host-stats pane is always named by the app: stored titles from
+    // before the rename, the canonical name, and hypothetical user overrides
+    // must all resolve to the derived title.
+    expect(matchesDerivedPaneTitle('Host Stats', hostStatsContent)).toBe(true)
+    expect(matchesDerivedPaneTitle('System Status', hostStatsContent)).toBe(true)
+    expect(matchesDerivedPaneTitle('My meter', hostStatsContent)).toBe(true)
+  })
+
+  it('displays the canonical System Status name for host-stats panes regardless of stored title', () => {
+    expect(getPaneDisplayTitle(hostStatsContent, undefined)).toBe('System Status')
+    expect(getPaneDisplayTitle(hostStatsContent, 'Host Stats')).toBe('System Status')
+    expect(getPaneDisplayTitle(hostStatsContent, 'My meter')).toBe('System Status')
   })
 })

--- a/test/unit/client/store/panesPersistence.test.ts
+++ b/test/unit/client/store/panesPersistence.test.ts
@@ -552,7 +552,7 @@ describe('Panes Persistence Integration', () => {
     expect(createdLayout.type).toBe('leaf')
     expect(createdLayout.content).toEqual({ kind: 'host-stats' })
     const createdPaneId = createdLayout.id
-    expect(store1.getState().panes.paneTitles[tabId][createdPaneId]).toBe('Host Stats')
+    expect(store1.getState().panes.paneTitles[tabId][createdPaneId]).toBe('System Status')
 
     vi.runAllTimers()
 

--- a/test/unit/server/host-stats/readers.test.ts
+++ b/test/unit/server/host-stats/readers.test.ts
@@ -36,6 +36,7 @@ import {
   readMeminfo,
   readNetDev,
   readPidCount,
+  readPidsConstraint,
   readPidsLimit,
   readPsi,
   readSelfFdCount,
@@ -71,6 +72,17 @@ let v1Cgroup: string
 let pidMaxOnlyProc: string
 let tcpOnlyProc: string
 let noOomProc: string
+let pidsChainProc: string
+let pidsChainCgroup: string
+let pidsMultiLeafWinsProc: string
+let pidsMultiLeafWinsCgroup: string
+let pidsMultiAncestorWinsProc: string
+let pidsMultiAncestorWinsCgroup: string
+let pidsNoCurrentProc: string
+let pidsNoCurrentCgroup: string
+let pidsRootCgroupProc: string
+let v1ChainProc: string
+let v1ChainCgroup: string
 
 function writeFile(root: string, rel: string, content: string): void {
   const full = path.join(root, rel)
@@ -147,6 +159,68 @@ beforeAll(() => {
   // vmstat without oom_kill (older kernels) -> oomKill null.
   noOomProc = path.join(tmp, 'no-oom', 'proc')
   writeFile(noOomProc, 'vmstat', 'pswpin 10\npswpout 20\npgmajfault 30\n')
+
+  // pids CHAIN: the v2 leaf pids.max is 'max' (unlimited) but an ANCESTOR
+  // slice carries a finite TasksMax — the WSL/systemd aggregate-limit shape.
+  // readPidsConstraint must walk the chain and bind to the ancestor pair.
+  pidsChainProc = path.join(tmp, 'pids-chain', 'proc')
+  pidsChainCgroup = path.join(tmp, 'pids-chain', 'cgroup')
+  writeFile(
+    pidsChainProc,
+    'self/cgroup',
+    '0::/user.slice/user-1000.slice/user@1000.service/app.slice/freshell.service\n',
+  )
+  writeFile(pidsChainProc, 'sys/kernel/threads-max', '999999\n')
+  writeFile(
+    pidsChainCgroup,
+    'user.slice/user-1000.slice/user@1000.service/app.slice/freshell.service/pids.max',
+    'max\n',
+  )
+  writeFile(pidsChainCgroup, 'user.slice/user-1000.slice/pids.max', '678924\n')
+  writeFile(pidsChainCgroup, 'user.slice/user-1000.slice/pids.current', '16240\n')
+
+  // TWO constrained nodes; the LEAF has the higher utilization (0.9 vs 0.5)
+  // -> the leaf is the binding constraint and must win.
+  pidsMultiLeafWinsProc = path.join(tmp, 'pids-multi-leaf', 'proc')
+  pidsMultiLeafWinsCgroup = path.join(tmp, 'pids-multi-leaf', 'cgroup')
+  writeFile(pidsMultiLeafWinsProc, 'self/cgroup', '0::/slices/a.service\n')
+  writeFile(pidsMultiLeafWinsCgroup, 'slices/a.service/pids.max', '100\n')
+  writeFile(pidsMultiLeafWinsCgroup, 'slices/a.service/pids.current', '90\n')
+  writeFile(pidsMultiLeafWinsCgroup, 'slices/pids.max', '1000\n')
+  writeFile(pidsMultiLeafWinsCgroup, 'slices/pids.current', '500\n')
+
+  // TWO constrained nodes; the ANCESTOR has the higher utilization
+  // (0.6 vs 0.4) -> the ancestor must win over the leaf.
+  pidsMultiAncestorWinsProc = path.join(tmp, 'pids-multi-ancestor', 'proc')
+  pidsMultiAncestorWinsCgroup = path.join(tmp, 'pids-multi-ancestor', 'cgroup')
+  writeFile(pidsMultiAncestorWinsProc, 'self/cgroup', '0::/slices/b.service\n')
+  writeFile(pidsMultiAncestorWinsCgroup, 'slices/b.service/pids.max', '1000\n')
+  writeFile(pidsMultiAncestorWinsCgroup, 'slices/b.service/pids.current', '400\n')
+  writeFile(pidsMultiAncestorWinsCgroup, 'slices/pids.max', '1000\n')
+  writeFile(pidsMultiAncestorWinsCgroup, 'slices/pids.current', '600\n')
+
+  // A finite pids.max whose pids.current is unreadable cannot form a
+  // same-node pair: the node must be skipped (no ratio -> not binding).
+  pidsNoCurrentProc = path.join(tmp, 'pids-no-current', 'proc')
+  pidsNoCurrentCgroup = path.join(tmp, 'pids-no-current', 'cgroup')
+  writeFile(pidsNoCurrentProc, 'self/cgroup', '0::/slices/c.service\n')
+  writeFile(pidsNoCurrentCgroup, 'slices/c.service/pids.max', 'max\n')
+  writeFile(pidsNoCurrentCgroup, 'slices/pids.max', '500\n')
+
+  // Process sits AT the cgroup2 root ('0::/'): no limit files exist there
+  // and resolveCgroupLeaf yields null -> no binding constraint.
+  pidsRootCgroupProc = path.join(tmp, 'pids-root-cgroup', 'proc')
+  writeFile(pidsRootCgroupProc, 'self/cgroup', '0::/\n')
+
+  // v1 pids controller chain: leaf pair finite but low utilization,
+  // ancestor pair higher -> the ancestor must win.
+  v1ChainProc = path.join(tmp, 'v1-chain', 'proc')
+  v1ChainCgroup = path.join(tmp, 'v1-chain', 'cgroup')
+  writeFile(v1ChainProc, 'self/cgroup', '3:pids:/limited.slice/svc.service\n')
+  writeFile(v1ChainCgroup, 'pids/limited.slice/svc.service/pids.max', '777\n')
+  writeFile(v1ChainCgroup, 'pids/limited.slice/svc.service/pids.current', '50\n')
+  writeFile(v1ChainCgroup, 'pids/limited.slice/pids.max', '1000\n')
+  writeFile(v1ChainCgroup, 'pids/limited.slice/pids.current', '900\n')
 })
 
 afterAll(() => {
@@ -395,6 +469,57 @@ describe('readPidsLimit', () => {
 
   it('never uses /proc/sys/kernel/pid_max (wrap boundary, not a process cap)', () => {
     expect(readPidsLimit(pidMaxOnlyProc, CGROUP)).toBeNull()
+  })
+})
+
+describe('readPidsConstraint', () => {
+  it('returns the leaf pair when the leaf is the binding constraint', () => {
+    // procmini leaf: pids.max 10854, pids.current 42 — the only constrained
+    // node in the committed tree.
+    expect(readPidsConstraint(PROMINI, CGROUP)).toEqual({ current: 42, max: 10854 })
+  })
+
+  it('walks the ancestor chain when the leaf is unlimited (WSL aggregate TasksMax)', () => {
+    expect(readPidsConstraint(pidsChainProc, pidsChainCgroup)).toEqual({
+      current: 16240,
+      max: 678924,
+    })
+  })
+
+  it('binds the highest-utilization constrained node (leaf wins)', () => {
+    expect(readPidsConstraint(pidsMultiLeafWinsProc, pidsMultiLeafWinsCgroup)).toEqual({
+      current: 90,
+      max: 100,
+    })
+  })
+
+  it('binds the highest-utilization constrained node (ancestor wins)', () => {
+    expect(readPidsConstraint(pidsMultiAncestorWinsProc, pidsMultiAncestorWinsCgroup)).toEqual({
+      current: 600,
+      max: 1000,
+    })
+  })
+
+  it('returns null when no node in the chain is constrained', () => {
+    // v2LimitedProc: leaf pids.max = 'max', no ancestor pids files at all.
+    expect(readPidsConstraint(v2LimitedProc, v2LimitedCgroup)).toBeNull()
+  })
+
+  it('returns null when a finite pids.max lacks pids.current (no same-node pair)', () => {
+    expect(readPidsConstraint(pidsNoCurrentProc, pidsNoCurrentCgroup)).toBeNull()
+  })
+
+  it('reads the cgroup v1 pids controller chain', () => {
+    // leaf 50/777 (0.06) loses to ancestor 900/1000 (0.9).
+    expect(readPidsConstraint(v1ChainProc, v1ChainCgroup)).toEqual({ current: 900, max: 1000 })
+  })
+
+  it('returns null at the cgroup2 root (no limit files exist there)', () => {
+    expect(readPidsConstraint(pidsRootCgroupProc, CGROUP)).toBeNull()
+  })
+
+  it('returns null when there is no cgroup data', () => {
+    expect(readPidsConstraint(missing, CGROUP)).toBeNull()
   })
 })
 

--- a/test/unit/server/host-stats/service.test.ts
+++ b/test/unit/server/host-stats/service.test.ts
@@ -38,6 +38,7 @@ vi.mock('../../../../server/host-stats/readers.js', () => {
     readSelfLimitsFdsMax: vi.fn(),
     readPidCount: vi.fn(),
     readPidsLimit: vi.fn(),
+    readPidsConstraint: vi.fn(),
     readCpuFreqMHz: vi.fn(),
     readMachineInfo: vi.fn(),
     readSelfInotifyStats: vi.fn(),
@@ -151,6 +152,7 @@ const SLOW_READERS = [
   'readSelfLimitsFdsMax',
   'readPidCount',
   'readPidsLimit',
+  'readPidsConstraint',
   'readCpuFreqMHz',
 ] as const
 
@@ -186,6 +188,7 @@ beforeEach(() => {
   vi.mocked(readersMock.readSelfLimitsFdsMax).mockReturnValue(1_048_576)
   vi.mocked(readersMock.readPidCount).mockReturnValue(900)
   vi.mocked(readersMock.readPidsLimit).mockReturnValue(4_194_304)
+  vi.mocked(readersMock.readPidsConstraint).mockReturnValue(null)
   vi.mocked(readersMock.readCpuFreqMHz).mockReturnValue(3400)
   vi.mocked(readersMock.readSelfInotifyStats).mockReturnValue({ instances: 3, watches: 420 })
   vi.mocked(readersMock.readInotifyLimits).mockReturnValue({ maxUserWatches: 1_048_576, maxUserInstances: 128 })
@@ -300,6 +303,7 @@ describe('start/stop (contract points 1, 5)', () => {
     expect(readerFn('readDiskStats')).toHaveBeenCalledWith(PROC)
     expect(readerFn('readCpuFreqMHz')).toHaveBeenCalledWith(SYS)
     expect(readerFn('readPidsLimit')).toHaveBeenCalledWith(PROC, CGROUP)
+    expect(readerFn('readPidsConstraint')).toHaveBeenCalledWith(PROC, CGROUP)
     vi.advanceTimersByTime(10000) // t=16000: fast at 8/10/12/14/16, slow at 10/15
     expect(readerFn('readCpuTimes')).toHaveBeenCalledTimes(9)
     expect(readerFn('readDiskStats')).toHaveBeenCalledTimes(3)
@@ -420,6 +424,38 @@ describe('delta-rate computation (contract point 1)', () => {
       rxErrorsTotal: 5, txErrorsTotal: 3, rxDroppedTotal: 3, txDroppedTotal: 5,
       rxErrorsDelta: 2, txErrorsDelta: 2, rxDroppedDelta: 1, txDroppedDelta: 1,
     })
+  })
+})
+
+describe('pids constraint (binding cgroup pair)', () => {
+  it('a resolved constraint pair replaces the system-wide count and leaf limit', () => {
+    vi.mocked(readersMock.readPidsConstraint).mockReturnValue({ current: 16_240, max: 678_924 })
+    const service = makeService()
+    service.start()
+    vi.advanceTimersByTime(5000) // first slow tick
+    expect(service.getSnapshot().live.limits).toEqual({
+      available: true,
+      fdsUsed: 128, fdsMax: 1_048_576,
+      pidsUsed: 16_240, pidsMax: 678_924,
+      timeWait: 42, ephemeralPorts: 28_232, // 60999 - 32768 + 1
+    })
+    // The pair short-circuits the legacy readers: mixing a system-wide count
+    // with a cgroup-scoped limit would be an incoherent ratio.
+    expect(readerFn('readPidCount')).not.toHaveBeenCalled()
+    expect(readerFn('readPidsLimit')).not.toHaveBeenCalled()
+  })
+
+  it('a null constraint falls back to the legacy system-wide pair', () => {
+    const service = makeService()
+    service.start()
+    vi.advanceTimersByTime(5000) // first slow tick
+    expect(service.getSnapshot().live.limits).toEqual({
+      available: true,
+      fdsUsed: 128, fdsMax: 1_048_576,
+      pidsUsed: 900, pidsMax: 4_194_304,
+      timeWait: 42, ephemeralPorts: 28_232,
+    })
+    expect(readerFn('readPidsConstraint')).toHaveBeenCalledTimes(1)
   })
 })
 


### PR DESCRIPTION
## Summary

Two changes to the host-pressure pane, developed TDD:

**pids now reads the real constraint (the WSL/systemd fix)**
- The limits tile previously paired a system-wide `/proc` process count with the leaf cgroup's `pids.max`. Under WSL/systemd the leaf is usually `max` while the real `TasksMax` lives on an ancestor slice (e.g. `user-1000.slice`), so the meter showed a near-zero ratio against millions.
- New reader `readPidsConstraint` (Node) / `read_pids_constraint` (Rust): walk the cgroup chain leaf→root (deepest first, never the fs root), qualify a node only when a finite `pids.max` AND readable `pids.current` exist on the same node, and return the highest-utilization pair (deepest wins ties). The limits section uses that pair; the legacy pair remains as fallback when nothing is constrained. Protocol shape unchanged.

**Pane renamed to System Status**
- `derivePaneTitle`, pane-title force (any stored title — legacy 'Host Stats' or a stale user override — resolves to the derived title), `deriveTabName`, paneKindLabel, picker label, MCP tool text, and the docs mock now say 'System Status'.
- Renaming is blocked at both entry points: the context-menu item is disabled and double-click-to-rename is guarded.
- Internal namespace comments (`hoststats.*` protocol, slice names) intentionally unchanged.

## Test plan
- TDD: 9 new Node reader cases (leaf binding, ancestor walk, utilization selection, no-pair skip, v1 chain, cgroup2 root, no cgroup data); service constraint-pair + fallback tests; Rust mirror incl. wiring test; client title/tab-name/menu/picker/persistence expectations; e2e spec updated to the new name.
- Full coordinated suite green on the branch (cloud image `1d5bf38f6e69`): client 119/117/119/119 files, server 83 passed + 2 skipped, electron 432 tests.
- Local parallel runs show the known load-flake victims (different tests each run, pass in isolation); documented repo pattern.